### PR TITLE
[benchmark] Fix linear-attention nightly upload and trim to two shapes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -174,6 +174,7 @@ jobs:
         run: |
           set -x
           source .venv/bin/activate
+          uv pip install pip
           # Newer FLA allows gated backward on Hopper with Triton 3.7.1+;
           # torch 2.12.1 provides that Triton version.
           PYTORCH_INDEX="${PYPI_CACHE_WHL_URL:-https://download.pytorch.org/whl/cpu}"

--- a/benchmarks/run_linattn.py
+++ b/benchmarks/run_linattn.py
@@ -24,15 +24,14 @@ import torch
 
 # (name, B, T, H, D); D is both the query/key and the value dim (D = DV).
 # The six production shapes from flash-linear-attention/benchmarks/ops/registry.
-# The full sweep times out CI, so we comment out three D=128 shapes and keep one
-# shape per head dim (64/128/256).
+# The full sweep times out CI, so we comment out all but two shapes.
 SHAPES: list[tuple[str, int, int, int, int]] = [
     # ("B1_T8192_H96_D128", 1, 8192, 96, 128),
     # ("B2_T16384_H16_D128", 2, 16384, 16, 128),
     # ("B4_T2048_H16_D128", 4, 2048, 16, 128),
     ("B4_T4096_H64_D128", 4, 4096, 64, 128),
     ("B8_T2048_H32_D256", 8, 2048, 32, 256),
-    ("B8_T1024_H8_D64", 8, 1024, 8, 64),
+    # ("B8_T1024_H8_D64", 8, 1024, 8, 64),
 ]
 
 # variant name -> example module under examples.linear. Each module's


### PR DESCRIPTION
Follow-up to #3107. The linattn kernels still did not reach the dashboard for two reasons.

## Upload failure

The sharded jobs ran the benchmark, then failed at "Gather runners info":

```
/__w/helion/helion/.venv/bin/python3: No module named pip
```

uv venvs ship without pip. Add `uv pip install pip` to the linattn setup step.

## 6h timeout

`kda` and `gated_delta_rule` never finished: they hit the 6h job limit at three shapes, so they never uploaded. Drop D64, keeping D128 and D256.

