### PR TITLE
[cute] Use SIMT stores for narrow tcgen05 outputs

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -6384,6 +6384,10 @@ def _emit_mma_pipeline(
         or tcgen05_role_local_n_edge_tma
         or tcgen05_role_local_double_edge_tma
     ) and tcgen05_output_edge_tma_store_fits_smem
+    store_outer_extent = bn if output_column_major else bm
+    prefer_simt_narrow_store = (
+        input_dtype == torch.float8_e4m3fn and store_outer_extent < 32
+    )
     # Flat kernels process one output tile per CTA, so the c_pipeline stage is
     # just the subtile index. Persistent kernels use a role-local tile counter
     # to rotate c_pipeline stages across work tiles. Static-full CtaGroup.TWO
@@ -6395,6 +6399,7 @@ def _emit_mma_pipeline(
     tcgen05_use_tma_store_epilogue = (
         mma_impl == "tcgen05"
         and tcgen05_use_tma_pipeline
+        and not prefer_simt_narrow_store
         and (
             tcgen05_static_full_tiles
             or tcgen05_grouped_worklist_static_full_tiles

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -3424,9 +3424,19 @@ def _codegen_cute_store_tcgen05_tile(
             )
         return static_setup, tile_setup
 
+    # A hybrid TMA/SIMT epilogue reaches SIMT only for edge tiles. A static
+    # output smaller than its selected tile also cannot produce a full tile,
+    # independent of whether its storage is row-major or column-major.
     simt_edge_only = (
         tcgen05_value.tma_store_full_tiles_only
         and not grouped_dynamic_d_tensormap_edge_only
+    )
+    static_m_size = tensor.shape[-2]
+    static_n_size = tensor.shape[-1]
+    simt_edge_only = simt_edge_only or (
+        isinstance(static_m_size, int)
+        and isinstance(static_n_size, int)
+        and (static_m_size < tcgen05_value.bm or static_n_size < tcgen05_value.bn)
     )
     simt_edge_aux_atoms: dict[int, str] = {}
     simt_edge_aux_atom_setup: list[str] = []


### PR DESCRIPTION
Stacked PRs:
 * #3308
 * #3307
 * #3311
 * __->__#3310


--- --- ---

### [cute] Use SIMT stores for narrow tcgen05 outputs


Choose the direct SIMT D-store epilogue for narrow FP8 output tiles. Define the outer store extent from the output orientation: BN counts column vectors for column-major output, while BM counts row vectors for row-major output. When that extent is below 32, bypass shared-memory staging and the TMA-store pipeline; wider tiles remain eligible for bulk asynchronous stores.

Generalize edge-only SIMT code generation to every statically shaped output whose logical M is smaller than BM or whose logical N is smaller than BN. Such an output cannot contain a full tile along that dimension, so omit the unreachable full-tile SIMT branch and always emit the predicated logical-divide copy, independent of output major order. The existing TMA-full/SIMT-edge hybrid and grouped dynamic-D TensorMap policies remain unchanged.

For swapped small-M scale_mm, M=2 and M=8 use predicated BN=16 edge stores, M=16 uses a full but narrow BN=16 direct SIMT store, and M=32 uses BN=32 and remains eligible for the TMA-store epilogue.

B200 performance versus the same stack with this commit reverted (CUDA graphs, cold L2, 200 repetitions across 16 shapes):

- overall: 1.0141x geomean
- M=2: 1.0407x geomean (3.0-4.8% individual gains)
- M=8: 1.0048x geomean
- M=16: 1.0121x geomean
- M=32: 0.9993x geomean (noise; BN=32 retains TMA)
