### PR TITLE
[compiler] Fix codegen crash on fixed-block-size `hl.tile` loops

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -627,6 +627,11 @@ class CompileEnvironment:
             source_expr = _symint_expr(source.value)
             if isinstance(source_expr, sympy.Symbol):
                 self.shape_env._constrain_unify(source.value, info.var)
+                # Match the block var's hint to the size it is now unified with,
+                # so both agree once the shared range is narrowed.
+                shape_env_var_hints(self.shape_env)[info.symbol()] = sympy.Integer(
+                    self.size_hint(source.value)
+                )
 
         from .host_function import HostFunction
         from .host_function import SymbolOrigin

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -37,6 +37,7 @@ import helion.language as hl
 
 datadir = Path(__file__).parent / "data"
 basic_kernels = import_path(datadir / "basic_kernels.py")
+FIXED_BLOCK_SIZE = 16
 
 
 @helion.kernel
@@ -272,6 +273,29 @@ class TestLoops(RefEagerTestBase, TestCase):
             args,
         )
         torch.testing.assert_close(result, torch.sin(args[0]))
+
+    @skipIfTileIR("tileir backend will ignore `range_num_stages` hint")
+    @skipIfNotTriton("range loop hints are Triton-specific")
+    def test_fixed_block_unroll_and_pipeline(self):
+        @helion.kernel(static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            bhn = x.size(0)
+            c = x.size(1)
+            for tile_bhn in hl.tile(bhn, block_size=1):
+                for tile_c in hl.tile(c, block_size=FIXED_BLOCK_SIZE):
+                    x_block = x[tile_bhn, tile_c].float()
+                    out[tile_bhn, tile_c] = x_block
+            return out
+
+        args = (torch.randn((1, 64), device=DEVICE, dtype=HALF_DTYPE),)
+        _, result = code_and_output(
+            fn,
+            args,
+            range_num_stages=[0, 2],
+            range_unroll_factors=[0, 2],
+        )
+        torch.testing.assert_close(result, args[0])
 
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")


### PR DESCRIPTION
## TL;DR

A fixed-size `hl.tile` loop stores the wrong size for its block-size variable: the allocator's default hint (`64`) instead of the real block size (`16` in this repro). Most configs never read that hint, so the mismatch goes unnoticed. Pipelining and unrolling the same loop together triggers that read, and compilation fails with:

```text
Error in codegen for node x_block ... 64 not in VR[16, 16]
```

**The fix:** the block var is already registered equal to the size symbol, so give it that symbol's true hint, keeping the two consistent.

**Test:** a regression test compiles the fixed-tile kernel with both range options set and asserts the output equals the input.

## Issue

This kernel has a nested tile loop whose inner loop uses a fixed block size from a module constant (`FIXED_BLOCK_SIZE = 16`):

```python
for tile_bhn in hl.tile(BHN, block_size=1):                 # outer loop
    for tile_row in hl.tile(C, block_size=FIXED_BLOCK_SIZE):  # inner loop, fixed size
        x_block = x[tile_bhn, tile_row].float()
```

It compiles fine under most configs. But when the autotuner both pipelines and unrolls the inner loop (`range_num_stages >= 2` and `range_unroll_factors >= 2`), compilation dies with:

```text
Error in codegen for node x_block ... 64 not in VR[16, 16]
```

The fixed-tile path allocates the inner loop's block-size variable without passing the known size, so its hint falls back to the allocator's default:

```python
def allocate_block_size(..., hint: int = 64):
```

This leaves two ShapeEnv symbols that should agree but do not (`u2` is registered equal to `u1`, yet carries the wrong hint):

```text
u1  (source fixed size):   value 16, hint 16
u2  (allocated, u2 == u1): hint 64          <- should be 16
```

For ordinary configs Helion never forces these symbols to a concrete value, so ShapeEnv never has to reconcile `u2`'s hint with the fact that `u2 == u1 == 16`. The wrong `64` stays dormant and those configs compile.

With both `range_num_stages` and `range_unroll_factors` set, Helion caps the pipeline depth:

```python
elif range_num_stages > 1 and range_unroll_factor > 1 and ...:
    block_size = int(env.block_sizes[block_idx].from_config_assert(config))
    ...
    range_num_stages = min(max(1, ceil(remainder / step)), range_num_stages)
```

Computing that cap calls `int(...)` on the block size, so it concretizes it to `16`. That resolves `u1` and records `u2 == u1`. When Helion generates the Triton code for the inner `x[...]` read, ShapeEnv resolves `u2` to `16` through that equality,

```text
u2 allowed range: VR[16, 16]
```

and rechecks `u2`'s stored hint, `64`, against it. It does not fit:

```text
64 not in VR[16, 16]
```

## Minimal Repro

```python
import torch

import helion
import helion.language as hl


FIXED_BLOCK_SIZE = 16


@helion.kernel(static_shapes=True)
def repro(x):
    BHN = x.size(0)
    C = x.size(1)
    out = torch.empty_like(x)

    for tile_bhn in hl.tile(BHN, block_size=1):
        for tile_row in hl.tile(C, block_size=FIXED_BLOCK_SIZE):
            x_block = x[tile_bhn, tile_row].float()
            out[tile_bhn, tile_row] = x_block
    return out


CONFIG = helion.Config(
    range_num_stages=[0, 2],
    range_unroll_factors=[0, 2],
)

x = torch.empty((1, 64), device="cuda", dtype=torch.bfloat16)
bound = helion.kernel(repro.fn, config=CONFIG, static_shapes=True).bind((x,))
bound.to_triton_code(CONFIG)
```

## Fix

Where `allocate_block_size` constrains the block var equal to the size symbol, give it that symbol's hint too, in `helion/_compiler/compile_environment.py`:

```python
self.shape_env._constrain_unify(source.value, info.var)
shape_env_var_hints(self.shape_env)[info.symbol()] = sympy.Integer(
    self.size_hint(source.value)
)
```
