### PR TITLE
Fix rank mismatch for size-1 slice store patterns

### DIFF
--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -695,17 +695,18 @@ class PointerIndexingStrategy(IndexingStrategy):
                 tensor_dim += 1
                 k_index += 1
 
-        # If pointer is scalar but output_size has dimensions, reshape value to scalar.
-        # Skip reshaping for scalar constants which don't have shape.
         backend = CompileEnvironment.current().backend
-        if (
-            not pointer_has_block_dims
-            and output_size
-            and not isinstance(value, ast.Constant)
-        ):
-            # Pointer is scalar but value may have shape - squeeze to scalar
-            reshape = backend.reshape_expr("{value}", "[]")
-            value = expr_from_string(reshape, value=value)
+        if not pointer_has_block_dims and not isinstance(value, ast.Constant):
+            if output_size:
+                reshape = backend.reshape_expr("{value}", "[]")
+                value = expr_from_string(reshape, value=value)
+            elif state.fx_node is not None and len(state.fx_node.args) > 2:
+                value_node = state.fx_node.args[2]
+                if isinstance(value_node, torch.fx.Node):
+                    val_meta = value_node.meta.get("val")
+                    if isinstance(val_meta, torch.Tensor) and val_meta.ndim > 0:
+                        reshape = backend.reshape_expr("{value}", "[]")
+                        value = expr_from_string(reshape, value=value)
 
         offset_expr = indexing.index_expr
         # If dimensions need broadcasting for store, broadcast the pointer

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -695,18 +695,24 @@ class PointerIndexingStrategy(IndexingStrategy):
                 tensor_dim += 1
                 k_index += 1
 
+        # Pointer is scalar but output_size has dimensions, reshape value to scalar.
         backend = CompileEnvironment.current().backend
-        if not pointer_has_block_dims and not isinstance(value, ast.Constant):
-            if output_size:
-                reshape = backend.reshape_expr("{value}", "[]")
-                value = expr_from_string(reshape, value=value)
-            elif state.fx_node is not None and len(state.fx_node.args) > 2:
-                value_node = state.fx_node.args[2]
-                if isinstance(value_node, torch.fx.Node):
-                    val_meta = value_node.meta.get("val")
-                    if isinstance(val_meta, torch.Tensor) and val_meta.ndim > 0:
-                        reshape = backend.reshape_expr("{value}", "[]")
-                        value = expr_from_string(reshape, value=value)
+        needs_squeeze = bool(output_size)
+        if (
+            not needs_squeeze
+            and state.fx_node is not None
+            and len(state.fx_node.args) > 2
+        ):
+            value_node = state.fx_node.args[2]
+            if isinstance(value_node, torch.fx.Node):
+                val_meta = value_node.meta.get("val")
+                needs_squeeze = isinstance(val_meta, torch.Tensor) and val_meta.ndim > 0
+        if (
+            not pointer_has_block_dims
+            and not isinstance(value, ast.Constant)
+            and needs_squeeze
+        ):
+            value = expr_from_string(backend.reshape_expr("{value}", "[]"), value=value)
 
         offset_expr = indexing.index_expr
         # If dimensions need broadcasting for store, broadcast the pointer

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -446,8 +446,9 @@ class TensorType(TypeInfo):
                 rhs_rank = value.fake_value.ndim
                 # Allow scalar tensors (rank 0) to be assigned to any rank (broadcasts)
                 if rhs_rank != 0 and lhs_rank != rhs_rank:
+                    env = CompileEnvironment.current()
                     can_squeeze = rhs_rank > lhs_rank and all(
-                        value.fake_value.size(d) == 1
+                        env.known_equal(value.fake_value.size(d), 1)
                         for d in range(rhs_rank - lhs_rank)
                     )
                     if not can_squeeze:

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -446,11 +446,16 @@ class TensorType(TypeInfo):
                 rhs_rank = value.fake_value.ndim
                 # Allow scalar tensors (rank 0) to be assigned to any rank (broadcasts)
                 if rhs_rank != 0 and lhs_rank != rhs_rank:
-                    raise exc.RankMismatch(
-                        lhs_rank,
-                        rhs_rank,
-                        f"LHS shape: {tuple(lhs_shape)}, RHS shape: {tuple(value.fake_value.shape)}",
+                    can_squeeze = rhs_rank > lhs_rank and all(
+                        value.fake_value.size(d) == 1
+                        for d in range(rhs_rank - lhs_rank)
                     )
+                    if not can_squeeze:
+                        raise exc.RankMismatch(
+                            lhs_rank,
+                            rhs_rank,
+                            f"LHS shape: {tuple(lhs_shape)}, RHS shape: {tuple(value.fake_value.shape)}",
+                        )
             elif isinstance(value, (NumericType, LiteralType)):
                 # Allow scalar assignment to tensor (broadcasts to tensor shape)
                 pass

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -2059,6 +2059,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src_result, expected_src)
         torch.testing.assert_close(dst_result, expected_dst)
 
+    @xfailIfCute("incorrect results on cute backend")
     def test_range_slice_dynamic(self):
         """Test both [i:i+1] = scalar and [i] = [i:i+1] patterns"""
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -2059,9 +2059,6 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src_result, expected_src)
         torch.testing.assert_close(dst_result, expected_dst)
 
-    @skipIfNormalMode(
-        "InternalError: AssertionError in type_propagation.py - slice indexing error"
-    )
     def test_range_slice_dynamic(self):
         """Test both [i:i+1] = scalar and [i] = [i:i+1] patterns"""
 


### PR DESCRIPTION
### Summary:

- Allow `src[i] = dst[i:i+1]` patterns in compiled mode by handling the rank mismatch when extra dims are size 1.
- Enables `test_range_slice_dynamic` which was previously skipped.


### Tests:

- `pytest test/test_indexing.py -k test_range_slice_dynamic`