### PR TITLE
Support specializing concrete tensor strides

### DIFF
--- a/docs/deployment_autotuning.md
+++ b/docs/deployment_autotuning.md
@@ -410,6 +410,11 @@ result3 = rms_norm_fwd(torch.randn([2048, 2048], device="cuda"), weight_2048)  #
 Use `hl.specialize()` when a dimension is performance-critical and you want
 it specialized regardless of how the kernel is called.
 
+Tensor strides can be specialized in the same way, for example
+`row_stride = hl.specialize(x.stride(0))`. The stride is inlined in generated
+code and included in the kernel cache key, so inputs with different layouts
+compile separate variants.
+
 ### `torch._dynamo.mark_static()` - External Specialization
 
 Use `torch._dynamo.mark_static()` **before** calling the kernel to specialize

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -58,43 +58,84 @@ class TensorDescriptorLayoutGuard:
     atomic_op_indices: set[int] = dataclasses.field(default_factory=set)
 
 
-def _is_supported_tensor_descriptor_layout_guard_source(source: Source) -> bool:
+def _is_supported_tensor_input_source(source: Source) -> bool:
+    if isinstance(source, LocalSource):
+        return True
+    if isinstance(source, GetItemSource):
+        return (
+            isinstance(source.index, (int, str))
+            and not source.index_is_slice
+            and _is_supported_tensor_input_source(source.base)
+        )
+    return False
+
+
+def _is_supported_tensor_descriptor_layout_guard_source(
+    source: Source,
+    root_values: typing.Mapping[str, object],
+) -> bool:
     if isinstance(source, LocalSource):
         return True
     if isinstance(source, GetItemSource):
         return (
             isinstance(source.index, int)
             and not source.index_is_slice
-            and _is_supported_tensor_descriptor_layout_guard_source(source.base)
+            and _is_supported_tensor_descriptor_layout_guard_source(
+                source.base, root_values
+            )
+            and isinstance(
+                _replay_tensor_input_source(source.base, root_values), (list, tuple)
+            )
         )
     return False
 
 
-def _replay_tensor_descriptor_layout_guard_source(
+def _replay_tensor_input_source(
     source: Source,
     root_values: typing.Mapping[str, object],
 ) -> object:
     if isinstance(source, LocalSource):
         return root_values.get(source.local_name)
     if isinstance(source, GetItemSource):
-        if not isinstance(source.index, int) or source.index_is_slice:
+        if not isinstance(source.index, (int, str)) or source.index_is_slice:
             return None
-        base = _replay_tensor_descriptor_layout_guard_source(source.base, root_values)
-        if isinstance(base, (list, tuple)) and 0 <= source.index < len(base):
+        base = _replay_tensor_input_source(source.base, root_values)
+        if (
+            isinstance(source.index, int)
+            and isinstance(base, (list, tuple))
+            and 0 <= source.index < len(base)
+        ):
             return base[source.index]
+        if isinstance(base, dict) and source.index in base:
+            return base[source.index]
+        if isinstance(source.index, str) and base is not None:
+            return getattr(base, source.index, None)
     return None
 
 
-def _find_tensor_descriptor_layout_guard_source(
+def _find_tensor_input_source(
     target: torch.Tensor,
     value: object,
     source: Source,
 ) -> Source | None:
     if value is target:
         return source
-    if isinstance(value, (list, tuple)):
-        for index, item in enumerate(value):
-            result = _find_tensor_descriptor_layout_guard_source(
+    if isinstance(value, dict):
+        items = value.items()
+    elif dataclasses.is_dataclass(value) and not isinstance(value, type):
+        items = (
+            (field.name, getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        )
+    elif isinstance(value, tuple) and hasattr(value, "_fields"):
+        items = ((name, getattr(value, name)) for name in value._fields)
+    elif isinstance(value, (list, tuple)):
+        items = enumerate(value)
+    else:
+        return None
+    for index, item in items:
+        if isinstance(index, (int, str)):
+            result = _find_tensor_input_source(
                 target,
                 item,
                 GetItemSource(source, index),
@@ -273,11 +314,11 @@ class CompileEnvironment:
         # TODO(hinriksnaer): tracing state, not env config. move to CompilerState?
         self.kernel_min_element_bits: int = 32  # smallest dtype bits across all tensors
         self.specialized_vars: set[sympy.Symbol] = set()
-        self.specialized_strides: set[tuple[str, int]] = set()
+        self.specialized_strides: set[TensorPropertySource] = set()
         self.tensor_descriptor_layout_guards: dict[
             Source, TensorDescriptorLayoutGuard
         ] = {}
-        self._tensor_descriptor_layout_guard_source_cache: dict[int, Source | None] = {}
+        self._tensor_input_source_cache: dict[int, Source | None] = {}
         self.jagged_tile_parent_ids: dict[int, list[int]] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
         # Set by the Pallas backend when config["pallas_loop_type"] ==
@@ -309,6 +350,7 @@ class CompileEnvironment:
         # them to host-call arg positions.
         self.compact_worklist_offset_params: list[str] = []
         self._symint_cache: dict[object, torch.SymInt] = {}
+        self._input_symint_cache: dict[Source, torch.SymInt] = {}
         self._foreign_symint_cache: dict[
             tuple[int, sympy.Expr], int | torch.SymInt
         ] = {}
@@ -367,8 +409,8 @@ class CompileEnvironment:
         """Specialize dynamic kernels on TD-relevant stride layout predicates."""
         if self.settings.static_shapes:
             return
-        source = self._tensor_descriptor_layout_guard_source(fake_tensor)
-        if source is None:
+        source = self.tensor_input_source(fake_tensor)
+        if source is None or not self._is_tensor_descriptor_layout_guard_source(source):
             return
         guard = self.tensor_descriptor_layout_guards.setdefault(
             source,
@@ -385,15 +427,26 @@ class CompileEnvironment:
     def has_tensor_descriptor_layout_guard(self, fake_tensor: torch.Tensor) -> bool:
         if self.settings.static_shapes:
             return True
-        source = self._tensor_descriptor_layout_guard_source(fake_tensor)
-        return source is not None and source in self.tensor_descriptor_layout_guards
+        source = self.tensor_input_source(fake_tensor)
+        return (
+            source is not None
+            and self._is_tensor_descriptor_layout_guard_source(source)
+            and source in self.tensor_descriptor_layout_guards
+        )
 
-    def _tensor_descriptor_layout_guard_source(
-        self, fake_tensor: torch.Tensor
-    ) -> Source | None:
+    def _is_tensor_descriptor_layout_guard_source(self, source: Source) -> bool:
+        from .host_function import HostFunction
+
+        return _is_supported_tensor_descriptor_layout_guard_source(
+            source,
+            HostFunction.current().params.arguments,
+        )
+
+    def tensor_input_source(self, fake_tensor: torch.Tensor) -> Source | None:
+        """Return a replayable source for a direct or container tensor input."""
         cache_key = id(fake_tensor)
-        if cache_key in self._tensor_descriptor_layout_guard_source_cache:
-            return self._tensor_descriptor_layout_guard_source_cache[cache_key]
+        if cache_key in self._tensor_input_source_cache:
+            return self._tensor_input_source_cache[cache_key]
 
         source = self.input_sources.get(fake_tensor)
         from .host_function import HostFunction
@@ -401,15 +454,14 @@ class CompileEnvironment:
         root_values = HostFunction.current().params.arguments
         if (
             source is not None
-            and _is_supported_tensor_descriptor_layout_guard_source(source)
-            and _replay_tensor_descriptor_layout_guard_source(source, root_values)
-            is fake_tensor
+            and _is_supported_tensor_input_source(source)
+            and _replay_tensor_input_source(source, root_values) is fake_tensor
         ):
             result = source
         else:
             result = None
             for local_name, value in root_values.items():
-                candidate = _find_tensor_descriptor_layout_guard_source(
+                candidate = _find_tensor_input_source(
                     fake_tensor,
                     value,
                     LocalSource(local_name, is_input=True),
@@ -418,7 +470,7 @@ class CompileEnvironment:
                     result = candidate
                     break
 
-        self._tensor_descriptor_layout_guard_source_cache[cache_key] = result
+        self._tensor_input_source_cache[cache_key] = result
         return result
 
     def tensor_descriptor_layout_signature(
@@ -747,6 +799,26 @@ class CompileEnvironment:
         if result is None:
             result = self.create_unbacked_symint(hint)
             self._symint_cache[key] = result
+        return result
+
+    def input_symint(self, value: int, source: Source) -> torch.SymInt:
+        """Represent a concrete input property symbolically during propagation."""
+        result = self._input_symint_cache.get(source)
+        if result is None:
+            expr = self.shape_env.create_symbol(
+                value,
+                source,
+                dynamic_dim=DimDynamic.DYNAMIC,
+            )
+            result = typing.cast(
+                "torch.SymInt",
+                self.shape_env.create_symintnode(
+                    expr,
+                    hint=value,
+                    source=source,
+                ),
+            )
+            self._input_symint_cache[source] = result
         return result
 
     def _normalize_shape_to_block_vars(

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -801,12 +801,19 @@ class CompileEnvironment:
             self._symint_cache[key] = result
         return result
 
-    def input_symint(self, value: int, source: Source) -> torch.SymInt:
-        """Represent a concrete input property symbolically during propagation."""
+    def input_symint(self, value: int | torch.SymInt, source: Source) -> torch.SymInt:
+        """Represent an input property with an independent symbolic value.
+
+        FakeTensor may express a contiguous stride in terms of a size symbol.  A
+        dynamic kernel can be reused with a different layout, so exposing that
+        expression to user code would incorrectly couple the runtime stride to
+        the runtime size.
+        """
         result = self._input_symint_cache.get(source)
         if result is None:
+            hint = self.size_hint(value)
             expr = self.shape_env.create_symbol(
-                value,
+                hint,
                 source,
                 dynamic_dim=DimDynamic.DYNAMIC,
             )
@@ -814,7 +821,7 @@ class CompileEnvironment:
                 "torch.SymInt",
                 self.shape_env.create_symintnode(
                     expr,
-                    hint=value,
+                    hint=hint,
                     source=source,
                 ),
             )

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -16,7 +16,8 @@ from typing import cast
 
 import sympy
 import torch
-from torch._dynamo.source import LocalSource
+from torch._dynamo.source import TensorProperty
+from torch._dynamo.source import TensorPropertySource
 from torch.fx.graph import _Namespace
 
 from .. import exc
@@ -794,10 +795,11 @@ class DeviceFunction:
         v = fake_value.stride(dim)
         env = CompileEnvironment.current()
         # Check if this stride was explicitly specialized
-        source = env.input_sources.get(fake_value)
+        source = env.tensor_input_source(fake_value)
         if (
-            isinstance(source, LocalSource)
-            and (source.local_name, dim) in env.specialized_strides
+            source is not None
+            and TensorPropertySource(source, TensorProperty.STRIDE, dim)
+            in env.specialized_strides
         ):
             return StaticShape(int(v))
         if isinstance(v, int):

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -39,6 +39,7 @@ from .variable_origin import GetItemOrigin
 from .variable_origin import GridOrigin
 from .variable_origin import Origin
 from .variable_origin import TensorSizeOrigin
+from .variable_origin import TensorStrideOrigin
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -555,17 +556,57 @@ class TensorAttributeType(TypeInfo):
         attr = self.attr()
         if attr in {"dim", "ndimension"} and not (args or kwargs):
             return TypeInfo.from_example(self.tensor.fake_value.ndim, origin)
-        if attr in {"shape", "size", "stride"} and not kwargs:
+        stride_dim_kwarg = attr == "stride" and not args and set(kwargs) == {"dim"}
+        if (attr in {"shape", "size", "stride"} and not kwargs) or stride_dim_kwarg:
             fn = getattr(self.tensor.fake_value, attr)
             try:
-                return TypeInfo.from_example(
-                    fn(*[x.as_literal() for x in args]),
-                    origin,
-                )
+                literal_args = [x.as_literal() for x in args]
+                literal_kwargs = {
+                    key: value.as_literal() for key, value in kwargs.items()
+                }
+                result = fn(*literal_args, **literal_kwargs)
             except NotImplementedError:
                 raise exc.TypeInferenceError(
                     f"Tensor.{attr}() args must be literals"
                 ) from None
+            if attr == "stride":
+                if literal_args or literal_kwargs:
+                    dim = cast(
+                        "int",
+                        literal_args[0] if literal_args else literal_kwargs["dim"],
+                    )
+                    if dim < 0:
+                        dim += self.tensor.fake_value.ndim
+                    stride_origin = TensorStrideOrigin(self.tensor.origin, dim)
+                    if (
+                        isinstance(result, int)
+                        and not CompileEnvironment.current().settings.static_shapes
+                    ):
+                        result = CompileEnvironment.current().input_symint(
+                            result,
+                            stride_origin.to_source(),
+                        )
+                    return TypeInfo.from_example(
+                        result,
+                        stride_origin,
+                    )
+                return SequenceType(
+                    origin,
+                    tuple(
+                        TypeInfo.from_example(
+                            CompileEnvironment.current().input_symint(
+                                stride,
+                                TensorStrideOrigin(self.tensor.origin, dim).to_source(),
+                            )
+                            if isinstance(stride, int)
+                            and not CompileEnvironment.current().settings.static_shapes
+                            else stride,
+                            TensorStrideOrigin(self.tensor.origin, dim),
+                        )
+                        for dim, stride in enumerate(cast("tuple[int, ...]", result))
+                    ),
+                )
+            return TypeInfo.from_example(result, origin)
         if attr == "item" and not (args or kwargs):
             if origin.is_device():
                 raise exc.NotAllowedOnDevice("Tensor.item()")

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -579,7 +579,7 @@ class TensorAttributeType(TypeInfo):
                         dim += self.tensor.fake_value.ndim
                     stride_origin = TensorStrideOrigin(self.tensor.origin, dim)
                     if (
-                        isinstance(result, int)
+                        isinstance(result, (int, torch.SymInt))
                         and not CompileEnvironment.current().settings.static_shapes
                     ):
                         result = CompileEnvironment.current().input_symint(
@@ -598,7 +598,7 @@ class TensorAttributeType(TypeInfo):
                                 stride,
                                 TensorStrideOrigin(self.tensor.origin, dim).to_source(),
                             )
-                            if isinstance(stride, int)
+                            if isinstance(stride, (int, torch.SymInt))
                             and not CompileEnvironment.current().settings.static_shapes
                             else stride,
                             TensorStrideOrigin(self.tensor.origin, dim),

--- a/helion/_compiler/variable_origin.py
+++ b/helion/_compiler/variable_origin.py
@@ -30,11 +30,19 @@ if TYPE_CHECKING:
             dynamism: frozenset[str] | None = None,
             is_derefed_cell_contents: bool = False,
         ) -> None: ...
+
+    class TensorProperty:
+        STRIDE: object
+
+    class TensorPropertySource(Source):
+        def __init__(self, base: Source, prop: object, idx: int) -> None: ...
 else:
     from torch._dynamo.source import AttrSource
     from torch._dynamo.source import GetItemSource
     from torch._dynamo.source import GlobalSource
     from torch._dynamo.source import LocalSource
+    from torch._dynamo.source import TensorProperty
+    from torch._dynamo.source import TensorPropertySource
 
 
 @dataclasses.dataclass
@@ -231,6 +239,24 @@ class TensorSizeOrigin(WrappedOrigin):
 
     def to_source(self) -> Source:
         return GetItemSource(AttrSource(self.value.to_source(), "shape"), self.key)
+
+
+@dataclasses.dataclass
+class TensorStrideOrigin(WrappedOrigin):
+    """Origin of one stride from a tensor argument."""
+
+    key: int
+
+    def host_str(self) -> str:
+        return f"{self.value.host_str()}.stride({self.key!r})"
+
+    def suggest_var_name(self) -> str:
+        return f"{self.value.suggest_var_name()}_stride_{self.key}"
+
+    def to_source(self) -> Source:
+        return TensorPropertySource(
+            self.value.to_source(), TensorProperty.STRIDE, self.key
+        )
 
 
 @dataclasses.dataclass

--- a/helion/language/constexpr.py
+++ b/helion/language/constexpr.py
@@ -6,7 +6,6 @@ from typing import NamedTuple
 from typing_extensions import TypeVar
 
 import torch
-from torch._dynamo.source import LocalSource
 from torch._dynamo.source import TensorProperty
 from torch._dynamo.source import TensorPropertySource
 
@@ -69,10 +68,11 @@ class ProcessGroupName(ConstExpr):
 @_decorators.api(is_device_only=False)
 def specialize(value: _T) -> _T:
     """
-    Turn dynamic shapes into compile-time constants. Examples::
+    Turn dynamic tensor sizes or strides into compile-time constants. Examples::
 
            channels = hl.specialize(tensor.size(1))
            height, width = hl.specialize(tensor.shape[-2:])
+           row_stride = hl.specialize(tensor.stride(0))
 
     Args:
         value: The symbolic value or sequence of symbolic values to specialize on.
@@ -90,12 +90,23 @@ def specialize(value: _T) -> _T:
 def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
     from .._compiler.compile_environment import CompileEnvironment
     from .._compiler.compile_environment import _symint_free_symbols
+    from .._compiler.variable_origin import TensorStrideOrigin
 
     if origin.is_device():
         raise exc.SpecializeOnDevice
 
     proxy = value.proxy()
     env = CompileEnvironment.current()
+
+    def record_concrete_stride(type_info: TypeInfo) -> None:
+        stride_origin = type_info.origin
+        if isinstance(stride_origin, TensorStrideOrigin):
+            source = stride_origin.to_source()
+            assert isinstance(source, TensorPropertySource)
+            env.specialized_strides.add(source)
+
+    if not env.settings.static_shapes:
+        value.tree_map(record_concrete_stride)
 
     def handle_symint(symint: torch.SymInt) -> int:
         syms = _symint_free_symbols(symint)
@@ -106,10 +117,9 @@ def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
                 if (
                     isinstance(source, TensorPropertySource)
                     and source.prop == TensorProperty.STRIDE
-                    and isinstance(source.base, LocalSource)
                     and source.idx is not None
                 ):
-                    env.specialized_strides.add((source.base.local_name, source.idx))
+                    env.specialized_strides.add(source)
         return symint.__int__()
 
     _convert_specializable(proxy, on_symint=handle_symint)
@@ -131,10 +141,9 @@ def _(value: _T) -> _T:
                 if (
                     isinstance(source, TensorPropertySource)
                     and source.prop == TensorProperty.STRIDE
-                    and isinstance(source.base, LocalSource)
                     and source.idx is not None
                 ):
-                    env.specialized_strides.add((source.base.local_name, source.idx))
+                    env.specialized_strides.add(source)
         return symint
 
     return _convert_specializable(value, on_symint=handle_symint)

--- a/helion/language/constexpr.py
+++ b/helion/language/constexpr.py
@@ -90,23 +90,12 @@ def specialize(value: _T) -> _T:
 def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
     from .._compiler.compile_environment import CompileEnvironment
     from .._compiler.compile_environment import _symint_free_symbols
-    from .._compiler.variable_origin import TensorStrideOrigin
 
     if origin.is_device():
         raise exc.SpecializeOnDevice
 
     proxy = value.proxy()
     env = CompileEnvironment.current()
-
-    def record_concrete_stride(type_info: TypeInfo) -> None:
-        stride_origin = type_info.origin
-        if isinstance(stride_origin, TensorStrideOrigin):
-            source = stride_origin.to_source()
-            assert isinstance(source, TensorPropertySource)
-            env.specialized_strides.add(source)
-
-    if not env.settings.static_shapes:
-        value.tree_map(record_concrete_stride)
 
     def handle_symint(symint: torch.SymInt) -> int:
         syms = _symint_free_symbols(symint)

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -1011,6 +1011,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         """
         if (
             not self.env.specialized_vars
+            and not self.env.specialized_strides
             and not self.env.tensor_descriptor_layout_guards
         ):
             return []
@@ -1029,7 +1030,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     ) -> Hashable:
                         result = _inner(args)
                         # Handle list of tensors: return tuple of sizes for all tensors
-                        if isinstance(result, list):
+                        if isinstance(result, (list, tuple)):
                             return tuple(
                                 cast("torch.Tensor", t).size(_index) for t in result
                             )
@@ -1045,7 +1046,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     ) -> Hashable:
                         result = _inner(args)
                         # Handle list of tensors: return tuple of strides for all tensors
-                        if isinstance(result, list):
+                        if isinstance(result, (list, tuple)):
                             return tuple(
                                 cast("torch.Tensor", t).stride(_index) for t in result
                             )
@@ -1054,16 +1055,21 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     return stride_extractor
                 raise exc.SpecializeArgType(v)
             if isinstance(v, GetItemSource):
-                if not isinstance(v.index, int) or v.index_is_slice:
+                if not isinstance(v.index, (int, str)) or v.index_is_slice:
                     raise exc.SpecializeArgType(v)
                 inner = make_extractor(v.base)
 
                 def getitem_extractor(
                     args: Sequence[object],
                     _inner: Callable[[Sequence[object]], Hashable] = inner,
-                    _index: int = v.index,
+                    _index: int | str = v.index,
                 ) -> Hashable:
-                    return cast("Sequence[object]", _inner(args))[_index]
+                    result = _inner(args)
+                    if isinstance(result, dict):
+                        return cast("Hashable", result[_index])
+                    if isinstance(_index, str):
+                        return cast("Hashable", getattr(result, _index))
+                    return cast("Sequence[Hashable]", result)[_index]
 
                 return getitem_extractor
             if isinstance(v, LocalSource):
@@ -1075,8 +1081,19 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             n: i for i, n in enumerate(self.kernel.signature.parameters.keys())
         }
         extractors: list[Callable[[Sequence[object]], Hashable]] = []
+        extracted_strides: set[TensorPropertySource] = set()
         for v in sorted(self.env.specialized_vars, key=lambda v: v.name):
             source = self.env.shape_env.var_to_sources[v][0]
+            extractors.append(make_extractor(source))
+            if (
+                isinstance(source, TensorPropertySource)
+                and source.prop == TensorProperty.STRIDE
+                and source.idx is not None
+            ):
+                extracted_strides.add(source)
+        for source in sorted(self.env.specialized_strides, key=repr):
+            if source in extracted_strides:
+                continue
             extractors.append(make_extractor(source))
         implicit_config = self._fixed_config_for_td_layout_guards()
         for source, guard in sorted(

--- a/test/test_specialize.py
+++ b/test/test_specialize.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import math
 import unittest
 
@@ -16,6 +17,11 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion.exc import ShapeSpecializingAllocation
 import helion.language as hl
+
+
+@dataclasses.dataclass
+class TensorContainer:
+    x: torch.Tensor
 
 
 @onlyBackends(["triton", "cute"])
@@ -362,6 +368,159 @@ class TestSpecialize(RefEagerTestBase, TestCase):
         self.assertIn("137", code)
         # Verify x_stride_0 is NOT passed as an argument (it should be inlined)
         self.assertNotIn("x_stride_0", code)
+
+    def test_specialize_concrete_stride(self):
+        """Concrete contiguous strides are inlined and guarded in the cache key."""
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            stride = hl.specialize(x.stride(-1))
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] + stride
+            return out
+
+        x = torch.randn([64, 64], device=DEVICE)
+        code, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x + 1)
+        self.assertNotIn("x_stride_1", code)
+
+        transposed = x.T
+        self.assertIsNot(fn.bind((x,)), fn.bind((transposed,)))
+        torch.testing.assert_close(fn(transposed), transposed + 64)
+
+    def test_specialize_concrete_stride_tuple(self):
+        """A tuple of concrete strides retains each dimension's cache guard."""
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            stride0, stride1 = hl.specialize(x.stride())
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] + stride0 * 2 + stride1
+            return out
+
+        x = torch.randn([64, 64], device=DEVICE)
+        code, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x + 129)
+        self.assertNotIn("x_stride_0", code)
+        self.assertNotIn("x_stride_1", code)
+
+        transposed = x.T
+        self.assertIsNot(fn.bind((x,)), fn.bind((transposed,)))
+        torch.testing.assert_close(fn(transposed), transposed + 66)
+
+    def test_specialize_concrete_stride_keyword_dim(self):
+        """The keyword spelling retains the tensor stride origin."""
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            stride = hl.specialize(x.stride(dim=-1))
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] + stride
+            return out
+
+        x = torch.randn([64, 64], device=DEVICE)
+        transposed = x.T
+        self.assertIsNot(fn.bind((x,)), fn.bind((transposed,)))
+        torch.testing.assert_close(fn(x), x + 1)
+        torch.testing.assert_close(fn(transposed), transposed + 64)
+
+    def test_specialize_concrete_stride_expression(self):
+        """Concrete stride dependencies survive host-side arithmetic."""
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            stride = hl.specialize(x.stride(-1) * 2)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] + stride
+            return out
+
+        x = torch.randn([64, 64], device=DEVICE)
+        transposed = x.T
+        self.assertIsNot(fn.bind((x,)), fn.bind((transposed,)))
+        torch.testing.assert_close(fn(x), x + 2)
+        torch.testing.assert_close(fn(transposed), transposed + 128)
+
+    def test_specialize_concrete_stride_container(self):
+        """Tensor paths through list and tuple arguments are guarded exactly."""
+
+        for container_type in (list, tuple):
+
+            @helion.kernel(static_shapes=False, autotune_effort="none")
+            def fn(xs: list[torch.Tensor]) -> torch.Tensor:
+                x = xs[0]
+                stride = hl.specialize(x.stride(-1))
+                out = torch.empty_like(x)
+                for tile in hl.tile(x.size()):
+                    out[tile] = x[tile] + stride
+                return out
+
+            with self.subTest(container_type=container_type.__name__):
+                x = torch.randn([64, 64], device=DEVICE)
+                transposed = x.T
+                contiguous_args = (container_type([x]),)
+                transposed_args = (container_type([transposed]),)
+                self.assertIsNot(
+                    fn.bind(contiguous_args),
+                    fn.bind(transposed_args),
+                )
+                torch.testing.assert_close(fn(*contiguous_args), x + 1)
+                torch.testing.assert_close(fn(*transposed_args), transposed + 64)
+
+    def test_specialize_concrete_stride_dict(self):
+        """Mapping paths are replayable, and static kernels need no extra guard."""
+
+        for static_shapes in (False, True):
+
+            @helion.kernel(
+                static_shapes=static_shapes,
+                autotune_effort="none",
+            )
+            def fn(xs: dict[str, torch.Tensor]) -> torch.Tensor:
+                x = xs["x"]
+                stride = hl.specialize(x.stride(-1))
+                out = torch.empty_like(x)
+                for tile in hl.tile(x.size()):
+                    out[tile] = x[tile] + stride
+                return out
+
+            with self.subTest(static_shapes=static_shapes):
+                x = torch.randn([64, 64], device=DEVICE)
+                transposed = x.T
+                contiguous_args = ({"x": x},)
+                transposed_args = ({"x": transposed},)
+                self.assertIsNot(
+                    fn.bind(contiguous_args),
+                    fn.bind(transposed_args),
+                )
+                torch.testing.assert_close(fn(*contiguous_args), x + 1)
+                torch.testing.assert_close(fn(*transposed_args), transposed + 64)
+
+    def test_specialize_concrete_stride_dataclass(self):
+        """Attribute-like container fields retain their input source path."""
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(xs: TensorContainer, device: torch.device) -> torch.Tensor:
+            x = xs.x
+            stride = hl.specialize(x.stride(-1))
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] + stride
+            return out
+
+        x = torch.randn([64, 64], device=DEVICE)
+        transposed = x.T
+        contiguous_args = (TensorContainer(x), x.device)
+        transposed_args = (TensorContainer(transposed), x.device)
+        self.assertIsNot(
+            fn.bind(contiguous_args),
+            fn.bind(transposed_args),
+        )
+        torch.testing.assert_close(fn(*contiguous_args), x + 1)
+        torch.testing.assert_close(fn(*transposed_args), transposed + 64)
 
     def test_specialize_stride_creates_different_variants(self):
         """Test that different stride patterns create different kernel variants."""

--- a/test/test_specialize.py
+++ b/test/test_specialize.py
@@ -340,6 +340,49 @@ class TestSpecialize(RefEagerTestBase, TestCase):
         # Verify x_size_0 is NOT passed as an argument (it should be static)
         self.assertNotIn("x_size_0", code)
 
+    def test_unspecialized_stride_is_runtime_value(self):
+        """An unspecialized stride is not inlined from the example input."""
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            stride = x.stride(0)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] + stride
+            return out
+
+        x = torch.randn([64, 64], device=DEVICE)
+        code, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x + x.stride(0))
+        self.assertIn("stride = x.stride(0)", code)
+        self.assertIn("x_stride_0", code)
+
+        transposed = x.T
+        self.assertIs(fn.bind((x,)), fn.bind((transposed,)))
+        torch.testing.assert_close(fn(transposed), transposed + transposed.stride(0))
+
+    def test_unspecialized_stride_host_control_flow(self):
+        """Host control flow reads an unspecialized stride at runtime."""
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            if x.stride(0) == 1:
+                value = 1
+            else:
+                value = 2
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] + value
+            return out
+
+        x = torch.randn([64, 64], device=DEVICE)
+        transposed = x.T
+        code, result = code_and_output(fn, (x,))
+        self.assertIn("if x.stride(0) == 1:", code)
+        torch.testing.assert_close(result, x + 2)
+        self.assertIs(fn.bind((x,)), fn.bind((transposed,)))
+        torch.testing.assert_close(fn(transposed), transposed + 1)
+
     def test_specialize_stride_basic(self):
         """Test that hl.specialize works with tensor strides."""
 
@@ -467,7 +510,9 @@ class TestSpecialize(RefEagerTestBase, TestCase):
                     fn.bind(contiguous_args),
                     fn.bind(transposed_args),
                 )
-                torch.testing.assert_close(fn(*contiguous_args), x + 1)
+                code, result = code_and_output(fn, contiguous_args)
+                self.assertNotIn("x_stride_1", code)
+                torch.testing.assert_close(result, x + 1)
                 torch.testing.assert_close(fn(*transposed_args), transposed + 64)
 
     def test_specialize_concrete_stride_dict(self):

--- a/test/test_specialize.py
+++ b/test/test_specialize.py
@@ -355,7 +355,6 @@ class TestSpecialize(RefEagerTestBase, TestCase):
         code, result = code_and_output(fn, (x,))
         torch.testing.assert_close(result, x + x.stride(0))
         self.assertIn("stride = x.stride(0)", code)
-        self.assertIn("x_stride_0", code)
 
         transposed = x.T
         self.assertIs(fn.bind((x,)), fn.bind((transposed,)))

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -853,10 +853,29 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
                 result[tile] = x[tile]
             return result
 
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            config=helion.Config(
+                block_sizes=[32, 32],
+                indexing=["tensor_descriptor", "pointer"],
+            ),
+        )
+        def copy_int_dict(xs: dict[int, torch.Tensor]) -> torch.Tensor:
+            x = xs[0]
+            result = torch.empty(x.size(), device=x.device, dtype=x.dtype)
+            for tile in hl.tile(x.size()):
+                result[tile] = x[tile]
+            return result
+
         x = torch.randn([64, 1024], device=DEVICE, dtype=HALF_DTYPE)
-        code, result = code_and_output(copy_dict, ({"x": x},))
-        torch.testing.assert_close(result, x)
-        self.assertNotIn(get_tensor_descriptor_fn_name(), code)
+        for kernel, args in (
+            (copy_dict, ({"x": x},)),
+            (copy_int_dict, ({0: x},)),
+        ):
+            code, result = code_and_output(kernel, args)
+            torch.testing.assert_close(result, x)
+            self.assertNotIn(get_tensor_descriptor_fn_name(), code)
 
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     @skipIfRefEager("Test checks bound kernel specialization cache")

--- a/test/test_type_propagation.expected
+++ b/test/test_type_propagation.expected
@@ -385,7 +385,7 @@ x.size()
     # Name: TensorType([5, 5], torch.int32) ArgumentOrigin(name='x')
 x.stride()
     attr5 = 
-    # Call: LiteralType(5) SourceOrigin(location=<SourceLocation all_ast_nodes.py:N>)
+    # Call: LiteralType(5) TensorStrideOrigin(value=ArgumentOrigin(name='x'), key=0)
     # Attribute: TensorAttributeType AttributeOrigin(value=ArgumentOrigin(name='x'), key='stride')
     # Name: TensorType([5, 5], torch.int32) ArgumentOrigin(name='x')
 x.stride(


### PR DESCRIPTION
## Summary

`hl.specialize()` handled symbolic tensor strides, but common concrete strides such as `1` could be inlined without entering the runtime specialization key. A compiled kernel could then be incorrectly reused for an input with a different layout.

  ## Usage

  ```python
  @helion.kernel(static_shapes=False)
  def copy(x: torch.Tensor) -> torch.Tensor:
      # Compile separate variants when the innermost layout changes.
      hl.specialize(x.stride(-1))

      out = torch.empty_like(x)
      for tile in hl.tile(x.size()):
          out[tile] = x[tile]
      return out
```
  This also supports expressions and complete stride tuples:
```
  stride = hl.specialize(x.stride(-1) * 2)
  strides = hl.specialize(x.stride())
```
  ## Changes

  - Tracks concrete stride provenance through TensorStrideOrigin.
  - Preserves stride dependencies through host-side expressions.
  - Supports positional, keyword, tuple, and negative-dimension stride calls.
  - Adds exact stride values to the bound-kernel cache key.
  - Supports tensors nested in lists, tuples, dictionaries, and dataclasses.
  - Avoids redundant guards for static_shapes=True.
  - Keeps existing tensor-descriptor eligibility unchanged.
  - Documents stride specialization behavior.
