### PR TITLE
[pallas] make jax_fn export work without torch_tpu (JAX-native TPU serve)

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1180,11 +1180,20 @@ def _pallas_prepare_args(
     if interpret:
         placeholder_fn = _jax_placeholder_for_tensor
     else:
-        from torch_tpu._internal.pallas.pallas import (  # pyrefly: ignore[missing-import]
-            jax_placeholder,
-        )
+        try:
+            from torch_tpu._internal.pallas.pallas import (  # pyrefly: ignore[missing-import]
+                jax_placeholder,
+            )
 
-        placeholder_fn = jax_placeholder
+            placeholder_fn = jax_placeholder
+        except ImportError:
+            # torch_tpu is only required for the torch-tensor entry path (its
+            # JaxCallable dispatch). The jax_fn export builds a native
+            # pl.pallas_call and only needs a jax placeholder (shape/dtype) per
+            # output -- the interpret path already uses the native factory below.
+            # Fall back to it so jax_fn works on a JAX-native TPU serve that does
+            # not ship the torch_tpu wheel.
+            placeholder_fn = _jax_placeholder_for_tensor
 
     output_set = set(_output_indices)
     inplace_set = set(_inplace_indices) if _inplace_indices is not None else output_set


### PR DESCRIPTION
Stacked PRs:
 * #3113
 * __->__#3115


--- --- ---

### [pallas] make jax_fn export work without torch_tpu (JAX-native TPU serve)


Kernel.jax_fn builds a native pl.pallas_call and runs it on JAX arrays directly --
it does NOT use torch_tpu's JaxCallable dispatch (that is only the torch-tensor
entry path). But _pallas_prepare_args hard-imported torch_tpu's jax_placeholder to
build the per-output shape/dtype placeholders, so jax_fn crashed with
"ModuleNotFoundError: No module named 'torch_tpu'" on a JAX-native TPU serve that
does not ship the torch_tpu wheel. (Only the multi-host serve hit it; single-host
dev pods have torch_tpu installed, which is why the bench passed but the serve
crash-looped at the rejection-sampler precompile.)

The interpret path already uses a native placeholder factory
(_jax_placeholder_for_tensor -> jax.ShapeDtypeStruct); fall back to it when
torch_tpu is unavailable. _device_for_jax_export already degrades to cpu without
torch_tpu and the autotuner cache-key import is already guarded, so jax_placeholder
was the last hard torch_tpu dependency on the jax_fn path.

Verified on tpu7x-8: with torch_tpu's pallas bridge blocked, topk_reduce_kernel.jax_fn
compiles + runs correctly (top-1 exact). Lets msl-tpu-kernel's Helion rejection
sampler run on the T5-42B serve with no torch_tpu install.
