### PR TITLE
Fix negative indexing in compiled mode

### DIFF
--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -1383,8 +1383,6 @@ class SubscriptIndexing(NamedTuple):
             if k is None:
                 output_size.append(1)
             elif isinstance(k, int):
-                if k < 0:
-                    k += input_size[0]
                 input_size.popleft()
             elif (
                 state is not None
@@ -1603,7 +1601,7 @@ class SubscriptIndexing(NamedTuple):
             elif isinstance(k, int):
                 if k < 0:
                     k += fake_value.size(len(index_values))
-                index_values.append(repr(k))
+                index_values.append(state.device_function.literal_expr(k))
             elif (
                 tile_info := _get_tile_with_offset_info(k, state.fx_node, n)
             ) is not None:
@@ -2013,7 +2011,7 @@ class BlockedSubscriptIndexing:
             elif isinstance(k, int):
                 if k < 0:
                     k += fake_value.size(len(res.offsets))
-                res.offsets.append(repr(k))
+                res.offsets.append(state.device_function.literal_expr(k))
                 res.block_shape.append(1)
             elif (
                 tile_info := _get_tile_with_offset_info(k, state.fx_node, n)

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -1383,6 +1383,8 @@ class SubscriptIndexing(NamedTuple):
             if k is None:
                 output_size.append(1)
             elif isinstance(k, int):
+                if k < 0:
+                    k += input_size[0]
                 input_size.popleft()
             elif (
                 state is not None
@@ -1599,6 +1601,8 @@ class SubscriptIndexing(NamedTuple):
             if k is None:
                 output_idx += 1
             elif isinstance(k, int):
+                if k < 0:
+                    k += fake_value.size(len(index_values))
                 index_values.append(repr(k))
             elif (
                 tile_info := _get_tile_with_offset_info(k, state.fx_node, n)
@@ -2007,6 +2011,8 @@ class BlockedSubscriptIndexing:
             if k is None:
                 pass  # handled by reshaped_size
             elif isinstance(k, int):
+                if k < 0:
+                    k += fake_value.size(len(res.offsets))
                 res.offsets.append(repr(k))
                 res.block_shape.append(1)
             elif (

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1777,7 +1777,6 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src2_result, expected_src2)
         torch.testing.assert_close(dst2_result, expected_dst2)
 
-    @skipIfNormalMode("InternalError: Negative indexes")
     def test_negative_indexing(self):
         """Test both setter from scalar and getter for [-1]"""
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1777,6 +1777,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src2_result, expected_src2)
         torch.testing.assert_close(dst2_result, expected_dst2)
 
+    @xfailIfCute("InternalError: Negative indexes")
     def test_negative_indexing(self):
         """Test both setter from scalar and getter for [-1]"""
 
@@ -1802,6 +1803,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src_result, expected_src)
         torch.testing.assert_close(dst_result, expected_dst)
 
+    @xfailIfCute("InternalError: Negative indexes")
     def test_negative_indexing_multidim(self):
         """Test negative indexing on multiple dimensions: x[-1, -1]"""
 
@@ -1819,6 +1821,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         expected[-1, -1] = 42.0
         torch.testing.assert_close(result, expected)
 
+    @xfailIfCute("InternalError: Negative indexes")
     def test_negative_indexing_with_tile(self):
         """Test mixed tile and negative index: x[tile, -1]"""
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1802,6 +1802,41 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src_result, expected_src)
         torch.testing.assert_close(dst_result, expected_dst)
 
+    def test_negative_indexing_multidim(self):
+        """Test negative indexing on multiple dimensions: x[-1, -1]"""
+
+        @helion.kernel(autotune_effort="none")
+        def kernel(x: torch.Tensor) -> torch.Tensor:
+            for _ in hl.grid(1):
+                x[-1, -1] = 42.0
+            return x
+
+        M, N = 64, 128
+        x = torch.zeros([M, N], device=DEVICE)
+        result = kernel(x)
+
+        expected = torch.zeros([M, N], device=DEVICE)
+        expected[-1, -1] = 42.0
+        torch.testing.assert_close(result, expected)
+
+    def test_negative_indexing_with_tile(self):
+        """Test mixed tile and negative index: x[tile, -1]"""
+
+        @helion.kernel(autotune_effort="none")
+        def kernel(x: torch.Tensor) -> torch.Tensor:
+            (rows,) = x.shape[:1]
+            for tile_r in hl.tile(rows):
+                x[tile_r, -1] = 1.0
+            return x
+
+        M, N = 64, 128
+        x = torch.zeros([M, N], device=DEVICE)
+        result = kernel(x)
+
+        expected = torch.zeros([M, N], device=DEVICE)
+        expected[:, -1] = 1.0
+        torch.testing.assert_close(result, expected)
+
     @skipIfNormalMode(
         "RankMismatch: Cannot assign a tensor of rank 2 to a buffer of rank 3"
     )


### PR DESCRIPTION
## Summary
- Fix negative integer indexing (ex. `dst[-1]`) in compiled mode.

## Test
- `pytest test/test_indexing.py -k test_negative_indexing `