### PR TITLE
[pallas] Emit a valid literal for a non-finite constant_pad_nd fill

### DIFF
--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -10,6 +10,7 @@ imports it at the bottom so registration keeps the same eager timing as before.
 from __future__ import annotations
 
 import ast
+import math
 from operator import getitem
 from typing import TYPE_CHECKING
 from typing import cast
@@ -79,6 +80,21 @@ def codegen_view_pallas(ctx: LoweringContext, node: Node) -> object:
     return expr_from_string(f"jnp.reshape({{tensor}}, {shape_str})", tensor=tensor)
 
 
+def _pad_fill_literal(value: object) -> str:
+    """Render a ``constant_pad_nd`` fill value as valid Python source.
+
+    ``repr()`` is wrong for the non-finite floats: it yields bare ``inf`` /
+    ``-inf`` / ``nan``, which are not names in the generated module (the
+    artifact raises ``NameError: name 'inf' is not defined``). Spell those as
+    ``float('inf')`` etc., which is valid in any module and needs no import.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        # repr() of the value is itself the bare name (``-inf``), so quote the
+        # str() form: float('-inf') / float('inf') / float('nan').
+        return f"float({str(value)!r})"
+    return repr(value)
+
+
 @constant_pad_nd_lowering.register_codegen("pallas")
 def codegen_constant_pad_nd_pallas(ctx: LoweringContext, node: Node) -> object:
     """``F.pad(x, pad, value)`` (aten.constant_pad_nd) -> inline ``jnp.pad``.
@@ -104,7 +120,7 @@ def codegen_constant_pad_nd_pallas(ctx: LoweringContext, node: Node) -> object:
     ]
     pw = "(" + ", ".join(f"({lo}, {hi})" for lo, hi in pad_width) + ")"
     return expr_from_string(
-        f"jnp.pad({{t}}, {pw}, mode='constant', constant_values={value!r})",
+        f"jnp.pad({{t}}, {pw}, mode='constant', constant_values={_pad_fill_literal(value)})",
         t=tensor,
     )
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -698,6 +698,19 @@ def _constant_pad_pallas_kernel(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="pallas", static_shapes=True)
+def _constant_pad_neg_inf_pallas_kernel(x: torch.Tensor) -> torch.Tensor:
+    """F.pad with a non-finite fill. repr(-inf) is the bare name ``-inf``, which
+    is undefined in the generated module, so this must emit ``float('-inf')``."""
+    rows, cols = x.shape
+    out = torch.empty([rows, cols + 128], dtype=x.dtype, device=x.device)
+    for tile in hl.tile(rows):
+        out[tile, :] = torch.nn.functional.pad(
+            x[tile, :], (0, 128), value=float("-inf")
+        )
+    return out
+
+
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
@@ -1013,6 +1026,25 @@ class TestPallas(TestCase):
         self.assertIn("jnp.pad", code)
         expected = torch.nn.functional.pad(x, (0, 128), value=0.0)
         torch.testing.assert_close(result, expected)
+
+    def test_constant_pad_nd_non_finite_fill(self) -> None:
+        """A non-finite fill must be emitted as ``float('-inf')``.
+
+        ``repr(float('-inf'))`` is ``-inf``, which parses as a negated *name*;
+        emitting it verbatim made the artifact raise ``NameError: name 'inf' is
+        not defined`` at run time.
+        """
+        for dtype in (torch.float32, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                torch.manual_seed(0)
+                x = torch.randn(16, 128, device=DEVICE, dtype=dtype)
+                code, result = code_and_output(
+                    _constant_pad_neg_inf_pallas_kernel, (x,), block_sizes=[8]
+                )
+                self.assertIn("float('-inf')", code)
+                self.assertNotIn("constant_values=-inf", code)
+                expected = torch.nn.functional.pad(x, (0, 128), value=float("-inf"))
+                torch.testing.assert_close(result, expected)
 
     def test_store_slice_1d(self) -> None:
         """Store value sliced when block_size > tensor dim (1D)."""


### PR DESCRIPTION

`codegen_constant_pad_nd_pallas` rendered the pad fill value with `repr()`, so
`F.pad(x, pad, value=float("-inf"))` was emitted as `constant_values=-inf`.
That parses as a negation of the *name* `inf`, which does not exist in the
generated module, so the artifact raised `NameError: name 'inf' is not defined`
at run time -- after compiling cleanly. Same for `inf` and `nan`.

Spell non-finite floats as `float('-inf')` / `float('inf')` / `float('nan')`,
which is valid in any module and needs no import. Finite values keep using
`repr()`, which was already correct (`repr(-1e30)` -> `-1e+30`).

Test: test_constant_pad_nd_non_finite_fill (float32 + bfloat16), asserting both
the emitted literal and the numerics. Run on TPU.

Found while padding a top-k result up to a Mosaic-legal 128-wide store, where
-inf is the natural fill for the trailing columns.

Known adjacent gap, not addressed here: a fill read from a *host global* rather
than written inline reaches the lowering as an unbacked SymFloat and fails with
`GuardOnDataDependentSymNode`, because `CompileEnvironment.to_fake` gives host
ints a concrete hint but host floats none.
