### PR TITLE
Make the Triton launcher helion-dependency-free (torch + triton only)

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -28,8 +28,8 @@ from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel
 from .settings import is_pallas_interpret as _module_is_pallas_interpret
-from .triton.launcher import default_launcher as default_launcher
-from .triton.launcher import get_num_sm as get_num_sm
+from .triton.launcher import default_launcher as _triton_default_launcher
+from .triton.launcher import get_num_sm as _triton_get_num_sm
 from .triton.launcher import set_triton_allocator as set_triton_allocator
 
 if TYPE_CHECKING:
@@ -80,6 +80,55 @@ def _patch_cutlass_jit_shutdown_unload() -> None:
     module_type.__del__ = _helion_del
     module_type._helion_shutdown_patch = True
     _CUTLASS_SHUTDOWN_PATCHED = True
+
+
+def default_launcher(
+    triton_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    num_warps: int,
+    num_stages: int,
+    ptx_options: str | None = None,
+    launch_cooperative_grid: bool = False,
+    **kwargs: dict,
+) -> object:
+    """Thin in-process wrapper over the dependency-free
+    :func:`helion.runtime.triton.launcher.default_launcher` that translates
+    Triton's opaque "incompatible dimensions" error into
+    :class:`helion.exc.ShapeMismatch`.
+    """
+    try:
+        return _triton_default_launcher(
+            triton_kernel,
+            grid,
+            *args,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            ptx_options=ptx_options,
+            launch_cooperative_grid=launch_cooperative_grid,
+            **kwargs,
+        )
+    except Exception as error:
+        message = str(error)
+        if "Cannot make_shape_compatible: incompatible dimensions" in message:
+            raise exc.ShapeMismatch("kernel operands", message) from error
+        raise
+
+
+def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
+    """Number of SMs (persistent-kernel grid size) for any Helion device.
+
+    Adds the CPU (Pallas-interpret) and TPU cases on top of the dependency-free
+    GPU helper :func:`helion.runtime.triton.launcher.get_num_sm`. See that
+    function for argument/return semantics.
+    """
+    if device.type == "cpu":
+        if not _module_is_pallas_interpret():
+            raise AssertionError("TODO: implement for other devices")
+        return 1
+    if device.type == "tpu":
+        return 1
+    return _triton_get_num_sm(device, reserved_sms=reserved_sms)
 
 
 def _pallas_make_block_spec(

--- a/helion/runtime/triton/launcher.py
+++ b/helion/runtime/triton/launcher.py
@@ -1,4 +1,4 @@
-"""Runtime launch helpers for the Triton backend.
+"""Helion-dependency-free runtime launch helpers for the Triton backend.
 
 This module holds the small set of runtime symbols that Helion's *generated*
 Triton code depends on at execution time:
@@ -8,11 +8,14 @@ Triton code depends on at execution time:
 * :func:`set_triton_allocator` -- installs the scratch allocator used by TMA /
   tensor-descriptor kernels (device-function prefix statement).
 
-Keeping these in a single dedicated module (rather than scattered through
-``helion.runtime``) lets the ahead-of-time precompiler bulk-export exactly this
-file into a standalone kernel. It is intended to depend only on ``torch`` and
-``triton`` (that guarantee is enforced in a follow-up change; today it still
-reaches back into a couple of ``helion`` helpers).
+It depends only on ``torch`` and ``triton`` -- no other ``helion`` module -- so
+the ahead-of-time precompiler can bulk-export this file verbatim into a
+standalone kernel with zero Helion runtime dependency.
+
+Helion-specific behavior that is only meaningful in-process (translating
+Triton's opaque shape errors into :class:`helion.exc.ShapeMismatch`, and the
+CPU/TPU cases of :func:`get_num_sm`) lives in thin wrappers in
+:mod:`helion.runtime`, not here.
 """
 
 from __future__ import annotations
@@ -21,12 +24,13 @@ import contextvars
 
 import torch
 
-from ... import exc
-from ..._utils import triton_is_available
-from ..settings import is_pallas_interpret as _module_is_pallas_interpret
-
-if triton_is_available():
+try:
     import triton
+except ImportError:
+    triton = None  # type: ignore[assignment]
+
+
+if triton is not None:
 
     def _alloc_fn(size: int, alignment: int, stream: int | None) -> torch.Tensor:
         # Dynamically get device from Triton backend
@@ -50,6 +54,7 @@ if triton_is_available():
         # if allocator isn't NullAllocator, we assume it is set by the user
         if isinstance(existing, NullAllocator):
             set_allocator(_alloc_fn)
+
 else:
 
     def set_triton_allocator() -> None:  # type: ignore[misc]
@@ -58,10 +63,11 @@ else:
 
 def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
     """
-    Get the number of streaming multiprocessors (SMs) for the specified device.
+    Get the number of streaming multiprocessors (SMs) for the specified GPU.
 
     Args:
-        device: Device to query.
+        device: Device to query. Must be a GPU device (``cuda``/``xpu``/``mps``/
+            ``mtia``); CPU/TPU handling lives in :func:`helion.runtime.get_num_sm`.
         reserved_sms: Number of SMs to keep free for other work (e.g., communication
             kernels). Defaults to 0 meaning all device SMs are available to Helion.
 
@@ -70,13 +76,6 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
         for any reserved SMs. Always at least 1.
     """
     available_sms: int
-    if device.type == "cpu":
-        if not _module_is_pallas_interpret():
-            raise AssertionError("TODO: implement for other devices")
-        return 1
-    if device.type == "tpu":
-        return 1
-
     assert device.type in [
         "cuda",
         "xpu",
@@ -135,13 +134,7 @@ def default_launcher(
     }
     if ptx_options is not None:
         run_kwargs["ptx_options"] = ptx_options
-    try:
-        return triton_kernel.run(  # type: ignore[union-attr]
-            *args,
-            **run_kwargs,
-        )
-    except Exception as error:
-        message = str(error)
-        if "Cannot make_shape_compatible: incompatible dimensions" in message:
-            raise exc.ShapeMismatch("kernel operands", message) from error
-        raise
+    return triton_kernel.run(  # type: ignore[union-attr]
+        *args,
+        **run_kwargs,
+    )

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -19,10 +19,7 @@ def _tpu_device() -> torch.device:
 
 class TestRuntimeGetNumSm(unittest.TestCase):
     def test_pallas_interpret_cpu_returns_one(self) -> None:
-        with patch(
-            "helion.runtime.triton.launcher._module_is_pallas_interpret",
-            return_value=True,
-        ):
+        with patch("helion.runtime._module_is_pallas_interpret", return_value=True):
             self.assertEqual(helion.runtime.get_num_sm(torch.device("cpu")), 1)
             self.assertEqual(
                 helion.runtime.get_num_sm(torch.device("cpu"), reserved_sms=8),
@@ -31,10 +28,7 @@ class TestRuntimeGetNumSm(unittest.TestCase):
 
     def test_normal_cpu_still_unsupported(self) -> None:
         with (
-            patch(
-                "helion.runtime.triton.launcher._module_is_pallas_interpret",
-                return_value=False,
-            ),
+            patch("helion.runtime._module_is_pallas_interpret", return_value=False),
             self.assertRaisesRegex(
                 AssertionError,
                 "TODO: implement for other devices",


### PR DESCRIPTION
Stacked PRs:
 * #3187
 * #3186
 * #3190
 * #3184
 * #3183
 * #3182
 * #3181
 * #3180
 * __->__#3179


--- --- ---

### Make the Triton launcher helion-dependency-free (torch + triton only)


`helion/runtime/triton/launcher.py` now imports only `torch` and `triton` — no
other `helion` module — so the ahead-of-time precompiler can bulk-export it
verbatim into a standalone kernel with zero Helion runtime dependency.

The helion-specific behavior that only matters in-process moves into thin
wrappers in `helion.runtime`:

- `default_launcher`: the dep-free base just calls `triton_kernel.run(...)`;
  `helion.runtime.default_launcher` wraps it to translate Triton's opaque
  "incompatible dimensions" error into `helion.exc.ShapeMismatch`.
- `get_num_sm`: the dep-free base handles GPU devices (cuda/xpu/mps/mtia);
  `helion.runtime.get_num_sm` adds the CPU (Pallas-interpret) and TPU cases.
- `set_triton_allocator`: already dep-free (the `triton` availability check is
  now an inline `try: import triton`); re-exported unchanged.

Generated code is unchanged — it still imports `from helion.runtime import
default_launcher` and calls `helion.runtime.get_num_sm(...)` (the wrappers), so
in-process behavior and the codegen-string / `patch("helion.runtime.get_num_sm")`
tests are untouched. `test/test_runtime.py`'s Pallas-interpret patch retargets
`helion.runtime._module_is_pallas_interpret` (the wrapper's lookup site).

`get_num_xcd` stays in `helion._compat` for now; it joins the dep-free launcher
in the precompile change that needs to inline it.

Verified on H100: `ruff`/`pyrefly` clean (no new errors vs. base), `test_runtime`
/ `test_persistent_kernels` / `test_config_api` / `test_dot_requirements` pass,
and `add` compiles + runs correctly through the wrapper.
