### PR TITLE
Add pretuned CuTe flash attention kernel

### DIFF
--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -24,6 +24,7 @@ pretuned_kernels/
 │   ├── _helion_aot_vector_add_cuda_sm100.py   # B200 heuristic
 │   └── _helion_aot_vector_add_cuda_sm90.py    # H100 heuristic
 ├── softmax/
+├── attention/                        # B200 CuTe (tcgen05) non-causal flash attention
 ├── layer_norm/
 ├── rms_norm/
 ├── cross_entropy/
@@ -48,6 +49,7 @@ At runtime Helion picks the file matching the current GPU.
 |---|---|---|
 | `vector_add` | `2**i for i in range(19, 29)` | `x + y` |
 | `softmax` | Triton tutorial `M=4096, N=128*i for i in range(2, 100)` + realistic long-context shapes | `F.softmax` |
+| `attention` | Non-causal dense `(z, h, seq, head_dim)` shapes from the CuTe attention harness (B200 CuTe tcgen05 flash backend only; CUDA-graph timed) | `F.scaled_dot_product_attention` |
 | `layer_norm` | Triton tutorial `M=4096, N=512*i for i in range(2, 32)` + realistic hidden-size shapes | `F.layer_norm` |
 | `rms_norm` | TritonBench `(M=2048, H)` default + NPOT shapes + realistic LLM hidden-size and production-style shapes | `F.rms_norm` |
 | `cross_entropy` | TritonBench/Liger token-vocab sweep + realistic LLM vocabulary shapes | `F.cross_entropy` |
@@ -110,7 +112,7 @@ runtime based on the running GPU's compute capability (with fallback to
 older compatible capabilities, e.g. `sm120` → `sm100`).
 
 For a kernel whose `main()` benchmarks under CUDA graphs (`use_cudagraph()`
-returns `True`, e.g. `scaled_mm` and the vLLM-ported ops), set
+returns `True`, e.g. `scaled_mm`, `attention`, and the vLLM-ported ops), set
 `HELION_BENCHMARK_CUDAGRAPH=1` for the autotune run so the autotuner benchmarks
 candidate configs the same way — matching the deployment/benchmark timing
 regime.

--- a/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
+++ b/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
@@ -1,0 +1,41 @@
+"""
+Heuristic for kernel: attention (B200 / sm100, CuTe tcgen05 flash backend)
+Backend: decision_tree
+
+Provides:
+- key_attention(*args): Returns config index (also serves as cache key)
+- autotune_attention(*args): Returns config dict for the given arguments
+
+Configs are the B200 compiler-selected Flash seed configs captured from
+benchmark runs (paste P2418822908) at Helion revision
+9ca92a66d199a917f4fbe65dfc313879505649b4 on an NVIDIA B200 (1965 MHz, 1000 W).
+The kernel is non-causal, so config selection depends on (seq_len, head_dim):
+
+- head_dim >= 128                -> config_02 (index 1)
+- head_dim == 64, seq_len <= 4096 -> config_01 (index 0)
+- head_dim == 64, seq_len  > 4096 -> config_06 (index 2)
+"""
+
+import torch
+
+
+def key_attention(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    q = args[0]
+    seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
+    head_dim = int(q.shape[-1]) if isinstance(q, torch.Tensor) and q.ndim >= 1 else 0
+    if head_dim >= 128:
+        return 1
+    if seq_len <= 4096:
+        return 0
+    return 2
+
+
+def autotune_attention(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [1, 128, 128], 'cute_flash_causal_kv_order': 'ascending', 'cute_flash_causal_loop_split': False, 'cute_flash_causal_lpt_swizzle': 0, 'cute_flash_corr_regs': 64, 'cute_flash_disc_pipe': 4, 'cute_flash_e2e_offset': 2, 'cute_flash_e2e_offset0': 0, 'cute_flash_e2e_schedule': '16/4', 'cute_flash_epi_tma': False, 'cute_flash_kv_stage': 3, 'cute_flash_masked_e2e_schedule': 'inherit', 'cute_flash_packed_reduce': False, 'cute_flash_persistent': True, 'cute_flash_rescale_chunk_cols': 32, 'cute_flash_rescale_threshold': 8.0, 'cute_flash_role_map': 'helion', 'cute_flash_s_stage': 2, 'cute_flash_small_biased': True, 'cute_flash_softmax_regs': 200, 'cute_flash_topology': 'fa4'},
+        {'block_sizes': [1, 128, 128], 'cute_flash_causal_kv_order': 'ascending', 'cute_flash_causal_loop_split': False, 'cute_flash_causal_lpt_swizzle': 0, 'cute_flash_corr_regs': 64, 'cute_flash_disc_pipe': 2, 'cute_flash_e2e_offset': 0, 'cute_flash_e2e_offset0': 0, 'cute_flash_e2e_schedule': '8/2', 'cute_flash_epi_tma': True, 'cute_flash_kv_stage': 3, 'cute_flash_masked_e2e_schedule': 'inherit', 'cute_flash_packed_reduce': False, 'cute_flash_persistent': True, 'cute_flash_rescale_chunk_cols': 16, 'cute_flash_rescale_threshold': 8.0, 'cute_flash_role_map': 'helion', 'cute_flash_s_stage': 2, 'cute_flash_small_biased': True, 'cute_flash_softmax_regs': 200, 'cute_flash_topology': 'fa4'},
+        {'block_sizes': [1, 128, 128], 'cute_flash_causal_kv_order': 'ascending', 'cute_flash_causal_loop_split': False, 'cute_flash_causal_lpt_swizzle': 0, 'cute_flash_corr_regs': 64, 'cute_flash_disc_pipe': 3, 'cute_flash_e2e_offset': 2, 'cute_flash_e2e_offset0': 0, 'cute_flash_e2e_schedule': '16/4', 'cute_flash_epi_tma': False, 'cute_flash_kv_stage': 2, 'cute_flash_masked_e2e_schedule': 'inherit', 'cute_flash_packed_reduce': True, 'cute_flash_persistent': True, 'cute_flash_rescale_chunk_cols': 32, 'cute_flash_rescale_threshold': 8.0, 'cute_flash_role_map': 'helion', 'cute_flash_s_stage': 2, 'cute_flash_small_biased': True, 'cute_flash_softmax_regs': 200, 'cute_flash_topology': 'fa4'},
+    ]
+    return _C[key_attention(*args)]

--- a/pretuned_kernels/attention/attention.py
+++ b/pretuned_kernels/attention/attention.py
@@ -1,0 +1,149 @@
+"""Scaled dot-product (flash) attention for the B200 CuTe (tcgen05) backend.
+
+Ported from ``examples/attention.py`` (the ``attention_output`` variant, which
+returns only the attention output so it lines up 1:1 with
+``F.scaled_dot_product_attention``).  Runs on Helion's CuTe (tcgen05) flash
+backend and is pretuned for the non-causal dense attention shapes that back the
+B200 CuTe attention benchmark (``benchmarks/cute/compare_attention_backends.py``);
+the checked-in AOT heuristic selects the flash config per-shape instead of
+online autotuning.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+import helion.experimental
+import helion.language as hl
+
+
+def _attention_sdpa(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    return F.scaled_dot_product_attention(q, k, v)
+
+
+@helion.experimental.aot_kernel(backend="cute", static_shapes=True)
+def attention(
+    q_in: torch.Tensor,
+    k_in: torch.Tensor,
+    v_in: torch.Tensor,
+) -> torch.Tensor:
+    """Computes scaled dot-product attention and returns the output tensor.
+
+    Args:
+        q_in: Query tensor of shape [..., seq_len_q, head_dim]
+        k_in: Key tensor of shape [..., seq_len_k, head_dim]
+        v_in: Value tensor of shape [..., seq_len_k, head_dim]
+
+    Returns:
+        Output tensor of shape [..., seq_len_q, head_dim].
+    """
+    m_dim = q_in.size(-2)
+    n_dim = k_in.size(-2)
+    assert n_dim == v_in.size(-2)
+    head_dim = hl.specialize(q_in.size(-1))
+    assert head_dim == k_in.size(-1) == v_in.size(-1)
+    q_view = q_in.reshape([-1, m_dim, head_dim])
+    v_view = v_in.reshape([-1, n_dim, head_dim])
+    k_view = k_in.reshape([-1, n_dim, head_dim])
+    out = torch.empty_like(q_view)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    qk_scale = sm_scale * 1.44269504  # 1/log(2)
+    for tile_b, tile_m in hl.tile([q_view.size(0), m_dim]):
+        m_i = hl.full([tile_b, tile_m], float("-inf"), dtype=torch.float32)
+        l_i = torch.full_like(m_i, 1.0)
+        acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+        q = q_view[tile_b, tile_m, :]
+        for tile_n in hl.tile(v_view.size(1)):
+            # scaling Q in-loop on-demand reduces spillage, faster than keeping pre-scaled Q
+            q_scaled = q * qk_scale
+            k = k_view[tile_b, tile_n, :]
+            qk = torch.bmm(q_scaled, k.transpose(1, 2), torch.float32)
+            m_ij = torch.maximum(m_i, torch.amax(qk, -1))
+            qk = qk - m_ij[:, :, None]
+            p = torch.exp2(qk)
+            l_ij = torch.sum(p, -1)
+            alpha = torch.exp2(m_i - m_ij)
+            l_i = l_i * alpha + l_ij
+            acc = acc * alpha[:, :, None]
+            v = v_view[tile_b, tile_n, :]
+            p = p.to(v.dtype)
+            acc = torch.baddbmm(acc, p, v)
+            m_i = m_ij
+        acc = acc / l_i[:, :, None]
+        out[tile_b, tile_m, :] = acc.to(out.dtype)
+    return out.view(q_in.size())
+
+
+def _baselines() -> list[tuple[str, object]]:
+    """Baselines main() benchmarks against.
+
+    SDPA is a single fused op, so ``torch.compile`` has nothing to fuse and is
+    not a meaningful separate baseline -- torch SDPA is the only one.
+    """
+    return [
+        ("torch", _attention_sdpa),
+    ]
+
+
+def use_cudagraph() -> bool:
+    """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py).
+
+    Attention is timed under CUDA graphs (like ``scaled_mm``) so the numbers
+    reflect kernel-only latency rather than the CuTe AOT dispatch's host
+    overhead, which otherwise dominates the small-shape rows.
+    """
+    return True
+
+
+def main(verbose: bool = True) -> dict:
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep
+
+    # (z, h, seq_len, head_dim, dtype) -- non-causal dense attention shapes from
+    # the CuTe attention benchmark harness (benchmarks/cute/compare_attention_backends.py).
+    shapes = [
+        (1, 4, 512, 64, torch.float16),
+        (2, 8, 512, 64, torch.float16),
+        (2, 32, 1024, 64, torch.float16),
+        (2, 32, 2048, 64, torch.float16),
+        (4, 32, 4096, 128, torch.bfloat16),
+        (8, 32, 8192, 128, torch.bfloat16),
+    ]
+    baselines = _baselines()
+
+    def make_calls(shape: tuple[int, int, int, int, torch.dtype]) -> tuple:
+        z, h, seq_len, head_dim, dtype = shape
+        q, k, v = (
+            torch.randn([z, h, seq_len, head_dim], device="cuda", dtype=dtype)
+            for _ in range(3)
+        )
+
+        def helion_call() -> torch.Tensor:
+            return attention(q, k, v)
+
+        base_calls = [(name, (lambda fn=fn: fn(q, k, v))) for name, fn in baselines]
+        return (
+            helion_call,
+            base_calls,
+            f"{z:>2d}  {h:>3d}  {seq_len:>6d}  {head_dim:>4d}",
+        )
+
+    return run_sweep(
+        shapes,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        warmup=50,
+        rep=200,
+        verbose=verbose,
+        shape_header=f"{'z':>2s}  {'h':>3s}  {'seq':>6s}  {'d':>4s}",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/run.py
+++ b/pretuned_kernels/run.py
@@ -45,6 +45,7 @@ KERNELS = [
     "nvfp4_gemv",
     "nvfp4_gemv_cute",
     "cross_entropy",
+    "attention",
     # Ported from vLLM (vllm/kernels/helion/ops); torch-native baselines.
     "silu_mul_fp8",
     "dynamic_per_token_scaled_fp8_quant",

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -71,6 +71,7 @@ def _run_pretuned_kernel_main_and_parse_summary(name):
 
 _CORRECTNESS_SHAPES = {
     "vector_add": [2**20],
+    "attention": [(2, 8, 512, 64)],
     "softmax": [(4096, 1024)],
     "layer_norm": [(4096, 1024)],
     "rms_norm": [(2048, 4096)],
@@ -90,6 +91,15 @@ def _make_vector_add_inputs(shape):
     x = torch.randn(n, device=DEVICE, dtype=torch.float32)
     y = torch.randn(n, device=DEVICE, dtype=torch.float32)
     return (x, y), lambda: x + y
+
+
+def _make_attention_inputs(shape):
+    z, h, seq_len, head_dim = shape
+    q, k, v = (
+        torch.randn(z, h, seq_len, head_dim, device=DEVICE, dtype=torch.float16)
+        for _ in range(3)
+    )
+    return (q, k, v), lambda: F.scaled_dot_product_attention(q, k, v)
 
 
 def _make_softmax_inputs(shape):
@@ -211,6 +221,7 @@ def _make_rope_bwd_inputs(shape):
 
 _INPUT_BUILDERS = {
     "vector_add": _make_vector_add_inputs,
+    "attention": _make_attention_inputs,
     "softmax": _make_softmax_inputs,
     "layer_norm": _make_layer_norm_inputs,
     "rms_norm": _make_rms_norm_inputs,
@@ -223,6 +234,7 @@ _INPUT_BUILDERS = {
 # vector_add because reductions accumulate fp32 and round back to fp16/bf16.
 _TOLERANCES = {
     "vector_add": (1e-5, 1e-5),
+    "attention": (5e-2, 2e-2),
     "softmax": (1e-3, 1e-3),
     "layer_norm": (1e-2, 1e-2),
     "rms_norm": (1e-2, 1e-2),
@@ -371,6 +383,9 @@ class TestPretunedKernelsCorrectness(TestCase):
 
     def test_vector_add(self):
         self._run_correctness("vector_add")
+
+    def test_attention(self):
+        self._run_correctness("attention")
 
     def test_softmax(self):
         self._run_correctness("softmax")


### PR DESCRIPTION
Port examples/attention.py (attention_output variant) as a pretuned kernel on the B200 CuTe (tcgen05) flash backend. The checked-in AOT heuristic selects the flash config per-shape from the B200 configs in paste P2418822908 (non-causal: head_dim 64/seq<=4096 -> config_01, head_dim 128 -> config_02, head_dim 64/ long-seq -> config_06) instead of online autotuning.

Benchmarked (CUDA-graph timed) against torch SDPA over the non-causal dense shapes from benchmarks/cute/compare_attention_backends.py: geomean ~0.91x vs SDPA (cuDNN) on B200, matching the H1-2026 Helion recap's 'trails slightly behind SDPA' claim. CUDA-graph timing is required because this CuTe stack predates main's fast-dispatch cache.

Wires attention into run.py (dashboard runner) and adds a correctness test. Requires the CuTe flash fast-path (PR #3042); not functional on main yet.

based on https://github.com/pytorch/helion/pull/3042 stack.