### PR TITLE
[cutedsl] Correct attention benchmark config detection

### DIFF
--- a/benchmarks/cute/compare_attention_backends.py
+++ b/benchmarks/cute/compare_attention_backends.py
@@ -586,9 +586,14 @@ def _shape_dict(args: argparse.Namespace) -> dict[str, Any]:
 
 
 def _helion_codegen_markers(code: str) -> dict[str, bool]:
+    tcgen05_prefixes = ("cute.nvgpu.tcgen05.", "cute_tcgen05_flash.")
     return {
-        "uses_tcgen05": "cute.nvgpu.tcgen05.CtaGroup" in code,
-        "uses_tcgen05_two_cta": "cute.nvgpu.tcgen05.CtaGroup.TWO" in code,
+        "uses_tcgen05": any(prefix in code for prefix in tcgen05_prefixes),
+        "uses_tcgen05_two_cta": any(
+            f"{prefix}CtaGroup.TWO" in code for prefix in tcgen05_prefixes
+        )
+        or "is_two_cta=True" in code
+        or "'use_2cta_instrs': True" in code,
         "uses_tma_umma_pipeline": "PipelineTmaUmma.create(" in code,
     }
 
@@ -684,9 +689,13 @@ def _compiler_flash_seed_config(
         return None
     config_spec = cast("_BoundWithConfigSpec", bound).config_spec
     if config_spec.compiler_default_config is not None:
-        return dict(config_spec.default_config().config)
-    if config_spec.compiler_seed_configs:
-        return dict(config_spec.compiler_seed_configs[0].config)
+        default_config = dict(config_spec.default_config().config)
+        if any(key.startswith("cute_flash_") for key in default_config):
+            return default_config
+    for seed in config_spec.compiler_seed_configs:
+        seed_config = dict(seed.config)
+        if any(key.startswith("cute_flash_") for key in seed_config):
+            return seed_config
     return None
 
 

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -197,10 +197,16 @@ def test_attention_compiler_flash_seed_config_falls_back_to_seed_list():
             compiler_seed_configs=[
                 SimpleNamespace(
                     config={
+                        "block_sizes": [64, 64],
+                        "num_warps": 8,
+                    }
+                ),
+                SimpleNamespace(
+                    config={
                         "block_sizes": [1, 128, 128],
                         "cute_flash_kv_order": "ascending",
                     }
-                )
+                ),
             ],
         )
     )
@@ -210,6 +216,32 @@ def test_attention_compiler_flash_seed_config_falls_back_to_seed_list():
     assert config == {
         "block_sizes": [1, 128, 128],
         "cute_flash_kv_order": "ascending",
+    }
+
+
+def test_attention_compiler_flash_seed_config_skips_nonflash_default():
+    bound = SimpleNamespace(
+        config_spec=SimpleNamespace(
+            compiler_default_config=object(),
+            compiler_seed_configs=[
+                SimpleNamespace(
+                    config={
+                        "block_sizes": [1, 128, 128],
+                        "cute_flash_topology": "fa4",
+                    }
+                )
+            ],
+            default_config=lambda: SimpleNamespace(
+                config={"block_sizes": [64, 64], "num_warps": 8}
+            ),
+        )
+    )
+
+    config = compare_attention_backends._compiler_flash_seed_config(bound, "cute")
+
+    assert config == {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_topology": "fa4",
     }
 
 
@@ -270,6 +302,30 @@ def test_attention_helion_cute_timer_selects_bench_fn():
         is None
     )
     assert calls == ["get_do_bench"]
+
+
+@pytest.mark.parametrize(
+    "two_cta_marker",
+    (
+        "cute_tcgen05_flash.CtaGroup.TWO",
+        "is_two_cta=True",
+        "'use_2cta_instrs': True",
+    ),
+)
+def test_attention_codegen_markers_accept_generated_tcgen05_alias(
+    two_cta_marker: str,
+):
+    code = f"""
+from cutlass.cute.nvgpu import tcgen05 as cute_tcgen05_flash
+cute_tcgen05_flash.commit(ptr, mask, {two_cta_marker})
+PipelineTmaUmma.create()
+"""
+
+    assert compare_attention_backends._helion_codegen_markers(code) == {
+        "uses_tcgen05": True,
+        "uses_tcgen05_two_cta": True,
+        "uses_tma_umma_pipeline": True,
+    }
 
 
 def test_attention_markdown_and_wide_csv_include_timer():


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3147
 * #3146
 * #3145
 * #3144
 * #3143
 * #3142
 * #3141
 * #3140
 * #3139
 * __->__#3138


--- --- ---

[cutedsl] Correct attention benchmark config detection

Recognize aliased tcgen05 and two-CTA markers in generated code. Select the promoted or seeded CuTe flash configuration while skipping unrelated defaults and seeds.