### PR TITLE
Suppress pyrefly bad-override on HelionTemplateBuffer prologue-fusion hook

### DIFF
--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -403,7 +403,12 @@ class HelionTemplateBuffer(TemplateBuffer):
     def set_current_node(self, node: object) -> AbstractContextManager[None]:
         return nullcontext()
 
-    def has_aliasing_or_mutation_for_prologue_fusion(
+    # A recent torch widened this hook's declared parameter to an internal
+    # Protocol (`_HasAliasingOrMutation`); Inductor always passes a
+    # `SchedulerNode` at runtime, so keep the precise annotation and suppress
+    # the parameter-contravariance check rather than depend on a private,
+    # version-fragile torch type.
+    def has_aliasing_or_mutation_for_prologue_fusion(  # pyrefly: ignore[bad-override]
         self,
         scheduler_node: SchedulerNode,
     ) -> bool:


### PR DESCRIPTION
Unblocks the `lint` job, which is currently red on **every open PR** (e.g. #3027) with a pyrefly `bad-override` on `HelionTemplateBuffer.has_aliasing_or_mutation_for_prologue_fusion` after a torch nightly widened the `TemplateBuffer` parent's declared parameter type.

Suppressed with `# pyrefly: ignore[bad-override]`.
