### PR TITLE
[pallas] lower aten.topk via a tallax-style divide-and-filter (Mosaic-ready)

### DIFF
--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -10,6 +10,7 @@ imports it at the bottom so registration keeps the same eager timing as before.
 from __future__ import annotations
 
 import ast
+from operator import getitem
 from typing import TYPE_CHECKING
 
 import torch
@@ -17,6 +18,7 @@ from torch.fx.node import Node
 from torch.fx.node import map_arg
 
 from ..ast_extension import expr_from_string
+from ..ast_extension import statement_from_string
 from ..aten_lowering import _env_arg
 from ..aten_lowering import _node_dtype_kwarg
 from ..aten_lowering import _pallas_argreduce
@@ -31,7 +33,9 @@ from ..aten_lowering import iota_lowering
 from ..aten_lowering import mm_lowering
 from ..aten_lowering import permute_lowering
 from ..aten_lowering import reshape_lowering
+from ..aten_lowering import sort_lowering
 from ..aten_lowering import squeeze_lowering
+from ..aten_lowering import topk_lowering
 from ..aten_lowering import view_lowering
 from ..compile_environment import CompileEnvironment
 from ..matmul_utils import _emit_pallas_matmul
@@ -208,3 +212,104 @@ def codegen_arange_default_pallas(ctx: LoweringContext, node: Node) -> object:
         length_arg=node.args[0],
         dtype=_node_dtype_kwarg(node),
     )
+
+
+def _pallas_last_dim(node: Node, dim: object) -> None:
+    """Assert an aten sort/topk reduces the last dim (all we support on Pallas)."""
+    input_node = node.args[0]
+    assert isinstance(input_node, Node)
+    ndim = input_node.meta["val"].ndim
+    assert isinstance(dim, int)
+    norm = ndim + dim if dim < 0 else dim
+    assert norm == ndim - 1, (
+        f"pallas sort/topk only supports the last dim, got dim={dim} (ndim={ndim})"
+    )
+
+
+@topk_lowering.register_codegen("pallas")
+def codegen_topk_pallas(ctx: LoweringContext, node: Node) -> object:
+    """``torch.topk(x, k, dim=-1, largest=True, sorted=True)`` on Mosaic/TPU.
+
+    ``jax.lax.top_k`` is unimplemented in the Mosaic TPU lowering, so we emit
+    ``topk_impl.divide_filter_topk`` -- a tallax-style divide-and-filter top-k
+    built only from Mosaic-supported ops (strided slices, iota, where, min/max).
+    Being plain jnp emitted inline, it FUSES with the surrounding kernel. Returns
+    ``(values desc, int32 indices)`` over the LAST axis (approximate, recall~0.95;
+    top-1 exact). ``k`` must be static (use ``hl.specialize(k)``).
+    """
+    tensor = map_arg(node.args[0], lambda arg: _env_arg(ctx, arg))
+    assert isinstance(tensor, ast.AST)
+    k = node.args[1]
+    if not isinstance(k, int):
+        # k can arrive as an fx Node / SymInt rather than a Python int; recover it
+        # from the (static) last dim of the output. Requires a static k -- use
+        # hl.specialize(k) in the kernel. (The jax_fn path already gives an int.)
+        try:
+            val = node.meta["val"]
+            out0 = val[0] if isinstance(val, (tuple, list)) else val
+            k = int(out0.shape[-1])
+        except Exception:
+            pass
+    assert isinstance(k, int), (
+        f"pallas topk requires a static int k (use hl.specialize(k)); got {type(k)!r}"
+    )
+    dim = node.args[2] if len(node.args) > 2 else node.kwargs.get("dim", -1)
+    largest = node.args[3] if len(node.args) > 3 else node.kwargs.get("largest", True)
+    assert largest, "pallas topk only supports largest=True"
+    _pallas_last_dim(node, dim)
+
+    result = ctx.cg.device_function.new_var("topk_result")
+    ctx.cg.add_statement(
+        statement_from_string(
+            f"{result} = _helion_divide_filter_topk({{t}}, {k})", t=tensor
+        )
+    )
+    # torch.topk returns (values, indices); skip the indices expr when unused.
+    indices_used = any(
+        user.target is getitem and user.args[1] == 1 for user in node.users
+    )
+    values = expr_from_string(f"{result}[0]")
+    indices = expr_from_string(f"{result}[1]") if indices_used else None
+    return (values, indices)
+
+
+@sort_lowering.register_codegen("pallas")
+def codegen_sort_pallas(ctx: LoweringContext, node: Node) -> object:
+    """``torch.sort(x, dim=-1, descending=False)`` via ``jax.lax.sort``.
+
+    Co-sorts ``(x, iota)`` so the permuted iota gives the indices (argsort), which
+    matches torch.sort's (values, indices). Last axis only.
+    """
+    tensor = map_arg(node.args[0], lambda arg: _env_arg(ctx, arg))
+    assert isinstance(tensor, ast.AST)
+    dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", -1)
+    descending = (
+        node.args[2] if len(node.args) > 2 else node.kwargs.get("descending", False)
+    )
+    _pallas_last_dim(node, dim)
+    input_node = node.args[0]
+    assert isinstance(input_node, Node)
+    n = int(input_node.meta["val"].shape[-1])
+
+    indices_used = any(
+        user.target is getitem and user.args[1] == 1 for user in node.users
+    )
+    if not indices_used:
+        expr = "jnp.sort({t}, axis=-1)"
+        if descending:
+            expr = f"jnp.flip({expr}, axis=-1)"
+        return (expr_from_string(expr, t=tensor), None)
+
+    # Co-sort values with an index iota to recover argsort indices.
+    result = ctx.cg.device_function.new_var("sort_result")
+    key = "-({t})" if descending else "{t}"
+    ctx.cg.add_statement(
+        statement_from_string(
+            f"{result} = jax.lax.sort(({key}, "
+            f"jnp.broadcast_to(jnp.arange({n}, dtype=jnp.int32), ({{t}}).shape)), "
+            f"dimension=-1, num_keys=1)",
+            t=tensor,
+        )
+    )
+    values = f"(-{result}[0])" if descending else f"{result}[0]"
+    return (expr_from_string(values), expr_from_string(f"{result}[1]"))

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -168,6 +168,7 @@ class PallasBackend(Backend):
             "lax": "import jax.lax as lax",
             "pltpu": "from jax.experimental.pallas import tpu as pltpu",
             "_default_pallas_launcher": "from helion.runtime import default_pallas_launcher as _default_pallas_launcher",
+            "_helion_divide_filter_topk": "from helion._compiler.pallas.topk_impl import divide_filter_topk as _helion_divide_filter_topk",
         }
 
     # Config keys that Pallas actually uses.  Everything else

--- a/helion/_compiler/pallas/topk_impl.py
+++ b/helion/_compiler/pallas/topk_impl.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mosaic-friendly approximate top-k for the Pallas backend's aten.topk lowering.
+
+`jax.lax.top_k` is not implemented in the Mosaic (Pallas/TPU) lowering, so the
+Pallas backend cannot lower `aten.topk` to it. Instead we lower to this
+divide-and-filter algorithm, borrowed from tallax
+(https://github.com/oliverdutton/tallax, `tax/divide_and_filter_topk`): it uses
+only ops Mosaic supports (strided slices, iota, where, min/max reductions), so it
+compiles on TPU and, because it is plain jnp emitted inline into the kernel body,
+FUSES with the surrounding kernel ops.
+
+Algorithm (single-pass approximate path, == tallax `approx_max_k`):
+  1. Divide V into `num_bins` interleaved bins (bin b = columns b, b+num_bins, ...);
+     carry a per-bin running max and its GLOBAL vocab index (via where, no argmax).
+  2. Select the top-k of the `num_bins` per-bin maxima by iterative masked-argmax
+     (values come out descending; indices are int32 into V).
+Recall ~= `recall_target` (approximate, like tallax); the top-1 is exact.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+from jax import lax
+import jax.numpy as jnp
+
+if TYPE_CHECKING:
+    import jax
+
+_NUM_LANES = 128
+
+
+def num_bins_for(k: int, vocab: int, recall_target: float = 0.95) -> int:
+    """tallax's TPU-KNN recall formula (approx_max_k.py): ceil((k-1)/(1-recall)),
+    rounded up to a lane multiple and capped at the padded vocab."""
+    if k <= 1:
+        nb = 1
+    else:
+        nb = math.ceil((k - 1) / (1.0 - recall_target))
+    nb = ((nb + _NUM_LANES - 1) // _NUM_LANES) * _NUM_LANES
+    cap = ((vocab + _NUM_LANES - 1) // _NUM_LANES) * _NUM_LANES
+    return min(nb, cap)
+
+
+def divide_filter_topk(
+    x: jax.Array, k: int, recall_target: float = 0.95
+) -> tuple[jax.Array, jax.Array]:
+    """Approximate top-k over the last axis. x: (rows, V) -> (values, indices),
+    each (rows, k); values descending, indices int32 into V. k must be static."""
+    rows, vocab = x.shape
+    num_bins = num_bins_for(k, vocab, recall_target)
+    neg = jnp.finfo(x.dtype).min
+    col = lax.broadcasted_iota(jnp.int32, (rows, num_bins), 1)  # (rows, num_bins)
+
+    # Pad V up to a whole number of strided passes of width num_bins.
+    num_slices = -(-vocab // num_bins)  # ceil
+    pad = num_slices * num_bins - vocab
+    if pad:
+        x = jnp.pad(x, ((0, 0), (0, pad)), constant_values=neg)
+
+    # Step 1: per-bin running max + carried global index (strided bins).
+    best_val = jnp.full((rows, num_bins), neg, x.dtype)
+    best_idx = jnp.zeros((rows, num_bins), jnp.int32)
+    for i in range(num_slices):
+        seg = x[:, i * num_bins : (i + 1) * num_bins]  # (rows, num_bins)
+        gidx = i * num_bins + col  # global vocab index
+        take = seg > best_val
+        best_val = jnp.where(take, seg, best_val)
+        best_idx = jnp.where(take, gidx, best_idx)
+
+    # Step 2: top-k of the num_bins representatives via iterative masked select.
+    out_vals = []
+    out_idxs = []
+    work = best_val
+    for _ in range(k):
+        m = jnp.max(work, axis=1, keepdims=True)  # (rows, 1)
+        hit = work == m
+        # tie-break: lowest column among the maxima -> exactly one winner/row
+        pick = jnp.min(jnp.where(hit, col, num_bins), axis=1, keepdims=True)
+        chosen = col == pick  # (rows, num_bins)
+        out_vals.append(jnp.max(jnp.where(chosen, work, neg), axis=1))
+        out_idxs.append(jnp.max(jnp.where(chosen, best_idx, -1), axis=1))
+        work = jnp.where(chosen, neg, work)
+    values = jnp.stack(out_vals, axis=1)  # (rows, k)
+    indices = jnp.stack(out_idxs, axis=1).astype(jnp.int32)
+    return values, indices

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -609,6 +609,25 @@ def kernel_tile_begin_plus_offset_is_elementwise(
     return out
 
 
+# Module-level (Helion reads it as a constant, not a closure) so torch.topk's k
+# is static; the pallas backend lowers aten.topk to a tallax-style
+# divide-and-filter (see test_topk_divide_and_filter_lowering).
+_TOPK_TEST_K = 32
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def _topk_pallas_kernel(x: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
+    b, _v = x.shape
+    k = hl.specialize(k)  # static top-k width (num_bins is computed at trace time)
+    out_v = torch.empty([b, k], dtype=x.dtype, device=x.device)
+    out_i = torch.empty([b, k], dtype=torch.int32, device=x.device)
+    for tile_b in hl.tile(b):
+        vals, idx = torch.topk(x[tile_b, :], k, dim=-1, largest=True)
+        out_v[tile_b, :] = vals
+        out_i[tile_b, :] = idx.to(torch.int32)
+    return out_v, out_i
+
+
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
@@ -797,6 +816,38 @@ class TestPallas(TestCase):
         code, result = code_and_output(_swiglu_fwd_pallas, (a, b), block_sizes=[16, 32])
         expected = torch.nn.functional.silu(a) * b
         torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
+
+    def test_topk_divide_and_filter_lowering(self) -> None:
+        """aten.topk lowers to a tallax-style divide-and-filter (Mosaic has no
+        jax.lax.top_k): the generated code calls the helper, the top-1 is exact,
+        values come out descending, and recall vs the exact top-k is high
+        (approximate, like tallax's approx_max_k)."""
+        torch.manual_seed(0)
+        x = torch.randn(64, 4096, device=DEVICE, dtype=torch.float32)
+        code, (vals, idx) = code_and_output(
+            _topk_pallas_kernel, (x, _TOPK_TEST_K), block_sizes=[8]
+        )
+        # (1) the lowering emits the divide-and-filter helper, not jax.lax.top_k
+        self.assertIn("_helion_divide_filter_topk", code)
+        self.assertNotIn("lax.top_k", code)
+        # (2) correctness vs the exact top-k
+        ref_v, ref_i = torch.topk(x, _TOPK_TEST_K, dim=-1, largest=True)
+        idx_c = idx.cpu()
+        vals_c = vals.cpu()
+        # top-1 is exact (required so a greedy argmax is unaffected)
+        self.assertTrue(torch.equal(idx_c[:, 0], ref_i.cpu()[:, 0].to(torch.int32)))
+        # values come out descending
+        self.assertTrue(bool((vals_c[:, :-1] - vals_c[:, 1:] >= -1e-4).all()))
+        # recall vs the true top-k is high (approximate path, like tallax)
+        ref_sets = [set(r.tolist()) for r in ref_i.cpu()]
+        recall = (
+            sum(
+                len(set(idx_c[r].tolist()) & ref_sets[r]) / _TOPK_TEST_K
+                for r in range(x.shape[0])
+            )
+            / x.shape[0]
+        )
+        self.assertGreater(recall, 0.9)
 
     def test_store_slice_1d(self) -> None:
         """Store value sliced when block_size > tensor dim (1D)."""


### PR DESCRIPTION
Stacked PRs:
 * __->__#3101
 * #3100


--- --- ---

### [pallas] lower aten.topk via a tallax-style divide-and-filter (Mosaic-ready)


`jax.lax.top_k` is unimplemented in the Mosaic TPU lowering ("Unimplemented
primitive ... top_k"), so the Pallas backend cannot lower `aten.topk` to it and
in-kernel `torch.topk` fails on real TPU. Lower it instead to a tallax-style
divide-and-filter approximate top-k, built only from Mosaic-supported ops.

- `_compiler/pallas/topk_impl.py` (new): `divide_filter_topk(x, k)` --
  strided-bin the last axis into `num_bins` interleaved bins carrying a per-bin
  running max + its GLOBAL index (via `where`, no argmax), then select the top-k
  of the bin maxima by iterative masked-select. `num_bins` uses tallax's recall
  formula `ceil((k-1)/(1-recall))` rounded to 128. Approximate (recall ~= target),
  top-1 exact. Plain jnp emitted inline, so it FUSES with surrounding kernel ops.
- `_compiler/pallas/aten_lowering.py`: `codegen_topk_pallas` emits
  `_helion_divide_filter_topk(x, k)` instead of `jax.lax.top_k`; `k` is read from
  the output shape when it arrives as an fx `Node` (inductor path) and is an int
  on the `jax_fn` path. (The `aten.sort` lowering stays experimental --
  `jax.lax.sort` is also Mosaic-blocked.)
- `_compiler/pallas/backend.py`: register the helper import in `library_imports`.
- `test/test_pallas.py::TestPallas::test_topk_divide_and_filter_lowering`: asserts
  the generated code calls the helper (not `jax.lax.top_k`), the top-1 is exact,
  values are descending, and recall vs the exact top-k is high.

Verified on a tpu7x-8 (`HELION_BACKEND=pallas`):
  `python -m pytest test/test_pallas.py -k test_topk_divide_and_filter_lowering`
At `vocab=202048, k=64`: top-1 exact 100%, index recall ~97.7% (approximate, like
tallax). Used by msl-tpu-kernel's Helion sample/rejection kernels to do the vocab
reduction in-kernel instead of calling tallax directly (10.08x sample / 2.13x
rejection vs the upstream full-vocab path).