### PR TITLE
support divergent branch shapes for block-size constexpr conditions

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -456,6 +456,49 @@ class DeviceFunction:
         env = CompileEnvironment.current()
         return env.block_sizes[block_id].from_config(self.config)
 
+    def evaluate_constexpr_condition(self, test: object) -> bool | None:
+        """Resolve a control-flow test to a concrete bool for the current config.
+
+        Block sizes are symbolic during the (single) frontend pass but become
+        concrete integers per-config at codegen time.  A branch condition that
+        depends only on block sizes (and other constants) is therefore a
+        compile-time constant here, even though it could not be folded earlier.
+        Substituting the config's block sizes lets us decide the branch and emit
+        only the live side, which is what makes shape-divergent branches legal.
+
+        Returns the concrete bool, or ``None`` if the test is not a compile-time
+        constant for this config (e.g. it depends on a runtime value).
+        """
+        if isinstance(test, (bool, int)):
+            return bool(test)
+        if not isinstance(test, torch.SymBool):
+            return None
+        # NB: a boolean expression (And/Or/Relational) is a sympy.Basic but not a
+        # sympy.Expr, so we classify its free symbols directly rather than via
+        # find_block_size_symbols (which only handles sympy.Expr).
+        expr = test._sympy_()
+        if not isinstance(expr, sympy.Basic):
+            return None
+        env = CompileEnvironment.current()
+        hf = HostFunction.current()
+        subs: dict[sympy.Basic, sympy.Basic] = {}
+        for symbol in expr.free_symbols:
+            origin_info = hf.expr_to_origin.get(symbol)
+            if origin_info is None or not isinstance(
+                origin_info.origin, BlockSizeOrigin
+            ):
+                return None
+            value = env.block_sizes[origin_info.origin.block_id].from_config(
+                self.config
+            )
+            if not isinstance(value, int):
+                return None
+            subs[symbol] = sympy.Integer(value)
+        resolved = expr.xreplace(subs)
+        if resolved.free_symbols:
+            return None
+        return bool(resolved)
+
     def try_map_block_symbols_to_vars(self, expr: sympy.Expr) -> sympy.Expr | None:
         """Try to map all block size symbols in expression to their variable names.
 

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -436,6 +436,19 @@ class IfGraphInfo(NodeArgsGraphInfo):
         assert isinstance(state.codegen, GenerateAST)
 
         test = state.ast_arg(0)
+        # A branch condition that depends only on block sizes is a compile-time
+        # constant for this config, even though it stayed symbolic during the
+        # single frontend pass.  evaluate_constexpr_condition resolves it to a
+        # concrete bool, or None if it is a genuine runtime condition.  When it is
+        # constant, emit it as a literal ``True``/``False`` so Triton drops the
+        # dead branch entirely and only the live branch is compiled; when it is
+        # None, leave it as a runtime condition.
+        constexpr_test = state.device_function.evaluate_constexpr_condition(
+            state.proxy_arg(0)
+        )
+        if constexpr_test is not None:
+            test = expr_from_string(repr(constexpr_test))
+
         body_stmts: list[ast.AST] = []
         orelse_stmts: list[ast.AST] = []
         if_ast_node = create(ast.If, test=test, body=body_stmts, orelse=orelse_stmts)

--- a/test/test_constexpr.py
+++ b/test/test_constexpr.py
@@ -6,6 +6,7 @@ import unittest
 import torch
 
 import helion
+from helion import exc
 from helion._compat import use_tileir_tunables
 from helion._compiler.compile_environment import FixedBlockSizeSource
 from helion._testing import DEVICE
@@ -268,6 +269,195 @@ class TestConstExpr(RefEagerTestBase, TestCase):
             compiled = bound.compile_config(config)
             result = compiled(x, w, hl.constexpr(flag))
             self.assertEqual(result.shape, x.shape)
+
+    @skipIfRefEager("compile_config not supported in ref eager mode")
+    @skipIfMTIA("Not supported on MTIA. PE failure crashes on DMA_IN")
+    def test_block_size_constexpr_branch_selects_per_config(self):
+        """A branch whose condition depends on a block size must pick the branch
+        per-config, not freeze one branch during the single frontend pass
+        (issue #3044)."""
+
+        @helion.kernel(static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            (n,) = x.shape
+            bs = hl.register_block_size(n)
+            flag = hl.constexpr(bs < 64)
+            out = torch.empty_like(x)
+            for tile in hl.tile(n, block_size=bs):
+                if flag:
+                    out[tile] = x[tile] + 1
+                else:
+                    out[tile] = x[tile] + 2
+            return out
+
+        x = torch.zeros(128, device=DEVICE)
+        bound = fn.bind((x,))
+        for block_size in [32, 128]:
+            result = bound.compile_config(helion.Config(block_sizes=[block_size]))(x)
+            expected = x + (1 if block_size < 64 else 2)
+            torch.testing.assert_close(result, expected)
+
+    @skipIfMTIA("Not supported on MTIA. PE failure crashes on DMA_IN")
+    def test_block_size_constexpr_branch_divergent_shapes(self):
+        """Branches selected by a block-size constexpr may use variables with
+        different shapes -- e.g. a swap-AB GEMM that transposes its accumulator
+        for small M (issue #3044).
+
+        The branches must be fully duplicated: each branch owns its accumulator
+        and store, so no variable is *merged* across the branches (a merge would
+        require one consistent shape).  The block-size condition is resolved
+        per-config at codegen, so only the live branch is emitted.  A shared K
+        block size keeps the inner ``hl.tile(K)`` loops on one block id (an
+        un-shared loop would create distinct tile ids that then conflict when the
+        branch scopes merge).
+        """
+
+        @helion.kernel(static_shapes=True)
+        def matmul_swap_ab(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            M, K = a.size()
+            _, N = b.size()
+            out = torch.empty([M, N], dtype=a.dtype, device=a.device)
+            block_m = hl.register_block_size(M)
+            block_n = hl.register_block_size(N)
+            block_k = hl.register_block_size(K)
+            swap_ab = hl.constexpr(block_m < 64 and block_n >= 64)
+            for tile_m, tile_n in hl.tile([M, N], block_size=[block_m, block_n]):
+                if swap_ab:
+                    acc_swap = hl.zeros([tile_n, tile_m], dtype=torch.float32)
+                    for tile_k in hl.tile(K, block_size=block_k):
+                        a_blk = hl.load(
+                            a, [tile_m.index[None, :], tile_k.index[:, None]]
+                        )
+                        b_blk = hl.load(
+                            b, [tile_k.index[None, :], tile_n.index[:, None]]
+                        )
+                        acc_swap = hl.dot(
+                            b_blk, a_blk, acc=acc_swap, out_dtype=torch.float32
+                        )
+                    out[tile_m, tile_n] = acc_swap.t().to(out.dtype)
+                else:
+                    acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                    for tile_k in hl.tile(K, block_size=block_k):
+                        acc = hl.dot(
+                            a[tile_m, tile_k],
+                            b[tile_k, tile_n],
+                            acc=acc,
+                            out_dtype=torch.float32,
+                        )
+                    out[tile_m, tile_n] = acc.to(out.dtype)
+            return out
+
+        M, K, N = 64, 512, 256
+        a = torch.randn(M, K, device=DEVICE, dtype=torch.float16)
+        b = torch.randn(K, N, device=DEVICE, dtype=torch.float16)
+        expected = a @ b
+
+        if self._in_ref_eager_mode:
+            # Ref-eager runs the body directly with no config/codegen (block
+            # sizes are the full dims), so just check the result is correct.
+            torch.testing.assert_close(
+                matmul_swap_ab(a, b), expected, rtol=1e-2, atol=1e-2
+            )
+            return
+
+        bound = matmul_swap_ab.bind((a, b))
+        # Both swap (block_m < 64 <= block_n) and non-swap configs must compile
+        # and produce correct results.  The swap branches are mathematically
+        # equivalent (A @ B == (B.T @ A.T).T), so also assert on the generated
+        # code that the condition folds to the correct branch per config: the
+        # taken branch becomes `if True:` and the dead one `if False:`.
+        for bm, bn in [(32, 128), (64, 64), (128, 32)]:
+            config = helion.Config(block_sizes=[bm, bn, 64])
+            code = bound.to_triton_code(config)
+            swap = bm < 64 <= bn
+            self.assertEqual(code.count("if True:"), 1 if swap else 0)
+            self.assertEqual(code.count("if False:"), 0 if swap else 1)
+            result = bound.compile_config(config)(a, b)
+            torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+
+    @skipIfRefEager("compile_config not supported in ref eager mode")
+    @skipIfMTIA("Not supported on MTIA. PE failure crashes on DMA_IN")
+    def test_block_size_constexpr_branch_merged_divergent_shapes_rejected(self):
+        """Merging a variable with different shapes across the branches is still
+        rejected even when the condition is a block-size constexpr: the branches
+        must be duplicated instead (see
+        test_block_size_constexpr_branch_divergent_shapes)."""
+
+        @helion.kernel(static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            n, m = x.shape
+            bs_n = hl.register_block_size(n)
+            bs_m = hl.register_block_size(m)
+            swap = hl.constexpr(bs_n < 64 and bs_m >= 64)
+            out = torch.empty_like(x)
+            for tile_n, tile_m in hl.tile([n, m], block_size=[bs_n, bs_m]):
+                # `acc` is written in both branches with different shapes and then
+                # used after the `if` -> a control-flow merge with divergent shape.
+                if swap:
+                    acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                else:
+                    acc = hl.zeros([tile_n, tile_m], dtype=torch.float32)
+                out[tile_n, tile_m] = x[tile_n, tile_m] + acc.sum()
+            return out
+
+        with self.assertRaises(exc.ControlFlowTensorMismatch):
+            fn.bind((torch.zeros([64, 128], device=DEVICE),)).to_triton_code(
+                helion.Config(block_sizes=[32, 128])
+            )
+
+    @skipIfRefEager("evaluate_constexpr_condition is a codegen-time helper")
+    @skipIfMTIA("Not supported on MTIA. PE failure crashes on DMA_IN")
+    def test_evaluate_constexpr_condition(self):
+        """DeviceFunction.evaluate_constexpr_condition resolves a block-size test
+        to a concrete bool for the current config, and returns None when the test
+        is not a per-config compile-time constant."""
+        from helion._compiler.generate_ast import GenerateAST
+
+        @helion.kernel(static_shapes=True)
+        def k(x: torch.Tensor) -> torch.Tensor:
+            n, m = x.shape
+            block_m = hl.register_block_size(n)
+            block_n = hl.register_block_size(m)
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([n, m], block_size=[block_m, block_n]):
+                out[tile_m, tile_n] = x[tile_m, tile_n]
+            return out
+
+        bound = k.bind((torch.zeros([128, 128], device=DEVICE),))
+
+        def evaluate(config, make_test):
+            with bound.env, bound.host_function:
+                device_function = GenerateAST(
+                    bound.host_function, config
+                ).device_function
+                block_m = bound.env.block_sizes[0].var
+                block_n = bound.env.block_sizes[1].var
+                runtime = bound.env.create_unbacked_symint()
+                return device_function.evaluate_constexpr_condition(
+                    make_test(block_m, block_n, runtime)
+                )
+
+        swap = helion.Config(block_sizes=[32, 128])  # block_m < 64 <= block_n
+        non_swap = helion.Config(block_sizes=[128, 32])
+
+        # A block-size condition resolves to the concrete bool for the config.
+        self.assertIs(evaluate(swap, lambda bm, bn, r: (bm < 64) & (bn >= 64)), True)
+        self.assertIs(
+            evaluate(non_swap, lambda bm, bn, r: (bm < 64) & (bn >= 64)), False
+        )
+        self.assertIs(evaluate(swap, lambda bm, bn, r: bm < 64), True)
+        self.assertIs(evaluate(non_swap, lambda bm, bn, r: bm < 64), False)
+
+        # Plain bool/int literals pass through.
+        self.assertIs(evaluate(swap, lambda bm, bn, r: True), True)
+        self.assertIs(evaluate(swap, lambda bm, bn, r: False), False)
+        self.assertIs(evaluate(swap, lambda bm, bn, r: 1), True)
+
+        # Non-constant tests return None: runtime symbols, a mix of block-size and
+        # runtime symbols, and non-bool objects.
+        self.assertIsNone(evaluate(swap, lambda bm, bn, r: r < 5))
+        self.assertIsNone(evaluate(swap, lambda bm, bn, r: (bm < 64) & (r < 5)))
+        self.assertIsNone(evaluate(swap, lambda bm, bn, r: "not-a-bool"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs:
 * __->__#3061
 * #3060
 * #3059


--- --- ---

### support divergent branch shapes for block-size constexpr conditions

An `if`/`else` whose condition depends only on block sizes (e.g.
`hl.constexpr(block_m < 64 and block_n >= 64)`) is a compile-time constant
*per config*, even though it stays symbolic during the single, shared frontend
pass. This PR resolves such a condition per-config at codegen and emits it as a
literal `True`/`False`, so Triton drops the dead branch entirely and compiles
only the live one.

This lets the branches use variables with **different shapes** — e.g. a swap-AB
GEMM that transposes its accumulator for small M (`A @ B == (B.T @ A.T).T`) —
**provided the branches are fully duplicated**: each branch must own its
divergent-shaped variables and its stores. A variable *merged* across the
branches (assigned in both, then used after the `if`) still requires one
consistent shape, because that merge is resolved during the shared,
config-independent frontend pass, before the per-config fold happens. Sharing
the K block size (`hl.register_block_size(K)`) keeps each branch's inner
`hl.tile(K)` loop on the same block id.

Implementation:
- `DeviceFunction.evaluate_constexpr_condition` substitutes the config's
  concrete block sizes into the test's sympy expression and returns the concrete
  bool, or `None` if it is a genuine runtime condition.
- `IfGraphInfo.codegen` emits the resolved literal `True`/`False` when the test
  is constant, and leaves a runtime condition unchanged otherwise.

A genuine runtime-conditioned shape divergence is unaffected: its condition does
not fold to a constant, so both branches are emitted and the existing
control-flow / `_phi` / `hl.dot` shape checks reject the mismatch as before.

Depends on #3059 (preserve the symbolic comparison/`and` expression) and #3060
(make `hl.constexpr(...)` in a kernel body transparent) so the condition reaches
codegen as a block-size expression rather than an opaque frozen bool.

Fixes #3044.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>