### PR TITLE
[cute] expose loop orders for tcgen05

### DIFF
--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -2685,6 +2685,31 @@ class CuteTcgen05Config:
     ) -> None:
         if not self.search_enabled:
             return
+        pid_type = config.get("pid_type")
+        cluster_m = config.get("tcgen05_cluster_m", 1)
+        cluster_n = config.get("tcgen05_cluster_n", 1)
+        loop_orders = config.get("loop_orders")
+        default_loop_orders = [
+            spec._fill_missing() for spec in self.config_spec.loop_orders
+        ]
+        if (
+            isinstance(pid_type, str)
+            and pid_type.startswith("persistent")
+            and (cluster_m != 1 or cluster_n != 1)
+            and loop_orders
+            and loop_orders != default_loop_orders
+        ):
+            # The tcgen05 clustered scheduler applies the physical M/N cluster
+            # shape to work-tile coordinates 0/1. Alternate PID orders are safe
+            # for single-CTA scheduling, but clustered scheduling must become
+            # block-ID-aware before those coordinates can be reordered.
+            if fix_invalid:
+                config["loop_orders"] = default_loop_orders
+            else:
+                raise InvalidConfig(
+                    "non-default loop_orders require tcgen05_cluster_m=1 and "
+                    "tcgen05_cluster_n=1 for persistent tcgen05 kernels"
+                )
         pid_type_for_default = config.get("pid_type")
         strategy_validation_fragments = self.strategy_validation_fragments()
         for key, fragment in strategy_validation_fragments.items():
@@ -2742,6 +2767,11 @@ class CuteTcgen05Config:
         fields: dict[str, BlockIdSequence[Any] | ConfigSpecFragment] = {
             "l2_groupings": self.config_spec.l2_groupings,
         }
+        if (
+            self.config_spec.supports_config_key("loop_orders")
+            and len(self.config_spec.loop_orders) > 0
+        ):
+            fields["loop_orders"] = self.config_spec.loop_orders
         fields.update(self.optional_fragments(for_search=True))
         fields.update(self.strategy_autotune_fragments())
         fields.update(self.aux_load_mode_autotune_fragments())

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -2685,30 +2685,23 @@ class CuteTcgen05Config:
     ) -> None:
         if not self.search_enabled:
             return
-        pid_type = config.get("pid_type")
-        cluster_m = config.get("tcgen05_cluster_m", 1)
-        cluster_n = config.get("tcgen05_cluster_n", 1)
-        loop_orders = config.get("loop_orders")
         default_loop_orders = [
             spec._fill_missing() for spec in self.config_spec.loop_orders
         ]
-        if (
-            isinstance(pid_type, str)
-            and pid_type.startswith("persistent")
-            and (cluster_m != 1 or cluster_n != 1)
-            and loop_orders
-            and loop_orders != default_loop_orders
-        ):
-            # The tcgen05 clustered scheduler applies the physical M/N cluster
-            # shape to work-tile coordinates 0/1. Alternate PID orders are safe
-            # for single-CTA scheduling, but clustered scheduling must become
-            # block-ID-aware before those coordinates can be reordered.
+        loop_orders = config.get("loop_orders", default_loop_orders)
+        cluster_shape = (
+            config.get("tcgen05_cluster_m", 1),
+            config.get("tcgen05_cluster_n", 1),
+        )
+        if cluster_shape != (1, 1) and loop_orders != default_loop_orders:
+            # The clustered scheduler binds physical M/N dimensions to work-tile
+            # coordinates 0/1. Reordering is safe for a single CTA, but clustered
+            # scheduling must become block-ID-aware before those coordinates move.
             if fix_invalid:
                 config["loop_orders"] = default_loop_orders
             else:
                 raise InvalidConfig(
-                    "non-default loop_orders require tcgen05_cluster_m=1 and "
-                    "tcgen05_cluster_n=1 for persistent tcgen05 kernels"
+                    "non-default loop_orders require tcgen05 cluster shape (1, 1)"
                 )
         pid_type_for_default = config.get("pid_type")
         strategy_validation_fragments = self.strategy_validation_fragments()

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2153,15 +2153,9 @@ class ConfigSpec:
                 )
             elif self.supports_config_key("num_threads"):
                 fields["num_threads"] = self.num_threads
-                # Universal pid emission honors ``loop_orders`` (the
-                # launch grid swaps which tile axis is outer), and the
-                # better order is shape-dependent. Expose only on the
-                # non-tcgen05 branch — the tcgen05 persistent
-                # scheduler relies on a fixed
-                # ``pid_info[0]=M, pid_info[1]=N`` mapping for
-                # ``cluster_m`` / virtual-PID logic, so sampling
-                # ``loop_orders=[[1, 0]]`` there would steer cluster
-                # logic onto the wrong axis.
+                # Universal pid emission honors ``loop_orders`` and the
+                # better order is shape-dependent. tcgen05 exposes the same
+                # field from CuteTcgen05Config.flat_fields().
                 if (
                     self.supports_config_key("loop_orders")
                     and len(self.loop_orders) > 0

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -3618,8 +3618,7 @@ class TestCuteAutotuner(TestCase):
         self.assertIn("loop_orders", flat_keys)
 
         gen = ConfigGeneration(bound.config_spec)
-        config = bound.config_spec.default_config()
-        config.config.update(
+        config = helion.Config(
             block_sizes=[128, 128, 64],
             loop_orders=[[1, 0]],
             pid_type="persistent_interleaved",

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -3600,26 +3600,40 @@ class TestCuteAutotuner(TestCase):
         )
         self.assertEqual(round_tripped.loop_orders, [[1, 0]])
 
-    def test_cute_tcgen05_search_surface_excludes_loop_orders(self) -> None:
-        """tcgen05 persistent scheduler relies on a fixed
-        ``pid_info[0]=M, pid_info[1]=N`` mapping (``cluster_m`` and
-        virtual-PID logic). Sampling ``loop_orders=[[1, 0]]`` for a
-        tcgen05 config would steer cluster logic onto the wrong axis.
-        The cute non-tcgen05 widening must not leak into the tcgen05
-        branch.
-        """
-        bound = _get_examples_matmul().bind(
-            (
-                torch.randn([1024, 1024], device=DEVICE, dtype=torch.bfloat16),
-                torch.randn([1024, 1024], device=DEVICE, dtype=torch.bfloat16),
-            )
+    @skipIfCudaCapabilityLessThan(
+        (10, 0), reason="tcgen05 requires CUDA capability >= 10.0"
+    )
+    def test_cute_tcgen05_search_surface_includes_loop_orders(self) -> None:
+        """tcgen05 autotuning can explore alternate output-tile orders."""
+        args = (
+            torch.randn([1024, 1024], device=DEVICE, dtype=torch.bfloat16),
+            torch.randn([1024, 1024], device=DEVICE, dtype=torch.bfloat16),
         )
+        bound = _get_examples_matmul().bind(args)
         # Confirm we are on the tcgen05 search branch.
         self.assertTrue(bound.config_spec.cute_tcgen05_search_enabled)
         flat_keys = {
             key for key, _count, _is_sequence in bound.config_spec.flat_key_layout()
         }
-        self.assertNotIn("loop_orders", flat_keys)
+        self.assertIn("loop_orders", flat_keys)
+
+        gen = ConfigGeneration(bound.config_spec)
+        config = bound.config_spec.default_config()
+        config.config.update(
+            block_sizes=[128, 128, 64],
+            loop_orders=[[1, 0]],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=1,
+            tcgen05_cluster_n=1,
+        )
+        round_tripped = gen.unflatten(gen.flatten(config))
+        self.assertEqual(round_tripped.loop_orders, [[1, 0]])
+        code = bound.to_triton_code(round_tripped)
+        self.assertIn("cute.gemm(", code)
+        self.assertIn("StaticPersistentTileScheduler", code)
+
+        actual = bound.compile_config(round_tripped)(*args)
+        torch.testing.assert_close(actual, args[0] @ args[1], atol=0.125, rtol=0.02)
 
     def test_cute_flash_search_surface(self) -> None:
         """The flash-attention autotune surface (Tasks #25 + #28) appears only

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -2308,7 +2308,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
 
         # The clustered scheduler still assigns physical cluster M/N to work-tile
-        # coordinates 0/1. Autotuning repairs an alternate PID order to the
+        # coordinates 0/1. Autotuning repairs an alternate loop order to the
         # default; an explicit user config gets a clear validation error.
         clustered_alt_order = helion.Config.from_dict(default_cluster_m2_config.config)
         clustered_alt_order.config["loop_orders"] = [[1, 0]]
@@ -2316,15 +2316,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertEqual(clustered_alt_order.config["tcgen05_cluster_m"], 2)
         self.assertEqual(clustered_alt_order.loop_orders, [[0, 1]])
 
-        explicit_clustered_alt_order = helion.Config.from_dict(
-            default_cluster_m2_config.config
-        )
-        explicit_clustered_alt_order.config["loop_orders"] = [[1, 0]]
+        clustered_alt_order.config["loop_orders"] = [[1, 0]]
         with self.assertRaisesRegex(
             helion.exc.InvalidConfig,
-            "non-default loop_orders require tcgen05_cluster_m=1",
+            r"non-default loop_orders require tcgen05 cluster shape \(1, 1\)",
         ):
-            bound.config_spec.normalize(explicit_clustered_alt_order)
+            bound.config_spec.normalize(clustered_alt_order)
 
         # An explicit FFI request still projects onto the generalized seed.
         requested_ffi_config = helion.Config(

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -2307,6 +2307,25 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, bk],
         )
 
+        # The clustered scheduler still assigns physical cluster M/N to work-tile
+        # coordinates 0/1. Autotuning repairs an alternate PID order to the
+        # default; an explicit user config gets a clear validation error.
+        clustered_alt_order = helion.Config.from_dict(default_cluster_m2_config.config)
+        clustered_alt_order.config["loop_orders"] = [[1, 0]]
+        bound.config_spec.normalize(clustered_alt_order, _fix_invalid=True)
+        self.assertEqual(clustered_alt_order.config["tcgen05_cluster_m"], 2)
+        self.assertEqual(clustered_alt_order.loop_orders, [[0, 1]])
+
+        explicit_clustered_alt_order = helion.Config.from_dict(
+            default_cluster_m2_config.config
+        )
+        explicit_clustered_alt_order.config["loop_orders"] = [[1, 0]]
+        with self.assertRaisesRegex(
+            helion.exc.InvalidConfig,
+            "non-default loop_orders require tcgen05_cluster_m=1",
+        ):
+            bound.config_spec.normalize(explicit_clustered_alt_order)
+
         # An explicit FFI request still projects onto the generalized seed.
         requested_ffi_config = helion.Config(
             block_sizes=[256, 256, 128],


### PR DESCRIPTION
The field was previously excluded because clustered scheduling binds work-tile coordinates 0/1 to physical M/N cluster dimensions. This restriction only applies to clustered configurations:

  - Cluster shape (1, 1) may explore alternate loop orders.
  - Autotuner candidates with larger clusters are normalized to the default order.
  - Invalid explicit clustered configurations are rejected.

B200 BF16 paired ablation with all configuration fields fixed except loop_orders:

| Kernel | Shape | Default | Best order | Best | Speedup |
|:---|:---|---:|:---:|---:|---:|
| MM | 16384x2048x4096 | 715 TFLOP/s | [1,0] | 942 TFLOP/s | 1.32x |
| BMM | 1152x256x384x512 | 300 TFLOP/s | [2,1,0] | 447 TFLOP/s | 1.49x |
| BMM | 1152x256x384x2816 | 300 TFLOP/s | [1,2,0] | 478 TFLOP/s | 1.60x |
| BMM | 64x512x512x2048 | 373 TFLOP/s | [2,1,0] | 558 TFLOP/s | 1.49x |

The preferred order is shape-dependent. For MM 2048x16384x4096, the default remained faster at 925 versus 646 TFLOP/s, so this should be tuned rather than changed globally.
