### PR TITLE
Fix ConstDictVariable call for latest torch nightly

### DIFF
--- a/helion/_compiler/_dynamo/variables.py
+++ b/helion/_compiler/_dynamo/variables.py
@@ -379,7 +379,7 @@ class HelionKernelVariable(VariableTracker):
         hop_kwargs = {
             "kernel_idx": self._kernel_idx,
             "constant_args": constant_args,
-            "tensor_args": ConstDictVariable(tensor_args, dict).as_proxy(),
+            "tensor_args": ConstDictVariable(tensor_args).as_proxy(),
             "output_spec": output_spec,
         }
 


### PR DESCRIPTION
## Problem

pytorch/pytorch#189549 (\"[dynamo] Represent ConstDictVariable as dict only; split OrderedDict storage\") removed the `user_cls` parameter from `torch._dynamo.variables.ConstDictVariable.__init__`.

The existing call `ConstDictVariable(tensor_args, dict)` in `helion/_compiler/_dynamo/variables.py` breaks on recent nightlies:
- On intermediate nightlies: `TypeError: ConstDictVariable.__init__() takes 2 positional arguments but 3 were given`
- On the newest nightly (post-#189549): passing `user_cls` by keyword instead fails with `TypeError: VariableTracker.__init__() got an unexpected keyword argument 'user_cls'` (it falls through `**kwargs`)

This breaks every test in `test/test_torch_compile.py`.

## Fix

Drop the argument entirely. `dict` was the default, and the refactor makes a plain `dict` the only container `ConstDictVariable` represents, so `ConstDictVariable(tensor_args)` is behavior-preserving and works across old and new torch.

## Testing

`test/test_torch_compile.py` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)