### PR TITLE
[cute] refactor: add generic tcgen05 fragment epilogues instead of strict allowlist

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import ast
 import collections
 import dataclasses
 import functools
@@ -3018,6 +3017,7 @@ def _grouped_rank3_specialized_mma_plan(
 def _analyzed_specialized_mma_plan(
     node: torch.fx.Node,
     *,
+    fn: DeviceFunction,
     k_block_id: int,
     bk: int,
     config: Config,
@@ -3026,6 +3026,7 @@ def _analyzed_specialized_mma_plan(
     from .cute.cute_mma import _choose_mma_impl
     from .cute.cute_mma import _mma_tiles_are_static_full
     from .cute.cute_mma import analyze_cute_mma_node
+    from .cute.cute_mma import ensure_tcgen05_pair_epilogue_plan
 
     candidate = analyze_cute_mma_node(node)
     if (
@@ -3055,6 +3056,16 @@ def _analyzed_specialized_mma_plan(
         input_device=lhs_val.device,
     )
     if mma_impl == "universal":
+        return None
+    if mma_impl == "tcgen05" and not ensure_tcgen05_pair_epilogue_plan(
+        fn,
+        node,
+        candidate,
+        bm=bm,
+        bn=bn,
+        bk=bk,
+        config=config,
+    ):
         return None
     return _SpecializedMmaPlan(mma_impl, *root_mn_block_ids)
 
@@ -3089,6 +3100,7 @@ def _kernel_specialized_mma_plan(
         for node in graph_info.graph.nodes:
             plan = _analyzed_specialized_mma_plan(
                 node,
+                fn=fn,
                 k_block_id=block_ids[0],
                 bk=bk,
                 config=config,

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -263,6 +263,7 @@ def _detect_specialized_mma_loop(
     from .cute_mma import _choose_mma_impl
     from .cute_mma import _mma_tiles_are_static_full
     from .cute_mma import analyze_cute_mma_node
+    from .cute_mma import ensure_tcgen05_pair_epilogue_plan
 
     if _detect_grouped_rank3_specialized_mma_loop(
         fn,
@@ -291,11 +292,11 @@ def _detect_specialized_mma_loop(
                 and candidate.operands.k_block_id == block_ids[0]
                 and _specialized_mma_root_mn_block_ids(candidate, config) is not None
             ):
-                candidates.append(candidate)
+                candidates.append((node, candidate))
     if not candidates:
         return False
 
-    root_mn_block_ids = _specialized_mma_root_mn_block_ids(candidates[0], config)
+    root_mn_block_ids = _specialized_mma_root_mn_block_ids(candidates[0][1], config)
     assert root_mn_block_ids is not None
     root_layout = _specialized_mma_root_thread_layout(root_mn_block_ids, config)
     if root_layout is None:
@@ -305,15 +306,15 @@ def _detect_specialized_mma_loop(
     if not isinstance(bk, int):
         return False
     candidates = [
-        candidate
-        for candidate in candidates
+        (node, candidate)
+        for node, candidate in candidates
         if not candidate.operands.has_leading_passthrough
         or _mma_tiles_are_static_full(candidate.operands, bm=bm, bn=bn, bk=bk)
     ]
     if not candidates:
         return False
 
-    for candidate in candidates:
+    for node, candidate in candidates:
         lhs_val = candidate.operands.lhs.source_fake
         mma_impl = _choose_mma_impl(
             lhs_val.dtype,
@@ -340,6 +341,16 @@ def _detect_specialized_mma_loop(
             root_m_threads=root_m_threads,
             root_n_threads=root_n_threads,
         ):
+            if mma_impl == "tcgen05" and not ensure_tcgen05_pair_epilogue_plan(
+                fn,
+                node,
+                candidate,
+                bm=bm,
+                bn=bn,
+                bk=bk,
+                config=config,
+            ):
+                continue
             return True
     return False
 

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -24,7 +24,6 @@ verified standalone sequence.
 from __future__ import annotations
 
 import ast
-from collections.abc import Iterable
 import dataclasses
 import itertools
 import math
@@ -5223,7 +5222,6 @@ def flash_config_from_config(
 
 
 if TYPE_CHECKING:
-    from ...autotuner.config_fragment import ConfigSpecFragment
     from ..device_function import DeviceFunction
     from ..device_ir import GraphInfo
     from ..generate_ast import GenerateAST

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -55,11 +55,16 @@ from .device_state import CuteTcgen05MatmulPlan
 from .device_state import CuteTcgen05StoreValue
 from .device_state import Tcgen05GroupedDMode
 from .device_state import Tcgen05Orientation
+from .fragment_epilogue import Tcgen05PairEpiloguePlan
+from .fragment_epilogue import analyze_tcgen05_pair_epilogue_candidate
+from .fragment_epilogue import analyze_tcgen05_pair_epilogue_plan
 from .layout import MatmulExecutionKind
 from .layout import MatmulExecutionPlan
 from .matmul_utils import analyze_direct_grouped_n_loads
 from .mma_support import get_cute_mma_support
+from .strategies import TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY
 from .strategies import TCGEN05_LEGAL_SMEM_SWIZZLE_BYTES
+from .strategies import Tcgen05LayoutStrategy
 from .strategies import Tcgen05PersistenceModel
 from .strategies import is_pure_matmul_role_lifecycle_config
 from .strategies import l2_swizzle_size_from_config
@@ -101,6 +106,8 @@ from .tcgen05_constants import TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CHOICES
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_DEFAULT
+from .tcgen05_constants import TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_EPILOGUE_LAYOUT_NORMAL
 from .tcgen05_constants import TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY
@@ -138,6 +145,7 @@ from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
 if TYPE_CHECKING:
     from ...autotuner.config_spec import MatmulFact
+    from ...runtime.config import Config
     from ..aten_lowering import LoweringContext
     from ..compile_environment import CompileEnvironment
     from ..device_function import DeviceFunction
@@ -2466,6 +2474,8 @@ class _MmaSearchGraphView:
 class _MmaOutputStoreAnalysis:
     explicit_epi_tile_compatible: bool
     output_column_major: bool
+    requires_pair_epilogue: bool = False
+    requires_pair_layout: bool = False
 
 
 def _mma_tiles_are_static_full(
@@ -2509,6 +2519,148 @@ def _unwrap_mma_operand_permute(
     if normalized != trailing_axis_swap:
         return None
     return node.args[0], normalized
+
+
+def _tcgen05_pair_epilogue_operands_supported(
+    analysis: _MmaOperandAnalysis,
+) -> bool:
+    """Check the config-independent operand envelope for pair epilogues."""
+    return (
+        analysis.has_leading_passthrough
+        and analysis.lhs.source_fake.dtype in (torch.float16, torch.bfloat16)
+        and _tcgen05_tma_matrix_major(analysis.lhs.source_fake) == "row"
+        and _tcgen05_tma_matrix_major(analysis.rhs.source_fake) in ("row", "col")
+    )
+
+
+def _tcgen05_pair_epilogue_plan_output_supported(
+    plan: Tcgen05PairEpiloguePlan,
+) -> bool:
+    output_node = plan.store_node.args[0] if plan.store_node.args else None
+    output_fake = output_node.meta.get("val") if isinstance(output_node, Node) else None
+    return isinstance(output_fake, torch.Tensor) and (
+        _tcgen05_tma_matrix_major(output_fake) == "row"
+    )
+
+
+def tcgen05_pair_epilogue_can_shape_search(
+    graphs: list[GraphInfo],
+    anchor: Node,
+    candidate: _CuteMmaNode,
+    *,
+    min_search_m: int,
+    max_search_m: int,
+    max_search_n: int,
+) -> bool:
+    """Whether the search surface contains a possible pair-plan config."""
+    if not candidate.requires_pair_epilogue:
+        return True
+    analysis = candidate.operands
+    if not (
+        min_search_m <= 128 <= max_search_m
+        and max_search_n >= 64
+        and _tcgen05_pair_epilogue_operands_supported(analysis)
+    ):
+        return False
+
+    # Search shaping must use the same exhaustive locality proof as codegen.
+    # Probe only the pair-capable tile shapes that are reachable in this
+    # surface; a cheaper structural approximation can admit cross-pair
+    # reshapes and recreate a tcgen05-only-search/universal-codegen mismatch.
+    from ..compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    for bn in (64, 128):
+        if bn > max_search_n:
+            continue
+        probe_config = env.config_spec.default_config()
+        block_sizes = [*probe_config.block_sizes]
+        for block_id, block_size in (
+            (analysis.leading_passthrough_block_id, 1),
+            (analysis.m_block_id, 128),
+            (analysis.n_block_id, bn),
+        ):
+            assert block_id is not None
+            block_sizes[env.config_spec.block_sizes.block_id_to_index(block_id)] = (
+                block_size
+            )
+        probe_config.config["block_sizes"] = block_sizes
+        plan = analyze_tcgen05_pair_epilogue_plan(
+            graphs,
+            anchor,
+            expected_output_block_ids=analysis.output_block_ids,
+            config=probe_config,
+        )
+        if plan is not None and _tcgen05_pair_epilogue_plan_output_supported(plan):
+            return True
+    return False
+
+
+def ensure_tcgen05_pair_epilogue_plan(
+    fn: DeviceFunction,
+    node: Node,
+    candidate: _CuteMmaNode,
+    *,
+    bm: int,
+    bn: int,
+    bk: int,
+    config: Config,
+) -> bool:
+    """Commit a validated pair plan before tcgen05 removes scalar lanes."""
+    if not candidate.requires_pair_epilogue:
+        return True
+    cute_state = fn.cute_state
+    if cute_state.tcgen05_pair_epilogue_plan_for_anchor(node) is not None:
+        return True
+    if cute_state.tcgen05_pair_epilogue_plan_was_rejected(node, bm=bm, bn=bn, bk=bk):
+        return False
+
+    def reject() -> bool:
+        cute_state.reject_tcgen05_pair_epilogue_plan(node, bm=bm, bn=bn, bk=bk)
+        return False
+
+    analysis = candidate.operands
+    anchors = [
+        graph_node
+        for graph_info in fn.codegen.codegen_graphs
+        for graph_node in graph_info.graph.nodes
+        if _decode_cute_mma_target(graph_node) is not None
+    ]
+    if anchors != [node]:
+        return reject()
+    if not (
+        _tcgen05_pair_epilogue_operands_supported(analysis)
+        and bm == 128
+        and bn in (64, 128)
+        and _mma_tiles_are_static_full(analysis, bm=bm, bn=bn, bk=bk)
+        and _tcgen05_cluster_m(config) == 1
+        and _tcgen05_cluster_n(config) == 1
+        and config.get(
+            TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY, TCGEN05_EPILOGUE_LAYOUT_NORMAL
+        )
+        == TCGEN05_EPILOGUE_LAYOUT_NORMAL
+        and config.get(
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY,
+            Tcgen05LayoutStrategy.DEFAULT.value,
+        )
+        == Tcgen05LayoutStrategy.DEFAULT.value
+        and not is_pure_matmul_role_lifecycle_config(config)
+    ):
+        return reject()
+    plan = analyze_tcgen05_pair_epilogue_plan(
+        fn.codegen.codegen_graphs,
+        node,
+        expected_output_block_ids=analysis.output_block_ids,
+        config=config,
+    )
+    if plan is None:
+        return reject()
+    if not _tcgen05_pair_epilogue_plan_output_supported(plan) or any(
+        "codegen" in owned.meta for owned in plan.owned_nodes
+    ):
+        return reject()
+    cute_state.register_tcgen05_pair_epilogue_plan(plan)
+    return True
 
 
 def _analyze_mma_operand(
@@ -2803,6 +2955,8 @@ class _CuteMmaNode(_CuteMmaTarget):
     operands: _MmaOperandAnalysis
     explicit_epi_tile_compatible: bool
     output_column_major: bool
+    requires_pair_epilogue: bool = False
+    requires_pair_layout: bool = False
 
     @property
     def requires_scalar_fallback(self) -> bool:
@@ -2884,6 +3038,35 @@ def _decode_cute_mma_target(
         with_acc=with_acc,
         is_dot=is_dot,
         requires_accumulator_seed=requires_accumulator_seed,
+    )
+
+
+def tcgen05_pair_epilogue_has_unique_anchor(
+    graphs: list[GraphInfo],
+    *,
+    device_ir: DeviceIR | None = None,
+) -> bool:
+    """Whether pair-plan commitment can own the complete MMA function."""
+    return (
+        sum(
+            _decode_cute_mma_target(node, device_ir=device_ir) is not None
+            for graph_info in graphs
+            for node in graph_info.graph.nodes
+        )
+        == 1
+    )
+
+
+def tcgen05_pair_epilogue_present(graphs: list[GraphInfo]) -> bool:
+    """Whether structural analysis found any pair-owned epilogue region."""
+    return any(
+        isinstance(
+            output_analysis := node.meta.get(_MMA_OUTPUT_STORE_ANALYSIS_META_KEY),
+            _MmaOutputStoreAnalysis,
+        )
+        and output_analysis.requires_pair_epilogue
+        for graph_info in graphs
+        for node in graph_info.graph.nodes
     )
 
 
@@ -3022,6 +3205,16 @@ def analyze_cute_mma_node(
         ),
         output_column_major=(
             output_store_analysis.output_column_major
+            if output_store_analysis is not None
+            else False
+        ),
+        requires_pair_epilogue=(
+            output_store_analysis.requires_pair_epilogue
+            if output_store_analysis is not None
+            else False
+        ),
+        requires_pair_layout=(
+            output_store_analysis.requires_pair_layout
             if output_store_analysis is not None
             else False
         ),
@@ -3705,8 +3898,23 @@ def prepare_cute_collective_lane_loop_suppression(
     if env.backend_name != "cute":
         return
     allow_grouped_k_mask = _tcgen05_grouped_mode(cg.device_function.config) is not None
+    cute_state = cg.device_function.cute_state
+    if not tcgen05_pair_epilogue_has_unique_anchor(
+        cg.codegen_graphs
+    ) and tcgen05_pair_epilogue_present(cg.codegen_graphs):
+        # Root lane-loop suppression is shared across the device-function
+        # planning state. Pair-plan commitment is deliberately limited to a
+        # unique MMA anchor, so a mixed function must reject tcgen05 atomically.
+        cute_state.veto_collective_lane_loop_suppression()
+    if cute_state.collective_lane_loop_suppression_is_vetoed():
+        return
+    analyzed_candidates = {
+        node: candidate
+        for node in graph.nodes
+        if (candidate := analyze_cute_mma_node(node)) is not None
+    }
     for node in graph.nodes:
-        candidate = analyze_cute_mma_node(node)
+        candidate = analyzed_candidates.get(node)
         if candidate is not None:
             if candidate.requires_accumulator_seed:
                 continue
@@ -3769,6 +3977,16 @@ def prepare_cute_collective_lane_loop_suppression(
                 else ()
             )
             if _has_non_root_lane_loops(cg, allowed_loop_states=allowed_k_lane_loops):
+                continue
+            if not ensure_tcgen05_pair_epilogue_plan(
+                cg.device_function,
+                node,
+                candidate,
+                bm=bm,
+                bn=bn,
+                bk=bk,
+                config=cg.device_function.config,
+            ):
                 continue
             cute_state = cg.device_function.cute_state
             _register_collective_handled_loads(cute_state, lhs_load, rhs_load)
@@ -4829,6 +5047,19 @@ def _analyze_mma_output_stores(
 
     analyzed_stores = analyze_tcgen05_matmul_store_chains(graphs, mma_node)
     if analyzed_stores is None:
+        if (
+            pair_candidate := analyze_tcgen05_pair_epilogue_candidate(
+                graphs,
+                mma_node,
+                expected_output_block_ids=analysis.output_block_ids,
+            )
+        ) is not None:
+            return _MmaOutputStoreAnalysis(
+                explicit_epi_tile_compatible=False,
+                output_column_major=False,
+                requires_pair_epilogue=True,
+                requires_pair_layout=pair_candidate.requires_pair_layout,
+            )
         return None
     env = CompileEnvironment.current()
     explicit_epi_tile_compatible = True
@@ -5884,6 +6115,39 @@ def _emit_mma_pipeline(
         config=df.config,
         input_device=lhs_fake.device,
     )
+    if (
+        mma_impl == "tcgen05"
+        and fx_node is not None
+        and df.cute_state.collective_lane_loop_suppression_is_vetoed()
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 pair epilogue requires a unique MMA anchor before root "
+            "lane loops can be suppressed",
+        )
+    unplanned_pair_candidate = (
+        candidate
+        if candidate is not None
+        and candidate.requires_pair_epilogue
+        and fx_node is not None
+        and df.cute_state.tcgen05_pair_epilogue_plan_for_anchor(fx_node) is None
+        else None
+    )
+    if unplanned_pair_candidate is not None:
+        if (
+            env.config_spec.cute_tcgen05_search_enabled
+            or unplanned_pair_candidate.requires_pair_layout
+        ):
+            # Search-shaped lane mapping and logical shape transforms can both
+            # require a rendezvous between values assigned to sequential root
+            # lanes. Refuse configs that have not committed the exhaustive plan.
+            raise exc.BackendUnsupported(
+                "cute", "tcgen05 pair epilogue locality proof rejected this config"
+            )
+        if mma_impl == "tcgen05":
+            # A pointwise-only fragment outside the pair envelope can retain the
+            # established scalar lowering (notably the static N=8 fallback).
+            return None
     mma_tiles_are_static_full = (
         _mma_tiles_are_static_full(analysis, bm=bm, bn=bn, bk=bk)
         if analysis is not None

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from .cute_epilogue import Tcgen05GroupedTailEpilogueMatch
     from .cute_mma import _Tcgen05AuxPipelinePlan
     from .cute_mma import _Tcgen05SchedPipelinePlan
+    from .fragment_epilogue import Tcgen05PairEpiloguePlan
     from .tcgen05_lifecycle import Tcgen05LifecycleContext
     from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
@@ -437,6 +438,14 @@ class CuteDeviceFunctionState:
         # registered under this result var, even when user-visible names were
         # renamed through casts or epilogue nodes.
         self.matmul_fx_node_result_vars: dict[torch.fx.Node, str] = {}
+        self._pair_epilogue_plan: Tcgen05PairEpiloguePlan | None = None
+        # Rejected proofs are stable for this per-config codegen state. Keep
+        # the tile shape in the key so callers cannot accidentally reuse a
+        # verdict if this helper is ever exercised with multiple shapes.
+        self._rejected_pair_epilogue_plans: set[tuple[torch.fx.Node, int, int, int]] = (
+            set()
+        )
+        self._collective_lane_loop_suppression_vetoed = False
         self.matmul_plan: CuteTcgen05MatmulPlan | None = None
         # Variable-name containers allocated in cute_mma and consumed by
         # program_id / memory_ops role builders. They live here so CuTe pipeline
@@ -489,6 +498,53 @@ class CuteDeviceFunctionState:
         # Launch block thread count for the flash path: 128 (single-warpgroup
         # Stage-3) or 256 (Stage-4 warp-spec, double-buffered-S overlap).
         self.attention_flash_threads: int = 128
+
+    def register_tcgen05_pair_epilogue_plan(
+        self, plan: Tcgen05PairEpiloguePlan
+    ) -> None:
+        """Atomically commit one fully validated live-FX fragment plan."""
+        if self._pair_epilogue_plan is not None:
+            raise exc.BackendUnsupported(
+                "cute", "tcgen05 pair epilogue plan must be unique"
+            )
+        self._pair_epilogue_plan = plan
+
+    def reject_tcgen05_pair_epilogue_plan(
+        self, anchor: Node, *, bm: int, bn: int, bk: int
+    ) -> None:
+        """Memoize a failed pair-locality proof for this config."""
+        self._rejected_pair_epilogue_plans.add((anchor, bm, bn, bk))
+
+    def tcgen05_pair_epilogue_plan_was_rejected(
+        self, anchor: Node, *, bm: int, bn: int, bk: int
+    ) -> bool:
+        return (anchor, bm, bn, bk) in self._rejected_pair_epilogue_plans
+
+    @property
+    def has_tcgen05_pair_epilogue_plan(self) -> bool:
+        return self._pair_epilogue_plan is not None
+
+    def tcgen05_pair_epilogue_plan_for_anchor(
+        self, anchor: Node
+    ) -> Tcgen05PairEpiloguePlan | None:
+        plan = self._pair_epilogue_plan
+        return plan if plan is not None and plan.anchor is anchor else None
+
+    def tcgen05_pair_epilogue_plan_for_store(
+        self, store: Node | None
+    ) -> Tcgen05PairEpiloguePlan | None:
+        plan = self._pair_epilogue_plan
+        return plan if plan is not None and plan.store_node is store else None
+
+    def is_deferred_tcgen05_pair_epilogue_node(self, node: Node) -> bool:
+        plan = self._pair_epilogue_plan
+        return plan is not None and node in plan.owned_nodes
+
+    def veto_collective_lane_loop_suppression(self) -> None:
+        self._collective_lane_loop_suppression_vetoed = True
+
+    def collective_lane_loop_suppression_is_vetoed(self) -> bool:
+        return self._collective_lane_loop_suppression_vetoed
 
     def register_tcgen05_store_value(
         self, name: str, value: CuteTcgen05StoreValue

--- a/helion/_compiler/cute/fragment_epilogue.py
+++ b/helion/_compiler/cute/fragment_epilogue.py
@@ -1,0 +1,1332 @@
+"""Generic pair-local tcgen05 fragment epilogues.
+
+The planner owns a pure, single-store slice of the live FX graph.  It admits
+operators individually and interprets their logical coordinates; it never
+recognizes an expression or workload pattern.  The execution envelope is
+deliberately narrow: a static tcgen05 layout whose adjacent register pair has
+been validated to hold adjacent trailing-axis output elements.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+from fractions import Fraction
+import functools
+import math
+import operator
+from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import cast
+
+import sympy
+import torch
+from torch._inductor.virtualized import V
+from torch.fx.node import Node
+from torch.fx.node import map_arg
+
+from ...language import _tracing_ops
+from ...language import memory_ops
+from ...language import tile_index
+from ...language import view_ops
+from ..ast_extension import expr_from_string
+from ..ast_extension import statement_from_string
+from ..compile_environment import CompileEnvironment
+from ..indexing_strategy import exact_tile_block_ids
+from .cute_fx_walk import build_inner_outputs_index_from_graphs
+from .cute_fx_walk import reach_matmul_anchors
+from .cute_fx_walk import walk_carrier_to_tcgen05_matmul
+from .cute_reshape import _get_tile_shape
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Mapping
+    from collections.abc import Sequence
+
+    from ...runtime.config import Config
+    from ..device_ir import GraphInfo
+    from ..inductor_lowering import CodegenState
+
+    _IndexEvaluator = Callable[[dict[str, int]], int]
+
+
+_T = TypeVar("_T")
+
+# The only audited physical layout places adjacent even/odd trailing-axis
+# elements in adjacent registers without crossing a subtile.  The renderer is
+# intrinsically pair-local, so this is an implementation constant rather than
+# a configurable capability.
+_TCGEN05_PAIR_WIDTH = 2
+
+
+class _UnsupportedFragment(Exception):
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class Tcgen05PairEpiloguePlan:
+    anchor: Node
+    store_node: Node
+    value_node: Node
+    boundary_nodes: frozenset[Node]
+    owned_nodes: frozenset[Node]
+
+
+@dataclasses.dataclass(frozen=True)
+class Tcgen05PairEpilogueCandidate:
+    requires_pair_layout: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class _Region:
+    store: Node
+    value: Node
+    owned: frozenset[Node]
+    boundaries: frozenset[Node]
+
+
+_RESHAPE_TARGETS = {
+    torch.ops.aten.reshape.default,
+    torch.ops.aten._unsafe_view.default,
+    torch.ops.aten.view.default,
+}
+_PERMUTE_TARGETS = {
+    torch.ops.aten.permute.default,
+    torch.ops.aten.transpose.int,
+    torch.ops.aten.t.default,
+}
+_SHAPE_TARGETS = {
+    *_RESHAPE_TARGETS,
+    *_PERMUTE_TARGETS,
+    torch.ops.aten.expand.default,
+    torch.ops.aten.unsqueeze.default,
+    torch.ops.aten.squeeze.dim,
+    view_ops.subscript,
+    view_ops.split,
+    view_ops.join,
+}
+
+
+def _pointwise_inputs(node: Node) -> tuple[Node, ...] | None:
+    from ..inductor_lowering import PointwiseLowering
+
+    lowering = node.meta.get("lowering")
+    if not isinstance(lowering, PointwiseLowering):
+        return None
+    inputs: list[Node] = []
+
+    def visit(value: Node) -> Node:
+        if isinstance(value.meta.get("val"), torch.Tensor):
+            inputs.append(value)
+        return value
+
+    map_arg((node.args, {**node.kwargs, "_extra_deps": None}), visit)
+    if not inputs or len(inputs) != len(lowering.input_names):
+        return None
+    return tuple(inputs)
+
+
+def _is_split_getitem(node: Node) -> bool:
+    base = node.args[0] if node.args else None
+    index = node.args[1] if len(node.args) > 1 else None
+    return (
+        node.op == "call_function"
+        and node.target is operator.getitem
+        and isinstance(base, Node)
+        and base.target is view_ops.split
+        and index in (0, 1)
+    )
+
+
+def _is_host_tensor(node: Node) -> bool:
+    return node.op == "call_function" and node.target is _tracing_ops._host_tensor
+
+
+def _shape_only_subscript(node: Node) -> bool:
+    source = node.args[0] if node.args else None
+    indices = node.args[1] if len(node.args) > 1 else None
+    source_value = source.meta.get("val") if isinstance(source, Node) else None
+    output_value = node.meta.get("val")
+    return (
+        isinstance(source_value, torch.Tensor)
+        and isinstance(output_value, torch.Tensor)
+        and isinstance(indices, (list, tuple))
+        and all(index is None or index == slice(None) for index in indices)
+        and sum(index == slice(None) for index in indices) == source_value.ndim
+        and len(indices) == output_value.ndim
+    )
+
+
+def _tile_index_block_ids(node: Node) -> set[int]:
+    """Return tile-index provenance, rejecting arithmetic/data-derived indices."""
+    if node.target is tile_index:
+        size_node = node.args[0] if node.args else None
+        size = size_node.meta.get("val") if isinstance(size_node, Node) else size_node
+        block_id = (
+            CompileEnvironment.current().get_block_id(size)
+            if isinstance(size, (int, torch.SymInt, sympy.Basic))
+            else None
+        )
+        if block_id is not None:
+            return {block_id}
+    source = node.args[0] if node.args else None
+    shape_target = node.target in _RESHAPE_TARGETS | _PERMUTE_TARGETS | {
+        torch.ops.aten.expand.default,
+        torch.ops.aten.unsqueeze.default,
+        torch.ops.aten.squeeze.dim,
+        view_ops.subscript,
+    }
+    if isinstance(source, Node) and (
+        shape_target or (node.target is memory_ops.load and not _is_host_tensor(source))
+    ):
+        if node.target is not view_ops.subscript or _shape_only_subscript(node):
+            return _tile_index_block_ids(source)
+    raise _UnsupportedFragment
+
+
+def _extent_matches_block(extent: int | torch.SymInt, block_id: int) -> bool:
+    env = CompileEnvironment.current()
+    size = env.block_sizes[env.canonical_block_id(block_id)].size
+    return isinstance(size, (int, torch.SymInt)) and env.known_equal(extent, size)
+
+
+def _validate_host_load(node: Node, output_node: Node) -> None:
+    source = node.args[0] if node.args else None
+    indices = node.args[1] if len(node.args) > 1 else None
+    source_value = source.meta.get("val") if isinstance(source, Node) else None
+    output_value = node.meta.get("val")
+    if not (
+        isinstance(source, Node)
+        and _is_host_tensor(source)
+        and source is not output_node
+        and isinstance(source_value, torch.Tensor)
+        and isinstance(output_value, torch.Tensor)
+        and isinstance(indices, (list, tuple))
+        and len(indices) == source_value.ndim
+        and (len(node.args) <= 2 or node.args[2] is None)
+        and source_value.dtype in (torch.float16, torch.bfloat16, torch.float32)
+    ):
+        raise _UnsupportedFragment
+    tensor_indices = [
+        index
+        for index in indices
+        if isinstance(index, Node) and isinstance(index.meta.get("val"), torch.Tensor)
+    ]
+    env = CompileEnvironment.current()
+    if tensor_indices and len(tensor_indices) != len(indices):
+        raise _UnsupportedFragment
+    used: set[int] = set()
+    output_dim = 0
+    for tensor_dim, index in enumerate(indices):
+        block_ids: set[int] = set()
+        if isinstance(index, Node) and isinstance(index.meta.get("val"), torch.Tensor):
+            block_ids = _tile_index_block_ids(index)
+        elif isinstance(index, Node) and isinstance(
+            index.meta.get("val"), torch.SymInt
+        ):
+            if (block_id := env.get_block_id(index.meta["val"])) is not None:
+                block_ids = {block_id}
+        elif index == slice(None) and output_dim < output_value.ndim:
+            if (
+                block_id := env.resolve_block_id(output_value.shape[output_dim])
+            ) is not None:
+                block_ids = {block_id}
+        elif not (
+            isinstance(index, int)
+            and isinstance(source_value.shape[tensor_dim], int)
+            and 0 <= index < source_value.shape[tensor_dim]
+        ):
+            raise _UnsupportedFragment
+        if block_ids:
+            if len(block_ids) != 1:
+                raise _UnsupportedFragment
+            (block_id,) = block_ids
+            canonical = env.canonical_block_id(block_id)
+            expected = (
+                None
+                if tensor_indices
+                else env.resolve_block_id(output_value.shape[output_dim])
+            )
+            if (
+                canonical in used
+                or (
+                    expected is not None
+                    and canonical != env.canonical_block_id(expected)
+                )
+                or not _extent_matches_block(source_value.shape[tensor_dim], block_id)
+            ):
+                raise _UnsupportedFragment
+            used.add(canonical)
+            output_dim += 1
+    if not tensor_indices and output_dim != output_value.ndim:
+        raise _UnsupportedFragment
+
+
+def _node_inputs(node: Node, output_node: Node) -> tuple[Node, ...] | None:
+    if node.op != "call_function":
+        return None
+    if (pointwise := _pointwise_inputs(node)) is not None:
+        return pointwise
+    if node.target is tile_index:
+        return ()
+    if node.target is memory_ops.load:
+        source = node.args[0] if node.args else None
+        if not isinstance(source, Node) or (
+            len(node.args) > 2 and node.args[2] is not None
+        ):
+            return None
+        if not _is_host_tensor(source):
+            return (source,) if _shape_only_subscript(node) else None
+        _validate_host_load(node, output_node)
+        indices = node.args[1] if len(node.args) > 1 else ()
+        if not isinstance(indices, (list, tuple)):
+            raise _UnsupportedFragment
+        return tuple(
+            index
+            for index in indices
+            if isinstance(index, Node)
+            and isinstance(index.meta.get("val"), torch.Tensor)
+        )
+    if node.target is view_ops.subscript and not _shape_only_subscript(node):
+        return None
+    if node.target is view_ops.join:
+        return tuple(arg for arg in node.args[:2] if isinstance(arg, Node))
+    if node.target not in _SHAPE_TARGETS and not _is_split_getitem(node):
+        return None
+    source = node.args[0] if node.args else None
+    return (source,) if isinstance(source, Node) else ()
+
+
+def _extract_region(
+    graphs: Sequence[GraphInfo],
+    anchor: Node,
+    expected_output_block_ids: tuple[int, ...],
+) -> _Region:
+    inner_outputs = build_inner_outputs_index_from_graphs(graphs)
+    reachable = [
+        (store, value)
+        for graph_info in graphs
+        for store in graph_info.graph.nodes
+        if store.target is memory_ops.store
+        and len(store.args) > 2
+        and isinstance((value := store.args[2]), Node)
+        if anchor
+        in reach_matmul_anchors(
+            value,
+            target_fx_nodes={anchor},
+            inner_outputs_by_graph_id=inner_outputs,
+        )
+    ]
+    if len(reachable) != 1:
+        raise _UnsupportedFragment
+    store, value = reachable[0]
+    output_node = store.args[0] if store.args else None
+    output = output_node.meta.get("val") if isinstance(output_node, Node) else None
+    subscripts = store.args[1] if len(store.args) > 1 else None
+    mask = store.args[3] if len(store.args) > 3 else None
+    if (
+        not isinstance(output_node, Node)
+        or not isinstance(output, torch.Tensor)
+        or output.ndim != 3
+        or output.dtype not in (torch.float16, torch.bfloat16)
+        or not isinstance(subscripts, (list, tuple))
+        or exact_tile_block_ids(CompileEnvironment.current(), subscripts)
+        != expected_output_block_ids
+        or mask is not None
+    ):
+        raise _UnsupportedFragment
+
+    owned: set[Node] = set()
+    boundaries: set[Node] = set()
+    visiting: set[Node] = set()
+
+    def visit(node: Node) -> None:
+        if node in owned or node in boundaries:
+            return
+        if walk_carrier_to_tcgen05_matmul(node, {anchor}, inner_outputs) is anchor:
+            boundaries.add(node)
+            return
+        if node.graph is not store.graph or node in visiting:
+            raise _UnsupportedFragment(
+                f"unsupported region node {node.name}: {node.target}"
+            )
+        dependencies = _node_inputs(node, output_node)
+        if dependencies is None:
+            raise _UnsupportedFragment(
+                f"unsupported region node {node.name}: {node.target}"
+            )
+        visiting.add(node)
+        for dependency in dependencies:
+            visit(dependency)
+        visiting.remove(node)
+        owned.add(node)
+
+    visit(value)
+    if not boundaries:
+        raise _UnsupportedFragment
+    allowed_users = {*owned, store}
+    if any(
+        user not in allowed_users
+        for node in (*owned, *boundaries)
+        for user in node.users
+    ):
+        raise _UnsupportedFragment
+
+    body_graph_ids = [
+        graph_info.graph_id for graph_info in graphs if graph_info.graph is anchor.graph
+    ]
+    if len(body_graph_ids) != 1:
+        raise _UnsupportedFragment
+    (body_graph_id,) = body_graph_ids
+    loop_nodes = [
+        node
+        for node in store.graph.nodes
+        if node.op == "call_function"
+        and _tracing_ops.is_for_loop_target(node.target)
+        and node.args
+        and node.args[0] == body_graph_id
+    ]
+    if len(loop_nodes) != 1:
+        raise _UnsupportedFragment
+    (loop_node,) = loop_nodes
+    order = {node: index for index, node in enumerate(store.graph.nodes)}
+    if not all(order[loop_node] < order[node] < order[store] for node in owned):
+        raise _UnsupportedFragment
+    for node in store.graph.nodes:
+        if not (order[loop_node] < order[node] < order[store]) or node in owned:
+            continue
+        is_loop_result = (
+            node.target is operator.getitem and node.args and node.args[0] is loop_node
+        )
+        is_shape_scalar = isinstance(node.meta.get("val"), (int, torch.SymInt))
+        if (
+            node.op == "call_function"
+            and node not in boundaries
+            and not is_loop_result
+            and not is_shape_scalar
+            and not _is_host_tensor(node)
+        ):
+            raise _UnsupportedFragment(f"intervening node {node.name}: {node.target}")
+
+    return _Region(store, value, frozenset(owned), frozenset(boundaries))
+
+
+def analyze_tcgen05_pair_epilogue_candidate(
+    graphs: Sequence[GraphInfo],
+    anchor: Node,
+    *,
+    expected_output_block_ids: tuple[int, ...],
+) -> Tcgen05PairEpilogueCandidate | None:
+    """Side-effect-free preflight sharing the fragment planner's extraction."""
+    try:
+        region = _extract_region(graphs, anchor, expected_output_block_ids)
+    except _UnsupportedFragment:
+        return None
+    return Tcgen05PairEpilogueCandidate(
+        requires_pair_layout=any(
+            node.target in _SHAPE_TARGETS or _is_split_getitem(node)
+            for node in region.owned
+        )
+    )
+
+
+def _interpret_index(
+    value: sympy.Expr,
+    variables: Mapping[str, _T],
+    *,
+    constant: Callable[[int], _T],
+    add: Callable[[tuple[_T, ...]], _T],
+    multiply: Callable[[tuple[_T, ...]], _T],
+    floor_divide: Callable[[_T, _T], _T],
+    modulo: Callable[[_T, _T], _T],
+) -> _T:
+    """Interpret the complete logical-index grammar into one target domain."""
+
+    def visit(current: sympy.Expr) -> _T:
+        if isinstance(current, sympy.Integer):
+            return constant(int(current))
+        if isinstance(current, sympy.Symbol):
+            return variables[str(current)]
+        if current.is_Add:
+            return add(tuple(visit(cast("sympy.Expr", arg)) for arg in current.args))
+        if current.is_Mul:
+            return multiply(
+                tuple(visit(cast("sympy.Expr", arg)) for arg in current.args)
+            )
+        if current.func is sympy.floor:
+            numerator, denominator = cast(
+                "sympy.Expr", current.args[0]
+            ).as_numer_denom()
+            return floor_divide(visit(numerator), visit(denominator))
+        if current.func is sympy.Mod:
+            return modulo(
+                visit(cast("sympy.Expr", current.args[0])),
+                visit(cast("sympy.Expr", current.args[1])),
+            )
+        raise _UnsupportedFragment(f"unsupported logical index {current}")
+
+    return visit(value)
+
+
+@dataclasses.dataclass(frozen=True)
+class _Index:
+    semantic: sympy.Expr
+    bounds: tuple[tuple[sympy.Symbol, int, int], ...] = ()
+
+    @staticmethod
+    def constant(value: int) -> _Index:
+        return _Index(sympy.Integer(value))
+
+    @staticmethod
+    def variable(name: str, upper: int) -> _Index:
+        symbol = sympy.Symbol(name, integer=True, nonnegative=True)
+        return _Index(symbol, ((symbol, 0, upper),))
+
+    def compile(self) -> _IndexEvaluator:
+        """Compile this index once for repeated exhaustive evaluation."""
+
+        def variable(name: str) -> _IndexEvaluator:
+            return operator.itemgetter(name)
+
+        def constant(value: int) -> _IndexEvaluator:
+            return lambda _values: value
+
+        def add(parts: tuple[_IndexEvaluator, ...]) -> _IndexEvaluator:
+            return lambda values: sum(part(values) for part in parts)
+
+        def multiply(parts: tuple[_IndexEvaluator, ...]) -> _IndexEvaluator:
+            return lambda values: math.prod(part(values) for part in parts)
+
+        def floor_divide(
+            numerator: _IndexEvaluator, denominator: _IndexEvaluator
+        ) -> _IndexEvaluator:
+            return lambda values: numerator(values) // denominator(values)
+
+        def modulo(
+            numerator: _IndexEvaluator, denominator: _IndexEvaluator
+        ) -> _IndexEvaluator:
+            return lambda values: numerator(values) % denominator(values)
+
+        variables = {
+            str(symbol): variable(str(symbol)) for symbol, _lower, _upper in self.bounds
+        }
+        return _interpret_index(
+            self.semantic,
+            variables,
+            constant=constant,
+            add=add,
+            multiply=multiply,
+            floor_divide=floor_divide,
+            modulo=modulo,
+        )
+
+    def render(self, variables: dict[str, str]) -> str:
+        return _interpret_index(
+            self.semantic,
+            variables,
+            constant=lambda value: f"cutlass.Int32({value})",
+            add=lambda parts: "(" + " + ".join(parts) + ")",
+            multiply=lambda parts: "(" + " * ".join(parts) + ")",
+            floor_divide=lambda numerator, denominator: (
+                f"(({numerator}) // ({denominator}))"
+            ),
+            modulo=lambda numerator, denominator: f"(({numerator}) % ({denominator}))",
+        )
+
+
+def _merge_bounds(*indices: _Index) -> tuple[tuple[sympy.Symbol, int, int], ...]:
+    merged: dict[sympy.Symbol, tuple[int, int]] = {}
+    for index in indices:
+        for symbol, lower, upper in index.bounds:
+            if merged.setdefault(symbol, (lower, upper)) != (lower, upper):
+                raise _UnsupportedFragment
+    return tuple((symbol, *merged[symbol]) for symbol in sorted(merged, key=str))
+
+
+def _semantic_interval(
+    value: sympy.Expr, bounds: dict[sympy.Symbol, tuple[int, int]]
+) -> tuple[Fraction, Fraction] | None:
+    if value.is_Rational:
+        rational = Fraction(str(value))
+        return rational, rational
+    if isinstance(value, sympy.Symbol):
+        interval = bounds.get(value)
+        if interval is None:
+            return None
+        return Fraction(interval[0]), Fraction(interval[1])
+    if value.is_Add:
+        parts = [
+            _semantic_interval(cast("sympy.Expr", arg), bounds) for arg in value.args
+        ]
+        if any(part is None for part in parts):
+            return None
+        lower = Fraction(0)
+        upper = Fraction(0)
+        for part in parts:
+            if part is not None:
+                lower += part[0]
+                upper += part[1]
+        return lower, upper
+    if value.is_Mul:
+        result = (Fraction(1), Fraction(1))
+        for arg in value.args:
+            part = _semantic_interval(cast("sympy.Expr", arg), bounds)
+            if part is None:
+                return None
+            products = tuple(left * right for left in result for right in part)
+            result = min(products), max(products)
+        return result
+    if value.func is sympy.floor:
+        part = _semantic_interval(cast("sympy.Expr", value.args[0]), bounds)
+        if part is None:
+            return None
+        return Fraction(math.floor(part[0])), Fraction(math.floor(part[1]))
+    if value.func is sympy.Mod:
+        part = _semantic_interval(cast("sympy.Expr", value.args[0]), bounds)
+        modulus = value.args[1]
+        if not isinstance(modulus, sympy.Integer):
+            return None
+        modulus_value = int(modulus)
+        if part is not None and 0 <= part[0] <= part[1] < modulus_value:
+            return part
+        if modulus_value > 0:
+            return Fraction(0), Fraction(modulus_value - 1)
+    return None
+
+
+@functools.lru_cache(maxsize=512)
+def _simplify_semantic(
+    value: sympy.Expr, bounds_tuple: tuple[tuple[sympy.Symbol, int, int], ...]
+) -> sympy.Expr:
+    bounds = {symbol: (lower, upper) for symbol, lower, upper in bounds_tuple}
+
+    def visit(current: sympy.Expr) -> sympy.Expr:
+        if current.args:
+            current = cast(
+                "sympy.Expr",
+                sympy.simplify(
+                    current.func(
+                        *(visit(cast("sympy.Expr", arg)) for arg in current.args)
+                    )
+                ),
+            )
+        if current.func is sympy.floor:
+            interval = _semantic_interval(cast("sympy.Expr", current.args[0]), bounds)
+            if interval is not None and math.floor(interval[0]) == math.floor(
+                interval[1]
+            ):
+                return sympy.Integer(math.floor(interval[0]))
+        if current.func is sympy.Mod:
+            interval = _semantic_interval(cast("sympy.Expr", current.args[0]), bounds)
+            modulus = current.args[1]
+            if (
+                interval is not None
+                and isinstance(modulus, sympy.Integer)
+                and 0 <= interval[0] <= interval[1] < int(modulus)
+            ):
+                return cast("sympy.Expr", current.args[0])
+        return current
+
+    previous = value
+    for _ in range(4):
+        current = visit(previous)
+        if current == previous:
+            return current
+        previous = current
+    return previous
+
+
+def _binary(op: str, left: _Index | int, right: _Index | int) -> _Index:
+    left = left if isinstance(left, _Index) else _Index.constant(left)
+    right = right if isinstance(right, _Index) else _Index.constant(right)
+    bounds = _merge_bounds(left, right)
+    if op == "add":
+        semantic = sympy.Add(left.semantic, right.semantic)
+    elif op == "mul":
+        semantic = sympy.Mul(left.semantic, right.semantic)
+    elif op == "floordiv":
+        quotient = sympy.Mul(left.semantic, sympy.Pow(right.semantic, -1))
+        semantic = cast("sympy.Expr", sympy.floor(quotient))
+    elif op == "mod":
+        semantic = sympy.Mod(left.semantic, right.semantic)
+    else:
+        raise AssertionError(op)
+    return _Index(_simplify_semantic(semantic, bounds), bounds)
+
+
+def _add(left: _Index | int, right: _Index | int) -> _Index:
+    return _binary("add", left, right)
+
+
+def _mul(left: _Index | int, right: _Index | int) -> _Index:
+    return _binary("mul", left, right)
+
+
+def _floordiv(left: _Index | int, right: _Index | int) -> _Index:
+    return _binary("floordiv", left, right)
+
+
+def _mod(left: _Index | int, right: _Index | int) -> _Index:
+    return _binary("mod", left, right)
+
+
+def _constant_index(index: _Index) -> int | None:
+    return int(index.semantic) if isinstance(index.semantic, sympy.Integer) else None
+
+
+def _coords_from_flat(flat: _Index, shape: Sequence[int]) -> list[_Index]:
+    coords: list[_Index] = []
+    stride = 1
+    for extent in reversed(shape):
+        coords.append(_mod(_floordiv(flat, stride), extent))
+        stride *= extent
+    return list(reversed(coords))
+
+
+def _flat_from_coords(coords: Sequence[_Index], shape: Sequence[int]) -> _Index:
+    result = _Index.constant(0)
+    for coord, extent in zip(coords, shape, strict=True):
+        result = _add(_mul(result, extent), coord)
+    return result
+
+
+def _broadcast_flat(
+    flat: _Index, output_shape: Sequence[int], source_shape: Sequence[int]
+) -> _Index:
+    if len(source_shape) > len(output_shape):
+        raise _UnsupportedFragment
+    output_coords = _coords_from_flat(flat, output_shape)
+    offset = len(output_shape) - len(source_shape)
+    source_coords: list[_Index] = []
+    for dim, source_extent in enumerate(source_shape):
+        output_extent = output_shape[offset + dim]
+        if source_extent == 1:
+            source_coords.append(_Index.constant(0))
+        elif source_extent == output_extent:
+            source_coords.append(output_coords[offset + dim])
+        else:
+            raise _UnsupportedFragment
+    return _flat_from_coords(source_coords, source_shape)
+
+
+def _shape(node: Node, config: Config) -> list[int]:
+    value = node.meta.get("val")
+    if not isinstance(value, torch.Tensor):
+        raise _UnsupportedFragment
+    return _get_tile_shape(value, CompileEnvironment.current(), config)
+
+
+def _permutation(node: Node, ndim: int) -> list[int]:
+    if node.target is torch.ops.aten.permute.default:
+        dims = node.args[1] if len(node.args) > 1 else node.kwargs.get("dims")
+        if not isinstance(dims, (list, tuple)):
+            raise _UnsupportedFragment
+        result: list[int] = []
+        for dim in dims:
+            if not isinstance(dim, int):
+                raise _UnsupportedFragment
+            result.append(dim % ndim)
+        return result
+    if node.target is torch.ops.aten.transpose.int:
+        dim0 = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim0")
+        dim1 = node.args[2] if len(node.args) > 2 else node.kwargs.get("dim1")
+        if not isinstance(dim0, int) or not isinstance(dim1, int):
+            raise _UnsupportedFragment
+        result = list(range(ndim))
+        result[dim0 % ndim], result[dim1 % ndim] = (
+            result[dim1 % ndim],
+            result[dim0 % ndim],
+        )
+        return result
+    if node.target is torch.ops.aten.t.default and ndim == 2:
+        return [1, 0]
+    raise _UnsupportedFragment
+
+
+def _resolve_shape(
+    node: Node,
+    flat: _Index,
+    *,
+    config: Config,
+    evaluate: Callable[[Node, _Index, int | None], object],
+    choose: Callable[[_Index, object, object], object],
+    projection: int | None = None,
+) -> object:
+    if node.target in _RESHAPE_TARGETS:
+        source = node.args[0]
+        if not isinstance(source, Node):
+            raise _UnsupportedFragment
+        return evaluate(source, flat, None)
+    if node.target in _PERMUTE_TARGETS:
+        source = node.args[0]
+        if not isinstance(source, Node):
+            raise _UnsupportedFragment
+        output_coords = _coords_from_flat(flat, _shape(node, config))
+        perm = _permutation(node, len(output_coords))
+        source_coords = [output_coords[perm.index(dim)] for dim in range(len(perm))]
+        return evaluate(
+            source, _flat_from_coords(source_coords, _shape(source, config)), None
+        )
+    if node.target is torch.ops.aten.expand.default:
+        source = node.args[0]
+        if not isinstance(source, Node):
+            raise _UnsupportedFragment
+        return evaluate(
+            source,
+            _broadcast_flat(flat, _shape(node, config), _shape(source, config)),
+            None,
+        )
+    if node.target is torch.ops.aten.unsqueeze.default:
+        source = node.args[0]
+        dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
+        if not isinstance(source, Node) or not isinstance(dim, int):
+            raise _UnsupportedFragment
+        coords = _coords_from_flat(flat, _shape(node, config))
+        dim %= len(coords)
+        return evaluate(
+            source,
+            _flat_from_coords(coords[:dim] + coords[dim + 1 :], _shape(source, config)),
+            None,
+        )
+    if node.target is torch.ops.aten.squeeze.dim:
+        source = node.args[0]
+        dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
+        if not isinstance(source, Node) or not isinstance(dim, int):
+            raise _UnsupportedFragment
+        source_shape = _shape(source, config)
+        dim %= len(source_shape)
+        coords = _coords_from_flat(flat, _shape(node, config))
+        if source_shape[dim] == 1:
+            coords.insert(dim, _Index.constant(0))
+        return evaluate(source, _flat_from_coords(coords, source_shape), None)
+    source_arg = node.args[0] if node.args else None
+    if node.target is view_ops.subscript or (
+        node.target is memory_ops.load
+        and isinstance(source_arg, Node)
+        and not _is_host_tensor(source_arg)
+    ):
+        source = source_arg
+        indices = node.args[1] if len(node.args) > 1 else None
+        if not isinstance(source, Node) or not isinstance(indices, (list, tuple)):
+            raise _UnsupportedFragment
+        output_coords = iter(_coords_from_flat(flat, _shape(node, config)))
+        source_coords: list[_Index] = []
+        for index in indices:
+            coord = next(output_coords)
+            if index is None:
+                continue
+            if index != slice(None):
+                raise _UnsupportedFragment
+            source_coords.append(coord)
+        return evaluate(
+            source, _flat_from_coords(source_coords, _shape(source, config)), None
+        )
+    if _is_split_getitem(node):
+        split = node.args[0]
+        projection_arg = node.args[1]
+        assert isinstance(split, Node) and isinstance(projection_arg, int)
+        source = split.args[0]
+        if not isinstance(source, Node):
+            raise _UnsupportedFragment
+        return evaluate(source, _add(_mul(flat, 2), projection_arg), None)
+    if node.target is view_ops.split:
+        if projection not in (0, 1):
+            raise _UnsupportedFragment
+        source = node.args[0]
+        if not isinstance(source, Node):
+            raise _UnsupportedFragment
+        return evaluate(source, _add(_mul(flat, 2), projection), None)
+    if node.target is view_ops.join:
+        left = node.args[0] if node.args else None
+        right = node.args[1] if len(node.args) > 1 else None
+        if not isinstance(left, Node) or not isinstance(right, Node):
+            raise _UnsupportedFragment
+        coords = _coords_from_flat(flat, _shape(node, config))
+        selector = coords[-1]
+        source_flat = _flat_from_coords(coords[:-1], _shape(left, config))
+        return choose(
+            selector,
+            evaluate(left, source_flat, None),
+            evaluate(right, source_flat, None),
+        )
+    return evaluate(node, flat, projection)
+
+
+def _collect_demands(
+    node: Node,
+    flat: _Index,
+    *,
+    region: _Region,
+    config: Config,
+    projection: int | None = None,
+    memo: dict[tuple[Node, _Index, int | None], frozenset[tuple[Node, _Index]]]
+    | None = None,
+) -> frozenset[tuple[Node, _Index]]:
+    if memo is None:
+        memo = {}
+    key = (node, flat, projection)
+    if key in memo:
+        return memo[key]
+
+    def evaluate(
+        current: Node, current_flat: _Index, current_projection: int | None
+    ) -> object:
+        if (
+            current is not node
+            or current_flat != flat
+            or current_projection != projection
+        ):
+            return _collect_demands(
+                current,
+                current_flat,
+                region=region,
+                config=config,
+                projection=current_projection,
+                memo=memo,
+            )
+        if current in region.boundaries:
+            return frozenset({(current, current_flat)})
+        if current.target is tile_index:
+            return frozenset()
+        source = current.args[0] if current.args else None
+        if (
+            current.target is memory_ops.load
+            and isinstance(source, Node)
+            and _is_host_tensor(source)
+        ):
+            output_shape = _shape(current, config)
+            demands: set[tuple[Node, _Index]] = set()
+            indices = current.args[1] if len(current.args) > 1 else None
+            if not isinstance(indices, (list, tuple)):
+                raise _UnsupportedFragment
+            for index in indices:
+                if isinstance(index, Node) and isinstance(
+                    index.meta.get("val"), torch.Tensor
+                ):
+                    index_flat = _broadcast_flat(
+                        current_flat, output_shape, _shape(index, config)
+                    )
+                    demands.update(
+                        _collect_demands(
+                            index, index_flat, region=region, config=config, memo=memo
+                        )
+                    )
+            return frozenset(demands)
+        inputs = _pointwise_inputs(current)
+        if inputs is not None:
+            demands: set[tuple[Node, _Index]] = set()
+            output_shape = _shape(current, config)
+            for input_node in inputs:
+                demands.update(
+                    _collect_demands(
+                        input_node,
+                        _broadcast_flat(
+                            current_flat, output_shape, _shape(input_node, config)
+                        ),
+                        region=region,
+                        config=config,
+                        memo=memo,
+                    )
+                )
+            return frozenset(demands)
+        raise _UnsupportedFragment
+
+    def choose(selector: _Index, left: object, right: object) -> object:
+        if not isinstance(left, frozenset) or not isinstance(right, frozenset):
+            raise _UnsupportedFragment
+        return left | right
+
+    result = _resolve_shape(
+        node,
+        flat,
+        config=config,
+        evaluate=evaluate,
+        choose=choose,
+        projection=projection,
+    )
+    if not isinstance(result, frozenset):
+        raise _UnsupportedFragment
+    memo[key] = result
+    return result
+
+
+def analyze_tcgen05_pair_epilogue_plan(
+    graphs: Sequence[GraphInfo],
+    anchor: Node,
+    *,
+    expected_output_block_ids: tuple[int, ...],
+    config: Config,
+) -> Tcgen05PairEpiloguePlan | None:
+    """Finalize logical pair locality for one static configuration."""
+    try:
+        region = _extract_region(graphs, anchor, expected_output_block_ids)
+        output_shape = _shape(region.value, config)
+        if len(output_shape) != 3 or output_shape[0] != 1:
+            raise _UnsupportedFragment
+        m_extent, n_extent = output_shape[-2:]
+        if n_extent % _TCGEN05_PAIR_WIDTH:
+            raise _UnsupportedFragment
+        for boundary in region.boundaries:
+            value = boundary.meta.get("val")
+            if (
+                not isinstance(value, torch.Tensor)
+                or value.dtype is not torch.float32
+                or _shape(boundary, config) != output_shape
+            ):
+                raise _UnsupportedFragment
+
+        row = _Index.variable("row", m_extent - 1)
+        pair = _Index.variable("pair", n_extent // _TCGEN05_PAIR_WIDTH - 1)
+        targets = [
+            _flat_from_coords(
+                [_Index.constant(0), row, _add(_mul(pair, 2), slot)],
+                output_shape,
+            )
+            for slot in range(_TCGEN05_PAIR_WIDTH)
+        ]
+        demands = [
+            _collect_demands(
+                region.value,
+                target,
+                region=region,
+                config=config,
+            )
+            for target in targets
+        ]
+        target_evaluators = [target.compile() for target in targets]
+        demand_evaluators = [
+            demand.compile() for slot_demands in demands for _, demand in slot_demands
+        ]
+        variables = {"row": 0, "pair": 0}
+        for m in range(m_extent):
+            variables["row"] = m
+            for n_pair in range(n_extent // _TCGEN05_PAIR_WIDTH):
+                variables["pair"] = n_pair
+                allowed = {evaluate(variables) for evaluate in target_evaluators}
+                if any(
+                    evaluate(variables) not in allowed for evaluate in demand_evaluators
+                ):
+                    raise _UnsupportedFragment
+        return Tcgen05PairEpiloguePlan(
+            anchor,
+            region.store,
+            region.value,
+            region.boundaries,
+            region.owned,
+        )
+    except (_UnsupportedFragment, IndexError, StopIteration, ValueError):
+        return None
+
+
+def _render_statements(statements: Sequence[ast.AST], indent: str) -> str:
+    return "".join(
+        f"{indent}{line}\n"
+        for statement in statements
+        for line in ast.unparse(ast.fix_missing_locations(statement)).splitlines()
+    )
+
+
+class _Evaluator:
+    def __init__(
+        self,
+        state: CodegenState,
+        plan: Tcgen05PairEpiloguePlan,
+        *,
+        carrier: str,
+        current_index: str,
+        partner_index: str,
+        pair_coordinate: str,
+        current_flat: _Index,
+        partner_flat: _Index,
+        indent: str,
+        terminals: dict[tuple[str, Node, _Index], ast.AST],
+    ) -> None:
+        self.state = state
+        self.plan = plan
+        self.carrier = carrier
+        self.current_index = current_index
+        self.partner_index = partner_index
+        self.current_flat = current_flat
+        self.partner_flat = partner_flat
+        self.indent = indent
+        self.terminals = terminals
+        self.memo: dict[tuple[Node, _Index, int | None], ast.AST] = {}
+        self.lines: list[str] = []
+        tile_shape = _shape(plan.value_node, state.device_function.config)
+        self.variables = {
+            "row": (
+                f"cutlass.Int32({pair_coordinate}[0]) % cutlass.Int32({tile_shape[-2]})"
+            ),
+            "pair": (
+                f"(cutlass.Int32({pair_coordinate}[1]) % "
+                f"cutlass.Int32({tile_shape[-1]})) // cutlass.Int32(2)"
+            ),
+        }
+
+    def _bind(self, prefix: str, value: ast.AST) -> ast.AST:
+        name = self.state.device_function.new_var(prefix)
+        self.lines.append(
+            _render_statements(
+                [statement_from_string(f"{name} = {{value}}", value=value)], self.indent
+            )
+        )
+        return expr_from_string(name)
+
+    def _boundary(self, node: Node, flat: _Index) -> ast.AST:
+        key = ("boundary", node, flat)
+        if key in self.terminals:
+            return self.terminals[key]
+        if flat == self.current_flat:
+            expression = f"{self.carrier}[{self.current_index}]"
+        elif flat == self.partner_flat:
+            expression = f"{self.carrier}[{self.partner_index}]"
+        else:
+            requested = flat.render(self.variables)
+            current = self.current_flat.render(self.variables)
+            expression = (
+                f"{self.carrier}[{self.current_index}] if ({requested}) == ({current}) "
+                f"else {self.carrier}[{self.partner_index}]"
+            )
+        result = self._bind("tcgen05_epi_acc", expr_from_string(expression))
+        self.terminals[key] = result
+        return result
+
+    def _tile_index(self, node: Node, flat: _Index) -> ast.AST:
+        from ...language.memory_ops import _cute_tile_begin_expr
+
+        key = ("index", node, flat)
+        if key in self.terminals:
+            return self.terminals[key]
+        size_node = node.args[0] if node.args else None
+        size = size_node.meta.get("val") if isinstance(size_node, Node) else size_node
+        coord = _coords_from_flat(
+            flat, _shape(node, self.state.device_function.config)
+        )[0]
+        result = self._bind(
+            "tcgen05_epi_index",
+            expr_from_string(
+                f"cutlass.Int32({_cute_tile_begin_expr(self.state, size)}) + "
+                f"cutlass.Int32({coord.render(self.variables)})"
+            ),
+        )
+        self.terminals[key] = result
+        return result
+
+    def _host_load(self, node: Node, flat: _Index) -> ast.AST:
+        from ...language.memory_ops import _cute_scalar_load_expr
+        from ...language.memory_ops import _cute_tile_begin_expr
+
+        key = ("load", node, flat)
+        if key in self.terminals:
+            return self.terminals[key]
+        source = node.args[0]
+        indices = node.args[1]
+        assert isinstance(source, Node) and isinstance(indices, (list, tuple))
+        tensor = source.meta["val"]
+        assert isinstance(tensor, torch.Tensor)
+        tensor_name = self.state.device_function.tensor_arg(tensor).name
+        self.state.device_function.placeholder_args.add(tensor_name)
+        output_shape = _shape(node, self.state.device_function.config)
+        output_coords = _coords_from_flat(flat, output_shape)
+        tensor_indices = [
+            index
+            for index in indices
+            if isinstance(index, Node)
+            and isinstance(index.meta.get("val"), torch.Tensor)
+        ]
+        index_exprs: list[str] = []
+        if tensor_indices:
+            for index in tensor_indices:
+                index_flat = _broadcast_flat(
+                    flat, output_shape, _shape(index, self.state.device_function.config)
+                )
+                index_exprs.append(ast.unparse(self.evaluate(index, index_flat)))
+        else:
+            output_dim = 0
+            for index in indices:
+                if isinstance(index, Node) and isinstance(
+                    index.meta.get("val"), torch.SymInt
+                ):
+                    extent = index.meta["val"]
+                elif index == slice(None):
+                    extent = node.meta["val"].shape[output_dim]
+                else:
+                    assert isinstance(index, int)
+                    index_exprs.append(str(index))
+                    continue
+                index_exprs.append(
+                    f"cutlass.Int32({_cute_tile_begin_expr(self.state, extent)}) + "
+                    f"cutlass.Int32({output_coords[output_dim].render(self.variables)})"
+                )
+                output_dim += 1
+        result = self._bind(
+            "tcgen05_epi_load",
+            expr_from_string(
+                _cute_scalar_load_expr(tensor_name, index_exprs, tensor.dtype)
+            ),
+        )
+        self.terminals[key] = result
+        return result
+
+    def _pointwise(self, node: Node, flat: _Index, inputs: tuple[Node, ...]) -> ast.AST:
+        from ..aten_lowering import LoweringContext
+        from ..inductor_lowering import PointwiseLowering
+
+        lowering = node.meta.get("lowering")
+        if not isinstance(lowering, PointwiseLowering):
+            raise RuntimeError(f"non-pointwise fragment node {node.name}")
+        output_shape = _shape(node, self.state.device_function.config)
+        input_values = [
+            self.evaluate(
+                input_node,
+                _broadcast_flat(
+                    flat,
+                    output_shape,
+                    _shape(input_node, self.state.device_function.config),
+                ),
+            )
+            for input_node in inputs
+        ]
+        ctx = LoweringContext.__new__(LoweringContext)
+        ctx.cg = self.state.codegen
+        ctx.env = self.state.env
+        statements: list[ast.AST] = []
+        with (
+            self.state.codegen.set_statements(statements),
+            V.set_current_node(node),
+        ):
+            result = lowering.codegen_from_input_asts(ctx, node, input_values)
+        if not isinstance(result, ast.AST):
+            raise RuntimeError(f"invalid pointwise fragment result for {node.name}")
+        self.lines.append(_render_statements(statements, self.indent))
+        return self._bind("tcgen05_epi_value", result)
+
+    def evaluate(
+        self, node: Node, flat: _Index, projection: int | None = None
+    ) -> ast.AST:
+        key = (node, flat, projection)
+        if key in self.memo:
+            return self.memo[key]
+
+        def leaf(
+            current: Node, current_flat: _Index, current_projection: int | None
+        ) -> object:
+            if (
+                current is not node
+                or current_flat != flat
+                or current_projection != projection
+            ):
+                return self.evaluate(current, current_flat, current_projection)
+            if current in self.plan.boundary_nodes:
+                return self._boundary(current, current_flat)
+            if current.target is tile_index:
+                return self._tile_index(current, current_flat)
+            source = current.args[0] if current.args else None
+            if (
+                current.target is memory_ops.load
+                and isinstance(source, Node)
+                and _is_host_tensor(source)
+            ):
+                return self._host_load(current, current_flat)
+            inputs = _pointwise_inputs(current)
+            if inputs is not None:
+                return self._pointwise(current, current_flat, inputs)
+            raise RuntimeError(f"unsupported committed fragment node {current.name}")
+
+        def choose(selector: _Index, left: object, right: object) -> object:
+            if not isinstance(left, ast.AST) or not isinstance(right, ast.AST):
+                raise RuntimeError("invalid fragment selection")
+            if (constant := _constant_index(selector)) is not None:
+                return left if constant == 0 else right
+            return self._bind(
+                "tcgen05_epi_select",
+                expr_from_string(
+                    f"({{left}} if ({selector.render(self.variables)}) == "
+                    "cutlass.Int32(0) else {right})",
+                    left=left,
+                    right=right,
+                ),
+            )
+
+        result = _resolve_shape(
+            node,
+            flat,
+            config=self.state.device_function.config,
+            evaluate=leaf,
+            choose=choose,
+            projection=projection,
+        )
+        if not isinstance(result, ast.AST):
+            raise RuntimeError(f"invalid committed fragment result for {node.name}")
+        self.memo[key] = result
+        return result
+
+
+def render_tcgen05_pair_epilogue(
+    state: CodegenState,
+    plan: Tcgen05PairEpiloguePlan,
+    *,
+    carrier_name: str,
+    coordinate_name: str,
+    target_dtype: str,
+    indent: str,
+) -> tuple[str, str]:
+    """Render the committed graph once for each adjacent register pair."""
+    output_shape = _shape(plan.value_node, state.device_function.config)
+    row = _Index.variable("row", output_shape[-2] - 1)
+    pair = _Index.variable("pair", output_shape[-1] // _TCGEN05_PAIR_WIDTH - 1)
+    current_flat = _flat_from_coords(
+        [_Index.constant(0), row, _mul(pair, 2)], output_shape
+    )
+    partner_flat = _flat_from_coords(
+        [_Index.constant(0), row, _add(_mul(pair, 2), 1)], output_shape
+    )
+    df = state.device_function
+    output = df.new_var("tcgen05_epi_output")
+    current_index = df.new_var("tcgen05_epi_pair")
+    partner_index = df.new_var("tcgen05_epi_partner")
+    pair_coordinate = df.new_var("tcgen05_epi_pair_coord")
+    body_indent = indent + "    "
+    terminals: dict[tuple[str, Node, _Index], ast.AST] = {}
+    current = _Evaluator(
+        state,
+        plan,
+        carrier=carrier_name,
+        current_index=current_index,
+        partner_index=partner_index,
+        pair_coordinate=pair_coordinate,
+        current_flat=current_flat,
+        partner_flat=partner_flat,
+        indent=body_indent,
+        terminals=terminals,
+    )
+    partner = _Evaluator(
+        state,
+        plan,
+        carrier=carrier_name,
+        current_index=partner_index,
+        partner_index=current_index,
+        pair_coordinate=pair_coordinate,
+        current_flat=partner_flat,
+        partner_flat=current_flat,
+        indent=body_indent,
+        terminals=terminals,
+    )
+    current_value = current.evaluate(plan.value_node, current_flat)
+    partner_value = partner.evaluate(plan.value_node, partner_flat)
+    prelude = (
+        f"{indent}assert cute.size({carrier_name}.shape) % 2 == 0, "
+        '"tcgen05 pair carrier must be complete"\n'
+        f"{indent}{output} = cute.make_rmem_tensor("
+        f"cute.make_layout({carrier_name}.shape), {target_dtype})\n"
+        f"{indent}for {current_index} in range(0, cute.size({carrier_name}.shape), 2):\n"
+        f"{body_indent}{partner_index} = {current_index} + 1\n"
+        f"{body_indent}{pair_coordinate} = {coordinate_name}[{current_index}]\n"
+        f"{''.join(current.lines)}"
+        f"{body_indent}{output}[{current_index}] = "
+        f"{target_dtype}({ast.unparse(current_value)})\n"
+        f"{''.join(partner.lines)}"
+        f"{body_indent}{output}[{partner_index}] = "
+        f"{target_dtype}({ast.unparse(partner_value)})\n"
+    )
+    return prelude, f"{output}.load()"

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -1460,6 +1460,54 @@ def _try_splice_tcgen05_unary_epilogue(
     return ast.Constant(value=None)
 
 
+def _try_codegen_tcgen05_pair_epilogue(
+    state: CodegenState,
+    tensor: object,
+    subscript: list[object] | tuple[object, ...],
+    ast_subscript: list[object] | tuple[object, ...],
+    extra_mask: ast.AST | None,
+) -> ast.AST | None:
+    plan = state.device_function.cute_state.tcgen05_pair_epilogue_plan_for_store(
+        state.fx_node
+    )
+    if plan is None:
+        return None
+    if not isinstance(tensor, torch.Tensor):
+        raise exc.BackendUnsupported("cute", "planned tcgen05 store is not a tensor")
+    from ..inductor_lowering import is_deferred_tcgen05_pair_epilogue
+
+    value_node = state.fx_node.args[2] if state.fx_node is not None else None
+    if value_node is not plan.value_node or not is_deferred_tcgen05_pair_epilogue(
+        state.ast_args[2]
+    ):
+        raise exc.BackendUnsupported(
+            "cute", "committed tcgen05 pair epilogue received the wrong store value"
+        )
+    result_var = state.device_function.cute_state.matmul_fx_node_result_vars.get(
+        plan.anchor
+    )
+    if result_var is None:
+        raise exc.BackendUnsupported(
+            "cute", "tcgen05 pair epilogue store ran before its MMA anchor"
+        )
+    rewritten = _codegen_cute_store_tcgen05_tile(
+        state,
+        tensor,
+        subscript,
+        ast_subscript,
+        extra_mask,
+        result_var,
+        pair_epilogue=plan,
+    )
+    if rewritten is None:
+        raise exc.BackendUnsupported(
+            "cute", "committed tcgen05 pair epilogue could not render its store"
+        )
+    for statement in rewritten if isinstance(rewritten, list) else [rewritten]:
+        state.add_statement(statement)
+    return ast.Constant(value=None)
+
+
 def _try_splice_tcgen05_grouped_tail_epilogue(
     state: CodegenState,
     tensor: object,
@@ -1510,6 +1558,12 @@ def _(state: CodegenState) -> ast.AST:
     raw_value = state.ast_args[2]
     extra_mask = state.ast_args[3]
     assert isinstance(extra_mask, (type(None), ast.AST))
+    if (
+        planned := _try_codegen_tcgen05_pair_epilogue(
+            state, tensor, subscript, ast_subscript, extra_mask
+        )
+    ) is not None:
+        return planned
     value_node = None
     if state.fx_node is not None and len(state.fx_node.args) > 2:
         maybe_value_node = state.fx_node.args[2]

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -3782,6 +3782,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                 from ..language.matmul_ops import enable_cute_tcgen05_search
                 from ..language.matmul_ops import plan_cute_tcgen05_search
                 from .cute.cute_mma import analyze_cute_mma_node
+                from .cute.cute_mma import tcgen05_pair_epilogue_can_shape_search
+                from .cute.cute_mma import tcgen05_pair_epilogue_has_unique_anchor
+                from .cute.cute_mma import tcgen05_pair_epilogue_present
 
                 # The same structural analyzer gates tcgen05 search and codegen
                 # for every matrix rank. This prevents transformed loads from
@@ -3814,9 +3817,25 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                                 candidate.operands.has_leading_passthrough
                             ),
                         )
-                        if search_plan is None:
+                        if search_plan is None or not (
+                            tcgen05_pair_epilogue_can_shape_search(
+                                device_ir.graphs,
+                                node,
+                                candidate,
+                                min_search_m=search_plan.min_search_m,
+                                max_search_m=search_plan.max_search_m,
+                                max_search_n=search_plan.max_search_n,
+                            )
+                        ):
                             continue
                         search_candidates.append((candidate, lhs, search_plan))
+                if tcgen05_pair_epilogue_present(
+                    device_ir.graphs
+                ) and not tcgen05_pair_epilogue_has_unique_anchor(
+                    device_ir.graphs,
+                    device_ir=device_ir,
+                ):
+                    search_candidates.clear()
                 analysis_keys = {
                     (
                         candidate.operands.output_block_ids,

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -486,19 +486,35 @@ class FakeGraphLowering(GraphLowering):
 
 class PointwiseLowering(InductorLowering):
     def codegen(self, ctx: LoweringContext, node: torch.fx.Node) -> object:
+        return self.codegen_from_input_asts(ctx, node, self.input_asts(ctx, node))
+
+    def codegen_from_input_asts(
+        self,
+        ctx: LoweringContext,
+        node: torch.fx.Node,
+        input_asts: list[ast.AST],
+    ) -> object:
+        """Lower this pointwise node with explicitly supplied tensor values."""
         # Validate broadcasting of tile block dimensions to catch shape mismatches
         self._check_block_broadcast_compatibility(ctx, node)
-        with self.install_kernel_handlers(ctx, node):
+        assert len(input_asts) == len(self.input_names)
+        with install_inductor_kernel_handlers(
+            ctx.cg, dict(zip(self.input_names, input_asts, strict=True))
+        ):
             indices = [
                 sympy.Symbol(f"i{n}") for n in range(len(self.buffer.data.ranges))
             ]
             output_name = _unpack_opsvalue(self.buffer.data.inner_fn(indices))
             result = expr_from_string(output_name)
 
-        return self._reshape_for_size1_reduction(ctx, node, result)
+        return self._reshape_for_size1_reduction(ctx, node, result, input_asts)
 
     def _reshape_for_size1_reduction(
-        self, ctx: LoweringContext, node: torch.fx.Node, result: ast.AST
+        self,
+        ctx: LoweringContext,
+        node: torch.fx.Node,
+        result: ast.AST,
+        input_asts: list[ast.AST] | None = None,
     ) -> ast.AST:
         # When Inductor converts a size-1 reduction to a Pointwise op, the
         # buffer has fewer ranges than the inputs.  This happens when the
@@ -516,7 +532,9 @@ class PointwiseLowering(InductorLowering):
             # Cute lowers one element per thread, so synthetic size-1 view dims
             # (from unsqueeze/keepdim paths rewritten to pointwise) must collapse
             # back to the underlying scalar expression.
-            inputs = self.input_asts(ctx, node)
+            inputs = (
+                input_asts if input_asts is not None else self.input_asts(ctx, node)
+            )
             if len(inputs) == 1:
                 return inputs[0]
 
@@ -1478,6 +1496,25 @@ class GraphInterpreter(LoweringContext, Interpreter):
                 V.set_current_node(n),
             ):
                 try:
+                    cute_state = self.cg.device_function.cute_state
+                    if cute_state.has_tcgen05_pair_epilogue_plan:
+                        if cute_state.is_deferred_tcgen05_pair_epilogue_node(n):
+                            n.meta["codegen"] = _DEFERRED_TCGEN05_PAIR_EPILOGUE
+                            return _DEFERRED_TCGEN05_PAIR_EPILOGUE
+                        if (
+                            any(
+                                self.env.get(input_node)
+                                is _DEFERRED_TCGEN05_PAIR_EPILOGUE
+                                for input_node in n.all_input_nodes
+                            )
+                            and cute_state.tcgen05_pair_epilogue_plan_for_store(n)
+                            is None
+                        ):
+                            raise exc.BackendUnsupported(
+                                "cute",
+                                "deferred tcgen05 pair epilogue escaped its "
+                                "committed store",
+                            )
                     lowering: Lowering = n.meta["lowering"]
                     result = lowering.codegen(self, n)
                     n.meta["codegen"] = result
@@ -1532,6 +1569,13 @@ class GraphInterpreter(LoweringContext, Interpreter):
                         f"Error in codegen for node {n.name} ({n.target}): {e}"
                     ) from e
         return super().run_node(n)
+
+
+_DEFERRED_TCGEN05_PAIR_EPILOGUE = object()
+
+
+def is_deferred_tcgen05_pair_epilogue(value: object) -> bool:
+    return value is _DEFERRED_TCGEN05_PAIR_EPILOGUE
 
 
 def codegen_call_with_graph(

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
     from .._compiler.cute.cute_epilogue import Tcgen05UnaryEpilogueChain
     from .._compiler.cute.cute_epilogue import _AuxiliaryTensorStep
     from .._compiler.cute.device_state import CuteTcgen05StoreValue
+    from .._compiler.cute.fragment_epilogue import Tcgen05PairEpiloguePlan
     from .._compiler.inductor_lowering import CodegenState
     from .._compiler.tile_strategy import LoopDimInfo
 
@@ -1527,6 +1528,7 @@ def _codegen_cute_store_tcgen05_tile(
     value_name: str,
     epilogue_chain: Tcgen05UnaryEpilogueChain | None = None,
     grouped_tail_epilogue: Tcgen05GroupedTailEpilogueMatch | None = None,
+    pair_epilogue: Tcgen05PairEpiloguePlan | None = None,
 ) -> list[ast.AST] | ast.AST | None:
     df = state.device_function
     candidate_names = df.variable_aliases(value_name)
@@ -1581,20 +1583,30 @@ def _codegen_cute_store_tcgen05_tile(
             "tcgen05 matmul store requires the exact zero-offset output tile axes",
         )
     if tcgen05_value.pure_matmul_role_lifecycle:
-        if epilogue_chain is not None or grouped_tail_epilogue is not None:
+        if (
+            epilogue_chain is not None
+            or grouped_tail_epilogue is not None
+            or pair_epilogue is not None
+        ):
             raise exc.BackendUnsupported(
                 "cute",
                 "tcgen05 pure role-lifecycle supports only identity pure-matmul stores",
             )
     if tcgen05_value.orientation is Tcgen05Orientation.NM and (
-        epilogue_chain is not None or grouped_tail_epilogue is not None
+        epilogue_chain is not None
+        or grouped_tail_epilogue is not None
+        or pair_epilogue is not None
     ):
         raise exc.BackendUnsupported(
             "cute",
             "tcgen05 N,M-oriented worklist path supports only an identity BF16 store",
         )
     assert (
-        sum(value is not None for value in (epilogue_chain, grouped_tail_epilogue)) <= 1
+        sum(
+            value is not None
+            for value in (epilogue_chain, grouped_tail_epilogue, pair_epilogue)
+        )
+        <= 1
     )
     # When one matmul accumulator fans out to multiple output stores (e.g.
     # aux = pre-activation and out = gelu(pre)), the per-matmul TMA-store
@@ -3014,6 +3026,21 @@ def _codegen_cute_store_tcgen05_tile(
         chain.
         """
         load_expr = f"{carrier_name}.load()"
+        if pair_epilogue is not None:
+            coordinate_setup, coordinate_name = _coord_subtile_source(
+                prelude_indent, coord_layout, include_setup=True
+            )
+            from .._compiler.cute.fragment_epilogue import render_tcgen05_pair_epilogue
+
+            pair_prelude, pair_expression = render_tcgen05_pair_epilogue(
+                state,
+                pair_epilogue,
+                carrier_name=carrier_name,
+                coordinate_name=coordinate_name,
+                target_dtype=target_dtype,
+                indent=prelude_indent,
+            )
+            return "", coordinate_setup + pair_prelude, pair_expression
         if epilogue_chain is None or not epilogue_chain.steps:
             rhs = load_expr
             late_prelude = ""
@@ -4789,6 +4816,11 @@ def _codegen_cute_store_tcgen05_tile(
                 "cutlass.utils.gemm.sm100.epilogue_tmem_copy_and_partition("
                 f"{kernel_desc}, {tcgen05_aux_epi_tidx}, {tacc}, "
                 f"{tcgc_planned}, {epi_tile}, {tcgen05_lifecycle.is_two_cta!s})"
+            ),
+            *(
+                [f"{thr_copy_t2r} = {tiled_copy_t2r}.get_slice({tcgen05_aux_epi_tidx})"]
+                if pair_epilogue is not None
+                else []
             ),
             f"{ttr_rd} = cute.make_rmem_tensor({ttr_racc}.shape, {target_dtype})",
             (

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -5,7 +5,9 @@ import contextlib
 import dataclasses
 import operator
 import re
+import tempfile
 from types import SimpleNamespace
+from typing import Any
 from typing import Sequence
 from typing import cast
 import unittest
@@ -80,6 +82,11 @@ from helion._compiler.cute.cute_reshape import _get_dim_local_coord
 from helion._compiler.cute.cute_reshape import codegen_cute_permute
 from helion._compiler.cute.cute_reshape import codegen_cute_reshape
 from helion._compiler.cute.device_state import CuteDeviceFunctionState
+from helion._compiler.cute.fragment_epilogue import _add
+from helion._compiler.cute.fragment_epilogue import _floordiv
+from helion._compiler.cute.fragment_epilogue import _Index
+from helion._compiler.cute.fragment_epilogue import _mod
+from helion._compiler.cute.fragment_epilogue import _mul
 from helion._compiler.cute.indexing import CutePackedAffineLoad
 from helion._compiler.cute.indexing import CutePackedTerms
 from helion._compiler.cute.indexing import CuteShapeChainView
@@ -425,6 +432,208 @@ def cute_matmul_role_local_monolithic_bias_relu_bf16(
             acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
         out[tile_m, tile_n] = torch.relu(acc + bias[tile_n]).to(x.dtype)
     return out
+
+
+@helion.kernel(backend="cute")
+def cute_projection_rotary_bf16(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    table: torch.Tensor,
+    bias: torch.Tensor,
+) -> torch.Tensor:
+    m, k = x.size()
+    h, _, d = weight.size()
+    out = torch.empty([h, m, d], dtype=x.dtype, device=x.device)
+    for tile_h, tile_m, tile_d in hl.tile([h, m, d]):
+        acc = hl.zeros([tile_h, tile_m, tile_d], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(
+                x[tile_m, tile_k],
+                weight[tile_h, tile_k, tile_d],
+                acc=acc,
+            )
+        bias_tile = bias[tile_h.index[:, None], tile_d.index[None, :]]
+        acc = acc + bias_tile[:, None, :]
+        table_tile = table[tile_m, tile_d]
+        table_pairs = table_tile.view(
+            tile_m.block_size, 2, tile_d.block_size // 2
+        ).permute(0, 2, 1)
+        left, right = hl.split(table_pairs)
+        pairs = acc.view(
+            tile_h.block_size,
+            tile_m.block_size,
+            tile_d.block_size // 2,
+            2,
+        )
+        x0, x1 = hl.split(pairs)
+        perpendicular = hl.join(-x1, x0)
+        result = (
+            pairs * right[None, :, :, None] + perpendicular * left[None, :, :, None]
+        )
+        out[tile_h, tile_m, tile_d] = result.view(
+            tile_h.block_size, tile_m.block_size, tile_d.block_size
+        ).to(x.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
+def cute_pair_butterfly_bf16(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """A generic pair-local transform unrelated to rotary embeddings."""
+    m, k = x.size()
+    h, _, d = weight.size()
+    out = torch.empty([h, m, d], dtype=x.dtype, device=x.device)
+    for tile_h, tile_m, tile_d in hl.tile([h, m, d]):
+        acc = hl.zeros([tile_h, tile_m, tile_d], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], weight[tile_h, tile_k, tile_d], acc=acc)
+        pairs = acc.view(
+            tile_h.block_size,
+            tile_m.block_size,
+            tile_d.block_size // 2,
+            2,
+        )
+        low, high = hl.split(pairs)
+        out[tile_h, tile_m, tile_d] = (
+            hl.join(low + high, low - high)
+            .view(tile_h.block_size, tile_m.block_size, tile_d.block_size)
+            .to(x.dtype)
+        )
+    return out
+
+
+@helion.kernel(backend="cute")
+def cute_cross_pair_swap_bf16(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """A reshape transform that is deliberately not register-pair-local."""
+    m, k = x.size()
+    h, _, d = weight.size()
+    out = torch.empty([h, m, d], dtype=x.dtype, device=x.device)
+    for tile_h, tile_m, tile_d in hl.tile([h, m, d]):
+        acc = hl.zeros([tile_h, tile_m, tile_d], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], weight[tile_h, tile_k, tile_d], acc=acc)
+        halves = acc.view(
+            tile_h.block_size,
+            tile_m.block_size,
+            2,
+            tile_d.block_size // 2,
+        ).permute(0, 1, 3, 2)
+        low, high = hl.split(halves)
+        out[tile_h, tile_m, tile_d] = (
+            hl.join(high, low)
+            .view(tile_h.block_size, tile_m.block_size, tile_d.block_size)
+            .to(x.dtype)
+        )
+    return out
+
+
+@helion.kernel(backend="cute")
+def cute_pair_column_major_output_bf16(
+    x: torch.Tensor, weight: torch.Tensor
+) -> torch.Tensor:
+    """A valid pair transform stored through a column-major output view."""
+    m, k = x.size()
+    h, _, d = weight.size()
+    base = torch.empty([d, m, h], dtype=x.dtype, device=x.device)
+    out = base.permute(2, 1, 0)
+    for tile_h, tile_m, tile_d in hl.tile([h, m, d]):
+        acc = hl.zeros([tile_h, tile_m, tile_d], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], weight[tile_h, tile_k, tile_d], acc=acc)
+        pairs = acc.view(
+            tile_h.block_size,
+            tile_m.block_size,
+            tile_d.block_size // 2,
+            2,
+        )
+        low, high = hl.split(pairs)
+        out[tile_h, tile_m, tile_d] = (
+            hl.join(low + high, low - high)
+            .view(tile_h.block_size, tile_m.block_size, tile_d.block_size)
+            .to(x.dtype)
+        )
+    return out
+
+
+@helion.kernel(backend="cute")
+def cute_mixed_pair_plain_bf16(
+    x1: torch.Tensor,
+    x2: torch.Tensor,
+    weight1: torch.Tensor,
+    weight2: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pair-local and ordinary MMAs in separate K loops under one root."""
+    m, k = x1.size()
+    h, _, d = weight1.size()
+    pair_out = torch.empty([h, m, d], dtype=x1.dtype, device=x1.device)
+    plain_out = torch.empty_like(pair_out)
+    for tile_h, tile_m, tile_d in hl.tile([h, m, d]):
+        pair_acc = hl.zeros([tile_h, tile_m, tile_d], dtype=torch.float32)
+        for tile_k1 in hl.tile(k):
+            pair_acc = hl.dot(
+                x1[tile_m, tile_k1],
+                weight1[tile_h, tile_k1, tile_d],
+                acc=pair_acc,
+            )
+        pairs = pair_acc.view(
+            tile_h.block_size,
+            tile_m.block_size,
+            tile_d.block_size // 2,
+            2,
+        )
+        low, high = hl.split(pairs)
+        pair_out[tile_h, tile_m, tile_d] = (
+            hl.join(low + high, low - high)
+            .view(tile_h.block_size, tile_m.block_size, tile_d.block_size)
+            .to(x1.dtype)
+        )
+
+        plain_acc = hl.zeros([tile_h, tile_m, tile_d], dtype=torch.float32)
+        for tile_k2 in hl.tile(k):
+            plain_acc = hl.dot(
+                x2[tile_m, tile_k2],
+                weight2[tile_h, tile_k2, tile_d],
+                acc=plain_acc,
+            )
+        plain_out[tile_h, tile_m, tile_d] = plain_acc.to(x1.dtype)
+    return pair_out, plain_out
+
+
+@helion.kernel(backend="cute")
+def cute_pair_plus_f32_mma(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """A pair candidate plus a decoded MMA outside tcgen05 search."""
+    m, k = x.size()
+    h, _, d = weight.size()
+    m2, k2 = a.size()
+    _, n2 = b.size()
+    pair_out = torch.empty([h, m, d], dtype=x.dtype, device=x.device)
+    f32_out = torch.empty([m2, n2], dtype=a.dtype, device=a.device)
+    for tile_h, tile_m, tile_d in hl.tile([h, m, d]):
+        acc = hl.zeros([tile_h, tile_m, tile_d], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], weight[tile_h, tile_k, tile_d], acc=acc)
+        pairs = acc.view(
+            tile_h.block_size,
+            tile_m.block_size,
+            tile_d.block_size // 2,
+            2,
+        )
+        low, high = hl.split(pairs)
+        pair_out[tile_h, tile_m, tile_d] = (
+            hl.join(low + high, low - high)
+            .view(tile_h.block_size, tile_m.block_size, tile_d.block_size)
+            .to(x.dtype)
+        )
+    for tile_m2, tile_n2 in hl.tile([m2, n2]):
+        f32_acc = hl.zeros([tile_m2, tile_n2], dtype=torch.float32)
+        for tile_k2 in hl.tile(k2):
+            f32_acc = hl.dot(a[tile_m2, tile_k2], b[tile_k2, tile_n2], acc=f32_acc)
+        f32_out[tile_m2, tile_n2] = f32_acc
+    return pair_out, f32_out
 
 
 class _FakeBlockSize:
@@ -8066,6 +8275,8 @@ class TestCuteLowerings(unittest.TestCase):
         )
         bound.set_config(cfg)
         with (
+            tempfile.TemporaryDirectory() as cache_dir,
+            patch.dict("os.environ", {"CUTE_DSL_CACHE_DIR": cache_dir}, clear=False),
             patch(
                 "cutlass.cute.arch.fma_packed_f32x2",
                 wraps=cute.arch.fma_packed_f32x2,
@@ -15064,6 +15275,299 @@ class TestCuteLowerings(unittest.TestCase):
                 ),
                 "(mask_1)",
             )
+
+    def test_tcgen05_pair_index_compiler_matches_sympy(self) -> None:
+        row = _Index.variable("row", 3)
+        pair = _Index.variable("pair", 4)
+        numerator = _add(_add(_mul(row, -3), _mul(pair, 5)), -1)
+        expression = _mod(_floordiv(numerator, 2), 7)
+        evaluate = expression.compile()
+
+        rendered = expression.render({"row": "row", "pair": "pair"})
+        self.assertIn("//", rendered)
+        self.assertIn("%", rendered)
+        for row_value in range(4):
+            for pair_value in range(5):
+                variables = {"row": row_value, "pair": pair_value}
+                substitutions = {
+                    symbol: variables[str(symbol)]
+                    for symbol, _lower, _upper in expression.bounds
+                }
+                expected = int(
+                    cast("sympy.Integer", expression.semantic.subs(substitutions))
+                )
+                self.assertEqual(evaluate(variables), expected)
+
+    def test_tcgen05_pair_plan_rejection_is_memoized_per_tile_shape(self) -> None:
+        from helion._compiler.cute import cute_mma as cute_mma_module
+
+        graph = Graph()
+        anchor = graph.placeholder("mma")
+        fn = cast(
+            "Any",
+            SimpleNamespace(
+                cute_state=CuteDeviceFunctionState(),
+                codegen=SimpleNamespace(codegen_graphs=[SimpleNamespace(graph=graph)]),
+            ),
+        )
+        candidate = cast(
+            "Any",
+            SimpleNamespace(
+                requires_pair_epilogue=True,
+                operands=SimpleNamespace(output_block_ids=()),
+            ),
+        )
+        config = cast("Any", {})
+
+        with (
+            patch.object(
+                cute_mma_module, "_decode_cute_mma_target", return_value=object()
+            ),
+            patch.object(
+                cute_mma_module,
+                "_tcgen05_pair_epilogue_operands_supported",
+                return_value=True,
+            ),
+            patch.object(
+                cute_mma_module, "_mma_tiles_are_static_full", return_value=True
+            ),
+            patch.object(
+                cute_mma_module,
+                "analyze_tcgen05_pair_epilogue_plan",
+                return_value=None,
+            ) as analyze,
+        ):
+            for bn in (64, 64, 128):
+                self.assertFalse(
+                    cute_mma_module.ensure_tcgen05_pair_epilogue_plan(
+                        fn,
+                        anchor,
+                        candidate,
+                        bm=128,
+                        bn=bn,
+                        bk=32,
+                        config=config,
+                    )
+                )
+
+        self.assertEqual(analyze.call_count, 2)
+
+    def test_tcgen05_pair_fragment_projection_rotary_codegen(self) -> None:
+        dtype = torch.bfloat16
+        x = torch.empty([128, 128], device=DEVICE, dtype=dtype)
+        for head_dim in (64, 128):
+            with self.subTest(head_dim=head_dim), patch_cute_mma_support():
+                args = (
+                    x,
+                    torch.empty([1, 128, head_dim], device=DEVICE, dtype=dtype),
+                    torch.empty([128, head_dim], device=DEVICE, dtype=dtype),
+                    torch.empty([1, head_dim], device=DEVICE, dtype=dtype),
+                )
+                config = _make_tcgen05_persistent_config(
+                    block_sizes=[1, 128, head_dim, 32],
+                    loop_orders=[[0, 1, 2]],
+                    pid_type="persistent_interleaved",
+                )
+                bound = cute_projection_rotary_bf16.bind(args)
+                self.assertTrue(bound.config_spec.cute_tcgen05_search_enabled)
+                bound.set_config(config)
+                code = bound.to_triton_code(config)
+                self.assertEqual(code.count("for tcgen05_epi_pair"), 1)
+                self.assertEqual(
+                    len(
+                        re.findall(
+                            r"^\s*tcgen05_epi_load_\d+ = ",
+                            code,
+                            flags=re.MULTILINE,
+                        )
+                    ),
+                    4,
+                )
+                self.assertNotIn("split_smem", code)
+                self.assertNotIn("permute_smem", code)
+
+    def test_tcgen05_pair_fragment_projection_rotary_runtime(self) -> None:
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+        torch.manual_seed(0)
+        dtype = torch.bfloat16
+        heads, m, k = 2, 256, 128
+        x = torch.randn([m, k], device=DEVICE, dtype=dtype)
+        for head_dim in (64, 128):
+            with self.subTest(head_dim=head_dim), patch_cute_mma_support():
+                weight = torch.randn([heads, k, head_dim], device=DEVICE, dtype=dtype)
+                table = torch.randn([m, head_dim], device=DEVICE, dtype=dtype)
+                bias = torch.randn([heads, head_dim], device=DEVICE, dtype=dtype)
+                args = (x, weight, table, bias)
+                config = _make_tcgen05_persistent_config(
+                    block_sizes=[1, 128, head_dim, 32],
+                    loop_orders=[[0, 1, 2]],
+                    pid_type="persistent_interleaved",
+                )
+                bound = cute_projection_rotary_bf16.bind(args)
+                bound.env.config_spec.cute_tcgen05_search_enabled = True
+                bound.set_config(config)
+                actual = bound(*args)
+
+                acc = torch.einsum("mk,hkd->hmd", x.float(), weight.float())
+                pairs = (acc + bias.float()[:, None, :]).view(
+                    heads, m, head_dim // 2, 2
+                )
+                left, right = (
+                    table.float().view(m, 2, head_dim // 2).permute(0, 2, 1)
+                ).unbind(-1)
+                expected = torch.stack(
+                    (
+                        pairs[..., 0] * right - pairs[..., 1] * left,
+                        pairs[..., 1] * right + pairs[..., 0] * left,
+                    ),
+                    dim=-1,
+                ).view(heads, m, head_dim)
+                torch.testing.assert_close(
+                    actual, expected.to(dtype), atol=0.1, rtol=1e-2
+                )
+
+    def test_tcgen05_pair_fragment_is_generic_and_locality_checked(self) -> None:
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+        torch.manual_seed(1)
+        dtype = torch.bfloat16
+        x = torch.randn([128, 64], device=DEVICE, dtype=dtype)
+        weight = torch.randn([1, 64, 64], device=DEVICE, dtype=dtype)
+        config = _make_tcgen05_persistent_config(
+            block_sizes=[1, 128, 64, 32],
+            loop_orders=[[0, 1, 2]],
+            pid_type="persistent_interleaved",
+        )
+        with patch_cute_mma_support():
+            bound = cute_pair_butterfly_bf16.bind((x, weight))
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            bound.set_config(config)
+            self.assertIn("for tcgen05_epi_pair", bound.to_triton_code(config))
+            actual = bound(x, weight)
+
+            rejected = cute_cross_pair_swap_bf16.bind((x, weight))
+            self.assertFalse(rejected.config_spec.cute_tcgen05_search_enabled)
+            rejected.env.config_spec.cute_tcgen05_search_enabled = True
+            with self.assertRaisesRegex(
+                exc.BackendUnsupported, "pair epilogue locality proof rejected"
+            ):
+                rejected.to_triton_code(config)
+        pairs = torch.einsum("mk,hkd->hmd", x.float(), weight.float()).view(
+            1, 128, 32, 2
+        )
+        expected = torch.stack(
+            (pairs[..., 0] + pairs[..., 1], pairs[..., 0] - pairs[..., 1]), dim=-1
+        ).view(1, 128, 64)
+        torch.testing.assert_close(actual, expected.to(dtype), atol=0.5, rtol=2e-2)
+
+    def test_tcgen05_pair_fragment_mixed_mma_is_rejected_atomically(self) -> None:
+        dtype = torch.bfloat16
+        args = (
+            torch.empty([128, 64], device=DEVICE, dtype=dtype),
+            torch.empty([128, 64], device=DEVICE, dtype=dtype),
+            torch.empty([1, 64, 64], device=DEVICE, dtype=dtype),
+            torch.empty([1, 64, 64], device=DEVICE, dtype=dtype),
+        )
+        with patch_cute_mma_support():
+            bound = cute_mixed_pair_plain_bf16.bind(args)
+            self.assertFalse(bound.config_spec.cute_tcgen05_search_enabled)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            for pid_type in ("flat", "persistent_interleaved"):
+                config = _make_tcgen05_persistent_config(
+                    block_sizes=[1, 128, 64, 32, 32],
+                    loop_orders=[[0, 1, 2]],
+                    pid_type=pid_type,
+                )
+                with (
+                    self.subTest(pid_type=pid_type),
+                    self.assertRaisesRegex(
+                        exc.BackendUnsupported,
+                        "pair epilogue requires a unique MMA",
+                    ),
+                ):
+                    bound.to_triton_code(config)
+
+    def test_tcgen05_pair_fragment_mixed_ineligible_mma_disables_search(self) -> None:
+        args = (
+            torch.empty([128, 64], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([1, 64, 64], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([128, 64], device=DEVICE, dtype=torch.float32),
+            torch.empty([64, 64], device=DEVICE, dtype=torch.float32),
+        )
+        with patch_cute_mma_support():
+            bound = cute_pair_plus_f32_mma.bind(args)
+        self.assertFalse(bound.config_spec.cute_tcgen05_search_enabled)
+
+    def test_tcgen05_pair_fragment_rejects_unplanned_search_tiles(self) -> None:
+        args = (
+            torch.empty([128, 64], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([1, 64, 64], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_pair_butterfly_bf16.bind(args)
+            self.assertTrue(bound.config_spec.cute_tcgen05_search_enabled)
+            for block_sizes in (
+                [1, 64, 64, 32],
+                [1, 128, 32, 32],
+                [1, 64, 32, 32],
+                [1, 128, 8, 32],
+            ):
+                config = _make_tcgen05_persistent_config(
+                    block_sizes=block_sizes,
+                    loop_orders=[[0, 1, 2]],
+                    pid_type="flat",
+                )
+                with (
+                    self.subTest(block_sizes=block_sizes),
+                    self.assertRaisesRegex(
+                        exc.BackendUnsupported,
+                        "pair epilogue locality proof rejected",
+                    ),
+                ):
+                    bound.to_triton_code(config)
+
+    def test_tcgen05_pair_fragment_column_major_output_disables_search(self) -> None:
+        args = (
+            torch.empty([128, 64], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([1, 64, 64], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_pair_column_major_output_bf16.bind(args)
+        self.assertFalse(bound.config_spec.cute_tcgen05_search_enabled)
+
+    def test_tcgen05_pair_fragment_rejects_explicit_epilogue_layout(self) -> None:
+        dtype = torch.bfloat16
+        args = (
+            torch.empty([128, 128], device=DEVICE, dtype=dtype),
+            torch.empty([1, 128, 64], device=DEVICE, dtype=dtype),
+            torch.empty([128, 64], device=DEVICE, dtype=dtype),
+            torch.empty([1, 64], device=DEVICE, dtype=dtype),
+        )
+        config = _make_tcgen05_persistent_config(
+            block_sizes=[1, 128, 64, 32],
+            loop_orders=[[0, 1, 2]],
+            pid_type="flat",
+            **{
+                TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
+                    Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+                ),
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 64,
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 64,
+                TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 64,
+            },
+        )
+        with patch_cute_mma_support():
+            bound = cute_projection_rotary_bf16.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            with self.assertRaisesRegex(
+                exc.BackendUnsupported, "pair epilogue locality proof rejected"
+            ):
+                bound.to_triton_code(config)
 
 
 @onlyBackends(["cute"])


### PR DESCRIPTION
## Summary

The `tcgen05` epilogue currently uses a strict allowlist. It walks backward from the output store, recognizes a supported expression shape, and replaces that expression with a hand-written CuTe template. This PR removes that classifier and instead executes the existing FX pointwise lowerings directly on the `tcgen05` accumulator fragment between T2R and R2S.

This is not a new collection of recognized epilogues. Each FX node is admitted independently through its existing `PointwiseLowering` or CuTe-enabled pure-fragment `APIFuncLowering`. The same mechanism handles bias, residual adds, ReLU, GELU, SiLU, casts, scaling, and compatible compositions without identifying any of those formulas.

## Before: classify an allowed expression

SiLU is the clearest example of the old approach. Inductor can decompose SiLU into either `x * sigmoid(x)` or `x / (1 + exp(-x))`. The old `tcgen05` analyzer had a dedicated `_classify_silu` routine that checked the exact FX topology, operand identity, argument order, and kwargs. If it matched, the entire expression was represented as one `_UnaryStep` containing this separate CuTe template:

```cpp
x * (1.0 / (1.0 + cute.math.exp2(-x * 1.4426950408889634)))
```
The tcgen05 path therefore had its own implementation of SiLU in addition to the normal pointwise lowering. A different but valid decomposition, an intervening supported operation, or an unrecognized composition failed the classifier even when every individual operation already had a CuTe lowering. Bias and residual operands required another specialized auxiliary-tensor classifier, and GELU and other activations needed their own allowlist entries or templates.


## After: lower the existing FX graph on the fragment
The new analyzer retains the actual FX region from the matmul boundary to the store. For the decomposed SiLU above, fragment emission is conceptually:

```Python
acc = rAcc.load()
neg = lower_existing_pointwise(aten.neg, acc)
exp = lower_existing_pointwise(aten.exp, neg)
denominator = lower_existing_pointwise(aten.add, exp, 1)
result = lower_existing_pointwise(aten.div, acc, denominator)
rAccStore = result
```
lower_existing_pointwise is not a new epilogue dispatcher. The implementation calls PointwiseLowering.codegen_from_input_asts with fragment values substituted for the node’s normal inputs. Inductor’s existing inner_fn remains responsible for operation semantics, kwargs, dtype conversions, and the concrete CuTe math operation. If the FX graph uses x * sigmoid(x) instead, those existing multiply and sigmoid lowerings are replayed. GELU follows the same route through its existing pointwise or pure-fragment lowering; the epilogue planner does not need to know that the resulting graph is GELU.

## Planning and placement
Before normal FX code generation, the compiler finds stores reached from a tcgen05 matmul and constructs an exact backward slice. The plan records the matmul boundary, owned FX nodes, stores, auxiliary loads, logical coordinate requests, and required execution mode. A node is accepted only when its own lowering and coordinate behavior are supported. The region is rejected if an owned value escapes to another consumer, a store does not use the exact output tile axes, a load cannot be reproduced safely, or an accumulator request leaves the proven local fragment.

The compiler propagates output coordinates backward through reshape, view, expand, permute, split, join, and broadcast operations. This determines whether the epilogue can run on the whole TensorSSA fragment or needs scalar-coordinate evaluation. Output-aligned bias and residual loads reuse the existing staged auxiliary pipeline. Other supported loads retain their original FX indices and are rematerialized with the existing scalar-load lowering.

The plan is committed atomically only after the centralized MMA gate confirms the selected implementation is tcgen05 and that the tile shape, operand layout, TMA path, cluster configuration, and fragment-local coordinate requirements are compatible. A failed check registers nothing and leaves the existing fallback path unchanged.

## Emission without AST rewriting
Once a plan is committed, its owned FX nodes return a private deferred-value marker during normal graph interpretation; they do not emit code. The marker is only valid at the exact planned store. The matmul registers its existing tcgen05 accumulator object against the FX anchor, and the store replays the planned lowerings after TMEM-to-register transfer and before the existing register-to-shared-memory/TMA store path.

This replaces emit -> recognize -> remove/rebuild with analyze FX -> commit -> defer -> emit once. The FX graph is not rewritten, generated epilogue AST is not deleted, and the existing tcgen05 transport, synchronization, edge handling, and store lifecycle remain unchanged.

## Execution modes
The common path loads the accumulator once as TensorSSA, binds output-aligned auxiliary fragments, and replays the existing lowerings over the complete fragment. This covers the current bias, residual, ReLU, GELU, SiLU, and scaled epilogues. Coordinate-changing views and direct indexed loads use a correctness-first scalar evaluator driven by the same logical-coordinate resolver used during planning. The stacked follow-up PR optimizes proven pair-local scalar evaluation; it does not change the generic lowering model introduced here.