### PR TITLE
Fix CuTe backend Ruff formatting

### DIFF
--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -2341,9 +2341,7 @@ class CuteBackend(Backend):
                 inactive_block_ids=inactive_block_ids,
             )
         nd_block_size = [bs.from_config_assert(config) for bs in block_size_infos]
-        block_size = functools.reduce(
-            operator.mul, nd_block_size
-        )  # pyrefly: ignore[incompatible-overload-residual]
+        block_size = functools.reduce(operator.mul, nd_block_size)  # pyrefly: ignore[incompatible-overload-residual]
         # Resolve per-axis thread counts then flatten to a single total
         all_auto = all(nt <= 0 for nt in num_threads_config)
         flat_num_threads = functools.reduce(


### PR DESCRIPTION
## Summary

- Apply Ruff 0.15.14 formatting to the CuTe backend block-size reduction.
- Fix the post-merge lint failure from https://github.com/pytorch/helion/actions/runs/30657448466/job/91245262318.

## Test plan

- Ruff 0.15.14 format check on helion/_compiler/cute/backend.py
- Ruff 0.15.14 check on helion/_compiler/cute/backend.py
- git diff --check