### PR TITLE
pallas: lower aten.constant_pad_nd (F.pad) to jnp.pad

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -265,6 +265,9 @@ argmax_lowering = register_lowering(torch.ops.aten.argmax.default)
 argmin_lowering = register_lowering(torch.ops.aten.argmin.default)
 
 
+constant_pad_nd_lowering = register_lowering(torch.ops.aten.constant_pad_nd.default)
+
+
 def _argreduce_schema(node: Node) -> tuple[torch.Tensor, int | None, bool]:
     input_node = cast("Node", node.args[0])
     input_val = input_node.meta["val"]

--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import ast
 from operator import getitem
 from typing import TYPE_CHECKING
+from typing import cast
 
 import torch
 from torch.fx.node import Node
@@ -28,6 +29,7 @@ from ..aten_lowering import argmax_lowering
 from ..aten_lowering import argmin_lowering
 from ..aten_lowering import baddbmm_lowering
 from ..aten_lowering import bmm_lowering
+from ..aten_lowering import constant_pad_nd_lowering
 from ..aten_lowering import expand_lowering
 from ..aten_lowering import iota_lowering
 from ..aten_lowering import mm_lowering
@@ -75,6 +77,36 @@ def codegen_view_pallas(ctx: LoweringContext, node: Node) -> object:
                 tensor=tensor,
             )
     return expr_from_string(f"jnp.reshape({{tensor}}, {shape_str})", tensor=tensor)
+
+
+@constant_pad_nd_lowering.register_codegen("pallas")
+def codegen_constant_pad_nd_pallas(ctx: LoweringContext, node: Node) -> object:
+    """``F.pad(x, pad, value)`` (aten.constant_pad_nd) -> inline ``jnp.pad``.
+
+    Mosaic lacks a direct constant_pad_nd lowering, so emit a fused ``jnp.pad``.
+    ``pad`` is aten's flat, from-the-last-dim format
+    ``[last_lo, last_hi, 2ndlast_lo, 2ndlast_hi, ...]``; convert to jnp's per-dim
+    ``((lo, hi), ...)`` ordered from the first dim. Used e.g. to pad a top-k
+    output up to a 128-aligned width so the store is Mosaic-tile-aligned on jax
+    0.10.0 without computing a wider top-k.
+    """
+    tensor = map_arg(node.args[0], lambda arg: _env_arg(ctx, arg))
+    assert isinstance(tensor, ast.AST)
+    pad = [int(p) for p in cast("list[int]", node.args[1])]  # static pad widths
+    value = node.args[2] if len(node.args) > 2 else node.kwargs.get("value", 0)
+    ndim = node.meta["val"].ndim
+    npad = len(pad) // 2
+    pad_width = [
+        (pad[2 * (ndim - 1 - j)], pad[2 * (ndim - 1 - j) + 1])
+        if (ndim - 1 - j) < npad
+        else (0, 0)
+        for j in range(ndim)
+    ]
+    pw = "(" + ", ".join(f"({lo}, {hi})" for lo, hi in pad_width) + ")"
+    return expr_from_string(
+        f"jnp.pad({{t}}, {pw}, mode='constant', constant_values={value!r})",
+        t=tensor,
+    )
 
 
 @permute_lowering.register_codegen("pallas")

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -671,6 +671,17 @@ def _topk_pallas_kernel(x: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Te
     return out_v, out_i
 
 
+@helion.kernel(backend="pallas", static_shapes=True)
+def _constant_pad_pallas_kernel(x: torch.Tensor) -> torch.Tensor:
+    """F.pad -> aten.constant_pad_nd -> jnp.pad on the pallas backend (pad the
+    lane dim, mirroring the spec-decode sampler's in-kernel output padding)."""
+    rows, cols = x.shape
+    out = torch.empty([rows, cols + 128], dtype=x.dtype, device=x.device)
+    for tile in hl.tile(rows):
+        out[tile, :] = torch.nn.functional.pad(x[tile, :], (0, 128), value=0.0)
+    return out
+
+
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
@@ -928,6 +939,17 @@ class TestPallas(TestCase):
             / x.shape[0]
         )
         self.assertGreaterEqual(recall, 0.99)
+
+    def test_constant_pad_nd_lowering(self) -> None:
+        """F.pad lowers to aten.constant_pad_nd -> jnp.pad on the pallas backend."""
+        torch.manual_seed(0)
+        x = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            _constant_pad_pallas_kernel, (x,), block_sizes=[8]
+        )
+        self.assertIn("jnp.pad", code)
+        expected = torch.nn.functional.pad(x, (0, 128), value=0.0)
+        torch.testing.assert_close(result, expected)
 
     def test_store_slice_1d(self) -> None:
         """Store value sliced when block_size > tensor dim (1D)."""


### PR DESCRIPTION
Stacked PRs:
 * #3128
 * #3125
 * __->__#3127


--- --- ---

### pallas: lower aten.constant_pad_nd (F.pad) to jnp.pad


torch.nn.functional.pad / aten.constant_pad_nd had no pallas lowering, so a kernel
that pads a tile (e.g. padding a reduction result out to a tile-aligned width)
failed to lower. Register constant_pad_nd_lowering and a pallas codegen that emits
jnp.pad, converting aten's flat last-dim-first pad list to jnp's per-dim
((before, after), ...) form.

Test: test_pallas.py::TestPallas::test_constant_pad_nd_lowering -- F.pad in a
kernel emits jnp.pad and matches torch.nn.functional.pad.
