### PR TITLE
[cute] Support generic one-CTA tcgen05 K tails

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2685,7 +2685,7 @@ def _kernel_specialized_mma_plan(
 ) -> _SpecializedMmaPlan | None:
     from .compile_environment import CompileEnvironment
     from .cute.cute_mma import _choose_mma_impl
-    from .cute.cute_mma import _mma_tiles_are_static_full
+    from .cute.cute_mma import _mma_tile_coverage
     from .cute.cute_mma import analyze_cute_mma_node
     from .device_ir import ForLoopGraphInfo
     from .host_function import HostFunction
@@ -2725,9 +2725,9 @@ def _kernel_specialized_mma_plan(
                 continue
             if (
                 candidate.operands.has_leading_passthrough
-                and not _mma_tiles_are_static_full(
+                and not _mma_tile_coverage(
                     candidate.operands, bm=bm, bn=bn, bk=bk
-                )
+                ).is_full_or_k_tail
             ):
                 continue
             lhs_val = candidate.operands.lhs.source_fake

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -130,7 +130,7 @@ def _detect_specialized_mma_loop(
     from ..host_function import HostFunction
     from .cute_mma import _choose_mma_impl
     from .cute_mma import _mma_active_n_threads
-    from .cute_mma import _mma_tiles_are_static_full
+    from .cute_mma import _mma_tile_coverage
     from .cute_mma import _tcgen05_root_m_threads
     from .cute_mma import analyze_cute_mma_node
 
@@ -209,7 +209,7 @@ def _detect_specialized_mma_loop(
         candidate
         for candidate in candidates
         if not candidate.operands.has_leading_passthrough
-        or _mma_tiles_are_static_full(candidate.operands, bm=bm, bn=bn, bk=bk)
+        or _mma_tile_coverage(candidate.operands, bm=bm, bn=bn, bk=bk).is_full_or_k_tail
     ]
     if not candidates:
         return False

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -46,7 +46,9 @@ from .device_state import CuteTcgen05MatmulPlan
 from .device_state import CuteTcgen05StoreValue
 from .layout import MatmulExecutionKind
 from .layout import MatmulExecutionPlan
+from .matmul_utils import CuteMmaTileCoverage
 from .matmul_utils import analyze_direct_grouped_n_loads
+from .matmul_utils import classify_cute_mma_tile_coverage
 from .mma_support import get_cute_mma_support
 from .strategies import TCGEN05_LEGAL_SMEM_SWIZZLE_BYTES
 from .strategies import Tcgen05PersistenceModel
@@ -561,14 +563,16 @@ class _MmaOutputStoreAnalysis:
     explicit_epi_tile_compatible: bool
 
 
-def _mma_tiles_are_static_full(
+def _mma_tile_coverage(
     analysis: _MmaOperandAnalysis, *, bm: int, bn: int, bk: int
-) -> bool:
-    """Whether the analyzed matrix extents are divisible by their tile sizes."""
-    return (
-        int(analysis.lhs.matrix_rows) % bm == 0
-        and int(analysis.rhs.matrix_cols) % bn == 0
-        and int(analysis.lhs.matrix_cols) % bk == 0
+) -> CuteMmaTileCoverage:
+    return classify_cute_mma_tile_coverage(
+        m=int(analysis.lhs.matrix_rows),
+        n=int(analysis.rhs.matrix_cols),
+        k=int(analysis.lhs.matrix_cols),
+        block_m=bm,
+        block_n=bn,
+        block_k=bk,
     )
 
 
@@ -1254,9 +1258,8 @@ def prepare_cute_collective_lane_loop_suppression(
             != "tcgen05"
         ):
             continue
-        if analysis.has_leading_passthrough and not _mma_tiles_are_static_full(
-            analysis, bm=bm, bn=bn, bk=bk
-        ):
+        coverage = _mma_tile_coverage(analysis, bm=bm, bn=bn, bk=bk)
+        if analysis.has_leading_passthrough and not coverage.is_full_or_k_tail:
             continue
         if (
             len(lhs_load.users) != 1
@@ -2304,10 +2307,8 @@ def _emit_mma_pipeline(
         config=df.config,
         input_device=lhs_fake.device,
     )
-    mma_tiles_are_static_full = _mma_tiles_are_static_full(
-        analysis, bm=bm, bn=bn, bk=bk
-    )
-    if analysis.has_leading_passthrough and not mma_tiles_are_static_full:
+    tile_coverage = _mma_tile_coverage(analysis, bm=bm, bn=bn, bk=bk)
+    if analysis.has_leading_passthrough and not tile_coverage.is_full_or_k_tail:
         return None
     # A leading-passthrough collective absorbs its serialized K loop. Other
     # non-root lane loops must already have been suppressed by MMA planning;
@@ -2369,10 +2370,27 @@ def _emit_mma_pipeline(
             "tcgen05 matmul with a leading passthrough axis does not support "
             "tcgen05_cluster_n != 1",
         )
-    tcgen05_static_output_tiles = m_size % bm == 0 and n_size % bn == 0
-    tcgen05_static_full_tiles = mma_tiles_are_static_full
-    tcgen05_has_k_tail = k_total_size > bk and k_total_size % bk != 0
-    tcgen05_k_tail_only = tcgen05_static_output_tiles and tcgen05_has_k_tail
+    tcgen05_static_output_tiles = tile_coverage.output_tiles_full
+    tcgen05_static_full_tiles = tile_coverage.is_static_full
+    tcgen05_has_k_tail = tile_coverage.has_k_tail
+    tcgen05_k_tail_only = tile_coverage.is_k_tail_only
+    tcgen05_one_cta_k_tail = (
+        mma_impl == "tcgen05"
+        and tcgen05_k_tail_only
+        and tcgen05_cluster_m == 1
+        and tcgen05_cluster_n_requested == 1
+    )
+    if (
+        analysis.has_leading_passthrough
+        and mma_impl == "tcgen05"
+        and tcgen05_k_tail_only
+        and not tcgen05_one_cta_k_tail
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 matmul with a leading passthrough K tail requires "
+            "tcgen05_cluster_m=1 and tcgen05_cluster_n=1",
+        )
     tcgen05_double_edge_output = m_size % bm != 0 and n_size % bn != 0
     tcgen05_double_edge_tma = (
         mma_impl == "tcgen05"
@@ -2425,6 +2443,13 @@ def _emit_mma_pipeline(
         and tcgen05_requested_two_cta
         and tcgen05_k_tail_only
     )
+    # Keep role-local producer and consumer state aligned by treating the
+    # partial K tile as a normal TMA stage; bounded TMA tensors zero-fill it.
+    tcgen05_preserve_tma_for_one_cta_k_tail = (
+        tcgen05_one_cta_k_tail
+        and tcgen05_use_tma_pipeline
+        and tcgen05_pid_is_persistent
+    )
     tcgen05_m_edge_only = (
         mma_impl == "tcgen05"
         and tcgen05_use_tma_pipeline
@@ -2452,6 +2477,7 @@ def _emit_mma_pipeline(
         and not tcgen05_static_full_tiles
         and not tcgen05_mixed_tma_scalar_fallback
         and not tcgen05_preserve_tma_for_two_cta_k_tail
+        and not tcgen05_preserve_tma_for_one_cta_k_tail
         and not tcgen05_m_edge_only
         and not tcgen05_n_edge_only
         and not tcgen05_double_edge_tma
@@ -2523,7 +2549,7 @@ def _emit_mma_pipeline(
         tcgen05_preserve_tma_for_two_cta_k_tail
         and tcgen05_is_two_cta
         and tcgen05_cluster_n == 1
-    )
+    ) or tcgen05_preserve_tma_for_one_cta_k_tail
     # Mirror the K-tail role-local guard so later cluster demotion or
     # cluster_n enablement cannot silently admit unvalidated edge ownership.
     tcgen05_role_local_m_edge_tma = (

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -49,6 +49,7 @@ from .layout import MatmulExecutionPlan
 from .matmul_utils import CuteMmaTileCoverage
 from .matmul_utils import analyze_direct_grouped_n_loads
 from .matmul_utils import classify_cute_mma_tile_coverage
+from .matmul_utils import cute_tma_tensor_is_aligned
 from .mma_support import get_cute_mma_support
 from .strategies import TCGEN05_LEGAL_SMEM_SWIZZLE_BYTES
 from .strategies import Tcgen05PersistenceModel
@@ -2161,8 +2162,14 @@ def _emit_mma_pipeline(
     # A must be row-major (M,K) K-contiguous == "row"; the K-major A SMEM
     # layout Helion emits expects the standard row-major A. Only B's major
     # mode is made layout-aware here.
-    tcgen05_use_tma_a = _dtype_tma_ok and _lhs_major == "row"
-    tcgen05_use_tma_b = _dtype_tma_ok and _rhs_major in ("row", "col")
+    tcgen05_use_tma_a = (
+        _dtype_tma_ok and _lhs_major == "row" and cute_tma_tensor_is_aligned(lhs_fake)
+    )
+    tcgen05_use_tma_b = (
+        _dtype_tma_ok
+        and _rhs_major in ("row", "col")
+        and cute_tma_tensor_is_aligned(rhs_fake)
+    )
     # B is K-major when its (K, N) storage is K-contiguous (column-major),
     # i.e. stride[0] == 1 -> _rhs_major == "col".
     tcgen05_b_k_major = _rhs_major == "col"
@@ -2444,7 +2451,8 @@ def _emit_mma_pipeline(
         and tcgen05_k_tail_only
     )
     # Keep role-local producer and consumer state aligned by treating the
-    # partial K tile as a normal TMA stage; bounded TMA tensors zero-fill it.
+    # partial K tile as a normal TMA stage. The operand-level TMA gate above
+    # ensures bounded TMA tensors can safely zero-fill the tail.
     tcgen05_preserve_tma_for_one_cta_k_tail = (
         tcgen05_one_cta_k_tail
         and tcgen05_use_tma_pipeline

--- a/helion/_compiler/cute/matmul_utils.py
+++ b/helion/_compiler/cute/matmul_utils.py
@@ -34,6 +34,50 @@ class DirectGroupedNLoadPlan:
     rhs_n_offset: int
 
 
+@dataclass(frozen=True)
+class CuteMmaTileCoverage:
+    """Static MMA tile coverage relevant to collective code generation."""
+
+    output_tiles_full: bool
+    k_tiles_full: bool
+    has_k_tail: bool
+
+    @property
+    def is_static_full(self) -> bool:
+        return self.output_tiles_full and self.k_tiles_full
+
+    @property
+    def is_k_tail_only(self) -> bool:
+        return self.output_tiles_full and self.has_k_tail
+
+    @property
+    def is_full_or_k_tail(self) -> bool:
+        return self.is_static_full or self.is_k_tail_only
+
+
+def classify_cute_mma_tile_coverage(
+    *, m: int, n: int, k: int, block_m: int, block_n: int, block_k: int
+) -> CuteMmaTileCoverage:
+    """Classify whether an MMA problem is full-tile or has only a K tail."""
+    k_tiles_full = k % block_k == 0
+    return CuteMmaTileCoverage(
+        output_tiles_full=m % block_m == 0 and n % block_n == 0,
+        k_tiles_full=k_tiles_full,
+        has_k_tail=k > block_k and not k_tiles_full,
+    )
+
+
+def largest_power_of_two_divisor_at_most(
+    extent: int, maximum: int, minimum: int
+) -> int | None:
+    """Return the largest power-of-two divisor in ``[minimum, maximum]``."""
+    if extent <= 0 or maximum <= 0 or minimum <= 0:
+        return None
+    maximum_power_of_two = 1 << (maximum.bit_length() - 1)
+    candidate = min(maximum_power_of_two, extent & -extent)
+    return candidate if candidate >= minimum else None
+
+
 def _cute_static_int_extent(size: object) -> int | None:
     if not isinstance(size, (int, torch.SymInt, sympy.Expr)):
         return None

--- a/helion/_compiler/cute/matmul_utils.py
+++ b/helion/_compiler/cute/matmul_utils.py
@@ -55,6 +55,21 @@ class CuteMmaTileCoverage:
         return self.is_static_full or self.is_k_tail_only
 
 
+def cute_tma_tensor_is_aligned(tensor: torch.Tensor) -> bool:
+    """Return whether a tensor satisfies TMA's 16-byte alignment contract."""
+    itemsize = tensor.dtype.itemsize
+    storage_offset = _cute_static_int_extent(tensor.storage_offset())
+    if storage_offset is None or storage_offset * itemsize % 16 != 0:
+        return False
+    for tensor_stride in tensor.stride():
+        stride = _cute_static_int_extent(tensor_stride)
+        if stride is None or stride <= 0:
+            return False
+        if stride != 1 and stride * itemsize % 16 != 0:
+            return False
+    return True
+
+
 def classify_cute_mma_tile_coverage(
     *, m: int, n: int, k: int, block_m: int, block_n: int, block_k: int
 ) -> CuteMmaTileCoverage:

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -13,6 +13,7 @@ from ...autotuner.config_fragment import EnumFragment
 from ...autotuner.config_fragment import IntegerFragment
 from ...exc import InvalidConfig
 from ...runtime.config import Config
+from .matmul_utils import largest_power_of_two_divisor_at_most
 from .strategies import ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC
 from .strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from .strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
@@ -284,6 +285,20 @@ class CuteTcgen05Config:
         if max(indices) >= len(block_sizes):
             return None
         return block_sizes, m_index, n_index, k_index
+
+    def _matmul_static_extents(self) -> tuple[int, int, int] | None:
+        if self.matmul_block_ids is None:
+            return None
+        for fact in self.config_spec.matmul_facts:
+            if (
+                (fact.m_block_id, fact.n_block_id, fact.k_block_id)
+                == self.matmul_block_ids
+                and fact.static_m is not None
+                and fact.static_n is not None
+                and fact.static_k is not None
+            ):
+                return fact.static_m, fact.static_n, fact.static_k
+        return None
 
     def _matmul_block_fragments(
         self,
@@ -1854,7 +1869,7 @@ class CuteTcgen05Config:
         config_view = self._matmul_config_view(config)
         if config_view is None:
             return
-        block_sizes, m_index, _, _ = config_view
+        block_sizes, m_index, n_index, _ = config_view
         constraints = self.cluster_m2_search_constraints
         if constraints is not None and constraints.allow_edge_k_tail_family:
             # persistent_interleaved stays in the flat enum so cluster_m=2
@@ -1862,9 +1877,33 @@ class CuteTcgen05Config:
             # same surface must use the validated flat edge fallback.
             config["pid_type"] = "flat"
             return
-        bm = block_sizes[m_index]
-        if isinstance(bm, int) and not isinstance(bm, bool):
-            block_sizes[m_index] = min(bm, TCGEN05_ONE_CTA_MAX_BLOCK_M)
+        static_extents = self._matmul_static_extents()
+        fragments = self._matmul_block_fragments()
+        if static_extents is None or fragments is None:
+            return
+        static_m, static_n, _ = static_extents
+        bm_fragment, bn_fragment, _ = fragments
+        for block_index, static_size, minimum, maximum in (
+            (
+                m_index,
+                static_m,
+                bm_fragment.low,
+                TCGEN05_ONE_CTA_MAX_BLOCK_M,
+            ),
+            (n_index, static_n, bn_fragment.low, bn_fragment.high),
+        ):
+            block_size = block_sizes[block_index]
+            if not isinstance(block_size, int) or isinstance(block_size, bool):
+                continue
+            divisor = largest_power_of_two_divisor_at_most(
+                static_size,
+                min(block_size, maximum),
+                minimum,
+            )
+            if divisor is None:
+                config["pid_type"] = "flat"
+                return
+            block_sizes[block_index] = divisor
 
     def restrict_num_epi_warps_search(self, choices: tuple[int, ...]) -> None:
         assert choices, "tcgen05_num_epi_warps search must allow at least one value"

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -3652,6 +3652,7 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                 from ..language.matmul_ops import enable_cute_tcgen05_search
                 from ..language.matmul_ops import plan_cute_tcgen05_search
                 from .cute.cute_mma import analyze_cute_mma_node
+                from .cute.matmul_utils import cute_tma_tensor_is_aligned
 
                 # The same structural analyzer gates tcgen05 search and codegen
                 # for every matrix rank. This prevents transformed loads from
@@ -3710,6 +3711,11 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                         explicit_epi_tile_compatible=all(
                             item.explicit_epi_tile_compatible
                             for item, _lhs, _plan in search_candidates
+                        ),
+                        tma_operands_aligned=all(
+                            cute_tma_tensor_is_aligned(operand.source_fake)
+                            for item, _lhs, _plan in search_candidates
+                            for operand in (item.operands.lhs, item.operands.rhs)
                         ),
                     )
         config_spec.raise_grid_block_minimums()

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -11,7 +11,10 @@ from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.compile_environment import _to_sympy
 from .._compiler.compile_environment import format_shape
 from .._compiler.compile_environment import shape_env_var_hints
+from .._compiler.cute.matmul_utils import classify_cute_mma_tile_coverage
 from .._compiler.cute.matmul_utils import cute_outer_accumulates_result
+from .._compiler.cute.matmul_utils import largest_power_of_two_divisor_at_most
+from .._compiler.cute.tcgen05_constants import TCGEN05_ONE_CTA_MAX_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
@@ -383,7 +386,6 @@ def plan_cute_tcgen05_search(
             min_search_m = 64
         max_search_m = min(max_search_m, static_m & -static_m)
         max_search_n = min(max_search_n, static_n & -static_n)
-        max_search_k = min(max_search_k, static_k & -static_k)
         if max_search_m < min_search_m or max_search_n < 8 or max_search_k < mma_k:
             return None
     if static_m % max_search_m != 0 and static_n % max_search_n != 0:
@@ -436,21 +438,41 @@ def enable_cute_tcgen05_search(
     max_search_n = plan.max_search_n
     max_search_k = plan.max_search_k
     spec.cute_tcgen05_search_enabled = True
-    allow_full_tile_persistent_pid_types = (
-        static_m % max_search_m == 0
-        and static_n % max_search_n == 0
-        and static_k % max_search_k == 0
+    max_tile_coverage = classify_cute_mma_tile_coverage(
+        m=static_m,
+        n=static_n,
+        k=static_k,
+        block_m=max_search_m,
+        block_n=max_search_n,
+        block_k=max_search_k,
     )
+    persistent_block_m = largest_power_of_two_divisor_at_most(
+        static_m,
+        min(max_search_m, TCGEN05_ONE_CTA_MAX_BLOCK_M),
+        plan.min_search_m,
+    )
+    persistent_block_n = largest_power_of_two_divisor_at_most(static_n, max_search_n, 8)
+    allow_persistent_pid_types = False
+    if persistent_block_m is not None and persistent_block_n is not None:
+        persistent_tile_coverage = classify_cute_mma_tile_coverage(
+            m=static_m,
+            n=static_n,
+            k=static_k,
+            block_m=persistent_block_m,
+            block_n=persistent_block_n,
+            block_k=max_search_k,
+        )
+        allow_persistent_pid_types = persistent_tile_coverage.is_full_or_k_tail
     max_cluster_m2_search_k = TCGEN05_TWO_CTA_MAX_K_TILES * max_search_k
     allow_full_tile_cluster_m2_search = (
-        allow_full_tile_persistent_pid_types
+        max_tile_coverage.is_static_full
         and max_search_m >= TCGEN05_TWO_CTA_BLOCK_M
         and max_search_n >= TCGEN05_TWO_CTA_BLOCK_N
         and static_k <= max_cluster_m2_search_k
     )
     allow_edge_cluster_m2_search = (
         not has_leading_passthrough
-        and not allow_full_tile_persistent_pid_types
+        and not max_tile_coverage.is_static_full
         and plan.max_tcgen05_m >= TCGEN05_TWO_CTA_BLOCK_M
         and plan.max_tcgen05_n >= TCGEN05_TWO_CTA_BLOCK_N
         and static_m >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
@@ -464,7 +486,7 @@ def enable_cute_tcgen05_search(
     allow_fp8_small_grid_cluster_m2_search = (
         not has_leading_passthrough
         and plan.is_fp8
-        and allow_full_tile_persistent_pid_types
+        and max_tile_coverage.is_static_full
         and max_search_m >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
         and max_search_n >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
         and static_k <= max_cluster_m2_search_k
@@ -492,7 +514,7 @@ def enable_cute_tcgen05_search(
                 allow_cluster_m2_search = False
                 allow_fp8_small_grid_cluster_m2_search = False
     spec.narrow_tcgen05_autotune_to_validated_configs(
-        allow_persistent_pid_types=allow_full_tile_persistent_pid_types,
+        allow_persistent_pid_types=allow_persistent_pid_types,
         allow_cluster_m2_search=allow_cluster_m2_search,
         cluster_m2_static_k=static_k if allow_cluster_m2_search else None,
         allow_cluster_m2_edge_k_tail_family=allow_edge_cluster_m2_search,

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -419,6 +419,7 @@ def enable_cute_tcgen05_search(
     input_dtype: torch.dtype,
     has_leading_passthrough: bool,
     explicit_epi_tile_compatible: bool,
+    tma_operands_aligned: bool,
 ) -> None:
     """Apply one preflighted tcgen05 search plan to the shared config."""
     env = CompileEnvironment.current()
@@ -462,16 +463,20 @@ def enable_cute_tcgen05_search(
             block_n=persistent_block_n,
             block_k=max_search_k,
         )
-        allow_persistent_pid_types = persistent_tile_coverage.is_full_or_k_tail
+        allow_persistent_pid_types = (
+            tma_operands_aligned and persistent_tile_coverage.is_full_or_k_tail
+        )
     max_cluster_m2_search_k = TCGEN05_TWO_CTA_MAX_K_TILES * max_search_k
     allow_full_tile_cluster_m2_search = (
-        max_tile_coverage.is_static_full
+        tma_operands_aligned
+        and max_tile_coverage.is_static_full
         and max_search_m >= TCGEN05_TWO_CTA_BLOCK_M
         and max_search_n >= TCGEN05_TWO_CTA_BLOCK_N
         and static_k <= max_cluster_m2_search_k
     )
     allow_edge_cluster_m2_search = (
-        not has_leading_passthrough
+        tma_operands_aligned
+        and not has_leading_passthrough
         and not max_tile_coverage.is_static_full
         and plan.max_tcgen05_m >= TCGEN05_TWO_CTA_BLOCK_M
         and plan.max_tcgen05_n >= TCGEN05_TWO_CTA_BLOCK_N
@@ -484,7 +489,8 @@ def enable_cute_tcgen05_search(
         and static_k % max_search_k != 0
     )
     allow_fp8_small_grid_cluster_m2_search = (
-        not has_leading_passthrough
+        tma_operands_aligned
+        and not has_leading_passthrough
         and plan.is_fp8
         and max_tile_coverage.is_static_full
         and max_search_m >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -59,6 +59,24 @@ def _batched_tcgen05_two_cta_config(*, cluster_n: int = 1) -> helion.Config:
     )
 
 
+def _tcgen05_one_cta_k_tail_config(
+    block_sizes: list[int], *, pid_type: str
+) -> helion.Config:
+    return helion.Config(
+        block_sizes=block_sizes,
+        l2_groupings=[1],
+        num_stages=2,
+        num_warps=8,
+        pid_type=pid_type,  # type: ignore[arg-type]
+        tcgen05_cluster_m=1,
+        tcgen05_cluster_n=1,
+        tcgen05_ab_stages=2,
+        tcgen05_acc_stages=2,
+        tcgen05_c_stages=2,
+        tcgen05_num_epi_warps=4,
+    )
+
+
 def _leading_tcgen05_direct_entry_config() -> helion.Config:
     return helion.Config(
         block_sizes=[1, 256, 256, 64],
@@ -1024,6 +1042,21 @@ def cute_rhs_batched_dot_tcgen05(w: torch.Tensor, y: torch.Tensor) -> torch.Tens
         for tile_k in hl.tile(k):
             acc = hl.dot(w[tile_m, tile_k], y[tile_b, tile_k, tile_n], acc=acc)
         out[tile_b, tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+@helion.kernel(backend="cute")
+def cute_rhs_batched_dot_bias_tcgen05(
+    w: torch.Tensor, y: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    m, k = w.size()
+    b, _, n = y.size()
+    out = torch.empty([b, m, n], dtype=torch.bfloat16, device=w.device)
+    for tile_b, tile_m, tile_n in hl.tile([b, m, n]):
+        acc = hl.zeros([tile_b, tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(w[tile_m, tile_k], y[tile_b, tile_k, tile_n], acc=acc)
+        out[tile_b, tile_m, tile_n] = (acc + bias[tile_n]).to(torch.bfloat16)
     return out
 
 
@@ -5250,11 +5283,10 @@ class TestCuteBackend(TestCase):
             self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
 
         config = _batched_tcgen05_two_cta_config()
-        # (M, N, K): M-edge, N-edge, K-tail (M/N full), double-edge + K-tail.
+        # (M, N, K): M-edge, N-edge, double-edge + K-tail.
         partial_shapes = [
             (300, 256, 128),
             (256, 300, 128),
-            (256, 256, 100),
             (300, 300, 100),
         ]
 
@@ -5278,42 +5310,159 @@ class TestCuteBackend(TestCase):
                 ):
                     bound.to_triton_code(config)
 
-    def test_batched_one_cta_partial_tiles_fall_back_correctly(self) -> None:
+        # A K-tail-only shape enters tcgen05 search, but its search surface is
+        # deliberately restricted to one CTA. An explicit two-CTA config must
+        # still fail before it can use the batch-unaware clustered tail path.
+        args = _bmm_args(256, 256, 100)
+        with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+            bound = cute_batched_baddbmm_tcgen05.bind(args)
+            self.assertTrue(bound.config_spec.cute_tcgen05_search_enabled)
+            self.assertEqual(bound.config_spec._tcgen05_cluster_m_search_choices, (1,))
+            with self.assertRaisesRegex(
+                helion.exc.BackendUnsupported,
+                "leading passthrough K tail requires tcgen05_cluster_m=1",
+            ):
+                bound.to_triton_code(config)
+
+    def test_batched_one_cta_output_edge_falls_back_correctly(self) -> None:
         support = get_cute_mma_support()
         if not support.tcgen05_f16bf16:
             self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
 
-        # Leading-passthrough MMA is validated only for static full M/N/K
-        # tiles. Partial configs must use the scalar fallback.
-        cases = [
-            ("N edge", (2, 64, 32), (2, 32, 10)),
-            ("K tail", (2, 64, 35), (2, 35, 8)),
-        ]
-        for label, lhs_shape, rhs_shape in cases:
-            for mma_impl in ("tcgen05", "universal"):
-                args = (
-                    torch.randn(*lhs_shape, device=DEVICE, dtype=HALF_DTYPE),
-                    torch.randn(*rhs_shape, device=DEVICE, dtype=HALF_DTYPE),
+        args = (
+            torch.randn(2, 64, 32, device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn(2, 32, 10, device=DEVICE, dtype=HALF_DTYPE),
+        )
+        for mma_impl in ("tcgen05", "universal"):
+            with (
+                self.subTest(mma_impl=mma_impl),
+                patch.dict(
+                    os.environ,
+                    {"HELION_CUTE_MMA_IMPL": mma_impl},
+                    clear=False,
+                ),
+            ):
+                bound = cute_batched_baddbmm_tcgen05.bind(args)
+                self.assertFalse(bound.config_spec.cute_tcgen05_search_enabled)
+                config = helion.Config(
+                    block_sizes=[1, 64, 8, 16],
+                    pid_type="flat",
                 )
-                with (
-                    self.subTest(case=label, mma_impl=mma_impl),
-                    patch.dict(
-                        os.environ,
-                        {"HELION_CUTE_MMA_IMPL": mma_impl},
-                        clear=False,
-                    ),
-                ):
-                    bound = cute_batched_baddbmm_tcgen05.bind(args)
-                    self.assertFalse(bound.config_spec.cute_tcgen05_search_enabled)
-                    config = helion.Config(
-                        block_sizes=[1, 64, 8, 16],
-                        pid_type="flat",
+                code = bound.to_triton_code(config)
+                out = bound.compile_config(config)(*args)
+                expected = torch.bmm(args[0].float(), args[1].float())
+                self.assertNotIn("cute.gemm(", code)
+                torch.testing.assert_close(out, expected, atol=1e-1, rtol=1e-2)
+
+    def test_one_cta_k_tail_coverage_is_generic(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        k = 104  # BK=64 plus a 40-element tail.
+        regular_args = (
+            torch.randn(128, k, device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn(k, 128, device=DEVICE, dtype=HALF_DTYPE),
+        )
+        lhs_leading_args = (
+            torch.randn(2, 128, k, device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn(k, 128, device=DEVICE, dtype=HALF_DTYPE),
+        )
+        rhs_leading_args = (
+            torch.randn(128, k, device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn(2, k, 128, device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn(128, device=DEVICE, dtype=HALF_DTYPE),
+        )
+        cases = (
+            (
+                "regular persistent",
+                cute_matmul_mma,
+                regular_args,
+                [128, 128, 64],
+                "persistent_interleaved",
+                regular_args[0].float() @ regular_args[1].float(),
+                None,
+            ),
+            (
+                "lhs leading flat",
+                cute_mixed_rank_batched_dot_tcgen05,
+                lhs_leading_args,
+                [1, 128, 128, 64],
+                "flat",
+                torch.matmul(lhs_leading_args[0].float(), lhs_leading_args[1].float()),
+                "'lhs_leading_passthrough': True",
+            ),
+            (
+                "rhs leading persistent bias",
+                cute_rhs_batched_dot_bias_tcgen05,
+                rhs_leading_args,
+                [1, 128, 128, 64],
+                "persistent_interleaved",
+                torch.matmul(rhs_leading_args[0].float(), rhs_leading_args[1].float())
+                + rhs_leading_args[2].float(),
+                "'rhs_leading_passthrough': True",
+            ),
+        )
+
+        with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+            for (
+                label,
+                kernel,
+                args,
+                block_sizes,
+                pid_type,
+                expected,
+                plan_marker,
+            ) in cases:
+                with self.subTest(case=label):
+                    kernel.reset()
+                    bound = kernel.bind(args)
+                    self.assertTrue(bound.config_spec.cute_tcgen05_search_enabled)
+                    self.assertIn(
+                        "persistent_interleaved", bound.config_spec.allowed_pid_types
+                    )
+                    self.assertEqual(
+                        bound.config_spec._tcgen05_cluster_m_search_choices, (1,)
+                    )
+                    config = _tcgen05_one_cta_k_tail_config(
+                        block_sizes, pid_type=pid_type
                     )
                     code = bound.to_triton_code(config)
                     out = bound.compile_config(config)(*args)
-                    expected = torch.bmm(args[0].float(), args[1].float())
-                    self.assertNotIn("cute.gemm(", code)
-                    torch.testing.assert_close(out, expected, atol=1e-1, rtol=1e-2)
+                    torch.testing.assert_close(
+                        out.float(), expected, atol=2e-1, rtol=2e-2
+                    )
+                    self.assertIn("cute.gemm(", code)
+                    if plan_marker is not None:
+                        self.assertIn(plan_marker, code)
+                    if pid_type.startswith("persistent"):
+                        self.assertIn("PipelineTmaUmma.create", code)
+                        self.assertRegex(
+                            code,
+                            r"tile_offset_\d+ < cutlass\.Int32\(104\)",
+                        )
+
+    def test_batched_k_tail_forced_universal_falls_back_correctly(self) -> None:
+        args = (
+            torch.randn(2, 64, 35, device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn(2, 35, 8, device=DEVICE, dtype=HALF_DTYPE),
+        )
+        with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "universal"}, clear=False):
+            cute_batched_baddbmm_tcgen05.reset()
+            bound = cute_batched_baddbmm_tcgen05.bind(args)
+            config = helion.Config(
+                block_sizes=[1, 64, 8, 16],
+                pid_type="flat",
+            )
+            code = bound.to_triton_code(config)
+            out = bound.compile_config(config)(*args)
+        self.assertNotIn("cute.gemm(", code)
+        torch.testing.assert_close(
+            out,
+            torch.bmm(args[0].float(), args[1].float()),
+            atol=1e-1,
+            rtol=1e-2,
+        )
 
     def test_batched_tcgen05_cluster_n_rejected_cleanly(self) -> None:
         support = get_cute_mma_support()

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -15824,9 +15824,11 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         kernel = self._bias_residual_gelu_kernel()
         args = (
             torch.empty([640, 128], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([128, 642], device=DEVICE, dtype=torch.bfloat16),
+            # Keep the row-vector extent unaligned while giving the matrix
+            # operands valid 16-byte-aligned padded TMA strides.
+            torch.empty([128, 648], device=DEVICE, dtype=torch.bfloat16)[:, :642],
             torch.empty([642], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([640, 642], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([640, 648], device=DEVICE, dtype=torch.bfloat16)[:, :642],
         )
 
         with patch_cute_mma_support():

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -8367,13 +8367,7 @@ class TestCuteLowerings(unittest.TestCase):
         torch.testing.assert_close(out, expected, atol=3e-1, rtol=2e-2)
 
     def test_tcgen05_persistent_partial_multi_tile_runtime_guard(self) -> None:
-        """Partial legacy persistent + tcgen05 still raises ``RuntimeError``.
-
-        Static full tiles use role-local persistent loops and have multi-tile
-        coverage. Partial K/M/N shapes stay on the legacy shared TMA fallback
-        path, which still launch-fails for multi-tile shapes; keep the
-        host-side guard for that non-role-local path.
-        """
+        """An unaligned TMA operand stays on the guarded persistent path."""
 
         from helion._compiler.cute.mma_support import get_cute_mma_support
 
@@ -8394,9 +8388,9 @@ class TestCuteLowerings(unittest.TestCase):
                 out[tile_m, tile_n] = acc.to(x.dtype)
             return out
 
-        # K=17 is not a static full tile for bk=16, so role-local extraction
-        # stays disabled. M/N are 2x2 tiles, so the legacy multi-tile guard
-        # must fire before the CUDA launch.
+        # The contiguous lhs has a 34-byte row stride, which cannot be encoded
+        # safely by TMA. M/N are 2x2 tiles, so the legacy multi-tile guard must
+        # fire before the CUDA launch.
         args = (
             torch.randn(256, 17, device=DEVICE, dtype=torch.float16),
             torch.randn(17, 256, device=DEVICE, dtype=torch.float16),
@@ -8417,6 +8411,56 @@ class TestCuteLowerings(unittest.TestCase):
                 "supports runtime execution only",
             ):
                 bound(*args)
+
+    def test_tcgen05_persistent_aligned_k_tail_multi_tile_correctness(self) -> None:
+        """A 16-byte-aligned K-tail uses role-local persistent loops."""
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_aligned_k_tail(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.randn(256, 24, device=DEVICE, dtype=torch.float16),
+            torch.randn(24, 256, device=DEVICE, dtype=torch.float16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_aligned_k_tail.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            cfg = _make_tcgen05_persistent_config(
+                block_sizes=[128, 128, 16],
+                pid_type="persistent_blocked",
+            )
+            bound.set_config(cfg)
+            code = bound.to_triton_code(cfg)
+            self.assertNotIn("_helion_tcgen05_persistent_total_tiles", code)
+            for role in range(3):
+                self.assertIn(
+                    f"while tcgen05_role_local_{role}_work_tile.is_valid_tile",
+                    code,
+                )
+            out = bound(*args)
+
+        torch.testing.assert_close(
+            out,
+            args[0] @ args[1],
+            atol=2e-1,
+            rtol=1e-2,
+        )
 
     def test_tcgen05_persistent_cluster_m2_multi_tile_runtime_guard(self) -> None:
         """CtaGroup.ONE cluster_m=2 fallback remains guarded."""

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -11,6 +11,7 @@ import helion
 from helion import _compat
 from helion._compiler.autotuner_heuristics.cute import CuteTcgen05ClusterM2Heuristic
 from helion._compiler.cute.matmul_utils import classify_cute_mma_tile_coverage
+from helion._compiler.cute.matmul_utils import cute_tma_tensor_is_aligned
 from helion._compiler.cute.matmul_utils import largest_power_of_two_divisor_at_most
 from helion._compiler.cute.strategies import ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC
 from helion._compiler.cute.strategies import Tcgen05LayoutOverrides
@@ -246,6 +247,15 @@ def _bind_cute_strategy_kernel():
 
 @onlyBackends(["triton", "cute"])
 class TestDotRequirements(RefEagerTestDisabled, TestCase):
+    def test_cute_tma_tensor_alignment(self) -> None:
+        self.assertTrue(cute_tma_tensor_is_aligned(torch.empty(128, 24)))
+        self.assertFalse(cute_tma_tensor_is_aligned(torch.empty(128, 17)))
+        self.assertTrue(cute_tma_tensor_is_aligned(torch.empty(128, 24).T))
+        self.assertFalse(cute_tma_tensor_is_aligned(torch.empty(128, 17).T))
+
+        offset = torch.empty(128 * 24 + 1)[1:].view(128, 24)
+        self.assertFalse(cute_tma_tensor_is_aligned(offset))
+
     def test_cute_mma_tile_coverage_classification(self) -> None:
         self.assertEqual(largest_power_of_two_divisor_at_most(128, 96, 8), 64)
 
@@ -296,6 +306,22 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(normalized.pid_type, "persistent_interleaved")
         self.assertEqual(flat, gen.flatten(normalized))
         gen.encode_config(flat)
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_unaligned_tma_stride_disables_persistent_search(
+        self,
+    ) -> None:
+        args = (
+            torch.empty([256, 17], device=DEVICE, dtype=HALF_DTYPE),
+            torch.empty([17, 256], device=DEVICE, dtype=HALF_DTYPE),
+        )
+        _cute_strategy_matmul_kernel.reset()
+        with patch_cute_mma_support():
+            bound = _cute_strategy_matmul_kernel.bind(args)
+
+        self.assertTrue(bound.config_spec.cute_tcgen05_search_enabled)
+        self.assertNotIn("persistent_blocked", bound.config_spec.allowed_pid_types)
+        self.assertNotIn("persistent_interleaved", bound.config_spec.allowed_pid_types)
 
     @patch.object(_compat, "_min_dot_size", lambda *args: (2, 8, 16))
     def test_hl_dot_sets_min_size(self) -> None:

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -10,6 +10,8 @@ import torch
 import helion
 from helion import _compat
 from helion._compiler.autotuner_heuristics.cute import CuteTcgen05ClusterM2Heuristic
+from helion._compiler.cute.matmul_utils import classify_cute_mma_tile_coverage
+from helion._compiler.cute.matmul_utils import largest_power_of_two_divisor_at_most
 from helion._compiler.cute.strategies import ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC
 from helion._compiler.cute.strategies import Tcgen05LayoutOverrides
 from helion._compiler.cute.strategies import Tcgen05LayoutStrategy
@@ -244,6 +246,57 @@ def _bind_cute_strategy_kernel():
 
 @onlyBackends(["triton", "cute"])
 class TestDotRequirements(RefEagerTestDisabled, TestCase):
+    def test_cute_mma_tile_coverage_classification(self) -> None:
+        self.assertEqual(largest_power_of_two_divisor_at_most(128, 96, 8), 64)
+
+        full = classify_cute_mma_tile_coverage(
+            m=128, n=128, k=128, block_m=128, block_n=128, block_k=64
+        )
+        self.assertTrue(full.is_static_full)
+        self.assertTrue(full.is_full_or_k_tail)
+
+        k_tail = classify_cute_mma_tile_coverage(
+            m=128, n=128, k=104, block_m=128, block_n=128, block_k=64
+        )
+        self.assertTrue(k_tail.is_k_tail_only)
+        self.assertTrue(k_tail.is_full_or_k_tail)
+
+        single_partial_k = classify_cute_mma_tile_coverage(
+            m=128, n=128, k=40, block_m=128, block_n=128, block_k=64
+        )
+        self.assertFalse(single_partial_k.is_full_or_k_tail)
+
+        output_edge = classify_cute_mma_tile_coverage(
+            m=130, n=128, k=104, block_m=128, block_n=128, block_k=64
+        )
+        self.assertFalse(output_edge.is_full_or_k_tail)
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_k_tail_reaches_smaller_persistent_tile(self) -> None:
+        args = (
+            torch.empty([192, 104], device=DEVICE, dtype=HALF_DTYPE),
+            torch.empty([104, 128], device=DEVICE, dtype=HALF_DTYPE),
+        )
+        _cute_strategy_matmul_kernel.reset()
+        with patch_cute_mma_support():
+            bound = _cute_strategy_matmul_kernel.bind(args)
+        spec = bound.config_spec
+        self.assertIn("persistent_interleaved", spec.allowed_pid_types)
+        self.assertEqual(spec._tcgen05_cluster_m_search_choices, (1,))
+
+        gen = ConfigGeneration(spec)
+        sampled = helion.Config(
+            block_sizes=[128, 128, 64],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=1,
+        )
+        flat, normalized = gen.canonicalize_flat(gen.flatten(sampled))
+
+        self.assertEqual(normalized.block_sizes[:3], [64, 128, 64])
+        self.assertEqual(normalized.pid_type, "persistent_interleaved")
+        self.assertEqual(flat, gen.flatten(normalized))
+        gen.encode_config(flat)
+
     @patch.object(_compat, "_min_dot_size", lambda *args: (2, 8, 16))
     def test_hl_dot_sets_min_size(self) -> None:
         @helion.kernel
@@ -1462,8 +1515,7 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
     def test_cute_tcgen05_partial_tile_search_keeps_persistent_pid_types_out(
         self,
     ) -> None:
-        """Autotune excludes persistent pid types when the search can sample
-        block sizes that produce partial tiles."""
+        """Autotune excludes persistence when no full output tile is reachable."""
 
         @helion.kernel(backend="cute")
         def cute_matmul_mma(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -1479,7 +1531,7 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
 
         args = (
             torch.randn([256, 64], device=DEVICE, dtype=HALF_DTYPE),
-            torch.randn([64, 192], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn([64, 193], device=DEVICE, dtype=HALF_DTYPE),
         )
         with patch_cute_mma_support():
             bound = cute_matmul_mma.bind(args)


### PR DESCRIPTION
Enable one-CTA tcgen05 kernels when output tiles are fully covered but the final K tile is partial.

  This change:
  - introduces a shared semantic M/N/K tile-coverage classifier
  - supports regular GEMM and either leading-batch operand orientation
  - preserves the persistent TMA pipeline for K-tail tiles
  - predicates and zero-fills the final TMA load
  - retains the existing scalar-tail path for flat scheduling
  - exposes smaller valid persistent tiles when the maximum sampled tile does not divide M/N
  - keeps clustered and output-edge combinations conservatively rejected
