### PR TITLE
[pallas] enable pallas worklist grouping = 2

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -321,7 +321,7 @@ class CompileEnvironment:
         self._tensor_input_source_cache: dict[int, Source | None] = {}
         self.jagged_tile_parent_ids: dict[int, list[int]] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
-        # Set by the Pallas backend when worklist grouping is 1 and
+        # Set by the Pallas backend when worklist grouping is 1 or 2 and
         # detect_compact_worklist_plan succeeds; gates the compact-worklist
         # codegen path (see helion/_compiler/pallas/compact_worklist.py).
         self.compact_worklist_plan: CompactWorklistPlan | None = None

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -152,6 +152,17 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         self.resident_prep_lowering_stack: list[
             dict[tuple[int, str], ResidentPrepLowering]
         ] = []
+        # Grouping-2 worklists codegen the compact body twice, once per static
+        # compact block size. Shape-independent ordered-loop resources are shared
+        # across those mutually exclusive bodies.
+        self.grouped_compact_common_statements: list[ast.AST] | None = None
+        self.grouped_resident_prep_lowering_cache: dict[
+            tuple[object, ...], list[ResidentPrepLowering]
+        ] = {}
+        self.grouped_resident_prep_refill_cache: dict[tuple[object, ...], str] = {}
+        self.grouped_fori_dma_resource_cache: dict[
+            tuple[object, ...], tuple[str, str]
+        ] = {}
 
         # Now create device function and initialize CodegenInterface
         self.device_function = DeviceFunction(

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -4,11 +4,13 @@ helion/_compiler/backend.py."""
 from __future__ import annotations
 
 import ast
+import dataclasses
 import enum
 import math
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
+from typing import cast
 
 import torch
 
@@ -1157,7 +1159,7 @@ class PallasBackend(Backend):
                 name_to_index[arg.host_str()] = i
         offset_indices = [name_to_index[n] for n in env.compact_worklist_offset_params]
         fields = metadata_field_names(plan)
-        # Compact-tile tensors (aligned load + exact store) both get a per-tile
+        # Compact-tile tensors (aligned load + exact store) both get a max-sized
         # pl.Element BlockSpec sliced at tile_start, so Pallas double-buffers BOTH
         # the load prefetch and the store write-back across work items.
         #
@@ -1234,7 +1236,7 @@ class PallasBackend(Backend):
             f"_compact_num_scalar_prefetch={len(fields)}",
             f"_compact_aligned_arg_indices={aligned_indices!r}",
             f"_compact_tile_start_ref_pos={fields.index('tile_starts')}",
-            f"_compact_block={env.compact_worklist_block}",
+            f"_compact_block={env.compact_worklist_block * plan.grouping}",
             f"_compact_ordered_aligned_arg_indices={ordered_indices!r}",
             f"_compact_range_start_ref_pos={range_start_ref_pos}",
             f"_compact_ordered_offset_arg_index={ordered_offset_arg_index}",
@@ -1297,7 +1299,7 @@ class PallasBackend(Backend):
         ):
             raise exc.InvalidConfig(
                 "pallas_loop_type='unroll' requires static inner-loop bounds or "
-                "pallas_worklist_grouping=1."
+                "pallas_worklist_grouping in (1, 2)."
             )
 
         plan_tiling(graphs, config, tile_strategy)
@@ -1317,7 +1319,7 @@ class PallasBackend(Backend):
         env.compact_worklist_ordered_block = 1
         env.compact_worklist_offset_params = []
 
-        if grouping == 1:
+        if grouping in (1, 2):
             self._setup_compact_worklist(graphs, config)
 
     def _setup_compact_worklist(self, graphs: list[GraphInfo], config: Config) -> None:
@@ -1338,7 +1340,10 @@ class PallasBackend(Backend):
 
         env = CompileEnvironment.current()
         host_fn = HostFunction.current()
-        plan = detect_compact_worklist_plan(host_fn)
+        plan = dataclasses.replace(
+            detect_compact_worklist_plan(host_fn),
+            grouping=cast("int", config.get("pallas_worklist_grouping", 1)),
+        )
         env.compact_worklist_plan = plan
 
         device_fn = DeviceFunction.current()
@@ -1395,14 +1400,15 @@ class PallasBackend(Backend):
     ) -> int:
         """Static UPPER: the padded length of the worklist metadata arrays.
 
-        Must be >= the worst-case ``num_work = sum_owners cdiv(length, BLOCK)``,
+        Must be >= the worst-case
+        ``num_work = sum_owners cdiv(length, BLOCK * grouping)``,
         else the dynamic Pallas grid indexes past the scalar-prefetch metadata
         (``jnp.repeat(total_repeat_length=UPPER)`` would silently truncate the
         worklist).  Detection only accepts the packed-offsets idiom (store
-        safety), so owner ranges are contiguous/non-overlapping
-        (``sum(length) == total``) and the tight megablocks bound
-        ``cdiv(total, BLOCK) + num_owners - 1`` provably holds.  All terms are
-        concrete ints under ``static_shapes=True``.
+        safety), so owner ranges are contiguous/non-overlapping. The compact
+        input shape is at least their packed total (and may include padding), so
+        ``cdiv(total, BLOCK * grouping) + num_owners - 1`` provably holds. All
+        terms are concrete ints under ``static_shapes=True``.
         """
         from ...runtime.compact_worklist import packed_upper_bound
         from ..compile_environment import CompileEnvironment
@@ -1420,11 +1426,11 @@ class PallasBackend(Backend):
                 f"compact_worklist: could not evaluate owner-count expression "
                 f"{plan.num_owners_expr!r}: {e}"
             ) from e
-        # total_compact = leading dim of the compact_aligned_load tensor.
+        # total_compact = padded leading dim of the compact_aligned_load tensor.
         compact_arg = next(
             p.arg_name for p in plan.tensor_policies if p.kind == "compact_aligned_load"
         )
         total = int(params[compact_arg].shape[0])
-        block = CompileEnvironment.current().compact_worklist_block
+        block = CompileEnvironment.current().compact_worklist_block * plan.grouping
         # Single source of the tight megablocks bound (also unit-tested).
         return packed_upper_bound(total, num_owners, block)

--- a/helion/_compiler/pallas/compact_worklist.py
+++ b/helion/_compiler/pallas/compact_worklist.py
@@ -114,6 +114,8 @@ class CompactWorklistPlan:
     # bound (NOT assumed to be base.shape[0] - 1, which only holds for the
     # offsets-array idiom).
     num_owners_expr: str = ""
+    # Number of consecutive compact base tiles combined into one work item.
+    grouping: int = 1
 
     @property
     def owner_axis(self) -> Axis:
@@ -708,6 +710,7 @@ def render_build_worklist(
             f"    dep_len = {ast.unparse(dep_len_resolved)}",
         ]
         dep_kwargs = ", dep_base=dep_base, dep_len=dep_len"
+    grouping_kwarg = "" if plan.grouping == 1 else f", grouping={plan.grouping}"
 
     # The owner-count expression (e.g. "offsets.shape[0] - 1" or "B") may
     # introduce additional free host names the builder must take as params.
@@ -724,7 +727,8 @@ def render_build_worklist(
         *dep_lines,
         (
             "    return flatten_worklist("
-            f"base, length, {block_expr}, {upper_expr}{dep_kwargs})"
+            f"base, length, {block_expr}, {upper_expr}"
+            f"{grouping_kwarg}{dep_kwargs})"
         ),
     ]
     return "\n".join(lines), offset_params

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -9,6 +9,7 @@ the same eager timing as before.
 from __future__ import annotations
 
 import ast
+import contextlib
 import logging
 import operator
 from typing import TYPE_CHECKING
@@ -41,6 +42,7 @@ log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from collections.abc import Iterator
     from collections.abc import Sequence
 
     from ...runtime.config import Config
@@ -125,6 +127,11 @@ def _(state: CodegenState) -> object:
             if pallas_loop_type == "emit_pipeline":
                 return _codegen_emit_pipeline(state)
             assert pallas_loop_type == "fori_loop"
+        if _is_compact_tile_loop(state):
+            plan = CompileEnvironment.current().compact_worklist_plan
+            assert plan is not None
+            if plan.grouping == 2:
+                return _codegen_grouped_compact_tile(state)
         return _codegen_fori_loop(state)
     if pallas_loop_type == "emit_pipeline":
         return _codegen_emit_pipeline(state)
@@ -149,6 +156,12 @@ def _(state: CodegenState) -> None:
                 _codegen_emit_pipeline(state)
                 return None
             assert pallas_loop_type == "fori_loop"
+        if _is_compact_tile_loop(state):
+            plan = CompileEnvironment.current().compact_worklist_plan
+            assert plan is not None
+            if plan.grouping == 2:
+                _codegen_grouped_compact_tile(state)
+                return None
         _codegen_fori_loop(state)
         return None
     if pallas_loop_type == "emit_pipeline":
@@ -230,6 +243,17 @@ def _prepare_resident_prep_lowerings(
     metadata_ref_for_field(plan, "range_len")
 
     graph_info = state.get_graph(state.proxy_arg(0))
+    cache_key = (
+        graph_info.graph_id,
+        decision.physical_window,
+        active_hoists,
+    )
+    common_statements = state.codegen.grouped_compact_common_statements
+    if common_statements is not None:
+        cached = state.codegen.grouped_resident_prep_lowering_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
     load_nodes = {node.name: node for node in graph_info.graph.nodes}
     needed_hosts = {hoist.host_arg for hoist in active_hoists}
     resident_windows: dict[str, tuple[str, torch.Tensor]] = {}
@@ -291,6 +315,8 @@ def _prepare_resident_prep_lowerings(
         if fill is not None:
             load_tail_fills[lw.hoist.load_node_name] = fill
     elide_installed_prep_load_masks(graph_info.graph, load_tail_fills)
+    if common_statements is not None:
+        state.codegen.grouped_resident_prep_lowering_cache[cache_key] = lowerings
     return lowerings
 
 
@@ -554,6 +580,168 @@ def _is_compact_ordered_inner_loop(state: CodegenState) -> bool:
         _compact_axis_kind(state, i) == "ordered"
         for i in range(len(graph_info.block_ids))
     )
+
+
+def _is_compact_tile_loop(state: CodegenState) -> bool:
+    """True for the parallel compact-tile loop represented by the work item."""
+    from ..device_ir import ForLoopGraphInfo
+
+    plan = CompileEnvironment.current().compact_worklist_plan
+    if plan is None:
+        return False
+    graph_info = state.get_graph(state.proxy_arg(0))
+    if not isinstance(graph_info, ForLoopGraphInfo):
+        return False
+    if graph_info.block_ids != [plan.compact_axis.block_id]:
+        return False
+    args = state.proxy_args[-1]
+    return isinstance(args, list) and not _loop_carried_indices(state, len(args))
+
+
+@contextlib.contextmanager
+def _compact_block_variant(state: CodegenState, factor: int) -> Iterator[None]:
+    """Temporarily codegen the compact loop with ``factor * base_block``."""
+    if factor == 1:
+        yield
+        return
+
+    from ...runtime.config import Config
+    from ..tile_dispatch import TileStrategyDispatch
+
+    env = CompileEnvironment.current()
+    plan = env.compact_worklist_plan
+    assert plan is not None and factor == 2
+    block_id = plan.compact_axis.block_id
+    fn = state.device_function
+
+    block_sizes = [*fn.config.block_sizes]
+    block_index = env.config_spec.block_sizes.block_id_to_index(block_id)
+    block_sizes[block_index] *= factor
+    variant_config = Config.from_dict({**fn.config.config, "block_sizes": block_sizes})
+
+    original_config = fn.config
+    original_tile_strategy = fn.tile_strategy
+    original_block_cache = fn.block_size_var_cache
+    original_expr_cache = fn.expr_to_var_info
+
+    variant_block_cache = original_block_cache.copy()
+    variant_block_cache.pop((block_id,), None)
+    variant_expr_cache = {}
+    for expr, info in original_expr_cache.items():
+        block_mapping, _ = find_block_size_symbols(expr)
+        if block_id not in block_mapping.values():
+            variant_expr_cache[expr] = info
+
+    fn.config = variant_config
+    fn.block_size_var_cache = variant_block_cache
+    fn.expr_to_var_info = variant_expr_cache
+    try:
+        fn.tile_strategy = TileStrategyDispatch(fn, variant_config)
+        yield
+    finally:
+        fn.config = original_config
+        fn.tile_strategy = original_tile_strategy
+        fn.block_size_var_cache = original_block_cache
+        fn.expr_to_var_info = original_expr_cache
+
+
+def _compact_output_initializers(state: CodegenState) -> list[ast.stmt]:
+    """Zero the full max-sized output window before the one-tile body."""
+    from ..device_function import TensorArg
+
+    plan = CompileEnvironment.current().compact_worklist_plan
+    assert plan is not None and plan.grouping == 2
+    output_hosts = {
+        policy.arg_name
+        for policy in plan.tensor_policies
+        if policy.kind == "compact_exact_store"
+    }
+    statements: list[ast.stmt] = []
+    for arg in state.device_function.arguments:
+        if not isinstance(arg, TensorArg) or arg.host_str() not in output_hosts:
+            continue
+        indices = ", ".join(":" for _ in range(arg.fake_value.ndim))
+        statements.append(
+            statement_from_string(
+                f"{arg.name}[{indices}] = jnp.zeros_like({arg.name}[{indices}])"
+            )
+        )
+    assert len(statements) == len(output_hosts)
+    return statements
+
+
+def _codegen_grouped_compact_tile(state: CodegenState) -> None:
+    """Emit static base-block and double-block compact-body variants."""
+    from .compact_worklist import compact_ref_names
+
+    env = CompileEnvironment.current()
+    plan = env.compact_worklist_plan
+    assert plan is not None and plan.grouping == 2
+    assert _is_compact_tile_loop(state)
+
+    codegen = state.codegen
+    common_statements: list[ast.AST] = []
+    branch_defs: list[ast.FunctionDef] = []
+    extent_ref = f"{compact_ref_names(plan)[1]}_ref"
+
+    counter_names = (
+        "atomic_op_index",
+        "device_load_index",
+        "device_load_cache_modifier_index",
+        "device_store_index",
+        "device_store_cache_modifier_index",
+        "device_memory_op_index",
+    )
+    initial_counters = {
+        name: getattr(state.device_function, name) for name in counter_names
+    }
+    final_counters: dict[str, int] | None = None
+    previous_common = codegen.grouped_compact_common_statements
+    assert previous_common is None
+    assert not codegen.grouped_resident_prep_lowering_cache
+    assert not codegen.grouped_resident_prep_refill_cache
+    assert not codegen.grouped_fori_dma_resource_cache
+    codegen.grouped_compact_common_statements = common_statements
+    try:
+        for factor in (1, 2):
+            for name, value in initial_counters.items():
+                setattr(state.device_function, name, value)
+            branch_body: list[ast.AST] = []
+            with (
+                codegen.set_statements(branch_body),
+                _compact_block_variant(state, factor),
+            ):
+                result = _codegen_fori_loop(state)
+            assert result is None
+            if factor == 1:
+                branch_body[:0] = _compact_output_initializers(state)
+                final_counters = {
+                    name: getattr(state.device_function, name) for name in counter_names
+                }
+
+            fn_name = state.device_function.new_var(f"_compact_group_{factor}")
+            comparison = "<=" if factor == 1 else ">"
+            fn_def = statement_from_string(
+                f"@pl.when({extent_ref}[_wid] {comparison} "
+                f"{env.compact_worklist_block})\n"
+                f"def {fn_name}():\n"
+                f"    pass"
+            )
+            assert isinstance(fn_def, ast.FunctionDef)
+            fn_def.body = cast("list[ast.stmt]", branch_body) or [ast.Pass()]
+            branch_defs.append(fn_def)
+    finally:
+        codegen.grouped_compact_common_statements = previous_common
+        codegen.grouped_resident_prep_lowering_cache.clear()
+        codegen.grouped_resident_prep_refill_cache.clear()
+        codegen.grouped_fori_dma_resource_cache.clear()
+        for name, value in (final_counters or initial_counters).items():
+            setattr(state.device_function, name, value)
+
+    for statement in common_statements:
+        state.add_statement(statement)
+    for fn_def in branch_defs:
+        state.add_statement(fn_def)
 
 
 def _compact_worklist_bounds(
@@ -2644,7 +2832,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     )
 
     # Compact worklist: the compact-tile aligned_load and exact_store tensors use
-    # per-tile pl.Element BlockSpecs, which Pallas double-buffers across the
+    # max-sized pl.Element BlockSpecs, which Pallas double-buffers across the
     # work-item grid.  Keep them OUT of the manual make_async_copy DMA path: with
     # a single straight-line compact tile there is no inner loop to overlap, so a
     # DMA start()/wait() would run fully serial (load -> wait -> compute -> store
@@ -2733,15 +2921,36 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         uses_load_prefetch = load_buffer_count == 2
         state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
         hbm_name = state.device_function.tensor_arg(fake).name
-        vmem_name = state.device_function.register_scratch(
-            (load_buffer_count, *vmem_shape) if uses_load_prefetch else vmem_shape,
-            fake.dtype,
-            name_hint=hbm_name.replace("_hbm", "") + "_buf",
+        resource_key = (
+            graph_info.graph_id,
+            hbm_name,
+            direction,
+            vmem_shape,
+            load_buffer_count,
         )
-        sem_name = state.device_function.register_dma_semaphore(
-            name_hint=hbm_name.replace("_hbm", "") + "_sem",
-            shape=(load_buffer_count,) if uses_load_prefetch else (),
+        resource_cache = (
+            state.codegen.grouped_fori_dma_resource_cache
+            if state.codegen.grouped_compact_common_statements is not None
+            and _is_compact_ordered_inner_loop(state)
+            else None
         )
+        cached_resource = (
+            resource_cache.get(resource_key) if resource_cache is not None else None
+        )
+        if cached_resource is None:
+            vmem_name = state.device_function.register_scratch(
+                (load_buffer_count, *vmem_shape) if uses_load_prefetch else vmem_shape,
+                fake.dtype,
+                name_hint=hbm_name.replace("_hbm", "") + "_buf",
+            )
+            sem_name = state.device_function.register_dma_semaphore(
+                name_hint=hbm_name.replace("_hbm", "") + "_sem",
+                shape=(load_buffer_count,) if uses_load_prefetch else (),
+            )
+            if resource_cache is not None:
+                resource_cache[resource_key] = (vmem_name, sem_name)
+        else:
+            vmem_name, sem_name = cached_resource
         tensor_to_dma_scratch[hbm_name] = vmem_name
         tensor_to_sem[hbm_name] = sem_name
         if uses_load_prefetch:
@@ -2817,14 +3026,38 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     )
     if resident_prep_lowerings:
         assert len(grid_parts) == 1
-        num_ordered_tiles = state.device_function.new_var("_rc_num_ordered_tiles")
-        state.add_statement(
-            statement_from_string(f"{num_ordered_tiles} = {grid_parts[0]}")
+        refill_key = tuple(
+            (
+                lowering.hoist.graph_id,
+                lowering.hoist.prep_node_name,
+                lowering.cache_name,
+            )
+            for lowering in resident_prep_lowerings
         )
+        common_statements = state.codegen.grouped_compact_common_statements
+        num_ordered_tiles = (
+            state.codegen.grouped_resident_prep_refill_cache.get(refill_key)
+            if common_statements is not None
+            else None
+        )
+        if num_ordered_tiles is None:
+            num_ordered_tiles = state.device_function.new_var("_rc_num_ordered_tiles")
+            target = common_statements
+            with state.codegen.set_statements(target):
+                state.add_statement(
+                    statement_from_string(f"{num_ordered_tiles} = {grid_parts[0]}")
+                )
+                _emit_resident_prep_refill(
+                    state,
+                    block_ids,
+                    [num_ordered_tiles],
+                    resident_prep_lowerings,
+                )
+            if common_statements is not None:
+                state.codegen.grouped_resident_prep_refill_cache[refill_key] = (
+                    num_ordered_tiles
+                )
         grid_parts = [num_ordered_tiles]
-        _emit_resident_prep_refill(
-            state, block_ids, grid_parts, resident_prep_lowerings
-        )
 
     def _build_dma_slices(
         fake: torch.Tensor,
@@ -3088,20 +3321,14 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             ):
                 state.codegen.add_statement(statement)
 
-    # Compact-worklist outer tile: it IS the grid (exactly one tile per work
-    # item, since the builder guarantees extent <= BLOCK), so emit the body
+    # Compact-worklist outer tile: it IS the grid (exactly one static compact
+    # body per work item), so emit the body
     # straight-line with the loop var bound to 0 -- no fori_loop wrapper (which
     # would add control-flow overhead and block pipelining for the common
     # no-ordered-axis case). The ordered inner tile does not reach here: it lowers
     # separately through the loop type selected by the _for_loop Pallas dispatch.
-    plan = CompileEnvironment.current().compact_worklist_plan
-    is_compact_tile = (
-        plan is not None
-        and not carried  # the compact tile is parallel (no carried state)
-        and len(block_ids) == 1
-        and block_ids[0] == plan.compact_axis.block_id
-    )
-    if is_compact_tile:
+    if _is_compact_tile_loop(state):
+        assert not carried
         # No nonlocal declarations: the body runs at kernel scope (scratch refs
         # are kernel params, directly assignable -- nonlocal would be invalid).
         state.add_statement(statement_from_string(f"{loop_vars[0]} = 0"))

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -470,7 +470,7 @@ VALID_KEYS: frozenset[str] = frozenset(
 # Loop types the autotuner searches by default for every Pallas inner loop.
 AUTOTUNED_PALLAS_LOOP_TYPES = ("emit_pipeline", "unroll", "fori_loop")
 VALID_PALLAS_LOOP_TYPES = AUTOTUNED_PALLAS_LOOP_TYPES
-VALID_PALLAS_WORKLIST_GROUPINGS = (0, 1)
+VALID_PALLAS_WORKLIST_GROUPINGS = (0, 1, 2)
 VALID_PID_TYPES = (
     "flat",
     "xyz",

--- a/helion/runtime/compact_worklist.py
+++ b/helion/runtime/compact_worklist.py
@@ -32,7 +32,7 @@ class CompactWorkMetadata(NamedTuple):
     """Scalar-prefetch metadata describing one compact worklist.
 
     Each of the array fields has the static shape ``[UPPER]``; entry ``i``
-    describes the ``i``-th compact tile (work item).  ``num_work`` is the
+    describes the ``i``-th compact tile group (work item).  ``num_work`` is the
     *traced* number of work items actually produced (``<= UPPER``); only the
     first ``num_work`` grid points execute, so the padded tail of every array is
     never indexed.
@@ -47,25 +47,24 @@ class CompactWorkMetadata(NamedTuple):
 
     owner_ids: Array  # int32[UPPER]   (per work item: which owner produced it)
     tile_starts: Array  # int32[UPPER] (absolute compact-tile start row)
-    tile_extents: Array  # int32[UPPER] (valid rows in the tile, in [1, block])
+    tile_extents: Array  # int32[UPPER] (valid rows in the tile group)
     range_start: Array | None  # int32[UPPER] | None  (ordered range begin)
     range_len: Array | None  # int32[UPPER] | None    (ordered range length, RAW)
     num_work: Array  # int32[]  TRACED scalar (never .item()-ed)
 
 
 def packed_upper_bound(total_compact: int, num_owners: int, block: int) -> int:
-    """Static megablocks bound on the number of compact tiles, PACKED ranges only.
+    """Static megablocks bound on the number of work items, PACKED ranges only.
 
-    Tight/safe **only when** owner ranges are packed/non-overlapping
-    (``sum(lengths) == total_compact``): then each owner wastes at most one
-    partial leading tile, so the worst case is ``cdiv(total_compact, block) +
-    num_owners - 1`` (tokamax: ``tiles_m + num_groups - 1``).  ``total_compact``
-    (e.g. ``total_q``) and ``num_owners`` (e.g. ``num_seq``) are static tensor
-    shapes, so this is a static Python int and no per-owner max length is needed.
+    Safe when owner ranges are packed/non-overlapping and ``total_compact`` is
+    at least ``sum(lengths)``. Equality gives the tight bound; a padded backing
+    tensor only makes it conservative. Each owner wastes at most one partial
+    leading block, so the worst case is ``cdiv(total_compact, block) +
+    num_owners - 1`` (tokamax: ``tiles_m + num_groups - 1``). Both inputs are
+    static shape data, so no event-size constant or per-owner maximum is needed.
 
     For general (possibly-overlapping) ranges this bound can UNDER-count
-    ``num_work``; the backend uses a conservative ``num_owners * cdiv(total,
-    block)`` instead (see ``backend._compact_worklist_upper``).
+    ``num_work``.
     """
     return -(-total_compact // block) + num_owners - 1
 
@@ -76,16 +75,17 @@ def flatten_worklist(
     block: int,
     UPPER: int,
     *,
+    grouping: int = 1,
     dep_base: Array | None = None,
     dep_len: Array | None = None,
 ) -> CompactWorkMetadata:
-    """Flatten a ragged ``owner x tile`` product into a padded compact worklist.
+    """Flatten a ragged ``owner x tile-group`` product into a padded worklist.
 
     ``base`` and ``length`` are ``int`` arrays of shape ``[P]`` (one entry per
     owner): ``base[p]`` is the absolute start row of owner ``p``'s compact slab
-    and ``length[p]`` its row count.  The owner is split into
-    ``cdiv(length[p], block)`` tiles; the flat list of all such tiles across all
-    owners is the worklist.
+    and ``length[p]`` its row count. The owner is split into base tiles of
+    ``block`` rows, then up to ``grouping`` consecutive base tiles from that
+    owner are combined into one work item.
 
     ``dep_base``/``dep_len`` (optional, ``[P]``) carry a per-owner ordered range
     (e.g. KV) that is gathered per work item and stored **raw** (never clamped).
@@ -101,9 +101,12 @@ def flatten_worklist(
     base = jnp.asarray(base, jnp.int32)
     length = jnp.asarray(length, jnp.int32)
     block_i = jnp.int32(block)
+    grouping_i = jnp.int32(grouping)
+    group_span = block_i * grouping_i
 
-    # Per-owner tile count -- parallel level, NOT clamped to a minimum of 1.
-    cnt = (length + block_i - 1) // block_i  # [P]
+    # Per-owner group count -- parallel level, NOT clamped to a minimum of 1.
+    logical_cnt = (length + block_i - 1) // block_i
+    cnt = (logical_cnt + grouping_i - 1) // grouping_i
     off = jnp.cumsum(cnt) - cnt  # exclusive scan: first work-item index per owner
     num_work = cnt.sum().astype(jnp.int32)  # TRACED scalar; never .item()-ed
 
@@ -114,17 +117,13 @@ def flatten_worklist(
     # total_repeat_length truncates the worklist and tiles are SILENTLY DROPPED.
     work = jnp.repeat(jnp.arange(p, dtype=jnp.int32), cnt, total_repeat_length=UPPER)
 
-    # tile_in[i] = index of this tile within its owner (0-based).
-    tile_in = jnp.arange(UPPER, dtype=jnp.int32) - off[work]
-    tile_starts = (base[work] + tile_in * block_i).astype(jnp.int32)
-    # Last tile of an owner is partial; clamp the extent to [.., block].  In the
-    # valid range [0, num_work) this is always in [1, block]; clip(min=0) is
-    # defensive for the padded tail (where length-tile_in*block can go negative),
-    # which the runtime grid never indexes but keeps the array non-negative.
-    tile_extents = jnp.clip(length[work] - tile_in * block_i, 0, block_i).astype(
+    # group_in[i] = index of this tile group within its owner (0-based).
+    group_in = jnp.arange(UPPER, dtype=jnp.int32) - off[work]
+    group_offset = group_in * group_span
+    tile_starts = (base[work] + group_offset).astype(jnp.int32)
+    tile_extents = jnp.clip(length[work] - group_offset, 0, group_span).astype(
         jnp.int32
     )
-
     range_start = None if dep_base is None else jnp.asarray(dep_base, jnp.int32)[work]
     range_len = None if dep_len is None else jnp.asarray(dep_len, jnp.int32)[work]
 

--- a/test/test_pallas_worklist.py
+++ b/test/test_pallas_worklist.py
@@ -65,7 +65,9 @@ def _expr(src: str) -> ast.AST:
     return ast.parse(src, mode="eval").body
 
 
-def _python_flatten_reference(base, length, block, *, dep_base=None, dep_len=None):
+def _python_flatten_reference(
+    base, length, block, *, grouping=1, dep_base=None, dep_len=None
+):
     """Slow, obviously-correct Python reference for :func:`flatten_worklist`.
 
     Returns plain Python lists over the *valid* ``[0, num_work)`` range only
@@ -77,12 +79,14 @@ def _python_flatten_reference(base, length, block, *, dep_base=None, dep_len=Non
     range_start = []
     range_len = []
     for p in range(len(base)):
-        cnt = -(-int(length[p]) // block)  # cdiv, NOT clamped up
-        for t in range(cnt):
+        logical_count = -(-int(length[p]) // block)  # cdiv, NOT clamped up
+        for t in range(0, logical_count, grouping):
+            tile_count = min(grouping, logical_count - t)
             owner_ids.append(p)
             tile_starts.append(int(base[p]) + t * block)
-            tile_extents.append(min(block, int(length[p]) - t * block))
+            tile_extents.append(min(tile_count * block, int(length[p]) - t * block))
             if dep_base is not None:
+                assert dep_len is not None
                 range_start.append(int(dep_base[p]))
                 range_len.append(int(dep_len[p]))
     return {
@@ -100,7 +104,7 @@ def _python_flatten_reference(base, length, block, *, dep_base=None, dep_len=Non
 class TestWorklistBuilder(unittest.TestCase):
     """Unit tests for :func:`flatten_worklist`."""
 
-    def _check(self, lengths, block, *, dep_lengths=None):
+    def _check(self, lengths, block, *, grouping=1, dep_lengths=None):
         """Build with JAX and assert the valid range matches the reference."""
         lengths = list(lengths)
         # Owners are packed contiguously, so base = exclusive cumsum of lengths.
@@ -109,7 +113,7 @@ class TestWorklistBuilder(unittest.TestCase):
             base.append(base[-1] + L)
         total = sum(lengths)
         num_owners = len(lengths)
-        UPPER = packed_upper_bound(total, num_owners, block)
+        UPPER = packed_upper_bound(total, num_owners, block * grouping)
 
         dep_base = None
         if dep_lengths is not None:
@@ -123,13 +127,19 @@ class TestWorklistBuilder(unittest.TestCase):
             jnp.asarray(lengths, jnp.int32),
             block,
             UPPER,
+            grouping=grouping,
             dep_base=None if dep_base is None else jnp.asarray(dep_base, jnp.int32),
             dep_len=None
             if dep_lengths is None
             else jnp.asarray(dep_lengths, jnp.int32),
         )
         ref = _python_flatten_reference(
-            base, lengths, block, dep_base=dep_base, dep_len=dep_lengths
+            base,
+            lengths,
+            block,
+            grouping=grouping,
+            dep_base=dep_base,
+            dep_len=dep_lengths,
         )
 
         num_work = int(meta.num_work)
@@ -184,6 +194,26 @@ class TestWorklistBuilder(unittest.TestCase):
 
     def test_with_dep_range(self):
         self._check([300, 100, 256], block=128, dep_lengths=[512, 64, 200])
+
+    def test_grouping_two(self):
+        meta, num_work = self._check(
+            [0, 3, 8, 9, 16, 17, 24, 25],
+            block=8,
+            grouping=2,
+            dep_lengths=[1, 2, 3, 4, 5, 6, 7, 8],
+        )
+        self.assertEqual(
+            np.asarray(meta.owner_ids)[:num_work].tolist(),
+            [1, 2, 3, 4, 5, 5, 6, 6, 7, 7],
+        )
+        self.assertEqual(
+            np.asarray(meta.tile_starts)[:num_work].tolist(),
+            [0, 3, 11, 20, 36, 52, 53, 69, 77, 93],
+        )
+        self.assertEqual(
+            np.asarray(meta.tile_extents)[:num_work].tolist(),
+            [3, 8, 9, 16, 16, 1, 16, 8, 16, 9],
+        )
 
     def test_empty_dep_stored_raw(self):
         # An empty ordered range (kv_len == 0) must be stored RAW (not clamped
@@ -259,7 +289,7 @@ def _axis(kind, loop_var, block_id=0):
     )
 
 
-def _plan(*, ordered, owner_indexed):
+def _plan(*, ordered, owner_indexed, grouping=1):
     axes = [_axis("owner_grid", "seq", 0), _axis("compact_tile", "tile_q", 1)]
     if ordered:
         axes.append(_axis("ordered", "tile_kv", 2))
@@ -267,7 +297,10 @@ def _plan(*, ordered, owner_indexed):
     if owner_indexed:
         policies.append(TensorPolicy(arg_name="k", kind="owner_indexed"))
     return CompactWorklistPlan(
-        axes=tuple(axes), tensor_policies=tuple(policies), upper_bound_expr=""
+        axes=tuple(axes),
+        tensor_policies=tuple(policies),
+        upper_bound_expr="",
+        grouping=grouping,
     )
 
 
@@ -285,6 +318,11 @@ class TestMetadataArgNames(unittest.TestCase):
             (
                 "fully_jagged",
                 _plan(ordered=True, owner_indexed=False),
+                ["work_seq", "q_begin", "q_extent", "kv_begin", "kv_len"],
+            ),
+            (
+                "grouped",
+                _plan(ordered=True, owner_indexed=False, grouping=2),
                 ["work_seq", "q_begin", "q_extent", "kv_begin", "kv_len"],
             ),
         ]
@@ -572,12 +610,12 @@ def _offsets(lengths):
 
 
 def _worklist_config(
-    block_sizes: list[int], *, loop_type: str = "unroll"
+    block_sizes: list[int], *, loop_type: str = "unroll", grouping: int = 1
 ) -> helion.Config:
     return helion.Config(
         block_sizes=block_sizes,
         pallas_loop_type=loop_type,
-        pallas_worklist_grouping=1,
+        pallas_worklist_grouping=grouping,
     )
 
 
@@ -684,7 +722,7 @@ class TestDetectAndGating(unittest.TestCase):
         self.assertIsInstance(grouping_field, EnumFragment)
         choices = loop_type_field.choices
         self.assertEqual(choices, ("fori_loop", "emit_pipeline", "unroll"))
-        self.assertEqual(grouping_field.choices, (0, 1))
+        self.assertEqual(grouping_field.choices, (0, 1, 2))
         self.assertEqual(list(bk.env.config_spec.grid_block_ids), [0])
 
     def test_gating_absent_for_non_jagged(self):
@@ -1042,14 +1080,14 @@ class TestWorklistConfig(unittest.TestCase):
         kernel = self._kernel(fn, _worklist_config([16, 16]))
         args = (torch.randn(64, 64), torch.randn(64, 64))
         bound = kernel.bind(args)
-        with self.assertRaises(exc.InvalidConfig):
-            bound.ensure_config_exists(args)
-            bound.to_triton_code(bound._config)
+        for grouping in (1, 2):
+            with self.subTest(grouping=grouping), self.assertRaises(exc.InvalidConfig):
+                bound.to_triton_code(_worklist_config([16, 16], grouping=grouping))
 
     def test_invalid_worklist_grouping_raises(self):
         args = (torch.randn(64, 64), torch.randn(64, 64))
         bound = _add_kernel.bind(args)
-        for grouping in (True, 2):
+        for grouping in (True, -1, 3):
             with (
                 self.subTest(grouping=grouping),
                 self.assertRaisesRegex(
@@ -1121,6 +1159,51 @@ class TestWorklistLoopDispatch(unittest.TestCase):
         self.assertIn("lax.fori_loop", code)
         self.assertNotIn("pltpu.emit_pipeline(", code)
         self.assertIn("_compact_aligned_arg_indices=", code)
+
+    def test_grouping_two_emits_static_compact_variants(self):
+        qo = _offsets([12, 20, 5, 30])
+        lq = int(qo[-1])
+        args = (
+            torch.randn(lq, 4, 128),
+            torch.randn(4, 16, 4, 128),
+            torch.randn(4, 16, 4, 128),
+            qo,
+        )
+        code = _dense_kv_kernel.bind(args).to_triton_code(
+            _worklist_config([8], grouping=2)
+        )
+
+        self.assertIn("grouping=2", code)
+        self.assertIn("@pl.when(q_extent_ref[_wid] <= 8)", code)
+        self.assertIn("@pl.when(q_extent_ref[_wid] > 8)", code)
+        self.assertIn("_BLOCK_SIZE_1 = int(8)", code)
+        self.assertIn("_BLOCK_SIZE_2 = int(16)", code)
+        self.assertIn("q[pl.ds(0, _BLOCK_SIZE_1)", code)
+        self.assertIn("q[pl.ds(0, _BLOCK_SIZE_2)", code)
+        self.assertIn("out[:, :, :] = jnp.zeros_like(out[:, :, :])", code)
+        self.assertIn("_compact_block=16", code)
+        self.assertIn("_compact_num_scalar_prefetch=3", code)
+
+    def test_grouping_two_composes_with_loop_types(self):
+        for loop_type in ("unroll", "emit_pipeline", "fori_loop"):
+            with self.subTest(loop_type=loop_type):
+                code = _fully_jagged_kernel.bind(
+                    self._fully_jagged_args()
+                ).to_triton_code(
+                    _worklist_config([8, 8], loop_type=loop_type, grouping=2)
+                )
+                self.assertIn("@pl.when(q_extent_ref[_wid] <= 8)", code)
+                self.assertIn("@pl.when(q_extent_ref[_wid] > 8)", code)
+                if loop_type == "unroll":
+                    self.assertEqual(code.count("def _rc_prep_refill():"), 1)
+                    self.assertNotIn("k_prep_1", code)
+                elif loop_type == "emit_pipeline":
+                    self.assertEqual(code.count("pltpu.emit_pipeline("), 2)
+                    self.assertNotIn("_rc_prep_refill", code)
+                else:
+                    self.assertIn("pltpu.make_async_copy", code)
+                    self.assertNotIn("k_buf_1", code)
+                    self.assertNotIn("v_buf_1", code)
 
     def test_emit_pipeline_streams(self):
         code = _fully_jagged_kernel.bind(self._fully_jagged_args()).to_triton_code(
@@ -1292,9 +1375,17 @@ class TestConfigStateIsolation(unittest.TestCase):
             qo,
         )
         bound = kernel.bind(args)
-        # Worklist config first -> sets env.compact_worklist_plan.
+        # Grouping 2 first exercises the temporary doubled-block codegen state.
+        grouped = bound.to_triton_code(
+            _worklist_config([8], loop_type="fori_loop", grouping=2)
+        )
+        self.assertIn("@pl.when(q_extent_ref[_wid] <= 8)", grouped)
+        self.assertIn("_compact_block=16", grouped)
+        # A subsequent grouping-1 config must recover the original block and body.
         worklist = bound.to_triton_code(_worklist_config([8], loop_type="fori_loop"))
         self.assertIn("work_seq_ref", worklist)
+        self.assertNotIn("_compact_group_", worklist)
+        self.assertIn("_compact_block=8", worklist)
         # Then a fori config on the SAME bound kernel (same env): must be clean.
         fori = bound.to_triton_code(
             helion.Config(block_sizes=[8], pallas_loop_type="fori_loop")
@@ -1356,13 +1447,15 @@ class TestWorklistNumerics(unittest.TestCase):
         q = torch.randn(lq, H, D, device=DEVICE, dtype=torch.bfloat16)
         k = torch.randn(B, KV, H, D, device=DEVICE, dtype=torch.bfloat16)
         v = torch.randn(B, KV, H, D, device=DEVICE, dtype=torch.bfloat16)
-        _, out = code_and_output(
-            _dense_kv_kernel,
-            (q, k, v, qo.to(DEVICE)),
-            **_worklist_config([block]),
-        )
         ref = _eager_dense_kv(q.cpu(), k.cpu(), v.cpu(), qo)
-        torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
+        for grouping in (1, 2):
+            with self.subTest(grouping=grouping):
+                _, out = code_and_output(
+                    _dense_kv_kernel,
+                    (q, k, v, qo.to(DEVICE)),
+                    **_worklist_config([block], grouping=grouping),
+                )
+                torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
 
     def test_dense_kv_empty_batch_zero_grid(self):
         # total_q == 0 => num_work == 0 => dynamic grid=(0,).  End-to-end guard
@@ -1434,12 +1527,21 @@ class TestWorklistNumerics(unittest.TestCase):
         k = torch.randn(lkv, H, D, device=DEVICE, dtype=torch.bfloat16)
         v = torch.randn(lkv, H, D, device=DEVICE, dtype=torch.bfloat16)
         ref = _eager_fully_jagged(q.cpu(), k.cpu(), v.cpu(), qo, kvo)
-        for loop_type in ("unroll", "fori_loop"):
-            with self.subTest(loop_type=loop_type):
+        configs = (
+            ("unroll", 1),
+            ("fori_loop", 1),
+            ("unroll", 2),
+            ("emit_pipeline", 2),
+            ("fori_loop", 2),
+        )
+        for loop_type, grouping in configs:
+            with self.subTest(loop_type=loop_type, grouping=grouping):
                 _, out = code_and_output(
                     _fully_jagged_kernel,
                     (q, k, v, qo.to(DEVICE), kvo.to(DEVICE)),
-                    **_worklist_config([block, block], loop_type=loop_type),
+                    **_worklist_config(
+                        [block, block], loop_type=loop_type, grouping=grouping
+                    ),
                 )
                 torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
 
@@ -1500,7 +1602,7 @@ class TestWorklistJaxExport(unittest.TestCase):
         qod = jnp.asarray(qo.numpy())
         kernel = helion.kernel(
             _dense_kv_kernel.fn,
-            config=_worklist_config([block]),
+            config=_worklist_config([block], grouping=2),
             static_shapes=True,
             backend="pallas",
         )


### PR DESCRIPTION
This follow-up enables `pallas_worklist_grouping=2`. Grouping 2 combines up to two consecutive base tiles from the same jagged owner into one flattened worklist item.

The benefit is we concatenate and process two matmuls in one

```python
 # Grouping 1, performed by two work items
  q0.shape == [H, B, D]
  q1.shape == [H, B, D]
  scores0 = q0 @ k.T
  scores1 = q1 @ k.T

  # Grouping 2, performed by one work item
  q01.shape == [H, 2 * B, D]
  scores01 = q01 @ k.T
```

- Extend pallas_worklist_grouping validation to accept 2.
- Enable flattened-worklist setup for grouping values 1 and 2.
- Teach flatten_worklist() to combine consecutive base tiles without crossing owner boundaries.
- Keep the existing metadata fields: owner, tile start, tile extent, and optional ordered-range metadata.
- Size the static worklist upper bound from the padded compact input shape using the effective block * grouping span.
- Use a maximum-sized 2 * block launcher BlockSpec for grouped compact inputs and outputs.
- Generate two statically shaped compact-body variants:
  - extent <= block: execute the base-block variant.
  - extent > block: execute the double-block variant.
- Select between these variants at runtime with mutually exclusive pl.when predicates.
- Zero the unused portion of the maximum-sized output window in the one-tile variant so the launcher writeback cannot expose stale values.

| loop_type | kernel | g1 | g2 | Δ |
| --- | --- | --- | --- | --- |
| unroll | gdpa | 175.9 | 186.8 | +6.2% |
| | hstu | 193.1 | 201.0 | +4.1% |
| emit_pipeline | gdpa | 123.2 | 147.9 | +20% |
| | hstu | 133.9 | 159.3 | +19% |
| fori_loop | gdpa | 82.5 | 112.3 | +36% |
| | hstu | 87.2 | 119.1 | +37% |