### PR TITLE
Rename `aot_kernel` to `pretuned_kernel`

### DIFF
--- a/helion/__init__.py
+++ b/helion/__init__.py
@@ -10,6 +10,7 @@ from ._utils import cdiv
 from ._utils import next_power_of_2
 from .autotuner import aot_kernel
 from .autotuner import from_cache
+from .autotuner import pretuned_kernel
 from .runtime import Config
 from .runtime import Kernel
 from .runtime import PrecompilationInput
@@ -36,6 +37,7 @@ __all__ = [
     "language",
     "next_power_of_2",
     "precompile",
+    "pretuned_kernel",
     "runtime",
 ]
 

--- a/helion/autotuner/__init__.py
+++ b/helion/autotuner/__init__.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from .aot_cache import AOTAutotuneCache as AOTAutotuneCache
 from .aot_kernel import aot_kernel as aot_kernel
+from .aot_kernel import pretuned_kernel as pretuned_kernel
 from .config_fragment import BooleanFragment as BooleanFragment
 from .config_fragment import EnumFragment as EnumFragment
 from .config_fragment import IntegerFragment as IntegerFragment

--- a/helion/autotuner/aot_kernel.py
+++ b/helion/autotuner/aot_kernel.py
@@ -1,13 +1,14 @@
 """
-AOT Kernel Decorator
-====================
+Pretuned Kernel Decorator
+=========================
 
-Provides a simplified decorator for creating kernels with AOT (Ahead-of-Time)
-autotuning support. This decorator automatically configures the kernel for
-heuristic-based config selection.
+Provides a simplified decorator (``helion.pretuned_kernel``, formerly
+``helion.aot_kernel``) for creating kernels with AOT (Ahead-of-Time) autotuning
+support. This decorator automatically configures the kernel for heuristic-based
+config selection.
 
 Usage:
-    @helion.aot_kernel()
+    @helion.pretuned_kernel()
     def my_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         ...
 
@@ -338,7 +339,7 @@ class _AOTKernelDecorator:
 
 
 @overload
-def aot_kernel(
+def pretuned_kernel(
     fn: Callable[..., _R],
     *,
     config: ConfigLike | None = None,
@@ -351,7 +352,7 @@ def aot_kernel(
 
 
 @overload
-def aot_kernel(
+def pretuned_kernel(
     fn: None = None,
     *,
     config: ConfigLike | None = None,
@@ -363,7 +364,7 @@ def aot_kernel(
 ) -> _AOTKernelDecorator: ...
 
 
-def aot_kernel(
+def pretuned_kernel(
     fn: Callable[..., _R] | None = None,
     *,
     config: ConfigLike | None = None,
@@ -420,7 +421,7 @@ def aot_kernel(
         Kernel: A Kernel object configured for AOT autotuning.
 
     Example:
-        @helion.aot_kernel()
+        @helion.pretuned_kernel()
         def matmul(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
             m, k = a.shape
             _, n = b.shape
@@ -436,7 +437,7 @@ def aot_kernel(
         result = matmul(x, y)
 
         # Example with batched dimension:
-        @helion.aot_kernel(batched=[[0, None], None])
+        @helion.pretuned_kernel(batched=[[0, None], None])
         def rms_norm(x: torch.Tensor, eps: float) -> torch.Tensor:
             # x has shape (batch, hidden), first dim is batched
             ...
@@ -450,7 +451,7 @@ def aot_kernel(
             return [(torch.randn(1024, size, device="cuda"), 1e-5)
                     for size in range(128, 4096, 128)]
 
-        @helion.aot_kernel(
+        @helion.pretuned_kernel(
             batched=[[0, None], None],
             collect_fn=my_collect_inputs,
             measure_fn=my_measure_inputs,
@@ -473,11 +474,11 @@ def aot_kernel(
     user_key: KeyFunction | None = cast("KeyFunction | None", settings.pop("key", None))
 
     if fn is None:
-        # Called as @aot_kernel() - return a decorator
+        # Called as @pretuned_kernel() - return a decorator
         return cast(
             "_AOTKernelDecorator",
             functools.partial(
-                aot_kernel,
+                pretuned_kernel,
                 config=config,
                 configs=configs,
                 batched=batched,
@@ -515,3 +516,10 @@ def aot_kernel(
     k._aot_user_key = user_key  # type: ignore[attr-defined]
 
     return k
+
+
+# Deprecated alias: ``aot_kernel`` was renamed to ``pretuned_kernel`` to make
+# clear it is ahead-of-time pre-*tuning* (heuristic config selection), as opposed
+# to :func:`helion.precompile` pre-*compilation*. Kept as a backward-compatible
+# alias so existing ``helion.aot_kernel`` callers keep working unchanged.
+aot_kernel = pretuned_kernel


### PR DESCRIPTION
Stacked PRs:
 * #3189
 * __->__#3188
 * #3187
 * #3186
 * #3190
 * #3185
 * #3184
 * #3183
 * #3182
 * #3181
 * #3180
 * #3179


--- --- ---

### Rename `aot_kernel` to `pretuned_kernel`


Per the precompilation design, rename `aot_kernel` -> `pretuned_kernel` to make
clear it is ahead-of-time pre-*tuning* (heuristic config selection that still
runs the full Helion stack at call time), as distinct from the new
`helion.precompile` pre-*compilation* (a standalone, helion-free file).

`pretuned_kernel` is now the canonical decorator (exported from `helion` and
`helion.autotuner`). `helion.aot_kernel` is kept as a backward-compatible alias
(`aot_kernel = pretuned_kernel`) so existing callers -- including the
`pretuned_kernels/` and `examples/` -- keep working unchanged. The AOT
pre-tuning *machinery* (`AOTAutotuneCache`, `aot_key`, `HELION_AOT_MODE`, the
generated heuristic files) keeps the accurate "AOT" name; only the user-facing
decorator is renamed.

Verified on H100: `test_aot_autotuning` (24 passed); `helion.aot_kernel is
helion.pretuned_kernel`, both in `helion.__all__`. `ruff`/`pyrefly` clean (83
baseline).
