### PR TITLE
[Pallas] Elide redundant fast-math matmul masks

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -109,7 +109,8 @@ def my_kernel(x: torch.Tensor) -> torch.Tensor:
 
    If ``True``, enable fast math approximations. This activates both Helion-level optimizations
    (e.g. fast sigmoid) and Inductor-level fast math (flush-to-zero exp, fast online softmax,
-   etc.). May reduce numerical precision. Default is ``False``. Controlled by ``HELION_FAST_MATH=1``.
+   etc.). May reduce numerical precision and change NaN/Inf behavior. Default is ``False``.
+   Controlled by ``HELION_FAST_MATH=1``.
 
 .. autoattribute:: Settings.persistent_reserved_sms
 
@@ -319,7 +320,7 @@ Built-in values for ``HELION_AUTOTUNER`` include ``"LFBOTreeSearch"`` (default),
 | ``JAX_DEFAULT_MATMUL_PRECISION`` | ``dot_precision`` | Accepts JAX matmul precision values for Pallas dot products (``"default"``, ``"high"``, ``"highest"``, etc., mapped to Helion ``DotPrecision``). On TPU these values emit Pallas default precision. This variable does not apply to the Triton backend. |
 | ``HELION_INDEX_DTYPE`` | ``index_dtype`` | Choose the index dtype (accepts any ``torch.<dtype>`` name, e.g. ``int64``), or set to ``auto``/unset to allow Helion to pick ``int32`` vs ``int64`` based on input sizes. |
 | ``HELION_STATIC_SHAPES`` | ``static_shapes`` | Set to ``0``/``false`` to disable global static shape specialization. |
-| ``HELION_FAST_MATH`` | ``fast_math`` | Set to ``1`` to enable fast math approximations (Helion-level and Inductor-level). May reduce numerical precision. |
+| ``HELION_FAST_MATH`` | ``fast_math`` | Set to ``1`` to enable fast math approximations (Helion-level and Inductor-level). May reduce numerical precision and change NaN/Inf behavior. |
 | ``HELION_PERSISTENT_RESERVED_SMS`` | ``persistent_reserved_sms`` | Reserve this many streaming multiprocessors when launching persistent kernels (``0`` uses all available SMs). |
 | ``HELION_FORCE_AUTOTUNE`` | ``force_autotune`` | Force the autotuner to run even when explicit configs are provided. The result is saved to the cache. |
 | ``HELION_AUTOTUNE_FORCE_PERSISTENT`` | ``autotune_force_persistent`` | Restrict ``pid_type`` to persistent kernel strategies during config search. |

--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -494,15 +494,28 @@ def apply_dot_requirements(lowering: AtenLowering, node: Node) -> Lowering:
     return lowering
 
 
+def matmul_masked_value(node: Node) -> float | bool | None:
+    """Propagate zero padding through a matmul under fast-math semantics."""
+    if not CompileEnvironment.current().settings.fast_math:
+        # In strict mode, zero multiplied by NaN or infinity is not zero.
+        return None
+    lhs, rhs = cast("tuple[Node, Node]", node.args[:2])
+    return (
+        0 if cached_masked_value(lhs) == 0 and cached_masked_value(rhs) == 0 else None
+    )
+
+
 bmm_lowering = register_lowering(
     torch.ops.aten.bmm.default,
     apply_dot_requirements,
+    masked_value_fn=matmul_masked_value,
 )
 
 
 mm_lowering = register_lowering(
     torch.ops.aten.mm.default,
     apply_dot_requirements,
+    masked_value_fn=matmul_masked_value,
 )
 
 

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -59,17 +59,8 @@ class ResidentPrepLowering:
     hoist: ResidentPrepHoist
     resident_window_name: str
     cache_name: str
-    # The value the refill writes into the cache's padded (out-of-range) tail; it also
-    # serves as the elision key, since a downstream per-tile ``_mask_to`` with this same
-    # fill is then redundant and may be dropped (letting Mosaic fold the transpose into
-    # the matmul push).  Every prep that installs a refill -- all of them today -- must
-    # declare a finite value: ``_emit_resident_prep_refill`` emits it as a bare literal
-    # and asserts it is non-None and finite.  The ``None`` default is a construction guard
-    # only -- a new prep kind that forgets to set a fill is not silently opted into elision
-    # (the elision dict skips ``None``) and trips that refill assert -- NOT a usable "write
-    # a fill but keep the load mask" mode.  Expressing that needs the field split into a
-    # required tail-write value plus an optional (separate) elision fill.
-    tail_fill_value: float | None = None
+    # Fill written to the padded tail and used to identify redundant masks.
+    tail_fill_value: float
 
 
 class GenerateAST(NodeVisitor, CodegenInterface):

--- a/helion/_compiler/pallas/compact_worklist.py
+++ b/helion/_compiler/pallas/compact_worklist.py
@@ -476,45 +476,28 @@ def elide_installed_prep_load_masks(
     graph: torch.fx.Graph,
     load_tail_fills: Mapping[str, float],
 ) -> None:
-    """Drop the redundant per-tile OOB masks on loads whose prep cache was installed.
+    """Drop redundant masks after resident prep lowerings are installed.
 
-    ``load_tail_fills`` maps the load node name of each ACTUALLY-installed prep lowering
-    to the value that lowering's refill writes into the cache's padded tail (its
-    ``tail_fill_value``).  Because the refill already wrote that value there, a
-    downstream ``_mask_to`` with the same fill is redundant; deleting it also lets
-    Mosaic fold the transpose into the matmul push.
-
-    Called from prep-lowering installation with only the lowerings that survived
-    validation, so a prep that fell back to resident-only leaves its load's mask in
-    place (correctness is never coupled to admission-time optimism).  Elision is keyed
-    on the declared ``tail_fill_value``: a flash-style ``_mask_to(scores, -inf)`` (fill
-    != the cache's tail fill, and downstream of the dot) is preserved automatically.
-    Non-resident (streamed) deferred loads keep their unknown masked value untouched.
+    ``load_tail_fills`` maps each installed load to the value written into its prep
+    cache's padded tail. Deferred loads without an installed prep remain unknown and
+    keep their masks.
     """
     from ..host_function import HostFunction
     from ..node_masking import remove_unnecessary_masking
 
     if not load_tail_fills:
         return
-    # ``remove_unnecessary_masking`` recomputes masked values, which for loop-carried
-    # (phi) nodes walks the enclosing graphs via ``DeviceIR.current()``; make the device
-    # IR current since prep-lowering install runs during codegen, outside the pass.
+    # Loop placeholders resolve masked values through the enclosing device IR.
     with HostFunction.current().device_ir:
         for node in graph.nodes:
-            fill = load_tail_fills.get(node.name)
-            if fill is not None:
-                # The refill wrote ``fill`` into the padded tail: declare it so the
-                # matching-fill ``_mask_to`` downstream is judged redundant.
-                node.meta["masked_value"] = fill
-            elif (
-                node.meta.get("masked_value") is None
-                and "pallas_deferred_mask_block_ids" in node.meta
-            ):
-                # A non-resident deferred load: keep its unknown masked value so its
-                # (still-needed) deferred mask is preserved.
+            if node.op == "placeholder":
+                # Prep installation changes inner loads and their descendants only.
                 continue
+            if node.name in load_tail_fills:
+                node.meta["masked_value"] = load_tail_fills[node.name]
+            elif "pallas_deferred_mask_block_ids" in node.meta:
+                node.meta["masked_value"] = None
             else:
-                # Drop the stale cache so masked values recompute from the loads above.
                 node.meta.pop("masked_value", None)
         remove_unnecessary_masking(graph)
 

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -304,16 +304,11 @@ def _prepare_resident_prep_lowerings(
                 tail_fill_value=0.0,
             )
         )
-    # These lowerings are now installed (all validation above passed; any fallback
-    # returned early), so it is safe to drop the redundant per-tile masks on exactly
-    # these loads -- keyed on each lowering's declared tail fill, which also preserves
-    # a flash-style _mask_to(scores, -inf) whose fill differs.  Coupling elision to the
-    # installed set (not admission) keeps correctness off the "prep always emits" path.
-    load_tail_fills: dict[str, float] = {}
-    for lw in lowerings:
-        fill = lw.tail_fill_value
-        if fill is not None:
-            load_tail_fills[lw.hoist.load_node_name] = fill
+    # Fallback paths above return before declaring any tail-fill guarantees.
+    load_tail_fills = {
+        lowering.hoist.load_node_name: lowering.tail_fill_value
+        for lowering in lowerings
+    }
     elide_installed_prep_load_masks(graph_info.graph, load_tail_fills)
     if common_statements is not None:
         state.codegen.grouped_resident_prep_lowering_cache[cache_key] = lowerings
@@ -357,12 +352,9 @@ def _emit_resident_prep_refill(
     refill_tail_stmts: list[ast.stmt] = []
     for lowering in lowerings:
         assert isinstance(lowering, ResidentPrepLowering)
-        # The tail fill is emitted as a bare literal below, so it must be a finite
-        # number.  A non-finite (inf/-inf/nan) or undeclared (None) fill would need
-        # deliberate literal formatting; today only the transpose prep (0.0) reaches
-        # here, so assert rather than silently mis-emit.
+        # Generated fill literals currently support finite values only.
         tail_fill = lowering.tail_fill_value
-        assert tail_fill is not None and -float("inf") < tail_fill < float("inf"), (
+        assert -float("inf") < tail_fill < float("inf"), (
             "resident prep refill supports only finite numeric tail_fill_value"
         )
         perm = lowering.hoist.perm

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -623,7 +623,8 @@ class Settings(_Settings):
         "dot_precision": "Precision for dot products. For Triton backend, see `triton.language.dot` (can be 'tf32', 'tf32x3', 'ieee'). For JAX/Pallas backend, accepted values emit Pallas default precision on TPU. Unified mappings exist so that any value can be used on any backend.",
         "fast_math": (
             "If True, enable fast math approximations (Helion-level and Inductor-level). "
-            "May reduce numerical precision. Set HELION_FAST_MATH=1 to enable."
+            "May reduce numerical precision and change NaN/Inf behavior. "
+            "Set HELION_FAST_MATH=1 to enable."
         ),
         "static_shapes": (
             "If True, use static shapes for all tensors. This is a performance optimization. "

--- a/test/test_masking.py
+++ b/test/test_masking.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import types
 import unittest
 from unittest.mock import patch
 
@@ -7,6 +8,8 @@ import torch
 
 import helion
 from helion import _compat
+from helion._compiler.aten_lowering import matmul_masked_value
+from helion._compiler.compile_environment import CompileEnvironment
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
@@ -16,6 +19,26 @@ from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 import helion.language as hl
 from helion.runtime.settings import _get_backend
+
+
+class TestMatmulMaskedValue(unittest.TestCase):
+    def test_requires_fast_math_and_two_zero_padded_operands(self) -> None:
+        graph = torch.fx.Graph()
+        lhs = graph.placeholder("lhs")
+        rhs = graph.placeholder("rhs")
+        lhs.meta["masked_value"] = 0
+        rhs.meta["masked_value"] = 0
+        mm = graph.call_function(torch.ops.aten.mm.default, (lhs, rhs))
+
+        env = types.SimpleNamespace(settings=types.SimpleNamespace(fast_math=False))
+        with patch.object(CompileEnvironment, "current", return_value=env):
+            self.assertIsNone(matmul_masked_value(mm))
+
+            env.settings.fast_math = True
+            self.assertEqual(matmul_masked_value(mm), 0)
+
+            rhs.meta["masked_value"] = None
+            self.assertIsNone(matmul_masked_value(mm))
 
 
 @onlyBackends(["triton", "cute"])

--- a/test/test_pallas_worklist.py
+++ b/test/test_pallas_worklist.py
@@ -1549,6 +1549,35 @@ class TestWorklistNumerics(unittest.TestCase):
         "the resident-cache ordered KV path is validated on real TPU, not "
         "Pallas interpret mode"
     )
+    def test_grouped_fast_math_mask_elision_matches_eager(self):
+        H, D, block = 2, 16, 16
+        qo = _offsets([10, 23, 7, 40])
+        kvo = _offsets([16, 5, 0, 33])
+        lq, lkv = int(qo[-1]), int(kvo[-1])
+        torch.manual_seed(0)
+        q = torch.randn(lq, H, D, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.randn(lkv, H, D, device=DEVICE, dtype=torch.bfloat16)
+        v = torch.randn(lkv, H, D, device=DEVICE, dtype=torch.bfloat16)
+        ref = _eager_fully_jagged(q.cpu(), k.cpu(), v.cpu(), qo, kvo)
+        kernel = helion.kernel(
+            _fully_jagged_kernel.fn,
+            backend="pallas",
+            static_shapes=True,
+            fast_math=True,
+        )
+
+        code, out = code_and_output(
+            kernel,
+            (q, k, v, qo.to(DEVICE), kvo.to(DEVICE)),
+            **_worklist_config([block, block], loop_type="unroll", grouping=2),
+        )
+        self.assertEqual(code.count("lax.dot_general(scores"), 2)
+        torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
+
+    @skipIfPallasInterpret(
+        "the resident-cache ordered KV path is validated on real TPU, not "
+        "Pallas interpret mode"
+    )
     def test_fully_jagged_long_kv_matches_eager(self):
         # Long, jagged KV (several kvblock trips, non-divisible final tiles per
         # sequence): the end-to-end numeric check for a jagged ordered reduction,
@@ -1830,6 +1859,17 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
             kvo,
         )
 
+    def _fast_math_resident_code(self, grouping: int) -> str:
+        kernel = helion.kernel(
+            _fully_jagged_kernel.fn,
+            backend="pallas",
+            static_shapes=True,
+            fast_math=True,
+        )
+        return kernel.bind(self._resident_args()).to_triton_code(
+            _worklist_config([8, 8], grouping=grouping)
+        )
+
     def test_resident_prep_zero_fill_load_mask_elided_from_reduction(self):
         # The prep-hoisted resident K load reads a zero-filled cache (the refill writes
         # tail_fill_value=0 once), so its per-tile fill-0 mask is redundant and dropped.
@@ -1852,12 +1892,42 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
         self.assertRegex(body, rf"\b{src} = \w+_prep\[")
         self.assertNotRegex(body, rf"\b{src} = jnp\.where")
 
+    def test_fast_math_elides_zero_score_masks_for_both_groupings(self):
+        for grouping in (1, 2):
+            with self.subTest(grouping=grouping):
+                code = self._fast_math_resident_code(grouping)
+                score_masks = [
+                    line
+                    for line in code.splitlines()
+                    if "jnp.where" in line and ", scores" in line
+                ]
+                self.assertEqual(score_masks, [])
+                self.assertEqual(code.count("lax.dot_general(scores"), grouping)
+
+    def test_strict_math_keeps_zero_score_mask(self):
+        code = _fully_jagged_kernel.bind(self._resident_args()).to_triton_code(
+            _worklist_config([8, 8])
+        )
+        score_masks = [
+            line
+            for line in code.splitlines()
+            if "jnp.where" in line and ", scores" in line
+        ]
+        self.assertEqual(len(score_masks), 1)
+        self.assertNotIn("lax.dot_general(scores", code)
+
     def test_flash_resident_prep_keeps_softmax_neg_inf_mask(self):
         # Flash's fill-0 K/V load masks elide (prep cache zeroed), but the amax
         # reduction's softmax mask fills -inf (!= the cache's 0 tail) and is downstream
         # of the dot, so it is preserved.  Assert the score mask specifically: a
         # jnp.where whose fill is a -inf full (not merely the m_i init's -inf full).
-        code = _flash_prep_kernel.bind(self._resident_args()).to_triton_code(
+        kernel = helion.kernel(
+            _flash_prep_kernel.fn,
+            backend="pallas",
+            static_shapes=True,
+            fast_math=True,
+        )
+        code = kernel.bind(self._resident_args()).to_triton_code(
             _worklist_config([8, 8])
         )
         self.assertIn("_rc_prep_refill", code)  # prep cache installed


### PR DESCRIPTION
This extends the existing resident-prep mask elision through mm and bmm results.

  When both matmul operands are proven zero-padded, the result is also treated as zero-padded under fast_math. This lets the existing masking cleanup remove redundant where(scores, 0) operations before a subsequent matmul.

  The rule is backend-independent, while the motivating case is flattened Pallas worklists using resident-cache unroll.

  ## Motivation

  The resident-prep cache physically zero-fills its padded K/V tail. Its per-tile load masks can therefore be removed exactly.

  Previously, masked-value propagation stopped at the first matmul:
```python
  scores = q @ k.T
  masked_scores = where(valid, scores, 0)
  out = masked_scores @ v
```
  For finite inputs, zero-padded Q/K operands already produce zero-padded scores. With fast_math, the generated code can instead use:
```python
  scores = q @ k.T
  out = scores @ v
```
  Removing the intermediate mask gives Mosaic a cleaner matmul path.

  ## Semantics

  - The score-mask optimization requires fast_math=True.
  - Strict mode retains the score mask because IEEE 0 * NaN and 0 * Inf are not zero.
  - The resident-cache load-mask optimization remains exact and does not require fast math.
  - Flash-style where(scores, -inf) masks remain intact because their fill differs from the propagated zero value.
  - Grouping 1 and grouping 2 are both supported.
  - bmm.dtype inherits the same masked-value behavior through the existing bmm lowering.

  The public fast_math documentation now explicitly notes that it may change NaN/Inf behavior.

  ## Cleanup

  - Make resident-prep tail fills required rather than optional.
  - Simplify construction of installed load-to-fill facts.
  - Reset stale masked-value metadata while preserving placeholders and deferred loads.
  - Reuse the updated graph safely across grouping-2’s static B and 2B bodies.

  ## Testing

  Added coverage for:

  - Generic fast-math matmul masked-value propagation.
  - Strict-mode score-mask preservation.
  - Grouping 1 and 2 score-mask elision.
  - Flash -inf mask preservation.
  - Resident-prep fallback behavior.
  - Real-TPU grouped numerical correctness.
