### PR TITLE
[ci] Pin Quack to 0.6.1

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -152,7 +152,9 @@ jobs:
           set -x
           source .venv/bin/activate
           uv pip install pip
-          uv pip install quack-kernels --no-deps
+          # Quack 0.6.2 requires nvidia-cutlass-dsl==4.6.1, which is incompatible
+          # with Helion's nvidia-cutlass-dsl==4.5.2 pin.
+          uv pip install "quack-kernels==0.6.1" --no-deps
           mkdir -p benchmarks/ && pushd benchmarks/
           git clone https://github.com/pytorch-labs/tritonbench/
           pushd tritonbench/


### PR DESCRIPTION
## Summary

- pin `quack-kernels` to the last working `0.6.1` release in benchmark CI
- document that Quack 0.6.2 requires `nvidia-cutlass-dsl==4.6.1`, conflicting with Helion's `4.5.2` pin

## Context

The [B200 CuTe RMSNorm benchmark](https://github.com/pytorch/helion/actions/runs/30896001298/job/91950573551) began resolving Quack 0.6.2 after its release. TritonBench eagerly imports its optional Quack RMSNorm implementation, which then fails to import `alloc_reserved_mbarrier` from CUTLASS DSL 4.5.2. The preceding successful run resolved Quack 0.6.1.

## Testing

- `git diff --check`