### PR TITLE
Fix BackendImplementationMissing: repair codegen registration skipped by circular-import partial cache

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -62,9 +62,9 @@ class AtenLowering(Lowering):
         self, backend: str
     ) -> Callable[[CodegenHandler], CodegenHandler]:
         def decorator(handler: CodegenHandler) -> CodegenHandler:
-            assert backend not in self.codegen_impls, (
-                f"codegen already registered for backend {backend!r}"
-            )
+            # Idempotent: repair_backend_codegen() may reload this codegen module
+            # (see CodegenDict.__missing__), re-running this decorator. Overwrite
+            # rather than assert so the repair reload is safe.
             self.codegen_impls[backend] = handler
             return handler
 

--- a/helion/_compiler/backend_registry.py
+++ b/helion/_compiler/backend_registry.py
@@ -102,6 +102,54 @@ def import_backend_codegen() -> None:
                 raise
 
 
+def repair_backend_codegen() -> None:
+    """Force-complete backend codegen registrations skipped due to partial import.
+
+    :func:`import_backend_codegen` relies on ``importlib.import_module`` to run
+    each backend's ``@_decorators.codegen`` / ``register_codegen`` handlers. When
+    a codegen module is already present in ``sys.modules`` in a partially
+    initialized state -- a circular import during package init cached it before
+    its module-scope registrations ran -- ``import_module`` returns the
+    incomplete module and the registrations are silently skipped, leaving
+    ``APIFunc._codegen`` empty for that backend. That surfaces later as
+    :class:`~helion.exc.BackendImplementationMissing` at codegen time (notably
+    under ``torch.compile`` in a packaged runtime, where the init import order
+    differs).
+
+    This reloads each backend's codegen leaf modules so their registrations run.
+    It is only safe once imports are settled (i.e. at codegen time, not during
+    package init) and relies on codegen registration being idempotent (see
+    ``_decorators.codegen`` and ``aten_lowering.register_codegen``).
+    """
+    import types
+
+    if not _REGISTRY:
+        for _cls in _BUILTIN_BACKENDS:
+            register_compiler_backend(_cls)
+    seen: set[str] = set()
+    for backend_cls in _REGISTRY.values():
+        package = backend_cls.__module__.rsplit(".", 1)[0]
+        if package in seen:
+            continue
+        seen.add(package)
+        module_name = f"{package}._codegen_modules"
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as e:
+            if e.name != module_name:
+                raise
+            continue
+        # ``_codegen_modules`` may itself be cached partial; reloading it re-binds
+        # its leaf submodule attributes, and reloading each leaf re-runs the
+        # module-scope registration decorators (idempotently).
+        importlib.reload(module)
+        for value in list(vars(module).values()):
+            if isinstance(value, types.ModuleType) and value.__name__.startswith(
+                package + "."
+            ):
+                importlib.reload(value)
+
+
 # register built-in backends
 for _cls in _BUILTIN_BACKENDS:
     register_compiler_backend(_cls)

--- a/helion/language/_decorators.py
+++ b/helion/language/_decorators.py
@@ -39,9 +39,27 @@ if TYPE_CHECKING:
 class CodegenDict(dict[str, "Callable[[CodegenState], object]"]):
     """A dict subclass that falls back to the 'common' key when a backend key is missing."""
 
+    # Set once the (global) codegen-registration repair has been attempted, so a
+    # genuinely-unregistered backend does not re-trigger the (expensive) reload on
+    # every lookup. See __missing__ / backend_registry.repair_backend_codegen.
+    _repaired: bool = False
+
     def __missing__(self, key: str) -> Callable[[CodegenState], object]:
         if key != "common" and "common" in self:
             return self["common"]
+        # A backend codegen can be absent because its codegen module was cached
+        # partially-initialized during a circular import at package-init time, so
+        # its module-scope @codegen registrations never ran (import_backend_codegen's
+        # importlib.import_module is a no-op on a partially cached module, leaving
+        # this dict empty). By codegen time imports are settled, so force-complete
+        # the registrations once and retry before giving up.
+        if key != "common" and not CodegenDict._repaired:
+            CodegenDict._repaired = True
+            from .._compiler.backend_registry import repair_backend_codegen
+
+            repair_backend_codegen()
+            if dict.__contains__(self, key):
+                return dict.__getitem__(self, key)
         raise KeyError(key)
 
     # pyrefly: ignore[bad-override]
@@ -282,9 +300,9 @@ def codegen(
         assert is_api_func(original_fn), (
             f"{type_propagation.__qualname__} can only be used on API functions"
         )
-        assert backend not in original_fn._codegen, (
-            f"codegen already registered for backend {backend!r}"
-        )
+        # Idempotent: repair_backend_codegen() may reload this codegen module (see
+        # CodegenDict.__missing__), re-running this decorator. Overwrite rather than
+        # assert so the repair reload is safe.
         original_fn._codegen[backend] = codegen_fn
         return _no_call
 

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -2338,13 +2338,13 @@ def _find_device(args: tuple[object, ...]) -> torch.device:
         if isinstance(arg, (tuple, list)):
             for item in arg:
                 try:
-                    return _find_device(item)
+                    return _find_device((item,))
                 except exc.NoTensorArgs:
                     pass
         elif isinstance(arg, dict):
             for item in arg.values():
                 try:
-                    return _find_device(item)
+                    return _find_device((item,))
                 except exc.NoTensorArgs:
                     pass
     raise exc.NoTensorArgs


### PR DESCRIPTION
Summary:
Under torch.compile in packaged runtimes (e.g. aps_ads_vm training), Helion kernels
could fail at pt2_warmup with `BackendImplementationMissing: Backend 'triton' is
missing required implementation: codegen for API function load`.

Root cause: `import_backend_codegen()` registers each backend's per-op codegen by
`importlib.import_module("<pkg>._codegen_modules")`. If that codegen module (or one
of its leaf modules such as `triton/memory_ops.py`) is already present in
`sys.modules` in a partially-initialized state -- a circular import during package
init cached it before its module-scope `_decorators.codegen` / `register_codegen`
handlers ran -- `import_module` returns the incomplete module and the registrations
are silently skipped, leaving `APIFunc._codegen` empty for that backend. This is
import-order dependent (nondeterministic) and surfaces only at codegen time.

Fix:
- `CodegenDict.__missing__`: when a backend codegen key is absent, attempt a
  one-time global repair (imports are settled by codegen time) and retry before
  raising KeyError.
- `backend_registry.repair_backend_codegen()`: reload each backend's codegen leaf
  modules so their registration decorators re-run.
- Make codegen registration idempotent (`_decorators.codegen`,
  `aten_lowering.register_codegen`) so the repair reload cannot trip the
  "already registered" assert.

Differential Revision: D114782445


