### PR TITLE
Don't call get_num_sm for non-CUDA under torch.distributed (TPU serve fix)

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -319,7 +319,12 @@ class CompileEnvironment:
             ):
                 self.config_spec.disallow_pid_type(pid_type)
 
-        if dist.is_initialized():
+        # CUDA symmetric-memory persistent-kernel sizing only. Guard on CUDA: the
+        # Pallas/TPU backend traces with a cpu-device torch tensor (the torch<->jax
+        # bridge), so under a multi-host (dist-initialized) serve this would call
+        # get_num_sm(cpu) -> "TODO: implement for other devices" and crash the
+        # kernel compile. _SymmetricMemory / SM-multiplier are irrelevant to Pallas.
+        if dist.is_initialized() and device.type == "cuda":
             from torch._C._distributed_c10d import _SymmetricMemory
 
             from .._dist_utils import max_num_blocks_for_symm_mem


### PR DESCRIPTION
Stacked PRs:
 * #3113
 * #3115
 * __->__#3114


--- --- ---

### Don't call get_num_sm for non-CUDA under torch.distributed (TPU serve fix)


`CompileEnvironment.__init__` computes a CUDA symmetric-memory persistent-kernel
grid clamp inside `if dist.is_initialized()`, calling get_num_sm(device). On a
multi-host (dist-initialized) TPU serve the Helion Pallas kernel is traced with a
cpu-device torch tensor (the torch<->jax bridge), so get_num_sm(cpu) hits
"TODO: implement for other devices" and crashes the kernel compile -> vLLM engine
core init fails -> the LeaderWorkerSet recreates the whole group (RecreateGroupOnPodRestart)
-> the serve crash-loops and never reaches ready. Single-host runs don't init
torch.distributed so the block is skipped -- which is why dunfanlu-torchtpu passed
while the serve churned every ~20 min at the random_rejection_sampler precompile.

The block (_SymmetricMemory / max_num_sm_multiplier) is CUDA-only, so guard it on
`device.type == "cuda"`. No effect on CUDA; skipped for Pallas/TPU.
