### PR TITLE
[pallas] Support sliding-window Pallas ordered bounds

### DIFF
--- a/helion/_compiler/pallas/compact_worklist.py
+++ b/helion/_compiler/pallas/compact_worklist.py
@@ -119,6 +119,11 @@ class CompactWorklistPlan:
     # The ordered loop computes only through the current compact tile's end,
     # while its metadata and resident window retain the full source range.
     ordered_end_clamped_to_compact: bool = False
+    # Sliding window: the ordered loop starts this many elements before the
+    # current compact tile's start, floored at the source begin.  Like the end
+    # clamp this narrows only the compute range -- range_len, the resident
+    # window, and its refills still describe the whole source range.
+    ordered_begin_window: int | None = None
 
     @property
     def owner_axis(self) -> Axis:
@@ -900,6 +905,97 @@ def _is_tile_end(expr: ast.AST, tile_var: str) -> bool:
     )
 
 
+def _is_tile_begin(expr: ast.AST, tile_var: str) -> bool:
+    if (
+        isinstance(expr, ast.Attribute)
+        and expr.attr == "begin"
+        and isinstance(expr.value, ast.Name)
+        and expr.value.id == tile_var
+    ):
+        return True
+    return (
+        _is_named_call(expr, "tile_begin", "hl")
+        and isinstance(expr, ast.Call)
+        and len(expr.args) == 1
+        and not expr.keywords
+        and isinstance(expr.args[0], ast.Name)
+        and expr.args[0].id == tile_var
+    )
+
+
+def _tile_begin_lookback(expr: ast.AST, tile_var: str) -> int | None:
+    """Return ``W`` for ``tile.begin - W`` / ``tile.begin``, else ``None``.
+
+    ``W`` is the sliding window's lookback in elements.  It is emitted as a
+    constant offset from the compact tile's start, so it must be a non-negative
+    integer literal.
+
+    A module global is deliberately NOT resolved here.  The kernel body reads
+    one at runtime -- it becomes a launcher-passed argument -- so baking its
+    value into the iteration bound would let a later rebind mask a window this
+    loop never visits.  A name assigned inside the kernel is fine and needs no
+    handling here: the caller has already inlined the prologue, so a literal
+    arrives as a ``Constant``.  Anything else in the ``tile.begin - X`` shape
+    is a window the caller clearly meant, so reject it by name rather than let
+    it fall through to the generic host-bound error.
+    """
+    if _is_tile_begin(expr, tile_var):
+        return 0
+    if not (
+        isinstance(expr, ast.BinOp)
+        and isinstance(expr.op, ast.Sub)
+        and _is_tile_begin(expr.left, tile_var)
+    ):
+        return None
+    window = expr.right
+    # bool is an int subclass; a window of True is a typo, not a width.  A
+    # negative literal parses as a UnaryOp, so it lands in the raise below.
+    if isinstance(window, ast.Constant) and type(window.value) is int:
+        return window.value
+    raise exc.InvalidConfig(
+        "compact_worklist: a sliding-window lookback must be an integer "
+        f"literal, got {ast.unparse(window)!r}.  A module constant is read at "
+        "runtime by the kernel body, so it would not stay in step with the "
+        "iteration bound.  Write the literal inline, or bind it to a name "
+        "inside the kernel before the loop (assignments there are inlined "
+        "into the bound, so the body sees the same value)."
+    )
+
+
+def _ordered_source_begin(
+    begin: ast.AST,
+    compact_var: str,
+) -> tuple[ast.AST, int | None]:
+    """Split an ordered begin into its source begin and any window lookback.
+
+    Accepts one form on the ordered loop's begin argument::
+
+        max(<host expr>, tile.begin - W)   -> source begin is <host expr>
+
+    Returns the full SOURCE begin -- what sizes range_len and the resident
+    window -- plus ``W``, the number of elements before the compact tile's
+    start that this work item computes from.  ``None`` means the begin is an
+    ordinary source bound.  Both operands render from what the kernel wrote, so
+    like the ``min`` end form this needs no agreement between the two begins.
+
+    A non-literal window raises from :func:`_tile_begin_lookback`.
+    """
+    if not (
+        _is_named_call(begin, "max", "builtins")
+        and isinstance(begin, ast.Call)
+        and len(begin.args) == 2
+        and not begin.keywords
+    ):
+        return begin, None
+    lhs = _tile_begin_lookback(begin.args[0], compact_var)
+    rhs = _tile_begin_lookback(begin.args[1], compact_var)
+    if (lhs is None) == (rhs is None):
+        return begin, None
+    if lhs is None:
+        return begin.args[0], rhs
+    return begin.args[1], lhs
+
+
 def _ordered_source_end(
     begin: ast.AST,
     end: ast.AST,
@@ -1235,6 +1331,7 @@ def detect_compact_worklist_plan(
     # An inner tile loop is only supported when it is the ordered (carried-state)
     # axis: a name assigned in its body, read in its body, and read after it.
     ordered_end_clamped_to_compact = False
+    ordered_begin_window: int | None = None
     if ordered_loop is not None:
         if not isinstance(ordered_loop.target, ast.Name):
             raise exc.InvalidConfig("compact_worklist: ordered tile var is not a Name.")
@@ -1252,9 +1349,22 @@ def detect_compact_worklist_plan(
                 "scope. Only an ordered carried-state inner loop is supported."
             )
 
-    # Prologue scalar assigns in the grid body BEFORE the compact tile loop
-    # (start = offsets[source], ...); a later reassignment must not leak in.
-    prologue = _collect_prologue_assigns(grid_loop.body, before=compact_loop)
+    # Prologue scalar assigns visible to the compact bounds: function-level
+    # ones (a window width, a shared stride) plus those in the grid body BEFORE
+    # the compact tile loop (start = offsets[source], ...).  Grid-body names
+    # shadow function-level ones, and a later reassignment must not leak in.
+    #
+    # A function-level name that one of the loops then rebinds as its target is
+    # dropped: inside the nest the loop coordinate wins, so inlining the outer
+    # value would rewrite ``offsets[seq_idx]`` to the pre-loop ``offsets[0]``
+    # and hand every owner the same range.
+    loop_targets = {owner_var, compact_var, ordered_var}
+    prologue = {
+        **{
+            name: value for name, value in top_level.items() if name not in loop_targets
+        },
+        **_collect_prologue_assigns(grid_loop.body, before=compact_loop),
+    }
 
     # Compact axis (bounds-carry): base = begin, length = end - begin.
     compact_call = _loop_iter_call(compact_loop)
@@ -1330,6 +1440,7 @@ def detect_compact_worklist_plan(
         }
         o_begin = _inline(_to_plain(ordered_call.args[0]), ordered_prologue)
         o_end = _inline(_to_plain(ordered_call.args[1]), ordered_prologue)
+        o_begin, ordered_begin_window = _ordered_source_begin(o_begin, compact_var)
         o_end, ordered_end_clamped_to_compact = _ordered_source_end(
             o_begin,
             o_end,
@@ -1393,6 +1504,7 @@ def detect_compact_worklist_plan(
         upper_bound_expr="",  # finalized at codegen via program_id.num_pids_expr
         num_owners_expr=num_owners_expr,
         ordered_end_clamped_to_compact=ordered_end_clamped_to_compact,
+        ordered_begin_window=ordered_begin_window,
     )
 
 

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -879,14 +879,20 @@ def _compact_worklist_bounds(
     begin_ref, extent_ref = (f"{n}_ref" for n in ref_names(plan))
     begin = f"{begin_ref}[_wid]"
     end = f"{begin} + {extent_ref}[_wid]"
-    if kind == "ordered" and plan.ordered_end_clamped_to_compact:
-        # The source range above still spans the whole reused window; this work
-        # item computes only through the compact tile's current end.
+    if kind == "ordered":
+        # The source range above still spans the whole reused window; these
+        # narrow only what this work item computes.  Resident-window reads take
+        # the local offset as (absolute offset - range_start), so a begin that
+        # no longer coincides with the window base needs nothing extra.
         compact_begin, compact_extent = (
             f"{name}_ref" for name in compact_ref_names(plan)
         )
-        compact_end = f"{compact_begin}[_wid] + {compact_extent}[_wid]"
-        end = f"jnp.minimum({end}, {compact_end})"
+        if plan.ordered_begin_window is not None:
+            window_start = f"{compact_begin}[_wid] - {plan.ordered_begin_window}"
+            begin = f"jnp.maximum({begin}, {window_start})"
+        if plan.ordered_end_clamped_to_compact:
+            compact_end = f"{compact_begin}[_wid] + {compact_extent}[_wid]"
+            end = f"jnp.minimum({end}, {compact_end})"
     return begin, end
 
 

--- a/helion/language/builtin_ops.py
+++ b/helion/language/builtin_ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+from typing import TYPE_CHECKING
 from typing import cast
 
 import sympy
@@ -9,6 +10,9 @@ import torch
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.compile_environment import _to_sympy
 from . import _decorators
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def compute_symbolic_min_max(
@@ -31,11 +35,16 @@ def compute_symbolic_min_max(
     return shape_env.create_symintnode(expr, hint=hint)  # type: ignore[return-value]
 
 
-def _compute_scalar_tensor_min(
+def _compute_scalar_tensor_min_max(
     args: tuple[int | torch.SymInt | torch.Tensor, ...],
+    elementwise: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
 ) -> torch.Tensor:
+    """Reduce mixed int/SymInt/0-D tensor args with ``elementwise``.
+
+    Non-tensor args are materialized against the first tensor, so the result
+    keeps that tensor's dtype and device.
+    """
     reference = next(arg for arg in args if isinstance(arg, torch.Tensor))
-    assert isinstance(reference, torch.Tensor)
     if any(isinstance(arg, torch.Tensor) and arg.ndim != 0 for arg in args):
         raise TypeError("device min/max only supports scalar tensor arguments")
     tensor_args = [
@@ -46,7 +55,7 @@ def _compute_scalar_tensor_min(
     ]
     result = tensor_args[0]
     for arg in tensor_args[1:]:
-        result = torch.minimum(result, arg)
+        result = elementwise(result, arg)
     return result
 
 
@@ -66,21 +75,25 @@ def _builtin_min(
         The minimum value with the corresponding scalar representation.
     """
     if any(isinstance(arg, torch.Tensor) for arg in args):
-        return _compute_scalar_tensor_min(args)
+        return _compute_scalar_tensor_min_max(args, torch.minimum)
     return compute_symbolic_min_max(args, op=builtins.min)  # type: ignore[arg-type]
 
 
 @_decorators.device_func_replacement(builtins.max)
-def _builtin_max(*args: int | torch.SymInt) -> torch.SymInt | int:
-    """Device replacement for builtin max() that supports symbolic integers.
+def _builtin_max(
+    *args: int | torch.SymInt | torch.Tensor,
+) -> torch.SymInt | torch.Tensor | int:
+    """Device replacement for max() over symbolic ints or scalar tensors.
 
-    Returns the maximum value among the provided arguments, preserving
-    symbolic integer expressions when present.
+    A scalar tensor result is used when any input is a scalar tensor; otherwise
+    symbolic integer expressions are preserved.
 
     Args:
-        *args: Integer arguments, which may be concrete ints or symbolic SymInts
+        *args: Concrete ints, symbolic SymInts, or scalar tensors.
 
     Returns:
-        The maximum value, as a SymInt if any argument is symbolic, otherwise int
+        The maximum value with the corresponding scalar representation.
     """
-    return compute_symbolic_min_max(args, op=builtins.max)
+    if any(isinstance(arg, torch.Tensor) for arg in args):
+        return _compute_scalar_tensor_min_max(args, torch.maximum)
+    return compute_symbolic_min_max(args, op=builtins.max)  # type: ignore[arg-type]

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -735,6 +735,25 @@ class TestMisc(RefEagerTestBase, TestCase):
 
         torch.testing.assert_close(helion_out, ref_out, rtol=1e-3, atol=1e-3)
 
+    def test_builtin_min_max_over_scalar_tensors(self) -> None:
+        """min()/max() mixing a loaded 0-D tensor with an int must pick correctly.
+
+        The Pallas worklist rewrites such a bound into its own metadata, so the
+        traced op is dead there and a min/max mix-up would not show up in those
+        numerics.  Here the value reaches the output.
+        """
+
+        @helion.kernel(autotune_effort="none")
+        def clamp_kernel(values):
+            out = torch.zeros_like(values)
+            for i in hl.grid(values.size(0)):
+                out[i] = min(max(values[i], 3), 7)
+            return out
+
+        values = torch.tensor([-5, 0, 3, 4, 7, 9], dtype=torch.int32, device=DEVICE)
+        _, result = code_and_output(clamp_kernel, (values,))
+        torch.testing.assert_close(result, values.clamp(3, 7))
+
     def test_torch_tensor_constant_in_kernel(self):
         """Test that torch.tensor() with a constant value works inside a kernel."""
 

--- a/test/test_pallas_worklist.py
+++ b/test/test_pallas_worklist.py
@@ -433,6 +433,44 @@ def _causal_jagged_kernel(q, k, v, offsets):
     return out
 
 
+# Sliding-window causal attention: each query attends to the keys in a fixed
+# span before it, so the ordered loop's begin also depends on the enclosing
+# tile.  The kernel below spells the span as a literal in both its bound and
+# its mask, since a module global would be read at runtime by the body while
+# the bound baked a value.  This copy is for the reference and the assertions;
+# test_sliding_window_preserves_source_range pins it to the kernel's literal.
+_SLIDING_WINDOW = 16
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def _sliding_window_jagged_kernel(q, k, v, offsets):
+    H = hl.specialize(q.size(1))
+    D = hl.specialize(q.size(2))
+    num_sequences = offsets.size(0) - 1
+    out = torch.empty_like(q)
+    for seq_idx in hl.grid(num_sequences):
+        q_start = offsets[seq_idx]
+        q_end = offsets[seq_idx + 1]
+        k_start = offsets[seq_idx]
+        k_end = offsets[seq_idx + 1]
+        for tile_q in hl.tile(q_start, q_end):
+            q_blk = q[tile_q, :, :].transpose(0, 1)
+            acc = hl.zeros([H, tile_q, D], dtype=torch.float32)
+            for tile_k in hl.tile(
+                max(k_start, tile_q.begin - 16),
+                min(k_end, tile_q.end),
+            ):
+                k_blk = k[tile_k, :, :].transpose(0, 1)
+                v_blk = v[tile_k, :, :].transpose(0, 1)
+                scores = torch.bmm(q_blk, k_blk.transpose(-2, -1))
+                delta = tile_q.index[None, :, None] - tile_k.index[None, None, :]
+                keep = (delta >= 0) & (delta <= 16)
+                scores = torch.where(keep, scores, 0.0)
+                acc = torch.baddbmm(acc, scores.to(v.dtype), v_blk)
+            out[tile_q, :, :] = acc.transpose(0, 1).to(out.dtype)
+    return out
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def _flash_prep_kernel(q, k, v, q_offsets, kv_offsets):
     """Jagged flash attention: a max reduction (amax) whose padded scores must be -inf,
@@ -709,7 +747,7 @@ class TestDetectAndGating(unittest.TestCase):
             "foo.min(offsets[seq_idx + 1], tile_q.end)",
             # A different tile's edge is not the enclosing compact tile.
             "min(offsets[seq_idx + 1], tile_k.end)",
-            # Begin edges (sliding windows) are not recognized yet.
+            # A begin edge is the sliding-window form, matched separately.
             "max(offsets[seq_idx], tile_q.begin)",
         ):
             with self.subTest(unsupported=unsupported):
@@ -722,6 +760,161 @@ class TestDetectAndGating(unittest.TestCase):
                 )
                 self.assertFalse(clamped)
                 self.assertEqual(ast.unparse(source_end), unsupported)
+
+    def test_sliding_window_begin_grammar(self):
+        """The begin recognizer accepts exactly ``max(src, tile.begin - W)``."""
+        from helion._compiler.pallas.compact_worklist import _ordered_source_begin
+
+        for accepted, window in (
+            ("max(offsets[seq_idx], tile_q.begin - 16)", 16),
+            ("max(tile_q.begin - 16, offsets[seq_idx])", 16),
+            ("builtins.max(offsets[seq_idx], hl.tile_begin(tile_q) - 4)", 4),
+            # A bare begin is the degenerate zero-lookback window.
+            ("max(offsets[seq_idx], tile_q.begin)", 0),
+        ):
+            with self.subTest(accepted=accepted):
+                source_begin, got = _ordered_source_begin(_expr(accepted), "tile_q")
+                self.assertEqual(got, window)
+                self.assertEqual(ast.unparse(source_begin), "offsets[seq_idx]")
+
+        for unsupported in (
+            # An ordinary source bound.
+            "offsets[seq_idx]",
+            # min() is the end form, not a lookback.
+            "min(offsets[seq_idx], tile_q.begin - 16)",
+            # A different tile's edge.
+            "max(offsets[seq_idx], tile_k.begin - 16)",
+            # Adding to the edge is a lookahead, which the clamp cannot express.
+            "max(offsets[seq_idx], tile_q.begin + 16)",
+            # Neither operand is an edge.
+            "max(offsets[seq_idx], 0)",
+        ):
+            with self.subTest(unsupported=unsupported):
+                source_begin, got = _ordered_source_begin(_expr(unsupported), "tile_q")
+                self.assertIsNone(got)
+                self.assertEqual(ast.unparse(source_begin), unsupported)
+
+        # A non-literal lookback is clearly an attempted window, so it is named
+        # rather than left to the generic host-bound error.  A module global in
+        # particular is read at runtime by the kernel body, so baking it into
+        # the iteration bound would let a rebind mask keys the loop never
+        # visits.
+        for rejected in (
+            "max(offsets[seq_idx], tile_q.begin - WINDOW)",
+            "max(offsets[seq_idx], tile_q.begin - w * 2)",
+            # A negative literal parses as a unary minus, not a Constant.
+            "max(offsets[seq_idx], tile_q.begin - -4)",
+        ):
+            with (
+                self.subTest(rejected=rejected),
+                self.assertRaisesRegex(exc.InvalidConfig, "integer literal"),
+            ):
+                _ordered_source_begin(_expr(rejected), "tile_q")
+
+    def test_sliding_window_accepts_a_kernel_local_window(self):
+        """A name bound inside the kernel is the workaround the error names.
+
+        Prologue assignments are inlined before the begin is matched, so the
+        literal reaches the bound and the body sees the same value -- unlike a
+        module global, which the body would read at runtime.  Function level
+        and grid body both work; the window sits at function level here since
+        that is the more natural place to write it.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def kernel(q, k, v, offsets):
+            H = hl.specialize(q.size(1))
+            D = hl.specialize(q.size(2))
+            window = 12
+            out = torch.empty_like(q)
+            for seq_idx in hl.grid(offsets.size(0) - 1):
+                start = offsets[seq_idx]
+                end = offsets[seq_idx + 1]
+                for tile_q in hl.tile(start, end):
+                    q_blk = q[tile_q, :, :].transpose(0, 1)
+                    acc = hl.zeros([H, tile_q, D], dtype=torch.float32)
+                    for tile_k in hl.tile(
+                        max(start, tile_q.begin - window), min(end, tile_q.end)
+                    ):
+                        k_blk = k[tile_k, :, :].transpose(0, 1)
+                        v_blk = v[tile_k, :, :].transpose(0, 1)
+                        scores = torch.bmm(q_blk, k_blk.transpose(-2, -1))
+                        delta = (
+                            tile_q.index[None, :, None] - tile_k.index[None, None, :]
+                        )
+                        keep = (delta >= 0) & (delta <= window)
+                        scores = torch.where(keep, scores, 0.0)
+                        acc = torch.baddbmm(acc, scores.to(v.dtype), v_blk)
+                    out[tile_q, :, :] = acc.transpose(0, 1).to(out.dtype)
+            return out
+
+        offsets = _offsets([12, 20, 5, 30])
+        length = int(offsets[-1])
+        args = (
+            torch.randn(length, 4, 128),
+            torch.randn(length, 4, 128),
+            torch.randn(length, 4, 128),
+            offsets,
+        )
+        bound = kernel.bind(args)
+        assert bound.host_function is not None
+        with bound.env:
+            plan = detect_compact_worklist_plan(bound.host_function)
+        self.assertEqual(plan.ordered_begin_window, 12)
+        code = bound.to_triton_code(_worklist_config([8, 8]))
+        self.assertIn("q_begin_ref[_wid] - 12", code)
+        # No launcher-passed copy of the window: nothing can drift from it.
+        self.assertNotIn("_source_module", code)
+
+    def test_function_level_name_does_not_shadow_a_loop_coordinate(self):
+        """A pre-loop name a loop rebinds must not be inlined into its bounds.
+
+        Function-level assignments reach the compact bounds so a window width
+        can live there, but the owner coordinate is bound by the grid loop:
+        inlining the pre-loop value would rewrite offsets[seq_idx] to
+        offsets[0] and give every owner the same range.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def kernel(q, k, v, offsets):
+            H = hl.specialize(q.size(1))
+            D = hl.specialize(q.size(2))
+            out = torch.empty_like(q)
+            seq_idx = 0
+            for seq_idx in hl.grid(offsets.size(0) - 1):
+                start = offsets[seq_idx]
+                end = offsets[seq_idx + 1]
+                for tile_q in hl.tile(start, end):
+                    q_blk = q[tile_q, :, :].transpose(0, 1)
+                    acc = hl.zeros([H, tile_q, D], dtype=torch.float32)
+                    for tile_k in hl.tile(start, end):
+                        k_blk = k[tile_k, :, :].transpose(0, 1)
+                        v_blk = v[tile_k, :, :].transpose(0, 1)
+                        scores = torch.bmm(q_blk, k_blk.transpose(-2, -1))
+                        acc = torch.baddbmm(acc, scores.to(v.dtype), v_blk)
+                    out[tile_q, :, :] = acc.transpose(0, 1).to(out.dtype)
+            return out
+
+        offsets = _offsets([12, 20, 5])
+        length = int(offsets[-1])
+        args = (
+            torch.randn(length, 4, 128),
+            torch.randn(length, 4, 128),
+            torch.randn(length, 4, 128),
+            offsets,
+        )
+        bound = kernel.bind(args)
+        assert bound.host_function is not None
+        with bound.env:
+            plan = detect_compact_worklist_plan(bound.host_function)
+        compact = plan.compact_axis
+        self.assertEqual(ast.unparse(compact.base), "offsets[seq_idx]")
+        self.assertEqual(
+            ast.unparse(compact.length),
+            "offsets[seq_idx + 1] - offsets[seq_idx]",
+        )
+        # Still the packed-offsets idiom, which the shadowed form would lose.
+        self.assertEqual(compact.packed_offset_arg, "offsets")
 
     def test_direct_tile_end_requires_matching_begins(self):
         from helion._compiler.pallas.compact_worklist import _ordered_source_end
@@ -1341,6 +1534,51 @@ class TestWorklistLoopDispatch(unittest.TestCase):
             "offsets[seq_idx + 1] - offsets[seq_idx]",
         )
 
+    def test_sliding_window_preserves_source_range(self):
+        args = self._causal_jagged_args()
+        bound = _sliding_window_jagged_kernel.bind(args)
+        assert bound.host_function is not None
+        with bound.env:
+            plan = detect_compact_worklist_plan(bound.host_function)
+        self.assertEqual(plan.ordered_begin_window, _SLIDING_WINDOW)
+        self.assertTrue(plan.ordered_end_clamped_to_compact)
+        ordered = plan.ordered_axis
+        assert ordered is not None
+        # Both clamps narrow only the compute range; the resident window and
+        # its refills still cover the whole source range.
+        self.assertEqual(ast.unparse(ordered.base), "offsets[seq_idx]")
+        self.assertEqual(
+            ast.unparse(ordered.length),
+            "offsets[seq_idx + 1] - offsets[seq_idx]",
+        )
+
+    def test_sliding_window_composes_with_loop_types_and_grouping(self):
+        args = self._causal_jagged_args()
+        window_begin = (
+            f"jnp.maximum(k_begin_ref[_wid], q_begin_ref[_wid] - {_SLIDING_WINDOW})"
+        )
+        compute_end = (
+            "jnp.minimum(k_begin_ref[_wid] + k_len_ref[_wid], "
+            "q_begin_ref[_wid] + q_extent_ref[_wid])"
+        )
+        for grouping in (1, 2):
+            for loop_type, marker in (
+                ("unroll", "def _dynamic_unroll_body"),
+                ("fori_loop", "jax.lax.fori_loop"),
+                ("emit_pipeline", "pltpu.emit_pipeline"),
+            ):
+                with self.subTest(grouping=grouping, loop_type=loop_type):
+                    code = _sliding_window_jagged_kernel.bind(args).to_triton_code(
+                        _worklist_config([8, 8], grouping=grouping, loop_type=loop_type)
+                    )
+                    self.assertIn(marker, code)
+                    self.assertIn(window_begin, code)
+                    self.assertIn(compute_end, code)
+                    if loop_type == "unroll":
+                        # Resident reads stay window-relative off the source
+                        # start, so a begin past that start needs no rebasing.
+                        self.assertIn("pl.ds(offset_2 - k_begin_ref[_wid]", code)
+
     def test_dependent_tile_end_composes_with_loop_types_and_grouping(self):
         args = self._causal_jagged_args()
         for grouping in (1, 2):
@@ -1552,6 +1790,22 @@ def _eager_causal_jagged(q, k, v, offsets):
     return out
 
 
+def _eager_sliding_window_jagged(q, k, v, offsets, window=_SLIDING_WINDOW):
+    out = torch.empty_like(q)
+    for s in range(len(offsets) - 1):
+        begin, end = int(offsets[s]), int(offsets[s + 1])
+        qb = q[begin:end].transpose(0, 1)
+        kb = k[begin:end].transpose(0, 1)
+        vb = v[begin:end].transpose(0, 1)
+        scores = torch.bmm(qb, kb.transpose(-2, -1))
+        idx = torch.arange(end - begin)
+        delta = idx[:, None] - idx[None, :]
+        keep = (delta >= 0) & (delta <= window)
+        kept = torch.where(keep, scores, torch.zeros_like(scores))
+        out[begin:end] = torch.bmm(kept, vb).transpose(0, 1)
+    return out
+
+
 def _exact_causal_jagged_inputs(offsets, num_heads, head_dim):
     length = int(offsets[-1])
     q = torch.ones(length, num_heads, head_dim, dtype=torch.float32)
@@ -1738,6 +1992,45 @@ class TestWorklistNumerics(unittest.TestCase):
                     ),
                 )
                 torch.testing.assert_close(out.cpu(), ref, rtol=0, atol=0)
+
+    def test_sliding_window_matches_eager(self):
+        H, D, block = 2, 128, 8
+        # Longer than the window, so tiles exist that the lookback excludes
+        # entirely -- the case a plain causal clamp would still visit.  Two
+        # sequences so the second rebases off a nonzero resident-window start.
+        offsets = _offsets([40, 24])
+        q, k, v = _exact_causal_jagged_inputs(offsets, H, D)
+        ref = _eager_sliding_window_jagged(q.cpu(), k.cpu(), v.cpu(), offsets)
+        for grouping in (1, 2):
+            with self.subTest(grouping=grouping):
+                _, out = code_and_output(
+                    _sliding_window_jagged_kernel,
+                    (q, k, v, offsets.to(DEVICE)),
+                    **_worklist_config(
+                        [block, block], loop_type="unroll", grouping=grouping
+                    ),
+                )
+                torch.testing.assert_close(out.cpu(), ref, rtol=0, atol=0)
+
+    @skipIfPallasInterpret(
+        "dynamic worklist streaming is validated on real TPU, not Pallas interpret"
+    )
+    def test_sliding_window_streaming_matches_eager(self):
+        H, D, block = 2, 128, 8
+        offsets = _offsets([40, 13])
+        q, k, v = _exact_causal_jagged_inputs(offsets, H, D)
+        ref = _eager_sliding_window_jagged(q.cpu(), k.cpu(), v.cpu(), offsets)
+        for grouping in (1, 2):
+            for loop_type in ("fori_loop", "emit_pipeline"):
+                with self.subTest(grouping=grouping, loop_type=loop_type):
+                    _, out = code_and_output(
+                        _sliding_window_jagged_kernel,
+                        (q, k, v, offsets.to(DEVICE)),
+                        **_worklist_config(
+                            [block, block], loop_type=loop_type, grouping=grouping
+                        ),
+                    )
+                    torch.testing.assert_close(out.cpu(), ref, rtol=0, atol=0)
 
     @skipIfPallasInterpret(
         "dynamic worklist streaming is validated on real TPU, not Pallas interpret"


### PR DESCRIPTION
Recognize a dependent LOWER bound on a flattened worklist's ordered loop, so a sliding window is expressible alongside the existing causal upper bound:

```python
    for tile_k in hl.tile(
        max(k_start, tile_q.begin - 16),
        min(k_end, tile_q.end),
    ):
```

Like the end clamp, this narrows only what each work item computes.  The ordered axis's metadata still describes the whole source range, so the resident window, its overflow guard, and the prep-cache refill are unchanged and successive work items keep reusing one resident range.

Nothing was needed for the local window offset: resident-window and prep-cache reads already take it as (absolute offset - range_start), so a begin that no longer coincides with the window base rebases itself.

- _ordered_source_begin splits max(<host expr>, tile.begin - W) into its source begin and the lookback W, mirroring _ordered_source_end.
- W must be an integer literal.  A module global is deliberately NOT resolved: the kernel body reads one at runtime -- it becomes a launcher-passed argument -- so baking its value into the iteration bound would let a rebind mask a window the loop never visits.  Since tile.begin - X is unambiguously an attempted window, a non-literal is named rather than left to the generic host-bound error.
- _compact_worklist_bounds applies it as jnp.maximum against the source begin, next to the existing jnp.minimum on the end.
- max() gains the scalar-tensor support min() already had, needed because a jagged lower bound floors against an offsets entry.  The shared helper now takes the elementwise op.  Worklist remapping makes the traced result dead in a sliding-window kernel, so the op is pinned by its own test in test_misc instead.

Dense sliding windows already worked through the ordinary bound path and are unaffected.  Generated code for the 42 kernel/config combinations without a window bound is unchanged.