### PR TITLE
[cutedsl] Seed flash autotuning across legal families

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -90,6 +90,7 @@ def compiler_seed_configs(
     configs: list[Config] = []
     env.config_spec.autotuner_heuristics = []
     env.config_spec.compiler_default_config = None
+    env.config_spec.compiler_seed_timeout_retry_repetitions = None
     if env.settings.disable_autotuner_heuristics:
         return configs
 

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -737,7 +737,7 @@ class CuteFlashAttentionHeuristic(AutotunerHeuristic):
         from ..cute.cute_flash import flash_attention_seed_config
 
         assert spec._cute_flash_head_dim is not None
-        return flash_attention_seed_config(
+        seed = flash_attention_seed_config(
             spec._cute_flash_head_dim,
             spec._cute_flash_num_kv,
             dtype=spec._cute_flash_dtype,
@@ -747,6 +747,12 @@ class CuteFlashAttentionHeuristic(AutotunerHeuristic):
             small_biased_candidate=spec._cute_flash_small_biased_candidate,
             block_size_targets=spec._cute_flash_block_size_target_list(),
         )
+        if seed is not None:
+            # A fresh worker retry uses one setup launch plus three timed
+            # launches. The median is robust while using half the launches of
+            # the normal path that timed out.
+            spec.compiler_seed_timeout_retry_repetitions = 3
+        return seed
 
 
 class CuteFlashAttentionCausalLptHeuristic(AutotunerHeuristic):

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -68,6 +68,7 @@ class FlashSearchSurface(NamedTuple):
     requires_ws_overlap: bool
     small_biased_candidate: bool
     standard_dense_output: bool
+    standard_causal_output: bool
 
 
 class AttentionSoftmaxPattern(NamedTuple):
@@ -2792,6 +2793,9 @@ def detect_flash_search_surface(device_ir: DeviceIR) -> FlashSearchSurface | Non
             flash_attention_graph_small_biased_candidate_from_graphs,
         )
         from .cute.cute_flash import (
+            flash_attention_graph_standard_causal_output_from_graphs,
+        )
+        from .cute.cute_flash import (
             flash_attention_graph_standard_dense_output_from_graphs,
         )
 
@@ -2815,6 +2819,14 @@ def detect_flash_search_surface(device_ir: DeviceIR) -> FlashSearchSurface | Non
             root_block_ids=root_grid_ids,
             kv_block_id=block_ids[0],
             score_plan=pattern.score_plan,
+        )
+        standard_causal_output = (
+            flash_attention_graph_standard_causal_output_from_graphs(
+                device_ir.graphs,
+                root_block_ids=root_grid_ids,
+                kv_block_id=block_ids[0],
+                score_plan=pattern.score_plan,
+            )
         )
         q_seq = env.block_sizes[root_grid_ids[1]].size
         kv_seq = env.block_sizes[block_ids[0]].size
@@ -2855,6 +2867,7 @@ def detect_flash_search_surface(device_ir: DeviceIR) -> FlashSearchSurface | Non
             requires_ws_overlap=pattern.score_plan.requires_ws_overlap,
             small_biased_candidate=small_biased_candidate,
             standard_dense_output=standard_dense_output,
+            standard_causal_output=standard_causal_output,
         )
     return None
 

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -822,28 +822,50 @@ def flash_attention_graph_standard_dense_output_from_graphs(
     kv_block_id: int | None = None,
     score_plan: AttentionScorePlan,
 ) -> bool:
-    """Detector-time mirror of the codegen ``standard_dense_output`` gate.
-
-    ``resolve_flash_config`` uses this flag to decide whether the manual
-    degree-1 exp2 packets are selectable, so config normalization has to reach
-    the same answer as codegen or it would project a requested ``deg1_*`` packet
-    back onto the generic default.
-    """
+    """Return whether the graph has canonical dense output-only semantics."""
     graph_plan = _flash_graph_output_plan_from_graphs(
         graphs,
         root_block_ids=root_block_ids,
         kv_block_id=kv_block_id,
         score_plan=score_plan,
     )
-    if graph_plan is None:
-        return False
-    return (
-        not score_plan.is_causal
+    return bool(
+        graph_plan is not None
         and graph_plan.lse_name is None
         and not graph_plan.bias_names
         and not graph_plan.alibi_names
         and not graph_plan.document_names
         and _standard_dense_score_plan_supported(score_plan)
+    )
+
+
+def flash_attention_graph_standard_causal_output_from_graphs(
+    graphs: Iterable[GraphInfo],
+    *,
+    root_block_ids: Sequence[int] | None = None,
+    kv_block_id: int | None = None,
+    score_plan: AttentionScorePlan,
+) -> bool:
+    """Return whether the graph has canonical causal output-only semantics."""
+    graph_plan = _flash_graph_output_plan_from_graphs(
+        graphs,
+        root_block_ids=root_block_ids,
+        kv_block_id=kv_block_id,
+        score_plan=score_plan,
+    )
+    return bool(
+        graph_plan is not None
+        and graph_plan.lse_name is None
+        and not graph_plan.bias_names
+        and not graph_plan.alibi_names
+        and not graph_plan.document_names
+        and score_plan.modifier_kinds == (CAUSAL_MASK_KIND,)
+        and math.isclose(
+            score_plan.qk_scale_log2,
+            math.log2(math.e) / math.sqrt(score_plan.head_dim),
+            rel_tol=1e-8,
+            abs_tol=1e-8,
+        )
     )
 
 
@@ -1143,7 +1165,7 @@ class FlashAttentionConfig:
     precompute_qk_desc: bool = False
     # Initial TMA prologue order for the FA4 load warp. 0 preserves Helion's
     # original Q0/K/Q1/V order; 4 keeps the measured K/Q0/Q1/V variant for
-    # long-shape seeds. The remaining values are manual/autotune experiments.
+    # long-shape seeds. The remaining values are available as manual overrides.
     first_load_order: int = 0
     # KV traversal order for FA4. Upstream FA4 walks dense non-causal KV blocks
     # from the end toward the beginning; Helion's original path was ascending.
@@ -1191,7 +1213,7 @@ class FlashAttentionConfig:
     skip_rescale_stats: bool = False
     # TMEM O-rescale chunk width. hd64 defaults to 32 cols because 64 cols pushes
     # some FA4 attention shapes over the ptxas register target, but manual
-    # experiments can opt into 64 cols to test reduced loop/address overhead.
+    # Manual configurations can opt into 64 columns.
     rescale_chunk_cols: int = 0
     # FA4 setmaxregister budgets for softmax and correction warpgroups. Softmax
     # regs are part of the characterized autotune surface; correction regs stay
@@ -1281,6 +1303,7 @@ def _flash_causal_hd64_seed_num_kv_supported(num_kv: int | None) -> bool:
 
 
 _FLASH_CAUSAL_HD64_LONG_AUTOTUNE_MIN_KV = 4096
+_FLASH_CAUSAL_HD64_HYBRID_SEED_MIN_KV = 512
 
 
 def _flash_causal_hd64_seed_params(num_kv: int) -> tuple[int, int, int, int]:
@@ -1395,6 +1418,11 @@ _FLASH_DEG1_EXP2_PACKETS = frozenset(
 )
 _FLASH_DEG1_EXP2_OFFSET = 0
 _FLASH_DEG1_EXP2_OFFSET0 = 10
+# Dense hd64 two-CTA uses fixed per-CTA resources, so sequence length does not
+# impose an upper bound.  The degree-1 packets require at least this many
+# aligned KV tiles to stay within their validated numerical envelope.
+_FLASH_DENSE_HD64_2CTA_MIN_KV = 256
+_FLASH_DENSE_DEG1_LONG_PACKET_MIN_KV = 2048
 _FLASH_MANUAL_EXP2_PACKET_PARAMS: dict[str, tuple[int, int]] = {
     _FLASH_DEG2_EXP2_PACKET: (8, 3),
     _FLASH_HYBRID_EXP2_PACKET: (8, 4),
@@ -1407,6 +1435,11 @@ _FLASH_MANUAL_EXP2_PACKET_SCHEDULES: dict[str, tuple[int, int]] = {
     _FLASH_DEG1_EXP2_PACKET: (16, 8),
     _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET: (8, 2),
 }
+
+
+def _flash_dense_hd64_2cta_num_kv_supported(num_kv: int) -> bool:
+    """Return whether ``num_kv`` is in the aligned dense hd64 2CTA envelope."""
+    return num_kv >= _FLASH_DENSE_HD64_2CTA_MIN_KV and num_kv % 4 == 0
 
 
 class _FlashDiscExp2CodegenParams(NamedTuple):
@@ -2330,8 +2363,7 @@ def resolve_flash_config(
     )
     if separate_kv_rings:
         # The one-CTA family isolates K/V depth. The causal cluster family may
-        # compose the already-validated TMA epilogue after its no-epilogue
-        # attribution run.
+        # compose the already-validated TMA epilogue.
         use_2cta_instrs = causal_two_cta
         use_cga2_local_cta = False
         use_clc_scheduler = False
@@ -2348,11 +2380,11 @@ def resolve_flash_config(
             epi_stg_gmem = "stage"
         kv_stage = min(max(kv_stage, 2), _flash_deep_1cta_kv_stage_cap(head_dim))
     dense_degree1_packet = (
-        _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
-        if 256 <= num_kv < 2048
+        None
+        if not _flash_dense_hd64_2cta_num_kv_supported(num_kv)
+        else _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
+        if num_kv < _FLASH_DENSE_DEG1_LONG_PACKET_MIN_KV
         else _FLASH_DEG1_EXP2_PACKET
-        if num_kv == 2048
-        else None
     )
     dense_degree1_eligible = (
         standard_dense_output
@@ -2579,7 +2611,7 @@ def resolve_flash_config(
 
 
 # ---------------------------------------------------------------------------
-# Autotune surface for the flash-attention config (Tasks #25 + #28).
+# Autotune surface for the flash-attention config.
 #
 # Mirrors the ``Tcgen05WarpSpec`` pattern in ``strategies.py`` /
 # ``tcgen05_config.py``. Independent arithmetic fields retain individual keys;
@@ -2784,11 +2816,6 @@ _FLASH_DENSE_HD64_MID_MIN_KV = 16
 _FLASH_DENSE_HD64_LONG_MIN_KV = 64
 _FLASH_DENSE_HD64_VERY_LONG_MIN_KV = 256
 _FLASH_RESCALE_THRESHOLD_VALUES = (0.0, 4.0, 8.0, 12.0, 16.0, 32.0)
-
-
-def _flash_dense_hd64_2cta_num_kv_supported(num_kv: int) -> bool:
-    """Return whether dense hd64 two-CTA supports the bounded long-sequence range."""
-    return 256 <= num_kv <= 2048 and num_kv % 4 == 0
 
 
 def _flash_safe_rescale_threshold_values(dtype: torch.dtype) -> tuple[float, ...]:
@@ -3043,7 +3070,7 @@ def flash_attention_value_prior_weights(
         }
         if pipeline_family != "fa4":
             pipeline_family_priors["fa4"] = 1.0
-        if num_kv in (512, 2048) and dtype is torch.float16:
+        if _flash_dense_hd64_2cta_num_kv_supported(num_kv) and dtype is torch.float16:
             pipeline_family_priors["fa4_2cta"] = 4.0
         very_long_dense_hd64_fa4 = num_kv >= _FLASH_DENSE_HD64_VERY_LONG_MIN_KV
         priors = cast(
@@ -3334,6 +3361,7 @@ def _flash_seed_fragments(
     has_kv_tile_pruning: bool,
     requires_ws_overlap: bool,
     small_biased_candidate: bool,
+    standard_dense_output: bool = False,
     topology_override: str | None,
 ) -> dict[str, ConfigSpecFragment]:
     return flash_autotune_fragments(
@@ -3344,6 +3372,7 @@ def _flash_seed_fragments(
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
         small_biased_candidate=small_biased_candidate,
+        standard_dense_output=standard_dense_output,
         topology_override=topology_override,
     )
 
@@ -3479,6 +3508,66 @@ def _flash_default_seed_config(
     return Config.from_dict(seed)
 
 
+def _flash_dense_degree1_seed_config(
+    head_dim: int,
+    num_kv: int,
+    *,
+    dtype: torch.dtype,
+    is_causal: bool,
+    has_kv_tile_pruning: bool,
+    requires_ws_overlap: bool,
+    small_biased_candidate: bool,
+    standard_dense_output: bool,
+    block_size_targets: Sequence[int],
+) -> Config | None:
+    """Return a general dense degree-1 seed from ``fa4_2cta`` defaults."""
+    if (
+        not standard_dense_output
+        or is_causal
+        or dtype is not torch.float16
+        or head_dim != 64
+        or has_kv_tile_pruning
+        or requires_ws_overlap
+        or small_biased_candidate
+        or not _flash_dense_hd64_2cta_num_kv_supported(num_kv)
+    ):
+        return None
+    block_sizes = _flash_seed_block_sizes(block_size_targets)
+    if block_sizes is None:
+        return None
+
+    fragments = flash_autotune_fragments(
+        head_dim,
+        num_kv,
+        dtype=dtype,
+        is_causal=is_causal,
+        has_kv_tile_pruning=has_kv_tile_pruning,
+        requires_ws_overlap=requires_ws_overlap,
+        small_biased_candidate=small_biased_candidate,
+        standard_dense_output=standard_dense_output,
+        pipeline_family_override="fa4_2cta",
+    )
+    values = {key: fragment.default() for key, fragment in fragments.items()}
+    packet_values: dict[str, object]
+    if num_kv < _FLASH_DENSE_DEG1_LONG_PACKET_MIN_KV:
+        packet_values = {
+            FLASH_EXP2_PACKET_KEY: _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET,
+            FLASH_E2E_SCHEDULE_KEY: "8/2",
+        }
+    else:
+        packet_values = {
+            FLASH_EXP2_PACKET_KEY: _FLASH_DEG1_EXP2_PACKET,
+            FLASH_E2E_SCHEDULE_KEY: "16/8",
+            FLASH_E2E_OFFSET_KEY: _FLASH_DEG1_EXP2_OFFSET,
+            FLASH_E2E_OFFSET0_KEY: _FLASH_DEG1_EXP2_OFFSET0,
+            FLASH_KV_STAGE_KEY: 2,
+        }
+    packet_values[FLASH_PIPELINE_FAMILY_KEY] = "fa4_2cta"
+    if not _flash_seed_set_all(values, fragments, packet_values):
+        return None
+    return Config.from_dict({"block_sizes": block_sizes, **values})
+
+
 def _flash_dense_sp_seed_config(
     head_dim: int,
     num_kv: int,
@@ -3490,7 +3579,7 @@ def _flash_dense_sp_seed_config(
     small_biased_candidate: bool,
     block_size_targets: Sequence[int],
 ) -> Config | None:
-    # This is a manual experiment seed for the resident softmax variant. It is
+    # This is an explicit seed for the resident softmax variant. It is
     # intentionally not emitted by flash_attention_seed_configs() until that
     # family is faster and stable enough for automatic autotune exploration.
     if (
@@ -3672,6 +3761,7 @@ def _flash_causal_split_seed_config(
         softmax_regs,
         lpt_swizzle,
     ) = _flash_causal_hd64_seed_params(num_kv)
+    use_long_causal_schedule = num_kv >= 512
     split_masked_schedule = "16/4"
     split_lpt_swizzle = 8 if num_kv <= 128 else lpt_swizzle
     split_disc_pipe = 2 if num_kv <= 128 else 4
@@ -3699,6 +3789,97 @@ def _flash_causal_split_seed_config(
         FLASH_CAUSAL_LPT_SWIZZLE_KEY: split_lpt_swizzle,
         FLASH_CAUSAL_KV_ORDER_KEY: _flash_causal_hd64_seed_kv_order(num_kv),
         FLASH_SOFTMAX_REGS_KEY: softmax_regs,
+    }
+    if use_long_causal_schedule:
+        family_values.update(
+            {
+                FLASH_E2E_SCHEDULE_KEY: "16/4",
+                FLASH_MASKED_E2E_SCHEDULE_KEY: "8/2",
+                FLASH_E2E_OFFSET_KEY: 0,
+                FLASH_E2E_OFFSET0_KEY: 14,
+                FLASH_DISC_PIPE_KEY: 3,
+                FLASH_EXP2_PACKET_KEY: "4x1",
+                FLASH_WAIT_HINT_KEY: 0,
+                FLASH_EPI_TMA_KEY: False,
+                FLASH_EPI_STG_KEY: True,
+                FLASH_EPI_STG_GMEM_KEY: "pair",
+                FLASH_RESCALE_CHUNK_COLS_KEY: 16,
+                FLASH_ROLE_MAP_KEY: "fa4",
+            }
+        )
+    if not _flash_seed_set_all(seed, fragments, family_values):
+        return None
+    return Config.from_dict(seed)
+
+
+def _flash_causal_hybrid_seed_config(
+    head_dim: int,
+    num_kv: int,
+    *,
+    dtype: torch.dtype,
+    is_causal: bool,
+    has_kv_tile_pruning: bool,
+    requires_ws_overlap: bool,
+    small_biased_candidate: bool,
+    standard_causal_output: bool,
+    block_size_targets: Sequence[int],
+) -> Config | None:
+    """Return the long-causal hybrid-exp2 compiler seed.
+
+    The hybrid packet uses degree 1 only in the unmasked suffix; diagonal tiles
+    retain degree 2. It remains a compiler seed because manual packet modes are
+    accepted by the fragments but excluded from random search.
+    """
+    if (
+        not is_causal
+        or head_dim != 64
+        or dtype is not torch.float16
+        or has_kv_tile_pruning
+        or requires_ws_overlap
+        or small_biased_candidate
+        or not standard_causal_output
+        or num_kv < _FLASH_CAUSAL_HD64_HYBRID_SEED_MIN_KV
+        or not _flash_causal_hd64_seed_num_kv_supported(num_kv)
+    ):
+        return None
+    block_sizes = _flash_seed_block_sizes(block_size_targets)
+    if block_sizes is None:
+        return None
+
+    fragments = _flash_seed_fragments(
+        head_dim,
+        num_kv,
+        dtype=dtype,
+        is_causal=is_causal,
+        has_kv_tile_pruning=has_kv_tile_pruning,
+        requires_ws_overlap=requires_ws_overlap,
+        small_biased_candidate=small_biased_candidate,
+        topology_override="fa4",
+    )
+    seed: dict[str, object] = {"block_sizes": block_sizes}
+    family_values: dict[str, object] = {
+        FLASH_PIPELINE_FAMILY_KEY: "fa4",
+        FLASH_S_STAGE_KEY: 2,
+        FLASH_KV_STAGE_KEY: 2,
+        FLASH_PERSISTENT_KEY: False,
+        FLASH_E2E_SCHEDULE_KEY: "16/8",
+        FLASH_MASKED_E2E_SCHEDULE_KEY: "16/8",
+        FLASH_E2E_OFFSET_KEY: 0,
+        FLASH_E2E_OFFSET0_KEY: 10,
+        FLASH_DISC_PIPE_KEY: 3,
+        FLASH_EXP2_PACKET_KEY: _FLASH_HYBRID_EXP2_PACKET,
+        FLASH_WAIT_HINT_KEY: 10_000_000,
+        FLASH_EPI_TMA_KEY: False,
+        FLASH_EPI_STG_KEY: False,
+        FLASH_EPI_STG_GMEM_KEY: "stage",
+        FLASH_RESCALE_CHUNK_COLS_KEY: 16,
+        FLASH_ROLE_MAP_KEY: "helion",
+        FLASH_CAUSAL_LOOP_SPLIT_KEY: True,
+        FLASH_RESCALE_THRESHOLD_KEY: 8.0,
+        FLASH_PACKED_REDUCE_KEY: True,
+        FLASH_CAUSAL_LPT_SWIZZLE_KEY: 0,
+        FLASH_CAUSAL_KV_ORDER_KEY: "descending",
+        FLASH_SOFTMAX_REGS_KEY: _flash_causal_hd64_seed_params(num_kv)[2],
     }
     if not _flash_seed_set_all(seed, fragments, family_values):
         return None
@@ -3772,6 +3953,62 @@ def flash_attention_seed_config(
     raise AssertionError(f"unknown flash attention seed kind: {seed_kind!r}")
 
 
+def _flash_canonical_family_seed_configs(
+    head_dim: int,
+    num_kv: int | None,
+    *,
+    dtype: torch.dtype,
+    is_causal: bool,
+    has_kv_tile_pruning: bool,
+    requires_ws_overlap: bool,
+    small_biased_candidate: bool,
+    standard_dense_output: bool,
+    block_size_targets: Sequence[int],
+) -> tuple[Config, ...]:
+    """Return one dependency-consistent seed per legal pipeline family."""
+    if num_kv is None:
+        return ()
+    block_sizes = _flash_seed_block_sizes(block_size_targets)
+    if block_sizes is None:
+        return ()
+
+    fragments = flash_autotune_fragments(
+        head_dim,
+        num_kv,
+        dtype=dtype,
+        is_causal=is_causal,
+        has_kv_tile_pruning=has_kv_tile_pruning,
+        requires_ws_overlap=requires_ws_overlap,
+        small_biased_candidate=small_biased_candidate,
+        standard_dense_output=standard_dense_output,
+    )
+    family_fragment = fragments[FLASH_PIPELINE_FAMILY_KEY]
+    assert isinstance(family_fragment, EnumFragment)
+    families = (
+        family_fragment.choices
+        if family_fragment.search_choices is None
+        else family_fragment.search_choices
+    )
+    seeds: list[Config] = []
+    for family in families:
+        assert isinstance(family, str)
+        family_fragments = flash_autotune_fragments(
+            head_dim,
+            num_kv,
+            dtype=dtype,
+            is_causal=is_causal,
+            has_kv_tile_pruning=has_kv_tile_pruning,
+            requires_ws_overlap=requires_ws_overlap,
+            small_biased_candidate=small_biased_candidate,
+            standard_dense_output=standard_dense_output,
+            pipeline_family_override=family,
+        )
+        values = {key: fragment.default() for key, fragment in family_fragments.items()}
+        values[FLASH_PIPELINE_FAMILY_KEY] = family
+        seeds.append(Config.from_dict({"block_sizes": block_sizes, **values}))
+    return tuple(seeds)
+
+
 def flash_attention_seed_configs(
     head_dim: int,
     num_kv: int | None,
@@ -3781,6 +4018,8 @@ def flash_attention_seed_configs(
     has_kv_tile_pruning: bool = False,
     requires_ws_overlap: bool = False,
     small_biased_candidate: bool = False,
+    standard_dense_output: bool = False,
+    standard_causal_output: bool = False,
     block_size_targets: Sequence[int] = _FLASH_SEED_BLOCK_SIZE_TARGETS,
 ) -> tuple[Config, ...]:
     seeds: list[Config] = []
@@ -3796,6 +4035,20 @@ def flash_attention_seed_configs(
     )
     if default_seed is not None:
         seeds.append(default_seed)
+    if num_kv is not None:
+        dense_degree1_seed = _flash_dense_degree1_seed_config(
+            head_dim,
+            num_kv,
+            dtype=dtype,
+            is_causal=is_causal,
+            has_kv_tile_pruning=has_kv_tile_pruning,
+            requires_ws_overlap=requires_ws_overlap,
+            small_biased_candidate=small_biased_candidate,
+            standard_dense_output=standard_dense_output,
+            block_size_targets=block_size_targets,
+        )
+        if dense_degree1_seed is not None:
+            seeds.append(dense_degree1_seed)
     causal_lpt_seed = flash_attention_seed_config(
         head_dim,
         num_kv,
@@ -3822,6 +4075,33 @@ def flash_attention_seed_configs(
     )
     if causal_split_seed is not None:
         seeds.append(causal_split_seed)
+    if num_kv is not None:
+        causal_hybrid_seed = _flash_causal_hybrid_seed_config(
+            head_dim,
+            num_kv,
+            dtype=dtype,
+            is_causal=is_causal,
+            has_kv_tile_pruning=has_kv_tile_pruning,
+            requires_ws_overlap=requires_ws_overlap,
+            small_biased_candidate=small_biased_candidate,
+            standard_causal_output=standard_causal_output,
+            block_size_targets=block_size_targets,
+        )
+        if causal_hybrid_seed is not None:
+            seeds.append(causal_hybrid_seed)
+    for family_seed in _flash_canonical_family_seed_configs(
+        head_dim,
+        num_kv,
+        dtype=dtype,
+        is_causal=is_causal,
+        has_kv_tile_pruning=has_kv_tile_pruning,
+        requires_ws_overlap=requires_ws_overlap,
+        small_biased_candidate=small_biased_candidate,
+        standard_dense_output=standard_dense_output,
+        block_size_targets=block_size_targets,
+    ):
+        if family_seed not in seeds:
+            seeds.append(family_seed)
     return tuple(seeds)
 
 
@@ -3847,7 +4127,7 @@ def flash_autotune_fragments(
       * ``s_stage`` — warp-spec double-buffered-S overlap (1 vs 2).
       * ``kv_stage`` — K/V TMA ring depth. Most flash kernels keep the validated
         2/3-stage envelope; dense hd64 FA4 additionally accepts sparse deeper
-        manual/cache-transfer values while actively searching only the stable
+        manual values while actively searching only the stable
         2/3-stage subset.
       * ``persistent`` — static-persistent scheduler on/off.
       * ``e2e_schedule`` — paired exp2-pipe-split schedule choices. This
@@ -3890,7 +4170,7 @@ def flash_autotune_fragments(
         compact set of batch/head interleave group sizes.
       * ``causal_kv_order`` — causal-only KV traversal order. The original
         Helion stream walks left-to-right; upstream FA4 walks diagonal-first and
-        then backward. Both orders remain accepted for manual/cache-transfer
+        then backward. Both orders remain accepted for fixed
         configs; causal hd64 actively searches the diagonal-first descending
         stream so split-loop candidates are meaningful rather than clamped away.
       * ``small_biased`` — enables the small contiguous biased-attention SIMT
@@ -4163,7 +4443,7 @@ def flash_autotune_fragments(
         )
     # fa4 disc PASS2 software-pipeline depth lever. The first choice is the
     # shape-resolved default; the remaining validated depths are accepted for
-    # autotune/cache transfer. They are consumed only by the fa4 emitter.
+    # fixed configurations. They are consumed only by the fa4 emitter.
     if dense_hd64_fa4 or causal_hd64_seeded_fa4:
         disc_pipe_choices = _flash_choices_with_default(
             defaults.disc_pipe_depth,
@@ -4564,7 +4844,7 @@ def flash_autotune_fragments(
         pipeline_family_search_choices: tuple[str, ...] | None = None
     else:
         pipeline_family_search: list[str] = ["fa4" if fa4_eligible else "ws_overlap"]
-        if not long_causal_hd64_seeded_fa4:
+        if pipeline_family_search[0] != "ws_overlap":
             pipeline_family_search.append("ws_overlap")
         if use_2cta_eligible:
             pipeline_family_search.append("fa4_2cta")

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -3644,7 +3644,7 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         device_ir.register_rollable_reductions()
         if CompileEnvironment.current().backend.name == "cute":
             _register_cute_lane_vector_width_specs(config_spec)
-            # Enable the flash-attention autotune surface (Tasks #25 + #28) when
+            # Enable the flash-attention autotune surface when
             # the dense flash dataflow is detected, analogous to how a matmul
             # detection sets ``cute_tcgen05_search_enabled``. Default-off
             # otherwise so the flash knobs never widen the search surface for
@@ -3663,6 +3663,7 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                     requires_ws_overlap=flash_shape.requires_ws_overlap,
                     small_biased_candidate=flash_shape.small_biased_candidate,
                     standard_dense_output=flash_shape.standard_dense_output,
+                    standard_causal_output=flash_shape.standard_causal_output,
                 )
             else:
                 from ..language.matmul_ops import enable_cute_tcgen05_search

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -363,6 +363,15 @@ class BaseSearch(BaseAutotuner):
             log=self.log,
             autotune_metrics=self._autotune_metrics,
         )
+        if self.config_spec.compiler_seed_timeout_retry_repetitions is not None:
+            seed_config_gen = self.config_spec.create_config_generation(
+                overrides=self.settings.autotune_config_overrides or None,
+                advanced_controls_files=self.settings.autotune_search_acf or None,
+                process_group_name=self.kernel.env.process_group_name,
+            )
+            self.benchmark_provider.set_compiler_seed_configs(
+                [config for _flat, config in seed_config_gen.seed_flat_config_pairs()]
+            )
         self.benchmark_provider.set_budget_exceeded_fn(self._autotune_budget_exceeded)
 
     def _is_restricted_search(self) -> bool:

--- a/helion/autotuner/benchmark_job.py
+++ b/helion/autotuner/benchmark_job.py
@@ -29,6 +29,7 @@ class BenchmarkJob:
     warmup: int = 1
     rep: int = 50
     use_wall_clock: bool = False
+    fixed_repetitions: int | None = None
 
     def __call__(self) -> float:
         # Subprocess inherits parent stderr; capture so Triton runtime
@@ -39,14 +40,25 @@ class BenchmarkJob:
                 args = load_trusted_kernel_args(self.args_path)
                 bench = do_bench_generic if self.use_wall_clock else do_bench
                 # return_mode="median" guarantees a float return.
-                return cast(
-                    "float",
-                    bench(
-                        functools.partial(fn, *args),
+                benchmark_fn = functools.partial(fn, *args)
+                if self.fixed_repetitions is None:
+                    result = bench(
+                        benchmark_fn,
                         return_mode="median",
                         warmup=self.warmup,
                         rep=self.rep,
-                    ),
+                    )
+                else:
+                    result = bench(
+                        benchmark_fn,
+                        return_mode="median",
+                        warmup=self.warmup,
+                        rep=self.rep,
+                        fixed_repetitions=self.fixed_repetitions,
+                    )
+                return cast(
+                    "float",
+                    result,
                 )
             finally:
                 _unload_compiled_fn(fn)

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -76,6 +76,11 @@ if TYPE_CHECKING:
 
 MultiShapeAggregation = Literal["geomean", "max"]
 MultiShapeReference = Literal["default", "baseline"] | None
+_SUCCESSFUL_BENCHMARK_STATUSES = frozenset(("ok", "deduplicated"))
+
+
+def _benchmark_status_succeeded(status: str) -> bool:
+    return status in _SUCCESSFUL_BENCHMARK_STATUSES
 
 
 @dataclasses.dataclass
@@ -154,15 +159,18 @@ def _format_multi_shape_measurement(
         ]
         shape_text = f" tensor_shapes={tensor_shapes}" if tensor_shapes else ""
         status = statuses[index] if statuses is not None else "ok"
-        if status != "ok" or not math.isfinite(timing) or timing <= 0:
+        succeeded = _benchmark_status_succeeded(status)
+        if not succeeded or not math.isfinite(timing) or timing <= 0:
             row = f"arg_sets[{index}]{shape_text}: status={status}"
             if math.isfinite(timing):
                 row += f", latency={timing:.6f} ms"
         else:
             row = f"arg_sets[{index}]{shape_text}: latency={timing:.6f} ms"
+            if status != "ok":
+                row += f", status={status}"
         if (
             references is not None
-            and status == "ok"
+            and succeeded
             and math.isfinite(timing)
             and timing > 0
         ):
@@ -407,6 +415,10 @@ class BenchmarkProvider(abc.ABC):
         """Install the search's budget-check hook on this provider."""
         self.budget_exceeded_fn = fn
 
+    def set_compiler_seed_configs(self, configs: Sequence[Config]) -> None:
+        """Register normalized compiler-owned seeds, if the provider needs them."""
+        return None
+
     @abc.abstractmethod
     def benchmark(
         self,
@@ -489,6 +501,8 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._last_benchmark_failure_status: Literal["error", "timeout"] | None = None
         self._effective_source_hashes: set[str] = set()
         self._effective_source_results: dict[str, BenchmarkResult] = {}
+        self._compiler_seed_configs: set[Config] = set()
+        self._compiler_seed_source_hashes: set[str] = set()
         # budget_exceeded_fn inherits the class-level _never_exceeded default
         # until BaseSearch._prepare installs the search's real hook.
 
@@ -523,6 +537,23 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._last_benchmark_failure_status = status
         self._autotune_metrics.num_worker_failures += 1
         self._worker_failure_config_ids.append(id(config))
+
+    def set_compiler_seed_configs(self, configs: Sequence[Config]) -> None:
+        self._compiler_seed_source_hashes = set()
+        if self._compiler_seed_timeout_retry_repetitions() is None:
+            self._compiler_seed_configs = set()
+            return
+        self._compiler_seed_configs = {copy.deepcopy(config) for config in configs}
+
+    def _compiler_seed_timeout_retry_repetitions(self) -> int | None:
+        repetitions = self.config_spec.compiler_seed_timeout_retry_repetitions
+        return repetitions if type(repetitions) is int and repetitions > 0 else None
+
+    def _is_compiler_seed_config(self, config: Config) -> bool:
+        return (
+            self._compiler_seed_timeout_retry_repetitions() is not None
+            and config in self._compiler_seed_configs
+        )
 
     def _compute_baseline(
         self,
@@ -756,6 +787,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._precompile_result_counter = count()
         self._effective_source_hashes.clear()
         self._effective_source_results.clear()
+        self._compiler_seed_source_hashes.clear()
         # Drop the baseline tensors (GPU memory) so refcount frees them
         # the moment the provider loses its last external reference.
         self._baseline_output = None
@@ -977,6 +1009,8 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 unique_compiled[index] = fn
                 continue
             source_hashes[index] = source_hash
+            if self._is_compiler_seed_config(all_configs[index]):
+                self._compiler_seed_source_hashes.add(source_hash)
             if source_hash not in seen_sources:
                 seen_sources.add(source_hash)
                 self._autotune_metrics.num_unique_sources += 1
@@ -1078,7 +1112,20 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 )
             ):
                 self._last_benchmark_failure_status = None
-                perf = self._benchmark_function(config, fn)
+                representative_index = valid_indices[index]
+                source_hash = source_hashes.get(representative_index)
+                compiler_seed_source = self._is_compiler_seed_config(config) or (
+                    source_hash is not None
+                    and source_hash in self._compiler_seed_source_hashes
+                )
+                if compiler_seed_source and source_hash is not None:
+                    perf = self._benchmark_function(
+                        config,
+                        fn,
+                        effective_source_hash=source_hash,
+                    )
+                else:
+                    perf = self._benchmark_function(config, fn)
                 status = (
                     "ok"
                     if math.isfinite(perf)
@@ -1173,13 +1220,26 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         """
         clear_jit_fast_path_caches(fn, self.log)
 
-    def _benchmark_function(self, config: Config, fn: CompiledConfig) -> float:
+    def _benchmark_function(
+        self,
+        config: Config,
+        fn: CompiledConfig,
+        *,
+        effective_source_hash: str | None = None,
+    ) -> float:
         """Benchmark a single compiled function.  Returns time in ms or inf."""
         self._autotune_metrics.num_configs_tested += 1
         self.log.debug(lambda: f"Running benchmark for {config!r}")
 
         if self._subprocess_benchmark_enabled():
-            result = self._benchmark_function_subprocess(config, fn)
+            if effective_source_hash is not None:
+                result = self._benchmark_function_subprocess(
+                    config,
+                    fn,
+                    effective_source_hash=effective_source_hash,
+                )
+            else:
+                result = self._benchmark_function_subprocess(config, fn)
             if result is not None:
                 return result
             # None means the subprocess path could not handle this config
@@ -1360,15 +1420,47 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             self._clear_jit_fast_path_caches(fn)
 
     def _benchmark_function_subprocess(
-        self, config: Config, fn: CompiledConfig
+        self,
+        config: Config,
+        fn: CompiledConfig,
+        *,
+        effective_source_hash: str | None = None,
     ) -> float | None:
         """Benchmark ``fn`` in a long-lived spawn subprocess with a per-call
         timeout. Returns the measured latency in ms, ``inf`` for a failure
         we classified and handled, or ``None`` if the subprocess path cannot
-        handle this config and the caller should fall back to in-process.
+        handle this config and the caller should fall back to in-process. An
+        eligible timed-out compiler seed gets one budget-gated retry whose
+        fixed repetition count comes from ``ConfigSpec``.
         """
+        retry_repetitions = self._compiler_seed_timeout_retry_repetitions()
+        retry_compiler_seed_timeout = retry_repetitions is not None and (
+            config in self._compiler_seed_configs
+            or (
+                effective_source_hash is not None
+                and effective_source_hash in self._compiler_seed_source_hashes
+            )
+        )
         try:
-            latency = self._run_subprocess_benchmark_job(fn, warmup=1, rep=50)
+            try:
+                latency = self._run_subprocess_benchmark_job(fn, warmup=1, rep=50)
+            except BenchmarkTimeout:
+                if not retry_compiler_seed_timeout or self.budget_exceeded_fn():
+                    raise
+                assert retry_repetitions is not None
+                self.log.debug(
+                    lambda: (
+                        "Retrying timed-out compiler seed with "
+                        f"{retry_repetitions} measured "
+                        f"repetitions: {config!r}"
+                    )
+                )
+                latency = self._run_subprocess_benchmark_job(
+                    fn,
+                    warmup=1,
+                    rep=50,
+                    fixed_repetitions=retry_repetitions,
+                )
             if latency is None:
                 return None
         except BenchmarkSubprocessError as e:
@@ -1516,6 +1608,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         *,
         warmup: int,
         rep: int,
+        fixed_repetitions: int | None = None,
     ) -> float | None:
         if self._precompile_args_path is None:
             return None
@@ -1533,6 +1626,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             warmup=warmup,
             rep=rep,
             use_wall_clock=self._subprocess_benchmark_uses_wall_clock(),
+            fixed_repetitions=fixed_repetitions,
         )
         return float(
             self._benchmark_worker.run(
@@ -1639,6 +1733,10 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
         for child in self.children:
             child.set_budget_exceeded_fn(_never_exceeded)
 
+    def set_compiler_seed_configs(self, configs: Sequence[Config]) -> None:
+        for child in self.children:
+            child.set_compiler_seed_configs(configs)
+
     def setup(self) -> None:
         case_index = 0
         try:
@@ -1681,7 +1779,7 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
                 desc="Benchmarking default reference",
             )[0]
             if (
-                result.status != "ok"
+                not _benchmark_status_succeeded(result.status)
                 or not math.isfinite(result.perf)
                 or result.perf <= 0
             ):
@@ -1777,11 +1875,13 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
         materialized_keys = [repr(config) for config in materialized]
         executed_configs = [copy.deepcopy(config) for config in materialized]
 
-        child_failure_snapshots = [
+        child_metric_snapshots = [
             (
                 len(child._accuracy_failure_config_ids),
                 len(child._compile_failure_config_ids),
                 len(child._worker_failure_config_ids),
+                child._autotune_metrics.num_unique_sources,
+                child._autotune_metrics.num_source_deduplications,
             )
             for child in self.children
         ]
@@ -1798,9 +1898,13 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
             accuracy_failure_ids: set[int] = set()
             compile_failure_ids: set[int] = set()
             worker_failure_ids: set[int] = set()
-            for child, (before_accuracy, before_compile, before_worker) in zip(
-                self.children, child_failure_snapshots, strict=True
-            ):
+            for child, (
+                before_accuracy,
+                before_compile,
+                before_worker,
+                before_unique_sources,
+                before_source_deduplications,
+            ) in zip(self.children, child_metric_snapshots, strict=True):
                 accuracy_failure_ids.update(
                     child._accuracy_failure_config_ids[before_accuracy:]
                 )
@@ -1810,6 +1914,13 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
                 worker_failure_ids.update(
                     child._worker_failure_config_ids[before_worker:]
                 )
+                self._autotune_metrics.num_unique_sources += (
+                    child._autotune_metrics.num_unique_sources - before_unique_sources
+                )
+                self._autotune_metrics.num_source_deduplications += (
+                    child._autotune_metrics.num_source_deduplications
+                    - before_source_deduplications
+                )
             self._autotune_metrics.num_accuracy_failures += len(accuracy_failure_ids)
             self._autotune_metrics.num_compile_failures += len(compile_failure_ids)
             self._autotune_metrics.num_worker_failures += len(worker_failure_ids)
@@ -1818,7 +1929,9 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
             row = [child[child_config_index] for child in child_results]
             timings = [result.perf for result in row]
             valid = all(
-                result.status == "ok" and math.isfinite(result.perf) and result.perf > 0
+                _benchmark_status_succeeded(result.status)
+                and math.isfinite(result.perf)
+                and result.perf > 0
                 for result in row
             )
             perf = (

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -505,6 +505,7 @@ def do_bench(
     process_group_name: str | None = None,
     *,
     default_cudagraph: bool = False,
+    fixed_repetitions: int | None = None,
 ) -> float | tuple[float, ...]:
     """
     Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with
@@ -522,6 +523,8 @@ def do_bench(
     :type quantiles: list[float], optional
     :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
     :type return_mode: str
+    :param fixed_repetitions: Skip adaptive estimation and time exactly this many
+        calls after the initial setup call.
     """
     from triton import runtime
     from triton.testing import _summarize_statistics
@@ -542,22 +545,29 @@ def do_bench(
 
     cache = runtime.driver.active.get_empty_cache_for_benchmark()  # pyrefly: ignore
 
-    # Estimate the runtime of the function
-    start_event = di.Event(enable_timing=True)
-    end_event = di.Event(enable_timing=True)
-    start_event.record()
-    for _ in range(5):
-        runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
-        benchmark_function()
-    end_event.record()
-    di.synchronize()
-    estimate_ms = sync_object(
-        start_event.elapsed_time(end_event) / 5, process_group_name=process_group_name
-    )
+    if fixed_repetitions is None:
+        # Estimate the runtime of the function
+        start_event = di.Event(enable_timing=True)
+        end_event = di.Event(enable_timing=True)
+        start_event.record()
+        for _ in range(5):
+            runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
+            benchmark_function()
+        end_event.record()
+        di.synchronize()
+        estimate_ms = sync_object(
+            start_event.elapsed_time(end_event) / 5,
+            process_group_name=process_group_name,
+        )
 
-    # compute number of warmup and repeat
-    n_warmup = max(1, int(warmup / estimate_ms))
-    n_repeat = max(1, int(rep / estimate_ms))
+        # compute number of warmup and repeat
+        n_warmup = max(1, int(warmup / estimate_ms))
+        n_repeat = max(1, int(rep / estimate_ms))
+    else:
+        if fixed_repetitions < 1:
+            raise ValueError("fixed_repetitions must be at least 1")
+        n_warmup = 0
+        n_repeat = fixed_repetitions
     start_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
     end_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
     # Warm-up
@@ -593,9 +603,13 @@ def do_bench_generic(
     process_group_name: str | None = None,
     *,
     default_cudagraph: bool = False,  # accepted for API symmetry; wall-clock timing doesn't use CG
+    fixed_repetitions: int | None = None,
 ) -> float | tuple[float, ...]:
     """
     Benchmark using wall-clock timing for backends without Triton event timing.
+
+    ``fixed_repetitions`` skips adaptive estimation and times exactly that many
+    calls after the initial setup call.
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
@@ -604,22 +618,28 @@ def do_bench_generic(
 
     clear_l2 = _make_l2_cache_clearer()
 
-    # Estimate the runtime of the function
-    synchronize_device()
-    start = time.perf_counter()
-    for _ in range(5):
-        clear_l2()
-        # Keep the latest asynchronous output alive through synchronization.
-        _output = fn()
-    synchronize_device()
-    end = time.perf_counter()
-    estimate_ms = sync_object(
-        (end - start) * 1000 / 5, process_group_name=process_group_name
-    )
+    if fixed_repetitions is None:
+        # Estimate the runtime of the function
+        synchronize_device()
+        start = time.perf_counter()
+        for _ in range(5):
+            clear_l2()
+            # Keep the latest asynchronous output alive through synchronization.
+            _output = fn()
+        synchronize_device()
+        end = time.perf_counter()
+        estimate_ms = sync_object(
+            (end - start) * 1000 / 5, process_group_name=process_group_name
+        )
 
-    # compute number of warmup and repeat
-    n_warmup = max(1, int(warmup / estimate_ms))
-    n_repeat = max(1, int(rep / estimate_ms))
+        # compute number of warmup and repeat
+        n_warmup = max(1, int(warmup / estimate_ms))
+        n_repeat = max(1, int(rep / estimate_ms))
+    else:
+        if fixed_repetitions < 1:
+            raise ValueError("fixed_repetitions must be at least 1")
+        n_warmup = 0
+        n_repeat = fixed_repetitions
     # Warm-up
     for _ in range(n_warmup):
         fn()

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -49,6 +49,7 @@ class ConfigGeneration:
         config_spec: ConfigSpec,
         *,
         overrides: Mapping[str, object] | None = None,
+        _flash_pipeline_family_override: str | None = None,
         advanced_controls_files: list[str] | None = None,
         process_group_name: str | None = None,
     ) -> None:
@@ -69,11 +70,23 @@ class ConfigGeneration:
         self.config_spec = config_spec
         self.process_group_name = process_group_name
         self._advanced_controls_files = advanced_controls_files
-        self.flat_spec: list[ConfigSpecFragment] = []
-        config_spec.flat_config(
-            _collect_spec,
-            advanced_controls_files=advanced_controls_files,
+        self._flash_pipeline_family_override = (
+            _flash_pipeline_family_override
+            if config_spec.cute_flash_search_enabled
+            else None
         )
+        self.flat_spec: list[ConfigSpecFragment] = []
+        if self._flash_pipeline_family_override is None:
+            config_spec.flat_config(
+                _collect_spec,
+                advanced_controls_files=advanced_controls_files,
+            )
+        else:
+            config_spec._flat_config_with_flash_family(
+                _collect_spec,
+                advanced_controls_files=advanced_controls_files,
+                flash_pipeline_family=self._flash_pipeline_family_override,
+            )
         assert self.flat_spec, "No config values to tune"
         self._override_values = dict(overrides or {})
         self.block_size_indices: list[int] = [
@@ -165,9 +178,17 @@ class ConfigGeneration:
         """
         mapping: dict[str, tuple[list[int], bool]] = {}
         idx = 0
-        for key, count, is_sequence in self.config_spec.flat_key_layout(
-            advanced_controls_files=self._advanced_controls_files
-        ):
+        layout = (
+            self.config_spec.flat_key_layout(
+                advanced_controls_files=self._advanced_controls_files
+            )
+            if self._flash_pipeline_family_override is None
+            else self.config_spec._flat_key_layout_with_flash_family(
+                advanced_controls_files=self._advanced_controls_files,
+                flash_pipeline_family=self._flash_pipeline_family_override,
+            )
+        )
+        for key, count, is_sequence in layout:
             mapping[key] = (list(range(idx, idx + count)), is_sequence)
             idx += count
         assert idx == len(self.flat_spec), (
@@ -284,7 +305,13 @@ class ConfigGeneration:
     def flatten(self, config: Config) -> FlatConfig:
         """Inverse of unflatten: convert a Config to a FlatConfig."""
         result = self._fragment_default_flat()
-        flat_fields = self.config_spec._flat_fields()
+        flat_fields = (
+            self.config_spec._flat_fields()
+            if self._flash_pipeline_family_override is None
+            else self.config_spec._flat_fields_with_flash_family(
+                self._flash_pipeline_family_override
+            )
+        )
         for key, (indices, is_sequence) in self._key_to_flat_indices.items():
             if key not in config.config:
                 has_default, value = self.config_spec.flatten_missing_field_default(
@@ -335,10 +362,17 @@ class ConfigGeneration:
         assert len(flat_values) == len(self.flat_spec)
         self._repair_cute_num_threads(flat_values)
         count: itertools.count[int] = itertools.count()
-        config = self.config_spec.flat_config(
-            get_next_value,
-            advanced_controls_files=self._advanced_controls_files,
-        )
+        if self._flash_pipeline_family_override is None:
+            config = self.config_spec.flat_config(
+                get_next_value,
+                advanced_controls_files=self._advanced_controls_files,
+            )
+        else:
+            config = self.config_spec._flat_config_with_flash_family(
+                get_next_value,
+                advanced_controls_files=self._advanced_controls_files,
+                flash_pipeline_family=self._flash_pipeline_family_override,
+            )
         assert next(count) == len(flat_values)
         config = self._apply_overrides(config)
         # Overrides may reintroduce pointer stores that break subtiled outputs

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -639,7 +639,7 @@ class ConfigSpec:
         self.has_pallas_inner_loops: bool = False
         self.has_symbolic_or_data_dependent_bounds: bool = False
         self._cute_tcgen05_config = CuteTcgen05Config(self)
-        # CuTe flash-attention autotune surface gating (Tasks #25 + #28).
+        # CuTe flash-attention autotune surface gating.
         # Default False so the flash knobs never appear in the search surface
         # and behavior is byte-identical to the env-only path. Set True when the
         # flash detector fires (see ``lower_to_device_ir``). The shape needed to
@@ -653,9 +653,13 @@ class ConfigSpec:
         self._cute_flash_requires_ws_overlap: bool = False
         self._cute_flash_small_biased_candidate: bool = False
         self._cute_flash_standard_dense_output: bool = False
+        self._cute_flash_standard_causal_output: bool = False
         self._cute_flash_block_size_targets: dict[int, int] = {}
         self.compiler_default_config: helion.Config | None = None
         self.compiler_seed_configs: list[helion.Config] = []
+        # Compiler paths can opt their seeds into a single bounded timeout
+        # retry. ``None`` leaves all benchmark behavior unchanged.
+        self.compiler_seed_timeout_retry_repetitions: int | None = None
         self.autotuner_heuristics: list[str] = []
         self.matmul_facts: list[MatmulFact] = []
         # The Stage-1 categorizing product the reduction seed + allocator consume.
@@ -1160,6 +1164,7 @@ class ConfigSpec:
         requires_ws_overlap: bool = False,
         small_biased_candidate: bool = False,
         standard_dense_output: bool = False,
+        standard_causal_output: bool = False,
     ) -> None:
         self.cute_flash_search_enabled = True
         self._cute_flash_head_dim = head_dim
@@ -1170,6 +1175,7 @@ class ConfigSpec:
         self._cute_flash_requires_ws_overlap = requires_ws_overlap
         self._cute_flash_small_biased_candidate = small_biased_candidate
         self._cute_flash_standard_dense_output = standard_dense_output
+        self._cute_flash_standard_causal_output = standard_causal_output
         self._cute_flash_block_size_targets = dict(block_size_targets)
         for block_id, target in block_size_targets.items():
             spec = self.block_sizes.block_id_lookup(block_id)
@@ -1384,6 +1390,8 @@ class ConfigSpec:
                     has_kv_tile_pruning=self._cute_flash_has_kv_tile_pruning,
                     requires_ws_overlap=self._cute_flash_requires_ws_overlap,
                     small_biased_candidate=self._cute_flash_small_biased_candidate,
+                    standard_dense_output=self._cute_flash_standard_dense_output,
+                    standard_causal_output=self._cute_flash_standard_causal_output,
                     block_size_targets=self._cute_flash_block_size_target_list(),
                 )
             )
@@ -2234,9 +2242,32 @@ class ConfigSpec:
     ) -> ConfigGeneration:
         from .config_generation import ConfigGeneration
 
+        effective_overrides = overrides
+        family_override: str | None = None
+        if self.cute_flash_search_enabled and overrides:
+            exact_family = overrides.get(FLASH_PIPELINE_FAMILY_KEY)
+            if _flash_pipeline_family_flags(exact_family) is not None:
+                family_override = cast("str", exact_family)
+            elif FLASH_PIPELINE_FAMILY_KEY not in overrides:
+                legacy = {
+                    key: overrides[key]
+                    for key in FLASH_LEGACY_STRUCTURAL_CONFIG_KEYS
+                    if overrides.get(key) is not None
+                }
+                if legacy:
+                    if FLASH_PERSISTENT_KEY in overrides:
+                        legacy[FLASH_PERSISTENT_KEY] = overrides[FLASH_PERSISTENT_KEY]
+                    family_override = self._resolve_cute_flash_config(
+                        legacy
+                    ).pipeline_family
+                    effective_overrides = {
+                        **overrides,
+                        FLASH_PIPELINE_FAMILY_KEY: family_override,
+                    }
         return ConfigGeneration(
             self,
-            overrides=overrides,
+            overrides=effective_overrides,
+            _flash_pipeline_family_override=family_override,
             advanced_controls_files=advanced_controls_files,
             process_group_name=process_group_name,
         )
@@ -2306,6 +2337,12 @@ class ConfigSpec:
     def _flat_fields(
         self,
     ) -> dict[str, BlockIdSequence[Any] | ConfigSpecFragment]:
+        return self._flat_fields_with_flash_family()
+
+    def _flat_fields_with_flash_family(
+        self,
+        _flash_pipeline_family_override: str | None = None,
+    ) -> dict[str, BlockIdSequence[Any] | ConfigSpecFragment]:
         """Return {key: field} for all tunable fields in flat_config() order.
 
         This is the single source of truth for field ordering.
@@ -2333,6 +2370,7 @@ class ConfigSpec:
                             self._cute_flash_small_biased_candidate
                         ),
                         standard_dense_output=self._cute_flash_standard_dense_output,
+                        pipeline_family_override=_flash_pipeline_family_override,
                     )
                 )
             elif self.supports_config_key("num_threads"):
@@ -2520,16 +2558,29 @@ class ConfigSpec:
         return EnumFragment(tuple(files))
 
     def flat_key_layout(
-        self, *, advanced_controls_files: list[str] | None = None
+        self,
+        *,
+        advanced_controls_files: list[str] | None = None,
     ) -> list[tuple[str, int, bool]]:
         """Return (key_name, num_flat_entries, is_sequence) for each field.
 
         is_sequence is True for BlockIdSequence keys whose list values
         are spread across individual flat slots.
         """
-        result = [
-            (key, *field._flat_key_info()) for key, field in self._flat_fields().items()
-        ]
+        fields = self._flat_fields()
+        result = [(key, *field._flat_key_info()) for key, field in fields.items()]
+        if self._advanced_controls_file_fragment(advanced_controls_files) is not None:
+            result.append(("advanced_controls_file", 1, False))
+        return result
+
+    def _flat_key_layout_with_flash_family(
+        self,
+        *,
+        advanced_controls_files: list[str] | None,
+        flash_pipeline_family: str,
+    ) -> list[tuple[str, int, bool]]:
+        fields = self._flat_fields_with_flash_family(flash_pipeline_family)
+        result = [(key, *field._flat_key_info()) for key, field in fields.items()]
         if self._advanced_controls_file_fragment(advanced_controls_files) is not None:
             result.append(("advanced_controls_file", 1, False))
         return result
@@ -2541,8 +2592,34 @@ class ConfigSpec:
         advanced_controls_files: list[str] | None = None,
     ) -> helion.Config:
         """Map a flattened version of the config using the given function."""
+        return self._flat_config_from_fields(
+            fn,
+            self._flat_fields(),
+            advanced_controls_files=advanced_controls_files,
+        )
+
+    def _flat_config_with_flash_family(
+        self,
+        fn: Callable[[ConfigSpecFragment], object],
+        *,
+        advanced_controls_files: list[str] | None,
+        flash_pipeline_family: str,
+    ) -> helion.Config:
+        return self._flat_config_from_fields(
+            fn,
+            self._flat_fields_with_flash_family(flash_pipeline_family),
+            advanced_controls_files=advanced_controls_files,
+        )
+
+    def _flat_config_from_fields(
+        self,
+        fn: Callable[[ConfigSpecFragment], object],
+        fields: Mapping[str, BlockIdSequence[Any] | ConfigSpecFragment],
+        *,
+        advanced_controls_files: list[str] | None,
+    ) -> helion.Config:
         config: dict[str, Any] = {}
-        for key, field in self._flat_fields().items():
+        for key, field in fields.items():
             config[key] = field._flat_config(self, fn)
 
         for name in (

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -238,6 +238,7 @@ class TestAutotuneIgnoreErrors(TestCase):
         search.config_spec = SimpleNamespace(
             default_config=lambda: helion.Config(block_sizes=[1]),
             cute_flash_search_enabled=False,
+            compiler_seed_timeout_retry_repetitions=None,
             backend=SimpleNamespace(
                 should_deduplicate_generated_sources=lambda config_spec: False,
                 get_do_bench=lambda: None,
@@ -3803,7 +3804,7 @@ class TestCuteAutotuner(TestCase):
         torch.testing.assert_close(actual, args[0] @ args[1], atol=0.125, rtol=0.02)
 
     def test_cute_flash_search_surface(self) -> None:
-        """The flash-attention autotune surface (Tasks #25 + #28) appears only
+        """The flash-attention autotune surface appears only
         when the dense flash dataflow is detected.
 
         For an attention kernel bind ``cute_flash_search_enabled`` is True and
@@ -4451,7 +4452,7 @@ class TestCuteAutotuner(TestCase):
             FLASH_KV_STAGE_KEY: (2,),
             FLASH_E2E_SCHEDULE_KEY: ("8/2",),
             FLASH_MASKED_E2E_SCHEDULE_KEY: ("16/4",),
-            FLASH_PIPELINE_FAMILY_KEY: ("fa4",),
+            FLASH_PIPELINE_FAMILY_KEY: ("fa4", "ws_overlap"),
             FLASH_DISC_PIPE_KEY: (4,),
             FLASH_E2E_OFFSET_KEY: (9,),
             FLASH_E2E_OFFSET0_KEY: (3,),
@@ -5429,6 +5430,23 @@ class TestCuteAutotuner(TestCase):
         for key in FLASH_CONFIG_KEYS:
             self.assertNotIn(key, mm_keys)
 
+    def test_cute_flash_two_cta_uses_general_softmax_register_search(self) -> None:
+        from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_REGS_KEY
+        from helion._compiler.cute.cute_flash import flash_autotune_fragments
+
+        for num_kv in (512, 1536, 2048):
+            with self.subTest(num_kv=num_kv):
+                fragment = flash_autotune_fragments(
+                    64,
+                    num_kv,
+                    dtype=torch.float16,
+                    is_causal=False,
+                    standard_dense_output=True,
+                    pipeline_family_override="fa4_2cta",
+                )[FLASH_SOFTMAX_REGS_KEY]
+                self.assertEqual(set(fragment.search_choices or ()), {192, 200})
+                self.assertLessEqual({192, 200}, set(fragment.choices))
+
 
 @onlyBackends(["triton"])
 class TestAutotuneRandomSeed(RefEagerTestDisabled, TestCase):
@@ -6326,7 +6344,8 @@ class TestAutotuneBudget(TestCase):
         search.args = ()
         search.log = AutotuningLogger(settings)
         search.config_spec = SimpleNamespace(
-            default_config=lambda: helion.Config(block_sizes=[1])
+            default_config=lambda: helion.Config(block_sizes=[1]),
+            compiler_seed_timeout_retry_repetitions=None,
         )
         search._benchmark_provider_cls = LocalBenchmarkProvider
         search.best_perf_so_far = float("inf")
@@ -6595,6 +6614,41 @@ class TestAutotuneBudget(TestCase):
             search._autotune_budget_exceeded,
         )
 
+    def test_prepare_registers_normalized_compiler_seeds(self) -> None:
+        normalized = helion.Config(block_sizes=[64])
+
+        class RecordingProvider(LocalBenchmarkProvider):
+            def __init__(self, *, config_spec, **_kwargs) -> None:
+                self.config_spec = config_spec
+
+        settings = Settings(autotune_log_level=logging.CRITICAL)
+        search = BaseSearch.__new__(BaseSearch)
+        search.settings = settings
+        search.kernel = SimpleNamespace(env=SimpleNamespace(process_group_name=None))
+        config_gen = Mock()
+        config_gen.seed_flat_config_pairs.return_value = [([64], normalized)]
+        search.config_spec = SimpleNamespace(
+            compiler_seed_timeout_retry_repetitions=3,
+            create_config_generation=Mock(return_value=config_gen),
+        )
+        search.args = ()
+        search.log = AutotuningLogger(settings)
+        search._benchmark_provider_cls = RecordingProvider
+        search._prepared = False
+
+        search._prepare()
+        normalized.config["block_sizes"][0] = 128
+
+        self.assertEqual(
+            search.benchmark_provider._compiler_seed_configs,
+            {helion.Config(block_sizes=[64])},
+        )
+        search.config_spec.create_config_generation.assert_called_once_with(
+            overrides=None,
+            advanced_controls_files=None,
+            process_group_name=None,
+        )
+
     def _make_stub_provider(self):
         """Construct a minimal ``LocalBenchmarkProvider`` for budget-loop
         tests without standing up a real kernel/config_spec.
@@ -6636,6 +6690,8 @@ class TestAutotuneBudget(TestCase):
         provider._precompile_tmpdir = None
         provider._effective_source_hashes = set()
         provider._effective_source_results = {}
+        provider._compiler_seed_configs = set()
+        provider._compiler_seed_source_hashes = set()
         return provider
 
     def test_cute_flash_benchmark_deduplicates_effective_sources(self) -> None:
@@ -6687,6 +6743,76 @@ class TestAutotuneBudget(TestCase):
         self.assertIsNot(repeated_results[0], results[0])
         self.assertEqual(provider._autotune_metrics.num_unique_sources, 2)
         self.assertEqual(provider._autotune_metrics.num_source_deduplications, 2)
+
+    def test_compiler_seed_alias_marks_source_for_timeout_retry(self) -> None:
+        provider = self._make_stub_provider()
+        provider.config_spec = SimpleNamespace(
+            cute_flash_search_enabled=True,
+            compiler_seed_timeout_retry_repetitions=3,
+            backend=SimpleNamespace(
+                generated_source_hash=lambda fn: "shared",
+                should_deduplicate_generated_sources=lambda config_spec: True,
+            ),
+        )
+        representative = helion.Config(block_sizes=[1])
+        compiler_seed_alias = helion.Config(block_sizes=[2])
+        provider.set_compiler_seed_configs([compiler_seed_alias])
+
+        with patch.object(
+            LocalBenchmarkProvider,
+            "_benchmark_function",
+            return_value=1.0,
+        ) as benchmark:
+            results = provider.benchmark([representative, compiler_seed_alias])
+
+        self.assertEqual([result.perf for result in results], [1.0, 1.0])
+        benchmark.assert_called_once_with(
+            representative,
+            results[0].fn,
+            effective_source_hash="shared",
+        )
+
+    def test_compiler_seed_source_provenance_survives_batches(self) -> None:
+        provider = self._make_stub_provider()
+        provider.config_spec = SimpleNamespace(
+            cute_flash_search_enabled=True,
+            compiler_seed_timeout_retry_repetitions=3,
+            backend=SimpleNamespace(
+                generated_source_hash=lambda fn: "shared",
+                should_deduplicate_generated_sources=lambda config_spec: True,
+            ),
+        )
+        compiler_seed = helion.Config(block_sizes=[1])
+        later_alias = helion.Config(block_sizes=[2])
+        provider.set_compiler_seed_configs([compiler_seed])
+
+        with patch.object(
+            LocalBenchmarkProvider,
+            "_benchmark_function",
+            side_effect=(math.inf, 1.0),
+        ) as benchmark:
+            first = provider.benchmark([compiler_seed])
+            second = provider.benchmark([later_alias])
+
+        self.assertEqual(first[0].perf, math.inf)
+        self.assertEqual(second[0].perf, 1.0)
+        self.assertEqual(
+            benchmark.call_args_list[1],
+            unittest.mock.call(
+                later_alias,
+                second[0].fn,
+                effective_source_hash="shared",
+            ),
+        )
+
+    def test_disabled_compiler_seed_retry_does_not_register_seeds(self) -> None:
+        provider = self._make_stub_provider()
+        seed = helion.Config(block_sizes=[1])
+
+        provider.set_compiler_seed_configs([seed])
+
+        self.assertFalse(provider._is_compiler_seed_config(seed))
+        self.assertEqual(provider._compiler_seed_configs, set())
 
     def test_backend_policy_can_disable_effective_source_dedup(self) -> None:
         provider = self._make_stub_provider()

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -89,6 +89,8 @@ from helion._compiler.cute.cute_flash import FLASH_USE_2CTA_KEY
 from helion._compiler.cute.cute_flash import FLASH_WAIT_HINT_KEY
 from helion._compiler.cute.cute_flash import flash_attention_seed_config
 from helion._compiler.cute.cute_flash import flash_attention_seed_configs
+from helion._compiler.cute.cute_flash import flash_autotune_fragments
+from helion._compiler.cute.cute_flash import resolve_flash_config
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY
@@ -178,6 +180,7 @@ from helion._testing import patch_cute_mma_support
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 from helion.autotuner import IntegerFragment
+from helion.autotuner.config_fragment import EnumFragment
 from helion.autotuner.config_generation import ConfigGeneration
 from helion.autotuner.config_spec import BlockSizeSpec
 from helion.autotuner.config_spec import ConfigSpec
@@ -324,6 +327,7 @@ class TestAutotunerHeuristic(TestCase):
 
     def test_cute_flash_disable_heuristics_keeps_value_priors(self) -> None:
         spec = ConfigSpec(backend=CuteBackend())
+        self.assertIsNone(spec.compiler_seed_timeout_retry_repetitions)
         for block_id, size_hint in enumerate((1, 128, 128)):
             spec.block_sizes.append(
                 BlockSizeSpec(block_id=block_id, size_hint=size_hint)
@@ -334,12 +338,14 @@ class TestAutotunerHeuristic(TestCase):
             block_size_targets={0: 1, 1: 128, 2: 128},
             is_causal=True,
         )
+        self.assertIsNone(spec.compiler_seed_timeout_retry_repetitions)
         env = MagicMock()
         env.backend_name = "cute"
         env.config_spec = spec
         env.settings = Settings(disable_autotuner_heuristics=True)
 
         self.assertEqual(compiler_seed_configs(env, MagicMock()), [])
+        self.assertIsNone(spec.compiler_seed_timeout_retry_repetitions)
         self.assertEqual(spec.compiler_seed_configs, [])
         self.assertEqual(spec.autotuner_heuristics, [])
         self.assertTrue(spec.autotune_seed_configs())
@@ -351,6 +357,25 @@ class TestAutotunerHeuristic(TestCase):
 
         self.assertGreaterEqual(len(population), 4)
         self.assertIn(spec.default_config(), population)
+
+    def test_cute_flash_seed_enables_bounded_timeout_retry(self) -> None:
+        spec = ConfigSpec(backend=CuteBackend())
+        for block_id, size_hint in enumerate((1, 128, 128)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+            )
+        spec.enable_cute_flash_search(
+            head_dim=64,
+            num_kv=64,
+            block_size_targets={0: 1, 1: 128, 2: 128},
+        )
+        env = MagicMock()
+        env.config_spec = spec
+
+        seed = CuteFlashAttentionHeuristic.get_seed_config(env, MagicMock())
+
+        self.assertIsNotNone(seed)
+        self.assertEqual(spec.compiler_seed_timeout_retry_repetitions, 3)
 
     def test_seed_flat_config_pairs_skips_invalid_compiler_seed(self) -> None:
         spec = ConfigSpec(backend=TritonBackend())
@@ -2145,7 +2170,307 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertEqual(split_seed_256.config[FLASH_E2E_OFFSET0_KEY], 11)
         self.assertEqual(split_seed_256.config[FLASH_RESCALE_CHUNK_COLS_KEY], 16)
         self.assertEqual(split_seed_256.config[FLASH_CAUSAL_LPT_SWIZZLE_KEY], 4)
-        self.assertEqual(len(flash_attention_seed_configs(64, 64, is_causal=True)), 3)
+        split_seed_512 = flash_attention_seed_config(
+            64, 512, is_causal=True, seed_kind="causal_split"
+        )
+        assert split_seed_512 is not None
+        lpt_seed_512 = flash_attention_seed_config(
+            64, 512, is_causal=True, seed_kind="causal_lpt"
+        )
+        assert lpt_seed_512 is not None
+        self.assertNotEqual(split_seed_512, lpt_seed_512)
+        self.assertNotEqual(
+            resolve_flash_config(64, 512, split_seed_512.config, is_causal=True),
+            resolve_flash_config(64, 512, lpt_seed_512.config, is_causal=True),
+        )
+        self.assertEqual(split_seed_512.config[FLASH_E2E_SCHEDULE_KEY], "16/4")
+        self.assertEqual(split_seed_512.config[FLASH_MASKED_E2E_SCHEDULE_KEY], "8/2")
+        self.assertEqual(split_seed_512.config[FLASH_E2E_OFFSET_KEY], 0)
+        self.assertEqual(split_seed_512.config[FLASH_E2E_OFFSET0_KEY], 14)
+        self.assertEqual(split_seed_512.config[FLASH_DISC_PIPE_KEY], 3)
+        self.assertEqual(split_seed_512.config[FLASH_EXP2_PACKET_KEY], "4x1")
+        self.assertEqual(split_seed_512.config[FLASH_WAIT_HINT_KEY], 0)
+        self.assertFalse(split_seed_512.config[FLASH_EPI_TMA_KEY])
+        self.assertTrue(split_seed_512.config[FLASH_EPI_STG_KEY])
+        self.assertEqual(split_seed_512.config[FLASH_EPI_STG_GMEM_KEY], "pair")
+        self.assertEqual(split_seed_512.config[FLASH_RESCALE_CHUNK_COLS_KEY], 16)
+        self.assertEqual(split_seed_512.config[FLASH_ROLE_MAP_KEY], "fa4")
+        split_seed_4096 = flash_attention_seed_config(
+            64, 4096, is_causal=True, seed_kind="causal_split"
+        )
+        assert split_seed_4096 is not None
+        self.assertEqual(split_seed_4096.config, split_seed_512.config)
+
+        causal_seeds = flash_attention_seed_configs(64, 64, is_causal=True)
+        self.assertLessEqual(
+            {"fa4", "ws_overlap"},
+            {seed.config.get(FLASH_PIPELINE_FAMILY_KEY) for seed in causal_seeds},
+        )
+
+    def test_cute_flash_family_seeds_cover_legal_search_surface(self) -> None:
+        cases = (
+            (64, 256, torch.float16, False, False, True),
+            (64, 1024, torch.float16, False, False, True),
+            (64, 512, torch.float16, True, False, False),
+            (128, 256, torch.float16, False, False, True),
+            (64, 256, torch.bfloat16, False, False, False),
+            (64, 256, torch.float16, False, True, False),
+        )
+        for (
+            head_dim,
+            num_kv,
+            dtype,
+            is_causal,
+            requires_ws_overlap,
+            standard_dense_output,
+        ) in cases:
+            with self.subTest(
+                head_dim=head_dim,
+                num_kv=num_kv,
+                dtype=str(dtype),
+                is_causal=is_causal,
+                requires_ws_overlap=requires_ws_overlap,
+            ):
+                fragments = flash_autotune_fragments(
+                    head_dim,
+                    num_kv,
+                    dtype=dtype,
+                    is_causal=is_causal,
+                    requires_ws_overlap=requires_ws_overlap,
+                    standard_dense_output=standard_dense_output,
+                )
+                family_fragment = fragments[FLASH_PIPELINE_FAMILY_KEY]
+                self.assertIsInstance(family_fragment, EnumFragment)
+                assert isinstance(family_fragment, EnumFragment)
+                legal_families = set(
+                    family_fragment.choices
+                    if family_fragment.search_choices is None
+                    else family_fragment.search_choices
+                )
+
+                spec = ConfigSpec(backend=CuteBackend())
+                for block_id, target in enumerate((1, 128, 128)):
+                    spec.block_sizes.append(
+                        BlockSizeSpec(block_id=block_id, size_hint=target)
+                    )
+                spec.enable_cute_flash_search(
+                    head_dim=head_dim,
+                    num_kv=num_kv,
+                    block_size_targets={0: 1, 1: 128, 2: 128},
+                    dtype=dtype,
+                    is_causal=is_causal,
+                    requires_ws_overlap=requires_ws_overlap,
+                    standard_dense_output=standard_dense_output,
+                )
+                spec.compiler_seed_configs = list(
+                    flash_attention_seed_configs(
+                        head_dim,
+                        num_kv,
+                        dtype=dtype,
+                        is_causal=is_causal,
+                        requires_ws_overlap=requires_ws_overlap,
+                        standard_dense_output=standard_dense_output,
+                    )
+                )
+                config_gen = ConfigGeneration(spec)
+                normalized_seeds = [
+                    config for _flat, config in config_gen.seed_flat_config_pairs()
+                ]
+                self.assertLessEqual(len(normalized_seeds), 5)
+                self.assertLessEqual(
+                    legal_families,
+                    {
+                        config.config[FLASH_PIPELINE_FAMILY_KEY]
+                        for config in normalized_seeds
+                    },
+                )
+                for family in legal_families:
+                    family_gen = spec.create_config_generation(
+                        overrides={FLASH_PIPELINE_FAMILY_KEY: family}
+                    )
+                    family_default = family_gen.unflatten(family_gen.default_flat())
+                    self.assertIn(family_default, normalized_seeds)
+
+    def test_cute_flash_dense_degree1_seed_uses_family_defaults(self) -> None:
+        degree1_packets = {"deg1_8x2_corr10", "deg1_16x8"}
+        for num_kv in (256, 260, 512, 1024, 1536, 2044, 2048, 2052, 4096):
+            with self.subTest(num_kv=num_kv):
+                seeds = flash_attention_seed_configs(
+                    64,
+                    num_kv,
+                    dtype=torch.float16,
+                    standard_dense_output=True,
+                )
+                degree1_seeds = [
+                    seed
+                    for seed in seeds
+                    if seed.config.get(FLASH_EXP2_PACKET_KEY) in degree1_packets
+                ]
+                self.assertEqual(len(degree1_seeds), 1)
+                config = degree1_seeds[0].config
+                fragments = flash_autotune_fragments(
+                    64,
+                    num_kv,
+                    dtype=torch.float16,
+                    standard_dense_output=True,
+                    pipeline_family_override="fa4_2cta",
+                )
+
+                self.assertEqual(config[FLASH_PIPELINE_FAMILY_KEY], "fa4_2cta")
+                changed_keys = {FLASH_EXP2_PACKET_KEY, FLASH_E2E_SCHEDULE_KEY}
+                if num_kv < 2048:
+                    self.assertEqual(config[FLASH_EXP2_PACKET_KEY], "deg1_8x2_corr10")
+                    self.assertEqual(config[FLASH_E2E_SCHEDULE_KEY], "8/2")
+                    self.assertEqual(
+                        config[FLASH_E2E_OFFSET_KEY],
+                        fragments[FLASH_E2E_OFFSET_KEY].default(),
+                    )
+                    self.assertEqual(
+                        config[FLASH_E2E_OFFSET0_KEY],
+                        fragments[FLASH_E2E_OFFSET0_KEY].default(),
+                    )
+                else:
+                    self.assertEqual(config[FLASH_EXP2_PACKET_KEY], "deg1_16x8")
+                    self.assertEqual(config[FLASH_E2E_SCHEDULE_KEY], "16/8")
+                    self.assertEqual(config[FLASH_E2E_OFFSET_KEY], 0)
+                    self.assertEqual(config[FLASH_E2E_OFFSET0_KEY], 10)
+                    self.assertEqual(config[FLASH_KV_STAGE_KEY], 2)
+                    changed_keys.update(
+                        {
+                            FLASH_E2E_OFFSET_KEY,
+                            FLASH_E2E_OFFSET0_KEY,
+                            FLASH_KV_STAGE_KEY,
+                        }
+                    )
+
+                for key, fragment in fragments.items():
+                    if key not in changed_keys:
+                        self.assertEqual(config[key], fragment.default())
+                packet_fragment = fragments[FLASH_EXP2_PACKET_KEY]
+                self.assertIsInstance(packet_fragment, EnumFragment)
+                assert isinstance(packet_fragment, EnumFragment)
+                self.assertNotIn(
+                    config[FLASH_EXP2_PACKET_KEY],
+                    packet_fragment.search_choices or (),
+                )
+
+    def test_cute_flash_dense_degree1_seed_gates(self) -> None:
+        degree1_packets = {"deg1_8x2_corr10", "deg1_16x8"}
+
+        def has_degree1_seed(
+            head_dim: int = 64,
+            num_kv: int = 512,
+            **kwargs: object,
+        ) -> bool:
+            return any(
+                seed.config.get(FLASH_EXP2_PACKET_KEY) in degree1_packets
+                for seed in flash_attention_seed_configs(
+                    head_dim,
+                    num_kv,
+                    **kwargs,
+                )
+            )
+
+        cases = (
+            {"standard_dense_output": False},
+            {"standard_dense_output": True, "is_causal": True},
+            {"standard_dense_output": True, "dtype": torch.bfloat16},
+            {"standard_dense_output": True, "head_dim": 128},
+            {"standard_dense_output": True, "has_kv_tile_pruning": True},
+            {"standard_dense_output": True, "requires_ws_overlap": True},
+            {"standard_dense_output": True, "small_biased_candidate": True},
+            {
+                "standard_dense_output": True,
+                "block_size_targets": (1, 64, 128),
+            },
+            {"standard_dense_output": True, "num_kv": 252},
+            {"standard_dense_output": True, "num_kv": 258},
+            {"standard_dense_output": True, "num_kv": 2050},
+        )
+        for case in cases:
+            subtest_case = {
+                key: str(value) if isinstance(value, torch.dtype) else value
+                for key, value in case.items()
+            }
+            with self.subTest(case=subtest_case):
+                case = dict(case)
+                head_dim = int(case.pop("head_dim", 64))
+                num_kv = int(case.pop("num_kv", 512))
+                self.assertFalse(has_degree1_seed(head_dim, num_kv, **case))
+
+    def test_cute_flash_long_causal_hybrid_seed(self) -> None:
+        for num_kv in (512, 4096, 8192):
+            with self.subTest(num_kv=num_kv):
+                seeds = flash_attention_seed_configs(
+                    64,
+                    num_kv,
+                    is_causal=True,
+                    standard_causal_output=True,
+                )
+                hybrid = [
+                    seed
+                    for seed in seeds
+                    if seed.config.get(FLASH_EXP2_PACKET_KEY) == "hybrid_deg1_16x8"
+                ]
+                self.assertEqual(len(hybrid), 1)
+                config = hybrid[0].config
+                self.assertEqual(config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
+                self.assertEqual(config[FLASH_E2E_SCHEDULE_KEY], "16/8")
+                self.assertEqual(config[FLASH_MASKED_E2E_SCHEDULE_KEY], "16/8")
+                self.assertTrue(config[FLASH_CAUSAL_LOOP_SPLIT_KEY])
+
+        for num_kv in (256, 768):
+            with self.subTest(num_kv=num_kv):
+                self.assertFalse(
+                    any(
+                        seed.config.get(FLASH_EXP2_PACKET_KEY) == "hybrid_deg1_16x8"
+                        for seed in flash_attention_seed_configs(
+                            64,
+                            num_kv,
+                            is_causal=True,
+                            standard_causal_output=True,
+                        )
+                    )
+                )
+
+        spec = ConfigSpec(backend=CuteBackend())
+        for block_id, target in enumerate((1, 128, 128)):
+            spec.block_sizes.append(BlockSizeSpec(block_id=block_id, size_hint=target))
+        spec.enable_cute_flash_search(
+            head_dim=64,
+            num_kv=8192,
+            block_size_targets={0: 1, 1: 128, 2: 128},
+            dtype=torch.float16,
+            is_causal=True,
+            standard_causal_output=True,
+        )
+        spec.compiler_seed_configs = list(
+            flash_attention_seed_configs(
+                64,
+                8192,
+                is_causal=True,
+                standard_causal_output=True,
+            )
+        )
+        normalized = [
+            config for _flat, config in ConfigGeneration(spec).seed_flat_config_pairs()
+        ]
+        self.assertEqual(len(normalized), 4)
+        self.assertEqual(
+            {
+                (
+                    config.config[FLASH_PIPELINE_FAMILY_KEY],
+                    config.config[FLASH_EXP2_PACKET_KEY],
+                )
+                for config in normalized
+            },
+            {
+                ("fa4", "1x1"),
+                ("fa4", "4x1"),
+                ("fa4", "hybrid_deg1_16x8"),
+                ("ws_overlap", "1x1"),
+            },
+        )
 
     @onlyBackends(["cute"])
     def test_cute_flash_attention_seed_heuristic(self) -> None:
@@ -2247,6 +2572,10 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertNotIn(FLASH_E2E_OFFSET_KEY, seed.config)
         self.assertIn(seed, bound.config_spec.compiler_seed_configs)
         self.assertIsNone(bound.config_spec.compiler_default_config)
+        self.assertEqual(
+            bound.config_spec.compiler_seed_timeout_retry_repetitions,
+            3,
+        )
 
         bf16_args = tuple(
             torch.empty(1, 1, 49152, 64, dtype=torch.bfloat16, device=DEVICE)
@@ -2387,6 +2716,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             for _ in range(3)
         )
         causal_65536_bound = causal_flash_attn.bind(causal_65536_args)
+        self.assertTrue(
+            causal_65536_bound.config_spec._cute_flash_standard_causal_output
+        )
         self.assertIn(
             CuteFlashAttentionCausalLptHeuristic.name,
             causal_65536_bound.config_spec.autotuner_heuristics,
@@ -2403,6 +2735,31 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertIn(
             causal_65536_seed, causal_65536_bound.config_spec.compiler_seed_configs
         )
+        hybrid_seeds = [
+            seed
+            for seed in causal_65536_bound.config_spec.compiler_seed_configs
+            if seed.config.get(FLASH_EXP2_PACKET_KEY) == "hybrid_deg1_16x8"
+        ]
+        self.assertEqual(len(hybrid_seeds), 1)
+        with patch.object(
+            PatternSearch,
+            "_find_similar_cached_configs",
+            return_value=[],
+        ):
+            quick_search = PatternSearch(
+                causal_65536_bound,
+                causal_65536_args,
+                initial_population=30,
+                initial_population_strategy=(
+                    InitialPopulationStrategy.FROM_BEST_AVAILABLE
+                ),
+                best_available_pad_random=False,
+            )
+            quick_configs = [
+                quick_search.config_gen.unflatten(flat)
+                for flat in quick_search._generate_initial_population_flat()
+            ]
+        self.assertEqual(len(quick_configs), 4)
         self.assertIsNone(causal_65536_bound.config_spec.compiler_default_config)
         causal_65536_gen = ConfigGeneration(causal_65536_bound.config_spec)
         causal_65536_default = causal_65536_gen.unflatten(

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -42,6 +42,7 @@ from helion.autotuner.benchmark_worker import BenchmarkSubprocessError
 from helion.autotuner.benchmark_worker import BenchmarkTimeout
 from helion.autotuner.benchmark_worker import BenchmarkWorker
 from helion.autotuner.benchmark_worker import BenchmarkWorkerDied
+from helion.autotuner.benchmarking import do_bench_generic
 from helion.autotuner.kernel_args import load_trusted_kernel_args
 from helion.autotuner.metrics import AutotuneMetrics
 from helion.autotuner.precompile_future import SerializedCompiledFunction
@@ -237,6 +238,59 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         load_args.assert_called_once_with("/tmp/args.pt")
         event_bench.assert_not_called()
         wall_clock_bench.assert_called_once()
+        self.assertNotIn("fixed_repetitions", wall_clock_bench.call_args.kwargs)
+
+    def test_wall_clock_fixed_repetitions_run_setup_and_measurements(self) -> None:
+        invocation_count = 0
+
+        def fn() -> None:
+            nonlocal invocation_count
+            invocation_count += 1
+
+        with (
+            patch("helion.autotuner.benchmarking.synchronize_device"),
+            patch(
+                "helion.autotuner.benchmarking._make_l2_cache_clearer",
+                return_value=lambda: None,
+            ),
+        ):
+            result = do_bench_generic(
+                fn,
+                warmup=1,
+                rep=50,
+                return_mode="median",
+                fixed_repetitions=3,
+            )
+
+        self.assertEqual(invocation_count, 4)
+        self.assertTrue(math.isfinite(cast("float", result)))
+
+    def test_benchmark_job_forwards_fixed_repetitions(self) -> None:
+        fn = _ReturnValue(torch.empty(()))
+
+        with (
+            patch(
+                "helion.autotuner.benchmark_job._load_compiled_fn",
+                return_value=fn,
+            ),
+            patch(
+                "helion.autotuner.benchmark_job.load_trusted_kernel_args",
+                return_value=(),
+            ),
+            patch(
+                "helion.autotuner.benchmark_job.do_bench_generic",
+                return_value=1.25,
+            ) as wall_clock_bench,
+        ):
+            result = BenchmarkJob(
+                fn_spec=cast("SerializedCompiledFunction", object()),
+                args_path="/tmp/args.pt",
+                use_wall_clock=True,
+                fixed_repetitions=1,
+            )()
+
+        self.assertEqual(result, 1.25)
+        self.assertEqual(wall_clock_bench.call_args.kwargs["fixed_repetitions"], 1)
 
     def test_benchmark_job_unloads_module_after_failure(self) -> None:
         fn = _ReturnValue(torch.empty(()))
@@ -388,6 +442,9 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
 
     def test_benchmark_timeout_has_worker_metric_and_status(self) -> None:
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.config_spec = SimpleNamespace(
+            compiler_seed_timeout_retry_repetitions=None
+        )
         provider.log = Mock()
         provider._autotune_metrics = AutotuneMetrics()
         provider._worker_failure_config_ids = []
@@ -396,7 +453,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
             provider,
             "_run_subprocess_benchmark_job",
             side_effect=BenchmarkTimeout("timed out"),
-        ):
+        ) as run_job:
             result = provider._benchmark_function_subprocess(
                 Config(), cast("CompiledConfig", object())
             )
@@ -405,9 +462,132 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         self.assertEqual(provider._last_benchmark_failure_status, "timeout")
         self.assertEqual(provider._autotune_metrics.num_worker_failures, 1)
         self.assertEqual(provider._autotune_metrics.num_compile_failures, 0)
+        run_job.assert_called_once()
+
+    def test_compiler_seed_timeout_retries_with_three_repetitions(self) -> None:
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.settings = Settings(autotune_accuracy_check=False)
+        provider.config_spec = SimpleNamespace(
+            compiler_seed_timeout_retry_repetitions=3
+        )
+        provider.log = Mock()
+        provider._autotune_metrics = AutotuneMetrics()
+        fn = cast("CompiledConfig", object())
+        config = Config()
+        provider.set_compiler_seed_configs([config])
+
+        with patch.object(
+            provider,
+            "_run_subprocess_benchmark_job",
+            side_effect=(BenchmarkTimeout("timed out"), 2.75),
+        ) as run_job:
+            result = provider._benchmark_function_subprocess(
+                config,
+                fn,
+            )
+
+        self.assertEqual(result, 2.75)
+        self.assertEqual(
+            run_job.call_args_list,
+            [
+                unittest.mock.call(fn, warmup=1, rep=50),
+                unittest.mock.call(
+                    fn,
+                    warmup=1,
+                    rep=50,
+                    fixed_repetitions=3,
+                ),
+            ],
+        )
+        self.assertEqual(provider._autotune_metrics.num_worker_failures, 0)
+
+    def test_compiler_seed_retry_timeout_is_one_worker_failure(self) -> None:
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.config_spec = SimpleNamespace(
+            compiler_seed_timeout_retry_repetitions=3
+        )
+        provider.log = Mock()
+        provider._autotune_metrics = AutotuneMetrics()
+        provider._worker_failure_config_ids = []
+        config = Config()
+        provider.set_compiler_seed_configs([config])
+
+        with patch.object(
+            provider,
+            "_run_subprocess_benchmark_job",
+            side_effect=(
+                BenchmarkTimeout("first timeout"),
+                BenchmarkTimeout("retry timeout"),
+            ),
+        ) as run_job:
+            result = provider._benchmark_function_subprocess(
+                config,
+                cast("CompiledConfig", object()),
+            )
+
+        self.assertEqual(result, math.inf)
+        self.assertEqual(run_job.call_count, 2)
+        self.assertEqual(provider._last_benchmark_failure_status, "timeout")
+        self.assertEqual(provider._autotune_metrics.num_worker_failures, 1)
+        self.assertEqual(provider._autotune_metrics.num_compile_failures, 0)
+
+    def test_compiler_seed_timeout_does_not_retry_after_budget(self) -> None:
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.config_spec = SimpleNamespace(
+            compiler_seed_timeout_retry_repetitions=3
+        )
+        provider.log = Mock()
+        provider._autotune_metrics = AutotuneMetrics()
+        provider._worker_failure_config_ids = []
+        provider.budget_exceeded_fn = Mock(return_value=True)
+        config = Config()
+        provider.set_compiler_seed_configs([config])
+
+        with patch.object(
+            provider,
+            "_run_subprocess_benchmark_job",
+            side_effect=BenchmarkTimeout("timed out"),
+        ) as run_job:
+            result = provider._benchmark_function_subprocess(
+                config,
+                cast("CompiledConfig", object()),
+            )
+
+        self.assertEqual(result, math.inf)
+        run_job.assert_called_once()
+        provider.budget_exceeded_fn.assert_called_once_with()
+        self.assertEqual(provider._last_benchmark_failure_status, "timeout")
+
+    def test_disabled_compiler_seed_timeout_retry_does_not_run(self) -> None:
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.config_spec = SimpleNamespace(
+            compiler_seed_timeout_retry_repetitions=None
+        )
+        provider.log = Mock()
+        provider._autotune_metrics = AutotuneMetrics()
+        provider._worker_failure_config_ids = []
+        config = Config()
+        provider.set_compiler_seed_configs([config])
+
+        with patch.object(
+            provider,
+            "_run_subprocess_benchmark_job",
+            side_effect=BenchmarkTimeout("timed out"),
+        ) as run_job:
+            result = provider._benchmark_function_subprocess(
+                config,
+                cast("CompiledConfig", object()),
+            )
+
+        self.assertEqual(result, math.inf)
+        run_job.assert_called_once()
+        self.assertEqual(provider._last_benchmark_failure_status, "timeout")
 
     def test_benchmark_worker_death_has_error_status(self) -> None:
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.config_spec = SimpleNamespace(
+            compiler_seed_timeout_retry_repetitions=None
+        )
         provider.log = Mock()
         provider._autotune_metrics = AutotuneMetrics()
         provider._worker_failure_config_ids = []
@@ -416,7 +596,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
             provider,
             "_run_subprocess_benchmark_job",
             side_effect=BenchmarkWorkerDied("worker exited"),
-        ):
+        ) as run_job:
             result = provider._benchmark_function_subprocess(
                 Config(), cast("CompiledConfig", object())
             )
@@ -425,6 +605,32 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         self.assertEqual(provider._last_benchmark_failure_status, "error")
         self.assertEqual(provider._autotune_metrics.num_worker_failures, 1)
         self.assertEqual(provider._autotune_metrics.num_compile_failures, 0)
+        run_job.assert_called_once()
+
+    def test_fixed_repetition_job_uses_existing_benchmark_timeout(self) -> None:
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.settings = Settings(autotune_benchmark_timeout=17)
+        provider._precompile_args_path = "/tmp/args.pt"
+        provider._benchmark_worker = Mock()
+        provider._benchmark_worker.run.return_value = 1.25
+        provider._subprocess_benchmark_uses_wall_clock = lambda: True
+
+        with patch(
+            "helion.autotuner.benchmark_provider._serialize_compiled_fn",
+            return_value=cast("SerializedCompiledFunction", object()),
+        ):
+            result = provider._run_subprocess_benchmark_job(
+                cast("CompiledConfig", object()),
+                warmup=1,
+                rep=50,
+                fixed_repetitions=3,
+            )
+
+        self.assertEqual(result, 1.25)
+        provider._benchmark_worker.run.assert_called_once()
+        job = provider._benchmark_worker.run.call_args.args[0]
+        self.assertEqual(job.fixed_repetitions, 3)
+        self.assertEqual(provider._benchmark_worker.run.call_args.kwargs["timeout"], 17)
 
     def test_subprocess_accuracy_check_skips_mutated_args(self) -> None:
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -3237,10 +3237,11 @@ class TestCuteBackend(TestCase):
             (131072, "deg1_8x2_corr10", 2, 1),
             (196608, "deg1_8x2_corr10", 2, 1),
             (262144, "deg1_16x8", 0, 10),
+            (262656, "deg1_16x8", 0, 10),
         )
         for sequence_length, packet, offset, offset0 in cases:
             with self.subTest(sequence_length=sequence_length):
-                torch.manual_seed(20260728 + sequence_length)
+                torch.manual_seed(1000 + sequence_length)
                 q, k, v = (
                     torch.randn(
                         1,
@@ -3252,18 +3253,64 @@ class TestCuteBackend(TestCase):
                     )
                     for _ in range(3)
                 )
+                config: dict[str, object] = {
+                    "block_sizes": [1, 128, 128],
+                    "cute_flash_pipeline_family": "fa4_2cta",
+                    "cute_flash_exp2_packet": packet,
+                    "cute_flash_e2e_offset": offset,
+                    "cute_flash_e2e_offset0": offset0,
+                }
+                if packet == "deg1_16x8":
+                    config["cute_flash_kv_stage"] = 2
                 code, out = code_and_output(
                     cute_dense_attention,
                     (q, k, v),
-                    block_sizes=[1, 128, 128],
-                    cute_flash_pipeline_family="fa4_2cta",
-                    cute_flash_exp2_packet=packet,
-                    cute_flash_e2e_offset=offset,
-                    cute_flash_e2e_offset0=offset0,
+                    **config,
                 )
+                self.assertIn("is_two_cta=True", code)
                 self.assertIn("degree1=True", code)
                 expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
                 torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)
+
+    def test_flash_attention_dense_degree1_seed_requires_standard_output(self) -> None:
+        target = torch.empty(1, 1, 262_144, 64, dtype=torch.float16, device=DEVICE)
+        cases = (
+            (cute_dense_attention, True),
+            (cute_dense_attention_with_lse, False),
+            (cute_softcap_attention, False),
+        )
+        for kernel, expected_standard in cases:
+            with self.subTest(kernel=kernel.__name__):
+                bound = kernel.bind((target, target, target))
+                self.assertEqual(
+                    bound.config_spec._cute_flash_standard_dense_output,
+                    expected_standard,
+                )
+                has_degree1_seed = any(
+                    seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY)
+                    in {"deg1_8x2_corr10", "deg1_16x8"}
+                    for seed in bound.config_spec.compiler_seed_configs
+                )
+                self.assertEqual(has_degree1_seed, expected_standard)
+
+    def test_flash_attention_hybrid_seed_excludes_auxiliary_outputs(self) -> None:
+        target = torch.empty(1, 1, 65_536, 64, dtype=torch.float16, device=DEVICE)
+        slopes = torch.empty(1, dtype=torch.float32, device=DEVICE)
+        cases = (
+            (cute_causal_attention, (target, target, target)),
+            (cute_alibi_attention, (target, target, target, slopes)),
+        )
+        for kernel, args in cases:
+            with self.subTest(kernel=kernel.__name__):
+                bound = kernel.bind(args)
+                self.assertFalse(bound.config_spec._cute_flash_standard_causal_output)
+                self.assertFalse(
+                    any(
+                        seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY)
+                        == "hybrid_deg1_16x8"
+                        for seed in bound.config_spec.compiler_seed_configs
+                    )
+                )
 
     def test_flash_attention_bias_fires_and_matches_sdpa(self) -> None:
         q, k, v = (
@@ -4666,7 +4713,23 @@ class TestCuteBackend(TestCase):
             dense_unaligned = resolve_flash_config(64, 258, force_two_cta)
             dense_256k = resolve_flash_config(64, 2048, force_two_cta)
             dense_midrange = resolve_flash_config(64, 1536, force_two_cta)
-            dense_above_range = resolve_flash_config(64, 2052, force_two_cta)
+            dense_long = resolve_flash_config(64, 2052, force_two_cta)
+            dense_long_unaligned = resolve_flash_config(64, 2050, force_two_cta)
+            dense_long_seed = next(
+                seed
+                for seed in _cute_flash.flash_attention_seed_configs(
+                    64,
+                    2052,
+                    standard_dense_output=True,
+                )
+                if seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY) == "deg1_16x8"
+            )
+            dense_long_degree1 = resolve_flash_config(
+                64,
+                2052,
+                dense_long_seed.config,
+                standard_dense_output=True,
+            )
             dense_bf16 = resolve_flash_config(
                 64, 512, force_two_cta, dtype=torch.bfloat16
             )
@@ -4691,8 +4754,20 @@ class TestCuteBackend(TestCase):
         self.assertEqual(dense_256k.pipeline_family, "fa4_2cta")
         self.assertTrue(dense_midrange.use_2cta_instrs)
         self.assertEqual(dense_midrange.pipeline_family, "fa4_2cta")
-        self.assertFalse(dense_above_range.use_2cta_instrs)
-        self.assertEqual(dense_above_range.pipeline_family, "fa4")
+        self.assertTrue(dense_long.use_2cta_instrs)
+        self.assertEqual(dense_long.pipeline_family, "fa4_2cta")
+        self.assertTrue(dense_long_degree1.use_2cta_instrs)
+        self.assertEqual(dense_long_degree1.pipeline_family, "fa4_2cta")
+        self.assertEqual(dense_long_degree1.exp2_packet, "deg1_16x8")
+        self.assertTrue(
+            _cute_flash._flash_disc_exp2_codegen_params(
+                dense_long_degree1.exp2_packet,
+                dense_long_degree1.e2e_freq,
+                dense_long_degree1.e2e_res,
+            ).degree1_unmasked
+        )
+        self.assertFalse(dense_long_unaligned.use_2cta_instrs)
+        self.assertEqual(dense_long_unaligned.pipeline_family, "fa4")
         self.assertFalse(dense_bf16.use_2cta_instrs)
         self.assertEqual(dense_bf16.pipeline_family, "fa4")
         self.assertFalse(causal.use_2cta_instrs)
@@ -4736,10 +4811,17 @@ class TestCuteBackend(TestCase):
             eligible_midrange[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices
             or (),
         )
-        ineligible_above_range = _cute_flash.flash_autotune_fragments(64, 2052)
+        eligible_long = _cute_flash.flash_autotune_fragments(64, 2052)
+        self.assertIn(
+            "fa4_2cta",
+            eligible_long[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices or (),
+        )
+        ineligible_long_unaligned = _cute_flash.flash_autotune_fragments(64, 2050)
         self.assertNotIn(
             "fa4_2cta",
-            ineligible_above_range[_cute_flash.FLASH_PIPELINE_FAMILY_KEY].search_choices
+            ineligible_long_unaligned[
+                _cute_flash.FLASH_PIPELINE_FAMILY_KEY
+            ].search_choices
             or (),
         )
 
@@ -9866,7 +9948,7 @@ class TestCuteConfigValuePriors(TestCase):
             {8.0, 16.0, 32.0},
         )
         for key, values in {
-            FLASH_PIPELINE_FAMILY_KEY: {"fa4", "ws_overlap"},
+            FLASH_PIPELINE_FAMILY_KEY: {"fa4", "ws_overlap", "fa4_2cta"},
             FLASH_E2E_SCHEDULE_KEY: {"8/2", "16/4"},
             FLASH_E2E_OFFSET_KEY: {0},
             FLASH_E2E_OFFSET0_KEY: {1},

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -96,6 +96,33 @@ def _manual_config(
     return config
 
 
+def _hybrid_runtime_config() -> dict[str, object]:
+    return {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_pipeline_family": "fa4",
+        "cute_flash_s_stage": 2,
+        "cute_flash_kv_stage": 2,
+        "cute_flash_persistent": False,
+        "cute_flash_e2e_schedule": "16/8",
+        "cute_flash_masked_e2e_schedule": "16/8",
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 10,
+        "cute_flash_disc_pipe": 3,
+        "cute_flash_exp2_packet": _HYBRID_PACKET,
+        "cute_flash_wait_hint": 10_000_000,
+        "cute_flash_p_store_rep": 16,
+        "cute_flash_s_load_rep": 32,
+        "cute_flash_epi_tma": False,
+        "cute_flash_epi_stg": False,
+        "cute_flash_role_map": "helion",
+        "cute_flash_rescale_chunk_cols": 16,
+        "cute_flash_causal_loop_split": True,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_causal_kv_order": "descending",
+        "cute_flash_softmax_regs": 184,
+    }
+
+
 def test_degree2_polynomial_relative_error_bound() -> None:
     x = torch.linspace(0.0, 1.0, 100_001, dtype=torch.float32)
     c0, c1, c2 = _flash_runtime._POLY_EX2_DEG2
@@ -373,7 +400,7 @@ def test_short_degree1_packet_reverses_steady_correction_order(
 
 @onlyBackends(["cute"])
 def test_hybrid_packet_runtime_matches_sdpa_at_causal_boundaries() -> None:
-    torch.manual_seed(20260810)
+    torch.manual_seed(101)
     q, k, v = (
         torch.randn(1, 2, 1024, 64, dtype=torch.float16, device=DEVICE)
         for _ in range(3)
@@ -386,27 +413,7 @@ def test_hybrid_packet_runtime_matches_sdpa_at_causal_boundaries() -> None:
     code, out = code_and_output(
         _causal_attention_output,
         (q, k, v),
-        block_sizes=[1, 128, 128],
-        cute_flash_pipeline_family="fa4",
-        cute_flash_s_stage=2,
-        cute_flash_kv_stage=2,
-        cute_flash_persistent=False,
-        cute_flash_e2e_schedule="16/8",
-        cute_flash_masked_e2e_schedule="16/8",
-        cute_flash_e2e_offset=0,
-        cute_flash_e2e_offset0=10,
-        cute_flash_disc_pipe=3,
-        cute_flash_exp2_packet=_HYBRID_PACKET,
-        cute_flash_wait_hint=10_000_000,
-        cute_flash_p_store_rep=16,
-        cute_flash_s_load_rep=32,
-        cute_flash_epi_tma=False,
-        cute_flash_epi_stg=False,
-        cute_flash_role_map="helion",
-        cute_flash_causal_loop_split=True,
-        cute_flash_causal_lpt_swizzle=0,
-        cute_flash_causal_kv_order="descending",
-        cute_flash_softmax_regs=184,
+        **_hybrid_runtime_config(),
     )
     assert "degree1=True" in code
     assert "degree2=True" in code
@@ -419,6 +426,46 @@ def test_hybrid_packet_runtime_matches_sdpa_at_causal_boundaries() -> None:
         atol=0.05,
         rtol=0.02,
     )
+
+
+@onlyBackends(["cute"])
+def test_hybrid_packet_runtime_matches_sdpa_at_long_causal_threshold() -> None:
+    torch.manual_seed(102)
+    q, k, v = (
+        torch.randn(1, 1, 65_536, 64, dtype=torch.float16, device=DEVICE)
+        for _ in range(3)
+    )
+    q[:, :, 0, :] = 4.0
+    k[:, :, 0, :] = 4.0
+    q[:, :, 32_768, :] = -4.0
+    k[:, :, 32_768, :] = -4.0
+
+    _code, out = code_and_output(
+        _causal_attention_output,
+        (q, k, v),
+        **_hybrid_runtime_config(),
+    )
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+    torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)
+
+
+@onlyBackends(["cute"])
+def test_hybrid_packet_runtime_matches_sdpa_beyond_previous_seed_cap() -> None:
+    torch.manual_seed(103)
+    q, k, v = (
+        torch.randn(1, 1, 1_048_576, 64, dtype=torch.float16, device=DEVICE)
+        for _ in range(3)
+    )
+
+    code, out = code_and_output(
+        _causal_attention_output,
+        (q, k, v),
+        **_hybrid_runtime_config(),
+    )
+    assert "degree1=True" in code
+    assert "degree2=True" in code
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+    torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)
 
 
 def test_degree2_packet_normalizes_by_effective_schedule() -> None:

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -1353,6 +1353,9 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
             def __init__(self, **kwargs) -> None:
                 self.kwargs = kwargs
 
+            def set_compiler_seed_configs(self, configs) -> None:
+                pass
+
             def set_budget_exceeded_fn(self, fn) -> None:
                 pass
 
@@ -1415,7 +1418,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
 
         kernel = SimpleNamespace(
             settings=Settings(),
-            config_spec=SimpleNamespace(),
+            config_spec=SimpleNamespace(compiler_seed_timeout_retry_repetitions=None),
             env=SimpleNamespace(device=DEVICE, process_group_name=None),
         )
         args = (torch.randn([8], device=DEVICE),)
@@ -1607,6 +1610,9 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
             def __init__(self, **kwargs) -> None:
                 self.kwargs = kwargs
 
+            def set_compiler_seed_configs(self, configs) -> None:
+                pass
+
             def set_budget_exceeded_fn(self, fn) -> None:
                 pass
 
@@ -1626,7 +1632,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
 
         kernel = SimpleNamespace(
             settings=Settings(),
-            config_spec=SimpleNamespace(),
+            config_spec=SimpleNamespace(compiler_seed_timeout_retry_repetitions=None),
             env=SimpleNamespace(device=DEVICE, process_group_name=None),
         )
         args = (torch.randn([8], device=DEVICE),)

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -471,6 +471,8 @@ class _FakeBoundKernel:
         accuracy_failure_indices: list[int] | None = None,
         compile_failure_indices: list[int] | None = None,
         worker_failure_indices: list[int] | None = None,
+        unique_sources: int = 0,
+        source_deduplications: int = 0,
     ) -> None:
         self.config_spec = config_spec
         self.settings = SimpleNamespace(
@@ -488,6 +490,8 @@ class _FakeBoundKernel:
         self.accuracy_failures = len(self.accuracy_failure_indices)
         self.compile_failures = len(self.compile_failure_indices)
         self.worker_failures = len(self.worker_failure_indices)
+        self.unique_sources = unique_sources
+        self.source_deduplications = source_deduplications
 
 
 class _FakeLocalBenchmarkProvider:
@@ -511,6 +515,7 @@ class _FakeLocalBenchmarkProvider:
         self._compile_failure_config_ids: list[int] = []
         self._worker_failure_config_ids: list[int] = []
         self.benchmark_calls: list[tuple[list[Config], str]] = []
+        self.compiler_seed_config_calls: list[list[Config]] = []
         self.setup_count = 0
         self.cleanup_count = 0
         self.budget_exceeded_fn: Callable[[], bool] = lambda: False
@@ -518,6 +523,9 @@ class _FakeLocalBenchmarkProvider:
 
     def set_budget_exceeded_fn(self, fn: Callable[[], bool]) -> None:
         self.budget_exceeded_fn = fn
+
+    def set_compiler_seed_configs(self, configs: Sequence[Config]) -> None:
+        self.compiler_seed_config_calls.append(list(configs))
 
     def setup(self) -> None:
         self.setup_count += 1
@@ -534,6 +542,10 @@ class _FakeLocalBenchmarkProvider:
         self._autotune_metrics.num_accuracy_failures += self.kernel.accuracy_failures
         self._autotune_metrics.num_compile_failures += self.kernel.compile_failures
         self._autotune_metrics.num_worker_failures += self.kernel.worker_failures
+        self._autotune_metrics.num_unique_sources += self.kernel.unique_sources
+        self._autotune_metrics.num_source_deduplications += (
+            self.kernel.source_deduplications
+        )
         self._accuracy_failure_config_ids.extend(
             id(config)
             for index, config in enumerate(configs)
@@ -629,6 +641,58 @@ class TestMultiShapeBenchmarkProvider(unittest.TestCase):
             self.assertEqual(desc, f"joint shape {index + 1}")
             self.assertEqual(received[0].block_sizes, [64])
             self.assertIsNot(received[0], configs[0])
+
+    def test_deduplicated_child_result_is_successful(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [1.0], statuses=["deduplicated"]),
+                _FakeBoundKernel(spec, [4.0]),
+            ],
+            relative_to="default",
+            references=(0.5, 2.0),
+        )
+        config = Config(block_sizes=[64])
+
+        result = provider.benchmark([config])[0]
+
+        self.assertEqual(result.perf, 2.0)
+        self.assertEqual(result.status, "ok")
+        summary = _format_selected_multi_shape_measurement(
+            provider.args, _materialize_multi_shape_config(spec, config)
+        )
+        assert summary is not None
+        self.assertIn("latency=1.000000 ms, status=deduplicated", summary)
+        self.assertIn("ratio=2.000000x", summary)
+
+    def test_deduplicated_default_reference_is_successful(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [
+                _FakeBoundKernel(spec, [1.0], statuses=["deduplicated"]),
+                _FakeBoundKernel(spec, [4.0]),
+            ],
+            relative_to="default",
+        )
+
+        provider.setup()
+
+        self.assertEqual(provider.args.reference_latencies, (1.0, 4.0))
+
+    def test_compiler_seed_configs_are_forwarded_to_children(self) -> None:
+        spec = _make_config_spec()
+        provider, _ = self._make_provider(
+            [_FakeBoundKernel(spec, [1.0]), _FakeBoundKernel(spec, [2.0])]
+        )
+        configs = [Config(block_sizes=[64]), Config(block_sizes=[128])]
+
+        provider.set_compiler_seed_configs(configs)
+
+        children = cast("list[_FakeLocalBenchmarkProvider]", provider.children)
+        self.assertEqual(
+            [child.compiler_seed_config_calls for child in children],
+            [[configs], [configs]],
+        )
 
     def test_raw_and_relative_max_choose_different_configs(self) -> None:
         spec = _make_config_spec()
@@ -777,6 +841,24 @@ class TestMultiShapeBenchmarkProvider(unittest.TestCase):
         self.assertEqual(metrics.num_accuracy_failures, 3)
         self.assertEqual(metrics.num_compile_failures, 2)
         self.assertEqual(metrics.num_worker_failures, 3)
+
+    def test_source_metrics_sum_child_deltas(self) -> None:
+        spec = _make_config_spec()
+        provider, metrics = self._make_provider(
+            [
+                _FakeBoundKernel(
+                    spec, [1.0], unique_sources=2, source_deduplications=1
+                ),
+                _FakeBoundKernel(
+                    spec, [2.0], unique_sources=3, source_deduplications=4
+                ),
+            ]
+        )
+
+        provider.benchmark([Config(block_sizes=[64])])
+
+        self.assertEqual(metrics.num_unique_sources, 5)
+        self.assertEqual(metrics.num_source_deduplications, 5)
 
     def test_invalid_anchor_materialization_discards_only_one_config(self) -> None:
         spec = _make_config_spec()
@@ -1223,7 +1305,7 @@ class TestMultiShapeLLMSeeded(unittest.TestCase):
         )
 
         for second_stage in invalid_second_stages:
-            with self.subTest(config=second_stage.config):
+            with self.subTest(has_config=second_stage.config is not None):
                 search, seeded = self._make_search(
                     _StageSearch(winner, 0.6, 2), second_stage
                 )


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3232
 * #3231
 * #3230
 * #3229


--- --- ---

[cutedsl] Seed flash autotuning across legal families

Detect standard output-only flash graphs before enabling specialized arithmetic seeds. Add one dependency-consistent anchor for every legal pipeline family, along with guarded dense and causal incumbents.

Keep fixed-family normalization private to ConfigGeneration so ordinary autotuner APIs and non-flash search domains remain unchanged.