### PR TITLE
[cutedsl] Make dtype subtests xdist-safe

### DIFF
--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -5046,7 +5046,7 @@ class TestCuteBackend(TestCase):
             (HALF_DTYPE, 16, 16),
         )
         for dtype, block_m, block_n in cases:
-            with self.subTest(dtype=dtype, block_n=block_n):
+            with self.subTest(dtype=str(dtype), block_n=block_n):
                 args = (
                     torch.randn(2, block_m, 32, device=DEVICE, dtype=dtype),
                     torch.randn(2, 32, block_n, device=DEVICE, dtype=dtype),


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3147
 * #3146
 * #3145
 * #3144
 * #3143
 * #3142
 * #3141
 * __->__#3140
 * #3139


--- --- ---

[cutedsl] Make dtype subtests xdist-safe

Serialize dtype names instead of torch.dtype objects in unittest subtest metadata so CuTe tests can report through pytest-xdist.