### PR TITLE
[cutedsl] Optimize dense HD64 two-CTA flash attention

### DIFF
--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -8,6 +8,7 @@
 # real module compiled without that flag, and be imported by the generated code.
 import functools
 from functools import partial
+from itertools import starmap
 from typing import Any
 from typing import cast
 
@@ -205,6 +206,8 @@ def mbarrier_arrive(
 ) -> None:
     if cutlass.const_expr(peer_cta_rank is None):
         cute.arch.mbarrier_arrive(pfor_ptr_stage)
+    elif cutlass.const_expr(self_cta_rank is None):
+        cute.arch.mbarrier_arrive(pfor_ptr_stage, peer_cta_rank)
     else:
 
         def local_arrive() -> None:
@@ -321,6 +324,41 @@ def ex2_emulation_2(x: Float32, y: Float32) -> tuple:
     x_out = _combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0])
     y_out = _combine_int_frac_ex2(xy_rounded[1], xy_frac_ex2[1])
     return x_out, y_out
+
+
+def ex2_emulation_batch(pairs: list[tuple]) -> list[tuple]:
+    """Level-schedule software exp2 for independent packed pairs."""
+    xy_clamped = [
+        (cute.arch.fmax(x, -127.0), cute.arch.fmax(y, -127.0)) for x, y in pairs
+    ]
+    xy_rounded = [
+        cute.arch.add_packed_f32x2(
+            pair,
+            (_FP32_ROUND_INT, _FP32_ROUND_INT),
+            rnd="rm",
+        )
+        for pair in xy_clamped
+    ]
+    xy_rounded_back = [
+        _sub_packed_f32x2(pair, (_FP32_ROUND_INT, _FP32_ROUND_INT))
+        for pair in xy_rounded
+    ]
+    xy_frac = list(
+        starmap(_sub_packed_f32x2, zip(xy_clamped, xy_rounded_back, strict=True))
+    )
+    xy_frac_ex2 = [(_POLY_EX2_DEG3[-1], _POLY_EX2_DEG3[-1]) for _ in pairs]
+    for coefficient in reversed(_POLY_EX2_DEG3[:-1]):
+        xy_frac_ex2 = [
+            _fma_packed_f32x2(poly, frac, (coefficient, coefficient))
+            for poly, frac in zip(xy_frac_ex2, xy_frac, strict=True)
+        ]
+    return [
+        (
+            _combine_int_frac_ex2(rounded[0], frac_ex2[0]),
+            _combine_int_frac_ex2(rounded[1], frac_ex2[1]),
+        )
+        for rounded, frac_ex2 in zip(xy_rounded, xy_frac_ex2, strict=True)
+    ]
 
 
 def exp2_split_inplace(
@@ -947,6 +985,8 @@ def _disc_chunk_exp(
     e2e_res: int,
     e2e_offset: int,
     last_frag: bool,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
 ) -> None:
     """In-place packed scale-subtract then exp2(pipe-split) over ONE 32-elem chunk.
 
@@ -956,18 +996,56 @@ def _disc_chunk_exp(
     Verbatim from the serial ``fa4_disc_exp_convert_store`` body; factored out so the
     serial and software-pipelined pass2 share the SAME per-chunk numerics."""
     nf = cute.size(frg)
-    for i in range(0, nf, 2):
-        r0, r1 = cute.arch.fma_packed_f32x2(
-            (frg[i], frg[i + 1]),
-            (scale, scale),
-            (minus_max_scale, minus_max_scale),
-        )
-        use_xu = ((i + e2e_offset) % e2e_freq) < (e2e_freq - e2e_res) or last_frag
-        if use_xu:
-            frg[i] = cute.arch.exp2(r0)
-            frg[i + 1] = cute.arch.exp2(r1)
-        else:
-            frg[i], frg[i + 1] = ex2_emulation_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
+    if pair_batch == 1:
+        # Preserve the established instruction order for every caller that does
+        # not explicitly opt into cross-pair scheduling.
+        for i in range(0, nf, 2):
+            r0, r1 = cute.arch.fma_packed_f32x2(
+                (frg[i], frg[i + 1]),
+                (scale, scale),
+                (minus_max_scale, minus_max_scale),
+            )
+            use_xu = ((i + e2e_offset) % e2e_freq) < (e2e_freq - e2e_res) or last_frag
+            if use_xu:
+                frg[i] = cute.arch.exp2(r0)
+                frg[i + 1] = cute.arch.exp2(r1)
+            else:
+                frg[i], frg[i + 1] = ex2_emulation_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
+        return
+    assert pair_batch > 0 and nf % (2 * pair_batch) == 0
+    assert emu_batch > 0
+    for batch_start in range(0, nf, 2 * pair_batch):
+        scaled = []
+        for pair in range(pair_batch):
+            i = batch_start + 2 * pair
+            r0, r1 = cute.arch.fma_packed_f32x2(
+                (frg[i], frg[i + 1]),
+                (scale, scale),
+                (minus_max_scale, minus_max_scale),
+            )
+            use_xu = ((i + e2e_offset) % e2e_freq) < (e2e_freq - e2e_res) or last_frag
+            scaled.append((i, r0, r1, use_xu))
+        pending_indices = []
+        pending_values = []
+        for i, r0, r1, use_xu in scaled:
+            if use_xu:
+                frg[i] = cute.arch.exp2(r0)
+                frg[i + 1] = cute.arch.exp2(r1)
+            elif emu_batch == 1:
+                frg[i], frg[i + 1] = ex2_emulation_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
+            else:
+                pending_indices.append(i)
+                pending_values.append((r0, r1))
+                if len(pending_values) == emu_batch:
+                    results = ex2_emulation_batch(pending_values)
+                    for pending_i, result in zip(pending_indices, results, strict=True):
+                        frg[pending_i], frg[pending_i + 1] = result
+                    pending_indices = []
+                    pending_values = []
+        if pending_values:
+            results = ex2_emulation_batch(pending_values)
+            for pending_i, result in zip(pending_indices, results, strict=True):
+                frg[pending_i], frg[pending_i + 1] = result
 
 
 def _disc_chunk_convert_store(
@@ -2018,6 +2096,9 @@ def _fa4_sp_exp_convert_store_impl(
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
     whole_row_sum: bool = False,
+    early_split_publish: bool = False,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
     *,
     loc: object = None,
     ip: object = None,
@@ -2029,29 +2110,71 @@ def _fa4_sp_exp_convert_store_impl(
     src = cute.logical_divide(tLDrS, cute.make_layout(32))
     dst = cute.logical_divide(tSTrS_e, cute.make_layout(32))
     frag_count = cute.size(tLDrS) // 32
-    for ci in range(frag_count):
-        frg = cast("cute.Tensor", src[None, ci])
-        _disc_chunk_exp(
-            frg,
-            scale,
-            minus_max_scale,
-            e2e_freq,
-            e2e_res,
-            e2e_offset,
-            ci >= frag_count - 1,
-        )
-        cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
-    for ci in range(p_store_chunks):
-        cute.copy(tiled_st, tSTrS[None, None, ci], tSTtS[None, None, ci])
-        if cutlass.const_expr(pfor2_ptr_stage is not None):
-            if ci == p_store_split - 1:
-                cute.arch.fence_view_async_tmem_store()
-                mbarrier_arrive(pfor_ptr_stage, pfor_peer_cta_rank, pfor_self_cta_rank)
-    cute.arch.fence_view_async_tmem_store()
-    if cutlass.const_expr(pfor2_ptr_stage is None):
+    if cutlass.const_expr(early_split_publish and pfor2_ptr_stage is not None):
+        for ci in range(p_store_split):
+            frg = cast("cute.Tensor", src[None, ci])
+            _disc_chunk_exp(
+                frg,
+                scale,
+                minus_max_scale,
+                e2e_freq,
+                e2e_res,
+                e2e_offset,
+                ci >= frag_count - 1,
+                pair_batch,
+                emu_batch,
+            )
+            cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
+        for ci in range(p_store_split):
+            cute.copy(tiled_st, tSTrS[None, None, ci], tSTtS[None, None, ci])
+        cute.arch.fence_view_async_tmem_store()
         mbarrier_arrive(pfor_ptr_stage, pfor_peer_cta_rank, pfor_self_cta_rank)
-    else:
+        for ci in range(p_store_split, frag_count):
+            frg = cast("cute.Tensor", src[None, ci])
+            _disc_chunk_exp(
+                frg,
+                scale,
+                minus_max_scale,
+                e2e_freq,
+                e2e_res,
+                e2e_offset,
+                ci >= frag_count - 1,
+                pair_batch,
+                emu_batch,
+            )
+            cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
+        for ci in range(p_store_split, p_store_chunks):
+            cute.copy(tiled_st, tSTrS[None, None, ci], tSTtS[None, None, ci])
+        cute.arch.fence_view_async_tmem_store()
         mbarrier_arrive(pfor2_ptr_stage, pfor_peer_cta_rank, pfor_self_cta_rank)
+    else:
+        for ci in range(frag_count):
+            frg = cast("cute.Tensor", src[None, ci])
+            _disc_chunk_exp(
+                frg,
+                scale,
+                minus_max_scale,
+                e2e_freq,
+                e2e_res,
+                e2e_offset,
+                ci >= frag_count - 1,
+                pair_batch,
+                emu_batch,
+            )
+            cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
+        for ci in range(p_store_chunks):
+            cute.copy(tiled_st, tSTrS[None, None, ci], tSTtS[None, None, ci])
+            if cutlass.const_expr(pfor2_ptr_stage is not None):
+                if ci == p_store_split - 1:
+                    cute.arch.fence_view_async_tmem_store()
+                    mbarrier_arrive(
+                        pfor_ptr_stage, pfor_peer_cta_rank, pfor_self_cta_rank
+                    )
+        cute.arch.fence_view_async_tmem_store()
+        if cutlass.const_expr(pfor2_ptr_stage is None):
+            mbarrier_arrive(pfor_ptr_stage, pfor_peer_cta_rank, pfor_self_cta_rank)
+        else:
+            mbarrier_arrive(pfor2_ptr_stage, pfor_peer_cta_rank, pfor_self_cta_rank)
     if cutlass.const_expr(whole_row_sum):
         return fadd_reduce_packed(tLDrS)
     p_sum = cutlass.Float32(0.0)
@@ -2078,6 +2201,9 @@ def fa4_sp_exp_convert_store(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    early_split_publish: bool = False,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
     *,
     loc: object = None,
     ip: object = None,
@@ -2100,6 +2226,10 @@ def fa4_sp_exp_convert_store(
         io_dtype,
         pfor_peer_cta_rank,
         pfor_self_cta_rank,
+        False,
+        early_split_publish,
+        pair_batch,
+        emu_batch,
     )
 
 
@@ -2121,6 +2251,9 @@ def fa4_sp_exp_convert_store_whole_rowsum(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    early_split_publish: bool = False,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
     *,
     loc: object = None,
     ip: object = None,
@@ -2144,6 +2277,9 @@ def fa4_sp_exp_convert_store_whole_rowsum(
         pfor_peer_cta_rank,
         pfor_self_cta_rank,
         True,
+        early_split_publish,
+        pair_batch,
+        emu_batch,
     )
 
 

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -1866,14 +1866,33 @@ def resolve_flash_config(
     use_2cta_cfg = _cfg(FLASH_USE_2CTA_KEY)
     if use_2cta_cfg is not None:
         use_2cta_instrs = bool(use_2cta_cfg)
-    if topology != "fa4" or is_causal or num_kv % 4 != 0 or head_dim != 128:
+    dense_hd64_2cta = (
+        head_dim == 64 and 256 <= num_kv <= 1024 and dtype is torch.float16
+    )
+    if (
+        topology != "fa4"
+        or is_causal
+        or num_kv % 4 != 0
+        or (head_dim != 128 and not dense_hd64_2cta)
+    ):
         use_2cta_instrs = False
-    if use_2cta_instrs:
+    if use_2cta_instrs and head_dim == 128:
         precompute_qk_desc = False
         if epi_stg_gmem == "pair":
             # Pair destinations span both CTA rows; without a rank slice the two
             # CTAs alias the same output half.
             epi_stg_gmem = "stage"
+    if use_2cta_instrs and dense_hd64_2cta:
+        # This family was characterized as a unit: the TMA epilogue and Rep16
+        # split publication are required to beat the established one-CTA seed.
+        epi_tma = True
+        epi_stg = False
+        epi_stg_gmem = "stage"
+        p_store_repetition = 16
+        split_p_arrive = True
+        softmax_disc = False
+        s_load_repetition = 32
+        precompute_qk_desc = True
     use_cga2_local_default = (
         _flash_dense_hd64_seed_cga2_local(num_kv) if long_dense_hd64_fa4 else False
     )
@@ -2436,6 +2455,11 @@ def flash_attention_value_prior_weights(
             {
                 FLASH_S_STAGE_KEY: {2: 1.0},
                 FLASH_TOPOLOGY_KEY: {"fa4": 4.0, "ws_overlap": 1.0},
+                FLASH_USE_2CTA_KEY: (
+                    {True: 4.0, False: 2.0}
+                    if num_kv == 512 and dtype is torch.float16
+                    else {False: 1.0}
+                ),
                 FLASH_PERSISTENT_KEY: {True: 1.0},
                 FLASH_PERSISTENT_CTAS_PER_SM_KEY: {
                     persistent_ctas_per_sm: 4.0,
@@ -3925,7 +3949,18 @@ def flash_autotune_fragments(
         and head_dim == 128
         and num_kv % 4 == 0
     )
-    use_2cta_eligible = dense_hd128_fa4
+    dense_hd64_2cta_fa4 = (
+        topology_choices[0] == "fa4"
+        and not is_causal
+        and head_dim == 64
+        and 256 <= num_kv <= 1024
+        and num_kv % 4 == 0
+        and dtype is torch.float16
+        and not has_kv_tile_pruning
+        and not requires_ws_overlap
+        and not small_biased_candidate
+    )
+    use_2cta_eligible = dense_hd128_fa4 or dense_hd64_2cta_fa4
     use_2cta_choices = (
         _flash_choices_with_default(defaults.use_2cta_instrs, (False, True))
         if use_2cta_eligible
@@ -6158,6 +6193,7 @@ def emit_flash_fa4_device_body(
     )
     cta_group_size = 2 if use_2cta_instrs else 1
     mma_m = 256 if use_2cta_instrs else 128
+    dense_hd64_2cta = use_2cta_instrs and hd == 64
     pfor2_count = 2 * 128 if use_2cta_instrs else 128
     pfor_count = (
         pfor2_count
@@ -6166,8 +6202,9 @@ def emit_flash_fa4_device_body(
         if use_2cta_instrs
         else 2 * 128
     )
+    pfor_self_cta_rank = "None" if dense_hd64_2cta else "flash_mma_tile_coord_v"
     pfor_peer_arg = (
-        ", cutlass.Int32(0), flash_mma_tile_coord_v" if use_2cta_instrs else ""
+        f", cutlass.Int32(0), {pfor_self_cta_rank}" if use_2cta_instrs else ""
     )
     commit_group_arg = (
         ", flash_tcgen05_mcast_mask, cute_tcgen05_flash.CtaGroup.TWO"
@@ -6201,11 +6238,14 @@ def emit_flash_fa4_device_body(
     kv_loop_bound = "flash_num_active_kv" if is_causal else "_flash_num_kv_tiles"
     kv_loop_bound_minus_1 = f"{kv_loop_bound} - 1"
     epi_smem = cfg.epi_tma or cfg.epi_stg
-    role_chain_default = _flash_role_chain_default(
-        hd=hd, num_kv=num_kv, is_causal=is_causal, role_map=cfg.role_map
+    role_chain_default = (
+        _flash_role_chain_default(
+            hd=hd, num_kv=num_kv, is_causal=is_causal, role_map=cfg.role_map
+        )
+        or dense_hd64_2cta
     )
     role_chain = (
-        not use_2cta_instrs
+        (not use_2cta_instrs or dense_hd64_2cta)
         and not use_cga2_local_cta
         and not use_clc_scheduler
         and _flash_bool_env("HELION_CUTE_FLASH_ROLE_CHAIN", role_chain_default)
@@ -7918,7 +7958,12 @@ if warp_idx == 15:
                     io_dtype,
                 ]
             if use_2cta_instrs:
-                sp_pass2_args.extend(["cutlass.Int32(0)", "flash_mma_tile_coord_v"])
+                sp_pass2_args.extend(["cutlass.Int32(0)", pfor_self_cta_rank])
+                if dense_hd64_2cta and not mixed_p_store:
+                    # Eight packed pairs expose enough affine/exp ILP to hide the
+                    # dependency chain without the register pressure of a full
+                    # 32-value fragment. Level-schedule the two software-exp pairs.
+                    sp_pass2_args.extend(["True", "8", "2"])
             sp_exp_block = (
                 f"            flash_p_sum = _helion_flash_rt.{sp_pass2_name}("
                 + ", ".join(sp_pass2_args)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -2624,6 +2624,36 @@ class TestCuteBackend(TestCase):
         self.assertTrue(cfg.epi_stg)
         self.assertEqual(cfg.epi_stg_gmem, "stage")
 
+    def test_flash_attention_fa4_dense_hd64_two_cta_matches_sdpa(self) -> None:
+        for seq_len in (32768, 65536, 131072):
+            with self.subTest(seq_len=seq_len):
+                q, k, v = (
+                    torch.randn(1, 1, seq_len, 64, dtype=torch.float16, device=DEVICE)
+                    for _ in range(3)
+                )
+                code, out = code_and_output(
+                    cute_dense_attention,
+                    (q, k, v),
+                    block_sizes=[1, 128, 128],
+                    cute_flash_topology="fa4",
+                    cute_flash_persistent=True,
+                    cute_flash_use_2cta=True,
+                    cute_flash_epi_tma=True,
+                )
+
+                self.assertIn("cta_group=2", code)
+                self.assertIn("is_two_cta=True", code)
+                self.assertIn("elif warp_idx < 4:", code)
+                self.assertIn("mbarrier_init(flash_pfor_ptr + flash_st, 512)", code)
+                self.assertIn("mbarrier_init(flash_pfor2_ptr + flash_st, 256)", code)
+                self.assertIn("fa4_correction_epilogue_to_smem_scoped_2cta", code)
+                self.assertIn("'use_2cta_instrs': True", code)
+                self.assertIn("gemm_ptx_precomputed_qk_static", code)
+                self.assertIn(", True, 8, 2)", code)
+
+                expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+                torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
     def test_flash_attention_clc_preserves_explicit_flattened_geometry(self) -> None:
         q, k, v = (
             torch.randn(2, 32, 8192, 64, dtype=torch.float16, device=DEVICE)
@@ -4100,6 +4130,76 @@ class TestCuteBackend(TestCase):
         self.assertFalse(cfg_128k.epi_stg)
         self.assertFalse(cfg_256k.epi_tma)
         self.assertTrue(cfg_256k.epi_stg)
+
+    def test_flash_attention_dense_hd64_two_cta_eligibility(self) -> None:
+        force_two_cta = {
+            "cute_flash_topology": "fa4",
+            "cute_flash_use_2cta": True,
+            "cute_flash_precompute_qk_desc": True,
+            "cute_flash_epi_tma": False,
+            "cute_flash_epi_stg": True,
+            "cute_flash_epi_stg_gmem": "pair",
+            "cute_flash_p_store_rep": 32,
+            "cute_flash_s_load_rep": 16,
+            "cute_flash_softmax_disc": True,
+            "cute_flash_split_p_arrive": False,
+        }
+        with patch.dict(os.environ, {}, clear=True):
+            dense_64k = resolve_flash_config(64, 512, force_two_cta)
+            dense_32k = resolve_flash_config(64, 256, force_two_cta)
+            dense_128k = resolve_flash_config(64, 1024, force_two_cta)
+            dense_unaligned = resolve_flash_config(64, 258, force_two_cta)
+            dense_256k = resolve_flash_config(64, 2048, force_two_cta)
+            dense_bf16 = resolve_flash_config(
+                64, 512, force_two_cta, dtype=torch.bfloat16
+            )
+            causal = resolve_flash_config(64, 512, force_two_cta, is_causal=True)
+            dense_hd128 = resolve_flash_config(128, 512, force_two_cta)
+
+        self.assertTrue(dense_64k.use_2cta_instrs)
+        self.assertTrue(dense_64k.precompute_qk_desc)
+        self.assertTrue(dense_64k.epi_tma)
+        self.assertFalse(dense_64k.epi_stg)
+        self.assertEqual(dense_64k.epi_stg_gmem, "stage")
+        self.assertEqual(dense_64k.p_store_repetition, 16)
+        self.assertEqual(dense_64k.s_load_repetition, 32)
+        self.assertFalse(dense_64k.softmax_disc)
+        self.assertTrue(dense_64k.split_p_arrive)
+        self.assertTrue(dense_32k.use_2cta_instrs)
+        self.assertTrue(dense_128k.use_2cta_instrs)
+        self.assertFalse(dense_unaligned.use_2cta_instrs)
+        self.assertFalse(dense_256k.use_2cta_instrs)
+        self.assertFalse(dense_bf16.use_2cta_instrs)
+        self.assertFalse(causal.use_2cta_instrs)
+        self.assertTrue(dense_hd128.use_2cta_instrs)
+        self.assertFalse(dense_hd128.precompute_qk_desc)
+
+        fragments = _cute_flash.flash_autotune_fragments(64, 512)
+        two_cta = fragments[_cute_flash.FLASH_USE_2CTA_KEY]
+        epi_tma = fragments[_cute_flash.FLASH_EPI_TMA_KEY]
+        self.assertEqual(set(two_cta.search_choices or ()), {False, True})
+        self.assertEqual(epi_tma.search_choices, (False,))
+
+        eligible_32k = _cute_flash.flash_autotune_fragments(64, 256)
+        self.assertEqual(
+            set(eligible_32k[_cute_flash.FLASH_USE_2CTA_KEY].search_choices or ()),
+            {False, True},
+        )
+        eligible_128k = _cute_flash.flash_autotune_fragments(64, 1024)
+        self.assertEqual(
+            set(eligible_128k[_cute_flash.FLASH_USE_2CTA_KEY].search_choices or ()),
+            {False, True},
+        )
+        ineligible_unaligned = _cute_flash.flash_autotune_fragments(64, 258)
+        self.assertEqual(
+            ineligible_unaligned[_cute_flash.FLASH_USE_2CTA_KEY].search_choices,
+            (False,),
+        )
+        ineligible = _cute_flash.flash_autotune_fragments(64, 2048)
+        self.assertEqual(
+            ineligible[_cute_flash.FLASH_USE_2CTA_KEY].search_choices,
+            (False,),
+        )
 
     def test_flash_attention_fa4_persistent_config_overrides_env(self) -> None:
         with patch.dict(os.environ, {"HELION_CUTE_FLASH_PERSISTENT": "1"}, clear=True):


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3147
 * #3146
 * #3145
 * #3144
 * #3143
 * #3142
 * #3141
 * #3140
 * #3139


--- --- ---

[cutedsl] Optimize dense HD64 two-CTA flash attention

Enable the characterized two-CTA bundle for aligned noncausal fp16 HD64 shapes from 32K through 128K. Batch software exp2 work and publish the first probability split early while preserving one-CTA defaults.