### PR TITLE
CI: pin B200 test jobs to mt-l-x86iamx-22-225-b200 runner temporarily

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -69,7 +69,7 @@
       "backend": "triton"
     },
     {
-      "runner": "linux.dgx.b200",
+      "runner": "mt-l-x86iamx-22-225-b200",
       "python-version": "3.12",
       "ref-eager": false,
       "image": "nvidia/cuda:13.1.0-devel-ubuntu24.04",
@@ -80,7 +80,7 @@
       "backend": "triton"
     },
     {
-      "runner": "linux.dgx.b200",
+      "runner": "mt-l-x86iamx-22-225-b200",
       "python-version": "3.12",
       "ref-eager": false,
       "image": "nvidia/cuda:13.2.0-devel-ubuntu24.04",
@@ -128,7 +128,7 @@
       "backend": "pallas"
     },
     {
-      "runner": "linux.dgx.b200",
+      "runner": "mt-l-x86iamx-22-225-b200",
       "python-version": "3.12",
       "ref-eager": false,
       "image": "nvidia/cuda:13.1.0-devel-ubuntu24.04",


### PR DESCRIPTION
Helion's B200 CI jobs request the generic `linux.dgx.b200` pool label, which schedules them onto an unhealthy B200 machine — jobs fail at the "CUDA Compute Check" step (a basic `a @ a` matmul), indicating the runner/container is broken rather than the code.

PyTorch's B200 smoke tests use a `map_ec2_to_arc` step that rewrites `linux.dgx.b200` to the concrete Meta-fleet machine `mt-l-x86iamx-22-225-b200` (forcing the `mt-` prefix because H100/B200 exist only on the Meta fleet). Helion has no such mapping and already hardcodes its H100 jobs to `mt-l-x86iamx-22-225-h100`.

Point Helion's B200 test jobs at the same healthy runner torch uses, matching the existing H100 pattern. This PR touches only the CI test matrix (.github/matrix.json); benchmark workflows are left unchanged.