### PR TITLE
[autotuner] Add multi-shape autotuning

### DIFF
--- a/benchmarks/kda_prefill_autotune.py
+++ b/benchmarks/kda_prefill_autotune.py
@@ -1,0 +1,261 @@
+"""Multi-shape autotuning entry point for KDA prefill helpers."""
+
+from __future__ import annotations
+
+import argparse
+from itertools import pairwise
+
+from examples.linear.kda_prefill import _chunk_output
+from examples.linear.kda_prefill import _chunk_state
+from examples.linear.kda_prefill import _chunk_state_varlen
+from examples.linear.kda_prefill import _intra_matrices_wide
+from examples.linear.kda_prefill import _intra_matrices_wide_forward
+from examples.linear.kda_prefill import _intra_solve
+from examples.linear.kda_prefill import _intra_solve_recompute
+from examples.linear.kda_prefill import _intra_solve_recompute_newton
+from examples.linear.kda_prefill import _recompute_u
+from examples.linear.kda_prefill import _recompute_w_kg
+from examples.linear.kda_prefill import prepare_chunk_indices
+from examples.linear.kda_prefill import prepare_chunk_offsets
+import torch
+
+
+def _matrix_args(sequence_length: int, varlen: bool = False) -> tuple[object, ...]:
+    batch, heads, key_dim = 1, 16, 128
+    q = torch.nn.functional.normalize(
+        torch.randn(
+            batch,
+            sequence_length,
+            heads,
+            key_dim,
+            device="cuda",
+        ),
+        dim=-1,
+    ).to(torch.bfloat16)
+    k = torch.nn.functional.normalize(
+        torch.randn_like(q, dtype=torch.float32),
+        dim=-1,
+    ).to(torch.bfloat16)
+    g_step = (
+        -torch.rand(
+            batch,
+            sequence_length,
+            heads,
+            key_dim,
+            device="cuda",
+        )
+        * 0.1
+    )
+    beta = torch.rand(batch, sequence_length, heads, device="cuda") * 0.1
+    if varlen:
+        if sequence_length == 512:
+            lengths = [129, 383]
+        elif sequence_length == 8192:
+            lengths = [513, 1023, 2049, 4607]
+        else:
+            first = sequence_length // 3 + 1
+            lengths = [first, sequence_length - first]
+        cu_seqlens = torch.tensor(
+            [0, *torch.tensor(lengths).cumsum(0).tolist()],
+            device="cuda",
+            dtype=torch.int32,
+        )
+        chunk_indices = prepare_chunk_indices(cu_seqlens)
+    else:
+        lengths = [sequence_length]
+        cu_seqlens = torch.empty(0, device="cuda", dtype=torch.int32)
+        chunk_indices = torch.empty(0, 2, device="cuda", dtype=torch.long)
+    g = torch.empty_like(g_step)
+    sequence_begin = 0
+    for length in lengths:
+        for chunk_begin in range(sequence_begin, sequence_begin + length, 64):
+            chunk_end = min(chunk_begin + 64, sequence_begin + length)
+            g[:, chunk_begin:chunk_end] = (
+                torch.cumsum(
+                    g_step[:, chunk_begin:chunk_end],
+                    dim=1,
+                )
+                * 1.4426950216293335
+            )
+        sequence_begin += length
+    return q, k, g, beta, cu_seqlens, chunk_indices, key_dim**-0.5, varlen
+
+
+def _kernel_args(
+    kernel_name: str,
+    sequence_length: int,
+    varlen: bool,
+    newton_schulz: bool,
+) -> tuple[object, ...]:
+    matrix_args = _matrix_args(sequence_length, varlen)
+    preinvert_diagonal = not newton_schulz
+    if kernel_name == "matrix":
+        return (*matrix_args, preinvert_diagonal, newton_schulz)
+
+    q, k, g, beta, cu_seqlens, chunk_indices, _, is_varlen = matrix_args
+    v = torch.randn_like(q)
+    matrix_kernel = (
+        _intra_matrices_wide_forward
+        if preinvert_diagonal
+        else _intra_matrices_wide
+    )
+    aqk, akk = matrix_kernel(
+        *matrix_args,
+        preinvert_diagonal,
+        newton_schulz,
+    )
+    qg = (q.float() * (q.size(-1) ** -0.5) * torch.exp2(g)).to(q.dtype)
+    wk = (k.float() * beta[..., None] * torch.exp2(g)).to(k.dtype)
+    kg = torch.empty_like(k)
+    if is_varlen:
+        sequence_offsets = cu_seqlens.tolist()
+    else:
+        sequence_offsets = [0, q.size(1)]
+    chunk_decays = []
+    for sequence_begin, sequence_end in pairwise(sequence_offsets):
+        for chunk_begin in range(sequence_begin, sequence_end, 64):
+            chunk_end = min(chunk_begin + 64, sequence_end)
+            chunk_decays.append(torch.exp2(g[0, chunk_end - 1]))
+            kg[:, chunk_begin:chunk_end] = (
+                k[:, chunk_begin:chunk_end].float()
+                * torch.exp2(
+                    g[:, chunk_end - 1 : chunk_end] - g[:, chunk_begin:chunk_end]
+                )
+            ).to(k.dtype)
+    if kernel_name == "fused":
+        return (
+            akk,
+            wk,
+            v,
+            beta,
+            cu_seqlens,
+            chunk_indices,
+            is_varlen,
+            newton_schulz,
+            preinvert_diagonal,
+        )
+    solve_args = (akk, k, cu_seqlens, chunk_indices, is_varlen)
+    if kernel_name == "solve":
+        return solve_args
+
+    inverse = _intra_solve(*solve_args)
+    if kernel_name == "u":
+        return v, beta, inverse, cu_seqlens, chunk_indices, is_varlen
+    if kernel_name == "w":
+        return k, g, beta, inverse, cu_seqlens, chunk_indices, is_varlen
+    if kernel_name in {"state", "output"}:
+        solve_kernel = (
+            _intra_solve_recompute_newton
+            if newton_schulz
+            else _intra_solve_recompute
+        )
+        w, u = solve_kernel(
+            akk,
+            wk,
+            v,
+            beta,
+            cu_seqlens,
+            chunk_indices,
+            is_varlen,
+            newton_schulz,
+            preinvert_diagonal,
+        )
+        if is_varlen:
+            num_sequences = cu_seqlens.size(0) - 1
+            chunk_offsets = prepare_chunk_offsets(cu_seqlens)
+        else:
+            num_sequences = q.size(0)
+            chunk_offsets = torch.empty(0, device="cuda", dtype=torch.long)
+        initial_state = torch.zeros(
+            num_sequences,
+            q.size(2),
+            v.size(3),
+            k.size(3),
+            device="cuda",
+            dtype=torch.float32,
+        )
+        initial_state_indices = torch.arange(
+            num_sequences,
+            device="cuda",
+            dtype=torch.int32,
+        )
+        state_args = (
+            kg,
+            w,
+            u,
+            torch.stack(chunk_decays),
+            initial_state,
+            initial_state_indices,
+            cu_seqlens,
+            chunk_indices,
+            chunk_offsets,
+            is_varlen,
+        )
+        if kernel_name == "state":
+            return state_args
+        state_kernel = _chunk_state_varlen if is_varlen else _chunk_state
+        h, v_new = state_kernel(*state_args)
+        return (
+            qg,
+            v_new,
+            aqk,
+            h,
+            v.clone(),
+            cu_seqlens,
+            chunk_indices,
+            is_varlen,
+        )
+    raise AssertionError(f"unsupported kernel: {kernel_name}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sequence-lengths", type=int, nargs="+", default=[512, 8192])
+    parser.add_argument("--cache-tag", default="kda-prefill-matrix-gb200-v1")
+    parser.add_argument("--varlen", action="store_true")
+    parser.add_argument("--newton-schulz", action="store_true")
+    parser.add_argument(
+        "--kernel",
+        choices=["matrix", "solve", "fused", "u", "w", "state", "output"],
+        default="matrix",
+    )
+    args = parser.parse_args()
+
+    fused_kernel = (
+        _intra_solve_recompute_newton
+        if args.newton_schulz
+        else _intra_solve_recompute
+    )
+    state_kernel = _chunk_state_varlen if args.varlen else _chunk_state
+    matrix_kernel = (
+        _intra_matrices_wide if args.newton_schulz else _intra_matrices_wide_forward
+    )
+    kernels = {
+        "matrix": matrix_kernel,
+        "solve": _intra_solve,
+        "fused": fused_kernel,
+        "u": _recompute_u,
+        "w": _recompute_w_kg,
+        "state": state_kernel,
+        "output": _chunk_output,
+    }
+    winner = kernels[args.kernel].autotune_multi(
+        [
+            _kernel_args(
+                args.kernel,
+                length,
+                args.varlen,
+                args.newton_schulz,
+            )
+            for length in args.sequence_lengths
+        ],
+        aggregation="geomean",
+        relative_to=None,
+        cache_tag=args.cache_tag,
+        force=True,
+    )
+    print(f"Multi-shape winner: {winner}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/linear/kda_packed_decode.py
+++ b/examples/linear/kda_packed_decode.py
@@ -1,0 +1,995 @@
+"""Helion versus SGLang packed Kimi Delta Attention decode.
+
+This module implements the exact callable contract of SGLang's default
+``fused_recurrent_kda_packed_decode`` kernel and provides a correctness and
+latency comparison against that kernel loaded from an SGLang checkout.
+
+The production Kimi-Linear-48B-A3B shape is K=V=128 with 32 global heads.
+Tensor parallelism shards those heads, so the default benchmark uses TP=2 and
+16 local heads. Activations are bfloat16 while the recurrent state is float32.
+This published-model default selects SGLang's in-tree Triton decode. Explicitly
+using a bfloat16 state on SM100 makes SGLang auto-select external FlashInfer and
+is a different baseline.
+
+Run from the Helion repository root:
+
+    python -m examples.linear.kda_packed_decode
+    python -m examples.linear.kda_packed_decode --tp-sizes 1 2 4 8
+    HELION_PRINT_OUTPUT_CODE=1 python -m examples.linear.kda_packed_decode
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import importlib.util
+import inspect
+from pathlib import Path
+import statistics
+import sys
+from types import ModuleType
+from typing import Callable
+from typing import cast
+from typing import Literal
+
+import torch
+
+import helion
+import helion.language as hl
+
+KIMI_GLOBAL_HEADS = 32
+KIMI_HEAD_K_DIM = 128
+KIMI_HEAD_V_DIM = 128
+KIMI_KDA_LAYERS = 20
+SOFTPLUS_THRESHOLD = 20.0
+
+
+# CUDA x traverses V tiles, keeping the x grid at 16 across all supported TP sizes.
+_KDA_CONFIG = helion.Config(
+    block_sizes=[8],
+    loop_orders=[[2, 1, 0]],
+    num_warps=1,
+    num_stages=1,
+    indexing="pointer",
+    pid_type="xyz",
+)
+
+@helion.kernel(
+    static_shapes=False,
+    config=_KDA_CONFIG,
+)
+def _helion_fused_recurrent_kda_packed_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: hl.constexpr = False,  # pyrefly: ignore[bad-function-definition]
+) -> torch.Tensor:
+    """Fused packed KDA decode body; mutates ``initial_state`` and ``out``."""
+    B = mixed_qkv.size(0)
+    HV = hl.specialize(initial_state.size(-3))
+    V = hl.specialize(initial_state.size(-2))
+    K = hl.specialize(initial_state.size(-1))
+    H = hl.specialize((mixed_qkv.size(1) - HV * V) // (2 * K))
+    heads_per_q = HV // H
+
+    hl.specialize(
+        (
+            mixed_qkv.stride(0),
+            mixed_qkv.stride(1),
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            A_log.stride(0),
+            dt_bias.stride(0),
+            initial_state.stride(0),
+            initial_state.stride(1),
+            initial_state.stride(2),
+            initial_state.stride(3),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            out.stride(3),
+            ssm_state_indices.stride(0),
+        )
+    )
+
+    block_v = hl.register_block_size(1, V)
+
+    for tile_b, tile_hv, tile_v in hl.tile([B, HV, V], block_size=[1, 1, block_v]):
+        k_offsets = hl.arange(K)
+        i_b = tile_b.id
+        i_hv = tile_hv.id
+        i_h = i_hv // heads_per_q
+
+        state_index = ssm_state_indices[i_b].long()
+        if state_index < 0:
+            out[i_b, 0, i_hv, tile_v] = 0.0
+        else:
+            q_offsets = i_h * K + k_offsets
+            k_input_offsets = H * K + i_h * K + k_offsets
+            v_offsets = 2 * H * K + i_hv * V + tile_v.index
+
+            gate_input = a[i_b, i_hv * K + k_offsets].float()
+            gate_input = gate_input + dt_bias[i_hv * K + k_offsets].float()
+            gate_exp = torch.exp(gate_input)
+            softplus = torch.where(
+                gate_input <= 20.0,
+                torch.log(1.0 + gate_exp),
+                gate_input,
+            )
+            A_log_value = A_log[i_hv].float()
+            A = torch.exp(A_log_value)
+            beta = torch.sigmoid(b[i_b, i_hv].float())
+            log_decay = -A * softplus
+
+            state = initial_state[state_index, i_hv, tile_v.index, k_offsets].float()
+            decay = torch.exp(log_decay)
+            state = state * decay[None, :]
+
+            k = mixed_qkv[i_b, k_input_offsets].float()
+            if use_qk_l2norm_in_kernel:
+                k = k / torch.sqrt((k * k).sum() + 1e-6)
+            v = mixed_qkv[i_b, v_offsets].float()
+            value_residual = v - (state * k[None, :]).sum(-1)
+            value_residual = value_residual * beta
+            state = state + value_residual[:, None] * k[None, :]
+
+            q = mixed_qkv[i_b, q_offsets].float()
+            if use_qk_l2norm_in_kernel:
+                q = q / torch.sqrt((q * q).sum() + 1e-6)
+            q = q * scale
+            output = (state * q[None, :]).sum(-1)
+
+            out[i_b, 0, i_hv, tile_v] = output.to(out.dtype)
+            initial_state[state_index, i_hv, tile_v.index, k_offsets] = state
+
+    return out
+
+
+
+def _validate_packed_decode_inputs(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    initial_state: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+) -> tuple[int, int, int, int, int]:
+    """Apply the shape and layout checks from SGLang's packed wrapper."""
+    if mixed_qkv.ndim != 2:
+        raise ValueError(
+            f"`mixed_qkv` must be a 2D tensor (got ndim={mixed_qkv.ndim})."
+        )
+    if mixed_qkv.stride(-1) != 1:
+        raise ValueError("`mixed_qkv` must be contiguous in the last dim.")
+    if a.ndim != 2 or b.ndim != 2:
+        raise ValueError(
+            f"`a` and `b` must be 2D tensors (got a.ndim={a.ndim}, b.ndim={b.ndim})."
+        )
+    if a.stride(-1) != 1 or b.stride(-1) != 1:
+        raise ValueError("`a`/`b` must be contiguous in the last dim.")
+    if A_log.ndim != 1 or dt_bias.ndim != 1:
+        raise ValueError("`A_log`/`dt_bias` must be 1D tensors.")
+    if A_log.stride(0) != 1 or dt_bias.stride(0) != 1:
+        raise ValueError("`A_log`/`dt_bias` must be contiguous.")
+    if ssm_state_indices.ndim != 1:
+        raise ValueError(
+            "`ssm_state_indices` must be 1D for packed decode "
+            f"(got ndim={ssm_state_indices.ndim})."
+        )
+    if not out.is_contiguous():
+        raise ValueError("`out` must be contiguous.")
+
+    device = mixed_qkv.device
+    if any(
+        tensor.device != device
+        for tensor in (
+            a,
+            b,
+            A_log,
+            dt_bias,
+            initial_state,
+            out,
+            ssm_state_indices,
+        )
+    ):
+        raise ValueError("All inputs must be on the same device.")
+
+    B = mixed_qkv.shape[0]
+    if a.shape[0] != B or b.shape[0] != B:
+        raise ValueError(
+            "Mismatched batch sizes: "
+            f"mixed_qkv.shape[0]={B}, a.shape[0]={a.shape[0]}, "
+            f"b.shape[0]={b.shape[0]}."
+        )
+    if ssm_state_indices.shape[0] != B:
+        raise ValueError(
+            f"`ssm_state_indices` must have shape [B] "
+            f"(got {tuple(ssm_state_indices.shape)}; expected ({B},))."
+        )
+
+    if initial_state.ndim != 4:
+        raise ValueError(
+            f"`initial_state` must be a 4D tensor (got ndim={initial_state.ndim})."
+        )
+    if initial_state.stride(-1) != 1:
+        raise ValueError("`initial_state` must be contiguous in the last dim.")
+    HV, V, K = initial_state.shape[-3:]
+    if a.shape[1] != HV * K:
+        raise ValueError(
+            f"`a` must have shape [B, HV*K] with HV={HV}, K={K} "
+            f"(got a.shape={tuple(a.shape)})."
+        )
+    if b.shape[1] != HV:
+        raise ValueError(
+            f"`b` must have shape [B, HV] with HV={HV} (got b.shape={tuple(b.shape)})."
+        )
+    if A_log.numel() != HV:
+        raise ValueError(f"`A_log` must have {HV} elements (got {A_log.numel()}).")
+    if dt_bias.numel() != HV * K:
+        raise ValueError(
+            f"`dt_bias` must have {HV * K} elements (got {dt_bias.numel()})."
+        )
+    if out.shape != (B, 1, HV, V):
+        raise ValueError(
+            f"`out` must have shape {(B, 1, HV, V)} (got out.shape={tuple(out.shape)})."
+        )
+
+    qkv_dim = mixed_qkv.shape[1]
+    qk_dim = qkv_dim - HV * V
+    if qk_dim <= 0 or qk_dim % 2 != 0:
+        raise ValueError(
+            f"Invalid packed `mixed_qkv` last dim={qkv_dim} for HV={HV}, V={V}."
+        )
+    q_dim = qk_dim // 2
+    if q_dim % K != 0:
+        raise ValueError(
+            f"Invalid packed Q size {q_dim}: must be divisible by K={K}. "
+            "KDA packed decode requires num_q_heads == num_k_heads and "
+            "head_q_dim == head_k_dim."
+        )
+    H = q_dim // K
+    if H <= 0 or HV % H != 0:
+        raise ValueError(
+            f"Invalid head config inferred from mixed_qkv: H={H}, HV={HV}."
+        )
+    return B, H, HV, K, V
+
+
+def helion_fused_recurrent_kda_packed_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Helion implementation of SGLang's packed KDA decode contract.
+
+    Inputs, mutations, padding semantics, and outputs match
+    ``fused_recurrent_kda_packed_decode``:
+
+    * ``mixed_qkv`` is ``[B, 2*H*K + HV*V]`` after the short convolution.
+    * ``a`` and ``b`` are raw forget-gate and beta logits.
+    * ``initial_state`` is ``[num_slots, HV, V, K]`` and is updated in place.
+    * ``ssm_state_indices == -1`` writes a zero output and leaves state untouched.
+    * ``out`` is ``[B, 1, HV, V]`` and is written in place.
+    * The return is the same ``(out, initial_state)`` object pair supplied by the
+      caller.
+    """
+    _validate_packed_decode_inputs(
+        mixed_qkv,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        initial_state,
+        out,
+        ssm_state_indices,
+    )
+    result = _helion_fused_recurrent_kda_packed_decode(
+        mixed_qkv,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        scale,
+        initial_state,
+        out,
+        ssm_state_indices,
+        use_qk_l2norm_in_kernel,
+    )
+    return result, initial_state
+
+
+def torch_fused_recurrent_kda_packed_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent PyTorch reference with the same mutating contract."""
+    B, H, HV, K, V = _validate_packed_decode_inputs(
+        mixed_qkv,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        initial_state,
+        out,
+        ssm_state_indices,
+    )
+
+    q_end = H * K
+    k_end = 2 * H * K
+    q = mixed_qkv[:, :q_end].reshape(B, H, K).float()
+    k = mixed_qkv[:, q_end:k_end].reshape(B, H, K).float()
+    v = mixed_qkv[:, k_end:].reshape(B, HV, V).float()
+    if HV != H:
+        repeat = HV // H
+        q = q.repeat_interleave(repeat, dim=1)
+        k = k.repeat_interleave(repeat, dim=1)
+
+    if use_qk_l2norm_in_kernel:
+        q = q / torch.sqrt((q * q).sum(-1, keepdim=True) + 1e-6)
+        k = k / torch.sqrt((k * k).sum(-1, keepdim=True) + 1e-6)
+    q = q * scale
+
+    gate_input = a.reshape(B, HV, K).float() + dt_bias.reshape(1, HV, K).float()
+    softplus = torch.where(
+        gate_input <= SOFTPLUS_THRESHOLD,
+        torch.log(1.0 + torch.exp(gate_input)),
+        gate_input,
+    )
+    log_decay = -torch.exp(A_log.reshape(1, HV, 1).float()) * softplus
+    beta = torch.sigmoid(b.float())
+
+    valid = ssm_state_indices >= 0
+    safe_indices = torch.where(valid, ssm_state_indices, 0).long()
+    state = initial_state.index_select(0, safe_indices).float()
+    state = state * torch.exp(log_decay)[:, :, None, :]
+    value_residual = v - (state * k[:, :, None, :]).sum(-1)
+    value_residual = value_residual * beta[:, :, None]
+    state = state + value_residual[:, :, :, None] * k[:, :, None, :]
+    output = (state * q[:, :, None, :]).sum(-1)
+
+    out[:, 0] = torch.where(valid[:, None, None], output, 0.0).to(out.dtype)
+    if valid.any():
+        initial_state[safe_indices[valid]] = state[valid].to(initial_state.dtype)
+    return out, initial_state
+
+
+PackedDecode = Callable[
+    [
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        float,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        bool,
+    ],
+    tuple[torch.Tensor, torch.Tensor],
+]
+PackedDecodeArgs = tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    float,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    bool,
+]
+
+
+@dataclass
+class KDAInputs:
+    mixed_qkv: torch.Tensor
+    a: torch.Tensor
+    b: torch.Tensor
+    A_log: torch.Tensor
+    dt_bias: torch.Tensor
+    scale: float
+    initial_state: torch.Tensor
+    out: torch.Tensor
+    ssm_state_indices: torch.Tensor
+    use_qk_l2norm_in_kernel: bool = True
+
+    def args(self) -> PackedDecodeArgs:
+        return (
+            self.mixed_qkv,
+            self.a,
+            self.b,
+            self.A_log,
+            self.dt_bias,
+            self.scale,
+            self.initial_state,
+            self.out,
+            self.ssm_state_indices,
+            self.use_qk_l2norm_in_kernel,
+        )
+
+    def clone_mutable(self) -> KDAInputs:
+        return KDAInputs(
+            mixed_qkv=self.mixed_qkv,
+            a=self.a,
+            b=self.b,
+            A_log=self.A_log,
+            dt_bias=self.dt_bias,
+            scale=self.scale,
+            initial_state=self.initial_state.clone(),
+            out=torch.empty_like(self.out),
+            ssm_state_indices=self.ssm_state_indices,
+            use_qk_l2norm_in_kernel=self.use_qk_l2norm_in_kernel,
+        )
+
+
+def make_kda_inputs(
+    B: int,
+    H: int,
+    HV: int,
+    K: int,
+    V: int,
+    *,
+    device: torch.device | str = "cuda",
+    activation_dtype: torch.dtype = torch.bfloat16,
+    state_dtype: torch.dtype = torch.float32,
+    pool_size: int | None = None,
+    seed: int = 42,
+    padded: bool = False,
+) -> KDAInputs:
+    """Create stable, production-layout packed KDA decode inputs."""
+    if HV % H != 0:
+        raise ValueError(f"HV={HV} must be divisible by H={H}")
+    if pool_size is None:
+        pool_size = B + 16
+    if pool_size < B:
+        raise ValueError(f"pool_size={pool_size} must be at least B={B}")
+
+    generator = torch.Generator(device=device).manual_seed(seed)
+    qkv_dim = 2 * H * K + HV * V
+    mixed_qkv = (
+        torch.randn(
+            B,
+            qkv_dim,
+            device=device,
+            dtype=activation_dtype,
+            generator=generator,
+        )
+        * 0.1
+    )
+    a = (
+        torch.randn(
+            B,
+            HV * K,
+            device=device,
+            dtype=activation_dtype,
+            generator=generator,
+        )
+        * 0.5
+        - 1.0
+    )
+    b = (
+        torch.randn(
+            B,
+            HV,
+            device=device,
+            dtype=activation_dtype,
+            generator=generator,
+        )
+        * 0.5
+    )
+    A_log = (
+        torch.randn(HV, device=device, dtype=torch.float32, generator=generator) * 0.2
+    )
+    dt_bias = (
+        torch.randn(HV * K, device=device, dtype=torch.float32, generator=generator)
+        * 0.1
+    )
+    initial_state = (
+        torch.randn(
+            pool_size,
+            HV,
+            V,
+            K,
+            device=device,
+            dtype=state_dtype,
+            generator=generator,
+        )
+        * 0.01
+    )
+    ssm_state_indices = torch.arange(B, device=device, dtype=torch.int32)
+    if padded:
+        ssm_state_indices[1::2] = -1
+    out = torch.empty(B, 1, HV, V, device=device, dtype=activation_dtype)
+    return KDAInputs(
+        mixed_qkv=mixed_qkv.contiguous(),
+        a=a.contiguous(),
+        b=b.contiguous(),
+        A_log=A_log.contiguous(),
+        dt_bias=dt_bias.contiguous(),
+        scale=K**-0.5,
+        initial_state=initial_state.contiguous(),
+        out=out,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+
+def _install_namespace(name: str, path: Path | None = None) -> None:
+    module = ModuleType(name)
+    module.__path__ = [] if path is None else [str(path)]  # type: ignore[attr-defined]
+    sys.modules[name] = module
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_sglang_packed_decode(sglang_root: Path) -> PackedDecode:
+    """Load the exact SGLang baseline without importing the full server package."""
+    fla_dir = (
+        sglang_root / "python" / "sglang" / "kernels" / "ops" / "attention" / "fla"
+    )
+    baseline_path = fla_dir / "fused_recurrent.py"
+    op_path = fla_dir / "op.py"
+    if not baseline_path.is_file() or not op_path.is_file():
+        raise FileNotFoundError(
+            f"Expected SGLang KDA sources under {fla_dir}; "
+            "pass --sglang-root explicitly."
+        )
+
+    package_paths = {
+        "sglang": sglang_root / "python" / "sglang",
+        "sglang.kernels": sglang_root / "python" / "sglang" / "kernels",
+        "sglang.kernels.ops": sglang_root / "python" / "sglang" / "kernels" / "ops",
+        "sglang.kernels.ops.attention": fla_dir.parent,
+        "sglang.kernels.ops.attention.fla": fla_dir,
+    }
+    for name, path in package_paths.items():
+        _install_namespace(name, path)
+
+    utils_name = "sglang.kernels.ops.attention.fla.utils"
+    utils = ModuleType(utils_name)
+    utils.input_guard = lambda fn: fn  # type: ignore[attr-defined]
+    utils.is_gather_supported = hasattr(  # type: ignore[attr-defined]
+        __import__("triton.language", fromlist=["gather"]), "gather"
+    )
+    sys.modules[utils_name] = utils
+
+    _load_module("sglang.kernels.ops.attention.fla.op", op_path)
+    module = _load_module(
+        "sglang.kernels.ops.attention.fla.fused_recurrent", baseline_path
+    )
+    baseline = module.fused_recurrent_kda_packed_decode
+    if not callable(baseline):
+        raise TypeError(f"Unexpected baseline object: {baseline!r}")
+    return cast("PackedDecode", baseline)
+
+
+def assert_matching_signatures(baseline: PackedDecode) -> None:
+    """Check argument names, order, kinds, and defaults against SGLang."""
+    expected = inspect.signature(baseline)
+    actual = inspect.signature(helion_fused_recurrent_kda_packed_decode)
+    expected_params = list(expected.parameters.values())
+    actual_params = list(actual.parameters.values())
+    if len(expected_params) != len(actual_params):
+        raise AssertionError(f"Signature length mismatch: {actual} != {expected}")
+    for actual_param, expected_param in zip(
+        actual_params, expected_params, strict=True
+    ):
+        if (
+            actual_param.name != expected_param.name
+            or actual_param.kind != expected_param.kind
+            or actual_param.default != expected_param.default
+        ):
+            raise AssertionError(
+                f"Signature mismatch at {actual_param.name}: {actual} != {expected}"
+            )
+
+
+def _max_abs_diff(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    return float((actual.float() - expected.float()).abs().max())
+
+
+def check_correctness(
+    baseline: PackedDecode,
+    inputs: KDAInputs,
+    *,
+    atol: float = 2e-2,
+    rtol: float = 1e-2,
+) -> tuple[float, float]:
+    """Check reference, output/state values, mutations, aliases, and padding."""
+    original_state = inputs.initial_state.clone()
+    original_readonly = tuple(
+        tensor.clone()
+        for tensor in (
+            inputs.mixed_qkv,
+            inputs.a,
+            inputs.b,
+            inputs.A_log,
+            inputs.dt_bias,
+            inputs.ssm_state_indices,
+        )
+    )
+
+    reference_inputs = inputs.clone_mutable()
+    baseline_inputs = inputs.clone_mutable()
+    helion_inputs = inputs.clone_mutable()
+
+    reference_result = torch_fused_recurrent_kda_packed_decode(*reference_inputs.args())
+    baseline_result = baseline(*baseline_inputs.args())
+    helion_result = helion_fused_recurrent_kda_packed_decode(*helion_inputs.args())
+    torch.cuda.synchronize()
+
+    for result, call_inputs, name in (
+        (reference_result, reference_inputs, "reference"),
+        (baseline_result, baseline_inputs, "SGLang"),
+        (helion_result, helion_inputs, "Helion"),
+    ):
+        if result[0].data_ptr() != call_inputs.out.data_ptr():
+            raise AssertionError(f"{name} did not return the supplied out tensor")
+        if result[1].data_ptr() != call_inputs.initial_state.data_ptr():
+            raise AssertionError(f"{name} did not return the supplied state tensor")
+
+    torch.testing.assert_close(
+        baseline_inputs.out, reference_inputs.out, atol=atol, rtol=rtol
+    )
+    torch.testing.assert_close(
+        baseline_inputs.initial_state,
+        reference_inputs.initial_state,
+        atol=atol,
+        rtol=rtol,
+    )
+    torch.testing.assert_close(
+        helion_inputs.out, baseline_inputs.out, atol=atol, rtol=rtol
+    )
+    torch.testing.assert_close(
+        helion_inputs.initial_state,
+        baseline_inputs.initial_state,
+        atol=atol,
+        rtol=rtol,
+    )
+
+    valid_indices = inputs.ssm_state_indices[inputs.ssm_state_indices >= 0].long()
+    touched = torch.zeros(
+        original_state.shape[0], dtype=torch.bool, device=original_state.device
+    )
+    touched[valid_indices] = True
+    if not torch.equal(helion_inputs.initial_state[~touched], original_state[~touched]):
+        raise AssertionError("Helion modified an unselected state-cache row")
+    invalid = inputs.ssm_state_indices < 0
+    if invalid.any() and torch.count_nonzero(helion_inputs.out[invalid]) != 0:
+        raise AssertionError("Helion did not zero output for a padded state index")
+
+    for current, original, name in zip(
+        (
+            inputs.mixed_qkv,
+            inputs.a,
+            inputs.b,
+            inputs.A_log,
+            inputs.dt_bias,
+            inputs.ssm_state_indices,
+        ),
+        original_readonly,
+        ("mixed_qkv", "a", "b", "A_log", "dt_bias", "ssm_state_indices"),
+        strict=True,
+    ):
+        if not torch.equal(current, original):
+            raise AssertionError(f"Read-only input {name} was modified")
+
+    return (
+        _max_abs_diff(helion_inputs.out, baseline_inputs.out),
+        _max_abs_diff(
+            helion_inputs.initial_state[valid_indices],
+            baseline_inputs.initial_state[valid_indices],
+        ),
+    )
+
+
+def benchmark_one(
+    baseline: PackedDecode,
+    inputs: KDAInputs,
+    *,
+    warmup_ms: int,
+    rep_ms: int,
+    rounds: int,
+) -> tuple[float, float]:
+    """Return median SGLang and Helion latency in milliseconds."""
+    from triton.testing import do_bench
+
+    baseline_inputs = inputs.clone_mutable()
+    helion_inputs = inputs.clone_mutable()
+
+    def run_baseline() -> None:
+        baseline(*baseline_inputs.args())
+
+    def run_helion() -> None:
+        helion_fused_recurrent_kda_packed_decode(*helion_inputs.args())
+
+    run_baseline()
+    run_helion()
+    torch.cuda.synchronize()
+    samples: dict[str, list[float]] = {"SGLang": [], "Helion": []}
+    benchmarks = (("SGLang", run_baseline), ("Helion", run_helion))
+    for round_index in range(rounds):
+        round_benchmarks = benchmarks if round_index % 2 == 0 else benchmarks[::-1]
+        for name, fn in round_benchmarks:
+            samples[name].append(float(do_bench(fn, warmup=warmup_ms, rep=rep_ms)))
+    return statistics.median(samples["SGLang"]), statistics.median(samples["Helion"])
+
+
+def autotune_decode_shapes(
+    batch_sizes: list[int],
+    *,
+    local_heads: int,
+    activation_dtype: torch.dtype,
+    state_dtype: torch.dtype,
+    seed: int,
+    aggregation: Literal["geomean", "max"],
+) -> helion.Config:
+    """Select one config using equal-weight relative latency across batch sizes."""
+    arg_sets = [
+        make_kda_inputs(
+            batch_size,
+            local_heads,
+            local_heads,
+            KIMI_HEAD_K_DIM,
+            KIMI_HEAD_V_DIM,
+            activation_dtype=activation_dtype,
+            state_dtype=state_dtype,
+            seed=seed + index,
+        ).args()
+        for index, batch_size in enumerate(batch_sizes)
+    ]
+    cache_tag = (
+        "kda-packed-decode-v1-"
+        f"h{local_heads}-b{'-'.join(map(str, batch_sizes))}-"
+        f"{str(activation_dtype).removeprefix('torch.')}-"
+        f"{str(state_dtype).removeprefix('torch.')}"
+    )
+    return _helion_fused_recurrent_kda_packed_decode.autotune_multi(
+        arg_sets,
+        aggregation=aggregation,
+        relative_to="default",
+        cache_tag=cache_tag,
+        force=True,
+    )
+
+
+def _dtype(name: str) -> torch.dtype:
+    return {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+    }[name]
+
+
+def _default_sglang_root() -> Path:
+    return Path(__file__).resolve().parents[3] / "sglang"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare Helion with SGLang's default packed KDA decode kernel."
+    )
+    parser.add_argument("--sglang-root", type=Path, default=_default_sglang_root())
+    parser.add_argument(
+        "--mode", choices=("all", "correctness", "bench"), default="all"
+    )
+    parser.add_argument(
+        "--batch-sizes", type=int, nargs="+", default=[1, 4, 16, 64, 128, 256]
+    )
+    parser.add_argument(
+        "--multi-autotune",
+        action="store_true",
+        help="Jointly autotune one config before running the selected mode.",
+    )
+    parser.add_argument(
+        "--tune-batch-sizes", type=int, nargs="+", default=[1, 256]
+    )
+    parser.add_argument(
+        "--tune-aggregation", choices=("geomean", "max"), default="geomean"
+    )
+    parser.add_argument(
+        "--tp-sizes",
+        type=int,
+        nargs="+",
+        default=[2],
+        help="Tensor-parallel sizes; local heads are 32 / TP (default: 2).",
+    )
+    parser.add_argument(
+        "--activation-dtype",
+        choices=("float16", "bfloat16", "float32"),
+        default="bfloat16",
+    )
+    parser.add_argument(
+        "--state-dtype",
+        choices=("float16", "bfloat16", "float32"),
+        default="float32",
+        help="Kimi-Linear's default recurrent-state dtype is float32.",
+    )
+    parser.add_argument("--warmup-ms", type=int, default=100)
+    parser.add_argument("--rep-ms", type=int, default=500)
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--atol", type=float, default=2e-2)
+    parser.add_argument("--rtol", type=float, default=1e-2)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required for the SGLang and Helion kernels.")
+    if args.rounds < 1:
+        raise SystemExit("--rounds must be at least 1.")
+    for tp_size in args.tp_sizes:
+        if KIMI_GLOBAL_HEADS % tp_size != 0:
+            raise SystemExit(
+                f"TP={tp_size} does not divide {KIMI_GLOBAL_HEADS} Kimi heads."
+            )
+
+    baseline = load_sglang_packed_decode(args.sglang_root.resolve())
+    assert_matching_signatures(baseline)
+
+    activation_dtype = _dtype(args.activation_dtype)
+    state_dtype = _dtype(args.state_dtype)
+    device = torch.device("cuda")
+    capability = torch.cuda.get_device_capability(device)
+    print(
+        f"Device: {torch.cuda.get_device_name(device)} "
+        f"(SM{capability[0]}{capability[1]})"
+    )
+    print(f"SGLang source: {args.sglang_root.resolve()}")
+    print(f"Helion config: {_KDA_CONFIG}")
+    print(
+        f"Contract: activation={activation_dtype}, state={state_dtype}, "
+        f"K={KIMI_HEAD_K_DIM}, V={KIMI_HEAD_V_DIM}, "
+        "raw gate/beta logits, q/k L2 normalization"
+    )
+    if capability[0] >= 10 and state_dtype is torch.bfloat16:
+        print(
+            "Note: this still compares the explicit Triton source; SGLang's "
+            "SM100 server default for a bfloat16 state is external FlashInfer."
+        )
+
+    if args.multi_autotune:
+        if len(args.tp_sizes) != 1:
+            raise SystemExit("--multi-autotune requires exactly one --tp-sizes value.")
+        local_heads = KIMI_GLOBAL_HEADS // args.tp_sizes[0]
+        print(
+            "Joint autotune: "
+            f"B={args.tune_batch_sizes}, H={local_heads}, "
+            f"aggregation={args.tune_aggregation}, relative_to=default"
+        )
+        winner = autotune_decode_shapes(
+            args.tune_batch_sizes,
+            local_heads=local_heads,
+            activation_dtype=activation_dtype,
+            state_dtype=state_dtype,
+            seed=args.seed,
+            aggregation=args.tune_aggregation,
+        )
+        print(f"Joint autotune winner: {winner}")
+
+    if args.mode in ("all", "correctness"):
+        print("\nCorrectness and mutation contract")
+        for tp_size in args.tp_sizes:
+            local_heads = KIMI_GLOBAL_HEADS // tp_size
+            for batch_size in args.batch_sizes:
+                inputs = make_kda_inputs(
+                    batch_size,
+                    local_heads,
+                    local_heads,
+                    KIMI_HEAD_K_DIM,
+                    KIMI_HEAD_V_DIM,
+                    device=device,
+                    activation_dtype=activation_dtype,
+                    state_dtype=state_dtype,
+                    seed=args.seed,
+                )
+                output_diff, state_diff = check_correctness(
+                    baseline, inputs, atol=args.atol, rtol=args.rtol
+                )
+                print(
+                    f"  TP={tp_size} B={batch_size:>3} H={local_heads:>2}: "
+                    f"PASS output_max={output_diff:.3e} "
+                    f"state_max={state_diff:.3e}"
+                )
+
+            padded_inputs = make_kda_inputs(
+                4,
+                local_heads,
+                local_heads,
+                KIMI_HEAD_K_DIM,
+                KIMI_HEAD_V_DIM,
+                device=device,
+                activation_dtype=activation_dtype,
+                state_dtype=state_dtype,
+                seed=args.seed + 1,
+                padded=True,
+            )
+            check_correctness(baseline, padded_inputs, atol=args.atol, rtol=args.rtol)
+            print(f"  TP={tp_size} padded cache indices: PASS")
+
+        grouped_inputs = make_kda_inputs(
+            4,
+            8,
+            16,
+            KIMI_HEAD_K_DIM,
+            KIMI_HEAD_V_DIM,
+            device=device,
+            activation_dtype=activation_dtype,
+            state_dtype=state_dtype,
+            seed=args.seed + 2,
+        )
+        check_correctness(baseline, grouped_inputs, atol=args.atol, rtol=args.rtol)
+        print("  grouped heads H=8, HV=16: PASS")
+
+    if args.mode in ("all", "bench"):
+        print("\nLatency (microseconds, lower is better)")
+        print("  TP    B   H |  SGLang   Helion  speedup  saved/layer  saved/20 layers")
+        print("  " + "-" * 72)
+        for tp_size in args.tp_sizes:
+            local_heads = KIMI_GLOBAL_HEADS // tp_size
+            for batch_size in args.batch_sizes:
+                inputs = make_kda_inputs(
+                    batch_size,
+                    local_heads,
+                    local_heads,
+                    KIMI_HEAD_K_DIM,
+                    KIMI_HEAD_V_DIM,
+                    device=device,
+                    activation_dtype=activation_dtype,
+                    state_dtype=state_dtype,
+                    seed=args.seed,
+                )
+                baseline_ms, helion_ms = benchmark_one(
+                    baseline,
+                    inputs,
+                    warmup_ms=args.warmup_ms,
+                    rep_ms=args.rep_ms,
+                    rounds=args.rounds,
+                )
+                baseline_us = baseline_ms * 1000
+                helion_us = helion_ms * 1000
+                saved_us = baseline_us - helion_us
+                speedup = baseline_us / helion_us
+                print(
+                    f"  {tp_size:>2} {batch_size:>4} {local_heads:>3} | "
+                    f"{baseline_us:>7.1f} {helion_us:>8.1f} "
+                    f"{speedup:>7.2f}x {saved_us:>11.1f} "
+                    f"{saved_us * KIMI_KDA_LAYERS:>15.1f}"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/linear/kda_prefill.py
+++ b/examples/linear/kda_prefill.py
@@ -1,0 +1,1982 @@
+"""Helion kernels for SGLang's Kimi Delta Attention prefill path.
+
+The public :func:`chunk_kda` entry point in this module is intended to match
+``sglang.kernels.ops.attention.fla.kda.chunk_kda``.  KDA uses 64-token chunks
+and keeps the cumulative per-key decay in base-2 logarithm space.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import helion
+import helion.language as hl
+
+CHUNK_SIZE = 64
+# Rounded identically to flash-linear-attention/SGLang before FP32 multiply.
+RCP_LN2 = 1.4426950216293335
+L2_NORM_EPS = 1e-6
+SOFTPLUS_THRESHOLD = 20.0
+
+
+_CHUNK_INDICES_CACHE: list[tuple[torch.Tensor, int, torch.Tensor]] = []
+_CHUNK_OFFSETS_CACHE: list[tuple[torch.Tensor, int, torch.Tensor]] = []
+
+
+_L2_NORM_CONFIG = helion.Config(
+    block_sizes=[8],
+    num_warps=4,
+    num_stages=2,
+    indexing="pointer",
+)
+
+
+@helion.kernel(static_shapes=False, config=_L2_NORM_CONFIG)
+def _l2norm_qk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Normalize Q and K rows with Triton's FP32 accumulation contract."""
+    B = q.size(0)
+    T = q.size(1)
+    H = hl.specialize(q.size(2))
+    K = hl.specialize(q.size(3))
+    hl.specialize(
+        (
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+        )
+    )
+
+    q_out = torch.empty_like(q)
+    k_out = torch.empty_like(k)
+    q_rows = q.view(B * T * H, K)
+    k_rows = k.view(B * T * H, K)
+    q_out_rows = q_out.view(B * T * H, K)
+    k_out_rows = k_out.view(B * T * H, K)
+    block_rows = hl.register_block_size(1, 16)
+
+    for tile_rows in hl.tile(B * T * H, block_size=block_rows):
+        q_value = q_rows[tile_rows, :].float()
+        k_value = k_rows[tile_rows, :].float()
+        q_norm = torch.sqrt((q_value * q_value).sum(-1) + L2_NORM_EPS)
+        k_norm = torch.sqrt((k_value * k_value).sum(-1) + L2_NORM_EPS)
+        q_out_rows[tile_rows, :] = (q_value / q_norm[:, None]).to(q.dtype)
+        k_out_rows[tile_rows, :] = (k_value / k_norm[:, None]).to(k.dtype)
+
+    return q_out, k_out
+
+
+_GATE_FIXED_CONFIG = helion.Config(
+    block_sizes=[16],
+    loop_orders=[[2, 3, 1, 0]],
+    num_warps=1,
+    num_stages=1,
+    indexing="pointer",
+)
+
+
+_GATE_VARLEN_CONFIG = helion.Config(
+    block_sizes=[16],
+    loop_orders=[[2, 1, 0]],
+    num_warps=1,
+    num_stages=1,
+    indexing="pointer",
+)
+
+
+def _activate_gate(
+    raw_gate: torch.Tensor,
+    a_log: torch.Tensor,
+    lower_bound: float,
+    use_lower_bound: hl.constexpr,
+) -> torch.Tensor:
+    a = torch.exp(a_log.float())
+    if use_lower_bound:
+        return lower_bound * torch.sigmoid(a * raw_gate)
+    softplus = torch.where(
+        raw_gate < SOFTPLUS_THRESHOLD,
+        torch.log(1.0 + torch.exp(raw_gate)),
+        raw_gate,
+    )
+    return -a * softplus
+
+
+@helion.kernel(static_shapes=False, config=_GATE_FIXED_CONFIG)
+def _gate_cumsum_fixed(
+    g: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    lower_bound: float,
+    activate: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    has_bias: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    use_lower_bound: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> torch.Tensor:
+    """Gate activation and chunk-local cumsum for equal-length batches."""
+    B = g.size(0)
+    T = g.size(1)
+    H = hl.specialize(g.size(2))
+    K = hl.specialize(g.size(3))
+    hl.specialize(
+        (
+            g.stride(1),
+            g.stride(2),
+            g.stride(3),
+            a_log.stride(0),
+            dt_bias.stride(0),
+        )
+    )
+
+    out = torch.empty_like(g, dtype=torch.float32)
+    g_rows = g.view(B * T * H, K)
+    out_rows = out.view(B * T * H, K)
+    chunks = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    block_k = hl.register_block_size(16, K)
+
+    for tile_b, tile_chunk, tile_h, tile_k in hl.tile(
+        [B, chunks, H, K],
+        block_size=[1, 1, 1, block_k],
+    ):
+        time = hl.arange(64)
+        token = tile_chunk.id * CHUNK_SIZE + time
+        valid = token < T
+        row = (tile_b.id * T + token) * H + tile_h.id
+        value = hl.load(
+            g_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        if activate:
+            if has_bias:
+                value = value + dt_bias[tile_h.id * K + tile_k.index].float()[None, :]
+            value = _activate_gate(
+                value,
+                a_log[tile_h.id],
+                lower_bound,
+                use_lower_bound,
+            )
+        value = torch.cumsum(value, dim=0) * scale
+        hl.store(
+            out_rows,
+            [row[:, None], tile_k.index[None, :]],
+            value,
+            extra_mask=valid[:, None],
+        )
+
+    return out
+
+
+@helion.kernel(static_shapes=False, config=_GATE_VARLEN_CONFIG)
+def _gate_cumsum_varlen(
+    g: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    scale: float,
+    lower_bound: float,
+    activate: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    has_bias: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    use_lower_bound: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> torch.Tensor:
+    """Gate activation and chunk-local cumsum for packed ragged sequences."""
+    T = g.size(1)
+    H = hl.specialize(g.size(2))
+    K = hl.specialize(g.size(3))
+    chunks = chunk_indices.size(0)
+    hl.specialize(
+        (
+            g.stride(1),
+            g.stride(2),
+            g.stride(3),
+            a_log.stride(0),
+            dt_bias.stride(0),
+            cu_seqlens.stride(0),
+            chunk_indices.stride(0),
+            chunk_indices.stride(1),
+        )
+    )
+
+    out = torch.empty_like(g, dtype=torch.float32)
+    g_rows = g.view(T * H, K)
+    out_rows = out.view(T * H, K)
+    block_k = hl.register_block_size(16, K)
+
+    for tile_chunk, tile_h, tile_k in hl.tile(
+        [chunks, H, K],
+        block_size=[1, 1, block_k],
+    ):
+        time = hl.arange(64)
+        sequence = chunk_indices[tile_chunk.id, 0].long()
+        local_chunk = chunk_indices[tile_chunk.id, 1].long()
+        begin = cu_seqlens[sequence].long()
+        end = cu_seqlens[sequence + 1].long()
+        token = begin + local_chunk * CHUNK_SIZE + time
+        valid = token < end
+        row = token * H + tile_h.id
+        value = hl.load(
+            g_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        if activate:
+            if has_bias:
+                value = value + dt_bias[tile_h.id * K + tile_k.index].float()[None, :]
+            value = _activate_gate(
+                value,
+                a_log[tile_h.id],
+                lower_bound,
+                use_lower_bound,
+            )
+        value = torch.cumsum(value, dim=0) * scale
+        hl.store(
+            out_rows,
+            [row[:, None], tile_k.index[None, :]],
+            value,
+            extra_mask=valid[:, None],
+        )
+
+    return out
+
+
+def prepare_chunk_indices(
+    cu_seqlens: torch.Tensor,
+    chunk_size: int = CHUNK_SIZE,
+) -> torch.Tensor:
+    """Build the same ``(sequence, local_chunk)`` map used by SGLang."""
+    for index, (cached_cu_seqlens, cached_chunk_size, result) in enumerate(
+        _CHUNK_INDICES_CACHE
+    ):
+        if cu_seqlens is cached_cu_seqlens and chunk_size == cached_chunk_size:
+            _CHUNK_INDICES_CACHE.append(_CHUNK_INDICES_CACHE.pop(index))
+            return result
+
+    lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunk_counts = torch.div(
+        lengths + chunk_size - 1,
+        chunk_size,
+        rounding_mode="floor",
+    )
+    local_chunks = torch.cat(
+        [
+            torch.arange(count, device=cu_seqlens.device, dtype=cu_seqlens.dtype)
+            for count in chunk_counts.tolist()
+        ]
+    )
+    result = torch.stack(
+        [local_chunks.eq(0).cumsum(0) - 1, local_chunks],
+        dim=1,
+    )
+    _CHUNK_INDICES_CACHE.append((cu_seqlens, chunk_size, result))
+    if len(_CHUNK_INDICES_CACHE) > 4:
+        _CHUNK_INDICES_CACHE.pop(0)
+    return result
+
+
+def prepare_chunk_offsets(
+    cu_seqlens: torch.Tensor,
+    chunk_size: int = CHUNK_SIZE,
+) -> torch.Tensor:
+    """Return the packed output offset for each ragged sequence."""
+    for index, (cached_cu_seqlens, cached_chunk_size, result) in enumerate(
+        _CHUNK_OFFSETS_CACHE
+    ):
+        if cu_seqlens is cached_cu_seqlens and chunk_size == cached_chunk_size:
+            _CHUNK_OFFSETS_CACHE.append(_CHUNK_OFFSETS_CACHE.pop(index))
+            return result
+
+    lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunk_counts = torch.div(
+        lengths + chunk_size - 1,
+        chunk_size,
+        rounding_mode="floor",
+    )
+    result = torch.cat([cu_seqlens.new_zeros(1), chunk_counts]).cumsum(0)
+    _CHUNK_OFFSETS_CACHE.append((cu_seqlens, chunk_size, result))
+    if len(_CHUNK_OFFSETS_CACHE) > 4:
+        _CHUNK_OFFSETS_CACHE.pop(0)
+    return result
+
+
+def gate_chunk_cumsum(
+    g: torch.Tensor,
+    *,
+    a_log: torch.Tensor | None,
+    dt_bias: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_indices: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    scale: float = RCP_LN2,
+) -> torch.Tensor:
+    """Apply KDA gate preprocessing with SGLang-compatible option semantics."""
+    flat_a_log = (
+        a_log.reshape(-1)
+        if a_log is not None
+        else torch.empty(1, device=g.device, dtype=torch.float32)
+    )
+    flat_bias = (
+        dt_bias.reshape(-1)
+        if dt_bias is not None
+        else torch.empty(1, device=g.device, dtype=torch.float32)
+    )
+    activate = a_log is not None
+    has_bias = dt_bias is not None
+    use_lower_bound = lower_bound is not None
+    lower_bound_value = 0.0 if lower_bound is None else lower_bound
+
+    if cu_seqlens is None:
+        return _gate_cumsum_fixed(
+            g,
+            flat_a_log,
+            flat_bias,
+            scale,
+            lower_bound_value,
+            activate,
+            has_bias,
+            use_lower_bound,
+        )
+
+    if g.size(0) != 1:
+        raise ValueError("varlen KDA requires batch size 1")
+    if chunk_indices is None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens)
+    return _gate_cumsum_varlen(
+        g,
+        flat_a_log,
+        flat_bias,
+        cu_seqlens,
+        chunk_indices,
+        scale,
+        lower_bound_value,
+        activate,
+        has_bias,
+        use_lower_bound,
+    )
+
+
+_INTRA_MATRIX_CONFIG = helion.Config(
+    block_sizes=[32],
+    loop_orders=[[2, 1, 0]],
+    num_warps=1,
+    num_stages=2,
+    indexing="pointer",
+)
+
+
+@helion.kernel(static_shapes=False, config=_INTRA_MATRIX_CONFIG)
+def _intra_matrices_wide(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    scale: float,
+    is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute a full 16x64 causal matrix row per CTA."""
+    B = q.size(0)
+    T = q.size(1)
+    H = hl.specialize(q.size(2))
+    K = hl.specialize(q.size(3))
+    chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    total_chunks = chunk_indices.size(0) if is_varlen else B * chunks_per_batch
+    hl.specialize(
+        (
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            g.stride(1),
+            g.stride(2),
+            g.stride(3),
+            beta.stride(1),
+            beta.stride(2),
+        )
+    )
+
+    aqk = torch.empty([B, T, H, CHUNK_SIZE], dtype=q.dtype, device=q.device)
+    akk = torch.empty([B, T, H, CHUNK_SIZE], dtype=torch.float32, device=q.device)
+    q_rows = q.view(B * T * H, K)
+    k_rows = k.view(B * T * H, K)
+    g_rows = g.view(B * T * H, K)
+    beta_rows = beta.view(B * T * H)
+    aqk_rows = aqk.view(B * T * H, CHUNK_SIZE)
+    akk_rows = akk.view(B * T * H, CHUNK_SIZE)
+    block_k = hl.register_block_size(32, K)
+
+    for tile_chunk, tile_h, tile_row_block in hl.tile(
+        [total_chunks, H, 4],
+        block_size=[1, 1, 1],
+    ):
+        if is_varlen:
+            sequence = chunk_indices[tile_chunk.id, 0].long()
+            local_chunk = chunk_indices[tile_chunk.id, 1].long()
+            begin = cu_seqlens[sequence].long()
+            end = cu_seqlens[sequence + 1].long()
+        else:
+            sequence = tile_chunk.id // chunks_per_batch
+            local_chunk = tile_chunk.id % chunks_per_batch
+            begin = sequence * T
+            end = begin + T
+
+        row_lane = hl.arange(16)
+        col_lane = hl.arange(64)
+        chunk_begin = begin + local_chunk * CHUNK_SIZE
+        row_local = tile_row_block.id * 16 + row_lane
+        row_token = chunk_begin + row_local
+        col_token = chunk_begin + col_lane
+        row_valid = row_token < end
+        col_valid = col_token < end
+        block_causal = col_lane < (tile_row_block.id + 1) * 16
+        row = row_token * H + tile_h.id
+        col = col_token * H + tile_h.id
+        anchor_token = chunk_begin + tile_row_block.id * 16
+        anchor = anchor_token * H + tile_h.id
+        aqk_off = hl.zeros([16, 64], dtype=torch.float32)
+        akk_off = hl.zeros([16, 64], dtype=torch.float32)
+        aqk_diag = hl.zeros([16, 16], dtype=torch.float32)
+        akk_diag = hl.zeros([16, 16], dtype=torch.float32)
+
+        for tile_k in hl.tile(K, block_size=block_k):
+            q_row = hl.load(
+                q_rows,
+                [row[:, None], tile_k.index[None, :]],
+                extra_mask=row_valid[:, None],
+            ).float()
+            k_row = hl.load(
+                k_rows,
+                [row[:, None], tile_k.index[None, :]],
+                extra_mask=row_valid[:, None],
+            ).float()
+            g_row = hl.load(
+                g_rows,
+                [row[:, None], tile_k.index[None, :]],
+                extra_mask=row_valid[:, None],
+            ).float()
+            k_col = hl.load(
+                k_rows,
+                [col[:, None], tile_k.index[None, :]],
+                extra_mask=col_valid[:, None] & block_causal[:, None],
+            ).float()
+            g_col = hl.load(
+                g_rows,
+                [col[:, None], tile_k.index[None, :]],
+                extra_mask=col_valid[:, None] & block_causal[:, None],
+            ).float()
+            g_anchor = hl.load(
+                g_rows,
+                [anchor, tile_k.index],
+                extra_mask=anchor_token < end,
+            ).float()
+            off_col = col_lane < tile_row_block.id * 16
+            off_col_delta = torch.where(
+                off_col[:, None],
+                g_anchor[None, :] - g_col,
+                0.0,
+            )
+            q_off = (q_row * torch.exp2(g_row - g_anchor[None, :])).to(torch.bfloat16)
+            k_off = (k_row * torch.exp2(g_row - g_anchor[None, :])).to(torch.bfloat16)
+            k_col_off = (k_col * torch.exp2(off_col_delta)).to(torch.bfloat16)
+            aqk_off = hl.dot(
+                q_off,
+                k_col_off.T,
+                acc=aqk_off,
+                out_dtype=torch.float32,
+            )
+            akk_off = hl.dot(
+                k_off,
+                k_col_off.T,
+                acc=akk_off,
+                out_dtype=torch.float32,
+            )
+
+            diag_delta = torch.clamp(
+                g_row - g_anchor[None, :],
+                -126.0,
+                126.0,
+            )
+            q_diag = q_row * torch.exp2(diag_delta)
+            k_diag_fwd = k_row * torch.exp2(diag_delta)
+            k_diag_bwd = k_row * torch.exp2(-diag_delta)
+            aqk_diag = hl.dot(
+                q_diag,
+                k_diag_bwd.T,
+                acc=aqk_diag,
+                out_dtype=torch.float32,
+            )
+            akk_diag = hl.dot(
+                k_diag_fwd,
+                k_diag_bwd.T,
+                acc=akk_diag,
+                out_dtype=torch.float32,
+            )
+
+        causal = row_local[:, None] >= col_lane[None, :]
+        strictly_causal = row_local[:, None] > col_lane[None, :]
+        row_beta = hl.load(
+            beta_rows,
+            [row],
+            extra_mask=row_valid,
+        ).float()
+        hl.store(
+            aqk_rows,
+            [row[:, None], col_lane[None, :]],
+            torch.where(causal & col_valid[None, :], aqk_off * scale, 0.0),
+            extra_mask=row_valid[:, None],
+        )
+        hl.store(
+            akk_rows,
+            [row[:, None], col_lane[None, :]],
+            torch.where(
+                strictly_causal & col_valid[None, :],
+                akk_off * row_beta[:, None],
+                0.0,
+            ),
+            extra_mask=row_valid[:, None],
+        )
+        diag_col = tile_row_block.id * 16 + row_lane
+        diag_causal = row_lane[:, None] >= row_lane[None, :]
+        diag_strict = row_lane[:, None] > row_lane[None, :]
+        hl.store(
+            aqk_rows,
+            [row[:, None], diag_col[None, :]],
+            torch.where(diag_causal & row_valid[None, :], aqk_diag * scale, 0.0),
+            extra_mask=row_valid[:, None],
+        )
+        hl.store(
+            akk_rows,
+            [row[:, None], diag_col[None, :]],
+            torch.where(
+                diag_strict & row_valid[None, :],
+                akk_diag * row_beta[:, None],
+                0.0,
+            ),
+            extra_mask=row_valid[:, None],
+        )
+
+    return aqk, akk
+
+
+@helion.kernel(static_shapes=False, config=_INTRA_MATRIX_CONFIG)
+def _intra_matrices(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    scale: float,
+    is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute causal QK and beta-scaled KK blocks for each KDA chunk."""
+    B = q.size(0)
+    T = q.size(1)
+    H = hl.specialize(q.size(2))
+    K = hl.specialize(q.size(3))
+    chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    total_chunks = chunk_indices.size(0) if is_varlen else B * chunks_per_batch
+    hl.specialize(
+        (
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            g.stride(1),
+            g.stride(2),
+            g.stride(3),
+            beta.stride(1),
+            beta.stride(2),
+        )
+    )
+
+    aqk = torch.zeros([B, T, H, CHUNK_SIZE], dtype=q.dtype, device=q.device)
+    akk = torch.zeros([B, T, H, CHUNK_SIZE], dtype=torch.float32, device=q.device)
+    q_rows = q.view(B * T * H, K)
+    k_rows = k.view(B * T * H, K)
+    g_rows = g.view(B * T * H, K)
+    beta_rows = beta.view(B * T * H)
+    aqk_rows = aqk.view(B * T * H, CHUNK_SIZE)
+    akk_rows = akk.view(B * T * H, CHUNK_SIZE)
+    block_k = hl.register_block_size(32, K)
+
+    for tile_chunk, tile_h, tile_row_block, tile_col_block in hl.tile(
+        [total_chunks, H, 4, 4],
+        block_size=[1, 1, 1, 1],
+    ):
+        if tile_col_block.id <= tile_row_block.id:
+            if is_varlen:
+                sequence = chunk_indices[tile_chunk.id, 0].long()
+                local_chunk = chunk_indices[tile_chunk.id, 1].long()
+                begin = cu_seqlens[sequence].long()
+                end = cu_seqlens[sequence + 1].long()
+            else:
+                sequence = tile_chunk.id // chunks_per_batch
+                local_chunk = tile_chunk.id % chunks_per_batch
+                begin = sequence * T
+                end = begin + T
+
+            lane = hl.arange(16)
+            chunk_begin = begin + local_chunk * CHUNK_SIZE
+            row_token = chunk_begin + tile_row_block.id * 16 + lane
+            col_token = chunk_begin + tile_col_block.id * 16 + lane
+            row_valid = row_token < end
+            col_valid = col_token < end
+            row = row_token * H + tile_h.id
+            col = col_token * H + tile_h.id
+            anchor_row = chunk_begin + tile_row_block.id * 16
+            anchor = anchor_row * H + tile_h.id
+            aqk_value = hl.zeros([16, 16], dtype=torch.float32)
+            akk_value = hl.zeros([16, 16], dtype=torch.float32)
+
+            for tile_k in hl.tile(K, block_size=block_k):
+                q_row = hl.load(
+                    q_rows,
+                    [row[:, None], tile_k.index[None, :]],
+                    extra_mask=row_valid[:, None],
+                ).float()
+                k_row = hl.load(
+                    k_rows,
+                    [row[:, None], tile_k.index[None, :]],
+                    extra_mask=row_valid[:, None],
+                ).float()
+                g_row = hl.load(
+                    g_rows,
+                    [row[:, None], tile_k.index[None, :]],
+                    extra_mask=row_valid[:, None],
+                ).float()
+                k_col = hl.load(
+                    k_rows,
+                    [col[:, None], tile_k.index[None, :]],
+                    extra_mask=col_valid[:, None],
+                ).float()
+                g_col = hl.load(
+                    g_rows,
+                    [col[:, None], tile_k.index[None, :]],
+                    extra_mask=col_valid[:, None],
+                ).float()
+                g_anchor = hl.load(
+                    g_rows,
+                    [anchor, tile_k.index],
+                    extra_mask=anchor_row < end,
+                ).float()
+
+                if tile_row_block.id == tile_col_block.id:
+                    delta_row = torch.clamp(
+                        g_row - g_anchor[None, :],
+                        -126.0,
+                        126.0,
+                    )
+                    delta_col = torch.clamp(
+                        g_anchor[None, :] - g_col,
+                        -126.0,
+                        126.0,
+                    )
+                    q_scaled = (q_row * torch.exp2(delta_row)).to(torch.bfloat16)
+                    k_scaled = (k_row * torch.exp2(delta_row)).to(torch.bfloat16)
+                    k_col_scaled = (k_col * torch.exp2(delta_col)).to(torch.bfloat16)
+                else:
+                    q_scaled = (q_row * torch.exp2(g_row - g_anchor[None, :])).to(
+                        torch.bfloat16
+                    )
+                    k_scaled = (k_row * torch.exp2(g_row - g_anchor[None, :])).to(
+                        torch.bfloat16
+                    )
+                    k_col_scaled = (k_col * torch.exp2(g_anchor[None, :] - g_col)).to(
+                        torch.bfloat16
+                    )
+
+                aqk_value = hl.dot(
+                    q_scaled,
+                    k_col_scaled.T,
+                    acc=aqk_value,
+                    out_dtype=torch.float32,
+                )
+                akk_value = hl.dot(
+                    k_scaled,
+                    k_col_scaled.T,
+                    acc=akk_value,
+                    out_dtype=torch.float32,
+                )
+
+            row_local = tile_row_block.id * 16 + lane
+            col_local = tile_col_block.id * 16 + lane
+            aqk_mask = row_valid[:, None] & col_valid[None, :]
+            akk_mask = row_valid[:, None] & col_valid[None, :]
+            aqk_causal = row_local[:, None] >= col_local[None, :]
+            akk_causal = row_local[:, None] > col_local[None, :]
+            row_beta = hl.load(
+                beta_rows,
+                [row],
+                extra_mask=row_valid,
+            ).float()
+            hl.store(
+                aqk_rows,
+                [row[:, None], col_local[None, :]],
+                torch.where(aqk_causal, aqk_value * scale, 0.0),
+                extra_mask=aqk_mask,
+            )
+            hl.store(
+                akk_rows,
+                [row[:, None], col_local[None, :]],
+                torch.where(akk_causal, akk_value * row_beta[:, None], 0.0),
+                extra_mask=akk_mask,
+            )
+
+    return aqk, akk
+
+
+def _invert_lower_16(matrix: torch.Tensor) -> torch.Tensor:
+    lane = hl.arange(16)
+    strictly_lower = lane[:, None] > lane[None, :]
+    inverse = -torch.where(strictly_lower, matrix, 0.0)
+    for row in range(2, 16):
+        value = -torch.where((lane == row)[:, None], matrix, 0.0).sum(0)
+        value = torch.where(lane < row, value, 0.0)
+        value = value + (value[:, None] * inverse).sum(0)
+        inverse = torch.where((lane == row)[:, None], value[None, :], inverse)
+    return inverse + (lane[:, None] == lane[None, :]).float()
+
+
+_INTRA_SOLVE_CONFIG = helion.Config(
+    loop_orders=[[1, 0]],
+    num_warps=2,
+    num_stages=2,
+    indexing="pointer",
+)
+
+
+@helion.kernel(static_shapes=False, config=_INTRA_SOLVE_CONFIG)
+def _intra_solve(
+    akk: torch.Tensor,
+    output_template: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> torch.Tensor:
+    """Invert the 64x64 unit-lower KDA system as four 16x16 blocks."""
+    B = akk.size(0)
+    T = akk.size(1)
+    H = hl.specialize(akk.size(2))
+    chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    total_chunks = chunk_indices.size(0) if is_varlen else B * chunks_per_batch
+    hl.specialize((akk.stride(1), akk.stride(2), akk.stride(3)))
+
+    inverse = torch.empty(
+        [B, T, H, CHUNK_SIZE],
+        dtype=output_template.dtype,
+        device=akk.device,
+    )
+    akk_rows = akk.view(B * T * H, CHUNK_SIZE)
+    inverse_rows = inverse.view(B * T * H, CHUNK_SIZE)
+
+    for tile_chunk, tile_h in hl.tile(
+        [total_chunks, H],
+        block_size=[1, 1],
+    ):
+        if is_varlen:
+            sequence = chunk_indices[tile_chunk.id, 0].long()
+            local_chunk = chunk_indices[tile_chunk.id, 1].long()
+            begin = cu_seqlens[sequence].long()
+            end = cu_seqlens[sequence + 1].long()
+        else:
+            sequence = tile_chunk.id // chunks_per_batch
+            local_chunk = tile_chunk.id % chunks_per_batch
+            begin = sequence * T
+            end = begin + T
+
+        lane = hl.arange(16)
+        chunk_begin = begin + local_chunk * CHUNK_SIZE
+        row0 = chunk_begin + lane
+        row1 = chunk_begin + 16 + lane
+        row2 = chunk_begin + 32 + lane
+        row3 = chunk_begin + 48 + lane
+        valid0 = row0 < end
+        valid1 = row1 < end
+        valid2 = row2 < end
+        valid3 = row3 < end
+        flat0 = row0 * H + tile_h.id
+        flat1 = row1 * H + tile_h.id
+        flat2 = row2 * H + tile_h.id
+        flat3 = row3 * H + tile_h.id
+        col0 = lane
+        col1 = 16 + lane
+        col2 = 32 + lane
+        col3 = 48 + lane
+
+        m00 = hl.load(
+            akk_rows,
+            [flat0[:, None], col0[None, :]],
+            extra_mask=valid0[:, None] & valid0[None, :],
+        ).float()
+        m10 = hl.load(
+            akk_rows,
+            [flat1[:, None], col0[None, :]],
+            extra_mask=valid1[:, None] & valid0[None, :],
+        ).float()
+        m11 = hl.load(
+            akk_rows,
+            [flat1[:, None], col1[None, :]],
+            extra_mask=valid1[:, None] & valid1[None, :],
+        ).float()
+        m20 = hl.load(
+            akk_rows,
+            [flat2[:, None], col0[None, :]],
+            extra_mask=valid2[:, None] & valid0[None, :],
+        ).float()
+        m21 = hl.load(
+            akk_rows,
+            [flat2[:, None], col1[None, :]],
+            extra_mask=valid2[:, None] & valid1[None, :],
+        ).float()
+        m22 = hl.load(
+            akk_rows,
+            [flat2[:, None], col2[None, :]],
+            extra_mask=valid2[:, None] & valid2[None, :],
+        ).float()
+        m30 = hl.load(
+            akk_rows,
+            [flat3[:, None], col0[None, :]],
+            extra_mask=valid3[:, None] & valid0[None, :],
+        ).float()
+        m31 = hl.load(
+            akk_rows,
+            [flat3[:, None], col1[None, :]],
+            extra_mask=valid3[:, None] & valid1[None, :],
+        ).float()
+        m32 = hl.load(
+            akk_rows,
+            [flat3[:, None], col2[None, :]],
+            extra_mask=valid3[:, None] & valid2[None, :],
+        ).float()
+        m33 = hl.load(
+            akk_rows,
+            [flat3[:, None], col3[None, :]],
+            extra_mask=valid3[:, None] & valid3[None, :],
+        ).float()
+
+        i00 = _invert_lower_16(m00)
+        i11 = _invert_lower_16(m11)
+        i22 = _invert_lower_16(m22)
+        i33 = _invert_lower_16(m33)
+        i10 = -hl.dot(
+            hl.dot(i11, m10, out_dtype=torch.float32),
+            i00,
+            out_dtype=torch.float32,
+        )
+        i21 = -hl.dot(
+            hl.dot(i22, m21, out_dtype=torch.float32),
+            i11,
+            out_dtype=torch.float32,
+        )
+        i32 = -hl.dot(
+            hl.dot(i33, m32, out_dtype=torch.float32),
+            i22,
+            out_dtype=torch.float32,
+        )
+        i20 = -hl.dot(
+            i22,
+            hl.dot(m20, i00, out_dtype=torch.float32)
+            + hl.dot(m21, i10, out_dtype=torch.float32),
+            out_dtype=torch.float32,
+        )
+        i31 = -hl.dot(
+            i33,
+            hl.dot(m31, i11, out_dtype=torch.float32)
+            + hl.dot(m32, i21, out_dtype=torch.float32),
+            out_dtype=torch.float32,
+        )
+        i30 = -hl.dot(
+            i33,
+            hl.dot(m30, i00, out_dtype=torch.float32)
+            + hl.dot(m31, i10, out_dtype=torch.float32)
+            + hl.dot(m32, i20, out_dtype=torch.float32),
+            out_dtype=torch.float32,
+        )
+
+        hl.store(
+            inverse_rows,
+            [flat0[:, None], col0[None, :]],
+            i00,
+            extra_mask=valid0[:, None] & valid0[None, :],
+        )
+        hl.store(
+            inverse_rows,
+            [flat1[:, None], col0[None, :]],
+            i10,
+            extra_mask=valid1[:, None] & valid0[None, :],
+        )
+        hl.store(
+            inverse_rows,
+            [flat1[:, None], col1[None, :]],
+            i11,
+            extra_mask=valid1[:, None] & valid1[None, :],
+        )
+        hl.store(
+            inverse_rows,
+            [flat2[:, None], col0[None, :]],
+            i20,
+            extra_mask=valid2[:, None] & valid0[None, :],
+        )
+        hl.store(
+            inverse_rows,
+            [flat2[:, None], col1[None, :]],
+            i21,
+            extra_mask=valid2[:, None] & valid1[None, :],
+        )
+        hl.store(
+            inverse_rows,
+            [flat2[:, None], col2[None, :]],
+            i22,
+            extra_mask=valid2[:, None] & valid2[None, :],
+        )
+        hl.store(
+            inverse_rows,
+            [flat3[:, None], col0[None, :]],
+            i30,
+            extra_mask=valid3[:, None] & valid0[None, :],
+        )
+        hl.store(
+            inverse_rows,
+            [flat3[:, None], col1[None, :]],
+            i31,
+            extra_mask=valid3[:, None] & valid1[None, :],
+        )
+        hl.store(
+            inverse_rows,
+            [flat3[:, None], col2[None, :]],
+            i32,
+            extra_mask=valid3[:, None] & valid2[None, :],
+        )
+        hl.store(
+            inverse_rows,
+            [flat3[:, None], col3[None, :]],
+            i33,
+            extra_mask=valid3[:, None] & valid3[None, :],
+        )
+
+    return inverse
+
+
+_RECOMPUTE_U_CONFIG = helion.Config(
+    block_sizes=[128],
+    loop_orders=[[0, 1, 2, 3]],
+    static_ranges=[True],
+    num_warps=2,
+    num_stages=2,
+    indexing="pointer",
+)
+
+
+@helion.kernel(static_shapes=False, config=_RECOMPUTE_U_CONFIG)
+def _recompute_u(
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> torch.Tensor:
+    B = v.size(0)
+    T = v.size(1)
+    H = hl.specialize(v.size(2))
+    V = hl.specialize(v.size(3))
+    chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    total_chunks = chunk_indices.size(0) if is_varlen else B * chunks_per_batch
+    u = torch.empty_like(v)
+    v_rows = v.view(B * T * H, V)
+    beta_rows = beta.view(B * T * H)
+    inverse_rows = inverse.view(B * T * H, CHUNK_SIZE)
+    u_rows = u.view(B * T * H, V)
+    block_v = hl.register_block_size(32, V)
+
+    for tile_chunk, tile_h, tile_row_block, tile_v in hl.tile(
+        [total_chunks, H, 4, V],
+        block_size=[1, 1, 1, block_v],
+    ):
+        if is_varlen:
+            sequence = chunk_indices[tile_chunk.id, 0].long()
+            local_chunk = chunk_indices[tile_chunk.id, 1].long()
+            begin = cu_seqlens[sequence].long()
+            end = cu_seqlens[sequence + 1].long()
+        else:
+            sequence = tile_chunk.id // chunks_per_batch
+            local_chunk = tile_chunk.id % chunks_per_batch
+            begin = sequence * T
+            end = begin + T
+
+        lane = hl.arange(16)
+        chunk_begin = begin + local_chunk * CHUNK_SIZE
+        row_token = chunk_begin + tile_row_block.id * 16 + lane
+        row_valid = row_token < end
+        row = row_token * H + tile_h.id
+        value = hl.zeros([16, tile_v], dtype=torch.float32)
+        for source_block in range(4):
+            if source_block <= tile_row_block.id:
+                source_token = chunk_begin + source_block * 16 + lane
+                source_valid = source_token < end
+                source = source_token * H + tile_h.id
+                inv = hl.load(
+                    inverse_rows,
+                    [row[:, None], (source_block * 16 + lane)[None, :]],
+                    extra_mask=row_valid[:, None] & source_valid[None, :],
+                )
+                source_v = hl.load(
+                    v_rows,
+                    [source[:, None], tile_v.index[None, :]],
+                    extra_mask=source_valid[:, None],
+                )
+                source_beta = hl.load(
+                    beta_rows,
+                    [source],
+                    extra_mask=source_valid,
+                )
+                value = hl.dot(
+                    inv,
+                    (source_v * source_beta[:, None]).to(v.dtype),
+                    acc=value,
+                    out_dtype=torch.float32,
+                )
+        hl.store(
+            u_rows,
+            [row[:, None], tile_v.index[None, :]],
+            value,
+            extra_mask=row_valid[:, None],
+        )
+    return u
+
+
+_RECOMPUTE_W_CONFIG = helion.Config(
+    block_sizes=[128],
+    loop_orders=[[1, 2, 0, 3]],
+    l2_groupings=[4],
+    static_ranges=[True],
+    num_warps=4,
+    num_stages=2,
+    indexing="pointer",
+)
+
+
+@helion.kernel(static_shapes=False, config=_RECOMPUTE_W_CONFIG)
+def _recompute_w_kg(
+    k: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    inverse: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B = k.size(0)
+    T = k.size(1)
+    H = hl.specialize(k.size(2))
+    K = hl.specialize(k.size(3))
+    chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    total_chunks = chunk_indices.size(0) if is_varlen else B * chunks_per_batch
+    w = torch.empty_like(k)
+    kg = torch.empty_like(k)
+    k_rows = k.view(B * T * H, K)
+    g_rows = g.view(B * T * H, K)
+    beta_rows = beta.view(B * T * H)
+    inverse_rows = inverse.view(B * T * H, CHUNK_SIZE)
+    w_rows = w.view(B * T * H, K)
+    kg_rows = kg.view(B * T * H, K)
+    block_k = hl.register_block_size(32, K)
+
+    for tile_chunk, tile_h, tile_row_block, tile_k in hl.tile(
+        [total_chunks, H, 4, K],
+        block_size=[1, 1, 1, block_k],
+    ):
+        if is_varlen:
+            sequence = chunk_indices[tile_chunk.id, 0].long()
+            local_chunk = chunk_indices[tile_chunk.id, 1].long()
+            begin = cu_seqlens[sequence].long()
+            end = cu_seqlens[sequence + 1].long()
+        else:
+            sequence = tile_chunk.id // chunks_per_batch
+            local_chunk = tile_chunk.id % chunks_per_batch
+            begin = sequence * T
+            end = begin + T
+
+        lane = hl.arange(16)
+        chunk_begin = begin + local_chunk * CHUNK_SIZE
+        row_token = chunk_begin + tile_row_block.id * 16 + lane
+        row_valid = row_token < end
+        row = row_token * H + tile_h.id
+        value = hl.zeros([16, tile_k], dtype=torch.float32)
+        for source_block in range(4):
+            if source_block <= tile_row_block.id:
+                source_token = chunk_begin + source_block * 16 + lane
+                source_valid = source_token < end
+                source = source_token * H + tile_h.id
+                inv = hl.load(
+                    inverse_rows,
+                    [row[:, None], (source_block * 16 + lane)[None, :]],
+                    extra_mask=row_valid[:, None] & source_valid[None, :],
+                )
+                source_k = hl.load(
+                    k_rows,
+                    [source[:, None], tile_k.index[None, :]],
+                    extra_mask=source_valid[:, None],
+                )
+                source_g = hl.load(
+                    g_rows,
+                    [source[:, None], tile_k.index[None, :]],
+                    extra_mask=source_valid[:, None],
+                ).float()
+                source_beta = hl.load(
+                    beta_rows,
+                    [source],
+                    extra_mask=source_valid,
+                ).float()
+                weighted_k = (
+                    source_k.float() * source_beta[:, None] * torch.exp2(source_g)
+                ).to(k.dtype)
+                value = hl.dot(
+                    inv,
+                    weighted_k,
+                    acc=value,
+                    out_dtype=torch.float32,
+                )
+
+        row_k = hl.load(
+            k_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=row_valid[:, None],
+        ).float()
+        row_g = hl.load(
+            g_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=row_valid[:, None],
+        ).float()
+        if is_varlen:
+            chunk_end = end.new_full([], CHUNK_SIZE) + chunk_begin
+            last_token = torch.minimum(chunk_end, end) - 1
+        else:
+            last_token = min(chunk_begin + CHUNK_SIZE, end) - 1
+        last = last_token * H + tile_h.id
+        last_g = g_rows[last, tile_k.index].float()
+        kg_value = row_k * torch.exp2(last_g[None, :] - row_g)
+        hl.store(
+            w_rows,
+            [row[:, None], tile_k.index[None, :]],
+            value,
+            extra_mask=row_valid[:, None],
+        )
+        hl.store(
+            kg_rows,
+            [row[:, None], tile_k.index[None, :]],
+            kg_value,
+            extra_mask=row_valid[:, None],
+        )
+    return w, kg
+
+
+_FUSED_SOLVE_RECOMPUTE_CONFIG = helion.Config(
+    block_sizes=[64, 32],
+    loop_orders=[[0, 1]],
+    num_warps=1,
+    num_stages=2,
+    indexing="pointer",
+)
+
+
+@helion.kernel(static_shapes=False, config=_FUSED_SOLVE_RECOMPUTE_CONFIG)
+def _intra_solve_recompute(
+    akk: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Solve the 64x64 system and emit W, U, and KG from registers."""
+    B = k.size(0)
+    T = k.size(1)
+    H = hl.specialize(k.size(2))
+    K = hl.specialize(k.size(3))
+    V = hl.specialize(v.size(3))
+    chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    total_chunks = chunk_indices.size(0) if is_varlen else B * chunks_per_batch
+    w = torch.empty_like(k)
+    u = torch.empty_like(v)
+    kg = torch.empty_like(k)
+    akk_rows = akk.view(B * T * H, CHUNK_SIZE)
+    k_rows = k.view(B * T * H, K)
+    v_rows = v.view(B * T * H, V)
+    g_rows = g.view(B * T * H, K)
+    beta_rows = beta.view(B * T * H)
+    w_rows = w.view(B * T * H, K)
+    u_rows = u.view(B * T * H, V)
+    kg_rows = kg.view(B * T * H, K)
+    block_v = hl.register_block_size(32, V)
+    block_k = hl.register_block_size(32, K)
+
+    for tile_chunk, tile_h in hl.tile(
+        [total_chunks, H],
+        block_size=[1, 1],
+    ):
+        if is_varlen:
+            sequence = chunk_indices[tile_chunk.id, 0].long()
+            local_chunk = chunk_indices[tile_chunk.id, 1].long()
+            begin = cu_seqlens[sequence].long()
+            end = cu_seqlens[sequence + 1].long()
+        else:
+            sequence = tile_chunk.id // chunks_per_batch
+            local_chunk = tile_chunk.id % chunks_per_batch
+            begin = sequence * T
+            end = begin + T
+
+        lane = hl.arange(16)
+        chunk_begin = begin + local_chunk * CHUNK_SIZE
+        row0 = chunk_begin + lane
+        row1 = chunk_begin + 16 + lane
+        row2 = chunk_begin + 32 + lane
+        row3 = chunk_begin + 48 + lane
+        valid0 = row0 < end
+        valid1 = row1 < end
+        valid2 = row2 < end
+        valid3 = row3 < end
+        flat0 = row0 * H + tile_h.id
+        flat1 = row1 * H + tile_h.id
+        flat2 = row2 * H + tile_h.id
+        flat3 = row3 * H + tile_h.id
+        col0 = lane
+        col1 = 16 + lane
+        col2 = 32 + lane
+        col3 = 48 + lane
+
+        m00 = hl.load(
+            akk_rows,
+            [flat0[:, None], col0[None, :]],
+            extra_mask=valid0[:, None] & valid0[None, :],
+        ).float()
+        m10 = hl.load(
+            akk_rows,
+            [flat1[:, None], col0[None, :]],
+            extra_mask=valid1[:, None] & valid0[None, :],
+        ).float()
+        m11 = hl.load(
+            akk_rows,
+            [flat1[:, None], col1[None, :]],
+            extra_mask=valid1[:, None] & valid1[None, :],
+        ).float()
+        m20 = hl.load(
+            akk_rows,
+            [flat2[:, None], col0[None, :]],
+            extra_mask=valid2[:, None] & valid0[None, :],
+        ).float()
+        m21 = hl.load(
+            akk_rows,
+            [flat2[:, None], col1[None, :]],
+            extra_mask=valid2[:, None] & valid1[None, :],
+        ).float()
+        m22 = hl.load(
+            akk_rows,
+            [flat2[:, None], col2[None, :]],
+            extra_mask=valid2[:, None] & valid2[None, :],
+        ).float()
+        m30 = hl.load(
+            akk_rows,
+            [flat3[:, None], col0[None, :]],
+            extra_mask=valid3[:, None] & valid0[None, :],
+        ).float()
+        m31 = hl.load(
+            akk_rows,
+            [flat3[:, None], col1[None, :]],
+            extra_mask=valid3[:, None] & valid1[None, :],
+        ).float()
+        m32 = hl.load(
+            akk_rows,
+            [flat3[:, None], col2[None, :]],
+            extra_mask=valid3[:, None] & valid2[None, :],
+        ).float()
+        m33 = hl.load(
+            akk_rows,
+            [flat3[:, None], col3[None, :]],
+            extra_mask=valid3[:, None] & valid3[None, :],
+        ).float()
+
+        i00 = _invert_lower_16(m00)
+        i11 = _invert_lower_16(m11)
+        i22 = _invert_lower_16(m22)
+        i33 = _invert_lower_16(m33)
+        i10 = -hl.dot(
+            hl.dot(i11, m10, out_dtype=torch.float32),
+            i00,
+            out_dtype=torch.float32,
+        )
+        i21 = -hl.dot(
+            hl.dot(i22, m21, out_dtype=torch.float32),
+            i11,
+            out_dtype=torch.float32,
+        )
+        i32 = -hl.dot(
+            hl.dot(i33, m32, out_dtype=torch.float32),
+            i22,
+            out_dtype=torch.float32,
+        )
+        i20 = -hl.dot(
+            i22,
+            hl.dot(m20, i00, out_dtype=torch.float32)
+            + hl.dot(m21, i10, out_dtype=torch.float32),
+            out_dtype=torch.float32,
+        )
+        i31 = -hl.dot(
+            i33,
+            hl.dot(m31, i11, out_dtype=torch.float32)
+            + hl.dot(m32, i21, out_dtype=torch.float32),
+            out_dtype=torch.float32,
+        )
+        i30 = -hl.dot(
+            i33,
+            hl.dot(m30, i00, out_dtype=torch.float32)
+            + hl.dot(m31, i10, out_dtype=torch.float32)
+            + hl.dot(m32, i20, out_dtype=torch.float32),
+            out_dtype=torch.float32,
+        )
+        i00 = i00.to(k.dtype)
+        i10 = i10.to(k.dtype)
+        i11 = i11.to(k.dtype)
+        i20 = i20.to(k.dtype)
+        i21 = i21.to(k.dtype)
+        i22 = i22.to(k.dtype)
+        i30 = i30.to(k.dtype)
+        i31 = i31.to(k.dtype)
+        i32 = i32.to(k.dtype)
+        i33 = i33.to(k.dtype)
+
+        beta0 = hl.load(beta_rows, [flat0], extra_mask=valid0).float()
+        beta1 = hl.load(beta_rows, [flat1], extra_mask=valid1).float()
+        beta2 = hl.load(beta_rows, [flat2], extra_mask=valid2).float()
+        beta3 = hl.load(beta_rows, [flat3], extra_mask=valid3).float()
+        for tile_v in hl.tile(V, block_size=block_v):
+            v0 = hl.load(
+                v_rows,
+                [flat0[:, None], tile_v.index[None, :]],
+                extra_mask=valid0[:, None],
+            )
+            v1 = hl.load(
+                v_rows,
+                [flat1[:, None], tile_v.index[None, :]],
+                extra_mask=valid1[:, None],
+            )
+            v2 = hl.load(
+                v_rows,
+                [flat2[:, None], tile_v.index[None, :]],
+                extra_mask=valid2[:, None],
+            )
+            v3 = hl.load(
+                v_rows,
+                [flat3[:, None], tile_v.index[None, :]],
+                extra_mask=valid3[:, None],
+            )
+            vb0 = (v0 * beta0[:, None]).to(v.dtype)
+            vb1 = (v1 * beta1[:, None]).to(v.dtype)
+            vb2 = (v2 * beta2[:, None]).to(v.dtype)
+            vb3 = (v3 * beta3[:, None]).to(v.dtype)
+            u0 = hl.dot(i00, vb0, out_dtype=torch.float32)
+            u1 = hl.dot(i10, vb0, out_dtype=torch.float32) + hl.dot(
+                i11, vb1, out_dtype=torch.float32
+            )
+            u2 = (
+                hl.dot(i20, vb0, out_dtype=torch.float32)
+                + hl.dot(i21, vb1, out_dtype=torch.float32)
+                + hl.dot(i22, vb2, out_dtype=torch.float32)
+            )
+            u3 = (
+                hl.dot(i30, vb0, out_dtype=torch.float32)
+                + hl.dot(i31, vb1, out_dtype=torch.float32)
+                + hl.dot(i32, vb2, out_dtype=torch.float32)
+                + hl.dot(i33, vb3, out_dtype=torch.float32)
+            )
+            hl.store(
+                u_rows,
+                [flat0[:, None], tile_v.index[None, :]],
+                u0,
+                extra_mask=valid0[:, None],
+            )
+            hl.store(
+                u_rows,
+                [flat1[:, None], tile_v.index[None, :]],
+                u1,
+                extra_mask=valid1[:, None],
+            )
+            hl.store(
+                u_rows,
+                [flat2[:, None], tile_v.index[None, :]],
+                u2,
+                extra_mask=valid2[:, None],
+            )
+            hl.store(
+                u_rows,
+                [flat3[:, None], tile_v.index[None, :]],
+                u3,
+                extra_mask=valid3[:, None],
+            )
+
+        if is_varlen:
+            chunk_end = end.new_full([], CHUNK_SIZE) + chunk_begin
+            last_token = torch.minimum(chunk_end, end) - 1
+        else:
+            last_token = min(chunk_begin + CHUNK_SIZE, end) - 1
+        last = last_token * H + tile_h.id
+        for tile_k in hl.tile(K, block_size=block_k):
+            k0 = hl.load(
+                k_rows,
+                [flat0[:, None], tile_k.index[None, :]],
+                extra_mask=valid0[:, None],
+            )
+            k1 = hl.load(
+                k_rows,
+                [flat1[:, None], tile_k.index[None, :]],
+                extra_mask=valid1[:, None],
+            )
+            k2 = hl.load(
+                k_rows,
+                [flat2[:, None], tile_k.index[None, :]],
+                extra_mask=valid2[:, None],
+            )
+            k3 = hl.load(
+                k_rows,
+                [flat3[:, None], tile_k.index[None, :]],
+                extra_mask=valid3[:, None],
+            )
+            g0 = hl.load(
+                g_rows,
+                [flat0[:, None], tile_k.index[None, :]],
+                extra_mask=valid0[:, None],
+            ).float()
+            g1 = hl.load(
+                g_rows,
+                [flat1[:, None], tile_k.index[None, :]],
+                extra_mask=valid1[:, None],
+            ).float()
+            g2 = hl.load(
+                g_rows,
+                [flat2[:, None], tile_k.index[None, :]],
+                extra_mask=valid2[:, None],
+            ).float()
+            g3 = hl.load(
+                g_rows,
+                [flat3[:, None], tile_k.index[None, :]],
+                extra_mask=valid3[:, None],
+            ).float()
+            wk0 = (k0.float() * beta0[:, None] * torch.exp2(g0)).to(k.dtype)
+            wk1 = (k1.float() * beta1[:, None] * torch.exp2(g1)).to(k.dtype)
+            wk2 = (k2.float() * beta2[:, None] * torch.exp2(g2)).to(k.dtype)
+            wk3 = (k3.float() * beta3[:, None] * torch.exp2(g3)).to(k.dtype)
+            w0 = hl.dot(i00, wk0, out_dtype=torch.float32)
+            w1 = hl.dot(i10, wk0, out_dtype=torch.float32) + hl.dot(
+                i11, wk1, out_dtype=torch.float32
+            )
+            w2 = (
+                hl.dot(i20, wk0, out_dtype=torch.float32)
+                + hl.dot(i21, wk1, out_dtype=torch.float32)
+                + hl.dot(i22, wk2, out_dtype=torch.float32)
+            )
+            w3 = (
+                hl.dot(i30, wk0, out_dtype=torch.float32)
+                + hl.dot(i31, wk1, out_dtype=torch.float32)
+                + hl.dot(i32, wk2, out_dtype=torch.float32)
+                + hl.dot(i33, wk3, out_dtype=torch.float32)
+            )
+            last_g = g_rows[last, tile_k.index].float()
+            kg0 = k0.float() * torch.exp2(last_g[None, :] - g0)
+            kg1 = k1.float() * torch.exp2(last_g[None, :] - g1)
+            kg2 = k2.float() * torch.exp2(last_g[None, :] - g2)
+            kg3 = k3.float() * torch.exp2(last_g[None, :] - g3)
+            hl.store(
+                w_rows,
+                [flat0[:, None], tile_k.index[None, :]],
+                w0,
+                extra_mask=valid0[:, None],
+            )
+            hl.store(
+                w_rows,
+                [flat1[:, None], tile_k.index[None, :]],
+                w1,
+                extra_mask=valid1[:, None],
+            )
+            hl.store(
+                w_rows,
+                [flat2[:, None], tile_k.index[None, :]],
+                w2,
+                extra_mask=valid2[:, None],
+            )
+            hl.store(
+                w_rows,
+                [flat3[:, None], tile_k.index[None, :]],
+                w3,
+                extra_mask=valid3[:, None],
+            )
+            hl.store(
+                kg_rows,
+                [flat0[:, None], tile_k.index[None, :]],
+                kg0,
+                extra_mask=valid0[:, None],
+            )
+            hl.store(
+                kg_rows,
+                [flat1[:, None], tile_k.index[None, :]],
+                kg1,
+                extra_mask=valid1[:, None],
+            )
+            hl.store(
+                kg_rows,
+                [flat2[:, None], tile_k.index[None, :]],
+                kg2,
+                extra_mask=valid2[:, None],
+            )
+            hl.store(
+                kg_rows,
+                [flat3[:, None], tile_k.index[None, :]],
+                kg3,
+                extra_mask=valid3[:, None],
+            )
+
+    return w, u, kg
+
+
+def chunk_kda_fwd_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor | None,
+    chunk_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Helion equivalent of SGLang's intra-chunk KDA preparation."""
+    is_varlen = cu_seqlens is not None
+    if is_varlen:
+        if chunk_indices is None:
+            chunk_indices = prepare_chunk_indices(cu_seqlens)
+        metadata = cu_seqlens
+    else:
+        metadata = torch.empty(0, device=q.device, dtype=torch.int32)
+        chunk_indices = torch.empty(0, 2, device=q.device, dtype=torch.long)
+
+    aqk, akk = _intra_matrices_wide(
+        q,
+        k,
+        g,
+        beta,
+        metadata,
+        chunk_indices,
+        scale,
+        is_varlen,
+    )
+    w, u, kg = _intra_solve_recompute(
+        akk,
+        k,
+        v,
+        g,
+        beta,
+        metadata,
+        chunk_indices,
+        is_varlen,
+    )
+    return w, u, kg, aqk
+
+
+_STATE_CONFIG = helion.Config(
+    block_sizes=[16],
+    num_warps=4,
+    num_stages=3,
+    indexing="pointer",
+)
+
+
+@helion.kernel(static_shapes=False, config=_STATE_CONFIG)
+def _chunk_state(
+    kg: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor,
+    initial_state: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Propagate KDA state between chunks and update the state pool in place."""
+    B = kg.size(0)
+    T = kg.size(1)
+    H = hl.specialize(kg.size(2))
+    K = hl.specialize(kg.size(3))
+    V = hl.specialize(u.size(3))
+    N = cu_seqlens.size(0) - 1 if is_varlen else B
+    chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    total_chunks = chunk_indices.size(0) if is_varlen else chunks_per_batch
+    hl.specialize(
+        (
+            kg.stride(1),
+            kg.stride(2),
+            kg.stride(3),
+            w.stride(1),
+            w.stride(2),
+            w.stride(3),
+            u.stride(1),
+            u.stride(2),
+            u.stride(3),
+            g.stride(1),
+            g.stride(2),
+            g.stride(3),
+            initial_state.stride(0),
+            initial_state.stride(1),
+            initial_state.stride(2),
+            initial_state.stride(3),
+            initial_state_indices.stride(0),
+        )
+    )
+
+    h = torch.empty(
+        [B, total_chunks, H, V, K],
+        dtype=kg.dtype,
+        device=kg.device,
+    )
+    v_new = torch.empty_like(u)
+    kg_rows = kg.view(B * T * H, K)
+    w_rows = w.view(B * T * H, K)
+    u_rows = u.view(B * T * H, V)
+    g_rows = g.view(B * T * H, K)
+    v_new_rows = v_new.view(B * T * H, V)
+    h_rows = h.view(B * total_chunks * H, V, K)
+    block_v = hl.register_block_size(1, V)
+
+    for tile_sequence, tile_h, tile_v in hl.tile(
+        [N, H, V],
+        block_size=[1, 1, block_v],
+    ):
+        if is_varlen:
+            begin = cu_seqlens[tile_sequence.id].long()
+            end = cu_seqlens[tile_sequence.id + 1].long()
+            output_offset = chunk_offsets[tile_sequence.id].long()
+        else:
+            begin = tile_sequence.id * T
+            end = begin + T
+            output_offset = tile_sequence.id * chunks_per_batch
+        sequence_length = end - begin
+        state_index = initial_state_indices[tile_sequence.id].long()
+        state = initial_state[
+            state_index,
+            tile_h.id,
+            tile_v.index,
+            :,
+        ].float()
+
+        for token_tile in hl.tile(sequence_length, block_size=64):
+            global_chunk = output_offset + token_tile.id
+            h_rows[
+                global_chunk * H + tile_h.id,
+                tile_v,
+                :,
+            ] = state.to(h.dtype)
+            token = begin + token_tile.index
+            valid = token < end
+            row = token * H + tile_h.id
+            w_value = hl.load(
+                w_rows,
+                [row[:, None], hl.arange(K)[None, :]],
+                extra_mask=valid[:, None],
+            )
+            residual = -hl.dot(
+                w_value,
+                state.T.to(w.dtype),
+                out_dtype=torch.float32,
+            )
+            residual = residual + u_rows[row, tile_v].float()
+            v_new_rows[row, tile_v] = residual.to(v_new.dtype)
+            if is_varlen:
+                chunk_end = (
+                    end.new_full([], CHUNK_SIZE) + begin + token_tile.id * CHUNK_SIZE
+                )
+                last_token = torch.minimum(chunk_end, end) - 1
+            else:
+                last_token = (
+                    min(
+                        begin + (token_tile.id + 1) * CHUNK_SIZE,
+                        end,
+                    )
+                    - 1
+                )
+            last_row = last_token * H + tile_h.id
+            last_g = g_rows[last_row, :].float()
+            state = state * torch.exp2(last_g)[None, :]
+            kg_value = hl.load(
+                kg_rows,
+                [row[:, None], hl.arange(K)[None, :]],
+                extra_mask=valid[:, None],
+            )
+            state = state + hl.dot(
+                residual.T.to(kg.dtype),
+                kg_value,
+                out_dtype=torch.float32,
+            )
+
+        initial_state[
+            state_index,
+            tile_h.id,
+            tile_v.index,
+            :,
+        ] = state.to(initial_state.dtype)
+
+    return h, v_new
+
+
+_OUTPUT_CONFIG = helion.Config(
+    block_sizes=[64],
+    loop_orders=[[2, 1, 0]],
+    num_warps=8,
+    num_stages=2,
+    indexing="pointer",
+)
+
+
+@helion.kernel(static_shapes=False, config=_OUTPUT_CONFIG)
+def _chunk_output(
+    q: torch.Tensor,
+    v_new: torch.Tensor,
+    g: torch.Tensor,
+    aqk: torch.Tensor,
+    h: torch.Tensor,
+    out: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    scale: float,
+    is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> torch.Tensor:
+    """Compose inter-chunk state output and causal intra-chunk output."""
+    B = q.size(0)
+    T = q.size(1)
+    H = hl.specialize(q.size(2))
+    K = hl.specialize(q.size(3))
+    V = hl.specialize(v_new.size(3))
+    chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    total_chunks = chunk_indices.size(0) if is_varlen else B * chunks_per_batch
+    h_chunks = h.size(1)
+    hl.specialize(
+        (
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            v_new.stride(1),
+            v_new.stride(2),
+            v_new.stride(3),
+            g.stride(1),
+            g.stride(2),
+            g.stride(3),
+            aqk.stride(1),
+            aqk.stride(2),
+            aqk.stride(3),
+            h.stride(1),
+            h.stride(2),
+            h.stride(3),
+            h.stride(4),
+            out.stride(1),
+            out.stride(2),
+            out.stride(3),
+        )
+    )
+
+    q_rows = q.view(B * T * H, K)
+    g_rows = g.view(B * T * H, K)
+    v_rows = v_new.view(B * T * H, V)
+    aqk_rows = aqk.view(B * T * H, CHUNK_SIZE)
+    h_rows = h.view(B * h_chunks * H, V, K)
+    out_rows = out.view(B * T * H, V)
+    block_v = hl.register_block_size(32, V)
+
+    for tile_chunk, tile_h, tile_v in hl.tile(
+        [total_chunks, H, V],
+        block_size=[1, 1, block_v],
+    ):
+        if is_varlen:
+            sequence = chunk_indices[tile_chunk.id, 0].long()
+            local_chunk = chunk_indices[tile_chunk.id, 1].long()
+            begin = cu_seqlens[sequence].long()
+            end = cu_seqlens[sequence + 1].long()
+            h_chunk = tile_chunk.id
+        else:
+            sequence = tile_chunk.id // chunks_per_batch
+            local_chunk = tile_chunk.id % chunks_per_batch
+            begin = sequence * T
+            end = begin + T
+            h_chunk = tile_chunk.id
+
+        lane = hl.arange(64)
+        token = begin + local_chunk * CHUNK_SIZE + lane
+        valid = token < end
+        row = token * H + tile_h.id
+        q_value = hl.load(
+            q_rows,
+            [row[:, None], hl.arange(K)[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        g_value = hl.load(
+            g_rows,
+            [row[:, None], hl.arange(K)[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        h_value = h_rows[
+            h_chunk * H + tile_h.id,
+            tile_v,
+            :,
+        ]
+        qg = (q_value * scale * torch.exp2(g_value)).to(q.dtype)
+        output = hl.dot(
+            qg,
+            h_value.T,
+            out_dtype=torch.float32,
+        )
+        a_value = hl.load(
+            aqk_rows,
+            [row[:, None], lane[None, :]],
+            extra_mask=valid[:, None],
+        )
+        v_value = hl.load(
+            v_rows,
+            [row, tile_v],
+            extra_mask=valid[:, None],
+        )
+        output = hl.dot(
+            a_value.to(v_new.dtype),
+            v_value,
+            acc=output,
+            out_dtype=torch.float32,
+        )
+        hl.store(
+            out_rows,
+            [row, tile_v],
+            output,
+            extra_mask=valid[:, None],
+        )
+
+    return out
+
+
+def chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    initial_state_indices: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    output_intermediate_states: bool = False,
+    **kwargs: object,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Match the public forward contract of SGLang's Triton ``chunk_kda``."""
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    if initial_state is None or initial_state_indices is None:
+        raise ValueError("KDA prefill requires an indexed initial-state pool")
+
+    q = q.contiguous()
+    k = k.contiguous()
+    if use_qk_l2norm_in_kernel:
+        q, k = _l2norm_qk(q, k)
+    v = v.contiguous()
+    g = g.contiguous()
+    beta = beta.contiguous()
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens) if cu_seqlens is not None else None
+    )
+    g = gate_chunk_cumsum(
+        g,
+        a_log=A_log,
+        dt_bias=dt_bias,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        lower_bound=lower_bound,
+    )
+    w, u, kg, aqk = chunk_kda_fwd_intra(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale,
+        cu_seqlens,
+        chunk_indices,
+    )
+
+    is_varlen = cu_seqlens is not None
+    if is_varlen:
+        chunk_offsets = prepare_chunk_offsets(cu_seqlens)
+        metadata = cu_seqlens
+    else:
+        metadata = torch.empty(0, device=q.device, dtype=torch.int32)
+        chunk_offsets = torch.empty(0, device=q.device, dtype=torch.long)
+    h, v_new = _chunk_state(
+        kg,
+        w,
+        u,
+        g,
+        initial_state,
+        initial_state_indices,
+        metadata,
+        chunk_indices
+        if chunk_indices is not None
+        else torch.empty(0, 2, device=q.device, dtype=torch.long),
+        chunk_offsets,
+        is_varlen,
+    )
+    if chunk_indices is None:
+        chunk_indices = torch.empty(0, 2, device=q.device, dtype=torch.long)
+    output = _chunk_output(
+        q,
+        v_new,
+        g,
+        aqk,
+        h,
+        v,
+        metadata,
+        chunk_indices,
+        scale,
+        is_varlen,
+    )
+    if output_intermediate_states:
+        return output, h
+    return output
+
+
+def main() -> None:
+    """Compile the front-end kernels for the production Kimi-Linear shape."""
+    device = torch.device("cuda")
+    q = torch.randn(1, 512, 16, 128, device=device, dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    g = torch.randn_like(q)
+    a_log = torch.randn(16, device=device)
+    dt_bias = torch.randn(16 * 128, device=device)
+    _l2norm_qk(q, k)
+    gate_chunk_cumsum(
+        g,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        cu_seqlens=None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/linear/kda_prefill.py
+++ b/examples/linear/kda_prefill.py
@@ -244,6 +244,287 @@ def _gate_cumsum_varlen(
     return out
 
 
+@helion.kernel(static_shapes=False, config=_GATE_FIXED_CONFIG)
+def _gate_cumsum_operands_fixed(
+    g: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    gate_scale: float,
+    q_scale: float,
+    lower_bound: float,
+    activate: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    has_bias: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    use_lower_bound: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Compute cumulative gates and rounded Q/K operands in one pass."""
+    B = g.size(0)
+    T = g.size(1)
+    H = hl.specialize(g.size(2))
+    K = hl.specialize(g.size(3))
+    chunks = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
+    hl.specialize(
+        (
+            g.stride(1),
+            g.stride(2),
+            g.stride(3),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            beta.stride(1),
+            beta.stride(2),
+            a_log.stride(0),
+            dt_bias.stride(0),
+        )
+    )
+
+    out = torch.empty_like(g, dtype=torch.float32)
+    qg = torch.empty_like(q)
+    wk = torch.empty_like(k)
+    kg = torch.empty_like(k)
+    chunk_decay = torch.empty(
+        [B * chunks, H, K],
+        dtype=torch.float32,
+        device=g.device,
+    )
+    g_rows = g.view(B * T * H, K)
+    q_rows = q.view(B * T * H, K)
+    k_rows = k.view(B * T * H, K)
+    beta_rows = beta.view(B * T * H)
+    out_rows = out.view(B * T * H, K)
+    qg_rows = qg.view(B * T * H, K)
+    wk_rows = wk.view(B * T * H, K)
+    kg_rows = kg.view(B * T * H, K)
+    block_k = hl.register_block_size(16, K)
+
+    for tile_b, tile_chunk, tile_h, tile_k in hl.tile(
+        [B, chunks, H, K],
+        block_size=[1, 1, 1, block_k],
+    ):
+        time = hl.arange(64)
+        token = tile_chunk.id * CHUNK_SIZE + time
+        valid = token < T
+        row = (tile_b.id * T + token) * H + tile_h.id
+        value = hl.load(
+            g_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        if activate:
+            if has_bias:
+                value = value + dt_bias[tile_h.id * K + tile_k.index].float()[
+                    None, :
+                ]
+            value = _activate_gate(
+                value,
+                a_log[tile_h.id],
+                lower_bound,
+                use_lower_bound,
+            )
+        value = torch.where(valid[:, None], value, 0.0)
+        value = torch.cumsum(value, dim=0) * gate_scale
+        q_value = hl.load(
+            q_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        k_value = hl.load(
+            k_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        beta_value = hl.load(beta_rows, [row], extra_mask=valid).float()
+        last_gate = torch.where(time[:, None] == 63, value, 0.0).sum(0)
+        gate_value = torch.exp2(value)
+        global_chunk = tile_b.id * chunks + tile_chunk.id
+        hl.store(
+            out_rows,
+            [row[:, None], tile_k.index[None, :]],
+            value,
+            extra_mask=valid[:, None],
+        )
+        hl.store(
+            qg_rows,
+            [row[:, None], tile_k.index[None, :]],
+            (q_value * q_scale * gate_value).to(q.dtype),
+            extra_mask=valid[:, None],
+        )
+        hl.store(
+            wk_rows,
+            [row[:, None], tile_k.index[None, :]],
+            (k_value * beta_value[:, None] * gate_value).to(k.dtype),
+            extra_mask=valid[:, None],
+        )
+        hl.store(
+            kg_rows,
+            [row[:, None], tile_k.index[None, :]],
+            (k_value * torch.exp2(last_gate[None, :] - value)).to(k.dtype),
+            extra_mask=valid[:, None],
+        )
+        hl.store(
+            chunk_decay,
+            [global_chunk, tile_h.id, tile_k.index],
+            torch.exp2(last_gate),
+        )
+
+    return out, qg, wk, kg, chunk_decay
+
+
+@helion.kernel(static_shapes=False, config=_GATE_VARLEN_CONFIG)
+def _gate_cumsum_operands_varlen(
+    g: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    chunk_indices: torch.Tensor,
+    gate_scale: float,
+    q_scale: float,
+    lower_bound: float,
+    activate: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    has_bias: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    use_lower_bound: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Packed cumulative gates with rounded Q/K operands."""
+    T = g.size(1)
+    H = hl.specialize(g.size(2))
+    K = hl.specialize(g.size(3))
+    chunks = chunk_indices.size(0)
+    hl.specialize(
+        (
+            g.stride(1),
+            g.stride(2),
+            g.stride(3),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            beta.stride(1),
+            beta.stride(2),
+            a_log.stride(0),
+            dt_bias.stride(0),
+            cu_seqlens.stride(0),
+            chunk_indices.stride(0),
+            chunk_indices.stride(1),
+        )
+    )
+
+    out = torch.empty_like(g, dtype=torch.float32)
+    qg = torch.empty_like(q)
+    wk = torch.empty_like(k)
+    kg = torch.empty_like(k)
+    chunk_decay = torch.empty(
+        [chunks, H, K],
+        dtype=torch.float32,
+        device=g.device,
+    )
+    g_rows = g.view(T * H, K)
+    q_rows = q.view(T * H, K)
+    k_rows = k.view(T * H, K)
+    beta_rows = beta.view(T * H)
+    out_rows = out.view(T * H, K)
+    qg_rows = qg.view(T * H, K)
+    wk_rows = wk.view(T * H, K)
+    kg_rows = kg.view(T * H, K)
+    block_k = hl.register_block_size(16, K)
+
+    for tile_chunk, tile_h, tile_k in hl.tile(
+        [chunks, H, K],
+        block_size=[1, 1, block_k],
+    ):
+        time = hl.arange(64)
+        sequence = chunk_indices[tile_chunk.id, 0].long()
+        local_chunk = chunk_indices[tile_chunk.id, 1].long()
+        begin = cu_seqlens[sequence].long()
+        end = cu_seqlens[sequence + 1].long()
+        token = begin + local_chunk * CHUNK_SIZE + time
+        valid = token < end
+        row = token * H + tile_h.id
+        value = hl.load(
+            g_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        if activate:
+            if has_bias:
+                value = value + dt_bias[tile_h.id * K + tile_k.index].float()[
+                    None, :
+                ]
+            value = _activate_gate(
+                value,
+                a_log[tile_h.id],
+                lower_bound,
+                use_lower_bound,
+            )
+        value = torch.where(valid[:, None], value, 0.0)
+        value = torch.cumsum(value, dim=0) * gate_scale
+        q_value = hl.load(
+            q_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        k_value = hl.load(
+            k_rows,
+            [row[:, None], tile_k.index[None, :]],
+            extra_mask=valid[:, None],
+        ).float()
+        beta_value = hl.load(beta_rows, [row], extra_mask=valid).float()
+        last_gate = torch.where(time[:, None] == 63, value, 0.0).sum(0)
+        gate_value = torch.exp2(value)
+        hl.store(
+            out_rows,
+            [row[:, None], tile_k.index[None, :]],
+            value,
+            extra_mask=valid[:, None],
+        )
+        hl.store(
+            qg_rows,
+            [row[:, None], tile_k.index[None, :]],
+            (q_value * q_scale * gate_value).to(q.dtype),
+            extra_mask=valid[:, None],
+        )
+        hl.store(
+            wk_rows,
+            [row[:, None], tile_k.index[None, :]],
+            (k_value * beta_value[:, None] * gate_value).to(k.dtype),
+            extra_mask=valid[:, None],
+        )
+        hl.store(
+            kg_rows,
+            [row[:, None], tile_k.index[None, :]],
+            (k_value * torch.exp2(last_gate[None, :] - value)).to(k.dtype),
+            extra_mask=valid[:, None],
+        )
+        hl.store(
+            chunk_decay,
+            [tile_chunk.id, tile_h.id, tile_k.index],
+            torch.exp2(last_gate),
+        )
+
+    return out, qg, wk, kg, chunk_decay
+
+
 def prepare_chunk_indices(
     cu_seqlens: torch.Tensor,
     chunk_size: int = CHUNK_SIZE,
@@ -359,9 +640,92 @@ def gate_chunk_cumsum(
     )
 
 
+def gate_chunk_cumsum_operands(
+    g: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    q_scale: float,
+    a_log: torch.Tensor | None,
+    dt_bias: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_indices: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    gate_scale: float = RCP_LN2,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Gate preprocessing plus rounded operands reused by later stages."""
+    flat_a_log = (
+        a_log.reshape(-1)
+        if a_log is not None
+        else torch.empty(1, device=g.device, dtype=torch.float32)
+    )
+    flat_bias = (
+        dt_bias.reshape(-1)
+        if dt_bias is not None
+        else torch.empty(1, device=g.device, dtype=torch.float32)
+    )
+    activate = a_log is not None
+    has_bias = dt_bias is not None
+    use_lower_bound = lower_bound is not None
+    lower_bound_value = 0.0 if lower_bound is None else lower_bound
+
+    if cu_seqlens is None:
+        return _gate_cumsum_operands_fixed(
+            g,
+            q,
+            k,
+            beta,
+            flat_a_log,
+            flat_bias,
+            gate_scale,
+            q_scale,
+            lower_bound_value,
+            activate,
+            has_bias,
+            use_lower_bound,
+        )
+
+    if g.size(0) != 1:
+        raise ValueError("varlen KDA requires batch size 1")
+    if chunk_indices is None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens)
+    return _gate_cumsum_operands_varlen(
+        g,
+        q,
+        k,
+        beta,
+        flat_a_log,
+        flat_bias,
+        cu_seqlens,
+        chunk_indices,
+        gate_scale,
+        q_scale,
+        lower_bound_value,
+        activate,
+        has_bias,
+        use_lower_bound,
+    )
+
+
 _INTRA_MATRIX_CONFIG = helion.Config(
     block_sizes=[32],
     loop_orders=[[2, 1, 0]],
+    num_warps=1,
+    num_stages=2,
+    indexing="pointer",
+)
+
+
+_INTRA_MATRIX_FORWARD_CONFIG = helion.Config(
+    block_sizes=[32],
+    loop_orders=[[1, 2, 0]],
     num_warps=1,
     num_stages=2,
     indexing="pointer",
@@ -378,6 +742,8 @@ def _intra_matrices_wide(
     chunk_indices: torch.Tensor,
     scale: float,
     is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
+    preinvert_diagonal: hl.constexpr = False,  # pyrefly: ignore[bad-function-definition]
+    newton_schulz: hl.constexpr = False,  # pyrefly: ignore[bad-function-definition]
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Compute a full 16x64 causal matrix row per CTA."""
     B = q.size(0)
@@ -461,42 +827,47 @@ def _intra_matrices_wide(
                 [row[:, None], tile_k.index[None, :]],
                 extra_mask=row_valid[:, None],
             ).float()
-            k_col = hl.load(
-                k_rows,
-                [col[:, None], tile_k.index[None, :]],
-                extra_mask=col_valid[:, None] & block_causal[:, None],
-            ).float()
-            g_col = hl.load(
-                g_rows,
-                [col[:, None], tile_k.index[None, :]],
-                extra_mask=col_valid[:, None] & block_causal[:, None],
-            ).float()
             g_anchor = hl.load(
                 g_rows,
                 [anchor, tile_k.index],
                 extra_mask=anchor_token < end,
             ).float()
-            off_col = col_lane < tile_row_block.id * 16
-            off_col_delta = torch.where(
-                off_col[:, None],
-                g_anchor[None, :] - g_col,
-                0.0,
-            )
-            q_off = (q_row * torch.exp2(g_row - g_anchor[None, :])).to(torch.bfloat16)
-            k_off = (k_row * torch.exp2(g_row - g_anchor[None, :])).to(torch.bfloat16)
-            k_col_off = (k_col * torch.exp2(off_col_delta)).to(torch.bfloat16)
-            aqk_off = hl.dot(
-                q_off,
-                k_col_off.T,
-                acc=aqk_off,
-                out_dtype=torch.float32,
-            )
-            akk_off = hl.dot(
-                k_off,
-                k_col_off.T,
-                acc=akk_off,
-                out_dtype=torch.float32,
-            )
+            if tile_row_block.id > 0:
+                k_col = hl.load(
+                    k_rows,
+                    [col[:, None], tile_k.index[None, :]],
+                    extra_mask=col_valid[:, None] & block_causal[:, None],
+                ).float()
+                g_col = hl.load(
+                    g_rows,
+                    [col[:, None], tile_k.index[None, :]],
+                    extra_mask=col_valid[:, None] & block_causal[:, None],
+                ).float()
+                off_col = col_lane < tile_row_block.id * 16
+                off_col_delta = torch.where(
+                    off_col[:, None],
+                    g_anchor[None, :] - g_col,
+                    0.0,
+                )
+                q_off = (
+                    q_row * torch.exp2(g_row - g_anchor[None, :])
+                ).to(torch.bfloat16)
+                k_off = (
+                    k_row * torch.exp2(g_row - g_anchor[None, :])
+                ).to(torch.bfloat16)
+                k_col_off = (k_col * torch.exp2(off_col_delta)).to(torch.bfloat16)
+                aqk_off = hl.dot(
+                    q_off,
+                    k_col_off.T,
+                    acc=aqk_off,
+                    out_dtype=torch.float32,
+                )
+                akk_off = hl.dot(
+                    k_off,
+                    k_col_off.T,
+                    acc=akk_off,
+                    out_dtype=torch.float32,
+                )
 
             diag_delta = torch.clamp(
                 g_row - g_anchor[None, :],
@@ -545,6 +916,16 @@ def _intra_matrices_wide(
         diag_col = tile_row_block.id * 16 + row_lane
         diag_causal = row_lane[:, None] >= row_lane[None, :]
         diag_strict = row_lane[:, None] > row_lane[None, :]
+        diagonal_matrix = torch.where(
+            diag_strict & row_valid[None, :],
+            akk_diag * row_beta[:, None],
+            0.0,
+        )
+        if preinvert_diagonal:
+            diagonal_matrix = _invert_lower_16(
+                diagonal_matrix,
+                newton_schulz,
+            )
         hl.store(
             aqk_rows,
             [row[:, None], diag_col[None, :]],
@@ -554,15 +935,17 @@ def _intra_matrices_wide(
         hl.store(
             akk_rows,
             [row[:, None], diag_col[None, :]],
-            torch.where(
-                diag_strict & row_valid[None, :],
-                akk_diag * row_beta[:, None],
-                0.0,
-            ),
+            diagonal_matrix,
             extra_mask=row_valid[:, None],
         )
 
     return aqk, akk
+
+
+_intra_matrices_wide_forward = helion.kernel(
+    static_shapes=False,
+    config=_INTRA_MATRIX_FORWARD_CONFIG,
+)(_intra_matrices_wide.fn)
 
 
 @helion.kernel(static_shapes=False, config=_INTRA_MATRIX_CONFIG)
@@ -735,7 +1118,7 @@ def _intra_matrices(
     return aqk, akk
 
 
-def _invert_lower_16(matrix: torch.Tensor) -> torch.Tensor:
+def _invert_lower_16_forward_substitution(matrix: torch.Tensor) -> torch.Tensor:
     lane = hl.arange(16)
     strictly_lower = lane[:, None] > lane[None, :]
     inverse = -torch.where(strictly_lower, matrix, 0.0)
@@ -745,6 +1128,34 @@ def _invert_lower_16(matrix: torch.Tensor) -> torch.Tensor:
         value = value + (value[:, None] * inverse).sum(0)
         inverse = torch.where((lane == row)[:, None], value[None, :], inverse)
     return inverse + (lane[:, None] == lane[None, :]).float()
+
+
+def _invert_lower_16_newton_schulz(matrix: torch.Tensor) -> torch.Tensor:
+    lane = hl.arange(16)
+    strictly_lower = lane[:, None] > lane[None, :]
+    diagonal = lane[:, None] == lane[None, :]
+    lower = torch.where(strictly_lower, matrix, 0.0)
+    system = (lower + diagonal.float()).to(torch.bfloat16)
+    inverse = diagonal.float() - lower
+    for _ in range(3):
+        inverse_bf16 = inverse.to(torch.bfloat16)
+        correction = hl.dot(system, inverse_bf16, out_dtype=torch.float32)
+        inverse = 2.0 * inverse_bf16.float() - hl.dot(
+            inverse_bf16,
+            correction.to(torch.bfloat16),
+            out_dtype=torch.float32,
+        )
+        inverse = torch.where(strictly_lower | diagonal, inverse, 0.0)
+    return inverse
+
+
+def _invert_lower_16(
+    matrix: torch.Tensor,
+    newton_schulz: hl.constexpr,
+) -> torch.Tensor:
+    if newton_schulz:
+        return _invert_lower_16_newton_schulz(matrix)
+    return _invert_lower_16_forward_substitution(matrix)
 
 
 _INTRA_SOLVE_CONFIG = helion.Config(
@@ -864,10 +1275,10 @@ def _intra_solve(
             extra_mask=valid3[:, None] & valid3[None, :],
         ).float()
 
-        i00 = _invert_lower_16(m00)
-        i11 = _invert_lower_16(m11)
-        i22 = _invert_lower_16(m22)
-        i33 = _invert_lower_16(m33)
+        i00 = _invert_lower_16_forward_substitution(m00)
+        i11 = _invert_lower_16_forward_substitution(m11)
+        i22 = _invert_lower_16_forward_substitution(m22)
+        i33 = _invert_lower_16_forward_substitution(m33)
         i10 = -hl.dot(
             hl.dot(i11, m10, out_dtype=torch.float32),
             i00,
@@ -1181,45 +1592,56 @@ def _recompute_w_kg(
     return w, kg
 
 
-_FUSED_SOLVE_RECOMPUTE_CONFIG = helion.Config(
-    block_sizes=[64, 32],
+_FORWARD_SOLVE_RECOMPUTE_CONFIG = helion.Config(
+    block_sizes=[64, 64],
     loop_orders=[[0, 1]],
     num_warps=1,
-    num_stages=2,
+    num_stages=3,
     indexing="pointer",
 )
 
 
-@helion.kernel(static_shapes=False, config=_FUSED_SOLVE_RECOMPUTE_CONFIG)
+_NEWTON_SOLVE_RECOMPUTE_CONFIG = helion.Config(
+    block_sizes=[64, 64],
+    loop_orders=[[0, 1]],
+    num_warps=2,
+    num_stages=3,
+    indexing="pointer",
+)
+
+
+@helion.kernel(static_shapes=False, config=_FORWARD_SOLVE_RECOMPUTE_CONFIG)
 def _intra_solve_recompute(
     akk: torch.Tensor,
-    k: torch.Tensor,
+    wk: torch.Tensor,
     v: torch.Tensor,
-    g: torch.Tensor,
     beta: torch.Tensor,
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
     is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Solve the 64x64 system and emit W, U, and KG from registers."""
-    B = k.size(0)
-    T = k.size(1)
-    H = hl.specialize(k.size(2))
-    K = hl.specialize(k.size(3))
+    newton_schulz: hl.constexpr = False,  # pyrefly: ignore[bad-function-definition]
+    diagonal_preinverted: hl.constexpr = False,  # pyrefly: ignore[bad-function-definition]
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Solve the 64x64 system and emit W and U from pre-scaled operands.
+
+    Forward substitution preserves the Triton baseline's floating-point order.
+    Newton-Schulz is an explicitly selected, algebraically equivalent fast path.
+    """
+    B = wk.size(0)
+    T = wk.size(1)
+    H = hl.specialize(wk.size(2))
+    K = hl.specialize(wk.size(3))
     V = hl.specialize(v.size(3))
     chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
     total_chunks = chunk_indices.size(0) if is_varlen else B * chunks_per_batch
-    w = torch.empty_like(k)
-    u = torch.empty_like(v)
-    kg = torch.empty_like(k)
+    w = wk
+    u = v
     akk_rows = akk.view(B * T * H, CHUNK_SIZE)
-    k_rows = k.view(B * T * H, K)
+    wk_rows = wk.view(B * T * H, K)
     v_rows = v.view(B * T * H, V)
-    g_rows = g.view(B * T * H, K)
     beta_rows = beta.view(B * T * H)
     w_rows = w.view(B * T * H, K)
     u_rows = u.view(B * T * H, V)
-    kg_rows = kg.view(B * T * H, K)
     block_v = hl.register_block_size(32, V)
     block_k = hl.register_block_size(32, K)
 
@@ -1308,10 +1730,16 @@ def _intra_solve_recompute(
             extra_mask=valid3[:, None] & valid3[None, :],
         ).float()
 
-        i00 = _invert_lower_16(m00)
-        i11 = _invert_lower_16(m11)
-        i22 = _invert_lower_16(m22)
-        i33 = _invert_lower_16(m33)
+        if diagonal_preinverted:
+            i00 = m00
+            i11 = m11
+            i22 = m22
+            i33 = m33
+        else:
+            i00 = _invert_lower_16(m00, newton_schulz)
+            i11 = _invert_lower_16(m11, newton_schulz)
+            i22 = _invert_lower_16(m22, newton_schulz)
+            i33 = _invert_lower_16(m33, newton_schulz)
         i10 = -hl.dot(
             hl.dot(i11, m10, out_dtype=torch.float32),
             i00,
@@ -1346,16 +1774,16 @@ def _intra_solve_recompute(
             + hl.dot(m32, i20, out_dtype=torch.float32),
             out_dtype=torch.float32,
         )
-        i00 = i00.to(k.dtype)
-        i10 = i10.to(k.dtype)
-        i11 = i11.to(k.dtype)
-        i20 = i20.to(k.dtype)
-        i21 = i21.to(k.dtype)
-        i22 = i22.to(k.dtype)
-        i30 = i30.to(k.dtype)
-        i31 = i31.to(k.dtype)
-        i32 = i32.to(k.dtype)
-        i33 = i33.to(k.dtype)
+        i00 = i00.to(wk.dtype)
+        i10 = i10.to(wk.dtype)
+        i11 = i11.to(wk.dtype)
+        i20 = i20.to(wk.dtype)
+        i21 = i21.to(wk.dtype)
+        i22 = i22.to(wk.dtype)
+        i30 = i30.to(wk.dtype)
+        i31 = i31.to(wk.dtype)
+        i32 = i32.to(wk.dtype)
+        i33 = i33.to(wk.dtype)
 
         beta0 = hl.load(beta_rows, [flat0], extra_mask=valid0).float()
         beta1 = hl.load(beta_rows, [flat1], extra_mask=valid1).float()
@@ -1426,57 +1854,27 @@ def _intra_solve_recompute(
                 extra_mask=valid3[:, None],
             )
 
-        if is_varlen:
-            chunk_end = end.new_full([], CHUNK_SIZE) + chunk_begin
-            last_token = torch.minimum(chunk_end, end) - 1
-        else:
-            last_token = min(chunk_begin + CHUNK_SIZE, end) - 1
-        last = last_token * H + tile_h.id
         for tile_k in hl.tile(K, block_size=block_k):
-            k0 = hl.load(
-                k_rows,
+            wk0 = hl.load(
+                wk_rows,
                 [flat0[:, None], tile_k.index[None, :]],
                 extra_mask=valid0[:, None],
             )
-            k1 = hl.load(
-                k_rows,
+            wk1 = hl.load(
+                wk_rows,
                 [flat1[:, None], tile_k.index[None, :]],
                 extra_mask=valid1[:, None],
             )
-            k2 = hl.load(
-                k_rows,
+            wk2 = hl.load(
+                wk_rows,
                 [flat2[:, None], tile_k.index[None, :]],
                 extra_mask=valid2[:, None],
             )
-            k3 = hl.load(
-                k_rows,
+            wk3 = hl.load(
+                wk_rows,
                 [flat3[:, None], tile_k.index[None, :]],
                 extra_mask=valid3[:, None],
             )
-            g0 = hl.load(
-                g_rows,
-                [flat0[:, None], tile_k.index[None, :]],
-                extra_mask=valid0[:, None],
-            ).float()
-            g1 = hl.load(
-                g_rows,
-                [flat1[:, None], tile_k.index[None, :]],
-                extra_mask=valid1[:, None],
-            ).float()
-            g2 = hl.load(
-                g_rows,
-                [flat2[:, None], tile_k.index[None, :]],
-                extra_mask=valid2[:, None],
-            ).float()
-            g3 = hl.load(
-                g_rows,
-                [flat3[:, None], tile_k.index[None, :]],
-                extra_mask=valid3[:, None],
-            ).float()
-            wk0 = (k0.float() * beta0[:, None] * torch.exp2(g0)).to(k.dtype)
-            wk1 = (k1.float() * beta1[:, None] * torch.exp2(g1)).to(k.dtype)
-            wk2 = (k2.float() * beta2[:, None] * torch.exp2(g2)).to(k.dtype)
-            wk3 = (k3.float() * beta3[:, None] * torch.exp2(g3)).to(k.dtype)
             w0 = hl.dot(i00, wk0, out_dtype=torch.float32)
             w1 = hl.dot(i10, wk0, out_dtype=torch.float32) + hl.dot(
                 i11, wk1, out_dtype=torch.float32
@@ -1492,11 +1890,6 @@ def _intra_solve_recompute(
                 + hl.dot(i32, wk2, out_dtype=torch.float32)
                 + hl.dot(i33, wk3, out_dtype=torch.float32)
             )
-            last_g = g_rows[last, tile_k.index].float()
-            kg0 = k0.float() * torch.exp2(last_g[None, :] - g0)
-            kg1 = k1.float() * torch.exp2(last_g[None, :] - g1)
-            kg2 = k2.float() * torch.exp2(last_g[None, :] - g2)
-            kg3 = k3.float() * torch.exp2(last_g[None, :] - g3)
             hl.store(
                 w_rows,
                 [flat0[:, None], tile_k.index[None, :]],
@@ -1521,32 +1914,14 @@ def _intra_solve_recompute(
                 w3,
                 extra_mask=valid3[:, None],
             )
-            hl.store(
-                kg_rows,
-                [flat0[:, None], tile_k.index[None, :]],
-                kg0,
-                extra_mask=valid0[:, None],
-            )
-            hl.store(
-                kg_rows,
-                [flat1[:, None], tile_k.index[None, :]],
-                kg1,
-                extra_mask=valid1[:, None],
-            )
-            hl.store(
-                kg_rows,
-                [flat2[:, None], tile_k.index[None, :]],
-                kg2,
-                extra_mask=valid2[:, None],
-            )
-            hl.store(
-                kg_rows,
-                [flat3[:, None], tile_k.index[None, :]],
-                kg3,
-                extra_mask=valid3[:, None],
-            )
 
-    return w, u, kg
+    return w, u
+
+
+_intra_solve_recompute_newton = helion.kernel(
+    static_shapes=False,
+    config=_NEWTON_SOLVE_RECOMPUTE_CONFIG,
+)(_intra_solve_recompute.fn)
 
 
 def chunk_kda_fwd_intra(
@@ -1555,9 +1930,12 @@ def chunk_kda_fwd_intra(
     v: torch.Tensor,
     g: torch.Tensor,
     beta: torch.Tensor,
+    wk: torch.Tensor,
+    kg: torch.Tensor,
     scale: float,
     cu_seqlens: torch.Tensor | None,
     chunk_indices: torch.Tensor | None = None,
+    newton_schulz: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Helion equivalent of SGLang's intra-chunk KDA preparation."""
     is_varlen = cu_seqlens is not None
@@ -1569,7 +1947,13 @@ def chunk_kda_fwd_intra(
         metadata = torch.empty(0, device=q.device, dtype=torch.int32)
         chunk_indices = torch.empty(0, 2, device=q.device, dtype=torch.long)
 
-    aqk, akk = _intra_matrices_wide(
+    preinvert_diagonal = not newton_schulz
+    matrix_kernel = (
+        _intra_matrices_wide_forward
+        if preinvert_diagonal
+        else _intra_matrices_wide
+    )
+    aqk, akk = matrix_kernel(
         q,
         k,
         g,
@@ -1578,34 +1962,51 @@ def chunk_kda_fwd_intra(
         chunk_indices,
         scale,
         is_varlen,
+        preinvert_diagonal,
+        newton_schulz,
     )
-    w, u, kg = _intra_solve_recompute(
+    solve_kernel = (
+        _intra_solve_recompute_newton
+        if newton_schulz
+        else _intra_solve_recompute
+    )
+    w, u = solve_kernel(
         akk,
-        k,
+        wk,
         v,
-        g,
         beta,
         metadata,
         chunk_indices,
         is_varlen,
+        newton_schulz,
+        preinvert_diagonal,
     )
     return w, u, kg, aqk
 
 
-_STATE_CONFIG = helion.Config(
+_STATE_FIXED_CONFIG = helion.Config(
     block_sizes=[16],
+    num_warps=8,
+    num_stages=3,
+    indexing="pointer",
+)
+
+
+_STATE_VARLEN_CONFIG = helion.Config(
+    block_sizes=[16],
+    loop_orders=[[1, 2, 0]],
     num_warps=4,
     num_stages=3,
     indexing="pointer",
 )
 
 
-@helion.kernel(static_shapes=False, config=_STATE_CONFIG)
+@helion.kernel(static_shapes=False, config=_STATE_FIXED_CONFIG)
 def _chunk_state(
     kg: torch.Tensor,
     w: torch.Tensor,
     u: torch.Tensor,
-    g: torch.Tensor,
+    chunk_decay: torch.Tensor,
     initial_state: torch.Tensor,
     initial_state_indices: torch.Tensor,
     cu_seqlens: torch.Tensor,
@@ -1633,9 +2034,9 @@ def _chunk_state(
             u.stride(1),
             u.stride(2),
             u.stride(3),
-            g.stride(1),
-            g.stride(2),
-            g.stride(3),
+            chunk_decay.stride(0),
+            chunk_decay.stride(1),
+            chunk_decay.stride(2),
             initial_state.stride(0),
             initial_state.stride(1),
             initial_state.stride(2),
@@ -1649,11 +2050,11 @@ def _chunk_state(
         dtype=kg.dtype,
         device=kg.device,
     )
-    v_new = torch.empty_like(u)
+    v_new = u
     kg_rows = kg.view(B * T * H, K)
     w_rows = w.view(B * T * H, K)
     u_rows = u.view(B * T * H, V)
-    g_rows = g.view(B * T * H, K)
+    decay_rows = chunk_decay.view(-1, K)
     v_new_rows = v_new.view(B * T * H, V)
     h_rows = h.view(B * total_chunks * H, V, K)
     block_v = hl.register_block_size(1, V)
@@ -1701,22 +2102,8 @@ def _chunk_state(
             )
             residual = residual + u_rows[row, tile_v].float()
             v_new_rows[row, tile_v] = residual.to(v_new.dtype)
-            if is_varlen:
-                chunk_end = (
-                    end.new_full([], CHUNK_SIZE) + begin + token_tile.id * CHUNK_SIZE
-                )
-                last_token = torch.minimum(chunk_end, end) - 1
-            else:
-                last_token = (
-                    min(
-                        begin + (token_tile.id + 1) * CHUNK_SIZE,
-                        end,
-                    )
-                    - 1
-                )
-            last_row = last_token * H + tile_h.id
-            last_g = g_rows[last_row, :].float()
-            state = state * torch.exp2(last_g)[None, :]
+            decay = decay_rows[global_chunk * H + tile_h.id, :]
+            state = state * decay[None, :]
             kg_value = hl.load(
                 kg_rows,
                 [row[:, None], hl.arange(K)[None, :]],
@@ -1738,48 +2125,50 @@ def _chunk_state(
     return h, v_new
 
 
+_chunk_state_varlen = helion.kernel(
+    static_shapes=False,
+    config=_STATE_VARLEN_CONFIG,
+)(_chunk_state.fn)
+
+
 _OUTPUT_CONFIG = helion.Config(
-    block_sizes=[64],
-    loop_orders=[[2, 1, 0]],
-    num_warps=8,
-    num_stages=2,
+    block_sizes=[128],
+    loop_orders=[[1, 2, 0]],
+    l2_groupings=[32],
+    num_warps=2,
+    num_stages=4,
     indexing="pointer",
 )
 
 
 @helion.kernel(static_shapes=False, config=_OUTPUT_CONFIG)
 def _chunk_output(
-    q: torch.Tensor,
+    qg: torch.Tensor,
     v_new: torch.Tensor,
-    g: torch.Tensor,
     aqk: torch.Tensor,
     h: torch.Tensor,
     out: torch.Tensor,
     cu_seqlens: torch.Tensor,
     chunk_indices: torch.Tensor,
-    scale: float,
     is_varlen: hl.constexpr,  # pyrefly: ignore[bad-function-definition]
 ) -> torch.Tensor:
     """Compose inter-chunk state output and causal intra-chunk output."""
-    B = q.size(0)
-    T = q.size(1)
-    H = hl.specialize(q.size(2))
-    K = hl.specialize(q.size(3))
+    B = qg.size(0)
+    T = qg.size(1)
+    H = hl.specialize(qg.size(2))
+    K = hl.specialize(qg.size(3))
     V = hl.specialize(v_new.size(3))
     chunks_per_batch = (T + CHUNK_SIZE - 1) // CHUNK_SIZE
     total_chunks = chunk_indices.size(0) if is_varlen else B * chunks_per_batch
     h_chunks = h.size(1)
     hl.specialize(
         (
-            q.stride(1),
-            q.stride(2),
-            q.stride(3),
+            qg.stride(1),
+            qg.stride(2),
+            qg.stride(3),
             v_new.stride(1),
             v_new.stride(2),
             v_new.stride(3),
-            g.stride(1),
-            g.stride(2),
-            g.stride(3),
             aqk.stride(1),
             aqk.stride(2),
             aqk.stride(3),
@@ -1793,8 +2182,7 @@ def _chunk_output(
         )
     )
 
-    q_rows = q.view(B * T * H, K)
-    g_rows = g.view(B * T * H, K)
+    qg_rows = qg.view(B * T * H, K)
     v_rows = v_new.view(B * T * H, V)
     aqk_rows = aqk.view(B * T * H, CHUNK_SIZE)
     h_rows = h.view(B * h_chunks * H, V, K)
@@ -1822,24 +2210,18 @@ def _chunk_output(
         token = begin + local_chunk * CHUNK_SIZE + lane
         valid = token < end
         row = token * H + tile_h.id
-        q_value = hl.load(
-            q_rows,
+        qg_value = hl.load(
+            qg_rows,
             [row[:, None], hl.arange(K)[None, :]],
             extra_mask=valid[:, None],
-        ).float()
-        g_value = hl.load(
-            g_rows,
-            [row[:, None], hl.arange(K)[None, :]],
-            extra_mask=valid[:, None],
-        ).float()
+        )
         h_value = h_rows[
             h_chunk * H + tile_h.id,
             tile_v,
             :,
         ]
-        qg = (q_value * scale * torch.exp2(g_value)).to(q.dtype)
         output = hl.dot(
-            qg,
+            qg_value,
             h_value.T,
             out_dtype=torch.float32,
         )
@@ -1886,11 +2268,17 @@ def chunk_kda(
     output_intermediate_states: bool = False,
     **kwargs: object,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-    """Match the public forward contract of SGLang's Triton ``chunk_kda``."""
+    """Match the public forward contract of SGLang's Triton ``chunk_kda``.
+
+    ``newton_schulz=True`` in ``kwargs`` enables a faster inverse with a
+    different floating-point operation order. The default uses Triton's
+    forward-substitution order.
+    """
     if scale is None:
         scale = k.shape[-1] ** -0.5
     if initial_state is None or initial_state_indices is None:
         raise ValueError("KDA prefill requires an indexed initial-state pool")
+    newton_schulz = bool(kwargs.get("newton_schulz", False))
 
     q = q.contiguous()
     k = k.contiguous()
@@ -1902,8 +2290,12 @@ def chunk_kda(
     chunk_indices = (
         prepare_chunk_indices(cu_seqlens) if cu_seqlens is not None else None
     )
-    g = gate_chunk_cumsum(
+    g, qg, wk, kg, chunk_decay = gate_chunk_cumsum_operands(
         g,
+        q,
+        k,
+        beta,
+        q_scale=scale,
         a_log=A_log,
         dt_bias=dt_bias,
         cu_seqlens=cu_seqlens,
@@ -1916,9 +2308,12 @@ def chunk_kda(
         v,
         g,
         beta,
+        wk,
+        kg,
         scale,
         cu_seqlens,
         chunk_indices,
+        newton_schulz,
     )
 
     is_varlen = cu_seqlens is not None
@@ -1928,11 +2323,12 @@ def chunk_kda(
     else:
         metadata = torch.empty(0, device=q.device, dtype=torch.int32)
         chunk_offsets = torch.empty(0, device=q.device, dtype=torch.long)
-    h, v_new = _chunk_state(
+    state_kernel = _chunk_state_varlen if is_varlen else _chunk_state
+    h, v_new = state_kernel(
         kg,
         w,
         u,
-        g,
+        chunk_decay,
         initial_state,
         initial_state_indices,
         metadata,
@@ -1945,15 +2341,13 @@ def chunk_kda(
     if chunk_indices is None:
         chunk_indices = torch.empty(0, 2, device=q.device, dtype=torch.long)
     output = _chunk_output(
-        q,
+        qg,
         v_new,
-        g,
         aqk,
         h,
         v,
         metadata,
         chunk_indices,
-        scale,
         is_varlen,
     )
     if output_intermediate_states:

--- a/examples/linear/kda_prefill_sglang_benchmarking.md
+++ b/examples/linear/kda_prefill_sglang_benchmarking.md
@@ -1,0 +1,494 @@
+# KDA Prefill: Helion and SGLang Benchmarking Notes
+
+This note records the Kimi Delta Attention (KDA) prefill implementation, the
+baseline used for comparison, and the commands used on two GB200 GPUs. The
+`sitecustomize.py` integration is an A/B harness, not a proposed SGLang API.
+
+## Baseline and dispatch
+
+For `moonshotai/Kimi-Linear-48B-A3B-Instruct`, SGLang's default linear-attention
+backend is `triton`. The prefill/extend call chain is:
+
+```text
+KDAAttnBackend.forward_extend
+  -> KDAKernelDispatcher.extend
+  -> TritonKDAKernel.extend
+  -> sglang.kernels.ops.attention.fla.kda.chunk_kda
+```
+
+The dispatcher and wrapper live in:
+
+```text
+python/sglang/srt/layers/attention/linear/kda_backend.py
+python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
+```
+
+The kernels used by the default path are in-tree under:
+
+```text
+python/sglang/kernels/ops/attention/fla/kda.py
+python/sglang/kernels/ops/attention/fla/chunk_intra.py
+python/sglang/kernels/ops/attention/fla/chunk_delta_h.py
+```
+
+This code was copied from Flash Linear Attention and adapted through vLLM, but
+it is vendored into SGLang and does not import an external FLA package at
+runtime.
+
+SGLang also has two non-default KDA prefill implementations:
+
+- `cutedsl`: in-tree Blackwell kernels, selected explicitly with
+  `--linear-attn-prefill-backend cutedsl`. It requires SM100 and K=128, and the
+  current wrapper cannot return intermediate states for the default
+  `extra_buffer` radix-cache strategy.
+- `flashkda`: an optional wrapper around the external MoonshotAI `flash_kda`
+  CUTLASS package. Unsupported shapes, gates, speculative extend, and requests
+  for intermediate states fall back to the Triton baseline.
+
+FlashInfer is not a KDA prefill baseline. Its SGLang wrapper implements KDA
+decode and verify only and explicitly leaves extend/prefill to Triton or CuTe
+DSL.
+
+## Production contract
+
+The TP=2 shape for Kimi Linear 48B is:
+
+```text
+global heads:       32
+local heads/GPU:    16
+K:                  128
+V:                  128
+chunk size:         64
+activation/output:  bfloat16
+recurrent state:    float32
+```
+
+The Helion public entry point has the same parameter order and defaults as
+SGLang's `chunk_kda`:
+
+```python
+chunk_kda(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    scale=None,
+    initial_state=None,
+    initial_state_indices=None,
+    use_qk_l2norm_in_kernel=False,
+    cu_seqlens=None,
+    A_log=None,
+    dt_bias=None,
+    lower_bound=None,
+    output_intermediate_states=False,
+    **kwargs,
+)
+```
+
+It preserves the corresponding numerical and mutation contract:
+
+- fixed-length and packed variable-length input;
+- raw gates with `A_log`, optional `dt_bias`, and optional safe-gate
+  `lower_bound`, or already activated gates when `A_log` is absent;
+- optional in-kernel Q/K L2 normalization;
+- indexed FP32 or BF16 state pools in `[slot, H, V, K]` layout;
+- in-place output through `v` and in-place final-state updates;
+- optional intermediate states with the same fixed/packed layouts;
+- partial chunks, FP16 or BF16 activations, K up to 256, and arbitrary V.
+
+The implementation and focused tests are:
+
+```text
+examples/linear/kda_prefill.py
+test/test_kda_prefill.py
+```
+
+## Implementation
+
+The production path launches six Helion-generated kernels:
+
+1. Q/K L2 normalization.
+2. Gate activation and chunk-local cumulative sum.
+3. Chunk-local QK and KKT matrices.
+4. Fused triangular solve plus U, W, and gated-K recomputation.
+5. Recurrent chunk-state update.
+6. Output projection and in-place output store.
+
+The important fusion is step 4. Keeping solve and recomputation separate was
+slower for every production sequence length tested.
+
+The selected single configuration is used for all observed sequence lengths
+and packed batch compositions. The performance-critical stages use:
+
+| Stage | Blocks | Loop order | Warps | Stages | Indexing |
+|---|---|---|---:|---:|---|
+| matrices | 32 | `[2, 1, 0]` | 1 | 2 | pointer |
+| fused solve/recompute | 64, 32 | `[0, 1]` | 1 | 2 | pointer |
+| state | 16 | default | 4 | 3 | pointer |
+| output | 64 | `[2, 1, 0]` | 8 | 2 | pointer |
+
+All kernels use `static_shapes=False`. H, K, V, inner layouts, dtypes,
+fixed/varlen mode, and optional numerical modes remain specialized. Total
+sequence length and every leading stride derived from it stay dynamic, matching
+the Triton baseline's `do_not_specialize=["T"]` behavior. Generated launch
+code takes runtime T, grid sizes, and leading strides while retaining constexpr
+H/K/V.
+
+## Tuning findings
+
+Multi-shape autotuning and focused sweeps used one geometric-mean objective,
+with production points at T=512 and T=8192 and validation at T=2048.
+
+- The best fused solve/recompute candidate used a V tile of 64, K tile of 32,
+  one warp, and two stages. Relative to the prior 64x64/four-warp version, its
+  stage latency ratios were 0.893, 0.463, and 0.498 at T=512/2048/8192.
+- State tile 16 with four warps was the best universal compromise: roughly
+  8-9% faster for packed varlen, 4.3% faster at fixed T=8192, and only 0.7%
+  slower at fixed T=512.
+- Matrix tuning selected block 32, one warp, and two stages.
+- Tensor descriptors were emitted for the contiguous normalization loads, but
+  that variant was 3-4x slower. Gathered matrix/output addresses did not lower
+  to descriptors. Pointer indexing is retained.
+- L2 grouping was useful only for the now-unused split W helper. Eviction hints,
+  persistent PID, `maxnreg`, range unrolling, and range staging were neutral or
+  slower on the production kernels. Four range stages regressed performance.
+- Warp specialization reached the Triton operation but failed in the SM100
+  compiler for the matrix kernel, so it is not enabled.
+- A broad random fused search found configurations with minute-long compile
+  outliers and a worse geometric mean. Those were rejected because compile
+  behavior is part of the acceptance criteria.
+
+The autotuning entry point is:
+
+```text
+benchmarks/kda_prefill_autotune.py
+```
+
+For example:
+
+```bash
+python benchmarks/kda_prefill_autotune.py \
+  --kernel fused \
+  --varlen \
+  --sequence-lengths 512 8192 \
+  --cache-tag kda-prefill-fused-gb200
+```
+
+## Microbenchmark results
+
+Environment:
+
+```text
+Helion:  7ba4dc7070252d110a03d3f4bcb575d53f5e9699 + this worktree
+SGLang:  d0b9689805232d8ab37789121cbc3b766b5c723e + benchmark changes
+Torch:   2.11.0+cu130
+Triton:  3.6.0
+GPU:     NVIDIA GB200, SM100, 152 SMs
+```
+
+SGLang's existing CuTe DSL prefill benchmark was extended in place to include
+Helion. With BF16, H=16, K=V=128, one fixed sequence, and CUDA-graph timing:
+
+| T | Triton (ms) | CuTe DSL (ms) | Helion (ms) | Triton/Helion |
+|---:|---:|---:|---:|---:|
+| 512 | 0.067 | 0.031 | 0.055 | 1.24x |
+| 2048 | 0.174 | 0.099 | 0.131 | 1.33x |
+| 8192 | 0.672 | 0.364 | 0.424 | 1.59x |
+
+CuTe DSL remains faster on this fixed-shape GB200 microbenchmark. The relevant
+command is:
+
+```bash
+cd /path/to/sglang
+python benchmark/bench_linear_attention/bench_kda_prefill_cutedsl.py \
+  --mode bench \
+  --dtype bfloat16 \
+  --num-heads 16 \
+  --seq-lens 512 2048 8192 \
+  --helion-root /path/to/helion-multi-autotune
+```
+
+A paired packed-varlen benchmark using raw gates, internal Q/K normalization,
+H=16, K=V=128, and ragged non-aligned lengths produced:
+
+| Total T | Triton (ms) | Helion (ms) | Triton/Helion |
+|---:|---:|---:|---:|
+| 512 | 0.067706 | 0.062355 | 1.086x |
+| 2048 | 0.155155 | 0.148765 | 1.043x |
+| 8192 | 0.534346 | 0.435134 | 1.228x |
+
+### BF16 decode tuning
+
+The decode kernel now has separate fixed configurations for FP32 and BF16
+recurrent state. The public parameter order, return tuple, aliases, in-place
+state/output mutations, padding behavior, and numerical operations are shared
+by both paths. The FP32 configuration is unchanged.
+
+One multi-shape search evaluated 1,752 configurations on B=1 and B=256 with an
+equal-weight geometric mean of latency ratios. The selected BF16 configuration
+uses a V tile of 16, one warp, four stages, flat PID, L2 grouping 16, and the
+exact indexing and eviction fields recorded in
+`examples/linear/kda_packed_decode.py`. It improved the raw kernel as follows:
+
+| B | Prior config (us) | BF16 config (us) | Ratio |
+|---:|---:|---:|---:|
+| 1 | 11.360 | 8.288 | 0.730x |
+| 256 | 72.224 | 51.680 | 0.716x |
+
+The joint objective was `0.7225x`, or a `1.384x` raw-kernel speedup. The search
+command was:
+
+```bash
+cd /home/eche/local/helion-multi-autotune
+python -m examples.linear.kda_packed_decode \
+  --sglang-root /home/eche/local/sglang \
+  --mode correctness \
+  --batch-sizes 1 \
+  --tp-sizes 2 \
+  --activation-dtype bfloat16 \
+  --state-dtype bfloat16 \
+  --multi-autotune \
+  --tune-batch-sizes 1 256 \
+  --tune-aggregation geomean
+```
+
+SGLang's existing FlashInfer decode benchmark was extended with an optional
+paired Helion baseline. It validates both Helion variants against packed
+Triton, alternates timing order for three rounds, and reports medians. Direct
+timing includes Python validation, output allocation, and dispatch, which hide
+most of the raw gain at small B. The tuned kernel remained `1.68-1.83x` faster
+than FlashInfer and was 8% faster than the old Helion config at B=256:
+
+```bash
+cd /home/eche/local/sglang
+python benchmark/bench_linear_attention/bench_kda_flashinfer_mtp.py \
+  --mode bench \
+  --task decode \
+  --dtype bfloat16 \
+  --batch-sizes 1 4 16 32 64 128 256 \
+  --num-q-heads 16 \
+  --num-v-heads 16 \
+  --helion-root /home/eche/local/helion \
+  --helion-baseline-root /home/eche/local/helion-multi-autotune
+```
+
+Generated Triton confirmed the selected block, PID, stage, L2, and eviction
+choices. The requested tensor-descriptor indexing entries were downgraded to
+pointer loads because these accesses are gathered through runtime state indices;
+no descriptor instructions were emitted. The exact autotuned config is retained.
+
+A follow-up inline Triton experiment isolated only the recurrent-state access.
+The pointer and TMA specializations shared launch geometry and all arithmetic;
+TMA used a `[1, 1, block_v, 128]` descriptor box with the state slot loaded from
+`ssm_state_indices` on device. Descriptor load/store was bitwise identical to
+the pointer variant, confirming that dynamic slot coordinates are supported.
+It was not profitable:
+
+| Block V | Warps | B=1 TMA/pointer | B=256 TMA/pointer | Geomean |
+|---:|---:|---:|---:|---:|
+| 16 | 1 | 1.796x | 1.433x | 1.605x |
+| 32 | 1 | 1.856x | 1.052x | 1.398x |
+| 32 | 2 | 2.016x | 1.273x | 1.602x |
+| 64 | 8 | 1.522x | 1.255x | 1.382x |
+| 128 | 8 | 1.675x | 1.638x | 1.656x |
+
+Issuing the transfer before the independent gate exponentials improved overlap,
+but the best matched result still regressed by 26.8% at B=1 and 9.5% at B=256.
+The production kernel therefore retains coalesced pointer state access. The
+reproducer is `benchmarks/kda_decode_tma_probe.py`.
+
+The fresh TP=2 BF16 end-to-end comparison used default FlashInfer decode and
+Triton prefill as the baseline. The Helion row selected Triton only as the
+packed-decode integration carrier, then substituted the tuned Helion decode;
+prefill remained Triton. Each server ran one 20-request warmup followed by three
+100-request samples of the workload documented below.
+
+| Configuration | Input tok/s samples | Median | Geomean | vs baseline |
+|---|---:|---:|---:|---:|
+| Default FlashInfer decode | 26,952 / 25,937 / 28,201 | 26,952 | 27,014 | baseline |
+| Tuned Helion decode | 27,275 / 27,874 / 27,286 | 27,286 | 27,477 | +1.24% median, +1.71% geomean |
+
+Every matched run generated identical text and token lengths, processed 247,525
+input and 485 output tokens, and had zero request errors. Logs, JSONL outputs,
+the paired microbenchmark, and generated code are under:
+
+```text
+/home/eche/results/kda-bf16-decode-tuning-20260724
+/home/eche/results/kda-bf16-decode-tuned-e2e-20260724
+```
+
+## Dynamic-shape and startup behavior
+
+After one T=512 compile, previously unseen T=2048 and T=8192 calls reused the
+same six bound kernels in 0.00225 and 0.00209 seconds and emitted no additional
+code. A TP=2 server emitted exactly 12 output-code events, six per worker, all
+before readiness and none during the serving benchmarks.
+
+Cold compilation remains a cost. A local first compile took about 13.35
+seconds. Across comparable TP=2 launches, Helion reached readiness roughly
+10-12 seconds later than Triton. This is substantially better than specializing
+and compiling for every new T, but it is not compile-time parity with the
+existing Triton path.
+
+## End-to-end A/B result
+
+The serving workload used two GB200 GPUs, TP=2, FP32 recurrent state, Triton
+decode, 100 deterministic random prompts derived with the SGLang benchmarker,
+target input length 4096 with range ratio 0.25, output length 8, concurrency 4,
+seed 4242, and a cache flush before each measured run. Each run processed
+247,525 input tokens and 485 output tokens with zero errors.
+
+| Backend | Run 1 input tok/s | Run 2 input tok/s | Geomean |
+|---|---:|---:|---:|
+| Triton prefill | 26,575 | 27,597 | 27,081 |
+| Helion prefill | 27,542 | 28,957 | 28,241 |
+
+The clean-run geomean improvement is **4.28%**. One earlier Helion sample had a
+non-reproducing 4.38-second scheduler stall and is preserved in the result
+directory as `helion-prefill-n100.jsonl`; there was no Helion code generation
+during the stall. It is excluded from the clean-run geomean rather than hidden.
+
+Results and logs from this machine are under:
+
+```text
+/home/eche/results/kda-prefill-ab-20260723
+```
+
+## End-to-end reproduction
+
+Set paths and offline mode:
+
+```bash
+export HELION_ROOT=/path/to/helion-multi-autotune
+export SGLANG_ROOT=/path/to/sglang
+export MODEL=/path/to/Kimi-Linear-48B-A3B-Instruct/snapshot
+export DATASET=/path/to/ShareGPT_V3_unfiltered_cleaned_split.json
+export RESULTS=/path/to/results/kda-prefill-ab
+export PYTHONPATH="${HELION_ROOT}/scripts/kda_sglang_ab:${HELION_ROOT}:${SGLANG_ROOT}/python"
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+mkdir -p "${RESULTS}"
+```
+
+Launch the default Triton baseline:
+
+```bash
+cd "${SGLANG_ROOT}"
+unset SGLANG_KDA_HELION_PREFILL
+python -m sglang.launch_server \
+  --model-path "${MODEL}" \
+  --trust-remote-code \
+  --tp-size 2 \
+  --linear-attn-backend triton \
+  --linear-attn-decode-backend triton \
+  --linear-attn-prefill-backend triton \
+  --mamba-ssm-dtype float32 \
+  --disable-custom-all-reduce \
+  --port 30000 \
+  2>&1 | tee "${RESULTS}/triton-server.log"
+```
+
+For Helion, use the same command with:
+
+```bash
+export SGLANG_KDA_HELION_PREFILL=1
+```
+
+With only this flag, the hook in `scripts/kda_sglang_ab/sitecustomize.py`
+replaces only `kda_triton.chunk_kda`; decode and all other model kernels remain
+unchanged. `SGLANG_KDA_HELION_DECODE=1` independently enables the packed-decode
+substitution. Confirm the corresponding two `first ... call` markers, one per
+TP worker, before using a Helion result.
+
+After the server reports readiness, run one short workload to settle the full
+serving path, then measure:
+
+```bash
+python -m sglang.benchmark.serving \
+  --backend sglang \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --dataset-name random \
+  --dataset-path "${DATASET}" \
+  --model "${MODEL}" \
+  --num-prompts 100 \
+  --random-input-len 4096 \
+  --random-output-len 8 \
+  --random-range-ratio 0.25 \
+  --max-concurrency 4 \
+  --seed 4242 \
+  --temperature 0 \
+  --flush-cache \
+  --warmup-requests 1 \
+  --output-details \
+  --disable-tqdm \
+  --output-file "${RESULTS}/result.jsonl"
+```
+
+## Verification
+
+Run the focused contract tests before benchmarking:
+
+```bash
+cd "${HELION_ROOT}"
+pytest test/test_kda_prefill.py -x -vv -s
+```
+
+The final run passed all four tests in 51.06 seconds. A wider direct packed test
+at T=73, H=2, K=256, and V=80 had maximum output error `3.052e-5`, maximum
+intermediate-state error `1.707e-4`, finite outputs, and exact preservation of
+untouched state-pool rows.
+
+SGLang's benchmark correctness mode also passed Helion and CuTe DSL against
+`fused_recurrent_kda` at T=128, 192, 256, 512, and 1024 with H=16 and K=V=128.
+Helion's largest output error was `7.32e-4`; its largest final-state error was
+`4.90e-3`.
+
+## Default-backend FP32/BF16 matrix
+
+On 2026-07-24, the TP=2 serving benchmark was repeated without the base or
+prefill backend arguments. SGLang resolved the default backends as follows:
+
+```text
+FP32 state: decode=triton,     prefill=triton
+BF16 state: decode=flashinfer, prefill=triton
+```
+
+Helion decode requires `TritonKDAKernel` as its integration point. Therefore,
+the BF16 decode-only and combined rows explicitly selected
+`--linear-attn-decode-backend triton`, then replaced its packed-decode callable
+with Helion. Their performance comparison is still against the flag-free
+FlashInfer baseline. BF16 prefill-only retained default FlashInfer decode.
+
+Each configuration ran one 20-request warmup followed by three deterministic
+100-request samples. Each sample processed 247,525 input and 485 output tokens
+with no request errors. The primary statistic is the three-run median because
+the serving benchmark occasionally contains multi-second scheduling stalls.
+
+| State | Configuration | Input tok/s samples | Median | vs default | Geomean |
+|---|---|---|---:|---:|---:|
+| FP32 | default Triton/Triton | 24,129 / 26,784 / 25,279 | 25,279 | baseline | 25,374 |
+| FP32 | Helion decode | 27,449 / 29,436 / 28,704 | 28,704 | +13.55% | 28,518 |
+| FP32 | Helion prefill | 16,588 / 26,729 / 25,833 | 25,833 | +2.19% | 22,541 |
+| FP32 | Helion decode + prefill | 29,113 / 29,148 / 29,636 | 29,148 | +15.31% | 29,298 |
+| BF16 | default FlashInfer/Triton | 25,618 / 27,369 / 27,437 | 27,369 | baseline | 26,795 |
+| BF16 | Helion decode | 25,594 / 27,795 / 27,175 | 27,175 | -0.71% | 26,838 |
+| BF16 | Helion prefill | 27,169 / 28,700 / 27,496 | 27,496 | +0.46% | 27,781 |
+| BF16 | Helion decode + prefill | 29,196 / 28,937 / 29,420 | 29,196 | +6.67% | 29,183 |
+
+The first FP32 Helion-prefill sample reproduced the previously observed
+one-time long-run stall. It emitted no new Helion code and subsequent samples
+were normal. It is retained in both the raw samples and geomean; the median is
+reported as the robust primary result. The small BF16 prefill-only difference
+is within observed run-to-run noise, while the combined improvements are much
+larger and stable across all three samples.
+
+BF16 state also nearly doubled recurrent-state capacity at the same memory
+budget: `max_mamba_cache_size` increased from 2,605 to 5,040 and
+`max_running_requests` from 521 to 1,008. The complete logs and JSONL outputs
+are saved under:
+
+```text
+/home/eche/results/kda-default-matrix-20260724
+```

--- a/examples/linear/kda_prefill_sglang_benchmarking.md
+++ b/examples/linear/kda_prefill_sglang_benchmarking.md
@@ -63,6 +63,13 @@ activation/output:  bfloat16
 recurrent state:    float32
 ```
 
+SGLang's normal Kimi prefill/extend path concatenates each request's new tokens
+and always passes `query_start_loc` as `cu_seqlens`. The default hot-path
+specialization is therefore **packed varlen + forward substitution + FP32
+state**. Fixed-length input remains supported for direct callers and isolated
+microbenchmarks. Newton-Schulz is opt-in and can be combined with either input
+layout.
+
 The Helion public entry point has the same parameter order and defaults as
 SGLang's `chunk_kda`:
 
@@ -118,15 +125,19 @@ The production path launches six Helion-generated kernels:
 The important fusion is step 4. Keeping solve and recomputation separate was
 slower for every production sequence length tested.
 
-The selected single configuration is used for all observed sequence lengths
-and packed batch compositions. The performance-critical stages use:
+Each numerical path has one selected configuration for all observed sequence
+lengths. Fixed and packed state propagation also use separate configurations
+because they have materially different load patterns:
 
-| Stage | Blocks | Loop order | Warps | Stages | Indexing |
+| Stage/path | Blocks | Loop order | Warps | Stages | Indexing |
 |---|---|---|---:|---:|---|
-| matrices | 32 | `[2, 1, 0]` | 1 | 2 | pointer |
-| fused solve/recompute | 64, 32 | `[0, 1]` | 1 | 2 | pointer |
-| state | 16 | default | 4 | 3 | pointer |
-| output | 64 | `[2, 1, 0]` | 8 | 2 | pointer |
+| matrices, forward substitution | 32 | `[1, 2, 0]` | 1 | 2 | pointer |
+| matrices, Newton-Schulz | 32 | `[2, 1, 0]` | 1 | 2 | pointer |
+| solve/recompute, forward substitution | 64, 64 | `[0, 1]` | 1 | 3 | pointer |
+| solve/recompute, Newton-Schulz | 64, 64 | `[0, 1]` | 2 | 3 | pointer |
+| state, fixed length | 16 | default | 8 | 3 | pointer |
+| state, packed varlen | 16 | `[1, 2, 0]` | 4 | 3 | pointer |
+| output | 128 | `[1, 2, 0]` | 2 | 4 | pointer |
 
 All kernels use `static_shapes=False`. H, K, V, inner layouts, dtypes,
 fixed/varlen mode, and optional numerical modes remain specialized. Total
@@ -140,13 +151,25 @@ H/K/V.
 Multi-shape autotuning and focused sweeps used one geometric-mean objective,
 with production points at T=512 and T=8192 and validation at T=2048.
 
-- The best fused solve/recompute candidate used a V tile of 64, K tile of 32,
-  one warp, and two stages. Relative to the prior 64x64/four-warp version, its
-  stage latency ratios were 0.893, 0.463, and 0.498 at T=512/2048/8192.
-- State tile 16 with four warps was the best universal compromise: roughly
-  8-9% faster for packed varlen, 4.3% faster at fixed T=8192, and only 0.7%
-  slower at fixed T=512.
-- Matrix tuning selected block 32, one warp, and two stages.
+- The prologue now emits the cumulative gate, rounded Q/K operands, gated K,
+  and each chunk's final decay in one pass. This removes repeated exponentials
+  and avoids rereading the last gate in state propagation.
+- Forward substitution distributes the four independent 16x16 diagonal
+  inversions over the matrix CTAs. The solve consumes those pre-inverted
+  blocks. This was bitwise identical for the matrix, W, and U intermediates and
+  reduced full-pipeline latency by 13.5%, 12.3%, and 3.4% at
+  T=512/2048/8192 relative to doing the same inversions in the solve CTA.
+- Moving Newton-Schulz inversion into the matrix stage was neutral or slower,
+  so that path keeps inversion in the solve CTA. Three BF16 MMA-style
+  refinements match the CuTe DSL structure and outperform FP32 refinements
+  while remaining within the recurrent-reference tolerance.
+- Separate solve sweeps selected one warp for forward substitution and two for
+  Newton-Schulz. Both use 64x64 registered blocks and three pipeline stages.
+- Fixed state propagation benefits from eight warps: 11.320, 36.134, and
+  162.226 us at T=512/2048/8192, versus 11.552, 37.091, and 172.232 us with four
+  warps. Packed varlen instead prefers four warps and loop order `[1, 2, 0]`.
+- Matrix tuning selected block 32, one warp, and two stages, with distinct loop
+  orders for the two inverse paths.
 - Tensor descriptors were emitted for the contiguous normalization loads, but
   that variant was 3-4x slower. Gathered matrix/output addresses did not lower
   to descriptors. Pointer indexing is retained.
@@ -190,14 +213,20 @@ GPU:     NVIDIA GB200, SM100, 152 SMs
 SGLang's existing CuTe DSL prefill benchmark was extended in place to include
 Helion. With BF16, H=16, K=V=128, one fixed sequence, and CUDA-graph timing:
 
-| T | Triton (ms) | CuTe DSL (ms) | Helion (ms) | Triton/Helion |
-|---:|---:|---:|---:|---:|
-| 512 | 0.067 | 0.031 | 0.055 | 1.24x |
-| 2048 | 0.174 | 0.099 | 0.131 | 1.33x |
-| 8192 | 0.672 | 0.364 | 0.424 | 1.59x |
+| T | Triton (ms) | CuTe DSL (ms) | Helion forward-substitution (ms) | Triton/Helion | Helion Newton-Schulz (ms) | Triton/Helion-NS |
+|---:|---:|---:|---:|---:|---:|---:|
+| 512 | 0.067 | 0.031 | 0.042 | 1.62x | 0.039 | 1.74x |
+| 2048 | 0.176 | 0.099 | 0.107 | 1.64x | 0.103 | 1.68x |
+| 8192 | 0.674 | 0.363 | 0.379 | 1.78x | 0.367 | 1.82x |
 
-CuTe DSL remains faster on this fixed-shape GB200 microbenchmark. The relevant
-command is:
+The default forward-substitution path retains the Triton baseline's inverse
+operation order. Newton-Schulz is algebraically equivalent and passes the same
+recurrent-reference tolerances, but changes floating-point ordering. It is
+therefore opt-in through the ``newton_schulz=True`` keyword and is reported as a
+separate result rather than as a replacement for the default baseline.
+
+CuTe DSL remains faster on this fixed-shape GB200 microbenchmark. The default
+benchmark command is:
 
 ```bash
 cd /path/to/sglang
@@ -209,14 +238,17 @@ python benchmark/bench_linear_attention/bench_kda_prefill_cutedsl.py \
   --helion-root /path/to/helion-multi-autotune
 ```
 
+Add ``--helion-newton-schulz`` to select and clearly label the experimental
+Newton-Schulz specialization.
+
 A paired packed-varlen benchmark using raw gates, internal Q/K normalization,
 H=16, K=V=128, and ragged non-aligned lengths produced:
 
-| Total T | Triton (ms) | Helion (ms) | Triton/Helion |
-|---:|---:|---:|---:|
-| 512 | 0.067706 | 0.062355 | 1.086x |
-| 2048 | 0.155155 | 0.148765 | 1.043x |
-| 8192 | 0.534346 | 0.435134 | 1.228x |
+| Total T | Triton (ms) | Helion forward (ms) | Triton/Helion | Helion NS (ms) | Triton/Helion-NS |
+|---:|---:|---:|---:|---:|---:|
+| 512 | 0.067957 | 0.052078 | 1.305x | 0.047767 | 1.423x |
+| 2048 | 0.157140 | 0.126784 | 1.239x | 0.122787 | 1.280x |
+| 8192 | 0.532932 | 0.438449 | 1.215x | 0.430456 | 1.238x |
 
 ### BF16 decode tuning
 
@@ -355,6 +387,35 @@ Results and logs from this machine are under:
 /home/eche/results/kda-prefill-ab-20260723
 ```
 
+### Path-isolated follow-up
+
+After tuning the forward-substitution and Newton-Schulz paths separately, a
+fresh TP=2 run kept FP32 state and Triton decode fixed. Each clean row is one
+100-request sample after a 20-request warmup:
+
+| Prefill path | Input tok/s | Duration (s) | Mean TTFT (ms) | P99 TTFT (ms) | vs Triton |
+|---|---:|---:|---:|---:|---:|
+| Triton | 26,874.99 | 9.21 | 218.15 | 349.65 | baseline |
+| Helion forward substitution | 26,487.65 | 9.34 | 252.91 | 367.74 | -1.44% |
+| Helion Newton-Schulz | 25,926.43 | 9.55 | 237.83 | 402.78 | -3.53% |
+
+The first forward and first Newton measured samples each hit the same isolated
+1.7-second p99 TTFT scheduler stall. They are preserved as the non-`r2` files
+and excluded from the table. With only one clean serving sample per path, the
+small differences above are not robust enough to override the paired kernel
+measurements or the earlier multi-run serving result.
+
+All rows processed the same 247,525 input and 485 output tokens with no request
+errors. Forward substitution generated byte-identical text to Triton.
+Newton-Schulz preserved every output length but changed 90 of 100 generated
+texts, which is consistent with its intentionally different floating-point
+order. Both Helion servers emitted 12 generated-code events before readiness
+and none during measurement. The complete artifacts are under:
+
+```text
+/home/eche/results/kda-prefill-structural-20260724
+```
+
 ## End-to-end reproduction
 
 Set paths and offline mode:
@@ -389,11 +450,15 @@ python -m sglang.launch_server \
   2>&1 | tee "${RESULTS}/triton-server.log"
 ```
 
-For Helion, use the same command with:
+For the numerical-contract Helion path, use the same command with:
 
 ```bash
 export SGLANG_KDA_HELION_PREFILL=1
+unset HELION_KDA_PREFILL_NEWTON_SCHULZ
 ```
+
+Set `HELION_KDA_PREFILL_NEWTON_SCHULZ=1` in addition to the substitution flag
+to benchmark the separately tuned Newton-Schulz path.
 
 With only this flag, the hook in `scripts/kda_sglang_ab/sitecustomize.py`
 replaces only `kda_triton.chunk_kda`; decode and all other model kernels remain
@@ -435,15 +500,18 @@ cd "${HELION_ROOT}"
 pytest test/test_kda_prefill.py -x -vv -s
 ```
 
-The final run passed all four tests in 51.06 seconds. A wider direct packed test
+The final run passed all four tests in 36.01 seconds. A wider direct packed test
 at T=73, H=2, K=256, and V=80 had maximum output error `3.052e-5`, maximum
 intermediate-state error `1.707e-4`, finite outputs, and exact preservation of
-untouched state-pool rows.
+untouched state-pool rows. A Newton-Schulz packed-varlen safe-gate check at
+K=V=32 preserved the in-place and untouched-slot contracts with maximum output
+and state errors of `1.831e-4` and `7.321e-4`.
 
-SGLang's benchmark correctness mode also passed Helion and CuTe DSL against
-`fused_recurrent_kda` at T=128, 192, 256, 512, and 1024 with H=16 and K=V=128.
-Helion's largest output error was `7.32e-4`; its largest final-state error was
-`4.90e-3`.
+SGLang's benchmark correctness mode also passed both Helion paths and CuTe DSL
+against `fused_recurrent_kda` at T=128, 192, 256, 512, and 1024 with H=32 and
+K=V=128. Both Helion paths had maximum output error `4.88e-4`; the largest
+final-state errors were `4.39e-3` for forward substitution and `4.71e-3` for
+Newton-Schulz.
 
 ## Default-backend FP32/BF16 matrix
 

--- a/examples/linear/kda_prefill_sglang_benchmarking.md
+++ b/examples/linear/kda_prefill_sglang_benchmarking.md
@@ -560,3 +560,35 @@ are saved under:
 ```text
 /home/eche/results/kda-default-matrix-20260724
 ```
+
+## ShareGPT FP32-state occupancy sweep
+
+A flag-free default baseline and the three Helion substitutions were measured
+with 128 fixed-seed ShareGPT prompts, 64 output tokens per prompt, FP32 state,
+TP=2, and concurrency 1/4/16/32/64/128. No linear-attention backend arguments
+were supplied; SGLang resolved the baseline to Triton decode and Triton prefill.
+Each cache-flushed cell processed 31,609 input and 8,192 output tokens with 128
+successful requests and no nonempty errors.
+
+| Configuration | C=1 | C=4 | C=16 | C=32 | C=64 | C=128 | Ratio geomean |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Triton baseline | 848.3 | 2,427.6 | 7,206.0 | 12,780.0 | 19,239.6 | 30,858.0 | 1.0000x |
+| Helion decode | 876.7 | 2,535.2 | 7,339.8 | 12,992.4 | 19,886.1 | 30,915.2 | 1.0247x |
+| Helion prefill | 948.6 | 2,543.5 | 7,562.7 | 13,067.4 | 19,592.1 | 31,292.5 | 1.0445x |
+| Helion decode + prefill | 942.0 | 2,469.7 | 7,296.1 | 12,964.2 | 19,299.5 | 30,430.8 | 1.0233x |
+
+Values are total input-plus-output tokens per second. The geomean speedups were
+2.47% for decode, 4.45% for prefill, and 2.33% for both. Prefill-only reduced
+mean-TTFT geomean by 9.95%; at concurrency 1 it improved total throughput by
+11.82% and reduced mean TTFT from 156.1 to 117.7 ms. The combined row was not
+additive in this one-run sweep, so its small differences at higher occupancy
+should be treated as serving variance rather than a kernel interaction.
+
+The first baseline C=128 sample and a later baseline C=64 repeat each hit an
+isolated scheduler stall. Both are preserved; the table uses the clean original
+C=64 and clean repeated C=128. Full logs, JSONL files, per-cell percentages, and
+the outlier policy are under:
+
+```text
+/home/eche/results/kda-sharegpt-occupancy-fp32-20260724
+```

--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -21,6 +21,10 @@ from torch._inductor.codecache import torch_key
 from .. import exc
 from .._utils import counters
 from .base_search import BaseAutotuner
+from .benchmark_provider import _format_selected_multi_shape_measurement
+from .benchmark_provider import _has_valid_multi_shape_measurement
+from .benchmark_provider import _materialize_multi_shape_config
+from .benchmark_provider import _MultiShapeAutotuneArgs
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -215,6 +219,26 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
             )
         self.kernel: BoundKernel = kernel  # type: ignore[assignment]
         self.args = self.autotuner.args
+        if isinstance(self.args, _MultiShapeAutotuneArgs):
+            self.args.defer_selected_log = True
+
+    def _format_performance(self, value: float) -> str:
+        suffix = (
+            "x"
+            if isinstance(self.args, _MultiShapeAutotuneArgs)
+            and self.args.relative_to is not None
+            else "ms"
+        )
+        return f"{value:.4f}{suffix}"
+
+    def _log_selected_multi_shape(self, summary: str) -> None:
+        if self.autotuner.settings.autotune_log:
+            # The inner search's structured-log context is closed by the time
+            # the cache layer selects its final winner.
+            with self.autotuner.log.autotune_logging():
+                self.autotuner.log(summary)
+        else:
+            self.autotuner.log(summary)
 
     @abc.abstractmethod
     def get(self) -> Config | None:
@@ -311,6 +335,19 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         self.autotuner.log("Starting autotuning process, this may take a while...")
 
         config = self._run_autotune_trials()
+        if isinstance(self.args, _MultiShapeAutotuneArgs):
+            if self.args.search_started and not self.args.found_valid_config:
+                raise exc.NoConfigFound
+            config = _materialize_multi_shape_config(self.autotuner.config_spec, config)
+            if self.args.search_started and not _has_valid_multi_shape_measurement(
+                self.args,
+                self.autotuner.config_spec,
+                config,
+            ):
+                raise exc.NoConfigFound
+            summary = _format_selected_multi_shape_measurement(self.args, config)
+            if summary is not None:
+                self._log_selected_multi_shape(summary)
 
         if not skip_cache_env:
             self.put(config)
@@ -357,7 +394,7 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         trial_low_water_perf = trial_autotuner.best_perf_so_far
         self.autotuner.log(
             f"Best-of-K trial {i + 1}/{k} complete: "
-            f"low-water perf={trial_low_water_perf:.4f}ms "
+            f"low-water perf={self._format_performance(trial_low_water_perf)} "
             f"config={trial_config}"
         )
         return trial_config, trial_low_water_perf
@@ -420,15 +457,29 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         )
 
         trial_results: list[tuple[int, Config, float]] = []
+        is_multi_shape = isinstance(self.args, _MultiShapeAutotuneArgs)
         try:
             for i in range(k):
                 trial_seed = base_seed + i
                 try:
                     settings.autotune_random_seed = trial_seed
                     settings.autotune_compile_timeout = base_compile_timeout
-                    trial_config, trial_low_water_perf = self._run_one_trial(
-                        i, k, trial_seed
-                    )
+                    try:
+                        trial_config, trial_low_water_perf = self._run_one_trial(
+                            i, k, trial_seed
+                        )
+                    except exc.NoConfigFound:
+                        if not is_multi_shape:
+                            raise
+                        self.autotuner.log(
+                            f"Best-of-K trial {i + 1}/{k} found no valid config"
+                        )
+                        continue
+                    if is_multi_shape and not math.isfinite(trial_low_water_perf):
+                        self.autotuner.log(
+                            f"Best-of-K trial {i + 1}/{k} returned no finite timing"
+                        )
+                        continue
                     trial_results.append((i, trial_config, trial_low_water_perf))
                 finally:
                     settings.autotune_random_seed = base_seed
@@ -447,12 +498,17 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         finally:
             self.autotuner = original_autotuner
 
+        if not trial_results:
+            raise exc.NoConfigFound
+
         # Final rebench: time each trial's returned config in a single fresh
         # benchmark round so we pick by an apples-to-apples measurement
         # rather than each trial's optimistic low-water mark.
         rebench_perfs = self._rebench_trial_configs(
             [config for (_, config, _) in trial_results]
         )
+        if is_multi_shape and not any(math.isfinite(perf) for perf in rebench_perfs):
+            raise exc.NoConfigFound
 
         best_idx = min(
             range(len(trial_results)),
@@ -463,20 +519,24 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         best_trial_idx, best_config, _ = trial_results[best_idx]
         best_perf = rebench_perfs[best_idx]
 
-        low_water_summary = ", ".join(f"{p:.4f}" for (_, _, p) in trial_results)
-        rebench_summary = ", ".join(f"{p:.4f}" for p in rebench_perfs)
+        low_water_summary = ", ".join(
+            self._format_performance(perf) for _, _, perf in trial_results
+        )
+        rebench_summary = ", ".join(
+            self._format_performance(perf) for perf in rebench_perfs
+        )
         self.autotuner.log(
             f"Best-of-K complete: picked trial {best_trial_idx + 1}/{k} "
-            f"(rebench perf={best_perf:.4f}ms); "
-            f"per-trial low-water perfs (ms): [{low_water_summary}]; "
-            f"per-trial rebench perfs (ms): [{rebench_summary}]"
+            f"(rebench perf={self._format_performance(best_perf)}); "
+            f"per-trial low-water objectives: [{low_water_summary}]; "
+            f"per-trial rebench objectives: [{rebench_summary}]"
         )
         return best_config
 
     def _rebench_trial_configs(self, configs: list[Config]) -> list[float]:
         """Benchmark K candidate configs in a single fresh autotuner round.
 
-        Returns one perf (ms) per input config, in input order. Used to pick
+        Returns one scalar objective per input config, in input order. Used to pick
         the best-of-K winner without trusting each trial's own optimistic
         ``best_perf_so_far`` low-water mark, which can be inflated by a
         single fast outlier timing during the search.

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
+from torch.utils._pytree import tree_flatten
 from torch.utils._pytree import tree_map_only
 
 from .. import exc
@@ -33,7 +34,9 @@ from ..runtime.settings import _env_get_int
 from .benchmark_provider import BenchmarkProvider
 from .benchmark_provider import BenchmarkResult
 from .benchmark_provider import LocalBenchmarkProvider
+from .benchmark_provider import MultiShapeBenchmarkProvider
 from .benchmark_provider import _clone_args
+from .benchmark_provider import _MultiShapeAutotuneArgs
 from .benchmark_provider import _unset_fn
 from .benchmarking import clear_jit_fast_path_caches
 from .benchmarking import do_bench
@@ -271,6 +274,20 @@ class BaseSearch(BaseAutotuner):
         self._pinned_finalist_configs: set[Config] = set()
         self._pinned_finalist_members: dict[Config, PopulationMember] = {}
 
+    @property
+    def performance_unit(self) -> Literal["ms", "ratio"]:
+        args = getattr(self, "args", ())
+        if isinstance(args, _MultiShapeAutotuneArgs) and args.relative_to is not None:
+            return "ratio"
+        return "ms"
+
+    @property
+    def performance_suffix(self) -> str:
+        return "x" if self.performance_unit == "ratio" else "ms"
+
+    def format_performance(self, value: float) -> str:
+        return f"{value:.4f}{self.performance_suffix}"
+
     def _prepare(self) -> None:
         """Some initialization deferred until autotuning actually runs.
 
@@ -294,9 +311,26 @@ class BaseSearch(BaseAutotuner):
             except OSError:
                 self.log.debug("Failed to read Helion kernel source", exc_info=True)
         kernel_name = getattr(kernel_obj, "name", "")
-        tensors = [arg for arg in self.args if isinstance(arg, torch.Tensor)]
-        input_shapes = str([tuple(t.shape) for t in tensors])
-        dtypes = str([str(t.dtype) for t in tensors])
+        if isinstance(self.args, _MultiShapeAutotuneArgs):
+            case_tensors = []
+            for _, case_args in self.args.cases:
+                leaves, _ = tree_flatten(case_args)
+                case_tensors.append(
+                    [value for value in leaves if isinstance(value, torch.Tensor)]
+                )
+            input_shapes = str(
+                [
+                    [tuple(tensor.shape) for tensor in tensors]
+                    for tensors in case_tensors
+                ]
+            )
+            dtypes = str(
+                [[str(tensor.dtype) for tensor in tensors] for tensors in case_tensors]
+            )
+        else:
+            tensors = [arg for arg in self.args if isinstance(arg, torch.Tensor)]
+            input_shapes = str([tuple(t.shape) for t in tensors])
+            dtypes = str([str(t.dtype) for t in tensors])
         hardware = get_device_name(extract_device(self.args)) or ""
         self._autotune_metrics: AutotuneMetrics = AutotuneMetrics(
             kernel_name=kernel_name,
@@ -316,7 +350,12 @@ class BaseSearch(BaseAutotuner):
             settings=self.settings.to_dict(),
             _device_ir=getattr(host_function, "_device_ir", None),
         )
-        self.benchmark_provider = self._benchmark_provider_cls(
+        provider_cls = (
+            MultiShapeBenchmarkProvider
+            if isinstance(self.args, _MultiShapeAutotuneArgs)
+            else self._benchmark_provider_cls
+        )
+        self.benchmark_provider = provider_cls(
             kernel=self.kernel,
             settings=self.settings,
             config_spec=self.config_spec,
@@ -545,10 +584,19 @@ class BaseSearch(BaseAutotuner):
             exit_stack.enter_context(patch.dict(os.environ, env_overrides, clear=False))
             self.benchmark_provider.setup()
             exit_stack.callback(self.benchmark_provider.cleanup)
+            best: Config | None = None
             try:
                 best = self._autotune()
+                if isinstance(
+                    self.benchmark_provider, MultiShapeBenchmarkProvider
+                ) and isinstance(self.args, _MultiShapeAutotuneArgs):
+                    if not self.benchmark_provider.has_valid_measurement(best):
+                        raise exc.NoConfigFound
+                    if not self.args.defer_selected_log:
+                        self.benchmark_provider.log_selected(best)
             finally:
-                self._finalize_autotune_metrics()
+                self._finalize_autotune_metrics(best)
+        assert best is not None
         end = time.perf_counter()
         kernel_decorator = self.kernel.format_kernel_decorator(best, self.settings)
 
@@ -704,9 +752,17 @@ class BaseSearch(BaseAutotuner):
     def set_generation(self, generation: int) -> None:
         self._autotune_metrics.num_generations = generation
 
-    def _finalize_autotune_metrics(self) -> None:
+    def _finalize_autotune_metrics(self, best_config: Config | None = None) -> None:
+        best_perf = self.best_perf_so_far
+        if self.performance_unit == "ratio":
+            best_perf = (
+                self.benchmark_provider.raw_latency(best_config)
+                if best_config is not None
+                and isinstance(self.benchmark_provider, MultiShapeBenchmarkProvider)
+                else inf
+            )
         self._autotune_metrics.best_perf_ms = (
-            self.best_perf_so_far if math.isfinite(self.best_perf_so_far) else 0.0
+            best_perf if math.isfinite(best_perf) else 0.0
         )
         self._autotune_metrics.finalize()
         _run_post_autotune_hooks(self._autotune_metrics)
@@ -1323,7 +1379,8 @@ class PopulationBasedSearch(BaseSearch):
         if after.config != before.config:
             self.log(
                 "Final verification selected a different config: "
-                f"{before.perf:.4f}ms -> {after.perf:.4f}ms"
+                f"{self.format_performance(before.perf)} -> "
+                f"{self.format_performance(after.perf)}"
             )
         return after
 
@@ -1375,6 +1432,17 @@ class PopulationBasedSearch(BaseSearch):
             desc: Description for the progress bar.
         """
         if len(members) < 2:
+            return
+        if isinstance(self.benchmark_provider, MultiShapeBenchmarkProvider):
+            provider_timings = self.benchmark_provider.rebenchmark(
+                [member.config for member in members],
+                [member.perf for member in members],
+                desc=desc,
+            )
+            for member, timing in zip(members, provider_timings, strict=True):
+                member.perfs.append(timing)
+                if timing < self.best_perf_so_far:
+                    self.best_perf_so_far = timing
             return
 
         # Size the in-process repeat from the candidates being rechecked. A
@@ -1616,8 +1684,10 @@ class PopulationBasedSearch(BaseSearch):
                 delta_pct = (delta / current_perf * 100) if current_perf != 0 else 0
                 status = "ok" if candidate.perf <= current_perf else "worse"
                 self.log.debug(
-                    f"  reset to {candidate.config}: {candidate.perf:.4f}ms "
-                    f"(delta={delta:+.4f}ms, {delta_pct:+.1f}%) [{status}]"
+                    f"  reset to {candidate.config}: "
+                    f"{self.format_performance(candidate.perf)} "
+                    f"(delta={delta:+.4f}{self.performance_suffix}, "
+                    f"{delta_pct:+.1f}%) [{status}]"
                 )
 
             # Collect all single-attribute resets that maintained performance
@@ -1654,7 +1724,8 @@ class PopulationBasedSearch(BaseSearch):
 
             if simplified:
                 self.log(
-                    f"Finishing round {round_num}: simplified to {current.config}, perf={current.perf:.4f}ms"
+                    f"Finishing round {round_num}: simplified to {current.config}, "
+                    f"perf={self.format_performance(current.perf)}"
                 )
             else:
                 self.log(
@@ -1662,8 +1733,13 @@ class PopulationBasedSearch(BaseSearch):
                 )
                 break
 
-        # Minimize the final config by removing values that match defaults
-        minimal_config = current.config.minimize(self.config_spec)
+        # Multi-shape winners must stay explicit: minimizing can collapse an
+        # optional tuned reset and a compiler-promoted default to the same key.
+        minimal_config = (
+            current.config
+            if isinstance(self.args, _MultiShapeAutotuneArgs)
+            else current.config.minimize(self.config_spec)
+        )
         current = PopulationMember(
             fn=current.fn,
             perfs=current.perfs,
@@ -1734,7 +1810,7 @@ class PopulationBasedSearch(BaseSearch):
         if best_member is not best:
             self.log(
                 f"Final-pick re-picked {best_member.config} "
-                f"({best_member.perf:.4f}ms) over {best.config}"
+                f"({self.format_performance(best_member.perf)}) over {best.config}"
             )
         self.best_perf_so_far = min(self.best_perf_so_far, best_member.perf)
         return best_member
@@ -1765,7 +1841,15 @@ class PopulationBasedSearch(BaseSearch):
         # real searches always have them.
         settings = getattr(self, "settings", None)
         config_spec = getattr(self, "config_spec", None)
-        if settings is None or config_spec is None or not settings.static_shapes:
+        if (
+            isinstance(
+                getattr(self, "benchmark_provider", None),
+                MultiShapeBenchmarkProvider,
+            )
+            or settings is None
+            or config_spec is None
+            or not settings.static_shapes
+        ):
             return None
         return config_spec.backend.get_paired_device_micros_bench()
 

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -478,6 +478,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._autotune_metrics = autotune_metrics
         self._accuracy_failure_config_ids: list[int] = []
         self._compile_failure_config_ids: list[int] = []
+        self._worker_failure_config_ids: list[int] = []
         self._precompile_tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._precompile_args_path: str | None = None
         self._precompile_baseline_path: str | None = None
@@ -509,6 +510,15 @@ class LocalBenchmarkProvider(BenchmarkProvider):
     def _record_compile_failure(self, config: Config) -> None:
         self._autotune_metrics.num_compile_failures += 1
         self._compile_failure_config_ids.append(id(config))
+
+    def _record_worker_failure(
+        self,
+        config: Config,
+        status: Literal["error", "timeout"],
+    ) -> None:
+        self._last_benchmark_failure_status = status
+        self._autotune_metrics.num_worker_failures += 1
+        self._worker_failure_config_ids.append(id(config))
 
     def _compute_baseline(
         self,
@@ -1249,10 +1259,10 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         except BenchmarkSubprocessError as e:
             # Timeout or unexpected worker exit; skip config and continue.
             self.log.warning(f"Benchmark subprocess failed for {config!r}: {e}")
-            self._last_benchmark_failure_status = (
-                "timeout" if isinstance(e, BenchmarkTimeout) else "error"
+            self._record_worker_failure(
+                config,
+                "timeout" if isinstance(e, BenchmarkTimeout) else "error",
             )
-            self._autotune_metrics.num_worker_failures += 1
             return inf
         except Exception as e:
             e.__traceback__ = None
@@ -1281,10 +1291,10 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 self.log.warning(
                     f"Accuracy check subprocess failed for {config!r}: {e}"
                 )
-                self._last_benchmark_failure_status = (
-                    "timeout" if isinstance(e, BenchmarkTimeout) else "error"
+                self._record_worker_failure(
+                    config,
+                    "timeout" if isinstance(e, BenchmarkTimeout) else "error",
                 )
-                self._autotune_metrics.num_worker_failures += 1
                 return inf
             except Exception as e:
                 e.__traceback__ = None
@@ -1656,6 +1666,7 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
             (
                 len(child._accuracy_failure_config_ids),
                 len(child._compile_failure_config_ids),
+                len(child._worker_failure_config_ids),
             )
             for child in self.children
         ]
@@ -1671,7 +1682,8 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
         if record_results:
             accuracy_failure_ids: set[int] = set()
             compile_failure_ids: set[int] = set()
-            for child, (before_accuracy, before_compile) in zip(
+            worker_failure_ids: set[int] = set()
+            for child, (before_accuracy, before_compile, before_worker) in zip(
                 self.children, child_failure_snapshots, strict=True
             ):
                 accuracy_failure_ids.update(
@@ -1680,8 +1692,12 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
                 compile_failure_ids.update(
                     child._compile_failure_config_ids[before_compile:]
                 )
+                worker_failure_ids.update(
+                    child._worker_failure_config_ids[before_worker:]
+                )
             self._autotune_metrics.num_accuracy_failures += len(accuracy_failure_ids)
             self._autotune_metrics.num_compile_failures += len(compile_failure_ids)
+            self._autotune_metrics.num_worker_failures += len(worker_failure_ids)
         for child_config_index, config_index in enumerate(valid_indices):
             original = configs[config_index]
             row = [child[child_config_index] for child in child_results]

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import copy
+import dataclasses
 import datetime
 import functools
 from itertools import count
@@ -71,6 +72,153 @@ if TYPE_CHECKING:
     from .base_search import _AutotunableKernel
     from .logger import AutotuningLogger
     from .metrics import AutotuneMetrics
+
+
+MultiShapeAggregation = Literal["geomean", "max"]
+MultiShapeReference = Literal["default", "baseline"] | None
+
+
+@dataclasses.dataclass
+class _MultiShapeAutotuneArgs:
+    """Private carrier that keeps existing autotuners anchored to one args tuple."""
+
+    cases: tuple[tuple[BoundKernel, tuple[object, ...]], ...]
+    aggregation: MultiShapeAggregation
+    relative_to: MultiShapeReference
+    cache_tag: str | None
+    workload_key: tuple[object, ...]
+    reference_latencies: tuple[float, ...] | None = None
+    measurements: dict[str, tuple[tuple[float, ...], float, tuple[str, ...]]] = (
+        dataclasses.field(default_factory=dict)
+    )
+    defer_selected_log: bool = False
+    search_started: bool = False
+    found_valid_config: bool = False
+
+    def __len__(self) -> int:
+        return len(self.cases[0][1])
+
+    def __getitem__(self, index: int | slice) -> object:
+        return self.cases[0][1][index]
+
+
+def _aggregate_values(
+    values: Sequence[float], aggregation: MultiShapeAggregation
+) -> float:
+    if not values or any(not math.isfinite(value) or value <= 0 for value in values):
+        return inf
+    if aggregation == "max":
+        return max(values)
+    return math.exp(math.fsum(math.log(value) for value in values) / len(values))
+
+
+def _aggregate_multi_shape_timings(
+    timings: Sequence[float],
+    *,
+    aggregation: MultiShapeAggregation,
+    references: Sequence[float] | None,
+) -> float:
+    """Reduce per-shape timings to the scalar objective used by searches."""
+    raw = _aggregate_values(timings, aggregation)
+    if references is None or not math.isfinite(raw):
+        return raw
+    if len(timings) != len(references) or not math.isfinite(
+        _aggregate_values(references, aggregation)
+    ):
+        return inf
+    ratios = [
+        timing / reference
+        for timing, reference in zip(timings, references, strict=True)
+    ]
+    return _aggregate_values(ratios, aggregation)
+
+
+def _format_multi_shape_measurement(
+    args: _MultiShapeAutotuneArgs,
+    config: Config,
+    timings: Sequence[float],
+    aggregate: float,
+    *,
+    selected: bool,
+    statuses: Sequence[str] | None = None,
+) -> str:
+    """Format one joint result with enough detail to explain its objective."""
+    references = args.reference_latencies
+    rows = []
+    for index, ((_, case_args), timing) in enumerate(
+        zip(args.cases, timings, strict=True)
+    ):
+        leaves, _ = tree_flatten(case_args)
+        tensor_shapes = [
+            tuple(value.shape) for value in leaves if torch.is_tensor(value)
+        ]
+        shape_text = f" tensor_shapes={tensor_shapes}" if tensor_shapes else ""
+        status = statuses[index] if statuses is not None else "ok"
+        if status != "ok" or not math.isfinite(timing) or timing <= 0:
+            row = f"arg_sets[{index}]{shape_text}: status={status}"
+            if math.isfinite(timing):
+                row += f", latency={timing:.6f} ms"
+        else:
+            row = f"arg_sets[{index}]{shape_text}: latency={timing:.6f} ms"
+        if (
+            references is not None
+            and status == "ok"
+            and math.isfinite(timing)
+            and timing > 0
+        ):
+            reference = references[index]
+            row += (
+                f", {args.relative_to} reference={reference:.6f} ms"
+                f", ratio={timing / reference:.6f}x"
+            )
+        rows.append(row)
+
+    if not math.isfinite(aggregate):
+        objective = "rejected"
+    elif references is None:
+        objective = f"{args.aggregation}(latencies)={aggregate:.6f} ms"
+    else:
+        objective = (
+            f"{args.aggregation}(latency ratios vs {args.relative_to})={aggregate:.6f}x"
+        )
+    if selected:
+        details = "\n  ".join([*rows, f"objective: {objective}"])
+        return f"Selected multi-shape config {config}:\n  {details}"
+    return f"Multi-shape candidate {config}: {'; '.join([*rows, f'objective: {objective}'])}"
+
+
+def _format_selected_multi_shape_measurement(
+    args: _MultiShapeAutotuneArgs, config: Config
+) -> str | None:
+    measurement = args.measurements.get(repr(config))
+    if measurement is None:
+        return None
+    timings, aggregate, statuses = measurement
+    return _format_multi_shape_measurement(
+        args,
+        config,
+        timings,
+        aggregate,
+        selected=True,
+        statuses=statuses,
+    )
+
+
+def _materialize_multi_shape_config(config_spec: ConfigSpec, config: Config) -> Config:
+    """Normalize a detached config against the anchor shape."""
+    result = copy.deepcopy(config)
+    config_spec.normalize(result)
+    return result
+
+
+def _has_valid_multi_shape_measurement(
+    args: _MultiShapeAutotuneArgs,
+    config_spec: ConfigSpec,
+    config: Config,
+) -> bool:
+    materialized = _materialize_multi_shape_config(config_spec, config)
+    measurement = args.measurements.get(repr(materialized))
+    return measurement is not None and math.isfinite(measurement[1])
 
 
 def _clone_args(
@@ -318,12 +466,18 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         log: AutotuningLogger,
         autotune_metrics: AutotuneMetrics,
     ) -> None:
+        if isinstance(args, _MultiShapeAutotuneArgs):
+            raise TypeError(
+                "LocalBenchmarkProvider cannot benchmark multi-shape args directly"
+            )
         self.kernel = kernel
         self.settings = settings
         self.config_spec = config_spec
         self.args = args
         self.log = log
         self._autotune_metrics = autotune_metrics
+        self._accuracy_failure_config_ids: list[int] = []
+        self._compile_failure_config_ids: list[int] = []
         self._precompile_tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._precompile_args_path: str | None = None
         self._precompile_baseline_path: str | None = None
@@ -347,6 +501,14 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             self._compute_effective_tolerances()
         )
         self._jobs = self._decide_num_jobs()
+
+    def _record_accuracy_failure(self, config: Config) -> None:
+        self._autotune_metrics.num_accuracy_failures += 1
+        self._accuracy_failure_config_ids.append(id(config))
+
+    def _record_compile_failure(self, config: Config) -> None:
+        self._autotune_metrics.num_compile_failures += 1
+        self._compile_failure_config_ids.append(id(config))
 
     def _compute_baseline(
         self,
@@ -959,7 +1121,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 or self._validate_against_baseline(config, output, working_args)
             )
             if not pass_accuracy_check:
-                self._autotune_metrics.num_accuracy_failures += 1
+                self._record_accuracy_failure(config)
             if not all(
                 all_gather_object(
                     pass_accuracy_check,
@@ -1067,7 +1229,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 self.log.debug(f"Benchmarking failed: {type(e).__name__}: {e}")
                 self.kernel.maybe_log_repro(self.log.debug, self.args, config)
 
-            self._autotune_metrics.num_compile_failures += 1
+            self._record_compile_failure(config)
             return inf
         finally:
             self._clear_jit_fast_path_caches(fn)
@@ -1104,12 +1266,12 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     f"{type(e).__qualname__}: {e}\n  Config: {decorator}"
                 )
                 self.kernel.maybe_log_repro(self.log.warning, self.args, config)
-                self._autotune_metrics.num_compile_failures += 1
+                self._record_compile_failure(config)
                 return inf
             self.log.debug(
                 f"Benchmark subprocess raised for {config!r}: {type(e).__name__}: {e}"
             )
-            self._autotune_metrics.num_compile_failures += 1
+            self._record_compile_failure(config)
             return inf
 
         if self.settings.autotune_accuracy_check:
@@ -1138,13 +1300,13 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                         f"{type(e).__qualname__}: {e}\n  Config: {decorator}"
                     )
                     self.kernel.maybe_log_repro(self.log.warning, self.args, config)
-                    self._autotune_metrics.num_compile_failures += 1
+                    self._record_compile_failure(config)
                     return inf
                 self.log.debug(
                     f"Accuracy check subprocess raised for {config!r}: "
                     f"{type(e).__name__}: {e}"
                 )
-                self._autotune_metrics.num_compile_failures += 1
+                self._record_compile_failure(config)
                 return inf
 
             if accuracy_result is not None:
@@ -1155,7 +1317,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                             f"{accuracy_result.message}\n"
                             "Use HELION_AUTOTUNE_ACCURACY_CHECK=0 to disable this check.\n"
                         )
-                    self._autotune_metrics.num_accuracy_failures += 1
+                    self._record_accuracy_failure(config)
                     return inf
                 return float(latency)
 
@@ -1166,7 +1328,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     output = fn(*self.args)
                     synchronize_device()
                 if not self._validate_against_baseline(config, output, self.args):
-                    self._autotune_metrics.num_accuracy_failures += 1
+                    self._record_accuracy_failure(config)
                     return inf
             except Exception as e:
                 e.__traceback__ = None
@@ -1184,7 +1346,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 self.log.debug(
                     f"Accuracy check raised for {config!r}: {type(e).__name__}: {e}"
                 )
-                self._autotune_metrics.num_compile_failures += 1
+                self._record_compile_failure(config)
                 return inf
             finally:
                 # Same as the in-process path: drop JIT fast-path caches so
@@ -1291,3 +1453,412 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     timing = None
             timings.append(None if timing is None else float(timing))
         return timings
+
+
+class MultiShapeBenchmarkProvider(BenchmarkProvider):
+    """Compose ordinary local providers and expose one scalar per config."""
+
+    mutated_arg_indices: Sequence[int] = ()
+
+    def __init__(
+        self,
+        kernel: _AutotunableKernel,
+        settings: Settings,
+        config_spec: ConfigSpec,
+        args: Sequence[object],
+        log: AutotuningLogger,
+        autotune_metrics: AutotuneMetrics,
+    ) -> None:
+        if not isinstance(args, _MultiShapeAutotuneArgs):
+            raise TypeError("MultiShapeBenchmarkProvider requires multi-shape args")
+        from .metrics import AutotuneMetrics
+
+        self.kernel = kernel
+        self.settings = settings
+        self.config_spec = config_spec
+        self.args = args
+        self.log = log
+        self._autotune_metrics = autotune_metrics
+        self.args.search_started = True
+        self.children: list[LocalBenchmarkProvider] = []
+        child_log = copy.copy(log)
+        child_log._log_sink = None
+        case_index = 0
+        try:
+            for index, (case_kernel, case_args) in enumerate(args.cases):
+                case_index = index
+                child = LocalBenchmarkProvider(
+                    kernel=case_kernel,
+                    settings=case_kernel.settings,
+                    config_spec=case_kernel.config_spec,
+                    args=case_args,
+                    # Child rows are implementation details, so only their text logs
+                    # are forwarded to the aggregate logger.
+                    log=child_log,
+                    autotune_metrics=AutotuneMetrics(),
+                )
+                child.set_budget_exceeded_fn(_never_exceeded)
+                self.children.append(child)
+        except Exception as error:
+            for child in reversed(self.children):
+                child.cleanup()
+            if f"arg_sets[{case_index}]" in str(error):
+                raise
+            raise exc.AutotuneError(
+                "Failed to prepare multi-shape autotune "
+                f"arg_sets[{case_index}]: {error}"
+            ) from error
+
+    def set_budget_exceeded_fn(self, fn: Callable[[], bool]) -> None:
+        self.budget_exceeded_fn = fn
+        for child in self.children:
+            child.set_budget_exceeded_fn(_never_exceeded)
+
+    def setup(self) -> None:
+        case_index = 0
+        try:
+            for index, child in enumerate(self.children):
+                case_index = index
+                child.setup()
+            if (
+                self.args.relative_to is not None
+                and self.args.reference_latencies is None
+            ):
+                reference_values = []
+                for case_index, child in enumerate(self.children):
+                    reference_values.append(self._measure_reference(child, case_index))
+                references = tuple(reference_values)
+                if _aggregate_values(references, self.args.aggregation) == inf:
+                    raise exc.AutotuneError(
+                        "Multi-shape reference timings must be finite and positive"
+                    )
+                self.args.reference_latencies = references
+        except Exception as error:
+            for child in reversed(self.children):
+                child.cleanup()
+            if f"arg_sets[{case_index}]" in str(error):
+                raise
+            raise exc.AutotuneError(
+                f"Failed to set up multi-shape autotune arg_sets[{case_index}]: {error}"
+            ) from error
+
+    def cleanup(self) -> None:
+        for child in reversed(self.children):
+            child.cleanup()
+        self.budget_exceeded_fn = _never_exceeded
+
+    def _measure_reference(
+        self, child: LocalBenchmarkProvider, case_index: int
+    ) -> float:
+        if self.args.relative_to == "default":
+            result = child.benchmark(
+                [child.config_spec.default_config()],
+                desc="Benchmarking default reference",
+            )[0]
+            if (
+                result.status != "ok"
+                or not math.isfinite(result.perf)
+                or result.perf <= 0
+            ):
+                raise exc.AutotuneError(
+                    "Default config reference benchmark failed for "
+                    f"arg_sets[{case_index}]"
+                )
+            return result.perf
+        baseline_fn = child.settings.autotune_baseline_fn
+        if baseline_fn is None:
+            raise exc.AutotuneError(
+                "relative_to='baseline' requires autotune_baseline_fn for "
+                f"arg_sets[{case_index}]"
+            )
+        if child.mutated_arg_indices:
+            reference_args = _clone_args(
+                child.args,
+                child.kernel.env.process_group_name,
+                idx_to_clone=child.mutated_arg_indices,
+            )
+        else:
+            reference_args = child.args
+        backend = getattr(child.config_spec, "backend", None)
+        benchmark_runner = (
+            backend.get_do_bench() if backend is not None else None
+        ) or do_bench
+        try:
+            timing = benchmark_runner(
+                functools.partial(baseline_fn, *reference_args),
+                return_mode="median",
+                warmup=1,
+                rep=50,
+                process_group_name=child.kernel.env.process_group_name,
+            )
+        except Exception as error:
+            raise exc.AutotuneError(
+                f"Baseline reference benchmark failed for arg_sets[{case_index}]"
+            ) from error
+        if isinstance(timing, tuple):
+            timing = timing[0]
+        timing = float(timing)
+        if not math.isfinite(timing) or timing <= 0:
+            raise exc.AutotuneError(
+                "Baseline reference benchmark returned invalid timing "
+                f"{timing!r} for arg_sets[{case_index}]"
+            )
+        return timing
+
+    def benchmark(
+        self,
+        configs: list[Config],
+        *,
+        desc: str = "Benchmarking",
+    ) -> list[BenchmarkResult]:
+        return self._benchmark(configs, desc=desc, record_results=True)
+
+    def _benchmark(
+        self,
+        configs: list[Config],
+        *,
+        desc: str,
+        record_results: bool,
+        check_budget: bool = True,
+    ) -> list[BenchmarkResult]:
+        if not configs:
+            return []
+        if check_budget and self.budget_exceeded_fn():
+            return [
+                BenchmarkResult(config, _unset_fn, inf, "error", None)
+                for config in configs
+            ]
+
+        materialized: list[Config] = []
+        valid_indices: list[int] = []
+        results = [
+            BenchmarkResult(config, _unset_fn, inf, "error", None) for config in configs
+        ]
+        for config_index, config in enumerate(configs):
+            try:
+                materialized.append(
+                    _materialize_multi_shape_config(self.config_spec, config)
+                )
+            except exc.InvalidConfig as error:
+                self.log.debug(
+                    f"Skipping config that is invalid for the anchor shape: {error}"
+                )
+                if record_results:
+                    self._record_aggregate_result(config, results[config_index])
+            else:
+                valid_indices.append(config_index)
+        if not materialized:
+            return results
+        materialized_keys = [repr(config) for config in materialized]
+        executed_configs = [copy.deepcopy(config) for config in materialized]
+
+        child_failure_snapshots = [
+            (
+                len(child._accuracy_failure_config_ids),
+                len(child._compile_failure_config_ids),
+            )
+            for child in self.children
+        ]
+        child_results = [
+            self._benchmark_child(
+                child,
+                materialized,
+                desc=f"{desc} shape {index + 1}",
+                case_index=index,
+            )
+            for index, child in enumerate(self.children)
+        ]
+        if record_results:
+            accuracy_failure_ids: set[int] = set()
+            compile_failure_ids: set[int] = set()
+            for child, (before_accuracy, before_compile) in zip(
+                self.children, child_failure_snapshots, strict=True
+            ):
+                accuracy_failure_ids.update(
+                    child._accuracy_failure_config_ids[before_accuracy:]
+                )
+                compile_failure_ids.update(
+                    child._compile_failure_config_ids[before_compile:]
+                )
+            self._autotune_metrics.num_accuracy_failures += len(accuracy_failure_ids)
+            self._autotune_metrics.num_compile_failures += len(compile_failure_ids)
+        for child_config_index, config_index in enumerate(valid_indices):
+            original = configs[config_index]
+            row = [child[child_config_index] for child in child_results]
+            timings = [result.perf for result in row]
+            valid = all(
+                result.status == "ok" and math.isfinite(result.perf) and result.perf > 0
+                for result in row
+            )
+            perf = (
+                _aggregate_multi_shape_timings(
+                    timings,
+                    aggregation=self.args.aggregation,
+                    references=self.args.reference_latencies,
+                )
+                if valid
+                else inf
+            )
+            if valid:
+                timing_tuple = tuple(timings)
+                statuses = tuple(result.status for result in row)
+                self.args.measurements[materialized_keys[child_config_index]] = (
+                    timing_tuple,
+                    perf,
+                    statuses,
+                )
+                self.log.debug(
+                    lambda config=original, values=timing_tuple, objective=perf: (
+                        _format_multi_shape_measurement(
+                            self.args,
+                            config,
+                            values,
+                            objective,
+                            selected=False,
+                        )
+                    )
+                )
+            else:
+                statuses = tuple(result.status for result in row)
+                timing_tuple = tuple(timings)
+                measurement_key = materialized_keys[child_config_index]
+                self.args.measurements[measurement_key] = (
+                    timing_tuple,
+                    inf,
+                    statuses,
+                )
+                self.log.debug(
+                    lambda config=original, values=timing_tuple, states=statuses: (
+                        _format_multi_shape_measurement(
+                            self.args,
+                            config,
+                            values,
+                            inf,
+                            selected=False,
+                            statuses=states,
+                        )
+                    )
+                )
+            timed_out = any(result.status == "timeout" for result in row)
+            if timed_out:
+                status: Literal["ok", "error", "timeout"] = "timeout"
+            else:
+                status = "ok" if math.isfinite(perf) else "error"
+            compile_times = [
+                result.compile_time for result in row if result.compile_time is not None
+            ]
+            compile_time = max(compile_times, default=None)
+            anchor_fn = row[0].fn
+            result = BenchmarkResult(
+                config=original,
+                fn=anchor_fn,
+                perf=perf,
+                status=status,
+                compile_time=compile_time,
+            )
+            results[config_index] = result
+            if math.isfinite(perf):
+                self.args.found_valid_config = True
+            if record_results:
+                self._record_aggregate_result(
+                    executed_configs[child_config_index],
+                    result,
+                    timings=timings,
+                )
+        return results
+
+    def _benchmark_child(
+        self,
+        child: LocalBenchmarkProvider,
+        configs: list[Config],
+        *,
+        desc: str,
+        case_index: int,
+    ) -> list[BenchmarkResult]:
+        try:
+            return child.benchmark(configs, desc=desc)
+        except Exception as error:
+            if not self._is_skippable_child_failure(child, error):
+                raise
+            self.log.debug(
+                "Skipping all configs for "
+                f"arg_sets[{case_index}] after {type(error).__name__}: {error}"
+            )
+            return [
+                BenchmarkResult(config, _unset_fn, inf, "error", None)
+                for config in configs
+            ]
+
+    @staticmethod
+    def _is_skippable_child_failure(
+        child: LocalBenchmarkProvider, error: Exception
+    ) -> bool:
+        if match_unrecoverable_runtime_error(error):
+            return False
+        if isinstance(error, exc.InvalidConfig):
+            return True
+        backend = getattr(child.config_spec, "backend", None)
+        action = (
+            backend.classify_autotune_exception(error) if backend is not None else None
+        ) or classify_triton_exception(error)
+        return child.settings.autotune_ignore_errors or action == "debug"
+
+    def _record_aggregate_result(
+        self,
+        config: Config,
+        result: BenchmarkResult,
+        *,
+        timings: Sequence[float] | None = None,
+    ) -> None:
+        self._autotune_metrics.num_configs_tested += 1
+        config_id = self.log.register_config(config)
+        if config_id is None:
+            return
+        self.log.record_autotune_entry(
+            AutotuneLogEntry(
+                generation=self._autotune_metrics.num_generations,
+                status=result.status,
+                perf_ms=(
+                    _aggregate_values(timings, self.args.aggregation)
+                    if timings is not None and math.isfinite(result.perf)
+                    else None
+                ),
+                compile_time=result.compile_time,
+                config_id=config_id,
+                config=config,
+            )
+        )
+
+    def raw_latency(self, config: Config) -> float:
+        materialized = _materialize_multi_shape_config(self.config_spec, config)
+        measurement = self.args.measurements.get(repr(materialized))
+        if measurement is None:
+            return inf
+        timings, _, _ = measurement
+        return _aggregate_values(timings, self.args.aggregation)
+
+    def has_valid_measurement(self, config: Config) -> bool:
+        return _has_valid_multi_shape_measurement(self.args, self.config_spec, config)
+
+    def log_selected(self, config: Config) -> None:
+        materialized = _materialize_multi_shape_config(self.config_spec, config)
+        summary = _format_selected_multi_shape_measurement(self.args, materialized)
+        if summary is not None:
+            self.log(summary)
+
+    def rebenchmark(
+        self,
+        configs: list[Config],
+        previous_timings: list[float],
+        *,
+        desc: str,
+    ) -> list[float]:
+        if self.budget_exceeded_fn():
+            return list(previous_timings)
+        results = self._benchmark(
+            configs,
+            desc=desc,
+            record_results=False,
+            check_budget=False,
+        )
+        return [result.perf for result in results]

--- a/helion/autotuner/de_surrogate_hybrid.py
+++ b/helion/autotuner/de_surrogate_hybrid.py
@@ -187,7 +187,7 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
 
         best = self.best
         self.log("=" * 70)
-        self.log(f"✓ Best configuration: {best.perf:.4f} ms")
+        self.log(f"✓ Best configuration: {self.format_performance(best.perf)}")
         self.log(f"Total evaluations: {len(self.all_observations)}")
         self.log("=" * 70)
 
@@ -235,7 +235,8 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
         surrogate_status = "SURROGATE" if use_surrogate else "STANDARD"
         self.log(
             f"Gen {generation}: {surrogate_status} | "
-            f"best={best_perf:.4f} ms | replaced={replacements}/{self.population_size} | "
+            f"best={self.format_performance(best_perf)} | "
+            f"replaced={replacements}/{self.population_size} | "
             f"total_evals={len(self.all_observations)}"
         )
 

--- a/helion/autotuner/finite_search.py
+++ b/helion/autotuner/finite_search.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from .. import exc
 from .base_search import BaseSearch
+from .benchmark_provider import _MultiShapeAutotuneArgs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -45,6 +46,8 @@ class FiniteSearch(BaseSearch):
             if result.perf < best_time:
                 best_time = result.perf
                 best_config = result.config
+        if best_config is None and isinstance(self.args, _MultiShapeAutotuneArgs):
+            raise exc.NoConfigFound
         assert best_config is not None
         return best_config
 

--- a/helion/autotuner/llm/feedback.py
+++ b/helion/autotuner/llm/feedback.py
@@ -18,6 +18,11 @@ MAX_ANCHORS_IN_PROMPT = 2
 MAX_CHANGED_FIELDS_PER_CONFIG = 6
 
 
+def _format_performance(perf: float, performance_unit: str) -> str:
+    suffix = " ms" if performance_unit == "ms" else "x"
+    return f"{perf:.4f}{suffix}"
+
+
 def format_config_for_prompt(cfg: Config | dict[str, object]) -> str:
     """Serialize a config exactly as it should appear in prompt examples."""
     return json.dumps(dict(cfg), sort_keys=True, separators=(",", ":"))
@@ -70,6 +75,7 @@ def format_results_for_llm(
     default_config_dict: dict[str, object],
     *,
     limit: int = MAX_RESULTS_IN_PROMPT,
+    performance_unit: str = "ms",
 ) -> str:
     """Format successful and failed benchmark results into a compact block."""
     if not results:
@@ -81,7 +87,7 @@ def format_results_for_llm(
     lines: list[str] = []
     for index, (cfg, perf) in enumerate(sorted_results[:limit], start=1):
         lines.append(
-            f"  #{index}: {perf:.4f} ms — "
+            f"  #{index}: {_format_performance(perf, performance_unit)} — "
             f"{format_config_diff(default_config_dict, cfg)}"
         )
     if failed_count > 0:
@@ -92,6 +98,8 @@ def format_results_for_llm(
 def summarize_search_state_for_llm(
     results: list[BenchmarkResult],
     default_config_dict: dict[str, object],
+    *,
+    performance_unit: str = "ms",
 ) -> str:
     """Summarize the current best result, coverage, and failure counts."""
     finite = finite_results(results)
@@ -101,7 +109,7 @@ def summarize_search_state_for_llm(
     best_cfg, best_perf = finite[0]
     lines = [
         (
-            f"  Best so far: {best_perf:.4f} ms — "
+            f"  Best so far: {_format_performance(best_perf, performance_unit)} — "
             f"{format_config_diff(default_config_dict, best_cfg)}"
         )
     ]
@@ -155,6 +163,7 @@ def summarize_anchor_configs_for_llm(
     default_config_dict: dict[str, object],
     *,
     limit: int = MAX_ANCHORS_IN_PROMPT,
+    performance_unit: str = "ms",
 ) -> str:
     """Show the strongest current configs that the next round should refine."""
     finite = finite_results(results)
@@ -170,7 +179,8 @@ def summarize_anchor_configs_for_llm(
             gap_pct = ((perf - best_perf) / best_perf) * 100
             delta = f"+{gap_pct:.1f}%"
         lines.append(
-            f"  Anchor {index} ({delta}): {perf:.4f} ms — "
+            f"  Anchor {index} ({delta}): "
+            f"{_format_performance(perf, performance_unit)} — "
             f"{format_config_diff(default_config_dict, cfg)}"
         )
     return "\n".join(lines)

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -261,14 +261,17 @@ class LLMGuidedSearch(PopulationBasedSearch):
             search_state=summarize_search_state_for_llm(
                 self._all_benchmark_results,
                 self._default_config_dict,
+                performance_unit=self.performance_unit,
             ),
             anchor_configs=summarize_anchor_configs_for_llm(
                 self._all_benchmark_results,
                 self._default_config_dict,
+                performance_unit=self.performance_unit,
             ),
             results=format_results_for_llm(
                 self._all_benchmark_results,
                 self._default_config_dict,
+                performance_unit=self.performance_unit,
             ),
             top_patterns=analyze_top_configs(
                 self._all_benchmark_results,

--- a/helion/autotuner/llm_seeded_lfbo.py
+++ b/helion/autotuner/llm_seeded_lfbo.py
@@ -22,8 +22,10 @@ import time
 from typing import TYPE_CHECKING
 from typing import cast
 
+from .. import exc
 from .base_search import BaseSearch
 from .base_search import PopulationBasedSearch
+from .benchmark_provider import _MultiShapeAutotuneArgs
 from .effort_profile import QUICK_LLM_SEARCH_DEFAULTS
 from .llm.transport import DEFAULT_REQUEST_TIMEOUT_S
 from .llm_search import LLMGuidedSearch
@@ -284,7 +286,16 @@ class LLMSeededSearch(BaseSearch):
         )
         llm_search = self._make_llm_search()
         llm_start = time.perf_counter()
-        llm_seed_config = llm_search.autotune(skip_cache=True)
+        try:
+            llm_seed_config = llm_search.autotune(skip_cache=True)
+        except exc.NoConfigFound:
+            if not isinstance(self.args, _MultiShapeAutotuneArgs):
+                raise
+            llm_seed_config = None
+        if isinstance(self.args, _MultiShapeAutotuneArgs) and not math.isfinite(
+            llm_search.best_perf_so_far
+        ):
+            llm_seed_config = None
         llm_wall_time = time.perf_counter() - llm_start
         return llm_search, llm_seed_config, llm_wall_time
 
@@ -292,7 +303,7 @@ class LLMSeededSearch(BaseSearch):
         self,
         llm_seed_config: Config | None,
         llm_search: LLMGuidedSearch | None = None,
-    ) -> tuple[BaseSearch, Config, float]:
+    ) -> tuple[BaseSearch, Config | None, float]:
         """Run stage 2, optionally seeded from the stage-1 best config."""
         seeded = llm_seed_config is not None
         self.log(
@@ -309,7 +320,16 @@ class LLMSeededSearch(BaseSearch):
                 second_stage_search, llm_seed_config, llm_search
             )
         second_stage_start = time.perf_counter()
-        best_config = second_stage_search.autotune()
+        try:
+            best_config = second_stage_search.autotune()
+        except exc.NoConfigFound:
+            if not isinstance(self.args, _MultiShapeAutotuneArgs):
+                raise
+            best_config = None
+        if isinstance(self.args, _MultiShapeAutotuneArgs) and not math.isfinite(
+            second_stage_search.best_perf_so_far
+        ):
+            best_config = None
         second_stage_wall_time = time.perf_counter() - second_stage_start
         return second_stage_search, best_config, second_stage_wall_time
 
@@ -326,10 +346,15 @@ class LLMSeededSearch(BaseSearch):
         llm_metrics = llm_search._autotune_metrics if llm_search else None
         second_stage_metrics = second_stage_search._autotune_metrics
         second_stage_tested = second_stage_metrics.num_configs_tested
+        llm_perf = self._finite_perf(llm_search)
+        second_stage_perf = self._finite_perf(second_stage_search)
+        performance_unit = self.performance_unit
 
         self.hybrid_stage_breakdown = {
-            "used_llm_seed": llm_search is not None,
-            "llm_seed_perf_ms": self._finite_perf(llm_search),
+            "used_llm_seed": llm_seed_config is not None,
+            "objective_unit": performance_unit,
+            "llm_seed_objective": llm_perf,
+            "llm_seed_perf_ms": llm_perf if performance_unit == "ms" else None,
             "llm_seed_time_s": llm_wall_time,
             "llm_seed_configs_tested": (
                 llm_metrics.num_configs_tested if llm_metrics else 0
@@ -338,7 +363,10 @@ class LLMSeededSearch(BaseSearch):
                 dict(llm_seed_config) if llm_seed_config is not None else None
             ),
             "second_stage_algorithm": self.second_stage_algorithm,
-            "second_stage_perf_ms": self._finite_perf(second_stage_search),
+            "second_stage_objective": second_stage_perf,
+            "second_stage_perf_ms": (
+                second_stage_perf if performance_unit == "ms" else None
+            ),
             "second_stage_time_s": second_stage_wall_time,
             "second_stage_configs_tested": second_stage_tested,
         }
@@ -383,7 +411,11 @@ class LLMSeededSearch(BaseSearch):
             second_stage_search,
             second_stage_wall_time,
         )
-        return best_config
+        if best_config is not None:
+            return best_config
+        if llm_seed_config is not None:
+            return llm_seed_config
+        raise exc.NoConfigFound
 
 
 class LLMSeededLFBOTreeSearch(LLMSeededSearch):

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -136,15 +136,27 @@ class LocalAutotuneCache(AutotuneCacheBase):
         self.key = self._generate_key()
 
     def _generate_key(self) -> LooseAutotuneCacheKey:
-        in_memory_cache_key = self.kernel.kernel._create_bound_kernel_cache_key(
-            self.kernel,
-            tuple(self.args),
-            self.kernel.kernel._base_specialization_key(self.args),
+        from .benchmark_provider import _MultiShapeAutotuneArgs
+
+        multi_args = (
+            self.args if isinstance(self.args, _MultiShapeAutotuneArgs) else None
         )
+        if multi_args is None:
+            in_memory_cache_key = self.kernel.kernel._create_bound_kernel_cache_key(
+                self.kernel,
+                tuple(self.args),
+                self.kernel.kernel._base_specialization_key(self.args),
+            )
+            specialization_key = in_memory_cache_key.specialization_key
+            extra_results = in_memory_cache_key.extra_results
+            dev = extract_device(self.args)
+        else:
+            specialization_key = multi_args.workload_key
+            extra_results = ()
+            dev = multi_args.cases[0][0].env.device
         kernel_source = textwrap.dedent(inspect.getsource(self.kernel.kernel.fn))
         kernel_source_hash = hashlib.sha256(kernel_source.encode("utf-8")).hexdigest()
 
-        dev = extract_device(self.args)
         assert dev is not None
 
         hardware = get_device_name(dev)
@@ -187,8 +199,8 @@ class LocalAutotuneCache(AutotuneCacheBase):
             advanced_controls_files=self.autotuner.settings.autotune_search_acf or None
         )
         return LooseAutotuneCacheKey(
-            specialization_key=in_memory_cache_key.specialization_key,
-            extra_results=in_memory_cache_key.extra_results,
+            specialization_key=specialization_key,
+            extra_results=extra_results,
             kernel_source_hash=kernel_source_hash,
             hardware=hardware,
             runtime_name=runtime_name,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Sequence
 import contextlib
 import dataclasses
 import functools
@@ -18,7 +19,7 @@ from typing import Any
 from typing import Callable
 from typing import Generic
 from typing import Hashable
-from typing import Sequence
+from typing import Literal
 from typing import TypeVar
 from typing import cast
 from typing import overload
@@ -67,7 +68,6 @@ from .settings import Settings
 
 if TYPE_CHECKING:
     from collections.abc import Hashable
-    from collections.abc import Sequence
 
     from torch._guards import Source
 
@@ -111,6 +111,52 @@ _TPU_COMPILE_CAPTURE = os.environ.get("HELION_TPU_COMPILE_CAPTURE", "0") == "1"
 _graph_module_hash_cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
 
 _INT32_INDEX_LIMIT = torch.iinfo(torch.int32).max
+
+
+def _current_device_index(device_type: str) -> int:
+    device_module = getattr(torch, device_type, None)
+    current_device = getattr(device_module, "current_device", None)
+    if callable(current_device):
+        return cast("int", current_device())
+
+    accelerator = getattr(torch, "accelerator", None)
+    current_accelerator = getattr(accelerator, "current_accelerator", None)
+    current_device_index = getattr(accelerator, "current_device_index", None)
+    if callable(current_accelerator) and callable(current_device_index):
+        accelerator_device = cast("torch.device", current_accelerator())
+        if accelerator_device.type == device_type:
+            return cast("int", current_device_index())
+    raise exc.InvalidAPIUsage(
+        f"autotune_multi requires a current indexed accelerator, got {device_type!r}"
+    )
+
+
+def _canonicalize_multi_shape_device(device: torch.device) -> torch.device:
+    if device.type in ("cpu", "meta", "mps"):
+        raise exc.InvalidAPIUsage(
+            f"autotune_multi requires an indexed accelerator device, got {device}"
+        )
+    if device.index is not None:
+        return device
+    return torch.device(device.type, _current_device_index(device.type))
+
+
+def _has_unspecialized_numeric_value(value: object) -> bool:
+    """Return whether normal specialization records only a numeric value's type."""
+    if isinstance(value, ConstExpr):
+        return False
+    if type(value) in (bool, int, float):
+        return True
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return any(
+            _has_unspecialized_numeric_value(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        )
+    if isinstance(value, dict):
+        return any(_has_unspecialized_numeric_value(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_has_unspecialized_numeric_value(item) for item in value)
+    return False
 
 
 def _resolve_index_dtype(
@@ -505,6 +551,260 @@ class Kernel(Generic[_R]):
         """
         args = self.normalize_args(*args)
         return self.bind(args).autotune(args, force=force, **options)
+
+    def autotune_multi(
+        self,
+        arg_sets: Sequence[Sequence[object]],
+        *,
+        aggregation: Literal["geomean", "max"] = "geomean",
+        relative_to: Literal["default", "baseline"] | None = None,
+        cache_tag: str | None = None,
+        force: bool = True,
+        **options: object,
+    ) -> Config:
+        """Find one config using an objective measured across several inputs.
+
+        The first argument set anchors config generation. Each candidate is measured
+        on every set, then reduced with a geometric mean or maximum. ``relative_to``
+        optionally optimizes per-shape latency relative to each shape's default config
+        or custom baseline. Only the supplied bound specializations are configured.
+
+        Every argument set must bind normally to the same exact, current accelerator
+        device. Distributed processes are not supported. A non-empty ``cache_tag`` is
+        required for custom callbacks, dynamic-shape tuning, and runtime numeric
+        arguments; callers own tag invalidation in those cases.
+
+        Args:
+            arg_sets: Non-empty sequence of representative kernel argument sequences.
+            aggregation: Joint objective, either ``"geomean"`` or ``"max"``.
+            relative_to: Optional ``"default"`` or ``"baseline"`` normalization.
+            cache_tag: User-managed cache discriminator for dynamic shapes, runtime
+                numeric arguments, or callbacks.
+            force: If true, ignore pinned configs and cache reads during the search.
+            options: Additional options forwarded to the registered autotuner.
+
+        Returns:
+            The config selected for all supplied specializations.
+        """
+        from ..autotuner.benchmark_provider import LocalBenchmarkProvider
+        from ..autotuner.benchmark_provider import _has_valid_multi_shape_measurement
+        from ..autotuner.benchmark_provider import _materialize_multi_shape_config
+        from ..autotuner.benchmark_provider import _MultiShapeAutotuneArgs
+        from .settings import default_autotuner_fn
+
+        if aggregation not in ("geomean", "max"):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi aggregation must be 'geomean' or 'max'"
+            )
+        if relative_to not in (None, "default", "baseline"):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi relative_to must be None, 'default', or 'baseline'"
+            )
+        if cache_tag is not None and (not isinstance(cache_tag, str) or not cache_tag):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi cache_tag must be a non-empty string"
+            )
+        if (
+            not isinstance(arg_sets, Sequence)
+            or isinstance(arg_sets, (str, bytes))
+            or not arg_sets
+        ):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi arg_sets must be a non-empty sequence"
+            )
+        if dist.is_initialized():
+            raise exc.InvalidAPIUsage(
+                "autotune_multi does not support an initialized distributed process group"
+            )
+        if self.settings.backend not in {"triton", "tileir", "cute", "pallas"}:
+            raise exc.InvalidAPIUsage(
+                f"autotune_multi does not support backend {self.settings.backend!r}"
+            )
+        if self.settings.autotuner_fn is not default_autotuner_fn:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires the default registered autotuner"
+            )
+        if self.settings.autotune_cache == "AOTAutotuneCache":
+            raise exc.InvalidAPIUsage(
+                "autotune_multi does not support AOTAutotuneCache"
+            )
+        if self.settings.autotune_cache not in {
+            "LocalAutotuneCache",
+            "StrictLocalAutotuneCache",
+            "RemoteAutotuneCache",
+            "StrictRemoteAutotuneCache",
+        }:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires a built-in local or remote best-config cache"
+            )
+        if "benchmark_provider_cls" in options:
+            if options.pop("benchmark_provider_cls") is not LocalBenchmarkProvider:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi does not support a custom benchmark provider"
+                )
+        if relative_to == "baseline" and self.settings.autotune_baseline_fn is None:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi relative_to='baseline' requires autotune_baseline_fn"
+            )
+        if self.settings.autotune_benchmark_fn is not None:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi does not support autotune_benchmark_fn"
+            )
+
+        custom_callbacks = (
+            self.settings.autotune_baseline_fn,
+            self.settings.autotune_baseline_accuracy_check_fn,
+            self.settings.autotune_config_filter,
+        )
+        if cache_tag is None and any(fn is not None for fn in custom_callbacks):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires cache_tag when a custom baseline, "
+                "accuracy check, or config filter is configured"
+            )
+        if cache_tag is None and not self.settings.static_shapes:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires cache_tag when static_shapes=False"
+            )
+
+        normalized_arg_sets: list[tuple[object, ...]] = []
+        for case_index, arg_set in enumerate(arg_sets):
+            if not isinstance(arg_set, Sequence) or isinstance(arg_set, (str, bytes)):
+                raise exc.InvalidAPIUsage(
+                    f"autotune_multi arg_sets[{case_index}] must be a sequence"
+                )
+            try:
+                normalized_arg_sets.append(self.normalize_args(*arg_set))
+            except TypeError as error:
+                raise exc.InvalidAPIUsage(
+                    f"autotune_multi arg_sets[{case_index}] does not match the "
+                    f"kernel signature: {error}"
+                ) from error
+
+        if cache_tag is None:
+            for case_index, normalized_args in enumerate(normalized_arg_sets):
+                if any(
+                    annotation is not ConstExpr
+                    and _has_unspecialized_numeric_value(value)
+                    for value, annotation in zip(
+                        normalized_args, self._annotations, strict=True
+                    )
+                ):
+                    raise exc.InvalidAPIUsage(
+                        "autotune_multi requires cache_tag when an argument set "
+                        "contains a runtime numeric value; "
+                        f"arg_sets[{case_index}] does"
+                    )
+
+        cases: list[tuple[BoundKernel[_R], tuple[object, ...]]] = []
+        case_keys: list[BoundKernelInMemoryCacheKey] = []
+        for case_index, normalized_args in enumerate(normalized_arg_sets):
+            try:
+                bound_kernel = self.bind(normalized_args)
+            except exc.NoTensorArgs as error:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi requires each argument set to have a device "
+                    f"discoverable by normal kernel binding; arg_sets[{case_index}] did not"
+                ) from error
+            signature = self._base_specialization_key(normalized_args)
+            case_key = self._get_bound_kernel_cache_key(normalized_args, signature)
+            assert case_key is not None
+            cases.append((bound_kernel, normalized_args))
+            case_keys.append(case_key)
+
+        anchor = cases[0][0]
+        canonical_device = _canonicalize_multi_shape_device(anchor.env.device)
+        current_index = _current_device_index(canonical_device.type)
+        if canonical_device.index != current_index:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires the indexed accelerator to be current: "
+                f"got {canonical_device}, current index is {current_index}"
+            )
+
+        unique_bound_kernels: list[BoundKernel[_R]] = []
+        seen_bound_kernel_ids: set[int] = set()
+        for bound_kernel, _ in cases:
+            if id(bound_kernel) not in seen_bound_kernel_ids:
+                seen_bound_kernel_ids.add(id(bound_kernel))
+                unique_bound_kernels.append(bound_kernel)
+
+        anchor_backend = anchor.env.backend.name
+        anchor_capability = target_device_capability(anchor.env.device)
+        advanced_controls_files = self.settings.autotune_search_acf or None
+        anchor_fingerprint = anchor.config_spec.structural_fingerprint(
+            advanced_controls_files=advanced_controls_files
+        )
+        for case_index, (bound_kernel, _) in enumerate(cases):
+            if bound_kernel.env.process_group_name is not None:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi does not support a bound kernel with a process group"
+                )
+            bound_device = _canonicalize_multi_shape_device(bound_kernel.env.device)
+            if bound_device != canonical_device:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi bound a different device for "
+                    f"arg_sets[{case_index}]: {bound_device} != {canonical_device}"
+                )
+            if bound_kernel.env.backend.name != anchor_backend:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi requires every case to use the same backend"
+                )
+            if target_device_capability(bound_kernel.env.device) != anchor_capability:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi requires every case to have the same device capability"
+                )
+            fingerprint = bound_kernel.config_spec.structural_fingerprint(
+                advanced_controls_files=advanced_controls_files
+            )
+            if fingerprint != anchor_fingerprint:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi requires structurally compatible ConfigSpec "
+                    f"instances; arg_sets[{case_index}] is incompatible with the anchor"
+                )
+        multi_args = _MultiShapeAutotuneArgs(
+            cases=tuple(cases),
+            aggregation=aggregation,
+            relative_to=relative_to,
+            cache_tag=cache_tag,
+            workload_key=(
+                "multi_shape:v1",
+                aggregation,
+                relative_to,
+                cache_tag,
+                tuple(
+                    (case_key.specialization_key, case_key.extra_results)
+                    for case_key in case_keys
+                ),
+            ),
+            reference_latencies=None,
+        )
+
+        ephemeral = anchor.env.backend.make_ephemeral_cache()
+        ctx = ephemeral if ephemeral is not None else contextlib.nullcontext()
+        with ctx:
+            config = anchor.env.backend.autotune(
+                anchor,
+                cast("Sequence[object]", multi_args),
+                force=force,
+                **options,
+            )
+        if multi_args.search_started and not multi_args.found_valid_config:
+            raise exc.NoConfigFound
+        if multi_args.search_started and not _has_valid_multi_shape_measurement(
+            multi_args,
+            anchor.config_spec,
+            config,
+        ):
+            raise exc.NoConfigFound
+        winner = _materialize_multi_shape_config(anchor.config_spec, config)
+        if ephemeral is not None:
+            for bound_kernel in unique_bound_kernels:
+                bound_kernel.env.backend.finalize_ephemeral_cache(bound_kernel, winner)
+
+        for bound_kernel in unique_bound_kernels:
+            bound_kernel.compile_config(winner)
+        for bound_kernel in unique_bound_kernels:
+            bound_kernel.set_config(winner)
+        return winner
 
     def __call__(self, *args: object, **kwargs: object) -> _R:
         """

--- a/scripts/kda_sglang_ab/sitecustomize.py
+++ b/scripts/kda_sglang_ab/sitecustomize.py
@@ -1,0 +1,85 @@
+"""Opt-in Helion KDA substitutions for SGLang A/B benchmarks."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _load_source_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+enable_decode = (
+    os.environ.get("SGLANG_KDA_HELION_DECODE") == "1"
+    or os.environ.get("SGLANG_KDA_HELION") == "1"
+)
+enable_prefill = os.environ.get("SGLANG_KDA_HELION_PREFILL") == "1"
+
+if enable_decode or enable_prefill:
+    from sglang.srt.layers.attention.linear.kernels import kda_triton
+
+if enable_decode:
+    decode_root = os.environ.get("HELION_KDA_DECODE_ROOT")
+    if decode_root is None:
+        from examples.linear.kda_packed_decode import (
+            helion_fused_recurrent_kda_packed_decode,
+        )
+    else:
+        decode_module = _load_source_module(
+            "_helion_kda_decode_ab",
+            Path(decode_root) / "examples/linear/kda_packed_decode.py",
+        )
+        helion_fused_recurrent_kda_packed_decode = (
+            decode_module.helion_fused_recurrent_kda_packed_decode
+        )
+
+    _decode_called = False
+
+    def _helion_packed_decode(*args: object, **kwargs: object) -> object:
+        global _decode_called
+        if not _decode_called:
+            print("[helion-kda-ab] first packed decode call", flush=True)
+            _decode_called = True
+        return helion_fused_recurrent_kda_packed_decode(*args, **kwargs)
+
+    kda_triton.fused_recurrent_kda_packed_decode = _helion_packed_decode
+    print("[helion-kda-ab] installed packed decode substitution", flush=True)
+
+if enable_prefill:
+    prefill_root = os.environ.get("HELION_KDA_PREFILL_ROOT")
+    if prefill_root is None:
+        from examples.linear.kda_prefill import chunk_kda as helion_chunk_kda
+    else:
+        prefill_module = _load_source_module(
+            "_helion_kda_prefill_ab",
+            Path(prefill_root) / "examples/linear/kda_prefill.py",
+        )
+        helion_chunk_kda = prefill_module.chunk_kda
+    newton_schulz = os.environ.get("HELION_KDA_PREFILL_NEWTON_SCHULZ") == "1"
+
+    _prefill_called = False
+
+    def _helion_chunk_kda(*args: object, **kwargs: object) -> object:
+        global _prefill_called
+        if not _prefill_called:
+            inverse = "newton-schulz" if newton_schulz else "forward-substitution"
+            print(f"[helion-kda-ab] first prefill call ({inverse})", flush=True)
+            _prefill_called = True
+        kwargs["newton_schulz"] = newton_schulz
+        return helion_chunk_kda(*args, **kwargs)
+
+    kda_triton.chunk_kda = _helion_chunk_kda
+    print("[helion-kda-ab] installed prefill substitution", flush=True)

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -390,6 +390,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
         provider.log = Mock()
         provider._autotune_metrics = AutotuneMetrics()
+        provider._worker_failure_config_ids = []
 
         with patch.object(
             provider,
@@ -409,6 +410,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
         provider.log = Mock()
         provider._autotune_metrics = AutotuneMetrics()
+        provider._worker_failure_config_ids = []
 
         with patch.object(
             provider,

--- a/test/test_kda_packed_decode.py
+++ b/test/test_kda_packed_decode.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import inspect
+
+from examples.linear.kda_packed_decode import _helion_fused_recurrent_kda_packed_decode
+from examples.linear.kda_packed_decode import helion_fused_recurrent_kda_packed_decode
+from examples.linear.kda_packed_decode import make_kda_inputs
+from examples.linear.kda_packed_decode import torch_fused_recurrent_kda_packed_decode
+import torch
+
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import onlyBackends
+
+
+@onlyBackends(["triton"])
+class TestKdaPackedDecode(RefEagerTestDisabled, TestCase):
+    def test_uses_one_config_for_all_shapes(self) -> None:
+        self.assertEqual(len(_helion_fused_recurrent_kda_packed_decode.configs), 1)
+        self.assertFalse(
+            _helion_fused_recurrent_kda_packed_decode.settings.static_shapes
+        )
+        config = _helion_fused_recurrent_kda_packed_decode.configs[0]
+        self.assertEqual(config.block_sizes, [8])
+        self.assertEqual(config.loop_orders, [[2, 1, 0]])
+        self.assertEqual(config.pid_type, "xyz")
+
+    def test_public_signature(self) -> None:
+        signature = inspect.signature(helion_fused_recurrent_kda_packed_decode)
+        self.assertEqual(
+            list(signature.parameters),
+            [
+                "mixed_qkv",
+                "a",
+                "b",
+                "A_log",
+                "dt_bias",
+                "scale",
+                "initial_state",
+                "out",
+                "ssm_state_indices",
+                "use_qk_l2norm_in_kernel",
+            ],
+        )
+        self.assertIs(signature.parameters["use_qk_l2norm_in_kernel"].default, False)
+
+    def test_values_mutations_aliases_and_padding(self) -> None:
+        for use_qk_l2norm_in_kernel in (False, True):
+            with self.subTest(use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel):
+                inputs = make_kda_inputs(
+                    3,
+                    2,
+                    4,
+                    128,
+                    128,
+                    device=DEVICE,
+                    pool_size=7,
+                    seed=123,
+                )
+                inputs.ssm_state_indices.copy_(
+                    torch.tensor([5, -1, 2], device=DEVICE, dtype=torch.int32)
+                )
+                inputs.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+                original_state = inputs.initial_state.clone()
+
+                reference_inputs = inputs.clone_mutable()
+                actual_inputs = inputs.clone_mutable()
+                torch_fused_recurrent_kda_packed_decode(*reference_inputs.args())
+                result = helion_fused_recurrent_kda_packed_decode(*actual_inputs.args())
+
+                self.assertEqual(result[0].data_ptr(), actual_inputs.out.data_ptr())
+                self.assertEqual(
+                    result[1].data_ptr(), actual_inputs.initial_state.data_ptr()
+                )
+                torch.testing.assert_close(
+                    actual_inputs.out, reference_inputs.out, atol=2e-2, rtol=1e-2
+                )
+                torch.testing.assert_close(
+                    actual_inputs.initial_state,
+                    reference_inputs.initial_state,
+                    atol=2e-2,
+                    rtol=1e-2,
+                )
+                self.assertEqual(torch.count_nonzero(actual_inputs.out[1]).item(), 0)
+
+                untouched = torch.tensor(
+                    [0, 1, 3, 4, 6], device=DEVICE, dtype=torch.long
+                )
+                self.assertTrue(
+                    torch.equal(
+                        actual_inputs.initial_state[untouched],
+                        original_state[untouched],
+                    )
+                )

--- a/test/test_kda_prefill.py
+++ b/test/test_kda_prefill.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import inspect
+import math
+
+from examples.linear.kda_prefill import chunk_kda
+import torch
+
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import onlyBackends
+
+
+def _torch_chunk_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    *,
+    scale: float | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    if use_qk_l2norm_in_kernel:
+        q = (
+            q.float() / torch.sqrt((q.float().square()).sum(-1, keepdim=True) + 1e-6)
+        ).to(q.dtype)
+        k = (
+            k.float() / torch.sqrt((k.float().square()).sum(-1, keepdim=True) + 1e-6)
+        ).to(k.dtype)
+
+    if A_log is not None:
+        raw = g.float()
+        if dt_bias is not None:
+            raw = raw + dt_bias.reshape(g.shape[2], g.shape[3])[None, None]
+        a = torch.exp(A_log.reshape(-1).float())[None, None, :, None]
+        if lower_bound is None:
+            gate = -a * torch.nn.functional.softplus(raw)
+        else:
+            gate = lower_bound * torch.sigmoid(a * raw)
+    else:
+        gate = g.float()
+
+    output = torch.empty_like(v)
+    h_chunks: list[torch.Tensor] = []
+    if cu_seqlens is None:
+        sequences = [
+            (batch, batch * q.shape[1], (batch + 1) * q.shape[1])
+            for batch in range(q.shape[0])
+        ]
+    else:
+        offsets = cu_seqlens.cpu().tolist()
+        sequences = [
+            (sequence, offsets[sequence], offsets[sequence + 1])
+            for sequence in range(len(offsets) - 1)
+        ]
+
+    for sequence, begin, end in sequences:
+        state_index = int(initial_state_indices[sequence].item())
+        state = initial_state[state_index].float()
+        sequence_chunks: list[torch.Tensor] = []
+        for flat_token in range(begin, end):
+            if (flat_token - begin) % 64 == 0:
+                sequence_chunks.append(state.to(q.dtype))
+            if cu_seqlens is None:
+                batch = sequence
+                token = flat_token - begin
+            else:
+                batch = 0
+                token = flat_token
+            q_t = q[batch, token].float()
+            k_t = k[batch, token].float()
+            v_t = v[batch, token].float()
+            beta_t = beta[batch, token].float()
+            state = state * torch.exp(gate[batch, token])[:, None, :]
+            prediction = (state * k_t[:, None, :]).sum(-1)
+            residual = (v_t - prediction) * beta_t[:, None]
+            state = state + residual[:, :, None] * k_t[:, None, :]
+            output[batch, token] = (
+                (state * (q_t * scale)[:, None, :]).sum(-1).to(output.dtype)
+            )
+        initial_state[state_index] = state.to(initial_state.dtype)
+        h_chunks.extend(sequence_chunks)
+
+    h = torch.stack(h_chunks).unsqueeze(0)
+    if cu_seqlens is None:
+        chunks_per_batch = math.ceil(q.shape[1] / 64)
+        h = h.reshape(q.shape[0], chunks_per_batch, *h.shape[2:])
+    return output, h
+
+
+@onlyBackends(["triton"])
+class TestKdaPrefill(RefEagerTestDisabled, TestCase):
+    def test_public_signature(self) -> None:
+        signature = inspect.signature(chunk_kda)
+        expected_names = [
+            "q",
+            "k",
+            "v",
+            "g",
+            "beta",
+            "scale",
+            "initial_state",
+            "initial_state_indices",
+            "use_qk_l2norm_in_kernel",
+            "cu_seqlens",
+            "A_log",
+            "dt_bias",
+            "lower_bound",
+            "output_intermediate_states",
+            "kwargs",
+        ]
+        self.assertEqual(list(signature.parameters), expected_names)
+        self.assertEqual(
+            [parameter.kind for parameter in signature.parameters.values()],
+            [inspect.Parameter.POSITIONAL_OR_KEYWORD] * 14
+            + [inspect.Parameter.VAR_KEYWORD],
+        )
+        self.assertEqual(
+            [parameter.default for parameter in signature.parameters.values()],
+            [inspect.Parameter.empty] * 5
+            + [None, None, None, False, None, None, None, None, False]
+            + [inspect.Parameter.empty],
+        )
+
+    def test_fixed_partial_chunk_and_state_pool(self) -> None:
+        torch.manual_seed(123)
+        B, T, H, K, V = 2, 17, 2, 32, 32
+        q = torch.randn(B, T, H, K, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.randn_like(q)
+        v = torch.randn(B, T, H, V, device=DEVICE, dtype=torch.bfloat16) * 0.1
+        g = torch.randn_like(q) * 0.2
+        beta = torch.rand(B, T, H, device=DEVICE)
+        a_log = torch.full([H], -2.0, device=DEVICE)
+        dt_bias = torch.zeros(H * K, device=DEVICE)
+        indices = torch.tensor([3, 1], device=DEVICE, dtype=torch.int32)
+        initial = torch.randn(5, H, V, K, device=DEVICE) * 0.01
+
+        reference_state = initial.clone()
+        actual_state = initial.clone()
+        expected, expected_h = _torch_chunk_kda(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            reference_state,
+            indices,
+            use_qk_l2norm_in_kernel=True,
+            A_log=a_log,
+            dt_bias=dt_bias,
+        )
+        output_buffer = v.clone()
+        actual, actual_h = chunk_kda(
+            q,
+            k,
+            output_buffer,
+            g,
+            beta,
+            initial_state=actual_state,
+            initial_state_indices=indices,
+            use_qk_l2norm_in_kernel=True,
+            A_log=a_log,
+            dt_bias=dt_bias,
+            output_intermediate_states=True,
+        )
+
+        self.assertEqual(actual.data_ptr(), output_buffer.data_ptr())
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(actual_h, expected_h, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(actual_state, reference_state, atol=2e-2, rtol=2e-2)
+        self.assertTrue(torch.equal(actual_state[0], initial[0]))
+        self.assertTrue(torch.equal(actual_state[2], initial[2]))
+        self.assertTrue(torch.equal(actual_state[4], initial[4]))
+
+    def test_varlen_safe_gate(self) -> None:
+        torch.manual_seed(456)
+        lengths = [1, 15, 17]
+        T, H, K, V = sum(lengths), 2, 32, 32
+        cu_seqlens = torch.tensor(
+            [0, *torch.tensor(lengths).cumsum(0).tolist()],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+        q = torch.randn(1, T, H, K, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.randn_like(q)
+        v = torch.randn(1, T, H, V, device=DEVICE, dtype=torch.bfloat16) * 0.1
+        g = torch.randn_like(q) * 0.2
+        beta = torch.rand(1, T, H, device=DEVICE)
+        a_log = torch.full([H], -2.0, device=DEVICE)
+        indices = torch.tensor([4, 1, 3], device=DEVICE, dtype=torch.int32)
+        initial = torch.randn(6, H, V, K, device=DEVICE) * 0.01
+
+        reference_state = initial.clone()
+        actual_state = initial.clone()
+        expected, expected_h = _torch_chunk_kda(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            reference_state,
+            indices,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=cu_seqlens,
+            A_log=a_log,
+            lower_bound=-0.01,
+        )
+        actual, actual_h = chunk_kda(
+            q,
+            k,
+            v.clone(),
+            g,
+            beta,
+            initial_state=actual_state,
+            initial_state_indices=indices,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=cu_seqlens,
+            A_log=a_log,
+            lower_bound=-0.01,
+            output_intermediate_states=True,
+        )
+
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(actual_h, expected_h, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(actual_state, reference_state, atol=2e-2, rtol=2e-2)
+
+    def test_fp16_preactivated_gate(self) -> None:
+        torch.manual_seed(789)
+        B, T, H, K, V = 1, 17, 1, 32, 32
+        q = torch.nn.functional.normalize(
+            torch.randn(B, T, H, K, device=DEVICE), dim=-1
+        ).half()
+        k = torch.nn.functional.normalize(
+            torch.randn(B, T, H, K, device=DEVICE), dim=-1
+        ).half()
+        v = torch.randn(B, T, H, V, device=DEVICE, dtype=torch.float16) * 0.1
+        g = -torch.rand(B, T, H, K, device=DEVICE) * 0.01
+        beta = torch.rand(B, T, H, device=DEVICE)
+        indices = torch.tensor([1], device=DEVICE, dtype=torch.int32)
+        initial = torch.randn(3, H, V, K, device=DEVICE, dtype=torch.bfloat16) * 0.01
+
+        reference_state = initial.clone()
+        actual_state = initial.clone()
+        expected, expected_h = _torch_chunk_kda(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            reference_state,
+            indices,
+        )
+        actual, actual_h = chunk_kda(
+            q,
+            k,
+            v.clone(),
+            g,
+            beta,
+            initial_state=actual_state,
+            initial_state_indices=indices,
+            output_intermediate_states=True,
+        )
+
+        self.assertEqual(actual.dtype, torch.float16)
+        self.assertEqual(actual_h.dtype, torch.float16)
+        torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(actual_h, expected_h, atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(actual_state, reference_state, atol=2e-2, rtol=2e-2)

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -17,6 +17,8 @@ import torch
 import helion
 from helion import exc
 from helion._compiler.backend import TritonBackend
+from helion._testing import DEVICE
+from helion._testing import skipIfRefEager
 from helion.autotuner import benchmark_provider as benchmark_provider_module
 from helion.autotuner.base_search import BaseSearch
 from helion.autotuner.base_search import PopulationBasedSearch
@@ -1230,6 +1232,7 @@ class TestMultiShapeLLMSeeded(unittest.TestCase):
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+@skipIfRefEager("Autotuning requires compilation, not supported in ref eager mode")
 class TestMultiShapeAutotuneIntegration(unittest.TestCase):
     @staticmethod
     def _make_add_case(
@@ -1257,8 +1260,8 @@ class TestMultiShapeAutotuneIntegration(unittest.TestCase):
             return out
 
         arg_sets = [
-            (torch.randn(256, device="cuda"), torch.randn(256, device="cuda")),
-            (torch.randn(2048, device="cuda"), torch.randn(2048, device="cuda")),
+            (torch.randn(256, device=DEVICE), torch.randn(256, device=DEVICE)),
+            (torch.randn(2048, device=DEVICE), torch.randn(2048, device=DEVICE)),
         ]
         return add, arg_sets
 

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -1,0 +1,1307 @@
+from __future__ import annotations
+
+import contextlib
+import math
+import os
+from pathlib import Path
+import tempfile
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from typing import cast
+import unittest
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import torch
+
+import helion
+from helion import exc
+from helion._compiler.backend import TritonBackend
+from helion.autotuner import benchmark_provider as benchmark_provider_module
+from helion.autotuner.base_search import BaseSearch
+from helion.autotuner.base_search import PopulationBasedSearch
+from helion.autotuner.base_search import PopulationMember
+from helion.autotuner.benchmark_provider import BenchmarkResult
+from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
+from helion.autotuner.benchmark_provider import MultiShapeAggregation
+from helion.autotuner.benchmark_provider import MultiShapeBenchmarkProvider
+from helion.autotuner.benchmark_provider import MultiShapeReference
+from helion.autotuner.benchmark_provider import _aggregate_multi_shape_timings
+from helion.autotuner.benchmark_provider import _format_selected_multi_shape_measurement
+from helion.autotuner.benchmark_provider import _materialize_multi_shape_config
+from helion.autotuner.benchmark_provider import _MultiShapeAutotuneArgs
+from helion.autotuner.config_spec import BlockSizeSpec
+from helion.autotuner.config_spec import ConfigSpec
+from helion.autotuner.config_spec import LoopOrderSpec
+from helion.autotuner.finite_search import FiniteSearch
+from helion.autotuner.llm_seeded_lfbo import LLMSeededSearch
+from helion.autotuner.local_cache import LocalAutotuneCache
+from helion.autotuner.metrics import AutotuneMetrics
+import helion.language as hl
+from helion.runtime.config import Config
+from helion.runtime.kernel import Kernel
+from helion.runtime.settings import Settings
+from helion.runtime.settings import default_autotuner_fn
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Iterable
+    from collections.abc import Sequence
+
+
+class TestMultiShapeTimingAggregation(unittest.TestCase):
+    def test_raw_geometric_mean_and_max(self) -> None:
+        self.assertAlmostEqual(
+            _aggregate_multi_shape_timings(
+                [1.0, 4.0], aggregation="geomean", references=None
+            ),
+            2.0,
+        )
+        self.assertEqual(
+            _aggregate_multi_shape_timings(
+                [1.0, 4.0], aggregation="max", references=None
+            ),
+            4.0,
+        )
+
+    def test_reference_max_returns_ratio(self) -> None:
+        self.assertEqual(
+            _aggregate_multi_shape_timings(
+                [4.0, 8.0], aggregation="max", references=[2.0, 8.0]
+            ),
+            2.0,
+        )
+        self.assertAlmostEqual(
+            _aggregate_multi_shape_timings(
+                [4.0, 8.0], aggregation="geomean", references=[2.0, 8.0]
+            ),
+            math.sqrt(2.0),
+        )
+
+    def test_invalid_values_and_references_return_infinity(self) -> None:
+        for timings in ([], [0.0], [-1.0], [math.inf], [math.nan]):
+            with self.subTest(timings=timings):
+                self.assertEqual(
+                    _aggregate_multi_shape_timings(
+                        timings, aggregation="geomean", references=None
+                    ),
+                    math.inf,
+                )
+        for references in ([1.0], [1.0, 0.0], [1.0, math.inf]):
+            with self.subTest(references=references):
+                self.assertEqual(
+                    _aggregate_multi_shape_timings(
+                        [2.0, 8.0], aggregation="max", references=references
+                    ),
+                    math.inf,
+                )
+
+
+def _make_config_spec() -> ConfigSpec:
+    spec = ConfigSpec(backend=TritonBackend())
+    spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+    spec.loop_orders.append(LoopOrderSpec([0]))
+    return spec
+
+
+def _make_carrier(
+    cases: Sequence[tuple[object, tuple[object, ...]]],
+    *,
+    aggregation: MultiShapeAggregation = "geomean",
+    relative_to: MultiShapeReference = None,
+    cache_tag: str | None = None,
+    workload_key: tuple[object, ...] = ("workload",),
+    reference_latencies: tuple[float, ...] | None = None,
+) -> _MultiShapeAutotuneArgs:
+    return _MultiShapeAutotuneArgs(
+        cases=tuple(cases),  # type: ignore[arg-type]
+        aggregation=aggregation,
+        relative_to=relative_to,
+        cache_tag=cache_tag,
+        workload_key=workload_key,
+        reference_latencies=reference_latencies,
+    )
+
+
+class TestMultiShapeConfigMaterialization(unittest.TestCase):
+    def test_alias_overlay_is_detached(self) -> None:
+        spec = _make_config_spec()
+        default = spec.default_config()
+        sparse = Config(block_size=64)
+
+        result = _materialize_multi_shape_config(spec, sparse)
+
+        self.assertEqual(result.block_sizes, [64])
+        self.assertEqual(result.num_warps, default.num_warps)
+        self.assertNotIn("block_size", result.config)
+        self.assertEqual(sparse.config, {"block_size": 64})
+        result.block_sizes[0] = 128
+        result.loop_orders[0][0] = 1
+        self.assertEqual(default.block_sizes, [32])
+        self.assertEqual(default.loop_orders, [[0]])
+
+    def test_singular_plural_collision_is_invalid(self) -> None:
+        with self.assertRaises(helion.exc.InvalidConfig):
+            _materialize_multi_shape_config(
+                _make_config_spec(), Config(block_size=32, block_sizes=[64])
+            )
+
+    def test_explicit_reset_removes_compiler_default(self) -> None:
+        spec = Mock()
+        spec.default_config.return_value = Config(block_sizes=[32], num_threads=[8])
+
+        def normalize(config: Config) -> None:
+            if "block_size" in config.config:
+                config.config["block_sizes"] = [config.config.pop("block_size")]
+            if config.config.get("num_threads") == [0]:
+                config.config.pop("num_threads")
+
+        spec.normalize.side_effect = normalize
+
+        result = _materialize_multi_shape_config(
+            spec, Config(block_size=64, num_threads=[0])
+        )
+
+        self.assertEqual(result.block_sizes, [64])
+        self.assertNotIn("num_threads", result.config)
+
+    def test_missing_optional_reset_does_not_restore_compiler_default(self) -> None:
+        spec = Mock()
+        spec.default_config.return_value = Config.from_dict(
+            {"block_sizes": [32], "epilogue_subtile": 2}
+        )
+
+        def normalize(config: Config) -> None:
+            config.config.setdefault("block_sizes", [32])
+            config.config.setdefault("num_warps", 4)
+
+        spec.normalize.side_effect = normalize
+
+        result = _materialize_multi_shape_config(
+            spec,
+            Config.from_dict({"block_sizes": [64]}),
+        )
+
+        self.assertEqual(result.block_sizes, [64])
+        self.assertEqual(result.num_warps, 4)
+        self.assertNotIn("epilogue_subtile", result.config)
+        spec.default_config.assert_not_called()
+
+
+class TestMultiShapeAutotuneArgs(unittest.TestCase):
+    def test_sequence_operations_use_anchor_args(self) -> None:
+        anchor_args = ("first", 2, [3])
+        carrier = _make_carrier(((object(), anchor_args), (object(), ("secondary",))))
+
+        self.assertEqual(len(carrier), 3)
+        self.assertEqual(carrier[0], "first")
+        self.assertIs(carrier[-1], anchor_args[-1])
+        self.assertEqual(list(cast("Iterable[object]", carrier)), list(anchor_args))
+
+
+def _cache_kernel_source(value: object) -> object:
+    return value
+
+
+class _RuntimeConfigSpec:
+    def structural_fingerprint(
+        self, *, advanced_controls_files: list[str] | None
+    ) -> tuple[tuple[str, int]]:
+        return (("block_sizes", 1),)
+
+    def structural_fingerprint_hash(
+        self, *, advanced_controls_files: list[str] | None
+    ) -> str:
+        return "fake-config-spec"
+
+    def normalize(self, config: Config) -> None:
+        config.config.setdefault("num_warps", 4)
+
+
+class _RuntimeBackend:
+    name = "triton"
+
+    def __init__(self) -> None:
+        self.autotune_calls: list[tuple[object, object]] = []
+        self.finalized: list[object] = []
+
+    def make_ephemeral_cache(self) -> contextlib.AbstractContextManager[None]:
+        return contextlib.nullcontext()
+
+    def autotune(
+        self, bound_kernel: object, args: object, *, force: bool, **options: object
+    ) -> Config:
+        self.autotune_calls.append((bound_kernel, args))
+        return Config(block_sizes=[64])
+
+    def finalize_ephemeral_cache(self, bound_kernel: object, config: Config) -> None:
+        self.finalized.append(bound_kernel)
+
+
+class _RuntimeBoundKernel:
+    def __init__(self, backend: _RuntimeBackend, settings: SimpleNamespace) -> None:
+        self.kernel = SimpleNamespace(
+            fn=_cache_kernel_source,
+            settings=settings,
+            _base_specialization_key=Mock(
+                side_effect=AssertionError("single-shape cache key recomputed")
+            ),
+            _create_bound_kernel_cache_key=Mock(
+                side_effect=AssertionError("single-shape cache key recomputed")
+            ),
+        )
+        self.settings = settings
+        self.config_spec = _RuntimeConfigSpec()
+        self.env = SimpleNamespace(
+            backend=backend,
+            device=torch.device("cuda", 0),
+            process_group_name=None,
+        )
+        self.compile_config = Mock()
+        self.set_config = Mock()
+        self.extra_cache_key = Mock(return_value="")
+
+
+def _runtime_settings(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "backend": "triton",
+        "autotuner_fn": default_autotuner_fn,
+        "autotune_cache": "LocalAutotuneCache",
+        "autotune_baseline_fn": None,
+        "autotune_baseline_accuracy_check_fn": None,
+        "autotune_benchmark_fn": None,
+        "autotune_config_filter": None,
+        "autotune_search_acf": [],
+        "autotune_accuracy_check": True,
+        "autotune_baseline_atol": None,
+        "autotune_baseline_rtol": None,
+        "autotune_best_of_k": 1,
+        "static_shapes": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class TestMultiShapeRuntime(unittest.TestCase):
+    @patch("helion.autotuner.local_cache.torch.version.cuda", "13.0")
+    @patch("helion.autotuner.local_cache.torch.cuda.is_available", return_value=True)
+    @patch("helion.autotuner.local_cache.get_device_name", return_value="Fake GPU")
+    def test_local_cache_uses_joint_workload_key(
+        self, device_name: object, cuda_available: object
+    ) -> None:
+        settings = _runtime_settings()
+        bound = _RuntimeBoundKernel(_RuntimeBackend(), settings)
+        workload_key = (
+            "multi_shape:v1",
+            "max",
+            "default",
+            "workload-v2",
+            (("shape-a",), ("shape-b",)),
+        )
+        cache = object.__new__(LocalAutotuneCache)
+        cache.kernel = bound  # pyrefly: ignore [bad-assignment]
+        cache.args = _make_carrier(  # pyrefly: ignore [bad-assignment]
+            ((bound, ("anchor", 8)), (bound, ("secondary", 16))),
+            workload_key=workload_key,
+        )
+        cache.autotuner = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+            settings=settings
+        )
+
+        key = cache._generate_key()
+
+        self.assertEqual(key.specialization_key, workload_key)
+        self.assertEqual(key.extra_results, ())
+        bound.kernel._base_specialization_key.assert_not_called()
+        bound.kernel._create_bound_kernel_cache_key.assert_not_called()
+
+    def test_option_validation_precedes_normalization_and_binding(self) -> None:
+        invalid_options = (
+            ({"aggregation": "median"}, "aggregation"),
+            ({"relative_to": "fastest"}, "relative_to"),
+            ({"cache_tag": ""}, "non-empty string"),
+            ({"cache_tag": 1}, "non-empty string"),
+        )
+        for kwargs, message in invalid_options:
+            kernel = object.__new__(Kernel)
+            kernel.normalize_args = Mock()
+            kernel.bind = Mock()
+
+            with (
+                self.subTest(kwargs=kwargs),
+                self.assertRaisesRegex(exc.InvalidAPIUsage, message),
+            ):
+                kernel.autotune_multi([("real-argument",)], **kwargs)  # type: ignore[arg-type]
+
+            kernel.normalize_args.assert_not_called()
+            kernel.bind.assert_not_called()
+
+    @patch("helion.runtime.kernel.dist.is_initialized", return_value=False)
+    def test_unsupported_settings_fail_before_binding(
+        self, distributed: object
+    ) -> None:
+        cases = (
+            (
+                "custom accuracy callback without cache tag",
+                _runtime_settings(autotune_baseline_accuracy_check_fn=Mock()),
+                {},
+                "requires cache_tag",
+            ),
+            (
+                "custom benchmark callback",
+                _runtime_settings(autotune_benchmark_fn=Mock()),
+                {"cache_tag": "callback-v1"},
+                "does not support",
+            ),
+            (
+                "dynamic shapes without cache tag",
+                _runtime_settings(static_shapes=False),
+                {},
+                "static_shapes=False",
+            ),
+        )
+        for name, settings, kwargs, message in cases:
+            kernel = object.__new__(Kernel)
+            kernel.settings = settings  # pyrefly: ignore [bad-assignment]
+            kernel.normalize_args = Mock()
+            kernel.bind = Mock()
+
+            with (
+                self.subTest(case=name),
+                self.assertRaisesRegex(exc.InvalidAPIUsage, message),
+            ):
+                kernel.autotune_multi([("real-argument",)], **kwargs)
+
+            kernel.normalize_args.assert_not_called()
+            kernel.bind.assert_not_called()
+
+    @patch("helion.runtime.kernel.dist.is_initialized", return_value=False)
+    def test_runtime_numeric_values_require_cache_tag(
+        self, distributed: object
+    ) -> None:
+        kernel = object.__new__(Kernel)
+        kernel.settings = _runtime_settings()  # pyrefly: ignore [bad-assignment]
+        kernel._annotations = [object]
+        kernel.normalize_args = Mock(side_effect=lambda *args: tuple(args))
+        kernel.bind = Mock()
+
+        with self.assertRaisesRegex(exc.InvalidAPIUsage, "runtime numeric value"):
+            kernel.autotune_multi([([1, 2],)])
+
+        kernel.bind.assert_not_called()
+
+    @patch("helion.runtime.kernel.target_device_capability", return_value=(9, 0))
+    @patch("helion.runtime.kernel._current_device_index", return_value=0)
+    @patch("helion.runtime.kernel.dist.is_initialized", return_value=False)
+    def test_builds_workload_key_and_installs_one_winner(
+        self,
+        distributed: object,
+        current: object,
+        capability: object,
+    ) -> None:
+        backend = _RuntimeBackend()
+        settings = _runtime_settings()
+        bounds = [
+            _RuntimeBoundKernel(backend, settings),
+            _RuntimeBoundKernel(backend, settings),
+        ]
+        case_keys = [
+            SimpleNamespace(specialization_key=("shape", 8), extra_results=()),
+            SimpleNamespace(specialization_key=("shape", 16), extra_results=()),
+        ]
+        kernel = object.__new__(Kernel)
+        kernel.settings = settings  # pyrefly: ignore [bad-assignment]
+        kernel._annotations = [object, object]
+        kernel.normalize_args = Mock(side_effect=lambda *args: tuple(args))
+        kernel.bind = Mock(side_effect=bounds)
+        kernel._base_specialization_key = Mock(
+            side_effect=[("shape", 8), ("shape", 16)]
+        )
+        kernel._get_bound_kernel_cache_key = Mock(side_effect=case_keys)
+
+        winner = kernel.autotune_multi(
+            [("case-a", 8), ("case-b", 16)], cache_tag="numeric-shapes-v1"
+        )
+
+        self.assertEqual(winner.config, {"block_sizes": [64], "num_warps": 4})
+        self.assertEqual(len(backend.autotune_calls), 1)
+        carrier = backend.autotune_calls[0][1]
+        self.assertIsInstance(carrier, _MultiShapeAutotuneArgs)
+        self.assertEqual(
+            carrier.workload_key,
+            (
+                "multi_shape:v1",
+                "geomean",
+                None,
+                "numeric-shapes-v1",
+                ((("shape", 8), ()), (("shape", 16), ())),
+            ),
+        )
+        self.assertEqual(backend.finalized, bounds)
+        for bound in bounds:
+            bound.compile_config.assert_called_once_with(winner)
+            bound.set_config.assert_called_once_with(winner)
+
+
+class _Log:
+    def __init__(self) -> None:
+        self.debug_messages: list[object] = []
+
+    def debug(self, message: object) -> None:
+        self.debug_messages.append(message)
+
+    def register_config(self, config: Config) -> None:
+        return None
+
+    def record_autotune_entry(self, entry: object) -> None:
+        pass
+
+
+class _FakeBoundKernel:
+    def __init__(
+        self,
+        config_spec: ConfigSpec,
+        timings: list[float],
+        statuses: list[str] | None = None,
+        compile_times: list[float | None] | None = None,
+        *,
+        error: Exception | None = None,
+        accuracy_failure_indices: list[int] | None = None,
+        compile_failure_indices: list[int] | None = None,
+    ) -> None:
+        self.config_spec = config_spec
+        self.settings = SimpleNamespace(
+            autotune_baseline_fn=None,
+            autotune_ignore_errors=False,
+        )
+        self.env = SimpleNamespace(process_group_name=None)
+        self.timings = timings
+        self.statuses = statuses or ["ok"] * len(timings)
+        self.compile_times = compile_times or [None] * len(timings)
+        self.error = error
+        self.accuracy_failure_indices = accuracy_failure_indices or []
+        self.compile_failure_indices = compile_failure_indices or []
+        self.accuracy_failures = len(self.accuracy_failure_indices)
+        self.compile_failures = len(self.compile_failure_indices)
+
+
+class _FakeLocalBenchmarkProvider:
+    mutated_arg_indices: tuple[int, ...] = ()
+
+    def __init__(
+        self,
+        kernel: _FakeBoundKernel,
+        settings: object,
+        config_spec: ConfigSpec,
+        args: tuple[object, ...],
+        log: object,
+        autotune_metrics: AutotuneMetrics,
+    ) -> None:
+        self.kernel = kernel
+        self.settings = settings
+        self.config_spec = config_spec
+        self.args = args
+        self._autotune_metrics = autotune_metrics
+        self._accuracy_failure_config_ids: list[int] = []
+        self._compile_failure_config_ids: list[int] = []
+        self.benchmark_calls: list[tuple[list[Config], str]] = []
+        self.setup_count = 0
+        self.cleanup_count = 0
+        self.budget_exceeded_fn: Callable[[], bool] = lambda: False
+        self.fns = [lambda: None for _ in kernel.timings]
+
+    def set_budget_exceeded_fn(self, fn: Callable[[], bool]) -> None:
+        self.budget_exceeded_fn = fn
+
+    def setup(self) -> None:
+        self.setup_count += 1
+
+    def cleanup(self) -> None:
+        self.cleanup_count += 1
+
+    def benchmark(
+        self, configs: list[Config], *, desc: str = "Benchmarking"
+    ) -> list[BenchmarkResult]:
+        self.benchmark_calls.append((configs, desc))
+        if self.kernel.error is not None:
+            raise self.kernel.error
+        self._autotune_metrics.num_accuracy_failures += self.kernel.accuracy_failures
+        self._autotune_metrics.num_compile_failures += self.kernel.compile_failures
+        self._accuracy_failure_config_ids.extend(
+            id(config)
+            for index, config in enumerate(configs)
+            if index in self.kernel.accuracy_failure_indices
+        )
+        self._compile_failure_config_ids.extend(
+            id(config)
+            for index, config in enumerate(configs)
+            if index in self.kernel.compile_failure_indices
+        )
+        if len(configs) > len(self.kernel.timings):
+            raise AssertionError("fake child received too many configs")
+        return [
+            BenchmarkResult(
+                config,
+                self.fns[index],
+                self.kernel.timings[index],
+                self.kernel.statuses[index],  # type: ignore[arg-type]
+                self.kernel.compile_times[index],
+            )
+            for index, config in enumerate(configs)
+        ]
+
+
+class TestMultiShapeBenchmarkProvider(unittest.TestCase):
+    def _make_provider(
+        self,
+        cases: list[_FakeBoundKernel],
+        *,
+        aggregation: MultiShapeAggregation = "geomean",
+        relative_to: MultiShapeReference = None,
+        references: tuple[float, ...] | None = None,
+        carrier: _MultiShapeAutotuneArgs | None = None,
+    ) -> tuple[MultiShapeBenchmarkProvider, AutotuneMetrics]:
+        if carrier is None:
+            carrier = _make_carrier(
+                tuple((case, (index,)) for index, case in enumerate(cases)),
+                aggregation=aggregation,
+                relative_to=relative_to,
+                reference_latencies=references,
+            )
+        metrics = AutotuneMetrics()
+        with patch.object(
+            benchmark_provider_module,
+            "LocalBenchmarkProvider",
+            _FakeLocalBenchmarkProvider,
+        ):
+            provider = MultiShapeBenchmarkProvider(
+                kernel=cases[0],  # type: ignore[arg-type]
+                settings=cases[0].settings,  # type: ignore[arg-type]
+                config_spec=cases[0].config_spec,
+                args=cast("Sequence[object]", carrier),
+                log=_Log(),  # type: ignore[arg-type]
+                autotune_metrics=metrics,
+            )
+        return provider, metrics
+
+    def test_rectangular_aggregation_preserves_original_config_identity(self) -> None:
+        spec = _make_config_spec()
+        provider, metrics = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [1.0, 8.0], compile_times=[0.1, None]),
+                _FakeBoundKernel(spec, [4.0, 2.0], compile_times=[0.2, 0.4]),
+            ]
+        )
+        configs = [Config(block_size=64), Config(block_sizes=[128])]
+
+        results = provider.benchmark(configs, desc="joint")
+
+        self.assertEqual([result.perf for result in results], [2.0, 4.0])
+        self.assertEqual([result.compile_time for result in results], [0.2, 0.4])
+        self.assertIs(results[0].config, configs[0])
+        self.assertIs(results[1].config, configs[1])
+        self.assertEqual(metrics.num_configs_tested, 2)
+        self.assertTrue(provider.args.found_valid_config)
+        children = cast("list[_FakeLocalBenchmarkProvider]", provider.children)
+        self.assertTrue(
+            all(child._autotune_metrics is not metrics for child in children)
+        )
+        debug_message = cast("_Log", provider.log).debug_messages[0]
+        assert callable(debug_message)
+        self.assertIn(
+            "objective: geomean(latencies)=2.000000 ms",
+            debug_message(),
+        )
+        for index, child in enumerate(children):
+            received, desc = child.benchmark_calls[0]
+            self.assertEqual(desc, f"joint shape {index + 1}")
+            self.assertEqual(received[0].block_sizes, [64])
+            self.assertIsNot(received[0], configs[0])
+
+    def test_raw_and_relative_max_choose_different_configs(self) -> None:
+        spec = _make_config_spec()
+        configs = [Config(block_sizes=[64]), Config(block_sizes=[128])]
+
+        def select(references: tuple[float, ...] | None) -> Config:
+            provider, _ = self._make_provider(
+                [
+                    _FakeBoundKernel(spec, [1.0, 4.0]),
+                    _FakeBoundKernel(spec, [100.0, 6.0]),
+                ],
+                aggregation="max",
+                references=references,
+            )
+            search = SimpleNamespace(
+                configs=configs,
+                benchmark_batch=lambda candidates, *, desc: provider.benchmark(
+                    candidates, desc=desc
+                ),
+            )
+            return FiniteSearch._autotune(cast("object", search))  # type: ignore[arg-type]
+
+        self.assertIs(select(None), configs[1])
+        self.assertIs(select((1.0, 100.0)), configs[0])
+
+    def test_relative_logging_reports_shape_rows_and_keeps_perf_ms_raw(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [_FakeBoundKernel(spec, [4.0]), _FakeBoundKernel(spec, [8.0])],
+            aggregation="max",
+            relative_to="default",
+            references=(2.0, 8.0),
+        )
+        provider.log = Mock()
+        provider.log.register_config.return_value = "config-id"
+        config = Config(block_sizes=[64])
+
+        result = provider.benchmark([config])[0]
+
+        self.assertEqual(result.perf, 2.0)
+        entry = provider.log.record_autotune_entry.call_args.args[0]
+        self.assertEqual(entry.perf_ms, 8.0)
+        self.assertIsNot(entry.config, config)
+        self.assertEqual(entry.config.num_warps, 4)
+        debug_message = provider.log.debug.call_args.args[0]()
+        self.assertIn("arg_sets[0]: latency=4.000000 ms", debug_message)
+        self.assertIn("default reference=2.000000 ms", debug_message)
+        self.assertIn("arg_sets[1]: latency=8.000000 ms", debug_message)
+        self.assertIn(
+            "objective: max(latency ratios vs default)=2.000000x", debug_message
+        )
+
+        materialized = _materialize_multi_shape_config(spec, config)
+        self.assertEqual(provider.raw_latency(config), 8.0)
+        summary = _format_selected_multi_shape_measurement(provider.args, materialized)
+        assert summary is not None
+        self.assertIn("Selected multi-shape config", summary)
+        self.assertIn("ratio=2.000000x", summary)
+        self.assertIn("ratio=1.000000x", summary)
+
+    def test_relative_metrics_keep_millisecond_contract(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [_FakeBoundKernel(spec, [4.0]), _FakeBoundKernel(spec, [8.0])],
+            aggregation="max",
+            relative_to="default",
+            references=(2.0, 8.0),
+        )
+        config = Config(block_sizes=[64])
+        result = provider.benchmark([config])[0]
+        search = object.__new__(FiniteSearch)
+        search.args = provider.args
+        search.benchmark_provider = provider
+        search.best_perf_so_far = result.perf
+        search._autotune_metrics = AutotuneMetrics()
+
+        search._finalize_autotune_metrics(config)
+        self.assertEqual(search._autotune_metrics.best_perf_ms, 8.0)
+
+        search._autotune_metrics = AutotuneMetrics()
+        search._finalize_autotune_metrics(None)
+        self.assertEqual(search._autotune_metrics.best_perf_ms, 0.0)
+
+    def test_any_invalid_shape_discards_config_and_timeout_wins_status(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(
+                    spec,
+                    [1.0, math.inf],
+                    statuses=["ok", "timeout"],
+                    compile_times=[0.1, 0.3],
+                ),
+                _FakeBoundKernel(
+                    spec,
+                    [math.inf, math.inf],
+                    statuses=["error", "error"],
+                    compile_times=[0.2, 0.4],
+                ),
+            ]
+        )
+
+        results = provider.benchmark(
+            [Config(block_sizes=[64]), Config(block_sizes=[128])]
+        )
+
+        self.assertEqual([result.perf for result in results], [math.inf, math.inf])
+        self.assertEqual([result.status for result in results], ["error", "timeout"])
+        self.assertFalse(provider.args.found_valid_config)
+        summary = _format_selected_multi_shape_measurement(
+            provider.args,
+            _materialize_multi_shape_config(spec, Config(block_sizes=[64])),
+        )
+        assert summary is not None
+        self.assertIn("objective: rejected", summary)
+
+    def test_failure_metrics_count_config_union_once(self) -> None:
+        spec = _make_config_spec()
+        provider, metrics = self._make_provider(
+            [
+                _FakeBoundKernel(
+                    spec,
+                    [math.inf, math.inf, 3.0],
+                    accuracy_failure_indices=[0, 1],
+                    compile_failure_indices=[0],
+                ),
+                _FakeBoundKernel(
+                    spec,
+                    [math.inf, 2.0, math.inf],
+                    accuracy_failure_indices=[0, 2],
+                    compile_failure_indices=[0, 1],
+                ),
+            ]
+        )
+
+        provider.benchmark(
+            [
+                Config(block_sizes=[64]),
+                Config(block_sizes=[128]),
+                Config(block_sizes=[256]),
+            ]
+        )
+
+        self.assertEqual(metrics.num_accuracy_failures, 3)
+        self.assertEqual(metrics.num_compile_failures, 2)
+
+    def test_invalid_anchor_materialization_discards_only_one_config(self) -> None:
+        spec = _make_config_spec()
+        provider, metrics = self._make_provider(
+            [_FakeBoundKernel(spec, [2.0]), _FakeBoundKernel(spec, [8.0])]
+        )
+
+        results = provider.benchmark(
+            [
+                Config(block_size=32, block_sizes=[64]),
+                Config(block_sizes=[128]),
+            ]
+        )
+
+        self.assertEqual([result.perf for result in results], [math.inf, 4.0])
+        self.assertEqual(metrics.num_configs_tested, 2)
+        for child in provider.children:
+            self.assertEqual(len(child.benchmark_calls[0][0]), 1)
+
+    def test_skippable_batch_failure_becomes_infinite_rows(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [1.0, 2.0]),
+                _FakeBoundKernel(spec, [1.0, 2.0], error=RuntimeError("compile")),
+            ]
+        )
+        with patch.object(provider, "_is_skippable_child_failure", return_value=True):
+            results = provider.benchmark(
+                [Config(block_sizes=[64]), Config(block_sizes=[128])]
+            )
+        self.assertEqual([result.perf for result in results], [math.inf, math.inf])
+
+    def test_fatal_batch_failure_propagates(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [1.0]),
+                _FakeBoundKernel(spec, [1.0], error=RuntimeError("fatal")),
+            ]
+        )
+        with (
+            patch.object(provider, "_is_skippable_child_failure", return_value=False),
+            self.assertRaisesRegex(RuntimeError, "fatal"),
+        ):
+            provider.benchmark([Config(block_sizes=[64])])
+
+    def test_warn_classified_batch_failure_is_not_hidden(self) -> None:
+        child = SimpleNamespace(
+            config_spec=SimpleNamespace(
+                backend=SimpleNamespace(
+                    classify_autotune_exception=lambda error: "warn"
+                )
+            ),
+            settings=SimpleNamespace(autotune_ignore_errors=False),
+        )
+
+        self.assertFalse(
+            MultiShapeBenchmarkProvider._is_skippable_child_failure(
+                cast("object", child), RuntimeError("compiler bug")
+            )
+        )
+
+    def test_reference_timings_are_reused_across_search_providers(self) -> None:
+        spec = _make_config_spec()
+        cases = [_FakeBoundKernel(spec, [2.0]), _FakeBoundKernel(spec, [8.0])]
+        provider, _ = self._make_provider(
+            cases,
+            relative_to="default",
+        )
+
+        provider.setup()
+        later_provider, _ = self._make_provider(cases, carrier=provider.args)
+        later_provider.setup()
+
+        self.assertEqual(provider.args.reference_latencies, (2.0, 8.0))
+        first_children = cast("list[_FakeLocalBenchmarkProvider]", provider.children)
+        later_children = cast(
+            "list[_FakeLocalBenchmarkProvider]", later_provider.children
+        )
+        self.assertEqual([child.setup_count for child in later_children], [1, 1])
+        self.assertEqual(
+            [len(child.benchmark_calls) for child in first_children], [1, 1]
+        )
+        self.assertTrue(all(not child.benchmark_calls for child in later_children))
+
+    def test_reference_failure_names_shape_and_cleans_up(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [2.0]),
+                _FakeBoundKernel(spec, [math.inf], statuses=["error"]),
+            ],
+            relative_to="default",
+        )
+
+        with self.assertRaisesRegex(
+            helion.exc.AutotuneError, r"reference benchmark failed for arg_sets\[1\]"
+        ):
+            provider.setup()
+
+        children = cast("list[_FakeLocalBenchmarkProvider]", provider.children)
+        self.assertEqual([child.cleanup_count for child in children], [1, 1])
+
+    def test_rebenchmark_reruns_joint_pipeline_and_records_latest_failure(self) -> None:
+        spec = _make_config_spec()
+        first = _FakeBoundKernel(spec, [1.0, 4.0])
+        second = _FakeBoundKernel(spec, [9.0, 1.0])
+        provider, metrics = self._make_provider([first, second])
+        configs = [Config(block_sizes=[64]), Config(block_sizes=[128])]
+        initial = provider.benchmark(configs)
+        tested = metrics.num_configs_tested
+        second.timings = [16.0, math.inf]
+        second.statuses = ["ok", "error"]
+
+        timings = provider.rebenchmark(
+            configs,
+            [result.perf for result in initial],
+            desc="confirm",
+        )
+
+        self.assertEqual(timings, [4.0, math.inf])
+        self.assertEqual(metrics.num_configs_tested, tested)
+        first_summary = _format_selected_multi_shape_measurement(
+            provider.args,
+            _materialize_multi_shape_config(spec, configs[0]),
+        )
+        second_summary = _format_selected_multi_shape_measurement(
+            provider.args,
+            _materialize_multi_shape_config(spec, configs[1]),
+        )
+        assert first_summary is not None
+        assert second_summary is not None
+        self.assertIn("latency=16.000000 ms", first_summary)
+        self.assertIn("objective: rejected", second_summary)
+        self.assertTrue(provider.has_valid_measurement(configs[0]))
+        self.assertFalse(provider.has_valid_measurement(configs[1]))
+        for child in provider.children:
+            self.assertEqual(len(child.benchmark_calls), 2)
+
+    def test_rebenchmark_preserves_previous_values_after_budget(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [_FakeBoundKernel(spec, [1.0, 2.0]), _FakeBoundKernel(spec, [3.0, 4.0])]
+        )
+        provider.set_budget_exceeded_fn(lambda: True)
+        previous = [1.5, 2.5]
+
+        self.assertEqual(
+            provider.rebenchmark(
+                [Config(block_sizes=[64]), Config(block_sizes=[128])],
+                previous,
+                desc="confirm",
+            ),
+            previous,
+        )
+        self.assertTrue(all(not child.benchmark_calls for child in provider.children))
+
+    def test_completed_rebenchmark_failure_wins_over_crossed_budget(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [math.inf], statuses=["error"]),
+                _FakeBoundKernel(spec, [1.0]),
+            ]
+        )
+        budget_exceeded = Mock(side_effect=(False, True))
+        provider.set_budget_exceeded_fn(budget_exceeded)
+
+        timings = provider.rebenchmark(
+            [Config(block_sizes=[64])],
+            [2.0],
+            desc="confirm",
+        )
+
+        self.assertEqual(timings, [math.inf])
+        budget_exceeded.assert_called_once_with()
+
+    def test_population_search_uses_provider_rebenchmark_hook(self) -> None:
+        provider = object.__new__(MultiShapeBenchmarkProvider)
+        provider.rebenchmark = Mock()  # type: ignore[method-assign]
+        provider.rebenchmark.return_value = [3.0, 1.0]
+        configs = [Config(block_sizes=[64]), Config(block_sizes=[128])]
+        members = [
+            PopulationMember(lambda: None, [2.0], [], config) for config in configs
+        ]
+        search = SimpleNamespace(
+            benchmark_provider=provider,
+            best_perf_so_far=2.0,
+        )
+
+        PopulationBasedSearch.rebenchmark(cast("object", search), members, desc="again")  # type: ignore[arg-type]
+
+        self.assertEqual([member.perfs for member in members], [[2.0, 3.0], [2.0, 1.0]])
+        self.assertEqual(search.best_perf_so_far, 1.0)
+        provider.rebenchmark.assert_called_once_with(configs, [2.0, 2.0], desc="again")
+
+    def test_local_provider_rejects_carrier_directly(self) -> None:
+        carrier = _make_carrier(((object(), (object(),)),))
+        with self.assertRaisesRegex(TypeError, "cannot benchmark multi-shape"):
+            LocalBenchmarkProvider(
+                kernel=cast("object", object()),
+                settings=cast("object", object()),
+                config_spec=cast("object", object()),
+                args=cast("Sequence[object]", carrier),
+                log=cast("object", object()),
+                autotune_metrics=AutotuneMetrics(),
+            )
+
+
+class TestMultiShapeSearchOrchestration(unittest.TestCase):
+    @staticmethod
+    def _make_base_search(args: object) -> BaseSearch:
+        search = BaseSearch.__new__(BaseSearch)
+        search.args = args  # pyrefly: ignore [bad-assignment]
+        search.settings = Settings(autotune_log=False, autotune_log_details=False)
+        search.log = Mock()
+        search.best_perf_so_far = math.inf
+        search._autotune_metrics = AutotuneMetrics()
+        search.config_spec = Mock()
+        search.config_spec.default_config.return_value = Config(num_warps=4)
+        search.kernel = Mock()
+        search.kernel.format_kernel_decorator.return_value = "@helion.kernel(...)"
+        search.kernel.get_cached_path.return_value = None
+        search.benchmark_provider = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+            setup=Mock(), cleanup=Mock()
+        )
+        search._prepare = Mock()  # type: ignore[method-assign]
+        search._autotune = Mock(  # type: ignore[method-assign]
+            side_effect=exc.NoConfigFound
+        )
+        search._finalize_autotune_metrics = Mock()  # type: ignore[method-assign]
+        return search
+
+    def test_finite_search_rejects_all_nonfinite_configs(self) -> None:
+        configs = [Config(num_warps=2), Config(num_warps=4)]
+        results = [
+            BenchmarkResult(config, lambda: None, perf, "error", None)
+            for config, perf in zip(configs, (math.inf, math.nan), strict=True)
+        ]
+        search = SimpleNamespace(
+            args=_make_carrier(((object(), ()),)),
+            configs=configs,
+            benchmark_batch=lambda configs, *, desc: results,
+        )
+
+        with self.assertRaises(exc.NoConfigFound):
+            FiniteSearch._autotune(cast("object", search))  # type: ignore[arg-type]
+
+    def test_base_search_propagates_no_config_and_cleans_up(self) -> None:
+        search = self._make_base_search(_make_carrier(((object(), ()),)))
+
+        with self.assertRaises(exc.NoConfigFound):
+            BaseSearch.autotune(search)
+
+        search.benchmark_provider.cleanup.assert_called_once_with()
+
+    def test_final_pick_resolution_handles_partial_and_multi_shape_searches(
+        self,
+    ) -> None:
+        partial_search = object.__new__(PopulationBasedSearch)
+        self.assertIsNone(partial_search._resolve_device_micros_paired_bench())
+
+        search = object.__new__(PopulationBasedSearch)
+        search.benchmark_provider = object.__new__(MultiShapeBenchmarkProvider)
+        search.settings = SimpleNamespace(static_shapes=True)
+        search.config_spec = SimpleNamespace(backend=Mock())
+
+        self.assertIsNone(search._resolve_device_micros_paired_bench())
+        search.config_spec.backend.get_paired_device_micros_bench.assert_not_called()
+
+
+class TestMultiShapeCacheBoundary(unittest.TestCase):
+    @staticmethod
+    def _make_cache(carrier: _MultiShapeAutotuneArgs) -> LocalAutotuneCache:
+        cache = object.__new__(LocalAutotuneCache)
+        cache.args = carrier  # pyrefly: ignore [bad-assignment]
+        cache.autotuner = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+            log=Mock(),
+            config_spec=_make_config_spec(),
+            settings=SimpleNamespace(autotune_log=None),
+        )
+        cache._run_autotune_trials = Mock(  # type: ignore[method-assign]
+            return_value=Config(block_size=64)
+        )
+        cache.put = Mock()  # type: ignore[method-assign]
+        return cache
+
+    def test_all_invalid_run_raises_before_cache_put(self) -> None:
+        carrier = _make_carrier(((object(), ()),))
+        carrier.search_started = True
+        cache = self._make_cache(carrier)
+
+        with self.assertRaises(exc.NoConfigFound):
+            cache.autotune(skip_cache=True)
+
+        cache.put.assert_not_called()
+
+    @patch("helion.autotuner.base_cache.should_skip_cache", return_value=False)
+    def test_valid_run_materializes_winner_before_cache_put(
+        self, skip_cache: object
+    ) -> None:
+        carrier = _make_carrier(((object(), ()),))
+        carrier.search_started = True
+        carrier.found_valid_config = True
+        cache = self._make_cache(carrier)
+        materialized = _materialize_multi_shape_config(
+            cache.autotuner.config_spec,
+            Config(block_size=64),
+        )
+        carrier.measurements[repr(materialized)] = ((1.0,), 1.0, ("ok",))
+
+        result = cache.autotune(skip_cache=True)
+
+        self.assertEqual(result.block_sizes, [64])
+        self.assertNotIn("block_size", result.config)
+        cache.put.assert_called_once_with(result)
+
+
+class _TrialLog:
+    def __call__(self, message: str, *args: object, **kwargs: object) -> None:
+        pass
+
+
+class TestMultiShapeBestOfK(unittest.TestCase):
+    @staticmethod
+    def _make_cache(
+        outcomes: list[tuple[Config, float] | type[exc.NoConfigFound]],
+    ) -> LocalAutotuneCache:
+        settings = SimpleNamespace(
+            autotune_best_of_k=len(outcomes),
+            autotune_random_seed=20,
+            autotune_compile_timeout=60,
+        )
+        outcome_iter = iter(outcomes)
+
+        class _Search:
+            def __init__(self) -> None:
+                self.settings = settings
+                self.log = _TrialLog()
+                self.best_perf_so_far = math.inf
+
+            def autotune(self) -> Config:
+                outcome = next(outcome_iter)
+                if outcome is exc.NoConfigFound:
+                    raise exc.NoConfigFound
+                config, perf = outcome
+                self.best_perf_so_far = perf
+                return config
+
+        cache = object.__new__(LocalAutotuneCache)
+        cache.args = _make_carrier(  # pyrefly: ignore [bad-assignment]
+            ((object(), ()),)
+        )
+        cache.autotuner = _Search()  # pyrefly: ignore [bad-assignment]
+        cache._autotuner_factory = _Search
+        cache._release_trial_state = Mock()  # type: ignore[method-assign]
+        return cache
+
+    def test_failed_trials_are_skipped(self) -> None:
+        invalid = Config(num_warps=2)
+        winner = Config(num_warps=4)
+        cache = self._make_cache(
+            [exc.NoConfigFound, (invalid, math.inf), (winner, 1.0)]
+        )
+        cache._rebench_trial_configs = Mock(  # type: ignore[method-assign]
+            return_value=[0.8]
+        )
+
+        self.assertEqual(cache._run_autotune_trials(), winner)
+        cache._rebench_trial_configs.assert_called_once_with([winner])
+
+    def test_all_failed_trials_raise_before_rebenchmark(self) -> None:
+        cache = self._make_cache([exc.NoConfigFound, exc.NoConfigFound])
+        cache._rebench_trial_configs = Mock()  # type: ignore[method-assign]
+
+        with self.assertRaises(exc.NoConfigFound):
+            cache._run_autotune_trials()
+        cache._rebench_trial_configs.assert_not_called()
+
+    def test_all_failed_final_rebenchmarks_raise(self) -> None:
+        cache = self._make_cache(
+            [(Config(num_warps=2), 1.0), (Config(num_warps=4), 2.0)]
+        )
+        cache._rebench_trial_configs = Mock(  # type: ignore[method-assign]
+            return_value=[math.inf, math.inf]
+        )
+
+        with self.assertRaises(exc.NoConfigFound):
+            cache._run_autotune_trials()
+
+
+class _StageSearch:
+    def __init__(self, config: Config | None, perf: float, tested: int) -> None:
+        self.config = config
+        self.best_perf_so_far = perf
+        self._autotune_metrics = AutotuneMetrics(num_configs_tested=tested)
+
+    def autotune(self, *, skip_cache: bool = False) -> Config:
+        if self.config is None:
+            raise exc.NoConfigFound
+        return self.config
+
+
+class TestMultiShapeLLMSeeded(unittest.TestCase):
+    @staticmethod
+    def _make_search(
+        llm_stage: _StageSearch, second_stage: _StageSearch
+    ) -> tuple[LLMSeededSearch, list[bool]]:
+        kernel = SimpleNamespace(settings=Settings(), config_spec=SimpleNamespace())
+        search = LLMSeededSearch(
+            kernel,
+            _make_carrier(((object(), ()),)),
+            llm_max_rounds=1,
+            second_stage_algorithm="FiniteSearch",
+        )
+        search._autotune_metrics = AutotuneMetrics()
+        search._make_llm_search = lambda: llm_stage  # type: ignore[method-assign,return-value]
+        seeded_values: list[bool] = []
+
+        def make_second_stage(*, seeded: bool) -> _StageSearch:
+            seeded_values.append(seeded)
+            return second_stage
+
+        search._make_second_stage_search = make_second_stage  # type: ignore[method-assign,return-value]
+        return search, seeded_values
+
+    def test_failed_llm_stage_runs_second_stage_unseeded(self) -> None:
+        winner = Config(num_warps=4)
+        search, seeded = self._make_search(
+            _StageSearch(None, math.inf, 2),
+            _StageSearch(winner, 0.7, 3),
+        )
+
+        self.assertEqual(search._autotune(), winner)
+        self.assertEqual(seeded, [False])
+        self.assertFalse(search.hybrid_stage_breakdown["used_llm_seed"])
+
+    def test_invalid_second_stage_returns_valid_llm_seed(self) -> None:
+        winner = Config(num_warps=4)
+        invalid_second_stages = (
+            _StageSearch(None, math.inf, 3),
+            _StageSearch(Config(num_warps=8), math.inf, 3),
+        )
+
+        for second_stage in invalid_second_stages:
+            with self.subTest(config=second_stage.config):
+                search, seeded = self._make_search(
+                    _StageSearch(winner, 0.6, 2), second_stage
+                )
+
+                self.assertEqual(search._autotune(), winner)
+                self.assertEqual(seeded, [True])
+                self.assertEqual(search.best_perf_so_far, 0.6)
+
+    def test_both_failed_stages_raise_after_metrics(self) -> None:
+        search, seeded = self._make_search(
+            _StageSearch(None, math.inf, 2),
+            _StageSearch(None, math.inf, 3),
+        )
+
+        with self.assertRaises(exc.NoConfigFound):
+            search._autotune()
+        self.assertEqual(seeded, [False])
+        self.assertEqual(search._autotune_metrics.num_configs_tested, 5)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestMultiShapeAutotuneIntegration(unittest.TestCase):
+    @staticmethod
+    def _make_add_case(
+        *, best_of_k: int | None = None, log_path: str | None = None
+    ) -> tuple[Kernel, list[tuple[torch.Tensor, torch.Tensor]]]:
+        settings: dict[str, object] = {}
+        if best_of_k is not None:
+            settings["autotune_best_of_k"] = best_of_k
+        if log_path is not None:
+            settings["autotune_log"] = log_path
+
+        @helion.kernel(
+            configs=[
+                helion.Config(block_sizes=[64], num_warps=4),
+                helion.Config(block_sizes=[128], num_warps=4),
+            ],
+            autotune_benchmark_subprocess=False,
+            autotune_precompile=None,
+            **settings,
+        )
+        def add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(a)
+            for tile in hl.tile(a.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        arg_sets = [
+            (torch.randn(256, device="cuda"), torch.randn(256, device="cuda")),
+            (torch.randn(2048, device="cuda"), torch.randn(2048, device="cuda")),
+        ]
+        return add, arg_sets
+
+    def test_finite_search_installs_one_config_for_two_shapes(self) -> None:
+        add, arg_sets = self._make_add_case()
+
+        winner = add.autotune_multi(
+            arg_sets,
+            aggregation="max",
+            relative_to="default",
+            force=False,
+        )
+
+        self.assertIn(winner.block_sizes[0], (64, 128))
+        for args in arg_sets:
+            torch.testing.assert_close(add(*args), args[0] + args[1])
+
+    def test_cache_best_of_k_persists_selected_breakdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "multi_shape"
+            add, arg_sets = self._make_add_case(
+                best_of_k=2,
+                log_path=str(log_path),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "HELION_AUTOTUNER": "FiniteSearch",
+                    "HELION_SKIP_CACHE": "1",
+                },
+            ):
+                add.autotune_multi(
+                    arg_sets,
+                    aggregation="max",
+                    relative_to="default",
+                )
+
+            log_text = log_path.with_suffix(".log").read_text()
+            self.assertIn("Selected multi-shape config", log_text)
+            self.assertIn("arg_sets[0]", log_text)
+            self.assertIn("arg_sets[1]", log_text)
+            self.assertIn("objective: max(latency ratios vs default)=", log_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -470,6 +470,7 @@ class _FakeBoundKernel:
         error: Exception | None = None,
         accuracy_failure_indices: list[int] | None = None,
         compile_failure_indices: list[int] | None = None,
+        worker_failure_indices: list[int] | None = None,
     ) -> None:
         self.config_spec = config_spec
         self.settings = SimpleNamespace(
@@ -483,8 +484,10 @@ class _FakeBoundKernel:
         self.error = error
         self.accuracy_failure_indices = accuracy_failure_indices or []
         self.compile_failure_indices = compile_failure_indices or []
+        self.worker_failure_indices = worker_failure_indices or []
         self.accuracy_failures = len(self.accuracy_failure_indices)
         self.compile_failures = len(self.compile_failure_indices)
+        self.worker_failures = len(self.worker_failure_indices)
 
 
 class _FakeLocalBenchmarkProvider:
@@ -506,6 +509,7 @@ class _FakeLocalBenchmarkProvider:
         self._autotune_metrics = autotune_metrics
         self._accuracy_failure_config_ids: list[int] = []
         self._compile_failure_config_ids: list[int] = []
+        self._worker_failure_config_ids: list[int] = []
         self.benchmark_calls: list[tuple[list[Config], str]] = []
         self.setup_count = 0
         self.cleanup_count = 0
@@ -529,6 +533,7 @@ class _FakeLocalBenchmarkProvider:
             raise self.kernel.error
         self._autotune_metrics.num_accuracy_failures += self.kernel.accuracy_failures
         self._autotune_metrics.num_compile_failures += self.kernel.compile_failures
+        self._autotune_metrics.num_worker_failures += self.kernel.worker_failures
         self._accuracy_failure_config_ids.extend(
             id(config)
             for index, config in enumerate(configs)
@@ -538,6 +543,11 @@ class _FakeLocalBenchmarkProvider:
             id(config)
             for index, config in enumerate(configs)
             if index in self.kernel.compile_failure_indices
+        )
+        self._worker_failure_config_ids.extend(
+            id(config)
+            for index, config in enumerate(configs)
+            if index in self.kernel.worker_failure_indices
         )
         if len(configs) > len(self.kernel.timings):
             raise AssertionError("fake child received too many configs")
@@ -744,12 +754,14 @@ class TestMultiShapeBenchmarkProvider(unittest.TestCase):
                     [math.inf, math.inf, 3.0],
                     accuracy_failure_indices=[0, 1],
                     compile_failure_indices=[0],
+                    worker_failure_indices=[0, 1],
                 ),
                 _FakeBoundKernel(
                     spec,
                     [math.inf, 2.0, math.inf],
                     accuracy_failure_indices=[0, 2],
                     compile_failure_indices=[0, 1],
+                    worker_failure_indices=[0, 2],
                 ),
             ]
         )
@@ -764,6 +776,7 @@ class TestMultiShapeBenchmarkProvider(unittest.TestCase):
 
         self.assertEqual(metrics.num_accuracy_failures, 3)
         self.assertEqual(metrics.num_compile_failures, 2)
+        self.assertEqual(metrics.num_worker_failures, 3)
 
     def test_invalid_anchor_materialization_discards_only_one_config(self) -> None:
         spec = _make_config_spec()


### PR DESCRIPTION
Sometimes we just want to find a single config to work well across multiple shapes. This PR adds `Kernel.autotune_multi(...)` to autotune over multiple shapes. Multi-shape tuning changes how candidates are measured while leaving existing config generation and search algorithms unchanged.

This PR proposes the following API:
```python
config = kernel.autotune_multi(
   ((x1,w1), (x2,w2), (x3,w3)), # multiple inputs with different shapes
    aggregation="geomean",
    relative_to="default",
)
```
The new keywords determine how we aggregate the latency across different shapes into a single score (and this way enable us to re-use the existing autotuners)
- relative_to = None or 'default' or 'baseline'. 
    - If it's None, we just aggregate raw latency. 
    - If it's default, we measure the  latency ratio against the default config. 
    - If it's 'baseline' we measure latency ratio against `autotune_baseline_fn`.
- aggregation = "geomean" or "max"

We include latency ratio as a possible objective so that the performance on a slow shape doesn't completely dominate the score. If a config is inaccurate or fails on 1 shape, we consider that a failed config.

Some notes on the implementation:
- Each argument set is normalized and bound independently through the existing Kernel.bind path. The first case anchors config generation.
- Duplicate bindings remain separate benchmark cases but are deduplicated when installing the winner.
- A private `_MultiShapeAutotuneArgs` carrier holds the ordered bound kernels, arguments, objective, workload key, reference timings, and observed measurements. 
- The carrier exposes the anchor arguments as a sequence, allowing normal backend dispatch, cache wrappers, and registered autotuners to run without adding multi-shape versions of each search algorithm.
- BaseSearch detects the carrier and substitutes MultiShapeBenchmarkProvider for the ordinary local provider. MultiShapeBenchmarkProvider creates one LocalBenchmarkProvider per argument set. We are able to re-use:
    - compilation and device precompilation
    - baseline output and mutation handling
    - accuracy checks
    - subprocess isolation and timeouts
    - backend timing and exception classification
    - autotuners

On rebenchmarking and accuracy:
- Population final verification and best-of-K selection rerun the complete joint benchmark pipeline. The composite finishes a rectangular batch once started so results remain aligned across shapes.
- Invalid configs and expected benchmark failures reject only the affected candidate. Fatal compiler or runtime failures continue to propagate.
- Best-of-K skips trials without a finite joint result. LLM-seeded searches can recover from a failed first or second stage. A run where every candidate is invalid raises NoConfigFound before caching or installation.

Here are some examples of multi-shape tuning for matmul and softmax (triton). X axis is latency ratio vs default config for one shape and y axis is the latency ratio for another. We plot the latency ratios for configs encountered in each generation (autotune_effort = quick) along the pareto frontier after each generation (configs with non-dominated latencies). We see a clear tradeoff in performance, and we see that the autotuner finds a good middle ground.

<img width="2520" height="990" alt="latency_ratio_pareto_fronts" src="https://github.com/user-attachments/assets/90821b4e-5b76-44d7-aaf4-71a4e65080d7" />

