### PR TITLE
[autotuner][cute] widen the tcgen05 matmul search space: block_n=128 cluster_m=2 + ab=4

### DIFF
--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -860,9 +860,53 @@ class CuteTcgen05Config:
             block_sizes[n_index] = TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
             return
         block_sizes[m_index] = TCGEN05_TWO_CTA_BLOCK_M
-        # Only the fully validated narrow-N CLC+aux-TMA seed may keep
-        # block_n=128; other candidates use the canonical block_n=256.
-        if is_narrow_clc_aux_tma:
+        # Block-N shaping for the surviving cluster_m=2 candidates. A CtaGroup.TWO
+        # matmul has exactly two validated N tiles: 128 (a 256x128 output tile)
+        # and 256. Both are hardware-legal because the 2-CTA MMA decision keys
+        # only on ``block_m`` (pinned to 256 here), not ``block_n``; a prior
+        # investigation verified bn=128 cm2 compiles + is numerically correct on
+        # the eligible shapes of all three families and fails cleanly (inf-able,
+        # never wrong-output) elsewhere, so the historical bn=256 pin on the
+        # edge/batched families was coverage-conservatism, not a hardware limit.
+        # We therefore round every sampled block_n to one of those two tiles: the
+        # narrow band (<=128) snaps DOWN to 128, and 256 stays 256. Rounding the
+        # band up to 128 rather than up to 256 is deliberate -- the 256x256 tile
+        # is already emitted by every cluster_m=2 seed builder
+        # (``get_seed_config``, ``full_tile_direct_entry_seed_config``,
+        # ``_c_input_seed_config``), so it is in the initial population by
+        # construction and does not need a search draw to be discovered, whereas
+        # the generic ``[256,128,*]`` tile (the +8.3% Stage-2 win) is NOT seeded
+        # and is reachable ONLY via search. Biasing the band toward the un-seeded
+        # tile spends search draws where discovery is actually needed. The three
+        # families this covers, all verified to compile + pass at bn=128:
+        #   * plain 2-D DEFAULT-layout full-tile path -- the +8.3% ``[256,128,*]``
+        #     cm2 tile (Stage 2);
+        #   * the edge-K-tail family -- a generic (non-narrow-CLC) bn=128 edge
+        #     candidate carries bk=``TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K`` (128)
+        #     from the K shaping above and the coherent edge seed pipeline applied
+        #     in the ``edge_k_tail_family`` block below (the narrow-seed acc/l2
+        #     overrides stay gated on ``is_narrow_clc_aux_tma`` and are NOT
+        #     half-applied to it); its ``[256,128,128]`` tile;
+        #   * the batched leading-passthrough family -- its ``[*,256,128,*]`` cm2
+        #     tile (Stage 2b).
+        # The bm==bn==256 requirement lives only in the FFI/EXPLICIT_EPI_TILE
+        # envelope, which ``_fix_target1_tvm_ffi_search_config`` has already
+        # settled before this runs: an explicit FFI request carries the seed's
+        # own 256x256 tile, and a partial one has been repaired back to the
+        # DEFAULT layout. The ``layout == DEFAULT`` guard below therefore snaps
+        # only candidates that are genuinely on the default path. block_m stays
+        # pinned to 256 (block_m=128 is the fp8-small-grid path handled above).
+        sampled_bn = block_sizes[n_index]
+        layout = config.get(
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY,
+            Tcgen05LayoutStrategy.DEFAULT.value,
+        )
+        if is_narrow_clc_aux_tma or (
+            layout == Tcgen05LayoutStrategy.DEFAULT.value
+            and isinstance(sampled_bn, int)
+            and not isinstance(sampled_bn, bool)
+            and sampled_bn <= TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
+        ):
             block_sizes[n_index] = TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
         else:
             block_sizes[n_index] = TCGEN05_TWO_CTA_BLOCK_N
@@ -1207,29 +1251,35 @@ class CuteTcgen05Config:
             config["tcgen05_ab_stages"] = 2
 
     def _fix_ab_stages_search_config(self, config: dict[str, object]) -> None:
-        # Budget-aware ab=3 admission for the lifted ``for_search`` cap (see
+        # Budget-aware deep-AB admission for the lifted ``for_search`` cap (see
         # ``optional_fragments`` and cute_plan.md §4.5 for the empirical narrative).
         # Mirror ``_fix_c_stages_search_config`` (fail-CLOSED, cast-based): on the
         # canonical 256x256 DEFAULT-layout role-local path, demote a directly-sampled
-        # ab=3 to 2 when it does not fit the per-CTA SMEM budget. The invariant — the
-        # new dimension over the bare-AB ``_fix_ab_stages_three_search_config`` gate —
-        # is REAL source-C presence, keyed on the PRECISE
-        # ``exact_shape_aux_kernel_detected`` (rank-2 exact-shape residual_add), NOT
-        # the broad ``aux_kernel_detected`` (also True for a rowvec broadcast bias
-        # that has no source-C ring): a real source-C materializes the larger
-        # (128, 64) C ring, so AB(ab=3) + C overflows the cap even at c=2 and MUST
+        # ab>=3 to the deepest depth that fits the per-CTA SMEM budget. This runs
+        # AFTER ``_fix_cluster_m2_search_config`` shapes the block sizes, so it judges
+        # the tile that will actually reach codegen: a sampled bn that snapped to the
+        # canonical 256 -> [256,256,128] cm2 ab4 overflows at 262144 B and is demoted
+        # to the fitting ab=3. The Stage-2 searchable narrow-N [256,128,*] cm2 tile is
+        # NOT the canonical 256x256 tile, so it stays out of this gate entirely and
+        # keeps its sampled ab4 (196608 B, fits) — its budget was already enforced by
+        # ``_validate_direct_entry_ab_stage_envelope`` (16-bit cm2 default-layout
+        # branch). The invariant — the new dimension over the bare-AB
+        # ``_fix_ab_stages_three_search_config`` gate — is REAL source-C presence,
+        # keyed on the PRECISE ``exact_shape_aux_kernel_detected`` (rank-2 exact-shape
+        # residual_add), NOT the broad ``aux_kernel_detected`` (also True for a rowvec
+        # broadcast bias that has no source-C ring): a real source-C materializes the
+        # larger (128, 64) C ring, so AB + C overflows the cap even at c=2 and MUST
         # demote, while the plain / rowvec-bias family (no source-C ring) keeps the
         # bare-AB calibration so its ab=3 winner stays searchable. The exact-shape
         # residual cluster_m=2 full-tile candidates are already forced to ab=2 by
-        # ``_fix_aux_tma_full_tile_search_config`` (runs first); this gate's source-C
-        # branch is the fail-closed backstop for any exact-shape residual ab=3 that
-        # projection does not claim (e.g. cluster_m=1). The EXPLICIT_EPI_TILE
+        # ``_fix_aux_tma_full_tile_search_config`` (runs first). The EXPLICIT_EPI_TILE
         # direct-entry (TVM-FFI) seeds use a separate (128, 32) tile + own admission
         # and are out of the DEFAULT-layout scope, so their seeded ab=3/ab=6 is
         # untouched.
         if not self.search_enabled:
             return
-        if config.get("tcgen05_ab_stages") != 3:
+        ab_stages = config.get("tcgen05_ab_stages")
+        if type(ab_stages) is not int or ab_stages < 3:
             return
         if not self._is_default_layout_full_tile_config(config):
             return
@@ -1238,35 +1288,42 @@ class CuteTcgen05Config:
             config["tcgen05_ab_stages"] = 2
             return
         block_sizes, m_index, n_index, k_index = config_view
+        bm = cast("int", block_sizes[m_index])
+        bn = cast("int", block_sizes[n_index])
+        bk = cast("int", block_sizes[k_index])
         cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
         if self.exact_shape_aux_kernel_detected:
-            # Real source-C present: require AB(ab=3) + the (128, 64) C ring to fit
-            # together. ``c_stages_fits`` fails CLOSED when no SMEM budget is
-            # recorded (non-B200 / CPU host), so the over-budget and no-budget
-            # arms are both covered by a single ``not c_stages_fits`` check.
+            # Real source-C present: require AB + the (128, 64) C ring to fit
+            # together at the sampled depth. ``c_stages_fits`` fails CLOSED when no
+            # SMEM budget is recorded (non-B200 / CPU host), so the over-budget and
+            # no-budget arms are both covered.
             c_stages = cast("int", config.get("tcgen05_c_stages", 2))
-            fits = self.c_stages_fits(
-                bm=cast("int", block_sizes[m_index]),
-                bn=cast("int", block_sizes[n_index]),
-                bk=cast("int", block_sizes[k_index]),
-                cluster_m=cluster_m,
-                ab_stages=3,
-                c_stages=c_stages,
-                has_source_c=True,
-            )
+
+            def _fits(ab: int) -> bool:
+                return self.c_stages_fits(
+                    bm=bm,
+                    bn=bn,
+                    bk=bk,
+                    cluster_m=cluster_m,
+                    ab_stages=ab,
+                    c_stages=c_stages,
+                    has_source_c=True,
+                )
         else:
             # Plain / rowvec-bias store (no source-C ring): the bare-AB gate is the
             # calibrated admission — the small no-source-C epilogue D ring rides the
             # non-AB reservation. ``ab_stages_three_fits`` returns False with no
             # budget recorded, so this also fails CLOSED.
-            fits = self.ab_stages_three_fits(
-                bm=cast("int", block_sizes[m_index]),
-                bn=cast("int", block_sizes[n_index]),
-                bk=cast("int", block_sizes[k_index]),
-                cluster_m=cluster_m,
-            )
-        if not fits:
-            config["tcgen05_ab_stages"] = 2
+            def _fits(ab: int) -> bool:
+                return self.ab_stages_three_fits(
+                    bm=bm, bn=bn, bk=bk, cluster_m=cluster_m, ab_stages=ab
+                )
+
+        # Demote to the deepest depth in [2, ab_stages] that fits (floor 2, the
+        # historical demote target for a non-fitting ab=3 on this path).
+        while ab_stages > 2 and not _fits(ab_stages):
+            ab_stages -= 1
+        config["tcgen05_ab_stages"] = ab_stages
 
     def _fix_with_scheduler_search_config(self, config: dict[str, object]) -> None:
         if not (self.search_enabled and self.aux_kernel_detected):
@@ -1478,12 +1535,40 @@ class CuteTcgen05Config:
             )
         ):
             return
-        # FP8 (1-byte) operands fit a deeper AB pipeline than the bf16-tuned
-        # cap of 3; admit ab_stages > 3 for fp8 as long as the AB SMEM fits the
-        # per-CTA budget. This lets Helion emit the same deeply-pipelined
-        # CtaGroup.TWO kernel CUTLASS uses for fp8 compute-bound GEMMs.
+        # A deeper AB pipeline than the bf16-tuned cap of 3 is admitted whenever
+        # the per-CTA AB SMEM fits the budget, for two families:
+        #   * FP8 (1-byte) operands, any tile — lets Helion emit the same
+        #     deeply-pipelined CtaGroup.TWO kernel CUTLASS uses for fp8
+        #     compute-bound GEMMs.
+        #   * Stage 2: 16-bit ``cluster_m=2`` on the DEFAULT layout — the
+        #     narrow-N (block_n=128) full-tile cm2 tile fits ab=4 in the
+        #     203776 B budget (196608 B at [256,128,128]) and runs +8.3% over the
+        #     cm1 winner on 512x4096x4096 bf16. ``max_ab_stages_that_fit`` applies
+        #     the 16-bit hard cap (6) AND the SMEM budget, so the real ab6/bk128
+        #     overflow (294912 B) is still rejected -> clamped to what fits. The
+        #     canonical 256x256 cm2 tile only fits ab<=3, so a snapped ab4 there
+        #     is clamped back to 3 here. cluster_m=1 keeps the strict ab<=3 cap
+        #     (its reachable bf16 tiles overflow beyond ab3), and EXPLICIT_EPI_TILE
+        #     / FFI configs are handled by the direct-entry tuple branch above.
+        #     The batched leading-passthrough family is admitted too: per-CTA AB
+        #     SMEM is batch-invariant (``tcgen05_ab_smem_bytes_per_cta`` takes only
+        #     bm/bn/bk/dtype/stages/cluster_m, and the leading axis is squeezed to
+        #     block size 1 in codegen), so a batched ``[*,256,128,128]`` cm2 tile
+        #     fits ab=4 identically and ``max_ab_stages_that_fit`` still enforces
+        #     the real per-CTA cap.
         constraints = self.ab_stages_three_search_constraints
-        if constraints is not None and constraints.dtype_bytes == 1:  # FP8
+        is_fp8 = constraints is not None and constraints.dtype_bytes == 1
+        layout = config.get(
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY,
+            Tcgen05LayoutStrategy.DEFAULT.value,
+        )
+        is_16bit_default_cm2 = (
+            constraints is not None
+            and constraints.dtype_bytes == 2
+            and config.get("tcgen05_cluster_m") == 2
+            and layout == Tcgen05LayoutStrategy.DEFAULT.value
+        )
+        if is_fp8 or is_16bit_default_cm2:
             config_view = self._matmul_config_view(config)
             cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
             if config_view is not None:
@@ -1504,7 +1589,8 @@ class CuteTcgen05Config:
             return
         raise InvalidConfig(
             "tcgen05_ab_stages > 3 is only supported by the validated "
-            "TVM-FFI direct-entry path (or fp8 within the SMEM budget)"
+            "TVM-FFI direct-entry path, a 16-bit cluster_m=2 DEFAULT-layout "
+            "tile within the SMEM budget, or fp8 within the SMEM budget"
         )
 
     def _is_validated_clc_persistence_search_candidate(
@@ -1981,13 +2067,21 @@ class CuteTcgen05Config:
             # Cycle 97: make ab=3 BUDGET-AWARE-SEARCHABLE. Where the device/dtype
             # admits ab=3 at all (the SMEM-budget constraints were recorded by
             # ``allow_ab_stages_three_search`` at bind time — B200-class optin cap,
-            # bf16/fp16), lift the ``for_search`` cap to 3 so the autotuner can
-            # SAMPLE ab=3 directly instead of reaching it only through the per-shape
+            # bf16/fp16), lift the ``for_search`` cap so the autotuner can SAMPLE
+            # deeper AB directly instead of reaching it only through the per-shape
             # FFI / gelu seeds. ``_fix_ab_stages_search_config`` then demotes any
-            # sampled ab=3 that does not fit (the residual/source-C ring overflows;
-            # cluster_m=1 256x256 overflows bare-AB) before codegen, so admission is
-            # free but an overflowing kernel is never generated.
-            ab_stages_max = 3
+            # sampled candidate that does not fit (the residual/source-C ring
+            # overflows; cluster_m=1 256x256 overflows bare-AB) before codegen, so
+            # admission is free but an overflowing kernel is never generated.
+            #
+            # Stage 2: the cap is 4 (not 3) for 16-bit so the DEFAULT-layout
+            # narrow-N (block_n=128) cluster_m=2 tile can search ab=4 — the
+            # ``[256,128,128] cm2 ab4`` config that runs +8.3% over the cm1 winner
+            # on 512x4096x4096 bf16 (fits the 203776 B per-CTA budget at 196608 B).
+            # ab=4 at the canonical 256x256 tile overflows (262144 B) and is
+            # demoted by ``_fix_ab_stages_search_config`` after shaping; ab>=5 stays
+            # a seed/validation-only depth (the ab6/bk128 overflow guard is real).
+            ab_stages_max = 4
             # FP8 (1-byte) operands fit a deeper AB pipeline; widen the
             # validation range so an explicit deep-staged fp8 config is
             # accepted (``_validate_direct_entry_ab_stage_envelope`` clamps it to

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -15,6 +15,9 @@ from .._compiler.cute.matmul_utils import cute_outer_accumulates_result
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
+from .._compiler.cute.tcgen05_constants import (
+    TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
+)
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
@@ -482,7 +485,15 @@ def enable_cute_tcgen05_search(
                 cluster_n = TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
             else:
                 cluster_m = TCGEN05_TWO_CTA_BLOCK_M
-                cluster_n = TCGEN05_TWO_CTA_BLOCK_N
+                # Count clusters at the narrowest tile these families can emit
+                # (block_n=128, a 256x128 output tile), not the 256x256 artifact:
+                # bn=128 yields 2x the clusters and fills where a 256x256 cm2 would
+                # underfill. Both non-fp8 families reaching here can emit bn=128
+                # (full-tile: the +8.3% S2 win; edge-K-tail: Stage 2b made its
+                # generic [256,128,128] tile searchable), so bn=128 is the honest
+                # best-fill count for both. fp8-small-grid counts at its own
+                # 128x128 tile in the branch above.
+                cluster_n = TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
             work_clusters = (
                 plan.leading_work_multiplier
                 * (static_m // cluster_m)

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -2396,12 +2396,13 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             for_search=True
         )["tcgen05_ab_stages"]
         self.assertIsInstance(search_ab_stages_fragment, IntegerFragment)
-        # Cycle 97: the for_search ab cap is BUDGET-AWARE — lifted to 3 wherever
-        # ab=3 is admissible (the SMEM-budget constraints were recorded at bind
-        # time, i.e. bf16/fp16 on a B200-class optin cap), else 2. Conditioning on
-        # the recorded constraints keeps the assertion deterministic across hosts.
+        # Stage 2: the for_search ab cap is BUDGET-AWARE — lifted to 4 for 16-bit
+        # wherever the SMEM-budget constraints were recorded at bind time (bf16/fp16
+        # on a B200-class optin cap) so the narrow-N cluster_m=2 tile can search
+        # ab=4, else 2. Conditioning on the recorded constraints keeps the assertion
+        # deterministic across hosts.
         expected_search_ab_high = (
-            3
+            4
             if bound.config_spec._cute_tcgen05_config.ab_stages_three_search_constraints
             is not None
             else 2
@@ -2826,7 +2827,13 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             and config["block_sizes"][1] == TCGEN05_TWO_CTA_BLOCK_N
         )
         projected_wide_clc_aux_tma_config = dict(raw_wide_clc_aux_tma_seed)
-        projected_wide_clc_aux_tma_config["block_sizes"] = [128, 64, 64]
+        # Mangle bm (128->256) and bk (64->128) but keep bn on the wide 256
+        # tile: the block_n normalizer now rounds a sub-128 sampled bn UP to the
+        # narrow 128 tile, so only bn=256 stays on the wide CLC+aux-TMA path this
+        # assertion (wide l2/acc knobs, [256,256,128]) covers. The sub-128 ->
+        # narrow-128 round-up is covered separately by the cluster_m1 persistent
+        # search test's [256,32,16] -> [256,128,16] case.
+        projected_wide_clc_aux_tma_config["block_sizes"] = [128, 256, 64]
         projected_wide_clc_aux_tma_config["pid_type"] = "flat"
         projected_wide_clc_aux_tma_config["tcgen05_acc_stages"] = (
             TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES
@@ -3207,7 +3214,11 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
 
         def make_minimal_preprojection_clc_aux_tma_config() -> dict[str, object]:
             return {
-                "block_sizes": [128, 64, 64],
+                # bn stays on the wide 256 tile: this exercises the wide
+                # CLC+aux-TMA recovery ([256,256,128] + wide knobs). A sub-128 bn
+                # would now round UP to the narrow 128 tile instead of the 256
+                # this assertion checks.
+                "block_sizes": [128, 256, 64],
                 "indexing": ["tensor_descriptor"] * bound.config_spec.indexing.length,
                 "pid_type": "flat",
                 "tcgen05_cluster_m": 2,
@@ -3289,11 +3300,18 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             TCGEN05_AUX_LOAD_MODE_TMA
         )
         bound.config_spec.normalize(narrow_invalid_cluster_n_config, _fix_invalid=True)
+        # cluster_n=2 disqualifies the narrow-N CLC + aux-TMA seed path
+        # (``is_narrow_clc_aux_tma`` requires cluster_n=1), so the candidate is
+        # shaped as a generic cluster_m=2 edge tile. Stage 2b made a generic
+        # DEFAULT-layout bn=128 edge tile searchable, so block_n now SURVIVES at
+        # 128 (with the generic edge K tail) instead of snapping to the canonical
+        # 256; the persistence model still falls back to STATIC_PERSISTENT, which
+        # is what this sub-case guards.
         self.assertEqual(
             narrow_invalid_cluster_n_config["block_sizes"][:3],
             [
                 TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
@@ -3407,17 +3425,27 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             ),
         }
         spec.normalize(narrow_config, _fix_invalid=True)
+        # Stage 2b made a generic DEFAULT-layout bn=128 cluster_m=2 edge tile
+        # searchable, so block_n now SURVIVES at 128 (with the generic edge K
+        # tail) instead of snapping to the canonical 256. The narrow-N CLC +
+        # aux-TMA SEED still requires an N edge at 128 (which this N=4224 shape
+        # lacks -- 128 is a full tile), so the CLC-persistent validation fails
+        # and the persistence model correctly falls back to STATIC_PERSISTENT.
+        # (This surviving bn=128 tile fails cleanly -- BackendUnsupported /
+        # runtime guard -- on this M-edge, N-full shape, so autotune drops it;
+        # it is numerically correct on shapes where a bn=128 edge tile is
+        # eligible. It is never compiles-but-wrong.)
         self.assertEqual(
             narrow_config["block_sizes"][:3],
             [
                 TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
         self.assertEqual(
             narrow_config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY],
-            Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+            Tcgen05PersistenceModel.STATIC_PERSISTENT.value,
         )
 
     @onlyBackends(["cute"])
@@ -4125,11 +4153,15 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertTrue(residual_tcfg.aux_kernel_detected)
         self.assertTrue(residual_tcfg.exact_shape_aux_kernel_detected)
 
-        # The for_search ab fragment is lifted to 3 (the budget was recorded at
-        # bind via the mocked B200 cap) for every family.
+        # Stage 2: the for_search ab fragment is lifted to 4 for 16-bit (the
+        # budget was recorded at bind via the mocked B200 cap) for every family,
+        # so the narrow-N DEFAULT-layout cluster_m=2 tile can search ab=4. A
+        # sampled ab=4 that does not fit the shaped tile is demoted before codegen
+        # by the envelope validator (cluster_m=1 / canonical 256x256) or
+        # ``_fix_ab_stages_search_config`` (shaped-to-256x256 cm2 overflow).
         for tcfg in (plain_tcfg, bias_tcfg, residual_tcfg):
             ab_fragment = tcfg.optional_fragments(for_search=True)["tcgen05_ab_stages"]
-            self.assertEqual(ab_fragment.high, 3)
+            self.assertEqual(ab_fragment.high, 4)
 
         def _ab3_config(cluster_m: int = 2) -> helion.Config:
             return helion.Config(
@@ -4310,11 +4342,16 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
 
         self.assertEqual(config_dict["tcgen05_cluster_m"], 2)
         self.assertEqual(config_dict["pid_type"], "persistent_interleaved")
+        # Stage 2b made a generic DEFAULT-layout bn=128 cluster_m=2 edge tile
+        # searchable, so the sampled block_n=128 now SURVIVES at 128 (with the
+        # generic edge K tail) instead of snapping to the canonical 256. block_m
+        # is still pinned to 256 and the edge ab2 seed overrides still apply
+        # (this test's subject).
         self.assertEqual(
             config_dict["block_sizes"][:3],
             [
                 TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -4855,7 +4855,12 @@ class TestCuteBackend(TestCase):
                 "tcgen05_cluster_m": 2,
             }
             bound.config_spec.normalize(projected, _fix_invalid=True)
-            self.assertEqual(projected["block_sizes"], [1, 256, 256, 64])
+            # Stage 2b made a generic DEFAULT-layout bn=128 cluster_m=2 tile
+            # searchable for the batched leading-passthrough family, so the
+            # sampled block_n=128 (index 2) now SURVIVES at 128 instead of
+            # snapping to the canonical 256. block_m (index 1) is still pinned
+            # to 256.
+            self.assertEqual(projected["block_sizes"], [1, 256, 128, 64])
             self.assertEqual(projected["pid_type"], "persistent_interleaved")
 
             def search_spec(m: int, n: int, k: int) -> ConfigSpec:
@@ -4910,8 +4915,19 @@ class TestCuteBackend(TestCase):
             "helion.language.matmul_ops._cuda_num_sms_or_zero",
             return_value=148,
         ):
-            self.assertEqual(cluster_choices(32), (1,))
-            self.assertEqual(cluster_choices(64), (1, 2))
+            # The wave-quant gate multiplies the per-batch output-cluster count
+            # by the batch (``leading_work_multiplier``); cluster_m=2 search is
+            # only admitted once that product clears ``num_sms // 4`` (= 37).
+            # Stage 2b made the batched leading-passthrough family search a
+            # bn=128 cluster_m=2 tile, so the count is taken at the narrow tile
+            # (256x128 -> 256//256 * 256//128 = 2 clusters per batch), moving the
+            # threshold to batch >= 19 (2 * 19 = 38 >= 37). A small batch that
+            # underfills stays cluster_m=1; a large batch enables cluster_m=2.
+            # If the batch factor were NOT counted the product would be a
+            # batch-independent 2 and cluster_m=2 would never enable -- so this
+            # boundary is what proves batch clusters are counted.
+            self.assertEqual(cluster_choices(16), (1,))
+            self.assertEqual(cluster_choices(32), (1, 2))
 
     def test_batched_direct_entry_seeds_match_epilogue_support(self) -> None:
         support = get_cute_mma_support()

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -203,6 +203,9 @@ from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE,
 )
 from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
+)
+from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE,
 )
 from helion._compiler.cute.tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
@@ -18053,9 +18056,16 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             config_dict["indexing"],
             ["tensor_descriptor"] * spec.indexing.length,
         )
+        # Stage 2b: a sampled block_n=128 now survives as its own valid cm2 tile
+        # for the edge-K-tail family (block_m still pinned to 256), instead of
+        # snapping to the canonical block_n=256.
         self.assertEqual(
             config_dict["block_sizes"],
-            [256, 256, TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K],
+            [
+                256,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
+            ],
         )
         self.assertEqual(config_dict["pid_type"], "persistent_interleaved")
         self.assertNotIn("epilogue_subtile", config_dict)

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -489,17 +489,24 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         is narrowed for shapes whose cluster_m=2 work-cluster count
         cannot saturate even a quarter-wave of cluster slots.
 
-        The gate measures ``(M / 256) * (N / 256)`` cluster_m=2 work
-        clusters and compares against ``num_sms // 4``. The threshold
-        was lowered from ``num_sms // 2`` (one full wave of 2-SM cluster
-        slots) because the generalized TVM-FFI direct entry has a much
-        lower launch/epilogue overhead and wins at ~64 work clusters
-        (0.86 of a wave on a 148-SM B200). With the SM count mocked to
-        B200's 148 the threshold is 37 cluster slots: 1024^3 sits at 16
-        clusters (< 37) and narrows to ``cluster_m=1`` only, while 2048^3
-        sits at 64 clusters (>= 37) and now KEEPS cluster_m=2 search
-        exposed. The 4096^3 G2 closure baseline (256 clusters) also keeps
-        cluster_m=2 search (covered by
+        Stage 2: the gate counts work clusters at the NARROWEST N tile
+        the full-tile cluster_m=2 search admits — ``(M / 256) * (N / 128)``
+        (block_n=128, a 256x128 output tile) rather than the 256x256
+        artifact ``(M / 256) * (N / 256)``. A block_n=128 cm2 tile produces
+        2x the clusters and fills the device where a 256x256 cm2 would
+        underfill, so counting at the tile the search can actually pick
+        keeps the gate honest for the bn=128 default-layout cm2 path (the
+        +8.3% 512x4096x4096 win). The comparison is against ``num_sms // 4``
+        (lowered from ``num_sms // 2`` because the generalized TVM-FFI
+        direct entry wins at ~0.86 of a wave). With the SM count mocked to
+        B200's 148 the threshold is 37 cluster slots: 1024^3 sits at 32
+        clusters ((1024/256)*(1024/128) = 4*8) < 37 and narrows to
+        ``cluster_m=1`` only, while 2048^3 sits at 128 clusters (>= 37) and
+        KEEPS cluster_m=2 search exposed. The 512x4096x4096 medium-M shape
+        now sits at 64 clusters ((512/256)*(4096/128) = 2*32) >= 37 and is
+        ADMITTED (it was suppressed under the old 256x256 count at 32
+        clusters) — the Stage-2 behavior change. The 4096^3 G2 closure
+        baseline (512 clusters) also keeps cluster_m=2 search (covered by
         ``test_cute_tcgen05_two_cta_enters_validated_search_space``).
 
         Mocking ``_cuda_num_sms_or_zero`` keeps the test hermetic:
@@ -519,10 +526,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                 out[tile_m, tile_n] = acc.to(x.dtype)
             return out
 
-        def bind_at(size: int):
+        def bind_at(size: int, n: int | None = None):
+            n = size if n is None else n
             args = (
                 torch.empty([size, size], device=DEVICE, dtype=HALF_DTYPE),
-                torch.empty([size, size], device=DEVICE, dtype=HALF_DTYPE),
+                torch.empty([size, n], device=DEVICE, dtype=HALF_DTYPE),
             )
             with (
                 patch_cute_mma_support(),
@@ -533,10 +541,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             ):
                 return cute_matmul_mma.bind(args).config_spec
 
-        # Suppressed: 1024^3 = 16 cluster slots < 148 // 4 = 37. cluster_m=2
-        # search is suppressed and the cluster_m2 seed / fixup machinery is
-        # disabled so the autotuner never spends budget on the cluster_m=2 seed
-        # for a shape where it has no productive lever.
+        # Suppressed: 1024^3 = (1024/256)*(1024/128) = 32 cluster slots < 148 // 4
+        # = 37 (counted at the narrow-N block_n=128 tile). cluster_m=2 search is
+        # suppressed and the cluster_m2 seed / fixup machinery is disabled so the
+        # autotuner never spends budget on the cluster_m=2 seed for a shape where
+        # it has no productive lever.
         suppressed_spec = bind_at(1024)
         self.assertEqual(suppressed_spec._tcgen05_cluster_m_search_choices, (1,))
         self.assertIsNone(suppressed_spec._tcgen05_cluster_m2_search_constraints)
@@ -551,15 +560,29 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertIn("persistent_interleaved", suppressed_spec.allowed_pid_types)
         self.assertIn("persistent_blocked", suppressed_spec.allowed_pid_types)
 
-        # Admitted (positive control for the lowered // 4 boundary): 2048^3 = 64
-        # cluster slots >= 37. cluster_m=2 search stays exposed, its constraints
-        # are recorded, and the cluster_m=2 seed heuristic is registered.
+        # Admitted (positive control for the lowered // 4 boundary): 2048^3 =
+        # (2048/256)*(2048/128) = 128 cluster slots >= 37. cluster_m=2 search
+        # stays exposed, its constraints are recorded, and the cluster_m=2 seed
+        # heuristic is registered.
         admitted_spec = bind_at(2048)
         self.assertEqual(admitted_spec._tcgen05_cluster_m_search_choices, (1, 2))
         self.assertIsNotNone(admitted_spec._tcgen05_cluster_m2_search_constraints)
         self.assertIn(
             CuteTcgen05ClusterM2Heuristic.name,
             admitted_spec.autotuner_heuristics,
+        )
+
+        # Stage 2 behavior change: the 512x4096x4096 medium-M shape sits at
+        # (512/256)*(4096/128) = 64 clusters counted at the narrow-N tile
+        # (>= 37, ADMITTED), where the old 256x256 count put it at
+        # (512/256)*(4096/256) = 32 (< 37, suppressed). This is the shape whose
+        # bn=128 cm2 + ab4 config runs +8.3% over the cm1 winner.
+        s2_spec = bind_at(512, n=4096)
+        self.assertEqual(s2_spec._tcgen05_cluster_m_search_choices, (1, 2))
+        self.assertIsNotNone(s2_spec._tcgen05_cluster_m2_search_constraints)
+        self.assertIn(
+            CuteTcgen05ClusterM2Heuristic.name,
+            s2_spec.autotuner_heuristics,
         )
 
     @onlyBackends(["cute"])
@@ -787,8 +810,10 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(two_cta_config["tcgen05_cluster_m"], 2)
         self.assertEqual(two_cta_config["pid_type"], "persistent_interleaved")
         # The ordinary cluster_m=2 arm preserves its valid bk=16 sample instead
-        # of collapsing into the distinct bk=128 FFI direct-entry seed.
-        self.assertEqual(two_cta_config["block_sizes"][:3], [256, 256, 16])
+        # of collapsing into the distinct bk=128 FFI direct-entry seed. The
+        # sub-128 sampled block_n rounds UP to the narrow 128 cm2 tile (the
+        # un-seeded [256,128,*] tile that only search can reach), not to 256.
+        self.assertEqual(two_cta_config["block_sizes"][:3], [256, 128, 16])
         self.assertIs(two_cta_config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY], False)
 
     @onlyBackends(["cute"])
@@ -904,12 +929,18 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
 
         search_fragments = spec._tcgen05_optional_fragments(for_search=True)
         # Cycle 97: ab=3 is BUDGET-AWARE-SEARCHABLE — the for_search cap is lifted
-        # to 3 wherever the SMEM-budget constraints were recorded (here: the mocked
-        # B200 budget), so the autotuner can SAMPLE ab=3 directly. A sampled ab=3
-        # that does not fit is then demoted by ``_fix_ab_stages_search_config`` (the
-        # over-budget cases below). The validation surface is independently 3 for
-        # explicit configs.
-        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 3)
+        # wherever the SMEM-budget constraints were recorded (here: the mocked
+        # B200 budget), so the autotuner can SAMPLE deeper AB directly. A sampled
+        # candidate that does not fit is then demoted by
+        # ``_fix_ab_stages_search_config`` (the over-budget cases below).
+        # Stage 2: the 16-bit for_search cap is 4 (not 3) so the DEFAULT-layout
+        # narrow-N (block_n=128) cluster_m=2 tile can search ab=4 — the
+        # ``[256,128,128] cm2 ab4`` config that runs +8.3% over the cm1 winner on
+        # 512x4096x4096 bf16 (196 608 B fits the 203 776 B budget). ab=4 at the
+        # canonical 256x256 tile overflows (262 144 B) and is demoted after
+        # shaping; the validation surface is independently 6 for explicit FFI /
+        # deep-AB configs.
+        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 4)
         validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
         # 16-bit 4096^3 is FFI-eligible (fp16 == bf16 parity), so the validation
         # surface admits the deeper FFI direct-entry stage tuples — up to ab=6
@@ -931,6 +962,36 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         spec.normalize(keep_config, _fix_invalid=True)
         self.assertEqual(keep_config["tcgen05_ab_stages"], 3)
         self.assertEqual(keep_config["tcgen05_cluster_m"], 2)
+
+        # Stage 2: the DEFAULT-layout narrow-N cluster_m=2 tile ([256,128,128])
+        # fits ab=4 in the B200 budget (196 608 bytes) and survives search
+        # normalization as [256,128,128] cm2 ab4 — the +8.3% config.
+        bn128_cm2_ab4 = {
+            "block_sizes": [256, 128, 128],
+            "l2_groupings": [2],
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 2,
+            "tcgen05_ab_stages": 4,
+        }
+        spec.normalize(bn128_cm2_ab4, _fix_invalid=True)
+        self.assertEqual(bn128_cm2_ab4["block_sizes"], [256, 128, 128])
+        self.assertEqual(bn128_cm2_ab4["tcgen05_cluster_m"], 2)
+        self.assertEqual(bn128_cm2_ab4["tcgen05_ab_stages"], 4)
+
+        # A cluster_m=2 candidate whose sampled block_n snaps to the canonical
+        # 256 (the shaped [256,256,128] cm2 tile) overflows at ab=4
+        # (262 144 bytes) and must be demoted to the fitting ab=3.
+        canonical_cm2_ab4 = {
+            "block_sizes": [256, 256, 128],
+            "l2_groupings": [4],
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 2,
+            "tcgen05_ab_stages": 4,
+        }
+        spec.normalize(canonical_cm2_ab4, _fix_invalid=True)
+        self.assertEqual(canonical_cm2_ab4["block_sizes"], [256, 256, 128])
+        self.assertEqual(canonical_cm2_ab4["tcgen05_cluster_m"], 2)
+        self.assertEqual(canonical_cm2_ab4["tcgen05_ab_stages"], 3)
 
         # ab=3 over-budget shapes get demoted to ab=2. The cute_dsl
         # ptxas failure is the loud backstop for explicit user configs
@@ -1030,7 +1091,8 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                 )
             self.assertIsNotNone(spec._tcgen05_ab_stages_three_search_constraints)
             search_fragments = spec._tcgen05_optional_fragments(for_search=True)
-            self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 3)
+            # Stage 2: 16-bit for_search AB cap is 4 (narrow-N cm2 ab4 searchable).
+            self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 4)
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_ab_stages_three_seeded_in_initial_population(


### PR DESCRIPTION
Stacked PRs:
 * #3152
 * #3151
 * __->__#3150
 * #3167
 * #3149
 * #3148


--- --- ---

### [autotuner][cute] widen the tcgen05 matmul search space: block_n=128 cluster_m=2 + ab=4


Overarching goal: widen the CuTe autotuner's matmul search space so it can reach
valid, often-faster configs it previously could not. Several non-hardware "coverage"
gates pinned or dropped valid CtaGroup.TWO (cluster_m=2) configs so the autotuner
could not SEARCH them. Headline: the 256x128 tile (block_n=128, ab_stages=4) on
medium-M bf16 was unreachable yet runs 699.1 vs 645.3 TF/s for the reachable cm1
winner on 512x4096x4096 bf16 = +8.3% (cold-L2 cobench, set_config, no autotuner).

Gates lifted (each verified compiles + numerically correct on B200):
  * wave-quant gate counts clusters at the emittable narrow tile (bn=128 = 2x the
    clusters of 256x256) for every non-fp8 cm2 family (drops the earlier
    leading_work_multiplier==1 restriction so the batched family qualifies).
  * cm2 block_n shaping rounds a sampled bn<=128 UP to the 128 tile (was: only
    exact-128 kept). The 256x256 tile is already seeded, so it needs no search draw;
    the [256,128,*] tile is un-seeded and reachable only via search.
  * 16-bit ab-stage search cap 3 -> 4.
  * ab-envelope validator admits 16-bit cm2 DEFAULT-layout ab>3 within SMEM budget,
    including the batched family (per-CTA AB SMEM is batch-invariant; leading axis
    squeezed to 1). GPU-verified: batched [1,256,128,128] cm2 bf16 ab4 -> ab=4,
    CtaGroup.TWO, compiles, matches torch.bmm.
  * bn=128 cm2 admission extended from the 2-D full-tile path to edge-K-tail + batched
    (2-CTA decision keys on block_m only).
Genuine limits still enforced (ab6/bk128 overflow rejected; cluster_m=1 keeps ab<=3).

Shapes that could not search cluster_m=2 before and now do (bind-time, HEAD vs base):
512x4096x4096 (cluster_m search choices (1,) -> (1,2); 32 clusters@256 -> 64@128, so
the [256,128,128] cm2 ab4 tile is now drawn and kept). The already-cm2-searchable
1024x4096x4096 and 2048x4096x4096 additionally gain the ab4 narrow tile (were ab3-only).
Tests updated; no new regressions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
