### PR TITLE
[Pallas] Fix bridge helion measurement on TPU: device-agnostic compile-time sync

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1576,7 +1576,17 @@ def run_kernel_variants(
                         nonlocal first_call
                         if first_call:
                             first_call = False
-                            torch.cuda.synchronize()
+                            # Flush previously-queued work before the
+                            # compile-time counter starts (a pre-call counter
+                            # flush, not a result sync -- hence
+                            # accelerator.synchronize here, not the autotuner's
+                            # tensor-level synchronize_device). Bare
+                            # torch.cuda.synchronize() raised "Torch not compiled
+                            # with CUDA enabled" on TPU (torch_tpu builds against
+                            # CPU torch), failing every helion impl under
+                            # --measure-compile-time.
+                            if torch.accelerator.is_available():
+                                torch.accelerator.synchronize()
                             reset_compile_time()
                             try:
                                 result = original()


### PR DESCRIPTION
Helion's tritonbench-bridge driver (`benchmarks/run.py`) wraps the first call of each helion impl to measure compile time, and that wrapper called a bare `torch.cuda.synchronize()`. The TPU bridge sets `--measure-compile-time` (`HELION_MEASURE_COMPILE_TIME=1`), so on TPU — where torch is the CPU build + torch_tpu — that raised `Torch not compiled with CUDA enabled`, failing **every** helion impl. The job still passed (`--keep-going`), but recorded `helion_speedup`/`helion_accuracy` = `0.0` for all kernels — the helion column was silently empty.

Guard the sync with `torch.accelerator` (the device-agnostic pattern already used in `helion/autotuner/benchmarking.py`), so it drains queued work on CUDA and TPU alike.

Verified on the TPU runner (bridge, gemm): `helion_speedup` `[0.0,0.0]` → `[0.55,0.55]`, `helion_accuracy` `0.0` → `1.0`, `helion_latency_ms` `0.0` → `~0.31ms` ([run 29784265608](https://github.com/pytorch/helion/actions/runs/29784265608)). PRs don't trigger the benchmark workflows, so this isn't visible in PR CI.

Prerequisite for measuring helion on TPU through the bridge.