### PR TITLE
[autotuner] Deduplicate CuTe flash effective sources

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -518,6 +518,24 @@ class Backend(abc.ABC):
         """
         return None
 
+    def generated_source_hash(self, compiled_fn: object) -> str | None:
+        """Return the exact generated-source hash attached to ``compiled_fn``.
+
+        Backends may return ``None`` when generated-source identity is not
+        available. The autotuner uses a non-``None`` value only for
+        backend-scoped effective-code deduplication.
+        """
+        return None
+
+    def should_deduplicate_generated_sources(self, config_spec: ConfigSpec) -> bool:
+        """Whether the autotuner may merge source-identical candidates.
+
+        This is disabled by default because source identity is not necessarily
+        sufficient to establish benchmark equivalence for every backend and
+        search domain.
+        """
+        return False
+
     def classify_autotune_exception(self, err: BaseException) -> str | None:
         """Classify an exception that occurred during autotuning.
 

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -1026,6 +1026,18 @@ class CuteBackend(Backend):
                 source.encode("utf-8")
             ).hexdigest()
 
+    def generated_source_hash(self, compiled_fn: object) -> str | None:
+        fn_globals = getattr(compiled_fn, "__globals__", None)
+        fn_name = getattr(compiled_fn, "__name__", None)
+        if not isinstance(fn_globals, dict) or not isinstance(fn_name, str):
+            return None
+        cute_kernel = fn_globals.get(f"_helion_{fn_name}")
+        source_hash = getattr(cute_kernel, "_helion_cute_source_hash", None)
+        return source_hash if isinstance(source_hash, str) else None
+
+    def should_deduplicate_generated_sources(self, config_spec: ConfigSpec) -> bool:
+        return config_spec.cute_flash_search_enabled
+
     def classify_autotune_exception(self, err: BaseException) -> str | None:
         # Exceptions raised from inside the cute/cutlass DSL during compile or
         # launch are expected when an invalid config is tried; treat them as

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -803,7 +803,13 @@ class PopulationMember:
     flat_values: FlatConfig
     config: Config
     status: Literal[
-        "ok", "error", "timeout", "peer_compilation_fail", "filtered", "unknown"
+        "ok",
+        "error",
+        "timeout",
+        "peer_compilation_fail",
+        "filtered",
+        "deduplicated",
+        "unknown",
     ] = "unknown"
     compile_time: float | None = None
 

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -343,7 +343,9 @@ class BenchmarkResult(NamedTuple):
     config: Config
     fn: Callable[..., object]
     perf: float
-    status: Literal["ok", "error", "timeout", "peer_compilation_fail", "filtered"]
+    status: Literal[
+        "ok", "error", "timeout", "peer_compilation_fail", "filtered", "deduplicated"
+    ]
     compile_time: float | None
 
 
@@ -485,6 +487,8 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._precompile_result_counter: count[int] = count()
         self._benchmark_worker: BenchmarkWorker | None = None
         self._last_benchmark_failure_status: Literal["error", "timeout"] | None = None
+        self._effective_source_hashes: set[str] = set()
+        self._effective_source_results: dict[str, BenchmarkResult] = {}
         # budget_exceeded_fn inherits the class-level _never_exceeded default
         # until BaseSearch._prepare installs the search's real hook.
 
@@ -750,6 +754,8 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._precompile_args_path = None
         self._precompile_baseline_path = None
         self._precompile_result_counter = count()
+        self._effective_source_hashes.clear()
+        self._effective_source_results.clear()
         # Drop the baseline tensors (GPU memory) so refcount frees them
         # the moment the provider loses its last external reference.
         self._baseline_output = None
@@ -766,6 +772,20 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             return False
         custom_bench = backend.get_do_bench()
         return backend.name == "cute" and custom_bench is do_bench_generic
+
+    def _effective_source_dedup_enabled(self) -> bool:
+        """Whether this provider may collapse source-identical candidates.
+
+        Rank-specialized distributed code can produce a different source
+        partition on each rank. Keeping every rank's benchmark loop identical
+        is more important than deduplicating those uncommon searches.
+        """
+        return (
+            self.config_spec.backend.should_deduplicate_generated_sources(
+                self.config_spec
+            )
+            and not dist.is_initialized()
+        )
 
     def _subprocess_benchmark_enabled(self) -> bool:
         """Subprocess benchmark path is opt-in and skipped for distributed /
@@ -906,6 +926,15 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         compiled: dict[int, Callable[..., object]] = {}
         futures: list[PrecompileFuture] | None = None
 
+        # Initialize results before source deduplication so source aliases and
+        # unhandled budget-tail entries can be filled positionally.
+        results: list[BenchmarkResult] = [
+            BenchmarkResult(
+                config=c, fn=_unset_fn, perf=inf, status="error", compile_time=None
+            )
+            for c in all_configs
+        ]
+
         # Compilation phase
         for i, config in enumerate(all_configs):
             if self._budget_exceeded_synced():
@@ -927,6 +956,52 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     f"{self.kernel.format_kernel_decorator(config, self.settings)}",
                     exc_info=True,
                 )
+
+        source_hashes: dict[int, str] = {}
+        aliases_by_representative: dict[int, list[int]] = {}
+        deduplicated_indices: set[int] = set()
+        unique_compiled: dict[int, Callable[..., object]] = {}
+        representative_by_hash: dict[str, int] = {}
+        deduplicate_sources = self._effective_source_dedup_enabled()
+        backend = self.config_spec.backend if deduplicate_sources else None
+        seen_sources = self._effective_source_hashes
+        cached_source_results = self._effective_source_results
+
+        for index, fn in compiled.items():
+            source_hash = (
+                backend.generated_source_hash(fn)
+                if deduplicate_sources and backend is not None
+                else None
+            )
+            if source_hash is None:
+                unique_compiled[index] = fn
+                continue
+            source_hashes[index] = source_hash
+            if source_hash not in seen_sources:
+                seen_sources.add(source_hash)
+                self._autotune_metrics.num_unique_sources += 1
+            cached_result = cached_source_results.get(source_hash)
+            if cached_result is not None:
+                results[index] = BenchmarkResult(
+                    config=all_configs[index],
+                    fn=cached_result.fn,
+                    perf=cached_result.perf,
+                    status="deduplicated",
+                    compile_time=None,
+                )
+                deduplicated_indices.add(index)
+                self._autotune_metrics.num_source_deduplications += 1
+                continue
+            representative = representative_by_hash.get(source_hash)
+            if representative is not None:
+                aliases_by_representative.setdefault(representative, []).append(index)
+                deduplicated_indices.add(index)
+                self._autotune_metrics.num_source_deduplications += 1
+                continue
+            representative_by_hash[source_hash] = index
+            unique_compiled[index] = fn
+
+        compiled = unique_compiled
         fns = list(compiled.values())
         valid_indices = list(compiled.keys())
         configs = [all_configs[i] for i in valid_indices]
@@ -955,14 +1030,6 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         else:
             is_workings = [True] * len(configs)
             precompile_status = ["ok"] * len(configs)
-
-        # Initialize results with defaults
-        results: list[BenchmarkResult] = [
-            BenchmarkResult(
-                config=c, fn=_unset_fn, perf=inf, status="error", compile_time=None
-            )
-            for c in all_configs
-        ]
 
         # Benchmark loop with progress reporting
         iterator = iter_with_progress(
@@ -1001,6 +1068,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                         compile_time=compile_time,
                         config_id=config_id,
                         config=config,
+                        source_hash=source_hashes.get(valid_indices[index]),
                     )
                 )
             if all(
@@ -1036,6 +1104,27 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     status=status,
                     compile_time=compile_time,
                 )
+            representative_index = valid_indices[index]
+            representative_result = results[representative_index]
+            source_hash = source_hashes.get(representative_index)
+            if (
+                source_hash is not None
+                and representative_result.status == "ok"
+                and math.isfinite(representative_result.perf)
+            ):
+                cached_source_results[source_hash] = representative_result
+            for alias_index in aliases_by_representative.get(representative_index, ()):
+                results[alias_index] = BenchmarkResult(
+                    config=all_configs[alias_index],
+                    fn=representative_result.fn,
+                    perf=representative_result.perf,
+                    status=(
+                        "deduplicated"
+                        if math.isfinite(representative_result.perf)
+                        else representative_result.status
+                    ),
+                    compile_time=None,
+                )
             if config_id is not None:
                 self.log.record_autotune_entry(
                     AutotuneLogEntry(
@@ -1045,6 +1134,32 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                         compile_time=compile_time,
                         config_id=config_id,
                         config=config,
+                        source_hash=source_hash,
+                    )
+                )
+
+        for index in deduplicated_indices:
+            result = results[index]
+            config = all_configs[index]
+            source_hash = source_hashes[index]
+            if result.status == "deduplicated":
+                self.log.debug(
+                    lambda config=config, source_hash=source_hash: (
+                        f"Reusing effective generated source {source_hash} "
+                        f"for {config!r}"
+                    )
+                )
+            config_id = self.log.register_config(config)
+            if config_id is not None:
+                self.log.record_autotune_entry(
+                    AutotuneLogEntry(
+                        generation=self._autotune_metrics.num_generations,
+                        status=result.status,
+                        perf_ms=result.perf if math.isfinite(result.perf) else None,
+                        compile_time=None,
+                        config_id=config_id,
+                        config=config,
+                        source_hash=source_hash,
                     )
                 )
         return results

--- a/helion/autotuner/llm_seeded_lfbo.py
+++ b/helion/autotuner/llm_seeded_lfbo.py
@@ -52,6 +52,8 @@ _AGGREGATED_METRIC_FIELDS = (
     "num_compile_failures",
     "num_worker_failures",
     "num_accuracy_failures",
+    "num_unique_sources",
+    "num_source_deduplications",
     "num_generations",
 )
 

--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -51,6 +51,25 @@ ExcInfoParam: TypeAlias = (
     | None
 )
 
+_AUTOTUNE_CSV_FIELDS = (
+    "run_id",
+    "timestamp_s",
+    "config_id",
+    "generation",
+    "status",
+    "perf_ms",
+    "compile_time_s",
+    "config",
+)
+_AUTOTUNE_SOURCE_CSV_FIELDS = (
+    "run_id",
+    "timestamp_s",
+    "config_id",
+    "generation",
+    "status",
+    "source_hash",
+)
+
 
 class _ElapsedFormatter(logging.Formatter):
     def __init__(self, elapsed_fn: Callable[[], int]) -> None:
@@ -281,11 +300,15 @@ class AutotuneLogEntry(NamedTuple):
     compile_time: float | None
     config_id: str
     config: Config
+    source_hash: str | None = None
 
 
 class AutotuneLogSink:
     """
     Writes autotune results to CSV and connects autotune logs to a file handler.
+
+    Entries carrying generated-source identity also populate a lazy
+    ``.sources.csv`` sidecar, leaving the established main CSV schema unchanged.
     """
 
     def __init__(
@@ -296,12 +319,15 @@ class AutotuneLogSink:
     ) -> None:
         self._base_path = Path(base_path)
         self.csv_path = self._base_path.with_suffix(".csv")
+        self.source_path = self._base_path.with_suffix(".sources.csv")
         self.log_path = self._base_path.with_suffix(".log")
         self.meta_path = self._base_path.with_suffix(".meta.jsonl")
         self._metadata = metadata
         self._collect_dataset = collect_dataset
         self._csv_file: io.TextIOWrapper | None = None
         self._csv_writer: CsvWriter | None = None
+        self._source_csv_file: io.TextIOWrapper | None = None
+        self._source_csv_writer: CsvWriter | None = None
         self._log_handler: logging.FileHandler | None = None
         self._run_start_time: float | None = None
         # config_id -> full config; flushed to the .meta.jsonl record at end_run.
@@ -331,18 +357,7 @@ class AutotuneLogSink:
         self._csv_file = self.csv_path.open("a", encoding="utf-8", newline="")
         self._csv_writer = csv.writer(self._csv_file)
         if write_header:
-            self._csv_writer.writerow(
-                [
-                    "run_id",
-                    "timestamp_s",
-                    "config_id",
-                    "generation",
-                    "status",
-                    "perf_ms",
-                    "compile_time_s",
-                    "config",
-                ]
-            )
+            self._csv_writer.writerow(_AUTOTUNE_CSV_FIELDS)
             self._csv_file.flush()
         handler = logging.FileHandler(self.log_path, mode="a", encoding="utf-8")
         handler.setLevel(logging.DEBUG)
@@ -354,6 +369,11 @@ class AutotuneLogSink:
             self._csv_file.close()
         self._csv_file = None
         self._csv_writer = None
+        if self._source_csv_file is not None:
+            self._source_csv_file.flush()
+            self._source_csv_file.close()
+        self._source_csv_file = None
+        self._source_csv_writer = None
         if self._log_handler is not None:
             self._log_handler.flush()
             self._log_handler.close()
@@ -420,6 +440,34 @@ class AutotuneLogSink:
         )
         if self._csv_file is not None:
             self._csv_file.flush()
+        if entry.source_hash is not None:
+            self._record_source_hash(entry, run_id, timestamp_field)
+
+    def _record_source_hash(
+        self, entry: AutotuneLogEntry, run_id: str, timestamp_field: str
+    ) -> None:
+        if self._source_csv_writer is None:
+            write_header = (
+                not self.source_path.exists() or self.source_path.stat().st_size == 0
+            )
+            self._source_csv_file = self.source_path.open(
+                "a", encoding="utf-8", newline=""
+            )
+            self._source_csv_writer = csv.writer(self._source_csv_file)
+            if write_header:
+                self._source_csv_writer.writerow(_AUTOTUNE_SOURCE_CSV_FIELDS)
+        self._source_csv_writer.writerow(
+            [
+                run_id,
+                timestamp_field,
+                entry.config_id,
+                entry.generation,
+                entry.status,
+                entry.source_hash,
+            ]
+        )
+        assert self._source_csv_file is not None
+        self._source_csv_file.flush()
 
 
 SUPPRESSED_TRITON_CODE_MSG = (

--- a/helion/autotuner/metrics.py
+++ b/helion/autotuner/metrics.py
@@ -35,6 +35,8 @@ class AutotuneMetrics:
     num_compile_failures: int = 0
     num_worker_failures: int = 0
     num_accuracy_failures: int = 0
+    num_unique_sources: int = 0
+    num_source_deduplications: int = 0
     num_generations: int = 0
     autotune_time: float = 0.0
     best_perf_ms: float = 0.0
@@ -60,6 +62,8 @@ class AutotuneMetrics:
             "num_compile_failures": self.num_compile_failures,
             "num_worker_failures": self.num_worker_failures,
             "num_accuracy_failures": self.num_accuracy_failures,
+            "num_unique_sources": self.num_unique_sources,
+            "num_source_deduplications": self.num_source_deduplications,
             "num_generations": self.num_generations,
             "autotune_time": self.autotune_time,
             "best_perf_ms": self.best_perf_ms,

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -236,7 +236,13 @@ class TestAutotuneIgnoreErrors(TestCase):
         search.args = args
         search.log = AutotuningLogger(settings)
         search.config_spec = SimpleNamespace(
-            default_config=lambda: helion.Config(block_sizes=[1])
+            default_config=lambda: helion.Config(block_sizes=[1]),
+            cute_flash_search_enabled=False,
+            backend=SimpleNamespace(
+                should_deduplicate_generated_sources=lambda config_spec: False,
+                get_do_bench=lambda: None,
+                classify_autotune_exception=lambda error: None,
+            ),
         )
         search._benchmark_provider_cls = LocalBenchmarkProvider
         search.best_perf_so_far = float("inf")
@@ -567,6 +573,7 @@ class TestAutotuneIgnoreErrors(TestCase):
                 compile_time=0.5,
                 config_id=config_id,
                 config=config,
+                source_hash="source-abc",
             )
             logger.record_autotune_entry(entry)
             logger("finalized entry", level=logging.CRITICAL)
@@ -603,6 +610,11 @@ class TestAutotuneIgnoreErrors(TestCase):
         self.assertEqual(cell("perf_ms"), "1.234000")
         self.assertEqual(cell("compile_time_s"), "0.50")
         self.assertEqual(cell("config"), str(config))
+        source_rows = list(
+            csv.reader(base_path.with_suffix(".sources.csv").read_text().splitlines())
+        )
+        self.assertEqual(source_rows[0][-2:], ["status", "source_hash"])
+        self.assertEqual(source_rows[1][-2:], ["ok", "source-abc"])
         log_text = log_path.read_text()
         self.assertIn("finalized entry", log_text)
 
@@ -6367,7 +6379,13 @@ class TestAutotuneBudget(TestCase):
         # Match the cute backend's path: CuteBackend.supports_precompile()
         # is False, which clears autotune_precompile in autotune setup.
         provider.settings.autotune_precompile = None
-        provider.config_spec = SimpleNamespace()
+        provider.config_spec = SimpleNamespace(
+            cute_flash_search_enabled=False,
+            compiler_seed_timeout_retry_repetitions=None,
+            backend=SimpleNamespace(
+                should_deduplicate_generated_sources=lambda config_spec: False
+            ),
+        )
         provider.args = ()
         provider.log = AutotuningLogger(provider.settings)
         provider._autotune_metrics = SimpleNamespace(
@@ -6375,6 +6393,8 @@ class TestAutotuneBudget(TestCase):
             num_compile_failures=0,
             num_worker_failures=0,
             num_accuracy_failures=0,
+            num_unique_sources=0,
+            num_source_deduplications=0,
             num_generations=0,
             kernel_source="",
         )
@@ -6382,7 +6402,184 @@ class TestAutotuneBudget(TestCase):
         provider._benchmark_worker = None
         provider._precompile_args_path = None
         provider._precompile_tmpdir = None
+        provider._effective_source_hashes = set()
+        provider._effective_source_results = {}
         return provider
+
+    def test_cute_flash_benchmark_deduplicates_effective_sources(self) -> None:
+        provider = self._make_stub_provider()
+
+        def generated_source_hash(fn):
+            return fn.source_hash
+
+        provider.config_spec = SimpleNamespace(
+            cute_flash_search_enabled=True,
+            compiler_seed_timeout_retry_repetitions=None,
+            backend=SimpleNamespace(
+                generated_source_hash=generated_source_hash,
+                should_deduplicate_generated_sources=lambda config_spec: True,
+            ),
+        )
+
+        def compile_config(config, allow_print):
+            def fn():
+                return None
+
+            block_size = config.get("block_sizes")[0]
+            fn.source_hash = "shared" if block_size in (1, 2, 4) else "unique"
+            return fn
+
+        provider.kernel.compile_config = compile_config
+        configs = [
+            helion.Config(block_sizes=[1]),
+            helion.Config(block_sizes=[2]),
+            helion.Config(block_sizes=[3]),
+        ]
+        repeated_config = helion.Config(block_sizes=[4])
+        with patch.object(
+            LocalBenchmarkProvider,
+            "_benchmark_function",
+            side_effect=(1.0, 2.0),
+        ) as benchmark:
+            results = provider.benchmark(configs)
+            repeated_results = provider.benchmark([repeated_config])
+
+        self.assertEqual(benchmark.call_count, 2)
+        self.assertEqual([result.perf for result in results], [1.0, 1.0, 2.0])
+        self.assertEqual(results[1].status, "deduplicated")
+        self.assertIs(results[0].fn, results[1].fn)
+        self.assertEqual(repeated_results[0].perf, 1.0)
+        self.assertEqual(repeated_results[0].status, "deduplicated")
+        self.assertIs(repeated_results[0].config, repeated_config)
+        self.assertIs(repeated_results[0].fn, results[0].fn)
+        self.assertIsNot(repeated_results[0], results[0])
+        self.assertEqual(provider._autotune_metrics.num_unique_sources, 2)
+        self.assertEqual(provider._autotune_metrics.num_source_deduplications, 2)
+
+    def test_backend_policy_can_disable_effective_source_dedup(self) -> None:
+        provider = self._make_stub_provider()
+        provider.config_spec = SimpleNamespace(
+            cute_flash_search_enabled=False,
+            compiler_seed_timeout_retry_repetitions=None,
+            backend=SimpleNamespace(
+                generated_source_hash=lambda fn: "shared",
+                should_deduplicate_generated_sources=lambda config_spec: False,
+            ),
+        )
+        configs = [
+            helion.Config(block_sizes=[1]),
+            helion.Config(block_sizes=[2]),
+        ]
+        with patch.object(
+            LocalBenchmarkProvider,
+            "_benchmark_function",
+            side_effect=(1.0, 2.0),
+        ) as benchmark:
+            results = provider.benchmark(configs)
+
+        self.assertEqual(benchmark.call_count, 2)
+        self.assertEqual([result.perf for result in results], [1.0, 2.0])
+        self.assertEqual(provider._autotune_metrics.num_unique_sources, 0)
+        self.assertEqual(provider._autotune_metrics.num_source_deduplications, 0)
+
+    def test_failed_effective_source_is_retried(self) -> None:
+        provider = self._make_stub_provider()
+        provider.config_spec = SimpleNamespace(
+            cute_flash_search_enabled=True,
+            compiler_seed_timeout_retry_repetitions=None,
+            backend=SimpleNamespace(
+                generated_source_hash=lambda fn: "shared",
+                should_deduplicate_generated_sources=lambda config_spec: True,
+            ),
+        )
+        configs = [helion.Config(block_sizes=[1])]
+        with patch.object(
+            LocalBenchmarkProvider,
+            "_benchmark_function",
+            side_effect=(math.inf, 1.0),
+        ) as benchmark:
+            first = provider.benchmark(configs)
+            second = provider.benchmark(configs)
+
+        self.assertEqual(benchmark.call_count, 2)
+        self.assertEqual(first[0].status, "error")
+        self.assertEqual(second[0].status, "ok")
+
+    def test_failed_effective_source_alias_is_logged(self) -> None:
+        provider = self._make_stub_provider()
+        provider.config_spec = SimpleNamespace(
+            compiler_seed_timeout_retry_repetitions=None,
+            backend=SimpleNamespace(
+                generated_source_hash=lambda fn: "shared",
+                should_deduplicate_generated_sources=lambda config_spec: True,
+            ),
+        )
+        representative = helion.Config(block_sizes=[1])
+        alias = helion.Config(block_sizes=[2])
+
+        with (
+            patch.object(
+                LocalBenchmarkProvider,
+                "_benchmark_function",
+                return_value=math.inf,
+            ),
+            patch.object(
+                provider.log,
+                "register_config",
+                side_effect=lambda config: (
+                    "representative" if config is representative else "alias"
+                ),
+            ),
+            patch.object(provider.log, "record_autotune_entry") as record_entry,
+        ):
+            results = provider.benchmark([representative, alias])
+
+        alias_entries = [
+            call.args[0]
+            for call in record_entry.call_args_list
+            if call.args[0].config is alias
+        ]
+        self.assertEqual([result.status for result in results], ["error", "error"])
+        self.assertEqual(len(alias_entries), 1)
+        self.assertEqual(alias_entries[0].status, "error")
+        self.assertIsNone(alias_entries[0].perf_ms)
+        self.assertEqual(alias_entries[0].source_hash, "shared")
+
+    def test_effective_source_dedup_is_disabled_for_distributed(self) -> None:
+        provider = self._make_stub_provider()
+        provider.config_spec = SimpleNamespace(
+            backend=SimpleNamespace(
+                should_deduplicate_generated_sources=lambda config_spec: True
+            )
+        )
+        with patch(
+            "helion.autotuner.benchmark_provider.dist.is_initialized",
+            return_value=True,
+        ):
+            self.assertFalse(provider._effective_source_dedup_enabled())
+
+    def test_cute_backend_reports_attached_generated_source_hash(self) -> None:
+        from helion._compiler.backend import CuteBackend
+
+        backend = CuteBackend()
+        compiled = SimpleNamespace(
+            __name__="kernel",
+            __globals__={
+                "_helion_kernel": SimpleNamespace(_helion_cute_source_hash="source-abc")
+            },
+        )
+        self.assertEqual(backend.generated_source_hash(compiled), "source-abc")
+        self.assertIsNone(backend.generated_source_hash(SimpleNamespace()))
+        self.assertTrue(
+            backend.should_deduplicate_generated_sources(
+                SimpleNamespace(cute_flash_search_enabled=True)
+            )
+        )
+        self.assertFalse(
+            backend.should_deduplicate_generated_sources(
+                SimpleNamespace(cute_flash_search_enabled=False)
+            )
+        )
 
     def test_benchmark_provider_short_circuits_compile_loop(self) -> None:
         """``LocalBenchmarkProvider.benchmark`` must stop compiling

--- a/test/test_kernel_metadata.py
+++ b/test/test_kernel_metadata.py
@@ -185,6 +185,7 @@ class TestAutotuneLogSink(TestCase):
             sidecar = json.loads(
                 sink.meta_path.read_text(encoding="utf-8").splitlines()[0]
             )
+            source_path_exists = sink.source_path.exists()
 
         header, data = rows[0], rows[1:]
         self.assertEqual(header, _LEAN_CSV_HEADER)
@@ -195,6 +196,7 @@ class TestAutotuneLogSink(TestCase):
 
         self.assertTrue(cell("config"))
         self.assertIn("32", cell("config"))
+        self.assertFalse(source_path_exists)
 
         self.assertEqual(set(sidecar), _SIDECAR_KEYS)
         self.assertIn("def _add_kernel", sidecar["kernel_source"])

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -1367,6 +1367,8 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
                     num_compile_failures=1,
                     num_worker_failures=2,
                     num_accuracy_failures=2,
+                    num_unique_sources=3,
+                    num_source_deduplications=4,
                     num_generations=3,
                 )
                 llm_instances.append(self)
@@ -1398,6 +1400,8 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
                     num_compile_failures=3,
                     num_worker_failures=4,
                     num_accuracy_failures=5,
+                    num_unique_sources=5,
+                    num_source_deduplications=6,
                     num_generations=6,
                 )
                 self.seed_configs = None
@@ -1450,6 +1454,8 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
         self.assertEqual(search._autotune_metrics.num_compile_failures, 4)
         self.assertEqual(search._autotune_metrics.num_worker_failures, 6)
         self.assertEqual(search._autotune_metrics.num_accuracy_failures, 7)
+        self.assertEqual(search._autotune_metrics.num_unique_sources, 8)
+        self.assertEqual(search._autotune_metrics.num_source_deduplications, 10)
         self.assertEqual(search._autotune_metrics.num_generations, 9)
         self.assertEqual(search.hybrid_stage_breakdown["llm_seed_configs_tested"], 7)
         self.assertEqual(


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3232
 * #3231
 * #3230
 * __->__#3229


--- --- ---

[autotuner] Deduplicate CuTe flash effective sources

Hash generated CuTe flash sources and benchmark one representative per effective kernel, including aliases discovered in later LFBO generations. Keep the behavior gated to local CuTe flash searches and preserve per-config results and logging.