### PR TITLE
[cutedsl] Make dense flash rescaling and scheduling safe

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -519,6 +519,7 @@ class CuteFlashAttentionHeuristic(AutotunerHeuristic):
         return flash_attention_seed_config(
             spec._cute_flash_head_dim,
             spec._cute_flash_num_kv,
+            dtype=spec._cute_flash_dtype,
             is_causal=spec._cute_flash_is_causal,
             has_kv_tile_pruning=spec._cute_flash_has_kv_tile_pruning,
             requires_ws_overlap=spec._cute_flash_requires_ws_overlap,
@@ -544,6 +545,7 @@ class CuteFlashAttentionCausalLptHeuristic(AutotunerHeuristic):
             flash_attention_seed_config(
                 spec._cute_flash_head_dim,
                 spec._cute_flash_num_kv,
+                dtype=spec._cute_flash_dtype,
                 is_causal=spec._cute_flash_is_causal,
                 has_kv_tile_pruning=spec._cute_flash_has_kv_tile_pruning,
                 requires_ws_overlap=spec._cute_flash_requires_ws_overlap,
@@ -568,6 +570,7 @@ class CuteFlashAttentionCausalLptHeuristic(AutotunerHeuristic):
         return flash_attention_seed_config(
             spec._cute_flash_head_dim,
             spec._cute_flash_num_kv,
+            dtype=spec._cute_flash_dtype,
             is_causal=spec._cute_flash_is_causal,
             has_kv_tile_pruning=spec._cute_flash_has_kv_tile_pruning,
             requires_ws_overlap=spec._cute_flash_requires_ws_overlap,

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -58,6 +58,7 @@ log: logging.Logger = logging.getLogger(__name__)
 class FlashSearchSurface(NamedTuple):
     head_dim: int
     num_kv: int
+    io_dtype: torch.dtype
     block_size_targets: dict[int, int]
     is_causal: bool
     has_kv_tile_pruning: bool
@@ -67,6 +68,7 @@ class FlashSearchSurface(NamedTuple):
 
 class AttentionSoftmaxPattern(NamedTuple):
     score_plan: AttentionScorePlan
+    io_dtype: torch.dtype
 
     @property
     def head_dim(self) -> int:
@@ -2572,7 +2574,8 @@ def _attention_softmax_pattern_head_dim(
     )
     if not score_plan.has_lowering():
         return None
-    return AttentionSoftmaxPattern(score_plan=score_plan)
+    assert operand_dtype is not None
+    return AttentionSoftmaxPattern(score_plan=score_plan, io_dtype=operand_dtype)
 
 
 def detect_flash_search_surface(device_ir: DeviceIR) -> FlashSearchSurface | None:
@@ -2663,6 +2666,7 @@ def detect_flash_search_surface(device_ir: DeviceIR) -> FlashSearchSurface | Non
         return FlashSearchSurface(
             head_dim=pattern.head_dim,
             num_kv=(kv_seq + 127) // 128,
+            io_dtype=pattern.io_dtype,
             block_size_targets=block_size_targets,
             is_causal=pattern.is_causal,
             has_kv_tile_pruning=pattern.score_plan.has_kv_tile_pruning,

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -760,6 +760,7 @@ class CuteBackend(Backend):
             for key, weights in flash_attention_value_prior_weights(
                 config_spec._cute_flash_head_dim or 0,
                 config_spec._cute_flash_num_kv,
+                dtype=config_spec._cute_flash_dtype,
                 is_causal=config_spec._cute_flash_is_causal,
                 has_kv_tile_pruning=config_spec._cute_flash_has_kv_tile_pruning,
                 requires_ws_overlap=config_spec._cute_flash_requires_ws_overlap,

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -1690,7 +1690,7 @@ def resolve_flash_config(
         8.0 if dtype in (torch.float16, torch.bfloat16) else 0.0
     )
     rescale_threshold_default = (
-        _flash_dense_hd64_seed_rescale_threshold(num_kv)
+        _flash_dense_hd64_seed_rescale_threshold(num_kv, dtype)
         if long_dense_hd64_fa4 and dtype in (torch.float16, torch.bfloat16)
         else dtype_rescale_threshold_default
     )
@@ -1701,6 +1701,11 @@ def resolve_flash_config(
     if rescale_threshold_cfg is not None:
         rescale_threshold = float(rescale_threshold_cfg)  # type: ignore[arg-type]
     if not math.isfinite(rescale_threshold):
+        rescale_threshold = rescale_threshold_default
+    if rescale_threshold >= math.log2(torch.finfo(dtype).max):
+        # A pinned score can be up to exp2(threshold) before the fp32
+        # probabilities are cast to the I/O dtype. Reject stale/manual values
+        # that can overflow that cast; the shape default is always safe.
         rescale_threshold = rescale_threshold_default
     skip_rescale_stats_default = (
         _flash_dense_hd64_seed_skip_rescale_stats(num_kv)
@@ -1923,12 +1928,21 @@ def resolve_flash_config(
         clc_use_pdl = bool(clc_use_pdl_cfg)
     if not use_clc_scheduler:
         clc_use_pdl = False
-    clc_stages = int(os.environ.get("HELION_CUTE_FLASH_CLC_STAGES", "1"))
+    clc_stages = int(
+        os.environ.get(
+            "HELION_CUTE_FLASH_CLC_STAGES", "2" if use_clc_scheduler else "1"
+        )
+    )
     clc_stages_cfg = _cfg(FLASH_CLC_STAGES_KEY)
     if clc_stages_cfg is not None:
         clc_stages = int(clc_stages_cfg)  # type: ignore[arg-type]
-    if not use_clc_scheduler or clc_stages not in (1, 2, 3):
+    if not use_clc_scheduler:
         clc_stages = 1
+    elif clc_stages not in (2, 3):
+        # A one-stage CLC response pipeline can deadlock when several kernels
+        # contend for the GPU. Two stages is performance-neutral and keeps the
+        # producer from reusing the only response slot while roles retire it.
+        clc_stages = 2
     if (
         topology != "fa4"
         or not persistent
@@ -2172,6 +2186,17 @@ _FLASH_SEED_BLOCK_SIZE_TARGETS = (1, 128, 128)
 _FLASH_DENSE_HD64_MID_MIN_KV = 16
 _FLASH_DENSE_HD64_LONG_MIN_KV = 64
 _FLASH_DENSE_HD64_VERY_LONG_MIN_KV = 256
+_FLASH_RESCALE_THRESHOLD_VALUES = (0.0, 4.0, 8.0, 12.0, 16.0, 32.0)
+
+
+def _flash_safe_rescale_threshold_values(dtype: torch.dtype) -> tuple[float, ...]:
+    """Return thresholds whose largest pinned probability fits in ``dtype``."""
+    max_log2 = math.log2(torch.finfo(dtype).max)
+    return tuple(
+        threshold
+        for threshold in _FLASH_RESCALE_THRESHOLD_VALUES
+        if threshold < max_log2
+    )
 
 
 def _flash_dense_hd64_seed_params(
@@ -2203,10 +2228,13 @@ def _flash_dense_hd64_seed_params(
     return 3, 0, 0, 1, False, 8.0, 8, True
 
 
-def _flash_dense_hd64_seed_rescale_threshold(num_kv: int) -> float:
-    if num_kv == 2048:
-        return 32.0
-    return _flash_dense_hd64_seed_params(num_kv)[5]
+def _flash_dense_hd64_seed_rescale_threshold(
+    num_kv: int, dtype: torch.dtype = torch.float16
+) -> float:
+    threshold = 32.0 if num_kv == 2048 else _flash_dense_hd64_seed_params(num_kv)[5]
+    if threshold >= math.log2(torch.finfo(dtype).max):
+        return 8.0
+    return threshold
 
 
 def _flash_dense_hd64_seed_e2e_schedule(num_kv: int) -> str:
@@ -2329,6 +2357,7 @@ def flash_attention_value_prior_weights(
     head_dim: int,
     num_kv: int | None,
     *,
+    dtype: torch.dtype = torch.float16,
     is_causal: bool = False,
     has_kv_tile_pruning: bool = False,
     requires_ws_overlap: bool = False,
@@ -2357,7 +2386,10 @@ def flash_attention_value_prior_weights(
             rescale_chunk_cols,
             packed_reduce,
         ) = _flash_dense_hd64_seed_params(num_kv)
-        rescale_threshold = _flash_dense_hd64_seed_rescale_threshold(num_kv)
+        rescale_threshold = _flash_dense_hd64_seed_rescale_threshold(num_kv, dtype)
+        rescale_threshold_priors = (
+            (8.0, 16.0, 32.0) if dtype is torch.bfloat16 else (8.0, 12.0)
+        )
         p_store_rep = _flash_dense_hd64_seed_p_store_rep(num_kv)
         s_load_rep = _flash_dense_hd64_seed_s_load_rep(num_kv)
         split_p_arrive = _flash_dense_hd64_seed_split_p_arrive(num_kv)
@@ -2454,7 +2486,7 @@ def flash_attention_value_prior_weights(
                         rescale_threshold: 4.0,
                         **{
                             threshold: 3.0
-                            for threshold in (8.0, 16.0, 32.0)
+                            for threshold in rescale_threshold_priors
                             if threshold != rescale_threshold
                         },
                     }
@@ -2519,7 +2551,7 @@ def flash_attention_value_prior_weights(
                     **{heads: 2.0 for heads in (0, 32) if heads != clc_heads_per_batch},
                 },
                 FLASH_CLC_PDL_KEY: {False: 4.0, True: 1.0},
-                FLASH_CLC_STAGES_KEY: {1: 4.0, 2: 1.0, 3: 1.0},
+                FLASH_CLC_STAGES_KEY: {2: 4.0, 3: 1.0, 1: 1.0},
                 FLASH_LOCAL_TMA_PARTITION_KEY: {
                     local_tma_partition: 4.0,
                     not local_tma_partition: 1.0,
@@ -2681,6 +2713,7 @@ def _flash_seed_fragments(
     head_dim: int,
     num_kv: int,
     *,
+    dtype: torch.dtype,
     is_causal: bool,
     has_kv_tile_pruning: bool,
     requires_ws_overlap: bool,
@@ -2690,6 +2723,7 @@ def _flash_seed_fragments(
     return flash_autotune_fragments(
         head_dim,
         num_kv,
+        dtype=dtype,
         is_causal=is_causal,
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
@@ -2709,6 +2743,7 @@ def _flash_default_seed_config(
     head_dim: int,
     num_kv: int,
     *,
+    dtype: torch.dtype,
     is_causal: bool,
     has_kv_tile_pruning: bool,
     requires_ws_overlap: bool,
@@ -2725,6 +2760,7 @@ def _flash_default_seed_config(
     fragments = _flash_seed_fragments(
         head_dim,
         num_kv,
+        dtype=dtype,
         is_causal=is_causal,
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
@@ -2757,7 +2793,7 @@ def _flash_default_seed_config(
             rescale_chunk_cols,
             packed_reduce,
         ) = _flash_dense_hd64_seed_params(num_kv)
-        rescale_threshold = _flash_dense_hd64_seed_rescale_threshold(num_kv)
+        rescale_threshold = _flash_dense_hd64_seed_rescale_threshold(num_kv, dtype)
         family_values = {
             FLASH_S_STAGE_KEY: 2,
             FLASH_KV_STAGE_KEY: kv_stage,
@@ -2801,7 +2837,7 @@ def _flash_default_seed_config(
                 num_kv
             ),
             FLASH_CLC_PDL_KEY: False,
-            FLASH_CLC_STAGES_KEY: 1,
+            FLASH_CLC_STAGES_KEY: 2 if _flash_dense_hd64_seed_clc(num_kv) else 1,
             FLASH_LOCAL_TMA_PARTITION_KEY: _flash_dense_hd64_seed_local_tma_partition(
                 num_kv
             ),
@@ -2827,6 +2863,7 @@ def _flash_dense_sp_seed_config(
     head_dim: int,
     num_kv: int,
     *,
+    dtype: torch.dtype,
     is_causal: bool,
     has_kv_tile_pruning: bool,
     requires_ws_overlap: bool,
@@ -2852,6 +2889,7 @@ def _flash_dense_sp_seed_config(
     fragments = _flash_seed_fragments(
         head_dim,
         num_kv,
+        dtype=dtype,
         is_causal=is_causal,
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
@@ -2868,6 +2906,7 @@ def _flash_dense_sp_seed_config(
         rescale_chunk_cols,
         packed_reduce,
     ) = _flash_dense_hd64_seed_params(num_kv)
+    rescale_threshold = _flash_dense_hd64_seed_rescale_threshold(num_kv, dtype)
     seed: dict[str, object] = {"block_sizes": block_sizes}
     family_values: dict[str, object] = {
         FLASH_TOPOLOGY_KEY: "fa4",
@@ -2919,6 +2958,7 @@ def _flash_causal_lpt_seed_config(
     head_dim: int,
     num_kv: int,
     *,
+    dtype: torch.dtype,
     is_causal: bool,
     has_kv_tile_pruning: bool,
     requires_ws_overlap: bool,
@@ -2939,6 +2979,7 @@ def _flash_causal_lpt_seed_config(
     fragments = _flash_seed_fragments(
         head_dim,
         num_kv,
+        dtype=dtype,
         is_causal=is_causal,
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
@@ -2981,6 +3022,7 @@ def _flash_causal_split_seed_config(
     head_dim: int,
     num_kv: int,
     *,
+    dtype: torch.dtype,
     is_causal: bool,
     has_kv_tile_pruning: bool,
     requires_ws_overlap: bool,
@@ -3001,6 +3043,7 @@ def _flash_causal_split_seed_config(
     fragments = _flash_seed_fragments(
         head_dim,
         num_kv,
+        dtype=dtype,
         is_causal=is_causal,
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
@@ -3050,6 +3093,7 @@ def flash_attention_seed_config(
     head_dim: int,
     num_kv: int | None,
     *,
+    dtype: torch.dtype = torch.float16,
     is_causal: bool = False,
     has_kv_tile_pruning: bool = False,
     requires_ws_overlap: bool = False,
@@ -3069,6 +3113,7 @@ def flash_attention_seed_config(
         return _flash_default_seed_config(
             head_dim,
             num_kv,
+            dtype=dtype,
             is_causal=is_causal,
             has_kv_tile_pruning=has_kv_tile_pruning,
             requires_ws_overlap=requires_ws_overlap,
@@ -3079,6 +3124,7 @@ def flash_attention_seed_config(
         return _flash_causal_lpt_seed_config(
             head_dim,
             num_kv,
+            dtype=dtype,
             is_causal=is_causal,
             has_kv_tile_pruning=has_kv_tile_pruning,
             requires_ws_overlap=requires_ws_overlap,
@@ -3089,6 +3135,7 @@ def flash_attention_seed_config(
         return _flash_dense_sp_seed_config(
             head_dim,
             num_kv,
+            dtype=dtype,
             is_causal=is_causal,
             has_kv_tile_pruning=has_kv_tile_pruning,
             requires_ws_overlap=requires_ws_overlap,
@@ -3099,6 +3146,7 @@ def flash_attention_seed_config(
         return _flash_causal_split_seed_config(
             head_dim,
             num_kv,
+            dtype=dtype,
             is_causal=is_causal,
             has_kv_tile_pruning=has_kv_tile_pruning,
             requires_ws_overlap=requires_ws_overlap,
@@ -3112,6 +3160,7 @@ def flash_attention_seed_configs(
     head_dim: int,
     num_kv: int | None,
     *,
+    dtype: torch.dtype = torch.float16,
     is_causal: bool = False,
     has_kv_tile_pruning: bool = False,
     requires_ws_overlap: bool = False,
@@ -3122,6 +3171,7 @@ def flash_attention_seed_configs(
     default_seed = flash_attention_seed_config(
         head_dim,
         num_kv,
+        dtype=dtype,
         is_causal=is_causal,
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
@@ -3133,6 +3183,7 @@ def flash_attention_seed_configs(
     causal_lpt_seed = flash_attention_seed_config(
         head_dim,
         num_kv,
+        dtype=dtype,
         is_causal=is_causal,
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
@@ -3145,6 +3196,7 @@ def flash_attention_seed_configs(
     causal_split_seed = flash_attention_seed_config(
         head_dim,
         num_kv,
+        dtype=dtype,
         is_causal=is_causal,
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
@@ -3161,6 +3213,7 @@ def flash_autotune_fragments(
     head_dim: int,
     num_kv: int,
     *,
+    dtype: torch.dtype = torch.float16,
     is_causal: bool = False,
     has_kv_tile_pruning: bool = False,
     requires_ws_overlap: bool = False,
@@ -3259,6 +3312,7 @@ def flash_autotune_fragments(
             if topology_config is not None
             else None
         ),
+        dtype=dtype,
         is_causal=is_causal,
         prefer_packed_reduce=has_kv_tile_pruning or requires_ws_overlap,
     )
@@ -3641,15 +3695,16 @@ def flash_autotune_fragments(
         e2e_offset0_choices = (defaults.e2e_offset0,)
         e2e_offset_search_choices = None
         e2e_offset0_search_choices = None
+    safe_rescale_thresholds = _flash_safe_rescale_threshold_values(dtype)
     if dense_hd64_fa4 or causal_hd64_seeded_fa4:
         rescale_threshold_choices = _flash_choices_with_default(
-            defaults.rescale_threshold, (0.0, 4.0, 8.0, 12.0, 16.0, 32.0)
+            defaults.rescale_threshold, safe_rescale_thresholds
         )
         rescale_threshold_search_defaults = (
             (32.0, 16.0, 8.0)
+            if very_long_dense_hd64_fa4 and dtype is torch.bfloat16
+            else (8.0, 12.0)
             if very_long_dense_hd64_fa4
-            else (8.0, 12.0, 32.0)
-            if dense_hd64_fa4 and num_kv >= _FLASH_DENSE_HD64_VERY_LONG_MIN_KV
             else (8.0,)
         )
         rescale_threshold_search_choices: tuple[float, ...] | None = (
@@ -3692,7 +3747,7 @@ def flash_autotune_fragments(
             defaults.rescale_threshold,
             *(
                 threshold
-                for threshold in (0.0, 4.0, 8.0, 12.0, 16.0, 32.0)
+                for threshold in safe_rescale_thresholds
                 if threshold != defaults.rescale_threshold
             ),
         )
@@ -3929,7 +3984,7 @@ def flash_autotune_fragments(
     clc_stages_search_choices: tuple[int, ...] | None = (
         (defaults.clc_stages,)
         if use_clc_eligible and very_long_dense_hd64_fa4
-        else clc_stages_choices
+        else (2, 3)
         if use_clc_eligible
         else (1,)
     )
@@ -5826,7 +5881,10 @@ def _flash_fa4_wrap(
     if use_clc_scheduler:
         assert num_m_pairs is not None
         assert clc_heads_per_batch is not None and clc_heads_per_batch > 0
-        clc_m_pair_expr = "cutlass.Int32(flash_clc_work.tile_idx[0])"
+        clc_m_pair_expr = (
+            f"cutlass.Int32({num_m_pairs} - 1) - "
+            "cutlass.Int32(flash_clc_work.tile_idx[0])"
+        )
         advance = """        flash_clc_pipeline.consumer_wait(flash_clc_consumer_state)
         flash_clc_response_ptr = (
             flash_clc_response_base
@@ -8675,7 +8733,7 @@ def codegen_attention_flash(cg: GenerateAST) -> bool:
     clc_heads_per_batch = cfg.clc_heads_per_batch
     if (
         cfg.use_clc_scheduler
-        and (clc_heads_per_batch <= 0 or clc_heads_per_batch == batch)
+        and clc_heads_per_batch <= 0
         and plan.tensor_4d_batch > 0
         and plan.tensor_4d_heads > 0
         and plan.tensor_4d_batch * plan.tensor_4d_heads == batch

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -3642,6 +3642,7 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                 config_spec.enable_cute_flash_search(
                     head_dim=flash_shape.head_dim,
                     num_kv=flash_shape.num_kv,
+                    dtype=flash_shape.io_dtype,
                     block_size_targets=flash_shape.block_size_targets,
                     is_causal=flash_shape.is_causal,
                     has_kv_tile_pruning=flash_shape.has_kv_tile_pruning,

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -640,6 +640,7 @@ class ConfigSpec:
         self.cute_flash_search_enabled: bool = False
         self._cute_flash_head_dim: int | None = None
         self._cute_flash_num_kv: int | None = None
+        self._cute_flash_dtype: torch.dtype = torch.float16
         self._cute_flash_is_causal: bool = False
         self._cute_flash_has_kv_tile_pruning: bool = False
         self._cute_flash_requires_ws_overlap: bool = False
@@ -837,6 +838,7 @@ class ConfigSpec:
         fragments = flash_autotune_fragments(
             self._cute_flash_head_dim,
             self._cute_flash_num_kv,
+            dtype=self._cute_flash_dtype,
             is_causal=self._cute_flash_is_causal,
             has_kv_tile_pruning=self._cute_flash_has_kv_tile_pruning,
             requires_ws_overlap=self._cute_flash_requires_ws_overlap,
@@ -1016,6 +1018,7 @@ class ConfigSpec:
         *,
         head_dim: int,
         num_kv: int,
+        dtype: torch.dtype = torch.float16,
         block_size_targets: Mapping[int, int],
         is_causal: bool = False,
         has_kv_tile_pruning: bool = False,
@@ -1025,6 +1028,7 @@ class ConfigSpec:
         self.cute_flash_search_enabled = True
         self._cute_flash_head_dim = head_dim
         self._cute_flash_num_kv = num_kv
+        self._cute_flash_dtype = dtype
         self._cute_flash_is_causal = is_causal
         self._cute_flash_has_kv_tile_pruning = has_kv_tile_pruning
         self._cute_flash_requires_ws_overlap = requires_ws_overlap
@@ -1238,6 +1242,7 @@ class ConfigSpec:
                 flash_attention_seed_configs(
                     self._cute_flash_head_dim,
                     self._cute_flash_num_kv,
+                    dtype=self._cute_flash_dtype,
                     is_causal=self._cute_flash_is_causal,
                     has_kv_tile_pruning=self._cute_flash_has_kv_tile_pruning,
                     requires_ws_overlap=self._cute_flash_requires_ws_overlap,
@@ -2140,6 +2145,7 @@ class ConfigSpec:
                     flash_autotune_fragments(
                         self._cute_flash_head_dim,
                         self._cute_flash_num_kv,
+                        dtype=self._cute_flash_dtype,
                         is_causal=self._cute_flash_is_causal,
                         has_kv_tile_pruning=self._cute_flash_has_kv_tile_pruning,
                         requires_ws_overlap=self._cute_flash_requires_ws_overlap,

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -4007,9 +4007,7 @@ class TestCuteAutotuner(TestCase):
         )
         rescale_threshold_choices = flash_fragments[FLASH_RESCALE_THRESHOLD_KEY].choices
         self.assertEqual(rescale_threshold_choices[0], 8.0)
-        self.assertEqual(
-            set(rescale_threshold_choices), {0.0, 4.0, 8.0, 12.0, 16.0, 32.0}
-        )
+        self.assertEqual(set(rescale_threshold_choices), {0.0, 4.0, 8.0, 12.0})
         rescale_chunk_cols_choices = flash_fragments[
             FLASH_RESCALE_CHUNK_COLS_KEY
         ].choices
@@ -4157,7 +4155,7 @@ class TestCuteAutotuner(TestCase):
         )
         self.assertEqual(
             set(long_ws_fragments[FLASH_RESCALE_THRESHOLD_KEY].choices),
-            {0.0, 4.0, 8.0, 12.0, 16.0, 32.0},
+            {0.0, 4.0, 8.0, 12.0},
         )
         self.assertEqual(
             set(long_ws_fragments[FLASH_PACKED_REDUCE_KEY].choices), {False, True}
@@ -4358,7 +4356,14 @@ class TestCuteAutotuner(TestCase):
         very_long_dense_fragments = flash_autotune_fragments(64, 256, is_causal=False)
         self.assertEqual(
             very_long_dense_fragments[FLASH_RESCALE_THRESHOLD_KEY].search_choices,
-            (8.0, 32.0, 16.0),
+            (8.0, 12.0),
+        )
+        very_long_bf16_fragments = flash_autotune_fragments(
+            64, 384, dtype=torch.bfloat16, is_causal=False
+        )
+        self.assertEqual(
+            very_long_bf16_fragments[FLASH_RESCALE_THRESHOLD_KEY].search_choices,
+            (32.0, 16.0, 8.0),
         )
         self.assertEqual(
             long_dense_fragments[FLASH_PERSISTENT_CTAS_PER_SM_KEY].search_choices,
@@ -4509,7 +4514,7 @@ class TestCuteAutotuner(TestCase):
         }
         very_long_dense_search_choices_by_num_kv = {
             256: {
-                FLASH_RESCALE_THRESHOLD_KEY: (8.0, 32.0, 16.0),
+                FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_OTHER_REGS_KEY: (40,),
                 FLASH_FIRST_LOAD_ORDER_KEY: (0,),
                 FLASH_E2E_SCHEDULE_KEY: ("8/2", "16/4"),
@@ -4525,7 +4530,7 @@ class TestCuteAutotuner(TestCase):
                 FLASH_KV_STAGE_KEY: (2, 3),
             },
             384: {
-                FLASH_RESCALE_THRESHOLD_KEY: (32.0, 16.0, 8.0),
+                FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_OTHER_REGS_KEY: (32,),
                 FLASH_FIRST_LOAD_ORDER_KEY: (0,),
                 FLASH_E2E_SCHEDULE_KEY: ("8/2", "16/4"),
@@ -4541,7 +4546,7 @@ class TestCuteAutotuner(TestCase):
                 FLASH_KV_STAGE_KEY: (2, 3),
             },
             512: {
-                FLASH_RESCALE_THRESHOLD_KEY: (8.0, 32.0, 16.0),
+                FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_OTHER_REGS_KEY: (32,),
                 FLASH_FIRST_LOAD_ORDER_KEY: (0,),
                 FLASH_E2E_SCHEDULE_KEY: ("8/2", "16/4"),
@@ -4558,7 +4563,7 @@ class TestCuteAutotuner(TestCase):
                 FLASH_KV_STAGE_KEY: (2, 3),
             },
             1024: {
-                FLASH_RESCALE_THRESHOLD_KEY: (8.0, 32.0, 16.0),
+                FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_OTHER_REGS_KEY: (40,),
                 FLASH_FIRST_LOAD_ORDER_KEY: (0,),
                 FLASH_E2E_SCHEDULE_KEY: ("16/4", "8/2"),
@@ -4576,9 +4581,10 @@ class TestCuteAutotuner(TestCase):
                 FLASH_KV_STAGE_KEY: (2, 3),
                 FLASH_CLC_KEY: (True,),
                 FLASH_CLC_HEADS_PER_BATCH_KEY: (32,),
+                FLASH_CLC_STAGES_KEY: (2,),
             },
             2048: {
-                FLASH_RESCALE_THRESHOLD_KEY: (32.0, 16.0, 8.0),
+                FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_CORR_TILE_SIZE_KEY: (8, 16),
                 FLASH_SOFTMAX_REGS_KEY: (192, 200),
                 FLASH_ROLE_MAP_KEY: ("helion", "fa4"),
@@ -4704,7 +4710,7 @@ class TestCuteAutotuner(TestCase):
             long_dense_fragments[FLASH_CLC_PDL_KEY].search_choices, (False, True)
         )
         self.assertEqual(
-            long_dense_fragments[FLASH_CLC_STAGES_KEY].search_choices, (1, 2, 3)
+            long_dense_fragments[FLASH_CLC_STAGES_KEY].search_choices, (2, 3)
         )
         self.assertEqual(
             long_dense_fragments[FLASH_LOCAL_TMA_PARTITION_KEY].search_choices,
@@ -4787,7 +4793,7 @@ class TestCuteAutotuner(TestCase):
         )
         self.assertEqual(
             set(odd_fragments[FLASH_RESCALE_THRESHOLD_KEY].choices),
-            {0.0, 4.0, 8.0, 12.0, 16.0, 32.0},
+            {0.0, 4.0, 8.0, 12.0},
         )
         long_odd_fragments = flash_autotune_fragments(64, 65, is_causal=False)
         self.assertEqual(
@@ -4802,7 +4808,7 @@ class TestCuteAutotuner(TestCase):
         )
         self.assertEqual(
             set(long_odd_fragments[FLASH_RESCALE_THRESHOLD_KEY].choices),
-            {0.0, 4.0, 8.0, 12.0, 16.0, 32.0},
+            {0.0, 4.0, 8.0, 12.0},
         )
         valid_wide_offset = helion.Config(
             block_sizes=[1, 128, 128],

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1638,7 +1638,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 3,
                 1,
                 True,
-                32.0,
+                8.0,
                 8,
                 False,
                 1,
@@ -1760,7 +1760,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertTrue(very_long_config[FLASH_EPI_STG_KEY])
         self.assertEqual(very_long_config[FLASH_CORR_TILE_SIZE_KEY], 8)
         self.assertEqual(very_long_config.get(FLASH_ROLE_MAP_KEY, "helion"), "helion")
-        self.assertEqual(very_long_config[FLASH_RESCALE_THRESHOLD_KEY], 32.0)
+        self.assertEqual(very_long_config[FLASH_RESCALE_THRESHOLD_KEY], 8.0)
         self.assertEqual(very_long_config[FLASH_RESCALE_CHUNK_COLS_KEY], 8)
         self.assertTrue(very_long_config[FLASH_PACKED_REDUCE_KEY])
         self.assertFalse(very_long_config[FLASH_LOCAL_TMA_PARTITION_KEY])
@@ -2021,6 +2021,18 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertNotIn(FLASH_E2E_OFFSET_KEY, seed.config)
         self.assertIn(seed, bound.config_spec.compiler_seed_configs)
         self.assertIsNone(bound.config_spec.compiler_default_config)
+
+        bf16_args = tuple(
+            torch.empty(1, 1, 49152, 64, dtype=torch.bfloat16, device=DEVICE)
+            for _ in range(3)
+        )
+        bf16_bound = flash_attn.bind(bf16_args)
+        self.assertIs(bf16_bound.config_spec._cute_flash_dtype, torch.bfloat16)
+        bf16_seed = heuristic.get_seed_config(
+            bf16_bound.env, bf16_bound.host_function.device_ir
+        )
+        assert bf16_seed is not None
+        self.assertEqual(bf16_seed.config[FLASH_RESCALE_THRESHOLD_KEY], 32.0)
 
         dense_2048_args = tuple(
             torch.empty(1, 1, 2048, 64, dtype=torch.float16, device=DEVICE)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -2465,6 +2465,75 @@ class TestCuteBackend(TestCase):
                 expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
                 torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
+    def test_flash_attention_fa4_fp16_rescale_threshold_stays_finite(self) -> None:
+        q = torch.ones(1, 1, 256, 64, dtype=torch.float16, device=DEVICE)
+        k = torch.zeros_like(q)
+        k[:, :, 128:, :] = 20.0 * math.log(2.0) / 8.0
+        v = torch.zeros_like(q)
+        v[:, :, :128, :] = 1.0
+        with patch.dict(
+            os.environ,
+            {"HELION_CUTE_FLASH_RESCALE_THRESHOLD": "32"},
+            clear=False,
+        ):
+            code, out = code_and_output(
+                cute_dense_attention,
+                (q, k, v),
+                block_sizes=[1, 128, 128],
+                cute_flash_topology="fa4",
+                cute_flash_kv_order="ascending",
+            )
+
+        self.assertIn("flash_acc_log >= -8.0", code)
+        self.assertTrue(torch.isfinite(out).all())
+        expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_flash_attention_fa4_dense_128k_clc_seed_matches_sdpa(self) -> None:
+        q, k, v = (
+            torch.randn(2, 32, 131072, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        code, out = code_and_output(
+            cute_dense_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+        )
+
+        self.assertIn(
+            "flash_clc_pipeline = cutlass_pipeline_flash."
+            "PipelineClcFetchAsync.create("
+            "barrier_storage=storage.clc_mbar_ptr.data_ptr(), num_stages=2,",
+            code,
+        )
+        self.assertIn("problem_shape_ntile_mnl=(512, 32, 2)", code)
+        self.assertIn(
+            "flash_m_pair = cutlass.Int32(512 - 1) - "
+            "cutlass.Int32(flash_clc_work.tile_idx[0])",
+            code,
+        )
+        expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_flash_attention_clc_preserves_explicit_flattened_geometry(self) -> None:
+        q, k, v = (
+            torch.randn(2, 32, 8192, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        code, out = code_and_output(
+            cute_dense_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+            cute_flash_topology="fa4",
+            cute_flash_persistent=True,
+            cute_flash_clc=True,
+            cute_flash_clc_heads_per_batch=64,
+        )
+
+        self.assertIn("problem_shape_ntile_mnl=(32, 64, 1)", code)
+        expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
     def test_flash_attention_bfloat16_fires_and_matches_sdpa(self) -> None:
         q, k, v = (
             torch.randn(2, 8, 256, 128, dtype=torch.bfloat16, device=DEVICE)
@@ -3615,6 +3684,21 @@ class TestCuteBackend(TestCase):
         )
         self.assertEqual(cfg.rescale_threshold, 4.0)
 
+        fp16_cfg = resolve_flash_config(
+            64,
+            2,
+            {"cute_flash_rescale_threshold": 32.0},
+            dtype=torch.float16,
+        )
+        bf16_cfg = resolve_flash_config(
+            64,
+            2,
+            {"cute_flash_rescale_threshold": 32.0},
+            dtype=torch.bfloat16,
+        )
+        self.assertEqual(fp16_cfg.rescale_threshold, 8.0)
+        self.assertEqual(bf16_cfg.rescale_threshold, 32.0)
+
         with patch.dict(
             os.environ,
             {
@@ -3822,6 +3906,15 @@ class TestCuteBackend(TestCase):
         self.assertEqual(cfg_64k.first_load_order, 0)
         self.assertEqual(cfg_128k.first_load_order, 0)
         self.assertEqual(cfg_256k.first_load_order, 4)
+        self.assertEqual(cfg_64k.rescale_threshold, 8.0)
+        self.assertTrue(cfg_128k.use_clc_scheduler)
+        self.assertEqual(cfg_128k.clc_stages, 2)
+        with patch.dict(
+            os.environ,
+            {"HELION_CUTE_FLASH_CLC_STAGES": "1"},
+            clear=True,
+        ):
+            self.assertEqual(resolve_flash_config(64, 1024).clc_stages, 2)
 
     def test_flash_attention_dense_hd64_epi_tma_seed_buckets(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
@@ -7483,7 +7576,7 @@ class TestCuteConfigValuePriors(TestCase):
             FLASH_CLC_KEY: {False, True},
             FLASH_CLC_HEADS_PER_BATCH_KEY: {0, 32},
             FLASH_CLC_PDL_KEY: {False, True},
-            FLASH_CLC_STAGES_KEY: {1, 2, 3},
+            FLASH_CLC_STAGES_KEY: {2, 3},
             FLASH_LOCAL_TMA_PARTITION_KEY: {False, True},
             FLASH_TENSOR_4D_TMA_KEY: {False, True},
             FLASH_E2E_OFFSET_KEY: {0, 1, 2, 3},
@@ -7499,6 +7592,15 @@ class TestCuteConfigValuePriors(TestCase):
         self._assert_prior_choices(
             very_long_priors[FLASH_RESCALE_THRESHOLD_KEY],
             very_long_fragments[FLASH_RESCALE_THRESHOLD_KEY],
+            {8.0, 12.0},
+        )
+        bound.config_spec._cute_flash_num_kv = 384
+        bound.config_spec._cute_flash_dtype = torch.bfloat16
+        bf16_priors = CuteBackend().config_value_priors(bound.config_spec)
+        bf16_fragments = bound.config_spec._flat_fields()
+        self._assert_prior_choices(
+            bf16_priors[FLASH_RESCALE_THRESHOLD_KEY],
+            bf16_fragments[FLASH_RESCALE_THRESHOLD_KEY],
             {8.0, 16.0, 32.0},
         )
         for key, values in {


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3147
 * #3146
 * #3145
 * #3144
 * #3143
 * __->__#3142
 * #3141
 * #3140
 * #3139


--- --- ---

[cutedsl] Make dense flash rescaling and scheduling safe

Thread input dtype through flash seeds and search so fp16 cannot select overflowing pinned thresholds. Require safe CLC staging, preserve explicit flattened geometry, and cover the overflow path end to end.