### PR TITLE
Gate distributed-only compilation on symmetric-memory usage not dist.is_initialized()

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -25,7 +25,6 @@ from torch._inductor.codegen.wrapper import (
 from torch._inductor.runtime.runtime_utils import next_power_of_2
 from torch._subclasses import FakeTensor
 from torch._subclasses import FakeTensorMode
-import torch.distributed as dist
 from torch.fx.experimental.symbolic_shapes import DimDynamic
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
@@ -223,6 +222,7 @@ class CompileEnvironment:
         settings: Settings,
         *,
         index_dtype: torch.dtype | None = None,
+        is_distributed: bool = False,
     ) -> None:
         from ..autotuner.config_spec import ConfigSpec
 
@@ -312,7 +312,7 @@ class CompileEnvironment:
         self._foreign_symint_cache: dict[
             tuple[int, sympy.Expr], int | torch.SymInt
         ] = {}
-        if settings.autotune_force_persistent or dist.is_initialized():
+        if settings.autotune_force_persistent or is_distributed:
             for pid_type in (
                 "flat",
                 "xyz",
@@ -324,7 +324,7 @@ class CompileEnvironment:
         # bridge), so under a multi-host (dist-initialized) serve this would call
         # get_num_sm(cpu) -> "TODO: implement for other devices" and crash the
         # kernel compile. _SymmetricMemory / SM-multiplier are irrelevant to Pallas.
-        if dist.is_initialized() and device.type == "cuda":
+        if is_distributed and device.type == "cuda":
             from torch._C._distributed_c10d import _SymmetricMemory
 
             from .._dist_utils import max_num_blocks_for_symm_mem

--- a/helion/_dist_utils.py
+++ b/helion/_dist_utils.py
@@ -14,6 +14,7 @@ from torch import Tensor
 from torch._C._distributed_c10d import _SymmetricMemory
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
+from torch.utils._pytree import tree_leaves
 
 import helion
 from helion import exc
@@ -29,10 +30,8 @@ def _resolve_process_group(name: str) -> dist.ProcessGroup:
 
 
 def all_gather_object(obj: T, process_group_name: str | None = None) -> list[T]:
-    if not dist.is_initialized():
+    if not dist.is_initialized() or process_group_name is None:
         return [obj]
-
-    assert process_group_name is not None
 
     group = _resolve_process_group(process_group_name)
     object_list = [None] * dist.get_world_size(group)
@@ -45,10 +44,9 @@ def sync_object(obj: T, process_group_name: str | None = None) -> T:
     r"""
     Synchronize the number of repeations across all ranks.
     """
-    if not dist.is_initialized():
+    if not dist.is_initialized() or process_group_name is None:
         return obj
 
-    assert process_group_name is not None
     group = _resolve_process_group(process_group_name)
     object_list = [obj]
     # use the value from group rank 0
@@ -95,6 +93,30 @@ def is_symm_mem_tensor(t: Tensor, process_group_name: str | None = None) -> bool
         return False
 
 
+def kernel_uses_symm_mem(args: tuple[object, ...]) -> bool:
+    """Return True if this is a distributed kernel operating on symmetric memory.
+
+    Helion's distributed-only compilation behavior (persistent-only PID types,
+    signal-pad SM-count limits, and process-group resolution) is only needed for
+    kernels that actually use symmetric-memory tensors. Gating on this instead of
+    ``dist.is_initialized()`` avoids penalizing and warning on ordinary kernels
+    that merely run inside a process where torch.distributed happens to be
+    initialized (e.g. vLLM). See GitHub issue #3024.
+    """
+    if not dist.is_initialized():
+        return False
+    if not hasattr(symm_mem, "is_symm_mem_tensor"):
+        # Older PyTorch cannot cheaply detect symmetric-memory tensors without a
+        # process group, so fall back to the previous conservative behavior.
+        return True
+    # Flatten containers (list/tuple/dict) so symmetric-memory tensors passed
+    # nested inside an argument are still detected.
+    return any(
+        isinstance(leaf, Tensor) and symm_mem.is_symm_mem_tensor(leaf)
+        for leaf in tree_leaves(args)
+    )
+
+
 def get_signal_pad_ptrs_dev(t: Tensor, process_group_name: str | None = None) -> int:
     assert dist.is_initialized()
     assert process_group_name is not None
@@ -116,10 +138,10 @@ def check_config_consistancy(
     if (
         os.getenv("HELION_DIST_CHECK_CONFIG_CONSISTANCY") != "1"
         or not dist.is_initialized()
+        or process_group_name is None
     ):
         return
 
-    assert process_group_name is not None
     group = _resolve_process_group(process_group_name)
     all_configs = [None] * dist.get_world_size(group)
     # pyrefly: ignore[bad-argument-type]
@@ -184,11 +206,10 @@ def sync_seed(
     ranks have different seeds after the call. This ensures different
     rank can generate independent random tensors.
     """
-    if not dist.is_initialized():
+    if not dist.is_initialized() or process_group_name is None:
         yield
         return
 
-    assert process_group_name is not None
     seeds = sync_object(SeedEnsemble.get_seeds(), process_group_name=process_group_name)
 
     try:
@@ -199,7 +220,18 @@ def sync_seed(
             SeedEnsemble.update_seeds_with_rank()
 
 
-def _find_process_group_name(fn: Callable, args: tuple[object, ...]) -> str | None:
+def kernel_declares_process_group(fn: Callable) -> bool:
+    """True if the kernel has an ``hl.ProcessGroupName``-annotated argument, an
+    explicit declaration that it is a distributed kernel."""
+    return any(
+        param.annotation == "hl.ProcessGroupName"
+        for param in inspect.signature(fn).parameters.values()
+    )
+
+
+def _find_process_group_name(
+    fn: Callable, args: tuple[object, ...], is_distributed: bool = False
+) -> str | None:
     from helion._compiler.compile_environment import warning
     from helion.exc import ProcessGroupNameNotFound
 
@@ -211,6 +243,11 @@ def _find_process_group_name(fn: Callable, args: tuple[object, ...]) -> str | No
         if param.annotation == "hl.ProcessGroupName":
             assert isinstance(arg, str), f"{type(arg)}"
             return arg
+
+    # Only distributed kernels need a process group. Ordinary kernels must not
+    # resolve one or warn about a missing hl.ProcessGroupName annotation.
+    if not is_distributed:
+        return None
 
     warning(ProcessGroupNameNotFound)
     assert dist.group.WORLD is not None

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -54,6 +54,8 @@ from .._compiler.output_header import assert_no_conflicts
 from .._compiler.variable_origin import ArgumentOrigin
 from .._dist_utils import _find_process_group_name
 from .._dist_utils import check_config_consistancy as dist_check_config_consistancy
+from .._dist_utils import kernel_declares_process_group
+from .._dist_utils import kernel_uses_symm_mem
 from .._logging import LazyString
 from .._utils import counters
 from ..autotuner.base_search import _AutotunableKernel
@@ -186,6 +188,10 @@ class Kernel(Generic[_R]):
         self.signature: inspect.Signature = inspect.signature(fn)
         self.settings: Settings = settings or Settings()
         self._key_fn: Callable[..., Hashable] | None = key
+        # Whether the kernel declares distributed intent via an hl.ProcessGroupName
+        # argument. Computed once so the per-call is_distributed check stays cheap
+        # on the dispatch hot path (avoids re-running inspect.signature). See #3024.
+        self._declares_process_group: bool = kernel_declares_process_group(fn)
         self.configs: list[Config] = [
             # pyrefly: ignore [bad-argument-type]
             Config(**config) if isinstance(config, dict) else config
@@ -277,6 +283,21 @@ class Kernel(Generic[_R]):
         extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
         return BoundKernelInMemoryCacheKey(signature, extra_results)
 
+    def _compute_is_distributed(self, args: Sequence[object]) -> bool:
+        """Whether this call should compile as a distributed kernel.
+
+        True when the arguments carry symmetric-memory tensors, or the author
+        declared distributed intent (``settings.distributed`` or an
+        ``hl.ProcessGroupName`` argument) inside an initialized process group.
+        This is folded into the specialization key so a symmetric-memory call
+        and an identically-shaped ordinary call never share a compiled kernel.
+        See GitHub issue #3024.
+        """
+        return kernel_uses_symm_mem(tuple(args)) or (
+            dist.is_initialized()
+            and (self.settings.distributed or self._declares_process_group)
+        )
+
     def _fast_dispatch_key(self, args: tuple[object, ...]) -> Hashable | None:
         """
         Build a cheap dispatch key for the fast-path cache in ``__call__``.
@@ -319,6 +340,7 @@ class Kernel(Generic[_R]):
                 return None
         if not has_tensor:
             return None
+        key.append(self._compute_is_distributed(args))
         if self._key_fn is not None:
             key.append(self._key_fn(*args))
         return tuple(key)
@@ -377,9 +399,16 @@ class Kernel(Generic[_R]):
             else:
                 result.append(self._specialization_key(value))
         device_type, device_capability = _device_specialization_key(args)
+        is_distributed = self._compute_is_distributed(args)
         if self._key_fn is not None:
-            return (*result, device_type, device_capability, self._key_fn(*args))
-        return (*result, device_type, device_capability)
+            return (
+                *result,
+                device_type,
+                device_capability,
+                is_distributed,
+                self._key_fn(*args),
+            )
+        return (*result, device_type, device_capability, is_distributed)
 
     def specialization_key(self, args: Sequence[object]) -> tuple[Hashable, ...]:
         """
@@ -575,10 +604,16 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         self._backward_compiled: (
             tuple[Kernel[object], str, BoundKernel[object]] | None
         ) = None
+        # Distributed detection lives on Kernel so the same value feeds both the
+        # specialization cache key and CompileEnvironment gating; that keeps a
+        # symmetric-memory call from ever aliasing a non-distributed compiled
+        # kernel of the same shape. See GitHub issue #3024.
+        is_distributed = self.kernel._compute_is_distributed(args)
         self._env = CompileEnvironment(
             _find_device(args),
             self.kernel.settings,
             index_dtype=_resolve_index_dtype(self.kernel.settings, args),
+            is_distributed=is_distributed,
         )
 
         if is_ref_mode_enabled(self.kernel.settings):
@@ -587,7 +622,9 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             return
 
         with self.env:
-            self._env.process_group_name = _find_process_group_name(kernel.fn, args)
+            self._env.process_group_name = _find_process_group_name(
+                kernel.fn, args, is_distributed
+            )
 
             assert len(args) == len(self.kernel.signature.parameters)
             self.fake_args: list[object] = []

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -408,6 +408,9 @@ class _Settings:
             False,
         )
     )
+    distributed: bool = dataclasses.field(
+        default_factory=functools.partial(_env_get_bool, "HELION_DISTRIBUTED", False)
+    )
     autotune_log_level: int = dataclasses.field(default_factory=_get_autotune_log_level)
     autotune_log: str | None = dataclasses.field(default_factory=_get_autotune_log_path)
     autotune_log_details: bool = dataclasses.field(
@@ -633,6 +636,12 @@ class Settings(_Settings):
         "autotune_force_persistent": (
             "If True, restrict pid_type choices to persistent kernels only during config selection. "
             "Set HELION_AUTOTUNE_FORCE_PERSISTENT=1 to force persistent kernel autotuning globally."
+        ),
+        "distributed": (
+            "Force distributed compilation behavior (persistent-only PID types, signal-pad SM "
+            "limits, and process-group resolution). Normally auto-detected from symmetric-memory "
+            "tensor arguments; set this for distributed kernels whose symmetric memory is not passed "
+            "as a detectable tensor. Set HELION_DISTRIBUTED=1 to force globally."
         ),
         "autotune_log_level": (
             "Log level for autotuning using Python logging levels. Default is logging.INFO. "

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -264,8 +264,8 @@ class TestConfigAPI(TestCase):
         ):
             sm100_key = device_key_kernel._base_specialization_key((device,))
 
-        self.assertEqual(sm90_key[-2:], ("cuda", (9, 0)))
-        self.assertEqual(sm100_key[-2:], ("cuda", (10, 0)))
+        self.assertEqual(sm90_key[-3:], ("cuda", (9, 0), False))
+        self.assertEqual(sm100_key[-3:], ("cuda", (10, 0), False))
         self.assertNotEqual(sm90_key, sm100_key)
 
     def test_config_constructor_signature_contains_expected_kwargs(self) -> None:
@@ -431,10 +431,11 @@ class TestSettingsEnv(TestCase):
     def test_distributed_limits_pid_types_to_persistent(self) -> None:
         settings = helion.Settings()
         with (
-            patch("torch.distributed.is_initialized", return_value=True),
             patch("helion._dist_utils.max_num_blocks_for_symm_mem", return_value=10000),
         ):
-            env = CompileEnvironment(torch.device("cuda", 0), settings)
+            env = CompileEnvironment(
+                torch.device("cuda", 0), settings, is_distributed=True
+            )
         self.assertEqual(
             env.config_spec.allowed_pid_types,
             ("persistent_blocked", "persistent_interleaved"),
@@ -444,11 +445,12 @@ class TestSettingsEnv(TestCase):
         # max_blocks=10000, 200 SMs -> 10000 // 200 = 50 -> floor pow2 = 32
         settings = helion.Settings()
         with (
-            patch("torch.distributed.is_initialized", return_value=True),
             patch("helion._dist_utils.max_num_blocks_for_symm_mem", return_value=10000),
             patch("helion.runtime.get_num_sm", return_value=200),
         ):
-            env = CompileEnvironment(torch.device("cuda", 0), settings)
+            env = CompileEnvironment(
+                torch.device("cuda", 0), settings, is_distributed=True
+            )
         self.assertEqual(env.config_spec.max_num_sm_multiplier, 32)
 
     def test_persistent_block_limit_handles_zero_raw_max(self) -> None:
@@ -456,11 +458,12 @@ class TestSettingsEnv(TestCase):
         # without crashing on `1 << -1`.
         settings = helion.Settings()
         with (
-            patch("torch.distributed.is_initialized", return_value=True),
             patch("helion._dist_utils.max_num_blocks_for_symm_mem", return_value=144),
             patch("helion.runtime.get_num_sm", return_value=148),
         ):
-            env = CompileEnvironment(torch.device("cuda", 0), settings)
+            env = CompileEnvironment(
+                torch.device("cuda", 0), settings, is_distributed=True
+            )
         self.assertEqual(env.config_spec.max_num_sm_multiplier, 1)
 
     def test_backend_env_var_accepts_cute(self) -> None:

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import contextlib
 from datetime import timedelta
+import io
 import os
 import unittest
+from unittest.mock import patch
+import warnings
 
 import torch
 from torch import Tensor
@@ -13,18 +16,22 @@ import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
 from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import TestCase as CommonTestCase
 from torch.testing._internal.common_utils import instantiate_parametrized_tests
 from torch.testing._internal.common_utils import parametrize
 from torch.testing._internal.common_utils import run_tests
 
 import helion
 from helion._dist_utils import all_gather_object
+from helion._dist_utils import kernel_uses_symm_mem
 from helion._dist_utils import sync_object
 from helion._dist_utils import sync_seed
+from helion._testing import DEVICE
 from helion._testing import EXAMPLES_DIR
 from helion._testing import TestCase
 from helion._testing import import_path
 from helion._testing import onlyBackends
+from helion._testing import skipIfRefEager
 from helion._testing import skipIfXPU
 from helion.autotuner import search_algorithms
 from helion.autotuner.effort_profile import _PROFILES
@@ -35,6 +42,11 @@ from helion.autotuner.effort_profile import RandomSearchConfig
 import helion.language as hl
 
 autotuner_names = ["fixed", *search_algorithms]
+
+# torch.distributed._symmetric_memory.is_symm_mem_tensor exists only on newer
+# PyTorch. The symm-mem-based gating degrades to conservative behavior without it,
+# so the tests that assert the fine-grained gating require the API.
+_HAS_SYMM_MEM_DETECT = hasattr(symm_mem, "is_symm_mem_tensor")
 
 
 def custom_get_timeout(test_id: str) -> int:
@@ -573,6 +585,162 @@ class TestDistributed(TestCase, MultiProcessTestCase):
 
         expected = ref_fn(a_local, b_local, tp_group)
         torch.testing.assert_close(result, expected, rtol=1e-1, atol=1e-1)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestDistributedGating(CommonTestCase):
+    """Issue #3024: single-process checks that distributed gating keys off
+    symmetric-memory usage, not torch.distributed.is_initialized()."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._owns_pg = not dist.is_initialized()
+        if self._owns_pg:
+            dist.init_process_group(
+                backend="gloo", world_size=1, rank=0, store=dist.HashStore()
+            )
+
+    def tearDown(self) -> None:
+        if self._owns_pg and dist.is_initialized():
+            dist.destroy_process_group()
+        super().tearDown()
+
+    @staticmethod
+    def _make_add() -> object:
+        @helion.kernel(autotune_effort="none")
+        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        return add
+
+    def _bind_add(self):
+        x = torch.randn(512, 512, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(512, 512, device=DEVICE, dtype=torch.bfloat16)
+        stderr = io.StringIO()
+        with (
+            warnings.catch_warnings(record=True) as caught,
+            contextlib.redirect_stderr(stderr),
+        ):
+            warnings.simplefilter("always")
+            bound = self._make_add().bind((x, y))
+        return bound, stderr.getvalue(), caught
+
+    @unittest.skipUnless(_HAS_SYMM_MEM_DETECT, "requires symm_mem.is_symm_mem_tensor")
+    def test_non_distributed_kernel_not_constrained(self) -> None:
+        x = torch.randn(4, device=DEVICE)
+        self.assertFalse(kernel_uses_symm_mem((x, x)))
+        bound, stderr, caught = self._bind_add()
+        spec = bound.env.config_spec
+        self.assertIn("flat", spec.allowed_pid_types)
+        self.assertEqual(spec.max_num_sm_multiplier, 128)
+        self.assertIsNone(bound.env.process_group_name)
+        self.assertNotIn("ProcessGroupNameNotFound", stderr)
+        self.assertFalse(any("max_num_sm" in str(w.message) for w in caught))
+
+    @unittest.skipUnless(_HAS_SYMM_MEM_DETECT, "requires symm_mem.is_symm_mem_tensor")
+    @skipIfRefEager("process-group resolution only happens in compiled mode")
+    def test_symm_mem_kernel_still_distributed(self) -> None:
+        with patch.object(symm_mem, "is_symm_mem_tensor", return_value=True):
+            self.assertTrue(kernel_uses_symm_mem(([torch.randn(4, device=DEVICE)],)))
+            with (
+                patch(
+                    "helion._dist_utils.max_num_blocks_for_symm_mem", return_value=10000
+                ),
+                patch("helion.runtime.get_num_sm", return_value=200),
+            ):
+                bound, stderr, _ = self._bind_add()
+        spec = bound.env.config_spec
+        self.assertNotIn("flat", spec.allowed_pid_types)
+        self.assertNotIn("xyz", spec.allowed_pid_types)
+        self.assertLess(spec.max_num_sm_multiplier, 128)
+        self.assertIsNotNone(bound.env.process_group_name)
+        self.assertIn("ProcessGroupNameNotFound", stderr)
+
+    @unittest.skipUnless(_HAS_SYMM_MEM_DETECT, "requires symm_mem.is_symm_mem_tensor")
+    @skipIfRefEager("process-group resolution only happens in compiled mode")
+    def test_symm_mem_call_does_not_alias_cached_kernel(self) -> None:
+        # Same kernel object and identical shapes: a symmetric-memory call must
+        # not reuse the non-distributed kernel cached from an ordinary call, and
+        # the ordinary key must still resolve back to it. See issue #3024.
+        @helion.kernel(autotune_effort="none")
+        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        x = torch.randn(512, 512, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(512, 512, device=DEVICE, dtype=torch.bfloat16)
+
+        bound_normal = add.bind((x, y))
+        self.assertIn("flat", bound_normal.env.config_spec.allowed_pid_types)
+
+        with (
+            patch.object(symm_mem, "is_symm_mem_tensor", return_value=True),
+            patch("helion._dist_utils.max_num_blocks_for_symm_mem", return_value=10000),
+            patch("helion.runtime.get_num_sm", return_value=200),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            bound_symm = add.bind((x, y))
+            symm_fast_key = add._fast_dispatch_key((x, y))
+
+        self.assertIsNot(bound_normal, bound_symm)
+        self.assertNotIn("flat", bound_symm.env.config_spec.allowed_pid_types)
+        # the fast-dispatch key carries the distributed bit too
+        self.assertNotEqual(add._fast_dispatch_key((x, y)), symm_fast_key)
+        # the ordinary key still resolves back to the original compiled kernel
+        self.assertIs(bound_normal, add.bind((x, y)))
+
+    @unittest.skipUnless(_HAS_SYMM_MEM_DETECT, "requires symm_mem.is_symm_mem_tensor")
+    @skipIfRefEager("process-group resolution only happens in compiled mode")
+    def test_explicit_distributed_flag(self) -> None:
+        @helion.kernel(autotune_effort="none", distributed=True)
+        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        x = torch.randn(512, 512, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(512, 512, device=DEVICE, dtype=torch.bfloat16)
+        self.assertFalse(kernel_uses_symm_mem((x, y)))
+        with (
+            patch("helion._dist_utils.max_num_blocks_for_symm_mem", return_value=10000),
+            patch("helion.runtime.get_num_sm", return_value=200),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            bound = add.bind((x, y))
+        spec = bound.env.config_spec
+        self.assertNotIn("flat", spec.allowed_pid_types)
+        self.assertLess(spec.max_num_sm_multiplier, 128)
+        self.assertIsNotNone(bound.env.process_group_name)
+
+    def test_distributed_flag_without_process_group(self) -> None:
+        if not self._owns_pg:
+            self.skipTest("needs exclusive control of the process group")
+        if dist.is_initialized():
+            dist.destroy_process_group()  # we created it; next test's setUp re-inits
+
+        @helion.kernel(autotune_effort="none", distributed=True)
+        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE, dtype=torch.bfloat16)
+        bound = add.bind((x, x))  # must not raise
+        self.assertIn("flat", bound.env.config_spec.allowed_pid_types)
+        self.assertIsNone(bound.env.process_group_name)
+
+    def test_coordination_helpers_tolerate_none_pg(self) -> None:
+        self.assertEqual(all_gather_object("x", process_group_name=None), ["x"])
+        self.assertEqual(sync_object("x", process_group_name=None), "x")
+        with sync_seed(process_group_name=None):
+            pass
 
 
 if __name__ == "__main__":

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -127,6 +127,11 @@ _cute_two_matmuls_force_persistent_kernel = helion.kernel(
     backend="cute",
     autotune_force_persistent=True,
 )
+_cute_two_matmuls_distributed_kernel = helion.kernel(
+    _cute_two_matmuls_impl,
+    backend="cute",
+    distributed=True,
+)
 
 
 @helion.kernel(backend="cute")
@@ -1727,7 +1732,7 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             ),
             patch("helion._dist_utils.max_num_blocks_for_symm_mem", return_value=10000),
         ):
-            bound = _cute_two_matmuls_kernel.bind(args)
+            bound = _cute_two_matmuls_distributed_kernel.bind(args)
         self.assertFalse(bound.config_spec.cute_tcgen05_search_enabled)
 
     def test_narrow_tcgen05_autotune_to_validated_configs_helper(self) -> None:


### PR DESCRIPTION
Helion decided a kernel was "distributed" from the process-global torch.distributed.is_initialized(). Inside vLLM (dist initialized, even at TP=1) this made every ordinary kernel inherit distributed behavior: ProcessGroupNameNotFound log spam, an un-suppressible max_num_sm_multiplier warning, and a needlessly narrowed autotuning search space (flat/xyz pid types disallowed).

This gates that behavior per-kernel: is_distributed = kernel_uses_symm_mem(args) or (dist.is_initialized() and (settings.distributed or <hl.ProcessGroupName annotation>)). Symmetric memory is only used by distributed kernels, so its presence is a reliable signal; the explicit distributed=True setting and the annotation are escape hatches. The autotuner's cross-rank helpers now no-op when there's no process group, so non-distributed autotuning no longer crashes.

Verified with vLLM (--linear-backend helion, Qwen3-1.7B-FP8): ProcessGroupNameNotFound 28→0, max_num_sm warning 2→0, same 28 kernels compiled, clean startup.

Fixes: https://github.com/pytorch/helion/issues/3024