### PR TITLE
[Pallas] Materialize each benchmark output so a lazy torch.compile baseline can't inflate neighbors

### DIFF
--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -15,6 +15,7 @@ from typing import Callable
 from typing import TypeVar
 
 import torch
+from torch.utils._pytree import tree_leaves
 
 from ..runtime.settings import _env_get_bool
 from ..runtime.settings import is_pallas_interpret
@@ -129,6 +130,37 @@ def synchronize_device() -> None:
         torch.accelerator.synchronize()
 
 
+def _materialize_output(out: object) -> None:
+    """Force ``out`` to finish computing on-device, then drain the device.
+
+    ``synchronize_device()`` is a device-wide barrier: it waits for work that
+    has already been *dispatched*, but it does not *trigger* a lazily-executed
+    graph. On TorchTPU a ``torch.compile`` baseline (and lazily-materialized
+    kernels) record their work and defer it, so the barrier returns before that
+    work runs; the deferred work then executes inside the *next* timed
+    candidate's window, inflating that candidate's time while the lazy one is
+    measured as ~0ms. Waiting on the specific output tensor forces this
+    candidate's work to materialize inside its own timing window.
+
+    Non-TPU tensors dispatch eagerly (CUDA/CuTe), so there is nothing to force
+    and we just drain the device — leaving those backends' timing unchanged.
+    """
+    tpu_tensors = [
+        leaf
+        for leaf in tree_leaves(out)
+        if isinstance(leaf, torch.Tensor) and leaf.device.type == "tpu"
+    ]
+    if tpu_tensors:
+        # A device-wide sync alone will not trigger the lazy graph; wait on the
+        # produced tensors so their work runs before we stop the timer.
+        from torch_tpu._internal.sync import (  # pyrefly: ignore[missing-import]
+            synchronize as _tpu_sync,
+        )
+
+        _tpu_sync(tpu_tensors, wait=True)
+    synchronize_device()
+
+
 def compute_repeat(
     fn: Callable[[], object],
     *,
@@ -185,7 +217,7 @@ def compute_repeat_generic(
     """
     # Warm the pipeline once before collecting timing samples.
     _output = fn()
-    synchronize_device()
+    _materialize_output(_output)
 
     clear_l2 = _make_l2_cache_clearer()
     start = time.perf_counter()
@@ -193,7 +225,7 @@ def compute_repeat_generic(
         clear_l2()
         # Keep the latest asynchronous output alive through synchronization.
         _output = fn()
-    synchronize_device()
+    _materialize_output(_output)
     end = time.perf_counter()
 
     estimate_ms = (end - start) * 1000 / max(estimate_runs, 1)
@@ -286,7 +318,7 @@ def interleaved_bench_generic(
     _output: object = None
     for fn in fns:
         _output = fn()
-    synchronize_device()
+    _materialize_output(_output)
 
     clear_l2 = _make_l2_cache_clearer()
     all_times: list[list[float]] = [[] for _ in range(len(fns))]
@@ -302,10 +334,11 @@ def interleaved_bench_generic(
             clear_l2()
             synchronize_device()
             start = time.perf_counter()
-            # Dropping an asynchronous output before the sync can trigger device
-            # buffer destruction inside the timed region.
+            # Wait on this candidate's own output so its (possibly lazy) work
+            # materializes inside its timing window; a device-wide barrier
+            # would let a lazy candidate defer work into the next one's window.
             _output = fns[j]()
-            synchronize_device()
+            _materialize_output(_output)
             end = time.perf_counter()
             all_times[j].append((end - start) * 1000)  # convert to ms
 
@@ -599,7 +632,7 @@ def do_bench_generic(
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
     _output = fn()
-    synchronize_device()
+    _materialize_output(_output)
 
     clear_l2 = _make_l2_cache_clearer()
 
@@ -610,7 +643,7 @@ def do_bench_generic(
         clear_l2()
         # Keep the latest asynchronous output alive through synchronization.
         _output = fn()
-    synchronize_device()
+    _materialize_output(_output)
     end = time.perf_counter()
     estimate_ms = sync_object(
         (end - start) * 1000 / 5, process_group_name=process_group_name
@@ -632,7 +665,7 @@ def do_bench_generic(
         synchronize_device()
         t0 = time.perf_counter()
         _output = fn()
-        synchronize_device()
+        _materialize_output(_output)
         t1 = time.perf_counter()
         times.append((t1 - t0) * 1000)  # convert to ms
     return _summarize_statistics_fallback(times, quantiles, return_mode)


### PR DESCRIPTION
## Summary

The Pallas/TPU wall-clock bench (`interleaved_bench_generic`, `do_bench_generic`, `compute_repeat_generic`) closes each candidate's timing window with a **device-wide** `synchronize_device()`. A device-wide barrier waits for work that has already been *dispatched*, but on the current torch_tpu it does **not** force a lazily-executed `torch.compile` graph to run. When a kernel is benchmarked against a `torch.compile` baseline (the standard `run_tpu.py` setup uses both `torch` and `torch_compile` baselines, interleaved), the compiled baseline records ~0 ms and defers its work, which then executes inside the **next** candidate's window:

- the `torch_compile` baseline is measured as ~0 ms, and
- the following candidate (e.g. the Helion kernel) absorbs that work and is measured **~3× its real time**.

The kernel is not slower — only the reported number is wrong. This surfaced as a large, real-looking regression on VMEM-heavy kernels (flash_attention and similar) on the TPU perf dashboard.

## Fix

Wait on **each candidate's own output tensor** before stopping its timer, so its (possibly lazy) work materializes inside its own window instead of leaking into the next candidate's. The interleaved per-call wall-clock structure is otherwise unchanged; only the "stop the timer" step now guarantees the candidate's work is done.

- TPU tensors: wait on the produced tensors, then drain the device.
- Non-TPU tensors (CUDA / CuTe): dispatch is eager, so there is nothing to force — the path falls through to the existing device-wide drain and **timing is unchanged**.

> Note (see thread): this per-output approach does **not** cover backward kernels — a backward fn returns the input tensors while the lazy work lives in their `.grad`, which is never forced; and a fwd-no-grad fn returning `None` has nothing to wait on. There is no drain-all shortcut either (a tensorless `torch_tpu…synchronize(wait=True)` also returns early). So this PR is a partial stopgap; the complete fix is to restore a working device-wide barrier (revert the pin or fix torch_tpu — see Alternatives).

## Dashboard data (verifiable)

Nightly `flash_attention` on TPU. `helion avg` is the dashboard's `helion_latency_avg_ms`, **averaged over the kernel's benchmarked shapes** — not the `[8,32,8192,256]` value alone (see reconciliation below). `tc_speedup` ≈ 1.0 ⇒ compiled baseline materialized (healthy); ≫ 1 ⇒ it went fake-fast (bug).

| date | commit | helion avg (ms) | tc_speedup | note |
|---|---|---|---|---|
| 07-02 | df7ebeab | 21.40 | 0.97 | healthy (pre-#3013: per-tensor sync) |
| 07-03 | 6d4381f6 | 21.13 | 0.97 | healthy |
| 07-04 | 6d4381f6 | 21.24 | 0.97 | healthy |
| 07-05 | 6d4381f6 | 21.14 | 0.97 | healthy |
| 07-06 | 6d4381f6 | 21.13 | 0.97 | healthy |
| 07-06 | 8c77f944 | 46.53 | 0.95 | one-off spike; tc still ~1 → not the sync issue |
| 07-07 | 89e986e9 | 21.26 | 0.96 | healthy |
| 07-08 | 300516ab | 21.03 | 0.96 | #3013 (device-wide sync) landed 7-8 |
| 07-09 | 5f1547d1 | 20.85 | 0.98 | healthy — device-sync live |
| 07-10 | 5f1547d1 | 21.01 | 0.97 | healthy |
| 07-11 | 9ca92a66 | 20.85 | 0.97 | healthy |
| 07-12 | bdfb5962 | 65.13 | 39.00 | ← #3026 dropped benchmark output (R1) |
| 07-13 | bdfb5962 | 64.81 | 39.83 | |
| 07-14 | bdfb5962 | 65.58 | 38.92 | |
| 07-15 | 0b82b03f | 64.66 | 34.46 | |
| 07-16 | 7a4cb2fc | 64.57 | 31.40 | |
| 07-17 | c59bc69c | **20.95** | 0.99 | ← #3084 restored output; **still OLD torch_tpu pin** → healthy |
| 07-18 | 7935fe6e | 64.10 | 22.79 | ← first nightly on **NEW torch_tpu pin** (#3075, landed 7-17) |
| 07-19 | 8379fd86 | 65.23 | 25.93 | |
| 07-20 | 47752ff4 | 66.11 | 23.13 | |
| 07-21 | a59de0ba | 68.11 | 23.40 | still broken |

Two clean "healthy" brackets on the OLD pin (07-02→07-11 and 07-17), broken only after the pin bump (07-18+). The 07-12→07-16 dip is a separate, Helion-side bug (#3026), fixed by #3084 on 07-17. (07-01 `7a66309b` is a failed/empty run — `helion=0` — and is omitted.)

**Reconciliation with the tables below:** `helion avg` here is over flash_attention's benchmarked shapes. The `[8,32,8192,256]` shape alone (used in the Findings/Verification tables) is ~42 ms healthy / ~128 ms broken and dominates the average once combined with the other (~0.5 ms) shape — so avg ~21 ↔ ~65 corresponds to that shape's ~42 ↔ ~128.

Pull the same numbers straight from the live dashboard (no transcription):

```bash
curl -s https://helionlang.com/dashboard/dashboard-data.json \
| jq -r '.summary[] | select(.kernel=="flash_attention" and .platform_short=="tpu")
         | .history[] | select(.date > "2026-07-01")
         | "\(.date[0:10])  \(.sha)  helion=\(.helion_latency_avg_ms)  tc_speedup=\(.torch_compile_speedup_geomean)"'
```

## Findings

**R1 and #3084 are correct.** #3084's numbers reproduce today: measured via a many-call / self-attributing method (`do_bench`, non-interleaved), `torch_compile` materializes to ~88 ms — matching #3084's report. The failure only appears in the *interleaved* path, which times a single call per candidate.

**R2 is the current cause, and it is a torch_tpu behavior change — bisected on-device**, holding everything else constant (original device-sync bench, no fix):

| torch_tpu pin | jax | helion ms | torch_compile ms | device-sync works? |
| --- | --- | --- | --- | --- |
| `a9906ed1` (old) | 0.10.1 | 41.9 | 89.6 | ✅ |
| `a9906ed1` (old) | 0.10.2 | 41.8 | 89.5 | ✅ (jax exonerated) |
| `58759701` (**#3075**) | 0.10.2 | 128.9 | 0.44 | ❌ |

Only the torch_tpu pin flips it. On the old pin, a device-wide `synchronize()` still forced a `torch.compile` output to materialize; on the new pin it does not (a single compiled call + device sync leaves the output deferred, measured ~0 ms). Minimal repro (prints ~89 ms on the old pin, ~0.11 ms on the new pin):

```python
o = torch.compile(sdpa)(q, k, v)
torch.accelerator.synchronize()   # timed region
```

Within the pin bump's 78-commit range the change is in the first ~half (commit `f2dbb4cd` already exhibits it); a precise bisect is blocked because mid-stack commits are coupled to specific torch nightlies and don't build against the current torch — best pinned down in torch_tpu's own CI. Filed upstream: https://github.com/google-pytorch/torch_tpu/issues/2402 (with a minimal repro).

**Verification of the fix** (flash_attention forward `[8,32,8192,256]`, identical config, on the current — #3075 — stack; backward is not covered — see the Fix note):

| scenario | before | after |
| --- | --- | --- |
| helion, `torch` baseline only | 42 ms | 42 ms |
| helion, `torch` + `torch_compile` baselines (interleaved) | **128 ms** | **42 ms** |
| `torch_compile` baseline (same run) | 0.4 ms (unmaterialized) | 89 ms (materialized) |

Both loop-order variants of the config measure ~42 ms — the config was never slow; the difference was entirely measurement.

## Why CUDA/GPU never hit this

Two independent, structural reasons — this is TPU-only and the fix is a no-op on GPU:

1. **GPU doesn't use this path.** The `_generic` functions are the fallback for backends without Triton event timing. On CUDA the harness uses Triton's `do_bench`, which times with CUDA events bracketing each candidate's own kernels on the stream — a neighbor's work can't leak in. No wall-clock + device-wide barrier is involved.
2. **GPU execution is eager stream-dispatch.** A call (including a `torch.compile`d one) enqueues its kernels at call time; there is no deferred graph that materializes later in another candidate's window.

## Alternatives considered

The immediate trigger is the torch_tpu behavior change in #3075: a device-wide sync no longer drains a dispatched `torch.compile` graph.

1. **This PR — per-output wait (backend-agnostic).** Each candidate materializes its own output. Robust for forward kernels, but does **not** cover backward (`.grad`) or fwd-no-grad (`None`) — a partial stopgap.
2. **Revert the torch_tpu pin update (#3075).** Rolling the pin back to `a9906ed1` restores the device-wide-sync-materializes-compiled-output behavior, so the dashboard would recover with **no benchmark change** and **all kernel shapes covered**. Downsides: it gives up whatever #3075 brought in, and it leaves the bench relying on a backend guarantee that just proved fragile across a pin bump.
3. **Fix torch_tpu upstream.** Treat #3075 as a torch_tpu regression (a device-wide sync should drain a dispatched compiled graph) and fix it there; then device-sync keeps working for all shapes. Filed as https://github.com/google-pytorch/torch_tpu/issues/2402. Independent of this PR.

Given the backward-kernel gap in option 1, the reverting-the-pin / upstream-fix path is preferable; this PR is kept as a documented partial fallback.

## Note for external callers

Anything that benchmarks TPU functions through these `_generic` helpers (e.g. the tritonbench integration) now gets per-output materialization on the TPU path. A caller that relied on the previous device-wide-only behavior — where a lazy `torch.compile` baseline read as ~0 ms — will see its numbers change to the materialized (correct) values.
