### PR TITLE
Add grouped GEMM benchmark harnesses

### DIFF
--- a/benchmarks/cute/compare_grouped_gemm_backends.py
+++ b/benchmarks/cute/compare_grouped_gemm_backends.py
@@ -1,0 +1,847 @@
+# ruff: noqa: ANN401
+"""Reproduce the Helion versus CUTLASS CuTeDSL grouped-GEMM comparison.
+
+The comparison is intentionally narrow: FP16 NT grouped GEMM, a 128x64 MMA
+tile, a 1x1 cluster, and the seven published workloads below.  Every workload
+runs in a fresh subprocess with fresh compiler caches.  Both implementations
+consume the same A/B tensors, write separate outputs, and are timed through
+CUDA graph replay.  The CUTLASS graph includes the pinned-host pointer-table
+upload performed by the published reference wrapper before each kernel launch.
+
+Use ``grouped_gemm.py`` from NVIDIA/cutlass commit
+``db1c288993354c88e551c40c19a8fb93a774a241``::
+
+    CUDA_VISIBLE_DEVICES=0 python benchmarks/cute/compare_grouped_gemm_backends.py \
+      --cutlass-source /path/to/CUTLASS/examples/python/CuTeDSL/blackwell/grouped_gemm.py \
+      --out-dir grouped_gemm_cutlass_results --stream-subprocesses
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+import importlib.metadata
+import json
+import linecache
+import math
+import os
+from pathlib import Path
+import statistics
+import subprocess
+import sys
+import time
+from types import ModuleType
+from typing import TYPE_CHECKING
+from typing import Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Mapping
+    from collections.abc import Sequence
+
+    import torch
+
+hl: Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CUTLASS_COMMIT = "db1c288993354c88e551c40c19a8fb93a774a241"
+CUTLASS_SHA256 = "05b74a05682c024557d83284e32f973ed5be4f0d1a1a12c72fe7824c29f7e94f"
+HELION_CUTE_MMA_IMPL = "tcgen05"
+DEFAULT_OUT_DIR = Path("grouped_gemm_cutlass_results")
+CTA_M, CTA_N, CTA_K = 128, 64, 64
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    problems: tuple[tuple[int, int, int, int], ...]
+    reserved_sms: int
+    ab_stages: int | None
+
+    @property
+    def shape_label(self) -> str:
+        shapes = ", ".join(
+            f"g{i}: {m}x{n}x{k}" for i, (m, n, k, _l) in enumerate(self.problems)
+        )
+        return f"G{len(self.problems)} [{shapes}]"
+
+
+def _doc_case(name: str, m1: int, n3: int, *, reserved_sms: int = 0) -> Case:
+    return Case(
+        name,
+        (
+            (8192, 1280, 32, 1),
+            (m1, 384, 1536, 1),
+            (640, 1280, 16, 1),
+            (640, n3, 16, 1),
+        ),
+        reserved_sms=reserved_sms,
+        ab_stages=4,
+    )
+
+
+CASES = (
+    Case(
+        "default_small_parity",
+        ((128, 128, 128, 1), (512, 128, 128, 1), (128, 256, 128, 1)),
+        reserved_sms=0,
+        ab_stages=None,
+    ),
+    _doc_case("doc_no_mn_tail", 128, 128),
+    _doc_case("doc_no_mn_g3_192_extra_full", 128, 192),
+    _doc_case("doc_original", 16, 160, reserved_sms=3),
+    _doc_case("doc_mtail_g1_g3_192_extra_full", 16, 192, reserved_sms=3),
+    _doc_case("doc_mtail_g1_only", 16, 128),
+    _doc_case("doc_ntail_g3_160", 128, 160),
+)
+CASES_BY_NAME = {case.name: case for case in CASES}
+
+
+@dataclass
+class PreparedLaunch:
+    call: Callable[[], object]
+    owners: tuple[object, ...]
+
+    def __call__(self) -> object:
+        return self.call()
+
+
+def _make_helion_kernel() -> tuple[Any, Any]:
+    global hl, torch
+    import torch
+
+    import helion
+    import helion.language as hl
+
+    @helion.kernel(backend="cute")
+    def grouped_gemm(
+        a_placeholder: Any,
+        b_placeholder: Any,
+        layout: Any,
+        n_sizes: Any,
+        k_sizes: Any,
+        out_placeholder: Any,
+        direct_pointers: Any,
+        direct_strides: Any,
+    ) -> Any:
+        m, max_k = a_placeholder.size()
+        _groups, max_n, _k = b_placeholder.size()
+        for tile_m, tile_n in hl.tile([m, max_n]):
+            group_id = layout[tile_m.begin]
+            safe_group_id = torch.where(group_id >= 0, group_id, 0)
+            valid_rows = layout[tile_m] == safe_group_id
+            valid_cols = tile_n.index < n_sizes[safe_group_id]
+            valid = valid_rows[:, None] & valid_cols[None, :]  # pyrefly: ignore[bad-index]
+            group_k = k_sizes[safe_group_id]
+            acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+            for tile_k in hl.tile(max_k):  # pyrefly: ignore[bad-assignment]
+                valid_k = (tile_k.index < group_k)[None, :]  # pyrefly: ignore[bad-index]
+                a_tile = a_placeholder[tile_m, tile_k]
+                b_tile = b_placeholder[safe_group_id, tile_n, tile_k]
+                a_tile = torch.where(valid_k, a_tile, torch.zeros_like(a_tile))
+                b_tile = torch.where(valid_k, b_tile, torch.zeros_like(b_tile))
+                acc = torch.addmm(acc, a_tile, b_tile.T)
+            old = out_placeholder[tile_m, tile_n]
+            out_placeholder[tile_m, tile_n] = torch.where(
+                valid, acc.to(out_placeholder.dtype), old
+            )
+        return out_placeholder
+
+    return grouped_gemm, helion
+
+
+def _placeholder(shape: tuple[int, ...], device: torch.device) -> torch.Tensor:
+    import torch
+
+    base = torch.empty(max(1, shape[-1]), device=device, dtype=torch.float16)
+    return torch.as_strided(base, shape, (0,) * (len(shape) - 1) + (1,))
+
+
+def _prepare_helion(
+    case: Case,
+    group_a: tuple[torch.Tensor, ...],
+    group_b: tuple[torch.Tensor, ...],
+    outputs: tuple[torch.Tensor, ...],
+) -> tuple[PreparedLaunch, dict[str, object]]:
+    import torch
+
+    kernel, helion = _make_helion_kernel()
+    problems = case.problems
+    device = group_a[0].device
+    aligned_m = tuple((m + CTA_M - 1) // CTA_M * CTA_M for m, _n, _k, _l in problems)
+    padded_m = sum(aligned_m)
+    max_n = max(n for _m, n, _k, _l in problems)
+    max_k = max(k for _m, _n, k, _l in problems)
+    layout = torch.empty(padded_m, device=device, dtype=torch.int32)
+    cursor = 0
+    for group, ((m, _n, _k, _l), padded) in enumerate(
+        zip(problems, aligned_m, strict=True)
+    ):
+        layout[cursor : cursor + m].fill_(group)
+        layout[cursor + m : cursor + padded].fill_(-1)
+        cursor += padded
+    n_sizes = torch.tensor([p[1] for p in problems], device=device, dtype=torch.int32)
+    k_sizes = torch.tensor([p[2] for p in problems], device=device, dtype=torch.int32)
+    direct_pointers = torch.tensor(
+        [
+            (a.data_ptr(), b.data_ptr(), out.data_ptr())
+            for a, b, out in zip(group_a, group_b, outputs, strict=True)
+        ],
+        device=device,
+        dtype=torch.int64,
+    )
+    direct_strides = torch.tensor(
+        [
+            (tuple(a.stride()), tuple(b.stride()), tuple(out.stride()))
+            for a, b, out in zip(group_a, group_b, outputs, strict=True)
+        ],
+        device=device,
+        dtype=torch.int32,
+    )
+    kernel_args = (
+        _placeholder((padded_m, max_k), device),
+        _placeholder((len(problems), max_n, max_k), device),
+        layout,
+        n_sizes,
+        k_sizes,
+        _placeholder((padded_m, max_n), device),
+        direct_pointers,
+        direct_strides,
+    )
+    config = helion.Config(
+        block_sizes=[CTA_M, CTA_N, CTA_K],
+        l2_groupings=[1],
+        loop_orders=[[0, 1]],
+        num_stages=2,
+        num_warps=8,
+        pid_type="persistent_interleaved",
+        tcgen05_cluster_m=1,
+        tcgen05_cluster_n=1,
+        tcgen05_acc_stages=2,
+        tcgen05_c_stages=2,
+        tcgen05_num_epi_warps=4,
+        tcgen05_grouped_mode="direct",
+        tcgen05_grouped_external_direct_pointers="direct_pointers",
+        tcgen05_grouped_external_direct_strides="direct_strides",
+        **(
+            {"tcgen05_grouped_static_reserved_sms": case.reserved_sms}
+            if case.reserved_sms
+            else {}
+        ),
+    )
+    if case.ab_stages is not None:
+        config.config["tcgen05_ab_stages"] = case.ab_stages
+    bound = kernel.bind(kernel_args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    bound.set_config(config)
+
+    def launch() -> object:
+        with torch.cuda.device(device):
+            return bound(*kernel_args)
+
+    owners: tuple[object, ...] = (*group_a, *group_b, *outputs, *kernel_args, bound)
+    return PreparedLaunch(launch, owners), {
+        "block_sizes": [CTA_M, CTA_N, CTA_K],
+        "cluster_shape_mn": [1, 1],
+        "reserved_sms": case.reserved_sms,
+        "ab_stages": case.ab_stages,
+    }
+
+
+def _load_cutlass_source(source: Path) -> tuple[ModuleType, dict[str, str]]:
+    """Hash and execute the retained bytes under an immutable synthetic name."""
+    path = source.expanduser().resolve(strict=True)
+    source_bytes = path.read_bytes()
+    digest = hashlib.sha256(source_bytes).hexdigest()
+    if digest != CUTLASS_SHA256:
+        raise ValueError(
+            f"CUTLASS source SHA256 mismatch: expected {CUTLASS_SHA256} from "
+            f"commit {CUTLASS_COMMIT}, got {digest}"
+        )
+    module_name = f"_helion_cutlass_grouped_gemm_{CUTLASS_COMMIT[:12]}"
+    filename = f"<helion-cutlass-grouped-gemm-{digest}.py>"
+    source_text = source_bytes.decode("utf-8")
+    linecache.cache[filename] = (
+        len(source_bytes),
+        None,
+        source_text.splitlines(keepends=True),
+        filename,
+    )
+    module = ModuleType(module_name)
+    module.__file__ = filename
+    sys.modules[module_name] = module
+    try:
+        exec(compile(source_bytes, filename, "exec"), vars(module))
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        linecache.cache.pop(filename, None)
+        raise
+    return module, {
+        "source_path": str(path),
+        "source_sha256": digest,
+        "expected_cutlass_commit": CUTLASS_COMMIT,
+        "cutlass_dsl_version": importlib.metadata.version("nvidia-cutlass-dsl"),
+    }
+
+
+def _prepare_cutlass(
+    module: ModuleType,
+    problems: tuple[tuple[int, int, int, int], ...],
+    group_a: tuple[torch.Tensor, ...],
+    group_b: tuple[torch.Tensor, ...],
+    outputs: tuple[torch.Tensor, ...],
+) -> PreparedLaunch:
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.torch as cutlass_torch
+    import cutlass.utils as cutlass_utils
+    import torch
+
+    from helion.runtime import _ensure_cute_dsl_arch_env
+
+    _ensure_cute_dsl_arch_env(())
+    initial = tuple(
+        module.create_tensor_and_stride(1, 8, 8, False, cutlass.Float16)[2]
+        for _ in range(3)
+    )
+    dims, dims_torch = cutlass_torch.cute_tensor_like(
+        torch.tensor(problems, dtype=torch.int32),
+        cutlass.Int32,
+        is_dynamic_layout=False,
+        assumed_align=16,
+    )
+    strides_data = [
+        (tuple(a.stride()), tuple(b.stride()), tuple(out.stride()))
+        for a, b, out in zip(group_a, group_b, outputs, strict=True)
+    ]
+    strides, strides_torch = cutlass_torch.cute_tensor_like(
+        torch.tensor(strides_data, dtype=torch.int32),
+        cutlass.Int32,
+        is_dynamic_layout=False,
+        assumed_align=16,
+    )
+    device = group_a[0].device
+    pointers_host = torch.tensor(
+        [
+            (a.data_ptr(), b.data_ptr(), out.data_ptr())
+            for a, b, out in zip(group_a, group_b, outputs, strict=True)
+        ],
+        dtype=torch.int64,
+        pin_memory=True,
+    )
+    pointers_torch = torch.empty_like(pointers_host, device=device)
+    pointers = cutlass_torch.from_dlpack(pointers_torch, assumed_align=16)
+    pointers.element_type = cutlass.Int64
+    hardware = cutlass_utils.HardwareInfo()
+    max_active_clusters = hardware.get_max_active_clusters(1)
+    tensormap_torch = torch.empty(
+        (
+            max_active_clusters,
+            module.GroupedGemmKernel.num_tensormaps,
+            module.GroupedGemmKernel.bytes_per_tensormap // 8,
+        ),
+        device=device,
+        dtype=torch.int64,
+    )
+    tensormap = cutlass_torch.from_dlpack(tensormap_torch, assumed_align=16)
+    tensormap.element_type = cutlass.Int64
+    kernel = module.GroupedGemmKernel(
+        cutlass.Float32,
+        False,
+        (CTA_M, CTA_N),
+        (1, 1),
+        cutlass_utils.TensorMapUpdateMode.SMEM,
+    )
+    total_clusters = sum(
+        ((m + CTA_M - 1) // CTA_M) * ((n + CTA_N - 1) // CTA_N)
+        for m, n, _k, _l in problems
+    )
+    compiled = cute.compile(
+        kernel,
+        *initial,
+        len(problems),
+        dims,
+        strides,
+        pointers,
+        total_clusters,
+        tensormap,
+        max_active_clusters,
+        cutlass_torch.default_stream(),
+        options="--opt-level 2",
+    )
+
+    def launch() -> object:
+        pointers_torch.copy_(pointers_host, non_blocking=True)
+        return compiled(
+            *initial,
+            dims,
+            strides,
+            pointers,
+            tensormap,
+            cutlass_torch.current_stream(),
+        )
+
+    owners: tuple[object, ...] = (
+        compiled,
+        *initial,
+        dims,
+        strides,
+        pointers,
+        tensormap,
+        dims_torch,
+        strides_torch,
+        pointers_host,
+        pointers_torch,
+        tensormap_torch,
+        *group_a,
+        *group_b,
+        *outputs,
+    )
+    return PreparedLaunch(launch, owners)
+
+
+def _make_inputs(
+    problems: Sequence[tuple[int, int, int, int]], device: torch.device
+) -> tuple[
+    tuple[torch.Tensor, ...], tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]
+]:
+    import torch
+
+    group_a = tuple(
+        torch.randn(m, k, device=device, dtype=torch.float16)
+        for m, _n, k, _l in problems
+    )
+    group_b = tuple(
+        torch.randn(n, k, device=device, dtype=torch.float16)
+        for _m, n, k, _l in problems
+    )
+    expected = tuple(
+        (a.float() @ b.float().T).half() for a, b in zip(group_a, group_b, strict=True)
+    )
+    return group_a, group_b, expected
+
+
+def _outputs(
+    group_a: Sequence[torch.Tensor], group_b: Sequence[torch.Tensor]
+) -> tuple[torch.Tensor, ...]:
+    import torch
+
+    return tuple(
+        torch.empty(a.size(0), b.size(0), device=a.device, dtype=torch.float16)
+        for a, b in zip(group_a, group_b, strict=True)
+    )
+
+
+def _capture(
+    launch: PreparedLaunch, warmups: int, *, track_cute: bool = False
+) -> torch.cuda.CUDAGraph:
+    import torch
+
+    import helion.runtime as helion_runtime
+
+    for _ in range(warmups):
+        launch()
+    torch.cuda.synchronize()
+    if track_cute:
+        with helion_runtime.cute_cuda_graph() as graph:
+            launch()
+    else:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            launch()
+    torch.cuda.synchronize()
+    return graph
+
+
+def _correctness(
+    outputs: Sequence[torch.Tensor], expected: Sequence[torch.Tensor]
+) -> dict[str, object]:
+    import torch
+
+    max_abs = 0.0
+    for actual, reference in zip(outputs, expected, strict=True):
+        max_abs = max(max_abs, float((actual.float() - reference.float()).abs().max()))
+        torch.testing.assert_close(actual, reference, rtol=2e-2, atol=2e-2)
+    return {"ok": True, "max_abs": max_abs}
+
+
+def _thermal_warmup(duration_ms: int) -> None:
+    import torch
+
+    if duration_ms <= 0:
+        return
+    value = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
+    end = time.monotonic() + duration_ms / 1000
+    while time.monotonic() < end:
+        for _ in range(50):
+            value = value @ value
+        torch.cuda.synchronize()
+
+
+def _do_bench(fn: Callable[[], object], args: argparse.Namespace) -> float:
+    from triton.testing import do_bench
+
+    value: Any = do_bench(
+        fn, warmup=args.warmup_ms, rep=args.rep_ms, return_mode="mean"
+    )
+    return float(value[0] if isinstance(value, tuple) else value)
+
+
+def _bench_pair(
+    replays: Mapping[str, Callable[[], object]], args: argparse.Namespace
+) -> dict[str, dict[str, Any]]:
+    import torch
+
+    if args.cache_warmup_calls:
+        for fn in replays.values():
+            for _ in range(args.cache_warmup_calls):
+                fn()
+        torch.cuda.synchronize()
+    _thermal_warmup(args.thermal_warmup_ms)
+    names = tuple(replays)
+    samples = {name: [] for name in names}
+    for run in range(args.num_runs):
+        order = names if run % 2 == 0 else names[::-1]
+        for name in order:
+            samples[name].append(_do_bench(replays[name], args))
+    method = (
+        "one shared cache/thermal warmup phase, then paired external "
+        "triton.testing.do_bench CUDA-event runs alternating Helion/CUTLASS "
+        "and CUTLASS/Helion"
+    )
+    return {
+        name: {
+            "median_ms": statistics.median(values),
+            "runs_ms": values,
+            "method": method,
+        }
+        for name, values in samples.items()
+    }
+
+
+def _configure_worker(case_dir: Path) -> dict[str, str]:
+    cache_names = (
+        "HELION_CACHE_DIR",
+        "CUTE_DSL_CACHE_DIR",
+        "TORCHINDUCTOR_CACHE_DIR",
+        "TRITON_CACHE_DIR",
+        "CUDA_CACHE_PATH",
+    )
+    os.environ.update(
+        {
+            "HELION_BACKEND": "cute",
+            "HELION_CUTE_MMA_IMPL": HELION_CUTE_MMA_IMPL,
+            "CUTE_DSL_KEEP": "ir,ptx,cubin",
+            "CUTE_DSL_DUMP_DIR": str(case_dir / "dump"),
+        }
+    )
+    (case_dir / "dump").mkdir(parents=True, exist_ok=True)
+    for name in cache_names:
+        path = case_dir / "cache" / name.lower()
+        path.mkdir(parents=True, exist_ok=True)
+        os.environ[name] = str(path)
+    keys = (
+        "CUDA_VISIBLE_DEVICES",
+        "HELION_BACKEND",
+        "HELION_CUTE_MMA_IMPL",
+        *cache_names,
+    )
+    return {key: os.environ.get(key, "") for key in keys}
+
+
+def _run_case(args: argparse.Namespace) -> int:
+    import torch
+
+    if not args.case or len(args.case) != 1:
+        raise ValueError("--run-case requires exactly one --case")
+    case = CASES_BY_NAME[args.case[0]]
+    case_dir = args.out_dir / "cutlass" / case.name
+    if case_dir.exists() and any(case_dir.iterdir()):
+        raise ValueError(f"refusing to reuse nonempty case directory: {case_dir}")
+    case_dir.mkdir(parents=True, exist_ok=True)
+    env = _configure_worker(case_dir)
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    torch.cuda.set_device(0)
+    torch.manual_seed(args.seed)
+    device = torch.device("cuda", 0)
+    cutlass_module, provenance = _load_cutlass_source(args.cutlass_source)
+    group_a, group_b, expected = _make_inputs(case.problems, device)
+    helion_outputs = _outputs(group_a, group_b)
+    cutlass_outputs = _outputs(group_a, group_b)
+
+    helion_launch, helion_config = _prepare_helion(
+        case, group_a, group_b, helion_outputs
+    )
+    cutlass_launch = _prepare_cutlass(
+        cutlass_module, case.problems, group_a, group_b, cutlass_outputs
+    )
+    helion_graph = _capture(helion_launch, args.compile_warmups, track_cute=True)
+    cutlass_graph = _capture(cutlass_launch, args.compile_warmups)
+
+    helion_graph.replay()
+    cutlass_graph.replay()
+    torch.cuda.synchronize()
+    correctness = {
+        "helion_retained": _correctness(helion_outputs, expected),
+        "cutlass": _correctness(cutlass_outputs, expected),
+    }
+    replay = {
+        "helion_retained": helion_graph.replay,
+        "cutlass": cutlass_graph.replay,
+    }
+    timings = _bench_pair(replay, args)
+    ratio = float(timings["helion_retained"]["median_ms"]) / float(
+        timings["cutlass"]["median_ms"]
+    )
+    result = {
+        "comparison": "cutlass_cutedsl_blackwell_grouped_gemm",
+        "case": case.name,
+        "shape_label": case.shape_label,
+        "problem_sizes": [list(problem) for problem in case.problems],
+        "device_name": torch.cuda.get_device_name(device),
+        "capability": list(torch.cuda.get_device_capability(device)),
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "cutlass_reference": provenance,
+        "helion_config": helion_config,
+        "settings": {
+            "seed": args.seed,
+            "compile_warmups": args.compile_warmups,
+            "num_runs": args.num_runs,
+            "warmup_ms": args.warmup_ms,
+            "rep_ms": args.rep_ms,
+            "cache_warmup_calls": args.cache_warmup_calls,
+            "thermal_warmup_ms": args.thermal_warmup_ms,
+            "fresh_subprocess_per_case": True,
+            "cutlass_graph_includes_pointer_table_upload": True,
+            "env": env,
+        },
+        "correctness": correctness,
+        "timings": timings,
+        "ratios_to_cutlass": {"helion_retained": ratio},
+    }
+    output = case_dir / "result.json"
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({"case": case.name, "result": str(output), "ratio": ratio}))
+    return 0
+
+
+def _geomean(values: Sequence[float]) -> float | None:
+    return math.exp(sum(map(math.log, values)) / len(values)) if values else None
+
+
+def _git(*args: str) -> str:
+    return subprocess.check_output(("git", *args), cwd=REPO_ROOT, text=True).strip()
+
+
+def _build_summary(
+    args: argparse.Namespace,
+    cases: Sequence[Case],
+    commands: Sequence[Mapping[str, object]],
+    failures: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    rows = []
+    for case in cases:
+        path = args.out_dir / "cutlass" / case.name / "result.json"
+        if not path.exists():
+            rows.append({"case": case.name, "status": "missing", "path": str(path)})
+            continue
+        result = json.loads(path.read_text())
+        rows.append(
+            {
+                "case": case.name,
+                "shape_label": case.shape_label,
+                "problem_sizes": result["problem_sizes"],
+                "status": "ok",
+                "timings": result["timings"],
+                "retained_over_cutlass": result["ratios_to_cutlass"].get(
+                    "helion_retained"
+                ),
+            }
+        )
+    ratios = [
+        float(value)
+        for row in rows
+        if isinstance((value := row.get("retained_over_cutlass")), int | float)
+    ]
+    return {
+        "artifact_dir": str(args.out_dir),
+        "top_level_command": " ".join(sys.argv),
+        "cutlass_source": str(args.cutlass_source),
+        "cutlass_commit": CUTLASS_COMMIT,
+        "cutlass_sha256": CUTLASS_SHA256,
+        "helion_cute_mma_impl": HELION_CUTE_MMA_IMPL,
+        "helion_git": {
+            "head": _git("rev-parse", "HEAD"),
+            "status_short": _git("status", "--short"),
+            "benchmark_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        },
+        "methodology": (
+            "fresh subprocess/case; common inputs; paired external do_bench CUDA "
+            "graph replays; one shared cache/thermal warmup phase; alternate "
+            "Helion/CUTLASS then CUTLASS/Helion; CUTLASS graph includes "
+            "pinned-host pointer-table upload"
+        ),
+        "rows": rows,
+        "wins": sum(ratio < 1 for ratio in ratios),
+        "total": len(ratios),
+        "geomean_helion_over_cutlass": _geomean(ratios),
+        "commands": list(commands),
+        "failures": list(failures),
+    }
+
+
+def _write_summary(args: argparse.Namespace, summary: Mapping[str, object]) -> None:
+    json_path = args.out_dir / "summary.json"
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({"summary": str(json_path)}))
+
+
+def _positive(text: str) -> int:
+    value = int(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return value
+
+
+def _non_negative(text: str) -> int:
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative integer")
+    return value
+
+
+def _positive_even(text: str) -> int:
+    value = _positive(text)
+    if value % 2:
+        raise argparse.ArgumentTypeError("expected a positive even integer")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--list-cases", action="store_true")
+    mode.add_argument("--run-case", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--case", choices=CASES_BY_NAME, action="append")
+    parser.add_argument("--cutlass-source", type=Path)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--cuda-visible-devices")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--compile-warmups", type=_positive, default=2)
+    parser.add_argument("--num-runs", type=_positive_even, default=6)
+    parser.add_argument("--warmup-ms", type=_non_negative, default=1000)
+    parser.add_argument("--rep-ms", type=_positive, default=500)
+    parser.add_argument("--cache-warmup-calls", type=_non_negative, default=5)
+    parser.add_argument("--thermal-warmup-ms", type=_non_negative, default=10000)
+    parser.add_argument("--stream-subprocesses", action="store_true")
+    parser.add_argument(
+        "--json", action="store_true", help="JSON output for --list-cases"
+    )
+    return parser
+
+
+def _selected_cases(args: argparse.Namespace) -> tuple[Case, ...]:
+    return tuple(CASES_BY_NAME[name] for name in args.case) if args.case else CASES
+
+
+def _worker_command(args: argparse.Namespace, case: Case) -> list[str]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--run-case",
+        "--case",
+        case.name,
+    ]
+    forwarded = (
+        ("cutlass-source", args.cutlass_source),
+        ("out-dir", args.out_dir),
+        ("seed", args.seed),
+        ("compile-warmups", args.compile_warmups),
+        ("num-runs", args.num_runs),
+        ("warmup-ms", args.warmup_ms),
+        ("rep-ms", args.rep_ms),
+        ("cache-warmup-calls", args.cache_warmup_calls),
+        ("thermal-warmup-ms", args.thermal_warmup_ms),
+    )
+    for name, value in forwarded:
+        if value is not None:
+            command.extend((f"--{name}", str(value)))
+    return command
+
+
+def _run_all(args: argparse.Namespace) -> int:
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    cases = _selected_cases(args)
+    env = os.environ.copy()
+    repo_path = str(REPO_ROOT)
+    env["PYTHONPATH"] = repo_path + os.pathsep + env.get("PYTHONPATH", "")
+    if args.cuda_visible_devices is not None:
+        env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
+    commands = []
+    failures = []
+    for case in cases:
+        command = _worker_command(args, case)
+        print(json.dumps({"starting": case.name}), flush=True)
+        proc = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        stdout_path = args.out_dir / f"cutlass_{case.name}.stdout.txt"
+        stderr_path = args.out_dir / f"cutlass_{case.name}.stderr.txt"
+        stdout_path.write_text(proc.stdout)
+        stderr_path.write_text(proc.stderr)
+        if args.stream_subprocesses:
+            print(proc.stdout, end="")
+            print(proc.stderr, end="", file=sys.stderr)
+        record = {
+            "case": case.name,
+            "cmd": command,
+            "returncode": proc.returncode,
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+        }
+        commands.append(record)
+        if proc.returncode:
+            failures.append(record)
+            if not args.stream_subprocesses:
+                print(proc.stderr, file=sys.stderr)
+    _write_summary(args, _build_summary(args, cases, commands, failures))
+    return int(bool(failures))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    args.out_dir = args.out_dir.expanduser().resolve()
+    if args.list_cases:
+        cases = _selected_cases(args)
+        payload = [
+            {
+                "name": case.name,
+                "shape_label": case.shape_label,
+                "problems": case.problems,
+            }
+            for case in cases
+        ]
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            for case in cases:
+                print(f"{case.name}: {case.shape_label}")
+        return 0
+    if args.cutlass_source is None:
+        parser.error("--cutlass-source is required")
+    args.cutlass_source = args.cutlass_source.expanduser().resolve()
+    return _run_case(args) if args.run_case else _run_all(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/cute/deepgemm_selected_path.py
+++ b/benchmarks/cute/deepgemm_selected_path.py
@@ -1,0 +1,630 @@
+# ruff: noqa: ANN401,E402
+
+"""Reproduce the Helion/DeepGEMM grouped BF16 NT comparison."""
+
+from __future__ import annotations
+
+import argparse
+from hashlib import sha256
+import importlib
+import json
+import os
+from pathlib import Path
+import random
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+from typing import NamedTuple
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import torch
+
+import helion
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+)
+import helion.language as hl
+import helion.runtime as helion_runtime
+
+DEEPGEMM_SELECTED_TILE_M = 256
+DEEPGEMM_SELECTED_TILE_N = 128
+DEEPGEMM_SELECTED_TILE_K = 64
+M_ALIGNMENT = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+DEEPGEMM_COMMIT = "559d79fb6994a58b8a15b4b93bf13ccc16edf247"
+DEEPGEMM_CUTLASS_COMMIT = "f3fde58372d33e9a5650ba7b80fc48b3b49d40c8"
+DEFAULT_L2_FLUSH_BYTES = 8_000_000_000
+CACHE_DIRS = {
+    "CUDA_CACHE_PATH": "cuda",
+    "CUTE_DSL_CACHE_DIR": "cute_dsl",
+    "DG_JIT_CACHE_DIR": "deepgemm_jit",
+    "HELION_CACHE_DIR": "helion",
+    "TORCHINDUCTOR_CACHE_DIR": "torchinductor",
+    "TRITON_CACHE_DIR": "triton",
+    "TORCH_EXTENSIONS_DIR": "torch_extensions",
+    "XDG_CACHE_HOME": "xdg",
+}
+
+
+class OfficialShape(NamedTuple):
+    row_index: int
+    groups: int
+    expected_m_per_group: int
+    n: int
+    k: int
+
+
+OFFICIAL_SHAPES = (
+    OfficialShape(0, 4, 8192, 6144, 7168),
+    OfficialShape(1, 4, 8192, 7168, 3072),
+    OfficialShape(2, 4, 8192, 4096, 4096),
+    OfficialShape(3, 4, 8192, 4096, 2048),
+    OfficialShape(4, 8, 4096, 6144, 7168),
+    OfficialShape(5, 8, 4096, 7168, 3072),
+    OfficialShape(6, 8, 4096, 4096, 4096),
+    OfficialShape(7, 8, 4096, 4096, 2048),
+)
+
+
+def align(value: int, alignment: int) -> int:
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def parse_rows(value: str) -> list[int]:
+    if value.strip().lower() == "all":
+        return list(range(len(OFFICIAL_SHAPES)))
+    rows: set[int] = set()
+    for item in value.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "-" in item:
+            start_text, end_text = item.split("-", 1)
+            start, end = int(start_text), int(end_text)
+            if start > end:
+                raise argparse.ArgumentTypeError(f"invalid row range {item}")
+            rows.update(range(start, end + 1))
+        else:
+            rows.add(int(item))
+    result = sorted(rows)
+    invalid = [row for row in result if row not in range(len(OFFICIAL_SHAPES))]
+    if not result or invalid:
+        message = (
+            f"row indices out of range: {invalid}" if invalid else "no rows selected"
+        )
+        raise argparse.ArgumentTypeError(message)
+    return result
+
+
+def official_actual_ms(seed: int = 0) -> tuple[tuple[int, ...], ...]:
+    rng = random.Random(seed)
+    return tuple(
+        tuple(
+            int(shape.expected_m_per_group * rng.uniform(0.7, 1.3))
+            for _ in range(shape.groups)
+        )
+        for shape in OFFICIAL_SHAPES
+    )
+
+
+def selected_key(
+    a_packed: torch.Tensor,
+    b_grouped: torch.Tensor,
+    worklist: torch.Tensor,
+) -> tuple[int, ...]:
+    return (*a_packed.shape, *b_grouped.shape, int(worklist.size(0)))
+
+
+def selected_kernel_body(
+    A_packed: torch.Tensor,
+    B_grouped: torch.Tensor,
+    work_tile_metadata: torch.Tensor,
+) -> torch.Tensor:
+    """
+    DeepGEMM-selected generated segment fallback for BF16 NT.
+
+    ``work_tile_metadata`` is int32 ``[W, 4]`` with compact rows
+    ``(group, group_start, actual_m, aligned_m)``. The selected N,M generated
+    path derives each source-M chunk's valid and store extents on device from
+    the grouped scheduler M tile.
+    """
+    M_total_aligned, K = A_packed.shape
+    _G, N, K2 = B_grouped.shape
+    assert K == K2, "K dimension mismatch between A_packed and B_grouped"
+    assert work_tile_metadata.size(1) == 4
+
+    block_m = hl.register_block_size(DEEPGEMM_SELECTED_TILE_M)
+    block_n = hl.register_block_size(DEEPGEMM_SELECTED_TILE_N)
+    block_k = hl.register_block_size(DEEPGEMM_SELECTED_TILE_K)
+    out = torch.empty(
+        M_total_aligned,
+        N,
+        dtype=A_packed.dtype,
+        device=A_packed.device,
+    )
+
+    for work_tile, tile_m, tile_n in hl.tile(
+        [work_tile_metadata.size(0), DEEPGEMM_SELECTED_TILE_M, N],
+        block_size=[1, block_m, block_n],
+    ):
+        work_id = work_tile.begin
+        group_id = work_tile_metadata[work_id, 0]
+        global_m_start = work_tile_metadata[work_id, 1]
+        valid_m = work_tile_metadata[work_id, 2]
+        store_m = work_tile_metadata[work_id, 3]
+        local_m = tile_m.index
+        row_index = global_m_start + local_m
+        valid_rows = local_m < valid_m
+        store_rows = local_m < store_m
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(K, block_size=block_k):
+            a_blk = hl.load(
+                A_packed,
+                [row_index, tile_k],
+                extra_mask=valid_rows[:, None],  # pyrefly: ignore[bad-index]
+            )
+            acc = torch.addmm(
+                acc,
+                a_blk,
+                B_grouped[group_id, tile_n, tile_k].T,
+            )
+        hl.store(
+            out,
+            [row_index, tile_n],
+            acc.to(out.dtype),
+            extra_mask=store_rows[:, None],  # pyrefly: ignore[bad-index]
+        )
+
+    return out
+
+
+def selected_config() -> helion.Config:
+    return helion.Config(
+        block_sizes=[
+            DEEPGEMM_SELECTED_TILE_M,
+            DEEPGEMM_SELECTED_TILE_N,
+            DEEPGEMM_SELECTED_TILE_K,
+        ],
+        l2_groupings=[1],
+        loop_orders=[[0, 1, 2]],
+        num_stages=7,
+        num_warps=8,
+        pid_type="persistent_interleaved",
+        tcgen05_cluster_m=2,
+        tcgen05_cluster_n=1,
+        tcgen05_ab_stages=7,
+        tcgen05_acc_stages=2,
+        tcgen05_c_stages=2,
+        tcgen05_num_epi_warps=4,
+        tcgen05_grouped_mode="worklist_nm",
+    )
+
+
+def make_case(
+    shape: OfficialShape,
+    actual_ms: Sequence[int],
+    device: torch.device,
+    m_alignment: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    aligned_ms = [align(value, m_alignment) for value in actual_ms]
+    m_total = sum(aligned_ms)
+    a = torch.randn((m_total, shape.k), device=device, dtype=torch.bfloat16)
+    b = torch.randn(
+        (shape.groups, shape.n, shape.k), device=device, dtype=torch.bfloat16
+    )
+    layout = torch.empty(m_total, device=device, dtype=torch.int32)
+    ref = torch.empty((m_total, shape.n), device=device, dtype=torch.bfloat16)
+    rows: list[tuple[int, int, int, int]] = []
+    start = 0
+    for group, (actual_m, aligned_m) in enumerate(
+        zip(actual_ms, aligned_ms, strict=True)
+    ):
+        actual_end, aligned_end = start + actual_m, start + aligned_m
+        layout[start:actual_end] = group
+        layout[actual_end:aligned_end] = -1
+        a[actual_end:aligned_end] = 0
+        ref[start:aligned_end] = a[start:aligned_end] @ b[group].T
+        rows.append((group, start, actual_m, aligned_m))
+        start = aligned_end
+    worklist = torch.tensor(rows, device=device, dtype=torch.int32)
+    return a.contiguous(), b.contiguous(), layout, ref, worklist
+
+
+def calc_diff(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    actual64, expected64 = actual.double(), expected.double()
+    denominator = (actual64.square() + expected64.square()).sum()
+    if float(denominator) == 0.0:
+        return 0.0
+    return float((1 - 2 * (actual64 * expected64).sum() / denominator).item())
+
+
+def correctness(
+    out: torch.Tensor,
+    ref: torch.Tensor,
+    layout: torch.Tensor,
+    max_diff: float,
+    padding_atol: float,
+    *,
+    require_zero_padding: bool,
+) -> dict[str, Any]:
+    valid, padding = layout >= 0, layout < 0
+    valid_diff = calc_diff(out[valid], ref[valid])
+    padding_max = float(out[padding].float().abs().max()) if padding.any() else 0.0
+    zero_padding_ok = padding_max <= padding_atol
+    return {
+        "valid_rows": int(valid.sum().item()),
+        "padding_rows": int(padding.sum().item()),
+        "calc_diff_valid": valid_diff,
+        "max_abs_padding_vs_zero": padding_max,
+        "require_zero_padding": require_zero_padding,
+        "zero_padding_ok": zero_padding_ok,
+        "ok": valid_diff <= max_diff and (zero_padding_ok or not require_zero_padding),
+    }
+
+
+def capture_and_check(
+    fn: Any,
+    ref: torch.Tensor,
+    layout: torch.Tensor,
+    args: argparse.Namespace,
+    *,
+    require_zero_padding: bool,
+    track_cute: bool = False,
+) -> tuple[Any, list[Any], dict[str, Any]]:
+    held = [fn() for _ in range(args.compile_warmups + 1)]
+    torch.cuda.synchronize()
+    if track_cute:
+        with helion_runtime.cute_cuda_graph() as graph:
+            captured = fn()
+    else:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = fn()
+    held.append(captured)
+    captured[layout < 0] = 13.0
+    graph.replay()
+    torch.cuda.synchronize()
+    check = correctness(
+        captured,
+        ref,
+        layout,
+        args.max_diff,
+        args.padding_atol,
+        require_zero_padding=require_zero_padding,
+    )
+    return graph, held, check
+
+
+def thermal_warmup(duration_ms: int) -> None:
+    if duration_ms <= 0:
+        return
+    value = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
+    end = time.monotonic() + duration_ms / 1000
+    while time.monotonic() < end:
+        for _ in range(50):
+            value = value @ value
+        torch.cuda.synchronize()
+
+
+def graph_timings(
+    graphs: Sequence[Any],
+    args: argparse.Namespace,
+    flops: int,
+) -> list[dict[str, Any]]:
+    graph_count = len(graphs)
+    for sample in range(args.warmups):
+        order = (
+            range(graph_count) if sample % 2 == 0 else range(graph_count - 1, -1, -1)
+        )
+        for index in order:
+            graphs[index].replay()
+    torch.cuda.synchronize()
+    thermal_warmup(args.thermal_warmup_ms)
+    l2_flush = (
+        torch.empty(args.l2_flush_bytes // 4, dtype=torch.int, device="cuda")
+        if args.l2_flush_bytes
+        else None
+    )
+    values: list[list[float]] = [[] for _ in graphs]
+    for sample in range(args.samples):
+        order = (
+            range(graph_count) if sample % 2 == 0 else range(graph_count - 1, -1, -1)
+        )
+        events: list[tuple[int, list[tuple[Any, Any]]]] = []
+        for index in order:
+            pairs = []
+            for _ in range(args.iters):
+                if l2_flush is not None:
+                    l2_flush.zero_()
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                start.record()
+                graphs[index].replay()
+                end.record()
+                pairs.append((start, end))
+            events.append((index, pairs))
+        torch.cuda.synchronize()
+        for index, pairs in events:
+            values[index].append(
+                statistics.mean(start.elapsed_time(end) * 1000 for start, end in pairs)
+            )
+    medians = [statistics.median(item) for item in values]
+    return [
+        {
+            "median_us": median,
+            "valid_tflops": flops / (median * 1e-6) / 1e12,
+            "samples_us": samples,
+        }
+        for median, samples in zip(medians, values, strict=True)
+    ]
+
+
+def git_output(root: Path, *args: str) -> str:
+    command = ["git", "-C", str(root), *args]
+    return subprocess.check_output(command, text=True).rstrip("\n")
+
+
+def git_provenance(root: Path) -> dict[str, Any]:
+    status = git_output(root, "status", "--porcelain=v1", "--untracked-files=all")
+    cutlass = root / "third-party" / "cutlass"
+    return {
+        "head": git_output(root, "rev-parse", "HEAD"),
+        "dirty": bool(status),
+        "status": status.splitlines(),
+        "cutlass_head": git_output(cutlass, "rev-parse", "HEAD"),
+        "cutlass_submodule_status": git_output(
+            root, "submodule", "status", "--", "third-party/cutlass"
+        ),
+    }
+
+
+def import_deepgemm(root: Path, m_alignment: int) -> tuple[Any, dict[str, Any]]:
+    root = root.expanduser().resolve()
+    if not root.is_dir():
+        raise RuntimeError(f"DeepGEMM root does not exist: {root}")
+    sys.path.insert(0, str(root))
+    module = importlib.import_module("deep_gemm")
+    if module.__file__ is None:
+        raise RuntimeError("deep_gemm has no module origin")
+    origin = Path(module.__file__).resolve()
+    if not origin.is_relative_to(root):
+        raise RuntimeError(f"deep_gemm resolved outside {root}: {origin}")
+    module.set_mk_alignment_for_contiguous_layout(m_alignment)
+    effective = int(module.get_mk_alignment_for_contiguous_layout())
+    if effective != m_alignment:
+        raise RuntimeError(f"DeepGEMM alignment is {effective}, expected {m_alignment}")
+    provenance = git_provenance(root)
+    if provenance["head"] != DEEPGEMM_COMMIT:
+        raise RuntimeError(
+            f"DeepGEMM HEAD is {provenance['head']}, expected {DEEPGEMM_COMMIT}"
+        )
+    if provenance["cutlass_head"] != DEEPGEMM_CUTLASS_COMMIT:
+        raise RuntimeError(
+            "DeepGEMM CUTLASS HEAD is "
+            f"{provenance['cutlass_head']}, expected {DEEPGEMM_CUTLASS_COMMIT}"
+        )
+    unexpected_status = set(provenance["status"]) - {"?? deep_gemm/include/fmt"}
+    if unexpected_status:
+        raise RuntimeError(
+            f"DeepGEMM checkout has unexpected changes: {unexpected_status}"
+        )
+    provenance.update({"module_origin": origin, "mk_alignment": effective})
+    return module, provenance
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", default="all")
+    parser.add_argument("--compare-deepgemm", action="store_true")
+    parser.add_argument("--deepgemm-root", type=Path)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--samples", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--warmups", type=int, default=5)
+    parser.add_argument("--compile-warmups", type=int, default=2)
+    parser.add_argument("--thermal-warmup-ms", type=int, default=10000)
+    parser.add_argument("--l2-flush-bytes", type=int, default=DEFAULT_L2_FLUSH_BYTES)
+    parser.add_argument("--m-alignment", type=int, default=M_ALIGNMENT)
+    parser.add_argument("--artifact-dir", type=Path)
+    parser.add_argument("--cache-root", type=Path)
+    parser.add_argument("--json-output", "--output", dest="json_output", type=Path)
+    parser.add_argument("--max-diff", type=float, default=1e-3)
+    parser.add_argument("--padding-atol", type=float, default=0.0)
+    return parser
+
+
+def run_shape(
+    args: argparse.Namespace,
+    shape: OfficialShape,
+    actual_ms: Sequence[int],
+    device: torch.device,
+    kernel: helion.Kernel,
+    deep_gemm: Any | None,
+) -> dict[str, Any]:
+    a, b, layout, ref, worklist = make_case(shape, actual_ms, device, args.m_alignment)
+    kernel_args = (a, b, worklist)
+    bound = kernel.bind(kernel_args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+
+    def helion_fn() -> torch.Tensor:
+        return bound(*kernel_args)
+
+    helion_graph, held, helion_check = capture_and_check(
+        helion_fn,
+        ref,
+        layout,
+        args,
+        require_zero_padding=True,
+        track_cute=True,
+    )
+    checks = {"helion_graph": helion_check}
+    deep_graph: Any | None = None
+    deep_held: list[Any] = []
+    if deep_gemm is not None:
+        deep_module = deep_gemm
+        deep_out = torch.empty_like(ref)
+
+        def deep_fn() -> torch.Tensor:
+            deep_module.m_grouped_bf16_gemm_nt_contiguous(a, b, deep_out, layout)
+            return deep_out
+
+        deep_graph, deep_held, checks["deepgemm_graph"] = capture_and_check(
+            deep_fn,
+            ref,
+            layout,
+            args,
+            require_zero_padding=False,
+        )
+    if not all(check["ok"] for check in checks.values()):
+        raise RuntimeError(f"correctness failed for official row {shape.row_index}")
+    valid_m = sum(actual_ms)
+    valid_flops = 2 * valid_m * shape.n * shape.k
+    graphs = (helion_graph,) if deep_graph is None else (helion_graph, deep_graph)
+    timings = graph_timings(graphs, args, valid_flops)
+    helion_timing = timings[0]
+    deep_timing = timings[1] if deep_graph is not None else None
+    row: dict[str, Any] = {
+        "row_index": shape.row_index,
+        "shape": shape._asdict(),
+        "actual_ms": list(actual_ms),
+        "work_tile_metadata": worklist.cpu().tolist(),
+        "selected_config": dict(kernel.configs[0]),
+        "correctness": checks,
+        "helion_graph_timing": helion_timing,
+    }
+    if deep_timing is not None:
+        row["deepgemm_graph_timing"] = deep_timing
+        row["ratio_helion_over_deepgemm"] = (
+            helion_timing["median_us"] / deep_timing["median_us"]
+        )
+    return row
+
+
+def run(args: argparse.Namespace) -> int:
+    selected_rows = parse_rows(args.rows)
+    artifact_dir = (args.artifact_dir or Path(tempfile.mkdtemp())).resolve()
+    output_path = (args.json_output or artifact_dir / "selected_results.json").resolve()
+    cache_root = (args.cache_root or artifact_dir / "caches").resolve()
+    if cache_root.exists() and (not cache_root.is_dir() or any(cache_root.iterdir())):
+        raise ValueError(f"refusing to reuse nonempty cache directory: {cache_root}")
+    output: dict[str, Any] = {
+        "artifact_dir": artifact_dir,
+        "json_output": output_path,
+        "official_shapes": [shape._asdict() for shape in OFFICIAL_SHAPES],
+        "selected_rows": selected_rows,
+        "rng_policy": "seed 0; one DeepGEMM-compatible stream across official rows",
+        "timing_methodology": (
+            "paired cold-L2 CUDA-event graph timings; each sample is the mean of "
+            "consecutive replays; first implementation alternates per sample"
+            if args.compare_deepgemm
+            else "single-implementation cold-L2 CUDA-event graph timings"
+        ),
+        "settings": vars(args),
+        "helion": {
+            "head": git_output(REPO_ROOT, "rev-parse", "HEAD"),
+            "dirty": bool(git_output(REPO_ROOT, "status", "--porcelain=v1")),
+            "benchmark_sha256": sha256(Path(__file__).read_bytes()).hexdigest(),
+        },
+        "rows": [],
+    }
+    os.environ["HELION_BACKEND"] = "cute"
+    os.environ["HELION_CUTE_MMA_IMPL"] = "tcgen05"
+    for name, subdir in CACHE_DIRS.items():
+        os.environ[name] = str(cache_root / subdir)
+    output["environment"] = {
+        key: value
+        for key, value in os.environ.items()
+        if key.startswith("HELION_")
+        or key in CACHE_DIRS
+        or key.endswith(("CUDA_HOME", "CUDA_VISIBLE_DEVICES"))
+    }
+    if (
+        min(args.samples, args.iters) <= 0
+        or min(
+            args.warmups,
+            args.compile_warmups,
+            args.thermal_warmup_ms,
+            args.l2_flush_bytes,
+        )
+        < 0
+    ):
+        raise ValueError(
+            "samples/iters must be positive; warmups and L2 flush must be non-negative"
+        )
+    if args.compare_deepgemm and args.samples % 2:
+        raise ValueError("--samples must be even when comparing DeepGEMM")
+    if args.l2_flush_bytes % 4:
+        raise ValueError("--l2-flush-bytes must be divisible by 4")
+    if args.m_alignment <= 0 or args.m_alignment % M_ALIGNMENT:
+        raise ValueError(f"--m-alignment must be a positive multiple of {M_ALIGNMENT}")
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available")
+    requested = torch.device(args.device)
+    if requested.type != "cuda":
+        raise RuntimeError(f"expected CUDA device, got {requested}")
+    if requested.index is not None:
+        torch.cuda.set_device(requested)
+    device = torch.device("cuda", torch.cuda.current_device())
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] < 10:
+        raise RuntimeError(f"compute capability {capability} is unsupported")
+    output.update(
+        device=str(device),
+        device_name=torch.cuda.get_device_name(device),
+        capability=capability,
+        torch=torch.__version__,
+        torch_cuda=torch.version.cuda,
+    )
+    deep_gemm = None
+    if args.compare_deepgemm:
+        if args.deepgemm_root is None:
+            raise RuntimeError("--compare-deepgemm requires --deepgemm-root")
+        deep_gemm, output["deepgemm"] = import_deepgemm(
+            args.deepgemm_root, args.m_alignment
+        )
+    torch.manual_seed(0)
+    actual_ms = official_actual_ms()
+    kernel = helion.kernel(
+        static_shapes=False, key=selected_key, config=selected_config()
+    )(selected_kernel_body)
+    with torch.cuda.device(device):
+        for row_index in selected_rows:
+            row = run_shape(
+                args,
+                OFFICIAL_SHAPES[row_index],
+                actual_ms[row_index],
+                device,
+                kernel,
+                deep_gemm,
+            )
+            output["rows"].append(row)
+            print(json.dumps(row, default=str, sort_keys=True), flush=True)
+            torch.cuda.empty_cache()
+    ratios = [row.get("ratio_helion_over_deepgemm") for row in output["rows"]]
+    ratios = [float(value) for value in ratios if value is not None]
+    if ratios:
+        output["deepgemm_comparison_summary"] = {
+            "geomean_ratio_helion_over_deepgemm": statistics.geometric_mean(ratios),
+            "helion_faster_rows": sum(value < 1 for value in ratios),
+            "rows": len(ratios),
+        }
+    output["status"] = "ok"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(output, default=str, indent=2, sort_keys=True) + "\n"
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return run(build_arg_parser().parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_cute_grouped_gemm_benchmark.py
+++ b/test/test_cute_grouped_gemm_benchmark.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+BENCHMARK_DIR = Path(__file__).resolve().parents[1] / "benchmarks" / "cute"
+
+
+def _load_script(filename: str, module_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, BENCHMARK_DIR / filename)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cutlass_benchmark() -> Any:
+    return _load_script(
+        "compare_grouped_gemm_backends.py",
+        "helion_test_compare_grouped_gemm_backends",
+    )
+
+
+@pytest.fixture(scope="module")
+def deepgemm_benchmark() -> Any:
+    return _load_script(
+        "deepgemm_selected_path.py",
+        "helion_test_deepgemm_selected_path",
+    )
+
+
+def test_published_manifests_are_fixed(
+    cutlass_benchmark: Any, deepgemm_benchmark: Any
+) -> None:
+    manifest = (
+        tuple(
+            (case.name, case.problems, case.reserved_sms, case.ab_stages)
+            for case in cutlass_benchmark.CASES
+        ),
+        tuple(tuple(shape) for shape in deepgemm_benchmark.OFFICIAL_SHAPES),
+        deepgemm_benchmark.selected_config().config,
+    )
+    assert hashlib.sha256(repr(manifest).encode()).hexdigest() == (
+        "deffec6097179b24ed4071fda1d7908fe57a1d291f0191187655bb39d9e5d9de"
+    )
+
+
+def test_cutlass_timings_are_paired_and_balanced(
+    cutlass_benchmark: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+    thermal_warmups: list[int] = []
+    args = cutlass_benchmark._parser().parse_args([])
+    assert (args.num_runs, args.cache_warmup_calls, args.thermal_warmup_ms) == (
+        6,
+        5,
+        10000,
+    )
+    args.num_runs = 2
+    args.cache_warmup_calls = args.thermal_warmup_ms = 0
+
+    def fake_bench(fn: Any, _args: argparse.Namespace) -> float:
+        fn()
+        return 1.0
+
+    monkeypatch.setattr(cutlass_benchmark, "_do_bench", fake_bench)
+    monkeypatch.setattr(cutlass_benchmark, "_thermal_warmup", thermal_warmups.append)
+    timings = cutlass_benchmark._bench_pair(
+        {
+            "helion_retained": lambda: order.append("H"),
+            "cutlass": lambda: order.append("C"),
+        },
+        args,
+    )
+
+    assert order == list("HCCH")
+    assert thermal_warmups == [0]
+    assert timings["helion_retained"]["runs_ms"] == [1.0, 1.0]
+    with pytest.raises(argparse.ArgumentTypeError, match="positive even"):
+        cutlass_benchmark._positive_even("5")
+
+
+def test_cutlass_loader_verifies_and_retains_bytes(
+    cutlass_benchmark: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    source = tmp_path / "grouped_gemm.py"
+    source.write_text("raise AssertionError('must not execute')\n")
+    with pytest.raises(ValueError, match="CUTLASS source SHA256 mismatch"):
+        cutlass_benchmark._load_cutlass_source(source)
+
+    source.write_text(
+        "class GroupedGemmKernel:\n"
+        "    marker = 'verified'\n"
+        "    num_tensormaps = bytes_per_tensormap = 1\n"
+        "def create_tensor_and_stride(*args):\n"
+        "    return args\n"
+    )
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    monkeypatch.setattr(cutlass_benchmark, "CUTLASS_SHA256", digest)
+    monkeypatch.setattr(
+        cutlass_benchmark.importlib.metadata, "version", lambda _name: "test"
+    )
+
+    module, provenance = cutlass_benchmark._load_cutlass_source(source)
+    source.write_text("raise AssertionError('changed after verification')\n")
+
+    assert module.GroupedGemmKernel.marker == "verified"
+    assert module.__file__ == f"<helion-cutlass-grouped-gemm-{digest}.py>"
+    assert provenance["source_sha256"] == digest
+    assert provenance["expected_cutlass_commit"] == cutlass_benchmark.CUTLASS_COMMIT
+
+
+def test_deepgemm_rows_and_single_rng_stream(deepgemm_benchmark: Any) -> None:
+    actual = deepgemm_benchmark.official_actual_ms(seed=0)
+    expected = (
+        (9884, 9459, 7801, 7007),
+        (8247, 7724, 9586, 7225),
+        (8076, 8601, 10197, 8215),
+        (7119, 9449, 8773, 6965),
+        (5102, 5282, 4858, 5084, 3629, 4660, 5076, 4548),
+        (4027, 3114, 3934, 4368, 5111, 5242, 4039, 4993),
+        (3507, 4845, 4215, 2901, 4635, 3847, 4894, 4509),
+        (2870, 4080, 4999, 3466, 3666, 5006, 3336, 4261),
+    )
+    selected = deepgemm_benchmark.parse_rows("7,2-4,2")
+
+    assert actual == expected
+    assert selected == [2, 3, 4, 7]
+    assert tuple(actual[row] for row in selected) == tuple(
+        expected[row] for row in selected
+    )
+    assert deepgemm_benchmark.parse_rows("all") == list(range(8))
+    with pytest.raises(argparse.ArgumentTypeError, match="invalid row range"):
+        deepgemm_benchmark.parse_rows("4-2")
+    with pytest.raises(argparse.ArgumentTypeError, match="out of range"):
+        deepgemm_benchmark.parse_rows("8")
+
+
+def test_deepgemm_timings_are_paired_and_alternate_first_graph(
+    deepgemm_benchmark: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    replay_order: list[str] = []
+    synchronizations = 0
+
+    class FakeGraph:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def replay(self) -> None:
+            replay_order.append(self.name)
+
+    class FakeEvent:
+        def record(self) -> None:
+            pass
+
+        def elapsed_time(self, end: FakeEvent) -> float:
+            return 2.0
+
+    class FakeL2Flush:
+        zero_calls = 0
+
+        def zero_(self) -> None:
+            self.zero_calls += 1
+
+    def synchronize() -> None:
+        nonlocal synchronizations
+        synchronizations += 1
+
+    monkeypatch.setattr(
+        deepgemm_benchmark.torch.cuda, "Event", lambda **_kwargs: FakeEvent()
+    )
+    monkeypatch.setattr(deepgemm_benchmark.torch.cuda, "synchronize", synchronize)
+    l2_flush = FakeL2Flush()
+    monkeypatch.setattr(
+        deepgemm_benchmark.torch,
+        "empty",
+        lambda size, **_kwargs: l2_flush if size == 1 else None,
+    )
+    thermal_warmups: list[int] = []
+    monkeypatch.setattr(deepgemm_benchmark, "thermal_warmup", thermal_warmups.append)
+    args = argparse.Namespace(
+        samples=4,
+        iters=2,
+        warmups=2,
+        thermal_warmup_ms=0,
+        l2_flush_bytes=4,
+    )
+
+    first, second = deepgemm_benchmark.graph_timings(
+        (FakeGraph("H"), FakeGraph("D")), args, flops=4_000_000_000
+    )
+
+    assert replay_order == list("HDDHHHDDDDHHHHDDDDHH")
+    assert synchronizations == 1 + args.samples
+    assert thermal_warmups == [0]
+    assert l2_flush.zero_calls == 2 * args.samples * args.iters
+    assert first["samples_us"] == second["samples_us"] == [2000.0] * args.samples
+    defaults = deepgemm_benchmark.build_arg_parser().parse_args([])
+    assert (
+        defaults.samples,
+        defaults.iters,
+        defaults.warmups,
+        defaults.thermal_warmup_ms,
+        defaults.l2_flush_bytes,
+    ) == (10, 50, 5, 10000, 8_000_000_000)


### PR DESCRIPTION
Stacked PRs:
 * #3042
 * __->__#3034
 * #3033
 * #3032
 * #3031


--- --- ---

## Implementation

This PR adds two standalone grouped-GEMM reproducibility scripts and their focused contract tests. It does not change production compiler or runtime code.

- `benchmarks/cute/compare_grouped_gemm_backends.py` compares seven explicit grouped NT shape sets with NVIDIA CUTLASS CuTeDSL. It verifies the pinned `grouped_gemm.py` digest before loading it, uses common inputs and correctness checks, runs each case in a fresh subprocess/cache, captures both implementations in CUDA graphs, and records paired rounds with alternating execution order.
- The CUTLASS harness retains each stream's pointer table and TensorMap workspace through launch completion, retains captured resources through graph replay, and includes the reference wrapper's pinned-host pointer-table upload inside the measured graph.
- `benchmarks/cute/deepgemm_selected_path.py` reproduces DeepGEMM's eight official grouped shapes and its seed-0 actual-M stream. It verifies the DeepGEMM and CUTLASS revisions, isolates caches, checks valid output and padding behavior, captures both implementations, and applies the documented thermal-warmup, cold-L2, pairing, and order-alternation policy.
- Both scripts record commands, source revisions/digests, environment, device, correctness, raw samples, medians, and aggregate ratios in machine-readable artifacts.
- `test/test_cute_grouped_gemm_benchmark.py` checks pinned-source loading, published cases, CLI and RNG/row contracts, pairing/order, resource lifetime, graph replay, cache isolation, and timing semantics with focused fakes.

The unit tests do **not** execute either full GPU benchmark. The standalone commands below are the reproducible performance entry points.

## Performance Results

Geometric-mean latency ratios are shown first. Ratios are Helion/reference, so values below `1.0` favor Helion.

| Reference | Repeat 1 geomean | Repeat 2 geomean | Result |
|---|---:|---:|---|
| CUTLASS CuTeDSL | **0.8928** | **0.8926** | Helion is 10.7% lower latency; 7/7 wins in both repeats |
| DeepGEMM | **0.9949** | **0.9948** | Helion is 0.5% lower latency; 6/8 wins in both repeats |

Both final repeats were collected from clean Helion commit `a9f735af2d8a78c0de49c45e99ca0a6503a40ca3` on an NVIDIA B200 (compute capability 10.0), using PyTorch `2.11.0+cu130` and CUDA `13.0`. The benchmark workers pin `HELION_CUTE_MMA_IMPL=tcgen05` to measure this path directly.

### CUTLASS CuTeDSL

Physical GPU 0. Each case uses common inputs, correctness checks, CUDA graph replay, and a fresh subprocess with fresh compiler caches. Each graph is prepared with `--compile-warmups 2`; both replays then receive five cache-warmup calls and one shared 10-second BF16 thermal warmup. Six paired `triton.testing.do_bench` rounds alternate Helion/CUTLASS and CUTLASS/Helion. Every round uses CUDA-event timing with `warmup=1000 ms` and `rep=500 ms`; the table reports the median of the six round means. The CUTLASS graph includes its pinned-host pointer-table upload.

Pinned reference: NVIDIA/cutlass `db1c288993354c88e551c40c19a8fb93a774a241`, `grouped_gemm.py` SHA256 `05b74a05682c024557d83284e32f973ed5be4f0d1a1a12c72fe7824c29f7e94f`, and `nvidia-cutlass-dsl==4.5.2`. Harness SHA256: `7e2efca8f381b431ab40ba3fd476378989308ef0d77766f62805a6b920039c75`.

| Case | Exact per-group `M x N x K` | R1 Helion us | R1 CUTLASS us | R1 H/C | R2 Helion us | R2 CUTLASS us | R2 H/C |
|---|---|---:|---:|---:|---:|---:|---:|
| `default_small_parity` | G3 [g0: 128x128x128, g1: 512x128x128, g2: 128x256x128] | 10.229 | 14.355 | 0.713 | 10.247 | 14.382 | 0.712 |
| `doc_no_mn_tail` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.532 | 24.572 | 0.917 | 22.534 | 24.575 | 0.917 |
| `doc_no_mn_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.921 | 24.583 | 0.932 | 22.897 | 24.611 | 0.930 |
| `doc_original` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x160x16] | 22.958 | 24.622 | 0.932 | 22.909 | 24.582 | 0.932 |
| `doc_mtail_g1_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.625 | 24.673 | 0.917 | 22.610 | 24.588 | 0.920 |
| `doc_mtail_g1_only` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.580 | 24.590 | 0.918 | 22.573 | 24.578 | 0.918 |
| `doc_ntail_g3_160` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x160x16] | 23.222 | 24.578 | 0.945 | 23.197 | 24.575 | 0.944 |

```bash
CUDA_VISIBLE_DEVICES=0 conda run --no-capture-output -n helion \
  python benchmarks/cute/compare_grouped_gemm_backends.py \
  --cutlass-source /tmp/cutlass-db1c2889-grouped-gemm.py \
  --out-dir <fresh-output-dir> --cuda-visible-devices 0 \
  --seed 0 --compile-warmups 2 --num-runs 6 \
  --warmup-ms 1000 --rep-ms 500 --cache-warmup-calls 5 \
  --thermal-warmup-ms 10000 --stream-subprocesses
```

### DeepGEMM

Physical GPU 3. Official shape is `(G, expected M/group, N, K)`; `actual M/group` is the exact seed-0 DeepGEMM-compatible M stream shared by both implementations. Each row uses `--compile-warmups 2`, five alternating graph warmups, and one 10-second BF16 thermal warmup. Ten paired samples alternate which implementation runs first; each sample averages 50 graph replays. An 8 GB L2 clear matching upstream DeepGEMM's `bench_kineto` default runs before every replay and outside its CUDA-event interval. The table reports the median of the ten sample means, and each repeat uses fresh compiler caches.

Pinned reference: DeepGEMM `559d79fb6994a58b8a15b4b93bf13ccc16edf247`, CUTLASS submodule `f3fde58372d33e9a5650ba7b80fc48b3b49d40c8`, and M alignment 224. The only untracked reference-checkout path was DeepGEMM's generated `deep_gemm/include/fmt` directory. Harness SHA256: `484741ae5259f8ce4f2f6216dc25c29def001dcb25b231e555b95998a667271e`.

| Row | Official `(G, M, N, K)` | Actual M/group | R1 Helion us | R1 DeepGEMM us | R1 H/D | R2 Helion us | R2 DeepGEMM us | R2 H/D |
|---:|---|---|---:|---:|---:|---:|---:|---:|
| 0 | `(4, 8192, 6144, 7168)` | `9884, 9459, 7801, 7007` | 2646.708 | 2518.028 | 1.051 | 2677.416 | 2562.513 | 1.045 |
| 1 | `(4, 8192, 7168, 3072)` | `8247, 7724, 9586, 7225` | 1070.407 | 1093.971 | 0.978 | 1081.872 | 1096.028 | 0.987 |
| 2 | `(4, 8192, 4096, 4096)` | `8076, 8601, 10197, 8215` | 872.093 | 877.294 | 0.994 | 873.244 | 880.124 | 0.992 |
| 3 | `(4, 8192, 4096, 2048)` | `7119, 9449, 8773, 6965` | 395.633 | 409.112 | 0.967 | 398.398 | 408.255 | 0.976 |
| 4 | `(8, 4096, 6144, 7168)` | `5102, 5282, 4858, 5084, 3629, 4660, 5076, 4548` | 3051.274 | 3021.418 | 1.010 | 3036.491 | 2995.513 | 1.014 |
| 5 | `(8, 4096, 7168, 3072)` | `4027, 3114, 3934, 4368, 5111, 5242, 4039, 4993` | 1168.279 | 1199.356 | 0.974 | 1166.589 | 1210.240 | 0.964 |
| 6 | `(8, 4096, 4096, 4096)` | `3507, 4845, 4215, 2901, 4635, 3847, 4894, 4509` | 835.664 | 836.549 | 0.999 | 837.359 | 838.471 | 0.999 |
| 7 | `(8, 4096, 4096, 2048)` | `2870, 4080, 4999, 3466, 3666, 5006, 3336, 4261` | 400.494 | 405.255 | 0.988 | 401.995 | 408.534 | 0.984 |

```bash
CUDA_VISIBLE_DEVICES=3 conda run --no-capture-output -n helion \
  python benchmarks/cute/deepgemm_selected_path.py \
  --rows all --compare-deepgemm \
  --deepgemm-root /tmp/DeepGEMM-559d79fb --device cuda \
  --samples 10 --iters 50 --warmups 5 --compile-warmups 2 \
  --thermal-warmup-ms 10000 --l2-flush-bytes 8000000000 \
  --m-alignment 224 --artifact-dir <fresh-output-dir> \
  --json-output <fresh-output-dir>/selected_results.json
```

All correctness checks passed in both final repeats.
