### PR TITLE
[examples] Apply the KDA input preamble in the kernels

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -66,10 +66,10 @@ on:
         type: string
         default: "vector_add,layer_norm,rms_norm,vector_exp,sum"
       kernels_linattn:
-        description: 'Comma-separated list of linear-attention variants (vs FLA) from benchmarks/run_linattn.py::VARIANTS; the matrix shards these and each run emits a forward and a forward+backward ("-bwd") dashboard row.'
+        description: 'Comma-separated list of linear-attention variants (vs FLA) from benchmarks/run_linattn.py::VARIANTS; the matrix shards these and each run emits a forward and a forward+backward ("-bwd") dashboard row, except forward-only variants which emit only the forward.'
         required: false
         type: string
-        default: "vanilla_linear_attn,simple_gla,retention,full_gla,delta_rule,gated_delta_rule,kda"
+        default: "vanilla_linear_attn,simple_gla,retention,full_gla,delta_rule,gated_delta_rule,kda,kda_fused"
       env_vars:
         description: 'Environment variables for benchmark runner'
         required: false
@@ -205,7 +205,7 @@ jobs:
     if: ${{ github.event.inputs.run_b200_linattn == 'true' }}
     uses: ./.github/workflows/compute-benchmark-matrix.yml
     with:
-      max-runners: 7
+      max-runners: 8
       kernels: ${{ github.event.inputs.kernels_linattn }}
 
   run-b200-linattn:
@@ -232,7 +232,7 @@ jobs:
     if: ${{ github.event.inputs.run_h100_linattn == 'true' }}
     uses: ./.github/workflows/compute-benchmark-matrix.yml
     with:
-      max-runners: 7
+      max-runners: 8
       kernels: ${{ github.event.inputs.kernels_linattn }}
 
   run-h100-linattn:

--- a/benchmarks/run_linattn.py
+++ b/benchmarks/run_linattn.py
@@ -45,7 +45,12 @@ VARIANTS = [
     "delta_rule",
     "gated_delta_rule",
     "kda",
+    "kda_fused",
 ]
+
+# Variants run with fused_preamble, mapped to the example module they share. These
+# are forward-only, so they emit no "-bwd" row.
+FUSED_PREAMBLE_VARIANTS = {"kda_fused": "kda"}
 
 # benchmark() takes (B, H, T, D, DV); our shapes use D == DV.
 _CONFIGS = [(name, b, h, t, d, d) for (name, b, t, h, d) in SHAPES]
@@ -96,7 +101,6 @@ def write_results_json(
         vrd = verdicts.get(variant, [])
         # ok / REF-ERR -> 1.0; FAIL / HEL-ERR -> 0.0.
         fwd_ok = [0.0 if v[0] in ("FAIL", "HEL-ERR") else 1.0 for v in vrd]
-        bwd_ok = [0.0 if v[1] in ("FAIL", "HEL-ERR") else 1.0 for v in vrd]
         # Forward: Helion accuracy + latency + speedup vs the FLA baseline.
         add_metric(variant, "helion_accuracy", labels, fwd_ok)
         add_metric(variant, "helion_latency_ms", labels, [r[1] for r in rows])
@@ -106,7 +110,11 @@ def write_results_json(
             labels,
             [r[2] / r[1] if r[1] else 0.0 for r in rows],
         )
+        if variant in FUSED_PREAMBLE_VARIANTS:
+            # Forward-only: no backward to time, and no verdict to report.
+            continue
         # Forward+backward as a separate "<variant>-bwd" row.
+        bwd_ok = [0.0 if v[1] in ("FAIL", "HEL-ERR") else 1.0 for v in vrd]
         bwd = f"{variant}-bwd"
         add_metric(bwd, "helion_accuracy", labels, bwd_ok)
         add_metric(bwd, "helion_latency_ms", labels, [r[3] for r in rows])
@@ -157,10 +165,12 @@ def main() -> None:
     verdicts: dict[str, list[tuple[str, str]]] = {}
     for name in names:
         print(f"=== {name} ===")
-        mod = importlib.import_module(f"examples.linear.example_{name}")
+        base = FUSED_PREAMBLE_VARIANTS.get(name, name)
+        mod = importlib.import_module(f"examples.linear.example_{base}")
         harness = mod.HARNESS
-        verdicts[name] = harness.accuracy(bench_configs)
-        results[name] = harness.benchmark(bench_configs)
+        kw = {"fused_preamble": True} if name in FUSED_PREAMBLE_VARIANTS else {}
+        verdicts[name] = harness.accuracy(bench_configs, **kw)
+        results[name] = harness.benchmark(bench_configs, **kw)
 
     if args.output:
         write_results_json(args.output, results, verdicts)

--- a/examples/linear/example_kda.py
+++ b/examples/linear/example_kda.py
@@ -19,6 +19,9 @@ def main() -> None:
     print(f"=== {HARNESS.title} ===")
     HARNESS.test()
     print()
+    print(f"=== {HARNESS.title}: fused input preamble ===")
+    HARNESS.test_fused_preamble()
+    print()
     HARNESS.benchmark()
 
 

--- a/examples/linear/linear_attention_engine.py
+++ b/examples/linear/linear_attention_engine.py
@@ -295,14 +295,46 @@ RCP_LN2 = 1.4426950408889634
 
 
 @helion.kernel()
-def chunk_cumsum_gc_helion(g: torch.Tensor) -> torch.Tensor:
+def l2norm_fwd_helion(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """Unit-norm each row over the last (head) axis, in fp32.
+    y[..., d] = x[..., d] / sqrt(sum_d x^2 + eps)     # [B, T, H, D]"""
+    B, T, H, D = x.size()
+    y = torch.empty_like(x)
+    for tile_b, tile_t, tile_h in hl.tile([B, T, H]):
+        xt = x[tile_b, tile_t, tile_h, :].to(torch.float32)
+        rstd = torch.rsqrt((xt * xt).sum(dim=-1, keepdim=True) + eps)
+        y[tile_b, tile_t, tile_h, :] = (xt * rstd).to(x.dtype)
+    return y
+
+
+@helion.kernel()
+def chunk_cumsum_gc_helion(
+    g: torch.Tensor,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    H: int = 1,
+    N: int = 1,
+    use_gate: hl.constexpr = False,  # pyrefly: ignore[bad-function-definition]
+    has_bias: hl.constexpr = True,  # pyrefly: ignore[bad-function-definition]
+    use_lower_bound: hl.constexpr = True,  # pyrefly: ignore[bad-function-definition]
+) -> torch.Tensor:
     """Per-chunk cumulative log-decay over the chunk (C) axis.
         gc[i] = sum_{j <= i} g[j]        # [BHN, C, D], fp32
     Computed as the tensor-core matmul gc = L @ g with L the [C, C]
     lower-triangular ones matrix, instead of a strided scan over the C axis
     (dim -2 of a [BH, N, C, D] tensor) whose steps stride by D. The bf16 g is
     exactly representable in tf32, and the sum accumulates in fp32, so gc keeps
-    the same precision as an fp32 scan while reading g once through the MMA."""
+    the same precision as an fp32 scan while reading g once through the MMA.
+
+    With use_gate=True, g arrives pre-activation and the gate is applied before the
+    sum, over rows flattened as [B, H, N]:
+        h  = (r // N) % H                # head of row r
+        gb = g + dt_bias[h]              # has_bias=True, else gb = g
+      - use_lower_bound=True (default):
+            g = lower_bound * sigmoid(exp(A_log[h]) * gb)
+      - use_lower_bound=False:
+            g = -exp(A_log[h]) * softplus(gb)"""
     BHN = g.size(0)
     C = hl.specialize(g.size(1))
     D = g.size(2)
@@ -312,6 +344,16 @@ def chunk_cumsum_gc_helion(g: torch.Tensor) -> torch.Tensor:
         ltri = (idx[:, None] >= idx[None, :]).to(torch.float32)  # [C, C] incl. diag
         L = ltri[None, :, :].broadcast_to([tile_bhn, C, C])  # pyrefly: ignore[no-matching-overload]
         gt = g[tile_bhn, :, tile_d].to(torch.float32)  # [b, C, d]
+        if use_gate:
+            h_idx = (tile_bhn.index // N) % H
+            a = torch.exp(A_log[h_idx].to(torch.float32))[:, None, None]  # pyrefly: ignore[unsupported-operation]
+            if has_bias:
+                gt = gt + dt_bias[h_idx, tile_d][:, None, :]  # pyrefly: ignore[unsupported-operation]
+            if use_lower_bound:
+                gt = lower_bound * torch.sigmoid(a * gt)  # pyrefly: ignore[unsupported-operation]
+            else:
+                sp = torch.clamp(gt, min=0.0) + torch.log1p(torch.exp(-torch.abs(gt)))
+                gt = -a * sp
         gc[tile_bhn, :, tile_d] = hl.dot(L, gt)
     return gc
 
@@ -1831,6 +1873,9 @@ class ChunkedLinearAttnFn(torch.autograd.Function):
         initial_state: torch.Tensor | None,
         return_final_state: bool,
         scale: float = 1.0,
+        A_log: torch.Tensor | None = None,
+        dt_bias: torch.Tensor | None = None,
+        lower_bound: float | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         tensors = [q, k, v]
         ctx.has_g = g is not None
@@ -1864,6 +1909,9 @@ class ChunkedLinearAttnFn(torch.autograd.Function):
                 initial_state=initial_state,
                 return_final_state=return_final_state,
                 scale=scale,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                lower_bound=lower_bound,
             )
             ctx.h_all = h_all
             ctx.v_new_all = v_new_all
@@ -1901,6 +1949,9 @@ class ChunkedLinearAttnFn(torch.autograd.Function):
         None,
         None,
         None,
+        None,
+        None,
+        None,
     ]:
         tensors = ctx.saved_tensors
         q, k, v = tensors[:3]
@@ -1928,7 +1979,7 @@ class ChunkedLinearAttnFn(torch.autograd.Function):
                 scale=ctx.scale,
                 needs_dg=ctx.needs_input_grad[3],
             )
-            return dq, dk, dv, dg, None, None, None, None, None, None
+            return dq, dk, dv, dg, None, None, None, None, None, None, None, None, None
 
         A_inv = ctx.A_inv
         w_wy = ctx.w_wy
@@ -1951,7 +2002,7 @@ class ChunkedLinearAttnFn(torch.autograd.Function):
                 w_wy=w_wy,
                 scale=ctx.scale,
             )
-            return dq, dk, dv, dg, dbeta, None, None, None, None, None
+            return dq, dk, dv, dg, dbeta, None, None, None, None, None, None, None, None
 
         dq, dk, dv, dg, dbeta, da = _helion_chunked_bwd_delta(
             q,
@@ -1968,7 +2019,7 @@ class ChunkedLinearAttnFn(torch.autograd.Function):
             g=g,
             scale=ctx.scale,
         )
-        return dq, dk, dv, dg, dbeta, da, None, None, None, None
+        return dq, dk, dv, dg, dbeta, da, None, None, None, None, None, None, None
 
 
 # ════════════════════════════════════════════════════════════════════════════════
@@ -2138,6 +2189,9 @@ def _helion_chunked_fwd_delta(
     initial_state: torch.Tensor | None = None,
     return_final_state: bool = False,
     scale: float = 1.0,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -2176,7 +2230,17 @@ def _helion_chunked_fwd_delta(
         decay_last = g_cs[:, :, -1]
         g_cs_flat = g_cs.reshape(BHN, C)
     elif diag_anchored:
-        g_cs_flat = chunk_cumsum_gc_helion(g.reshape(BHN, C, D))
+        g_cs_flat = chunk_cumsum_gc_helion(
+            g.reshape(BHN, C, D),
+            A_log,
+            dt_bias,
+            lower_bound,
+            H,
+            N,
+            use_gate=A_log is not None,
+            has_bias=dt_bias is not None,
+            use_lower_bound=lower_bound is not None,
+        )
         g_cs = g_cs_flat.reshape(BH, N, C, D)
         decay_last = g_cs[:, :, -1, :]
 
@@ -2692,6 +2756,9 @@ def chunked_linear_attn(
     return_final_state: Literal[False] = ...,
     head_first: bool = ...,
     scale: float = ...,
+    A_log: torch.Tensor | None = ...,
+    dt_bias: torch.Tensor | None = ...,
+    lower_bound: float | None = ...,
 ) -> torch.Tensor: ...
 
 
@@ -2708,6 +2775,9 @@ def chunked_linear_attn(
     return_final_state: Literal[True] = ...,
     head_first: bool = ...,
     scale: float = ...,
+    A_log: torch.Tensor | None = ...,
+    dt_bias: torch.Tensor | None = ...,
+    lower_bound: float | None = ...,
 ) -> tuple[torch.Tensor, torch.Tensor]: ...
 
 
@@ -2723,6 +2793,9 @@ def chunked_linear_attn(
     return_final_state: bool = False,
     head_first: bool = True,
     scale: float = 1.0,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """Public entry point for chunked linear attention. g=None means no decay.
 
@@ -2768,7 +2841,19 @@ def chunked_linear_attn(
             a = torch.nn.functional.pad(a, [0, 0, 0, pad])
 
     o, final_state = ChunkedLinearAttnFn.apply(
-        q, k, v, g, beta, a, C, initial_state, return_final_state, scale
+        q,
+        k,
+        v,
+        g,
+        beta,
+        a,
+        C,
+        initial_state,
+        return_final_state,
+        scale,
+        A_log,
+        dt_bias,
+        lower_bound,
     )
 
     if pad > 0:
@@ -2989,9 +3074,52 @@ def helion_chunk_kda(
     scale: float = 1.0,
     initial_state: torch.Tensor | None = None,
     return_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    use_gate_in_kernel: bool = False,
+    use_beta_sigmoid_in_kernel: bool = False,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """KDA, optionally applying the model's input transforms on the way in.
+
+    All three flags default off, meaning the caller has already transformed its
+    inputs. Turning one on moves that transform into the kernels:
+      - use_qk_l2norm_in_kernel=True: q, k arrive raw, normed per head over D:
+            q = q / ||q||,  k = k / ||k||
+      - use_gate_in_kernel=True: g arrives pre-activation, A_log [H] required,
+        dt_bias [H, D] and lower_bound optional:
+            g = lower_bound * sigmoid(exp(A_log) * (g + dt_bias))   lower_bound set
+            g = -exp(A_log) * softplus(g + dt_bias)                 otherwise
+      - use_beta_sigmoid_in_kernel=True: beta arrives as logits:
+            beta = sigmoid(beta)
+    None of the three transforms has a backward, so a flag set on an input with
+    requires_grad=True raises NotImplementedError.
+    """
     assert g is not None
     assert beta is not None
+    any_flag = (
+        use_qk_l2norm_in_kernel or use_gate_in_kernel or use_beta_sigmoid_in_kernel
+    )
+    needs_grad = (
+        q.requires_grad or k.requires_grad or g.requires_grad or beta.requires_grad
+    )
+    if any_flag and needs_grad:
+        raise NotImplementedError(
+            "the in-kernel KDA preamble is forward-only; call with the flags off "
+            "and transform the inputs outside the kernel to keep gradients"
+        )
+
+    if use_qk_l2norm_in_kernel:
+        q, k = l2norm_fwd_helion(q), l2norm_fwd_helion(k)
+    if use_beta_sigmoid_in_kernel:
+        beta = torch.sigmoid(beta)
+    if use_gate_in_kernel:
+        assert A_log is not None
+    else:
+        A_log = None
+        dt_bias = None
+        lower_bound = None
     return chunked_linear_attn(
         q,
         k,
@@ -3002,6 +3130,9 @@ def helion_chunk_kda(
         scale=scale,
         initial_state=initial_state,
         return_final_state=return_final_state,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        lower_bound=lower_bound,
     )
 
 

--- a/examples/linear/linear_attention_fla.py
+++ b/examples/linear/linear_attention_fla.py
@@ -187,6 +187,7 @@ else:
         scale: float = 1.0,
         initial_state: torch.Tensor | None = None,
         return_final_state: bool = False,
+        **preamble: object,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         assert g is not None
         assert beta is not None
@@ -199,6 +200,7 @@ else:
             scale=scale,
             initial_state=initial_state,
             output_final_state=return_final_state,
+            **preamble,  # pyrefly: ignore[bad-argument-type]
         )
 
     _FLA_FWD = {

--- a/examples/linear/linear_attention_harness.py
+++ b/examples/linear/linear_attention_harness.py
@@ -41,7 +41,11 @@ BENCH_C = 64
 
 @dataclass
 class Inputs:
-    """Variant inputs: q/k/v/scale always, plus the decay/correction extras."""
+    """Variant inputs: q/k/v/scale always, plus the decay/correction extras.
+
+    preamble is set only when the tensors are pre-activation: it holds the
+    *_in_kernel flags and gate parameters.
+    """
 
     q: torch.Tensor
     k: torch.Tensor
@@ -50,6 +54,7 @@ class Inputs:
     g: torch.Tensor | None = None
     beta: torch.Tensor | None = None
     gate: torch.Tensor | None = None
+    preamble: dict = field(default_factory=dict)
 
 
 def _rand_qkv(
@@ -194,11 +199,31 @@ def make_kda_inputs(
     dtype: torch.dtype = DTYPE,
     device: str | torch.device = DEVICE,
     requires_grad: bool = False,
+    fused_preamble: bool = False,
 ) -> Inputs:
-    q, k, v = _rand_q_norm_k_v(B, H, T, D, DV, dtype, device, requires_grad)
-    g = -torch.rand(B, H, T, D, device=device, dtype=dtype).abs() * 0.1
-    beta = torch.sigmoid(torch.randn(B, H, T, device=device, dtype=dtype))
-    return Inputs(q=q, k=k, v=v, scale=1.0 / math.sqrt(D), g=g, beta=beta)
+    if not fused_preamble:
+        q, k, v = _rand_q_norm_k_v(B, H, T, D, DV, dtype, device, requires_grad)
+        g = -torch.rand(B, H, T, D, device=device, dtype=dtype).abs() * 0.1
+        beta = torch.sigmoid(torch.randn(B, H, T, device=device, dtype=dtype))
+        return Inputs(q=q, k=k, v=v, scale=1.0 / math.sqrt(D), g=g, beta=beta)
+
+    q, k, v = _rand_qkv(B, H, T, D, DV, dtype, device, requires_grad)
+    return Inputs(
+        q=q,
+        k=k,
+        v=v,
+        scale=1.0 / math.sqrt(D),
+        g=torch.randn(B, H, T, D, device=device, dtype=dtype),
+        beta=torch.randn(B, H, T, device=device, dtype=dtype),
+        preamble={
+            "use_qk_l2norm_in_kernel": True,
+            "use_gate_in_kernel": True,
+            "use_beta_sigmoid_in_kernel": True,
+            "A_log": torch.zeros(H, dtype=torch.float32, device=device),
+            "dt_bias": torch.zeros(H, D, dtype=torch.float32, device=device),
+            "lower_bound": -5.0,
+        },
+    )
 
 
 def make_mamba2_ssd_inputs(
@@ -263,6 +288,9 @@ _VARIANT_SPECS: dict[
 }
 
 
+_FUSED_PREAMBLE_VARIANTS = frozenset({LinearAttentionVariant.KDA})
+
+
 @dataclass
 class LinearAttentionExampleHarness:
     """Test, benchmark, and accuracy harness for one linear-attention variant."""
@@ -270,14 +298,16 @@ class LinearAttentionExampleHarness:
     variant: LinearAttentionVariant
     title: str = field(init=False)
     make_inputs: Callable[..., Inputs] = field(init=False)
+    has_fused_preamble: bool = field(init=False)
     grad_tensors: tuple[str, ...] = field(init=False)
 
     def __post_init__(self) -> None:
         self.title, self.make_inputs, self.grad_tensors = _VARIANT_SPECS[self.variant]
+        self.has_fused_preamble = self.variant in _FUSED_PREAMBLE_VARIANTS
 
     def helion_fwd(self, i: Inputs, C: int) -> torch.Tensor:
         fwd = get_helion_fwd_kernel(self.variant)
-        out = fwd(i.q, i.k, i.v, i.g, i.beta, C=C, scale=i.scale)
+        out = fwd(i.q, i.k, i.v, i.g, i.beta, C=C, scale=i.scale, **i.preamble)
         assert isinstance(out, torch.Tensor)
         return out
 
@@ -294,6 +324,7 @@ class LinearAttentionExampleHarness:
             i.g,
             i.beta,
             scale=scale,
+            **i.preamble,
         )
         return o
 
@@ -303,7 +334,13 @@ class LinearAttentionExampleHarness:
     def reference(self, i: Inputs) -> torch.Tensor:
         assert i.g is not None
         return naive_recurrent_reference(
-            i.q, i.k, i.v, i.g.float(), beta=i.beta, q_scale=i.scale
+            i.q,
+            i.k,
+            i.v,
+            i.g.float(),
+            beta=i.beta,
+            q_scale=i.scale,
+            **i.preamble,
         )
 
     def chunked_reference(self, i: Inputs, C: int) -> torch.Tensor:
@@ -316,16 +353,30 @@ class LinearAttentionExampleHarness:
     def test(self) -> None:
         run_test(self, TEST_SHAPE, TEST_C)
 
+    def test_fused_preamble(self) -> None:
+        assert self.has_fused_preamble, (
+            f"{self.variant.value} has no in-kernel input preamble"
+        )
+        run_test(self, TEST_SHAPE, TEST_C, fused_preamble=True)
+
     def benchmark(
-        self, configs: list | None = None
+        self, configs: list | None = None, fused_preamble: bool = False
     ) -> list[tuple[str, float, float, float, float]]:
         return run_benchmark(
-            self, configs if configs is not None else BENCH_CONFIGS, BENCH_C
+            self,
+            configs if configs is not None else BENCH_CONFIGS,
+            BENCH_C,
+            fused_preamble=fused_preamble,
         )
 
-    def accuracy(self, configs: list | None = None) -> list[tuple[str, str]]:
+    def accuracy(
+        self, configs: list | None = None, fused_preamble: bool = False
+    ) -> list[tuple[str, str]]:
         return run_accuracy(
-            self, configs if configs is not None else BENCH_CONFIGS, BENCH_C
+            self,
+            configs if configs is not None else BENCH_CONFIGS,
+            BENCH_C,
+            fused_preamble=fused_preamble,
         )
 
 
@@ -388,11 +439,17 @@ def run_test(
     harness: LinearAttentionExampleHarness,
     test_shape: tuple[int, int, int, int, int],
     C: int,
+    fused_preamble: bool = False,
 ) -> None:
-    """Forward + backward correctness vs reference and FLA."""
+    """Forward + backward correctness vs reference and FLA.
+
+    fused_preamble asks for pre-activation inputs, which have no backward, so only
+    the forward is checked.
+    """
     torch.manual_seed(42)
     B, H, T, D, DV = test_shape
-    inputs = harness.make_inputs(B, H, T, D, DV, dtype=DTYPE, device=DEVICE)
+    extra = {"fused_preamble": True} if fused_preamble else {}
+    inputs = harness.make_inputs(B, H, T, D, DV, dtype=DTYPE, device=DEVICE, **extra)
     scale = inputs.scale
 
     # === Forward: vs naive recurrent reference ===
@@ -414,6 +471,11 @@ def run_test(
             f"  fwd vs FLA:       {fla_err:.4e}"
             f" {'PASS' if fla_err < ACC_FWD_TOL else 'FAIL'}"
         )
+
+    if inputs.preamble:
+        # The in-kernel preamble has no backward, so there is nothing more to check.
+        print("All tests passed.")
+        return
 
     # === Backward: Helion grads vs chunked reference ===
     grad_out = torch.randn(B, H, T, DV, device=DEVICE, dtype=DTYPE)
@@ -451,21 +513,37 @@ def _time_config(
     harness: LinearAttentionExampleHarness,
     shape: tuple[int, int, int, int, int],
     C: int,
+    fused_preamble: bool = False,
 ) -> tuple[float, float, float, float]:
-    """Time helion/FLA forward and fwd+bwd for one shape."""
+    """Time helion/FLA forward and fwd+bwd for one shape.
+
+    The fwd+bwd pair is 0.0 for pre-activation inputs, which have no backward.
+    """
     bi, hi, ti, di, dvi = shape
+    extra = {"fused_preamble": True} if fused_preamble else {}
     inputs = harness.make_inputs(
-        bi, hi, ti, di, dvi, dtype=DTYPE, device=DEVICE, requires_grad=True
+        bi,
+        hi,
+        ti,
+        di,
+        dvi,
+        dtype=DTYPE,
+        device=DEVICE,
+        requires_grad=not fused_preamble,
+        **extra,
     )
     scale = inputs.scale
-    grad_out = torch.randn(bi, hi, ti, dvi, device=DEVICE, dtype=DTYPE)
     fla_inputs = _fla_inputs(inputs)
-    go_t = _htf(grad_out)
-    h_grads = [getattr(inputs, n) for n in harness.grad_tensors]
-    fla_grads = [getattr(fla_inputs, n) for n in harness.grad_tensors]
 
     fwd_ms = do_bench(lambda: harness.helion_fwd(inputs, C))
     fla_fwd_ms = do_bench(lambda: harness.fla_fwd(fla_inputs, scale))
+    if inputs.preamble:
+        return cast("float", fwd_ms), cast("float", fla_fwd_ms), 0.0, 0.0
+
+    grad_out = torch.randn(bi, hi, ti, dvi, device=DEVICE, dtype=DTYPE)
+    go_t = _htf(grad_out)
+    h_grads = [getattr(inputs, n) for n in harness.grad_tensors]
+    fla_grads = [getattr(fla_inputs, n) for n in harness.grad_tensors]
     fb_ms = do_bench(
         lambda: harness.helion_fb(inputs, grad_out, C),
         grad_to_none=h_grads,  # pyrefly: ignore[bad-argument-type]
@@ -486,11 +564,13 @@ def run_benchmark(
     harness: LinearAttentionExampleHarness,
     configs: list,
     C: int,
+    fused_preamble: bool = False,
 ) -> list[tuple[str, float, float, float, float]]:
     """Benchmark forward and fwd+bwd, comparing against FLA.
 
     Returns one (config, helion_fwd_ms, fla_fwd_ms, helion_fb_ms, fla_fb_ms) row
-    per config; empty when fla is unavailable.
+    per config; empty when fla is unavailable. The fwd+bwd pair is 0.0 with
+    fused_preamble, whose inputs have no backward.
     """
     rows: list[tuple[str, float, float, float, float]] = []
     if not _has_fla(harness):
@@ -504,7 +584,9 @@ def run_benchmark(
     print("-" * 72)
 
     for shape in configs:
-        fwd_ms, fla_fwd_ms, fb_ms, fla_fb_ms = _time_config(harness, shape, C)
+        fwd_ms, fla_fwd_ms, fb_ms, fla_fb_ms = _time_config(
+            harness, shape, C, fused_preamble=fused_preamble
+        )
         cfg = f"({','.join(str(x) for x in shape)})"
         print(
             f"{cfg:<24} {fwd_ms:>10.3f} {fla_fwd_ms:>10.3f}"
@@ -519,18 +601,23 @@ def run_accuracy(
     harness: LinearAttentionExampleHarness,
     configs: list,
     C: int,
+    fused_preamble: bool = False,
 ) -> list[tuple[str, str]]:
     """Per-config (fwd, bwd) verdicts vs the fp32 PyTorch reference.
 
     Each of fwd and bwd is one of: ``ok`` (matches within tolerance), ``FAIL``
     (ran but over tolerance), ``HEL-ERR`` (the Helion kernel errored), ``REF-ERR``
-    (the reference errored, e.g. its autograd graph OOMs). Forward compares
-    against the naive recurrent reference; backward compares autograd gradients
-    against the chunked reference.
+    (the reference errored, e.g. its autograd graph OOMs), ``n/a`` (there is no
+    backward, as with pre-activation inputs). Forward compares against the naive
+    recurrent reference; backward compares autograd gradients against the chunked
+    reference.
     """
     verdicts: list[tuple[str, str]] = []
+    extra = {"fused_preamble": True} if fused_preamble else {}
     for bi, hi, ti, di, dvi in configs:
-        inputs = harness.make_inputs(bi, hi, ti, di, dvi, dtype=DTYPE, device=DEVICE)
+        inputs = harness.make_inputs(
+            bi, hi, ti, di, dvi, dtype=DTYPE, device=DEVICE, **extra
+        )
 
         try:
             out = harness.helion_fwd(inputs, C)
@@ -545,6 +632,10 @@ def run_accuracy(
                 fwd = "REF-ERR"
             else:
                 fwd = "ok" if _rel_error(out, ref) < ACC_FWD_TOL else "FAIL"
+
+        if inputs.preamble:
+            verdicts.append((fwd, "n/a"))
+            continue
 
         grad_out = torch.randn(bi, hi, ti, dvi, device=DEVICE, dtype=DTYPE)
         try:

--- a/examples/linear/linear_attention_utils.py
+++ b/examples/linear/linear_attention_utils.py
@@ -205,8 +205,42 @@ def naive_recurrent_reference(
     decay: torch.Tensor,
     beta: torch.Tensor | None = None,
     q_scale: float = 1.0,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    use_gate_in_kernel: bool = False,
+    use_beta_sigmoid_in_kernel: bool = False,
 ) -> torch.Tensor:
-    """Step-by-step recurrent computation. Slow but correct."""
+    """Step-by-step recurrent computation. Slow but correct.
+
+    The optional arguments apply the input preamble first, so the reference can be
+    fed the same pre-activation tensors a model produces:
+        use_qk_l2norm_in_kernel:    q, k = q / ||q||, k / ||k||
+        use_beta_sigmoid_in_kernel: beta = sigmoid(beta)
+        use_gate_in_kernel:         decay = lower_bound * sigmoid(exp(A_log) *
+                                    (decay + dt_bias)), or -exp(A_log) *
+                                    softplus(...) when lower_bound is None
+    The names match the flags on the kernels, so a caller forwards one dict to both.
+    """
+    if use_qk_l2norm_in_kernel:
+        q = F.normalize(q.float(), dim=-1).to(q.dtype)
+        k = F.normalize(k.float(), dim=-1).to(k.dtype)
+    if use_gate_in_kernel:
+        assert A_log is not None
+        H_, D_ = decay.shape[1], decay.shape[-1]
+        gb = decay.float()
+        if dt_bias is not None:
+            gb = gb + dt_bias.view(1, H_, 1, D_)
+        a = torch.exp(A_log.float()).view(1, H_, 1, 1)
+        if lower_bound is not None:
+            decay = lower_bound * torch.sigmoid(a * gb)
+        else:
+            decay = -a * F.softplus(gb)
+    if use_beta_sigmoid_in_kernel:
+        assert beta is not None
+        beta = torch.sigmoid(beta.float()).to(beta.dtype)
+
     B, H, T, D = q.shape
     DV = v.shape[-1]
     S = q.new_zeros(B, H, D, DV, dtype=torch.float32)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2894,14 +2894,14 @@ class TestExamples(RefEagerTestBase, TestCase):
                 )
                 kernel.settings.autotune_effort = "none"
 
-    def _run_linear_example(self, name: str) -> None:
+    def _run_linear_example(self, name: str, method: str = "test") -> None:
         import importlib
 
         self._skip_linear_engine_autotune()
         mod = importlib.import_module(f"examples.linear.{name}")
         harness = getattr(mod, "HARNESS", None)
         if harness is not None:
-            harness.test()
+            getattr(harness, method)()
         else:
             mod.test()
 
@@ -2960,6 +2960,13 @@ class TestExamples(RefEagerTestBase, TestCase):
     @skipIfCute("linear-attention examples not supported on cute backend")
     def test_linear_kda(self):
         self._run_linear_example("example_kda")
+
+    @pytest.mark.timeout(600)
+    @skipIfRefEager("linear examples assert against their own reference")
+    @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
+    def test_linear_kda_fused_preamble(self):
+        self._run_linear_example("example_kda", method="test_fused_preamble")
 
     # ── Monkey-patch tests: plug our engine into FLA layers ──
 


### PR DESCRIPTION
Stacked PRs:
 * #3291
 * #3290
 * #3289
 * __->__#3288


--- --- ---

### [examples] Apply the KDA input preamble in the kernels


FlashKDA and vLLM both fold KDA's input preamble into the kernel: the q/k L2 norm, the gate activated from a raw projection, and the beta sigmoid. The engine required all three already applied. `helion_chunk_kda` now folds them in too, behind the same three flags FLA uses. The flags are forward only: FlashKDA implements no backward, and vLLM is an inference engine.

## What's here
- **`use_qk_l2norm_in_kernel`** normalizes q and k in a new kernel, `l2norm_fwd_helion`.
- **`use_gate_in_kernel`** applies the gate inside `chunk_cumsum_gc_helion`, in fp32 before the sum.
- **`use_beta_sigmoid_in_kernel`** applies `torch.sigmoid` on the host.
- **`naive_recurrent_reference`** applies all three transforms itself, so it checks the kernels on the same pre-activation inputs.

## Tests
`test_linear_kda_fused_preamble` runs the flags through the same harness as `test_linear_kda`. A `kda_fused` variant in `benchmarks/run_linattn.py` benchmarks it on the same shapes as `kda`; being forward-only it emits no `-bwd` dashboard row, and the linattn benchmark matrix goes from 7 shards to 8.

## Benchmarks
`%FLA = 100 * fla_ms / helion_ms` on H100, autotuned with `HELION_AUTOTUNE_EFFORT=full`. **Higher is faster than FLA.** `kda` takes the transformed inputs, `kda_fused` the raw ones with the flags on.

Forward:

| variant | B1_T8192_H96_D128 | B2_T16384_H16_D128 | B4_T2048_H16_D128 | B4_T4096_H64_D128 | B8_T2048_H32_D256 | B8_T1024_H8_D64 |
|---|---|---|---|---|---|---|
| kda | 119% | 116% | 104% | 117% | 109% | 98% |
| kda_fused | 116% | 114% | 123% | 113% | 107% | 127% |

Forward + backward:

| variant | B1_T8192_H96_D128 | B2_T16384_H16_D128 | B4_T2048_H16_D128 | B4_T4096_H64_D128 | B8_T2048_H32_D256 | B8_T1024_H8_D64 |
|---|---|---|---|---|---|---|
| kda | 118% | 113% | 113% | 117% | 109% | 120% |
