### PR TITLE
Support mismatched-shape tensors in control flow based on block-size constexpr

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -50,6 +50,31 @@ log = logging.getLogger(__name__)
 TensorDescriptorLayoutSignature = tuple[int | None, tuple[bool, ...]]
 
 
+# Set while type-propagating or tracing the branches of an `if` whose condition
+# is a compile-time constant that depends only on block sizes.  Such a condition
+# is resolved per-config at codegen, where only the live branch is emitted (see
+# DeviceFunction.evaluate_constexpr_condition and IfGraphInfo.codegen).  Because
+# exactly one branch survives per config, the branches may legally define a
+# variable with the same rank but different shapes (e.g. a transposed
+# accumulator), so shape-equality checks that would otherwise reject the merge
+# are relaxed while this flag is set.
+_block_size_constexpr_branch = threading.local()
+
+
+def in_block_size_constexpr_branch() -> bool:
+    return getattr(_block_size_constexpr_branch, "value", False)
+
+
+@contextlib.contextmanager
+def block_size_constexpr_branch() -> typing.Iterator[None]:
+    prev = getattr(_block_size_constexpr_branch, "value", False)
+    _block_size_constexpr_branch.value = True
+    try:
+        yield
+    finally:
+        _block_size_constexpr_branch.value = prev
+
+
 @dataclasses.dataclass
 class TensorDescriptorLayoutGuard:
     ndim: int

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -456,6 +456,49 @@ class DeviceFunction:
         env = CompileEnvironment.current()
         return env.block_sizes[block_id].from_config(self.config)
 
+    def evaluate_constexpr_condition(self, test: object) -> bool | None:
+        """Resolve a control-flow test to a concrete bool for the current config.
+
+        Block sizes are symbolic during the (single) frontend pass but become
+        concrete integers per-config at codegen time.  A branch condition that
+        depends only on block sizes (and other constants) is therefore a
+        compile-time constant here, even though it could not be folded earlier.
+        Substituting the config's block sizes lets us decide the branch and emit
+        only the live side, which is what makes shape-divergent branches legal.
+
+        Returns the concrete bool, or ``None`` if the test is not a compile-time
+        constant for this config (e.g. it depends on a runtime value).
+        """
+        if isinstance(test, (bool, int)):
+            return bool(test)
+        if not isinstance(test, torch.SymBool):
+            return None
+        # NB: a boolean expression (And/Or/Relational) is a sympy.Basic but not a
+        # sympy.Expr, so we classify its free symbols directly rather than via
+        # find_block_size_symbols (which only handles sympy.Expr).
+        expr = test._sympy_()
+        if not isinstance(expr, sympy.Basic):
+            return None
+        env = CompileEnvironment.current()
+        hf = HostFunction.current()
+        subs: dict[sympy.Basic, sympy.Basic] = {}
+        for symbol in expr.free_symbols:
+            origin_info = hf.expr_to_origin.get(symbol)
+            if origin_info is None or not isinstance(
+                origin_info.origin, BlockSizeOrigin
+            ):
+                return None
+            value = env.block_sizes[origin_info.origin.block_id].from_config(
+                self.config
+            )
+            if not isinstance(value, int):
+                return None
+            subs[symbol] = sympy.Integer(value)
+        resolved = expr.xreplace(subs)
+        if resolved.free_symbols:
+            return None
+        return bool(resolved)
+
     def try_map_block_symbols_to_vars(self, expr: sympy.Expr) -> sympy.Expr | None:
         """Try to map all block size symbols in expression to their variable names.
 

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -20,6 +20,7 @@ from typing import Protocol
 from typing import cast
 from unittest.mock import patch
 
+import sympy
 import torch
 from torch._dynamo.convert_frame import compile_lock
 from torch._inductor.decomposition import select_decomp_table
@@ -47,6 +48,7 @@ from .ast_extension import create
 from .ast_extension import expr_from_string
 from .ast_read_writes import ReadWrites
 from .compile_environment import CompileEnvironment
+from .compile_environment import block_size_constexpr_branch
 from .host_function import HostFunction
 from .inductor_lowering import APIFuncLowering
 from .inductor_lowering import CodegenState
@@ -436,6 +438,19 @@ class IfGraphInfo(NodeArgsGraphInfo):
         assert isinstance(state.codegen, GenerateAST)
 
         test = state.ast_arg(0)
+        # A branch condition that depends only on block sizes is a compile-time
+        # constant for this config, even though it stayed symbolic during the
+        # single frontend pass.  Emit it as a literal ``True``/``False`` so Triton
+        # drops the dead branch entirely.  This is what makes branches whose
+        # tensor shapes differ (e.g. an accumulator that is transposed in one
+        # branch) legal: Triton type-checks a branch against the other only when
+        # the condition is a runtime value, not a compile-time constant.
+        constexpr_test = state.device_function.evaluate_constexpr_condition(
+            state.proxy_arg(0)
+        )
+        if constexpr_test is not None:
+            test = expr_from_string(repr(constexpr_test))
+
         body_stmts: list[ast.AST] = []
         orelse_stmts: list[ast.AST] = []
         if_ast_node = create(ast.If, test=test, body=body_stmts, orelse=orelse_stmts)
@@ -1799,6 +1814,28 @@ class DeviceIR:
         return tls.device_irs[-1]
 
 
+def _is_block_size_constexpr_proxy(test_proxy: object) -> bool:
+    """True if ``test_proxy`` is a SymBool depending only on block sizes.
+
+    Mirrors ``_is_block_size_constexpr_test`` in type_propagation: such a
+    condition is a compile-time constant per-config and is resolved at codegen,
+    so the branches may define a variable with divergent (same-rank) shapes.
+    """
+    from .variable_origin import BlockSizeOrigin
+
+    if not isinstance(test_proxy, torch.SymBool):
+        return False
+    expr = test_proxy._sympy_()
+    if not isinstance(expr, sympy.Basic) or not expr.free_symbols:
+        return False
+    hf = HostFunction.current()
+    for symbol in expr.free_symbols:
+        origin_info = hf.expr_to_origin.get(symbol)
+        if origin_info is None or not isinstance(origin_info.origin, BlockSizeOrigin):
+            return False
+    return True
+
+
 class WalkDeviceAST(NodeVisitor):
     def __init__(self, device_ir: DeviceIR) -> None:
         super().__init__()
@@ -2296,7 +2333,17 @@ class WalkDeviceAST(NodeVisitor):
             if body:
                 self._body(body)
             return
-        self._create_if_subgraph(test_proxy, node.body, node.orelse)
+        # A condition that depends only on block sizes is a compile-time constant
+        # resolved per-config at codegen, so the branches may define a variable
+        # with divergent shapes (e.g. a transposed accumulator).  Relax the
+        # trace-time shape checks (_phi, hl.dot acc) while building the branches.
+        cm = (
+            block_size_constexpr_branch()
+            if _is_block_size_constexpr_proxy(test_proxy)
+            else contextlib.nullcontext()
+        )
+        with cm:
+            self._create_if_subgraph(test_proxy, node.body, node.orelse)
 
     def _create_if_subgraph(
         self,

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -29,6 +29,7 @@ from .compile_environment import CompileEnvironment
 from .compile_environment import FixedBlockSizeSource
 from .compile_environment import LoopSpecBlockSizeSource
 from .compile_environment import _symint_expr
+from .compile_environment import in_block_size_constexpr_branch
 from .compile_environment import warning
 from .device_function import contains_only_block_size_symbols
 from .host_function import HostFunction
@@ -493,7 +494,10 @@ class TensorType(TypeInfo):
                     var=var_name,
                     details=f"rank {self.fake_value.dim()} != {other.fake_value.dim()}",
                 )
-            if self.fake_value.size() != other.fake_value.size():
+            if (
+                self.fake_value.size() != other.fake_value.size()
+                and not in_block_size_constexpr_branch()
+            ):
                 raise exc.ControlFlowTensorMismatch(
                     var=var_name,
                     details=f"size {self.fake_value.size()} != {other.fake_value.size()}",

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -64,6 +64,16 @@ class TypeInfo:
 
     @classmethod
     def from_example(cls, value: object, origin: Origin) -> TypeInfo:
+        from ..language.constexpr import ConstExpr
+
+        if type(value) is ConstExpr:
+            # hl.constexpr(...) used inside a kernel body marks its argument as a
+            # compile-time constant.  It is transparent to control flow and
+            # arithmetic, so represent it by its wrapped value's type.  Without
+            # this, ConstExpr (a NamedTuple) becomes a ClassType whose
+            # truth_value() is unconditionally True, which silently freezes the
+            # `if` to its true branch for every config.
+            return cls.from_example(value.value, origin)
         if isinstance(value, torch.Tensor):
             # TODO(jansel): need to wrap this in a fake tensor
             # TODO(jansel): tensor subclass support

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -23,6 +23,7 @@ from .ast_extension import ExtendedAST
 from .ast_extension import LoopType
 from .ast_extension import create
 from .compile_environment import CompileEnvironment
+from .compile_environment import block_size_constexpr_branch
 from .compile_environment import warning
 from .output_header import library_imports
 from .source_location import current_location
@@ -197,6 +198,34 @@ def _unsupported(
         raise exc.UnsupportedPythonType(python_type.__name__)
 
     return visit
+
+
+def _is_block_size_constexpr_test(test: TypeInfo) -> bool:
+    """Return True if ``test`` is a symbolic bool that depends only on block sizes.
+
+    Such a condition cannot be folded during the (single) frontend pass because
+    block sizes are still symbolic, but it *is* a compile-time constant for each
+    concrete config and is resolved per-config at codegen.  This is what lets an
+    ``if``/``else`` define a variable with divergent shapes across branches.
+    """
+    import sympy
+
+    from .host_function import HostFunction
+    from .variable_origin import BlockSizeOrigin
+
+    if not isinstance(test, SymBoolType):
+        return False
+    expr = test.value._sympy_()
+    # A boolean expression (And/Or/Relational) is a sympy.Basic but not a
+    # sympy.Expr, so check free symbols directly instead of find_block_size_symbols.
+    if not isinstance(expr, sympy.Basic) or not expr.free_symbols:
+        return False
+    hf = HostFunction.current()
+    for symbol in expr.free_symbols:
+        origin_info = hf.expr_to_origin.get(symbol)
+        if origin_info is None or not isinstance(origin_info.origin, BlockSizeOrigin):
+            return False
+    return True
 
 
 class TypePropagation(ast.NodeVisitor):
@@ -876,6 +905,16 @@ class TypePropagation(ast.NodeVisitor):
         if has_truth_val:
             # For constant conditions, only type propagate one branch
             self.scope.merge(self._body(node.body if truth_val else node.orelse))
+        elif _is_block_size_constexpr_test(test):
+            # The condition is a compile-time constant that depends on block
+            # sizes: it stays symbolic during this single frontend pass but is
+            # resolved per-config at codegen, where only the live branch is
+            # emitted (see DeviceFunction.evaluate_constexpr_condition and
+            # IfGraphInfo.codegen).  Because exactly one branch survives per
+            # config, the branches may legally define a variable with the same
+            # rank but different shapes (e.g. a transposed accumulator).
+            with block_size_constexpr_branch():
+                self.scope.merge_if_else(self._body(node.body), self._body(node.orelse))
         else:
             self.scope.merge_if_else(self._body(node.body), self._body(node.orelse))
         return NoType(origin=self.origin())

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from typing import NoReturn
 from typing import Protocol
 
+import torch
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.convert_frame import compile_lock
 
@@ -300,6 +301,19 @@ class TypePropagation(ast.NodeVisitor):
                 return right if val is True else left
         except NotImplementedError:
             pass
+        if isinstance(left, SymBoolType) and isinstance(right, SymBoolType):
+            # Preserve the symbolic conjunction/disjunction (e.g.
+            # ``block_m < 64 and block_n >= 64``) instead of minting a fresh
+            # unbacked bool, so a block-size-only condition stays resolvable
+            # per-config at codegen.  ``&``/``|`` on SymBool build the combined
+            # symbolic expression without forcing a guard.
+            combined = (
+                left.value | right.value
+                if isinstance(op, ast.Or)
+                else left.value & right.value
+            )
+            if isinstance(combined, torch.SymBool):
+                return SymBoolType(self.origin(), combined)
         if (
             isinstance(left, (NumericType, LiteralType))
             and isinstance(right, (NumericType, LiteralType))
@@ -346,6 +360,18 @@ class TypePropagation(ast.NodeVisitor):
             right,
             (NumericType, LiteralType),
         ):
+            # Preserve the symbolic comparison expression (e.g. ``block_m < 64``)
+            # rather than minting a fresh unbacked bool.  This keeps the block-size
+            # dependency intact so a block-size-only condition can be resolved
+            # per-config at codegen (see IfGraphInfo.codegen), which is what makes
+            # block-size-dependent control flow work on the host.
+            if not isinstance(op, CMP_ALWAYS_BOOL):
+                try:
+                    result = _eval_compare(op, left.proxy(), right.proxy())
+                except NotImplementedError:
+                    result = None
+                if isinstance(result, torch.SymBool):
+                    return SymBoolType(self.origin(), result)
             return SymBoolType.new_unbacked(self.origin())
         if isinstance(op, CMP_ALWAYS_BOOL):
             return SymBoolType.new_unbacked(self.origin())

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -3102,7 +3102,18 @@ def _(lhs: object, rhs: object) -> object:
         return lhs
     assert isinstance(lhs, torch.Tensor), lhs
     assert isinstance(rhs, torch.Tensor), rhs
-    assert lhs.size() == rhs.size()
+    # Branches merged here may have the same rank but different shapes when the
+    # branch condition depends only on block sizes: such a condition is resolved
+    # per-config at codegen, where only the live branch is emitted (see
+    # DeviceFunction.evaluate_constexpr_condition and IfGraphInfo.codegen).  A
+    # genuine runtime-conditioned shape divergence is instead rejected later by
+    # Triton, since both branches are emitted when the condition is not constant.
+    from .._compiler.compile_environment import in_block_size_constexpr_branch
+
+    if in_block_size_constexpr_branch():
+        assert lhs.dim() == rhs.dim()
+    else:
+        assert lhs.size() == rhs.size()
     assert lhs.dtype == rhs.dtype
     assert lhs.device == rhs.device
     return torch.empty_like(lhs)

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -244,7 +244,15 @@ def _(
         if acc.ndim not in (2, 3):
             raise ValueError(f"hl.dot: acc must be 2D or 3D tensor, got {acc.ndim}D")
 
-        if list(acc.shape) != expected_shape:
+        # Inside a block-size-constexpr branch the accumulator can be carried in
+        # with the shape of the *other* branch (which is dropped for this config
+        # at codegen), so only the rank is meaningful here.  See
+        # in_block_size_constexpr_branch / IfGraphInfo.codegen.
+        from .._compiler.compile_environment import in_block_size_constexpr_branch
+
+        if list(acc.shape) != expected_shape and not (
+            in_block_size_constexpr_branch() and acc.ndim == len(expected_shape)
+        ):
             raise ValueError(
                 f"hl.dot: acc shape {list(acc.shape)} incompatible with result shape {expected_shape}"
             )

--- a/test/test_constexpr.py
+++ b/test/test_constexpr.py
@@ -248,6 +248,85 @@ class TestConstExpr(RefEagerTestBase, TestCase):
             result = compiled(x, w, hl.constexpr(flag))
             self.assertEqual(result.shape, x.shape)
 
+    @skipIfRefEager("compile_config not supported in ref eager mode")
+    @skipIfMTIA("Not supported on MTIA. PE failure crashes on DMA_IN")
+    def test_block_size_constexpr_branch_selects_per_config(self):
+        """A branch whose condition depends on a block size must pick the branch
+        per-config, not freeze one branch during the single frontend pass
+        (issue #3044)."""
+
+        @helion.kernel(static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            (n,) = x.shape
+            bs = hl.register_block_size(n)
+            flag = hl.constexpr(bs < 64)
+            out = torch.empty_like(x)
+            for tile in hl.tile(n, block_size=bs):
+                if flag:
+                    out[tile] = x[tile] + 1
+                else:
+                    out[tile] = x[tile] + 2
+            return out
+
+        x = torch.zeros(128, device=DEVICE)
+        bound = fn.bind((x,))
+        for block_size in [32, 128]:
+            result = bound.compile_config(helion.Config(block_sizes=[block_size]))(x)
+            expected = x + (1 if block_size < 64 else 2)
+            torch.testing.assert_close(result, expected)
+
+    @skipIfRefEager("compile_config not supported in ref eager mode")
+    @skipIfMTIA("Not supported on MTIA. PE failure crashes on DMA_IN")
+    def test_block_size_constexpr_branch_divergent_shapes(self):
+        """Branches selected by a block-size constexpr may define a variable
+        with the same rank but different shapes -- e.g. a swap-AB GEMM that
+        transposes its accumulator for small M (issue #3044)."""
+
+        @helion.kernel(static_shapes=True)
+        def matmul_swap_ab(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            M, K = a.size()
+            _, N = b.size()
+            out = torch.empty([M, N], dtype=a.dtype, device=a.device)
+            block_m = hl.register_block_size(M)
+            block_n = hl.register_block_size(N)
+            swap_ab = hl.constexpr(block_m < 64 and block_n >= 64)
+            for tile_m, tile_n in hl.tile([M, N], block_size=[block_m, block_n]):
+                if swap_ab:
+                    acc = hl.zeros([tile_n, tile_m], dtype=torch.float32)
+                else:
+                    acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(K):
+                    if swap_ab:
+                        a_blk = hl.load(
+                            a, [tile_m.index[None, :], tile_k.index[:, None]]
+                        )
+                        b_blk = hl.load(
+                            b, [tile_k.index[None, :], tile_n.index[:, None]]
+                        )
+                        acc = hl.dot(b_blk, a_blk, acc=acc, out_dtype=torch.float32)
+                    else:
+                        acc = hl.dot(
+                            a[tile_m, tile_k],
+                            b[tile_k, tile_n],
+                            acc=acc,
+                            out_dtype=torch.float32,
+                        )
+                if swap_ab:
+                    acc = acc.t()
+                out[tile_m, tile_n] = acc.to(out.dtype)
+            return out
+
+        M, K, N = 64, 512, 256
+        a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+        b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+        expected = a @ b
+        bound = matmul_swap_ab.bind((a, b))
+        # Both swap (block_m < 64 <= block_n) and non-swap configs must compile
+        # and produce correct results.
+        for bm, bn in [(32, 128), (64, 64), (128, 32)]:
+            result = bound.compile_config(helion.Config(block_sizes=[bm, bn, 64]))(a, b)
+            torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_type_propagation.expected
+++ b/test/test_type_propagation.expected
@@ -815,7 +815,7 @@ i *
             # Name: SymIntType(u0) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
 sm_count
             if 
-            # Compare: SymBoolType(Eq(u11, 1)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Compare: SymBoolType(u0*u4 + u2 < 128) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
             # Name: SymIntType(u0*u4 + u2) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
 idx < 
             # Name: LiteralType(128) GetItemOrigin(value=AttributeOrigin(value=ArgumentOrigin(name='x'), key='shape'), key=0)


### PR DESCRIPTION
Fixes #3044 

- support divergent branch shapes for block-size constexpr conditions
- fix hl.constexpr(...) in kernel body freezing the true branch
- type prop: preserve symbolic comparison and boolean expressions


Fixes #3044.

## Motivation

For a GEMM on Hopper the underlying MMA uses a fixed block size of 64 in the M
dimension. For small M a common trick is to swap the operands —
`A @ B = (Bᵀ @ Aᵀ)ᵀ` — to raise core utilization. Expressed in Helion this means
branching on the tile shape and giving the accumulator a **different (transposed)
shape** in each branch:

```python
for tile_m, tile_n in hl.tile([M, N], block_size=[block_m, block_n]):
    swap_ab = hl.constexpr(block_m < 64 and block_n >= 64)
    if swap_ab:
        acc = hl.zeros([tile_n, tile_m], acc_dtype)   # [block_n, block_m]
    else:
        acc = hl.zeros([tile_m, tile_n], acc_dtype)   # [block_m, block_n]
    ...
    if swap_ab:
        acc = acc.t()
    out[tile_m, tile_n] = acc
```

Before this change Helion could not compile such a kernel:

- Autotuning only ever produced configs where `block_size_m == block_size_n`,
  because any config with `block_m != block_n` failed during compilation with
  `ControlFlowTensorMismatch: Tensor mismatch in control flow for variable 'acc'`
  (or, further down, Triton's `AssertionError("Mismatched type for acc between
  then block ... and else block ...")`).

Triton itself supports mismatched tensor shapes across a branch when the
condition is a compile-time constant (it drops the dead branch before type
checking). This PR makes Helion support the same pattern when the branch
condition is a **block-size-derived constexpr**.

## Root cause

Helion's frontend (type propagation + device-IR lowering) runs **once** per
`BoundKernel`, with block sizes still symbolic, and is never re-keyed on the
autotuning config. Only codegen runs per-config, where block sizes become
concrete integers. Consequently:

1. A branch whose shape depends on a block size cannot be folded at the frontend
   — the condition is symbolic there — so both branches are merged and the
   accumulator's two shapes collide.
2. Even when the branches were traced, Helion emitted the condition as an
   ordinary runtime local (`_and = _BLOCK_SIZE_0 < 64 and ...`). Triton only
   performs dead-branch elimination when the `if` test is a *compile-time
   constant*, so it type-checked **both** branches and rejected the mismatched
   accumulator.

Separately, this work uncovered a **latent correctness bug**: `hl.constexpr(expr)`
used inside a kernel body became a `ClassType` (via the `NamedTuple` path) whose
`truth_value()` is unconditionally `True`. That silently froze every
`if hl.constexpr(...)` to its *true* branch for **all** configs — a kernel could
return the wrong branch's result without any error. (The swap-AB GEMM masked
this because both branches are mathematically equivalent; a branch that computes
genuinely different values would have produced silently wrong output.)

## The fix

The key insight: a condition that depends only on block sizes is a compile-time
constant **per config**, so it must be emitted as a real device `if` and
resolved at codegen (where block sizes are concrete), emitting only the live
branch. Triton then drops the dead branch, and the divergent shapes are legal.

The change is split into three commits:

### 1. `type prop: preserve symbolic comparison and boolean expressions`

`_compare` and `_bool_op` in `type_propagation.py` previously minted a fresh
unbacked bool for symbolic operands, discarding the expression (`block_m < 64`
became an opaque `Eq(u11, 1)`). They now preserve the real relation
(`block_m < 64`, `And(block_m < 64, block_n >= 64)`), keeping the block-size
dependency intact so the condition stays recognizable downstream.

- `helion/_compiler/type_propagation.py`
- `test/test_type_propagation.expected` — one line updates to show the true
  comparison expression instead of a fresh unbacked bool (a strict improvement).

### 2. `fix hl.constexpr(...) in kernel body freezing the true branch`

`TypeInfo.from_example` now treats `hl.constexpr(x)` inside a kernel body as
transparent — represented by its wrapped value's type — instead of an
always-true `ClassType`. This fixes the latent wrong-branch bug and unifies the
two spellings the issue proposes (branching on `tile.block_size` vs. wrapping in
`hl.constexpr`).

- `helion/_compiler/type_info.py`

### 3. `support divergent branch shapes for block-size constexpr conditions`

The feature itself:

- **`compile_environment.py`** — a thread-local `block_size_constexpr_branch()`
  context manager (with `in_block_size_constexpr_branch()`), set while type-
  propagating or tracing the branches of such an `if`.
- **`device_function.py`** — `evaluate_constexpr_condition(test)` substitutes the
  current config's block sizes into the test's sympy expression and returns a
  concrete `bool`, or `None` if the test is not a per-config constant.
- **`device_ir.py`** — `IfGraphInfo.codegen` emits the test as a literal
  `True`/`False` when it resolves to a constant, so Triton drops the dead branch;
  `WalkDeviceAST.visit_If` enters the context while building the branch subgraphs
  when the predicate depends only on block sizes.
- **`type_info.py`** (`TensorType.merge`), **`type_propagation.py`**
  (`visit_If`), **`_tracing_ops.py`** (`_phi` fake), **`matmul_ops.py`**
  (`hl.dot` accumulator check) — trace-time shape-equality checks are relaxed to
  **rank-only** while tracing a block-size constexpr branch. A genuine
  runtime-conditioned shape divergence is unaffected: its condition does not
  resolve to a constant, both branches are emitted, and Triton still rejects the
  mismatch.
- **`test/test_constexpr.py`** — two regression tests (see below).

## Behavior after the fix

The issue's kernel now compiles and autotunes across all block-size
combinations. Verified end-to-end on B200 for the reporter's exact kernel
(`register_block_size` + host-level `hl.constexpr`) at their real dimensions
`M=4, N=10240` (masked M), producing correct results for both swap
(`block_m < 64 <= block_n`) and non-swap configs. Both the `hl.constexpr(...)`
spelling and the `tile_m.block_size < 64 and tile_n.block_size >= 64` spelling
work.

## Tests

Added to `test/test_constexpr.py`:

- `test_block_size_constexpr_branch_selects_per_config` — asserts a
  block-size-conditioned branch picks the correct branch **per config** (guards
  against the latent freeze-to-true regression).
- `test_block_size_constexpr_branch_divergent_shapes` — the swap-AB GEMM with a
  transposed accumulator; checks correct results for swap and non-swap configs.

All existing `test_constexpr`, `test_control_flow`, `test_matmul`,
`test_type_propagation`, `test_indexing`, `test_specialize`, `test_loops`,
`test_reductions`, and `test_views` tests pass. `./lint.sh` is clean for the
touched files.

## Known limitation

One kernel *shape* remains unsupported: `hl.tile([M, N])` (auto-allocated block
sizes) combined with a manually transposed `hl.load(x, [tile_a.index[None, :],
tile_b.index[:, None]])` in the swap branch **and** a masked (non-power-of-2)
tile dimension. This hits a pre-existing quirk in broadcast-tensor-indexer mask
attribution, exposed — not introduced — by making the divergent branch reachable.
The reporter's kernel (using `hl.register_block_size`) is unaffected, and the
`hl.tile` form has a working alternative: use tile-subscript indexing
(`b[tile_k, tile_n].T`) in the swap branch instead of the manual transposed
`hl.load`.


## Commits

- `30eed31d` type prop: preserve symbolic comparison and boolean expressions
- `beb0ceb5` fix hl.constexpr(...) in kernel body freezing the true branch
- `90a7dee1` support divergent branch shapes for block-size constexpr conditions
dev@gpu-dev-f417a92a:~/helion-issue3044$