### PR TITLE
Fix _find_device host overhead in tuple/dict recursion

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -2338,13 +2338,13 @@ def _find_device(args: tuple[object, ...]) -> torch.device:
         if isinstance(arg, (tuple, list)):
             for item in arg:
                 try:
-                    return _find_device(item)
+                    return _find_device((item,))
                 except exc.NoTensorArgs:
                     pass
         elif isinstance(arg, dict):
             for item in arg.values():
                 try:
-                    return _find_device(item)
+                    return _find_device((item,))
                 except exc.NoTensorArgs:
                     pass
     raise exc.NoTensorArgs


### PR DESCRIPTION
Summary:
`_find_device` scans kernel arguments for a `torch.device`/`torch.Tensor` to determine the launch device, recursing into nested `tuple`/`list`/`dict` containers. The recursion passed each element directly as `_find_device(item)`.

`_find_device` treats its argument as a tuple of args and iterates it (`for arg in args`). Passing a bare `item` that is itself a `torch.Tensor` made the recursive call iterate over the tensor (`for arg in tensor`), materializing the rows of the tensor on the host before the first row matched the `isinstance(arg, torch.Tensor)` check -- a real per-call host overhead on the hot argument-processing path. A 0-dim scalar tensor also fails to iterate at all.

Wrap the recursed element in a single-element tuple, `_find_device((item,))`, so the recursion sees exactly one arg and hits the `torch.Tensor` fast path directly. Behavior is unchanged for every previously-working case; the tensor is no longer iterated.

Differential Revision: D114780871


