### PR TITLE
[CuTe] Beat CUTLASS across the scaled FP8 matmul sweep

### DIFF
--- a/helion/_compiler/cute/cute_epilogue.py
+++ b/helion/_compiler/cute/cute_epilogue.py
@@ -146,6 +146,13 @@ class _AuxiliaryTensorStep:
     broadcast_axis: int | None = None
 
 
+@dataclasses.dataclass(frozen=True)
+class _AuxiliaryTensorProductStep:
+    """A carrier multiplied by an explicitly parenthesized pair of aux loads."""
+
+    operands: tuple[_AuxiliaryTensorStep, _AuxiliaryTensorStep]
+
+
 # The cute DSL surface for whitelisted unary operations. Renderings are
 # inline Python expressions on a TensorSSA value. All renderings
 # preserve dtype (we only operate on float accumulators here), so the
@@ -466,7 +473,7 @@ class Tcgen05UnaryEpilogueChain:
     and the partitioned tile, neither of which this module knows about.
     """
 
-    steps: tuple[_UnaryStep | _AuxiliaryTensorStep, ...]
+    steps: tuple[_UnaryStep | _AuxiliaryTensorStep | _AuxiliaryTensorProductStep, ...]
 
     @property
     def auxiliary_tensor_steps(self) -> tuple[_AuxiliaryTensorStep, ...]:
@@ -477,7 +484,13 @@ class Tcgen05UnaryEpilogueChain:
         per-thread aux load setup runs once per output tile (outside
         the per-subtile chain rendering).
         """
-        return tuple(s for s in self.steps if isinstance(s, _AuxiliaryTensorStep))
+        result: list[_AuxiliaryTensorStep] = []
+        for step in self.steps:
+            if isinstance(step, _AuxiliaryTensorStep):
+                result.append(step)
+            elif isinstance(step, _AuxiliaryTensorProductStep):
+                result.extend(step.operands)
+        return tuple(result)
 
     def render_prelude_and_expr(
         self,
@@ -532,6 +545,18 @@ class Tcgen05UnaryEpilogueChain:
         cur_expr = carrier_name
         local = carrier_name
         for step in self.steps:
+            if isinstance(step, _AuxiliaryTensorProductStep):
+                lhs_aux = next(aux_local_iter)
+                rhs_aux = next(aux_local_iter)
+                local = local_name_factory(  # type: ignore[operator]
+                    "tcgen05_chain_step"
+                )
+                assert isinstance(local, str)
+                prelude_lines.append(
+                    f"{prelude_indent}{local} = {cur_expr} * ({lhs_aux} * {rhs_aux})\n"
+                )
+                cur_expr = local
+                continue
             if isinstance(step, _AuxiliaryTensorStep):
                 # Auxiliary-tensor binary op. The splice site has
                 # already bound the per-thread aux load to a local
@@ -707,7 +732,13 @@ def _classify_binary(
     carrier_tile_shape: tuple[object, ...] | None,
     carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None = None,
     carrier_global_shape: tuple[object, ...] | None = None,
-) -> tuple[_UnaryStep | _AuxiliaryTensorStep, torch.fx.Node] | None:
+) -> (
+    tuple[
+        _UnaryStep | _AuxiliaryTensorStep | _AuxiliaryTensorProductStep,
+        torch.fx.Node,
+    ]
+    | None
+):
     """Classify ``cur`` (a ``call_function`` node whose target is on the
     binary whitelist) as a single chain step plus its FX carrier node.
 
@@ -745,6 +776,15 @@ def _classify_binary(
     rhs_is_node = isinstance(rhs, torch.fx.Node)
     if lhs_is_node and rhs_is_node:
         assert isinstance(lhs, torch.fx.Node) and isinstance(rhs, torch.fx.Node)
+        if target is torch.ops.aten.mul.Tensor:
+            product_operands = _classify_auxiliary_product(
+                rhs,
+                carrier_tile_shape=carrier_tile_shape,
+                carrier_tile_index_nodes=carrier_tile_index_nodes,
+                carrier_global_shape=carrier_global_shape,
+            )
+            if product_operands is not None:
+                return _AuxiliaryTensorProductStep(product_operands), lhs
         # Both args are FX nodes. One must be a recognized auxiliary
         # tensor load; the other is the chain carrier. If both look
         # like aux loads or neither does, bail — the chain has no
@@ -847,6 +887,48 @@ def _classify_binary(
         )
         return _UnaryStep(op_name="div", template=template), scalar_carrier
     return None
+
+
+def _classify_auxiliary_product(
+    node: torch.fx.Node,
+    *,
+    carrier_tile_shape: tuple[object, ...] | None,
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    carrier_global_shape: tuple[object, ...] | None,
+) -> tuple[_AuxiliaryTensorStep, _AuxiliaryTensorStep] | None:
+    """Recognize ``aux_load * aux_load`` without changing FP association."""
+    if (
+        node.op != "call_function"
+        or node.target is not torch.ops.aten.mul.Tensor
+        or node.kwargs
+        or len(node.args) != 2
+    ):
+        return None
+    result: list[_AuxiliaryTensorStep] = []
+    for operand in node.args[:2]:
+        if not isinstance(operand, torch.fx.Node):
+            return None
+        load_node, aux_template = _aux_load_operand(operand)
+        if aux_template != "{aux}":
+            return None
+        kind = aux_tensor_load_kind(
+            load_node,
+            carrier_tile_shape=carrier_tile_shape,
+            carrier_tile_index_nodes=carrier_tile_index_nodes,
+            carrier_global_shape=carrier_global_shape,
+        )
+        if kind is None:
+            return None
+        broadcast_axis = kind[1] if kind[0] == "broadcast" else None
+        result.append(
+            _AuxiliaryTensorStep(
+                op_name="mul",
+                op_template="{carrier} * {aux}",
+                load_node=load_node,
+                broadcast_axis=broadcast_axis,
+            )
+        )
+    return result[0], result[1]
 
 
 def _carrier_tile_shape(node: torch.fx.Node) -> tuple[object, ...] | None:
@@ -1052,7 +1134,7 @@ def analyze_tcgen05_unary_epilogue_chain(
     carrier_tile_shape = _carrier_tile_shape(chain_input)
     carrier_tile_index_nodes = _carrier_tile_index_nodes(chain_input)
 
-    steps: list[_UnaryStep | _AuxiliaryTensorStep] = []
+    steps: list[_UnaryStep | _AuxiliaryTensorStep | _AuxiliaryTensorProductStep] = []
     cur: torch.fx.Node = chain_input
     # Bound the walk so a pathological FX graph cannot loop forever.
     # 32 unary ops between the matmul and the store is an absurd upper

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -2459,6 +2459,17 @@ def _emit_mma_pipeline(
             "tcgen05 MMA codegen",
         )
     tcgen05_pid_is_persistent = _is_persistent_pid_config(df.config)
+    tcgen05_role_local_small_n_edge_tma = (
+        mma_impl == "tcgen05"
+        and tcgen05_use_tma_pipeline
+        and tcgen05_pid_is_persistent
+        and tcgen05_cluster_m == 1
+        and _tcgen05_cluster_n(df.config) == 1
+        and 0 < n_size < bn
+        and rhs_operand.trailing_transpose
+        and m_size % bm == 0
+        and k_total_size % bk == 0
+    )
     tcgen05_requested_two_cta = _tcgen05_use_2cta_instrs(
         bm=bm,
         cluster_m=tcgen05_cluster_m,
@@ -2566,6 +2577,7 @@ def _emit_mma_pipeline(
         and not tcgen05_m_edge_only
         and not tcgen05_n_edge_only
         and not tcgen05_double_edge_tma
+        and not tcgen05_role_local_small_n_edge_tma
     ):
         # Mixed TMA full K tiles + scalar fallback tails are currently
         # validated only for flat one-CTA kernels. Persistent CtaGroup.TWO
@@ -2640,12 +2652,12 @@ def _emit_mma_pipeline(
         TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY
     )
     if df.config.get(TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY, False):
-        one_shot_m_slots = (m_size // bm) * (2 if tcgen05_is_two_cta else 1)
-        one_shot_n_slots = n_size // bn
+        one_shot_m_slots = ((m_size + bm - 1) // bm) * (2 if tcgen05_is_two_cta else 1)
+        one_shot_n_slots = (n_size + bn - 1) // bn
         one_shot_work_ctas = one_shot_m_slots * one_shot_n_slots
         if not (
             tcgen05_pid_is_persistent
-            and tcgen05_static_full_tiles
+            and (tcgen05_static_full_tiles or tcgen05_role_local_small_n_edge_tma)
             and input_dtype == torch.float8_e4m3fn
             and not analysis.has_leading_passthrough
             and role_scheduler_cluster_cap is None
@@ -2656,7 +2668,8 @@ def _emit_mma_pipeline(
             raise exc.BackendUnsupported(
                 "cute",
                 f"{TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY}=True requires a "
-                "static-full, unbatched persistent FP8 grid without a role "
+                "static-full or small-N-edge unbatched persistent FP8 grid "
+                "without a role "
                 "scheduler cluster cap and with at most "
                 f"{TCGEN05_ONE_SHOT_ROLE_SCHEDULER_MAX_CTAS} work CTAs",
             )
@@ -2749,6 +2762,7 @@ def _emit_mma_pipeline(
             or tcgen05_role_local_m_edge_tma
             or tcgen05_role_local_n_edge_tma
             or tcgen05_role_local_double_edge_tma
+            or tcgen05_role_local_small_n_edge_tma
         )
         and tcgen05_role_local_codegen_allowed
         and tcgen05_pid_is_persistent
@@ -2939,6 +2953,8 @@ def _emit_mma_pipeline(
     tcgen05_use_tma_store_epilogue = (
         mma_impl == "tcgen05"
         and tcgen05_use_tma_pipeline
+        # Narrow stores are faster through the direct SIMT epilogue.
+        and bn >= 32
         and (
             tcgen05_static_full_tiles
             or tcgen05_role_local_k_tail_tma
@@ -4426,7 +4442,7 @@ def _emit_mma_pipeline(
                 f"{m_offset_var} < cutlass.Int32({m_size}) "
                 f"and {n_offset_var} + cutlass.Int32({bn}) <= cutlass.Int32({n_size}) "
             )
-        if tcgen05_role_local_n_edge_tma:
+        if tcgen05_role_local_n_edge_tma or tcgen05_role_local_small_n_edge_tma:
             # The role-local N-edge path lets TMA handle the partial B stripe
             # while the SIMT epilogue predicates aux loads and D stores.
             return (

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -95,6 +95,9 @@ from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_PID_TYPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_PROBLEM_SHAPE
+from .tcgen05_constants import TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_ONE_SHOT_ROLE_SCHEDULER_MAX_CTAS
+from .tcgen05_constants import TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
@@ -437,6 +440,23 @@ def _trace_to_load(node: Node) -> Node | None:
     return cur
 
 
+def _load_exclusively_feeds_operand(
+    load_node: Node, operand_node: Node, mma_node: Node
+) -> bool:
+    """Whether a load reaches one MMA through an exclusive wrapper chain."""
+    current = load_node
+    while current is not operand_node:
+        if len(current.users) != 1:
+            return False
+        (current,) = current.users
+        if current.op != "call_function" or current.target not in (
+            *_TRACE_THROUGH_TARGETS,
+            torch.ops.aten.permute.default,
+        ):
+            return False
+    return set(current.users) == {mma_node}
+
+
 def _trace_to_load_tensor(node: Node) -> tuple[Node, str, torch.Tensor] | None:
     """Trace through dtype casts to find the underlying load tensor."""
     load_node = _trace_to_load(node)
@@ -489,15 +509,26 @@ class _MmaOperandInfo:
     # (N leading axes is a possible future generalization).
     load: Node
     source_fake: torch.Tensor
+    logical_fake: torch.Tensor
     block_ids: tuple[int, ...]
+    trailing_transpose: bool = False
+
+    @property
+    def matrix_major(self) -> str | None:
+        major = _tcgen05_tma_matrix_major(self.source_fake)
+        if not self.trailing_transpose or major is None:
+            return major
+        return "col" if major == "row" else "row"
 
     @property
     def matrix_rows(self) -> int | torch.SymInt:
-        return self.source_fake.size(-2)
+        axis = -1 if self.trailing_transpose else -2
+        return self.source_fake.size(axis)
 
     @property
     def matrix_cols(self) -> int | torch.SymInt:
-        return self.source_fake.size(-1)
+        axis = -2 if self.trailing_transpose else -1
+        return self.source_fake.size(axis)
 
     @property
     def matrix_row_block_id(self) -> int:
@@ -559,6 +590,7 @@ class _MmaOperandAnalysis:
 @dataclass(frozen=True)
 class _MmaOutputStoreAnalysis:
     explicit_epi_tile_compatible: bool
+    output_column_major: bool
 
 
 def _mma_tiles_are_static_full(
@@ -576,7 +608,27 @@ def _analyze_mma_operand(
     node: Node,
     env: CompileEnvironment,
 ) -> _MmaOperandInfo | None:
-    info = _direct_load_tensor(node)
+    trailing_transpose = False
+    load_value = node
+    if node.op == "call_function" and node.target is torch.ops.aten.permute.default:
+        if len(node.args) != 2 or not isinstance(node.args[0], Node):
+            return None
+        value_fake = node.meta.get("val")
+        order = node.args[1]
+        if not isinstance(value_fake, torch.Tensor) or not isinstance(
+            order, (list, tuple)
+        ):
+            return None
+        normalized = tuple(int(dim) % value_fake.ndim for dim in order)
+        if normalized != (
+            *range(value_fake.ndim - 2),
+            value_fake.ndim - 1,
+            value_fake.ndim - 2,
+        ):
+            return None
+        load_value = node.args[0]
+        trailing_transpose = True
+    info = _direct_load_tensor(load_value)
     if info is None:
         return None
     load_node, _, source_fake = info
@@ -597,14 +649,20 @@ def _analyze_mma_operand(
             block_size, source_fake.size(dim)
         ):
             return None
+    if trailing_transpose:
+        block_ids = (*block_ids[:-2], block_ids[-1], block_ids[-2])
     if source_fake.ndim not in (2, 3):
+        return None
+    if trailing_transpose and source_fake.ndim == 3:
         return None
     if value_fake.ndim not in (2, source_fake.ndim):
         return None
     return _MmaOperandInfo(
         load=load_node,
         source_fake=source_fake,
+        logical_fake=value_fake,
         block_ids=block_ids,
+        trailing_transpose=trailing_transpose,
     )
 
 
@@ -637,7 +695,7 @@ def _analyze_mma_operands(
     # matrices. Keep other layouts out of the shared search/planning/codegen
     # capability until their rank-3 descriptor mapping is supported.
     if leading_passthrough_block_id is not None and any(
-        operand.source_fake.stride(-1) != 1
+        operand.matrix_major != "row"
         for operand in (lhs, rhs)
         if operand.is_leading_passthrough
     ):
@@ -664,6 +722,7 @@ class _CuteMmaNode(_CuteMmaTarget):
 
     operands: _MmaOperandAnalysis
     explicit_epi_tile_compatible: bool
+    output_column_major: bool
 
     @property
     def requires_scalar_fallback(self) -> bool:
@@ -769,7 +828,10 @@ def analyze_cute_mma_node(
     if not _mma_result_can_be_deferred(node) or not _mma_loop_is_exclusive(node):
         return None
     output_store_analysis: _MmaOutputStoreAnalysis | None = None
-    if operands.has_leading_passthrough:
+    needs_output_store_analysis = operands.has_leading_passthrough or (
+        operands.lhs.trailing_transpose and operands.rhs.trailing_transpose
+    )
+    if needs_output_store_analysis:
         cached = node.meta.get(_MMA_OUTPUT_STORE_ANALYSIS_META_KEY)
         if isinstance(cached, _MmaOutputStoreAnalysis):
             output_store_analysis = cached
@@ -806,13 +868,18 @@ def analyze_cute_mma_node(
         out_dtype=target.out_dtype,
         operands=operands,
         explicit_epi_tile_compatible=(
-            _tcgen05_tma_matrix_major(operands.lhs.source_fake) == "row"
-            and _tcgen05_tma_matrix_major(operands.rhs.source_fake) in ("row", "col")
+            operands.lhs.matrix_major == "row"
+            and operands.rhs.matrix_major in ("row", "col")
             and (
                 output_store_analysis.explicit_epi_tile_compatible
                 if output_store_analysis is not None
                 else True
             )
+        ),
+        output_column_major=(
+            output_store_analysis.output_column_major
+            if output_store_analysis is not None
+            else False
         ),
         with_acc=target.with_acc,
         is_dot=target.is_dot,
@@ -1258,12 +1325,9 @@ def prepare_cute_collective_lane_loop_suppression(
             analysis, bm=bm, bn=bn, bk=bk
         ):
             continue
-        if (
-            len(lhs_load.users) != 1
-            or len(rhs_load.users) != 1
-            or next(iter(lhs_load.users)) is not node
-            or next(iter(rhs_load.users)) is not node
-        ):
+        if not _load_exclusively_feeds_operand(
+            lhs_load, candidate.lhs, node
+        ) or not _load_exclusively_feeds_operand(rhs_load, candidate.rhs, node):
             continue
 
         # Mirror the real codegen bailout in ``_emit_mma_pipeline`` (it returns
@@ -1340,6 +1404,7 @@ class _PerKiterTmaArgs:
     # (cute_plan.md §6.12.7). Default 1 preserves byte-identity for the
     # validated cluster_m=2 cluster_n=1 path.
     cluster_n: int = 1
+    cluster_m: int = 2
     # Static-full one-CTA pipelined TMA loops can drop the per-K runtime
     # full-tile branch and scalar fallback. Non-pipelined/asymmetric or two-CTA
     # TMA paths must keep the guarded fallback path.
@@ -1387,6 +1452,7 @@ def _tcgen05_two_cta_owner_predicate(
     is_two_cta: bool,
     gate_exec_warp: bool,
     cluster_n: int = 1,
+    cluster_m: int = 2,
 ) -> str | None:
     """Owner-of-the-V-pair predicate for AB consumer release / MMA issuance.
 
@@ -1404,7 +1470,7 @@ def _tcgen05_two_cta_owner_predicate(
     if gate_exec_warp:
         predicate_terms.append(exec_active)
     if is_two_cta:
-        if cluster_n > 1:
+        if cluster_n > 1 or cluster_m > 2:
             predicate_terms.append(_TCGEN05_V_LEADER_PREDICATE)
         else:
             predicate_terms.append(_TCGEN05_CLUSTER_LEADER_PREDICATE)
@@ -1431,9 +1497,6 @@ def _build_kloop_pipeline_producer_if(
     """
     assert args.use_tma_a and args.use_tma_b, (
         "pipelined branch requires both A and B to be TMA-loaded"
-    )
-    assert not (args.static_full_tiles and args.is_two_cta), (
-        "static-full fast path is only valid for one-CTA pipelined TMA loops"
     )
     k_offset = f"{args.tma_k_tile} + cutlass.Int32({args.ab_stage_count})"
     predicate_terms = []
@@ -1477,13 +1540,13 @@ def _build_kloop_pipeline_consumer_if(
     include_scalar_fallback: bool = True,
     use_existing_try_token: bool = False,
     sync_before_scalar_fallback: bool = False,
+    owner_already_gated: bool = False,
 ) -> ast.stmt:
     """Per-K-iter TMA consumer / scalar-fallback ``if`` for the pipelined branch."""
     if args.static_full_tiles:
-        assert not args.is_two_cta, (
-            "static-full fast path is only valid for one-CTA pipelined TMA loops"
+        assert gate_exec_warp or owner_already_gated, (
+            "static-full fast path requires an exec-warp or outer-owner gate"
         )
-        assert gate_exec_warp, "static-full fast path requires an exec-warp gate"
         assert not include_scalar_fallback, (
             "static-full fast path has no scalar fallback branch"
         )
@@ -1503,14 +1566,18 @@ def _build_kloop_pipeline_consumer_if(
             f"{args.tma_pipeline}.consumer_wait("
             f"{args.tma_consumer_state}, {args.tma_consumer_try_token})"
         )
-    full_tile_src = _tcgen05_emit_optional_gate(
-        consumer_src,
-        _tcgen05_two_cta_owner_predicate(
+    owner_predicate = None
+    if not owner_already_gated:
+        owner_predicate = _tcgen05_two_cta_owner_predicate(
             args.exec_active,
             is_two_cta=args.is_two_cta,
             gate_exec_warp=gate_exec_warp,
             cluster_n=args.cluster_n,
-        ),
+            cluster_m=args.cluster_m,
+        )
+    full_tile_src = _tcgen05_emit_optional_gate(
+        consumer_src,
+        owner_predicate,
         indent="" if args.static_full_tiles else "    ",
     )
     if args.static_full_tiles:
@@ -1537,16 +1604,20 @@ def _build_kloop_pipeline_consumer_prefetch_stmts(
     args: _PerKiterTmaArgs,
     *,
     gate_exec_warp: bool = True,
+    owner_already_gated: bool = False,
 ) -> list[ast.stmt]:
     """Peek the next AB full barrier after advancing the consumer state."""
     assert args.is_two_cta, "AB consumer prefetch is validated for CtaGroup.TWO"
     predicate = args.tma_next_consumer_tile
-    owner_predicate = _tcgen05_two_cta_owner_predicate(
-        args.exec_active,
-        is_two_cta=args.is_two_cta,
-        gate_exec_warp=gate_exec_warp,
-        cluster_n=args.cluster_n,
-    )
+    owner_predicate = None
+    if not owner_already_gated:
+        owner_predicate = _tcgen05_two_cta_owner_predicate(
+            args.exec_active,
+            is_two_cta=args.is_two_cta,
+            gate_exec_warp=gate_exec_warp,
+            cluster_n=args.cluster_n,
+            cluster_m=args.cluster_m,
+        )
     if owner_predicate is not None:
         predicate = f"{predicate} and {owner_predicate}"
     return [
@@ -1564,6 +1635,7 @@ def _build_kloop_pipeline_release_if(
     *,
     gate_exec_warp: bool = True,
     include_scalar_fallback: bool = True,
+    owner_already_gated: bool = False,
 ) -> ast.stmt:
     """Per-K-iter consumer release ``if`` for the pipelined branch.
 
@@ -1575,23 +1647,25 @@ def _build_kloop_pipeline_release_if(
     multicast mask; separate peer arrivals over-count the empty barrier.
     """
     if args.static_full_tiles:
-        assert not args.is_two_cta, (
-            "static-full fast path is only valid for one-CTA pipelined TMA loops"
+        assert gate_exec_warp or owner_already_gated, (
+            "static-full fast path requires an exec-warp or outer-owner gate"
         )
-        assert gate_exec_warp, "static-full fast path requires an exec-warp gate"
         assert not include_scalar_fallback, (
             "static-full fast path has no scalar fallback branch"
         )
     release_src = f"{args.tma_pipeline}.consumer_release({args.tma_consumer_state})"
-    release_gate = _tcgen05_two_cta_owner_predicate(
-        args.exec_active,
-        is_two_cta=args.is_two_cta,
-        gate_exec_warp=gate_exec_warp,
-        cluster_n=args.cluster_n,
-    )
+    release_gate = None
+    if not owner_already_gated:
+        release_gate = _tcgen05_two_cta_owner_predicate(
+            args.exec_active,
+            is_two_cta=args.is_two_cta,
+            gate_exec_warp=gate_exec_warp,
+            cluster_n=args.cluster_n,
+            cluster_m=args.cluster_m,
+        )
     advance_src = emit_pipeline_advance(args.tma_consumer_state)
     indent = "" if args.static_full_tiles else "    "
-    if args.is_two_cta:
+    if args.is_two_cta and not owner_already_gated:
         # With gate_exec_warp=False the caller is already inside the
         # role-local exec loop, so every iteration can advance local state.
         advance_gate = args.exec_active if gate_exec_warp else None
@@ -1605,6 +1679,25 @@ def _build_kloop_pipeline_release_if(
             release_src + "\n" + advance_src, release_gate, indent=indent
         )
     if args.static_full_tiles:
+        if args.is_two_cta and gate_exec_warp and not owner_already_gated:
+            owner_gate = _tcgen05_two_cta_owner_predicate(
+                args.exec_active,
+                is_two_cta=True,
+                gate_exec_warp=False,
+                cluster_n=args.cluster_n,
+                cluster_m=args.cluster_m,
+            )
+            assert owner_gate is not None
+            full_tile_src = (
+                f"if {args.exec_active}:\n"
+                f"    if {owner_gate}:\n"
+                f"        {release_src}\n" + textwrap.indent(advance_src, "    ")
+            )
+        elif owner_already_gated:
+            # Keep the release and state advance in one AST statement. The
+            # compile-time-true wrapper disappears during CuTe lowering.
+            full_tile_src = textwrap.indent(release_src + "\n" + advance_src, "    ")
+            full_tile_src = f"if True:\n{full_tile_src}"
         return statement_from_string(full_tile_src)
     fallback_src = (
         "\nelse:\n    cute.arch.sync_threads()" if include_scalar_fallback else ""
@@ -1620,6 +1713,7 @@ def _build_tcgen05_mma_accumulate_reset_stmt(
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
+    cluster_m: int = 2,
 ) -> ast.stmt:
     reset_src = f"{tiled_mma}.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, False)"
     predicate = _tcgen05_two_cta_owner_predicate(
@@ -1627,6 +1721,7 @@ def _build_tcgen05_mma_accumulate_reset_stmt(
         is_two_cta=is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=cluster_n,
+        cluster_m=cluster_m,
     )
     if predicate is None:
         return statement_from_string(reset_src)
@@ -1644,6 +1739,8 @@ def _build_tcgen05_mma_issue_stmt(
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
+    cluster_m: int = 2,
+    owner_already_gated: bool = False,
 ) -> ast.stmt:
     issue_src = (
         f"for _tcgen05_kblk_idx in range(cute.size({tcgen05_frag_a}, mode=[2])):\n"
@@ -1656,12 +1753,15 @@ def _build_tcgen05_mma_issue_stmt(
         "    )\n"
         f"    {tiled_mma}.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, True)"
     )
-    predicate = _tcgen05_two_cta_owner_predicate(
-        exec_active,
-        is_two_cta=is_two_cta,
-        gate_exec_warp=gate_exec_warp,
-        cluster_n=cluster_n,
-    )
+    predicate = None
+    if not owner_already_gated:
+        predicate = _tcgen05_two_cta_owner_predicate(
+            exec_active,
+            is_two_cta=is_two_cta,
+            gate_exec_warp=gate_exec_warp,
+            cluster_n=cluster_n,
+            cluster_m=cluster_m,
+        )
     if predicate is not None:
         issue_src = f"if {predicate}:\n{textwrap.indent(issue_src, '    ')}"
     return statement_from_string(issue_src)
@@ -2055,6 +2155,7 @@ def _analyze_mma_output_stores(
         return None
     env = CompileEnvironment.current()
     explicit_epi_tile_compatible = True
+    output_column_major: bool | None = None
     for store, chain in analyzed_stores:
         tensor_node = store.args[0] if store.args else None
         tensor_fake = (
@@ -2076,8 +2177,18 @@ def _analyze_mma_output_stores(
             tensor_fake.dtype == analysis.lhs.source_fake.dtype
             and all(step.broadcast_axis == 1 for step in chain.auxiliary_tensor_steps)
         )
+        strides = tensor_fake.stride()
+        shape = tensor_fake.shape
+        store_column_major = (
+            tensor_fake.ndim >= 2 and strides[-2] == 1 and strides[-1] == shape[-2]
+        )
+        if output_column_major is None:
+            output_column_major = store_column_major
+        elif output_column_major != store_column_major:
+            return None
     return _MmaOutputStoreAnalysis(
-        explicit_epi_tile_compatible=explicit_epi_tile_compatible
+        explicit_epi_tile_compatible=explicit_epi_tile_compatible,
+        output_column_major=bool(output_column_major),
     )
 
 
@@ -2153,8 +2264,8 @@ def _emit_mma_pipeline(
         torch.bfloat16,
         torch.float8_e4m3fn,
     )
-    _lhs_major = _tcgen05_tma_matrix_major(lhs_fake)
-    _rhs_major = _tcgen05_tma_matrix_major(rhs_fake)
+    _lhs_major = lhs_operand.matrix_major
+    _rhs_major = rhs_operand.matrix_major
     # A must be row-major (M,K) K-contiguous == "row"; the K-major A SMEM
     # layout Helion emits expects the standard row-major A. Only B's major
     # mode is made layout-aware here.
@@ -2494,6 +2605,12 @@ def _emit_mma_pipeline(
             not tcgen05_requested_two_cta and m_size // bm < tcgen05_cluster_m
         ):
             tcgen05_cluster_m = 1
+        elif (
+            tcgen05_requested_two_cta
+            and tcgen05_cluster_m == 4
+            and ((m_size + bm - 1) // bm) % 2 != 0
+        ):
+            tcgen05_cluster_m = 2
     assert tcgen05_cluster_m == 1 or bm >= 128
     tcgen05_is_two_cta = tcgen05_requested_two_cta and tcgen05_cluster_m > 1
     # ``tcgen05_cluster_n`` is the multicast factor along the cluster's N
@@ -2519,6 +2636,53 @@ def _emit_mma_pipeline(
         tcgen05_cluster_n = 1
     else:
         tcgen05_cluster_n = tcgen05_cluster_n_requested
+    role_scheduler_cluster_cap = df.config.get(
+        TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY
+    )
+    if df.config.get(TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY, False):
+        one_shot_m_slots = (m_size // bm) * (2 if tcgen05_is_two_cta else 1)
+        one_shot_n_slots = n_size // bn
+        one_shot_work_ctas = one_shot_m_slots * one_shot_n_slots
+        if not (
+            tcgen05_pid_is_persistent
+            and tcgen05_static_full_tiles
+            and input_dtype == torch.float8_e4m3fn
+            and not analysis.has_leading_passthrough
+            and role_scheduler_cluster_cap is None
+            and one_shot_work_ctas <= TCGEN05_ONE_SHOT_ROLE_SCHEDULER_MAX_CTAS
+            and one_shot_m_slots % tcgen05_cluster_m == 0
+            and one_shot_n_slots % tcgen05_cluster_n == 0
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY}=True requires a "
+                "static-full, unbatched persistent FP8 grid without a role "
+                "scheduler cluster cap and with at most "
+                f"{TCGEN05_ONE_SHOT_ROLE_SCHEDULER_MAX_CTAS} work CTAs",
+            )
+    if role_scheduler_cluster_cap is not None:
+        role_scheduler_cluster_cap = int(role_scheduler_cluster_cap)
+        scheduler_m_slots = (m_size // bm) * (2 if tcgen05_is_two_cta else 1)
+        scheduler_n_slots = n_size // bn
+        scheduler_cluster_size = tcgen05_cluster_m * tcgen05_cluster_n
+        scheduler_work_clusters = (scheduler_m_slots // tcgen05_cluster_m) * (
+            scheduler_n_slots // tcgen05_cluster_n
+        )
+        if not (
+            tcgen05_pid_is_persistent
+            and tcgen05_static_full_tiles
+            and input_dtype == torch.float8_e4m3fn
+            and scheduler_m_slots % tcgen05_cluster_m == 0
+            and scheduler_n_slots % tcgen05_cluster_n == 0
+            and role_scheduler_cluster_cap <= scheduler_work_clusters
+            and role_scheduler_cluster_cap * scheduler_cluster_size
+            <= TCGEN05_ONE_SHOT_ROLE_SCHEDULER_MAX_CTAS
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY} requires an "
+                "static-full persistent FP8 cluster grid within residency",
+            )
     tcgen05_role_local_k_tail_tma = (
         tcgen05_preserve_tma_for_two_cta_k_tail
         and tcgen05_is_two_cta
@@ -2623,10 +2787,7 @@ def _emit_mma_pipeline(
         else "cutlass.pipeline"
     )
     tcgen05_static_full_tma_fast_path = (
-        tcgen05_static_full_tiles
-        and tcgen05_use_tma_pipeline
-        and not tcgen05_is_two_cta
-        and not tcgen05_use_role_local_mma_exec
+        tcgen05_static_full_tiles and tcgen05_use_tma_pipeline
     )
     tcgen05_acc_producer_mode = df.config.get(
         TCGEN05_ACC_PRODUCER_MODE_CONFIG_KEY,
@@ -2817,10 +2978,8 @@ def _emit_mma_pipeline(
         mma_impl == "tcgen05"
         and fx_node is not None
         and cg.current_grid_state is not None
-        and len(lhs_load.users) == 1
-        and len(rhs_load.users) == 1
-        and next(iter(lhs_load.users)) is fx_node
-        and next(iter(rhs_load.users)) is fx_node
+        and _load_exclusively_feeds_operand(lhs_load, candidate.lhs, fx_node)
+        and _load_exclusively_feeds_operand(rhs_load, candidate.rhs, fx_node)
     )
     if tcgen05_collective_handles_operand_loads:
         cute_state = df.cute_state
@@ -2983,6 +3142,7 @@ def _emit_mma_pipeline(
                 is_two_cta=tcgen05_is_two_cta,
                 gate_exec_warp=False,
                 cluster_n=tcgen05_cluster_n,
+                cluster_m=tcgen05_cluster_m,
             )
             assert ab_consumer_prefetch_owner_predicate is not None
             _emit_per_tile(
@@ -3018,6 +3178,7 @@ def _emit_mma_pipeline(
             tiled_mma=tiled_mma,
             is_two_cta=tcgen05_is_two_cta,
             cluster_n=tcgen05_cluster_n,
+            cluster_m=tcgen05_cluster_m,
         )
         prefix.append(reset_accumulate_stmt)
         per_tile_stmts.append(reset_accumulate_stmt)
@@ -3058,7 +3219,7 @@ def _emit_mma_pipeline(
     #   - cluster_m=2 cluster_n=2 V=2: 2 + 1 - 1 = 2 (the cluster_n=2 fix)
     #   - cluster_m=1 cluster_n=1 V=1 (no use_2cta): 1 (collapses to single
     #     CTA; no multicast)
-    if tcgen05_is_two_cta and tcgen05_cluster_n > 1:
+    if tcgen05_is_two_cta and (tcgen05_cluster_m > 2 or tcgen05_cluster_n > 1):
         # V=2 absorbs cluster_m into the cluster_layout_vmnk V dim; the
         # post-V CTAs along M (= cluster_m // V) carry the B multicast,
         # while cluster_n CTAs along N carry the A multicast.
@@ -3297,27 +3458,48 @@ def _emit_mma_pipeline(
         explicit_epi_tile_dtype_ok = (
             input_dtype == torch.bfloat16 and epi_elem_dtype_str == "cutlass.BFloat16"
         ) or (input_dtype == torch.float16 and epi_elem_dtype_str == "cutlass.Float16")
+        fp8_m64_explicit_epi_tile = (
+            tcgen05_static_full_tiles
+            and not tcgen05_is_two_cta
+            and input_dtype == torch.float8_e4m3fn
+            and epi_elem_dtype_str == "cutlass.BFloat16"
+            and (m_size, bm) == (64, 64)
+            and bn in (16, 32, 64, 128)
+            and (
+                tcgen05_explicit_epi_tile_m,
+                tcgen05_explicit_epi_tile_n,
+                tcgen05_explicit_d_store_box_n,
+            )
+            == (64, min(bn, 64), min(bn, 64))
+            and all(d.broadcast_axis in (1, 2) for d in aux_tensor_descriptors_value)
+        )
         if explicit_epi_tile_requested:
             if not (
-                tcgen05_static_full_tiles
-                and tcgen05_is_two_cta
-                and bm == TCGEN05_TWO_CTA_BLOCK_M
-                and bn == TCGEN05_TWO_CTA_BLOCK_N
-                and explicit_epi_tile_dtype_ok
-                and aux_descriptors_compatible_with_explicit_epi_tile
+                fp8_m64_explicit_epi_tile
+                or (
+                    tcgen05_static_full_tiles
+                    and tcgen05_is_two_cta
+                    and bm == TCGEN05_TWO_CTA_BLOCK_M
+                    and bn == TCGEN05_TWO_CTA_BLOCK_N
+                    and explicit_epi_tile_dtype_ok
+                    and aux_descriptors_compatible_with_explicit_epi_tile
+                )
             ):
                 raise exc.BackendUnsupported(
                     "cute",
                     "explicit tcgen05 epilogue tile overrides are validated only "
-                    "for static-full 16-bit (bf16/fp16) pure matmul CtaGroup.TWO "
-                    "kernels (rank-1 rowvec aux tensors admitted for the bias "
-                    "envelope)",
+                    "for the static-full 16-bit (bf16/fp16) CtaGroup.TWO "
+                    "envelope or the scaled FP8 M64 CtaGroup.ONE envelope",
                 )
             if (
-                tcgen05_explicit_epi_tile_m,
-                tcgen05_explicit_epi_tile_n,
-                tcgen05_explicit_d_store_box_n,
-            ) != _TCGEN05_EXPLICIT_EPI_TILE_VALIDATED_SHAPE:
+                not fp8_m64_explicit_epi_tile
+                and (
+                    tcgen05_explicit_epi_tile_m,
+                    tcgen05_explicit_epi_tile_n,
+                    tcgen05_explicit_d_store_box_n,
+                )
+                != _TCGEN05_EXPLICIT_EPI_TILE_VALIDATED_SHAPE
+            ):
                 raise exc.BackendUnsupported(
                     "cute",
                     "explicit tcgen05 epilogue tile is currently validated only "
@@ -3410,6 +3592,7 @@ def _emit_mma_pipeline(
             is_two_cta=tcgen05_is_two_cta,
             gate_exec_warp=True,
             cluster_n=tcgen05_cluster_n,
+            cluster_m=tcgen05_cluster_m,
         )
         candidate_block_shape = tcgen05_matmul_plan.block_shape
         df.cute_state.register_tcgen05_matmul_plan(tcgen05_matmul_plan)
@@ -3664,7 +3847,7 @@ def _emit_mma_pipeline(
                     f"{mma_slice_linear} = "
                     + (
                         "cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) "
-                        f"% cutlass.Int32({tcgen05_cluster_m})"
+                        "% cutlass.Int32(2)"
                         if tcgen05_cluster_m > 1
                         else "cutlass.Int32(0)"
                     )
@@ -3731,6 +3914,7 @@ def _emit_mma_pipeline(
                 explicit_epi_tile_m=tcgen05_explicit_epi_tile_m,
                 explicit_epi_tile_n=tcgen05_explicit_epi_tile_n,
                 b_k_major=tcgen05_b_k_major,
+                output_column_major=candidate.output_column_major,
             )
         )
         prefix.append(
@@ -4264,14 +4448,13 @@ def _emit_mma_pipeline(
     def _tcgen05_tma_tile_predicate(
         *, k_tile_start_expr: str, full_tile_end_expr: str
     ) -> str:
-        return (
-            _tcgen05_tma_output_tile_predicate()
-            + "and "
-            + _tcgen05_tma_k_tile_predicate(
-                k_tile_start_expr=k_tile_start_expr,
-                full_tile_end_expr=full_tile_end_expr,
-            )
+        k_predicate = _tcgen05_tma_k_tile_predicate(
+            k_tile_start_expr=k_tile_start_expr,
+            full_tile_end_expr=full_tile_end_expr,
         )
+        if tcgen05_static_full_tma_fast_path:
+            return k_predicate
+        return _tcgen05_tma_output_tile_predicate() + "and " + k_predicate
 
     tma_k_tile = df.new_var("tcgen05_tma_k_tile")
     tma_barrier_ptr = df.new_var("tcgen05_tma_barrier")
@@ -4351,6 +4534,10 @@ def _emit_mma_pipeline(
             # to the golden.
             if tcgen05_b_k_major:
                 ab_tma_plan["b_k_major"] = True
+            if lhs_operand.trailing_transpose:
+                ab_tma_plan["lhs_trailing_transpose"] = True
+            if rhs_operand.trailing_transpose:
+                ab_tma_plan["rhs_trailing_transpose"] = True
             if lhs_operand.is_leading_passthrough:
                 ab_tma_plan["lhs_leading_passthrough"] = True
             if rhs_operand.is_leading_passthrough:
@@ -4381,6 +4568,13 @@ def _emit_mma_pipeline(
             if tcgen05_matmul_plan.is_clc_persistent:
                 ab_tma_plan["use_pdl"] = True
             cg.cute_wrapper_plans.append(ab_tma_plan)
+            prefix.append(
+                statement_from_string(
+                    f"if {tma_warp}:\n"
+                    f"    cute.nvgpu.cpasync.prefetch_descriptor({tma_atom_a})\n"
+                    f"    cute.nvgpu.cpasync.prefetch_descriptor({tma_atom_b})"
+                )
+            )
         prefix.append(
             statement_from_string(
                 f"{smem_a_ptr} = cute.arch.alloc_smem("
@@ -5010,6 +5204,7 @@ def _emit_mma_pipeline(
                 scalar_load_a=scalar_load_a,
                 scalar_load_b=scalar_load_b,
                 cluster_n=tcgen05_cluster_n,
+                cluster_m=tcgen05_cluster_m,
                 static_full_tiles=tcgen05_static_full_tma_fast_path,
             )
             if tcgen05_use_tma_pipeline:
@@ -5065,6 +5260,12 @@ def _emit_mma_pipeline(
                     assert mma_stage_stmt is not None
                     assert smem_a_mma_stmt is not None
                     assert smem_b_mma_stmt is not None
+                    outer_owner_gated_exec = (
+                        tcgen05_static_full_tma_fast_path
+                        and tcgen05_is_two_cta
+                        and tcgen05_cluster_m == 2
+                        and tcgen05_cluster_n == 1
+                    )
                     exec_loop_body: list[ast.stmt] = [
                         mma_stage_stmt,
                         smem_a_mma_stmt,
@@ -5092,13 +5293,10 @@ def _emit_mma_pipeline(
                     exec_loop_body.append(
                         _build_kloop_pipeline_consumer_if(
                             tma_kloop_args,
-                            # Static-full pipeline builders require their
-                            # internal exec gate to keep emitting a single
-                            # statement. The outer wrapper below makes the
-                            # cloned loop's role ownership explicit.
                             gate_exec_warp=tcgen05_static_full_tma_fast_path,
                             include_scalar_fallback=False,
                             use_existing_try_token=tcgen05_use_role_local_ab_consumer_prefetch,
+                            owner_already_gated=outer_owner_gated_exec,
                         )
                     )
                     if not diagnose_skip_umma_issue:
@@ -5116,20 +5314,19 @@ def _emit_mma_pipeline(
                                 tcgen05_frag_a=tcgen05_frag_a,
                                 tcgen05_frag_b=tcgen05_frag_b,
                                 mma_stage=mma_stage,
-                                # See the consumer wait comment above: pure
-                                # lifecycle has an outer exec-active role
-                                # wrapper plus the static-full builder gate.
                                 gate_exec_warp=tcgen05_static_full_tma_fast_path,
                                 is_two_cta=tcgen05_is_two_cta,
                                 cluster_n=tcgen05_cluster_n,
+                                cluster_m=tcgen05_cluster_m,
+                                owner_already_gated=outer_owner_gated_exec,
                             )
                         )
                     exec_loop_body.append(
                         _build_kloop_pipeline_release_if(
                             tma_kloop_args,
-                            # See the consumer wait comment above.
                             gate_exec_warp=tcgen05_static_full_tma_fast_path,
                             include_scalar_fallback=False,
+                            owner_already_gated=outer_owner_gated_exec,
                         )
                     )
                     if tcgen05_use_role_local_ab_consumer_prefetch:
@@ -5137,6 +5334,7 @@ def _emit_mma_pipeline(
                             _build_kloop_pipeline_consumer_prefetch_stmts(
                                 tma_kloop_args,
                                 gate_exec_warp=False,
+                                owner_already_gated=outer_owner_gated_exec,
                             )
                         )
                     exec_loop = _clone_k_loop_with_body(
@@ -5148,15 +5346,23 @@ def _emit_mma_pipeline(
                             else None
                         ),
                     )
-                    exec_stmt: ast.stmt = exec_loop
+                    exec_role_stmt: ast.stmt = exec_loop
+                    if outer_owner_gated_exec:
+                        # Only the V-leader consumes AB stages and issues UMMA.
+                        # Keep the follower out of the cloned K loop entirely;
+                        # its per-tile accumulator state still advances below.
+                        exec_role_stmt = _wrap_stmt_in_if(
+                            exec_loop, _TCGEN05_CLUSTER_LEADER_PREDICATE
+                        )
+                    exec_stmt = exec_role_stmt
                     if tcgen05_use_pure_matmul_role_lifecycle:
                         exec_stmt = _wrap_stmt_in_if(
-                            exec_loop, tcgen05_plan.exec_active
+                            exec_role_stmt, tcgen05_plan.exec_active
                         )
                     prefix.append(exec_stmt)
                     per_tile_stmts.append(exec_stmt)
                     if tcgen05_use_role_local_mma_exec:
-                        mma_exec_role_stmts.append(exec_loop)
+                        mma_exec_role_stmts.append(exec_role_stmt)
                 else:
                     cg.add_statement(
                         statement_from_string(
@@ -5297,6 +5503,7 @@ def _emit_mma_pipeline(
                             mma_stage=mma_stage,
                             is_two_cta=tcgen05_is_two_cta,
                             cluster_n=tcgen05_cluster_n,
+                            cluster_m=tcgen05_cluster_m,
                         )
                     )
                 if tcgen05_use_tma:
@@ -5476,6 +5683,7 @@ def _emit_mma_pipeline(
                 explicit_epi_tile_m=tcgen05_explicit_epi_tile_m,
                 explicit_epi_tile_n=tcgen05_explicit_epi_tile_n,
                 explicit_d_store_box_n=tcgen05_explicit_d_store_box_n,
+                output_column_major=candidate.output_column_major,
             ),
         )
         if tcgen05_pure_matmul_object is not None:
@@ -5574,7 +5782,7 @@ def _tcgen05_config_int(config: object, key: str, default: int) -> int:
 
 
 def _tcgen05_cluster_m(config: object) -> int:
-    return max(1, min(2, _tcgen05_config_int(config, "tcgen05_cluster_m", 1)))
+    return max(1, min(4, _tcgen05_config_int(config, "tcgen05_cluster_m", 1)))
 
 
 def _tcgen05_cluster_n(config: object) -> int:
@@ -5616,7 +5824,7 @@ def _tcgen05_use_2cta_instrs(
     # the f16/bf16 bm=128 + cluster_m=2 config point is owned by the legacy
     # clustered CTA-local CtaGroup.ONE family (guarded diagnostic bridge and
     # multi-tile runtime guard).
-    if cluster_m != 2:
+    if cluster_m not in (2, 4):
         return False
     if bm == TCGEN05_TWO_CTA_BLOCK_M:
         return True
@@ -5700,7 +5908,7 @@ def _mma_impl_matches_problem_shape(
         # budget sane; the explicit G4 proof key admits only the smallest
         # 512-N candidate.
         mma_k = 32 if is_fp8 else 16
-        if bk < mma_k or bk > 256 or bk % mma_k != 0:
+        if bk < mma_k or bk > 512 or bk % mma_k != 0:
             return False
         if bm in (64, 128):
             return True
@@ -5981,6 +6189,7 @@ def _make_tcgen05_layout_plan_setup(
     explicit_epi_tile_m: int | None = None,
     explicit_epi_tile_n: int | None = None,
     b_k_major: bool = False,
+    output_column_major: bool = False,
 ) -> list[ast.AST]:
     # `compute_epilogue_tile_shape` must receive `elem_ty_d` and `elem_ty_c`
     # equal to the eventual D-output dtype so the helper takes the
@@ -6016,7 +6225,11 @@ def _make_tcgen05_layout_plan_setup(
         bn=bn,
         is_two_cta=is_two_cta,
         elem_dtype=epi_elem_dtype_str,
-        c_layout=plan.c_layout,
+        c_layout=(
+            "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
+            if output_column_major
+            else "cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
+        ),
         explicit_expr=explicit_epi_tile_expr,
     )
     return [
@@ -6029,7 +6242,8 @@ def _make_tcgen05_layout_plan_setup(
             f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b, b_k_major=b_k_major)}"
         ),
         statement_from_string(
-            f"{plan.c_layout} = cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
+            f"{plan.c_layout} = cutlass.utils.layout.LayoutEnum."
+            f"{'COL_MAJOR' if output_column_major else 'ROW_MAJOR'}"
         ),
         statement_from_string(f"{plan.epi_tile} = {epi_tile_expr}"),
         statement_from_string(

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -619,7 +619,7 @@ def _analyze_mma_operand(
             order, (list, tuple)
         ):
             return None
-        normalized = tuple(int(dim) % value_fake.ndim for dim in order)
+        normalized = tuple(int(cast("int", dim)) % value_fake.ndim for dim in order)
         if normalized != (
             *range(value_fake.ndim - 2),
             value_fake.ndim - 1,
@@ -2674,7 +2674,7 @@ def _emit_mma_pipeline(
                 f"{TCGEN05_ONE_SHOT_ROLE_SCHEDULER_MAX_CTAS} work CTAs",
             )
     if role_scheduler_cluster_cap is not None:
-        role_scheduler_cluster_cap = int(role_scheduler_cluster_cap)
+        role_scheduler_cluster_cap = int(cast("int", role_scheduler_cluster_cap))
         scheduler_m_slots = (m_size // bm) * (2 if tcgen05_is_two_cta else 1)
         scheduler_n_slots = n_size // bn
         scheduler_cluster_size = tcgen05_cluster_m * tcgen05_cluster_n

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -277,10 +277,10 @@ class CuteDeviceFunctionState:
         # matmul accumulator. When a single accumulator fans out to multiple
         # output stores (e.g. aux = pre-activation, out = gelu(pre)), each store
         # site must emit its own descriptor kernel params or the generated
-        # function gets duplicate argument names. Track which StoreValue object
-        # ids have already emitted their TMA-store kernel params so 2nd+ store
-        # sites can allocate fresh per-store names.
-        self._tcgen05_emitted_tma_store_value_ids: set[int] = set()
+        # Track which StoreValue object ids have emitted a store so 2nd+ fan-out
+        # sites reuse the accumulator without repeating its lifecycle. TMA
+        # stores also use this to allocate fresh per-store descriptor names.
+        self._tcgen05_emitted_store_value_ids: set[int] = set()
         # Snapshot of the accumulator consumer-state stage index, keyed by the
         # acc consumer-state variable name. A multi-store fan-out reads the same
         # accumulator TMEM stage; the primary store advances the consumer state
@@ -402,20 +402,17 @@ class CuteDeviceFunctionState:
         self._tcgen05_acc_stage_index_vars[acc_consumer_state] = snapshot
         return snapshot, True
 
-    def tcgen05_tma_store_names_already_emitted(
-        self, value: CuteTcgen05StoreValue
-    ) -> bool:
-        """Return whether this StoreValue already emitted TMA-store kernel params.
+    def tcgen05_store_value_already_emitted(self, value: CuteTcgen05StoreValue) -> bool:
+        """Return whether this StoreValue already emitted an output store.
 
-        The first store site that uses a given accumulator's StoreValue keeps the
-        per-matmul ``tma_store_atom`` / ``tma_store_tensor`` names. Later store
-        sites fanning out from the same accumulator must allocate fresh per-store
-        names so the generated kernel signature has no duplicate parameters and so
-        each store binds its own TMA descriptor.
+        The first store owns the accumulator wait/advance and one-shot pipeline
+        and TMEM cleanup. Later fan-out stores reuse the live accumulator without
+        repeating that lifecycle, regardless of whether the stores use TMA or
+        SIMT. TMA callers additionally allocate fresh descriptor names.
         """
         value_id = id(value)
-        already_emitted = value_id in self._tcgen05_emitted_tma_store_value_ids
-        self._tcgen05_emitted_tma_store_value_ids.add(value_id)
+        already_emitted = value_id in self._tcgen05_emitted_store_value_ids
+        self._tcgen05_emitted_store_value_ids.add(value_id)
         return already_emitted
 
     def register_tcgen05_matmul_plan(self, plan: CuteTcgen05MatmulPlan) -> None:

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -53,6 +53,7 @@ class CuteTcgen05StoreValue:
     explicit_epi_tile_m: int | None = None
     explicit_epi_tile_n: int | None = None
     explicit_d_store_box_n: int | None = None
+    output_column_major: bool = False
 
     def __post_init__(self) -> None:
         if self.pure_matmul_object is not None:

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -982,7 +982,7 @@ _STRATEGY_REQUIRES_WARPGROUP_ALIGNED_TOTAL: frozenset[Tcgen05Strategy] = frozens
 # cross-fragment validator so a user config can't reach a
 # hanging runtime.
 _STRATEGY_SUPPORTED_CLUSTER_M: dict[Tcgen05Strategy, frozenset[int]] = {
-    Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC: frozenset({1, 2}),
+    Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC: frozenset({1, 2, 4}),
     Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: frozenset({1, 2}),
     Tcgen05Strategy.PURE_MATMUL_ROLE_LIFECYCLE: frozenset({1}),
 }

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -93,7 +93,10 @@ from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_PID_TYPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_STAGE_CONFIGS
 from .tcgen05_constants import TCGEN05_ONE_CTA_MAX_BLOCK_M
+from .tcgen05_constants import TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES
+from .tcgen05_constants import TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CHOICES
+from .tcgen05_constants import TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODES
@@ -191,6 +194,8 @@ CUTE_TCGEN05_DIAGNOSTIC_CONFIG_KEYS: frozenset[str] = frozenset(
         TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY,
         TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY,
         TCGEN05_LARGE_BN_PROOF_CONFIG_KEY,
+        TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY,
+        TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY,
         TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY,
         TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY,
         TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY,
@@ -944,7 +949,7 @@ class CuteTcgen05Config:
         constraints = self.ab_stages_three_search_constraints
         if constraints is None:
             return False
-        if cluster_m not in (1, 2):
+        if cluster_m not in (1, 2, 4):
             return False
         if bm <= 0 or bn <= 0 or bk <= 0:
             return False
@@ -954,7 +959,7 @@ class CuteTcgen05Config:
             bk=bk,
             dtype_bytes=constraints.dtype_bytes,
             ab_stages=ab_stages,
-            cluster_m=cluster_m,
+            cluster_m=min(cluster_m, 2),
         )
         return bytes_per_cta <= constraints.per_cta_smem_budget_bytes
 
@@ -985,7 +990,7 @@ class CuteTcgen05Config:
         constraints = self.ab_stages_three_search_constraints
         if constraints is None:
             return False
-        if cluster_m not in (1, 2):
+        if cluster_m not in (1, 2, 4):
             return False
         if bm <= 0 or bn <= 0 or bk <= 0:
             return False
@@ -997,7 +1002,7 @@ class CuteTcgen05Config:
             bk=bk,
             dtype_bytes=constraints.dtype_bytes,
             ab_stages=ab_stages,
-            cluster_m=cluster_m,
+            cluster_m=min(cluster_m, 2),
         )
         # The epilogue processes the full per-CTA output tile (bm, bn); unlike
         # the AB operands it is NOT split across the cluster, so the C-ring
@@ -1022,7 +1027,7 @@ class CuteTcgen05Config:
 
     def _fix_c_stages_search_config(self, config: dict[str, object]) -> None:
         # Workstream A Stage 2 (cycle 90): true admission gate for the deeper C
-        # ring. ``tcgen05_c_stages`` is an ``EnumFragment((2, 4))`` knob, so the
+        # ring. ``tcgen05_c_stages`` is an ``EnumFragment((2, 3, 4))`` knob, so the
         # autotuner can SAMPLE c=4 independently of any projection — a directly
         # sampled 256x256 cluster_m=2 ab=3 + c=4 reaches ptxas and fails with a
         # raw ``too much shared`` error (verified cycle-90). Mirror
@@ -1155,7 +1160,7 @@ class CuteTcgen05Config:
         constraints = self.ab_stages_three_search_constraints
         if constraints is None or bm <= 0 or bn <= 0 or bk <= 0:
             return 0
-        if cluster_m not in (1, 2):
+        if cluster_m not in (1, 2, 4):
             return 0
 
         # Calculate SMEM cost for ab_stages=1 (baseline)
@@ -1165,7 +1170,7 @@ class CuteTcgen05Config:
             bk=bk,
             dtype_bytes=constraints.dtype_bytes,
             ab_stages=1,
-            cluster_m=cluster_m,
+            cluster_m=min(cluster_m, 2),
         )
 
         # Edge cases: invalid calculation or even ab_stages=1 doesn't fit
@@ -1946,7 +1951,7 @@ class CuteTcgen05Config:
         if for_search and self.cluster_m_search_choices is not None:
             cluster_m_choices = self.cluster_m_search_choices
         else:
-            cluster_m_choices = (1, 2)
+            cluster_m_choices = (1, 2, 4)
         cluster_n_choices: tuple[int, ...] = (1,) if for_search else (1, 2)
         if for_search and self.num_epi_warps_search_choices is not None:
             num_epi_warps_fragment: ConfigSpecFragment = EnumFragment(
@@ -2008,7 +2013,7 @@ class CuteTcgen05Config:
             "tcgen05_cluster_n": EnumFragment(cluster_n_choices),
             "tcgen05_ab_stages": IntegerFragment(1, ab_stages_max, 2),
             "tcgen05_acc_stages": IntegerFragment(1, 2, 2),
-            "tcgen05_c_stages": EnumFragment((2, 4)),
+            "tcgen05_c_stages": EnumFragment((2, 4) if for_search else (2, 3, 4)),
             "tcgen05_num_epi_warps": num_epi_warps_fragment,
             TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: EnumFragment(l2_swizzle_choices),
         }
@@ -2363,6 +2368,24 @@ class CuteTcgen05Config:
             self._validate_direct_entry_ab_stage_envelope(
                 config, fix_invalid=fix_invalid
             )
+            if config.get("tcgen05_c_stages") == 3 and config.get(
+                "block_sizes"
+            ) not in (
+                [64, 32, 256],
+                [64, 32, 512],
+                [64, 64, 128],
+                [128, 64, 256],
+                [128, 128, 128],
+                [256, 128, 128],
+            ):
+                if fix_invalid:
+                    config["tcgen05_c_stages"] = 2
+                else:
+                    raise InvalidConfig(
+                        "tcgen05_c_stages=3 is validated only for block_sizes "
+                        "in {[64,32,256], [64,32,512], [64,64,128], [128,64,256], "
+                        "[128,128,128], [256,128,128]}"
+                    )
         else:
             for key in optional_fragments:
                 if key not in config:
@@ -2479,6 +2502,17 @@ class CuteTcgen05Config:
         )
         self._validate_bool_config(
             config, TCGEN05_LARGE_BN_PROOF_CONFIG_KEY, fix_invalid=fix_invalid
+        )
+        self._validate_bool_config(
+            config,
+            TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY,
+            fix_invalid=fix_invalid,
+        )
+        self._validate_int_enum_config(
+            config,
+            TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY,
+            TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CHOICES,
+            fix_invalid=fix_invalid,
         )
         self._validate_bool_config(
             config,

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -107,9 +107,10 @@ def tcgen05_ab_smem_bytes_per_cta(
     The role-local lowering allocates the tcgen05 A/B SMEM staging via
     ``cutlass.utils.blackwell_helpers.make_smem_layout_a/b`` whose per-CTA
     ``cosize`` is the partitioned tile-shape times ``num_stages``. For
-    ``cluster_m=2`` (CtaGroup.TWO) the tiled MMA partitions A and B across
-    the two cluster CTAs so each CTA holds half of each operand. For
-    ``cluster_m=1`` (CtaGroup.ONE) each CTA holds the full A/B operand.
+    ``cluster_m in (2, 4)`` (one or two CtaGroup.TWO pairs) the tiled MMA
+    partitions A and B across each pair, so every CTA holds half of each
+    operand. For ``cluster_m=1`` (CtaGroup.ONE) each CTA holds the full A/B
+    operand.
 
     The autotune search-space gate uses this helper to admit
     ``tcgen05_ab_stages=3`` candidates only when the per-CTA cost fits
@@ -120,10 +121,10 @@ def tcgen05_ab_smem_bytes_per_cta(
     CtaGroup.ONE ab=3 = 294 912 bytes / overflows the 232 KB optin cap).
     """
     assert ab_stages >= 1
-    assert cluster_m in (1, 2)
+    assert cluster_m in (1, 2, 4)
     a_per_stage = bm * bk * dtype_bytes
     b_per_stage = bn * bk * dtype_bytes
-    if cluster_m == 2:
+    if cluster_m > 1:
         # CtaGroup.TWO: tiled MMA partitions both operands across the two
         # cluster CTAs. Each CTA's SMEM holds half of A and half of B.
         a_per_stage //= 2
@@ -270,6 +271,14 @@ TCGEN05_C_STORE_MODES = (
     TCGEN05_C_STORE_MODE_SKIP_EPILOGUE_STORE,
 )
 TCGEN05_AUX_LOAD_MODE_CONFIG_KEY = "tcgen05_aux_load_mode"
+TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY = "tcgen05_one_shot_role_scheduler"
+TCGEN05_ONE_SHOT_ROLE_SCHEDULER_MAX_CTAS = 148
+TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY = "tcgen05_role_scheduler_cluster_cap"
+TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CHOICES = (
+    64,
+    65,
+    67,
+)
 TCGEN05_AUX_LOAD_MODE_SIMT = "simt"
 TCGEN05_AUX_LOAD_MODE_TMA = "tma"
 TCGEN05_AUX_LOAD_MODES = (

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -3726,6 +3726,12 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                             item.explicit_epi_tile_compatible
                             for item, _lhs, _plan in search_candidates
                         ),
+                        allow_fp8_small_n_persistent=(
+                            all(
+                                item.operands.rhs.trailing_transpose
+                                for item, _lhs, _plan in search_candidates
+                            )
+                        ),
                     )
         config_spec.raise_grid_block_minimums()
         if len(device_ir.root_ids) > 1:

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -19,6 +19,8 @@ from .compile_environment import CompileEnvironment
 from .cute.cutedsl_compat import emit_pipeline_advance
 from .cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_DEFAULT
 from .cute.strategies import l2_swizzle_size_from_config
+from .cute.tcgen05_constants import TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY
+from .cute.tcgen05_constants import TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_NORMAL
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_WARP_LEADER
@@ -49,6 +51,8 @@ def _stmt_name_uses(stmt: ast.AST) -> tuple[set[str], set[str]]:
                 writes.add(node.id)
             else:
                 reads.add(node.id)
+        if isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Name):
+            reads.add(node.target.id)
     return reads, writes
 
 
@@ -1274,7 +1278,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             # CtaGroup.TWO uses two CTAs to produce one logical M tile. Model
             # scheduler M as CTA slots, then collapse back to logical M when
             # binding virtual_pid for PID decomposition.
-            dims[0] = f"({dims[0]}) * {self._tcgen05_cluster_m()}"
+            dims[0] = f"({dims[0]}) * 2"
         # cluster_n>1 leaves the scheduler N dim equal to the logical N
         # tile count; the cluster_shape ``(cluster_m, cluster_n, 1)``
         # passed to ``PersistentTileSchedulerParams`` allocates one
@@ -1323,6 +1327,11 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
 
     def _tcgen05_grid_work_clusters_expr(self, total_clusters: str) -> str:
         """Return the scheduler z dimension for the persistent launch grid."""
+        cluster_cap = DeviceFunction.current().config.get(
+            TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY
+        )
+        if cluster_cap is not None:
+            return f"min(({total_clusters}), {int(cluster_cap)})"
         max_persistent_clusters = self._tcgen05_max_persistent_work_clusters_expr()
         return f"min(({total_clusters}), ({max_persistent_clusters}))"
 
@@ -1361,7 +1370,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
 
     def _tcgen05_logical_m_coord_expr(self, coord: str) -> str:
         if self._tcgen05_is_two_cta():
-            return f"({coord}) // cutlass.Int32({self._tcgen05_cluster_m()})"
+            return f"({coord}) // cutlass.Int32(2)"
         if self._tcgen05_uses_cluster_m2_one_cta_role_local_bridge():
             # The shared clustered scheduler publishes ``base_m + peer_rank``
             # into each CTA's SMEM slot. The guarded role-local bridge omits
@@ -2069,7 +2078,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         )
         use_validated_two_cta_role_local_body = (
             full_role_local_body
-            and layout.cluster_m == 2
+            and layout.cluster_m in (2, 4)
             and self._tcgen05_has_validated_role_local_two_cta_runtime()
             and not is_multi_root
         )
@@ -2080,7 +2089,11 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         omit_shared_loop = (
             full_role_local_body
             and not is_multi_root
-            and (layout.cluster_m > 1 or self._tcgen05_has_scheduler_warp())
+            and (
+                layout.cluster_m > 1
+                or self._tcgen05_has_scheduler_warp()
+                or self._tcgen05_shared_loop_safe_to_omit(partition, post_loop_stmts)
+            )
         )
         if self._tcgen05_uses_staged_work_tile_mailbox() and not omit_shared_loop:
             raise exc.InvalidConfig(
@@ -2706,9 +2719,9 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         acc pipelines (the existing pipeline barriers carry the data
         dependency); no ``cute.arch.sync_threads()`` is emitted inside
         the role-local loop. The caller decides whether to append a residual
-        shared loop after these role-local loops; validated cluster_m=1 keeps
-        it for existing CTA-wide barriers, while guarded fully role-local
-        CtaGroup.TWO omits it.
+        shared loop after these role-local loops. It is omitted when the
+        residual shared body contains only cloned dependency setup and legacy
+        barriers that no longer protect shared work.
 
         The returned statement is the role-local ``while`` itself,
         wrapped in ``if {role_predicate}:`` so only the matching warps
@@ -2761,6 +2774,11 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         )
         sched_var = device_function.new_var(f"{scheduler_var_prefix}_tile_sched")
         work_tile_var = device_function.new_var(f"{scheduler_var_prefix}_work_tile")
+        one_shot_role_scheduler = bool(
+            device_function.config.get(
+                TCGEN05_ONE_SHOT_ROLE_SCHEDULER_CONFIG_KEY, False
+            )
+        )
 
         prelude: list[ast.stmt] = []
         if (
@@ -2811,9 +2829,9 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         # scheduler shares its cluster shape with the shared scheduler,
         # so the two iterate the same tiles in the same order and the
         # role-local virtual_pid_var matches the shared one tile-by-tile.
-        coord_terms: list[str] = []
-        for i in range(len(self.pid_info)):
-            coord_terms.append(f"{work_tile_var}.tile_idx[{i}]")
+        coord_terms = [
+            f"{work_tile_var}.tile_idx[{i}]" for i in range(len(self.pid_info))
+        ]
         linear_pid_expr = self._tcgen05_linear_virtual_pid_from_coords_expr(coord_terms)
 
         per_tile_body: list[ast.stmt] = [
@@ -2828,23 +2846,25 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                     f"{tile_counter_var} = {tile_counter_var} + cutlass.Int32(1)"
                 )
             )
-        per_tile_body.extend(
-            [
-                statement_from_string(f"{sched_var}.advance_to_next_work()"),
-                statement_from_string(
-                    f"{work_tile_var} = {sched_var}.get_current_work()"
-                ),
-            ]
-        )
-
-        prelude.append(
-            create(
-                ast.While,
-                test=expr_from_string(f"{work_tile_var}.is_valid_tile"),
-                body=per_tile_body,
-                orelse=[],
+        if one_shot_role_scheduler:
+            prelude.extend(per_tile_body)
+        else:
+            per_tile_body.extend(
+                [
+                    statement_from_string(f"{sched_var}.advance_to_next_work()"),
+                    statement_from_string(
+                        f"{work_tile_var} = {sched_var}.get_current_work()"
+                    ),
+                ]
             )
-        )
+            prelude.append(
+                create(
+                    ast.While,
+                    test=expr_from_string(f"{work_tile_var}.is_valid_tile"),
+                    body=per_tile_body,
+                    orelse=[],
+                )
+            )
 
         return create(
             ast.If,
@@ -4828,6 +4848,26 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             "statement(s) while omitting the residual shared loop: " + "; ".join(unsafe)
         )
 
+    def _tcgen05_shared_loop_safe_to_omit(
+        self,
+        partition: Tcgen05PersistentProgramIDs._PartitionedRoleBody,
+        post_loop_stmts: list[ast.stmt],
+    ) -> bool:
+        if not all(
+            self._tcgen05_shared_stmt_safe_to_omit(stmt)
+            for stmt in partition.shared_body_extracted
+        ):
+            return False
+        shared_writes: set[str] = set()
+        for stmt in partition.shared_body_extracted:
+            _, writes = _stmt_name_uses(stmt)
+            shared_writes.update(writes)
+        post_loop_reads: set[str] = set()
+        for stmt in post_loop_stmts:
+            reads, _ = _stmt_name_uses(stmt)
+            post_loop_reads.update(reads)
+        return not bool(shared_writes & post_loop_reads)
+
     def _build_tcgen05_persistent_tile_body_role_local(
         self,
         device_function: DeviceFunction,
@@ -4855,11 +4895,9 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         - ``shared_tile_body`` is the optional per-tile body for the shared
           ``while`` (the work-tile body without the extracted role blocks).
           Built via :meth:`_build_tcgen05_persistent_tile_body` with existing
-          ``cute.arch.sync_threads()`` calls preserved. Validated cluster_m=1
-          role-local kernels still append this loop after role-local work so
-          those CTA-wide barriers remain valid for epilogue synchronization
-          and work-tile metadata publication. Guarded fully role-local
-          CtaGroup.TWO codegen omits the residual shared loop in the caller.
+          ``cute.arch.sync_threads()`` calls preserved. The caller omits this
+          loop only when the residual statements are dependency-only setup or
+          legacy barriers that no longer protect shared work.
 
         Caller wires both into the persistent kernel as siblings of
         each other inside the same setup list when the residual shared loop

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -1331,7 +1331,8 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             TCGEN05_ROLE_SCHEDULER_CLUSTER_CAP_CONFIG_KEY
         )
         if cluster_cap is not None:
-            return f"min(({total_clusters}), {int(cluster_cap)})"
+            cluster_cap = int(cast("int", cluster_cap))
+            return f"min(({total_clusters}), {cluster_cap})"
         max_persistent_clusters = self._tcgen05_max_persistent_work_clusters_expr()
         return f"min(({total_clusters}), ({max_persistent_clusters}))"
 

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -353,7 +353,7 @@ def plan_cute_tcgen05_search(
         or static_n is None
         or static_k is None
         or static_m < 64
-        or static_n < 8
+        or static_n < 1
         or static_k < mma_k
     ):
         return None
@@ -367,7 +367,7 @@ def plan_cute_tcgen05_search(
     def pow2_floor_at_least(value: int, minimum: int) -> int:
         return 1 << (max(minimum, value).bit_length() - 1)
 
-    max_tcgen05_n = min(256, pow2_floor_at_least(static_n, 8))
+    max_tcgen05_n = min(256, pow2_floor_at_least(static_n, 16))
     max_tcgen05_m = 256 if max_tcgen05_n >= 128 and static_m >= 256 else 128
     max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
     max_search_n = max_tcgen05_n
@@ -417,6 +417,7 @@ def enable_cute_tcgen05_search(
     input_dtype: torch.dtype,
     has_leading_passthrough: bool,
     explicit_epi_tile_compatible: bool,
+    allow_fp8_small_n_persistent: bool,
 ) -> None:
     """Apply one preflighted tcgen05 search plan to the shared config."""
     env = CompileEnvironment.current()
@@ -439,6 +440,13 @@ def enable_cute_tcgen05_search(
     allow_full_tile_persistent_pid_types = (
         static_m % max_search_m == 0
         and static_n % max_search_n == 0
+        and static_k % max_search_k == 0
+    )
+    allow_fp8_small_n_persistent_pid_types = (
+        plan.is_fp8
+        and allow_fp8_small_n_persistent
+        and 0 < static_n < max_search_n
+        and static_m % max_search_m == 0
         and static_k % max_search_k == 0
     )
     max_cluster_m2_search_k = TCGEN05_TWO_CTA_MAX_K_TILES * max_search_k
@@ -492,7 +500,10 @@ def enable_cute_tcgen05_search(
                 allow_cluster_m2_search = False
                 allow_fp8_small_grid_cluster_m2_search = False
     spec.narrow_tcgen05_autotune_to_validated_configs(
-        allow_persistent_pid_types=allow_full_tile_persistent_pid_types,
+        allow_persistent_pid_types=(
+            allow_full_tile_persistent_pid_types
+            or allow_fp8_small_n_persistent_pid_types
+        ),
         allow_cluster_m2_search=allow_cluster_m2_search,
         cluster_m2_static_k=static_k if allow_cluster_m2_search else None,
         allow_cluster_m2_edge_k_tail_family=allow_edge_cluster_m2_search,

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -1834,6 +1834,8 @@ def _codegen_cute_store_tcgen05_tile(
     tcgen05_aux_epi_warp_count = tcgen05_value.epi_warp_count
     tcgen05_aux_epilogue_rest_mode = tcgen05_value.epilogue_rest_mode
     tcgen05_aux_use_tma_store_epilogue = tcgen05_value.use_tma_store_epilogue
+    tcgen05_aux_partial_output_tma_store = tcgen05_value.partial_output_tma_store
+    tcgen05_aux_output_column_major = tcgen05_value.output_column_major
     tcgen05_explicit_store_tile_expr: str | None = None
     if tcgen05_value.has_explicit_epilogue_tile:
         assert tcgen05_value.explicit_epi_tile_m is not None
@@ -2818,11 +2820,11 @@ def _codegen_cute_store_tcgen05_tile(
                 elif (
                     tcgen05_is_two_cta_m128(
                         is_two_cta=tcgen05_lifecycle.is_two_cta,
-                        bm=tcgen05_value.bm,
+                        bm=tcgen05_aux_bm,
                     )
-                    and tcgen05_value.use_tma_store_epilogue
-                    and not tcgen05_value.partial_output_tma_store
-                    and not tcgen05_value.output_column_major
+                    and tcgen05_aux_use_tma_store_epilogue
+                    and not tcgen05_aux_partial_output_tma_store
+                    and not tcgen05_aux_output_column_major
                 ):
                     lines.append(
                         _materialize_two_row_colvec_source(

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -1544,11 +1544,10 @@ def _codegen_cute_store_tcgen05_tile(
     # (those would hang waiting on a producer that has already drained) and
     # without re-emitting the matmul drain / TMEM-free teardown.
     is_secondary_store = (
-        tcgen05_value.use_tma_store_epilogue
-        and not tcgen05_value.pure_matmul_role_lifecycle
-        and df.cute_state.tcgen05_tma_store_names_already_emitted(tcgen05_value)
+        not tcgen05_value.pure_matmul_role_lifecycle
+        and df.cute_state.tcgen05_store_value_already_emitted(tcgen05_value)
     )
-    if is_secondary_store:
+    if is_secondary_store and tcgen05_value.use_tma_store_epilogue:
         tcgen05_value = dataclasses.replace(
             tcgen05_value,
             tma_store_atom=df.new_var("tcgen05_tma_store_atom"),

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -14,6 +14,7 @@ from .._compiler.ast_extension import expr_from_string
 from .._compiler.ast_extension import statement_from_string
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.compile_environment import _symint_expr
+from .._compiler.cute.cute_epilogue import _AuxiliaryTensorProductStep
 from .._compiler.cute.cutedsl_compat import emit_pipeline_advance
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_is_two_cta_m128
@@ -112,6 +113,9 @@ class _AuxStepRecord:
     # accumulator ``consumer_wait`` so the rowvec GMEM latency hides under
     # the MMA wait. ``None`` keeps the per-subtile GMEM load.
     aux_rmem_full: str | None = None
+    # Full-tile bm=256 four-CTA path: one per-row scalar is invariant across
+    # all N subtiles, so retain it in a scalar register for the tile.
+    colvec_scalar_full: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1799,6 +1803,20 @@ def _codegen_cute_store_tcgen05_tile(
                         )
                         and tcgen05_value.use_tma_store_epilogue
                         and not tcgen05_value.partial_output_tma_store
+                        and not tcgen05_value.output_column_major
+                    )
+                    else None
+                ),
+                colvec_scalar_full=(
+                    df.new_var(f"tcgen05_colvec_scalar_full_{aux_idx}")
+                    if (
+                        aux_step.broadcast_axis == 2
+                        and tcgen05_lifecycle.is_two_cta
+                        and tcgen05_value.bm == 256
+                        and tcgen05_value.bn == 128
+                        and tcgen05_value.use_tma_store_epilogue
+                        and not tcgen05_value.partial_output_tma_store
+                        and not tcgen05_value.output_column_major
                     )
                     else None
                 ),
@@ -1884,6 +1902,15 @@ def _codegen_cute_store_tcgen05_tile(
     # GMEM path byte-identical.
     aux_matmul_plan = df.cute_state.matmul_plan
     aux_pipeline_plan_obj = df.cute_state.aux_pipeline_plan
+    use_full_tile_bm256_colvec_scalar = (
+        aux_matmul_plan is not None
+        and aux_matmul_plan.cluster_n == 2
+        and tcgen05_lifecycle.is_two_cta
+        and tcgen05_value.bm == 256
+        and tcgen05_value.bn == 128
+        and not tcgen05_value.partial_output_tma_store
+        and not tcgen05_value.output_column_major
+    )
     # Workstream A Stage 4 (cycle 93, Path B): when the plan carries a store
     # warp, the per-subtile R2S->TMA-D tail is split by warp role and the
     # second epilogue barrier is replaced by the C-store pipeline edge. The
@@ -1992,6 +2019,15 @@ def _codegen_cute_store_tcgen05_tile(
     # per-subtile (the generic ``ttr_aux_subtile.load()`` path below, placed
     # after the c_pipeline acquire / acc ``consumer_wait`` / T2R prefix per the
     # cycle-69 placement).
+    use_full_tile_bm256_rowvec_stage = (
+        tcgen05_lifecycle.is_two_cta
+        and tcgen05_value.bm == 256
+        and tcgen05_value.bn == 128
+        and aux_matmul_plan is not None
+        and aux_matmul_plan.cluster_n == 2
+        and not tcgen05_value.partial_output_tma_store
+        and not tcgen05_value.output_column_major
+    )
     rowvec_aux_stage_records: list[_RowvecAuxStageRecord | None] = []
     for aux_idx, rec in enumerate(aux_step_records):
         copy_bits = 128
@@ -2002,7 +2038,7 @@ def _codegen_cute_store_tcgen05_tile(
             copy_bits=copy_bits,
         )
         if (
-            tcgen05_value.partial_output_tma_store
+            (tcgen05_value.partial_output_tma_store or use_full_tile_bm256_rowvec_stage)
             and tcgen05_value.use_tma_store_epilogue
             and rec.broadcast_axis == 1
             and copy_elems is not None
@@ -2047,7 +2083,12 @@ def _codegen_cute_store_tcgen05_tile(
                 [
                     (
                         f"{stage.smem_layout} = cute.make_layout("
-                        f"({tcgen05_aux_bn},), stride=(1,))"
+                        + (
+                            f"({tcgen05_aux_epi_warp_count}, {tcgen05_aux_bn}), "
+                            f"stride=({tcgen05_aux_bn}, 1))"
+                            if use_full_tile_bm256_rowvec_stage
+                            else f"({tcgen05_aux_bn},), stride=(1,))"
+                        )
                     ),
                     (
                         f"{stage.smem_ptr} = cute.arch.alloc_smem("
@@ -2070,39 +2111,74 @@ def _codegen_cute_store_tcgen05_tile(
             stage = rowvec_aux_stage_records[aux_idx]
             if stage is None:
                 continue
+            if use_full_tile_bm256_rowvec_stage:
+                copy_source = (
+                    f"    cute.copy({stage.tiled_copy}, {stage.gmem_part}, "
+                    f"{stage.smem_part})"
+                )
+                copy_thread_layout = "32"
+                copy_tidx = f"{tcgen05_aux_epi_tidx} % cutlass.Int32(32)"
+                copy_smem = (
+                    f"{stage.smem}[{tcgen05_aux_epi_tidx} // cutlass.Int32(32), None]"
+                )
+            else:
+                copy_source = (
+                    f"    {stage.coord} = {stage.thr_copy}.partition_S("
+                    f"cute.make_identity_tensor({tcgen05_aux_bn}))\n"
+                    f"    {stage.limit} = min({n_size} - ({n_index}), "
+                    f"cutlass.Int32({stage.aux_extent}) - ({n_index}), "
+                    f"cutlass.Int32({tcgen05_aux_bn}))\n"
+                    f"    {stage.pred} = cute.make_rmem_tensor("
+                    f"(1, cute.size({stage.smem_part}.shape[1])), cutlass.Boolean)\n"
+                    f"    for _rowvec_i in cutlass.range("
+                    f"cute.size({stage.smem_part}.shape[1]), unroll_full=True):\n"
+                    f"        {stage.pred}[0, _rowvec_i] = "
+                    f"{stage.coord}[0, _rowvec_i] < {stage.limit}\n"
+                    f"    cute.copy({stage.tiled_copy}, {stage.gmem_part}, "
+                    f"{stage.smem_part}, pred={stage.pred})"
+                )
+                copy_thread_layout = str(tcgen05_aux_epi_warp_count * 32)
+                copy_tidx = tcgen05_aux_epi_tidx
+                copy_smem = stage.smem
             lines.append(
                 f"if {tcgen05_aux_epi_active}:\n"
                 f"    {stage.tiled_copy} = cute.make_tiled_copy_tv("
                 f"cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), "
                 f"{rec.aux_dtype}, num_bits_per_copy={stage.copy_bits}), "
-                f"cute.make_layout({tcgen05_aux_epi_warp_count * 32}), "
+                f"cute.make_layout({copy_thread_layout}), "
                 f"cute.make_layout({stage.copy_elems}))\n"
                 f"    {stage.thr_copy} = {stage.tiled_copy}.get_slice("
-                f"{tcgen05_aux_epi_tidx})\n"
+                f"{copy_tidx})\n"
                 f"    {stage.gmem_tile} = cute.local_tile("
                 f"{rec.aux_tensor_name}, ({tcgen05_aux_bn},), "
                 f"({tile_coord_n},))\n"
                 f"    {stage.gmem_part} = {stage.thr_copy}.partition_S("
                 f"{stage.gmem_tile})\n"
                 f"    {stage.smem_part} = {stage.thr_copy}.partition_D("
-                f"{stage.smem})\n"
-                f"    {stage.coord} = {stage.thr_copy}.partition_S("
-                f"cute.make_identity_tensor({tcgen05_aux_bn}))\n"
-                f"    {stage.limit} = min({n_size} - ({n_index}), "
-                f"cutlass.Int32({stage.aux_extent}) - ({n_index}), "
-                f"cutlass.Int32({tcgen05_aux_bn}))\n"
-                f"    {stage.pred} = cute.make_rmem_tensor("
-                f"(1, cute.size({stage.smem_part}.shape[1])), cutlass.Boolean)\n"
-                f"    for _rowvec_i in cutlass.range("
-                f"cute.size({stage.smem_part}.shape[1]), unroll_full=True):\n"
-                f"        {stage.pred}[0, _rowvec_i] = "
-                f"{stage.coord}[0, _rowvec_i] < {stage.limit}\n"
-                f"    cute.copy({stage.tiled_copy}, {stage.gmem_part}, "
-                f"{stage.smem_part}, pred={stage.pred})\n"
-                f"    cute.arch.fence_acq_rel_cta()\n"
-                f"    {epilog_sync_barrier}.arrive_and_wait()"
+                f"{copy_smem})\n"
+                f"{copy_source}"
             )
         return lines
+
+    def _rowvec_aux_wait_lines() -> list[str]:
+        """Synchronize staged scale data at its first consumer boundary."""
+
+        if use_full_tile_bm256_rowvec_stage or not any(
+            stage is not None for stage in rowvec_aux_stage_records
+        ):
+            return []
+        fence_source = (
+            ""
+            if use_full_tile_bm256_rowvec_stage
+            else "    cute.arch.fence_acq_rel_cta()\n"
+        )
+        return [
+            (
+                f"if {tcgen05_aux_epi_active}:\n"
+                f"{fence_source}"
+                f"    {epilog_sync_barrier}.arrive_and_wait()"
+            )
+        ]
 
     def _simt_edge_coord_subtile_source(indent: str) -> str:
         return (
@@ -2290,10 +2366,16 @@ def _codegen_cute_store_tcgen05_tile(
                 assert rec.broadcast_axis == 1
                 assert rec.aux_view2d is not None
                 # The compact SMEM rowvec is allocated and populated per output
-                # tile, so its 2-D broadcast view is already tile-sized.
+                # tile, so its broadcast view is already tile-sized.
+                rowvec_smem_iterator = (
+                    f"{rowvec_stage.smem}[{tcgen05_aux_epi_tidx} // "
+                    "cutlass.Int32(32), None].iterator"
+                    if use_full_tile_bm256_rowvec_stage
+                    else f"{rowvec_stage.smem}.iterator"
+                )
                 lines.append(
                     f"{rec.aux_view2d} = cute.make_tensor("
-                    f"{rowvec_stage.smem}.iterator, "
+                    f"{rowvec_smem_iterator}, "
                     f"cute.make_layout(({tcgen05_bm}, {tcgen05_bn}), "
                     f"stride=(0, 1)))"
                 )
@@ -2395,6 +2477,18 @@ def _codegen_cute_store_tcgen05_tile(
                         if rec.aux_rmem_full is not None and not force_gmem_aux
                         else []
                     ),
+                    *(
+                        [
+                            (
+                                f"{rec.colvec_scalar_full} = "
+                                f"{rec.ttr_aux_grouped}[(0, 0, 0, 0)]"
+                            )
+                        ]
+                        if use_full_tile_bm256_colvec_scalar
+                        and rec.colvec_scalar_full is not None
+                        and not force_gmem_aux
+                        else []
+                    ),
                 ]
             )
         return lines
@@ -2421,6 +2515,32 @@ def _codegen_cute_store_tcgen05_tile(
             f"{rec.ttr_aux_subtile}, {rec.aux_rmem})\n"  # type: ignore[attr-defined]
             f"{indent}{rec.aux_loaded} = "  # type: ignore[attr-defined]
             f"{rec.aux_rmem}.load()\n"  # type: ignore[attr-defined]
+        )
+
+    def _materialize_two_row_colvec_source(
+        indent: str, rec: object, carrier_name: str
+    ) -> str:
+        """Load the two distinct row scales in a bm=128 2-CTA fragment once."""
+        coord0 = f"{rec.aux_rmem}_coord0"  # type: ignore[attr-defined]
+        coord1 = f"{rec.aux_rmem}_coord1"  # type: ignore[attr-defined]
+        scale0 = f"{rec.aux_rmem}_scale0"  # type: ignore[attr-defined]
+        scale1 = f"{rec.aux_rmem}_scale1"  # type: ignore[attr-defined]
+        value_i = f"{rec.aux_rmem}_value_i"  # type: ignore[attr-defined]
+        return (
+            _simt_edge_coord_subtile_source(indent) + f"{indent}{rec.aux_rmem} = "  # type: ignore[attr-defined]
+            f"cute.make_rmem_tensor(cute.make_layout({carrier_name}.shape), "
+            f"{rec.aux_dtype})\n"  # type: ignore[attr-defined]
+            f"{indent}{coord0} = {ttr_cc_subtile}[0][0]\n"
+            f"{indent}{coord1} = {ttr_cc_subtile}[1][0]\n"
+            f"{indent}{scale0} = {rec.aux_tensor_name}[{coord0}, 0]\n"  # type: ignore[attr-defined]
+            f"{indent}{scale1} = {rec.aux_tensor_name}[{coord1}, 0]\n"  # type: ignore[attr-defined]
+            f"{indent}for _colvec_i in cutlass.range("
+            f"cute.size({rec.aux_rmem}.shape), unroll_full=True):\n"  # type: ignore[attr-defined]
+            f"{indent}    {value_i} = {scale1}\n"
+            f"{indent}    if _colvec_i % 2 == 0:\n"
+            f"{indent}        {value_i} = {scale0}\n"
+            f"{indent}    {rec.aux_rmem}[_colvec_i] = {value_i}\n"  # type: ignore[attr-defined]
+            f"{indent}{rec.aux_loaded} = {rec.aux_rmem}.load()\n"  # type: ignore[attr-defined]
         )
 
     def _aux_subtile_load_source(
@@ -2653,10 +2773,33 @@ def _codegen_cute_store_tcgen05_tile(
                     f"[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
                 )
                 if tcgen05_colvec_fragment_single_m_row:
+                    if (
+                        use_full_tile_bm256_colvec_scalar
+                        and rec.colvec_scalar_full is not None
+                    ):
+                        lines.append(
+                            f"{prelude_indent}{rec.aux_loaded} = "
+                            f"{rec.colvec_scalar_full}\n"
+                        )
+                    else:
+                        lines.append(
+                            f"{prelude_indent}{rec.aux_loaded} = "
+                            f"{rec.ttr_aux_grouped}"
+                            f"[(0, 0, 0, cutlass.Int32(_tcgen05_subtile))]\n"
+                        )
+                elif (
+                    tcgen05_is_two_cta_m128(
+                        is_two_cta=tcgen05_lifecycle.is_two_cta,
+                        bm=tcgen05_value.bm,
+                    )
+                    and tcgen05_value.use_tma_store_epilogue
+                    and not tcgen05_value.partial_output_tma_store
+                    and not tcgen05_value.output_column_major
+                ):
                     lines.append(
-                        f"{prelude_indent}{rec.aux_loaded} = "
-                        f"{rec.ttr_aux_grouped}"
-                        f"[(0, 0, 0, cutlass.Int32(_tcgen05_subtile))]\n"
+                        _materialize_two_row_colvec_source(
+                            prelude_indent, rec, carrier_name
+                        )
                     )
                 else:
                     lines.append(
@@ -2760,6 +2903,20 @@ def _codegen_cute_store_tcgen05_tile(
             safe_direct_aux_with_full_tile=safe_direct_aux_with_full_tile,
         )
         aux_locals: tuple[str, ...] = tuple(rec.aux_loaded for rec in aux_step_records)
+        if (
+            len(epilogue_chain.steps) == 1
+            and isinstance(epilogue_chain.steps[0], _AuxiliaryTensorProductStep)
+            and len(aux_locals) == 2
+        ):
+            product = df.new_var("tcgen05_aux_product")
+            final_expr = df.new_var("tcgen05_chain_step")
+            return (
+                early_aux_prelude,
+                prelude_load + f"{prelude_indent}{product} = "
+                f"{aux_locals[0]} * {aux_locals[1]}\n"
+                + f"{prelude_indent}{final_expr} = {loaded} * {product}\n",
+                f"({final_expr}).to({target_dtype})",
+            )
         chain_prelude, final_expr = epilogue_chain.render_prelude_and_expr(
             loaded,
             df.new_var,
@@ -2809,7 +2966,11 @@ def _codegen_cute_store_tcgen05_tile(
                         tcgen05_value.bm,
                         tcgen05_value.bn,
                         target_dtype,
-                        c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+                        c_layout=(
+                            "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
+                            if tcgen05_value.output_column_major
+                            else "cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
+                        ),
                     )
                 }
                 if d_two_cta_m128 and not tcgen05_value.has_explicit_epilogue_tile
@@ -2827,6 +2988,8 @@ def _codegen_cute_store_tcgen05_tile(
         }
         if leading_passthrough_output:
             d_tma_plan["d_leading_passthrough"] = True
+        if tcgen05_value.output_column_major:
+            d_tma_plan["d_column_major"] = True
         state.codegen.cute_wrapper_plans.append(d_tma_plan)
 
     tcgen05_bm = tcgen05_value.bm
@@ -2835,6 +2998,11 @@ def _codegen_cute_store_tcgen05_tile(
     tcgen05_epilog_sync_barrier_id = tcgen05_value.epilog_sync_barrier_id
     tcgen05_c_stage_count = tcgen05_value.c_stage_count
     tcgen05_is_two_cta = tcgen05_lifecycle.is_two_cta
+    tcgen05_c_layout = (
+        "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
+        if tcgen05_value.output_column_major
+        else "cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
+    )
     tcgen05_thr_mma = tcgen05_value.thr_mma
     # The bm=128 CtaGroup.TWO family stores through the per-CTA epilogue tile
     # (m of 64, ``use_2cta=True``, no-source) so the store-side
@@ -2847,7 +3015,7 @@ def _codegen_cute_store_tcgen05_tile(
         bn=tcgen05_bn,
         is_two_cta=tcgen05_is_two_cta,
         elem_dtype=target_dtype,
-        c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+        c_layout=tcgen05_c_layout,
         explicit_expr=tcgen05_explicit_store_tile_expr,
     )
     full_tile_expr = (
@@ -2863,7 +3031,7 @@ def _codegen_cute_store_tcgen05_tile(
             (
                 f"{kernel_desc} = type('Tcgen05KernelDesc', (), {{"
                 f"'cta_tile_shape_mnk': ({tcgen05_store_tile_m}, {tcgen05_bn}, {tcgen05_bk}), "
-                "'c_layout': cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
+                f"'c_layout': {tcgen05_c_layout}, "
                 f"'c_dtype': {target_dtype}, "
                 "'acc_dtype': cutlass.Float32, "
                 f"'epilog_sync_bar_id': cutlass.Int32({tcgen05_epilog_sync_barrier_id}), "
@@ -3016,7 +3184,7 @@ def _codegen_cute_store_tcgen05_tile(
                 (
                     f"if {tcgen05_lifecycle.epi_active}:\n"
                     f"    {tcgen05_lifecycle.acc_pipeline}.consumer_wait({tcgen05_lifecycle.acc_consumer_state})"
-                )
+                ),
             ]
         ),
         f"{ttr_tacc} = cute.group_modes({ttr_tacc_stage}, 3, cute.rank({ttr_tacc_stage}))",
@@ -3162,6 +3330,10 @@ def _codegen_cute_store_tcgen05_tile(
         else []
     )
     tma_store_pipeline_setup = [
+        (
+            f"if {tcgen05_lifecycle.tma_warp}:\n"
+            f"    cute.nvgpu.cpasync.prefetch_descriptor({tcgen05_value.tma_store_atom})"
+        ),
         (
             f"{epilog_sync_barrier} = cutlass.pipeline.NamedBarrier("
             f"barrier_id=cutlass.Int32({tcgen05_value.epilog_sync_barrier_id}), "
@@ -3477,13 +3649,10 @@ def _codegen_cute_store_tcgen05_tile(
     ) -> str:
         """Return the t2r/math/store-source region.
 
-        The aux prelude is rendered inside ``body`` immediately after
-        the TMEM→register copy and before ``acc.load()`` / fused math.
-        Keeping residual and bias fragments out of the acquire/T2R
-        prefix shortens their live ranges through the R2S store path;
-        the long-scoreboard overlap from the older hoist was less
-        valuable on the packed Target8 epilogue than eliminating the
-        resulting local-memory spills.
+        The default path renders the aux prelude after the TMEM→register
+        copy to keep large residual fragments out of the store prefix. The
+        compact M64 and two-CTA M128 scaled-FP8 paths prefetch their small
+        scale fragments before the accumulator wait to hide the LDG latency.
         """
         assert allow_aux_chain or not aux_steps_in_chain, (
             "diagnostic / module-helper layouts reject aux-tensor chains at "
@@ -3511,11 +3680,21 @@ def _codegen_cute_store_tcgen05_tile(
                 f"                {tcgen05_acc_pipeline}.consumer_release({tcgen05_acc_consumer_state})\n"
             )
         )
+        pre_wait_aux = (
+            (
+                (not tcgen05_lifecycle.is_two_cta and tcgen05_value.bm == 64)
+                or (tcgen05_lifecycle.is_two_cta and tcgen05_value.bm == 128)
+                or use_full_tile_bm256_rowvec_stage
+            )
+            and bool(aux_steps_in_chain)
+            and not tcgen05_value.partial_output_tma_store
+        )
         return (
+            f"{early_aux_prelude if pre_wait_aux else ''}"
             f"{acc_wait}"
             f"        {ttr_tacc_mn} = {ttr_tacc}[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
             f"        cute.copy({tiled_copy_t2r}, {ttr_tacc_mn}, {ttr_racc})\n"
-            f"{early_aux_prelude}"
+            f"{'' if pre_wait_aux else early_aux_prelude}"
             f"{late_prelude}"
             f"        {acc_vec} = {rhs}\n"
             f"{acc_release}"
@@ -3925,7 +4104,7 @@ def _codegen_cute_store_tcgen05_tile(
         # `helion/runtime/__init__.py`; both describe one D SMEM stage.
         (
             f"{smem_d_layout} = cutlass.utils.blackwell_helpers.make_smem_layout_epi("
-            f"{target_dtype}, cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
+            f"{target_dtype}, {tcgen05_c_layout}, "
             f"{epi_tile}, {tcgen05_value.c_stage_count})"
         ),
         (
@@ -4088,6 +4267,7 @@ def _codegen_cute_store_tcgen05_tile(
         ),
         f"{ttr_tacc} = cute.group_modes({ttr_tacc_stage}, 3, cute.rank({ttr_tacc_stage}))",
         f"{subtile_count} = cutlass.const_expr(cute.size({ttr_tacc}.shape, mode=[3]))",
+        *_rowvec_aux_wait_lines(),
         *tma_store_pre_loop_acc_wait,
     ]
     # Warp 0 pre-acquires the first TMA-store SMEM stage before per-tile

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2671,6 +2671,36 @@ def _codegen_cute_store_tcgen05_tile(
                     + "\n",
                 ]
             )
+        if (
+            force_simt_edge_aux
+            and len(aux_step_records) == 2
+            and all(rec.broadcast_axis is not None for rec in aux_step_records)
+        ):
+            rec0, rec1 = aux_step_records
+            lines.append(
+                f"{prelude_indent}{rec0.ttr_aux_subtile} = "
+                f"{rec0.ttr_aux_grouped}[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
+                f"{prelude_indent}{rec1.ttr_aux_subtile} = "
+                f"{rec1.ttr_aux_grouped}[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
+                f"{prelude_indent}{rec0.aux_rmem} = cute.make_rmem_tensor("
+                f"{rec0.ttr_aux_subtile}.shape, {rec0.aux_dtype})\n"
+                f"{prelude_indent}{rec1.aux_rmem} = cute.make_rmem_tensor("
+                f"{rec1.ttr_aux_subtile}.shape, {rec1.aux_dtype})\n"
+                f"{prelude_indent}{rec0.aux_rmem}.fill(0)\n"
+                f"{prelude_indent}{rec1.aux_rmem}.fill(0)\n"
+                f"{_simt_edge_coord_subtile_source(prelude_indent)}"
+                f"{prelude_indent}for _edge_i in range(cute.size("
+                f"{rec0.ttr_aux_subtile}.shape)):\n"
+                f"{prelude_indent}    _coord = {ttr_cc_subtile}[_edge_i]\n"
+                f"{prelude_indent}    if cute.elem_less(_coord, ({m_size}, {n_size})):\n"
+                f"{prelude_indent}        {rec0.aux_rmem}[_edge_i] = "
+                f"{rec0.ttr_aux_subtile}[_edge_i]\n"
+                f"{prelude_indent}        {rec1.aux_rmem}[_edge_i] = "
+                f"{rec1.ttr_aux_subtile}[_edge_i]\n"
+                f"{prelude_indent}{rec0.aux_loaded} = {rec0.aux_rmem}.load()\n"
+                f"{prelude_indent}{rec1.aux_loaded} = {rec1.aux_rmem}.load()\n"
+            )
+            return "".join(lines)
         for aux_idx, rec in enumerate(aux_step_records):
             rowvec_stage = rowvec_aux_stage_records[aux_idx]
             if (
@@ -2692,8 +2722,6 @@ def _codegen_cute_store_tcgen05_tile(
                         copy_atom=simt_edge_aux_atoms[aux_idx],
                     )
                 else:
-                    # Rowvec broadcast stayed scalar in the cycle-74 ablation:
-                    # vectorizing it did not reduce stack pressure or runtime.
                     edge_aux_copy_source = _simt_edge_scalar_copy_source(
                         prelude_indent,
                         rec.ttr_aux_subtile,
@@ -3091,7 +3119,17 @@ def _codegen_cute_store_tcgen05_tile(
         )
         return static_setup, tile_setup
 
-    simt_edge_only = tcgen05_value.tma_store_full_tiles_only
+    # If either problem dimension is smaller than its CTA tile, every output
+    # tile is statically an edge tile. Reuse the edge-only path so auxiliary
+    # loads and the output store share one coordinate partition instead of
+    # rebuilding it behind a full/edge branch for every operand.
+    static_m_size = tensor.shape[-2]
+    static_n_size = tensor.shape[-1]
+    simt_edge_only = tcgen05_value.tma_store_full_tiles_only or (
+        isinstance(static_m_size, int)
+        and isinstance(static_n_size, int)
+        and (static_m_size < tcgen05_bm or static_n_size < tcgen05_bn)
+    )
     simt_edge_aux_atoms: dict[int, str] = {}
     simt_edge_aux_atom_setup: list[str] = []
     if simt_edge_only:
@@ -3099,9 +3137,6 @@ def _codegen_cute_store_tcgen05_tile(
             if rec.broadcast_axis is None:
                 edge_aux_atom = df.new_var(f"{rec.aux_rmem}_edge_atom")
                 simt_edge_aux_atoms[aux_idx] = edge_aux_atom
-                # Use a per-aux atom typed to the aux dtype. Reusing the
-                # output SIMT atom here was spill-free but slower on the
-                # measured Target8 edge path.
                 simt_edge_aux_atom_setup.append(
                     f"{edge_aux_atom} = "
                     f"cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), "
@@ -3113,9 +3148,19 @@ def _codegen_cute_store_tcgen05_tile(
     simt_early_aux, simt_late_prelude, simt_acc_vec_rhs = _splice_acc_vec(
         ttr_racc,
         "        ",
-        force_simt_edge_aux=tcgen05_value.tma_store_full_tiles_only,
+        force_simt_edge_aux=simt_edge_only,
     )
     simt_acc_vec_prelude = simt_early_aux + simt_late_prelude
+    prefetch_simt_aux = (
+        not tcgen05_value.use_tma_store_epilogue
+        and bool(aux_steps_in_chain)
+        and not is_secondary_store
+    )
+    simt_acc_wait = (
+        "        if _tcgen05_subtile == 0:\n"
+        f"            {tcgen05_lifecycle.acc_pipeline}.consumer_wait("
+        f"{tcgen05_lifecycle.acc_consumer_state})\n"
+    )
     if tcgen05_value.use_tma_store_epilogue:
         tma_static_store_setup, tma_tile_store_setup = store_common_setup(
             tcgen05_value.tma_store_tensor,
@@ -3177,16 +3222,6 @@ def _codegen_cute_store_tcgen05_tile(
             f"{ttr_tacc_stage} = {ttr_tacc_base}["
             f"(None, None, None, None, None, {tcgen05_acc_stage_index_expr})]"
         ),
-        *(
-            []
-            if is_secondary_store
-            else [
-                (
-                    f"if {tcgen05_lifecycle.epi_active}:\n"
-                    f"    {tcgen05_lifecycle.acc_pipeline}.consumer_wait({tcgen05_lifecycle.acc_consumer_state})"
-                ),
-            ]
-        ),
         f"{ttr_tacc} = cute.group_modes({ttr_tacc_stage}, 3, cute.rank({ttr_tacc_stage}))",
         f"{ttr_gc_grouped} = cute.group_modes({ttr_gc}, 3, cute.rank({ttr_gc}))",
         # Per-aux-step partitioning lines (one chain per auxiliary
@@ -3198,6 +3233,16 @@ def _codegen_cute_store_tcgen05_tile(
             thr_copy_t2r_var=thr_copy_t2r,
             define_thr_copy_t2r=False,
             force_gmem_aux=simt_edge_only,
+        ),
+        *(
+            [
+                (
+                    f"if {tcgen05_lifecycle.epi_active}:\n"
+                    f"    {tcgen05_lifecycle.acc_pipeline}.consumer_wait({tcgen05_lifecycle.acc_consumer_state})"
+                )
+            ]
+            if not (is_secondary_store or prefetch_simt_aux)
+            else []
         ),
         (
             f"{ttr_racc} = cute.make_rmem_tensor("
@@ -3240,9 +3285,14 @@ def _codegen_cute_store_tcgen05_tile(
             f"    if {tcgen05_lifecycle.epi_active}:\n"
             f"        {ttr_tacc_mn} = {ttr_tacc}[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
             f"        {ttr_gc_subtile} = {ttr_gc_grouped}[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
-            f"        cute.copy({tiled_copy_t2r}, {ttr_tacc_mn}, {ttr_racc})\n"
-            f"{simt_acc_vec_prelude}"
-            f"        {acc_vec} = {simt_acc_vec_rhs}\n"
+            + (f"{simt_early_aux}{simt_acc_wait}" if prefetch_simt_aux else "")
+            + f"        cute.copy({tiled_copy_t2r}, {ttr_tacc_mn}, {ttr_racc})\n"
+            + (
+                f"{simt_late_prelude}"
+                if prefetch_simt_aux
+                else f"{simt_acc_vec_prelude}"
+            )
+            + f"        {acc_vec} = {simt_acc_vec_rhs}\n"
             f"        {ttr_rd}.store({acc_vec})\n"
             # The secondary fan-out store reuses the still-live accumulator and
             # must not release it; the primary store owns the release + advance.

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2626,9 +2626,15 @@ def _append_cute_wrapper_plan(
         d_store_box_n: int | None = None,
         epi_tile_raw_expr: str | None = None,
         tensor_name: str | None = None,
+        column_major: bool = False,
     ) -> None:
         assert len(kernel_args) == 2
         tensor_expr = tensor_name if tensor_name is not None else f"arg{tensor_idx}"
+        c_layout = (
+            "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
+            if column_major
+            else "cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
+        )
         explicit_epi_tile = any(
             value is not None for value in (epi_tile_m, epi_tile_n, d_store_box_n)
         )
@@ -2653,7 +2659,7 @@ def _append_cute_wrapper_plan(
                 bm,
                 bn,
                 dtype,
-                c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+                c_layout=c_layout,
             )
         tma_atom, tma_tensor = kernel_args
         epi_tile = f"{tma_atom}_epi_tile"
@@ -2668,7 +2674,7 @@ def _append_cute_wrapper_plan(
                 (
                     f"    {smem_layout} = cutlass.utils.blackwell_helpers."
                     "make_smem_layout_epi("
-                    f"{dtype}, cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
+                    f"{dtype}, {c_layout}, "
                     f"{epi_tile}, {stage_count})"
                 ),
                 (
@@ -2969,6 +2975,7 @@ def _append_cute_wrapper_plan(
             d_store_box_n=plan_optional_int("d_store_box_n"),
             epi_tile_raw_expr=plan_optional_str("epi_tile_raw_expr"),
             tensor_name=d_tensor_name,
+            column_major=bool(plan.get("d_column_major")),
         )
         return
     if kind == "tcgen05_aux_tma":
@@ -3021,6 +3028,10 @@ def _append_cute_wrapper_plan(
     b_k_major = bool(plan.get("b_k_major"))
     lhs_leading_passthrough = bool(plan.get("lhs_leading_passthrough"))
     rhs_leading_passthrough = bool(plan.get("rhs_leading_passthrough"))
+    lhs_trailing_transpose = bool(plan.get("lhs_trailing_transpose"))
+    rhs_trailing_transpose = bool(plan.get("rhs_trailing_transpose"))
+    assert not (lhs_leading_passthrough and lhs_trailing_transpose)
+    assert not (rhs_leading_passthrough and rhs_trailing_transpose)
     kernel_args = [str(arg) for arg in cast("list[object]", plan["kernel_args"])]
     assert len(kernel_args) == 4
     tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b = kernel_args
@@ -3055,7 +3066,11 @@ def _append_cute_wrapper_plan(
     smem_b_layout = f"{tma_atom_b}_smem_layout"
     lhs_tma = f"{tma_atom_a}_lhs_tma"
     rhs_tma = f"{tma_atom_b}_rhs_tma"
-    lhs_tma_operand = lhs_tma if lhs_leading_passthrough else f"arg{lhs_idx}"
+    lhs_tma_operand = (
+        lhs_tma
+        if lhs_leading_passthrough or lhs_trailing_transpose
+        else f"arg{lhs_idx}"
+    )
     smem_a_layout_expr = tcgen05_smem_layout_expr(
         tiled_mma=tiled_mma,
         bm=bm,
@@ -3079,6 +3094,8 @@ def _append_cute_wrapper_plan(
     )
     if lhs_leading_passthrough:
         append_permuted_cute_tensor_view(lhs_tma, lhs_idx, (1, 2, 0))
+    elif lhs_trailing_transpose:
+        append_permuted_cute_tensor_view(lhs_tma, lhs_idx, (1, 0))
     if rhs_leading_passthrough:
         append_permuted_cute_tensor_view(rhs_tma, rhs_idx, (2, 1, 0))
     ab_tma_lines = [
@@ -3104,7 +3121,15 @@ def _append_cute_wrapper_plan(
         f"    {smem_a_layout} = {smem_a_layout_expr}",
         f"    {smem_b_layout} = {smem_b_layout_expr}",
     ]
-    if not rhs_leading_passthrough:
+    if rhs_trailing_transpose:
+        ab_tma_lines.append(
+            f"    {rhs_tma} = cute.make_tensor("
+            f"arg{rhs_idx}.iterator, "
+            "layout=cute.make_layout("
+            f"(arg{rhs_idx}_shape0, arg{rhs_idx}_shape1), "
+            f"stride=(arg{rhs_idx}_stride0, arg{rhs_idx}_stride1)))"
+        )
+    elif not rhs_leading_passthrough:
         ab_tma_lines.append(
             f"    {rhs_tma} = cute.make_tensor("
             f"arg{rhs_idx}.iterator, "

--- a/pr_description_cute_scale_mm.md
+++ b/pr_description_cute_scale_mm.md
@@ -1,0 +1,100 @@
+# [CuTe] Beat CUTLASS across the scaled FP8 matmul sweep
+
+## Summary
+
+Improve Blackwell CuTe scaled-FP8 matmul code generation and extend the
+production benchmark from 17 to 33 shapes. The added `M=2/8/16/32` shapes now
+use tensor cores instead of the scalar skinny-M fallback, and Helion is faster
+than CUTLASS on every shape in the complete GB200 sweep.
+
+## Codegen optimizations
+
+### Small-N tensor-core mainloop
+
+- Admit FP8 problems whose logical N is smaller than the minimum searched MMA
+  tile.
+- Pad the tcgen05 N tile to 16 columns and let TMA zero-fill columns outside
+  the source tensor instead of staging the narrow operand with thousands of
+  scalar loads.
+- Keep the optimized path narrowly guarded to persistent, single-CTA-cluster,
+  transposed-RHS problems with full M and K tiles.
+- Use ceiling tile counts when validating one-shot role scheduling so a single
+  partial N tile is counted correctly.
+- Keep `BN < 32` outputs on the direct SIMT epilogue; the TMA-store staging and
+  barriers cost more than they save for these narrow stores.
+
+### Narrow SIMT epilogue
+
+- Detect grids where one output dimension is smaller than its CTA tile, making
+  every output tile statically an edge tile.
+- Remove the unused full-tile branch for that case and share one coordinate
+  partition across both scale loads and the output store.
+- Fuse the predicates for the row and column scale fragments into one edge
+  traversal.
+- Issue scale loads before the accumulator consumer wait, overlapping global
+  memory latency with completion of the tensor-core mainloop. The accumulator
+  wait remains first-subtile-only for multi-subtile epilogues.
+- Multiply prefetched row and column scales into the accumulator sequentially,
+  avoiding an extra scale-product live range on the smallest four-CTA grid.
+
+### Existing wide-shape improvements in this branch
+
+- Add swapped A/B tcgen05 lowering with column-major output support.
+- Support role-local persistent scheduling for two-CTA and four-CTA clusters.
+- Add one-shot scheduling for device-filling static FP8 grids and bounded
+  persistent scheduling for larger grids.
+- Remove redundant scheduler and ownership work from validated static paths.
+- Tune broadcast row/column scale handling and TMA/SIMT epilogues.
+
+## Production tuning
+
+- Keep `M=1` on the scalar skinny-M decode kernel.
+- Dispatch all added `M=2/8/16/32` shapes through the swapped tensor-core
+  kernel.
+- Use `64x16x256`, one accumulator stage, and a nine-stage A/B pipeline for
+  `M=2/8/16`; reduce the A/B depth to seven for `K=2048`.
+- Use `64x32x128`, one accumulator stage, and a twelve-stage A/B pipeline for
+  `M=32`.
+- Use persistent-interleaved scheduling for `(2, 4096, 256)` and
+  persistent-blocked scheduling for the other new shapes.
+- Add exact AOT table entries for all 16 new shapes while preserving the
+  existing M64, M512, and 4096-square configurations.
+
+## Performance
+
+Tested on NVIDIA GB200 with cold-L2 CUDA-graph timing:
+
+```bash
+python pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+```
+
+Final complete sweep:
+
+- Helion vs CUTLASS: **33/33 wins**, 1.036x geomean
+- Helion vs torch: **33/33 wins**, 1.446x geomean
+- Helion vs best baseline: **33/33 wins**, 1.034x geomean
+
+Representative new shapes:
+
+| M | K | N | Helion (us) | CUTLASS (us) | Speedup |
+|---:|---:|---:|---:|---:|---:|
+| 2 | 4096 | 256 | 4.84 | 4.87 | 1.01x |
+| 8 | 4096 | 4096 | 6.78 | 6.99 | 1.03x |
+| 16 | 2048 | 4096 | 5.05 | 5.30 | 1.05x |
+| 32 | 4096 | 256 | 5.15 | 5.43 | 1.05x |
+
+## Verification
+
+- Explicit correctness checks passed against `torch._scaled_mm` for all 16 new
+  shapes (`rtol=0.03`, `atol=0.03`).
+- The complete 33-shape performance sweep completed successfully.
+- Added regression coverage for FP8 small-N persistent search and narrow SIMT
+  epilogue load/wait ordering.
+- Six focused planner, codegen-ordering, and GPU edge-correctness tests pass.
+- Ruff format/check passed for every changed Python file.
+- Python compile checks and `git diff --check` passed.
+
+`pytest` is absent from the active conda environment, so the focused tests were
+run by loading the existing pytest package from the `pyrefly-check` environment.
+The full lint wrapper also scans untracked profiling artifacts and reports
+unrelated errors there; targeted Ruff checks on all changed files pass.

--- a/pr_description_cute_scale_mm.md
+++ b/pr_description_cute_scale_mm.md
@@ -3,9 +3,10 @@
 ## Summary
 
 Improve Blackwell CuTe scaled-FP8 matmul code generation and extend the
-production benchmark from 17 to 33 shapes. The added `M=2/8/16/32` shapes now
-use tensor cores instead of the scalar skinny-M fallback, and Helion is faster
-than CUTLASS on every shape in the complete GB200 sweep.
+production benchmark from 17 to 45 shapes. The added `M=2/8/16/32` shapes now
+use tensor cores instead of the scalar skinny-M fallback. The latest 12 shapes
+use FP8 `(K, N)` pairs from vLLM's H100 `scaled_mm` configuration in
+vllm-project/vllm#46522.
 
 ## Codegen optimizations
 
@@ -57,8 +58,12 @@ than CUTLASS on every shape in the complete GB200 sweep.
   `M=32`.
 - Use persistent-interleaved scheduling for `(2, 4096, 256)` and
   persistent-blocked scheduling for the other new shapes.
-- Add exact AOT table entries for all 16 new shapes while preserving the
+- Add exact AOT table entries for all 28 new shapes while preserving the
   existing M64, M512, and 4096-square configurations.
+- Add `(2048, 12288)`, `(5120, 5120)`, and `(6144, 2048)` vLLM weight shapes
+  at each of `M=2/8/16/32`.
+- Use `64x32x256` with a seven-stage A/B pipeline for the new M=32 rows; this
+  improves that subset from 0.96-1.00x to 1.02-1.04x versus CUTLASS.
 
 ## Performance
 
@@ -68,26 +73,30 @@ Tested on NVIDIA GB200 with cold-L2 CUDA-graph timing:
 python pretuned_kernels/scale_mm_cute/scale_mm_cute.py
 ```
 
-Final complete sweep:
+Latest complete 45-shape sweep:
 
-- Helion vs CUTLASS: **33/33 wins**, 1.036x geomean
-- Helion vs torch: **33/33 wins**, 1.446x geomean
-- Helion vs best baseline: **33/33 wins**, 1.034x geomean
+- Helion vs CUTLASS: **44/45 wins**, 1.040x geomean
+- Helion vs torch: **45/45 wins**, 1.434x geomean
+- Helion vs best baseline: **44/45 wins**, 1.039x geomean
+
+The 12 vLLM-derived additions are **12/12 wins** versus CUTLASS with a 1.060x
+geomean. The only full-sweep miss is the pre-existing `(2, 4096, 256)` row at
+0.99x in that run; five isolated reruns ranged from 0.999x to 1.015x.
 
 Representative new shapes:
 
 | M | K | N | Helion (us) | CUTLASS (us) | Speedup |
 |---:|---:|---:|---:|---:|---:|
-| 2 | 4096 | 256 | 4.84 | 4.87 | 1.01x |
-| 8 | 4096 | 4096 | 6.78 | 6.99 | 1.03x |
-| 16 | 2048 | 4096 | 5.05 | 5.30 | 1.05x |
-| 32 | 4096 | 256 | 5.15 | 5.43 | 1.05x |
+| 2 | 2048 | 12288 | 8.16 | 8.40 | 1.03x |
+| 8 | 6144 | 2048 | 7.24 | 7.86 | 1.09x |
+| 16 | 5120 | 5120 | 8.02 | 8.45 | 1.05x |
+| 32 | 2048 | 12288 | 8.21 | 9.10 | 1.11x |
 
 ## Verification
 
-- Explicit correctness checks passed against `torch._scaled_mm` for all 16 new
+- Explicit correctness checks passed against `torch._scaled_mm` for all 28 new
   shapes (`rtol=0.03`, `atol=0.03`).
-- The complete 33-shape performance sweep completed successfully.
+- The complete 45-shape performance sweep completed successfully.
 - Added regression coverage for FP8 small-N persistent search and narrow SIMT
   epilogue load/wait ordering.
 - Six focused planner, codegen-ordering, and GPU edge-correctness tests pass.

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -95,10 +95,27 @@ _SMALL_M_SWAP_KEYS = [
         (4096, 6144),
     )
 ]
+_SMALL_M_SWAP_KEYS.extend(
+    (m, k, n)
+    for m in (2, 8, 16, 32)
+    for k, n in (
+        (2048, 12288),
+        (5120, 5120),
+        (6144, 2048),
+    )
+)
 
 
 def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
-    if m == 32:
+    if m == 32 and (k, n) in {
+        (2048, 12288),
+        (5120, 5120),
+        (6144, 2048),
+    }:
+        block_sizes = [64, 32, 256]
+        ab_stages = 7
+        acc_stages = 1
+    elif m == 32:
         block_sizes = [64, 32, 128]
         ab_stages = 12
         acc_stages = 1
@@ -124,7 +141,7 @@ def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
         "tcgen05_num_epi_warps": 4,
         "tcgen05_l2_swizzle_size": 1,
         "tcgen05_persistence_model": "static_persistent",
-        "tcgen05_one_shot_role_scheduler": True,
+        "tcgen05_one_shot_role_scheduler": n <= block_sizes[0] * 148,
     }
 
 

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -35,6 +35,7 @@ Provides, for each kernel <k>:
 """
 
 import math
+from typing import Any
 
 import torch
 
@@ -84,7 +85,51 @@ def autotune_scale_mm_cute_skinny_m(*args) -> dict:
 
 
 # === Kernel: scale_mm_cute_swap_ab ===
+_SMALL_M_SWAP_KEYS = [
+    (m, k, n)
+    for m in (2, 8, 16, 32)
+    for k, n in (
+        (4096, 4096),
+        (4096, 256),
+        (2048, 4096),
+        (4096, 6144),
+    )
+]
+
+
+def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
+    if m == 32:
+        block_sizes = [64, 32, 128]
+        ab_stages = 12
+        acc_stages = 1
+    else:
+        block_sizes = [64, 16, 256]
+        ab_stages = 7 if k == 2048 else 9
+        acc_stages = 1
+    pid_type = (
+        "persistent_interleaved"
+        if (m, k, n) == (2, 4096, 256)
+        else "persistent_blocked"
+    )
+    return {
+        "block_sizes": block_sizes,
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": pid_type,
+        "tcgen05_cluster_m": 1,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": ab_stages,
+        "tcgen05_acc_stages": acc_stages,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 1,
+        "tcgen05_persistence_model": "static_persistent",
+        "tcgen05_one_shot_role_scheduler": True,
+    }
+
+
 _KEYS_scale_mm_cute_swap_ab = [
+    *_SMALL_M_SWAP_KEYS,
     (64, 4096, 6144),
     (64, 4096, 24576),
     (64, 5120, 5120),
@@ -93,6 +138,7 @@ _KEYS_scale_mm_cute_swap_ab = [
 ]
 
 _CONFIGS_scale_mm_cute_swap_ab = [
+    *[_small_m_swap_config(*key) for key in _SMALL_M_SWAP_KEYS],
     {
         "block_sizes": [128, 64, 256],
         "l2_groupings": [1],

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -1,5 +1,5 @@
 """
-Auto-generated heuristic for kernels: scale_mm_cute, scale_mm_cute_skinny_m
+Auto-generated heuristic for kernels: scale_mm_cute, scale_mm_cute_skinny_m, scale_mm_cute_swap_ab
 Backend: explicit per-shape table (exact (M, K, N) -> tuned config)
 
 RowWise-scaled FP8 GEMM pretuned on NVIDIA B200 (sm100) for the Helion CuTe
@@ -83,6 +83,100 @@ def autotune_scale_mm_cute_skinny_m(*args) -> dict:
     return _CONFIGS_scale_mm_cute_skinny_m[key_scale_mm_cute_skinny_m(*args)]
 
 
+# === Kernel: scale_mm_cute_swap_ab ===
+_KEYS_scale_mm_cute_swap_ab = [
+    (64, 4096, 6144),
+    (64, 4096, 24576),
+    (64, 5120, 5120),
+    (64, 5120, 51200),
+    (64, 25600, 5120),
+]
+
+_CONFIGS_scale_mm_cute_swap_ab = [
+    {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_blocked",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 2,
+        "tcgen05_persistence_model": "static_persistent",
+        "tcgen05_one_shot_role_scheduler": True,
+    },
+    {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 2,
+        "tcgen05_persistence_model": "static_persistent",
+        "tcgen05_role_scheduler_cluster_cap": 65,
+    },
+    {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 3,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 8,
+        "tcgen05_persistence_model": "static_persistent",
+    },
+    {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_blocked",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 4,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 8,
+        "tcgen05_persistence_model": "static_persistent",
+        "tcgen05_role_scheduler_cluster_cap": 67,
+    },
+    {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": 4,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 1,
+        "tcgen05_persistence_model": "static_persistent",
+    },
+]
+
+
+def key_scale_mm_cute_swap_ab(*args) -> int:
+    return _select(_KEYS_scale_mm_cute_swap_ab, _mkn(args))
+
+
+def autotune_scale_mm_cute_swap_ab(*args) -> dict:
+    return _CONFIGS_scale_mm_cute_swap_ab[key_scale_mm_cute_swap_ab(*args)]
+
+
 # === Kernel: scale_mm_cute ===
 # Tuned (M, K, N) shapes, parallel to _CONFIGS_scale_mm_cute.
 _KEYS_scale_mm_cute = [
@@ -145,7 +239,7 @@ _CONFIGS_scale_mm_cute = [
     # (M, K, N) = (64, 4096, 6144) -- persistent bn=64 bk=128 ab=12; 0.86x vs cutlass (was 0.81).
     {'block_sizes': [64, 64, 128], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 12, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent'},
     # (M, K, N) = (64, 4096, 4096) -- persistent bn=32 bk=256; 0.94x vs cutlass (was 0.91).
-    {'block_sizes': [64, 32, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent'},
+    {'block_sizes': [64, 32, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 3, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent'},
     # (M, K, N) = (64, 4096, 24576) -- persistent bn=64 bk=128 ab=12; 0.89x vs cutlass (was 0.75).
     {'block_sizes': [64, 64, 128], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 12, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent'},
     # (M, K, N) = (64, 12288, 4096) -- persistent bn=32 bk=256; 1.02x vs cutlass (was 0.99).
@@ -160,6 +254,66 @@ _CONFIGS_scale_mm_cute = [
     {'block_sizes': [64, 64, 128], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 12, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent'},
 ]
 
+# Keep adjacent work tiles on the same persistent cluster for the 512x2048x4096
+# shape; swizzle 4 was the best cold-L2 schedule for its two-wave grid.
+_CONFIGS_scale_mm_cute[1].update(
+    {"pid_type": "persistent_blocked", "tcgen05_l2_swizzle_size": 4}
+)
+
+_CONFIGS_scale_mm_cute[0].update(
+    {
+        "block_sizes": [256, 256, 256],
+        "l2_groupings": [64],
+        "tcgen05_ab_stages": 3,
+        "tcgen05_l2_swizzle_size": 2,
+        "tcgen05_role_scheduler_cluster_cap": 64,
+    }
+)
+
+for _key, _config in zip(_KEYS_scale_mm_cute, _CONFIGS_scale_mm_cute):
+    if _key == (64, 2048, 2048):
+        _config.update(
+            {
+                "block_sizes": [64, 32, 256],
+                "indexing": ["tensor_descriptor"] * 5,
+                "pid_type": "persistent_blocked",
+                "tcgen05_ab_stages": 8,
+                "tcgen05_acc_stages": 2,
+                "tcgen05_persistence_model": "static_persistent",
+                "tcgen05_layout_strategy": "explicit_epi_tile",
+                "tcgen05_layout_overrides_epi_tile_m": 64,
+                "tcgen05_layout_overrides_epi_tile_n": 32,
+                "tcgen05_layout_overrides_d_store_box_n": 32,
+            }
+        )
+    elif _key == (64, 4096, 4096):
+        _config.update(
+            {
+                "block_sizes": [64, 32, 512],
+                "tcgen05_ab_stages": 4,
+                "tcgen05_one_shot_role_scheduler": True,
+            }
+        )
+
+# Use the widest validated M=64 epilogue subtile for the selected N tile. This
+# drains bn<=64 in one iteration and halves the bn=128 store loop from four
+# 32-column subtiles to two 64-column subtiles.
+for _config in _CONFIGS_scale_mm_cute:
+    if _config["block_sizes"][0] == 64 and _config["block_sizes"][1] in (
+        16,
+        64,
+        128,
+    ):
+        _epi_n = min(_config["block_sizes"][1], 64)
+        _config.update(
+            {
+                "tcgen05_layout_strategy": "explicit_epi_tile",
+                "tcgen05_layout_overrides_epi_tile_m": 64,
+                "tcgen05_layout_overrides_epi_tile_n": _epi_n,
+                "tcgen05_layout_overrides_d_store_box_n": _epi_n,
+            }
+        )
+
 
 def key_scale_mm_cute(*args) -> int:
     """Config index for the given args (also the cache key)."""
@@ -169,3 +323,37 @@ def key_scale_mm_cute(*args) -> int:
 def autotune_scale_mm_cute(*args) -> dict:
     """Config dict for the given args."""
     return _CONFIGS_scale_mm_cute[key_scale_mm_cute(*args)]
+
+
+# === Kernel: scale_mm_cute_m512 ===
+_KEYS_scale_mm_cute_m512 = [
+    (512, 2048, 4096),
+    (512, 2048, 2048),
+]
+
+_CONFIGS_scale_mm_cute_m512 = [
+    dict(_CONFIGS_scale_mm_cute[_KEYS_scale_mm_cute.index(key)])
+    for key in _KEYS_scale_mm_cute_m512
+]
+for _config in _CONFIGS_scale_mm_cute_m512:
+    _config["tcgen05_c_stages"] = 4
+_CONFIGS_scale_mm_cute_m512[0].update(
+    {
+        "block_sizes": [256, 128, 128],
+        "tcgen05_cluster_n": 2,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 1,
+        "tcgen05_c_stages": 3,
+        "tcgen05_l2_swizzle_size": 4,
+        "tcgen05_acc_wait_placement": "before_subtile_loop",
+        "tcgen05_one_shot_role_scheduler": True,
+    }
+)
+
+
+def key_scale_mm_cute_m512(*args) -> int:
+    return _select(_KEYS_scale_mm_cute_m512, _mkn(args))
+
+
+def autotune_scale_mm_cute_m512(*args) -> dict:
+    return _CONFIGS_scale_mm_cute_m512[key_scale_mm_cute_m512(*args)]

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -28,6 +28,13 @@ import helion.language as hl
 
 # M at or below this uses the skinny-M kernel (mirrors examples/fp8_gemm.py).
 _SKINNY_M_MAX = 1
+_SWAP_AB_SHAPES = {
+    (64, 4096, 6144),
+    (64, 4096, 24576),
+    (64, 5120, 5120),
+    (64, 5120, 51200),
+    (64, 25600, 5120),
+}
 
 
 @helion.aot_kernel(backend="cute", static_shapes=True)
@@ -47,8 +54,31 @@ def scale_mm_cute(
         for tile_k in hl.tile(k):
             acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
         # RowWise scale in the epilogue (per-row scale_a x per-column scale_b).
-        acc = acc * scale_a[tile_m, tile_n] * scale_b[tile_n]
-        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+        out[tile_m, tile_n] = (acc * scale_a[tile_m, tile_n] * scale_b[tile_n]).to(
+            torch.bfloat16
+        )
+    return out
+
+
+@helion.aot_kernel(backend="cute", static_shapes=True)
+def scale_mm_cute_m512(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """M512 variant with an explicit per-row scale broadcast."""
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    scale_a_2d = scale_a[:, :1].expand(m, n)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        tile_scale = scale_a_2d[tile_m, tile_n] * scale_b[tile_n]
+        out[tile_m, tile_n] = (acc * tile_scale).to(torch.bfloat16)
     return out
 
 
@@ -73,8 +103,37 @@ def scale_mm_cute_skinny_m(
         acc = hl.zeros([m, tile_n], dtype=torch.float32)
         for tile_k in hl.tile(k):
             acc = hl.dot(x[:, tile_k], y[tile_k, tile_n], acc=acc)
-        acc = acc * scale_a[:, tile_n] * scale_b[tile_n]
+        scale = scale_a[:, tile_n] * scale_b[tile_n]
+        acc = acc * scale
         out[:, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+@helion.aot_kernel(backend="cute", static_shapes=True)
+def scale_mm_cute_swap_ab(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """M64 FP8 GEMM using CUTLASS's swapped 4-CTA cluster topology."""
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    out_t = out.T
+    scale_a_t = scale_a.unsqueeze(0)
+    scale_b_t = scale_b.unsqueeze(-1).expand(n, m)
+    for tile_n, tile_m in hl.tile([n, m]):
+        acc = hl.zeros([tile_n, tile_m], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(
+                y[tile_k, tile_n].T,
+                x[tile_m, tile_k].T,
+                acc=acc,
+            )
+        scale = scale_b_t[tile_n, tile_m] * scale_a_t[tile_n, tile_m]
+        out_t[tile_n, tile_m] = (acc * scale).to(torch.bfloat16)
     return out
 
 
@@ -87,6 +146,11 @@ def _scale_mm_cute(
     """Dispatch to the skinny-M kernel for small M, else the [M, N]-tiled one."""
     if x.size(0) <= _SKINNY_M_MAX:
         return scale_mm_cute_skinny_m(x, y, scale_a, scale_b)
+    if x.size(0) == 512:
+        return scale_mm_cute_m512(x, y, scale_a, scale_b)
+    shape = (x.size(0), x.size(1), y.size(1))
+    if shape in _SWAP_AB_SHAPES:
+        return scale_mm_cute_swap_ab(x, y, scale_a[:, 0], scale_b)
     return scale_mm_cute(x, y, scale_a, scale_b)
 
 

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -13,7 +13,7 @@ Specialized kernels include:
 * :func:`scale_mm_cute` tiles over both M and N.
 * :func:`scale_mm_cute_skinny_m` keeps the full (small) M resident and tiles
   only over N for single-token decode.
-* :func:`scale_mm_cute_swap_ab` swaps M/N so M=2/8/16/32 can use efficient
+* :func:`scale_mm_cute_swap_ab` swaps M/N so small-M shapes can use efficient
   Blackwell tensor-core tiles.
 
 :func:`_scale_mm_cute` dispatches each pretuned shape to its specialized kernel.
@@ -31,7 +31,7 @@ import helion.language as hl
 # Only single-token decode uses the scalar skinny-M kernel. Wider small-M
 # shapes use the swapped tensor-core kernel below.
 _SKINNY_M_MAX = 1
-_SWAP_AB_SHAPES = {
+_SMALL_M_SWAP_SHAPES = {
     *(
         (m, k, n)
         for m in (2, 8, 16, 32)
@@ -42,6 +42,18 @@ _SWAP_AB_SHAPES = {
             (4096, 6144),
         )
     ),
+    *(
+        (m, k, n)
+        for m in (2, 8, 16, 32)
+        for k, n in (
+            (2048, 12288),
+            (5120, 5120),
+            (6144, 2048),
+        )
+    ),
+}
+_SWAP_AB_SHAPES = {
+    *_SMALL_M_SWAP_SHAPES,
     (64, 4096, 6144),
     (64, 4096, 24576),
     (64, 5120, 5120),
@@ -236,6 +248,8 @@ def use_cudagraph() -> bool:
 
 # Skinny-M (decode / small-batch) + small decoder-layer FP8 W8A8 serving shapes
 # that back the nightly B200 CuTe dashboard (benchmarks/run.py, PR #2788).
+# The M=2/8/16/32 additions include weight shapes from vLLM's H100 scaled_mm
+# config in vllm-project/vllm#46522.
 # The M=64 rows mirror the vLLM Qwen3 FP8 serving (K, N) weight shapes at a
 # small-batch token count.
 SHAPES = [  # (M, K, N)
@@ -256,6 +270,11 @@ SHAPES = [  # (M, K, N)
     (32, 4096, 256),
     (32, 2048, 4096),
     (32, 4096, 6144),
+    *sorted(
+        (m, k, n)
+        for m, k, n in _SMALL_M_SWAP_SHAPES
+        if (k, n) in {(2048, 12288), (5120, 5120), (6144, 2048)}
+    ),
     (4096, 4096, 4096),
     (1, 4096, 256),
     (512, 2048, 4096),

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -8,13 +8,15 @@ The kernel is ported from https://github.com/pytorch/helion/pull/2788/
 pretuned for the skinny-M (decode / small-batch) and small decoder-layer FP8
 W8A8 serving shapes that back the nightly B200 CuTe benchmark dashboard.
 
-Two kernels ship:
+Specialized kernels include:
 
 * :func:`scale_mm_cute` tiles over both M and N.
 * :func:`scale_mm_cute_skinny_m` keeps the full (small) M resident and tiles
-  only over N, which the CuTe backend runs faster for tiny M.
+  only over N for single-token decode.
+* :func:`scale_mm_cute_swap_ab` swaps M/N so M=2/8/16/32 can use efficient
+  Blackwell tensor-core tiles.
 
-:func:`_scale_mm_cute` dispatches to the skinny-M kernel when ``M <= 1``.
+:func:`_scale_mm_cute` dispatches each pretuned shape to its specialized kernel.
 """
 
 from __future__ import annotations
@@ -26,9 +28,20 @@ import torch
 import helion
 import helion.language as hl
 
-# M at or below this uses the skinny-M kernel (mirrors examples/fp8_gemm.py).
+# Only single-token decode uses the scalar skinny-M kernel. Wider small-M
+# shapes use the swapped tensor-core kernel below.
 _SKINNY_M_MAX = 1
 _SWAP_AB_SHAPES = {
+    *(
+        (m, k, n)
+        for m in (2, 8, 16, 32)
+        for k, n in (
+            (4096, 4096),
+            (4096, 256),
+            (2048, 4096),
+            (4096, 6144),
+        )
+    ),
     (64, 4096, 6144),
     (64, 4096, 24576),
     (64, 5120, 5120),
@@ -116,7 +129,7 @@ def scale_mm_cute_swap_ab(
     scale_a: torch.Tensor,
     scale_b: torch.Tensor,
 ) -> torch.Tensor:
-    """M64 FP8 GEMM using CUTLASS's swapped 4-CTA cluster topology."""
+    """Small-M FP8 GEMM with M/N swapped for efficient tensor-core tiles."""
     m, k = x.size()
     k2, n = y.size()
     assert k == k2, f"size mismatch {k} != {k2}"
@@ -132,8 +145,9 @@ def scale_mm_cute_swap_ab(
                 x[tile_m, tile_k].T,
                 acc=acc,
             )
-        scale = scale_b_t[tile_n, tile_m] * scale_a_t[tile_n, tile_m]
-        out_t[tile_n, tile_m] = (acc * scale).to(torch.bfloat16)
+        out_t[tile_n, tile_m] = (
+            acc * scale_a_t[tile_n, tile_m] * scale_b_t[tile_n, tile_m]
+        ).to(torch.bfloat16)
     return out
 
 
@@ -143,7 +157,7 @@ def _scale_mm_cute(
     scale_a: torch.Tensor,
     scale_b: torch.Tensor,
 ) -> torch.Tensor:
-    """Dispatch to the skinny-M kernel for small M, else the [M, N]-tiled one."""
+    """Dispatch each pretuned shape to its specialized CuTe kernel."""
     if x.size(0) <= _SKINNY_M_MAX:
         return scale_mm_cute_skinny_m(x, y, scale_a, scale_b)
     if x.size(0) == 512:
@@ -226,6 +240,22 @@ def use_cudagraph() -> bool:
 # small-batch token count.
 SHAPES = [  # (M, K, N)
     (1, 4096, 4096),
+    (2, 4096, 4096),
+    (2, 4096, 256),
+    (2, 2048, 4096),
+    (2, 4096, 6144),
+    (8, 4096, 4096),
+    (8, 4096, 256),
+    (8, 2048, 4096),
+    (8, 4096, 6144),
+    (16, 4096, 4096),
+    (16, 4096, 256),
+    (16, 2048, 4096),
+    (16, 4096, 6144),
+    (32, 4096, 4096),
+    (32, 4096, 256),
+    (32, 2048, 4096),
+    (32, 4096, 6144),
     (4096, 4096, 4096),
     (1, 4096, 256),
     (512, 2048, 4096),

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6222,7 +6222,9 @@ class TestCuteBackend(TestCase):
             tcgen05_c_stages=2,
             tcgen05_one_shot_role_scheduler=True,
         )
-        with self.assertRaisesRegex(BackendUnsupported, "static-full, unbatched"):
+        with self.assertRaisesRegex(
+            BackendUnsupported, "static-full or small-N-edge unbatched"
+        ):
             bound.to_triton_code(config)
 
     def test_matmul_mma_tcgen05_one_shot_rejects_leading_batch(self) -> None:

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -5088,10 +5088,10 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.gemm(", code)
         self.assertIn("'lhs_leading_passthrough': True", code)
         self.assertIn("'rhs_leading_passthrough': True", code)
-        self.assertIn("'d_leading_passthrough': True", code)
+        self.assertNotIn("'d_leading_passthrough': True", code)
         self.assertIn("cpasync.tma_partition", code)
-        self.assertIn("tcgen05_tma_store_atom", code)
-        self.assertNotIn("cute.copy(tcgen05_simt_atom", code)
+        self.assertNotIn("tcgen05_tma_store_atom", code)
+        self.assertIn("cute.copy(tcgen05_simt_atom", code)
 
     def test_batched_baddbmm_mma_tcgen05_two_cta(self) -> None:
         # A leading-batch matmul composes with the CtaGroup.TWO cluster

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -583,6 +583,33 @@ def cute_matmul_mma_fp8_rowwise_colwise_scale(
 
 
 @helion.kernel(backend="cute", static_shapes=True)
+def cute_matmul_mma_fp8_swapped_rowwise_colwise_scale(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_m: torch.Tensor,
+    scale_n: torch.Tensor,
+) -> torch.Tensor:
+    """Transpose the GEMM and output so a four-CTA cluster spans N."""
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    out_t = out.T
+    scale_m_t = scale_m.unsqueeze(0)
+    scale_n_t = scale_n.unsqueeze(-1).expand(n, m)
+    for tile_n, tile_m in hl.tile([n, m]):
+        acc = hl.zeros([tile_n, tile_m], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(
+                y[tile_k, tile_n].T,
+                x[tile_m, tile_k].T,
+                acc=acc,
+            )
+        scale = scale_n_t[tile_n, tile_m] * scale_m_t[tile_n, tile_m]
+        out_t[tile_n, tile_m] = (acc * scale).to(torch.bfloat16)
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
 def cute_matmul_mma_epilogue_f32_bias(
     x: torch.Tensor, y: torch.Tensor, bias: torch.Tensor
 ) -> torch.Tensor:
@@ -6052,6 +6079,11 @@ class TestCuteBackend(TestCase):
         self.assertIn("'epi_tile_raw_expr'", code)
         # The resolved CtaGroup decision is recorded for the host wrapper.
         self.assertIn("'use_2cta_instrs': True", code)
+        self.assertRegex(
+            code,
+            r"if cute\.arch\.make_warp_uniform\(cute\.arch\.block_idx_in_cluster\(\)\) "
+            r"== cutlass\.Int32\(0\):\n\s+for tile_\w+ in range",
+        )
 
     def test_matmul_mma_tcgen05_fp8_two_cta_m128_rowvec_scale(self) -> None:
         """Fused rowvec-scale epilogue on the bm=128 2-CTA family.
@@ -6080,6 +6112,169 @@ class TestCuteBackend(TestCase):
         self.assertFalse(out.float().isnan().any().item())
         self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
         self.assertIn("compute_epilogue_tile_shape((64, 128), True", code)
+
+    def test_matmul_mma_tcgen05_fp8_two_cta_m128_two_row_colvec_scale(
+        self,
+    ) -> None:
+        """The bm=128 two-CTA epilogue preserves both per-thread row scales."""
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        m, k, n = 256, 512, 256
+        x = (torch.randn(m, k, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(k, n, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        scale_m = (
+            (torch.arange(m, device=DEVICE, dtype=torch.float32) + 1.0)
+            .reshape(m, 1)
+            .expand(m, n)
+        )
+        scale_n = torch.linspace(0.5, 1.5, n, device=DEVICE)
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_rowwise_colwise_scale,
+            (x, y, scale_m, scale_n),
+            block_sizes=[128, 128, 128],
+            tcgen05_cluster_m=2,
+            pid_type="persistent_blocked",
+        )
+        ref = (x.float() @ y.float()) * scale_m * scale_n.reshape(1, -1)
+        torch.testing.assert_close(out.float(), ref, atol=2.0, rtol=5e-2)
+        self.assertFalse(out.float().isnan().any().item())
+        self.assertIn("if _colvec_i % 2 == 0", code)
+        self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
+
+    def test_matmul_mma_tcgen05_fp8_four_cta_one_shot_scheduler(self) -> None:
+        """The device-filling M512 grid assigns one tile to each cluster."""
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        m, k, n = 512, 2048, 4096
+        x = (torch.randn(m, k, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
+        y = (torch.randn(k, n, device=DEVICE) * 0.2).to(torch.float8_e4m3fn)
+        y = y.T.contiguous().T
+        scale_m = (torch.rand(m, 1, device=DEVICE) + 0.5).expand(m, n)
+        scale_n = torch.rand(n, device=DEVICE) + 0.5
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_rowwise_colwise_scale,
+            (x, y, scale_m, scale_n),
+            block_sizes=[256, 128, 128],
+            pid_type="persistent_blocked",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=2,
+            tcgen05_ab_stages=8,
+            tcgen05_acc_stages=1,
+            tcgen05_c_stages=2,
+            tcgen05_one_shot_role_scheduler=True,
+        )
+        ref = (x.float() @ y.float()) * scale_m * scale_n.reshape(1, -1)
+        torch.testing.assert_close(out.float(), ref, atol=2.0, rtol=5e-2)
+        self.assertIn("_helion_cute_cluster_shape = (2, 2, 1)", code)
+        self.assertIn("initial_work_tile_info()", code)
+        self.assertNotIn(".is_valid_tile", code)
+        self.assertNotIn("advance_to_next_work()", code)
+
+    def test_matmul_mma_tcgen05_one_shot_rejects_cluster_cap(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        m, k, n = 128, 128, 8192
+        x = torch.randn(m, k, device=DEVICE).to(torch.float8_e4m3fn)
+        y = torch.randn(k, n, device=DEVICE).to(torch.float8_e4m3fn)
+        scale_m = torch.ones(m, n, device=DEVICE)
+        scale_n = torch.ones(n, device=DEVICE)
+        bound = cute_matmul_mma_fp8_rowwise_colwise_scale.bind((x, y, scale_m, scale_n))
+        config = helion.Config(
+            block_sizes=[128, 128, 128],
+            pid_type="persistent_blocked",
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=1,
+            tcgen05_c_stages=2,
+            tcgen05_one_shot_role_scheduler=True,
+            tcgen05_role_scheduler_cluster_cap=64,
+        )
+        with self.assertRaisesRegex(BackendUnsupported, "without a role scheduler"):
+            bound.to_triton_code(config)
+
+    def test_matmul_mma_tcgen05_one_shot_rejects_partial_cluster_axis(
+        self,
+    ) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        m, k, n = 512, 128, 384
+        x = torch.randn(m, k, device=DEVICE).to(torch.float8_e4m3fn)
+        y = torch.randn(k, n, device=DEVICE).to(torch.float8_e4m3fn)
+        scale_m = torch.ones(m, n, device=DEVICE)
+        scale_n = torch.ones(n, device=DEVICE)
+        bound = cute_matmul_mma_fp8_rowwise_colwise_scale.bind((x, y, scale_m, scale_n))
+        config = helion.Config(
+            block_sizes=[256, 128, 128],
+            pid_type="persistent_blocked",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=1,
+            tcgen05_c_stages=2,
+            tcgen05_one_shot_role_scheduler=True,
+        )
+        with self.assertRaisesRegex(BackendUnsupported, "static-full, unbatched"):
+            bound.to_triton_code(config)
+
+    def test_matmul_mma_tcgen05_one_shot_rejects_leading_batch(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        x = torch.randn(2, 128, 128, device=DEVICE).to(torch.float8_e4m3fn)
+        y = torch.randn(2, 128, 128, device=DEVICE).to(torch.float8_e4m3fn)
+        bound = cute_batched_baddbmm_tcgen05.bind((x, y))
+        config = helion.Config(
+            block_sizes=[1, 128, 128, 128],
+            pid_type="persistent_blocked",
+            tcgen05_persistence_model="static_persistent",
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=1,
+            tcgen05_c_stages=2,
+            tcgen05_one_shot_role_scheduler=True,
+        )
+        with self.assertRaisesRegex(BackendUnsupported, "unbatched"):
+            bound.to_triton_code(config)
+
+    def test_matmul_mma_tcgen05_fp8_swapped_cluster_m4_scaled(self) -> None:
+        """Swapped operands and column-major output work with a four-CTA cluster."""
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        m, k, n = 64, 256, 512
+        x = (torch.randn(m, k, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(k, n, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = y.T.contiguous().T
+        scale_m = torch.linspace(0.5, 1.5, m, device=DEVICE)
+        scale_n = torch.linspace(1.5, 0.5, n, device=DEVICE)
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_swapped_rowwise_colwise_scale,
+            (x, y, scale_m, scale_n),
+            block_sizes=[128, 64, 256],
+            tcgen05_cluster_m=4,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_persistence_model="static_persistent",
+            pid_type="persistent_interleaved",
+        )
+        ref = (x.float() @ y.float()) * scale_m.reshape(-1, 1) * scale_n
+        torch.testing.assert_close(out.float(), ref, atol=2.0, rtol=5e-2)
+        self.assertFalse(out.float().isnan().any().item())
+        self.assertIn("_helion_cute_cluster_shape = (4, 1, 1)", code)
+        self.assertIn("cutlass.utils.layout.LayoutEnum.COL_MAJOR", code)
+        self.assertIn("'d_column_major': True", code)
 
     def test_matmul_mma_tcgen05_fp8_two_cta_m128_rowvec_prewait_hoist(self) -> None:
         """The bm=128 2-CTA family pre-hoists rowvec aux above the acc wait.

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -989,13 +989,14 @@ class TestCuteLowerings(unittest.TestCase):
         )
         # 4 epi + 1 exec + 1 ab_load = 6 warps, no power-of-2 round-up.
         self.assertIn("block=(64, 6, 1)", code)
-        self.assertIn("'kind': 'tcgen05_d_tma'", code)
-        self.assertIn("cutlass.pipeline.PipelineTmaStore.create", code)
+        self.assertNotIn("'kind': 'tcgen05_d_tma'", code)
+        self.assertNotIn("cutlass.pipeline.PipelineTmaStore.create", code)
         self.assertIn(
-            "tcgen05_gC = cute.local_tile(tcgen05_tma_store_tensor, (64, 8),",
+            "tcgen05_gC = cute.local_tile(out, (64, 8),",
             code,
         )
         self.assertIn("partition_C(tcgen05_gC)", code)
+        self.assertIn("cute.copy(tcgen05_simt_atom", code)
         self.assertNotIn("for _tcgen05_store_i in range(", code)
         self.assertNotIn("cute.arch.warp_reduction_sum", code)
 
@@ -2032,8 +2033,8 @@ class TestCuteLowerings(unittest.TestCase):
 
     def test_tcgen05_persistent_post_loop_stmts_appear_after_while(self) -> None:
         """Compiling a persistent_blocked kernel must emit the cleanup
-        block (producer_tail / TMEM allocator setup / free) AFTER the
-        ``while tcgen05_work_tile_valid`` loop.
+        block (producer_tail / TMEM allocator setup / free) AFTER all
+        persistent work-tile loops.
 
         Before the post-loop split landed, those statements stayed inside
         the persistent loop and were yielded back as scf.while carries,
@@ -2074,42 +2075,38 @@ class TestCuteLowerings(unittest.TestCase):
             )
             code = bound.to_triton_code(cfg)
 
-        # Locate the persistent while loop and verify post-loop
-        # statements live OUTSIDE its body. The cleanest check is to find
-        # the line of ``while tcgen05_work_tile_valid`` and the first
-        # following dedented statement (= post-loop boundary), then
-        # confirm producer_tail / free fall on the post-loop side.
-        lines = code.splitlines()
-        while_line_idx = next(
-            i for i, line in enumerate(lines) if "while tcgen05_work_tile_valid" in line
+        # Role-local codegen emits one work-tile loop per warp role. Verify
+        # one-shot cleanup follows the last of those loops, rather than being
+        # replayed in any role's per-tile body.
+        tree = ast.parse(code)
+        work_tile_loops = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.While)
+            and (
+                "tcgen05_role_local_" in ast.unparse(node.test)
+                or ast.unparse(node.test) == "tcgen05_work_tile_valid"
+            )
+        ]
+        self.assertTrue(
+            work_tile_loops, "expected at least one persistent work-tile loop"
         )
-        while_indent = len(lines[while_line_idx]) - len(
-            lines[while_line_idx].lstrip(" ")
+        last_work_tile_line = max(
+            node.end_lineno or node.lineno for node in work_tile_loops
         )
-        post_loop_line_idx = None
-        for i in range(while_line_idx + 1, len(lines)):
-            line = lines[i]
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#"):
-                continue
-            indent = len(line) - len(line.lstrip(" "))
-            if indent <= while_indent:
-                post_loop_line_idx = i
-                break
-        self.assertIsNotNone(
-            post_loop_line_idx, "post-loop statements should follow the while"
-        )
-        post_loop_block = "\n".join(lines[post_loop_line_idx:])
-        in_loop_block = "\n".join(lines[while_line_idx + 1 : post_loop_line_idx])
-        # Cleanup statements must be in the post-loop block, not the
-        # work-tile body.
         for tag in (
             "tcgen05_acc_pipeline.producer_tail",
             "tcgen05_tmem_allocator.free",
         ):
-            self.assertIn(tag, post_loop_block, f"{tag} must follow the while loop")
-            self.assertNotIn(
-                tag, in_loop_block, f"{tag} must not appear inside the while loop"
+            cleanup_calls = [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call) and tag in ast.unparse(node.func)
+            ]
+            self.assertTrue(cleanup_calls, f"expected cleanup call {tag}")
+            self.assertTrue(
+                all(node.lineno > last_work_tile_line for node in cleanup_calls),
+                f"{tag} must follow all work-tile loops",
             )
 
     def test_tcgen05_persistent_path_compiles(self) -> None:
@@ -2155,7 +2152,7 @@ class TestCuteLowerings(unittest.TestCase):
             # z-seeded and tile-advance scheduler paths lives in
             # ``test_tcgen05_persistent_multi_tile_runtime_correctness``.
             code = bound.to_triton_code(cfg)
-            self.assertIn("while tcgen05_work_tile_valid", code)
+            self.assertIn("while tcgen05_role_local_0_work_tile.is_valid_tile", code)
             self.assertIn("tcgen05_acc_pipeline.producer_tail", code)
             from helion._compiler.program_id import Tcgen05PersistentProgramIDs
 
@@ -4836,7 +4833,8 @@ class TestCuteLowerings(unittest.TestCase):
                 self.assertIn("tile_offset_0 = pid_0 * _BLOCK_SIZE_0", role_src)
                 self.assertIn("for tile_offset_2 in range", role_src)
                 self.assertIn(
-                    "if tcgen05_tma_full_tile and tcgen05_tma_next_full_tile",
+                    "if tcgen05_tma_initial_full_tile and "
+                    "tcgen05_tma_initial_next_full_tile",
                     role_src,
                 )
                 self.assertNotIn(
@@ -9831,12 +9829,18 @@ class TestCuteLowerings(unittest.TestCase):
                     self.assertIn("tcgen05_ab_consumer_state.advance()", role_src)
                     release_pos = role_src.index("tcgen05_ab_pipeline.consumer_release")
                     advance_pos = role_src.index("tcgen05_ab_consumer_state.advance()")
-                    next_ab_peek_blocks = [
+                    self.assertLess(release_pos, advance_pos)
+                    leader_blocks = [
                         ast.unparse(child)
                         for child in ast.walk(node)
                         if isinstance(child, ast.If)
-                        and "tcgen05_tma_next_consumer_tile" in ast.unparse(child.test)
                         and _TCGEN05_CLUSTER_LEADER_PREDICATE in ast.unparse(child.test)
+                    ]
+                    next_ab_peek_blocks = [
+                        block
+                        for block in leader_blocks
+                        if "tcgen05_tma_next_consumer_tile" in block
+                        and "tcgen05_ab_pipeline.consumer_try_wait" in block
                     ]
                     self.assertTrue(
                         next_ab_peek_blocks,
@@ -9850,15 +9854,8 @@ class TestCuteLowerings(unittest.TestCase):
                         "tcgen05_ab_pipeline.consumer_try_wait",
                         next_ab_peek_pos,
                     )
-                    self.assertLess(release_pos, advance_pos)
                     self.assertLess(advance_pos, next_ab_peek_pos)
                     self.assertLess(next_ab_peek_pos, next_ab_try_pos)
-                    leader_blocks = [
-                        ast.unparse(child)
-                        for child in ast.walk(node)
-                        if isinstance(child, ast.If)
-                        and _TCGEN05_CLUSTER_LEADER_PREDICATE in ast.unparse(child.test)
-                    ]
                     self.assertTrue(
                         any(
                             "tcgen05_acc_pipeline.producer_acquire("
@@ -13823,8 +13820,9 @@ class TestCuteLowerings(unittest.TestCase):
         self.assertIn(
             (
                 "compute_epilogue_tile_shape((128, 8), False, "
-                "tcgen05_c_layout_1, cutlass.Float16, "
-                "layout_c=tcgen05_c_layout_1, elem_ty_c=cutlass.Float16)"
+                "cutlass.utils.layout.LayoutEnum.ROW_MAJOR, cutlass.Float16, "
+                "layout_c=cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
+                "elem_ty_c=cutlass.Float16)"
             ),
             emitted,
         )
@@ -13943,8 +13941,9 @@ class TestCuteLowerings(unittest.TestCase):
         self.assertIn(
             (
                 "compute_epilogue_tile_shape((128, 8), False, "
-                "tcgen05_c_layout_1, cutlass.Float32, "
-                "layout_c=tcgen05_c_layout_1, elem_ty_c=cutlass.Float32)"
+                "cutlass.utils.layout.LayoutEnum.ROW_MAJOR, cutlass.Float32, "
+                "layout_c=cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
+                "elem_ty_c=cutlass.Float32)"
             ),
             emitted,
         )
@@ -18657,6 +18656,7 @@ class TestPersistentLoopSplitter(unittest.TestCase):
         class _StubDeviceFunction:
             def __init__(self) -> None:
                 self._counter = 0
+                self.config: dict[str, object] = {}
                 self.cute_state = CuteDeviceFunctionState()
 
             def new_var(self, name: str) -> str:

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -6684,6 +6684,105 @@ class TestCuteLowerings(unittest.TestCase):
             code,
         )
 
+    def test_tcgen05_fp8_narrow_simt_aux_load_precedes_acc_wait(self) -> None:
+        """A narrow SIMT epilogue overlaps scale loads with the MMA wait."""
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def scaled_fp8(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                out[tile_m, tile_n] = (
+                    acc * scale_a[tile_m, tile_n] * scale_b[tile_n]
+                ).to(torch.bfloat16)
+            return out
+
+        args = (
+            torch.empty([64, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([128, 16], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([64, 1], device=DEVICE).expand(64, 16),
+            torch.empty([16], device=DEVICE),
+        )
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[64, 16, 128],
+            pid_type="persistent_blocked",
+            tcgen05_cluster_m=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=1,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            indexing=["tensor_descriptor"] * 5,
+        )
+        with patch_cute_mma_support():
+            bound = scaled_fp8.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+
+        loop_pos = code.find("for _tcgen05_subtile in cutlass.range")
+        aux_load_pos = code.find("tcgen05_aux_loaded_0", loop_pos)
+        acc_wait_pos = code.find("tcgen05_acc_pipeline.consumer_wait", loop_pos)
+        t2r_copy_pos = code.find("cute.copy(tcgen05_tiled_copy_t2r,", loop_pos)
+        self.assertGreater(loop_pos, 0)
+        self.assertGreater(aux_load_pos, loop_pos)
+        self.assertGreater(acc_wait_pos, aux_load_pos)
+        self.assertGreater(t2r_copy_pos, acc_wait_pos)
+
+    def test_tcgen05_fp8_small_n_tma_runtime_correctness(self) -> None:
+        """TMA zero-fills an FP8 N edge smaller than the tcgen05 tile."""
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def small_n_fp8(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            out_t = out.T
+            for tile_n, tile_m in hl.tile([n, m]):
+                acc = hl.zeros([tile_n, tile_m], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(
+                        y[tile_k, tile_n].T,
+                        x[tile_m, tile_k].T,
+                        acc=acc,
+                    )
+                out_t[tile_n, tile_m] = acc.to(torch.bfloat16)
+            return out
+
+        x = torch.randn([2, 128], device=DEVICE).to(torch.float8_e4m3fn)
+        y = torch.randn([128, 64], device=DEVICE).to(torch.float8_e4m3fn)
+        y = y.T.contiguous().T
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[64, 16, 128],
+            pid_type="persistent_blocked",
+            tcgen05_cluster_m=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=1,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_one_shot_role_scheduler=True,
+            indexing=["tensor_descriptor"] * 3,
+        )
+        with patch_cute_mma_support():
+            bound = small_n_fp8.bind((x, y))
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            bound.set_config(cfg)
+            actual = bound(x, y)
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(actual, expected, atol=0.5, rtol=0.05)
+
     def test_tcgen05_fused_bias_broadcast_runtime_correctness(self) -> None:
         """``out[tile] = (acc + bias[tile_n]).to(x.dtype)`` after a
         tcgen05 matmul splices the rank-1 bias load inline at the

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -2824,7 +2824,7 @@ class TestCuteLowerings(unittest.TestCase):
             code = bound.to_triton_code(cfg)
 
         self.assertIn(
-            "tcgen05_epilogue_tile = (cute.make_layout(64), cute.make_layout(64))",
+            "tcgen05_epi_tile = (cute.make_layout(64), cute.make_layout(64))",
             code,
         )
         if get_cute_mma_support().tcgen05_f8:

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -2773,6 +2773,68 @@ class TestCuteLowerings(unittest.TestCase):
 
         torch.testing.assert_close(out, args[0] @ args[1], atol=2e-1, rtol=1e-2)
 
+    def test_tcgen05_fp8_m64_explicit_epilogue_tile_codegen(self) -> None:
+        """Scaled FP8 M64 kernels may drain up to 64 columns per subtile."""
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def scaled_fp8(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                scale = scale_a[tile_m, tile_n] * scale_b[tile_n]
+                out[tile_m, tile_n] = (acc * scale).to(torch.bfloat16)
+            return out
+
+        torch.manual_seed(0)
+        scale_a_base = torch.rand([64, 1], device=DEVICE) + 0.5
+        args = (
+            (0.1 * torch.randn([64, 128], device=DEVICE)).to(torch.float8_e4m3fn),
+            (0.1 * torch.randn([128, 64], device=DEVICE)).to(torch.float8_e4m3fn),
+            scale_a_base.expand(64, 64),
+            torch.rand([64], device=DEVICE) + 0.5,
+        )
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[64, 64, 128],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_layout_strategy="explicit_epi_tile",
+            tcgen05_layout_overrides_epi_tile_m=64,
+            tcgen05_layout_overrides_epi_tile_n=64,
+            tcgen05_layout_overrides_d_store_box_n=64,
+            indexing=["tensor_descriptor"] * 5,
+        )
+        with patch_cute_mma_support():
+            bound = scaled_fp8.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+
+        self.assertIn(
+            "tcgen05_epilogue_tile = (cute.make_layout(64), cute.make_layout(64))",
+            code,
+        )
+        if get_cute_mma_support().tcgen05_f8:
+            bound.set_config(cfg)
+            actual = bound(*args)
+            expected = ((args[0].float() @ args[1].float()) * args[2] * args[3]).to(
+                torch.bfloat16
+            )
+            torch.testing.assert_close(actual, expected, rtol=0.03, atol=0.03)
+
     def test_tcgen05_smem_swizzle_override_runtime_correctness(self) -> None:
         """Explicit ``smem_swizzle_*`` overrides produce numerically-
         correct output.
@@ -4755,10 +4817,8 @@ class TestCuteLowerings(unittest.TestCase):
         found_role_local_producer_loop = False
         found_role_local_exec_loop = False
         found_role_local_epi_loop = False
+        found_shared_loop = False
         shared_loop_has_tma_producer = False
-        shared_loop_preserves_barriers = False
-        shared_scheduler_retargeted_to_exec = False
-        shared_loop_excludes_tma = False
         for node in ast.walk(tree):
             if not (
                 isinstance(node, ast.If)
@@ -4856,6 +4916,7 @@ class TestCuteLowerings(unittest.TestCase):
                 and ast.unparse(node.test) == "tcgen05_work_tile_valid"
             ):
                 continue
+            found_shared_loop = True
             shared_src = ast.unparse(node)
             shared_loop_has_tma_producer = (
                 "producer_try_acquire(tcgen05_ab_producer_state)" in shared_src
@@ -4876,23 +4937,6 @@ class TestCuteLowerings(unittest.TestCase):
             )
             self.assertNotIn("cute.nvgpu.CopyUniversalOp()", shared_src)
             self.assertNotIn("PipelineTmaStore.create", shared_src)
-            shared_loop_preserves_barriers = "cute.arch.sync_threads()" in shared_src
-            shared_scheduler_retargeted_to_exec = (
-                "cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(4)"
-                in shared_src
-                and "tcgen05_tile_sched.advance_to_next_work()" in shared_src
-            )
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.If):
-                continue
-            test_src = ast.unparse(node.test)
-            if not (test_src.startswith("not ") and "cutlass.Int32(5)" in test_src):
-                continue
-            shared_loop_excludes_tma = any(
-                isinstance(child, ast.While)
-                and ast.unparse(child.test) == "tcgen05_work_tile_valid"
-                for child in node.body
-            )
         self.assertTrue(
             found_role_local_producer_loop,
             "Expected a role-local TMA producer while containing the "
@@ -4911,22 +4955,10 @@ class TestCuteLowerings(unittest.TestCase):
         self._assert_role_local_c_store_pipeline_lifetime(
             code, tree, epi_role_predicate
         )
-        self.assertTrue(
-            shared_loop_preserves_barriers,
-            "Shared persistent while must preserve CTA barriers so the "
-            "role-local warps can rejoin as barrier participants. Generated code:\n"
-            + code,
-        )
-        self.assertTrue(
-            shared_scheduler_retargeted_to_exec,
-            "Shared scheduler advance should be owned by the exec warp in "
-            "the role-local mainloop path. Generated code:\n" + code,
-        )
         self.assertFalse(
-            shared_loop_excludes_tma,
-            "The TMA warp must still enter the shared while after its "
-            "role-local producer loop so existing sync_threads barriers "
-            "remain valid. Generated code:\n" + code,
+            found_shared_loop,
+            "A dependency-only shared loop should be omitted after all work "
+            "moves into role-local schedulers. Generated code:\n" + code,
         )
         self.assertFalse(
             shared_loop_has_tma_producer,
@@ -6128,6 +6160,7 @@ class TestCuteLowerings(unittest.TestCase):
                         code = bound.to_triton_code(cfg)
                         self.assertNotIn("_helion_tcgen05_persistent_total_tiles", code)
                         self.assertRegex(code, r"\(\s*1\s*,\s*1\s*,\s*min\s*\(")
+                        self.assertNotIn("while tcgen05_work_tile_valid", code)
                         self.assertIn("cutlass.pipeline.PipelineTmaStore.create", code)
                         self.assertNotIn("cute.nvgpu.CopyUniversalOp()", code)
                         out = bound(*args)
@@ -6585,6 +6618,70 @@ class TestCuteLowerings(unittest.TestCase):
             aux_load_pos,
             "accumulator load must stay after the aux load so the fused "
             "epilogue has its aux operands",
+        )
+
+    def test_tcgen05_fp8_m128_aux_load_precedes_acc_wait(self) -> None:
+        """The small-grid two-CTA path overlaps scale loads with the acc wait."""
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def scaled_fp8(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                tile_scale = scale_a[tile_m, tile_n] * scale_b[tile_n]
+                out[tile_m, tile_n] = (acc * tile_scale).to(torch.bfloat16)
+            return out
+
+        args = (
+            torch.empty([512, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([128, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([512, 1], device=DEVICE).expand(512, 128),
+            torch.empty([128], device=DEVICE),
+        )
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[128, 128, 128],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            indexing=["tensor_descriptor"] * 5,
+        )
+        with patch_cute_mma_support():
+            bound = scaled_fp8.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+
+        loop_pos = code.find("for _tcgen05_subtile in cutlass.range")
+        self.assertGreaterEqual(loop_pos, 0)
+        acc_wait_pos = code.find("tcgen05_acc_pipeline.consumer_wait", loop_pos)
+        aux_load_pos = code.find("tcgen05_aux_loaded_0", loop_pos)
+        aux_product_pos = code.find("tcgen05_aux_product", loop_pos)
+        acc_load_pos = code.find("tcgen05_acc_loaded", loop_pos)
+        chain_step_pos = code.find("tcgen05_chain_step", loop_pos)
+        self.assertGreater(aux_load_pos, loop_pos)
+        self.assertGreater(aux_product_pos, aux_load_pos)
+        self.assertGreater(acc_wait_pos, aux_load_pos)
+        self.assertGreater(acc_load_pos, acc_wait_pos)
+        self.assertGreater(aux_product_pos, acc_load_pos)
+        self.assertGreater(chain_step_pos, acc_load_pos)
+        self.assertIn("tcgen05_aux_rmem_0_coord0", code)
+        self.assertIn("tcgen05_aux_rmem_0_scale1", code)
+        self.assertIn("tcgen05_tTR_cC_subtile[1][0]", code)
+        self.assertIn("if _colvec_i % 2 == 0", code)
+        self.assertNotIn(
+            "cute.autovec_copy(tcgen05_tTR_gAux_subtile_0, tcgen05_aux_rmem_0)",
+            code,
         )
 
     def test_tcgen05_fused_bias_broadcast_runtime_correctness(self) -> None:
@@ -8891,6 +8988,63 @@ class TestCuteLowerings(unittest.TestCase):
                     TCGEN05_LARGE_BN_PROOF_CONFIG_KEY: True,
                 }
             )
+
+    def test_tcgen05_c_stages_three_config_validation(self) -> None:
+        """C-stage 3 is explicit-only and restricted to measured tile shapes."""
+
+        config_spec = ConfigSpec(backend=CuteBackend())
+        config_spec.cute_tcgen05_search_enabled = True
+        for block_id in range(3):
+            config_spec.block_sizes.append(
+                BlockSizeSpec(
+                    block_id=block_id,
+                    size_hint=4096,
+                    max_size=4096,
+                )
+            )
+
+        validation_fragment = config_spec._cute_tcgen05_config.optional_fragments()[
+            "tcgen05_c_stages"
+        ]
+        search_fragment = config_spec._cute_tcgen05_config.optional_fragments(
+            for_search=True
+        )["tcgen05_c_stages"]
+        self.assertEqual(validation_fragment.choices, (2, 3, 4))
+        self.assertEqual(search_fragment.choices, (2, 4))
+
+        allowed_block_sizes = (
+            [64, 32, 256],
+            [64, 32, 512],
+            [64, 64, 128],
+            [128, 64, 256],
+            [128, 128, 128],
+            [256, 128, 128],
+        )
+        for block_sizes in allowed_block_sizes:
+            with self.subTest(block_sizes=block_sizes):
+                config: dict[str, object] = {
+                    "block_sizes": block_sizes,
+                    "tcgen05_c_stages": 3,
+                }
+                config_spec.normalize(config)
+                self.assertEqual(config["tcgen05_c_stages"], 3)
+
+        invalid_config: dict[str, object] = {
+            "block_sizes": [64, 64, 256],
+            "tcgen05_c_stages": 3,
+        }
+        with self.assertRaisesRegex(
+            exc.InvalidConfig,
+            "tcgen05_c_stages=3 is validated only for block_sizes",
+        ):
+            config_spec.normalize(invalid_config)
+
+        repaired_config: dict[str, object] = {
+            "block_sizes": [64, 64, 256],
+            "tcgen05_c_stages": 3,
+        }
+        config_spec.normalize(repaired_config, _fix_invalid=True)
+        self.assertEqual(repaired_config["tcgen05_c_stages"], 2)
 
     def test_tcgen05_ab_initial_producer_acquire_mode_config_validation(
         self,
@@ -19306,6 +19460,29 @@ class TestPersistentLoopSplitter(unittest.TestCase):
                 ):
                     splitter._assert_tcgen05_omit_shared_loop_safe(partition)
 
+    def test_omit_shared_loop_rejects_post_loop_dependency(self) -> None:
+        """A residual assignment cannot be dropped when cleanup reads it."""
+        from helion._compiler.program_id import Tcgen05PersistentProgramIDs
+
+        splitter, _ = self._make_helper()
+        partition = Tcgen05PersistentProgramIDs._PartitionedRoleBody(
+            role_blocks_inline=[],
+            role_blocks_extracted=[],
+            shared_body_extracted=[self._stmt("final_state = current_state")],
+        )
+
+        self.assertTrue(splitter._tcgen05_shared_loop_safe_to_omit(partition, []))
+        self.assertFalse(
+            splitter._tcgen05_shared_loop_safe_to_omit(
+                partition, [self._stmt("cleanup_state = final_state")]
+            )
+        )
+        self.assertFalse(
+            splitter._tcgen05_shared_loop_safe_to_omit(
+                partition, [self._stmt("final_state += 1")]
+            )
+        )
+
     def test_role_local_tile_body_can_skip_shared_body_build(self) -> None:
         """When the caller omits the residual shared loop, the role-local
         builder should not construct and discard that body. Dependency-only
@@ -19718,19 +19895,30 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
             _build_kloop_pipeline_release_if(args)
 
         two_cta_args = self._make_args(is_two_cta=True, static_full_tiles=True)
-        for builder in (
-            _build_kloop_pipeline_producer_if,
-            _build_kloop_pipeline_consumer_if,
-            _build_kloop_pipeline_release_if,
-        ):
-            with (
-                self.subTest(builder=builder.__name__),
-                self.assertRaisesRegex(AssertionError, "one-CTA"),
-            ):
-                if builder is _build_kloop_pipeline_producer_if:
-                    builder(two_cta_args)
-                else:
-                    builder(two_cta_args, include_scalar_fallback=False)
+        two_cta_producer = _build_kloop_pipeline_producer_if(two_cta_args)
+        self.assertEqual(
+            ast.unparse(two_cta_producer.test), "tma_warp and next_full_tile"
+        )
+
+        two_cta_consumer = _build_kloop_pipeline_consumer_if(
+            two_cta_args, include_scalar_fallback=False
+        )
+        self.assertEqual(
+            ast.unparse(two_cta_consumer.test),
+            f"exec_active and {_TCGEN05_CLUSTER_LEADER_PREDICATE}",
+        )
+
+        two_cta_release = _build_kloop_pipeline_release_if(
+            two_cta_args, include_scalar_fallback=False
+        )
+        self.assertEqual(ast.unparse(two_cta_release.test), "exec_active")
+        self.assertEqual(self._stmt_kinds(two_cta_release.body), ["If", "advance"])
+        release_gate = two_cta_release.body[0]
+        self.assertIsInstance(release_gate, ast.If)
+        self.assertEqual(
+            ast.unparse(release_gate.test), _TCGEN05_CLUSTER_LEADER_PREDICATE
+        )
+        self.assertEqual(self._stmt_kinds(release_gate.body), ["consumer_release"])
 
     def test_non_pipeline_builders_reject_static_full_fast_path(self) -> None:
         args = self._make_args(static_full_tiles=True)

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -1448,11 +1448,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         # is narrowed to num_epi_warps=4 so the autotuner does not
         # converge on a wrong-output config.
         self.assertEqual(spec._tcgen05_num_epi_warps_search_choices, (4,))
-        # The validated narrowing leaves cluster_m=2 still accepted as a
-        # legal value for an explicit user-supplied helion.Config
+        # The validated narrowing leaves cluster_m=2 and cluster_m=4 accepted
+        # as legal values for an explicit user-supplied helion.Config
         # (CUDA-launch-failure is loud and won't silently miscompute).
         validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
-        self.assertEqual(validation_fragments["tcgen05_cluster_m"].choices, (1, 2))
+        self.assertEqual(validation_fragments["tcgen05_cluster_m"].choices, (1, 2, 4))
         # num_epi_warps is the exception: validation is also tightened
         # to (4,) because non-4 values silently produce wrong output, so
         # an explicit user-supplied helion.Config must be rejected

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -1496,6 +1496,38 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(spec._tcgen05_num_epi_warps_search_choices, (4,))
 
     @onlyBackends(["cute"])
+    def test_cute_tcgen05_fp8_small_n_admits_persistent_search(self) -> None:
+        """FP8 N smaller than the MMA tile can use persistent TMA zero-fill."""
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def cute_matmul_mma(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            out_t = out.T
+            for tile_n, tile_m in hl.tile([n, m]):
+                acc = hl.zeros([tile_n, tile_m], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(
+                        y[tile_k, tile_n].T,
+                        x[tile_m, tile_k].T,
+                        acc=acc,
+                    )
+                out_t[tile_n, tile_m] = acc.to(torch.bfloat16)
+            return out
+
+        args = (
+            torch.empty([2, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([128, 256], device=DEVICE, dtype=torch.float8_e4m3fn),
+        )
+        with patch_cute_mma_support():
+            spec = cute_matmul_mma.bind(args).config_spec
+        self.assertTrue(spec.cute_tcgen05_search_enabled)
+        self.assertEqual([x.max_size for x in spec.block_sizes], [128, 8, 128])
+        self.assertIn("persistent_blocked", spec.allowed_pid_types)
+        self.assertIn("persistent_interleaved", spec.allowed_pid_types)
+
+    @onlyBackends(["cute"])
     def test_cute_tcgen05_double_edge_no_divisor_keeps_flat_search(self) -> None:
         """Double-edge flat tcgen05 search no longer needs divisor tiles."""
 


### PR DESCRIPTION
# [CuTe] Beat CUTLASS across the scaled FP8 matmul sweep

## Summary

Improve Blackwell CuTe scaled-FP8 matmul code generation and tune the production
kernels to outperform CUTLASS on all 17 benchmark shapes.

## Codegen optimizations

- Add swapped A/B tcgen05 lowering with column-major output support for skinny-M
  workloads.
- Support role-local persistent scheduling across two-CTA and four-CTA clusters.
- Add one-shot role scheduling for device-filling static FP8 grids.
- Remove scheduler validity checks and tile advancement when every cluster owns
  exactly one tile.
- Gate the static two-CTA K loop on the cluster leader and remove redundant
  ownership predicates from inner TMA/MMA builders.
- Add bounded persistent cluster scheduling for grids larger than physical
  residency.
- Improve FP8 epilogue handling for broadcast row and column scales.
- Reduce redundant auxiliary-coordinate work and overlap auxiliary loads with
  accumulator waits.
- Extend tcgen05 configuration validation for the required block/stage layouts.

## Scheduler safety

One-shot scheduling is admitted only when:

- The grid is static-full, persistent, and FP8.
- There is no leading/batch passthrough dimension.
- No role-scheduler cluster cap is configured.
- The CTA count fits the validated residency bound.
- The M and N scheduler dimensions are each divisible by their corresponding
  cluster dimensions.

These checks prevent skipped batches, omitted tiles, partial clusters, and
out-of-bounds TMA operations.

## Production tuning

- Add dedicated M512 and swapped skinny-M AOT configurations.
- Use four-CTA topology and one-shot scheduling for `(512, 2048, 4096)`.
- Tune AB/ACC/C pipeline depths, PID ordering, cluster dimensions, and L2
  swizzles per shape.
- Dispatch M512 and selected M64 shapes through their specialized kernels.

## Performance

Tested on NVIDIA GB200 with:

```bash
python pretuned_kernels/scale_mm_cute/scale_mm_cute.py
```

Two consecutive complete sweeps:

- Helion vs CUTLASS: 17/17 wins
- CUTLASS geomean speedup: 1.035x and 1.034x
- M512: 7.20 us Helion vs 7.32 us CUTLASS
- Helion vs torch: 17/17 wins

## Verification

- Production correctness checks passed for representative M512, small-grid,
  and wide-N configurations.
- Unsafe one-shot combinations are covered by regression tests.
- `ruff format --check`: passed
- `ruff check`: passed
- Python compile checks: passed
- `git diff --check`: passed
- Independent code review: LGTM

Pytest was unavailable in the current Conda environment (`No module named pytest`).
