### PR TITLE
[autotuner] promote reduction seed to default (sm90 + sm100) + make it safe

### DIFF
--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -209,7 +209,13 @@ def _materialize_config(
         and allowed_pid_types
         and supported["pid_type"] not in allowed_pid_types
     ):
-        supported.pop("pid_type")
+        # Replace an illegal pid_type with the highest-preference legal one rather
+        # than popping it: a plain pop lets ``normalize`` refill the field with
+        # ``VALID_PID_TYPES[0]`` (== 'flat'), which re-introduces the disallowed value
+        # (e.g. under ``hl.barrier()`` / a data-dependent grid bound / force-persistent,
+        # where 'flat' is disallowed). ``allowed_pid_types`` is guaranteed non-empty and
+        # order-preserving, so ``[0]`` is a valid persistent choice when 'flat' is stripped.
+        supported["pid_type"] = allowed_pid_types[0]
     config_spec.normalize(supported, _fix_invalid=True)
     config = Config(**cast("dict[str, Any]", supported))
     config_spec._shrink_for_numel_constraints(config)
@@ -543,6 +549,14 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     backend = "triton"
     # Widen the declared type so the sm100 subclass can retarget it (the base is sm90-only).
     HARDWARE_TARGETS: ClassVar[tuple[HardwareTarget, ...]] = (("cuda", "sm90"),)
+    # Promote the reduction seed to the compiler default (autotune off) for every tuned track
+    # that derives from this base -- sm90/H100 AND sm100/B200. The narrow fallback
+    # (TritonNarrowReductionHeuristic) does NOT derive from this base, so it stays unpromoted.
+    # This is safe because the seed only emits valid configs: it materializes through
+    # ``_materialize_config`` (an illegal ``pid_type`` is repaired to a legal persistent type),
+    # ``ReductionLoopSpec._normalize`` floors a degenerate looped chunk of 1, and the reduction
+    # roller refuses to roll a scan-containing reduction (which would drop the scan's chunk carry).
+    promote_seed_to_default = True
 
     # ----- THE BUDGET (a register/byte capacity; everything else is a per-axis desire) -----
     # Per-program persistent byte ceiling: the group's resident working set — the sum over its live
@@ -1250,7 +1264,11 @@ class TritonStandardReductionHeuristicSM90(_TritonReductionSeedBase):
             evict = cls._eviction_policies(env, "reread", pd.reread_eviction_index)
         if evict is not None:
             seed["load_eviction_policies"] = evict
-        return Config(**seed)
+        # Materialize through the shared guard so an emitted config value that is
+        # illegal for this kernel is repaired rather than shipped raw: a hardcoded
+        # ``pid_type='flat'`` is replaced with a legal persistent type when 'flat' is
+        # disallowed (barrier / data-dependent grid bound), matching the matmul seed path.
+        return _materialize_config(seed, config_spec=spec)
 
 
 class TritonUserTiledReductionHeuristicSM90(_TritonReductionSeedBase):
@@ -1312,7 +1330,10 @@ class TritonUserTiledReductionHeuristicSM90(_TritonReductionSeedBase):
             ev = cls._eviction_policies(env, "reread", pd.reread_eviction_index)
             if ev is not None:
                 seed["load_eviction_policies"] = ev
-        return Config(**seed)
+        # See the standard branch: materialize through the shared guard so an illegal
+        # ``pid_type='flat'`` (disallowed under a barrier / data-dependent bound) is
+        # repaired to a legal persistent type instead of shipping the raw seed.
+        return _materialize_config(seed, config_spec=spec)
 
 
 def _config_with_num_warps(cfg: Config, num_warps: int) -> Config:
@@ -1332,9 +1353,8 @@ class _TritonReductionSeedSM100(_TritonReductionSeedBase):
     ``cls.HARDWARE_TARGETS`` (sm100 here) — so hardware selection lives in ``is_eligible``, not in
     this ``get_seed_config``. Not registered; the two concrete subclasses below are.
 
-    ``promote_seed_to_default`` is left at the base default (``False``) here: the sm100 reduction
-    seed is still contributed as an autotuner seed, but is NOT promoted to the compiler default until
-    a later change flips it on (together with the config-validity fixes that make promotion safe)."""
+    ``promote_seed_to_default`` is inherited from :class:`_TritonReductionSeedBase` (``True`` for
+    every tuned track, sm90 and sm100 alike)."""
 
     HARDWARE_TARGETS = (("cuda", "sm100"),)
     # --- B200 constant overrides (re-tuned during the climb; unset = direct port of H100) ---

--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -25,6 +25,7 @@ from ..language.matmul_ops import dot_scaled as hl_dot_scaled
 from ..language.memory_ops import load
 from ..language.memory_ops import store
 from ..language.reduce_ops import _reduce
+from ..language.scan_ops import _associative_scan
 from ..language.view_ops import join as hl_join
 from ..language.view_ops import split as hl_split
 from .aten_lowering import aten_lowering_dispatch
@@ -102,6 +103,16 @@ class ReductionRoller:
             # TODO(jansel): support rolling user-defined reductions
             raise NotImplementedError(
                 "hl._reduce operations are not compatible with reduction rolling"
+            )
+
+        if node.target is _associative_scan:
+            # It appears associative scans are not rollable: a scan needs the
+            # running prefix from all prior elements, but the scan codegen assumes
+            # the whole scan dimension is one tile (there is no cross-tile prefix
+            # carry). Rolling re-runs the scan per chunk with no carry, silently
+            # dropping the cross-chunk prefix. Refuse to roll -> stay persistent.
+            raise NotImplementedError(
+                "hl.associative_scan operations are not compatible with reduction rolling"
             )
 
         if is_for_loop_target(node.target) or node.target is _if:

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2598,6 +2598,17 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
         if value is None:
             return None
         normalized = super()._normalize(name, value)
+        # A looped chunk of 1 is degenerate: "hold the whole axis" is encoded as
+        # ``None`` (persistent), not 1, and ``LoopedReductionStrategy`` rejects a
+        # block size <= 1.  The autotuner search never proposes < 8 (its fragment
+        # ``low`` is 8), but the reduction seed's byte budget can collapse the chunk
+        # to 1 on a reduction co-resident with a wide feature.  Floor a stray 1 up to
+        # that same search floor of 8; for a small extent the ``>= size_hint`` rule
+        # below then collapses it to persistent ``None``, and 1 is the only
+        # power-of-two chunk that can hit this (so legal chunks 2, 4, 8, ... are
+        # left byte-identical).
+        if isinstance(normalized, int) and normalized < 2:
+            normalized = 8
         # A looped reduction whose chunk equals or exceeds the reduction
         # extent has only one iteration — it is semantically identical to a
         # persistent reduction, but the looped codegen path occasionally

--- a/test/test_associative_scan.py
+++ b/test/test_associative_scan.py
@@ -10,7 +10,10 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfCute
+from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfRefEager
+from helion._testing import skipIfTileIR
 import helion.language as hl
 from helion.runtime.settings import _get_backend
 
@@ -1057,6 +1060,35 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
         if _get_backend() == "triton":
             self.assertIn("def argmax_combine_tuple_fn_", code)
             self.assertIn("tl.associative_scan", code)
+
+    @skipIfNotCUDA()
+    @skipIfRefEager(
+        "promoted-seed reduction_loops is only materialized in compiled mode"
+    )
+    @skipIfTileIR("TileIR reduction tiling differs")
+    @skipIfCute("reduction seed is Triton-only; CuTe uses its own reduction tiling")
+    def test_scan_in_reduction_default_config_not_looped(self) -> None:
+        """Regression: a scan (cumsum) inside a reduction over an axis co-resident with
+        a wide feature must not be emitted as a LOOPED reduction. The looped path
+        re-runs the scan per chunk with no cross-chunk prefix carry (silently wrong);
+        the reduction roller now refuses to roll a scan-containing reduction, keeping
+        it persistent. Run with the promoted default (no explicit config) and match
+        torch.cumsum; before the fix the seed looped this and was ~55% wrong. Shapes
+        are kept small so the persistent tile fits a small GPU."""
+
+        @helion.kernel(autotune_effort="none")
+        def cumsum_mid_reduce(x: torch.Tensor) -> torch.Tensor:
+            m, _r, n = x.shape
+            out = torch.empty([m, n], dtype=torch.float32, device=x.device)
+            for tile_m in hl.tile(m):
+                c = torch.cumsum(x[tile_m, :, :].to(torch.float32), dim=1)
+                out[tile_m, :] = c.amax(1)
+            return out
+
+        x = torch.randn([8, 4, 2048], device=DEVICE, dtype=torch.float32)
+        expected = torch.cumsum(x.double(), dim=1).amax(1).float()
+        _code, out = code_and_output(cumsum_mid_reduce, (x,))
+        torch.testing.assert_close(out, expected, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -15,6 +15,7 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 import helion.exc as exc
@@ -290,6 +291,34 @@ class TestBarrier(RefEagerTestBase, TestCase):
         self.assertEqual(len(device_ir.graphs), original_graph_count + 1)
         self.assertEqual(len(device_ir.rolled_reductions), 1)
         self.assertEqual(len(fake_env.config_spec.reduction_loops), 1)
+
+    @skipIfNotCUDA()
+    @skipIfRefEager("promoted-seed pid_type is only materialized in compiled mode")
+    @skipIfTileIR("TileIR does not support barrier operations")
+    def test_reduction_seed_default_config_is_persistent(self) -> None:
+        """Regression: the promoted sm100 reduction seed hardcodes pid_type='flat',
+        but hl.barrier() forces a persistent kernel. With autotuning off (no explicit
+        config, so the promoted seed IS the default) the kernel must still compile with
+        a persistent pid_type and match the reference -- before the fix this raised
+        helion.exc.BarrierRequiresPersistent. No pid_type/config is passed, so this
+        exercises config_spec.default_config() (the promoted seed)."""
+
+        @helion.kernel(autotune_effort="none")
+        def barrier_reduction(x: torch.Tensor) -> torch.Tensor:
+            m, _ = x.size()
+            partial = torch.empty([m], dtype=torch.float32, device=x.device)
+            out = torch.empty([m], dtype=torch.float32, device=x.device)
+            for tile_m in hl.tile(m):
+                partial[tile_m] = x[tile_m, :].to(torch.float32).sum(-1)
+            hl.barrier()
+            for tile_m in hl.tile(m):
+                out[tile_m] = partial[tile_m] * 2.0
+            return out
+
+        x = torch.randn([256, 8192], device=DEVICE, dtype=torch.float32)
+        expected = (x.double().sum(-1) * 2.0).float()
+        _code, out = code_and_output(barrier_reduction, (x,))
+        torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-2)
 
 
 @onlyBackends(["cute"])

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -13,6 +13,8 @@ from helion._testing import TestCase
 from helion._testing import _get_backend
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfCute
+from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfNotTriton
 from helion._testing import skipIfPallas
 from helion._testing import skipIfRefEager
@@ -997,6 +999,34 @@ class TestReductions(RefEagerTestBase, TestCase):
         inv_rms_y = torch.rsqrt(torch.mean(y_f * y_f, dim=-1) + 1e-5)
         expected_y = (y_f * inv_rms_y[:, None] * w2.float()).half()
         torch.testing.assert_close(out_y, expected_y, rtol=1e-2, atol=1e-2)
+
+    @skipIfNotCUDA()
+    @skipIfRefEager(
+        "promoted-seed reduction_loops is only materialized in compiled mode"
+    )
+    @skipIfTileIR("TileIR reduction tiling differs")
+    @skipIfCute("reduction seed is Triton-only; CuTe uses its own reduction tiling")
+    def test_mid_axis_reduce_wide_feature_default_config(self) -> None:
+        """Regression: a reduction over a small middle axis co-resident with a wide
+        feature ([M, R, N].sum(1), R small, N large) run with the promoted default (no
+        explicit config) must produce a VALID reduction_loops and match the reference.
+        The byte-budget reduction seed used to collapse the rolled chunk to
+        ``reduction_loops=[1]``, which ``LoopedReductionStrategy`` rejects (block_size >
+        1); the ``ReductionLoopSpec._normalize`` floor now repairs it. Shapes are kept
+        small so the persistent tile fits a small GPU under parallel test execution."""
+
+        @helion.kernel(autotune_effort="none")
+        def mid_axis_reduce(x: torch.Tensor) -> torch.Tensor:
+            m, _r, n = x.shape
+            out = torch.empty([m, n], dtype=torch.float32, device=x.device)
+            for tile_m in hl.tile(m):
+                out[tile_m, :] = x[tile_m, :, :].to(torch.float32).sum(1)
+            return out
+
+        x = torch.randn([8, 4, 2048], device=DEVICE, dtype=torch.float32)
+        expected = x.sum(1)
+        _code, out = code_and_output(mid_axis_reduce, (x,))
+        torch.testing.assert_close(out, expected, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs:
 * __->__#3036
 * #3035


--- --- ---

### [autotuner] promote reduction seed to default (sm90 + sm100) + make it safe


Set ``promote_seed_to_default = True`` on ``_TritonReductionSeedBase``, so the
reduction heuristic's config becomes the compiler default (autotune off) for
EVERY tuned reduction track that derives from it -- sm90/H100 AND sm100/B200,
both the standard (rolled) and user-tiled tracks. The conservative
``TritonNarrowReductionHeuristic`` fallback does not derive from that base, so it
stays unpromoted on untuned hardware. This consolidates the promote flag into one
source of truth (previously it was set only on the sm100 carrier).

Promotion is gated on three config-validity fixes that ensure the seed only ever
emits a config the base default would also run correctly. A seed-vs-default
correctness hunt on the B200 found these three seed-wrong breaks, where the
promoted seed crashed or was silently wrong on a kernel the pre-promotion default
handled; the fixes are hardware-agnostic, so they protect the sm90 path too:

1. pid_type: the reduction seeds hardcoded ``pid_type='flat'`` and returned the
   raw Config. When a kernel disallows 'flat' (``hl.barrier()`` / a data-dependent
   grid bound / force-persistent), the promoted seed crashed (BarrierRequiresPersistent)
   while the base default picked 'persistent_blocked'. Fix: route both reduction
   seeds through ``_materialize_config``, and make that guard REPLACE an illegal
   pid_type with ``allowed_pid_types[0]`` instead of popping it (a plain pop let
   ``normalize`` refill 'flat' again). This also repairs the same latent bug on the
   matmul table seed under force-persistent.

2. reduction_loops=[1]: on a reduction co-resident with a wide feature, the seed's
   byte budget collapsed the rolled chunk to ``reduction_loops=[1]``, which
   ``LoopedReductionStrategy`` rejects (block_size > 1). Fix: floor a degenerate
   looped chunk of 1 up to 8 in ``ReductionLoopSpec._normalize`` (1 is the only
   power-of-two chunk that can hit this, so legal chunks 2/4/8/... are byte-identical;
   for a small extent the existing ``>= size_hint -> None`` rule then collapses it
   to persistent).

3. scan-containing reduction: a ``torch.cumsum`` / ``hl.associative_scan`` inside a
   reduction that got rolled re-ran the scan per chunk with no cross-chunk prefix
   carry (silently wrong ~55%). Fix: the reduction roller now refuses to roll a
   graph containing ``_associative_scan`` (mirroring the existing ``hl._reduce``
   refusal), so it stays persistent.

Adds a regression test per break (barrier+reduction persistent default; mid-axis
wide-feature valid reduction_loops; scan-in-reduction stays persistent), each
verified to fail on the raw seed and pass with the fix, and gated to CUDA
(@skipIfNotCUDA) since the reduction seed only engages on sm90/sm100.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
