### PR TITLE
[Pallas] Separate memory analysis from TensorCore lowering

### DIFF
--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1434,6 +1434,7 @@ class PallasBackend(Backend):
         from ...autotuner.config_spec import VALID_PALLAS_WORKLIST_GROUPINGS
         from ..compile_environment import CompileEnvironment
         from .plan_tiling import plan_tiling
+        from .tensorcore_plan import build_tensorcore_plans
 
         # Validate pallas_loop_type before any codegen setup.
         self.build_launcher_name(config)
@@ -1447,6 +1448,7 @@ class PallasBackend(Backend):
         env = CompileEnvironment.current()
 
         plan_tiling(graphs, config, tile_strategy)
+        build_tensorcore_plans(graphs, config)
 
         # compact_worklist_* is per-CONFIG state, but one CompileEnvironment is
         # reused across all configs of a BoundKernel (see CompileEnvironment's

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -26,9 +26,10 @@ def load_expr(
     subscript: list[object],
     tensor: torch.Tensor,
 ) -> ast.AST:
-    """Pallas load codegen: normal path, or indirect gather if ``plan_tiling`` flagged it."""
+    """Emit a normal load or a selected TensorCore gather plan."""
     from helion._compiler.pallas.gather import emit_gather
-    from helion._compiler.pallas.plan_tiling import IndirectGatherPattern
+    from helion._compiler.pallas.tensorcore_plan import TENSORCORE_PLAN_META
+    from helion._compiler.pallas.tensorcore_plan import OneHotGatherPlan
 
     name = state.device_function.tensor_arg(tensor).name
     name = vmem_name(state, name)
@@ -38,9 +39,9 @@ def load_expr(
 
     assert state.fx_node is not None
     patterns = list(state.fx_node.meta.get("indexing_patterns") or ())
-    for pattern in patterns:
-        if isinstance(pattern, IndirectGatherPattern):
-            return emit_gather(state, pattern.plan, name)
+    plan = state.fx_node.meta.get(TENSORCORE_PLAN_META)
+    if isinstance(plan, OneHotGatherPlan):
+        return emit_gather(state, plan.plan, name)
 
     parts, none_dims = index_parts(state, subscript, tensor)
     scalar_load = classify_vmem_scalar_load(state, tensor, parts, patterns)
@@ -517,8 +518,7 @@ def _generated_index_code(
     """Generate index code based on the indexing pattern."""
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
     from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
-    from helion._compiler.pallas.plan_tiling import IndirectGatherPattern
-    from helion._compiler.pallas.plan_tiling import IndirectScatterPattern
+    from helion._compiler.pallas.plan_tiling import TensorIndexPattern
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TilePattern
@@ -546,16 +546,18 @@ def _generated_index_code(
             pattern, idx, state, subscript_index, in_pipeline
         )
 
-    if isinstance(pattern, IndirectGatherPattern):
-        # The gather emitter consumes the tensor index and projects the full
-        # resident table axis through one-hot, so normal load codegen must
-        # expose that axis instead of indexing it a second time.
-        return ":"
+    if isinstance(pattern, TensorIndexPattern):
+        from helion._compiler.pallas.tensorcore_plan import TENSORCORE_PLAN_META
+        from helion._compiler.pallas.tensorcore_plan import TensorCorePlan
 
-    if isinstance(pattern, IndirectScatterPattern):
-        # The scatter emitter consumes the tensor index and projects source lanes
-        # through one-hot matrices, so normal store codegen must expose the full
-        # resident target axis instead of indexing it a second time.
+        assert state.fx_node is not None
+        plan = state.fx_node.meta.get(TENSORCORE_PLAN_META)
+        assert (
+            isinstance(plan, TensorCorePlan)
+            and subscript_index in plan.indirect_positions
+        ), "TensorCore plan does not handle a tensor-valued index"
+        # The plan consumes the tensor index, so ordinary indexing must expose
+        # the full tensor axis instead of applying the index a second time.
         return ":"
 
     raise RuntimeError(

--- a/helion/_compiler/pallas/memory_access.py
+++ b/helion/_compiler/pallas/memory_access.py
@@ -1,0 +1,71 @@
+"""Backend-neutral Pallas memory operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from .plan_tiling import IndexingPattern
+
+
+MEMORY_ACCESS_META = "pallas_memory_access"
+
+
+class MemoryAccessKind(Enum):
+    """Logical effect of one Helion memory operation."""
+
+    LOAD = "load"
+    STORE = "store"
+    ATOMIC = "atomic"
+
+
+@dataclass(frozen=True)
+class MemoryAccess:
+    """One memory operation after shared Pallas indexing analysis."""
+
+    node: torch.fx.Node
+    kind: MemoryAccessKind
+    tensor_node: torch.fx.Node
+    tensor: torch.Tensor
+    subscript: tuple[object, ...]
+    patterns: tuple[IndexingPattern, ...]
+    value_node: torch.fx.Node | None
+
+
+def build_memory_access(
+    node: torch.fx.Node,
+    tensor: torch.Tensor,
+    subscript: list[object],
+    patterns: list[IndexingPattern],
+) -> MemoryAccess:
+    """Build target-independent metadata for one memory operation."""
+    from ...language import memory_ops
+    from ...language.atomic_ops import ATOMIC_OPS
+
+    tensor_node = node.args[0]
+    assert isinstance(tensor_node, torch.fx.Node)
+    if node.target is memory_ops.load:
+        kind = MemoryAccessKind.LOAD
+        value_node = None
+    elif node.target is memory_ops.store:
+        kind = MemoryAccessKind.STORE
+        value_node = node.args[2]
+    elif node.target in ATOMIC_OPS:
+        kind = MemoryAccessKind.ATOMIC
+        value_node = node.args[2]
+    else:
+        raise AssertionError(f"not a memory access target: {node.target}")
+
+    return MemoryAccess(
+        node=node,
+        kind=kind,
+        tensor_node=tensor_node,
+        tensor=tensor,
+        subscript=tuple(subscript),
+        patterns=tuple(patterns),
+        value_node=value_node if isinstance(value_node, torch.fx.Node) else None,
+    )

--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -43,25 +43,17 @@ def _(state: CodegenState) -> None:
         state, tensor, subscript, parts, value
     )
     idx_str = ", ".join(parts)
-    patterns = state.fx_node.meta.get("indexing_patterns") if state.fx_node else ()
     from .gather import emit_scatter_store
-    from .plan_tiling import IndirectScatterPattern
+    from .tensorcore_plan import TENSORCORE_PLAN_META
+    from .tensorcore_plan import OneHotScatterPlan
 
-    scatter_patterns = [
-        pattern
-        for pattern in patterns or ()
-        if isinstance(pattern, IndirectScatterPattern)
-    ]
-    assert len(scatter_patterns) <= 1, (
-        "Pallas store expected at most one indirect scatter pattern"
-    )
-    if scatter_patterns:
-        value = emit_scatter_store(
-            state, scatter_patterns[0].plan, name, idx_str, value
-        )
+    plan = state.fx_node.meta.get(TENSORCORE_PLAN_META) if state.fx_node else None
+    is_scatter = isinstance(plan, OneHotScatterPlan)
+    if is_scatter:
+        value = emit_scatter_store(state, plan.plan, name, idx_str, value)
     from .ordered_carry import emit_carry_store
 
-    if not scatter_patterns and state.device_function.carry_tiles:
+    if not is_scatter and state.device_function.carry_tiles:
         if emit_carry_store(state, tensor, subscript, name, idx_str, value):
             return
     state.codegen.add_statement(

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -21,8 +21,6 @@ if TYPE_CHECKING:
     from ..device_ir import GraphInfo
     from ..host_function import SymbolOrigin
     from ..tile_dispatch import TileStrategyDispatch
-    from .gather import GatherPlan
-    from .gather import ScatterPlan
 
 
 @dataclass
@@ -71,20 +69,6 @@ class NonePattern(IndexingPattern):
 @dataclass
 class TensorIndexPattern(IndexingPattern):
     """Tensor-valued index - no tiling. Resolved for indirect load/store codegen."""
-
-
-@dataclass
-class IndirectGatherPattern(IndexingPattern):
-    """Indirect gather load ``table[idx, ...]`` - no tiling on this dim."""
-
-    plan: GatherPlan
-
-
-@dataclass
-class IndirectScatterPattern(IndexingPattern):
-    """Indirect scatter store ``table[idx, ...]`` - no tiling on this dim."""
-
-    plan: ScatterPlan
 
 
 @dataclass
@@ -142,8 +126,11 @@ def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
     indexing_patterns = _analyze_subscript_patterns(
         tensor_val, list(subscript), dim_tilings, node, config
     )
-    _resolve_tensor_index_patterns(
-        node, tensor_val, list(subscript), indexing_patterns, config
+    from .memory_access import MEMORY_ACCESS_META
+    from .memory_access import build_memory_access
+
+    node.meta[MEMORY_ACCESS_META] = build_memory_access(
+        node, tensor_val, list(subscript), indexing_patterns
     )
     node.meta["indexing_patterns"] = indexing_patterns
 
@@ -401,42 +388,6 @@ def resident_block_elements(
         # Advance only on patterns that consume a tensor dim; NonePattern doesn't.
         tdim += 1
     return elements
-
-
-def _resolve_tensor_index_patterns(
-    node: torch.fx.Node,
-    tensor: torch.Tensor,
-    subscript: list[object],
-    patterns: list[IndexingPattern],
-    config: Config,
-) -> None:
-    """Replace TensorIndexPattern with Pallas indirect load/store patterns."""
-    positions = [i for i, p in enumerate(patterns) if isinstance(p, TensorIndexPattern)]
-    if not positions:
-        return
-
-    from ...language import memory_ops
-
-    if node.target is memory_ops.load:
-        from .gather import build_gather_plan
-
-        plan = build_gather_plan(tensor, subscript, positions, patterns, config)
-        for i in positions:
-            patterns[i] = IndirectGatherPattern(plan=plan)
-        return
-
-    if node.target is memory_ops.store:
-        from .gather import build_scatter_plan
-
-        plan = build_scatter_plan(tensor, subscript, positions)
-        for i in positions:
-            patterns[i] = IndirectScatterPattern(plan=plan)
-        return
-
-    op_name = getattr(node.target, "__name__", str(node.target))
-    raise NotImplementedError(
-        f"Pallas: tensor-indexed memory op is not supported for op={op_name}."
-    )
 
 
 # Helper functions moved from memory_ops.py

--- a/helion/_compiler/pallas/tensorcore_plan.py
+++ b/helion/_compiler/pallas/tensorcore_plan.py
@@ -1,0 +1,100 @@
+"""TensorCore plans for Pallas memory operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .memory_access import MemoryAccessKind
+from .plan_tiling import TensorIndexPattern
+
+if TYPE_CHECKING:
+    from ...runtime.config import Config
+    from ..device_ir import GraphInfo
+    from .gather import GatherPlan
+    from .gather import ScatterPlan
+    from .memory_access import MemoryAccess
+
+
+TENSORCORE_PLAN_META = "pallas_tensorcore_plan"
+
+
+@dataclass(frozen=True)
+class TensorCorePlan:
+    """TensorCore implementation of one memory operation."""
+
+    access: MemoryAccess
+    indirect_positions: tuple[int, ...]  # Positions in access.subscript.
+
+
+@dataclass(frozen=True)
+class OneHotGatherPlan(TensorCorePlan):
+    """Resident-table one-hot/MXU fallback for an indirect load."""
+
+    plan: GatherPlan
+
+
+@dataclass(frozen=True)
+class OneHotScatterPlan(TensorCorePlan):
+    """One-hot fallback for an indirect store."""
+
+    plan: ScatterPlan
+
+
+def _one_hot_gather(
+    access: MemoryAccess, positions: list[int], config: Config
+) -> OneHotGatherPlan:
+    from .gather import build_gather_plan
+
+    plan = build_gather_plan(
+        access.tensor,
+        list(access.subscript),
+        positions,
+        list(access.patterns),
+        config,
+    )
+    return OneHotGatherPlan(access, tuple(positions), plan)
+
+
+def _one_hot_scatter(
+    access: MemoryAccess, positions: list[int], _config: Config
+) -> OneHotScatterPlan:
+    from .gather import build_scatter_plan
+
+    plan = build_scatter_plan(access.tensor, list(access.subscript), positions)
+    return OneHotScatterPlan(access, tuple(positions), plan)
+
+
+def select_tensorcore_plan(
+    access: MemoryAccess, config: Config
+) -> TensorCorePlan | None:
+    """Choose a TensorCore implementation without changing shared patterns."""
+    positions = [
+        index
+        for index, pattern in enumerate(access.patterns)
+        if isinstance(pattern, TensorIndexPattern)
+    ]
+    if not positions:
+        return None
+    # One-hot is the fallback while Pallas has no native TensorCore indirect access.
+    if access.kind is MemoryAccessKind.LOAD:
+        return _one_hot_gather(access, positions, config)
+    if access.kind is MemoryAccessKind.STORE:
+        return _one_hot_scatter(access, positions, config)
+    op = access.node.target
+    op_name = getattr(op, "__name__", str(op))
+    raise NotImplementedError(
+        f"Pallas: tensor-indexed memory op is not supported for op={op_name}."
+    )
+
+
+def build_tensorcore_plans(graphs: list[GraphInfo], config: Config) -> None:
+    """Select TensorCore plans after shared memory analysis."""
+    from .memory_access import MEMORY_ACCESS_META
+    from .memory_access import MemoryAccess
+
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            access = node.meta.get(MEMORY_ACCESS_META)
+            if isinstance(access, MemoryAccess):
+                node.meta[TENSORCORE_PLAN_META] = select_tensorcore_plan(access, config)

--- a/test/test_pallas_memory_access.py
+++ b/test/test_pallas_memory_access.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import torch
+
+from helion import Config
+from helion._compiler.pallas.memory_access import MemoryAccessKind
+from helion._compiler.pallas.memory_access import build_memory_access
+from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+from helion._compiler.pallas.plan_tiling import IndexingPattern
+from helion._compiler.pallas.plan_tiling import TensorIndexPattern
+from helion._compiler.pallas.plan_tiling import TilePattern
+from helion._compiler.pallas.tensorcore_plan import OneHotGatherPlan
+from helion._compiler.pallas.tensorcore_plan import OneHotScatterPlan
+from helion._compiler.pallas.tensorcore_plan import select_tensorcore_plan
+from helion.language import memory_ops
+from helion.language.atomic_ops import atomic_add
+
+
+def _placeholder(
+    graph: torch.fx.Graph, name: str, value: torch.Tensor
+) -> torch.fx.Node:
+    node = graph.placeholder(name)
+    node.meta["val"] = value
+    return node
+
+
+def test_memory_access_snapshots_semantic_patterns() -> None:
+    graph = torch.fx.Graph()
+    table = torch.empty(128, 32)
+    index = torch.empty(16, dtype=torch.int32)
+    table_node = _placeholder(graph, "table", table)
+    index_node = _placeholder(graph, "index", index)
+    fx_subscript = (index_node, slice(None))
+    subscript: list[object] = list(fx_subscript)
+    load = graph.call_function(memory_ops.load, (table_node, fx_subscript))
+    load.meta["val"] = torch.empty(16, 32)
+    patterns: list[IndexingPattern] = [
+        TensorIndexPattern(),
+        ArbitrarySlicePattern(slice(None)),
+    ]
+
+    access = build_memory_access(load, table, subscript, patterns)
+    # Later tiling changes must not alter recorded memory semantics.
+    patterns[0] = TilePattern(0)
+
+    assert access.kind is MemoryAccessKind.LOAD
+    assert access.tensor is table
+    assert access.value_node is None
+    assert isinstance(access.patterns[0], TensorIndexPattern)
+
+
+def test_store_and_atomic_memory_accesses_record_values() -> None:
+    graph = torch.fx.Graph()
+    output = torch.empty(64, 32)
+    value = torch.empty(16, 32)
+    output_node = _placeholder(graph, "output", output)
+    value_node = _placeholder(graph, "value", value)
+    fx_subscript = (slice(None), slice(None))
+    subscript: list[object] = list(fx_subscript)
+    patterns: list[IndexingPattern] = [
+        TilePattern(0),
+        ArbitrarySlicePattern(slice(None)),
+    ]
+
+    store = graph.call_function(
+        memory_ops.store, (output_node, fx_subscript, value_node)
+    )
+    atomic = graph.call_function(atomic_add, (output_node, fx_subscript, value_node))
+
+    store_access = build_memory_access(store, output, subscript, patterns)
+    atomic_access = build_memory_access(atomic, output, subscript, patterns)
+
+    assert store_access.kind is MemoryAccessKind.STORE
+    assert atomic_access.kind is MemoryAccessKind.ATOMIC
+    assert store_access.value_node is value_node
+    assert atomic_access.value_node is value_node
+
+
+def test_tensorcore_plan_owns_indirect_fallbacks() -> None:
+    graph = torch.fx.Graph()
+    table = torch.empty(128, 32)
+    index = torch.empty(16, dtype=torch.int32)
+    value = torch.empty(16, 32)
+    table_node = _placeholder(graph, "table", table)
+    index_node = _placeholder(graph, "index", index)
+    value_node = _placeholder(graph, "value", value)
+    fx_subscript = (index_node, slice(None))
+    subscript: list[object] = list(fx_subscript)
+    patterns: list[IndexingPattern] = [
+        TensorIndexPattern(),
+        ArbitrarySlicePattern(slice(None)),
+    ]
+    load = graph.call_function(memory_ops.load, (table_node, fx_subscript))
+    load.meta["val"] = value
+    store = graph.call_function(
+        memory_ops.store, (table_node, fx_subscript, value_node)
+    )
+    load_access = build_memory_access(load, table, subscript, patterns)
+    store_access = build_memory_access(store, table, subscript, patterns)
+
+    gather_fallback = object()
+    scatter_fallback = object()
+    with (
+        patch(
+            "helion._compiler.pallas.gather.build_gather_plan",
+            return_value=gather_fallback,
+        ),
+        patch(
+            "helion._compiler.pallas.gather.build_scatter_plan",
+            return_value=scatter_fallback,
+        ),
+    ):
+        gather = select_tensorcore_plan(load_access, Config())
+        scatter = select_tensorcore_plan(store_access, Config())
+
+    assert isinstance(gather, OneHotGatherPlan)
+    assert isinstance(scatter, OneHotScatterPlan)
+    assert gather.plan is gather_fallback
+    assert scatter.plan is scatter_fallback


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3262
* #3261
* #3260
* #3259
* #3258
* #3257
* #3256
* #3255
* #3254
* #3253
* __->__ #3252

----

`plan_tiling` previously turned tensor-indexed operations directly into TensorCore gather/scatter patterns. This mixed shared indexing analysis with a target-specific implementation and makes the result difficult to reuse for other Pallas targets (sparsecore).

This PR separates the two:

- `MemoryAccess` records the operation, tensor, subscript and indexing patterns.
- TensorCore selects a separate `TensorCorePlan` after tiling analysis.
- Codegen emits the selected plan instead of finding TensorCore objects inside indexing patterns.

