### PR TITLE
[pallas] default divide-and-filter topk recall_target to 0.99

### DIFF
--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -234,7 +234,7 @@ def codegen_topk_pallas(ctx: LoweringContext, node: Node) -> object:
     ``topk_impl.divide_filter_topk`` -- a tallax-style divide-and-filter top-k
     built only from Mosaic-supported ops (strided slices, iota, where, min/max).
     Being plain jnp emitted inline, it FUSES with the surrounding kernel. Returns
-    ``(values desc, int32 indices)`` over the LAST axis (approximate, recall~0.95;
+    ``(values desc, int32 indices)`` over the LAST axis (approximate, recall~0.99;
     top-1 exact). ``k`` must be static (use ``hl.specialize(k)``).
     """
     tensor = map_arg(node.args[0], lambda arg: _env_arg(ctx, arg))

--- a/helion/_compiler/pallas/topk_impl.py
+++ b/helion/_compiler/pallas/topk_impl.py
@@ -31,9 +31,11 @@ if TYPE_CHECKING:
 _NUM_LANES = 128
 
 
-def num_bins_for(k: int, vocab: int, recall_target: float = 0.95) -> int:
+def num_bins_for(k: int, vocab: int, recall_target: float = 0.99) -> int:
     """tallax's TPU-KNN recall formula (approx_max_k.py): ceil((k-1)/(1-recall)),
-    rounded up to a lane multiple and capped at the padded vocab."""
+    rounded up to a lane multiple and capped at the padded vocab. Default recall
+    is 0.99 -- callers that feed the top-k into an exact threshold (e.g. a top-p
+    nucleus) need high recall; raising it costs more bins (i.e. more work)."""
     if k <= 1:
         nb = 1
     else:
@@ -44,7 +46,7 @@ def num_bins_for(k: int, vocab: int, recall_target: float = 0.95) -> int:
 
 
 def divide_filter_topk(
-    x: jax.Array, k: int, recall_target: float = 0.95
+    x: jax.Array, k: int, recall_target: float = 0.99
 ) -> tuple[jax.Array, jax.Array]:
     """Approximate top-k over the last axis. x: (rows, V) -> (values, indices),
     each (rows, k); values descending, indices int32 into V. k must be static."""

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -892,6 +892,27 @@ class TestPallas(TestCase):
         )
         self.assertGreater(recall, 0.9)
 
+    def test_topk_recall_target_default_099(self) -> None:
+        """Regression guard for the divide-and-filter default recall_target=0.99.
+        At k=64, V=32768 the approximate top-k must recall >=99% of the true
+        top-k; with the previous default (0.95) recall is only ~0.98 and this
+        FAILS. High recall matters when the top-k feeds an exact threshold (e.g. a
+        top-p nucleus, or a rejection sampler's target-prob normalization)."""
+        torch.manual_seed(0)
+        x = torch.randn(128, 32768, device=DEVICE, dtype=torch.float32)
+        _, (_vals, idx) = code_and_output(_topk_pallas_kernel, (x, 64), block_sizes=[8])
+        ref_i = torch.topk(x, 64, dim=-1, largest=True)[1].cpu()
+        idx_c = idx.cpu()
+        ref_sets = [set(r.tolist()) for r in ref_i]
+        recall = (
+            sum(
+                len(set(idx_c[r].tolist()) & ref_sets[r]) / 64
+                for r in range(x.shape[0])
+            )
+            / x.shape[0]
+        )
+        self.assertGreaterEqual(recall, 0.99)
+
     def test_store_slice_1d(self) -> None:
         """Store value sliced when block_size > tensor dim (1D)."""
 


### PR DESCRIPTION
Stacked PRs:
 * #3113
 * #3115
 * #3114
 * __->__#3112


--- --- ---

### [pallas] default divide-and-filter topk recall_target to 0.99


The divide-and-filter top-k lowering defaulted to recall_target=0.95. For TPU
LLM inference, during rejection sampling we need a threshold of 0.99: the
approximate top-k candidate set feeds an EXACT threshold (a top-p nucleus, or a
rejection sampler's target-prob normalization), and a lossy candidate set
mis-estimates the nucleus / normalization mass. Bump the default recall_target
0.95 -> 0.99 in num_bins_for / divide_filter_topk (and the codegen docstring).

Trade-off: num_bins = ceil((k-1)/(1-recall)) grows with recall (k=64: 1280 ->
6400), so the divide-and-filter does proportionally more work -- this is a
recall/speed knob, set here to the higher-recall default.

Regression test (test/test_pallas.py::test_topk_recall_target_default_099):
at k=64, V=32768 the lowered top-k must recall >=99% of the true top-k. It
passes at the new default (measured recall ~0.998) and FAILS at the old 0.95
default (measured recall 0.980), pinning the property that motivated the bump.

Benchmark (tpu7x-8, device time via tallax's harness): XLA lax.top_k vs tallax
approx_max_k vs this Helion lowering, tallax and Helion both at recall_target
0.99. `recall` is vs the exact top-k and is identical for tallax and Helion (same
target -> same num_bins), so it is shown once.

| config          |   b |  vocab |  k |  dt  |  XLA us | tallax us | helion us | hel/XLA | recall |
|-----------------|----:|-------:|---:|:----:|--------:|----------:|----------:|--------:|-------:|
| spec-decode     |  16 |  32768 |  5 | bf16 |   55.04 |      7.39 |      7.86 |   7.00x |  1.000 |
| spec-decode lg  | 128 |  32768 |  5 | bf16 |   59.78 |     17.94 |     27.02 |   2.21x |  0.998 |
| sample dev      |   8 | 202048 | 64 |  f32 |  203.70 |      8.41 |     22.51 |   9.05x |  0.998 |
| sample serve    | 128 | 202048 | 64 |  f32 | 3110.43 |    150.20 |    379.89 |   8.19x |  0.996 |
| gemini3 262K    |   8 | 262144 | 64 | bf16 |  258.44 |      8.34 |     22.72 |  11.37x |  0.994 |
| gemini3 262K lg | 128 | 262144 | 64 | bf16 | 4129.73 |     61.31 |    306.39 |  13.48x |  0.995 |

Helion beats XLA lax.top_k across the board (2.2x-13.5x). At the same recall
target tallax's bitonic stage-2 is still faster than this lowering's iterative
masked-select (the remaining gap). At recall 0.99 the approximate path recalls
0.994-1.000 of the exact top-k.
