### PR TITLE
[cute] Support trailing-transposed tcgen05 matmul

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -311,6 +311,50 @@ class _MmaOperandInfo:
     rhs_rank3_grouped_nt: bool = False
     rhs_segment_group: _Rank3RhsSegmentGroupInfo | None = None
     rhs_packed_group: _Rank3RhsPackedGroupInfo | None = None
+    source_to_logical_order: tuple[int, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if self.source_to_logical_order is None:
+            return
+        expected = self.source_fake.permute(self.source_to_logical_order)
+
+        def mismatch(field: str, actual: object, expected_value: object) -> str:
+            return (
+                f"Invalid MMA operand analysis: logical_fake {field} does not "
+                "match source_fake.permute(source_to_logical_order). The recorded "
+                "logical order is likely incorrect. Please report a bug to the "
+                "Helion maintainers with this context: "
+                f"source_to_logical_order={self.source_to_logical_order}, "
+                f"source_shape={self.source_fake.shape}, "
+                f"source_stride={self.source_fake.stride()}, "
+                f"logical_shape={self.logical_fake.shape}, "
+                f"logical_stride={self.logical_fake.stride()}, "
+                f"field={field}, actual={actual}, expected={expected_value}"
+            )
+
+        assert self.logical_fake.dtype == expected.dtype, mismatch(
+            "dtype", self.logical_fake.dtype, expected.dtype
+        )
+        assert self.logical_fake.device == expected.device, mismatch(
+            "device", self.logical_fake.device, expected.device
+        )
+        assert self.logical_fake.shape == expected.shape, mismatch(
+            "shape", self.logical_fake.shape, expected.shape
+        )
+        assert self.logical_fake.stride() == expected.stride(), mismatch(
+            "stride", self.logical_fake.stride(), expected.stride()
+        )
+        assert self.logical_fake.storage_offset() == expected.storage_offset(), (
+            mismatch(
+                "storage_offset",
+                self.logical_fake.storage_offset(),
+                expected.storage_offset(),
+            )
+        )
+
+    @property
+    def matrix_major(self) -> str | None:
+        return _tcgen05_tma_matrix_major(self.logical_fake)
 
     @property
     def matrix_rows(self) -> int | torch.SymInt:
@@ -893,6 +937,15 @@ def _tcgen05_tma_matrix_major(tensor: torch.Tensor) -> str | None:
     if tensor.stride(-2) == 1:
         return "col"
     return None
+
+
+def _compose_axis_orders(
+    source_to_logical: tuple[int, ...],
+    logical_to_target: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Map source axes directly into a target ordered from logical axes."""
+    assert len(source_to_logical) == len(logical_to_target)
+    return tuple(source_to_logical[logical_dim] for logical_dim in logical_to_target)
 
 
 def _rank3_rhs_index_block_id(index: Node, *, reduction: bool | None) -> int | None:
@@ -2412,6 +2465,7 @@ class _MmaSearchGraphView:
 @dataclass(frozen=True)
 class _MmaOutputStoreAnalysis:
     explicit_epi_tile_compatible: bool
+    output_column_major: bool
 
 
 def _mma_tiles_are_static_full(
@@ -2425,11 +2479,47 @@ def _mma_tiles_are_static_full(
     )
 
 
+def _unwrap_mma_operand_permute(
+    node: Node,
+) -> tuple[Node, tuple[int, ...] | None] | None:
+    """Unwrap the trailing-axis swap supported by collective MMA lowering.
+
+    Return ``(node, None)`` when no permutation is present, or the source node
+    and its source-to-logical axis order for a supported swap. Return ``None``
+    when the node is a malformed or unsupported permutation.
+    """
+    if node.op != "call_function" or node.target is not torch.ops.aten.permute.default:
+        return node, None
+    if len(node.args) != 2 or not isinstance(node.args[0], Node):
+        return None
+    value_fake = node.meta.get("val")
+    order = node.args[1]
+    if not isinstance(value_fake, torch.Tensor) or not isinstance(order, (list, tuple)):
+        return None
+    normalized = tuple(int(cast("int", dim)) % value_fake.ndim for dim in order)
+    # The order representation is general, but collective MMA lowering only
+    # supports swapping the two trailing matrix axes. Arbitrary permutations
+    # would also require remapping M/N/K, leading batch/group axes, tile block
+    # ids, and TMA coordinates throughout the rest of the lowering.
+    trailing_axis_swap = (
+        *range(value_fake.ndim - 2),
+        value_fake.ndim - 1,
+        value_fake.ndim - 2,
+    )
+    if normalized != trailing_axis_swap:
+        return None
+    return node.args[0], normalized
+
+
 def _analyze_mma_operand(
     node: Node,
     env: CompileEnvironment,
 ) -> _MmaOperandInfo | None:
-    info = _direct_load_tensor(node)
+    permute = _unwrap_mma_operand_permute(node)
+    if permute is None:
+        return None
+    load_value, source_to_logical_order = permute
+    info = _direct_load_tensor(load_value)
     if info is None:
         return None
     load_node, _, source_fake = info
@@ -2450,16 +2540,25 @@ def _analyze_mma_operand(
             block_size, source_fake.size(dim)
         ):
             return None
+    if source_to_logical_order is not None:
+        block_ids = tuple(block_ids[dim] for dim in source_to_logical_order)
     if source_fake.ndim not in (2, 3):
+        return None
+    if source_to_logical_order is not None and source_fake.ndim == 3:
         return None
     if value_fake.ndim not in (2, source_fake.ndim):
         return None
     return _MmaOperandInfo(
         load=load_node,
-        terminal=load_node,
+        terminal=node if source_to_logical_order is not None else load_node,
         source_fake=source_fake,
-        logical_fake=source_fake,
+        logical_fake=(
+            source_fake.permute(source_to_logical_order)
+            if source_to_logical_order is not None
+            else source_fake
+        ),
         block_ids=block_ids,
+        source_to_logical_order=source_to_logical_order,
     )
 
 
@@ -2492,7 +2591,7 @@ def _analyze_mma_operands(
     # matrices. Keep other layouts out of the shared search/planning/codegen
     # capability until their rank-3 descriptor mapping is supported.
     if leading_passthrough_block_id is not None and any(
-        operand.source_fake.stride(-1) != 1
+        operand.matrix_major != "row"
         for operand in (lhs, rhs)
         if operand.is_leading_passthrough
     ):
@@ -2703,6 +2802,7 @@ class _CuteMmaNode(_CuteMmaTarget):
 
     operands: _MmaOperandAnalysis
     explicit_epi_tile_compatible: bool
+    output_column_major: bool
 
     @property
     def requires_scalar_fallback(self) -> bool:
@@ -2838,7 +2938,11 @@ def analyze_cute_mma_node(
     if not _mma_result_can_be_deferred(node) or not _mma_loop_is_exclusive(node):
         return None
     output_store_analysis: _MmaOutputStoreAnalysis | None = None
-    if operands.has_leading_passthrough:
+    needs_output_store_analysis = operands.has_leading_passthrough or (
+        operands.lhs.source_to_logical_order is not None
+        and operands.rhs.source_to_logical_order is not None
+    )
+    if needs_output_store_analysis:
         cached = node.meta.get(_MMA_OUTPUT_STORE_ANALYSIS_META_KEY)
         if isinstance(cached, _MmaOutputStoreAnalysis):
             output_store_analysis = cached
@@ -2908,13 +3012,18 @@ def analyze_cute_mma_node(
         out_dtype=target.out_dtype,
         operands=operands,
         explicit_epi_tile_compatible=(
-            _tcgen05_tma_matrix_major(operands.lhs.source_fake) == "row"
-            and _tcgen05_tma_matrix_major(operands.rhs.source_fake) in ("row", "col")
+            operands.lhs.matrix_major == "row"
+            and operands.rhs.matrix_major in ("row", "col")
             and (
                 output_store_analysis.explicit_epi_tile_compatible
                 if output_store_analysis is not None
                 else True
             )
+        ),
+        output_column_major=(
+            output_store_analysis.output_column_major
+            if output_store_analysis is not None
+            else False
         ),
         with_acc=target.with_acc,
         is_dot=target.is_dot,
@@ -4704,7 +4813,10 @@ def _analyze_packed_split_mma_output_store(
         or analyzed_stores[0][1].steps
     ):
         return None
-    return _MmaOutputStoreAnalysis(explicit_epi_tile_compatible=True)
+    return _MmaOutputStoreAnalysis(
+        explicit_epi_tile_compatible=True,
+        output_column_major=_tcgen05_tma_matrix_major(tensor_fake) == "col",
+    )
 
 
 def _analyze_mma_output_stores(
@@ -4720,6 +4832,7 @@ def _analyze_mma_output_stores(
         return None
     env = CompileEnvironment.current()
     explicit_epi_tile_compatible = True
+    output_column_major: bool | None = None
     for store, chain in analyzed_stores:
         tensor_node = store.args[0] if store.args else None
         tensor_fake = (
@@ -4741,8 +4854,17 @@ def _analyze_mma_output_stores(
             tensor_fake.dtype == analysis.lhs.source_fake.dtype
             and all(step.broadcast_axis == 1 for step in chain.auxiliary_tensor_steps)
         )
+        store_major = _tcgen05_tma_matrix_major(tensor_fake)
+        if store_major is None:
+            return None
+        store_column_major = store_major == "col"
+        if output_column_major is None:
+            output_column_major = store_column_major
+        elif output_column_major != store_column_major:
+            return None
     return _MmaOutputStoreAnalysis(
-        explicit_epi_tile_compatible=explicit_epi_tile_compatible
+        explicit_epi_tile_compatible=explicit_epi_tile_compatible,
+        output_column_major=bool(output_column_major),
     )
 
 
@@ -5109,6 +5231,9 @@ def _emit_mma_pipeline(
     rhs_node = candidate.rhs if candidate is not None else rhs_node
     if not isinstance(lhs_node, Node) or not isinstance(rhs_node, Node):
         return None
+    output_column_major = (
+        candidate.output_column_major if candidate is not None else False
+    )
 
     env = CompileEnvironment.current()
     requested_schedule = _requested_tcgen05_grouped_schedule(grouped_mode)
@@ -5439,8 +5564,8 @@ def _emit_mma_pipeline(
         torch.bfloat16,
         torch.float8_e4m3fn,
     )
-    _lhs_major = _tcgen05_tma_matrix_major(lhs_fake)
-    _rhs_major = _tcgen05_tma_matrix_major(rhs_fake)
+    _lhs_major = lhs_operand.matrix_major
+    _rhs_major = rhs_operand.matrix_major
     # A must be row-major (M,K) K-contiguous == "row"; the K-major A SMEM
     # layout Helion emits expects the standard row-major A. Only B's major
     # mode is made layout-aware here.
@@ -7359,7 +7484,7 @@ def _emit_mma_pipeline(
     tcgen05_explicit_d_store_box_n: int | None = None
     tcgen05_d_store_layout = (
         "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
-        if nm_worklist
+        if nm_worklist or output_column_major
         else "cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
     )
     nm_explicit_store_wave = False
@@ -9096,9 +9221,21 @@ def _emit_mma_pipeline(
                 if tcgen05_grouped_dynamic_ab_tensormap_rank == 2:
                     ab_tma_plan["dynamic_ab_tensormap_rank"] = 2
             if lhs_operand.is_leading_passthrough:
-                ab_tma_plan["lhs_leading_passthrough"] = True
+                ab_tma_plan["lhs_tma_order"] = (1, 2, 0)
+            elif lhs_operand.source_to_logical_order is not None:
+                # A TensorMaps use logical (M, K) order. Compose that order
+                # with the program's source-to-logical permutation.
+                ab_tma_plan["lhs_tma_order"] = _compose_axis_orders(
+                    lhs_operand.source_to_logical_order, (0, 1)
+                )
             if rhs_operand.is_leading_passthrough:
-                ab_tma_plan["rhs_leading_passthrough"] = True
+                ab_tma_plan["rhs_tma_order"] = (2, 1, 0)
+            elif rhs_operand.source_to_logical_order is not None:
+                # B TensorMaps use logical (N, K) order. For B=x.T, composing
+                # that swap with x's source-to-logical swap produces identity.
+                ab_tma_plan["rhs_tma_order"] = _compose_axis_orders(
+                    rhs_operand.source_to_logical_order, (1, 0)
+                )
             # ``smem_swizzle_*`` overrides are recorded only when codegen
             # selected an explicit SMEM atom kind (either from a user
             # override or the scalar-edge fallback workaround). Keeping
@@ -10524,6 +10661,7 @@ def _emit_mma_pipeline(
                 segment_store_row_index=segment_store_row_index,
                 segment_store_valid_m=segment_store_valid_m,
                 orientation=tcgen05_matmul_plan.orientation,
+                output_column_major=output_column_major,
             ),
         )
         if tcgen05_pure_matmul_object is not None:

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -179,6 +179,13 @@ class CuteTcgen05StoreValue(_CuteTcgen05OrientationMixin):
     segment_store_row_index: Node | None = None
     segment_store_valid_m: Node | None = None
     orientation: Tcgen05Orientation = Tcgen05Orientation.MN
+    output_column_major: bool = False
+
+    @property
+    def d_store_layout(self) -> str:
+        if self.output_column_major:
+            return "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
+        return super().d_store_layout
 
     def __post_init__(self) -> None:
         if self.pure_matmul_object is not None:

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -3140,6 +3140,8 @@ def _codegen_cute_store_tcgen05_tile(
         }
         if leading_passthrough_output:
             d_tma_plan["d_leading_passthrough"] = True
+        if tcgen05_value.output_column_major:
+            d_tma_plan["d_column_major"] = True
         state.codegen.cute_wrapper_plans.append(d_tma_plan)
         if d_tma_uses_tail_rank3_mnl_tensor:
             tail_d_tma_plan = {

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -234,6 +234,16 @@ def _append_cute_wrapper_plan(
         assert value is None or isinstance(value, str)
         return value
 
+    def plan_optional_order(key: str) -> tuple[int, ...] | None:
+        value = plan.get(key)
+        if value is None:
+            return None
+        assert isinstance(value, (list, tuple))
+        assert all(type(dim) is int for dim in value)
+        order = tuple(int(dim) for dim in value)
+        assert sorted(order) == list(range(len(order)))
+        return order
+
     def append_permuted_cute_tensor_view(
         name: str,
         arg_idx: int,
@@ -268,13 +278,14 @@ def _append_cute_wrapper_plan(
         tensor_name: str | None = None,
         rank3_mnl_tensor: bool = False,
         orientation: str = "mn",
+        column_major: bool = False,
     ) -> None:
         assert len(kernel_args) == 2
         assert orientation in ("mn", "nm")
         worklist_nm_store = orientation == "nm"
         d_store_layout = (
             "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
-            if worklist_nm_store
+            if worklist_nm_store or column_major
             else "cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
         )
         tensor_expr = tensor_name if tensor_name is not None else f"arg{tensor_idx}"
@@ -651,6 +662,7 @@ def _append_cute_wrapper_plan(
             tensor_name=d_tensor_name,
             rank3_mnl_tensor=bool(plan.get("rank3_mnl_tensor")),
             orientation=_tcgen05_plan_orientation(plan),
+            column_major=bool(plan.get("d_column_major")),
         )
         return
     if kind == "tcgen05_aux_tma":
@@ -751,8 +763,8 @@ def _append_cute_wrapper_plan(
     # K-major (column-major / K-contiguous) B. Absent on the MN-major
     # (row-major B) default path.
     b_k_major = bool(plan.get("b_k_major"))
-    lhs_leading_passthrough = bool(plan.get("lhs_leading_passthrough"))
-    rhs_leading_passthrough = bool(plan.get("rhs_leading_passthrough"))
+    lhs_tma_order = plan_optional_order("lhs_tma_order")
+    rhs_tma_order = plan_optional_order("rhs_tma_order")
     rhs_rank3_grouped_nt = bool(plan.get("rhs_rank3_grouped_nt"))
     lhs_rank3_grouped_nt = bool(plan.get("lhs_rank3_grouped_nt"))
     orientation = _tcgen05_plan_orientation(plan)
@@ -800,7 +812,7 @@ def _append_cute_wrapper_plan(
     lhs_tma = f"{tma_atom_a}_lhs_tma"
     lhs_tma_arg = (
         lhs_tma
-        if dynamic_ab_tensormaps or swapped_nm or lhs_leading_passthrough
+        if (dynamic_ab_tensormaps or swapped_nm or lhs_tma_order is not None)
         else f"arg{lhs_idx}"
     )
     rhs_tma = f"{tma_atom_b}_rhs_tma"
@@ -913,12 +925,12 @@ def _append_cute_wrapper_plan(
         swizzle_override=smem_swizzle_b,
         b_k_major=b_k_major,
     )
-    if lhs_leading_passthrough:
-        append_permuted_cute_tensor_view(lhs_tma, lhs_idx, (1, 2, 0))
-    if rhs_leading_passthrough:
-        append_permuted_cute_tensor_view(rhs_tma, rhs_idx, (2, 1, 0))
-    lhs_tma_setup_lines = () if lhs_leading_passthrough else lhs_tma_setup
-    rhs_tma_setup_lines = () if rhs_leading_passthrough else rhs_tma_setup
+    if lhs_tma_order is not None:
+        append_permuted_cute_tensor_view(lhs_tma, lhs_idx, lhs_tma_order)
+    if rhs_tma_order is not None:
+        append_permuted_cute_tensor_view(rhs_tma, rhs_idx, rhs_tma_order)
+    lhs_tma_setup_lines = () if lhs_tma_order is not None else lhs_tma_setup
+    rhs_tma_setup_lines = () if rhs_tma_order is not None else rhs_tma_setup
     body.extend(
         (
             (

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6016,8 +6016,8 @@ class TestCuteBackend(TestCase):
         self.assertIn("cutlass.utils.blackwell_helpers.make_trivial_tiled_mma", code)
         self.assertIn("cute.nvgpu.tcgen05", code)
         self.assertIn("cute.gemm(", code)
-        self.assertIn("'lhs_leading_passthrough': True", code)
-        self.assertIn("'rhs_leading_passthrough': True", code)
+        self.assertIn("'lhs_tma_order': (1, 2, 0)", code)
+        self.assertIn("'rhs_tma_order': (2, 1, 0)", code)
         self.assertIn("'d_leading_passthrough': True", code)
         self.assertIn("cpasync.tma_partition", code)
         self.assertIn("tcgen05_tma_store_atom", code)
@@ -6049,8 +6049,8 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.gemm(", code)
         self.assertIn("CtaGroup.TWO", code)
         self.assertIn("mcast_mask", code)
-        self.assertIn("'lhs_leading_passthrough': True", code)
-        self.assertIn("'rhs_leading_passthrough': True", code)
+        self.assertIn("'lhs_tma_order': (1, 2, 0)", code)
+        self.assertIn("'rhs_tma_order': (2, 1, 0)", code)
 
     def test_leading_matmul_accepts_explicit_deep_direct_entry_config(self) -> None:
         support = get_cute_mma_support()
@@ -6439,7 +6439,7 @@ class TestCuteBackend(TestCase):
                     torch.randn(4, 256, 64, device=DEVICE, dtype=HALF_DTYPE),
                     torch.randn(64, 256, device=DEVICE, dtype=HALF_DTYPE),
                 ),
-                "'lhs_leading_passthrough': True",
+                "'lhs_tma_order': (1, 2, 0)",
             ),
             (
                 cute_rhs_batched_dot_tcgen05,
@@ -6447,7 +6447,7 @@ class TestCuteBackend(TestCase):
                     torch.randn(256, 64, device=DEVICE, dtype=HALF_DTYPE),
                     torch.randn(4, 64, 256, device=DEVICE, dtype=HALF_DTYPE),
                 ),
-                "'rhs_leading_passthrough': True",
+                "'rhs_tma_order': (2, 1, 0)",
             ),
             (
                 cute_mixed_rank_batched_dot_tcgen05,
@@ -6455,7 +6455,7 @@ class TestCuteBackend(TestCase):
                     torch.randn(4, 256, 64, device=DEVICE, dtype=HALF_DTYPE),
                     torch.randn(256, 64, device=DEVICE, dtype=HALF_DTYPE).T,
                 ),
-                "'lhs_leading_passthrough': True",
+                "'lhs_tma_order': (1, 2, 0)",
             ),
         )
         with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):

--- a/test/test_cute_device_state.py
+++ b/test/test_cute_device_state.py
@@ -19,6 +19,7 @@ from helion._compiler.cute.cutedsl_compat import emit_pipeline_advance
 from helion._compiler.cute.device_state import CuteDeviceFunctionState
 from helion._compiler.cute.device_state import CuteTcgen05MatmulPlan
 from helion._compiler.cute.device_state import CuteTcgen05StoreValue
+from helion._compiler.cute.device_state import Tcgen05Orientation
 from helion._compiler.cute.tcgen05_lifecycle import Tcgen05LifecycleContext
 from helion._compiler.cute.tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 from helion._compiler.cute.tcgen05_pure_matmul import Tcgen05TmaStoreBodyCoreParams
@@ -150,6 +151,26 @@ class _StatementCaptureGenerateAST(GenerateAST):
 
 @onlyBackends(["cute"])
 class TestCuteDeviceFunctionState(unittest.TestCase):
+    def test_tcgen05_store_value_d_store_layout_uses_output_layout(self) -> None:
+        value = CuteTcgen05StoreValue(
+            lifecycle_context=_lifecycle(), output_block_ids=(0, 1)
+        )
+
+        self.assertEqual(
+            value.d_store_layout,
+            "cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+        )
+        self.assertEqual(
+            dataclasses.replace(value, output_column_major=True).d_store_layout,
+            "cutlass.utils.layout.LayoutEnum.COL_MAJOR",
+        )
+        self.assertEqual(
+            dataclasses.replace(
+                value, orientation=Tcgen05Orientation.NM
+            ).d_store_layout,
+            "cutlass.utils.layout.LayoutEnum.COL_MAJOR",
+        )
+
     def test_get_tcgen05_store_value_checks_candidate_names(self) -> None:
         state = CuteDeviceFunctionState()
         value = CuteTcgen05StoreValue(

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -53,6 +53,7 @@ from helion._compiler.cute.cute_mma import _build_kloop_pipeline_release_if
 from helion._compiler.cute.cute_mma import _build_tcgen05_mma_accumulate_reset_stmt
 from helion._compiler.cute.cute_mma import _build_tcgen05_mma_issue_stmt
 from helion._compiler.cute.cute_mma import _choose_mma_impl
+from helion._compiler.cute.cute_mma import _compose_axis_orders
 from helion._compiler.cute.cute_mma import _decode_cute_mma_target
 from helion._compiler.cute.cute_mma import _emit_sched_pipeline_setup
 from helion._compiler.cute.cute_mma import _get_mma_k_loop_info
@@ -62,9 +63,11 @@ from helion._compiler.cute.cute_mma import _make_tcgen05_layout_plan_setup
 from helion._compiler.cute.cute_mma import _mma_epi_tidx_expr
 from helion._compiler.cute.cute_mma import _mma_loop_is_exclusive
 from helion._compiler.cute.cute_mma import _mma_result_can_be_deferred
+from helion._compiler.cute.cute_mma import _MmaOperandInfo
 from helion._compiler.cute.cute_mma import _MmaRoleCoordinatePlan
 from helion._compiler.cute.cute_mma import _new_tcgen05_layout_plan
 from helion._compiler.cute.cute_mma import _new_tcgen05_sched_pipeline_plan
+from helion._compiler.cute.cute_mma import _operand_infos_exclusive_for_mma
 from helion._compiler.cute.cute_mma import _PerKiterTmaArgs
 from helion._compiler.cute.cute_mma import _tcgen05_ab_stage_count
 from helion._compiler.cute.cute_mma import _tcgen05_epi_warp_count
@@ -72,6 +75,7 @@ from helion._compiler.cute.cute_mma import _tcgen05_explicit_epilogue_tile_suppo
 from helion._compiler.cute.cute_mma import _tcgen05_root_m_threads
 from helion._compiler.cute.cute_mma import _tcgen05_tmem_barrier_thread_count
 from helion._compiler.cute.cute_mma import _trace_mma_to_store_dtype
+from helion._compiler.cute.cute_mma import _unwrap_mma_operand_permute
 from helion._compiler.cute.cute_reshape import _get_dim_local_coord
 from helion._compiler.cute.cute_reshape import codegen_cute_permute
 from helion._compiler.cute.cute_reshape import codegen_cute_reshape
@@ -633,6 +637,107 @@ class TestCuteLowerings(unittest.TestCase):
                         ),
                         expected,
                     )
+
+    def test_mma_operand_matrix_major_tracks_source_order(self) -> None:
+        graph = Graph()
+        load = graph.placeholder("load")
+        row_major = torch.empty_strided((4, 8), (8, 1))
+
+        direct = _MmaOperandInfo(
+            load=load,
+            terminal=load,
+            source_fake=row_major,
+            logical_fake=row_major,
+            block_ids=(0, 1),
+        )
+        transposed = dataclasses.replace(
+            direct,
+            logical_fake=row_major.permute(1, 0),
+            block_ids=(1, 0),
+            source_to_logical_order=(1, 0),
+        )
+
+        self.assertEqual(direct.matrix_major, "row")
+        self.assertEqual(transposed.matrix_major, "col")
+        self.assertEqual((transposed.matrix_rows, transposed.matrix_cols), (8, 4))
+
+        padded_row_major = torch.empty_strided((4, 8), (16, 1))
+        self.assertEqual(
+            dataclasses.replace(
+                direct,
+                source_fake=padded_row_major,
+                logical_fake=padded_row_major.permute(1, 0),
+                block_ids=(1, 0),
+                source_to_logical_order=(1, 0),
+            ).matrix_major,
+            "col",
+        )
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "logical_fake shape does not match.*logical order is likely "
+            "incorrect.*report a bug to the Helion maintainers",
+        ):
+            dataclasses.replace(
+                direct,
+                source_to_logical_order=(1, 0),
+            )
+
+    def test_unwrap_mma_operand_permute(self) -> None:
+        graph = Graph()
+        load = graph.placeholder("load")
+        transpose = graph.call_function(torch.ops.aten.permute.default, (load, (1, 0)))
+        transpose.meta["val"] = torch.empty(4, 8).mT
+        unsupported = graph.call_function(
+            torch.ops.aten.permute.default, (load, (0, 1))
+        )
+        unsupported.meta["val"] = torch.empty(4, 8)
+
+        self.assertEqual(_unwrap_mma_operand_permute(load), (load, None))
+        self.assertEqual(_unwrap_mma_operand_permute(transpose), (load, (1, 0)))
+        self.assertIsNone(_unwrap_mma_operand_permute(unsupported))
+
+    def test_mma_source_and_tma_orders_are_composed(self) -> None:
+        source_transpose = (1, 0)
+
+        self.assertEqual(
+            _compose_axis_orders(source_transpose, (0, 1)),
+            (1, 0),
+        )
+        self.assertEqual(
+            _compose_axis_orders(source_transpose, (1, 0)),
+            (0, 1),
+        )
+
+    def test_mma_operand_exclusivity_tracks_source_order(self) -> None:
+        graph = Graph()
+        lhs_load = graph.placeholder("lhs_load")
+        rhs_load = graph.placeholder("rhs_load")
+        lhs_transpose = graph.call_function(
+            torch.ops.aten.permute.default, (lhs_load, (1, 0))
+        )
+        rhs_transpose = graph.call_function(
+            torch.ops.aten.permute.default, (rhs_load, (1, 0))
+        )
+        mma = graph.call_function(
+            torch.ops.aten.mm.default, (lhs_transpose, rhs_transpose)
+        )
+        source = torch.empty(4, 8)
+        lhs = _MmaOperandInfo(
+            load=lhs_load,
+            terminal=lhs_transpose,
+            source_fake=source,
+            logical_fake=source.mT,
+            source_to_logical_order=(1, 0),
+        )
+        rhs = dataclasses.replace(lhs, load=rhs_load, terminal=rhs_transpose)
+
+        self.assertTrue(_operand_infos_exclusive_for_mma(lhs, rhs, mma))
+        self.assertFalse(
+            _operand_infos_exclusive_for_mma(
+                dataclasses.replace(lhs, terminal=lhs_load), rhs, mma
+            )
+        )
 
     def _argreduce_ctx(self, inp: torch.fx.Node) -> object:
         return SimpleNamespace(
@@ -11275,6 +11380,84 @@ class TestCuteLowerings(unittest.TestCase):
         self.assertIn("cutlass.Float16, 1)", emitted)
         self.assertEqual(
             call_args, ["tma_atom_a", "tma_tensor_a", "tma_atom_b", "tma_tensor_b"]
+        )
+
+    def test_tcgen05_ab_tma_wrapper_plan_uses_explicit_orders(self) -> None:
+        body: list[str] = []
+        call_args: list[str] = []
+        _append_cute_wrapper_plan(
+            body,
+            call_args,
+            {
+                "kind": "tcgen05_ab_tma",
+                "lhs_idx": 0,
+                "rhs_idx": 1,
+                "lhs_tma_order": (1, 0),
+                "rhs_tma_order": (0, 1),
+                "bm": 64,
+                "bn": 16,
+                "bk": 256,
+                "ab_stage_count": 2,
+                "input_dtype": "cutlass.Float8E4M3FN",
+                "acc_dtype": "cutlass.Float32",
+                "kernel_args": [
+                    "tma_atom_a",
+                    "tma_tensor_a",
+                    "tma_atom_b",
+                    "tma_tensor_b",
+                ],
+            },
+        )
+        emitted = "\n".join(body)
+        self.assertIn(
+            "tma_atom_a_lhs_tma = cute.make_tensor(arg0.iterator, "
+            "layout=cute.make_layout((arg0_shape1, arg0_shape0), "
+            "stride=(arg0_stride1, arg0_stride0)))",
+            emitted,
+        )
+        self.assertIn(
+            "tma_atom_b_rhs_tma = cute.make_tensor(arg1.iterator, "
+            "layout=cute.make_layout((arg1_shape0, arg1_shape1), "
+            "stride=(arg1_stride0, arg1_stride1)))",
+            emitted,
+        )
+
+    def test_tcgen05_ab_tma_wrapper_plan_uses_rank3_orders(self) -> None:
+        body: list[str] = []
+        call_args: list[str] = []
+        _append_cute_wrapper_plan(
+            body,
+            call_args,
+            {
+                "kind": "tcgen05_ab_tma",
+                "lhs_idx": 0,
+                "rhs_idx": 1,
+                "lhs_tma_order": (1, 2, 0),
+                "rhs_tma_order": (2, 1, 0),
+                "bm": 64,
+                "bn": 16,
+                "bk": 32,
+                "ab_stage_count": 2,
+                "input_dtype": "cutlass.Float16",
+                "acc_dtype": "cutlass.Float32",
+                "kernel_args": [
+                    "tma_atom_a",
+                    "tma_tensor_a",
+                    "tma_atom_b",
+                    "tma_tensor_b",
+                ],
+            },
+        )
+        emitted = "\n".join(body)
+        self.assertIn(
+            "layout=cute.make_layout((arg0_shape1, arg0_shape2, arg0_shape0), "
+            "stride=(arg0_stride1, arg0_stride2, arg0_stride0))",
+            emitted,
+        )
+        self.assertIn(
+            "layout=cute.make_layout((arg1_shape2, arg1_shape1, arg1_shape0), "
+            "stride=(arg1_stride2, arg1_stride1, arg1_stride0))",
+            emitted,
         )
 
     def test_tcgen05_wide_codegen_uses_dense_physical_participant_ids(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3308
 * #3307
 * __->__#3306


--- --- ---

### [cute] Support trailing-transposed tcgen05 matmul


Recognize collective MMA operands that load a full tile and then swap the two trailing matrix axes. Record the source-to-logical axis order, compose it with CuTe A/B TensorMap conventions, and build the descriptor from the original source tensor without materializing the transpose.

Propagate column-major output requirements through the tcgen05 store value so swapped output layouts select the correct D-store layout. The launcher receives explicit TensorMap orders and remains agnostic to how compiler analysis derived them.

Coverage includes operand analysis and permutation invariants, TensorMap order generation, tcgen05 selection, column-major store layout, and end-to-end swapped codegen/runtime.

Full-stack B200 performance with the following persistent-small-N and scale_mm config commits (CUDA graphs, cold L2, 16 new shapes):
- vs the preserved pre-refactor implementation: 1.0004x geomean (0.46% mean absolute delta; noise)
- vs torch._scaled_mm: 1.370x geomean, 16/16 wins, best 1.56x
- vs vLLM CUTLASS: 0.920x geomean, 0/16 wins, best 0.98x
