### PR TITLE
cute: remove redundant subprocess-autotune DSL recompiles

### DIFF
--- a/helion/autotuner/benchmark_job.py
+++ b/helion/autotuner/benchmark_job.py
@@ -59,6 +59,78 @@ class AccuracyCheckResult:
     message: str = ""
 
 
+@dataclasses.dataclass(frozen=True)
+class BenchmarkAndAccuracyResult:
+    """Combined result of a fused benchmark + accuracy job.
+
+    ``latency`` is the measured time in ms.  ``accuracy`` is the accuracy
+    check outcome, or ``None`` when no baseline was supplied (accuracy check
+    disabled or a custom baseline fn forces the in-process fallback).
+    """
+
+    latency: float
+    accuracy: AccuracyCheckResult | None = None
+
+
+@dataclasses.dataclass
+class BenchmarkAndAccuracyJob:
+    """Time ``fn`` and (optionally) accuracy-check it in a single worker job.
+
+    Loading the compiled fn is what triggers the (expensive, for the CuTe DSL
+    backend) first-call compile.  Running the timing and the accuracy check as
+    two separate worker jobs re-loads the fn twice and therefore compiles it
+    twice.  This fused job loads the fn once and reuses the same in-memory
+    compiled object for both the timed benchmark and the accuracy check, so the
+    compile is paid once -- matching the in-process path -- while keeping both
+    steps inside the killable worker (an IMA in either step kills the worker,
+    not the parent).
+
+    ``baseline_path`` is ``None`` when the accuracy check is disabled; the job
+    then only times ``fn``.
+    """
+
+    fn_spec: SerializedCompiledFunction
+    args_path: str
+    baseline_path: str | None
+    atol: float
+    rtol: float
+    warmup: int = 1
+    rep: int = 50
+    use_wall_clock: bool = False
+
+    def __call__(self) -> BenchmarkAndAccuracyResult:
+        with capture_output():
+            fn = _load_compiled_fn(self.fn_spec)
+            args = load_trusted_kernel_args(self.args_path)
+            bench = do_bench_generic if self.use_wall_clock else do_bench
+            latency = cast(
+                "float",
+                bench(
+                    functools.partial(fn, *args),
+                    return_mode="median",
+                    warmup=self.warmup,
+                    rep=self.rep,
+                ),
+            )
+            if self.baseline_path is None:
+                return BenchmarkAndAccuracyResult(latency=latency, accuracy=None)
+            # Reuse the already-loaded (already-compiled) fn for the accuracy
+            # check; no second compile.
+            baseline_output = _load_trusted_baseline_output(self.baseline_path)
+            output = fn(*args)
+            synchronize_device()
+
+        try:
+            assert_close(output, baseline_output, atol=self.atol, rtol=self.rtol)
+        except AssertionError as e:
+            return BenchmarkAndAccuracyResult(
+                latency=latency, accuracy=AccuracyCheckResult(ok=False, message=str(e))
+            )
+        return BenchmarkAndAccuracyResult(
+            latency=latency, accuracy=AccuracyCheckResult(ok=True)
+        )
+
+
 @dataclasses.dataclass
 class AccuracyCheckJob:
     fn_spec: SerializedCompiledFunction

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -32,6 +32,8 @@ from .accuracy import assert_close as _assert_close
 from .accuracy import is_fp8_dtype
 from .benchmark_job import AccuracyCheckJob
 from .benchmark_job import AccuracyCheckResult
+from .benchmark_job import BenchmarkAndAccuracyJob
+from .benchmark_job import BenchmarkAndAccuracyResult
 from .benchmark_job import BenchmarkJob
 from .benchmark_worker import BenchmarkSubprocessError
 from .benchmark_worker import BenchmarkWorker
@@ -1073,66 +1075,35 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         we classified and handled, or ``None`` if the subprocess path cannot
         handle this config and the caller should fall back to in-process.
         """
+        # Fused path: time + accuracy-check in ONE worker job so the config is
+        # compiled once, not once per job. Only when the accuracy check would
+        # otherwise run as its own worker job (subprocess on, check on, no custom
+        # baseline fn / mutated args) and a baseline was written.
+        if (
+            self.settings.autotune_fused_accuracy_check
+            and self._subprocess_accuracy_check_enabled()
+            and self._precompile_baseline_path is not None
+        ):
+            fused = self._run_fused_benchmark_accuracy_job(config, fn, warmup=1, rep=50)
+            if fused is not None:
+                return fused
+            # None => the fused job could not handle this config (e.g. serialize
+            # failed); fall through to the legacy two-job / in-process path.
+
         try:
             latency = self._run_subprocess_benchmark_job(fn, warmup=1, rep=50)
             if latency is None:
                 return None
-        except BenchmarkSubprocessError as e:
-            # Timeout or unexpected worker exit; skip config and continue.
-            self.log.warning(f"Benchmark subprocess failed for {config!r}: {e}")
-            self._autotune_metrics.num_compile_failures += 1
-            return inf
         except Exception as e:
-            e.__traceback__ = None
-            if match_unrecoverable_runtime_error(e):
-                # Worker is already killed; parent CUDA is unaffected.
-                # Skip this config and continue the search.
-                decorator = self.kernel.format_kernel_decorator(config, self.settings)
-                self.log.warning(
-                    f"Skipping config that triggered an unrecoverable runtime "
-                    f"error in the benchmark subprocess: "
-                    f"{type(e).__qualname__}: {e}\n  Config: {decorator}"
-                )
-                self.kernel.maybe_log_repro(self.log.warning, self.args, config)
-                self._autotune_metrics.num_compile_failures += 1
-                return inf
-            self.log.debug(
-                f"Benchmark subprocess raised for {config!r}: {type(e).__name__}: {e}"
-            )
-            self._autotune_metrics.num_compile_failures += 1
-            return inf
+            return self._handle_subprocess_job_error(config, e, phase="benchmark")
 
         if self.settings.autotune_accuracy_check:
             try:
                 accuracy_result = self._run_subprocess_accuracy_check_job(fn)
-            except BenchmarkSubprocessError as e:
-                self.log.warning(
-                    f"Accuracy check subprocess failed for {config!r}: {e}"
-                )
-                self._autotune_metrics.num_compile_failures += 1
-                return inf
             except Exception as e:
-                e.__traceback__ = None
-                if match_unrecoverable_runtime_error(e):
-                    # Worker is already killed; parent CUDA is unaffected.
-                    # Skip this config and continue the search.
-                    decorator = self.kernel.format_kernel_decorator(
-                        config, self.settings
-                    )
-                    self.log.warning(
-                        f"Skipping config that triggered an unrecoverable runtime "
-                        f"error in the accuracy check subprocess: "
-                        f"{type(e).__qualname__}: {e}\n  Config: {decorator}"
-                    )
-                    self.kernel.maybe_log_repro(self.log.warning, self.args, config)
-                    self._autotune_metrics.num_compile_failures += 1
-                    return inf
-                self.log.debug(
-                    f"Accuracy check subprocess raised for {config!r}: "
-                    f"{type(e).__name__}: {e}"
+                return self._handle_subprocess_job_error(
+                    config, e, phase="accuracy check"
                 )
-                self._autotune_metrics.num_compile_failures += 1
-                return inf
 
             if accuracy_result is not None:
                 if not accuracy_result.ok:
@@ -1179,6 +1150,102 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 self._clear_jit_fast_path_caches(fn)
 
         return float(latency)
+
+    def _handle_subprocess_job_error(
+        self, config: Config, e: Exception, *, phase: str
+    ) -> float:
+        """Classify a subprocess benchmark/accuracy worker failure.
+
+        Shared by the benchmark, accuracy-check, and fused-job dispatch paths,
+        which all react to a worker failure identically: log, count it as a
+        compile failure, and return ``inf`` so the search skips the config and
+        continues. ``phase`` is the human-readable step name for the log
+        message (e.g. ``"benchmark"`` or ``"accuracy check"``). The parent CUDA
+        context is unaffected in every case here -- a timeout/exit killed the
+        worker, and an unrecoverable runtime error was raised *inside* the
+        worker -- so this never re-raises (unlike the in-process fallback).
+        """
+        self._autotune_metrics.num_compile_failures += 1
+        if isinstance(e, BenchmarkSubprocessError):
+            # Timeout or unexpected worker exit; skip config and continue.
+            self.log.warning(
+                f"{phase.capitalize()} subprocess failed for {config!r}: {e}"
+            )
+            return inf
+        e.__traceback__ = None
+        if match_unrecoverable_runtime_error(e):
+            # Worker is already killed; parent CUDA is unaffected.
+            # Skip this config and continue the search.
+            decorator = self.kernel.format_kernel_decorator(config, self.settings)
+            self.log.warning(
+                f"Skipping config that triggered an unrecoverable runtime "
+                f"error in the {phase} subprocess: "
+                f"{type(e).__qualname__}: {e}\n  Config: {decorator}"
+            )
+            self.kernel.maybe_log_repro(self.log.warning, self.args, config)
+            return inf
+        self.log.debug(
+            f"{phase.capitalize()} subprocess raised for {config!r}: "
+            f"{type(e).__name__}: {e}"
+        )
+        return inf
+
+    def _run_fused_benchmark_accuracy_job(
+        self,
+        config: Config,
+        fn: CompiledConfig,
+        *,
+        warmup: int,
+        rep: int,
+    ) -> float | None:
+        """Time ``fn`` and accuracy-check it in a single worker job.
+
+        Returns the measured latency (ms) on success, ``inf`` for a failure we
+        classified and handled (skip config, continue search), or ``None`` if
+        the fused job cannot handle this config (serialize failed) and the
+        caller should fall back to the legacy path.
+        """
+        if self._precompile_args_path is None or self._precompile_baseline_path is None:
+            return None
+        try:
+            fn_spec = _serialize_compiled_fn(fn)
+        except RuntimeError:
+            return None
+
+        if self._benchmark_worker is None:
+            self._benchmark_worker = BenchmarkWorker(device=None)
+
+        job = BenchmarkAndAccuracyJob(
+            fn_spec=fn_spec,
+            args_path=self._precompile_args_path,
+            baseline_path=self._precompile_baseline_path,
+            atol=self._effective_atol,
+            rtol=self._effective_rtol,
+            warmup=warmup,
+            rep=rep,
+            use_wall_clock=self._subprocess_benchmark_uses_wall_clock(),
+        )
+        try:
+            result = cast(
+                "BenchmarkAndAccuracyResult",
+                self._benchmark_worker.run(
+                    job, timeout=float(self.settings.autotune_benchmark_timeout)
+                ),
+            )
+        except Exception as e:
+            return self._handle_subprocess_job_error(config, e, phase="benchmark")
+
+        accuracy_result = result.accuracy
+        if accuracy_result is not None and not accuracy_result.ok:
+            if not self.settings.autotune_ignore_errors:
+                self.log.warning(
+                    f"Skipping config with accuracy mismatch: {config!r}\n"
+                    f"{accuracy_result.message}\n"
+                    "Use HELION_AUTOTUNE_ACCURACY_CHECK=0 to disable this check.\n"
+                )
+            self._autotune_metrics.num_accuracy_failures += 1
+            return inf
+        return float(result.latency)
 
     def _run_subprocess_accuracy_check_job(
         self, fn: CompiledConfig

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -619,6 +619,10 @@ def do_bench_generic(
     # compute number of warmup and repeat
     n_warmup = max(1, int(warmup / estimate_ms))
     n_repeat = max(1, int(rep / estimate_ms))
+    # NOTE: the CuTe first-call cost (cold compile OR warm disk reload via
+    # _reattach_cute_source_hash) MUST be absorbed by this warmup and never leak into
+    # the timed `perfs` below — otherwise the disk-cache reattach could bias config
+    # selection at a generation-boundary re-benchmark. Keep warmup before the timed loop.
     # Warm-up
     for _ in range(n_warmup):
         fn()

--- a/helion/autotuner/precompile_future.py
+++ b/helion/autotuner/precompile_future.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import contextlib
 import dataclasses
+import hashlib
 import inspect
 import multiprocessing as mp
 from multiprocessing import connection
@@ -158,7 +159,43 @@ def _load_compiled_fn(fn_spec: SerializedCompiledFunction) -> CompiledConfig:
         raise RuntimeError(
             f"Unable to locate compiled kernel '{fn_spec.function_name}' in generated module"
         )
+    _reattach_cute_source_hash(module, fn_spec)
     return fn
+
+
+def _reattach_cute_source_hash(
+    module: types.ModuleType, fn_spec: SerializedCompiledFunction
+) -> None:
+    """Re-attach the CuTe disk-cache source hash lost by the fresh-module exec.
+
+    The parent sets ``_helion_<name>._helion_cute_source_hash`` in
+    ``CuteBackend.annotate_compiled_module`` (only reachable from
+    ``BoundKernel.compile_config``); the on-disk DSL cache key derives from it
+    (``_cute_disk_cache_key``).  Loading the kernel here re-``exec``s the source
+    into a fresh module without that step, so every worker launcher would get
+    ``cache_key=None`` and unconditionally cold-compile -- even for a config the
+    worker already compiled and persisted moments earlier (e.g. the
+    higher-accuracy rebench pass).  Recomputing the same ``sha256(source)`` and
+    reattaching it lets the worker's launchers hit the on-disk cache, so a
+    repeat compile of the same config becomes a warm reload instead of a full
+    cutlass-DSL recompile.  No-op for non-CuTe kernels (attribute simply unused).
+    """
+    # Same source hash for every ``_helion_*`` object, mirroring the parent
+    # ``CuteBackend.annotate_compiled_module``. The scan fallback is safe: a wrong
+    # stamp only misses the cache (cold recompile), never a false hit.
+    source_hash = hashlib.sha256(fn_spec.source_code.encode("utf-8")).hexdigest()
+    kernel_obj = getattr(module, f"_helion_{fn_spec.function_name}", None)
+    candidates = [kernel_obj] if kernel_obj is not None else []
+    if not candidates:
+        candidates = [
+            v
+            for k, v in vars(module).items()
+            if k.startswith("_helion_") and callable(v)
+        ]
+    for obj in candidates:
+        with contextlib.suppress(AttributeError, TypeError):
+            # pyrefly: ignore [missing-attribute]
+            obj._helion_cute_source_hash = source_hash
 
 
 def _run_kernel_in_subprocess_spawn(

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -434,6 +434,11 @@ class _Settings:
             90 if is_fbcode() else 30,
         )
     )
+    autotune_fused_accuracy_check: bool = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_bool, "HELION_FUSED_ACCURACY_CHECK", False
+        )
+    )
     autotune_precompile: PrecompileMode = dataclasses.field(
         default_factory=functools.partial(
             _env_get_literal,
@@ -650,6 +655,7 @@ class Settings(_Settings):
         "autotune_compile_timeout": "Timeout for Triton compilation in seconds used for autotuning. Default is 60 seconds.",
         "autotune_benchmark_subprocess": "Run the autotune benchmark phase in a long-lived spawn subprocess so a hung/slow kernel can be killed without losing autotune progress. Enabled by default. Set HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=0 to disable.",
         "autotune_benchmark_timeout": "Per-config wall-clock timeout in seconds for the subprocess benchmark phase. Only applies when autotune_benchmark_subprocess is enabled. Default 30 seconds, raised automatically on environments with a heavier subprocess cold-start.",
+        "autotune_fused_accuracy_check": "When subprocess benchmarking is enabled, run the timed benchmark and the accuracy check as one fused worker job that loads (and compiles) the config once, instead of two separate jobs that each recompile. Cuts per-config compile cost ~2x on backends with expensive first-call compiles (e.g. CuTe DSL). Off by default; set HELION_FUSED_ACCURACY_CHECK=1 to enable.",
         "autotune_precompile": "Autotuner precompile mode: 'fork', 'spawn', or falsy/None to disable. Defaults to 'fork' on non-Windows platforms.",
         "autotune_precompile_jobs": "Maximum concurrent Triton precompile processes, default to cpu count.",
         "autotune_random_seed": "Seed used for autotuner random number generation. Defaults to HELION_AUTOTUNE_RANDOM_SEED or a time-based seed.",

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -32,6 +32,7 @@ from helion.autotuner.base_search import PopulationBasedSearch
 from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.benchmark_job import AccuracyCheckJob
 from helion.autotuner.benchmark_job import AccuracyCheckResult
+from helion.autotuner.benchmark_job import BenchmarkAndAccuracyJob
 from helion.autotuner.benchmark_job import BenchmarkJob
 from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
 from helion.autotuner.benchmark_worker import BenchmarkSubprocessError
@@ -220,6 +221,102 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
 
         self.assertFalse(result.ok)
         self.assertIn("Output leaf type mismatch", result.message)
+
+    def test_fused_job_loads_fn_once_and_returns_latency_and_accuracy(self) -> None:
+        # The fused job must load (and therefore compile) the fn exactly once,
+        # reusing it for both the timed benchmark and the accuracy check.
+        fn = _ReturnValue(torch.tensor([1.0]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args_path = Path(tmpdir) / "args.pt"
+            baseline_path = Path(tmpdir) / "baseline.pt"
+            torch.save((), args_path)
+            torch.save(torch.tensor([1.0]), baseline_path)
+
+            with (
+                patch(
+                    "helion.autotuner.benchmark_job._load_compiled_fn",
+                    return_value=fn,
+                ) as load_fn,
+                patch(
+                    "helion.autotuner.benchmark_job.do_bench",
+                    return_value=2.5,
+                ),
+            ):
+                result = BenchmarkAndAccuracyJob(
+                    fn_spec=cast("SerializedCompiledFunction", object()),
+                    args_path=str(args_path),
+                    baseline_path=str(baseline_path),
+                    atol=0.0,
+                    rtol=0.0,
+                )()
+
+        self.assertEqual(result.latency, 2.5)
+        self.assertIsNotNone(result.accuracy)
+        self.assertTrue(result.accuracy.ok)
+        # The whole point of the fix: one load == one compile for both steps.
+        load_fn.assert_called_once()
+
+    def test_fused_job_reports_accuracy_mismatch_with_latency(self) -> None:
+        fn = _ReturnValue(torch.tensor([2.0]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args_path = Path(tmpdir) / "args.pt"
+            baseline_path = Path(tmpdir) / "baseline.pt"
+            torch.save((), args_path)
+            torch.save(torch.tensor([1.0]), baseline_path)
+
+            with (
+                patch(
+                    "helion.autotuner.benchmark_job._load_compiled_fn",
+                    return_value=fn,
+                ),
+                patch(
+                    "helion.autotuner.benchmark_job.do_bench",
+                    return_value=3.0,
+                ),
+            ):
+                result = BenchmarkAndAccuracyJob(
+                    fn_spec=cast("SerializedCompiledFunction", object()),
+                    args_path=str(args_path),
+                    baseline_path=str(baseline_path),
+                    atol=0.0,
+                    rtol=0.0,
+                )()
+
+        # A timing is still produced, but the accuracy check flags the mismatch.
+        self.assertEqual(result.latency, 3.0)
+        self.assertIsNotNone(result.accuracy)
+        self.assertFalse(result.accuracy.ok)
+
+    def test_fused_job_times_only_when_no_baseline(self) -> None:
+        fn = _ReturnValue(torch.tensor([1.0]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args_path = Path(tmpdir) / "args.pt"
+            torch.save((), args_path)
+
+            with (
+                patch(
+                    "helion.autotuner.benchmark_job._load_compiled_fn",
+                    return_value=fn,
+                ) as load_fn,
+                patch(
+                    "helion.autotuner.benchmark_job.do_bench",
+                    return_value=4.0,
+                ),
+            ):
+                result = BenchmarkAndAccuracyJob(
+                    fn_spec=cast("SerializedCompiledFunction", object()),
+                    args_path=str(args_path),
+                    baseline_path=None,
+                    atol=0.0,
+                    rtol=0.0,
+                )()
+
+        self.assertEqual(result.latency, 4.0)
+        self.assertIsNone(result.accuracy)
+        load_fn.assert_called_once()
 
     def test_subprocess_accuracy_check_uses_benchmark_timeout(self) -> None:
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)


### PR DESCRIPTION
Stacked PRs:
 * #3152
 * #3151
 * #3150
 * #3167
 * #3149
 * __->__#3148


--- --- ---

### cute: remove redundant subprocess-autotune DSL recompiles


The killable-worker autotune path cold-compiled the CuTe DSL kernel ~twice per
config (separate bench + accuracy jobs) and the worker disk cache was disabled
(cache_key=None), so a fixed budget searched far fewer distinct configs under
subprocess than in-process. A cold cutlass-DSL compile is ~3.5s vs a ~0.05s warm
disk reload, so the wasted recompiles dominated.

Fixes: (1) BenchmarkAndAccuracyJob compiles the source once for both bench and
accuracy (behind HELION_FUSED_ACCURACY_CHECK, default off); (2)
_reattach_cute_source_hash restores the worker disk-cache key so repeats are warm
reloads.

Effect (single B200, effort=full, seed=2000, subprocess=ON, fp8 4096^3):
distinct configs in a 300 s budget: 44 -> 83 (+89%; 1 -> 2 generations). Inert on
Triton and in-process. (The 44 "before" arm is the parent commit d51ece6d8^, which
predates both fixes; "after" is this commit + HELION_FUSED_ACCURACY_CHECK=1.)

Compile-COST only: does not change the benchmark timer or selection. Verified no
selection regression from this change: on a >=2-generation autotune run, the final
winner ([256,256,128] cm2 ab6) was independently cold-L2 cudagraph-timed against the
heuristic seed and was within 30% of it (winner/seed = 1.00x, PASS -- the winner is
the seed config) -- i.e. the fix does not cause the tuner to crown a config markedly
worse than a known-good one.

Gating: the two fixes have DIFFERENT blast radii. (1) the fused job is behind
HELION_FUSED_ACCURACY_CHECK, default off. (2) _reattach_cute_source_hash is
UNCONDITIONAL and takes effect on every worker load, i.e. on the default-ON
subprocess-benchmark path. That is deliberate: the parent already stamps this hash
and already uses the on-disk DSL cache, so the worker's cache_key=None was a defect,
not a policy -- and a wrong stamp can only MISS the cache (cold recompile), never
produce a false hit, because the key also carries the full input specialization,
launch shape, compile options, CUTE_DSL_* env, and cutlass version. Its correctness
does rest on the timer absorbing the first call: both do_bench (benchmarking.py, fn()
+ sync before capture) and do_bench_generic (fn() + sync before the estimate loop)
already do, so the compile-or-reload cost never enters the timed samples. The NOTE
added to do_bench_generic marks that ordering as load-bearing for future editors --
if warmup ever moved after the timed loop, the reattach would turn a uniform
first-call penalty into a non-uniform one (cold for first-seen configs, warm for
repeats), which would bias selection where a uniform penalty largely cancels.

Timeout accounting: the fused job runs bench AND the accuracy check under a SINGLE
autotune_benchmark_timeout window, where the legacy two-job path gave each step its
own. The extra work inside that window is one kernel launch plus an assert_close --
not a second compile, which is the point of the change -- so the narrowing is small
next to a ~3.5 s cold compile, but it is not zero: a config near the timeout boundary
has slightly less headroom than before. Not compensated for deliberately (doubling
the window would also double what a genuinely hung config gets to hang for, weakening
the killable-worker hang protection).

Adaptation: zero-arg synchronize_device() (PR #3026). Refactor: 3 copies of
subprocess job-error handling -> _handle_subprocess_job_error.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
