### PR TITLE
[Pallas] Move welford to the run_tpu.py TPU holdout

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -51,15 +51,15 @@ on:
         # Triton bug is fixed. Forward `rope` stays in the list.
         default: "flash_attention,gdn_fwd_h,cross_entropy,grouped_gemm,gemm,welford,layer_norm-bwd,int4_gemm,softmax,layer_norm,mamba2_chunk_state,rms_norm-bwd,rope,jsd,mamba2_chunk_scan,kl_div,rms_norm"
       kernels_tpu:
-        description: 'Kernels benchmarked on TPU via run_tpu.py: the kernels the tritonbench bridge cannot fully cover on TPU — bmm (no tritonbench operator), cross_entropy (Helion Mosaic-codegen holdout), and flash_attention (the bridge''s torch.compile comparator is flex_attention, which does not run on TPU, so the bridge would drop flash_attention''s torch_compile column; run_tpu.py compiles the SDPA baseline instead and keeps it). Everything else runs via the bridge (kernels_tpu_bridge). `all` runs every kernel in benchmarks/run_tpu.py::KERNEL_MAPPINGS.'
+        description: 'Kernels benchmarked on TPU via run_tpu.py: the kernels the tritonbench bridge cannot fully cover on TPU — bmm (no tritonbench operator), cross_entropy (Helion Mosaic-codegen holdout), flash_attention (the bridge''s torch.compile comparator is flex_attention, which does not run on TPU, so the bridge would drop flash_attention''s torch_compile column; run_tpu.py compiles the SDPA baseline instead and keeps it), and welford (the tritonbench bridge''s accuracy check fails on TPU for every impl — a torch_tpu harness issue, not the kernel; run_tpu.py''s own check passes). Everything else runs via the bridge (kernels_tpu_bridge). `all` runs every kernel in benchmarks/run_tpu.py::KERNEL_MAPPINGS.'
         required: false
         type: string
-        default: "bmm,cross_entropy,flash_attention"
+        default: "bmm,cross_entropy,flash_attention,welford"
       kernels_tpu_bridge:
         description: 'Kernels benchmarked on TPU via the tritonbench bridge (benchmarks/run.py --device tpu). These land in the shared `tpu` dashboard column alongside kernels_tpu (disjoint sets).'
         required: false
         type: string
-        default: "gemm,welford,softmax,layer_norm,rms_norm,rms_norm-bwd,kl_div"
+        default: "gemm,softmax,layer_norm,rms_norm,rms_norm-bwd,kl_div"
       kernels_cute:
         description: 'Comma-separated list of kernels to benchmark on B200 with HELION_BACKEND=cute. Defaults to the CuTe-capable TritonBench subset.'
         required: false


### PR DESCRIPTION
`welford` fails accuracy on the tritonbench TPU bridge for *every* implementation (Helion and torch.compile alike) while passing under `run_tpu.py` — a torch_tpu harness issue, not the kernel (a direct call produces the correct output). Until that's root-caused, run `welford` via the `run_tpu.py` holdout (`kernels_tpu`) where it measures correctly.

`rms_norm-bwd` **stays on the bridge** — its earlier bridge failures are fixed at the source: the backward accuracy harness fed each implementation a *different* random `grad_output` on TPU (fixed by meta-pytorch/tritonbench#1207, which shares one gradient across impls), and the separate pallas autotune crash is #3206. So it no longer needs the holdout.

Depends on #1207 (+ tritonbench pin bump) and #3206 landing before `rms_norm-bwd` is green on the bridge.
