### PR TITLE
[Pallas] Schedule SparseCore programs from dependencies

### DIFF
--- a/helion/_compiler/pallas/sparsecore_program.py
+++ b/helion/_compiler/pallas/sparsecore_program.py
@@ -1,0 +1,250 @@
+"""SparseCore program and dependency-derived pipeline schedule."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+import math
+from typing import TYPE_CHECKING
+
+from .sparsecore_base import SC_VMEM_BYTES
+from .sparsecore_base import SC_VMEM_MARGIN
+from .sparsecore_base import _reject
+from .sparsecore_plan import DirectLoadPlan
+from .sparsecore_plan import DirectStorePlan
+from .sparsecore_plan import IndirectLoadPlan
+from .sparsecore_plan import IndirectStorePlan
+from .sparsecore_plan import SparseCoreMemoryPlan
+
+if TYPE_CHECKING:
+    import torch
+
+
+class TaskKind(Enum):
+    SYNC_TRANSFER = "sync_transfer"
+    ASYNC_START = "async_start"
+    ASYNC_WAIT = "async_wait"
+    STORE = "store"
+
+
+@dataclass(frozen=True)
+class Task:
+    kind: TaskKind
+    node: torch.fx.Node
+
+
+@dataclass(frozen=True)
+class ScheduleStage:
+    lag: int
+    tasks: tuple[Task, ...]
+
+
+@dataclass(frozen=True)
+class SparseCoreSchedule:
+    stages: tuple[ScheduleStage, ...]
+    depth: int
+
+
+@dataclass
+class SparseCoreProgram:
+    graph: torch.fx.Graph
+    memory_plans: tuple[SparseCoreMemoryPlan, ...]
+    item_count: int
+    tile_size: int
+    num_cores: int
+    num_subcores: int
+    plan_by_node: dict[torch.fx.Node, SparseCoreMemoryPlan] = field(init=False)
+    index_nodes: frozenset[torch.fx.Node] = field(init=False)
+    schedule: SparseCoreSchedule | None = None
+
+    @property
+    def total_subcores(self) -> int:
+        return self.num_cores * self.num_subcores
+
+    @property
+    def items_per_subcore(self) -> int:
+        return self.tile_size // self.total_subcores
+
+    @property
+    def item_blocks(self) -> int:
+        return math.ceil(self.item_count / self.tile_size)
+
+    @property
+    def padded_items(self) -> int:
+        return self.item_blocks * self.tile_size
+
+    def __post_init__(self) -> None:
+        self.plan_by_node = {plan.access.node: plan for plan in self.memory_plans}
+        if len(self.plan_by_node) != len(self.memory_plans):
+            raise AssertionError("duplicate SparseCore memory plan")
+        self.index_nodes = frozenset(
+            plan.index_node
+            for plan in self.memory_plans
+            if isinstance(plan, (IndirectLoadPlan, IndirectStorePlan))
+        )
+        for plan in self.memory_plans:
+            if not isinstance(plan, (IndirectLoadPlan, IndirectStorePlan)):
+                continue
+            index_plan = self.plan_by_node.get(plan.index_node)
+            if not isinstance(index_plan, (DirectLoadPlan, IndirectLoadPlan)):
+                _reject(
+                    "access_pattern",
+                    "indirect index must be produced by a memory load",
+                    node=plan.access.node,
+                )
+            if isinstance(plan, IndirectStorePlan) and isinstance(
+                index_plan, IndirectLoadPlan
+            ):
+                _reject(
+                    "access_pattern",
+                    "dependent indices for indirect stores are not implemented",
+                    node=plan.access.node,
+                )
+        for index_node in self.index_nodes:
+            for user in index_node.users:
+                plan = self.plan_by_node.get(user)
+                if (
+                    isinstance(plan, (IndirectLoadPlan, IndirectStorePlan))
+                    and plan.index_node is index_node
+                    and plan.access.value_node is not index_node
+                ):
+                    continue
+                _reject(
+                    "access_pattern",
+                    "a load used as an indirect index cannot also be used as a value",
+                    node=index_node,
+                )
+
+    @property
+    def loads(self) -> tuple[DirectLoadPlan | IndirectLoadPlan, ...]:
+        return tuple(
+            plan
+            for plan in self.memory_plans
+            if isinstance(plan, (DirectLoadPlan, IndirectLoadPlan))
+        )
+
+    @property
+    def stores(self) -> tuple[DirectStorePlan | IndirectStorePlan, ...]:
+        return tuple(
+            plan
+            for plan in self.memory_plans
+            if isinstance(plan, (DirectStorePlan, IndirectStorePlan))
+        )
+
+
+def load_buffer_shape(
+    program: SparseCoreProgram, plan: DirectLoadPlan | IndirectLoadPlan
+) -> tuple[int, ...]:
+    """Scratch shape for one load and one pipeline slot."""
+    if isinstance(plan, IndirectLoadPlan):
+        entries = plan.transfer.elements_per_item
+        entry_size = plan.layout.elements_per_item // entries
+        return (program.items_per_subcore * entries, entry_size)
+    if isinstance(plan, DirectLoadPlan) and plan.access.node in program.index_nodes:
+        return (program.items_per_subcore * plan.transfer.elements_per_item,)
+    return plan.layout.storage_shape
+
+
+class _ScheduleBuilder:
+    def __init__(self, program: SparseCoreProgram) -> None:
+        self.program = program
+        self.tasks: list[tuple[int, Task]] = []
+        self.value_lags: dict[torch.fx.Node, int] = {}
+
+    def add(self, lag: int, kind: TaskKind, node: torch.fx.Node) -> None:
+        self.tasks.append((lag, Task(kind, node)))
+
+    def value_lag(self, node: torch.fx.Node) -> int:
+        if node in self.value_lags:
+            return self.value_lags[node]
+        plan = self.program.plan_by_node.get(node)
+        if isinstance(plan, (DirectLoadPlan, IndirectLoadPlan)):
+            return self.load(plan)
+        if node.op in ("placeholder", "output"):
+            self.value_lags[node] = 0
+            return 0
+
+        from ...language._tracing_ops import _get_symnode
+        from ...language._tracing_ops import _host_tensor
+
+        if node.target in (_host_tensor, _get_symnode):
+            self.value_lags[node] = 0
+            return 0
+
+        lag = max(
+            (self.value_lag(parent) for parent in node.all_input_nodes), default=0
+        )
+        self.value_lags[node] = lag
+        return lag
+
+    def load(self, plan: DirectLoadPlan | IndirectLoadPlan) -> int:
+        node = plan.access.node
+        prior = self.value_lags.get(node)
+        if prior is not None:
+            return prior
+        lag = (
+            self.value_lag(plan.index_node) if isinstance(plan, IndirectLoadPlan) else 0
+        )
+        if isinstance(plan, IndirectLoadPlan) or (
+            isinstance(plan, DirectLoadPlan) and node not in self.program.index_nodes
+        ):
+            self.add(lag, TaskKind.ASYNC_START, node)
+            lag += 1
+            self.add(lag, TaskKind.ASYNC_WAIT, node)
+        else:
+            self.add(lag, TaskKind.SYNC_TRANSFER, node)
+        self.value_lags[node] = lag
+        return lag
+
+    def store(self, plan: DirectStorePlan | IndirectStorePlan) -> None:
+        value_node = plan.access.value_node
+        assert value_node is not None
+        lag = self.value_lag(value_node)
+        if isinstance(plan, IndirectStorePlan):
+            lag = max(lag, self.value_lag(plan.index_node))
+        self.add(lag, TaskKind.STORE, plan.access.node)
+
+    def build(self) -> SparseCoreSchedule:
+        # Stable task order keeps generated code and errors deterministic.
+        for plan in self.program.loads:
+            self.load(plan)
+        for plan in self.program.stores:
+            self.store(plan)
+
+        by_lag: dict[int, list[Task]] = {}
+        for lag, task in self.tasks:
+            by_lag.setdefault(lag, []).append(task)
+        stages = tuple(
+            ScheduleStage(lag, tuple(tasks)) for lag, tasks in sorted(by_lag.items())
+        )
+        depth = max(by_lag, default=0) + 1
+        return SparseCoreSchedule(stages, depth)
+
+
+def _verify_resources(program: SparseCoreProgram, schedule: SparseCoreSchedule) -> None:
+    ring_bytes = sum(
+        math.prod(load_buffer_shape(program, plan))
+        * plan.layout.storage_dtype.itemsize
+        * schedule.depth
+        for plan in program.loads
+    )
+    output_bytes = sum(
+        math.prod(plan.layout.storage_shape) * plan.layout.storage_dtype.itemsize
+        for plan in program.stores
+    )
+    used = ring_bytes + output_bytes
+    limit = SC_VMEM_BYTES - SC_VMEM_MARGIN
+    if used > limit:
+        _reject(
+            "resource",
+            f"VMEM program uses {used} bytes at pipeline depth {schedule.depth}; "
+            f"limit is {limit}",
+        )
+
+
+def schedule_sparsecore_program(program: SparseCoreProgram) -> None:
+    """Build the transfer schedule from FX value dependencies."""
+    schedule = _ScheduleBuilder(program).build()
+    _verify_resources(program, schedule)
+    program.schedule = schedule

--- a/test/test_pallas_sparsecore_schedule.py
+++ b/test/test_pallas_sparsecore_schedule.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from helion import exc
+from helion._compiler.pallas import sparsecore_program
+from helion._compiler.pallas.memory_access import MEMORY_ACCESS_META
+from helion._compiler.pallas.memory_access import build_memory_access
+from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+from helion._compiler.pallas.plan_tiling import TensorIndexPattern
+from helion._compiler.pallas.plan_tiling import TilePattern
+from helion._compiler.pallas.sparsecore_plan import SparseCorePlanContext
+from helion._compiler.pallas.sparsecore_plan import build_sparsecore_memory_plan
+from helion._compiler.pallas.sparsecore_program import SparseCoreProgram
+from helion._compiler.pallas.sparsecore_program import TaskKind
+from helion._compiler.pallas.sparsecore_program import schedule_sparsecore_program
+from helion.language import memory_ops
+
+
+def _placeholder(
+    graph: torch.fx.Graph, name: str, value: torch.Tensor
+) -> torch.fx.Node:
+    node = graph.placeholder(name)
+    node.meta["val"] = value
+    return node
+
+
+def _load(
+    graph: torch.fx.Graph,
+    source: torch.fx.Node,
+    source_value: torch.Tensor,
+    index: torch.fx.Node,
+    result: torch.Tensor,
+    *,
+    indirect: bool,
+) -> torch.fx.Node:
+    node = graph.call_function(memory_ops.load, (source, (index, slice(None))))
+    node.meta["val"] = result
+    patterns = (
+        [TensorIndexPattern(), ArbitrarySlicePattern(slice(None))]
+        if indirect
+        else [TilePattern(0), ArbitrarySlicePattern(slice(None))]
+    )
+    node.meta[MEMORY_ACCESS_META] = build_memory_access(
+        node, source_value, list(node.args[1]), patterns
+    )
+    return node
+
+
+def _program(graph: torch.fx.Graph, nodes: list[torch.fx.Node]) -> SparseCoreProgram:
+    context = SparseCorePlanContext(
+        {0: 256},
+        item_block_id=0,
+        items_per_subcore=8,
+    )
+    memory_plans = tuple(
+        build_sparsecore_memory_plan(node.meta[MEMORY_ACCESS_META], context)
+        for node in nodes
+    )
+    return SparseCoreProgram(
+        graph=graph,
+        memory_plans=memory_plans,
+        item_count=1024,
+        tile_size=256,
+        num_cores=2,
+        num_subcores=16,
+    )
+
+
+def test_independent_gathers_share_stage() -> None:
+    graph = torch.fx.Graph()
+    indices = torch.empty(1024, dtype=torch.int32)
+    index_arg = _placeholder(graph, "indices", indices)
+    tile = _placeholder(graph, "tile", torch.empty(256, dtype=torch.int32))
+    index_load = _load(
+        graph,
+        index_arg,
+        indices,
+        tile,
+        torch.empty(256, dtype=torch.int32),
+        indirect=False,
+    )
+    loads = [index_load]
+    for number in range(3):
+        table = torch.empty(4096, 64)
+        table_arg = _placeholder(graph, f"table{number}", table)
+        loads.append(
+            _load(
+                graph,
+                table_arg,
+                table,
+                index_load,
+                torch.empty(256, 64),
+                indirect=True,
+            )
+        )
+
+    program = _program(graph, loads)
+    schedule_sparsecore_program(program)
+    schedule = program.schedule
+
+    assert schedule is not None
+    assert schedule.depth == 2
+    assert [stage.lag for stage in schedule.stages] == [0, 1]
+    assert (
+        sum(
+            task.kind is TaskKind.ASYNC_START
+            for stage in schedule.stages
+            for task in stage.tasks
+        )
+        == 3
+    )
+
+
+def test_dependent_gather_uses_next_stage() -> None:
+    graph = torch.fx.Graph()
+    roots = torch.empty(1024, dtype=torch.int32)
+    roots_arg = _placeholder(graph, "roots", roots)
+    tile = _placeholder(graph, "tile", torch.empty(256, dtype=torch.int32))
+    root_load = _load(
+        graph,
+        roots_arg,
+        roots,
+        tile,
+        torch.empty(256, dtype=torch.int32),
+        indirect=False,
+    )
+    pointer = torch.empty(4096, 8, dtype=torch.int32)
+    pointer_arg = _placeholder(graph, "pointer", pointer)
+    pointer_load = _load(
+        graph,
+        pointer_arg,
+        pointer,
+        root_load,
+        torch.empty(256, 8, dtype=torch.int32),
+        indirect=True,
+    )
+    table = torch.empty(8192, 64)
+    table_arg = _placeholder(graph, "table", table)
+    data_load = _load(
+        graph,
+        table_arg,
+        table,
+        pointer_load,
+        torch.empty(256, 8, 64),
+        indirect=True,
+    )
+
+    program = _program(graph, [root_load, pointer_load, data_load])
+    schedule_sparsecore_program(program)
+    schedule = program.schedule
+
+    assert schedule is not None
+    assert schedule.depth == 3
+    assert [stage.lag for stage in schedule.stages] == [0, 1, 2]
+    waits = [
+        (stage.lag, task)
+        for stage in schedule.stages
+        for task in stage.tasks
+        if task.kind is TaskKind.ASYNC_WAIT
+    ]
+    assert [lag for lag, _ in waits] == [1, 2]
+
+
+def test_index_buffer_uses_scalar_storage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = torch.fx.Graph()
+    indices = torch.empty(1024, dtype=torch.int32)
+    index_arg = _placeholder(graph, "indices", indices)
+    tile = _placeholder(graph, "tile", torch.empty(256, dtype=torch.int32))
+    index_load = _load(
+        graph,
+        index_arg,
+        indices,
+        tile,
+        torch.empty(256, dtype=torch.int32),
+        indirect=False,
+    )
+    table = torch.empty(4096, 64)
+    table_arg = _placeholder(graph, "table", table)
+    data_load = _load(
+        graph,
+        table_arg,
+        table,
+        index_load,
+        torch.empty(256, 64),
+        indirect=True,
+    )
+    program = _program(graph, [index_load, data_load])
+    monkeypatch.setattr(sparsecore_program, "SC_VMEM_BYTES", 4500)
+    monkeypatch.setattr(sparsecore_program, "SC_VMEM_MARGIN", 0)
+
+    schedule_sparsecore_program(program)
+
+
+def test_computed_indirect_index_is_rejected() -> None:
+    graph = torch.fx.Graph()
+    indices = torch.empty(1024, dtype=torch.int32)
+    index_arg = _placeholder(graph, "indices", indices)
+    tile = _placeholder(graph, "tile", torch.empty(256, dtype=torch.int32))
+    index_load = _load(
+        graph,
+        index_arg,
+        indices,
+        tile,
+        torch.empty(256, dtype=torch.int32),
+        indirect=False,
+    )
+    adjusted = graph.call_function(torch.ops.aten.add.Tensor, (index_load, 1))
+    adjusted.meta["val"] = torch.empty(256, dtype=torch.int32)
+    table = torch.empty(4096, 64)
+    table_arg = _placeholder(graph, "table", table)
+    gather = _load(
+        graph,
+        table_arg,
+        table,
+        adjusted,
+        torch.empty(256, 64),
+        indirect=True,
+    )
+
+    with pytest.raises(
+        exc.InvalidConfig, match="indirect index must be produced by a memory load"
+    ):
+        _program(graph, [index_load, gather])
+
+
+def test_index_load_used_as_value_is_rejected() -> None:
+    """Helion: use `item_index = index[tile]` for both a gather and addition."""
+    graph = torch.fx.Graph()
+    indices = torch.empty(1024, dtype=torch.int32)
+    index_arg = _placeholder(graph, "indices", indices)
+    tile = _placeholder(graph, "tile", torch.empty(256, dtype=torch.int32))
+    index_load = _load(
+        graph,
+        index_arg,
+        indices,
+        tile,
+        torch.empty(256, dtype=torch.int32),
+        indirect=False,
+    )
+    table = torch.empty(4096, 64)
+    table_arg = _placeholder(graph, "table", table)
+    gather = _load(
+        graph,
+        table_arg,
+        table,
+        index_load,
+        torch.empty(256, 64),
+        indirect=True,
+    )
+    value = graph.call_function(torch.ops.aten.add.Tensor, (gather, index_load))
+    value.meta["val"] = torch.empty(256, 64)
+
+    with pytest.raises(
+        exc.InvalidConfig,
+        match="a load used as an indirect index cannot also be used as a value",
+    ):
+        _program(graph, [index_load, gather])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3262
* #3261
* #3260
* #3259
* #3258
* #3257
* #3256
* __->__ #3255
* #3254
* #3253
* #3252

----

This PR turns the SparseCore memory plans from #3254 into a deterministic transfer schedule. It introduces `SparseCoreProgram`, validates indirect-index dependencies, and assigns transfers and stores to pipeline stages from the FX dataflow.

- Direct index loads use synchronous transfers.
- Independent gathers share an asynchronous pipeline stage.
- Dependent gathers advance to the next stage.
- Stores wait for their value and index dependencies.
- Schedule depth determines ring-buffer allocation; configurations exceeding the SparseCore VMEM budget are rejected.

This PR only builds and validates the schedule. SparseCore computation and code generation are added by later PRs in the stack.

