### PR TITLE
Restore CuTe flash attention fast path

### DIFF
--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -2264,13 +2264,7 @@ class CuteBackend(Backend):
             # addmm/mm with float16/bfloat16 operands.
             mma_mode = False
             if is_device_loop:
-                mma_mode = _detect_specialized_mma_loop(
-                    fn,
-                    block_ids,
-                    block_sizes=nd_block_size,
-                    config=config,
-                )
-                if not mma_mode and _detect_attention_mma_loop(
+                if _detect_attention_mma_loop(
                     fn,
                     block_ids,
                     config=config,
@@ -2281,6 +2275,13 @@ class CuteBackend(Backend):
                     # whole device body; the FX-graph statement walk is bypassed.
                     mma_mode = True
                     fn.cute_state.attention_flash_block_ids = list(block_ids)
+                else:
+                    mma_mode = _detect_specialized_mma_loop(
+                        fn,
+                        block_ids,
+                        block_sizes=nd_block_size,
+                        config=config,
+                    )
             elif (
                 len(device_ir.grid_block_ids) == 1
                 and block_ids == device_ir.grid_block_ids[0]
@@ -2340,7 +2341,9 @@ class CuteBackend(Backend):
                 inactive_block_ids=inactive_block_ids,
             )
         nd_block_size = [bs.from_config_assert(config) for bs in block_size_infos]
-        block_size = functools.reduce(operator.mul, nd_block_size)  # pyrefly: ignore[incompatible-overload-residual]
+        block_size = functools.reduce(
+            operator.mul, nd_block_size
+        )  # pyrefly: ignore[incompatible-overload-residual]
         # Resolve per-axis thread counts then flatten to a single total
         all_auto = all(nt <= 0 for nt in num_threads_config)
         flat_num_threads = functools.reduce(

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -8777,6 +8777,23 @@ def flash_attention_tensor_plan(df: DeviceFunction) -> FlashTensorPlan | None:
     if graph_plan is None:
         return None
 
+    required_names = (
+        graph_plan.q_name,
+        graph_plan.k_name,
+        graph_plan.v_name,
+        graph_plan.o_name,
+        *graph_plan.bias_names,
+        *graph_plan.alibi_names,
+        *graph_plan.document_names,
+    )
+    if graph_plan.lse_name is not None:
+        required_names = (*required_names, graph_plan.lse_name)
+    host_tensors = _flash_graph_host_tensors(df.codegen.codegen_graphs)
+    if any(name not in host_tensors for name in required_names):
+        return None
+    for name in dict.fromkeys(required_names):
+        df.tensor_arg(host_tensors[name], prefer_name=name)
+
     tensor_args = [a for a in df.arguments if isinstance(a, TensorArg)]
     tensor_args_by_name = {a.name: a for a in tensor_args}
     q_arg = tensor_args_by_name.get(graph_plan.q_name)
@@ -8914,11 +8931,12 @@ def flash_attention_tensor_plan(df: DeviceFunction) -> FlashTensorPlan | None:
 def codegen_attention_flash(cg: GenerateAST) -> bool:
     """Replace the device body with the fused tcgen05 flash-attention kernel.
 
-    Called from ``generate_ast.visit_For`` after the FX body walk completes and
-    the flash detector has set ``attention_flash_block_ids``. Returns True when
-    the flash kernel was emitted (and the FX-derived body discarded), False when
-    the shape/layout is outside the validated envelope (so the caller keeps the
-    scalar fallback body). Because the detector routes through the same
+    Called from ``generate_ast.visit_For`` after the flash detector has set
+    ``attention_flash_block_ids``. Returns True when the flash kernel was emitted
+    and the FX-derived scalar body can be skipped, False when the shape/layout is
+    outside the validated envelope. The caller treats False as a late validation
+    failure and raises ``BackendUnsupported`` rather than emitting the scalar
+    body. Because the detector routes through the same
     ``flash_attention_tensor_plan`` gate, a False return here is a defensive
     backstop rather than an expected path.
     """

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -323,6 +323,24 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                 out.add(name)
         return out
 
+    def _clear_attention_flash_state(self) -> None:
+        cute_state = self.device_function.cute_state
+        cute_state.attention_flash_block_ids = None
+        cute_state.attention_flash_score_plan = None
+        cute_state.attention_flash_threads = 128
+
+    def _try_codegen_attention_flash_root(self) -> bool:
+        cute_state = self.device_function.cute_state
+        if cute_state.attention_flash_block_ids is None:
+            return False
+
+        from .cute.cute_flash import codegen_attention_flash
+
+        if codegen_attention_flash(self):
+            return True
+        self._clear_attention_flash_state()
+        raise exc.BackendUnsupported("cute", "flash attention failed late validation")
+
     def add_statement(self, stmt: ast.AST | str | None) -> None:
         if stmt is None:
             return
@@ -1083,27 +1101,32 @@ class GenerateAST(NodeVisitor, CodegenInterface):
 
                         codegen_fn(state)
                     root = root_graph_info.graph
-                    grid_state = self.current_grid_state
-                    if isinstance(grid_state, DeviceGridState):
-                        # Codegen the body first so synthetic free-``hl.arange``
-                        # lane loops registered *during* body lowering (CuTe
-                        # over-budget chunking) are visible to the wrap below.
-                        wrapped_body: list[ast.AST] = []
-                        with self.set_statements(wrapped_body):
-                            codegen_call_with_graph(self, root, [])
-                        if grid_state.has_lane_loops():
-                            self.statements_stack[-1].extend(grid_state.outer_prefix)
-                            if self.device_function.cute_state.consume_root_lane_loop_suppression():
-                                self.statements_stack[-1].extend(wrapped_body)
-                            else:
+                    if not self._try_codegen_attention_flash_root():
+                        grid_state = self.current_grid_state
+                        if isinstance(grid_state, DeviceGridState):
+                            # Codegen the body first so synthetic free-``hl.arange``
+                            # lane loops registered *during* body lowering (CuTe
+                            # over-budget chunking) are visible to the wrap below.
+                            wrapped_body: list[ast.AST] = []
+                            with self.set_statements(wrapped_body):
+                                codegen_call_with_graph(self, root, [])
+                            if grid_state.has_lane_loops():
                                 self.statements_stack[-1].extend(
-                                    grid_state.wrap_body(wrapped_body)
+                                    grid_state.outer_prefix
                                 )
-                            self.statements_stack[-1].extend(grid_state.outer_suffix)
+                                if self.device_function.cute_state.consume_root_lane_loop_suppression():
+                                    self.statements_stack[-1].extend(wrapped_body)
+                                else:
+                                    self.statements_stack[-1].extend(
+                                        grid_state.wrap_body(wrapped_body)
+                                    )
+                                self.statements_stack[-1].extend(
+                                    grid_state.outer_suffix
+                                )
+                            else:
+                                self.statements_stack[-1].extend(wrapped_body)
                         else:
-                            self.statements_stack[-1].extend(wrapped_body)
-                    else:
-                        codegen_call_with_graph(self, root, [])
+                            codegen_call_with_graph(self, root, [])
                 finally:
                     self.current_root_graph_info = previous_root_graph_info
 
@@ -1151,23 +1174,6 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                         self.device_function.body = self.device_function.cute_state.move_tcgen05_post_loop_stmts_to_end(
                             list(self.device_function.body)
                         )
-                # Fused tcgen05 flash-attention (HELION_CUTE_FLASH): the
-                # detector set ``attention_flash_block_ids``; replace the
-                # FX-derived scalar body with the dedicated tensor-core flash
-                # kernel that mirrors ``.notes/spikes/fa_tcgen05_spike.py``.
-                if (
-                    self.device_function.cute_state.attention_flash_block_ids
-                    is not None
-                ):
-                    from .cute.cute_flash import codegen_attention_flash
-
-                    if not codegen_attention_flash(self):
-                        # Codegen declined a config the detector could not fully
-                        # vet before the device-function arguments were populated
-                        # (e.g. non-contiguous operands). Clear the flash state so
-                        # the launch override does not force block=(N,1,1) onto
-                        # the scalar fallback body that stays in df.body.
-                        self.device_function.cute_state.attention_flash_block_ids = None
                 # Mark extra params as placeholder args — they appear only in
                 # placeholder strings, not in the AST body, so DCE would
                 # otherwise remove them.

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -2439,7 +2439,13 @@ class TestCuteBackend(TestCase):
         """With the gate default-on, square fp16 attention at [1,128,128] lowers
         to the fused tcgen05 flash kernel and matches SDPA for head_dim 64/128."""
         for head_dim in (64, 128):
-            with self.subTest(head_dim=head_dim):
+            with (
+                self.subTest(head_dim=head_dim),
+                patch(
+                    "helion._compiler.cute.backend._detect_specialized_mma_loop",
+                    return_value=True,
+                ),
+            ):
                 q, k, v = (
                     torch.randn(2, 8, 256, head_dim, dtype=torch.float16, device=DEVICE)
                     for _ in range(3)
@@ -2705,6 +2711,22 @@ class TestCuteBackend(TestCase):
         self.assertIn("problem_shape_ntile_mnl=(32, 64, 1)", code)
         expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
         torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_flash_attention_late_rejection_is_safe(self) -> None:
+        q, k, v = (
+            torch.randn(2, 8, 256, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        with (
+            patch(
+                "helion._compiler.cute.backend._detect_specialized_mma_loop",
+                return_value=True,
+            ),
+            patch.object(_cute_flash, "codegen_attention_flash", return_value=False),
+            self.assertRaisesRegex(BackendUnsupported, "failed late validation"),
+        ):
+            bound = cute_dense_attention.bind((q, k, v))
+            bound.to_triton_code(helion.Config(block_sizes=[1, 128, 128]))
 
     def test_flash_attention_bfloat16_fires_and_matches_sdpa(self) -> None:
         q, k, v = (


### PR DESCRIPTION
Stacked PRs:
 * __->__#3042
 * #3034
 * #3033
 * #3032
 * #3031


--- --- ---

## Implementation

This PR restores the fused CuTe flash-attention route without changing generic grouped-GEMM behavior.

- Runs flash-attention detection before generic specialized-MMA detection so the generic loop matcher cannot consume a compatible attention loop first.
- Resolves and registers graph-proven Q/K/V/output tensors and optional LSE, bias, ALiBi, and document-mask tensors before early fused replacement.
- Emits the fused flash root before scalar FX-body codegen, keeping the attention-specific replacement independent of scalar code that the fused kernel supersedes.
- Clears flash state and raises `BackendUnsupported` if late validation rejects the fused envelope, preventing scalar code from launching with partially installed flash-specific state.
- Adds regression coverage for detector precedence, graph argument registration, early replacement, and safe late rejection. The tests mock only the specialized-loop gate rather than globally forcing tcgen05.

No flash-attention performance claim is made here. The grouped-GEMM measurements below cover the full stack beneath this attention-only layer and are included as stack context.

## Performance Results

Geometric-mean latency ratios are shown first. Ratios are Helion/reference, so values below `1.0` favor Helion.

| Reference | Repeat 1 geomean | Repeat 2 geomean | Result |
|---|---:|---:|---|
| CUTLASS CuTeDSL | **0.8928** | **0.8926** | Helion is 10.7% lower latency; 7/7 wins in both repeats |
| DeepGEMM | **0.9949** | **0.9948** | Helion is 0.5% lower latency; 6/8 wins in both repeats |

Both final repeats were collected from clean Helion commit `a9f735af2d8a78c0de49c45e99ca0a6503a40ca3` on an NVIDIA B200 (compute capability 10.0), using PyTorch `2.11.0+cu130` and CUDA `13.0`. The benchmark workers pin `HELION_CUTE_MMA_IMPL=tcgen05` to measure this path directly.

### CUTLASS CuTeDSL

Physical GPU 0. Each case uses common inputs, correctness checks, CUDA graph replay, and a fresh subprocess with fresh compiler caches. Each graph is prepared with `--compile-warmups 2`; both replays then receive five cache-warmup calls and one shared 10-second BF16 thermal warmup. Six paired `triton.testing.do_bench` rounds alternate Helion/CUTLASS and CUTLASS/Helion. Every round uses CUDA-event timing with `warmup=1000 ms` and `rep=500 ms`; the table reports the median of the six round means. The CUTLASS graph includes its pinned-host pointer-table upload.

Pinned reference: NVIDIA/cutlass `db1c288993354c88e551c40c19a8fb93a774a241`, `grouped_gemm.py` SHA256 `05b74a05682c024557d83284e32f973ed5be4f0d1a1a12c72fe7824c29f7e94f`, and `nvidia-cutlass-dsl==4.5.2`. Harness SHA256: `7e2efca8f381b431ab40ba3fd476378989308ef0d77766f62805a6b920039c75`.

| Case | Exact per-group `M x N x K` | R1 Helion us | R1 CUTLASS us | R1 H/C | R2 Helion us | R2 CUTLASS us | R2 H/C |
|---|---|---:|---:|---:|---:|---:|---:|
| `default_small_parity` | G3 [g0: 128x128x128, g1: 512x128x128, g2: 128x256x128] | 10.229 | 14.355 | 0.713 | 10.247 | 14.382 | 0.712 |
| `doc_no_mn_tail` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.532 | 24.572 | 0.917 | 22.534 | 24.575 | 0.917 |
| `doc_no_mn_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.921 | 24.583 | 0.932 | 22.897 | 24.611 | 0.930 |
| `doc_original` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x160x16] | 22.958 | 24.622 | 0.932 | 22.909 | 24.582 | 0.932 |
| `doc_mtail_g1_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.625 | 24.673 | 0.917 | 22.610 | 24.588 | 0.920 |
| `doc_mtail_g1_only` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.580 | 24.590 | 0.918 | 22.573 | 24.578 | 0.918 |
| `doc_ntail_g3_160` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x160x16] | 23.222 | 24.578 | 0.945 | 23.197 | 24.575 | 0.944 |

```bash
CUDA_VISIBLE_DEVICES=0 conda run --no-capture-output -n helion \
  python benchmarks/cute/compare_grouped_gemm_backends.py \
  --cutlass-source /tmp/cutlass-db1c2889-grouped-gemm.py \
  --out-dir <fresh-output-dir> --cuda-visible-devices 0 \
  --seed 0 --compile-warmups 2 --num-runs 6 \
  --warmup-ms 1000 --rep-ms 500 --cache-warmup-calls 5 \
  --thermal-warmup-ms 10000 --stream-subprocesses
```

### DeepGEMM

Physical GPU 3. Official shape is `(G, expected M/group, N, K)`; `actual M/group` is the exact seed-0 DeepGEMM-compatible M stream shared by both implementations. Each row uses `--compile-warmups 2`, five alternating graph warmups, and one 10-second BF16 thermal warmup. Ten paired samples alternate which implementation runs first; each sample averages 50 graph replays. An 8 GB L2 clear matching upstream DeepGEMM's `bench_kineto` default runs before every replay and outside its CUDA-event interval. The table reports the median of the ten sample means, and each repeat uses fresh compiler caches.

Pinned reference: DeepGEMM `559d79fb6994a58b8a15b4b93bf13ccc16edf247`, CUTLASS submodule `f3fde58372d33e9a5650ba7b80fc48b3b49d40c8`, and M alignment 224. The only untracked reference-checkout path was DeepGEMM's generated `deep_gemm/include/fmt` directory. Harness SHA256: `484741ae5259f8ce4f2f6216dc25c29def001dcb25b231e555b95998a667271e`.

| Row | Official `(G, M, N, K)` | Actual M/group | R1 Helion us | R1 DeepGEMM us | R1 H/D | R2 Helion us | R2 DeepGEMM us | R2 H/D |
|---:|---|---|---:|---:|---:|---:|---:|---:|
| 0 | `(4, 8192, 6144, 7168)` | `9884, 9459, 7801, 7007` | 2646.708 | 2518.028 | 1.051 | 2677.416 | 2562.513 | 1.045 |
| 1 | `(4, 8192, 7168, 3072)` | `8247, 7724, 9586, 7225` | 1070.407 | 1093.971 | 0.978 | 1081.872 | 1096.028 | 0.987 |
| 2 | `(4, 8192, 4096, 4096)` | `8076, 8601, 10197, 8215` | 872.093 | 877.294 | 0.994 | 873.244 | 880.124 | 0.992 |
| 3 | `(4, 8192, 4096, 2048)` | `7119, 9449, 8773, 6965` | 395.633 | 409.112 | 0.967 | 398.398 | 408.255 | 0.976 |
| 4 | `(8, 4096, 6144, 7168)` | `5102, 5282, 4858, 5084, 3629, 4660, 5076, 4548` | 3051.274 | 3021.418 | 1.010 | 3036.491 | 2995.513 | 1.014 |
| 5 | `(8, 4096, 7168, 3072)` | `4027, 3114, 3934, 4368, 5111, 5242, 4039, 4993` | 1168.279 | 1199.356 | 0.974 | 1166.589 | 1210.240 | 0.964 |
| 6 | `(8, 4096, 4096, 4096)` | `3507, 4845, 4215, 2901, 4635, 3847, 4894, 4509` | 835.664 | 836.549 | 0.999 | 837.359 | 838.471 | 0.999 |
| 7 | `(8, 4096, 4096, 2048)` | `2870, 4080, 4999, 3466, 3666, 5006, 3336, 4261` | 400.494 | 405.255 | 0.988 | 401.995 | 408.534 | 0.984 |

```bash
CUDA_VISIBLE_DEVICES=3 conda run --no-capture-output -n helion \
  python benchmarks/cute/deepgemm_selected_path.py \
  --rows all --compare-deepgemm \
  --deepgemm-root /tmp/DeepGEMM-559d79fb --device cuda \
  --samples 10 --iters 50 --warmups 5 --compile-warmups 2 \
  --thermal-warmup-ms 10000 --l2-flush-bytes 8000000000 \
  --m-alignment 224 --artifact-dir <fresh-output-dir> \
  --json-output <fresh-output-dir>/selected_results.json
```

All correctness checks passed in both final repeats.
