### PR TITLE
pallas: round full block dims up to the Mosaic tiling (fixes ragged top-k on jax 0.10.0)

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -40,12 +40,16 @@ def load_expr(
         if isinstance(pattern, IndirectGatherPattern):
             return emit_gather(state, pattern.plan, name)
 
-    idx_str, none_dims = index_str(state, subscript, tensor)
+    parts, none_dims = index_parts(state, list(subscript), tensor)
+    idx_str = ", ".join(parts)
     mask_expr = _load_mask_expr(state, subscript, tensor)
     if mask_expr is not None:
         result = expr_from_string(f"{name}[{idx_str}] * ({mask_expr})")
     else:
         result = expr_from_string(f"{name}[{idx_str}]")
+    result = _narrow_loaded_value_for_roundup(
+        state, list(subscript), tensor, parts, result
+    )
     for dim in none_dims:
         result = expr_from_string(
             f"jnp.expand_dims({{result}}, axis={dim})", result=result
@@ -227,6 +231,75 @@ def _tensor_routed_to_fori_scratch(state: CodegenState, tensor: torch.Tensor) ->
     return isinstance(loop, ForiLoopState)
 
 
+def _pallas_round_full_dim(n: int, d: int, ndim: int) -> int:
+    """Mirror of ``helion.runtime._pallas_round_full_dim`` -- keep the two in sync.
+
+    Round a full (``None``-template) block dim UP to the Mosaic tiling (128 last,
+    8 second-last). The launcher widens the ``BlockSpec`` by exactly this amount so
+    the pipelined double-buffered scratch slice is 128-aligned on jax 0.10.0; here
+    we pad stored values by the same amount to fill the widened ref.
+    """
+    if d == ndim - 1:
+        return -(-n // 128) * 128
+    if d == ndim - 2:
+        return -(-n // 8) * 8
+    return n
+
+
+def _narrow_loaded_value_for_roundup(
+    state: CodegenState,
+    subscript: list[object],
+    tensor: torch.Tensor,
+    parts: list[str],
+    result: ast.AST,
+) -> ast.AST:
+    """Read-side mirror of ``sliced_value_for_store``'s value padding.
+
+    When the launcher rounds a full block dim UP (``_pallas_round_full_dim``), the
+    loaded ref includes rounded tail lanes holding clamped / garbage data. Slice the
+    loaded value back to the logical width so the kernel never sees them -- e.g. so a
+    top-k over a ragged vocab cannot return an out-of-range index. Only full (``:``,
+    non-tile) dims that the launcher actually widened are narrowed; everything else
+    is left untouched, so this is a no-op for already-aligned / non-rounded loads.
+    """
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    assert state.fx_node is not None
+    patterns = state.fx_node.meta.get("indexing_patterns")
+    if patterns is None:
+        return result
+
+    slices: list[str] = []
+    needs_slice = False
+    tensor_dim = 0
+    index_part_idx = 0
+    ndim = tensor.ndim
+    for idx, pattern in zip(subscript, patterns, strict=True):
+        if idx is None:
+            continue
+        value_slice = ":"
+        index_part = parts[index_part_idx]
+        index_part_idx += 1
+        dim_size = tensor.shape[tensor_dim]
+        if (
+            not isinstance(pattern, TilePattern)
+            and index_part == ":"
+            and isinstance(dim_size, int)
+            and _pallas_round_full_dim(dim_size, tensor_dim, ndim) > dim_size
+        ):
+            value_slice = f":{dim_size}"
+            needs_slice = True
+        slices.append(value_slice)
+        tensor_dim += 1
+
+    if not needs_slice:
+        return result
+    return expr_from_string(
+        f"{{result}}[{', '.join(slices)}]",
+        result=result,
+    )
+
+
 def sliced_value_for_store(
     state: CodegenState,
     tensor: torch.Tensor,
@@ -257,12 +330,18 @@ def sliced_value_for_store(
     if patterns is None:
         return value
 
-    if _tensor_routed_to_fori_scratch(state, tensor):
-        return value
+    # Clamp-slicing (block clamped DOWN to the tensor) is exempt for fori-scratch
+    # destinations -- their ref is block-shaped, not clamped. Round-up padding
+    # (block rounded UP past the tensor by _pallas_round_full_dim) applies either
+    # way: the ref is the widened block, so a narrower computed value (e.g. a top-k
+    # width) must be padded to fill it; the writeback DMA clamps the extra lanes.
+    slice_exempt = _tensor_routed_to_fori_scratch(state, tensor)
 
     env = CompileEnvironment.current()
     slices: list[str] = []
+    pad_afters: list[int] = []
     needs_slice = False
+    needs_pad = False
     tensor_dim = 0
 
     index_part_idx = 0
@@ -271,29 +350,42 @@ def sliced_value_for_store(
             continue
 
         value_slice = ":"
+        pad_after = 0
         index_part = index_parts[index_part_idx]
         index_part_idx += 1
+        dim_size = tensor.shape[tensor_dim]
         if isinstance(pattern, TilePattern) and index_part == ":":
-            block_size = env.block_sizes[pattern.block_id].from_config(state.config)
-            dim_size = tensor.shape[tensor_dim]
-            if (
-                isinstance(block_size, int)
-                and isinstance(dim_size, int)
-                and dim_size < block_size
-            ):
-                value_slice = f":{dim_size}"
-                needs_slice = True
+            if not slice_exempt:
+                block_size = env.block_sizes[pattern.block_id].from_config(state.config)
+                if (
+                    isinstance(block_size, int)
+                    and isinstance(dim_size, int)
+                    and dim_size < block_size
+                ):
+                    value_slice = f":{dim_size}"
+                    needs_slice = True
+        elif index_part == ":" and isinstance(dim_size, int):
+            rounded = _pallas_round_full_dim(dim_size, tensor_dim, tensor.ndim)
+            if rounded > dim_size:
+                pad_after = rounded - dim_size
+                needs_pad = True
 
         slices.append(value_slice)
+        pad_afters.append(pad_after)
         tensor_dim += 1
 
-    if not needs_slice:
-        return value
-
-    return expr_from_string(
-        f"{{value}}[{', '.join(slices)}]",
-        value=value,
-    )
+    if needs_slice:
+        value = expr_from_string(
+            f"{{value}}[{', '.join(slices)}]",
+            value=value,
+        )
+    if needs_pad:
+        pad_width = ", ".join(f"(0, {a})" for a in pad_afters)
+        value = expr_from_string(
+            f"jnp.pad({{value}}, ({pad_width}))",
+            value=value,
+        )
+    return value
 
 
 def _tile_needs_mask(

--- a/helion/_compiler/pallas/topk_impl.py
+++ b/helion/_compiler/pallas/topk_impl.py
@@ -467,28 +467,40 @@ def divide_filter_topk(
     each (rows, k); values descending, indices int32 into V. k must be static."""
     rows, vocab = x.shape
     orig_dtype = x.dtype
-    # Mosaic can't relayout the i1 masks produced by sub-32-bit (e.g. bf16)
-    # compares in the strided loop ("Invalid relayout ... vector<8x128xi1>"), so
-    # run the reduction in f32 and cast the returned values back. (tallax instead
-    # packs a bf16 value + its index into a single i32.)
-    if jnp.issubdtype(orig_dtype, jnp.floating) and orig_dtype != jnp.float32:
-        x = x.astype(jnp.float32)
+    # The [rows, vocab] buffer dominates scoped VMEM. Mosaic can't relayout the i1
+    # masks from sub-32-bit compares in the strided loop ("Invalid relayout ...
+    # vector<8x128xi1>"), but rather than upcast the WHOLE vocab to f32 (which doubles
+    # that dominant buffer for bf16 inputs), keep x in its native dtype and upcast
+    # each num_bins-wide slice to f32 for the compare below -- a small transient.
+    # best_val and the compares run in f32; returned values cast back to orig_dtype.
+    # (tallax instead packs a bf16 value + its index into a single i32.)
     num_bins = num_bins_for(k, vocab, recall_target)
-    neg = jnp.finfo(x.dtype).min
+    neg = jnp.finfo(jnp.float32).min  # best_val + compares run in f32 (see above)
     col = lax.broadcasted_iota(jnp.int32, (rows, num_bins), 1)  # (rows, num_bins)
 
-    # Pad V up to a whole number of strided passes of width num_bins.
-    num_slices = -(-vocab // num_bins)  # ceil
-    pad = num_slices * num_bins - vocab
-    if pad:
-        x = jnp.pad(x, ((0, 0), (0, pad)), constant_values=neg)
-
-    # Step 1: per-bin running max + carried global index (strided bins).
-    best_val = jnp.full((rows, num_bins), neg, x.dtype)
+    # Step 1: per-bin running max + carried global index (strided bins). Slice the
+    # ORIGINAL x in full num_bins-wide passes and pad ONLY the ragged tail -- never
+    # materialize a second full-vocab copy (jnp.pad of all of V doubles the scoped
+    # VMEM; tallax likewise handles the remainder in-loop via a small padded slice).
+    num_full_slices = vocab // num_bins
+    remainder = vocab - num_full_slices * num_bins
+    best_val = jnp.full((rows, num_bins), neg, jnp.float32)
     best_idx = jnp.zeros((rows, num_bins), jnp.int32)
-    for i in range(num_slices):
-        seg = x[:, i * num_bins : (i + 1) * num_bins]  # (rows, num_bins)
+    for i in range(num_full_slices):
+        seg = x[:, i * num_bins : (i + 1) * num_bins].astype(
+            jnp.float32
+        )  # f32 for compare
         gidx = i * num_bins + col  # global vocab index
+        take = seg > best_val
+        best_val = jnp.where(take, seg, best_val)
+        best_idx = jnp.where(take, gidx, best_idx)
+    if remainder:
+        seg = jnp.pad(
+            x[:, num_full_slices * num_bins :].astype(jnp.float32),
+            ((0, 0), (0, num_bins - remainder)),
+            constant_values=neg,
+        )  # pad only the small ragged tail (<= num_bins wide), not all of V
+        gidx = num_full_slices * num_bins + col
         take = seg > best_val
         best_val = jnp.where(take, seg, best_val)
         best_idx = jnp.where(take, gidx, best_idx)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -203,6 +203,26 @@ def default_launcher(
         raise
 
 
+def _pallas_round_full_dim(n: int, d: int, ndim: int) -> int:
+    """Round a full (``None``-template) block dim UP to the Mosaic tiling: the last
+    dim to a 128-multiple, the second-last to an 8-multiple.
+
+    On jax 0.10.0 Mosaic rejects a slice of a *tiled* (pipelined / double-buffered)
+    memref whose last dim isn't 128-aligned -- ``emit_pipeline``'s scratch
+    buffer-select fails with "Slice shape ... must be aligned to tiling (128), but
+    is <n>". Rounding the full dim up is free (a VMEM lane/sublane tile is that size
+    regardless); the pipeline clamps the ragged tail on reads, and the store codegen
+    (``sliced_value_for_store``) pads written values to fill the widened ref, so the
+    two MUST stay in sync. jax 0.10.1 tolerates the ragged tile (a harmless no-op for
+    already-aligned dims).
+    """
+    if d == ndim - 1:
+        return -(-n // 128) * 128
+    if d == ndim - 2:
+        return -(-n // 8) * 8
+    return n
+
+
 def _pallas_make_block_spec(
     pl: object,
     jnp: object,
@@ -230,10 +250,20 @@ def _pallas_make_block_spec(
         return pl.BlockSpec(full_shape, index_map_full, memory_space=memory_space)  # type: ignore[union-attr]
 
     block_shape_template, grid_dims = entry
+    ndim = len(block_shape_template)
+
     # Clamp to >= 1: empty tensors (zero-work grids) would otherwise produce
-    # 0-sized block dims, which the interpret machinery divides by.
+    # 0-sized block dims, which the interpret machinery divides by. A ``None``
+    # template ("keep the whole dim") is rounded UP to the Mosaic tiling via
+    # ``_pallas_round_full_dim`` so the pipelined double-buffered scratch slice is
+    # 128-aligned on jax 0.10.0 (the store codegen pads written values to match).
     block_shape = tuple(
-        max(min(bs, tensor.shape[d]) if bs is not None else tensor.shape[d], 1)
+        max(
+            min(bs, tensor.shape[d])
+            if bs is not None
+            else _pallas_round_full_dim(tensor.shape[d], d, ndim),
+            1,
+        )
         for d, bs in enumerate(block_shape_template)
     )
     # Block indices past the last block are clamped, matching pallas_call's

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -915,6 +915,36 @@ class TestPallas(TestCase):
         )
         self.assertGreaterEqual(recall, 0.99)
 
+    @skipIfPallasInterpret("topk bitonic path doesn't work in interpret mode")
+    def test_topk_bf16_vocab_reduction(self) -> None:
+        """bf16 input: the (rows, vocab) reduction buffer stays bf16 (halves the
+        scoped VMEM) while each num_bins slice upcasts to f32 for the compare, so
+        the top-1 value and a high recall survive."""
+        torch.manual_seed(0)
+        xf = torch.randn(64, 4096, device=DEVICE, dtype=torch.float32)
+        x = xf.to(torch.bfloat16)
+        _, (vals, idx) = code_and_output(
+            _topk_pallas_kernel, (x, _TOPK_TEST_K), block_sizes=[8]
+        )
+        # top-1 value matches the true max (index may differ under bf16 ties)
+        torch.testing.assert_close(
+            vals[:, 0].float().cpu(),
+            xf.max(dim=-1).values.cpu(),
+            rtol=0.03,
+            atol=0.05,
+        )
+        ref_i = torch.topk(xf, _TOPK_TEST_K, dim=-1, largest=True)[1].cpu()
+        idx_c = idx.cpu()
+        ref_sets = [set(r.tolist()) for r in ref_i]
+        recall = (
+            sum(
+                len(set(idx_c[r].tolist()) & ref_sets[r]) / _TOPK_TEST_K
+                for r in range(xf.shape[0])
+            )
+            / xf.shape[0]
+        )
+        self.assertGreater(recall, 0.9)
+
     def test_store_slice_1d(self) -> None:
         """Store value sliced when block_size > tensor dim (1D)."""
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -945,6 +945,32 @@ class TestPallas(TestCase):
         )
         self.assertGreater(recall, 0.9)
 
+    @skipIfPallasInterpret("topk bitonic path doesn't work in interpret mode")
+    def test_topk_ragged_vocab_roundup(self) -> None:
+        """Ragged vocab (V % 128 != 0) plus ragged k: the launcher rounds the full
+        block dims up to the Mosaic tiling, the load codegen narrows the loaded
+        value back (so the rounded tail can't leak a >=V index) and the store
+        codegen pads the k-wide result (the writeback DMA clamps it to k). The
+        output is the logical (rows, k) and every index is in-vocab."""
+        torch.manual_seed(0)
+        rows, vocab, k = 64, 4160, 50  # 4160 % 128 == 64, 50 % 128 == 50 (both ragged)
+        x = torch.randn(rows, vocab, device=DEVICE, dtype=torch.float32)
+        _, (vals, idx) = code_and_output(_topk_pallas_kernel, (x, k), block_sizes=[8])
+        idx_c = idx.cpu()
+        # logical output shape (not the rounded-up width)
+        self.assertEqual(tuple(idx_c.shape), (rows, k))
+        # the rounded tail must not leak an out-of-vocab index
+        self.assertGreaterEqual(int(idx_c.min()), 0)
+        self.assertLess(int(idx_c.max()), vocab)
+        ref_i = torch.topk(x, k, dim=-1, largest=True)[1].cpu()
+        self.assertTrue(torch.equal(idx_c[:, 0], ref_i[:, 0].to(torch.int32)))
+        ref_sets = [set(r.tolist()) for r in ref_i]
+        recall = (
+            sum(len(set(idx_c[r].tolist()) & ref_sets[r]) / k for r in range(rows))
+            / rows
+        )
+        self.assertGreater(recall, 0.9)
+
     def test_store_slice_1d(self) -> None:
         """Store value sliced when block_size > tensor dim (1D)."""
 


### PR DESCRIPTION
Stacked PRs:
 * #3127
 * __->__#3126
 * #3125


--- --- ---

### pallas: round full block dims up to the Mosaic tiling (fixes ragged top-k on jax 0.10.0)


A top-k over a ragged vocab -- e.g.

    @helion.kernel(backend="pallas")
    def topk(logits, k):                     # logits (rows, V), V % 128 != 0
        for t in hl.tile(rows):
            v, i = torch.topk(logits[t, :], k)   # k % 128 != 0 too
            out_v[t, :], out_i[t, :] = v, i.to(torch.int32)

fails to compile on jax 0.10.0:

    Mosaic: Slice shape along dimension 2 must be aligned to tiling (128), but is <V>

The launcher drives the grid with pltpu.emit_pipeline, which double-buffers each
pipe in_spec into a [2, block, V] VMEM scratch and slices it per step; 0.10.0's
Mosaic requires that tiled memref's last dim be a 128-multiple (second-last an
8-multiple). A full (None-template) block dim keeps the raw size (V, k), so the
slice is ragged and rejected. (jax 0.10.1 tolerates the ragged final tile.)

Fix: round full block dims UP to the tiling in _pallas_make_block_spec (shared
_pallas_round_full_dim), so the double-buffered scratch is aligned. To keep kernels
correct around the now-wider ref:
  - store codegen (sliced_value_for_store) pads a written value UP to the ref; the
    writeback DMA clamps it back to the logical out_shape.
  - load codegen (_narrow_loaded_value_for_roundup) narrows a loaded value BACK to
    the logical width, so the kernel never sees the rounded tail lanes (a top-k thus
    cannot return an out-of-range index).

No host-side padding; a no-op for already-aligned dims and on jax 0.10.1.

Test: test_pallas.py::TestPallas::test_topk_ragged_vocab_roundup -- a ragged-vocab,
ragged-k top-k returns the logical (rows, k) shape, every index in-vocab, recall > 0.9.
