### PR TITLE
[autotuner] don't crash heuristic hardware matching on unclassifiable devices

### DIFF
--- a/helion/_compiler/autotuner_heuristics/common.py
+++ b/helion/_compiler/autotuner_heuristics/common.py
@@ -73,7 +73,17 @@ def matches_hardware(
 ) -> bool:
     from ..._hardware import get_hardware_info
 
-    hardware = get_hardware_info(env.device)
+    # A device Helion cannot classify raises RuntimeError here (e.g. MTIA, which
+    # presents as cuda via torch.accelerator but whose build leaves both
+    # torch.version.cuda and torch.version.hip unset, so get_hardware_info falls
+    # through every branch). An unclassifiable device matches no target, so the
+    # honest answer is False -- and it must not escape, because should_promote()
+    # is called outside the try/except that guards is_eligible, where an escaping
+    # RuntimeError fails the whole compile.
+    try:
+        hardware = get_hardware_info(env.device)
+    except RuntimeError:
+        return False
     return (hardware.device_kind, hardware.compute_capability) in targets or (
         hardware.device_kind,
         None,

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -414,6 +414,26 @@ class TestAutotunerHeuristic(TestCase):
         with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
             self.assertFalse(_NotPromoting.should_promote(env))
 
+    def test_should_promote_declines_on_unclassifiable_device(self) -> None:
+        # On a device Helion cannot classify (e.g. MTIA), get_hardware_info raises
+        # RuntimeError. should_promote must degrade to "do not promote" rather than
+        # letting the exception escape and crash compilation.
+        env = MagicMock()
+        env.device = "mtia"
+
+        class _Sm90Only(AutotunerHeuristic):
+            promote_seed_to_default = True
+            PROMOTE_TARGETS = (("cuda", "sm90"),)
+
+        with patch(
+            "helion._hardware.get_hardware_info",
+            side_effect=RuntimeError(
+                "No supported GPU or TPU device found. "
+                "Helion requires CUDA, ROCm, XPU, or TPU."
+            ),
+        ):
+            self.assertFalse(_Sm90Only.should_promote(env))
+
     @onlyBackends(["triton"])
     @skipIfRefEager("Compiler pointwise facts are not collected in ref eager mode")
     def test_pointwise_seed_promotes_only_on_target_arch(self) -> None:


### PR DESCRIPTION

``matches_hardware`` called ``get_hardware_info(env.device)`` bare. On a device
Helion cannot classify that raises ``RuntimeError``, which failed the compile:

  RuntimeError: No supported GPU or TPU device found.
  Helion requires CUDA, ROCm, XPU, or TPU.

MTIA hits this. It presents as ``cuda:0`` via ``torch.accelerator``, so
``torch.cuda.is_available()`` is True, but its build leaves BOTH
``torch.version.cuda`` and ``torch.version.hip`` unset -- so
``get_hardware_info`` falls through the CUDA branch, the ROCm branch, and the
TPU probe, and raises.

The raise is not new (``matches_hardware`` dates to #2392), but until now every
caller was an ``is_eligible``, and ``compiler_seed_configs`` wraps ``is_eligible``
in ``try/except Exception`` -- so it was swallowed into a debug log. #3053 added
``should_promote()``, which ``compiler_seed_configs`` calls OUTSIDE that
try/except, so the RuntimeError started escaping:

  helion/runtime/kernel.py:423                          in bind
  helion/runtime/kernel.py:980                          in __init__
  helion/_compiler/autotuner_heuristics/__init__.py:113  in compiler_seed_configs
  helion/_compiler/autotuner_heuristics/registry.py:49   in should_promote
  helion/_compiler/autotuner_heuristics/common.py:76     in matches_hardware

Catch the RuntimeError in ``matches_hardware`` and return False. An
unclassifiable device matches no hardware target, so False is the honest answer
rather than a defensive swallow -- the query "is this device sm90/sm100?" has a
correct answer here, and it is "no".

Behavior on an unclassifiable device, verified end-to-end by simulating the
raise on a pointwise and a reduction kernel:

- Pointwise: restores the exact pre-#3053 result -- the seed fires as a search
  candidate, ``compiler_default_config`` stays None (no promotion off-target).
- Reduction: ``TritonNarrowReductionHeuristic`` inverts the check
  (``if matches_hardware(...): return False``, triton.py:1854), so it now
  proceeds past that gate instead of being skipped by the swallowed exception,
  and plants its conservative ``block_sizes=[1]`` seed. It sets no
  PROMOTE_TARGETS, so this is a SEARCH CANDIDATE only --
  ``compiler_default_config`` remains None and the compiler default is
  untouched. That heuristic is explicitly the fallback "for hardware WITHOUT a
  tuned track", so firing there is its intent.

No promoter other than the pointwise seed defines PROMOTE_TARGETS, so no
promoted default changes on any device.

Test: a should_promote unit test pinning the degrade-to-False contract. It fails
on main with the exact MTIA RuntimeError and passes with this change.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>