### PR TITLE
Fix pyrefly bad-argument-type on all_gather_object for torch nightly

### DIFF
--- a/helion/_dist_utils.py
+++ b/helion/_dist_utils.py
@@ -36,6 +36,7 @@ def all_gather_object(obj: T, process_group_name: str | None = None) -> list[T]:
 
     group = _resolve_process_group(process_group_name)
     object_list = [None] * dist.get_world_size(group)
+    # pyrefly: ignore[bad-argument-type]
     dist.all_gather_object(object_list, obj, group=group)
     return object_list  # pyrefly: ignore
 
@@ -121,6 +122,7 @@ def check_config_consistancy(
     assert process_group_name is not None
     group = _resolve_process_group(process_group_name)
     all_configs = [None] * dist.get_world_size(group)
+    # pyrefly: ignore[bad-argument-type]
     dist.all_gather_object(all_configs, config, group=group)
     if dist.get_rank() == 0:
         # do the check on rank 0


### PR DESCRIPTION
The torch nightly's `all_gather_object` stub now types the `obj` parameter as `None`, so pyrefly (1.1.1) fails lint on the two calls in `helion/_dist_utils.py`:

```
ERROR Argument `T` is not assignable to parameter `obj` with type `None` in `torch.distributed.distributed_c10d.all_gather_object` [bad-argument-type]
  --> helion/_dist_utils.py:39:41
  --> helion/_dist_utils.py:124:41
```

Add `# pyrefly: ignore[bad-argument-type]` above both calls, matching the suppression this file already uses (lines 88, 102, 230) for the same torch-stub mismatch. The calls themselves are correct; only the upstream stub is wrong.