### PR TITLE
refactor: move backend-specific sympy printers into per-backend `printer.py`

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -187,7 +187,7 @@ class Backend(abc.ABC):
 
     def sympy_printer_expr(self, expr: sympy.Expr) -> str:
         """Render a SymPy expression for this backend's device code."""
-        from .device_function import texpr
+        from .triton.printer import texpr
 
         return texpr(expr)
 

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -1121,7 +1121,7 @@ class CuteBackend(Backend):
         return f"cutlass.Int32({lane_var})"
 
     def sympy_printer_expr(self, expr: sympy.Expr) -> str:
-        from ..device_function import cute_texpr
+        from .printer import cute_texpr
 
         return cute_texpr(expr)
 

--- a/helion/_compiler/cute/printer.py
+++ b/helion/_compiler/cute/printer.py
@@ -1,0 +1,45 @@
+"""Cute-backend sympy expression printer.
+
+``HelionCutePrinter`` extends :class:`~helion._compiler.triton.printer.HelionTritonPrinter`
+to avoid Triton runtime helpers in device expressions.  Moved out of
+``device_function.py`` so each backend owns its own printer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import cast
+
+from ..triton.printer import HelionTritonPrinter
+
+if TYPE_CHECKING:
+    import sympy
+
+
+class HelionCutePrinter(HelionTritonPrinter):
+    """CuTe printer that avoids Triton runtime helpers in device expressions."""
+
+    def _print_basic_expr(self, expr: sympy.Basic) -> str:
+        return self.doprint(cast("sympy.Expr", expr))
+
+    def _print_FloorDiv(self, expr: sympy.Expr) -> str:
+        lhs, rhs = expr.args
+        return f"({self._print_basic_expr(lhs)} // {self._print_basic_expr(rhs)})"
+
+    def _print_CleanDiv(self, expr: sympy.Expr) -> str:
+        lhs, rhs = expr.args
+        return f"({self._print_basic_expr(lhs)} // {self._print_basic_expr(rhs)})"
+
+    def _print_CeilDiv(self, expr: sympy.Expr) -> str:
+        lhs, rhs = expr.args
+        lhs_printed = self._print_basic_expr(lhs)
+        rhs_printed = self._print_basic_expr(rhs)
+        return f"(({lhs_printed} + {rhs_printed} - 1) // {rhs_printed})"
+
+    def _print_PythonMod(self, expr: sympy.Expr) -> str:
+        lhs, rhs = expr.args
+        return f"({self._print_basic_expr(lhs)} % {self._print_basic_expr(rhs)})"
+
+
+def cute_texpr(expr: sympy.Expr) -> str:
+    return HelionCutePrinter().doprint(expr)

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -17,7 +17,6 @@ from typing import cast
 import sympy
 import torch
 from torch._dynamo.source import LocalSource
-from torch._inductor.codegen.triton import TritonPrinter
 from torch.fx.graph import _Namespace
 
 from .. import exc
@@ -1207,98 +1206,3 @@ class DeviceFunction:
             return tls.functions[-1]
         except (AttributeError, IndexError):
             raise NoCurrentFunction from None
-
-
-class HelionTritonPrinter(TritonPrinter):
-    """Custom Triton printer that does the following:
-
-    - Avoids wrapping float literals in tl.full().
-     Inductor's default TritonPrinter prints SymPy Float as a 0-D Triton value
-     via tl.full([], <val>, tl.float64). We override this to emit the raw numeric
-     literal, letting downstream type promotion and casts handle dtype.
-
-    - Avoids triton_helpers.div_floor_integer(...) calls when both operands are
-      provably non-negative integers. TritonPrinter by default converts
-      floor(u1/2) to triton_helpers.div_floor_integer(...). We override this to
-      emit u1 // 2 only when the numerator is known to be non-negative and the
-      denominator is a positive integer, so that we keep helper calls for cases
-      that rely on floor semantics with mixed signs.
-    """
-
-    def _print_Float(self, expr: sympy.Expr) -> str:
-        return str(expr)
-
-    def _print_ToFloat(self, expr: sympy.Expr) -> str:
-        assert expr.func.__name__ == "ToFloat" and len(expr.args) == 1
-        # pyrefly: ignore [missing-attribute]
-        return f"{self._print(expr.args[0])} + 0.0"
-
-    def _print_FloorDiv(self, expr: sympy.Expr) -> str:
-        lhs, rhs = expr.args
-        # Only use // operator when:
-        # 1. RHS is an integer constant
-        # 2. LHS is a constexpr argument (autotune parameter like block size)
-        # This ensures TMA descriptors get compile-time constants while preserving
-        if (
-            isinstance(rhs, sympy.Integer)
-            and getattr(lhs, "name", None) in DeviceFunction.current()._constexpr_args
-        ):
-            # pyrefly: ignore [missing-attribute]
-            lhs_str = self._print(lhs)
-            # pyrefly: ignore [missing-attribute]
-            rhs_str = self._print(rhs)
-            if not (lhs.is_Integer or lhs.is_Symbol):
-                lhs_str = f"({lhs_str})"
-            return f"{lhs_str} // {rhs_str}"
-        return super()._print_FloorDiv(expr)
-
-
-def texpr(expr: sympy.Expr) -> str:
-    return HelionTritonPrinter().doprint(expr)
-
-
-class HelionCutePrinter(HelionTritonPrinter):
-    """CuTe printer that avoids Triton runtime helpers in device expressions."""
-
-    def _print_basic_expr(self, expr: sympy.Basic) -> str:
-        return self.doprint(cast("sympy.Expr", expr))
-
-    def _print_FloorDiv(self, expr: sympy.Expr) -> str:
-        lhs, rhs = expr.args
-        return f"({self._print_basic_expr(lhs)} // {self._print_basic_expr(rhs)})"
-
-    def _print_CleanDiv(self, expr: sympy.Expr) -> str:
-        lhs, rhs = expr.args
-        return f"({self._print_basic_expr(lhs)} // {self._print_basic_expr(rhs)})"
-
-    def _print_CeilDiv(self, expr: sympy.Expr) -> str:
-        lhs, rhs = expr.args
-        lhs_printed = self._print_basic_expr(lhs)
-        rhs_printed = self._print_basic_expr(rhs)
-        return f"(({lhs_printed} + {rhs_printed} - 1) // {rhs_printed})"
-
-    def _print_PythonMod(self, expr: sympy.Expr) -> str:
-        lhs, rhs = expr.args
-        return f"({self._print_basic_expr(lhs)} % {self._print_basic_expr(rhs)})"
-
-
-def cute_texpr(expr: sympy.Expr) -> str:
-    return HelionCutePrinter().doprint(expr)
-
-
-class HelionPallasPrinter(HelionTritonPrinter):
-    """Pallas printer that emits plain Python operators instead of Triton runtime helpers."""
-
-    def _print_FloorDiv(self, expr: sympy.Expr) -> str:
-        lhs, rhs = expr.args
-        # pyrefly: ignore [missing-attribute]
-        return f"({self._print(lhs)} // {self._print(rhs)})"
-
-    def _print_PythonMod(self, expr: sympy.Expr) -> str:
-        lhs, rhs = expr.args
-        # pyrefly: ignore [missing-attribute]
-        return f"({self._print(lhs)} % {self._print(rhs)})"
-
-
-def pallas_texpr(expr: sympy.Expr) -> str:
-    return HelionPallasPrinter().doprint(expr)

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -222,7 +222,7 @@ class PallasBackend(Backend):
         return f"{offsets_var} = {lid} * {block_size_var} + jnp.arange(0, {block_size_var}, dtype={dtype})"
 
     def sympy_printer_expr(self, expr: sympy.Expr) -> str:
-        from ..device_function import pallas_texpr
+        from .printer import pallas_texpr
 
         return pallas_texpr(expr)
 

--- a/helion/_compiler/pallas/printer.py
+++ b/helion/_compiler/pallas/printer.py
@@ -1,0 +1,33 @@
+"""Pallas-backend sympy expression printer.
+
+``HelionPallasPrinter`` extends :class:`~helion._compiler.triton.printer.HelionTritonPrinter`
+to emit plain Python operators instead of Triton runtime helpers.  Moved out of
+``device_function.py`` so each backend owns its own printer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..triton.printer import HelionTritonPrinter
+
+if TYPE_CHECKING:
+    import sympy
+
+
+class HelionPallasPrinter(HelionTritonPrinter):
+    """Pallas printer that emits plain Python operators instead of Triton runtime helpers."""
+
+    def _print_FloorDiv(self, expr: sympy.Expr) -> str:
+        lhs, rhs = expr.args
+        # pyrefly: ignore [missing-attribute]
+        return f"({self._print(lhs)} // {self._print(rhs)})"
+
+    def _print_PythonMod(self, expr: sympy.Expr) -> str:
+        lhs, rhs = expr.args
+        # pyrefly: ignore [missing-attribute]
+        return f"({self._print(lhs)} % {self._print(rhs)})"
+
+
+def pallas_texpr(expr: sympy.Expr) -> str:
+    return HelionPallasPrinter().doprint(expr)

--- a/helion/_compiler/triton/printer.py
+++ b/helion/_compiler/triton/printer.py
@@ -1,0 +1,62 @@
+"""Triton-backend sympy expression printer.
+
+``HelionTritonPrinter`` customises inductor's ``TritonPrinter``; it is also the
+base class for the Cute and Pallas printers
+(``helion/_compiler/{cute,pallas}/printer.py``).  Moved out of
+``device_function.py`` so each backend owns its own printer.
+"""
+
+from __future__ import annotations
+
+import sympy
+from torch._inductor.codegen.triton import TritonPrinter
+
+
+class HelionTritonPrinter(TritonPrinter):
+    """Custom Triton printer that does the following:
+
+    - Avoids wrapping float literals in tl.full().
+     Inductor's default TritonPrinter prints SymPy Float as a 0-D Triton value
+     via tl.full([], <val>, tl.float64). We override this to emit the raw numeric
+     literal, letting downstream type promotion and casts handle dtype.
+
+    - Avoids triton_helpers.div_floor_integer(...) calls when both operands are
+      provably non-negative integers. TritonPrinter by default converts
+      floor(u1/2) to triton_helpers.div_floor_integer(...). We override this to
+      emit u1 // 2 only when the numerator is known to be non-negative and the
+      denominator is a positive integer, so that we keep helper calls for cases
+      that rely on floor semantics with mixed signs.
+    """
+
+    def _print_Float(self, expr: sympy.Expr) -> str:
+        return str(expr)
+
+    def _print_ToFloat(self, expr: sympy.Expr) -> str:
+        assert expr.func.__name__ == "ToFloat" and len(expr.args) == 1
+        # pyrefly: ignore [missing-attribute]
+        return f"{self._print(expr.args[0])} + 0.0"
+
+    def _print_FloorDiv(self, expr: sympy.Expr) -> str:
+        from ..device_function import DeviceFunction
+
+        lhs, rhs = expr.args
+        # Only use // operator when:
+        # 1. RHS is an integer constant
+        # 2. LHS is a constexpr argument (autotune parameter like block size)
+        # This ensures TMA descriptors get compile-time constants while preserving
+        if (
+            isinstance(rhs, sympy.Integer)
+            and getattr(lhs, "name", None) in DeviceFunction.current()._constexpr_args
+        ):
+            # pyrefly: ignore [missing-attribute]
+            lhs_str = self._print(lhs)
+            # pyrefly: ignore [missing-attribute]
+            rhs_str = self._print(rhs)
+            if not (lhs.is_Integer or lhs.is_Symbol):
+                lhs_str = f"({lhs_str})"
+            return f"{lhs_str} // {rhs_str}"
+        return super()._print_FloorDiv(expr)
+
+
+def texpr(expr: sympy.Expr) -> str:
+    return HelionTritonPrinter().doprint(expr)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1182,7 +1182,7 @@ class TestHelionTritonPrinter(TestCase):
         import sympy
         from torch.utils._sympy.functions import ToFloat
 
-        from helion._compiler.device_function import HelionTritonPrinter
+        from helion._compiler.triton.printer import HelionTritonPrinter
 
         printer = HelionTritonPrinter()
 
@@ -1205,7 +1205,7 @@ class TestHelionTritonPrinter(TestCase):
         """Test that Float expressions are printed as raw literals."""
         import sympy
 
-        from helion._compiler.device_function import HelionTritonPrinter
+        from helion._compiler.triton.printer import HelionTritonPrinter
 
         printer = HelionTritonPrinter()
 
@@ -1230,7 +1230,7 @@ class TestHelionTritonPrinter(TestCase):
         from torch.utils._sympy.functions import FloorDiv
 
         from helion._compiler.device_function import DeviceFunction
-        from helion._compiler.device_function import HelionTritonPrinter
+        from helion._compiler.triton.printer import HelionTritonPrinter
 
         printer = HelionTritonPrinter()
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -5085,7 +5085,7 @@ class TestPallasPrinter(TestCase):
         from torch.utils._sympy.functions import FloorDiv
         from torch.utils._sympy.functions import PythonMod
 
-        from helion._compiler.device_function import pallas_texpr
+        from helion._compiler.pallas.printer import pallas_texpr
 
         x, y = sympy.symbols("x y")
         self.assertEqual(pallas_texpr(PythonMod(x, y)), "(x % y)")


### PR DESCRIPTION

device_function.py held three backend-specific sympy printers --
HelionTritonPrinter, HelionCutePrinter, HelionPallasPrinter (plus their
texpr / cute_texpr / pallas_texpr helpers).  Move each into its backend's
folder so the backend owns its own printer:

- HelionTritonPrinter + texpr        -> triton/printer.py
- HelionCutePrinter + cute_texpr     -> cute/printer.py
- HelionPallasPrinter + pallas_texpr -> pallas/printer.py

The Cute and Pallas printers subclass HelionTritonPrinter, so they import it
from triton/printer.py.  Each backend's ``sympy_printer_expr`` now imports its
helper from the new location.  HelionTritonPrinter lazily imports
DeviceFunction inside ``_print_FloorDiv`` to avoid an import cycle.  No
behavior change.
