### PR TITLE
[Pallas] compact worklist: never request more scoped VMEM than the device allows

### DIFF
--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1478,9 +1478,7 @@ class PallasBackend(Backend):
             from ...runtime.pallas.launcher import _get_vmem_limit_bytes
             from .compact_worklist import build_resident_cache_admission
 
-            # Choose C from the conservative device-reported VMEM budget. The
-            # higher Mosaic compile ceiling used by the runtime is not an
-            # allocation budget.
+            # Choose C from the conservative device-reported VMEM budget.
             admission = build_resident_cache_admission(
                 graphs,
                 plan,

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -2450,19 +2450,14 @@ def _pallas_compile_compact_jit_fn(
             # scratch_types); pass whichever this pallas exposes.
             **{_pallas_kernel_scratch_kwarg(pl): all_scratch},  # pyrefly: ignore[bad-argument-type]
             compiler_params=pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                # Resident caching sizes its physical window from
-                # _get_vmem_limit_bytes during backend setup.  This 128MiB
-                # floor is ONLY a Mosaic compile ceiling so TPU7x accepts that
-                # already-sized allocation; do not use it to choose C.  A
-                # streamed compact_worklist kernel keeps the platform default.
-                vmem_limit_bytes=(
-                    max(
-                        _get_vmem_limit_bytes(pltpu, _pallas_interpret_enabled()),
-                        128 * 1024 * 1024,
-                    )
-                    if ordered_aligned_arg_indices
-                    else _get_vmem_limit_bytes(pltpu, _pallas_interpret_enabled())
-                ),
+                # The device capacity is also the largest scoped-Vmem XLA will
+                # accept, so never request more: a bare kernel call is clamped
+                # down with a warning, but the same request inside a shard_map
+                # is rejected outright (INVALID_ARGUMENT; see
+                # https://openxla.org/xla/errors/error_0200).
+                # Resident caching sizes its physical window conservatively
+                # from this capacity during backend setup.
+                vmem_limit_bytes=_get_vmem_limit_bytes(pltpu, interpret),
             ),
             interpret=interpret,
         )


### PR DESCRIPTION
removes the 128 * 1024 * 1024 vmem budget that would only be valid for v7