### PR TITLE
[cutedsl] Constrain FA4 resource use during autotuning

### DIFF
--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -21,6 +21,7 @@ from cutlass.cute.nvgpu import tcgen05
 from cutlass.cute.typing import Float32
 from cutlass.cutlass_dsl import T
 from cutlass.cutlass_dsl import dsl_user_op
+import cutlass.utils.blackwell_helpers as sm100_utils_flash
 
 
 @functools.cache
@@ -1782,6 +1783,111 @@ def fa4_store_o_smem_to_gmem_whole(
             out[None, rest_m, None],
             tOgO_epi[None, rest_m, None],
         )
+
+
+def fa4_correction_epilogue_to_smem(
+    tiled_t2r: object,
+    tiled_r2s: object,
+    tOtO_corr_t2r: cute.Tensor,
+    tOsO_corr_r2s: cute.Tensor,
+    tOcO_corr_t2r: cute.Tensor,
+    inv_sum: object,
+    chunks: int,
+) -> None:
+    """FA4 correction epilogue: rescale O in TMEM and stage fp16 output in SMEM."""
+    for i in range(chunks):
+        reg_src = cast("cute.Tensor", tOcO_corr_t2r[None, 0, 0, i])
+        reg = cute.make_rmem_tensor(reg_src.shape, cutlass.Float32)
+        cute.copy(tiled_t2r, tOtO_corr_t2r[None, 0, 0, i], reg)
+        reg.store(reg.load() * inv_sum)
+        cvt_copy(tiled_r2s, reg, tOsO_corr_r2s[None, 0, 0, i])
+
+
+def fa4_correction_epilogue_handoff_to_smem(
+    o_full_ptr_stage: object,
+    o_full_phase: object,
+    corr_epi_empty_ptr_stage: object,
+    corr_epi_empty_phase: object,
+    corr_epi_full_ptr_stage: object,
+    tiled_t2r: object,
+    tiled_r2s: object,
+    tOtO_corr_t2r: cute.Tensor,
+    tOsO_corr_r2s: cute.Tensor,
+    tOcO_corr_t2r: cute.Tensor,
+    inv_sum: object,
+    chunks: int,
+) -> None:
+    """Wait for O/epilogue handoff, stage final O in SMEM, then publish it."""
+    mbar_spin_wait(o_full_ptr_stage, o_full_phase)
+    mbar_spin_wait(corr_epi_empty_ptr_stage, corr_epi_empty_phase)
+    fa4_correction_epilogue_to_smem(
+        tiled_t2r,
+        tiled_r2s,
+        tOtO_corr_t2r,
+        tOsO_corr_r2s,
+        tOcO_corr_t2r,
+        inv_sum,
+        chunks,
+    )
+    cute.arch.fence_view_async_shared()
+    cute.arch.mbarrier_arrive(corr_epi_full_ptr_stage)
+
+
+def fa4_correction_epilogue_handoff_to_smem_scoped(
+    o_full_ptr_stage: object,
+    o_full_phase: object,
+    corr_epi_empty_ptr_stage: object,
+    corr_epi_empty_phase: object,
+    corr_epi_full_ptr_stage: object,
+    flash_pvt: object,
+    tOtO: cute.Tensor,
+    sO: cute.Tensor,
+    tidx: object,
+    inv_sum: object,
+    head_dim: int,
+    corr_tile_size: int,
+    o_dtype: object,
+) -> None:
+    """FA4 correction epilogue with copy-view lifetimes scoped after waits."""
+    mbar_spin_wait(o_full_ptr_stage, o_full_phase)
+    mbar_spin_wait(corr_epi_empty_ptr_stage, corr_epi_empty_phase)
+
+    o_layout = cutlass.utils.layout.LayoutEnum.ROW_MAJOR
+    epi_subtile = (128, corr_tile_size)
+    tmem_atom = sm100_utils_flash.get_tmem_load_op(
+        (128, head_dim),
+        o_layout,
+        o_dtype,
+        cutlass.Float32,
+        epi_subtile,
+        use_2cta_instrs=False,
+    )
+    cO = cute.make_identity_tensor((128, head_dim))
+    flash_pvt_copy = cast("Any", flash_pvt)
+    tOcO = flash_pvt_copy.partition_C(cO)
+    tOtO_i = cute.logical_divide(tOtO, cute.make_layout((128, corr_tile_size)))
+    tOcO_i = cute.logical_divide(tOcO, cute.make_layout((128, corr_tile_size)))
+    tOsO = flash_pvt_copy.partition_C(sO)
+    tOsO_i = cute.logical_divide(tOsO, cute.make_layout((128, corr_tile_size)))
+
+    tiled_t2r = tcgen05.make_tmem_copy(tmem_atom, tOtO_i[(None, None), 0])
+    smem_atom = sm100_utils_flash.get_smem_store_op(
+        o_layout, o_dtype, cutlass.Float32, tiled_t2r
+    )
+    tiled_r2s = cute.make_tiled_copy_D(smem_atom, tiled_t2r)
+    thr_t2r = tiled_t2r.get_slice(tidx)
+    tOcO_t2r = thr_t2r.partition_D(tOcO_i[(None, None), None])
+    tOtO_t2r = thr_t2r.partition_S(tOtO_i[(None, None), None])
+    tOsO_r2s = partition_D_position_independent(thr_t2r, tOsO_i[(None, None), None])
+
+    for i in range(head_dim // corr_tile_size):
+        reg_src = cast("cute.Tensor", tOcO_t2r[None, 0, 0, i])
+        reg = cute.make_rmem_tensor(reg_src.shape, cutlass.Float32)
+        cute.copy(tiled_t2r, tOtO_t2r[None, 0, 0, i], reg)
+        reg.store(reg.load() * inv_sum)
+        cvt_copy(tiled_r2s, reg, tOsO_r2s[None, 0, 0, i])
+    cute.arch.fence_view_async_shared()
+    cute.arch.mbarrier_arrive(corr_epi_full_ptr_stage)
 
 
 def _fa4_sp_exp_convert_store_impl(

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -6460,6 +6460,25 @@ tVsV, tVgV_dkl = cute_cpasync_flash.tma_partition(
     _flash_tma_v, 0, cute.make_layout(1),
     cute.group_modes(sV, 0, 3), cute.group_modes(tOgV, 0, 3)){setup_gmem_slice}"""
     )
+    fa4_stat_handoff = (
+        cfg.exp2_impl == "split"
+        and not is_causal
+        and hd == 64
+        and not has_lse
+        and not score_plan.modifiers
+        and _flash_bool_env("HELION_CUTE_FLASH_FA4_STAT_HANDOFF", True)
+    )
+    scale_layout = (
+        f"cute.make_layout(({q_stage} * 128))"
+        if fa4_stat_handoff
+        else f"cute.make_layout(({s_corr_stage}, {q_stage}, 128))"
+    )
+
+    def _scale_slot_expr(index: str, stage: str) -> str:
+        if fa4_stat_handoff:
+            return f"flash_scale_t[{stage} * 128 + flash_local_tidx]"
+        return f"flash_scale_t[{index}, {stage}, flash_local_tidx]"
+
     setup = f"""
 tidx, _, _ = cute.arch.thread_idx()
 warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -6473,8 +6492,7 @@ storage = smem.allocate(_flash_storage_cls)
 sQ = storage.sQ.get_tensor(_flash_qsl.outer, swizzle=_flash_qsl.inner)
 sK = storage.sK.get_tensor(_flash_ksl.outer, swizzle=_flash_ksl.inner)
 sV = cute.make_tensor(cute.recast_ptr(sK.iterator, _flash_vsl.inner), _flash_vsl.outer)
-flash_scale_t = storage.sScale.get_tensor(
-    cute.make_layout(({s_corr_stage}, {q_stage}, 128)))
+flash_scale_t = storage.sScale.get_tensor({scale_layout})
 
 # Raw mbarrier init -> fence -> CTA sync, before the pipelines.
 flash_s_full_ptr = storage.s_full_mbar.data_ptr()
@@ -6530,17 +6548,15 @@ flash_kv_prod, flash_kv_cons = cutlass_pipeline_flash.PipelineTmaUmma.create(
 
 flash_qkt = _flash_qk_mma.get_slice(flash_mma_tile_coord_v)
 flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
-tSrQ = flash_qkt.make_fragment_A(sQ)
-tSrK = flash_qkt.make_fragment_B(sK)
-tOrV = flash_pvt.make_fragment_B(sV)
-flash_qk_acc_shape = flash_qkt.partition_shape_C(({mma_m}, 128))
-tStS = flash_qkt.make_fragment_C(flash_qk_acc_shape)
-flash_pv_acc_shape = flash_pvt.partition_shape_C(({mma_m}, {hd}))
-tOtO = flash_pvt.make_fragment_C(flash_pv_acc_shape)
 {setup_tma_partitions}
     """
 
-    tmem_base_setup = f"""    flash_tmem.wait_for_alloc()
+    tmem_fragment_setup = f"""    flash_qk_acc_shape = flash_qkt.partition_shape_C(({mma_m}, 128))
+    tStS = flash_qkt.make_fragment_C(flash_qk_acc_shape)
+    flash_pv_acc_shape = flash_pvt.partition_shape_C(({mma_m}, {hd}))
+    tOtO = flash_pvt.make_fragment_C(flash_pv_acc_shape)
+"""
+    tmem_base_setup = f"""{tmem_fragment_setup}    flash_tmem.wait_for_alloc()
     flash_tmem_ptr = flash_tmem.retrieve_ptr(cutlass.Float32)
     tStS0_full = cute.make_tensor(flash_tmem_ptr, tStS.layout)
     tStS1_full = cute.make_tensor(flash_tmem_ptr + 128, tStS.layout)
@@ -6550,11 +6566,29 @@ tOtO = flash_pvt.make_fragment_C(flash_pv_acc_shape)
 """
     tmem_mma_setup = (
         tmem_base_setup
-        + f"""    tP = cute.make_tensor(tStS0.iterator, _flash_ptl.outer)
+        + f"""    tSrQ = flash_qkt.make_fragment_A(sQ)
+    tSrK = flash_qkt.make_fragment_B(sK)
+    tOrV = flash_pvt.make_fragment_B(sV)
+    tP = cute.make_tensor(tStS0.iterator, _flash_ptl.outer)
     tOrP0 = flash_pvt.make_fragment_A(tP)
     tOrP1 = cute.make_tensor(tOrP0.iterator + {p1_step}, tOrP0.layout)
 """
     )
+    score_store_needed = (
+        cfg.softmax_disc
+        and not _flash_fa4_runtime_disc_score_plan_supported(score_plan)
+    )
+    score_store_setup = ""
+    if score_store_needed:
+        score_store_setup = """    flash_score_st_atom = cute.make_copy_atom(
+        cute_tcgen05_flash.St32x32bOp(cute_tcgen05_flash.Repetition(32)), cutlass.Float32)
+    flash_tiled_score_st0 = cute_tcgen05_flash.make_tmem_copy(flash_score_st_atom, tStS0)
+    flash_tiled_score_st1 = cute_tcgen05_flash.make_tmem_copy(flash_score_st_atom, tStS1)
+    flash_thr_score_st0 = flash_tiled_score_st0.get_slice(flash_local_tidx)
+    flash_thr_score_st1 = flash_tiled_score_st1.get_slice(flash_local_tidx)
+    tScoreSTtS0 = flash_thr_score_st0.partition_D(tStS0)
+    tScoreSTtS1 = flash_thr_score_st1.partition_D(tStS1)
+"""
     tmem_softmax_setup = (
         tmem_base_setup
         + f"""    cS = cute.make_identity_tensor((128, 128))
@@ -6568,14 +6602,7 @@ tOtO = flash_pvt.make_fragment_C(flash_pv_acc_shape)
     tLDtS0 = flash_thr_ld0.partition_S(tStS0)
     tLDtS1 = flash_thr_ld1.partition_S(tStS1)
     tLDcS = flash_thr_ld0.partition_D(tScS)
-    flash_score_st_atom = cute.make_copy_atom(
-        cute_tcgen05_flash.St32x32bOp(cute_tcgen05_flash.Repetition(32)), cutlass.Float32)
-    flash_tiled_score_st0 = cute_tcgen05_flash.make_tmem_copy(flash_score_st_atom, tStS0)
-    flash_tiled_score_st1 = cute_tcgen05_flash.make_tmem_copy(flash_score_st_atom, tStS1)
-    flash_thr_score_st0 = flash_tiled_score_st0.get_slice(flash_local_tidx)
-    flash_thr_score_st1 = flash_tiled_score_st1.get_slice(flash_local_tidx)
-    tScoreSTtS0 = flash_thr_score_st0.partition_D(tStS0)
-    tScoreSTtS1 = flash_thr_score_st1.partition_D(tStS1)
+{score_store_setup.rstrip()}
 
     # Staged-P store atom repetition is autotuned. Rep16 preserves the original
     # 4-chunk FA4 granularity; Rep32 halves the P r2t chunk count on hd64.
@@ -6628,6 +6655,16 @@ tOtO = flash_pvt.make_fragment_C(flash_pv_acc_shape)
     def _tmem_softmax_setup_stage(stage: str) -> str:
         ptr_expr = "flash_tmem_ptr" if stage == "0" else "flash_tmem_ptr + 128"
         p_store_iter = p0_store_iter if stage == "0" else p1_store_iter
+        stage_score_store_setup = ""
+        if score_store_needed:
+            stage_score_store_setup = f"""    flash_score_st_atom = cute.make_copy_atom(
+        cute_tcgen05_flash.St32x32bOp(cute_tcgen05_flash.Repetition(32)), cutlass.Float32)
+    flash_tiled_score_st{stage} = cute_tcgen05_flash.make_tmem_copy(
+        flash_score_st_atom, tStS{stage})
+    flash_thr_score_st{stage} = flash_tiled_score_st{stage}.get_slice(
+        flash_local_tidx)
+    tScoreSTtS{stage} = flash_thr_score_st{stage}.partition_D(tStS{stage})
+"""
         coord_setup = (
             "    tLDcS = flash_thr_ld0.partition_D(tScS)\n"
             if stage == "0"
@@ -6640,6 +6677,8 @@ tOtO = flash_pvt.make_fragment_C(flash_pv_acc_shape)
         )
         return f"""    flash_tmem.wait_for_alloc()
     flash_tmem_ptr = flash_tmem.retrieve_ptr(cutlass.Float32)
+    flash_qk_acc_shape = flash_qkt.partition_shape_C(({mma_m}, 128))
+    tStS = flash_qkt.make_fragment_C(flash_qk_acc_shape)
     tStS{stage} = cute.make_tensor({ptr_expr}, tStS.layout)
     cS = cute.make_identity_tensor((128, 128))
     tScS = flash_qkt.partition_C(cS)
@@ -6650,13 +6689,7 @@ tOtO = flash_pvt.make_fragment_C(flash_pv_acc_shape)
     flash_thr_ld{stage} = flash_tiled_ld{stage}.get_slice(flash_local_tidx)
     tLDtS{stage} = flash_thr_ld{stage}.partition_S(tStS{stage})
 {coord_setup.rstrip()}
-    flash_score_st_atom = cute.make_copy_atom(
-        cute_tcgen05_flash.St32x32bOp(cute_tcgen05_flash.Repetition(32)), cutlass.Float32)
-    flash_tiled_score_st{stage} = cute_tcgen05_flash.make_tmem_copy(
-        flash_score_st_atom, tStS{stage})
-    flash_thr_score_st{stage} = flash_tiled_score_st{stage}.get_slice(
-        flash_local_tidx)
-    tScoreSTtS{stage} = flash_thr_score_st{stage}.partition_D(tStS{stage})
+{stage_score_store_setup.rstrip()}
 
     # Staged-P store atom repetition is autotuned. Rep16 preserves the original
     # 4-chunk FA4 granularity; Rep32 halves the P r2t chunk count on hd64.
@@ -6754,6 +6787,9 @@ sO = storage.sO.get_tensor(_flash_osl.outer, swizzle=_flash_osl.inner)
 """
         if epi_smem
         else ""
+    )
+    scoped_corr_epi_smem = epi_smem and _flash_bool_env(
+        "HELION_CUTE_FLASH_SCOPED_CORR_EPI", True
     )
     epi_tma_setup = (
         f"""
@@ -6893,6 +6929,7 @@ if warp_idx == 15:
         epi_prelude = "decode"
     elif cfg.epi_stg:
         epi_head = f"""    cute.arch.setmaxregister_decrease({cfg.other_regs})
+{textwrap.indent(epi_stg_setup.strip(), "    ") if cfg.epi_stg else ""}
     flash_corr_epi_full_phase = cutlass.Int32(0)
     with cute.arch.elect_one():
         cute.arch.mbarrier_arrive(flash_corr_epi_empty_ptr + 0)
@@ -7559,7 +7596,13 @@ if warp_idx == 15:
         def _corr_publish_alpha(indent: str) -> str:
             if cfg.skip_rescale_stats:
                 return ""
-            publish_alpha_store = f"{indent}flash_scale_t[{corr_prod_index}, {stage}, flash_local_tidx] = flash_alpha\n"
+            publish_alpha_store = (
+                f"{indent}{_scale_slot_expr(corr_prod_index, stage)} = flash_alpha\n"
+            )
+            if fa4_stat_handoff:
+                return f"""{publish_alpha_store.rstrip()}
+{indent}cute.arch.barrier_arrive(
+{indent}    barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)"""
             publish_alpha_advance = corr_prod_advance.replace("\n", f"\n{indent}")
             return f"""{indent}_helion_flash_rt.mbar_spin_wait(
 {indent}    {corr_empty_ptr} + {corr_prod_index}, flash_s_corr_prod_phase)
@@ -7570,9 +7613,15 @@ if warp_idx == 15:
 
         corr_publish_alpha = _corr_publish_alpha("                ")
         corr_rowsum_advance = corr_prod_advance.replace("\n", "\n        ")
-        corr_publish_rowsum = f"""        _helion_flash_rt.mbar_spin_wait(
+        if fa4_stat_handoff:
+            corr_publish_rowsum = f"""        {_scale_slot_expr(corr_prod_index, stage)} = flash_row_sum
+        cute.arch.barrier_arrive(
+            barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
+{lse_store}"""
+        else:
+            corr_publish_rowsum = f"""        _helion_flash_rt.mbar_spin_wait(
             {corr_empty_ptr} + {corr_prod_index}, flash_s_corr_prod_phase)
-        flash_scale_t[{corr_prod_index}, {stage}, flash_local_tidx] = flash_row_sum
+        {_scale_slot_expr(corr_prod_index, stage)} = flash_row_sum
         cute.arch.barrier_arrive(
             barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
 {lse_store}
@@ -7833,6 +7882,13 @@ if warp_idx == 15:
         if not sp_corr_publish_alpha and not cfg.skip_rescale_stats:
             sp_corr_publish_alpha = f"""            if {softmax_not_first}:
 {corr_publish_alpha}"""
+        fa4_publish_alpha_before_exp = fa4_stat_handoff and cfg.rescale_threshold > 0.0
+        sp_alpha_publish_pre = (
+            sp_corr_publish_alpha if fa4_publish_alpha_before_exp else ""
+        )
+        sp_alpha_publish_post = (
+            "" if fa4_publish_alpha_before_exp else sp_corr_publish_alpha
+        )
         return f"""        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)
         for {softmax_loop_var} in cutlass.range({kv_loop_bound}, unroll=1):{
@@ -7851,9 +7907,10 @@ if warp_idx == 15:
             if flash_row_max == -cutlass.Float32.inf:
                 flash_row_max_safe = cutlass.Float32(0.0)
 {_sp_alpha_pre}
+{sp_alpha_publish_pre}
 {sp_exp_block}
 {_sp_alpha_post}
-{sp_corr_publish_alpha}
+{sp_alpha_publish_post}
             flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum
 {sp_p_store_block}
 {final_corr_publish_rowsum}"""
@@ -7897,18 +7954,28 @@ if warp_idx == 15:
         if use_2cta_instrs
         else "    cute.arch.mbarrier_arrive(flash_tmem_dealloc_ptr)"
     )
+    softmax0_inner = _softmax_inner(
+        "0",
+        "flash_tiled_ld0",
+        "tLDtS0",
+        "flash_tiled_st0",
+        "tSTtS0",
+        "flash_tiled_score_st0",
+        "tScoreSTtS0",
+    )
+    softmax1_inner = _softmax_inner(
+        "1",
+        "flash_tiled_ld1",
+        "tLDtS1",
+        "flash_tiled_st1",
+        "tSTtS1",
+        "flash_tiled_score_st1",
+        "tScoreSTtS1",
+    )
     softmax0_block = _flash_fa4_wrap(
         "if warp_idx < 4:",
         softmax0_head,
-        _softmax_inner(
-            "0",
-            "flash_tiled_ld0",
-            "tLDtS0",
-            "flash_tiled_st0",
-            "tSTtS0",
-            "flash_tiled_score_st0",
-            "tScoreSTtS0",
-        ),
+        softmax0_inner,
         persistent,
         prelude=softmax_prelude,
         tail=tmem_dealloc_arrive,
@@ -7924,15 +7991,7 @@ if warp_idx == 15:
     softmax1_block = _flash_fa4_wrap(
         "if (warp_idx >= 4) & (warp_idx < 8):",
         softmax1_head,
-        _softmax_inner(
-            "1",
-            "flash_tiled_ld1",
-            "tLDtS1",
-            "flash_tiled_st1",
-            "tSTtS1",
-            "flash_tiled_score_st1",
-            "tScoreSTtS1",
-        ),
+        softmax1_inner,
         persistent,
         prelude=softmax_prelude,
         tail=tmem_dealloc_arrive,
@@ -7957,17 +8016,22 @@ if warp_idx == 15:
     _helion_flash_rt.mbarrier_arrive(flash_pfor_ptr + 0{pfor_peer_arg})
     _helion_flash_rt.mbarrier_arrive(flash_pfor_ptr + 1{pfor_peer_arg})"""
     )
-    corr_head = f"""    cute.arch.setmaxregister_decrease({cfg.corr_regs})
-{tmem_base_setup.rstrip()}
-{corr_epi_smem_setup.rstrip()}
-    flash_o_full_phase = cutlass.Int32(0)
-    flash_s_corr_cons_index = cutlass.Int32(0)
-    flash_s_corr_cons_phase = cutlass.Int32(0)
-    flash_corr_epi_empty_phase = cutlass.Int32(0){corr_pfor_prearrive}
+    corr_stat_empty_init = (
+        ""
+        if fa4_stat_handoff
+        else """
     cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)
     cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 1)
     cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)
     cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 1)"""
+    )
+    corr_head = f"""    cute.arch.setmaxregister_decrease({cfg.corr_regs})
+{tmem_base_setup.rstrip()}
+{"" if scoped_corr_epi_smem else corr_epi_smem_setup.rstrip()}
+    flash_o_full_phase = cutlass.Int32(0)
+    flash_s_corr_cons_index = cutlass.Int32(0)
+    flash_s_corr_cons_phase = cutlass.Int32(0)
+    flash_corr_epi_empty_phase = cutlass.Int32(0){corr_pfor_prearrive}{corr_stat_empty_init}"""
     if not epi_smem:
         corr_head += f"""
     flash_gO_corr = cute.flat_divide(_flash_mOt, cute.select((128, {hd}, 128), mode=[0, 1]))
@@ -7988,7 +8052,12 @@ if warp_idx == 15:
 
     def _corr_epi(stage: str, mtile: str) -> str:
         corr_cons_index = "0" if not is_causal else "flash_s_corr_cons_index"
-        scale_expr = f"flash_scale_t[{corr_cons_index}, {stage}, flash_local_tidx]"
+        scale_expr = _scale_slot_expr(corr_cons_index, stage)
+        stat_empty_arrive = (
+            ""
+            if fa4_stat_handoff
+            else f"        cute.arch.mbarrier_arrive(flash_s{stage}_corr_empty_ptr + {corr_cons_index})\n"
+        )
         if not epi_smem:
             # Committed path: per-thread t2r (Ld32x32 Rep16) -> rescale -> cast ->
             # STG.E.128 straight to gmem (coord->linear address division per thread =
@@ -7996,7 +8065,7 @@ if warp_idx == 15:
             return f"""        cute.arch.barrier(
             barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
         flash_inv_sum{stage} = _helion_flash_rt.rcp_approx_ftz({scale_expr})
-        cute.arch.mbarrier_arrive(flash_s{stage}_corr_empty_ptr + {corr_cons_index})
+{stat_empty_arrive}\
         _helion_flash_rt.mbar_spin_wait(flash_o_full_ptr + {stage}, flash_o_full_phase)
         tOgO_mma{stage} = {corr_gmem_o_index.format(mtile=mtile)}
         gO_epi{stage} = cute.zipped_divide(tOgO_mma{stage}, flash_epi_tiler{stage})
@@ -8014,52 +8083,70 @@ if warp_idx == 15:
         # {stage} of the 2-staged _flash_osl) via the SMEM-STORE atom matched to
         # the t2r tiled copy. A dedicated epilogue warp then drains sO either by
         # TMA-O or by vector STG.
+        if scoped_corr_epi_smem:
+            return f"""        cute.arch.barrier(
+            barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
+        flash_inv_sum{stage} = _helion_flash_rt.rcp_approx_ftz({scale_expr})
+{stat_empty_arrive}\
+        _helion_flash_rt.fa4_correction_epilogue_handoff_to_smem_scoped(
+            flash_o_full_ptr + {stage}, flash_o_full_phase,
+            flash_corr_epi_empty_ptr + {stage}, flash_corr_epi_empty_phase,
+            flash_corr_epi_full_ptr + {stage},
+            flash_pvt, tOtO{stage}, sO[None, None, {stage}], flash_local_tidx,
+            flash_inv_sum{stage}, {hd}, {cfg.corr_tile_size}, {io_dtype})
+"""
         return f"""        cute.arch.barrier(
             barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
         flash_inv_sum{stage} = _helion_flash_rt.rcp_approx_ftz({scale_expr})
-        cute.arch.mbarrier_arrive(flash_s{stage}_corr_empty_ptr + {corr_cons_index})
-        _helion_flash_rt.mbar_spin_wait(flash_o_full_ptr + {stage}, flash_o_full_phase)
-        _helion_flash_rt.mbar_spin_wait(
-            flash_corr_epi_empty_ptr + {stage}, flash_corr_epi_empty_phase)
-        for flash_i in cutlass.range_constexpr(flash_o_corr_chunks):
-            flash_oreg{stage} = cute.make_rmem_tensor(tOcO_corr_t2r[None, 0, 0, flash_i].shape, cutlass.Float32)
-            cute.copy(flash_o_tiled_t2r, tOtO{stage}_corr_t2r[None, 0, 0, flash_i], flash_oreg{stage})
-            flash_oreg{stage}.store(flash_oreg{stage}.load() * flash_inv_sum{stage})
-            _helion_flash_rt.cvt_copy(flash_o_tiled_r2s, flash_oreg{stage}, tOsO{stage}_corr_r2s[None, 0, 0, flash_i])
-        cute.arch.fence_view_async_shared()
-        cute.arch.mbarrier_arrive(flash_corr_epi_full_ptr + {stage})"""
+{stat_empty_arrive}\
+        _helion_flash_rt.fa4_correction_epilogue_handoff_to_smem(
+            flash_o_full_ptr + {stage}, flash_o_full_phase,
+            flash_corr_epi_empty_ptr + {stage}, flash_corr_epi_empty_phase,
+            flash_corr_epi_full_ptr + {stage},
+            flash_o_tiled_t2r, flash_o_tiled_r2s,
+            tOtO{stage}_corr_t2r, tOsO{stage}_corr_r2s, tOcO_corr_t2r,
+            flash_inv_sum{stage}, flash_o_corr_chunks)
+"""
 
     corr_epi_empty_toggle = (
         "        flash_corr_epi_empty_phase ^= 1" if epi_smem else ""
     )
     corr_cons_index = "0" if not is_causal else "flash_s_corr_cons_index"
     corr_empty0_early = (
-        "            cute.arch.mbarrier_arrive("
-        f"flash_s0_corr_empty_ptr + {corr_cons_index})"
-        if not is_causal
-        else ""
+        ""
+        if fa4_stat_handoff
+        else (
+            "            cute.arch.mbarrier_arrive("
+            f"flash_s0_corr_empty_ptr + {corr_cons_index})"
+            if not is_causal
+            else ""
+        )
     )
     corr_empty1_early = (
-        "            cute.arch.mbarrier_arrive("
-        f"flash_s1_corr_empty_ptr + {corr_cons_index})"
-        if not is_causal
-        else ""
+        ""
+        if fa4_stat_handoff
+        else (
+            "            cute.arch.mbarrier_arrive("
+            f"flash_s1_corr_empty_ptr + {corr_cons_index})"
+            if not is_causal
+            else ""
+        )
     )
     corr_empty0_late = (
         ""
-        if not is_causal
+        if fa4_stat_handoff or not is_causal
         else "            cute.arch.mbarrier_arrive("
         "flash_s0_corr_empty_ptr + flash_s_corr_cons_index)"
     )
     corr_empty1_late = (
         ""
-        if not is_causal
+        if fa4_stat_handoff or not is_causal
         else "            cute.arch.mbarrier_arrive("
         "flash_s1_corr_empty_ptr + flash_s_corr_cons_index)"
     )
     corr_stage0 = f"""            cute.arch.barrier(
                 barrier_id=3 + warp_idx % 4, number_of_threads=64)
-            flash_a0 = flash_scale_t[{corr_cons_index}, 0, flash_local_tidx]
+            flash_a0 = {_scale_slot_expr(corr_cons_index, "0")}
 {corr_empty0_early}
             flash_need_rescale0 = cute.arch.vote_ballot_sync(flash_a0 < 1.0) != 0
             if flash_need_rescale0:
@@ -8070,7 +8157,7 @@ if warp_idx == 15:
 {corr_empty0_late}"""
     corr_stage1 = f"""            cute.arch.barrier(
                 barrier_id=7 + warp_idx % 4, number_of_threads=64)
-            flash_a1 = flash_scale_t[{corr_cons_index}, 1, flash_local_tidx]
+            flash_a1 = {_scale_slot_expr(corr_cons_index, "1")}
 {corr_empty1_early}
             flash_need_rescale1 = cute.arch.vote_ballot_sync(flash_a1 < 1.0) != 0
             if flash_need_rescale1:
@@ -8105,12 +8192,17 @@ if warp_idx == 15:
         if flash_s_corr_cons_index == 0:
             flash_s_corr_cons_phase ^= 1
         flash_o_full_phase ^= 1"""
+    corr_prelude = (
+        "none"
+        if epi_smem and not is_causal and not has_lse and not score_plan.modifiers
+        else "decode"
+    )
     corr_block = _flash_fa4_wrap(
         "if (warp_idx >= 8) & (warp_idx < 12):",
         corr_head,
         corr_inner,
         persistent,
-        prelude="decode",
+        prelude=corr_prelude,
         tail=tmem_dealloc_arrive,
         total_tiles=total_tiles,
         num_m_pairs=num_m_pairs,
@@ -8126,7 +8218,6 @@ if warp_idx == 15:
         setup
         + epi_smem_setup
         + ("" if local_epi_tma_setup else epi_tma_setup)
-        + epi_stg_setup
         + empty_block
         + load_block
         + mma_block

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -577,36 +577,71 @@ class ConfigGeneration:
         if n <= 0:
             return [self.default_flat()]
         default_flat = self.default_flat()
+
+        if not self.config_spec.cute_flash_search_enabled:
+            result = [default_flat]
+            for flat, _config in self.user_seed_flat_config_pairs(
+                user_seed_configs, log_func
+            ):
+                if any(flat == existing for existing in result):
+                    continue
+                result.append(flat)
+                if len(result) >= n:
+                    return result[:n]
+            for flat, _config in self.seed_flat_config_pairs(log_func):
+                if any(flat == existing for existing in result):
+                    continue
+                result.append(flat)
+                if len(result) >= n:
+                    return result[:n]
+            priors_present = bool(self._config_value_priors)
+            for j in range(n - len(result)):
+                result.append(
+                    self.biased_random_flat()
+                    if priors_present and j % 2 == 0
+                    else self.random_flat()
+                )
+            return result
+
         result: list[FlatConfig] = []
+        seen: set[Config] = set()
         default_first = not self.config_spec.cute_flash_search_enabled
+
+        def append_valid(config: Config) -> bool:
+            if config in seen:
+                return False
+            seen.add(config)
+            result.append(self.flatten(config))
+            return len(result) >= n
+
+        def append_if_valid(flat: FlatConfig) -> bool:
+            try:
+                config = self.unflatten(flat)
+            except InvalidConfig:
+                return False
+            return append_valid(config)
+
         if default_first:
-            result.append(default_flat)
+            if append_if_valid(default_flat):
+                return result[:n]
 
         # Initial population order is normally default -> user seed configs ->
         # compiler seeds -> random.  Flash attention has backend-shaped compiler
         # seeds that are materially better anchors than the raw fragment default,
         # so try those seeds before the default when that search surface is active.
-        for flat, _config in self.user_seed_flat_config_pairs(
+        for _flat, config in self.user_seed_flat_config_pairs(
             user_seed_configs, log_func
         ):
-            if any(flat == existing for existing in result):
-                continue
-            result.append(flat)
-            if len(result) >= n:
+            if append_valid(config):
                 return result[:n]
 
-        for flat, _config in self.seed_flat_config_pairs(log_func):
-            if any(flat == existing for existing in result):
-                continue
-            result.append(flat)
-            if len(result) >= n:
+        for _flat, config in self.seed_flat_config_pairs(log_func):
+            if append_valid(config):
                 return result[:n]
 
         if not default_first:
-            if not any(default_flat == existing for existing in result):
-                result.append(default_flat)
-                if len(result) >= n:
-                    return result[:n]
+            if append_if_valid(default_flat):
+                return result[:n]
 
         # Fill the remainder with random configs. When the backend supplies
         # value priors, half the random fill is drawn from those priors (biased
@@ -614,11 +649,45 @@ class ConfigGeneration:
         # search keeps full coverage; with no priors every fill is uniform,
         # leaving the historical behavior unchanged.
         priors_present = bool(self._config_value_priors)
-        for j in range(n - len(result)):
+        invalid = 0
+        duplicate = 0
+        attempts = 0
+        max_attempts = max(64, (n - len(result)) * 64)
+        while len(result) < n and attempts < max_attempts:
+            j = attempts
+            attempts += 1
             if priors_present and j % 2 == 0:
-                result.append(self.biased_random_flat())
+                flat = self.biased_random_flat()
             else:
-                result.append(self.random_flat())
+                flat = self.random_flat()
+            try:
+                config = self.unflatten(flat)
+            except InvalidConfig:
+                invalid += 1
+                continue
+            if config in seen:
+                duplicate += 1
+                continue
+            seen.add(config)
+            result.append(self.flatten(config))
+        if len(result) < n and log_func is not None:
+            log_func(
+                "Generated only "
+                f"{len(result)}/{n} valid initial population configs "
+                f"after {attempts} random attempts "
+                f"({invalid} invalid, {duplicate} duplicate); "
+                "padding with duplicate valid configs."
+            )
+        if len(result) < n:
+            if not result:
+                raise InvalidConfig(
+                    "failed to generate any valid initial population configs"
+                )
+            pad_from = [copy.deepcopy(flat) for flat in result]
+            pad_idx = 0
+            while len(result) < n:
+                result.append(copy.deepcopy(pad_from[pad_idx % len(pad_from)]))
+                pad_idx += 1
         return result
 
     def random_population(
@@ -630,9 +699,18 @@ class ConfigGeneration:
     ) -> list[Config]:
         result: list[Config] = []
         attempts = 0
-        for flat in self.random_population_flat(
-            n, user_seed_configs=user_seed_configs, log_func=log_func
-        ):
+        if not self.config_spec.cute_flash_search_enabled:
+            flat_population = self.random_population_flat(
+                n, user_seed_configs=user_seed_configs, log_func=log_func
+            )
+        else:
+            try:
+                flat_population = self.random_population_flat(
+                    n, user_seed_configs=user_seed_configs, log_func=log_func
+                )
+            except InvalidConfig:
+                flat_population = []
+        for flat in flat_population:
             try:
                 result.append(self.unflatten(flat))
             except InvalidConfig:

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -30,6 +30,7 @@ from .._compat import warps_to_threads
 from .._compiler.cute.cute_flash import FLASH_CAUSAL_KV_ORDER_KEY
 from .._compiler.cute.cute_flash import FLASH_CAUSAL_LOOP_SPLIT_KEY
 from .._compiler.cute.cute_flash import FLASH_CONFIG_KEYS
+from .._compiler.cute.cute_flash import FLASH_CORR_REGS_KEY
 from .._compiler.cute.cute_flash import FLASH_E2E_FREQ_KEY
 from .._compiler.cute.cute_flash import FLASH_E2E_OFFSET0_KEY
 from .._compiler.cute.cute_flash import FLASH_E2E_OFFSET_KEY
@@ -38,7 +39,9 @@ from .._compiler.cute.cute_flash import FLASH_E2E_SCHEDULE_KEY
 from .._compiler.cute.cute_flash import FLASH_EPI_TMA_KEY
 from .._compiler.cute.cute_flash import FLASH_EXP2_IMPL_KEY
 from .._compiler.cute.cute_flash import FLASH_MASKED_E2E_SCHEDULE_KEY
+from .._compiler.cute.cute_flash import FLASH_OTHER_REGS_KEY
 from .._compiler.cute.cute_flash import FLASH_ROLE_MAP_KEY
+from .._compiler.cute.cute_flash import FLASH_SOFTMAX_REGS_KEY
 from .._compiler.cute.cute_flash import FLASH_TOPOLOGY_KEY
 from .._compiler.cute.cute_flash import _flash_causal_hd64_seed_num_kv_supported
 from .._compiler.cute.cute_flash import _flash_causal_hd64_seed_offset0
@@ -1012,6 +1015,71 @@ class ConfigSpec:
                         f"{FLASH_E2E_SCHEDULE_KEY}={config[FLASH_E2E_SCHEDULE_KEY]!r}, "
                         f"got {e2e_offset!r}"
                     )
+        self._normalize_cute_flash_register_budget(
+            config,
+            fragments,
+            effective_topology,
+            fix_invalid=fix_invalid,
+        )
+
+    def _normalize_cute_flash_register_budget(
+        self,
+        config: dict[str, object],
+        fragments: Mapping[str, ConfigSpecFragment],
+        effective_topology: str,
+        *,
+        fix_invalid: bool,
+    ) -> None:
+        if effective_topology != "fa4":
+            return
+        softmax_regs = config.get(FLASH_SOFTMAX_REGS_KEY)
+        corr_regs = config.get(FLASH_CORR_REGS_KEY)
+        other_regs = config.get(FLASH_OTHER_REGS_KEY)
+        if (
+            type(softmax_regs) is not int
+            or type(corr_regs) is not int
+            or type(other_regs) is not int
+        ):
+            return
+        budget = 2 * softmax_regs + corr_regs + other_regs
+        if budget <= 512:
+            return
+        message = (
+            "FA4 register budget exceeds 512: "
+            f"2 * {FLASH_SOFTMAX_REGS_KEY} ({softmax_regs}) + "
+            f"{FLASH_CORR_REGS_KEY} ({corr_regs}) + "
+            f"{FLASH_OTHER_REGS_KEY} ({other_regs}) = {budget}"
+        )
+        if not fix_invalid:
+            raise InvalidConfig(message)
+
+        def _int_choices(key: str) -> tuple[int, ...]:
+            fragment = cast("EnumFragment", fragments[key])
+            return tuple(value for value in fragment.choices if type(value) is int)
+
+        current = (softmax_regs, corr_regs, other_regs)
+        best: tuple[tuple[int, int, int], tuple[int, int, int]] | None = None
+        for softmax_candidate in _int_choices(FLASH_SOFTMAX_REGS_KEY):
+            for corr_candidate in _int_choices(FLASH_CORR_REGS_KEY):
+                for other_candidate in _int_choices(FLASH_OTHER_REGS_KEY):
+                    candidate = (softmax_candidate, corr_candidate, other_candidate)
+                    if 2 * softmax_candidate + corr_candidate + other_candidate > 512:
+                        continue
+                    score = (
+                        sum(a != b for a, b in zip(candidate, current, strict=True)),
+                        sum(
+                            abs(a - b) for a, b in zip(candidate, current, strict=True)
+                        ),
+                        -softmax_candidate,
+                    )
+                    if best is None or score < best[0]:
+                        best = (score, candidate)
+        if best is None:
+            raise InvalidConfig(message)
+        _score, (softmax_regs, corr_regs, other_regs) = best
+        config[FLASH_SOFTMAX_REGS_KEY] = softmax_regs
+        config[FLASH_CORR_REGS_KEY] = corr_regs
+        config[FLASH_OTHER_REGS_KEY] = other_regs
 
     def enable_cute_flash_search(
         self,

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -4023,8 +4023,10 @@ class TestCuteAutotuner(TestCase):
         self.assertEqual(manual_config[FLASH_RESCALE_CHUNK_COLS_KEY], 64)
         manual_corr_config = dict(attn_bound.config_spec.default_config().config)
         manual_corr_config[FLASH_CORR_REGS_KEY] = 72
+        manual_corr_config[FLASH_OTHER_REGS_KEY] = 40
         attn_bound.config_spec.normalize(manual_corr_config)
         self.assertEqual(manual_corr_config[FLASH_CORR_REGS_KEY], 72)
+        self.assertEqual(manual_corr_config[FLASH_OTHER_REGS_KEY], 40)
         manual_bad_corr_config = dict(attn_bound.config_spec.default_config().config)
         manual_bad_corr_config[FLASH_CORR_REGS_KEY] = 96
         with self.assertRaises(exc.InvalidConfig):
@@ -4863,9 +4865,11 @@ class TestCuteAutotuner(TestCase):
         long_manual_corr = helion.Config(
             block_sizes=[1, 128, 128],
             cute_flash_corr_regs=72,
+            cute_flash_other_regs=40,
         )
         long_bound.config_spec.normalize(long_manual_corr)
         self.assertEqual(long_manual_corr.config[FLASH_CORR_REGS_KEY], 72)
+        self.assertEqual(long_manual_corr.config[FLASH_OTHER_REGS_KEY], 40)
         long_manual_inf_threshold = helion.Config(
             block_sizes=[1, 128, 128],
             cute_flash_rescale_threshold=math.inf,
@@ -6555,8 +6559,57 @@ class TestConfigValuePriors(TestCase):
         ):
             # 1 default + 10 random fill slots (seeds suppressed above).
             gen.random_population_flat(11)
-        self.assertEqual(biased.call_count, 5)
-        self.assertEqual(uniform.call_count, 5)
+        # Duplicate or invalid draws are retried, but attempts continue to
+        # alternate between biased and uniform sampling.
+        self.assertGreaterEqual(biased.call_count + uniform.call_count, 10)
+        self.assertLessEqual(abs(biased.call_count - uniform.call_count), 1)
+
+    def test_population_fill_pads_after_unique_configs_exhausted(self) -> None:
+        gen, _ = self._add_config_gen()
+        default_flat = gen.default_flat()
+        normalized = gen.unflatten(default_flat)
+        gen.config_spec.cute_flash_search_enabled = True
+        with (
+            patch.object(gen, "default_flat", return_value=default_flat),
+            patch.object(gen, "user_seed_flat_config_pairs", return_value=[]),
+            patch.object(gen, "seed_flat_config_pairs", return_value=[]),
+            patch.object(gen, "biased_random_flat", return_value=default_flat),
+            patch.object(gen, "random_flat", return_value=default_flat),
+            patch.object(gen, "unflatten", return_value=normalized),
+            patch.object(gen, "flatten", return_value=default_flat),
+        ):
+            population = gen.random_population_flat(6)
+        self.assertEqual(population, [default_flat] * 6)
+
+    def test_flash_population_stores_normalized_flat_configs(self) -> None:
+        gen, _ = self._add_config_gen()
+        default_flat = gen.default_flat()
+        normalized = gen.unflatten(default_flat)
+        gen.config_spec.cute_flash_search_enabled = True
+        canonical_flat = [*default_flat]
+        with (
+            patch.object(gen, "default_flat", return_value=default_flat),
+            patch.object(gen, "user_seed_flat_config_pairs", return_value=[]),
+            patch.object(gen, "seed_flat_config_pairs", return_value=[]),
+            patch.object(gen, "unflatten", return_value=normalized),
+            patch.object(gen, "flatten", return_value=canonical_flat) as flatten,
+        ):
+            population = gen.random_population_flat(1)
+        self.assertEqual(population, [canonical_flat])
+        flatten.assert_called_once_with(normalized)
+
+    def test_non_flash_population_propagates_generation_failure(self) -> None:
+        gen, _ = self._add_config_gen()
+        gen.config_spec.cute_flash_search_enabled = False
+        with (
+            patch.object(
+                gen,
+                "random_population_flat",
+                side_effect=exc.InvalidConfig("invalid default"),
+            ),
+            self.assertRaisesRegex(exc.InvalidConfig, "invalid default"),
+        ):
+            gen.random_population(1)
 
 
 if __name__ == "__main__":

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -4420,12 +4420,18 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         # Future heuristics may add more compiler seeds; this test only
         # requires the CuTe cluster-m2 seed to be present.
         self.assertGreaterEqual(len(acf_configs), 2)
-        self.assertEqual(
+        acf_seed_configs = [
+            config
+            for config in acf_configs
+            if config.config["advanced_controls_file"] == "/tmp/helion-test.acf"
+        ]
+        self.assertGreaterEqual(len(acf_seed_configs), 1)
+        self.assertLessEqual(
             {config.config["advanced_controls_file"] for config in acf_configs},
-            {"/tmp/helion-test.acf"},
+            {"", "/tmp/helion-test.acf"},
         )
         self._assert_cute_tcgen05_cluster_m2_seeded(
-            acf_configs,
+            acf_seed_configs,
             expected_block_k=128,
             expected_indexing_length=3,
         )

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -22,6 +22,7 @@ from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion.exc import BackendUnsupported
 from helion.exc import CuteBackendUnavailable
+from helion.exc import InvalidConfig
 import helion.language as hl
 from helion.runtime import _build_cute_schema_and_args
 from helion.runtime import _cute_cluster_shape
@@ -2465,6 +2466,36 @@ class TestCuteBackend(TestCase):
                 expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
                 torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
+    def test_flash_attention_fa4_zero_threshold_publishes_computed_alpha(
+        self,
+    ) -> None:
+        q = torch.ones(1, 1, 256, 64, dtype=torch.float16, device=DEVICE)
+        k = torch.zeros_like(q)
+        k[:, :, 128:, :] = math.log(2.0) / 8.0
+        v = torch.zeros_like(q)
+        v[:, :, :128, :] = 1.0
+        code, out = code_and_output(
+            cute_dense_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+            cute_flash_topology="fa4",
+            cute_flash_softmax_disc=False,
+            cute_flash_exp2_impl="split",
+            cute_flash_rescale_threshold=0.0,
+        )
+
+        exp_call = code.index("flash_p_sum = _helion_flash_rt.fa4_sp_exp_convert_store")
+        alpha_compute = code.index("flash_alpha = cute.math.exp2(", exp_call)
+        rowsum_update = code.index(
+            "flash_row_sum = flash_row_sum * flash_alpha", alpha_compute
+        )
+        alpha_publish = code.index(" = flash_alpha", alpha_compute, rowsum_update)
+        self.assertLess(exp_call, alpha_compute)
+        self.assertLess(alpha_compute, alpha_publish)
+
+        expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
     def test_flash_attention_fa4_fp16_rescale_threshold_stays_finite(self) -> None:
         q = torch.ones(1, 1, 256, 64, dtype=torch.float16, device=DEVICE)
         k = torch.zeros_like(q)
@@ -3886,6 +3917,33 @@ class TestCuteBackend(TestCase):
         self.assertEqual(cfg.softmax_regs, 200)
         self.assertEqual(cfg.corr_regs, 64)
         self.assertEqual(cfg.other_regs, 48)
+
+    def test_flash_attention_fa4_register_budget_validation(self) -> None:
+        q, k, v = (
+            torch.empty(1, 1, 8192, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        bound = cute_dense_attention.bind((q, k, v))
+        self.assertTrue(bound.config_spec.cute_flash_search_enabled)
+
+        bad = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_topology="fa4",
+            cute_flash_softmax_regs=200,
+            cute_flash_corr_regs=80,
+            cute_flash_other_regs=40,
+        )
+        with self.assertRaisesRegex(InvalidConfig, "FA4 register budget exceeds 512"):
+            bound.config_spec.normalize(bad)
+
+        fixed = helion.Config.from_dict(bad.config)
+        bound.config_spec.normalize(fixed, _fix_invalid=True)
+        total = (
+            2 * fixed.config["cute_flash_softmax_regs"]
+            + fixed.config["cute_flash_corr_regs"]
+            + fixed.config["cute_flash_other_regs"]
+        )
+        self.assertLessEqual(total, 512)
 
     def test_flash_attention_dense_hd64_corr_reg_seed_buckets(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
@@ -7669,11 +7727,7 @@ class TestCuteConfigValuePriors(TestCase):
         with patch(
             "random.choices", side_effect=lambda values, weights, k: [values[0]]
         ):
-            population = [
-                gen.unflatten(flat).config for flat in gen.random_population_flat(4)
-            ]
-        self.assertEqual(len(population), 4)
-        biased_config = population[1]
+            biased_config = gen.unflatten(gen.biased_random_flat()).config
         self.assertEqual(biased_config[FLASH_TOPOLOGY_KEY], "fa4")
         self.assertEqual(biased_config[FLASH_E2E_SCHEDULE_KEY], "8/2")
         self.assertEqual(biased_config[FLASH_MASKED_E2E_SCHEDULE_KEY], "inherit")
@@ -7771,7 +7825,14 @@ class TestCuteConfigValuePriors(TestCase):
                 gen.unflatten(flat).config for flat in gen.random_population_flat(4)
             ]
         self.assertEqual(len(population), 4)
-        biased_config = population[1]
+        biased_config = next(
+            config
+            for config in population
+            if config[FLASH_CAUSAL_LPT_SWIZZLE_KEY] == 1
+            and config[FLASH_CAUSAL_KV_ORDER_KEY] == "descending"
+            and config[FLASH_MASKED_E2E_SCHEDULE_KEY] == "16/4"
+            and config[FLASH_ROLE_MAP_KEY] == "helion"
+        )
         self.assertEqual(biased_config[FLASH_CAUSAL_LPT_SWIZZLE_KEY], 1)
         self.assertEqual(biased_config[FLASH_CAUSAL_KV_ORDER_KEY], "descending")
         self.assertEqual(biased_config[FLASH_MASKED_E2E_SCHEDULE_KEY], "16/4")


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3147
 * #3146
 * #3145
 * #3144
 * __->__#3143
 * #3142
 * #3141
 * #3140
 * #3139


--- --- ---

[cutedsl] Constrain FA4 resource use during autotuning

Scope statistic and correction epilogue views after synchronization to reduce live register pressure. Enforce the FA4 role budget and canonicalize valid, unique flash-search populations without changing non-flash population behavior.