### PR TITLE
[cutedsl] Model and validate CuTe flash schedules

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -67,6 +67,7 @@ class FlashSearchSurface(NamedTuple):
     has_kv_tile_pruning: bool
     requires_ws_overlap: bool
     small_biased_candidate: bool
+    standard_dense_output: bool
 
 
 class AttentionSoftmaxPattern(NamedTuple):
@@ -2790,6 +2791,9 @@ def detect_flash_search_surface(device_ir: DeviceIR) -> FlashSearchSurface | Non
         from .cute.cute_flash import (
             flash_attention_graph_small_biased_candidate_from_graphs,
         )
+        from .cute.cute_flash import (
+            flash_attention_graph_standard_dense_output_from_graphs,
+        )
 
         if not flash_attention_graph_lse_plan_valid_from_graphs(
             device_ir.graphs,
@@ -2805,6 +2809,12 @@ def detect_flash_search_surface(device_ir: DeviceIR) -> FlashSearchSurface | Non
                 kv_block_id=block_ids[0],
                 score_plan=pattern.score_plan,
             )
+        )
+        standard_dense_output = flash_attention_graph_standard_dense_output_from_graphs(
+            device_ir.graphs,
+            root_block_ids=root_grid_ids,
+            kv_block_id=block_ids[0],
+            score_plan=pattern.score_plan,
         )
         q_seq = env.block_sizes[root_grid_ids[1]].size
         kv_seq = env.block_sizes[block_ids[0]].size
@@ -2844,6 +2854,7 @@ def detect_flash_search_surface(device_ir: DeviceIR) -> FlashSearchSurface | Non
             has_kv_tile_pruning=pattern.score_plan.has_kv_tile_pruning,
             requires_ws_overlap=pattern.score_plan.requires_ws_overlap,
             small_biased_candidate=small_biased_candidate,
+            standard_dense_output=standard_dense_output,
         )
     return None
 

--- a/helion/_compiler/cute/_flash_gemm_ptx.py
+++ b/helion/_compiler/cute/_flash_gemm_ptx.py
@@ -563,6 +563,7 @@ def gemm_ptx_precomputed_pv_ts(
     mbar_phase: Int32 | None = None,
     zero_init: bool | Boolean = False,
     cta_group: cute.nvgpu.tcgen05.CtaGroup | int = 1,
+    wait_hint: int = 10_000_000,
 ) -> None:
     smem_desc_base_b_lo, smem_desc_b_hi = i64_to_i32x2(smem_desc_base_b)
     tCrA_layout = cute.recast_layout(32, 16, tCrA_layout)
@@ -590,7 +591,7 @@ def gemm_ptx_precomputed_pv_ts(
         mbar_wait_str = (
             ".reg .pred P1; \n\t"
             "LAB_WAIT: \n\t"
-            "mbarrier.try_wait.parity.shared::cta.b64 P1, [$4], $5, 10000000; \n\t"
+            f"mbarrier.try_wait.parity.shared::cta.b64 P1, [$4], $5, {wait_hint}; \n\t"
             "@P1 bra DONE; \n\t"
             "bra     LAB_WAIT; \n\t"
             "DONE: \n\t"
@@ -668,6 +669,7 @@ def gemm_ptx_partial(
     zero_init: bool | Boolean = False,
     tA_addr: Int32 | None = None,
     cta_group: cute.nvgpu.tcgen05.CtaGroup | int | None = None,
+    wait_hint: int = 10_000_000,
 ) -> None:
     is_ts = op.a_src == cute.nvgpu.tcgen05.OperandSource.TMEM
     if const_expr(not is_ts):
@@ -800,7 +802,7 @@ def gemm_ptx_partial(
             mbar_wait_str = (
                 ".reg .pred P1; \n\t"
                 "LAB_WAIT: \n\t"
-                "mbarrier.try_wait.parity.shared::cta.b64 P1, [$4], $5, 10000000; \n\t"
+                f"mbarrier.try_wait.parity.shared::cta.b64 P1, [$4], $5, {wait_hint}; \n\t"
                 "@P1 bra DONE; \n\t"
                 "bra     LAB_WAIT; \n\t"
                 "DONE: \n\t"

--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -80,14 +80,16 @@ def flash_fa4_shared_storage(
     epi_tma: bool = False,
     use_clc_scheduler: bool = False,
     clc_stages: int = 1,
+    separate_kv: bool = False,
 ) -> type:
     """FA4-topology SharedStorage (faithful port of the spike struct).
 
     16-warp / 512-thread layout: 2 softmax warpgroups (128 threads each), a
     correction warpgroup, and single MMA/load/epilogue/empty warps. The raw
     mbarriers (s_full / pfor / pfor2 / o_full / s*_corr) are FA4-style raw
-    handshakes. K and V share one FA4-style KV pipeline and one shared-memory
-    ring; the emitter aliases the V tensor over ``sK`` with the V swizzle.
+    handshakes. Legacy FA4 aliases K and V onto one shared-memory ring. The
+    deep one-CTA family instead gives K and V independent rings and pipeline
+    barriers so both operands can remain resident concurrently.
     s0_corr / s1_corr use the first ``s_corr_stage`` slots as full barriers and
     the second half as empty barriers. ``sScale`` is the FA4-style softmax to
     correction handoff: steady slots carry alpha, and the final slot carries
@@ -98,6 +100,41 @@ def flash_fa4_shared_storage(
     softmax_threads = 128
     clc_response_size = clc_stages * 4 if use_clc_scheduler else 0
     clc_mbar_size = clc_stages * 2 if use_clc_scheduler else 0
+    separate_o_size = 128 * head_dim * 2 if epi_tma else 0
+
+    if separate_kv:
+
+        @cute.struct
+        class SharedStorage:
+            q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, q_stage * 2]
+            k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, kv_stage * 2]
+            v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, kv_stage * 2]
+            s_full_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            pfor_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            pfor2_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            o_full_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            corr_epi_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 4]
+            s0_corr_mbar_ptr: cute.struct.MemRange[cutlass.Int64, s_corr_stage * 2]
+            s1_corr_mbar_ptr: cute.struct.MemRange[cutlass.Int64, s_corr_stage * 2]
+            tmem_dealloc_mbar: cute.struct.MemRange[cutlass.Int64, 1]
+            tmem_holding_buf: cutlass.Int32
+            sScale: cute.struct.MemRange[
+                cutlass.Float32, s_corr_stage * q_stage * softmax_threads
+            ]
+            clc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, clc_mbar_size]
+            clc_response: cute.struct.MemRange[cutlass.Int32, clc_response_size]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[dtype, 128 * head_dim * q_stage], 1024
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[dtype, 128 * head_dim * kv_stage], 1024
+            ]
+            sV: cute.struct.Align[
+                cute.struct.MemRange[dtype, 128 * head_dim * kv_stage], 1024
+            ]
+            sO: cute.struct.Align[cute.struct.MemRange[dtype, separate_o_size], 1024]
+
+        return SharedStorage
 
     if epi_tma:
 
@@ -168,7 +205,9 @@ def flash_fa4_shared_storage(
     return SharedStorage
 
 
-def mbar_spin_wait(mbar_ptr: object, phase: object) -> None:
+def mbar_spin_wait(
+    mbar_ptr: object, phase: object, wait_hint: int = 10_000_000
+) -> None:
     """FA4-style TIGHT busy-spin mbarrier wait (NO nanosleep backoff).
 
     ``cute.arch.mbarrier_wait`` lowers to a try_wait with a NANOSLEEP backoff
@@ -187,7 +226,7 @@ def mbar_spin_wait(mbar_ptr: object, phase: object) -> None:
         "{\n\t"
         ".reg .pred P1;\n\t"
         "LAB_WAIT:\n\t"
-        "mbarrier.try_wait.parity.shared::cta.b64 P1, [$0], $1, 10000000;\n\t"
+        f"mbarrier.try_wait.parity.shared::cta.b64 P1, [$0], $1, {wait_hint};\n\t"
         "@P1 bra DONE;\n\t"
         "bra LAB_WAIT;\n\t"
         "DONE:\n\t"
@@ -263,6 +302,15 @@ _POLY_EX2_DEG3 = (
     0.695146143436431884765625,
     0.227564394474029541015625,
     0.077119089663028717041015625,
+)
+_POLY_EX2_DEG2 = (
+    1.0017247632060873,
+    0.65763628,
+    0.33718943,
+)
+_POLY_EX2_DEG1 = (
+    0.97017879,
+    0.97017879,
 )
 _FP32_ROUND_INT = float(2**23 + 2**22)
 
@@ -348,6 +396,110 @@ def ex2_emulation_batch(pairs: list[tuple]) -> list[tuple]:
     )
     xy_frac_ex2 = [(_POLY_EX2_DEG3[-1], _POLY_EX2_DEG3[-1]) for _ in pairs]
     for coefficient in reversed(_POLY_EX2_DEG3[:-1]):
+        xy_frac_ex2 = [
+            _fma_packed_f32x2(poly, frac, (coefficient, coefficient))
+            for poly, frac in zip(xy_frac_ex2, xy_frac, strict=True)
+        ]
+    return [
+        (
+            _combine_int_frac_ex2(rounded[0], frac_ex2[0]),
+            _combine_int_frac_ex2(rounded[1], frac_ex2[1]),
+        )
+        for rounded, frac_ex2 in zip(xy_rounded, xy_frac_ex2, strict=True)
+    ]
+
+
+def ex2_emulation_deg2_2(x: Float32, y: Float32) -> tuple:
+    """Packed degree-2 software exp2 with a [0, 1] minimax approximation."""
+    xy_clamped = (cute.arch.fmax(x, -127.0), cute.arch.fmax(y, -127.0))
+    xy_rounded = cute.arch.add_packed_f32x2(
+        xy_clamped,
+        (_FP32_ROUND_INT, _FP32_ROUND_INT),
+        rnd="rm",
+    )
+    xy_rounded_back = _sub_packed_f32x2(xy_rounded, (_FP32_ROUND_INT, _FP32_ROUND_INT))
+    xy_frac = _sub_packed_f32x2(xy_clamped, xy_rounded_back)
+    xy_frac_ex2 = _evaluate_polynomial_2(xy_frac[0], xy_frac[1], _POLY_EX2_DEG2)
+    x_out = _combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0])
+    y_out = _combine_int_frac_ex2(xy_rounded[1], xy_frac_ex2[1])
+    return x_out, y_out
+
+
+def ex2_emulation_deg2_batch(pairs: list[tuple]) -> list[tuple]:
+    """Level-schedule independent packed degree-2 software exp2 pairs."""
+    xy_clamped = [
+        (cute.arch.fmax(x, -127.0), cute.arch.fmax(y, -127.0)) for x, y in pairs
+    ]
+    xy_rounded = [
+        cute.arch.add_packed_f32x2(
+            pair,
+            (_FP32_ROUND_INT, _FP32_ROUND_INT),
+            rnd="rm",
+        )
+        for pair in xy_clamped
+    ]
+    xy_rounded_back = [
+        _sub_packed_f32x2(pair, (_FP32_ROUND_INT, _FP32_ROUND_INT))
+        for pair in xy_rounded
+    ]
+    xy_frac = list(
+        starmap(_sub_packed_f32x2, zip(xy_clamped, xy_rounded_back, strict=True))
+    )
+    xy_frac_ex2 = [(_POLY_EX2_DEG2[-1], _POLY_EX2_DEG2[-1]) for _ in pairs]
+    for coefficient in reversed(_POLY_EX2_DEG2[:-1]):
+        xy_frac_ex2 = [
+            _fma_packed_f32x2(poly, frac, (coefficient, coefficient))
+            for poly, frac in zip(xy_frac_ex2, xy_frac, strict=True)
+        ]
+    return [
+        (
+            _combine_int_frac_ex2(rounded[0], frac_ex2[0]),
+            _combine_int_frac_ex2(rounded[1], frac_ex2[1]),
+        )
+        for rounded, frac_ex2 in zip(xy_rounded, xy_frac_ex2, strict=True)
+    ]
+
+
+def ex2_emulation_deg1_2(x: Float32, y: Float32) -> tuple:
+    """Packed degree-1 software exp2 with a relative minimax approximation."""
+    # The linear polynomial starts below 1.0 (FP32 exponent 126), so clamping
+    # at -127 would wrap the reconstructed exponent field to 255.
+    xy_clamped = (cute.arch.fmax(x, -126.0), cute.arch.fmax(y, -126.0))
+    xy_rounded = cute.arch.add_packed_f32x2(
+        xy_clamped,
+        (_FP32_ROUND_INT, _FP32_ROUND_INT),
+        rnd="rm",
+    )
+    xy_rounded_back = _sub_packed_f32x2(xy_rounded, (_FP32_ROUND_INT, _FP32_ROUND_INT))
+    xy_frac = _sub_packed_f32x2(xy_clamped, xy_rounded_back)
+    xy_frac_ex2 = _evaluate_polynomial_2(xy_frac[0], xy_frac[1], _POLY_EX2_DEG1)
+    x_out = _combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0])
+    y_out = _combine_int_frac_ex2(xy_rounded[1], xy_frac_ex2[1])
+    return x_out, y_out
+
+
+def ex2_emulation_deg1_batch(pairs: list[tuple]) -> list[tuple]:
+    """Level-schedule independent packed degree-1 software exp2 pairs."""
+    xy_clamped = [
+        (cute.arch.fmax(x, -126.0), cute.arch.fmax(y, -126.0)) for x, y in pairs
+    ]
+    xy_rounded = [
+        cute.arch.add_packed_f32x2(
+            pair,
+            (_FP32_ROUND_INT, _FP32_ROUND_INT),
+            rnd="rm",
+        )
+        for pair in xy_clamped
+    ]
+    xy_rounded_back = [
+        _sub_packed_f32x2(pair, (_FP32_ROUND_INT, _FP32_ROUND_INT))
+        for pair in xy_rounded
+    ]
+    xy_frac = list(
+        starmap(_sub_packed_f32x2, zip(xy_clamped, xy_rounded_back, strict=True))
+    )
+    xy_frac_ex2 = [(_POLY_EX2_DEG1[-1], _POLY_EX2_DEG1[-1]) for _ in pairs]
+    for coefficient in reversed(_POLY_EX2_DEG1[:-1]):
         xy_frac_ex2 = [
             _fma_packed_f32x2(poly, frac, (coefficient, coefficient))
             for poly, frac in zip(xy_frac_ex2, xy_frac, strict=True)
@@ -784,31 +936,47 @@ def fa4_exp2_convert_rowsum(
     return cutlass.Float32(s0[0]) + cutlass.Float32(s0[1])  # pyrefly: ignore[bad-argument-type]
 
 
-def _fmax_reduce_chunk(frg: cute.Tensor, init_val: Float32) -> Float32:
-    """fmax over a small fragment ``frg`` (one 32-elem t2r chunk) with 2 scalar
-    accumulators, folding the running ``init_val`` row-max in. Used by the
-    chunked-t2r row-max pass so the full 128-elem row is NEVER held."""
+def _fmax_reduce_chunk_balanced(frg: cute.Tensor, init_val: Float32) -> Float32:
+    """Reduce one 16- or 32-value t2r chunk with a balanced FMNMX3 tree.
+
+    Four independent chains cover ``init_val`` and the scores in the minimum
+    eight or sixteen ternary max instructions. The longest dependency chain is
+    three or five instructions, while retaining the one-fragment footprint.
+    """
     n = cute.size(frg)
-    lm0 = cute.arch.fmax(init_val, frg[0])
-    lm0 = cute.arch.fmax(lm0, frg[1])
-    lm1 = cute.arch.fmax(frg[2], frg[3])
-    for i in range(4, n, 4):
-        lm0 = cute.arch.fmax(lm0, cute.arch.fmax(frg[i + 0], frg[i + 1]))
-        lm1 = cute.arch.fmax(lm1, cute.arch.fmax(frg[i + 2], frg[i + 3]))
-    return cute.arch.fmax(lm0, lm1)
+    assert n in (16, 32), "balanced row-max requires a 16- or 32-value chunk"
+    lm0 = _fmax3(init_val, frg[0], frg[1])
+    lm1 = _fmax3(frg[2], frg[3], frg[4])
+    lm2 = _fmax3(frg[5], frg[6], frg[7])
+    lm3 = _fmax3(frg[8], frg[9], frg[10])
+    lm0 = _fmax3(lm0, frg[11], frg[12])
+    lm1 = _fmax3(lm1, frg[13], frg[14])
+    if n == 16:
+        lm2 = _fmax3(lm2, lm3, frg[15])
+        return _fmax3(lm0, lm1, lm2)
+    lm2 = _fmax3(lm2, frg[15], frg[16])
+    lm3 = _fmax3(lm3, frg[17], frg[18])
+    lm0 = _fmax3(lm0, frg[19], frg[20])
+    lm1 = _fmax3(lm1, frg[21], frg[22])
+    lm2 = _fmax3(lm2, frg[23], frg[24])
+    lm3 = _fmax3(lm3, frg[25], frg[26])
+    lm0 = _fmax3(lm0, frg[27], frg[28])
+    lm1 = _fmax3(lm1, frg[29], frg[30])
+    lm2 = _fmax3(lm2, lm3, frg[31])
+    return _fmax3(lm0, lm1, lm2)
 
 
-def fa4_disc_rowmax(
+def fa4_disc_rowmax_balanced(
     tiled_ld: object,
     tLDtS: cute.Tensor,
     tLDcS: cute.Tensor,
     row_max: Float32,
     ld_chunks: int,
 ) -> Float32:
-    """CHUNKED-t2r PASS 1 (row-max). For each of ``ld_chunks`` 32-elem column
-    chunks, t2r ONE chunk into a small fragment, fold into the running max via
+    """CHUNKED-t2r PASS 1 (row-max). For each 16- or 32-element column
+    chunk, t2r ONE chunk into a small fragment, fold into the running max via
     scalar fmax, then FREE the chunk -- so the full fp32 row is NEVER simultaneously
-    resident (peak live = ONE 32-elem fragment). The chunked-t2r
+    resident (peak live = ONE chunk fragment). The chunked-t2r
     ``_disc_pass1_max`` structure is the key reason the softmax body is the only one
     that closes the FA4 200/64/48/24 setmaxnreg split with ZERO spill, whereas the
     whole-row ("sp") body keeps a 128-f32 row resident and spills past the grant.
@@ -825,12 +993,12 @@ def fa4_disc_rowmax(
     for ci in range(ld_chunks):
         frg = cute.make_rmem_tensor(ld_shape, cutlass.Float32)
         cute.copy(tiled_ld, tLDtS[None, ci, None, None], frg)
-        row_max = _fmax_reduce_chunk(frg, row_max)
+        row_max = _fmax_reduce_chunk_balanced(frg, row_max)
     cute.arch.fence_view_async_tmem_load()
     return row_max
 
 
-def fa4_disc_rowmax_causal(
+def fa4_disc_rowmax_causal_balanced(
     tiled_ld: object,
     tLDtS: cute.Tensor,
     tLDcS: cute.Tensor,
@@ -839,7 +1007,7 @@ def fa4_disc_rowmax_causal(
     m_block: cutlass.Int32,
     n_block: cutlass.Int32,
 ) -> Float32:
-    """Causal variant of ``fa4_disc_rowmax`` for the FA4 topology."""
+    """Causal variant of ``fa4_disc_rowmax_balanced`` for the FA4 topology."""
     ld_shape = tLDcS[None, 0, None, None].shape  # pyrefly: ignore[missing-attribute]
     for ci in range(ld_chunks):
         frg = cute.make_rmem_tensor(ld_shape, cutlass.Float32)
@@ -851,7 +1019,7 @@ def fa4_disc_rowmax_causal(
             n_block,
             ci,
         )
-        row_max = _fmax_reduce_chunk(frg, row_max)
+        row_max = _fmax_reduce_chunk_balanced(frg, row_max)
     cute.arch.fence_view_async_tmem_load()
     return row_max
 
@@ -875,6 +1043,8 @@ def fa4_disc_exp_convert_store(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
     *,
     loc: object = None,
     ip: object = None,
@@ -908,7 +1078,15 @@ def fa4_disc_exp_convert_store(
         cute.copy(tiled_ld, tLDtS[None, ci, None, None], frg)
         last_frag = ci >= p_store_chunks - 1
         _disc_chunk_exp(
-            frg, scale, minus_max_scale, e2e_freq, e2e_res, e2e_offset, last_frag
+            frg,
+            scale,
+            minus_max_scale,
+            e2e_freq,
+            e2e_res,
+            e2e_offset,
+            last_frag,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_convert_store(frg, tiled_st, tSTtS, tSTcS, ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(frg)
@@ -945,6 +1123,8 @@ def fa4_disc_exp_convert_store_causal(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
 ) -> Float32:
     """Causal variant of ``fa4_disc_exp_convert_store``."""
     p_sum = cutlass.Float32(0.0)
@@ -961,7 +1141,15 @@ def fa4_disc_exp_convert_store_causal(
         )
         last_frag = ci >= p_store_chunks - 1
         _disc_chunk_exp(
-            frg, scale, minus_max_scale, e2e_freq, e2e_res, e2e_offset, last_frag
+            frg,
+            scale,
+            minus_max_scale,
+            e2e_freq,
+            e2e_res,
+            e2e_offset,
+            last_frag,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_convert_store(frg, tiled_st, tSTtS, tSTcS, ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(frg)
@@ -987,6 +1175,8 @@ def _disc_chunk_exp(
     last_frag: bool,
     pair_batch: int = 1,
     emu_batch: int = 1,
+    degree2: bool = False,
+    degree1: bool = False,
 ) -> None:
     """In-place packed scale-subtract then exp2(pipe-split) over ONE 32-elem chunk.
 
@@ -995,6 +1185,7 @@ def _disc_chunk_exp(
     ``e2e_offset`` shifts the residue phase for the two softmax stages.
     Verbatim from the serial ``fa4_disc_exp_convert_store`` body; factored out so the
     serial and software-pipelined pass2 share the SAME per-chunk numerics."""
+    assert not (degree1 and degree2)
     nf = cute.size(frg)
     if pair_batch == 1:
         # Preserve the established instruction order for every caller that does
@@ -1009,6 +1200,10 @@ def _disc_chunk_exp(
             if use_xu:
                 frg[i] = cute.arch.exp2(r0)
                 frg[i + 1] = cute.arch.exp2(r1)
+            elif degree1:
+                frg[i], frg[i + 1] = ex2_emulation_deg1_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
+            elif degree2:
+                frg[i], frg[i + 1] = ex2_emulation_deg2_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
             else:
                 frg[i], frg[i + 1] = ex2_emulation_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
         return
@@ -1032,18 +1227,33 @@ def _disc_chunk_exp(
                 frg[i] = cute.arch.exp2(r0)
                 frg[i + 1] = cute.arch.exp2(r1)
             elif emu_batch == 1:
-                frg[i], frg[i + 1] = ex2_emulation_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
+                if degree1:
+                    frg[i], frg[i + 1] = ex2_emulation_deg1_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
+                elif degree2:
+                    frg[i], frg[i + 1] = ex2_emulation_deg2_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
+                else:
+                    frg[i], frg[i + 1] = ex2_emulation_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
             else:
                 pending_indices.append(i)
                 pending_values.append((r0, r1))
                 if len(pending_values) == emu_batch:
-                    results = ex2_emulation_batch(pending_values)
+                    if degree1:
+                        results = ex2_emulation_deg1_batch(pending_values)
+                    elif degree2:
+                        results = ex2_emulation_deg2_batch(pending_values)
+                    else:
+                        results = ex2_emulation_batch(pending_values)
                     for pending_i, result in zip(pending_indices, results, strict=True):
                         frg[pending_i], frg[pending_i + 1] = result
                     pending_indices = []
                     pending_values = []
         if pending_values:
-            results = ex2_emulation_batch(pending_values)
+            if degree1:
+                results = ex2_emulation_deg1_batch(pending_values)
+            elif degree2:
+                results = ex2_emulation_deg2_batch(pending_values)
+            else:
+                results = ex2_emulation_batch(pending_values)
             for pending_i, result in zip(pending_indices, results, strict=True):
                 frg[pending_i], frg[pending_i + 1] = result
 
@@ -1111,6 +1321,8 @@ def fa4_disc_exp_convert_store_rep32(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
     *,
     loc: object = None,
     ip: object = None,
@@ -1132,7 +1344,15 @@ def fa4_disc_exp_convert_store_rep32(
         frg = cute.make_rmem_tensor(ld_shape, cutlass.Float32)
         cute.copy(tiled_ld, tLDtS[None, ld_ci0, None, None], frg)
         _disc_chunk_exp(
-            frg, scale, minus_max_scale, e2e_freq, e2e_res, e2e_offset, False
+            frg,
+            scale,
+            minus_max_scale,
+            e2e_freq,
+            e2e_res,
+            e2e_offset,
+            False,
+            pair_batch,
+            emu_batch,
         )
         pchunk0 = cute.make_tensor(
             cute.recast_ptr(pchunk.iterator, dtype=io_dtype), frg.layout
@@ -1149,6 +1369,8 @@ def fa4_disc_exp_convert_store_rep32(
             e2e_res,
             e2e_offset,
             ci >= p_store_chunks - 1,
+            pair_batch,
+            emu_batch,
         )
         pchunk1 = cute.make_tensor(
             cute.recast_ptr(pchunk.iterator + half_f32, dtype=io_dtype), frg.layout
@@ -1189,6 +1411,8 @@ def fa4_disc_exp_convert_store_rep32_split(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
 ) -> Float32:
     """Rep32 P store while preserving the 3/4 staged-P release.
 
@@ -1207,7 +1431,15 @@ def fa4_disc_exp_convert_store_rep32_split(
         cute.copy(tiled_ld, tLDtS[None, ld_ci0, None, None], frg0)
         cute.copy(tiled_ld, tLDtS[None, ld_ci1, None, None], frg1)
         _disc_chunk_exp(
-            frg0, scale, minus_max_scale, e2e_freq, e2e_res, e2e_offset, False
+            frg0,
+            scale,
+            minus_max_scale,
+            e2e_freq,
+            e2e_res,
+            e2e_offset,
+            False,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_exp(
             frg1,
@@ -1217,6 +1449,8 @@ def fa4_disc_exp_convert_store_rep32_split(
             e2e_res,
             e2e_offset,
             ld_ci1 >= ld_chunks - 1,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_pair_convert_store(
             frg0, frg1, tiled_st32, tST32tS, tST32cS, pair_ci, io_dtype
@@ -1234,6 +1468,8 @@ def fa4_disc_exp_convert_store_rep32_split(
             e2e_res,
             e2e_offset,
             ld_ci >= ld_chunks - 1,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_convert_store(frg, tiled_st16, tST16tS, tST16cS, ld_ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(frg)
@@ -1251,6 +1487,8 @@ def fa4_disc_exp_convert_store_rep32_split(
             e2e_res,
             e2e_offset,
             ci >= ld_chunks - 1,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_convert_store(frg, tiled_st16, tST16tS, tST16cS, ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(frg)
@@ -1279,6 +1517,8 @@ def fa4_disc_exp_convert_store_rep32_pipe(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
 ) -> Float32:
     """Software-pipelined Rep32 PASS2.
 
@@ -1319,6 +1559,8 @@ def fa4_disc_exp_convert_store_rep32_pipe(
                 e2e_res,
                 e2e_offset,
                 ld_ci >= ld_chunks - 1,
+                pair_batch,
+                emu_batch,
             )
             pchunk_half = cute.make_tensor(
                 cute.recast_ptr(pchunk.iterator + half * half_f32, dtype=io_dtype),
@@ -1359,6 +1601,8 @@ def fa4_disc_exp_convert_store_sload16_pair_pipe(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
 ) -> Float32:
     """PASS2 for Rep16 S-loads paired into the regular Rep16 P-store.
 
@@ -1399,6 +1643,8 @@ def fa4_disc_exp_convert_store_sload16_pair_pipe(
                 e2e_res,
                 e2e_offset,
                 ld_ci >= ld_chunks - 1,
+                pair_batch,
+                emu_batch,
             )
             pchunk_half = cute.make_tensor(
                 cute.recast_ptr(pchunk.iterator + half * half_f32, dtype=io_dtype),
@@ -1440,6 +1686,8 @@ def fa4_disc_exp_convert_store_rep32_causal(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
 ) -> Float32:
     """Causal Rep32 PASS2 variant."""
     p_sum = cutlass.Float32(0.0)
@@ -1460,7 +1708,15 @@ def fa4_disc_exp_convert_store_rep32_causal(
             ld_ci0,
         )
         _disc_chunk_exp(
-            frg, scale, minus_max_scale, e2e_freq, e2e_res, e2e_offset, False
+            frg,
+            scale,
+            minus_max_scale,
+            e2e_freq,
+            e2e_res,
+            e2e_offset,
+            False,
+            pair_batch,
+            emu_batch,
         )
         pchunk0 = cute.make_tensor(
             cute.recast_ptr(pchunk.iterator, dtype=io_dtype), frg.layout
@@ -1484,6 +1740,8 @@ def fa4_disc_exp_convert_store_rep32_causal(
             e2e_res,
             e2e_offset,
             ci >= p_store_chunks - 1,
+            pair_batch,
+            emu_batch,
         )
         pchunk1 = cute.make_tensor(
             cute.recast_ptr(pchunk.iterator + half_f32, dtype=io_dtype), frg.layout
@@ -1525,6 +1783,8 @@ def fa4_disc_exp_convert_store_rep32_pipe_causal(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
 ) -> Float32:
     """Causal variant of ``fa4_disc_exp_convert_store_rep32_pipe``."""
     p_sum = cutlass.Float32(0.0)
@@ -1566,6 +1826,8 @@ def fa4_disc_exp_convert_store_rep32_pipe_causal(
                 e2e_res,
                 e2e_offset,
                 ld_ci >= ld_chunks - 1,
+                pair_batch,
+                emu_batch,
             )
             pchunk_half = cute.make_tensor(
                 cute.recast_ptr(pchunk.iterator + half * half_f32, dtype=io_dtype),
@@ -1608,6 +1870,8 @@ def fa4_disc_exp_convert_store_sload16_pair_pipe_causal(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
 ) -> Float32:
     """Causal variant of ``fa4_disc_exp_convert_store_sload16_pair_pipe``."""
     p_sum = cutlass.Float32(0.0)
@@ -1649,6 +1913,8 @@ def fa4_disc_exp_convert_store_sload16_pair_pipe_causal(
                 e2e_res,
                 e2e_offset,
                 ld_ci >= ld_chunks - 1,
+                pair_batch,
+                emu_batch,
             )
             pchunk_half = cute.make_tensor(
                 cute.recast_ptr(pchunk.iterator + half * half_f32, dtype=io_dtype),
@@ -1692,6 +1958,8 @@ def fa4_disc_exp_convert_store_rep32_split_causal(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
 ) -> Float32:
     """Causal Rep32 staged-P variant."""
     p_sum = cutlass.Float32(0.0)
@@ -1720,7 +1988,15 @@ def fa4_disc_exp_convert_store_rep32_split_causal(
             ld_ci1,
         )
         _disc_chunk_exp(
-            frg0, scale, minus_max_scale, e2e_freq, e2e_res, e2e_offset, False
+            frg0,
+            scale,
+            minus_max_scale,
+            e2e_freq,
+            e2e_res,
+            e2e_offset,
+            False,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_exp(
             frg1,
@@ -1730,6 +2006,8 @@ def fa4_disc_exp_convert_store_rep32_split_causal(
             e2e_res,
             e2e_offset,
             ld_ci1 >= ld_chunks - 1,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_pair_convert_store(
             frg0, frg1, tiled_st32, tST32tS, tST32cS, pair_ci, io_dtype
@@ -1754,6 +2032,8 @@ def fa4_disc_exp_convert_store_rep32_split_causal(
             e2e_res,
             e2e_offset,
             ld_ci >= ld_chunks - 1,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_convert_store(frg, tiled_st16, tST16tS, tST16cS, ld_ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(frg)
@@ -1778,6 +2058,8 @@ def fa4_disc_exp_convert_store_rep32_split_causal(
             e2e_res,
             e2e_offset,
             ci >= ld_chunks - 1,
+            pair_batch,
+            emu_batch,
         )
         _disc_chunk_convert_store(frg, tiled_st16, tST16tS, tST16cS, ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(frg)
@@ -1894,10 +2176,11 @@ def fa4_correction_epilogue_handoff_to_smem(
     tOcO_corr_t2r: cute.Tensor,
     inv_sum: object,
     chunks: int,
+    wait_hint: int = 10_000_000,
 ) -> None:
     """Wait for O/epilogue handoff, stage final O in SMEM, then publish it."""
-    mbar_spin_wait(o_full_ptr_stage, o_full_phase)
-    mbar_spin_wait(corr_epi_empty_ptr_stage, corr_epi_empty_phase)
+    mbar_spin_wait(o_full_ptr_stage, o_full_phase, wait_hint)
+    mbar_spin_wait(corr_epi_empty_ptr_stage, corr_epi_empty_phase, wait_hint)
     fa4_correction_epilogue_to_smem(
         tiled_t2r,
         tiled_r2s,
@@ -2028,10 +2311,11 @@ def fa4_correction_epilogue_handoff_to_smem_scoped(
     head_dim: int,
     corr_tile_size: int,
     o_dtype: object,
+    wait_hint: int = 10_000_000,
 ) -> None:
     """Wait for O/epilogue handoff, scope copy views, then publish staged O."""
-    mbar_spin_wait(o_full_ptr_stage, o_full_phase)
-    mbar_spin_wait(corr_epi_empty_ptr_stage, corr_epi_empty_phase)
+    mbar_spin_wait(o_full_ptr_stage, o_full_phase, wait_hint)
+    mbar_spin_wait(corr_epi_empty_ptr_stage, corr_epi_empty_phase, wait_hint)
     fa4_correction_epilogue_to_smem_scoped(
         flash_pvt,
         tOtO,
@@ -2060,10 +2344,11 @@ def fa4_correction_epilogue_handoff_to_smem_scoped_2cta(
     head_dim: int,
     corr_tile_size: int,
     o_dtype: object,
+    wait_hint: int = 10_000_000,
 ) -> None:
     """Wait for handoff and stage a two-CTA output in CTA-local shared memory."""
-    mbar_spin_wait(o_full_ptr_stage, o_full_phase)
-    mbar_spin_wait(corr_epi_empty_ptr_stage, corr_epi_empty_phase)
+    mbar_spin_wait(o_full_ptr_stage, o_full_phase, wait_hint)
+    mbar_spin_wait(corr_epi_empty_ptr_stage, corr_epi_empty_phase, wait_hint)
     fa4_correction_epilogue_to_smem_scoped_2cta(
         flash_pvt,
         tOtO,
@@ -2099,6 +2384,7 @@ def _fa4_sp_exp_convert_store_impl(
     early_split_publish: bool = False,
     pair_batch: int = 1,
     emu_batch: int = 1,
+    degree1: bool = False,
     *,
     loc: object = None,
     ip: object = None,
@@ -2123,6 +2409,8 @@ def _fa4_sp_exp_convert_store_impl(
                 ci >= frag_count - 1,
                 pair_batch,
                 emu_batch,
+                False,
+                degree1,
             )
             cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
         for ci in range(p_store_split):
@@ -2141,6 +2429,8 @@ def _fa4_sp_exp_convert_store_impl(
                 ci >= frag_count - 1,
                 pair_batch,
                 emu_batch,
+                False,
+                degree1,
             )
             cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
         for ci in range(p_store_split, p_store_chunks):
@@ -2160,6 +2450,8 @@ def _fa4_sp_exp_convert_store_impl(
                 ci >= frag_count - 1,
                 pair_batch,
                 emu_batch,
+                False,
+                degree1,
             )
             cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
         for ci in range(p_store_chunks):
@@ -2204,6 +2496,7 @@ def fa4_sp_exp_convert_store(
     early_split_publish: bool = False,
     pair_batch: int = 1,
     emu_batch: int = 1,
+    degree1: bool = False,
     *,
     loc: object = None,
     ip: object = None,
@@ -2230,6 +2523,7 @@ def fa4_sp_exp_convert_store(
         early_split_publish,
         pair_batch,
         emu_batch,
+        degree1,
     )
 
 
@@ -2254,6 +2548,7 @@ def fa4_sp_exp_convert_store_whole_rowsum(
     early_split_publish: bool = False,
     pair_batch: int = 1,
     emu_batch: int = 1,
+    degree1: bool = False,
     *,
     loc: object = None,
     ip: object = None,
@@ -2280,6 +2575,7 @@ def fa4_sp_exp_convert_store_whole_rowsum(
         early_split_publish,
         pair_batch,
         emu_batch,
+        degree1,
     )
 
 
@@ -2302,6 +2598,8 @@ def _fa4_sp_exp_convert_store_rep32_split_impl(
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
     whole_row_sum: bool = False,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
     *,
     loc: object = None,
     ip: object = None,
@@ -2318,6 +2616,8 @@ def _fa4_sp_exp_convert_store_rep32_split_impl(
             e2e_res,
             e2e_offset,
             ci >= frag_count - 1,
+            pair_batch,
+            emu_batch,
         )
     split_ld_chunks = frag_count * 3 // 4
     pair_chunks = split_ld_chunks // 2
@@ -2381,6 +2681,8 @@ def fa4_sp_exp_convert_store_rep32_split(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
     *,
     loc: object = None,
     ip: object = None,
@@ -2404,6 +2706,9 @@ def fa4_sp_exp_convert_store_rep32_split(
         io_dtype,
         pfor_peer_cta_rank,
         pfor_self_cta_rank,
+        False,
+        pair_batch,
+        emu_batch,
     )
 
 
@@ -2425,6 +2730,8 @@ def fa4_sp_exp_convert_store_rep32_split_whole_rowsum(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
     *,
     loc: object = None,
     ip: object = None,
@@ -2449,6 +2756,8 @@ def fa4_sp_exp_convert_store_rep32_split_whole_rowsum(
         pfor_peer_cta_rank,
         pfor_self_cta_rank,
         True,
+        pair_batch,
+        emu_batch,
     )
 
 
@@ -2511,6 +2820,10 @@ def fa4_disc_exp_convert_store_pipe(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
+    degree2: bool = False,
+    degree1: bool = False,
 ) -> Float32:
     """SOFTWARE-PIPELINED chunked-t2r PASS 2 (the L1 lever). Same numerics + staged-P
     handshake + zero-spill peak (ONE chunk + a bounded pipeline window) as the serial
@@ -2564,7 +2877,17 @@ def fa4_disc_exp_convert_store_pipe(
         cute.arch.fence_view_async_tmem_load()
         last_frag = ci >= p_store_chunks - 1
         _disc_chunk_exp(
-            cur, scale, minus_max_scale, e2e_freq, e2e_res, e2e_offset, last_frag
+            cur,
+            scale,
+            minus_max_scale,
+            e2e_freq,
+            e2e_res,
+            e2e_offset,
+            last_frag,
+            pair_batch,
+            emu_batch,
+            degree2,
+            degree1,
         )
         _disc_chunk_convert_store(cur, tiled_st, tSTtS, tSTcS, ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(cur)
@@ -2602,6 +2925,10 @@ def fa4_disc_exp_convert_store_pipe_causal(
     io_dtype: object = cutlass.Float16,
     pfor_peer_cta_rank: object = None,
     pfor_self_cta_rank: object = None,
+    pair_batch: int = 1,
+    emu_batch: int = 1,
+    degree2: bool = False,
+    degree1: bool = False,
 ) -> Float32:
     """Causal variant of ``fa4_disc_exp_convert_store_pipe``."""
     p_sum = cutlass.Float32(0.0)
@@ -2631,7 +2958,17 @@ def fa4_disc_exp_convert_store_pipe_causal(
         )
         last_frag = ci >= p_store_chunks - 1
         _disc_chunk_exp(
-            cur, scale, minus_max_scale, e2e_freq, e2e_res, e2e_offset, last_frag
+            cur,
+            scale,
+            minus_max_scale,
+            e2e_freq,
+            e2e_res,
+            e2e_offset,
+            last_frag,
+            pair_batch,
+            emu_batch,
+            degree2,
+            degree1,
         )
         _disc_chunk_convert_store(cur, tiled_st, tSTtS, tSTcS, ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(cur)

--- a/helion/_compiler/cute/causal_range.py
+++ b/helion/_compiler/cute/causal_range.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class IntegerInterval:
+    """A half-open interval of integer values."""
+
+    start: int
+    stop: int
+
+    @property
+    def is_empty(self) -> bool:
+        return self.start >= self.stop
+
+
+@dataclasses.dataclass(frozen=True)
+class TileLayout:
+    """Element coordinates covered by a tile-indexed tensor dimension."""
+
+    extent: int | None
+    stride: int
+    width: int
+    origin: int = 0
+
+
+@dataclasses.dataclass(frozen=True)
+class CausalRangeProof:
+    proven: bool
+    reason: str
+
+
+def _element_interval(
+    tile_interval: IntegerInterval,
+    layout: TileLayout,
+) -> IntegerInterval | None:
+    if tile_interval.is_empty or layout.stride <= 0 or layout.width <= 0:
+        return None
+    return IntegerInterval(
+        layout.origin + tile_interval.start * layout.stride,
+        layout.origin + (tile_interval.stop - 1) * layout.stride + layout.width,
+    )
+
+
+def _affine_maximum(
+    *,
+    coefficient: int,
+    constant: int,
+    domain: IntegerInterval,
+) -> int | None:
+    if domain.is_empty:
+        return None
+    endpoint = domain.stop - 1 if coefficient >= 0 else domain.start
+    return coefficient * endpoint + constant
+
+
+def prove_causal_tile_range_unmasked(
+    *,
+    query_tiles: IntegerInterval | None,
+    kv_tiles: IntegerInterval | None,
+    kv_minus_query: IntegerInterval | None,
+    query_layout: TileLayout,
+    kv_layout: TileLayout,
+    has_additional_modifiers: bool = False,
+    has_kv_tile_pruning: bool = False,
+) -> CausalRangeProof:
+    """Prove every lane in a tile range satisfies the standard causal mask.
+
+    ``kv_minus_query`` bounds the tile-index difference for every executed
+    query/KV pair. The proof is deliberately interval based: callers must
+    provide static bounds for the complete runtime range, and any missing or
+    partial-tile bound rejects mask elision.
+    """
+    if has_additional_modifiers:
+        return CausalRangeProof(False, "additional score modifiers")
+    if has_kv_tile_pruning:
+        return CausalRangeProof(False, "KV tile pruning")
+    if query_layout.extent is None or kv_layout.extent is None:
+        return CausalRangeProof(False, "dynamic extent")
+    if query_tiles is None or kv_tiles is None or kv_minus_query is None:
+        return CausalRangeProof(False, "symbolic range")
+    query_elements = _element_interval(query_tiles, query_layout)
+    kv_elements = _element_interval(kv_tiles, kv_layout)
+    if query_elements is None or kv_elements is None or kv_minus_query.is_empty:
+        return CausalRangeProof(False, "empty or invalid range")
+    if query_layout.extent < 0 or kv_layout.extent < 0:
+        return CausalRangeProof(False, "invalid extent")
+    if query_elements.start < 0 or query_elements.stop > query_layout.extent:
+        return CausalRangeProof(False, "query tile has out-of-bounds lanes")
+    if kv_elements.start < 0 or kv_elements.stop > kv_layout.extent:
+        return CausalRangeProof(False, "KV tile has out-of-bounds lanes")
+
+    # For every pair, kv_tile <= query_tile + max_delta. The causal predicate
+    # is true for the complete tiles only if the largest possible KV element
+    # lies strictly before the first query element. Using exclusive ends turns
+    # that condition into kv_end <= query_start.
+    max_delta = kv_minus_query.stop - 1
+    visibility_gap = _affine_maximum(
+        coefficient=kv_layout.stride - query_layout.stride,
+        constant=(
+            kv_layout.origin
+            + max_delta * kv_layout.stride
+            + kv_layout.width
+            - query_layout.origin
+        ),
+        domain=query_tiles,
+    )
+    if visibility_gap is None or visibility_gap > 0:
+        return CausalRangeProof(False, "range includes a masked causal lane")
+    return CausalRangeProof(True, "complete range is causally visible")
+
+
+def prove_descending_causal_prefix_unmasked(
+    *,
+    query_tiles: IntegerInterval | None,
+    query_layout: TileLayout,
+    kv_layout: TileLayout,
+    has_additional_modifiers: bool = False,
+    has_kv_tile_pruning: bool = False,
+) -> CausalRangeProof:
+    """Prove ``for i in range(q_tile): kv_tile = q_tile - 1 - i``.
+
+    This is the unmasked suffix of a descending causal traversal. The derived
+    intervals are conservative unions over every query tile in
+    ``query_tiles``; the affine difference interval retains the relationship
+    needed to prove causal visibility.
+    """
+    if query_tiles is None:
+        return CausalRangeProof(False, "symbolic range")
+    if query_tiles.start < 0 or query_tiles.stop <= 1:
+        return CausalRangeProof(False, "empty or invalid range")
+    kv_tiles = IntegerInterval(0, query_tiles.stop - 1)
+    kv_minus_query = IntegerInterval(-query_tiles.stop, 0)
+    return prove_causal_tile_range_unmasked(
+        query_tiles=query_tiles,
+        kv_tiles=kv_tiles,
+        kv_minus_query=kv_minus_query,
+        query_layout=query_layout,
+        kv_layout=kv_layout,
+        has_additional_modifiers=has_additional_modifiers,
+        has_kv_tile_pruning=has_kv_tile_pruning,
+    )

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -51,6 +51,13 @@ from .attention_plan import SLIDING_WINDOW_MASK_KIND
 from .attention_plan import SOFTCAP_KIND
 from .attention_plan import TENSOR_BIAS_KIND
 from .attention_plan import AttentionScorePlan
+from .causal_range import CausalRangeProof
+from .causal_range import IntegerInterval
+from .causal_range import TileLayout
+from .causal_range import prove_descending_causal_prefix_unmasked
+from .flash_schedule import FlashScheduleSpec
+from .flash_schedule import build_fa4_schedule
+from .flash_schedule import verify_flash_schedule
 
 _T = TypeVar("_T")
 
@@ -799,6 +806,47 @@ def flash_attention_graph_small_biased_candidate_from_graphs(
     )
 
 
+def _standard_dense_score_plan_supported(score_plan: AttentionScorePlan) -> bool:
+    return not score_plan.modifiers and math.isclose(
+        score_plan.qk_scale_log2,
+        math.log2(math.e) / math.sqrt(score_plan.head_dim),
+        rel_tol=1e-8,
+        abs_tol=1e-8,
+    )
+
+
+def flash_attention_graph_standard_dense_output_from_graphs(
+    graphs: Iterable[GraphInfo],
+    *,
+    root_block_ids: Sequence[int] | None = None,
+    kv_block_id: int | None = None,
+    score_plan: AttentionScorePlan,
+) -> bool:
+    """Detector-time mirror of the codegen ``standard_dense_output`` gate.
+
+    ``resolve_flash_config`` uses this flag to decide whether the manual
+    degree-1 exp2 packets are selectable, so config normalization has to reach
+    the same answer as codegen or it would project a requested ``deg1_*`` packet
+    back onto the generic default.
+    """
+    graph_plan = _flash_graph_output_plan_from_graphs(
+        graphs,
+        root_block_ids=root_block_ids,
+        kv_block_id=kv_block_id,
+        score_plan=score_plan,
+    )
+    if graph_plan is None:
+        return False
+    return (
+        not score_plan.is_causal
+        and graph_plan.lse_name is None
+        and not graph_plan.bias_names
+        and not graph_plan.alibi_names
+        and not graph_plan.document_names
+        and _standard_dense_score_plan_supported(score_plan)
+    )
+
+
 def flash_attention_graph_lse_plan_valid(
     df: DeviceFunction,
     *,
@@ -849,6 +897,15 @@ def _flash_kv_stage(head_dim: int) -> int:
     return 2
 
 
+def _flash_deep_1cta_kv_stage_cap(head_dim: int) -> int:
+    """Largest legal per-ring K/V depth while retaining local S2."""
+    if head_dim == 64:
+        return 4
+    if head_dim == 128:
+        return 2
+    return 0
+
+
 def _flash_persistent() -> bool:
     """Whether to emit a static-persistent scheduler (grid capped at num_SMs,
     each CTA strides over a flat tile-id range).
@@ -893,6 +950,8 @@ _FLASH_NUM_REGS_CONSUMER = 184
 
 class FlashPipelineFamilyFlags(NamedTuple):
     topology: str
+    separate_kv_rings: bool = False
+    causal_two_cta: bool = False
     use_2cta_instrs: bool = False
     use_cga2_local_cta: bool = False
     use_clc_scheduler: bool = False
@@ -903,6 +962,10 @@ class FlashPipelineFamilyFlags(NamedTuple):
 FLASH_PIPELINE_FAMILY_FLAGS: dict[str, FlashPipelineFamilyFlags] = {
     "ws_overlap": FlashPipelineFamilyFlags("ws_overlap"),
     "fa4": FlashPipelineFamilyFlags("fa4"),
+    "fa4_deep_1cta": FlashPipelineFamilyFlags("fa4", separate_kv_rings=True),
+    "fa4_2cta_causal": FlashPipelineFamilyFlags(
+        "fa4", causal_two_cta=True, use_2cta_instrs=True
+    ),
     "fa4_tma_4d": FlashPipelineFamilyFlags("fa4", tensor_4d_tma=True),
     "fa4_local_tma": FlashPipelineFamilyFlags("fa4", local_tma_partition=True),
     "fa4_local_tma_4d": FlashPipelineFamilyFlags(
@@ -931,6 +994,12 @@ FLASH_PIPELINE_FAMILY_FLAGS: dict[str, FlashPipelineFamilyFlags] = {
     ),
 }
 FLASH_PIPELINE_FAMILIES = tuple(FLASH_PIPELINE_FAMILY_FLAGS)
+FLASH_MANUAL_ONLY_PIPELINE_FAMILIES = frozenset({"fa4_deep_1cta", "fa4_2cta_causal"})
+FLASH_AUTOTUNE_PIPELINE_FAMILIES = tuple(
+    family
+    for family in FLASH_PIPELINE_FAMILIES
+    if family not in FLASH_MANUAL_ONLY_PIPELINE_FAMILIES
+)
 
 
 def _flash_pipeline_family_flags(
@@ -942,6 +1011,8 @@ def _flash_pipeline_family_flags(
 def _flash_pipeline_family_from_flags(
     *,
     topology: str,
+    separate_kv_rings: bool,
+    causal_two_cta: bool,
     use_2cta_instrs: bool,
     use_cga2_local_cta: bool,
     use_clc_scheduler: bool,
@@ -950,8 +1021,12 @@ def _flash_pipeline_family_from_flags(
 ) -> str:
     if topology != "fa4":
         return "ws_overlap"
-    if use_2cta_instrs:
-        base = "fa4_2cta"
+    if separate_kv_rings:
+        base = "fa4_deep_1cta"
+        local_tma_partition = False
+        tensor_4d_tma = False
+    elif use_2cta_instrs:
+        base = "fa4_2cta_causal" if causal_two_cta else "fa4_2cta"
         local_tma_partition = False
     elif use_cga2_local_cta:
         base = "fa4_cga2_local"
@@ -993,6 +1068,10 @@ class FlashAttentionConfig:
     num_mma_warps: int = 0
     num_load_warps: int = 0
     num_epilogue_warps: int = 0
+    # Query-stage count is structural: FA4's barrier/TMEM graph owns two local
+    # query slots, while ws_overlap owns one. Legacy fixed configs are accepted
+    # but canonicalized to this family-derived value.
+    q_tile_count: int = 1
     acc_stage: int = 1
     epi_stage: int = 1
     # exp2 defaults to the FMA/XU pipe-split (split f8/r2): measured +2.9pp hd64
@@ -1011,8 +1090,17 @@ class FlashAttentionConfig:
     masked_e2e_res: int = 2
     e2e_offset: int = 0
     e2e_offset0: int = 0
+    # Packed exp2 instruction scheduling within one score fragment. The first
+    # component is the packed-pair window; the second is the polynomial batch.
+    exp2_packet: str = "1x1"
     tmem_plan: str = "separate"
     tmem_s_to_p_offset: int = 0
+    # True alternates PV/QK by query slot; False groups the two PV issues before
+    # the two following QK issues. Both preserve P-before-QK TMEM alias edges.
+    mma_interleave: bool = True
+    # Explicit PTX mbarrier try-wait hint. Zero is a distinct policy, not an
+    # omitted operand.
+    wait_hint: int = 10_000_000
     # fa4 Stage 2b: issue the MMA-warp QK/PV via the FA4 ``gemm_ptx_partial`` (one
     # inline-asm region with literal-immediate descriptors) instead of cute.gemm.
     # Fits the MMA warp at 48 regs (cute.gemm spills ~116 STL/133 LDL) AND folds the
@@ -1094,6 +1182,9 @@ class FlashAttentionConfig:
     # ``resolve_flash_config``; HELION_CUTE_FLASH_RESCALE_THRESHOLD overrides. The
     # autotuner can refine the threshold for fa4 and ws_overlap shapes.
     rescale_threshold: float = 0.0
+    # Statistics handoff between the softmax and correction roles. ``single``
+    # uses the named-barrier handoff; ``ring2`` uses the two-slot mbarrier ring.
+    stat_transport: str = "ring2"
     # Experimental FA4_SKIP_RESCALE_STATS lever. The resolver currently clamps
     # this off because dropping per-KV alpha handoffs is only correct if every
     # later tile is known to stay on the pinned exponent base.
@@ -1131,6 +1222,13 @@ class FlashAttentionConfig:
     # the original transcription; ``fa4`` matches upstream's load/epilogue warp
     # ordering.
     role_map: str = "helion"
+    # One-CTA pipeline variant: K and V have distinct shared-memory rings and
+    # independent producer/consumer barriers. The score topology stays fixed at
+    # FA4's two local query stages.
+    separate_kv_rings: bool = False
+    # Causal CtaGroup.TWO uses a cluster-uniform K/V trip count while retaining
+    # rank-local query coordinates for masking and output ownership.
+    causal_two_cta: bool = False
     # Dense non-causal FA4 can use SM100 CtaGroup.TWO: two CTAs cooperate on one
     # logical M tile and each CTA owns one rank-local half. This is gated because
     # the raw-barrier FA4 transcription needs separate cluster-aware handshakes.
@@ -1281,6 +1379,72 @@ def _flash_e2e_schedule_name(exp2_impl: str, e2e_freq: int, e2e_res: int) -> str
     return f"{e2e_freq}/{e2e_res}"
 
 
+_FLASH_EXP2_PACKET_PARAMS: dict[str, tuple[int, int]] = {
+    "1x1": (1, 1),
+    "4x1": (4, 1),
+    "4x2": (4, 2),
+    "8x1": (8, 1),
+    "8x2": (8, 2),
+}
+_FLASH_DEG2_EXP2_PACKET = "deg2_16x6"
+_FLASH_HYBRID_EXP2_PACKET = "hybrid_deg1_16x8"
+_FLASH_DEG1_EXP2_PACKET = "deg1_16x8"
+_FLASH_DEG1_SHORT_CORR10_EXP2_PACKET = "deg1_8x2_corr10"
+_FLASH_DEG1_EXP2_PACKETS = frozenset(
+    (_FLASH_DEG1_EXP2_PACKET, _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET)
+)
+_FLASH_DEG1_EXP2_OFFSET = 0
+_FLASH_DEG1_EXP2_OFFSET0 = 10
+_FLASH_MANUAL_EXP2_PACKET_PARAMS: dict[str, tuple[int, int]] = {
+    _FLASH_DEG2_EXP2_PACKET: (8, 3),
+    _FLASH_HYBRID_EXP2_PACKET: (8, 4),
+    _FLASH_DEG1_EXP2_PACKET: (8, 4),
+    _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET: (8, 2),
+}
+_FLASH_MANUAL_EXP2_PACKET_SCHEDULES: dict[str, tuple[int, int]] = {
+    _FLASH_DEG2_EXP2_PACKET: (16, 6),
+    _FLASH_HYBRID_EXP2_PACKET: (16, 8),
+    _FLASH_DEG1_EXP2_PACKET: (16, 8),
+    _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET: (8, 2),
+}
+
+
+class _FlashDiscExp2CodegenParams(NamedTuple):
+    e2e_freq: int
+    e2e_res: int
+    pair_batch: int
+    emu_batch: int
+    degree2: bool
+    degree1_unmasked: bool
+
+
+def _flash_exp2_packet_params(packet: str) -> tuple[int, int]:
+    """Return the static packed-pair and emulation batches for ``packet``."""
+    return _FLASH_EXP2_PACKET_PARAMS.get(
+        packet,
+        _FLASH_MANUAL_EXP2_PACKET_PARAMS.get(packet, _FLASH_EXP2_PACKET_PARAMS["1x1"]),
+    )
+
+
+def _flash_disc_exp2_codegen_params(
+    packet: str, e2e_freq: int, e2e_res: int
+) -> _FlashDiscExp2CodegenParams:
+    """Return cadence, packet batches, and polynomial route for disc PASS2."""
+    pair_batch, emu_batch = _flash_exp2_packet_params(packet)
+    manual_schedule = _FLASH_MANUAL_EXP2_PACKET_SCHEDULES.get(packet)
+    if manual_schedule is not None:
+        return _FlashDiscExp2CodegenParams(
+            *manual_schedule,
+            pair_batch,
+            emu_batch,
+            packet not in _FLASH_DEG1_EXP2_PACKETS,
+            packet == _FLASH_HYBRID_EXP2_PACKET or packet in _FLASH_DEG1_EXP2_PACKETS,
+        )
+    return _FlashDiscExp2CodegenParams(
+        e2e_freq, e2e_res, pair_batch, emu_batch, False, False
+    )
+
+
 def _flash_masked_e2e_schedule_params(
     schedule: str,
     fallback_schedule: str,
@@ -1362,6 +1526,7 @@ def resolve_flash_config(
     dtype: torch.dtype = torch.float16,
     *,
     is_causal: bool = False,
+    standard_dense_output: bool = False,
     prefer_packed_reduce: bool = False,
 ) -> FlashAttentionConfig:
     """Resolve the flash-attention topology config from shape, env vars and config.
@@ -1503,6 +1668,25 @@ def resolve_flash_config(
     num_mma_warps = int(os.environ.get("HELION_CUTE_FLASH_NUM_MMA_WARPS", "0"))
     num_load_warps = int(os.environ.get("HELION_CUTE_FLASH_NUM_LOAD_WARPS", "0"))
     num_epilogue_warps = int(os.environ.get("HELION_CUTE_FLASH_NUM_EPI_WARPS", "0"))
+    # The FA4 emitter, TMEM layout, and barrier graph all own exactly two local
+    # query slots. Preserve the legacy input but canonicalize it to the selected
+    # structural family before it contributes to config identity.
+    q_tile_count = 2 if topology == "fa4" else 1
+    mma_interleave = _flash_bool_env("HELION_CUTE_FLASH_MMA_INTERLEAVE", True)
+    mma_interleave_cfg = _cfg(FLASH_MMA_INTERLEAVE_KEY)
+    if mma_interleave_cfg is not None:
+        mma_interleave = bool(mma_interleave_cfg)
+    if topology != "fa4":
+        mma_interleave = False
+    wait_hint_default = 10_000_000
+    wait_hint = int(
+        os.environ.get("HELION_CUTE_FLASH_WAIT_HINT", str(wait_hint_default))
+    )
+    wait_hint_cfg = _cfg(FLASH_WAIT_HINT_KEY)
+    if wait_hint_cfg is not None:
+        wait_hint = int(wait_hint_cfg)  # type: ignore[arg-type]
+    if wait_hint not in (0, wait_hint_default) or topology != "fa4":
+        wait_hint = wait_hint_default
     acc_stage = int(os.environ.get("HELION_CUTE_FLASH_ACC_STAGE", "1"))
     epi_stage = int(os.environ.get("HELION_CUTE_FLASH_EPI_STAGE", "1"))
     # Exp2 pipe-split schedule. The autotuner sees this as one paired schedule
@@ -1620,6 +1804,10 @@ def resolve_flash_config(
     # fa4 Stage 2b: PTX-path MMA warp (default ON for fa4). HELION_CUTE_FLASH_MMA_PTX=0
     # reverts to the cute.gemm path (the Stage-1/2a body, for A/B comparison).
     mma_ptx = _flash_bool_env("HELION_CUTE_FLASH_MMA_PTX", True)
+    if topology == "fa4" and not mma_ptx:
+        # The CuTe-GEMM fallback has one established interleaved issue order.
+        # Canonicalize the inactive arithmetic child before source identity.
+        mma_interleave = True
     # fa4 Step 2: chunked-t2r ("disc") softmax body (default ON for fa4).
     # HELION_CUTE_FLASH_SOFTMAX_DISC=0 reverts to the whole-row body for A/B.
     softmax_disc_default = (
@@ -1945,6 +2133,24 @@ def resolve_flash_config(
         role_map = "helion"
     if topology != "fa4":
         role_map = "helion"
+    separate_kv_rings = bool(
+        requested_family_flags is not None
+        and requested_family_flags.separate_kv_rings
+        and topology == "fa4"
+        and dtype in (torch.float16, torch.bfloat16)
+        and _flash_deep_1cta_kv_stage_cap(head_dim) > 0
+    )
+    requested_causal_two_cta = bool(
+        requested_family_flags is not None and requested_family_flags.causal_two_cta
+    )
+    causal_two_cta = bool(
+        requested_causal_two_cta
+        and is_causal
+        and topology == "fa4"
+        and head_dim == 64
+        and dtype is torch.float16
+        and num_kv % 4 == 0
+    )
     if requested_family_flags is not None:
         use_2cta_instrs = requested_family_flags.use_2cta_instrs
     else:
@@ -1953,22 +2159,31 @@ def resolve_flash_config(
         if use_2cta_cfg is not None:
             use_2cta_instrs = bool(use_2cta_cfg)
     dense_hd64_2cta = (
-        head_dim == 64 and 256 <= num_kv <= 1024 and dtype is torch.float16
+        head_dim == 64
+        and _flash_dense_hd64_2cta_num_kv_supported(num_kv)
+        and dtype is torch.float16
     )
     if (
         topology != "fa4"
-        or is_causal
+        or (is_causal and not causal_two_cta)
+        or (requested_causal_two_cta and not causal_two_cta)
         or num_kv % 4 != 0
-        or (head_dim != 128 and not dense_hd64_2cta)
+        or (head_dim != 128 and not dense_hd64_2cta and not causal_two_cta)
+        or (separate_kv_rings and not causal_two_cta)
     ):
         use_2cta_instrs = False
-    if use_2cta_instrs and head_dim == 128:
-        precompute_qk_desc = False
+        causal_two_cta = False
+    if use_2cta_instrs:
+        if head_dim == 128:
+            precompute_qk_desc = False
         if epi_stg_gmem == "pair":
             # Pair destinations span both CTA rows; without a rank slice the two
             # CTAs alias the same output half.
             epi_stg_gmem = "stage"
-    if use_2cta_instrs and dense_hd64_2cta:
+    if causal_two_cta:
+        # The causal cluster decoder currently uses contiguous cluster work.
+        causal_lpt_swizzle = 1
+    if use_2cta_instrs and dense_hd64_2cta and not is_causal:
         # This family was characterized as a unit: the TMA epilogue and Rep16
         # split publication are required to beat the established one-CTA seed.
         epi_tma = True
@@ -2003,6 +2218,7 @@ def resolve_flash_config(
         or num_kv % 4 != 0
         or head_dim != 64
         or use_2cta_instrs
+        or separate_kv_rings
     ):
         use_cga2_local_cta = False
     use_clc_scheduler_default = (
@@ -2027,6 +2243,7 @@ def resolve_flash_config(
         or num_kv % 2 != 0
         or use_2cta_instrs
         or use_cga2_local_cta
+        or separate_kv_rings
     ):
         use_clc_scheduler = False
     clc_heads_per_batch_default = (
@@ -2089,6 +2306,7 @@ def resolve_flash_config(
         and persistent
         and not use_2cta_instrs
         and not use_cga2_local_cta
+        and not separate_kv_rings
     )
     tensor_4d_tma_default = (
         _flash_dense_hd64_seed_tensor_4d_tma(num_kv) if long_dense_hd64_fa4 else False
@@ -2108,7 +2326,151 @@ def resolve_flash_config(
         and not is_causal
         and head_dim == 64
         and dtype is torch.float16
+        and not separate_kv_rings
     )
+    if separate_kv_rings:
+        # The one-CTA family isolates K/V depth. The causal cluster family may
+        # compose the already-validated TMA epilogue after its no-epilogue
+        # attribution run.
+        use_2cta_instrs = causal_two_cta
+        use_cga2_local_cta = False
+        use_clc_scheduler = False
+        clc_heads_per_batch = 0
+        clc_use_pdl = False
+        clc_stages = 1
+        local_tma_partition = False
+        tensor_4d_tma = False
+        recompute_tile_coords = False
+        if not causal_two_cta:
+            epi_tma = False
+            epi_stg = False
+            epi_stg_store = "slice"
+            epi_stg_gmem = "stage"
+        kv_stage = min(max(kv_stage, 2), _flash_deep_1cta_kv_stage_cap(head_dim))
+    dense_degree1_packet = (
+        _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
+        if 256 <= num_kv < 2048
+        else _FLASH_DEG1_EXP2_PACKET
+        if num_kv == 2048
+        else None
+    )
+    dense_degree1_eligible = (
+        standard_dense_output
+        and dense_degree1_packet is not None
+        and use_2cta_instrs
+        and not is_causal
+        and head_dim == 64
+        and dtype is torch.float16
+    )
+    exp2_packet_default = (
+        "8x2"
+        if use_2cta_instrs
+        and not is_causal
+        and head_dim == 64
+        and dtype is torch.float16
+        else "1x1"
+    )
+    exp2_packet = os.environ.get("HELION_CUTE_FLASH_EXP2_PACKET", exp2_packet_default)
+    exp2_packet_cfg = _cfg(FLASH_EXP2_PACKET_KEY)
+    if exp2_packet_cfg is not None:
+        exp2_packet = str(exp2_packet_cfg)
+    if dense_degree1_eligible and exp2_packet in _FLASH_DEG1_EXP2_PACKETS:
+        assert dense_degree1_packet is not None
+        exp2_packet = dense_degree1_packet
+    manual_exp2_common = (
+        topology == "fa4"
+        and head_dim == 64
+        and dtype is torch.float16
+        and exp2_impl == "split"
+        and q_tile_count == 2
+        and not use_cga2_local_cta
+        and not separate_kv_rings
+        and p_store_repetition == 16
+        and s_load_repetition == 32
+    )
+    manual_exp2_eligible = manual_exp2_common and (
+        (
+            is_causal
+            and not use_2cta_instrs
+            and softmax_disc
+            and disc_pipe_depth >= 2
+            and exp2_packet not in _FLASH_DEG1_EXP2_PACKETS
+        )
+        or (
+            not is_causal
+            and use_2cta_instrs
+            and not softmax_disc
+            and dense_degree1_eligible
+            and exp2_packet == dense_degree1_packet
+        )
+    )
+    if exp2_packet in _FLASH_MANUAL_EXP2_PACKET_PARAMS:
+        if not manual_exp2_eligible:
+            exp2_packet = exp2_packet_default
+    elif exp2_packet not in _FLASH_EXP2_PACKET_PARAMS:
+        exp2_packet = exp2_packet_default
+    if topology != "fa4" or exp2_impl != "split" or head_dim != 64:
+        exp2_packet = "1x1"
+    manual_exp2_schedule = _FLASH_MANUAL_EXP2_PACKET_SCHEDULES.get(exp2_packet)
+    if manual_exp2_schedule is not None:
+        # Manual polynomial packets are measured compound schedules. Canonicalize
+        # the cadence they replace so equivalent requests have one config identity;
+        # the phase offsets remain active tuning dimensions.
+        exp2_impl = "split"
+        e2e_freq, e2e_res = manual_exp2_schedule
+        e2e_schedule = f"{e2e_freq}/{e2e_res}"
+        if is_causal:
+            masked_e2e_freq = e2e_freq
+            masked_e2e_res = e2e_res
+            masked_e2e_schedule = e2e_schedule
+        else:
+            masked_e2e_freq = e2e_freq
+            masked_e2e_res = e2e_res
+            masked_e2e_schedule = "inherit"
+        e2e_offset_period = e2e_freq
+        e2e_offset_default = (
+            _FLASH_DEG1_EXP2_OFFSET
+            if exp2_packet in _FLASH_DEG1_EXP2_PACKETS
+            else causal_e2e_offset_default % e2e_offset_period
+        )
+        e2e_offset = int(
+            os.environ.get("HELION_CUTE_FLASH_E2E_OFFSET", str(e2e_offset_default))
+        )
+        if e2e_offset_cfg is not None:
+            e2e_offset = int(e2e_offset_cfg)  # type: ignore[arg-type]
+        e2e_offset = _flash_normalize_e2e_offset(
+            e2e_offset, e2e_offset_default, e2e_offset_period
+        )
+        e2e_offset0_default = (
+            _FLASH_DEG1_EXP2_OFFSET0
+            if exp2_packet in _FLASH_DEG1_EXP2_PACKETS
+            else _flash_causal_hd64_seed_offset0(num_kv) % e2e_offset_period
+        )
+        e2e_offset0 = int(
+            os.environ.get("HELION_CUTE_FLASH_E2E_OFFSET0", str(e2e_offset0_default))
+        )
+        if e2e_offset0_cfg is not None:
+            e2e_offset0 = int(e2e_offset0_cfg)  # type: ignore[arg-type]
+        e2e_offset0 = _flash_normalize_e2e_offset(
+            e2e_offset0, e2e_offset0_default, e2e_offset_period
+        )
+    stat_transport_eligible = (
+        topology == "fa4" and not is_causal and head_dim == 64 and exp2_impl == "split"
+    )
+    legacy_stat_handoff = _flash_bool_env("HELION_CUTE_FLASH_FA4_STAT_HANDOFF", True)
+    stat_transport_default = (
+        "single" if stat_transport_eligible and legacy_stat_handoff else "ring2"
+    )
+    stat_transport = os.environ.get(
+        "HELION_CUTE_FLASH_STAT_TRANSPORT", stat_transport_default
+    )
+    stat_transport_cfg = _cfg(FLASH_STAT_TRANSPORT_KEY)
+    if stat_transport_cfg is not None:
+        stat_transport = str(stat_transport_cfg)
+    if stat_transport not in ("ring2", "single"):
+        stat_transport = stat_transport_default
+    if not stat_transport_eligible:
+        stat_transport = "ring2"
     causal_loop_split_default = (
         causal_hd64_seeded_fa4 and causal_kv_order == "descending"
     )
@@ -2136,6 +2498,8 @@ def resolve_flash_config(
         causal_lpt_swizzle = 0
     pipeline_family = _flash_pipeline_family_from_flags(
         topology=topology,
+        separate_kv_rings=separate_kv_rings,
+        causal_two_cta=causal_two_cta,
         use_2cta_instrs=use_2cta_instrs,
         use_cga2_local_cta=use_cga2_local_cta,
         use_clc_scheduler=use_clc_scheduler,
@@ -2157,6 +2521,7 @@ def resolve_flash_config(
         num_mma_warps=num_mma_warps,
         num_load_warps=num_load_warps,
         num_epilogue_warps=num_epilogue_warps,
+        q_tile_count=q_tile_count,
         acc_stage=acc_stage,
         epi_stage=epi_stage,
         exp2_impl=exp2_impl,
@@ -2168,8 +2533,11 @@ def resolve_flash_config(
         masked_e2e_res=masked_e2e_res,
         e2e_offset=e2e_offset,
         e2e_offset0=e2e_offset0,
+        exp2_packet=exp2_packet,
         tmem_plan=tmem_plan,
         tmem_s_to_p_offset=tmem_s_to_p_offset,
+        mma_interleave=mma_interleave,
+        wait_hint=wait_hint,
         mma_ptx=mma_ptx,
         softmax_disc=softmax_disc,
         disc_pipe_depth=disc_pipe_depth,
@@ -2184,6 +2552,7 @@ def resolve_flash_config(
         epi_stg_store=epi_stg_store,
         epi_stg_gmem=epi_stg_gmem,
         rescale_threshold=rescale_threshold,
+        stat_transport=stat_transport,
         skip_rescale_stats=skip_rescale_stats,
         rescale_chunk_cols=rescale_chunk_cols,
         softmax_regs=softmax_regs,
@@ -2195,6 +2564,8 @@ def resolve_flash_config(
         causal_lpt_swizzle=causal_lpt_swizzle,
         causal_kv_order=causal_kv_order,
         role_map=role_map,
+        separate_kv_rings=separate_kv_rings,
+        causal_two_cta=causal_two_cta,
         use_2cta_instrs=use_2cta_instrs,
         use_cga2_local_cta=use_cga2_local_cta,
         use_clc_scheduler=use_clc_scheduler,
@@ -2237,6 +2608,9 @@ FLASH_E2E_FREQ_KEY = "cute_flash_e2e_freq"
 FLASH_E2E_RES_KEY = "cute_flash_e2e_res"
 FLASH_MMA_INTERLEAVE_KEY = "cute_flash_mma_interleave"
 FLASH_Q_TILE_COUNT_KEY = "cute_flash_q_tile_count"
+FLASH_STAT_TRANSPORT_KEY = "cute_flash_stat_transport"
+FLASH_WAIT_HINT_KEY = "cute_flash_wait_hint"
+FLASH_EXP2_PACKET_KEY = "cute_flash_exp2_packet"
 # Compound schedule family. Legacy topology/cluster/TMA keys normalize into it.
 FLASH_PIPELINE_FAMILY_KEY = "cute_flash_pipeline_family"
 # fa4 win (commit 38ff4d1a): the topology selector + the two fa4 perf levers.
@@ -2285,6 +2659,10 @@ FLASH_AUTOTUNE_CONFIG_KEYS: tuple[str, ...] = (
     FLASH_MASKED_E2E_SCHEDULE_KEY,
     FLASH_E2E_OFFSET_KEY,
     FLASH_E2E_OFFSET0_KEY,
+    FLASH_EXP2_PACKET_KEY,
+    FLASH_MMA_INTERLEAVE_KEY,
+    FLASH_WAIT_HINT_KEY,
+    FLASH_STAT_TRANSPORT_KEY,
     FLASH_PIPELINE_FAMILY_KEY,
     FLASH_SOFTMAX_DISC_KEY,
     FLASH_DISC_PIPE_KEY,
@@ -2329,13 +2707,16 @@ FLASH_LEGACY_CONFIG_KEYS: tuple[str, ...] = (
     FLASH_EXP2_IMPL_KEY,
     FLASH_E2E_FREQ_KEY,
     FLASH_E2E_RES_KEY,
-    FLASH_MMA_INTERLEAVE_KEY,
-    FLASH_Q_TILE_COUNT_KEY,
     *FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS,
 )
 
+# Accepted as an input and retained in normalized configs, but not sampled:
+# changing the local query-slot count requires selecting another structural
+# family rather than mutating an arithmetic child.
+FLASH_DERIVED_CONFIG_KEYS: tuple[str, ...] = (FLASH_Q_TILE_COUNT_KEY,)
+
 FLASH_CONFIG_KEYS: tuple[str, ...] = (
-    FLASH_AUTOTUNE_CONFIG_KEYS + FLASH_LEGACY_CONFIG_KEYS
+    FLASH_AUTOTUNE_CONFIG_KEYS + FLASH_LEGACY_CONFIG_KEYS + FLASH_DERIVED_CONFIG_KEYS
 )
 
 
@@ -2353,6 +2734,11 @@ def flash_effective_config_values(
         FLASH_MASKED_E2E_SCHEDULE_KEY: config.masked_e2e_schedule,
         FLASH_E2E_OFFSET_KEY: config.e2e_offset,
         FLASH_E2E_OFFSET0_KEY: config.e2e_offset0,
+        FLASH_EXP2_PACKET_KEY: config.exp2_packet,
+        FLASH_MMA_INTERLEAVE_KEY: config.mma_interleave,
+        FLASH_Q_TILE_COUNT_KEY: config.q_tile_count,
+        FLASH_WAIT_HINT_KEY: config.wait_hint,
+        FLASH_STAT_TRANSPORT_KEY: config.stat_transport,
         FLASH_PIPELINE_FAMILY_KEY: config.pipeline_family,
         FLASH_SOFTMAX_DISC_KEY: config.softmax_disc,
         FLASH_DISC_PIPE_KEY: config.disc_pipe_depth,
@@ -2386,7 +2772,11 @@ def flash_effective_config_values(
 
 
 def _flash_choices_with_default(default: _T, choices: Iterable[_T]) -> tuple[_T, ...]:
-    return (default, *(choice for choice in choices if choice != default))
+    ordered = [default]
+    for choice in choices:
+        if choice not in ordered:
+            ordered.append(choice)
+    return tuple(ordered)
 
 
 _FLASH_SEED_BLOCK_SIZE_TARGETS = (1, 128, 128)
@@ -2394,6 +2784,11 @@ _FLASH_DENSE_HD64_MID_MIN_KV = 16
 _FLASH_DENSE_HD64_LONG_MIN_KV = 64
 _FLASH_DENSE_HD64_VERY_LONG_MIN_KV = 256
 _FLASH_RESCALE_THRESHOLD_VALUES = (0.0, 4.0, 8.0, 12.0, 16.0, 32.0)
+
+
+def _flash_dense_hd64_2cta_num_kv_supported(num_kv: int) -> bool:
+    """Return whether dense hd64 two-CTA supports the bounded long-sequence range."""
+    return 256 <= num_kv <= 2048 and num_kv % 4 == 0
 
 
 def _flash_safe_rescale_threshold_values(dtype: torch.dtype) -> tuple[float, ...]:
@@ -2634,6 +3029,8 @@ def flash_attention_value_prior_weights(
         recompute_tile_coords = _flash_dense_hd64_seed_recompute_tile_coords(num_kv)
         pipeline_family = _flash_pipeline_family_from_flags(
             topology="fa4",
+            separate_kv_rings=False,
+            causal_two_cta=False,
             use_2cta_instrs=False,
             use_cga2_local_cta=_flash_dense_hd64_seed_cga2_local(num_kv),
             use_clc_scheduler=clc,
@@ -2646,7 +3043,7 @@ def flash_attention_value_prior_weights(
         }
         if pipeline_family != "fa4":
             pipeline_family_priors["fa4"] = 1.0
-        if num_kv == 512 and dtype is torch.float16:
+        if num_kv in (512, 2048) and dtype is torch.float16:
             pipeline_family_priors["fa4_2cta"] = 4.0
         very_long_dense_hd64_fa4 = num_kv >= _FLASH_DENSE_HD64_VERY_LONG_MIN_KV
         priors = cast(
@@ -3016,6 +3413,8 @@ def _flash_default_seed_config(
         family_values = {
             FLASH_PIPELINE_FAMILY_KEY: _flash_pipeline_family_from_flags(
                 topology="fa4",
+                separate_kv_rings=False,
+                causal_two_cta=False,
                 use_2cta_instrs=False,
                 use_cga2_local_cta=_flash_dense_hd64_seed_cga2_local(num_kv),
                 use_clc_scheduler=_flash_dense_hd64_seed_clc(num_kv),
@@ -3435,6 +3834,7 @@ def flash_autotune_fragments(
     has_kv_tile_pruning: bool = False,
     requires_ws_overlap: bool = False,
     small_biased_candidate: bool = False,
+    standard_dense_output: bool = False,
     topology_override: str | None = None,
     pipeline_family_override: str | None = None,
 ) -> dict[str, ConfigSpecFragment]:
@@ -3537,6 +3937,7 @@ def flash_autotune_fragments(
         defaults_config,
         dtype=dtype,
         is_causal=is_causal,
+        standard_dense_output=standard_dense_output,
         prefer_packed_reduce=has_kv_tile_pruning or requires_ws_overlap,
     )
     dense_hd64_fa4 = not is_causal and head_dim == 64 and defaults.topology == "fa4"
@@ -3578,11 +3979,18 @@ def flash_autotune_fragments(
         # Seed with the resolved default first (byte-identity), then the other.
         s_stage_choices = (defaults.s_stage, 1 if defaults.s_stage == 2 else 2)
         s_stage_search_choices = None
-    if dense_hd64_fa4:
+    kv_stage_search_choices: tuple[int, ...] | None
+    if defaults.separate_kv_rings:
+        kv_stage_choices = _flash_choices_with_default(
+            defaults.kv_stage,
+            tuple(range(2, _flash_deep_1cta_kv_stage_cap(head_dim) + 1)),
+        )
+        kv_stage_search_choices = None
+    elif dense_hd64_fa4:
         kv_stage_choices = _flash_choices_with_default(
             defaults.kv_stage, (2, 3, 4, 6, 8, 10)
         )
-        kv_stage_search_choices: tuple[int, ...] | None = (
+        kv_stage_search_choices = (
             _flash_choices_with_default(defaults.kv_stage, (2, 3))
             if very_long_dense_hd64_fa4
             else (
@@ -3700,6 +4108,41 @@ def flash_autotune_fragments(
     else:
         masked_e2e_schedule_choices = ("inherit",)
         masked_e2e_schedule_search_choices = None
+    # A manual exp2 packet canonicalizes ``e2e_schedule`` to the cadence it
+    # replaces, so those cadences have to be selectable for the projected config
+    # to round-trip through normalization. They stay out of the search choices
+    # and only appear where a manual packet is selectable at all (see
+    # ``exp2_packet_choices`` below).
+    manual_schedule_names = (
+        tuple(
+            dict.fromkeys(
+                f"{freq}/{res}"
+                for freq, res in _FLASH_MANUAL_EXP2_PACKET_SCHEDULES.values()
+            )
+        )
+        if defaults.topology == "fa4" and head_dim == 64
+        else ()
+    )
+    e2e_schedule_choices = _flash_choices_with_default(
+        defaults.e2e_schedule, (*e2e_schedule_choices, *manual_schedule_names)
+    )
+    if is_causal:
+        masked_e2e_schedule_choices = _flash_choices_with_default(
+            defaults.masked_e2e_schedule,
+            (*masked_e2e_schedule_choices, *manual_schedule_names),
+        )
+    manual_exp2_schedule = _FLASH_MANUAL_EXP2_PACKET_SCHEDULES.get(defaults.exp2_packet)
+    if manual_exp2_schedule is not None:
+        schedule_name = f"{manual_exp2_schedule[0]}/{manual_exp2_schedule[1]}"
+        assert defaults.e2e_schedule == schedule_name
+        e2e_schedule_choices = (defaults.e2e_schedule,)
+        e2e_schedule_search_choices = (defaults.e2e_schedule,)
+        if is_causal:
+            assert defaults.masked_e2e_schedule == schedule_name
+            masked_e2e_schedule_choices = (defaults.masked_e2e_schedule,)
+            masked_e2e_schedule_search_choices = (defaults.masked_e2e_schedule,)
+        else:
+            assert defaults.masked_e2e_schedule == "inherit"
     # FA4 processes a pair of adjacent Q tiles and therefore requires an even
     # KV-tile count. Family choices are constructed after the cluster/CLC
     # eligibility checks below.
@@ -4102,8 +4545,7 @@ def flash_autotune_fragments(
         defaults.topology == "fa4"
         and not is_causal
         and head_dim == 64
-        and 256 <= num_kv <= 1024
-        and num_kv % 4 == 0
+        and _flash_dense_hd64_2cta_num_kv_supported(num_kv)
         and dtype is torch.float16
         and not has_kv_tile_pruning
         and not requires_ws_overlap
@@ -4121,9 +4563,6 @@ def flash_autotune_fragments(
         pipeline_family_choices = ("ws_overlap",)
         pipeline_family_search_choices: tuple[str, ...] | None = None
     else:
-        pipeline_family_choices = _flash_choices_with_default(
-            defaults.pipeline_family, FLASH_PIPELINE_FAMILIES
-        )
         pipeline_family_search: list[str] = ["fa4" if fa4_eligible else "ws_overlap"]
         if not long_causal_hd64_seeded_fa4:
             pipeline_family_search.append("ws_overlap")
@@ -4133,8 +4572,26 @@ def flash_autotune_fragments(
             not very_long_dense_hd64_fa4 or defaults.use_clc_scheduler
         ):
             pipeline_family_search.append("fa4_clc")
+        manual_default = (
+            defaults.pipeline_family
+            if defaults.pipeline_family in FLASH_MANUAL_ONLY_PIPELINE_FAMILIES
+            else None
+        )
+        pipeline_family_enum = (
+            (*FLASH_AUTOTUNE_PIPELINE_FAMILIES, manual_default)
+            if manual_default is not None
+            else FLASH_AUTOTUNE_PIPELINE_FAMILIES
+        )
+        effective_family_default = (
+            pipeline_family_search[0]
+            if manual_default is not None
+            else defaults.pipeline_family
+        )
+        pipeline_family_choices = _flash_choices_with_default(
+            effective_family_default, pipeline_family_enum
+        )
         pipeline_family_search_choices = _flash_choices_with_default(
-            defaults.pipeline_family, pipeline_family_search
+            effective_family_default, pipeline_family_search
         )
     clc_heads_choices = _flash_choices_with_default(
         defaults.clc_heads_per_batch, (0, 1, 2, 4, 8, 16, 32, 64)
@@ -4243,6 +4700,48 @@ def flash_autotune_fragments(
         epi_stg_store_search_choices = None
         epi_stg_gmem_choices = (defaults.epi_stg_gmem,)
         epi_stg_gmem_search_choices = None
+    if defaults.topology == "fa4":
+        wait_hint_choices = _flash_choices_with_default(
+            defaults.wait_hint, (10_000_000, 0)
+        )
+        wait_hint_search_choices: tuple[int, ...] | None = wait_hint_choices
+        mma_interleave_choices = _flash_choices_with_default(
+            defaults.mma_interleave, (True, False)
+        )
+        mma_interleave_search_choices: tuple[bool, ...] | None = (
+            defaults.mma_interleave,
+        )
+    else:
+        wait_hint_choices = (10_000_000,)
+        wait_hint_search_choices = None
+        mma_interleave_choices = (False,)
+        mma_interleave_search_choices = None
+    if defaults.topology == "fa4" and head_dim == 64:
+        exp2_packet_choices = _flash_choices_with_default(
+            defaults.exp2_packet,
+            (*_FLASH_EXP2_PACKET_PARAMS, *_FLASH_MANUAL_EXP2_PACKET_PARAMS),
+        )
+        if defaults.exp2_packet in _FLASH_MANUAL_EXP2_PACKET_PARAMS:
+            exp2_packet_search_choices: tuple[str, ...] | None = (defaults.exp2_packet,)
+        else:
+            exp2_packet_search_choices = (
+                _flash_choices_with_default(defaults.exp2_packet, ("8x2", "1x1"))
+                if defaults.use_2cta_instrs
+                else _flash_choices_with_default(defaults.exp2_packet, ("1x1", "4x1"))
+            )
+    else:
+        exp2_packet_choices = ("1x1",)
+        exp2_packet_search_choices = None
+    if dense_hd64_fa4:
+        stat_transport_choices = _flash_choices_with_default(
+            defaults.stat_transport, ("ring2", "single")
+        )
+        stat_transport_search_choices: tuple[str, ...] | None = (
+            defaults.stat_transport,
+        )
+    else:
+        stat_transport_choices = ("ring2",)
+        stat_transport_search_choices = None
     return {
         FLASH_S_STAGE_KEY: EnumFragment(s_stage_choices, s_stage_search_choices),
         FLASH_KV_STAGE_KEY: EnumFragment(kv_stage_choices, kv_stage_search_choices),
@@ -4268,6 +4767,16 @@ def flash_autotune_fragments(
         ),
         FLASH_E2E_OFFSET0_KEY: EnumFragment(
             e2e_offset0_choices, e2e_offset0_search_choices
+        ),
+        FLASH_EXP2_PACKET_KEY: EnumFragment(
+            exp2_packet_choices, exp2_packet_search_choices
+        ),
+        FLASH_MMA_INTERLEAVE_KEY: EnumFragment(
+            mma_interleave_choices, mma_interleave_search_choices
+        ),
+        FLASH_WAIT_HINT_KEY: EnumFragment(wait_hint_choices, wait_hint_search_choices),
+        FLASH_STAT_TRANSPORT_KEY: EnumFragment(
+            stat_transport_choices, stat_transport_search_choices
         ),
         FLASH_PIPELINE_FAMILY_KEY: EnumFragment(
             pipeline_family_choices, pipeline_family_search_choices
@@ -4352,6 +4861,7 @@ def flash_config_from_config(
     dtype: torch.dtype = torch.float16,
     *,
     is_causal: bool = False,
+    standard_dense_output: bool = False,
 ) -> FlashAttentionConfig:
     """Reconstruct ``FlashAttentionConfig`` from a (normalized) config Mapping.
 
@@ -4365,6 +4875,7 @@ def flash_config_from_config(
         config,
         dtype=dtype,
         is_causal=is_causal,
+        standard_dense_output=standard_dense_output,
     )
 
 
@@ -4851,6 +5362,33 @@ def _flash_fa4_runtime_disc_score_plan_supported(
 ) -> bool:
     """Whether the hand-written FA4 disc runtime helpers cover this transform."""
     return all(modifier.kind == CAUSAL_MASK_KIND for modifier in score_plan.modifiers)
+
+
+def _flash_fa4_descending_causal_split_proof(
+    *,
+    sequence_extent: int,
+    num_query_tiles: int,
+    num_kv_tiles: int,
+    score_plan: AttentionScorePlan,
+) -> CausalRangeProof:
+    """Prove the FA4 descending split's mask-free runtime loop."""
+    if num_query_tiles != num_kv_tiles:
+        return CausalRangeProof(False, "query/KV tile-count mismatch")
+    if sequence_extent != num_kv_tiles * 128:
+        return CausalRangeProof(False, "partial or uncovered sequence tail")
+    tile_layout = TileLayout(extent=sequence_extent, stride=128, width=128)
+    return prove_descending_causal_prefix_unmasked(
+        query_tiles=IntegerInterval(0, num_query_tiles),
+        query_layout=tile_layout,
+        kv_layout=tile_layout,
+        has_additional_modifiers=(score_plan.modifier_kinds != (CAUSAL_MASK_KIND,)),
+        has_kv_tile_pruning=score_plan.has_kv_tile_pruning,
+    )
+
+
+def _flash_runtime_range_header(loop_var: str, loop_bound: str) -> str:
+    """Emit a runtime CuTe loop header; causal splitting must not unroll it."""
+    return f"for {loop_var} in cutlass.range({loop_bound}, unroll=1):"
 
 
 def _flash_kv_iteration(
@@ -6207,6 +6745,7 @@ def emit_flash_fa4_device_body(
     *,
     head_dim: int,
     num_kv: int,
+    sequence_extent: int,
     num_bh: int,
     total_tiles: int,
     cfg: FlashAttentionConfig,
@@ -6239,7 +6778,8 @@ def emit_flash_fa4_device_body(
     """
     hd = head_dim
     kv_stage = cfg.kv_stage
-    q_stage = 2
+    q_stage = cfg.q_tile_count
+    assert q_stage == 2
     s_corr_stage = 2
     assert total_tiles % num_bh == 0
     if cfg.skip_rescale_stats:
@@ -6250,6 +6790,12 @@ def emit_flash_fa4_device_body(
     causal_desc_kv = is_causal and cfg.causal_kv_order == "descending"
     desc_kv = causal_desc_kv or (not is_causal and cfg.kv_order == "descending")
     num_m_pairs = total_tiles // num_bh
+    causal_split_proof = _flash_fa4_descending_causal_split_proof(
+        sequence_extent=sequence_extent,
+        num_query_tiles=num_m_pairs * (4 if cfg.causal_two_cta else 2),
+        num_kv_tiles=num_kv,
+        score_plan=score_plan,
+    )
     persistent = cfg.persistent
     use_tensor_4d_tma = (
         cfg.tensor_4d_tma
@@ -6262,6 +6808,56 @@ def emit_flash_fa4_device_body(
     use_2cta_instrs = cfg.use_2cta_instrs
     use_cga2_local_cta = cfg.use_cga2_local_cta
     use_clc_scheduler = cfg.use_clc_scheduler
+    separate_kv_rings = cfg.separate_kv_rings
+    verified_shared_memory_bytes: int | None = None
+    if separate_kv_rings:
+        assert not use_cga2_local_cta
+        assert not use_clc_scheduler
+        assert not cfg.tensor_4d_tma
+        if not use_2cta_instrs:
+            assert not cfg.epi_tma
+            assert not cfg.epi_stg
+        verified_schedule = verify_flash_schedule(
+            build_fa4_schedule(
+                FlashScheduleSpec(
+                    head_dim=head_dim,
+                    kv_depth=kv_stage,
+                    query_slots_per_cta=q_stage,
+                    cta_count=2 if use_2cta_instrs else 1,
+                    separate_kv=True,
+                    causal=is_causal,
+                    multicast_kv=use_2cta_instrs,
+                    cooperative_mma=use_2cta_instrs,
+                    persistent=persistent,
+                    kv_iterations=num_kv if persistent else None,
+                    stage_output=cfg.epi_tma or cfg.epi_stg,
+                    split_p_arrive=cfg.split_p_arrive,
+                )
+            )
+        )
+        kv_stage = verified_schedule.spec.kv_depth
+        separate_kv_rings = verified_schedule.spec.separate_kv
+        verified_shared_memory_bytes = verified_schedule.schedule.shared_memory_bytes
+    elif use_2cta_instrs:
+        verified_schedule = verify_flash_schedule(
+            build_fa4_schedule(
+                FlashScheduleSpec(
+                    head_dim=head_dim,
+                    kv_depth=kv_stage,
+                    query_slots_per_cta=q_stage,
+                    cta_count=2,
+                    causal=is_causal,
+                    multicast_kv=True,
+                    cooperative_mma=True,
+                    persistent=persistent,
+                    kv_iterations=num_kv if persistent else None,
+                    stage_output=cfg.epi_tma or cfg.epi_stg,
+                    split_p_arrive=cfg.split_p_arrive,
+                )
+            )
+        )
+        kv_stage = verified_schedule.spec.kv_depth
+        verified_shared_memory_bytes = verified_schedule.schedule.shared_memory_bytes
     use_local_tma_partition = (
         cfg.local_tma_partition
         and persistent
@@ -6282,6 +6878,21 @@ def emit_flash_fa4_device_body(
         clc_heads_per_batch = num_bh
     clc_batch_count = num_bh // clc_heads_per_batch
     split_p_arrive = cfg.split_p_arrive
+    exp2_codegen = _flash_disc_exp2_codegen_params(
+        cfg.exp2_packet, cfg.e2e_freq, cfg.e2e_res
+    )
+    if exp2_codegen.degree2:
+        assert is_causal
+        assert hd == 64
+        assert io_dtype == "cutlass.Float16"
+        assert cfg.q_tile_count == 2
+        assert not use_2cta_instrs
+        assert not use_cga2_local_cta
+        assert not separate_kv_rings
+        assert cfg.softmax_disc
+        assert cfg.disc_pipe_depth >= 2
+        assert cfg.p_store_repetition == 16
+        assert cfg.s_load_repetition == 32
     sp_whole_row_sum = (
         _FLASH_DENSE_HD64_VERY_LONG_MIN_KV <= num_kv <= 2048
         and not is_causal
@@ -6290,7 +6901,8 @@ def emit_flash_fa4_device_body(
     )
     cta_group_size = 2 if use_2cta_instrs else 1
     mma_m = 256 if use_2cta_instrs else 128
-    dense_hd64_2cta = use_2cta_instrs and hd == 64
+    hd64_2cta = use_2cta_instrs and hd == 64
+    dense_hd64_2cta = hd64_2cta and not is_causal
     pfor2_count = 2 * 128 if use_2cta_instrs else 128
     pfor_count = (
         pfor2_count
@@ -6299,7 +6911,7 @@ def emit_flash_fa4_device_body(
         if use_2cta_instrs
         else 2 * 128
     )
-    pfor_self_cta_rank = "None" if dense_hd64_2cta else "flash_mma_tile_coord_v"
+    pfor_self_cta_rank = "None" if hd64_2cta else "flash_mma_tile_coord_v"
     pfor_peer_arg = (
         f", cutlass.Int32(0), {pfor_self_cta_rank}" if use_2cta_instrs else ""
     )
@@ -6348,6 +6960,8 @@ def emit_flash_fa4_device_body(
         and _flash_bool_env("HELION_CUTE_FLASH_ROLE_CHAIN", role_chain_default)
     )
     storage_extra_args = f", {epi_smem!s}, {use_clc_scheduler!s}, {cfg.clc_stages}"
+    if separate_kv_rings:
+        storage_extra_args += ", True"
     prefetch_epi_tma = (
         "\n    cute_cpasync_flash.prefetch_descriptor(_flash_tma_o)"
         if cfg.epi_tma
@@ -6490,6 +7104,16 @@ flash_m_tile0 = flash_m_pair * 2
 flash_m_tile1 = flash_m_pair * 2 + 1
 flash_q_mma_tile0 = flash_m_tile0
 flash_q_mma_tile1 = flash_m_tile1"""
+    if cfg.causal_two_cta:
+        causal_setup_pid = f"""
+flash_pid = cutlass.Int32(cute.arch.cluster_idx()[0])
+flash_m_pair_raw = flash_pid % {num_m_pairs}
+flash_bh = flash_pid // {num_m_pairs}
+flash_m_pair = {num_m_pairs - 1} - flash_m_pair_raw
+flash_q_mma_tile0 = flash_m_pair * 2
+flash_q_mma_tile1 = flash_q_mma_tile0 + 1
+flash_m_tile0 = flash_q_mma_tile0 * 2 + flash_mma_tile_coord_v
+flash_m_tile1 = flash_q_mma_tile1 * 2 + flash_mma_tile_coord_v"""
     if cfg.use_2cta_instrs:
         noncausal_setup_pid = f"""
 flash_pid = cutlass.Int32(cute.arch.cluster_idx()[0])
@@ -6521,12 +7145,15 @@ flash_q_mma_tile1 = flash_m_tile1"""
     setup_pid = (
         "" if persistent else (causal_setup_pid if is_causal else noncausal_setup_pid)
     )
-    active_kv_setup = (
-        """
+    if cfg.causal_two_cta:
+        active_kv_setup = """
+flash_num_active_kv = (
+    (flash_q_mma_tile1 + cutlass.Int32(1)) * cutlass.Int32(2))"""
+    elif is_causal:
+        active_kv_setup = """
 flash_num_active_kv = flash_m_tile1 + cutlass.Int32(1)"""
-        if is_causal
-        else ""
-    )
+    else:
+        active_kv_setup = ""
     if persistent:
         setup_gmem_slice = ""
     elif use_tensor_4d_tma:
@@ -6541,8 +7168,8 @@ tVgV = tVgV_dkl[None, 0, None, flash_head, flash_batch]"""
 tQgQ = tQgQ_qdl[None, None, 0, flash_bh]
 tKgK = tKgK_kdl[None, None, 0, flash_bh]
 tVgV = tVgV_dkl[None, 0, None, flash_bh]"""
-    cta_group_setup = (
-        """
+    if use_2cta_instrs:
+        cta_group_setup = """
 flash_mma_tile_coord_v = cute.arch.make_warp_uniform(
     cute.arch.block_idx_in_cluster())
 flash_cga2_local_rank = cutlass.Int32(0)
@@ -6553,8 +7180,8 @@ flash_tcgen05_mcast_mask = (
     cutlass_pipeline_flash.PipelineUmmaAsync._compute_tmem_sync_mask(
         flash_cta_layout_vmnk))
 """
-        if use_2cta_instrs
-        else """
+    elif use_cga2_local_cta:
+        cta_group_setup = """
 flash_mma_tile_coord_v = cutlass.Int32(0)
 flash_cga2_local_rank = cute.arch.make_warp_uniform(
     cute.arch.block_idx_in_cluster())
@@ -6562,8 +7189,8 @@ flash_is_leader_cta = cutlass.Boolean(True)
 flash_cta_layout_vmnk = None
 flash_tcgen05_mcast_mask = None
 """
-        if use_cga2_local_cta
-        else """
+    elif use_clc_scheduler:
+        cta_group_setup = """
 flash_mma_tile_coord_v = cutlass.Int32(0)
 flash_cga2_local_rank = cutlass.Int32(0)
 flash_is_leader_cta = cutlass.Boolean(True)
@@ -6571,15 +7198,14 @@ flash_cta_layout_vmnk = cute.tiled_divide(
     cute.make_layout((1, 1, 1)), (_flash_qk_mma.thr_id.shape,))
 flash_tcgen05_mcast_mask = None
 """
-        if use_clc_scheduler
-        else """
+    else:
+        cta_group_setup = """
 flash_mma_tile_coord_v = cutlass.Int32(0)
 flash_cga2_local_rank = cutlass.Int32(0)
 flash_is_leader_cta = cutlass.Boolean(True)
 flash_cta_layout_vmnk = None
 flash_tcgen05_mcast_mask = None
 """
-    )
     mixed_p_store = cfg.p_store_repetition == 32 and split_p_arrive
     p_store_repetition = 16 if mixed_p_store else cfg.p_store_repetition
     p_store_mixed_setup = (
@@ -6617,14 +7243,7 @@ tVsV, tVgV_dkl = cute_cpasync_flash.tma_partition(
     _flash_tma_v, 0, cute.make_layout(1),
     cute.group_modes(sV, 0, 3), cute.group_modes(tOgV, 0, 3)){setup_gmem_slice}"""
     )
-    fa4_stat_handoff = (
-        cfg.exp2_impl == "split"
-        and not is_causal
-        and hd == 64
-        and not has_lse
-        and not score_plan.modifiers
-        and _flash_bool_env("HELION_CUTE_FLASH_FA4_STAT_HANDOFF", True)
-    )
+    fa4_stat_handoff = cfg.stat_transport == "single"
     scale_layout = (
         f"cute.make_layout(({q_stage} * 128))"
         if fa4_stat_handoff
@@ -6636,6 +7255,39 @@ tVsV, tVgV_dkl = cute_cpasync_flash.tma_partition(
             return f"flash_scale_t[{stage} * 128 + flash_local_tidx]"
         return f"flash_scale_t[{index}, {stage}, flash_local_tidx]"
 
+    smem_kv_setup = (
+        "sK = storage.sK.get_tensor(_flash_ksl.outer, swizzle=_flash_ksl.inner)\n"
+        "sV = storage.sV.get_tensor(_flash_vsl.outer, swizzle=_flash_vsl.inner)"
+        if separate_kv_rings
+        else "sK = storage.sK.get_tensor(_flash_ksl.outer, swizzle=_flash_ksl.inner)\n"
+        "sV = cute.make_tensor(cute.recast_ptr(sK.iterator, _flash_vsl.inner), "
+        "_flash_vsl.outer)"
+    )
+    if separate_kv_rings:
+        kv_pipeline_setup = f"""flash_v_bytes = cute.size_in_bytes({io_dtype}, cute.select(_flash_vsl, mode=[0, 1, 2])){kv_tma_byte_scale}
+flash_k_prod, flash_k_cons = cutlass_pipeline_flash.PipelineTmaUmma.create(
+    num_stages={kv_stage},
+    producer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
+    consumer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
+    tx_count=flash_k_bytes, barrier_storage=storage.k_mbar_ptr.data_ptr(){kv_tma_cluster_arg},
+    defer_sync=True).make_participants()
+flash_v_prod, flash_v_cons = cutlass_pipeline_flash.PipelineTmaUmma.create(
+    num_stages={kv_stage},
+    producer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
+    consumer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
+    tx_count=flash_v_bytes, barrier_storage=storage.v_mbar_ptr.data_ptr(){kv_tma_cluster_arg}).make_participants(){cluster_init_arrive}{cluster_init_wait}"""
+    else:
+        kv_pipeline_setup = f"""flash_kv_prod, flash_kv_cons = cutlass_pipeline_flash.PipelineTmaUmma.create(
+    num_stages={kv_stage},
+    producer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
+    consumer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
+    tx_count=flash_k_bytes, barrier_storage=storage.kv_mbar_ptr.data_ptr(){kv_tma_cluster_arg}).make_participants(){cluster_init_arrive}{cluster_init_wait}{clc_setup}"""
+
+    storage_size_assert = (
+        f"\nassert _flash_storage_cls.size_in_bytes() == {verified_shared_memory_bytes}"
+        if verified_shared_memory_bytes is not None
+        else ""
+    )
     setup = f"""
 tidx, _, _ = cute.arch.thread_idx()
 warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -6643,12 +7295,11 @@ warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 flash_local_tidx = tidx % 128{prefetch_descriptors}
 
 _flash_storage_cls = _helion_flash_rt.flash_fa4_shared_storage(
-    {hd}, {kv_stage}, {q_stage}, {s_corr_stage}, {io_dtype}{storage_extra_args})
+    {hd}, {kv_stage}, {q_stage}, {s_corr_stage}, {io_dtype}{storage_extra_args}){storage_size_assert}
 smem = cutlass_utils_flash.SmemAllocator()
 storage = smem.allocate(_flash_storage_cls)
 sQ = storage.sQ.get_tensor(_flash_qsl.outer, swizzle=_flash_qsl.inner)
-sK = storage.sK.get_tensor(_flash_ksl.outer, swizzle=_flash_ksl.inner)
-sV = cute.make_tensor(cute.recast_ptr(sK.iterator, _flash_vsl.inner), _flash_vsl.outer)
+{smem_kv_setup}
 flash_scale_t = storage.sScale.get_tensor({scale_layout})
 
 # Raw mbarrier init -> fence -> CTA sync, before the pipelines.
@@ -6696,11 +7347,7 @@ flash_q_prod, flash_q_cons = cutlass_pipeline_flash.PipelineTmaUmma.create(
     producer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
     consumer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
     tx_count=flash_q_bytes, barrier_storage=storage.q_mbar_ptr.data_ptr(){q_tma_cluster_arg}).make_participants()
-flash_kv_prod, flash_kv_cons = cutlass_pipeline_flash.PipelineTmaUmma.create(
-    num_stages={kv_stage},
-    producer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
-    consumer_group=cutlass_pipeline_flash.CooperativeGroup(cutlass_pipeline_flash.Agent.Thread),
-    tx_count=flash_k_bytes, barrier_storage=storage.kv_mbar_ptr.data_ptr(){kv_tma_cluster_arg}).make_participants(){cluster_init_arrive}{cluster_init_wait}{clc_setup}
+{kv_pipeline_setup}
 
 flash_qkt = _flash_qk_mma.get_slice(flash_mma_tile_coord_v)
 flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
@@ -7069,7 +7716,7 @@ if warp_idx == 15:
         return (
             "_helion_flash_rt.mbar_spin_wait(\n"
             f"            flash_corr_epi_full_ptr + {stage}, "
-            "flash_corr_epi_full_phase)"
+            f"flash_corr_epi_full_phase, {cfg.wait_hint})"
         )
 
     def _epi_release_corr_empty(stage: str) -> str:
@@ -7215,10 +7862,12 @@ if warp_idx == 15:
     load_q1 = f"""        flash_qe1 = flash_q_prod.acquire_and_advance()
         cute.copy(_flash_tma_q, tQgQ[None, {load_q1_src}], tQsQ[None, flash_qe1.index],
                   tma_bar_ptr=flash_qe1.barrier)"""
-    load_k0 = f"""        flash_kve = flash_kv_prod.acquire_and_advance()
+    load_k_prod = "flash_k_prod" if separate_kv_rings else "flash_kv_prod"
+    load_v_prod = "flash_v_prod" if separate_kv_rings else "flash_kv_prod"
+    load_k0 = f"""        flash_kve = {load_k_prod}.acquire_and_advance()
         cute.copy(_flash_tma_k, tKgK[None, {load_first_kv}], tKsK[None, flash_kve.index],
                   tma_bar_ptr=flash_kve.barrier)"""
-    load_v0 = f"""        flash_kve = flash_kv_prod.acquire_and_advance()
+    load_v0 = f"""        flash_kve = {load_v_prod}.acquire_and_advance()
         cute.copy(_flash_tma_v, tVgV[None, {load_first_kv}], tVsV[None, flash_kve.index],
                   tma_bar_ptr=flash_kve.barrier)"""
     load_prologue = _flash_fa4_load_prologue_for_order(
@@ -7227,19 +7876,24 @@ if warp_idx == 15:
     load_inner = f"""{local_load_tma_block}{load_prologue}
         for {load_loop_var} in cutlass.range({kv_loop_bound_minus_1}, unroll=1):
             flash_kv_next = {load_next_kv}
-            flash_kve = flash_kv_prod.acquire_and_advance()
+            flash_kve = {load_k_prod}.acquire_and_advance()
             cute.copy(_flash_tma_k, tKgK[None, flash_kv_next], tKsK[None, flash_kve.index],
                       tma_bar_ptr=flash_kve.barrier)
-            flash_kve = flash_kv_prod.acquire_and_advance()
+            flash_kve = {load_v_prod}.acquire_and_advance()
             cute.copy(_flash_tma_v, tVgV[None, flash_kv_next], tVsV[None, flash_kve.index],
                       tma_bar_ptr=flash_kve.barrier)"""
+    load_tail = (
+        "    flash_k_prod.tail()\n    flash_v_prod.tail()\n    flash_q_prod.tail()"
+        if separate_kv_rings
+        else "    flash_kv_prod.tail()\n    flash_q_prod.tail()"
+    )
     load_block = _flash_fa4_wrap(
         f"{role_next} warp_idx == {load_warp}:",
         load_head,
         load_inner,
         persistent,
         prelude=load_prelude_mode,
-        tail="    flash_kv_prod.tail()\n    flash_q_prod.tail()",
+        tail=load_tail,
         total_tiles=total_tiles,
         num_m_pairs=num_m_pairs,
         use_2cta_instrs=use_2cta_instrs,
@@ -7265,7 +7919,10 @@ if warp_idx == 15:
     # and 1/4 PV K-chunks. The S/O TMEM column addresses are loop-invariant (TMEM is
     # fixed for the whole kernel) so they are hoisted into the head.
     def _mma_wait_p_ready(stage: str) -> str:
-        return f"_helion_flash_rt.mbar_spin_wait(flash_pfor_ptr + {stage}, flash_pfor_phase)"
+        return (
+            "_helion_flash_rt.mbar_spin_wait("
+            f"flash_pfor_ptr + {stage}, flash_pfor_phase, {cfg.wait_hint})"
+        )
 
     def _mma_commit_s_ready(stage: str) -> str:
         return (
@@ -7279,6 +7936,8 @@ if warp_idx == 15:
             f"    cute_tcgen05_flash.commit(flash_o_full_ptr + {stage}{commit_group_arg})"
         )
 
+    mma_k_cons = "flash_k_cons" if separate_kv_rings else "flash_kv_cons"
+    mma_v_cons = "flash_v_cons" if separate_kv_rings else "flash_kv_cons"
     if cfg.mma_ptx:
         # Each CTA owns 128 Q rows even when a CtaGroup.TWO MMA spans 256 rows.
         # SMEM descriptors use 16-byte units, so derive the stage stride from
@@ -7363,11 +8022,13 @@ if warp_idx == 15:
             if split_p_arrive
             else ""
         )
+        pv_wait_hint_arg = f", wait_hint={cfg.wait_hint}"
 
         # STEADY-loop body (in-place P): PV(i) issued BEFORE QK(i+1) -- the PV-before-QK
         # program order is what protects the in-place P-over-S; the pfor2 wait is folded
         # inside the PV gemm.
-        mma_steady_body = f"""
+        if cfg.mma_interleave:
+            mma_steady_body = f"""
             # stage 0: PV0(i) (pfor2 wait folded inside the gemm) then QK0(i+1).
             {_mma_wait_p_ready("0")}
             _helion_flash_ptx.gemm_ptx_precomputed_pv_ts(
@@ -7378,9 +8039,9 @@ if warp_idx == 15:
                 tOrP0[None, None, None, 0].layout,
                 tOrV[None, None, None, 0].layout,
                 "helion_flash_pv_mma_idesc",{pv0_split_wait_arg}
-                zero_init=flash_o_zero0{gemm_cta_group_arg})
+                zero_init=flash_o_zero0{gemm_cta_group_arg}{pv_wait_hint_arg})
             flash_o_zero0 = cutlass.Boolean(False)
-            flash_k_full = flash_kv_cons.wait_and_advance()
+            flash_k_full = {mma_k_cons}.wait_and_advance()
 {_qk_gemm("0", "flash_k_full")}
 {textwrap.indent(_mma_commit_s_ready("0"), "            ")}
             # stage 1: PV1(i) (pfor2 folded) then QK1(i+1).
@@ -7393,9 +8054,41 @@ if warp_idx == 15:
                 tOrP1[None, None, None, 0].layout,
                 tOrV[None, None, None, 0].layout,
                 "helion_flash_pv_mma_idesc",{pv1_split_wait_arg}
-                zero_init=flash_o_zero1{gemm_cta_group_arg})
+                zero_init=flash_o_zero1{gemm_cta_group_arg}{pv_wait_hint_arg})
             flash_o_zero1 = cutlass.Boolean(False)
             flash_v_full.release()
+{_qk_gemm("1", "flash_k_full")}
+{textwrap.indent(_mma_commit_s_ready("1"), "            ")}
+            flash_k_full.release()"""
+        else:
+            mma_steady_body = f"""
+            # grouped issue: finish both PV stages before starting either next QK.
+            {_mma_wait_p_ready("0")}
+            _helion_flash_ptx.gemm_ptx_precomputed_pv_ts(
+                flash_o0_addr, {pv_p0},
+                _helion_flash_ptx.make_smem_desc_start_addr(
+                    sV[None, None, None, flash_v_full.index].iterator),
+                flash_v_smem_base,
+                tOrP0[None, None, None, 0].layout,
+                tOrV[None, None, None, 0].layout,
+                "helion_flash_pv_mma_idesc",{pv0_split_wait_arg}
+                zero_init=flash_o_zero0{gemm_cta_group_arg}{pv_wait_hint_arg})
+            flash_o_zero0 = cutlass.Boolean(False)
+            {_mma_wait_p_ready("1")}
+            _helion_flash_ptx.gemm_ptx_precomputed_pv_ts(
+                flash_o1_addr, {pv_p1},
+                _helion_flash_ptx.make_smem_desc_start_addr(
+                    sV[None, None, None, flash_v_full.index].iterator),
+                flash_v_smem_base,
+                tOrP1[None, None, None, 0].layout,
+                tOrV[None, None, None, 0].layout,
+                "helion_flash_pv_mma_idesc",{pv1_split_wait_arg}
+                zero_init=flash_o_zero1{gemm_cta_group_arg}{pv_wait_hint_arg})
+            flash_o_zero1 = cutlass.Boolean(False)
+            flash_v_full.release()
+            flash_k_full = {mma_k_cons}.wait_and_advance()
+{_qk_gemm("0", "flash_k_full")}
+{textwrap.indent(_mma_commit_s_ready("0"), "            ")}
 {_qk_gemm("1", "flash_k_full")}
 {textwrap.indent(_mma_commit_s_ready("1"), "            ")}
             flash_k_full.release()"""
@@ -7403,7 +8096,7 @@ if warp_idx == 15:
         flash_q1_full = flash_q_cons.wait_and_advance()
 
         # PROLOGUE: QK0(0)->S0, QK1(0)->S1 against K0; then release K0.
-        flash_k0_full = flash_kv_cons.wait_and_advance()
+        flash_k0_full = {mma_k_cons}.wait_and_advance()
 {textwrap.indent(_qk_gemm("0", "flash_k0_full").lstrip(), "        ")}
 {textwrap.indent(_mma_commit_s_ready("0"), "        ")}
 {textwrap.indent(_qk_gemm("1", "flash_k0_full").lstrip(), "        ")}
@@ -7415,14 +8108,14 @@ if warp_idx == 15:
         flash_o_zero0 = cutlass.Boolean(True)
         flash_o_zero1 = cutlass.Boolean(True)
         for flash_i in cutlass.range({kv_loop_bound_minus_1}, unroll=1):
-            flash_v_full = flash_kv_cons.wait_and_advance(){mma_steady_body}
+            flash_v_full = {mma_v_cons}.wait_and_advance(){mma_steady_body}
             flash_pfor_phase ^= 1
 
         flash_q0_full.release()
         flash_q1_full.release()
 
         # EPILOGUE: PV(N-1) for both stages; commit O_full.
-        flash_v_full = flash_kv_cons.wait_and_advance()
+        flash_v_full = {mma_v_cons}.wait_and_advance()
         {_mma_wait_p_ready("0")}
         _helion_flash_ptx.gemm_ptx_precomputed_pv_ts(
             flash_o0_addr, {pv_p0},
@@ -7432,7 +8125,7 @@ if warp_idx == 15:
             tOrP0[None, None, None, 0].layout,
             tOrV[None, None, None, 0].layout,
             "helion_flash_pv_mma_idesc",{pv0_split_wait_arg}
-            zero_init=flash_o_zero0{gemm_cta_group_arg})
+            zero_init=flash_o_zero0{gemm_cta_group_arg}{pv_wait_hint_arg})
 {textwrap.indent(_mma_commit_o_ready("0"), "        ")}
         {_mma_wait_p_ready("1")}
         _helion_flash_ptx.gemm_ptx_precomputed_pv_ts(
@@ -7443,7 +8136,7 @@ if warp_idx == 15:
             tOrP1[None, None, None, 0].layout,
             tOrV[None, None, None, 0].layout,
             "helion_flash_pv_mma_idesc",{pv1_split_wait_arg}
-            zero_init=flash_o_zero1{gemm_cta_group_arg})
+            zero_init=flash_o_zero1{gemm_cta_group_arg}{pv_wait_hint_arg})
 {textwrap.indent(_mma_commit_o_ready("1"), "        ")}
         flash_v_full.release()
         # The 2 epilogue PV waits did NOT flip pfor_phase; flip once so the carried
@@ -7461,7 +8154,7 @@ if warp_idx == 15:
         flash_q1_full = flash_q_cons.wait_and_advance()
 
         # PROLOGUE: QK0(0)->S0, QK1(0)->S1 against K0; then release K0.
-        flash_k0_full = flash_kv_cons.wait_and_advance()
+        flash_k0_full = {mma_k_cons}.wait_and_advance()
         for flash_kp in cutlass.range(flash_nk, unroll_full=True):
             _flash_qk_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, flash_kp != 0)
             cute.gemm(_flash_qk_mma, tStS0, tSrQ[None, None, flash_kp, flash_q0_full.index],
@@ -7480,20 +8173,20 @@ if warp_idx == 15:
         flash_O_acc0 = False
         flash_O_acc1 = False
         for flash_i in cutlass.range({kv_loop_bound_minus_1}, unroll=1):
-            flash_v_full = flash_kv_cons.wait_and_advance()
+            flash_v_full = {mma_v_cons}.wait_and_advance()
             # stage 0: PV0(i) then QK0(i+1). STAGED-P: first 96 kv on pfor.
-            _helion_flash_rt.mbar_spin_wait(flash_pfor_ptr + 0, flash_pfor_phase)
+            _helion_flash_rt.mbar_spin_wait(flash_pfor_ptr + 0, flash_pfor_phase, {cfg.wait_hint})
             for flash_kp in cutlass.range_constexpr(flash_pv_split):
                 _flash_pv_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, flash_O_acc0 | (flash_kp != 0))
                 cute.gemm(_flash_pv_mma, tOtO0, tOrP0[None, None, flash_kp, 0],
                           tOrV[None, None, flash_kp, flash_v_full.index], tOtO0)
-            _helion_flash_rt.mbar_spin_wait(flash_pfor2_ptr + 0, flash_pfor_phase)
+            _helion_flash_rt.mbar_spin_wait(flash_pfor2_ptr + 0, flash_pfor_phase, {cfg.wait_hint})
             for flash_kp in cutlass.range_constexpr(flash_pv_split, flash_nk2):
                 _flash_pv_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, True)
                 cute.gemm(_flash_pv_mma, tOtO0, tOrP0[None, None, flash_kp, 0],
                           tOrV[None, None, flash_kp, flash_v_full.index], tOtO0)
             flash_O_acc0 = True
-            flash_k_full = flash_kv_cons.wait_and_advance()
+            flash_k_full = {mma_k_cons}.wait_and_advance()
             for flash_kp in cutlass.range(flash_nk, unroll_full=True):
                 _flash_qk_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, flash_kp != 0)
                 cute.gemm(_flash_qk_mma, tStS0, tSrQ[None, None, flash_kp, flash_q0_full.index],
@@ -7501,12 +8194,12 @@ if warp_idx == 15:
             with cute.arch.elect_one():
                 cute_tcgen05_flash.commit(flash_s_full_ptr + 0{commit_group_arg})
             # stage 1: PV1(i) then QK1(i+1). STAGED-P: first 96 kv on pfor.
-            _helion_flash_rt.mbar_spin_wait(flash_pfor_ptr + 1, flash_pfor_phase)
+            _helion_flash_rt.mbar_spin_wait(flash_pfor_ptr + 1, flash_pfor_phase, {cfg.wait_hint})
             for flash_kp in cutlass.range_constexpr(flash_pv_split):
                 _flash_pv_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, flash_O_acc1 | (flash_kp != 0))
                 cute.gemm(_flash_pv_mma, tOtO1, tOrP1[None, None, flash_kp, 0],
                           tOrV[None, None, flash_kp, flash_v_full.index], tOtO1)
-            _helion_flash_rt.mbar_spin_wait(flash_pfor2_ptr + 1, flash_pfor_phase)
+            _helion_flash_rt.mbar_spin_wait(flash_pfor2_ptr + 1, flash_pfor_phase, {cfg.wait_hint})
             for flash_kp in cutlass.range_constexpr(flash_pv_split, flash_nk2):
                 _flash_pv_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, True)
                 cute.gemm(_flash_pv_mma, tOtO1, tOrP1[None, None, flash_kp, 0],
@@ -7526,25 +8219,25 @@ if warp_idx == 15:
         flash_q1_full.release()
 
         # EPILOGUE: PV(N-1) for both stages; commit O_full.
-        flash_v_full = flash_kv_cons.wait_and_advance()
-        _helion_flash_rt.mbar_spin_wait(flash_pfor_ptr + 0, flash_pfor_phase)
+        flash_v_full = {mma_v_cons}.wait_and_advance()
+        _helion_flash_rt.mbar_spin_wait(flash_pfor_ptr + 0, flash_pfor_phase, {cfg.wait_hint})
         for flash_kp in cutlass.range_constexpr(flash_pv_split):
             _flash_pv_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, flash_O_acc0 | (flash_kp != 0))
             cute.gemm(_flash_pv_mma, tOtO0, tOrP0[None, None, flash_kp, 0],
                       tOrV[None, None, flash_kp, flash_v_full.index], tOtO0)
-        _helion_flash_rt.mbar_spin_wait(flash_pfor2_ptr + 0, flash_pfor_phase)
+        _helion_flash_rt.mbar_spin_wait(flash_pfor2_ptr + 0, flash_pfor_phase, {cfg.wait_hint})
         for flash_kp in cutlass.range_constexpr(flash_pv_split, flash_nk2):
             _flash_pv_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, True)
             cute.gemm(_flash_pv_mma, tOtO0, tOrP0[None, None, flash_kp, 0],
                       tOrV[None, None, flash_kp, flash_v_full.index], tOtO0)
         with cute.arch.elect_one():
             cute_tcgen05_flash.commit(flash_o_full_ptr + 0{commit_group_arg})
-        _helion_flash_rt.mbar_spin_wait(flash_pfor_ptr + 1, flash_pfor_phase)
+        _helion_flash_rt.mbar_spin_wait(flash_pfor_ptr + 1, flash_pfor_phase, {cfg.wait_hint})
         for flash_kp in cutlass.range_constexpr(flash_pv_split):
             _flash_pv_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, flash_O_acc1 | (flash_kp != 0))
             cute.gemm(_flash_pv_mma, tOtO1, tOrP1[None, None, flash_kp, 0],
                       tOrV[None, None, flash_kp, flash_v_full.index], tOtO1)
-        _helion_flash_rt.mbar_spin_wait(flash_pfor2_ptr + 1, flash_pfor_phase)
+        _helion_flash_rt.mbar_spin_wait(flash_pfor2_ptr + 1, flash_pfor_phase, {cfg.wait_hint})
         for flash_kp in cutlass.range_constexpr(flash_pv_split, flash_nk2):
             _flash_pv_mma.set(cute_tcgen05_flash.Field.ACCUMULATE, True)
             cute.gemm(_flash_pv_mma, tOtO1, tOrP1[None, None, flash_kp, 0],
@@ -7615,34 +8308,56 @@ if warp_idx == 15:
         else ""
     )
     softmax_not_first = "flash_kv_iter != 0" if desc_kv else "flash_kv != 0"
+    defer_causal_minus_scale = (
+        is_causal and _flash_fa4_runtime_disc_score_plan_supported(score_plan)
+    )
 
     # FA4 rescale_threshold (alpha-pin) softmax block. When the running max grows by
     # less than the threshold (scale_log2*(old-new) >= -thresh), keep the OLD max and
     # pin alpha=1.0 so the correction warp's vote_ballot(alpha<1.0) is false for the
     # whole warp -> the O-rescale (t2r/mul/r2t/fence) on the correction->PV critical
-    # path is SKIPPED. ``flash_minus_max_scale`` is computed AFTER the pin so
-    # PASS2's exp2 consumes the (possibly kept-old) max. The threshold is a static
-    # codegen constant (literal), so the compare is const-folded; threshold==0.0
-    # (fp8) emits the prior always-rescale block byte-identically.
+    # path is SKIPPED. For causal chunked softmax, the private
+    # ``flash_minus_max_scale`` computation follows alpha publication, shortening
+    # the correction handoff while still consuming the possibly pinned max before
+    # PASS2. Other paths retain their measured schedule; threshold==0.0 (fp8)
+    # emits the prior block byte-identically.
     # Stage-parameterized, so one definition covers both softmax warpgroups (0/1).
-    def _disc_alpha_block_for(not_first: str) -> str:
+    def _disc_alpha_blocks_for(not_first: str) -> tuple[str, str]:
         if cfg.rescale_threshold > 0.0:
             pin_condition = (
                 f"({not_first}) & (flash_acc_log >= -{cfg.rescale_threshold})"
             )
-            return f"""            flash_acc_log = _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe)
+            if defer_causal_minus_scale:
+                return (
+                    f"""            flash_acc_log = _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe)
+            flash_alpha = cute.math.exp2(flash_acc_log, fastmath=True)
+            if {pin_condition}:
+                flash_row_max = flash_old_row_max
+                flash_row_max_safe = flash_old_row_max
+                flash_alpha = cutlass.Float32(1.0)""",
+                    "            flash_minus_max_scale = (0.0 - flash_row_max_safe) * _flash_scale_log2",
+                )
+            return (
+                f"""            flash_acc_log = _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe)
             flash_alpha = cute.math.exp2(flash_acc_log, fastmath=True)
             if {pin_condition}:
                 flash_row_max = flash_old_row_max
                 flash_row_max_safe = flash_old_row_max
                 flash_alpha = cutlass.Float32(1.0)
-            flash_minus_max_scale = (0.0 - flash_row_max_safe) * _flash_scale_log2"""
+            flash_minus_max_scale = (0.0 - flash_row_max_safe) * _flash_scale_log2""",
+                "",
+            )
 
-        return """            flash_minus_max_scale = (0.0 - flash_row_max_safe) * _flash_scale_log2
+        return (
+            """            flash_minus_max_scale = (0.0 - flash_row_max_safe) * _flash_scale_log2
             flash_alpha = cute.math.exp2(
-                _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe), fastmath=True)"""
+                _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe), fastmath=True)""",
+            "",
+        )
 
-    _disc_alpha_block = _disc_alpha_block_for(softmax_not_first)
+    _disc_alpha_block, _disc_minus_scale_block = _disc_alpha_blocks_for(
+        softmax_not_first
+    )
     # The whole-row (non-disc) body computes flash_minus_max_scale BEFORE the exp2
     # PASS (which consumes it) and flash_alpha AFTER, so the alpha-pin reorders to a
     # PRE-exp block (decide alpha + pin the max) so the kept-old max feeds the exp
@@ -7669,7 +8384,10 @@ if warp_idx == 15:
                 _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe), fastmath=True)"""
 
     def _softmax_wait_s_ready(stage: str) -> str:
-        return f"_helion_flash_rt.mbar_spin_wait(flash_s_full_ptr + {stage}, flash_s_full_phase)"
+        return (
+            "_helion_flash_rt.mbar_spin_wait("
+            f"flash_s_full_ptr + {stage}, flash_s_full_phase, {cfg.wait_hint})"
+        )
 
     def _softmax_release_p_ready(stage: str) -> str:
         return ""
@@ -7683,9 +8401,20 @@ if warp_idx == 15:
         score_st: str,
         score_stt: str,
     ) -> str:
+        score_m_tile_expr = (
+            f"flash_q_mma_tile{stage} * cutlass.Int32(2)"
+            if use_2cta_instrs
+            else f"flash_m_tile{stage}"
+        )
+
         def _format_disc_pass2(name: str, *, causal: bool) -> str:
             e2e_freq = cfg.masked_e2e_freq if causal else cfg.e2e_freq
             e2e_res = cfg.masked_e2e_res if causal else cfg.e2e_res
+            disc_exp2_codegen = _flash_disc_exp2_codegen_params(
+                cfg.exp2_packet, e2e_freq, e2e_res
+            )
+            e2e_freq = disc_exp2_codegen.e2e_freq
+            e2e_res = disc_exp2_codegen.e2e_res
             e2e_offset = (
                 0
                 if e2e_res == 0
@@ -7734,10 +8463,26 @@ if warp_idx == 15:
             if (cfg.disc_pipe_depth >= 2 or sload16_paired) and not mixed_p_store:
                 args.append(str(cfg.disc_pipe_depth))
             if causal:
-                args.extend([f"flash_m_tile{stage}", "flash_kv"])
+                mask_m_tile = (
+                    f"flash_q_mma_tile{stage} * cutlass.Int32(2)"
+                    if use_2cta_instrs
+                    else f"flash_m_tile{stage}"
+                )
+                args.extend([mask_m_tile, "flash_kv"])
             args.append(io_dtype)
             if use_2cta_instrs:
                 args.extend(["cutlass.Int32(0)", "flash_mma_tile_coord_v"])
+            if disc_exp2_codegen.pair_batch != 1:
+                args.extend(
+                    [
+                        f"pair_batch={disc_exp2_codegen.pair_batch}",
+                        f"emu_batch={disc_exp2_codegen.emu_batch}",
+                    ]
+                )
+            if disc_exp2_codegen.degree1_unmasked and not causal:
+                args.append("degree1=True")
+            elif disc_exp2_codegen.degree2:
+                args.append("degree2=True")
             return f"_helion_flash_rt.{name}(" + ", ".join(args) + ")"
 
         pass2_call = _format_disc_pass2(_disc_pass2_name, causal=False)
@@ -7793,7 +8538,7 @@ if warp_idx == 15:
 {indent}    barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)"""
             publish_alpha_advance = corr_prod_advance.replace("\n", f"\n{indent}")
             return f"""{indent}_helion_flash_rt.mbar_spin_wait(
-{indent}    {corr_empty_ptr} + {corr_prod_index}, flash_s_corr_prod_phase)
+{indent}    {corr_empty_ptr} + {corr_prod_index}, flash_s_corr_prod_phase, {cfg.wait_hint})
 {publish_alpha_store.rstrip()}
 {indent}cute.arch.barrier_arrive(
 {indent}    barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
@@ -7808,7 +8553,7 @@ if warp_idx == 15:
 {lse_store}"""
         else:
             corr_publish_rowsum = f"""        _helion_flash_rt.mbar_spin_wait(
-            {corr_empty_ptr} + {corr_prod_index}, flash_s_corr_prod_phase)
+            {corr_empty_ptr} + {corr_prod_index}, flash_s_corr_prod_phase, {cfg.wait_hint})
         {_scale_slot_expr(corr_prod_index, stage)} = flash_row_sum
         cute.arch.barrier_arrive(
             barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
@@ -7825,7 +8570,7 @@ if warp_idx == 15:
                     score_tensor="flash_disc_frg",
                     coord_tensor="tLDcS[None, flash_ci, None, None]",
                     bh_expr="flash_bh",
-                    m_tile_expr=f"flash_m_tile{stage}",
+                    m_tile_expr=score_m_tile_expr,
                     kv_tile_expr="flash_kv",
                     chunk_expr="flash_ci",
                     io_dtype=io_dtype,
@@ -7834,7 +8579,7 @@ if warp_idx == 15:
             for flash_ci in cutlass.range_constexpr(flash_LD_CHUNKS):
                 flash_disc_frg = cute.make_rmem_tensor(flash_ld_shape, cutlass.Float32)
                 cute.copy({ld}, {ldt}[None, flash_ci, None, None], flash_disc_frg){score_transform}
-                flash_row_max = _helion_flash_rt._fmax_reduce_chunk(flash_disc_frg, flash_row_max)
+                flash_row_max = _helion_flash_rt._fmax_reduce_chunk_balanced(flash_disc_frg, flash_row_max)
                 cute.copy({score_st}, flash_disc_frg, {score_stt}[None, flash_ci, None, None])
             cute.arch.fence_view_async_tmem_load()
             cute.arch.fence_view_async_tmem_store()"""
@@ -7848,7 +8593,7 @@ if warp_idx == 15:
                 return f"""        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)
         for {softmax_loop_var} in cutlass.range({kv_loop_bound}, unroll=1):{softmax_actual_kv}
-            _helion_flash_rt.mbar_spin_wait(flash_s_full_ptr + {stage}, flash_s_full_phase)
+            _helion_flash_rt.mbar_spin_wait(flash_s_full_ptr + {stage}, flash_s_full_phase, {cfg.wait_hint})
             flash_s_full_phase ^= 1
             flash_old_row_max = flash_row_max
 {rowmax_block}
@@ -7857,11 +8602,12 @@ if warp_idx == 15:
                 flash_row_max_safe = cutlass.Float32(0.0)
 {_disc_alpha_block}
 {alpha_publish}
+{_disc_minus_scale_block}
 {pass2_block}
             flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum
 {final_corr_publish_rowsum}"""
             rowmax_dense_call = (
-                f"_helion_flash_rt.fa4_disc_rowmax("
+                f"_helion_flash_rt.fa4_disc_rowmax_balanced("
                 f"{ld}, {ldt}, tLDcS, flash_row_max, flash_LD_CHUNKS)"
             )
             direct_dense_rowmax = f"            flash_row_max = {rowmax_dense_call}"
@@ -7892,32 +8638,40 @@ if warp_idx == 15:
 {textwrap.indent(loop_pass2_block, "    ")}
             else:
                 flash_p_sum = {zero_pass2_call}"""
-                return f"""        for {loop_var} in cutlass.range({loop_bound}, unroll=1):{actual_kv}
-            _helion_flash_rt.mbar_spin_wait(flash_s_full_ptr + {stage}, flash_s_full_phase)
+                alpha_block, minus_scale_block = _disc_alpha_blocks_for(not_first)
+                loop_header = _flash_runtime_range_header(loop_var, loop_bound)
+                return f"""        {loop_header}{actual_kv}
+            _helion_flash_rt.mbar_spin_wait(flash_s_full_ptr + {stage}, flash_s_full_phase, {cfg.wait_hint})
             flash_s_full_phase ^= 1
             flash_old_row_max = flash_row_max
 {loop_rowmax_block}
             flash_row_max_safe = flash_row_max
             if flash_row_max == -cutlass.Float32.inf:
                 flash_row_max_safe = cutlass.Float32(0.0)
-{_disc_alpha_block_for(not_first)}
+{alpha_block}
 {alpha_publish}
+{minus_scale_block}
             flash_p_sum = cutlass.Float32(0.0)
 {loop_pass2_block}
             flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum
 {rowsum_publish}"""
 
             if is_causal:
+                mask_m_tile = score_m_tile_expr
                 rowmax_causal_call = (
-                    f"_helion_flash_rt.fa4_disc_rowmax_causal("
+                    f"_helion_flash_rt.fa4_disc_rowmax_causal_balanced("
                     f"{ld}, {ldt}, tLDcS, flash_row_max, flash_LD_CHUNKS, "
-                    f"flash_m_tile{stage}, flash_kv)"
+                    f"{mask_m_tile}, flash_kv)"
                 )
                 direct_causal_rowmax = (
                     f"            flash_row_max = {rowmax_causal_call}"
                 )
                 direct_causal_pass2 = f"            flash_p_sum = {pass2_causal_call}"
-                if causal_desc_kv and cfg.causal_loop_split:
+                if (
+                    causal_desc_kv
+                    and cfg.causal_loop_split
+                    and causal_split_proof.proven
+                ):
                     masked_loop = _format_disc_loop(
                         "flash_kv_mask_iter",
                         f"{kv_loop_bound} - flash_m_tile{stage}",
@@ -7976,13 +8730,18 @@ if warp_idx == 15:
             return f"""        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)
 {loop}"""
+        score_transform_m_tile = (
+            f"flash_q_mma_tile{stage} * cutlass.Int32(2)"
+            if use_2cta_instrs
+            else f"flash_m_tile{stage}"
+        )
         score_transform = _flash_score_transform_block(
             score_plan,
             indent="            ",
             score_tensor="tLDrS",
             coord_tensor="tLDcS",
             bh_expr="flash_bh",
-            m_tile_expr=f"flash_m_tile{stage}",
+            m_tile_expr=score_transform_m_tile,
             kv_tile_expr="flash_kv",
         )
         if split_p_arrive:
@@ -8056,11 +8815,17 @@ if warp_idx == 15:
                 ]
             if use_2cta_instrs:
                 sp_pass2_args.extend(["cutlass.Int32(0)", pfor_self_cta_rank])
-                if dense_hd64_2cta and not mixed_p_store:
-                    # Eight packed pairs expose enough affine/exp ILP to hide the
-                    # dependency chain without the register pressure of a full
-                    # 32-value fragment. Level-schedule the two software-exp pairs.
-                    sp_pass2_args.extend(["True", "8", "2"])
+                if hd64_2cta and not mixed_p_store:
+                    sp_pass2_args.append("early_split_publish=True")
+            if exp2_codegen.pair_batch != 1:
+                sp_pass2_args.extend(
+                    [
+                        f"pair_batch={exp2_codegen.pair_batch}",
+                        f"emu_batch={exp2_codegen.emu_batch}",
+                    ]
+                )
+            if exp2_codegen.degree1_unmasked:
+                sp_pass2_args.append("degree1=True")
             sp_exp_block = (
                 f"            flash_p_sum = _helion_flash_rt.{sp_pass2_name}("
                 + ", ".join(sp_pass2_args)
@@ -8207,13 +8972,16 @@ if warp_idx == 15:
         )
 
     def _corr_wait_o_ready(stage: str) -> str:
-        return f"_helion_flash_rt.mbar_spin_wait(flash_o_full_ptr + {stage}, flash_o_full_phase)"
+        return (
+            "_helion_flash_rt.mbar_spin_wait("
+            f"flash_o_full_ptr + {stage}, flash_o_full_phase, {cfg.wait_hint})"
+        )
 
     def _corr_wait_epi_empty(stage: str) -> str:
         return (
             "_helion_flash_rt.mbar_spin_wait(\n"
             f"            flash_corr_epi_empty_ptr + {stage}, "
-            "flash_corr_epi_empty_phase)"
+            f"flash_corr_epi_empty_phase, {cfg.wait_hint})"
         )
 
     def _corr_commit_epi_full(stage: str) -> str:
@@ -8335,7 +9103,8 @@ if warp_idx == 15:
             flash_corr_epi_empty_ptr + {stage}, flash_corr_epi_empty_phase,
             flash_corr_epi_full_ptr + {stage},
             flash_pvt, tOtO{stage}, sO[None, None, {stage}], flash_local_tidx,
-            flash_inv_sum{stage}, {hd}, {cfg.corr_tile_size}, {io_dtype})
+            flash_inv_sum{stage}, {hd}, {cfg.corr_tile_size}, {io_dtype},
+            {cfg.wait_hint})
 """
         return f"""        cute.arch.barrier(
             barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
@@ -8347,7 +9116,7 @@ if warp_idx == 15:
             flash_corr_epi_full_ptr + {stage},
             flash_o_tiled_t2r, flash_o_tiled_r2s,
             tOtO{stage}_corr_t2r, tOsO{stage}_corr_r2s, tOcO_corr_t2r,
-            flash_inv_sum{stage}, flash_o_corr_chunks)
+            flash_inv_sum{stage}, flash_o_corr_chunks, {cfg.wait_hint})
 """
 
     corr_epi_empty_toggle = (
@@ -8417,6 +9186,11 @@ if warp_idx == 15:
     # from the rank-zero base tile so the follower does not apply its rank twice.
     corr_output_m_tile0 = output_m_tile0 if not epi_smem else "flash_m_tile0"
     corr_output_m_tile1 = output_m_tile1 if not epi_smem else "flash_m_tile1"
+    corr_steady_stages = (
+        f"{corr_stage1}\n{corr_stage0}"
+        if cfg.exp2_packet == _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
+        else f"{corr_stage0}\n{corr_stage1}"
+    )
     if cfg.skip_rescale_stats:
         corr_inner = f"""        # Final: divide by row_sum, cast, store (waits MMA's last-tile O_full).
 {_corr_epi("0", corr_output_m_tile0)}
@@ -8426,8 +9200,7 @@ if warp_idx == 15:
         flash_o_full_phase ^= 1"""
     else:
         corr_inner = f"""        for flash_kv in cutlass.range({kv_loop_bound_minus_1}, unroll=1):
-{corr_stage0}
-{corr_stage1}
+{corr_steady_stages}
 {textwrap.indent(corr_cons_advance.rstrip(), "    ")}
         # Final: divide by row_sum, cast, store (waits MMA's last-tile O_full).
 {_corr_epi("0", corr_output_m_tile0)}
@@ -9082,6 +9855,14 @@ def codegen_attention_flash(cg: GenerateAST) -> bool:
         flash_config,
         dtype=io_dtype,
         is_causal=is_causal,
+        standard_dense_output=(
+            not is_causal
+            and lse_arg is None
+            and not bias_args
+            and not alibi_args
+            and not document_args
+            and _standard_dense_score_plan_supported(score_plan)
+        ),
         prefer_packed_reduce=bool(score_plan.modifiers),
     )
     clc_heads_per_batch = cfg.clc_heads_per_batch
@@ -9145,7 +9926,9 @@ def codegen_attention_flash(cg: GenerateAST) -> bool:
     # The fa4 topology processes a PAIR of adjacent 128-row Q-tiles per CTA, so
     # its tile space is seq // 256 (requires seq % 256 == 0).
     if cfg.topology == "fa4":
-        fa4_tile_rows = 512 if cfg.use_2cta_instrs or cfg.use_cga2_local_cta else 256
+        fa4_tile_rows = 128 * cfg.q_tile_count
+        if cfg.use_2cta_instrs or cfg.use_cga2_local_cta:
+            fa4_tile_rows *= 2
         if seq % fa4_tile_rows != 0:
             return False
         total_tiles = batch * (seq // fa4_tile_rows)
@@ -9177,7 +9960,7 @@ def codegen_attention_flash(cg: GenerateAST) -> bool:
         "topology": cfg.topology,
         # The fa4 topology stages 2 Q-tiles per CTA -> the Q smem layout must
         # be 2-deep (ws_overlap stages a single Q-tile -> 1).
-        "q_stage": 2 if cfg.topology == "fa4" else 1,
+        "q_stage": cfg.q_tile_count,
         # Lever A: build the O TMA-store atom host-side and pass it to the corr
         # epilogue (fa4-only; the env gate already forced topology == "fa4").
         "epi_tma": cfg.epi_tma,
@@ -9272,6 +10055,7 @@ def codegen_attention_flash(cg: GenerateAST) -> bool:
                 df,
                 head_dim=head_dim,
                 num_kv=num_kv,
+                sequence_extent=seq,
                 num_bh=batch,
                 total_tiles=total_tiles,
                 cfg=cfg,

--- a/helion/_compiler/cute/flash_schedule.py
+++ b/helion/_compiler/cute/flash_schedule.py
@@ -1,0 +1,1063 @@
+from __future__ import annotations
+
+from collections import defaultdict
+import dataclasses
+import enum
+
+
+class FlashScheduleError(ValueError):
+    """A structural flash schedule is unsafe or exceeds device resources."""
+
+
+class FlashNodeKind(enum.Enum):
+    Q_LOAD = "q_load"
+    K_LOAD = "k_load"
+    V_LOAD = "v_load"
+    DIAGONAL_LOAD = "diagonal_load"
+    QK_MMA = "qk_mma"
+    SOFTMAX = "softmax"
+    STAT_PUBLISH = "stat_publish"
+    CORRECTION = "correction"
+    PV_MMA = "pv_mma"
+    OUTPUT_STAGE = "output_stage"
+    OUTPUT_STORE = "output_store"
+
+
+class FlashMemorySpace(enum.Enum):
+    SMEM = "smem"
+    TMEM = "tmem"
+
+
+class FlashVisibility(enum.Enum):
+    CTA_PRIVATE = "cta_private"
+    CLUSTER_VISIBLE = "cluster_visible"
+
+
+class FlashSyncScope(enum.Enum):
+    CTA = "cta"
+    CLUSTER = "cluster"
+    CLUSTER_LEADER = "cluster_leader"
+
+
+class FlashOutputOrder(enum.Enum):
+    INTERLEAVED = "interleaved"
+    CTA_CONTIGUOUS = "cta_contiguous"
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashScheduleSpec:
+    head_dim: int
+    kv_depth: int
+    cta_count: int = 1
+    query_slots_per_cta: int = 2
+    separate_kv: bool = False
+    causal: bool = False
+    multicast_kv: bool = False
+    persistent: bool = False
+    kv_iterations: int | None = None
+    stage_output: bool = True
+    dtype_bytes: int = 2
+    private_causal_tail: bool = False
+    output_order: FlashOutputOrder = FlashOutputOrder.INTERLEAVED
+    cooperative_mma: bool = False
+    split_p_arrive: bool = True
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashNode:
+    name: str
+    kind: FlashNodeKind
+    cta_rank: int | None = None
+    query_slot: int | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashEdge:
+    source: str
+    target: str
+    iteration_delta: int = 0
+    barrier: str | None = None
+    arrival_count: int = 0
+    scope: FlashSyncScope = FlashSyncScope.CTA
+    resource_scope: FlashSyncScope = FlashSyncScope.CTA
+    resource: str | None = None
+    multicast: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashBarrier:
+    name: str
+    expected_arrivals: int
+    scope: FlashSyncScope
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashMemoryRegion:
+    name: str
+    space: FlashMemorySpace
+    offset: int
+    extent: int
+    alignment: int
+    visibility: FlashVisibility
+    writer: str
+    consumers: tuple[str, ...]
+    reuse_distance: int | None = None
+    alias_group: str | None = None
+    cta_rank: int | None = None
+    physical: bool = True
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashOutputOwner:
+    output_tile: int
+    cta_rank: int
+    query_slot: int
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashPhaseCycle:
+    barrier: str
+    phases: tuple[int, ...]
+    uses_per_work: int = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashSchedule:
+    spec: FlashScheduleSpec
+    nodes: tuple[FlashNode, ...]
+    edges: tuple[FlashEdge, ...]
+    barriers: tuple[FlashBarrier, ...]
+    memory_regions: tuple[FlashMemoryRegion, ...]
+    output_owners: tuple[FlashOutputOwner, ...]
+    phase_cycles: tuple[FlashPhaseCycle, ...]
+    shared_memory_bytes: int
+    tmem_columns: int
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashScheduleLimits:
+    shared_memory_bytes: int = 232448
+    tmem_columns: int = 512
+
+
+@dataclasses.dataclass(frozen=True)
+class VerifiedFlashSchedule:
+    schedule: FlashSchedule
+
+    @property
+    def spec(self) -> FlashScheduleSpec:
+        return self.schedule.spec
+
+
+def _node_name(kind: str, cta_rank: int, query_slot: int) -> str:
+    return f"{kind}_r{cta_rank}_q{query_slot}"
+
+
+def _kv_node_name(kind: str, cta_rank: int, multicast: bool) -> str:
+    if multicast:
+        return f"{kind}_multicast"
+    return f"{kind}_r{cta_rank}"
+
+
+def _shared_memory_bytes(spec: FlashScheduleSpec) -> int:
+    tile_bytes = 128 * spec.head_dim * spec.dtype_bytes
+    q_bytes = spec.query_slots_per_cta * tile_bytes
+    kv_rings = 2 if spec.separate_kv else 1
+    kv_bytes = kv_rings * spec.kv_depth * tile_bytes
+    output_bytes = spec.query_slots_per_cta * tile_bytes if spec.stage_output else 0
+    # Scale/stat transport plus aligned barrier storage in the current FA4 layout.
+    return q_bytes + kv_bytes + output_bytes + 3072
+
+
+def _output_tile(spec: FlashScheduleSpec, cta_rank: int, query_slot: int) -> int:
+    if spec.output_order is FlashOutputOrder.CTA_CONTIGUOUS:
+        return cta_rank * spec.query_slots_per_cta + query_slot
+    return query_slot * spec.cta_count + cta_rank
+
+
+def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
+    """Build the structural graph for an FA4-style local schedule.
+
+    Score storage is always two local query slots. With two CTAs this becomes
+    four aggregate CTA-local slices; it is not a temporal four-stage score ring.
+    """
+    if spec.head_dim not in (64, 128):
+        raise FlashScheduleError("FA4 schedule requires head_dim 64 or 128")
+    if spec.kv_depth < 2:
+        raise FlashScheduleError("FA4 schedule requires at least two K/V stages")
+    if spec.cta_count not in (1, 2):
+        raise FlashScheduleError("FA4 schedule supports one or two CTAs")
+    if spec.query_slots_per_cta != 2:
+        raise FlashScheduleError("FA4 schedule requires two local score slots")
+    if spec.multicast_kv and spec.cta_count != 2:
+        raise FlashScheduleError("K/V multicast requires a two-CTA schedule")
+    if spec.cooperative_mma and spec.cta_count != 2:
+        raise FlashScheduleError("a cooperative MMA requires two CTAs")
+    if spec.cooperative_mma and spec.output_order is not FlashOutputOrder.INTERLEAVED:
+        raise FlashScheduleError("a cooperative MMA requires interleaved output")
+    if spec.private_causal_tail and not (spec.causal and spec.multicast_kv):
+        raise FlashScheduleError("a private causal tail requires causal K/V multicast")
+    if not isinstance(spec.output_order, FlashOutputOrder):
+        raise FlashScheduleError("output order is invalid")
+    if spec.dtype_bytes <= 0:
+        raise FlashScheduleError("dtype size must be positive")
+
+    nodes: list[FlashNode] = []
+    edges: list[FlashEdge] = []
+    barriers: list[FlashBarrier] = []
+    regions: list[FlashMemoryRegion] = []
+    owners: list[FlashOutputOwner] = []
+
+    kv_visibility = (
+        FlashVisibility.CLUSTER_VISIBLE
+        if spec.multicast_kv
+        else FlashVisibility.CTA_PRIVATE
+    )
+    kv_scope = FlashSyncScope.CLUSTER if spec.multicast_kv else FlashSyncScope.CTA
+    kv_reuse_arrivals = (
+        1 if spec.cooperative_mma else spec.cta_count if spec.multicast_kv else 1
+    )
+    tile_bytes = 128 * spec.head_dim * spec.dtype_bytes
+    q_bytes = spec.query_slots_per_cta * tile_bytes
+    kv_ring_bytes = spec.kv_depth * tile_bytes
+    k_offset = q_bytes
+    v_offset = k_offset + (kv_ring_bytes if spec.separate_kv else 0)
+    output_offset = q_bytes + (2 if spec.separate_kv else 1) * kv_ring_bytes
+    overhead_offset = output_offset + (
+        spec.query_slots_per_cta * tile_bytes if spec.stage_output else 0
+    )
+
+    load_nodes: set[str] = set()
+    for rank in range(spec.cta_count):
+        k_load = _kv_node_name("k_load", rank, spec.multicast_kv)
+        v_load = _kv_node_name("v_load", rank, spec.multicast_kv)
+        for name, kind in (
+            (k_load, FlashNodeKind.K_LOAD),
+            (v_load, FlashNodeKind.V_LOAD),
+        ):
+            if name not in load_nodes:
+                nodes.append(FlashNode(name, kind, None if spec.multicast_kv else rank))
+                load_nodes.add(name)
+
+        barriers.extend(
+            [
+                FlashBarrier(f"k_ready_r{rank}", 1, kv_scope),
+                FlashBarrier(f"v_ready_r{rank}", 1, kv_scope),
+                FlashBarrier(
+                    f"k_reuse_r{rank}",
+                    kv_reuse_arrivals,
+                    kv_scope,
+                ),
+                FlashBarrier(
+                    f"v_reuse_r{rank}",
+                    kv_reuse_arrivals,
+                    kv_scope,
+                ),
+            ]
+        )
+        # Legacy FA4 alternates K and V acquisitions through one physical
+        # pipeline ring. K names that backing allocation and V is a logical
+        # view; only the separate-ring family has per-operand depth proofs.
+        regions.extend(
+            [
+                FlashMemoryRegion(
+                    f"K_r{rank}",
+                    FlashMemorySpace.SMEM,
+                    k_offset,
+                    kv_ring_bytes,
+                    1024,
+                    kv_visibility,
+                    k_load,
+                    tuple(
+                        _node_name("qk", rank, slot)
+                        for slot in range(spec.query_slots_per_cta)
+                    ),
+                    reuse_distance=spec.kv_depth if spec.separate_kv else None,
+                    alias_group=(
+                        None if spec.separate_kv else f"shared_kv_ring_r{rank}"
+                    ),
+                    cta_rank=rank,
+                ),
+                FlashMemoryRegion(
+                    f"V_r{rank}",
+                    FlashMemorySpace.SMEM,
+                    v_offset,
+                    kv_ring_bytes,
+                    1024,
+                    kv_visibility,
+                    v_load,
+                    tuple(
+                        _node_name("pv", rank, slot)
+                        for slot in range(spec.query_slots_per_cta)
+                    ),
+                    reuse_distance=spec.kv_depth if spec.separate_kv else None,
+                    alias_group=(
+                        None if spec.separate_kv else f"shared_kv_ring_r{rank}"
+                    ),
+                    cta_rank=rank,
+                    physical=spec.separate_kv,
+                ),
+            ]
+        )
+
+        if spec.private_causal_tail:
+            diagonal_k = f"diagonal_k_load_r{rank}"
+            diagonal_v = f"diagonal_v_load_r{rank}"
+            nodes.extend(
+                [
+                    FlashNode(diagonal_k, FlashNodeKind.DIAGONAL_LOAD, rank),
+                    FlashNode(diagonal_v, FlashNodeKind.DIAGONAL_LOAD, rank),
+                ]
+            )
+            regions.extend(
+                [
+                    FlashMemoryRegion(
+                        f"causal_diagonal_K_r{rank}",
+                        FlashMemorySpace.SMEM,
+                        0,
+                        tile_bytes,
+                        1024,
+                        FlashVisibility.CTA_PRIVATE,
+                        diagonal_k,
+                        tuple(
+                            _node_name("qk", rank, slot)
+                            for slot in range(spec.query_slots_per_cta)
+                        ),
+                        cta_rank=rank,
+                        physical=False,
+                    ),
+                    FlashMemoryRegion(
+                        f"causal_diagonal_V_r{rank}",
+                        FlashMemorySpace.SMEM,
+                        0,
+                        tile_bytes,
+                        1024,
+                        FlashVisibility.CTA_PRIVATE,
+                        diagonal_v,
+                        tuple(
+                            _node_name("pv", rank, slot)
+                            for slot in range(spec.query_slots_per_cta)
+                        ),
+                        cta_rank=rank,
+                        physical=False,
+                    ),
+                ]
+            )
+
+    for rank in range(spec.cta_count):
+        k_load = _kv_node_name("k_load", rank, spec.multicast_kv)
+        v_load = _kv_node_name("v_load", rank, spec.multicast_kv)
+        for slot in range(spec.query_slots_per_cta):
+            q_load = _node_name("q_load", rank, slot)
+            qk = _node_name("qk", rank, slot)
+            softmax = _node_name("softmax", rank, slot)
+            stat = _node_name("stat", rank, slot)
+            correction = _node_name("correction", rank, slot)
+            pv = _node_name("pv", rank, slot)
+            output_stage = _node_name("output_stage", rank, slot)
+            output_store = _node_name("output_store", rank, slot)
+            nodes.extend(
+                [
+                    FlashNode(q_load, FlashNodeKind.Q_LOAD, rank, slot),
+                    FlashNode(qk, FlashNodeKind.QK_MMA, rank, slot),
+                    FlashNode(softmax, FlashNodeKind.SOFTMAX, rank, slot),
+                    FlashNode(stat, FlashNodeKind.STAT_PUBLISH, rank, slot),
+                    FlashNode(correction, FlashNodeKind.CORRECTION, rank, slot),
+                    FlashNode(pv, FlashNodeKind.PV_MMA, rank, slot),
+                    FlashNode(output_stage, FlashNodeKind.OUTPUT_STAGE, rank, slot),
+                    FlashNode(output_store, FlashNodeKind.OUTPUT_STORE, rank, slot),
+                ]
+            )
+
+            q_ready = f"q_ready_r{rank}_q{slot}"
+            s_full = f"s_full_r{rank}_q{slot}"
+            stat_ready = f"stat_ready_r{rank}_q{slot}"
+            o_full = f"o_full_r{rank}_q{slot}"
+            barriers.extend(
+                [
+                    FlashBarrier(q_ready, 1, FlashSyncScope.CTA),
+                    FlashBarrier(s_full, 1, FlashSyncScope.CTA),
+                    FlashBarrier(stat_ready, 1, FlashSyncScope.CTA),
+                    FlashBarrier(o_full, 1, FlashSyncScope.CTA),
+                ]
+            )
+            edges.extend(
+                [
+                    FlashEdge(
+                        q_load,
+                        qk,
+                        barrier=q_ready,
+                        arrival_count=1,
+                        resource=f"Q_r{rank}_q{slot}",
+                    ),
+                    FlashEdge(
+                        k_load,
+                        qk,
+                        barrier=f"k_ready_r{rank}" if slot == 0 else None,
+                        arrival_count=1 if slot == 0 else 0,
+                        scope=kv_scope,
+                        resource_scope=kv_scope,
+                        resource=f"K_r{rank}",
+                        multicast=spec.multicast_kv,
+                    ),
+                    FlashEdge(
+                        qk,
+                        softmax,
+                        barrier=s_full,
+                        arrival_count=1,
+                        resource=f"S_r{rank}_q{slot}",
+                    ),
+                    FlashEdge(softmax, stat),
+                    FlashEdge(
+                        stat,
+                        correction,
+                        barrier=stat_ready,
+                        arrival_count=1,
+                        resource=f"STAT_r{rank}_q{slot}",
+                    ),
+                    FlashEdge(
+                        v_load,
+                        pv,
+                        barrier=f"v_ready_r{rank}" if slot == 0 else None,
+                        arrival_count=1 if slot == 0 else 0,
+                        scope=kv_scope,
+                        resource_scope=kv_scope,
+                        resource=f"V_r{rank}",
+                        multicast=spec.multicast_kv,
+                    ),
+                    FlashEdge(
+                        pv,
+                        output_stage,
+                        barrier=o_full,
+                        arrival_count=1,
+                        resource=f"O_r{rank}_q{slot}",
+                    ),
+                    FlashEdge(
+                        output_stage,
+                        output_store,
+                        resource=(
+                            f"O_stage_r{rank}_q{slot}" if spec.stage_output else None
+                        ),
+                    ),
+                    FlashEdge(pv, qk, iteration_delta=1),
+                    FlashEdge(
+                        pv,
+                        correction,
+                        iteration_delta=1,
+                        resource=f"O_r{rank}_q{slot}",
+                    ),
+                ]
+            )
+            if slot + 1 == spec.query_slots_per_cta:
+                if spec.cooperative_mma and rank != 0:
+                    reuse_ranks: tuple[int, ...] | range = ()
+                elif spec.multicast_kv:
+                    reuse_ranks = range(spec.cta_count)
+                else:
+                    reuse_ranks = (rank,)
+                for reuse_rank in reuse_ranks:
+                    edges.extend(
+                        [
+                            FlashEdge(
+                                qk,
+                                k_load,
+                                iteration_delta=spec.kv_depth,
+                                barrier=f"k_reuse_r{reuse_rank}",
+                                arrival_count=1,
+                                scope=kv_scope,
+                            ),
+                            FlashEdge(
+                                pv,
+                                v_load,
+                                iteration_delta=spec.kv_depth,
+                                barrier=f"v_reuse_r{reuse_rank}",
+                                arrival_count=1,
+                                scope=kv_scope,
+                            ),
+                        ]
+                    )
+            else:
+                edges.extend(
+                    [
+                        FlashEdge(
+                            qk,
+                            _node_name("qk", rank, slot + 1),
+                        ),
+                        FlashEdge(
+                            pv,
+                            _node_name("pv", rank, slot + 1),
+                        ),
+                    ]
+                )
+            if spec.private_causal_tail:
+                edges.extend(
+                    [
+                        FlashEdge(
+                            f"diagonal_k_load_r{rank}",
+                            qk,
+                            resource=f"causal_diagonal_K_r{rank}",
+                        ),
+                        FlashEdge(
+                            f"diagonal_v_load_r{rank}",
+                            pv,
+                            resource=f"causal_diagonal_V_r{rank}",
+                        ),
+                    ]
+                )
+
+            owners.append(FlashOutputOwner(_output_tile(spec, rank, slot), rank, slot))
+            regions.append(
+                FlashMemoryRegion(
+                    f"Q_r{rank}_q{slot}",
+                    FlashMemorySpace.SMEM,
+                    slot * tile_bytes,
+                    tile_bytes,
+                    1024,
+                    FlashVisibility.CTA_PRIVATE,
+                    q_load,
+                    (qk,),
+                    cta_rank=rank,
+                )
+            )
+            score_offset = slot * 128
+            regions.extend(
+                [
+                    FlashMemoryRegion(
+                        f"S_r{rank}_q{slot}",
+                        FlashMemorySpace.TMEM,
+                        score_offset,
+                        128,
+                        1,
+                        FlashVisibility.CTA_PRIVATE,
+                        qk,
+                        (softmax,),
+                        alias_group=f"score_p_r{rank}_q{slot}",
+                        cta_rank=rank,
+                    ),
+                    FlashMemoryRegion(
+                        f"P_r{rank}_q{slot}",
+                        FlashMemorySpace.TMEM,
+                        score_offset,
+                        128,
+                        1,
+                        FlashVisibility.CTA_PRIVATE,
+                        softmax,
+                        (pv,),
+                        reuse_distance=1,
+                        alias_group=f"score_p_r{rank}_q{slot}",
+                        cta_rank=rank,
+                    ),
+                    FlashMemoryRegion(
+                        f"O_r{rank}_q{slot}",
+                        FlashMemorySpace.TMEM,
+                        256 + slot * spec.head_dim,
+                        spec.head_dim,
+                        1,
+                        FlashVisibility.CTA_PRIVATE,
+                        pv,
+                        (correction, output_stage),
+                        cta_rank=rank,
+                    ),
+                ]
+            )
+            regions.append(
+                FlashMemoryRegion(
+                    f"STAT_r{rank}_q{slot}",
+                    FlashMemorySpace.SMEM,
+                    overhead_offset + slot * 64,
+                    64,
+                    16,
+                    FlashVisibility.CTA_PRIVATE,
+                    stat,
+                    (correction,),
+                    cta_rank=rank,
+                )
+            )
+            if spec.stage_output:
+                regions.append(
+                    FlashMemoryRegion(
+                        f"O_stage_r{rank}_q{slot}",
+                        FlashMemorySpace.SMEM,
+                        output_offset + slot * tile_bytes,
+                        tile_bytes,
+                        1024,
+                        FlashVisibility.CTA_PRIVATE,
+                        output_stage,
+                        (output_store,),
+                        cta_rank=rank,
+                    )
+                )
+
+    for slot in range(spec.query_slots_per_cta):
+        for rank in range(spec.cta_count):
+            if spec.cooperative_mma:
+                pfor = f"pfor_q{slot}"
+                pfor2 = f"pfor2_q{slot}"
+                pfor_scope = FlashSyncScope.CLUSTER_LEADER
+                if rank == 0:
+                    barriers.append(
+                        FlashBarrier(pfor, 256 * spec.cta_count, pfor_scope)
+                    )
+                    if spec.split_p_arrive:
+                        barriers.append(
+                            FlashBarrier(pfor2, 128 * spec.cta_count, pfor_scope)
+                        )
+            else:
+                rank_suffix = f"_r{rank}" if spec.cta_count > 1 else ""
+                pfor = f"pfor{rank_suffix}_q{slot}"
+                pfor2 = f"pfor2{rank_suffix}_q{slot}"
+                pfor_scope = FlashSyncScope.CTA
+                barriers.append(FlashBarrier(pfor, 256, pfor_scope))
+                if spec.split_p_arrive:
+                    barriers.append(FlashBarrier(pfor2, 128, pfor_scope))
+            softmax = _node_name("softmax", rank, slot)
+            correction = _node_name("correction", rank, slot)
+            pv = _node_name("pv", rank, slot)
+            edges.extend(
+                [
+                    FlashEdge(
+                        softmax,
+                        pv,
+                        barrier=pfor,
+                        arrival_count=128,
+                        scope=pfor_scope,
+                        resource=f"P_r{rank}_q{slot}",
+                    ),
+                    FlashEdge(
+                        correction,
+                        pv,
+                        barrier=pfor,
+                        arrival_count=128,
+                        scope=pfor_scope,
+                    ),
+                ]
+            )
+            if spec.split_p_arrive:
+                edges.append(
+                    FlashEdge(
+                        softmax,
+                        pv,
+                        barrier=pfor2,
+                        arrival_count=128,
+                        scope=pfor_scope,
+                    )
+                )
+
+    phase_cycles: tuple[FlashPhaseCycle, ...] = ()
+    if spec.persistent:
+        if spec.kv_iterations is None or spec.kv_iterations <= 0:
+            raise FlashScheduleError(
+                "persistent schedules require a positive K/V iteration count"
+            )
+        cycles = []
+        for barrier in barriers:
+            uses_per_work = (
+                spec.kv_iterations
+                if barrier.name.startswith(
+                    (
+                        "k_ready",
+                        "v_ready",
+                        "k_reuse",
+                        "v_reuse",
+                        "s_full",
+                        "stat_ready",
+                        "pfor",
+                    )
+                )
+                else 1
+            )
+            cycles.append(
+                FlashPhaseCycle(
+                    barrier.name,
+                    (0, uses_per_work & 1, 0),
+                    uses_per_work,
+                )
+            )
+        phase_cycles = tuple(cycles)
+    tmem_columns = 256 + spec.query_slots_per_cta * spec.head_dim
+    return FlashSchedule(
+        spec=spec,
+        nodes=tuple(nodes),
+        edges=tuple(edges),
+        barriers=tuple(barriers),
+        memory_regions=tuple(regions),
+        output_owners=tuple(owners),
+        phase_cycles=phase_cycles,
+        shared_memory_bytes=_shared_memory_bytes(spec),
+        tmem_columns=tmem_columns,
+    )
+
+
+def _reachable(
+    edges_by_source: dict[str, list[FlashEdge]],
+    source: str,
+    target: str,
+    iteration_delta: int,
+) -> bool:
+    pending = [(source, 0)]
+    seen: set[tuple[str, int]] = set()
+    while pending:
+        node, delta = pending.pop()
+        state = (node, delta)
+        if state in seen or delta > iteration_delta:
+            continue
+        seen.add(state)
+        if node == target and delta == iteration_delta:
+            return True
+        pending.extend(
+            (edge.target, delta + edge.iteration_delta)
+            for edge in edges_by_source.get(node, ())
+        )
+    return False
+
+
+def _validate_zero_delta_acyclic(
+    node_names: set[str], edges: tuple[FlashEdge, ...]
+) -> None:
+    adjacency: dict[str, list[str]] = defaultdict(list)
+    indegree = dict.fromkeys(node_names, 0)
+    for edge in edges:
+        if edge.iteration_delta == 0:
+            adjacency[edge.source].append(edge.target)
+            indegree[edge.target] += 1
+    pending = [name for name, degree in indegree.items() if degree == 0]
+    visited = 0
+    while pending:
+        source = pending.pop()
+        visited += 1
+        for target in adjacency.get(source, ()):
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                pending.append(target)
+    if visited != len(node_names):
+        raise FlashScheduleError("same-iteration schedule contains a cycle")
+
+
+def verify_flash_schedule(
+    schedule: FlashSchedule,
+    limits: FlashScheduleLimits | None = None,
+) -> VerifiedFlashSchedule:
+    if limits is None:
+        limits = FlashScheduleLimits()
+    if limits.shared_memory_bytes <= 0 or limits.tmem_columns <= 0:
+        raise FlashScheduleError("schedule limits must be positive")
+
+    node_by_name = {node.name: node for node in schedule.nodes}
+    node_names = set(node_by_name)
+    if len(node_names) != len(schedule.nodes):
+        raise FlashScheduleError("schedule node names must be unique")
+    for node in schedule.nodes:
+        if (
+            node.cta_rank is not None
+            and not 0 <= node.cta_rank < schedule.spec.cta_count
+        ):
+            raise FlashScheduleError(f"node {node.name} has an invalid CTA rank")
+        if node.query_slot is not None:
+            if node.cta_rank is None or not (
+                0 <= node.query_slot < schedule.spec.query_slots_per_cta
+            ):
+                raise FlashScheduleError(f"node {node.name} has an invalid query slot")
+    for edge in schedule.edges:
+        if edge.source not in node_names or edge.target not in node_names:
+            raise FlashScheduleError("schedule edge references an unknown node")
+        if edge.iteration_delta < 0:
+            raise FlashScheduleError("iteration deltas must be nonnegative")
+    _validate_zero_delta_acyclic(node_names, schedule.edges)
+
+    barrier_by_name = {barrier.name: barrier for barrier in schedule.barriers}
+    if len(barrier_by_name) != len(schedule.barriers):
+        raise FlashScheduleError("barrier names must be unique")
+    if any(barrier.expected_arrivals <= 0 for barrier in schedule.barriers):
+        raise FlashScheduleError("barrier arrivals must be positive")
+    arrivals: dict[str, int] = defaultdict(int)
+    for edge in schedule.edges:
+        if edge.barrier is None:
+            if edge.arrival_count != 0:
+                raise FlashScheduleError("arrival count requires a barrier")
+            continue
+        barrier = barrier_by_name.get(edge.barrier)
+        if barrier is None:
+            raise FlashScheduleError("edge references an unknown barrier")
+        if edge.scope is not barrier.scope:
+            raise FlashScheduleError(f"barrier scope mismatch for {barrier.name}")
+        if edge.arrival_count <= 0:
+            raise FlashScheduleError("barrier arrivals must be positive")
+        arrivals[barrier.name] += edge.arrival_count
+    for barrier in schedule.barriers:
+        if arrivals[barrier.name] != barrier.expected_arrivals:
+            raise FlashScheduleError(
+                f"barrier {barrier.name} expected {barrier.expected_arrivals} "
+                f"arrivals, got {arrivals[barrier.name]}"
+            )
+    if schedule.spec.multicast_kv:
+        for rank in range(schedule.spec.cta_count):
+            for operand, consumer_kind in (("k", "qk"), ("v", "pv")):
+                barrier_name = f"{operand}_reuse_r{rank}"
+                release_edges = [
+                    edge for edge in schedule.edges if edge.barrier == barrier_name
+                ]
+                source_ranks = (
+                    (0,)
+                    if schedule.spec.cooperative_mma
+                    else range(schedule.spec.cta_count)
+                )
+                expected_sources = {
+                    _node_name(
+                        consumer_kind,
+                        source_rank,
+                        schedule.spec.query_slots_per_cta - 1,
+                    )
+                    for source_rank in source_ranks
+                }
+                if (
+                    len(release_edges) != len(expected_sources)
+                    or {edge.source for edge in release_edges} != expected_sources
+                    or any(
+                        edge.target != f"{operand}_load_multicast"
+                        or edge.iteration_delta != schedule.spec.kv_depth
+                        or edge.arrival_count != 1
+                        or edge.scope is not FlashSyncScope.CLUSTER
+                        for edge in release_edges
+                    )
+                ):
+                    raise FlashScheduleError(
+                        "multicast K/V reuse has the wrong consumer releases"
+                    )
+
+    region_by_name = {region.name: region for region in schedule.memory_regions}
+    if len(region_by_name) != len(schedule.memory_regions):
+        raise FlashScheduleError("memory-region names must be unique")
+    edges_by_source: dict[str, list[FlashEdge]] = defaultdict(list)
+    resource_edges: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    for edge in schedule.edges:
+        edges_by_source[edge.source].append(edge)
+        if edge.multicast and edge.resource is None:
+            raise FlashScheduleError("multicast edge requires a memory resource")
+        if edge.resource is None:
+            continue
+        region = region_by_name.get(edge.resource)
+        if region is None:
+            raise FlashScheduleError("edge references an unknown memory region")
+        if edge.source != region.writer or edge.target not in region.consumers:
+            raise FlashScheduleError(
+                f"edge does not match the lifetime of memory region {region.name}"
+            )
+        resource_edges[region.name].add((edge.source, edge.target))
+        if region.visibility is FlashVisibility.CLUSTER_VISIBLE:
+            if edge.resource_scope not in (
+                FlashSyncScope.CLUSTER,
+                FlashSyncScope.CLUSTER_LEADER,
+            ):
+                raise FlashScheduleError("cluster-visible data uses a CTA-local edge")
+            if not edge.multicast:
+                raise FlashScheduleError("cluster-visible load is not multicast")
+        elif edge.resource_scope is not FlashSyncScope.CTA:
+            raise FlashScheduleError("CTA-private data uses a cluster-scoped edge")
+        if edge.multicast and region.visibility is FlashVisibility.CTA_PRIVATE:
+            raise FlashScheduleError("CTA-private data cannot be multicast")
+        if edge.multicast and not schedule.spec.multicast_kv:
+            raise FlashScheduleError("multicast edge is disabled by the schedule")
+        if region.visibility is FlashVisibility.CTA_PRIVATE:
+            source_rank = node_by_name[edge.source].cta_rank
+            target_rank = node_by_name[edge.target].cta_rank
+            if region.cta_rank is None:
+                raise FlashScheduleError(
+                    f"CTA-private memory region {region.name} has no owner"
+                )
+            if any(
+                rank is not None and rank != region.cta_rank
+                for rank in (source_rank, target_rank)
+            ):
+                raise FlashScheduleError(
+                    f"CTA-private memory region {region.name} crosses CTA ranks"
+                )
+
+    for region in schedule.memory_regions:
+        if region.offset < 0 or region.extent <= 0:
+            raise FlashScheduleError("memory regions require positive bounds")
+        if region.alignment <= 0 or region.offset % region.alignment != 0:
+            raise FlashScheduleError(f"memory region {region.name} is misaligned")
+        if region.writer not in node_names or any(
+            consumer not in node_names for consumer in region.consumers
+        ):
+            raise FlashScheduleError("memory lifetime references an unknown node")
+        if not region.consumers:
+            raise FlashScheduleError(f"memory region {region.name} has no consumer")
+        if region.cta_rank is not None and not (
+            0 <= region.cta_rank < schedule.spec.cta_count
+        ):
+            raise FlashScheduleError(
+                f"memory region {region.name} has an invalid CTA rank"
+            )
+        expected_edges = {(region.writer, consumer) for consumer in region.consumers}
+        if not expected_edges.issubset(resource_edges[region.name]):
+            raise FlashScheduleError(
+                f"memory region {region.name} has an uncovered consumer"
+            )
+        if region.reuse_distance is not None:
+            if region.reuse_distance <= 0:
+                raise FlashScheduleError("reuse distance must be positive")
+            for consumer in region.consumers:
+                if not _reachable(
+                    edges_by_source,
+                    consumer,
+                    region.writer,
+                    region.reuse_distance,
+                ):
+                    raise FlashScheduleError(
+                        f"memory region {region.name} is reused before all consumers"
+                    )
+
+    for rank in range(schedule.spec.cta_count):
+        k_region = region_by_name.get(f"K_r{rank}")
+        v_region = region_by_name.get(f"V_r{rank}")
+        if k_region is None or v_region is None:
+            raise FlashScheduleError("K/V ring representation is incomplete")
+        if schedule.spec.separate_kv:
+            if (
+                not k_region.physical
+                or not v_region.physical
+                or k_region.reuse_distance != schedule.spec.kv_depth
+                or v_region.reuse_distance != schedule.spec.kv_depth
+            ):
+                raise FlashScheduleError(
+                    "separate K/V rings must retain independent depth"
+                )
+        elif (
+            not k_region.physical
+            or v_region.physical
+            or k_region.offset != v_region.offset
+            or k_region.extent != v_region.extent
+            or k_region.alias_group is None
+            or k_region.alias_group != v_region.alias_group
+            or k_region.reuse_distance is not None
+            or v_region.reuse_distance is not None
+        ):
+            raise FlashScheduleError(
+                "aliased K/V must use one physical shared ring without "
+                "independent reuse claims"
+            )
+
+    for index, lhs in enumerate(schedule.memory_regions):
+        for rhs in schedule.memory_regions[index + 1 :]:
+            if (
+                not lhs.physical
+                or not rhs.physical
+                or lhs.space is not rhs.space
+                or lhs.cta_rank != rhs.cta_rank
+            ):
+                continue
+            overlaps = lhs.offset < rhs.offset + rhs.extent and rhs.offset < (
+                lhs.offset + lhs.extent
+            )
+            if not overlaps:
+                continue
+            if lhs.alias_group is None or lhs.alias_group != rhs.alias_group:
+                raise FlashScheduleError(
+                    f"memory regions {lhs.name} and {rhs.name} overlap illegally"
+                )
+            lhs_before_rhs = all(
+                _reachable(edges_by_source, consumer, rhs.writer, 0)
+                for consumer in lhs.consumers
+            )
+            rhs_before_lhs = all(
+                _reachable(edges_by_source, consumer, lhs.writer, 0)
+                for consumer in rhs.consumers
+            )
+            if not lhs_before_rhs and not rhs_before_lhs:
+                raise FlashScheduleError(
+                    f"aliased regions {lhs.name} and {rhs.name} have live overlap"
+                )
+
+    output_count = schedule.spec.cta_count * schedule.spec.query_slots_per_cta
+    output_tiles = [owner.output_tile for owner in schedule.output_owners]
+    if len(output_tiles) != len(set(output_tiles)):
+        raise FlashScheduleError("an output tile has multiple owners")
+    if set(output_tiles) != set(range(output_count)):
+        raise FlashScheduleError("output ownership is incomplete")
+    for owner in schedule.output_owners:
+        if not 0 <= owner.cta_rank < schedule.spec.cta_count:
+            raise FlashScheduleError("output owner has an invalid CTA rank")
+        if not 0 <= owner.query_slot < schedule.spec.query_slots_per_cta:
+            raise FlashScheduleError("output owner has an invalid query slot")
+        expected_tile = _output_tile(
+            schedule.spec,
+            owner.cta_rank,
+            owner.query_slot,
+        )
+        if owner.output_tile != expected_tile:
+            raise FlashScheduleError("output owner has an invalid tile mapping")
+        output_store = _node_name("output_store", owner.cta_rank, owner.query_slot)
+        if output_store not in node_names:
+            raise FlashScheduleError("output owner has no output-store node")
+
+    if schedule.spec.private_causal_tail:
+        for rank in range(schedule.spec.cta_count):
+            for kind, consumer_kind in (("K", "qk"), ("V", "pv")):
+                name = f"causal_diagonal_{kind}_r{rank}"
+                region = region_by_name.get(name)
+                if (
+                    region is None
+                    or region.visibility is not FlashVisibility.CTA_PRIVATE
+                    or region.cta_rank != rank
+                    or region.physical
+                ):
+                    raise FlashScheduleError(
+                        "causal multicast requires a private diagonal path"
+                    )
+                for slot in range(schedule.spec.query_slots_per_cta):
+                    consumer = _node_name(consumer_kind, rank, slot)
+                    if (region.writer, consumer) not in resource_edges[name]:
+                        raise FlashScheduleError(
+                            "causal multicast diagonal dependency is incomplete"
+                        )
+
+    expected_shared_memory = _shared_memory_bytes(schedule.spec)
+    if schedule.shared_memory_bytes != expected_shared_memory:
+        raise FlashScheduleError("shared-memory accounting does not match the schedule")
+    expected_tmem_columns = (
+        256 + schedule.spec.query_slots_per_cta * schedule.spec.head_dim
+    )
+    if schedule.tmem_columns != expected_tmem_columns:
+        raise FlashScheduleError("TMEM accounting does not match the schedule")
+    if schedule.shared_memory_bytes > limits.shared_memory_bytes:
+        raise FlashScheduleError("schedule exceeds shared-memory capacity")
+    if schedule.tmem_columns > limits.tmem_columns:
+        raise FlashScheduleError("schedule exceeds TMEM column capacity")
+    for region in schedule.memory_regions:
+        if not region.physical:
+            continue
+        capacity = (
+            schedule.shared_memory_bytes
+            if region.space is FlashMemorySpace.SMEM
+            else schedule.tmem_columns
+        )
+        if region.offset + region.extent > capacity:
+            raise FlashScheduleError(f"memory region {region.name} exceeds capacity")
+
+    phase_by_barrier = {cycle.barrier: cycle for cycle in schedule.phase_cycles}
+    if len(phase_by_barrier) != len(schedule.phase_cycles):
+        raise FlashScheduleError("barrier phase cycles must be unique")
+    if schedule.spec.persistent:
+        if set(phase_by_barrier) != set(barrier_by_name):
+            raise FlashScheduleError("persistent barrier phase coverage is incomplete")
+        for cycle in schedule.phase_cycles:
+            if cycle.uses_per_work <= 0:
+                raise FlashScheduleError("barrier use count must be positive")
+            if len(cycle.phases) < 2:
+                raise FlashScheduleError("barrier phase cycle has the wrong length")
+            if any(phase not in (0, 1) for phase in cycle.phases):
+                raise FlashScheduleError("barrier phases must be binary")
+            for current, following in zip(
+                cycle.phases[:-1],
+                cycle.phases[1:],
+                strict=True,
+            ):
+                if following != (current ^ (cycle.uses_per_work & 1)):
+                    raise FlashScheduleError(
+                        "persistent barrier phase is discontinuous across work items"
+                    )
+    elif schedule.phase_cycles:
+        raise FlashScheduleError("nonpersistent schedule has barrier phase cycles")
+
+    return VerifiedFlashSchedule(schedule)

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -3662,6 +3662,7 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                     has_kv_tile_pruning=flash_shape.has_kv_tile_pruning,
                     requires_ws_overlap=flash_shape.requires_ws_overlap,
                     small_biased_candidate=flash_shape.small_biased_candidate,
+                    standard_dense_output=flash_shape.standard_dense_output,
                 )
             else:
                 from ..language.matmul_ops import enable_cute_tcgen05_search

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -40,7 +40,6 @@ from .._compiler.cute.cute_flash import FLASH_MMA_INTERLEAVE_KEY
 from .._compiler.cute.cute_flash import FLASH_OTHER_REGS_KEY
 from .._compiler.cute.cute_flash import FLASH_PERSISTENT_KEY
 from .._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILY_KEY
-from .._compiler.cute.cute_flash import FLASH_Q_TILE_COUNT_KEY
 from .._compiler.cute.cute_flash import FLASH_SOFTMAX_REGS_KEY
 from .._compiler.cute.cute_flash import FLASH_TOPOLOGY_KEY
 from .._compiler.cute.cute_flash import FlashAttentionConfig
@@ -653,6 +652,7 @@ class ConfigSpec:
         self._cute_flash_has_kv_tile_pruning: bool = False
         self._cute_flash_requires_ws_overlap: bool = False
         self._cute_flash_small_biased_candidate: bool = False
+        self._cute_flash_standard_dense_output: bool = False
         self._cute_flash_block_size_targets: dict[int, int] = {}
         self.compiler_default_config: helion.Config | None = None
         self.compiler_seed_configs: list[helion.Config] = []
@@ -818,6 +818,7 @@ class ConfigSpec:
             flash_config,
             dtype=self._cute_flash_dtype,
             is_causal=self._cute_flash_is_causal,
+            standard_dense_output=self._cute_flash_standard_dense_output,
             prefer_packed_reduce=(
                 self._cute_flash_has_kv_tile_pruning
                 or self._cute_flash_requires_ws_overlap
@@ -838,8 +839,12 @@ class ConfigSpec:
             return
         assert self._cute_flash_head_dim is not None
         assert self._cute_flash_num_kv is not None
-        config.pop(FLASH_Q_TILE_COUNT_KEY, None)
-        config.pop(FLASH_MMA_INTERLEAVE_KEY, None)
+        # ``q_tile_count`` is a family-derived invariant and is projected back
+        # to its canonical value below.  The historical MMA key accepted any
+        # truthy object, so preserve that fixed-config compatibility before the
+        # active Boolean fragment validates it.
+        if FLASH_MMA_INTERLEAVE_KEY in config:
+            config[FLASH_MMA_INTERLEAVE_KEY] = bool(config[FLASH_MMA_INTERLEAVE_KEY])
         from .._compiler.cute.cute_flash import flash_autotune_fragments
 
         block_size_targets = self._cute_flash_block_size_target_list()
@@ -902,6 +907,7 @@ class ConfigSpec:
             has_kv_tile_pruning=self._cute_flash_has_kv_tile_pruning,
             requires_ws_overlap=self._cute_flash_requires_ws_overlap,
             small_biased_candidate=self._cute_flash_small_biased_candidate,
+            standard_dense_output=self._cute_flash_standard_dense_output,
             topology_override=cast("str | None", topology_override),
             pipeline_family_override=pipeline_family_override,
         )
@@ -1080,11 +1086,7 @@ class ConfigSpec:
             effective_topology,
             fix_invalid=fix_invalid,
         )
-        for key in (
-            *FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS,
-            FLASH_Q_TILE_COUNT_KEY,
-            FLASH_MMA_INTERLEAVE_KEY,
-        ):
+        for key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS:
             config.pop(key, None)
 
     def _normalize_cute_flash_register_budget(
@@ -1157,6 +1159,7 @@ class ConfigSpec:
         has_kv_tile_pruning: bool = False,
         requires_ws_overlap: bool = False,
         small_biased_candidate: bool = False,
+        standard_dense_output: bool = False,
     ) -> None:
         self.cute_flash_search_enabled = True
         self._cute_flash_head_dim = head_dim
@@ -1166,6 +1169,7 @@ class ConfigSpec:
         self._cute_flash_has_kv_tile_pruning = has_kv_tile_pruning
         self._cute_flash_requires_ws_overlap = requires_ws_overlap
         self._cute_flash_small_biased_candidate = small_biased_candidate
+        self._cute_flash_standard_dense_output = standard_dense_output
         self._cute_flash_block_size_targets = dict(block_size_targets)
         for block_id, target in block_size_targets.items():
             spec = self.block_sizes.block_id_lookup(block_id)
@@ -2328,6 +2332,7 @@ class ConfigSpec:
                         small_biased_candidate=(
                             self._cute_flash_small_biased_candidate
                         ),
+                        standard_dense_output=self._cute_flash_standard_dense_output,
                     )
                 )
             elif self.supports_config_key("num_threads"):

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -3815,6 +3815,7 @@ class TestCuteAutotuner(TestCase):
         into the search surface.
         """
         from helion._compiler.cute.cute_flash import FLASH_AUTOTUNE_CONFIG_KEYS
+        from helion._compiler.cute.cute_flash import FLASH_AUTOTUNE_PIPELINE_FAMILIES
         from helion._compiler.cute.cute_flash import FLASH_CAUSAL_KV_ORDER_KEY
         from helion._compiler.cute.cute_flash import FLASH_CAUSAL_LOOP_SPLIT_KEY
         from helion._compiler.cute.cute_flash import FLASH_CAUSAL_LPT_SWIZZLE_KEY
@@ -3834,6 +3835,7 @@ class TestCuteAutotuner(TestCase):
         from helion._compiler.cute.cute_flash import FLASH_EPI_STG_KEY
         from helion._compiler.cute.cute_flash import FLASH_EPI_STG_STORE_KEY
         from helion._compiler.cute.cute_flash import FLASH_EPI_TMA_KEY
+        from helion._compiler.cute.cute_flash import FLASH_EXP2_PACKET_KEY
         from helion._compiler.cute.cute_flash import FLASH_FIRST_LOAD_ORDER_KEY
         from helion._compiler.cute.cute_flash import FLASH_KV_ORDER_KEY
         from helion._compiler.cute.cute_flash import FLASH_KV_STAGE_KEY
@@ -3862,9 +3864,11 @@ class TestCuteAutotuner(TestCase):
         from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_DISC_KEY
         from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_REGS_KEY
         from helion._compiler.cute.cute_flash import FLASH_SPLIT_P_ARRIVE_KEY
+        from helion._compiler.cute.cute_flash import FLASH_STAT_TRANSPORT_KEY
         from helion._compiler.cute.cute_flash import FLASH_TENSOR_4D_TMA_KEY
         from helion._compiler.cute.cute_flash import FLASH_TOPOLOGY_KEY
         from helion._compiler.cute.cute_flash import FLASH_USE_2CTA_KEY
+        from helion._compiler.cute.cute_flash import FLASH_WAIT_HINT_KEY
         from helion._compiler.cute.cute_flash import flash_autotune_fragments
         from helion._compiler.cute.cute_flash import flash_config_from_config
         from helion._compiler.cute.cute_flash import flash_effective_config_values
@@ -4018,7 +4022,7 @@ class TestCuteAutotuner(TestCase):
                 FLASH_TENSOR_4D_TMA_KEY,
             },
         )
-        self.assertEqual(len(FLASH_PIPELINE_FAMILIES), 13)
+        self.assertEqual(len(FLASH_PIPELINE_FAMILIES), 15)
         # seq=256 -> num_kv=2 (even) is fa4-eligible (seq % 256 == 0), so the
         # topology fragment must offer fa4 (alongside the ws_overlap default
         # seed first) so the autotuner can pick the fa4 win for this shape.
@@ -4055,7 +4059,15 @@ class TestCuteAutotuner(TestCase):
         self.assertNotIn(FLASH_TOPOLOGY_KEY, sparse_fa4_config)
         e2e_schedule_choices = flash_fragments[FLASH_E2E_SCHEDULE_KEY].choices
         self.assertEqual(e2e_schedule_choices[0], "16/4")
-        self.assertEqual(set(e2e_schedule_choices), {"16/4", "8/2", "16/2", "xu"})
+        # The manual exp2 packets canonicalize onto "16/6"/"16/8", so those
+        # cadences are selectable as manual overrides on fa4 hd64 without
+        # entering the search surface.
+        self.assertEqual(
+            set(e2e_schedule_choices), {"16/4", "8/2", "16/2", "xu", "16/6", "16/8"}
+        )
+        self.assertEqual(
+            flash_fragments[FLASH_E2E_SCHEDULE_KEY].search_choices, ("16/4", "8/2")
+        )
         self.assertEqual(
             flash_fragments[FLASH_MASKED_E2E_SCHEDULE_KEY].choices, ("inherit",)
         )
@@ -4065,6 +4077,46 @@ class TestCuteAutotuner(TestCase):
         e2e_offset0_choices = flash_fragments[FLASH_E2E_OFFSET0_KEY].choices
         self.assertEqual(e2e_offset0_choices[0], 0)
         self.assertEqual(set(e2e_offset0_choices), set(range(16)))
+        self.assertEqual(
+            set(flash_fragments[FLASH_WAIT_HINT_KEY].choices), {0, 10_000_000}
+        )
+        # The polynomial packets are manual-only overrides: selectable as fixed
+        # configs but never offered to the search.
+        self.assertEqual(
+            set(flash_fragments[FLASH_EXP2_PACKET_KEY].choices),
+            {
+                "1x1",
+                "4x1",
+                "4x2",
+                "8x1",
+                "8x2",
+                "deg2_16x6",
+                "hybrid_deg1_16x8",
+                "deg1_16x8",
+                "deg1_8x2_corr10",
+            },
+        )
+        self.assertEqual(
+            flash_fragments[FLASH_EXP2_PACKET_KEY].search_choices, ("1x1", "4x1")
+        )
+        self.assertEqual(
+            set(flash_fragments[FLASH_STAT_TRANSPORT_KEY].choices),
+            {"ring2", "single"},
+        )
+        self.assertEqual(
+            set(flash_fragments[FLASH_MMA_INTERLEAVE_KEY].choices), {False, True}
+        )
+        self.assertEqual(
+            flash_fragments[FLASH_MMA_INTERLEAVE_KEY].search_choices, (True,)
+        )
+        self.assertEqual(
+            flash_fragments[FLASH_STAT_TRANSPORT_KEY].search_choices, ("single",)
+        )
+        self.assertEqual(
+            set(flash_fragments[FLASH_EXP2_PACKET_KEY].search_choices or ()),
+            {"1x1", "4x1"},
+        )
+        self.assertNotIn(FLASH_Q_TILE_COUNT_KEY, flash_fragments)
         # The fa4 levers offer narrow validated search sets.
         self.assertEqual(flash_fragments[FLASH_DISC_PIPE_KEY].choices[0], 4)
         self.assertEqual(
@@ -4165,7 +4217,7 @@ class TestCuteAutotuner(TestCase):
             env_xu_long_fragments = flash_autotune_fragments(64, 64, is_causal=False)
         self.assertEqual(
             set(env_xu_long_fragments[FLASH_E2E_SCHEDULE_KEY].choices),
-            {"16/4", "8/2", "16/2", "xu"},
+            {"16/4", "8/2", "16/2", "xu", "16/6", "16/8"},
         )
         self.assertEqual(
             env_xu_long_fragments[FLASH_E2E_SCHEDULE_KEY].search_choices,
@@ -4211,12 +4263,33 @@ class TestCuteAutotuner(TestCase):
             bad_topology_fragments = flash_autotune_fragments(64, 64, is_causal=False)
         self.assertEqual(
             set(bad_topology_fragments[FLASH_PIPELINE_FAMILY_KEY].choices),
-            set(FLASH_PIPELINE_FAMILIES),
+            set(FLASH_AUTOTUNE_PIPELINE_FAMILIES),
         )
         self.assertEqual(
             bad_topology_fragments[FLASH_PIPELINE_FAMILY_KEY].choices[0],
             "ws_overlap",
         )
+        for manual_family, causal in (
+            ("fa4_deep_1cta", False),
+            ("fa4_2cta_causal", True),
+        ):
+            with (
+                self.subTest(manual_family=manual_family),
+                unittest.mock.patch.dict(
+                    os.environ,
+                    {"HELION_CUTE_FLASH_PIPELINE_FAMILY": manual_family},
+                    clear=False,
+                ),
+            ):
+                manual_fragments = flash_autotune_fragments(
+                    64,
+                    512,
+                    is_causal=causal,
+                )
+            manual_fragment = manual_fragments[FLASH_PIPELINE_FAMILY_KEY]
+            self.assertIn(manual_family, manual_fragment.choices)
+            self.assertNotEqual(manual_fragment.default(), manual_family)
+            self.assertNotIn(manual_family, manual_fragment.search_choices or ())
         self.assertEqual(
             set(bad_topology_fragments[FLASH_E2E_SCHEDULE_KEY].choices),
             {"16/4", "8/2", "16/2", "xu"},
@@ -4279,7 +4352,7 @@ class TestCuteAutotuner(TestCase):
         )
         self.assertEqual(
             causal_fragments[FLASH_MASKED_E2E_SCHEDULE_KEY].choices,
-            ("inherit", "xu", "16/4", "8/2"),
+            ("inherit", "xu", "16/4", "8/2", "16/6", "16/8"),
         )
         self.assertEqual(
             causal_fragments[FLASH_MASKED_E2E_SCHEDULE_KEY].search_choices,
@@ -4401,7 +4474,7 @@ class TestCuteAutotuner(TestCase):
         long_dense_fragments = flash_autotune_fragments(64, 64, is_causal=False)
         self.assertEqual(
             set(long_dense_fragments[FLASH_PIPELINE_FAMILY_KEY].choices),
-            set(FLASH_PIPELINE_FAMILIES),
+            set(FLASH_AUTOTUNE_PIPELINE_FAMILIES),
         )
         self.assertEqual(
             long_dense_fragments[FLASH_PIPELINE_FAMILY_KEY].search_choices,
@@ -4413,7 +4486,7 @@ class TestCuteAutotuner(TestCase):
         )
         self.assertEqual(
             set(long_dense_fragments[FLASH_E2E_SCHEDULE_KEY].choices),
-            {"16/4", "8/2", "16/2", "xu"},
+            {"16/4", "8/2", "16/2", "xu", "16/6", "16/8"},
         )
         self.assertEqual(
             long_dense_fragments[FLASH_E2E_SCHEDULE_KEY].search_choices,
@@ -4653,7 +4726,7 @@ class TestCuteAutotuner(TestCase):
                 FLASH_CLC_STAGES_KEY: (2,),
             },
             2048: {
-                FLASH_PIPELINE_FAMILY_KEY: ("fa4", "ws_overlap"),
+                FLASH_PIPELINE_FAMILY_KEY: ("fa4", "ws_overlap", "fa4_2cta"),
                 FLASH_RESCALE_THRESHOLD_KEY: (8.0, 12.0),
                 FLASH_CORR_TILE_SIZE_KEY: (8, 16),
                 FLASH_SOFTMAX_REGS_KEY: (192, 200),
@@ -4836,11 +4909,11 @@ class TestCuteAutotuner(TestCase):
         )
         odd_bound = flash_attention.bind((q_odd, k_odd, v_odd))
         odd_fragments = odd_bound.config_spec._flat_fields()
-        # Odd-KV shapes keep all families in the manual enum surface for cache
+        # Odd-KV shapes retain the production family enum surface for cache
         # transfer, but only search ws_overlap and clamp stale fa4 families.
         self.assertEqual(
             set(odd_fragments[FLASH_PIPELINE_FAMILY_KEY].choices),
-            set(FLASH_PIPELINE_FAMILIES),
+            set(FLASH_AUTOTUNE_PIPELINE_FAMILIES),
         )
         self.assertEqual(
             odd_fragments[FLASH_PIPELINE_FAMILY_KEY].search_choices,
@@ -4895,7 +4968,7 @@ class TestCuteAutotuner(TestCase):
             cute_flash_clc_pdl=True,
             cute_flash_clc_stages=3,
             cute_flash_q_tile_count=-1,
-            cute_flash_mma_interleave=999,
+            cute_flash_mma_interleave=True,
         )
         family_compound = helion.Config(
             block_sizes=[1, 128, 128],
@@ -4904,8 +4977,8 @@ class TestCuteAutotuner(TestCase):
             cute_flash_clc_pdl=True,
             cute_flash_clc_stages=3,
         )
-        # Legacy configs without the family slot flatten identically, including
-        # before normalization. Dead knobs do not contribute to identity.
+        # Legacy structural configs flatten identically before normalization;
+        # the family-derived Q count does not add an independent search slot.
         self.assertEqual(
             long_gen.flatten(legacy_compound), long_gen.flatten(family_compound)
         )
@@ -4918,8 +4991,8 @@ class TestCuteAutotuner(TestCase):
         )
         for legacy_key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS:
             self.assertNotIn(legacy_key, legacy_compound)
-        self.assertNotIn(FLASH_Q_TILE_COUNT_KEY, legacy_compound)
-        self.assertNotIn(FLASH_MMA_INTERLEAVE_KEY, legacy_compound)
+        self.assertEqual(legacy_compound.config[FLASH_Q_TILE_COUNT_KEY], 2)
+        self.assertTrue(legacy_compound.config[FLASH_MMA_INTERLEAVE_KEY])
 
         clc_q, clc_k, clc_v = (
             torch.empty(1, 1, 131072, 64, dtype=torch.float16, device=DEVICE)
@@ -5126,6 +5199,17 @@ class TestCuteAutotuner(TestCase):
             self.assertIn(random_long[FLASH_EPI_STG_KEY], {False, True})
             self.assertIn(random_long[FLASH_EPI_STG_STORE_KEY], {"slice", "whole"})
             self.assertIn(random_long[FLASH_EPI_STG_GMEM_KEY], {"stage", "pair"})
+            self.assertIn(random_long[FLASH_WAIT_HINT_KEY], {0, 10_000_000})
+            self.assertIn(
+                random_long[FLASH_EXP2_PACKET_KEY],
+                {"1x1", "4x1", "4x2", "8x1", "8x2"},
+            )
+            self.assertIn(random_long[FLASH_STAT_TRANSPORT_KEY], {"ring2", "single"})
+            self.assertIn(random_long[FLASH_MMA_INTERLEAVE_KEY], {False, True})
+            self.assertEqual(
+                random_long[FLASH_Q_TILE_COUNT_KEY],
+                1 if random_long[FLASH_PIPELINE_FAMILY_KEY] == "ws_overlap" else 2,
+            )
             self.assertEqual(random_long[FLASH_RESCALE_THRESHOLD_KEY], 8.0)
             self.assertIn(random_long[FLASH_RESCALE_CHUNK_COLS_KEY], {16, 32})
             self.assertEqual(random_long[FLASH_S_STAGE_KEY], 2)

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -44,6 +44,7 @@ from helion._compiler.cute.cute_flash import FLASH_CLC_STAGES_KEY
 from helion._compiler.cute.cute_flash import FLASH_CONFIG_KEYS
 from helion._compiler.cute.cute_flash import FLASH_CORR_REGS_KEY
 from helion._compiler.cute.cute_flash import FLASH_CORR_TILE_SIZE_KEY
+from helion._compiler.cute.cute_flash import FLASH_DERIVED_CONFIG_KEYS
 from helion._compiler.cute.cute_flash import FLASH_DISC_PIPE_KEY
 from helion._compiler.cute.cute_flash import FLASH_E2E_OFFSET0_KEY
 from helion._compiler.cute.cute_flash import FLASH_E2E_OFFSET_KEY
@@ -52,6 +53,7 @@ from helion._compiler.cute.cute_flash import FLASH_EPI_STG_GMEM_KEY
 from helion._compiler.cute.cute_flash import FLASH_EPI_STG_KEY
 from helion._compiler.cute.cute_flash import FLASH_EPI_STG_STORE_KEY
 from helion._compiler.cute.cute_flash import FLASH_EPI_TMA_KEY
+from helion._compiler.cute.cute_flash import FLASH_EXP2_PACKET_KEY
 from helion._compiler.cute.cute_flash import FLASH_FIRST_LOAD_ORDER_KEY
 from helion._compiler.cute.cute_flash import FLASH_KV_ORDER_KEY
 from helion._compiler.cute.cute_flash import FLASH_KV_STAGE_KEY
@@ -80,9 +82,11 @@ from helion._compiler.cute.cute_flash import FLASH_SMALL_BIASED_KEY
 from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_DISC_KEY
 from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_REGS_KEY
 from helion._compiler.cute.cute_flash import FLASH_SPLIT_P_ARRIVE_KEY
+from helion._compiler.cute.cute_flash import FLASH_STAT_TRANSPORT_KEY
 from helion._compiler.cute.cute_flash import FLASH_TENSOR_4D_TMA_KEY
 from helion._compiler.cute.cute_flash import FLASH_TOPOLOGY_KEY
 from helion._compiler.cute.cute_flash import FLASH_USE_2CTA_KEY
+from helion._compiler.cute.cute_flash import FLASH_WAIT_HINT_KEY
 from helion._compiler.cute.cute_flash import flash_attention_seed_config
 from helion._compiler.cute.cute_flash import flash_attention_seed_configs
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
@@ -1671,7 +1675,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
     def test_cute_flash_accepts_extra_knobs(self) -> None:
         self.assertIn(FLASH_PIPELINE_FAMILY_KEY, FLASH_AUTOTUNE_CONFIG_KEYS)
         self.assertIn(FLASH_PIPELINE_FAMILY_KEY, FLASH_CONFIG_KEYS)
-        self.assertEqual(len(FLASH_PIPELINE_FAMILIES), 13)
+        self.assertEqual(len(FLASH_PIPELINE_FAMILIES), 15)
         self.assertEqual(
             set(FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS),
             {
@@ -1686,8 +1690,13 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         for legacy_key in FLASH_LEGACY_CONFIG_KEYS:
             self.assertIn(legacy_key, FLASH_CONFIG_KEYS)
             self.assertNotIn(legacy_key, FLASH_AUTOTUNE_CONFIG_KEYS)
-        self.assertIn(FLASH_MMA_INTERLEAVE_KEY, FLASH_LEGACY_CONFIG_KEYS)
-        self.assertIn(FLASH_Q_TILE_COUNT_KEY, FLASH_LEGACY_CONFIG_KEYS)
+        self.assertIn(FLASH_MMA_INTERLEAVE_KEY, FLASH_AUTOTUNE_CONFIG_KEYS)
+        self.assertIn(FLASH_Q_TILE_COUNT_KEY, FLASH_DERIVED_CONFIG_KEYS)
+        self.assertNotIn(FLASH_Q_TILE_COUNT_KEY, FLASH_AUTOTUNE_CONFIG_KEYS)
+        self.assertNotIn(FLASH_Q_TILE_COUNT_KEY, FLASH_LEGACY_CONFIG_KEYS)
+        self.assertIn(FLASH_WAIT_HINT_KEY, FLASH_AUTOTUNE_CONFIG_KEYS)
+        self.assertIn(FLASH_EXP2_PACKET_KEY, FLASH_AUTOTUNE_CONFIG_KEYS)
+        self.assertIn(FLASH_STAT_TRANSPORT_KEY, FLASH_AUTOTUNE_CONFIG_KEYS)
         self.assertIn(FLASH_PERSISTENT_CTAS_PER_SM_KEY, FLASH_CONFIG_KEYS)
         self.assertIn(FLASH_P_STORE_REP_KEY, FLASH_CONFIG_KEYS)
         self.assertIn(FLASH_S_LOAD_REP_KEY, FLASH_CONFIG_KEYS)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -53,6 +53,9 @@ _cute_grouped_reduce_shared_tree = importlib.import_module(
     "helion._compiler.cute.reduce_helpers"
 )._cute_grouped_reduce_shared_tree
 _cute_flash = importlib.import_module("helion._compiler.cute.cute_flash")
+flash_fa4_shared_storage = importlib.import_module(
+    "helion._compiler.cute._flash_runtime"
+).flash_fa4_shared_storage
 resolve_flash_config = _cute_flash.resolve_flash_config
 
 
@@ -2510,6 +2513,235 @@ class TestCuteBackend(TestCase):
                 expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
                 torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
+    def test_flash_attention_fa4_deep_one_cta_matches_sdpa(self) -> None:
+        cases = (
+            (torch.float16, 64, (2, 3, 4)),
+            (torch.float16, 128, (2,)),
+            (torch.bfloat16, 64, (3,)),
+        )
+        for dtype, head_dim, kv_stages in cases:
+            q, k, v = (
+                torch.randn(1, 2, 512, head_dim, dtype=dtype, device=DEVICE)
+                for _ in range(3)
+            )
+            expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+            for kv_stage in kv_stages:
+                with self.subTest(
+                    dtype=str(dtype), head_dim=head_dim, kv_stage=kv_stage
+                ):
+                    code, out = code_and_output(
+                        cute_dense_attention,
+                        (q, k, v),
+                        block_sizes=[1, 128, 128],
+                        cute_flash_pipeline_family="fa4_deep_1cta",
+                        cute_flash_kv_stage=kv_stage,
+                    )
+                    self.assertIn("sV = storage.sV.get_tensor", code)
+                    self.assertIn("barrier_storage=storage.k_mbar_ptr.data_ptr()", code)
+                    self.assertIn("barrier_storage=storage.v_mbar_ptr.data_ptr()", code)
+                    self.assertIn(
+                        "barrier_storage=storage.k_mbar_ptr.data_ptr(), "
+                        "defer_sync=True",
+                        code,
+                    )
+                    self.assertIn(
+                        f"assert _flash_storage_cls.size_in_bytes() == "
+                        f"{flash_fa4_shared_storage(head_dim, kv_stage, separate_kv=True).size_in_bytes()}",
+                        code,
+                    )
+                    self.assertIn("flash_k_prod.tail()", code)
+                    self.assertIn("flash_v_prod.tail()", code)
+                    self.assertNotIn("flash_kv_prod", code)
+                    self.assertNotIn("is_two_cta=True", code)
+                    self.assertNotIn("PipelineClcFetchAsync", code)
+                    self.assertNotIn("sO = storage.sO.get_tensor", code)
+                    tol = 3e-2 if dtype is torch.bfloat16 else 1e-2
+                    torch.testing.assert_close(out, expected, atol=tol, rtol=tol)
+
+    def test_flash_attention_fa4_sync_schedule_controls_match_sdpa(self) -> None:
+        for dtype in (torch.float16, torch.bfloat16):
+            with self.subTest(dtype=str(dtype)):
+                q, k, v = (
+                    torch.randn(1, 1, 512, 64, dtype=dtype, device=DEVICE)
+                    for _ in range(3)
+                )
+                code, (out, _lse) = code_and_output(
+                    cute_causal_attention,
+                    (q, k, v),
+                    block_sizes=[1, 128, 128],
+                    cute_flash_pipeline_family="fa4",
+                    cute_flash_mma_interleave=False,
+                    cute_flash_wait_hint=0,
+                    cute_flash_exp2_packet="8x2",
+                )
+                steady_start = code.index(
+                    "for flash_i in cutlass.range(flash_num_active_kv - 1"
+                )
+                steady_end = code.index("flash_pfor_phase ^= 1", steady_start)
+                steady = code[steady_start:steady_end]
+                self.assertLess(
+                    steady.index("gemm_ptx_precomputed_pv_ts(flash_o1_addr"),
+                    steady.index("flash_k_full ="),
+                )
+                self.assertIn("pair_batch=8, emu_batch=2", code)
+                self.assertIn("flash_pfor_phase, 0)", code)
+                self.assertIn("wait_hint=0", code)
+                expected = torch.nn.functional.scaled_dot_product_attention(
+                    q, k, v, is_causal=True
+                )
+                tol = 3e-2 if dtype is torch.bfloat16 else 1e-2
+                torch.testing.assert_close(out, expected, atol=tol, rtol=tol)
+
+    def test_flash_attention_single_stat_handoff_persistent_modifier_lse(self) -> None:
+        q, k, v = (
+            torch.randn(1, 64, 768, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        bias = torch.randn(1, 64, 768, 768, dtype=torch.float16, device=DEVICE) * 0.25
+        code, (out, lse) = code_and_output(
+            cute_biased_attention_with_lse,
+            (q, k, v, bias),
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4",
+            cute_flash_stat_transport="single",
+        )
+        self.assertIn("while flash_tile_id < 192", code)
+        self.assertNotIn("flash_s_corr_prod_phase", code)
+        expected = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=bias
+        )
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assertTrue(torch.isfinite(lse).all())
+
+    def test_flash_attention_fa4_deep_one_cta_causal_split_matches_sdpa(
+        self,
+    ) -> None:
+        q, k, v = (
+            torch.randn(1, 1, 512, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        expected = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, is_causal=True
+        )
+        scores = torch.matmul(q.float(), k.float().transpose(-1, -2)) / math.sqrt(64)
+        causal_mask = torch.ones(512, 512, dtype=torch.bool, device=DEVICE).tril()
+        expected_lse = torch.logsumexp(
+            scores.masked_fill(~causal_mask, -torch.inf), dim=-1
+        ) * math.log2(math.e)
+        for kv_stage in (2, 3, 4):
+            with self.subTest(kv_stage=kv_stage):
+                code, (out, lse) = code_and_output(
+                    cute_causal_attention,
+                    (q, k, v),
+                    block_sizes=[1, 128, 128],
+                    cute_flash_pipeline_family="fa4_deep_1cta",
+                    cute_flash_kv_stage=kv_stage,
+                    cute_flash_causal_kv_order="descending",
+                    cute_flash_causal_loop_split=True,
+                )
+                self.assertIn("flash_num_active_kv", code)
+                self.assertIn("for flash_kv_mask_iter in cutlass.range(", code)
+                self.assertIn("for flash_kv_unmask_iter in cutlass.range(", code)
+                self.assertIn("flash_k_prod.tail()", code)
+                self.assertIn("flash_v_prod.tail()", code)
+                self.assertNotIn("flash_kv_prod", code)
+                torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+                torch.testing.assert_close(lse, expected_lse, atol=2e-2, rtol=2e-2)
+
+    def test_flash_attention_fa4_deep_one_cta_persistent_boundary(self) -> None:
+        q, k, v = (
+            torch.randn(1, 1, 38400, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        code, out = code_and_output(
+            cute_dense_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_deep_1cta",
+            cute_flash_kv_stage=2,
+            cute_flash_persistent=True,
+            cute_flash_persistent_ctas_per_sm=1,
+        )
+        self.assertIn("while flash_tile_id < 150", code)
+        self.assertIn("flash_k_prod.tail()", code)
+        self.assertIn("flash_v_prod.tail()", code)
+        expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_flash_attention_fa4_causal_two_cta_matches_sdpa(self) -> None:
+        q, k, v = (
+            torch.randn(1, 2, 512, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        expected = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, is_causal=True
+        )
+        scores = torch.matmul(q.float(), k.float().transpose(-1, -2)) / math.sqrt(64)
+        causal_mask = torch.ones(512, 512, dtype=torch.bool, device=DEVICE).tril()
+        expected_lse = torch.logsumexp(
+            scores.masked_fill(~causal_mask, -torch.inf), dim=-1
+        ) * math.log2(math.e)
+
+        code, (out, lse) = code_and_output(
+            cute_causal_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_2cta_causal",
+            cute_flash_kv_stage=2,
+            cute_flash_causal_kv_order="descending",
+            cute_flash_causal_loop_split=True,
+        )
+
+        self.assertIn("cute.arch.cluster_idx()[0]", code)
+        self.assertIn("flash_q_mma_tile1 + cutlass.Int32(1)", code)
+        self.assertIn("cute_tcgen05_flash.CtaGroup.TWO", code)
+        self.assertIn("is_two_cta=True", code)
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(lse, expected_lse, atol=2e-2, rtol=2e-2)
+
+    def test_flash_attention_fa4_causal_two_cta_modifier_matches_sdpa(self) -> None:
+        q, k, v = (
+            torch.randn(1, 1, 512, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        bias = torch.randn(1, 1, 512, 512, dtype=torch.float16, device=DEVICE) * 0.25
+        code, out = code_and_output(
+            cute_causal_biased_attention,
+            (q, k, v, bias),
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_2cta_causal",
+        )
+        self.assertIn("add_score_bias_t2r", code)
+        self.assertIn("flash_q_mma_tile0 * cutlass.Int32(2)", code)
+        causal_mask = torch.ones(512, 512, dtype=torch.bool, device=DEVICE).tril()
+        expected = torch.nn.functional.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=bias.masked_fill(~causal_mask, -torch.inf),
+        )
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_flash_attention_fa4_causal_two_cta_tma_epilogue_matches_sdpa(
+        self,
+    ) -> None:
+        q, k, v = (
+            torch.randn(1, 1, 4096, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        code, (out, _lse) = code_and_output(
+            cute_causal_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_2cta_causal",
+        )
+        self.assertIn("_flash_tma_o", code)
+        self.assertIn("flash_mma_tile_coord_v", code)
+        expected = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, is_causal=True
+        )
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
     def test_flash_attention_fa4_zero_threshold_publishes_computed_alpha(
         self,
     ) -> None:
@@ -2689,7 +2921,9 @@ class TestCuteBackend(TestCase):
                 self.assertIn("fa4_correction_epilogue_to_smem_scoped_2cta", code)
                 self.assertIn("'use_2cta_instrs': True", code)
                 self.assertIn("gemm_ptx_precomputed_qk_static", code)
-                self.assertIn(", True, 8, 2)", code)
+                self.assertIn(
+                    "early_split_publish=True, pair_batch=8, emu_batch=2", code
+                )
 
                 expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
                 torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
@@ -2762,7 +2996,7 @@ class TestCuteBackend(TestCase):
                     cute_causal_attention, (q, k, v), block_sizes=[1, 128, 128]
                 )
                 self.assertTrue(_flash_fired(code))
-                self.assertIn("fa4_disc_rowmax_causal", code)
+                self.assertIn("fa4_disc_rowmax_causal_balanced", code)
                 self.assertIn("flash_lpt_group", code)
                 self.assertIn("flash_s0_corr_full_ptr", code)
                 expected = torch.nn.functional.scaled_dot_product_attention(
@@ -2785,6 +3019,25 @@ class TestCuteBackend(TestCase):
                 ) * math.log2(math.e)
                 torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
                 torch.testing.assert_close(lse, expected_lse, atol=2e-2, rtol=2e-2)
+
+    def test_flash_attention_fa4_sload16_balanced_rowmax_matches_sdpa(self) -> None:
+        q, k, v = (
+            torch.randn(1, 2, 512, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        code, out = code_and_output(
+            cute_dense_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4",
+            cute_flash_softmax_disc=True,
+            cute_flash_p_store_rep=16,
+            cute_flash_s_load_rep=16,
+        )
+        self.assertIn("fa4_disc_rowmax_balanced", code)
+        self.assertIn("fa4_disc_exp_convert_store_sload16_pair_pipe", code)
+        expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
     def test_flash_attention_causal_packed_reduce_matches_sdpa(self) -> None:
         q, k, v = (
@@ -2843,9 +3096,18 @@ class TestCuteBackend(TestCase):
             v,
             is_causal=True,
         )
+        scores = torch.matmul(q.float(), k.float().transpose(-1, -2)) / math.sqrt(64)
+        causal_mask = torch.ones(512, 512, dtype=torch.bool, device=DEVICE).tril()
+        expected_lse = torch.logsumexp(
+            scores.masked_fill(~causal_mask, -torch.inf), dim=-1
+        ) * math.log2(math.e)
+        boundary_rows = torch.tensor(
+            [0, 127, 128, 255, 256, 383, 384, 511],
+            device=DEVICE,
+        )
         for loop_split in (True, False):
             with self.subTest(loop_split=loop_split):
-                code, (out, _lse) = code_and_output(
+                code, (out, lse) = code_and_output(
                     cute_causal_attention,
                     (q, k, v),
                     block_sizes=[1, 128, 128],
@@ -2865,11 +3127,86 @@ class TestCuteBackend(TestCase):
                 self.assertTrue(_flash_fired(code))
                 self.assertIn("fa4_disc_zero_store", code)
                 if loop_split:
-                    self.assertIn("for flash_kv_mask_iter in", code)
+                    self.assertIn(
+                        "for flash_kv_mask_iter in cutlass.range(",
+                        code,
+                    )
+                    self.assertIn(
+                        "for flash_kv_unmask_iter in cutlass.range(",
+                        code,
+                    )
+                    self.assertNotIn(
+                        "range_constexpr(flash_m_tile",
+                        code,
+                    )
+                    masked_start = code.index(
+                        "for flash_kv_mask_iter in cutlass.range("
+                    )
+                    unmasked_start = code.index(
+                        "for flash_kv_unmask_iter in cutlass.range(", masked_start
+                    )
+                    masked_stage0 = code[masked_start:unmasked_start]
+                    alpha_store = masked_stage0.index(
+                        "flash_scale_t[flash_s_corr_prod_index, 0, "
+                        "flash_local_tidx] = flash_alpha"
+                    )
+                    alpha_publish = masked_stage0.index(
+                        "cute.arch.barrier_arrive(", alpha_store
+                    )
+                    self.assertEqual(masked_stage0.count("flash_minus_max_scale ="), 1)
+                    minus_scale = masked_stage0.index("flash_minus_max_scale =")
+                    probability_pass = masked_stage0.index(
+                        "flash_p_sum = cutlass.Float32(0.0)", minus_scale
+                    )
+                    self.assertLess(alpha_store, alpha_publish)
+                    self.assertLess(alpha_publish, minus_scale)
+                    self.assertLess(minus_scale, probability_pass)
                 else:
                     self.assertIn("for flash_kv_iter in", code)
                     self.assertNotIn("flash_kv_mask_iter", code)
                 torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+                torch.testing.assert_close(
+                    lse[:, :, boundary_rows],
+                    expected_lse[:, :, boundary_rows],
+                    atol=2e-2,
+                    rtol=2e-2,
+                )
+
+    def test_flash_attention_causal_fa4_split_bfloat16_boundaries(self) -> None:
+        q, k, v = (
+            torch.randn(1, 1, 256, 64, dtype=torch.bfloat16, device=DEVICE)
+            for _ in range(3)
+        )
+        code, (out, lse) = code_and_output(
+            cute_causal_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+            cute_flash_topology="fa4",
+            cute_flash_causal_kv_order="descending",
+            cute_flash_causal_loop_split=True,
+            cute_flash_softmax_disc=True,
+        )
+        self.assertIn("for flash_kv_unmask_iter in cutlass.range(", code)
+        self.assertNotIn("range_constexpr(flash_m_tile", code)
+        expected = torch.nn.functional.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            is_causal=True,
+        )
+        scores = torch.matmul(q.float(), k.float().transpose(-1, -2)) / math.sqrt(64)
+        causal_mask = torch.ones(256, 256, dtype=torch.bool, device=DEVICE).tril()
+        expected_lse = torch.logsumexp(
+            scores.masked_fill(~causal_mask, -torch.inf), dim=-1
+        ) * math.log2(math.e)
+        boundary_rows = torch.tensor([0, 127, 128, 255], device=DEVICE)
+        torch.testing.assert_close(out, expected, atol=3e-2, rtol=3e-2)
+        torch.testing.assert_close(
+            lse[:, :, boundary_rows],
+            expected_lse[:, :, boundary_rows],
+            atol=4e-2,
+            rtol=4e-2,
+        )
 
     def test_flash_attention_causal_single_warpgroup_matches_sdpa(self) -> None:
         q, k, v = (
@@ -2892,6 +3229,41 @@ class TestCuteBackend(TestCase):
             is_causal=True,
         )
         torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_flash_attention_dense_degree1_packet_matches_sdpa(self) -> None:
+        cases = (
+            (32768, "deg1_8x2_corr10", 5, 1),
+            (65536, "deg1_8x2_corr10", 2, 1),
+            (131072, "deg1_8x2_corr10", 2, 1),
+            (196608, "deg1_8x2_corr10", 2, 1),
+            (262144, "deg1_16x8", 0, 10),
+        )
+        for sequence_length, packet, offset, offset0 in cases:
+            with self.subTest(sequence_length=sequence_length):
+                torch.manual_seed(20260728 + sequence_length)
+                q, k, v = (
+                    torch.randn(
+                        1,
+                        1,
+                        sequence_length,
+                        64,
+                        dtype=torch.float16,
+                        device=DEVICE,
+                    )
+                    for _ in range(3)
+                )
+                code, out = code_and_output(
+                    cute_dense_attention,
+                    (q, k, v),
+                    block_sizes=[1, 128, 128],
+                    cute_flash_pipeline_family="fa4_2cta",
+                    cute_flash_exp2_packet=packet,
+                    cute_flash_e2e_offset=offset,
+                    cute_flash_e2e_offset0=offset0,
+                )
+                self.assertIn("degree1=True", code)
+                expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+                torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)
 
     def test_flash_attention_bias_fires_and_matches_sdpa(self) -> None:
         q, k, v = (
@@ -3072,12 +3444,23 @@ class TestCuteBackend(TestCase):
             cute_causal_biased_attention,
             (q, k, v, bias),
             block_sizes=[1, 128, 128],
+            cute_flash_topology="fa4",
+            cute_flash_causal_kv_order="descending",
+            cute_flash_causal_loop_split=True,
         )
         self.assertTrue(_flash_fired(code))
         self.assertIn("add_score_bias_t2r", code)
         self.assertIn("causal_mask_t2r", code)
         self.assertIn("flash_fa4_shared_storage", code)
+        self.assertNotIn("flash_kv_unmask_iter", code)
         _assert_score_modified_reductions(self, code)
+        modifier_loop = code.index("for flash_kv_iter in cutlass.range(")
+        minus_scale = code.index("flash_minus_max_scale =", modifier_loop)
+        alpha_store = code.index(
+            "flash_scale_t[flash_s_corr_prod_index, 0, flash_local_tidx] = flash_alpha",
+            modifier_loop,
+        )
+        self.assertLess(minus_scale, alpha_store)
         causal_mask = torch.ones(256, 256, dtype=torch.bool, device=DEVICE).tril()
         expected = torch.nn.functional.scaled_dot_product_attention(
             q,
@@ -3524,6 +3907,82 @@ class TestCuteBackend(TestCase):
         self.assertEqual(cfg.topology, "fa4")
         self.assertFalse(cfg.persistent)
         self.assertEqual(cfg.kv_stage, 2)
+
+    def test_flash_attention_deep_one_cta_resource_normalization(self) -> None:
+        self.assertEqual(
+            [
+                flash_fa4_shared_storage(64, stage, separate_kv=True).size_in_bytes()
+                for stage in (2, 3, 4)
+            ],
+            [101_376, 134_144, 166_912],
+        )
+        self.assertEqual(
+            flash_fa4_shared_storage(128, 2, separate_kv=True).size_in_bytes(),
+            199_680,
+        )
+        family = {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_deep_1cta"}
+        for requested, expected in ((1, 2), (2, 2), (3, 3), (4, 4), (8, 4)):
+            with self.subTest(head_dim=64, requested=requested):
+                cfg = resolve_flash_config(
+                    64,
+                    512,
+                    {
+                        **family,
+                        _cute_flash.FLASH_KV_STAGE_KEY: requested,
+                        _cute_flash.FLASH_EPI_TMA_KEY: True,
+                        _cute_flash.FLASH_EPI_STG_KEY: True,
+                    },
+                )
+                self.assertEqual(cfg.pipeline_family, "fa4_deep_1cta")
+                self.assertTrue(cfg.separate_kv_rings)
+                self.assertEqual(cfg.kv_stage, expected)
+                self.assertEqual(cfg.s_stage, 2)
+                self.assertFalse(cfg.epi_tma)
+                self.assertFalse(cfg.epi_stg)
+                self.assertFalse(cfg.use_2cta_instrs)
+                self.assertFalse(cfg.use_cga2_local_cta)
+                self.assertFalse(cfg.use_clc_scheduler)
+                self.assertFalse(cfg.local_tma_partition)
+                self.assertFalse(cfg.tensor_4d_tma)
+
+        hd128 = resolve_flash_config(
+            128,
+            512,
+            {**family, _cute_flash.FLASH_KV_STAGE_KEY: 4},
+        )
+        self.assertEqual(hd128.pipeline_family, "fa4_deep_1cta")
+        self.assertEqual(hd128.kv_stage, 2)
+
+    def test_flash_attention_unsupported_family_variants_normalize_atomically(
+        self,
+    ) -> None:
+        unsupported = (
+            resolve_flash_config(
+                64,
+                512,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: ("fa4_cga2_causal_multicast")},
+                is_causal=True,
+            ),
+            resolve_flash_config(
+                64,
+                512,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta_causal"},
+                dtype=torch.bfloat16,
+                is_causal=True,
+            ),
+            resolve_flash_config(
+                64,
+                512,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta_causal_deep"},
+                is_causal=True,
+            ),
+        )
+        for cfg in unsupported:
+            self.assertEqual(cfg.pipeline_family, "fa4")
+            self.assertFalse(cfg.separate_kv_rings)
+            self.assertFalse(cfg.causal_two_cta)
+            self.assertFalse(cfg.use_2cta_instrs)
+            self.assertFalse(cfg.use_cga2_local_cta)
 
     def test_flash_attention_fa4_disc_pipe_defaults_by_head_dim(self) -> None:
         with patch.dict(
@@ -4206,6 +4665,8 @@ class TestCuteBackend(TestCase):
             dense_128k = resolve_flash_config(64, 1024, force_two_cta)
             dense_unaligned = resolve_flash_config(64, 258, force_two_cta)
             dense_256k = resolve_flash_config(64, 2048, force_two_cta)
+            dense_midrange = resolve_flash_config(64, 1536, force_two_cta)
+            dense_above_range = resolve_flash_config(64, 2052, force_two_cta)
             dense_bf16 = resolve_flash_config(
                 64, 512, force_two_cta, dtype=torch.bfloat16
             )
@@ -4226,8 +4687,12 @@ class TestCuteBackend(TestCase):
         self.assertTrue(dense_128k.use_2cta_instrs)
         self.assertFalse(dense_unaligned.use_2cta_instrs)
         self.assertEqual(dense_unaligned.pipeline_family, "fa4")
-        self.assertFalse(dense_256k.use_2cta_instrs)
-        self.assertEqual(dense_256k.pipeline_family, "fa4")
+        self.assertTrue(dense_256k.use_2cta_instrs)
+        self.assertEqual(dense_256k.pipeline_family, "fa4_2cta")
+        self.assertTrue(dense_midrange.use_2cta_instrs)
+        self.assertEqual(dense_midrange.pipeline_family, "fa4_2cta")
+        self.assertFalse(dense_above_range.use_2cta_instrs)
+        self.assertEqual(dense_above_range.pipeline_family, "fa4")
         self.assertFalse(dense_bf16.use_2cta_instrs)
         self.assertEqual(dense_bf16.pipeline_family, "fa4")
         self.assertFalse(causal.use_2cta_instrs)
@@ -4260,34 +4725,68 @@ class TestCuteBackend(TestCase):
             ineligible_unaligned[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices
             or (),
         )
-        ineligible = _cute_flash.flash_autotune_fragments(64, 2048)
+        eligible_256k = _cute_flash.flash_autotune_fragments(64, 2048)
+        self.assertIn(
+            "fa4_2cta",
+            eligible_256k[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices or (),
+        )
+        eligible_midrange = _cute_flash.flash_autotune_fragments(64, 1536)
+        self.assertIn(
+            "fa4_2cta",
+            eligible_midrange[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices
+            or (),
+        )
+        ineligible_above_range = _cute_flash.flash_autotune_fragments(64, 2052)
         self.assertNotIn(
             "fa4_2cta",
-            ineligible[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices or (),
+            ineligible_above_range[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices
+            or (),
         )
 
     def test_flash_attention_pipeline_family_resolution(self) -> None:
         expected_flags = {
-            "ws_overlap": ("ws_overlap", False, False, False, False, False),
-            "fa4": ("fa4", False, False, False, False, False),
-            "fa4_tma_4d": ("fa4", False, False, False, False, True),
-            "fa4_local_tma": ("fa4", False, False, False, True, False),
-            "fa4_local_tma_4d": ("fa4", False, False, False, True, True),
-            "fa4_cga2_local": ("fa4", False, True, False, False, False),
+            "ws_overlap": (
+                "ws_overlap",
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+            ),
+            "fa4": ("fa4", False, False, False, False, False, False, False),
+            "fa4_deep_1cta": ("fa4", True, False, False, False, False, False, False),
+            "fa4_2cta_causal": ("fa4", False, True, True, False, False, False, False),
+            "fa4_tma_4d": ("fa4", False, False, False, False, False, False, True),
+            "fa4_local_tma": ("fa4", False, False, False, False, False, True, False),
+            "fa4_local_tma_4d": ("fa4", False, False, False, False, False, True, True),
+            "fa4_cga2_local": ("fa4", False, False, False, True, False, False, False),
             "fa4_cga2_local_tma_4d": (
                 "fa4",
+                False,
+                False,
                 False,
                 True,
                 False,
                 False,
                 True,
             ),
-            "fa4_2cta": ("fa4", True, False, False, False, False),
-            "fa4_2cta_tma_4d": ("fa4", True, False, False, False, True),
-            "fa4_clc": ("fa4", False, False, True, False, False),
-            "fa4_clc_tma_4d": ("fa4", False, False, True, False, True),
-            "fa4_clc_local_tma": ("fa4", False, False, True, True, False),
-            "fa4_clc_local_tma_4d": ("fa4", False, False, True, True, True),
+            "fa4_2cta": ("fa4", False, False, True, False, False, False, False),
+            "fa4_2cta_tma_4d": ("fa4", False, False, True, False, False, False, True),
+            "fa4_clc": ("fa4", False, False, False, False, True, False, False),
+            "fa4_clc_tma_4d": ("fa4", False, False, False, False, True, False, True),
+            "fa4_clc_local_tma": ("fa4", False, False, False, False, True, True, False),
+            "fa4_clc_local_tma_4d": (
+                "fa4",
+                False,
+                False,
+                False,
+                False,
+                True,
+                True,
+                True,
+            ),
         }
         self.assertEqual(set(expected_flags), set(_cute_flash.FLASH_PIPELINE_FAMILIES))
 
@@ -4299,11 +4798,14 @@ class TestCuteBackend(TestCase):
                         512,
                         {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: family_name},
                         dtype=torch.float16,
+                        is_causal="causal" in family_name,
                     )
                     self.assertEqual(cfg.pipeline_family, family_name)
                     self.assertEqual(
                         (
                             cfg.topology,
+                            cfg.separate_kv_rings,
+                            cfg.causal_two_cta,
                             cfg.use_2cta_instrs,
                             cfg.use_cga2_local_cta,
                             cfg.use_clc_scheduler,
@@ -4418,7 +4920,7 @@ class TestCuteBackend(TestCase):
                 512,
                 {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4"},
             )
-            with_dead_knobs = resolve_flash_config(
+            with_legacy_values = resolve_flash_config(
                 64,
                 512,
                 {
@@ -4427,10 +4929,103 @@ class TestCuteBackend(TestCase):
                     _cute_flash.FLASH_MMA_INTERLEAVE_KEY: 9,
                 },
             )
-            self.assertEqual(with_dead_knobs, base)
+            self.assertEqual(with_legacy_values, base)
             field_names = {field.name for field in dataclasses.fields(base)}
-            self.assertNotIn("q_tile_count", field_names)
-            self.assertNotIn("mma_interleave", field_names)
+            self.assertIn("q_tile_count", field_names)
+            self.assertIn("mma_interleave", field_names)
+            self.assertEqual(base.q_tile_count, 2)
+            self.assertTrue(base.mma_interleave)
+
+    def test_flash_attention_sync_and_softmax_controls_normalize(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            fa4 = resolve_flash_config(
+                64,
+                512,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4"},
+            )
+            self.assertEqual(fa4.q_tile_count, 2)
+            self.assertTrue(fa4.mma_interleave)
+            self.assertEqual(fa4.wait_hint, 10_000_000)
+            self.assertEqual(fa4.exp2_packet, "1x1")
+            self.assertEqual(fa4.stat_transport, "single")
+
+            ws = resolve_flash_config(
+                64,
+                512,
+                {
+                    _cute_flash.FLASH_PIPELINE_FAMILY_KEY: "ws_overlap",
+                    _cute_flash.FLASH_Q_TILE_COUNT_KEY: 17,
+                    _cute_flash.FLASH_MMA_INTERLEAVE_KEY: True,
+                    _cute_flash.FLASH_WAIT_HINT_KEY: 0,
+                    _cute_flash.FLASH_EXP2_PACKET_KEY: "8x2",
+                    _cute_flash.FLASH_STAT_TRANSPORT_KEY: "single",
+                },
+            )
+            self.assertEqual(ws.q_tile_count, 1)
+            self.assertFalse(ws.mma_interleave)
+            self.assertEqual(ws.wait_hint, 10_000_000)
+            self.assertEqual(ws.exp2_packet, "1x1")
+            self.assertEqual(ws.stat_transport, "ring2")
+
+            two_cta = resolve_flash_config(
+                64,
+                512,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta"},
+            )
+            self.assertEqual(two_cta.exp2_packet, "8x2")
+            hd128_two_cta = resolve_flash_config(
+                128,
+                512,
+                {_cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta"},
+            )
+            self.assertEqual(hd128_two_cta.exp2_packet, "1x1")
+
+            tuned = resolve_flash_config(
+                64,
+                512,
+                {
+                    _cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4",
+                    _cute_flash.FLASH_MMA_INTERLEAVE_KEY: False,
+                    _cute_flash.FLASH_WAIT_HINT_KEY: 0,
+                    _cute_flash.FLASH_EXP2_PACKET_KEY: "8x2",
+                    _cute_flash.FLASH_STAT_TRANSPORT_KEY: "ring2",
+                },
+            )
+            self.assertFalse(tuned.mma_interleave)
+            self.assertEqual(tuned.wait_hint, 0)
+            self.assertEqual(tuned.exp2_packet, "8x2")
+            self.assertEqual(tuned.stat_transport, "ring2")
+
+            causal = resolve_flash_config(
+                64,
+                512,
+                {
+                    _cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4",
+                    _cute_flash.FLASH_STAT_TRANSPORT_KEY: "single",
+                },
+                is_causal=True,
+            )
+            self.assertEqual(causal.stat_transport, "ring2")
+
+        with patch.dict(
+            os.environ,
+            {
+                "HELION_CUTE_FLASH_Q_TILE_COUNT": "legacy-nonnumeric",
+                "HELION_CUTE_FLASH_MMA_PTX": "0",
+            },
+            clear=True,
+        ):
+            inactive = resolve_flash_config(
+                64,
+                512,
+                {
+                    _cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4",
+                    _cute_flash.FLASH_Q_TILE_COUNT_KEY: "also-ignored",
+                    _cute_flash.FLASH_MMA_INTERLEAVE_KEY: False,
+                },
+            )
+        self.assertEqual(inactive.q_tile_count, 2)
+        self.assertTrue(inactive.mma_interleave)
 
     def test_flash_attention_fa4_persistent_config_overrides_env(self) -> None:
         with patch.dict(os.environ, {"HELION_CUTE_FLASH_PERSISTENT": "1"}, clear=True):
@@ -9326,6 +9921,15 @@ class TestCuteConfigValuePriors(TestCase):
             FLASH_EPI_STG_GMEM_KEY: {"stage"},
         }.items():
             self._assert_prior_choices(tma_priors[key], tma_fragments[key], values)
+        bound.config_spec._cute_flash_num_kv = 2048
+        bound.config_spec._cute_flash_dtype = torch.float16
+        two_cta_priors = CuteBackend().config_value_priors(bound.config_spec)
+        two_cta_fragments = bound.config_spec._flat_fields()
+        self._assert_prior_choices(
+            two_cta_priors[FLASH_PIPELINE_FAMILY_KEY],
+            two_cta_fragments[FLASH_PIPELINE_FAMILY_KEY],
+            {"fa4", "ws_overlap", "fa4_2cta"},
+        )
         bound.config_spec._cute_flash_num_kv = 64
 
         gen = ConfigGeneration(bound.config_spec)

--- a/test/test_cute_causal_range.py
+++ b/test/test_cute_causal_range.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+from helion._compiler.cute.attention_plan import causal_score_plan
+from helion._compiler.cute.causal_range import IntegerInterval
+from helion._compiler.cute.causal_range import TileLayout
+from helion._compiler.cute.causal_range import prove_causal_tile_range_unmasked
+from helion._compiler.cute.causal_range import prove_descending_causal_prefix_unmasked
+from helion._compiler.cute.cute_flash import _flash_fa4_descending_causal_split_proof
+from helion._compiler.cute.cute_flash import _flash_runtime_range_header
+
+
+@pytest.fixture
+def full_tiles() -> TileLayout:
+    return TileLayout(extent=512, stride=128, width=128)
+
+
+def test_descending_causal_prefix_proves_complete_visible_tiles(
+    full_tiles: TileLayout,
+) -> None:
+    proof = prove_descending_causal_prefix_unmasked(
+        query_tiles=IntegerInterval(0, 4),
+        query_layout=full_tiles,
+        kv_layout=full_tiles,
+    )
+    assert proof.proven
+
+
+def test_causal_range_rejects_diagonal_tile(full_tiles: TileLayout) -> None:
+    proof = prove_causal_tile_range_unmasked(
+        query_tiles=IntegerInterval(0, 4),
+        kv_tiles=IntegerInterval(0, 4),
+        kv_minus_query=IntegerInterval(-4, 1),
+        query_layout=full_tiles,
+        kv_layout=full_tiles,
+    )
+    assert not proof.proven
+    assert proof.reason == "range includes a masked causal lane"
+
+
+def test_causal_range_rejects_partial_sequence_tail() -> None:
+    partial_tiles = TileLayout(extent=500, stride=128, width=128)
+    proof = prove_descending_causal_prefix_unmasked(
+        query_tiles=IntegerInterval(0, 4),
+        query_layout=partial_tiles,
+        kv_layout=partial_tiles,
+    )
+    assert not proof.proven
+    assert proof.reason == "query tile has out-of-bounds lanes"
+
+
+@pytest.mark.parametrize(
+    ("query_tiles", "extent", "additional_modifiers", "tile_pruning", "reason"),
+    [
+        (None, 512, False, False, "symbolic range"),
+        (IntegerInterval(0, 4), None, False, False, "dynamic extent"),
+        (IntegerInterval(0, 4), 512, True, False, "additional score modifiers"),
+        (IntegerInterval(0, 4), 512, False, True, "KV tile pruning"),
+    ],
+)
+def test_descending_causal_prefix_conservative_fallbacks(
+    query_tiles: IntegerInterval | None,
+    extent: int | None,
+    additional_modifiers: bool,
+    tile_pruning: bool,
+    reason: str,
+) -> None:
+    layout = TileLayout(extent=extent, stride=128, width=128)
+    proof = prove_descending_causal_prefix_unmasked(
+        query_tiles=query_tiles,
+        query_layout=layout,
+        kv_layout=layout,
+        has_additional_modifiers=additional_modifiers,
+        has_kv_tile_pruning=tile_pruning,
+    )
+    assert not proof.proven
+    assert proof.reason == reason
+
+
+def test_causal_range_handles_distinct_tile_geometries() -> None:
+    proof = prove_causal_tile_range_unmasked(
+        query_tiles=IntegerInterval(0, 4),
+        kv_tiles=IntegerInterval(0, 7),
+        kv_minus_query=IntegerInterval(-8, -1),
+        query_layout=TileLayout(extent=512, stride=128, width=128),
+        kv_layout=TileLayout(extent=512, stride=64, width=64),
+    )
+    assert proof.proven
+
+
+def test_causal_split_loop_header_stays_runtime() -> None:
+    source = _flash_runtime_range_header(
+        "flash_kv_unmask_iter",
+        "flash_m_tile0",
+    )
+    assert source == (
+        "for flash_kv_unmask_iter in cutlass.range(flash_m_tile0, unroll=1):"
+    )
+    assert "range_constexpr" not in source
+
+
+def test_fa4_split_proof_requires_exact_static_sequence_coverage() -> None:
+    score_plan = causal_score_plan(64)
+    assert _flash_fa4_descending_causal_split_proof(
+        sequence_extent=512,
+        num_query_tiles=4,
+        num_kv_tiles=4,
+        score_plan=score_plan,
+    ).proven
+
+    tail = _flash_fa4_descending_causal_split_proof(
+        sequence_extent=500,
+        num_query_tiles=4,
+        num_kv_tiles=4,
+        score_plan=score_plan,
+    )
+    assert not tail.proven
+    assert tail.reason == "partial or uncovered sequence tail"
+
+    mismatch = _flash_fa4_descending_causal_split_proof(
+        sequence_extent=512,
+        num_query_tiles=4,
+        num_kv_tiles=3,
+        score_plan=score_plan,
+    )
+    assert not mismatch.proven
+    assert mismatch.reason == "query/KV tile-count mismatch"

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -1,0 +1,716 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import math
+import os
+from typing import TYPE_CHECKING
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+import torch
+
+import helion
+from helion._compiler.backend import CuteBackend
+from helion._compiler.cute import cute_flash
+from helion._compiler.cute.attention_plan import causal_score_plan
+from helion._compiler.cute.attention_plan import dense_score_plan
+from helion._testing import DEVICE
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+from helion.autotuner.config_fragment import EnumFragment
+from helion.autotuner.config_spec import BlockSizeSpec
+from helion.autotuner.config_spec import ConfigSpec
+import helion.language as hl
+
+if TYPE_CHECKING:
+    from helion._compiler.device_function import DeviceFunction
+
+pytest.importorskip("cutlass")
+pytest.importorskip("cutlass.cute")
+
+# ``_flash_runtime`` imports cutlass at module scope, so it must be loaded after
+# the skip gate above rather than with the normal top-of-file imports.
+_flash_runtime = importlib.import_module("helion._compiler.cute._flash_runtime")
+
+_DEG2_PACKET = "deg2_16x6"
+_HYBRID_PACKET = "hybrid_deg1_16x8"
+_DEG1_PACKET = "deg1_16x8"
+_DEG1_SHORT_PACKET = "deg1_8x2_corr10"
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _causal_attention_output(
+    q_in: torch.Tensor, k_in: torch.Tensor, v_in: torch.Tensor
+) -> torch.Tensor:
+    m_dim = q_in.size(-2)
+    n_dim = k_in.size(-2)
+    head_dim = hl.specialize(q_in.size(-1))
+    q_view = q_in.reshape([-1, m_dim, head_dim])
+    v_view = v_in.reshape([-1, n_dim, head_dim])
+    k_view = k_in.reshape([-1, n_dim, head_dim])
+    out = torch.empty_like(q_view)
+    qk_scale = (1.0 / math.sqrt(head_dim)) * math.log2(math.e)
+    for tile_b, tile_m in hl.tile([q_view.size(0), m_dim]):
+        m_i = hl.full([tile_b, tile_m], float("-inf"), dtype=torch.float32)
+        l_i = torch.full_like(m_i, 1.0)
+        acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+        qt = q_view[tile_b, tile_m, :]
+        for tile_n in hl.tile(v_view.size(1)):
+            kt = k_view[tile_b, tile_n, :]
+            qk = torch.bmm(qt * qk_scale, kt.transpose(1, 2), torch.float32)
+            qk = torch.where(
+                tile_m.index[None, :, None] >= tile_n.index[None, None, :],
+                qk,
+                float("-inf"),
+            )
+            m_ij_keepdim = torch.maximum(
+                m_i[:, :, None], torch.amax(qk, -1, keepdim=True)
+            )
+            qk = qk - m_ij_keepdim
+            m_ij = m_ij_keepdim.squeeze(-1)
+            p = torch.exp2(qk)
+            l_ij = torch.sum(p, -1)
+            alpha = torch.exp2(m_i - m_ij)
+            l_i = l_i * alpha + l_ij
+            acc = acc * alpha[:, :, None]
+            vt = v_view[tile_b, tile_n, :]
+            acc = torch.baddbmm(acc, p.to(vt.dtype), vt)
+            m_i = m_ij
+        out[tile_b, tile_m, :] = (acc / l_i[:, :, None]).to(out.dtype)
+    return out.view(q_in.size())
+
+
+def _manual_config(
+    packet: str = _DEG2_PACKET, **overrides: object
+) -> dict[str, object]:
+    config: dict[str, object] = {
+        cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4",
+        cute_flash.FLASH_EXP2_PACKET_KEY: packet,
+        cute_flash.FLASH_DISC_PIPE_KEY: 3,
+        cute_flash.FLASH_P_STORE_REP_KEY: 16,
+        cute_flash.FLASH_S_LOAD_REP_KEY: 32,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_degree2_polynomial_relative_error_bound() -> None:
+    x = torch.linspace(0.0, 1.0, 100_001, dtype=torch.float32)
+    c0, c1, c2 = _flash_runtime._POLY_EX2_DEG2
+    approximate = (torch.tensor(c2) * x + torch.tensor(c1)) * x + torch.tensor(c0)
+    relative_error = (approximate / torch.exp2(x) - 1.0).abs()
+
+    assert relative_error.max().item() < 0.00173
+
+
+def test_degree1_polynomial_relative_error_bound() -> None:
+    x = torch.linspace(0.0, 1.0, 100_001, dtype=torch.float32)
+    c0, c1 = _flash_runtime._POLY_EX2_DEG1
+    approximate = torch.tensor(c1) * x + torch.tensor(c0)
+    relative_error = (approximate / torch.exp2(x) - 1.0).abs()
+
+    assert relative_error.max().item() < 0.02983
+
+
+def test_degree2_packet_codegen_route_is_exact_and_manual_only() -> None:
+    assert cute_flash._flash_disc_exp2_codegen_params(_DEG2_PACKET, 8, 2) == (
+        16,
+        6,
+        8,
+        3,
+        True,
+        False,
+    )
+    assert cute_flash._flash_disc_exp2_codegen_params(_HYBRID_PACKET, 8, 2) == (
+        16,
+        8,
+        8,
+        4,
+        True,
+        True,
+    )
+    assert cute_flash._flash_disc_exp2_codegen_params(_DEG1_PACKET, 8, 2) == (
+        16,
+        8,
+        8,
+        4,
+        False,
+        True,
+    )
+    current_packets = {
+        "1x1": (1, 1),
+        "4x1": (4, 1),
+        "4x2": (4, 2),
+        "8x1": (8, 1),
+        "8x2": (8, 2),
+    }
+    for packet, (pair_batch, emu_batch) in current_packets.items():
+        assert cute_flash._flash_disc_exp2_codegen_params(packet, 13, 5) == (
+            13,
+            5,
+            pair_batch,
+            emu_batch,
+            False,
+            False,
+        )
+
+
+def test_degree2_packet_emits_exact_causal_pass2_arguments() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        config = cute_flash.resolve_flash_config(
+            64,
+            512,
+            _manual_config(),
+            dtype=torch.float16,
+            is_causal=True,
+        )
+    body = cute_flash.emit_flash_fa4_device_body(
+        cast("DeviceFunction", None),
+        head_dim=64,
+        num_kv=512,
+        sequence_extent=65_536,
+        num_bh=1,
+        total_tiles=256,
+        cfg=config,
+        has_lse=False,
+        io_dtype="cutlass.Float16",
+        score_plan=causal_score_plan(64),
+    )
+    module = ast.Module(body=body, type_ignores=[])
+    pass2_calls = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr
+        in {
+            "fa4_disc_exp_convert_store_pipe",
+            "fa4_disc_exp_convert_store_pipe_causal",
+        }
+    ]
+    assert len(pass2_calls) == 4
+    for call in pass2_calls:
+        assert ast.literal_eval(call.args[8]) == 16
+        assert ast.literal_eval(call.args[9]) == 6
+        keywords = {
+            keyword.arg: ast.literal_eval(keyword.value) for keyword in call.keywords
+        }
+        assert keywords == {"pair_batch": 8, "emu_batch": 3, "degree2": True}
+
+
+def test_hybrid_packet_uses_degree1_only_for_unmasked_pass2() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        config = cute_flash.resolve_flash_config(
+            64,
+            512,
+            _manual_config(_HYBRID_PACKET),
+            dtype=torch.float16,
+            is_causal=True,
+        )
+    body = cute_flash.emit_flash_fa4_device_body(
+        cast("DeviceFunction", None),
+        head_dim=64,
+        num_kv=512,
+        sequence_extent=65_536,
+        num_bh=1,
+        total_tiles=256,
+        cfg=config,
+        has_lse=False,
+        io_dtype="cutlass.Float16",
+        score_plan=causal_score_plan(64),
+    )
+    module = ast.Module(body=body, type_ignores=[])
+    pass2_calls = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr
+        in {
+            "fa4_disc_exp_convert_store_pipe",
+            "fa4_disc_exp_convert_store_pipe_causal",
+        }
+    ]
+    assert len(pass2_calls) == 4
+    for call in pass2_calls:
+        assert ast.literal_eval(call.args[8]) == 16
+        assert ast.literal_eval(call.args[9]) == 8
+        keywords = {
+            keyword.arg: ast.literal_eval(keyword.value) for keyword in call.keywords
+        }
+        polynomial = (
+            {"degree2": True}
+            if call.func.attr.endswith("_causal")
+            else {"degree1": True}
+        )
+        assert keywords == {"pair_batch": 8, "emu_batch": 4, **polynomial}
+
+
+@pytest.mark.parametrize(
+    ("packet", "num_kv", "sequence_extent", "total_tiles", "freq", "res", "emu"),
+    (
+        (_DEG1_SHORT_PACKET, 256, 32_768, 4_096, 8, 2, 2),
+        (_DEG1_SHORT_PACKET, 512, 65_536, 8_192, 8, 2, 2),
+        (_DEG1_SHORT_PACKET, 1024, 131_072, 16_384, 8, 2, 2),
+        (_DEG1_PACKET, 2048, 262_144, 32_768, 16, 8, 4),
+    ),
+)
+def test_degree1_packet_uses_whole_row_dense_pass2(
+    packet: str,
+    num_kv: int,
+    sequence_extent: int,
+    total_tiles: int,
+    freq: int,
+    res: int,
+    emu: int,
+) -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        config = cute_flash.resolve_flash_config(
+            64,
+            num_kv,
+            _manual_config(
+                packet,
+                **{cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta"},
+            ),
+            dtype=torch.float16,
+            is_causal=False,
+            standard_dense_output=True,
+        )
+    assert config.exp2_packet == packet
+    assert config.e2e_schedule == f"{freq}/{res}"
+    body = cute_flash.emit_flash_fa4_device_body(
+        cast("DeviceFunction", None),
+        head_dim=64,
+        num_kv=num_kv,
+        sequence_extent=sequence_extent,
+        num_bh=64,
+        total_tiles=total_tiles,
+        cfg=config,
+        has_lse=False,
+        io_dtype="cutlass.Float16",
+        score_plan=dense_score_plan(64),
+    )
+    module = ast.Module(body=body, type_ignores=[])
+    pass2_calls = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr
+        in {
+            "fa4_sp_exp_convert_store",
+            "fa4_sp_exp_convert_store_whole_rowsum",
+        }
+    ]
+    assert len(pass2_calls) == 2
+    for call in pass2_calls:
+        assert ast.literal_eval(call.args[6]) == freq
+        assert ast.literal_eval(call.args[7]) == res
+        keywords = {
+            keyword.arg: ast.literal_eval(keyword.value) for keyword in call.keywords
+        }
+        assert keywords == {
+            "early_split_publish": True,
+            "pair_batch": 8,
+            "emu_batch": emu,
+            "degree1": True,
+        }
+
+
+@pytest.mark.parametrize(
+    ("packet", "expected_alpha_stages"),
+    ((_DEG1_SHORT_PACKET, ("flash_a1", "flash_a0")), ("8x2", ("flash_a0", "flash_a1"))),
+)
+def test_short_degree1_packet_reverses_steady_correction_order(
+    packet: str, expected_alpha_stages: tuple[str, str]
+) -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        config = cute_flash.resolve_flash_config(
+            64,
+            256,
+            _manual_config(
+                packet,
+                **{cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta"},
+            ),
+            dtype=torch.float16,
+            is_causal=False,
+            standard_dense_output=True,
+        )
+    body = cute_flash.emit_flash_fa4_device_body(
+        cast("DeviceFunction", None),
+        head_dim=64,
+        num_kv=256,
+        sequence_extent=32_768,
+        num_bh=64,
+        total_tiles=4_096,
+        cfg=config,
+        has_lse=False,
+        io_dtype="cutlass.Float16",
+        score_plan=dense_score_plan(64),
+    )
+    correction_loop = next(
+        node
+        for node in ast.walk(ast.Module(body=body, type_ignores=[]))
+        if isinstance(node, ast.For)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "flash_kv"
+        and any(
+            isinstance(child, ast.Name) and child.id == "flash_a0"
+            for child in ast.walk(node)
+        )
+    )
+    alpha_stages = [
+        target.id
+        for statement in correction_loop.body
+        if isinstance(statement, ast.Assign)
+        for target in statement.targets
+        if isinstance(target, ast.Name) and target.id in ("flash_a0", "flash_a1")
+    ]
+    assert alpha_stages == list(expected_alpha_stages)
+
+
+@onlyBackends(["cute"])
+def test_hybrid_packet_runtime_matches_sdpa_at_causal_boundaries() -> None:
+    torch.manual_seed(20260810)
+    q, k, v = (
+        torch.randn(1, 2, 1024, 64, dtype=torch.float16, device=DEVICE)
+        for _ in range(3)
+    )
+    q[:, :, 0, :] = 4.0
+    k[:, :, 0, :] = 4.0
+    q[:, :, 128, :] = -4.0
+    k[:, :, 128, :] = -4.0
+
+    code, out = code_and_output(
+        _causal_attention_output,
+        (q, k, v),
+        block_sizes=[1, 128, 128],
+        cute_flash_pipeline_family="fa4",
+        cute_flash_s_stage=2,
+        cute_flash_kv_stage=2,
+        cute_flash_persistent=False,
+        cute_flash_e2e_schedule="16/8",
+        cute_flash_masked_e2e_schedule="16/8",
+        cute_flash_e2e_offset=0,
+        cute_flash_e2e_offset0=10,
+        cute_flash_disc_pipe=3,
+        cute_flash_exp2_packet=_HYBRID_PACKET,
+        cute_flash_wait_hint=10_000_000,
+        cute_flash_p_store_rep=16,
+        cute_flash_s_load_rep=32,
+        cute_flash_epi_tma=False,
+        cute_flash_epi_stg=False,
+        cute_flash_role_map="helion",
+        cute_flash_causal_loop_split=True,
+        cute_flash_causal_lpt_swizzle=0,
+        cute_flash_causal_kv_order="descending",
+        cute_flash_softmax_regs=184,
+    )
+    assert "degree1=True" in code
+    assert "degree2=True" in code
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+    torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)
+    boundary_rows = torch.tensor([0, 127, 128, 255, 1023], device=DEVICE)
+    torch.testing.assert_close(
+        out[:, :, boundary_rows],
+        expected[:, :, boundary_rows],
+        atol=0.05,
+        rtol=0.02,
+    )
+
+
+def test_degree2_packet_normalizes_by_effective_schedule() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        resolved = cute_flash.resolve_flash_config(
+            64,
+            512,
+            _manual_config(),
+            dtype=torch.float16,
+            is_causal=True,
+        )
+    assert resolved.exp2_packet == _DEG2_PACKET
+    assert resolved.e2e_schedule == "16/6"
+    assert resolved.masked_e2e_schedule == "16/6"
+
+
+@pytest.mark.parametrize(
+    ("packet", "num_kv", "freq", "res"),
+    (
+        (_DEG1_SHORT_PACKET, 256, 8, 2),
+        (_DEG1_SHORT_PACKET, 512, 8, 2),
+        (_DEG1_SHORT_PACKET, 1024, 8, 2),
+        (_DEG1_PACKET, 2048, 16, 8),
+    ),
+)
+def test_degree1_packet_requires_standard_dense_output(
+    packet: str, num_kv: int, freq: int, res: int
+) -> None:
+    overrides = _manual_config(
+        packet,
+        **{cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta"},
+    )
+    with patch.dict(os.environ, {}, clear=True):
+        nonstandard = cute_flash.resolve_flash_config(
+            64,
+            num_kv,
+            overrides,
+            dtype=torch.float16,
+            is_causal=False,
+        )
+        standard = cute_flash.resolve_flash_config(
+            64,
+            num_kv,
+            overrides,
+            dtype=torch.float16,
+            is_causal=False,
+            standard_dense_output=True,
+        )
+        causal = cute_flash.resolve_flash_config(
+            64,
+            num_kv,
+            overrides,
+            dtype=torch.float16,
+            is_causal=True,
+        )
+
+    assert nonstandard.exp2_packet == "8x2"
+    assert causal.exp2_packet != packet
+    assert standard.exp2_packet == packet
+    assert standard.masked_e2e_schedule == "inherit"
+    assert standard.masked_e2e_freq == standard.e2e_freq == freq
+    assert standard.masked_e2e_res == standard.e2e_res == res
+
+
+@pytest.mark.parametrize(
+    ("packet", "num_kv", "expected"),
+    (
+        (_DEG1_PACKET, 256, _DEG1_SHORT_PACKET),
+        (_DEG1_PACKET, 512, _DEG1_SHORT_PACKET),
+        (_DEG1_PACKET, 1024, _DEG1_SHORT_PACKET),
+        (_DEG1_SHORT_PACKET, 2048, _DEG1_PACKET),
+    ),
+)
+def test_degree1_packet_normalizes_to_shape_specific_family(
+    packet: str, num_kv: int, expected: str
+) -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        resolved = cute_flash.resolve_flash_config(
+            64,
+            num_kv,
+            _manual_config(
+                packet,
+                **{cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta"},
+            ),
+            dtype=torch.float16,
+            is_causal=False,
+            standard_dense_output=True,
+        )
+    assert resolved.exp2_packet == expected
+
+
+def test_hybrid_packet_normalizes_by_effective_schedule() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        resolved = cute_flash.resolve_flash_config(
+            64,
+            512,
+            _manual_config(_HYBRID_PACKET),
+            dtype=torch.float16,
+            is_causal=True,
+        )
+    assert resolved.exp2_packet == _HYBRID_PACKET
+    assert resolved.e2e_schedule == "16/8"
+    assert resolved.masked_e2e_schedule == "16/8"
+
+
+def test_degree2_packet_canonicalizes_dead_cadence_fields() -> None:
+    resolved = []
+    with patch.dict(os.environ, {}, clear=True):
+        for schedule, masked_schedule in (("8/2", "inherit"), ("16/4", "xu")):
+            resolved.append(
+                cute_flash.resolve_flash_config(
+                    64,
+                    512,
+                    _manual_config(
+                        **{
+                            cute_flash.FLASH_E2E_SCHEDULE_KEY: schedule,
+                            cute_flash.FLASH_MASKED_E2E_SCHEDULE_KEY: masked_schedule,
+                            cute_flash.FLASH_E2E_OFFSET_KEY: 14,
+                            cute_flash.FLASH_E2E_OFFSET0_KEY: 14,
+                        }
+                    ),
+                    dtype=torch.float16,
+                    is_causal=True,
+                )
+            )
+
+    assert resolved[0] == resolved[1]
+    assert resolved[0].e2e_offset == 14
+    assert resolved[0].e2e_offset0 == 14
+
+
+@pytest.mark.parametrize(
+    ("head_dim", "dtype", "is_causal", "overrides"),
+    (
+        pytest.param(64, torch.float16, False, {}, id="dense"),
+        pytest.param(128, torch.float16, True, {}, id="hd128"),
+        pytest.param(64, torch.bfloat16, True, {}, id="bf16"),
+        pytest.param(
+            64,
+            torch.float16,
+            True,
+            {cute_flash.FLASH_PIPELINE_FAMILY_KEY: "ws_overlap"},
+            id="ws-overlap",
+        ),
+        pytest.param(
+            64,
+            torch.float16,
+            True,
+            {cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_deep_1cta"},
+            id="deep-ring",
+        ),
+        pytest.param(
+            64,
+            torch.float16,
+            True,
+            {cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta_causal"},
+            id="two-cta",
+        ),
+        pytest.param(
+            64,
+            torch.float16,
+            True,
+            {cute_flash.FLASH_SOFTMAX_DISC_KEY: False},
+            id="whole-row",
+        ),
+        pytest.param(
+            64,
+            torch.float16,
+            True,
+            {cute_flash.FLASH_DISC_PIPE_KEY: 1},
+            id="serial-disc",
+        ),
+        pytest.param(
+            64,
+            torch.float16,
+            True,
+            {cute_flash.FLASH_P_STORE_REP_KEY: 32},
+            id="p-store-rep32",
+        ),
+        pytest.param(
+            64,
+            torch.float16,
+            True,
+            {cute_flash.FLASH_S_LOAD_REP_KEY: 16},
+            id="s-load-rep16",
+        ),
+        pytest.param(
+            64,
+            torch.float16,
+            True,
+            {cute_flash.FLASH_E2E_SCHEDULE_KEY: "xu"},
+            id="xu-only",
+        ),
+    ),
+)
+def test_degree2_packet_incompatible_schedule_normalizes(
+    head_dim: int,
+    dtype: torch.dtype,
+    is_causal: bool,
+    overrides: dict[str, object],
+) -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        resolved = cute_flash.resolve_flash_config(
+            head_dim,
+            512,
+            _manual_config(**overrides),
+            dtype=dtype,
+            is_causal=is_causal,
+        )
+    assert resolved.exp2_packet == "1x1"
+
+
+@pytest.mark.parametrize("packet", tuple(cute_flash._FLASH_EXP2_PACKET_PARAMS))
+def test_current_packets_keep_existing_normalization(packet: str) -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        resolved = cute_flash.resolve_flash_config(
+            64,
+            512,
+            _manual_config(**{cute_flash.FLASH_EXP2_PACKET_KEY: packet}),
+            dtype=torch.float16,
+            is_causal=True,
+        )
+    assert resolved.exp2_packet == packet
+
+
+@pytest.mark.parametrize(
+    ("packet", "schedule"),
+    ((_DEG2_PACKET, "16/6"), (_HYBRID_PACKET, "16/8")),
+)
+def test_manual_packet_config_spec_is_fixed_not_searched(
+    packet: str, schedule: str
+) -> None:
+    with patch.dict(
+        os.environ,
+        {"HELION_CUTE_FLASH_EXP2_PACKET": packet},
+        clear=True,
+    ):
+        spec = ConfigSpec(
+            backend=CuteBackend(),
+            target_device_capability=(10, 0),
+            device=torch.device("cpu"),
+            num_sm=148,
+        )
+        for block_id, size_hint in enumerate((1, 128, 128)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+            )
+        spec.enable_cute_flash_search(
+            head_dim=64,
+            num_kv=512,
+            dtype=torch.float16,
+            block_size_targets={0: 1, 1: 128, 2: 128},
+            is_causal=True,
+        )
+
+        fragment = spec._flat_fields()[cute_flash.FLASH_EXP2_PACKET_KEY]
+        assert isinstance(fragment, EnumFragment)
+        assert fragment.choices[0] == packet
+        assert set(fragment.choices) == {
+            *cute_flash._FLASH_EXP2_PACKET_PARAMS,
+            *cute_flash._FLASH_MANUAL_EXP2_PACKET_PARAMS,
+        }
+        assert fragment.search_choices == (packet,)
+
+        e2e_fragment = spec._flat_fields()[cute_flash.FLASH_E2E_SCHEDULE_KEY]
+        assert isinstance(e2e_fragment, EnumFragment)
+        assert e2e_fragment.choices == (schedule,)
+        assert e2e_fragment.search_choices == (schedule,)
+        masked_fragment = spec._flat_fields()[cute_flash.FLASH_MASKED_E2E_SCHEDULE_KEY]
+        assert isinstance(masked_fragment, EnumFragment)
+        assert masked_fragment.choices == (schedule,)
+        assert masked_fragment.search_choices == (schedule,)
+
+        config = spec.default_config()
+        spec.normalize(config)
+        assert config.config[cute_flash.FLASH_EXP2_PACKET_KEY] == packet
+
+
+def test_dense_degree1_environment_builds_canonical_fragments() -> None:
+    env = {
+        "HELION_CUTE_FLASH_PIPELINE_FAMILY": "fa4_2cta",
+        "HELION_CUTE_FLASH_EXP2_PACKET": _DEG1_PACKET,
+    }
+    with patch.dict(os.environ, env, clear=True):
+        fragments = cute_flash.flash_autotune_fragments(
+            64,
+            2048,
+            standard_dense_output=True,
+        )
+        nonstandard = cute_flash.flash_autotune_fragments(64, 2048)
+
+    assert fragments[cute_flash.FLASH_EXP2_PACKET_KEY].search_choices == (_DEG1_PACKET,)
+    assert fragments[cute_flash.FLASH_E2E_SCHEDULE_KEY].choices == ("16/8",)
+    assert fragments[cute_flash.FLASH_MASKED_E2E_SCHEDULE_KEY].choices == ("inherit",)
+    assert nonstandard[cute_flash.FLASH_EXP2_PACKET_KEY].choices[0] == "8x2"

--- a/test/test_cute_flash_schedule.py
+++ b/test/test_cute_flash_schedule.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from helion._compiler.cute.flash_schedule import FlashEdge
+from helion._compiler.cute.flash_schedule import FlashOutputOrder
+from helion._compiler.cute.flash_schedule import FlashSchedule
+from helion._compiler.cute.flash_schedule import FlashScheduleError
+from helion._compiler.cute.flash_schedule import FlashScheduleSpec
+from helion._compiler.cute.flash_schedule import FlashSyncScope
+from helion._compiler.cute.flash_schedule import build_fa4_schedule
+from helion._compiler.cute.flash_schedule import verify_flash_schedule
+
+
+def _replace_edge(
+    schedule: FlashSchedule,
+    *,
+    source: str,
+    target: str,
+    barrier: str | None = None,
+    arrival_count: int | None = None,
+    scope: FlashSyncScope | None = None,
+    multicast: bool | None = None,
+) -> FlashSchedule:
+    matches = [
+        index
+        for index, edge in enumerate(schedule.edges)
+        if edge.source == source
+        and edge.target == target
+        and (barrier is None or edge.barrier == barrier)
+    ]
+    assert len(matches) == 1
+    edges = list(schedule.edges)
+    edge = edges[matches[0]]
+    edges[matches[0]] = dataclasses.replace(
+        edge,
+        arrival_count=edge.arrival_count if arrival_count is None else arrival_count,
+        scope=edge.scope if scope is None else scope,
+        multicast=edge.multicast if multicast is None else multicast,
+    )
+    return dataclasses.replace(schedule, edges=tuple(edges))
+
+
+def _replace_region_alias(
+    schedule: FlashSchedule,
+    name: str,
+    alias_group: str | None,
+) -> FlashSchedule:
+    matches = [
+        index
+        for index, region in enumerate(schedule.memory_regions)
+        if region.name == name
+    ]
+    assert len(matches) == 1
+    regions = list(schedule.memory_regions)
+    regions[matches[0]] = dataclasses.replace(
+        regions[matches[0]], alias_group=alias_group
+    )
+    return dataclasses.replace(schedule, memory_regions=tuple(regions))
+
+
+@pytest.mark.parametrize(
+    ("head_dim", "kv_depth", "shared_memory_bytes", "tmem_columns"),
+    (
+        (64, 2, 101376, 384),
+        (128, 3, 232448, 512),
+    ),
+)
+def test_canonical_fa4_resources(
+    head_dim: int,
+    kv_depth: int,
+    shared_memory_bytes: int,
+    tmem_columns: int,
+) -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(head_dim, kv_depth))
+
+    verified = verify_flash_schedule(schedule)
+
+    assert verified.schedule is schedule
+    assert schedule.shared_memory_bytes == shared_memory_bytes
+    assert schedule.tmem_columns == tmem_columns
+
+
+@pytest.mark.parametrize(
+    ("kv_depth", "shared_memory_bytes"),
+    (
+        (2, 134144),
+        (3, 166912),
+        (4, 199680),
+    ),
+)
+def test_separate_kv_depth_resources(
+    kv_depth: int,
+    shared_memory_bytes: int,
+) -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, kv_depth, separate_kv=True))
+
+    verify_flash_schedule(schedule)
+
+    assert schedule.shared_memory_bytes == shared_memory_bytes
+
+
+def test_separate_kv_capacity_failure() -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 6, separate_kv=True))
+
+    with pytest.raises(FlashScheduleError, match="shared-memory capacity"):
+        verify_flash_schedule(schedule)
+
+
+def test_two_cta_memory_is_rank_local_and_output_is_interleaved() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            cta_count=2,
+            multicast_kv=True,
+            cooperative_mma=True,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    regions = {region.name: region for region in schedule.memory_regions}
+    assert regions["Q_r0_q0"].offset == regions["Q_r1_q0"].offset
+    assert regions["Q_r0_q0"].cta_rank == 0
+    assert regions["Q_r1_q0"].cta_rank == 1
+    assert {
+        (owner.cta_rank, owner.query_slot): owner.output_tile
+        for owner in schedule.output_owners
+    } == {
+        (0, 0): 0,
+        (1, 0): 1,
+        (0, 1): 2,
+        (1, 1): 3,
+    }
+    barriers = {barrier.name: barrier for barrier in schedule.barriers}
+    for rank in range(2):
+        assert barriers[f"k_reuse_r{rank}"].expected_arrivals == 1
+        assert barriers[f"v_reuse_r{rank}"].expected_arrivals == 1
+        assert {
+            edge.source for edge in schedule.edges if edge.barrier == f"k_reuse_r{rank}"
+        } == {"qk_r0_q1"}
+        assert {
+            edge.source for edge in schedule.edges if edge.barrier == f"v_reuse_r{rank}"
+        } == {"pv_r0_q1"}
+    assert barriers["pfor_q0"].scope is FlashSyncScope.CLUSTER_LEADER
+
+
+def test_independent_cga_output_is_cta_contiguous() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            cta_count=2,
+            multicast_kv=True,
+            output_order=FlashOutputOrder.CTA_CONTIGUOUS,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    assert {
+        (owner.cta_rank, owner.query_slot): owner.output_tile
+        for owner in schedule.output_owners
+    } == {
+        (0, 0): 0,
+        (0, 1): 1,
+        (1, 0): 2,
+        (1, 1): 3,
+    }
+    barriers = {barrier.name: barrier for barrier in schedule.barriers}
+    for rank in range(2):
+        for slot in range(2):
+            assert barriers[f"pfor_r{rank}_q{slot}"].expected_arrivals == 256
+            assert barriers[f"pfor_r{rank}_q{slot}"].scope is FlashSyncScope.CTA
+            assert barriers[f"pfor2_r{rank}_q{slot}"].expected_arrivals == 128
+            assert barriers[f"pfor2_r{rank}_q{slot}"].scope is FlashSyncScope.CTA
+
+
+def test_multicast_reuse_waits_for_both_ctas() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(64, 2, cta_count=2, multicast_kv=True)
+    )
+
+    verify_flash_schedule(schedule)
+
+    barriers = {barrier.name: barrier for barrier in schedule.barriers}
+    for rank in range(2):
+        for operand, consumer in (("k", "qk"), ("v", "pv")):
+            barrier = f"{operand}_reuse_r{rank}"
+            assert barriers[barrier].expected_arrivals == 2
+            assert {
+                edge.source for edge in schedule.edges if edge.barrier == barrier
+            } == {f"{consumer}_r0_q1", f"{consumer}_r1_q1"}
+
+
+def test_missing_cross_cta_reuse_release_is_rejected() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(64, 2, cta_count=2, multicast_kv=True)
+    )
+    schedule = dataclasses.replace(
+        schedule,
+        edges=tuple(
+            edge
+            for edge in schedule.edges
+            if not (edge.source == "qk_r1_q1" and edge.barrier == "k_reuse_r0")
+        ),
+    )
+
+    with pytest.raises(
+        FlashScheduleError,
+        match="barrier k_reuse_r0 expected 2 arrivals, got 1",
+    ):
+        verify_flash_schedule(schedule)
+
+
+def test_duplicate_same_cta_reuse_release_is_rejected() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(64, 2, cta_count=2, multicast_kv=True)
+    )
+    schedule = dataclasses.replace(
+        schedule,
+        edges=tuple(
+            dataclasses.replace(edge, source="qk_r0_q1")
+            if edge.source == "qk_r1_q1" and edge.barrier == "k_reuse_r0"
+            else edge
+            for edge in schedule.edges
+        ),
+    )
+
+    with pytest.raises(
+        FlashScheduleError,
+        match="multicast K/V reuse has the wrong consumer releases",
+    ):
+        verify_flash_schedule(schedule)
+
+
+def test_local_reuse_barriers_remain_single_arrival() -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 2, separate_kv=True))
+
+    verify_flash_schedule(schedule)
+
+    barriers = {barrier.name: barrier for barrier in schedule.barriers}
+    assert barriers["k_reuse_r0"].expected_arrivals == 1
+    assert barriers["v_reuse_r0"].expected_arrivals == 1
+
+
+def test_aliased_kv_is_one_physical_ring_without_independent_depths() -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 3))
+
+    verify_flash_schedule(schedule)
+
+    regions = {region.name: region for region in schedule.memory_regions}
+    k_region = regions["K_r0"]
+    v_region = regions["V_r0"]
+    assert k_region.physical
+    assert not v_region.physical
+    assert k_region.offset == v_region.offset
+    assert k_region.extent == v_region.extent == 3 * 128 * 64 * 2
+    assert k_region.alias_group == v_region.alias_group == "shared_kv_ring_r0"
+    assert k_region.reuse_distance is None
+    assert v_region.reuse_distance is None
+
+
+def test_aliased_kv_cannot_claim_independent_v_storage() -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 2))
+    regions = tuple(
+        dataclasses.replace(region, physical=True) if region.name == "V_r0" else region
+        for region in schedule.memory_regions
+    )
+    schedule = dataclasses.replace(schedule, memory_regions=regions)
+
+    with pytest.raises(
+        FlashScheduleError,
+        match="aliased K/V must use one physical shared ring",
+    ):
+        verify_flash_schedule(schedule)
+
+
+def test_barrier_arrival_count_corruption_is_rejected() -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 2))
+    schedule = _replace_edge(
+        schedule,
+        source="softmax_r0_q0",
+        target="pv_r0_q0",
+        barrier="pfor_q0",
+        arrival_count=127,
+    )
+
+    with pytest.raises(FlashScheduleError, match="pfor_q0 expected 256"):
+        verify_flash_schedule(schedule)
+
+
+def test_unsplit_probability_publication_has_no_pfor2_dependency() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(64, 2, separate_kv=True, split_p_arrive=False)
+    )
+
+    verify_flash_schedule(schedule)
+
+    assert all(not barrier.name.startswith("pfor2") for barrier in schedule.barriers)
+    assert all(
+        edge.barrier is None or not edge.barrier.startswith("pfor2")
+        for edge in schedule.edges
+    )
+
+
+def test_barrier_scope_corruption_is_rejected() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            cta_count=2,
+            multicast_kv=True,
+            cooperative_mma=True,
+        )
+    )
+    schedule = _replace_edge(
+        schedule,
+        source="correction_r0_q0",
+        target="pv_r0_q0",
+        scope=FlashSyncScope.CTA,
+    )
+
+    with pytest.raises(FlashScheduleError, match="barrier scope mismatch for pfor_q0"):
+        verify_flash_schedule(schedule)
+
+
+def test_missing_k_reuse_edge_is_rejected() -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 2, separate_kv=True))
+    schedule = dataclasses.replace(
+        schedule,
+        edges=tuple(edge for edge in schedule.edges if edge.barrier != "k_reuse_r0"),
+        barriers=tuple(
+            barrier for barrier in schedule.barriers if barrier.name != "k_reuse_r0"
+        ),
+    )
+
+    with pytest.raises(FlashScheduleError, match="K_r0 is reused before all consumers"):
+        verify_flash_schedule(schedule)
+
+
+def test_score_probability_alias_corruption_is_rejected() -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 2))
+    schedule = _replace_region_alias(schedule, "P_r0_q0", "wrong_alias")
+
+    with pytest.raises(
+        FlashScheduleError, match="S_r0_q0 and P_r0_q0 overlap illegally"
+    ):
+        verify_flash_schedule(schedule)
+
+
+def test_causal_multicast_does_not_invent_a_private_diagonal_path() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            cta_count=2,
+            causal=True,
+            multicast_kv=True,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    assert not _region_names(schedule, prefix="causal_diagonal_")
+    assert not {
+        node.name for node in schedule.nodes if node.name.startswith("diagonal_")
+    }
+
+
+def test_explicit_causal_tail_requires_private_diagonal_path() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            cta_count=2,
+            causal=True,
+            multicast_kv=True,
+            private_causal_tail=True,
+        )
+    )
+    region_name = "causal_diagonal_K_r0"
+    writer = "diagonal_k_load_r0"
+    schedule = dataclasses.replace(
+        schedule,
+        edges=tuple(
+            edge
+            for edge in schedule.edges
+            if not (edge.resource == region_name and edge.source == writer)
+        ),
+        memory_regions=tuple(
+            region for region in schedule.memory_regions if region.name != region_name
+        ),
+    )
+
+    with pytest.raises(FlashScheduleError, match="private diagonal path"):
+        verify_flash_schedule(schedule)
+
+
+def test_causal_private_diagonal_cannot_be_multicast() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            cta_count=2,
+            causal=True,
+            multicast_kv=True,
+            private_causal_tail=True,
+        )
+    )
+    schedule = _replace_edge(
+        schedule,
+        source="diagonal_k_load_r0",
+        target="qk_r0_q0",
+        multicast=True,
+    )
+
+    with pytest.raises(
+        FlashScheduleError, match="CTA-private data cannot be multicast"
+    ):
+        verify_flash_schedule(schedule)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    (
+        FlashScheduleSpec(64, 2, private_causal_tail=True),
+        FlashScheduleSpec(
+            64,
+            2,
+            cta_count=2,
+            multicast_kv=True,
+            private_causal_tail=True,
+        ),
+    ),
+)
+def test_private_causal_tail_requires_causal_multicast(
+    spec: FlashScheduleSpec,
+) -> None:
+    with pytest.raises(
+        FlashScheduleError,
+        match="private causal tail requires causal K/V multicast",
+    ):
+        build_fa4_schedule(spec)
+
+
+@pytest.mark.parametrize(
+    ("kv_iterations", "middle_phase"),
+    (
+        (4, 0),
+        (3, 1),
+    ),
+)
+def test_persistent_phase_continuity_at_work_boundary(
+    kv_iterations: int,
+    middle_phase: int,
+) -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            persistent=True,
+            kv_iterations=kv_iterations,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    cycles = {cycle.barrier: cycle for cycle in schedule.phase_cycles}
+    assert cycles["s_full_r0_q0"].uses_per_work == kv_iterations
+    assert cycles["s_full_r0_q0"].phases == (0, middle_phase, 0)
+    assert cycles["pfor_q0"].phases == (0, middle_phase, 0)
+
+
+def test_persistent_phase_corruption_is_rejected() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(64, 2, persistent=True, kv_iterations=3)
+    )
+    cycles = list(schedule.phase_cycles)
+    index = next(
+        index for index, cycle in enumerate(cycles) if cycle.barrier == "s_full_r0_q0"
+    )
+    cycles[index] = dataclasses.replace(cycles[index], phases=(0, 0, 0))
+    schedule = dataclasses.replace(schedule, phase_cycles=tuple(cycles))
+
+    with pytest.raises(FlashScheduleError, match="phase is discontinuous"):
+        verify_flash_schedule(schedule)
+
+
+@pytest.mark.parametrize("mode", ("duplicate", "missing"))
+def test_output_ownership_corruption_is_rejected(mode: str) -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 2))
+    if mode == "duplicate":
+        owners = (*schedule.output_owners, schedule.output_owners[0])
+        error = "multiple owners"
+    else:
+        owners = schedule.output_owners[:-1]
+        error = "ownership is incomplete"
+    schedule = dataclasses.replace(schedule, output_owners=owners)
+
+    with pytest.raises(FlashScheduleError, match=error):
+        verify_flash_schedule(schedule)
+
+
+def test_zero_delta_cycle_is_rejected() -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 2))
+    schedule = dataclasses.replace(
+        schedule,
+        edges=(
+            *schedule.edges,
+            FlashEdge("output_store_r0_q0", "q_load_r0_q0"),
+        ),
+    )
+
+    with pytest.raises(
+        FlashScheduleError, match="same-iteration schedule contains a cycle"
+    ):
+        verify_flash_schedule(schedule)
+
+
+def test_direct_and_staged_output_resources() -> None:
+    staged = build_fa4_schedule(FlashScheduleSpec(64, 2, stage_output=True))
+    direct = build_fa4_schedule(FlashScheduleSpec(64, 2, stage_output=False))
+
+    verify_flash_schedule(staged)
+    verify_flash_schedule(direct)
+
+    assert staged.shared_memory_bytes == 101376
+    assert direct.shared_memory_bytes == 68608
+    assert staged.shared_memory_bytes - direct.shared_memory_bytes == 32768
+    assert _region_names(staged, prefix="O_stage_") == {
+        "O_stage_r0_q0",
+        "O_stage_r0_q1",
+    }
+    assert not _region_names(direct, prefix="O_stage_")
+
+
+def _region_names(schedule: FlashSchedule, *, prefix: str) -> set[str]:
+    return {
+        region.name
+        for region in schedule.memory_regions
+        if region.name.startswith(prefix)
+    }


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3232
 * __->__#3231
 * #3230
 * #3229


--- --- ---

[cutedsl] Model and validate CuTe flash schedules

Introduce explicit causal-range and flash-schedule models, validate synchronization and resource invariants, and use the validated plan in CuTe code generation. Add backend-local runtime improvements and schedule-focused correctness tests without changing the automatic seed policy.