### PR TITLE
[Pallas] xsa TPU sweep: use bfloat16 (was float16, hit Mosaic vector-type bug)

### DIFF
--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -837,9 +837,14 @@ def _xsa_shapes(
         configs = configs[:num_shapes]
     out: list[tuple[str, tuple[Any, ...]]] = []
     for b, h, t, d in configs:
-        q = torch.randn(b, h, t, d, device=DEVICE, dtype=torch.float16)
-        k = torch.randn(b, h, t, d, device=DEVICE, dtype=torch.float16)
-        v = torch.randn(b, h, t, d, device=DEVICE, dtype=torch.float16)
+        # bfloat16, not float16: TPU Mosaic hits an "Invalid vector type for
+        # load" codegen error on fp16 attention shapes (the vector<8x128x2xf16>
+        # layout fp16 forces). bfloat16 sidesteps this; it's also the dtype
+        # test_examples.test_xsa uses (via HALF_DTYPE on TPU) and the sweep
+        # convention for every other kernel here.
+        q = torch.randn(b, h, t, d, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.randn(b, h, t, d, device=DEVICE, dtype=torch.bfloat16)
+        v = torch.randn(b, h, t, d, device=DEVICE, dtype=torch.bfloat16)
         out.append((f"[{b},{h},{t},{d}]", (q, k, v)))
     return out
 


### PR DESCRIPTION
## Summary

Change the xsa TPU sweep from `float16` to `bfloat16`. Both xsa rows FAILed in the 2026-07-28 full sweep with:

```
mosaic failed to compile TPU kernel: Invalid vector type for load
%424 = "tpu.load"(...) : (memref<1x1024x256xf16, ...>) -> vector<8x128x2xf16>
```

`fp16` at head_dim=256 forces the `vector<8x128x2xf16>` layout (2 elements per lane), which trips a Mosaic codegen path. `bfloat16` avoids that layout and compiles fine. It's also the dtype `test_examples.test_xsa` uses on TPU (`HALF_DTYPE` resolves to `bf16` there) and matches every other bf16-attention row in `benchmarks/run_tpu.py`.

Verified on TPU v7 with full autotune + `--subprocess-per-shape`:

| Shape | Helion (ms) | Torch (ms) | Helion vs eager | vs torch.compile |
|---|---|---|---|---|
| `[2,32,1024,256]` | 0.620 | 1.60 | **2.59×** | 1.74× |
| `[4,32,2048,256]` | 1.603 | 8.73 | **5.45×** | 2.52× |
