### PR TITLE
Add `OutputCodeOptions(allow_helion_deps=False)` to `BoundKernel.to_code` for standalone Triton kernels

### DIFF
--- a/helion/__init__.py
+++ b/helion/__init__.py
@@ -12,6 +12,7 @@ from .autotuner import aot_kernel
 from .autotuner import from_cache
 from .runtime import Config
 from .runtime import Kernel
+from .runtime import OutputCodeOptions
 from .runtime import kernel
 from .runtime import kernel as jit  # alias
 from .runtime.settings import RefMode
@@ -20,6 +21,7 @@ from .runtime.settings import Settings
 __all__ = [
     "Config",
     "Kernel",
+    "OutputCodeOptions",
     "RefMode",
     "Settings",
     "aot_kernel",

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -79,6 +79,42 @@ class AttentionSoftmaxPattern(NamedTuple):
         return self.score_plan.is_causal
 
 
+@dataclasses.dataclass(frozen=True)
+class LauncherInfo:
+    """Per-backend info for inlining the dependency-free launcher as a local
+    ``helion.runtime`` shim (see :mod:`helion.runtime.precompile`), used by
+    ``BoundKernel.to_code(options=OutputCodeOptions(allow_helion_deps=False))``."""
+
+    launcher_module: str  # dotted path of the dep-free launcher, inlined verbatim
+    launcher_symbol: str  # public launcher name that module defines
+    launcher_alias: str  # underscore alias generated code binds it to
+    deps: str  # runtime deps, for the header comment
+    # ``helion.runtime.<fn>`` runtime helpers the generated host wrapper calls
+    # (besides the launcher); the shim re-exports these so the body runs verbatim.
+    runtime_helper_names: tuple[str, ...] = ()
+
+
+def read_launcher_source(module_name: str) -> str:
+    """Raw source of a dependency-free launcher module."""
+    import importlib
+    from pathlib import Path
+
+    module = importlib.import_module(module_name)
+    assert module.__file__ is not None
+    return Path(module.__file__).read_text()
+
+
+def dedupe_preserve_order(items: list[str]) -> list[str]:
+    """De-duplicate ``items`` keeping first-seen order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
 class Backend(abc.ABC):
     """Abstract base class for Helion code generation backends.
 
@@ -702,6 +738,29 @@ class Backend(abc.ABC):
         values are the corresponding import statements.
         """
         ...
+
+    def embedded_helper_source(self, body: str) -> str:
+        """Source of in-kernel runtime helpers to inline into the generated module.
+
+        Backends that call a helion-defined helper from inside the generated
+        kernel can return its source here (instead of importing it) so the output
+        is self-contained -- which lets the precompiler produce a helion-free
+        standalone. Only helpers actually referenced in ``body`` should be
+        emitted. Injected between the imports and the kernel body. Default: none.
+        """
+        return ""
+
+    @property
+    def dependency_free_launcher_info(self) -> LauncherInfo:
+        """Info for inlining this backend's dependency-free launcher as a local
+        ``helion.runtime`` shim, used by
+        ``to_code(options=OutputCodeOptions(allow_helion_deps=False))``. Backends
+        that cannot yet emit a helion-free module raise ``NotImplementedError``.
+        """
+        raise NotImplementedError(
+            f"the {self.name!r} backend does not support "
+            "to_code(allow_helion_deps=False) yet"
+        )
 
     def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
         return []

--- a/helion/_compiler/output_code_utils.py
+++ b/helion/_compiler/output_code_utils.py
@@ -1,0 +1,219 @@
+"""Dependency-free ("standalone") output code for :meth:`BoundKernel.to_code`.
+
+By default ``to_code`` returns code that still imports ``helion`` at runtime (for
+the launcher and a few ``helion.runtime.*`` helpers). Passing
+:class:`~helion.runtime.kernel.OutputCodeOptions` with ``allow_helion_deps=False``
+instead yields a self-contained module whose only dependencies are ``torch`` + the
+backend DSL (e.g. ``triton``) -- so clients can check in a helion-generated kernel
+without taking on helion as a dependency.
+
+This module holds the backend-neutral machinery. :func:`build_dependency_free_code`
+is an AST transform over ``to_code``'s ``body_root`` (run before it is unparsed): it
+drops the helion imports (from ``import_lines``) and prepends -- as AST statements --
+the dependency-free launcher inlined as a local ``helion.runtime`` shim (so the
+body's verbatim ``helion.runtime.<fn>(...)`` calls resolve without the real package)
+plus any in-kernel runtime helpers the body references (via
+``Backend.embedded_helper_source``). The per-backend launcher info lives on the
+backend classes (``Backend.dependency_free_launcher_info`` in
+:mod:`helion._compiler.backend`).
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+from typing import Any
+
+from .backend import dedupe_preserve_order
+from .backend import read_launcher_source
+
+if TYPE_CHECKING:
+    from ..runtime.kernel import BoundKernel
+    from ..runtime.kernel import OutputCodeOptions
+    from .backend import LauncherInfo
+
+
+_SHIM_DOC = (
+    "Inlined dependency-free Helion runtime shim -- this file does NOT need the real "
+    "helion package. The generated kernel below is emitted verbatim, so it still "
+    "calls the runtime helpers as ``helion.runtime.<fn>(...)``; those resolve against "
+    "the ``helion`` namespace built from this function. The launcher is inlined in "
+    "this private scope so its symbols can never collide with the kernel name."
+)
+
+
+def build_dependency_free_code(
+    bound: BoundKernel[Any],
+    options: OutputCodeOptions,
+    import_lines: list[str],
+    body_root: ast.Module,
+) -> ast.Module:
+    """Rewrite ``to_code``'s split output into a self-contained (helion-free) module.
+
+    An optional AST processing step over ``body_root``, run before it is unparsed: it
+    mutates ``import_lines`` in place (drops the helion imports, adds ``types`` for
+    the shim) and prepends -- as AST statements -- the inlined ``helion.runtime``
+    shim and any in-kernel runtime helpers the body references (topk /
+    compact-worklist). Returns ``body_root`` so :meth:`BoundKernel.to_code` unparses
+    it in the shared path.
+
+    Torch-tensor only; ``jax_fn`` is handled by :func:`build_jax_fn_module`.
+    """
+    backend = bound.env.backend
+    info = backend.dependency_free_launcher_info
+    kernel_name = bound.kernel.name
+    _reject_body_helion_imports(body_root, kernel_name)
+    embedded = backend.embedded_helper_source(ast.unparse(body_root))
+    import_lines[:] = dedupe_preserve_order(
+        [imp for imp in import_lines if "helion" not in imp] + ["import types"]
+    )
+    preamble: list[ast.stmt] = _runtime_shim_statements(info)
+    if embedded:
+        preamble += ast.parse(embedded).body
+    body_root.body[:0] = preamble
+    ast.fix_missing_locations(body_root)
+    _check_kernel_name_not_shadowed(body_root, import_lines, kernel_name)
+    return body_root
+
+
+def _reject_body_helion_imports(body_root: ast.Module, kernel_name: str) -> None:
+    """Raise if the body AST imports helion anywhere (an in-kernel helper the
+    standalone can't satisfy). Module-level helion imports are handled separately
+    (dropped from ``import_lines``); this walks the body for a stray one."""
+    for node in ast.walk(body_root):
+        if isinstance(node, ast.Import) and any(
+            "helion" in alias.name for alias in node.names
+        ):
+            _raise_needs_helion(kernel_name)
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module is not None
+            and "helion" in node.module
+        ):
+            _raise_needs_helion(kernel_name)
+
+
+def _raise_needs_helion(kernel_name: str) -> None:
+    raise NotImplementedError(
+        f"cannot export {kernel_name!r} without helion deps: the generated kernel "
+        "still imports helion in its body (an in-kernel runtime helper is not "
+        "inlined yet)."
+    )
+
+
+def _runtime_shim_statements(info: LauncherInfo) -> list[ast.stmt]:
+    """The dependency-free launcher inlined as a local ``helion.runtime`` shim,
+    returned as AST statements to prepend to the module body.
+
+    The launcher is inlined inside ``_make_helion_runtime`` -- a private function
+    scope, so none of its symbols (``get_num_sm``, ``default_launcher``, ...) land at
+    module level where they could clash with the generated kernel -- and re-exported
+    on a ``types.SimpleNamespace`` as ``helion.runtime`` so the body's verbatim
+    ``helion.runtime.<fn>(...)`` calls resolve against it.
+
+    Built by editing the AST: parse a small template, splice the launcher body into
+    the function and the exports into the returned namespace -- no string surgery.
+    """
+    launcher_ast = ast.parse(read_launcher_source(info.launcher_module))
+    # Everything but the module docstring and ``from __future__`` (illegal inside a
+    # function) is inlined into ``_make_helion_runtime``; the launcher's own imports
+    # come along as function-local imports.
+    launcher_stmts = [
+        stmt
+        for stmt in launcher_ast.body
+        if not _is_future_import(stmt) and not _is_docstring_expr(stmt)
+    ]
+    # The launcher's module-level state (e.g. a ``global``-mutated cache) becomes a
+    # ``_make_helion_runtime`` local once inlined, so rewrite those ``global``
+    # declarations to ``nonlocal`` -- otherwise a nested helper would look for a
+    # module global that no longer exists.
+    global_to_nonlocal = _GlobalToNonlocal(set(_module_level_names(launcher_ast)))
+    launcher_stmts = [global_to_nonlocal.visit(stmt) for stmt in launcher_stmts]
+    exports = dedupe_preserve_order([*info.runtime_helper_names, info.launcher_symbol])
+    module = ast.parse(
+        "def _make_helion_runtime():\n"
+        "    return types.SimpleNamespace()\n"
+        "helion = types.SimpleNamespace(runtime=_make_helion_runtime())\n"
+        f"{info.launcher_alias} = helion.runtime.{info.launcher_symbol}\n"
+    )
+    make_fn = module.body[0]
+    assert isinstance(make_fn, ast.FunctionDef)
+    return_stmt = make_fn.body[0]
+    assert isinstance(return_stmt, ast.Return)
+    namespace_call = return_stmt.value
+    assert isinstance(namespace_call, ast.Call)
+    # Docstring explaining the shim, then the inlined launcher, then the return.
+    make_fn.body = [ast.Expr(ast.Constant(_SHIM_DOC)), *launcher_stmts, return_stmt]
+    namespace_call.keywords = [
+        ast.keyword(arg=name, value=ast.Name(id=name, ctx=ast.Load()))
+        for name in exports
+    ]
+    ast.fix_missing_locations(module)
+    return module.body
+
+
+def _is_future_import(node: ast.stmt) -> bool:
+    """True for a ``from __future__ import ...`` statement."""
+    return isinstance(node, ast.ImportFrom) and node.module == "__future__"
+
+
+def _is_docstring_expr(node: ast.stmt) -> bool:
+    """True for a bare string-literal statement (a module/function docstring)."""
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )
+
+
+def _check_kernel_name_not_shadowed(
+    body_root: ast.Module, import_lines: list[str], kernel_name: str
+) -> None:
+    """Ensure the kernel's host-wrapper is the only top-level binding of its name.
+
+    Launcher helpers live inside ``_make_helion_runtime`` (a private scope), so a
+    kernel named e.g. ``get_num_sm`` is fine. This only fires if the name still
+    clashes with a genuine module-level symbol (an import, the shim, the device
+    kernel) -- in which case we raise rather than emit a module whose later ``def``
+    silently shadows the earlier binding.
+    """
+    import_names = (
+        _module_level_names(ast.parse("\n".join(import_lines))) if import_lines else []
+    )
+    names = [*import_names, *_module_level_names(body_root)]
+    if names.count(kernel_name) > 1:
+        raise ValueError(
+            f"cannot export kernel {kernel_name!r} without helion deps: its name "
+            "collides with another top-level symbol in the generated module"
+        )
+
+
+def _module_level_names(tree: ast.Module) -> list[str]:
+    """Top-level names a module binds (defs, classes, assignments, imports)."""
+    names: list[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.append(node.name)
+        elif isinstance(node, ast.Assign):
+            names.extend(t.id for t in node.targets if isinstance(t, ast.Name))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.append(node.target.id)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.extend((a.asname or a.name).split(".")[0] for a in node.names)
+    return names
+
+
+class _GlobalToNonlocal(ast.NodeTransformer):
+    """Rewrite ``global X`` -> ``nonlocal X`` for names the shim inlines as
+    ``_make_helion_runtime`` locals (the launcher's module-level state), so a
+    nested launcher helper still rebinds the shared value rather than looking for a
+    module global that no longer exists. Names not inlined as locals are left as
+    ``global`` (there are none in the current launchers, but this stays correct)."""
+
+    def __init__(self, local_names: set[str]) -> None:
+        self._local_names = local_names
+
+    def visit_Global(self, node: ast.Global) -> ast.stmt:
+        if node.names and all(name in self._local_names for name in node.names):
+            return ast.copy_location(ast.Nonlocal(names=node.names), node)
+        return node

--- a/helion/_compiler/triton/backend.py
+++ b/helion/_compiler/triton/backend.py
@@ -17,6 +17,7 @@ import torch
 
 from ... import exc
 from ..backend import Backend
+from ..backend import LauncherInfo
 from ..backend import log
 
 if TYPE_CHECKING:
@@ -353,6 +354,19 @@ class TritonBackend(Backend):
     @property
     def default_launcher_name(self) -> str:
         return "_default_launcher"
+
+    @property
+    def dependency_free_launcher_info(self) -> LauncherInfo:
+        # get_num_sm / get_num_xcd / set_triton_allocator are launcher functions
+        # the generated host wrapper calls as ``helion.runtime.<fn>(``; the shim
+        # re-exports them (with the launcher) so those verbatim calls resolve.
+        return LauncherInfo(
+            launcher_module="helion.runtime.triton.launcher",
+            launcher_symbol="default_launcher",
+            launcher_alias="_default_launcher",
+            deps="torch + triton",
+            runtime_helper_names=("get_num_sm", "get_num_xcd", "set_triton_allocator"),
+        )
 
     @property
     def library_imports(self) -> dict[str, str]:

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -22,6 +22,7 @@ from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
 from .config import Config as Config
 from .kernel import Kernel as Kernel
+from .kernel import OutputCodeOptions as OutputCodeOptions
 from .kernel import kernel as kernel
 from .pallas.launcher import default_pallas_launcher as default_pallas_launcher
 from .settings import is_pallas_interpret as _module_is_pallas_interpret

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -207,6 +207,22 @@ def _device_specialization_key(
     return device.type, target_device_capability(device)
 
 
+@dataclasses.dataclass
+class OutputCodeOptions:
+    """Options for :meth:`BoundKernel.to_code`.
+
+    Passing ``options=None`` (the default) keeps ``to_code``'s original behavior.
+
+    Attributes:
+        allow_helion_deps: When ``False``, emit a self-contained module that does
+            not import ``helion`` at runtime -- the dependency-free launcher is
+            inlined (and any in-kernel runtime helpers are embedded) so the only
+            deps are ``torch`` + the backend DSL.
+    """
+
+    allow_helion_deps: bool = True
+
+
 class Kernel(Generic[_R]):
     def __init__(
         self,
@@ -1095,6 +1111,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         self,
         config: ConfigLike | None = None,
         *,
+        options: OutputCodeOptions | None = None,
         emit_repro_caller: bool = False,
         output_origin_lines: bool | None = None,
     ) -> str:
@@ -1103,6 +1120,11 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
 
         Args:
             config: The configuration to use for code generation.
+            options: Optional :class:`~helion.runtime.precompile.OutputCodeOptions`.
+                With ``allow_helion_deps=False`` the returned module is
+                self-contained (no ``helion`` import at runtime); ``jax_fn=True``
+                (Pallas only) emits a pure-JAX module operating on ``jax.Array``s.
+                ``None`` keeps the default behavior.
             emit_repro_caller: Emits a main function to call the kernel with example inputs.
 
         Returns:
@@ -1141,8 +1163,16 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     body_start = len(root.body)
                 body_root = ast.Module(body=root.body[body_start:], type_ignores=[])
                 ast.fix_missing_locations(body_root)
-                imports = "\n".join(import_lines)
+                if options is not None and not options.allow_helion_deps:
+                    # Optional AST step: rewrite body_root (+ import_lines) into a
+                    # self-contained, helion-free module before it is unparsed.
+                    from .._compiler.output_code_utils import build_dependency_free_code
+
+                    body_root = build_dependency_free_code(
+                        self, options, import_lines, body_root
+                    )
                 body = unparse(body_root, output_origin_lines=output_origin_lines)
+                imports = "\n".join(import_lines)
                 if imports:
                     return f"from __future__ import annotations\n\n{imports}\n\n{body}"
                 return f"from __future__ import annotations\n\n{body}"

--- a/test/test_bound_kernel.py
+++ b/test/test_bound_kernel.py
@@ -1,0 +1,209 @@
+"""Tests for :meth:`helion.runtime.kernel.BoundKernel.to_code` with
+:class:`helion.OutputCodeOptions` -- i.e. emitting dependency-free ("standalone")
+output code that runs with no ``helion`` runtime dependency (``torch`` + the
+backend DSL only)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import onlyBackends
+from helion._testing import skipIfRefEager
+import helion.language as hl
+
+_FREE = helion.OutputCodeOptions(allow_helion_deps=False)
+
+
+@helion.kernel(config=helion.Config(block_sizes=[32, 32]))
+def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    x, y = torch.broadcast_tensors(x, y)
+    out = torch.empty(
+        x.shape,
+        dtype=torch.promote_types(x.dtype, y.dtype),
+        device=x.device,
+    )
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+@helion.kernel(
+    config=helion.Config(block_sizes=[64, 64], pid_type="persistent_blocked")
+)
+def add_persistent(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """Persistent grid -> the launch computes its grid from ``get_num_sm``."""
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+@helion.kernel(config=helion.Config(block_sizes=[64, 64], indexing="tensor_descriptor"))
+def add_tma(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """TMA (tensor-descriptor) indexing -> the launch calls
+    ``set_triton_allocator`` for the device-side descriptor allocator."""
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+@helion.kernel(config=helion.Config(block_sizes=[32, 32]), static_shapes=False)
+def add_dynamic(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """static_shapes=False -> the standalone must run at any shape: the emitted
+    host wrapper derives the grid + output shape from the runtime input rather than
+    baking the sample shape."""
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+@helion.kernel(
+    config=helion.Config(block_sizes=[64, 64], pid_type="persistent_blocked")
+)
+def get_num_sm(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """A kernel deliberately named like a launcher helper. The launcher helpers
+    live in the private ``_make_helion_runtime`` scope, so this name cannot
+    collide with them (the persistent grid still calls the shim's get_num_sm)."""
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+def _write(tmp: str, code: str) -> str:
+    path = Path(tmp) / "generated.py"
+    path.write_text(code)
+    return str(path)
+
+
+def _run_add_no_helion(code: str, entrypoint: str, shape: tuple[int, int]) -> None:
+    """Run an **add** standalone in a subprocess where importing ``helion`` is
+    blocked, proving zero Helion runtime dependency and the right result. Specific
+    to add kernels -- it hardcodes the ``x + y`` reference."""
+    m, n = shape
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write(tmp, code)
+        script = textwrap.dedent(f"""
+            import sys
+            # Poison the helion package so any leftover dependency fails loudly.
+            sys.modules["helion"] = None
+            import importlib.util
+            import torch
+
+            spec = importlib.util.spec_from_file_location("_standalone", {path!r})
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            torch.manual_seed(0)
+            x = torch.randn([{m}, {n}], device="{DEVICE}", dtype=torch.bfloat16)
+            y = torch.randn([{m}, {n}], device="{DEVICE}", dtype=torch.bfloat16)
+            out = mod.{entrypoint}(x, y)
+            torch.testing.assert_close(out, x + y)
+            print("STANDALONE_OK")
+        """)
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True
+        )
+        if "STANDALONE_OK" not in result.stdout:
+            raise AssertionError(
+                f"standalone run failed:\nstdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+
+
+@onlyBackends(["triton"])
+@skipIfRefEager("to_code compiles real Triton code; not meaningful in ref-eager")
+class TestToCodeTriton(TestCase):
+    def test_default_still_has_helion_deps(self) -> None:
+        x = torch.randn([64, 64], device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn([64, 64], device=DEVICE, dtype=torch.bfloat16)
+        # options=None (default) keeps the original to_code behavior, which still
+        # depends on helion at runtime (here: the launcher import).
+        code = add.bind((x, y)).to_code()
+        self.assertIn("from helion.runtime import default_launcher", code)
+
+    def test_allow_helion_deps_false_has_no_helion_import(self) -> None:
+        x = torch.randn([64, 64], device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn([64, 64], device=DEVICE, dtype=torch.bfloat16)
+        code = add.bind((x, y)).to_code(options=_FREE)
+        # The helion *package* is never imported. The body DOES contain
+        # ``helion.runtime.*`` references, but they resolve against the inlined
+        # local ``helion`` shim (see the shim banner), not the real package.
+        self.assertNotIn("import helion", code)
+        self.assertNotIn("from helion", code)
+        self.assertIn("def default_launcher(", code)
+        self.assertIn(
+            "helion = types.SimpleNamespace(runtime=_make_helion_runtime())", code
+        )
+        self.assertIn("_default_launcher = helion.runtime.default_launcher", code)
+        self.assertIn("def add(", code)
+
+    def test_standalone_runs_without_helion(self) -> None:
+        x = torch.randn([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        code = add.bind((x, y)).to_code(options=_FREE)
+        _run_add_no_helion(code, "add", (128, 128))
+
+    def test_to_triton_code_alias_unchanged(self) -> None:
+        x = torch.randn([64, 64], device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn([64, 64], device=DEVICE, dtype=torch.bfloat16)
+        bound = add.bind((x, y))
+        # Back-compat: to_triton_code is an alias for to_code's default behavior.
+        self.assertEqual(bound.to_triton_code(), bound.to_code())
+
+    def test_persistent_kernel_get_num_sm_via_shim(self) -> None:
+        """A persistent kernel calls ``helion.runtime.get_num_sm`` to size its
+        grid. The body is emitted verbatim and the call is satisfied by the inlined
+        ``helion.runtime`` shim, so it runs with no real helion."""
+        x = torch.randn([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        code = add_persistent.bind((x, y)).to_code(options=_FREE)
+        self.assertNotIn("import helion", code)
+        self.assertIn("helion.runtime.get_num_sm(", code)  # verbatim body call
+        self.assertIn("get_num_sm=get_num_sm", code)  # shim re-export
+        _run_add_no_helion(code, "add_persistent", (128, 128))
+
+    def test_tma_kernel_set_triton_allocator_via_shim(self) -> None:
+        """A tensor-descriptor (TMA) kernel calls
+        ``helion.runtime.set_triton_allocator``; the shim satisfies it."""
+        x = torch.randn([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        code = add_tma.bind((x, y)).to_code(options=_FREE)
+        self.assertNotIn("import helion", code)
+        self.assertIn("helion.runtime.set_triton_allocator(", code)  # verbatim call
+        self.assertIn("set_triton_allocator=set_triton_allocator", code)
+        _run_add_no_helion(code, "add_tma", (128, 128))
+
+    def test_dynamic_shapes_run_at_other_shapes(self) -> None:
+        """A static_shapes=False kernel's standalone runs correctly at shapes other
+        than the one it was bound with (grid + output shape derived from input)."""
+        x = torch.zeros([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        y = torch.zeros([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        code = add_dynamic.bind((x, y)).to_code(options=_FREE)
+        for shape in ((128, 128), (256, 64), (64, 256)):
+            _run_add_no_helion(code, "add_dynamic", shape)
+
+    def test_kernel_named_like_runtime_helper(self) -> None:
+        """A kernel literally named ``get_num_sm`` exports safely: the launcher
+        helpers are isolated in a private scope, so the kernel name can't shadow
+        them (this would previously have produced two module-level defs)."""
+        x = torch.randn([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn([128, 128], device=DEVICE, dtype=torch.bfloat16)
+        code = get_num_sm.bind((x, y)).to_code(options=_FREE)
+        _run_add_no_helion(code, "get_num_sm", (128, 128))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #3186
 * #3184
 * #3190
 * __->__#3181


--- --- ---

### Add `OutputCodeOptions(allow_helion_deps=False)` to `BoundKernel.to_code` for standalone Triton kernels


Extend the existing `BoundKernel.to_code` with an optional
`options: OutputCodeOptions` argument (the public dataclass lives next to
`to_code` in `kernel.py`). With `allow_helion_deps=False`, `to_code` returns a
self-contained module whose only runtime dependencies are `torch` + the backend
DSL (here Triton) -- no `helion` import -- so callers can check in a
helion-generated kernel without taking on helion as a dependency.

Example:

    bound = add.bind((x, y))
    code = bound.to_code(cfg, options=OutputCodeOptions(allow_helion_deps=False))

emits a module whose deps are `torch` + `triton` (no `helion` import):

    import torch, triton, triton.language as tl, types
    helion = types.SimpleNamespace(runtime=_make_helion_runtime())  # inlined shim
    @triton.jit
    def _helion_add(x, y, out): ...
    def add(x, y, *, _launcher=_default_launcher):  # torch.Tensor -> torch.Tensor
        ...  # body's helion.runtime.<fn>(...) calls resolve against the shim

The backend-neutral machinery lives in `helion/_compiler/output_code_utils.py`.
`build_dependency_free_code` is an optional AST transform over `to_code`'s
`body_root`, run before it is unparsed: it drops the helion imports (from
`import_lines`) and prepends -- as AST statements -- the dependency-free launcher
inlined as a local `helion.runtime` shim (built in a private
`_make_helion_runtime()` scope so the launcher's helper names cannot collide with
the kernel's). The generated body's verbatim `helion.runtime.<fn>(...)` calls
resolve against it.

Per-backend launcher info lives on the backend classes
(`Backend.dependency_free_launcher_info`); `TritonBackend` supplies the Triton
launcher. `to_triton_code` remains an alias for the default behavior.
