### PR TITLE
Optimize CuTe codegen and kernels for NVFP4 GEMV; add pretuned NVFP4 GEMV CuTe benchmark

### DIFF
--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -1041,6 +1041,8 @@ class CuteBackend(Backend):
             "_cute_fp8e4m3fn_to_float32": "from helion._compiler.cute.quantized_helpers import fp8e4m3fn_to_float32 as _cute_fp8e4m3fn_to_float32",
             "_cute_fp8e4m3fn_x2_to_float32": "from helion._compiler.cute.quantized_helpers import fp8e4m3fn_x2_to_float32 as _cute_fp8e4m3fn_x2_to_float32",
             "_cute_float4_e2m1fn_x2_to_float32": "from helion._compiler.cute.quantized_helpers import float4_e2m1fn_x2_to_float32 as _cute_float4_e2m1fn_x2_to_float32",
+            "_cute_float4_e2m1fn_x16_to_float16": "from helion._compiler.cute.quantized_helpers import float4_e2m1fn_x16_to_float16 as _cute_float4_e2m1fn_x16_to_float16",
+            "_cute_bfloat16_x16_to_float16": "from helion._compiler.cute.quantized_helpers import bfloat16_x16_to_float16 as _cute_bfloat16_x16_to_float16",
             "_cute_grid_barrier": "from helion._compiler.cute.grid_barrier import grid_barrier as _cute_grid_barrier",
             "_cute_atomic_max_float32": "from helion._compiler.cute.atomic_helpers import atomic_max_float32 as _cute_atomic_max_float32",
             "_cute_atomic_min_float32": "from helion._compiler.cute.atomic_helpers import atomic_min_float32 as _cute_atomic_min_float32",
@@ -1056,6 +1058,18 @@ class CuteBackend(Backend):
         )
 
         class HelionCuteDSLOpOverrides(CuteDSLOpOverrides):
+            @staticmethod
+            def floordiv(a: CuteDSLArg, b: CuteDSLArg) -> CuteDSLArg:
+                return CuteDSLOpOverrides._apply_binary_op(a, b, "(({a}) // ({b}))")
+
+            @staticmethod
+            def mod(a: CuteDSLArg, b: CuteDSLArg) -> CuteDSLArg:
+                return CuteDSLOpOverrides._apply_binary_op(a, b, "(({a}) % ({b}))")
+
+            @staticmethod
+            def remainder(a: CuteDSLArg, b: CuteDSLArg) -> CuteDSLArg:
+                return HelionCuteDSLOpOverrides.mod(a, b)
+
             @staticmethod
             def where(
                 condition: CuteDSLArg,

--- a/helion/_compiler/cute/printer.py
+++ b/helion/_compiler/cute/printer.py
@@ -24,21 +24,21 @@ class HelionCutePrinter(HelionTritonPrinter):
 
     def _print_FloorDiv(self, expr: sympy.Expr) -> str:
         lhs, rhs = expr.args
-        return f"({self._print_basic_expr(lhs)} // {self._print_basic_expr(rhs)})"
+        return f"(({self._print_basic_expr(lhs)}) // ({self._print_basic_expr(rhs)}))"
 
     def _print_CleanDiv(self, expr: sympy.Expr) -> str:
         lhs, rhs = expr.args
-        return f"({self._print_basic_expr(lhs)} // {self._print_basic_expr(rhs)})"
+        return f"(({self._print_basic_expr(lhs)}) // ({self._print_basic_expr(rhs)}))"
 
     def _print_CeilDiv(self, expr: sympy.Expr) -> str:
         lhs, rhs = expr.args
         lhs_printed = self._print_basic_expr(lhs)
         rhs_printed = self._print_basic_expr(rhs)
-        return f"(({lhs_printed} + {rhs_printed} - 1) // {rhs_printed})"
+        return f"((({lhs_printed}) + ({rhs_printed}) - 1) // ({rhs_printed}))"
 
     def _print_PythonMod(self, expr: sympy.Expr) -> str:
         lhs, rhs = expr.args
-        return f"({self._print_basic_expr(lhs)} % {self._print_basic_expr(rhs)})"
+        return f"(({self._print_basic_expr(lhs)}) % ({self._print_basic_expr(rhs)}))"
 
 
 def cute_texpr(expr: sympy.Expr) -> str:

--- a/helion/_compiler/cute/quantized_helpers.py
+++ b/helion/_compiler/cute/quantized_helpers.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 
+from cutlass import Float16
 from cutlass import Float32
 from cutlass import Int8
 from cutlass import Int16
@@ -34,6 +35,22 @@ def _as_i16(
     if ir_type == "i16":
         return ir_value
     raise TypeError(f"unsupported quantized scalar type: {ir_type}")
+
+
+def _as_i64(
+    value: object,
+    *,
+    loc: ir.Location | None,
+    ip: ir.InsertionPoint | None,
+) -> ir.Value:
+    raw_value = getattr(value, "value", None)
+    if hasattr(raw_value, "type"):
+        ir_value = cast("Any", raw_value)
+    else:
+        ir_value = cast("Any", value).ir_value(loc=loc, ip=ip)
+    if str(cast("Any", ir_value).type) != "i64":
+        raise TypeError(f"expected packed i64 value, got {ir_value.type}")
+    return ir_value
 
 
 @dsl_user_op
@@ -142,4 +159,101 @@ def float4_e2m1fn_x2_to_float32(
     return (
         Float32(llvm.extractvalue(Float32.mlir_type, result, [0], loc=loc, ip=ip)),
         Float32(llvm.extractvalue(Float32.mlir_type, result, [1], loc=loc, ip=ip)),
+    )
+
+
+@dsl_user_op
+def float4_e2m1fn_x16_to_float16(
+    value: object,
+    *,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> tuple[Float16, ...]:
+    """Decode one packed 64-bit E2M1 group into sixteen FP16 values."""
+    value_i64 = _as_i64(value, loc=loc, ip=ip)
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal(  # pyrefly: ignore[missing-attribute]
+            [Float16.mlir_type] * 16
+        ),
+        [value_i64],
+        """
+        {
+          .reg .b32 lo, hi;
+          .reg .b8 c0,c1,c2,c3,c4,c5,c6,c7;
+          .reg .b32 h0,h1,h2,h3,h4,h5,h6,h7;
+          mov.b64 {lo, hi}, $16;
+          mov.b32 {c0,c1,c2,c3}, lo;
+          cvt.rn.f16x2.e2m1x2 h0, c0; cvt.rn.f16x2.e2m1x2 h1, c1;
+          cvt.rn.f16x2.e2m1x2 h2, c2; cvt.rn.f16x2.e2m1x2 h3, c3;
+          mov.b32 {c4,c5,c6,c7}, hi;
+          cvt.rn.f16x2.e2m1x2 h4, c4; cvt.rn.f16x2.e2m1x2 h5, c5;
+          cvt.rn.f16x2.e2m1x2 h6, c6; cvt.rn.f16x2.e2m1x2 h7, c7;
+          mov.b32 {$0,$1}, h0; mov.b32 {$2,$3}, h1;
+          mov.b32 {$4,$5}, h2; mov.b32 {$6,$7}, h3;
+          mov.b32 {$8,$9}, h4; mov.b32 {$10,$11}, h5;
+          mov.b32 {$12,$13}, h6; mov.b32 {$14,$15}, h7;
+        }
+        """,
+        ",".join(["=h"] * 16 + ["l"]),
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        Float16(llvm.extractvalue(Float16.mlir_type, result, [i], loc=loc, ip=ip))
+        for i in range(16)
+    )
+
+
+@dsl_user_op
+def bfloat16_x16_to_float16(
+    qword0: object,
+    qword1: object,
+    qword2: object,
+    qword3: object,
+    *,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> tuple[Float16, ...]:
+    """Convert four packed BF16 qwords into sixteen FP16 values."""
+    values_i64 = [
+        _as_i64(value, loc=loc, ip=ip) for value in (qword0, qword1, qword2, qword3)
+    ]
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal(  # pyrefly: ignore[missing-attribute]
+            [Float16.mlir_type] * 16
+        ),
+        values_i64,
+        """
+        {
+          .reg .b32 w0,w1,w2,w3,w4,w5,w6,w7;
+          .reg .b16 b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,b10,b11,b12,b13,b14,b15;
+          mov.b64 {w0,w1}, $16; mov.b64 {w2,w3}, $17;
+          mov.b64 {w4,w5}, $18; mov.b64 {w6,w7}, $19;
+          mov.b32 {b0,b1}, w0; mov.b32 {b2,b3}, w1;
+          mov.b32 {b4,b5}, w2; mov.b32 {b6,b7}, w3;
+          mov.b32 {b8,b9}, w4; mov.b32 {b10,b11}, w5;
+          mov.b32 {b12,b13}, w6; mov.b32 {b14,b15}, w7;
+          cvt.rn.f16.bf16 $0, b0; cvt.rn.f16.bf16 $1, b1;
+          cvt.rn.f16.bf16 $2, b2; cvt.rn.f16.bf16 $3, b3;
+          cvt.rn.f16.bf16 $4, b4; cvt.rn.f16.bf16 $5, b5;
+          cvt.rn.f16.bf16 $6, b6; cvt.rn.f16.bf16 $7, b7;
+          cvt.rn.f16.bf16 $8, b8; cvt.rn.f16.bf16 $9, b9;
+          cvt.rn.f16.bf16 $10, b10; cvt.rn.f16.bf16 $11, b11;
+          cvt.rn.f16.bf16 $12, b12; cvt.rn.f16.bf16 $13, b13;
+          cvt.rn.f16.bf16 $14, b14; cvt.rn.f16.bf16 $15, b15;
+        }
+        """,
+        ",".join(["=h"] * 16 + ["l"] * 4),
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        Float16(llvm.extractvalue(Float16.mlir_type, result, [i], loc=loc, ip=ip))
+        for i in range(16)
     )

--- a/helion/_compiler/cute/quantized_ops.py
+++ b/helion/_compiler/cute/quantized_ops.py
@@ -8,17 +8,18 @@ the same eager timing as before.
 
 from __future__ import annotations
 
+import ast
 from typing import TYPE_CHECKING
 
-from ... import exc
+import torch
+
 from ...language import _decorators
 from ...language.quantized_ops import float4_e2m1fn_x2_to_float32
+from ...language.quantized_ops import load_bfloat16_x16_to_float16
 from ...language.quantized_ops import load_float4_e2m1fn_x16_to_float16
 from ..ast_extension import expr_from_string
 
 if TYPE_CHECKING:
-    import ast
-
     from ..inductor_lowering import CodegenState
 
 
@@ -37,4 +38,63 @@ def _(state: CodegenState) -> list[ast.AST]:
 
 @_decorators.codegen(load_float4_e2m1fn_x16_to_float16, "cute")
 def _(state: CodegenState) -> list[ast.AST]:
-    raise exc.BackendUnsupported("cute", "load_float4_e2m1fn_x16_to_float16")
+    storage = state.proxy_arg(0)
+    if not isinstance(storage, torch.Tensor):
+        raise TypeError("load_float4_e2m1fn_x16_to_float16 storage must be a tensor")
+
+    base = state.device_function.tensor_arg(storage).name
+    group_offset = state.ast_arg(1)
+    extra_mask = state.ast_args[2]
+    load = expr_from_string(
+        f"cute.arch.load({base}.iterator + ({{offset}} * 8), cutlass.Uint64)",
+        offset=group_offset,
+    )
+    if extra_mask is not None:
+        assert isinstance(extra_mask, ast.AST)
+        load = expr_from_string(
+            "({load} if {mask} else cutlass.Uint64(0))",
+            load=load,
+            mask=extra_mask,
+        )
+    qword = state.codegen.lift(load, dce=True, prefix="fp4_qword")
+    call = expr_from_string(
+        "_cute_float4_e2m1fn_x16_to_float16({value})",
+        value=qword,
+    )
+    result = state.codegen.lift(call, dce=True, prefix="fp4_lanes")
+    return [expr_from_string(f"{result.id}[{i}]") for i in range(16)]
+
+
+@_decorators.codegen(load_bfloat16_x16_to_float16, "cute")
+def _(state: CodegenState) -> list[ast.AST]:
+    storage = state.proxy_arg(0)
+    if not isinstance(storage, torch.Tensor):
+        raise TypeError("load_bfloat16_x16_to_float16 storage must be a tensor")
+
+    base = state.device_function.tensor_arg(storage).name
+    group_offset = state.ast_arg(1)
+    extra_mask = state.ast_args[2]
+    qwords = []
+    for word in range(4):
+        load = expr_from_string(
+            f"cute.arch.load({base}.iterator + ({{offset}} * 16 + {word * 4}), "
+            "cutlass.Uint64)",
+            offset=group_offset,
+        )
+        if extra_mask is not None:
+            assert isinstance(extra_mask, ast.AST)
+            load = expr_from_string(
+                "({load} if {mask} else cutlass.Uint64(0))",
+                load=load,
+                mask=extra_mask,
+            )
+        qwords.append(state.codegen.lift(load, dce=True, prefix="bf16_qword"))
+    call = expr_from_string(
+        "_cute_bfloat16_x16_to_float16({q0}, {q1}, {q2}, {q3})",
+        q0=qwords[0],
+        q1=qwords[1],
+        q2=qwords[2],
+        q3=qwords[3],
+    )
+    result = state.codegen.lift(call, dce=True, prefix="bf16_lanes")
+    return [expr_from_string(f"{result.id}[{i}]") for i in range(16)]

--- a/helion/language/__init__.py
+++ b/helion/language/__init__.py
@@ -31,6 +31,7 @@ from .matmul_ops import dot_scaled as dot_scaled
 from .memory_ops import load as load
 from .memory_ops import store as store
 from .quantized_ops import float4_e2m1fn_x2_to_float32 as float4_e2m1fn_x2_to_float32
+from .quantized_ops import load_bfloat16_x16_to_float16 as load_bfloat16_x16_to_float16
 from .quantized_ops import (
     load_float4_e2m1fn_x16_to_float16 as load_float4_e2m1fn_x16_to_float16,
 )

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -7,6 +7,7 @@ from . import _decorators
 
 __all__ = [
     "float4_e2m1fn_x2_to_float32",
+    "load_bfloat16_x16_to_float16",
     "load_float4_e2m1fn_x16_to_float16",
 ]
 
@@ -29,6 +30,20 @@ def load_float4_e2m1fn_x16_to_float16(
 
     ``group_offsets`` indexes 8-byte groups relative to the start of contiguous
     ``torch.uint8`` or ``torch.float4_e2m1fn_x2`` storage.
+    """
+    raise exc.NotInsideKernel
+
+
+@_decorators.api(is_device_only=True, allow_host_tensor=True)
+def load_bfloat16_x16_to_float16(
+    storage: torch.Tensor,
+    group_offsets: torch.Tensor,
+    extra_mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """Load 16 contiguous BF16 values and convert them to FP16 lanes.
+
+    ``group_offsets`` indexes 16-value groups relative to the start of contiguous
+    BF16 storage.
     """
     raise exc.NotInsideKernel
 
@@ -56,6 +71,27 @@ def _(
         raise exc.InvalidAPIUsage(
             "hl.load_float4_e2m1fn_x16_to_float16 expects a "
             f"torch.uint8 or torch.float4_e2m1fn_x2 tensor, got {storage.dtype}"
+        )
+    return tuple(
+        torch.empty(
+            group_offsets.shape,
+            dtype=torch.float16,
+            device=group_offsets.device,
+        )
+        for _ in range(16)
+    )
+
+
+@_decorators.register_fake(load_bfloat16_x16_to_float16)
+def _(
+    storage: torch.Tensor,
+    group_offsets: torch.Tensor,
+    extra_mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, ...]:
+    if storage.dtype is not torch.bfloat16:
+        raise exc.InvalidAPIUsage(
+            "hl.load_bfloat16_x16_to_float16 expects bfloat16 storage, "
+            f"got {storage.dtype}"
         )
     return tuple(
         torch.empty(

--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -31,6 +31,7 @@ pretuned_kernels/
 ├── scaled_mm/
 ├── scale_mm_cute/                    # B200 CuTe (tcgen05) rowwise FP8 GEMM
 ├── nvfp4_gemv/                       # B200 Triton NVFP4 (W4A4 / W4A16) decode GEMV
+├── nvfp4_gemv_cute/                  # B200 Helion CuTe NVFP4 decode GEMV
 ├── silu_mul_fp8/                     # ported from vLLM (vllm/kernels/helion/ops)
 ├── dynamic_per_token_scaled_fp8_quant/
 ├── per_token_group_fp8_quant/
@@ -54,6 +55,7 @@ At runtime Helion picks the file matching the current GPU.
 | `scaled_mm` | vLLM Qwen3 FP8 `(K, N)` weight shapes at small token counts `M in {16, 64}` | `torch._scaled_mm` |
 | `scale_mm_cute` | Skinny-M FP8 decode + decoder-layer FP8 W8A8 serving `(M, K, N)` shapes (B200 CuTe backend only) | `torch._scaled_mm` (rowwise) + vLLM CUTLASS |
 | `nvfp4_gemv` | Decode (M=1) NVFP4 GEMV `(N, K)` weight shapes (Llama-3 / Qwen projections), W4A4 + W4A16 (B200 Triton backend) | NVFP4 dequant reference + vLLM CUTLASS `cutlass_scaled_fp4_mm` |
+| `nvfp4_gemv_cute` | Decode (M=1) NVFP4 GEMV `(N, K)` weight shapes, W4A4 + W4A16, using Helion kernels compiled with the CuTe backend on B200 | NVFP4 dequant reference + vLLM CUTLASS `cutlass_scaled_fp4_mm` |
 | `silu_mul_fp8` | vLLM `(num_tokens, intermediate)` decode shapes | torch-native silu-and-mul + fp8 quant |
 | `dynamic_per_token_scaled_fp8_quant` | vLLM `(num_tokens, hidden)` shapes | torch-native per-token fp8 quant |
 | `per_token_group_fp8_quant` | vLLM `(num_tokens, hidden, group)` shapes | torch-native per-group fp8 quant |

--- a/pretuned_kernels/nvfp4_gemv_cute/_helion_aot_nvfp4_gemv_cute_cuda_sm100.py
+++ b/pretuned_kernels/nvfp4_gemv_cute/_helion_aot_nvfp4_gemv_cute_cuda_sm100.py
@@ -1,0 +1,56 @@
+"""
+Pretuned B200 configs for the Helion CuTe NVFP4 GEMV kernels.
+
+These are actual ``@helion.aot_kernel(backend="cute")`` kernels. The configs
+come from the portable CuTe paths in ``examples/nvfp4_gemv.py`` and are used as
+shape-independent defaults for the decode sweep.
+"""
+
+_CONFIG_BF16IN = {
+    "block_sizes": [1, 128],
+    "indexing": ["pointer"] * 8,
+    "load_eviction_policies": [
+        "first",
+        "last",
+        "last",
+        "last",
+        "last",
+        "first",
+    ],
+    "num_threads": [1, 128],
+    "num_warps": 4,
+    "num_stages": 1,
+    "pid_type": "flat",
+    "range_warp_specializes": [None],
+}
+
+_CONFIG_FP4IN = {
+    "block_sizes": [1, 128],
+    "indexing": ["pointer"] * 5,
+    "load_eviction_policies": ["first", "last", "", "last"],
+    "num_threads": [1, 64],
+    "num_warps": 2,
+    "num_stages": 3,
+    "pid_type": "flat",
+    "range_warp_specializes": [None],
+}
+
+
+def key_nvfp4_gemv_bf16in_kernel(*args) -> int:
+    """Config index for the given args (also the cache key)."""
+    return 0
+
+
+def autotune_nvfp4_gemv_bf16in_kernel(*args) -> dict:
+    """Return the checked-in W4A16 CuTe config."""
+    return _CONFIG_BF16IN
+
+
+def key_nvfp4_gemv_fp4in_kernel(*args) -> int:
+    """Config index for the given args (also the cache key)."""
+    return 0
+
+
+def autotune_nvfp4_gemv_fp4in_kernel(*args) -> dict:
+    """Return the checked-in W4A4 CuTe config."""
+    return _CONFIG_FP4IN

--- a/pretuned_kernels/nvfp4_gemv_cute/_helion_aot_nvfp4_gemv_cute_cuda_sm100.py
+++ b/pretuned_kernels/nvfp4_gemv_cute/_helion_aot_nvfp4_gemv_cute_cuda_sm100.py
@@ -1,13 +1,13 @@
 """
 Pretuned B200 configs for the Helion CuTe NVFP4 GEMV kernels.
 
-These are actual ``@helion.aot_kernel(backend="cute")`` kernels. The configs
-come from the portable CuTe paths in ``examples/nvfp4_gemv.py`` and are used as
-shape-independent defaults for the decode sweep.
+These are actual ``@helion.aot_kernel(backend="cute")`` kernels. The defaults
+use 32 groups per block; W4A4 ``(N=4096, K=14336)`` uses 64 groups because its
+long reduction benefits more from fewer loop iterations than from occupancy.
 """
 
 _CONFIG_BF16IN = {
-    "block_sizes": [1, 128],
+    "block_sizes": [32],
     "indexing": ["pointer"] * 8,
     "load_eviction_policies": [
         "first",
@@ -17,7 +17,7 @@ _CONFIG_BF16IN = {
         "last",
         "first",
     ],
-    "num_threads": [1, 128],
+    "num_threads": [32],
     "num_warps": 4,
     "num_stages": 1,
     "pid_type": "flat",
@@ -25,32 +25,57 @@ _CONFIG_BF16IN = {
 }
 
 _CONFIG_FP4IN = {
-    "block_sizes": [1, 128],
+    "block_sizes": [32],
     "indexing": ["pointer"] * 5,
     "load_eviction_policies": ["first", "last", "", "last"],
-    "num_threads": [1, 64],
+    "num_threads": [32],
     "num_warps": 2,
     "num_stages": 3,
     "pid_type": "flat",
     "range_warp_specializes": [None],
 }
 
+_CONFIG_FP4IN_LONG_K = {**_CONFIG_FP4IN, "block_sizes": [64]}
 
-def key_nvfp4_gemv_bf16in_kernel(*args) -> int:
+
+def key_nvfp4_gemv_bf16in_rows2_kernel(*args) -> int:
     """Config index for the given args (also the cache key)."""
     return 0
 
 
-def autotune_nvfp4_gemv_bf16in_kernel(*args) -> dict:
+def autotune_nvfp4_gemv_bf16in_rows2_kernel(*args) -> dict:
     """Return the checked-in W4A16 CuTe config."""
     return _CONFIG_BF16IN
 
 
-def key_nvfp4_gemv_fp4in_kernel(*args) -> int:
+def key_nvfp4_gemv_bf16in_rows4_kernel(*args) -> int:
     """Config index for the given args (also the cache key)."""
     return 0
 
 
-def autotune_nvfp4_gemv_fp4in_kernel(*args) -> dict:
+def autotune_nvfp4_gemv_bf16in_rows4_kernel(*args) -> dict:
+    """Return the checked-in W4A16 CuTe config."""
+    return _CONFIG_BF16IN
+
+
+def key_nvfp4_gemv_fp4in_rows2_kernel(*args) -> int:
+    """Config index for the given args (also the cache key)."""
+    weight_bytes = args[0]
+    return int(weight_bytes.shape == (4096, 14336 // 2))
+
+
+def autotune_nvfp4_gemv_fp4in_rows2_kernel(*args) -> dict:
+    """Return the checked-in W4A4 CuTe config."""
+    if key_nvfp4_gemv_fp4in_rows2_kernel(*args):
+        return _CONFIG_FP4IN_LONG_K
+    return _CONFIG_FP4IN
+
+
+def key_nvfp4_gemv_fp4in_rows4_kernel(*args) -> int:
+    """Config index for the given args (also the cache key)."""
+    return 0
+
+
+def autotune_nvfp4_gemv_fp4in_rows4_kernel(*args) -> dict:
     """Return the checked-in W4A4 CuTe config."""
     return _CONFIG_FP4IN

--- a/pretuned_kernels/nvfp4_gemv_cute/nvfp4_gemv_cute.py
+++ b/pretuned_kernels/nvfp4_gemv_cute/nvfp4_gemv_cute.py
@@ -1,0 +1,402 @@
+"""Low-latency NVFP4 GEMV for decode (batch-size-1) inference on Blackwell --
+Helion CuTe (tcgen05) backend.
+
+The CuTe counterpart of ``pretuned_kernels/nvfp4_gemv`` (the Triton variant):
+same two decode regimes, same NVFP4 weight layout (packed E2M1 bytes with
+per-16-value E4M3 block scales in PyTorch's SWIZZLE_32_4_4 layout), but backed by
+actual Helion DSL kernels compiled with ``backend="cute"``:
+
+* :func:`_nvfp4_gemv_fp4in` -- NVFP4 weight * NVFP4 activation (W4A4).
+* :func:`_nvfp4_gemv_bf16in` -- NVFP4 weight * BF16 activation (W4A16).
+
+The kernels use the portable FP32-decode bodies from ``examples/nvfp4_gemv.py``
+and checked-in B200 CuTe configs. They go through Helion's normal compilation,
+configuration, caching, and launch path; there is no direct ``@cute.kernel`` or
+``default_cute_launcher`` shim.
+
+Benchmarked against the production vLLM CUTLASS NVFP4 GEMM
+(``ops.cutlass_scaled_fp4_mm`` -- the NVFP4 analog of ``cutlass_scaled_mm``,
+which has no dedicated GEMV, so decode is served by the M=1 GEMM) and
+``torch.compile`` of the NVFP4 dequant reference. The eager dequant reference is
+used only for a one-shot correctness check per shape (it is orders of magnitude
+slower than the kernel, so it is not a timed baseline).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING
+from typing import cast
+
+import torch
+
+import helion
+from helion._testing import import_path
+import helion.language as hl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_EXAMPLES_DIR = Path(__file__).resolve().parents[2] / "examples"
+_ex = import_path(_EXAMPLES_DIR / "nvfp4_gemv.py")
+make_fp8_scales = _ex.make_fp8_scales
+reference_nvfp4_gemv_fp4in = _ex.reference_nvfp4_gemv_fp4in
+reference_nvfp4_gemv_bf16in = _ex.reference_nvfp4_gemv_bf16in
+swizzled_scale_offsets = _ex.swizzled_scale_offsets
+
+# torch.compile of the NVFP4 dequant references -- a speedup-comparison baseline
+# only (correctness is checked against the eager reference).
+compiled_reference_nvfp4_gemv_fp4in = torch.compile(reference_nvfp4_gemv_fp4in)
+compiled_reference_nvfp4_gemv_bf16in = torch.compile(reference_nvfp4_gemv_bf16in)
+
+
+@helion.aot_kernel(backend="cute", static_shapes=True)
+def nvfp4_gemv_bf16in_kernel(
+    weight_fp4x2: torch.Tensor,
+    x_values: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out: torch.Tensor,
+    alpha: float = 1.0,
+) -> torch.Tensor:
+    """Helion CuTe W4A16 GEMV with FP32 accumulation."""
+    M, K_groups, _ = weight_fp4x2.shape
+    block_m = hl.register_block_size(1, 1)
+    block_k = hl.register_block_size(16, K_groups)
+
+    for tile_m in hl.tile(M, block_size=block_m):
+        row = tile_m.begin
+        acc = hl.zeros([], dtype=torch.float32)
+        for tile_k in hl.tile(K_groups, block_size=block_k):
+            contrib = hl.zeros([tile_k], dtype=torch.float32)
+            for byte in hl.static_range(8):
+                weight_lo, weight_hi = hl.float4_e2m1fn_x2_to_float32(
+                    weight_fp4x2[row, tile_k, byte]
+                )
+                contrib = contrib + weight_lo * x_values[tile_k, byte * 2].to(
+                    torch.float32
+                )
+                contrib = contrib + weight_hi * x_values[tile_k, byte * 2 + 1].to(
+                    torch.float32
+                )
+            scale_offsets = swizzled_scale_offsets(
+                cast("int", row), tile_k.index, K_groups
+            )
+            scale = hl.load(
+                weight_scale,
+                [scale_offsets],
+                extra_mask=tile_k.index < K_groups,
+            ).to(torch.float32)
+            acc = acc + (contrib * scale).sum()
+        out[row] = (acc * alpha).to(torch.bfloat16)
+    return out
+
+
+@helion.aot_kernel(backend="cute", static_shapes=True)
+def nvfp4_gemv_fp4in_kernel(
+    weight_fp4x2: torch.Tensor,
+    x_fp4x2: torch.Tensor,
+    weight_scale: torch.Tensor,
+    x_scale: torch.Tensor,
+    out: torch.Tensor,
+    alpha: float = 1.0,
+) -> torch.Tensor:
+    """Helion CuTe W4A4 GEMV with FP32 accumulation."""
+    M, K_groups, _ = weight_fp4x2.shape
+    block_m = hl.register_block_size(1, 1)
+    block_k = hl.register_block_size(16, K_groups)
+
+    for tile_m in hl.tile(M, block_size=block_m):
+        row = tile_m.begin
+        acc = hl.zeros([], dtype=torch.float32)
+        for tile_k in hl.tile(K_groups, block_size=block_k):
+            contrib = hl.zeros([tile_k], dtype=torch.float32)
+            for byte in hl.static_range(8):
+                weight_lo, weight_hi = hl.float4_e2m1fn_x2_to_float32(
+                    weight_fp4x2[row, tile_k, byte]
+                )
+                x_lo, x_hi = hl.float4_e2m1fn_x2_to_float32(x_fp4x2[tile_k, byte])
+                contrib = contrib + weight_lo * x_lo + weight_hi * x_hi
+            weight_scale_offsets = swizzled_scale_offsets(
+                cast("int", row), tile_k.index, K_groups
+            )
+            x_scale_offsets = swizzled_scale_offsets(
+                tile_k.index * 0, tile_k.index, K_groups
+            )
+            scale = hl.load(
+                weight_scale,
+                [weight_scale_offsets],
+                extra_mask=tile_k.index < K_groups,
+            ).to(torch.float32)
+            scale = scale * hl.load(
+                x_scale,
+                [x_scale_offsets],
+                extra_mask=tile_k.index < K_groups,
+            ).to(torch.float32)
+            acc = acc + (contrib * scale).sum()
+        out[row] = (acc * alpha).to(torch.bfloat16)
+    return out
+
+
+def _as_fp4x2(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dtype is torch.float4_e2m1fn_x2:
+        return tensor
+    if tensor.dtype is torch.uint8:
+        return tensor.view(torch.float4_e2m1fn_x2)
+    raise TypeError(f"expected uint8 or float4_e2m1fn_x2 tensor, got {tensor.dtype}")
+
+
+def _nvfp4_gemv_fp4in(
+    weight_packed: torch.Tensor,
+    x_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    x_scale: torch.Tensor,
+    alpha: float = 1.0,
+) -> torch.Tensor:
+    """Run the Helion CuTe W4A4 kernel."""
+    _ex._check_contiguous("weight_packed", weight_packed)
+    _ex._check_contiguous("x_packed", x_packed)
+    weight_fp4x2 = _as_fp4x2(weight_packed)
+    x_fp4x2 = _as_fp4x2(x_packed)
+    weight_bytes = weight_fp4x2.view(torch.uint8)
+    x_bytes = x_fp4x2.view(torch.uint8)
+    _ex._check_fp4_weight_storage("weight_packed", weight_bytes)
+    _ex._check_numel("x_packed", x_bytes, weight_bytes.shape[1])
+    groups = weight_bytes.shape[1] // 8
+    _ex._check_swizzled_scales(
+        "weight_scale", weight_scale, weight_bytes.shape[0], groups
+    )
+    _ex._check_swizzled_scales("x_scale", x_scale, 1, groups)
+    out = torch.empty(
+        weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
+    )
+    return nvfp4_gemv_fp4in_kernel(
+        weight_fp4x2.view(weight_bytes.shape[0], groups, 8),
+        x_fp4x2.view(groups, 8),
+        weight_scale.reshape(-1),
+        x_scale.reshape(-1),
+        out,
+        alpha,
+    )
+
+
+def _nvfp4_gemv_bf16in(
+    weight_packed: torch.Tensor,
+    x_bf16: torch.Tensor,
+    weight_scale: torch.Tensor,
+    alpha: float = 1.0,
+) -> torch.Tensor:
+    """Run the Helion CuTe W4A16 kernel."""
+    _ex._check_contiguous("weight_packed", weight_packed)
+    _ex._check_contiguous("x_bf16", x_bf16)
+    weight_fp4x2 = _as_fp4x2(weight_packed)
+    weight_bytes = weight_fp4x2.view(torch.uint8)
+    _ex._check_fp4_weight_storage("weight_packed", weight_bytes)
+    _ex._check_numel("x_bf16", x_bf16, weight_bytes.shape[1] * 2)
+    groups = weight_bytes.shape[1] // 8
+    _ex._check_swizzled_scales(
+        "weight_scale", weight_scale, weight_bytes.shape[0], groups
+    )
+    out = torch.empty(
+        weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
+    )
+    return nvfp4_gemv_bf16in_kernel(
+        weight_fp4x2.view(weight_bytes.shape[0], groups, 8),
+        x_bf16.view(groups, 16),
+        weight_scale.reshape(-1),
+        out,
+        alpha,
+    )
+
+
+def _check(
+    got: torch.Tensor, expected: torch.Tensor, variant: str, n: int, k: int
+) -> None:
+    """Correctness check vs the eager dequant reference (run once, never timed)."""
+    torch.testing.assert_close(
+        got.float(),
+        expected.float(),
+        atol=4.0,
+        rtol=2e-1,
+        msg=lambda m: f"{variant} N={n} K={k} mismatch vs reference:\n{m}",
+    )
+
+
+# Optional vLLM CUTLASS NVFP4 baseline (see the Triton variant for details).
+try:
+    from vllm import _custom_ops as _vllm_ops
+
+    _HAS_VLLM = hasattr(torch.ops._C, "cutlass_scaled_fp4_mm")
+    FLOAT4_E2M1_MAX = 6.0
+    FLOAT8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+except ImportError:
+    _vllm_ops = None
+    _HAS_VLLM = False
+
+
+def _vllm_quant_weight(weight_bf16: torch.Tensor) -> tuple:
+    amax = weight_bf16.abs().max().to(torch.float32)
+    global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / amax
+    weight_fp4, weight_sf = _vllm_ops.scaled_fp4_quant(weight_bf16, global_scale)
+    return weight_fp4, weight_sf, global_scale
+
+
+def _make_vllm_fp4in_call(
+    n: int, k: int, device: torch.device
+) -> Callable[[], torch.Tensor]:
+    """vLLM W4A4 decode baseline: activation pre-quantized, then the CUTLASS GEMM."""
+    weight_bf16 = torch.randn(n, k, device=device, dtype=torch.bfloat16)
+    x_bf16 = torch.randn(1, k, device=device, dtype=torch.bfloat16)
+    weight_fp4, weight_sf, weight_gs = _vllm_quant_weight(weight_bf16)
+    x_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / x_bf16.abs().max().to(torch.float32)
+    alpha = 1.0 / (x_gs * weight_gs)
+    x_fp4, x_sf = _vllm_ops.scaled_fp4_quant(x_bf16, x_gs)
+
+    def run() -> torch.Tensor:
+        return _vllm_ops.cutlass_scaled_fp4_mm(
+            x_fp4, weight_fp4, x_sf, weight_sf, alpha, torch.bfloat16
+        )
+
+    return run
+
+
+def _make_vllm_bf16in_call(
+    n: int, k: int, device: torch.device
+) -> Callable[[], torch.Tensor]:
+    """vLLM W4A16 decode baseline: quantize the BF16 activation on the fly, GEMM."""
+    weight_bf16 = torch.randn(n, k, device=device, dtype=torch.bfloat16)
+    x_bf16 = torch.randn(1, k, device=device, dtype=torch.bfloat16)
+    weight_fp4, weight_sf, weight_gs = _vllm_quant_weight(weight_bf16)
+    x_gs = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / x_bf16.abs().max().to(torch.float32)
+    alpha = 1.0 / (x_gs * weight_gs)
+
+    def run() -> torch.Tensor:
+        x_fp4, x_sf = _vllm_ops.scaled_fp4_quant(x_bf16, x_gs)
+        return _vllm_ops.cutlass_scaled_fp4_mm(
+            x_fp4, weight_fp4, x_sf, weight_sf, alpha, torch.bfloat16
+        )
+
+    return run
+
+
+def use_cudagraph() -> bool:
+    """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py).
+
+    True: decode (M=1) GEMVs are invoked one row at a time, where per-call host
+    launch overhead dominates -- exactly how vLLM issues them. CUDA graphs remove
+    that overhead; the shared _bench loop clears the L2 cache before every replay.
+    """
+    return True
+
+
+# Decode (M=1) NVFP4 GEMV weight shapes (N=output features, K=reduction dim) for
+# common projections. These match the Triton variant's shape coverage.
+SHAPES = [  # (N, K)
+    (4096, 4096),  # Llama-3-8B o_proj (square)
+    (6144, 4096),  # Llama-3-8B qkv_proj (q4096 + kv1024*2)
+    (28672, 4096),  # Llama-3-8B gate_up_proj (2 * 14336)
+    (4096, 14336),  # Llama-3-8B down_proj
+    (5120, 5120),  # 13B-class attention o_proj
+    (15360, 5120),  # 13B-class qkv_proj (3 * 5120)
+    (8192, 8192),  # 70B-class square projection (nvfp4_backend_comparison "o")
+    (10240, 8192),  # wide fused projection
+    (8192, 28672),  # nvfp4_backend_comparison "down": K_bytes=14336
+]
+
+_VARIANTS = ("fp4in", "bf16in")
+
+
+def _make_fp4in_inputs(n: int, k: int) -> tuple:
+    device = torch.device("cuda")
+    k_bytes = k // 2
+    weight = torch.randint(0, 256, (n, k_bytes), dtype=torch.uint8, device=device).view(
+        torch.float4_e2m1fn_x2
+    )
+    x = torch.randint(0, 256, (k_bytes,), dtype=torch.uint8, device=device).view(
+        torch.float4_e2m1fn_x2
+    )
+    weight_scale = make_fp8_scales((n, k_bytes // 8), device)
+    x_scale = make_fp8_scales((k_bytes // 8,), device)
+    return weight, x, weight_scale, x_scale
+
+
+def _make_bf16in_inputs(n: int, k: int) -> tuple:
+    device = torch.device("cuda")
+    k_bytes = k // 2
+    weight = torch.randint(0, 256, (n, k_bytes), dtype=torch.uint8, device=device).view(
+        torch.float4_e2m1fn_x2
+    )
+    x = torch.randn(k, dtype=torch.bfloat16, device=device)
+    weight_scale = make_fp8_scales((n, k_bytes // 8), device)
+    return weight, x, weight_scale
+
+
+def main(verbose: bool = True) -> dict:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep
+
+    device = torch.device("cuda")
+
+    def make_calls(entry: tuple[str, int, int]) -> tuple:
+        variant, n, k = entry
+        if variant == "fp4in":
+            weight, x, w_scale, x_scale = _make_fp4in_inputs(n, k)
+
+            def helion_call() -> torch.Tensor:
+                return _nvfp4_gemv_fp4in(weight, x, w_scale, x_scale)
+
+            _check(
+                helion_call(),
+                reference_nvfp4_gemv_fp4in(weight, x, w_scale, x_scale),
+                variant,
+                n,
+                k,
+            )
+
+            base_calls: list[tuple[str, Callable[[], torch.Tensor]]] = [
+                (
+                    "torch_compile",
+                    lambda: compiled_reference_nvfp4_gemv_fp4in(
+                        weight, x, w_scale, x_scale
+                    ),
+                ),
+            ]
+            if _HAS_VLLM:
+                base_calls.append(("cutlass", _make_vllm_fp4in_call(n, k, device)))
+        else:
+            weight, x, w_scale = _make_bf16in_inputs(n, k)
+
+            def helion_call() -> torch.Tensor:
+                return _nvfp4_gemv_bf16in(weight, x, w_scale)
+
+            _check(
+                helion_call(),
+                reference_nvfp4_gemv_bf16in(weight, x, w_scale),
+                variant,
+                n,
+                k,
+            )
+
+            base_calls = [
+                (
+                    "torch_compile",
+                    lambda: compiled_reference_nvfp4_gemv_bf16in(weight, x, w_scale),
+                ),
+            ]
+            if _HAS_VLLM:
+                base_calls.append(("cutlass", _make_vllm_bf16in_call(n, k, device)))
+        return helion_call, base_calls, f"{variant:>6s}  {n:>6d}  {k:>6d}"
+
+    entries = [(v, n, k) for v in _VARIANTS for (n, k) in SHAPES]
+    return run_sweep(
+        entries,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        verbose=verbose,
+        shape_header=f"{'kind':>6s}  {'N':>6s}  {'K':>6s}",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/nvfp4_gemv_cute/nvfp4_gemv_cute.py
+++ b/pretuned_kernels/nvfp4_gemv_cute/nvfp4_gemv_cute.py
@@ -1,5 +1,5 @@
 """Low-latency NVFP4 GEMV for decode (batch-size-1) inference on Blackwell --
-Helion CuTe (tcgen05) backend.
+Helion CuTe backend.
 
 The CuTe counterpart of ``pretuned_kernels/nvfp4_gemv`` (the Triton variant):
 same two decode regimes, same NVFP4 weight layout (packed E2M1 bytes with
@@ -9,10 +9,13 @@ actual Helion DSL kernels compiled with ``backend="cute"``:
 * :func:`_nvfp4_gemv_fp4in` -- NVFP4 weight * NVFP4 activation (W4A4).
 * :func:`_nvfp4_gemv_bf16in` -- NVFP4 weight * BF16 activation (W4A16).
 
-The kernels use the portable FP32-decode bodies from ``examples/nvfp4_gemv.py``
-and checked-in B200 CuTe configs. They go through Helion's normal compilation,
-configuration, caching, and launch path; there is no direct ``@cute.kernel`` or
-``default_cute_launcher`` shim.
+The kernels load each 16-value group as one aligned 64-bit word, decode FP4 (and
+BF16 activations) to FP16 with CuTe inline PTX, and accumulate in FP32. Programs
+compute two output rows for ``N <= 8192`` and four rows for wider outputs, which
+balances register pressure against activation reuse. Checked-in B200 CuTe
+configs select the reduction tile size. The implementation goes through
+Helion's normal compilation, configuration, caching, and launch path; there is
+no direct ``@cute.kernel`` or ``default_cute_launcher`` shim.
 
 Benchmarked against the production vLLM CUTLASS NVFP4 GEMM
 (``ops.cutlass_scaled_fp4_mm`` -- the NVFP4 analog of ``cutlass_scaled_mm``,
@@ -52,90 +55,317 @@ compiled_reference_nvfp4_gemv_fp4in = torch.compile(reference_nvfp4_gemv_fp4in)
 compiled_reference_nvfp4_gemv_bf16in = torch.compile(reference_nvfp4_gemv_bf16in)
 
 
+def _scaled_row_partial(
+    row: torch.SymInt,
+    tile_g: hl.Tile,
+    weight_bytes: torch.Tensor,
+    weight_scale: torch.Tensor,
+    x: tuple[torch.Tensor, ...],
+    x_scale_value: torch.Tensor | None,
+    groups: int,
+    rows: int,
+) -> torch.Tensor:
+    row_index = cast("int", row)
+    group_mask = tile_g.index < groups
+    row_mask = row_index < rows
+    weight = hl.load_float4_e2m1fn_x16_to_float16(
+        weight_bytes,
+        row_index * groups + tile_g.index,
+        extra_mask=group_mask & row_mask,
+    )
+    contribution = hl.zeros([tile_g], dtype=torch.float16)
+    for i in hl.static_range(16):
+        contribution = contribution + weight[i] * x[i]
+    scale_offsets = swizzled_scale_offsets(row_index, tile_g.index, groups)
+    scale = hl.load(
+        weight_scale,
+        [scale_offsets],
+        extra_mask=group_mask & row_mask,
+    ).to(torch.float32)
+    if x_scale_value is not None:
+        scale = scale * x_scale_value
+    return (contribution.to(torch.float32) * scale).sum()
+
+
 @helion.aot_kernel(backend="cute", static_shapes=True)
-def nvfp4_gemv_bf16in_kernel(
-    weight_fp4x2: torch.Tensor,
+def nvfp4_gemv_bf16in_rows2_kernel(
+    weight_bytes: torch.Tensor,
     x_values: torch.Tensor,
     weight_scale: torch.Tensor,
     out: torch.Tensor,
     alpha: float = 1.0,
 ) -> torch.Tensor:
-    """Helion CuTe W4A16 GEMV with FP32 accumulation."""
-    M, K_groups, _ = weight_fp4x2.shape
-    block_m = hl.register_block_size(1, 1)
-    block_k = hl.register_block_size(16, K_groups)
-
-    for tile_m in hl.tile(M, block_size=block_m):
-        row = tile_m.begin
-        acc = hl.zeros([], dtype=torch.float32)
-        for tile_k in hl.tile(K_groups, block_size=block_k):
-            contrib = hl.zeros([tile_k], dtype=torch.float32)
-            for byte in hl.static_range(8):
-                weight_lo, weight_hi = hl.float4_e2m1fn_x2_to_float32(
-                    weight_fp4x2[row, tile_k, byte]
-                )
-                contrib = contrib + weight_lo * x_values[tile_k, byte * 2].to(
-                    torch.float32
-                )
-                contrib = contrib + weight_hi * x_values[tile_k, byte * 2 + 1].to(
-                    torch.float32
-                )
-            scale_offsets = swizzled_scale_offsets(
-                cast("int", row), tile_k.index, K_groups
+    """Helion CuTe W4A16 GEMV with coalesced FP4 decode."""
+    M, K_bytes = weight_bytes.shape
+    K_groups = K_bytes // 8
+    block_g = hl.register_block_size(16, K_groups)
+    for program in hl.grid((M + 1) // 2):
+        row0 = program * 2
+        row1 = row0 + 1
+        acc0 = hl.zeros([], dtype=torch.float32)
+        acc1 = hl.zeros([], dtype=torch.float32)
+        for tile_g in hl.tile(K_groups, block_size=block_g):
+            group_mask = tile_g.index < K_groups
+            x = hl.load_bfloat16_x16_to_float16(
+                x_values,
+                tile_g.index,
+                extra_mask=group_mask,
             )
-            scale = hl.load(
-                weight_scale,
-                [scale_offsets],
-                extra_mask=tile_k.index < K_groups,
-            ).to(torch.float32)
-            acc = acc + (contrib * scale).sum()
-        out[row] = (acc * alpha).to(torch.bfloat16)
+            acc0 = acc0 + _scaled_row_partial(
+                row0, tile_g, weight_bytes, weight_scale, x, None, K_groups, M
+            )
+            acc1 = acc1 + _scaled_row_partial(
+                row1, tile_g, weight_bytes, weight_scale, x, None, K_groups, M
+            )
+        hl.store(
+            out,
+            [row0],
+            (acc0 * alpha).to(torch.bfloat16),
+            extra_mask=row0 < M,
+        )
+        hl.store(
+            out,
+            [row1],
+            (acc1 * alpha).to(torch.bfloat16),
+            extra_mask=row1 < M,
+        )
     return out
 
 
 @helion.aot_kernel(backend="cute", static_shapes=True)
-def nvfp4_gemv_fp4in_kernel(
-    weight_fp4x2: torch.Tensor,
-    x_fp4x2: torch.Tensor,
+def nvfp4_gemv_fp4in_rows2_kernel(
+    weight_bytes: torch.Tensor,
+    x_bytes: torch.Tensor,
     weight_scale: torch.Tensor,
     x_scale: torch.Tensor,
     out: torch.Tensor,
     alpha: float = 1.0,
 ) -> torch.Tensor:
-    """Helion CuTe W4A4 GEMV with FP32 accumulation."""
-    M, K_groups, _ = weight_fp4x2.shape
-    block_m = hl.register_block_size(1, 1)
-    block_k = hl.register_block_size(16, K_groups)
-
-    for tile_m in hl.tile(M, block_size=block_m):
-        row = tile_m.begin
-        acc = hl.zeros([], dtype=torch.float32)
-        for tile_k in hl.tile(K_groups, block_size=block_k):
-            contrib = hl.zeros([tile_k], dtype=torch.float32)
-            for byte in hl.static_range(8):
-                weight_lo, weight_hi = hl.float4_e2m1fn_x2_to_float32(
-                    weight_fp4x2[row, tile_k, byte]
-                )
-                x_lo, x_hi = hl.float4_e2m1fn_x2_to_float32(x_fp4x2[tile_k, byte])
-                contrib = contrib + weight_lo * x_lo + weight_hi * x_hi
-            weight_scale_offsets = swizzled_scale_offsets(
-                cast("int", row), tile_k.index, K_groups
+    """Helion CuTe W4A4 GEMV with coalesced FP4 decode."""
+    M, K_bytes = weight_bytes.shape
+    K_groups = K_bytes // 8
+    block_g = hl.register_block_size(16, K_groups)
+    for program in hl.grid((M + 1) // 2):
+        row0 = program * 2
+        row1 = row0 + 1
+        acc0 = hl.zeros([], dtype=torch.float32)
+        acc1 = hl.zeros([], dtype=torch.float32)
+        for tile_g in hl.tile(K_groups, block_size=block_g):
+            group_mask = tile_g.index < K_groups
+            x = hl.load_float4_e2m1fn_x16_to_float16(
+                x_bytes,
+                tile_g.index,
+                extra_mask=group_mask,
             )
             x_scale_offsets = swizzled_scale_offsets(
-                tile_k.index * 0, tile_k.index, K_groups
+                tile_g.index * 0, tile_g.index, K_groups
             )
-            scale = hl.load(
-                weight_scale,
-                [weight_scale_offsets],
-                extra_mask=tile_k.index < K_groups,
-            ).to(torch.float32)
-            scale = scale * hl.load(
+            x_scale_value = hl.load(
                 x_scale,
                 [x_scale_offsets],
-                extra_mask=tile_k.index < K_groups,
+                extra_mask=group_mask,
             ).to(torch.float32)
-            acc = acc + (contrib * scale).sum()
-        out[row] = (acc * alpha).to(torch.bfloat16)
+            acc0 = acc0 + _scaled_row_partial(
+                row0,
+                tile_g,
+                weight_bytes,
+                weight_scale,
+                x,
+                x_scale_value,
+                K_groups,
+                M,
+            )
+            acc1 = acc1 + _scaled_row_partial(
+                row1,
+                tile_g,
+                weight_bytes,
+                weight_scale,
+                x,
+                x_scale_value,
+                K_groups,
+                M,
+            )
+        hl.store(
+            out,
+            [row0],
+            (acc0 * alpha).to(torch.bfloat16),
+            extra_mask=row0 < M,
+        )
+        hl.store(
+            out,
+            [row1],
+            (acc1 * alpha).to(torch.bfloat16),
+            extra_mask=row1 < M,
+        )
+    return out
+
+
+@helion.aot_kernel(backend="cute", static_shapes=True)
+def nvfp4_gemv_bf16in_rows4_kernel(
+    weight_bytes: torch.Tensor,
+    x_values: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out: torch.Tensor,
+    alpha: float,
+) -> torch.Tensor:
+    M, K_bytes = weight_bytes.shape
+    K_groups = K_bytes // 8
+    block_g = hl.register_block_size(16, K_groups)
+    for program in hl.grid((M + 3) // 4):
+        row0 = program * 4
+        row1 = row0 + 1
+        row2 = row0 + 2
+        row3 = row0 + 3
+        acc0 = hl.zeros([], dtype=torch.float32)
+        acc1 = hl.zeros([], dtype=torch.float32)
+        acc2 = hl.zeros([], dtype=torch.float32)
+        acc3 = hl.zeros([], dtype=torch.float32)
+        for tile_g in hl.tile(K_groups, block_size=block_g):
+            group_mask = tile_g.index < K_groups
+            x = hl.load_bfloat16_x16_to_float16(
+                x_values,
+                tile_g.index,
+                extra_mask=group_mask,
+            )
+            acc0 = acc0 + _scaled_row_partial(
+                row0, tile_g, weight_bytes, weight_scale, x, None, K_groups, M
+            )
+            acc1 = acc1 + _scaled_row_partial(
+                row1, tile_g, weight_bytes, weight_scale, x, None, K_groups, M
+            )
+            acc2 = acc2 + _scaled_row_partial(
+                row2, tile_g, weight_bytes, weight_scale, x, None, K_groups, M
+            )
+            acc3 = acc3 + _scaled_row_partial(
+                row3, tile_g, weight_bytes, weight_scale, x, None, K_groups, M
+            )
+        hl.store(
+            out,
+            [row0],
+            (acc0 * alpha).to(torch.bfloat16),
+            extra_mask=row0 < M,
+        )
+        hl.store(
+            out,
+            [row1],
+            (acc1 * alpha).to(torch.bfloat16),
+            extra_mask=row1 < M,
+        )
+        hl.store(
+            out,
+            [row2],
+            (acc2 * alpha).to(torch.bfloat16),
+            extra_mask=row2 < M,
+        )
+        hl.store(
+            out,
+            [row3],
+            (acc3 * alpha).to(torch.bfloat16),
+            extra_mask=row3 < M,
+        )
+    return out
+
+
+@helion.aot_kernel(backend="cute", static_shapes=True)
+def nvfp4_gemv_fp4in_rows4_kernel(
+    weight_bytes: torch.Tensor,
+    x_bytes: torch.Tensor,
+    weight_scale: torch.Tensor,
+    x_scale: torch.Tensor,
+    out: torch.Tensor,
+    alpha: float,
+) -> torch.Tensor:
+    M, K_bytes = weight_bytes.shape
+    K_groups = K_bytes // 8
+    block_g = hl.register_block_size(16, K_groups)
+    for program in hl.grid((M + 3) // 4):
+        row0 = program * 4
+        row1 = row0 + 1
+        row2 = row0 + 2
+        row3 = row0 + 3
+        acc0 = hl.zeros([], dtype=torch.float32)
+        acc1 = hl.zeros([], dtype=torch.float32)
+        acc2 = hl.zeros([], dtype=torch.float32)
+        acc3 = hl.zeros([], dtype=torch.float32)
+        for tile_g in hl.tile(K_groups, block_size=block_g):
+            group_mask = tile_g.index < K_groups
+            x = hl.load_float4_e2m1fn_x16_to_float16(
+                x_bytes,
+                tile_g.index,
+                extra_mask=group_mask,
+            )
+            x_scale_offsets = swizzled_scale_offsets(
+                tile_g.index * 0, tile_g.index, K_groups
+            )
+            x_scale_value = hl.load(
+                x_scale,
+                [x_scale_offsets],
+                extra_mask=group_mask,
+            ).to(torch.float32)
+            acc0 = acc0 + _scaled_row_partial(
+                row0,
+                tile_g,
+                weight_bytes,
+                weight_scale,
+                x,
+                x_scale_value,
+                K_groups,
+                M,
+            )
+            acc1 = acc1 + _scaled_row_partial(
+                row1,
+                tile_g,
+                weight_bytes,
+                weight_scale,
+                x,
+                x_scale_value,
+                K_groups,
+                M,
+            )
+            acc2 = acc2 + _scaled_row_partial(
+                row2,
+                tile_g,
+                weight_bytes,
+                weight_scale,
+                x,
+                x_scale_value,
+                K_groups,
+                M,
+            )
+            acc3 = acc3 + _scaled_row_partial(
+                row3,
+                tile_g,
+                weight_bytes,
+                weight_scale,
+                x,
+                x_scale_value,
+                K_groups,
+                M,
+            )
+        hl.store(
+            out,
+            [row0],
+            (acc0 * alpha).to(torch.bfloat16),
+            extra_mask=row0 < M,
+        )
+        hl.store(
+            out,
+            [row1],
+            (acc1 * alpha).to(torch.bfloat16),
+            extra_mask=row1 < M,
+        )
+        hl.store(
+            out,
+            [row2],
+            (acc2 * alpha).to(torch.bfloat16),
+            extra_mask=row2 < M,
+        )
+        hl.store(
+            out,
+            [row3],
+            (acc3 * alpha).to(torch.bfloat16),
+            extra_mask=row3 < M,
+        )
     return out
 
 
@@ -171,9 +401,14 @@ def _nvfp4_gemv_fp4in(
     out = torch.empty(
         weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
     )
-    return nvfp4_gemv_fp4in_kernel(
-        weight_fp4x2.view(weight_bytes.shape[0], groups, 8),
-        x_fp4x2.view(groups, 8),
+    kernel = (
+        nvfp4_gemv_fp4in_rows4_kernel
+        if weight_bytes.shape[0] > 8192
+        else nvfp4_gemv_fp4in_rows2_kernel
+    )
+    return kernel(
+        weight_bytes,
+        x_bytes,
         weight_scale.reshape(-1),
         x_scale.reshape(-1),
         out,
@@ -201,8 +436,13 @@ def _nvfp4_gemv_bf16in(
     out = torch.empty(
         weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
     )
-    return nvfp4_gemv_bf16in_kernel(
-        weight_fp4x2.view(weight_bytes.shape[0], groups, 8),
+    kernel = (
+        nvfp4_gemv_bf16in_rows4_kernel
+        if weight_bytes.shape[0] > 8192
+        else nvfp4_gemv_bf16in_rows2_kernel
+    )
+    return kernel(
+        weight_bytes,
         x_bf16.view(groups, 16),
         weight_scale.reshape(-1),
         out,

--- a/pretuned_kernels/run.py
+++ b/pretuned_kernels/run.py
@@ -43,6 +43,7 @@ KERNELS = [
     "scaled_mm",
     "scale_mm_cute",
     "nvfp4_gemv",
+    "nvfp4_gemv_cute",
     "cross_entropy",
     # Ported from vLLM (vllm/kernels/helion/ops); torch-native baselines.
     "silu_mul_fp8",

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1173,6 +1173,36 @@ class TestTritonExactGelu(RefEagerTestBase, TestCase):
         self.assertIn("tl.bfloat16", code)
 
 
+class TestHelionCutePrinter(TestCase):
+    def test_compound_division_operands_are_parenthesized(self) -> None:
+        import sympy
+        from torch.utils._sympy.functions import CeilDiv
+        from torch.utils._sympy.functions import CleanDiv
+        from torch.utils._sympy.functions import FloorDiv
+        from torch.utils._sympy.functions import PythonMod
+
+        from helion._compiler.cute.printer import cute_texpr
+
+        x = sympy.Symbol("x", integer=True)
+        expressions = (
+            FloorDiv(2 * x + 1, 128),
+            PythonMod(2 * x + 1, 32),
+            sympy.Function.__new__(
+                CleanDiv, 2 * x + 1, sympy.Integer(128), evaluate=False
+            ),
+            sympy.Function.__new__(
+                CeilDiv, 2 * x + 1, sympy.Integer(128), evaluate=False
+            ),
+        )
+        for expression in expressions:
+            rendered = cute_texpr(expression)
+            for value in (0, 31, 64, 129):
+                self.assertEqual(
+                    eval(rendered, {"__builtins__": {}}, {"x": value}),
+                    int(expression.subs(x, value)),
+                )
+
+
 @onlyBackends(["triton"])
 class TestHelionTritonPrinter(TestCase):
     """Tests for the HelionTritonPrinter class."""

--- a/test/test_quantized_ops.py
+++ b/test/test_quantized_ops.py
@@ -95,6 +95,85 @@ class TestCuteQuantizedOps(RefEagerTestDisabled, TestCase):
         torch.testing.assert_close(hi, _dequant_e2m1((raw_i32 >> 4) & 0xF))
         self.assertIn("_cute_float4_e2m1fn_x2_to_float32", code)
 
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan(
+        (10, 0), reason="FP4 conversion instructions require Blackwell"
+    )
+    def test_load_float4_e2m1fn_x16_to_float16(self):
+        @helion.kernel(autotune_effort="none", static_shapes=True)
+        def fp4_to_f16_lanes(x: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                (offsets.size(0), 16), dtype=torch.float16, device=x.device
+            )
+            for tile in hl.tile(offsets.size(0), block_size=4):
+                lanes = hl.load_float4_e2m1fn_x16_to_float16(
+                    x,
+                    offsets[tile],
+                    extra_mask=tile.index < offsets.size(0),
+                )
+                for i in hl.static_range(16):
+                    out[tile, i] = lanes[i]
+            return out
+
+        raw = torch.arange(16, dtype=torch.uint8, device=DEVICE) * 17
+        offsets = torch.tensor([0, 1], dtype=torch.int64, device=DEVICE)
+        code, result = code_and_output(fp4_to_f16_lanes, (raw, offsets))
+
+        raw_i32 = raw.view(2, 8).to(torch.int32)
+        nibbles = torch.stack((raw_i32 & 0xF, (raw_i32 >> 4) & 0xF), dim=-1)
+        expected = _dequant_e2m1(nibbles.reshape(2, 16)).to(torch.float16)
+        torch.testing.assert_close(result, expected)
+        self.assertIn("cute.arch.load", code)
+        self.assertIn("cutlass.Uint64", code)
+        self.assertIn("_cute_float4_e2m1fn_x16_to_float16", code)
+
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan(
+        (10, 0), reason="Packed BF16 conversion requires Blackwell"
+    )
+    def test_load_bfloat16_x16_to_float16(self):
+        @helion.kernel(autotune_effort="none", static_shapes=True)
+        def bf16_to_f16_lanes(x: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                (offsets.size(0), 16), dtype=torch.float16, device=x.device
+            )
+            for tile in hl.tile(offsets.size(0), block_size=4):
+                lanes = hl.load_bfloat16_x16_to_float16(
+                    x,
+                    offsets[tile],
+                    extra_mask=tile.index < offsets.size(0),
+                )
+                for i in hl.static_range(16):
+                    out[tile, i] = lanes[i]
+            return out
+
+        values = torch.randn(32, dtype=torch.bfloat16, device=DEVICE)
+        offsets = torch.tensor([0, 1], dtype=torch.int64, device=DEVICE)
+        code, result = code_and_output(bf16_to_f16_lanes, (values, offsets))
+
+        torch.testing.assert_close(result, values.view(2, 16).to(torch.float16))
+        self.assertIn("cute.arch.load", code)
+        self.assertIn("_cute_bfloat16_x16_to_float16", code)
+
+    @skipIfNotCUDA()
+    def test_grouped_row_index_precedence(self):
+        @helion.kernel(autotune_effort="none", static_shapes=True)
+        def grouped_row_indices(out: torch.Tensor) -> torch.Tensor:
+            for program in hl.grid(out.size(0)):
+                row = program * 2 + 1
+                out[program] = (row // 128) * 100 + row % 32
+            return out
+
+        out = torch.empty(130, dtype=torch.int64, device=DEVICE)
+        code, result = code_and_output(grouped_row_indices, (out,))
+
+        program = torch.arange(130, dtype=torch.int64, device=DEVICE)
+        row = program * 2 + 1
+        expected = (row // 128) * 100 + row % 32
+        torch.testing.assert_close(result, expected)
+        self.assertIn("//", code)
+        self.assertIn("%", code)
+
 
 @onlyBackends(["triton"])
 class TestTritonQuantizedOps(RefEagerTestDisabled, TestCase):


### PR DESCRIPTION
## Summary

  Improve the Helion CuTe NVFP4 GEMV kernel on B200 using packed codegen and shape-adaptive scheduling.

  ## Changes

  - Add aligned 64-bit CuTe loads and inline PTX conversion for:
      - 16 packed E2M1 FP4 values → FP16
      - 16 BF16 values → FP16

  - Compute multiple output rows per program:
      - 2 rows when N <= 8192
      - 4 rows for wider outputs

  - Hoist W4A4 activation-scale loads outside per-row work.
  - Add masked tail stores for output sizes not divisible by 2 or 4.
  - Add a tuned 64-group configuration for W4A4 (N=4096, K=14336).
  - Fix operand precedence for CuTe floor division, modulo, CleanDiv, and CeilDiv.
  - Update the kernel documentation and add regression tests.

  ## Performance

  B200, cold-L2 CUDA-graph benchmark against CUTLASS:

   Metric             Before          After
  ━━━━━━━━━━━━━━━━━  ━━━━━━━━  ━━━━━━━━━━━━━
   Wins vs CUTLASS      0/18    up to 15/18
  ─────────────────  ────────  ─────────────
   Geometric mean     0.329×         1.133×

  Contended repeat: 14/18 wins and 1.099× geometric mean.

  The remaining consistent losses are the longest BF16-input reductions; targeted config sweeps indicate these need
  further codegen improvements rather than different launch configs.

  ## Testing

  - All 18 benchmark shapes pass reference correctness checks.
  - Tail correctness tested with non-divisible row counts.
  - Targeted CuTe tests: 6 passed, 2 skipped.
  - Ruff, formatting, codespell, and git diff --check pass.
  - Full CuTe suite: 1827 passed, 1235 skipped; remaining failures are unrelated existing CuTe backend gaps.
