### PR TITLE
Make the Pallas launcher dependency-free (torch + jax only)

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -992,10 +992,6 @@ class Backend(abc.ABC):
         return triton_precision_by_dot_precision.get(precision, "")
 
 
-# TPU does not natively support 64-bit element types.
-_PALLAS_UNSUPPORTED_DTYPES = frozenset({torch.int64, torch.uint64, torch.float64})
-
-
 def _largest_divisor_at_most(size: int, limit: int) -> int:
     for divisor in range(limit, 0, -1):
         if size % divisor == 0:

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1385,7 +1385,7 @@ class PallasBackend(Backend):
                 plan,
                 host_fn.params.arguments,
                 ordered_block=env.compact_worklist_ordered_block,
-                vmem_bytes=_get_vmem_limit_bytes(pltpu),
+                vmem_bytes=_get_vmem_limit_bytes(pltpu, env.settings.pallas_interpret),
             )
             if not admission.decision.active:
                 raise exc.InvalidConfig(

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -5,16 +5,16 @@ generated Pallas code invokes) plus the shared block-spec / compile / caching
 helpers it and the pure-JAX export path (`helion.runtime.pallas_jax_export`)
 build on.
 
-Isolated here (out of the catch-all `helion.runtime`) so the ahead-of-time
-precompiler can bulk-export it. Making it depend only on torch + jax is a
-follow-up; today it still reaches into a couple of `helion` helpers
-(`settings`, `_compiler.backend`).
+Depends only on ``torch`` and ``jax`` -- no other ``helion`` module -- so the
+ahead-of-time precompiler can bulk-export this file verbatim into a standalone
+kernel with zero Helion runtime dependency.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 import inspect
+import os
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
@@ -22,13 +22,33 @@ from typing import cast
 
 import torch
 
-from ..settings import is_pallas_interpret as _module_is_pallas_interpret
-
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterable
 
     import jax
+
+
+# Dtypes Mosaic/Pallas cannot lower. Kept here (rather than imported from the
+# compiler) so the launcher stays dependency-free; the compiler applies the same
+# check at codegen time.
+_PALLAS_UNSUPPORTED_DTYPES = frozenset({torch.int64, torch.uint64, torch.float64})
+
+
+def _pallas_interpret_enabled() -> bool:
+    """Whether Pallas interpret mode (CPU, no TPU) is on, per the
+    ``HELION_PALLAS_INTERPRET`` env var.
+
+    Dependency-free stand-in for ``helion.runtime.settings.is_pallas_interpret``
+    at the launcher's call sites: the launcher runs at kernel-execution time,
+    where no ``CompileEnvironment`` is active, so ``is_pallas_interpret`` already
+    reduces to this env-var read (``Settings.pallas_interpret`` itself defaults
+    from the same variable).
+    """
+    value = os.environ.get("HELION_PALLAS_INTERPRET")
+    if value is None or (value := value.strip()) == "":
+        return False
+    return value.lower() in ("1", "true", "yes", "on", "y", "t")
 
 
 def _pallas_make_block_spec(
@@ -103,8 +123,13 @@ def _pallas_make_block_spec(
 _CACHED_VMEM_LIMIT_BYTES: int | None = None
 
 
-def _get_vmem_limit_bytes(pltpu: object) -> int:
-    """Safely retrieves the TPU VMEM capacity without crashing on hardware locks."""
+def _get_vmem_limit_bytes(pltpu: object, interpret: bool) -> int:
+    """Safely retrieves the TPU VMEM capacity without crashing on hardware locks.
+
+    ``interpret`` picks the synthetic CPU TPU-info budget over a real-TPU query.
+    Callers pass the compile-time ``settings.pallas_interpret`` (compiler) or the
+    runtime env-var value (launcher), so this helper stays dependency-free.
+    """
     global _CACHED_VMEM_LIMIT_BYTES
     if _CACHED_VMEM_LIMIT_BYTES is not None:
         return _CACHED_VMEM_LIMIT_BYTES
@@ -112,9 +137,7 @@ def _get_vmem_limit_bytes(pltpu: object) -> int:
     # In interpret mode there is no real TPU; query the synthetic TPU info
     # registered by ``_ensure_cpu_tpu_info`` so the budget matches what real
     # TPU 7X reports rather than falling back to the conservative 16MB default.
-    from ..settings import is_pallas_interpret
-
-    if is_pallas_interpret():
+    if interpret:
         try:
             from jax._src.pallas.mosaic.tpu_info import registry
 
@@ -567,8 +590,6 @@ def _pallas_jnp_dtype_map() -> dict[str, object]:
 
 def _pallas_check_dtypes(args: tuple[object, ...]) -> None:
     """Raise if any tensor arg uses a dtype unsupported on TPU."""
-    from ..._compiler.backend import _PALLAS_UNSUPPORTED_DTYPES
-
     for a in args:
         if isinstance(a, torch.Tensor) and a.dtype in _PALLAS_UNSUPPORTED_DTYPES:
             raise TypeError(
@@ -1404,7 +1425,7 @@ def _pallas_check_vmem_or_raise(
         output_indices,
         pallas_aliases,
     )
-    vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
+    vmem_limit_bytes = _get_vmem_limit_bytes(pltpu, _pallas_interpret_enabled())
     if estimated_vmem > vmem_limit_bytes:
         raise RuntimeError(
             f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
@@ -1760,7 +1781,7 @@ def _pallas_install_launcher_cache(
     interpret = (
         _pallas_interpret
         if _pallas_interpret is not None
-        else _module_is_pallas_interpret()
+        else _pallas_interpret_enabled()
     )
     if interpret:
         _ensure_cpu_tpu_info()
@@ -2293,9 +2314,12 @@ def _pallas_compile_compact_jit_fn(
                 # already-sized allocation; do not use it to choose C.  A
                 # streamed compact_worklist kernel keeps the platform default.
                 vmem_limit_bytes=(
-                    max(_get_vmem_limit_bytes(pltpu), 128 * 1024 * 1024)
+                    max(
+                        _get_vmem_limit_bytes(pltpu, _pallas_interpret_enabled()),
+                        128 * 1024 * 1024,
+                    )
                     if ordered_aligned_arg_indices
-                    else _get_vmem_limit_bytes(pltpu)
+                    else _get_vmem_limit_bytes(pltpu, _pallas_interpret_enabled())
                 ),
             ),
             interpret=interpret,
@@ -2353,7 +2377,7 @@ def _pallas_install_compact_launcher_cache(
     interpret = (
         _pallas_interpret
         if _pallas_interpret is not None
-        else _module_is_pallas_interpret()
+        else _pallas_interpret_enabled()
     )
     if interpret:
         _ensure_cpu_tpu_info()

--- a/test/test_pallas_worklist.py
+++ b/test/test_pallas_worklist.py
@@ -1678,7 +1678,7 @@ class TestResidentCacheWindowGuard(unittest.TestCase):
         operands = [((total, 4, 128), 2), ((total, 4, 128), 2)]
         c = compact_ordered_physical_window(
             operands,
-            _get_vmem_limit_bytes(pltpu),
+            _get_vmem_limit_bytes(pltpu, False),
             128,
             prep_operands=operands,
         )


### PR DESCRIPTION
Stacked PRs:
 * #3186
 * #3184
 * #3181
 * #3187
 * #3190
 * __->__#3183


--- --- ---

### Make the Pallas launcher dependency-free (torch + jax only)


`helion/runtime/pallas/launcher.py` now imports only torch + jax (+ stdlib) --
no other `helion` module -- so the precompiler can bulk-export it into a
standalone Pallas kernel with zero Helion runtime dependency. Two helion deps
are severed:

- `_PALLAS_UNSUPPORTED_DTYPES` (the {int64,uint64,float64} frozenset TPU can't
  lower) moves from `helion/_compiler/backend.py` -- which only defined it for
  the launcher's import; nothing else used it -- into the launcher.
- `is_pallas_interpret` (from `helion.runtime.settings`) is replaced by a
  dep-free `_pallas_interpret_enabled()` env-var read at the launcher's own
  runtime call sites (the two `default_pallas_launcher` install-path fallbacks),
  where no `CompileEnvironment` is active so `is_pallas_interpret` already
  reduces to that env var (`Settings.pallas_interpret` itself defaults from it).

`_get_vmem_limit_bytes` is called both at runtime (launcher) and at compile time
(`_compiler/pallas/backend.py`, where a `CompileEnvironment` IS active), so
rather than have it read the env var it now takes `interpret` as a parameter:
the compiler passes `env.settings.pallas_interpret` (honoring decorator-set
interpret) and the launcher passes `_pallas_interpret_enabled()`. This keeps the
launcher dependency-free with no behavior change at either site -- mirroring how
the launcher install path already threads `_pallas_interpret` as a kwarg.

Verified on the TPU pod: non-interpret pallas add/topk/jax_fn and the
compact-worklist window/budget/guard/matmul tests pass; the launcher imports only
torch+jax. `ruff`/`pyrefly` clean (83 baseline); Triton `add` still correct on
H100. (Interpret-mode `add` tests fail identically on the base commit -- a
pre-existing pod JAX-version issue, not from this change.)
