### PR TITLE
[dashboard] Show pretuned kernel failures

### DIFF
--- a/.github/dashboard/README.md
+++ b/.github/dashboard/README.md
@@ -4,7 +4,7 @@ Interactive dashboard for visualizing Helion benchmark results across GPU platfo
 
 Deployed at https://helionlang.com/dashboard/ alongside the main docs. The docs-deploy workflow runs `build_dashboard_data.py` after each docs push or Benchmark Dispatch completion, generating `dashboard-data.json` that `index.html` fetches at runtime.
 
-The **Pretuned** tab is fed by a separate pipeline: the nightly **Benchmark Pretuned Dispatch** workflow runs every kernel under `pretuned_kernels/` (via `pretuned_kernels/run.py`) against its checked-in heuristic and uploads aggregate `SUMMARY` metrics. `build_pretuned_dashboard_data.py` aggregates those into `pretuned-dashboard-data.json`, which `index.html` lazily fetches when the Pretuned tab is opened. It tracks geomean speedup vs PyTorch eager, win counts, and best speedup per kernel/platform over time.
+The **Pretuned** tab is fed by a separate pipeline: the nightly **Benchmark Pretuned Dispatch** workflow runs every kernel under `pretuned_kernels/` (via `pretuned_kernels/run.py`) against its checked-in heuristic and uploads aggregate `SUMMARY` metrics or an error for each kernel. `build_pretuned_dashboard_data.py` aggregates those into `pretuned-dashboard-data.json`, which `index.html` lazily fetches when the Pretuned tab is opened. It tracks the latest CI status plus geomean speedup vs PyTorch eager, win counts, and best speedup per kernel/platform over time.
 
 ## Local development
 

--- a/.github/dashboard/build_pretuned_dashboard_data.py
+++ b/.github/dashboard/build_pretuned_dashboard_data.py
@@ -4,9 +4,9 @@
 Companion to build_dashboard_data.py for the pretuned-kernel suite
 (pretuned_kernels/run.py output). Fetches runs of the "Benchmark Pretuned
 Dispatch" workflow, downloads each run's pretuned-results-* artifacts, and
-aggregates the per-kernel SUMMARY metrics (geomean speedup vs eager, win count,
-best speedup) into a single JSON the dashboard's Pretuned tab renders with no
-client-side computation. Supports incremental updates via --existing-url.
+aggregates the per-kernel results (including failures and SUMMARY metrics) into
+a single JSON the dashboard's Pretuned tab renders with no client-side
+computation. Supports incremental updates via --existing-url.
 
 Scheduled runs (GitHub event == "schedule") are treated as the nightly trend;
 manual workflow_dispatch runs stay in per-kernel history for context but never
@@ -154,43 +154,60 @@ def parse_run(run_dir, active_platforms=None):
         except (json.JSONDecodeError, OSError):
             continue
         for rec in records or []:
-            if "geomean" not in rec:
-                # Kernel crashed on this run; skip (build_history records gaps).
+            if "geomean" not in rec and "error" not in rec:
+                # Unsupported kernels are intentionally skipped on platforms
+                # without a checked-in heuristic.
                 continue
-            kernels.append(
-                {
-                    "kernel": rec["kernel"],
-                    "platform": rec.get("device", platform_short),
-                    "platform_short": platform_short,
-                    "compute": rec.get("compute_capability", ""),
-                    "cudagraph": bool(rec.get("cudagraph", False)),
-                    "geomean": rec["geomean"],
-                    "helion_wins": rec.get("helion_wins", 0),
-                    "total": rec.get("total", 0),
-                    "best_speedup": rec.get("best_speedup", 0.0),
-                    # Per-baseline breakdown for the dashboard dropdown (or None
-                    # for single-baseline kernels).
-                    "baselines": rec.get("baselines"),
-                }
-            )
+            kernel = {
+                "kernel": rec["kernel"],
+                "platform": rec.get("device", platform_short),
+                "platform_short": platform_short,
+                "compute": rec.get("compute_capability", ""),
+            }
+            if "cudagraph" in rec:
+                kernel["cudagraph"] = bool(rec["cudagraph"])
+            if "error" in rec:
+                kernel["error"] = rec["error"]
+            else:
+                kernel.update(
+                    {
+                        "geomean": rec["geomean"],
+                        "helion_wins": rec.get("helion_wins", 0),
+                        "total": rec.get("total", 0),
+                        "best_speedup": rec.get("best_speedup", 0.0),
+                        # Per-baseline breakdown for the dashboard dropdown (or
+                        # None for single-baseline kernels).
+                        "baselines": rec.get("baselines"),
+                    }
+                )
+            kernels.append(kernel)
     return kernels
 
 
 def build_history_entry(run, k):
-    return {
+    entry = {
         "run_id": run["run_id"],
         "sha": run["sha"],
         "full_sha": run["full_sha"],
         "date": run["date"],
         "branch": run.get("branch", "main"),
         "is_nightly": bool(run.get("is_nightly")),
-        "cudagraph": bool(k.get("cudagraph", False)),
-        "geomean": round(k["geomean"], 4),
-        "helion_wins": k["helion_wins"],
-        "total": k["total"],
-        "best_speedup": round(k["best_speedup"], 4),
-        "baselines": k.get("baselines"),
     }
+    if "cudagraph" in k:
+        entry["cudagraph"] = bool(k["cudagraph"])
+    if "error" in k:
+        entry["error"] = k["error"]
+    else:
+        entry.update(
+            {
+                "geomean": round(k["geomean"], 4),
+                "helion_wins": k["helion_wins"],
+                "total": k["total"],
+                "best_speedup": round(k["best_speedup"], 4),
+                "baselines": k.get("baselines"),
+            }
+        )
+    return entry
 
 
 def build_dashboard_data(cache_dir, runs_meta, existing_data=None, active_platforms=None):
@@ -240,15 +257,19 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None, active_platfo
         for k in run["kernels"]:
             key = f"{k['kernel']}|{k['platform_short']}"
             if key not in kernel_index:
+                previous = existing_summary.get(key, {})
                 kernel_index[key] = {
                     "kernel": k["kernel"],
                     "platform": k["platform"],
                     "platform_short": k["platform_short"],
                     "compute": k["compute"],
-                    "cudagraph": k.get("cudagraph", False),
+                    "cudagraph": k.get(
+                        "cudagraph", previous.get("cudagraph", False)
+                    ),
                     "history": [],
                 }
-            kernel_index[key]["cudagraph"] = k.get("cudagraph", False)
+            if "cudagraph" in k:
+                kernel_index[key]["cudagraph"] = k["cudagraph"]
             kernel_index[key]["history"].append(build_history_entry(run, k))
 
     # Backfill from cached history for runs whose artifacts have expired.
@@ -280,20 +301,21 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None, active_platfo
 
     summary = []
     for key, entry in sorted(kernel_index.items()):
-        latest = prev = None
-        for h in reversed(entry["history"]):
-            if not is_nightly_main(h):
-                continue
-            if latest is None:
-                latest = h
-            elif prev is None:
-                prev = h
-                break
+        nightly_history = [h for h in entry["history"] if is_nightly_main(h)]
+        latest = nightly_history[-1] if nightly_history else None
+        failed = bool(latest and "error" in latest)
+        prev = next(
+            (h for h in reversed(nightly_history[:-1]) if "geomean" in h), None
+        )
         geomean_delta = (
-            fmt_delta(latest["geomean"], prev["geomean"]) if latest and prev else None
+            fmt_delta(latest["geomean"], prev["geomean"])
+            if latest and not failed and prev
+            else None
         )
         status = (
-            "improved"
+            "failed"
+            if failed
+            else "improved"
             if geomean_delta and geomean_delta > 10
             else "regressed"
             if geomean_delta and geomean_delta < -10
@@ -307,13 +329,15 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None, active_platfo
                 "compute": entry["compute"],
                 "cudagraph": bool(entry.get("cudagraph", False)),
                 "has_nightly_data": latest is not None,
+                "failed": failed,
+                "error": latest.get("error") if failed else None,
                 "status": status,
                 "geomean_delta_pct": geomean_delta,
-                "geomean": latest["geomean"] if latest else 0,
-                "helion_wins": latest["helion_wins"] if latest else 0,
-                "total": latest["total"] if latest else 0,
-                "best_speedup": latest["best_speedup"] if latest else 0,
-                "baselines": latest.get("baselines") if latest else None,
+                "geomean": latest.get("geomean", 0) if latest else 0,
+                "helion_wins": latest.get("helion_wins", 0) if latest else 0,
+                "total": latest.get("total", 0) if latest else 0,
+                "best_speedup": latest.get("best_speedup", 0) if latest else 0,
+                "baselines": latest.get("baselines") if latest and not failed else None,
                 "last_seen_date": latest["date"] if latest else None,
                 "history": entry["history"],
             }
@@ -325,6 +349,8 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None, active_platfo
     unique_kernels = sorted({s["kernel"] for s in nightly_summary})
     improved = sum(1 for s in nightly_summary if s["status"] == "improved")
     regressed = sum(1 for s in nightly_summary if s["status"] == "regressed")
+    failed = sum(1 for s in nightly_summary if s["failed"])
+    successful_summary = [s for s in nightly_summary if not s["failed"]]
 
     overview_runs = [r for r in runs_meta_sorted if is_nightly_main(r)]
     latest_nightly_run = overview_runs[-1] if overview_runs else {}
@@ -343,9 +369,16 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None, active_platfo
             "num_platforms": len(platforms),
             "improved_count": improved,
             "regressed_count": regressed,
-            "unchanged_count": len(nightly_summary) - improved - regressed,
-            "geomean": round(geo_mean([s["geomean"] for s in nightly_summary]), 4),
-            "helion_wins": sum(1 for s in nightly_summary if s["geomean"] > 1.0),
+            "failed_count": failed,
+            "unchanged_count": sum(
+                1 for s in nightly_summary if s["status"] == "unchanged"
+            ),
+            "geomean": round(
+                geo_mean([s["geomean"] for s in successful_summary]), 4
+            ),
+            "helion_wins": sum(
+                1 for s in successful_summary if s["geomean"] > 1.0
+            ),
         },
         "summary": summary,
     }
@@ -399,8 +432,19 @@ def main():
     cache_dir = "./pretuned-benchmark-cache"
     os.makedirs(cache_dir, exist_ok=True)
     existing_ids = {r["run_id"] for r in existing.get("runs", [])}
+    latest_nightly_id = max(
+        (
+            r
+            for r in runs
+            if r.get("is_nightly") and r.get("branch", "main") == "main"
+        ),
+        key=lambda r: r["date"],
+        default={},
+    ).get("run_id")
     for r in runs:
-        if r["run_id"] in existing_ids:
+        # Refresh the latest nightly so newly added result fields (such as
+        # per-kernel errors) take effect without waiting for another run.
+        if r["run_id"] in existing_ids and r["run_id"] != latest_nightly_id:
             continue
         print(f"Downloading run {r['run_id']} ({r['sha']})...")
         download_artifacts(args.repo, r["run_id"], os.path.join(cache_dir, r["run_id"]))

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -1127,8 +1127,8 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
 // -------- Pretuned Kernels Tab --------
 // Lazily fetches pretuned-dashboard-data.json (built by
 // build_pretuned_dashboard_data.py from the Benchmark Pretuned Dispatch nightly).
-// Aggregate-only: each pretuned kernel reports geomean speedup vs PyTorch eager,
-// win count, and best speedup across its checked-in shape sweep.
+// Each pretuned kernel reports either a failure or aggregate speedup metrics
+// across its checked-in shape sweep.
 let PRETUNED_DATA = null;
 let PRETUNED_LOADED = false;
 let pretunedPlatform = 'all';
@@ -1155,19 +1155,33 @@ function renderPretuned() {
     s.has_nightly_data && (pretunedPlatform === 'all' || s.platform_short === pretunedPlatform)
   );
   entries.sort((a, b) => a.platform_short.localeCompare(b.platform_short) || a.kernel.localeCompare(b.kernel));
-  const gmVals = entries.map(e => e.geomean).filter(v => v > 0);
+  const successfulEntries = entries.filter(e => !e.failed);
+  const failedEntries = entries.filter(e => e.failed);
+  const gmVals = successfulEntries.map(e => e.geomean).filter(v => v > 0);
   const overallGM = geomean(gmVals, null);
-  const wins = entries.filter(e => e.geomean > 1.0).length;
-  const sub = `${entries.length} kernel/platform combos`;
+  const wins = successfulEntries.filter(e => e.geomean > 1.0).length;
+  const sub = `${successfulEntries.length} successful kernel/platform combos`;
+  const lr = D.latest_run || {};
+  const ciPass = failedEntries.length === 0;
   let html = '';
   html += '<h2 style="margin-bottom:4px">Pretuned Kernels vs PyTorch Eager</h2>';
   html += '<p style="font-size:13px;color:var(--text-dim);margin-bottom:16px">Nightly run of every kernel under <code>pretuned_kernels/</code> against its checked-in heuristic. Speedup is geomean over each kernel\'s shape sweep; higher = faster than eager.</p>';
   html += '<div class="filter-bar"><select id="pt-plat-filter"><option value="all">All Platforms</option>';
   shorts.forEach(p => { html += `<option value="${p}"${p === pretunedPlatform ? ' selected' : ''}>${platName(p)}</option>`; });
   html += '</select></div>';
+  html += '<div class="status-row">';
+  html += statusCard('Latest Commit',
+    lr.sha ? `<a href="${commitUrl(lr.full_sha)}" target="_blank">${escHtml(lr.sha)}</a>` : '--',
+    lr.date ? formatDate(lr.date) : 'No nightly run',
+    { extraHtml: lr.run_id ? `<div class="sub">Run <a href="${runUrl(lr.run_id)}" target="_blank">#${lr.run_id}</a></div>` : '' });
+  html += statusCard('CI Status',
+    ciPass ? 'PASS' : failedEntries.length + ' FAIL',
+    ciPass ? 'All kernels ran successfully' : 'Click for details',
+    { id: 'pt-ci-status-card', clickable: !ciPass, valueColor: ciPass ? 'var(--green)' : 'var(--red)' });
+  html += '</div>';
   html += '<div class="summary-row">';
   html += summaryCard('Geomean Speedup', formatSpeedup(overallGM), sub, { valueColor: 'var(--green)' });
-  html += summaryCard('Helion Wins', wins, `of ${entries.length} combos faster than eager`, { valueColor: 'var(--green)' });
+  html += summaryCard('Helion Wins', wins, `of ${successfulEntries.length} successful combos`, { valueColor: 'var(--green)' });
   html += summaryCard('Kernels', `${new Set(entries.map(e => e.kernel)).size}`, 'pretuned kernels covered');
   html += summaryCard('Platforms', `${new Set(entries.map(e => e.platform_short)).size}`, 'GPU architectures');
   html += '</div>';
@@ -1180,7 +1194,8 @@ function renderPretuned() {
   }
   html += '<div class="table-wrap"><table class="data-table"><thead><tr><th>Kernel</th><th>Bench</th><th>Platform</th><th>Commit</th><th>Geomean</th><th>Wins</th><th>Best</th><th>Δ vs prev</th></tr></thead><tbody>';
   entries.forEach(e => {
-    const latest = e.history && e.history.length > 0 ? e.history[e.history.length - 1] : null;
+    const latest = [...(e.history || [])].reverse().find(h =>
+      h.is_nightly && (h.branch || 'main') === 'main');
     const commitLink = latest ? `<a href="${commitUrl(latest.full_sha)}" target="_blank" style="font-family:monospace;font-size:12px">${escHtml(latest.sha)}</a>` : '--';
     const gmColor = e.geomean >= 1.0 ? 'var(--green)' : 'var(--red)';
     const hasBaselines = e.baselines && Object.keys(e.baselines).length > 0;
@@ -1192,10 +1207,9 @@ function renderPretuned() {
       <td>${cudagraphBadge(e.cudagraph)}</td>
       <td>${platBadge(e.platform_short)}</td>
       <td>${commitLink}</td>
-      <td style="color:${gmColor}">${formatSpeedup(e.geomean)}</td>
-      <td>${e.helion_wins}/${e.total}</td>
-      <td style="color:var(--green)">${formatSpeedup(e.best_speedup)}</td>
-      <td>${formatDelta(e.geomean_delta_pct, false)}</td>
+      ${e.failed
+        ? '<td style="color:var(--red);font-weight:700">FAILED</td><td>--</td><td>--</td><td>--</td>'
+        : `<td style="color:${gmColor}">${formatSpeedup(e.geomean)}</td><td>${e.helion_wins}/${e.total}</td><td style="color:var(--green)">${formatSpeedup(e.best_speedup)}</td><td>${formatDelta(e.geomean_delta_pct, false)}</td>`}
     </tr>`;
   });
   html += `</tbody><tfoot><tr>
@@ -1209,7 +1223,24 @@ function renderPretuned() {
     pretunedPlatform = ev.target.value;
     renderPretuned();
   });
+  if (!ciPass) {
+    document.getElementById('pt-ci-status-card').addEventListener('click', () => {
+      showPretunedFailures(failedEntries);
+    });
+  }
   if (runs.length >= 2) setTimeout(renderPretunedTrendChart, 50);
+}
+function showPretunedFailures(failures) {
+  let html = modalHeader(
+    `Pretuned CI Failures — ${failures.length} kernel/platform result(s)`,
+    'Kernels that failed in their latest nightly run');
+  html += '<ul class="fail-list">';
+  failures.forEach(f => {
+    html += `<li><span class="fail-kernel">${escHtml(f.kernel)}</span>${platBadge(f.platform_short)}`
+      + `<span class="fail-shapes">${escHtml(f.error || 'Unknown error')}</span></li>`;
+  });
+  html += '</ul>';
+  openModal(html);
 }
 function showPretunedBaselines(kernel, ps) {
   const e = (PRETUNED_DATA && PRETUNED_DATA.summary || []).find(

--- a/test/test_pretuned_dashboard.py
+++ b/test/test_pretuned_dashboard.py
@@ -1,0 +1,117 @@
+"""Tests for the pretuned benchmark dashboard data builder."""
+
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import json
+from pathlib import Path
+
+_BUILDER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "dashboard"
+    / "build_pretuned_dashboard_data.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "_pretuned_dashboard_builder", _BUILDER_PATH
+)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_BUILDER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_BUILDER)
+
+
+def _run(run_id: str, date: str) -> dict[str, object]:
+    return {
+        "run_id": run_id,
+        "sha": f"sha{run_id}",
+        "full_sha": f"full-sha-{run_id}",
+        "date": date,
+        "branch": "main",
+        "is_nightly": True,
+    }
+
+
+def _write_artifact(cache_dir: Path, run_id: str, records: list[dict]) -> None:
+    artifact_dir = cache_dir / run_id / "pretuned-results-h100"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "pretuned-bench.json").write_text(json.dumps(records))
+
+
+def test_latest_kernel_failure_replaces_previous_speedup(tmp_path: Path) -> None:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    first_run = _run("1", (now - datetime.timedelta(days=1)).isoformat())
+    second_run = _run("2", now.isoformat())
+    runs = [first_run, second_run]
+    common = {
+        "device": "NVIDIA H100",
+        "compute_capability": "sm90",
+        "cudagraph": False,
+    }
+    _write_artifact(
+        tmp_path / "first-build",
+        "1",
+        [
+            {
+                **common,
+                "kernel": "failed_kernel",
+                "geomean": 2.0,
+                "helion_wins": 4,
+                "total": 4,
+                "best_speedup": 2.5,
+            },
+            {
+                **common,
+                "kernel": "healthy_kernel",
+                "geomean": 1.5,
+                "helion_wins": 3,
+                "total": 4,
+                "best_speedup": 2.0,
+            },
+        ],
+    )
+    existing = _BUILDER.build_dashboard_data(tmp_path / "first-build", [first_run])
+
+    _write_artifact(
+        tmp_path / "incremental-build",
+        "2",
+        [
+            {
+                **common,
+                "kernel": "failed_kernel",
+                "error": "RuntimeError: compile failed",
+            },
+            {
+                **common,
+                "kernel": "healthy_kernel",
+                "geomean": 3.0,
+                "helion_wins": 4,
+                "total": 4,
+                "best_speedup": 3.5,
+            },
+            {
+                **common,
+                "kernel": "unsupported_kernel",
+                "skipped": "pretuned for ['b200']; current hardware is h100",
+            },
+        ],
+    )
+
+    data = _BUILDER.build_dashboard_data(
+        tmp_path / "incremental-build", runs, existing_data=existing
+    )
+    summary = {entry["kernel"]: entry for entry in data["summary"]}
+
+    failed = summary["failed_kernel"]
+    assert failed["failed"] is True
+    assert failed["status"] == "failed"
+    assert failed["error"] == "RuntimeError: compile failed"
+    assert failed["geomean"] == 0
+    assert failed["geomean_delta_pct"] is None
+    assert failed["history"][-1]["error"] == "RuntimeError: compile failed"
+
+    assert "unsupported_kernel" not in summary
+    assert data["stats"]["failed_count"] == 1
+    assert data["stats"]["unchanged_count"] == 0
+    assert data["stats"]["geomean"] == 3.0


### PR DESCRIPTION
Expose pretuned kernels nightly run failures in nightly benchmark

The two failures are fixed in https://github.com/pytorch/helion/pull/3205

Screenshots:

<img width="1443" height="786" alt="Screenshot 2026-07-30 at 11 34 59 AM" src="https://github.com/user-attachments/assets/0b73383f-44cf-4e9f-930f-b178c1a8b461" />
<img width="1213" height="509" alt="Screenshot 2026-07-30 at 11 35 08 AM" src="https://github.com/user-attachments/assets/475f8791-13c5-4366-ae73-c9aee37cd886" />
