### PR TITLE
[cute] Automatically use one-shot role schedulers

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -6640,6 +6640,25 @@ def _emit_mma_pipeline(
         tcgen05_scheduler_warp_count_for_plan = tcgen05_effective_scheduler_warps
         tcgen05_sched_stage_count_for_plan = tcgen05_sched_stage_count_value
         tcgen05_persistence_model_for_plan = tcgen05_persistence_model_str
+
+        # When the entire grid fits in one wave, every persistent CTA receives
+        # exactly one tile.
+        one_shot_m_slots = (m_size // bm) * (2 if tcgen05_is_two_cta else 1)
+        one_shot_n_slots = n_size // bn
+        one_shot_work_ctas = one_shot_m_slots * one_shot_n_slots
+        tcgen05_one_shot_role_scheduler = (
+            tcgen05_pid_is_persistent
+            and tcgen05_static_full_tiles
+            and (analysis is None or not analysis.has_leading_passthrough)
+            and one_shot_work_ctas <= env.config_spec.num_sm
+            # A partial cluster could access out of bounds.
+            and one_shot_m_slots % tcgen05_cluster_m == 0
+            and one_shot_n_slots % tcgen05_cluster_n == 0
+            and tcgen05_use_role_local_persistent_body
+            and tcgen05_effective_scheduler_warps == 0
+            and tcgen05_grouped_plan is None
+            and tcgen05_l2_swizzle_size_value == 1
+        )
         tcgen05_matmul_plan = CuteTcgen05MatmulPlan(
             bm=tcgen05_mma_bm,
             bn=tcgen05_mma_bn,
@@ -6658,6 +6677,7 @@ def _emit_mma_pipeline(
             c_stage_count=tcgen05_c_stage_count_value,
             epi_warp_count=tcgen05_epi_warp_count_value,
             ab_load_warp_count=tcgen05_warp_spec.ab_load_warps,
+            one_shot_role_scheduler=tcgen05_one_shot_role_scheduler,
             scheduler_warp_count=tcgen05_scheduler_warp_count_for_plan,
             sched_stage_count=tcgen05_sched_stage_count_for_plan,
             # ``c_input_warp_count`` plumbs the warp-spec slot

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -205,6 +205,7 @@ class CuteTcgen05MatmulPlan(_CuteTcgen05OrientationMixin):
     c_stage_count: int
     epi_warp_count: int
     ab_load_warp_count: int = 1
+    one_shot_role_scheduler: bool = False
     # Dedicated scheduler warp count for ROLE_LOCAL_WITH_SCHEDULER. Default
     # zero keeps MONOLITHIC's historical role IDs; one adds a scheduler warp
     # after the AB-load warp that publishes work-tile metadata through the

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -2891,23 +2891,25 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                     f"{tile_counter_var} = {tile_counter_var} + cutlass.Int32(1)"
                 )
             )
-        per_tile_body.extend(
-            [
-                statement_from_string(f"{sched_var}.advance_to_next_work()"),
-                statement_from_string(
-                    f"{work_tile_var} = {sched_var}.get_current_work()"
-                ),
-            ]
-        )
-
-        prelude.append(
-            create(
-                ast.While,
-                test=expr_from_string(f"{work_tile_var}.is_valid_tile"),
-                body=per_tile_body,
-                orelse=[],
+        if (plan := self._tcgen05_plan()) is not None and plan.one_shot_role_scheduler:
+            prelude.extend(per_tile_body)
+        else:
+            per_tile_body.extend(
+                [
+                    statement_from_string(f"{sched_var}.advance_to_next_work()"),
+                    statement_from_string(
+                        f"{work_tile_var} = {sched_var}.get_current_work()"
+                    ),
+                ]
             )
-        )
+            prelude.append(
+                create(
+                    ast.While,
+                    test=expr_from_string(f"{work_tile_var}.is_valid_tile"),
+                    body=per_tile_body,
+                    orelse=[],
+                )
+            )
 
         return create(
             ast.If,

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -718,27 +718,26 @@ class TestCuteLowerings(unittest.TestCase):
     def _role_local_while_source_for_predicate(
         self, code: str, tree: ast.AST, role_predicate: str
     ) -> tuple[str, int, int]:
+        role_blocks: list[ast.If] = []
         matches: list[ast.While] = []
         for node in ast.walk(tree):
             if not (
                 isinstance(node, ast.If) and ast.unparse(node.test) == role_predicate
             ):
                 continue
+            role_blocks.append(node)
             for role_child in ast.walk(node):
                 if isinstance(
                     role_child, ast.While
                 ) and "tcgen05_role_local" in ast.unparse(role_child.test):
                     matches.append(role_child)
-        self.assertEqual(
-            len(matches),
-            1,
-            "Expected exactly one role-local while for "
-            f"{role_predicate!r}. Generated code:\n{code}",
-        )
-        role_src = ast.get_source_segment(code, matches[0])
+        self.assertEqual(len(role_blocks), 1, code)
+        self.assertLessEqual(len(matches), 1, code)
+        role_node: ast.If | ast.While = matches[0] if matches else role_blocks[0]
+        role_src = ast.get_source_segment(code, role_node)
         self.assertIsNotNone(
             role_src,
-            "Expected parsed role-local while to preserve source extent. "
+            "Expected parsed role-local body to preserve source extent. "
             "Generated code:\n" + code,
         )
         assert role_src is not None
@@ -2060,53 +2059,57 @@ class TestCuteLowerings(unittest.TestCase):
             torch.randn(256, 32, device=DEVICE, dtype=torch.float16),
             torch.randn(32, 256, device=DEVICE, dtype=torch.float16),
         )
-        with patch_cute_mma_support():
-            bound = cute_matmul_persistent_post_loop.bind(args)
-            bound.env.config_spec.cute_tcgen05_search_enabled = True
-            # ``persistent_blocked`` is normally disallowed for tcgen05
-            # via ``enforce_dot_requirements`` because autotune can still
-            # choose configs that fall back to guarded partial persistent
-            # paths. The codegen itself accepts the explicit config, which
-            # is what this structural test exercises.
-            cfg = _make_tcgen05_persistent_config(
-                block_sizes=[128, 128, 16],
-                pid_type="persistent_blocked",
-            )
-            code = bound.to_triton_code(cfg)
+        for num_sm in (0, 148):
+            with self.subTest(num_sm=num_sm), patch_cute_mma_support():
+                bound = cute_matmul_persistent_post_loop.bind(args)
+                bound.env.config_spec.cute_tcgen05_search_enabled = True
+                bound.env.config_spec.num_sm = num_sm
+                # ``persistent_blocked`` is normally disallowed for tcgen05
+                # via ``enforce_dot_requirements`` because autotune can still
+                # choose configs that fall back to guarded partial persistent
+                # paths. The codegen itself accepts the explicit config, which
+                # is what this structural test exercises.
+                cfg = _make_tcgen05_persistent_config(
+                    block_sizes=[128, 128, 16],
+                    pid_type="persistent_blocked",
+                )
+                code = bound.to_triton_code(cfg)
 
-        # Role-local codegen emits one work-tile loop per warp role. Verify
-        # one-shot cleanup follows the last of those loops, rather than being
-        # replayed in any role's per-tile body.
-        tree = ast.parse(code)
-        work_tile_loops = [
-            node
-            for node in ast.walk(tree)
-            if isinstance(node, ast.While)
-            and (
-                "tcgen05_role_local_" in ast.unparse(node.test)
-                or ast.unparse(node.test) == "tcgen05_work_tile_valid"
-            )
-        ]
-        self.assertTrue(
-            work_tile_loops, "expected at least one persistent work-tile loop"
-        )
-        last_work_tile_line = max(
-            node.end_lineno or node.lineno for node in work_tile_loops
-        )
-        for tag in (
-            "tcgen05_acc_pipeline.producer_tail",
-            "tcgen05_tmem_allocator.free",
-        ):
-            cleanup_calls = [
-                node
-                for node in ast.walk(tree)
-                if isinstance(node, ast.Call) and tag in ast.unparse(node.func)
-            ]
-            self.assertTrue(cleanup_calls, f"expected cleanup call {tag}")
-            self.assertTrue(
-                all(node.lineno > last_work_tile_line for node in cleanup_calls),
-                f"{tag} must follow all work-tile loops",
-            )
+                # Role-local codegen emits one work-tile loop per warp role
+                # unless one-shot is admitted. Cleanup must follow the last
+                # loop in the persistent case and remain present in both.
+                tree = ast.parse(code)
+                work_tile_loops = [
+                    node
+                    for node in ast.walk(tree)
+                    if isinstance(node, ast.While)
+                    and (
+                        "tcgen05_role_local_" in ast.unparse(node.test)
+                        or ast.unparse(node.test) == "tcgen05_work_tile_valid"
+                    )
+                ]
+                self.assertEqual(bool(work_tile_loops), num_sm == 0, code)
+                for tag in (
+                    "tcgen05_acc_pipeline.producer_tail",
+                    "tcgen05_tmem_allocator.free",
+                ):
+                    cleanup_calls = [
+                        node
+                        for node in ast.walk(tree)
+                        if isinstance(node, ast.Call) and tag in ast.unparse(node.func)
+                    ]
+                    self.assertTrue(cleanup_calls, f"expected cleanup call {tag}")
+                    if work_tile_loops:
+                        last_work_tile_line = max(
+                            node.end_lineno or node.lineno for node in work_tile_loops
+                        )
+                        self.assertTrue(
+                            all(
+                                node.lineno > last_work_tile_line
+                                for node in cleanup_calls
+                            ),
+                            f"{tag} must follow all work-tile loops",
+                        )
 
     def test_tcgen05_persistent_post_loop_runtime_correctness(self) -> None:
         """The role-local persistent kernel runs after omitting its shared loop."""
@@ -2178,29 +2181,32 @@ class TestCuteLowerings(unittest.TestCase):
             torch.randn(256, 32, device=DEVICE, dtype=torch.float16),
             torch.randn(32, 256, device=DEVICE, dtype=torch.float16),
         )
-        with patch_cute_mma_support():
-            bound = cute_matmul_persistent_compile.bind(args)
-            bound.env.config_spec.cute_tcgen05_search_enabled = True
-            cfg = _make_tcgen05_persistent_config(
-                block_sizes=[128, 128, 16],
-                pid_type="persistent_blocked",
-            )
-            # The act of generating the Python source already runs the
-            # CuTe DSL preprocessor; the IR verifier runs at first
-            # execution (cute.compile). The code-string checks below pin
-            # the persistent host wrapper shape; runtime coverage for both
-            # z-seeded and tile-advance scheduler paths lives in
-            # ``test_tcgen05_persistent_multi_tile_runtime_correctness``.
-            code = bound.to_triton_code(cfg)
-            self.assertIn("while tcgen05_role_local_0_work_tile.is_valid_tile", code)
-            self.assertIn("tcgen05_acc_pipeline.producer_tail", code)
-            from helion._compiler.program_id import Tcgen05PersistentProgramIDs
+        for num_sm in (0, 148):
+            with self.subTest(num_sm=num_sm), patch_cute_mma_support():
+                bound = cute_matmul_persistent_compile.bind(args)
+                bound.env.config_spec.cute_tcgen05_search_enabled = True
+                bound.env.config_spec.num_sm = num_sm
+                cfg = _make_tcgen05_persistent_config(
+                    block_sizes=[128, 128, 16],
+                    pid_type="persistent_blocked",
+                )
+                # The act of generating the Python source already runs the
+                # CuTe DSL preprocessor; the IR verifier runs at first
+                # execution (cute.compile). The code-string checks below pin
+                # the persistent host wrapper shape; runtime coverage for both
+                # z-seeded and tile-advance scheduler paths lives in
+                # ``test_tcgen05_persistent_multi_tile_runtime_correctness``.
+                code = bound.to_triton_code(cfg)
+                role_loop = "while tcgen05_role_local_0_work_tile.is_valid_tile"
+                self.assertEqual(role_loop in code, num_sm == 0, code)
+                self.assertIn("tcgen05_acc_pipeline.producer_tail", code)
+                from helion._compiler.program_id import Tcgen05PersistentProgramIDs
 
-            self.assertNotIn(
-                Tcgen05PersistentProgramIDs._MULTI_TILE_GUARD_TOTAL_VAR,
-                code,
-            )
-            self.assertRegex(code, r"\(\s*1\s*,\s*1\s*,\s*min\s*\(")
+                self.assertNotIn(
+                    Tcgen05PersistentProgramIDs._MULTI_TILE_GUARD_TOTAL_VAR,
+                    code,
+                )
+                self.assertRegex(code, r"\(\s*1\s*,\s*1\s*,\s*min\s*\(")
 
     def test_tcgen05_role_local_monolithic_codegen_markers(self) -> None:
         """The retained role-local monolithic seed emits the required
@@ -4770,16 +4776,26 @@ class TestCuteLowerings(unittest.TestCase):
             torch.randn(128, 32, device=DEVICE, dtype=torch.float16),
             torch.randn(32, 128, device=DEVICE, dtype=torch.float16),
         )
-        with patch_cute_mma_support():
-            bound = cute_matmul_persistent_role.bind(args)
-            bound.env.config_spec.cute_tcgen05_search_enabled = True
-            cfg = _make_tcgen05_persistent_config(
-                block_sizes=[128, 128, 16],
-                pid_type="persistent_blocked",
-            )
-            bound.set_config(cfg)
-            code = bound.to_triton_code(cfg)
-            out = bound(*args)
+        results: dict[int, tuple[str, torch.Tensor]] = {}
+        for num_sm in (0, 148):
+            with self.subTest(num_sm=num_sm), patch_cute_mma_support():
+                bound = cute_matmul_persistent_role.bind(args)
+                bound.env.config_spec.cute_tcgen05_search_enabled = True
+                bound.env.config_spec.num_sm = num_sm
+                cfg = _make_tcgen05_persistent_config(
+                    block_sizes=[128, 128, 16],
+                    pid_type="persistent_blocked",
+                )
+                bound.set_config(cfg)
+                generated_code = bound.to_triton_code(cfg)
+                self.assertEqual(
+                    "while tcgen05_role_local" in generated_code,
+                    num_sm == 0,
+                    generated_code,
+                )
+                results[num_sm] = (generated_code, bound(*args))
+
+        code, out = results[0]
         self.assertIn("'kind': 'tcgen05_d_tma'", code)
         self.assertIn(
             "tcgen05_tma_store_role_tile = tcgen05_tma_store_role_tile + cutlass.Int32(1)",
@@ -4920,6 +4936,9 @@ class TestCuteLowerings(unittest.TestCase):
             "loop. Generated code:\n" + code,
         )
         torch.testing.assert_close(out, args[0] @ args[1], atol=2e-1, rtol=1e-2)
+        torch.testing.assert_close(
+            results[148][1], args[0] @ args[1], atol=2e-1, rtol=1e-2
+        )
 
     def test_tcgen05_flat_static_full_uses_tma_store_epilogue(self) -> None:
         """Static-full flat tcgen05 lowers the first G2 TMA-store epilogue.
@@ -5786,10 +5805,9 @@ class TestCuteLowerings(unittest.TestCase):
             )
             bound.set_config(cfg)
             code = bound.to_triton_code(cfg)
+            self.assertNotIn("while tcgen05_role_local", code)
             self.assertIn(
-                "if True:\n"
-                "                            if _tcgen05_subtile == 0:\n"
-                "                                tcgen05_acc_pipeline.consumer_wait",
+                "tcgen05_acc_pipeline.consumer_wait(tcgen05_acc_consumer_state)",
                 code,
             )
             out = bound(*args)
@@ -9398,10 +9416,7 @@ class TestCuteLowerings(unittest.TestCase):
                 code,
             )
             self.assertIn("StaticPersistentTileScheduler.create", code)
-            self.assertIn(
-                "while tcgen05_role_local_0_work_tile.is_valid_tile",
-                code,
-            )
+            self.assertNotIn("while tcgen05_role_local", code)
             self.assertIn(
                 "tcgen05_ab_pipeline_consumer_group = "
                 "cutlass.pipeline.CooperativeGroup("
@@ -9713,7 +9728,7 @@ class TestCuteLowerings(unittest.TestCase):
                         "cutlass.utils.StaticPersistentTileScheduler.create(",
                         code,
                     )
-                    self.assertIn(
+                    self.assertNotIn(
                         "while tcgen05_role_local_0_work_tile.is_valid_tile",
                         code,
                     )
@@ -9929,41 +9944,41 @@ class TestCuteLowerings(unittest.TestCase):
         )
         from helion._compiler.program_id import Tcgen05PersistentProgramIDs
 
-        with patch_cute_mma_support():
-            bound = cute_matmul_cluster_m2_two_cta_grid.bind(args)
-            bound.env.config_spec.cute_tcgen05_search_enabled = True
-            cfg = _make_tcgen05_persistent_config(
-                block_sizes=[256, 256, 16],
-                l2_groupings=[4],
-                num_sm_multiplier=2,
-                pid_type="persistent_blocked",
-                tcgen05_cluster_m=2,
-            )
-            bound.set_config(cfg)
-            code = bound.to_triton_code(cfg)
-            self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
-            self.assertIn(
-                "tcgen05_role_local_0_tile_sched = "
-                "cutlass.utils.StaticPersistentTileScheduler.create(",
-                code,
-            )
-            self.assertIn("StaticPersistentTileScheduler.create", code)
-            self.assertIn(
-                "while tcgen05_role_local_0_work_tile.is_valid_tile",
-                code,
-            )
-            total_var = Tcgen05PersistentProgramIDs._MULTI_TILE_GUARD_TOTAL_VAR
-            self.assertNotIn(total_var, code)
-            launcher_lines = [
-                line
-                for line in code.splitlines()
-                if "_launcher(" in line and "_helion_cute" in line
-            ]
-            self.assertEqual(len(launcher_lines), 1, code)
-            self.assertRegex(launcher_lines[0], r"_launcher\([^,]+,\s*\(2,\s*1,")
-            self.assertIn("_NUM_SM", launcher_lines[0])
-            self.assertRegex(launcher_lines[0], r"//\s*2")
-            self.assertIn("min(", launcher_lines[0])
+        for num_sm in (0, 148):
+            with self.subTest(num_sm=num_sm), patch_cute_mma_support():
+                bound = cute_matmul_cluster_m2_two_cta_grid.bind(args)
+                bound.env.config_spec.cute_tcgen05_search_enabled = True
+                bound.env.config_spec.num_sm = num_sm
+                cfg = _make_tcgen05_persistent_config(
+                    block_sizes=[256, 256, 16],
+                    l2_groupings=[4],
+                    num_sm_multiplier=2,
+                    pid_type="persistent_blocked",
+                    tcgen05_cluster_m=2,
+                )
+                bound.set_config(cfg)
+                code = bound.to_triton_code(cfg)
+                self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
+                self.assertIn(
+                    "tcgen05_role_local_0_tile_sched = "
+                    "cutlass.utils.StaticPersistentTileScheduler.create(",
+                    code,
+                )
+                self.assertIn("StaticPersistentTileScheduler.create", code)
+                role_loop = "while tcgen05_role_local_0_work_tile.is_valid_tile"
+                self.assertEqual(role_loop in code, num_sm == 0, code)
+                total_var = Tcgen05PersistentProgramIDs._MULTI_TILE_GUARD_TOTAL_VAR
+                self.assertNotIn(total_var, code)
+                launcher_lines = [
+                    line
+                    for line in code.splitlines()
+                    if "_launcher(" in line and "_helion_cute" in line
+                ]
+                self.assertEqual(len(launcher_lines), 1, code)
+                self.assertRegex(launcher_lines[0], r"_launcher\([^,]+,\s*\(2,\s*1,")
+                self.assertIn("_NUM_SM", launcher_lines[0])
+                self.assertRegex(launcher_lines[0], r"//\s*2")
+                self.assertIn("min(", launcher_lines[0])
 
     def test_tcgen05_persistent_cluster_m2_two_cta_grid_z_limit_uses_recycling(
         self,
@@ -10138,10 +10153,15 @@ class TestCuteLowerings(unittest.TestCase):
                         "cutlass.utils.StaticPersistentTileScheduler.create(",
                         code,
                     )
-                    self.assertIn(
-                        "while tcgen05_role_local_0_work_tile.is_valid_tile",
-                        code,
-                    )
+                    # K only changes the inner reduction loop. This 256x256
+                    # output has one logical tile, mapped to one two-CTA
+                    # cluster, so every CTA receives exactly one work tile
+                    # and no role-local scheduler backedge is needed.
+                    if bound.env.config_spec.num_sm >= 2:
+                        self.assertNotIn(
+                            "while tcgen05_role_local_",
+                            code,
+                        )
                     self.assertIn("StaticPersistentTileScheduler.create", code)
                     total_var = Tcgen05PersistentProgramIDs._MULTI_TILE_GUARD_TOTAL_VAR
                     self.assertNotIn(total_var, code)
@@ -18418,6 +18438,47 @@ class TestPersistentLoopSplitter(unittest.TestCase):
         self.assertTrue(
             splitter._tcgen05_shared_loop_has_meaningful_work(observable_partition, [])
         )
+
+    def test_role_local_one_shot_scheduler_omits_tile_loop(self) -> None:
+        from helion._compiler.cute.device_state import CuteTcgen05MatmulPlan
+        from helion._compiler.program_id import Tcgen05PersistentProgramIDs
+
+        stub_df, splitter = self._make_role_local_stubs(num_pid_dims=2)
+        plan = CuteTcgen05MatmulPlan(
+            bm=64,
+            bn=64,
+            bk=128,
+            k_tile_count=16,
+            cluster_m=1,
+            is_two_cta=False,
+            uses_role_local_persistent_body=True,
+            uses_cluster_m2_one_cta_role_local_bridge=False,
+            cta_thread_count=192,
+            physical_m_threads=32,
+            acc_stage_count=2,
+            ab_stage_count=2,
+            c_stage_count=2,
+            epi_warp_count=4,
+            one_shot_role_scheduler=True,
+        )
+        splitter._tcgen05_plan = lambda: plan  # type: ignore[method-assign]
+        role_block = Tcgen05PersistentProgramIDs._PersistentRoleBlock(
+            role_predicate="__test_tma_load_warp__",
+            stmts=[self._stmt("tma_pipeline.producer_acquire(state)")],
+        )
+
+        emitted = splitter._build_role_local_while(
+            stub_df,
+            self._make_minimal_layout(),
+            role_block,
+            scheduler_var_prefix="one_shot_test",
+        )
+        emitted_src = ast.unparse(emitted)
+
+        self.assertFalse(any(isinstance(node, ast.While) for node in ast.walk(emitted)))
+        self.assertIn("producer_acquire(state)", emitted_src)
+        self.assertNotIn("advance_to_next_work", emitted_src)
+        self.assertNotIn("get_current_work", emitted_src)
 
     def _make_role_local_stubs(self, *, num_pid_dims: int = 2) -> tuple[object, object]:
         """Build a richer device-function stub plus per-pid stubs that

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -451,8 +451,8 @@ class TestPretunedKernelsCorrectness(TestCase):
 @onlyBackends(["cute"])
 @skipIfRefEager("Pretuned kernels use AOT; ref-eager bypasses heuristic logic.")
 class TestPretunedCuteCodegen(TestCase):
-    def test_scale_mm_64x5120x5120_omits_shared_loop(self) -> None:
-        """The tuned FP8 persistent kernel has only role-local tile loops."""
+    def test_scale_mm_one_shot_uses_target_sm_count(self) -> None:
+        """One-shot codegen follows the compile target's actual SM count."""
 
         module = _import_pretuned_kernel_module("scale_mm_cute")
         m, k, n = 64, 5120, 5120
@@ -479,10 +479,28 @@ class TestPretunedCuteCodegen(TestCase):
         with patch_cute_mma_support():
             bound = module.scale_mm_cute.bind(args)
             bound.env.config_spec.cute_tcgen05_search_enabled = True
-            code = bound.to_triton_code(config)
+            bound.env.config_spec.num_sm = 80
+            one_shot_code = bound.to_triton_code(config)
+            bound.env.config_spec.num_sm = 79
+            persistent_code = bound.to_triton_code(config)
+            bound.env.config_spec.num_sm = 80
+            swizzled_config_values = dict(config)
+            swizzled_config_values["tcgen05_l2_swizzle_size"] = 8
+            swizzled_code = bound.to_triton_code(
+                helion.Config(**swizzled_config_values)
+            )
 
-        self.assertIn("while tcgen05_role_local_0_work_tile.is_valid_tile", code)
-        self.assertNotIn("while tcgen05_work_tile_valid", code)
+        self.assertNotIn(
+            "while tcgen05_role_local_0_work_tile.is_valid_tile", one_shot_code
+        )
+        self.assertIn(
+            "while tcgen05_role_local_0_work_tile.is_valid_tile", persistent_code
+        )
+        self.assertIn(
+            "while tcgen05_role_local_0_work_tile.is_valid_tile", swizzled_code
+        )
+        self.assertNotIn("while tcgen05_work_tile_valid", one_shot_code)
+        self.assertNotIn("while tcgen05_work_tile_valid", persistent_code)
 
 
 @onlyBackends(["triton"])


### PR DESCRIPTION
Stacked PRs:
 * #3302
 * __->__#3296


--- --- ---

### [cute] Automatically use one-shot role schedulers


Detect static-full, unbatched persistent role-local tcgen05 kernels whose complete clustered work grid fits on the compile target's available SMs. Carry that decision in the matmul plan and emit each role body once, omitting the redundant role-local while backedge, scheduler advance, and work-tile refresh.

Keep the normal persistent scheduler for partial clusters, grouped schedules, dedicated scheduler-warps, leading-dimension passthrough, grids larger than the target SM count, and L2-swizzled layouts whose scheduler padding still requires validity checks. The SM limit comes from the target ConfigSpec rather than a B200-specific constant.

Add focused AST coverage for straight-line role emission and end-to-end codegen coverage for the SM-count and L2-swizzle admission boundaries.

On B200, repeated cold-L2 A/B medians improved the clearest short-K shapes: 512x2048x2048 from 6.79 to 6.50 us (-4.3%), 64x2048x4096 from 6.33 to 6.26 us (-1.1%), and 64x4096x4096 from 8.23 to 8.03 us (-2.4%). The full automatic scale_mm_cute sweep measured 1.243x geomean speedup versus torch.
