### PR TITLE
Move pallas_jax_export.py and _tpu_compile_capture.py from runtime/ into runtime/pallas

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -107,7 +107,8 @@ def _td_layout_guard_active_for_config(
 _R = TypeVar("_R")
 CompiledConfig = Callable[..., _R]
 
-# Opt-in: auto-capture Pallas kernels under torch.compile (see _tpu_compile_capture).
+# Opt-in: auto-capture Pallas kernels under torch.compile (see
+# pallas._tpu_compile_capture).
 # Off by default so the eager dispatch path is unchanged.
 _TPU_COMPILE_CAPTURE = os.environ.get("HELION_TPU_COMPILE_CAPTURE", "0") == "1"
 
@@ -323,7 +324,7 @@ class Kernel(Generic[_R]):
         # registration (unannotated, mutating, or autotuning among configs=[...]).
         self._capture_op: Callable[..., Any] | None = None
         if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
-            from ._tpu_compile_capture import register_decoration_op
+            from .pallas._tpu_compile_capture import register_decoration_op
 
             self._capture_op = register_decoration_op(self)
 
@@ -923,8 +924,8 @@ class Kernel(Generic[_R]):
         if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
             # Local import: _tpu_compile_capture pulls in the dynamo HOP machinery,
             # not ready when kernel.py first loads during ``import helion``.
-            from ._tpu_compile_capture import RUN_NORMAL
-            from ._tpu_compile_capture import auto_capture_call
+            from .pallas._tpu_compile_capture import RUN_NORMAL
+            from .pallas._tpu_compile_capture import auto_capture_call
 
             result = auto_capture_call(self, args)
             if result is not RUN_NORMAL:
@@ -963,7 +964,7 @@ class Kernel(Generic[_R]):
 
         This only supports kernels compiled for the Pallas backend.
         """
-        from .pallas_jax_export import make_jax_fn
+        from .pallas.jax_export import make_jax_fn
 
         cached = getattr(self, "_jax_fn_callable", None)
         if cached is not None:

--- a/helion/runtime/pallas/_tpu_compile_capture.py
+++ b/helion/runtime/pallas/_tpu_compile_capture.py
@@ -25,12 +25,12 @@ from typing import Callable
 
 import torch
 
-from .._compiler._dynamo.variables import _detect_mutated_inputs
-from .._compiler._dynamo.variables import infer_output_spec
-from ..language import constexpr
+from ..._compiler._dynamo.variables import _detect_mutated_inputs
+from ..._compiler._dynamo.variables import infer_output_spec
+from ...language import constexpr
 
 if TYPE_CHECKING:
-    from .kernel import Kernel
+    from ..kernel import Kernel
 
 _capture_lib = torch.library.Library("helion_capture", "FRAGMENT")
 _op_counter = 0

--- a/helion/runtime/pallas/jax_export.py
+++ b/helion/runtime/pallas/jax_export.py
@@ -40,8 +40,8 @@ import torch
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from .kernel import Kernel
-    from .pallas.launcher import _BlockSpecInfo
+    from ..kernel import Kernel
+    from .launcher import _BlockSpecInfo
 
 
 _TORCH_TO_JNP_DTYPE: dict[torch.dtype, object] | None = None
@@ -294,9 +294,9 @@ def default_pallas_jax_launcher(
     output(s) as ``_JaxExportTensor`` so the Helion wrapper's trailing
     reshape/view operations stay traceable.
     """
-    from .pallas.launcher import _pallas_apply_ds_padding
-    from .pallas.launcher import _pallas_jax_call
-    from .settings import is_pallas_interpret
+    from ..settings import is_pallas_interpret
+    from .launcher import _pallas_apply_ds_padding
+    from .launcher import _pallas_jax_call
 
     interpret = (
         _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -2,7 +2,7 @@
 
 Holds `default_pallas_launcher` (the torch-tensor / TorchTPU launcher that
 generated Pallas code invokes) plus the shared block-spec / compile / caching
-helpers it and the pure-JAX export path (`helion.runtime.pallas_jax_export`)
+helpers it and the pure-JAX export path (`helion.runtime.pallas.jax_export`)
 build on.
 
 Depends only on ``torch`` and ``jax`` -- no other ``helion`` module -- so the

--- a/test/test_compile_capture.py
+++ b/test/test_compile_capture.py
@@ -20,14 +20,14 @@ from helion._compiler._dynamo.variables import _detect_mutated_inputs
 from helion._testing import DEVICE
 from helion._testing import skipUnlessPallas
 import helion.language as hl
-from helion.runtime._tpu_compile_capture import _const_scalar
-from helion.runtime._tpu_compile_capture import _decoration_schema
-from helion.runtime._tpu_compile_capture import _freeze
-from helion.runtime._tpu_compile_capture import _is_functional
-from helion.runtime._tpu_compile_capture import _resolves_without_benchmark
-from helion.runtime._tpu_compile_capture import _signature
-from helion.runtime._tpu_compile_capture import _tensors
-from helion.runtime._tpu_compile_capture import register_decoration_op
+from helion.runtime.pallas._tpu_compile_capture import _const_scalar
+from helion.runtime.pallas._tpu_compile_capture import _decoration_schema
+from helion.runtime.pallas._tpu_compile_capture import _freeze
+from helion.runtime.pallas._tpu_compile_capture import _is_functional
+from helion.runtime.pallas._tpu_compile_capture import _resolves_without_benchmark
+from helion.runtime.pallas._tpu_compile_capture import _signature
+from helion.runtime.pallas._tpu_compile_capture import _tensors
+from helion.runtime.pallas._tpu_compile_capture import register_decoration_op
 
 
 @helion.kernel(


### PR DESCRIPTION
Stacked PRs:
 * #3228
 * #3227
 * __->__#3226


--- --- ---

### Move pallas_jax_export.py and _tpu_compile_capture.py from runtime/ into runtime/pallas


Both modules are Pallas-specific but sat at the top of `helion/runtime/`. Move
them next to the launcher they build on, matching the existing subpackage
convention (`pallas/launcher.py`):

    runtime/pallas_jax_export.py    -> runtime/pallas/jax_export.py
    runtime/_tpu_compile_capture.py -> runtime/pallas/_tpu_compile_capture.py

Pure git-renames plus the mechanical import fixups: the moved modules' relative
imports gain one level of depth (e.g. `..language` -> `...language`,
`.pallas.launcher` -> `.launcher`), and their importers (`kernel.py`,
`test/test_compile_capture.py`, and the launcher docstring) point at the new
paths. No behavior change.