### PR TITLE
Add ellipsis indexing support in normal mode

### DIFF
--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -758,8 +758,41 @@ class TypePropagation(ast.NodeVisitor):
 
     def visit_Subscript(self, node: ast.Subscript) -> TypeInfo:
         value_type = self.visit(node.value)
+        if isinstance(value_type, TensorType):
+            self._expand_ellipsis_in_subscript(node, value_type.fake_value.ndim)
         slice_type = self.visit(node.slice)
         return value_type.propagate_getitem(slice_type, self.origin())
+
+    def _expand_ellipsis_in_subscript(self, node: ast.Subscript, ndim: int) -> None:
+        sl = node.slice
+        if isinstance(sl, ast.Constant) and sl.value is ...:
+            slices = [
+                create(ast.Slice, lower=None, upper=None, step=None)
+                for _ in range(ndim)
+            ]
+            node.slice = create(ast.Tuple, elts=slices, ctx=ast.Load())
+            return
+        if not isinstance(sl, ast.Tuple):
+            return
+        ellipsis_indices = [
+            i
+            for i, elt in enumerate(sl.elts)
+            if isinstance(elt, ast.Constant) and elt.value is ...
+        ]
+        if not ellipsis_indices:
+            return
+        idx = ellipsis_indices[0]
+        dims_consumed = sum(
+            1
+            for elt in sl.elts
+            if not (isinstance(elt, ast.Constant) and elt.value in (..., None))
+        )
+        n_expand = ndim - dims_consumed
+        slices = [
+            create(ast.Slice, lower=None, upper=None, step=None)
+            for _ in range(n_expand)
+        ]
+        sl.elts[idx : idx + 1] = slices
 
     def visit_Slice(self, node: ast.Slice) -> TypeInfo:
         lower = (

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -758,12 +758,14 @@ class TypePropagation(ast.NodeVisitor):
 
     def visit_Subscript(self, node: ast.Subscript) -> TypeInfo:
         value_type = self.visit(node.value)
+        # ellipsis expansion not yet supported for StackTensorType.
         if isinstance(value_type, TensorType):
             self._expand_ellipsis_in_subscript(node, value_type.fake_value.ndim)
         slice_type = self.visit(node.slice)
         return value_type.propagate_getitem(slice_type, self.origin())
 
     def _expand_ellipsis_in_subscript(self, node: ast.Subscript, ndim: int) -> None:
+        """Expand ellipsis to full-dim slices, idempotent."""
         sl = node.slice
         if isinstance(sl, ast.Constant) and sl.value is ...:
             slices = [
@@ -781,13 +783,24 @@ class TypePropagation(ast.NodeVisitor):
         ]
         if not ellipsis_indices:
             return
+        if len(ellipsis_indices) > 1:
+            raise exc.TypeInferenceError(
+                "an index can only have a single ellipsis (...)"
+            )
         idx = ellipsis_indices[0]
         dims_consumed = sum(
             1
             for elt in sl.elts
-            if not (isinstance(elt, ast.Constant) and elt.value in (..., None))
+            if not (
+                isinstance(elt, ast.Constant)
+                and (elt.value is ... or elt.value is None)
+            )
         )
         n_expand = ndim - dims_consumed
+        if n_expand < 0:
+            raise exc.TypeInferenceError(
+                f"too many indices for tensor of dimension {ndim}"
+            )
         slices = [
             create(ast.Slice, lower=None, upper=None, step=None)
             for _ in range(n_expand)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1840,9 +1840,6 @@ class TestIndexing(RefEagerTestBase, TestCase):
         expected[:, -1] = 1.0
         torch.testing.assert_close(result, expected)
 
-    @skipIfNormalMode(
-        "RankMismatch: Cannot assign a tensor of rank 2 to a buffer of rank 3"
-    )
     def test_ellipsis_indexing(self):
         """Test both setter from scalar and getter for [..., i]"""
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -11,6 +11,7 @@ from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 import helion
 from helion import _compat
+from helion import exc
 from helion._compat import get_tensor_descriptor_fn_name
 from helion._compat import supports_tensor_descriptor
 from helion._compat import use_tileir_tunables
@@ -1864,6 +1865,114 @@ class TestIndexing(RefEagerTestBase, TestCase):
         expected_dst = torch.ones([2, 3, N], device=DEVICE)
         torch.testing.assert_close(src_result, expected_src)
         torch.testing.assert_close(dst_result, expected_dst)
+
+    def test_ellipsis_trailing(self):
+        """Test trailing ellipsis: x[i, ...]"""
+
+        @helion.kernel(autotune_effort="none")
+        def kernel(
+            src: torch.Tensor, dst: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            N = src.shape[0]
+            for i in hl.grid(N):
+                dst[i, ...] = 1.0
+                src[i, ...] = dst[i, ...]
+            return src, dst
+
+        N = 8
+        src = torch.zeros([N, 4, 16], device=DEVICE)
+        dst = torch.zeros([N, 4, 16], device=DEVICE)
+
+        src_result, dst_result = kernel(src, dst)
+
+        expected = torch.ones([N, 4, 16], device=DEVICE)
+        torch.testing.assert_close(src_result, expected)
+        torch.testing.assert_close(dst_result, expected)
+
+    def test_ellipsis_middle(self):
+        """Test middle ellipsis: x[i, ..., j]"""
+
+        @helion.kernel(autotune_effort="none")
+        def kernel(x: torch.Tensor) -> torch.Tensor:
+            M, N = x.shape[0], x.shape[-1]
+            for i in hl.grid(M):
+                for j in hl.grid(N):
+                    x[i, ..., j] = 42.0
+            return x
+
+        x = torch.zeros([4, 8, 16], device=DEVICE)
+        result = kernel(x)
+
+        expected = torch.full([4, 8, 16], 42.0, device=DEVICE)
+        torch.testing.assert_close(result, expected)
+
+    def test_ellipsis_bare(self):
+        """Test bare ellipsis: x[...]"""
+
+        @helion.kernel(autotune_effort="none")
+        def kernel(x: torch.Tensor) -> torch.Tensor:
+            for _ in hl.grid(1):
+                x[...] = 7.0
+            return x
+
+        x = torch.zeros([4, 8], device=DEVICE)
+        result = kernel(x)
+
+        expected = torch.full([4, 8], 7.0, device=DEVICE)
+        torch.testing.assert_close(result, expected)
+
+    def test_ellipsis_with_none(self):
+        """Test ellipsis with None (newaxis): x[None, ..., i]"""
+
+        @helion.kernel(autotune_effort="none")
+        def kernel(x: torch.Tensor) -> torch.Tensor:
+            N = x.shape[-1]
+            for i in hl.grid(N):
+                x[None, ..., i] = 1.0
+            return x
+
+        x = torch.zeros([4, 8], device=DEVICE)
+        result = kernel(x)
+
+        expected = torch.ones([4, 8], device=DEVICE)
+        torch.testing.assert_close(result, expected)
+
+    @skipIfRefEager("Type inference errors are not raised in ref eager mode")
+    def test_ellipsis_multiple_error(self):
+        """Multiple ellipses should raise an error"""
+
+        @helion.kernel(autotune_effort="none")
+        def kernel(x: torch.Tensor) -> torch.Tensor:
+            for _ in hl.grid(1):
+                x[..., ...] = 1.0
+            return x
+
+        x = torch.zeros([4, 8], device=DEVICE)
+        with self.assertRaisesRegex(
+            exc.TypeInferenceError,
+            r"an index can only have a single ellipsis",
+        ):
+            code_and_output(kernel, (x,))
+
+    @skipIfRefEager("Type inference errors are not raised in ref eager mode")
+    def test_ellipsis_over_indexing_error(self):
+        """Too many indices with ellipsis should raise an error"""
+
+        @helion.kernel(autotune_effort="none")
+        def kernel(x: torch.Tensor) -> torch.Tensor:
+            M, N = x.shape
+            for i in hl.grid(M):
+                for j in hl.grid(N):
+                    for k in hl.grid(1):
+                        x[i, j, k, ...] = 1.0
+            return x
+
+        x = torch.zeros([4, 8], device=DEVICE)
+        with self.assertRaisesRegex(
+            exc.TypeInferenceError,
+            r"too many indices for tensor of dimension 2",
+        ):
+            code_and_output(kernel, (x,))
 
     @skipIfNormalMode(
         "RankMismatch: Cannot assign a tensor of rank 2 to a buffer of rank 3"


### PR DESCRIPTION
### Summary:
Adds ellipsis support in kernel tensor indexing by expanding it to equivalent full-slice  AST nodes during type propagation.

### Test:
` pytest test/test_indexing.py -k test_ellipsis_indexing -x -vv -s`
