### PR TITLE
[autotuner] keep population configs canonical

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -870,8 +870,8 @@ class PopulationBasedSearch(BaseSearch):
         Returns:
             A population member with the benchmark results.
         """
-        config = self.config_gen.unflatten(flat_values)
-        member = PopulationMember(_unset_fn, [], flat_values, config)
+        canonical_flat, config = self.config_gen.canonicalize_flat(flat_values)
+        member = PopulationMember(_unset_fn, [], canonical_flat, config)
         self.benchmark_population([member], desc="Benchmarking")
         return member
 
@@ -925,10 +925,10 @@ class PopulationBasedSearch(BaseSearch):
             configuration is invalid.
         """
         try:
-            config = self.config_gen.unflatten(flat_values)
+            canonical_flat, config = self.config_gen.canonicalize_flat(flat_values)
         except exc.InvalidConfig:
             return None
-        return PopulationMember(_unset_fn, [], flat_values, config)
+        return PopulationMember(_unset_fn, [], canonical_flat, config)
 
     def _generate_best_available_population_flat(self) -> list[FlatConfig]:
         """
@@ -1060,7 +1060,8 @@ class PopulationBasedSearch(BaseSearch):
         """
         results = self.benchmark_batch([m.config for m in members], desc=desc)
         for member, result in zip(members, results, strict=True):
-            assert result.config is member.config
+            member.config = result.config
+            member.flat_values = self.config_gen.flatten(result.config)
             member.perfs.append(result.perf)
             member.fn = result.fn
             member.status = result.status
@@ -1100,7 +1101,11 @@ class PopulationBasedSearch(BaseSearch):
             # cannot change this key's hash (-> KeyError on prune / orphaned
             # entries) or the config recompiled during final verification.
             snapshot = copy.deepcopy(config)
-            target[snapshot] = dataclasses.replace(member, config=snapshot)
+            target[snapshot] = dataclasses.replace(
+                member,
+                flat_values=copy.deepcopy(member.flat_values),
+                config=snapshot,
+            )
 
     def _prune_benchmarked_members(self, top_k: int) -> None:
         if len(self._benchmarked_members) <= top_k:
@@ -1656,7 +1661,7 @@ class PopulationBasedSearch(BaseSearch):
         current = PopulationMember(
             fn=current.fn,
             perfs=current.perfs,
-            flat_values=current.flat_values,
+            flat_values=self.config_gen.flatten(minimal_config),
             config=minimal_config,
             status=current.status,
             compile_time=current.compile_time,

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -295,15 +295,16 @@ class ConfigGeneration:
                     continue
             else:
                 value = config.config[key]
-            field = flat_fields[key]
             if is_sequence:
                 assert isinstance(value, list)
+                field = flat_fields[key]
                 assert isinstance(field, BlockIdSequence)
                 encoded_values = field._encode_flat_values(self.config_spec, value)
                 for idx, encoded_value in zip(indices, encoded_values, strict=True):
                     result[idx] = copy.deepcopy(encoded_value)
             else:
                 assert len(indices) == 1
+                field = self.flat_spec[indices[0]]
                 if isinstance(field, ListOf) and not isinstance(value, list):
                     value = [copy.deepcopy(value) for _ in range(field.length)]
                 result[indices[0]] = copy.deepcopy(value)

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -295,18 +295,25 @@ class ConfigGeneration:
                     continue
             else:
                 value = config.config[key]
+            field = flat_fields[key]
             if is_sequence:
                 assert isinstance(value, list)
-                field = flat_fields[key]
                 assert isinstance(field, BlockIdSequence)
                 encoded_values = field._encode_flat_values(self.config_spec, value)
                 for idx, encoded_value in zip(indices, encoded_values, strict=True):
-                    result[idx] = encoded_value
+                    result[idx] = copy.deepcopy(encoded_value)
             else:
                 assert len(indices) == 1
-                result[indices[0]] = value
+                if isinstance(field, ListOf) and not isinstance(value, list):
+                    value = [copy.deepcopy(value) for _ in range(field.length)]
+                result[indices[0]] = copy.deepcopy(value)
         self._repair_cute_num_threads(result)
         return result
+
+    def canonicalize_flat(self, flat_values: FlatConfig) -> tuple[FlatConfig, Config]:
+        """Normalize a flat config and return an owned matching flat/config pair."""
+        config = self.unflatten(copy.deepcopy(flat_values))
+        return self.flatten(config), config
 
     def unflatten(self, flat_values: FlatConfig) -> Config:
         """
@@ -438,8 +445,7 @@ class ConfigGeneration:
         seen: set[Config] = set()
         for i, config in enumerate(self.config_spec.compiler_seed_configs):
             try:
-                flat = self.flatten(config)
-                normalized = self.unflatten(flat)
+                flat, normalized = self.canonicalize_flat(self.flatten(config))
             except (
                 InvalidConfig,
                 ValueError,
@@ -466,8 +472,7 @@ class ConfigGeneration:
         seen: set[Config] = set()
         for i, config in enumerate(user_seed_configs):
             try:
-                flat = self.flatten(config)
-                normalized = self.unflatten(flat)
+                flat, normalized = self.canonicalize_flat(self.flatten(config))
             except (
                 InvalidConfig,
                 ValueError,

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from contextlib import nullcontext
+import copy
 import csv
 import logging
 import math
@@ -1415,6 +1416,81 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         for _ in range(50):
             result = gen.differential_mutation(base, a, b, c, crossover_rate=0.9)
             self.assertEqual(result[warp_idx], base[warp_idx])
+
+    def test_population_member_canonicalizes_overridden_flat_values(self):
+        args = (
+            torch.randn([8, 512, 512], device=DEVICE),
+            torch.randn([8, 512, 512], device=DEVICE),
+        )
+        spec = basic_kernels.add.bind(args).config_spec
+        gen = ConfigGeneration(spec, overrides={"num_warps": 8})
+        raw_flat = gen.default_flat()
+        original_flat = copy.deepcopy(raw_flat)
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.config_gen = gen
+
+        member = search.make_unbenchmarked(raw_flat)
+
+        self.assertIsNotNone(member)
+        assert member is not None
+        self.assertEqual(raw_flat, original_flat)
+        self.assertIsNot(member.flat_values, raw_flat)
+        self.assertEqual(member.config.num_warps, 8)
+        self.assertEqual(member.flat_values[gen.num_warps_index], 8)
+        self.assertEqual(member.flat_values, gen.flatten(member.config))
+        gen.encode_config(member.flat_values)
+
+        [(seed_flat, seed_config)] = gen.user_seed_flat_config_pairs(
+            [helion.Config(num_warps=4)]
+        )
+        self.assertEqual(seed_config.num_warps, 8)
+        self.assertEqual(seed_flat, gen.flatten(seed_config))
+
+    def test_scalar_list_override_has_encodable_flat_values(self):
+        args = (
+            torch.randn([8, 512, 512], device=DEVICE),
+            torch.randn([8, 512, 512], device=DEVICE),
+        )
+        spec = basic_kernels.add.bind(args).config_spec
+        gen = ConfigGeneration(spec, overrides={"indexing": "pointer"})
+
+        flat, config = gen.canonicalize_flat(gen.default_flat())
+
+        indexing_indices, is_sequence = gen._key_to_flat_indices["indexing"]
+        self.assertFalse(is_sequence)
+        self.assertEqual(len(indexing_indices), 1)
+        self.assertEqual(flat[indexing_indices[0]], ["pointer"] * spec.indexing.length)
+        self.assertEqual(flat, gen.flatten(config))
+        gen.encode_config(flat)
+
+    def test_population_adopts_config_filter_replacement(self):
+        args = (
+            torch.randn([8, 512, 512], device=DEVICE),
+            torch.randn([8, 512, 512], device=DEVICE),
+        )
+        bound_kernel = basic_kernels.add.bind(args)
+        search = PatternSearch(bound_kernel, args, initial_population=1)
+        member = search.make_unbenchmarked(search.config_gen.default_flat())
+        assert member is not None
+        replacement = helion.Config.from_dict({**member.config.config, "num_warps": 8})
+        result = SimpleNamespace(
+            config=replacement,
+            perf=float("inf"),
+            fn=lambda: None,
+            status="error",
+            compile_time=None,
+        )
+
+        with patch.object(search, "benchmark_batch", return_value=[result]):
+            search.benchmark_population([member])
+
+        self.assertIs(member.config, replacement)
+        self.assertEqual(member.flat_values, search.config_gen.flatten(replacement))
+        self.assertEqual(
+            member.flat_values[search.config_gen.num_warps_index],
+            8,
+        )
+        search.config_gen.encode_config(member.flat_values)
 
     def test_lfbo_pattern_search_skips_overridden_indices(self):
         """LFBOPatternSearch._generate_neighbors skips overridden indices."""


### PR DESCRIPTION
Population-based searches retain both a `Config` and its flattened representation. Config normalization, overrides, and config filters can modify or replace the `Config` while leaving the flattened values stale.                                                                                                                                                                                                          
                                                                                                                                                                                                                  
  This change:                                                                                                                                                                                                    
                                                                                                                                                                                                                  
  - canonicalizes flat/config pairs at population boundaries                                                                                                                                                      
  - updates flat values when benchmark filtering replaces a config                                                                                                                                                
  - canonicalizes compiler and user seed configs                                                                                                                                                                  
  - deep-copies nested flattened values                                                                                                                                                                           
  - expands scalar `ListOf` overrides into encodable lists                                                                                                                                                        
  - snapshots configs and flat values with independent ownership                                                                                                                                                  
                                                                                                                                                                                                                  
  This preserves the invariant:                                                                                                                                                                                   
                                                                                                                                                                                                                  
  `member.flat_values == config_gen.flatten(member.config)`                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                    
                                                                                 