### PR TITLE
[Pallas] Sample TPU bridge shapes equally-spaced (cap kl_div / rms_norm-bwd)

### DIFF
--- a/.github/workflows/benchmark_tpu_bridge.yml
+++ b/.github/workflows/benchmark_tpu_bridge.yml
@@ -115,9 +115,11 @@ jobs:
             # --precision (see below), drop --cudagraph and
             # --latency-measure-mode triton_do_bench (CUDA/Triton-only; TPU uses
             # the wall-clock _do_bench_tpu path). Shapes are tritonbench's own,
-            # count-capped by --num-inputs; per-kernel shape args (e.g. embedding
-            # --B/--T/--D/--v-range) are supplied via inputs.env-vars / custom
-            # args where a default shape exceeds TPU vmem.
+            # sampled equally-spaced across the full range by --num-inputs /
+            # --input-sample-mode (not just the smallest first-k, so the
+            # dashboard covers small/mid/large); per-kernel shape args (e.g.
+            # embedding --B/--T/--D/--v-range) are supplied via inputs.env-vars /
+            # custom args where a default shape exceeds TPU vmem.
             #
             # Precision follows the canonical helion examples per kernel: bf16
             # for gemm/softmax/layer_norm/rms_norm (examples/rms_norm.py runs
@@ -131,6 +133,21 @@ jobs:
             case "$kernel" in
               kl_div|welford) PRECISION=fp32 ;;
             esac
+            # Most kernels sample 6 shapes equally-spaced across their range.
+            # Two exceptions take the feasible low end via first-k instead of
+            # spanning to the top:
+            #   - kl_div: at fp32 its reduction reaches V=131072, which OOMs TPU
+            #     vmem and autotunes for hours.
+            #   - rms_norm / rms_norm-bwd: their largest shape (H=32768) sits
+            #     ~66KB over the 32MB scoped-vmem ceiling and helion's autotuner
+            #     bails (no working config found). Drop that top shape (keep
+            #     H<=16384) until the helion autotuner handles it.
+            NUM_INPUTS=6
+            SAMPLE_MODE=equally-spaced-k
+            case "$kernel" in
+              kl_div) NUM_INPUTS=4; SAMPLE_MODE=first-k ;;
+              rms_norm|rms_norm-bwd) NUM_INPUTS=5; SAMPLE_MODE=first-k ;;
+            esac
             ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 HELION_MEASURE_COMPILE_TIME=1 \
               python benchmarks/run.py \
                 --op $kernel \
@@ -139,7 +156,8 @@ jobs:
                 --helion-backend pallas \
                 --metrics speedup,accuracy,latency \
                 --measure-compile-time \
-                --num-inputs 2 \
+                --num-inputs $NUM_INPUTS \
+                --input-sample-mode $SAMPLE_MODE \
                 --only $IMPLS \
                 --only-match-mode prefix-with-baseline \
                 --baseline $BASELINE \


### PR DESCRIPTION
The TPU bridge sampled only `--num-inputs 2` with the default first-k mode, so the dashboard showed just the two *smallest* shapes per kernel. This samples 6 shapes `equally-spaced` across each operator's range (matching the GPU nightly's `--input-sample-mode equally-spaced-k`), so small/mid/large are all represented.

Two kernels take the feasible low end via `first-k` instead of spanning to the top. They fail for unrelated reasons, so they get separate caps:

- `kl_div`: its reduction reaches V=131072 (`2**17`). At fp32 that shape does not finish — a single-shape run was still in generation 0 of the autotune search after 45 minutes. → `first-k 4` (V≤32768).
- `rms_norm-bwd`: at H=32768 (`2**15`) helion reports `Autotuning reference config failed while computing baseline`, so the kernel yields no column at all. → `first-k 5` (H≤16384).

`rms_norm` forward is **not** capped: H=32768 runs clean.

### Re-measured on tpu7x, 2026-09-14

This PR originally capped `rms_norm` and `rms_norm-bwd` together, attributing both to the helion autotuner abandoning its search near the 32 MB scoped-vmem ceiling. That is no longer the failure:

| shape | result |
|---|---|
| `rms_norm` H=16384 | accuracy 1, helion 1.36x |
| `rms_norm` H=32768 | accuracy 1, helion **1.93x** |
| `rms_norm-bwd` H=16384 | accuracy 1, helion 2.41x |
| `rms_norm-bwd` H=32768 | **`Autotuning reference config failed while computing baseline`** |

Forward now runs to the top of its range, so capping it only discards a working dashboard column. Backward still fails, but at exactly one shape and for a different reason: not "no working config found" from the vmem ceiling, but the missing `autotune_baseline_fn` this PR's earlier description already flagged as a prerequisite — the error message names it as the fix. `first-k 5` is therefore the exact cutoff, not a conservative guess.

Measured both in isolation (`--input-id 5 --num-inputs 1`) and as the last shape of a full 6-shape `equally-spaced-k` sweep, to rule out state carried over from earlier shapes in the same process; the two agree (1.90x vs 1.93x).

### Note for reviewers

This workflow is `on: workflow_call`, reached only through `benchmark_dispatch.yml`, so no pull-request check exercises the changed file — CI status on this PR is not evidence either way.

`kl_div`'s cap is supported as "does not finish in 45 minutes", which is what was measured; the earlier description said it OOMs, and that was not re-confirmed. Either way it is unusable in a sweep.

Rebased onto current main: this now sits alongside the per-kernel `timeout` from #3594 and the `rms_norm-bwd` fp32 switch from #3595. That fp32 switch postdates the original measurements here, which is part of why the rms_norm caps needed re-deriving.
