### PR TITLE
pallas: Use bf16 vocab reduction buffer to reduce VMEM usage in topk

### DIFF
--- a/helion/_compiler/pallas/topk_impl.py
+++ b/helion/_compiler/pallas/topk_impl.py
@@ -467,28 +467,40 @@ def divide_filter_topk(
     each (rows, k); values descending, indices int32 into V. k must be static."""
     rows, vocab = x.shape
     orig_dtype = x.dtype
-    # Mosaic can't relayout the i1 masks produced by sub-32-bit (e.g. bf16)
-    # compares in the strided loop ("Invalid relayout ... vector<8x128xi1>"), so
-    # run the reduction in f32 and cast the returned values back. (tallax instead
-    # packs a bf16 value + its index into a single i32.)
-    if jnp.issubdtype(orig_dtype, jnp.floating) and orig_dtype != jnp.float32:
-        x = x.astype(jnp.float32)
+    # The [rows, vocab] buffer dominates scoped VMEM. Mosaic can't relayout the i1
+    # masks from sub-32-bit compares in the strided loop ("Invalid relayout ...
+    # vector<8x128xi1>"), but rather than upcast the WHOLE vocab to f32 (which doubles
+    # that dominant buffer for bf16 inputs), keep x in its native dtype and upcast
+    # each num_bins-wide slice to f32 for the compare below -- a small transient.
+    # best_val and the compares run in f32; returned values cast back to orig_dtype.
+    # (tallax instead packs a bf16 value + its index into a single i32.)
     num_bins = num_bins_for(k, vocab, recall_target)
-    neg = jnp.finfo(x.dtype).min
+    neg = jnp.finfo(jnp.float32).min  # best_val + compares run in f32 (see above)
     col = lax.broadcasted_iota(jnp.int32, (rows, num_bins), 1)  # (rows, num_bins)
 
-    # Pad V up to a whole number of strided passes of width num_bins.
-    num_slices = -(-vocab // num_bins)  # ceil
-    pad = num_slices * num_bins - vocab
-    if pad:
-        x = jnp.pad(x, ((0, 0), (0, pad)), constant_values=neg)
-
-    # Step 1: per-bin running max + carried global index (strided bins).
-    best_val = jnp.full((rows, num_bins), neg, x.dtype)
+    # Step 1: per-bin running max + carried global index (strided bins). Slice the
+    # ORIGINAL x in full num_bins-wide passes and pad ONLY the ragged tail -- never
+    # materialize a second full-vocab copy (jnp.pad of all of V doubles the scoped
+    # VMEM; tallax likewise handles the remainder in-loop via a small padded slice).
+    num_full_slices = vocab // num_bins
+    remainder = vocab - num_full_slices * num_bins
+    best_val = jnp.full((rows, num_bins), neg, jnp.float32)
     best_idx = jnp.zeros((rows, num_bins), jnp.int32)
-    for i in range(num_slices):
-        seg = x[:, i * num_bins : (i + 1) * num_bins]  # (rows, num_bins)
+    for i in range(num_full_slices):
+        seg = x[:, i * num_bins : (i + 1) * num_bins].astype(
+            jnp.float32
+        )  # f32 for compare
         gidx = i * num_bins + col  # global vocab index
+        take = seg > best_val
+        best_val = jnp.where(take, seg, best_val)
+        best_idx = jnp.where(take, gidx, best_idx)
+    if remainder:
+        seg = jnp.pad(
+            x[:, num_full_slices * num_bins :].astype(jnp.float32),
+            ((0, 0), (0, num_bins - remainder)),
+            constant_values=neg,
+        )  # pad only the small ragged tail (<= num_bins wide), not all of V
+        gidx = num_full_slices * num_bins + col
         take = seg > best_val
         best_val = jnp.where(take, seg, best_val)
         best_idx = jnp.where(take, gidx, best_idx)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -940,6 +940,36 @@ class TestPallas(TestCase):
         )
         self.assertGreaterEqual(recall, 0.99)
 
+    @skipIfPallasInterpret("topk bitonic path doesn't work in interpret mode")
+    def test_topk_bf16_vocab_reduction(self) -> None:
+        """bf16 input: the (rows, vocab) reduction buffer stays bf16 (halves the
+        scoped VMEM) while each num_bins slice upcasts to f32 for the compare, so
+        the top-1 value and a high recall survive."""
+        torch.manual_seed(0)
+        xf = torch.randn(64, 4096, device=DEVICE, dtype=torch.float32)
+        x = xf.to(torch.bfloat16)
+        _, (vals, idx) = code_and_output(
+            _topk_pallas_kernel, (x, _TOPK_TEST_K), block_sizes=[8]
+        )
+        # top-1 value matches the true max (index may differ under bf16 ties)
+        torch.testing.assert_close(
+            vals[:, 0].float().cpu(),
+            xf.max(dim=-1).values.cpu(),
+            rtol=0.03,
+            atol=0.05,
+        )
+        ref_i = torch.topk(xf, _TOPK_TEST_K, dim=-1, largest=True)[1].cpu()
+        idx_c = idx.cpu()
+        ref_sets = [set(r.tolist()) for r in ref_i]
+        recall = (
+            sum(
+                len(set(idx_c[r].tolist()) & ref_sets[r]) / _TOPK_TEST_K
+                for r in range(xf.shape[0])
+            )
+            / xf.shape[0]
+        )
+        self.assertGreater(recall, 0.9)
+
     def test_constant_pad_nd_lowering(self) -> None:
         """F.pad lowers to aten.constant_pad_nd -> jnp.pad on the pallas backend."""
         torch.manual_seed(0)


### PR DESCRIPTION
Stacked PRs:
 * #3128
 * __->__#3125


--- --- ---

### pallas: Use bf16 vocab reduction buffer to reduce VMEM usage in topk


divide_filter_topk upcast the ENTIRE (rows, vocab) input to f32 (Mosaic can't
relayout the i1 masks from sub-32-bit compares), making that buffer -- the dominant
scoped-VMEM consumer -- f32. A top-k over a large vocabulary (e.g. a (rows, ~200K)
logits reduction feeding a sampler) then overruns a tight scoped-vmem cap: at a
~24MB cap the f32 buffer OOMs by a few hundred KB at precompile.

Keep the (rows, vocab) buffer in its native dtype and upcast each num_bins-wide
slice to f32 for the compare instead (best_val + compares stay f32; the per-slice
upcast is a small transient). Halves the dominant buffer for bf16 inputs -> fits
under the cap at recall ~0.989 (vs ~0.996 f32). f32 inputs unchanged (per-slice
cast is a no-op). Also handle the ragged tail in-loop instead of jnp.pad-ing all of
V (avoids a second full-vocab buffer).

Test: test_pallas.py::TestPallas::test_topk_bf16_vocab_reduction -- bf16 top-k
keeps the top-1 value exact and recall > 0.9.
