### PR TITLE
[ci] Bound KDA component autotuning time

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -279,6 +279,12 @@ jobs:
           echo "Kernels: ${KERNELS:-all}"
           echo "=========================================="
 
+          # KDA tunes ten component kernels for each of two shapes. Cap each
+          # search at 15 minutes so the combined job stays below six hours.
+          if [[ "$KERNELS" == "kda" ]]; then
+            export HELION_AUTOTUNE_BUDGET_SECONDS=900
+          fi
+
           ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 \
           python -m benchmarks.run_linattn \
               "${KERNEL_FLAG[@]}" \


### PR DESCRIPTION
## Summary

- cap each KDA component autotune at 900 seconds in the linear-attention benchmark job
- leave the existing 5400-second budget unchanged for every other linear-attention variant
- preserve normal behavior for KDA component searches that finish before the cap

KDA autotunes ten component kernels for each of two shapes. A 900-second cap gives the 20 searches a nominal five-hour ceiling, leaving one hour for setup, correctness references, FLA measurements, result generation, and artifact upload before GitHub Actions' six-hour limit. Searches that hit the cap return their best configuration found so far.

## Failure

The [Aug 3 B200 KDA job](https://github.com/pytorch/helion/actions/runs/30799794262/job/91642480985) was canceled at 6h00m05s before `run_linattn` wrote `helionbench.json`, so both `kda` and `kda-bwd` were missing from the dashboard.

Recent B200 KDA job history:

| Date | Runtime | Result | Job |
| --- | ---: | --- | --- |
| Jul 30 | 5h51m56s | Success | [job 90910896526](https://github.com/pytorch/helion/actions/runs/30528444683/job/90910896526) |
| Jul 31 | 5h48m57s | Success | [job 91191116909](https://github.com/pytorch/helion/actions/runs/30618247877/job/91191116909) |
| Aug 1 | 5h34m47s | Success | [job 91387634301](https://github.com/pytorch/helion/actions/runs/30692341054/job/91387634301) |
| Aug 2 | 5h23m13s | Success | [job 91529668832](https://github.com/pytorch/helion/actions/runs/30740401662/job/91529668832) |
| Aug 3 | 6h00m05s | Canceled | [job 91642480985](https://github.com/pytorch/helion/actions/runs/30799794262/job/91642480985) |

The Aug 2 and Aug 3 runs used the same Helion revision, PyTorch 2.12.1, Triton 3.7.1, FLA revision, and autotune seed. Aug 3 searched 800 more configurations and spent 38 additional minutes autotuning, pushing a workload already close to the limit over six hours.

## Testing

- `git diff --check`
- parsed `.github/workflows/benchmark.yml` with PyYAML