### PR TITLE
[cute] Harden role-local N-edge TMA lowering

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -6384,6 +6384,10 @@ def _emit_mma_pipeline(
         or tcgen05_role_local_n_edge_tma
         or tcgen05_role_local_double_edge_tma
     ) and tcgen05_output_edge_tma_store_fits_smem
+    store_outer_extent = bn if output_column_major else bm
+    prefer_simt_narrow_store = (
+        input_dtype == torch.float8_e4m3fn and store_outer_extent < 32
+    )
     # Flat kernels process one output tile per CTA, so the c_pipeline stage is
     # just the subtile index. Persistent kernels use a role-local tile counter
     # to rotate c_pipeline stages across work tiles. Static-full CtaGroup.TWO
@@ -6395,6 +6399,7 @@ def _emit_mma_pipeline(
     tcgen05_use_tma_store_epilogue = (
         mma_impl == "tcgen05"
         and tcgen05_use_tma_pipeline
+        and not prefer_simt_narrow_store
         and (
             tcgen05_static_full_tiles
             or tcgen05_grouped_worklist_static_full_tiles

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -6050,12 +6050,16 @@ def _emit_mma_pipeline(
         mma_impl == "tcgen05"
         and tcgen05_use_tma_pipeline
         and tcgen05_pid_is_persistent
-        and tcgen05_cluster_m == 2
         and tcgen05_cluster_n_requested == 1
-        and tcgen05_requested_two_cta
         and m_size % bm == 0
         and n_size % bn != 0
         and k_total_size % bk == 0
+        # Both supported tcgen05 CTA protocols can consume a general N
+        # remainder through the role-local TMA producer.
+        and (
+            (tcgen05_cluster_m == 2 and tcgen05_requested_two_cta)
+            or tcgen05_cluster_m == 1
+        )
     )
     if (
         mma_impl == "tcgen05"
@@ -6140,9 +6144,7 @@ def _emit_mma_pipeline(
     tcgen05_role_local_m_edge_tma = (
         tcgen05_m_edge_only and tcgen05_is_two_cta and tcgen05_cluster_n == 1
     )
-    tcgen05_role_local_n_edge_tma = (
-        tcgen05_n_edge_only and tcgen05_is_two_cta and tcgen05_cluster_n == 1
-    )
+    tcgen05_role_local_n_edge_tma = tcgen05_n_edge_only and tcgen05_cluster_n == 1
     tcgen05_role_local_double_edge_tma = (
         tcgen05_double_edge_tma and tcgen05_is_two_cta and tcgen05_cluster_n == 1
     )
@@ -6379,9 +6381,16 @@ def _emit_mma_pipeline(
     tcgen05_output_edge_tma_store_fits_smem = (
         tcgen05_ab_stage_count_value <= TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
     )
+    # ``tcgen05_is_two_cta`` below gates only the hybrid output-store protocol,
+    # not role-local edge-TMA input loading. The mixed full-tile TMA-store plus
+    # edge SIMT-store epilogue is validated for CtaGroup.TWO; enabling its
+    # conditional store-pipeline state and tile counters for one CTA currently
+    # produces IR that NVVM rejects. One-CTA N-edge kernels therefore keep the
+    # predicated SIMT epilogue for every tile. This is an implementation
+    # boundary, not a tcgen05 hardware requirement.
     tcgen05_use_output_edge_tma_store_for_full_tiles = (
         tcgen05_role_local_m_edge_tma
-        or tcgen05_role_local_n_edge_tma
+        or (tcgen05_role_local_n_edge_tma and tcgen05_is_two_cta and n_size >= bn)
         or tcgen05_role_local_double_edge_tma
     ) and tcgen05_output_edge_tma_store_fits_smem
     store_outer_extent = bn if output_column_major else bm

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -5580,6 +5580,12 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             "cutlass.Float8E4M3FN",
             "cutlass.Int32",
             "cutlass.Int64",
+            "cutlass.Uint8",
+            # Scalar fallback loads left behind after all work-producing
+            # statements move into role-local tcgen05 loops are side-effect
+            # free. They may be discarded when none of their results feed
+            # post-loop cleanup; stores and pipeline operations remain unsafe.
+            "cute.arch.load",
         }
     )
 
@@ -5593,6 +5599,19 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 return None
             return f"{base}.{func.attr}"
         return None
+
+    @staticmethod
+    def _tcgen05_is_iterator_load(expr: ast.Call) -> bool:
+        return (
+            isinstance(expr.func, ast.Attribute)
+            and expr.func.attr == "load"
+            and not expr.args
+            and not expr.keywords
+            and any(
+                isinstance(node, ast.Attribute) and node.attr == "iterator"
+                for node in ast.walk(expr.func.value)
+            )
+        )
 
     @classmethod
     def _tcgen05_expr_safe_to_omit(cls, expr: ast.AST) -> bool:
@@ -5638,6 +5657,14 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 for part in (expr.lower, expr.upper, expr.step)
             )
         if isinstance(expr, ast.Call):
+            # Generated scalar fallback loads can appear either as the
+            # canonical ``cute.arch.load(...)`` helper or as a zero-argument
+            # ``iterator.load()`` method call. Both are side-effect free; the
+            # surrounding residual-body and post-loop dependency checks still
+            # retain the shared loop whenever the loaded value is observed.
+            if cls._tcgen05_is_iterator_load(expr):
+                assert isinstance(expr.func, ast.Attribute)
+                return cls._tcgen05_expr_safe_to_omit(expr.func.value)
             call_path = cls._tcgen05_call_path(expr.func)
             if call_path in {"max", "min"} and expr.keywords:
                 return False

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -3424,9 +3424,19 @@ def _codegen_cute_store_tcgen05_tile(
             )
         return static_setup, tile_setup
 
+    # A hybrid TMA/SIMT epilogue reaches SIMT only for edge tiles. A static
+    # output smaller than its selected tile also cannot produce a full tile,
+    # independent of whether its storage is row-major or column-major.
     simt_edge_only = (
         tcgen05_value.tma_store_full_tiles_only
         and not grouped_dynamic_d_tensormap_edge_only
+    )
+    static_m_size = tensor.shape[-2]
+    static_n_size = tensor.shape[-1]
+    simt_edge_only = simt_edge_only or (
+        isinstance(static_m_size, int)
+        and isinstance(static_n_size, int)
+        and (static_m_size < tcgen05_value.bm or static_n_size < tcgen05_value.bn)
     )
     simt_edge_aux_atoms: dict[int, str] = {}
     simt_edge_aux_atom_setup: list[str] = []

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -1,5 +1,5 @@
 """
-Auto-generated heuristic for kernels: scale_mm_cute, scale_mm_cute_skinny_m
+Auto-generated heuristic for kernels: scale_mm_cute, scale_mm_cute_skinny_m, scale_mm_cute_swap_ab
 Backend: explicit per-shape table (exact (M, K, N) -> tuned config)
 
 RowWise-scaled FP8 GEMM pretuned on NVIDIA B200 (sm100) for the Helion CuTe
@@ -35,6 +35,7 @@ Provides, for each kernel <k>:
 """
 
 import math
+from typing import Any
 
 import torch
 
@@ -81,6 +82,64 @@ def key_scale_mm_cute_skinny_m(*args) -> int:
 def autotune_scale_mm_cute_skinny_m(*args) -> dict:
     """Config dict for the given args."""
     return _CONFIGS_scale_mm_cute_skinny_m[key_scale_mm_cute_skinny_m(*args)]
+
+
+# === Kernel: scale_mm_cute_swap_ab ===
+_SMALL_M_SWAP_KEYS = [
+    (m, k, n)
+    for m in (2, 8, 16, 32)
+    for k, n in (
+        (4096, 4096),
+        (4096, 256),
+        (2048, 4096),
+        (4096, 6144),
+    )
+]
+
+
+def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
+    if m == 32:
+        block_sizes = [64, 32, 128]
+        ab_stages = 12
+        acc_stages = 1
+    else:
+        block_sizes = [64, 16, 256]
+        ab_stages = 7 if k == 2048 else 9
+        acc_stages = 1
+    pid_type = (
+        "persistent_interleaved"
+        if (m, k, n) == (2, 4096, 256)
+        else "persistent_blocked"
+    )
+    return {
+        "block_sizes": block_sizes,
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": pid_type,
+        "tcgen05_cluster_m": 1,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": ab_stages,
+        "tcgen05_acc_stages": acc_stages,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 1,
+        "tcgen05_persistence_model": "static_persistent",
+    }
+
+
+_KEYS_scale_mm_cute_swap_ab = _SMALL_M_SWAP_KEYS
+
+_CONFIGS_scale_mm_cute_swap_ab = [
+    _small_m_swap_config(*key) for key in _SMALL_M_SWAP_KEYS
+]
+
+
+def key_scale_mm_cute_swap_ab(*args) -> int:
+    return _select(_KEYS_scale_mm_cute_swap_ab, _mkn(args))
+
+
+def autotune_scale_mm_cute_swap_ab(*args) -> dict:
+    return _CONFIGS_scale_mm_cute_swap_ab[key_scale_mm_cute_swap_ab(*args)]
 
 
 # === Kernel: scale_mm_cute ===

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -8,13 +8,15 @@ The kernel is ported from https://github.com/pytorch/helion/pull/2788/
 pretuned for the skinny-M (decode / small-batch) and small decoder-layer FP8
 W8A8 serving shapes that back the nightly B200 CuTe benchmark dashboard.
 
-Two kernels ship:
+Specialized kernels include:
 
 * :func:`scale_mm_cute` tiles over both M and N.
 * :func:`scale_mm_cute_skinny_m` keeps the full (small) M resident and tiles
-  only over N, which the CuTe backend runs faster for tiny M.
+  only over N for single-token decode.
+* :func:`scale_mm_cute_swap_ab` swaps M/N so M=2/8/16/32 can use efficient
+  Blackwell tensor-core tiles.
 
-:func:`_scale_mm_cute` dispatches to the skinny-M kernel when ``M <= 1``.
+:func:`_scale_mm_cute` dispatches each pretuned shape to its specialized kernel.
 """
 
 from __future__ import annotations
@@ -26,8 +28,19 @@ import torch
 import helion
 import helion.language as hl
 
-# M at or below this uses the skinny-M kernel (mirrors examples/fp8_gemm.py).
+# Only single-token decode uses the scalar skinny-M kernel. Wider small-M
+# shapes use the swapped tensor-core kernel below.
 _SKINNY_M_MAX = 1
+_SWAP_AB_SHAPES = {
+    (m, k, n)
+    for m in (2, 8, 16, 32)
+    for k, n in (
+        (4096, 4096),
+        (4096, 256),
+        (2048, 4096),
+        (4096, 6144),
+    )
+}
 
 
 @helion.aot_kernel(backend="cute", static_shapes=True)
@@ -78,15 +91,47 @@ def scale_mm_cute_skinny_m(
     return out
 
 
+@helion.aot_kernel(backend="cute", static_shapes=True)
+def scale_mm_cute_swap_ab(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """Small-M FP8 GEMM with M/N swapped for efficient tensor-core tiles."""
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    out_t = out.T
+    scale_a_t = scale_a.unsqueeze(0)
+    scale_b_t = scale_b.unsqueeze(-1).expand(n, m)
+    for tile_n, tile_m in hl.tile([n, m]):
+        acc = hl.zeros([tile_n, tile_m], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(
+                y[tile_k, tile_n].T,
+                x[tile_m, tile_k].T,
+                acc=acc,
+            )
+        out_t[tile_n, tile_m] = (
+            acc * scale_a_t[tile_n, tile_m] * scale_b_t[tile_n, tile_m]
+        ).to(torch.bfloat16)
+    return out
+
+
 def _scale_mm_cute(
     x: torch.Tensor,
     y: torch.Tensor,
     scale_a: torch.Tensor,
     scale_b: torch.Tensor,
 ) -> torch.Tensor:
-    """Dispatch to the skinny-M kernel for small M, else the [M, N]-tiled one."""
+    """Dispatch each pretuned shape to its specialized CuTe kernel."""
     if x.size(0) <= _SKINNY_M_MAX:
         return scale_mm_cute_skinny_m(x, y, scale_a, scale_b)
+    shape = (x.size(0), x.size(1), y.size(1))
+    if shape in _SWAP_AB_SHAPES:
+        return scale_mm_cute_swap_ab(x, y, scale_a[:, 0], scale_b)
     return scale_mm_cute(x, y, scale_a, scale_b)
 
 

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -10653,45 +10653,122 @@ class TestCuteLowerings(unittest.TestCase):
                 ).to(x.dtype)
             return out
 
-        torch.manual_seed(0)
-        args = (
-            torch.randn(256, 128, device=DEVICE, dtype=torch.bfloat16),
-            torch.randn(128, 384, device=DEVICE, dtype=torch.bfloat16),
-            torch.randn(384, device=DEVICE, dtype=torch.bfloat16),
-            torch.randn(256, 384, device=DEVICE, dtype=torch.bfloat16),
-        )
         from helion._compiler.program_id import Tcgen05PersistentProgramIDs
 
-        with patch_cute_mma_support():
-            bound = cute_matmul_cluster_m2_two_cta_n_edge.bind(args)
-            bound.env.config_spec.cute_tcgen05_search_enabled = True
-            cfg = _make_tcgen05_persistent_config(
-                block_sizes=[256, 256, 128],
-                pid_type="persistent_interleaved",
-                tcgen05_cluster_m=2,
-                tcgen05_ab_stages=3,
-                tcgen05_acc_stages=1,
-                tcgen05_c_stages=4,
-                num_warps=4,
-            )
-            bound.set_config(cfg)
-            code = bound.to_triton_code(cfg)
-            self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
-            self.assertIn("PipelineTmaUmma.create", code)
-            self.assertNotIn("PipelineTmaStore.create", code)
-            self.assertIn(
-                "while tcgen05_role_local_0_work_tile.is_valid_tile",
-                code,
-            )
-            self.assertIn("tile_offset_1 < cutlass.Int32(384)", code)
-            total_var = Tcgen05PersistentProgramIDs._MULTI_TILE_GUARD_TOTAL_VAR
-            self.assertNotIn(total_var, code)
-            out = bound(*args)
-        expected = torch.nn.functional.gelu(
-            1.25 * (args[0] @ args[1]).float() + 0.5 * args[3] + args[2],
-            approximate="tanh",
-        ).to(args[0].dtype)
-        torch.testing.assert_close(out, expected, atol=3e-1, rtol=2e-2)
+        for n, expect_tma_store in ((128, False), (384, True)):
+            with self.subTest(n=n):
+                torch.manual_seed(0)
+                args = (
+                    torch.randn(256, 128, device=DEVICE, dtype=torch.bfloat16),
+                    torch.randn(128, n, device=DEVICE, dtype=torch.bfloat16),
+                    torch.randn(n, device=DEVICE, dtype=torch.bfloat16),
+                    torch.randn(256, n, device=DEVICE, dtype=torch.bfloat16),
+                )
+                with patch_cute_mma_support():
+                    bound = cute_matmul_cluster_m2_two_cta_n_edge.bind(args)
+                    bound.env.config_spec.cute_tcgen05_search_enabled = True
+                    cfg = _make_tcgen05_persistent_config(
+                        block_sizes=[256, 256, 128],
+                        pid_type="persistent_interleaved",
+                        tcgen05_cluster_m=2,
+                        tcgen05_ab_stages=2,
+                        tcgen05_acc_stages=1,
+                        tcgen05_c_stages=4,
+                        num_warps=4,
+                    )
+                    bound.set_config(cfg)
+                    code = bound.to_triton_code(cfg)
+                    self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
+                    self.assertIn("PipelineTmaUmma.create", code)
+                    if expect_tma_store:
+                        self.assertIn("PipelineTmaStore.create", code)
+                    else:
+                        self.assertNotIn("PipelineTmaStore.create", code)
+                    self.assertIn(
+                        "while tcgen05_role_local_0_work_tile.is_valid_tile",
+                        code,
+                    )
+                    self.assertIn(f"tile_offset_1 < cutlass.Int32({n})", code)
+                    total_var = Tcgen05PersistentProgramIDs._MULTI_TILE_GUARD_TOTAL_VAR
+                    self.assertNotIn(total_var, code)
+                    out = bound(*args)
+                expected = torch.nn.functional.gelu(
+                    1.25 * (args[0] @ args[1]).float() + 0.5 * args[3] + args[2],
+                    approximate="tanh",
+                ).to(args[0].dtype)
+                torch.testing.assert_close(out, expected, atol=3e-1, rtol=2e-2)
+
+    def test_tcgen05_persistent_one_cta_n_edge_rhs_layouts(self) -> None:
+        """One-CTA role-local TMA handles general N edges for both RHS views."""
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def direct_rhs(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        @helion.kernel(backend="cute")
+        def transposed_rhs(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            n, _ = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(
+                        acc,
+                        x[tile_m, tile_k],
+                        y[tile_n, tile_k].T,
+                    )
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        config = _make_tcgen05_persistent_config(
+            block_sizes=[128, 256, 128],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=1,
+            tcgen05_c_stages=4,
+            num_warps=4,
+        )
+        for n in (128, 384):
+            for name, kernel in (
+                ("direct", direct_rhs),
+                ("transposed", transposed_rhs),
+            ):
+                with self.subTest(n=n, rhs=name):
+                    torch.manual_seed(0)
+                    x = torch.randn(256, 128, device=DEVICE, dtype=torch.bfloat16)
+                    logical_y = torch.randn(128, n, device=DEVICE, dtype=torch.bfloat16)
+                    y = logical_y if name == "direct" else logical_y.T.contiguous()
+                    with patch_cute_mma_support():
+                        bound = kernel.bind((x, y))
+                        bound.env.config_spec.cute_tcgen05_search_enabled = True
+                        bound.set_config(config)
+                        code = bound.to_triton_code(config)
+                        self.assertIn("PipelineTmaUmma.create", code)
+                        self.assertIn("while tcgen05_role_local", code)
+                        self.assertNotIn("while tcgen05_work_tile_valid", code)
+                        self.assertNotIn("PipelineTmaStore.create", code)
+                        actual = bound(x, y)
+                    torch.testing.assert_close(
+                        actual,
+                        x @ logical_y,
+                        atol=2e-1,
+                        rtol=1e-2,
+                    )
 
     def test_tcgen05_persistent_cluster_m2_two_cta_double_edge_runtime_correctness(
         self,
@@ -18827,13 +18904,28 @@ class TestPersistentLoopSplitter(unittest.TestCase):
                 partition, [self._stmt("final_state += 1")]
             )
 
-        observable_partition = Tcgen05PersistentProgramIDs._PartitionedRoleBody(
+        scalar_load_partition = Tcgen05PersistentProgramIDs._PartitionedRoleBody(
             role_blocks_inline=[],
             role_blocks_extracted=[],
             shared_body_extracted=[self._stmt("value = tensor.iterator.load()")],
         )
+        self.assertFalse(
+            splitter._tcgen05_shared_loop_has_meaningful_work(scalar_load_partition, [])
+        )
         self.assertTrue(
-            splitter._tcgen05_shared_loop_has_meaningful_work(observable_partition, [])
+            splitter._tcgen05_shared_loop_has_meaningful_work(
+                scalar_load_partition, [self._stmt("cleanup(value)")]
+            )
+        )
+        stateful_load_partition = Tcgen05PersistentProgramIDs._PartitionedRoleBody(
+            role_blocks_inline=[],
+            role_blocks_extracted=[],
+            shared_body_extracted=[self._stmt("value = state.load()")],
+        )
+        self.assertTrue(
+            splitter._tcgen05_shared_loop_has_meaningful_work(
+                stateful_load_partition, []
+            )
         )
 
     def _make_role_local_stubs(self, *, num_pid_dims: int = 2) -> tuple[object, object]:


### PR DESCRIPTION
Stacked PRs:
 * #3308
 * #3307
 * __->__#3311
 * #3310


--- --- ---

### [cute] Harden role-local N-edge TMA lowering


Generalize persistent one-CTA tcgen05 N-edge lowering beyond the original
swapped small-N scale_mm shape. Direct and trailing-transposed RHS layouts now
use the role-local TMA producer for either a single partial N tile or full N
tiles followed by a partial tile. CtaGroup.TWO retains its existing general
N-edge support.

TMA supplies full and partial A/B tiles while TensorMap bounds handling pads
the N remainder, and the predicated SIMT epilogue writes only valid output
elements. Keep one-CTA N-edge kernels on the SIMT epilogue for every tile: the
mixed full-tile TMA-store plus edge SIMT-store path is currently validated only
for CtaGroup.TWO and produces invalid NVVM for one CTA.

Fully role-local codegen can leave dependency-only scalar fallback loads in the
residual shared body after TMA, MMA, and epilogue work has moved into role-local
loops. Recognize both cute.arch.load and generated iterator.load spellings as
side-effect-free, but only for pure iterator-based receivers. Continue to keep
the shared loop for generic load methods, stores, pipeline operations, or any
definition consumed by post-loop cleanup.

Add B200 runtime coverage for direct and transposed RHS layouts with both a
single N-edge tile and full-plus-edge N tiles. The tests also pin omission of
the obsolete shared loop and the all-SIMT one-CTA epilogue. Existing two-CTA
N-edge, swapped scale_mm, and pretuned-kernel coverage remains green.

This commit also carries the swapped scale_mm kernel and all 16 pretuned
M=2/8/16/32 serving configurations. M=2/8 exercise the generalized partial-N
path; M=16/32 use the static-full role-local path.
