### PR TITLE
[cutedsl] Fix descending causal flash initialization

### DIFF
--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -7676,6 +7676,7 @@ if warp_idx == 15:
                 softmax_not_first,
                 rowmax_block,
                 pass2_block,
+                zero_first_tile=is_causal and causal_desc_kv and stage == "0",
             )
             return f"""        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -2568,37 +2568,44 @@ class TestCuteBackend(TestCase):
         )
         torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
-    def test_flash_attention_causal_fa4_split_loop_matches_sdpa(self) -> None:
+    def test_flash_attention_causal_fa4_descending_loops_match_sdpa(self) -> None:
         q, k, v = (
             torch.randn(1, 1, 512, 64, dtype=torch.float16, device=DEVICE)
             for _ in range(3)
         )
-        code, (out, _lse) = code_and_output(
-            cute_causal_attention,
-            (q, k, v),
-            block_sizes=[1, 128, 128],
-            cute_flash_topology="fa4",
-            cute_flash_causal_kv_order="descending",
-            cute_flash_causal_loop_split=True,
-            cute_flash_masked_e2e_schedule="16/4",
-            cute_flash_e2e_schedule="8/2",
-            cute_flash_e2e_offset=0,
-            cute_flash_e2e_offset0=1,
-            cute_flash_disc_pipe=4,
-            cute_flash_role_map="fa4",
-            cute_flash_epi_tma=True,
-            cute_flash_rescale_chunk_cols=16,
-            cute_flash_softmax_regs=200,
-        )
-        self.assertTrue(_flash_fired(code))
-        self.assertIn("fa4_disc_zero_store", code)
         expected = torch.nn.functional.scaled_dot_product_attention(
             q,
             k,
             v,
             is_causal=True,
         )
-        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        for loop_split in (True, False):
+            with self.subTest(loop_split=loop_split):
+                code, (out, _lse) = code_and_output(
+                    cute_causal_attention,
+                    (q, k, v),
+                    block_sizes=[1, 128, 128],
+                    cute_flash_topology="fa4",
+                    cute_flash_causal_kv_order="descending",
+                    cute_flash_causal_loop_split=loop_split,
+                    cute_flash_masked_e2e_schedule="16/4",
+                    cute_flash_e2e_schedule="8/2",
+                    cute_flash_e2e_offset=0,
+                    cute_flash_e2e_offset0=1,
+                    cute_flash_disc_pipe=4,
+                    cute_flash_role_map="fa4",
+                    cute_flash_epi_tma=True,
+                    cute_flash_rescale_chunk_cols=16,
+                    cute_flash_softmax_regs=200,
+                )
+                self.assertTrue(_flash_fired(code))
+                self.assertIn("fa4_disc_zero_store", code)
+                if loop_split:
+                    self.assertIn("for flash_kv_mask_iter in", code)
+                else:
+                    self.assertIn("for flash_kv_iter in", code)
+                    self.assertNotIn("flash_kv_mask_iter", code)
+                torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
     def test_flash_attention_causal_single_warpgroup_matches_sdpa(self) -> None:
         q, k, v = (


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3147
 * #3146
 * #3145
 * #3144
 * #3143
 * #3142
 * __->__#3141
 * #3140
 * #3139


--- --- ---

[cutedsl] Fix descending causal flash initialization

Zero stage-zero score storage before the unsplit descending causal loop, matching the split-loop initialization. Exercise both loop forms against SDPA.