### PR TITLE
[pallas] refactor: separate compact_worklist from loop types

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -321,10 +321,9 @@ class CompileEnvironment:
         self._tensor_input_source_cache: dict[int, Source | None] = {}
         self.jagged_tile_parent_ids: dict[int, list[int]] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
-        # Set by the Pallas backend when config["pallas_loop_type"] ==
-        # "compact_worklist" and detect_compact_worklist_plan succeeds; gates the
-        # whole compact-worklist codegen path (see helion/_compiler/pallas/
-        # compact_worklist.py).
+        # Set by the Pallas backend when worklist grouping is 1 and
+        # detect_compact_worklist_plan succeeds; gates the compact-worklist
+        # codegen path (see helion/_compiler/pallas/compact_worklist.py).
         self.compact_worklist_plan: CompactWorklistPlan | None = None
         # Final resident-cache decision for this concrete config.  This includes
         # the cached physical window integer; runtime/codegen consumers must read

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -1338,10 +1338,8 @@ if __name__ == "__main__":
     """)
 
 
-def _maybe_emit_compact_worklist_builder(codegen: GenerateAST, config: Config) -> None:
+def _maybe_emit_compact_worklist_builder(codegen: GenerateAST) -> None:
     """Emit the module-level jnp ``_build_worklist`` for a compact-worklist kernel."""
-    if config.get("pallas_loop_type") != "compact_worklist":
-        return
     env = CompileEnvironment.current()
     plan = env.compact_worklist_plan
     if plan is None:
@@ -1387,7 +1385,7 @@ def generate_ast(
             # Emit the worklist builder + record its offset params BEFORE the host
             # body is visited (the launcher call -- which reads the offset params
             # via build_launcher_args -- is generated during that visit).
-            _maybe_emit_compact_worklist_builder(codegen, config)
+            _maybe_emit_compact_worklist_builder(codegen)
 
             for stmt in func.body:
                 codegen.add_statement(codegen.visit(stmt))

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -178,6 +178,7 @@ class PallasBackend(Backend):
             "block_sizes",
             "loop_orders",
             "flatten_loops",
+            "pallas_worklist_grouping",
             "pallas_loop_type",
             "pallas_load_buffer_count",
             "pallas_pre_broadcast",
@@ -1080,7 +1081,6 @@ class PallasBackend(Backend):
                 launcher_args.append(f"_smem_arg_indices={smem_arg_indices!r}")
 
         # Pass scratch shapes for pipeline/fori_loop launcher
-        pallas_loop_type = config.get("pallas_loop_type", "unroll")
         scratch_shapes = [
             (
                 s.shape,
@@ -1127,7 +1127,10 @@ class PallasBackend(Backend):
         if matmul_spec is not None:
             launcher_args.append(f"_matmul_dot_general={matmul_spec!r}")
 
-        if pallas_loop_type == "compact_worklist" and sorted_args is not None:
+        if (
+            CompileEnvironment.current().compact_worklist_plan is not None
+            and sorted_args is not None
+        ):
             launcher_args.extend(self._compact_worklist_launcher_args(sorted_args))
 
         return launcher_args
@@ -1242,10 +1245,9 @@ class PallasBackend(Backend):
     def build_launcher_name(self, config: Config) -> str:
         """Return the single Pallas launcher name.
 
-        All ``pallas_loop_type`` values (``unroll``, ``emit_pipeline``,
-        ``fori_loop``, ``compact_worklist``) route through the same
-        ``default_pallas_launcher``; the loop-shape choice happens
-        inside based on the launcher-observable kwargs codegen emits.
+        All ``pallas_loop_type`` values route through the same
+        ``default_pallas_launcher``; worklist flattening is selected separately
+        by its launcher-observable kwargs.
         """
         from ...autotuner.config_spec import VALID_PALLAS_LOOP_TYPES
 
@@ -1274,19 +1276,39 @@ class PallasBackend(Backend):
         config: Config,
         tile_strategy: TileStrategyDispatch,
     ) -> None:
+        from ...autotuner.config_spec import VALID_PALLAS_WORKLIST_GROUPINGS
         from ..compile_environment import CompileEnvironment
         from .plan_tiling import plan_tiling
+
+        # Validate pallas_loop_type before any codegen setup.
+        self.build_launcher_name(config)
+        grouping = config.get("pallas_worklist_grouping", 0)
+        if type(grouping) is not int or grouping not in VALID_PALLAS_WORKLIST_GROUPINGS:
+            raise exc.InvalidConfig(
+                "Invalid pallas_worklist_grouping "
+                f"{grouping!r}. Expected one of {VALID_PALLAS_WORKLIST_GROUPINGS}."
+            )
+
+        env = CompileEnvironment.current()
+        if (
+            grouping == 0
+            and config.get("pallas_loop_type", "unroll") == "unroll"
+            and env.config_spec.has_symbolic_or_data_dependent_bounds
+        ):
+            raise exc.InvalidConfig(
+                "pallas_loop_type='unroll' requires static inner-loop bounds or "
+                "pallas_worklist_grouping=1."
+            )
 
         plan_tiling(graphs, config, tile_strategy)
 
         # compact_worklist_* is per-CONFIG state, but one CompileEnvironment is
         # reused across all configs of a BoundKernel (see CompileEnvironment's
-        # "no config-specific state" contract).  Reset before re-detecting so a
-        # later non-compact config never inherits a prior compact config's plan
+        # "no config-specific state" contract). Reset before re-detecting so a
+        # later non-flattened config never inherits a prior compact config's plan
         # -- many lowering paths gate on ``env.compact_worklist_plan is not None``
         # (PID strategy, loop-bound remap, fori handling, ds slicing), not on
-        # pallas_loop_type, so a stale plan would mis-lower a fori/emit config.
-        env = CompileEnvironment.current()
+        # config values, so a stale plan would mis-lower a later config.
         env.compact_worklist_plan = None
         env.compact_worklist_resident_cache_decision = None
         env.compact_worklist_resident_prep_hoists = ()
@@ -1295,7 +1317,7 @@ class PallasBackend(Backend):
         env.compact_worklist_ordered_block = 1
         env.compact_worklist_offset_params = []
 
-        if config.get("pallas_loop_type") == "compact_worklist":
+        if grouping == 1:
             self._setup_compact_worklist(graphs, config)
 
     def _setup_compact_worklist(self, graphs: list[GraphInfo], config: Config) -> None:
@@ -1308,11 +1330,9 @@ class PallasBackend(Backend):
         megablocks ``UPPER``.  ``detect_*`` raises ``exc.InvalidConfig`` on a
         non-matching kernel (autotuner-skippable).
         """
-        from ...runtime import _get_vmem_limit_bytes
         from ..compile_environment import CompileEnvironment
         from ..device_function import DeviceFunction
         from ..host_function import HostFunction
-        from .compact_worklist import build_resident_cache_admission
         from .compact_worklist import detect_compact_worklist_plan
         from .compact_worklist import metadata_arg_names
 
@@ -1344,22 +1364,31 @@ class PallasBackend(Backend):
                 env.compact_worklist_ordered_block = int(ordered_block)
         env.compact_worklist_upper = self._compact_worklist_upper(plan, config, host_fn)
 
-        import jax.experimental.pallas.tpu as pltpu
+        if config.get("pallas_loop_type", "unroll") == "unroll" and (
+            plan.ordered_axis is not None
+        ):
+            import jax.experimental.pallas.tpu as pltpu
 
-        # Choose C from the conservative device-reported VMEM budget.  The runtime
-        # may pass a higher Mosaic compile ceiling for resident-window kernels so TPU7x
-        # accepts this already-sized allocation, but that ceiling is deliberately
-        # not used here as an allocation budget.
-        vmem_bytes = _get_vmem_limit_bytes(pltpu)
-        admission = build_resident_cache_admission(
-            graphs,
-            plan,
-            host_fn.params.arguments,
-            ordered_block=env.compact_worklist_ordered_block,
-            vmem_bytes=vmem_bytes,
-        )
-        env.compact_worklist_resident_prep_hoists = admission.prep_hoists
-        env.compact_worklist_resident_cache_decision = admission.decision
+            from ...runtime import _get_vmem_limit_bytes
+            from .compact_worklist import build_resident_cache_admission
+
+            # Choose C from the conservative device-reported VMEM budget. The
+            # higher Mosaic compile ceiling used by the runtime is not an
+            # allocation budget.
+            admission = build_resident_cache_admission(
+                graphs,
+                plan,
+                host_fn.params.arguments,
+                ordered_block=env.compact_worklist_ordered_block,
+                vmem_bytes=_get_vmem_limit_bytes(pltpu),
+            )
+            if not admission.decision.active:
+                raise exc.InvalidConfig(
+                    "pallas_loop_type='unroll' requires resident ordered-loop "
+                    f"admission: {admission.decision.inactive_reason}."
+                )
+            env.compact_worklist_resident_prep_hoists = admission.prep_hoists
+            env.compact_worklist_resident_cache_decision = admission.decision
 
     def _compact_worklist_upper(
         self, plan: CompactWorklistPlan, config: Config, host_fn: HostFunction

--- a/helion/_compiler/pallas/compact_worklist.py
+++ b/helion/_compiler/pallas/compact_worklist.py
@@ -1,4 +1,4 @@
-"""Compile-time plan + resolver for the ``compact_worklist`` Pallas loop type.
+"""Compile-time plan and resolver for Pallas compact-worklist flattening.
 
 Recognises the supported jagged loop nest, captures each axis's ``(base,
 length)`` as resolvable host AST, and renders the per-kernel ``jnp`` gathers
@@ -18,9 +18,8 @@ The supported loop shape is::
             out[tile_m] = finalize(acc)  # store in the compact region
 
 Detection rejects anything outside this shape with ``exc.InvalidConfig`` so the
-autotuner scores an offered-but-unmatched config ``inf`` and skips it (rather
-than aborting), while an explicit hardcoded ``compact_worklist`` surfaces the
-clear error.
+autotuner scores an offered-but-unmatched grouping-1 config ``inf`` and skips it,
+while an explicit grouping of 1 surfaces the clear error.
 """
 
 from __future__ import annotations

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -112,27 +112,23 @@ def _extract_subscript_vals(subscript: object) -> list[object]:
 def _(state: CodegenState) -> object:
     """Emit inner device loops for Pallas/TPU.
 
-    When ``pallas_loop_type="emit_pipeline"``, generates ``pltpu.emit_pipeline``
-    calls with automatic DMA pipelining.  When ``pallas_loop_type="fori_loop"``,
-    generates ``jax.lax.fori_loop`` with explicit ``pltpu.make_async_copy`` DMA.
-    Otherwise falls through to the common ``ForLoopGraphInfo.codegen`` path.
+    Worklist flattening is handled before the ordinary loop-type dispatch: its
+    compact tile is already represented by the work-item grid, while its ordered
+    loop uses the configured resident or streaming lowering.
     """
     config = state.config
     pallas_loop_type = config.get("pallas_loop_type", "unroll")
+    if CompileEnvironment.current().compact_worklist_plan is not None:
+        if _is_compact_ordered_inner_loop(state):
+            if pallas_loop_type == "unroll":
+                return _codegen_resident_cache(state)
+            if pallas_loop_type == "emit_pipeline":
+                return _codegen_emit_pipeline(state)
+            assert pallas_loop_type == "fori_loop"
+        return _codegen_fori_loop(state)
     if pallas_loop_type == "emit_pipeline":
         return _codegen_emit_pipeline(state)
     if pallas_loop_type == "fori_loop":
-        return _codegen_fori_loop(state)
-    if pallas_loop_type == "compact_worklist":
-        # The compact tile becomes the grid (no loop).  The ordered inner tile
-        # uses the resident-cache fori path when the ordered range can be
-        # proven/windowed; otherwise it streams through emit_pipeline.  The
-        # single-iteration compact tile lowers through the fori path.  Both have
-        # begin/end remapped to metadata refs (see _compact_worklist_bounds).
-        if _is_compact_ordered_inner_loop(state):
-            if _resident_cache_applies(state):
-                return _codegen_resident_cache(state)
-            return _codegen_emit_pipeline(state)
         return _codegen_fori_loop(state)
     # unroll: fall through to common codegen path
     # pyrefly: ignore[bad-return]
@@ -144,58 +140,40 @@ def _(state: CodegenState) -> None:
     """Emit inner stepped device loops for Pallas/TPU."""
     config = state.config
     pallas_loop_type = config.get("pallas_loop_type", "unroll")
+    if CompileEnvironment.current().compact_worklist_plan is not None:
+        if _is_compact_ordered_inner_loop(state):
+            if pallas_loop_type == "unroll":
+                _codegen_resident_cache(state)
+                return None
+            if pallas_loop_type == "emit_pipeline":
+                _codegen_emit_pipeline(state)
+                return None
+            assert pallas_loop_type == "fori_loop"
+        _codegen_fori_loop(state)
+        return None
     if pallas_loop_type == "emit_pipeline":
         _codegen_emit_pipeline(state)
         return None
-    if pallas_loop_type in ("fori_loop", "compact_worklist"):
-        # Route compact_worklist through the same lowering as _for_loop so the
-        # compact metadata (begin/end remap, synthetic compact tile) is applied
-        # rather than falling through to the common (non-compact) codegen.
-        if pallas_loop_type == "compact_worklist" and _is_compact_ordered_inner_loop(
-            state
-        ):
-            if _resident_cache_applies(state):
-                _codegen_resident_cache(state)
-                return None
-            _codegen_emit_pipeline(state)
-            return None
+    if pallas_loop_type == "fori_loop":
         _codegen_fori_loop(state)
         return None
     # pyrefly: ignore[bad-return]
     return state.get_graph(state.proxy_arg(0)).codegen(state)
 
 
-def _resident_cache_applies(state: CodegenState) -> bool:
-    """Whether the ordered reduction should use the resident-cache path.
-
-    Automatic compile-time decision (not a tuning knob), gated on:
-    - a bound-checkable ordered range plus compact active-owner mask: packed offset
-      arrays prove both the ordered length and which owners produce work; and
-    - a viable physical window: VMEM can hold at least one ordered block of the
-      resident operands.
-
-    If the range/window proof is absent -- unusual ordered bounds or an oversized
-    per-token footprint -- the ordered loop stays on the streamed
-    ``emit_pipeline`` path unchanged.
-    """
-    env = CompileEnvironment.current()
-    decision = env.compact_worklist_resident_cache_decision
-    return decision is not None and decision.active
-
-
 def _codegen_resident_cache(state: CodegenState) -> object:
     """Range-keyed resident-window lowering for the compact-worklist ordered loop.
 
-    Selected by :func:`_resident_cache_applies` for an ordered inner reduction
-    with a guardable packed range and a viable VMEM window.  The ordered operand
-    is held in a per-range resident ``pl.Element(C)`` window keyed on
-    ``range_start`` (``C`` is the compile-threaded physical window).  Optional
-    prep-cache descriptors are handled inside ``_codegen_fori_loop``.
+    The ordered operand is held in a per-range resident ``pl.Element(C)`` window
+    keyed on ``range_start`` (``C`` is the compile-threaded physical window).
+    Optional prep-cache descriptors are handled inside ``_codegen_fori_loop``.
 
-    Ranges longer than ``C`` are NOT handled in-kernel: the launcher raises
-    (``runtime._compact_raise_if_range_exceeds_window``) rather than over-read the
-    fixed window -- there is no in-kernel streamed ``else``.
+    Ranges longer than ``C`` are NOT handled in-kernel: the torch launcher raises
+    (``runtime._compact_raise_if_range_exceeds_window``), while JAX export keeps
+    this as a caller precondition. There is no in-kernel streamed ``else``.
     """
+    decision = CompileEnvironment.current().compact_worklist_resident_cache_decision
+    assert decision is not None and decision.active
     return _codegen_fori_loop(state)
 
 
@@ -563,10 +541,9 @@ def _compact_axis_kind(state: CodegenState, loop_dim_index: int) -> str | None:
 def _is_compact_ordered_inner_loop(state: CodegenState) -> bool:
     """True if this ``_for_loop`` is the compact-worklist ordered inner tile.
 
-    The ordered tile is the carried inner reduction; it is the only
-    compact-worklist loop that may stream via ``_codegen_emit_pipeline`` when the
-    resident-cache window is inactive.  The owner grid and the single-iteration
-    compact tile stay on the fori path.
+    The ordered tile is the carried inner reduction selected by
+    ``pallas_loop_type``. The owner grid and single-iteration compact tile stay
+    on the fori path.
     """
     from ..device_ir import ForLoopGraphInfo
 
@@ -601,7 +578,7 @@ def _get_loop_begin_and_end(
 ) -> tuple[str, str]:
     """Extract the begin and end values from the _for_loop state args.
 
-    Under ``compact_worklist`` the compact tile's begin/end are remapped to the
+    Under worklist flattening the compact tile's begin/end are remapped to the
     per-work-item metadata refs: begin =
     ``tile_starts_ref[_wid]``, end =
     ``tile_starts_ref[_wid] + tile_extents_ref[_wid]`` (and likewise the ordered
@@ -3115,9 +3092,8 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     # item, since the builder guarantees extent <= BLOCK), so emit the body
     # straight-line with the loop var bound to 0 -- no fori_loop wrapper (which
     # would add control-flow overhead and block pipelining for the common
-    # no-ordered-axis case).  The ordered inner tile does not reach here: it lowers
-    # separately via the resident-cache path or emit_pipeline fallback (see the
-    # _for_loop pallas dispatch).
+    # no-ordered-axis case). The ordered inner tile does not reach here: it lowers
+    # separately through the loop type selected by the _for_loop Pallas dispatch.
     plan = CompileEnvironment.current().compact_worklist_plan
     is_compact_tile = (
         plan is not None

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -391,6 +391,7 @@ _BASE_BACKEND_TUNABLE_KEYS: frozenset[str] = frozenset(
         "matrix_instr_nonkdim",
         "num_ctas",
         "occupancy",
+        "pallas_worklist_grouping",
         "pallas_loop_type",
         "pallas_pre_broadcast",
         *CUTE_TCGEN05_TUNABLE_KEYS,
@@ -468,12 +469,8 @@ VALID_KEYS: frozenset[str] = frozenset(
 )
 # Loop types the autotuner searches by default for every Pallas inner loop.
 AUTOTUNED_PALLAS_LOOP_TYPES = ("emit_pipeline", "unroll", "fori_loop")
-# Full validation superset: "compact_worklist" is a tuned loop type but is only
-# *offered* to compactable kernels (owner hl.grid + jagged bounds), so it is gate
-# -appended to the search choices rather than living in the default set.  Keeping
-# AUTOTUNED_PALLAS_LOOP_TYPES first preserves `[0] == "emit_pipeline"` for the
-# setdefault below.
-VALID_PALLAS_LOOP_TYPES = (*AUTOTUNED_PALLAS_LOOP_TYPES, "compact_worklist")
+VALID_PALLAS_LOOP_TYPES = AUTOTUNED_PALLAS_LOOP_TYPES
+VALID_PALLAS_WORKLIST_GROUPINGS = (0, 1)
 VALID_PID_TYPES = (
     "flat",
     "xyz",
@@ -2257,8 +2254,6 @@ class ConfigSpec:
         else:
             fields.update(self.backend_tunable_fragments)
         if self.has_pallas_inner_loops:
-            # Default to the non-compact set; "compact_worklist" is gated below so
-            # it never leaks into non-jagged kernels.
             choices = AUTOTUNED_PALLAS_LOOP_TYPES
             if self.has_symbolic_or_data_dependent_bounds:
                 # Exclude "unroll" (uses Python range(), can't handle traced
@@ -2269,12 +2264,13 @@ class ConfigSpec:
                 # is set, to avoid wasted autotuning effort. See PR #1969 review discussion.
                 choices = ("fori_loop", "emit_pipeline")
                 if self.grid_block_ids:
-                    # Owner hl.grid + jagged bounds => compaction is applicable.
-                    # Offer it as a tuned choice; detect_compact_worklist_plan
-                    # raises exc.InvalidConfig (autotuner-skippable) if the full
-                    # pattern doesn't match, so a residual mismatch is scored inf
-                    # and skipped rather than fatal.
-                    choices = (*choices, "compact_worklist")
+                    # Owner hl.grid + jagged bounds may be compactable. The full
+                    # detector remains authoritative, so residual mismatches are
+                    # autotuner-skippable InvalidConfig candidates.
+                    choices = (*choices, "unroll")
+                    fields["pallas_worklist_grouping"] = EnumFragment(
+                        choices=VALID_PALLAS_WORKLIST_GROUPINGS
+                    )
             fields["pallas_loop_type"] = EnumFragment(choices=choices)
             if self.supports_config_key("pallas_pre_broadcast"):
                 fields["pallas_pre_broadcast"] = BooleanFragment()

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -358,9 +358,9 @@ def compact_ordered_physical_window(
     still get a legal ``pl.Element(block, padding=...)`` window instead of a
     zero-sized allocation.
 
-    Returns 0 when the budget cannot hold one ordered block.  Resident caching is
-    an automatic optimization, so the compiler treats that as "inactive" and
-    falls back to the streamed ordered loop.
+    Returns 0 when the budget cannot hold one ordered block. The selected loop
+    policy decides whether that is an invalid resident config or irrelevant to a
+    streamed config.
     """
     if not operands:
         return 0

--- a/helion/runtime/compact_worklist.py
+++ b/helion/runtime/compact_worklist.py
@@ -1,4 +1,4 @@
-"""JAX worklist builder for the ``compact_worklist`` Pallas loop type.
+"""JAX builder for Pallas compact-worklist flattening.
 
 Pure JAX and unit-testable on CPU, with no dependency on the Helion compiler.
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4823,9 +4823,9 @@ class TestPallas(TestCase):
         consumer layout: a raw load + a post-transpose ``jnp.where``, not an eager
         multiplicative load mask.
 
-        The deferral is an FX-graph pass, so it is independent of the pallas loop
-        type -- asserted here for both ``fori_loop`` and ``compact_worklist`` on a
-        generic (non-attention) per-token jagged projection whose partial tiles
+        The deferral is an FX-graph pass, so it is independent of worklist
+        flattening -- asserted here for ordinary ``fori_loop`` and flattened
+        ``unroll`` on a generic per-token jagged projection whose partial tiles
         make the mask load-bearing.
         """
 
@@ -4855,13 +4855,14 @@ class TestPallas(TestCase):
             s, e = int(offsets[i]), int(offsets[i + 1])
             ref[s:e] = torch.bmm(x[s:e].transpose(0, 1), w).transpose(0, 1)
 
-        for loop_type in ("fori_loop", "compact_worklist"):
-            with self.subTest(loop_type=loop_type):
+        for loop_type, grouping in (("fori_loop", 0), ("unroll", 1)):
+            with self.subTest(loop_type=loop_type, grouping=grouping):
                 code, out = code_and_output(
                     jagged_proj,
                     (x, w, offsets),
                     block_sizes=[block],
                     pallas_loop_type=loop_type,
+                    pallas_worklist_grouping=grouping,
                 )
                 # x's masked load is raw (no eager ``* mask``), feeds a transpose,
                 # and the mask reappears as a post-transpose ``jnp.where``.
@@ -4870,11 +4871,11 @@ class TestPallas(TestCase):
                 self.assertRegex(producer, r"= x\[")
                 self.assertNotIn("* mask", producer)
                 self.assertIn("jnp.where", code)
-                # compact_worklist matches the eager reference on the partial
-                # tiles.  fori_loop miscompiles jagged tiles in pallas interpret
+                # Worklist flattening matches the eager reference on the partial
+                # tiles. fori_loop miscompiles jagged tiles in pallas interpret
                 # (a pre-existing, unrelated issue), so it is not a sound numeric
                 # oracle here; for it we assert only the codegen above.
-                if loop_type == "compact_worklist":
+                if grouping == 1:
                     torch.testing.assert_close(
                         out.cpu(), ref.cpu(), rtol=2e-2, atol=2e-2
                     )

--- a/test/test_pallas_worklist.py
+++ b/test/test_pallas_worklist.py
@@ -1,8 +1,8 @@
-"""Tests for the ``compact_worklist`` Pallas loop type.
+"""Tests for Pallas flattened worklists.
 
 Layered bottom-up so each layer is tested before the next depends on it:
 
-1. Builder unit tests (this file, ``TestCompactWorklistBuilder``) -- pure JAX,
+1. Builder unit tests (this file, ``TestWorklistBuilder``) -- pure JAX,
    CPU-only, no Helion compiler.  Assert :func:`flatten_worklist` matches a slow
    Python reference across length distributions and edge cases.
 
@@ -37,6 +37,7 @@ from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfPallasInterpret
 from helion._testing import skipUnlessPallas
+from helion.autotuner.config_fragment import EnumFragment
 import helion.language as hl
 from helion.runtime.settings import is_pallas_interpret
 
@@ -96,7 +97,7 @@ def _python_flatten_reference(base, length, block, *, dep_base=None, dep_len=Non
 
 @onlyBackends(["pallas"])
 @unittest.skipUnless(HAS_JAX, "jax not available")
-class TestCompactWorklistBuilder(unittest.TestCase):
+class TestWorklistBuilder(unittest.TestCase):
     """Unit tests for :func:`flatten_worklist`."""
 
     def _check(self, lengths, block, *, dep_lengths=None):
@@ -570,9 +571,19 @@ def _offsets(lengths):
     )
 
 
+def _worklist_config(
+    block_sizes: list[int], *, loop_type: str = "unroll"
+) -> helion.Config:
+    return helion.Config(
+        block_sizes=block_sizes,
+        pallas_loop_type=loop_type,
+        pallas_worklist_grouping=1,
+    )
+
+
 @onlyBackends(["pallas"])
 class TestDetectAndGating(unittest.TestCase):
-    """detect_compact_worklist_plan + autotuner gating over real traces.
+    """Flattened-worklist detection and autotuner gating over real traces.
 
     Runs on CPU: ``kernel.bind`` traces with fake tensors, no device needed.
     """
@@ -615,10 +626,10 @@ class TestDetectAndGating(unittest.TestCase):
     def test_dense_kv_bounds_general(self):
         # Proves capture is general (no +1 pattern-match): length is end - begin.
         plan = self._dense_kv_plan()
-        compact = plan.compact_axis
-        self.assertEqual(ast.unparse(compact.base), "q_offsets[seq_idx]")
+        axis = plan.compact_axis
+        self.assertEqual(ast.unparse(axis.base), "q_offsets[seq_idx]")
         self.assertEqual(
-            ast.unparse(compact.length),
+            ast.unparse(axis.length),
             "q_offsets[seq_idx + 1] - q_offsets[seq_idx]",
         )
 
@@ -655,7 +666,7 @@ class TestDetectAndGating(unittest.TestCase):
             ["work_seq", "q_begin", "q_extent", "kv_begin", "kv_len"],
         )
 
-    def test_gating_offers_compact_worklist_for_jagged(self):
+    def test_gating_offers_worklist_grouping_for_jagged(self):
         qo = _offsets([16, 16, 16, 16])
         lq = int(qo[-1])
         bk = _dense_kv_kernel.bind(
@@ -667,8 +678,13 @@ class TestDetectAndGating(unittest.TestCase):
             )
         )
         fields = bk.env.config_spec._flat_fields()
-        choices = fields["pallas_loop_type"].choices
-        self.assertIn("compact_worklist", choices)
+        loop_type_field = fields["pallas_loop_type"]
+        grouping_field = fields["pallas_worklist_grouping"]
+        self.assertIsInstance(loop_type_field, EnumFragment)
+        self.assertIsInstance(grouping_field, EnumFragment)
+        choices = loop_type_field.choices
+        self.assertEqual(choices, ("fori_loop", "emit_pipeline", "unroll"))
+        self.assertEqual(grouping_field.choices, (0, 1))
         self.assertEqual(list(bk.env.config_spec.grid_block_ids), [0])
 
     def test_gating_absent_for_non_jagged(self):
@@ -676,11 +692,12 @@ class TestDetectAndGating(unittest.TestCase):
         fields = bk.env.config_spec._flat_fields()
         # No inner Pallas loops -> no pallas_loop_type field at all.
         self.assertNotIn("pallas_loop_type", fields)
+        self.assertNotIn("pallas_worklist_grouping", fields)
 
 
 @onlyBackends(["pallas"])
 @unittest.skipUnless(HAS_JAX, "jax not available")
-class TestBuildWorklistRender(unittest.TestCase):
+class TestWorklistRender(unittest.TestCase):
     """The generated jnp _build_worklist.
 
     Renders the builder from a real plan, execs it under JAX (CPU), and checks
@@ -933,7 +950,7 @@ class TestHostBoundValidation(unittest.TestCase):
 
 @onlyBackends(["pallas"])
 class TestPolicyClassification(unittest.TestCase):
-    """Unsupported compact indexing is rejected, not silently dropped."""
+    """Unsupported flattened-axis indexing is rejected, not silently dropped."""
 
     def _grid_loop(self, src):
         return ast.parse(src).body[0]
@@ -951,7 +968,7 @@ class TestPolicyClassification(unittest.TestCase):
         self.assertEqual(policies["q"], "compact_aligned_load")
         self.assertEqual(policies["out"], "compact_exact_store")
 
-    def test_non_leading_compact_dim_rejected(self):
+    def test_non_leading_flattened_dim_rejected(self):
         loop = self._grid_loop(
             "for seq in g:\n"
             "    for tile_q in t:\n"
@@ -972,15 +989,13 @@ class TestPolicyClassification(unittest.TestCase):
 
 
 @onlyBackends(["pallas"])
-class TestNoSilentFallback(unittest.TestCase):
-    """compact_worklist routes to the compact launcher, never the default."""
+class TestWorklistConfig(unittest.TestCase):
+    """Flattening is explicit, validated, and emitted only for matching kernels."""
 
-    def _kernel(self, fn, **cfg):
-        return helion.kernel(
-            fn, config=helion.Config(**cfg), static_shapes=True, backend="pallas"
-        )
+    def _kernel(self, fn, config):
+        return helion.kernel(fn, config=config, static_shapes=True, backend="pallas")
 
-    def test_matching_kernel_generates_compact(self):
+    def test_grouping_one_generates_worklist(self):
         def fn(q, k, v, q_offsets):
             out = torch.empty_like(q)
             for seq_idx in hl.grid(q_offsets.size(0) - 1):
@@ -1004,14 +1019,11 @@ class TestNoSilentFallback(unittest.TestCase):
             torch.randn(4, 16, 2, 8),
             qo,
         )
-        kernel = self._kernel(fn, block_sizes=[8], pallas_loop_type="compact_worklist")
+        kernel = self._kernel(fn, _worklist_config([8]))
         bound = kernel.bind(args)
-        code = bound.to_triton_code(
-            helion.Config(block_sizes=[8], pallas_loop_type="compact_worklist")
-        )
-        # Emits the compact-worklist-specific launcher kwargs and the
-        # in-jit worklist builder; the unified launcher dispatches to
-        # the compact compile path based on ``_compact_build_worklist``.
+        code = bound.to_triton_code(_worklist_config([8]))
+        # The unified launcher selects its flattened path from the generated
+        # builder kwargs; there is no separate launcher name.
         self.assertIn("_compact_build_worklist=_build_worklist", code)
         self.assertIn("def _build_worklist(", code)
         # Offsets arg index is non-empty (q_offsets feeds the builder).
@@ -1027,44 +1039,117 @@ class TestNoSilentFallback(unittest.TestCase):
                 out[tile] = x[tile] + y[tile]
             return out
 
-        kernel = self._kernel(
-            fn, block_sizes=[16, 16], pallas_loop_type="compact_worklist"
-        )
+        kernel = self._kernel(fn, _worklist_config([16, 16]))
         args = (torch.randn(64, 64), torch.randn(64, 64))
         bound = kernel.bind(args)
         with self.assertRaises(exc.InvalidConfig):
             bound.ensure_config_exists(args)
             bound.to_triton_code(bound._config)
 
+    def test_invalid_worklist_grouping_raises(self):
+        args = (torch.randn(64, 64), torch.randn(64, 64))
+        bound = _add_kernel.bind(args)
+        for grouping in (True, 2):
+            with (
+                self.subTest(grouping=grouping),
+                self.assertRaisesRegex(
+                    exc.InvalidConfig, "Invalid pallas_worklist_grouping"
+                ),
+            ):
+                bound.to_triton_code(
+                    helion.Config(
+                        block_sizes=[16, 16],
+                        pallas_worklist_grouping=grouping,
+                    )
+                )
+
+    def test_grouping_zero_is_noop_for_unsupported_kernel(self):
+        args = (torch.randn(64, 64), torch.randn(64, 64))
+        code = _add_kernel.bind(args).to_triton_code(
+            helion.Config(
+                block_sizes=[16, 16],
+                pallas_worklist_grouping=0,
+            )
+        )
+        self.assertNotIn("_compact_build_worklist", code)
+        self.assertNotIn("_build_worklist", code)
+
+    def test_grouping_zero_dynamic_unroll_raises(self):
+        qo = _offsets([12, 20, 5, 30])
+        lq = int(qo[-1])
+        args = (
+            torch.randn(lq, 2, 8),
+            torch.randn(4, 16, 2, 8),
+            torch.randn(4, 16, 2, 8),
+            qo,
+        )
+        with self.assertRaisesRegex(
+            exc.InvalidConfig, "requires static inner-loop bounds"
+        ):
+            _dense_kv_kernel.bind(args).to_triton_code(
+                helion.Config(
+                    block_sizes=[8],
+                    pallas_loop_type="unroll",
+                    pallas_worklist_grouping=0,
+                )
+            )
+
 
 @onlyBackends(["pallas"])
-class TestOrderedResidencyClassification(unittest.TestCase):
-    def test_fully_jagged_ordered_kv_uses_resident_fori_without_new_launcher_api(self):
+class TestWorklistLoopDispatch(unittest.TestCase):
+    @staticmethod
+    def _fully_jagged_args():
         qo = _offsets([12, 20, 5, 30])
         kvo = _offsets([13, 7, 19, 11])
         lq, lkv = int(qo[-1]), int(kvo[-1])
-        args = (
+        return (
             torch.randn(lq, 4, 128),
             torch.randn(lkv, 4, 128),
             torch.randn(lkv, 4, 128),
             qo,
             kvo,
         )
-        code = _fully_jagged_kernel.bind(args).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+
+    def test_unroll_uses_resident_fori(self):
+        code = _fully_jagged_kernel.bind(self._fully_jagged_args()).to_triton_code(
+            _worklist_config([8, 8])
         )
 
-        # A jagged ordered reduction lowers via the resident-cache fori path (the
-        # default for compact_worklist), not emit_pipeline. This test covers only
-        # that classification: the reduction uses jax.lax.fori_loop, it reuses the
-        # existing compact launcher (no extra launcher API), and q/out remain
-        # compact aligned windows. The transpose-cache structure emitted inside the
-        # fori is asserted separately by TestResidentPrepHoistCodegen.
+        # A flattened unroll reduction lowers via the resident-cache fori path,
+        # reuses the unified launcher, and keeps q/out in aligned windows. The
+        # transpose-cache structure is covered by TestResidentPrepHoistCodegen.
         self.assertIn("lax.fori_loop", code)
         self.assertNotIn("pltpu.emit_pipeline(", code)
         self.assertIn("_compact_aligned_arg_indices=", code)
 
-    def test_dense_kv_owner_indexed_tensors_have_no_ordered_pipeline(self):
+    def test_emit_pipeline_streams(self):
+        code = _fully_jagged_kernel.bind(self._fully_jagged_args()).to_triton_code(
+            _worklist_config([8, 8], loop_type="emit_pipeline")
+        )
+
+        self.assertIn("_compact_build_worklist=_build_worklist", code)
+        self.assertIn("pltpu.emit_pipeline(", code)
+        self.assertNotIn("_rc_prep_refill", code)
+        self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
+        self.assertIn("_compact_ordered_window=0", code)
+
+    def test_default_loop_type_streams_with_fori(self):
+        code = _fully_jagged_kernel.bind(self._fully_jagged_args()).to_triton_code(
+            helion.Config(
+                block_sizes=[8, 8],
+                pallas_worklist_grouping=1,
+            )
+        )
+
+        self.assertIn("_compact_build_worklist=_build_worklist", code)
+        self.assertIn("jax.lax.fori_loop", code)
+        self.assertIn("pltpu.make_async_copy", code)
+        self.assertNotIn("pltpu.emit_pipeline(", code)
+        self.assertNotIn("_rc_prep_refill", code)
+        self.assertIn("_compact_ordered_aligned_arg_indices=[]", code)
+        self.assertIn("_compact_ordered_window=0", code)
+
+    def test_no_ordered_axis_skips_inner_pipeline(self):
         qo = _offsets([12, 20, 5, 30])
         lq = int(qo[-1])
         args = (
@@ -1073,16 +1158,14 @@ class TestOrderedResidencyClassification(unittest.TestCase):
             torch.randn(4, 16, 4, 128),
             qo,
         )
-        code = _dense_kv_kernel.bind(args).to_triton_code(
-            helion.Config(block_sizes=[8], pallas_loop_type="compact_worklist")
-        )
+        code = _dense_kv_kernel.bind(args).to_triton_code(_worklist_config([8]))
 
         self.assertNotIn("_hbm_arg_indices=", code)
         self.assertNotIn("pltpu.make_async_copy", code)
         # Dense-KV has no ordered axis, so no inner pipeline either.
         self.assertNotIn("pltpu.emit_pipeline", code)
 
-    def test_kv_owned_backward_shape_uses_resident_ordered_q_like_loads(self):
+    def test_unroll_uses_resident_q_like_loads(self):
         qo = _offsets([12, 20, 5, 30])
         kvo = _offsets([13, 7, 19, 11])
         lq, lkv = int(qo[-1]), int(kvo[-1])
@@ -1094,12 +1177,11 @@ class TestOrderedResidencyClassification(unittest.TestCase):
             kvo,
         )
         code = _kv_owned_jagged_kernel.bind(args).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+            _worklist_config([8, 8])
         )
 
         # Here the ordered axis is the q-like loop; under resident caching it
-        # lowers via the fori path (not emit_pipeline).  out stays the compact
-        # exact-store window.
+        # lowers via the fori path while out stays the exact-store window.
         self.assertIn("lax.fori_loop", code)
         self.assertNotIn("pltpu.emit_pipeline(", code)
         self.assertIn("_compact_aligned_arg_indices=", code)
@@ -1189,15 +1271,15 @@ class TestUpperBoundPacking(unittest.TestCase):
 
 @onlyBackends(["pallas"])
 class TestConfigStateIsolation(unittest.TestCase):
-    """compact plan must not leak into a later config.
+    """A worklist plan must not leak into a later config.
 
     One CompileEnvironment is reused across all configs of a BoundKernel, and
     many lowering paths gate on ``env.compact_worklist_plan is not None``.  If a
-    compact config is codegen'd first, a later fori/emit/unroll config on the
-    same kernel must NOT inherit the stale plan and emit compact codegen.
+    worklist config is codegen'd first, a later fori/emit/unroll config on the
+    same kernel must not inherit the stale plan.
     """
 
-    def test_no_stale_compact_plan_in_later_config(self):
+    def test_worklist_plan_does_not_leak_to_later_config(self):
         kernel = helion.kernel(
             _dense_kv_kernel.fn, static_shapes=True, backend="pallas"
         )
@@ -1210,11 +1292,9 @@ class TestConfigStateIsolation(unittest.TestCase):
             qo,
         )
         bound = kernel.bind(args)
-        # Compact config first -> sets env.compact_worklist_plan.
-        compact = bound.to_triton_code(
-            helion.Config(block_sizes=[8], pallas_loop_type="compact_worklist")
-        )
-        self.assertIn("work_seq_ref", compact)  # sanity: compact really compiled
+        # Worklist config first -> sets env.compact_worklist_plan.
+        worklist = bound.to_triton_code(_worklist_config([8], loop_type="fori_loop"))
+        self.assertIn("work_seq_ref", worklist)
         # Then a fori config on the SAME bound kernel (same env): must be clean.
         fori = bound.to_triton_code(
             helion.Config(block_sizes=[8], pallas_loop_type="fori_loop")
@@ -1245,20 +1325,20 @@ class TestPrologueScoping(unittest.TestCase):
         self.assertEqual(ast.unparse(unscoped["x"]), "a[g] + 5")
 
 
-@skipUnlessPallas("compact_worklist numerics need Pallas TPU or interpret mode")
-class TestCompactWorklistNumerics(unittest.TestCase):
-    """Device/interpret numerics for compact_worklist vs an eager ground truth.
+@skipUnlessPallas("worklist-flattening numerics need Pallas TPU or interpret mode")
+class TestWorklistNumerics(unittest.TestCase):
+    """Device/interpret numerics for worklist flattening vs eager ground truth.
 
-    These are the device-side guards the host tests can't give: compact_worklist's
-    masked full-block ordered-overwrite store and its ordered inner loop (lowered
-    via ``emit_pipeline``) must reproduce the exact result of a plain per-sequence
-    torch computation.  Dense-KV (no ordered axis) runs in pallas interpret on
-    CPU; the fully-jagged ordered-loop cases are TPU-only (see per-test skips).
+    These are the device-side guards the host tests can't give: the masked
+    full-block ordered-overwrite store and resident ordered loop must reproduce
+    the exact result of a plain per-sequence torch computation. Dense-KV (no
+    ordered axis) runs in Pallas interpret on CPU; fully jagged ordered-loop
+    cases are TPU-only (see per-test skips).
 
     NB: the comparison is against an INDEPENDENT eager reference.  The ordered
     inner loop's lowering miscompiles these jagged patterns in interpret mode
     (verified: large abs error vs eager), so interpret is not a sound oracle for
-    it.  On real TPU, compact_worklist matches eager to bf16-matmul roundoff.
+    it. On real TPU, worklist flattening matches eager to bf16-matmul roundoff.
     """
 
     def test_dense_kv_unaligned_matches_eager(self):
@@ -1279,8 +1359,7 @@ class TestCompactWorklistNumerics(unittest.TestCase):
         _, out = code_and_output(
             _dense_kv_kernel,
             (q, k, v, qo.to(DEVICE)),
-            block_sizes=[block],
-            pallas_loop_type="compact_worklist",
+            **_worklist_config([block]),
         )
         ref = _eager_dense_kv(q.cpu(), k.cpu(), v.cpu(), qo)
         torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
@@ -1297,8 +1376,7 @@ class TestCompactWorklistNumerics(unittest.TestCase):
         _, out = code_and_output(
             _dense_kv_kernel,
             (q, k, v, qo.to(DEVICE)),
-            block_sizes=[block],
-            pallas_loop_type="compact_worklist",
+            **_worklist_config([block]),
         )
         self.assertEqual(tuple(out.shape), (0, H, D))
 
@@ -1321,7 +1399,7 @@ class TestCompactWorklistNumerics(unittest.TestCase):
         torch.manual_seed(0)
         q_big = torch.randn(lq_big, H, D, device=DEVICE, dtype=torch.bfloat16)
         q_small = torch.randn(lq_small, H, D, device=DEVICE, dtype=torch.bfloat16)
-        cfg = {"block_sizes": [block], "pallas_loop_type": "compact_worklist"}
+        cfg = _worklist_config([block])
         # Compile the larger length first, then the smaller one on the SAME kernel.
         code_big, out_big = code_and_output(
             _dense_kv_kernel, (q_big, k, v, qo_big.to(DEVICE)), **cfg
@@ -1341,7 +1419,7 @@ class TestCompactWorklistNumerics(unittest.TestCase):
         self.assertEqual(tuple(out_small.shape), (lq_small, H, D))
 
     @skipIfPallasInterpret(
-        "the resident-cache ordered KV path is validated on real TPU, not "
+        "the flattened ordered KV paths are validated on real TPU, not "
         "Pallas interpret mode"
     )
     def test_fully_jagged_with_empty_kv_matches_eager(self):
@@ -1355,14 +1433,15 @@ class TestCompactWorklistNumerics(unittest.TestCase):
         q = torch.randn(lq, H, D, device=DEVICE, dtype=torch.bfloat16)
         k = torch.randn(lkv, H, D, device=DEVICE, dtype=torch.bfloat16)
         v = torch.randn(lkv, H, D, device=DEVICE, dtype=torch.bfloat16)
-        _, out = code_and_output(
-            _fully_jagged_kernel,
-            (q, k, v, qo.to(DEVICE), kvo.to(DEVICE)),
-            block_sizes=[block, block],  # compact Q tile + ordered KV tile
-            pallas_loop_type="compact_worklist",
-        )
         ref = _eager_fully_jagged(q.cpu(), k.cpu(), v.cpu(), qo, kvo)
-        torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
+        for loop_type in ("unroll", "fori_loop"):
+            with self.subTest(loop_type=loop_type):
+                _, out = code_and_output(
+                    _fully_jagged_kernel,
+                    (q, k, v, qo.to(DEVICE), kvo.to(DEVICE)),
+                    **_worklist_config([block, block], loop_type=loop_type),
+                )
+                torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
 
     @skipIfPallasInterpret(
         "the resident-cache ordered KV path is validated on real TPU, not "
@@ -1392,8 +1471,7 @@ class TestCompactWorklistNumerics(unittest.TestCase):
         _, out = code_and_output(
             _fully_jagged_kernel,
             (q, k, v, qo.to(DEVICE), kvo.to(DEVICE)),
-            block_sizes=[qblock, kvblock],
-            pallas_loop_type="compact_worklist",
+            **_worklist_config([qblock, kvblock]),
         )
         ref = _eager_fully_jagged(q.cpu(), k.cpu(), v.cpu(), qo, kvo).float()
         rel_l2 = ((out.cpu().float() - ref).norm() / ref.norm()).item()
@@ -1402,8 +1480,8 @@ class TestCompactWorklistNumerics(unittest.TestCase):
 
 @unittest.skipUnless(HAS_JAX, "jax not available")
 @skipUnlessPallas("jax_fn export needs Pallas TPU or interpret mode")
-class TestCompactWorklistJaxExport(unittest.TestCase):
-    """compact_worklist embeds in an outer ``jax.jit`` via ``Kernel.jax_fn``.
+class TestWorklistJaxExport(unittest.TestCase):
+    """Worklist flattening embeds in outer ``jax.jit`` via ``Kernel.jax_fn``.
 
     Guards the pure-JAX export path: ``jax.jit(kernel.jax_fn)`` must match the
     eager result.
@@ -1422,9 +1500,7 @@ class TestCompactWorklistJaxExport(unittest.TestCase):
         qod = jnp.asarray(qo.numpy())
         kernel = helion.kernel(
             _dense_kv_kernel.fn,
-            config=helion.Config(
-                block_sizes=[block], pallas_loop_type="compact_worklist"
-            ),
+            config=_worklist_config([block]),
             static_shapes=True,
             backend="pallas",
         )
@@ -1506,7 +1582,7 @@ class TestResidentCacheWindowGuard(unittest.TestCase):
     def test_active_window_uncheckable_bound_raises(self):
         guard, k, c = self._setup()
         offsets = torch.tensor([0, c + 1, 2 * c + 1], dtype=torch.int32)
-        # Window active ([1, 2]) but the ordered bound or compact active-owner mask
+        # Window active ([1, 2]) but the ordered bound or active-owner mask
         # is not checkable (index -1): must RAISE rather than silently proceed.
         with self.assertRaisesRegex(RuntimeError, "not a.*checkable"):
             guard((offsets, k, k), [1, 2], -1, 0, c)
@@ -1520,7 +1596,7 @@ class TestResidentCacheWindowGuard(unittest.TestCase):
         offsets = torch.tensor([0], dtype=torch.int32)
         guard((offsets, k, k), [1, 2], 0, 0, c)
 
-    def test_zero_compact_source_is_not_guarded(self):
+    def test_zero_work_source_is_not_guarded(self):
         guard, k, c = self._setup()
         # Source 0 has a KV range larger than the window, but q_len==0, so it
         # produces no worklist item and never refills the resident cache.
@@ -1528,7 +1604,7 @@ class TestResidentCacheWindowGuard(unittest.TestCase):
         kv_offsets = torch.tensor([0, c + 1, c + 1], dtype=torch.int32)
         guard((q_offsets, kv_offsets, k, k), [2, 3], 1, 0, c)
 
-    def test_live_compact_source_is_guarded(self):
+    def test_active_work_source_is_guarded(self):
         guard, k, c = self._setup()
         q_offsets = torch.tensor([0, 1, 1], dtype=torch.int32)
         kv_offsets = torch.tensor([0, c + 1, c + 1], dtype=torch.int32)
@@ -1584,8 +1660,7 @@ class TestOrderedWindowBudget(unittest.TestCase):
         self.assertEqual(self._physical(operands, 128, prep_operands=operands), 128)
 
     def test_budget_too_small_returns_zero_physical_window(self):
-        # resident caching falls back to streaming when VMEM cannot hold one ordered
-        # block of the cached operands.
+        # A resident config is invalid when VMEM cannot hold one ordered block.
         operands = [((1_000_000, 4, 128), 4)]
         self.assertLess(self._budget(operands, vmem=1024, prep_operands=operands), 128)
         self.assertEqual(
@@ -1612,18 +1687,8 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
     """Codegen checks for optional resident-prep cache lowering."""
 
     def test_jagged_gdpa_emits_resident_prep_cache(self):
-        qo = _offsets([12, 20, 5, 30])
-        kvo = _offsets([13, 7, 19, 11])
-        lq, lkv = int(qo[-1]), int(kvo[-1])
-        args = (
-            torch.randn(lq, 4, 128),
-            torch.randn(lkv, 4, 128),
-            torch.randn(lkv, 4, 128),
-            qo,
-            kvo,
-        )
-        code = _fully_jagged_kernel.bind(args).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+        code = _fully_jagged_kernel.bind(self._resident_args()).to_triton_code(
+            _worklist_config([8, 8])
         )
         self.assertIn("_rc_prep_refill", code)
         self.assertIn("jnp.maximum(_wid - 1, 0)", code)
@@ -1671,7 +1736,7 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
         import re
 
         code = _fully_jagged_kernel.bind(self._resident_args()).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+            _worklist_config([8, 8])
         )
         body = code[code.index("def _fori_body_0") :]
         dot = re.search(r"dot_general\(\w+, (permute_\d+),", body)
@@ -1691,7 +1756,7 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
         # of the dot, so it is preserved.  Assert the score mask specifically: a
         # jnp.where whose fill is a -inf full (not merely the m_i init's -inf full).
         code = _flash_prep_kernel.bind(self._resident_args()).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+            _worklist_config([8, 8])
         )
         self.assertIn("_rc_prep_refill", code)  # prep cache installed
         self.assertRegex(code, r"jnp\.where\([^\n]*jnp\.full\(\[\], float\('-inf'\)")
@@ -1706,7 +1771,7 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
             return_value=[],
         ):
             code = _fully_jagged_kernel.bind(self._resident_args()).to_triton_code(
-                helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+                _worklist_config([8, 8])
             )
         self.assertNotIn("_prep[", code)  # no prep cache installed -> none read
         self.assertIn("jnp.where", code)  # per-tile masks preserved
@@ -1720,7 +1785,7 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
             qo,
         )
         code = _four_dim_major_permute_ordered_kernel.bind(args).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+            _worklist_config([8, 8])
         )
         self.assertIn("_rc_prep_refill", code)
         self.assertIn("jnp.transpose", code)
@@ -1780,7 +1845,7 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         from helion._compiler.pallas.compact_worklist import detect_resident_prep_hoists
         from helion._compiler.pallas.plan_tiling import plan_tiling
 
-        config = helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+        config = _worklist_config([8, 8])
         bk = kernel.bind(args)
         with bk.env, bk.host_function:
             codegen = GenerateAST(bk.host_function, config)
@@ -1851,7 +1916,7 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         lq = int(qo[-1])
         args = (torch.randn(lq, 4, 128), torch.randn(lq, 4, 128), qo)
         code = _noprep_ordered_kernel.bind(args).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+            _worklist_config([8, 8])
         )
         self.assertNotIn("_rc_prep_refill", code)
         self.assertNotIn("_prep", code)
@@ -1862,6 +1927,18 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         self.assertNotIn("_compact_ordered_offset_arg_index=-1", code)
         self.assertNotIn("_compact_active_mask_arg_index=-1", code)
         self.assertNotIn("_compact_ordered_window=0", code)
+
+    def test_resident_unroll_rejects_insufficient_vmem(self):
+        qo = _offsets([12, 20, 5, 30])
+        lq = int(qo[-1])
+        args = (torch.randn(lq, 4, 128), torch.randn(lq, 4, 128), qo)
+        with (
+            patch("helion.runtime._get_vmem_limit_bytes", return_value=1),
+            self.assertRaisesRegex(
+                exc.InvalidConfig, "VMEM budget cannot hold one ordered block"
+            ),
+        ):
+            _noprep_ordered_kernel.bind(args).to_triton_code(_worklist_config([8, 8]))
 
     def test_active_resident_cache_requires_range_start_metadata(self):
         from helion._compiler.backend import PallasBackend
@@ -1896,7 +1973,7 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         ):
             PallasBackend()._compact_worklist_launcher_args(args)
 
-    def test_unpacked_ordered_bound_stays_streamed(self):
+    def test_unpacked_ordered_bound_streams_with_emit_pipeline(self):
         qo = _offsets([12, 20, 5, 30])
         kvo = _offsets([13, 7, 19, 11])
         lq, lkv = int(qo[-1]), int(kvo[-1])
@@ -1908,7 +1985,7 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
             kvo,
         )
         code = _unpacked_ordered_kernel.bind(args).to_triton_code(
-            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+            _worklist_config([8, 8], loop_type="emit_pipeline")
         )
         self.assertNotIn("_rc_prep_refill", code)
         self.assertNotIn("_prep", code)
@@ -1917,6 +1994,20 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         self.assertIn("_compact_ordered_offset_arg_index=-1", code)
         self.assertIn("_compact_active_mask_arg_index=-1", code)
         self.assertIn("_compact_ordered_window=0", code)
+
+    def test_unpacked_ordered_bound_rejects_resident_unroll(self):
+        qo = _offsets([12, 20, 5, 30])
+        kvo = _offsets([13, 7, 19, 11])
+        lq, lkv = int(qo[-1]), int(kvo[-1])
+        args = (
+            torch.randn(lq, 4, 128),
+            torch.randn(lkv + 8, 4, 128),
+            torch.randn(lkv + 8, 4, 128),
+            qo,
+            kvo,
+        )
+        with self.assertRaisesRegex(exc.InvalidConfig, "ordered bound is not packed"):
+            _unpacked_ordered_kernel.bind(args).to_triton_code(_worklist_config([8, 8]))
 
     def test_resident_ordered_entries_filter_ordered_operands(self):
         from helion._compiler.pallas.compact_worklist import resident_ordered_entries
@@ -1972,7 +2063,7 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         self.assertEqual(decision.resident_key_fields, ("range_start",))
         self.assertEqual(decision.prep_key_fields, ("range_start", "range_len"))
 
-    def test_resident_cache_decision_falls_back_when_window_not_viable(self):
+    def test_resident_cache_decision_is_inactive_when_window_not_viable(self):
         from helion._compiler.pallas.compact_worklist import (
             build_resident_cache_decision,
         )


### PR DESCRIPTION
Worklist construction is a scheduling transformation rather than an inner-loop lowering. This PR separates it from pallas_loop_type.

  - Add `pallas_worklist_grouping`:
      - 0: disable worklist flattening.
      - 1: one flattened tile per work item.
  - Remove "compact_worklist" from pallas_loop_type.
  - Expose worklist grouping only for eligible outer-grid plus jagged-inner-loop kernels.
  - Keep the existing unified Pallas launcher and worklist implementation.
  - Select ordered-loop lowering independently:
      - unroll: resident-cache lowering.
      - emit_pipeline: streamed pipeline lowering.
      - fori_loop: streamed fori lowering.
  - Fail resident unroll when VMEM admission fails rather than falling back to streaming.
  - Reject grouping 0 with dynamic unroll before it fails during JAX tracing.
  - Preserve existing shape-derived worklist and resident-window sizing.

Grouping 2, which groups consecutive same-owner tiles into one work item, remains a follow-up.


```python
pallas_loop_type="compact_worklist"     # before

pallas_worklist_grouping=1    # after
pallas_loop_type="unroll"
```