### PR TITLE
Fix flaky linear-attention test OOM

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2830,6 +2830,11 @@ class TestExamples(RefEagerTestBase, TestCase):
         # restored after the test.
         from examples.linear import linear_attention_engine as engine
 
+        # Free cached GPU memory after each test so xdist workers
+        # sharing one GPU don't OOM.
+        if torch.cuda.is_available():
+            self.addCleanup(torch.cuda.empty_cache)
+
         for kernel in vars(engine).values():
             if isinstance(kernel, helion.Kernel):
                 original_effort = kernel.settings.autotune_effort


### PR DESCRIPTION
The linear-attention example tests intermittently fail on H100 with `Triton Error [CUDA]: out of memory` under xdist. They compile many kernels and nothing frees the allocator cache between them, so concurrent workers on one GPU run out of memory.

Free cached GPU memory in `_skip_linear_engine_autotune`, which every linattn test calls.