### PR TITLE
[pallas][jax_fn] handle Helion-lifted constant tensors in the export launcher

### DIFF
--- a/helion/runtime/pallas_jax_export.py
+++ b/helion/runtime/pallas_jax_export.py
@@ -251,6 +251,24 @@ def _device_for_jax_export() -> torch.device:
     return torch.device("cpu")
 
 
+def _tensor_arg_to_jax(arg: object) -> object:
+    """Return the JAX array for a kernel tensor argument.
+
+    Most tensor args are ``_JaxExportTensor`` adapters carrying the caller's JAX
+    array. Helion can also lift Python scalar constants used in the kernel body
+    (e.g. an epsilon threshold or a ``-inf`` mask fill) into ``torch.tensor([...])``
+    device constants in the generated host wrapper; those arrive as plain torch
+    tensors (not adapters), so materialize them as JAX arrays here.
+    """
+    if isinstance(arg, _JaxExportTensor):
+        return arg._jax_arr
+    if isinstance(arg, torch.Tensor):
+        import jax.numpy as jnp
+
+        return jnp.asarray(arg.detach().cpu().numpy())
+    return arg
+
+
 def default_pallas_jax_launcher(
     pallas_kernel: object,
     grid: tuple[int, ...],
@@ -374,9 +392,7 @@ def default_pallas_jax_launcher(
             interpret=interpret,
         )
 
-    jax_inputs = [
-        cast("_JaxExportTensor", args[i])._jax_arr for i in result.tensor_arg_indices
-    ]
+    jax_inputs = [_tensor_arg_to_jax(args[i]) for i in result.tensor_arg_indices]
     jax_results = result.jit_fn(*jax_inputs)  # type: ignore[operator]
     if not isinstance(jax_results, (tuple, list)):
         jax_results = (jax_results,)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4895,6 +4895,11 @@ class TestPallasIndirectGather(TestCase):
 instantiate_parametrized_tests(TestPallasIndirectGather)
 
 
+# Module-level so Helion lifts it into a host-wrapper torch.tensor([...]) kernel
+# arg (see test_jax_fn_lifted_constant).
+_JAXFN_LIFTED_CONST = 0.5
+
+
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallasJaxFn(TestCase):
     """End-to-end tests for the ``Kernel.jax_fn`` pure-JAX export path.
@@ -4951,6 +4956,31 @@ class TestPallasJaxFn(TestCase):
         ref_c = ref_a + ref_b
         ref = float(jnp.sum(ref_c) + jnp.mean(ref_c) * 0.5)
         self.assertAlmostEqual(result, ref, places=2)
+
+    def test_jax_fn_lifted_constant(self) -> None:
+        """jax_fn handles a Python float constant that Helion lifts into a
+        host-wrapper ``torch.tensor([...])`` kernel arg (regression: the launcher
+        assumed every tensor arg was a ``_JaxExportTensor`` -> AttributeError
+        ``_jax_arr``)."""
+        jax, jnp = self._import_jax()
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[128, 128]),
+        )
+        def thresh_kernel(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                v = x[tile]
+                out[tile] = torch.where(v > _JAXFN_LIFTED_CONST, v, 0.0)
+            return out
+
+        f = jax.jit(thresh_kernel.jax_fn)
+        a = (jnp.arange(128 * 128, dtype=jnp.float32) / (128 * 128)).reshape(128, 128)
+        result = jax.block_until_ready(f(a))
+        ref = jnp.where(a > _JAXFN_LIFTED_CONST, a, 0.0)
+        self.assertTrue(bool(jnp.allclose(result, ref, atol=1e-5)))
 
     def test_jax_fn_unroll(self) -> None:
         """jax_fn drives an unroll kernel inside ``jax.jit``."""


### PR DESCRIPTION
Stacked PRs:
 * #3104
 * __->__#3100


--- --- ---

### [pallas][jax_fn] handle Helion-lifted constant tensors in the export launcher


Kernel bodies that reference a Python scalar constant (e.g. an eps threshold or a
-inf mask fill) make Helion lift it into a `torch.tensor([...])` constant in the
generated host wrapper. The `jax_fn` launcher assumed every tensor arg was a
`_JaxExportTensor` and read `._jax_arr`, raising `AttributeError` on such
constants. Add `_tensor_arg_to_jax` to convert plain torch constant tensors to
JAX arrays.

Test: `TestPallasJaxFn.test_jax_fn_lifted_constant` (fails without the fix).
