### PR TITLE
[cutedsl] Normalize CuTe flash pipeline families

### DIFF
--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -891,6 +891,83 @@ _FLASH_NUM_REGS_PRODUCER = 96
 _FLASH_NUM_REGS_CONSUMER = 184
 
 
+class FlashPipelineFamilyFlags(NamedTuple):
+    topology: str
+    use_2cta_instrs: bool = False
+    use_cga2_local_cta: bool = False
+    use_clc_scheduler: bool = False
+    local_tma_partition: bool = False
+    tensor_4d_tma: bool = False
+
+
+FLASH_PIPELINE_FAMILY_FLAGS: dict[str, FlashPipelineFamilyFlags] = {
+    "ws_overlap": FlashPipelineFamilyFlags("ws_overlap"),
+    "fa4": FlashPipelineFamilyFlags("fa4"),
+    "fa4_tma_4d": FlashPipelineFamilyFlags("fa4", tensor_4d_tma=True),
+    "fa4_local_tma": FlashPipelineFamilyFlags("fa4", local_tma_partition=True),
+    "fa4_local_tma_4d": FlashPipelineFamilyFlags(
+        "fa4", local_tma_partition=True, tensor_4d_tma=True
+    ),
+    "fa4_cga2_local": FlashPipelineFamilyFlags("fa4", use_cga2_local_cta=True),
+    "fa4_cga2_local_tma_4d": FlashPipelineFamilyFlags(
+        "fa4", use_cga2_local_cta=True, tensor_4d_tma=True
+    ),
+    "fa4_2cta": FlashPipelineFamilyFlags("fa4", use_2cta_instrs=True),
+    "fa4_2cta_tma_4d": FlashPipelineFamilyFlags(
+        "fa4", use_2cta_instrs=True, tensor_4d_tma=True
+    ),
+    "fa4_clc": FlashPipelineFamilyFlags("fa4", use_clc_scheduler=True),
+    "fa4_clc_tma_4d": FlashPipelineFamilyFlags(
+        "fa4", use_clc_scheduler=True, tensor_4d_tma=True
+    ),
+    "fa4_clc_local_tma": FlashPipelineFamilyFlags(
+        "fa4", use_clc_scheduler=True, local_tma_partition=True
+    ),
+    "fa4_clc_local_tma_4d": FlashPipelineFamilyFlags(
+        "fa4",
+        use_clc_scheduler=True,
+        local_tma_partition=True,
+        tensor_4d_tma=True,
+    ),
+}
+FLASH_PIPELINE_FAMILIES = tuple(FLASH_PIPELINE_FAMILY_FLAGS)
+
+
+def _flash_pipeline_family_flags(
+    family: object,
+) -> FlashPipelineFamilyFlags | None:
+    return FLASH_PIPELINE_FAMILY_FLAGS.get(family) if isinstance(family, str) else None
+
+
+def _flash_pipeline_family_from_flags(
+    *,
+    topology: str,
+    use_2cta_instrs: bool,
+    use_cga2_local_cta: bool,
+    use_clc_scheduler: bool,
+    local_tma_partition: bool,
+    tensor_4d_tma: bool,
+) -> str:
+    if topology != "fa4":
+        return "ws_overlap"
+    if use_2cta_instrs:
+        base = "fa4_2cta"
+        local_tma_partition = False
+    elif use_cga2_local_cta:
+        base = "fa4_cga2_local"
+        local_tma_partition = False
+    elif use_clc_scheduler:
+        base = "fa4_clc"
+    else:
+        base = "fa4"
+    if local_tma_partition:
+        base += "_local_tma"
+    if tensor_4d_tma:
+        base += "_tma_4d" if not local_tma_partition else "_4d"
+    assert base in FLASH_PIPELINE_FAMILY_FLAGS
+    return base
+
+
 @dataclasses.dataclass(frozen=True)
 class FlashAttentionConfig:
     """Resolved topology config for the CuTe flash-attention codegen.
@@ -910,12 +987,12 @@ class FlashAttentionConfig:
 
     # Stage B/C topology fields (consumed by the fa4 emitter)
     topology: str = "ws_overlap"
+    pipeline_family: str = "ws_overlap"
     num_softmax_warpgroups: int = 1
     num_correction_warps: int = 0
     num_mma_warps: int = 0
     num_load_warps: int = 0
     num_epilogue_warps: int = 0
-    q_tile_count: int = 1
     acc_stage: int = 1
     epi_stage: int = 1
     # exp2 defaults to the FMA/XU pipe-split (split f8/r2): measured +2.9pp hd64
@@ -936,7 +1013,6 @@ class FlashAttentionConfig:
     e2e_offset0: int = 0
     tmem_plan: str = "separate"
     tmem_s_to_p_offset: int = 0
-    mma_interleave: bool = False
     # fa4 Stage 2b: issue the MMA-warp QK/PV via the FA4 ``gemm_ptx_partial`` (one
     # inline-asm region with literal-immediate descriptors) instead of cute.gemm.
     # Fits the MMA warp at 48 regs (cute.gemm spills ~116 STL/133 LDL) AND folds the
@@ -1325,12 +1401,27 @@ def resolve_flash_config(
     # length is a multiple of 256 (the fa4 body handles two 128-row Q tiles per
     # work item); otherwise fall back to ws_overlap.
     topology_default = "fa4" if num_kv % 2 == 0 else "ws_overlap"
-    topology = os.environ.get("HELION_CUTE_FLASH_TOPOLOGY", topology_default)
-    # Config override: the autotuner picks the topology. Stale/ineligible fa4
-    # values can appear for best-config cache transfer, but are clamped below.
-    topology_cfg = _cfg(FLASH_TOPOLOGY_KEY)
-    if topology_cfg is not None:
-        topology = str(topology_cfg)
+    legacy_structural_config = any(
+        _cfg(key) is not None for key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS
+    )
+    pipeline_family_cfg = _cfg(FLASH_PIPELINE_FAMILY_KEY)
+    pipeline_family_env = os.environ.get("HELION_CUTE_FLASH_PIPELINE_FAMILY")
+    requested_family_flags = (
+        _flash_pipeline_family_flags(pipeline_family_cfg)
+        if pipeline_family_cfg is not None
+        else None
+        if legacy_structural_config
+        else _flash_pipeline_family_flags(pipeline_family_env)
+    )
+    if requested_family_flags is not None:
+        topology = requested_family_flags.topology
+    else:
+        topology = os.environ.get("HELION_CUTE_FLASH_TOPOLOGY", topology_default)
+        # Legacy fixed configs and environment overrides remain accepted. The
+        # compound family above takes precedence when explicitly selected.
+        topology_cfg = _cfg(FLASH_TOPOLOGY_KEY)
+        if topology_cfg is not None:
+            topology = str(topology_cfg)
     if topology not in ("ws_overlap", "fa4"):
         topology = "ws_overlap"
     if topology == "fa4" and num_kv % 2 != 0:
@@ -1412,10 +1503,6 @@ def resolve_flash_config(
     num_mma_warps = int(os.environ.get("HELION_CUTE_FLASH_NUM_MMA_WARPS", "0"))
     num_load_warps = int(os.environ.get("HELION_CUTE_FLASH_NUM_LOAD_WARPS", "0"))
     num_epilogue_warps = int(os.environ.get("HELION_CUTE_FLASH_NUM_EPI_WARPS", "0"))
-    q_tile_count = int(os.environ.get("HELION_CUTE_FLASH_Q_TILE_COUNT", "1"))
-    q_tile_count_cfg = _cfg(FLASH_Q_TILE_COUNT_KEY)
-    if q_tile_count_cfg is not None:
-        q_tile_count = int(q_tile_count_cfg)  # type: ignore[arg-type]
     acc_stage = int(os.environ.get("HELION_CUTE_FLASH_ACC_STAGE", "1"))
     epi_stage = int(os.environ.get("HELION_CUTE_FLASH_EPI_STAGE", "1"))
     # Exp2 pipe-split schedule. The autotuner sees this as one paired schedule
@@ -1530,10 +1617,6 @@ def resolve_flash_config(
     tmem_s_to_p_offset = int(
         os.environ.get("HELION_CUTE_FLASH_TMEM_S_TO_P_OFFSET", "0")
     )
-    mma_interleave = _flash_bool_env("HELION_CUTE_FLASH_MMA_INTERLEAVE", False)
-    mma_interleave_cfg = _cfg(FLASH_MMA_INTERLEAVE_KEY)
-    if mma_interleave_cfg is not None:
-        mma_interleave = bool(mma_interleave_cfg)
     # fa4 Stage 2b: PTX-path MMA warp (default ON for fa4). HELION_CUTE_FLASH_MMA_PTX=0
     # reverts to the cute.gemm path (the Stage-1/2a body, for A/B comparison).
     mma_ptx = _flash_bool_env("HELION_CUTE_FLASH_MMA_PTX", True)
@@ -1862,10 +1945,13 @@ def resolve_flash_config(
         role_map = "helion"
     if topology != "fa4":
         role_map = "helion"
-    use_2cta_instrs = _flash_bool_env("HELION_CUTE_FLASH_USE_2CTA", False)
-    use_2cta_cfg = _cfg(FLASH_USE_2CTA_KEY)
-    if use_2cta_cfg is not None:
-        use_2cta_instrs = bool(use_2cta_cfg)
+    if requested_family_flags is not None:
+        use_2cta_instrs = requested_family_flags.use_2cta_instrs
+    else:
+        use_2cta_instrs = _flash_bool_env("HELION_CUTE_FLASH_USE_2CTA", False)
+        use_2cta_cfg = _cfg(FLASH_USE_2CTA_KEY)
+        if use_2cta_cfg is not None:
+            use_2cta_instrs = bool(use_2cta_cfg)
     dense_hd64_2cta = (
         head_dim == 64 and 256 <= num_kv <= 1024 and dtype is torch.float16
     )
@@ -1887,6 +1973,7 @@ def resolve_flash_config(
         # split publication are required to beat the established one-CTA seed.
         epi_tma = True
         epi_stg = False
+        epi_stg_store = "slice"
         epi_stg_gmem = "stage"
         p_store_repetition = 16
         split_p_arrive = True
@@ -1896,15 +1983,20 @@ def resolve_flash_config(
     use_cga2_local_default = (
         _flash_dense_hd64_seed_cga2_local(num_kv) if long_dense_hd64_fa4 else False
     )
-    use_cga2_local_cta = _flash_bool_env(
-        "HELION_CUTE_FLASH_CGA2_LOCAL", use_cga2_local_default
-    )
     use_cga2_local_cfg = _cfg(FLASH_CGA2_LOCAL_KEY)
-    use_cga2_local_overridden = (
-        "HELION_CUTE_FLASH_CGA2_LOCAL" in os.environ or use_cga2_local_cfg is not None
-    )
-    if use_cga2_local_cfg is not None:
-        use_cga2_local_cta = bool(use_cga2_local_cfg)
+    if requested_family_flags is not None:
+        use_cga2_local_cta = requested_family_flags.use_cga2_local_cta
+        use_cga2_local_overridden = True
+    else:
+        use_cga2_local_cta = _flash_bool_env(
+            "HELION_CUTE_FLASH_CGA2_LOCAL", use_cga2_local_default
+        )
+        use_cga2_local_overridden = (
+            "HELION_CUTE_FLASH_CGA2_LOCAL" in os.environ
+            or use_cga2_local_cfg is not None
+        )
+        if use_cga2_local_cfg is not None:
+            use_cga2_local_cta = bool(use_cga2_local_cfg)
     if (
         topology != "fa4"
         or is_causal
@@ -1916,12 +2008,15 @@ def resolve_flash_config(
     use_clc_scheduler_default = (
         _flash_dense_hd64_seed_clc(num_kv) if long_dense_hd64_fa4 else False
     )
-    use_clc_scheduler = _flash_bool_env(
-        "HELION_CUTE_FLASH_CLC", use_clc_scheduler_default
-    )
-    use_clc_scheduler_cfg = _cfg(FLASH_CLC_KEY)
-    if use_clc_scheduler_cfg is not None:
-        use_clc_scheduler = bool(use_clc_scheduler_cfg)
+    if requested_family_flags is not None:
+        use_clc_scheduler = requested_family_flags.use_clc_scheduler
+    else:
+        use_clc_scheduler = _flash_bool_env(
+            "HELION_CUTE_FLASH_CLC", use_clc_scheduler_default
+        )
+        use_clc_scheduler_cfg = _cfg(FLASH_CLC_KEY)
+        if use_clc_scheduler_cfg is not None:
+            use_clc_scheduler = bool(use_clc_scheduler_cfg)
     if use_clc_scheduler and use_cga2_local_cta and not use_cga2_local_overridden:
         use_cga2_local_cta = False
     if (
@@ -1979,25 +2074,41 @@ def resolve_flash_config(
         if long_dense_hd64_fa4
         else False
     )
-    local_tma_partition = _flash_bool_env(
-        "HELION_CUTE_FLASH_LOCAL_TMA", local_tma_partition_default
+    if requested_family_flags is not None:
+        local_tma_partition = requested_family_flags.local_tma_partition
+    else:
+        local_tma_partition = _flash_bool_env(
+            "HELION_CUTE_FLASH_LOCAL_TMA", local_tma_partition_default
+        )
+        local_tma_partition_cfg = _cfg(FLASH_LOCAL_TMA_PARTITION_KEY)
+        if local_tma_partition_cfg is not None:
+            local_tma_partition = bool(local_tma_partition_cfg)
+    local_tma_partition = (
+        local_tma_partition
+        and topology == "fa4"
+        and persistent
+        and not use_2cta_instrs
+        and not use_cga2_local_cta
     )
-    local_tma_partition_cfg = _cfg(FLASH_LOCAL_TMA_PARTITION_KEY)
-    if local_tma_partition_cfg is not None:
-        local_tma_partition = bool(local_tma_partition_cfg)
-    local_tma_partition = local_tma_partition and topology == "fa4"
-    if use_cga2_local_cta:
-        local_tma_partition = False
     tensor_4d_tma_default = (
         _flash_dense_hd64_seed_tensor_4d_tma(num_kv) if long_dense_hd64_fa4 else False
     )
-    tensor_4d_tma = _flash_bool_env(
-        "HELION_CUTE_FLASH_TENSOR_4D", tensor_4d_tma_default
+    if requested_family_flags is not None:
+        tensor_4d_tma = requested_family_flags.tensor_4d_tma
+    else:
+        tensor_4d_tma = _flash_bool_env(
+            "HELION_CUTE_FLASH_TENSOR_4D", tensor_4d_tma_default
+        )
+        tensor_4d_tma_cfg = _cfg(FLASH_TENSOR_4D_TMA_KEY)
+        if tensor_4d_tma_cfg is not None:
+            tensor_4d_tma = bool(tensor_4d_tma_cfg)
+    tensor_4d_tma = (
+        tensor_4d_tma
+        and topology == "fa4"
+        and not is_causal
+        and head_dim == 64
+        and dtype is torch.float16
     )
-    tensor_4d_tma_cfg = _cfg(FLASH_TENSOR_4D_TMA_KEY)
-    if tensor_4d_tma_cfg is not None:
-        tensor_4d_tma = bool(tensor_4d_tma_cfg)
-    tensor_4d_tma = tensor_4d_tma and topology == "fa4"
     causal_loop_split_default = (
         causal_hd64_seeded_fa4 and causal_kv_order == "descending"
     )
@@ -2009,6 +2120,28 @@ def resolve_flash_config(
         causal_loop_split = bool(causal_loop_split_cfg)
     if not is_causal or topology != "fa4" or causal_kv_order != "descending":
         causal_loop_split = False
+    if topology == "fa4":
+        # FA4 has a fixed two-query score pipeline. The generic WS s-stage and
+        # row-reduction choices do not participate in its emitted source.
+        s_stage = 2
+        packed_reduce = True
+        if not softmax_disc:
+            disc_pipe_depth = 1
+    else:
+        # Canonicalize FA4-only children so WS candidates that emit the same
+        # source also have the same normalized config identity.
+        disc_pipe_depth = 1
+        e2e_offset = 0
+        e2e_offset0 = 0
+        causal_lpt_swizzle = 0
+    pipeline_family = _flash_pipeline_family_from_flags(
+        topology=topology,
+        use_2cta_instrs=use_2cta_instrs,
+        use_cga2_local_cta=use_cga2_local_cta,
+        use_clc_scheduler=use_clc_scheduler,
+        local_tma_partition=local_tma_partition,
+        tensor_4d_tma=tensor_4d_tma,
+    )
     return FlashAttentionConfig(
         s_stage=s_stage,
         kv_stage=kv_stage,
@@ -2018,12 +2151,12 @@ def resolve_flash_config(
         num_regs_producer=_FLASH_NUM_REGS_PRODUCER,
         num_regs_consumer=_FLASH_NUM_REGS_CONSUMER,
         topology=topology,
+        pipeline_family=pipeline_family,
         num_softmax_warpgroups=num_softmax_warpgroups,
         num_correction_warps=num_correction_warps,
         num_mma_warps=num_mma_warps,
         num_load_warps=num_load_warps,
         num_epilogue_warps=num_epilogue_warps,
-        q_tile_count=q_tile_count,
         acc_stage=acc_stage,
         epi_stage=epi_stage,
         exp2_impl=exp2_impl,
@@ -2037,7 +2170,6 @@ def resolve_flash_config(
         e2e_offset0=e2e_offset0,
         tmem_plan=tmem_plan,
         tmem_s_to_p_offset=tmem_s_to_p_offset,
-        mma_interleave=mma_interleave,
         mma_ptx=mma_ptx,
         softmax_disc=softmax_disc,
         disc_pipe_depth=disc_pipe_depth,
@@ -2079,11 +2211,10 @@ def resolve_flash_config(
 # Autotune surface for the flash-attention config (Tasks #25 + #28).
 #
 # Mirrors the ``Tcgen05WarpSpec`` pattern in ``strategies.py`` /
-# ``tcgen05_config.py``: each autotunable field gets its own config key so the
-# autotuner can permute them independently, a ``FLASH_CONFIG_KEYS`` tuple
-# aggregates them, and ``flash_config_from_config`` reconstructs the dataclass
-# from a config Mapping (falling back to env/shape resolution for every key the
-# config does not carry).
+# ``tcgen05_config.py``. Independent arithmetic fields retain individual keys;
+# structural scheduling is represented by one compound pipeline-family key.
+# ``FLASH_CONFIG_KEYS`` aggregates the active and legacy inputs, and
+# ``flash_config_from_config`` reconstructs the effective dataclass.
 #
 # Gating: these keys are ONLY inserted into the search surface when
 # ``ConfigSpec.cute_flash_search_enabled`` is True (set when the flash detector
@@ -2106,6 +2237,8 @@ FLASH_E2E_FREQ_KEY = "cute_flash_e2e_freq"
 FLASH_E2E_RES_KEY = "cute_flash_e2e_res"
 FLASH_MMA_INTERLEAVE_KEY = "cute_flash_mma_interleave"
 FLASH_Q_TILE_COUNT_KEY = "cute_flash_q_tile_count"
+# Compound schedule family. Legacy topology/cluster/TMA keys normalize into it.
+FLASH_PIPELINE_FAMILY_KEY = "cute_flash_pipeline_family"
 # fa4 win (commit 38ff4d1a): the topology selector + the two fa4 perf levers.
 FLASH_TOPOLOGY_KEY = "cute_flash_topology"
 FLASH_SOFTMAX_DISC_KEY = "cute_flash_softmax_disc"
@@ -2152,7 +2285,7 @@ FLASH_AUTOTUNE_CONFIG_KEYS: tuple[str, ...] = (
     FLASH_MASKED_E2E_SCHEDULE_KEY,
     FLASH_E2E_OFFSET_KEY,
     FLASH_E2E_OFFSET0_KEY,
-    FLASH_TOPOLOGY_KEY,
+    FLASH_PIPELINE_FAMILY_KEY,
     FLASH_SOFTMAX_DISC_KEY,
     FLASH_DISC_PIPE_KEY,
     FLASH_SPLIT_P_ARRIVE_KEY,
@@ -2177,15 +2310,19 @@ FLASH_AUTOTUNE_CONFIG_KEYS: tuple[str, ...] = (
     FLASH_CAUSAL_LPT_SWIZZLE_KEY,
     FLASH_CAUSAL_KV_ORDER_KEY,
     FLASH_ROLE_MAP_KEY,
-    FLASH_USE_2CTA_KEY,
-    FLASH_CGA2_LOCAL_KEY,
-    FLASH_CLC_KEY,
     FLASH_CLC_HEADS_PER_BATCH_KEY,
     FLASH_CLC_PDL_KEY,
     FLASH_CLC_STAGES_KEY,
+    FLASH_CAUSAL_LOOP_SPLIT_KEY,
+)
+
+FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS: tuple[str, ...] = (
+    FLASH_TOPOLOGY_KEY,
+    FLASH_USE_2CTA_KEY,
+    FLASH_CGA2_LOCAL_KEY,
+    FLASH_CLC_KEY,
     FLASH_LOCAL_TMA_PARTITION_KEY,
     FLASH_TENSOR_4D_TMA_KEY,
-    FLASH_CAUSAL_LOOP_SPLIT_KEY,
 )
 
 FLASH_LEGACY_CONFIG_KEYS: tuple[str, ...] = (
@@ -2194,11 +2331,58 @@ FLASH_LEGACY_CONFIG_KEYS: tuple[str, ...] = (
     FLASH_E2E_RES_KEY,
     FLASH_MMA_INTERLEAVE_KEY,
     FLASH_Q_TILE_COUNT_KEY,
+    *FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS,
 )
 
 FLASH_CONFIG_KEYS: tuple[str, ...] = (
     FLASH_AUTOTUNE_CONFIG_KEYS + FLASH_LEGACY_CONFIG_KEYS
 )
+
+
+def flash_effective_config_values(
+    config: FlashAttentionConfig,
+) -> dict[str, object]:
+    """Project a resolved flash config onto the active autotune schema."""
+    return {
+        FLASH_S_STAGE_KEY: config.s_stage,
+        FLASH_KV_STAGE_KEY: config.kv_stage,
+        FLASH_PERSISTENT_KEY: config.persistent,
+        FLASH_PERSISTENT_CTAS_PER_SM_KEY: config.persistent_ctas_per_sm,
+        FLASH_RECOMPUTE_TILE_COORDS_KEY: config.recompute_tile_coords,
+        FLASH_E2E_SCHEDULE_KEY: config.e2e_schedule,
+        FLASH_MASKED_E2E_SCHEDULE_KEY: config.masked_e2e_schedule,
+        FLASH_E2E_OFFSET_KEY: config.e2e_offset,
+        FLASH_E2E_OFFSET0_KEY: config.e2e_offset0,
+        FLASH_PIPELINE_FAMILY_KEY: config.pipeline_family,
+        FLASH_SOFTMAX_DISC_KEY: config.softmax_disc,
+        FLASH_DISC_PIPE_KEY: config.disc_pipe_depth,
+        FLASH_SPLIT_P_ARRIVE_KEY: config.split_p_arrive,
+        FLASH_P_STORE_REP_KEY: config.p_store_repetition,
+        FLASH_S_LOAD_REP_KEY: config.s_load_repetition,
+        FLASH_PRECOMPUTE_QK_DESC_KEY: config.precompute_qk_desc,
+        FLASH_FIRST_LOAD_ORDER_KEY: config.first_load_order,
+        FLASH_KV_ORDER_KEY: config.kv_order,
+        FLASH_EPI_TMA_KEY: config.epi_tma,
+        FLASH_EPI_STG_KEY: config.epi_stg,
+        FLASH_EPI_STG_STORE_KEY: config.epi_stg_store,
+        FLASH_EPI_STG_GMEM_KEY: config.epi_stg_gmem,
+        FLASH_RESCALE_THRESHOLD_KEY: config.rescale_threshold,
+        FLASH_SKIP_RESCALE_STATS_KEY: config.skip_rescale_stats,
+        FLASH_RESCALE_CHUNK_COLS_KEY: config.rescale_chunk_cols,
+        FLASH_SOFTMAX_REGS_KEY: config.softmax_regs,
+        FLASH_CORR_REGS_KEY: config.corr_regs,
+        FLASH_OTHER_REGS_KEY: config.other_regs,
+        FLASH_CORR_TILE_SIZE_KEY: config.corr_tile_size,
+        FLASH_PACKED_REDUCE_KEY: config.packed_reduce,
+        FLASH_SMALL_BIASED_KEY: config.small_biased,
+        FLASH_CAUSAL_LPT_SWIZZLE_KEY: config.causal_lpt_swizzle,
+        FLASH_CAUSAL_KV_ORDER_KEY: config.causal_kv_order,
+        FLASH_ROLE_MAP_KEY: config.role_map,
+        FLASH_CLC_HEADS_PER_BATCH_KEY: config.clc_heads_per_batch,
+        FLASH_CLC_PDL_KEY: config.clc_use_pdl,
+        FLASH_CLC_STAGES_KEY: config.clc_stages,
+        FLASH_CAUSAL_LOOP_SPLIT_KEY: config.causal_loop_split,
+    }
 
 
 def _flash_choices_with_default(default: _T, choices: Iterable[_T]) -> tuple[_T, ...]:
@@ -2448,18 +2632,28 @@ def flash_attention_value_prior_weights(
         clc_heads_per_batch = _flash_dense_hd64_seed_clc_heads_per_batch(num_kv)
         persistent_ctas_per_sm = _flash_dense_hd64_seed_persistent_ctas_per_sm(num_kv)
         recompute_tile_coords = _flash_dense_hd64_seed_recompute_tile_coords(num_kv)
-        local_tma_partition = _flash_dense_hd64_seed_local_tma_partition(num_kv)
+        pipeline_family = _flash_pipeline_family_from_flags(
+            topology="fa4",
+            use_2cta_instrs=False,
+            use_cga2_local_cta=_flash_dense_hd64_seed_cga2_local(num_kv),
+            use_clc_scheduler=clc,
+            local_tma_partition=_flash_dense_hd64_seed_local_tma_partition(num_kv),
+            tensor_4d_tma=_flash_dense_hd64_seed_tensor_4d_tma(num_kv),
+        )
+        pipeline_family_priors: dict[object, float] = {
+            pipeline_family: 4.0,
+            "ws_overlap": 1.0,
+        }
+        if pipeline_family != "fa4":
+            pipeline_family_priors["fa4"] = 1.0
+        if num_kv == 512 and dtype is torch.float16:
+            pipeline_family_priors["fa4_2cta"] = 4.0
         very_long_dense_hd64_fa4 = num_kv >= _FLASH_DENSE_HD64_VERY_LONG_MIN_KV
         priors = cast(
             "dict[str, dict[object, float]]",
             {
                 FLASH_S_STAGE_KEY: {2: 1.0},
-                FLASH_TOPOLOGY_KEY: {"fa4": 4.0, "ws_overlap": 1.0},
-                FLASH_USE_2CTA_KEY: (
-                    {True: 4.0, False: 2.0}
-                    if num_kv == 512 and dtype is torch.float16
-                    else {False: 1.0}
-                ),
+                FLASH_PIPELINE_FAMILY_KEY: pipeline_family_priors,
                 FLASH_PERSISTENT_KEY: {True: 1.0},
                 FLASH_PERSISTENT_CTAS_PER_SM_KEY: {
                     persistent_ctas_per_sm: 4.0,
@@ -2582,24 +2776,12 @@ def flash_attention_value_prior_weights(
                     **{stage: 2.0 for stage in (2, 3) if stage != kv_stage},
                 },
                 FLASH_PACKED_REDUCE_KEY: {packed_reduce: 4.0, not packed_reduce: 1.0},
-                FLASH_CGA2_LOCAL_KEY: (
-                    {False: 2.0, True: 2.0} if num_kv % 4 == 0 else {False: 1.0}
-                ),
-                FLASH_CLC_KEY: {clc: 4.0, not clc: 1.0},
                 FLASH_CLC_HEADS_PER_BATCH_KEY: {
                     clc_heads_per_batch: 4.0,
                     **{heads: 2.0 for heads in (0, 32) if heads != clc_heads_per_batch},
                 },
                 FLASH_CLC_PDL_KEY: {False: 4.0, True: 1.0},
                 FLASH_CLC_STAGES_KEY: {2: 4.0, 3: 1.0, 1: 1.0},
-                FLASH_LOCAL_TMA_PARTITION_KEY: {
-                    local_tma_partition: 4.0,
-                    not local_tma_partition: 1.0,
-                },
-                FLASH_TENSOR_4D_TMA_KEY: {
-                    _flash_dense_hd64_seed_tensor_4d_tma(num_kv): 4.0,
-                    (not _flash_dense_hd64_seed_tensor_4d_tma(num_kv)): 2.0,
-                },
                 FLASH_E2E_OFFSET_KEY: {
                     e2e_offset: 4.0,
                     **{offset: 2.0 for offset in (0, 1, 2, 3) if offset != e2e_offset},
@@ -2617,9 +2799,6 @@ def flash_attention_value_prior_weights(
                     FLASH_EPI_STG_STORE_KEY: {"slice": 1.0},
                     FLASH_EPI_STG_GMEM_KEY: {"stage": 1.0},
                     FLASH_PACKED_REDUCE_KEY: {packed_reduce: 1.0},
-                    FLASH_CGA2_LOCAL_KEY: {
-                        _flash_dense_hd64_seed_cga2_local(num_kv): 1.0
-                    },
                     FLASH_SKIP_RESCALE_STATS_KEY: {False: 1.0},
                 }
             )
@@ -2687,7 +2866,7 @@ def flash_attention_value_prior_weights(
         return cast(
             "dict[str, dict[object, float]]",
             {
-                FLASH_TOPOLOGY_KEY: {"fa4": 4.0, "ws_overlap": 1.0},
+                FLASH_PIPELINE_FAMILY_KEY: {"fa4": 4.0, "ws_overlap": 1.0},
                 FLASH_PERSISTENT_KEY: {False: 1.0},
                 FLASH_KV_STAGE_KEY: {
                     2: 4.0,
@@ -2812,7 +2991,7 @@ def _flash_default_seed_config(
     if small_biased_candidate:
         _flash_seed_set(seed, fragments, FLASH_SMALL_BIASED_KEY, True)
     if topology is not None and not _flash_seed_set(
-        seed, fragments, FLASH_TOPOLOGY_KEY, topology
+        seed, fragments, FLASH_PIPELINE_FAMILY_KEY, topology
     ):
         return None
 
@@ -2835,6 +3014,14 @@ def _flash_default_seed_config(
         ) = _flash_dense_hd64_seed_params(num_kv)
         rescale_threshold = _flash_dense_hd64_seed_rescale_threshold(num_kv, dtype)
         family_values = {
+            FLASH_PIPELINE_FAMILY_KEY: _flash_pipeline_family_from_flags(
+                topology="fa4",
+                use_2cta_instrs=False,
+                use_cga2_local_cta=_flash_dense_hd64_seed_cga2_local(num_kv),
+                use_clc_scheduler=_flash_dense_hd64_seed_clc(num_kv),
+                local_tma_partition=_flash_dense_hd64_seed_local_tma_partition(num_kv),
+                tensor_4d_tma=_flash_dense_hd64_seed_tensor_4d_tma(num_kv),
+            ),
             FLASH_S_STAGE_KEY: 2,
             FLASH_KV_STAGE_KEY: kv_stage,
             FLASH_PERSISTENT_KEY: True,
@@ -2871,17 +3058,11 @@ def _flash_default_seed_config(
             ),
             FLASH_RESCALE_CHUNK_COLS_KEY: rescale_chunk_cols,
             FLASH_PACKED_REDUCE_KEY: packed_reduce,
-            FLASH_CGA2_LOCAL_KEY: _flash_dense_hd64_seed_cga2_local(num_kv),
-            FLASH_CLC_KEY: _flash_dense_hd64_seed_clc(num_kv),
             FLASH_CLC_HEADS_PER_BATCH_KEY: _flash_dense_hd64_seed_clc_heads_per_batch(
                 num_kv
             ),
             FLASH_CLC_PDL_KEY: False,
             FLASH_CLC_STAGES_KEY: 2 if _flash_dense_hd64_seed_clc(num_kv) else 1,
-            FLASH_LOCAL_TMA_PARTITION_KEY: _flash_dense_hd64_seed_local_tma_partition(
-                num_kv
-            ),
-            FLASH_TENSOR_4D_TMA_KEY: _flash_dense_hd64_seed_tensor_4d_tma(num_kv),
         }
         role_map = _flash_dense_hd64_seed_role_map(num_kv)
         if role_map != "helion":
@@ -2949,7 +3130,7 @@ def _flash_dense_sp_seed_config(
     rescale_threshold = _flash_dense_hd64_seed_rescale_threshold(num_kv, dtype)
     seed: dict[str, object] = {"block_sizes": block_sizes}
     family_values: dict[str, object] = {
-        FLASH_TOPOLOGY_KEY: "fa4",
+        FLASH_PIPELINE_FAMILY_KEY: "fa4_local_tma_4d",
         FLASH_S_STAGE_KEY: 2,
         FLASH_KV_STAGE_KEY: kv_stage,
         FLASH_PERSISTENT_KEY: True,
@@ -2982,12 +3163,8 @@ def _flash_dense_sp_seed_config(
         FLASH_SKIP_RESCALE_STATS_KEY: _flash_dense_hd64_seed_skip_rescale_stats(num_kv),
         FLASH_RESCALE_CHUNK_COLS_KEY: rescale_chunk_cols,
         FLASH_PACKED_REDUCE_KEY: packed_reduce,
-        FLASH_CGA2_LOCAL_KEY: False,
-        FLASH_CLC_KEY: False,
         FLASH_CLC_PDL_KEY: False,
         FLASH_CLC_STAGES_KEY: 1,
-        FLASH_LOCAL_TMA_PARTITION_KEY: True,
-        FLASH_TENSOR_4D_TMA_KEY: True,
     }
     if not _flash_seed_set_all(seed, fragments, family_values):
         return None
@@ -3032,7 +3209,7 @@ def _flash_causal_lpt_seed_config(
     offset0 = _flash_causal_hd64_seed_offset0(num_kv)
     seed: dict[str, object] = {"block_sizes": block_sizes}
     family_values: dict[str, object] = {
-        FLASH_TOPOLOGY_KEY: "fa4",
+        FLASH_PIPELINE_FAMILY_KEY: "fa4",
         FLASH_S_STAGE_KEY: 2,
         FLASH_KV_STAGE_KEY: 2,
         FLASH_PERSISTENT_KEY: False,
@@ -3103,7 +3280,7 @@ def _flash_causal_split_seed_config(
     split_offset0 = 0 if num_kv <= 128 else _flash_causal_hd64_seed_offset0(num_kv)
     seed: dict[str, object] = {"block_sizes": block_sizes}
     family_values: dict[str, object] = {
-        FLASH_TOPOLOGY_KEY: "fa4",
+        FLASH_PIPELINE_FAMILY_KEY: "fa4",
         FLASH_S_STAGE_KEY: 2,
         FLASH_KV_STAGE_KEY: 2,
         FLASH_PERSISTENT_KEY: False,
@@ -3259,6 +3436,7 @@ def flash_autotune_fragments(
     requires_ws_overlap: bool = False,
     small_biased_candidate: bool = False,
     topology_override: str | None = None,
+    pipeline_family_override: str | None = None,
 ) -> dict[str, ConfigSpecFragment]:
     """Return ``{config_key: ConfigSpecFragment}`` for the flash autotune surface.
 
@@ -3288,14 +3466,11 @@ def flash_autotune_fragments(
         preserve the FA4-aligned program order, but gives the autotuner the same
         phase freedom for the first softmax warpgroup when a shape benefits from
         different XU/FMA pipe staggering.
-      * ``topology`` — the device-body topology selector. ``ws_overlap`` (the
-        fallback) plus ``fa4`` (the commit-38ff4d1a win, ~77% SDPA) WHEN the
-        shape meets the fa4 2-Q-tile envelope (``seq % 256 == 0`` i.e.
-        ``num_kv`` even; head_dim is already pinned to {64, 128} by the
-        detector, and ``resolve_flash_config`` clamps FA4's aliased K/V ring to
-        at least 2 stages). Causal even-KV shapes also use FA4, but with the
-        persistent scheduler disabled; odd-KV shapes accept stale cached
-        ``fa4`` configs and resolve them back to ``ws_overlap`` before codegen.
+      * ``pipeline_family`` — one compound device schedule. It replaces the
+        independent topology, cluster, CLC, local-TMA, and tensor-map switches,
+        so the search enumerates legal emitted schedules instead of a Boolean
+        product containing aliases. Legacy fixed configs are normalized into
+        this family before candidate identity is constructed.
       * ``disc_pipe`` / ``epi_tma`` / ``rescale_threshold`` / ``packed_reduce`` —
         fa4/ws perf levers for PASS2 software-pipelining, epilogue TMA-store,
         alpha-pin O-rescale skipping, rescale chunk width, and packed ws row
@@ -3335,23 +3510,31 @@ def flash_autotune_fragments(
     build. They are sourced from ``resolve_flash_config`` (env/shape) as single
     values and can be promoted to fragments once characterized.
     """
-    env_topology = os.environ.get("HELION_CUTE_FLASH_TOPOLOGY")
     valid_topology_override = (
         topology_override if topology_override in ("fa4", "ws_overlap") else None
     )
-    topology_config = "ws_overlap" if requires_ws_overlap else valid_topology_override
-    if topology_config is None and env_topology is not None:
-        topology_config = (
-            env_topology if env_topology in ("fa4", "ws_overlap") else None
-        )
+    valid_pipeline_family_override = (
+        pipeline_family_override
+        if pipeline_family_override in FLASH_PIPELINE_FAMILY_FLAGS
+        else None
+    )
+    if requires_ws_overlap:
+        defaults_config: Mapping[str, object] | None = {
+            FLASH_PIPELINE_FAMILY_KEY: "ws_overlap"
+        }
+    elif valid_pipeline_family_override is not None:
+        defaults_config = {FLASH_PIPELINE_FAMILY_KEY: valid_pipeline_family_override}
+    elif valid_topology_override is not None:
+        # Preserve legacy topology semantics, including shape-derived cluster
+        # and CLC defaults. Re-encoding this as the base family would suppress
+        # those defaults before legacy configs are normalized.
+        defaults_config = {FLASH_TOPOLOGY_KEY: valid_topology_override}
+    else:
+        defaults_config = None
     defaults = resolve_flash_config(
         head_dim,
         num_kv,
-        (
-            {FLASH_TOPOLOGY_KEY: topology_config}
-            if topology_config is not None
-            else None
-        ),
+        defaults_config,
         dtype=dtype,
         is_causal=is_causal,
         prefer_packed_reduce=has_kv_tile_pruning or requires_ws_overlap,
@@ -3517,44 +3700,10 @@ def flash_autotune_fragments(
     else:
         masked_e2e_schedule_choices = ("inherit",)
         masked_e2e_schedule_search_choices = None
-    # Topology: default to fa4 only when the shape meets the fa4 2-Q-tile envelope.
-    # The fa4 device body processes a PAIR of adjacent 128-row Q-tiles per CTA, so
-    # it requires ``seq % 256 == 0``. The codegen already gates seq % 128 == 0 (so
-    # seq == num_kv * 128); ``seq % 256 == 0`` is therefore exactly ``num_kv`` even.
-    # Ineligible shapes still include fa4 as a cache-compatibility enum value, but
-    # resolve_flash_config() clamps it to ws_overlap before codegen. The FIRST
-    # choice is the env/shape-resolved default. With no env override, eligible
-    # shapes default to fa4 so the default config exercises the faster topology;
-    # invalid env values are sanitized by resolve_flash_config().
+    # FA4 processes a pair of adjacent Q tiles and therefore requires an even
+    # KV-tile count. Family choices are constructed after the cluster/CLC
+    # eligibility checks below.
     fa4_eligible = num_kv % 2 == 0
-    topology_search_choices: tuple[str, ...] | None = None
-    if requires_ws_overlap:
-        topology_choices = ("ws_overlap",)
-        topology_search_choices = None
-    elif dense_hd64_fa4 or causal_hd64_seeded_fa4:
-        topology_choices = _flash_choices_with_default(
-            defaults.topology, ("fa4", "ws_overlap")
-        )
-        topology_search_defaults = ("fa4", "ws_overlap")
-        topology_search_choices = (
-            ("fa4",)
-            if long_causal_hd64_seeded_fa4
-            else _flash_choices_with_default(
-                defaults.topology, topology_search_defaults
-            )
-        )
-    elif fa4_eligible:
-        # Seed with the resolved default first, then the other topology.
-        topology_choices: tuple[str, ...] = (
-            defaults.topology,
-            "fa4" if defaults.topology != "fa4" else "ws_overlap",
-        )
-    else:
-        # Ineligible shapes still accept stale cached fa4 configs so best-available
-        # autotune handoff can transfer dense runs to causal/odd-KV runs. The
-        # resolver clamps fa4 back to ws_overlap before codegen, so this is only
-        # cache compatibility, not a second device topology.
-        topology_choices = ("ws_overlap", "fa4")
     if dense_hd64_fa4:
         softmax_disc_choices = _flash_choices_with_default(
             defaults.softmax_disc, (True, False)
@@ -3944,13 +4093,13 @@ def flash_autotune_fragments(
         else (defaults.role_map,)
     )
     dense_hd128_fa4 = (
-        topology_choices[0] == "fa4"
+        defaults.topology == "fa4"
         and not is_causal
         and head_dim == 128
         and num_kv % 4 == 0
     )
     dense_hd64_2cta_fa4 = (
-        topology_choices[0] == "fa4"
+        defaults.topology == "fa4"
         and not is_causal
         and head_dim == 64
         and 256 <= num_kv <= 1024
@@ -3961,31 +4110,6 @@ def flash_autotune_fragments(
         and not small_biased_candidate
     )
     use_2cta_eligible = dense_hd128_fa4 or dense_hd64_2cta_fa4
-    use_2cta_choices = (
-        _flash_choices_with_default(defaults.use_2cta_instrs, (False, True))
-        if use_2cta_eligible
-        else (False,)
-    )
-    use_2cta_search_choices: tuple[bool, ...] | None = (
-        use_2cta_choices if use_2cta_eligible else (False,)
-    )
-    use_cga2_local_eligible = (
-        dense_hd64_fa4 and not is_causal and head_dim == 64 and num_kv % 4 == 0
-    )
-    use_cga2_local_choices = (
-        _flash_choices_with_default(defaults.use_cga2_local_cta, (False, True))
-        if use_cga2_local_eligible
-        else (False,)
-    )
-    use_cga2_local_search_choices: tuple[bool, ...] | None = (
-        # The very-long hd64 target already saturates with one CTA per tile, so
-        # two-local-CTA variants remain manual.
-        (defaults.use_cga2_local_cta,)
-        if very_long_dense_hd64_fa4
-        else use_cga2_local_choices
-        if use_cga2_local_eligible
-        else (False,)
-    )
     use_clc_eligible = (
         dense_hd64_fa4
         and not is_causal
@@ -3993,18 +4117,25 @@ def flash_autotune_fragments(
         and num_kv % 2 == 0
         and defaults.persistent
     )
-    use_clc_choices = (
-        _flash_choices_with_default(defaults.use_clc_scheduler, (True, False))
-        if use_clc_eligible
-        else (False,)
-    )
-    use_clc_search_choices: tuple[bool, ...] | None = (
-        (defaults.use_clc_scheduler,)
-        if use_clc_eligible and very_long_dense_hd64_fa4
-        else use_clc_choices
-        if use_clc_eligible
-        else (False,)
-    )
+    if requires_ws_overlap:
+        pipeline_family_choices = ("ws_overlap",)
+        pipeline_family_search_choices: tuple[str, ...] | None = None
+    else:
+        pipeline_family_choices = _flash_choices_with_default(
+            defaults.pipeline_family, FLASH_PIPELINE_FAMILIES
+        )
+        pipeline_family_search: list[str] = ["fa4" if fa4_eligible else "ws_overlap"]
+        if not long_causal_hd64_seeded_fa4:
+            pipeline_family_search.append("ws_overlap")
+        if use_2cta_eligible:
+            pipeline_family_search.append("fa4_2cta")
+        if use_clc_eligible and (
+            not very_long_dense_hd64_fa4 or defaults.use_clc_scheduler
+        ):
+            pipeline_family_search.append("fa4_clc")
+        pipeline_family_search_choices = _flash_choices_with_default(
+            defaults.pipeline_family, pipeline_family_search
+        )
     clc_heads_choices = _flash_choices_with_default(
         defaults.clc_heads_per_batch, (0, 1, 2, 4, 8, 16, 32, 64)
     )
@@ -4038,31 +4169,6 @@ def flash_autotune_fragments(
         else (2, 3)
         if use_clc_eligible
         else (1,)
-    )
-    local_tma_eligible = dense_hd64_fa4 and not is_causal and head_dim == 64
-    local_tma_choices = (
-        _flash_choices_with_default(defaults.local_tma_partition, (False, True))
-        if local_tma_eligible
-        else (False,)
-    )
-    local_tma_search_choices: tuple[bool, ...] | None = (
-        (defaults.local_tma_partition,)
-        if very_long_dense_hd64_fa4
-        else local_tma_choices
-        if local_tma_eligible
-        else (False,)
-    )
-    tensor_4d_tma_choices = (
-        _flash_choices_with_default(defaults.tensor_4d_tma, (False, True))
-        if local_tma_eligible
-        else (False,)
-    )
-    tensor_4d_tma_search_choices: tuple[bool, ...] | None = (
-        (defaults.tensor_4d_tma,)
-        if very_long_dense_hd64_fa4
-        else tensor_4d_tma_choices
-        if local_tma_eligible
-        else (False,)
     )
     causal_loop_split_choices = (
         defaults.causal_loop_split,
@@ -4163,7 +4269,9 @@ def flash_autotune_fragments(
         FLASH_E2E_OFFSET0_KEY: EnumFragment(
             e2e_offset0_choices, e2e_offset0_search_choices
         ),
-        FLASH_TOPOLOGY_KEY: EnumFragment(topology_choices, topology_search_choices),
+        FLASH_PIPELINE_FAMILY_KEY: EnumFragment(
+            pipeline_family_choices, pipeline_family_search_choices
+        ),
         FLASH_SOFTMAX_DISC_KEY: EnumFragment(
             softmax_disc_choices, softmax_disc_search_choices
         ),
@@ -4224,23 +4332,12 @@ def flash_autotune_fragments(
             causal_kv_order_choices, causal_kv_order_search_choices
         ),
         FLASH_ROLE_MAP_KEY: EnumFragment(role_map_choices, role_map_search_choices),
-        FLASH_USE_2CTA_KEY: EnumFragment(use_2cta_choices, use_2cta_search_choices),
-        FLASH_CGA2_LOCAL_KEY: EnumFragment(
-            use_cga2_local_choices, use_cga2_local_search_choices
-        ),
-        FLASH_CLC_KEY: EnumFragment(use_clc_choices, use_clc_search_choices),
         FLASH_CLC_HEADS_PER_BATCH_KEY: EnumFragment(
             clc_heads_choices, clc_heads_search_choices
         ),
         FLASH_CLC_PDL_KEY: EnumFragment(clc_pdl_choices, clc_pdl_search_choices),
         FLASH_CLC_STAGES_KEY: EnumFragment(
             clc_stages_choices, clc_stages_search_choices
-        ),
-        FLASH_LOCAL_TMA_PARTITION_KEY: EnumFragment(
-            local_tma_choices, local_tma_search_choices
-        ),
-        FLASH_TENSOR_4D_TMA_KEY: EnumFragment(
-            tensor_4d_tma_choices, tensor_4d_tma_search_choices
         ),
         FLASH_CAUSAL_LOOP_SPLIT_KEY: EnumFragment(
             causal_loop_split_choices, causal_loop_split_search_choices
@@ -8978,7 +9075,7 @@ def codegen_attention_flash(cg: GenerateAST) -> bool:
     num_kv = (seq + 127) // 128
     flash_config: Mapping[str, object] | None = df.config
     if score_plan.requires_ws_overlap:
-        flash_config = {**df.config, FLASH_TOPOLOGY_KEY: "ws_overlap"}
+        flash_config = {**df.config, FLASH_PIPELINE_FAMILY_KEY: "ws_overlap"}
     cfg = resolve_flash_config(
         head_dim,
         num_kv,

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -26,8 +26,6 @@ from .._compat import supports_maxnreg
 from .._compat import supports_tensor_descriptor
 from .._compat import target_device_capability as get_target_device_capability
 from .._compat import warps_to_threads
-from .._compiler.cute.cute_flash import FLASH_CAUSAL_KV_ORDER_KEY
-from .._compiler.cute.cute_flash import FLASH_CAUSAL_LOOP_SPLIT_KEY
 from .._compiler.cute.cute_flash import FLASH_CONFIG_KEYS
 from .._compiler.cute.cute_flash import FLASH_CORR_REGS_KEY
 from .._compiler.cute.cute_flash import FLASH_E2E_FREQ_KEY
@@ -35,13 +33,17 @@ from .._compiler.cute.cute_flash import FLASH_E2E_OFFSET0_KEY
 from .._compiler.cute.cute_flash import FLASH_E2E_OFFSET_KEY
 from .._compiler.cute.cute_flash import FLASH_E2E_RES_KEY
 from .._compiler.cute.cute_flash import FLASH_E2E_SCHEDULE_KEY
-from .._compiler.cute.cute_flash import FLASH_EPI_TMA_KEY
 from .._compiler.cute.cute_flash import FLASH_EXP2_IMPL_KEY
+from .._compiler.cute.cute_flash import FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS
 from .._compiler.cute.cute_flash import FLASH_MASKED_E2E_SCHEDULE_KEY
+from .._compiler.cute.cute_flash import FLASH_MMA_INTERLEAVE_KEY
 from .._compiler.cute.cute_flash import FLASH_OTHER_REGS_KEY
-from .._compiler.cute.cute_flash import FLASH_ROLE_MAP_KEY
+from .._compiler.cute.cute_flash import FLASH_PERSISTENT_KEY
+from .._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILY_KEY
+from .._compiler.cute.cute_flash import FLASH_Q_TILE_COUNT_KEY
 from .._compiler.cute.cute_flash import FLASH_SOFTMAX_REGS_KEY
 from .._compiler.cute.cute_flash import FLASH_TOPOLOGY_KEY
+from .._compiler.cute.cute_flash import FlashAttentionConfig
 from .._compiler.cute.cute_flash import _flash_causal_hd64_seed_num_kv_supported
 from .._compiler.cute.cute_flash import _flash_causal_hd64_seed_offset0
 from .._compiler.cute.cute_flash import _flash_causal_hd64_seed_params
@@ -51,6 +53,9 @@ from .._compiler.cute.cute_flash import _flash_masked_e2e_schedule_params
 from .._compiler.cute.cute_flash import _flash_normalize_e2e_offset
 from .._compiler.cute.cute_flash import _flash_normalize_e2e_params
 from .._compiler.cute.cute_flash import _flash_parse_e2e_schedule
+from .._compiler.cute.cute_flash import _flash_pipeline_family_flags
+from .._compiler.cute.cute_flash import flash_effective_config_values
+from .._compiler.cute.cute_flash import resolve_flash_config
 from .._compiler.cute.tcgen05_config import CUTE_TCGEN05_DIAGNOSTIC_CONFIG_KEYS
 from .._compiler.cute.tcgen05_config import CUTE_TCGEN05_STRATEGY_CONFIG_KEYS
 from .._compiler.cute.tcgen05_config import CUTE_TCGEN05_TUNABLE_KEYS
@@ -799,22 +804,42 @@ class ConfigSpec:
     def cute_tcgen05_matmul_has_non_tcgen05_operand(self, value: bool) -> None:
         self._cute_tcgen05_config.matmul_has_non_tcgen05_operand = value
 
+    def _resolve_cute_flash_config(
+        self, config: Mapping[str, object]
+    ) -> FlashAttentionConfig:
+        assert self._cute_flash_head_dim is not None
+        assert self._cute_flash_num_kv is not None
+        flash_config = config
+        if self._cute_flash_requires_ws_overlap:
+            flash_config = {**config, FLASH_PIPELINE_FAMILY_KEY: "ws_overlap"}
+        return resolve_flash_config(
+            self._cute_flash_head_dim,
+            self._cute_flash_num_kv,
+            flash_config,
+            dtype=self._cute_flash_dtype,
+            is_causal=self._cute_flash_is_causal,
+            prefer_packed_reduce=(
+                self._cute_flash_has_kv_tile_pruning
+                or self._cute_flash_requires_ws_overlap
+            ),
+        )
+
     def _normalize_cute_flash(
         self, config: dict[str, object], *, fix_invalid: bool
     ) -> None:
-        """Normalize the flash-attention knobs (Tasks #25 + #28).
+        """Normalize the flash-attention autotune surface.
 
         Only runs when ``cute_flash_search_enabled`` is set (the flash detector
-        fired). Mirrors ``CuteTcgen05Config.normalize_strategy``: each key in
-        ``FLASH_CONFIG_KEYS`` is validated against its fragment's choices and
-        defaulted (to the fragment default = env/shape-resolved current value)
-        when absent. When the flag is off this is a no-op so configs never grow
-        the flash keys and behavior is byte-identical to today.
+        fired). Active keys are validated against their fragments, while legacy
+        structural keys are projected into the compound pipeline-family key and
+        removed before the config is used as an autotune identity.
         """
         if not self.cute_flash_search_enabled:
             return
         assert self._cute_flash_head_dim is not None
         assert self._cute_flash_num_kv is not None
+        config.pop(FLASH_Q_TILE_COUNT_KEY, None)
+        config.pop(FLASH_MMA_INTERLEAVE_KEY, None)
         from .._compiler.cute.cute_flash import flash_autotune_fragments
 
         block_size_targets = self._cute_flash_block_size_target_list()
@@ -829,15 +854,46 @@ class ConfigSpec:
         elif not self._is_cute_flash_config_envelope(config, block_size_targets):
             return
 
+        has_legacy_structural_config = any(
+            config.get(key) is not None for key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS
+        )
+        legacy_effective = None
+        if has_legacy_structural_config and FLASH_PIPELINE_FAMILY_KEY not in config:
+            legacy_resolution_config = {
+                key: config[key]
+                for key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS
+                if key in config
+            }
+            if FLASH_PERSISTENT_KEY in config:
+                legacy_resolution_config[FLASH_PERSISTENT_KEY] = config[
+                    FLASH_PERSISTENT_KEY
+                ]
+            legacy_effective = self._resolve_cute_flash_config(legacy_resolution_config)
         if self._cute_flash_requires_ws_overlap:
-            config[FLASH_TOPOLOGY_KEY] = "ws_overlap"
+            config[FLASH_PIPELINE_FAMILY_KEY] = "ws_overlap"
             topology_override = "ws_overlap"
+            pipeline_family_override = "ws_overlap"
         else:
-            valid_manual_topologies = {"fa4", "ws_overlap"}
-            topology_value = config.get(FLASH_TOPOLOGY_KEY)
-            topology_override = (
-                topology_value if topology_value in valid_manual_topologies else None
+            requested_family = _flash_pipeline_family_flags(
+                config.get(FLASH_PIPELINE_FAMILY_KEY)
             )
+            pipeline_family_override = (
+                str(config[FLASH_PIPELINE_FAMILY_KEY])
+                if requested_family is not None
+                else legacy_effective.pipeline_family
+                if legacy_effective is not None
+                else None
+            )
+            if requested_family is not None:
+                topology_override = requested_family.topology
+            else:
+                valid_manual_topologies = {"fa4", "ws_overlap"}
+                topology_value = config.get(FLASH_TOPOLOGY_KEY)
+                topology_override = (
+                    topology_value
+                    if topology_value in valid_manual_topologies
+                    else None
+                )
         fragments = flash_autotune_fragments(
             self._cute_flash_head_dim,
             self._cute_flash_num_kv,
@@ -847,10 +903,14 @@ class ConfigSpec:
             requires_ws_overlap=self._cute_flash_requires_ws_overlap,
             small_biased_candidate=self._cute_flash_small_biased_candidate,
             topology_override=cast("str | None", topology_override),
+            pipeline_family_override=pipeline_family_override,
         )
         e2e_offset_was_present = FLASH_E2E_OFFSET_KEY in config
         e2e_offset0_was_present = FLASH_E2E_OFFSET0_KEY in config
         e2e_offset_keys = (FLASH_E2E_OFFSET_KEY, FLASH_E2E_OFFSET0_KEY)
+        explicit_e2e_offsets = {
+            key: config[key] for key in e2e_offset_keys if key in config
+        }
         for key, fragment in fragments.items():
             choices = cast("EnumFragment", fragment).choices
             if key in config:
@@ -868,22 +928,21 @@ class ConfigSpec:
                             f"got {config[key]!r}"
                         )
             else:
-                if key not in e2e_offset_keys:
+                if key not in (*e2e_offset_keys, FLASH_PIPELINE_FAMILY_KEY):
                     config[key] = fragment.default()
-        effective_topology = cast("str", config[FLASH_TOPOLOGY_KEY])
-        if effective_topology == "fa4" and self._cute_flash_num_kv % 2 != 0:
-            effective_topology = "ws_overlap"
-        if fix_invalid:
-            config[FLASH_TOPOLOGY_KEY] = effective_topology
-        if effective_topology != "fa4":
-            config[FLASH_ROLE_MAP_KEY] = "helion"
-            config[FLASH_EPI_TMA_KEY] = False
-            config[FLASH_MASKED_E2E_SCHEDULE_KEY] = "inherit"
-            config[FLASH_CAUSAL_KV_ORDER_KEY] = "ascending"
-            config[FLASH_CAUSAL_LOOP_SPLIT_KEY] = False
-        causal_kv_order = config.get(FLASH_CAUSAL_KV_ORDER_KEY)
-        if not self._cute_flash_is_causal or causal_kv_order != "descending":
-            config[FLASH_CAUSAL_LOOP_SPLIT_KEY] = False
+        if FLASH_PIPELINE_FAMILY_KEY not in config:
+            family_fragment = fragments[FLASH_PIPELINE_FAMILY_KEY]
+            config[FLASH_PIPELINE_FAMILY_KEY] = (
+                legacy_effective.pipeline_family
+                if legacy_effective is not None
+                else family_fragment.default()
+            )
+
+        effective = self._resolve_cute_flash_config(config)
+        effective_topology = effective.topology
+        config.update(flash_effective_config_values(effective))
+        if effective_topology == "fa4":
+            config.update(explicit_e2e_offsets)
         e2e_schedule_default = (
             "8/2"
             if (
@@ -1021,6 +1080,12 @@ class ConfigSpec:
             effective_topology,
             fix_invalid=fix_invalid,
         )
+        for key in (
+            *FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS,
+            FLASH_Q_TILE_COUNT_KEY,
+            FLASH_MMA_INTERLEAVE_KEY,
+        ):
+            config.pop(key, None)
 
     def _normalize_cute_flash_register_budget(
         self,
@@ -2178,6 +2243,8 @@ class ConfigSpec:
         config: dict[str, object],
     ) -> tuple[bool, object]:
         if self.backend_name == "cute":
+            if self.cute_flash_search_enabled and key == FLASH_PIPELINE_FAMILY_KEY:
+                return True, self._resolve_cute_flash_config(config).pipeline_family
             return self._cute_tcgen05_config.flatten_missing_field_default(key, config)
         return False, None
 

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -3808,9 +3808,9 @@ class TestCuteAutotuner(TestCase):
 
         For an attention kernel bind ``cute_flash_search_enabled`` is True and
         every active flash autotune knob is in ``flat_key_layout()`` -- including
-        the paired exp2 schedule and the fa4-win knobs (``topology``,
-        ``disc_pipe``, ``epi_tma``), with the ``topology`` fragment offering
-        ``fa4`` for the fa4-eligible (even-num_kv) shape; for a non-attention
+        the paired exp2 schedule and the compound pipeline family, with the
+        family fragment offering ``fa4`` for the fa4-eligible (even-num_kv)
+        shape; for a non-attention
         cute kernel (a matmul) the flag is False and none of the flash knobs leak
         into the search surface.
         """
@@ -3827,27 +3827,31 @@ class TestCuteAutotuner(TestCase):
         from helion._compiler.cute.cute_flash import FLASH_CORR_REGS_KEY
         from helion._compiler.cute.cute_flash import FLASH_CORR_TILE_SIZE_KEY
         from helion._compiler.cute.cute_flash import FLASH_DISC_PIPE_KEY
-        from helion._compiler.cute.cute_flash import FLASH_E2E_FREQ_KEY
         from helion._compiler.cute.cute_flash import FLASH_E2E_OFFSET0_KEY
         from helion._compiler.cute.cute_flash import FLASH_E2E_OFFSET_KEY
-        from helion._compiler.cute.cute_flash import FLASH_E2E_RES_KEY
         from helion._compiler.cute.cute_flash import FLASH_E2E_SCHEDULE_KEY
         from helion._compiler.cute.cute_flash import FLASH_EPI_STG_GMEM_KEY
         from helion._compiler.cute.cute_flash import FLASH_EPI_STG_KEY
         from helion._compiler.cute.cute_flash import FLASH_EPI_STG_STORE_KEY
         from helion._compiler.cute.cute_flash import FLASH_EPI_TMA_KEY
-        from helion._compiler.cute.cute_flash import FLASH_EXP2_IMPL_KEY
         from helion._compiler.cute.cute_flash import FLASH_FIRST_LOAD_ORDER_KEY
         from helion._compiler.cute.cute_flash import FLASH_KV_ORDER_KEY
         from helion._compiler.cute.cute_flash import FLASH_KV_STAGE_KEY
+        from helion._compiler.cute.cute_flash import FLASH_LEGACY_CONFIG_KEYS
+        from helion._compiler.cute.cute_flash import FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS
         from helion._compiler.cute.cute_flash import FLASH_LOCAL_TMA_PARTITION_KEY
         from helion._compiler.cute.cute_flash import FLASH_MASKED_E2E_SCHEDULE_KEY
+        from helion._compiler.cute.cute_flash import FLASH_MMA_INTERLEAVE_KEY
         from helion._compiler.cute.cute_flash import FLASH_OTHER_REGS_KEY
         from helion._compiler.cute.cute_flash import FLASH_P_STORE_REP_KEY
         from helion._compiler.cute.cute_flash import FLASH_PACKED_REDUCE_KEY
         from helion._compiler.cute.cute_flash import FLASH_PERSISTENT_CTAS_PER_SM_KEY
         from helion._compiler.cute.cute_flash import FLASH_PERSISTENT_KEY
+        from helion._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILIES
+        from helion._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILY_KEY
         from helion._compiler.cute.cute_flash import FLASH_PRECOMPUTE_QK_DESC_KEY
+        from helion._compiler.cute.cute_flash import FLASH_Q_TILE_COUNT_KEY
+        from helion._compiler.cute.cute_flash import FLASH_RECOMPUTE_TILE_COORDS_KEY
         from helion._compiler.cute.cute_flash import FLASH_RESCALE_CHUNK_COLS_KEY
         from helion._compiler.cute.cute_flash import FLASH_RESCALE_THRESHOLD_KEY
         from helion._compiler.cute.cute_flash import FLASH_ROLE_MAP_KEY
@@ -3860,7 +3864,10 @@ class TestCuteAutotuner(TestCase):
         from helion._compiler.cute.cute_flash import FLASH_SPLIT_P_ARRIVE_KEY
         from helion._compiler.cute.cute_flash import FLASH_TENSOR_4D_TMA_KEY
         from helion._compiler.cute.cute_flash import FLASH_TOPOLOGY_KEY
+        from helion._compiler.cute.cute_flash import FLASH_USE_2CTA_KEY
         from helion._compiler.cute.cute_flash import flash_autotune_fragments
+        from helion._compiler.cute.cute_flash import flash_config_from_config
+        from helion._compiler.cute.cute_flash import flash_effective_config_values
 
         @helion.kernel(backend="cute", static_shapes=True)
         def flash_attention(q_in, k_in, v_in):
@@ -3979,17 +3986,14 @@ class TestCuteAutotuner(TestCase):
         }
         for key in FLASH_AUTOTUNE_CONFIG_KEYS:
             self.assertIn(key, attn_keys)
-        for legacy_key in (
-            FLASH_EXP2_IMPL_KEY,
-            FLASH_E2E_FREQ_KEY,
-            FLASH_E2E_RES_KEY,
-        ):
+        for legacy_key in FLASH_LEGACY_CONFIG_KEYS:
             self.assertNotIn(legacy_key, attn_keys)
         for generic_key in ("num_threads", "loop_orders", "cute_vector_widths"):
             self.assertNotIn(generic_key, attn_keys)
-        # The fa4-win knobs are explicitly part of the surface when enabled.
+        # Structural flags are represented by one compound family. The CLC
+        # children remain active because they tune a selected CLC family.
         for fa4_key in (
-            FLASH_TOPOLOGY_KEY,
+            FLASH_PIPELINE_FAMILY_KEY,
             FLASH_SOFTMAX_DISC_KEY,
             FLASH_DISC_PIPE_KEY,
             FLASH_EPI_TMA_KEY,
@@ -3998,21 +4002,31 @@ class TestCuteAutotuner(TestCase):
             FLASH_EPI_STG_GMEM_KEY,
             FLASH_CORR_TILE_SIZE_KEY,
             FLASH_OTHER_REGS_KEY,
-            FLASH_CLC_KEY,
             FLASH_CLC_HEADS_PER_BATCH_KEY,
             FLASH_CLC_PDL_KEY,
             FLASH_CLC_STAGES_KEY,
-            FLASH_LOCAL_TMA_PARTITION_KEY,
-            FLASH_TENSOR_4D_TMA_KEY,
         ):
             self.assertIn(fa4_key, attn_keys)
+        self.assertEqual(
+            set(FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS),
+            {
+                FLASH_TOPOLOGY_KEY,
+                FLASH_USE_2CTA_KEY,
+                FLASH_CGA2_LOCAL_KEY,
+                FLASH_CLC_KEY,
+                FLASH_LOCAL_TMA_PARTITION_KEY,
+                FLASH_TENSOR_4D_TMA_KEY,
+            },
+        )
+        self.assertEqual(len(FLASH_PIPELINE_FAMILIES), 13)
         # seq=256 -> num_kv=2 (even) is fa4-eligible (seq % 256 == 0), so the
         # topology fragment must offer fa4 (alongside the ws_overlap default
         # seed first) so the autotuner can pick the fa4 win for this shape.
         flash_fragments = attn_bound.config_spec._flat_fields()
-        topology_choices = flash_fragments[FLASH_TOPOLOGY_KEY].choices
-        self.assertEqual(topology_choices[0], "fa4")
-        self.assertIn("fa4", topology_choices)
+        family_choices = flash_fragments[FLASH_PIPELINE_FAMILY_KEY].choices
+        self.assertEqual(family_choices[0], "fa4")
+        self.assertIn("fa4", family_choices)
+        self.assertIn("ws_overlap", family_choices)
         self.assertEqual(
             flash_fragments[FLASH_SMALL_BIASED_KEY].search_choices, (True,)
         )
@@ -4028,16 +4042,17 @@ class TestCuteAutotuner(TestCase):
         sparse_bound = sparse_flash_attention.bind((q, k, v))
         sparse_fragments_from_bound = sparse_bound.config_spec._flat_fields()
         self.assertEqual(
-            sparse_fragments_from_bound[FLASH_TOPOLOGY_KEY].choices,
+            sparse_fragments_from_bound[FLASH_PIPELINE_FAMILY_KEY].choices,
             ("ws_overlap",),
         )
         sparse_default_config = sparse_bound.config_spec.default_config().config
-        self.assertEqual(sparse_default_config[FLASH_TOPOLOGY_KEY], "ws_overlap")
+        self.assertEqual(sparse_default_config[FLASH_PIPELINE_FAMILY_KEY], "ws_overlap")
         self.assertTrue(sparse_default_config[FLASH_PACKED_REDUCE_KEY])
         sparse_fa4_config = dict(sparse_default_config)
         sparse_fa4_config[FLASH_TOPOLOGY_KEY] = "fa4"
         sparse_bound.config_spec.normalize(sparse_fa4_config)
-        self.assertEqual(sparse_fa4_config[FLASH_TOPOLOGY_KEY], "ws_overlap")
+        self.assertEqual(sparse_fa4_config[FLASH_PIPELINE_FAMILY_KEY], "ws_overlap")
+        self.assertNotIn(FLASH_TOPOLOGY_KEY, sparse_fa4_config)
         e2e_schedule_choices = flash_fragments[FLASH_E2E_SCHEDULE_KEY].choices
         self.assertEqual(e2e_schedule_choices[0], "16/4")
         self.assertEqual(set(e2e_schedule_choices), {"16/4", "8/2", "16/2", "xu"})
@@ -4184,7 +4199,7 @@ class TestCuteAutotuner(TestCase):
         )
         self.assertEqual(
             env_xu_long_fragments[FLASH_S_STAGE_KEY].search_choices,
-            (1, 2),
+            (2,),
         )
         self.assertEqual(
             env_xu_long_fragments[FLASH_SOFTMAX_REGS_KEY].choices,
@@ -4195,10 +4210,13 @@ class TestCuteAutotuner(TestCase):
         ):
             bad_topology_fragments = flash_autotune_fragments(64, 64, is_causal=False)
         self.assertEqual(
-            bad_topology_fragments[FLASH_TOPOLOGY_KEY].choices,
-            ("ws_overlap", "fa4"),
+            set(bad_topology_fragments[FLASH_PIPELINE_FAMILY_KEY].choices),
+            set(FLASH_PIPELINE_FAMILIES),
         )
-        self.assertIsNone(bad_topology_fragments[FLASH_TOPOLOGY_KEY].search_choices)
+        self.assertEqual(
+            bad_topology_fragments[FLASH_PIPELINE_FAMILY_KEY].choices[0],
+            "ws_overlap",
+        )
         self.assertEqual(
             set(bad_topology_fragments[FLASH_E2E_SCHEDULE_KEY].choices),
             {"16/4", "8/2", "16/2", "xu"},
@@ -4244,7 +4262,7 @@ class TestCuteAutotuner(TestCase):
             {"ascending", "descending"},
         )
         self.assertEqual(
-            causal_fragments[FLASH_TOPOLOGY_KEY].search_choices,
+            causal_fragments[FLASH_PIPELINE_FAMILY_KEY].search_choices,
             ("fa4", "ws_overlap"),
         )
         self.assertEqual(
@@ -4360,7 +4378,7 @@ class TestCuteAutotuner(TestCase):
             FLASH_KV_STAGE_KEY: (2,),
             FLASH_E2E_SCHEDULE_KEY: ("8/2",),
             FLASH_MASKED_E2E_SCHEDULE_KEY: ("16/4",),
-            FLASH_TOPOLOGY_KEY: ("fa4",),
+            FLASH_PIPELINE_FAMILY_KEY: ("fa4",),
             FLASH_DISC_PIPE_KEY: (4,),
             FLASH_E2E_OFFSET_KEY: (9,),
             FLASH_E2E_OFFSET0_KEY: (3,),
@@ -4382,12 +4400,12 @@ class TestCuteAutotuner(TestCase):
             )
         long_dense_fragments = flash_autotune_fragments(64, 64, is_causal=False)
         self.assertEqual(
-            long_dense_fragments[FLASH_TOPOLOGY_KEY].choices,
-            ("fa4", "ws_overlap"),
+            set(long_dense_fragments[FLASH_PIPELINE_FAMILY_KEY].choices),
+            set(FLASH_PIPELINE_FAMILIES),
         )
         self.assertEqual(
-            long_dense_fragments[FLASH_TOPOLOGY_KEY].search_choices,
-            ("fa4", "ws_overlap"),
+            long_dense_fragments[FLASH_PIPELINE_FAMILY_KEY].search_choices,
+            ("fa4", "ws_overlap", "fa4_clc"),
         )
         self.assertEqual(
             long_dense_fragments[FLASH_ROLE_MAP_KEY].search_choices,
@@ -4496,10 +4514,6 @@ class TestCuteAutotuner(TestCase):
             (0,),
         )
         self.assertEqual(
-            very_long_dense_fragments[FLASH_CLC_KEY].search_choices,
-            (False,),
-        )
-        self.assertEqual(
             very_long_dense_fragments[FLASH_CLC_HEADS_PER_BATCH_KEY].search_choices,
             (0,),
         )
@@ -4551,14 +4565,6 @@ class TestCuteAutotuner(TestCase):
             very_long_dense_fragments[FLASH_EPI_STG_GMEM_KEY].search_choices,
             ("stage",),
         )
-        self.assertEqual(
-            very_long_dense_fragments[FLASH_LOCAL_TMA_PARTITION_KEY].search_choices,
-            (False,),
-        )
-        self.assertEqual(
-            very_long_dense_fragments[FLASH_TENSOR_4D_TMA_KEY].search_choices,
-            (False,),
-        )
         common_very_long_dense_search_choices = {
             FLASH_PERSISTENT_CTAS_PER_SM_KEY: (1,),
             FLASH_CORR_TILE_SIZE_KEY: (8, 16),
@@ -4566,7 +4572,6 @@ class TestCuteAutotuner(TestCase):
             FLASH_DISC_PIPE_KEY: (1,),
             FLASH_P_STORE_REP_KEY: (16,),
             FLASH_S_LOAD_REP_KEY: (32,),
-            FLASH_CLC_KEY: (False,),
             FLASH_CLC_HEADS_PER_BATCH_KEY: (0,),
             FLASH_CLC_PDL_KEY: (False,),
             FLASH_CLC_STAGES_KEY: (1,),
@@ -4580,6 +4585,7 @@ class TestCuteAutotuner(TestCase):
         }
         very_long_dense_search_choices_by_num_kv = {
             256: {
+                FLASH_PIPELINE_FAMILY_KEY: ("fa4", "ws_overlap", "fa4_2cta"),
                 FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_OTHER_REGS_KEY: (40,),
                 FLASH_FIRST_LOAD_ORDER_KEY: (0,),
@@ -4588,14 +4594,12 @@ class TestCuteAutotuner(TestCase):
                 FLASH_PRECOMPUTE_QK_DESC_KEY: (False,),
                 FLASH_E2E_OFFSET0_KEY: (1,),
                 FLASH_KV_ORDER_KEY: ("descending",),
-                FLASH_CGA2_LOCAL_KEY: (False,),
                 FLASH_CORR_REGS_KEY: (64,),
                 FLASH_EPI_TMA_KEY: (True,),
-                FLASH_LOCAL_TMA_PARTITION_KEY: (False,),
-                FLASH_TENSOR_4D_TMA_KEY: (False,),
                 FLASH_KV_STAGE_KEY: (2, 3),
             },
             384: {
+                FLASH_PIPELINE_FAMILY_KEY: ("fa4", "ws_overlap", "fa4_2cta"),
                 FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_OTHER_REGS_KEY: (32,),
                 FLASH_FIRST_LOAD_ORDER_KEY: (0,),
@@ -4604,14 +4608,12 @@ class TestCuteAutotuner(TestCase):
                 FLASH_PRECOMPUTE_QK_DESC_KEY: (False,),
                 FLASH_E2E_OFFSET0_KEY: (3,),
                 FLASH_KV_ORDER_KEY: ("ascending",),
-                FLASH_CGA2_LOCAL_KEY: (False,),
                 FLASH_CORR_REGS_KEY: (72,),
                 FLASH_EPI_TMA_KEY: (True,),
-                FLASH_LOCAL_TMA_PARTITION_KEY: (False,),
-                FLASH_TENSOR_4D_TMA_KEY: (False,),
                 FLASH_KV_STAGE_KEY: (2, 3),
             },
             512: {
+                FLASH_PIPELINE_FAMILY_KEY: ("fa4", "ws_overlap", "fa4_2cta"),
                 FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_OTHER_REGS_KEY: (32,),
                 FLASH_FIRST_LOAD_ORDER_KEY: (4,),
@@ -4620,17 +4622,20 @@ class TestCuteAutotuner(TestCase):
                 FLASH_PRECOMPUTE_QK_DESC_KEY: (True,),
                 FLASH_E2E_OFFSET0_KEY: (0,),
                 FLASH_KV_ORDER_KEY: ("descending",),
-                FLASH_CGA2_LOCAL_KEY: (False,),
                 FLASH_CORR_REGS_KEY: (80,),
                 FLASH_CORR_TILE_SIZE_KEY: (16, 8),
                 FLASH_EPI_TMA_KEY: (False,),
                 FLASH_EPI_STG_KEY: (True,),
-                FLASH_LOCAL_TMA_PARTITION_KEY: (False,),
-                FLASH_TENSOR_4D_TMA_KEY: (False,),
                 FLASH_KV_STAGE_KEY: (2, 3),
                 FLASH_ROLE_MAP_KEY: ("fa4", "helion"),
             },
             1024: {
+                FLASH_PIPELINE_FAMILY_KEY: (
+                    "fa4_clc",
+                    "fa4",
+                    "ws_overlap",
+                    "fa4_2cta",
+                ),
                 FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_OTHER_REGS_KEY: (40,),
                 FLASH_FIRST_LOAD_ORDER_KEY: (0,),
@@ -4639,19 +4644,16 @@ class TestCuteAutotuner(TestCase):
                 FLASH_PRECOMPUTE_QK_DESC_KEY: (False,),
                 FLASH_E2E_OFFSET0_KEY: (0,),
                 FLASH_KV_ORDER_KEY: ("descending",),
-                FLASH_CGA2_LOCAL_KEY: (False,),
                 FLASH_PERSISTENT_CTAS_PER_SM_KEY: (1,),
                 FLASH_CORR_REGS_KEY: (72,),
                 FLASH_EPI_TMA_KEY: (True,),
                 FLASH_EPI_STG_KEY: (False,),
-                FLASH_LOCAL_TMA_PARTITION_KEY: (False,),
-                FLASH_TENSOR_4D_TMA_KEY: (False,),
                 FLASH_KV_STAGE_KEY: (2, 3),
-                FLASH_CLC_KEY: (True,),
                 FLASH_CLC_HEADS_PER_BATCH_KEY: (32,),
                 FLASH_CLC_STAGES_KEY: (2,),
             },
             2048: {
+                FLASH_PIPELINE_FAMILY_KEY: ("fa4", "ws_overlap"),
                 FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_CORR_TILE_SIZE_KEY: (8, 16),
                 FLASH_SOFTMAX_REGS_KEY: (192, 200),
@@ -4666,10 +4668,7 @@ class TestCuteAutotuner(TestCase):
                 FLASH_CORR_REGS_KEY: (80,),
                 FLASH_EPI_TMA_KEY: (False,),
                 FLASH_EPI_STG_KEY: (True,),
-                FLASH_LOCAL_TMA_PARTITION_KEY: (False,),
-                FLASH_TENSOR_4D_TMA_KEY: (False,),
                 FLASH_KV_STAGE_KEY: (3, 2),
-                FLASH_CGA2_LOCAL_KEY: (False,),
             },
         }
         for num_kv, expected in very_long_dense_search_choices_by_num_kv.items():
@@ -4768,9 +4767,6 @@ class TestCuteAutotuner(TestCase):
             (False, True),
         )
         self.assertEqual(
-            long_dense_fragments[FLASH_CLC_KEY].search_choices, (False, True)
-        )
-        self.assertEqual(
             long_dense_fragments[FLASH_CLC_HEADS_PER_BATCH_KEY].search_choices,
             (0, 32, 16, 64),
         )
@@ -4779,14 +4775,6 @@ class TestCuteAutotuner(TestCase):
         )
         self.assertEqual(
             long_dense_fragments[FLASH_CLC_STAGES_KEY].search_choices, (2, 3)
-        )
-        self.assertEqual(
-            long_dense_fragments[FLASH_LOCAL_TMA_PARTITION_KEY].search_choices,
-            (False, True),
-        )
-        self.assertEqual(
-            long_dense_fragments[FLASH_TENSOR_4D_TMA_KEY].search_choices,
-            (False, True),
         )
         self.assertEqual(
             long_dense_fragments[FLASH_PACKED_REDUCE_KEY].search_choices, (True,)
@@ -4798,7 +4786,9 @@ class TestCuteAutotuner(TestCase):
             requires_ws_overlap=True,
         )
         self.assertEqual(sparse_fragments[FLASH_PACKED_REDUCE_KEY].choices[0], True)
-        self.assertEqual(sparse_fragments[FLASH_TOPOLOGY_KEY].choices, ("ws_overlap",))
+        self.assertEqual(
+            sparse_fragments[FLASH_PIPELINE_FAMILY_KEY].choices, ("ws_overlap",)
+        )
         with unittest.mock.patch.dict(
             os.environ, {"HELION_CUTE_FLASH_PACKED_REDUCE": "0"}
         ):
@@ -4807,7 +4797,7 @@ class TestCuteAutotuner(TestCase):
             )
         self.assertEqual(
             packed_reduce_off_fragments[FLASH_PACKED_REDUCE_KEY].search_choices,
-            (False, True),
+            (True,),
         )
         self.assertEqual(
             set(long_dense_fragments[FLASH_CORR_REGS_KEY].choices),
@@ -4821,7 +4811,7 @@ class TestCuteAutotuner(TestCase):
             {32, 40, 48, 56, 64, 80},
         )
         self.assertEqual(
-            long_dense_fragments[FLASH_TOPOLOGY_KEY].differential_mutation(
+            long_dense_fragments[FLASH_PIPELINE_FAMILY_KEY].differential_mutation(
                 "ws_overlap", "fa4", "fa4"
             ),
             "ws_overlap",
@@ -4846,11 +4836,15 @@ class TestCuteAutotuner(TestCase):
         )
         odd_bound = flash_attention.bind((q_odd, k_odd, v_odd))
         odd_fragments = odd_bound.config_spec._flat_fields()
-        # Odd-KV shapes keep stale fa4-only values in the enum surface for
-        # best-config cache transfer, but resolve_flash_config() clamps them back
-        # to ws_overlap/no-op values before codegen.
+        # Odd-KV shapes keep all families in the manual enum surface for cache
+        # transfer, but only search ws_overlap and clamp stale fa4 families.
         self.assertEqual(
-            odd_fragments[FLASH_TOPOLOGY_KEY].choices, ("ws_overlap", "fa4")
+            set(odd_fragments[FLASH_PIPELINE_FAMILY_KEY].choices),
+            set(FLASH_PIPELINE_FAMILIES),
+        )
+        self.assertEqual(
+            odd_fragments[FLASH_PIPELINE_FAMILY_KEY].search_choices,
+            ("ws_overlap",),
         )
         self.assertEqual(set(odd_fragments[FLASH_DISC_PIPE_KEY].choices), {1, 2, 3, 4})
         self.assertEqual(
@@ -4890,6 +4884,132 @@ class TestCuteAutotuner(TestCase):
         )
         long_bound = flash_attention.bind((long_q, long_k, long_v))
         long_gen = ConfigGeneration(long_bound.config_spec)
+
+        legacy_compound = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_topology="fa4",
+            cute_flash_clc=True,
+            cute_flash_local_tma_partition=True,
+            cute_flash_tensor_4d_tma=True,
+            cute_flash_clc_heads_per_batch=32,
+            cute_flash_clc_pdl=True,
+            cute_flash_clc_stages=3,
+            cute_flash_q_tile_count=-1,
+            cute_flash_mma_interleave=999,
+        )
+        family_compound = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_clc_local_tma_4d",
+            cute_flash_clc_heads_per_batch=32,
+            cute_flash_clc_pdl=True,
+            cute_flash_clc_stages=3,
+        )
+        # Legacy configs without the family slot flatten identically, including
+        # before normalization. Dead knobs do not contribute to identity.
+        self.assertEqual(
+            long_gen.flatten(legacy_compound), long_gen.flatten(family_compound)
+        )
+        long_bound.config_spec.normalize(legacy_compound)
+        long_bound.config_spec.normalize(family_compound)
+        self.assertEqual(legacy_compound, family_compound)
+        self.assertEqual(
+            legacy_compound.config[FLASH_PIPELINE_FAMILY_KEY],
+            "fa4_clc_local_tma_4d",
+        )
+        for legacy_key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS:
+            self.assertNotIn(legacy_key, legacy_compound)
+        self.assertNotIn(FLASH_Q_TILE_COUNT_KEY, legacy_compound)
+        self.assertNotIn(FLASH_MMA_INTERLEAVE_KEY, legacy_compound)
+
+        clc_q, clc_k, clc_v = (
+            torch.empty(1, 1, 131072, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        clc_bound = flash_attention.bind((clc_q, clc_k, clc_v))
+        legacy_clc = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_topology="fa4",
+            cute_flash_clc=True,
+        )
+        family_clc = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_clc",
+        )
+        clc_bound.config_spec.normalize(legacy_clc)
+        clc_bound.config_spec.normalize(family_clc)
+        self.assertEqual(legacy_clc, family_clc)
+        self.assertEqual(legacy_clc.config[FLASH_CLC_HEADS_PER_BATCH_KEY], 32)
+        self.assertEqual(legacy_clc.config[FLASH_CLC_STAGES_KEY], 2)
+
+        family_authoritative = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4",
+            cute_flash_topology="ws_overlap",
+            cute_flash_use_2cta=True,
+            cute_flash_cga2_local=True,
+            cute_flash_clc=True,
+            cute_flash_local_tma_partition=True,
+            cute_flash_tensor_4d_tma=True,
+        )
+        long_bound.config_spec.normalize(family_authoritative, _fix_invalid=True)
+        self.assertEqual(family_authoritative.config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
+        for legacy_key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS:
+            self.assertNotIn(legacy_key, family_authoritative)
+
+        inactive_children = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4",
+            cute_flash_persistent=False,
+            cute_flash_persistent_ctas_per_sm=4,
+            cute_flash_recompute_tile_coords=True,
+            cute_flash_clc_heads_per_batch=64,
+            cute_flash_clc_pdl=True,
+            cute_flash_clc_stages=3,
+        )
+        long_bound.config_spec.normalize(inactive_children, _fix_invalid=True)
+        self.assertEqual(inactive_children.config[FLASH_PERSISTENT_CTAS_PER_SM_KEY], 1)
+        self.assertFalse(inactive_children.config[FLASH_RECOMPUTE_TILE_COORDS_KEY])
+        self.assertEqual(inactive_children.config[FLASH_CLC_HEADS_PER_BATCH_KEY], 0)
+        self.assertFalse(inactive_children.config[FLASH_CLC_PDL_KEY])
+        self.assertEqual(inactive_children.config[FLASH_CLC_STAGES_KEY], 1)
+
+        two_cta_q, two_cta_k, two_cta_v = (
+            torch.empty(1, 1, 65536, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        two_cta_bound = flash_attention.bind((two_cta_q, two_cta_k, two_cta_v))
+        two_cta_alias = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_2cta",
+            cute_flash_epi_tma=False,
+            cute_flash_epi_stg=True,
+            cute_flash_epi_stg_store="whole",
+            cute_flash_epi_stg_gmem="pair",
+            cute_flash_p_store_rep=32,
+            cute_flash_s_load_rep=16,
+            cute_flash_softmax_disc=True,
+            cute_flash_disc_pipe=4,
+            cute_flash_split_p_arrive=False,
+            cute_flash_precompute_qk_desc=False,
+        )
+        two_cta_canonical = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_2cta",
+            cute_flash_epi_tma=True,
+            cute_flash_epi_stg=False,
+            cute_flash_epi_stg_store="slice",
+            cute_flash_epi_stg_gmem="stage",
+            cute_flash_p_store_rep=16,
+            cute_flash_s_load_rep=32,
+            cute_flash_softmax_disc=False,
+            cute_flash_disc_pipe=1,
+            cute_flash_split_p_arrive=True,
+            cute_flash_precompute_qk_desc=True,
+        )
+        two_cta_bound.config_spec.normalize(two_cta_alias, _fix_invalid=True)
+        two_cta_bound.config_spec.normalize(two_cta_canonical, _fix_invalid=True)
+        self.assertEqual(two_cta_alias, two_cta_canonical)
+
         long_manual_xu = helion.Config(
             block_sizes=[1, 128, 128],
             cute_flash_e2e_schedule="xu",
@@ -4902,23 +5022,40 @@ class TestCuteAutotuner(TestCase):
             cute_flash_topology="ws_overlap",
         )
         long_bound.config_spec.normalize(long_manual_ws)
-        self.assertEqual(long_manual_ws.config[FLASH_TOPOLOGY_KEY], "ws_overlap")
+        self.assertEqual(long_manual_ws.config[FLASH_PIPELINE_FAMILY_KEY], "ws_overlap")
+        self.assertNotIn(FLASH_TOPOLOGY_KEY, long_manual_ws)
         self.assertEqual(long_manual_ws.config[FLASH_E2E_SCHEDULE_KEY], "8/2")
         self.assertEqual(long_manual_ws.config[FLASH_E2E_OFFSET_KEY], 0)
         self.assertEqual(long_manual_ws.config[FLASH_DISC_PIPE_KEY], 1)
         self.assertFalse(long_manual_ws.config[FLASH_PACKED_REDUCE_KEY])
+        ws_offset_alias = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="ws_overlap",
+            cute_flash_e2e_offset=7,
+            cute_flash_e2e_offset0=11,
+        )
+        ws_offset_canonical = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="ws_overlap",
+        )
+        long_bound.config_spec.normalize(ws_offset_alias)
+        long_bound.config_spec.normalize(ws_offset_canonical)
+        self.assertEqual(ws_offset_alias, ws_offset_canonical)
         long_manual_bad_topology = helion.Config(
             block_sizes=[1, 128, 128],
             cute_flash_topology="bad",
         )
         long_bound.config_spec.normalize(long_manual_bad_topology, _fix_invalid=True)
-        self.assertEqual(long_manual_bad_topology.config[FLASH_TOPOLOGY_KEY], "fa4")
+        self.assertEqual(
+            long_manual_bad_topology.config[FLASH_PIPELINE_FAMILY_KEY], "ws_overlap"
+        )
+        self.assertNotIn(FLASH_TOPOLOGY_KEY, long_manual_bad_topology)
         self.assertEqual(
             long_manual_bad_topology.config[FLASH_E2E_SCHEDULE_KEY],
             "8/2",
         )
-        self.assertEqual(long_manual_bad_topology.config[FLASH_DISC_PIPE_KEY], 3)
-        self.assertTrue(long_manual_bad_topology.config[FLASH_PACKED_REDUCE_KEY])
+        self.assertEqual(long_manual_bad_topology.config[FLASH_DISC_PIPE_KEY], 1)
+        self.assertFalse(long_manual_bad_topology.config[FLASH_PACKED_REDUCE_KEY])
         long_manual_threshold = helion.Config(
             block_sizes=[1, 128, 128],
             cute_flash_rescale_threshold=12.0,
@@ -4952,12 +5089,12 @@ class TestCuteAutotuner(TestCase):
             cute_flash_packed_reduce=False,
         )
         long_bound.config_spec.normalize(long_manual_structural)
-        self.assertEqual(long_manual_structural.config[FLASH_S_STAGE_KEY], 1)
+        self.assertEqual(long_manual_structural.config[FLASH_S_STAGE_KEY], 2)
         self.assertEqual(long_manual_structural.config[FLASH_KV_STAGE_KEY], 3)
         self.assertEqual(long_manual_structural.config[FLASH_DISC_PIPE_KEY], 2)
         self.assertTrue(long_manual_structural.config[FLASH_EPI_TMA_KEY])
         self.assertFalse(long_manual_structural.config[FLASH_PERSISTENT_KEY])
-        self.assertFalse(long_manual_structural.config[FLASH_PACKED_REDUCE_KEY])
+        self.assertTrue(long_manual_structural.config[FLASH_PACKED_REDUCE_KEY])
         for config in (
             long_manual_xu,
             long_manual_ws,
@@ -4979,9 +5116,12 @@ class TestCuteAutotuner(TestCase):
             self.assertEqual(random_long[FLASH_MASKED_E2E_SCHEDULE_KEY], "inherit")
             self.assertIn(random_long[FLASH_E2E_OFFSET_KEY], set(range(16)))
             self.assertIn(random_long[FLASH_E2E_OFFSET0_KEY], set(range(16)))
-            self.assertIn(random_long[FLASH_TOPOLOGY_KEY], {"fa4", "ws_overlap"})
+            self.assertIn(
+                random_long[FLASH_PIPELINE_FAMILY_KEY],
+                {"fa4", "ws_overlap", "fa4_clc"},
+            )
             self.assertIn(random_long[FLASH_SOFTMAX_DISC_KEY], {False, True})
-            self.assertIn(random_long[FLASH_DISC_PIPE_KEY], {2, 3, 4})
+            self.assertIn(random_long[FLASH_DISC_PIPE_KEY], {1, 2, 3, 4})
             self.assertIn(random_long[FLASH_EPI_TMA_KEY], {False, True})
             self.assertIn(random_long[FLASH_EPI_STG_KEY], {False, True})
             self.assertIn(random_long[FLASH_EPI_STG_STORE_KEY], {"slice", "whole"})
@@ -5000,30 +5140,38 @@ class TestCuteAutotuner(TestCase):
             self.assertIn(random_long[FLASH_SKIP_RESCALE_STATS_KEY], {False, True})
             self.assertIn(random_long[FLASH_OTHER_REGS_KEY], {32, 40, 48, 56, 64, 80})
             self.assertIn(random_long[FLASH_CORR_TILE_SIZE_KEY], {8, 16, 32})
-            self.assertIn(random_long[FLASH_CLC_KEY], {False, True})
             self.assertIn(random_long[FLASH_CLC_PDL_KEY], {False, True})
             self.assertIn(random_long[FLASH_CLC_STAGES_KEY], {1, 2, 3})
-            self.assertIn(random_long[FLASH_LOCAL_TMA_PARTITION_KEY], {False, True})
-            self.assertIn(random_long[FLASH_TENSOR_4D_TMA_KEY], {False, True})
             self.assertIn(
                 random_long[FLASH_CLC_HEADS_PER_BATCH_KEY],
                 {0, 1, 2, 4, 8, 16, 32, 64},
             )
             self.assertTrue(random_long[FLASH_PACKED_REDUCE_KEY])
+            effective_values = flash_effective_config_values(
+                flash_config_from_config(random_long, 64, 64)
+            )
+            for key, value in effective_values.items():
+                self.assertEqual(random_long[key], value, key)
+            for legacy_key in FLASH_LEGACY_CONFIG_KEYS:
+                self.assertNotIn(legacy_key, random_long)
         odd_fa4_without_offset = helion.Config(
             block_sizes=[1, 128, 128],
             cute_flash_topology="fa4",
             cute_flash_e2e_schedule="16/4",
         )
         odd_bound.config_spec.normalize(odd_fa4_without_offset)
+        self.assertEqual(
+            odd_fa4_without_offset.config[FLASH_PIPELINE_FAMILY_KEY], "ws_overlap"
+        )
+        self.assertNotIn(FLASH_TOPOLOGY_KEY, odd_fa4_without_offset)
         self.assertEqual(odd_fa4_without_offset.config[FLASH_E2E_OFFSET_KEY], 0)
-        invalid_narrow_offset = helion.Config(
+        inactive_narrow_offset = helion.Config(
             block_sizes=[1, 128, 128],
             cute_flash_e2e_schedule="8/2",
             cute_flash_e2e_offset=13,
         )
-        with self.assertRaises(exc.InvalidConfig):
-            odd_bound.config_spec.normalize(invalid_narrow_offset)
+        odd_bound.config_spec.normalize(inactive_narrow_offset)
+        self.assertEqual(inactive_narrow_offset.config[FLASH_E2E_OFFSET_KEY], 0)
         with patch.dict(os.environ, {"HELION_CUTE_FLASH_E2E_SCHEDULE": "xu"}):
             xu_default_fragments = flash_autotune_fragments(64, 2, is_causal=False)
         self.assertEqual(

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -32,6 +32,7 @@ from helion._compiler.autotuner_heuristics.triton import (
 from helion._compiler.autotuner_heuristics.triton import _h100_matmul_tile
 from helion._compiler.backend import CuteBackend
 from helion._compiler.backend import TritonBackend
+from helion._compiler.cute.cute_flash import FLASH_AUTOTUNE_CONFIG_KEYS
 from helion._compiler.cute.cute_flash import FLASH_CAUSAL_KV_ORDER_KEY
 from helion._compiler.cute.cute_flash import FLASH_CAUSAL_LOOP_SPLIT_KEY
 from helion._compiler.cute.cute_flash import FLASH_CAUSAL_LPT_SWIZZLE_KEY
@@ -54,6 +55,8 @@ from helion._compiler.cute.cute_flash import FLASH_EPI_TMA_KEY
 from helion._compiler.cute.cute_flash import FLASH_FIRST_LOAD_ORDER_KEY
 from helion._compiler.cute.cute_flash import FLASH_KV_ORDER_KEY
 from helion._compiler.cute.cute_flash import FLASH_KV_STAGE_KEY
+from helion._compiler.cute.cute_flash import FLASH_LEGACY_CONFIG_KEYS
+from helion._compiler.cute.cute_flash import FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS
 from helion._compiler.cute.cute_flash import FLASH_LOCAL_TMA_PARTITION_KEY
 from helion._compiler.cute.cute_flash import FLASH_MASKED_E2E_SCHEDULE_KEY
 from helion._compiler.cute.cute_flash import FLASH_MMA_INTERLEAVE_KEY
@@ -62,6 +65,8 @@ from helion._compiler.cute.cute_flash import FLASH_P_STORE_REP_KEY
 from helion._compiler.cute.cute_flash import FLASH_PACKED_REDUCE_KEY
 from helion._compiler.cute.cute_flash import FLASH_PERSISTENT_CTAS_PER_SM_KEY
 from helion._compiler.cute.cute_flash import FLASH_PERSISTENT_KEY
+from helion._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILIES
+from helion._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILY_KEY
 from helion._compiler.cute.cute_flash import FLASH_PRECOMPUTE_QK_DESC_KEY
 from helion._compiler.cute.cute_flash import FLASH_Q_TILE_COUNT_KEY
 from helion._compiler.cute.cute_flash import FLASH_RECOMPUTE_TILE_COORDS_KEY
@@ -77,6 +82,7 @@ from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_REGS_KEY
 from helion._compiler.cute.cute_flash import FLASH_SPLIT_P_ARRIVE_KEY
 from helion._compiler.cute.cute_flash import FLASH_TENSOR_4D_TMA_KEY
 from helion._compiler.cute.cute_flash import FLASH_TOPOLOGY_KEY
+from helion._compiler.cute.cute_flash import FLASH_USE_2CTA_KEY
 from helion._compiler.cute.cute_flash import flash_attention_seed_config
 from helion._compiler.cute.cute_flash import flash_attention_seed_configs
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
@@ -335,7 +341,7 @@ class TestAutotunerHeuristic(TestCase):
         self.assertTrue(spec.autotune_seed_configs())
 
         config_gen = spec.create_config_generation()
-        self.assertIn(FLASH_TOPOLOGY_KEY, config_gen._config_value_priors)
+        self.assertIn(FLASH_PIPELINE_FAMILY_KEY, config_gen._config_value_priors)
         self.assertIn(FLASH_CAUSAL_KV_ORDER_KEY, config_gen._config_value_priors)
         population = config_gen.random_population(4)
 
@@ -1663,8 +1669,25 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             )
 
     def test_cute_flash_accepts_extra_knobs(self) -> None:
-        self.assertIn(FLASH_MMA_INTERLEAVE_KEY, FLASH_CONFIG_KEYS)
-        self.assertIn(FLASH_Q_TILE_COUNT_KEY, FLASH_CONFIG_KEYS)
+        self.assertIn(FLASH_PIPELINE_FAMILY_KEY, FLASH_AUTOTUNE_CONFIG_KEYS)
+        self.assertIn(FLASH_PIPELINE_FAMILY_KEY, FLASH_CONFIG_KEYS)
+        self.assertEqual(len(FLASH_PIPELINE_FAMILIES), 13)
+        self.assertEqual(
+            set(FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS),
+            {
+                FLASH_TOPOLOGY_KEY,
+                FLASH_CGA2_LOCAL_KEY,
+                FLASH_CLC_KEY,
+                FLASH_LOCAL_TMA_PARTITION_KEY,
+                FLASH_TENSOR_4D_TMA_KEY,
+                FLASH_USE_2CTA_KEY,
+            },
+        )
+        for legacy_key in FLASH_LEGACY_CONFIG_KEYS:
+            self.assertIn(legacy_key, FLASH_CONFIG_KEYS)
+            self.assertNotIn(legacy_key, FLASH_AUTOTUNE_CONFIG_KEYS)
+        self.assertIn(FLASH_MMA_INTERLEAVE_KEY, FLASH_LEGACY_CONFIG_KEYS)
+        self.assertIn(FLASH_Q_TILE_COUNT_KEY, FLASH_LEGACY_CONFIG_KEYS)
         self.assertIn(FLASH_PERSISTENT_CTAS_PER_SM_KEY, FLASH_CONFIG_KEYS)
         self.assertIn(FLASH_P_STORE_REP_KEY, FLASH_CONFIG_KEYS)
         self.assertIn(FLASH_S_LOAD_REP_KEY, FLASH_CONFIG_KEYS)
@@ -1698,7 +1721,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             assert seed is not None
             config = seed.config
             self.assertEqual(config["block_sizes"], [1, 128, 128])
-            self.assertEqual(config[FLASH_TOPOLOGY_KEY], "fa4")
+            self.assertEqual(config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
             self.assertEqual(config[FLASH_S_STAGE_KEY], 2)
             self.assertEqual(config[FLASH_KV_STAGE_KEY], 3)
             self.assertTrue(config[FLASH_PERSISTENT_KEY])
@@ -1723,9 +1746,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             self.assertEqual(config[FLASH_RESCALE_THRESHOLD_KEY], 8.0)
             self.assertFalse(config[FLASH_SKIP_RESCALE_STATS_KEY])
             self.assertFalse(config[FLASH_PACKED_REDUCE_KEY])
-            self.assertFalse(config[FLASH_CLC_KEY])
-            self.assertFalse(config[FLASH_LOCAL_TMA_PARTITION_KEY])
-            self.assertFalse(config[FLASH_TENSOR_4D_TMA_KEY])
+            for legacy_key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS:
+                self.assertNotIn(legacy_key, config)
 
         for (
             num_kv,
@@ -1893,7 +1915,17 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             assert seed is not None
             config = seed.config
             self.assertEqual(config["block_sizes"], [1, 128, 128])
-            self.assertEqual(config[FLASH_TOPOLOGY_KEY], "fa4")
+            if cga2_local:
+                expected_family = "fa4_cga2_local"
+            elif clc:
+                expected_family = (
+                    "fa4_clc_local_tma" if local_tma_partition else "fa4_clc"
+                )
+            elif local_tma_partition:
+                expected_family = "fa4_local_tma"
+            else:
+                expected_family = "fa4"
+            self.assertEqual(config[FLASH_PIPELINE_FAMILY_KEY], expected_family)
             self.assertEqual(config[FLASH_S_STAGE_KEY], 2)
             self.assertEqual(config[FLASH_KV_STAGE_KEY], 2)
             self.assertTrue(config[FLASH_PERSISTENT_KEY])
@@ -1922,16 +1954,14 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             self.assertEqual(config[FLASH_RESCALE_CHUNK_COLS_KEY], rescale_chunk_cols)
             self.assertEqual(config[FLASH_SKIP_RESCALE_STATS_KEY], skip_rescale_stats)
             self.assertTrue(config[FLASH_PACKED_REDUCE_KEY])
-            self.assertEqual(config[FLASH_CGA2_LOCAL_KEY], cga2_local)
-            self.assertEqual(config[FLASH_CLC_KEY], clc)
             self.assertEqual(config[FLASH_CLC_HEADS_PER_BATCH_KEY], clc_heads_per_batch)
-            self.assertEqual(config[FLASH_LOCAL_TMA_PARTITION_KEY], local_tma_partition)
-            self.assertFalse(config[FLASH_TENSOR_4D_TMA_KEY])
+            for legacy_key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS:
+                self.assertNotIn(legacy_key, config)
 
         very_long_seed = flash_attention_seed_config(64, 2048)
         assert very_long_seed is not None
         very_long_config = very_long_seed.config
-        self.assertEqual(very_long_config[FLASH_TOPOLOGY_KEY], "fa4")
+        self.assertEqual(very_long_config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
         self.assertEqual(very_long_config[FLASH_KV_STAGE_KEY], 3)
         self.assertEqual(very_long_config[FLASH_E2E_SCHEDULE_KEY], "16/4")
         self.assertEqual(very_long_config[FLASH_E2E_OFFSET_KEY], 0)
@@ -1952,8 +1982,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertEqual(very_long_config[FLASH_RESCALE_THRESHOLD_KEY], 8.0)
         self.assertEqual(very_long_config[FLASH_RESCALE_CHUNK_COLS_KEY], 8)
         self.assertTrue(very_long_config[FLASH_PACKED_REDUCE_KEY])
-        self.assertFalse(very_long_config[FLASH_LOCAL_TMA_PARTITION_KEY])
-        self.assertFalse(very_long_config[FLASH_TENSOR_4D_TMA_KEY])
+        for legacy_key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS:
+            self.assertNotIn(legacy_key, very_long_config)
 
         dense_sp_seed = flash_attention_seed_config(
             64,
@@ -1971,9 +2001,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertEqual(dense_sp_config[FLASH_KV_ORDER_KEY], "descending")
         self.assertEqual(dense_sp_config[FLASH_CORR_REGS_KEY], 80)
         self.assertEqual(dense_sp_config[FLASH_OTHER_REGS_KEY], 32)
-        self.assertFalse(dense_sp_config[FLASH_CGA2_LOCAL_KEY])
-        self.assertTrue(dense_sp_config[FLASH_LOCAL_TMA_PARTITION_KEY])
-        self.assertTrue(dense_sp_config[FLASH_TENSOR_4D_TMA_KEY])
+        self.assertEqual(dense_sp_config[FLASH_PIPELINE_FAMILY_KEY], "fa4_local_tma_4d")
         dense_sp_512_seed = flash_attention_seed_config(
             64,
             512,
@@ -1996,7 +2024,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
 
         short_seed = flash_attention_seed_config(64, 8)
         assert short_seed is not None
-        self.assertEqual(short_seed.config[FLASH_TOPOLOGY_KEY], "fa4")
+        self.assertEqual(short_seed.config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
         self.assertNotIn(FLASH_E2E_OFFSET_KEY, short_seed.config)
 
         sparse_seed = flash_attention_seed_config(
@@ -2006,7 +2034,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             requires_ws_overlap=True,
         )
         assert sparse_seed is not None
-        self.assertEqual(sparse_seed.config[FLASH_TOPOLOGY_KEY], "ws_overlap")
+        self.assertEqual(sparse_seed.config[FLASH_PIPELINE_FAMILY_KEY], "ws_overlap")
         self.assertTrue(sparse_seed.config[FLASH_PACKED_REDUCE_KEY])
         self.assertNotIn(FLASH_E2E_OFFSET_KEY, sparse_seed.config)
 
@@ -2050,7 +2078,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             assert seed is not None
             config = seed.config
             self.assertEqual(config["block_sizes"], [1, 128, 128])
-            self.assertEqual(config[FLASH_TOPOLOGY_KEY], "fa4")
+            self.assertEqual(config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
             self.assertEqual(config[FLASH_S_STAGE_KEY], 2)
             self.assertEqual(config[FLASH_KV_STAGE_KEY], 2)
             self.assertFalse(config[FLASH_PERSISTENT_KEY])
@@ -2206,7 +2234,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         seed = heuristic.get_seed_config(bound.env, bound.host_function.device_ir)
         assert seed is not None
         self.assertEqual(seed.config["block_sizes"], [1, 128, 128])
-        self.assertEqual(seed.config[FLASH_TOPOLOGY_KEY], "fa4")
+        self.assertEqual(seed.config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
         self.assertNotIn(FLASH_E2E_OFFSET_KEY, seed.config)
         self.assertIn(seed, bound.config_spec.compiler_seed_configs)
         self.assertIsNone(bound.config_spec.compiler_default_config)
@@ -2247,9 +2275,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertEqual(dense_2048_seed.config[FLASH_CORR_TILE_SIZE_KEY], 16)
         self.assertEqual(dense_2048_seed.config[FLASH_RESCALE_CHUNK_COLS_KEY], 16)
         self.assertFalse(dense_2048_seed.config[FLASH_PACKED_REDUCE_KEY])
-        self.assertFalse(dense_2048_seed.config[FLASH_CLC_KEY])
-        self.assertFalse(dense_2048_seed.config[FLASH_LOCAL_TMA_PARTITION_KEY])
-        self.assertFalse(dense_2048_seed.config[FLASH_TENSOR_4D_TMA_KEY])
+        self.assertEqual(dense_2048_seed.config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
         self.assertIn(
             dense_2048_seed, dense_2048_bound.config_spec.compiler_seed_configs
         )
@@ -2279,9 +2305,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertEqual(dense_8192_seed.config[FLASH_RESCALE_CHUNK_COLS_KEY], 16)
         self.assertEqual(dense_8192_seed.config[FLASH_RESCALE_THRESHOLD_KEY], 8.0)
         self.assertTrue(dense_8192_seed.config[FLASH_PACKED_REDUCE_KEY])
-        self.assertFalse(dense_8192_seed.config[FLASH_CLC_KEY])
-        self.assertFalse(dense_8192_seed.config[FLASH_LOCAL_TMA_PARTITION_KEY])
-        self.assertFalse(dense_8192_seed.config[FLASH_TENSOR_4D_TMA_KEY])
+        self.assertEqual(dense_8192_seed.config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
         self.assertNotIn(FLASH_CAUSAL_LPT_SWIZZLE_KEY, dense_8192_seed.config)
         dense_8192_gen = ConfigGeneration(dense_8192_bound.config_spec)
         dense_8192_roundtrip = dense_8192_gen.unflatten(
@@ -2306,7 +2330,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         assert causal_hd64_seed is not None
         self.assertEqual(causal_hd64_seed.config["block_sizes"], [1, 128, 128])
-        self.assertEqual(causal_hd64_seed.config[FLASH_TOPOLOGY_KEY], "fa4")
+        self.assertEqual(causal_hd64_seed.config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
         self.assertTrue(causal_hd64_seed.config[FLASH_PACKED_REDUCE_KEY])
         self.assertIn(
             causal_hd64_seed, causal_hd64_bound.config_spec.compiler_seed_configs
@@ -2397,7 +2421,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             causal_hd128_bound.env, causal_hd128_bound.host_function.device_ir
         )
         assert causal_hd128_seed is not None
-        self.assertEqual(causal_hd128_seed.config[FLASH_TOPOLOGY_KEY], "fa4")
+        self.assertEqual(causal_hd128_seed.config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
         self.assertEqual(causal_hd128_seed.config[FLASH_KV_STAGE_KEY], 2)
 
         # fp32 attention is not flash-eligible (the kernel hardcodes fp16).

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from concurrent.futures import ThreadPoolExecutor
+import dataclasses
 from dataclasses import dataclass
 import gc
 import importlib
@@ -4212,6 +4213,7 @@ class TestCuteBackend(TestCase):
             dense_hd128 = resolve_flash_config(128, 512, force_two_cta)
 
         self.assertTrue(dense_64k.use_2cta_instrs)
+        self.assertEqual(dense_64k.pipeline_family, "fa4_2cta")
         self.assertTrue(dense_64k.precompute_qk_desc)
         self.assertTrue(dense_64k.epi_tma)
         self.assertFalse(dense_64k.epi_stg)
@@ -4223,38 +4225,212 @@ class TestCuteBackend(TestCase):
         self.assertTrue(dense_32k.use_2cta_instrs)
         self.assertTrue(dense_128k.use_2cta_instrs)
         self.assertFalse(dense_unaligned.use_2cta_instrs)
+        self.assertEqual(dense_unaligned.pipeline_family, "fa4")
         self.assertFalse(dense_256k.use_2cta_instrs)
+        self.assertEqual(dense_256k.pipeline_family, "fa4")
         self.assertFalse(dense_bf16.use_2cta_instrs)
+        self.assertEqual(dense_bf16.pipeline_family, "fa4")
         self.assertFalse(causal.use_2cta_instrs)
+        self.assertEqual(causal.pipeline_family, "fa4")
         self.assertTrue(dense_hd128.use_2cta_instrs)
         self.assertFalse(dense_hd128.precompute_qk_desc)
 
         fragments = _cute_flash.flash_autotune_fragments(64, 512)
-        two_cta = fragments[_cute_flash.FLASH_USE_2CTA_KEY]
+        family = fragments[_cute_flash.FLASH_PIPELINE_FAMILY_KEY]
         epi_tma = fragments[_cute_flash.FLASH_EPI_TMA_KEY]
-        self.assertEqual(set(two_cta.search_choices or ()), {False, True})
+        self.assertEqual(
+            set(family.search_choices or ()),
+            {"fa4", "ws_overlap", "fa4_2cta"},
+        )
         self.assertEqual(epi_tma.search_choices, (False,))
 
         eligible_32k = _cute_flash.flash_autotune_fragments(64, 256)
-        self.assertEqual(
-            set(eligible_32k[_cute_flash.FLASH_USE_2CTA_KEY].search_choices or ()),
-            {False, True},
+        self.assertIn(
+            "fa4_2cta",
+            eligible_32k[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices or (),
         )
         eligible_128k = _cute_flash.flash_autotune_fragments(64, 1024)
-        self.assertEqual(
-            set(eligible_128k[_cute_flash.FLASH_USE_2CTA_KEY].search_choices or ()),
-            {False, True},
+        self.assertIn(
+            "fa4_2cta",
+            eligible_128k[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices or (),
         )
         ineligible_unaligned = _cute_flash.flash_autotune_fragments(64, 258)
-        self.assertEqual(
-            ineligible_unaligned[_cute_flash.FLASH_USE_2CTA_KEY].search_choices,
-            (False,),
+        self.assertNotIn(
+            "fa4_2cta",
+            ineligible_unaligned[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices
+            or (),
         )
         ineligible = _cute_flash.flash_autotune_fragments(64, 2048)
-        self.assertEqual(
-            ineligible[_cute_flash.FLASH_USE_2CTA_KEY].search_choices,
-            (False,),
+        self.assertNotIn(
+            "fa4_2cta",
+            ineligible[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices or (),
         )
+
+    def test_flash_attention_pipeline_family_resolution(self) -> None:
+        expected_flags = {
+            "ws_overlap": ("ws_overlap", False, False, False, False, False),
+            "fa4": ("fa4", False, False, False, False, False),
+            "fa4_tma_4d": ("fa4", False, False, False, False, True),
+            "fa4_local_tma": ("fa4", False, False, False, True, False),
+            "fa4_local_tma_4d": ("fa4", False, False, False, True, True),
+            "fa4_cga2_local": ("fa4", False, True, False, False, False),
+            "fa4_cga2_local_tma_4d": (
+                "fa4",
+                False,
+                True,
+                False,
+                False,
+                True,
+            ),
+            "fa4_2cta": ("fa4", True, False, False, False, False),
+            "fa4_2cta_tma_4d": ("fa4", True, False, False, False, True),
+            "fa4_clc": ("fa4", False, False, True, False, False),
+            "fa4_clc_tma_4d": ("fa4", False, False, True, False, True),
+            "fa4_clc_local_tma": ("fa4", False, False, True, True, False),
+            "fa4_clc_local_tma_4d": ("fa4", False, False, True, True, True),
+        }
+        self.assertEqual(set(expected_flags), set(_cute_flash.FLASH_PIPELINE_FAMILIES))
+
+        with patch.dict(os.environ, {}, clear=True):
+            for family_name, expected in expected_flags.items():
+                with self.subTest(family=family_name):
+                    cfg = resolve_flash_config(
+                        64,
+                        512,
+                        {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: family_name},
+                        dtype=torch.float16,
+                    )
+                    self.assertEqual(cfg.pipeline_family, family_name)
+                    self.assertEqual(
+                        (
+                            cfg.topology,
+                            cfg.use_2cta_instrs,
+                            cfg.use_cga2_local_cta,
+                            cfg.use_clc_scheduler,
+                            cfg.local_tma_partition,
+                            cfg.tensor_4d_tma,
+                        ),
+                        expected,
+                    )
+
+            legacy_by_family = {
+                "ws_overlap": {_cute_flash.FLASH_TOPOLOGY_KEY: "ws_overlap"},
+                "fa4_2cta_tma_4d": {
+                    _cute_flash.FLASH_TOPOLOGY_KEY: "fa4",
+                    _cute_flash.FLASH_USE_2CTA_KEY: True,
+                    _cute_flash.FLASH_TENSOR_4D_TMA_KEY: True,
+                },
+                "fa4_cga2_local_tma_4d": {
+                    _cute_flash.FLASH_TOPOLOGY_KEY: "fa4",
+                    _cute_flash.FLASH_CGA2_LOCAL_KEY: True,
+                    _cute_flash.FLASH_TENSOR_4D_TMA_KEY: True,
+                },
+                "fa4_clc_local_tma_4d": {
+                    _cute_flash.FLASH_TOPOLOGY_KEY: "fa4",
+                    _cute_flash.FLASH_CLC_KEY: True,
+                    _cute_flash.FLASH_LOCAL_TMA_PARTITION_KEY: True,
+                    _cute_flash.FLASH_TENSOR_4D_TMA_KEY: True,
+                },
+            }
+            for family_name, legacy_config in legacy_by_family.items():
+                with self.subTest(legacy_family=family_name):
+                    family_cfg = resolve_flash_config(
+                        64,
+                        512,
+                        {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: family_name},
+                        dtype=torch.float16,
+                    )
+                    legacy_cfg = resolve_flash_config(
+                        64,
+                        512,
+                        legacy_config,
+                        dtype=torch.float16,
+                    )
+                    self.assertEqual(legacy_cfg, family_cfg)
+
+            family_wins = resolve_flash_config(
+                64,
+                512,
+                {
+                    _cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4",
+                    _cute_flash.FLASH_TOPOLOGY_KEY: "ws_overlap",
+                    _cute_flash.FLASH_USE_2CTA_KEY: True,
+                    _cute_flash.FLASH_CGA2_LOCAL_KEY: True,
+                    _cute_flash.FLASH_CLC_KEY: True,
+                    _cute_flash.FLASH_LOCAL_TMA_PARTITION_KEY: True,
+                    _cute_flash.FLASH_TENSOR_4D_TMA_KEY: True,
+                },
+                dtype=torch.float16,
+            )
+            self.assertEqual(family_wins.pipeline_family, "fa4")
+
+            odd_kv = resolve_flash_config(
+                64,
+                511,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: ("fa4_clc_local_tma_4d")},
+                dtype=torch.float16,
+            )
+            self.assertEqual(odd_kv.pipeline_family, "ws_overlap")
+            bf16_2cta = resolve_flash_config(
+                64,
+                512,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta_tma_4d"},
+                dtype=torch.bfloat16,
+            )
+            self.assertEqual(bf16_2cta.pipeline_family, "fa4")
+            causal_clc = resolve_flash_config(
+                64,
+                512,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: ("fa4_clc_local_tma_4d")},
+                dtype=torch.float16,
+                is_causal=True,
+            )
+            self.assertEqual(causal_clc.pipeline_family, "fa4")
+
+            legacy_clc = resolve_flash_config(
+                64,
+                1024,
+                {
+                    _cute_flash.FLASH_TOPOLOGY_KEY: "fa4",
+                    _cute_flash.FLASH_CLC_KEY: True,
+                },
+            )
+            family_clc = resolve_flash_config(
+                64,
+                1024,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_clc"},
+            )
+            self.assertEqual(legacy_clc, family_clc)
+            self.assertEqual(family_clc.clc_heads_per_batch, 32)
+            self.assertEqual(family_clc.clc_stages, 2)
+            clc_fragments = _cute_flash.flash_autotune_fragments(
+                64,
+                1024,
+                pipeline_family_override="fa4_clc",
+            )
+            self.assertEqual(
+                clc_fragments[_cute_flash.FLASH_CLC_HEADS_PER_BATCH_KEY].default(),
+                32,
+            )
+
+            base = resolve_flash_config(
+                64,
+                512,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4"},
+            )
+            with_dead_knobs = resolve_flash_config(
+                64,
+                512,
+                {
+                    _cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4",
+                    _cute_flash.FLASH_Q_TILE_COUNT_KEY: 17,
+                    _cute_flash.FLASH_MMA_INTERLEAVE_KEY: 9,
+                },
+            )
+            self.assertEqual(with_dead_knobs, base)
+            field_names = {field.name for field in dataclasses.fields(base)}
+            self.assertNotIn("q_tile_count", field_names)
+            self.assertNotIn("mma_interleave", field_names)
 
     def test_flash_attention_fa4_persistent_config_overrides_env(self) -> None:
         with patch.dict(os.environ, {"HELION_CUTE_FLASH_PERSISTENT": "1"}, clear=True):
@@ -4317,7 +4493,7 @@ class TestCuteBackend(TestCase):
                 2,
                 prefer_packed_reduce=True,
             )
-        self.assertFalse(sparse_env_override.packed_reduce)
+        self.assertTrue(sparse_env_override.packed_reduce)
 
         sparse_config_override = resolve_flash_config(
             64,
@@ -4325,7 +4501,7 @@ class TestCuteBackend(TestCase):
             {"cute_flash_packed_reduce": False},
             prefer_packed_reduce=True,
         )
-        self.assertFalse(sparse_config_override.packed_reduce)
+        self.assertTrue(sparse_config_override.packed_reduce)
 
     def test_flash_attention_small_biased_config_overrides(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
@@ -4348,7 +4524,7 @@ class TestCuteBackend(TestCase):
         self.assertEqual(resolve_flash_config(64, 64).causal_lpt_swizzle, 0)
         short_causal = resolve_flash_config(64, 2, is_causal=True)
         self.assertEqual(short_causal.e2e_offset, 2)
-        self.assertFalse(short_causal.packed_reduce)
+        self.assertTrue(short_causal.packed_reduce)
         self.assertEqual(short_causal.causal_lpt_swizzle, 0)
         self.assertEqual(
             resolve_flash_config(64, 64, is_causal=True).causal_lpt_swizzle,
@@ -8996,9 +9172,7 @@ class TestCuteConfigValuePriors(TestCase):
 
     def test_flash_priors_bias_dense_hd64_fa4_values(self) -> None:
         from helion._compiler.backend import CuteBackend
-        from helion._compiler.cute.cute_flash import FLASH_CGA2_LOCAL_KEY
         from helion._compiler.cute.cute_flash import FLASH_CLC_HEADS_PER_BATCH_KEY
-        from helion._compiler.cute.cute_flash import FLASH_CLC_KEY
         from helion._compiler.cute.cute_flash import FLASH_CLC_PDL_KEY
         from helion._compiler.cute.cute_flash import FLASH_CLC_STAGES_KEY
         from helion._compiler.cute.cute_flash import FLASH_CORR_REGS_KEY
@@ -9014,13 +9188,14 @@ class TestCuteConfigValuePriors(TestCase):
         from helion._compiler.cute.cute_flash import FLASH_FIRST_LOAD_ORDER_KEY
         from helion._compiler.cute.cute_flash import FLASH_KV_ORDER_KEY
         from helion._compiler.cute.cute_flash import FLASH_KV_STAGE_KEY
-        from helion._compiler.cute.cute_flash import FLASH_LOCAL_TMA_PARTITION_KEY
+        from helion._compiler.cute.cute_flash import FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS
         from helion._compiler.cute.cute_flash import FLASH_MASKED_E2E_SCHEDULE_KEY
         from helion._compiler.cute.cute_flash import FLASH_OTHER_REGS_KEY
         from helion._compiler.cute.cute_flash import FLASH_P_STORE_REP_KEY
         from helion._compiler.cute.cute_flash import FLASH_PACKED_REDUCE_KEY
         from helion._compiler.cute.cute_flash import FLASH_PERSISTENT_CTAS_PER_SM_KEY
         from helion._compiler.cute.cute_flash import FLASH_PERSISTENT_KEY
+        from helion._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILY_KEY
         from helion._compiler.cute.cute_flash import FLASH_PRECOMPUTE_QK_DESC_KEY
         from helion._compiler.cute.cute_flash import FLASH_RESCALE_CHUNK_COLS_KEY
         from helion._compiler.cute.cute_flash import FLASH_RESCALE_THRESHOLD_KEY
@@ -9029,8 +9204,6 @@ class TestCuteConfigValuePriors(TestCase):
         from helion._compiler.cute.cute_flash import FLASH_SKIP_RESCALE_STATS_KEY
         from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_DISC_KEY
         from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_REGS_KEY
-        from helion._compiler.cute.cute_flash import FLASH_TENSOR_4D_TMA_KEY
-        from helion._compiler.cute.cute_flash import FLASH_TOPOLOGY_KEY
         from helion.autotuner.config_generation import ConfigGeneration
 
         q, k, v = (
@@ -9046,7 +9219,7 @@ class TestCuteConfigValuePriors(TestCase):
 
         expected = {
             FLASH_S_STAGE_KEY: {2},
-            FLASH_TOPOLOGY_KEY: {"fa4", "ws_overlap"},
+            FLASH_PIPELINE_FAMILY_KEY: {"fa4", "ws_overlap"},
             FLASH_PERSISTENT_KEY: {True},
             FLASH_PERSISTENT_CTAS_PER_SM_KEY: {1, 2, 3, 4},
             FLASH_E2E_SCHEDULE_KEY: {"8/2", "16/4"},
@@ -9070,13 +9243,9 @@ class TestCuteConfigValuePriors(TestCase):
             FLASH_SOFTMAX_REGS_KEY: {184, 200},
             FLASH_KV_STAGE_KEY: {2, 3},
             FLASH_PACKED_REDUCE_KEY: {True},
-            FLASH_CGA2_LOCAL_KEY: {False, True},
-            FLASH_CLC_KEY: {False, True},
             FLASH_CLC_HEADS_PER_BATCH_KEY: {0, 32},
             FLASH_CLC_PDL_KEY: {False, True},
             FLASH_CLC_STAGES_KEY: {2, 3},
-            FLASH_LOCAL_TMA_PARTITION_KEY: {False, True},
-            FLASH_TENSOR_4D_TMA_KEY: {False, True},
             FLASH_E2E_OFFSET_KEY: {0, 1, 2, 3},
             FLASH_E2E_OFFSET0_KEY: {0, 1, 2, 3},
         }
@@ -9102,7 +9271,7 @@ class TestCuteConfigValuePriors(TestCase):
             {8.0, 16.0, 32.0},
         )
         for key, values in {
-            FLASH_TOPOLOGY_KEY: {"fa4", "ws_overlap"},
+            FLASH_PIPELINE_FAMILY_KEY: {"fa4", "ws_overlap"},
             FLASH_E2E_SCHEDULE_KEY: {"8/2", "16/4"},
             FLASH_E2E_OFFSET_KEY: {0},
             FLASH_E2E_OFFSET0_KEY: {1},
@@ -9126,13 +9295,9 @@ class TestCuteConfigValuePriors(TestCase):
             FLASH_EPI_STG_STORE_KEY: {"slice"},
             FLASH_EPI_STG_GMEM_KEY: {"stage"},
             FLASH_PACKED_REDUCE_KEY: {True},
-            FLASH_CGA2_LOCAL_KEY: {False},
-            FLASH_CLC_KEY: {False},
             FLASH_CLC_HEADS_PER_BATCH_KEY: {0},
             FLASH_CLC_PDL_KEY: {False},
             FLASH_CLC_STAGES_KEY: {1},
-            FLASH_LOCAL_TMA_PARTITION_KEY: {False},
-            FLASH_TENSOR_4D_TMA_KEY: {False},
         }.items():
             self._assert_prior_choices(
                 very_long_priors[key],
@@ -9168,7 +9333,7 @@ class TestCuteConfigValuePriors(TestCase):
             "random.choices", side_effect=lambda values, weights, k: [values[0]]
         ):
             biased_config = gen.unflatten(gen.biased_random_flat()).config
-        self.assertEqual(biased_config[FLASH_TOPOLOGY_KEY], "fa4")
+        self.assertEqual(biased_config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
         self.assertEqual(biased_config[FLASH_E2E_SCHEDULE_KEY], "8/2")
         self.assertEqual(biased_config[FLASH_MASKED_E2E_SCHEDULE_KEY], "inherit")
         self.assertEqual(biased_config[FLASH_KV_STAGE_KEY], 2)
@@ -9187,9 +9352,8 @@ class TestCuteConfigValuePriors(TestCase):
         self.assertEqual(biased_config[FLASH_CORR_TILE_SIZE_KEY], 16)
         self.assertFalse(biased_config[FLASH_SKIP_RESCALE_STATS_KEY])
         self.assertEqual(biased_config[FLASH_RESCALE_CHUNK_COLS_KEY], 16)
-        self.assertFalse(biased_config[FLASH_CLC_KEY])
-        self.assertFalse(biased_config[FLASH_LOCAL_TMA_PARTITION_KEY])
-        self.assertFalse(biased_config[FLASH_TENSOR_4D_TMA_KEY])
+        for legacy_key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS:
+            self.assertNotIn(legacy_key, biased_config)
 
     def test_flash_priors_bias_causal_hd64_shape_family_values(self) -> None:
         from helion._compiler.backend import CuteBackend
@@ -9205,9 +9369,9 @@ class TestCuteConfigValuePriors(TestCase):
         from helion._compiler.cute.cute_flash import FLASH_MASKED_E2E_SCHEDULE_KEY
         from helion._compiler.cute.cute_flash import FLASH_PACKED_REDUCE_KEY
         from helion._compiler.cute.cute_flash import FLASH_PERSISTENT_KEY
+        from helion._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILY_KEY
         from helion._compiler.cute.cute_flash import FLASH_ROLE_MAP_KEY
         from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_REGS_KEY
-        from helion._compiler.cute.cute_flash import FLASH_TOPOLOGY_KEY
         from helion.autotuner.config_generation import ConfigGeneration
 
         q, k, v = (
@@ -9226,7 +9390,7 @@ class TestCuteConfigValuePriors(TestCase):
                 priors = CuteBackend().config_value_priors(bound.config_spec)
                 fragments = bound.config_spec._flat_fields()
                 expected = {
-                    FLASH_TOPOLOGY_KEY: {"fa4", "ws_overlap"},
+                    FLASH_PIPELINE_FAMILY_KEY: {"fa4", "ws_overlap"},
                     FLASH_PERSISTENT_KEY: {False},
                     FLASH_KV_STAGE_KEY: {2, 3, 4, 6, 8, 10},
                     FLASH_E2E_SCHEDULE_KEY: {"16/4", "8/2", "xu"},


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3232
 * #3231
 * __->__#3230
 * #3229


--- --- ---

[cutedsl] Normalize CuTe flash pipeline families

Represent structural flash topology choices with one pipeline-family key, derive legacy flags during normalization, and retain compatibility for existing fixed and cached configurations. Keep family-dependent fields canonical so generic autotuners compare stable config identities.