### PR TITLE
refactor: move Metal-specific codegen into `helion/_compiler/metal/`

### DIFF
--- a/helion/_compiler/metal/memory_ops.py
+++ b/helion/_compiler/metal/memory_ops.py
@@ -1,0 +1,73 @@
+"""Metal-backend codegen for ops defined in ``helion.language.memory_ops``.
+
+Backend-specific codegen bodies live here (not in the backend-neutral language
+module).  Importing this module runs the ``@_decorators.codegen(op, "metal")``
+registrations; ``memory_ops`` imports it at the bottom so registration keeps
+the same eager timing as before.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+import torch
+
+from ... import exc
+from ...language import _decorators
+from ...language.memory_ops import load
+from ...language.memory_ops import store
+
+if TYPE_CHECKING:
+    from ..inductor_lowering import CodegenState
+
+
+@_decorators.codegen(store, "metal")
+def _(state: CodegenState) -> ast.AST:
+    # Metal delegates to the same PointerIndexingStrategy as Triton.
+    # This produces tl.store(ptr + offset, val, mask) in the AST;
+    # the MSL walker translates it to Metal.
+    tensor = state.proxy_arg(0)
+    subscript = state.proxy_arg(1)
+    assert isinstance(subscript, (list, tuple))
+    value = state.ast_arg(2)
+    extra_mask = state.ast_args[3]
+    assert isinstance(extra_mask, (type(None), ast.AST))
+
+    if isinstance(tensor, torch.Tensor):
+        device_fn = state.device_function
+        device_fn.device_store_index += 1
+        indexing_idx = device_fn.device_memory_op_index
+        device_fn.device_memory_op_index += 1
+        strategy = device_fn.get_indexing_strategy(indexing_idx)
+        return strategy.codegen_store(
+            state, tensor, [*subscript], value, extra_mask, None
+        )
+    raise exc.BackendUnsupported("metal", f"store target type: {type(tensor)}")
+
+
+@_decorators.codegen(load, "metal")
+def _(state: CodegenState) -> ast.AST:
+    # Metal delegates to the same PointerIndexingStrategy as Triton.
+    # This produces tl.load(ptr + offset, mask, other=0) in the AST;
+    # the MSL walker translates it to Metal.
+    tensor = state.proxy_arg(0)
+    subscript = state.proxy_arg(1)
+    assert isinstance(subscript, (list, tuple))
+    ast_subscript = state.ast_args[1]
+    assert isinstance(ast_subscript, (list, tuple))
+    extra_mask = state.ast_args[2]
+    assert isinstance(extra_mask, (type(None), ast.AST))
+    eviction_policy = state.ast_args[3] if len(state.ast_args) > 3 else None
+    assert isinstance(eviction_policy, (type(None), ast.AST))
+
+    if isinstance(tensor, torch.Tensor):
+        device_fn = state.device_function
+        device_fn.device_load_index += 1
+        indexing_idx = device_fn.device_memory_op_index
+        device_fn.device_memory_op_index += 1
+        strategy = device_fn.get_indexing_strategy(indexing_idx)
+        return strategy.codegen_load(
+            state, tensor, [*subscript], extra_mask, eviction_policy, None
+        )
+    raise exc.BackendUnsupported("metal", f"load tensor type: {type(tensor)}")

--- a/helion/_compiler/metal/tracing_ops.py
+++ b/helion/_compiler/metal/tracing_ops.py
@@ -1,0 +1,54 @@
+"""Metal-backend codegen for ops defined in ``helion.language._tracing_ops``.
+
+Backend-specific codegen bodies live here (not in the backend-neutral language
+module).  Importing this module runs the ``@_decorators.codegen(op, "metal")``
+registrations; ``_tracing_ops`` imports it at the bottom so registration keeps
+the same eager timing as before.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from torch._inductor.codegen.simd import constant_repr
+
+from ...language import _decorators
+from ...language._tracing_ops import _mask_to
+from ..ast_extension import expr_from_string
+from ..compile_environment import CompileEnvironment
+
+if TYPE_CHECKING:
+    import ast
+
+    from ..inductor_lowering import CodegenState
+
+
+@_decorators.codegen(_mask_to, "metal")
+def _(state: CodegenState) -> ast.AST:
+    tensor = state.proxy_arg(0)
+    assert isinstance(tensor, torch.Tensor)
+    other = state.proxy_arg(1)
+    assert isinstance(other, (int, float, bool))
+    mask_exprs: list[str] = []
+    input_sizes = [*tensor.size()]
+    for size in input_sizes:
+        if (
+            index := CompileEnvironment.current().resolve_block_id(size)
+        ) is not None and (mask_var := state.codegen.mask_var(index)) is not None:
+            if mask_var not in mask_exprs:
+                mask_exprs.append(mask_var)
+    if not mask_exprs:
+        return state.ast_arg(0)
+    mask_expr = " and ".join(mask_exprs)
+    input_dtype = tensor.dtype
+    other_typed = CompileEnvironment.current().backend.cast_ast(
+        expr_from_string(constant_repr(other)),
+        input_dtype,
+    )
+    return expr_from_string(
+        "({expr} if {mask} else {other})",
+        expr=state.ast_arg(0),
+        mask=expr_from_string(mask_expr),
+        other=other_typed,
+    )

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -383,36 +383,6 @@ def _(tensor: torch.Tensor, other: float) -> torch.Tensor:
     return torch.empty_like(tensor)
 
 
-@_decorators.codegen(_mask_to, "metal")
-def _(state: CodegenState) -> ast.AST:
-    tensor = state.proxy_arg(0)
-    assert isinstance(tensor, torch.Tensor)
-    other = state.proxy_arg(1)
-    assert isinstance(other, (int, float, bool))
-    mask_exprs: list[str] = []
-    input_sizes = [*tensor.size()]
-    for size in input_sizes:
-        if (
-            index := CompileEnvironment.current().resolve_block_id(size)
-        ) is not None and (mask_var := state.codegen.mask_var(index)) is not None:
-            if mask_var not in mask_exprs:
-                mask_exprs.append(mask_var)
-    if not mask_exprs:
-        return state.ast_arg(0)
-    mask_expr = " and ".join(mask_exprs)
-    input_dtype = tensor.dtype
-    other_typed = CompileEnvironment.current().backend.cast_ast(
-        expr_from_string(constant_repr(other)),
-        input_dtype,
-    )
-    return expr_from_string(
-        "({expr} if {mask} else {other})",
-        expr=state.ast_arg(0),
-        mask=expr_from_string(mask_expr),
-        other=other_typed,
-    )
-
-
 @_decorators.get_masked_value(_mask_to)
 def _(node: torch.fx.Node) -> float | bool:
     value = node.args[1]
@@ -473,5 +443,6 @@ def _(node: torch.fx.Node) -> float | bool | None:
 # @_decorators.codegen(op, "<backend>") registrations run with the same eager
 # timing as when the bodies lived in this file -- no behavior change.
 import helion._compiler.cute.tracing_ops  # noqa: E402, F401
+import helion._compiler.metal.tracing_ops  # noqa: E402, F401
 import helion._compiler.pallas.tracing_ops  # noqa: E402, F401
 import helion._compiler.triton.tracing_ops  # noqa: E402, F401

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -4443,30 +4443,6 @@ def _codegen_cute_store_permute_lane_loops(
     )
 
 
-@_decorators.codegen(store, "metal")
-def _(state: CodegenState) -> ast.AST:
-    # Metal delegates to the same PointerIndexingStrategy as Triton.
-    # This produces tl.store(ptr + offset, val, mask) in the AST;
-    # the MSL walker translates it to Metal.
-    tensor = state.proxy_arg(0)
-    subscript = state.proxy_arg(1)
-    assert isinstance(subscript, (list, tuple))
-    value = state.ast_arg(2)
-    extra_mask = state.ast_args[3]
-    assert isinstance(extra_mask, (type(None), ast.AST))
-
-    if isinstance(tensor, torch.Tensor):
-        device_fn = state.device_function
-        device_fn.device_store_index += 1
-        indexing_idx = device_fn.device_memory_op_index
-        device_fn.device_memory_op_index += 1
-        strategy = device_fn.get_indexing_strategy(indexing_idx)
-        return strategy.codegen_store(
-            state, tensor, [*subscript], value, extra_mask, None
-        )
-    raise exc.BackendUnsupported("metal", f"store target type: {type(tensor)}")
-
-
 # TODO(joydddd): Add support for stack tensor in ref mode.
 @_decorators.ref(store)
 def _(
@@ -4656,33 +4632,6 @@ def _maybe_materialize_tile_index_load(
     return expr_from_string(f"{base_var}[{', '.join(parts)}]")
 
 
-@_decorators.codegen(load, "metal")
-def _(state: CodegenState) -> ast.AST:
-    # Metal delegates to the same PointerIndexingStrategy as Triton.
-    # This produces tl.load(ptr + offset, mask, other=0) in the AST;
-    # the MSL walker translates it to Metal.
-    tensor = state.proxy_arg(0)
-    subscript = state.proxy_arg(1)
-    assert isinstance(subscript, (list, tuple))
-    ast_subscript = state.ast_args[1]
-    assert isinstance(ast_subscript, (list, tuple))
-    extra_mask = state.ast_args[2]
-    assert isinstance(extra_mask, (type(None), ast.AST))
-    eviction_policy = state.ast_args[3] if len(state.ast_args) > 3 else None
-    assert isinstance(eviction_policy, (type(None), ast.AST))
-
-    if isinstance(tensor, torch.Tensor):
-        device_fn = state.device_function
-        device_fn.device_load_index += 1
-        indexing_idx = device_fn.device_memory_op_index
-        device_fn.device_memory_op_index += 1
-        strategy = device_fn.get_indexing_strategy(indexing_idx)
-        return strategy.codegen_load(
-            state, tensor, [*subscript], extra_mask, eviction_policy, None
-        )
-    raise exc.BackendUnsupported("metal", f"load tensor type: {type(tensor)}")
-
-
 @_decorators.get_masked_value(load)
 def _(node: torch.fx.Node) -> int:
     return 0  # loads are always masked to 0
@@ -4785,5 +4734,6 @@ def _(
 # @_decorators.codegen(op, "<backend>") registrations run with the same eager
 # timing as when the bodies lived in this file -- no behavior change.
 import helion._compiler.cute.memory_ops  # noqa: E402, F401
+import helion._compiler.metal.memory_ops  # noqa: E402, F401
 import helion._compiler.pallas.memory_ops  # noqa: E402, F401
 import helion._compiler.triton.memory_ops  # noqa: E402, F401


### PR DESCRIPTION

Relocate the Metal backend `@_decorators.codegen(op, "metal")` bodies out of the
backend-neutral language modules into the Metal backend folder:

  `helion/_compiler/metal/metal_tracing_ops.py`  (`_mask_to`)
  `helion/_compiler/metal/metal_memory_ops.py`   (`store`, `load`)

Each language module keeps the backend-neutral op + a bottom
`from .._compiler.metal import metal_<module>  # noqa: E402, F401` (ruff sorts the
backend imports cute/metal/pallas/triton). No metal-only module-level helpers
existed, so none were moved; shared imports stay in the language module.

No behavior change: all 3 metal codegens now resolve from
`helion._compiler.metal.*`; no residual metal codegens in `helion/language/`;
other backends untouched; ruff clean. This completes the per-backend codegen
separation for all backends (pallas, triton, cute, metal).
