### PR TITLE
[autotuner] split reduction seed heuristics into per-hardware classes

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -18,11 +18,12 @@ from .pallas import PallasMatmulF32NoTilingSeedHeuristic
 from .pallas import PallasMatmulNoTilingSeedHeuristic
 from .triton import TritonB200MatmulHeuristic
 from .triton import TritonMatmulReductionEpilogueHeuristic
+from .triton import TritonNarrowReductionHeuristic
 from .triton import TritonPointwiseSeedHeuristic
 from .triton import TritonSkinnyGemmHeuristic
-from .triton import TritonStandardReductionHeuristic
+from .triton import TritonStandardReductionHeuristicSM90
 from .triton import TritonStandardReductionHeuristicSM100
-from .triton import TritonUserTiledReductionHeuristic
+from .triton import TritonUserTiledReductionHeuristicSM90
 from .triton import TritonUserTiledReductionHeuristicSM100
 
 if TYPE_CHECKING:
@@ -49,10 +50,11 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         TritonSkinnyGemmHeuristic,
         TritonB200MatmulHeuristic,
         TritonMatmulReductionEpilogueHeuristic,
-        TritonStandardReductionHeuristic,
+        TritonStandardReductionHeuristicSM90,
         TritonStandardReductionHeuristicSM100,
-        TritonUserTiledReductionHeuristic,
+        TritonUserTiledReductionHeuristicSM90,
         TritonUserTiledReductionHeuristicSM100,
+        TritonNarrowReductionHeuristic,
         TritonPointwiseSeedHeuristic,
     ),
     "pallas": (

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -528,12 +528,16 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     ``ReductionKernelFact`` through ONE budget allocator (:meth:`size_reduction_tiles`); the
     subclasses differ ONLY in how they map the allocation onto knobs (EMISSION routing):
 
-    - **standard** (:class:`TritonStandardReductionHeuristic`): Helion rolls the rdim into a
+    - **standard** (:class:`TritonStandardReductionHeuristicSM90`): Helion rolls the rdim into a
       ``reduction_loops`` loop, so the primary reduction's size lands on that knob.
-    - **user-tiled** (:class:`TritonUserTiledReductionHeuristic`): the user hand-writes the
+    - **user-tiled** (:class:`TritonUserTiledReductionHeuristicSM90`): the user hand-writes the
       ``hl.tile`` loop, so each reduction axis is a ``block_sizes`` entry.
 
-    Not registered; only the subclasses are.
+    Each track has a sm90/H100 class (``*SM90``) and a sm100/B200 subclass (``*SM100``); the
+    conservative upstream fallback for unclaimed hardware lives in the standalone
+    :class:`TritonNarrowReductionHeuristic`. Every concrete class gates its own hardware in
+    ``is_eligible`` (via ``cls.HARDWARE_TARGETS``), so ``get_seed_config`` never declines for the
+    wrong GPU. Not registered; only the concrete subclasses are.
     """
 
     backend = "triton"
@@ -1146,62 +1150,36 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
         )
 
 
-class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
-    """standard (Helion-rolled rdim) inner-reduction seed: Helion rolls the reduction axis
-    into a ``reduction_loops`` loop from a single ``.sum(-1)``-style op — sum, long_sum,
-    rms_norm, layer_norm, softmax-row, cross_entropy. Triton analog of
+class TritonStandardReductionHeuristicSM90(_TritonReductionSeedBase):
+    """standard (Helion-rolled rdim) inner-reduction seed for sm90/H100: Helion rolls the
+    reduction axis into a ``reduction_loops`` loop from a single ``.sum(-1)``-style op — sum,
+    long_sum, rms_norm, layer_norm, softmax-row, cross_entropy. Triton analog of
     ``CuteReductionTileHeuristic`` (keeps its registry name), deepening the original
     one-row/persistent/``['last']`` seed with the num_warps ramp, persistent-vs-looped,
     and per-slot eviction.
 
     Gated by ``_triton_reduction_eligible`` (standard track) — broader than upstream
     ``is_canonical_row_reduction`` (also multi-axis rollable rows and raised-``autotuner_min``
-    large-M shapes). Off sm90 the H100-tuned levers are unvalidated, so it falls back to
-    ``_narrow_seed`` (pre-existing behavior preserved).
+    large-M shapes) — AND the sm90 hardware target. sm100 routes to
+    :class:`TritonStandardReductionHeuristicSM100`; unclaimed hardware routes to
+    :class:`TritonNarrowReductionHeuristic`.
     """
 
     name = "triton_reduction_tile"
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        if not matches_hardware(env, cls.HARDWARE_TARGETS):
+            return False
         if not _triton_reduction_eligible(env, device_ir):
             return False
         pd = _primary_descriptor_selected(env)
         return pd is not None and _is_standard_reduction(pd)
 
     @classmethod
-    def _narrow_seed(cls, env: CompileEnvironment) -> Config:
-        """The upstream conservative standard seed (one row/program, single persistent pass,
-        ``['last']`` eviction where supported). A verbatim port used off sm90 so non-sm90
-        behavior is unchanged.
-        """
-        spec = env.config_spec
-        seed: dict[str, Any] = {
-            "block_sizes": [1],
-            "reduction_loops": [None],
-        }
-        # Emit 'last' only where the backend supports it; backends that restrict
-        # eviction to ("",) keep the spec default so the seed stays valid.
-        eviction = spec.load_eviction_policies
-        if (
-            eviction.length
-            and isinstance(eviction.inner, EnumFragment)
-            and "last" in eviction.inner.choices
-        ):
-            seed["load_eviction_policies"] = ["last"] * eviction.length
-        return Config(**seed)
-
-    @classmethod
     def get_seed_config(
         cls, env: CompileEnvironment, device_ir: DeviceIR
     ) -> Config | None:
-        if not matches_hardware(env, cls.HARDWARE_TARGETS):
-            # sm100 has its own subclass (``TritonStandardReductionHeuristicSM100``); decline here so
-            # exactly one reduction seed fires on B200.
-            if matches_hardware(env, (("cuda", "sm100"),)):
-                return None
-            # Off any other target: keep the upstream conservative seed.
-            return cls._narrow_seed(env)
         spec = env.config_spec
         pd = _primary_descriptor_selected(env)
         if pd is None:
@@ -1275,10 +1253,10 @@ class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
         return Config(**seed)
 
 
-class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
-    """user-tiled inner-reduction seed: fires when the user hand-writes the ``hl.tile`` loop
-    over the reduction axis (so the rdim is an ordinary ``block_sizes`` entry, e.g.
-    ``hl.tile(n, block_size=R_BLOCK)``), which the upstream gate rejects entirely.
+class TritonUserTiledReductionHeuristicSM90(_TritonReductionSeedBase):
+    """user-tiled inner-reduction seed for sm90/H100: fires when the user hand-writes the
+    ``hl.tile`` loop over the reduction axis (so the rdim is an ordinary ``block_sizes`` entry,
+    e.g. ``hl.tile(n, block_size=R_BLOCK)``), which the upstream gate rejects entirely.
 
     Every axis (the reduction r_block(s), the grid rows, the apply loops) is sized by the shared
     :meth:`size_reduction_tiles` ONE budget allocator — there are NO per-band branches. The kernel
@@ -1294,6 +1272,8 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        if not matches_hardware(env, cls.HARDWARE_TARGETS):
+            return False
         if not _triton_reduction_eligible(env, device_ir):
             return False
         pd = _primary_descriptor_selected(env)
@@ -1303,9 +1283,6 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
     def get_seed_config(
         cls, env: CompileEnvironment, device_ir: DeviceIR
     ) -> Config | None:
-        if not matches_hardware(env, cls.HARDWARE_TARGETS):
-            # Off sm90: upstream never fired on user-tiled, so no prior seed to preserve. Decline.
-            return None
         spec = env.config_spec
         pd = _primary_descriptor_selected(env)
         if pd is None:
@@ -1346,12 +1323,14 @@ def _config_with_num_warps(cfg: Config, num_warps: int) -> Config:
 
 
 # ============================ sm100 (B200) dedicated subclasses ============================ #
-# Re-target the sm90 reduction seeds at sm100 via a subclass that overrides only the hardware gate +
+# Re-target the sm90 reduction seeds at sm100 via a subclass that overrides only the hardware target +
 # B200 constants; the sm90/H100 emit is a separate class + gate, so it stays frozen.
 class _TritonReductionSeedSM100(_TritonReductionSeedBase):
     """sm100 (B200) constant/gate carrier for the two reduction seed tracks. Overrides the hardware
-    gate and re-tunes constants (as class attributes) only where a B200 measurement demands it. Not
-    registered; the two concrete subclasses below are.
+    target and re-tunes constants (as class attributes) only where a B200 measurement demands it. The
+    concrete subclasses inherit ``is_eligible`` from their sm90 track class, which gates on
+    ``cls.HARDWARE_TARGETS`` (sm100 here) — so hardware selection lives in ``is_eligible``, not in
+    this ``get_seed_config``. Not registered; the two concrete subclasses below are.
 
     ``promote_seed_to_default`` is left at the base default (``False``) here: the sm100 reduction
     seed is still contributed as an autotuner seed, but is NOT promoted to the compiler default until
@@ -1375,10 +1354,7 @@ class _TritonReductionSeedSM100(_TritonReductionSeedBase):
     def get_seed_config(
         cls, env: CompileEnvironment, device_ir: DeviceIR
     ) -> Config | None:
-        # Fire the inherited rich seed ONLY on sm100; decline elsewhere so this promoted class never
-        # overrides the frozen sm90/H100 default.
-        if not matches_hardware(env, cls.HARDWARE_TARGETS):
-            return None
+        # Build the inherited sm90-track seed (is_eligible already confirmed sm100), then re-tune.
         cfg = super().get_seed_config(env, device_ir)
         if cfg is None:
             return None
@@ -1425,23 +1401,73 @@ class _TritonReductionSeedSM100(_TritonReductionSeedBase):
 
 
 class TritonStandardReductionHeuristicSM100(
-    _TritonReductionSeedSM100, TritonStandardReductionHeuristic
+    _TritonReductionSeedSM100, TritonStandardReductionHeuristicSM90
 ):
     """standard (Helion-rolled rdim) inner-reduction seed for sm100/B200: the rich
-    :class:`TritonStandardReductionHeuristic` allocator with B200 constants from
+    :class:`TritonStandardReductionHeuristicSM90` allocator with B200 constants from
     :class:`_TritonReductionSeedSM100`."""
 
     name = "triton_reduction_tile_sm100"
 
 
 class TritonUserTiledReductionHeuristicSM100(
-    _TritonReductionSeedSM100, TritonUserTiledReductionHeuristic
+    _TritonReductionSeedSM100, TritonUserTiledReductionHeuristicSM90
 ):
     """user-tiled inner-reduction seed for sm100/B200: the rich
-    :class:`TritonUserTiledReductionHeuristic` allocator with B200 constants from
+    :class:`TritonUserTiledReductionHeuristicSM90` allocator with B200 constants from
     :class:`_TritonReductionSeedSM100`."""
 
     name = "triton_reduction_user_tile_sm100"
+
+
+# Hardware the tuned reduction seeds own; the narrow fallback yields to these targets.
+_TUNED_REDUCTION_TARGETS: tuple[HardwareTarget, ...] = (
+    ("cuda", "sm90"),
+    ("cuda", "sm100"),
+)
+
+
+class TritonNarrowReductionHeuristic(AutotunerHeuristic):
+    """Conservative upstream reduction fallback for hardware WITHOUT a tuned track (anything
+    other than sm90/sm100): one row/program, single persistent pass, ``['last']`` eviction where
+    supported. Fires only for a STANDARD (Helion-rolled) reduction — the user-tiled track had no
+    upstream seed, so it stays unclaimed on non-sm90/sm100. Not promoted (the un-tuned baseline
+    should not override the compiler default). This is the verbatim pre-sm100 behavior, now its own
+    class rather than an off-target branch inside the sm90 heuristic.
+    """
+
+    name = "triton_reduction_narrow"
+    backend = "triton"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        # Only where no tuned track owns the hardware.
+        if matches_hardware(env, _TUNED_REDUCTION_TARGETS):
+            return False
+        if not _triton_reduction_eligible(env, device_ir):
+            return False
+        pd = _primary_descriptor_selected(env)
+        return pd is not None and _is_standard_reduction(pd)
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        spec = env.config_spec
+        seed: dict[str, Any] = {
+            "block_sizes": [1],
+            "reduction_loops": [None],
+        }
+        # Emit 'last' only where the backend supports it; backends that restrict
+        # eviction to ("",) keep the spec default so the seed stays valid.
+        eviction = spec.load_eviction_policies
+        if (
+            eviction.length
+            and isinstance(eviction.inner, EnumFragment)
+            and "last" in eviction.inner.choices
+        ):
+            seed["load_eviction_policies"] = ["last"] * eviction.length
+        return Config(**seed)
 
 
 class TritonMatmulReductionEpilogueHeuristic(AutotunerHeuristic):

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -16,13 +16,17 @@ from helion._compiler.autotuner_heuristics.cute import CuteFlashAttentionHeurist
 from helion._compiler.autotuner_heuristics.cute import CuteFp8GemmSkinnyMHeuristic
 from helion._compiler.autotuner_heuristics.cute import CuteTcgen05ClusterM2Heuristic
 from helion._compiler.autotuner_heuristics.registry import AutotunerHeuristic
+from helion._compiler.autotuner_heuristics.triton import TritonNarrowReductionHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonPointwiseSeedHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonSkinnyGemmHeuristic
 from helion._compiler.autotuner_heuristics.triton import (
-    TritonStandardReductionHeuristic,
+    TritonStandardReductionHeuristicSM90,
 )
 from helion._compiler.autotuner_heuristics.triton import (
-    TritonUserTiledReductionHeuristic,
+    TritonStandardReductionHeuristicSM100,
+)
+from helion._compiler.autotuner_heuristics.triton import (
+    TritonUserTiledReductionHeuristicSM90,
 )
 from helion._compiler.backend import CuteBackend
 from helion._compiler.backend import TritonBackend
@@ -950,7 +954,9 @@ class TestTritonStandardReductionHeuristic(TestCase):
             patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
             patch("helion.runtime.get_num_sm", return_value=132),
         ):
-            seed = TritonStandardReductionHeuristic.get_seed_config(env, MagicMock())
+            seed = TritonStandardReductionHeuristicSM90.get_seed_config(
+                env, MagicMock()
+            )
         self.assertEqual(seed.config["block_sizes"], [1])
         self.assertEqual(seed.config["reduction_loops"], [None])
         # rnumel ramp: 1024 falls in the <=1024 band -> 4 warps.
@@ -976,7 +982,9 @@ class TestTritonStandardReductionHeuristic(TestCase):
             patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
             patch("helion.runtime.get_num_sm", return_value=132),
         ):
-            seed = TritonStandardReductionHeuristic.get_seed_config(env, MagicMock())
+            seed = TritonStandardReductionHeuristicSM90.get_seed_config(
+                env, MagicMock()
+            )
         self.assertEqual(
             seed.config["load_eviction_policies"],
             ["first", "first", "first", "first"],
@@ -999,7 +1007,9 @@ class TestTritonStandardReductionHeuristic(TestCase):
             patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
             patch("helion.runtime.get_num_sm", return_value=132),
         ):
-            seed = TritonStandardReductionHeuristic.get_seed_config(env, MagicMock())
+            seed = TritonStandardReductionHeuristicSM90.get_seed_config(
+                env, MagicMock()
+            )
         spec.compiler_seed_configs = [seed]
         pairs = ConfigGeneration(spec).seed_flat_config_pairs()
         self.assertEqual(len(pairs), 1)
@@ -1008,16 +1018,23 @@ class TestTritonStandardReductionHeuristic(TestCase):
 
     def test_not_eligible_without_single_reduction_tile(self) -> None:
         env = MagicMock()
-        # No reduction loop -> not a reduction.
-        spec = ConfigSpec(backend=TritonBackend())
-        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
-        env.config_spec = spec
-        self.assertFalse(TritonStandardReductionHeuristic.is_eligible(env, MagicMock()))
-        # A matmul fact disqualifies even a 1-tile/1-reduction shape.
-        spec_mm = self._reduction_spec(reduction_size_hint=1024)
-        spec_mm.matmul_facts = [MagicMock()]
-        env.config_spec = spec_mm
-        self.assertFalse(TritonStandardReductionHeuristic.is_eligible(env, MagicMock()))
+        # Pin the sm90 target so this exercises the STRUCTURAL gate, not the hardware gate
+        # (is_eligible now checks hardware first).
+        with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
+            # No reduction loop -> not a reduction.
+            spec = ConfigSpec(backend=TritonBackend())
+            spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+            env.config_spec = spec
+            self.assertFalse(
+                TritonStandardReductionHeuristicSM90.is_eligible(env, MagicMock())
+            )
+            # A matmul fact disqualifies even a 1-tile/1-reduction shape.
+            spec_mm = self._reduction_spec(reduction_size_hint=1024)
+            spec_mm.matmul_facts = [MagicMock()]
+            env.config_spec = spec_mm
+            self.assertFalse(
+                TritonStandardReductionHeuristicSM90.is_eligible(env, MagicMock())
+            )
 
     @onlyBackends(["triton"])
     @skipIfRefEager("Compiler heuristics are not collected in ref eager mode")
@@ -1047,36 +1064,92 @@ class TestTritonStandardReductionHeuristic(TestCase):
         red = row_reduction.bind(
             (torch.randn(1024, 1024, device=DEVICE, dtype=HALF_DTYPE),)
         )
-        self.assertTrue(
-            TritonStandardReductionHeuristic.is_eligible(
-                red.env, red.host_function.device_ir
-            )
-        )
-        # Pin the sm90/H100 target so the tuned seed path runs regardless of the CI runner's
-        # GPU: on sm100 (B200) this class declines (returns None) so the dedicated
-        # ``TritonStandardReductionHeuristicSM100`` subclass is the sole reduction seed, so an
-        # unpatched call would return None on a B200 runner.
-        with (
-            patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
-            patch("helion.runtime.get_num_sm", return_value=132),
-        ):
-            seed = TritonStandardReductionHeuristic.get_seed_config(
-                red.env, red.host_function.device_ir
-            )
-        self.assertEqual(seed.config["block_sizes"], [1])
-        self.assertEqual(seed.config["reduction_loops"], [None])
-
         mm = matmul.bind(
             (
                 torch.randn(256, 256, device=DEVICE, dtype=HALF_DTYPE),
                 torch.randn(256, 256, device=DEVICE, dtype=HALF_DTYPE),
             )
         )
-        self.assertFalse(
-            TritonStandardReductionHeuristic.is_eligible(
-                mm.env, mm.host_function.device_ir
+        # Pin the sm90/H100 target so the sm90 heuristic is exercised regardless of the CI
+        # runner's GPU: the hardware gate now lives in ``is_eligible`` (sm100/B200 routes to
+        # ``TritonStandardReductionHeuristicSM100``, other GPUs to the narrow fallback), so on a
+        # B200 runner the unpatched ``is_eligible`` would be False.
+        with (
+            patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
+            patch("helion.runtime.get_num_sm", return_value=132),
+        ):
+            self.assertTrue(
+                TritonStandardReductionHeuristicSM90.is_eligible(
+                    red.env, red.host_function.device_ir
+                )
             )
+            seed = TritonStandardReductionHeuristicSM90.get_seed_config(
+                red.env, red.host_function.device_ir
+            )
+            # A matmul is not a reduction, so the reduction seed declines even on its own target.
+            self.assertFalse(
+                TritonStandardReductionHeuristicSM90.is_eligible(
+                    mm.env, mm.host_function.device_ir
+                )
+            )
+        self.assertEqual(seed.config["block_sizes"], [1])
+        self.assertEqual(seed.config["reduction_loops"], [None])
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler heuristics are not collected in ref eager mode")
+    def test_exactly_one_reduction_track_eligible_per_hardware(self) -> None:
+        # The hardware gate lives in ``is_eligible``: for a standard reduction, EXACTLY one of
+        # the three standard-track classes fires per GPU — sm90 -> SM90, sm100 -> SM100, anything
+        # else -> the narrow fallback — and none of them return None-for-deferral from
+        # ``get_seed_config``. This is the invariant the class split exists to guarantee.
+        @helion.kernel(backend="triton")
+        def row_reduction(x: torch.Tensor) -> torch.Tensor:
+            m, _ = x.size()
+            out = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                row = x[tile_m, :]
+                shifted = row - torch.amax(row, dim=-1, keepdim=True)
+                out[tile_m] = torch.log(torch.sum(torch.exp(shifted), dim=-1))
+            return out
+
+        red = row_reduction.bind(
+            (torch.randn(1024, 1024, device=DEVICE, dtype=HALF_DTYPE),)
         )
+        env, device_ir = red.env, red.host_function.device_ir
+        # (hardware, the one class expected to fire).
+        cases = [
+            (HOPPER_HARDWARE, TritonStandardReductionHeuristicSM90),
+            (BLACKWELL_HARDWARE, TritonStandardReductionHeuristicSM100),
+            (
+                HardwareInfo(
+                    device_kind="cuda",
+                    hardware_name="NVIDIA A10G",
+                    runtime_version="12.8",
+                    compute_capability="sm86",
+                ),
+                TritonNarrowReductionHeuristic,
+            ),
+        ]
+        tracks = [
+            TritonStandardReductionHeuristicSM90,
+            TritonStandardReductionHeuristicSM100,
+            TritonNarrowReductionHeuristic,
+        ]
+        for hardware, expected in cases:
+            with (
+                patch("helion._hardware.get_hardware_info", return_value=hardware),
+                patch("helion.runtime.get_num_sm", return_value=132),
+            ):
+                eligible = [t for t in tracks if t.is_eligible(env, device_ir)]
+                self.assertEqual(
+                    eligible,
+                    [expected],
+                    f"{hardware.compute_capability}: expected only {expected.__name__}",
+                )
+                # The eligible class always yields a real Config (never None-for-deferral).
+                seed = expected.get_seed_config(env, device_ir)
+                self.assertIsNotNone(seed)
+                self.assertEqual(seed.config["block_sizes"], [1])
 
 
 _FP8_SKINNY_M_SEED_BLOCK_SIZES = [1, 256]
@@ -4370,10 +4443,10 @@ class TestTritonReductionHeuristic(TestCase):
     track:
 
     - rms_norm wide (rnumel=16384): the standard path
-      (``TritonStandardReductionHeuristic``) seeds a persistent reduction
+      (``TritonStandardReductionHeuristicSM90``) seeds a persistent reduction
       (``reduction_loops=[None]``) with the rnumel-ramp warp count.
     - kl_div wide (rnumel=131072): the Band-B (user-tiled) path
-      (``TritonUserTiledReductionHeuristic``) caps R_BLOCK by the accumulator footprint
+      (``TritonUserTiledReductionHeuristicSM90``) caps R_BLOCK by the accumulator footprint
       instead of going full-N persistent, with M at floor 1.
     """
 
@@ -4388,7 +4461,7 @@ class TestTritonReductionHeuristic(TestCase):
             torch.randn([n], device=DEVICE, dtype=torch.float32),
             1e-5,
         )
-        heuristic = TritonStandardReductionHeuristic
+        heuristic = TritonStandardReductionHeuristicSM90
 
         # Pin the kernel to the triton backend: autotuner_heuristics is keyed on
         # env.backend_name, and the tileir lane (where @onlyBackends(["triton"]) still
@@ -4397,7 +4470,8 @@ class TestTritonReductionHeuristic(TestCase):
         kernel = helion.kernel(rms_norm_fwd.fn, backend="triton")
 
         # Force the sm90 deep path so the test exercises the H100-tuned seed on any
-        # runner (off-sm90 the heuristic falls back to the conservative narrow seed).
+        # runner (off-sm90 a different class fires: SM100 on B200, the narrow fallback
+        # elsewhere).
         with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
             bound = kernel.bind(args)
 
@@ -4410,7 +4484,7 @@ class TestTritonReductionHeuristic(TestCase):
             # row in the reduction scope), so no reduce-then-apply tile is captured.
             self.assertEqual(kf.non_reduction_loop_block_ids, ())
             self.assertIn(
-                TritonStandardReductionHeuristic.name,
+                TritonStandardReductionHeuristicSM90.name,
                 bound.config_spec.autotuner_heuristics,
             )
             self.assertTrue(
@@ -4436,7 +4510,7 @@ class TestTritonReductionHeuristic(TestCase):
         log_q = torch.log_softmax(torch.randn([m, n], device=DEVICE), dim=-1)
         p = torch.softmax(torch.randn([m, n], device=DEVICE), dim=-1)
         args = (log_q, p)
-        heuristic = TritonUserTiledReductionHeuristic
+        heuristic = TritonUserTiledReductionHeuristicSM90
 
         # Pin the kernel to the triton backend: autotuner_heuristics is keyed on
         # env.backend_name, and the tileir lane (where @onlyBackends(["triton"]) still
@@ -4445,7 +4519,8 @@ class TestTritonReductionHeuristic(TestCase):
         kernel = helion.kernel(kl_div_forward.fn, backend="triton")
 
         # Force the sm90 deep path so the Band-B seed is exercised on any runner
-        # (off-sm90 the heuristic declines to the conservative narrow seed).
+        # (off-sm90 a different class fires: SM100 on B200; the narrow fallback covers
+        # only the standard track, so user-tiled simply does not seed elsewhere).
         with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
             bound = kernel.bind(args)
 
@@ -4458,7 +4533,7 @@ class TestTritonReductionHeuristic(TestCase):
             self.assertGreaterEqual(fact.carried_2d_count, 1)
             self.assertEqual(kf.non_reduction_loop_block_ids, ())
             self.assertIn(
-                TritonUserTiledReductionHeuristic.name,
+                TritonUserTiledReductionHeuristicSM90.name,
                 bound.config_spec.autotuner_heuristics,
             )
             self.assertTrue(
@@ -4518,8 +4593,8 @@ class TestTritonReductionHeuristic(TestCase):
 
         def check(m: int, n: int, expect_looped: bool) -> None:
             # Force the sm90 deep path so the standard+normalize seed is exercised on
-            # any runner (off-sm90 the heuristic falls back to the narrow seed, which
-            # does not widen the normalize tile).
+            # any runner (off-sm90 the narrow fallback fires instead, which does not
+            # widen the normalize tile).
             with patch(
                 "helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE
             ):
@@ -4538,7 +4613,7 @@ class TestTritonReductionHeuristic(TestCase):
                 self.assertNotIn(fact.block_id, kf.non_reduction_loop_block_ids)
                 self.assertEqual(fact.carried_2d_count, 0)
                 self.assertIn(
-                    TritonStandardReductionHeuristic.name,
+                    TritonStandardReductionHeuristicSM90.name,
                     bound.config_spec.autotuner_heuristics,
                 )
                 # Exactly one seed; block_sizes has an entry per tiled dim (grid +
@@ -4560,7 +4635,7 @@ class TestTritonReductionHeuristic(TestCase):
             if expect_looped:
                 self.assertEqual(
                     seed["reduction_loops"],
-                    [TritonStandardReductionHeuristic.LOOPED_CHUNK],
+                    [TritonStandardReductionHeuristicSM90.LOOPED_CHUNK],
                 )
                 # At m_block==1 the normalize tile is clamped to the SAME ÷M_BLOCK
                 # register-resident footprint as the reduction tile, NOT left at
@@ -4572,7 +4647,8 @@ class TestTritonReductionHeuristic(TestCase):
                 from helion._utils import prev_power_of_2
 
                 expected_norm = prev_power_of_2(
-                    TritonStandardReductionHeuristic.ROW_PERSIST_MAX_BYTES // (1 * 4)
+                    TritonStandardReductionHeuristicSM90.ROW_PERSIST_MAX_BYTES
+                    // (1 * 4)
                 )
                 self.assertEqual(expected_norm, 32768)
                 self.assertEqual(seed["block_sizes"][norm_idx], expected_norm)
@@ -4595,7 +4671,7 @@ class TestTritonReductionHeuristic(TestCase):
         # constructed spec (bare-spec, no active env — the allocator reads stored hints).
         from helion.autotuner.config_spec import BlockSizeSpec
 
-        H = TritonUserTiledReductionHeuristic
+        H = TritonUserTiledReductionHeuristicSM90
         size_hint = 4096  # next_pow2(size_hint) == 4096
 
         def spec_with(reduction_bid: int, norm_bid: int) -> ConfigSpec:


### PR DESCRIPTION
Stacked PRs:
 * #3036
 * __->__#3035


--- --- ---

### [autotuner] split reduction seed heuristics into per-hardware classes


Refactor the reduction seed heuristics so hardware selection lives in
``is_eligible`` (matching the matmul convention: TritonSkinnyGemmHeuristic /
TritonB200MatmulHeuristic each gate hardware in is_eligible and never decline
for the wrong GPU inside get_seed_config).

Before, a single ``TritonStandardReductionHeuristic`` gated only on kernel
STRUCTURE in ``is_eligible`` and then re-gated on HARDWARE inside
``get_seed_config`` — returning None on sm100 to defer to the promoted
``...SM100`` subclass, and falling back to a narrow seed on unclaimed GPUs.
That made ``is_eligible`` and ``get_seed_config`` disagree on B200 (eligible
True, seed None), which is the trap that broke
``test_fires_for_reduction_not_matmul`` on the B200 runner.

Now each concrete class owns exactly one hardware target and its
``get_seed_config`` never declines for the wrong GPU:

- ``TritonStandardReductionHeuristicSM90`` / ``TritonUserTiledReductionHeuristicSM90``
  (renamed from the unqualified names; gate sm90 in is_eligible)
- ``TritonStandardReductionHeuristicSM100`` / ``TritonUserTiledReductionHeuristicSM100``
  (inherit is_eligible from their SM90 track, which gates on the sm100
  HARDWARE_TARGETS override)
- ``TritonNarrowReductionHeuristic`` (new): the conservative upstream fallback,
  extracted into its own class, eligible only on hardware WITHOUT a tuned track
  and only for a standard reduction (user-tiled had no upstream seed) — verbatim
  pre-sm100 behavior, not promoted.

The registry ``name`` strings are unchanged for the sm90/sm100 tracks (cache
continuity); the fallback adds ``triton_reduction_narrow``. Exactly one
reduction track is eligible per GPU (sm90 -> SM90, sm100 -> SM100, else ->
narrow), codified by the new
``test_exactly_one_reduction_track_eligible_per_hardware``.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
