### PR TITLE
[examples] Add FlashKDA as a second baseline for kda_varlen

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -183,6 +183,11 @@ jobs:
           uv pip install "git+https://github.com/fla-org/flash-linear-attention@6bd90692588c81fe102ee6e12ac70686359658a2" --no-deps
           python -c "from packaging.version import Version; import torch, triton; print('torch', torch.__version__, 'triton', triton.__version__); assert torch.cuda.is_available(); assert Version(triton.__version__) >= Version('3.7.1'), triton.__version__"
           python -c "import fla; print('fla', fla.__name__)"
+          # FlashKDA builds a CUDA extension: --no-build-isolation for the torch
+          # import in its setup.py, and FLASH_KDA_CUDA_ARCHS so the arch does not
+          # depend on a device being visible while installing.
+          FLASH_KDA_CUDA_ARCHS=all uv pip install "git+https://github.com/MoonshotAI/FlashKDA" --no-build-isolation --no-deps
+          python -c "import flash_kda; print('flash_kda', flash_kda.__name__)"
 
       - name: Run TritonBench Benchmark
         if: inputs.suite == 'tritonbench'

--- a/benchmarks/run_linattn.py
+++ b/benchmarks/run_linattn.py
@@ -36,7 +36,8 @@ SHAPES: list[tuple[str, int, int, int, int]] = [
 
 # Variants with their own examples.linear.example_<name> module, whose
 # benchmark(configs) returns (cfg, helion_fwd_ms, fla_fwd_ms, helion_fb_ms,
-# fla_fb_ms) rows. Each emits a forward and a forward+backward ("<variant>-bwd") row.
+# fla_fb_ms, flashkda_fwd_ms) rows. Each emits a forward and a forward+backward
+# ("<variant>-bwd") row.
 DENSE_VARIANTS = [
     "vanilla_linear_attn",
     "simple_gla",
@@ -127,6 +128,16 @@ def write_results_json(
             labels,
             [r[2] / r[1] if r[1] else 0.0 for r in rows],
         )
+        # FlashKDA against the same FLA baseline, on the varlen shapes only.
+        fk = [r[5] for r in rows]
+        if any(fk):
+            add_metric(variant, "flashkda_latency_ms", labels, fk)
+            add_metric(
+                variant,
+                "flashkda_speedup",
+                labels,
+                [r[2] / r[5] if r[5] else 0.0 for r in rows],
+            )
         if variant in FUSED_PREAMBLE_VARIANTS or variant in VARLEN_VARIANTS:
             # Forward-only: no backward to time, and no verdict to report.
             continue

--- a/examples/linear/linear_attention_flashkda.py
+++ b/examples/linear/linear_attention_flashkda.py
@@ -1,0 +1,100 @@
+"""FlashKDA forward kernel, adapted to the shared wrapper signature.
+
+FlashKDA is a hand-written CUDA extension and is optional for these examples. It
+implements KDA only, forward only, at D == 128, and it takes the model's input
+transforms itself, so it pairs with the fused-preamble flags rather than with
+pre-transformed inputs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Protocol
+
+from .linear_attention_engine import LinearAttentionVariant
+
+if TYPE_CHECKING:
+    import torch
+
+
+class FlashKdaForwardKernel(Protocol):
+    def __call__(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor | None = None,
+        beta: torch.Tensor | None = None,
+        *,
+        scale: float = 1.0,
+        initial_state: torch.Tensor | None = None,
+        return_final_state: bool = False,
+        cu_seqlens: torch.Tensor | None = None,
+        **preamble: object,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]: ...
+
+
+_FLASHKDA_FWD: dict[LinearAttentionVariant, FlashKdaForwardKernel] = {}
+
+try:
+    import flash_kda  # pyrefly: ignore[missing-import]
+except ImportError:
+    pass
+else:
+    import torch
+
+    def flashkda_fwd(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor | None = None,
+        beta: torch.Tensor | None = None,
+        *,
+        scale: float = 1.0,
+        initial_state: torch.Tensor | None = None,
+        return_final_state: bool = False,
+        cu_seqlens: torch.Tensor | None = None,
+        **preamble: object,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """flash_kda.fwd, which writes o and the final state into out params.
+
+        State is [N, H, V, K], the state_v_first orientation. cu_seqlens is int64
+        here where the engine takes int32.
+        """
+        assert g is not None
+        assert beta is not None
+        out = torch.empty_like(v)
+        final_state = (
+            torch.empty_like(initial_state)
+            if return_final_state and initial_state is not None
+            else None
+        )
+        flash_kda.fwd(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            scale,
+            out,
+            A_log=preamble["A_log"],
+            dt_bias=preamble["dt_bias"],
+            lower_bound=preamble["lower_bound"],
+            initial_state=initial_state,
+            final_state=final_state,
+            cu_seqlens=None if cu_seqlens is None else cu_seqlens.to(torch.int64),
+        )
+        return out, final_state
+
+    _FLASHKDA_FWD = {LinearAttentionVariant.KDA: flashkda_fwd}
+
+
+def get_flashkda_fwd_kernel(
+    variant: LinearAttentionVariant,
+) -> FlashKdaForwardKernel | None:
+    return _FLASHKDA_FWD.get(variant)
+
+
+def flashkda_supports(d: int, dv: int) -> bool:
+    """FlashKDA is compiled for D == DV == 128 only."""
+    return d == 128 and dv == 128

--- a/examples/linear/linear_attention_harness.py
+++ b/examples/linear/linear_attention_harness.py
@@ -21,6 +21,8 @@ from .linear_attention_engine import LinearAttentionVariant
 from .linear_attention_engine import get_helion_fwd_kernel
 from .linear_attention_engine import recurrent_step
 from .linear_attention_fla import get_fla_fwd_kernel
+from .linear_attention_flashkda import flashkda_supports
+from .linear_attention_flashkda import get_flashkda_fwd_kernel
 from .linear_attention_utils import ACC_BWD_TOL
 from .linear_attention_utils import ACC_FWD_TOL
 from .linear_attention_utils import chunked_linear_attn_reference
@@ -381,6 +383,20 @@ class LinearAttentionExampleHarness:
     def fla_fb(self, i: Inputs, go_t: torch.Tensor, scale: float) -> None:
         self.fla_fwd(i, scale).backward(go_t)
 
+    def flashkda_fwd(self, i: Inputs, scale: float) -> torch.Tensor:
+        fwd = get_flashkda_fwd_kernel(self.variant)
+        assert fwd is not None
+        o, _ = fwd(
+            i.q,
+            i.k,
+            i.v,
+            i.g,
+            i.beta,
+            scale=scale,
+            **i.preamble,
+        )
+        return o
+
     def reference(self, i: Inputs) -> torch.Tensor:
         assert i.g is not None
         # The reference walks a head-first [B, H, T, *] batch; varlen inputs are
@@ -428,7 +444,7 @@ class LinearAttentionExampleHarness:
         fused_preamble: bool = False,
         varlen: bool = False,
         varlen_lengths: list[int] | None = None,
-    ) -> list[tuple[str, float, float, float, float]]:
+    ) -> list[tuple[str, float, float, float, float, float]]:
         return run_benchmark(
             self,
             configs if configs is not None else BENCH_CONFIGS,
@@ -470,6 +486,22 @@ def _grad_leaves(
 
 def _has_fla(harness: LinearAttentionExampleHarness) -> bool:
     return get_fla_fwd_kernel(harness.variant) is not None
+
+
+def _has_flashkda(
+    harness: LinearAttentionExampleHarness, inputs: Inputs, d: int, dv: int
+) -> bool:
+    """FlashKDA runs the varlen KDA forward only, at D == DV == 128.
+
+    It reads q/k/v/g token-major and takes the input transforms itself, which is
+    the varlen path's layout and flag set. The dense path is head-first, so it is
+    excluded rather than fed transposed tensors.
+    """
+    return (
+        get_flashkda_fwd_kernel(harness.variant) is not None
+        and flashkda_supports(d, dv)
+        and _is_varlen(inputs)
+    )
 
 
 def _is_varlen(inputs: Inputs) -> bool:
@@ -613,11 +645,11 @@ def _time_config(
     fused_preamble: bool = False,
     varlen: bool = False,
     varlen_lengths: list[int] | None = None,
-) -> tuple[float, float, float, float]:
-    """Time helion/FLA forward and fwd+bwd for one shape.
+) -> tuple[float, float, float, float, float]:
+    """Time helion/FLA forward and fwd+bwd for one shape, plus FlashKDA forward.
 
     The fwd+bwd pair is 0.0 for pre-activation inputs, which have no backward, and
-    varlen is one such case.
+    varlen is one such case. The FlashKDA time is 0.0 wherever it does not apply.
     """
     bi, hi, ti, di, dvi = shape
     extra: dict[str, object] = {}
@@ -642,8 +674,19 @@ def _time_config(
 
     fwd_ms = do_bench(lambda: harness.helion_fwd(inputs, C))
     fla_fwd_ms = do_bench(lambda: harness.fla_fwd(fla_inputs, scale))
+    fk_ms = (
+        do_bench(lambda: harness.flashkda_fwd(inputs, scale))
+        if _has_flashkda(harness, inputs, di, dvi)
+        else 0.0
+    )
     if inputs.preamble:
-        return cast("float", fwd_ms), cast("float", fla_fwd_ms), 0.0, 0.0
+        return (
+            cast("float", fwd_ms),
+            cast("float", fla_fwd_ms),
+            0.0,
+            0.0,
+            cast("float", fk_ms),
+        )
 
     grad_out = torch.randn(bi, hi, ti, dvi, device=DEVICE, dtype=DTYPE)
     go_t = _htf(grad_out)
@@ -662,6 +705,7 @@ def _time_config(
         cast("float", fla_fwd_ms),
         cast("float", fb_ms),
         cast("float", fla_fb_ms),
+        cast("float", fk_ms),
     )
 
 
@@ -672,26 +716,27 @@ def run_benchmark(
     fused_preamble: bool = False,
     varlen: bool = False,
     varlen_lengths: list[int] | None = None,
-) -> list[tuple[str, float, float, float, float]]:
-    """Benchmark forward and fwd+bwd, comparing against FLA.
+) -> list[tuple[str, float, float, float, float, float]]:
+    """Benchmark forward and fwd+bwd, comparing against FLA and FlashKDA.
 
-    Returns one (config, helion_fwd_ms, fla_fwd_ms, helion_fb_ms, fla_fb_ms) row
-    per config; empty when fla is unavailable. The fwd+bwd pair is 0.0 with
-    fused_preamble, whose inputs have no backward.
+    Returns one (config, helion_fwd_ms, fla_fwd_ms, helion_fb_ms, fla_fb_ms,
+    flashkda_fwd_ms) row per config; empty when fla is unavailable. The fwd+bwd
+    pair is 0.0 with fused_preamble, whose inputs have no backward, and the
+    FlashKDA time is 0.0 wherever it does not apply.
     """
-    rows: list[tuple[str, float, float, float, float]] = []
+    rows: list[tuple[str, float, float, float, float, float]] = []
     if not _has_fla(harness):
         warnings.warn("fla not installed, skipping benchmark", stacklevel=1)
         return rows
 
     print(
         f"{'Config':<24} {'Helion fwd':>10} {'FLA fwd':>10}"
-        f" {'Helion f+b':>12} {'FLA f+b':>12}"
+        f" {'Helion f+b':>12} {'FLA f+b':>12} {'FlashKDA':>10}"
     )
-    print("-" * 72)
+    print("-" * 83)
 
     for shape in configs:
-        fwd_ms, fla_fwd_ms, fb_ms, fla_fb_ms = _time_config(
+        fwd_ms, fla_fwd_ms, fb_ms, fla_fb_ms, fk_ms = _time_config(
             harness,
             shape,
             C,
@@ -702,9 +747,9 @@ def run_benchmark(
         cfg = f"({','.join(str(x) for x in shape)})"
         print(
             f"{cfg:<24} {fwd_ms:>10.3f} {fla_fwd_ms:>10.3f}"
-            f" {fb_ms:>12.3f} {fla_fb_ms:>12.3f}"
+            f" {fb_ms:>12.3f} {fla_fb_ms:>12.3f} {fk_ms:>10.3f}"
         )
-        rows.append((cfg, fwd_ms, fla_fwd_ms, fb_ms, fla_fb_ms))
+        rows.append((cfg, fwd_ms, fla_fwd_ms, fb_ms, fla_fb_ms, fk_ms))
 
     return rows
 


### PR DESCRIPTION
Stacked PRs:
 * #3298
 * __->__#3291
 * #3290


--- --- ---

### [examples] Add FlashKDA as a second baseline for kda_varlen


[FlashKDA](https://github.com/MoonshotAI/FlashKDA) implements the same KDA forward as `kda_varlen`. Benchmarking it on the same shapes gives the dashboard a `flashkda_speedup` column next to `helion_speedup`, both measured against FLA.

## What's here
- **`examples/linear/linear_attention_flashkda.py`** and `harness.flashkda_fwd`, wiring FlashKDA in as a second baseline for `kda_varlen`.
- **`flashkda_latency_ms` and `flashkda_speedup`** in `benchmarks/run_linattn.py`.
- **The install in `benchmark.yml`**, beside FLA's.

It is forward-only, takes its inputs token-major and pre-activation, and is compiled for `D == DV == 128`.

## Benchmarks
`%FLA = 100 * fla_ms / row_ms` on H100, autotuned with `HELION_AUTOTUNE_EFFORT=full`. **Higher is faster than FLA.**

| variant | fixed_T8192_H96_D128 | fixed_T8192_H64_D128 | ragged_T8192_H96_D128 | ragged_T8192_H64_D128 | uniform_T8192_H96_D128 | uniform_T8192_H64_D128 |
|---|---|---|---|---|---|---|
| kda_varlen | 100% | 91% | 95% | 90% | 99% | 91% |
| flash_kda | 232% | 183% | 229% | 217% | 257% | 259% |

So FlashKDA is about 2.2x ahead of us. It is written in CuTe, and these numbers are
Helion on the Triton backend, so the next thing to try is `HELION_BACKEND=cute`.
