### PR TITLE
Stabilize ROCm autotune random seed tests

### DIFF
--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -138,8 +138,12 @@ class RecordingRandomSearch(RandomSearch):
         super().__init__(*args, **kwargs)
         self.samples: list[float] = []
 
-    def _autotune(self):
+    def _autotune(self) -> helion.Config:
         self.samples.append(random.random())
+        if torch.version.hip is not None:
+            # This test covers seed propagation, not benchmark behavior. Avoid
+            # competing GPU benchmarks across ROCm xdist workers.
+            return self.config_spec.default_config()
         return super()._autotune()
 
 


### PR DESCRIPTION
For ROCm, autotune times out and crashes the worker. For this test if we're on AMD, we will instead just output the default config, as this test is meant to test that the seed is fired -- not anything about autotuning