### PR TITLE
[examples] Stabilize Welford variance computation

### DIFF
--- a/examples/welford.py
+++ b/examples/welford.py
@@ -48,15 +48,15 @@ def welford(
         acc_m2 = torch.zeros_like(acc_cnt)
 
         for tile_n in hl.tile(n):
-            chunk = x[tile_m, tile_n]
+            valid = tile_n.index < n
+            chunk = x[tile_m, tile_n].to(torch.float32)
             # Count of VALID columns (the divisor): use the true valid count, not the constexpr
             # tile width (over-counts last-tile padding). Cast the mask to int32 BEFORE summing —
             # a bool operand gives CuTe a saturating accumulator (-> NaN).
-            Tn = (tile_n.index < n).to(torch.int32).sum()
-            sum_x = torch.sum(chunk, dim=-1)
-            sum_x2 = torch.sum(chunk * chunk, dim=-1)
-            mean_c = sum_x / Tn
-            m2_c = sum_x2 - (sum_x * sum_x) / Tn
+            Tn = valid.to(torch.int32).sum()
+            mean_c = torch.sum(chunk, dim=-1) / Tn
+            centered = torch.where(valid, chunk - mean_c[:, None], 0.0)
+            m2_c = torch.sum(centered * centered, dim=-1)
 
             delta = mean_c - acc_mean
             new_cnt = acc_cnt + Tn
@@ -70,12 +70,12 @@ def welford(
         rstd_col = rstd_tile[:, None]
 
         for tile_n in hl.tile(n):
-            xi_chuck = x[tile_m, tile_n]
-            w_chuck = weight[tile_n][None, :]
-            b_chuck = bias[tile_n][None, :]
+            xi_chunk = x[tile_m, tile_n].to(torch.float32)
+            w_chunk = weight[tile_n][None, :]
+            b_chunk = bias[tile_n][None, :]
 
-            y = (xi_chuck - mean_col) * rstd_col
-            y = y * w_chuck + b_chuck
+            y = (xi_chunk - mean_col) * rstd_col
+            y = y * w_chunk + b_chunk
 
             out[tile_m, tile_n] = y.to(x.dtype)
     return out

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -38,6 +38,7 @@ from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
 from helion._testing import skipIfXPU
+from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
@@ -638,6 +639,46 @@ class TestExamples(RefEagerTestBase, TestCase):
                 eps=1e-05,
             ),
         )
+
+    @parametrize("reduction_block_size", (32, 1024))
+    @onlyBackends(["triton"])
+    @skipIfNotCUDA()
+    @skipIfRefEager("Test requires compiling a specific reduction config")
+    @skipUnlessTensorDescriptor("Test configs require tensor descriptor support")
+    def test_welford_bfloat16_accuracy(self, reduction_block_size):
+        from examples.welford import eager_layer_norm
+        from examples.welford import welford
+
+        config = helion.Config(
+            atomic_indexing=[],
+            block_sizes=[16, reduction_block_size, 256],
+            indexing=[
+                "pointer",
+                "pointer",
+                "pointer",
+                "tensor_descriptor",
+                "pointer",
+            ],
+            load_eviction_policies=["last", "first", "", "last"],
+            num_stages=1,
+            num_warps=4,
+            pid_type="flat",
+            range_flattens=[None, None, None],
+            range_multi_buffers=[None, None, None],
+            range_num_stages=[0, 0, 0],
+            range_unroll_factors=[0, 0, 0],
+        )
+
+        torch.manual_seed(1337)
+        rows, columns = 4096, 1024
+        weight = torch.randn(columns, device=DEVICE, dtype=torch.bfloat16)
+        bias = torch.randn(columns, device=DEVICE, dtype=torch.bfloat16)
+        x = torch.randn(rows, columns, device=DEVICE, dtype=torch.bfloat16)
+        expected = eager_layer_norm(weight, bias, x)
+
+        actual = welford.bind((weight, bias, x)).compile_config(config)(weight, bias, x)
+
+        torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
     def test_low_mem_dropout(self):
         from examples.low_mem_dropout import low_mem_dropout


### PR DESCRIPTION
## Summary

- compute per-chunk Welford statistics in FP32 using centered squared differences instead of subtracting raw second moments
- mask padded columns before the centered M2 reduction and keep the existing Chan/Welford merge
- add seeded BF16 accuracy coverage for reduction block sizes 32 and 1024

The previous `sum(x^2) - sum(x)^2 / n` calculation loses precision through cancellation. On the compact regression input, the 1024-wide reduction produced 11 values outside `atol=rtol=0.01`; the centered calculation produces none.

We compute `Σ(xᵢ - mean)² ` instead. 

## Nightly failures

- [First failing nightly benchmark dispatch](https://github.com/pytorch/helion/actions/runs/29905576561) (`90bad434`, July 22)
- [B200 Welford benchmark job](https://github.com/pytorch/helion/actions/runs/29905576561/job/88980600248)
- [H100 Welford benchmark job](https://github.com/pytorch/helion/actions/runs/29905576561/job/88980600740)

Both platform jobs recorded Welford accuracy mismatches at the benchmark tolerance.

## Test plan

- `pytest test/test_examples.py -k welford -x -vv -s`
- `HELION_BACKEND=cute pytest test/test_examples.py::TestExamples::test_welford -x -vv -s`
- `python -m py_compile examples/welford.py test/test_examples.py`
- `git diff --check`

Pallas-interpret could not be exercised locally because JAX is not installed. `./lint.sh fix` could not run because ruff and pyrefly are not installed; CI will provide those checks.