### PR TITLE
Skip cute-backend-unsupported constexpr and linear-attention tests

### DIFF
--- a/test/test_constexpr.py
+++ b/test/test_constexpr.py
@@ -14,6 +14,7 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfCute
 from helion._testing import skipIfMTIA
 from helion._testing import skipIfRefEager
 import helion.language as hl
@@ -272,6 +273,7 @@ class TestConstExpr(RefEagerTestBase, TestCase):
 
     @skipIfRefEager("compile_config not supported in ref eager mode")
     @skipIfMTIA("Not supported on MTIA. PE failure crashes on DMA_IN")
+    @skipIfCute("cute backend does not support ConstExpr launcher scalar arguments")
     def test_block_size_constexpr_branch_selects_per_config(self):
         """A branch whose condition depends on a block size must pick the branch
         per-config, not freeze one branch during the single frontend pass
@@ -298,6 +300,7 @@ class TestConstExpr(RefEagerTestBase, TestCase):
             torch.testing.assert_close(result, expected)
 
     @skipIfMTIA("Not supported on MTIA. PE failure crashes on DMA_IN")
+    @skipIfCute("cute backend does not support mixed tcgen05 matmul collective plans")
     def test_block_size_constexpr_branch_divergent_shapes(self):
         """Branches selected by a block-size constexpr may use variables with
         different shapes -- e.g. a swap-AB GEMM that transposes its accumulator

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -28,6 +28,7 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfA10G
 from helion._testing import skipIfCudaCapabilityLessThan
 from helion._testing import skipIfCudaSharedMemoryLessThan
+from helion._testing import skipIfCute
 from helion._testing import skipIfFn
 from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfPallas
@@ -2820,48 +2821,56 @@ class TestExamples(RefEagerTestBase, TestCase):
     @pytest.mark.timeout(600)
     @skipIfRefEager("linear examples assert against their own reference")
     @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
     def test_linear_simple_gla(self):
         self._run_linear_example("example_simple_gla")
 
     @pytest.mark.timeout(600)
     @skipIfRefEager("linear examples assert against their own reference")
     @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
     def test_linear_full_gla(self):
         self._run_linear_example("example_full_gla")
 
     @pytest.mark.timeout(600)
     @skipIfRefEager("linear examples assert against their own reference")
     @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
     def test_linear_vanilla_linear_attn(self):
         self._run_linear_example("example_vanilla_linear_attn")
 
     @pytest.mark.timeout(600)
     @skipIfRefEager("linear examples assert against their own reference")
     @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
     def test_linear_retention(self):
         self._run_linear_example("example_retention")
 
     @pytest.mark.timeout(600)
     @skipIfRefEager("linear examples assert against their own reference")
     @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
     def test_linear_mamba2_ssd(self):
         self._run_linear_example("example_mamba2_ssd")
 
     @pytest.mark.timeout(600)
     @skipIfRefEager("linear examples assert against their own reference")
     @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
     def test_linear_delta_rule(self):
         self._run_linear_example("example_delta_rule")
 
     @pytest.mark.timeout(600)
     @skipIfRefEager("linear examples assert against their own reference")
     @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
     def test_linear_gated_delta_rule(self):
         self._run_linear_example("example_gated_delta_rule")
 
     @pytest.mark.timeout(600)
     @skipIfRefEager("linear examples assert against their own reference")
     @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
     def test_linear_kda(self):
         self._run_linear_example("example_kda")
 


### PR DESCRIPTION
## What

The `test-cu130-py3.12-pytorch-nightly-cute-b200` CI job fails on **10 pre-existing tests** that are present on `main` (independent of any PR — e.g. surfaced by the run for #3074, which only adds a CI workflow):

| Test | cute failure |
|---|---|
| `test_constexpr::test_block_size_constexpr_branch_selects_per_config` | BackendUnsupported: ConstExpr launcher scalar argument |
| `test_constexpr::test_block_size_constexpr_branch_divergent_shapes` | BackendUnsupported: mixed tcgen05 matmul collective plans |
| `test_examples::test_linear_delta_rule` | BackendUnsupported: direct mm w/o active K tile |
| `test_examples::test_linear_gated_delta_rule` | BackendUnsupported: direct mm w/o active K tile |
| `test_examples::test_linear_kda` | BackendUnsupported: direct mm w/o active K tile |
| `test_examples::test_linear_mamba2_ssd` | pointer must be 16 bytes aligned |
| `test_examples::test_linear_retention` | pointer must be 16 bytes aligned |
| `test_examples::test_linear_simple_gla` | pointer must be 16 bytes aligned |
| `test_examples::test_linear_full_gla` | forward error (numerical) |
| `test_examples::test_linear_vanilla_linear_attn` | forward error (numerical) |

## Change

All ten are genuine cute-backend limitations, so skip them on the cute backend via `@skipIfCute`. Other backends (triton, etc.) still run them.

Failing run: https://github.com/pytorch/helion/actions/runs/29518300097/job/87688951459