### PR TITLE
[pallas] enable a max_extent hint for jagged hl.tile loops

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -708,6 +708,14 @@ class Backend(abc.ABC):
         """
         return None
 
+    def register_specializations(self, hf: HostFunction) -> None:
+        """Register backend-required guards after device IR lowering.
+
+        These guards become part of the BoundKernel cache key, so this hook must
+        run before the first cache key is created.
+        """
+        return None
+
     def pre_codegen(
         self,
         graphs: list[GraphInfo],
@@ -1586,6 +1594,30 @@ class PallasBackend(Backend):
     @property
     def pad_factory_tensors_to_power_of_2(self) -> bool:
         return False
+
+    def register_specializations(self, hf: HostFunction) -> None:
+        """Guard compact ordered-operand tails used in fixed VMEM buffers."""
+        from .compile_environment import CompileEnvironment
+        from .compile_environment import _symint_free_symbols
+        from .pallas.compact_worklist import detect_compact_worklist_plan
+        from .pallas.compact_worklist import resident_ordered_entries
+
+        env = CompileEnvironment.current()
+        if env.settings.static_shapes:
+            return
+        try:
+            plan = detect_compact_worklist_plan(hf)
+        except exc.InvalidConfig:
+            return
+        if plan.compact_axis.extent_bound is None or plan.ordered_axis is None:
+            return
+
+        for policy in resident_ordered_entries(plan):
+            arg = hf.params.arguments[policy.arg_name]
+            assert isinstance(arg, torch.Tensor)
+            for size in arg.shape[1:]:
+                if isinstance(size, torch.SymInt):
+                    env.specialized_vars.update(_symint_free_symbols(size))
 
     def max_reduction_threads(self) -> int | None:
         return None

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -26,6 +26,7 @@ import sympy
 import torch
 
 from .. import exc
+from .._utils import cdiv
 from .ast_extension import expr_from_string
 from .cute.attention_plan import ALIBI_BIAS_KIND
 from .cute.attention_plan import CAUSAL_MASK_KIND
@@ -2632,8 +2633,8 @@ class PallasBackend(Backend):
             and p.arg_name in name_to_index
         ]
         # The cached resident-cache decision drives every resident-window launcher
-        # arg: resident-window tensors, the exact physical window integer, and the
-        # ordered/compact offset args used by the overflow guard.
+        # arg. Shape-derived windows retain the eager overflow guard; a user-provided
+        # ordered extent is a caller contract and sizes the full window directly.
         decision = env.compact_worklist_resident_cache_decision
         ordered_indices: list[int] = []
         range_start_ref_pos = -1
@@ -2661,22 +2662,27 @@ class PallasBackend(Backend):
             ordered_indices = [
                 name_to_index[name] for name in decision.resident_operands
             ]
-            ordered_offset_arg_index = name_to_index.get(
-                decision.range_spec.ordered_offset_arg, -1
-            )
-            active_mask_arg_index = name_to_index.get(
-                decision.range_spec.compact_offset_arg, -1
-            )
             ordered_window = decision.physical_window
-            if (
-                range_start_ref_pos < 0
-                or ordered_offset_arg_index < 0
-                or active_mask_arg_index < 0
-            ):
+            if range_start_ref_pos < 0:
                 raise exc.InvalidConfig(
-                    "compact_worklist resident caching: active range metadata or "
-                    "offset args are missing from the kernel argument list."
+                    "compact_worklist resident caching: active range metadata is "
+                    "missing from the kernel argument list."
                 )
+            ordered_axis = plan.ordered_axis
+            assert ordered_axis is not None
+            if ordered_axis.extent_bound is None:
+                ordered_offset_arg_index = name_to_index.get(
+                    decision.range_spec.ordered_offset_arg, -1
+                )
+                active_mask_arg_index = name_to_index.get(
+                    decision.range_spec.compact_offset_arg, -1
+                )
+                if ordered_offset_arg_index < 0 or active_mask_arg_index < 0:
+                    raise exc.InvalidConfig(
+                        "compact_worklist resident caching: offset args needed by "
+                        "the shape-derived window guard are missing from the kernel "
+                        "argument list."
+                    )
         return [
             "_compact_build_worklist=_build_worklist",
             f"_compact_offset_arg_indices={offset_indices!r}",
@@ -2744,7 +2750,6 @@ class PallasBackend(Backend):
         env.compact_worklist_plan = None
         env.compact_worklist_resident_cache_decision = None
         env.compact_worklist_resident_prep_hoists = ()
-        env.compact_worklist_upper = 1
         env.compact_worklist_block = 1
         env.compact_worklist_ordered_block = 1
         env.compact_worklist_offset_params = []
@@ -2758,9 +2763,9 @@ class PallasBackend(Backend):
         Runs early (pre_codegen) so ``env.compact_worklist_plan`` is set when the
         grid strategy selects ``WorklistProgramIDs`` and the inner loop remaps its
         begin/end to metadata refs.  Registers the N metadata ref names as
-        ``wrapper_only_params`` (kernel-signature-only) and computes the static
-        megablocks ``UPPER``.  ``detect_*`` raises ``exc.InvalidConfig`` on a
-        non-matching kernel (autotuner-skippable).
+        ``wrapper_only_params`` (kernel-signature-only) and computes the
+        host/JAX-static megablocks ``UPPER`` expression. ``detect_*`` raises
+        ``exc.InvalidConfig`` on a non-matching kernel (autotuner-skippable).
         """
         from ..runtime import _get_vmem_limit_bytes
         from .compile_environment import CompileEnvironment
@@ -2773,7 +2778,11 @@ class PallasBackend(Backend):
         env = CompileEnvironment.current()
         host_fn = HostFunction.current()
         plan = detect_compact_worklist_plan(host_fn)
-        env.compact_worklist_plan = plan
+        if not env.settings.static_shapes and plan.compact_axis.extent_bound is None:
+            raise exc.InvalidConfig(
+                "compact_worklist with static_shapes=False requires "
+                "max_extent on the compact hl.tile loop."
+            )
 
         device_fn = DeviceFunction.current()
         for name in metadata_arg_names(plan):
@@ -2785,7 +2794,8 @@ class PallasBackend(Backend):
         # ordered block would undersize the worklist metadata).
         compact_block = env.block_sizes[plan.compact_axis.block_id].from_config(config)
         assert compact_block is not None, "compact tile has no block size"
-        env.compact_worklist_block = int(compact_block)
+        compact_block = int(compact_block)
+        env.compact_worklist_block = compact_block
         # Ordered (reduction) tile block -- resident caching uses this compile-side to
         # choose a block-aligned physical window (it can differ from the compact
         # block, e.g. compact_block != ordered_block).
@@ -2796,7 +2806,13 @@ class PallasBackend(Backend):
             )
             if ordered_block is not None:
                 env.compact_worklist_ordered_block = int(ordered_block)
-        env.compact_worklist_upper = self._compact_worklist_upper(plan, config, host_fn)
+        plan = dataclasses.replace(
+            plan,
+            upper_bound_expr=self._compact_worklist_upper_expr(
+                plan, compact_block, host_fn
+            ),
+        )
+        env.compact_worklist_plan = plan
 
         import jax.experimental.pallas.tpu as pltpu
 
@@ -2811,26 +2827,31 @@ class PallasBackend(Backend):
             host_fn.params.arguments,
             ordered_block=env.compact_worklist_ordered_block,
             vmem_bytes=vmem_bytes,
+            dynamic_shapes=not env.settings.static_shapes,
+            specialized_size_dims=env.specialized_size_dimensions(),
         )
         env.compact_worklist_resident_prep_hoists = admission.prep_hoists
         env.compact_worklist_resident_cache_decision = admission.decision
 
-    def _compact_worklist_upper(
-        self, plan: CompactWorklistPlan, config: Config, host_fn: HostFunction
-    ) -> int:
-        """Static UPPER: the padded length of the worklist metadata arrays.
+    def _compact_worklist_upper_expr(
+        self, plan: CompactWorklistPlan, block: int, host_fn: HostFunction
+    ) -> str:
+        """Host/JAX-static padded length of the worklist metadata arrays.
 
         Must be >= the worst-case ``num_work = sum_owners cdiv(length, BLOCK)``,
         else the dynamic Pallas grid indexes past the scalar-prefetch metadata
         (``jnp.repeat(total_repeat_length=UPPER)`` would silently truncate the
-        worklist).  Detection only accepts the packed-offsets idiom (store
-        safety), so owner ranges are contiguous/non-overlapping
-        (``sum(length) == total``) and the tight megablocks bound
-        ``cdiv(total, BLOCK) + num_owners - 1`` provably holds.  All terms are
-        concrete ints under ``static_shapes=True``.
+        worklist). A user extent bound gives the direct per-owner bound
+        ``num_owners * cdiv(max_extent, BLOCK)`` without observing the compact
+        tensor's dynamic leading dimension. Without a hint, retain the packed
+        static-shape fallback.
         """
         from ..runtime.compact_worklist import packed_upper_bound
-        from .compile_environment import CompileEnvironment
+
+        extent_bound = plan.compact_axis.extent_bound
+        if extent_bound is not None:
+            tiles_per_owner = cdiv(extent_bound, block)
+            return f"({plan.num_owners_expr}) * {tiles_per_owner}"
 
         params = dict(host_fn.params.arguments)
         # Owner count from the captured grid bound (e.g. offsets.shape[0] - 1).
@@ -2850,9 +2871,8 @@ class PallasBackend(Backend):
             p.arg_name for p in plan.tensor_policies if p.kind == "compact_aligned_load"
         )
         total = int(params[compact_arg].shape[0])
-        block = CompileEnvironment.current().compact_worklist_block
         # Single source of the tight megablocks bound (also unit-tested).
-        return packed_upper_bound(total, num_owners, block)
+        return str(packed_upper_bound(total, num_owners, block))
 
 
 def _detect_mma_loop(

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -294,11 +294,8 @@ class CompileEnvironment:
         # Optional prep-cache descriptors admitted for this concrete config.  Kept
         # separate from the correctness-bearing resident-window decision.
         self.compact_worklist_resident_prep_hoists: tuple[ResidentPrepHoist, ...] = ()
-        # Static megablocks upper bound (int) for the compact worklist grid /
-        # metadata, computed at pre_codegen from static shapes.
-        self.compact_worklist_upper: int = 1
         # Compact-axis tile block size (int), resolved from the config at
-        # pre_codegen; used by the worklist builder and UPPER (NOT max(block_sizes)).
+        # pre_codegen; used by the worklist builder (NOT max(block_sizes)).
         self.compact_worklist_block: int = 1
         # Ordered (reduction) tile block size.  May differ from the compact block
         # (e.g. compact_block != ordered_block); resident caching sizes its window to a
@@ -1017,6 +1014,20 @@ class CompileEnvironment:
         if _has_unbacked(size._sympy_()):
             return size
         return self.size_hint(size)
+
+    def specialized_size_dimensions(self) -> set[tuple[str, int]]:
+        """Return input dimensions guarded exactly in the BoundKernel cache key."""
+        result: set[tuple[str, int]] = set()
+        for symbol in self.specialized_vars:
+            for source in self.shape_env.var_to_sources.get(symbol, ()):
+                if (
+                    isinstance(source, TensorPropertySource)
+                    and source.prop == TensorProperty.SIZE
+                    and isinstance(source.base, LocalSource)
+                    and source.idx is not None
+                ):
+                    result.add((source.base.local_name, source.idx))
+        return result
 
     def size_hint(self, n: int | torch.SymInt) -> int:
         if isinstance(n, torch.SymInt):

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -1332,7 +1332,7 @@ def _maybe_emit_compact_worklist_builder(codegen: GenerateAST, config: Config) -
     source, offset_params = render_build_worklist(
         plan,
         block_expr=str(env.compact_worklist_block),
-        upper_expr=str(env.compact_worklist_upper),
+        upper_expr=plan.upper_bound_expr,
     )
     env.compact_worklist_offset_params = offset_params
     codegen.module_statements.append(statement_from_string(source))

--- a/helion/_compiler/kernel_compiler.py
+++ b/helion/_compiler/kernel_compiler.py
@@ -78,6 +78,7 @@ class KernelCompiler:
             self.propagate_types(hf)
             self.finalize_config()
             self.lower(hf)
+            self.register_specializations(hf)
         return hf
 
     def parse(
@@ -159,6 +160,11 @@ class KernelCompiler:
             factory_padding,
         ):
             hf.device_ir = lower_to_device_ir(hf)
+
+    def register_specializations(self, hf: HostFunction) -> None:
+        """Let the backend add cache-key guards discovered from device IR."""
+        with measure("HostFunction.register_specializations"):
+            self.backend.register_specializations(hf)
 
     @contextlib.contextmanager
     def _compilation_context(self) -> typing.Generator[None, None, None]:

--- a/helion/_compiler/pallas/compact_worklist.py
+++ b/helion/_compiler/pallas/compact_worklist.py
@@ -38,6 +38,7 @@ from ..ast_read_writes import ReadWrites
 from ..ast_read_writes import ast_rename
 
 if TYPE_CHECKING:
+    from collections.abc import AbstractSet
     from collections.abc import Iterable
     from collections.abc import Mapping
 
@@ -72,6 +73,8 @@ class Axis:
     # construction; resident caching uses it to prove the resident-window overflow
     # guard (``max(diff(T))``) can't under-count the range.
     packed_offset_arg: str | None = None
+    # Optional user-provided upper bound on this loop's per-owner extent.
+    extent_bound: int | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -109,7 +112,9 @@ class CompactWorklistPlan:
 
     axes: tuple[Axis, ...]  # owner_grid + compact_tile + optional ordered
     tensor_policies: tuple[TensorPolicy, ...]
-    upper_bound_expr: str  # static UPPER = cdiv(total, BLOCK) + owners - 1
+    # Host/JAX-static expression for the padded metadata length. With an extent
+    # bound this may depend on an input shape, which JAX resolves while tracing.
+    upper_bound_expr: str
     # jnp host expression for the owner count P (the grid size), e.g.
     # "offsets.shape[0] - 1" or "lo.shape[0]"; taken from the owner hl.grid
     # bound (NOT assumed to be base.shape[0] - 1, which only holds for the
@@ -402,16 +407,48 @@ class ResidentCacheAdmission:
     prep_hoists: tuple[ResidentPrepHoist, ...]
 
 
+def _inactive_resident_cache_admission(
+    resident_names: tuple[str, ...], reason: str
+) -> ResidentCacheAdmission:
+    return ResidentCacheAdmission(
+        ResidentCacheDecision(resident_names, None, 0, reason),
+        (),
+    )
+
+
 def _tensor_footprints(
     host_args: Mapping[str, object],
     arg_names: Iterable[str],
+    *,
+    leading_extent: int | None = None,
 ) -> list[tuple[tuple[int, ...], int]]:
     footprints: list[tuple[tuple[int, ...], int]] = []
     for arg_name in arg_names:
         arg = host_args[arg_name]
         assert isinstance(arg, torch.Tensor)
-        footprints.append((tuple(int(s) for s in arg.shape), arg.dtype.itemsize))
+        # A bound replaces the dynamic leading SymInt; admitted tail dims have
+        # exact-size guards in the BoundKernel cache key.
+        leading = leading_extent if leading_extent is not None else int(arg.shape[0])
+        shape = (leading, *(int(size) for size in arg.shape[1:]))
+        footprints.append((shape, arg.dtype.itemsize))
     return footprints
+
+
+def _unstable_tail_shape_args(
+    host_args: Mapping[str, object],
+    arg_names: Iterable[str],
+    specialized_size_dims: AbstractSet[tuple[str, int]],
+) -> tuple[str, ...]:
+    """Return operands whose footprint depends on an unspecialized tail dim."""
+    unstable: list[str] = []
+    for arg_name in arg_names:
+        arg = host_args[arg_name]
+        assert isinstance(arg, torch.Tensor)
+        if any(
+            (arg_name, dim) not in specialized_size_dims for dim in range(1, arg.ndim)
+        ):
+            unstable.append(arg_name)
+    return tuple(unstable)
 
 
 def build_resident_cache_admission(
@@ -421,24 +458,66 @@ def build_resident_cache_admission(
     *,
     ordered_block: int,
     vmem_bytes: int,
+    dynamic_shapes: bool = False,
+    specialized_size_dims: AbstractSet[tuple[str, int]] = frozenset(),
 ) -> ResidentCacheAdmission:
     """Admit resident caching and optional prep hoists for one concrete config.
 
     Backend setup supplies concrete config facts (host shapes, ordered block, VMEM
     budget). This helper owns the compact-worklist-specific policy: detect prep
     candidates, account for their scratch footprint, choose the one physical
-    resident window, and drop optional prep when it cannot fit.
+    resident window, and drop optional prep when it cannot fit. Dynamic kernels
+    supply ``specialized_size_dims`` so an admission cannot outlive the tail
+    dimensions used for its VMEM footprint; an unstable footprint falls back to
+    streaming.
     """
     from ...runtime import compact_ordered_physical_window
 
+    resident_names = tuple(policy.arg_name for policy in resident_ordered_entries(plan))
+    ordered_extent_bound = (
+        None if plan.ordered_axis is None else plan.ordered_axis.extent_bound
+    )
+    if (
+        plan.ordered_axis is not None
+        and ordered_extent_bound is None
+        and dynamic_shapes
+    ):
+        return _inactive_resident_cache_admission(
+            resident_names, "dynamic ordered extent has no max_extent"
+        )
+    unstable_residents = (
+        _unstable_tail_shape_args(host_args, resident_names, specialized_size_dims)
+        if dynamic_shapes
+        else ()
+    )
+    if unstable_residents:
+        return _inactive_resident_cache_admission(
+            resident_names,
+            f"dynamic resident tail shape: {unstable_residents}",
+        )
     resident_operands = _tensor_footprints(
         host_args,
-        tuple(policy.arg_name for policy in resident_ordered_entries(plan)),
+        resident_names,
+        leading_extent=ordered_extent_bound,
     )
     prep_hoists = detect_resident_prep_hoists(graphs, plan)
+    unstable_prep = (
+        _unstable_tail_shape_args(
+            host_args,
+            (hoist.host_arg for hoist in prep_hoists),
+            specialized_size_dims,
+        )
+        if dynamic_shapes
+        else ()
+    )
+    if unstable_prep:
+        prep_hoists = tuple(
+            hoist for hoist in prep_hoists if hoist.host_arg not in unstable_prep
+        )
     prep_operands = _tensor_footprints(
         host_args,
         tuple(hoist.host_arg for hoist in prep_hoists),
+        leading_extent=ordered_extent_bound,
     )
 
     physical_window_no_prep = compact_ordered_physical_window(
@@ -446,6 +525,7 @@ def build_resident_cache_admission(
         vmem_bytes,
         ordered_block,
         prep_operands=[],
+        max_extent=ordered_extent_bound,
     )
     physical_window = physical_window_no_prep
     admitted_hoists = prep_hoists
@@ -455,6 +535,7 @@ def build_resident_cache_admission(
             vmem_bytes,
             ordered_block,
             prep_operands=prep_operands,
+            max_extent=ordered_extent_bound,
         )
         if physical_window_with_prep > 0:
             physical_window = physical_window_with_prep
@@ -674,9 +755,9 @@ def render_build_worklist(
     calls the library :func:`flatten_worklist`; nothing is ``.item()``-ed, so
     the returned ``num_work`` stays a traced ``jax.Array``.
 
-    ``block_expr``/``upper_expr`` are host expressions (static ints at codegen);
-    they are textual so the caller can pass either literals (tests) or the
-    codegen block-size var / ``program_id.num_pids_expr``.
+    ``block_expr``/``upper_expr`` are textual host expressions. The block is a
+    codegen-time integer; the upper bound may also reference input shapes, which
+    are static while JAX traces the builder.
     """
     leak_ok = _bound_tensors(plan)
     subs = {plan.owner_axis.loop_var: owner_array}
@@ -881,11 +962,9 @@ def _packed_consecutive(begin: ast.AST, end: ast.AST, owner_var: str) -> bool:
     This is the packed-offsets idiom: owner ranges are contiguous and
     non-overlapping (``sum(length) == total``), so the tight megablocks UPPER
     bound ``cdiv(total, block) + owners - 1`` provably bounds ``num_work``.
-    Distinct begin/end tensors or non-consecutive indices may overlap or exceed
-    ``total``, so they must fall back to a conservative UPPER.
-
-    Conservatively returns ``False`` on anything it can't prove (the caller then
-    over-allocates metadata, which is safe; a too-small UPPER would not be).
+    Conservatively returns ``False`` on anything it cannot prove. Compact-axis
+    detection then rejects the kernel for store safety; an ordered axis remains
+    valid but is ineligible for resident caching.
     """
 
     def _same_ast(a: ast.AST, b: ast.AST) -> bool:
@@ -926,15 +1005,19 @@ def _packed_consecutive(begin: ast.AST, end: ast.AST, owner_var: str) -> bool:
     return b is not None and e is not None and e == b + 1
 
 
-def _block_id_of_loop(loop: ast.For) -> int | None:
-    """Best-effort block id from the loop iterator's attached type info."""
+def _tile_info_of_loop(loop: ast.For) -> tuple[int, int | None] | None:
+    """Return the block id and extent bound attached to a tile loop."""
     call = _loop_iter_call(loop)
     if call is None:
         return None
     type_info = getattr(call, "_type_info", None)
     inner = getattr(type_info, "inner", None)
     block_id = getattr(inner, "block_id", None)
-    return block_id if isinstance(block_id, int) else None
+    if not isinstance(block_id, int):
+        return None
+    extent_bound = getattr(inner, "extent_bound", None)
+    assert extent_bound is None or isinstance(extent_bound, int)
+    return block_id, extent_bound
 
 
 def _find_grid_loop(body: list[ast.stmt]) -> ast.For | None:
@@ -1216,11 +1299,12 @@ def detect_compact_worklist_plan(
     )
 
     owner_block_id = device_ir.grid_block_ids[0][0]
-    compact_block_id = _block_id_of_loop(compact_loop)
-    if compact_block_id is None:
+    compact_tile_info = _tile_info_of_loop(compact_loop)
+    if compact_tile_info is None:
         raise exc.InvalidConfig(
             "compact_worklist: could not resolve the compact tile block id."
         )
+    compact_block_id, compact_extent_bound = compact_tile_info
 
     axes: list[Axis] = [
         Axis(
@@ -1239,6 +1323,7 @@ def detect_compact_worklist_plan(
             length=_length_ast(c_begin, c_end),
             block_size_var="",  # filled at codegen from the config block size
             packed_offset_arg=compact_packed_arg,
+            extent_bound=compact_extent_bound,
         ),
     ]
 
@@ -1257,11 +1342,12 @@ def detect_compact_worklist_plan(
         }
         o_begin = _inline(_to_plain(ordered_call.args[0]), ordered_prologue)
         o_end = _inline(_to_plain(ordered_call.args[1]), ordered_prologue)
-        ordered_block_id = _block_id_of_loop(ordered_loop)
-        if ordered_block_id is None:
+        ordered_tile_info = _tile_info_of_loop(ordered_loop)
+        if ordered_tile_info is None:
             raise exc.InvalidConfig(
                 "compact_worklist: could not resolve the ordered tile block id."
             )
+        ordered_block_id, ordered_extent_bound = ordered_tile_info
         # Resident caching needs a bound whose consecutive diffs are EXACTLY the
         # per-source length; prove the packed-consecutive idiom (base=T[g],
         # end=T[g+1] on one Name tensor).  A bound like ``T[g+1]+128`` reads only
@@ -1282,6 +1368,7 @@ def detect_compact_worklist_plan(
                 length=_length_ast(o_begin, o_end),
                 block_size_var="",
                 packed_offset_arg=ordered_packed_arg,
+                extent_bound=ordered_extent_bound,
             )
         )
 

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -645,9 +645,8 @@ class WorklistProgramIDs(ProgramIDs):
     ``codegen`` emits ``_wid = pl.program_id(0)`` and recovers the owner
     coordinate from the ``owner_ids`` scalar-prefetch ref (``work_<owner>_ref[
     _wid]``) so owner-indexed tensors slice the right owner; ``codegen_grid``
-    renders the **static** ``UPPER`` (megablocks bound) as the host grid
-    positional, while the compact launcher overrides it with the traced
-    ``num_work``.
+    renders the host-computable ``UPPER`` (megablocks bound) as the grid
+    positional, while the compact launcher overrides it with traced ``num_work``.
     """
 
     upper_expr: str = "1"

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -2461,7 +2461,9 @@ class BlockSizeTileStrategy(TileStrategy):
             # Compact worklist: the owner hl.grid becomes the work-item grid.
             from .program_id import WorklistProgramIDs
 
-            return WorklistProgramIDs(upper_expr=str(env.compact_worklist_upper))
+            return WorklistProgramIDs(
+                upper_expr=env.compact_worklist_plan.upper_bound_expr
+            )
         backend_name = env.backend.name
         pid_type = self.fn.config.pid_type
         if pid_type == "xyz":

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -1069,13 +1069,17 @@ def _detect_outer_block_bound(
 
 class TileIndexType(TypeInfo):
     block_id: int
+    extent_bound: int | None
 
     def __str__(self) -> str:
         return f"{type(self).__name__}({self.block_id})"
 
-    def __init__(self, origin: Origin, block_id: int) -> None:
+    def __init__(
+        self, origin: Origin, block_id: int, extent_bound: int | None = None
+    ) -> None:
         super().__init__(origin)
         self.block_id = block_id
+        self.extent_bound = extent_bound
 
     def proxy(self) -> object:
         with proxy_tensor.disable_proxy_modes_tracing():
@@ -1094,6 +1098,7 @@ class TileIndexType(TypeInfo):
         numel: int | torch.SymInt | AutoSize | None,
         origin: Origin,
         block_size: int | torch.SymInt | None = None,
+        extent_bound: int | None = None,
     ) -> TileIndexType:
         env = CompileEnvironment.current()
         if block_size is None:
@@ -1132,14 +1137,19 @@ class TileIndexType(TypeInfo):
                 numel,
                 source=FixedBlockSizeSource(block_size),
             )
-        return TileIndexType(origin, block_id)
+        return TileIndexType(origin, block_id, extent_bound)
 
     def merge(self, other: TypeInfo, var_name: str | None = None) -> TypeInfo:
         if isinstance(other, TileIndexType):
-            if self.block_id == other.block_id:
+            if (
+                self.block_id == other.block_id
+                and self.extent_bound == other.extent_bound
+            ):
                 return self
             raise exc.TypeInferenceError(
-                f"TileIndexType mismatch in control flow: {self.block_id} and {other.block_id}"
+                f"TileIndexType mismatch in control flow: "
+                f"{self.block_id}/{self.extent_bound} and "
+                f"{other.block_id}/{other.extent_bound}"
             )
         return super().merge(other, var_name=var_name)
 

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -2511,6 +2511,18 @@ def _check_dma_alignment(vmem_shape: tuple[int, ...]) -> bool:
     return True
 
 
+def _guarded_static_size(
+    size: int | torch.SymInt, env: CompileEnvironment
+) -> int | None:
+    """Resolve a size only when its symbols are exact BoundKernel guards."""
+    if isinstance(size, int):
+        return size
+    expr = env.specialize_expr(size._sympy_())
+    if expr.free_symbols:
+        return None
+    return int(expr)
+
+
 def _is_supported_contiguous_row_slab_dma(
     fake: torch.Tensor,
     sub_meta: list[object],
@@ -2568,12 +2580,12 @@ def _is_supported_contiguous_row_slab_dma(
             return False
         if dim_idx in dim_to_bid:
             return False
-        dim_size = fake.shape[dim_idx]
-        if not isinstance(dim_size, int) or vmem_shape[dim_idx] != dim_size:
+        dim_size = _guarded_static_size(fake.shape[dim_idx], env)
+        if dim_size is None or vmem_shape[dim_idx] != dim_size:
             return False
 
-    lane_dim = fake.shape[-1]
-    return isinstance(lane_dim, int) and lane_dim % 128 == 0
+    lane_dim = _guarded_static_size(fake.shape[-1], env)
+    return lane_dim is not None and lane_dim % 128 == 0
 
 
 def _can_stream_inner_tile(

--- a/helion/language/constexpr.py
+++ b/helion/language/constexpr.py
@@ -86,55 +86,49 @@ def specialize(value: _T) -> _T:
     raise exc.NotInsideKernel
 
 
-@_decorators.type_propagation(specialize)
-def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
+def _record_specialized_symint(symint: torch.SymInt) -> None:
+    """Record guards for a symbolic host value specialized by an API."""
     from .._compiler.compile_environment import CompileEnvironment
     from .._compiler.compile_environment import _symint_free_symbols
 
+    env = CompileEnvironment.current()
+    syms = _symint_free_symbols(symint)
+    env.specialized_vars.update(syms)
+    for sym in syms:
+        # pyrefly: ignore [no-matching-overload]
+        for source in env.shape_env.var_to_sources.get(sym, []):
+            if (
+                isinstance(source, TensorPropertySource)
+                and source.prop == TensorProperty.STRIDE
+                and isinstance(source.base, LocalSource)
+                and source.idx is not None
+            ):
+                env.specialized_strides.add((source.base.local_name, source.idx))
+
+
+def _specialize_proxy(value: _T) -> _T:
+    """Specialize a host value and record the symbols that require guards."""
+
+    def handle_symint(symint: torch.SymInt) -> int:
+        _record_specialized_symint(symint)
+        return symint.__int__()
+
+    return _convert_specializable(value, on_symint=handle_symint)
+
+
+@_decorators.type_propagation(specialize)
+def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
     if origin.is_device():
         raise exc.SpecializeOnDevice
 
-    proxy = value.proxy()
-    env = CompileEnvironment.current()
-
-    def handle_symint(symint: torch.SymInt) -> int:
-        syms = _symint_free_symbols(symint)
-        env.specialized_vars.update(syms)
-        # Track stride specializations
-        for sym in syms:
-            for source in env.shape_env.var_to_sources.get(sym, []):
-                if (
-                    isinstance(source, TensorPropertySource)
-                    and source.prop == TensorProperty.STRIDE
-                    and isinstance(source.base, LocalSource)
-                    and source.idx is not None
-                ):
-                    env.specialized_strides.add((source.base.local_name, source.idx))
-        return symint.__int__()
-
-    _convert_specializable(proxy, on_symint=handle_symint)
+    _specialize_proxy(value.proxy())
     return value
 
 
 @_decorators.register_fake(specialize)
 def _(value: _T) -> _T:
-    from .._compiler.compile_environment import CompileEnvironment
-    from .._compiler.compile_environment import _symint_free_symbols
-
-    env = CompileEnvironment.current()
-
     def handle_symint(symint: torch.SymInt) -> torch.SymInt:
-        syms = _symint_free_symbols(symint)
-        env.specialized_vars.update(syms)
-        for sym in syms:
-            for source in env.shape_env.var_to_sources.get(sym, []):
-                if (
-                    isinstance(source, TensorPropertySource)
-                    and source.prop == TensorProperty.STRIDE
-                    and isinstance(source.base, LocalSource)
-                    and source.idx is not None
-                ):
-                    env.specialized_strides.add((source.base.local_name, source.idx))
+        _record_specialized_symint(symint)
         return symint
 
     return _convert_specializable(value, on_symint=handle_symint)

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -124,11 +124,6 @@ def tile(
                     is specialized automatically, so changing the bound may compile a
                     new kernel. For multidimensional tiles, provide one bound per
                     dimension. The caller must ensure runtime extents do not exceed it.
-                    This bounds generated loop state; it does not make JAX array shapes
-                    polymorphic. Reusing one JAX executable across logical lengths
-                    requires caller-managed fixed-capacity arrays and runtime offsets.
-                    When calling ``Kernel.jax_fn`` through ``jax.jit``, the bound's
-                    position must be listed in ``static_argnums``.
 
     Returns:
         Iterator[Tile] or Iterator[Sequence[Tile]]: Iterator over tile objects

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -66,6 +66,8 @@ def tile(
     end_or_none: int | torch.Tensor | None = None,
     /,
     block_size: object = None,
+    *,
+    max_extent: int | Sequence[int] | None = None,
 ) -> Iterator[Tile]: ...
 
 
@@ -78,6 +80,8 @@ def tile(
     end_or_none: Sequence[int | torch.Tensor] | None = None,
     /,
     block_size: object = None,
+    *,
+    max_extent: int | Sequence[int] | None = None,
 ) -> Iterator[Sequence[Tile]]: ...
 
 
@@ -89,6 +93,8 @@ def tile(
     end_or_none: int | torch.Tensor | Sequence[int | torch.Tensor] | None = None,
     /,
     block_size: object = None,
+    *,
+    max_extent: int | Sequence[int] | None = None,
 ) -> Iterator[Tile] | Iterator[Sequence[Tile]]:
     """
     Break up an iteration space defined by a size or sequence of sizes into tiles.
@@ -114,6 +120,15 @@ def tile(
                       Otherwise, the end of iteration space.
         end_or_none: If 2+ positional args provided, the end of iteration space.
         block_size: Fixed block size (overrides autotuning) or None for autotuned size
+        max_extent: Hard upper bound on the iteration-space extent. A dynamic integer
+                    is specialized automatically, so changing the bound may compile a
+                    new kernel. For multidimensional tiles, provide one bound per
+                    dimension. The caller must ensure runtime extents do not exceed it.
+                    This bounds generated loop state; it does not make JAX array shapes
+                    polymorphic. Reusing one JAX executable across logical lengths
+                    requires caller-managed fixed-capacity arrays and runtime offsets.
+                    When calling ``Kernel.jax_fn`` through ``jax.jit``, the bound's
+                    position must be listed in ``static_argnums``.
 
     Returns:
         Iterator[Tile] or Iterator[Sequence[Tile]]: Iterator over tile objects
@@ -242,6 +257,34 @@ def _check_matching(a: object, b: object) -> None:
         )
 
 
+def _specialize_one_max_extent(value: object) -> int:
+    """Normalize one tile extent bound to a compile-time integer."""
+    from .constexpr import _specialize_proxy
+
+    try:
+        specialized = _specialize_proxy(value)
+    except exc.SpecializeArgType:
+        specialized = value
+    if type(specialized) is not int:
+        raise exc.TypeInferenceError(
+            "hl.tile() max_extent must be a compile-time integer or a sequence of "
+            f"integers, got {type(value).__name__}"
+        )
+    if specialized < 0:
+        raise exc.TypeInferenceError(
+            f"hl.tile() max_extent must be non-negative, got {specialized}"
+        )
+    return specialized
+
+
+def _specialize_max_extent(value: object) -> int | list[int] | tuple[int, ...]:
+    """Normalize a tile extent bound to compile-time integer values."""
+    if isinstance(value, (list, tuple)):
+        bounds = [_specialize_one_max_extent(item) for item in value]
+        return type(value)(bounds)
+    return _specialize_one_max_extent(value)
+
+
 def _allow_static_range(begin: object, end: object, step: object) -> bool:
     """
     Only enable tl.stagic_range when:
@@ -296,6 +339,7 @@ def _(
     /,
     block_size: TypeInfo | None = None,
     *,
+    max_extent: TypeInfo | None = None,
     origin: Origin,
 ) -> TypeInfo:
     parent = ExtendedAST.current()[-2]
@@ -310,6 +354,11 @@ def _(
         _check_matching(proxy_end, proxy_block_size)
     else:
         proxy_block_size = begin.tree_map(lambda n: None)
+    if _not_none(max_extent):
+        proxy_max_extent = _specialize_max_extent(_to_proxy(max_extent))
+        _check_matching(proxy_end, proxy_max_extent)
+    else:
+        proxy_max_extent = begin.tree_map(lambda n: None)
 
     if unpack := not isinstance(proxy_end, (list, tuple)):
         begin_list: list[int | torch.SymInt | torch.Tensor] = [
@@ -321,12 +370,14 @@ def _(
         block_size_list: list[int | torch.SymInt | torch.Tensor | None] = [
             cast("int | torch.SymInt | torch.Tensor | None", proxy_block_size)
         ]
+        max_extent_list: list[int | None] = [cast("int | None", proxy_max_extent)]
     else:
         begin_list = cast("list[int | torch.SymInt | torch.Tensor]", proxy_begin)
         end_list = cast("list[int | torch.SymInt | torch.Tensor]", proxy_end)
         block_size_list = cast(
             "list[int | torch.SymInt | torch.Tensor | None]", proxy_block_size
         )
+        max_extent_list = list(cast("list[int] | tuple[int, ...]", proxy_max_extent))
     block_size_list = Tile._tiles_to_sizes(block_size_list)
 
     # pyrefly: ignore [unbound-name]
@@ -338,10 +389,11 @@ def _(
     results = []
     has_data_dependent_bounds = False
     has_symbolic_bounds = False
-    for begin_part, end_part, bs in zip(
+    for begin_part, end_part, bs, extent_bound in zip(
         begin_list,
         end_list,
         block_size_list,
+        max_extent_list,
         strict=True,
     ):
         if isinstance(begin_part, Tile) or isinstance(end_part, Tile):
@@ -349,22 +401,38 @@ def _(
         size = end_part - begin_part  # type: ignore[operator]
         if isinstance(size, int) and size < 0:
             raise exc.InvalidTileRange(begin_part, end_part)
+        if isinstance(size, int) and extent_bound is not None and size > extent_bound:
+            raise exc.TypeInferenceError(
+                f"hl.tile() range extent {size} exceeds max_extent {extent_bound}"
+            )
         if isinstance(size, torch.Tensor):
             size = None  # data dependent size
             has_data_dependent_bounds = True
         if isinstance(begin_part, torch.SymInt) or isinstance(end_part, torch.SymInt):
             has_symbolic_bounds = True
         if bs is None:
-            results.append(TileIndexType.allocate(size, origin))
+            results.append(
+                TileIndexType.allocate(size, origin, extent_bound=extent_bound)
+            )
         elif isinstance(bs, int):
-            results.append(TileIndexType.allocate(size, origin, bs))
+            results.append(
+                TileIndexType.allocate(size, origin, bs, extent_bound=extent_bound)
+            )
         elif isinstance(bs, torch.SymInt):
             env = CompileEnvironment.current()
             index = env.get_block_id(bs)
             if index is None:
-                results.append(TileIndexType.allocate(size, origin, bs))
+                results.append(
+                    TileIndexType.allocate(size, origin, bs, extent_bound=extent_bound)
+                )
             else:
-                results.append(TileIndexType(origin=origin, block_id=index))
+                results.append(
+                    TileIndexType(
+                        origin=origin,
+                        block_id=index,
+                        extent_bound=extent_bound,
+                    )
+                )
                 env.block_sizes[index].mark_alternate_size(size)
 
     _add_config_choices(
@@ -535,6 +603,7 @@ def _(
     begin_or_end: int | torch.Tensor | list[int | torch.Tensor],
     end_or_none: int | torch.Tensor | list[int | torch.Tensor] | None = None,
     block_size: int | torch.Tensor | list[int | torch.Tensor] | None = None,
+    max_extent: int | Sequence[int] | None = None,
 ) -> Iterator[RefTile | tuple[RefTile, ...]]:
     begin, end = _normalize_begin_end_ref(begin_or_end, end_or_none)
     scalar_input = not isinstance(begin, list) and not isinstance(end, list)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -25,6 +25,7 @@ from .._compat import get_num_xcd as get_num_xcd
 from .._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
+from .._utils import cdiv
 from .._utils import triton_is_available
 from .config import Config as Config
 from .kernel import Kernel as Kernel
@@ -335,6 +336,7 @@ def compact_ordered_physical_window(
     ordered_block: int,
     *,
     prep_operands: list[tuple[tuple[int, ...], int]],
+    max_extent: int | None = None,
 ) -> int:
     """Block-aligned physical resident window that fits the VMEM budget.
 
@@ -343,9 +345,11 @@ def compact_ordered_physical_window(
     window, optional prep-cache scratch, and the refill/reduction ``pl.ds`` slices
     are all tiled by the ordered block, so the allocation must be a block multiple.
     Round the budget DOWN to a block multiple so the allocation never exceeds the
-    VMEM budget; cap by the operand extent rounded UP to one block so short tensors
-    still get a legal ``pl.Element(block, padding=...)`` window instead of a
-    zero-sized allocation.
+    VMEM budget. With ``max_extent``, admit caching only if its full block-rounded
+    extent fits; this makes the resident window valid for every shape covered by
+    the user's bound. Without it, retain the shape-derived behavior and cap by the
+    operand extent rounded UP to one block so short tensors still get a legal
+    ``pl.Element(block, padding=...)`` window.
 
     Returns 0 when the budget cannot hold one ordered block.  Resident caching is
     an automatic optimization, so the compiler treats that as "inactive" and
@@ -360,8 +364,11 @@ def compact_ordered_physical_window(
     budget_physical = (budget_capacity // block) * block
     if budget_physical <= 0:
         return 0
+    if max_extent is not None:
+        extent_physical = cdiv(max_extent, block) * block
+        return extent_physical if extent_physical <= budget_physical else 0
     min_leading = min(max(1, int(shape[0])) for shape, _itemsize in operands)
-    extent_physical = ((min_leading + block - 1) // block) * block
+    extent_physical = cdiv(min_leading, block) * block
     return min(budget_physical, extent_physical)
 
 
@@ -386,10 +393,9 @@ def _compact_raise_if_range_exceeds_window(
     lengths, so sources with no compact work are ignored because they produce no
     worklist item and never refill the cache.
 
-    Best-effort magnitude: reached with materialized offsets only on the
-    concrete/eager (torch) launch path; under ``jax.jit`` the offsets are tracers
-    and the caller guarantees the bound (a future change that sizes the window from
-    a caller-provided max per-source length would remove this caveat).
+    This host check is only used by concrete/eager legacy shape-derived windows.
+    Bounded windows are safe by construction and skip it; under ``jax.jit``, the
+    legacy no-hint path retains the caller-guaranteed window contract.
     """
     if not ordered_aligned_arg_indices:
         return  # resident caching inactive (no resident window) -> nothing to guard
@@ -1775,6 +1781,20 @@ def _pallas_compile_jit_fn(
 _PALLAS_CACHE_ATTR = "_pallas_cache"
 
 
+def _pallas_compact_cache_key(
+    grid: tuple[int, ...], args: tuple[object, ...]
+) -> tuple[object, ...]:
+    """Shape-specific cache key for a compact-worklist Pallas callable."""
+    return (
+        grid,
+        tuple(
+            (tuple(arg.shape), arg.dtype)
+            for arg in args
+            if isinstance(arg, torch.Tensor)
+        ),
+    )
+
+
 def _pallas_install_launcher_cache(
     pallas_kernel: object,
     grid: tuple[int, ...],
@@ -1871,7 +1891,7 @@ def _pallas_invoke_cached_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None,
 ) -> object:
     """Shared fast-invoke tail: lift direct-call snapshot, ds-pad, dispatch."""
-    _grid = cache[0]
+    _cache_key = cache[0]
     jax_callable = cache[1]
     tensor_arg_indices = cast("list[int]", cache[2])
     arg_to_tensor_pos = cast("dict[int, int]", cache[3])
@@ -1882,7 +1902,7 @@ def _pallas_invoke_cached_launcher(
         direct_call = getattr(jax_callable, "_helion_direct_call", None)
         if direct_call is not None:
             cache = (
-                _grid,
+                _cache_key,
                 jax_callable,
                 tensor_arg_indices,
                 arg_to_tensor_pos,
@@ -1925,8 +1945,9 @@ def default_pallas_launcher(
     _compact_aligned_arg_indices: list[int] | None = None,
     _compact_tile_start_ref_pos: int = 1,
     _compact_block: int = 1,
-    # Resident-cache (owner-cache) params: the backstop below reads all of them
-    # every call; the three compile-relevant ones are threaded to the install path.
+    # Resident-cache (owner-cache) params. The legacy shape-derived-window
+    # backstop reads the offset indices; the compile-relevant values are also
+    # threaded to the install path.
     _compact_ordered_aligned_arg_indices: list[int] | None = None,
     _compact_range_start_ref_pos: int = -1,
     _compact_ordered_offset_arg_index: int = -1,
@@ -1957,12 +1978,10 @@ def default_pallas_launcher(
     are excluded from pallas_call inputs to save VMEM.  Their results are
     returned as torch tensors.
     """
-    if _compact_build_worklist is not None:
-        # Resident-cache correctness backstop: runs EVERY call (the offset arrays are
-        # runtime data even when the compiled kernel is cached for this grid), raising
-        # rather than silently over-reading the resident window when a source's ordered
-        # reduction length exceeds the compile-time window C.  No-ops when resident
-        # caching is inactive (empty _compact_ordered_aligned_arg_indices).
+    if _compact_build_worklist is not None and _compact_ordered_offset_arg_index >= 0:
+        # Shape-derived resident windows retain the legacy eager correctness
+        # backstop. A bounded ordered loop leaves the offset index at -1 because
+        # max_extent is the caller contract and sizes the full window directly.
         _compact_raise_if_range_exceeds_window(
             args,
             _compact_ordered_aligned_arg_indices,
@@ -1970,8 +1989,13 @@ def default_pallas_launcher(
             _compact_active_mask_arg_index,
             _compact_ordered_window,
         )
+    cache_key: tuple[object, ...] = (
+        _pallas_compact_cache_key(grid, args)
+        if _compact_build_worklist is not None
+        else grid
+    )
     cache = getattr(pallas_kernel, _PALLAS_CACHE_ATTR, None)
-    if cache is None or cache[0] != grid:
+    if cache is None or cache[0] != cache_key:
         if _compact_build_worklist is not None:
             cache = _pallas_install_compact_launcher_cache(
                 pallas_kernel,
@@ -2439,7 +2463,7 @@ def _pallas_install_compact_launcher_cache(
         _ds_pad_dims,
     )
     cache = (
-        grid,
+        _pallas_compact_cache_key(grid, args),
         jax_callable,
         result.tensor_arg_indices,
         result.arg_to_tensor_pos,

--- a/helion/runtime/compact_worklist.py
+++ b/helion/runtime/compact_worklist.py
@@ -8,9 +8,9 @@ per-owner ``base``/``length`` (and optional dependent ``dep_base``/``dep_len``)
 arrays as ``jnp`` expressions, then calls :func:`flatten_worklist` here to turn
 the ragged owner x tile product into a flat, padded worklist.  Everything runs
 inside the launcher's internal ``jax.jit`` with **nothing ``.item()``-ed**, so
-there is no device->host sync and no per-shape recompile: ``num_work`` is a
-traced ``jax.Array`` fed straight into ``grid=(num_work,)``; ``UPPER`` is the
-only (static, shape-derived) Python int.
+there is no device->host sync: ``num_work`` is a traced ``jax.Array`` fed
+straight into ``grid=(num_work,)``; ``UPPER`` is static during JAX tracing and
+may be derived from input shapes plus a user-provided tile extent bound.
 
 The padding scheme mirrors tokamax's ``gmm`` (``jnp.repeat(...,
 total_repeat_length=UPPER)`` + ``num_work = cnt.sum()`` fed to ``grid=``): the
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import NamedTuple
+
+from .._utils import cdiv
 
 if TYPE_CHECKING:
     from jax import Array
@@ -64,10 +66,11 @@ def packed_upper_bound(total_compact: int, num_owners: int, block: int) -> int:
     shapes, so this is a static Python int and no per-owner max length is needed.
 
     For general (possibly-overlapping) ranges this bound can UNDER-count
-    ``num_work``; the backend uses a conservative ``num_owners * cdiv(total,
-    block)`` instead (see ``backend._compact_worklist_upper``).
+    ``num_work``. A per-owner ``max_extent`` instead gives the conservative
+    ``num_owners * cdiv(max_extent, block)`` bound; without one, compact-worklist
+    detection requires packed ranges before using this helper.
     """
-    return -(-total_compact // block) + num_owners - 1
+    return cdiv(total_compact, block) + num_owners - 1
 
 
 def flatten_worklist(

--- a/helion/runtime/pallas_jax_export.py
+++ b/helion/runtime/pallas_jax_export.py
@@ -318,11 +318,12 @@ def default_pallas_jax_launcher(
         # window IS applied, but the host overflow guard
         # (runtime._compact_raise_if_range_exceeds_window) is NOT run here -- the
         # offsets are jit tracers, so a per-source reduction length exceeding the
-        # window size C cannot be checked at trace time.  Contract: the caller
-        # must ensure every ordered (reduction) range <= C (VMEM-derived,
-        # thousands of tokens; the torch/eager launcher does enforce this).
-        # Sizing C from a caller-provided max bound would make the window
-        # overflow-proof by construction.
+        # window size C cannot be checked at trace time. Contract: the caller must
+        # ensure every ordered (reduction) range <= C. When the ordered hl.tile
+        # supplies max_extent, admission sizes C to the full bound or disables
+        # resident caching. The static no-hint path retains the legacy VMEM-derived
+        # C contract; its eager launcher validates offsets, but JAX tracers cannot
+        # be checked at trace time.
         from . import _pallas_compile_compact_jit_fn
 
         result = _pallas_compile_compact_jit_fn(

--- a/test/test_pallas_compact_worklist.py
+++ b/test/test_pallas_compact_worklist.py
@@ -730,11 +730,10 @@ class TestDetectAndGating(unittest.TestCase):
         self.assertIsInstance(max_seq_len, torch.SymInt)
         self.assertTrue(bk.env.specialized_vars)
 
-    def test_no_hint_keeps_extent_bounds_absent(self):
-        plan = self._fully_jagged_plan()
-        self.assertIsNone(plan.compact_axis.extent_bound)
-        self.assertIsNotNone(plan.ordered_axis)
-        self.assertIsNone(plan.ordered_axis.extent_bound)
+        # Without a hint, both axes keep extent_bound absent.
+        no_hint = self._fully_jagged_plan()
+        self.assertIsNone(no_hint.compact_axis.extent_bound)
+        self.assertIsNone(no_hint.ordered_axis.extent_bound)
 
     def test_dynamic_shapes_require_compact_extent_bound(self):
         qo = _offsets([10, 23, 7, 40])
@@ -1463,50 +1462,6 @@ class TestCompactWorklistNumerics(unittest.TestCase):
             torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
         self.assertEqual(len(kernel._bound_kernels), 1)
 
-    def test_bounded_dense_kv_reuses_fixed_capacity_compilation(self):
-        import helion.runtime as helion_runtime
-
-        B, H, KV, D, block, max_seq_len = 4, 2, 16, 16, 16, 64
-        capacity = B * max_seq_len
-        kernel = helion.kernel(
-            _bounded_dense_kv_kernel.fn,
-            backend="pallas",
-            static_shapes=False,
-            config=helion.Config(
-                block_sizes=[block], pallas_loop_type="compact_worklist"
-            ),
-        )
-
-        def make_case(lengths, seed):
-            qo = _offsets(lengths)
-            torch.manual_seed(seed)
-            q = torch.randn(capacity, H, D, device=DEVICE, dtype=torch.bfloat16)
-            k = torch.randn(B, KV, H, D, device=DEVICE, dtype=torch.bfloat16)
-            v = torch.randn(B, KV, H, D, device=DEVICE, dtype=torch.bfloat16)
-            args = (max_seq_len, q, k, v, qo.to(DEVICE))
-            return args, _eager_dense_kv(q.cpu(), k.cpu(), v.cpu(), qo), int(qo[-1])
-
-        cases = (
-            make_case([10, 23, 7, 40], 0),
-            make_case([5, 12, 3, 20], 1),
-        )
-        with patch.object(
-            helion_runtime,
-            "_pallas_install_compact_launcher_cache",
-            wraps=helion_runtime._pallas_install_compact_launcher_cache,
-        ) as install:
-            for args, ref, active_tokens in (*cases, cases[0]):
-                out = kernel(*args)
-                self.assertEqual(tuple(out.shape), (capacity, H, D))
-                torch.testing.assert_close(
-                    out[:active_tokens].cpu(),
-                    ref[:active_tokens],
-                    rtol=2e-2,
-                    atol=2e-2,
-                )
-        self.assertEqual(install.call_count, 1)
-        self.assertEqual(len(kernel._bound_kernels), 1)
-
     def _check_dynamic_ordered_matches_eager(self, kernel):
         H, D, block, max_seq_len = 4, 128, 8, 64
         offsets = _offsets([12, 20, 5, 30])
@@ -1848,29 +1803,15 @@ class TestOrderedWindowBudget(unittest.TestCase):
             0,
         )
 
-    def test_max_extent_sizes_the_full_window(self):
+    def test_max_extent_window_sizing(self):
         operands = [((1_000_000, 4, 128), 2)]
+        # max_extent rounds up to the ordered-block multiple: cdiv(257, 128) * 128.
         self.assertEqual(
-            self._physical(
-                operands,
-                128,
-                prep_operands=[],
-                max_extent=257,
-            ),
-            384,
+            self._physical(operands, 128, prep_operands=[], max_extent=257), 384
         )
-
-    def test_max_extent_over_budget_disables_resident_cache(self):
-        operands = [((1_000_000, 4, 128), 2)]
+        # ...unless VMEM cannot hold it, in which case resident caching disables.
         self.assertEqual(
-            self._physical(
-                operands,
-                128,
-                vmem=1024,
-                prep_operands=[],
-                max_extent=257,
-            ),
-            0,
+            self._physical(operands, 128, vmem=1024, prep_operands=[], max_extent=257), 0
         )
 
     def test_dtype_scales_window(self):
@@ -2161,55 +2102,6 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         self.assertIn("_compact_ordered_offset_arg_index=-1", code)
         self.assertIn("_compact_active_mask_arg_index=-1", code)
 
-    def test_dynamic_resident_tail_shape_adds_cache_guard(self):
-        offsets = _offsets([12, 20, 5, 30])
-        total = int(offsets[-1])
-        _bounded_noprep_ordered_kernel.reset()
-
-        def args(heads, width):
-            return (
-                64,
-                torch.randn(total, heads, width),
-                torch.randn(total, heads, width),
-                offsets,
-            )
-
-        small_args = args(2, 8)
-        small_bound = _bounded_noprep_ordered_kernel.bind(small_args)
-        self.assertTrue(
-            {("k", 1), ("k", 2)}.issubset(small_bound.env.specialized_size_dimensions())
-        )
-        k_only_tail_change = (
-            small_args[0],
-            small_args[1],
-            torch.randn(total, 4, 8),
-            small_args[3],
-        )
-        self.assertEqual(
-            _bounded_noprep_ordered_kernel._base_specialization_key(small_args),
-            _bounded_noprep_ordered_kernel._base_specialization_key(k_only_tail_change),
-        )
-        self.assertNotEqual(
-            _bounded_noprep_ordered_kernel.specialization_key(small_args),
-            _bounded_noprep_ordered_kernel.specialization_key(k_only_tail_change),
-        )
-        for block_sizes in ([8, 8], [16, 8]):
-            code = small_bound.to_triton_code(
-                helion.Config(
-                    block_sizes=block_sizes,
-                    pallas_loop_type="compact_worklist",
-                )
-            )
-            self.assertNotIn("_compact_ordered_aligned_arg_indices=[]", code)
-            self.assertNotIn("_compact_ordered_window=0", code)
-
-        # The resident footprint changed, so the exact tail guards select a new
-        # BoundKernel while leading token-count changes still reuse one.
-        self.assertIsNot(
-            small_bound,
-            _bounded_noprep_ordered_kernel.bind(args(4, 16)),
-        )
-
     def test_bounded_self_attention_auto_specializes_kv_resident_tails(self):
         _bounded_fully_jagged_kernel.reset()
         offsets = _offsets([12, 20, 5, 30])
@@ -2254,41 +2146,36 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         )
         self.assertIs(bound, rebound)
 
-    def test_extent_bound_over_vmem_budget_streams_ordered_loop(self):
+    def test_ordered_loop_streams_when_resident_cache_unavailable(self):
         qo = _offsets([12, 20, 5, 30])
         lq = int(qo[-1])
-        args = (
-            1_000_000,
-            torch.randn(lq, 4, 128),
-            torch.randn(lq, 4, 128),
-            qo,
-        )
-        code = _bounded_noprep_ordered_kernel.bind(args).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
-        )
-        self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
-        self.assertIn("_compact_ordered_window=0", code)
-        self.assertIn("pltpu.emit_pipeline(", code)
-        self.assertIn("pipeline_mode=pl.Buffered", code)
-        self.assertIn("_hbm_arg_indices=", code)
-
-    def test_dynamic_unbounded_ordered_loop_streams(self):
-        qo = _offsets([12, 20, 5, 30])
-        total = int(qo[-1])
-        args = (
-            64,
-            torch.randn(total, 4, 128),
-            torch.randn(total, 4, 128),
-            qo,
-        )
-        code = _compact_bounded_only_ordered_kernel.bind(args).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
-        )
-        self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
-        self.assertIn("_compact_ordered_window=0", code)
-        self.assertIn("pltpu.emit_pipeline(", code)
-        self.assertIn("pipeline_mode=pl.Buffered", code)
-        self.assertIn("_hbm_arg_indices=", code)
+        # The resident cache is unavailable two ways: the extent bound blows the
+        # VMEM budget (window can't be allocated), or the ordered loop carries no
+        # extent bound at all.  Both fall back to the streamed emit_pipeline.
+        cases = [
+            (
+                "over_vmem_budget",
+                _bounded_noprep_ordered_kernel,
+                (1_000_000, torch.randn(lq, 4, 128), torch.randn(lq, 4, 128), qo),
+            ),
+            (
+                "unbounded_ordered",
+                _compact_bounded_only_ordered_kernel,
+                (64, torch.randn(lq, 4, 128), torch.randn(lq, 4, 128), qo),
+            ),
+        ]
+        for name, kernel, args in cases:
+            with self.subTest(name=name):
+                code = kernel.bind(args).to_triton_code(
+                    helion.Config(
+                        block_sizes=[8, 8], pallas_loop_type="compact_worklist"
+                    )
+                )
+                self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
+                self.assertIn("_compact_ordered_window=0", code)
+                self.assertIn("pltpu.emit_pipeline(", code)
+                self.assertIn("pipeline_mode=pl.Buffered", code)
+                self.assertIn("_hbm_arg_indices=", code)
 
     def test_active_resident_cache_requires_range_start_metadata(self):
         from helion._compiler.backend import PallasBackend

--- a/test/test_pallas_compact_worklist.py
+++ b/test/test_pallas_compact_worklist.py
@@ -376,6 +376,27 @@ def _fully_jagged_kernel(q, k, v, q_offsets, kv_offsets):
     return out
 
 
+@helion.kernel(backend="pallas", static_shapes=False)
+def _bounded_fully_jagged_kernel(max_seq_len, q, k, v, q_offsets):
+    """Self-attention shape: only Q tail dimensions are user-specialized."""
+    H = hl.specialize(q.size(1))
+    D = hl.specialize(q.size(2))
+    out = torch.empty_like(q)
+    for seq_idx in hl.grid(q_offsets.size(0) - 1):
+        start = q_offsets[seq_idx]
+        end = q_offsets[seq_idx + 1]
+        for tile_q in hl.tile(start, end, max_extent=max_seq_len):
+            q_blk = q[tile_q, :, :].transpose(0, 1)
+            acc = hl.zeros([H, tile_q, D], dtype=torch.float32)
+            for tile_kv in hl.tile(start, end, max_extent=max_seq_len):
+                k_blk = k[tile_kv, :, :].transpose(0, 1)
+                v_blk = v[tile_kv, :, :].transpose(0, 1)
+                scores = torch.bmm(q_blk, k_blk.transpose(-2, -1))
+                acc = acc + torch.bmm(scores.to(v.dtype), v_blk)
+            out[tile_q, :, :] = acc.transpose(0, 1).to(out.dtype)
+    return out
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def _flash_prep_kernel(q, k, v, q_offsets, kv_offsets):
     """Jagged flash attention: a max reduction (amax) whose padded scores must be -inf,
@@ -458,22 +479,7 @@ def _noprep_ordered_kernel(q, k, q_offsets):
 @helion.kernel(backend="pallas", static_shapes=False)
 def _bounded_noprep_ordered_kernel(max_seq_len, q, k, q_offsets):
     """Dynamic-shape variant whose tile bounds size worklist and cache state."""
-    hl.specialize(k.shape[1:])
-    out = torch.empty_like(q)
-    for seq_idx in hl.grid(q_offsets.size(0) - 1):
-        start = q_offsets[seq_idx]
-        end = q_offsets[seq_idx + 1]
-        for tile_q in hl.tile(start, end, max_extent=max_seq_len):
-            acc = q[tile_q, :, :].to(torch.float32)
-            for tile_kv in hl.tile(start, end, max_extent=max_seq_len):
-                acc = acc + k[tile_kv, :, :].sum(0, keepdim=True).to(torch.float32)
-            out[tile_q, :, :] = acc.to(out.dtype)
-    return out
-
-
-@helion.kernel(backend="pallas", static_shapes=False)
-def _bounded_dynamic_tail_ordered_kernel(max_seq_len, q, k, q_offsets):
-    """Bounded ordered loop whose resident footprint remains dynamic."""
+    hl.specialize(q.shape[1:])
     out = torch.empty_like(q)
     for seq_idx in hl.grid(q_offsets.size(0) - 1):
         start = q_offsets[seq_idx]
@@ -2155,10 +2161,10 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         self.assertIn("_compact_ordered_offset_arg_index=-1", code)
         self.assertIn("_compact_active_mask_arg_index=-1", code)
 
-    def test_dynamic_tail_shape_disables_resident_cache(self):
+    def test_dynamic_resident_tail_shape_adds_cache_guard(self):
         offsets = _offsets([12, 20, 5, 30])
         total = int(offsets[-1])
-        _bounded_dynamic_tail_ordered_kernel.reset()
+        _bounded_noprep_ordered_kernel.reset()
 
         def args(heads, width):
             return (
@@ -2169,7 +2175,24 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
             )
 
         small_args = args(2, 8)
-        small_bound = _bounded_dynamic_tail_ordered_kernel.bind(small_args)
+        small_bound = _bounded_noprep_ordered_kernel.bind(small_args)
+        self.assertTrue(
+            {("k", 1), ("k", 2)}.issubset(small_bound.env.specialized_size_dimensions())
+        )
+        k_only_tail_change = (
+            small_args[0],
+            small_args[1],
+            torch.randn(total, 4, 8),
+            small_args[3],
+        )
+        self.assertEqual(
+            _bounded_noprep_ordered_kernel._base_specialization_key(small_args),
+            _bounded_noprep_ordered_kernel._base_specialization_key(k_only_tail_change),
+        )
+        self.assertNotEqual(
+            _bounded_noprep_ordered_kernel.specialization_key(small_args),
+            _bounded_noprep_ordered_kernel.specialization_key(k_only_tail_change),
+        )
         for block_sizes in ([8, 8], [16, 8]):
             code = small_bound.to_triton_code(
                 helion.Config(
@@ -2177,15 +2200,59 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
                     pallas_loop_type="compact_worklist",
                 )
             )
-            self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
-            self.assertIn("_compact_ordered_window=0", code)
+            self.assertNotIn("_compact_ordered_aligned_arg_indices=[]", code)
+            self.assertNotIn("_compact_ordered_window=0", code)
 
-        # Tail dimensions remain dynamic, so one BoundKernel may serve both shapes;
-        # streaming keeps its VMEM decision valid for either one.
-        self.assertIs(
+        # The resident footprint changed, so the exact tail guards select a new
+        # BoundKernel while leading token-count changes still reuse one.
+        self.assertIsNot(
             small_bound,
-            _bounded_dynamic_tail_ordered_kernel.bind(args(4, 16)),
+            _bounded_noprep_ordered_kernel.bind(args(4, 16)),
         )
+
+    def test_bounded_self_attention_auto_specializes_kv_resident_tails(self):
+        _bounded_fully_jagged_kernel.reset()
+        offsets = _offsets([12, 20, 5, 30])
+        total = int(offsets[-1])
+        args = (
+            64,
+            torch.randn(total, 4, 128),
+            torch.randn(total, 4, 128),
+            torch.randn(total, 4, 128),
+            offsets,
+        )
+        bound = _bounded_fully_jagged_kernel.bind(args)
+        self.assertTrue(
+            {("k", 1), ("k", 2), ("v", 1), ("v", 2)}.issubset(
+                bound.env.specialized_size_dimensions()
+            )
+        )
+        code = bound.to_triton_code(
+            helion.Config(
+                block_sizes=[8, 8],
+                pallas_loop_type="compact_worklist",
+            )
+        )
+        self.assertIn("lax.fori_loop", code)
+        self.assertNotIn("pltpu.emit_pipeline(", code)
+        self.assertNotIn("_compact_ordered_aligned_arg_indices=[]", code)
+        # The ordered (kv) tile feeds a bmm, so its block is floored to 128 (the MXU
+        # contraction width) regardless of block_sizes[1]. The resident window is a
+        # block multiple sized from max_extent: cdiv(64, 128) * 128 == 128, not 64.
+        self.assertIn("_compact_ordered_window=128", code)
+
+        smaller_offsets = _offsets([8, 7])
+        smaller_total = int(smaller_offsets[-1])
+        rebound = _bounded_fully_jagged_kernel.bind(
+            (
+                64,
+                torch.randn(smaller_total, 4, 128),
+                torch.randn(smaller_total, 4, 128),
+                torch.randn(smaller_total, 4, 128),
+                smaller_offsets,
+            )
+        )
+        self.assertIs(bound, rebound)
 
     def test_extent_bound_over_vmem_budget_streams_ordered_loop(self):
         qo = _offsets([12, 20, 5, 30])
@@ -2201,6 +2268,9 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         )
         self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
         self.assertIn("_compact_ordered_window=0", code)
+        self.assertIn("pltpu.emit_pipeline(", code)
+        self.assertIn("pipeline_mode=pl.Buffered", code)
+        self.assertIn("_hbm_arg_indices=", code)
 
     def test_dynamic_unbounded_ordered_loop_streams(self):
         qo = _offsets([12, 20, 5, 30])
@@ -2216,6 +2286,9 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         )
         self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
         self.assertIn("_compact_ordered_window=0", code)
+        self.assertIn("pltpu.emit_pipeline(", code)
+        self.assertIn("pipeline_mode=pl.Buffered", code)
+        self.assertIn("_hbm_arg_indices=", code)
 
     def test_active_resident_cache_requires_range_start_metadata(self):
         from helion._compiler.backend import PallasBackend

--- a/test/test_pallas_compact_worklist.py
+++ b/test/test_pallas_compact_worklist.py
@@ -336,6 +336,23 @@ def _dense_kv_kernel(q, k, v, q_offsets):
     return out
 
 
+@helion.kernel(backend="pallas", static_shapes=False)
+def _bounded_dense_kv_kernel(max_seq_len, q, k, v, q_offsets):
+    num_sequences = q_offsets.size(0) - 1
+    out = torch.empty_like(q)
+    for seq_idx in hl.grid(num_sequences):
+        q_start = q_offsets[seq_idx]
+        q_end = q_offsets[seq_idx + 1]
+        k_blk = k[seq_idx, :, :, :].transpose(0, 1)
+        v_blk = v[seq_idx, :, :, :].transpose(0, 1)
+        for tile_q in hl.tile(q_start, q_end, max_extent=max_seq_len):
+            q_blk = q[tile_q, :, :].transpose(0, 1)
+            scores = torch.bmm(q_blk, k_blk.transpose(-2, -1))
+            acc = torch.bmm(scores.to(v.dtype), v_blk)
+            out[tile_q, :, :] = acc.transpose(0, 1).to(out.dtype)
+    return out
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def _fully_jagged_kernel(q, k, v, q_offsets, kv_offsets):
     H = hl.specialize(q.size(1))
@@ -431,6 +448,52 @@ def _noprep_ordered_kernel(q, k, q_offsets):
         start = q_offsets[seq_idx]
         end = q_offsets[seq_idx + 1]
         for tile_q in hl.tile(start, end):
+            acc = q[tile_q, :, :].to(torch.float32)
+            for tile_kv in hl.tile(start, end):
+                acc = acc + k[tile_kv, :, :].sum(0, keepdim=True).to(torch.float32)
+            out[tile_q, :, :] = acc.to(out.dtype)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=False)
+def _bounded_noprep_ordered_kernel(max_seq_len, q, k, q_offsets):
+    """Dynamic-shape variant whose tile bounds size worklist and cache state."""
+    hl.specialize(k.shape[1:])
+    out = torch.empty_like(q)
+    for seq_idx in hl.grid(q_offsets.size(0) - 1):
+        start = q_offsets[seq_idx]
+        end = q_offsets[seq_idx + 1]
+        for tile_q in hl.tile(start, end, max_extent=max_seq_len):
+            acc = q[tile_q, :, :].to(torch.float32)
+            for tile_kv in hl.tile(start, end, max_extent=max_seq_len):
+                acc = acc + k[tile_kv, :, :].sum(0, keepdim=True).to(torch.float32)
+            out[tile_q, :, :] = acc.to(out.dtype)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=False)
+def _bounded_dynamic_tail_ordered_kernel(max_seq_len, q, k, q_offsets):
+    """Bounded ordered loop whose resident footprint remains dynamic."""
+    out = torch.empty_like(q)
+    for seq_idx in hl.grid(q_offsets.size(0) - 1):
+        start = q_offsets[seq_idx]
+        end = q_offsets[seq_idx + 1]
+        for tile_q in hl.tile(start, end, max_extent=max_seq_len):
+            acc = q[tile_q, :, :].to(torch.float32)
+            for tile_kv in hl.tile(start, end, max_extent=max_seq_len):
+                acc = acc + k[tile_kv, :, :].sum(0, keepdim=True).to(torch.float32)
+            out[tile_q, :, :] = acc.to(out.dtype)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=False)
+def _compact_bounded_only_ordered_kernel(max_seq_len, q, k, q_offsets):
+    """Dynamic ordered loop without a resident-cache extent bound."""
+    out = torch.empty_like(q)
+    for seq_idx in hl.grid(q_offsets.size(0) - 1):
+        start = q_offsets[seq_idx]
+        end = q_offsets[seq_idx + 1]
+        for tile_q in hl.tile(start, end, max_extent=max_seq_len):
             acc = q[tile_q, :, :].to(torch.float32)
             for tile_kv in hl.tile(start, end):
                 acc = acc + k[tile_kv, :, :].sum(0, keepdim=True).to(torch.float32)
@@ -644,6 +707,84 @@ class TestDetectAndGating(unittest.TestCase):
             metadata_arg_names(self._fully_jagged_plan()),
             ["work_seq", "q_begin", "q_extent", "kv_begin", "kv_len"],
         )
+
+    def test_tile_extent_bounds_are_captured_and_specialized(self):
+        qo = _offsets([12, 20, 5, 30])
+        lq = int(qo[-1])
+        bk = _bounded_noprep_ordered_kernel.bind(
+            (64, torch.randn(lq, 2, 8), torch.randn(lq, 2, 8), qo)
+        )
+        assert bk.host_function is not None
+        with bk.env:
+            plan = detect_compact_worklist_plan(bk.host_function)
+        self.assertEqual(plan.compact_axis.extent_bound, 64)
+        self.assertIsNotNone(plan.ordered_axis)
+        self.assertEqual(plan.ordered_axis.extent_bound, 64)
+        max_seq_len = bk.host_function.params.arguments["max_seq_len"]
+        self.assertIsInstance(max_seq_len, torch.SymInt)
+        self.assertTrue(bk.env.specialized_vars)
+
+    def test_no_hint_keeps_extent_bounds_absent(self):
+        plan = self._fully_jagged_plan()
+        self.assertIsNone(plan.compact_axis.extent_bound)
+        self.assertIsNotNone(plan.ordered_axis)
+        self.assertIsNone(plan.ordered_axis.extent_bound)
+
+    def test_dynamic_shapes_require_compact_extent_bound(self):
+        qo = _offsets([10, 23, 7, 40])
+        total = int(qo[-1])
+        kernel = helion.kernel(
+            _dense_kv_kernel.fn,
+            backend="pallas",
+            static_shapes=False,
+            config=helion.Config(block_sizes=[16], pallas_loop_type="compact_worklist"),
+        )
+        args = (
+            torch.randn(total, 2, 16),
+            torch.randn(4, 16, 2, 16),
+            torch.randn(4, 16, 2, 16),
+            qo,
+        )
+        with self.assertRaisesRegex(
+            exc.InvalidConfig,
+            "static_shapes=False requires max_extent",
+        ):
+            kernel.bind(args).ensure_config_exists(args)
+
+    def test_extent_bound_specializes_without_specializing_leading_shapes(self):
+        def args(max_seq_len, lengths, *, heads=2, width=8):
+            offsets = _offsets(lengths)
+            total = int(offsets[-1])
+            return (
+                max_seq_len,
+                torch.randn(total, heads, width),
+                torch.randn(total, heads, width),
+                offsets,
+            )
+
+        _bounded_noprep_ordered_kernel.reset()
+        bound_64 = _bounded_noprep_ordered_kernel.bind(args(64, [12, 20, 5, 30]))
+        rebound_64 = _bounded_noprep_ordered_kernel.bind(args(64, [8, 7]))
+        bound_128 = _bounded_noprep_ordered_kernel.bind(args(128, [8, 7]))
+        rebound_tail = _bounded_noprep_ordered_kernel.bind(
+            args(64, [8, 7], heads=4, width=16)
+        )
+        self.assertIs(bound_64, rebound_64)
+        self.assertIsNot(bound_64, bound_128)
+        self.assertIsNot(bound_64, rebound_tail)
+
+    def test_static_extent_cannot_exceed_bound(self):
+        @helion.kernel(backend="pallas")
+        def invalid_bound(x):
+            out = torch.empty_like(x)
+            for tile in hl.tile(16, max_extent=8):
+                out[tile] = x[tile]
+            return out
+
+        with self.assertRaisesRegex(
+            exc.TypeInferenceError, "range extent 16 exceeds max_extent 8"
+        ):
+            invalid_bound.bind((torch.randn(16),))
 
     def test_gating_offers_compact_worklist_for_jagged(self):
         qo = _offsets([16, 16, 16, 16])
@@ -1126,6 +1267,19 @@ def _eager_fully_jagged(q, k, v, qo, kvo):
     return out
 
 
+def _eager_noprep_ordered(q, k, offsets, block):
+    """Ground truth matching the ordered loop's blockwise bf16 reductions."""
+    out = torch.empty_like(q)
+    for seq in range(len(offsets) - 1):
+        begin, end = int(offsets[seq]), int(offsets[seq + 1])
+        acc = q[begin:end].float()
+        for tile_begin in range(begin, end, block):
+            tile_end = min(tile_begin + block, end)
+            acc += k[tile_begin:tile_end].sum(0, keepdim=True).float()
+        out[begin:end] = acc.to(out.dtype)
+    return out
+
+
 @onlyBackends(["pallas"])
 class TestUpperBoundPacking(unittest.TestCase):
     """Only packed-offset bounds are accepted; non-packed is rejected.
@@ -1275,6 +1429,106 @@ class TestCompactWorklistNumerics(unittest.TestCase):
         ref = _eager_dense_kv(q.cpu(), k.cpu(), v.cpu(), qo)
         torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
 
+    def test_bounded_dense_kv_rebuilds_runtime_specs_for_new_shape(self):
+        B, H, KV, D, block, max_seq_len = 4, 2, 16, 16, 16, 64
+        kernel = helion.kernel(
+            _bounded_dense_kv_kernel.fn,
+            backend="pallas",
+            static_shapes=False,
+            config=helion.Config(
+                block_sizes=[block], pallas_loop_type="compact_worklist"
+            ),
+        )
+
+        def make_case(lengths, seed):
+            qo = _offsets(lengths)
+            torch.manual_seed(seed)
+            q = torch.randn(int(qo[-1]), H, D, device=DEVICE, dtype=torch.bfloat16)
+            k = torch.randn(B, KV, H, D, device=DEVICE, dtype=torch.bfloat16)
+            v = torch.randn(B, KV, H, D, device=DEVICE, dtype=torch.bfloat16)
+            args = (max_seq_len, q, k, v, qo.to(DEVICE))
+            return args, _eager_dense_kv(q.cpu(), k.cpu(), v.cpu(), qo)
+
+        case_a, ref_a = make_case([10, 23, 7, 40], 0)
+        case_b, ref_b = make_case([5, 12, 3, 20], 1)
+        for args, ref in ((case_a, ref_a), (case_a, ref_a), (case_b, ref_b)):
+            out = kernel(*args)
+            self.assertEqual(tuple(out.shape), tuple(ref.shape))
+            torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
+        self.assertEqual(len(kernel._bound_kernels), 1)
+
+    def test_bounded_dense_kv_reuses_fixed_capacity_compilation(self):
+        import helion.runtime as helion_runtime
+
+        B, H, KV, D, block, max_seq_len = 4, 2, 16, 16, 16, 64
+        capacity = B * max_seq_len
+        kernel = helion.kernel(
+            _bounded_dense_kv_kernel.fn,
+            backend="pallas",
+            static_shapes=False,
+            config=helion.Config(
+                block_sizes=[block], pallas_loop_type="compact_worklist"
+            ),
+        )
+
+        def make_case(lengths, seed):
+            qo = _offsets(lengths)
+            torch.manual_seed(seed)
+            q = torch.randn(capacity, H, D, device=DEVICE, dtype=torch.bfloat16)
+            k = torch.randn(B, KV, H, D, device=DEVICE, dtype=torch.bfloat16)
+            v = torch.randn(B, KV, H, D, device=DEVICE, dtype=torch.bfloat16)
+            args = (max_seq_len, q, k, v, qo.to(DEVICE))
+            return args, _eager_dense_kv(q.cpu(), k.cpu(), v.cpu(), qo), int(qo[-1])
+
+        cases = (
+            make_case([10, 23, 7, 40], 0),
+            make_case([5, 12, 3, 20], 1),
+        )
+        with patch.object(
+            helion_runtime,
+            "_pallas_install_compact_launcher_cache",
+            wraps=helion_runtime._pallas_install_compact_launcher_cache,
+        ) as install:
+            for args, ref, active_tokens in (*cases, cases[0]):
+                out = kernel(*args)
+                self.assertEqual(tuple(out.shape), (capacity, H, D))
+                torch.testing.assert_close(
+                    out[:active_tokens].cpu(),
+                    ref[:active_tokens],
+                    rtol=2e-2,
+                    atol=2e-2,
+                )
+        self.assertEqual(install.call_count, 1)
+        self.assertEqual(len(kernel._bound_kernels), 1)
+
+    def _check_dynamic_ordered_matches_eager(self, kernel):
+        H, D, block, max_seq_len = 4, 128, 8, 64
+        offsets = _offsets([12, 20, 5, 30])
+        total = int(offsets[-1])
+        torch.manual_seed(0)
+        q = torch.randn(total, H, D, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.randn(total, H, D, device=DEVICE, dtype=torch.bfloat16)
+        _, out = code_and_output(
+            kernel,
+            (max_seq_len, q, k, offsets.to(DEVICE)),
+            block_sizes=[block, block],
+            pallas_loop_type="compact_worklist",
+        )
+        ref = _eager_noprep_ordered(q.cpu(), k.cpu(), offsets, block)
+        torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
+
+    @skipIfPallasInterpret(
+        "dynamic ordered-loop numerics require real TPU resident-cache lowering"
+    )
+    def test_dynamic_bounded_ordered_resident_matches_eager(self):
+        self._check_dynamic_ordered_matches_eager(_bounded_noprep_ordered_kernel)
+
+    @skipIfPallasInterpret(
+        "dynamic ordered-loop numerics require real TPU pipeline lowering"
+    )
+    def test_dynamic_unbounded_ordered_streaming_matches_eager(self):
+        self._check_dynamic_ordered_matches_eager(_compact_bounded_only_ordered_kernel)
+
     def test_dense_kv_empty_batch_zero_grid(self):
         # total_q == 0 => num_work == 0 => dynamic grid=(0,).  End-to-end guard
         # that the empty-batch launch returns an empty output (Mosaic tolerates
@@ -1400,6 +1654,37 @@ class TestCompactWorklistJaxExport(unittest.TestCase):
             atol=2e-2,
         )
 
+    def test_bounded_jax_fn_under_jit_with_static_extent(self):
+        import jax
+        import jax.numpy as jnp
+
+        B, H, KV, D, block, max_seq_len = 4, 2, 16, 16, 16, 64
+        qo = _offsets([10, 23, 7, 40])
+        lq = int(qo[-1])
+        q = jax.random.normal(jax.random.PRNGKey(0), (lq, H, D), jnp.bfloat16)
+        k = jax.random.normal(jax.random.PRNGKey(1), (B, KV, H, D), jnp.bfloat16)
+        v = jax.random.normal(jax.random.PRNGKey(2), (B, KV, H, D), jnp.bfloat16)
+        qod = jnp.asarray(qo.numpy())
+        kernel = helion.kernel(
+            _bounded_dense_kv_kernel.fn,
+            config=helion.Config(
+                block_sizes=[block], pallas_loop_type="compact_worklist"
+            ),
+            static_shapes=False,
+            backend="pallas",
+        )
+
+        eager = jax.block_until_ready(kernel.jax_fn(max_seq_len, q, k, v, qod))
+        jitted = jax.block_until_ready(
+            jax.jit(kernel.jax_fn, static_argnums=0)(max_seq_len, q, k, v, qod)
+        )
+        np.testing.assert_allclose(
+            np.asarray(jitted).astype(np.float32),
+            np.asarray(eager).astype(np.float32),
+            rtol=2e-2,
+            atol=2e-2,
+        )
+
 
 @unittest.skipUnless(HAS_JAX, "jax not available")
 class TestResidentCacheWindowGuard(unittest.TestCase):
@@ -1498,11 +1783,23 @@ class TestOrderedWindowBudget(unittest.TestCase):
             operands, vmem, prep_operands=prep_operands
         )
 
-    def _physical(self, operands, block, vmem=64 * 1024 * 1024, *, prep_operands):
+    def _physical(
+        self,
+        operands,
+        block,
+        vmem=64 * 1024 * 1024,
+        *,
+        prep_operands,
+        max_extent=None,
+    ):
         from helion.runtime import compact_ordered_physical_window
 
         return compact_ordered_physical_window(
-            operands, vmem, block, prep_operands=prep_operands
+            operands,
+            vmem,
+            block,
+            prep_operands=prep_operands,
+            max_extent=max_extent,
         )
 
     def test_vmem_bound_budgets_window_plus_cache(self):
@@ -1542,6 +1839,31 @@ class TestOrderedWindowBudget(unittest.TestCase):
         self.assertLess(self._budget(operands, vmem=1024, prep_operands=operands), 128)
         self.assertEqual(
             self._physical(operands, 128, vmem=1024, prep_operands=operands),
+            0,
+        )
+
+    def test_max_extent_sizes_the_full_window(self):
+        operands = [((1_000_000, 4, 128), 2)]
+        self.assertEqual(
+            self._physical(
+                operands,
+                128,
+                prep_operands=[],
+                max_extent=257,
+            ),
+            384,
+        )
+
+    def test_max_extent_over_budget_disables_resident_cache(self):
+        operands = [((1_000_000, 4, 128), 2)]
+        self.assertEqual(
+            self._physical(
+                operands,
+                128,
+                vmem=1024,
+                prep_operands=[],
+                max_extent=257,
+            ),
             0,
         )
 
@@ -1814,6 +2136,86 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         self.assertNotIn("_compact_ordered_offset_arg_index=-1", code)
         self.assertNotIn("_compact_active_mask_arg_index=-1", code)
         self.assertNotIn("_compact_ordered_window=0", code)
+
+    def test_extent_bound_drives_dynamic_worklist_and_resident_window(self):
+        qo = _offsets([12, 20, 5, 30])
+        lq = int(qo[-1])
+        args = (64, torch.randn(lq, 4, 128), torch.randn(lq, 4, 128), qo)
+        code = _bounded_noprep_ordered_kernel.bind(args).to_triton_code(
+            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+        )
+        self.assertRegex(
+            code,
+            r"flatten_worklist\(base, length, \d+, "
+            r"\(q_offsets\.shape\[0\] - 1\) \* \d+",
+        )
+        self.assertIn("_compact_ordered_window=64", code)
+        # max_extent sizes the full window, so its caller contract replaces the
+        # eager, synchronizing shape-derived-window guard.
+        self.assertIn("_compact_ordered_offset_arg_index=-1", code)
+        self.assertIn("_compact_active_mask_arg_index=-1", code)
+
+    def test_dynamic_tail_shape_disables_resident_cache(self):
+        offsets = _offsets([12, 20, 5, 30])
+        total = int(offsets[-1])
+        _bounded_dynamic_tail_ordered_kernel.reset()
+
+        def args(heads, width):
+            return (
+                64,
+                torch.randn(total, heads, width),
+                torch.randn(total, heads, width),
+                offsets,
+            )
+
+        small_args = args(2, 8)
+        small_bound = _bounded_dynamic_tail_ordered_kernel.bind(small_args)
+        for block_sizes in ([8, 8], [16, 8]):
+            code = small_bound.to_triton_code(
+                helion.Config(
+                    block_sizes=block_sizes,
+                    pallas_loop_type="compact_worklist",
+                )
+            )
+            self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
+            self.assertIn("_compact_ordered_window=0", code)
+
+        # Tail dimensions remain dynamic, so one BoundKernel may serve both shapes;
+        # streaming keeps its VMEM decision valid for either one.
+        self.assertIs(
+            small_bound,
+            _bounded_dynamic_tail_ordered_kernel.bind(args(4, 16)),
+        )
+
+    def test_extent_bound_over_vmem_budget_streams_ordered_loop(self):
+        qo = _offsets([12, 20, 5, 30])
+        lq = int(qo[-1])
+        args = (
+            1_000_000,
+            torch.randn(lq, 4, 128),
+            torch.randn(lq, 4, 128),
+            qo,
+        )
+        code = _bounded_noprep_ordered_kernel.bind(args).to_triton_code(
+            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+        )
+        self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
+        self.assertIn("_compact_ordered_window=0", code)
+
+    def test_dynamic_unbounded_ordered_loop_streams(self):
+        qo = _offsets([12, 20, 5, 30])
+        total = int(qo[-1])
+        args = (
+            64,
+            torch.randn(total, 4, 128),
+            torch.randn(total, 4, 128),
+            qo,
+        )
+        code = _compact_bounded_only_ordered_kernel.bind(args).to_triton_code(
+            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+        )
+        self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
+        self.assertIn("_compact_ordered_window=0", code)
 
     def test_active_resident_cache_requires_range_start_metadata(self):
         from helion._compiler.backend import PallasBackend

--- a/test/test_ref_eager.py
+++ b/test/test_ref_eager.py
@@ -111,6 +111,19 @@ class TestRefEagerMisc(TestCase):
             expected = x * 2.0
             torch.testing.assert_close(result, expected)
 
+    def test_tile_max_extent_support(self):
+        @helion.kernel(ref_mode=helion.RefMode.EAGER)
+        def kernel(x: torch.Tensor, max_extent: int) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0), block_size=3, max_extent=max_extent):
+                out[tile] = x[tile] * 2.0
+            return out
+
+        with assert_ref_eager_mode():
+            x = torch.randn(8, device=DEVICE)
+            result = kernel(x, 8)
+            torch.testing.assert_close(result, x * 2.0)
+
     def test_tile_begin_with_block_size_1(self):
         @helion.kernel(ref_mode=helion.RefMode.EAGER)
         def kernel(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Adds an optional max_extent= keyword to hl.tile() that gives a hard, compile-time upper bound on a tile loop's iteration-space extent. Right now, the only user of this feature is the pallas backend for the compact-worklist loop type designed for jagged kernels.

Jagged kernels typically have some max_extent or max_seq_len or max_tokens in their input signature.

Example usage:
```python
for tq in hl.tile(q_start, q_end, max_extent=max_seq_len):
      ...
```
Note that max_extent must resolve to a **compile-time integer**: a plain int, an hl.constexpr, or a dynamic SymInt/arg (auto-specialized, exactly like hl.specialize). A genuinely data-dependent runtime value is rejected with a clear TypeInferenceError.

A compile-time range check raises if a statically-known extent exceeds its bound; at runtime the caller must ensure extents don't exceed it (it's a caller contract, not a clamp). Because the bound is baked into the specialization key, a new value recompiles once; an unchanged value never recompiles.

The mechanism:
- hl.tile (helion/language/loops.py) has a new keyword on all three overloads; _specialize_max_extent normalizes it to per-dim compile-time ints, and the type-propagation path threads it as each axis's extent_bound and enforces the static range check.
- Backend.register_specializations(hf) (backend.py, kernel_compiler.py) — new generic no-op backend hook, called from KernelCompiler.parse after lowering and before the first BoundKernel cache key is created. The PallasBackend override, for static_shapes=False + a compact extent_bound + an ordered axis, specializes each resident ordered operand's trailing dims into env.specialized_vars so they become exact guards.

For compact_worklist this enables `static_shapes = False` by (1) removing a compile time computed upper bound for the metadata lengths and (2) allowing us to directly measure the amount of VMEM we need for caching.

@jansel this is a (slightly) new language feature, which I expect will be helpful for jagged kernels for other backends as well.