### PR TITLE
[triton] improve nvfp4_gemv for bf16in

### DIFF
--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -525,6 +525,103 @@ def _fp4_storage(tensor: Tensor) -> Tensor:
     return tensor
 
 
+def _e4m3_byte_to_f32(scale_byte: Tensor) -> Tensor:
+    """Decode one E4M3 scale byte to fp32 (Triton inline PTX)."""
+    return hl.inline_asm_elementwise(
+        """
+        {
+          .reg .b16 sc, scale_lo, scale_hi;
+          .reg .b32 scale_h2;
+          mov.b32 {sc, _}, $1;
+          cvt.rn.f16x2.e4m3x2 scale_h2, sc;
+          mov.b32 {scale_lo, scale_hi}, scale_h2;
+          cvt.f32.f16 $0, scale_lo;
+        }
+        """,
+        "=f,r",
+        [scale_byte],
+        dtype=torch.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+def _fp4_qword_to_f16x16(qword: Tensor) -> tuple[Tensor, ...]:
+    """Decode one int64 (16 packed E2M1 fp4 = 1 scale group) into 16 fp16 lanes."""
+    outs = ",".join("=h" for _ in range(16))
+    return hl.inline_asm_elementwise(
+        """
+        {
+          .reg .b32 lo, hi;
+          .reg .b8 c0,c1,c2,c3,c4,c5,c6,c7;
+          .reg .b32 h0,h1,h2,h3,h4,h5,h6,h7;
+          mov.b64 {lo, hi}, $16;
+          mov.b32 {c0,c1,c2,c3}, lo;
+          cvt.rn.f16x2.e2m1x2 h0, c0; cvt.rn.f16x2.e2m1x2 h1, c1;
+          cvt.rn.f16x2.e2m1x2 h2, c2; cvt.rn.f16x2.e2m1x2 h3, c3;
+          mov.b32 {c4,c5,c6,c7}, hi;
+          cvt.rn.f16x2.e2m1x2 h4, c4; cvt.rn.f16x2.e2m1x2 h5, c5;
+          cvt.rn.f16x2.e2m1x2 h6, c6; cvt.rn.f16x2.e2m1x2 h7, c7;
+          mov.b32 {$0,$1}, h0; mov.b32 {$2,$3}, h1;
+          mov.b32 {$4,$5}, h2; mov.b32 {$6,$7}, h3;
+          mov.b32 {$8,$9}, h4; mov.b32 {$10,$11}, h5;
+          mov.b32 {$12,$13}, h6; mov.b32 {$14,$15}, h7;
+        }
+        """,
+        f"{outs},l",
+        [qword],
+        dtype=(torch.float16,) * 16,
+        is_pure=True,
+        pack=1,
+    )
+
+
+def _nvfp4_gemv_bf16in_triton_body(
+    weight_i64: Tensor,  # (M, K_groups) int64 packed NVFP4 weight
+    x_values: Tensor,  # (K_groups, 16) bf16 activation
+    weight_scale_bytes: Tensor,  # int8 view of SWIZZLE_32_4_4 E4M3 scales
+    out: Tensor,  # (M,) bf16 output
+    alpha: float = 1.0,
+) -> Tensor:
+    """W4A16 NVFP4 GEMV, Triton backend (fp16 decode, fp32 scale).
+
+    Two coalescing wins make this genuine Helion->Triton output competitive with
+    the hand-PTX CuTe kernel above (faster on the wider-N shapes) -- ncu showed a
+    naive decode is not DRAM-bound but stalls on uncoalesced loads:
+
+    * Weight: each 16-value group is one contiguous int64 (8 bytes), loaded
+      unit-stride and decoded with ``_fp4_qword_to_f16x16``. (Reading it as two
+      int32 words would make each load stride-2, halving coalescing.)
+    * Activation: load a group's 16 bf16 as one contiguous ``(block_g, 16)`` tile,
+      then peel each lane with a masked sum (the DSL cannot subscript a loaded
+      tile as ``xt[:, j]``) -- the contiguous load is what coalesces.
+
+    The per-group E4M3 scale stays a swizzled gather: SWIZZLE_32_4_4's max
+    contiguous run is 4 bytes, so it cannot be coalesced for M-tiled access.
+    """
+    M, K_groups = weight_i64.shape
+    block_m = hl.register_block_size(1, 16)
+    block_g = hl.register_block_size(K_groups)
+    f16 = torch.float16
+    for tile_m in hl.tile(M, block_size=block_m):
+        acc = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_g in hl.tile(K_groups, block_size=block_g):
+            w = _fp4_qword_to_f16x16(weight_i64[tile_m, tile_g])  # 16 fp16 lanes
+            xt = x_values[tile_g, :].to(f16)  # (block_g, 16) contiguous coalesced
+            lane = hl.arange(16)[None, :]
+            contrib = hl.zeros([block_m, block_g], dtype=f16)
+            for i in hl.static_range(16):
+                xi = torch.where(lane == i, xt, 0.0).sum(-1)[None, :]
+                contrib = contrib + w[i] * xi
+            scale_offsets = swizzled_scale_offsets(
+                tile_m.index[:, None], tile_g.index[None, :], K_groups
+            )
+            scale = _e4m3_byte_to_f32(weight_scale_bytes[scale_offsets])
+            acc = acc + (contrib.to(torch.float32) * scale).sum(-1)
+        out[tile_m] = (acc * alpha).to(torch.bfloat16)
+    return out
+
+
 def _nvfp4_gemv_bf16in_body(
     weight_fp4x2: Tensor,
     x_values: Tensor,
@@ -614,14 +711,14 @@ def _nvfp4_gemv_fp4in_body(
     return out
 
 
-# Share the DSL bodies across backends; each backend keeps its tuned config.
-BF16IN_TRITON_CONFIG = helion.Config(block_sizes=[1, 512], num_warps=1, num_stages=2)
+# Triton W4A16 uses the coalesced-load ``_nvfp4_gemv_bf16in_triton_body``; block_m=16
+# (activation reuse across 16 rows) + inner K tile block_g=128. The cute backend
+# uses the hand-PTX fast path (``_fast_nvfp4_gemv_bf16in_kernel``), falling back to
+# the portable f32-decode ``_nvfp4_gemv_bf16in_body`` for shapes the fast path does
+# not cover (``BF16IN_CONFIG``). fp4in still shares one DSL body across backends.
+BF16IN_TRITON_CONFIG = helion.Config(block_sizes=[16, 128], num_warps=4, num_stages=3)
 FP4IN_TRITON_CONFIG = helion.Config(block_sizes=[1, 128], num_warps=4, num_stages=3)
 
-BF16IN_CONFIGS: dict[BackendName, helion.Config] = {
-    "triton": BF16IN_TRITON_CONFIG,
-    "cute": BF16IN_CONFIG,
-}
 FP4IN_CONFIGS: dict[BackendName, helion.Config] = {
     "triton": FP4IN_TRITON_CONFIG,
     "cute": FP4IN_CONFIG,
@@ -638,12 +735,25 @@ def _selected_backend(backend: BackendName | None) -> BackendName:
 
 
 @functools.cache
-def _nvfp4_gemv_bf16in_kernel(backend: BackendName) -> helion.Kernel[Tensor]:
+def _nvfp4_gemv_bf16in_triton_kernel() -> helion.Kernel[Tensor]:
+    """Coalesced-load W4A16 GEMV, Triton backend (the triton path)."""
+    return helion.kernel(
+        _nvfp4_gemv_bf16in_triton_body,
+        static_shapes=True,
+        config=BF16IN_TRITON_CONFIG,
+        backend="triton",
+    )
+
+
+@functools.cache
+def _nvfp4_gemv_bf16in_cute_fallback_kernel() -> helion.Kernel[Tensor]:
+    """Portable f32-decode W4A16 GEMV: cute fallback for shapes the hand-PTX fast
+    path can't cover (the triton path uses ``_nvfp4_gemv_bf16in_triton_body``)."""
     return helion.kernel(
         _nvfp4_gemv_bf16in_body,
         static_shapes=True,
-        config=BF16IN_CONFIGS[backend],
-        backend=backend,
+        config=BF16IN_CONFIG,
+        backend="cute",
     )
 
 
@@ -697,9 +807,23 @@ def nvfp4_gemv_bf16in(
             block=(128, 1, 1),
         )
         return out
-    return _nvfp4_gemv_bf16in_kernel(backend)(
-        weight_fp4x2.view(weight_bytes.shape[0], weight_bytes.shape[1] // 8, 8),
-        x_bf16.view(weight_bytes.shape[1] // 8, 16),
+    n_rows, k_bytes = weight_bytes.shape
+    groups = k_bytes // 8
+    if backend == "triton":
+        # Coalesced-load Triton kernel: weight as one int64 per group, activation
+        # as contiguous (groups, 16) bf16, scales as the raw SWIZZLE_32_4_4 bytes.
+        return _nvfp4_gemv_bf16in_triton_kernel()(
+            weight_bytes.view(torch.int64).view(n_rows, groups),
+            x_bf16.view(groups, 16),
+            weight_scale.reshape(-1).view(torch.int8),
+            out,
+            alpha,
+        )
+    # cute fallback (shapes the hand-PTX fast path does not cover): the portable
+    # f32-decode DSL body.
+    return _nvfp4_gemv_bf16in_cute_fallback_kernel()(
+        weight_fp4x2.view(n_rows, groups, 8),
+        x_bf16.view(groups, 16),
         weight_scale.reshape(-1),
         out,
         alpha,

--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -185,18 +185,15 @@ def _nvfp4_gemv_bf16in_triton_body(
 ) -> Tensor:
     """W4A16 NVFP4 GEMV, Triton backend (fp16 decode, fp32 scale).
 
-    Two coalescing wins make this genuine Helion->Triton output competitive:
-    ncu showed a naive decode is not DRAM-bound but stalls on uncoalesced loads:
+    Loads are arranged to improve memory coalescing:
 
-    * Weight: each 16-value group is one contiguous 8-byte chunk, loaded as one
-      64-bit word by ``hl.load_float4_e2m1fn_x16_to_float16``. (Reading it as
-      two int32 words would make each load stride-2, halving coalescing.)
-    * Activation: load a group's 16 bf16 as one contiguous ``(block_g, 16)`` tile,
-      then peel each lane with a masked sum (the DSL cannot subscript a loaded
-      tile as ``xt[:, j]``) -- the contiguous load is what coalesces.
+    * Weight: each 16-value group is loaded as one contiguous 64-bit word by
+      ``hl.load_float4_e2m1fn_x16_to_float16``.
+    * Activation: each group of 16 bf16 values is loaded as a contiguous
+      ``(block_g, 16)`` tile before selecting individual lanes.
 
-    The per-group E4M3 scale stays a swizzled gather: SWIZZLE_32_4_4's max
-    contiguous run is 4 bytes, so it cannot be coalesced for M-tiled access.
+    The per-group E4M3 scale remains a swizzled gather because SWIZZLE_32_4_4
+    provides at most four contiguous scale bytes for this access pattern.
     """
     M = hl.specialize(weight_bytes.size(0))
     K_bytes = hl.specialize(weight_bytes.size(1))
@@ -371,9 +368,7 @@ def _nvfp4_gemv_fp4in_triton_body(
 
 
 # Triton W4A16 uses the coalesced-load body with block_m=16 and block_g=128.
-# Triton W4A4 uses the autotuned pretuned config from nvfp4_gemv. The CuTe
-# backend remains a Helion DSL fallback for coverage rather than a hand-written
-# CuTe fast path.
+# Triton W4A4 uses the autotuned pretuned config from nvfp4_gemv.
 BF16IN_TRITON_CONFIG = helion.Config(block_sizes=[16, 128], num_warps=4, num_stages=3)
 FP4IN_TRITON_CONFIG = helion.Config(
     block_sizes=[4, 256],

--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import functools
 from typing import TYPE_CHECKING
-from typing import Any
 from typing import Literal
 from typing import cast
 
@@ -28,44 +27,14 @@ import helion
 from helion._testing import DEVICE
 from helion._testing import run_example
 import helion.language as hl
-from helion.runtime import default_cute_launcher
 from helion.runtime.settings import _get_backend
-
-cutlass: Any
-cute: Any
-dsl_user_op: Any
-
-if _get_backend() == "cute":
-    try:
-        import cutlass
-        from cutlass import Int32
-        from cutlass._mlir.dialects import llvm
-        import cutlass.cute as cute
-        from cutlass.cute.arch.nvvm_wrappers import _normalize_ptr
-        from cutlass.cute.typing import Float32
-        from cutlass.cute.typing import Pointer as CutePointer
-        from cutlass.cute.typing import Tensor as CuteTensor
-        from cutlass.cutlass_dsl import T
-        from cutlass.cutlass_dsl import dsl_user_op
-    except ModuleNotFoundError as e:
-        if e.name is None or not e.name.startswith("cutlass"):
-            raise
-        cutlass = cast("Any", None)
-        cute = cast("Any", None)
-        dsl_user_op = cast("Any", None)
-else:
-    cutlass = cast("Any", None)
-    cute = cast("Any", None)
-    dsl_user_op = cast("Any", None)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from cutlass._mlir import ir
-
 BackendName = Literal["triton", "cute"]
 
-BF16IN_CONFIG = helion.Config(
+BF16IN_CUTE_CONFIG = helion.Config(
     block_sizes=[1, 128],
     indexing=["pointer"] * 8,
     load_eviction_policies=["first", "last", "last", "last", "last", "first"],
@@ -76,7 +45,7 @@ BF16IN_CONFIG = helion.Config(
     range_warp_specializes=[None],
 )
 
-FP4IN_CONFIG = helion.Config(
+FP4IN_CUTE_CONFIG = helion.Config(
     block_sizes=[1, 128],
     indexing=["pointer"] * 5,
     load_eviction_policies=["first", "last", "", "last"],
@@ -153,362 +122,23 @@ def _check_swizzled_scales(
         )
 
 
-if cute is not None and dsl_user_op is not None:
+def _check_contiguous(name: str, tensor: Tensor) -> None:
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
 
-    def _fast_swizzled_scale_offset(
-        row: Int32,
-        col: Int32,
-        scale_cols: int,
-    ) -> Int32:
-        num_col_tiles = (scale_cols + 3) // 4
-        tile = (row >> Int32(7)) * Int32(num_col_tiles) + (col >> Int32(2))
-        return (
-            tile * Int32(512)
-            + (row & Int32(31)) * Int32(16)
-            + ((row >> Int32(5)) & Int32(3)) * Int32(4)
-            + (col & Int32(3))
+
+def _check_fp4_weight_storage(name: str, storage: Tensor) -> None:
+    if storage.dim() != 2:
+        raise ValueError(f"{name} must be a 2D packed FP4 tensor")
+    if storage.shape[1] % 8 != 0:
+        raise ValueError(
+            f"{name} K bytes must be divisible by 8; got {storage.shape[1]}"
         )
 
-    @dsl_user_op
-    def _fast_bf16_16bytes_dual_ptr(
-        acc: Float32,
-        weight_ptr: CutePointer,
-        x_ptr: CutePointer,
-        scale_ptr: CutePointer,
-        *,
-        loc: ir.Location | None = None,
-        ip: ir.InsertionPoint | None = None,
-    ) -> Float32:
-        acc_ir = Float32(acc).ir_value(loc=loc, ip=ip)
-        weight_ir = _normalize_ptr(weight_ptr, loc=loc, ip=ip)
-        x_ir = _normalize_ptr(x_ptr, loc=loc, ip=ip)
-        scale_ir = _normalize_ptr(scale_ptr, loc=loc, ip=ip)
-        result = llvm.inline_asm(
-            T.f32(),
-            [acc_ir, weight_ir, x_ir, scale_ir],
-            """
-            {
-              .reg .b8 wb0, wb1, wb2, wb3, wb4, wb5, wb6, wb7;
-              .reg .b16 scales, sf0, sf1, b0, b1, h0, h1, lo, hi, sumh;
-              .reg .b32 wr0, wr1, wr2, wr3;
-              .reg .b32 xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7;
-              .reg .b32 yr0, yr1, yr2, yr3, yr4, yr5, yr6, yr7;
-              .reg .b32 w0, w1, w2, w3, w4, w5, w6, w7;
-              .reg .b32 z0, z1, z2, z3, z4, z5, z6, z7;
-              .reg .b32 x0, x1, x2, x3, x4, x5, x6, x7;
-              .reg .b32 y0, y1, y2, y3, y4, y5, y6, y7;
-              .reg .b32 prod0, prod1, sf2;
-              mov.f32 $0, $1;
-              ld.global.L1::no_allocate.v4.u32 {wr0, wr1, wr2, wr3}, [$2];
-              ld.global.L1::evict_last.L2::evict_last.v8.u32
-                {xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7}, [$3];
-              ld.global.L1::evict_last.L2::evict_last.v8.u32
-                {yr0, yr1, yr2, yr3, yr4, yr5, yr6, yr7}, [$3+32];
-              ld.global.L1::no_allocate.u16 scales, [$4];
-              cvt.rn.f16x2.e4m3x2 sf2, scales;
-              mov.b32 {sf0, sf1}, sf2;
-              mov.b32 {wb0, wb1, wb2, wb3}, wr0;
-              cvt.rn.f16x2.e2m1x2 w0, wb0; cvt.rn.f16x2.e2m1x2 w1, wb1;
-              cvt.rn.f16x2.e2m1x2 w2, wb2; cvt.rn.f16x2.e2m1x2 w3, wb3;
-              mov.b32 {wb4, wb5, wb6, wb7}, wr1;
-              cvt.rn.f16x2.e2m1x2 w4, wb4; cvt.rn.f16x2.e2m1x2 w5, wb5;
-              cvt.rn.f16x2.e2m1x2 w6, wb6; cvt.rn.f16x2.e2m1x2 w7, wb7;
-              mov.b32 {wb0, wb1, wb2, wb3}, wr2;
-              cvt.rn.f16x2.e2m1x2 z0, wb0; cvt.rn.f16x2.e2m1x2 z1, wb1;
-              cvt.rn.f16x2.e2m1x2 z2, wb2; cvt.rn.f16x2.e2m1x2 z3, wb3;
-              mov.b32 {wb4, wb5, wb6, wb7}, wr3;
-              cvt.rn.f16x2.e2m1x2 z4, wb4; cvt.rn.f16x2.e2m1x2 z5, wb5;
-              cvt.rn.f16x2.e2m1x2 z6, wb6; cvt.rn.f16x2.e2m1x2 z7, wb7;
-              mov.b32 {b0, b1}, xr0; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x0, {h0, h1};
-              mov.b32 {b0, b1}, xr1; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x1, {h0, h1};
-              mov.b32 {b0, b1}, xr2; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x2, {h0, h1};
-              mov.b32 {b0, b1}, xr3; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x3, {h0, h1};
-              mov.b32 {b0, b1}, xr4; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x4, {h0, h1};
-              mov.b32 {b0, b1}, xr5; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x5, {h0, h1};
-              mov.b32 {b0, b1}, xr6; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x6, {h0, h1};
-              mov.b32 {b0, b1}, xr7; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x7, {h0, h1};
-              mov.b32 {b0, b1}, yr0; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y0, {h0, h1};
-              mov.b32 {b0, b1}, yr1; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y1, {h0, h1};
-              mov.b32 {b0, b1}, yr2; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y2, {h0, h1};
-              mov.b32 {b0, b1}, yr3; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y3, {h0, h1};
-              mov.b32 {b0, b1}, yr4; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y4, {h0, h1};
-              mov.b32 {b0, b1}, yr5; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y5, {h0, h1};
-              mov.b32 {b0, b1}, yr6; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y6, {h0, h1};
-              mov.b32 {b0, b1}, yr7; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y7, {h0, h1};
-              mul.rn.f16x2 prod0, w0, x0;   mul.rn.f16x2 prod1, z0, y0;
-              fma.rn.f16x2 prod0, w1, x1, prod0;   fma.rn.f16x2 prod1, z1, y1, prod1;
-              fma.rn.f16x2 prod0, w2, x2, prod0;   fma.rn.f16x2 prod1, z2, y2, prod1;
-              fma.rn.f16x2 prod0, w3, x3, prod0;   fma.rn.f16x2 prod1, z3, y3, prod1;
-              fma.rn.f16x2 prod0, w4, x4, prod0;   fma.rn.f16x2 prod1, z4, y4, prod1;
-              fma.rn.f16x2 prod0, w5, x5, prod0;   fma.rn.f16x2 prod1, z5, y5, prod1;
-              fma.rn.f16x2 prod0, w6, x6, prod0;   fma.rn.f16x2 prod1, z6, y6, prod1;
-              fma.rn.f16x2 prod0, w7, x7, prod0;   fma.rn.f16x2 prod1, z7, y7, prod1;
-              mov.b32 {lo, hi}, prod0; add.rn.f16 sumh, lo, hi;
-              fma.rn.f32.f16 $0, sumh, sf0, $0;
-              mov.b32 {lo, hi}, prod1; add.rn.f16 sumh, lo, hi;
-              fma.rn.f32.f16 $0, sumh, sf1, $0;
-            }
-            """,
-            "=f,f,l,l,l",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-        return Float32(result)
 
-    @dsl_user_op
-    def _fast_fp4_32bytes_ptr(
-        acc: Float32,
-        weight_ptr: CutePointer,
-        x_ptr: CutePointer,
-        w_scale_ptr: CutePointer,
-        x_scale_ptr: CutePointer,
-        *,
-        loc: ir.Location | None = None,
-        ip: ir.InsertionPoint | None = None,
-    ) -> Float32:
-        acc_ir = Float32(acc).ir_value(loc=loc, ip=ip)
-        weight_ir = _normalize_ptr(weight_ptr, loc=loc, ip=ip)
-        x_ir = _normalize_ptr(x_ptr, loc=loc, ip=ip)
-        w_scale_ir = _normalize_ptr(w_scale_ptr, loc=loc, ip=ip)
-        x_scale_ir = _normalize_ptr(x_scale_ptr, loc=loc, ip=ip)
-        result = llvm.inline_asm(
-            T.f32(),
-            [acc_ir, weight_ir, x_ir, w_scale_ir, x_scale_ir],
-            """
-            {
-              .reg .b8 b0, b1, b2, b3, b4, b5, b6, b7;
-              .reg .b16 wsc0, wsc1, xsc0, xsc1, sf0, sf1, lo, hi, sumh;
-              .reg .b32 wr0, wr1, wr2, wr3, wr4, wr5, wr6, wr7;
-              .reg .b32 xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7;
-              .reg .b32 w0, w1, w2, w3, w4, w5, w6, w7;
-              .reg .b32 x0, x1, x2, x3, x4, x5, x6, x7;
-              .reg .b32 prod, wsf2, xsf2, sf2;
-              mov.f32 $0, $1;
-              ld.global.L1::no_allocate.L2::evict_first.v8.b32
-                {wr0, wr1, wr2, wr3, wr4, wr5, wr6, wr7}, [$2];
-              ld.global.L1::evict_last.L2::evict_last.v8.b32
-                {xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7}, [$3];
-              ld.global.L1::no_allocate.v2.b16 {wsc0, wsc1}, [$4];
-              ld.global.L1::evict_last.v2.b16 {xsc0, xsc1}, [$5];
-              cvt.rn.f16x2.e4m3x2 wsf2, wsc0;
-              cvt.rn.f16x2.e4m3x2 xsf2, xsc0;
-              mul.rn.f16x2 sf2, wsf2, xsf2;
-              mov.b32 {sf0, sf1}, sf2;
-              mov.b32 {b0, b1, b2, b3}, wr0;
-              mov.b32 {b4, b5, b6, b7}, wr1;
-              cvt.rn.f16x2.e2m1x2 w0, b0; cvt.rn.f16x2.e2m1x2 w1, b1;
-              cvt.rn.f16x2.e2m1x2 w2, b2; cvt.rn.f16x2.e2m1x2 w3, b3;
-              cvt.rn.f16x2.e2m1x2 w4, b4; cvt.rn.f16x2.e2m1x2 w5, b5;
-              cvt.rn.f16x2.e2m1x2 w6, b6; cvt.rn.f16x2.e2m1x2 w7, b7;
-              mov.b32 {b0, b1, b2, b3}, xr0;
-              mov.b32 {b4, b5, b6, b7}, xr1;
-              cvt.rn.f16x2.e2m1x2 x0, b0; cvt.rn.f16x2.e2m1x2 x1, b1;
-              cvt.rn.f16x2.e2m1x2 x2, b2; cvt.rn.f16x2.e2m1x2 x3, b3;
-              cvt.rn.f16x2.e2m1x2 x4, b4; cvt.rn.f16x2.e2m1x2 x5, b5;
-              cvt.rn.f16x2.e2m1x2 x6, b6; cvt.rn.f16x2.e2m1x2 x7, b7;
-              mul.rn.f16x2 prod, w0, x0; fma.rn.f16x2 prod, w1, x1, prod;
-              fma.rn.f16x2 prod, w2, x2, prod; fma.rn.f16x2 prod, w3, x3, prod;
-              fma.rn.f16x2 prod, w4, x4, prod; fma.rn.f16x2 prod, w5, x5, prod;
-              fma.rn.f16x2 prod, w6, x6, prod; fma.rn.f16x2 prod, w7, x7, prod;
-              mov.b32 {lo, hi}, prod; add.rn.f16 sumh, lo, hi;
-              fma.rn.f32.f16 $0, sumh, sf0, $0;
-              mov.b32 {b0, b1, b2, b3}, wr2;
-              mov.b32 {b4, b5, b6, b7}, wr3;
-              cvt.rn.f16x2.e2m1x2 w0, b0; cvt.rn.f16x2.e2m1x2 w1, b1;
-              cvt.rn.f16x2.e2m1x2 w2, b2; cvt.rn.f16x2.e2m1x2 w3, b3;
-              cvt.rn.f16x2.e2m1x2 w4, b4; cvt.rn.f16x2.e2m1x2 w5, b5;
-              cvt.rn.f16x2.e2m1x2 w6, b6; cvt.rn.f16x2.e2m1x2 w7, b7;
-              mov.b32 {b0, b1, b2, b3}, xr2;
-              mov.b32 {b4, b5, b6, b7}, xr3;
-              cvt.rn.f16x2.e2m1x2 x0, b0; cvt.rn.f16x2.e2m1x2 x1, b1;
-              cvt.rn.f16x2.e2m1x2 x2, b2; cvt.rn.f16x2.e2m1x2 x3, b3;
-              cvt.rn.f16x2.e2m1x2 x4, b4; cvt.rn.f16x2.e2m1x2 x5, b5;
-              cvt.rn.f16x2.e2m1x2 x6, b6; cvt.rn.f16x2.e2m1x2 x7, b7;
-              mul.rn.f16x2 prod, w0, x0; fma.rn.f16x2 prod, w1, x1, prod;
-              fma.rn.f16x2 prod, w2, x2, prod; fma.rn.f16x2 prod, w3, x3, prod;
-              fma.rn.f16x2 prod, w4, x4, prod; fma.rn.f16x2 prod, w5, x5, prod;
-              fma.rn.f16x2 prod, w6, x6, prod; fma.rn.f16x2 prod, w7, x7, prod;
-              mov.b32 {lo, hi}, prod; add.rn.f16 sumh, lo, hi;
-              fma.rn.f32.f16 $0, sumh, sf1, $0;
-              cvt.rn.f16x2.e4m3x2 wsf2, wsc1;
-              cvt.rn.f16x2.e4m3x2 xsf2, xsc1;
-              mul.rn.f16x2 sf2, wsf2, xsf2;
-              mov.b32 {sf0, sf1}, sf2;
-              mov.b32 {b0, b1, b2, b3}, wr4;
-              mov.b32 {b4, b5, b6, b7}, wr5;
-              cvt.rn.f16x2.e2m1x2 w0, b0; cvt.rn.f16x2.e2m1x2 w1, b1;
-              cvt.rn.f16x2.e2m1x2 w2, b2; cvt.rn.f16x2.e2m1x2 w3, b3;
-              cvt.rn.f16x2.e2m1x2 w4, b4; cvt.rn.f16x2.e2m1x2 w5, b5;
-              cvt.rn.f16x2.e2m1x2 w6, b6; cvt.rn.f16x2.e2m1x2 w7, b7;
-              mov.b32 {b0, b1, b2, b3}, xr4;
-              mov.b32 {b4, b5, b6, b7}, xr5;
-              cvt.rn.f16x2.e2m1x2 x0, b0; cvt.rn.f16x2.e2m1x2 x1, b1;
-              cvt.rn.f16x2.e2m1x2 x2, b2; cvt.rn.f16x2.e2m1x2 x3, b3;
-              cvt.rn.f16x2.e2m1x2 x4, b4; cvt.rn.f16x2.e2m1x2 x5, b5;
-              cvt.rn.f16x2.e2m1x2 x6, b6; cvt.rn.f16x2.e2m1x2 x7, b7;
-              mul.rn.f16x2 prod, w0, x0; fma.rn.f16x2 prod, w1, x1, prod;
-              fma.rn.f16x2 prod, w2, x2, prod; fma.rn.f16x2 prod, w3, x3, prod;
-              fma.rn.f16x2 prod, w4, x4, prod; fma.rn.f16x2 prod, w5, x5, prod;
-              fma.rn.f16x2 prod, w6, x6, prod; fma.rn.f16x2 prod, w7, x7, prod;
-              mov.b32 {lo, hi}, prod; add.rn.f16 sumh, lo, hi;
-              fma.rn.f32.f16 $0, sumh, sf0, $0;
-              mov.b32 {b0, b1, b2, b3}, wr6;
-              mov.b32 {b4, b5, b6, b7}, wr7;
-              cvt.rn.f16x2.e2m1x2 w0, b0; cvt.rn.f16x2.e2m1x2 w1, b1;
-              cvt.rn.f16x2.e2m1x2 w2, b2; cvt.rn.f16x2.e2m1x2 w3, b3;
-              cvt.rn.f16x2.e2m1x2 w4, b4; cvt.rn.f16x2.e2m1x2 w5, b5;
-              cvt.rn.f16x2.e2m1x2 w6, b6; cvt.rn.f16x2.e2m1x2 w7, b7;
-              mov.b32 {b0, b1, b2, b3}, xr6;
-              mov.b32 {b4, b5, b6, b7}, xr7;
-              cvt.rn.f16x2.e2m1x2 x0, b0; cvt.rn.f16x2.e2m1x2 x1, b1;
-              cvt.rn.f16x2.e2m1x2 x2, b2; cvt.rn.f16x2.e2m1x2 x3, b3;
-              cvt.rn.f16x2.e2m1x2 x4, b4; cvt.rn.f16x2.e2m1x2 x5, b5;
-              cvt.rn.f16x2.e2m1x2 x6, b6; cvt.rn.f16x2.e2m1x2 x7, b7;
-              mul.rn.f16x2 prod, w0, x0; fma.rn.f16x2 prod, w1, x1, prod;
-              fma.rn.f16x2 prod, w2, x2, prod; fma.rn.f16x2 prod, w3, x3, prod;
-              fma.rn.f16x2 prod, w4, x4, prod; fma.rn.f16x2 prod, w5, x5, prod;
-              fma.rn.f16x2 prod, w6, x6, prod; fma.rn.f16x2 prod, w7, x7, prod;
-              mov.b32 {lo, hi}, prod; add.rn.f16 sumh, lo, hi;
-              fma.rn.f32.f16 $0, sumh, sf1, $0;
-            }
-            """,
-            "=f,f,l,l,l,l",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-        return Float32(result)
-
-    @cute.kernel
-    def _fast_nvfp4_gemv_bf16in_kernel(
-        weight: CuteTensor,
-        x: CuteTensor,
-        weight_scale: CuteTensor,
-        out: CuteTensor,
-        alpha: Float32,
-        k_bytes: cutlass.Constexpr[int],
-    ) -> None:
-        tid_x, _, _ = cute.arch.thread_idx()
-        row, _, _ = cute.arch.block_idx()
-        tid = Int32(tid_x)
-        smem = cute.arch.alloc_smem(Float32, 128, alignment=16)
-        partial = Float32(0.0)
-        k_bytes_i32 = Int32(k_bytes)  # pyrefly: ignore[bad-argument-type]
-        scale_cols = k_bytes // 8  # pyrefly: ignore[unsupported-operation]
-        weight_row_ptr = weight.iterator + row * k_bytes_i32
-        thread_k_base = tid * Int32(16)
-        thread_scale_base = tid * Int32(2)
-        num_iters = k_bytes // 2048  # pyrefly: ignore[unsupported-operation]
-        for iter_k in cutlass.range(num_iters, unroll_full=True):
-            k_tile_base = Int32(iter_k * 2048) + thread_k_base
-            scale_tile_base = Int32(iter_k * 256) + thread_scale_base
-            scale_offset = _fast_swizzled_scale_offset(
-                row,
-                scale_tile_base,
-                scale_cols,
-            )
-            partial = _fast_bf16_16bytes_dual_ptr(
-                partial,
-                weight_row_ptr + k_tile_base,
-                x.iterator + k_tile_base * Int32(2),
-                weight_scale.iterator + scale_offset,
-            )
-        cute.arch.store(smem + tid, partial)
-        cute.arch.sync_threads()
-        block_val = Float32(0.0)
-        if tid < Int32(64):
-            block_val = partial + cute.arch.load(smem + tid + Int32(64), Float32)
-            cute.arch.store(smem + tid, block_val)
-        cute.arch.sync_threads()
-        if tid < Int32(32):
-            block_val += cute.arch.load(smem + tid + Int32(32), Float32)
-            block_val += cute.arch.shuffle_sync_down(block_val, 16)
-            block_val += cute.arch.shuffle_sync_down(block_val, 8)
-            block_val += cute.arch.shuffle_sync_down(block_val, 4)
-            block_val += cute.arch.shuffle_sync_down(block_val, 2)
-            block_val += cute.arch.shuffle_sync_down(block_val, 1)
-        if tid == Int32(0):
-            out[row] = (block_val * alpha).to(cutlass.BFloat16)
-
-    @cute.kernel
-    def _fast_nvfp4_gemv_fp4in_kernel(
-        weight: CuteTensor,
-        x: CuteTensor,
-        weight_scale: CuteTensor,
-        x_scale: CuteTensor,
-        out: CuteTensor,
-        alpha: Float32,
-        k_bytes: cutlass.Constexpr[int],
-    ) -> None:
-        tid_x, _, _ = cute.arch.thread_idx()
-        row, _, _ = cute.arch.block_idx()
-        tid = Int32(tid_x)
-        smem = cute.arch.alloc_smem(Float32, 2, alignment=16)
-        partial = Float32(0.0)
-        k_bytes_i32 = Int32(k_bytes)  # pyrefly: ignore[bad-argument-type]
-        scale_cols = k_bytes // 8  # pyrefly: ignore[unsupported-operation]
-        weight_row_ptr = weight.iterator + row * k_bytes_i32
-        thread_k_base = tid * Int32(32)
-        thread_scale_base = tid * Int32(4)
-        num_iters = k_bytes // 2048  # pyrefly: ignore[unsupported-operation]
-        for iter_k in cutlass.range(num_iters, unroll_full=True):
-            k_tile_base = Int32(iter_k * 2048) + thread_k_base
-            scale_tile_base = Int32(iter_k * 256) + thread_scale_base
-            scale_offset = _fast_swizzled_scale_offset(
-                row,
-                scale_tile_base,
-                scale_cols,
-            )
-            x_scale_offset = _fast_swizzled_scale_offset(
-                Int32(0),
-                scale_tile_base,
-                scale_cols,
-            )
-            partial = _fast_fp4_32bytes_ptr(
-                partial,
-                weight_row_ptr + k_tile_base,
-                x.iterator + k_tile_base,
-                weight_scale.iterator + scale_offset,
-                x_scale.iterator + x_scale_offset,
-            )
-        lane = tid & Int32(31)
-        warp_id = tid >> Int32(5)
-        warp_val = partial
-        warp_val += cute.arch.shuffle_sync_down(warp_val, 16)
-        warp_val += cute.arch.shuffle_sync_down(warp_val, 8)
-        warp_val += cute.arch.shuffle_sync_down(warp_val, 4)
-        warp_val += cute.arch.shuffle_sync_down(warp_val, 2)
-        warp_val += cute.arch.shuffle_sync_down(warp_val, 1)
-        if lane == Int32(0):
-            cute.arch.store(smem + warp_id, warp_val)
-        cute.arch.sync_threads()
-        block_val = Float32(0.0)
-        if tid < Int32(32):
-            if tid < Int32(2):
-                block_val = cute.arch.load(smem + tid, Float32)
-            block_val += cute.arch.shuffle_sync_down(block_val, 4)
-            block_val += cute.arch.shuffle_sync_down(block_val, 2)
-            block_val += cute.arch.shuffle_sync_down(block_val, 1)
-        if tid == Int32(0):
-            out[row] = (block_val * alpha).to(cutlass.BFloat16)
-
-else:
-    _fast_nvfp4_gemv_bf16in_kernel = None
-    _fast_nvfp4_gemv_fp4in_kernel = None
-
-
-def _can_use_fast_cute_path(*tensors: Tensor, k_bytes: int) -> bool:
-    return (
-        _fast_nvfp4_gemv_bf16in_kernel is not None
-        and k_bytes % 2048 == 0
-        and all(tensor.is_cuda and tensor.is_contiguous() for tensor in tensors)
-        and torch.cuda.get_device_capability(tensors[0].device) >= (10, 0)
-    )
+def _check_numel(name: str, tensor: Tensor, expected: int) -> None:
+    if tensor.numel() != expected:
+        raise ValueError(f"{name} must contain {expected} values; got {tensor.numel()}")
 
 
 def _as_fp4x2(tensor: Tensor) -> Tensor:
@@ -546,38 +176,8 @@ def _e4m3_byte_to_f32(scale_byte: Tensor) -> Tensor:
     )
 
 
-def _fp4_qword_to_f16x16(qword: Tensor) -> tuple[Tensor, ...]:
-    """Decode one int64 (16 packed E2M1 fp4 = 1 scale group) into 16 fp16 lanes."""
-    outs = ",".join("=h" for _ in range(16))
-    return hl.inline_asm_elementwise(
-        """
-        {
-          .reg .b32 lo, hi;
-          .reg .b8 c0,c1,c2,c3,c4,c5,c6,c7;
-          .reg .b32 h0,h1,h2,h3,h4,h5,h6,h7;
-          mov.b64 {lo, hi}, $16;
-          mov.b32 {c0,c1,c2,c3}, lo;
-          cvt.rn.f16x2.e2m1x2 h0, c0; cvt.rn.f16x2.e2m1x2 h1, c1;
-          cvt.rn.f16x2.e2m1x2 h2, c2; cvt.rn.f16x2.e2m1x2 h3, c3;
-          mov.b32 {c4,c5,c6,c7}, hi;
-          cvt.rn.f16x2.e2m1x2 h4, c4; cvt.rn.f16x2.e2m1x2 h5, c5;
-          cvt.rn.f16x2.e2m1x2 h6, c6; cvt.rn.f16x2.e2m1x2 h7, c7;
-          mov.b32 {$0,$1}, h0; mov.b32 {$2,$3}, h1;
-          mov.b32 {$4,$5}, h2; mov.b32 {$6,$7}, h3;
-          mov.b32 {$8,$9}, h4; mov.b32 {$10,$11}, h5;
-          mov.b32 {$12,$13}, h6; mov.b32 {$14,$15}, h7;
-        }
-        """,
-        f"{outs},l",
-        [qword],
-        dtype=(torch.float16,) * 16,
-        is_pure=True,
-        pack=1,
-    )
-
-
 def _nvfp4_gemv_bf16in_triton_body(
-    weight_i64: Tensor,  # (M, K_groups) int64 packed NVFP4 weight
+    weight_bytes: Tensor,  # (M, K_bytes) uint8 packed NVFP4 weight
     x_values: Tensor,  # (K_groups, 16) bf16 activation
     weight_scale_bytes: Tensor,  # int8 view of SWIZZLE_32_4_4 E4M3 scales
     out: Tensor,  # (M,) bf16 output
@@ -585,13 +185,12 @@ def _nvfp4_gemv_bf16in_triton_body(
 ) -> Tensor:
     """W4A16 NVFP4 GEMV, Triton backend (fp16 decode, fp32 scale).
 
-    Two coalescing wins make this genuine Helion->Triton output competitive with
-    the hand-PTX CuTe kernel above (faster on the wider-N shapes) -- ncu showed a
-    naive decode is not DRAM-bound but stalls on uncoalesced loads:
+    Two coalescing wins make this genuine Helion->Triton output competitive:
+    ncu showed a naive decode is not DRAM-bound but stalls on uncoalesced loads:
 
-    * Weight: each 16-value group is one contiguous int64 (8 bytes), loaded
-      unit-stride and decoded with ``_fp4_qword_to_f16x16``. (Reading it as two
-      int32 words would make each load stride-2, halving coalescing.)
+    * Weight: each 16-value group is one contiguous 8-byte chunk, loaded as one
+      64-bit word by ``hl.load_float4_e2m1fn_x16_to_float16``. (Reading it as
+      two int32 words would make each load stride-2, halving coalescing.)
     * Activation: load a group's 16 bf16 as one contiguous ``(block_g, 16)`` tile,
       then peel each lane with a masked sum (the DSL cannot subscript a loaded
       tile as ``xt[:, j]``) -- the contiguous load is what coalesces.
@@ -599,14 +198,24 @@ def _nvfp4_gemv_bf16in_triton_body(
     The per-group E4M3 scale stays a swizzled gather: SWIZZLE_32_4_4's max
     contiguous run is 4 bytes, so it cannot be coalesced for M-tiled access.
     """
-    M, K_groups = weight_i64.shape
+    M = hl.specialize(weight_bytes.size(0))
+    K_bytes = hl.specialize(weight_bytes.size(1))
+    K_groups = K_bytes // 8
     block_m = hl.register_block_size(1, 16)
     block_g = hl.register_block_size(K_groups)
     f16 = torch.float16
     for tile_m in hl.tile(M, block_size=block_m):
         acc = hl.zeros([tile_m], dtype=torch.float32)
         for tile_g in hl.tile(K_groups, block_size=block_g):
-            w = _fp4_qword_to_f16x16(weight_i64[tile_m, tile_g])  # 16 fp16 lanes
+            group_offsets = tile_m.index[:, None] * K_groups + tile_g.index[None, :]
+            weight_mask = (tile_m.index[:, None] < M) & (
+                tile_g.index[None, :] < K_groups
+            )
+            w = hl.load_float4_e2m1fn_x16_to_float16(
+                weight_bytes,
+                group_offsets,
+                extra_mask=weight_mask,
+            )
             xt = x_values[tile_g, :].to(f16)  # (block_g, 16) contiguous coalesced
             lane = hl.arange(16)[None, :]
             contrib = hl.zeros([block_m, block_g], dtype=f16)
@@ -711,18 +320,120 @@ def _nvfp4_gemv_fp4in_body(
     return out
 
 
-# Triton W4A16 uses the coalesced-load ``_nvfp4_gemv_bf16in_triton_body``; block_m=16
-# (activation reuse across 16 rows) + inner K tile block_g=128. The cute backend
-# uses the hand-PTX fast path (``_fast_nvfp4_gemv_bf16in_kernel``), falling back to
-# the portable f32-decode ``_nvfp4_gemv_bf16in_body`` for shapes the fast path does
-# not cover (``BF16IN_CONFIG``). fp4in still shares one DSL body across backends.
-BF16IN_TRITON_CONFIG = helion.Config(block_sizes=[16, 128], num_warps=4, num_stages=3)
-FP4IN_TRITON_CONFIG = helion.Config(block_sizes=[1, 128], num_warps=4, num_stages=3)
+def _nvfp4_gemv_fp4in_triton_body(
+    weight_bytes: Tensor,  # (M, K_bytes) uint8 packed NVFP4 weight
+    x_bytes: Tensor,  # (K_bytes,) uint8 packed NVFP4 activation
+    weight_scale_bytes: Tensor,  # int8 view of SWIZZLE_32_4_4 E4M3 scales
+    x_scale_bytes: Tensor,  # int8 view of SWIZZLE_32_4_4 E4M3 scales
+    out: Tensor,  # (M,) bf16 output
+    alpha: float = 1.0,
+) -> Tensor:
+    """W4A4 NVFP4 GEMV, Triton backend."""
+    M = hl.specialize(weight_bytes.size(0))
+    K_bytes = hl.specialize(weight_bytes.size(1))
+    K_groups = K_bytes // 8
+    block_m = hl.register_block_size(1, 16)
+    block_g = hl.register_block_size(K_groups)
 
-FP4IN_CONFIGS: dict[BackendName, helion.Config] = {
-    "triton": FP4IN_TRITON_CONFIG,
-    "cute": FP4IN_CONFIG,
-}
+    for tile_m in hl.tile(M, block_size=block_m):
+        acc = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_g in hl.tile(K_groups, block_size=block_g):
+            group_offsets = tile_m.index[:, None] * K_groups + tile_g.index[None, :]
+            group_mask = tile_g.index < K_groups
+            weight_mask = (tile_m.index[:, None] < M) & group_mask[None, :]
+            w = hl.load_float4_e2m1fn_x16_to_float16(
+                weight_bytes,
+                group_offsets,
+                extra_mask=weight_mask,
+            )
+            x = hl.load_float4_e2m1fn_x16_to_float16(
+                x_bytes,
+                tile_g.index,
+                extra_mask=group_mask,
+            )
+            contrib = hl.zeros([block_m, block_g], dtype=torch.float16)
+            for i in hl.static_range(16):
+                contrib = contrib + w[i] * x[i][None, :]
+
+            weight_scale_offsets = swizzled_scale_offsets(
+                tile_m.index[:, None], tile_g.index[None, :], K_groups
+            )
+            x_scale_offsets = swizzled_scale_offsets(
+                tile_g.index * 0,
+                tile_g.index,
+                K_groups,
+            )
+            scale = _e4m3_byte_to_f32(weight_scale_bytes[weight_scale_offsets])
+            scale = scale * _e4m3_byte_to_f32(x_scale_bytes[x_scale_offsets])[None, :]
+            acc = acc + (contrib.to(torch.float32) * scale).sum(-1)
+        out[tile_m] = (acc * alpha).to(torch.bfloat16)
+    return out
+
+
+def _nvfp4_scaled_mm_gemv_body(
+    out: Tensor,  # (1, M) bf16 output
+    x_bytes: Tensor,  # (1, K_bytes) uint8 packed NVFP4 activation
+    weight_bytes: Tensor,  # (M, K_bytes) uint8 packed NVFP4 weight
+    x_scale: Tensor,  # (128, round_up(K_groups, 4)) E4M3 swizzled scales
+    weight_scale: Tensor,  # (round_up(M, 128), round_up(K_groups, 4)) E4M3 scales
+    alpha: Tensor,  # (1,) fp32
+) -> Tensor:
+    """Single-row NVFP4 scaled matmul with the CUTLASS-style in-place signature."""
+    M = hl.specialize(weight_bytes.size(0))
+    K_bytes = hl.specialize(weight_bytes.size(1))
+    K_groups = K_bytes // 8
+    x_scale_bytes = x_scale.view(torch.int8).reshape(-1)
+    weight_scale_bytes = weight_scale.view(torch.int8).reshape(-1)
+    block_m = hl.register_block_size(1, 16)
+    block_g = hl.register_block_size(K_groups)
+
+    for tile_m in hl.tile(M, block_size=block_m):
+        alpha_value = alpha[0].to(torch.float32)
+        acc = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_g in hl.tile(K_groups, block_size=block_g):
+            group_offsets = tile_m.index[:, None] * K_groups + tile_g.index[None, :]
+            group_mask = tile_g.index < K_groups
+            weight_mask = (tile_m.index[:, None] < M) & group_mask[None, :]
+            w = hl.load_float4_e2m1fn_x16_to_float16(
+                weight_bytes,
+                group_offsets,
+                extra_mask=weight_mask,
+            )
+            x = hl.load_float4_e2m1fn_x16_to_float16(
+                x_bytes,
+                tile_g.index,
+                extra_mask=group_mask,
+            )
+            contrib = hl.zeros([block_m, block_g], dtype=torch.float16)
+            for i in hl.static_range(16):
+                contrib = contrib + w[i] * x[i][None, :]
+
+            weight_scale_offsets = swizzled_scale_offsets(
+                tile_m.index[:, None], tile_g.index[None, :], K_groups
+            )
+            x_scale_offsets = swizzled_scale_offsets(
+                tile_g.index * 0,
+                tile_g.index,
+                K_groups,
+            )
+            scale = _e4m3_byte_to_f32(weight_scale_bytes[weight_scale_offsets])
+            scale = scale * _e4m3_byte_to_f32(x_scale_bytes[x_scale_offsets])[None, :]
+            acc = acc + (contrib.to(torch.float32) * scale).sum(-1)
+        out[0, tile_m] = (acc * alpha_value).to(torch.bfloat16)
+    return out
+
+
+# Triton W4A16 uses the coalesced-load body with block_m=16 and block_g=128.
+# Triton W4A4 uses the autotuned pretuned config from nvfp4_gemv. The CuTe
+# backend remains a Helion DSL fallback for coverage rather than a hand-written
+# CuTe fast path.
+BF16IN_TRITON_CONFIG = helion.Config(block_sizes=[16, 128], num_warps=4, num_stages=3)
+FP4IN_TRITON_CONFIG = helion.Config(
+    block_sizes=[4, 256],
+    num_warps=2,
+    num_stages=3,
+    range_multi_buffers=[None, True],
+)
 
 
 def _selected_backend(backend: BackendName | None) -> BackendName:
@@ -746,24 +457,44 @@ def _nvfp4_gemv_bf16in_triton_kernel() -> helion.Kernel[Tensor]:
 
 
 @functools.cache
-def _nvfp4_gemv_bf16in_cute_fallback_kernel() -> helion.Kernel[Tensor]:
-    """Portable f32-decode W4A16 GEMV: cute fallback for shapes the hand-PTX fast
-    path can't cover (the triton path uses ``_nvfp4_gemv_bf16in_triton_body``)."""
+def _nvfp4_gemv_bf16in_cute_kernel() -> helion.Kernel[Tensor]:
+    """Portable f32-decode W4A16 GEMV for Helion's CuTe backend."""
     return helion.kernel(
         _nvfp4_gemv_bf16in_body,
         static_shapes=True,
-        config=BF16IN_CONFIG,
+        config=BF16IN_CUTE_CONFIG,
         backend="cute",
     )
 
 
 @functools.cache
-def _nvfp4_gemv_fp4in_kernel(backend: BackendName) -> helion.Kernel[Tensor]:
+def _nvfp4_gemv_fp4in_triton_kernel() -> helion.Kernel[Tensor]:
+    return helion.kernel(
+        _nvfp4_gemv_fp4in_triton_body,
+        static_shapes=True,
+        config=FP4IN_TRITON_CONFIG,
+        backend="triton",
+    )
+
+
+@functools.cache
+def _nvfp4_gemv_fp4in_cute_kernel() -> helion.Kernel[Tensor]:
     return helion.kernel(
         _nvfp4_gemv_fp4in_body,
         static_shapes=True,
-        config=FP4IN_CONFIGS[backend],
-        backend=backend,
+        config=FP4IN_CUTE_CONFIG,
+        backend="cute",
+    )
+
+
+@functools.cache
+def nvfp4_scaled_mm_gemv_kernel() -> helion.Kernel[Tensor]:
+    """Return the single Helion W4A4 GEMV kernel matching stable CUTLASS inputs."""
+    return helion.kernel(
+        _nvfp4_scaled_mm_gemv_body,
+        static_shapes=True,
+        config=FP4IN_TRITON_CONFIG,
+        backend="triton",
     )
 
 
@@ -777,8 +508,12 @@ def nvfp4_gemv_bf16in(
 ) -> Tensor:
     """Compute ``weight_packed @ x_bf16`` for NVFP4 weights and BF16 input."""
     backend = _selected_backend(backend)
+    _check_contiguous("weight_packed", weight_packed)
+    _check_contiguous("x_bf16", x_bf16)
     weight_fp4x2 = _as_fp4x2(weight_packed)
     weight_bytes = weight_fp4x2.view(torch.uint8)
+    _check_fp4_weight_storage("weight_packed", weight_bytes)
+    _check_numel("x_bf16", x_bf16, weight_bytes.shape[1] * 2)
     scale_cols = weight_bytes.shape[1] // 8
     _check_swizzled_scales(
         "weight_scale",
@@ -789,39 +524,19 @@ def nvfp4_gemv_bf16in(
     out = torch.empty(
         weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
     )
-    if backend == "cute" and _can_use_fast_cute_path(
-        weight_bytes,
-        x_bf16,
-        weight_scale,
-        k_bytes=weight_bytes.shape[1],
-    ):
-        default_cute_launcher(
-            _fast_nvfp4_gemv_bf16in_kernel,
-            (weight_bytes.shape[0],),
-            weight_bytes,
-            x_bf16,
-            weight_scale.view(torch.uint8),
-            out,
-            alpha,
-            weight_bytes.shape[1],
-            block=(128, 1, 1),
-        )
-        return out
     n_rows, k_bytes = weight_bytes.shape
     groups = k_bytes // 8
     if backend == "triton":
-        # Coalesced-load Triton kernel: weight as one int64 per group, activation
-        # as contiguous (groups, 16) bf16, scales as the raw SWIZZLE_32_4_4 bytes.
+        # Coalesced-load Triton kernel: weight stored as bytes, activation as
+        # contiguous (groups, 16) bf16, scales as the raw SWIZZLE_32_4_4 bytes.
         return _nvfp4_gemv_bf16in_triton_kernel()(
-            weight_bytes.view(torch.int64).view(n_rows, groups),
+            weight_bytes,
             x_bf16.view(groups, 16),
             weight_scale.reshape(-1).view(torch.int8),
             out,
             alpha,
         )
-    # cute fallback (shapes the hand-PTX fast path does not cover): the portable
-    # f32-decode DSL body.
-    return _nvfp4_gemv_bf16in_cute_fallback_kernel()(
+    return _nvfp4_gemv_bf16in_cute_kernel()(
         weight_fp4x2.view(n_rows, groups, 8),
         x_bf16.view(groups, 16),
         weight_scale.reshape(-1),
@@ -841,10 +556,14 @@ def nvfp4_gemv_fp4in(
 ) -> Tensor:
     """Compute ``weight_packed @ x_packed`` for NVFP4 weights and input."""
     backend = _selected_backend(backend)
+    _check_contiguous("weight_packed", weight_packed)
+    _check_contiguous("x_packed", x_packed)
     weight_fp4x2 = _as_fp4x2(weight_packed)
     x_fp4x2 = _as_fp4x2(x_packed)
     weight_bytes = weight_fp4x2.view(torch.uint8)
     x_bytes = x_fp4x2.view(torch.uint8)
+    _check_fp4_weight_storage("weight_packed", weight_bytes)
+    _check_numel("x_packed", x_bytes, weight_bytes.shape[1])
     scale_cols = weight_bytes.shape[1] // 8
     _check_swizzled_scales(
         "weight_scale",
@@ -856,27 +575,16 @@ def nvfp4_gemv_fp4in(
     out = torch.empty(
         weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
     )
-    if backend == "cute" and _can_use_fast_cute_path(
-        weight_bytes,
-        x_bytes,
-        weight_scale,
-        x_scale,
-        k_bytes=weight_bytes.shape[1],
-    ):
-        default_cute_launcher(
-            _fast_nvfp4_gemv_fp4in_kernel,
-            (weight_bytes.shape[0],),
+    if backend == "triton":
+        return _nvfp4_gemv_fp4in_triton_kernel()(
             weight_bytes,
             x_bytes,
-            weight_scale.view(torch.uint8),
-            x_scale.view(torch.uint8),
+            weight_scale.reshape(-1).view(torch.int8),
+            x_scale.reshape(-1).view(torch.int8),
             out,
             alpha,
-            weight_bytes.shape[1],
-            block=(64, 1, 1),
         )
-        return out
-    return _nvfp4_gemv_fp4in_kernel(backend)(
+    return _nvfp4_gemv_fp4in_cute_kernel()(
         weight_fp4x2.view(weight_bytes.shape[0], weight_bytes.shape[1] // 8, 8),
         x_fp4x2.view(weight_bytes.shape[1] // 8, 8),
         weight_scale.reshape(-1),

--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -370,59 +370,6 @@ def _nvfp4_gemv_fp4in_triton_body(
     return out
 
 
-def _nvfp4_scaled_mm_gemv_body(
-    out: Tensor,  # (1, M) bf16 output
-    x_bytes: Tensor,  # (1, K_bytes) uint8 packed NVFP4 activation
-    weight_bytes: Tensor,  # (M, K_bytes) uint8 packed NVFP4 weight
-    x_scale: Tensor,  # (128, round_up(K_groups, 4)) E4M3 swizzled scales
-    weight_scale: Tensor,  # (round_up(M, 128), round_up(K_groups, 4)) E4M3 scales
-    alpha: Tensor,  # (1,) fp32
-) -> Tensor:
-    """Single-row NVFP4 scaled matmul with the CUTLASS-style in-place signature."""
-    M = hl.specialize(weight_bytes.size(0))
-    K_bytes = hl.specialize(weight_bytes.size(1))
-    K_groups = K_bytes // 8
-    x_scale_bytes = x_scale.view(torch.int8).reshape(-1)
-    weight_scale_bytes = weight_scale.view(torch.int8).reshape(-1)
-    block_m = hl.register_block_size(1, 16)
-    block_g = hl.register_block_size(K_groups)
-
-    for tile_m in hl.tile(M, block_size=block_m):
-        alpha_value = alpha[0].to(torch.float32)
-        acc = hl.zeros([tile_m], dtype=torch.float32)
-        for tile_g in hl.tile(K_groups, block_size=block_g):
-            group_offsets = tile_m.index[:, None] * K_groups + tile_g.index[None, :]
-            group_mask = tile_g.index < K_groups
-            weight_mask = (tile_m.index[:, None] < M) & group_mask[None, :]
-            w = hl.load_float4_e2m1fn_x16_to_float16(
-                weight_bytes,
-                group_offsets,
-                extra_mask=weight_mask,
-            )
-            x = hl.load_float4_e2m1fn_x16_to_float16(
-                x_bytes,
-                tile_g.index,
-                extra_mask=group_mask,
-            )
-            contrib = hl.zeros([block_m, block_g], dtype=torch.float16)
-            for i in hl.static_range(16):
-                contrib = contrib + w[i] * x[i][None, :]
-
-            weight_scale_offsets = swizzled_scale_offsets(
-                tile_m.index[:, None], tile_g.index[None, :], K_groups
-            )
-            x_scale_offsets = swizzled_scale_offsets(
-                tile_g.index * 0,
-                tile_g.index,
-                K_groups,
-            )
-            scale = _e4m3_byte_to_f32(weight_scale_bytes[weight_scale_offsets])
-            scale = scale * _e4m3_byte_to_f32(x_scale_bytes[x_scale_offsets])[None, :]
-            acc = acc + (contrib.to(torch.float32) * scale).sum(-1)
-        out[0, tile_m] = (acc * alpha_value).to(torch.bfloat16)
-    return out
-
-
 # Triton W4A16 uses the coalesced-load body with block_m=16 and block_g=128.
 # Triton W4A4 uses the autotuned pretuned config from nvfp4_gemv. The CuTe
 # backend remains a Helion DSL fallback for coverage rather than a hand-written
@@ -484,17 +431,6 @@ def _nvfp4_gemv_fp4in_cute_kernel() -> helion.Kernel[Tensor]:
         static_shapes=True,
         config=FP4IN_CUTE_CONFIG,
         backend="cute",
-    )
-
-
-@functools.cache
-def nvfp4_scaled_mm_gemv_kernel() -> helion.Kernel[Tensor]:
-    """Return the single Helion W4A4 GEMV kernel matching stable CUTLASS inputs."""
-    return helion.kernel(
-        _nvfp4_scaled_mm_gemv_body,
-        static_shapes=True,
-        config=FP4IN_TRITON_CONFIG,
-        backend="triton",
     )
 
 

--- a/helion/_compiler/cute/quantized_ops.py
+++ b/helion/_compiler/cute/quantized_ops.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ... import exc
 from ...language import _decorators
 from ...language.quantized_ops import float4_e2m1fn_x2_to_float32
+from ...language.quantized_ops import load_float4_e2m1fn_x16_to_float16
 from ..ast_extension import expr_from_string
 
 if TYPE_CHECKING:
@@ -31,3 +33,8 @@ def _(state: CodegenState) -> list[ast.AST]:
         expr_from_string(f"{result.id}[0]"),
         expr_from_string(f"{result.id}[1]"),
     ]
+
+
+@_decorators.codegen(load_float4_e2m1fn_x16_to_float16, "cute")
+def _(state: CodegenState) -> list[ast.AST]:
+    raise exc.BackendUnsupported("cute", "load_float4_e2m1fn_x16_to_float16")

--- a/helion/_compiler/triton/quantized_ops.py
+++ b/helion/_compiler/triton/quantized_ops.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 import ast
 from typing import TYPE_CHECKING
 
+import torch
+
+from ... import exc
 from ...language import _decorators
 from ...language.quantized_ops import float4_e2m1fn_x2_to_float32
+from ...language.quantized_ops import load_float4_e2m1fn_x16_to_float16
 from ..ast_extension import create
 from ..ast_extension import expr_from_string
 
@@ -60,3 +64,65 @@ def _(state: CodegenState) -> list[ast.AST]:
         expr_from_string(f"{result.id}[0]"),
         expr_from_string(f"{result.id}[1]"),
     ]
+
+
+_FP4X16_TO_F16_ASM = """
+{
+    .reg .b32 lo, hi;
+    .reg .b8 c0,c1,c2,c3,c4,c5,c6,c7;
+    .reg .b32 h0,h1,h2,h3,h4,h5,h6,h7;
+    mov.b64 {lo, hi}, $16;
+    mov.b32 {c0,c1,c2,c3}, lo;
+    cvt.rn.f16x2.e2m1x2 h0, c0; cvt.rn.f16x2.e2m1x2 h1, c1;
+    cvt.rn.f16x2.e2m1x2 h2, c2; cvt.rn.f16x2.e2m1x2 h3, c3;
+    mov.b32 {c4,c5,c6,c7}, hi;
+    cvt.rn.f16x2.e2m1x2 h4, c4; cvt.rn.f16x2.e2m1x2 h5, c5;
+    cvt.rn.f16x2.e2m1x2 h6, c6; cvt.rn.f16x2.e2m1x2 h7, c7;
+    mov.b32 {$0,$1}, h0; mov.b32 {$2,$3}, h1;
+    mov.b32 {$4,$5}, h2; mov.b32 {$6,$7}, h3;
+    mov.b32 {$8,$9}, h4; mov.b32 {$10,$11}, h5;
+    mov.b32 {$12,$13}, h6; mov.b32 {$14,$15}, h7;
+}
+"""
+
+
+@_decorators.codegen(load_float4_e2m1fn_x16_to_float16, "triton")
+def _(state: CodegenState) -> list[ast.AST]:
+    storage = state.proxy_arg(0)
+    if not isinstance(storage, torch.Tensor):
+        raise exc.InvalidAPIUsage(
+            "hl.load_float4_e2m1fn_x16_to_float16 expects tensor storage"
+        )
+    group_offset = state.ast_arg(1)
+    extra_mask = state.ast_args[2]
+    base = state.device_function.tensor_arg(storage).name
+    if extra_mask is None:
+        load_call = expr_from_string(
+            f"tl.load({base}.to(tl.pointer_type(tl.uint64)) + {{offset}})",
+            offset=group_offset,
+        )
+    else:
+        assert isinstance(extra_mask, ast.AST)
+        mask_ast: ast.AST = extra_mask
+        load_call = expr_from_string(
+            f"tl.load({base}.to(tl.pointer_type(tl.uint64)) + {{offset}}, "
+            "{mask}, other=0)",
+            offset=group_offset,
+            mask=mask_ast,
+        )
+    qword = state.codegen.lift(load_call, dce=True, prefix="fp4_qword")
+    call = create(
+        ast.Call,
+        func=expr_from_string("tl.inline_asm_elementwise"),
+        args=[
+            create(ast.Constant, value=_FP4X16_TO_F16_ASM),
+            create(ast.Constant, value=f"{','.join('=h' for _ in range(16))},l"),
+            create(ast.List, elts=[qword], ctx=ast.Load()),
+            expr_from_string("(" + ", ".join("tl.float16" for _ in range(16)) + ")"),
+            create(ast.Constant, value=True),  # is_pure
+            create(ast.Constant, value=1),  # pack
+        ],
+        keywords=[],
+    )
+    result = state.codegen.lift(call, dce=True, prefix="fp4_lanes")
+    return [expr_from_string(f"{result.id}[{i}]") for i in range(16)]

--- a/helion/language/__init__.py
+++ b/helion/language/__init__.py
@@ -31,6 +31,9 @@ from .matmul_ops import dot_scaled as dot_scaled
 from .memory_ops import load as load
 from .memory_ops import store as store
 from .quantized_ops import float4_e2m1fn_x2_to_float32 as float4_e2m1fn_x2_to_float32
+from .quantized_ops import (
+    load_float4_e2m1fn_x16_to_float16 as load_float4_e2m1fn_x16_to_float16,
+)
 from .random_ops import rand as rand
 from .random_ops import rand4x as rand4x
 from .random_ops import randint as randint

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -5,7 +5,10 @@ import torch
 from .. import exc
 from . import _decorators
 
-__all__ = ["float4_e2m1fn_x2_to_float32"]
+__all__ = [
+    "float4_e2m1fn_x2_to_float32",
+    "load_float4_e2m1fn_x16_to_float16",
+]
 
 
 @_decorators.api(is_device_only=True)
@@ -13,6 +16,20 @@ def float4_e2m1fn_x2_to_float32(
     value: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Unpack a ``torch.float4_e2m1fn_x2`` scalar tensor into FP32 lanes."""
+    raise exc.NotInsideKernel
+
+
+@_decorators.api(is_device_only=True, allow_host_tensor=True)
+def load_float4_e2m1fn_x16_to_float16(
+    storage: torch.Tensor,
+    group_offsets: torch.Tensor,
+    extra_mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """Load 8 packed FP4 bytes and unpack them into 16 FP16 lanes.
+
+    ``group_offsets`` indexes 8-byte groups relative to the start of contiguous
+    ``torch.uint8`` or ``torch.float4_e2m1fn_x2`` storage.
+    """
     raise exc.NotInsideKernel
 
 
@@ -26,4 +43,25 @@ def _(value: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     return (
         torch.empty(value.shape, dtype=torch.float32, device=value.device),
         torch.empty(value.shape, dtype=torch.float32, device=value.device),
+    )
+
+
+@_decorators.register_fake(load_float4_e2m1fn_x16_to_float16)
+def _(
+    storage: torch.Tensor,
+    group_offsets: torch.Tensor,
+    extra_mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, ...]:
+    if storage.dtype not in (torch.uint8, torch.float4_e2m1fn_x2):
+        raise exc.InvalidAPIUsage(
+            "hl.load_float4_e2m1fn_x16_to_float16 expects a "
+            f"torch.uint8 or torch.float4_e2m1fn_x2 tensor, got {storage.dtype}"
+        )
+    return tuple(
+        torch.empty(
+            group_offsets.shape,
+            dtype=torch.float16,
+            device=group_offsets.device,
+        )
+        for _ in range(16)
     )

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1974,6 +1974,55 @@ class TestExamples(RefEagerTestBase, TestCase):
             rtol=2e-1,
         )
 
+        with self.assertRaisesRegex(ValueError, "x_bf16 must contain"):
+            mod.nvfp4_gemv_bf16in(weight, x_bf16[:-16], weight_scale)
+        with self.assertRaisesRegex(ValueError, "x_packed must contain"):
+            mod.nvfp4_gemv_fp4in(weight, x_packed[:-8], weight_scale, x_scale)
+
+        noncontiguous_weight = torch.randint(
+            0,
+            256,
+            (M, K_bytes + 8),
+            dtype=torch.uint8,
+            device=DEVICE,
+        )[:, :K_bytes]
+        self.assertFalse(noncontiguous_weight.is_contiguous())
+        with self.assertRaisesRegex(ValueError, "weight_packed must be contiguous"):
+            mod.nvfp4_gemv_bf16in(noncontiguous_weight, x_bf16, weight_scale)
+
+        bad_k_weight = torch.randint(
+            0,
+            256,
+            (M, K_bytes - 1),
+            dtype=torch.uint8,
+            device=DEVICE,
+        )
+        with self.assertRaisesRegex(ValueError, "K bytes must be divisible by 8"):
+            mod.nvfp4_gemv_bf16in(bad_k_weight, x_bf16[:-2], weight_scale)
+
+        if _get_backend() == "triton":
+            scale_cols = K_bytes // 8
+            scale_cols_padded = ((scale_cols + 3) // 4) * 4
+            scaled_mm_out = torch.empty(
+                (1, M),
+                dtype=torch.bfloat16,
+                device=DEVICE,
+            )
+            mod.nvfp4_scaled_mm_gemv_kernel()(
+                scaled_mm_out,
+                x_packed.view(1, K_bytes),
+                weight,
+                x_scale.reshape(128, scale_cols_padded),
+                weight_scale.reshape(128, scale_cols_padded),
+                torch.ones(1, dtype=torch.float32, device=DEVICE),
+            )
+            torch.testing.assert_close(
+                scaled_mm_out[0],
+                fp4_expected,
+                atol=4.0,
+                rtol=2e-1,
+            )
+
     @xfailIfPallas("JAX tracer error")
     @skipIfRefEager("hl.jagged_tile does not support ref mode yet")
     def test_jagged_sum(self):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2000,29 +2000,6 @@ class TestExamples(RefEagerTestBase, TestCase):
         with self.assertRaisesRegex(ValueError, "K bytes must be divisible by 8"):
             mod.nvfp4_gemv_bf16in(bad_k_weight, x_bf16[:-2], weight_scale)
 
-        if _get_backend() == "triton":
-            scale_cols = K_bytes // 8
-            scale_cols_padded = ((scale_cols + 3) // 4) * 4
-            scaled_mm_out = torch.empty(
-                (1, M),
-                dtype=torch.bfloat16,
-                device=DEVICE,
-            )
-            mod.nvfp4_scaled_mm_gemv_kernel()(
-                scaled_mm_out,
-                x_packed.view(1, K_bytes),
-                weight,
-                x_scale.reshape(128, scale_cols_padded),
-                weight_scale.reshape(128, scale_cols_padded),
-                torch.ones(1, dtype=torch.float32, device=DEVICE),
-            )
-            torch.testing.assert_close(
-                scaled_mm_out[0],
-                fp4_expected,
-                atol=4.0,
-                rtol=2e-1,
-            )
-
     @xfailIfPallas("JAX tracer error")
     @skipIfRefEager("hl.jagged_tile does not support ref mode yet")
     def test_jagged_sum(self):

--- a/test/test_quantized_ops.py
+++ b/test/test_quantized_ops.py
@@ -129,6 +129,40 @@ class TestTritonQuantizedOps(RefEagerTestDisabled, TestCase):
         self.assertIn("=f,=f,h", code)
         self.assertIn("tl.inline_asm_elementwise", code)
 
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan(
+        (10, 0), reason="FP4 conversion instructions require Blackwell"
+    )
+    def test_load_float4_e2m1fn_x16_to_float16(self):
+        @helion.kernel(autotune_effort="none")
+        def fp4_to_f16_lanes(x: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                (offsets.size(0), 16),
+                dtype=torch.float16,
+                device=x.device,
+            )
+            for tile in hl.tile(offsets.size(0), block_size=4):
+                lanes = hl.load_float4_e2m1fn_x16_to_float16(
+                    x,
+                    offsets[tile],
+                    extra_mask=tile.index < offsets.size(0),
+                )
+                for i in hl.static_range(16):
+                    out[tile, i] = lanes[i]
+            return out
+
+        raw = torch.arange(16, dtype=torch.uint8, device=DEVICE) * 17
+        offsets = torch.tensor([0, 1], dtype=torch.int64, device=DEVICE)
+        code, result = code_and_output(fp4_to_f16_lanes, (raw, offsets))
+
+        raw_i32 = raw.view(2, 8).to(torch.int32)
+        nibbles = torch.stack((raw_i32 & 0xF, (raw_i32 >> 4) & 0xF), dim=-1)
+        expected = _dequant_e2m1(nibbles.reshape(2, 16)).to(torch.float16)
+        torch.testing.assert_close(result, expected)
+        self.assertIn("tl.pointer_type(tl.uint64)", code)
+        self.assertIn("[fp4_qword_", code)
+        self.assertIn("=h,=h", code)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Updated Helion nvfp4_gemv kernels to be more competitive with vllm cutlass.
  - Adds a Triton-only hl.load_float4_e2m1fn_x16_to_float16 helper for coalesced 64-bit FP4 group loads.
  - Updates examples/nvfp4_gemv.py to use coalesced Helion Triton W4A16/W4A4 paths.
  - Removes the hand-written fast CuTe kernel path; backend="cute" remains covered through Helion’s CuTe backend fallback.

 Benchmarked on NVIDIA GB200, CUDA graphs with L2 clearing, rep=100, warmup=25:
| variant | N | K | helion:triton (us) | cutlass (us) | speedup |
|:---|---:|---:|---:|---:|---:|
| bf16in | 4096 | 4096 | 7.88 | 10.97 | 1.39x |
| bf16in | 6144 | 4096 | 8.99 | 11.77 | 1.31x |
| bf16in | 28672 | 4096 | 26.08 | 26.10 | 1.00x |
| bf16in | 4096 | 14336 | 21.68 | 22.63 | 1.04x |
| bf16in | 5120 | 5120 | 11.48 | 12.51 | 1.09x |
| bf16in | 15360 | 5120 | 22.36 | 18.38 | 0.82x |
| bf16in | 8192 | 8192 | 17.15 | 20.59 | 1.20x |
| bf16in | 10240 | 8192 | 19.81 | 22.92 | 1.16x |
| bf16in | 8192 | 28672 | 54.26 | 55.48 | 1.02x |
| fp4in | 4096 | 4096 | 5.72 | 8.74 | 1.53x |
| fp4in | 6144 | 4096 | 6.99 | 9.87 | 1.41x |
| fp4in | 28672 | 4096 | 20.73 | 26.36 | 1.27x |
| fp4in | 4096 | 14336 | 14.29 | 21.26 | 1.49x |
| fp4in | 5120 | 5120 | 9.48 | 10.61 | 1.12x |
| fp4in | 15360 | 5120 | 19.27 | 16.69 | 0.87x |
| fp4in | 8192 | 8192 | 13.04 | 19.03 | 1.46x |
| fp4in | 10240 | 8192 | 15.26 | 22.26 | 1.46x |
| fp4in | 8192 | 28672 | 35.04 | 58.46 | 1.67x |

@LironKesem @yushangdi 