### PR TITLE
[Pallas] Retain benchmark outputs until device sync

### DIFF
--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -184,14 +184,15 @@ def compute_repeat_generic(
     Used for backends that don't have Triton's event-based timing (e.g., Pallas/TPU).
     """
     # Warm the pipeline once before collecting timing samples.
-    fn()
+    _output = fn()
     synchronize_device()
 
     clear_l2 = _make_l2_cache_clearer()
     start = time.perf_counter()
     for _ in range(estimate_runs):
         clear_l2()
-        fn()
+        # Keep the latest asynchronous output alive through synchronization.
+        _output = fn()
     synchronize_device()
     end = time.perf_counter()
 
@@ -282,8 +283,9 @@ def interleaved_bench_generic(
     Used for backends that don't have Triton's event-based timing (e.g., Pallas/TPU).
     """
     # warmup
+    _output: object = None
     for fn in fns:
-        fn()
+        _output = fn()
     synchronize_device()
 
     clear_l2 = _make_l2_cache_clearer()
@@ -300,7 +302,9 @@ def interleaved_bench_generic(
             clear_l2()
             synchronize_device()
             start = time.perf_counter()
-            fns[j]()
+            # Dropping an asynchronous output before the sync can trigger device
+            # buffer destruction inside the timed region.
+            _output = fns[j]()
             synchronize_device()
             end = time.perf_counter()
             all_times[j].append((end - start) * 1000)  # convert to ms
@@ -594,7 +598,7 @@ def do_bench_generic(
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
-    fn()
+    _output = fn()
     synchronize_device()
 
     clear_l2 = _make_l2_cache_clearer()
@@ -604,7 +608,8 @@ def do_bench_generic(
     start = time.perf_counter()
     for _ in range(5):
         clear_l2()
-        fn()
+        # Keep the latest asynchronous output alive through synchronization.
+        _output = fn()
     synchronize_device()
     end = time.perf_counter()
     estimate_ms = sync_object(
@@ -626,7 +631,7 @@ def do_bench_generic(
         clear_l2()
         synchronize_device()
         t0 = time.perf_counter()
-        fn()
+        _output = fn()
         synchronize_device()
         t1 = time.perf_counter()
         times.append((t1 - t0) * 1000)  # convert to ms

--- a/helion/autotuner/precompile_future.py
+++ b/helion/autotuner/precompile_future.py
@@ -175,7 +175,8 @@ def _run_kernel_in_subprocess_spawn(
         assert isinstance(args, (tuple, list))
         synchronize_device()
         with capture_output() as _cap:
-            fn(*args)
+            # Keep asynchronous device buffers alive until execution completes.
+            _output = fn(*args)
         synchronize_device()
         _write_result_file(result_path, {"status": "ok"})
     except Exception as exc:


### PR DESCRIPTION

Before  #3026 , each timed call stored out = fn() and kept that output alive through synchronize_device(out). A later assignment could therefore release only an output whose asynchronous TPU work had already completed.

bdfb5962 removed the assignment and evaluated fn() as a bare expression. CPython decrements that temporary result before executing the following synchronize_device(). This does not eliminate destruction: it moves destruction of the still-unsynchronized TorchTPU DeviceBuffer chain between the timer start and end, where stale-buffer tracking and materialization/deallocation work are charged to the benchmark. Lazy torch.compile graphs can take the opposite invalid path: losing their last live output can skip materialization, making that comparator artificially fast.

Controlled identical-config TPU measurements (9ca92a66 / bdfb5962 / fixed) were: flash attention [2,32,1024,64] 3.3375 / 5.0244 / 3.3455 ms; flash attention [8,32,8192,256] 617.5454 / 696.0297 / 617.6435 ms; softmax [65536,2560] 1.5458 / 1.9161 / 1.5416 ms; and rms_norm-bwd [8192,8192] 1.6898 / 2.0254 / 1.7095 ms. The lazy torch.compile attention timing was 80.7800 / 0.2578 / 80.4612 ms, confirming the skipped-work artifact.

Retain each result through synchronization in the generic benchmark and precompile paths.
