### PR TITLE
Insert tl.debug_barrier() for intra-loop store->load read-after-write hazard; add correctness check to pretuned benchmark

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -164,6 +164,8 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         # Decide once which sibling for-loops need a tl.debug_barrier()
         # to make global writes visible to subsequent reads.
         self._compute_inter_loop_barriers()
+        # Same, for a store->load read-after-write *within* one loop body.
+        self._compute_intra_loop_barriers()
 
     def get_graph(self, graph_id: int) -> GraphInfo:
         return self.codegen_graphs[graph_id]
@@ -260,6 +262,23 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                 pending_global_writes |= self._triton_global_barrier_tensor_names(
                     cur_info.host_loop_writes
                 )
+
+    def _compute_intra_loop_barriers(self) -> None:
+        """Mark loads that read a tensor an earlier store in the same body wrote,
+        so the Triton ``load`` codegen emits a ``tl.debug_barrier()`` before them.
+
+        Gated on Triton for the same reason as ``_compute_inter_loop_barriers``:
+        ``tl.debug_barrier()`` lowers to ``ttg.barrier`` which the TileIR pass
+        pipeline does not legalize.
+        """
+        from .loop_dependency_checker import mark_intra_loop_raw_barriers
+
+        env = CompileEnvironment.current()
+        if env.codegen_name != "triton" or env.backend.name == "tileir":
+            return
+        mark_intra_loop_raw_barriers(
+            self.codegen_graphs, self.host_function.device_ir.root_ids
+        )
 
     def _triton_global_barrier_tensor_names(self, names: frozenset[str]) -> set[str]:
         """Names that may participate in cross-wavefront global (HBM) coherence.
@@ -1215,7 +1234,9 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             return expr_from_string(
                 self.host_function.literal_expr(
                     [
-                        self.device_function.resolved_block_size(x.block_id)  # pyrefly: ignore[missing-attribute]
+                        self.device_function.resolved_block_size(
+                            x.block_id
+                        )  # pyrefly: ignore[missing-attribute]
                         for x in values
                     ]
                 )

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -1234,9 +1234,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             return expr_from_string(
                 self.host_function.literal_expr(
                     [
-                        self.device_function.resolved_block_size(
-                            x.block_id
-                        )  # pyrefly: ignore[missing-attribute]
+                        self.device_function.resolved_block_size(x.block_id)  # pyrefly: ignore[missing-attribute]
                         for x in values
                     ]
                 )

--- a/helion/_compiler/loop_dependency_checker.py
+++ b/helion/_compiler/loop_dependency_checker.py
@@ -10,6 +10,141 @@ if TYPE_CHECKING:
     import ast
     from collections.abc import Callable
 
+    from .device_ir import GraphInfo
+
+
+# fx node meta key marking a load that must be preceded by ``tl.debug_barrier()``.
+INTRA_LOOP_RAW_BARRIER_META = "_needs_debug_barrier_before"
+
+
+def mark_intra_loop_raw_barriers(
+    graphs: list[GraphInfo], root_graph_ids: list[int]
+) -> None:
+    """Mark loads that read storage written earlier in a device-loop body.
+
+    Within a single device-loop body, ``qkv[a] = v`` followed by ``qkv[b]`` is a
+    read-after-write on the same storage. When the store and the load use
+    different-shaped index tensors their Triton thread->element layouts differ, so
+    an element written by one thread is read back by another with no
+    synchronization in between -- a data race (observed corrupting ~0.8% of
+    outputs on B200). Helion already inserts ``tl.debug_barrier()`` for the
+    analogous hazard *between* sequential top-level loops
+    (``needs_inter_loop_debug_barrier_for_global_raw``); this extends the same
+    guarantee to a store->load *within* one loop body.
+
+    We mark the load's FX node; the Triton ``load`` codegen emits a
+    ``tl.debug_barrier()`` before it. The barrier flushes every prior write in the
+    block, so once emitted the pending-write set is cleared and later loads need a
+    new store to re-arm. Storage identity comes from the fake tensor's underlying
+    storage, so distinct FX nodes for aliases and views compare equal. The walk
+    follows Helion control-flow subgraphs and merges pending writes at joins.
+    """
+    marker = _IntraLoopRawBarrierMarker(graphs)
+    for graph_id in root_graph_ids:
+        marker.run_graph(graph_id, set())
+
+
+class _IntraLoopRawBarrierMarker:
+    def __init__(self, graphs: list[GraphInfo]) -> None:
+        self.graphs = graphs
+
+    def _storage_ids(self, graph_id: int, obj: object) -> set[int]:
+        import torch
+
+        from .device_ir import NodeArgsGraphInfo
+
+        if isinstance(obj, (list, tuple)):
+            result: set[int] = set()
+            for item in obj:
+                result.update(self._storage_ids(graph_id, item))
+            return result
+        if not isinstance(obj, torch.fx.Node):
+            return set()
+        graph_info = self.graphs[graph_id]
+        value = obj.meta.get("val")
+        result = (
+            {id(value.untyped_storage())} if isinstance(value, torch.Tensor) else set()
+        )
+        if (
+            obj.op == "placeholder"
+            and obj.graph is graph_info.graph
+            and isinstance(graph_info, NodeArgsGraphInfo)
+        ):
+            result.update(
+                self._storage_ids(graph_id, graph_info.placeholder_to_outer_arg(obj))
+            )
+        if result:
+            return result
+        for arg in obj.args:
+            result.update(self._storage_ids(graph_id, arg))
+        return result
+
+    def run_graph(self, graph_id: int, written: set[int]) -> set[int]:
+        from ..language import memory_ops
+        from ..language._tracing_ops import _for_loop
+        from ..language._tracing_ops import _for_loop_step
+        from ..language._tracing_ops import _if
+        from ..language._tracing_ops import _while_loop
+        from .device_ir import ForLoopGraphInfo
+        from .device_ir import IfGraphInfo
+        from .device_ir import WhileLoopGraphInfo
+
+        pending = set(written)
+        for node in self.graphs[graph_id].graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target is memory_ops.store:
+                pending.update(self._storage_ids(graph_id, node.args[0]))
+                continue
+            if node.target is memory_ops.load:
+                if node.meta.get(INTRA_LOOP_RAW_BARRIER_META):
+                    pending.clear()
+                elif pending & self._storage_ids(graph_id, node.args[0]):
+                    node.meta[INTRA_LOOP_RAW_BARRIER_META] = True
+                    pending.clear()
+                continue
+            if node.target is _if:
+                if_graph_id = node.args[1]
+                assert isinstance(if_graph_id, int)
+                if_info = self.graphs[if_graph_id]
+                assert isinstance(if_info, IfGraphInfo)
+                if_pending = self.run_graph(if_graph_id, pending)
+                if if_info.else_branch is None:
+                    pending |= if_pending
+                else:
+                    else_graph_id = (
+                        if_info.else_branch
+                        if isinstance(if_info.else_branch, int)
+                        else if_info.else_branch.graph_id
+                    )
+                    else_pending = self.run_graph(else_graph_id, pending)
+                    pending = if_pending | else_pending
+                continue
+            if node.target in (_for_loop, _for_loop_step):
+                loop_graph_id = node.args[0]
+                assert isinstance(loop_graph_id, int)
+                loop_info = self.graphs[loop_graph_id]
+                assert isinstance(loop_info, ForLoopGraphInfo)
+                loop_input = set() if loop_info.needs_barrier_before else pending
+                loop_pending = self.run_graph(loop_graph_id, loop_input)
+                # Without a pre-loop barrier, zero iterations preserve the input state.
+                pending = (
+                    loop_pending
+                    if loop_info.needs_barrier_before
+                    else pending | loop_pending
+                )
+                continue
+            if node.target is _while_loop:
+                body_graph_id = node.args[1]
+                assert isinstance(body_graph_id, int)
+                body_info = self.graphs[body_graph_id]
+                assert isinstance(body_info, WhileLoopGraphInfo)
+                condition_pending = self.run_graph(body_info.cond_graph_id, pending)
+                body_pending = self.run_graph(body_graph_id, condition_pending)
+                # The condition executes at least once; the body may not execute.
+                pending = condition_pending | body_pending
+        return pending
+
 
 def needs_inter_loop_debug_barrier_for_global_raw(
     prev_global_writes: set[str],

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -6727,6 +6727,16 @@ def _maybe_materialize_tile_index_load(
 
 @_decorators.codegen(load, "triton")
 def _(state: CodegenState) -> ast.AST:
+    # A store to this tensor earlier in the same loop body followed by this load
+    # is a cross-thread read-after-write on global memory; emit a barrier so the
+    # store is visible before the read (see mark_intra_loop_raw_barriers).
+    from .._compiler.loop_dependency_checker import INTRA_LOOP_RAW_BARRIER_META
+
+    if state.fx_node is not None and state.fx_node.meta.get(
+        INTRA_LOOP_RAW_BARRIER_META
+    ):
+        state.add_statement(statement_from_string("tl.debug_barrier()"))
+
     tensor = state.proxy_arg(0)
     subscript = state.proxy_arg(1)
     assert isinstance(subscript, (list, tuple))

--- a/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/dynamic_per_token_scaled_fp8_quant.py
+++ b/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/dynamic_per_token_scaled_fp8_quant.py
@@ -131,18 +131,29 @@ def use_cudagraph() -> bool:
     return True
 
 
+def _bench_shapes() -> list[tuple[int, int]]:
+    """The (num_tokens, hidden_size) shapes main() benchmarks (and tests check)."""
+    # hidden_size / num_tokens drawn from the vLLM input generator.
+    hidden_sizes = [2048, 4096, 5120]
+    num_tokens_list = [1, 4, 16, 64, 256, 1024, 2048, 4096]
+    return [(t, h) for h in hidden_sizes for t in num_tokens_list]
+
+
 def correctness_check() -> None:
     """Assert the Helion kernel matches the torch reference (used by the tests)."""
     torch.manual_seed(0)
-    x = torch.randn(16, 4096, device="cuda", dtype=torch.bfloat16)
-    result = torch.empty_like(x, dtype=torch.float8_e4m3fn)
-    scale = torch.empty((16, 1), device="cuda", dtype=torch.float32)
-    result_ref = torch.empty_like(result)
-    scale_ref = torch.empty_like(scale)
-    dynamic_per_token_scaled_fp8_quant(result, x, scale)
-    _dynamic_per_token_scaled_fp8_quant_torch(result_ref, x, scale_ref)
-    torch.testing.assert_close(scale, scale_ref, rtol=1e-2, atol=1e-4)
-    torch.testing.assert_close(result.float(), result_ref.float(), rtol=0.2, atol=0.2)
+    for num_tokens, hidden_size in _bench_shapes():
+        x = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+        result = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+        scale = torch.empty((num_tokens, 1), device="cuda", dtype=torch.float32)
+        result_ref = torch.empty_like(result)
+        scale_ref = torch.empty_like(scale)
+        dynamic_per_token_scaled_fp8_quant(result, x, scale)
+        _dynamic_per_token_scaled_fp8_quant_torch(result_ref, x, scale_ref)
+        torch.testing.assert_close(scale, scale_ref, rtol=1e-2, atol=1e-4)
+        torch.testing.assert_close(
+            result.float(), result_ref.float(), rtol=0.2, atol=0.2
+        )
 
 
 def main(verbose: bool = True) -> dict:
@@ -152,10 +163,7 @@ def main(verbose: bool = True) -> dict:
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from _bench import run_sweep
 
-    # hidden_size / num_tokens drawn from the vLLM input generator.
-    hidden_sizes = [2048, 4096, 5120]
-    num_tokens_list = [1, 4, 16, 64, 256, 1024, 2048, 4096]
-    shapes = [(t, h) for h in hidden_sizes for t in num_tokens_list]
+    shapes = _bench_shapes()
     baselines = _baselines()
 
     def make_calls(shape: tuple) -> tuple:
@@ -184,4 +192,6 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    # Verify numerics across every benchmarked shape before timing.
+    correctness_check()
     main()

--- a/pretuned_kernels/fused_qk_norm_rope/fused_qk_norm_rope.py
+++ b/pretuned_kernels/fused_qk_norm_rope/fused_qk_norm_rope.py
@@ -30,6 +30,17 @@ try:
     _HAS_VLLM = hasattr(_vllm_ir.ops, "rms_norm") and hasattr(
         _VllmRotaryEmbedding, "forward_static"
     )
+    if _HAS_VLLM:
+        # Match vLLM's CUDA eager default (see cuda.py get_default_ir_op_priority)
+        # so the baseline dispatches rms_norm to the compiled vllm_c kernel
+        # instead of the pure-PyTorch "native" fallback -- otherwise the vLLM
+        # baseline is artificially slow (and logs a "Priority not set" warning).
+        # import_ir_kernels() registers the platform's impls (e.g. vllm_c) that
+        # set_default requires; it's lazily imported, like vLLM's own KernelConfig.
+        from vllm.platforms import current_platform
+
+        current_platform.import_ir_kernels()
+        _vllm_ir.ops.rms_norm.set_default(["vllm_c", "native"])
 except ImportError:
     _HAS_VLLM = False
 

--- a/pretuned_kernels/fused_qk_norm_rope/fused_qk_norm_rope.py
+++ b/pretuned_kernels/fused_qk_norm_rope/fused_qk_norm_rope.py
@@ -308,16 +308,24 @@ def _make_inputs(
     )
 
 
+def _bench_shapes() -> list[tuple[int, int, int]]:
+    """The (num_tokens, q_heads, kv_heads) shapes main() benchmarks."""
+    num_tokens_list = [1, 8, 32, 128, 512, 2048, 8192]
+    num_heads_pair = [(16, 8), (32, 8), (64, 8)]
+    return [(t, qh, kvh) for (qh, kvh) in num_heads_pair for t in num_tokens_list]
+
+
 def correctness_check() -> None:
     """Assert the Helion kernel matches the torch reference (used by the tests)."""
     torch.manual_seed(0)
-    args = _make_inputs(16, 16, 8)
-    qkv = args[0]
-    qkv_helion = qkv.clone()
-    qkv_torch = qkv.clone()
-    fused_qk_norm_rope(qkv_helion, *args[1:])
-    _fused_qk_norm_rope_torch(qkv_torch, *args[1:])
-    torch.testing.assert_close(qkv_helion, qkv_torch, rtol=2e-2, atol=2e-2)
+    for num_tokens, q_heads, kv_heads in _bench_shapes():
+        args = _make_inputs(num_tokens, q_heads, kv_heads)
+        qkv = args[0]
+        qkv_helion = qkv.clone()
+        qkv_torch = qkv.clone()
+        fused_qk_norm_rope(qkv_helion, *args[1:])
+        _fused_qk_norm_rope_torch(qkv_torch, *args[1:])
+        torch.testing.assert_close(qkv_helion, qkv_torch, rtol=2e-2, atol=2e-2)
 
 
 def main(verbose: bool = True) -> dict:
@@ -327,9 +335,7 @@ def main(verbose: bool = True) -> dict:
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from _bench import run_sweep
 
-    num_tokens_list = [1, 8, 32, 128, 512, 2048, 8192]
-    num_heads_pair = [(16, 8), (32, 8), (64, 8)]
-    shapes = [(t, qh, kvh) for (qh, kvh) in num_heads_pair for t in num_tokens_list]
+    shapes = _bench_shapes()
     baselines = _baselines()
 
     def make_calls(shape: tuple) -> tuple:
@@ -363,4 +369,6 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    # Verify numerics across every benchmarked shape before timing.
+    correctness_check()
     main()

--- a/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
+++ b/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
@@ -145,21 +145,29 @@ def use_cudagraph() -> bool:
     return True
 
 
+def _bench_shapes() -> list[tuple[int, int]]:
+    """Shapes main() benchmarks: (num_tokens, hidden_size) pairs."""
+    hidden_sizes = [2048, 4096, 5120]
+    num_tokens_list = [1, 4, 16, 64, 256, 1024, 2048, 8192]
+    return [(t, h) for h in hidden_sizes for t in num_tokens_list]
+
+
 def correctness_check() -> None:
     """Assert the Helion kernel matches the torch reference (used by the tests)."""
     torch.manual_seed(0)
-    num_tokens, hidden_size, group_size = 16, 4096, 128
-    inp = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
-    groups = hidden_size // group_size
-    oq = torch.empty_like(inp, dtype=torch.float8_e4m3fn)
-    os = torch.empty((num_tokens, groups), device="cuda", dtype=torch.float32)
-    oq_ref = torch.empty_like(oq)
-    os_ref = torch.empty_like(os)
+    group_size = 128
     const = (group_size, 1e-10, -448.0, 448.0, False)
-    per_token_group_fp8_quant(inp, oq, os, *const)
-    _per_token_group_fp8_quant_torch(inp, oq_ref, os_ref, *const)
-    torch.testing.assert_close(os, os_ref, rtol=1e-2, atol=1e-6)
-    torch.testing.assert_close(oq.float(), oq_ref.float(), rtol=0.2, atol=0.2)
+    for num_tokens, hidden_size in _bench_shapes():
+        inp = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+        groups = hidden_size // group_size
+        oq = torch.empty_like(inp, dtype=torch.float8_e4m3fn)
+        os = torch.empty((num_tokens, groups), device="cuda", dtype=torch.float32)
+        oq_ref = torch.empty_like(oq)
+        os_ref = torch.empty_like(os)
+        per_token_group_fp8_quant(inp, oq, os, *const)
+        _per_token_group_fp8_quant_torch(inp, oq_ref, os_ref, *const)
+        torch.testing.assert_close(os, os_ref, rtol=1e-2, atol=1e-6)
+        torch.testing.assert_close(oq.float(), oq_ref.float(), rtol=0.2, atol=0.2)
 
 
 def main(verbose: bool = True) -> dict:
@@ -175,9 +183,7 @@ def main(verbose: bool = True) -> dict:
     group_size = 128
     scale_ue8m0 = False
 
-    hidden_sizes = [2048, 4096, 5120]
-    num_tokens_list = [1, 4, 16, 64, 256, 1024, 2048, 8192]
-    shapes = [(t, h) for h in hidden_sizes for t in num_tokens_list]
+    shapes = _bench_shapes()
     baselines = _baselines()
 
     def make_calls(shape: tuple) -> tuple:
@@ -234,4 +240,6 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    # Verify numerics across every benchmarked shape before timing.
+    correctness_check()
     main()

--- a/pretuned_kernels/rms_norm_dynamic_per_token_quant/rms_norm_dynamic_per_token_quant.py
+++ b/pretuned_kernels/rms_norm_dynamic_per_token_quant/rms_norm_dynamic_per_token_quant.py
@@ -202,22 +202,33 @@ def use_cudagraph() -> bool:
     return True
 
 
+def _bench_shapes() -> list[tuple[int, int]]:
+    """Shapes main() benchmarks (from the vLLM input_generator / pick_config grid)."""
+    hidden_sizes = [2048, 4096, 5120]
+    num_tokens_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
+    return [(h, t) for h in hidden_sizes for t in num_tokens_list]
+
+
 def correctness_check() -> None:
-    """Assert the Helion kernel matches the torch reference (used by the tests)."""
+    """Assert the Helion kernel matches the torch reference for every bench shape."""
     torch.manual_seed(0)
-    num_tokens, hidden_size = 16, 4096
-    x_in = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
-    weight = torch.normal(
-        mean=1.0, std=1.0, size=(hidden_size,), dtype=x_in.dtype, device="cuda"
-    )
-    result = torch.empty_like(x_in, dtype=torch.float8_e4m3fn)
-    scale = torch.empty((num_tokens, 1), device="cuda", dtype=torch.float32)
-    result_ref = torch.empty_like(result)
-    scale_ref = torch.empty_like(scale)
-    rms_norm_dynamic_per_token_quant(result, x_in, weight, scale, 1e-6)
-    _rms_norm_dynamic_per_token_quant_torch(result_ref, x_in, weight, scale_ref, 1e-6)
-    torch.testing.assert_close(scale, scale_ref, rtol=2e-2, atol=1e-4)
-    torch.testing.assert_close(result.float(), result_ref.float(), rtol=0.2, atol=0.2)
+    for hidden_size, num_tokens in _bench_shapes():
+        x_in = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+        weight = torch.normal(
+            mean=1.0, std=1.0, size=(hidden_size,), dtype=x_in.dtype, device="cuda"
+        )
+        result = torch.empty_like(x_in, dtype=_FP8_DTYPE)
+        scale = torch.empty((num_tokens, 1), device="cuda", dtype=torch.float32)
+        result_ref = torch.empty_like(result)
+        scale_ref = torch.empty_like(scale)
+        rms_norm_dynamic_per_token_quant(result, x_in, weight, scale, 1e-6)
+        _rms_norm_dynamic_per_token_quant_torch(
+            result_ref, x_in, weight, scale_ref, 1e-6
+        )
+        torch.testing.assert_close(scale, scale_ref, rtol=2e-2, atol=1e-4)
+        torch.testing.assert_close(
+            result.float(), result_ref.float(), rtol=0.2, atol=0.2
+        )
 
 
 def main(verbose: bool = True) -> dict:
@@ -228,9 +239,7 @@ def main(verbose: bool = True) -> dict:
     from _bench import run_sweep
 
     # Representative sweep from the vLLM input_generator / pick_config grid.
-    hidden_sizes = [2048, 4096, 5120]
-    num_tokens_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
-    shapes = [(h, t) for h in hidden_sizes for t in num_tokens_list]
+    shapes = _bench_shapes()
     epsilon = 1e-6
     baselines = _baselines()
 
@@ -267,4 +276,6 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    # Verify numerics across every benchmarked shape before timing.
+    correctness_check()
     main()

--- a/pretuned_kernels/rms_norm_per_block_quant/rms_norm_per_block_quant.py
+++ b/pretuned_kernels/rms_norm_per_block_quant/rms_norm_per_block_quant.py
@@ -260,41 +260,57 @@ def _make_inputs(
     return (result, inp, weight, scale, epsilon, scale_ub, residual, group_size, False)
 
 
+def _bench_shapes() -> list[tuple[int, int, int]]:
+    """The (hidden_size, group_size, num_tokens) shapes main() benchmarks."""
+    hidden_size_list = [2048, 4096, 5120]
+    group_size_list = [128]
+    num_tokens_list = [1, 8, 32, 64, 128, 256, 1024, 4096]
+    return [
+        (h, g, t)
+        for h in hidden_size_list
+        for g in group_size_list
+        for t in num_tokens_list
+    ]
+
+
 def correctness_check() -> None:
     """Assert the Helion kernel matches the torch reference (used by the tests)."""
     torch.manual_seed(0)
-    args = _make_inputs(16, 4096, 128)
-    (
-        result,
-        inp,
-        weight,
-        scale,
-        epsilon,
-        scale_ub,
-        residual,
-        group_size,
-        is_transposed,
-    ) = args
-    result_ref = torch.empty_like(result)
-    scale_ref = torch.empty_like(scale)
-    residual_ref = residual.clone()
-    rms_norm_per_block_quant(*args)
-    _rms_norm_per_block_quant_torch(
-        result_ref,
-        inp,
-        weight,
-        scale_ref,
-        epsilon,
-        scale_ub,
-        residual_ref,
-        group_size,
-        is_transposed,
-    )
-    torch.testing.assert_close(scale, scale_ref, rtol=2e-2, atol=1e-4)
-    torch.testing.assert_close(result.float(), result_ref.float(), rtol=0.2, atol=0.2)
-    torch.testing.assert_close(
-        residual.float(), residual_ref.float(), rtol=2e-2, atol=2e-2
-    )
+    for hidden_size, group_size, num_tokens in _bench_shapes():
+        args = _make_inputs(num_tokens, hidden_size, group_size)
+        (
+            result,
+            inp,
+            weight,
+            scale,
+            epsilon,
+            scale_ub,
+            residual,
+            group_size,
+            is_transposed,
+        ) = args
+        result_ref = torch.empty_like(result)
+        scale_ref = torch.empty_like(scale)
+        residual_ref = residual.clone()
+        rms_norm_per_block_quant(*args)
+        _rms_norm_per_block_quant_torch(
+            result_ref,
+            inp,
+            weight,
+            scale_ref,
+            epsilon,
+            scale_ub,
+            residual_ref,
+            group_size,
+            is_transposed,
+        )
+        torch.testing.assert_close(scale, scale_ref, rtol=2e-2, atol=1e-4)
+        torch.testing.assert_close(
+            result.float(), result_ref.float(), rtol=0.2, atol=0.2
+        )
+        torch.testing.assert_close(
+            residual.float(), residual_ref.float(), rtol=2e-2, atol=2e-2
+        )
 
 
 def main(verbose: bool = True) -> dict:
@@ -304,15 +320,7 @@ def main(verbose: bool = True) -> dict:
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from _bench import run_sweep
 
-    hidden_size_list = [2048, 4096, 5120]
-    group_size_list = [128]
-    num_tokens_list = [1, 8, 32, 64, 128, 256, 1024, 4096]
-    shapes = [
-        (h, g, t)
-        for h in hidden_size_list
-        for g in group_size_list
-        for t in num_tokens_list
-    ]
+    shapes = _bench_shapes()
     baselines = _baselines()
 
     def make_calls(shape: tuple[int, int, int]) -> tuple:
@@ -356,4 +364,6 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    # Verify numerics across every benchmarked shape before timing.
+    correctness_check()
     main()

--- a/pretuned_kernels/silu_and_mul_per_block_quant/silu_and_mul_per_block_quant.py
+++ b/pretuned_kernels/silu_and_mul_per_block_quant/silu_and_mul_per_block_quant.py
@@ -188,23 +188,33 @@ def use_cudagraph() -> bool:
     return True
 
 
+def _bench_shapes() -> list[tuple[int, int]]:
+    """The (num_tokens, intermediate_size) shapes main() benchmarks."""
+    intermediate_sizes = [6144, 12288, 25600]
+    num_tokens_list = [1, 8, 32, 64, 128, 256, 1024, 4096]
+    return [(t, i) for i in intermediate_sizes for t in num_tokens_list]
+
+
 def correctness_check() -> None:
     """Assert the Helion kernel matches the torch reference (used by the tests)."""
+    group_size = 128
     torch.manual_seed(0)
-    num_tokens, intermediate, group_size = 16, 6144, 128
-    x = torch.randn(num_tokens, 2 * intermediate, device="cuda", dtype=torch.bfloat16)
-    out = torch.empty(
-        num_tokens, intermediate, device="cuda", dtype=torch.float8_e4m3fn
-    )
-    scales = torch.empty(
-        num_tokens, intermediate // group_size, device="cuda", dtype=torch.float32
-    )
-    out_ref = torch.empty_like(out)
-    scales_ref = torch.empty_like(scales)
-    silu_and_mul_per_block_quant(out, x, scales, group_size)
-    _silu_and_mul_per_block_quant_torch(out_ref, x, scales_ref, group_size)
-    torch.testing.assert_close(scales, scales_ref, rtol=1e-2, atol=1e-4)
-    torch.testing.assert_close(out.float(), out_ref.float(), rtol=0.2, atol=0.2)
+    for num_tokens, intermediate in _bench_shapes():
+        x = torch.randn(
+            num_tokens, 2 * intermediate, device="cuda", dtype=torch.bfloat16
+        )
+        out = torch.empty(
+            num_tokens, intermediate, device="cuda", dtype=torch.float8_e4m3fn
+        )
+        scales = torch.empty(
+            num_tokens, intermediate // group_size, device="cuda", dtype=torch.float32
+        )
+        out_ref = torch.empty_like(out)
+        scales_ref = torch.empty_like(scales)
+        silu_and_mul_per_block_quant(out, x, scales, group_size)
+        _silu_and_mul_per_block_quant_torch(out_ref, x, scales_ref, group_size)
+        torch.testing.assert_close(scales, scales_ref, rtol=1e-2, atol=1e-4)
+        torch.testing.assert_close(out.float(), out_ref.float(), rtol=0.2, atol=0.2)
 
 
 def main(verbose: bool = True) -> dict:
@@ -214,10 +224,8 @@ def main(verbose: bool = True) -> dict:
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from _bench import run_sweep
 
-    intermediate_sizes = [6144, 12288, 25600]
-    num_tokens_list = [1, 8, 32, 64, 128, 256, 1024, 4096]
     group_size = 128
-    shapes = [(t, i) for i in intermediate_sizes for t in num_tokens_list]
+    shapes = _bench_shapes()
     baselines = _baselines()
 
     def make_calls(shape: tuple[int, int]) -> tuple:
@@ -255,4 +263,6 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    # Verify numerics across every benchmarked shape before timing.
+    correctness_check()
     main()

--- a/pretuned_kernels/silu_mul_fp8/silu_mul_fp8.py
+++ b/pretuned_kernels/silu_mul_fp8/silu_mul_fp8.py
@@ -97,14 +97,24 @@ def use_cudagraph() -> bool:
     return True
 
 
+def _bench_shapes() -> list[tuple[int, int]]:
+    """The (num_tokens, intermediate) shapes main() benchmarks."""
+    intermediate_sizes = [2048, 2880, 4096, 8192, 11008, 14336]
+    num_tokens_list = [1, 8, 32, 64, 128, 256]
+    return [(t, i) for i in intermediate_sizes for t in num_tokens_list]
+
+
 def correctness_check() -> None:
     """Assert the Helion kernel matches the torch reference (used by the tests)."""
     torch.manual_seed(0)
-    x = torch.randn(16, 2 * 2048, device="cuda", dtype=torch.bfloat16)
-    scale = torch.tensor([1.3], device="cuda", dtype=torch.float32)
-    got = silu_mul_fp8(x, scale).float()
-    ref = _silu_mul_fp8_torch(x, scale).float()
-    torch.testing.assert_close(got, ref, rtol=0.2, atol=0.2)
+    for num_tokens, intermediate in _bench_shapes():
+        x = torch.randn(
+            num_tokens, 2 * intermediate, device="cuda", dtype=torch.bfloat16
+        )
+        scale = torch.tensor([1.0], device="cuda", dtype=torch.float32)
+        got = silu_mul_fp8(x, scale).float()
+        ref = _silu_mul_fp8_torch(x, scale).float()
+        torch.testing.assert_close(got, ref, rtol=0.2, atol=0.2)
 
 
 def main(verbose: bool = True) -> dict:
@@ -114,9 +124,7 @@ def main(verbose: bool = True) -> dict:
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from _bench import run_sweep
 
-    intermediate_sizes = [2048, 2880, 4096, 8192, 11008, 14336]
-    num_tokens_list = [1, 8, 32, 64, 128, 256]
-    shapes = [(t, i) for i in intermediate_sizes for t in num_tokens_list]
+    shapes = _bench_shapes()
     baselines = _baselines()
 
     def make_calls(shape: tuple[int, int]) -> tuple:
@@ -142,4 +150,6 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    # Verify numerics across every benchmarked shape before timing.
+    correctness_check()
     main()

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -1578,6 +1578,132 @@ class TestLoops(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, x + 1)
         self.assertNotIn("tl.debug_barrier()", code)
 
+    @skipIfNotTriton(
+        "tl.debug_barrier() is only emitted in Triton device codegen (not Pallas/JAX)"
+    )
+    def test_intra_loop_store_then_load_barrier(self):
+        """A store to a tensor followed by a load of the same tensor *within one
+        loop body* (using a different-shaped index) is a cross-thread
+        read-after-write; codegen must emit tl.debug_barrier() between them so the
+        store is visible before the reload (multi-warp, Triton)."""
+
+        @helion.kernel(autotune_effort="none")
+        def store_then_reload(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            for tile_m in hl.tile(m):
+                # store the whole row, then read back a slice of it (different
+                # index shape -> different thread<->element layout -> RAW race).
+                row = x[tile_m, :] * 2.0
+                x[tile_m, :] = row
+                half = hl.arange(n // 2)
+                lo = x[tile_m, half]
+                hi = x[tile_m, half + n // 2]
+                x[tile_m, half] = hi
+                x[tile_m, half + n // 2] = lo
+            return x
+
+        torch.manual_seed(0)
+        m, n = 64, 128
+        x = torch.randn(m, n, device=DEVICE, dtype=torch.float32)
+        expected = x * 2.0
+        expected = torch.cat([expected[:, n // 2 :], expected[:, : n // 2]], dim=-1)
+        for num_warps in (4, 8):
+            code, result = code_and_output(
+                store_then_reload,
+                (x.clone(),),
+                block_sizes=[1],
+                num_warps=num_warps,
+                num_stages=2,
+            )
+            self.assertIn("tl.debug_barrier()", code)
+            torch.testing.assert_close(result, expected)
+
+    @skipIfNotTriton(
+        "tl.debug_barrier() is Triton codegen-specific; "
+        "the negative assertion is trivially true on non-Triton backends"
+    )
+    def test_intra_loop_load_before_store_no_barrier(self):
+        """A load that precedes the store (read-modify-write) is not a hazard and
+        must not get an intra-loop barrier."""
+
+        @helion.kernel(autotune_effort="none")
+        def load_then_store(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            for tile_m in hl.tile(m):
+                row = x[tile_m, :]  # load BEFORE any store to x
+                x[tile_m, :] = row + 1.0
+            return x
+
+        x = torch.randn(64, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            load_then_store,
+            (x.clone(),),
+            block_sizes=[1],
+            num_warps=4,
+            num_stages=1,
+        )
+        torch.testing.assert_close(result, x + 1.0)
+        self.assertNotIn("tl.debug_barrier()", code)
+
+    @skipIfNotTriton("intra-loop barriers are Triton codegen-specific")
+    def test_intra_loop_barrier_tracks_storage_aliases(self):
+        @helion.kernel(autotune_effort="none")
+        def store_then_load_view(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            alias = x.view(m, n)
+            for tile_m in hl.tile(m):
+                x[tile_m, :] = x[tile_m, :] * 2.0
+                half = hl.arange(n // 2)
+                lo = alias[tile_m, half]
+                hi = alias[tile_m, half + n // 2]
+                x[tile_m, half] = hi
+                x[tile_m, half + n // 2] = lo
+            return x
+
+        x = torch.randn(64, 128, device=DEVICE, dtype=torch.float32)
+        expected = x * 2.0
+        expected = torch.cat([expected[:, 64:], expected[:, :64]], dim=-1)
+        code, result = code_and_output(
+            store_then_load_view,
+            (x.clone(),),
+            block_sizes=[1],
+            num_warps=4,
+            num_stages=2,
+        )
+        self.assertIn("tl.debug_barrier()", code)
+        torch.testing.assert_close(result, expected)
+
+    @skipIfNotTriton("intra-loop barriers are Triton codegen-specific")
+    def test_intra_loop_barrier_crosses_if_subgraph(self):
+        @helion.kernel(autotune_effort="none")
+        def store_then_load_in_branch(
+            x: torch.Tensor, flag: torch.Tensor
+        ) -> torch.Tensor:
+            m, n = x.shape
+            for tile_m in hl.tile(m):
+                x[tile_m, :] = x[tile_m, :] * 2.0
+                if flag[0] > 0:
+                    half = hl.arange(n // 2)
+                    lo = x[tile_m, half]
+                    hi = x[tile_m, half + n // 2]
+                    x[tile_m, half] = hi
+                    x[tile_m, half + n // 2] = lo
+            return x
+
+        x = torch.randn(64, 128, device=DEVICE, dtype=torch.float32)
+        flag = torch.ones(1, device=DEVICE)
+        expected = x * 2.0
+        expected = torch.cat([expected[:, 64:], expected[:, :64]], dim=-1)
+        code, result = code_and_output(
+            store_then_load_in_branch,
+            (x.clone(), flag),
+            block_sizes=[1],
+            num_warps=4,
+            num_stages=2,
+        )
+        self.assertIn("tl.debug_barrier()", code)
+        torch.testing.assert_close(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Fix a silent intra-loop global-memory read-after-write race by emitting
  `tl.debug_barrier()` before a load when the same underlying storage was written
  earlier in the device-loop execution.
- Make the analysis storage-aware and control-flow-aware so it handles tensor
  views, aliases, `if` branches, nested device loops, and `while` subgraphs.
- Configure the `fused_qk_norm_rope` vLLM baseline to use vLLM's compiled
  `rms_norm` implementation rather than its native PyTorch fallback.
- Expand each vLLM-ported pretuned kernel's `correctness_check()` to cover every
  benchmarked shape, including shape/config combinations that previously escaped
  the single-shape spot checks.

## Problem

`fused_qk_norm_rope` normalizes a Q/K head in place and then reloads parts of that
head to apply RoPE. The store and reload use differently shaped index tensors,
which can produce different Triton thread-to-element layouts. An element written
by one thread may therefore be reloaded by another thread before the write is
visible.

The race is silent and configuration-dependent. On B200 it reproduced with the
`(q_heads=64, kv_heads=8, num_tokens=8)` tuned configuration at `num_warps=8`,
corrupting roughly 0.8% of outputs. The corrupted elements varied across repeated
runs with identical inputs. Configurations using one warp did not expose the race.

Helion already inserts a barrier for the analogous dependency between sequential
device loops. This PR extends that protection to store-then-load dependencies
inside one device-loop execution.

## Compiler Fix

`mark_intra_loop_raw_barriers()` starts from the actual DeviceIR root graph IDs
and walks each graph in execution order. It maintains a set of storages written
since the most recent barrier:

- A store adds its tensor storage to the pending-write set.
- A load whose storage is pending is marked with
  `INTRA_LOOP_RAW_BARRIER_META`.
- A marked load clears the complete pending-write set because the emitted CTA
  barrier synchronizes all preceding writes.
- A later store re-arms the analysis for subsequent loads.

Storage identity uses the FakeTensor's underlying `UntypedStorage`, rather than
the immediate FX node identity. This detects distinct FX values and views that
alias the same allocation. Subgraph placeholders are also related back to their
outer arguments so storage identity remains connected across graph boundaries.

The walk recursively handles `if`/`else`, nested device loops, and `while`
condition/body graphs, merging pending writes at control-flow joins. It also
honors an existing inter-loop barrier instead of adding a redundant barrier to
the first load inside that loop.

The analysis is enabled only for Triton codegen and remains disabled for TileIR,
whose lowering pipeline does not legalize `ttg.barrier`. Triton load codegen emits
`tl.debug_barrier()` immediately before a marked load.

## Pretuned Benchmark Updates

The vLLM comparison for `fused_qk_norm_rope` now sets the RMSNorm IR operation
priority to:

```python
["vllm_c", "native"]
```

This matches vLLM's CUDA eager default and prevents the benchmark from silently
using the slower native PyTorch fallback.

The following vLLM-ported kernels now share a module-level `_bench_shapes()` list
between `main()` and `correctness_check()`, and correctness is checked for every
benchmarked shape:

- `silu_mul_fp8`
- `dynamic_per_token_scaled_fp8_quant`
- `per_token_group_fp8_quant`
- `rms_norm_dynamic_per_token_quant`
- `rms_norm_per_block_quant`
- `silu_and_mul_per_block_quant`
- `fused_qk_norm_rope`

This ensures tuned, shape-specific configurations are exercised by correctness
tests rather than timing alone.

## Tests

- Added a positive multi-warp store-then-load test that verifies both barrier
  emission and output correctness.
- Added a negative load-before-store test that verifies ordinary
  read-modify-write code does not receive a barrier.
- Added coverage for distinct tensor views sharing storage.
- Added coverage for a dependency crossing an `if` subgraph boundary.
- Verified the complete loop and barrier suites:

  ```text
  63 passed, 3 skipped
  ```

- Verified `fused_qk_norm_rope` through the pretuned-kernel correctness test.
- Ruff and the targeted Pyrefly compiler check pass.
- Existing example golden output is unchanged.
