### PR TITLE
Round maxRegAutoWS values up to a multiple of 8

### DIFF
--- a/examples/blackwell_attention.py
+++ b/examples/blackwell_attention.py
@@ -107,7 +107,7 @@ def _fma_f32x2(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor) -> torch.Tenso
 #       ],
 #       _triton_range_id_data_partition_factor=0,
 #       _triton_range_value_data_partition_factor=0,
-#       _triton_config_maxRegAutoWS=196,
+#       _triton_config_maxRegAutoWS=200,
 #   )
 # pyrefly: ignore [no-matching-overload]
 @helion.kernel(
@@ -302,13 +302,13 @@ def _bwd_preprocess(o_in: torch.Tensor, do_in: torch.Tensor) -> torch.Tensor:
 #           ["opndA,smem,1,8", "opndD,tmem,1,11"],
 #           ["opndA,tmem,1,5", "opndD,tmem,1,10"],
 #       ],
-#       _triton_config_maxRegAutoWS=188,
+#       _triton_config_maxRegAutoWS=192,
 #   )
 #
 # The AutoWS variant also registers:
 #   hl.register_tunable(
 #       "_triton_config_maxRegAutoWS",
-#       EnumFragment(choices=(160, 168, 176, 184, 188, 192, 196)),
+#       EnumFragment(choices=(160, 168, 176, 184, 192, 200)),
 #   )
 #
 # pyrefly: ignore [no-matching-overload]


### PR DESCRIPTION
Summary:
AutoWS register budgets must be divisible by 8. Both entry points validate it:

- `triton.Config(minRegAutoWS=..., maxRegAutoWS=...)` -- checked by
  `_check_reg_auto_ws_alignment` in `runtime/autotuner.py` and again in
  `nvidia/backend/compiler.py`, raising
  `ValueError: maxRegAutoWS must be divisible by 8`.
- `tlx.async_task(num_regs=... / registers=...)` -- checked by
  `_validate_num_regs` in `tlx/language/tlx/async_task_utils.py`.

The AutoWS design doc gives the reason: the value "must be divisible by 8 so
the emitted register allocation matches the backend warp-group granularity".

`examples/blackwell_attention.py` carried three `maxRegAutoWS` values that are
not multiples of 8. Rounded up to the next multiple, matching what the compiler
does by default:

- `196` -> `200`
- `188` -> `192`
- the AutoWS-variant tunable `EnumFragment(choices=(160, 168, 176, 184, 188,
  192, 196))` -> `(160, 168, 176, 184, 192, 200)`

Note the choices tuple drops from 7 entries to 6: rounding `188` up lands on
`192`, which was already in the set, so the duplicate is removed. `196` -> `200`
is a new entry.

All three sites are inside commented-out AutoWS-variant config blocks, so
nothing fails to compile today -- the active tunable is
`EnumFragment(choices=(152, 192))`, which is already valid. But those comments
document the configuration to enable for the AutoWS variant, and 2 of the 7
documented choices would have raised as soon as the autotuner selected them.

Not covered here: 16 `tlx.async_task(..., registers=100)` sites in
`third-party/triton/stable` and `fbcode/triton_mtia`, excluded per request.
Those are a live divisibility violation -- they only survive because
`_validate_num_regs` currently exists in the `beta` tree, so they will start
raising when stable/mtia pick it up. `beta` already uses `registers=96`.

___

Differential Revision: D114755486


