### PR TITLE
[cute] Generalize grouped N,M worklist profiles

### DIFF
--- a/benchmarks/cute/deepgemm_selected_path.py
+++ b/benchmarks/cute/deepgemm_selected_path.py
@@ -27,16 +27,15 @@ if str(REPO_ROOT) not in sys.path:
 import torch
 
 import helion
-from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
-)
 import helion.language as hl
 import helion.runtime as helion_runtime
 
 DEEPGEMM_SELECTED_TILE_M = 256
 DEEPGEMM_SELECTED_TILE_N = 128
 DEEPGEMM_SELECTED_TILE_K = 64
-M_ALIGNMENT = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+# Pin the historical DeepGEMM-selected BK64 schedule.  This benchmark must not
+# silently change when compiler defaults evolve.
+M_ALIGNMENT = 224
 DEEPGEMM_COMMIT = "559d79fb6994a58b8a15b4b93bf13ccc16edf247"
 DEEPGEMM_CUTLASS_COMMIT = "f3fde58372d33e9a5650ba7b80fc48b3b49d40c8"
 DEFAULT_L2_FLUSH_BYTES = 8_000_000_000
@@ -203,6 +202,7 @@ def selected_config() -> helion.Config:
         tcgen05_c_stages=2,
         tcgen05_num_epi_warps=4,
         tcgen05_grouped_mode="worklist_nm",
+        tcgen05_grouped_worklist_source_m_tile=M_ALIGNMENT,
     )
 
 

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -41,6 +41,7 @@ from ..ast_extension import statement_from_string
 from ..dtype_utils import cast_ast
 from ..host_function import HostFunction
 from ..indexing_strategy import exact_tile_block_ids
+from ..indexing_strategy import subscript_tile_info
 from ..matmul_utils import _needs_f32_accumulator
 from ..tile_strategy import DeviceLoopState
 from .aux_tensor import analyze_tcgen05_matmul_store_chains
@@ -111,8 +112,12 @@ from .tcgen05_constants import TCGEN05_GROUPED_MODES
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_BLOCK_K_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
@@ -124,6 +129,7 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
+from .tcgen05_constants import tcgen05_c_smem_bytes_per_cta
 from .tcgen05_lifecycle import Tcgen05LifecycleContext
 from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
@@ -850,6 +856,26 @@ def _rank3_rhs_index_block_id(index: Node, *, reduction: bool | None) -> int | N
     return canonical_block_id
 
 
+def _rank3_rhs_exact_index_block_id(
+    index: Node, *, reduction: bool | None
+) -> int | None:
+    """Return the canonical block axis only for an unshifted tile subscript."""
+    from ..compile_environment import CompileEnvironment
+
+    block_id = _rank3_rhs_index_block_id(index, reduction=reduction)
+    if block_id is None:
+        return None
+    env = CompileEnvironment.current()
+    tile_info = subscript_tile_info(env, index)
+    if (
+        tile_info is None
+        or not env.known_equal(tile_info.offset, 0)
+        or env.canonical_block_id(tile_info.block_id) != block_id
+    ):
+        return None
+    return block_id
+
+
 def _rank3_rhs_safe_group_load(
     cg: GenerateAST,
     group_index: Node,
@@ -1072,7 +1098,7 @@ def _rank3_rhs_segment_lhs_info(
         or not isinstance(extra_mask, Node)
     ):
         return None
-    lhs_k_block_id = _rank3_rhs_index_block_id(indices[1], reduction=None)
+    lhs_k_block_id = _rank3_rhs_exact_index_block_id(indices[1], reduction=None)
     if lhs_k_block_id is None or canonical_block_id(
         lhs_k_block_id
     ) != canonical_block_id(k_block_id):
@@ -1083,6 +1109,7 @@ def _rank3_rhs_segment_lhs_info(
         row_index.op != "call_function"
         or row_index.target not in (operator.add, torch.ops.aten.add.Tensor)
         or len(row_index.args) != 2
+        or row_index.kwargs
         or not all(isinstance(arg, Node) for arg in row_index.args)
     ):
         return None
@@ -1359,8 +1386,8 @@ def _trace_rank3_grouped_rhs_nt_operand(
         segment_group_info = _rank3_rhs_segment_group_load(cg, indices[0])
         if segment_group_info is None:
             return None
-    rhs_n_block_id = _rank3_rhs_index_block_id(indices[1], reduction=False)
-    rhs_k_block_id = _rank3_rhs_index_block_id(indices[2], reduction=None)
+    rhs_n_block_id = _rank3_rhs_exact_index_block_id(indices[1], reduction=False)
+    rhs_k_block_id = _rank3_rhs_exact_index_block_id(indices[2], reduction=None)
     if rhs_n_block_id is None or rhs_k_block_id is None:
         return None
     grouped_k_mask = None
@@ -2496,6 +2523,7 @@ def _prove_rank3_rhs_grouped_mma(
             node,
             segment_lhs,
             segment_group,
+            n_block_id=axes.n_block_id,
             allow_store_extent_metadata=allow_segment_store_extent_metadata,
         )
         if segment_store is None:
@@ -4103,11 +4131,13 @@ def _rank3_rhs_segment_store_info(
     segment_lhs_info: _Rank3RhsSegmentLhsInfo,
     segment_group: _Rank3RhsSegmentGroupInfo | None = None,
     *,
+    n_block_id: int,
     allow_store_extent_metadata: bool = False,
 ) -> _Rank3RhsSegmentStoreInfo | None:
     import operator
 
     from ...language import memory_ops
+    from ..compile_environment import CompileEnvironment
 
     stores = _trace_mma_to_stores(mma_node, cg.codegen_graphs)
     if stores is None or len(stores) != 1:
@@ -4125,8 +4155,15 @@ def _rank3_rhs_segment_store_info(
         not isinstance(index, list | tuple)
         or len(index) != 2
         or not isinstance(index[0], Node)
+        or not isinstance(index[1], Node)
         or not isinstance(extra_mask, Node)
     ):
+        return None
+    env = CompileEnvironment.current()
+    store_n_block_id = _rank3_rhs_exact_index_block_id(index[1], reduction=False)
+    if store_n_block_id is None or env.canonical_block_id(
+        store_n_block_id
+    ) != env.canonical_block_id(n_block_id):
         return None
     store_row = _trace_to_outer_graph_arg(cg, index[0])
     if store_row is not segment_lhs_info.row_index:
@@ -4188,6 +4225,64 @@ def _requested_tcgen05_grouped_schedule(
     if grouped_mode != TCGEN05_GROUPED_MODE_WORKLIST_NM:
         return None
     return Tcgen05Orientation.NM
+
+
+def _append_aligned_smem(offset: int, size: int, alignment: int) -> int:
+    assert offset >= 0 and size >= 0 and alignment > 0
+    return ((offset + alignment - 1) // alignment) * alignment + size
+
+
+def _tcgen05_grouped_worklist_smem_bytes(
+    *,
+    sched_stage_count: int,
+    bm: int,
+    bn: int,
+    bk: int,
+    dtype_bytes: int,
+    ab_stages: int,
+    acc_stages: int,
+    c_stages: int,
+    cluster_m: int,
+) -> int:
+    """Exact ordered SMEM footprint of the host N,M grouped worklist path.
+
+    Keep this in the same order as the ``cute.arch.alloc_smem`` calls emitted
+    by the grouped scheduler and tcgen05 collective.  The BK64/source-224
+    profile intentionally reaches the 227-KiB opt-in cap, so a coarse reserve
+    would reject a valid compiled kernel while omitting even one mailbox,
+    barrier, TensorMap, or alignment pad is unsafe.
+    """
+    assert sched_stage_count > 0 and cluster_m in (1, 2)
+    a_stage_bytes = bm * bk * dtype_bytes
+    b_stage_bytes = bn * bk * dtype_bytes
+    assert a_stage_bytes % cluster_m == 0
+    assert b_stage_bytes % cluster_m == 0
+
+    offset = 0
+    offset = _append_aligned_smem(
+        offset,
+        TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT * sched_stage_count * 4,
+        16,
+    )
+    # TMEM allocator state and accumulator/scheduler pipeline mbarriers.
+    offset = _append_aligned_smem(offset, 4, 4)
+    offset = _append_aligned_smem(offset, 8, 8)
+    offset = _append_aligned_smem(offset, acc_stages * 2 * 8, 8)
+    offset = _append_aligned_smem(offset, sched_stage_count * 2 * 8, 8)
+    # A/B stages, two mutable input TensorMaps, and the AB pipeline barriers.
+    offset = _append_aligned_smem(offset, ab_stages * a_stage_bytes // cluster_m, 128)
+    offset = _append_aligned_smem(offset, ab_stages * b_stage_bytes // cluster_m, 128)
+    offset = _append_aligned_smem(offset, 2 * 128, 128)
+    offset = _append_aligned_smem(offset, ab_stages * 8, 8)
+    # One mutable output TensorMap and the aligned TMA-store ring.
+    offset = _append_aligned_smem(offset, 128, 128)
+    c_smem_bytes = tcgen05_c_smem_bytes_per_cta(
+        epi_tile_m=TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[0],
+        epi_tile_n=TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[1],
+        dtype_bytes=dtype_bytes,
+        c_stages=c_stages,
+    )
+    return _append_aligned_smem(offset, c_smem_bytes, 1024)
 
 
 def _emit_mma_pipeline(
@@ -4789,18 +4884,30 @@ def _emit_mma_pipeline(
         return f"{rhs_arg_name}[{k_expr}, {n_expr}]"
 
     tcgen05_nm_orientation = requested_schedule is Tcgen05Orientation.NM
-    tcgen05_mma_bm = (
-        TCGEN05_GROUPED_WORKLIST_MMA_M_TILE if tcgen05_nm_orientation else bm
-    )
-    tcgen05_mma_bn = (
-        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE if tcgen05_nm_orientation else bn
-    )
-    tcgen05_source_bm = (
-        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE if tcgen05_nm_orientation else bm
-    )
-    tcgen05_source_bn = (
-        TCGEN05_GROUPED_WORKLIST_MMA_M_TILE if tcgen05_nm_orientation else bn
-    )
+    tcgen05_worklist_source_m_tile: int | None = None
+    if tcgen05_nm_orientation:
+        if bk not in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES:
+            return _unsupported_schedule("block_k must be 64 or 128")
+        tcgen05_worklist_source_m_tile = _tcgen05_config_int(
+            df.config,
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+        )
+        if (
+            tcgen05_worklist_source_m_tile
+            not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+        ):
+            return _unsupported_schedule(
+                f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY} must be "
+                f"one of {TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES}"
+            )
+        tcgen05_mma_bm = TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
+        tcgen05_mma_bn = tcgen05_worklist_source_m_tile
+        tcgen05_source_bm = tcgen05_worklist_source_m_tile
+        tcgen05_source_bn = TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
+    else:
+        tcgen05_mma_bm = tcgen05_source_bm = bm
+        tcgen05_mma_bn = tcgen05_source_bn = bn
 
     tcgen05_cluster_m = _tcgen05_cluster_m(df.config)
     tcgen05_large_bn_proof = _tcgen05_large_bn_proof_enabled(df.config)
@@ -5327,6 +5434,9 @@ def _emit_mma_pipeline(
     tcgen05_c_stage_count_value = _tcgen05_config_int(
         df.config, "tcgen05_c_stages", _tcgen05_c_stage_count(bn)
     )
+    tcgen05_acc_stage_count_value = _tcgen05_config_int(
+        df.config, "tcgen05_acc_stages", _tcgen05_acc_stage_count(tcgen05_mma_bn)
+    )
     tcgen05_output_edge_tma_store_fits_smem = (
         tcgen05_ab_stage_count_value <= TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
     )
@@ -5442,17 +5552,21 @@ def _emit_mma_pipeline(
         worklist_nm_static_checks = {
             "bf16_operands": input_dtype == torch.bfloat16,
             "bf16_store": epi_elem_dtype_str == "cutlass.BFloat16",
-            "tile_256x128x64": bm == 256 and bn == 128 and bk == 64,
+            "tile_256x128x64_or_128": (
+                bm == 256
+                and bn == 128
+                and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+            ),
             "n_multiple_32": (
                 rhs_source_n is not None
                 and rhs_source_n > 0
                 and rhs_source_n % TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[2] == 0
             ),
-            "k_multiple_64": (
+            "k_multiple_block_k": (
                 lhs_source_k is not None
                 and rhs_source_k is not None
-                and lhs_source_k % 64 == 0
-                and rhs_source_k % 64 == 0
+                and lhs_source_k % bk == 0
+                and rhs_source_k % bk == 0
             ),
             "common_k": (
                 lhs_source_k is not None
@@ -5473,9 +5587,10 @@ def _emit_mma_pipeline(
                 f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} is validated only for "
                 "generated BF16 NT contiguous "
                 "segment-worklist kernels: contiguous A_packed[M,K], "
-                "contiguous B_grouped[G,N,K], common K%64==0, "
+                "contiguous B_grouped[G,N,K], common K%block_k==0, "
                 "N%32==0, "
-                "CtaGroup.TWO 256x128x64, zero accumulator, and identity BF16 "
+                "CtaGroup.TWO 256x128x(64|128), zero accumulator, and "
+                "identity BF16 "
                 "store; failed checks: " + ", ".join(failed_static_checks),
             )
     if tcgen05_grouped_static_persistent_requested:
@@ -5512,7 +5627,7 @@ def _emit_mma_pipeline(
             and tcgen05_cluster_m == 2
             and tcgen05_cluster_n == 1
             and bm == TCGEN05_TWO_CTA_BLOCK_M
-            and bk == 64
+            and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
         )
         grouped_common_k_pair_allowed = (
             tcgen05_grouped_k_mask is not None
@@ -5562,8 +5677,10 @@ def _emit_mma_pipeline(
                 or tcgen05_grouped_dynamic_ab_tensormaps_requested
                 or tcgen05_grouped_worklist_persistent
             ),
-            "dynamic_ab_tensormaps_bk64_only": (
-                not tcgen05_grouped_dynamic_ab_tensormaps_requested or bk == 64
+            "dynamic_ab_tensormaps_supported_bk": (
+                not tcgen05_grouped_dynamic_ab_tensormaps_requested
+                or bk == 64
+                or (requested_schedule is not None and bk == 128)
             ),
             "dynamic_ab_tensormaps_exact_k_sizes": (
                 not tcgen05_grouped_dynamic_ab_tensormaps_requested
@@ -5575,7 +5692,7 @@ def _emit_mma_pipeline(
                 or (
                     tcgen05_grouped_dynamic_ab_tensormaps_requested
                     and (bm == 128 or grouped_worklist_two_cta)
-                    and bk == 64
+                    and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
                 )
             ),
             "no_scheduler_warp": (
@@ -5598,8 +5715,8 @@ def _emit_mma_pipeline(
                 "only for FP16/BF16 rank3 RHS grouped-NT CtaGroup.ONE "
                 "persistent_interleaved static-full 128x(64|128)x(16|32|64|128) "
                 "TMA-load + TMA-store kernels, or the generated segment "
-                "worklist BK64 dynamic-TensorMap variant (including the "
-                "CtaGroup.TWO 256x(64|128)x64 worklist shape), with no "
+                "worklist BK64/BK128 dynamic-TensorMap variant (including the "
+                "CtaGroup.TWO 256x(64|128)x(64|128) worklist shape), with no "
                 "scheduler/C-input/store warp variants; failed checks: "
                 + ", ".join(failed_grouped_checks),
             )
@@ -5613,8 +5730,38 @@ def _emit_mma_pipeline(
                 "cute",
                 f"{TCGEN05_GROUPED_MODE_CONFIG_KEY} requires at least one RHS group",
             )
+        if requested_schedule is Tcgen05Orientation.NM:
+            grouped_smem_capacity = CuteTcgen05Config.per_cta_smem_capacity_bytes(
+                lhs_info.source_fake.device
+            )
+            grouped_smem_required = _tcgen05_grouped_worklist_smem_bytes(
+                sched_stage_count=_tcgen05_config_int(
+                    df.config, TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY, 1
+                ),
+                bm=tcgen05_mma_bm,
+                bn=tcgen05_mma_bn,
+                bk=bk,
+                dtype_bytes=input_dtype.itemsize,
+                ab_stages=tcgen05_ab_stage_count_value,
+                acc_stages=tcgen05_acc_stage_count_value,
+                c_stages=tcgen05_c_stage_count_value,
+                cluster_m=tcgen05_cluster_m,
+            )
+            if (
+                grouped_smem_capacity <= 0
+                or grouped_smem_required > grouped_smem_capacity
+            ):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped N,M worklist generated allocations "
+                    f"require {grouped_smem_required} bytes of per-CTA "
+                    f"SMEM, exceeding the {grouped_smem_capacity}-byte capacity",
+                )
         tcgen05_grouped_dynamic_ab_tensormap_rank = (
-            3 if tcgen05_grouped_dynamic_ab_tensormaps_requested and bk == 64 else None
+            3
+            if tcgen05_grouped_dynamic_ab_tensormaps_requested
+            and (bk == 64 or (requested_schedule is not None and bk == 128))
+            else None
         )
         tcgen05_grouped_layout_arg_name = df.tensor_arg(grouped_layout_tensor).name
         if tcgen05_grouped_k_mask is not None:
@@ -5733,9 +5880,9 @@ def _emit_mma_pipeline(
                     f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} is validated only "
                     "for generated BF16 NT contiguous "
                     "segment-worklist kernels: contiguous A_packed[M,K], "
-                    "contiguous B_grouped[G,N,K], common K%64==0, "
+                    "contiguous B_grouped[G,N,K], common K%block_k==0, "
                     "N%32==0, "
-                    "CtaGroup.TWO 256x128x64, dynamic A/B/D TensorMaps, "
+                    "CtaGroup.TWO 256x128x(64|128), dynamic A/B/D TensorMaps, "
                     "zero accumulator, and identity BF16 store; failed checks: "
                     + ", ".join(failed_worklist_nm_checks),
                 )
@@ -5863,6 +6010,9 @@ def _emit_mma_pipeline(
             direct_strides=tcgen05_grouped_direct_strides,
             d_mode=tcgen05_grouped_d_mode,
             d_tensormap=tcgen05_grouped_d_tensormap,
+            source_m_tile=(
+                tcgen05_worklist_source_m_tile if tcgen05_nm_orientation else None
+            ),
         )
     if requested_schedule is not None and (
         tcgen05_grouped_plan is None
@@ -6235,9 +6385,6 @@ def _emit_mma_pipeline(
         tcgen05_cta_thread_count = max(tcgen05_cta_thread_count, 4 * 32)
     if mma_impl == "tcgen05" and tcgen05_cluster_m * tcgen05_cluster_n > 1:
         df.cute_state.cluster_shape = (tcgen05_cluster_m, tcgen05_cluster_n, 1)
-    tcgen05_acc_stage_count_value = _tcgen05_config_int(
-        df.config, "tcgen05_acc_stages", _tcgen05_acc_stage_count(tcgen05_mma_bn)
-    )
     # PipelineTmaUmma empty barriers are released by the leader CTA with the
     # pipeline's multicast mask. Peer CTAs still advance local consumer state,
     # but they must not add a second empty-barrier arrival: doing so lets the
@@ -6569,7 +6716,8 @@ def _emit_mma_pipeline(
                         "cute",
                         "tcgen05 N,M-oriented explicit store is validated only "
                         "for the BF16 grouped worklist TMA-store "
-                        "path with block_m=256, block_n=128, block_k=64, "
+                        "path with block_m=256, block_n=128, "
+                        "block_k=64 or 128, "
                         "CtaGroup.TWO, and no auxiliary epilogue tensors",
                     )
             elif not (
@@ -7867,6 +8015,11 @@ def _emit_mma_pipeline(
                         "bm": bm,
                         "bn": bn,
                         "bk": bk,
+                        **(
+                            {"source_m_tile": grouped_plan.source_m_tile}
+                            if grouped_plan.source_m_tile is not None
+                            else {}
+                        ),
                         "cluster_m": tcgen05_cluster_m,
                         "cluster_n": tcgen05_cluster_n,
                         **(
@@ -8810,11 +8963,10 @@ def _emit_mma_pipeline(
         if mma_impl == "tcgen05" and tcgen05_use_tma:
             assert tcgen05_plan is not None
             assert tma_warp is not None
-            # The validated explicit two-CTA store-box family uses bk=64 to
-            # match Quack's four logical 2CTA MMA K blocks. Python ``range``
-            # lets the outer K-loop duplicate those issue sites; a CuTe range
-            # with no-unroll metadata keeps that guarded family in one loop
-            # body while normal loops keep their existing range lowering.
+            # The validated explicit two-CTA store-box family uses a CuTe
+            # range with no-unroll metadata so its guarded K-iteration body
+            # remains compact.  The generated N,M worklist admits BK64 and
+            # BK128; other explicit-store families keep their BK64 envelope.
             tcgen05_use_nounroll_k_loop = (
                 any(
                     value is not None
@@ -8826,7 +8978,7 @@ def _emit_mma_pipeline(
                 )
                 and tcgen05_static_full_tiles
                 and tcgen05_is_two_cta
-                and bk == 64
+                and (bk == 64 or nm_worklist)
             )
             tma_kloop_args = _PerKiterTmaArgs(
                 tma_pipeline=tma_pipeline,

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -60,10 +60,17 @@ class CuteTcgen05GroupedPlan:
     direct_strides: str | None = None
     d_mode: Tcgen05GroupedDMode = Tcgen05GroupedDMode.NONE
     d_tensormap: str | None = None
+    # N,M worklists carry their source-row tile explicitly so runtime metadata
+    # validation and launch bounds consume the exact schedule selected by the
+    # compiler.
+    source_m_tile: int | None = None
 
     def __post_init__(self) -> None:
         assert (self.valid_m is None) == (self.store_m is None)
         assert (self.orientation is Tcgen05Orientation.NM) == (self.valid_m is not None)
+        assert (self.orientation is Tcgen05Orientation.NM) == (
+            self.source_m_tile is not None
+        )
         assert (self.direct_pointers is None) == (self.direct_strides is None)
         assert (self.d_mode is Tcgen05GroupedDMode.NONE) == (self.d_tensormap is None)
 

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -96,6 +96,8 @@ from .tcgen05_constants import TCGEN05_GROUPED_MODES
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CONFIG_KEY
@@ -207,6 +209,7 @@ CUTE_TCGEN05_DIAGNOSTIC_CONFIG_KEYS: frozenset[str] = frozenset(
         TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY,
         TCGEN05_GROUPED_MODE_CONFIG_KEY,
         TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
         TCGEN05_LARGE_BN_PROOF_CONFIG_KEY,
         TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY,
         TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY,
@@ -905,6 +908,24 @@ class CuteTcgen05Config:
     def prepare_normalization(
         self, config: dict[str, object], *, fix_invalid: bool
     ) -> None:
+        source_m_tile_key = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+        source_m_tile = config.get(source_m_tile_key)
+        if source_m_tile_key in config and (
+            type(source_m_tile) is not int
+            or source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+            or config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            != TCGEN05_GROUPED_MODE_WORKLIST_NM
+        ):
+            if fix_invalid:
+                config.pop(source_m_tile_key)
+            else:
+                raise InvalidConfig(
+                    f"{source_m_tile_key} requires "
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} and one of "
+                    f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES}, got "
+                    f"{source_m_tile!r}"
+                )
         reserved_sms_key = TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
         reserved_sms = config.get(reserved_sms_key)
         if reserved_sms_key in config and (
@@ -2209,6 +2230,9 @@ class CuteTcgen05Config:
             fragments[TCGEN05_GROUPED_MODE_CONFIG_KEY] = EnumFragment(
                 TCGEN05_GROUPED_MODES
             )
+            fragments[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = EnumFragment(
+                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+            )
         direct_entry_seed_eligible = self.full_tile_direct_entry_seed_eligible()
         if direct_entry_seed_eligible or (
             not for_search and self._direct_entry_k_block_index() is not None
@@ -3002,6 +3026,24 @@ class CuteTcgen05Config:
             # path, while exact-proof compiler seeds survive flatten/unflatten.
             fields[TCGEN05_GROUPED_MODE_CONFIG_KEY] = EnumFragment(
                 (None, *grouped_seed_modes),
+                search_choices=(None,),
+            )
+        grouped_source_m_tiles = tuple(
+            dict.fromkeys(
+                source_m_tile
+                for config in self.config_spec.compiler_seed_configs
+                if (
+                    source_m_tile := config.config.get(
+                        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+                    )
+                )
+                and type(source_m_tile) is int
+                and source_m_tile in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+            )
+        )
+        if grouped_source_m_tiles:
+            fields[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = EnumFragment(
+                (None, *grouped_source_m_tiles),
                 search_choices=(None,),
             )
         fields.update(self.strategy_autotune_fragments())

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -463,12 +463,26 @@ TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY = (
 TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY = (
     "tcgen05_grouped_external_direct_strides"
 )
-# Source rows consumed per compact N,M worklist group. This is tied to the
-# schedule's 256x224 source tile and must not leak into general grouped-GEMM
-# tiling decisions.
+# Validated source-row tiles for compact N,M worklist schedules.  The selected
+# tile is carried explicitly by the schedule plan; it is independent of the
+# CTA K tile and must not leak into general grouped-GEMM tiling decisions.
+TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY = (
+    "tcgen05_grouped_worklist_source_m_tile"
+)
 TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE = 224
+TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE = 256
+TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES = (64, 128)
+TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES = (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+    TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+)
 TCGEN05_GROUPED_WORKLIST_MMA_M_TILE = 256
 TCGEN05_GROUPED_WORKLIST_STORE_SHAPE = (128, 32, 32)
+# The grouped scheduler publishes CTA M/N, validity, metadata/group indices,
+# problem M/N/K, and the packed-output row start through one Int32 mailbox.
+TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT = 9
+
+
 TCGEN05_LARGE_BN_PROOF_PROBLEM_SHAPE = (64, 512, 16)
 TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES = (64, 512, 16)
 TCGEN05_LARGE_BN_PROOF_CLUSTER_M = 1

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -19,6 +19,7 @@ from .compile_environment import CompileEnvironment
 from .cute.cutedsl_compat import emit_pipeline_advance
 from .cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_DEFAULT
 from .cute.strategies import l2_swizzle_size_from_config
+from .cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_NORMAL
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_WARP_LEADER
@@ -200,7 +201,6 @@ _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_M = 5
 _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_N = 6
 _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_K = 7
 _TCGEN05_GROUPED_SELECTED_MAILBOX_GLOBAL_M_START = 8
-_TCGEN05_GROUPED_SELECTED_MAILBOX_FIELD_COUNT = 9
 
 
 if TYPE_CHECKING:
@@ -1276,7 +1276,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
 
     def _tcgen05_work_tile_mailbox_field_count(self) -> int:
         if self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox():
-            return _TCGEN05_GROUPED_SELECTED_MAILBOX_FIELD_COUNT
+            return TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT
         return 4
 
     def _tcgen05_has_validated_role_local_two_cta_runtime(self) -> bool:

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -40,7 +40,9 @@ from ..._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
 )
 from ..._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
-from ..._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+from ..._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES,
+)
 from ..._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
 from ..triton.launcher import get_num_sm
 
@@ -2464,7 +2466,7 @@ def _validate_tcgen05_grouped_worklist_nm(
         return
     lhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A")
     rhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B")
-    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+    source_m_tile = _plan_int_value(plan, "source_m_tile")
     expected_store_end = 0
     seen_groups: set[int] = set()
     for row in rows:
@@ -2719,11 +2721,20 @@ def _build_tcgen05_grouped_static_metadata(
     bn = _plan_int_value(plan, "bn")
     bk = _plan_int_value(plan, "bk")
     worklist_nm = _tcgen05_plan_orientation(plan) == "nm"
-    worklist_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE if worklist_nm else bm
     n_size = _plan_int_value(plan, "n_size")
     k_total_size = _plan_int_value(plan, "k_total_size")
-    scheduler_bm = TCGEN05_GROUPED_WORKLIST_MMA_M_TILE if worklist_nm else bm
-    scheduler_bn = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE if worklist_nm else bn
+    if worklist_nm:
+        worklist_m_tile = _plan_int_value(plan, "source_m_tile")
+        if worklist_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist scheduler requires a validated source M tile",
+            )
+        scheduler_bm = TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
+        scheduler_bn = worklist_m_tile
+    else:
+        worklist_m_tile = scheduler_bm = bm
+        scheduler_bn = bn
     dynamic_ab_tensormaps = bool(plan.get("dynamic_ab_tensormaps"))
     dynamic_d_tensormap = bool(plan.get("dynamic_d_tensormap"))
     direct_pointer_metadata = bool(plan.get("direct_pointer_metadata"))
@@ -2738,10 +2749,11 @@ def _build_tcgen05_grouped_static_metadata(
         raise exc.BackendUnsupported(
             "cute", "tcgen05 N,M orientation requires grouped worklist metadata"
         )
-    if dynamic_ab_tensormaps and bk != 64:
+    if dynamic_ab_tensormaps and bk != 64 and not (worklist_nm and bk == 128):
         raise exc.BackendUnsupported(
             "cute",
-            "tcgen05 grouped dynamic A/B TensorMaps are validated only for BK64",
+            "tcgen05 grouped dynamic A/B TensorMaps are validated only for "
+            "BK64, or BK128 on the N,M worklist path",
         )
     direct_lhs: torch.Tensor | None = None
     direct_rhs: torch.Tensor | None = None

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -30,6 +30,9 @@ from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX,
 )
 from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY,
 )
 from helion._compiler.cute.tcgen05_constants import (
@@ -1023,6 +1026,71 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             generation.encode_config(flat)
             self.assertEqual(pid_fragment.pattern_neighbors(flat[pid_index]), ["flat"])
             self.assertEqual(mode_fragment.pattern_neighbors(flat[mode_index]), [None])
+
+    def test_grouped_worklist_source_tile_normalization(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+        config = helion.Config(
+            block_sizes=[256, 128, 128],
+            pid_type="persistent_interleaved",
+            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            tcgen05_grouped_worklist_source_m_tile=256,
+        )
+        spec.normalize(config)
+        self.assertEqual(
+            config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY],
+            256,
+        )
+
+        for invalid_value in (256.0, True, 225):
+            wrong_type_config = helion.Config(
+                block_sizes=[256, 128, 128],
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                tcgen05_grouped_worklist_source_m_tile=256,
+            )
+            wrong_type_config.config[
+                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+            ] = invalid_value
+            with self.assertRaisesRegex(exc.InvalidConfig, "source_m_tile"):
+                spec.normalize(wrong_type_config)
+
+        invalid = helion.Config(
+            block_sizes=[256, 128, 128],
+            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_DYNAMIC,
+            tcgen05_grouped_worklist_source_m_tile=256,
+        )
+        with self.assertRaisesRegex(exc.InvalidConfig, "source_m_tile"):
+            spec.normalize(invalid)
+        spec.normalize(invalid, _fix_invalid=True)
+        self.assertNotIn(
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+            invalid.config,
+        )
+
+    def test_grouped_worklist_source_tile_seed_round_trip(self) -> None:
+        from helion.autotuner.config_generation import ConfigGeneration
+
+        spec = self._make_cute_tcgen05_spec()
+        seed = helion.Config(
+            block_sizes=[256, 128, 128],
+            pid_type="persistent_interleaved",
+            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            tcgen05_grouped_worklist_source_m_tile=256,
+        )
+        spec.compiler_seed_configs = [seed]
+
+        generation = ConfigGeneration(spec)
+        [(flat, normalized)] = generation.seed_flat_config_pairs()
+        self.assertEqual(
+            normalized.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY],
+            256,
+        )
+        generation.encode_config(flat)
+        round_trip = generation.unflatten(flat)
+        self.assertEqual(
+            round_trip.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY],
+            256,
+        )
 
     def test_tcgen05_search_fields_do_not_leak_to_other_backends(self) -> None:
         from helion._compiler.backend import MetalBackend

--- a/test/test_cute_deepgemm_selected.py
+++ b/test/test_cute_deepgemm_selected.py
@@ -12,7 +12,13 @@ from helion._compat import requires_cuda_version
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
 from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+)
+from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
 )
 from helion._testing import DEVICE
 from helion._testing import matchesBackends
@@ -26,14 +32,16 @@ if matchesBackends(["cute"]):
     pytest.importorskip("cutlass.cute")
 
 
-def _aligned_m(actual_m: int) -> int:
-    tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+def _aligned_m(
+    actual_m: int,
+    tile: int = TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+) -> int:
     return ((actual_m + tile - 1) // tile) * tile
 
 
-def _selected_config() -> helion.Config:
+def _selected_config(block_k: int = 128) -> helion.Config:
     config = helion.Config(
-        block_sizes=[256, 128, 64],
+        block_sizes=[256, 128, block_k],
         l2_groupings=[1],
         loop_orders=[[0, 1, 2]],
         num_stages=7,
@@ -41,12 +49,17 @@ def _selected_config() -> helion.Config:
         pid_type="persistent_interleaved",
         tcgen05_cluster_m=2,
         tcgen05_cluster_n=1,
-        tcgen05_ab_stages=7,
+        tcgen05_ab_stages={64: 7, 128: 3}[block_k],
         tcgen05_acc_stages=2,
         tcgen05_c_stages=2,
         tcgen05_num_epi_warps=4,
     )
     config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = TCGEN05_GROUPED_MODE_WORKLIST_NM
+    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = (
+        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+        if block_k == 128
+        else TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+    )
     return config
 
 
@@ -55,6 +68,7 @@ def _selected_kernel(
     a_packed: torch.Tensor,
     b_grouped: torch.Tensor,
     work_tile_metadata: torch.Tensor,
+    row_alpha: hl.constexpr = 1,  # pyrefly: ignore[bad-function-definition]
 ) -> torch.Tensor:
     m_total_aligned, k = a_packed.shape
     _g, n, k2 = b_grouped.shape
@@ -79,7 +93,10 @@ def _selected_kernel(
         valid_m = work_tile_metadata[work_id, 2]
         store_m = work_tile_metadata[work_id, 3]
         local_m = tile_m.index
-        row_index = global_m_start + local_m
+        if row_alpha == 1:
+            row_index = global_m_start + local_m
+        else:
+            row_index = torch.add(global_m_start, local_m, alpha=2)
         valid_rows = local_m < valid_m
         store_rows = local_m < store_m
         acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
@@ -107,25 +124,28 @@ def _make_args(
     m_sizes: tuple[int, ...] = (17, 11),
     *,
     n: int = 128,
-    k: int = 64,
+    k: int = 128,
     dtype: torch.dtype = torch.bfloat16,
     dirty_padding: bool = False,
+    source_m_tile: int = TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     starts: list[int] = []
     cursor = 0
     for actual_m in m_sizes:
         starts.append(cursor)
-        cursor += _aligned_m(actual_m)
+        cursor += _aligned_m(actual_m, source_m_tile)
 
     a_packed = torch.zeros((cursor, k), device=DEVICE, dtype=dtype)
     for start, actual_m in zip(starts, m_sizes, strict=True):
         a_packed[start : start + actual_m].normal_()
         if dirty_padding:
-            a_packed[start + actual_m : start + _aligned_m(actual_m)].normal_()
+            a_packed[
+                start + actual_m : start + _aligned_m(actual_m, source_m_tile)
+            ].normal_()
     b_grouped = torch.randn((len(m_sizes), n, k), device=DEVICE, dtype=dtype)
     work_tile_metadata = torch.tensor(
         [
-            [group, start, actual_m, _aligned_m(actual_m)]
+            [group, start, actual_m, _aligned_m(actual_m, source_m_tile)]
             for group, (start, actual_m) in enumerate(zip(starts, m_sizes, strict=True))
         ],
         device=DEVICE,
@@ -134,15 +154,20 @@ def _make_args(
     return a_packed, b_grouped, work_tile_metadata
 
 
-def _configured_bound(args: tuple[torch.Tensor, ...]):
+def _configured_bound(args: tuple[torch.Tensor, ...], block_k: int = 128):
     _selected_kernel.reset()
     bound = _selected_kernel.bind(args)
     bound.env.config_spec.cute_tcgen05_search_enabled = True
-    bound.set_config(_selected_config())
+    bound.set_config(_selected_config(block_k))
     return bound
 
 
-def _code_for(args: tuple[torch.Tensor, ...]) -> str:
+def _code_for(
+    args: tuple[torch.Tensor, ...],
+    config: helion.Config | None = None,
+) -> str:
+    if config is None:
+        config = _selected_config()
     _selected_kernel.reset()
     bound = _selected_kernel.bind(args)
     bound.env.config_spec.cute_tcgen05_search_enabled = True
@@ -150,7 +175,7 @@ def _code_for(args: tuple[torch.Tensor, ...]) -> str:
         patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
         patch_cute_mma_support(),
     ):
-        return bound.to_triton_code(_selected_config())
+        return bound.to_triton_code(config)
 
 
 def _wrapper_plans(code: str) -> list[dict[str, object]]:
@@ -206,15 +231,15 @@ def _require_runtime_cuda13_sm100() -> None:
 def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
     _require_codegen_cuda()
 
-    code = _code_for(_make_args((1, 127, 224, 256), n=224, k=64))
+    code = _code_for(_make_args((1, 127, 224, 256), n=224, k=128))
 
     assert code.count("StaticPersistentGroupTileScheduler.create") == 1
     assert "TensorMapManager" in code
     assert "update_tensormap" in code
     assert "cute.nvgpu.tcgen05.CtaGroup.TWO" in code
-    assert "(256, 224)" in code
-    assert "cute.local_tile(tma_tensor_a, (256, 64)" in code
-    assert "cute.local_tile(tma_tensor_b, (224, 64)" in code
+    assert "(256, 256)" in code
+    assert "cute.local_tile(tma_tensor_a, (256, 128)" in code
+    assert "cute.local_tile(tma_tensor_b, (256, 128)" in code
     assert "StMatrix8x8x16bOp(transpose=True, num_matrices=4)" in code
     assert "cute.arch.alloc_smem(cutlass.Int32, 9" in code
 
@@ -236,11 +261,77 @@ def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
     }
 
 
+def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
+    _require_codegen_cuda()
+
+    config = _selected_config(64)
+    config.config.pop(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+    code = _code_for(
+        _make_args(
+            (1, 127, 224, 256),
+            n=224,
+            k=64,
+            source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+        ),
+        config,
+    )
+
+    assert "(256, 224, 64)" in code
+    assert "cute.local_tile(tma_tensor_a, (256, 64)" in code
+    assert "cute.local_tile(tma_tensor_b, (224, 64)" in code
+    plan = next(
+        plan
+        for plan in _wrapper_plans(code)
+        if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert plan["bk"] == 64
+    assert plan["source_m_tile"] == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+
+
+def test_grouped_worklist_nm_rejects_over_budget_host_metadata_profile() -> None:
+    _require_codegen_cuda()
+
+    config = _selected_config(64)
+    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = (
+        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+    )
+    args = _make_args(
+        (224, 256),
+        n=224,
+        k=64,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+    )
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="grouped N,M worklist generated allocations require",
+    ):
+        _code_for(args, config)
+
+
+def test_grouped_worklist_nm_rejects_alpha_scaled_row() -> None:
+    _require_codegen_cuda()
+
+    args = (*_make_args((224, 256), n=224, k=128), 2)
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    assert not bound.env.config_spec.cute_tcgen05_search_enabled
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+        pytest.raises(
+            helion.exc.BackendUnsupported,
+            match="rank3 grouped semantic proof failed",
+        ),
+    ):
+        bound.to_triton_code(_selected_config())
+
+
 @pytest.mark.parametrize(
     ("case", "match"),
     (
         ("fp16", "bf16_operands"),
-        ("k96", "k_multiple_64"),
+        ("k96", "k_multiple_block_k"),
         ("n196", f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}|n_multiple_32"),
         ("strided_b", f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}|contiguous_b_grouped"),
     ),
@@ -267,17 +358,36 @@ def test_grouped_worklist_nm_rejects_ineligible_inputs(case: str, match: str) ->
         _code_for(args)
 
 
-def test_grouped_worklist_nm_runtime_and_graph_replay() -> None:
+@pytest.mark.parametrize(
+    ("block_k", "source_m_tile"),
+    (
+        (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE),
+        (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE),
+    ),
+)
+def test_grouped_worklist_nm_runtime_and_graph_replay(
+    block_k: int,
+    source_m_tile: int,
+) -> None:
     _require_runtime_cuda13_sm100()
 
-    args = _make_args((224, 449, 256), n=512, k=128, dirty_padding=True)
-    assert args[2].cpu().tolist() == [
-        [0, 0, 224, 224],
-        [1, 224, 449, 672],
-        [2, 896, 256, 448],
-    ]
+    m_sizes = (224, 449, 256)
+    args = _make_args(
+        m_sizes,
+        n=512,
+        k=2 * block_k,
+        dirty_padding=True,
+        source_m_tile=source_m_tile,
+    )
+    expected_metadata = []
+    start = 0
+    for group, actual_m in enumerate(m_sizes):
+        store_m = _aligned_m(actual_m, source_m_tile)
+        expected_metadata.append([group, start, actual_m, store_m])
+        start += store_m
+    assert args[2].cpu().tolist() == expected_metadata
     with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
-        bound = _configured_bound(args)
+        bound = _configured_bound(args, block_k)
         warmup = bound(*args)
         torch.cuda.synchronize()
         _assert_output(warmup, args)

--- a/test/test_cute_grouped_gemm_benchmark.py
+++ b/test/test_cute_grouped_gemm_benchmark.py
@@ -47,10 +47,16 @@ def test_published_manifests_are_fixed(
             for case in cutlass_benchmark.CASES
         ),
         tuple(tuple(shape) for shape in deepgemm_benchmark.OFFICIAL_SHAPES),
+        (
+            deepgemm_benchmark.DEEPGEMM_SELECTED_TILE_M,
+            deepgemm_benchmark.DEEPGEMM_SELECTED_TILE_N,
+            deepgemm_benchmark.DEEPGEMM_SELECTED_TILE_K,
+            deepgemm_benchmark.M_ALIGNMENT,
+        ),
         deepgemm_benchmark.selected_config().config,
     )
     assert hashlib.sha256(repr(manifest).encode()).hexdigest() == (
-        "deffec6097179b24ed4071fda1d7908fe57a1d291f0191187655bb39d9e5d9de"
+        "608089dc016171e07938f1a67c9c42ed56e292a2d99038b8a2410393d7aa8c74"
     )
 
 


### PR DESCRIPTION
Stacked PRs:
 * #3314
 * #3313
 * __->__#3312

--- --- ---

### [cute] Generalize grouped N,M worklist profiles

## Summary

The generated CuTe tcgen05 N,M grouped-worklist path was previously tied to one schedule: `BM=256`, `BN=128`, `BK=64`, with source rows packed in 224-row chunks.

This PR makes the worklist profile explicit end to end and adds support for:

- `BK` values of 64 and 128;
- source-row tiles of 224 and 256;
- BK128 dynamic A/B TensorMaps on the validated N,M worklist path; and
- K-size validation against the selected `BK`, rather than always requiring a multiple of 64.

The legacy BK64/source-224 behavior remains the default when the new source-tile setting is omitted.

## Configuration and runtime plumbing

A new `tcgen05_grouped_worklist_source_m_tile` configuration field records the selected source-row tile. It is accepted only for `tcgen05_grouped_mode="worklist_nm"` and only for the validated values 224 and 256.

The field is preserved through seed normalization, flattening, and unflattening without expanding the ordinary autotuning search space. The selected value is also carried in the generated wrapper plan, so runtime metadata validation, source-row alignment, launch bounds, and scheduler dimensions all use the same profile chosen by the compiler.

## Shared-memory safety

Different `BK`, source-tile, and pipeline-stage combinations have materially different shared-memory requirements. This PR computes the ordered per-CTA allocation footprint for the generated worklist kernel, including:

- the nine-field scheduler mailbox;
- pipeline barriers and TMEM allocator state;
- A/B pipeline stages after cluster partitioning;
- mutable A, B, and output TensorMaps; and
- the aligned TMA-store ring.

The compiler rejects a profile when that footprint exceeds the device's opt-in shared-memory capacity. Exact accounting matters because the legacy BK64/source-224 profile reaches the 227-KiB limit: a coarse reserve can reject a valid profile, while incomplete accounting can admit a kernel that cannot launch.

## Semantic matching safety

The grouped-worklist transformation is now more conservative about the source program it accepts. It requires:

- unshifted tile coordinates for the A reduction axis and B N/K axes;
- an unshifted output N coordinate matching the MMA N tile; and
- an exact `group_start + local_m` row expression, with no `alpha` or other keyword-modified addition.

These checks keep the matcher fail-closed for programs that resemble the supported grouped GEMM structurally but have different indexing semantics.

## Benchmark stability

The checked-in DeepGEMM comparison benchmark now explicitly pins its historical BK64/source-224 profile. Compiler defaults can therefore evolve without silently changing previously published benchmark inputs or schedules. The fixed benchmark manifest also includes the tile and alignment values.

## Local performance on public leaderboard shapes

The following are Helion-only local pre-submit measurements for the eight public DeepGEMM grouped BF16 NT shape rows. No leaderboard submission source was inspected or used.

The run used the legacy profile retained by this PR (`[256, 128, 64]`, source tile 224) on an NVIDIA GB300 with CUDA 13.0 and PyTorch `2.14.0.dev20260807+cu130`.

| Row | Groups | Target M/group | N | K | Valid sum(M) | Median (us) | Valid TFLOP/s |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 4 | 8192 | 6144 | 7168 | 34,151 | 1,861.91 | 1,615.6 |
| 1 | 4 | 8192 | 7168 | 3072 | 32,782 | 866.74 | 1,665.7 |
| 2 | 4 | 8192 | 4096 | 4096 | 35,089 | 703.44 | 1,673.8 |
| 3 | 4 | 8192 | 4096 | 2048 | 32,306 | 340.26 | 1,592.9 |
| 4 | 8 | 4096 | 6144 | 7168 | 38,239 | 2,070.72 | 1,626.5 |
| 5 | 8 | 4096 | 7168 | 3072 | 34,828 | 927.04 | 1,654.5 |
| 6 | 8 | 4096 | 4096 | 4096 | 33,353 | 667.35 | 1,677.0 |
| 7 | 8 | 4096 | 4096 | 2048 | 31,684 | 340.22 | 1,562.4 |

Actual per-group M values use the benchmark's seed-0 public generation policy. Timings are captured CUDA-graph replays with two compile warmups, five graph warmups, a 10-second thermal warmup, and an 8-GB L2 flush before each measured replay. Each result is the median of ten samples, with each sample averaging 50 replays. TFLOP/s counts only valid, unpadded rows.

All eight rows passed correctness with zero reported valid-row difference and exactly zero output in padded rows. These figures came from local full-stack validation and are not official dashboard scores.

## Test coverage

- Configuration normalization rejects invalid types, values, and grouped modes.
- Seeded source-tile values survive config-generation round trips.
- Codegen and wrapper plans cover BK128/source-256 and legacy BK64/source-224 profiles.
- An over-budget BK64/source-256 configuration is rejected before launch.
- Unsafe alpha-scaled row indexing and ineligible dtype, K, N, and stride cases fail closed.
- Runtime correctness and CUDA graph replay cover both BK64 and BK128, including dirty packed-row padding and multiple K iterations.
- The benchmark manifest locks its public shapes, tile profile, alignment, and selected configuration.
