### PR TITLE
[cutedsl] Clean up isolated autotune workers

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1875,6 +1875,7 @@ def print_autotune_metrics(metrics: list[AutotuneMetrics]) -> None:
         "Time (s)",
         "Configs",
         "Compile Fail",
+        "Worker Fail",
         "Accuracy Fail",
         "Generations",
         "Best Perf (ms)",
@@ -1885,6 +1886,7 @@ def print_autotune_metrics(metrics: list[AutotuneMetrics]) -> None:
     total_time = 0.0
     total_configs = 0
     total_compile_failures = 0
+    total_worker_failures = 0
     total_accuracy_failures = 0
     total_generations = 0
     total_configs_per_second = 0.0
@@ -1896,6 +1898,7 @@ def print_autotune_metrics(metrics: list[AutotuneMetrics]) -> None:
         total_time += m.autotune_time
         total_configs += m.num_configs_tested
         total_compile_failures += m.num_compile_failures
+        total_worker_failures += m.num_worker_failures
         total_accuracy_failures += m.num_accuracy_failures
         total_generations += m.num_generations
         total_configs_per_second += cps
@@ -1907,6 +1910,7 @@ def print_autotune_metrics(metrics: list[AutotuneMetrics]) -> None:
                 f"{m.autotune_time:.2f}",
                 m.num_configs_tested,
                 m.num_compile_failures,
+                m.num_worker_failures,
                 m.num_accuracy_failures,
                 m.num_generations,
                 f"{m.best_perf_ms:.4f}",
@@ -1922,6 +1926,7 @@ def print_autotune_metrics(metrics: list[AutotuneMetrics]) -> None:
                 f"{total_time / n:.2f}",
                 f"{total_configs / n:.1f}",
                 f"{total_compile_failures / n:.1f}",
+                f"{total_worker_failures / n:.1f}",
                 f"{total_accuracy_failures / n:.1f}",
                 f"{total_generations / n:.1f}",
                 "",
@@ -1933,6 +1938,7 @@ def print_autotune_metrics(metrics: list[AutotuneMetrics]) -> None:
                 f"{total_time:.2f}",
                 total_configs,
                 total_compile_failures,
+                total_worker_failures,
                 total_accuracy_failures,
                 total_generations,
                 "",

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -570,6 +570,12 @@ class BaseSearch(BaseAutotuner):
                 f"{self._autotune_metrics.num_configs_tested} configs failed due "
                 "to compile failures."
             )
+        if self._autotune_metrics.num_worker_failures:
+            self.log.warning(
+                f"{self._autotune_metrics.num_worker_failures} of "
+                f"{self._autotune_metrics.num_configs_tested} configs failed in "
+                "isolated benchmark workers."
+            )
         cached_path = self.kernel.get_cached_path(best)
         if cached_path is not None and is_master_rank():
             self.log(f"Code of selected kernel: {cached_path}")

--- a/helion/autotuner/benchmark_job.py
+++ b/helion/autotuner/benchmark_job.py
@@ -16,6 +16,7 @@ from .benchmarking import synchronize_device
 from .kernel_args import load_trusted_kernel_args
 from .logger import capture_output
 from .precompile_future import _load_compiled_fn
+from .precompile_future import _unload_compiled_fn
 
 if TYPE_CHECKING:
     from .precompile_future import SerializedCompiledFunction
@@ -34,18 +35,21 @@ class BenchmarkJob:
         # diagnostics don't leak to the user's terminal.
         with capture_output():
             fn = _load_compiled_fn(self.fn_spec)
-            args = load_trusted_kernel_args(self.args_path)
-            bench = do_bench_generic if self.use_wall_clock else do_bench
-            # return_mode="median" guarantees a float return (not the tuple variant).
-            return cast(
-                "float",
-                bench(
-                    functools.partial(fn, *args),
-                    return_mode="median",
-                    warmup=self.warmup,
-                    rep=self.rep,
-                ),
-            )
+            try:
+                args = load_trusted_kernel_args(self.args_path)
+                bench = do_bench_generic if self.use_wall_clock else do_bench
+                # return_mode="median" guarantees a float return.
+                return cast(
+                    "float",
+                    bench(
+                        functools.partial(fn, *args),
+                        return_mode="median",
+                        warmup=self.warmup,
+                        rep=self.rep,
+                    ),
+                )
+            finally:
+                _unload_compiled_fn(fn)
 
 
 @functools.cache
@@ -71,10 +75,13 @@ class AccuracyCheckJob:
         # Keep compile/launch diagnostics out of the autotune progress stream.
         with capture_output():
             fn = _load_compiled_fn(self.fn_spec)
-            args = load_trusted_kernel_args(self.args_path)
-            baseline_output = _load_trusted_baseline_output(self.baseline_path)
-            output = fn(*args)
-            synchronize_device()
+            try:
+                args = load_trusted_kernel_args(self.args_path)
+                baseline_output = _load_trusted_baseline_output(self.baseline_path)
+                output = fn(*args)
+                synchronize_device()
+            finally:
+                _unload_compiled_fn(fn)
 
         try:
             assert_close(output, baseline_output, atol=self.atol, rtol=self.rtol)

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -34,6 +34,7 @@ from .benchmark_job import AccuracyCheckJob
 from .benchmark_job import AccuracyCheckResult
 from .benchmark_job import BenchmarkJob
 from .benchmark_worker import BenchmarkSubprocessError
+from .benchmark_worker import BenchmarkTimeout
 from .benchmark_worker import BenchmarkWorker
 from .benchmarking import clear_jit_fast_path_caches
 from .benchmarking import do_bench
@@ -328,6 +329,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._precompile_baseline_path: str | None = None
         self._precompile_result_counter: count[int] = count()
         self._benchmark_worker: BenchmarkWorker | None = None
+        self._last_benchmark_failure_status: Literal["error", "timeout"] | None = None
         # budget_exceeded_fn inherits the class-level _never_exceeded default
         # until BaseSearch._prepare installs the search's real hook.
 
@@ -835,8 +837,13 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     process_group_name=self.kernel.env.process_group_name,
                 )
             ):
+                self._last_benchmark_failure_status = None
                 perf = self._benchmark_function(config, fn)
-                status = "ok" if math.isfinite(perf) else "error"
+                status = (
+                    "ok"
+                    if math.isfinite(perf)
+                    else self._last_benchmark_failure_status or "error"
+                )
                 recorded_perf = perf if math.isfinite(perf) else None
                 results[valid_indices[index]] = BenchmarkResult(
                     config=config,
@@ -1080,7 +1087,10 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         except BenchmarkSubprocessError as e:
             # Timeout or unexpected worker exit; skip config and continue.
             self.log.warning(f"Benchmark subprocess failed for {config!r}: {e}")
-            self._autotune_metrics.num_compile_failures += 1
+            self._last_benchmark_failure_status = (
+                "timeout" if isinstance(e, BenchmarkTimeout) else "error"
+            )
+            self._autotune_metrics.num_worker_failures += 1
             return inf
         except Exception as e:
             e.__traceback__ = None
@@ -1109,7 +1119,10 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 self.log.warning(
                     f"Accuracy check subprocess failed for {config!r}: {e}"
                 )
-                self._autotune_metrics.num_compile_failures += 1
+                self._last_benchmark_failure_status = (
+                    "timeout" if isinstance(e, BenchmarkTimeout) else "error"
+                )
+                self._autotune_metrics.num_worker_failures += 1
                 return inf
             except Exception as e:
                 e.__traceback__ = None

--- a/helion/autotuner/llm_seeded_lfbo.py
+++ b/helion/autotuner/llm_seeded_lfbo.py
@@ -48,6 +48,7 @@ _DISALLOWED_SECOND_STAGE_ALGORITHMS = {
 _AGGREGATED_METRIC_FIELDS = (
     "num_configs_tested",
     "num_compile_failures",
+    "num_worker_failures",
     "num_accuracy_failures",
     "num_generations",
 )

--- a/helion/autotuner/metrics.py
+++ b/helion/autotuner/metrics.py
@@ -33,6 +33,7 @@ class AutotuneMetrics:
     _start_time: float = dataclasses.field(default_factory=time.perf_counter)
     num_configs_tested: int = 0
     num_compile_failures: int = 0
+    num_worker_failures: int = 0
     num_accuracy_failures: int = 0
     num_generations: int = 0
     autotune_time: float = 0.0
@@ -57,6 +58,7 @@ class AutotuneMetrics:
             "search_algorithm": self.search_algorithm,
             "num_configs_tested": self.num_configs_tested,
             "num_compile_failures": self.num_compile_failures,
+            "num_worker_failures": self.num_worker_failures,
             "num_accuracy_failures": self.num_accuracy_failures,
             "num_generations": self.num_generations,
             "autotune_time": self.autotune_time,

--- a/helion/autotuner/precompile_future.py
+++ b/helion/autotuner/precompile_future.py
@@ -4,6 +4,7 @@ import collections
 import contextlib
 import dataclasses
 import inspect
+import linecache
 import multiprocessing as mp
 from multiprocessing import connection
 import os
@@ -25,6 +26,7 @@ import uuid
 from .. import exc
 from ..runtime.precompile_shim import already_compiled
 from ..runtime.precompile_shim import make_precompiler
+from .benchmarking import clear_jit_fast_path_caches
 from .benchmarking import synchronize_device
 from .kernel_args import load_trusted_kernel_args
 from .logger import SUPPRESSED_TRITON_CODE_MSG
@@ -99,6 +101,7 @@ class SerializedCompiledFunction:
     source_code: str
     filename: str | None
     module_name: str | None
+    source_hash: str | None = None
 
 
 @dataclasses.dataclass
@@ -134,11 +137,19 @@ def _serialize_compiled_fn(fn: CompiledConfig) -> SerializedCompiledFunction:
                 source_code = inspect.getsource(module)
     if source_code is None:
         raise RuntimeError("Unable to capture source for compiled kernel")
+    source_hash: str | None = None
+    fn_globals = getattr(fn, "__globals__", None)
+    if isinstance(fn_globals, dict):
+        kernel = fn_globals.get(f"_helion_{fn.__name__}")
+        value = getattr(kernel, "_helion_cute_source_hash", None)
+        if isinstance(value, str):
+            source_hash = value
     return SerializedCompiledFunction(
         function_name=fn.__name__,
         source_code=source_code,
         filename=filename,
         module_name=module_name,
+        source_hash=source_hash,
     )
 
 
@@ -149,16 +160,58 @@ def _load_compiled_fn(fn_spec: SerializedCompiledFunction) -> CompiledConfig:
     module.__loader__ = None
     module.__package__ = None
     sys.modules[module_name] = module
-    exec(
-        compile(fn_spec.source_code, module.__file__, "exec"),
-        module.__dict__,
-    )
-    fn = getattr(module, fn_spec.function_name, None)
-    if fn is None:
-        raise RuntimeError(
-            f"Unable to locate compiled kernel '{fn_spec.function_name}' in generated module"
+    try:
+        exec(
+            compile(fn_spec.source_code, module.__file__, "exec"),
+            module.__dict__,
         )
-    return fn
+        fn = getattr(module, fn_spec.function_name, None)
+        if fn is None:
+            raise RuntimeError(
+                f"Unable to locate compiled kernel '{fn_spec.function_name}' "
+                "in generated module"
+            )
+        cute_kernel = module.__dict__.get(f"_helion_{fn_spec.function_name}")
+        if cute_kernel is not None and fn_spec.source_hash is not None:
+            # Backend annotation is runtime metadata and is not present in the
+            # generated source. Carry the parent's exact value because
+            # PyCodeCache treats strip-equivalent source as one file key.
+            with contextlib.suppress(AttributeError, TypeError):
+                cute_kernel._helion_cute_source_hash = fn_spec.source_hash
+        return fn
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
+
+
+def _unload_compiled_fn(fn: CompiledConfig) -> None:
+    """Release caches and the temporary module created by ``_load_compiled_fn``."""
+    clear_jit_fast_path_caches(fn)
+    module_name = getattr(fn, "__module__", "")
+    if module_name.startswith("_helion_autotune_subprocess_"):
+        module = sys.modules.get(module_name)
+        if module is not None:
+            cute_kernel = module.__dict__.get(f"_helion_{fn.__name__}")
+            if cute_kernel is not None:
+                launchers = getattr(
+                    cute_kernel, "_helion_cute_compiled_launchers", None
+                )
+                if isinstance(launchers, dict):
+                    for launcher in launchers.values():
+                        jit_func = getattr(launcher, "_jit_func", None)
+                        wrapped = getattr(jit_func, "__wrapped__", jit_func)
+                        code = getattr(wrapped, "__code__", None)
+                        filename = getattr(code, "co_filename", "")
+                        if filename.startswith("<helion_cute_launcher:"):
+                            linecache.cache.pop(filename, None)
+                for cache_name in (
+                    "_helion_cute_compiled_launchers",
+                    "_helion_cute_launch_arg_cache",
+                ):
+                    cache = getattr(cute_kernel, cache_name, None)
+                    if isinstance(cache, dict):
+                        cache.clear()
+        sys.modules.pop(module_name, None)
 
 
 def _run_kernel_in_subprocess_spawn(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -3475,7 +3475,11 @@ def _create_cute_wrapper(
         [line + "\n" for line in source.splitlines()],
         filename,
     )
-    exec(compile(source, filename, "exec"), namespace)
+    try:
+        exec(compile(source, filename, "exec"), namespace)
+    except BaseException:
+        linecache.cache.pop(filename, None)
+        raise
     return namespace[func_name]
 
 

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -6309,6 +6309,7 @@ class TestAutotuneBudget(TestCase):
         provider._autotune_metrics = SimpleNamespace(
             num_configs_tested=0,
             num_compile_failures=0,
+            num_worker_failures=0,
             num_accuracy_failures=0,
             num_generations=0,
             kernel_source="",

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import linecache
 import math
 import multiprocessing as mp
 from multiprocessing.connection import Connection
@@ -11,8 +12,10 @@ from pathlib import Path
 import pickle
 import random
 import signal
+import sys
 import tempfile
 import time
+from types import ModuleType
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from typing import Any
@@ -28,6 +31,7 @@ from helion._testing import RefEagerTestDisabled
 from helion._testing import import_path
 from helion._testing import onlyBackends
 from helion._testing import skipIfXPU
+from helion._testing import skipUnlessCuteAvailable
 from helion.autotuner.base_search import PopulationBasedSearch
 from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.benchmark_job import AccuracyCheckJob
@@ -39,9 +43,14 @@ from helion.autotuner.benchmark_worker import BenchmarkTimeout
 from helion.autotuner.benchmark_worker import BenchmarkWorker
 from helion.autotuner.benchmark_worker import BenchmarkWorkerDied
 from helion.autotuner.kernel_args import load_trusted_kernel_args
+from helion.autotuner.metrics import AutotuneMetrics
 from helion.autotuner.precompile_future import SerializedCompiledFunction
+from helion.autotuner.precompile_future import _load_compiled_fn
 from helion.autotuner.precompile_future import _run_kernel_in_subprocess_spawn
+from helion.autotuner.precompile_future import _serialize_compiled_fn
+from helion.autotuner.precompile_future import _unload_compiled_fn
 from helion.autotuner.random_search import RandomSearch
+from helion.runtime import _create_cute_wrapper
 from helion.runtime.config import Config
 from helion.runtime.settings import Settings
 
@@ -95,6 +104,110 @@ class _ReturnValue:
 
 
 class TestBenchmarkWorkerFailureModes(unittest.TestCase):
+    @skipUnlessCuteAvailable("_create_cute_wrapper requires the CuTe DSL")
+    def test_cute_wrapper_failure_does_not_leak_linecache(self) -> None:
+        launcher_filenames_before = {
+            filename
+            for filename in linecache.cache
+            if filename.startswith("<helion_cute_launcher:")
+        }
+
+        with (
+            patch("builtins.exec", side_effect=RuntimeError("decoration failed")),
+            self.assertRaisesRegex(RuntimeError, "decoration failed"),
+        ):
+            _create_cute_wrapper(object(), (), (32, 1, 1))
+
+        launcher_filenames_after = {
+            filename
+            for filename in linecache.cache
+            if filename.startswith("<helion_cute_launcher:")
+        }
+        self.assertEqual(launcher_filenames_after, launcher_filenames_before)
+
+    def test_compiled_fn_restores_cute_source_hash_and_unloads(self) -> None:
+        launcher_filename = "<helion_cute_launcher:test>"
+        source = (
+            "class Kernel:\n"
+            "    pass\n"
+            f"exec(compile('def launcher():\\n    pass\\n', {launcher_filename!r}, 'exec'))\n"
+            "class Launcher:\n"
+            "    pass\n"
+            "compiled_launcher = Launcher()\n"
+            "compiled_launcher._jit_func = launcher\n"
+            "_helion_call = Kernel()\n"
+            "_helion_call._helion_cute_compiled_launchers = "
+            "{'compiled': compiled_launcher}\n"
+            "_helion_call._helion_cute_launch_arg_cache = {'args': object()}\n"
+            "def call():\n"
+            "    return _helion_call._helion_cute_source_hash\n"
+        )
+        expected_hash = "parent-source-hash"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "compiled_module.py"
+            path.write_text(source)
+            source_module = ModuleType("_test_compiled_module")
+            source_module.__file__ = str(path)
+            sys.modules[source_module.__name__] = source_module
+            try:
+                exec(compile(source, str(path), "exec"), source_module.__dict__)
+                source_module._helion_call._helion_cute_source_hash = expected_hash
+                fn_spec = _serialize_compiled_fn(source_module.call)
+            finally:
+                sys.modules.pop(source_module.__name__, None)
+
+        fn = _load_compiled_fn(fn_spec)
+        module_name = fn.__module__
+        loaded_module = sys.modules[module_name]
+        cute_kernel = loaded_module._helion_call
+        self.assertEqual(fn_spec.source_hash, expected_hash)
+        self.assertEqual(fn(), expected_hash)
+        self.assertIn(module_name, sys.modules)
+        linecache.cache[launcher_filename] = (0, None, [], launcher_filename)
+
+        _unload_compiled_fn(fn)
+        self.assertNotIn(module_name, sys.modules)
+        self.assertEqual(cute_kernel._helion_cute_compiled_launchers, {})
+        self.assertEqual(cute_kernel._helion_cute_launch_arg_cache, {})
+        self.assertNotIn(launcher_filename, linecache.cache)
+
+    def test_compiled_fn_unload_clears_triton_fast_path_cache(self) -> None:
+        source = (
+            "class Kernel:\n"
+            "    def __init__(self):\n"
+            "        self.cleared = False\n"
+            "    def clear_fast_path_caches(self):\n"
+            "        self.cleared = True\n"
+            "_helion_call = Kernel()\n"
+            "def call():\n"
+            "    pass\n"
+        )
+        fn_spec = SerializedCompiledFunction("call", source, None, None)
+        fn = _load_compiled_fn(fn_spec)
+        kernel = fn.__globals__["_helion_call"]
+
+        _unload_compiled_fn(fn)
+
+        self.assertTrue(kernel.cleared)
+
+    def test_compiled_fn_load_failure_does_not_leak_module(self) -> None:
+        module_prefix = "_helion_autotune_subprocess_"
+        modules_before = {
+            name for name in sys.modules if name.startswith(module_prefix)
+        }
+        fn_spec = SerializedCompiledFunction(
+            function_name="call",
+            source_code="raise RuntimeError('load failed')\n",
+            filename=None,
+            module_name=None,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "load failed"):
+            _load_compiled_fn(fn_spec)
+
+        modules_after = {name for name in sys.modules if name.startswith(module_prefix)}
+        self.assertEqual(modules_after, modules_before)
+
     def test_benchmark_job_can_use_wall_clock_bench(self) -> None:
         fn = _ReturnValue(torch.empty(()))
 
@@ -124,6 +237,32 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         load_args.assert_called_once_with("/tmp/args.pt")
         event_bench.assert_not_called()
         wall_clock_bench.assert_called_once()
+
+    def test_benchmark_job_unloads_module_after_failure(self) -> None:
+        fn = _ReturnValue(torch.empty(()))
+
+        with (
+            patch(
+                "helion.autotuner.benchmark_job._load_compiled_fn",
+                return_value=fn,
+            ),
+            patch(
+                "helion.autotuner.benchmark_job.load_trusted_kernel_args",
+                return_value=(),
+            ),
+            patch(
+                "helion.autotuner.benchmark_job.do_bench",
+                side_effect=RuntimeError("benchmark failed"),
+            ),
+            patch("helion.autotuner.benchmark_job._unload_compiled_fn") as unload_fn,
+            self.assertRaisesRegex(RuntimeError, "benchmark failed"),
+        ):
+            BenchmarkJob(
+                fn_spec=cast("SerializedCompiledFunction", object()),
+                args_path="/tmp/args.pt",
+            )()
+
+        unload_fn.assert_called_once_with(fn)
 
     def test_accuracy_check_job_passes(self) -> None:
         fn = _ReturnValue(torch.tensor([1.0]))
@@ -246,6 +385,44 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         provider._benchmark_worker.run.assert_called_once()
         _, kwargs = provider._benchmark_worker.run.call_args
         self.assertEqual(kwargs["timeout"], 17.0)
+
+    def test_benchmark_timeout_has_worker_metric_and_status(self) -> None:
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.log = Mock()
+        provider._autotune_metrics = AutotuneMetrics()
+
+        with patch.object(
+            provider,
+            "_run_subprocess_benchmark_job",
+            side_effect=BenchmarkTimeout("timed out"),
+        ):
+            result = provider._benchmark_function_subprocess(
+                Config(), cast("CompiledConfig", object())
+            )
+
+        self.assertEqual(result, math.inf)
+        self.assertEqual(provider._last_benchmark_failure_status, "timeout")
+        self.assertEqual(provider._autotune_metrics.num_worker_failures, 1)
+        self.assertEqual(provider._autotune_metrics.num_compile_failures, 0)
+
+    def test_benchmark_worker_death_has_error_status(self) -> None:
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.log = Mock()
+        provider._autotune_metrics = AutotuneMetrics()
+
+        with patch.object(
+            provider,
+            "_run_subprocess_benchmark_job",
+            side_effect=BenchmarkWorkerDied("worker exited"),
+        ):
+            result = provider._benchmark_function_subprocess(
+                Config(), cast("CompiledConfig", object())
+            )
+
+        self.assertEqual(result, math.inf)
+        self.assertEqual(provider._last_benchmark_failure_status, "error")
+        self.assertEqual(provider._autotune_metrics.num_worker_failures, 1)
+        self.assertEqual(provider._autotune_metrics.num_compile_failures, 0)
 
     def test_subprocess_accuracy_check_skips_mutated_args(self) -> None:
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
@@ -571,7 +748,8 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
             call_count[0] += 1
             if call_count[0] % 3 == 0:
                 call_count[1] += 1
-                self._autotune_metrics.num_compile_failures += 1
+                self._last_benchmark_failure_status = "timeout"
+                self._autotune_metrics.num_worker_failures += 1
                 return math.inf
             return original(self, config, fn)
 
@@ -593,10 +771,12 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
             "_benchmark_function_subprocess",
             maybe_fail,
         ):
-            RandomSearch(bound_kernel, args, 20).autotune()
+            search = RandomSearch(bound_kernel, args, 20)
+            search.autotune()
 
         self.assertGreaterEqual(call_count[0], 6)
         self.assertGreaterEqual(call_count[1], 2)
+        self.assertEqual(search._autotune_metrics.num_worker_failures, call_count[1])
 
     @skipIfXPU("matmul config space includes maxnreg, unsupported on XPU")
     def test_autotune_continues_when_accuracy_check_crashes(self) -> None:

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -1365,6 +1365,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
                 self._autotune_metrics = AutotuneMetrics(
                     num_configs_tested=7,
                     num_compile_failures=1,
+                    num_worker_failures=2,
                     num_accuracy_failures=2,
                     num_generations=3,
                 )
@@ -1395,6 +1396,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
                 self._autotune_metrics = AutotuneMetrics(
                     num_configs_tested=11,
                     num_compile_failures=3,
+                    num_worker_failures=4,
                     num_accuracy_failures=5,
                     num_generations=6,
                 )
@@ -1446,6 +1448,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
         self.assertEqual(lfbo_instances[0].seed_configs, [Config(num_warps=4)])
         self.assertEqual(search._autotune_metrics.num_configs_tested, 18)
         self.assertEqual(search._autotune_metrics.num_compile_failures, 4)
+        self.assertEqual(search._autotune_metrics.num_worker_failures, 6)
         self.assertEqual(search._autotune_metrics.num_accuracy_failures, 7)
         self.assertEqual(search._autotune_metrics.num_generations, 9)
         self.assertEqual(search.hybrid_stage_breakdown["llm_seed_configs_tested"], 7)
@@ -1498,6 +1501,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
                 self._autotune_metrics = AutotuneMetrics(
                     num_configs_tested=4,
                     num_compile_failures=1,
+                    num_worker_failures=1,
                     num_accuracy_failures=0,
                     num_generations=2,
                 )
@@ -1529,6 +1533,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
                 self._autotune_metrics = AutotuneMetrics(
                     num_configs_tested=6,
                     num_compile_failures=2,
+                    num_worker_failures=2,
                     num_accuracy_failures=1,
                     num_generations=5,
                 )
@@ -1580,6 +1585,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
         )
         self.assertEqual(search._autotune_metrics.num_configs_tested, 10)
         self.assertEqual(search._autotune_metrics.num_compile_failures, 3)
+        self.assertEqual(search._autotune_metrics.num_worker_failures, 3)
         self.assertEqual(search._autotune_metrics.num_accuracy_failures, 1)
         self.assertEqual(search._autotune_metrics.num_generations, 7)
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3147
 * #3146
 * #3145
 * #3144
 * #3143
 * #3142
 * #3141
 * #3140
 * __->__#3139


--- --- ---

[cutedsl] Clean up isolated autotune workers

Classify worker failures separately from compile failures. Unload generated modules, launcher caches, and linecache entries after benchmark and accuracy jobs so long tuning runs do not retain worker state.