### PR TITLE
[cute] Add two-CTA static-full TMA fast path

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -3885,9 +3885,9 @@ class _PerKiterTmaArgs:
     # (cute_plan.md §6.12.7). Default 1 preserves byte-identity for the
     # validated cluster_m=2 cluster_n=1 path.
     cluster_n: int = 1
-    # Static-full one-CTA pipelined TMA loops can drop the per-K runtime
-    # full-tile branch and scalar fallback. Non-pipelined/asymmetric or two-CTA
-    # TMA paths must keep the guarded fallback path.
+    # Static-full pipelined TMA loops can drop the per-K runtime full-tile
+    # branch and scalar fallback. Non-pipelined/asymmetric paths must keep the
+    # guarded fallback path.
     static_full_tiles: bool = False
     tma_desc_ptr_a: str | None = None
     tma_desc_ptr_b: str | None = None
@@ -3988,13 +3988,6 @@ def _build_kloop_pipeline_producer_if(
     assert args.use_tma_a and args.use_tma_b, (
         "pipelined branch requires both A and B to be TMA-loaded"
     )
-    assert not (args.static_full_tiles and args.is_two_cta), (
-        "static-full fast path is only valid for one-CTA pipelined TMA loops"
-    )
-    if load_current_tile:
-        assert not args.static_full_tiles, (
-            "current-tile producer is only used by role-local pipelined TMA loops"
-        )
     k_offset = (
         args.tma_k_tile
         if load_current_tile
@@ -4012,7 +4005,8 @@ def _build_kloop_pipeline_producer_if(
     )
     # CtaGroup.TWO uses CTA-rank-specific TMA partitions, so both CTAs issue
     # these copies; PipelineTmaUmma gates the full-barrier tx setup internally.
-    src = f"if {' and '.join(predicate_terms)}:\n"
+    predicate = " and ".join(predicate_terms) or "True"
+    src = f"if {predicate}:\n"
     producer_advance_src = (
         emit_pipeline_advance(args.tma_producer_state, indent="    ")
         if not args.skip_producer_advance
@@ -4051,9 +4045,6 @@ def _build_kloop_pipeline_consumer_if(
 ) -> ast.stmt:
     """Per-K-iter TMA consumer / scalar-fallback ``if`` for the pipelined branch."""
     if args.static_full_tiles:
-        assert not args.is_two_cta, (
-            "static-full fast path is only valid for one-CTA pipelined TMA loops"
-        )
         assert gate_exec_warp, "static-full fast path requires an exec-warp gate"
         assert not include_scalar_fallback, (
             "static-full fast path has no scalar fallback branch"
@@ -4146,9 +4137,6 @@ def _build_kloop_pipeline_release_if(
     multicast mask; separate peer arrivals over-count the empty barrier.
     """
     if args.static_full_tiles:
-        assert not args.is_two_cta, (
-            "static-full fast path is only valid for one-CTA pipelined TMA loops"
-        )
         assert gate_exec_warp, "static-full fast path requires an exec-warp gate"
         assert not include_scalar_fallback, (
             "static-full fast path has no scalar fallback branch"
@@ -4176,6 +4164,19 @@ def _build_kloop_pipeline_release_if(
             release_src + "\n" + advance_src, release_gate, indent=indent
         )
     if args.static_full_tiles:
+        if args.is_two_cta and gate_exec_warp:
+            owner_gate = _tcgen05_two_cta_owner_predicate(
+                args.exec_active,
+                is_two_cta=True,
+                gate_exec_warp=False,
+                cluster_n=args.cluster_n,
+            )
+            assert owner_gate is not None
+            full_tile_src = (
+                f"if {args.exec_active}:\n"
+                f"    if {owner_gate}:\n"
+                f"        {release_src}\n" + textwrap.indent(advance_src, "    ")
+            )
         return statement_from_string(full_tile_src)
     fallback_src = (
         "\nelse:\n    cute.arch.sync_threads()" if include_scalar_fallback else ""
@@ -6080,8 +6081,7 @@ def _emit_mma_pipeline(
     tcgen05_static_full_tma_fast_path = (
         tcgen05_static_full_tiles
         and tcgen05_use_tma_pipeline
-        and not tcgen05_is_two_cta
-        and not tcgen05_use_role_local_mma_exec
+        and not tcgen05_grouped_static_persistent_requested
     )
     tcgen05_acc_producer_mode = df.config.get(
         TCGEN05_ACC_PRODUCER_MODE_CONFIG_KEY,
@@ -10052,6 +10052,12 @@ def _emit_mma_pipeline(
                     assert mma_stage_stmt is not None
                     assert smem_a_mma_stmt is not None
                     assert smem_b_mma_stmt is not None
+                    outer_owner_gated_exec = (
+                        tcgen05_static_full_tma_fast_path
+                        and tcgen05_is_two_cta
+                        and tcgen05_cluster_m == 2
+                        and tcgen05_cluster_n == 1
+                    )
                     exec_loop_body: list[ast.stmt] = [
                         mma_stage_stmt,
                         smem_a_mma_stmt,
@@ -10079,10 +10085,6 @@ def _emit_mma_pipeline(
                     exec_loop_body.append(
                         _build_kloop_pipeline_consumer_if(
                             tma_kloop_args,
-                            # Static-full pipeline builders require their
-                            # internal exec gate to keep emitting a single
-                            # statement. The outer wrapper below makes the
-                            # cloned loop's role ownership explicit.
                             gate_exec_warp=tcgen05_static_full_tma_fast_path,
                             include_scalar_fallback=False,
                             use_existing_try_token=tcgen05_use_role_local_ab_consumer_prefetch,
@@ -10103,9 +10105,6 @@ def _emit_mma_pipeline(
                                 tcgen05_frag_a=tcgen05_frag_a,
                                 tcgen05_frag_b=tcgen05_frag_b,
                                 mma_stage=mma_stage,
-                                # See the consumer wait comment above: pure
-                                # lifecycle has an outer exec-active role
-                                # wrapper plus the static-full builder gate.
                                 gate_exec_warp=tcgen05_static_full_tma_fast_path,
                                 is_two_cta=tcgen05_is_two_cta,
                                 cluster_n=tcgen05_cluster_n,
@@ -10114,7 +10113,6 @@ def _emit_mma_pipeline(
                     exec_loop_body.append(
                         _build_kloop_pipeline_release_if(
                             tma_kloop_args,
-                            # See the consumer wait comment above.
                             gate_exec_warp=tcgen05_static_full_tma_fast_path,
                             include_scalar_fallback=False,
                         )
@@ -10131,15 +10129,23 @@ def _emit_mma_pipeline(
                         exec_loop_body,
                         iter_expr=cloned_k_loop_iter_expr,
                     )
-                    exec_stmt: ast.stmt = exec_loop
+                    exec_role_stmt: ast.stmt = exec_loop
+                    if outer_owner_gated_exec:
+                        # Only the V-leader consumes AB stages and issues UMMA.
+                        # Keep the follower out of the cloned K loop entirely;
+                        # it still participates in the TMA-load role.
+                        exec_role_stmt = _wrap_stmt_in_if(
+                            exec_loop, _TCGEN05_CLUSTER_LEADER_PREDICATE
+                        )
+                    exec_stmt: ast.stmt = exec_role_stmt
                     if tcgen05_use_pure_matmul_role_lifecycle:
                         exec_stmt = _wrap_stmt_in_if(
-                            exec_loop, tcgen05_plan.exec_active
+                            exec_role_stmt, tcgen05_plan.exec_active
                         )
                     prefix.append(exec_stmt)
                     per_tile_stmts.append(exec_stmt)
                     if tcgen05_use_role_local_mma_exec:
-                        mma_exec_role_stmts.append(exec_loop)
+                        mma_exec_role_stmts.append(exec_role_stmt)
                 else:
                     cg.add_statement(
                         statement_from_string(

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -4747,13 +4747,14 @@ class TestCuteLowerings(unittest.TestCase):
         """Persistent tcgen05 lifts producer, exec, and epi work into
         role-local persistent loops. The TMA producer K-loop is now a
         top-level extracted role block, not an inline wrapper inside the
-        shared K-loop, and its predicate drops the inline
-        ``tcgen05_tma_warp`` gate because the enclosing role-local loop
-        already restricts execution to that warp. The MMA-exec role owns
-        AB consumer wait/release, UMMA issue, and acc producer state. The
-        epi role owns acc consumer wait/release and the TMA-store epilogue
-        with a role-local tile counter for the SMEM ring. The generated kernel
-        is also executed and checked against PyTorch."""
+        shared K-loop. Its predicate drops the inline ``tcgen05_tma_warp``
+        gate because the enclosing role-local loop already restricts execution
+        to that warp, and drops the current-tile full check because this
+        configuration is statically divisible. The MMA-exec role owns AB
+        consumer wait/release, UMMA issue, and acc producer state. The epi role
+        owns acc consumer wait/release and the TMA-store epilogue with a
+        role-local tile counter for the SMEM ring. The generated kernel is also
+        executed and checked against PyTorch."""
 
         from helion._compiler.cute.mma_support import get_cute_mma_support
 
@@ -4826,13 +4827,10 @@ class TestCuteLowerings(unittest.TestCase):
                 self.assertIn("pid_0 = virtual_pid % num_blocks_0", role_src)
                 self.assertIn("tile_offset_0 = pid_0 * _BLOCK_SIZE_0", role_src)
                 self.assertIn("for tile_offset_2 in range", role_src)
-                self.assertIn(
-                    "if tcgen05_tma_full_tile and tcgen05_tma_next_full_tile",
-                    role_src,
-                )
+                self.assertIn("if tcgen05_tma_next_full_tile:", role_src)
+                self.assertNotIn("tcgen05_tma_full_tile =", role_src)
                 self.assertNotIn(
-                    "tcgen05_tma_full_tile and tcgen05_tma_warp and "
-                    "tcgen05_tma_next_full_tile",
+                    "tcgen05_tma_warp and tcgen05_tma_next_full_tile",
                     role_src,
                 )
                 found_role_local_producer_loop = True
@@ -9718,6 +9716,22 @@ class TestCuteLowerings(unittest.TestCase):
                     )
                     found_role_local_tma = True
                 elif test_src == exec_role_predicate:
+                    outer_owner_k_loops = [
+                        loop
+                        for owner in ast.walk(node)
+                        if isinstance(owner, ast.If)
+                        and ast.unparse(owner.test) == _TCGEN05_CLUSTER_LEADER_PREDICATE
+                        for loop in ast.walk(owner)
+                        if isinstance(loop, ast.For)
+                        and "tcgen05_ab_pipeline.consumer_wait" in ast.unparse(loop)
+                        and "cute.gemm(" in ast.unparse(loop)
+                    ]
+                    self.assertEqual(
+                        len(outer_owner_k_loops),
+                        1,
+                        "Expected the complete MMA K loop to be nested under the "
+                        "CtaGroup.TWO leader gate. Generated role code:\n" + role_src,
+                    )
                     first_ab_peek_pos = role_src.index(
                         "tcgen05_ab_pipeline.consumer_try_wait"
                     )
@@ -19918,6 +19932,19 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
         self.assertIsInstance(producer, ast.If)
         self.assertEqual(ast.unparse(producer.test), "tma_warp and next_full_tile")
 
+        current_tile_producer = _build_kloop_pipeline_producer_if(
+            args,
+            gate_tma_warp=False,
+            load_current_tile=True,
+        )
+        self.assertEqual(ast.unparse(current_tile_producer.test), "True")
+        current_tile_src = ast.unparse(
+            ast.Module(body=current_tile_producer.body, type_ignores=[])
+        )
+        self.assertIn("gA[None, tma_k_tile]", current_tile_src)
+        self.assertIn("gB[None, tma_k_tile]", current_tile_src)
+        self.assertNotIn("tma_k_tile +", current_tile_src)
+
         consumer = _build_kloop_pipeline_consumer_if(
             args,
             include_scalar_fallback=False,
@@ -19938,19 +19965,30 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
             _build_kloop_pipeline_release_if(args)
 
         two_cta_args = self._make_args(is_two_cta=True, static_full_tiles=True)
-        for builder in (
-            _build_kloop_pipeline_producer_if,
-            _build_kloop_pipeline_consumer_if,
-            _build_kloop_pipeline_release_if,
-        ):
-            with (
-                self.subTest(builder=builder.__name__),
-                self.assertRaisesRegex(AssertionError, "one-CTA"),
-            ):
-                if builder is _build_kloop_pipeline_producer_if:
-                    builder(two_cta_args)
-                else:
-                    builder(two_cta_args, include_scalar_fallback=False)
+        two_cta_producer = _build_kloop_pipeline_producer_if(two_cta_args)
+        self.assertEqual(
+            ast.unparse(two_cta_producer.test), "tma_warp and next_full_tile"
+        )
+
+        two_cta_consumer = _build_kloop_pipeline_consumer_if(
+            two_cta_args, include_scalar_fallback=False
+        )
+        self.assertEqual(
+            ast.unparse(two_cta_consumer.test),
+            f"exec_active and {_TCGEN05_CLUSTER_LEADER_PREDICATE}",
+        )
+
+        two_cta_release = _build_kloop_pipeline_release_if(
+            two_cta_args, include_scalar_fallback=False
+        )
+        self.assertEqual(ast.unparse(two_cta_release.test), "exec_active")
+        self.assertEqual(self._stmt_kinds(two_cta_release.body), ["If", "advance"])
+        release_gate = two_cta_release.body[0]
+        self.assertIsInstance(release_gate, ast.If)
+        self.assertEqual(
+            ast.unparse(release_gate.test), _TCGEN05_CLUSTER_LEADER_PREDICATE
+        )
+        self.assertEqual(self._stmt_kinds(release_gate.body), ["consumer_release"])
 
     def test_non_pipeline_builders_reject_static_full_fast_path(self) -> None:
         args = self._make_args(static_full_tiles=True)


### PR DESCRIPTION
## Summary

- extend the static-full pipelined TMA path to persistent CtaGroup.TWO matmuls
- keep per-CTA TMA production while leader-gating the complete MMA consumer K loop
- remove current-tile full checks from static-full producer/consumer paths while retaining pipeline lookahead validation
- add builder coverage and an end-to-end generated-code assertion for leader-gated MMA versus ungated TMA production

## Performance

B200, cold-L2 CUDA graphs, `512x2048x2048` FP8 `scale_mm_cute`, `BM=BN=BK=128`, repeated 500-replay medians on an idle GPU:

| Revision | Latency |
|---|---:|
| `origin/main` (`53d95bf3`) | 6.8716 us |
| parent (`76bc8a9c`) | 6.5411 us |
| this PR | 6.3347 us |

That is an 8.48% throughput improvement over `origin/main` and a 3.26% incremental improvement over the parent commit.

The owner-gating ablation measured redundant inner checks at 0.04% and the outer leader gate at 0.37%, so this version retains the simple inner checks and the profitable outer gate.

## Testing

- 21 `TestPerKiterTmaBuilders` tests passed
- persistent `cluster_m=2` two-CTA runtime/codegen test passed
- Ruff format and lint passed
- output matched `torch._scaled_mm` with maximum absolute error 0.000122
