### PR TITLE
[autotuner] tune the pointwise seed heuristic for sm100

### DIFF
--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from ...autotuner.config_spec import BlockSizeSpec
     from ...autotuner.config_spec import ConfigSpec
     from ...autotuner.config_spec import MatmulFact
+    from ...autotuner.config_spec import PointwiseElementwiseFact
     from ...autotuner.config_spec import ReductionDescriptor
     from ...autotuner.config_spec import ReductionKernelFact
     from ..compile_environment import CompileEnvironment
@@ -991,8 +992,15 @@ class TritonPointwiseSeedHeuristic(AutotunerHeuristic):
     promote_seed_to_default = True
     PROMOTE_TARGETS = (("cuda", "sm90"), ("cuda", "sm100"))
 
+    # Arches whose pointwise constants have been measured. An allow-list, not a
+    # ``>= sm100`` compare: an unmeasured arch (including a same-generation consumer
+    # part with a different SM count / bandwidth) keeps the conservative sm90 path.
+    TUNED_TARGETS: ClassVar[tuple[HardwareTarget, ...]] = (("cuda", "sm100"),)
+
     # Hill-climbed constants (see _lab/pointwise/NOTEBOOK.md).
     TILE_BYTES = 8192  # target HBM bytes moved per tile
+    # Higher per-SM bandwidth needs more bytes in flight per program to saturate it.
+    TILE_BYTES_SM100 = 16384
     MIN_WAVES = 8  # grid >= num_sm * MIN_WAVES (size_hint-aware grid floor)
     BLOCK_FLOOR = 256  # never regress toward the bs=32 default
     # Per-program register/working-set ceiling (fp32-compute bytes) before spill / block-numel
@@ -1007,6 +1015,50 @@ class TritonPointwiseSeedHeuristic(AutotunerHeuristic):
     ELEMS_PER_WARP = (
         64  # each warp needs at least this many tile elements to be worth spawning
     )
+    # Tile elements per thread at the optimum, as a ladder over the gather stride: a
+    # stride-k gather discards part of every 32B sector, so the same useful bytes need
+    # more requests in flight and the per-thread element count falls. Bands (16/4/2)
+    # rather than a ``16 // stride`` formula because they measure better -- stride 2
+    # wants 4, not 8, and the falloff flattens past stride 4. Tile elements, not
+    # elements-times-slab: the optimum does not scale with the untiled slab.
+    ELEMS_PER_THREAD_BY_STRIDE = ((1, 16), (4, 4))
+    ELEMS_PER_THREAD_WIDE_GATHER = 2
+    # Warp slots per SM (threads/SM / 32), the hardware residency limit. A CTA asking
+    # ``nw`` warps leaves room for ``slots // nw`` CTAs per SM, so the grid stays within
+    # one resident wave iff ``programs <= num_sm * (slots // nw)``: warps are free until
+    # they cost a second wave. Inert on a saturated grid (the largest fitting nw is 1).
+    # Overridden by the device's own limit where available.
+    WARP_SLOTS_PER_SM = 64
+    # Target a fraction just under a full wave -- the last warp doubling before the
+    # boundary costs more per-CTA parallelism than it buys in latency hiding.
+    WAVE_TARGET_NUMERATOR = 3
+    WAVE_TARGET_DENOMINATOR = 4
+    # Grid floor for occ_cap. Looser than sm90's: with ~2x the SMs the same wave count
+    # is twice the programs, and the tighter value only bound cells that BLOCK_FLOOR
+    # then clamped straight back, so it never adapted the tile.
+    MIN_WAVES_SM100 = 4
+
+    @classmethod
+    def tile_bytes_for(cls, env: CompileEnvironment) -> int:
+        """The per-program HBM byte budget for this device.
+
+        Arch-keyed rather than one promoted-everywhere constant: the sm90 value was
+        hill-climbed on H100 and B200 wants a larger tile (see ``TILE_BYTES_SM100``).
+        """
+        return (
+            cls.TILE_BYTES_SM100
+            if matches_hardware(env, cls.TUNED_TARGETS)
+            else cls.TILE_BYTES
+        )
+
+    @classmethod
+    def min_waves_for(cls, env: CompileEnvironment) -> int:
+        """The occupancy-cap wave count for this device (see ``MIN_WAVES_SM100``)."""
+        return (
+            cls.MIN_WAVES_SM100
+            if matches_hardware(env, cls.TUNED_TARGETS)
+            else cls.MIN_WAVES
+        )
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
@@ -1019,16 +1071,25 @@ class TritonPointwiseSeedHeuristic(AutotunerHeuristic):
         spec = env.config_spec
         fact = spec.pointwise_facts[0]
         num_sm = max(1, get_num_sm(env.device))
+        tuned_arch = matches_hardware(env, cls.TUNED_TARGETS)
         # slab_numel (untiled inner slab per tiled element) scaled by two widths into two caps:
         # budget_target = tiled elements per bandwidth-saturating program (STORAGE bytes); reg_cap =
         # how many fit before the fp32 working set spills (COMPUTE bytes; coarse proxy — see the fact).
         # A heavy rope slab makes both ~1, so it is not tiled past ~1 (vs the old spilling [1,256]).
         slab_bytes = max(1, fact.slab_numel * fact.storage_itemsize)
         reg_bytes = max(1, fact.slab_numel * fact.compute_itemsize)
-        budget_target = max(1, cls.TILE_BYTES // slab_bytes)
+        # Charge bytes FETCHED from HBM, not bytes the kernel finds useful: a stride-k
+        # gather pulls k 32B sectors per useful sector, so a W-element tile costs
+        # k*W*slab_bytes of real traffic. Charging useful bytes over-sizes a strided
+        # tile by k, and makes two kernels with the same fact but different gather
+        # strides get the same width when their optima differ by exactly that factor.
+        fetch_bytes = (
+            slab_bytes * max(1, fact.gather_stride) if tuned_arch else slab_bytes
+        )
+        budget_target = max(1, cls.tile_bytes_for(env) // fetch_bytes)
         reg_cap = max(1, cls.REGISTER_BYTES // reg_bytes)
         # size_hint-aware: cap the tile so the grid keeps the SMs busy on small problems.
-        occ_cap = max(1, fact.total_numel // (num_sm * cls.MIN_WAVES))
+        occ_cap = max(1, fact.total_numel // (num_sm * cls.min_waves_for(env)))
         target = max(1, min(budget_target, reg_cap, occ_cap))
         # Anti-undershoot floor, capped by the REGISTER budget only (NOT budget_target, NOT occ_cap):
         # keep a coalesced per-operand run, lowering it only on a genuine register overflow (a heavy
@@ -1044,13 +1105,87 @@ class TritonPointwiseSeedHeuristic(AutotunerHeuristic):
         tile_numel = 1
         for b in block_sizes:
             tile_numel *= b
-        # num_warps only when the SFU ramp raises it above the default; else None (Config drops None
-        # keys), so the flat family stays block_sizes-only and byte-identical (no dead knob).
-        num_warps = cls._warps_for(fact.sfu_ops, tile_numel)
+        # num_warps: lanes + residency on a tuned arch, else the SFU ramp. Emitted only
+        # when it differs from the compiler default, so a shape landing on the default
+        # stays block_sizes-only (no dead knob).
+        if tuned_arch:
+            num_warps = cls._warps_for_sm100(
+                fact, tile_numel, num_sm, cls.warp_slots_per_sm(env)
+            )
+        else:
+            num_warps = cls._warps_for(fact.sfu_ops, tile_numel)
         return Config(
             block_sizes=block_sizes,
-            num_warps=num_warps if num_warps > cls.DEFAULT_WARPS else None,
+            num_warps=num_warps if num_warps != cls.DEFAULT_WARPS else None,
         )
+
+    @classmethod
+    def warp_slots_per_sm(cls, env: CompileEnvironment) -> int:
+        """Resident warp slots per SM, queried from the device where available."""
+        props = getattr(torch.cuda, "get_device_properties", None)
+        if props is not None and env.device.type == "cuda":
+            threads = getattr(props(env.device), "max_threads_per_multi_processor", 0)
+            if threads:
+                return max(1, threads // 32)
+        return cls.WARP_SLOTS_PER_SM
+
+    @classmethod
+    def _elems_per_thread(cls, gather_stride: int) -> int:
+        """Tile elements per thread at the optimum, by gather stride (banded, not a
+        formula -- see ``ELEMS_PER_THREAD_BY_STRIDE``). Unknown stride reads coalesced."""
+        stride = max(1, gather_stride)
+        for limit, elems in cls.ELEMS_PER_THREAD_BY_STRIDE:
+            if stride <= limit:
+                return elems
+        return cls.ELEMS_PER_THREAD_WIDE_GATHER
+
+    @classmethod
+    def _warps_for_sm100(
+        cls,
+        fact: PointwiseElementwiseFact,
+        tile_numel: int,
+        num_sm: int,
+        warp_slots: int,
+    ) -> int:
+        """num_warps from tile lanes and grid residency.
+
+        ``sfu_ops`` alone is the wrong signal for bandwidth-bound work -- a 1-op
+        activation sits below ``SFU_W8``, so every such kernel fell to the default warp
+        count regardless of tile size. Two terms replace it, combined with ``max``
+        because both answer "how many warps does this program want":
+
+        * lanes the tile can keep busy, ``tile_numel / (32 * elems_per_thread)``;
+        * the largest warp count whose CTAs still fit resident at once (see
+          ``WARP_SLOTS_PER_SM``) -- warps are free until they cost a second wave. Inert
+          on a saturated grid, so it speaks only where warps are still free.
+
+        This is not the usual occupancy lever, which shrinks the TILE for more CTAs;
+        that is ``occ_cap`` in ``get_seed_config``, and shrinking the tile instead
+        measured worse on every cell tried. The SFU ramp is kept as a floor, since
+        transcendental latency is independent of byte traffic.
+        """
+        per_thread = cls._elems_per_thread(fact.gather_stride)
+        work = cls._pow2_floor(max(1, tile_numel // (32 * per_thread)))
+        programs = max(1, fact.total_numel // max(1, tile_numel))
+        wave_slots = (
+            warp_slots * cls.WAVE_TARGET_NUMERATOR // cls.WAVE_TARGET_DENOMINATOR
+        )
+        resident_wave = cls._pow2_floor(max(1, (num_sm * wave_slots) // programs))
+        target = max(work, resident_wave)
+        # The SFU ramp as a floor (never lowers the ladder's answer).
+        if fact.sfu_ops >= cls.SFU_W16:
+            target = max(target, cls.MAX_WARPS)
+        elif fact.sfu_ops >= cls.SFU_W8:
+            target = max(target, 8)
+        # Starvation cap: warps with too few elements hurt, so a program cannot use more
+        # warps than its WIDEST SINGLE load/store gives it lanes for. That uses the MAX
+        # per-op fan-out, not the ``slab_numel`` SUM the byte budgets use -- lanes do not
+        # add across ops, since a CTA's separate vector instructions run over the same
+        # threads. It also keeps a partially tiled kernel honest, where a size-1 tile
+        # still materializes a wide untiled load.
+        lanes = tile_numel * max(1, fact.max_op_slab_numel)
+        cap = cls._pow2_floor(max(1, lanes // cls.ELEMS_PER_WARP))
+        return max(1, min(cls.MAX_WARPS, target, cap))
 
     @classmethod
     def _warps_for(cls, sfu_ops: int, tile_numel: int) -> int:

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -54,6 +54,7 @@ from .ast_extension import expr_from_string
 from .ast_read_writes import ReadWrites
 from .compile_environment import CompileEnvironment
 from .host_function import HostFunction
+from .indexing_strategy import subscript_index_scale
 from .indexing_strategy import subscript_tile_info
 from .inductor_lowering import APIFuncLowering
 from .inductor_lowering import CodegenState
@@ -1505,6 +1506,7 @@ class DeviceIR:
         spec = env.config_spec
         from ..autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
         from ..autotuner.config_spec import PointwiseElementwiseFact
+        from ..language import memory_ops
         from ..language.atomic_ops import ATOMIC_OPS
         from ..language.inline_asm_ops import inline_asm_elementwise
         from ..language.inline_triton_ops import inline_triton
@@ -1565,6 +1567,52 @@ class DeviceIR:
                 return [s for v in val for s in _val_itemsizes(v)]
             return []
 
+        # The node set ``compute_itemsize`` may measure: DATA, excluding ADDRESSES.
+        #
+        # A load/store's index arguments are tensor-valued too, and index arithmetic is
+        # int64 once a tensor crosses the int32 indexing threshold -- so a plain bf16
+        # kernel reported width 8 purely because its tensors got large, halving ``reg_cap``
+        # on exactly the shapes that least want a smaller tile. The split is data vs
+        # address, NOT float vs integer: filtering to floats would leave a genuine
+        # int-compute kernel at the ``1`` initializer, over-estimating ``reg_cap`` instead.
+        # No cheaper proxy works -- a tile index is both a legal address and legal data, so
+        # dtype, node metadata and lowering class all fail to separate them.
+        #
+        # Walk BACKWARD from each store's value / mask, CUTTING at load nodes: a load is
+        # itself data, but its own index arithmetic is reachable backward through it. The
+        # cut also excludes a gather's loaded index, so this under-counts that case's true
+        # register pressure. One reverse-order pass suffices since FX order is topological.
+        #
+        # If nothing tensor-valued is reachable (a store of a bare scalar, or no store),
+        # fall back to the accessed buffer dtypes rather than the ``1`` initializer -- and
+        # only then, so a successful walk is never widened.
+        def _data_path_nodes() -> tuple[set[int], int]:
+            data: set[int] = set()
+            buffer_width = 1
+            for graph_info in self.graphs:
+                for node in reversed(list(graph_info.graph.nodes)):
+                    if node.op != "call_function":
+                        continue
+                    is_load = node.target is memory_ops.load
+                    if is_load or node.target is memory_ops.store:
+                        # Seed the data side: a store's value (arg 2) and either op's
+                        # extra_mask (store arg 3 / load arg 2).
+                        for pos in (2, 3) if not is_load else (2,):
+                            if len(node.args) > pos and isinstance(
+                                node.args[pos], torch.fx.Node
+                            ):
+                                data.add(id(node.args[pos]))
+                        accessed = _accessed_tensor_fake(node)
+                        if accessed is not None:
+                            buffer_width = max(buffer_width, accessed.dtype.itemsize)
+                        if is_load:
+                            continue  # CUT: args[1] is the ADDRESS, never an input
+                    if id(node) in data:
+                        data.update(id(arg) for arg in node.all_input_nodes)
+            return data, buffer_width
+
+        data_path_nodes, data_path_buffer_width = _data_path_nodes()
+
         # SFU (transcendental) op count — the num_warps signal, counted in the same graph walk. SFU
         # ops run on a distinct, low-throughput unit (~4 SFUs vs ~128 FP32 lanes/SM), so a
         # transcendental-heavy tile is latency-bound and wants more warps; an all-FMA tile of the same
@@ -1603,8 +1651,10 @@ class DeviceIR:
         sfu_ops = 0
         for graph_info in self.graphs:
             for node in graph_info.graph.nodes:
-                for size in _val_itemsizes(node.meta.get("val")):
-                    compute_itemsize = max(compute_itemsize, size)
+                # Data path only -- see ``_data_path_nodes``.
+                if id(node) in data_path_nodes:
+                    for size in _val_itemsizes(node.meta.get("val")):
+                        compute_itemsize = max(compute_itemsize, size)
                 if node.op == "call_function":
                     if node.target in _unsafe_pointwise_ops:
                         # Not tile-independent (see the set's comment above). Record no fact so the
@@ -1617,6 +1667,9 @@ class DeviceIR:
                     )[0]
                     if base in _SFU_OPS:
                         sfu_ops += 1
+        # Nothing tensor-valued reachable -> the buffer widths, never the 1 initializer.
+        if compute_itemsize == 1:
+            compute_itemsize = max(1, data_path_buffer_width)
 
         # slab_numel = sum over FULL-EXTENT load/store ops (accessed_numel >= total_numel) of the
         # untiled elements each drags per tiled element, accessed_numel // total_numel. Flat kernel:
@@ -1630,17 +1683,50 @@ class DeviceIR:
         tiled_ids = {bs.block_id for bs in spec.block_sizes}
         contig: set[int] = set()
         slab_numel = 0
+        max_op_slab_numel = 1
         storage_itemsize = 1
+        gather_stride = 1
         for memfact in spec.memory_op_facts:
             if memfact.dtype is None or memfact.accessed_numel < total_numel:
                 continue
             slab_numel += memfact.accessed_numel // total_numel
+            # The widest tile any ONE op materializes, per tiled element -- the same per-op
+            # quantity ``slab_numel`` sums, kept as a MAX because bytes add across ops but
+            # lanes do not (see ``PointwiseElementwiseFact``).
+            #
+            # Computed from the SUBSCRIPTS, not ``accessed_numel // total_numel``: that is a
+            # per-tensor ratio, so it also counts an op whose tensor is merely wider than
+            # the problem, overstating lanes. Product of extents at positions that are not
+            # a tiled axis; a tiled position contributes its block size, which the consumer
+            # supplies by scaling. Keyed on ``subscript_affine_block_ids`` so a scaled
+            # subscript counts as tiled rather than as fan-out.
+            op_slab = 1
+            for bid, extent in zip(
+                memfact.subscript_affine_block_ids,
+                memfact.subscript_extents,
+                strict=True,
+            ):
+                if bid is None or bid not in tiled_ids:
+                    op_slab *= max(1, extent)
+            max_op_slab_numel = max(max_op_slab_numel, op_slab)
             storage_itemsize = max(storage_itemsize, memfact.dtype.itemsize)
             for bid, stride in zip(
                 memfact.subscript_block_ids, memfact.subscript_strides, strict=True
             ):
                 if bid is not None and stride == 1 and bid in tiled_ids:
                     contig.add(bid)
+            # Widest address-expression scale on a tiled axis whose LAYOUT stride is 1 --
+            # gated there because that is where the sector-waste argument holds; a
+            # layout-strided fetch is already non-contiguous for other reasons. Keyed on
+            # ``subscript_affine_block_ids``, which resolves the axis through the scale.
+            for bid, scale, stride in zip(
+                memfact.subscript_affine_block_ids,
+                memfact.subscript_index_scales,
+                memfact.subscript_strides,
+                strict=True,
+            ):
+                if bid is not None and bid in tiled_ids and stride == 1:
+                    gather_stride = max(gather_stride, scale)
         spec.pointwise_facts.append(
             PointwiseElementwiseFact(
                 total_numel=total_numel,
@@ -1649,6 +1735,8 @@ class DeviceIR:
                 compute_itemsize=compute_itemsize,
                 contig_block_ids=tuple(sorted(contig)),
                 sfu_ops=sfu_ops,
+                gather_stride=gather_stride,
+                max_op_slab_numel=max_op_slab_numel,
             )
         )
 
@@ -3324,6 +3412,9 @@ def _collect_memory_op_facts(
             indexed_block_ids: tuple[int | None, ...] = ()
             subscript_block_ids: tuple[int | None, ...] = ()
             subscript_strides: tuple[int, ...] = ()
+            subscript_index_scales: tuple[int, ...] = ()
+            subscript_affine_block_ids: tuple[int | None, ...] = ()
+            subscript_extents: tuple[int, ...] = ()
             inner_extent: int | None = None
             accessed_numel = 0
             if fake is not None:
@@ -3363,6 +3454,18 @@ def _collect_memory_op_facts(
                     subscript_strides = tuple(
                         env.size_hint(fake_strides[pos]) for pos in positions
                     )
+                    # Gather stride + affine-resolved axis, same ``positions`` so all the
+                    # tuples align. See ``MemoryOpFact.subscript_index_scales``.
+                    affine = [
+                        subscript_index_scale(env, index_list[pos]) for pos in positions
+                    ]
+                    subscript_affine_block_ids = tuple(bid for bid, _ in affine)
+                    subscript_index_scales = tuple(scale for _, scale in affine)
+                    # Extent per subscript position; size_hint, not int(), so a SymInt dim
+                    # is not specialized.
+                    subscript_extents = tuple(
+                        env.size_hint(fake.shape[pos]) for pos in positions
+                    )
                 if fake.ndim >= 2:
                     # size_hint (not int()): int() would guard a SymInt inner dim to a
                     # constant, over-specializing dynamic-shape kernels. inner_extent is a
@@ -3388,6 +3491,9 @@ def _collect_memory_op_facts(
                         inner_extent=inner_extent,
                         subscript_block_ids=subscript_block_ids,
                         subscript_strides=subscript_strides,
+                        subscript_index_scales=subscript_index_scales,
+                        subscript_affine_block_ids=subscript_affine_block_ids,
+                        subscript_extents=subscript_extents,
                         accessed_numel=accessed_numel,
                     ),
                 )

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -77,6 +77,73 @@ def subscript_tile_info(
     return TileWithOffsetInfo(block_id, 0)
 
 
+def subscript_index_scale(
+    env: CompileEnvironment, subscript: object
+) -> tuple[int | None, int]:
+    """``(block_id, index_scale)`` for one load/store subscript position.
+
+    ``index_scale`` is the tile-index multiplier in the ADDRESS expression
+    (``x[tile]`` -> 1, ``x[2 * tile.index]`` -> 2): the GATHER stride, distinct from
+    the accessed tensor's ``.stride()`` (a layout property, already recorded as
+    ``MemoryOpFact.subscript_strides``). A stride-k gather touches k sectors per
+    useful sector, which no layout stride can express.
+
+    The block-id is returned alongside because a scaled subscript loses its tile
+    provenance: ``subscript_tile_info`` reads ``meta["tile_with_offset"]``, set for
+    ``tile_index + const`` but not ``tile_index * const``. Walking the affine chain
+    here recovers both. Non-affine forms return ``(None, 1)`` -- assume coalesced
+    rather than guess a penalty.
+    """
+    info = subscript_tile_info(env, subscript)
+    if info is not None:
+        return info.block_id, 1
+    if not isinstance(subscript, torch.fx.Node):
+        return None, 1
+    scale = 1
+    node: torch.fx.Node = subscript
+    # Bounded walk down an affine chain; the idiomatic form is 1-2 links deep.
+    for _ in range(8):
+        target = node.target
+        args = node.args
+        if target is torch.ops.aten.mul.Tensor and len(args) == 2:
+            factor = args[1]
+            operand = args[0]
+            if not isinstance(factor, int):
+                # x * tile form: the int may be on either side.
+                factor, operand = operand, factor
+            if (
+                isinstance(factor, int)
+                and factor >= 1
+                and isinstance(operand, torch.fx.Node)
+            ):
+                scale *= factor
+                node = operand
+                continue
+            return None, 1
+        if target is torch.ops.aten.add.Tensor and len(args) == 2:
+            offset, operand = args[1], args[0]
+            if not isinstance(offset, int):
+                offset, operand = operand, offset
+            if isinstance(offset, int) and isinstance(operand, torch.fx.Node):
+                node = operand
+                continue
+            return None, 1
+        # Reached the base of the chain: either a tile-provenance node or a
+        # ``tile_index`` HOP whose own argument carries the provenance.
+        base = subscript_tile_info(env, node)
+        if base is not None:
+            return base.block_id, scale
+        inner = args[0] if args else None
+        if isinstance(inner, torch.fx.Node):
+            base = subscript_tile_info(env, inner)
+            if base is not None:
+                return base.block_id, scale
+            node = inner
+            continue
+        return None, 1
+    return None, 1
+
+
 def exact_tile_block_ids(
     env: CompileEnvironment, subscripts: Sequence[object]
 ) -> tuple[int, ...] | None:

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -283,6 +283,23 @@ class MemoryOpFact(NamedTuple):
     # ``subscript_block_ids`` (from ``.stride()``). A stride-1 position is the contiguous (coalescing)
     # axis — the last subscript for a row-major tensor, a different one for a transposed/strided view.
     subscript_strides: tuple[int, ...] = ()
+    # GATHER stride per subscript position: the multiplier on the tile index in the op's
+    # ADDRESS expression (``x[tile]`` → 1, ``x[2*tile.index]`` → 2). Independent of
+    # ``subscript_strides``, the accessed tensor's LAYOUT stride -- two ops can index the
+    # same row-major tensor while one reads it stride-2 and the other stride-1. A stride-k
+    # gather wastes ``1 - 1/k`` of every 32B sector, so this is the coalescing signal;
+    # 1 means coalesced or unknown. See ``indexing_strategy.subscript_index_scale``.
+    subscript_index_scales: tuple[int, ...] = ()
+    # Size-hinted extent at each subscript position. With ``subscript_affine_block_ids``
+    # this gives the tile ONE op materializes: the product of extents at non-tiled
+    # positions (a tiled position contributes its block size). Distinct from
+    # ``accessed_numel``, a per-TENSOR count that also grows for an oversized tensor.
+    subscript_extents: tuple[int, ...] = ()
+    # Block-ids resolved THROUGH an affine (scaled/offset) subscript.
+    # ``subscript_block_ids`` reads ``meta["tile_with_offset"]``, which the lowering sets
+    # for ``tile_index + const`` but not ``tile_index * const``, so a scaled subscript
+    # loses its axis there. Separate field so existing consumers are unaffected.
+    subscript_affine_block_ids: tuple[int | None, ...] = ()
     # DISTINCT HBM elements the op's accessed tensor touches: product of its size-hinted shape dims
     # over NON-broadcast dims (``stride != 0``); a stride-0 dim contributes factor 1 (``0`` if no
     # resolvable fake tensor). A FULL-EXTENT op has ``accessed_numel`` == the problem numel; a
@@ -332,6 +349,16 @@ class PointwiseElementwiseFact(NamedTuple):
     - ``sfu_ops``: count of transcendental (SFU) ops. SFU ops are latency-bound on a distinct unit, so
       a transcendental-heavy tile wants more warps while an all-FMA tile of the same op count does not
       — so SFU count (not total op count) drives the num_warps ramp.
+    - ``gather_stride``: the widest GATHER stride any full-extent op applies to a tiled axis in
+      its ADDRESS expression (``x[tile]`` → 1, ``x[2*tile.index]`` → 2). A stride-k gather
+      touches k 32B sectors per useful sector, so the same useful bytes cost ~k× the requests —
+      the coalescing input to the byte budget and the num_warps ramp. NOT the layout stride,
+      which cannot distinguish two ops indexing one row-major tensor at different strides.
+      1 means coalesced, or an address form the walk does not recognize.
+    - ``max_op_slab_numel``: the LARGEST single op's untiled fan-out, vs ``slab_numel``'s SUM
+      of the same quantity. Bytes ADD across ops (so the sum sizes the byte/register budgets)
+      but LANES do not (separate vector instructions over the same threads), so the max is what
+      bounds a num_warps starvation cap.
     """
 
     total_numel: int
@@ -340,6 +367,8 @@ class PointwiseElementwiseFact(NamedTuple):
     compute_itemsize: int
     contig_block_ids: tuple[int, ...] = ()
     sfu_ops: int = 0
+    gather_stride: int = 1
+    max_op_slab_numel: int = 1
 
 
 def shrink_block_sizes_for_numel_constraints(

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1087,6 +1087,265 @@ class TestRopePointwiseSeed(TestCase):
         self.assertGreater(math.prod(ew_seed.config["block_sizes"]), 8)
 
 
+class TestPointwiseComputeItemsize(TestCase):
+    """``compute_itemsize`` measures DATA width, not index width.
+
+    The fact walks only what reaches a load/store's data path, so int64 address
+    arithmetic does not inflate it. The split is data-vs-address, not
+    float-vs-integer -- both directions are asserted here.
+    """
+
+    @staticmethod
+    def _fact(kernel: object, args: tuple[object, ...]) -> object:
+        bound = kernel.bind(args)  # pyrefly: ignore [missing-attribute]
+        facts = bound.config_spec.pointwise_facts
+        assert len(facts) == 1, facts
+        return facts[0]
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler pointwise facts are not collected in ref eager mode")
+    def test_int64_indexing_does_not_inflate_compute_itemsize(self) -> None:
+        # int64-INDEXED but half-precision DATA (promoting to fp32 -> 4).
+        # The SCALED subscript is load-bearing: a plain ``x[tile]`` lowers to a
+        # ``_get_symnode`` with no tensor val, so no int64 node exists and the test
+        # would pass even with the fix reverted.
+        @helion.kernel(backend="triton", index_dtype=torch.int64, static_shapes=False)
+        def add_int64_index(x: torch.Tensor) -> torch.Tensor:
+            m, n2 = x.shape
+            n2 = hl.specialize(n2)
+            n = n2 // 2
+            out = x.new_empty(m, n)
+            for tile_m, tile_n in hl.tile([m, n]):
+                a = x[tile_m, 2 * tile_n.index].to(torch.float32)
+                b = x[tile_m, 2 * tile_n.index + 1].to(torch.float32)
+                out[tile_m, tile_n] = (a * b).to(out.dtype)
+            return out
+
+        x = torch.randn(256, 512, device=DEVICE, dtype=HALF_DTYPE)
+        bound = add_int64_index.bind((x,))
+        self.assertEqual(bound.env.index_dtype, torch.int64)
+        # Guard the guard: an int64 tensor is actually present to be picked up.
+        self.assertTrue(
+            any(
+                isinstance(node.meta.get("val"), torch.Tensor)
+                and node.meta["val"].dtype == torch.int64
+                for graph_info in bound.host_function.device_ir.graphs
+                for node in graph_info.graph.nodes
+            )
+        )
+        facts = bound.config_spec.pointwise_facts
+        self.assertEqual(len(facts), 1)
+        fact = facts[0]
+        self.assertEqual(fact.storage_itemsize, 2)
+        # 4 = the fp32 compute promotion, not 8 = the int64 index arithmetic.
+        self.assertEqual(fact.compute_itemsize, 4)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler pointwise facts are not collected in ref eager mode")
+    def test_integer_compute_kernel_reports_its_data_width(self) -> None:
+        # Guards against filtering to float dtypes: this DATA is genuinely int64, so
+        # 8 is correct and a float-only walk would report 1 and emit a spilling tile.
+        @helion.kernel(backend="triton")
+        def add_int64_data(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        x = torch.ones(256, 256, device=DEVICE, dtype=torch.int64)
+        y = torch.ones(256, 256, device=DEVICE, dtype=torch.int64)
+        fact = self._fact(add_int64_data, (x, y))
+        self.assertEqual(fact.storage_itemsize, 8)
+        self.assertEqual(fact.compute_itemsize, 8)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler pointwise facts are not collected in ref eager mode")
+    def test_gather_index_tensor_does_not_inflate_compute_itemsize(self) -> None:
+        # A gather whose index was itself loaded as int64: the cut at loads means the
+        # walk never reaches it, so the data width stays half-precision.
+        @helion.kernel(backend="triton")
+        def gather_rows(x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile(x.size()):
+                out[tile_m, tile_n] = x[idx[tile_m], tile_n]
+            return out
+
+        x = torch.randn(256, 256, device=DEVICE, dtype=HALF_DTYPE)
+        idx = torch.zeros(256, device=DEVICE, dtype=torch.int64)
+        fact = self._fact(gather_rows, (x, idx))
+        self.assertEqual(fact.compute_itemsize, 2)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler pointwise facts are not collected in ref eager mode")
+    def test_intermediate_wider_than_every_buffer_is_counted(self) -> None:
+        # Why the walk cannot just read buffer dtypes: every buffer is half-precision
+        # but an fp64 intermediate is register-resident, and under-reporting it
+        # over-estimates ``reg_cap``. ``storage_itemsize`` already covers buffers.
+        @helion.kernel(backend="triton")
+        def fp64_intermediate(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                a = x[tile].to(torch.float64)
+                b = y[tile].to(torch.float64)
+                out[tile] = (a * b + a).to(out.dtype)
+            return out
+
+        x = torch.randn(256, 256, device=DEVICE, dtype=HALF_DTYPE)
+        y = torch.randn(256, 256, device=DEVICE, dtype=HALF_DTYPE)
+        fact = self._fact(fp64_intermediate, (x, y))
+        self.assertEqual(fact.storage_itemsize, 2)
+        self.assertEqual(fact.compute_itemsize, 8)
+
+
+class TestPointwiseGatherStride(TestCase):
+    """``gather_stride`` is the address-expression scale, not the layout stride.
+
+    Two kernels can index one row-major tensor -- identical layout strides -- while
+    reading it at different gather strides, and their optimal tiles then differ.
+    """
+
+    @staticmethod
+    def _fact(kernel: object, args: tuple[object, ...]) -> object:
+        bound = kernel.bind(args)  # pyrefly: ignore [missing-attribute]
+        facts = bound.config_spec.pointwise_facts
+        assert len(facts) == 1, facts
+        return facts[0]
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler pointwise facts are not collected in ref eager mode")
+    def test_interleaved_and_contiguous_halves_differ(self) -> None:
+        @helion.kernel(backend="triton", static_shapes=False)
+        def interleaved(x: torch.Tensor) -> torch.Tensor:
+            m, n2 = x.shape
+            n2 = hl.specialize(n2)
+            n = n2 // 2
+            out = x.new_empty(m, n)
+            for tile_m, tile_n in hl.tile([m, n]):
+                a = x[tile_m, 2 * tile_n.index]
+                b = x[tile_m, 2 * tile_n.index + 1]
+                out[tile_m, tile_n] = a * b
+            return out
+
+        @helion.kernel(backend="triton", static_shapes=False)
+        def halves(x: torch.Tensor) -> torch.Tensor:
+            m, n2 = x.shape
+            n2 = hl.specialize(n2)
+            n = n2 // 2
+            out = x.new_empty(m, n)
+            for tile_m, tile_n in hl.tile([m, n]):
+                a = x[tile_m, tile_n.index]
+                b = x[tile_m, tile_n.index + n]
+                out[tile_m, tile_n] = a * b
+            return out
+
+        x = torch.randn(256, 512, device=DEVICE, dtype=HALF_DTYPE)
+        inter = self._fact(interleaved, (x,))
+        contig = self._fact(halves, (x,))
+        # The stride-2 gather is recognized...
+        self.assertEqual(inter.gather_stride, 2)
+        # ...and the stride-1 control is not penalized.
+        self.assertEqual(contig.gather_stride, 1)
+        # Layout stride is 1 for both, so ``subscript_strides`` cannot tell them apart.
+        for fact_owner in (interleaved, halves):
+            bound = fact_owner.bind((x,))
+            inner = [
+                m.subscript_strides[-1]
+                for m in bound.config_spec.memory_op_facts
+                if m.subscript_strides
+            ]
+            self.assertTrue(all(s == 1 for s in inner), inner)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler pointwise facts are not collected in ref eager mode")
+    def test_plain_elementwise_is_stride_one(self) -> None:
+        @helion.kernel(backend="triton")
+        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        x = torch.randn(256, 256, device=DEVICE, dtype=HALF_DTYPE)
+        self.assertEqual(self._fact(add, (x, x)).gather_stride, 1)
+
+    @onlyBackends(["triton"])
+    def test_elems_per_thread_is_a_three_band_ladder(self) -> None:
+        # Bands are 16 coalesced / 4 at strides 2-4 / 2 beyond. Guards two wrong
+        # forms: saturate-at-2 (returns 4 past stride 4) and a continuous
+        # ``16 // stride`` (returns 8 at stride 2).
+        eps = TritonPointwiseSeedHeuristic._elems_per_thread
+        self.assertEqual(eps(1), 16)
+        for stride in (2, 3, 4):
+            self.assertEqual(eps(stride), 4, f"stride {stride}")
+        for stride in (8, 16, 32):
+            self.assertEqual(eps(stride), 2, f"stride {stride}")
+        # Monotonically non-increasing, and never below the wide-gather floor.
+        values = [eps(s) for s in (1, 2, 4, 8, 16, 64, 1024)]
+        self.assertEqual(values, sorted(values, reverse=True))
+        self.assertGreaterEqual(
+            min(values), TritonPointwiseSeedHeuristic.ELEMS_PER_THREAD_WIDE_GATHER
+        )
+        # A degenerate/absent stride reads as coalesced rather than penalized.
+        self.assertEqual(eps(0), 16)
+
+
+class TestPointwiseArchConstants(TestCase):
+    """The seed's byte constants are arch-keyed; unmeasured arches keep the sm90 path."""
+
+    @onlyBackends(["triton"])
+    def test_tile_bytes_and_waves_are_arch_keyed(self) -> None:
+        from helion._compiler.compile_environment import CompileEnvironment
+
+        env = MagicMock(spec=CompileEnvironment)
+        env.device = torch.device(DEVICE)
+        with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
+            self.assertEqual(
+                TritonPointwiseSeedHeuristic.tile_bytes_for(env),
+                TritonPointwiseSeedHeuristic.TILE_BYTES,
+            )
+            self.assertEqual(
+                TritonPointwiseSeedHeuristic.min_waves_for(env),
+                TritonPointwiseSeedHeuristic.MIN_WAVES,
+            )
+        with patch(
+            "helion._hardware.get_hardware_info", return_value=BLACKWELL_HARDWARE
+        ):
+            self.assertEqual(
+                TritonPointwiseSeedHeuristic.tile_bytes_for(env),
+                TritonPointwiseSeedHeuristic.TILE_BYTES_SM100,
+            )
+            self.assertEqual(
+                TritonPointwiseSeedHeuristic.min_waves_for(env),
+                TritonPointwiseSeedHeuristic.MIN_WAVES_SM100,
+            )
+        # An arch the seed FIRES on but was never tuned for keeps the conservative
+        # sm90-calibrated values, not the B200 ones. Covers both directions of the
+        # allow-list: an OLDER arch (sm80), and -- the case a ``>= sm100`` version
+        # compare would get wrong -- a NEWER/adjacent one. sm120 (consumer Blackwell,
+        # GB202) and a hypothetical future sm110 both sort above sm100 numerically
+        # while having entirely different SM counts and HBM bandwidth, so neither may
+        # inherit B200's fitted constants.
+        for name, cc in (("sm80", "sm80"), ("sm120", "sm120"), ("sm110", "sm110")):
+            hardware = HardwareInfo(
+                device_kind="cuda",
+                hardware_name=f"untuned-{name}",
+                runtime_version="12.8",
+                compute_capability=cc,
+            )
+            with (
+                self.subTest(arch=name),
+                patch("helion._hardware.get_hardware_info", return_value=hardware),
+            ):
+                self.assertEqual(
+                    TritonPointwiseSeedHeuristic.tile_bytes_for(env),
+                    TritonPointwiseSeedHeuristic.TILE_BYTES,
+                )
+                self.assertEqual(
+                    TritonPointwiseSeedHeuristic.min_waves_for(env),
+                    TritonPointwiseSeedHeuristic.MIN_WAVES,
+                )
+
+
 class TestTritonStandardReductionHeuristic(TestCase):
     """Triton standard row-reduction heuristic: seeds the "one row per program"
     skeleton with an rnumel-scaled ``num_warps`` ramp and faithful per-slot load


### PR DESCRIPTION

Tunes `TritonPointwiseSeedHeuristic` for sm100. **sm90 is byte-identical** — every
behavioural change is gated on a `TUNED_TARGETS` allow-list, so an unmeasured arch
(including a same-generation consumer part with a different SM count / bandwidth)
keeps the existing sm90-calibrated path.

## Perf: new vs the currently-landed heuristic

B200. Both configs are timed as arms in a **single process**, interleaved, cold-L2
with the cache flush inside the timed cudagraph, numerics validated per arm before
timing, and a byte-identical null arm per shape giving that shape's own noise floor.

| kernel | shapes | geomean |
|---|---|---|
| `silu_and_mul` | 15 | **1.133x** |
| `rope` | 10 | **1.076x** |
| `swiglu` | 10 | **1.004x** |
| `silu_and_mul` (interleaved) | 15 | **1.002x** |
| `silu_mul_fp8` | 10 | **0.983x** |
| **all** | **60** | **1.043x** |

19 shapes faster beyond their noise floor, 8 slower, 33 in-noise.

The two sglang `silu_and_mul` variants are the same math over the same shapes,
differing only in access pattern (contiguous halves vs a stride-2 gather), so they
isolate the coalescing work below. `silu_mul_fp8` and `rope` are the vLLM-ported and
TritonBench kernels from `pretuned_kernels/`; `swiglu` is `examples/swiglu.py`, one of
the kernels the existing constants were originally tuned against.

`silu_mul_fp8` regresses 1.7% geomean, from two shapes at 0.87x / 0.94x. Its
bandwidth-vs-tile-width curve is non-monotonic there (a local peak, a dip, then the
global peak), so the seed lands in the dip and no smooth `f(shape)` rule hits both
peaks. Three candidate fixes were tried and each cost more elsewhere than it
recovered, so this is left as a known residual rather than papered over with a
per-kernel special case. Four of the `swiglu` regressions are 0.975–0.993x.

## Changes

**1. `num_warps` from tile lanes + grid residency, not `sfu_ops`.** A 1-op activation
sits below `SFU_W8`, so every such kernel fell to the default warp count no matter how
large its tile — the wrong signal for bandwidth-bound work. Two terms replace it,
combined with `max`: lanes the tile can keep busy (a banded elements-per-thread ladder
over the gather stride), and the largest warp count whose CTAs still fit resident at
once — warps are free until they cost a second resident wave. The residency term is
naturally inert on a saturated grid. The SFU ramp is kept as a floor, since
transcendental latency is independent of byte traffic.

**2. The byte budget charges bytes FETCHED, not bytes useful.** A stride-k gather pulls
k 32B sectors per useful sector, so a W-element tile costs `k*W*slab_bytes` of real
traffic; charging useful bytes over-sizes a strided tile by exactly k.

**3. New `PointwiseElementwiseFact.gather_stride`** — the tile-index multiplier in a
load's *address* expression (`x[tile]` → 1, `x[2 * tile.index]` → 2). This is distinct
from the layout stride already recorded in `MemoryOpFact.subscript_strides`, which
cannot distinguish two ops indexing the same row-major tensor at different gather
strides. That is exactly the sglang pair: previously they produced an identical
`PointwiseElementwiseFact` despite ~2x different optimal tiles, so one fact could not
serve both. Populated via a new `subscript_index_scale` walk, which also recovers the
block-id that a scaled subscript loses (the lowering records tile provenance for
`tile + const` but not `tile * const`).

**4. `compute_itemsize` measures DATA width, excluding address arithmetic.** Index
arithmetic is int64 once a tensor crosses the int32 indexing threshold, so a plain bf16
kernel reported width 8 purely because its tensors got large — halving `reg_cap` on
exactly the shapes that least want a smaller tile. The walk starts from each store's
value and cuts at load nodes.

The split is deliberately data-vs-address, **not** float-vs-integer: filtering to float
dtypes would leave a genuine int-compute kernel at the initializer of 1 and
*over*-estimate `reg_cap`, which is the direction that emits a spilling tile. There is
a test for that case. No cheaper proxy works here — a tile index is both a legal
address and legal data, so dtype, node metadata and lowering class all fail to separate
them.

Also adds `max_op_slab_numel` (the largest single op's untiled fan-out) alongside the
existing `slab_numel` (the sum of the same per-op quantity). Bytes add across ops, so
the sum correctly sizes the byte/register budgets; lanes do not, since those tiles are
separate vector instructions over the same threads — so the max is what bounds a
`num_warps` starvation cap.

## Tests

6 new tests in `test_autotuner_heuristics.py` covering the data/address split (both
directions, including the integer-compute guard and a gather whose index is itself
loaded), `gather_stride` vs the layout stride on the sglang pair, and the arch gating.
Each was revert-verified: with the corresponding fix reverted, the test fails.