### PR TITLE
[xpu][build] Open TRITON_BUILD_PROTON for XPU

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,11 +166,6 @@ jobs:
           git -C triton checkout ${{ matrix.triton-pin }}
           cd triton/
           uv pip install -r python/requirements.txt
-          # Disable proton on XPU: proton's NVIDIA sources (CuptiApi.cpp, NvtxApi.cpp)
-          # require CUDA headers that are not present on Intel XPU runners.
-          if [ "${{ matrix.alias }}" == "xpu" ]; then
-            export TRITON_BUILD_PROTON=OFF
-          fi
           MAX_JOBS=$(nproc) TRITON_PARALLEL_LINK_JOBS=2 uv pip install .
           cd /tmp/$USER
           rm -rf triton/


### PR DESCRIPTION
Formerly, we disabled the PROTON build on XPU, now it could be opened.