### PR TITLE
[Pallas] Bound compact-worklist DMA windows to tensor extents

### DIFF
--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -901,18 +901,31 @@ class PallasBackend(Backend):
         sorted_args: list[Argument] | None,
         config: Config,
     ) -> list[tuple[int, int, int, int]] | None:
-        """Identify pl.ds() dims that may need padding and their block sizes.
+        """Identify dims that may need padding and their block sizes.
 
         Uses ``pallas_pad_info`` recorded during codegen to identify which
-        tensor dimensions use ``pl.ds()`` slicing.
+        tensor dimensions use ``pl.ds()`` slicing, plus the compact-worklist
+        windows (see :meth:`_compact_window_pad_info`), whose slicing lives in a
+        BlockSpec rather than in the kernel body.
 
-        Returns ``[(arg_index, tensor_dim, block_size, extra_pad), ...]``
-        or ``None``.  The launcher computes the actual pad amount at runtime
-        as ``(-tensor.shape[dim]) % block_size + extra_pad``.
+        Returns ``[(arg_index, tensor_dim, block_size, extra_pad), ...]`` or
+        ``None``.  ``_pallas_resolve_ds_pad_amounts`` turns each entry into
+        ``(-rows) % block_size + extra_pad`` rows, which expresses both kinds of
+        requirement:
 
-        ``extra_pad`` is 0 when the tile loop starts at offset 0,
-        ``begin % block_size`` for a constant begin offset, or
-        ``block_size - 1`` for a data-dependent begin.
+        * A ``pl.ds`` tile loop rounds its dim up to a block multiple, so it
+          sets the real ``block_size``, with ``extra_pad`` 0 for a loop starting
+          at offset 0, ``begin % block_size`` for a constant begin, or
+          ``block_size - 1`` for a data-dependent begin.
+        * A compact-worklist window needs a FIXED number of rows past the end
+          and no rounding, so it sets ``block_size = 1`` (making the modulo term
+          vanish) and puts the whole requirement in ``extra_pad`` -- see
+          :meth:`_compact_window_pad_info`.
+
+        One ``(arg_index, dim)`` may appear more than once when a tensor is
+        reached by several windows.  They are NOT merged here: an alignment
+        requirement's size depends on the row count, which this pass does not
+        have, so the largest cannot be identified until launch time.
         """
         if sorted_args is None:
             return None
@@ -923,22 +936,111 @@ class PallasBackend(Backend):
 
         env = CompileEnvironment.current()
         device_fn = DeviceFunction.current()
-        if not device_fn.pallas_pad_info:
-            return None
 
         result: list[tuple[int, int, int, int]] = []
-        for i, arg in enumerate(sorted_args):
-            if not isinstance(arg, TensorArg):
-                continue
-            dims_info = device_fn.pallas_pad_info.get(id(arg.fake_value))
-            if dims_info is not None:
-                for dim, (block_id, extra_pad) in dims_info.items():
-                    bsi = env.block_sizes[block_id]
-                    bs = bsi.from_config(config)
-                    if isinstance(bs, int) and bs > 1:
-                        result.append((i, dim, bs, extra_pad))
+        if device_fn.pallas_pad_info:
+            for i, arg in enumerate(sorted_args):
+                if not isinstance(arg, TensorArg):
+                    continue
+                dims_info = device_fn.pallas_pad_info.get(id(arg.fake_value))
+                if dims_info is not None:
+                    for dim, (block_id, extra_pad) in dims_info.items():
+                        bsi = env.block_sizes[block_id]
+                        bs = bsi.from_config(config)
+                        # A 1-wide alignment block never needs rounding, so it is
+                        # dropped.  This test applies ONLY to alignment entries:
+                        # the compact-window entries below deliberately carry
+                        # ``block_size = 1`` to mean "no rounding, pad exactly
+                        # ``extra_pad``", and dropping those would silently
+                        # restore the out-of-bounds window read they prevent.
+                        if isinstance(bs, int) and bs > 1:
+                            result.append((i, dim, bs, extra_pad))
 
+        # Sorted by arg index so the emitted list stays stable across compiles
+        # (the tensor-policy order these come from is insertion order).
+        result.extend(
+            (arg_index, 0, 1, min_slack)
+            for arg_index, min_slack in sorted(
+                self._compact_window_pad_info(sorted_args)
+            )
+        )
         return result or None
+
+    def _compact_window_pad_info(
+        self, sorted_args: list[Argument]
+    ) -> list[tuple[int, int]]:
+        """Rows of slack each compact-worklist window needs past the tensor end.
+
+        Returns ``[(arg_index, slack_rows), ...]`` for dim 0.  These are
+        absolute requirements, not alignment ones: a window opens at a runtime
+        row and spans a fixed length, so rounding the tensor to a block multiple
+        is both unnecessary and insufficient.  The caller emits them with
+        ``block_size = 1`` so the pad formula reduces to exactly ``slack_rows``.
+
+        Compact-worklist operands are sliced by a ``pl.Element`` BlockSpec at a
+        runtime row offset rather than by a ``pl.ds()`` in the kernel body, so
+        codegen never records them in ``pallas_pad_info`` and they would
+        otherwise get no padding at all.  They still need it: Pallas clamps a
+        block dim against the array only when that dim is TILED (jax's Mosaic
+        ``_create_bounded_slice`` returns ``ds(start, block)`` verbatim when the
+        dim has no tiling, which is the case for the leading dim of a
+        ``(rows, ...)`` tensor), and ``Element``'s ``padding=`` never reaches
+        that computation.  A compact/jagged tensor is normally allocated with
+        exactly ``sum(lengths)`` rows, so without slack the window DMAs whole
+        blocks past the buffer: the core halts with a BoundsCheck on
+        ``dma.hbm_to_vmem``, and the matching full-block store writes past the
+        output.
+
+        The two window kinds differ by one row, because their starts differ:
+
+        * A compact tile only exists for a range with rows in it, and its start
+          is that range's base plus a whole number of tile steps, so it begins
+          no later than ``rows - 1`` and reaches ``rows - 1 + block``.  Slack
+          ``block - 1``.
+        * A resident window is keyed on a range START, which is a separate
+          per-owner base: an owner whose compact range is non-empty may still
+          have an EMPTY ordered range, and if it is the trailing one that base
+          equals ``rows``.  The window then reaches ``rows + window``.  Slack
+          ``window``.
+
+        Which range overshoots is runtime data, hence the conservative bounds.
+        """
+        from ..compile_environment import CompileEnvironment
+        from ..device_function import TensorArg
+
+        env = CompileEnvironment.current()
+        plan = env.compact_worklist_plan
+        if plan is None:
+            return []
+
+        name_to_index = {
+            arg.host_str(): i
+            for i, arg in enumerate(sorted_args)
+            if isinstance(arg, TensorArg)
+        }
+
+        entries: list[tuple[int, int]] = []
+        # Compact-tile operands: one ``compact_block``-row window at tile_start.
+        compact_block = env.compact_worklist_block * plan.grouping
+        if compact_block > 0:
+            for policy in plan.tensor_policies:
+                if policy.kind not in ("compact_aligned_load", "compact_exact_store"):
+                    continue
+                arg_index = name_to_index.get(policy.arg_name)
+                if arg_index is not None:
+                    entries.append((arg_index, compact_block - 1))
+
+        # Resident (owner-cache) operands: one ``physical_window``-row window at
+        # range_start, which is likewise an unaligned runtime row offset.
+        decision = env.compact_worklist_resident_cache_decision
+        if decision is not None and decision.active and decision.physical_window > 0:
+            window = decision.physical_window
+            for name in decision.resident_operands:
+                arg_index = name_to_index.get(name)
+                if arg_index is not None:
+                    entries.append((arg_index, window))
+
+        return entries
 
     def _detect_matmul_dot_general_lowering(
         self,
@@ -1278,14 +1380,20 @@ class PallasBackend(Backend):
         # make_async_copy over pl.ds(tile_start, tile_extent) serializes (~1.8x
         # slower: 4.5ms vs 2.5ms) because a straight-line compact tile has no inner
         # loop to overlap; (b) a pl.BoundedSlice store BlockSpec (exact + double-buffered)
-        # is rejected by this JAX's Mosaic lowering ("Unsupported block dimension
-        # type: BoundedSlice" -- it only works inside pltpu.emit_pipeline).  The
-        # full-block write's only hazard is a partial last tile overlapping the
-        # next owner's leading rows; "arbitrary" dimension semantics serialize
-        # that grid-ordered overlap so the later, correct write wins (verified
-        # bitwise == fori_loop across uniform/partial/unaligned/jagged + 5 random
-        # seeds).  Robust+fast exact store == the deferred emit_pipeline +
-        # pl.BoundedSlice path.
+        # was rejected by the Mosaic lowering of the JAX this was written against
+        # ("Unsupported block dimension type: BoundedSlice" -- it only worked inside
+        # pltpu.emit_pipeline).  jax 0.11 DOES lower a BoundedSlice block dim in a
+        # plain pallas_call (measured: same throughput as pl.Element, and its
+        # index_map can clamp the transfer to the tensor so the row padding
+        # _compute_pad_info adds for pl.Element becomes unnecessary -- worth ~8% on
+        # jagged self-attention).  It stays unused because pyproject pins no jax
+        # floor and the older lowering has no fallback within one BlockSpec.
+        # The full-block write's only hazard WITHIN the tensor is a partial last
+        # tile overlapping the next owner's leading rows; "arbitrary" dimension
+        # semantics serialize that grid-ordered overlap so the later, correct write
+        # wins (verified bitwise == fori_loop across uniform/partial/unaligned/jagged
+        # + 5 random seeds).  Running off the END of the tensor is a separate hazard
+        # handled by padding; see _compact_window_pad_info.
         aligned_indices = [
             name_to_index[p.arg_name]
             for p in plan.tensor_policies

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -901,31 +901,19 @@ class PallasBackend(Backend):
         sorted_args: list[Argument] | None,
         config: Config,
     ) -> list[tuple[int, int, int, int]] | None:
-        """Identify dims that may need padding and their block sizes.
+        """Identify pl.ds() dims that may need padding and their block sizes.
 
         Uses ``pallas_pad_info`` recorded during codegen to identify which
-        tensor dimensions use ``pl.ds()`` slicing, plus the compact-worklist
-        windows (see :meth:`_compact_window_pad_info`), whose slicing lives in a
-        BlockSpec rather than in the kernel body.
+        tensor dimensions use ``pl.ds()`` slicing, plus the one dummy row an
+        empty resident operand needs (see :meth:`_zero_row_resident_pad_info`).
 
-        Returns ``[(arg_index, tensor_dim, block_size, extra_pad), ...]`` or
-        ``None``.  ``_pallas_resolve_ds_pad_amounts`` turns each entry into
-        ``(-rows) % block_size + extra_pad`` rows, which expresses both kinds of
-        requirement:
+        Returns ``[(arg_index, tensor_dim, block_size, extra_pad), ...]``
+        or ``None``.  The launcher computes the actual pad amount at runtime
+        as ``(-tensor.shape[dim]) % block_size + extra_pad``.
 
-        * A ``pl.ds`` tile loop rounds its dim up to a block multiple, so it
-          sets the real ``block_size``, with ``extra_pad`` 0 for a loop starting
-          at offset 0, ``begin % block_size`` for a constant begin, or
-          ``block_size - 1`` for a data-dependent begin.
-        * A compact-worklist window needs a FIXED number of rows past the end
-          and no rounding, so it sets ``block_size = 1`` (making the modulo term
-          vanish) and puts the whole requirement in ``extra_pad`` -- see
-          :meth:`_compact_window_pad_info`.
-
-        One ``(arg_index, dim)`` may appear more than once when a tensor is
-        reached by several windows.  They are NOT merged here: an alignment
-        requirement's size depends on the row count, which this pass does not
-        have, so the largest cannot be identified until launch time.
+        ``extra_pad`` is 0 when the tile loop starts at offset 0,
+        ``begin % block_size`` for a constant begin offset, or
+        ``block_size - 1`` for a data-dependent begin.
         """
         if sorted_args is None:
             return None
@@ -947,100 +935,50 @@ class PallasBackend(Backend):
                     for dim, (block_id, extra_pad) in dims_info.items():
                         bsi = env.block_sizes[block_id]
                         bs = bsi.from_config(config)
-                        # A 1-wide alignment block never needs rounding, so it is
-                        # dropped.  This test applies ONLY to alignment entries:
-                        # the compact-window entries below deliberately carry
-                        # ``block_size = 1`` to mean "no rounding, pad exactly
-                        # ``extra_pad``", and dropping those would silently
-                        # restore the out-of-bounds window read they prevent.
                         if isinstance(bs, int) and bs > 1:
                             result.append((i, dim, bs, extra_pad))
 
-        # Sorted by arg index so the emitted list stays stable across compiles
-        # (the tensor-policy order these come from is insertion order).
-        result.extend(
-            (arg_index, 0, 1, min_slack)
-            for arg_index, min_slack in sorted(
-                self._compact_window_pad_info(sorted_args)
-            )
-        )
+        result.extend(self._zero_row_resident_pad_info(sorted_args))
         return result or None
 
-    def _compact_window_pad_info(
+    def _zero_row_resident_pad_info(
         self, sorted_args: list[Argument]
-    ) -> list[tuple[int, int]]:
-        """Rows of slack each compact-worklist window needs past the tensor end.
+    ) -> list[tuple[int, int, int, int]]:
+        """One dummy row for each resident operand that has NO rows.
 
-        Returns ``[(arg_index, slack_rows), ...]`` for dim 0.  These are
-        absolute requirements, not alignment ones: a window opens at a runtime
-        row and spans a fixed length, so rounding the tensor to a block multiple
-        is both unnecessary and insufficient.  The caller emits them with
-        ``block_size = 1`` so the pad formula reduces to exactly ``slack_rows``.
+        A resident window is opened on the operand whether or not any ordered
+        range is non-empty, so an operand with zero rows leaves the window with
+        no in-bounds row to slice.  Giving it a single row makes the window's
+        clamped slice ``pl.ds(0, 1)`` -- a legal, one-row transfer.  The row is
+        never read: an operand is only empty when every ordered range is empty,
+        so the reduction is zero-trip.
 
-        Compact-worklist operands are sliced by a ``pl.Element`` BlockSpec at a
-        runtime row offset rather than by a ``pl.ds()`` in the kernel body, so
-        codegen never records them in ``pallas_pad_info`` and they would
-        otherwise get no padding at all.  They still need it: Pallas clamps a
-        block dim against the array only when that dim is TILED (jax's Mosaic
-        ``_create_bounded_slice`` returns ``ds(start, block)`` verbatim when the
-        dim has no tiling, which is the case for the leading dim of a
-        ``(rows, ...)`` tensor), and ``Element``'s ``padding=`` never reaches
-        that computation.  A compact/jagged tensor is normally allocated with
-        exactly ``sum(lengths)`` rows, so without slack the window DMAs whole
-        blocks past the buffer: the core halts with a BoundsCheck on
-        ``dma.hbm_to_vmem``, and the matching full-block store writes past the
-        output.
+        Emitting the pad rather than declining to cache keeps the resident
+        decision ACTIVE, which matters because ``pallas_loop_type='unroll'``
+        rejects an inactive decision outright and a legal all-empty ordered
+        reduction would otherwise stop compiling.
 
-        The two window kinds differ by one row, because their starts differ:
-
-        * A compact tile only exists for a range with rows in it, and its start
-          is that range's base plus a whole number of tile steps, so it begins
-          no later than ``rows - 1`` and reaches ``rows - 1 + block``.  Slack
-          ``block - 1``.
-        * A resident window is keyed on a range START, which is a separate
-          per-owner base: an owner whose compact range is non-empty may still
-          have an EMPTY ordered range, and if it is the trailing one that base
-          equals ``rows``.  The window then reaches ``rows + window``.  Slack
-          ``window``.
-
-        Which range overshoots is runtime data, hence the conservative bounds.
+        ``block_size = 1`` makes ``(-rows) % block_size`` vanish, so the pad is
+        exactly ``extra_pad`` (one row).  That formula pads unconditionally, so
+        this must only ever fire for a CONCRETELY empty operand -- otherwise a
+        real tensor would take a full copy.  Every non-degenerate kernel gets an
+        empty list from this helper (ordinary ``pallas_pad_info`` entries are
+        unaffected and can still request padding of their own).
         """
         from ..compile_environment import CompileEnvironment
         from ..device_function import TensorArg
 
-        env = CompileEnvironment.current()
-        plan = env.compact_worklist_plan
-        if plan is None:
+        decision = CompileEnvironment.current().compact_worklist_resident_cache_decision
+        if decision is None or not decision.active:
             return []
-
-        name_to_index = {
-            arg.host_str(): i
+        resident = set(decision.resident_operands)
+        return [
+            (i, 0, 1, 1)
             for i, arg in enumerate(sorted_args)
             if isinstance(arg, TensorArg)
-        }
-
-        entries: list[tuple[int, int]] = []
-        # Compact-tile operands: one ``compact_block``-row window at tile_start.
-        compact_block = env.compact_worklist_block * plan.grouping
-        if compact_block > 0:
-            for policy in plan.tensor_policies:
-                if policy.kind not in ("compact_aligned_load", "compact_exact_store"):
-                    continue
-                arg_index = name_to_index.get(policy.arg_name)
-                if arg_index is not None:
-                    entries.append((arg_index, compact_block - 1))
-
-        # Resident (owner-cache) operands: one ``physical_window``-row window at
-        # range_start, which is likewise an unaligned runtime row offset.
-        decision = env.compact_worklist_resident_cache_decision
-        if decision is not None and decision.active and decision.physical_window > 0:
-            window = decision.physical_window
-            for name in decision.resident_operands:
-                arg_index = name_to_index.get(name)
-                if arg_index is not None:
-                    entries.append((arg_index, window))
-
-        return entries
+            and arg.host_str() in resident
+            and int(arg.fake_value.size(0)) == 0
+        ]
 
     def _detect_matmul_dot_general_lowering(
         self,
@@ -1372,28 +1310,25 @@ class PallasBackend(Backend):
         offset_indices = [name_to_index[n] for n in env.compact_worklist_offset_params]
         fields = metadata_field_names(plan)
         # Compact-tile tensors (aligned load + exact store) both get a max-sized
-        # pl.Element BlockSpec sliced at tile_start, so Pallas double-buffers BOTH
-        # the load prefetch and the store write-back across work items.
+        # compact window sliced at tile_start, so Pallas double-buffers BOTH the
+        # load prefetch and the store write-back across work items.
         #
         # The store is a masked full-block write.  The two robust EXACT-store
         # alternatives were both worse/unavailable here: (a) staging VMEM +
         # make_async_copy over pl.ds(tile_start, tile_extent) serializes (~1.8x
         # slower: 4.5ms vs 2.5ms) because a straight-line compact tile has no inner
-        # loop to overlap; (b) a pl.BoundedSlice store BlockSpec (exact + double-buffered)
-        # was rejected by the Mosaic lowering of the JAX this was written against
-        # ("Unsupported block dimension type: BoundedSlice" -- it only worked inside
-        # pltpu.emit_pipeline).  jax 0.11 DOES lower a BoundedSlice block dim in a
-        # plain pallas_call (measured: same throughput as pl.Element, and its
-        # index_map can clamp the transfer to the tensor so the row padding
-        # _compute_pad_info adds for pl.Element becomes unnecessary -- worth ~8% on
-        # jagged self-attention).  It stays unused because pyproject pins no jax
-        # floor and the older lowering has no fallback within one BlockSpec.
-        # The full-block write's only hazard WITHIN the tensor is a partial last
-        # tile overlapping the next owner's leading rows; "arbitrary" dimension
-        # semantics serialize that grid-ordered overlap so the later, correct write
-        # wins (verified bitwise == fori_loop across uniform/partial/unaligned/jagged
-        # + 5 random seeds).  Running off the END of the tensor is a separate hazard
-        # handled by padding; see _compact_window_pad_info.
+        # loop to overlap; (b) a pl.BoundedSlice store BlockSpec was once rejected by
+        # Mosaic ("Unsupported block dimension type: BoundedSlice"), but that is a
+        # LOWERING-PATH difference, not a version one: pl.pallas_call and
+        # emit_pipeline's compute_slice still reject it while the pl.kernel pipeline
+        # this launcher uses lowers it on jax 0.10.1 and 0.11.0 alike, so the window
+        # IS a BoundedSlice now (see _compact_window_block_spec).  The
+        # full-block write's only hazard is a partial last tile overlapping the
+        # next owner's leading rows; "arbitrary" dimension semantics serialize
+        # that grid-ordered overlap so the later, correct write wins (verified
+        # bitwise == fori_loop across uniform/partial/unaligned/jagged + 5 random
+        # seeds).  Robust+fast exact store == the deferred emit_pipeline +
+        # pl.BoundedSlice path.
         aligned_indices = [
             name_to_index[p.arg_name]
             for p in plan.tensor_policies

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -708,7 +708,7 @@ def _is_compact_aligned_load(
 ) -> bool:
     """True if *tensor* is a compact-tile aligned-load or exact-store tensor.
 
-    Both get a per-tile ``pl.Element`` BlockSpec sliced at ``tile_start`` (Pallas
+    Both get a per-tile window BlockSpec sliced at ``tile_start`` (Pallas
     double-buffers the load's prefetch and the store's write-back), so the body
     accesses the whole sliced block at local offset 0.
     """
@@ -731,7 +731,7 @@ def _is_ordered_aligned_load(
 ) -> bool:
     """True if *tensor* is a resident ordered reduction operand.
 
-    Resident operands get a per-range ``pl.Element(C)`` window keyed on
+    Resident operands get a per-range ``C``-row window keyed on
     ``range_start`` (not tile_start), so the fori body reads at the LOCAL
     ordered-tile offset ``offset - range_start`` rather than the absolute offset.
     """
@@ -775,12 +775,12 @@ def _ds_expr(
     if block_size is None:
         return ":"
     # compact_aligned_load: the tensor is a per-tile sliced BlockSpec block (the
-    # launcher slices it to one tile at tile_start via pl.Element, so Pallas
+    # launcher slices it to one tile at tile_start, so Pallas
     # double-buffers it across work items).  The body therefore reads the whole
     # sliced block at local offset 0, not the absolute tile_start.
     if not tile_offset and _is_compact_aligned_load(state, block_id, tensor):
         return f"pl.ds(0, {block_size})"
-    # Resident ordered operand: pl.Element(C) window at range_start, so read
+    # Resident ordered operand: C-row window at range_start, so read
     # at the LOCAL offset within the window (absolute offset - range_start).
     if not tile_offset and _is_ordered_aligned_load(state, block_id, tensor):
         from helion._compiler.compile_environment import CompileEnvironment

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -275,7 +275,7 @@ def _(state: CodegenState) -> None:
 def _codegen_resident_cache(state: CodegenState) -> object:
     """Range-keyed resident-window lowering for the compact-worklist ordered loop.
 
-    The ordered operand is held in a per-range resident ``pl.Element(C)`` window
+    The ordered operand is held in a per-range resident ``C``-row window
     keyed on ``range_start`` (``C`` is the compile-threaded physical window).
     Optional prep-cache descriptors are installed by the dynamic resident loop.
 
@@ -3134,7 +3134,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     )
 
     # Compact worklist: the compact-tile aligned_load and exact_store tensors use
-    # max-sized pl.Element BlockSpecs, which Pallas double-buffers across the
+    # max-sized window BlockSpecs, which Pallas double-buffers across the
     # work-item grid.  Keep them OUT of the manual make_async_copy DMA path: with
     # a single straight-line compact tile there is no inner loop to overlap, so a
     # DMA start()/wait() would run fully serial (load -> wait -> compute -> store
@@ -3156,7 +3156,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         }
 
     # Resident caching: only active resident ordered operands are held in a
-    # per-range pl.Element window and read at the local ordered-tile offset (see
+    # per-range resident window and read at the local ordered-tile offset (see
     # codegen._is_ordered_aligned_load).  Keep just those OFF the streamed
     # make_async_copy path.  Gate on the SAME decision the window is built from,
     # so an inactive residency decision leaves every operand streaming.

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -831,11 +831,16 @@ def _pallas_padded_output_dims_by_arg(
     whose ``arg_idx`` is in ``output_arg_set`` so callers can slice
     those outputs back to their original shapes.  Both the torch path
     (via ``_LauncherFastPath``) and the JAX-export launcher use this.
+
+    A ``(arg_idx, dim)`` may appear more than once (a tensor reached by several
+    slicing windows), but it is padded once, so each dim is listed once.
     """
     padded_dims_by_arg: dict[int, list[int]] = {}
     for arg_idx, dim, _bs, _extra in _ds_pad_dims:
         if arg_idx in output_arg_set:
-            padded_dims_by_arg.setdefault(arg_idx, []).append(dim)
+            dims = padded_dims_by_arg.setdefault(arg_idx, [])
+            if dim not in dims:
+                dims.append(dim)
     return padded_dims_by_arg
 
 
@@ -958,6 +963,60 @@ def _pallas_collect_outputs(
     return tuple(output_only_results)
 
 
+def _pallas_resolve_ds_pad_amounts(
+    args: tuple[object, ...],
+    _ds_pad_dims: list[tuple[int, int, int, int]],
+) -> dict[int, dict[int, int]]:
+    """Rows of padding each ``(arg, dim)`` needs, as ``{arg_idx: {dim: pad}}``.
+
+    Every ``(arg_index, dim, block_size, extra_pad)`` entry asks for
+    ``(-rows) % block_size + extra_pad`` rows.  That covers two different
+    requirements:
+
+    * ALIGNMENT (``block_size > 1``) -- a ``pl.ds`` loop steps the dim in
+      ``block_size`` chunks, so the tensor rounds up to a block multiple.
+    * FIXED RIGHT SLACK (``block_size == 1``) -- a window opens at an arbitrary
+      runtime row and spans a fixed length, so it needs a set number of rows of
+      headroom past the end and nothing rounded.  ``(-rows) % 1`` is always 0,
+      so the amount is exactly ``extra_pad``.  These entries are DELIBERATE and
+      load-bearing: do not filter them out alongside the ``bs > 1`` test that
+      ``_compute_pad_info`` applies to alignment entries, or a compact-worklist
+      window silently loses its padding and reads past the tensor again.
+
+    ``_ds_pad_dims`` may carry SEVERAL entries for one ``(arg, dim)`` -- a tensor
+    can be reached by more than one window (e.g. a compact-aligned operand that
+    is also resident-cached), and the two kinds mix.  Their amounts are ordered
+    only once ``rows`` is known (an entry with a larger block can need LESS than
+    one with a smaller block and a bigger ``extra_pad``), so they cannot be
+    compared where they are emitted.  Resolve them here and keep the max, so a
+    single pad satisfies every window.
+
+    Every amount is measured against the ORIGINAL shape, so callers must apply
+    at most one pad per ``(arg, dim)``; padding once per entry would compound.
+    Zero-pad entries are dropped, so an empty result means "nothing to do".
+    """
+    amounts: dict[int, dict[int, int]] = {}
+    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
+        a = args[arg_idx]
+        if not isinstance(a, torch.Tensor):
+            continue
+        pad_amount = (-a.shape[dim]) % block_size + extra_pad
+        if pad_amount == 0:
+            continue
+        per_dim = amounts.setdefault(arg_idx, {})
+        if pad_amount > per_dim.get(dim, 0):
+            per_dim[dim] = pad_amount
+    return amounts
+
+
+def _pallas_pad_tensor_dims(a: torch.Tensor, dims: dict[int, int]) -> torch.Tensor:
+    """Pad ``a`` at the end of each ``dim`` by ``dims[dim]`` rows, in one call."""
+    pad_widths = [0] * (2 * a.ndim)
+    for dim, pad_amount in dims.items():
+        pad_widths[2 * (a.ndim - 1 - dim) + 1] = pad_amount
+    return torch.nn.functional.pad(a, pad_widths)
+
+
 def _pallas_apply_ds_padding_fast(
     args: tuple[object, ...],
     _ds_pad_dims: list[tuple[int, int, int, int]],
@@ -965,33 +1024,22 @@ def _pallas_apply_ds_padding_fast(
     padded_output_arg_indices: frozenset[int],
 ) -> tuple[tuple[object, ...], dict[int, torch.Tensor] | None, bool]:
     """``_pallas_apply_ds_padding`` with a short-circuit when every pad amount is zero."""
-    args_list: list[object] | None = None
-    orig_output_tensors: dict[int, torch.Tensor] | None = None
-    any_padding = False
-    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
-        a = args[arg_idx] if args_list is None else args_list[arg_idx]
-        if not isinstance(a, torch.Tensor):
-            continue
-        pad_amount = (-a.shape[dim]) % block_size + extra_pad
-        if pad_amount == 0:
-            continue
-        any_padding = True
-        if args_list is None:
-            args_list = list(args)
-        if arg_idx in padded_output_arg_indices:
-            if orig_output_tensors is None:
-                orig_output_tensors = {}
-            if arg_idx not in orig_output_tensors:
-                orig_output_tensors[arg_idx] = cast("torch.Tensor", a)
-        pad_widths = [0] * (2 * a.ndim)
-        pad_widths[2 * (a.ndim - 1 - dim) + 1] = pad_amount
-        args_list[arg_idx] = torch.nn.functional.pad(a, pad_widths)
+    amounts = _pallas_resolve_ds_pad_amounts(args, _ds_pad_dims)
     if fast_path.ds_pad_required is None:
         # First-call precomputation: lock in whether any pad amount is
         # non-zero so subsequent calls can elide the iteration outright.
-        fast_path.ds_pad_required = any_padding
-    if args_list is None:
+        fast_path.ds_pad_required = bool(amounts)
+    if not amounts:
         return args, None, False
+    args_list = list(args)
+    orig_output_tensors: dict[int, torch.Tensor] | None = None
+    for arg_idx, dims in amounts.items():
+        a = cast("torch.Tensor", args_list[arg_idx])
+        if arg_idx in padded_output_arg_indices:
+            if orig_output_tensors is None:
+                orig_output_tensors = {}
+            orig_output_tensors[arg_idx] = a
+        args_list[arg_idx] = _pallas_pad_tensor_dims(a, dims)
     return tuple(args_list), orig_output_tensors, True
 
 
@@ -1342,11 +1390,12 @@ def _pallas_apply_ds_padding(
     _output_indices: list[int],
     _ds_pad_dims: list[tuple[int, int, int, int]],
 ) -> tuple[tuple[object, ...], dict[int, torch.Tensor]]:
-    """Pad tensor args so ``pl.ds(offset, block_size)`` never reads OOB.
+    """Pad tensor args so a windowed read never runs past the tensor.
 
     ``_ds_pad_dims`` contains ``(arg_index, dim, block_size, extra_pad)``
-    tuples.  The pad amount is ``(-tensor.shape[dim]) % block_size +
-    extra_pad``, where *extra_pad* accounts for non-zero loop begins.
+    tuples, possibly several for one ``(arg_index, dim)``;
+    :func:`_pallas_resolve_ds_pad_amounts` turns them into the single largest
+    pad each position needs, so every tensor is padded exactly once.
 
     Returns the padded args tuple and a dict mapping output arg indices
     to their original (unpadded) tensors for post-call copy-back.
@@ -1354,18 +1403,11 @@ def _pallas_apply_ds_padding(
     args_list = list(args)
     orig_output_tensors: dict[int, torch.Tensor] = {}
     output_set = set(_output_indices)
-    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
-        a = args_list[arg_idx]
-        if not isinstance(a, torch.Tensor):
-            continue
-        pad_amount = (-a.shape[dim]) % block_size + extra_pad
-        if pad_amount == 0:
-            continue
-        if arg_idx in output_set and arg_idx not in orig_output_tensors:
+    for arg_idx, dims in _pallas_resolve_ds_pad_amounts(args, _ds_pad_dims).items():
+        a = cast("torch.Tensor", args_list[arg_idx])
+        if arg_idx in output_set:
             orig_output_tensors[arg_idx] = a
-        pad_widths = [0] * (2 * a.ndim)
-        pad_widths[2 * (a.ndim - 1 - dim) + 1] = pad_amount
-        args_list[arg_idx] = torch.nn.functional.pad(a, pad_widths)
+        args_list[arg_idx] = _pallas_pad_tensor_dims(a, dims)
     return tuple(args_list), orig_output_tensors
 
 
@@ -2137,6 +2179,57 @@ def default_pallas_launcher(
     )
 
 
+def _compact_window_block_spec(
+    t: object,
+    window: int,
+    ref_pos: int,
+    scalar_refs: tuple[object, ...],
+) -> object:
+    """BlockSpec for one compact-worklist window: ``window`` rows of dim 0 at the
+    runtime row offset in ``scalar_refs[ref_pos]``, other dims full.
+
+    The offset is a RAW compact row (an owner base plus a tile step), never
+    aligned down to a sublane boundary, so the block dim must accept a dynamic,
+    possibly-unaligned start.  ``pl.Element`` is the mechanism that tolerates
+    that: Mosaic lowers an element-indexed block to a dynamic-offset access,
+    where a plain int block dim would require an aligned, fixed-grid block.
+
+    ``pl.Element`` always transfers the FULL window, which runs off the end of a
+    compact/jagged tensor -- normally allocated with exactly ``sum(lengths)``
+    rows -- on the last tile of the final range.  Pallas does not prevent that:
+    it clamps a block dim against the array only when that dim is TILED (jax's
+    Mosaic ``_create_bounded_slice`` returns ``ds(start, window)`` verbatim when
+    the dim has no tiling, which is the case for the leading dim of a
+    ``(rows, ...)`` tensor), and ``Element``'s ``padding=`` never reaches that
+    computation.  Unpadded, the window DMAs whole blocks past the buffer: a
+    BoundsCheck core halt on ``dma.hbm_to_vmem``, plus a matching full-block
+    store past the output.  So the caller's tensor must carry enough rows of
+    slack past the end to cover the last window, which ``_compute_pad_info``
+    requests as a fixed-slack pad -- ``window - 1`` for a per-tile window,
+    whose start is at most ``rows - 1``, and a full ``window`` for a resident
+    one, whose start is a range base that an empty trailing range puts at
+    ``rows``.  ``_compact_window_pad_info`` derives both.
+
+    The kernel body slices ``pl.ds(0, window)`` off a window-sized ref and masks
+    the tail, so rows past a range's end are already ignored.
+    """
+    from jax.experimental import pallas as pl
+    import jax.numpy as jnp
+
+    ndim = int(t.ndim)  # type: ignore[attr-defined]
+    block_shape = (pl.Element(window, padding=(0, window)), *t.shape[1:])  # type: ignore[union-attr,attr-defined]
+
+    def index_map(
+        wid: object,
+        _pos: int = ref_pos,
+        _nd: int = ndim,
+    ) -> tuple[object, ...]:
+        start = scalar_refs[_pos][wid]  # type: ignore[index]
+        return (start, *(jnp.int32(0) for _ in range(_nd - 1)))
+
+    return pl.BlockSpec(block_shape, index_map)  # type: ignore[union-attr]
+
+
 def _pallas_compact_in_out_specs(
     pl: object,
     jnp: object,
@@ -2178,57 +2271,24 @@ def _pallas_compact_in_out_specs(
         t = args[idx]
         assert _is_torch_tensor_or_jax_array(t)
         if idx in aligned_set:
-            # compact_aligned_load: slice dim 0 to one tile at tile_start via
-            # pl.Element so Pallas prefetches/double-buffers it; other dims full.
-            # Use the FULL compact_block (not min with the tensor length): the
-            # body slices ``pl.ds(0, compact_block)``, and the ``padding=(0,
-            # compact_block)`` lets the read overshoot the tensor end (handles a
-            # short compact dimension).  Clamping the block here would mismatch the
-            # body's pl.ds size and slice out of bounds.
-            #
-            # tile_start is the RAW compact offset (base + tile*block), NOT
-            # sublane-aligned-down: packed rows can start at arbitrary
-            # offsets.  pl.Element is exactly the mechanism that tolerates a
-            # dynamic, possibly-unaligned start -- Mosaic lowers an element-indexed
-            # block to a dynamic-offset (un)masked access, where a plain int block
-            # dim would require an aligned, fixed-grid block.  Verified bitwise ==
-            # fori_loop on unaligned/random offsets; this holds for both the load
-            # and the full-block store.
-            # Element only on dim 0: emit_pipeline rejects it on the lane dim.
-            block = compact_block
-            elt = pl.Element(block, padding=(0, block))  # type: ignore[union-attr]
-            block_shape = (elt, *t.shape[1:])
-
-            def aligned_index_map(
-                wid: object,
-                _pos: int = tile_start_ref_pos,
-                _nd: int = t.ndim,
-            ) -> tuple[object, ...]:
-                tile_start = scalar_refs[_pos][wid]  # type: ignore[index]
-                return (tile_start, *(jnp.int32(0) for _ in range(_nd - 1)))  # type: ignore[union-attr]
-
-            return pl.BlockSpec(block_shape, aligned_index_map)  # type: ignore[union-attr]
+            # compact_aligned_load / compact_exact_store: one compact_block-row
+            # window at tile_start, so Pallas prefetches and double-buffers both
+            # the load and the store write-back across work items.  Window
+            # sizing and the tensor-end hazard: _compact_window_block_spec.
+            # Windowed on dim 0 only: emit_pipeline rejects it on the lane dim.
+            return _compact_window_block_spec(
+                t, compact_block, tile_start_ref_pos, scalar_refs
+            )
         if idx in ordered_aligned_set:
-            # Resident caching: per-range resident window sized ``ordered_window`` (C)
-            # at ``range_start`` -- the fori body reads it at the local ordered-tile
-            # offset (offset - range_start).  padding=(0, C) tolerates reads past
-            # the range tail (same as the compact_aligned_load window).  Keying
-            # on range_start lets Pallas dedup the load across same-range tiles.
-            # Element only on dim 0: emit_pipeline rejects it on the lane dim.
+            # Resident caching: per-range resident window sized ``ordered_window``
+            # (C) at ``range_start`` -- the fori body reads it at the local
+            # ordered-tile offset (offset - range_start).  Keying on range_start
+            # lets Pallas dedup the load across same-range tiles.
             assert ordered_window > 0
             assert range_start_ref_pos >= 0
-            oelt = pl.Element(ordered_window, padding=(0, ordered_window))  # type: ignore[union-attr]
-            oblock_shape = (oelt, *t.shape[1:])
-
-            def ordered_index_map(
-                wid: object,
-                _pos: int = range_start_ref_pos,
-                _nd: int = t.ndim,
-            ) -> tuple[object, ...]:
-                start = scalar_refs[_pos][wid]  # type: ignore[index]
-                return (start, *(jnp.int32(0) for _ in range(_nd - 1)))  # type: ignore[union-attr]
-
-            return pl.BlockSpec(oblock_shape, ordered_index_map)  # type: ignore[union-attr]
+            return _compact_window_block_spec(
+                t, ordered_window, range_start_ref_pos, scalar_refs
+            )
         entry = block_spec_info[arg_to_tpos[idx]] if block_spec_info else None
         if entry is not None:
             block_shape_template, grid_dims = entry

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -204,7 +204,7 @@ def compact_ordered_budget_capacity(
 
     ``operands`` is ``[(shape, itemsize), ...]`` for every resident ordered
     operand.  Each ``C`` token costs that per-token footprint twice because the
-    ``pl.Element`` resident window is double-buffered by Pallas.  ``prep_operands``
+    resident window is double-buffered by Pallas.  ``prep_operands``
     adds any optional persistent prep-cache copies (for today's transpose-cache
     path, one more equivalent copy).  Pass ``[]`` for a resident-only/no-prep
     reduction.
@@ -228,13 +228,15 @@ def compact_ordered_physical_window(
     """Block-aligned physical resident window that fits the VMEM budget.
 
     :func:`compact_ordered_budget_capacity` gives the largest per-source length the
-    VMEM budget allows (the logical bound ``C``).  The resident ``pl.Element``
-    window, optional prep-cache scratch, and the refill/reduction ``pl.ds`` slices
-    are all tiled by the ordered block, so the allocation must be a block multiple.
-    Round the budget DOWN to a block multiple so the allocation never exceeds the
-    VMEM budget; cap by the operand extent rounded UP to one block so short tensors
-    still get a legal ``pl.Element(block, padding=...)`` window instead of a
-    zero-sized allocation.
+    VMEM budget allows (the logical bound ``C``).  The resident window, optional
+    prep-cache scratch, and the refill/reduction ``pl.ds`` slices are all tiled by
+    the ordered block, so the allocation must be a block multiple.  Round the
+    budget DOWN to a block multiple so the allocation never exceeds the VMEM
+    budget; cap by the operand extent rounded UP to one block so a short tensor
+    still gets a whole block rather than a zero-sized allocation -- including an
+    operand with no rows, which keeps resident caching (and therefore
+    ``pallas_loop_type='unroll'``) admissible for an all-empty ordered
+    reduction.
 
     Returns 0 when the budget cannot hold one ordered block. The selected loop
     policy decides whether that is an invalid resident config or irrelevant to a
@@ -249,6 +251,11 @@ def compact_ordered_physical_window(
     budget_physical = (budget_capacity // block) * block
     if budget_physical <= 0:
         return 0
+    # Floored to 1 so an operand with NO rows still admits a one-block window:
+    # returning 0 would make the resident decision inactive, and
+    # pallas_loop_type='unroll' rejects that outright, so a legal all-empty
+    # ordered reduction would stop compiling.  The window is made safe instead by
+    # padding one dummy row for such an operand (see _compute_pad_info).
     min_leading = min(max(1, int(shape[0])) for shape, _itemsize in operands)
     extent_physical = ((min_leading + block - 1) // block) * block
     return min(budget_physical, extent_physical)
@@ -831,16 +838,11 @@ def _pallas_padded_output_dims_by_arg(
     whose ``arg_idx`` is in ``output_arg_set`` so callers can slice
     those outputs back to their original shapes.  Both the torch path
     (via ``_LauncherFastPath``) and the JAX-export launcher use this.
-
-    A ``(arg_idx, dim)`` may appear more than once (a tensor reached by several
-    slicing windows), but it is padded once, so each dim is listed once.
     """
     padded_dims_by_arg: dict[int, list[int]] = {}
     for arg_idx, dim, _bs, _extra in _ds_pad_dims:
         if arg_idx in output_arg_set:
-            dims = padded_dims_by_arg.setdefault(arg_idx, [])
-            if dim not in dims:
-                dims.append(dim)
+            padded_dims_by_arg.setdefault(arg_idx, []).append(dim)
     return padded_dims_by_arg
 
 
@@ -963,60 +965,6 @@ def _pallas_collect_outputs(
     return tuple(output_only_results)
 
 
-def _pallas_resolve_ds_pad_amounts(
-    args: tuple[object, ...],
-    _ds_pad_dims: list[tuple[int, int, int, int]],
-) -> dict[int, dict[int, int]]:
-    """Rows of padding each ``(arg, dim)`` needs, as ``{arg_idx: {dim: pad}}``.
-
-    Every ``(arg_index, dim, block_size, extra_pad)`` entry asks for
-    ``(-rows) % block_size + extra_pad`` rows.  That covers two different
-    requirements:
-
-    * ALIGNMENT (``block_size > 1``) -- a ``pl.ds`` loop steps the dim in
-      ``block_size`` chunks, so the tensor rounds up to a block multiple.
-    * FIXED RIGHT SLACK (``block_size == 1``) -- a window opens at an arbitrary
-      runtime row and spans a fixed length, so it needs a set number of rows of
-      headroom past the end and nothing rounded.  ``(-rows) % 1`` is always 0,
-      so the amount is exactly ``extra_pad``.  These entries are DELIBERATE and
-      load-bearing: do not filter them out alongside the ``bs > 1`` test that
-      ``_compute_pad_info`` applies to alignment entries, or a compact-worklist
-      window silently loses its padding and reads past the tensor again.
-
-    ``_ds_pad_dims`` may carry SEVERAL entries for one ``(arg, dim)`` -- a tensor
-    can be reached by more than one window (e.g. a compact-aligned operand that
-    is also resident-cached), and the two kinds mix.  Their amounts are ordered
-    only once ``rows`` is known (an entry with a larger block can need LESS than
-    one with a smaller block and a bigger ``extra_pad``), so they cannot be
-    compared where they are emitted.  Resolve them here and keep the max, so a
-    single pad satisfies every window.
-
-    Every amount is measured against the ORIGINAL shape, so callers must apply
-    at most one pad per ``(arg, dim)``; padding once per entry would compound.
-    Zero-pad entries are dropped, so an empty result means "nothing to do".
-    """
-    amounts: dict[int, dict[int, int]] = {}
-    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
-        a = args[arg_idx]
-        if not isinstance(a, torch.Tensor):
-            continue
-        pad_amount = (-a.shape[dim]) % block_size + extra_pad
-        if pad_amount == 0:
-            continue
-        per_dim = amounts.setdefault(arg_idx, {})
-        if pad_amount > per_dim.get(dim, 0):
-            per_dim[dim] = pad_amount
-    return amounts
-
-
-def _pallas_pad_tensor_dims(a: torch.Tensor, dims: dict[int, int]) -> torch.Tensor:
-    """Pad ``a`` at the end of each ``dim`` by ``dims[dim]`` rows, in one call."""
-    pad_widths = [0] * (2 * a.ndim)
-    for dim, pad_amount in dims.items():
-        pad_widths[2 * (a.ndim - 1 - dim) + 1] = pad_amount
-    return torch.nn.functional.pad(a, pad_widths)
-
-
 def _pallas_apply_ds_padding_fast(
     args: tuple[object, ...],
     _ds_pad_dims: list[tuple[int, int, int, int]],
@@ -1024,22 +972,33 @@ def _pallas_apply_ds_padding_fast(
     padded_output_arg_indices: frozenset[int],
 ) -> tuple[tuple[object, ...], dict[int, torch.Tensor] | None, bool]:
     """``_pallas_apply_ds_padding`` with a short-circuit when every pad amount is zero."""
-    amounts = _pallas_resolve_ds_pad_amounts(args, _ds_pad_dims)
-    if fast_path.ds_pad_required is None:
-        # First-call precomputation: lock in whether any pad amount is
-        # non-zero so subsequent calls can elide the iteration outright.
-        fast_path.ds_pad_required = bool(amounts)
-    if not amounts:
-        return args, None, False
-    args_list = list(args)
+    args_list: list[object] | None = None
     orig_output_tensors: dict[int, torch.Tensor] | None = None
-    for arg_idx, dims in amounts.items():
-        a = cast("torch.Tensor", args_list[arg_idx])
+    any_padding = False
+    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
+        a = args[arg_idx] if args_list is None else args_list[arg_idx]
+        if not isinstance(a, torch.Tensor):
+            continue
+        pad_amount = (-a.shape[dim]) % block_size + extra_pad
+        if pad_amount == 0:
+            continue
+        any_padding = True
+        if args_list is None:
+            args_list = list(args)
         if arg_idx in padded_output_arg_indices:
             if orig_output_tensors is None:
                 orig_output_tensors = {}
-            orig_output_tensors[arg_idx] = a
-        args_list[arg_idx] = _pallas_pad_tensor_dims(a, dims)
+            if arg_idx not in orig_output_tensors:
+                orig_output_tensors[arg_idx] = cast("torch.Tensor", a)
+        pad_widths = [0] * (2 * a.ndim)
+        pad_widths[2 * (a.ndim - 1 - dim) + 1] = pad_amount
+        args_list[arg_idx] = torch.nn.functional.pad(a, pad_widths)
+    if fast_path.ds_pad_required is None:
+        # First-call precomputation: lock in whether any pad amount is
+        # non-zero so subsequent calls can elide the iteration outright.
+        fast_path.ds_pad_required = any_padding
+    if args_list is None:
+        return args, None, False
     return tuple(args_list), orig_output_tensors, True
 
 
@@ -1390,12 +1349,11 @@ def _pallas_apply_ds_padding(
     _output_indices: list[int],
     _ds_pad_dims: list[tuple[int, int, int, int]],
 ) -> tuple[tuple[object, ...], dict[int, torch.Tensor]]:
-    """Pad tensor args so a windowed read never runs past the tensor.
+    """Pad tensor args so ``pl.ds(offset, block_size)`` never reads OOB.
 
     ``_ds_pad_dims`` contains ``(arg_index, dim, block_size, extra_pad)``
-    tuples, possibly several for one ``(arg_index, dim)``;
-    :func:`_pallas_resolve_ds_pad_amounts` turns them into the single largest
-    pad each position needs, so every tensor is padded exactly once.
+    tuples.  The pad amount is ``(-tensor.shape[dim]) % block_size +
+    extra_pad``, where *extra_pad* accounts for non-zero loop begins.
 
     Returns the padded args tuple and a dict mapping output arg indices
     to their original (unpadded) tensors for post-call copy-back.
@@ -1403,11 +1361,18 @@ def _pallas_apply_ds_padding(
     args_list = list(args)
     orig_output_tensors: dict[int, torch.Tensor] = {}
     output_set = set(_output_indices)
-    for arg_idx, dims in _pallas_resolve_ds_pad_amounts(args, _ds_pad_dims).items():
-        a = cast("torch.Tensor", args_list[arg_idx])
-        if arg_idx in output_set:
+    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
+        a = args_list[arg_idx]
+        if not isinstance(a, torch.Tensor):
+            continue
+        pad_amount = (-a.shape[dim]) % block_size + extra_pad
+        if pad_amount == 0:
+            continue
+        if arg_idx in output_set and arg_idx not in orig_output_tensors:
             orig_output_tensors[arg_idx] = a
-        args_list[arg_idx] = _pallas_pad_tensor_dims(a, dims)
+        pad_widths = [0] * (2 * a.ndim)
+        pad_widths[2 * (a.ndim - 1 - dim) + 1] = pad_amount
+        args_list[arg_idx] = torch.nn.functional.pad(a, pad_widths)
     return tuple(args_list), orig_output_tensors
 
 
@@ -2185,47 +2150,54 @@ def _compact_window_block_spec(
     ref_pos: int,
     scalar_refs: tuple[object, ...],
 ) -> object:
-    """BlockSpec for one compact-worklist window: ``window`` rows of dim 0 at the
-    runtime row offset in ``scalar_refs[ref_pos]``, other dims full.
+    """BlockSpec for one compact-worklist window: up to ``window`` rows of dim 0
+    at the runtime row offset in ``scalar_refs[ref_pos]``, other dims full.
 
     The offset is a RAW compact row (an owner base plus a tile step), never
     aligned down to a sublane boundary, so the block dim must accept a dynamic,
-    possibly-unaligned start.  ``pl.Element`` is the mechanism that tolerates
-    that: Mosaic lowers an element-indexed block to a dynamic-offset access,
-    where a plain int block dim would require an aligned, fixed-grid block.
+    possibly-unaligned start.
 
-    ``pl.Element`` always transfers the FULL window, which runs off the end of a
-    compact/jagged tensor -- normally allocated with exactly ``sum(lengths)``
-    rows -- on the last tile of the final range.  Pallas does not prevent that:
-    it clamps a block dim against the array only when that dim is TILED (jax's
-    Mosaic ``_create_bounded_slice`` returns ``ds(start, window)`` verbatim when
-    the dim has no tiling, which is the case for the leading dim of a
-    ``(rows, ...)`` tensor), and ``Element``'s ``padding=`` never reaches that
-    computation.  Unpadded, the window DMAs whole blocks past the buffer: a
-    BoundsCheck core halt on ``dma.hbm_to_vmem``, plus a matching full-block
-    store past the output.  So the caller's tensor must carry enough rows of
-    slack past the end to cover the last window, which ``_compute_pad_info``
-    requests as a fixed-slack pad -- ``window - 1`` for a per-tile window,
-    whose start is at most ``rows - 1``, and a full ``window`` for a resident
-    one, whose start is a range base that an empty trailing range puts at
-    ``rows``.  ``_compact_window_pad_info`` derives both.
+    ``pl.BoundedSlice`` accepts one AND lets the index map choose the transfer
+    SIZE, which is what keeps the window inside the tensor.  That matters
+    because a compact/jagged tensor is normally allocated with exactly
+    ``sum(lengths)`` rows, so a fixed full-window transfer runs off the end on
+    the last window of the final range -- a BoundsCheck core halt on
+    ``dma.hbm_to_vmem``, plus a matching store past the output.  Pallas does not
+    prevent that by itself: it clamps a block dim against the array only when
+    that dim is TILED (jax's Mosaic ``_create_bounded_slice`` returns
+    ``ds(start, size)`` verbatim when the dim has no tiling, which is the case
+    for the leading dim of a ``(rows, ...)`` tensor).  A ``pl.Element`` window
+    cannot express the clamp -- its size is fixed and its ``padding=`` never
+    reaches that computation -- and would instead need the CALLER's tensor
+    padded, costing a full copy of every windowed operand.
 
-    The kernel body slices ``pl.ds(0, window)`` off a window-sized ref and masks
-    the tail, so rows past a range's end are already ignored.
+    The START is clamped too, and both clamps are held at or above zero:
+    worklist entries past ``num_work`` are padded with a repeated owner but an
+    unbounded group offset, so they can record a start beyond the tensor.  A
+    resident operand with no rows of its own is given one dummy row instead (see
+    ``_zero_row_resident_pad_info``), so the clamp always has an in-bounds row
+    and this slice is never empty.
+
+    The kernel body still slices ``pl.ds(0, window)`` off a window-sized ref and
+    masks the tail, so a short transfer only leaves already-masked rows stale.
     """
     from jax.experimental import pallas as pl
     import jax.numpy as jnp
 
     ndim = int(t.ndim)  # type: ignore[attr-defined]
-    block_shape = (pl.Element(window, padding=(0, window)), *t.shape[1:])  # type: ignore[union-attr,attr-defined]
+    block_shape = (pl.BoundedSlice(window), *t.shape[1:])  # type: ignore[union-attr,attr-defined]
 
     def index_map(
         wid: object,
         _pos: int = ref_pos,
         _nd: int = ndim,
+        _rows: int = int(t.shape[0]),  # type: ignore[attr-defined]
+        _window: int = window,
     ) -> tuple[object, ...]:
         start = scalar_refs[_pos][wid]  # type: ignore[index]
-        return (start, *(jnp.int32(0) for _ in range(_nd - 1)))
+        start = jnp.clip(start, 0, max(_rows - 1, 0))
+        size = jnp.clip(jnp.int32(_rows) - start, 0, _window)
+        return (pl.ds(start, size), *(jnp.int32(0) for _ in range(_nd - 1)))
 
     return pl.BlockSpec(block_shape, index_map)  # type: ignore[union-attr]
 
@@ -2255,8 +2227,8 @@ def _pallas_compact_in_out_specs(
     owner-indexed tensor (its ``grid_dims`` carry the owner grid dim ``0``) gets
     an ``index_map`` that reads ``owner_ids[wid]`` (a ``scalar_refs`` table); a
     compact-aligned-load tensor (``aligned_set``) gets a per-tile
-    ``pl.Element`` slice at ``tile_start`` so Pallas double-buffers it across work
-    items; everything else is full/SMEM.  ``scalar_refs`` are the SMEM refs
+    ``pl.BoundedSlice`` window at ``tile_start`` so Pallas double-buffers it
+    across work items; everything else is full/SMEM.  ``scalar_refs`` are the SMEM refs
     holding the worklist metadata tables; every ``index_map`` receives only
     ``wid`` and closes over them.
     """
@@ -2416,8 +2388,8 @@ def _pallas_compile_compact_jit_fn(
     )
     out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
     # NOTE: the shared _pallas_check_vmem_or_raise estimator does not yet
-    # understand pl.Element block shapes (compact_aligned_load), so it is not
-    # applied here; adding pl.Element support to the estimator is a follow-up.
+    # understand the compact window's block shape (compact_aligned_load), so it
+    # is not applied here; teaching the estimator about it is a follow-up.
     # Offsets-tensor positions within the tensor-arg list (jit_fn input order).
     offset_tpos = [arg_to_tensor_pos[i] for i in offset_arg_indices]
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4189,8 +4189,11 @@ class TestPallas(TestCase):
             match.group(1)
         )  # [(arg, dim, block_size, extra_pad)]
         self.assertTrue(pad_dims, "expected pl.ds pad dims to be present")
+        # Unpack every field rather than starring: a starred bind silently
+        # follows the tuple's last field if its shape ever changes, which would
+        # stop this from checking extra_pad at all.
         self.assertTrue(
-            all(extra_pad == 0 for *_, extra_pad in pad_dims),
+            all(extra_pad == 0 for _arg, _dim, _bs, extra_pad in pad_dims),
             f"block-aligned begin should skip the pad (extra_pad==0), got {pad_dims}",
         )
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4189,11 +4189,8 @@ class TestPallas(TestCase):
             match.group(1)
         )  # [(arg, dim, block_size, extra_pad)]
         self.assertTrue(pad_dims, "expected pl.ds pad dims to be present")
-        # Unpack every field rather than starring: a starred bind silently
-        # follows the tuple's last field if its shape ever changes, which would
-        # stop this from checking extra_pad at all.
         self.assertTrue(
-            all(extra_pad == 0 for _arg, _dim, _bs, extra_pad in pad_dims),
+            all(extra_pad == 0 for *_, extra_pad in pad_dims),
             f"block-aligned begin should skip the pad (extra_pad==0), got {pad_dims}",
         )
 

--- a/test/test_pallas_worklist.py
+++ b/test/test_pallas_worklist.py
@@ -2586,6 +2586,7 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         self.assertIsNone(ordered_resident_bound_arg(plan(None)))
 
 
+@onlyBackends(["pallas"])
 class TestCompactWindowSpec(unittest.TestCase):
     """The BlockSpec a compact-worklist window is built from.
 

--- a/test/test_pallas_worklist.py
+++ b/test/test_pallas_worklist.py
@@ -13,6 +13,7 @@ corresponding checkpoints land.
 from __future__ import annotations
 
 import ast
+import re
 import types
 import unittest
 from unittest.mock import patch
@@ -39,6 +40,7 @@ from helion._testing import skipIfPallasInterpret
 from helion._testing import skipUnlessPallas
 from helion.autotuner.config_fragment import EnumFragment
 import helion.language as hl
+from helion.runtime.pallas.launcher import _pallas_resolve_ds_pad_amounts
 from helion.runtime.settings import is_pallas_interpret
 
 if _get_backend() == "pallas" and is_pallas_interpret():
@@ -2561,6 +2563,102 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
 
         self.assertEqual(ordered_resident_bound_arg(plan("kvo")), "kvo")
         self.assertIsNone(ordered_resident_bound_arg(plan(None)))
+
+
+class TestCompactWindowPadding(unittest.TestCase):
+    """Row slack the compact-worklist windows request, and how it resolves.
+
+    A compact window is sliced by a BlockSpec at a runtime row offset, so the
+    kernel body never records it as a ``pl.ds`` and the caller's tensor gets no
+    padding unless ``_compute_pad_info`` asks for it.  Without that slack the
+    window DMAs a whole block past a tensor allocated with exactly
+    ``sum(lengths)`` rows, halting the core on a bounds check.
+    """
+
+    def test_fixed_slack_pads_exactly(self):
+        """``block_size == 1`` means "no rounding, pad exactly ``extra_pad``"."""
+        t = torch.zeros(200, 4)
+        self.assertEqual(
+            _pallas_resolve_ds_pad_amounts((t,), [(0, 0, 1, 255)]),
+            {0: {0: 255}},
+        )
+
+    def test_alignment_and_fixed_slack_resolve_to_the_max(self):
+        """Several requirements on one (arg, dim) take the max, never the sum.
+
+        Neither parameter orders them, which is why the winner cannot be chosen
+        where the entries are emitted: at 200 rows the fixed-slack entry
+        dominates one pair and the alignment entry dominates another, and the
+        second pair flips once the row count makes its modulo term vanish.
+        """
+        t200 = torch.zeros(200, 4)
+        # alignment (-200) % 128 == 56 vs fixed 255 -> 255, and NOT 56 + 255.
+        self.assertEqual(
+            _pallas_resolve_ds_pad_amounts((t200,), [(0, 0, 128, 0), (0, 0, 1, 255)]),
+            {0: {0: 255}},
+        )
+        # alignment (-200) % 1024 == 824 dominates the fixed 8 here ...
+        self.assertEqual(
+            _pallas_resolve_ds_pad_amounts((t200,), [(0, 0, 1024, 0), (0, 0, 1, 8)]),
+            {0: {0: 824}},
+        )
+        # ... but at 1024 rows that same pair flips: the modulo term is 0.
+        t1024 = torch.zeros(1024, 4)
+        self.assertEqual(
+            _pallas_resolve_ds_pad_amounts((t1024,), [(0, 0, 1024, 0), (0, 0, 1, 8)]),
+            {0: {0: 8}},
+        )
+
+
+@onlyBackends(["pallas"])
+class TestCompactWindowPadEmission(unittest.TestCase):
+    """The slack ``_compute_pad_info`` actually emits for each window kind."""
+
+    def _emitted(self, block=64):
+        """Launcher kwargs of a jagged ordered kernel, which has both windows."""
+        qo = _offsets([300, 100, 256])
+        lq = int(qo[-1])
+        bk = _noprep_ordered_kernel.bind(
+            (torch.randn(lq, 2, 8), torch.randn(lq, 2, 8), qo)
+        )
+        code = bk.to_triton_code(_worklist_config([block, block]))
+
+        def grab(name):
+            match = re.search(rf"{name}=(\[[^\]]*\]|\d+)", code)
+            self.assertIsNotNone(match, f"expected {name} in the launcher call")
+            return ast.literal_eval(match.group(1))
+
+        return {
+            name: grab(name)
+            for name in (
+                "_ds_pad_dims",
+                "_compact_aligned_arg_indices",
+                "_compact_ordered_aligned_arg_indices",
+                "_compact_block",
+                "_compact_ordered_window",
+            )
+        }
+
+    def test_compact_tile_window_requests_block_minus_one(self):
+        """A per-tile window only exists for a range with rows in it, so it
+        starts no later than ``rows - 1`` and reaches ``rows - 1 + block``."""
+        got = self._emitted()
+        aligned = got["_compact_aligned_arg_indices"]
+        self.assertTrue(aligned, "expected compact-aligned args")
+        for arg in aligned:
+            self.assertIn((arg, 0, 1, got["_compact_block"] - 1), got["_ds_pad_dims"])
+
+    def test_resident_window_requests_a_full_window(self):
+        """A resident window is keyed on a range START, and an owner whose
+        ordered range is empty puts that base at ``rows`` -- so it reaches
+        ``rows + window`` and needs one row more than the per-tile window."""
+        got = self._emitted()
+        ordered = got["_compact_ordered_aligned_arg_indices"]
+        self.assertTrue(ordered, "expected resident (owner-cache) args")
+        for arg in ordered:
+            self.assertIn(
+                (arg, 0, 1, got["_compact_ordered_window"]), got["_ds_pad_dims"]
+            )
 
 
 if __name__ == "__main__":

--- a/test/test_pallas_worklist.py
+++ b/test/test_pallas_worklist.py
@@ -13,7 +13,6 @@ corresponding checkpoints land.
 from __future__ import annotations
 
 import ast
-import re
 import types
 import unittest
 from unittest.mock import patch
@@ -40,13 +39,12 @@ from helion._testing import skipIfPallasInterpret
 from helion._testing import skipUnlessPallas
 from helion.autotuner.config_fragment import EnumFragment
 import helion.language as hl
-from helion.runtime.pallas.launcher import _pallas_resolve_ds_pad_amounts
 from helion.runtime.settings import is_pallas_interpret
 
 if _get_backend() == "pallas" and is_pallas_interpret():
     pytest.skip(
         "compact worklist is TPU-only: JAX interpret mode does not support "
-        "pl.Element block specs",
+        "dynamic pl.BoundedSlice sizes",
         allow_module_level=True,
     )
 
@@ -1804,6 +1802,29 @@ class TestWorklistNumerics(unittest.TestCase):
                 torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
 
     @skipIfPallasInterpret(
+        "the zero-row resident DMA path is validated on real TPU, not "
+        "Pallas interpret mode"
+    )
+    def test_fully_jagged_all_empty_kv_matches_zero(self):
+        """Positive Q with globally empty K/V exercises the dummy resident row."""
+        H, D, block = 2, 16, 16
+        qo = _offsets([10, 23, 7, 40])
+        kvo = _offsets([0, 0, 0, 0])
+        lq = int(qo[-1])
+        torch.manual_seed(0)
+        q = torch.randn(lq, H, D, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.empty(0, H, D, device=DEVICE, dtype=torch.bfloat16)
+        v = torch.empty(0, H, D, device=DEVICE, dtype=torch.bfloat16)
+
+        _, out = code_and_output(
+            _fully_jagged_kernel,
+            (q, k, v, qo.to(DEVICE), kvo.to(DEVICE)),
+            **_worklist_config([block, block], loop_type="unroll"),
+        )
+
+        torch.testing.assert_close(out, torch.zeros_like(q), rtol=0, atol=0)
+
+    @skipIfPallasInterpret(
         "the resident-cache ordered KV path is validated on real TPU, not "
         "Pallas interpret mode"
     )
@@ -2565,100 +2586,142 @@ class TestResidentCacheAndPrepHoist(unittest.TestCase):
         self.assertIsNone(ordered_resident_bound_arg(plan(None)))
 
 
-class TestCompactWindowPadding(unittest.TestCase):
-    """Row slack the compact-worklist windows request, and how it resolves.
+class TestCompactWindowSpec(unittest.TestCase):
+    """The BlockSpec a compact-worklist window is built from.
 
-    A compact window is sliced by a BlockSpec at a runtime row offset, so the
-    kernel body never records it as a ``pl.ds`` and the caller's tensor gets no
-    padding unless ``_compute_pad_info`` asks for it.  Without that slack the
-    window DMAs a whole block past a tensor allocated with exactly
-    ``sum(lengths)`` rows, halting the core on a bounds check.
+    The window must clamp its own transfer: a compact/jagged tensor is normally
+    allocated with exactly ``sum(lengths)`` rows, so a fixed full-window
+    transfer reads past the end on the last window of the final range.
     """
 
-    def test_fixed_slack_pads_exactly(self):
-        """``block_size == 1`` means "no rounding, pad exactly ``extra_pad``"."""
-        t = torch.zeros(200, 4)
-        self.assertEqual(
-            _pallas_resolve_ds_pad_amounts((t,), [(0, 0, 1, 255)]),
-            {0: {0: 255}},
-        )
+    def _spec(self, rows=200, window=256, start=0):
+        import jax.numpy as jnp
 
-    def test_alignment_and_fixed_slack_resolve_to_the_max(self):
-        """Several requirements on one (arg, dim) take the max, never the sum.
+        from helion.runtime.pallas.launcher import _compact_window_block_spec
 
-        Neither parameter orders them, which is why the winner cannot be chosen
-        where the entries are emitted: at 200 rows the fixed-slack entry
-        dominates one pair and the alignment entry dominates another, and the
-        second pair flips once the row count makes its modulo term vanish.
+        t = torch.zeros(rows, 2, 8)
+        starts = jnp.asarray([start], jnp.int32)
+        return _compact_window_block_spec(t, window, 0, (starts,)), rows, window
+
+    def test_window_is_a_self_clamping_bounded_slice(self):
+        """A BoundedSlice block dim lets the index map pick the transfer size,
+        which is what an Element window cannot express."""
+        from jax.experimental import pallas as pl
+
+        spec, _rows, window = self._spec()
+        self.assertIsInstance(spec.block_shape[0], pl.BoundedSlice)
+        self.assertEqual(spec.block_shape[0].block_size, window)
+        # Trailing dims ride along whole.
+        self.assertEqual(tuple(spec.block_shape[1:]), (2, 8))
+
+    def test_transfer_never_leaves_the_tensor(self):
+        """start + size <= rows for every start, including a start past the end.
+
+        Worklist entries past ``num_work`` are padded with a repeated owner but
+        an unbounded group offset, so they can record a start beyond the tensor;
+        the slice has to stay legal for those too.
         """
-        t200 = torch.zeros(200, 4)
-        # alignment (-200) % 128 == 56 vs fixed 255 -> 255, and NOT 56 + 255.
+        rows, window = 200, 256
+        for start in (0, 1, rows - window // 2, rows - 1, rows, rows + 10_000):
+            with self.subTest(start=start):
+                spec, _, _ = self._spec(rows=rows, window=window, start=start)
+                sliced = spec.index_map(0)[0]
+                lo = int(sliced.start)
+                size = int(sliced.size)
+                self.assertGreaterEqual(lo, 0)
+                self.assertGreaterEqual(size, 1)
+                self.assertLessEqual(lo + size, rows)
+
+    def test_one_row_operand_slices_that_row(self):
+        """An empty resident operand is padded to one dummy row, so the window
+        has an in-bounds row to slice: ``ds(0, 1)`` rather than ``ds(0, 0)``.
+
+        The row is never read -- an operand is only empty when every ordered
+        range is empty, so the reduction is zero-trip.
+        """
+        spec, _rows, _window = self._spec(rows=1, window=256, start=0)
+        sliced = spec.index_map(0)[0]
+        self.assertEqual(int(sliced.start), 0)
+        self.assertEqual(int(sliced.size), 1)
+
+    def test_zero_row_operand_keeps_a_one_block_window(self):
+        """A zero-row operand must still admit a window.
+
+        Returning 0 would make the resident decision inactive, and
+        ``pallas_loop_type='unroll'`` rejects that outright, so a legal
+        all-empty ordered reduction would stop compiling.
+        """
+        from helion.runtime.pallas.launcher import compact_ordered_physical_window
+
+        vmem = 64 * 1024 * 1024
         self.assertEqual(
-            _pallas_resolve_ds_pad_amounts((t200,), [(0, 0, 128, 0), (0, 0, 1, 255)]),
-            {0: {0: 255}},
+            compact_ordered_physical_window(
+                [((0, 2, 8), 2)], vmem, 128, prep_operands=[]
+            ),
+            128,
         )
-        # alignment (-200) % 1024 == 824 dominates the fixed 8 here ...
-        self.assertEqual(
-            _pallas_resolve_ds_pad_amounts((t200,), [(0, 0, 1024, 0), (0, 0, 1, 8)]),
-            {0: {0: 824}},
-        )
-        # ... but at 1024 rows that same pair flips: the modulo term is 0.
-        t1024 = torch.zeros(1024, 4)
-        self.assertEqual(
-            _pallas_resolve_ds_pad_amounts((t1024,), [(0, 0, 1024, 0), (0, 0, 1, 8)]),
-            {0: {0: 8}},
-        )
+
+    def test_full_window_when_it_fits(self):
+        """A window wholly inside the tensor transfers all of it -- the clamp
+        must not shrink transfers that were already in bounds."""
+        spec, _rows, window = self._spec(rows=4096, window=256, start=1000)
+        sliced = spec.index_map(0)[0]
+        self.assertEqual(int(sliced.start), 1000)
+        self.assertEqual(int(sliced.size), window)
 
 
 @onlyBackends(["pallas"])
-class TestCompactWindowPadEmission(unittest.TestCase):
-    """The slack ``_compute_pad_info`` actually emits for each window kind."""
+class TestZeroRowResidentPadding(unittest.TestCase):
+    """A resident operand with no rows gets exactly one dummy row.
 
-    def _emitted(self, block=64):
-        """Launcher kwargs of a jagged ordered kernel, which has both windows."""
-        qo = _offsets([300, 100, 256])
-        lq = int(qo[-1])
-        bk = _noprep_ordered_kernel.bind(
-            (torch.randn(lq, 2, 8), torch.randn(lq, 2, 8), qo)
+    Positive Q with all-empty KV is a legal zero-trip ordered reduction, but the
+    resident window is opened regardless, so an operand with zero rows would
+    leave it with no in-bounds row to slice.
+    """
+
+    def _pad_dims_and_resident(self, kvlens, block=128):
+        import ast as _ast
+        import re as _re
+
+        qo = _offsets([300, 100])
+        ko = _offsets(kvlens)
+        lq, lk = int(qo[-1]), int(ko[-1])
+        bk = _fully_jagged_kernel.bind(
+            (
+                torch.randn(lq, 2, 8),
+                torch.randn(lk, 2, 8),
+                torch.randn(lk, 2, 8),
+                qo,
+                ko,
+            )
         )
         code = bk.to_triton_code(_worklist_config([block, block]))
 
-        def grab(name):
-            match = re.search(rf"{name}=(\[[^\]]*\]|\d+)", code)
-            self.assertIsNotNone(match, f"expected {name} in the launcher call")
-            return ast.literal_eval(match.group(1))
+        def grab(name, default=None):
+            match = _re.search(rf"{name}=(\[[^\]]*\]|\d+)", code)
+            if match is None:
+                return default
+            return _ast.literal_eval(match.group(1))
 
-        return {
-            name: grab(name)
-            for name in (
-                "_ds_pad_dims",
-                "_compact_aligned_arg_indices",
-                "_compact_ordered_aligned_arg_indices",
-                "_compact_block",
-                "_compact_ordered_window",
-            )
-        }
+        return (
+            grab("_ds_pad_dims", []),
+            grab("_compact_ordered_aligned_arg_indices", []),
+        )
 
-    def test_compact_tile_window_requests_block_minus_one(self):
-        """A per-tile window only exists for a range with rows in it, so it
-        starts no later than ``rows - 1`` and reaches ``rows - 1 + block``."""
-        got = self._emitted()
-        aligned = got["_compact_aligned_arg_indices"]
-        self.assertTrue(aligned, "expected compact-aligned args")
-        for arg in aligned:
-            self.assertIn((arg, 0, 1, got["_compact_block"] - 1), got["_ds_pad_dims"])
+    def test_zero_row_kv_pads_one_row_per_resident_operand(self):
+        pad_dims, resident = self._pad_dims_and_resident([0, 0])
+        self.assertTrue(resident, "expected an active resident window for zero-row KV")
+        for arg in resident:
+            # block_size 1 makes the pad formula reduce to extra_pad: one row.
+            self.assertIn((arg, 0, 1, 1), pad_dims)
 
-    def test_resident_window_requests_a_full_window(self):
-        """A resident window is keyed on a range START, and an owner whose
-        ordered range is empty puts that base at ``rows`` -- so it reaches
-        ``rows + window`` and needs one row more than the per-tile window."""
-        got = self._emitted()
-        ordered = got["_compact_ordered_aligned_arg_indices"]
-        self.assertTrue(ordered, "expected resident (owner-cache) args")
-        for arg in ordered:
-            self.assertIn(
-                (arg, 0, 1, got["_compact_ordered_window"]), got["_ds_pad_dims"]
-            )
+    def test_non_empty_kv_pads_nothing(self):
+        """The dummy row must be confined to the degenerate case: padding a real
+        operand would copy the whole tensor."""
+        pad_dims, resident = self._pad_dims_and_resident([256, 128])
+        self.assertTrue(resident, "expected an active resident window")
+        for arg in resident:
+            self.assertNotIn((arg, 0, 1, 1), pad_dims)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace fixed-size `pl.Element` compact-worklist windows with self-clamping `pl.BoundedSlice` BlockSpecs.

This prevents compact aligned loads, stores, and resident ordered operands from issuing TPU DMAs beyond the physical end of packed tensors.

## Problem

Compact and jagged tensors are normally allocated with exactly `sum(lengths)` rows. The compact-worklist launcher previously opened a fixed-size `pl.Element` window at each runtime tile or range start.

For the final window, `start + window` can exceed the tensor’s leading extent. `pl.Element(..., padding=...)` does not clamp the underlying DMA slice for this untiled dimension, allowing out-of-bounds HBM-to-VMEM transfers and store writebacks. On TPU this can produce a `BoundsCheck` core halt.

## Fix

Introduce a shared compact-window BlockSpec using:

`pl.BoundedSlice(window)`

Its index map dynamically clamps both components:

- `start` remains within the tensor.
- `size` is limited to `min(window, rows - start)`.

The same helper is used for:

- Compact aligned loads.
- Compact exact stores.
- Resident ordered-reduction operands.

The kernel body still sees a statically sized VMEM window and retains its existing tail masks. Only the underlying DMA extent changes.

`BoundedSlice` is supported by the buffered `pl.kernel` pipeline used here in JAX 0.10.1. The unsupported top-level `pl.pallas_call` and unbuffered `compute_slice` paths are not used by this compact launcher.

## Zero-Row Operands

Explicit unroll requires resident-cache admission. Returning a zero physical window for globally empty K/V would disable residency and reject an otherwise valid zero-trip reduction.

For an active resident operand with `shape[0] == 0`, the compiler therefore emits one existing-format padding entry:

`(arg_index, 0, 1, 1)`

This adds one dummy row, allowing a legal `pl.ds(0, 1)` transfer while retaining a one-block resident window. The ordered range length remains zero, so the dummy row is never consumed.

This exception is strictly limited to concretely empty compact resident operands. Nonempty operands emit no additional padding entry.