### PR TITLE
[examples] Add a variable-length KDA forward

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -69,7 +69,7 @@ on:
         description: 'Comma-separated list of linear-attention variants (vs FLA) from benchmarks/run_linattn.py::VARIANTS; the matrix shards these and each run emits a forward and a forward+backward ("-bwd") dashboard row, except forward-only variants which emit only the forward.'
         required: false
         type: string
-        default: "vanilla_linear_attn,simple_gla,retention,full_gla,delta_rule,gated_delta_rule,kda,kda_fused"
+        default: "vanilla_linear_attn,simple_gla,retention,full_gla,delta_rule,gated_delta_rule,kda,kda_fused,kda_varlen"
       env_vars:
         description: 'Environment variables for benchmark runner'
         required: false
@@ -205,7 +205,7 @@ jobs:
     if: ${{ github.event.inputs.run_b200_linattn == 'true' }}
     uses: ./.github/workflows/compute-benchmark-matrix.yml
     with:
-      max-runners: 8
+      max-runners: 9
       kernels: ${{ github.event.inputs.kernels_linattn }}
 
   run-b200-linattn:
@@ -232,7 +232,7 @@ jobs:
     if: ${{ github.event.inputs.run_h100_linattn == 'true' }}
     uses: ./.github/workflows/compute-benchmark-matrix.yml
     with:
-      max-runners: 8
+      max-runners: 9
       kernels: ${{ github.event.inputs.kernels_linattn }}
 
   run-h100-linattn:

--- a/benchmarks/run_linattn.py
+++ b/benchmarks/run_linattn.py
@@ -34,10 +34,10 @@ SHAPES: list[tuple[str, int, int, int, int]] = [
     # ("B8_T1024_H8_D64", 8, 1024, 8, 64),
 ]
 
-# variant name -> example module under examples.linear. Each module's
+# Variants with their own examples.linear.example_<name> module, whose
 # benchmark(configs) returns (cfg, helion_fwd_ms, fla_fwd_ms, helion_fb_ms,
-# fla_fb_ms) rows.
-VARIANTS = [
+# fla_fb_ms) rows. Each emits a forward and a forward+backward ("<variant>-bwd") row.
+DENSE_VARIANTS = [
     "vanilla_linear_attn",
     "simple_gla",
     "retention",
@@ -45,12 +45,28 @@ VARIANTS = [
     "delta_rule",
     "gated_delta_rule",
     "kda",
-    "kda_fused",
 ]
 
-# Variants run with fused_preamble, mapped to the example module they share. These
-# are forward-only, so they emit no "-bwd" row.
+# Variants that re-run another variant's module with a flag, mapped to the module
+# they borrow. Both take pre-activation inputs and so are forward-only, emitting no
+# "-bwd" row; kda_varlen additionally passes cu_seqlens.
 FUSED_PREAMBLE_VARIANTS = {"kda_fused": "kda"}
+VARLEN_VARIANTS = {"kda_varlen": "kda"}
+
+VARIANTS = [*DENSE_VARIANTS, *FUSED_PREAMBLE_VARIANTS, *VARLEN_VARIANTS]
+
+# (name, sequence lengths, H, D) for the varlen variants. The lengths are FlashKDA's
+# three cases from its benchmarks/bench_fwd.py, verbatim, each holding 8192 tokens. As
+# with SHAPES the full sweep times out CI, so all but the ragged pair are commented
+# out: ragged is the case no dense shape can express.
+VARLEN_SHAPES: list[tuple[str, list[int], int, int]] = [
+    # ("fixed_T8192_H96_D128", [8192], 96, 128),
+    # ("fixed_T8192_H64_D128", [8192], 64, 128),
+    ("ragged_T8192_H96_D128", [1300, 547, 2048, 963, 271, 3063], 96, 128),
+    ("ragged_T8192_H64_D128", [1300, 547, 2048, 963, 271, 3063], 64, 128),
+    # ("uniform_T8192_H96_D128", [1024] * 8, 96, 128),
+    # ("uniform_T8192_H64_D128", [1024] * 8, 64, 128),
+]
 
 # benchmark() takes (B, H, T, D, DV); our shapes use D == DV.
 _CONFIGS = [(name, b, h, t, d, d) for (name, b, t, h, d) in SHAPES]
@@ -97,7 +113,8 @@ def write_results_json(
     for variant, rows in results.items():
         if not rows:
             continue
-        labels = [s[0] for s in SHAPES[: len(rows)]]
+        shapes = VARLEN_SHAPES if variant in VARLEN_VARIANTS else SHAPES
+        labels = [s[0] for s in shapes[: len(rows)]]
         vrd = verdicts.get(variant, [])
         # ok / REF-ERR -> 1.0; FAIL / HEL-ERR -> 0.0.
         fwd_ok = [0.0 if v[0] in ("FAIL", "HEL-ERR") else 1.0 for v in vrd]
@@ -110,7 +127,7 @@ def write_results_json(
             labels,
             [r[2] / r[1] if r[1] else 0.0 for r in rows],
         )
-        if variant in FUSED_PREAMBLE_VARIANTS:
+        if variant in FUSED_PREAMBLE_VARIANTS or variant in VARLEN_VARIANTS:
             # Forward-only: no backward to time, and no verdict to report.
             continue
         # Forward+backward as a separate "<variant>-bwd" row.
@@ -158,17 +175,30 @@ def main() -> None:
     if unknown:
         raise SystemExit(f"unknown kernels: {unknown}; choose from {VARIANTS}")
 
-    configs = _CONFIGS if args.num_shapes is None else _CONFIGS[: args.num_shapes]
-    bench_configs = [c[1:] for c in configs]  # drop the label for benchmark()
-
     results: dict[str, list[tuple[Any, ...]]] = {}
     verdicts: dict[str, list[tuple[str, str]]] = {}
     for name in names:
         print(f"=== {name} ===")
-        base = FUSED_PREAMBLE_VARIANTS.get(name, name)
+        base = FUSED_PREAMBLE_VARIANTS.get(name) or VARLEN_VARIANTS.get(name, name)
         mod = importlib.import_module(f"examples.linear.example_{base}")
         harness = mod.HARNESS
+        if name in VARLEN_VARIANTS:
+            # Each varlen row carries its own sequence lengths, so the rows run one at
+            # a time and their results concatenate.
+            shapes = VARLEN_SHAPES
+            if args.num_shapes is not None:
+                shapes = shapes[: args.num_shapes]
+            verdicts[name], results[name] = [], []
+            for _, lens, h, d in shapes:
+                cfg = [(len(lens), h, sum(lens), d, d)]
+                kw = {"varlen": True, "varlen_lengths": lens}
+                verdicts[name] += harness.accuracy(cfg, **kw)
+                results[name] += harness.benchmark(cfg, **kw)
+            continue
+
         kw = {"fused_preamble": True} if name in FUSED_PREAMBLE_VARIANTS else {}
+        configs = _CONFIGS if args.num_shapes is None else _CONFIGS[: args.num_shapes]
+        bench_configs = [c[1:] for c in configs]
         verdicts[name] = harness.accuracy(bench_configs, **kw)
         results[name] = harness.benchmark(bench_configs, **kw)
 

--- a/examples/linear/example_kda.py
+++ b/examples/linear/example_kda.py
@@ -22,6 +22,9 @@ def main() -> None:
     print(f"=== {HARNESS.title}: fused input preamble ===")
     HARNESS.test_fused_preamble()
     print()
+    print(f"=== {HARNESS.title}: varlen ===")
+    HARNESS.test_varlen()
+    print()
     HARNESS.benchmark()
 
 

--- a/examples/linear/linear_attention_engine.py
+++ b/examples/linear/linear_attention_engine.py
@@ -296,14 +296,14 @@ RCP_LN2 = 1.4426950408889634
 
 @helion.kernel()
 def l2norm_fwd_helion(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-    """Unit-norm each row over the last (head) axis, in fp32.
-    y[..., d] = x[..., d] / sqrt(sum_d x^2 + eps)     # [B, T, H, D]"""
-    B, T, H, D = x.size()
+    """Unit-norm each row over the D axis, in fp32.
+    y[n, d] = x[n, d] / sqrt(sum_d x[n]^2 + eps)     # [N, D]"""
+    N, D = x.size()
     y = torch.empty_like(x)
-    for tile_b, tile_t, tile_h in hl.tile([B, T, H]):
-        xt = x[tile_b, tile_t, tile_h, :].to(torch.float32)
+    for tile_n in hl.tile(N):
+        xt = x[tile_n, :].to(torch.float32)
         rstd = torch.rsqrt((xt * xt).sum(dim=-1, keepdim=True) + eps)
-        y[tile_b, tile_t, tile_h, :] = (xt * rstd).to(x.dtype)
+        y[tile_n, :] = (xt * rstd).to(x.dtype)
     return y
 
 
@@ -356,6 +356,66 @@ def chunk_cumsum_gc_helion(
                 gt = -a * sp
         gc[tile_bhn, :, tile_d] = hl.dot(L, gt)
     return gc
+
+
+@helion.kernel()
+def chunk_cumsum_gc_varlen_helion(
+    g: torch.Tensor,
+    token_base: torch.Tensor,
+    valid_len: torch.Tensor,
+    gc: torch.Tensor,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+    use_gate: hl.constexpr = False,  # pyrefly: ignore[bad-function-definition]
+    has_bias: hl.constexpr = True,  # pyrefly: ignore[bad-function-definition]
+    use_lower_bound: hl.constexpr = True,  # pyrefly: ignore[bad-function-definition]
+) -> None:
+    """chunk_cumsum_gc_helion over a varlen batch, g read token-major.
+
+    Row r of the flat [H * NT] chunk axis addresses its own tokens, the four lines
+    every varlen kernel here opens with:
+        h     = r // NT                  # head
+        j     = r  % NT                  # chunk, over all sequences
+        rows  = token_base[j] + i        # its tokens, i in [0, C)
+        valid = i < valid_len[j]         # False past this sequence's end
+    so g is read where it lies, never copied into chunk-major order:
+        gt = g[rows, h] * valid          # [C, D] fp32, tail zeroed
+    With use_gate=True gt arrives pre-activation and the gate applies before the sum:
+      - use_lower_bound=True (default):
+            gt = lower_bound * sigmoid(exp(A_log[h]) * (gt + dt_bias[h]))
+      - use_lower_bound=False:
+            gt = -exp(A_log[h]) * softplus(gt + dt_bias[h])
+    The gate maps 0 to lower_bound * sigmoid(0) != 0, so the tail is masked again
+    after it, then the cumsum is the same triangular matmul as the dense kernel:
+        gt = gt * valid                  # [C, D]
+        gc[r] = L @ gt                   # [C, D], L the [C, C] lower-triangular ones
+    A zeroed tail holds the running sum flat, leaving the chunk total gc[C-1]
+    unchanged. Separate from the dense kernel because the chunk axis must be
+    block_size=1 for a scalar row, and hl.tile cannot sit inside a branch."""
+    NT = token_base.size(0)
+    C = hl.specialize(gc.size(1))
+    for tile_r, tile_d in hl.tile([gc.size(0), g.size(2)], block_size=[1, None]):
+        idx = hl.arange(C)
+        ltri = (idx[:, None] >= idx[None, :]).to(torch.float32)  # [C, C] incl. diag
+        j = tile_r.begin % NT
+        h = tile_r.begin // NT
+        valid = idx < valid_len[j]
+        gt = hl.load(g, [token_base[j] + idx, h, tile_d], extra_mask=valid[:, None]).to(
+            torch.float32
+        )  # [C, d]
+        gt = torch.where(valid[:, None], gt, 0.0)
+        if use_gate:
+            a = torch.exp(A_log[h].to(torch.float32))  # pyrefly: ignore[unsupported-operation]
+            if has_bias:
+                gt = gt + dt_bias[h : h + 1, tile_d]  # pyrefly: ignore[unsupported-operation]
+            if use_lower_bound:
+                gt = lower_bound * torch.sigmoid(a * gt)  # pyrefly: ignore[unsupported-operation]
+            else:
+                sp = torch.clamp(gt, min=0.0) + torch.log1p(torch.exp(-torch.abs(gt)))
+                gt = -a * sp
+            gt = torch.where(valid[:, None], gt, 0.0)
+        gc[tile_r.begin, :, tile_d] = hl.dot(ltri, gt)
 
 
 @helion.kernel()
@@ -538,6 +598,103 @@ def chunk_fwd_wy_delta_helion(
 
 
 @helion.kernel()
+def chunk_fwd_wy_delta_varlen_helion(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g_cs: torch.Tensor,
+    Akk: torch.Tensor,
+    token_base: torch.Tensor,
+    valid_len: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    k_state_out: torch.Tensor,
+) -> None:
+    """chunk_fwd_wy_delta_helion's diag_anchored path over a varlen batch.
+
+    k, v and beta are read token-major ([T_total, H, D], [T_total, H, DV],
+    [T_total, H]); g_cs, Akk and every output are per-chunk and stay chunk-major
+    [H * NT, C, *]. Row r addresses its tokens as in chunk_cumsum_gc_varlen_helion:
+        beta_i = beta[rows, h] * valid                # [C] fp32, tail zeroed
+        k_i    = k[rows, h]    * valid                # [C, D]
+        v_i    = v[rows, h]    * valid                # [C, DV]
+    then the transform is the dense diag_anchored one, with the anchored k-gram Akk
+    already carrying the per-channel decay and the strict mask:
+        A   = -(beta_i * Akk)                         # [C, C] strict lower
+        T   = (I - A)^-1                              # log2(C) Neumann doublings
+        w   = T @ (beta_i * exp2(RCP_LN2 * gc) * k_i)         # [C, D]
+        u   = T @ (beta_i * v_i)                              # [C, DV]
+        k_state_out = k_i * exp2(RCP_LN2 * (gc[C-1] - gc))    # [C, D]
+    A zero beta_i row zeros that row of A, so T keeps an identity row there and w, u
+    and k_state_out are all zero on it: the tail contributes nothing downstream.
+
+    The dense kernel also returns T as A_inv for its backward; this path is forward
+    only, so T is not stored. With DV == D the value loop rides the key loop, so u is
+    written in the same pass as w and k_state_out."""
+    NT = token_base.size(0)
+    C = hl.specialize(g_cs.size(1))
+    D = k.size(2)
+    DV = v.size(2)
+    assert C & (C - 1) == 0, f"chunk size C must be a power of two, got {C}"
+    n_doublings = C.bit_length() - 1
+    fuse_v = D == DV
+
+    for tile_r in hl.tile(w.size(0), block_size=1):
+        j = tile_r.begin % NT
+        h = tile_r.begin // NT
+        base = token_base[j]
+        idx = hl.arange(C)
+        valid = idx < valid_len[j]
+
+        beta_i = torch.where(
+            valid, hl.load(beta, [base + idx, h], extra_mask=valid), 0.0
+        ).to(torch.float32)  # [C]
+
+        A = -(beta_i[:, None] * Akk[tile_r.begin, :, :])
+        eye = (idx[:, None] == idx[None, :]).to(torch.float32)
+        T = eye + A
+        Apow = A
+        for _ in range(n_doublings - 1):
+            Apow = hl.dot(Apow, Apow)
+            T = hl.dot(Apow, T, acc=T)
+
+        for tile_d in hl.tile(D):
+            raw_k = torch.where(
+                valid[:, None],
+                hl.load(k, [base + idx, h, tile_d], extra_mask=valid[:, None]),
+                0,
+            ).to(torch.float32)
+            gc_d = g_cs[tile_r.begin, :, tile_d].to(torch.float32)
+            gc_last = g_cs[tile_r.begin, C - 1, tile_d].to(torch.float32)
+            kt = raw_k * beta_i[:, None] * torch.exp2(gc_d * RCP_LN2)
+            k_state_out[tile_r.begin, :, tile_d] = (
+                raw_k * torch.exp2((gc_last[None, :] - gc_d) * RCP_LN2)
+            ).to(k.dtype)
+            w[tile_r.begin, :, tile_d] = hl.dot(T, kt).to(w.dtype)
+            if fuse_v:
+                vt = (
+                    torch.where(
+                        valid[:, None],
+                        hl.load(v, [base + idx, h, tile_d], extra_mask=valid[:, None]),
+                        0,
+                    ).to(torch.float32)
+                    * beta_i[:, None]
+                )
+                u[tile_r.begin, :, tile_d] = hl.dot(T, vt).to(u.dtype)
+        if not fuse_v:
+            for tile_dv in hl.tile(DV):
+                vt = (
+                    torch.where(
+                        valid[:, None],
+                        hl.load(v, [base + idx, h, tile_dv], extra_mask=valid[:, None]),
+                        0,
+                    ).to(torch.float32)
+                    * beta_i[:, None]
+                )
+                u[tile_r.begin, :, tile_dv] = hl.dot(T, vt).to(u.dtype)
+
+
+@helion.kernel()
 def chunk_fwd_h_delta_helion(
     k: torch.Tensor,
     w: torch.Tensor,
@@ -615,6 +772,74 @@ def chunk_fwd_h_delta_helion(
             h_acc = hl.dot(k_i.transpose(-2, -1), vnew_i.to(k_i.dtype), acc=h_orig)
 
     return h_all, v_new
+
+
+@helion.kernel()
+def chunk_fwd_h_delta_varlen_helion(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    h0: torch.Tensor,
+    decay_last: torch.Tensor,
+    chunk_offsets: torch.Tensor,
+    NT: int,
+    H: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """chunk_fwd_h_delta_helion's diag_anchored serial pass, walked per sequence.
+
+    Sequence n owns chunks chunk_offsets[n] : chunk_offsets[n + 1], a count that
+    differs per sequence, so the walk is one program per (head, sequence) and the
+    trip count is a tensor load. All operands are chunk-major, row h * NT + j, and k
+    arrives with the anchored per-channel decay already applied. With decay_last =
+    gc[C-1] the per-channel chunk total, in natural-log space:
+        S = h0[h, n]                                 # [D, DV]
+        for j in chunk_offsets[n] : chunk_offsets[n + 1]:
+            h_all[h, j] = S                          # state entering chunk j
+            v_new[h, j] = u[h, j] - w[h, j] @ S      # [C, DV] delta correction
+            S = exp(decay_last[h, j])[:, None] * S
+                + k[h, j].T @ v_new[h, j]            # [D, DV]
+        ht[h, n] = S                                 # this sequence's final state
+    computed as exp2(RCP_LN2 * x) == exp(x):
+            S = exp2(RCP_LN2 * decay_last[h, j])[:, None] * S + ...
+    Initializing S inside the per-sequence loop is the boundary reset: no path can
+    carry it across one. A ragged chunk's tail rows are zero, so they add nothing to
+    either matmul, and ht is the final state directly, with no host-side last-chunk
+    arithmetic.
+
+    DV leads the tile axes, so a chunk row's DV slices differ by 1 in the flat program
+    id where an (H * N)-major order separates them by H * N. Matches FLA's
+    grid=(cdiv(V, BV), N * HV)."""
+    D = k.size(2)
+    DV = u.size(2)
+    N = chunk_offsets.size(0) - 1
+    C = k.size(1)
+    HNT = k.size(0)
+
+    h_all = torch.empty([HNT, D, DV], dtype=k.dtype, device=k.device)
+    v_new = torch.empty([HNT, C, DV], dtype=k.dtype, device=u.device)
+    ht = torch.empty([H * N, D, DV], dtype=torch.float32, device=k.device)
+
+    for tile_dv, tile_hn in hl.tile([DV, H * N], block_size=[None, 1]):
+        hn = tile_hn.begin
+        n = hn % N
+        h_off = (hn // N) * NT  # first chunk row of this head
+        h_acc = h0[hn, :, tile_dv].float()  # [D, bv]
+
+        for tile_j in hl.tile(chunk_offsets[n], chunk_offsets[n + 1], block_size=1):
+            j = h_off + tile_j.begin
+            h_all[j, :, tile_dv] = h_acc.to(h_all.dtype)
+            w_j = w[j, :, :]  # [C, D]
+            u_j = u[j, :, tile_dv]  # [C, bv]
+            vnew_j = u_j.float() - hl.dot(w_j, h_acc.to(w_j.dtype)).float()
+            v_new[j, :, tile_dv] = vnew_j.to(v_new.dtype)
+            gl = decay_last[j, :].float()  # [D]
+            h_acc = h_acc * torch.exp2(gl * RCP_LN2)[:, None]
+            k_j = k[j, :, :]  # [C, D]
+            h_acc = hl.dot(k_j.transpose(-2, -1), vnew_j.to(k_j.dtype), acc=h_acc)
+
+        ht[hn, :, tile_dv] = h_acc
+
+    return h_all, v_new, ht
 
 
 @helion.kernel()
@@ -1816,6 +2041,176 @@ def chunk_fwd_A_diag_anchored_helion(
 
 
 @helion.kernel()
+def chunk_fwd_A_diag_anchored_varlen_helion(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gc: torch.Tensor,
+    token_base: torch.Tensor,
+    valid_len: torch.Tensor,
+    A: torch.Tensor,
+    Akk: torch.Tensor,
+    scale: float,
+) -> None:
+    """chunk_fwd_A_diag_anchored_helion over a varlen batch, q/k read token-major.
+
+    Row r addresses its tokens as in chunk_cumsum_gc_varlen_helion; gc, A and Akk
+    are per-chunk and stay chunk-major [H * NT, C, *]. Per BC_DIAG-row sub-block,
+    with gc_n = gc at the sub-block's first row (the decay anchor) and cols the live
+    width 0 : (i + 1) * BC_DIAG:
+        q_blk = q[rows_blk, h] * valid_blk             # [BC_DIAG, D], tail zeroed
+        k_col = k[rows_col, h] * valid_col             # [cols, D]
+        qg    = q_blk * exp2(RCP_LN2 * (gc_blk - gc_n))       # [BC_DIAG, D]
+        kg    = k_col * exp2(RCP_LN2 * (gc_n - gc[cols]))     # [cols, D]
+        A[blk]   = (qg @ kg.T) * scale * causal        # [BC_DIAG, cols], t >= s
+        Akk[blk] = (k_blk * exp2(RCP_LN2 * (gc_blk - gc_n))) @ kg.T * strict
+    Anchoring at gc_n bounds each exponent to BC_DIAG rows, so exp2 stays in range,
+    exactly as in the dense kernel. Both grams always build; kda is the only varlen
+    variant.
+
+    A zeroed k column gives kg[s] = 0, hence A[:, s] = 0, so no key from the next
+    sequence enters the gram; zeroed rows are masked again by the output store.
+
+    The sub-blocks are written out, one per tier, each guarded on the chunk size:
+        tier 0:  rows  0..15,  cols  0..15      always
+        tier 1:  rows 16..31,  cols  0..31      C >= 2 * BC_DIAG
+        tier 2:  rows 32..47,  cols  0..47      C >= 3 * BC_DIAG
+        tier 3:  rows 48..63,  cols  0..63      C >= 4 * BC_DIAG
+    so C = 32 takes tiers 0-1 and C = 64 all four; the caller rejects any other C.
+    cols is the width the causal mask leaves nonzero, so both matmuls span
+    (1 + 2 + ... + NC) * BC_DIAG column-rows instead of NC * C, and the caller's
+    zeroed A and Akk already hold what the full-width form would store past it. Unrolled rather than tiled because each width must be a literal:
+    hl.arange rejects arithmetic on a specialized size. FLA's KDA unrolls the same way
+    in chunk_intra.py, on the same NC >= 3 / NC >= 4 guards."""
+    NT = token_base.size(0)
+    C = hl.specialize(gc.size(1))
+    D = hl.specialize(gc.size(2))
+    for tile_r in hl.tile(A.size(0), block_size=1):
+        r = tile_r.begin
+        j = r % NT
+        h = r // NT
+        base = token_base[j]
+        vlen = valid_len[j]
+        dcols = hl.arange(D)
+
+        # Sub-block 0: its live columns are its own rows, so the row operands serve
+        # as the column operands and k is read once.
+        rows0 = hl.arange(16)
+        cols0 = hl.arange(16)
+        m0 = rows0 < vlen
+        q0 = torch.where(
+            m0[:, None],
+            hl.load(q, [base + rows0, h, dcols], extra_mask=m0[:, None]),
+            0,
+        ).float()  # [BC_DIAG, D]
+        k0 = torch.where(
+            m0[:, None],
+            hl.load(k, [base + rows0, h, dcols], extra_mask=m0[:, None]),
+            0,
+        ).float()
+        g0 = gc[r, rows0, :].float()
+        n0 = gc[r, 0, :].float()
+        e0 = torch.exp2((g0 - n0[None, :]) * RCP_LN2)
+        kgt0 = (k0 * torch.exp2((n0[None, :] - g0) * RCP_LN2)).transpose(-2, -1)
+        a0 = hl.dot(q0 * e0, kgt0) * scale
+        A[r, rows0, cols0] = a0 * (rows0[:, None] >= cols0[None, :]).to(a0.dtype)
+        akk0 = hl.dot(k0 * e0, kgt0)
+        Akk[r, rows0, cols0] = akk0 * (rows0[:, None] > cols0[None, :]).to(akk0.dtype)
+
+        if C >= 2 * BC_DIAG:
+            rows1 = 16 + hl.arange(16)
+            cols1 = hl.arange(32)
+            m1 = rows1 < vlen
+            mc1 = cols1 < vlen
+            q1 = torch.where(
+                m1[:, None],
+                hl.load(q, [base + rows1, h, dcols], extra_mask=m1[:, None]),
+                0,
+            ).float()
+            k1 = torch.where(
+                m1[:, None],
+                hl.load(k, [base + rows1, h, dcols], extra_mask=m1[:, None]),
+                0,
+            ).float()
+            kc1 = torch.where(
+                mc1[:, None],
+                hl.load(k, [base + cols1, h, dcols], extra_mask=mc1[:, None]),
+                0,
+            ).float()
+            n1 = gc[r, 16, :].float()
+            e1 = torch.exp2((gc[r, rows1, :].float() - n1[None, :]) * RCP_LN2)
+            ec1 = torch.exp2((n1[None, :] - gc[r, cols1, :].float()) * RCP_LN2)
+            kgt1 = (kc1 * ec1).transpose(-2, -1)
+            a1 = hl.dot(q1 * e1, kgt1) * scale
+            A[r, rows1, cols1] = a1 * (rows1[:, None] >= cols1[None, :]).to(a1.dtype)
+            akk1 = hl.dot(k1 * e1, kgt1)
+            Akk[r, rows1, cols1] = akk1 * (rows1[:, None] > cols1[None, :]).to(
+                akk1.dtype
+            )
+
+        if C >= 3 * BC_DIAG:
+            rows2 = 32 + hl.arange(16)
+            cols2 = hl.arange(48)
+            m2 = rows2 < vlen
+            mc2 = cols2 < vlen
+            q2 = torch.where(
+                m2[:, None],
+                hl.load(q, [base + rows2, h, dcols], extra_mask=m2[:, None]),
+                0,
+            ).float()
+            k2 = torch.where(
+                m2[:, None],
+                hl.load(k, [base + rows2, h, dcols], extra_mask=m2[:, None]),
+                0,
+            ).float()
+            kc2 = torch.where(
+                mc2[:, None],
+                hl.load(k, [base + cols2, h, dcols], extra_mask=mc2[:, None]),
+                0,
+            ).float()
+            n2 = gc[r, 32, :].float()
+            e2 = torch.exp2((gc[r, rows2, :].float() - n2[None, :]) * RCP_LN2)
+            ec2 = torch.exp2((n2[None, :] - gc[r, cols2, :].float()) * RCP_LN2)
+            kgt2 = (kc2 * ec2).transpose(-2, -1)
+            a2 = hl.dot(q2 * e2, kgt2) * scale
+            A[r, rows2, cols2] = a2 * (rows2[:, None] >= cols2[None, :]).to(a2.dtype)
+            akk2 = hl.dot(k2 * e2, kgt2)
+            Akk[r, rows2, cols2] = akk2 * (rows2[:, None] > cols2[None, :]).to(
+                akk2.dtype
+            )
+
+        if C >= 4 * BC_DIAG:
+            rows3 = 48 + hl.arange(16)
+            cols3 = hl.arange(64)
+            m3 = rows3 < vlen
+            mc3 = cols3 < vlen
+            q3 = torch.where(
+                m3[:, None],
+                hl.load(q, [base + rows3, h, dcols], extra_mask=m3[:, None]),
+                0,
+            ).float()
+            k3 = torch.where(
+                m3[:, None],
+                hl.load(k, [base + rows3, h, dcols], extra_mask=m3[:, None]),
+                0,
+            ).float()
+            kc3 = torch.where(
+                mc3[:, None],
+                hl.load(k, [base + cols3, h, dcols], extra_mask=mc3[:, None]),
+                0,
+            ).float()
+            n3 = gc[r, 48, :].float()
+            e3 = torch.exp2((gc[r, rows3, :].float() - n3[None, :]) * RCP_LN2)
+            ec3 = torch.exp2((n3[None, :] - gc[r, cols3, :].float()) * RCP_LN2)
+            kgt3 = (kc3 * ec3).transpose(-2, -1)
+            a3 = hl.dot(q3 * e3, kgt3) * scale
+            A[r, rows3, cols3] = a3 * (rows3[:, None] >= cols3[None, :]).to(a3.dtype)
+            akk3 = hl.dot(k3 * e3, kgt3)
+            Akk[r, rows3, cols3] = akk3 * (rows3[:, None] > cols3[None, :]).to(
+                akk3.dtype
+            )
+
+
+@helion.kernel()
 def chunk_fwd_o_diag_anchored_helion(
     q: torch.Tensor,
     v: torch.Tensor,
@@ -1853,6 +2248,70 @@ def chunk_fwd_o_diag_anchored_helion(
         out[tile_bhn, :, tile_dv] = (o_cross + o_intra).to(out.dtype)
 
     return out
+
+
+@helion.kernel()
+def chunk_fwd_o_diag_anchored_varlen_helion(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    gc: torch.Tensor,
+    h: torch.Tensor,
+    A: torch.Tensor,
+    token_base: torch.Tensor,
+    valid_len: torch.Tensor,
+    out: torch.Tensor,
+    scale: float,
+) -> None:
+    """chunk_fwd_o_diag_anchored_helion over a varlen batch, q read and out written
+    token-major.
+
+    Row r addresses its tokens as in chunk_cumsum_gc_varlen_helion; v (the corrected
+    v_new), gc, h and A are per-chunk and stay chunk-major. A is the pre-masked
+    anchored score matrix, so the output is the dense one:
+        q_i     = q[rows, h] * valid                 # [C, D], tail zeroed
+        qg      = q_i * exp2(RCP_LN2 * gc)           # [C, D]
+        o_cross = (qg @ h) * scale                   # [C, DV] state term
+        o_intra = A @ v                              # [C, DV] intra-chunk term
+        out[rows, h] = o_cross + o_intra   where valid    # [C, DV]
+    Storing under valid is what protects the boundary: a row past a sequence's end is
+    never written, so it cannot overwrite the next sequence's first tokens. That makes
+    the write the inverse of the token-major reads, with no scatter pass.
+
+    A chunk owns one program and takes D and DV whole, so the body has no loop over
+    either; a DV loop would re-read q, gc and A per iteration."""
+    NT = token_base.size(0)
+    C = hl.specialize(gc.size(1))
+    D = hl.specialize(q.size(2))
+    DV = hl.specialize(out.size(2))
+
+    for tile_r in hl.tile(A.size(0), block_size=1):
+        j = tile_r.begin % NT
+        head = tile_r.begin // NT
+        base = token_base[j]
+        idx = hl.arange(C)
+        valid = idx < valid_len[j]
+        dcols = hl.arange(D)
+        vcols = hl.arange(DV)
+
+        qt = torch.where(
+            valid[:, None],
+            hl.load(q, [base + idx, head, dcols], extra_mask=valid[:, None]),
+            0,
+        ).float()  # [C, D]
+        gct = gc[tile_r.begin, :, :]
+        qg = (qt * torch.exp2(gct * RCP_LN2)).to(q.dtype)
+        ht = h[tile_r.begin, :, :]
+        o_cross = hl.dot(qg, ht.to(qg.dtype)) * scale
+
+        vt = v[tile_r.begin, :, :]
+        At = A[tile_r.begin, :, :]
+        o_intra = hl.dot(At.to(vt.dtype), vt)
+        hl.store(
+            out,
+            [base + idx, head, vcols],
+            (o_cross + o_intra).to(out.dtype),
+            extra_mask=valid[:, None],
+        )
 
 
 # Autograd integration
@@ -2339,6 +2798,130 @@ def _helion_chunked_fwd_delta(
         )
 
     return o.reshape(B, H, T, DV), h_all, v_new_all, A_inv, w, final_state
+
+
+def _helion_chunked_fwd_kda_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    C: int,
+    cu_seqlens: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    return_final_state: bool = False,
+    scale: float = 1.0,
+    A_log: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    lower_bound: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """KDA forward over a varlen batch (cu_seqlens), forward only.
+
+    Inputs are token-major [T_total, H, *] with cu_seqlens [N+1] marking the
+    boundaries. The host tables place every chunk, and the five kernels mirror the
+    dense diag_anchored pipeline:
+        chunk_offsets [N+1], token_base [NT], valid_len [NT]
+        NT = sum(ceil(len_n / C))            # total chunks, ragged
+        gc            = cumsum_gc_varlen(g)              # [H*NT, C, D] fp32
+        Aqk, Akk      = A_diag_anchored_varlen(q, k, gc) # [H*NT, C, C]
+        w, u, k_state = wy_delta_varlen(k, v, beta, gc, Akk)
+        h_all, v_new, ht = h_delta_varlen(k_state, w, u, h0, gc[C-1], chunk_offsets)
+        o             = o_diag_anchored_varlen(q, v_new, gc, h_all, Aqk)
+
+    q/k/v/g/beta are never copied: each kernel reads them where they lie and zeros
+    the rows past a sequence's end. Only the intermediates above are materialized, as
+    the dense path materializes its own. The state pass walks one sequence at a time,
+    so the recurrence resets at every boundary and ht is the final state per sequence
+    with no host-side last-chunk arithmetic. The output kernel stores token-major
+    under the same mask, so there is no scatter pass.
+
+    T_total < C is padded up to C, since a chunk addresses C rows and the store needs
+    them in bounds; valid_len still marks only the real tokens, so the padding reads
+    as zero and o is returned at the true T_total.
+    """
+    T_total, H, D = q.shape
+    if T_total < C:
+        extra = C - T_total
+        pad = lambda x: torch.cat([x, x.new_zeros(extra, *x.shape[1:])])  # noqa: E731
+        q, k, v, g, beta = pad(q), pad(k), pad(v), pad(g), pad(beta)
+    DV = v.shape[-1]
+    N = cu_seqlens.numel() - 1
+
+    # Place every chunk: sequence n owns chunk_offsets[n] : chunk_offsets[n + 1], and
+    # chunk j of it starts at token_base[j] with valid_len[j] rows of its own.
+    #     lens          = diff(cu_seqlens)                    # [N]
+    #     chunk_offsets = pad(cumsum(ceil(lens / C)), 1, 0)   # [N + 1]
+    #     token_base[j] = cu_seqlens[n] + i * C               # [NT], i within seq n
+    #     valid_len[j]  = min(lens[n] - i * C, C)             # [NT], rows in 1..C
+    lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunk_offsets = torch.nn.functional.pad(((lens + C - 1) // C).cumsum(0), (1, 0))
+    counts = chunk_offsets[1:] - chunk_offsets[:-1]
+    seq_id = torch.repeat_interleave(torch.arange(N, device=cu_seqlens.device), counts)
+    NT = int(chunk_offsets[-1])
+    local = torch.arange(NT, device=cu_seqlens.device) - chunk_offsets[seq_id]
+    token_base = cu_seqlens[seq_id] + local * C
+    valid_len = (lens[seq_id] - local * C).clamp(max=C)
+
+    HNT = H * NT
+    g_cs = torch.empty(HNT, C, D, dtype=torch.float32, device=q.device)
+    chunk_cumsum_gc_varlen_helion(
+        g,
+        token_base,
+        valid_len,
+        g_cs,
+        A_log,
+        dt_bias,
+        lower_bound,
+        use_gate=A_log is not None,
+        has_bias=dt_bias is not None,
+        use_lower_bound=lower_bound is not None,
+    )
+    decay_last = g_cs[:, C - 1, :]
+
+    Aqk = torch.zeros(HNT, C, C, dtype=q.dtype, device=q.device)
+    Akk = torch.zeros(HNT, C, C, dtype=q.dtype, device=q.device)
+    chunk_fwd_A_diag_anchored_varlen_helion(
+        q, k, g_cs, token_base, valid_len, Aqk, Akk, scale
+    )
+
+    w = torch.empty(HNT, C, D, dtype=k.dtype, device=k.device)
+    u = torch.empty(HNT, C, DV, dtype=v.dtype, device=v.device)
+    k_state = torch.empty(HNT, C, D, dtype=k.dtype, device=k.device)
+    chunk_fwd_wy_delta_varlen_helion(
+        k, v, beta, g_cs, Akk, token_base, valid_len, w, u, k_state
+    )
+
+    # The chunk operands are head-major (row h * NT + j), so the state pass indexes
+    # its own [H * N] axis the same way: row h * N + n. initial_state arrives in
+    # FLA's [N, H, D, DV] order, hence the transpose in and back out.
+    if initial_state is not None:
+        h0 = (
+            initial_state.reshape(N, H, D, DV)
+            .transpose(0, 1)
+            .reshape(H * N, D, DV)
+            .float()
+            .contiguous()
+        )
+    else:
+        h0 = q.new_zeros(H * N, D, DV, dtype=torch.float32)
+
+    h_all, v_new, ht = chunk_fwd_h_delta_varlen_helion(
+        k_state, w, u, h0, decay_last, chunk_offsets, NT, H
+    )
+
+    # Sized from the padded q so the masked store stays in bounds, then sliced back
+    # to the real token count on return.
+    o = q.new_zeros(q.size(0), H, DV)
+    chunk_fwd_o_diag_anchored_varlen_helion(
+        q, v_new, g_cs, h_all, Aqk, token_base, valid_len, o, scale
+    )
+    o = o[:T_total]
+
+    final_state = None
+    if return_final_state:
+        final_state = ht.reshape(H, N, D, DV).transpose(0, 1).contiguous()
+
+    return o, final_state
 
 
 def _helion_chunked_bwd(
@@ -3080,6 +3663,8 @@ def helion_chunk_kda(
     A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     lower_bound: float | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    state_v_first: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """KDA, optionally applying the model's input transforms on the way in.
 
@@ -3095,14 +3680,26 @@ def helion_chunk_kda(
             beta = sigmoid(beta)
     None of the three transforms has a backward, so a flag set on an input with
     requires_grad=True raises NotImplementedError.
+
+    cu_seqlens [N+1] switches to a variable-length batch. Inputs are then
+    token-major [1, T_total, H, D], the layout FLA, vLLM and FlashKDA all use for
+    a varlen batch, rather than the head-first layout of the dense path: sequence n
+    spans tokens cu_seqlens[n] : cu_seqlens[n+1] and the recurrence restarts at
+    each boundary. The output matches its inputs, [1, T_total, H, DV], and
+    initial_state / the returned final state are [N, H, D, DV], one per sequence.
+    This path is forward only.
+
+    state_v_first holds the state as [N, H, DV, D] instead of [N, H, D, DV], matching
+    what vLLM and FlashKDA use; the flag name is FLA's. It applies to initial_state
+    and the returned final state alike, so a returned state feeds straight back in.
     """
     assert g is not None
     assert beta is not None
     any_flag = (
         use_qk_l2norm_in_kernel or use_gate_in_kernel or use_beta_sigmoid_in_kernel
     )
-    needs_grad = (
-        q.requires_grad or k.requires_grad or g.requires_grad or beta.requires_grad
+    needs_grad = any(
+        t is not None and t.requires_grad for t in (q, k, v, g, beta, initial_state)
     )
     if any_flag and needs_grad:
         raise NotImplementedError(
@@ -3110,8 +3707,11 @@ def helion_chunk_kda(
             "and transform the inputs outside the kernel to keep gradients"
         )
 
+    if state_v_first and initial_state is not None:
+        initial_state = initial_state.transpose(-2, -1).contiguous()
+
     if use_qk_l2norm_in_kernel:
-        q, k = l2norm_fwd_helion(q), l2norm_fwd_helion(k)
+        q, k = (l2norm_fwd_helion(t.reshape(-1, t.size(-1))).view_as(t) for t in (q, k))
     if use_beta_sigmoid_in_kernel:
         beta = torch.sigmoid(beta)
     if use_gate_in_kernel:
@@ -3120,7 +3720,66 @@ def helion_chunk_kda(
         A_log = None
         dt_bias = None
         lower_bound = None
-    return chunked_linear_attn(
+
+    if cu_seqlens is not None:
+        if q.size(0) != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.size(0)} when "
+                "using `cu_seqlens`. Please flatten variable-length inputs before "
+                "processing."
+            )
+        if needs_grad:
+            raise NotImplementedError(
+                "the cu_seqlens path is forward-only; pass a dense batch "
+                "to keep gradients"
+            )
+        # chunk_fwd_A_diag_anchored_varlen_helion asserts the same bound; this raises
+        # the caller-facing error before a kernel trace does.
+        if C not in (2 * BC_DIAG, 4 * BC_DIAG):
+            raise ValueError(
+                f"chunk size C must be {2 * BC_DIAG} or {4 * BC_DIAG} for KDA, got {C}"
+            )
+        # Every kernel indexes tokens through cu_seqlens, so a vector that does not
+        # partition [0, T_total) reads the wrong rows rather than failing: an end
+        # below T_total leaves that much of the output at its zero initialization.
+        if int(cu_seqlens[-1]) != q.size(1):
+            raise ValueError(
+                f"cu_seqlens must end at T_total={q.size(1)}, got {int(cu_seqlens[-1])}"
+            )
+        if int(cu_seqlens[0]) != 0 or not bool(
+            (cu_seqlens[1:] > cu_seqlens[:-1]).all()
+        ):
+            raise ValueError("cu_seqlens must start at 0 and strictly increase")
+        # Grouped-query: give every query head its own key/value head, matching what
+        # chunked_linear_attn does for the dense path.
+        H_kv = k.size(2)
+        if H_kv < q.size(2):
+            assert q.size(2) % H_kv == 0
+            n_rep = q.size(2) // H_kv
+            k = k.repeat_interleave(n_rep, dim=2)
+            v = v.repeat_interleave(n_rep, dim=2)
+        o, final_state = _helion_chunked_fwd_kda_varlen(
+            q[0],
+            k[0],
+            v[0],
+            g[0],
+            beta[0],
+            C,
+            cu_seqlens,
+            initial_state=initial_state,
+            return_final_state=return_final_state,
+            scale=scale,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            lower_bound=lower_bound,
+        )
+        o = o.unsqueeze(0)
+        if return_final_state:
+            assert final_state is not None
+            return o, final_state.transpose(-2, -1) if state_v_first else final_state
+        return o
+
+    out = chunked_linear_attn(
         q,
         k,
         v,
@@ -3134,6 +3793,10 @@ def helion_chunk_kda(
         dt_bias=dt_bias,
         lower_bound=lower_bound,
     )
+    if return_final_state and state_v_first:
+        o, final_state = out
+        return o, final_state.transpose(-2, -1)
+    return out
 
 
 def helion_chunk_mamba2_ssd(

--- a/examples/linear/linear_attention_harness.py
+++ b/examples/linear/linear_attention_harness.py
@@ -34,6 +34,8 @@ from helion._testing import do_bench
 # Test/benchmark config
 DTYPE = torch.bfloat16
 TEST_SHAPE = (2, 4, 128, 32, 32)
+VARLEN_TEST_SHAPE = (3, 4, 100, 32, 32)
+VARLEN_TEST_LENGTHS = [100, 37, 163]
 TEST_C = 32
 BENCH_CONFIGS = [(1, 32, 2048, 128, 128), (1, 32, 4096, 128, 128)]
 BENCH_C = 64
@@ -200,7 +202,13 @@ def make_kda_inputs(
     device: str | torch.device = DEVICE,
     requires_grad: bool = False,
     fused_preamble: bool = False,
+    varlen: bool = False,
+    varlen_lengths: list[int] | None = None,
 ) -> Inputs:
+    if varlen:
+        assert varlen_lengths is not None, "varlen needs varlen_lengths"
+        return _make_kda_varlen_inputs(varlen_lengths, H, D, DV, dtype, device)
+
     if not fused_preamble:
         q, k, v = _rand_q_norm_k_v(B, H, T, D, DV, dtype, device, requires_grad)
         g = -torch.rand(B, H, T, D, device=device, dtype=dtype).abs() * 0.1
@@ -222,6 +230,45 @@ def make_kda_inputs(
             "A_log": torch.zeros(H, dtype=torch.float32, device=device),
             "dt_bias": torch.zeros(H, D, dtype=torch.float32, device=device),
             "lower_bound": -5.0,
+        },
+    )
+
+
+def _make_kda_varlen_inputs(
+    lens: list[int],
+    H: int,
+    D: int,
+    DV: int,
+    dtype: torch.dtype = DTYPE,
+    device: str | torch.device = DEVICE,
+) -> Inputs:
+    """Pre-activation KDA inputs as the sequences in lens, under one cu_seqlens.
+
+    Token-major [1, T_total, H, *], the layout FLA, vLLM and FlashKDA all take for a
+    variable-length batch, so both sides of the comparison read these as they are.
+    cu_seqlens rides in preamble beside the *_in_kernel flags, which helion_fwd and
+    fla_fwd already forward verbatim.
+    """
+    total = sum(lens)
+    cu_seqlens = torch.nn.functional.pad(
+        torch.tensor(lens, device=device, dtype=torch.int32).cumsum(0), (1, 0)
+    )
+    rand = lambda *shape: torch.randn(*shape, device=device, dtype=dtype)  # noqa: E731
+    return Inputs(
+        q=rand(1, total, H, D),
+        k=rand(1, total, H, D),
+        v=rand(1, total, H, DV),
+        scale=1.0 / math.sqrt(D),
+        g=rand(1, total, H, D),
+        beta=rand(1, total, H),
+        preamble={
+            "use_qk_l2norm_in_kernel": True,
+            "use_gate_in_kernel": True,
+            "use_beta_sigmoid_in_kernel": True,
+            "A_log": torch.rand(H, dtype=torch.float32, device=device),
+            "dt_bias": torch.rand(H, D, dtype=torch.float32, device=device),
+            "lower_bound": -5.0,
+            "cu_seqlens": cu_seqlens,
         },
     )
 
@@ -289,6 +336,7 @@ _VARIANT_SPECS: dict[
 
 
 _FUSED_PREAMBLE_VARIANTS = frozenset({LinearAttentionVariant.KDA})
+_VARLEN_VARIANTS = frozenset({LinearAttentionVariant.KDA})
 
 
 @dataclass
@@ -299,11 +347,13 @@ class LinearAttentionExampleHarness:
     title: str = field(init=False)
     make_inputs: Callable[..., Inputs] = field(init=False)
     has_fused_preamble: bool = field(init=False)
+    has_varlen: bool = field(init=False)
     grad_tensors: tuple[str, ...] = field(init=False)
 
     def __post_init__(self) -> None:
         self.title, self.make_inputs, self.grad_tensors = _VARIANT_SPECS[self.variant]
         self.has_fused_preamble = self.variant in _FUSED_PREAMBLE_VARIANTS
+        self.has_varlen = self.variant in _VARLEN_VARIANTS
 
     def helion_fwd(self, i: Inputs, C: int) -> torch.Tensor:
         fwd = get_helion_fwd_kernel(self.variant)
@@ -333,12 +383,15 @@ class LinearAttentionExampleHarness:
 
     def reference(self, i: Inputs) -> torch.Tensor:
         assert i.g is not None
+        # The reference walks a head-first [B, H, T, *] batch; varlen inputs are
+        # token-major, so hand it the transposed view. Its output follows suit.
+        t = _htf if _is_varlen(i) else (lambda x: x)
         return naive_recurrent_reference(
-            i.q,
-            i.k,
-            i.v,
-            i.g.float(),
-            beta=i.beta,
+            t(i.q),
+            t(i.k),
+            t(i.v),
+            t(i.g).float(),
+            beta=t(i.beta) if i.beta is not None else None,
             q_scale=i.scale,
             **i.preamble,
         )
@@ -359,24 +412,46 @@ class LinearAttentionExampleHarness:
         )
         run_test(self, TEST_SHAPE, TEST_C, fused_preamble=True)
 
+    def test_varlen(self) -> None:
+        assert self.has_varlen, f"{self.variant.value} has no varlen path"
+        run_test(
+            self,
+            VARLEN_TEST_SHAPE,
+            TEST_C,
+            varlen=True,
+            varlen_lengths=VARLEN_TEST_LENGTHS,
+        )
+
     def benchmark(
-        self, configs: list | None = None, fused_preamble: bool = False
+        self,
+        configs: list | None = None,
+        fused_preamble: bool = False,
+        varlen: bool = False,
+        varlen_lengths: list[int] | None = None,
     ) -> list[tuple[str, float, float, float, float]]:
         return run_benchmark(
             self,
             configs if configs is not None else BENCH_CONFIGS,
             BENCH_C,
             fused_preamble=fused_preamble,
+            varlen=varlen,
+            varlen_lengths=varlen_lengths,
         )
 
     def accuracy(
-        self, configs: list | None = None, fused_preamble: bool = False
+        self,
+        configs: list | None = None,
+        fused_preamble: bool = False,
+        varlen: bool = False,
+        varlen_lengths: list[int] | None = None,
     ) -> list[tuple[str, str]]:
         return run_accuracy(
             self,
             configs if configs is not None else BENCH_CONFIGS,
             BENCH_C,
             fused_preamble=fused_preamble,
+            varlen=varlen,
+            varlen_lengths=varlen_lengths,
         )
 
 
@@ -397,8 +472,18 @@ def _has_fla(harness: LinearAttentionExampleHarness) -> bool:
     return get_fla_fwd_kernel(harness.variant) is not None
 
 
+def _is_varlen(inputs: Inputs) -> bool:
+    """True when the inputs are varlen, i.e. already token-major."""
+    return "cu_seqlens" in inputs.preamble
+
+
 def _fla_inputs(inputs: Inputs) -> Inputs:
-    """Inputs in FLA's time-first layout: transpose every tensor, keep scalars."""
+    """Inputs in FLA's time-first layout: transpose every tensor, keep scalars.
+
+    Varlen inputs are token-major already, so they pass through untouched.
+    """
+    if _is_varlen(inputs):
+        return inputs
     out = dataclasses.replace(inputs)
     for f in dataclasses.fields(out):
         val = getattr(out, f.name)
@@ -440,20 +525,32 @@ def run_test(
     test_shape: tuple[int, int, int, int, int],
     C: int,
     fused_preamble: bool = False,
+    varlen: bool = False,
+    varlen_lengths: list[int] | None = None,
 ) -> None:
     """Forward + backward correctness vs reference and FLA.
 
     fused_preamble asks for pre-activation inputs, which have no backward, so only
-    the forward is checked.
+    the forward is checked. varlen adds cu_seqlens on top, so its tensors are
+    token-major and the comparisons transpose our output to the head-first layout
+    the reference returns.
     """
     torch.manual_seed(42)
     B, H, T, D, DV = test_shape
-    extra = {"fused_preamble": True} if fused_preamble else {}
+    extra: dict[str, object] = {}
+    if fused_preamble:
+        extra["fused_preamble"] = True
+    if varlen:
+        extra["varlen"] = True
+        extra["varlen_lengths"] = varlen_lengths
     inputs = harness.make_inputs(B, H, T, D, DV, dtype=DTYPE, device=DEVICE, **extra)
     scale = inputs.scale
+    # A varlen forward returns token-major; the reference and FLA both give
+    # head-first, so line our output up with them.
+    as_ref = _htf if varlen else (lambda x: x)
 
     # === Forward: vs naive recurrent reference ===
-    out = harness.helion_fwd(inputs, C)
+    out = as_ref(harness.helion_fwd(inputs, C))
     ref = harness.reference(inputs)
     fwd_err = _rel_error(out, ref)
     assert fwd_err < ACC_FWD_TOL, f"Forward error: {fwd_err}"
@@ -514,13 +611,21 @@ def _time_config(
     shape: tuple[int, int, int, int, int],
     C: int,
     fused_preamble: bool = False,
+    varlen: bool = False,
+    varlen_lengths: list[int] | None = None,
 ) -> tuple[float, float, float, float]:
     """Time helion/FLA forward and fwd+bwd for one shape.
 
-    The fwd+bwd pair is 0.0 for pre-activation inputs, which have no backward.
+    The fwd+bwd pair is 0.0 for pre-activation inputs, which have no backward, and
+    varlen is one such case.
     """
     bi, hi, ti, di, dvi = shape
-    extra = {"fused_preamble": True} if fused_preamble else {}
+    extra: dict[str, object] = {}
+    if fused_preamble:
+        extra["fused_preamble"] = True
+    if varlen:
+        extra["varlen"] = True
+        extra["varlen_lengths"] = varlen_lengths
     inputs = harness.make_inputs(
         bi,
         hi,
@@ -529,7 +634,7 @@ def _time_config(
         dvi,
         dtype=DTYPE,
         device=DEVICE,
-        requires_grad=not fused_preamble,
+        requires_grad=not (fused_preamble or varlen),
         **extra,
     )
     scale = inputs.scale
@@ -565,6 +670,8 @@ def run_benchmark(
     configs: list,
     C: int,
     fused_preamble: bool = False,
+    varlen: bool = False,
+    varlen_lengths: list[int] | None = None,
 ) -> list[tuple[str, float, float, float, float]]:
     """Benchmark forward and fwd+bwd, comparing against FLA.
 
@@ -585,7 +692,12 @@ def run_benchmark(
 
     for shape in configs:
         fwd_ms, fla_fwd_ms, fb_ms, fla_fb_ms = _time_config(
-            harness, shape, C, fused_preamble=fused_preamble
+            harness,
+            shape,
+            C,
+            fused_preamble=fused_preamble,
+            varlen=varlen,
+            varlen_lengths=varlen_lengths,
         )
         cfg = f"({','.join(str(x) for x in shape)})"
         print(
@@ -602,6 +714,8 @@ def run_accuracy(
     configs: list,
     C: int,
     fused_preamble: bool = False,
+    varlen: bool = False,
+    varlen_lengths: list[int] | None = None,
 ) -> list[tuple[str, str]]:
     """Per-config (fwd, bwd) verdicts vs the fp32 PyTorch reference.
 
@@ -613,14 +727,20 @@ def run_accuracy(
     reference.
     """
     verdicts: list[tuple[str, str]] = []
-    extra = {"fused_preamble": True} if fused_preamble else {}
+    extra: dict[str, object] = {}
+    if fused_preamble:
+        extra["fused_preamble"] = True
+    if varlen:
+        extra["varlen"] = True
+        extra["varlen_lengths"] = varlen_lengths
+    as_ref = _htf if varlen else (lambda x: x)
     for bi, hi, ti, di, dvi in configs:
         inputs = harness.make_inputs(
             bi, hi, ti, di, dvi, dtype=DTYPE, device=DEVICE, **extra
         )
 
         try:
-            out = harness.helion_fwd(inputs, C)
+            out = as_ref(harness.helion_fwd(inputs, C))
         except Exception:
             torch.cuda.empty_cache()
             fwd = "HEL-ERR"

--- a/examples/linear/linear_attention_utils.py
+++ b/examples/linear/linear_attention_utils.py
@@ -211,6 +211,7 @@ def naive_recurrent_reference(
     use_qk_l2norm_in_kernel: bool = False,
     use_gate_in_kernel: bool = False,
     use_beta_sigmoid_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Step-by-step recurrent computation. Slow but correct.
 
@@ -222,6 +223,10 @@ def naive_recurrent_reference(
                                     (decay + dt_bias)), or -exp(A_log) *
                                     softplus(...) when lower_bound is None
     The names match the flags on the kernels, so a caller forwards one dict to both.
+
+    cu_seqlens [N+1] marks sequence boundaries in a varlen batch (B == 1), where
+    sequence n spans tokens cu_seqlens[n] : cu_seqlens[n+1]. The state resets to
+    zero at each boundary, so no key from one sequence reaches another's output.
     """
     if use_qk_l2norm_in_kernel:
         q = F.normalize(q.float(), dim=-1).to(q.dtype)
@@ -246,8 +251,11 @@ def naive_recurrent_reference(
     S = q.new_zeros(B, H, D, DV, dtype=torch.float32)
     outputs = []
     diagonal = decay.dim() == 4
+    starts = set() if cu_seqlens is None else set(cu_seqlens[:-1].tolist())
 
     for t in range(T):
+        if t in starts:
+            S = torch.zeros_like(S)
         qt = q[:, :, t].float() * q_scale
         kt = k[:, :, t].float()
         vt = v[:, :, t].float()

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2968,6 +2968,13 @@ class TestExamples(RefEagerTestBase, TestCase):
     def test_linear_kda_fused_preamble(self):
         self._run_linear_example("example_kda", method="test_fused_preamble")
 
+    @pytest.mark.timeout(600)
+    @skipIfRefEager("linear examples assert against their own reference")
+    @skipIfNotCUDA()
+    @skipIfCute("linear-attention examples not supported on cute backend")
+    def test_linear_kda_varlen(self):
+        self._run_linear_example("example_kda", method="test_varlen")
+
     # ── Monkey-patch tests: plug our engine into FLA layers ──
 
     def _linear_attn_monkeypatch_test(


### PR DESCRIPTION
Stacked PRs:
 * #3291
 * #3290
 * __->__#3289


--- --- ---

### [examples] Add a variable-length KDA forward


FLA, vLLM and FlashKDA all take a variable-length batch the same way: one tensor of all the tokens plus `cu_seqlens` marking the boundaries. The engine had no way to express it, so a ragged batch had to be padded to its longest sequence. `helion_chunk_kda` now takes `cu_seqlens` and runs the batch as it is. Forward only: FlashKDA implements no backward, and vLLM is an inference engine.

- **`cu_seqlens`** switches `helion_chunk_kda` to a varlen batch: inputs token-major `[1, T_total, H, D]`, state `[N, H, D, DV]` one per sequence, and `state_v_first` for the `[N, H, DV, D]` vLLM and FlashKDA hold.
- **Five varlen kernels**, one per stage of the dense `diag_anchored` pipeline.
- **`chunk_fwd_h_delta_varlen_helion`** runs the serial state pass as one program per `(head, sequence)`, looping over that sequence's chunks `chunk_offsets[n] : chunk_offsets[n + 1]`. The state is initialized inside that loop, so each sequence starts from its own `h0` and writes its own final state.
- **`naive_recurrent_reference`** takes `cu_seqlens` and resets its state at each boundary.
- **`l2norm_fwd_helion`** tiles one axis over a `[N, D]` view instead of three over `[B, T, H, D]`.

`test_linear_kda_varlen` runs the varlen path through the same harness as `test_linear_kda`. A `kda_varlen` variant in `benchmarks/run_linattn.py` benchmarks it on FlashKDA's sequence partitions rather than the dense grid, and is forward-only, so it emits no `-bwd` dashboard row.

`%FLA = 100 * fla_ms / helion_ms` on H100, autotuned with `HELION_AUTOTUNE_EFFORT=full`. **Higher is faster than FLA.**

Shapes (`<partition>_T*_H*_D*` encodes the sequence lengths, total tokens, heads, head dim), from FlashKDA's `benchmarks/bench_fwd.py`:

- `fixed_T8192_H96_D128`, one sequence: `[8192]`
- `fixed_T8192_H64_D128`, one sequence: `[8192]`
- `ragged_T8192_H96_D128`, six sequences: `[1300, 547, 2048, 963, 271, 3063]`
- `ragged_T8192_H64_D128`, six sequences: `[1300, 547, 2048, 963, 271, 3063]`
- `uniform_T8192_H96_D128`, eight sequences: `[1024] * 8`
- `uniform_T8192_H64_D128`, eight sequences: `[1024] * 8`

Forward:

| variant | fixed_T8192_H96_D128 | fixed_T8192_H64_D128 | ragged_T8192_H96_D128 | ragged_T8192_H64_D128 | uniform_T8192_H96_D128 | uniform_T8192_H64_D128 |
|---|---|---|---|---|---|---|
| kda_varlen | 101% | 90% | 95% | 89% | 99% | 90% |
