### PR TITLE
[pretuned] per_token_group_fp8_quant: add single multi-shape config

### DIFF
--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -21,6 +21,10 @@ from torch._inductor.codecache import torch_key
 from .. import exc
 from .._utils import counters
 from .base_search import BaseAutotuner
+from .benchmark_provider import _format_selected_multi_shape_measurement
+from .benchmark_provider import _has_valid_multi_shape_measurement
+from .benchmark_provider import _materialize_multi_shape_config
+from .benchmark_provider import _MultiShapeAutotuneArgs
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -215,6 +219,26 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
             )
         self.kernel: BoundKernel = kernel  # type: ignore[assignment]
         self.args = self.autotuner.args
+        if isinstance(self.args, _MultiShapeAutotuneArgs):
+            self.args.defer_selected_log = True
+
+    def _format_performance(self, value: float) -> str:
+        suffix = (
+            "x"
+            if isinstance(self.args, _MultiShapeAutotuneArgs)
+            and self.args.relative_to is not None
+            else "ms"
+        )
+        return f"{value:.4f}{suffix}"
+
+    def _log_selected_multi_shape(self, summary: str) -> None:
+        if self.autotuner.settings.autotune_log:
+            # The inner search's structured-log context is closed by the time
+            # the cache layer selects its final winner.
+            with self.autotuner.log.autotune_logging():
+                self.autotuner.log(summary)
+        else:
+            self.autotuner.log(summary)
 
     @abc.abstractmethod
     def get(self) -> Config | None:
@@ -311,6 +335,19 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         self.autotuner.log("Starting autotuning process, this may take a while...")
 
         config = self._run_autotune_trials()
+        if isinstance(self.args, _MultiShapeAutotuneArgs):
+            if self.args.search_started and not self.args.found_valid_config:
+                raise exc.NoConfigFound
+            config = _materialize_multi_shape_config(self.autotuner.config_spec, config)
+            if self.args.search_started and not _has_valid_multi_shape_measurement(
+                self.args,
+                self.autotuner.config_spec,
+                config,
+            ):
+                raise exc.NoConfigFound
+            summary = _format_selected_multi_shape_measurement(self.args, config)
+            if summary is not None:
+                self._log_selected_multi_shape(summary)
 
         if not skip_cache_env:
             self.put(config)
@@ -357,7 +394,7 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         trial_low_water_perf = trial_autotuner.best_perf_so_far
         self.autotuner.log(
             f"Best-of-K trial {i + 1}/{k} complete: "
-            f"low-water perf={trial_low_water_perf:.4f}ms "
+            f"low-water perf={self._format_performance(trial_low_water_perf)} "
             f"config={trial_config}"
         )
         return trial_config, trial_low_water_perf
@@ -420,15 +457,29 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         )
 
         trial_results: list[tuple[int, Config, float]] = []
+        is_multi_shape = isinstance(self.args, _MultiShapeAutotuneArgs)
         try:
             for i in range(k):
                 trial_seed = base_seed + i
                 try:
                     settings.autotune_random_seed = trial_seed
                     settings.autotune_compile_timeout = base_compile_timeout
-                    trial_config, trial_low_water_perf = self._run_one_trial(
-                        i, k, trial_seed
-                    )
+                    try:
+                        trial_config, trial_low_water_perf = self._run_one_trial(
+                            i, k, trial_seed
+                        )
+                    except exc.NoConfigFound:
+                        if not is_multi_shape:
+                            raise
+                        self.autotuner.log(
+                            f"Best-of-K trial {i + 1}/{k} found no valid config"
+                        )
+                        continue
+                    if is_multi_shape and not math.isfinite(trial_low_water_perf):
+                        self.autotuner.log(
+                            f"Best-of-K trial {i + 1}/{k} returned no finite timing"
+                        )
+                        continue
                     trial_results.append((i, trial_config, trial_low_water_perf))
                 finally:
                     settings.autotune_random_seed = base_seed
@@ -447,12 +498,17 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         finally:
             self.autotuner = original_autotuner
 
+        if not trial_results:
+            raise exc.NoConfigFound
+
         # Final rebench: time each trial's returned config in a single fresh
         # benchmark round so we pick by an apples-to-apples measurement
         # rather than each trial's optimistic low-water mark.
         rebench_perfs = self._rebench_trial_configs(
             [config for (_, config, _) in trial_results]
         )
+        if is_multi_shape and not any(math.isfinite(perf) for perf in rebench_perfs):
+            raise exc.NoConfigFound
 
         best_idx = min(
             range(len(trial_results)),
@@ -463,20 +519,24 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
         best_trial_idx, best_config, _ = trial_results[best_idx]
         best_perf = rebench_perfs[best_idx]
 
-        low_water_summary = ", ".join(f"{p:.4f}" for (_, _, p) in trial_results)
-        rebench_summary = ", ".join(f"{p:.4f}" for p in rebench_perfs)
+        low_water_summary = ", ".join(
+            self._format_performance(perf) for _, _, perf in trial_results
+        )
+        rebench_summary = ", ".join(
+            self._format_performance(perf) for perf in rebench_perfs
+        )
         self.autotuner.log(
             f"Best-of-K complete: picked trial {best_trial_idx + 1}/{k} "
-            f"(rebench perf={best_perf:.4f}ms); "
-            f"per-trial low-water perfs (ms): [{low_water_summary}]; "
-            f"per-trial rebench perfs (ms): [{rebench_summary}]"
+            f"(rebench perf={self._format_performance(best_perf)}); "
+            f"per-trial low-water objectives: [{low_water_summary}]; "
+            f"per-trial rebench objectives: [{rebench_summary}]"
         )
         return best_config
 
     def _rebench_trial_configs(self, configs: list[Config]) -> list[float]:
         """Benchmark K candidate configs in a single fresh autotuner round.
 
-        Returns one perf (ms) per input config, in input order. Used to pick
+        Returns one scalar objective per input config, in input order. Used to pick
         the best-of-K winner without trusting each trial's own optimistic
         ``best_perf_so_far`` low-water mark, which can be inflated by a
         single fast outlier timing during the search.

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
+from torch.utils._pytree import tree_flatten
 from torch.utils._pytree import tree_map_only
 
 from .. import exc
@@ -33,7 +34,9 @@ from ..runtime.settings import _env_get_int
 from .benchmark_provider import BenchmarkProvider
 from .benchmark_provider import BenchmarkResult
 from .benchmark_provider import LocalBenchmarkProvider
+from .benchmark_provider import MultiShapeBenchmarkProvider
 from .benchmark_provider import _clone_args
+from .benchmark_provider import _MultiShapeAutotuneArgs
 from .benchmark_provider import _unset_fn
 from .benchmarking import clear_jit_fast_path_caches
 from .benchmarking import do_bench
@@ -271,6 +274,20 @@ class BaseSearch(BaseAutotuner):
         self._pinned_finalist_configs: set[Config] = set()
         self._pinned_finalist_members: dict[Config, PopulationMember] = {}
 
+    @property
+    def performance_unit(self) -> Literal["ms", "ratio"]:
+        args = getattr(self, "args", ())
+        if isinstance(args, _MultiShapeAutotuneArgs) and args.relative_to is not None:
+            return "ratio"
+        return "ms"
+
+    @property
+    def performance_suffix(self) -> str:
+        return "x" if self.performance_unit == "ratio" else "ms"
+
+    def format_performance(self, value: float) -> str:
+        return f"{value:.4f}{self.performance_suffix}"
+
     def _prepare(self) -> None:
         """Some initialization deferred until autotuning actually runs.
 
@@ -294,9 +311,26 @@ class BaseSearch(BaseAutotuner):
             except OSError:
                 self.log.debug("Failed to read Helion kernel source", exc_info=True)
         kernel_name = getattr(kernel_obj, "name", "")
-        tensors = [arg for arg in self.args if isinstance(arg, torch.Tensor)]
-        input_shapes = str([tuple(t.shape) for t in tensors])
-        dtypes = str([str(t.dtype) for t in tensors])
+        if isinstance(self.args, _MultiShapeAutotuneArgs):
+            case_tensors = []
+            for _, case_args in self.args.cases:
+                leaves, _ = tree_flatten(case_args)
+                case_tensors.append(
+                    [value for value in leaves if isinstance(value, torch.Tensor)]
+                )
+            input_shapes = str(
+                [
+                    [tuple(tensor.shape) for tensor in tensors]
+                    for tensors in case_tensors
+                ]
+            )
+            dtypes = str(
+                [[str(tensor.dtype) for tensor in tensors] for tensors in case_tensors]
+            )
+        else:
+            tensors = [arg for arg in self.args if isinstance(arg, torch.Tensor)]
+            input_shapes = str([tuple(t.shape) for t in tensors])
+            dtypes = str([str(t.dtype) for t in tensors])
         hardware = get_device_name(extract_device(self.args)) or ""
         self._autotune_metrics: AutotuneMetrics = AutotuneMetrics(
             kernel_name=kernel_name,
@@ -316,7 +350,12 @@ class BaseSearch(BaseAutotuner):
             settings=self.settings.to_dict(),
             _device_ir=getattr(host_function, "_device_ir", None),
         )
-        self.benchmark_provider = self._benchmark_provider_cls(
+        provider_cls = (
+            MultiShapeBenchmarkProvider
+            if isinstance(self.args, _MultiShapeAutotuneArgs)
+            else self._benchmark_provider_cls
+        )
+        self.benchmark_provider = provider_cls(
             kernel=self.kernel,
             settings=self.settings,
             config_spec=self.config_spec,
@@ -545,10 +584,19 @@ class BaseSearch(BaseAutotuner):
             exit_stack.enter_context(patch.dict(os.environ, env_overrides, clear=False))
             self.benchmark_provider.setup()
             exit_stack.callback(self.benchmark_provider.cleanup)
+            best: Config | None = None
             try:
                 best = self._autotune()
+                if isinstance(
+                    self.benchmark_provider, MultiShapeBenchmarkProvider
+                ) and isinstance(self.args, _MultiShapeAutotuneArgs):
+                    if not self.benchmark_provider.has_valid_measurement(best):
+                        raise exc.NoConfigFound
+                    if not self.args.defer_selected_log:
+                        self.benchmark_provider.log_selected(best)
             finally:
-                self._finalize_autotune_metrics()
+                self._finalize_autotune_metrics(best)
+        assert best is not None
         end = time.perf_counter()
         kernel_decorator = self.kernel.format_kernel_decorator(best, self.settings)
 
@@ -698,9 +746,17 @@ class BaseSearch(BaseAutotuner):
     def set_generation(self, generation: int) -> None:
         self._autotune_metrics.num_generations = generation
 
-    def _finalize_autotune_metrics(self) -> None:
+    def _finalize_autotune_metrics(self, best_config: Config | None = None) -> None:
+        best_perf = self.best_perf_so_far
+        if self.performance_unit == "ratio":
+            best_perf = (
+                self.benchmark_provider.raw_latency(best_config)
+                if best_config is not None
+                and isinstance(self.benchmark_provider, MultiShapeBenchmarkProvider)
+                else inf
+            )
         self._autotune_metrics.best_perf_ms = (
-            self.best_perf_so_far if math.isfinite(self.best_perf_so_far) else 0.0
+            best_perf if math.isfinite(best_perf) else 0.0
         )
         self._autotune_metrics.finalize()
         _run_post_autotune_hooks(self._autotune_metrics)
@@ -1312,7 +1368,8 @@ class PopulationBasedSearch(BaseSearch):
         if after.config != before.config:
             self.log(
                 "Final verification selected a different config: "
-                f"{before.perf:.4f}ms -> {after.perf:.4f}ms"
+                f"{self.format_performance(before.perf)} -> "
+                f"{self.format_performance(after.perf)}"
             )
         return after
 
@@ -1364,6 +1421,17 @@ class PopulationBasedSearch(BaseSearch):
             desc: Description for the progress bar.
         """
         if len(members) < 2:
+            return
+        if isinstance(self.benchmark_provider, MultiShapeBenchmarkProvider):
+            provider_timings = self.benchmark_provider.rebenchmark(
+                [member.config for member in members],
+                [member.perf for member in members],
+                desc=desc,
+            )
+            for member, timing in zip(members, provider_timings, strict=True):
+                member.perfs.append(timing)
+                if timing < self.best_perf_so_far:
+                    self.best_perf_so_far = timing
             return
 
         # Size the in-process repeat from the candidates being rechecked. A
@@ -1605,8 +1673,10 @@ class PopulationBasedSearch(BaseSearch):
                 delta_pct = (delta / current_perf * 100) if current_perf != 0 else 0
                 status = "ok" if candidate.perf <= current_perf else "worse"
                 self.log.debug(
-                    f"  reset to {candidate.config}: {candidate.perf:.4f}ms "
-                    f"(delta={delta:+.4f}ms, {delta_pct:+.1f}%) [{status}]"
+                    f"  reset to {candidate.config}: "
+                    f"{self.format_performance(candidate.perf)} "
+                    f"(delta={delta:+.4f}{self.performance_suffix}, "
+                    f"{delta_pct:+.1f}%) [{status}]"
                 )
 
             # Collect all single-attribute resets that maintained performance
@@ -1643,7 +1713,8 @@ class PopulationBasedSearch(BaseSearch):
 
             if simplified:
                 self.log(
-                    f"Finishing round {round_num}: simplified to {current.config}, perf={current.perf:.4f}ms"
+                    f"Finishing round {round_num}: simplified to {current.config}, "
+                    f"perf={self.format_performance(current.perf)}"
                 )
             else:
                 self.log(
@@ -1651,8 +1722,13 @@ class PopulationBasedSearch(BaseSearch):
                 )
                 break
 
-        # Minimize the final config by removing values that match defaults
-        minimal_config = current.config.minimize(self.config_spec)
+        # Multi-shape winners must stay explicit: minimizing can collapse an
+        # optional tuned reset and a compiler-promoted default to the same key.
+        minimal_config = (
+            current.config
+            if isinstance(self.args, _MultiShapeAutotuneArgs)
+            else current.config.minimize(self.config_spec)
+        )
         current = PopulationMember(
             fn=current.fn,
             perfs=current.perfs,
@@ -1723,7 +1799,7 @@ class PopulationBasedSearch(BaseSearch):
         if best_member is not best:
             self.log(
                 f"Final-pick re-picked {best_member.config} "
-                f"({best_member.perf:.4f}ms) over {best.config}"
+                f"({self.format_performance(best_member.perf)}) over {best.config}"
             )
         self.best_perf_so_far = min(self.best_perf_so_far, best_member.perf)
         return best_member
@@ -1754,7 +1830,15 @@ class PopulationBasedSearch(BaseSearch):
         # real searches always have them.
         settings = getattr(self, "settings", None)
         config_spec = getattr(self, "config_spec", None)
-        if settings is None or config_spec is None or not settings.static_shapes:
+        if (
+            isinstance(
+                getattr(self, "benchmark_provider", None),
+                MultiShapeBenchmarkProvider,
+            )
+            or settings is None
+            or config_spec is None
+            or not settings.static_shapes
+        ):
             return None
         return config_spec.backend.get_paired_device_micros_bench()
 

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import copy
+import dataclasses
 import datetime
 import functools
 from itertools import count
@@ -70,6 +71,153 @@ if TYPE_CHECKING:
     from .base_search import _AutotunableKernel
     from .logger import AutotuningLogger
     from .metrics import AutotuneMetrics
+
+
+MultiShapeAggregation = Literal["geomean", "max"]
+MultiShapeReference = Literal["default", "baseline"] | None
+
+
+@dataclasses.dataclass
+class _MultiShapeAutotuneArgs:
+    """Private carrier that keeps existing autotuners anchored to one args tuple."""
+
+    cases: tuple[tuple[BoundKernel, tuple[object, ...]], ...]
+    aggregation: MultiShapeAggregation
+    relative_to: MultiShapeReference
+    cache_tag: str | None
+    workload_key: tuple[object, ...]
+    reference_latencies: tuple[float, ...] | None = None
+    measurements: dict[str, tuple[tuple[float, ...], float, tuple[str, ...]]] = (
+        dataclasses.field(default_factory=dict)
+    )
+    defer_selected_log: bool = False
+    search_started: bool = False
+    found_valid_config: bool = False
+
+    def __len__(self) -> int:
+        return len(self.cases[0][1])
+
+    def __getitem__(self, index: int | slice) -> object:
+        return self.cases[0][1][index]
+
+
+def _aggregate_values(
+    values: Sequence[float], aggregation: MultiShapeAggregation
+) -> float:
+    if not values or any(not math.isfinite(value) or value <= 0 for value in values):
+        return inf
+    if aggregation == "max":
+        return max(values)
+    return math.exp(math.fsum(math.log(value) for value in values) / len(values))
+
+
+def _aggregate_multi_shape_timings(
+    timings: Sequence[float],
+    *,
+    aggregation: MultiShapeAggregation,
+    references: Sequence[float] | None,
+) -> float:
+    """Reduce per-shape timings to the scalar objective used by searches."""
+    raw = _aggregate_values(timings, aggregation)
+    if references is None or not math.isfinite(raw):
+        return raw
+    if len(timings) != len(references) or not math.isfinite(
+        _aggregate_values(references, aggregation)
+    ):
+        return inf
+    ratios = [
+        timing / reference
+        for timing, reference in zip(timings, references, strict=True)
+    ]
+    return _aggregate_values(ratios, aggregation)
+
+
+def _format_multi_shape_measurement(
+    args: _MultiShapeAutotuneArgs,
+    config: Config,
+    timings: Sequence[float],
+    aggregate: float,
+    *,
+    selected: bool,
+    statuses: Sequence[str] | None = None,
+) -> str:
+    """Format one joint result with enough detail to explain its objective."""
+    references = args.reference_latencies
+    rows = []
+    for index, ((_, case_args), timing) in enumerate(
+        zip(args.cases, timings, strict=True)
+    ):
+        leaves, _ = tree_flatten(case_args)
+        tensor_shapes = [
+            tuple(value.shape) for value in leaves if torch.is_tensor(value)
+        ]
+        shape_text = f" tensor_shapes={tensor_shapes}" if tensor_shapes else ""
+        status = statuses[index] if statuses is not None else "ok"
+        if status != "ok" or not math.isfinite(timing) or timing <= 0:
+            row = f"arg_sets[{index}]{shape_text}: status={status}"
+            if math.isfinite(timing):
+                row += f", latency={timing:.6f} ms"
+        else:
+            row = f"arg_sets[{index}]{shape_text}: latency={timing:.6f} ms"
+        if (
+            references is not None
+            and status == "ok"
+            and math.isfinite(timing)
+            and timing > 0
+        ):
+            reference = references[index]
+            row += (
+                f", {args.relative_to} reference={reference:.6f} ms"
+                f", ratio={timing / reference:.6f}x"
+            )
+        rows.append(row)
+
+    if not math.isfinite(aggregate):
+        objective = "rejected"
+    elif references is None:
+        objective = f"{args.aggregation}(latencies)={aggregate:.6f} ms"
+    else:
+        objective = (
+            f"{args.aggregation}(latency ratios vs {args.relative_to})={aggregate:.6f}x"
+        )
+    if selected:
+        details = "\n  ".join([*rows, f"objective: {objective}"])
+        return f"Selected multi-shape config {config}:\n  {details}"
+    return f"Multi-shape candidate {config}: {'; '.join([*rows, f'objective: {objective}'])}"
+
+
+def _format_selected_multi_shape_measurement(
+    args: _MultiShapeAutotuneArgs, config: Config
+) -> str | None:
+    measurement = args.measurements.get(repr(config))
+    if measurement is None:
+        return None
+    timings, aggregate, statuses = measurement
+    return _format_multi_shape_measurement(
+        args,
+        config,
+        timings,
+        aggregate,
+        selected=True,
+        statuses=statuses,
+    )
+
+
+def _materialize_multi_shape_config(config_spec: ConfigSpec, config: Config) -> Config:
+    """Normalize a detached config against the anchor shape."""
+    result = copy.deepcopy(config)
+    config_spec.normalize(result)
+    return result
+
+
+def _has_valid_multi_shape_measurement(
+    args: _MultiShapeAutotuneArgs,
+    config_spec: ConfigSpec,
+    config: Config,
+) -> bool:
+    materialized = _materialize_multi_shape_config(config_spec, config)
+    measurement = args.measurements.get(repr(materialized))
+    return measurement is not None and math.isfinite(measurement[1])
 
 
 def _clone_args(
@@ -317,12 +465,18 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         log: AutotuningLogger,
         autotune_metrics: AutotuneMetrics,
     ) -> None:
+        if isinstance(args, _MultiShapeAutotuneArgs):
+            raise TypeError(
+                "LocalBenchmarkProvider cannot benchmark multi-shape args directly"
+            )
         self.kernel = kernel
         self.settings = settings
         self.config_spec = config_spec
         self.args = args
         self.log = log
         self._autotune_metrics = autotune_metrics
+        self._accuracy_failure_config_ids: list[int] = []
+        self._compile_failure_config_ids: list[int] = []
         self._precompile_tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._precompile_args_path: str | None = None
         self._precompile_baseline_path: str | None = None
@@ -345,6 +499,14 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             self._compute_effective_tolerances()
         )
         self._jobs = self._decide_num_jobs()
+
+    def _record_accuracy_failure(self, config: Config) -> None:
+        self._autotune_metrics.num_accuracy_failures += 1
+        self._accuracy_failure_config_ids.append(id(config))
+
+    def _record_compile_failure(self, config: Config) -> None:
+        self._autotune_metrics.num_compile_failures += 1
+        self._compile_failure_config_ids.append(id(config))
 
     def _compute_baseline(
         self,
@@ -952,7 +1114,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 or self._validate_against_baseline(config, output, working_args)
             )
             if not pass_accuracy_check:
-                self._autotune_metrics.num_accuracy_failures += 1
+                self._record_accuracy_failure(config)
             if not all(
                 all_gather_object(
                     pass_accuracy_check,
@@ -1060,7 +1222,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 self.log.debug(f"Benchmarking failed: {type(e).__name__}: {e}")
                 self.kernel.maybe_log_repro(self.log.debug, self.args, config)
 
-            self._autotune_metrics.num_compile_failures += 1
+            self._record_compile_failure(config)
             return inf
         finally:
             self._clear_jit_fast_path_caches(fn)
@@ -1080,7 +1242,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         except BenchmarkSubprocessError as e:
             # Timeout or unexpected worker exit; skip config and continue.
             self.log.warning(f"Benchmark subprocess failed for {config!r}: {e}")
-            self._autotune_metrics.num_compile_failures += 1
+            self._record_compile_failure(config)
             return inf
         except Exception as e:
             e.__traceback__ = None
@@ -1094,12 +1256,12 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     f"{type(e).__qualname__}: {e}\n  Config: {decorator}"
                 )
                 self.kernel.maybe_log_repro(self.log.warning, self.args, config)
-                self._autotune_metrics.num_compile_failures += 1
+                self._record_compile_failure(config)
                 return inf
             self.log.debug(
                 f"Benchmark subprocess raised for {config!r}: {type(e).__name__}: {e}"
             )
-            self._autotune_metrics.num_compile_failures += 1
+            self._record_compile_failure(config)
             return inf
 
         if self.settings.autotune_accuracy_check:
@@ -1109,7 +1271,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 self.log.warning(
                     f"Accuracy check subprocess failed for {config!r}: {e}"
                 )
-                self._autotune_metrics.num_compile_failures += 1
+                self._record_compile_failure(config)
                 return inf
             except Exception as e:
                 e.__traceback__ = None
@@ -1125,13 +1287,13 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                         f"{type(e).__qualname__}: {e}\n  Config: {decorator}"
                     )
                     self.kernel.maybe_log_repro(self.log.warning, self.args, config)
-                    self._autotune_metrics.num_compile_failures += 1
+                    self._record_compile_failure(config)
                     return inf
                 self.log.debug(
                     f"Accuracy check subprocess raised for {config!r}: "
                     f"{type(e).__name__}: {e}"
                 )
-                self._autotune_metrics.num_compile_failures += 1
+                self._record_compile_failure(config)
                 return inf
 
             if accuracy_result is not None:
@@ -1142,7 +1304,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                             f"{accuracy_result.message}\n"
                             "Use HELION_AUTOTUNE_ACCURACY_CHECK=0 to disable this check.\n"
                         )
-                    self._autotune_metrics.num_accuracy_failures += 1
+                    self._record_accuracy_failure(config)
                     return inf
                 return float(latency)
 
@@ -1153,7 +1315,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     output = fn(*self.args)
                     synchronize_device()
                 if not self._validate_against_baseline(config, output, self.args):
-                    self._autotune_metrics.num_accuracy_failures += 1
+                    self._record_accuracy_failure(config)
                     return inf
             except Exception as e:
                 e.__traceback__ = None
@@ -1171,7 +1333,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 self.log.debug(
                     f"Accuracy check raised for {config!r}: {type(e).__name__}: {e}"
                 )
-                self._autotune_metrics.num_compile_failures += 1
+                self._record_compile_failure(config)
                 return inf
             finally:
                 # Same as the in-process path: drop JIT fast-path caches so
@@ -1278,3 +1440,412 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     timing = None
             timings.append(None if timing is None else float(timing))
         return timings
+
+
+class MultiShapeBenchmarkProvider(BenchmarkProvider):
+    """Compose ordinary local providers and expose one scalar per config."""
+
+    mutated_arg_indices: Sequence[int] = ()
+
+    def __init__(
+        self,
+        kernel: _AutotunableKernel,
+        settings: Settings,
+        config_spec: ConfigSpec,
+        args: Sequence[object],
+        log: AutotuningLogger,
+        autotune_metrics: AutotuneMetrics,
+    ) -> None:
+        if not isinstance(args, _MultiShapeAutotuneArgs):
+            raise TypeError("MultiShapeBenchmarkProvider requires multi-shape args")
+        from .metrics import AutotuneMetrics
+
+        self.kernel = kernel
+        self.settings = settings
+        self.config_spec = config_spec
+        self.args = args
+        self.log = log
+        self._autotune_metrics = autotune_metrics
+        self.args.search_started = True
+        self.children: list[LocalBenchmarkProvider] = []
+        child_log = copy.copy(log)
+        child_log._log_sink = None
+        case_index = 0
+        try:
+            for index, (case_kernel, case_args) in enumerate(args.cases):
+                case_index = index
+                child = LocalBenchmarkProvider(
+                    kernel=case_kernel,
+                    settings=case_kernel.settings,
+                    config_spec=case_kernel.config_spec,
+                    args=case_args,
+                    # Child rows are implementation details, so only their text logs
+                    # are forwarded to the aggregate logger.
+                    log=child_log,
+                    autotune_metrics=AutotuneMetrics(),
+                )
+                child.set_budget_exceeded_fn(_never_exceeded)
+                self.children.append(child)
+        except Exception as error:
+            for child in reversed(self.children):
+                child.cleanup()
+            if f"arg_sets[{case_index}]" in str(error):
+                raise
+            raise exc.AutotuneError(
+                "Failed to prepare multi-shape autotune "
+                f"arg_sets[{case_index}]: {error}"
+            ) from error
+
+    def set_budget_exceeded_fn(self, fn: Callable[[], bool]) -> None:
+        self.budget_exceeded_fn = fn
+        for child in self.children:
+            child.set_budget_exceeded_fn(_never_exceeded)
+
+    def setup(self) -> None:
+        case_index = 0
+        try:
+            for index, child in enumerate(self.children):
+                case_index = index
+                child.setup()
+            if (
+                self.args.relative_to is not None
+                and self.args.reference_latencies is None
+            ):
+                reference_values = []
+                for case_index, child in enumerate(self.children):
+                    reference_values.append(self._measure_reference(child, case_index))
+                references = tuple(reference_values)
+                if _aggregate_values(references, self.args.aggregation) == inf:
+                    raise exc.AutotuneError(
+                        "Multi-shape reference timings must be finite and positive"
+                    )
+                self.args.reference_latencies = references
+        except Exception as error:
+            for child in reversed(self.children):
+                child.cleanup()
+            if f"arg_sets[{case_index}]" in str(error):
+                raise
+            raise exc.AutotuneError(
+                f"Failed to set up multi-shape autotune arg_sets[{case_index}]: {error}"
+            ) from error
+
+    def cleanup(self) -> None:
+        for child in reversed(self.children):
+            child.cleanup()
+        self.budget_exceeded_fn = _never_exceeded
+
+    def _measure_reference(
+        self, child: LocalBenchmarkProvider, case_index: int
+    ) -> float:
+        if self.args.relative_to == "default":
+            result = child.benchmark(
+                [child.config_spec.default_config()],
+                desc="Benchmarking default reference",
+            )[0]
+            if (
+                result.status != "ok"
+                or not math.isfinite(result.perf)
+                or result.perf <= 0
+            ):
+                raise exc.AutotuneError(
+                    "Default config reference benchmark failed for "
+                    f"arg_sets[{case_index}]"
+                )
+            return result.perf
+        baseline_fn = child.settings.autotune_baseline_fn
+        if baseline_fn is None:
+            raise exc.AutotuneError(
+                "relative_to='baseline' requires autotune_baseline_fn for "
+                f"arg_sets[{case_index}]"
+            )
+        if child.mutated_arg_indices:
+            reference_args = _clone_args(
+                child.args,
+                child.kernel.env.process_group_name,
+                idx_to_clone=child.mutated_arg_indices,
+            )
+        else:
+            reference_args = child.args
+        backend = getattr(child.config_spec, "backend", None)
+        benchmark_runner = (
+            backend.get_do_bench() if backend is not None else None
+        ) or do_bench
+        try:
+            timing = benchmark_runner(
+                functools.partial(baseline_fn, *reference_args),
+                return_mode="median",
+                warmup=1,
+                rep=50,
+                process_group_name=child.kernel.env.process_group_name,
+            )
+        except Exception as error:
+            raise exc.AutotuneError(
+                f"Baseline reference benchmark failed for arg_sets[{case_index}]"
+            ) from error
+        if isinstance(timing, tuple):
+            timing = timing[0]
+        timing = float(timing)
+        if not math.isfinite(timing) or timing <= 0:
+            raise exc.AutotuneError(
+                "Baseline reference benchmark returned invalid timing "
+                f"{timing!r} for arg_sets[{case_index}]"
+            )
+        return timing
+
+    def benchmark(
+        self,
+        configs: list[Config],
+        *,
+        desc: str = "Benchmarking",
+    ) -> list[BenchmarkResult]:
+        return self._benchmark(configs, desc=desc, record_results=True)
+
+    def _benchmark(
+        self,
+        configs: list[Config],
+        *,
+        desc: str,
+        record_results: bool,
+        check_budget: bool = True,
+    ) -> list[BenchmarkResult]:
+        if not configs:
+            return []
+        if check_budget and self.budget_exceeded_fn():
+            return [
+                BenchmarkResult(config, _unset_fn, inf, "error", None)
+                for config in configs
+            ]
+
+        materialized: list[Config] = []
+        valid_indices: list[int] = []
+        results = [
+            BenchmarkResult(config, _unset_fn, inf, "error", None) for config in configs
+        ]
+        for config_index, config in enumerate(configs):
+            try:
+                materialized.append(
+                    _materialize_multi_shape_config(self.config_spec, config)
+                )
+            except exc.InvalidConfig as error:
+                self.log.debug(
+                    f"Skipping config that is invalid for the anchor shape: {error}"
+                )
+                if record_results:
+                    self._record_aggregate_result(config, results[config_index])
+            else:
+                valid_indices.append(config_index)
+        if not materialized:
+            return results
+        materialized_keys = [repr(config) for config in materialized]
+        executed_configs = [copy.deepcopy(config) for config in materialized]
+
+        child_failure_snapshots = [
+            (
+                len(child._accuracy_failure_config_ids),
+                len(child._compile_failure_config_ids),
+            )
+            for child in self.children
+        ]
+        child_results = [
+            self._benchmark_child(
+                child,
+                materialized,
+                desc=f"{desc} shape {index + 1}",
+                case_index=index,
+            )
+            for index, child in enumerate(self.children)
+        ]
+        if record_results:
+            accuracy_failure_ids: set[int] = set()
+            compile_failure_ids: set[int] = set()
+            for child, (before_accuracy, before_compile) in zip(
+                self.children, child_failure_snapshots, strict=True
+            ):
+                accuracy_failure_ids.update(
+                    child._accuracy_failure_config_ids[before_accuracy:]
+                )
+                compile_failure_ids.update(
+                    child._compile_failure_config_ids[before_compile:]
+                )
+            self._autotune_metrics.num_accuracy_failures += len(accuracy_failure_ids)
+            self._autotune_metrics.num_compile_failures += len(compile_failure_ids)
+        for child_config_index, config_index in enumerate(valid_indices):
+            original = configs[config_index]
+            row = [child[child_config_index] for child in child_results]
+            timings = [result.perf for result in row]
+            valid = all(
+                result.status == "ok" and math.isfinite(result.perf) and result.perf > 0
+                for result in row
+            )
+            perf = (
+                _aggregate_multi_shape_timings(
+                    timings,
+                    aggregation=self.args.aggregation,
+                    references=self.args.reference_latencies,
+                )
+                if valid
+                else inf
+            )
+            if valid:
+                timing_tuple = tuple(timings)
+                statuses = tuple(result.status for result in row)
+                self.args.measurements[materialized_keys[child_config_index]] = (
+                    timing_tuple,
+                    perf,
+                    statuses,
+                )
+                self.log.debug(
+                    lambda config=original, values=timing_tuple, objective=perf: (
+                        _format_multi_shape_measurement(
+                            self.args,
+                            config,
+                            values,
+                            objective,
+                            selected=False,
+                        )
+                    )
+                )
+            else:
+                statuses = tuple(result.status for result in row)
+                timing_tuple = tuple(timings)
+                measurement_key = materialized_keys[child_config_index]
+                self.args.measurements[measurement_key] = (
+                    timing_tuple,
+                    inf,
+                    statuses,
+                )
+                self.log.debug(
+                    lambda config=original, values=timing_tuple, states=statuses: (
+                        _format_multi_shape_measurement(
+                            self.args,
+                            config,
+                            values,
+                            inf,
+                            selected=False,
+                            statuses=states,
+                        )
+                    )
+                )
+            timed_out = any(result.status == "timeout" for result in row)
+            if timed_out:
+                status: Literal["ok", "error", "timeout"] = "timeout"
+            else:
+                status = "ok" if math.isfinite(perf) else "error"
+            compile_times = [
+                result.compile_time for result in row if result.compile_time is not None
+            ]
+            compile_time = max(compile_times, default=None)
+            anchor_fn = row[0].fn
+            result = BenchmarkResult(
+                config=original,
+                fn=anchor_fn,
+                perf=perf,
+                status=status,
+                compile_time=compile_time,
+            )
+            results[config_index] = result
+            if math.isfinite(perf):
+                self.args.found_valid_config = True
+            if record_results:
+                self._record_aggregate_result(
+                    executed_configs[child_config_index],
+                    result,
+                    timings=timings,
+                )
+        return results
+
+    def _benchmark_child(
+        self,
+        child: LocalBenchmarkProvider,
+        configs: list[Config],
+        *,
+        desc: str,
+        case_index: int,
+    ) -> list[BenchmarkResult]:
+        try:
+            return child.benchmark(configs, desc=desc)
+        except Exception as error:
+            if not self._is_skippable_child_failure(child, error):
+                raise
+            self.log.debug(
+                "Skipping all configs for "
+                f"arg_sets[{case_index}] after {type(error).__name__}: {error}"
+            )
+            return [
+                BenchmarkResult(config, _unset_fn, inf, "error", None)
+                for config in configs
+            ]
+
+    @staticmethod
+    def _is_skippable_child_failure(
+        child: LocalBenchmarkProvider, error: Exception
+    ) -> bool:
+        if match_unrecoverable_runtime_error(error):
+            return False
+        if isinstance(error, exc.InvalidConfig):
+            return True
+        backend = getattr(child.config_spec, "backend", None)
+        action = (
+            backend.classify_autotune_exception(error) if backend is not None else None
+        ) or classify_triton_exception(error)
+        return child.settings.autotune_ignore_errors or action == "debug"
+
+    def _record_aggregate_result(
+        self,
+        config: Config,
+        result: BenchmarkResult,
+        *,
+        timings: Sequence[float] | None = None,
+    ) -> None:
+        self._autotune_metrics.num_configs_tested += 1
+        config_id = self.log.register_config(config)
+        if config_id is None:
+            return
+        self.log.record_autotune_entry(
+            AutotuneLogEntry(
+                generation=self._autotune_metrics.num_generations,
+                status=result.status,
+                perf_ms=(
+                    _aggregate_values(timings, self.args.aggregation)
+                    if timings is not None and math.isfinite(result.perf)
+                    else None
+                ),
+                compile_time=result.compile_time,
+                config_id=config_id,
+                config=config,
+            )
+        )
+
+    def raw_latency(self, config: Config) -> float:
+        materialized = _materialize_multi_shape_config(self.config_spec, config)
+        measurement = self.args.measurements.get(repr(materialized))
+        if measurement is None:
+            return inf
+        timings, _, _ = measurement
+        return _aggregate_values(timings, self.args.aggregation)
+
+    def has_valid_measurement(self, config: Config) -> bool:
+        return _has_valid_multi_shape_measurement(self.args, self.config_spec, config)
+
+    def log_selected(self, config: Config) -> None:
+        materialized = _materialize_multi_shape_config(self.config_spec, config)
+        summary = _format_selected_multi_shape_measurement(self.args, materialized)
+        if summary is not None:
+            self.log(summary)
+
+    def rebenchmark(
+        self,
+        configs: list[Config],
+        previous_timings: list[float],
+        *,
+        desc: str,
+    ) -> list[float]:
+        if self.budget_exceeded_fn():
+            return list(previous_timings)
+        results = self._benchmark(
+            configs,
+            desc=desc,
+            record_results=False,
+            check_budget=False,
+        )
+        return [result.perf for result in results]

--- a/helion/autotuner/de_surrogate_hybrid.py
+++ b/helion/autotuner/de_surrogate_hybrid.py
@@ -187,7 +187,7 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
 
         best = self.best
         self.log("=" * 70)
-        self.log(f"✓ Best configuration: {best.perf:.4f} ms")
+        self.log(f"✓ Best configuration: {self.format_performance(best.perf)}")
         self.log(f"Total evaluations: {len(self.all_observations)}")
         self.log("=" * 70)
 
@@ -235,7 +235,8 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
         surrogate_status = "SURROGATE" if use_surrogate else "STANDARD"
         self.log(
             f"Gen {generation}: {surrogate_status} | "
-            f"best={best_perf:.4f} ms | replaced={replacements}/{self.population_size} | "
+            f"best={self.format_performance(best_perf)} | "
+            f"replaced={replacements}/{self.population_size} | "
             f"total_evals={len(self.all_observations)}"
         )
 

--- a/helion/autotuner/finite_search.py
+++ b/helion/autotuner/finite_search.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from .. import exc
 from .base_search import BaseSearch
+from .benchmark_provider import _MultiShapeAutotuneArgs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -45,6 +46,8 @@ class FiniteSearch(BaseSearch):
             if result.perf < best_time:
                 best_time = result.perf
                 best_config = result.config
+        if best_config is None and isinstance(self.args, _MultiShapeAutotuneArgs):
+            raise exc.NoConfigFound
         assert best_config is not None
         return best_config
 

--- a/helion/autotuner/llm/feedback.py
+++ b/helion/autotuner/llm/feedback.py
@@ -18,6 +18,11 @@ MAX_ANCHORS_IN_PROMPT = 2
 MAX_CHANGED_FIELDS_PER_CONFIG = 6
 
 
+def _format_performance(perf: float, performance_unit: str) -> str:
+    suffix = " ms" if performance_unit == "ms" else "x"
+    return f"{perf:.4f}{suffix}"
+
+
 def format_config_for_prompt(cfg: Config | dict[str, object]) -> str:
     """Serialize a config exactly as it should appear in prompt examples."""
     return json.dumps(dict(cfg), sort_keys=True, separators=(",", ":"))
@@ -70,6 +75,7 @@ def format_results_for_llm(
     default_config_dict: dict[str, object],
     *,
     limit: int = MAX_RESULTS_IN_PROMPT,
+    performance_unit: str = "ms",
 ) -> str:
     """Format successful and failed benchmark results into a compact block."""
     if not results:
@@ -81,7 +87,7 @@ def format_results_for_llm(
     lines: list[str] = []
     for index, (cfg, perf) in enumerate(sorted_results[:limit], start=1):
         lines.append(
-            f"  #{index}: {perf:.4f} ms — "
+            f"  #{index}: {_format_performance(perf, performance_unit)} — "
             f"{format_config_diff(default_config_dict, cfg)}"
         )
     if failed_count > 0:
@@ -92,6 +98,8 @@ def format_results_for_llm(
 def summarize_search_state_for_llm(
     results: list[BenchmarkResult],
     default_config_dict: dict[str, object],
+    *,
+    performance_unit: str = "ms",
 ) -> str:
     """Summarize the current best result, coverage, and failure counts."""
     finite = finite_results(results)
@@ -101,7 +109,7 @@ def summarize_search_state_for_llm(
     best_cfg, best_perf = finite[0]
     lines = [
         (
-            f"  Best so far: {best_perf:.4f} ms — "
+            f"  Best so far: {_format_performance(best_perf, performance_unit)} — "
             f"{format_config_diff(default_config_dict, best_cfg)}"
         )
     ]
@@ -155,6 +163,7 @@ def summarize_anchor_configs_for_llm(
     default_config_dict: dict[str, object],
     *,
     limit: int = MAX_ANCHORS_IN_PROMPT,
+    performance_unit: str = "ms",
 ) -> str:
     """Show the strongest current configs that the next round should refine."""
     finite = finite_results(results)
@@ -170,7 +179,8 @@ def summarize_anchor_configs_for_llm(
             gap_pct = ((perf - best_perf) / best_perf) * 100
             delta = f"+{gap_pct:.1f}%"
         lines.append(
-            f"  Anchor {index} ({delta}): {perf:.4f} ms — "
+            f"  Anchor {index} ({delta}): "
+            f"{_format_performance(perf, performance_unit)} — "
             f"{format_config_diff(default_config_dict, cfg)}"
         )
     return "\n".join(lines)

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -261,14 +261,17 @@ class LLMGuidedSearch(PopulationBasedSearch):
             search_state=summarize_search_state_for_llm(
                 self._all_benchmark_results,
                 self._default_config_dict,
+                performance_unit=self.performance_unit,
             ),
             anchor_configs=summarize_anchor_configs_for_llm(
                 self._all_benchmark_results,
                 self._default_config_dict,
+                performance_unit=self.performance_unit,
             ),
             results=format_results_for_llm(
                 self._all_benchmark_results,
                 self._default_config_dict,
+                performance_unit=self.performance_unit,
             ),
             top_patterns=analyze_top_configs(
                 self._all_benchmark_results,

--- a/helion/autotuner/llm_seeded_lfbo.py
+++ b/helion/autotuner/llm_seeded_lfbo.py
@@ -22,8 +22,10 @@ import time
 from typing import TYPE_CHECKING
 from typing import cast
 
+from .. import exc
 from .base_search import BaseSearch
 from .base_search import PopulationBasedSearch
+from .benchmark_provider import _MultiShapeAutotuneArgs
 from .effort_profile import QUICK_LLM_SEARCH_DEFAULTS
 from .llm.transport import DEFAULT_REQUEST_TIMEOUT_S
 from .llm_search import LLMGuidedSearch
@@ -283,7 +285,16 @@ class LLMSeededSearch(BaseSearch):
         )
         llm_search = self._make_llm_search()
         llm_start = time.perf_counter()
-        llm_seed_config = llm_search.autotune(skip_cache=True)
+        try:
+            llm_seed_config = llm_search.autotune(skip_cache=True)
+        except exc.NoConfigFound:
+            if not isinstance(self.args, _MultiShapeAutotuneArgs):
+                raise
+            llm_seed_config = None
+        if isinstance(self.args, _MultiShapeAutotuneArgs) and not math.isfinite(
+            llm_search.best_perf_so_far
+        ):
+            llm_seed_config = None
         llm_wall_time = time.perf_counter() - llm_start
         return llm_search, llm_seed_config, llm_wall_time
 
@@ -291,7 +302,7 @@ class LLMSeededSearch(BaseSearch):
         self,
         llm_seed_config: Config | None,
         llm_search: LLMGuidedSearch | None = None,
-    ) -> tuple[BaseSearch, Config, float]:
+    ) -> tuple[BaseSearch, Config | None, float]:
         """Run stage 2, optionally seeded from the stage-1 best config."""
         seeded = llm_seed_config is not None
         self.log(
@@ -308,7 +319,16 @@ class LLMSeededSearch(BaseSearch):
                 second_stage_search, llm_seed_config, llm_search
             )
         second_stage_start = time.perf_counter()
-        best_config = second_stage_search.autotune()
+        try:
+            best_config = second_stage_search.autotune()
+        except exc.NoConfigFound:
+            if not isinstance(self.args, _MultiShapeAutotuneArgs):
+                raise
+            best_config = None
+        if isinstance(self.args, _MultiShapeAutotuneArgs) and not math.isfinite(
+            second_stage_search.best_perf_so_far
+        ):
+            best_config = None
         second_stage_wall_time = time.perf_counter() - second_stage_start
         return second_stage_search, best_config, second_stage_wall_time
 
@@ -325,10 +345,15 @@ class LLMSeededSearch(BaseSearch):
         llm_metrics = llm_search._autotune_metrics if llm_search else None
         second_stage_metrics = second_stage_search._autotune_metrics
         second_stage_tested = second_stage_metrics.num_configs_tested
+        llm_perf = self._finite_perf(llm_search)
+        second_stage_perf = self._finite_perf(second_stage_search)
+        performance_unit = self.performance_unit
 
         self.hybrid_stage_breakdown = {
-            "used_llm_seed": llm_search is not None,
-            "llm_seed_perf_ms": self._finite_perf(llm_search),
+            "used_llm_seed": llm_seed_config is not None,
+            "objective_unit": performance_unit,
+            "llm_seed_objective": llm_perf,
+            "llm_seed_perf_ms": llm_perf if performance_unit == "ms" else None,
             "llm_seed_time_s": llm_wall_time,
             "llm_seed_configs_tested": (
                 llm_metrics.num_configs_tested if llm_metrics else 0
@@ -337,7 +362,10 @@ class LLMSeededSearch(BaseSearch):
                 dict(llm_seed_config) if llm_seed_config is not None else None
             ),
             "second_stage_algorithm": self.second_stage_algorithm,
-            "second_stage_perf_ms": self._finite_perf(second_stage_search),
+            "second_stage_objective": second_stage_perf,
+            "second_stage_perf_ms": (
+                second_stage_perf if performance_unit == "ms" else None
+            ),
             "second_stage_time_s": second_stage_wall_time,
             "second_stage_configs_tested": second_stage_tested,
         }
@@ -382,7 +410,11 @@ class LLMSeededSearch(BaseSearch):
             second_stage_search,
             second_stage_wall_time,
         )
-        return best_config
+        if best_config is not None:
+            return best_config
+        if llm_seed_config is not None:
+            return llm_seed_config
+        raise exc.NoConfigFound
 
 
 class LLMSeededLFBOTreeSearch(LLMSeededSearch):

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -136,15 +136,27 @@ class LocalAutotuneCache(AutotuneCacheBase):
         self.key = self._generate_key()
 
     def _generate_key(self) -> LooseAutotuneCacheKey:
-        in_memory_cache_key = self.kernel.kernel._create_bound_kernel_cache_key(
-            self.kernel,
-            tuple(self.args),
-            self.kernel.kernel._base_specialization_key(self.args),
+        from .benchmark_provider import _MultiShapeAutotuneArgs
+
+        multi_args = (
+            self.args if isinstance(self.args, _MultiShapeAutotuneArgs) else None
         )
+        if multi_args is None:
+            in_memory_cache_key = self.kernel.kernel._create_bound_kernel_cache_key(
+                self.kernel,
+                tuple(self.args),
+                self.kernel.kernel._base_specialization_key(self.args),
+            )
+            specialization_key = in_memory_cache_key.specialization_key
+            extra_results = in_memory_cache_key.extra_results
+            dev = extract_device(self.args)
+        else:
+            specialization_key = multi_args.workload_key
+            extra_results = ()
+            dev = multi_args.cases[0][0].env.device
         kernel_source = textwrap.dedent(inspect.getsource(self.kernel.kernel.fn))
         kernel_source_hash = hashlib.sha256(kernel_source.encode("utf-8")).hexdigest()
 
-        dev = extract_device(self.args)
         assert dev is not None
 
         hardware = get_device_name(dev)
@@ -187,8 +199,8 @@ class LocalAutotuneCache(AutotuneCacheBase):
             advanced_controls_files=self.autotuner.settings.autotune_search_acf or None
         )
         return LooseAutotuneCacheKey(
-            specialization_key=in_memory_cache_key.specialization_key,
-            extra_results=in_memory_cache_key.extra_results,
+            specialization_key=specialization_key,
+            extra_results=extra_results,
             kernel_source_hash=kernel_source_hash,
             hardware=hardware,
             runtime_name=runtime_name,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Sequence
 import contextlib
 import dataclasses
 import functools
@@ -18,7 +19,7 @@ from typing import Any
 from typing import Callable
 from typing import Generic
 from typing import Hashable
-from typing import Sequence
+from typing import Literal
 from typing import TypeVar
 from typing import cast
 from typing import overload
@@ -65,7 +66,6 @@ from .settings import Settings
 
 if TYPE_CHECKING:
     from collections.abc import Hashable
-    from collections.abc import Sequence
 
     from torch._guards import Source
 
@@ -109,6 +109,52 @@ _TPU_COMPILE_CAPTURE = os.environ.get("HELION_TPU_COMPILE_CAPTURE", "0") == "1"
 _graph_module_hash_cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
 
 _INT32_INDEX_LIMIT = torch.iinfo(torch.int32).max
+
+
+def _current_device_index(device_type: str) -> int:
+    device_module = getattr(torch, device_type, None)
+    current_device = getattr(device_module, "current_device", None)
+    if callable(current_device):
+        return cast("int", current_device())
+
+    accelerator = getattr(torch, "accelerator", None)
+    current_accelerator = getattr(accelerator, "current_accelerator", None)
+    current_device_index = getattr(accelerator, "current_device_index", None)
+    if callable(current_accelerator) and callable(current_device_index):
+        accelerator_device = cast("torch.device", current_accelerator())
+        if accelerator_device.type == device_type:
+            return cast("int", current_device_index())
+    raise exc.InvalidAPIUsage(
+        f"autotune_multi requires a current indexed accelerator, got {device_type!r}"
+    )
+
+
+def _canonicalize_multi_shape_device(device: torch.device) -> torch.device:
+    if device.type in ("cpu", "meta", "mps"):
+        raise exc.InvalidAPIUsage(
+            f"autotune_multi requires an indexed accelerator device, got {device}"
+        )
+    if device.index is not None:
+        return device
+    return torch.device(device.type, _current_device_index(device.type))
+
+
+def _has_unspecialized_numeric_value(value: object) -> bool:
+    """Return whether normal specialization records only a numeric value's type."""
+    if isinstance(value, ConstExpr):
+        return False
+    if type(value) in (bool, int, float):
+        return True
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return any(
+            _has_unspecialized_numeric_value(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        )
+    if isinstance(value, dict):
+        return any(_has_unspecialized_numeric_value(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_has_unspecialized_numeric_value(item) for item in value)
+    return False
 
 
 def _resolve_index_dtype(
@@ -476,6 +522,260 @@ class Kernel(Generic[_R]):
         """
         args = self.normalize_args(*args)
         return self.bind(args).autotune(args, force=force, **options)
+
+    def autotune_multi(
+        self,
+        arg_sets: Sequence[Sequence[object]],
+        *,
+        aggregation: Literal["geomean", "max"] = "geomean",
+        relative_to: Literal["default", "baseline"] | None = None,
+        cache_tag: str | None = None,
+        force: bool = True,
+        **options: object,
+    ) -> Config:
+        """Find one config using an objective measured across several inputs.
+
+        The first argument set anchors config generation. Each candidate is measured
+        on every set, then reduced with a geometric mean or maximum. ``relative_to``
+        optionally optimizes per-shape latency relative to each shape's default config
+        or custom baseline. Only the supplied bound specializations are configured.
+
+        Every argument set must bind normally to the same exact, current accelerator
+        device. Distributed processes are not supported. A non-empty ``cache_tag`` is
+        required for custom callbacks, dynamic-shape tuning, and runtime numeric
+        arguments; callers own tag invalidation in those cases.
+
+        Args:
+            arg_sets: Non-empty sequence of representative kernel argument sequences.
+            aggregation: Joint objective, either ``"geomean"`` or ``"max"``.
+            relative_to: Optional ``"default"`` or ``"baseline"`` normalization.
+            cache_tag: User-managed cache discriminator for dynamic shapes, runtime
+                numeric arguments, or callbacks.
+            force: If true, ignore pinned configs and cache reads during the search.
+            options: Additional options forwarded to the registered autotuner.
+
+        Returns:
+            The config selected for all supplied specializations.
+        """
+        from ..autotuner.benchmark_provider import LocalBenchmarkProvider
+        from ..autotuner.benchmark_provider import _has_valid_multi_shape_measurement
+        from ..autotuner.benchmark_provider import _materialize_multi_shape_config
+        from ..autotuner.benchmark_provider import _MultiShapeAutotuneArgs
+        from .settings import default_autotuner_fn
+
+        if aggregation not in ("geomean", "max"):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi aggregation must be 'geomean' or 'max'"
+            )
+        if relative_to not in (None, "default", "baseline"):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi relative_to must be None, 'default', or 'baseline'"
+            )
+        if cache_tag is not None and (not isinstance(cache_tag, str) or not cache_tag):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi cache_tag must be a non-empty string"
+            )
+        if (
+            not isinstance(arg_sets, Sequence)
+            or isinstance(arg_sets, (str, bytes))
+            or not arg_sets
+        ):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi arg_sets must be a non-empty sequence"
+            )
+        if dist.is_initialized():
+            raise exc.InvalidAPIUsage(
+                "autotune_multi does not support an initialized distributed process group"
+            )
+        if self.settings.backend not in {"triton", "tileir", "cute", "pallas"}:
+            raise exc.InvalidAPIUsage(
+                f"autotune_multi does not support backend {self.settings.backend!r}"
+            )
+        if self.settings.autotuner_fn is not default_autotuner_fn:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires the default registered autotuner"
+            )
+        if self.settings.autotune_cache == "AOTAutotuneCache":
+            raise exc.InvalidAPIUsage(
+                "autotune_multi does not support AOTAutotuneCache"
+            )
+        if self.settings.autotune_cache not in {
+            "LocalAutotuneCache",
+            "StrictLocalAutotuneCache",
+            "RemoteAutotuneCache",
+            "StrictRemoteAutotuneCache",
+        }:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires a built-in local or remote best-config cache"
+            )
+        if "benchmark_provider_cls" in options:
+            if options.pop("benchmark_provider_cls") is not LocalBenchmarkProvider:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi does not support a custom benchmark provider"
+                )
+        if relative_to == "baseline" and self.settings.autotune_baseline_fn is None:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi relative_to='baseline' requires autotune_baseline_fn"
+            )
+        if self.settings.autotune_benchmark_fn is not None:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi does not support autotune_benchmark_fn"
+            )
+
+        custom_callbacks = (
+            self.settings.autotune_baseline_fn,
+            self.settings.autotune_baseline_accuracy_check_fn,
+            self.settings.autotune_config_filter,
+        )
+        if cache_tag is None and any(fn is not None for fn in custom_callbacks):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires cache_tag when a custom baseline, "
+                "accuracy check, or config filter is configured"
+            )
+        if cache_tag is None and not self.settings.static_shapes:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires cache_tag when static_shapes=False"
+            )
+
+        normalized_arg_sets: list[tuple[object, ...]] = []
+        for case_index, arg_set in enumerate(arg_sets):
+            if not isinstance(arg_set, Sequence) or isinstance(arg_set, (str, bytes)):
+                raise exc.InvalidAPIUsage(
+                    f"autotune_multi arg_sets[{case_index}] must be a sequence"
+                )
+            try:
+                normalized_arg_sets.append(self.normalize_args(*arg_set))
+            except TypeError as error:
+                raise exc.InvalidAPIUsage(
+                    f"autotune_multi arg_sets[{case_index}] does not match the "
+                    f"kernel signature: {error}"
+                ) from error
+
+        if cache_tag is None:
+            for case_index, normalized_args in enumerate(normalized_arg_sets):
+                if any(
+                    annotation is not ConstExpr
+                    and _has_unspecialized_numeric_value(value)
+                    for value, annotation in zip(
+                        normalized_args, self._annotations, strict=True
+                    )
+                ):
+                    raise exc.InvalidAPIUsage(
+                        "autotune_multi requires cache_tag when an argument set "
+                        "contains a runtime numeric value; "
+                        f"arg_sets[{case_index}] does"
+                    )
+
+        cases: list[tuple[BoundKernel[_R], tuple[object, ...]]] = []
+        case_keys: list[BoundKernelInMemoryCacheKey] = []
+        for case_index, normalized_args in enumerate(normalized_arg_sets):
+            try:
+                bound_kernel = self.bind(normalized_args)
+            except exc.NoTensorArgs as error:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi requires each argument set to have a device "
+                    f"discoverable by normal kernel binding; arg_sets[{case_index}] did not"
+                ) from error
+            signature = self._base_specialization_key(normalized_args)
+            case_key = self._get_bound_kernel_cache_key(normalized_args, signature)
+            assert case_key is not None
+            cases.append((bound_kernel, normalized_args))
+            case_keys.append(case_key)
+
+        anchor = cases[0][0]
+        canonical_device = _canonicalize_multi_shape_device(anchor.env.device)
+        current_index = _current_device_index(canonical_device.type)
+        if canonical_device.index != current_index:
+            raise exc.InvalidAPIUsage(
+                "autotune_multi requires the indexed accelerator to be current: "
+                f"got {canonical_device}, current index is {current_index}"
+            )
+
+        unique_bound_kernels: list[BoundKernel[_R]] = []
+        seen_bound_kernel_ids: set[int] = set()
+        for bound_kernel, _ in cases:
+            if id(bound_kernel) not in seen_bound_kernel_ids:
+                seen_bound_kernel_ids.add(id(bound_kernel))
+                unique_bound_kernels.append(bound_kernel)
+
+        anchor_backend = anchor.env.backend.name
+        anchor_capability = target_device_capability(anchor.env.device)
+        advanced_controls_files = self.settings.autotune_search_acf or None
+        anchor_fingerprint = anchor.config_spec.structural_fingerprint(
+            advanced_controls_files=advanced_controls_files
+        )
+        for case_index, (bound_kernel, _) in enumerate(cases):
+            if bound_kernel.env.process_group_name is not None:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi does not support a bound kernel with a process group"
+                )
+            bound_device = _canonicalize_multi_shape_device(bound_kernel.env.device)
+            if bound_device != canonical_device:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi bound a different device for "
+                    f"arg_sets[{case_index}]: {bound_device} != {canonical_device}"
+                )
+            if bound_kernel.env.backend.name != anchor_backend:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi requires every case to use the same backend"
+                )
+            if target_device_capability(bound_kernel.env.device) != anchor_capability:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi requires every case to have the same device capability"
+                )
+            fingerprint = bound_kernel.config_spec.structural_fingerprint(
+                advanced_controls_files=advanced_controls_files
+            )
+            if fingerprint != anchor_fingerprint:
+                raise exc.InvalidAPIUsage(
+                    "autotune_multi requires structurally compatible ConfigSpec "
+                    f"instances; arg_sets[{case_index}] is incompatible with the anchor"
+                )
+        multi_args = _MultiShapeAutotuneArgs(
+            cases=tuple(cases),
+            aggregation=aggregation,
+            relative_to=relative_to,
+            cache_tag=cache_tag,
+            workload_key=(
+                "multi_shape:v1",
+                aggregation,
+                relative_to,
+                cache_tag,
+                tuple(
+                    (case_key.specialization_key, case_key.extra_results)
+                    for case_key in case_keys
+                ),
+            ),
+            reference_latencies=None,
+        )
+
+        ephemeral = anchor.env.backend.make_ephemeral_cache()
+        ctx = ephemeral if ephemeral is not None else contextlib.nullcontext()
+        with ctx:
+            config = anchor.env.backend.autotune(
+                anchor,
+                cast("Sequence[object]", multi_args),
+                force=force,
+                **options,
+            )
+        if multi_args.search_started and not multi_args.found_valid_config:
+            raise exc.NoConfigFound
+        if multi_args.search_started and not _has_valid_multi_shape_measurement(
+            multi_args,
+            anchor.config_spec,
+            config,
+        ):
+            raise exc.NoConfigFound
+        winner = _materialize_multi_shape_config(anchor.config_spec, config)
+        if ephemeral is not None:
+            for bound_kernel in unique_bound_kernels:
+                bound_kernel.env.backend.finalize_ephemeral_cache(bound_kernel, winner)
+
+        for bound_kernel in unique_bound_kernels:
+            bound_kernel.compile_config(winner)
+        for bound_kernel in unique_bound_kernels:
+            bound_kernel.set_config(winner)
+        return winner
 
     def __call__(self, *args: object, **kwargs: object) -> _R:
         """

--- a/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/_multi_shape_autotune.py
+++ b/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/_multi_shape_autotune.py
@@ -1,0 +1,95 @@
+"""Find ONE config for dynamic_per_token_scaled_fp8_quant across shapes (PR #3119).
+
+Uses ``Kernel.autotune_multi`` to search for a single config that performs well
+over a representative subset of the benchmark sweep, then prints it in the exact
+form checked into ``_multi_shape_config_cuda_sm<NN>.py``. Copy the printed
+``CONFIG`` there, then benchmark it against the per-shape heuristic with::
+
+    HELION_BENCHMARK_CUDAGRAPH=1 python dynamic_per_token_scaled_fp8_quant.py --single-config
+
+``autotune_multi`` requires the default autotuner + local best-config cache, so
+this wraps the kernel body with a plain ``helion.kernel`` (the shipped kernel
+uses ``aot_kernel``, whose AOTAutotuneCache ``autotune_multi`` rejects). The
+body is reused from the kernel module -- not duplicated.
+
+Run:
+    HELION_BENCHMARK_CUDAGRAPH=1 python _multi_shape_autotune.py
+"""
+
+from __future__ import annotations
+
+import os
+import pprint
+import sys
+
+import torch
+
+import helion
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from itertools import starmap
+
+from dynamic_per_token_scaled_fp8_quant import _bench_shapes
+from dynamic_per_token_scaled_fp8_quant import (
+    dynamic_per_token_scaled_fp8_quant as _aot_kernel,
+)
+
+# Plain helion.kernel over the same body (see module docstring).
+dynamic_per_token_scaled_fp8_quant = helion.kernel(
+    _aot_kernel.fn,
+    ignore_warnings=[helion.exc.TensorOperationInWrapper],
+)
+
+
+def _tune_shapes() -> list[tuple[int, int]]:
+    """Representative subset (num_tokens, hidden_size) for the joint objective.
+
+    Spans the two performance regimes (latency-bound tiny token counts and
+    bandwidth-bound large token counts) at the two hidden-size extremes; a config
+    robust across 2048 and 5120 generalizes to the 4096 middle. Keeps the
+    across-shape search tractable (each candidate is measured on every set)."""
+    return [
+        (1, 2048),
+        (64, 2048),
+        (1024, 2048),
+        (4096, 2048),
+        (1, 5120),
+        (64, 5120),
+        (1024, 5120),
+        (4096, 5120),
+    ]
+
+
+def _make_args(num_tokens: int, hidden_size: int) -> tuple:
+    x = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+    result = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    scale = torch.empty((num_tokens, 1), device="cuda", dtype=torch.float32)
+    return (result, x, scale)
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    tune_shapes = _tune_shapes()
+    assert set(tune_shapes) <= set(_bench_shapes())
+
+    # One representative argument set per tuning shape for the joint objective.
+    arg_sets = list(starmap(_make_args, tune_shapes))
+
+    print(
+        f"Multi-shape autotune over {len(arg_sets)} shapes: {tune_shapes}", flush=True
+    )
+    config = dynamic_per_token_scaled_fp8_quant.autotune_multi(
+        arg_sets,
+        aggregation="geomean",
+        relative_to="default",
+        cache_tag="dynamic_per_token_fp8_multishape_v1",
+    )
+
+    major, minor = torch.cuda.get_device_capability()
+    print(f"\n=== Winning config (sm{major}{minor}) ===")
+    print(f"Copy into _multi_shape_config_cuda_sm{major}{minor}.py:\n")
+    print("CONFIG = " + pprint.pformat(dict(config), sort_dicts=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/_multi_shape_config_cuda_sm90.py
+++ b/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/_multi_shape_config_cuda_sm90.py
@@ -1,0 +1,34 @@
+"""Single multi-shape config for kernel: dynamic_per_token_scaled_fp8_quant (sm90 / H100).
+
+Found with ``Kernel.autotune_multi`` (PR #3119) using a geometric-mean objective
+relative to each shape's default config, tuned jointly over a representative
+subset of the benchmark sweep (num_tokens, hidden_size) -- token extremes x
+hidden-size extremes:
+``[(1, 2048), (64, 2048), (1024, 2048), (4096, 2048),
+   (1, 5120), (64, 5120), (1024, 5120), (4096, 5120)]``.
+
+Unlike the per-shape ``_helion_aot_*`` heuristic (a shape->config lookup table),
+this is ONE config used for every shape. Benchmark it with::
+
+    python dynamic_per_token_scaled_fp8_quant.py --single-config
+
+Provides:
+- CONFIG: the config dict (pass to ``helion.kernel(config=...)``).
+"""
+
+from __future__ import annotations
+
+CONFIG = {
+    "block_sizes": [2048, 2048],
+    "range_unroll_factors": [0, 2, 3],
+    "range_multi_buffers": [None, None, None],
+    "range_flattens": [None, False, None],
+    "load_eviction_policies": ["", "last"],
+    "num_warps": 4,
+    "num_stages": 6,
+    "indexing": ["pointer", "pointer", "pointer", "pointer"],
+    "pid_type": "flat",
+    "atomic_indexing": [],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+}

--- a/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/dynamic_per_token_scaled_fp8_quant.py
+++ b/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/dynamic_per_token_scaled_fp8_quant.py
@@ -108,6 +108,52 @@ def _dynamic_per_token_scaled_fp8_quant_vllm(
     torch.ops._C.dynamic_per_token_scaled_fp8_quant(result, input, scale, scale_ub)
 
 
+def _load_multi_shape_config() -> dict:
+    """Load the checked-in single multi-shape config for the current GPU.
+
+    Mirrors the per-shape heuristic's file selection: prefer the file matching
+    the running compute capability (``_multi_shape_config_cuda_sm<NN>.py``), then
+    fall back to the highest available capability <= the current one.
+    """
+    import glob
+    import importlib.util
+    import os
+    import re
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    major, minor = torch.cuda.get_device_capability()
+    current = major * 10 + minor
+    candidates: dict[int, str] = {}
+    for path in glob.glob(os.path.join(here, "_multi_shape_config_cuda_sm*.py")):
+        match = re.search(r"_cuda_sm(\d+)\.py$", os.path.basename(path))
+        if match:
+            candidates[int(match.group(1))] = path
+    if not candidates:
+        raise FileNotFoundError(
+            "no _multi_shape_config_cuda_sm*.py found next to the kernel"
+        )
+    compatible = sorted(cc for cc in candidates if cc <= current)
+    chosen_cc = compatible[-1] if compatible else min(candidates)
+    spec = importlib.util.spec_from_file_location(
+        f"_multi_shape_config_sm{chosen_cc}", candidates[chosen_cc]
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.CONFIG
+
+
+def _single_config_kernel() -> object:
+    """Build a kernel pinned to the single multi-shape config (no autotuning)."""
+    config = helion.Config(**_load_multi_shape_config())
+    return helion.kernel(
+        dynamic_per_token_scaled_fp8_quant.fn,
+        config=config,
+        static_shapes=True,
+        ignore_warnings=[helion.exc.TensorOperationInWrapper],
+    )
+
+
 def _baselines() -> list[tuple[str, object]]:
     """Baselines main() benchmarks against (torch always; vLLM when installed).
 
@@ -156,7 +202,14 @@ def correctness_check() -> None:
         )
 
 
-def main(verbose: bool = True) -> dict:
+def main(verbose: bool = True, single_config: bool = False) -> dict:
+    """Benchmark the Helion kernel across the shape sweep.
+
+    By default uses the per-shape AOT heuristic (a shape->config lookup table).
+    With ``single_config=True`` (``--single-config`` on the CLI), pins the one
+    checked-in multi-shape config for the current GPU and uses it for every
+    shape -- directly comparable numbers for the multi-shape autotune tradeoff.
+    """
     import os
     import sys
 
@@ -165,6 +218,13 @@ def main(verbose: bool = True) -> dict:
 
     shapes = _bench_shapes()
     baselines = _baselines()
+    kernel = (
+        _single_config_kernel() if single_config else dynamic_per_token_scaled_fp8_quant
+    )
+    if single_config and verbose:
+        print(
+            f"Using single multi-shape config: {helion.Config(**_load_multi_shape_config())}"
+        )
 
     def make_calls(shape: tuple) -> tuple:
         num_tokens, hidden_size = shape
@@ -175,7 +235,7 @@ def main(verbose: bool = True) -> dict:
         scale_ref = torch.empty_like(scale)
 
         def helion_call() -> None:
-            dynamic_per_token_scaled_fp8_quant(result, x, scale)
+            kernel(result, x, scale)
 
         base_calls = [
             (n, (lambda fn=fn: fn(result_ref, x, scale_ref))) for n, fn in baselines
@@ -192,6 +252,16 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--single-config",
+        action="store_true",
+        help="Benchmark the single checked-in multi-shape config for every shape "
+        "instead of the per-shape AOT heuristic.",
+    )
+    cli_args = parser.parse_args()
     # Verify numerics across every benchmarked shape before timing.
     correctness_check()
-    main()
+    main(single_config=cli_args.single_config)

--- a/pretuned_kernels/fused_qk_norm_rope/_multi_shape_autotune.py
+++ b/pretuned_kernels/fused_qk_norm_rope/_multi_shape_autotune.py
@@ -1,0 +1,89 @@
+"""Find ONE config for fused_qk_norm_rope across shapes (PR #3119).
+
+Uses ``Kernel.autotune_multi`` to search for a single config that performs well
+over a representative subset of the benchmark sweep, then prints it in the exact
+form checked into ``_multi_shape_config_cuda_sm<NN>.py``. Copy the printed
+``CONFIG`` there, then benchmark it against the per-shape heuristic with::
+
+    HELION_BENCHMARK_CUDAGRAPH=1 python fused_qk_norm_rope.py --single-config
+
+``autotune_multi`` requires the default autotuner + local best-config cache, so
+this wraps the kernel body with a plain ``helion.kernel`` (the shipped kernel
+uses ``aot_kernel``, whose AOTAutotuneCache ``autotune_multi`` rejects). The
+body is reused from the kernel module -- not duplicated.
+
+Run:
+    HELION_BENCHMARK_CUDAGRAPH=1 python _multi_shape_autotune.py
+"""
+
+from __future__ import annotations
+
+import os
+import pprint
+import sys
+
+import torch
+
+import helion
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from itertools import starmap
+
+from fused_qk_norm_rope import _bench_shapes
+from fused_qk_norm_rope import _make_inputs
+from fused_qk_norm_rope import fused_qk_norm_rope as _aot_kernel
+
+# Plain helion.kernel over the same body (see module docstring).
+fused_qk_norm_rope = helion.kernel(
+    _aot_kernel.fn,
+    ignore_warnings=[helion.exc.TensorOperationInWrapper],
+)
+
+
+def _tune_shapes() -> list[tuple[int, int, int]]:
+    """Representative subset (num_tokens, q_heads, kv_heads) for the joint objective.
+
+    Spans the two performance regimes (latency-bound tiny token counts and
+    bandwidth-bound large token counts) at the two q-head extremes; a config
+    robust across the (16, 8) and (64, 8) head configs generalizes to the (32, 8)
+    middle. Keeps the across-shape search tractable (each candidate is measured
+    on every set)."""
+    return [
+        (1, 16, 8),
+        (128, 16, 8),
+        (2048, 16, 8),
+        (8192, 16, 8),
+        (1, 64, 8),
+        (128, 64, 8),
+        (2048, 64, 8),
+        (8192, 64, 8),
+    ]
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    tune_shapes = _tune_shapes()
+    assert set(tune_shapes) <= set(_bench_shapes())
+
+    # One representative argument set per tuning shape for the joint objective.
+    arg_sets = list(starmap(_make_inputs, tune_shapes))
+
+    print(
+        f"Multi-shape autotune over {len(arg_sets)} shapes: {tune_shapes}", flush=True
+    )
+    config = fused_qk_norm_rope.autotune_multi(
+        arg_sets,
+        aggregation="geomean",
+        relative_to="default",
+        # Runtime numeric args (eps, head counts) + tensors => cache_tag required.
+        cache_tag="fused_qk_norm_rope_multishape_v1",
+    )
+
+    major, minor = torch.cuda.get_device_capability()
+    print(f"\n=== Winning config (sm{major}{minor}) ===")
+    print(f"Copy into _multi_shape_config_cuda_sm{major}{minor}.py:\n")
+    print("CONFIG = " + pprint.pformat(dict(config), sort_dicts=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/fused_qk_norm_rope/_multi_shape_config_cuda_sm90.py
+++ b/pretuned_kernels/fused_qk_norm_rope/_multi_shape_config_cuda_sm90.py
@@ -1,0 +1,57 @@
+"""Single multi-shape config for kernel: fused_qk_norm_rope (sm90 / H100).
+
+Found with ``Kernel.autotune_multi`` (PR #3119) using a geometric-mean objective
+relative to each shape's default config, tuned jointly over a representative
+subset of the benchmark sweep (num_tokens, q_heads, kv_heads) -- token extremes
+x q-head extremes:
+``[(1, 16, 8), (128, 16, 8), (2048, 16, 8), (8192, 16, 8),
+   (1, 64, 8), (128, 64, 8), (2048, 64, 8), (8192, 64, 8)]``.
+
+Unlike the per-shape ``_helion_aot_*`` heuristic (a shape->config lookup table),
+this is ONE config used for every shape. Benchmark it with::
+
+    python fused_qk_norm_rope.py --single-config
+
+Provides:
+- CONFIG: the config dict (pass to ``helion.kernel(config=...)``).
+"""
+
+from __future__ import annotations
+
+CONFIG = {
+    "block_sizes": [16],
+    "loop_orders": [[1, 2, 0]],
+    "l2_groupings": [64],
+    "range_unroll_factors": [0],
+    "range_multi_buffers": [None],
+    "range_flattens": [None],
+    "load_eviction_policies": [
+        "",
+        "last",
+        "last",
+        "last",
+        "last",
+        "last",
+        "",
+        "last",
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+    ],
+    "pid_type": "flat",
+    "atomic_indexing": [],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+}

--- a/pretuned_kernels/fused_qk_norm_rope/fused_qk_norm_rope.py
+++ b/pretuned_kernels/fused_qk_norm_rope/fused_qk_norm_rope.py
@@ -238,6 +238,52 @@ def _fused_qk_norm_rope_vllm(
     qkv[:, q_size : q_size + kv_size].copy_(k)
 
 
+def _load_multi_shape_config() -> dict:
+    """Load the checked-in single multi-shape config for the current GPU.
+
+    Mirrors the per-shape heuristic's file selection: prefer the file matching
+    the running compute capability (``_multi_shape_config_cuda_sm<NN>.py``), then
+    fall back to the highest available capability <= the current one.
+    """
+    import glob
+    import importlib.util
+    import os
+    import re
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    major, minor = torch.cuda.get_device_capability()
+    current = major * 10 + minor
+    candidates: dict[int, str] = {}
+    for path in glob.glob(os.path.join(here, "_multi_shape_config_cuda_sm*.py")):
+        match = re.search(r"_cuda_sm(\d+)\.py$", os.path.basename(path))
+        if match:
+            candidates[int(match.group(1))] = path
+    if not candidates:
+        raise FileNotFoundError(
+            "no _multi_shape_config_cuda_sm*.py found next to the kernel"
+        )
+    compatible = sorted(cc for cc in candidates if cc <= current)
+    chosen_cc = compatible[-1] if compatible else min(candidates)
+    spec = importlib.util.spec_from_file_location(
+        f"_multi_shape_config_sm{chosen_cc}", candidates[chosen_cc]
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.CONFIG
+
+
+def _single_config_kernel() -> object:
+    """Build a kernel pinned to the single multi-shape config (no autotuning)."""
+    config = helion.Config(**_load_multi_shape_config())
+    return helion.kernel(
+        fused_qk_norm_rope.fn,
+        config=config,
+        static_shapes=True,
+        ignore_warnings=[helion.exc.TensorOperationInWrapper],
+    )
+
+
 def _baselines() -> list[tuple[str, object]]:
     """Baselines main() benchmarks against (torch always; vLLM when installed).
 
@@ -328,7 +374,14 @@ def correctness_check() -> None:
         torch.testing.assert_close(qkv_helion, qkv_torch, rtol=2e-2, atol=2e-2)
 
 
-def main(verbose: bool = True) -> dict:
+def main(verbose: bool = True, single_config: bool = False) -> dict:
+    """Benchmark the Helion kernel across the shape sweep.
+
+    By default uses the per-shape AOT heuristic (a shape->config lookup table).
+    With ``single_config=True`` (``--single-config`` on the CLI), pins the one
+    checked-in multi-shape config for the current GPU and uses it for every
+    shape -- directly comparable numbers for the multi-shape autotune tradeoff.
+    """
     import os
     import sys
 
@@ -337,6 +390,11 @@ def main(verbose: bool = True) -> dict:
 
     shapes = _bench_shapes()
     baselines = _baselines()
+    kernel = _single_config_kernel() if single_config else fused_qk_norm_rope
+    if single_config and verbose:
+        print(
+            f"Using single multi-shape config: {helion.Config(**_load_multi_shape_config())}"
+        )
 
     def make_calls(shape: tuple) -> tuple:
         num_tokens, q_heads, kv_heads = shape
@@ -346,7 +404,7 @@ def main(verbose: bool = True) -> dict:
         qkv_helion = qkv.clone()
 
         def helion_call() -> None:
-            fused_qk_norm_rope(qkv_helion, *rest)
+            kernel(qkv_helion, *rest)
 
         # Each baseline gets its own qkv clone (the op mutates it in place).
         base_calls = []
@@ -369,6 +427,16 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--single-config",
+        action="store_true",
+        help="Benchmark the single checked-in multi-shape config for every shape "
+        "instead of the per-shape AOT heuristic.",
+    )
+    cli_args = parser.parse_args()
     # Verify numerics across every benchmarked shape before timing.
     correctness_check()
-    main()
+    main(single_config=cli_args.single_config)

--- a/pretuned_kernels/per_token_group_fp8_quant/_multi_shape_autotune.py
+++ b/pretuned_kernels/per_token_group_fp8_quant/_multi_shape_autotune.py
@@ -1,0 +1,101 @@
+"""Find ONE config for per_token_group_fp8_quant across shapes (PR #3119).
+
+Uses ``Kernel.autotune_multi`` to search for a single config that performs well
+over a representative subset of the benchmark sweep, then prints it in the exact
+form checked into ``_multi_shape_config_cuda_sm<NN>.py``. Copy the printed
+``CONFIG`` there, then benchmark it against the per-shape heuristic with::
+
+    HELION_BENCHMARK_CUDAGRAPH=1 python per_token_group_fp8_quant.py --single-config
+
+``autotune_multi`` requires the default autotuner + local best-config cache, so
+this wraps the kernel body with a plain ``helion.kernel`` (the shipped kernel
+uses ``aot_kernel``, whose AOTAutotuneCache ``autotune_multi`` rejects). The
+body is reused from the kernel module -- not duplicated.
+
+Run:
+    HELION_BENCHMARK_CUDAGRAPH=1 python _multi_shape_autotune.py
+"""
+
+from __future__ import annotations
+
+import os
+import pprint
+import sys
+
+import torch
+
+import helion
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from itertools import starmap
+
+from per_token_group_fp8_quant import _bench_shapes
+from per_token_group_fp8_quant import per_token_group_fp8_quant as _aot_kernel
+
+# Plain helion.kernel over the same body (see module docstring).
+per_token_group_fp8_quant = helion.kernel(
+    _aot_kernel.fn,
+    ignore_warnings=[helion.exc.TensorOperationInWrapper],
+)
+
+GROUP_SIZE = 128
+EPS = 1e-10
+FP8_MIN, FP8_MAX = -448.0, 448.0
+SCALE_UE8M0 = False
+CONST = (GROUP_SIZE, EPS, FP8_MIN, FP8_MAX, SCALE_UE8M0)
+
+
+def _tune_shapes() -> list[tuple[int, int]]:
+    """Representative subset for the joint objective.
+
+    Spans the two performance regimes (latency-bound tiny token counts and
+    bandwidth-bound large token counts) at the two hidden-size extremes; a config
+    robust across 2048 and 5120 generalizes to the 4096 middle. Keeps the
+    across-shape search tractable (each candidate is measured on every set)."""
+    return [
+        (1, 2048),
+        (64, 2048),
+        (1024, 2048),
+        (8192, 2048),
+        (1, 5120),
+        (64, 5120),
+        (1024, 5120),
+        (8192, 5120),
+    ]
+
+
+def _make_args(num_tokens: int, hidden_size: int) -> tuple:
+    inp = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+    groups = hidden_size // GROUP_SIZE
+    oq = torch.empty_like(inp, dtype=torch.float8_e4m3fn)
+    os_ = torch.empty((num_tokens, groups), device="cuda", dtype=torch.float32)
+    return (inp, oq, os_, *CONST)
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    tune_shapes = _tune_shapes()
+    assert set(tune_shapes) <= set(_bench_shapes())
+
+    # One representative argument set per tuning shape for the joint objective.
+    arg_sets = list(starmap(_make_args, tune_shapes))
+
+    print(
+        f"Multi-shape autotune over {len(arg_sets)} shapes: {tune_shapes}", flush=True
+    )
+    config = per_token_group_fp8_quant.autotune_multi(
+        arg_sets,
+        aggregation="geomean",
+        relative_to="default",
+        # Runtime numeric args (eps/fp8_min/fp8_max) => cache_tag required.
+        cache_tag="ptgq_multishape_v1",
+    )
+
+    major, minor = torch.cuda.get_device_capability()
+    print(f"\n=== Winning config (sm{major}{minor}) ===")
+    print(f"Copy into _multi_shape_config_cuda_sm{major}{minor}.py:\n")
+    print("CONFIG = " + pprint.pformat(dict(config), sort_dicts=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/per_token_group_fp8_quant/_multi_shape_config_cuda_sm90.py
+++ b/pretuned_kernels/per_token_group_fp8_quant/_multi_shape_config_cuda_sm90.py
@@ -1,0 +1,36 @@
+"""Single multi-shape config for kernel: per_token_group_fp8_quant (sm90 / H100).
+
+Found with ``Kernel.autotune_multi`` (PR #3119) using a geometric-mean objective
+relative to each shape's default config, tuned jointly over a representative
+subset of the benchmark sweep (token extremes x hidden extremes):
+``[(1, 2048), (64, 2048), (1024, 2048), (8192, 2048),
+   (1, 5120), (64, 5120), (1024, 5120), (8192, 5120)]``.
+
+Unlike the per-shape ``_helion_aot_*`` heuristic (a shape->config lookup table),
+this is ONE config used for every shape. On the 24-shape H100 sweep it matches
+the per-shape heuristic's geomean vs torch_compile (2.72x vs 2.71x) while
+collapsing 41 configs to one. Benchmark it with::
+
+    python per_token_group_fp8_quant.py --single-config
+
+Provides:
+- CONFIG: the config dict (pass to ``helion.kernel(config=...)``).
+"""
+from __future__ import annotations
+
+CONFIG = {
+    "block_sizes": [8],
+    "loop_orders": [[2, 1, 0]],
+    "l2_groupings": [8],
+    "range_unroll_factors": [0],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [None],
+    "range_flattens": [None],
+    "load_eviction_policies": ["first"],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": ["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+    "atomic_indexing": [],
+    "pid_type": "flat",
+}

--- a/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
+++ b/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
@@ -125,6 +125,52 @@ def _per_token_group_fp8_quant_vllm(
     )
 
 
+def _load_multi_shape_config() -> dict:
+    """Load the checked-in single multi-shape config for the current GPU.
+
+    Mirrors the per-shape heuristic's file selection: prefer the file matching
+    the running compute capability (``_multi_shape_config_cuda_sm<NN>.py``), then
+    fall back to the highest available capability <= the current one.
+    """
+    import glob
+    import importlib.util
+    import os
+    import re
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    major, minor = torch.cuda.get_device_capability()
+    current = major * 10 + minor
+    candidates: dict[int, str] = {}
+    for path in glob.glob(os.path.join(here, "_multi_shape_config_cuda_sm*.py")):
+        match = re.search(r"_cuda_sm(\d+)\.py$", os.path.basename(path))
+        if match:
+            candidates[int(match.group(1))] = path
+    if not candidates:
+        raise FileNotFoundError(
+            "no _multi_shape_config_cuda_sm*.py found next to the kernel"
+        )
+    compatible = sorted(cc for cc in candidates if cc <= current)
+    chosen_cc = compatible[-1] if compatible else min(candidates)
+    spec = importlib.util.spec_from_file_location(
+        f"_multi_shape_config_sm{chosen_cc}", candidates[chosen_cc]
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.CONFIG
+
+
+def _single_config_kernel() -> object:
+    """Build a kernel pinned to the single multi-shape config (no autotuning)."""
+    config = helion.Config(**_load_multi_shape_config())
+    return helion.kernel(
+        per_token_group_fp8_quant.fn,
+        config=config,
+        static_shapes=True,
+        ignore_warnings=[helion.exc.TensorOperationInWrapper],
+    )
+
+
 def _baselines() -> list[tuple[str, object]]:
     """Baselines main() benchmarks against (torch always; vLLM when installed).
 
@@ -170,7 +216,14 @@ def correctness_check() -> None:
         torch.testing.assert_close(oq.float(), oq_ref.float(), rtol=0.2, atol=0.2)
 
 
-def main(verbose: bool = True) -> dict:
+def main(verbose: bool = True, single_config: bool = False) -> dict:
+    """Benchmark the Helion kernel across the shape sweep.
+
+    By default uses the per-shape AOT heuristic (a shape->config lookup table).
+    With ``single_config=True`` (``--single-config`` on the CLI), pins the one
+    checked-in multi-shape config for the current GPU and uses it for every
+    shape -- directly comparable numbers for the multi-shape autotune tradeoff.
+    """
     import os
     import sys
 
@@ -185,6 +238,11 @@ def main(verbose: bool = True) -> dict:
 
     shapes = _bench_shapes()
     baselines = _baselines()
+    kernel = _single_config_kernel() if single_config else per_token_group_fp8_quant
+    if single_config and verbose:
+        print(
+            f"Using single multi-shape config: {helion.Config(**_load_multi_shape_config())}"
+        )
 
     def make_calls(shape: tuple) -> tuple:
         num_tokens, hidden_size = shape
@@ -221,7 +279,7 @@ def main(verbose: bool = True) -> dict:
         )
 
         def helion_call() -> None:
-            per_token_group_fp8_quant(*args)
+            kernel(*args)
 
         base_calls = [(n, (lambda fn=fn: fn(*ref_args))) for n, fn in baselines]
         return (
@@ -240,6 +298,16 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--single-config",
+        action="store_true",
+        help="Benchmark the single checked-in multi-shape config for every shape "
+        "instead of the per-shape AOT heuristic.",
+    )
+    cli_args = parser.parse_args()
     # Verify numerics across every benchmarked shape before timing.
     correctness_check()
-    main()
+    main(single_config=cli_args.single_config)

--- a/pretuned_kernels/rms_norm_dynamic_per_token_quant/_multi_shape_autotune.py
+++ b/pretuned_kernels/rms_norm_dynamic_per_token_quant/_multi_shape_autotune.py
@@ -1,0 +1,102 @@
+"""Find ONE config for rms_norm_dynamic_per_token_quant across shapes (PR #3119).
+
+Uses ``Kernel.autotune_multi`` to search for a single config that performs well
+over a representative subset of the benchmark sweep, then prints it in the exact
+form checked into ``_multi_shape_config_cuda_sm<NN>.py``. Copy the printed
+``CONFIG`` there, then benchmark it against the per-shape heuristic with::
+
+    HELION_BENCHMARK_CUDAGRAPH=1 python rms_norm_dynamic_per_token_quant.py --single-config
+
+``autotune_multi`` requires the default autotuner + local best-config cache, so
+this wraps the kernel body with a plain ``helion.kernel`` (the shipped kernel
+uses ``aot_kernel``, whose AOTAutotuneCache ``autotune_multi`` rejects). The
+body is reused from the kernel module -- not duplicated.
+
+Run:
+    HELION_BENCHMARK_CUDAGRAPH=1 python _multi_shape_autotune.py
+"""
+
+from __future__ import annotations
+
+import os
+import pprint
+import sys
+
+import torch
+
+import helion
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from itertools import starmap
+
+from rms_norm_dynamic_per_token_quant import _FP8_DTYPE
+from rms_norm_dynamic_per_token_quant import _bench_shapes
+from rms_norm_dynamic_per_token_quant import (
+    rms_norm_dynamic_per_token_quant as _aot_kernel,
+)
+
+# Plain helion.kernel over the same body (see module docstring).
+rms_norm_dynamic_per_token_quant = helion.kernel(
+    _aot_kernel.fn,
+    ignore_warnings=[helion.exc.TensorOperationInWrapper],
+)
+
+EPSILON = 1e-6
+
+
+def _tune_shapes() -> list[tuple[int, int]]:
+    """Representative subset (hidden_size, num_tokens) for the joint objective.
+
+    Spans the two performance regimes (latency-bound tiny token counts and
+    bandwidth-bound large token counts) at the two hidden-size extremes; a config
+    robust across 2048 and 5120 generalizes to the 4096 middle. Keeps the
+    across-shape search tractable (each candidate is measured on every set)."""
+    return [
+        (2048, 1),
+        (2048, 64),
+        (2048, 512),
+        (2048, 2048),
+        (5120, 1),
+        (5120, 64),
+        (5120, 512),
+        (5120, 2048),
+    ]
+
+
+def _make_args(hidden_size: int, num_tokens: int) -> tuple:
+    x_in = torch.randn(num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16)
+    weight = torch.normal(
+        mean=1.0, std=1.0, size=(hidden_size,), dtype=x_in.dtype, device="cuda"
+    )
+    result = torch.empty_like(x_in, dtype=_FP8_DTYPE)
+    scale = torch.empty((num_tokens, 1), device="cuda", dtype=torch.float32)
+    return (result, x_in, weight, scale, EPSILON)
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    tune_shapes = _tune_shapes()
+    assert set(tune_shapes) <= set(_bench_shapes())
+
+    # One representative argument set per tuning shape for the joint objective.
+    arg_sets = list(starmap(_make_args, tune_shapes))
+
+    print(
+        f"Multi-shape autotune over {len(arg_sets)} shapes: {tune_shapes}", flush=True
+    )
+    config = rms_norm_dynamic_per_token_quant.autotune_multi(
+        arg_sets,
+        aggregation="geomean",
+        relative_to="default",
+        # Runtime numeric arg (epsilon) => cache_tag required.
+        cache_tag="rms_norm_dynamic_per_token_multishape_v1",
+    )
+
+    major, minor = torch.cuda.get_device_capability()
+    print(f"\n=== Winning config (sm{major}{minor}) ===")
+    print(f"Copy into _multi_shape_config_cuda_sm{major}{minor}.py:\n")
+    print("CONFIG = " + pprint.pformat(dict(config), sort_dicts=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/rms_norm_dynamic_per_token_quant/_multi_shape_config_cuda_sm90.py
+++ b/pretuned_kernels/rms_norm_dynamic_per_token_quant/_multi_shape_config_cuda_sm90.py
@@ -1,0 +1,42 @@
+"""Single multi-shape config for kernel: rms_norm_dynamic_per_token_quant (sm90 / H100).
+
+Found with ``Kernel.autotune_multi`` (PR #3119) using a geometric-mean objective
+relative to each shape's default config, tuned jointly over a representative
+subset of the benchmark sweep (hidden_size, num_tokens) -- token extremes x
+hidden-size extremes:
+``[(2048, 1), (2048, 64), (2048, 512), (2048, 2048),
+   (5120, 1), (5120, 64), (5120, 512), (5120, 2048)]``.
+
+Unlike the per-shape ``_helion_aot_*`` heuristic (a shape->config lookup table),
+this is ONE config used for every shape. Benchmark it with::
+
+    python rms_norm_dynamic_per_token_quant.py --single-config
+
+Provides:
+- CONFIG: the config dict (pass to ``helion.kernel(config=...)``).
+"""
+
+from __future__ import annotations
+
+CONFIG = {
+    "block_sizes": [16, 2048, 1024],
+    "range_unroll_factors": [0, 0, 2, 0],
+    "range_multi_buffers": [None, False, True, None],
+    "range_flattens": [None, False, False, True],
+    "load_eviction_policies": ["last", "last", "first", "", "last"],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+    ],
+    "pid_type": "flat",
+    "atomic_indexing": [],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+}

--- a/pretuned_kernels/rms_norm_dynamic_per_token_quant/rms_norm_dynamic_per_token_quant.py
+++ b/pretuned_kernels/rms_norm_dynamic_per_token_quant/rms_norm_dynamic_per_token_quant.py
@@ -179,6 +179,52 @@ def _rms_norm_dynamic_per_token_quant_vllm(
     )
 
 
+def _load_multi_shape_config() -> dict:
+    """Load the checked-in single multi-shape config for the current GPU.
+
+    Mirrors the per-shape heuristic's file selection: prefer the file matching
+    the running compute capability (``_multi_shape_config_cuda_sm<NN>.py``), then
+    fall back to the highest available capability <= the current one.
+    """
+    import glob
+    import importlib.util
+    import os
+    import re
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    major, minor = torch.cuda.get_device_capability()
+    current = major * 10 + minor
+    candidates: dict[int, str] = {}
+    for path in glob.glob(os.path.join(here, "_multi_shape_config_cuda_sm*.py")):
+        match = re.search(r"_cuda_sm(\d+)\.py$", os.path.basename(path))
+        if match:
+            candidates[int(match.group(1))] = path
+    if not candidates:
+        raise FileNotFoundError(
+            "no _multi_shape_config_cuda_sm*.py found next to the kernel"
+        )
+    compatible = sorted(cc for cc in candidates if cc <= current)
+    chosen_cc = compatible[-1] if compatible else min(candidates)
+    spec = importlib.util.spec_from_file_location(
+        f"_multi_shape_config_sm{chosen_cc}", candidates[chosen_cc]
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.CONFIG
+
+
+def _single_config_kernel() -> object:
+    """Build a kernel pinned to the single multi-shape config (no autotuning)."""
+    config = helion.Config(**_load_multi_shape_config())
+    return helion.kernel(
+        rms_norm_dynamic_per_token_quant.fn,
+        config=config,
+        static_shapes=True,
+        ignore_warnings=[helion.exc.TensorOperationInWrapper],
+    )
+
+
 def _baselines() -> list[tuple[str, object]]:
     """Baselines main() benchmarks against (torch always; vLLM when installed).
 
@@ -231,7 +277,14 @@ def correctness_check() -> None:
         )
 
 
-def main(verbose: bool = True) -> dict:
+def main(verbose: bool = True, single_config: bool = False) -> dict:
+    """Benchmark the Helion kernel across the shape sweep.
+
+    By default uses the per-shape AOT heuristic (a shape->config lookup table).
+    With ``single_config=True`` (``--single-config`` on the CLI), pins the one
+    checked-in multi-shape config for the current GPU and uses it for every
+    shape -- directly comparable numbers for the multi-shape autotune tradeoff.
+    """
     import os
     import sys
 
@@ -242,6 +295,13 @@ def main(verbose: bool = True) -> dict:
     shapes = _bench_shapes()
     epsilon = 1e-6
     baselines = _baselines()
+    kernel = (
+        _single_config_kernel() if single_config else rms_norm_dynamic_per_token_quant
+    )
+    if single_config and verbose:
+        print(
+            f"Using single multi-shape config: {helion.Config(**_load_multi_shape_config())}"
+        )
 
     def make_calls(shape: tuple[int, int]) -> tuple:
         hidden_size, num_tokens = shape
@@ -255,7 +315,7 @@ def main(verbose: bool = True) -> dict:
         scale_ref = torch.empty_like(scale)
 
         def helion_call() -> None:
-            rms_norm_dynamic_per_token_quant(result, x_in, weight, scale, epsilon)
+            kernel(result, x_in, weight, scale, epsilon)
 
         base_calls = [
             (
@@ -276,6 +336,16 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--single-config",
+        action="store_true",
+        help="Benchmark the single checked-in multi-shape config for every shape "
+        "instead of the per-shape AOT heuristic.",
+    )
+    cli_args = parser.parse_args()
     # Verify numerics across every benchmarked shape before timing.
     correctness_check()
-    main()
+    main(single_config=cli_args.single_config)

--- a/pretuned_kernels/rms_norm_per_block_quant/_multi_shape_autotune.py
+++ b/pretuned_kernels/rms_norm_per_block_quant/_multi_shape_autotune.py
@@ -1,0 +1,86 @@
+"""Find ONE config for rms_norm_per_block_quant across shapes (PR #3119).
+
+Uses ``Kernel.autotune_multi`` to search for a single config that performs well
+over a representative subset of the benchmark sweep, then prints it in the exact
+form checked into ``_multi_shape_config_cuda_sm<NN>.py``. Copy the printed
+``CONFIG`` there, then benchmark it against the per-shape heuristic with::
+
+    HELION_BENCHMARK_CUDAGRAPH=1 python rms_norm_per_block_quant.py --single-config
+
+``autotune_multi`` requires the default autotuner + local best-config cache, so
+this wraps the kernel body with a plain ``helion.kernel`` (the shipped kernel
+uses ``aot_kernel``, whose AOTAutotuneCache ``autotune_multi`` rejects). The
+body is reused from the kernel module -- not duplicated.
+
+Run:
+    HELION_BENCHMARK_CUDAGRAPH=1 python _multi_shape_autotune.py
+"""
+
+from __future__ import annotations
+
+import os
+import pprint
+import sys
+
+import torch
+
+import helion
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from rms_norm_per_block_quant import _bench_shapes
+from rms_norm_per_block_quant import _make_inputs
+from rms_norm_per_block_quant import rms_norm_per_block_quant as _aot_kernel
+
+# Plain helion.kernel over the same body (see module docstring).
+rms_norm_per_block_quant = helion.kernel(
+    _aot_kernel.fn,
+    ignore_warnings=[helion.exc.TensorOperationInWrapper],
+)
+
+
+def _tune_shapes() -> list[tuple[int, int, int]]:
+    """Representative subset (hidden, group, tokens) for the joint objective.
+
+    Spans the two performance regimes (latency-bound tiny token counts and
+    bandwidth-bound large token counts) at the two hidden-size extremes; a config
+    robust across 2048 and 5120 generalizes to the 4096 middle. Keeps the
+    across-shape search tractable (each candidate is measured on every set)."""
+    return [
+        (2048, 128, 1),
+        (2048, 128, 64),
+        (2048, 128, 1024),
+        (2048, 128, 4096),
+        (5120, 128, 1),
+        (5120, 128, 64),
+        (5120, 128, 1024),
+        (5120, 128, 4096),
+    ]
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    tune_shapes = _tune_shapes()
+    assert set(tune_shapes) <= set(_bench_shapes())
+
+    # One representative argument set per tuning shape for the joint objective.
+    arg_sets = [_make_inputs(t, h, g) for (h, g, t) in tune_shapes]
+
+    print(
+        f"Multi-shape autotune over {len(arg_sets)} shapes: {tune_shapes}", flush=True
+    )
+    config = rms_norm_per_block_quant.autotune_multi(
+        arg_sets,
+        aggregation="geomean",
+        relative_to="default",
+        # Runtime numeric args (epsilon/group_size) + tensor scale_ub => cache_tag.
+        cache_tag="rms_norm_pbq_multishape_v1",
+    )
+
+    major, minor = torch.cuda.get_device_capability()
+    print(f"\n=== Winning config (sm{major}{minor}) ===")
+    print(f"Copy into _multi_shape_config_cuda_sm{major}{minor}.py:\n")
+    print("CONFIG = " + pprint.pformat(dict(config), sort_dicts=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/rms_norm_per_block_quant/_multi_shape_config_cuda_sm90.py
+++ b/pretuned_kernels/rms_norm_per_block_quant/_multi_shape_config_cuda_sm90.py
@@ -1,0 +1,46 @@
+"""Single multi-shape config for kernel: rms_norm_per_block_quant (sm90 / H100).
+
+Found with ``Kernel.autotune_multi`` (PR #3119) using a geometric-mean objective
+relative to each shape's default config, tuned jointly over a representative
+subset of the benchmark sweep (hidden, group, token) -- token extremes x
+hidden-size extremes:
+``[(2048, 128, 1), (2048, 128, 64), (2048, 128, 1024), (2048, 128, 4096),
+   (5120, 128, 1), (5120, 128, 64), (5120, 128, 1024), (5120, 128, 4096)]``.
+
+Unlike the per-shape ``_helion_aot_*`` heuristic (a shape->config lookup table),
+this is ONE config used for every shape. Benchmark it with::
+
+    python rms_norm_per_block_quant.py --single-config
+
+Provides:
+- CONFIG: the config dict (pass to ``helion.kernel(config=...)``).
+"""
+
+from __future__ import annotations
+
+CONFIG = {
+    "block_sizes": [2048, 16],
+    "loop_orders": [[1, 0]],
+    "range_unroll_factors": [0, 2, 2, 4],
+    "range_multi_buffers": [None, True, True, True],
+    "range_flattens": [None, None, False, True],
+    "static_ranges": [False],
+    "load_eviction_policies": ["", "", "first", "last", "last", ""],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "tensor_descriptor",
+    ],
+    "pid_type": "flat",
+    "atomic_indexing": [],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+}

--- a/pretuned_kernels/rms_norm_per_block_quant/rms_norm_per_block_quant.py
+++ b/pretuned_kernels/rms_norm_per_block_quant/rms_norm_per_block_quant.py
@@ -219,6 +219,52 @@ def _rms_norm_per_block_quant_vllm(
     )
 
 
+def _load_multi_shape_config() -> dict:
+    """Load the checked-in single multi-shape config for the current GPU.
+
+    Mirrors the per-shape heuristic's file selection: prefer the file matching
+    the running compute capability (``_multi_shape_config_cuda_sm<NN>.py``), then
+    fall back to the highest available capability <= the current one.
+    """
+    import glob
+    import importlib.util
+    import os
+    import re
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    major, minor = torch.cuda.get_device_capability()
+    current = major * 10 + minor
+    candidates: dict[int, str] = {}
+    for path in glob.glob(os.path.join(here, "_multi_shape_config_cuda_sm*.py")):
+        match = re.search(r"_cuda_sm(\d+)\.py$", os.path.basename(path))
+        if match:
+            candidates[int(match.group(1))] = path
+    if not candidates:
+        raise FileNotFoundError(
+            "no _multi_shape_config_cuda_sm*.py found next to the kernel"
+        )
+    compatible = sorted(cc for cc in candidates if cc <= current)
+    chosen_cc = compatible[-1] if compatible else min(candidates)
+    spec = importlib.util.spec_from_file_location(
+        f"_multi_shape_config_sm{chosen_cc}", candidates[chosen_cc]
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.CONFIG
+
+
+def _single_config_kernel() -> object:
+    """Build a kernel pinned to the single multi-shape config (no autotuning)."""
+    config = helion.Config(**_load_multi_shape_config())
+    return helion.kernel(
+        rms_norm_per_block_quant.fn,
+        config=config,
+        static_shapes=True,
+        ignore_warnings=[helion.exc.TensorOperationInWrapper],
+    )
+
+
 def _baselines() -> list[tuple[str, object]]:
     """Baselines main() benchmarks against (torch always; vLLM when installed).
 
@@ -313,7 +359,14 @@ def correctness_check() -> None:
         )
 
 
-def main(verbose: bool = True) -> dict:
+def main(verbose: bool = True, single_config: bool = False) -> dict:
+    """Benchmark the Helion kernel across the shape sweep.
+
+    By default uses the per-shape AOT heuristic (a shape->config lookup table).
+    With ``single_config=True`` (``--single-config`` on the CLI), pins the one
+    checked-in multi-shape config for the current GPU and uses it for every
+    shape -- directly comparable numbers for the multi-shape autotune tradeoff.
+    """
     import os
     import sys
 
@@ -322,6 +375,11 @@ def main(verbose: bool = True) -> dict:
 
     shapes = _bench_shapes()
     baselines = _baselines()
+    kernel = _single_config_kernel() if single_config else rms_norm_per_block_quant
+    if single_config and verbose:
+        print(
+            f"Using single multi-shape config: {helion.Config(**_load_multi_shape_config())}"
+        )
 
     def make_calls(shape: tuple[int, int, int]) -> tuple:
         hidden_size, group_size, num_tokens = shape
@@ -345,7 +403,7 @@ def main(verbose: bool = True) -> dict:
         )
 
         def helion_call() -> None:
-            rms_norm_per_block_quant(*helion_args)
+            kernel(*helion_args)
 
         base_calls = [(n, (lambda fn=fn: fn(*ref_args))) for n, fn in baselines]
         return (
@@ -364,6 +422,16 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--single-config",
+        action="store_true",
+        help="Benchmark the single checked-in multi-shape config for every shape "
+        "instead of the per-shape AOT heuristic.",
+    )
+    cli_args = parser.parse_args()
     # Verify numerics across every benchmarked shape before timing.
     correctness_check()
-    main()
+    main(single_config=cli_args.single_config)

--- a/pretuned_kernels/silu_and_mul_per_block_quant/_multi_shape_autotune.py
+++ b/pretuned_kernels/silu_and_mul_per_block_quant/_multi_shape_autotune.py
@@ -1,0 +1,101 @@
+"""Find ONE config for silu_and_mul_per_block_quant across shapes (PR #3119).
+
+Uses ``Kernel.autotune_multi`` to search for a single config that performs well
+over a representative subset of the benchmark sweep, then prints it in the exact
+form checked into ``_multi_shape_config_cuda_sm<NN>.py``. Copy the printed
+``CONFIG`` there, then benchmark it against the per-shape heuristic with::
+
+    HELION_BENCHMARK_CUDAGRAPH=1 python silu_and_mul_per_block_quant.py --single-config
+
+``autotune_multi`` requires the default autotuner + local best-config cache, so
+this wraps the kernel body with a plain ``helion.kernel`` (the shipped kernel
+uses ``aot_kernel``, whose AOTAutotuneCache ``autotune_multi`` rejects). The
+body is reused from the kernel module -- not duplicated.
+
+Run:
+    HELION_BENCHMARK_CUDAGRAPH=1 python _multi_shape_autotune.py
+"""
+
+from __future__ import annotations
+
+import os
+import pprint
+import sys
+
+import torch
+
+import helion
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from itertools import starmap
+
+from silu_and_mul_per_block_quant import _bench_shapes
+from silu_and_mul_per_block_quant import silu_and_mul_per_block_quant as _aot_kernel
+
+# Plain helion.kernel over the same body (see module docstring).
+silu_and_mul_per_block_quant = helion.kernel(
+    _aot_kernel.fn,
+    ignore_warnings=[helion.exc.TensorOperationInWrapper],
+)
+
+GROUP_SIZE = 128
+
+
+def _tune_shapes() -> list[tuple[int, int]]:
+    """Representative subset for the joint objective.
+
+    Spans the two performance regimes (latency-bound tiny token counts and
+    bandwidth-bound large token counts) at the two intermediate-size extremes;
+    a config robust across 6144 and 25600 generalizes to the 12288 middle.
+    Keeps the across-shape search tractable (each candidate is measured on every
+    set)."""
+    return [
+        (1, 6144),
+        (64, 6144),
+        (1024, 6144),
+        (4096, 6144),
+        (1, 25600),
+        (64, 25600),
+        (1024, 25600),
+        (4096, 25600),
+    ]
+
+
+def _make_args(num_tokens: int, intermediate: int) -> tuple:
+    x = torch.randn(num_tokens, 2 * intermediate, device="cuda", dtype=torch.bfloat16)
+    out = torch.empty(
+        num_tokens, intermediate, device="cuda", dtype=torch.float8_e4m3fn
+    )
+    scales = torch.empty(
+        num_tokens, intermediate // GROUP_SIZE, device="cuda", dtype=torch.float32
+    )
+    return (out, x, scales, GROUP_SIZE)
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    tune_shapes = _tune_shapes()
+    assert set(tune_shapes) <= set(_bench_shapes())
+
+    # One representative argument set per tuning shape for the joint objective.
+    arg_sets = list(starmap(_make_args, tune_shapes))
+
+    print(
+        f"Multi-shape autotune over {len(arg_sets)} shapes: {tune_shapes}", flush=True
+    )
+    config = silu_and_mul_per_block_quant.autotune_multi(
+        arg_sets,
+        aggregation="geomean",
+        relative_to="default",
+        # Runtime numeric arg (group_size) => cache_tag required.
+        cache_tag="silu_mul_pbq_multishape_v1",
+    )
+
+    major, minor = torch.cuda.get_device_capability()
+    print(f"\n=== Winning config (sm{major}{minor}) ===")
+    print(f"Copy into _multi_shape_config_cuda_sm{major}{minor}.py:\n")
+    print("CONFIG = " + pprint.pformat(dict(config), sort_dicts=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/silu_and_mul_per_block_quant/_multi_shape_config_cuda_sm90.py
+++ b/pretuned_kernels/silu_and_mul_per_block_quant/_multi_shape_config_cuda_sm90.py
@@ -1,0 +1,35 @@
+"""Single multi-shape config for kernel: silu_and_mul_per_block_quant (sm90 / H100).
+
+Found with ``Kernel.autotune_multi`` (PR #3119) using a geometric-mean objective
+relative to each shape's default config, tuned jointly over a representative
+subset of the benchmark sweep (token extremes x intermediate-size extremes):
+``[(1, 6144), (64, 6144), (1024, 6144), (4096, 6144),
+   (1, 25600), (64, 25600), (1024, 25600), (4096, 25600)]``.
+
+Unlike the per-shape ``_helion_aot_*`` heuristic (a shape->config lookup table),
+this is ONE config used for every shape. Benchmark it with::
+
+    python silu_and_mul_per_block_quant.py --single-config
+
+Provides:
+- CONFIG: the config dict (pass to ``helion.kernel(config=...)``).
+"""
+
+from __future__ import annotations
+
+CONFIG = {
+    "block_sizes": [8],
+    "loop_orders": [[1, 0, 2]],
+    "l2_groupings": [64],
+    "range_unroll_factors": [0],
+    "range_multi_buffers": [None],
+    "range_flattens": [None],
+    "load_eviction_policies": ["first", "first"],
+    "num_warps": 4,
+    "num_stages": 6,
+    "indexing": ["tensor_descriptor", "pointer", "pointer", "pointer"],
+    "pid_type": "flat",
+    "atomic_indexing": [],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+}

--- a/pretuned_kernels/silu_and_mul_per_block_quant/silu_and_mul_per_block_quant.py
+++ b/pretuned_kernels/silu_and_mul_per_block_quant/silu_and_mul_per_block_quant.py
@@ -168,6 +168,52 @@ def _silu_and_mul_per_block_quant_vllm(
     )
 
 
+def _load_multi_shape_config() -> dict:
+    """Load the checked-in single multi-shape config for the current GPU.
+
+    Mirrors the per-shape heuristic's file selection: prefer the file matching
+    the running compute capability (``_multi_shape_config_cuda_sm<NN>.py``), then
+    fall back to the highest available capability <= the current one.
+    """
+    import glob
+    import importlib.util
+    import os
+    import re
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    major, minor = torch.cuda.get_device_capability()
+    current = major * 10 + minor
+    candidates: dict[int, str] = {}
+    for path in glob.glob(os.path.join(here, "_multi_shape_config_cuda_sm*.py")):
+        match = re.search(r"_cuda_sm(\d+)\.py$", os.path.basename(path))
+        if match:
+            candidates[int(match.group(1))] = path
+    if not candidates:
+        raise FileNotFoundError(
+            "no _multi_shape_config_cuda_sm*.py found next to the kernel"
+        )
+    compatible = sorted(cc for cc in candidates if cc <= current)
+    chosen_cc = compatible[-1] if compatible else min(candidates)
+    spec = importlib.util.spec_from_file_location(
+        f"_multi_shape_config_sm{chosen_cc}", candidates[chosen_cc]
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.CONFIG
+
+
+def _single_config_kernel() -> object:
+    """Build a kernel pinned to the single multi-shape config (no autotuning)."""
+    config = helion.Config(**_load_multi_shape_config())
+    return helion.kernel(
+        silu_and_mul_per_block_quant.fn,
+        config=config,
+        static_shapes=True,
+        ignore_warnings=[helion.exc.TensorOperationInWrapper],
+    )
+
+
 def _baselines() -> list[tuple[str, object]]:
     """Baselines main() benchmarks against (torch always; vLLM when installed).
 
@@ -217,7 +263,14 @@ def correctness_check() -> None:
         torch.testing.assert_close(out.float(), out_ref.float(), rtol=0.2, atol=0.2)
 
 
-def main(verbose: bool = True) -> dict:
+def main(verbose: bool = True, single_config: bool = False) -> dict:
+    """Benchmark the Helion kernel across the shape sweep.
+
+    By default uses the per-shape AOT heuristic (a shape->config lookup table).
+    With ``single_config=True`` (``--single-config`` on the CLI), pins the one
+    checked-in multi-shape config for the current GPU and uses it for every
+    shape -- directly comparable numbers for the multi-shape autotune tradeoff.
+    """
     import os
     import sys
 
@@ -227,6 +280,11 @@ def main(verbose: bool = True) -> dict:
     group_size = 128
     shapes = _bench_shapes()
     baselines = _baselines()
+    kernel = _single_config_kernel() if single_config else silu_and_mul_per_block_quant
+    if single_config and verbose:
+        print(
+            f"Using single multi-shape config: {helion.Config(**_load_multi_shape_config())}"
+        )
 
     def make_calls(shape: tuple[int, int]) -> tuple:
         num_tokens, intermediate = shape
@@ -245,7 +303,7 @@ def main(verbose: bool = True) -> dict:
         scales_ref = torch.empty_like(scales)
 
         def helion_call() -> None:
-            silu_and_mul_per_block_quant(out, x, scales, group_size)
+            kernel(out, x, scales, group_size)
 
         base_calls = [
             (n, (lambda fn=fn: fn(out_ref, x, scales_ref, group_size)))
@@ -263,6 +321,16 @@ def main(verbose: bool = True) -> dict:
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--single-config",
+        action="store_true",
+        help="Benchmark the single checked-in multi-shape config for every shape "
+        "instead of the per-shape AOT heuristic.",
+    )
+    cli_args = parser.parse_args()
     # Verify numerics across every benchmarked shape before timing.
     correctness_check()
-    main()
+    main(single_config=cli_args.single_config)

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -17,6 +17,8 @@ import torch
 import helion
 from helion import exc
 from helion._compiler.backend import TritonBackend
+from helion._testing import DEVICE
+from helion._testing import skipIfRefEager
 from helion.autotuner import benchmark_provider as benchmark_provider_module
 from helion.autotuner.base_search import BaseSearch
 from helion.autotuner.base_search import PopulationBasedSearch
@@ -1230,6 +1232,7 @@ class TestMultiShapeLLMSeeded(unittest.TestCase):
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+@skipIfRefEager("Autotuning requires compilation, not supported in ref eager mode")
 class TestMultiShapeAutotuneIntegration(unittest.TestCase):
     @staticmethod
     def _make_add_case(
@@ -1257,8 +1260,8 @@ class TestMultiShapeAutotuneIntegration(unittest.TestCase):
             return out
 
         arg_sets = [
-            (torch.randn(256, device="cuda"), torch.randn(256, device="cuda")),
-            (torch.randn(2048, device="cuda"), torch.randn(2048, device="cuda")),
+            (torch.randn(256, device=DEVICE), torch.randn(256, device=DEVICE)),
+            (torch.randn(2048, device=DEVICE), torch.randn(2048, device=DEVICE)),
         ]
         return add, arg_sets
 

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -1,0 +1,1307 @@
+from __future__ import annotations
+
+import contextlib
+import math
+import os
+from pathlib import Path
+import tempfile
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from typing import cast
+import unittest
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import torch
+
+import helion
+from helion import exc
+from helion._compiler.backend import TritonBackend
+from helion.autotuner import benchmark_provider as benchmark_provider_module
+from helion.autotuner.base_search import BaseSearch
+from helion.autotuner.base_search import PopulationBasedSearch
+from helion.autotuner.base_search import PopulationMember
+from helion.autotuner.benchmark_provider import BenchmarkResult
+from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
+from helion.autotuner.benchmark_provider import MultiShapeAggregation
+from helion.autotuner.benchmark_provider import MultiShapeBenchmarkProvider
+from helion.autotuner.benchmark_provider import MultiShapeReference
+from helion.autotuner.benchmark_provider import _aggregate_multi_shape_timings
+from helion.autotuner.benchmark_provider import _format_selected_multi_shape_measurement
+from helion.autotuner.benchmark_provider import _materialize_multi_shape_config
+from helion.autotuner.benchmark_provider import _MultiShapeAutotuneArgs
+from helion.autotuner.config_spec import BlockSizeSpec
+from helion.autotuner.config_spec import ConfigSpec
+from helion.autotuner.config_spec import LoopOrderSpec
+from helion.autotuner.finite_search import FiniteSearch
+from helion.autotuner.llm_seeded_lfbo import LLMSeededSearch
+from helion.autotuner.local_cache import LocalAutotuneCache
+from helion.autotuner.metrics import AutotuneMetrics
+import helion.language as hl
+from helion.runtime.config import Config
+from helion.runtime.kernel import Kernel
+from helion.runtime.settings import Settings
+from helion.runtime.settings import default_autotuner_fn
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Iterable
+    from collections.abc import Sequence
+
+
+class TestMultiShapeTimingAggregation(unittest.TestCase):
+    def test_raw_geometric_mean_and_max(self) -> None:
+        self.assertAlmostEqual(
+            _aggregate_multi_shape_timings(
+                [1.0, 4.0], aggregation="geomean", references=None
+            ),
+            2.0,
+        )
+        self.assertEqual(
+            _aggregate_multi_shape_timings(
+                [1.0, 4.0], aggregation="max", references=None
+            ),
+            4.0,
+        )
+
+    def test_reference_max_returns_ratio(self) -> None:
+        self.assertEqual(
+            _aggregate_multi_shape_timings(
+                [4.0, 8.0], aggregation="max", references=[2.0, 8.0]
+            ),
+            2.0,
+        )
+        self.assertAlmostEqual(
+            _aggregate_multi_shape_timings(
+                [4.0, 8.0], aggregation="geomean", references=[2.0, 8.0]
+            ),
+            math.sqrt(2.0),
+        )
+
+    def test_invalid_values_and_references_return_infinity(self) -> None:
+        for timings in ([], [0.0], [-1.0], [math.inf], [math.nan]):
+            with self.subTest(timings=timings):
+                self.assertEqual(
+                    _aggregate_multi_shape_timings(
+                        timings, aggregation="geomean", references=None
+                    ),
+                    math.inf,
+                )
+        for references in ([1.0], [1.0, 0.0], [1.0, math.inf]):
+            with self.subTest(references=references):
+                self.assertEqual(
+                    _aggregate_multi_shape_timings(
+                        [2.0, 8.0], aggregation="max", references=references
+                    ),
+                    math.inf,
+                )
+
+
+def _make_config_spec() -> ConfigSpec:
+    spec = ConfigSpec(backend=TritonBackend())
+    spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+    spec.loop_orders.append(LoopOrderSpec([0]))
+    return spec
+
+
+def _make_carrier(
+    cases: Sequence[tuple[object, tuple[object, ...]]],
+    *,
+    aggregation: MultiShapeAggregation = "geomean",
+    relative_to: MultiShapeReference = None,
+    cache_tag: str | None = None,
+    workload_key: tuple[object, ...] = ("workload",),
+    reference_latencies: tuple[float, ...] | None = None,
+) -> _MultiShapeAutotuneArgs:
+    return _MultiShapeAutotuneArgs(
+        cases=tuple(cases),  # type: ignore[arg-type]
+        aggregation=aggregation,
+        relative_to=relative_to,
+        cache_tag=cache_tag,
+        workload_key=workload_key,
+        reference_latencies=reference_latencies,
+    )
+
+
+class TestMultiShapeConfigMaterialization(unittest.TestCase):
+    def test_alias_overlay_is_detached(self) -> None:
+        spec = _make_config_spec()
+        default = spec.default_config()
+        sparse = Config(block_size=64)
+
+        result = _materialize_multi_shape_config(spec, sparse)
+
+        self.assertEqual(result.block_sizes, [64])
+        self.assertEqual(result.num_warps, default.num_warps)
+        self.assertNotIn("block_size", result.config)
+        self.assertEqual(sparse.config, {"block_size": 64})
+        result.block_sizes[0] = 128
+        result.loop_orders[0][0] = 1
+        self.assertEqual(default.block_sizes, [32])
+        self.assertEqual(default.loop_orders, [[0]])
+
+    def test_singular_plural_collision_is_invalid(self) -> None:
+        with self.assertRaises(helion.exc.InvalidConfig):
+            _materialize_multi_shape_config(
+                _make_config_spec(), Config(block_size=32, block_sizes=[64])
+            )
+
+    def test_explicit_reset_removes_compiler_default(self) -> None:
+        spec = Mock()
+        spec.default_config.return_value = Config(block_sizes=[32], num_threads=[8])
+
+        def normalize(config: Config) -> None:
+            if "block_size" in config.config:
+                config.config["block_sizes"] = [config.config.pop("block_size")]
+            if config.config.get("num_threads") == [0]:
+                config.config.pop("num_threads")
+
+        spec.normalize.side_effect = normalize
+
+        result = _materialize_multi_shape_config(
+            spec, Config(block_size=64, num_threads=[0])
+        )
+
+        self.assertEqual(result.block_sizes, [64])
+        self.assertNotIn("num_threads", result.config)
+
+    def test_missing_optional_reset_does_not_restore_compiler_default(self) -> None:
+        spec = Mock()
+        spec.default_config.return_value = Config.from_dict(
+            {"block_sizes": [32], "epilogue_subtile": 2}
+        )
+
+        def normalize(config: Config) -> None:
+            config.config.setdefault("block_sizes", [32])
+            config.config.setdefault("num_warps", 4)
+
+        spec.normalize.side_effect = normalize
+
+        result = _materialize_multi_shape_config(
+            spec,
+            Config.from_dict({"block_sizes": [64]}),
+        )
+
+        self.assertEqual(result.block_sizes, [64])
+        self.assertEqual(result.num_warps, 4)
+        self.assertNotIn("epilogue_subtile", result.config)
+        spec.default_config.assert_not_called()
+
+
+class TestMultiShapeAutotuneArgs(unittest.TestCase):
+    def test_sequence_operations_use_anchor_args(self) -> None:
+        anchor_args = ("first", 2, [3])
+        carrier = _make_carrier(((object(), anchor_args), (object(), ("secondary",))))
+
+        self.assertEqual(len(carrier), 3)
+        self.assertEqual(carrier[0], "first")
+        self.assertIs(carrier[-1], anchor_args[-1])
+        self.assertEqual(list(cast("Iterable[object]", carrier)), list(anchor_args))
+
+
+def _cache_kernel_source(value: object) -> object:
+    return value
+
+
+class _RuntimeConfigSpec:
+    def structural_fingerprint(
+        self, *, advanced_controls_files: list[str] | None
+    ) -> tuple[tuple[str, int]]:
+        return (("block_sizes", 1),)
+
+    def structural_fingerprint_hash(
+        self, *, advanced_controls_files: list[str] | None
+    ) -> str:
+        return "fake-config-spec"
+
+    def normalize(self, config: Config) -> None:
+        config.config.setdefault("num_warps", 4)
+
+
+class _RuntimeBackend:
+    name = "triton"
+
+    def __init__(self) -> None:
+        self.autotune_calls: list[tuple[object, object]] = []
+        self.finalized: list[object] = []
+
+    def make_ephemeral_cache(self) -> contextlib.AbstractContextManager[None]:
+        return contextlib.nullcontext()
+
+    def autotune(
+        self, bound_kernel: object, args: object, *, force: bool, **options: object
+    ) -> Config:
+        self.autotune_calls.append((bound_kernel, args))
+        return Config(block_sizes=[64])
+
+    def finalize_ephemeral_cache(self, bound_kernel: object, config: Config) -> None:
+        self.finalized.append(bound_kernel)
+
+
+class _RuntimeBoundKernel:
+    def __init__(self, backend: _RuntimeBackend, settings: SimpleNamespace) -> None:
+        self.kernel = SimpleNamespace(
+            fn=_cache_kernel_source,
+            settings=settings,
+            _base_specialization_key=Mock(
+                side_effect=AssertionError("single-shape cache key recomputed")
+            ),
+            _create_bound_kernel_cache_key=Mock(
+                side_effect=AssertionError("single-shape cache key recomputed")
+            ),
+        )
+        self.settings = settings
+        self.config_spec = _RuntimeConfigSpec()
+        self.env = SimpleNamespace(
+            backend=backend,
+            device=torch.device("cuda", 0),
+            process_group_name=None,
+        )
+        self.compile_config = Mock()
+        self.set_config = Mock()
+        self.extra_cache_key = Mock(return_value="")
+
+
+def _runtime_settings(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "backend": "triton",
+        "autotuner_fn": default_autotuner_fn,
+        "autotune_cache": "LocalAutotuneCache",
+        "autotune_baseline_fn": None,
+        "autotune_baseline_accuracy_check_fn": None,
+        "autotune_benchmark_fn": None,
+        "autotune_config_filter": None,
+        "autotune_search_acf": [],
+        "autotune_accuracy_check": True,
+        "autotune_baseline_atol": None,
+        "autotune_baseline_rtol": None,
+        "autotune_best_of_k": 1,
+        "static_shapes": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class TestMultiShapeRuntime(unittest.TestCase):
+    @patch("helion.autotuner.local_cache.torch.version.cuda", "13.0")
+    @patch("helion.autotuner.local_cache.torch.cuda.is_available", return_value=True)
+    @patch("helion.autotuner.local_cache.get_device_name", return_value="Fake GPU")
+    def test_local_cache_uses_joint_workload_key(
+        self, device_name: object, cuda_available: object
+    ) -> None:
+        settings = _runtime_settings()
+        bound = _RuntimeBoundKernel(_RuntimeBackend(), settings)
+        workload_key = (
+            "multi_shape:v1",
+            "max",
+            "default",
+            "workload-v2",
+            (("shape-a",), ("shape-b",)),
+        )
+        cache = object.__new__(LocalAutotuneCache)
+        cache.kernel = bound  # pyrefly: ignore [bad-assignment]
+        cache.args = _make_carrier(  # pyrefly: ignore [bad-assignment]
+            ((bound, ("anchor", 8)), (bound, ("secondary", 16))),
+            workload_key=workload_key,
+        )
+        cache.autotuner = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+            settings=settings
+        )
+
+        key = cache._generate_key()
+
+        self.assertEqual(key.specialization_key, workload_key)
+        self.assertEqual(key.extra_results, ())
+        bound.kernel._base_specialization_key.assert_not_called()
+        bound.kernel._create_bound_kernel_cache_key.assert_not_called()
+
+    def test_option_validation_precedes_normalization_and_binding(self) -> None:
+        invalid_options = (
+            ({"aggregation": "median"}, "aggregation"),
+            ({"relative_to": "fastest"}, "relative_to"),
+            ({"cache_tag": ""}, "non-empty string"),
+            ({"cache_tag": 1}, "non-empty string"),
+        )
+        for kwargs, message in invalid_options:
+            kernel = object.__new__(Kernel)
+            kernel.normalize_args = Mock()
+            kernel.bind = Mock()
+
+            with (
+                self.subTest(kwargs=kwargs),
+                self.assertRaisesRegex(exc.InvalidAPIUsage, message),
+            ):
+                kernel.autotune_multi([("real-argument",)], **kwargs)  # type: ignore[arg-type]
+
+            kernel.normalize_args.assert_not_called()
+            kernel.bind.assert_not_called()
+
+    @patch("helion.runtime.kernel.dist.is_initialized", return_value=False)
+    def test_unsupported_settings_fail_before_binding(
+        self, distributed: object
+    ) -> None:
+        cases = (
+            (
+                "custom accuracy callback without cache tag",
+                _runtime_settings(autotune_baseline_accuracy_check_fn=Mock()),
+                {},
+                "requires cache_tag",
+            ),
+            (
+                "custom benchmark callback",
+                _runtime_settings(autotune_benchmark_fn=Mock()),
+                {"cache_tag": "callback-v1"},
+                "does not support",
+            ),
+            (
+                "dynamic shapes without cache tag",
+                _runtime_settings(static_shapes=False),
+                {},
+                "static_shapes=False",
+            ),
+        )
+        for name, settings, kwargs, message in cases:
+            kernel = object.__new__(Kernel)
+            kernel.settings = settings  # pyrefly: ignore [bad-assignment]
+            kernel.normalize_args = Mock()
+            kernel.bind = Mock()
+
+            with (
+                self.subTest(case=name),
+                self.assertRaisesRegex(exc.InvalidAPIUsage, message),
+            ):
+                kernel.autotune_multi([("real-argument",)], **kwargs)
+
+            kernel.normalize_args.assert_not_called()
+            kernel.bind.assert_not_called()
+
+    @patch("helion.runtime.kernel.dist.is_initialized", return_value=False)
+    def test_runtime_numeric_values_require_cache_tag(
+        self, distributed: object
+    ) -> None:
+        kernel = object.__new__(Kernel)
+        kernel.settings = _runtime_settings()  # pyrefly: ignore [bad-assignment]
+        kernel._annotations = [object]
+        kernel.normalize_args = Mock(side_effect=lambda *args: tuple(args))
+        kernel.bind = Mock()
+
+        with self.assertRaisesRegex(exc.InvalidAPIUsage, "runtime numeric value"):
+            kernel.autotune_multi([([1, 2],)])
+
+        kernel.bind.assert_not_called()
+
+    @patch("helion.runtime.kernel.target_device_capability", return_value=(9, 0))
+    @patch("helion.runtime.kernel._current_device_index", return_value=0)
+    @patch("helion.runtime.kernel.dist.is_initialized", return_value=False)
+    def test_builds_workload_key_and_installs_one_winner(
+        self,
+        distributed: object,
+        current: object,
+        capability: object,
+    ) -> None:
+        backend = _RuntimeBackend()
+        settings = _runtime_settings()
+        bounds = [
+            _RuntimeBoundKernel(backend, settings),
+            _RuntimeBoundKernel(backend, settings),
+        ]
+        case_keys = [
+            SimpleNamespace(specialization_key=("shape", 8), extra_results=()),
+            SimpleNamespace(specialization_key=("shape", 16), extra_results=()),
+        ]
+        kernel = object.__new__(Kernel)
+        kernel.settings = settings  # pyrefly: ignore [bad-assignment]
+        kernel._annotations = [object, object]
+        kernel.normalize_args = Mock(side_effect=lambda *args: tuple(args))
+        kernel.bind = Mock(side_effect=bounds)
+        kernel._base_specialization_key = Mock(
+            side_effect=[("shape", 8), ("shape", 16)]
+        )
+        kernel._get_bound_kernel_cache_key = Mock(side_effect=case_keys)
+
+        winner = kernel.autotune_multi(
+            [("case-a", 8), ("case-b", 16)], cache_tag="numeric-shapes-v1"
+        )
+
+        self.assertEqual(winner.config, {"block_sizes": [64], "num_warps": 4})
+        self.assertEqual(len(backend.autotune_calls), 1)
+        carrier = backend.autotune_calls[0][1]
+        self.assertIsInstance(carrier, _MultiShapeAutotuneArgs)
+        self.assertEqual(
+            carrier.workload_key,
+            (
+                "multi_shape:v1",
+                "geomean",
+                None,
+                "numeric-shapes-v1",
+                ((("shape", 8), ()), (("shape", 16), ())),
+            ),
+        )
+        self.assertEqual(backend.finalized, bounds)
+        for bound in bounds:
+            bound.compile_config.assert_called_once_with(winner)
+            bound.set_config.assert_called_once_with(winner)
+
+
+class _Log:
+    def __init__(self) -> None:
+        self.debug_messages: list[object] = []
+
+    def debug(self, message: object) -> None:
+        self.debug_messages.append(message)
+
+    def register_config(self, config: Config) -> None:
+        return None
+
+    def record_autotune_entry(self, entry: object) -> None:
+        pass
+
+
+class _FakeBoundKernel:
+    def __init__(
+        self,
+        config_spec: ConfigSpec,
+        timings: list[float],
+        statuses: list[str] | None = None,
+        compile_times: list[float | None] | None = None,
+        *,
+        error: Exception | None = None,
+        accuracy_failure_indices: list[int] | None = None,
+        compile_failure_indices: list[int] | None = None,
+    ) -> None:
+        self.config_spec = config_spec
+        self.settings = SimpleNamespace(
+            autotune_baseline_fn=None,
+            autotune_ignore_errors=False,
+        )
+        self.env = SimpleNamespace(process_group_name=None)
+        self.timings = timings
+        self.statuses = statuses or ["ok"] * len(timings)
+        self.compile_times = compile_times or [None] * len(timings)
+        self.error = error
+        self.accuracy_failure_indices = accuracy_failure_indices or []
+        self.compile_failure_indices = compile_failure_indices or []
+        self.accuracy_failures = len(self.accuracy_failure_indices)
+        self.compile_failures = len(self.compile_failure_indices)
+
+
+class _FakeLocalBenchmarkProvider:
+    mutated_arg_indices: tuple[int, ...] = ()
+
+    def __init__(
+        self,
+        kernel: _FakeBoundKernel,
+        settings: object,
+        config_spec: ConfigSpec,
+        args: tuple[object, ...],
+        log: object,
+        autotune_metrics: AutotuneMetrics,
+    ) -> None:
+        self.kernel = kernel
+        self.settings = settings
+        self.config_spec = config_spec
+        self.args = args
+        self._autotune_metrics = autotune_metrics
+        self._accuracy_failure_config_ids: list[int] = []
+        self._compile_failure_config_ids: list[int] = []
+        self.benchmark_calls: list[tuple[list[Config], str]] = []
+        self.setup_count = 0
+        self.cleanup_count = 0
+        self.budget_exceeded_fn: Callable[[], bool] = lambda: False
+        self.fns = [lambda: None for _ in kernel.timings]
+
+    def set_budget_exceeded_fn(self, fn: Callable[[], bool]) -> None:
+        self.budget_exceeded_fn = fn
+
+    def setup(self) -> None:
+        self.setup_count += 1
+
+    def cleanup(self) -> None:
+        self.cleanup_count += 1
+
+    def benchmark(
+        self, configs: list[Config], *, desc: str = "Benchmarking"
+    ) -> list[BenchmarkResult]:
+        self.benchmark_calls.append((configs, desc))
+        if self.kernel.error is not None:
+            raise self.kernel.error
+        self._autotune_metrics.num_accuracy_failures += self.kernel.accuracy_failures
+        self._autotune_metrics.num_compile_failures += self.kernel.compile_failures
+        self._accuracy_failure_config_ids.extend(
+            id(config)
+            for index, config in enumerate(configs)
+            if index in self.kernel.accuracy_failure_indices
+        )
+        self._compile_failure_config_ids.extend(
+            id(config)
+            for index, config in enumerate(configs)
+            if index in self.kernel.compile_failure_indices
+        )
+        if len(configs) > len(self.kernel.timings):
+            raise AssertionError("fake child received too many configs")
+        return [
+            BenchmarkResult(
+                config,
+                self.fns[index],
+                self.kernel.timings[index],
+                self.kernel.statuses[index],  # type: ignore[arg-type]
+                self.kernel.compile_times[index],
+            )
+            for index, config in enumerate(configs)
+        ]
+
+
+class TestMultiShapeBenchmarkProvider(unittest.TestCase):
+    def _make_provider(
+        self,
+        cases: list[_FakeBoundKernel],
+        *,
+        aggregation: MultiShapeAggregation = "geomean",
+        relative_to: MultiShapeReference = None,
+        references: tuple[float, ...] | None = None,
+        carrier: _MultiShapeAutotuneArgs | None = None,
+    ) -> tuple[MultiShapeBenchmarkProvider, AutotuneMetrics]:
+        if carrier is None:
+            carrier = _make_carrier(
+                tuple((case, (index,)) for index, case in enumerate(cases)),
+                aggregation=aggregation,
+                relative_to=relative_to,
+                reference_latencies=references,
+            )
+        metrics = AutotuneMetrics()
+        with patch.object(
+            benchmark_provider_module,
+            "LocalBenchmarkProvider",
+            _FakeLocalBenchmarkProvider,
+        ):
+            provider = MultiShapeBenchmarkProvider(
+                kernel=cases[0],  # type: ignore[arg-type]
+                settings=cases[0].settings,  # type: ignore[arg-type]
+                config_spec=cases[0].config_spec,
+                args=cast("Sequence[object]", carrier),
+                log=_Log(),  # type: ignore[arg-type]
+                autotune_metrics=metrics,
+            )
+        return provider, metrics
+
+    def test_rectangular_aggregation_preserves_original_config_identity(self) -> None:
+        spec = _make_config_spec()
+        provider, metrics = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [1.0, 8.0], compile_times=[0.1, None]),
+                _FakeBoundKernel(spec, [4.0, 2.0], compile_times=[0.2, 0.4]),
+            ]
+        )
+        configs = [Config(block_size=64), Config(block_sizes=[128])]
+
+        results = provider.benchmark(configs, desc="joint")
+
+        self.assertEqual([result.perf for result in results], [2.0, 4.0])
+        self.assertEqual([result.compile_time for result in results], [0.2, 0.4])
+        self.assertIs(results[0].config, configs[0])
+        self.assertIs(results[1].config, configs[1])
+        self.assertEqual(metrics.num_configs_tested, 2)
+        self.assertTrue(provider.args.found_valid_config)
+        children = cast("list[_FakeLocalBenchmarkProvider]", provider.children)
+        self.assertTrue(
+            all(child._autotune_metrics is not metrics for child in children)
+        )
+        debug_message = cast("_Log", provider.log).debug_messages[0]
+        assert callable(debug_message)
+        self.assertIn(
+            "objective: geomean(latencies)=2.000000 ms",
+            debug_message(),
+        )
+        for index, child in enumerate(children):
+            received, desc = child.benchmark_calls[0]
+            self.assertEqual(desc, f"joint shape {index + 1}")
+            self.assertEqual(received[0].block_sizes, [64])
+            self.assertIsNot(received[0], configs[0])
+
+    def test_raw_and_relative_max_choose_different_configs(self) -> None:
+        spec = _make_config_spec()
+        configs = [Config(block_sizes=[64]), Config(block_sizes=[128])]
+
+        def select(references: tuple[float, ...] | None) -> Config:
+            provider, _ = self._make_provider(
+                [
+                    _FakeBoundKernel(spec, [1.0, 4.0]),
+                    _FakeBoundKernel(spec, [100.0, 6.0]),
+                ],
+                aggregation="max",
+                references=references,
+            )
+            search = SimpleNamespace(
+                configs=configs,
+                benchmark_batch=lambda candidates, *, desc: provider.benchmark(
+                    candidates, desc=desc
+                ),
+            )
+            return FiniteSearch._autotune(cast("object", search))  # type: ignore[arg-type]
+
+        self.assertIs(select(None), configs[1])
+        self.assertIs(select((1.0, 100.0)), configs[0])
+
+    def test_relative_logging_reports_shape_rows_and_keeps_perf_ms_raw(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [_FakeBoundKernel(spec, [4.0]), _FakeBoundKernel(spec, [8.0])],
+            aggregation="max",
+            relative_to="default",
+            references=(2.0, 8.0),
+        )
+        provider.log = Mock()
+        provider.log.register_config.return_value = "config-id"
+        config = Config(block_sizes=[64])
+
+        result = provider.benchmark([config])[0]
+
+        self.assertEqual(result.perf, 2.0)
+        entry = provider.log.record_autotune_entry.call_args.args[0]
+        self.assertEqual(entry.perf_ms, 8.0)
+        self.assertIsNot(entry.config, config)
+        self.assertEqual(entry.config.num_warps, 4)
+        debug_message = provider.log.debug.call_args.args[0]()
+        self.assertIn("arg_sets[0]: latency=4.000000 ms", debug_message)
+        self.assertIn("default reference=2.000000 ms", debug_message)
+        self.assertIn("arg_sets[1]: latency=8.000000 ms", debug_message)
+        self.assertIn(
+            "objective: max(latency ratios vs default)=2.000000x", debug_message
+        )
+
+        materialized = _materialize_multi_shape_config(spec, config)
+        self.assertEqual(provider.raw_latency(config), 8.0)
+        summary = _format_selected_multi_shape_measurement(provider.args, materialized)
+        assert summary is not None
+        self.assertIn("Selected multi-shape config", summary)
+        self.assertIn("ratio=2.000000x", summary)
+        self.assertIn("ratio=1.000000x", summary)
+
+    def test_relative_metrics_keep_millisecond_contract(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [_FakeBoundKernel(spec, [4.0]), _FakeBoundKernel(spec, [8.0])],
+            aggregation="max",
+            relative_to="default",
+            references=(2.0, 8.0),
+        )
+        config = Config(block_sizes=[64])
+        result = provider.benchmark([config])[0]
+        search = object.__new__(FiniteSearch)
+        search.args = provider.args
+        search.benchmark_provider = provider
+        search.best_perf_so_far = result.perf
+        search._autotune_metrics = AutotuneMetrics()
+
+        search._finalize_autotune_metrics(config)
+        self.assertEqual(search._autotune_metrics.best_perf_ms, 8.0)
+
+        search._autotune_metrics = AutotuneMetrics()
+        search._finalize_autotune_metrics(None)
+        self.assertEqual(search._autotune_metrics.best_perf_ms, 0.0)
+
+    def test_any_invalid_shape_discards_config_and_timeout_wins_status(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(
+                    spec,
+                    [1.0, math.inf],
+                    statuses=["ok", "timeout"],
+                    compile_times=[0.1, 0.3],
+                ),
+                _FakeBoundKernel(
+                    spec,
+                    [math.inf, math.inf],
+                    statuses=["error", "error"],
+                    compile_times=[0.2, 0.4],
+                ),
+            ]
+        )
+
+        results = provider.benchmark(
+            [Config(block_sizes=[64]), Config(block_sizes=[128])]
+        )
+
+        self.assertEqual([result.perf for result in results], [math.inf, math.inf])
+        self.assertEqual([result.status for result in results], ["error", "timeout"])
+        self.assertFalse(provider.args.found_valid_config)
+        summary = _format_selected_multi_shape_measurement(
+            provider.args,
+            _materialize_multi_shape_config(spec, Config(block_sizes=[64])),
+        )
+        assert summary is not None
+        self.assertIn("objective: rejected", summary)
+
+    def test_failure_metrics_count_config_union_once(self) -> None:
+        spec = _make_config_spec()
+        provider, metrics = self._make_provider(
+            [
+                _FakeBoundKernel(
+                    spec,
+                    [math.inf, math.inf, 3.0],
+                    accuracy_failure_indices=[0, 1],
+                    compile_failure_indices=[0],
+                ),
+                _FakeBoundKernel(
+                    spec,
+                    [math.inf, 2.0, math.inf],
+                    accuracy_failure_indices=[0, 2],
+                    compile_failure_indices=[0, 1],
+                ),
+            ]
+        )
+
+        provider.benchmark(
+            [
+                Config(block_sizes=[64]),
+                Config(block_sizes=[128]),
+                Config(block_sizes=[256]),
+            ]
+        )
+
+        self.assertEqual(metrics.num_accuracy_failures, 3)
+        self.assertEqual(metrics.num_compile_failures, 2)
+
+    def test_invalid_anchor_materialization_discards_only_one_config(self) -> None:
+        spec = _make_config_spec()
+        provider, metrics = self._make_provider(
+            [_FakeBoundKernel(spec, [2.0]), _FakeBoundKernel(spec, [8.0])]
+        )
+
+        results = provider.benchmark(
+            [
+                Config(block_size=32, block_sizes=[64]),
+                Config(block_sizes=[128]),
+            ]
+        )
+
+        self.assertEqual([result.perf for result in results], [math.inf, 4.0])
+        self.assertEqual(metrics.num_configs_tested, 2)
+        for child in provider.children:
+            self.assertEqual(len(child.benchmark_calls[0][0]), 1)
+
+    def test_skippable_batch_failure_becomes_infinite_rows(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [1.0, 2.0]),
+                _FakeBoundKernel(spec, [1.0, 2.0], error=RuntimeError("compile")),
+            ]
+        )
+        with patch.object(provider, "_is_skippable_child_failure", return_value=True):
+            results = provider.benchmark(
+                [Config(block_sizes=[64]), Config(block_sizes=[128])]
+            )
+        self.assertEqual([result.perf for result in results], [math.inf, math.inf])
+
+    def test_fatal_batch_failure_propagates(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [1.0]),
+                _FakeBoundKernel(spec, [1.0], error=RuntimeError("fatal")),
+            ]
+        )
+        with (
+            patch.object(provider, "_is_skippable_child_failure", return_value=False),
+            self.assertRaisesRegex(RuntimeError, "fatal"),
+        ):
+            provider.benchmark([Config(block_sizes=[64])])
+
+    def test_warn_classified_batch_failure_is_not_hidden(self) -> None:
+        child = SimpleNamespace(
+            config_spec=SimpleNamespace(
+                backend=SimpleNamespace(
+                    classify_autotune_exception=lambda error: "warn"
+                )
+            ),
+            settings=SimpleNamespace(autotune_ignore_errors=False),
+        )
+
+        self.assertFalse(
+            MultiShapeBenchmarkProvider._is_skippable_child_failure(
+                cast("object", child), RuntimeError("compiler bug")
+            )
+        )
+
+    def test_reference_timings_are_reused_across_search_providers(self) -> None:
+        spec = _make_config_spec()
+        cases = [_FakeBoundKernel(spec, [2.0]), _FakeBoundKernel(spec, [8.0])]
+        provider, _ = self._make_provider(
+            cases,
+            relative_to="default",
+        )
+
+        provider.setup()
+        later_provider, _ = self._make_provider(cases, carrier=provider.args)
+        later_provider.setup()
+
+        self.assertEqual(provider.args.reference_latencies, (2.0, 8.0))
+        first_children = cast("list[_FakeLocalBenchmarkProvider]", provider.children)
+        later_children = cast(
+            "list[_FakeLocalBenchmarkProvider]", later_provider.children
+        )
+        self.assertEqual([child.setup_count for child in later_children], [1, 1])
+        self.assertEqual(
+            [len(child.benchmark_calls) for child in first_children], [1, 1]
+        )
+        self.assertTrue(all(not child.benchmark_calls for child in later_children))
+
+    def test_reference_failure_names_shape_and_cleans_up(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [2.0]),
+                _FakeBoundKernel(spec, [math.inf], statuses=["error"]),
+            ],
+            relative_to="default",
+        )
+
+        with self.assertRaisesRegex(
+            helion.exc.AutotuneError, r"reference benchmark failed for arg_sets\[1\]"
+        ):
+            provider.setup()
+
+        children = cast("list[_FakeLocalBenchmarkProvider]", provider.children)
+        self.assertEqual([child.cleanup_count for child in children], [1, 1])
+
+    def test_rebenchmark_reruns_joint_pipeline_and_records_latest_failure(self) -> None:
+        spec = _make_config_spec()
+        first = _FakeBoundKernel(spec, [1.0, 4.0])
+        second = _FakeBoundKernel(spec, [9.0, 1.0])
+        provider, metrics = self._make_provider([first, second])
+        configs = [Config(block_sizes=[64]), Config(block_sizes=[128])]
+        initial = provider.benchmark(configs)
+        tested = metrics.num_configs_tested
+        second.timings = [16.0, math.inf]
+        second.statuses = ["ok", "error"]
+
+        timings = provider.rebenchmark(
+            configs,
+            [result.perf for result in initial],
+            desc="confirm",
+        )
+
+        self.assertEqual(timings, [4.0, math.inf])
+        self.assertEqual(metrics.num_configs_tested, tested)
+        first_summary = _format_selected_multi_shape_measurement(
+            provider.args,
+            _materialize_multi_shape_config(spec, configs[0]),
+        )
+        second_summary = _format_selected_multi_shape_measurement(
+            provider.args,
+            _materialize_multi_shape_config(spec, configs[1]),
+        )
+        assert first_summary is not None
+        assert second_summary is not None
+        self.assertIn("latency=16.000000 ms", first_summary)
+        self.assertIn("objective: rejected", second_summary)
+        self.assertTrue(provider.has_valid_measurement(configs[0]))
+        self.assertFalse(provider.has_valid_measurement(configs[1]))
+        for child in provider.children:
+            self.assertEqual(len(child.benchmark_calls), 2)
+
+    def test_rebenchmark_preserves_previous_values_after_budget(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [_FakeBoundKernel(spec, [1.0, 2.0]), _FakeBoundKernel(spec, [3.0, 4.0])]
+        )
+        provider.set_budget_exceeded_fn(lambda: True)
+        previous = [1.5, 2.5]
+
+        self.assertEqual(
+            provider.rebenchmark(
+                [Config(block_sizes=[64]), Config(block_sizes=[128])],
+                previous,
+                desc="confirm",
+            ),
+            previous,
+        )
+        self.assertTrue(all(not child.benchmark_calls for child in provider.children))
+
+    def test_completed_rebenchmark_failure_wins_over_crossed_budget(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [math.inf], statuses=["error"]),
+                _FakeBoundKernel(spec, [1.0]),
+            ]
+        )
+        budget_exceeded = Mock(side_effect=(False, True))
+        provider.set_budget_exceeded_fn(budget_exceeded)
+
+        timings = provider.rebenchmark(
+            [Config(block_sizes=[64])],
+            [2.0],
+            desc="confirm",
+        )
+
+        self.assertEqual(timings, [math.inf])
+        budget_exceeded.assert_called_once_with()
+
+    def test_population_search_uses_provider_rebenchmark_hook(self) -> None:
+        provider = object.__new__(MultiShapeBenchmarkProvider)
+        provider.rebenchmark = Mock()  # type: ignore[method-assign]
+        provider.rebenchmark.return_value = [3.0, 1.0]
+        configs = [Config(block_sizes=[64]), Config(block_sizes=[128])]
+        members = [
+            PopulationMember(lambda: None, [2.0], [], config) for config in configs
+        ]
+        search = SimpleNamespace(
+            benchmark_provider=provider,
+            best_perf_so_far=2.0,
+        )
+
+        PopulationBasedSearch.rebenchmark(cast("object", search), members, desc="again")  # type: ignore[arg-type]
+
+        self.assertEqual([member.perfs for member in members], [[2.0, 3.0], [2.0, 1.0]])
+        self.assertEqual(search.best_perf_so_far, 1.0)
+        provider.rebenchmark.assert_called_once_with(configs, [2.0, 2.0], desc="again")
+
+    def test_local_provider_rejects_carrier_directly(self) -> None:
+        carrier = _make_carrier(((object(), (object(),)),))
+        with self.assertRaisesRegex(TypeError, "cannot benchmark multi-shape"):
+            LocalBenchmarkProvider(
+                kernel=cast("object", object()),
+                settings=cast("object", object()),
+                config_spec=cast("object", object()),
+                args=cast("Sequence[object]", carrier),
+                log=cast("object", object()),
+                autotune_metrics=AutotuneMetrics(),
+            )
+
+
+class TestMultiShapeSearchOrchestration(unittest.TestCase):
+    @staticmethod
+    def _make_base_search(args: object) -> BaseSearch:
+        search = BaseSearch.__new__(BaseSearch)
+        search.args = args  # pyrefly: ignore [bad-assignment]
+        search.settings = Settings(autotune_log=False, autotune_log_details=False)
+        search.log = Mock()
+        search.best_perf_so_far = math.inf
+        search._autotune_metrics = AutotuneMetrics()
+        search.config_spec = Mock()
+        search.config_spec.default_config.return_value = Config(num_warps=4)
+        search.kernel = Mock()
+        search.kernel.format_kernel_decorator.return_value = "@helion.kernel(...)"
+        search.kernel.get_cached_path.return_value = None
+        search.benchmark_provider = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+            setup=Mock(), cleanup=Mock()
+        )
+        search._prepare = Mock()  # type: ignore[method-assign]
+        search._autotune = Mock(  # type: ignore[method-assign]
+            side_effect=exc.NoConfigFound
+        )
+        search._finalize_autotune_metrics = Mock()  # type: ignore[method-assign]
+        return search
+
+    def test_finite_search_rejects_all_nonfinite_configs(self) -> None:
+        configs = [Config(num_warps=2), Config(num_warps=4)]
+        results = [
+            BenchmarkResult(config, lambda: None, perf, "error", None)
+            for config, perf in zip(configs, (math.inf, math.nan), strict=True)
+        ]
+        search = SimpleNamespace(
+            args=_make_carrier(((object(), ()),)),
+            configs=configs,
+            benchmark_batch=lambda configs, *, desc: results,
+        )
+
+        with self.assertRaises(exc.NoConfigFound):
+            FiniteSearch._autotune(cast("object", search))  # type: ignore[arg-type]
+
+    def test_base_search_propagates_no_config_and_cleans_up(self) -> None:
+        search = self._make_base_search(_make_carrier(((object(), ()),)))
+
+        with self.assertRaises(exc.NoConfigFound):
+            BaseSearch.autotune(search)
+
+        search.benchmark_provider.cleanup.assert_called_once_with()
+
+    def test_final_pick_resolution_handles_partial_and_multi_shape_searches(
+        self,
+    ) -> None:
+        partial_search = object.__new__(PopulationBasedSearch)
+        self.assertIsNone(partial_search._resolve_device_micros_paired_bench())
+
+        search = object.__new__(PopulationBasedSearch)
+        search.benchmark_provider = object.__new__(MultiShapeBenchmarkProvider)
+        search.settings = SimpleNamespace(static_shapes=True)
+        search.config_spec = SimpleNamespace(backend=Mock())
+
+        self.assertIsNone(search._resolve_device_micros_paired_bench())
+        search.config_spec.backend.get_paired_device_micros_bench.assert_not_called()
+
+
+class TestMultiShapeCacheBoundary(unittest.TestCase):
+    @staticmethod
+    def _make_cache(carrier: _MultiShapeAutotuneArgs) -> LocalAutotuneCache:
+        cache = object.__new__(LocalAutotuneCache)
+        cache.args = carrier  # pyrefly: ignore [bad-assignment]
+        cache.autotuner = SimpleNamespace(  # pyrefly: ignore [bad-assignment]
+            log=Mock(),
+            config_spec=_make_config_spec(),
+            settings=SimpleNamespace(autotune_log=None),
+        )
+        cache._run_autotune_trials = Mock(  # type: ignore[method-assign]
+            return_value=Config(block_size=64)
+        )
+        cache.put = Mock()  # type: ignore[method-assign]
+        return cache
+
+    def test_all_invalid_run_raises_before_cache_put(self) -> None:
+        carrier = _make_carrier(((object(), ()),))
+        carrier.search_started = True
+        cache = self._make_cache(carrier)
+
+        with self.assertRaises(exc.NoConfigFound):
+            cache.autotune(skip_cache=True)
+
+        cache.put.assert_not_called()
+
+    @patch("helion.autotuner.base_cache.should_skip_cache", return_value=False)
+    def test_valid_run_materializes_winner_before_cache_put(
+        self, skip_cache: object
+    ) -> None:
+        carrier = _make_carrier(((object(), ()),))
+        carrier.search_started = True
+        carrier.found_valid_config = True
+        cache = self._make_cache(carrier)
+        materialized = _materialize_multi_shape_config(
+            cache.autotuner.config_spec,
+            Config(block_size=64),
+        )
+        carrier.measurements[repr(materialized)] = ((1.0,), 1.0, ("ok",))
+
+        result = cache.autotune(skip_cache=True)
+
+        self.assertEqual(result.block_sizes, [64])
+        self.assertNotIn("block_size", result.config)
+        cache.put.assert_called_once_with(result)
+
+
+class _TrialLog:
+    def __call__(self, message: str, *args: object, **kwargs: object) -> None:
+        pass
+
+
+class TestMultiShapeBestOfK(unittest.TestCase):
+    @staticmethod
+    def _make_cache(
+        outcomes: list[tuple[Config, float] | type[exc.NoConfigFound]],
+    ) -> LocalAutotuneCache:
+        settings = SimpleNamespace(
+            autotune_best_of_k=len(outcomes),
+            autotune_random_seed=20,
+            autotune_compile_timeout=60,
+        )
+        outcome_iter = iter(outcomes)
+
+        class _Search:
+            def __init__(self) -> None:
+                self.settings = settings
+                self.log = _TrialLog()
+                self.best_perf_so_far = math.inf
+
+            def autotune(self) -> Config:
+                outcome = next(outcome_iter)
+                if outcome is exc.NoConfigFound:
+                    raise exc.NoConfigFound
+                config, perf = outcome
+                self.best_perf_so_far = perf
+                return config
+
+        cache = object.__new__(LocalAutotuneCache)
+        cache.args = _make_carrier(  # pyrefly: ignore [bad-assignment]
+            ((object(), ()),)
+        )
+        cache.autotuner = _Search()  # pyrefly: ignore [bad-assignment]
+        cache._autotuner_factory = _Search
+        cache._release_trial_state = Mock()  # type: ignore[method-assign]
+        return cache
+
+    def test_failed_trials_are_skipped(self) -> None:
+        invalid = Config(num_warps=2)
+        winner = Config(num_warps=4)
+        cache = self._make_cache(
+            [exc.NoConfigFound, (invalid, math.inf), (winner, 1.0)]
+        )
+        cache._rebench_trial_configs = Mock(  # type: ignore[method-assign]
+            return_value=[0.8]
+        )
+
+        self.assertEqual(cache._run_autotune_trials(), winner)
+        cache._rebench_trial_configs.assert_called_once_with([winner])
+
+    def test_all_failed_trials_raise_before_rebenchmark(self) -> None:
+        cache = self._make_cache([exc.NoConfigFound, exc.NoConfigFound])
+        cache._rebench_trial_configs = Mock()  # type: ignore[method-assign]
+
+        with self.assertRaises(exc.NoConfigFound):
+            cache._run_autotune_trials()
+        cache._rebench_trial_configs.assert_not_called()
+
+    def test_all_failed_final_rebenchmarks_raise(self) -> None:
+        cache = self._make_cache(
+            [(Config(num_warps=2), 1.0), (Config(num_warps=4), 2.0)]
+        )
+        cache._rebench_trial_configs = Mock(  # type: ignore[method-assign]
+            return_value=[math.inf, math.inf]
+        )
+
+        with self.assertRaises(exc.NoConfigFound):
+            cache._run_autotune_trials()
+
+
+class _StageSearch:
+    def __init__(self, config: Config | None, perf: float, tested: int) -> None:
+        self.config = config
+        self.best_perf_so_far = perf
+        self._autotune_metrics = AutotuneMetrics(num_configs_tested=tested)
+
+    def autotune(self, *, skip_cache: bool = False) -> Config:
+        if self.config is None:
+            raise exc.NoConfigFound
+        return self.config
+
+
+class TestMultiShapeLLMSeeded(unittest.TestCase):
+    @staticmethod
+    def _make_search(
+        llm_stage: _StageSearch, second_stage: _StageSearch
+    ) -> tuple[LLMSeededSearch, list[bool]]:
+        kernel = SimpleNamespace(settings=Settings(), config_spec=SimpleNamespace())
+        search = LLMSeededSearch(
+            kernel,
+            _make_carrier(((object(), ()),)),
+            llm_max_rounds=1,
+            second_stage_algorithm="FiniteSearch",
+        )
+        search._autotune_metrics = AutotuneMetrics()
+        search._make_llm_search = lambda: llm_stage  # type: ignore[method-assign,return-value]
+        seeded_values: list[bool] = []
+
+        def make_second_stage(*, seeded: bool) -> _StageSearch:
+            seeded_values.append(seeded)
+            return second_stage
+
+        search._make_second_stage_search = make_second_stage  # type: ignore[method-assign,return-value]
+        return search, seeded_values
+
+    def test_failed_llm_stage_runs_second_stage_unseeded(self) -> None:
+        winner = Config(num_warps=4)
+        search, seeded = self._make_search(
+            _StageSearch(None, math.inf, 2),
+            _StageSearch(winner, 0.7, 3),
+        )
+
+        self.assertEqual(search._autotune(), winner)
+        self.assertEqual(seeded, [False])
+        self.assertFalse(search.hybrid_stage_breakdown["used_llm_seed"])
+
+    def test_invalid_second_stage_returns_valid_llm_seed(self) -> None:
+        winner = Config(num_warps=4)
+        invalid_second_stages = (
+            _StageSearch(None, math.inf, 3),
+            _StageSearch(Config(num_warps=8), math.inf, 3),
+        )
+
+        for second_stage in invalid_second_stages:
+            with self.subTest(config=second_stage.config):
+                search, seeded = self._make_search(
+                    _StageSearch(winner, 0.6, 2), second_stage
+                )
+
+                self.assertEqual(search._autotune(), winner)
+                self.assertEqual(seeded, [True])
+                self.assertEqual(search.best_perf_so_far, 0.6)
+
+    def test_both_failed_stages_raise_after_metrics(self) -> None:
+        search, seeded = self._make_search(
+            _StageSearch(None, math.inf, 2),
+            _StageSearch(None, math.inf, 3),
+        )
+
+        with self.assertRaises(exc.NoConfigFound):
+            search._autotune()
+        self.assertEqual(seeded, [False])
+        self.assertEqual(search._autotune_metrics.num_configs_tested, 5)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestMultiShapeAutotuneIntegration(unittest.TestCase):
+    @staticmethod
+    def _make_add_case(
+        *, best_of_k: int | None = None, log_path: str | None = None
+    ) -> tuple[Kernel, list[tuple[torch.Tensor, torch.Tensor]]]:
+        settings: dict[str, object] = {}
+        if best_of_k is not None:
+            settings["autotune_best_of_k"] = best_of_k
+        if log_path is not None:
+            settings["autotune_log"] = log_path
+
+        @helion.kernel(
+            configs=[
+                helion.Config(block_sizes=[64], num_warps=4),
+                helion.Config(block_sizes=[128], num_warps=4),
+            ],
+            autotune_benchmark_subprocess=False,
+            autotune_precompile=None,
+            **settings,
+        )
+        def add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(a)
+            for tile in hl.tile(a.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        arg_sets = [
+            (torch.randn(256, device="cuda"), torch.randn(256, device="cuda")),
+            (torch.randn(2048, device="cuda"), torch.randn(2048, device="cuda")),
+        ]
+        return add, arg_sets
+
+    def test_finite_search_installs_one_config_for_two_shapes(self) -> None:
+        add, arg_sets = self._make_add_case()
+
+        winner = add.autotune_multi(
+            arg_sets,
+            aggregation="max",
+            relative_to="default",
+            force=False,
+        )
+
+        self.assertIn(winner.block_sizes[0], (64, 128))
+        for args in arg_sets:
+            torch.testing.assert_close(add(*args), args[0] + args[1])
+
+    def test_cache_best_of_k_persists_selected_breakdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "multi_shape"
+            add, arg_sets = self._make_add_case(
+                best_of_k=2,
+                log_path=str(log_path),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "HELION_AUTOTUNER": "FiniteSearch",
+                    "HELION_SKIP_CACHE": "1",
+                },
+            ):
+                add.autotune_multi(
+                    arg_sets,
+                    aggregation="max",
+                    relative_to="default",
+                )
+
+            log_text = log_path.with_suffix(".log").read_text()
+            self.assertIn("Selected multi-shape config", log_text)
+            self.assertIn("arg_sets[0]", log_text)
+            self.assertIn("arg_sets[1]", log_text)
+            self.assertIn("objective: max(latency ratios vs default)=", log_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a single multi-shape config for the `per_token_group_fp8_quant` pretuned kernel, found with `Kernel.autotune_multi` (#3119), as an alternative to the per-shape AOT heuristic (a 41-entry shape→config lookup table).

## What's here
- **`_multi_shape_config_cuda_sm90.py`**: the checked-in single config for H100, found with a geomean objective (`relative_to="default"`) tuned jointly over a representative subset of the benchmark shapes (token extremes × hidden extremes). Named to mirror the existing per-shape `_helion_aot_*_cuda_sm90.py` convention.
- **`per_token_group_fp8_quant.py`**: a `--single-config` flag (and `main(single_config=...)`) that pins that one config for every shape instead of the per-shape heuristic, for a directly comparable benchmark. Default behavior is unchanged.
- **`_multi_shape_autotune.py`**: reproducer that runs `autotune_multi` and prints the config in the exact checked-in form.

## Result (H100 / sm90, CUDA-graph timing, 24-shape sweep)
The single config matches the per-shape heuristic's geomean vs `torch_compile` (~2.69x vs 2.70x) and wins on the same 24/24 shapes vs torch — while collapsing 41 configs to one. Two small per-shape regressions remain at `(2048, 2048)` and `(256, 5120)` (not in the tuning subset).

## Notes
- Depends on `autotune_multi` from #3119, so this is stacked on that branch as its base. `autotune_multi` requires the default autotuner + local best-config cache, so the reproducer wraps the kernel body with a plain `helion.kernel` (the shipped kernel uses `aot_kernel`, whose `AOTAutotuneCache` `autotune_multi` rejects).
- `sm100`/B200 config not included yet (needs a B200 tuning run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)