### PR TITLE
[pallas] ordered carry: allow dynamic number of columns

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -217,7 +217,7 @@ class ScratchArg:
     """
 
     name: str
-    shape: tuple[int, ...]
+    shape: tuple[int | torch.SymInt, ...]
     dtype: torch.dtype | None  # None for semaphores
     scratch_type: str = "vmem"  # "vmem" or "dma_semaphore"
 
@@ -1120,7 +1120,7 @@ class DeviceFunction:
 
     def register_scratch(
         self,
-        shape: tuple[int, ...],
+        shape: tuple[int | torch.SymInt, ...],
         dtype: torch.dtype | None,
         name_hint: str = "scratch",
         scratch_type: str = "vmem",

--- a/helion/_compiler/host_function.py
+++ b/helion/_compiler/host_function.py
@@ -283,7 +283,11 @@ class HostFunction:
         if isinstance(expr, list):
             return "[" + ", ".join(self.literal_expr(x) for x in expr) + "]"
         if isinstance(expr, tuple):
-            return "(" + ", ".join(self.literal_expr(x) for x in expr) + ", )"
+            if not expr:
+                return "()"
+            if len(expr) == 1:
+                return f"({self.literal_expr(expr[0])},)"
+            return "(" + ", ".join(self.literal_expr(x) for x in expr) + ")"
         return repr(expr)
 
     def debug_str(self) -> str:

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1090,7 +1090,10 @@ class PallasBackend(Backend):
             for s in device_fn._scratch_args
         ]
         if scratch_shapes:
-            launcher_args.append(f"_scratch_shapes={scratch_shapes!r}")
+            from ..host_function import HostFunction
+
+            scratch_shapes_str = HostFunction.current().literal_expr(scratch_shapes)
+            launcher_args.append(f"_scratch_shapes={scratch_shapes_str}")
 
         # Identify which launcher arg positions correspond to pipeline-body
         # tensors (need HBM refs); all others get proper BlockSpecs.

--- a/helion/_compiler/pallas/ordered_carry.py
+++ b/helion/_compiler/pallas/ordered_carry.py
@@ -142,7 +142,7 @@ class CarryStorePlan(NamedTuple):
     sublane: int
     block_row: int
     block_col: int
-    n_cols: int
+    n_cols: int | torch.SymInt
 
 
 def _carry_store_plan(
@@ -188,14 +188,10 @@ def _carry_store_plan(
     block_row = fn.resolved_block_size(row_block_id)
     block_col = fn.resolved_block_size(col_block_id)
     n_cols = tensor.size(1)
-    if not (
-        isinstance(block_row, int)
-        and isinstance(block_col, int)
-        and isinstance(n_cols, int)
-    ):
+    if not (isinstance(block_row, int) and isinstance(block_col, int)):
         raise NotImplementedError(
-            "Pallas ordered carry needs static block/column sizes "
-            f"(block_row={block_row!r}, block_col={block_col!r}, cols={n_cols!r})."
+            "Pallas ordered carry needs static block sizes "
+            f"(block_row={block_row!r}, block_col={block_col!r})."
         )
     if block_row % S != 0:
         raise NotImplementedError(

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -311,14 +311,15 @@ class TestPallasJaggedCarryBmm(TestCase):
         torch.testing.assert_close(out, jagged * 2)
 
     @xfailIfPallasInterpret(_XFAIL_INTERPRET)
-    def test_dynamic_rows_specialized_cols(self) -> None:
-        # static_shapes=False: the carry compiles once; grid is the runtime group count.
+    @parametrize("dynamic_cols", [True, False])
+    def test_dynamic_rows(self, dynamic_cols: bool) -> None:
         @helion.kernel(backend="pallas", static_shapes=False)
         def jagged_scale_dyn(
-            seq_offsets: torch.Tensor, jagged: torch.Tensor
+            seq_offsets: torch.Tensor, jagged: torch.Tensor, dynamic_cols: hl.constexpr
         ) -> torch.Tensor:
             L, D = jagged.shape
-            D = hl.specialize(D)
+            if not dynamic_cols:
+                D = hl.specialize(D)
             B = seq_offsets.shape[0] - 1
             out = torch.empty((L, D), dtype=jagged.dtype, device=jagged.device)
             for g in hl.grid(B):
@@ -333,7 +334,7 @@ class TestPallasJaggedCarryBmm(TestCase):
         jagged = torch.randn((25, 128), dtype=torch.bfloat16, device=DEVICE)
         code, out = code_and_output(
             jagged_scale_dyn,
-            (seq_offsets, jagged),
+            (seq_offsets, jagged, dynamic_cols),
             block_sizes=[16, 128],
             pallas_loop_type="emit_pipeline",
         )


### PR DESCRIPTION
Stacked PRs:
 * #3077
 * __->__#3076


--- --- ---

### [pallas] ordered carry: allow dynamic number of columns


There is no fundamental reason why n_cols should be static. Relax
this restriction by allowing scratch_shapes to be an expression,
not just a literal.
