### PR TITLE
refactor: centralize per-backend codegen registration via the backend registry

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -548,12 +548,3 @@ gather_lowering = register_lowering(
 
 
 topk_lowering = register_lowering(torch.ops.aten.topk.default)
-
-
-# Backend-specific register_codegen handlers for these lowerings live in per-backend
-# modules under helion/_compiler/<backend>/aten_lowering.py.  Import them here at module
-# import time so the @<op>_lowering.register_codegen("<backend>") registrations run with
-# the same eager timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.aten_lowering  # noqa: E402, F401
-import helion._compiler.pallas.aten_lowering  # noqa: E402, F401
-import helion._compiler.triton.aten_lowering  # noqa: E402, F401

--- a/helion/_compiler/backend_registry.py
+++ b/helion/_compiler/backend_registry.py
@@ -5,6 +5,7 @@ All backend lookup and instantiation should go through this module.
 
 from __future__ import annotations
 
+import importlib
 from typing import TYPE_CHECKING
 
 from .backend import CuteBackend
@@ -64,6 +65,41 @@ def all_reserved_launch_param_names() -> frozenset[str]:
     for backend_cls in _REGISTRY.values():
         result.update(backend_cls.reserved_launch_param_names())
     return frozenset(result)
+
+
+def import_backend_codegen() -> None:
+    """Import every registered backend's per-op codegen modules.
+
+    Each backend lists its own codegen modules in
+    ``helion/_compiler/<backend>/_codegen_modules.py``.  Importing that module
+    runs the backend's ``@_decorators.codegen(op, "<backend>")`` /
+    ``register_codegen("<backend>")`` handlers, wiring them onto the op and
+    aten-lowering objects they extend.
+
+    This is called once from ``helion.language`` after all language ops are
+    defined (so the eager registration timing matches the old per-file bottom
+    imports).  Because it is driven by the registry, adding a backend requires
+    no edits to the core ``helion/language`` files -- only registering the
+    backend class (below) and adding its ``_codegen_modules`` module.
+    """
+    seen: set[str] = set()
+    for backend_cls in _REGISTRY.values():
+        # e.g. "helion._compiler.cute.backend" -> "helion._compiler.cute".
+        # Subclasses that share a folder (e.g. TileIRBackend in the triton
+        # package) collapse to one import.
+        package = backend_cls.__module__.rsplit(".", 1)[0]
+        if package in seen:
+            continue
+        seen.add(package)
+        module = f"{package}._codegen_modules"
+        try:
+            importlib.import_module(module)
+        except ModuleNotFoundError as e:
+            # A backend without any per-op codegen modules is allowed; only
+            # swallow the missing _codegen_modules module itself, never a
+            # broken import inside it.
+            if e.name != module:
+                raise
 
 
 # register built-in backends

--- a/helion/_compiler/cute/_codegen_modules.py
+++ b/helion/_compiler/cute/_codegen_modules.py
@@ -1,0 +1,28 @@
+"""Cute-backend codegen module registry.
+
+Importing this module imports every Cute-backend codegen module, so their
+``@_decorators.codegen(op, "cute")`` and ``register_codegen("cute")`` handlers
+register onto the op / aten-lowering objects they extend.
+
+It is imported exactly once -- by
+:func:`helion._compiler.backend_registry.import_backend_codegen`, after all
+language ops are defined -- so adding a new Cute codegen module only requires
+listing it here, never editing the core ``helion/language`` files.
+"""
+
+from __future__ import annotations
+
+from . import aten_lowering  # noqa: F401
+from . import atomic_ops  # noqa: F401
+from . import barrier  # noqa: F401
+from . import device_print  # noqa: F401
+from . import gelu_tanh_approx  # noqa: F401
+from . import inline_asm_ops  # noqa: F401
+from . import matmul_ops  # noqa: F401
+from . import memory_ops  # noqa: F401
+from . import quantized_ops  # noqa: F401
+from . import reduce_ops  # noqa: F401
+from . import scan_ops  # noqa: F401
+from . import tile_ops  # noqa: F401
+from . import tracing_ops  # noqa: F401
+from . import view_ops  # noqa: F401

--- a/helion/_compiler/metal/_codegen_modules.py
+++ b/helion/_compiler/metal/_codegen_modules.py
@@ -1,0 +1,16 @@
+"""Metal-backend codegen module registry.
+
+Importing this module imports every Metal-backend codegen module, so their
+``@_decorators.codegen(op, "metal")`` and ``register_codegen("metal")``
+handlers register onto the op / aten-lowering objects they extend.
+
+It is imported exactly once -- by
+:func:`helion._compiler.backend_registry.import_backend_codegen`, after all
+language ops are defined -- so adding a new Metal codegen module only requires
+listing it here, never editing the core ``helion/language`` files.
+"""
+
+from __future__ import annotations
+
+from . import memory_ops  # noqa: F401
+from . import tracing_ops  # noqa: F401

--- a/helion/_compiler/pallas/_codegen_modules.py
+++ b/helion/_compiler/pallas/_codegen_modules.py
@@ -1,0 +1,21 @@
+"""Pallas-backend codegen module registry.
+
+Importing this module imports every Pallas-backend codegen module, so their
+``@_decorators.codegen(op, "pallas")`` and ``register_codegen("pallas")``
+handlers register onto the op / aten-lowering objects they extend.
+
+It is imported exactly once -- by
+:func:`helion._compiler.backend_registry.import_backend_codegen`, after all
+language ops are defined -- so adding a new Pallas codegen module only requires
+listing it here, never editing the core ``helion/language`` files.
+"""
+
+from __future__ import annotations
+
+from . import aten_lowering  # noqa: F401
+from . import atomic_ops  # noqa: F401
+from . import creation_ops  # noqa: F401
+from . import gelu_tanh_approx  # noqa: F401
+from . import matmul_ops  # noqa: F401
+from . import memory_ops  # noqa: F401
+from . import tracing_ops  # noqa: F401

--- a/helion/_compiler/triton/_codegen_modules.py
+++ b/helion/_compiler/triton/_codegen_modules.py
@@ -1,0 +1,29 @@
+"""Triton-backend codegen module registry.
+
+Importing this module imports every Triton-backend codegen module, so their
+``@_decorators.codegen(op, "triton")`` and ``register_codegen("triton")``
+handlers register onto the op / aten-lowering objects they extend.
+
+It is imported exactly once -- by
+:func:`helion._compiler.backend_registry.import_backend_codegen`, after all
+language ops are defined -- so adding a new Triton codegen module only requires
+listing it here, never editing the core ``helion/language`` files.
+"""
+
+from __future__ import annotations
+
+from . import aten_lowering  # noqa: F401
+from . import atomic_ops  # noqa: F401
+from . import barrier  # noqa: F401
+from . import debug_ops  # noqa: F401
+from . import device_print  # noqa: F401
+from . import gelu_tanh_approx  # noqa: F401
+from . import inline_asm_ops  # noqa: F401
+from . import inline_triton_ops  # noqa: F401
+from . import matmul_ops  # noqa: F401
+from . import memory_ops  # noqa: F401
+from . import quantized_ops  # noqa: F401
+from . import reduce_ops  # noqa: F401
+from . import scan_ops  # noqa: F401
+from . import tracing_ops  # noqa: F401
+from . import view_ops  # noqa: F401

--- a/helion/language/__init__.py
+++ b/helion/language/__init__.py
@@ -64,3 +64,12 @@ _MEMORY_OPS = (
     atomic_xchg,
     atomic_xor,
 )
+
+# All language ops are now defined.  Import each registered backend's per-op
+# codegen modules (helion/_compiler/<backend>/_codegen_modules.py) so their
+# @_decorators.codegen / register_codegen handlers register with the same eager
+# timing as the old per-file bottom imports.  This is driven by the backend
+# registry, so adding a backend needs no edits to the core language files.
+from .._compiler.backend_registry import import_backend_codegen  # noqa: E402
+
+import_backend_codegen()

--- a/helion/language/_gelu_tanh_approx.py
+++ b/helion/language/_gelu_tanh_approx.py
@@ -184,13 +184,3 @@ def install_gelu_decomp(
         return original_decomp(x, approximate=approximate)
 
     decomp_table[torch.ops.aten.gelu.default] = _gelu_decomp
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.gelu_tanh_approx  # noqa: E402, F401
-import helion._compiler.pallas.gelu_tanh_approx  # noqa: E402, F401
-import helion._compiler.triton.gelu_tanh_approx  # noqa: E402, F401

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -435,14 +435,3 @@ def _(node: torch.fx.Node) -> float | bool | None:
     (arg,) = node.args
     assert isinstance(arg, torch.fx.Node)
     return cached_masked_value(arg)
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.tracing_ops  # noqa: E402, F401
-import helion._compiler.metal.tracing_ops  # noqa: E402, F401
-import helion._compiler.pallas.tracing_ops  # noqa: E402, F401
-import helion._compiler.triton.tracing_ops  # noqa: E402, F401

--- a/helion/language/atomic_ops.py
+++ b/helion/language/atomic_ops.py
@@ -687,13 +687,3 @@ ATOMIC_OPS: frozenset[Callable[..., object]] = frozenset(
         atomic_xor,
     }
 )
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.atomic_ops  # noqa: E402, F401
-import helion._compiler.pallas.atomic_ops  # noqa: E402, F401
-import helion._compiler.triton.atomic_ops  # noqa: E402, F401

--- a/helion/language/barrier.py
+++ b/helion/language/barrier.py
@@ -47,12 +47,3 @@ def _(origin: Origin, **kwargs: object) -> LiteralType:
 def _() -> None:
     # No-op in ref/interpret mode
     return None
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.barrier  # noqa: E402, F401
-import helion._compiler.triton.barrier  # noqa: E402, F401

--- a/helion/language/creation_ops.py
+++ b/helion/language/creation_ops.py
@@ -218,11 +218,3 @@ def arange(
         dtype=dtype,
         device=env.device if device is None else device,
     )
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.pallas.creation_ops  # noqa: E402, F401

--- a/helion/language/debug_ops.py
+++ b/helion/language/debug_ops.py
@@ -49,11 +49,3 @@ def _(*args: object, origin: Origin, **kwargs: object) -> TypeInfo:
 @_decorators.ref(breakpoint)
 def _() -> None:
     builtins.breakpoint()
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.triton.debug_ops  # noqa: E402, F401

--- a/helion/language/device_print.py
+++ b/helion/language/device_print.py
@@ -66,12 +66,3 @@ def _(*args: object, origin: Origin, **kwargs: object) -> TypeInfo:
 @_decorators.ref(device_print)
 def _(prefix: str, *values: object) -> None:
     print(prefix, *values)
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.device_print  # noqa: E402, F401
-import helion._compiler.triton.device_print  # noqa: E402, F401

--- a/helion/language/inline_asm_ops.py
+++ b/helion/language/inline_asm_ops.py
@@ -138,12 +138,3 @@ def _(
     # Type assertion: dtypes[0] is guaranteed to be torch.dtype due to validation above
     assert isinstance(dtypes[0], torch.dtype)
     return torch.empty(broadcast_shape, dtype=dtypes[0], device=env.device)
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.inline_asm_ops  # noqa: E402, F401
-import helion._compiler.triton.inline_asm_ops  # noqa: E402, F401

--- a/helion/language/inline_triton_ops.py
+++ b/helion/language/inline_triton_ops.py
@@ -121,11 +121,3 @@ def _(
         )
     _validate_args(args)
     return _fake_outputs(output_like)
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.triton.inline_triton_ops  # noqa: E402, F401

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -745,13 +745,3 @@ def _(
     if acc is not None:
         return acc + result
     return result
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.matmul_ops  # noqa: E402, F401
-import helion._compiler.pallas.matmul_ops  # noqa: E402, F401
-import helion._compiler.triton.matmul_ops  # noqa: E402, F401

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -4726,14 +4726,3 @@ def _(
             valid_mask = valid_mask & in_bounds
 
     return torch.where(valid_mask, values, result)
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.memory_ops  # noqa: E402, F401
-import helion._compiler.metal.memory_ops  # noqa: E402, F401
-import helion._compiler.pallas.memory_ops  # noqa: E402, F401
-import helion._compiler.triton.memory_ops  # noqa: E402, F401

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -27,12 +27,3 @@ def _(value: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         torch.empty(value.shape, dtype=torch.float32, device=value.device),
         torch.empty(value.shape, dtype=torch.float32, device=value.device),
     )
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.quantized_ops  # noqa: E402, F401
-import helion._compiler.triton.quantized_ops  # noqa: E402, F401

--- a/helion/language/reduce_ops.py
+++ b/helion/language/reduce_ops.py
@@ -450,12 +450,3 @@ def _(
         return tuple(_fake_reduce_tensor(t, dim, keep_dims) for t in input_tensor)
     assert isinstance(input_tensor, torch.Tensor), input_tensor
     return _fake_reduce_tensor(input_tensor, dim, keep_dims)
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.reduce_ops  # noqa: E402, F401
-import helion._compiler.triton.reduce_ops  # noqa: E402, F401

--- a/helion/language/scan_ops.py
+++ b/helion/language/scan_ops.py
@@ -351,12 +351,3 @@ def _(
         return tuple(torch.empty_like(t) for t in input_tensor)
     assert isinstance(input_tensor, torch.Tensor), input_tensor
     return torch.empty_like(input_tensor)
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.scan_ops  # noqa: E402, F401
-import helion._compiler.triton.scan_ops  # noqa: E402, F401

--- a/helion/language/tile_ops.py
+++ b/helion/language/tile_ops.py
@@ -296,11 +296,3 @@ def _(state: CodegenState) -> ast.AST:
 @_decorators.ref(tile_id)
 def _(tile: RefTile) -> int:
     return tile._slice.start // tile._block_size
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.tile_ops  # noqa: E402, F401

--- a/helion/language/view_ops.py
+++ b/helion/language/view_ops.py
@@ -191,12 +191,3 @@ def _(tensor0: torch.Tensor, tensor1: torch.Tensor) -> torch.Tensor:
 def _(tensor0: torch.Tensor, tensor1: torch.Tensor) -> torch.Tensor:
     left, right = torch.broadcast_tensors(tensor0, tensor1)
     return torch.stack((left, right), dim=-1)
-
-
-# ---------------------------------------------------------------------------
-# Backend-specific codegens for these ops live in per-backend modules under
-# helion/_compiler/<backend>/.  Import them here (at module import time) so the
-# @_decorators.codegen(op, "<backend>") registrations run with the same eager
-# timing as when the bodies lived in this file -- no behavior change.
-import helion._compiler.cute.view_ops  # noqa: E402, F401
-import helion._compiler.triton.view_ops  # noqa: E402, F401


### PR DESCRIPTION
Stacked PRs:
 * #3097
 * __->__#3092


--- --- ---

### refactor: centralize per-backend codegen registration via the backend registry


The earlier per-backend codegen moves left ~40 scattered
`import helion._compiler.<backend>.<module>` bottom-imports across 17 core files
(16 under helion/language/ plus _compiler/aten_lowering.py) whose only job was to
trigger each backend's @_decorators.codegen / register_codegen handlers at import
time. Every new backend had to edit all of those core files.

Replace that with a registry-driven mechanism:

- Each backend lists its own codegen modules in
  helion/_compiler/<backend>/_codegen_modules.py (self-contained per backend).
- backend_registry.import_backend_codegen() imports each registered backend's
  _codegen_modules, deriving the package from the Backend class's __module__ (so
  TileIRBackend collapses onto the triton package, and a backend without codegen
  modules is skipped).
- helion/language/__init__.py calls it once, after all ops are defined, so the
  eager registration timing matches the old per-file bottom imports.

Adding a backend now touches only its own folder plus the single backend_registry
entry it already needs -- never the core language files. No behavior change: the
set of (op/lowering, backend) codegen registrations is identical before and after
(verified on triton locally and pallas on TPU).
