### PR TITLE
[DO NOT MERGE] Diagnose MI350X layer_norm accuracy failure

### DIFF
--- a/.github/workflows/diagnose_layer_norm_mi350x.yml
+++ b/.github/workflows/diagnose_layer_norm_mi350x.yml
@@ -1,0 +1,126 @@
+name: Diagnose MI350X layer norm accuracy
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/diagnose_layer_norm_mi350x.yml
+      - scripts/diagnose_layer_norm_mi350x.py
+  workflow_dispatch:
+
+concurrency:
+  group: mi350x-layer-norm-diagnostic-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  diagnose:
+    name: Reproduce and isolate on MI350X
+    runs-on: linux.rocm.gpu.ecosystem.gfx950.1
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    container:
+      image: rocm/dev-ubuntu-24.04:7.1.1-complete
+      options: --device=/dev/kfd --device=/dev/dri
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      HELION_AUTOTUNE_LOG_LEVEL: INFO
+      HELION_AUTOTUNE_BUDGET_SECONDS: "5400"
+      HELION_AUTOTUNE_RANDOM_SEED: "123456"
+      HELION_PRINT_OUTPUT_CODE: "1"
+      HIP_VISIBLE_DEVICES: "0"
+      ROCR_VISIBLE_DEVICES: "0"
+
+    steps:
+      - name: Setup toolchain
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y git
+
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Record ROCm and runner identity
+        run: |
+          set -euo pipefail
+          mkdir -p diagnostics/system
+          rocminfo 2>&1 | tee diagnostics/system/rocminfo.txt
+          rocm-smi --showdriverversion --showuniqueid --showserial --showbus --showproductname 2>&1 | tee diagnostics/system/rocm-smi.txt || true
+          amd-smi version 2>&1 | tee diagnostics/system/amd-smi-version.txt || true
+          cat /opt/rocm/.info/version 2>&1 | tee diagnostics/system/rocm-version.txt || true
+          uname -a 2>&1 | tee diagnostics/system/uname.txt
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Create virtual environment
+        run: uv venv --python 3.12
+
+      - name: Install exact benchmark dependencies
+        run: |
+          set -euo pipefail
+          source .venv/bin/activate
+          PYTORCH_INDEX="${PYPI_CACHE_WHL_URL:-https://download.pytorch.org/whl/cpu}"
+          UV_DEFAULT_INDEX= UV_INDEX= uv pip install -U "torch==2.11.*" --index-url "${PYTORCH_INDEX%/whl/*}/whl/rocm7.1"
+          SETUPTOOLS_SCM_PRETEND_VERSION="0.0.0" uv pip install -e .'[dev]'
+          python -c "import helion, torch, triton; print(helion.__file__, torch.__version__, triton.__version__)"
+
+      - name: Run fixed-config isolation matrix
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          source .venv/bin/activate
+          status=0
+          for variant in exact no_xcd_remap no_load_cache_modifiers no_store_cache_modifiers waves_per_eu_1 block_size_8; do
+            rm -rf "/tmp/helion-layer-norm-${variant}" "/tmp/torchinductor-layer-norm-${variant}"
+            if ! HELION_CACHE_DIR="/tmp/helion-layer-norm-${variant}" \
+              TORCHINDUCTOR_CACHE_DIR="/tmp/torchinductor-layer-norm-${variant}" \
+              python scripts/diagnose_layer_norm_mi350x.py \
+                --mode fixed \
+                --variant "${variant}" \
+                --iterations 250 \
+                --graph-repeats 128 \
+                --graph-replays 10 \
+                --output-dir "diagnostics/fixed-${variant}" \
+                2>&1 | tee "diagnostics/fixed-${variant}.log"; then
+              status=1
+            fi
+          done
+          exit "${status}"
+
+      - name: Reproduce the full autotune-to-accuracy sequence
+        run: |
+          set -euo pipefail
+          source .venv/bin/activate
+          rm -rf /tmp/helion-layer-norm-autotune /tmp/torchinductor-layer-norm-autotune
+          HELION_AUTOTUNE_LOG="$PWD/diagnostics/autotune" \
+          HELION_CACHE_DIR=/tmp/helion-layer-norm-autotune \
+          TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor-layer-norm-autotune \
+          python scripts/diagnose_layer_norm_mi350x.py \
+            --mode autotune \
+            --iterations 250 \
+            --graph-repeats 128 \
+            --graph-replays 10 \
+            --output-dir diagnostics/autotune-sequence \
+            2>&1 | tee diagnostics/autotune-sequence.log
+
+      - name: Print diagnostic summaries
+        if: always()
+        run: |
+          set -euo pipefail
+          find diagnostics -name summary.json -print -exec cat {} \;
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mi350x-layer-norm-diagnostics-${{ github.run_attempt }}
+          path: diagnostics
+          if-no-files-found: error

--- a/.github/workflows/diagnose_layer_norm_mi350x.yml
+++ b/.github/workflows/diagnose_layer_norm_mi350x.yml
@@ -48,6 +48,7 @@ jobs:
           mkdir -p diagnostics/system
           rocminfo 2>&1 | tee diagnostics/system/rocminfo.txt
           rocm-smi --showdriverversion --showuniqueid --showserial --showbus --showproductname 2>&1 | tee diagnostics/system/rocm-smi.txt || true
+          rocm-smi --showrasinfo --showpagesinfo --showreplaycount --showxgmierr --showuse --showmemuse 2>&1 | tee diagnostics/system/rocm-health-before.txt || true
           amd-smi version 2>&1 | tee diagnostics/system/amd-smi-version.txt || true
           cat /opt/rocm/.info/version 2>&1 | tee diagnostics/system/rocm-version.txt || true
           uname -a 2>&1 | tee diagnostics/system/uname.txt
@@ -105,11 +106,18 @@ jobs:
           TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor-layer-norm-autotune \
           python scripts/diagnose_layer_norm_mi350x.py \
             --mode autotune \
+            --precondition-autotune \
             --iterations 250 \
             --graph-repeats 128 \
             --graph-replays 10 \
             --output-dir diagnostics/autotune-sequence \
             2>&1 | tee diagnostics/autotune-sequence.log
+
+      - name: Record final ROCm health
+        if: always()
+        run: |
+          set -euo pipefail
+          rocm-smi --showrasinfo --showpagesinfo --showreplaycount --showxgmierr --showuse --showmemuse 2>&1 | tee diagnostics/system/rocm-health-after.txt || true
 
       - name: Print diagnostic summaries
         if: always()

--- a/scripts/diagnose_layer_norm_mi350x.py
+++ b/scripts/diagnose_layer_norm_mi350x.py
@@ -93,6 +93,14 @@ class PhaseResult(TypedDict):
     first_failures: list[dict[str, object]]
 
 
+class PhaseSuite(TypedDict):
+    direct_before_graph: PhaseResult
+    graph_benchmark: dict[str, object]
+    accuracy_after_graph: PhaseResult
+    raw_poison_after_graph: PhaseResult
+    raw_after_graph: PhaseResult
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=("fixed", "autotune"), required=True)
@@ -337,6 +345,51 @@ def run_tritonbench_accuracy_stress(
     }
 
 
+def run_phase_suite(
+    *,
+    iterations: int,
+    direct_iterations: int,
+    skip_graph: bool,
+    graph_repeats: int,
+    graph_replays: int,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    references: dict[str, torch.Tensor],
+) -> PhaseSuite:
+    direct = run_raw_stress(direct_iterations, x, weight, bias, references)
+    if skip_graph:
+        graph: dict[str, object] = {"skipped": True}
+    else:
+        graph = graph_benchmark(
+            lambda: layer_norm.layer_norm(x, [N], weight, bias, EPS),
+            graph_repeats=graph_repeats,
+            graph_replays=graph_replays,
+        )
+    accuracy = run_tritonbench_accuracy_stress(iterations, x, weight, bias)
+    raw_poison = run_raw_poison_stress(iterations, x, weight, bias, references)
+    post_graph_raw = run_raw_stress(20, x, weight, bias, references)
+    return {
+        "direct_before_graph": direct,
+        "graph_benchmark": graph,
+        "accuracy_after_graph": accuracy,
+        "raw_poison_after_graph": raw_poison,
+        "raw_after_graph": post_graph_raw,
+    }
+
+
+def count_suite_failures(phases: PhaseSuite) -> int:
+    return sum(
+        phase["failure_count"]
+        for phase in (
+            phases["direct_before_graph"],
+            phases["accuracy_after_graph"],
+            phases["raw_poison_after_graph"],
+            phases["raw_after_graph"],
+        )
+    )
+
+
 def archive_compiler_artifacts(
     output_dir: Path,
     bound: BoundKernel[object],
@@ -399,6 +452,7 @@ def environment_info() -> dict[str, object]:
 def main() -> int:
     args = parse_args()
     args.output_dir.mkdir(parents=True, exist_ok=True)
+    source_fn = layer_norm.layer_norm_fwd.fn
     x, weight, bias = make_inputs()
     references = {
         "x": x.detach().clone(),
@@ -415,13 +469,13 @@ def main() -> int:
     autotune_seconds = None
     if args.mode == "autotune":
         kernel = helion.kernel(
-            layer_norm.layer_norm_fwd.fn,
+            source_fn,
             static_shapes=True,
             force_autotune=True,
         )
     else:
         kernel = helion.kernel(
-            layer_norm.layer_norm_fwd.fn,
+            source_fn,
             config=make_config(args.variant),
             static_shapes=True,
         )
@@ -442,18 +496,54 @@ def main() -> int:
     direct_iterations = (
         min(args.iterations, 20) if args.mode == "autotune" else args.iterations
     )
-    direct = run_raw_stress(direct_iterations, x, weight, bias, references)
-    if args.skip_graph:
-        graph: dict[str, object] = {"skipped": True}
-    else:
-        graph = graph_benchmark(
-            lambda: layer_norm.layer_norm(x, [N], weight, bias, EPS),
+    phases = run_phase_suite(
+        iterations=args.iterations,
+        direct_iterations=direct_iterations,
+        skip_graph=args.skip_graph,
+        graph_repeats=args.graph_repeats,
+        graph_replays=args.graph_replays,
+        x=x,
+        weight=weight,
+        bias=bias,
+        references=references,
+    )
+    compiler = archive_compiler_artifacts(args.output_dir, bound, config)
+
+    post_autotune_exact = None
+    post_autotune_exact_failure_count = 0
+    if args.mode == "autotune":
+        exact_kernel = helion.kernel(
+            source_fn,
+            config=make_config("exact"),
+            static_shapes=True,
+        )
+        layer_norm.layer_norm_fwd = exact_kernel
+        layer_norm.layer_norm_fwd(x, [N], weight, bias, EPS)
+        torch.cuda.synchronize()
+        exact_bound = exact_kernel.bind((x, [N], weight, bias, EPS))
+        exact_config = exact_bound._config
+        assert exact_config is not None
+        exact_phases = run_phase_suite(
+            iterations=args.iterations,
+            direct_iterations=20,
+            skip_graph=args.skip_graph,
             graph_repeats=args.graph_repeats,
             graph_replays=args.graph_replays,
+            x=x,
+            weight=weight,
+            bias=bias,
+            references=references,
         )
-    accuracy = run_tritonbench_accuracy_stress(args.iterations, x, weight, bias)
-    raw_poison = run_raw_poison_stress(args.iterations, x, weight, bias, references)
-    post_graph_raw = run_raw_stress(20, x, weight, bias, references)
+        post_autotune_exact = {
+            "selected_config": dict(exact_config),
+            **exact_phases,
+            "compiler": archive_compiler_artifacts(
+                args.output_dir / "post-autotune-exact",
+                exact_bound,
+                exact_config,
+            ),
+        }
+        post_autotune_exact_failure_count = count_suite_failures(exact_phases)
     torch.cuda.synchronize()
 
     summary = {
@@ -468,19 +558,13 @@ def main() -> int:
             "weight": not torch.equal(weight, references["weight"]),
             "bias": not torch.equal(bias, references["bias"]),
         },
-        "direct_before_graph": direct,
-        "graph_benchmark": graph,
-        "accuracy_after_graph": accuracy,
-        "raw_poison_after_graph": raw_poison,
-        "raw_after_graph": post_graph_raw,
-        "compiler": archive_compiler_artifacts(args.output_dir, bound, config),
+        **phases,
+        "compiler": compiler,
+        "post_autotune_exact": post_autotune_exact,
     }
     summary_path = args.output_dir / "summary.json"
     summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
-    mismatch_count = sum(
-        phase["failure_count"]
-        for phase in (direct, accuracy, raw_poison, post_graph_raw)
-    )
+    mismatch_count = count_suite_failures(phases) + post_autotune_exact_failure_count
     print(
         "SUMMARY "
         f"mode={args.mode} variant={args.variant} "

--- a/scripts/diagnose_layer_norm_mi350x.py
+++ b/scripts/diagnose_layer_norm_mi350x.py
@@ -22,6 +22,7 @@ import helion
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from collections.abc import Iterator
 
     from helion.runtime.kernel import BoundKernel
 
@@ -109,6 +110,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--graph-repeats", type=int, default=128)
     parser.add_argument("--graph-replays", type=int, default=10)
     parser.add_argument("--skip-graph", action="store_true")
+    parser.add_argument("--precondition-autotune", action="store_true")
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--fail-on-mismatch", action="store_true")
     return parser.parse_args()
@@ -129,7 +131,7 @@ def make_config(variant: str) -> helion.Config:
     return helion.Config.from_dict(values)
 
 
-def make_inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+def iter_inputs() -> Iterator[tuple[int, torch.Tensor, torch.Tensor, torch.Tensor]]:
     torch.manual_seed(1337)
     for n in (1024, 1536, 2048, N):
         x = -2.3 + 0.5 * torch.randn((M, n), dtype=torch.float32, device="cuda")
@@ -138,7 +140,7 @@ def make_inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
             (n,), dtype=torch.float32, device="cuda", requires_grad=True
         )
         bias = torch.rand((n,), dtype=torch.float32, device="cuda", requires_grad=True)
-    return x, weight, bias
+        yield n, x, weight, bias
 
 
 def tensor_comparison(actual: torch.Tensor, expected: torch.Tensor) -> TensorComparison:
@@ -390,6 +392,53 @@ def count_suite_failures(phases: PhaseSuite) -> int:
     )
 
 
+def run_autotune_precondition_shape(
+    *,
+    source_fn: Callable[..., object],
+    n: int,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    output_dir: Path,
+    skip_graph: bool,
+    graph_repeats: int,
+    graph_replays: int,
+) -> dict[str, object]:
+    kernel = helion.kernel(source_fn, static_shapes=True, force_autotune=True)
+    layer_norm.layer_norm_fwd = kernel
+    start = time.perf_counter()
+    layer_norm.layer_norm(x, [n], weight, bias, EPS)
+    torch.cuda.synchronize()
+    autotune_seconds = time.perf_counter() - start
+    bound = kernel.bind((x, [n], weight, bias, EPS))
+    config = bound._config
+    assert config is not None
+    if skip_graph:
+        graph: dict[str, object] = {"skipped": True}
+    else:
+        graph = graph_benchmark(
+            lambda: layer_norm.layer_norm(x, [n], weight, bias, EPS),
+            graph_repeats=graph_repeats,
+            graph_replays=graph_replays,
+        )
+    probe = layer_norm.layer_norm(x, [n], weight, bias, EPS)
+    probe.data.fill_(float("nan"))
+    del probe
+    out = layer_norm.layer_norm(x, [n], weight, bias, EPS)
+    baseline = F.layer_norm(x, [n], weight, bias, EPS)
+    accuracy = tensor_comparison(out, baseline)
+    return {
+        "n": n,
+        "autotune_seconds": autotune_seconds,
+        "selected_config": dict(config),
+        "graph_benchmark": graph,
+        "accuracy": accuracy,
+        "compiler": archive_compiler_artifacts(
+            output_dir / f"precondition-{n}", bound, config
+        ),
+    }
+
+
 def archive_compiler_artifacts(
     output_dir: Path,
     bound: BoundKernel[object],
@@ -453,7 +502,29 @@ def main() -> int:
     args = parse_args()
     args.output_dir.mkdir(parents=True, exist_ok=True)
     source_fn = layer_norm.layer_norm_fwd.fn
-    x, weight, bias = make_inputs()
+    preconditioning = (
+        [] if args.mode == "autotune" and args.precondition_autotune else None
+    )
+    target_inputs = None
+    for n, input_x, input_weight, input_bias in iter_inputs():
+        if preconditioning is not None and n in (1024, 2048):
+            preconditioning.append(
+                run_autotune_precondition_shape(
+                    source_fn=source_fn,
+                    n=n,
+                    x=input_x,
+                    weight=input_weight,
+                    bias=input_bias,
+                    output_dir=args.output_dir,
+                    skip_graph=args.skip_graph,
+                    graph_repeats=args.graph_repeats,
+                    graph_replays=args.graph_replays,
+                )
+            )
+        if n == N:
+            target_inputs = (input_x, input_weight, input_bias)
+    assert target_inputs is not None
+    x, weight, bias = target_inputs
     references = {
         "x": x.detach().clone(),
         "weight": weight.detach().clone(),
@@ -552,6 +623,7 @@ def main() -> int:
         "requested_exact_config": EXACT_CONFIG,
         "selected_config": dict(config),
         "autotune_seconds": autotune_seconds,
+        "preconditioning": preconditioning,
         "environment": environment_info(),
         "input_mutation": {
             "x": not torch.equal(x, references["x"]),

--- a/scripts/diagnose_layer_norm_mi350x.py
+++ b/scripts/diagnose_layer_norm_mi350x.py
@@ -1,0 +1,495 @@
+"""Diagnose the intermittent MI350X layer_norm accuracy failure."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import time
+from typing import TYPE_CHECKING
+from typing import TypedDict
+
+import examples.layer_norm as layer_norm
+import torch
+import torch.nn.functional as F
+import triton
+
+import helion
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from helion.runtime.kernel import BoundKernel
+
+M = 4096
+N = 2560
+EPS = 1e-5
+ATOL = 1e-2
+RTOL = 1e-2
+
+EXACT_CONFIG: dict[str, object] = {
+    "atomic_indexing": [],
+    "block_sizes": [4],
+    "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "block_ptr",
+        "pointer",
+        "pointer",
+        "block_ptr",
+        "pointer",
+        "block_ptr",
+        "pointer",
+        "pointer",
+        "block_ptr",
+    ],
+    "load_cache_modifiers": [".cg", "", ".cg", "", "", ".cg", ".cg", ".cg"],
+    "load_eviction_policies": ["", "", "", "", "", "", "", ""],
+    "matrix_instr_nonkdim": 0,
+    "num_stages": 1,
+    "num_warps": 2,
+    "pid_type": "flat",
+    "range_flattens": [None],
+    "range_multi_buffers": [None],
+    "range_num_stages": [0],
+    "range_unroll_factors": [0],
+    "range_warp_specializes": [],
+    "reduction_loops": [None],
+    "store_cache_modifiers": [".wt", "", "", ""],
+    "waves_per_eu": 2,
+    "xcd_remap": True,
+}
+
+VARIANTS = (
+    "exact",
+    "no_xcd_remap",
+    "no_load_cache_modifiers",
+    "no_store_cache_modifiers",
+    "waves_per_eu_1",
+    "block_size_8",
+)
+
+
+class TensorComparison(TypedDict):
+    bad_count: int
+    nan_count: int
+    inf_count: int
+    max_abs: float
+    max_abs_location: list[int]
+    bad_row_count: int
+    first_bad_rows: list[int]
+    top_bad_rows: list[dict[str, int]]
+
+
+class PhaseResult(TypedDict):
+    launches: int
+    failure_count: int
+    worst_bad_count: int
+    first_failures: list[dict[str, object]]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("fixed", "autotune"), required=True)
+    parser.add_argument("--variant", choices=VARIANTS, default="exact")
+    parser.add_argument("--iterations", type=int, default=250)
+    parser.add_argument("--graph-repeats", type=int, default=128)
+    parser.add_argument("--graph-replays", type=int, default=10)
+    parser.add_argument("--skip-graph", action="store_true")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--fail-on-mismatch", action="store_true")
+    return parser.parse_args()
+
+
+def make_config(variant: str) -> helion.Config:
+    values = copy.deepcopy(EXACT_CONFIG)
+    if variant == "no_xcd_remap":
+        values["xcd_remap"] = False
+    elif variant == "no_load_cache_modifiers":
+        values["load_cache_modifiers"] = [""] * 8
+    elif variant == "no_store_cache_modifiers":
+        values["store_cache_modifiers"] = [""] * 4
+    elif variant == "waves_per_eu_1":
+        values["waves_per_eu"] = 1
+    elif variant == "block_size_8":
+        values["block_sizes"] = [8]
+    return helion.Config.from_dict(values)
+
+
+def make_inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(1337)
+    for n in (1024, 1536, 2048, N):
+        x = -2.3 + 0.5 * torch.randn((M, n), dtype=torch.float32, device="cuda")
+        x.requires_grad_()
+        weight = torch.rand(
+            (n,), dtype=torch.float32, device="cuda", requires_grad=True
+        )
+        bias = torch.rand((n,), dtype=torch.float32, device="cuda", requires_grad=True)
+    return x, weight, bias
+
+
+def tensor_comparison(actual: torch.Tensor, expected: torch.Tensor) -> TensorComparison:
+    close = torch.isclose(actual, expected, atol=ATOL, rtol=RTOL)
+    bad = ~close
+    bad_count = int(bad.sum().item())
+    diff = (actual - expected).abs()
+    finite_diff = torch.nan_to_num(diff, nan=-1.0, posinf=-1.0, neginf=-1.0)
+    flat_index = int(finite_diff.argmax().item())
+    max_abs = float(finite_diff.flatten()[flat_index].item())
+    if actual.ndim == 2:
+        location = list(divmod(flat_index, actual.shape[1]))
+    else:
+        location = [flat_index]
+    result: TensorComparison = {
+        "bad_count": bad_count,
+        "nan_count": int(actual.isnan().sum().item()),
+        "inf_count": int(actual.isinf().sum().item()),
+        "max_abs": max_abs,
+        "max_abs_location": location,
+        "bad_row_count": 0,
+        "first_bad_rows": [],
+        "top_bad_rows": [],
+    }
+    if actual.ndim == 2 and bad_count:
+        row_counts = bad.sum(dim=1)
+        bad_rows = torch.nonzero(row_counts, as_tuple=False).flatten()
+        top_counts, top_rows = torch.topk(row_counts, min(32, bad_rows.numel()))
+        result["bad_row_count"] = int(bad_rows.numel())
+        result["first_bad_rows"] = [int(row) for row in bad_rows[:128].cpu().tolist()]
+        result["top_bad_rows"] = [
+            {"row": int(row), "bad_count": int(count)}
+            for row, count in zip(
+                top_rows.cpu().tolist(), top_counts.cpu().tolist(), strict=True
+            )
+        ]
+    return result
+
+
+def record_failure(
+    failures: list[dict[str, object]],
+    *,
+    phase: str,
+    iteration: int,
+    comparisons: dict[str, TensorComparison],
+) -> None:
+    if all(result["bad_count"] == 0 for result in comparisons.values()):
+        return
+    failure: dict[str, object] = {
+        "phase": phase,
+        "iteration": iteration,
+        "comparisons": comparisons,
+    }
+    if len(failures) < 32:
+        failures.append(failure)
+    print(f"FAIL {json.dumps(failure, sort_keys=True)}", flush=True)
+
+
+def compare_raw_outputs(
+    out: torch.Tensor,
+    mean: torch.Tensor,
+    rstd: torch.Tensor,
+    references: dict[str, torch.Tensor],
+) -> dict[str, TensorComparison]:
+    reconstructed = (references["x"] - mean[:, None]) * rstd[:, None] * references[
+        "weight"
+    ] + references["bias"]
+    return {
+        "out_vs_torch": tensor_comparison(out, references["out"]),
+        "mean": tensor_comparison(mean, references["mean"]),
+        "rstd": tensor_comparison(rstd, references["rstd"]),
+        "out_vs_returned_stats": tensor_comparison(out, reconstructed),
+    }
+
+
+def run_raw_stress(
+    iterations: int,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    references: dict[str, torch.Tensor],
+) -> PhaseResult:
+    failures: list[dict[str, object]] = []
+    failure_count = 0
+    worst_bad_count = 0
+    for iteration in range(iterations):
+        out, mean, rstd = layer_norm.layer_norm_fwd(x, [N], weight, bias, EPS)
+        torch.cuda.synchronize()
+        comparisons = compare_raw_outputs(out, mean, rstd, references)
+        launch_bad = max(item["bad_count"] for item in comparisons.values())
+        if launch_bad:
+            failure_count += 1
+            worst_bad_count = max(worst_bad_count, launch_bad)
+            record_failure(
+                failures,
+                phase="raw_direct",
+                iteration=iteration,
+                comparisons=comparisons,
+            )
+    return {
+        "launches": iterations,
+        "failure_count": failure_count,
+        "worst_bad_count": worst_bad_count,
+        "first_failures": failures,
+    }
+
+
+def run_raw_poison_stress(
+    iterations: int,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    references: dict[str, torch.Tensor],
+) -> PhaseResult:
+    failures: list[dict[str, object]] = []
+    failure_count = 0
+    worst_bad_count = 0
+    for iteration in range(iterations):
+        probe = layer_norm.layer_norm_fwd(x, [N], weight, bias, EPS)
+        probe[0].data.fill_(float("nan"))
+        del probe
+        out, mean, rstd = layer_norm.layer_norm_fwd(x, [N], weight, bias, EPS)
+        torch.cuda.synchronize()
+        comparisons = compare_raw_outputs(out, mean, rstd, references)
+        launch_bad = max(item["bad_count"] for item in comparisons.values())
+        if launch_bad:
+            failure_count += 1
+            worst_bad_count = max(worst_bad_count, launch_bad)
+            record_failure(
+                failures,
+                phase="raw_poison_after_graph",
+                iteration=iteration,
+                comparisons=comparisons,
+            )
+    return {
+        "launches": iterations,
+        "failure_count": failure_count,
+        "worst_bad_count": worst_bad_count,
+        "first_failures": failures,
+    }
+
+
+def graph_benchmark(
+    fn: Callable[[], object], *, graph_repeats: int, graph_replays: int
+) -> dict[str, object]:
+    # pyrefly: ignore [missing-attribute]
+    cache = triton.runtime.driver.active.get_empty_cache_for_benchmark()
+    stream = torch.cuda.Stream()
+    start = time.perf_counter()
+    with torch.cuda.stream(stream):
+        cache.zero_()
+        fn()
+        for _ in range(5):
+            cache.zero_()
+            fn()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            for _ in range(graph_repeats):
+                cache.zero_()
+                fn()
+        torch.cuda.synchronize()
+        for _ in range(graph_replays):
+            graph.replay()
+            torch.cuda.synchronize()
+    elapsed = time.perf_counter() - start
+    return {
+        "captured_calls": graph_repeats,
+        "replays": graph_replays,
+        "elapsed_seconds": elapsed,
+    }
+
+
+def run_tritonbench_accuracy_stress(
+    iterations: int,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+) -> PhaseResult:
+    failures: list[dict[str, object]] = []
+    failure_count = 0
+    worst_bad_count = 0
+    for iteration in range(iterations):
+        probe = layer_norm.layer_norm(x, [N], weight, bias, EPS)
+        probe.data.fill_(float("nan"))
+        del probe
+        out = layer_norm.layer_norm(x, [N], weight, bias, EPS)
+        baseline = F.layer_norm(x, [N], weight, bias, EPS)
+        comparison = tensor_comparison(out, baseline)
+        bad_count = int(comparison["bad_count"])
+        if bad_count:
+            failure_count += 1
+            worst_bad_count = max(worst_bad_count, bad_count)
+            record_failure(
+                failures,
+                phase="tritonbench_poison_after_graph",
+                iteration=iteration,
+                comparisons={"out_vs_torch": comparison},
+            )
+    return {
+        "launches": iterations,
+        "failure_count": failure_count,
+        "worst_bad_count": worst_bad_count,
+        "first_failures": failures,
+    }
+
+
+def archive_compiler_artifacts(
+    output_dir: Path,
+    bound: BoundKernel[object],
+    config: helion.Config,
+) -> dict[str, object]:
+    generated_path_value = bound.get_cached_path(config)
+    backend_key = bound.backend_cache_key(config)
+    result: dict[str, object] = {
+        "backend_cache_key": backend_key,
+        "generated_path": generated_path_value,
+    }
+    artifact_dir = output_dir / "compiler-artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    if generated_path_value is not None:
+        generated_path = Path(generated_path_value)
+        shutil.copy2(generated_path, artifact_dir / generated_path.name)
+    if backend_key is not None:
+        cache_root_value = os.environ.get("HELION_CACHE_DIR")
+        if cache_root_value is not None:
+            matches = [
+                path
+                for path in Path(cache_root_value).rglob(backend_key)
+                if path.is_dir()
+            ]
+            if matches:
+                shutil.copytree(
+                    matches[0],
+                    artifact_dir / backend_key,
+                    dirs_exist_ok=True,
+                )
+                result["backend_cache_path"] = str(matches[0])
+    return result
+
+
+def environment_info() -> dict[str, object]:
+    properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    return {
+        "helion_file": helion.__file__,
+        "torch_version": torch.__version__,
+        "torch_git_version": torch.version.git_version,
+        "torch_hip_version": torch.version.hip,
+        "triton_version": triton.__version__,
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "device_count": torch.cuda.device_count(),
+        "current_device": torch.cuda.current_device(),
+        "device_name": torch.cuda.get_device_name(),
+        "device_properties": str(properties),
+        "visible_devices": {
+            name: os.environ.get(name)
+            for name in (
+                "CUDA_VISIBLE_DEVICES",
+                "HIP_VISIBLE_DEVICES",
+                "ROCR_VISIBLE_DEVICES",
+            )
+        },
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    x, weight, bias = make_inputs()
+    references = {
+        "x": x.detach().clone(),
+        "weight": weight.detach().clone(),
+        "bias": bias.detach().clone(),
+    }
+    references["mean"] = references["x"].mean(dim=-1)
+    centered = references["x"] - references["mean"][:, None]
+    references["rstd"] = torch.rsqrt((centered * centered).mean(dim=-1) + EPS)
+    references["out"] = F.layer_norm(
+        references["x"], [N], references["weight"], references["bias"], EPS
+    )
+
+    autotune_seconds = None
+    if args.mode == "autotune":
+        kernel = helion.kernel(
+            layer_norm.layer_norm_fwd.fn,
+            static_shapes=True,
+            force_autotune=True,
+        )
+    else:
+        kernel = helion.kernel(
+            layer_norm.layer_norm_fwd.fn,
+            config=make_config(args.variant),
+            static_shapes=True,
+        )
+    layer_norm.layer_norm_fwd = kernel
+
+    if args.mode == "autotune":
+        start = time.perf_counter()
+        layer_norm.layer_norm(x, [N], weight, bias, EPS)
+        torch.cuda.synchronize()
+        autotune_seconds = time.perf_counter() - start
+    else:
+        layer_norm.layer_norm_fwd(x, [N], weight, bias, EPS)
+        torch.cuda.synchronize()
+
+    bound = kernel.bind((x, [N], weight, bias, EPS))
+    config = bound._config
+    assert config is not None
+    direct_iterations = (
+        min(args.iterations, 20) if args.mode == "autotune" else args.iterations
+    )
+    direct = run_raw_stress(direct_iterations, x, weight, bias, references)
+    if args.skip_graph:
+        graph: dict[str, object] = {"skipped": True}
+    else:
+        graph = graph_benchmark(
+            lambda: layer_norm.layer_norm(x, [N], weight, bias, EPS),
+            graph_repeats=args.graph_repeats,
+            graph_replays=args.graph_replays,
+        )
+    accuracy = run_tritonbench_accuracy_stress(args.iterations, x, weight, bias)
+    raw_poison = run_raw_poison_stress(args.iterations, x, weight, bias, references)
+    post_graph_raw = run_raw_stress(20, x, weight, bias, references)
+    torch.cuda.synchronize()
+
+    summary = {
+        "mode": args.mode,
+        "requested_variant": args.variant,
+        "requested_exact_config": EXACT_CONFIG,
+        "selected_config": dict(config),
+        "autotune_seconds": autotune_seconds,
+        "environment": environment_info(),
+        "input_mutation": {
+            "x": not torch.equal(x, references["x"]),
+            "weight": not torch.equal(weight, references["weight"]),
+            "bias": not torch.equal(bias, references["bias"]),
+        },
+        "direct_before_graph": direct,
+        "graph_benchmark": graph,
+        "accuracy_after_graph": accuracy,
+        "raw_poison_after_graph": raw_poison,
+        "raw_after_graph": post_graph_raw,
+        "compiler": archive_compiler_artifacts(args.output_dir, bound, config),
+    }
+    summary_path = args.output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    mismatch_count = sum(
+        phase["failure_count"]
+        for phase in (direct, accuracy, raw_poison, post_graph_raw)
+    )
+    print(
+        "SUMMARY "
+        f"mode={args.mode} variant={args.variant} "
+        f"selected={config} mismatching_launches={mismatch_count} "
+        f"path={summary_path}",
+        flush=True,
+    )
+    return int(args.fail_on_mismatch and mismatch_count != 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Temporary diagnostic PR for the layer_norm accuracy failure in https://github.com/pytorch/helion/actions/runs/30896001298/job/91949040557. Do not merge.

The workflow runs on the same gfx950 runner and ROCm 7.1.1 container, pins all launches to physical GPU 0, and recreates the TritonBench order: autotune, fresh-stream CUDA graph capture/replay, allocator poisoning, then accuracy.

It isolates the selected failing config by changing one control at a time:
- XCD remapping
- load cache modifiers
- store cache modifiers
- waves per EU
- block size

It separately records CI-faithful unsynchronized accuracy and synchronized raw output/mean/rstd checks. That distinguishes stream ordering from incomplete stores and reduction errors. Each case uploads its generated Python, TTIR, TTGIR, LLVM IR, AMDGCN, HSACO, compiler metadata, failing row pattern, and runner/ROCm identity.

Local validation:
- Ruff, formatting, codespell, Python compilation, and workflow YAML parsing pass.
- The direct GPU-0 path completes with zero mismatches and archives backend key RK6GTRDJAC5TP7C3OUJXAA4DAXQC6PLPUDV4KMHWGVHSSC33ZLVA.
- This host has a ROCm 7.0 driver with cached ROCm 7.1 userspace, so non-default-stream Triton launch fails locally with HIP 709. The target runner has the matched 7.1.1 stack needed for the graph diagnostic.