### PR TITLE
type prop: preserve symbolic comparison and boolean expressions

### DIFF
--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from typing import NoReturn
 from typing import Protocol
 
+import torch
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.convert_frame import compile_lock
 
@@ -300,6 +301,19 @@ class TypePropagation(ast.NodeVisitor):
                 return right if val is True else left
         except NotImplementedError:
             pass
+        if isinstance(left, SymBoolType) and isinstance(right, SymBoolType):
+            # Preserve the symbolic conjunction/disjunction (e.g.
+            # ``block_m < 64 and block_n >= 64``) instead of minting a fresh
+            # unbacked bool, so a block-size-only condition stays resolvable
+            # per-config at codegen.  ``&``/``|`` on SymBool build the combined
+            # symbolic expression without forcing a guard.
+            combined = (
+                left.value | right.value
+                if isinstance(op, ast.Or)
+                else left.value & right.value
+            )
+            if isinstance(combined, torch.SymBool):
+                return SymBoolType(self.origin(), combined)
         if (
             isinstance(left, (NumericType, LiteralType))
             and isinstance(right, (NumericType, LiteralType))
@@ -346,6 +360,18 @@ class TypePropagation(ast.NodeVisitor):
             right,
             (NumericType, LiteralType),
         ):
+            # Preserve the symbolic comparison expression (e.g. ``block_m < 64``)
+            # rather than minting a fresh unbacked bool.  This keeps the block-size
+            # dependency intact so a block-size-only condition can be resolved
+            # per-config at codegen (see IfGraphInfo.codegen), which is what makes
+            # block-size-dependent control flow work on the host.
+            if not isinstance(op, CMP_ALWAYS_BOOL):
+                try:
+                    result = _eval_compare(op, left.proxy(), right.proxy())
+                except NotImplementedError:
+                    result = None
+                if isinstance(result, torch.SymBool):
+                    return SymBoolType(self.origin(), result)
             return SymBoolType.new_unbacked(self.origin())
         if isinstance(op, CMP_ALWAYS_BOOL):
             return SymBoolType.new_unbacked(self.origin())

--- a/test/test_type_propagation.expected
+++ b/test/test_type_propagation.expected
@@ -815,7 +815,7 @@ i *
             # Name: SymIntType(u0) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
 sm_count
             if 
-            # Compare: SymBoolType(Eq(u11, 1)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Compare: SymBoolType(u0*u4 + u2 < 128) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
             # Name: SymIntType(u0*u4 + u2) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
 idx < 
             # Name: LiteralType(128) GetItemOrigin(value=AttributeOrigin(value=ArgumentOrigin(name='x'), key='shape'), key=0)

--- a/test/test_type_propagation.py
+++ b/test/test_type_propagation.py
@@ -120,6 +120,34 @@ class TestTypePropagation(RefEagerTestDisabled, TestCase):
         output = type_propagation_report(use_device_properties, x)
         self.assertExpectedJournal(output)
 
+    def test_symbolic_comparison_preserves_expression(self):
+        """A comparison/`and` on symbolic block sizes must propagate the real
+        relation (e.g. ``block_m < 64``), not a fresh unbacked bool that discards
+        the operands. Preserving the expression keeps the block-size dependency
+        so the condition stays resolvable per-config at codegen."""
+
+        @helion.kernel
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            block_m = hl.register_block_size(m)
+            block_n = hl.register_block_size(n)
+            cmp = block_m < 64  # noqa: F841
+            both = block_m < 64 and block_n >= 64  # noqa: F841
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n], block_size=[block_m, block_n]):
+                out[tile_m, tile_n] = x[tile_m, tile_n]
+            return out
+
+        output = type_propagation_report(fn, torch.ones([128, 128], device=DEVICE))
+        # The comparison and the `and` propagate as real relationals over the
+        # block-size symbols, e.g. `SymBoolType(u0 < 64)` and a conjunction that
+        # still mentions `>= 64`. Before the fix they became opaque unbacked
+        # bools like `SymBoolType(Eq(u2, 1))` that dropped the operands.
+        self.assertIn("SymBoolType(", output)
+        self.assertIn("< 64)", output)
+        self.assertIn(">= 64", output)
+        self.assertNotRegex(output, r"SymBoolType\(Eq\(u\d+, 1\)\)")
+
     @skipIfXPU("CUDA-only")
     def test_cuda_device_properties_unsupported_attribute(self):
         @helion.kernel


### PR DESCRIPTION
Stacked PRs:
 * #3061
 * #3060
 * __->__#3059


--- --- ---

### type prop: preserve symbolic comparison and boolean expressions


Comparisons and and/or on symbolic values (e.g. a registered block size)
previously minted a fresh unbacked bool, discarding the expression. Keep
the real relation instead (block_m < 64, And(...)), so a condition that
depends only on block sizes stays recognizable and can be resolved
per-config later at codegen.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
