### PR TITLE
Move Triton launcher into `helion/runtime/triton/launcher.py`

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 from contextlib import suppress
-import contextvars
 from dataclasses import dataclass
 import hashlib
 import importlib
@@ -25,11 +24,13 @@ from .._compat import get_num_xcd as get_num_xcd
 from .._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
-from .._utils import triton_is_available
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel
 from .settings import is_pallas_interpret as _module_is_pallas_interpret
+from .triton.launcher import default_launcher as default_launcher
+from .triton.launcher import get_num_sm as get_num_sm
+from .triton.launcher import set_triton_allocator as set_triton_allocator
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -79,128 +80,6 @@ def _patch_cutlass_jit_shutdown_unload() -> None:
     module_type.__del__ = _helion_del
     module_type._helion_shutdown_patch = True
     _CUTLASS_SHUTDOWN_PATCHED = True
-
-
-if triton_is_available():
-    import triton
-
-    def _alloc_fn(size: int, alignment: int, stream: int | None) -> torch.Tensor:
-        # Dynamically get device from Triton backend
-        current_target = triton.runtime.driver.active.get_current_target()
-        if current_target is None:
-            raise RuntimeError("No active Triton target available")
-        backend = current_target.backend
-        return torch.empty(size, device=backend, dtype=torch.int8)
-
-    def set_triton_allocator() -> None:
-        try:
-            from triton import set_allocator
-            from triton.runtime._allocation import NullAllocator
-            from triton.runtime._allocation import _allocator
-        except ImportError:
-            return
-        if isinstance(_allocator, contextvars.ContextVar):
-            existing = _allocator.get()
-        else:  # older versions of Triton
-            existing = _allocator
-        # if allocator isn't NullAllocator, we assume it is set by the user
-        if isinstance(existing, NullAllocator):
-            set_allocator(_alloc_fn)
-else:
-
-    def set_triton_allocator() -> None:  # type: ignore[misc]
-        pass
-
-
-def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
-    """
-    Get the number of streaming multiprocessors (SMs) for the specified device.
-
-    Args:
-        device: Device to query.
-        reserved_sms: Number of SMs to keep free for other work (e.g., communication
-            kernels). Defaults to 0 meaning all device SMs are available to Helion.
-
-    Returns:
-        Grid size to use for a persistent kernel on the device after accounting
-        for any reserved SMs. Always at least 1.
-    """
-    available_sms: int
-    if device.type == "cpu":
-        if not _module_is_pallas_interpret():
-            raise AssertionError("TODO: implement for other devices")
-        return 1
-    if device.type == "tpu":
-        return 1
-
-    assert device.type in [
-        "cuda",
-        "xpu",
-        "mtia",
-        "mps",
-    ], "TODO: implement for other devices"
-    if device.type == "cuda":
-        available_sms = torch.cuda.get_device_properties(
-            device.index
-        ).multi_processor_count
-    # TODO(EikanWang): gpu_subslice_count is an out-of-date term. we change update it to XeCore number.
-    elif device.type == "xpu":
-        available_sms = torch.xpu.get_device_properties(device.index).gpu_subslice_count
-    elif device.type == "mps":
-        available_sms = torch.backends.mps.get_core_count()
-    elif device.type == "mtia":
-        device_props = torch.mtia.get_device_properties(device.index)
-        if "max_grid_height" in device_props and "max_grid_width" in device_props:
-            available_sms = (
-                device_props["max_grid_height"] * device_props["max_grid_width"]
-            )
-        else:
-            raise RuntimeError(
-                f"Unable to determine SM count for MTIA device. "
-                f"Available properties: {list(device_props.keys())}"
-            )
-    else:
-        raise NotImplementedError(
-            f"get_num_sm not implemented for device type: {device.type}"
-        )
-
-    if reserved_sms <= 0:
-        return available_sms
-    return max(available_sms - reserved_sms, 1)
-
-
-def default_launcher(
-    triton_kernel: object,
-    grid: tuple[int, ...],
-    *args: object,
-    num_warps: int,
-    num_stages: int,
-    ptx_options: str | None = None,
-    launch_cooperative_grid: bool = False,
-    **kwargs: dict,
-) -> object:
-    """Default launcher function that executes the kernel immediately."""
-    # For both CUDA and MTIA, use the same kernel execution
-    run_kwargs: dict = {
-        "grid": grid,
-        "warmup": False,
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-        "launch_cooperative_grid": launch_cooperative_grid,
-        **kwargs,
-    }
-    if ptx_options is not None:
-        run_kwargs["ptx_options"] = ptx_options
-    try:
-        return triton_kernel.run(  # type: ignore[union-attr]
-            *args,
-            **run_kwargs,
-        )
-    except Exception as error:
-        message = str(error)
-        if "Cannot make_shape_compatible: incompatible dimensions" in message:
-            raise exc.ShapeMismatch("kernel operands", message) from error
-        raise
 
 
 def _pallas_make_block_spec(

--- a/helion/runtime/triton/__init__.py
+++ b/helion/runtime/triton/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/helion/runtime/triton/launcher.py
+++ b/helion/runtime/triton/launcher.py
@@ -1,0 +1,147 @@
+"""Runtime launch helpers for the Triton backend.
+
+This module holds the small set of runtime symbols that Helion's *generated*
+Triton code depends on at execution time:
+
+* :func:`default_launcher` -- invokes a compiled ``triton.jit`` kernel.
+* :func:`get_num_sm` -- persistent-kernel grid size (host statement).
+* :func:`set_triton_allocator` -- installs the scratch allocator used by TMA /
+  tensor-descriptor kernels (device-function prefix statement).
+
+Keeping these in a single dedicated module (rather than scattered through
+``helion.runtime``) lets the ahead-of-time precompiler bulk-export exactly this
+file into a standalone kernel. It is intended to depend only on ``torch`` and
+``triton`` (that guarantee is enforced in a follow-up change; today it still
+reaches back into a couple of ``helion`` helpers).
+"""
+
+from __future__ import annotations
+
+import contextvars
+
+import torch
+
+from ... import exc
+from ..._utils import triton_is_available
+from ..settings import is_pallas_interpret as _module_is_pallas_interpret
+
+if triton_is_available():
+    import triton
+
+    def _alloc_fn(size: int, alignment: int, stream: int | None) -> torch.Tensor:
+        # Dynamically get device from Triton backend
+        current_target = triton.runtime.driver.active.get_current_target()
+        if current_target is None:
+            raise RuntimeError("No active Triton target available")
+        backend = current_target.backend
+        return torch.empty(size, device=backend, dtype=torch.int8)
+
+    def set_triton_allocator() -> None:
+        try:
+            from triton import set_allocator
+            from triton.runtime._allocation import NullAllocator
+            from triton.runtime._allocation import _allocator
+        except ImportError:
+            return
+        if isinstance(_allocator, contextvars.ContextVar):
+            existing = _allocator.get()
+        else:  # older versions of Triton
+            existing = _allocator
+        # if allocator isn't NullAllocator, we assume it is set by the user
+        if isinstance(existing, NullAllocator):
+            set_allocator(_alloc_fn)
+else:
+
+    def set_triton_allocator() -> None:  # type: ignore[misc]
+        pass
+
+
+def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
+    """
+    Get the number of streaming multiprocessors (SMs) for the specified device.
+
+    Args:
+        device: Device to query.
+        reserved_sms: Number of SMs to keep free for other work (e.g., communication
+            kernels). Defaults to 0 meaning all device SMs are available to Helion.
+
+    Returns:
+        Grid size to use for a persistent kernel on the device after accounting
+        for any reserved SMs. Always at least 1.
+    """
+    available_sms: int
+    if device.type == "cpu":
+        if not _module_is_pallas_interpret():
+            raise AssertionError("TODO: implement for other devices")
+        return 1
+    if device.type == "tpu":
+        return 1
+
+    assert device.type in [
+        "cuda",
+        "xpu",
+        "mtia",
+        "mps",
+    ], "TODO: implement for other devices"
+    if device.type == "cuda":
+        available_sms = torch.cuda.get_device_properties(
+            device.index
+        ).multi_processor_count
+    # TODO(EikanWang): gpu_subslice_count is an out-of-date term. we change update it to XeCore number.
+    elif device.type == "xpu":
+        available_sms = torch.xpu.get_device_properties(device.index).gpu_subslice_count
+    elif device.type == "mps":
+        available_sms = torch.backends.mps.get_core_count()
+    elif device.type == "mtia":
+        device_props = torch.mtia.get_device_properties(device.index)
+        if "max_grid_height" in device_props and "max_grid_width" in device_props:
+            available_sms = (
+                device_props["max_grid_height"] * device_props["max_grid_width"]
+            )
+        else:
+            raise RuntimeError(
+                f"Unable to determine SM count for MTIA device. "
+                f"Available properties: {list(device_props.keys())}"
+            )
+    else:
+        raise NotImplementedError(
+            f"get_num_sm not implemented for device type: {device.type}"
+        )
+
+    if reserved_sms <= 0:
+        return available_sms
+    return max(available_sms - reserved_sms, 1)
+
+
+def default_launcher(
+    triton_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    num_warps: int,
+    num_stages: int,
+    ptx_options: str | None = None,
+    launch_cooperative_grid: bool = False,
+    **kwargs: dict,
+) -> object:
+    """Default launcher function that executes the kernel immediately."""
+    # For both CUDA and MTIA, use the same kernel execution
+    run_kwargs: dict = {
+        "grid": grid,
+        "warmup": False,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "launch_cooperative_grid": launch_cooperative_grid,
+        **kwargs,
+    }
+    if ptx_options is not None:
+        run_kwargs["ptx_options"] = ptx_options
+    try:
+        return triton_kernel.run(  # type: ignore[union-attr]
+            *args,
+            **run_kwargs,
+        )
+    except Exception as error:
+        message = str(error)
+        if "Cannot make_shape_compatible: incompatible dimensions" in message:
+            raise exc.ShapeMismatch("kernel operands", message) from error
+        raise

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -19,7 +19,10 @@ def _tpu_device() -> torch.device:
 
 class TestRuntimeGetNumSm(unittest.TestCase):
     def test_pallas_interpret_cpu_returns_one(self) -> None:
-        with patch("helion.runtime._module_is_pallas_interpret", return_value=True):
+        with patch(
+            "helion.runtime.triton.launcher._module_is_pallas_interpret",
+            return_value=True,
+        ):
             self.assertEqual(helion.runtime.get_num_sm(torch.device("cpu")), 1)
             self.assertEqual(
                 helion.runtime.get_num_sm(torch.device("cpu"), reserved_sms=8),
@@ -28,7 +31,10 @@ class TestRuntimeGetNumSm(unittest.TestCase):
 
     def test_normal_cpu_still_unsupported(self) -> None:
         with (
-            patch("helion.runtime._module_is_pallas_interpret", return_value=False),
+            patch(
+                "helion.runtime.triton.launcher._module_is_pallas_interpret",
+                return_value=False,
+            ),
             self.assertRaisesRegex(
                 AssertionError,
                 "TODO: implement for other devices",


### PR DESCRIPTION
Stacked PRs:
 * #3189
 * #3188
 * #3187
 * #3186
 * #3190
 * #3185
 * #3184
 * #3183
 * #3182
 * #3181
 * #3180
 * #3179
 * __->__#3178


--- --- ---

### Move Triton launcher into `helion/runtime/triton/launcher.py`


Relocate the runtime symbols that Helion's *generated* Triton code depends on
at execution time out of the catch-all `helion/runtime/__init__.py` into a
dedicated `helion/runtime/triton/launcher.py`:

- `default_launcher` — runs a compiled `triton.jit` kernel
- `get_num_sm` — persistent-kernel grid size (host statement)
- `set_triton_allocator` (+ `_alloc_fn`) — TMA / tensor-descriptor scratch allocator

`helion.runtime` re-exports all three, so `helion.runtime.default_launcher`,
`helion.runtime.get_num_sm`, `helion.runtime.set_triton_allocator`, and the
generated `from helion.runtime import default_launcher` are unchanged.

This is a pure move with no behavior change — the module still reaches back into
a few `helion` helpers (`exc`, `settings`, `_utils`). Isolating these into one
small module is the first step toward making them dependency-free, so the
ahead-of-time precompiler can bulk-export exactly this file into a standalone
kernel.

Because `get_num_sm` now resolves its globals in the new module,
`test/test_runtime.py` is updated to patch
`helion.runtime.triton.launcher._module_is_pallas_interpret` (the moved
function's real lookup site) instead of `helion.runtime._module_is_pallas_interpret`.

Verified: `ruff`/`pyrefly` clean, `test_runtime` and `test_persistent_kernels`
pass, and the generated Triton for `examples/add.py` is byte-identical.
