### PR TITLE
[compiler] Fix masked `hl.load` on a size-1 indexed dimension

### DIFF
--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -624,8 +624,20 @@ class PointerIndexingStrategy(IndexingStrategy):
             else:
                 extra = ", other=0"
         name = state.device_function.tensor_arg(fake_tensor).name
-        # Optional hint for the allowlisted blocked-gather pattern.
         offset_ast = indexing.index_expr
+        if indexing.has_mask() and not indexing.block_shaped_offset:
+            # The size-1 dimensions dropped every block shaped term from the
+            # offset, and Triton cannot mask a scalar pointer. Add a block shaped
+            # zero to restore the shape without changing the offset.
+            env = CompileEnvironment.current()
+            shape_str = state.tile_strategy.shape_str(
+                SubscriptIndexing.compute_shape(fake_tensor, subscript, state)
+            )
+            offset_ast = expr_from_string(
+                f"{{offset}} + {env.backend.zeros_expr(shape_str, env.index_type())}",
+                offset=offset_ast,
+            )
+        # Optional hint for the allowlisted blocked-gather pattern.
         try:
             contiguity = _PointerLoadContiguity(state, fake_tensor, subscript).derive()
         except Exception:
@@ -678,57 +690,11 @@ class PointerIndexingStrategy(IndexingStrategy):
     ) -> ast.AST:
         indexing = SubscriptIndexing.create(state, fake_tensor, subscript, extra_mask)
         name = state.device_function.tensor_arg(fake_tensor).name
+        output_size = SubscriptIndexing.compute_shape(fake_tensor, subscript, state)
+
         # Check if the pointer is effectively scalar but the value has dimensions.
         # This happens when all block-indexed dimensions have size 1 in the target tensor.
         # In this case, we need to reshape the value to scalar to match the pointer.
-        env = CompileEnvironment.current()
-        output_size = SubscriptIndexing.compute_shape(fake_tensor, subscript, state)
-
-        # Determine if pointer has any block dimensions by checking if any block index
-        # targets a non-size-1 tensor dimension. We need to match the logic in
-        # SubscriptIndexing.create which skips dimensions where fake_tensor.size(i) == 1.
-        pointer_has_block_dims = False
-        tensor_dim = 0
-        k_index = 0
-        for k in subscript:
-            if k is None:
-                # None adds a dimension to output, not from tensor
-                pass
-            elif isinstance(k, int):
-                # Scalar int index - consumes tensor dim but adds scalar to pointer
-                tensor_dim += 1
-            elif _get_tile_with_offset_info(
-                k, state.fx_node, k_index
-            ) is not None or isinstance(k, torch.Tensor):
-                # Tensor index (tile.index + offset or regular tensor) - block index
-                if not env.known_equal(fake_tensor.size(tensor_dim), 1):
-                    pointer_has_block_dims = True
-                tensor_dim += 1
-                k_index += 1
-            elif isinstance(k, torch.SymInt):
-                # SymInt can be block index (with BlockSizeOrigin) or scalar
-                symbol = _symint_expr(k)
-                origin = None
-                if isinstance(symbol, sympy.Symbol):
-                    origin = HostFunction.current().expr_to_origin.get(symbol)
-                if origin and isinstance(origin.origin, BlockSizeOrigin):
-                    # Block index
-                    if not env.known_equal(fake_tensor.size(tensor_dim), 1):
-                        pointer_has_block_dims = True
-                # Both block and scalar SymInt consume a tensor dimension
-                tensor_dim += 1
-                k_index += 1
-            elif isinstance(k, slice):
-                # Slice - adds block dimension if slice_size > 1
-                size = fake_tensor.size(tensor_dim)
-                slice_size = compute_slice_size(k, size)
-                if not env.known_equal(slice_size, 1):
-                    if not env.known_equal(fake_tensor.size(tensor_dim), 1):
-                        pointer_has_block_dims = True
-                tensor_dim += 1
-                k_index += 1
-
-        # Pointer is scalar but output_size has dimensions, reshape value to scalar.
         backend = CompileEnvironment.current().backend
         needs_squeeze = bool(output_size)
         if (
@@ -741,7 +707,7 @@ class PointerIndexingStrategy(IndexingStrategy):
                 val_meta = value_node.meta.get("val")
                 needs_squeeze = isinstance(val_meta, torch.Tensor) and val_meta.ndim > 0
         if (
-            not pointer_has_block_dims
+            not indexing.block_shaped_offset
             and not isinstance(value, ast.Constant)
             and needs_squeeze
         ):
@@ -1344,6 +1310,9 @@ class PerDimIndexing:
     mask_expr: ast.AST
     broadcast_dims: tuple[tuple[int, int | torch.SymInt], ...]
     output_size: list[int | torch.SymInt]
+    # Per tensor dimension, whether that dimension's index is block shaped (a
+    # tile/tensor index rather than a scalar). Parallel to dim_index_exprs.
+    block_dims: tuple[bool, ...] = ()
 
     def has_mask(self) -> bool:
         return not (
@@ -1365,6 +1334,10 @@ class SubscriptIndexing(NamedTuple):
     # index variables (x_epilogue{i}_{d}) that Inductor's store_output() uses
     # to build broadcast-aware range tree entries.
     dim_index_exprs: tuple[str, ...] = ()
+    # Whether index_expr is block shaped. False when every block index landed on
+    # a size-1 dimension, since those terms are dropped from the offset sum and
+    # what remains is scalar.
+    block_shaped_offset: bool = True
 
     def has_mask(self) -> bool:
         return not (
@@ -1483,6 +1456,8 @@ class SubscriptIndexing(NamedTuple):
         tile_strategy = state.tile_strategy
         output_idx = 0
         index_values: list[str] = []
+        # Parallel to index_values: whether that dimension's index is block shaped.
+        block_dims: list[bool] = []
         mask_values: dict[str, None] = {}
         output_size = SubscriptIndexing.compute_shape(fake_value, index, state)
         env = CompileEnvironment.current()
@@ -1608,6 +1583,7 @@ class SubscriptIndexing(NamedTuple):
             elif isinstance(k, int):
                 if k < 0:
                     k += fake_value.size(len(index_values))
+                block_dims.append(False)
                 index_values.append(state.device_function.literal_expr(k))
             elif (
                 tile_info := _get_tile_with_offset_info(k, state.fx_node, n)
@@ -1617,6 +1593,7 @@ class SubscriptIndexing(NamedTuple):
                 full_block_size = env.block_sizes[env.canonical_block_id(block_id)].var
                 expand = tile_strategy.expand_str(output_size, output_idx)
                 i = len(index_values)
+                block_dims.append(True)
                 if tile_info.block_size is not None and not env.known_equal(
                     tile_info.block_size, full_block_size
                 ):
@@ -1658,6 +1635,7 @@ class SubscriptIndexing(NamedTuple):
                     index_var = state.codegen.index_var(block_id)
                     expand = tile_strategy.expand_str(output_size, output_idx)
                     i = len(index_values)
+                    block_dims.append(True)
                     index_values.append(f"({index_var}){expand}")
                     if (mask := state.codegen.mask_var(block_id)) and not _is_size_one(
                         fake_value.size(i)
@@ -1685,6 +1663,7 @@ class SubscriptIndexing(NamedTuple):
                         val = state.codegen.lift(ast_index[n], prefix="index").id
                     else:
                         val = state.device_function.literal_expr(k)
+                    block_dims.append(False)
                     index_values.append(f"({val})")
             elif isinstance(k, slice):
                 expand = tile_strategy.expand_str(output_size, output_idx)
@@ -1708,12 +1687,14 @@ class SubscriptIndexing(NamedTuple):
                                 state, block_idx, slice_size, dtype
                             )
                         # Generate strided index: start + index * step
+                        block_dims.append(True)
                         index_values.append(
                             f"({start} + ({base_index_expr}) * {step}){expand}"
                         )
                         if mask_expr is not None:
                             mask_values.setdefault(f"({mask_expr}){expand}")
                     else:
+                        block_dims.append(False)
                         index_values.append(f"{start}{expand}")
                 else:
                     slice_size = compute_slice_size(k, size)
@@ -1728,11 +1709,13 @@ class SubscriptIndexing(NamedTuple):
                                 state, block_idx, slice_size, dtype
                             )
                         start_expr = state.device_function.literal_expr(start)
+                        block_dims.append(True)
                         index_values.append(f"({start_expr} + ({index_var})){expand}")
                         if mask_expr is not None:
                             mask_values.setdefault(f"({mask_expr}){expand}")
                     else:
                         start_expr = state.device_function.literal_expr(start)
+                        block_dims.append(False)
                         index_values.append(f"{start_expr}{expand}")
                 output_idx += 1
             elif isinstance(k, torch.Tensor):
@@ -1745,6 +1728,7 @@ class SubscriptIndexing(NamedTuple):
                     idx_val, new_masks = handle_broadcast_tensor(
                         n, k, index_var, output_idx
                     )
+                    block_dims.append(True)
                     index_values.append(idx_val)
                     mask_values.update(new_masks)
                     if k is tensor_indexers[0]:
@@ -1756,6 +1740,7 @@ class SubscriptIndexing(NamedTuple):
                     if k.ndim < len(output_size)
                     else ""
                 )
+                block_dims.append(True)
                 index_values.append(f"({index_var}){expand}")
                 mask_block_id = (
                     env.get_block_id(output_size[output_idx])
@@ -1774,6 +1759,7 @@ class SubscriptIndexing(NamedTuple):
                 raise exc.InvalidIndexingType(type(k))
         assert len(output_size) == output_idx
         assert len(index_values) == fake_value.ndim
+        assert len(block_dims) == len(index_values)
 
         kwargs = {}
         if extra_mask is not None:
@@ -1784,6 +1770,7 @@ class SubscriptIndexing(NamedTuple):
             expr_from_string("&".join(mask_values) or "None", **kwargs),
             tuple(size1_broadcast_dims),
             output_size,
+            tuple(block_dims),
         )
 
     @staticmethod
@@ -1802,19 +1789,25 @@ class SubscriptIndexing(NamedTuple):
         def _is_size_one(size: int | torch.SymInt) -> bool:
             return env.known_equal(size, 1)
 
+        # A size-1 dimension contributes offset 0, so its term is dropped. That
+        # also drops its shape, so track whether a block shaped term survives.
         index_expr = []
+        block_shaped = False
         for i, idx in enumerate(per_dim.dim_index_exprs):
             if not _is_size_one(fake_value.size(i)):
                 stride = state.device_function.tensor_stride(fake_value, i).name
                 index_expr.append(f"{idx} * {stride}")
+                block_shaped |= per_dim.block_dims[i]
         if not index_expr:
             shape_str = state.tile_strategy.shape_str(per_dim.output_size)
             index_expr.append(env.backend.zeros_expr(shape_str, dtype))
+            block_shaped = bool(per_dim.output_size)
         return SubscriptIndexing(
             expr_from_string("+".join(index_expr)),
             per_dim.mask_expr,
             per_dim.broadcast_dims,
             per_dim.dim_index_exprs,
+            block_shaped,
         )
 
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -713,6 +713,34 @@ class TestIndexing(RefEagerTestBase, TestCase):
                         self.assertIn("tl.where", code_test)
                     torch.testing.assert_close(result_test, result_pointer)
 
+    def test_extra_mask_load_size_one_dim(self):
+        """An extra_mask load whose only block index hits a size-1 dimension."""
+
+        @helion.kernel(static_shapes=True)
+        def gather_rows(
+            x: torch.Tensor,
+            base: torch.Tensor,
+            valid: torch.Tensor,
+            out: torch.Tensor,
+        ) -> None:
+            for tile_j, tile_r in hl.tile(
+                [out.size(0), out.size(1)], block_size=[1, None]
+            ):
+                j = tile_j.begin
+                v = tile_r.index < valid[j]
+                xt = hl.load(x, [base[j] + tile_r.index, 0], extra_mask=v)
+                out[tile_j.begin, tile_r] = torch.where(v, xt, 0)
+
+        # x.size(0) == 1 makes the row index fold away, leaving a scalar offset.
+        x = torch.randn(1, 4, device=DEVICE, dtype=HALF_DTYPE)
+        base = torch.zeros(1, device=DEVICE, dtype=torch.int32)
+        valid = torch.ones(1, device=DEVICE, dtype=torch.int32)
+        out = x.new_empty(1, 8)
+        code_and_output(gather_rows, (x, base, valid, out), block_size=[8])
+        expected = torch.zeros_like(out)
+        expected[0, 0] = x[0, 0]
+        torch.testing.assert_close(out, expected)
+
     @skipIfTileIR("TileIR does not support block_ptr indexing")
     @skipIfRefEager("test checks generated Triton code")
     def test_mask_store_falls_back_to_pointer(self):


### PR DESCRIPTION
A masked `hl.load` compiles for a tensor with 2 rows and fails for the same tensor with 1 row:

```python
xt = hl.load(x, [base[j] + tile_r.index, 0], extra_mask=v)
```

```text
x of shape [2, 4]:  ok
x of shape [1, 4]:  Mask argument cannot be block type if pointer argument is not a block
```

The load covers one tile, so it needs one address and one mask bit per element in the tile, and Triton requires the two to have the same shape. Addresses come from `row_index * stride0 + col_index * stride1`, where the row index is a tile-wide vector and the column index is the scalar `0`, so the row term is what makes the sum tile-wide.

Helion drops the term of any size-1 dimension, since that dimension can only be indexed at 0 and adds nothing to the address. With 1 row that is the row term, and it was the only tile-wide part of the sum:

```python
# 2 rows: tile-wide address, tile-wide mask
xt = tl.load(x + (v_1 * 4 + 0 * 1), v_0, other=0)

# 1 row: row term dropped -> scalar address, still tile-wide mask
v_1 = load_1 + indices_1              # row vector computed, then unused
xt = tl.load(x + 0 * 1, v_0, other=0)
```

The dropped term really did add 0, so the address value is right. Dropping it also dropped the shape, which is the bug.

#1258 fixed this same mixed scalar/block indexing problem for stores. This is the load side of it.

**Fix:** record per dimension whether its index is vector shaped, then track in `SubscriptIndexing.create` whether any vector shaped term survives the size-1 drop. A masked load whose offset went scalar adds a block shaped zero to restore the shape.

`codegen_store` needs the same fact and re-derived it by walking the subscript again. It reads the flag now instead.

**Test:** a regression test runs the load against a 1 row tensor and checks the loaded values.
