### PR TITLE
pallas: skip squeezed index dims in sliced_value_for_store

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -257,6 +257,9 @@ def sliced_value_for_store(
     writeback DMA clamps the extent instead (see ``_build_dma_slices``).
     """
     from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TilePattern
 
     assert state.fx_node is not None
@@ -266,6 +269,15 @@ def sliced_value_for_store(
 
     if _tensor_routed_to_fori_scratch(state, tensor):
         return value
+
+    # Patterns that consume a tensor dim without it surviving into the stored
+    # value's shape (a scalar/offset index squeezes that dim) don't get a
+    # slice entry -- the value has no such dimension to slice.
+    squeezing_patterns = (
+        ArbitraryIndexPattern,
+        TileIndexWithOffsetPattern,
+        TileBeginWithOffsetPattern,
+    )
 
     env = CompileEnvironment.current()
     slices: list[str] = []
@@ -277,9 +289,13 @@ def sliced_value_for_store(
         if idx is None:
             continue
 
-        value_slice = ":"
         index_part = index_parts[index_part_idx]
         index_part_idx += 1
+        if isinstance(pattern, squeezing_patterns):
+            tensor_dim += 1
+            continue
+
+        value_slice = ":"
         if isinstance(pattern, TilePattern) and index_part == ":":
             block_size = env.block_sizes[pattern.block_id].from_config(state.config)
             dim_size = tensor.shape[tensor_dim]

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -3352,6 +3352,35 @@ class TestPallas(TestCase):
         expected = x + x[:, -1:]
         torch.testing.assert_close(result, expected)
 
+    @skipIfPallasInterpret("slicing error in JAX interpret mode")
+    def test_scalar_row_ragged_col_store(self) -> None:
+        """A store with a scalar row index and a ragged-tile column on the
+        same tensor must not misalign the value slice with the tensor's dims.
+
+        ``sliced_value_for_store`` clamp-slices a ``TilePattern`` dim whose
+        last tile is narrower than ``block_size`` (here ``m=20`` -> a
+        remainder tile of 108 against ``block_size=128``). The literal ``0`` row
+        index is a scalar (``ArbitraryIndexPattern``): it consumes a tensor
+        dim but is squeezed out of the *value*'s shape, so it must not get a
+        slice entry of its own -- otherwise the clamp slice is built against
+        the wrong dimension of the (lower-rank) value and Pallas rejects it
+        with "Too many indices".
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scalar_row_ragged_col_store(x: torch.Tensor) -> torch.Tensor:
+            _n, m = x.shape
+            out = torch.zeros_like(x)
+            for tile_m in hl.tile(m):
+                out[0, tile_m] = x[0, tile_m] * 2.0
+            return out
+
+        x = torch.randn(1, 20, device=DEVICE)
+        _, result = code_and_output(
+            scalar_row_ragged_col_store, (x,), block_sizes=[128]
+        )
+        torch.testing.assert_close(result, x * 2.0)
+
     @xfailIfPallasTpu(
         "Mixed scalar write + slice needs tensor duplication into SMEM and VMEM"
     )


### PR DESCRIPTION

``sliced_value_for_store`` clamps a stored value down to the ref's logical
width for each tile dim whose last block is ragged (``dim_size < block_size``).
It built one slice entry per *tensor* dim, but a scalar / offset index (e.g.
``out[0, tile]`` or ``out[tile.begin, tile]``) consumes a tensor dim without it
surviving into the *value*'s shape -- the value is already squeezed on that
axis. The extra ``:`` entry then made the slice rank exceed the value rank:

    out[0, tile_m] = ...   # m ragged against block_size
    # generated: out[0, :] = value[:, :m]   ->  value is 1-D
    # IndexError: Too many indices: array is 1-dimensional, but 2 were indexed

Skip squeezing patterns (``ArbitraryIndexPattern`` /
``TileIndexWithOffsetPattern`` / ``TileBeginWithOffsetPattern``) when building
the value slice, exactly as ``_load_mask_expr`` already does for the mask's
``out_dim`` -- so the slice is built against the dims the value actually has.

Test: test_pallas.py::TestPallas::test_scalar_row_ragged_col_store.
