### PR TITLE
fix hl.constexpr(...) in kernel body freezing the true branch

### DIFF
--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -64,6 +64,18 @@ class TypeInfo:
 
     @classmethod
     def from_example(cls, value: object, origin: Origin) -> TypeInfo:
+        from ..language.constexpr import ConstExpr
+
+        if isinstance(value, ConstExpr):
+            # hl.constexpr(...) used inside a kernel body marks its argument as a
+            # compile-time constant.  It is transparent to control flow and
+            # arithmetic, so represent it by its wrapped value's type.  Without
+            # this, ConstExpr (a NamedTuple, incl. subclasses like
+            # ProcessGroupName) becomes a ClassType whose truth_value() is
+            # bool(element_types) -- always True, since the wrapper always has its
+            # single 'value' field -- so an `if hl.constexpr(cond):` ignores cond
+            # and always takes the body.
+            return cls.from_example(value.value, origin)
         if isinstance(value, torch.Tensor):
             # TODO(jansel): need to wrap this in a fake tensor
             # TODO(jansel): tensor subclass support

--- a/test/test_constexpr.py
+++ b/test/test_constexpr.py
@@ -110,6 +110,27 @@ class TestConstExpr(RefEagerTestBase, TestCase):
         code, result = code_and_output(fn, (x, "default"))
         torch.testing.assert_close(result, x)
 
+    def test_constexpr_in_body_selects_branch(self):
+        """`hl.constexpr(cond)` used inside a kernel body must decide the branch
+        by the wrapped value, not unconditionally take the `if` branch."""
+
+        @helion.kernel()
+        def fn(x: torch.Tensor, flag: bool) -> torch.Tensor:
+            take_if = hl.constexpr(flag)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                if take_if:
+                    out[tile] = x[tile] + 1.0
+                else:
+                    out[tile] = x[tile] + 2.0
+            return out
+
+        x = torch.zeros([64], device=DEVICE)
+        _, result_true = code_and_output(fn, (x, True), block_sizes=[32])
+        torch.testing.assert_close(result_true, x + 1.0)
+        _, result_false = code_and_output(fn, (x, False), block_sizes=[32])
+        torch.testing.assert_close(result_false, x + 2.0)
+
     @skipIfRefEager("Triton codegen does not work in ref eager mode")
     @skipIfMTIA('Not supported on MTIA. Error: "Expected IntList but got GenericList"')
     def test_block_size_constexpr_assignment_in_host_code(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3061
 * __->__#3060
 * #3059


--- --- ---

### fix hl.constexpr(...) in kernel body freezing the true branch


hl.constexpr(expr) used inside a kernel body became a ClassType (via the
NamedTuple path) whose truth_value() is unconditionally True, silently
freezing the if to its true branch for every autotuning config. Represent
it by its wrapped value's type so it is transparent to control flow.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
