### PR TITLE
Preserve hl.specialize values for exported kernels

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -223,6 +223,7 @@ class CompileEnvironment:
         *,
         index_dtype: torch.dtype | None = None,
         is_distributed: bool = False,
+        preserve_specializations: bool = False,
     ) -> None:
         from ..autotuner.config_spec import ConfigSpec
 
@@ -230,6 +231,7 @@ class CompileEnvironment:
         # pyrefly: ignore [read-only]
         self.device = device
         self.settings = settings
+        self.preserve_specializations = preserve_specializations
         self.index_dtype: torch.dtype = (
             index_dtype or settings.index_dtype or torch.int32
         )
@@ -349,6 +351,8 @@ class CompileEnvironment:
 
     def specialize_expr(self, expr: sympy.Expr) -> sympy.Expr:
         """Substitute any specialized vars with their concrete values."""
+        if self.preserve_specializations:
+            return expr
         if subs := {
             s: sympy.Integer(shape_env_size_hint(self.shape_env, s))
             for s in expr.free_symbols & self.specialized_vars

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -269,6 +269,9 @@ class DeviceFunction:
         self._tensor_properties: dict[
             tuple[type[TensorPropertyArg], torch.Tensor, int], TensorPropertyArg
         ] = {}
+        self._specialized_tensor_stride_args: dict[
+            tuple[torch.Tensor, int], ConstExprArg
+        ] = {}
         self._unique_counter: dict[str, itertools.count[int]] = defaultdict(
             itertools.count
         )
@@ -812,6 +815,17 @@ class DeviceFunction:
             isinstance(source, LocalSource)
             and (source.local_name, dim) in env.specialized_strides
         ):
+            if env.preserve_specializations:
+                key = (fake_value, dim)
+                if key not in self._specialized_tensor_stride_args:
+                    tensor_arg = self.tensor_arg(fake_value)
+                    arg = ConstExprArg(
+                        name=f"{tensor_arg.name}_stride_{dim}",
+                        _host_str=f"{tensor_arg.host_str()}.stride({dim})",
+                    )
+                    self.arguments.append(arg)
+                    self._specialized_tensor_stride_args[key] = arg
+                return self._specialized_tensor_stride_args[key]
             return StaticShape(int(v))
         if isinstance(v, int):
             if env.settings.static_shapes:

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -261,6 +261,7 @@ class DeviceFunction:
             tuple[torch.Tensor, str], TensorDescriptorArg
         ] = {}
         self._expr_args: dict[sympy.Expr, SymbolArgument] = {}
+        self._specialized_expr_args: dict[sympy.Expr, ConstExprArg] = {}
         self._constexpr_args: dict[str, ConstExprArg] = {}
         self._constexpr_host_defs: set[str] = set()
         self._scratch_args: list[ScratchArg] = []
@@ -582,6 +583,8 @@ class DeviceFunction:
     def _lift_sympy_arg(self, expr: sympy.Expr) -> str:
         env = CompileEnvironment.current()
         origin = HostFunction.current().expr_to_origin[expr]
+        if env.preserve_specializations and expr.free_symbols & env.specialized_vars:
+            return self.specialized_expr_arg(expr, origin.origin).name
         if isinstance(origin.origin, TensorSizeOrigin):
             assert origin.fake_value is not None
             arg = self.tensor_size(
@@ -731,6 +734,16 @@ class DeviceFunction:
             self.arguments.append(arg)
             self._expr_args[sym] = arg
         return self._expr_args[sym]
+
+    def specialized_expr_arg(self, sym: sympy.Expr, origin: Origin) -> ConstExprArg:
+        if sym not in self._specialized_expr_args:
+            arg = ConstExprArg(
+                name=self.new_var(origin.suggest_var_name()),
+                _host_str=origin.host_str(),
+            )
+            self.arguments.append(arg)
+            self._specialized_expr_args[sym] = arg
+        return self._specialized_expr_args[sym]
 
     def constexpr_arg(self, name: str, value: object | None = None) -> bool:
         """Create a constexpr argument, returns True if created, False if already exists."""

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -1087,9 +1087,14 @@ def _run_bound_kernel(
 def code_and_output(
     fn: Kernel[_R],
     args: tuple[object, ...],
+    *,
+    preserve_specializations: bool = False,
     **kwargs: object,
 ) -> tuple[str, _R]:
-    bound = fn.bind(args)
+    bound = fn.bind(
+        args,
+        preserve_specializations=preserve_specializations,
+    )
     if is_ref_mode_enabled(bound.kernel.settings):
         if kwargs:
             # pyrefly: ignore [bad-argument-type]
@@ -1464,7 +1469,7 @@ def check_example(
         code, result = code_and_output(
             kernel_fn,
             args,
-            **kwargs,
+            **kwargs,  # pyrefly: ignore [bad-argument-type]
         )
     else:
         code = ""

--- a/helion/language/constexpr.py
+++ b/helion/language/constexpr.py
@@ -97,7 +97,7 @@ def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
     proxy = value.proxy()
     env = CompileEnvironment.current()
 
-    def handle_symint(symint: torch.SymInt) -> int:
+    def handle_symint(symint: torch.SymInt) -> int | torch.SymInt:
         syms = _symint_free_symbols(symint)
         env.specialized_vars.update(syms)
         # Track stride specializations
@@ -110,6 +110,8 @@ def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
                     and source.idx is not None
                 ):
                     env.specialized_strides.add((source.base.local_name, source.idx))
+        if env.preserve_specializations:
+            return symint
         return symint.__int__()
 
     _convert_specializable(proxy, on_symint=handle_symint)
@@ -142,6 +144,10 @@ def _(value: _T) -> _T:
 
 @_decorators.codegen(specialize, "common")
 def _(state: CodegenState) -> ast.AST:
+    from .._compiler.compile_environment import CompileEnvironment
+
+    if CompileEnvironment.current().preserve_specializations:
+        return state.ast_arg(0)
     specialized = _convert_specializable(state.proxy_arg(0))
     return expr_from_string(repr(specialized))
 

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -345,12 +345,20 @@ class Kernel(Generic[_R]):
             key.append(self._key_fn(*args))
         return tuple(key)
 
-    def bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
+    def bind(
+        self,
+        args: tuple[object, ...],
+        *,
+        preserve_specializations: bool = False,
+    ) -> BoundKernel[_R]:
         """
         Bind the given arguments to the Kernel and return a BoundKernel object.
 
         Args:
             args: The arguments to bind to the Kernel.
+            preserve_specializations: Preserve values passed to ``hl.specialize``
+                as runtime-provided backend constexpr arguments. This is intended
+                for exporting code that can be reused across input shapes.
 
         Returns:
             BoundKernel: A BoundKernel object with the given arguments bound.
@@ -363,6 +371,19 @@ class Kernel(Generic[_R]):
                 raise TypeError(
                     f"Too many arguments passed to the kernel, expected: {self._num_params} got: {len(args)}."
                 )
+            if preserve_specializations:
+                normalized_args = self.normalize_args(*args)
+                if len(normalized_args) != len(args):
+                    return self.bind(
+                        normalized_args,
+                        preserve_specializations=True,
+                    )
+                return BoundKernel(
+                    self,
+                    args,
+                    preserve_specializations=True,
+                )
+
             signature = self._base_specialization_key(args)
             cache_key = self._get_bound_kernel_cache_key(args, signature)
             bound_kernel = (
@@ -584,6 +605,8 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         self,
         kernel: Kernel[_R],
         args: tuple[object, ...],
+        *,
+        preserve_specializations: bool = False,
     ) -> None:
         """
         Initialize a BoundKernel object.
@@ -621,6 +644,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             self.kernel.settings,
             index_dtype=_resolve_index_dtype(self.kernel.settings, args),
             is_distributed=is_distributed,
+            preserve_specializations=preserve_specializations,
         )
 
         if is_ref_mode_enabled(self.kernel.settings):

--- a/test/test_specialize.py
+++ b/test/test_specialize.py
@@ -4,6 +4,7 @@ import math
 import unittest
 
 import torch
+from torch._inductor.codecache import PyCodeCache
 
 import helion
 from helion._testing import DEVICE
@@ -16,6 +17,34 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion.exc import ShapeSpecializingAllocation
 import helion.language as hl
+
+
+@onlyBackends(["triton"])
+class TestExportSpecialize(RefEagerTestBase, TestCase):
+    def test_export_preserves_specializations_as_constexpr(self):
+        @helion.kernel(static_shapes=False)
+        def specialized_add(x: torch.Tensor) -> torch.Tensor:
+            n = hl.specialize(x.size(1))
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([x.size(0), n]):
+                out[tile_m, tile_n] = x[tile_m, tile_n] + n
+            return out
+
+        x = torch.randn([4, 16], device=DEVICE)
+        config = helion.Config(block_sizes=[1, 4])
+        default_code = specialized_add.bind((x,)).to_code(config)
+        bound = specialized_add.bind((x,), preserve_specializations=True)
+        exported_code = bound.to_code(config)
+
+        self.assertNotIn("n: tl.constexpr", default_code)
+        self.assertIn("n: tl.constexpr", exported_code)
+        self.assertIn("x.size(1)", exported_code)
+
+        module = PyCodeCache.load(exported_code)
+        for shape in ([4, 16], [7, 32]):
+            value = torch.randn(shape, device=DEVICE)
+            result = module.specialized_add(value)
+            torch.testing.assert_close(result, value + shape[1])
 
 
 @onlyBackends(["triton", "cute"])

--- a/test/test_specialize.py
+++ b/test/test_specialize.py
@@ -5,6 +5,8 @@ import unittest
 
 import torch
 from torch._inductor.codecache import PyCodeCache
+from torch.testing._internal.common_utils import instantiate_parametrized_tests
+from torch.testing._internal.common_utils import parametrize
 
 import helion
 from helion._testing import DEVICE
@@ -17,6 +19,9 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion.exc import ShapeSpecializingAllocation
 import helion.language as hl
+from helion.runtime.settings import _get_backend
+
+_SPECIALIZATION_MODES = (False, True) if _get_backend() == "triton" else (False,)
 
 
 @onlyBackends(["triton"])
@@ -51,7 +56,33 @@ class TestExportSpecialize(RefEagerTestBase, TestCase):
 class TestSpecialize(RefEagerTestBase, TestCase):
     maxDiff = 163842
 
-    def test_sqrt_does_not_specialize(self):
+    def assert_bind_cache_behavior(
+        self,
+        fn: helion.Kernel[torch.Tensor],
+        x: torch.Tensor,
+        preserve_specializations: bool,
+    ) -> None:
+        bound = fn.bind(
+            (x,),
+            preserve_specializations=preserve_specializations,
+        )
+        rebound = fn.bind(
+            (torch.zeros_like(x),),
+            preserve_specializations=preserve_specializations,
+        )
+        self.assertTrueIfInNormalMode(
+            (bound is rebound) == (not preserve_specializations)
+        )
+        self.assertTrueIfInNormalMode(
+            bound
+            is not fn.bind(
+                (torch.zeros_like(x[:, 1:]),),
+                preserve_specializations=preserve_specializations,
+            )
+        )
+
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_sqrt_does_not_specialize(self, preserve_specializations: bool) -> None:
         @helion.kernel()
         def fn(
             x: torch.Tensor,
@@ -63,10 +94,17 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([512, 512], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_sizes=[32, 1], flatten_loop=True)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+            block_sizes=[32, 1],
+            flatten_loop=True,
+        )
         torch.testing.assert_close(result, x / math.sqrt(x.size(-1)))
 
-    def test_specialize_host(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_specialize_host(self, preserve_specializations: bool) -> None:
         @helion.kernel()
         def fn(
             x: torch.Tensor,
@@ -79,11 +117,17 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([500, 500], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_sizes=[32, 32])
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+            block_sizes=[32, 32],
+        )
         torch.testing.assert_close(result, x / math.sqrt(x.size(-1)))
 
     @skipIfRefEager("Ref eager mode won't raise ShapeSpecializingAllocation error")
-    def test_dynamic_size_block_errors(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_dynamic_size_block_errors(self, preserve_specializations: bool) -> None:
         @helion.kernel(static_shapes=False)
         def fn(
             x: torch.Tensor,
@@ -97,9 +141,17 @@ class TestSpecialize(RefEagerTestBase, TestCase):
 
         x = torch.randn([512, 512], device=DEVICE)
         with self.assertRaises(ShapeSpecializingAllocation):
-            code_and_output(fn, (x,), block_size=16)
+            code_and_output(
+                fn,
+                (x,),
+                preserve_specializations=preserve_specializations,
+                block_size=16,
+            )
 
-    def test_dynamic_size_block_specialize(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_dynamic_size_block_specialize(
+        self, preserve_specializations: bool
+    ) -> None:
         @helion.kernel()
         def fn(
             x: torch.Tensor,
@@ -113,11 +165,27 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([512, 512], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_size=32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+            block_size=32,
+        )
         torch.testing.assert_close(result, x + 1)
-        self.assertEqual(len(fn.bind((x,)).config_spec.reduction_loops), 0)
+        self.assertEqual(
+            len(
+                fn.bind(
+                    (x,),
+                    preserve_specializations=preserve_specializations,
+                ).config_spec.reduction_loops
+            ),
+            0,
+        )
 
-    def test_dynamic_size_block_non_power_of_two(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_dynamic_size_block_non_power_of_two(
+        self, preserve_specializations: bool
+    ) -> None:
         @helion.kernel()
         def fn(
             x: torch.Tensor,
@@ -131,17 +199,28 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([500, 500], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_size=32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+            block_size=32,
+        )
         torch.testing.assert_close(result, x + 1)
         self.assertTrueIfInNormalMode(
-            len(fn.bind((x,)).config_spec.reduction_loops) == 0
+            len(
+                fn.bind(
+                    (x,),
+                    preserve_specializations=preserve_specializations,
+                ).config_spec.reduction_loops
+            )
+            == 0
         )
-        self.assertTrueIfInNormalMode(fn.bind((x,)) is fn.bind((torch.zeros_like(x),)))
-        self.assertTrueIfInNormalMode(
-            fn.bind((x,)) is not fn.bind((torch.zeros_like(x[:, 1:]),))
-        )
+        self.assert_bind_cache_behavior(fn, x, preserve_specializations)
 
-    def test_dynamic_size_block_non_power_of_two_outplace(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_dynamic_size_block_non_power_of_two_outplace(
+        self, preserve_specializations: bool
+    ) -> None:
         @helion.kernel()
         def fn(
             x: torch.Tensor,
@@ -155,17 +234,28 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([500, 500], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_size=32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+            block_size=32,
+        )
         torch.testing.assert_close(result, x + 1)
         self.assertTrueIfInNormalMode(
-            len(fn.bind((x,)).config_spec.reduction_loops) == 0
+            len(
+                fn.bind(
+                    (x,),
+                    preserve_specializations=preserve_specializations,
+                ).config_spec.reduction_loops
+            )
+            == 0
         )
-        self.assertTrueIfInNormalMode(fn.bind((x,)) is fn.bind((torch.zeros_like(x),)))
-        self.assertTrueIfInNormalMode(
-            fn.bind((x,)) is not fn.bind((torch.zeros_like(x[:, 1:]),))
-        )
+        self.assert_bind_cache_behavior(fn, x, preserve_specializations)
 
-    def test_dynamic_size_block_non_power_of_two_swap_order(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_dynamic_size_block_non_power_of_two_swap_order(
+        self, preserve_specializations: bool
+    ) -> None:
         @helion.kernel()
         def fn(
             x: torch.Tensor,
@@ -179,17 +269,28 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([500, 500], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_size=32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+            block_size=32,
+        )
         torch.testing.assert_close(result, x + 1)
         self.assertTrueIfInNormalMode(
-            len(fn.bind((x,)).config_spec.reduction_loops) == 0
+            len(
+                fn.bind(
+                    (x,),
+                    preserve_specializations=preserve_specializations,
+                ).config_spec.reduction_loops
+            )
+            == 0
         )
-        self.assertTrueIfInNormalMode(fn.bind((x,)) is fn.bind((torch.zeros_like(x),)))
-        self.assertTrueIfInNormalMode(
-            fn.bind((x,)) is not fn.bind((torch.zeros_like(x[:, 1:]),))
-        )
+        self.assert_bind_cache_behavior(fn, x, preserve_specializations)
 
-    def test_dynamic_size_block_non_power_of_two_double_acc(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_dynamic_size_block_non_power_of_two_double_acc(
+        self, preserve_specializations: bool
+    ) -> None:
         @helion.kernel()
         def fn(
             x: torch.Tensor,
@@ -205,17 +306,28 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([500, 500], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_size=32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+            block_size=32,
+        )
         torch.testing.assert_close(result, x + 2)
         self.assertTrueIfInNormalMode(
-            len(fn.bind((x,)).config_spec.reduction_loops) == 0
+            len(
+                fn.bind(
+                    (x,),
+                    preserve_specializations=preserve_specializations,
+                ).config_spec.reduction_loops
+            )
+            == 0
         )
-        self.assertTrueIfInNormalMode(fn.bind((x,)) is fn.bind((torch.zeros_like(x),)))
-        self.assertTrueIfInNormalMode(
-            fn.bind((x,)) is not fn.bind((torch.zeros_like(x[:, 1:]),))
-        )
+        self.assert_bind_cache_behavior(fn, x, preserve_specializations)
 
-    def test_dynamic_size_block_non_power_of_two_matmul(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_dynamic_size_block_non_power_of_two_matmul(
+        self, preserve_specializations: bool
+    ) -> None:
         @helion.kernel()
         def fn(
             x: torch.Tensor,
@@ -240,17 +352,28 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([500, 500], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_size=32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+            block_size=32,
+        )
         torch.testing.assert_close(result, x + 2)
         self.assertTrueIfInNormalMode(
-            len(fn.bind((x,)).config_spec.reduction_loops) == 0
+            len(
+                fn.bind(
+                    (x,),
+                    preserve_specializations=preserve_specializations,
+                ).config_spec.reduction_loops
+            )
+            == 0
         )
-        self.assertTrueIfInNormalMode(fn.bind((x,)) is fn.bind((torch.zeros_like(x),)))
-        self.assertTrueIfInNormalMode(
-            fn.bind((x,)) is not fn.bind((torch.zeros_like(x[:, 1:]),))
-        )
+        self.assert_bind_cache_behavior(fn, x, preserve_specializations)
 
-    def test_tensor_factory_specialize_non_power_of_2(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_tensor_factory_specialize_non_power_of_2(
+        self, preserve_specializations: bool
+    ) -> None:
         def _test_with_factory(factory_fn, test_host=True):
             @helion.kernel()
             def reduce_kernel(
@@ -280,7 +403,11 @@ class TestSpecialize(RefEagerTestBase, TestCase):
                 return grad_weight.sum(0).to(x.dtype)
 
             x = torch.randn([128, 56], device=DEVICE, dtype=torch.float32)
-            code, result = code_and_output(reduce_kernel, (x, factory_fn, test_host))
+            code, result = code_and_output(
+                reduce_kernel,
+                (x, factory_fn, test_host),
+                preserve_specializations=preserve_specializations,
+            )
             reference = x.sum(0)
             torch.testing.assert_close(result, reference, rtol=1e-3, atol=1e-3)
 
@@ -308,7 +435,8 @@ class TestSpecialize(RefEagerTestBase, TestCase):
         _test_with_factory(lambda x, s, **kw: hl.zeros([s], **kw), test_host=False)
         _test_with_factory(lambda x, s, **kw: hl.full([s], 1.0, **kw), test_host=False)
 
-    def test_specialize_reduce(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_specialize_reduce(self, preserve_specializations: bool) -> None:
         @helion.kernel()
         def fn(
             x: torch.Tensor,
@@ -320,13 +448,25 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([500, 500], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_size=32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+            block_size=32,
+        )
         torch.testing.assert_close(result, x.sum(-1))
         self.assertTrueIfInNormalMode(
-            len(fn.bind((x,)).config_spec.reduction_loops) == 1
+            len(
+                fn.bind(
+                    (x,),
+                    preserve_specializations=preserve_specializations,
+                ).config_spec.reduction_loops
+            )
+            == 1
         )
 
-    def test_specialize_tuple_element(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_specialize_tuple_element(self, preserve_specializations: bool) -> None:
         """Test that hl.specialize works correctly with tuple elements."""
 
         @helion.kernel(config=helion.Config(block_sizes=[32]))
@@ -334,19 +474,27 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             out = x.new_empty(x.shape)
             val = hl.specialize(bitshift[0])
             for x_tile in hl.tile([x.shape[0]]):
-                # compute_val equivalent: 1 << (32 - val)
-                out[x_tile] = x[x_tile] + (1 << (32 - val))
+                out[x_tile] = x[x_tile] + val * 4096
             return out
 
         x = torch.ones(64, dtype=torch.int32, device=DEVICE)
-        code, result = code_and_output(foo, (x, (16, 16)))
-        # 1 << (32-16) = 1 << 16 = 65536
+        code, result = code_and_output(
+            foo,
+            (x, (16, 16)),
+            preserve_specializations=preserve_specializations,
+        )
+        # 16 * 4096 = 65536
         expected = x + 65536
         torch.testing.assert_close(result, expected)
-        # Verify that 65536 appears in the generated code as a constant
-        self.assertIn("65536", code)
+        if preserve_specializations:
+            self.assertIn("val: tl.constexpr", code)
+        else:
+            self.assertIn("65536", code)
 
-    def test_specialize_size_becomes_static(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_specialize_size_becomes_static(
+        self, preserve_specializations: bool
+    ) -> None:
         """Test that hl.specialize on a size makes it NOT passed to the triton kernel."""
 
         @helion.kernel(static_shapes=False)
@@ -358,12 +506,19 @@ class TestSpecialize(RefEagerTestBase, TestCase):
             return out
 
         x = torch.randn([137], device=DEVICE)  # Use prime to avoid alignment
-        code, result = code_and_output(fn, (x,))
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+        )
         torch.testing.assert_close(result, x + 1)
-        # Verify x_size_0 is NOT passed as an argument (it should be static)
-        self.assertNotIn("x_size_0", code)
+        if preserve_specializations:
+            self.assertIn("n: tl.constexpr", code)
+        else:
+            self.assertNotIn("x_size_0", code)
 
-    def test_specialize_stride_basic(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_specialize_stride_basic(self, preserve_specializations: bool) -> None:
         """Test that hl.specialize works with tensor strides."""
 
         @helion.kernel(static_shapes=False, autotune_effort="none")
@@ -385,14 +540,23 @@ class TestSpecialize(RefEagerTestBase, TestCase):
         storage = torch.randn(storage_size, device=DEVICE)
         x = torch.as_strided(storage, size, (stride0, stride1))
 
-        code, result = code_and_output(fn, (x,))
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+        )
         torch.testing.assert_close(result, x + x.stride(0))
-        # Verify the unique stride value 137 is inlined as a constant
-        self.assertIn("137", code)
-        # Verify x_stride_0 is NOT passed as an argument (it should be inlined)
-        self.assertNotIn("x_stride_0", code)
+        if preserve_specializations:
+            self.assertIn("x_stride_0: tl.constexpr", code)
+            self.assertIn("x.stride(0)", code)
+        else:
+            self.assertIn("137", code)
+            self.assertNotIn("x_stride_0", code)
 
-    def test_specialize_stride_creates_different_variants(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_specialize_stride_creates_different_variants(
+        self, preserve_specializations: bool
+    ) -> None:
         """Test that different stride patterns create different kernel variants."""
 
         @helion.kernel(static_shapes=False, autotune_effort="none")
@@ -419,19 +583,34 @@ class TestSpecialize(RefEagerTestBase, TestCase):
         x_b = torch.as_strided(storage_b, size, (stride0_b, 1))
 
         # These should create different bound kernels due to different strides
-        bound1 = fn.bind((x_a,))
-        bound2 = fn.bind((x_b,))
+        bound1 = fn.bind(
+            (x_a,),
+            preserve_specializations=preserve_specializations,
+        )
+        bound2 = fn.bind(
+            (x_b,),
+            preserve_specializations=preserve_specializations,
+        )
 
         # Verify different variants are used
         self.assertTrueIfInNormalMode(bound1 is not bound2)
 
         # Verify correctness
-        result1 = fn(x_a)
-        result2 = fn(x_b)
+        _, result1 = code_and_output(
+            fn,
+            (x_a,),
+            preserve_specializations=preserve_specializations,
+        )
+        _, result2 = code_and_output(
+            fn,
+            (x_b,),
+            preserve_specializations=preserve_specializations,
+        )
         torch.testing.assert_close(result1, x_a + stride0_a)
         torch.testing.assert_close(result2, x_b + stride0_b)
 
-    def test_specialize_stride_tuple(self):
+    @parametrize("preserve_specializations", _SPECIALIZATION_MODES)
+    def test_specialize_stride_tuple(self, preserve_specializations: bool) -> None:
         """Test that hl.specialize works with tuple of strides."""
 
         @helion.kernel(static_shapes=False, autotune_effort="none")
@@ -452,15 +631,26 @@ class TestSpecialize(RefEagerTestBase, TestCase):
         storage = torch.randn(storage_size, device=DEVICE)
         x = torch.as_strided(storage, size, (stride0, stride1))
 
-        code, result = code_and_output(fn, (x,))
+        code, result = code_and_output(
+            fn,
+            (x,),
+            preserve_specializations=preserve_specializations,
+        )
         expected = x + stride0 + stride1
         torch.testing.assert_close(result, expected)
-        # Verify both unique stride values appear in the generated code
-        self.assertIn("311", code)
-        self.assertIn("131", code)
-        # Verify both x_stride_0 and x_stride_1 are NOT passed as arguments (they should be inlined)
-        self.assertNotIn("x_stride_0", code)
-        self.assertNotIn("x_stride_1", code)
+        if preserve_specializations:
+            self.assertIn("x_stride_0: tl.constexpr", code)
+            self.assertIn("x_stride_1: tl.constexpr", code)
+            self.assertIn("x.stride(0)", code)
+            self.assertIn("x.stride(1)", code)
+        else:
+            self.assertIn("311", code)
+            self.assertIn("131", code)
+            self.assertNotIn("x_stride_0", code)
+            self.assertNotIn("x_stride_1", code)
+
+
+instantiate_parametrized_tests(TestSpecialize)
 
 
 @onlyBackends(["triton", "cute"])


### PR DESCRIPTION
## Summary

- add an opt-in `Kernel.bind(..., preserve_specializations=True)` export mode
- retain symbolic values passed through `hl.specialize` instead of embedding their example values
- lower retained device values, including specialized strides, to backend constexpr arguments so Triton can specialize and cache them at runtime
- preserve the existing literal-specialized bind and execution behavior by default
- parameterize the full Triton `TestSpecialize` suite over both lowering modes

## Motivation

`hl.specialize` currently works well for normal Helion execution because each bound shape is compiled independently. However, `BoundKernel.to_code()` embeds those values as Python and Triton literals, so a checked-in generated module only works for the shapes used during export.

The opt-in mode keeps the host expressions in the generated wrapper and passes them to the generated Triton kernel as `tl.constexpr` arguments. This allows one exported module to handle multiple runtime shapes while retaining Triton's per-value specialization.

## Duplicate work

I searched open PRs for `hl.specialize export constexpr`, `preserve specializations generated triton`, and `specialize to_code`. No overlapping PR or open issue was found. This PR does not duplicate an existing proposal.

## Validation

- `PYTHONPATH=$PWD /data/users/shangdiy/vllm-helion-generated/.venv/bin/python -m pytest test/test_specialize.py -q`
  - 36 passed
  - all 16 `TestSpecialize` methods run with `preserve_specializations=False` and `True` on Triton
- `uv tool run --offline ruff format --check helion/_compiler/device_function.py helion/_testing.py test/test_specialize.py`
  - passed
- `uv tool run --offline ruff check helion/_compiler/device_function.py helion/_testing.py test/test_specialize.py`
  - passed
- `PYTHONPATH=$PWD:/data/users/shangdiy/vllm-helion-generated/.venv/lib/python3.12/site-packages uv tool run --offline pyrefly check --ignore-missing-imports cutlass.cute --ignore-missing-imports jax.experimental helion/_compiler/device_function.py helion/_testing.py`
  - 0 errors
- H100 PTGQ smoke test: one module exported from `(tokens=4, hidden=2048, group=128)` produced correct results for `(4, 2048, 128)`, `(7, 4096, 128)`, and `(3, 3072, 64)`.

Model evaluation is not applicable: this changes an opt-in code-export path and leaves default Helion and model execution unchanged.

## AI assistance

AI assistance from OpenAI Codex was used to investigate, implement, and test this change. Before this draft is marked ready for review, the human submitter must review every changed line and be prepared to explain and defend the implementation end to end.
