### PR TITLE
[cute] Prepare grouped scheduler for device split sizes

### DIFF
--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -62,8 +62,12 @@ class CuteTcgen05GroupedPlan:
     d_tensormap: str | None = None
     # N,M worklists carry their source-row tile explicitly so runtime metadata
     # validation and launch bounds consume the exact schedule selected by the
-    # compiler.
+    # compiler.  For the device-split variant, ``layout`` names the device
+    # ``split_sizes[G]`` tensor while ``problem_sizes`` and ``starts`` are
+    # kernel-local SMEM tensors.  ``m_size`` lets the launcher derive a safe
+    # static cluster bound without reading split values on the host.
     source_m_tile: int | None = None
+    m_size: int | None = None
 
     def __post_init__(self) -> None:
         assert (self.valid_m is None) == (self.store_m is None)
@@ -73,6 +77,11 @@ class CuteTcgen05GroupedPlan:
         )
         assert (self.direct_pointers is None) == (self.direct_strides is None)
         assert (self.d_mode is Tcgen05GroupedDMode.NONE) == (self.d_tensormap is None)
+        assert not self.device_split_sizes or self.orientation is Tcgen05Orientation.NM
+
+    @property
+    def device_split_sizes(self) -> bool:
+        return self.m_size is not None
 
 
 class _CuteTcgen05Orientation(Protocol):

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -201,8 +201,6 @@ _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_M = 5
 _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_N = 6
 _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_K = 7
 _TCGEN05_GROUPED_SELECTED_MAILBOX_GLOBAL_M_START = 8
-
-
 if TYPE_CHECKING:
     import sympy
 
@@ -3000,6 +2998,24 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
 
         tile_start_var = device_function.new_var("tcgen05_grouped_selected_tile_start")
         source_tile_m = plan.source_tile_m
+        if grouped.device_split_sizes:
+            remaining_m = (
+                f"max({grouped.problem_m} - {tile_start_var}, cutlass.Int32(0))"
+            )
+            return [
+                statement_from_string(
+                    f"{tile_start_var} = {grouped_cta_tile_idx_m} * "
+                    f"cutlass.Int32({source_tile_m})"
+                ),
+                statement_from_string(
+                    f"{grouped_valid_m} = min(cutlass.Int32({source_tile_m}), "
+                    f"{remaining_m})"
+                ),
+                statement_from_string(
+                    f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
+                    f"{remaining_m})"
+                ),
+            ]
         return [
             statement_from_string(
                 f"{tile_start_var} = {grouped_cta_tile_idx_m} * "
@@ -3455,7 +3471,6 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         plan = self._tcgen05_plan()
         assert plan is not None and plan.grouped is not None
         grouped = plan.grouped
-        assert grouped.real_groups is not None
         source_tile_m = plan.source_tile_m
         source_tile_n = plan.source_tile_n
         grouped_starts = grouped.starts
@@ -3524,17 +3539,27 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         )
 
         def source_m_fast_raster_stmts() -> list[ast.stmt]:
-            source_n_tiles_expr = CompileEnvironment.current().backend.cdiv_expr(
+            backend = CompileEnvironment.current().backend
+            source_n_tiles_expr = backend.cdiv_expr(
                 f"{group_info_var}.problem_shape_m",
                 f"cutlass.Int32({source_tile_n})",
                 is_device=True,
             )
+            source_m_tiles_expr = (
+                backend.cdiv_expr(
+                    f"{group_info_var}.problem_shape_n",
+                    f"cutlass.Int32({source_tile_m})",
+                    is_device=True,
+                )
+                if grouped.device_split_sizes
+                else (
+                    f"{group_info_var}.problem_shape_n // "
+                    f"cutlass.Int32({source_tile_m})"
+                )
+            )
             return [
                 statement_from_string(f"{source_n_tiles_var} = {source_n_tiles_expr}"),
-                statement_from_string(
-                    f"{source_m_tiles_var} = {group_info_var}.problem_shape_n // "
-                    f"cutlass.Int32({source_tile_m})"
-                ),
+                statement_from_string(f"{source_m_tiles_var} = {source_m_tiles_expr}"),
                 create(
                     ast.If,
                     test=expr_from_string(
@@ -5627,6 +5652,13 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         self, partition: Tcgen05PersistentProgramIDs._PartitionedRoleBody
     ) -> list[ast.stmt]:
         plan = self._tcgen05_plan()
+        device_split_sizes = bool(
+            plan is not None
+            and plan.grouped is not None
+            and plan.grouped.device_split_sizes
+        )
+        if device_split_sizes:
+            return self._tcgen05_unsafe_shared_stmts(partition)
         worklist_metadata = bool(
             plan is not None
             and plan.grouped is not None

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -39,6 +39,7 @@ from ..._compiler.cute.strategies import tcgen05_smem_layout_expr
 from ..._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
 )
+from ..._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
 from ..._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
 from ..._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES,
@@ -1909,12 +1910,26 @@ def _tcgen05_grouped_static_plans(cute_kernel: object) -> list[dict[str, object]
     ]
 
 
+def _tcgen05_grouped_device_split_sizes(plan: dict[str, object]) -> bool:
+    return bool(plan.get("device_split_sizes"))
+
+
+def _tcgen05_grouped_host_metadata_plans(
+    cute_kernel: object,
+) -> list[dict[str, object]]:
+    return [
+        plan
+        for plan in _tcgen05_grouped_static_plans(cute_kernel)
+        if not _tcgen05_grouped_device_split_sizes(plan)
+    ]
+
+
 def _cute_grouped_static_metadata_matches(
     grouped_static_metadata: tuple[_Tcgen05GroupedStaticMetadataCacheEntry, ...],
     cute_kernel: object,
     args: tuple[object, ...],
 ) -> bool:
-    plans = _tcgen05_grouped_static_plans(cute_kernel)
+    plans = _tcgen05_grouped_host_metadata_plans(cute_kernel)
     if len(grouped_static_metadata) != len(plans):
         return False
     for plan, entry in zip(plans, grouped_static_metadata, strict=True):
@@ -2066,7 +2081,13 @@ def _tcgen05_grouped_static_layout_arg(
             "cute", "tcgen05 grouped scheduler layout must be a CUDA tensor"
         )
     worklist_metadata = bool(plan.get("worklist_metadata"))
-    if worklist_metadata:
+    if _tcgen05_grouped_device_split_sizes(plan):
+        if layout.ndim != 1:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped device split_sizes must have shape [G]",
+            )
+    elif worklist_metadata:
         if layout.ndim != 2 or layout.size(1) != 4:
             raise exc.BackendUnsupported(
                 "cute",
@@ -2081,6 +2102,100 @@ def _tcgen05_grouped_static_layout_arg(
             "cute", "tcgen05 grouped scheduler layout must be int32 or int64"
         )
     return layout
+
+
+def _validate_tcgen05_grouped_device_split_sizes(
+    plan: dict[str, object],
+    split_sizes: torch.Tensor,
+) -> None:
+    group_count = _plan_int_value(plan, "group_count")
+    if int(split_sizes.numel()) != group_count:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped device split_sizes length must match group count",
+        )
+    if _tcgen05_plan_orientation(plan) != "nm":
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped device split_sizes requires N,M orientation",
+        )
+    bk = _plan_int_value(plan, "bk")
+    source_m_tile = _plan_int_value(plan, "source_m_tile")
+    m_size = _plan_int_value(plan, "m_size")
+    n_size = _plan_int_value(plan, "n_size")
+    k_total_size = _plan_int_value(plan, "k_total_size")
+    int32_max = torch.iinfo(torch.int32).max
+    if any(
+        extent <= 0 or extent > int32_max
+        for extent in (group_count, m_size, n_size, k_total_size)
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped device split_sizes requires G, M, N, and K "
+            "dimensions to be positive signed Int32 values",
+        )
+    if (
+        bk not in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+        or source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+        or n_size % TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[2] != 0
+        or k_total_size % bk != 0
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped device split_sizes requires block_k 64 or 128, "
+            "a validated source M tile, output N divisible by 32, and K "
+            "divisible by the CTA K tile",
+        )
+    if (
+        not bool(plan.get("dynamic_ab_tensormaps"))
+        or _tcgen05_grouped_dynamic_ab_tensormap_rank(plan) != 2
+        or not bool(plan.get("dynamic_d_tensormap"))
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped device split_sizes requires rank-2 dynamic A/B "
+            "TensorMaps and a dynamic D TensorMap",
+        )
+
+
+def _tcgen05_grouped_device_split_total_clusters(
+    plan: dict[str, object],
+) -> int:
+    """Return a value-independent bound for device split-size metadata.
+
+    The kernel clips every raw group interval to the packed ``[0, M)`` extent,
+    so any one group can expose at most ``ceil(M / source_m_tile)`` row tiles,
+    regardless of split signs, sums, or overlaps.  Multiply that bound by G
+    and by the output-column cluster count.  The wrapper caps the physical grid
+    at the active-cluster limit, so this conservative logical bound does not
+    increase resident clusters and requires no host read of split values.
+    """
+    group_count = _plan_int_value(plan, "group_count")
+    m_size = _plan_int_value(plan, "m_size")
+    n_size = _plan_int_value(plan, "n_size")
+    source_m_tile = _plan_int_value(plan, "source_m_tile")
+    if (
+        group_count <= 0
+        or m_size <= 0
+        or n_size <= 0
+        or source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped device split_sizes requires positive G, M, and N "
+            "and a validated source M tile",
+        )
+    n_clusters = (
+        n_size + TCGEN05_GROUPED_WORKLIST_MMA_M_TILE - 1
+    ) // TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
+    packed_m_clusters = (m_size + source_m_tile - 1) // source_m_tile
+    total_clusters = n_clusters * group_count * packed_m_clusters
+    if total_clusters > torch.iinfo(torch.int32).max:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped device split_sizes cluster bound must fit signed Int32",
+        )
+    return total_clusters
 
 
 def _cute_dynamic_tensormap_contexts(
@@ -2624,6 +2739,8 @@ def _append_tcgen05_grouped_static_mutation_guards(
     args: tuple[object, ...],
 ) -> None:
     for plan in _tcgen05_grouped_static_plans(cute_kernel):
+        if _tcgen05_grouped_device_split_sizes(plan):
+            continue
         for label, index in (
             ("layout", _plan_int_value(plan, "layout_idx")),
             ("n_sizes", plan.get("n_sizes_idx")),
@@ -3425,27 +3542,10 @@ def _build_cute_schema_and_args(
         if owned:
             owned_tensors.append(tensor)
 
-    for plan in _tcgen05_grouped_static_plans(cute_kernel):
-        metadata_entry = _build_tcgen05_grouped_static_metadata(cute_kernel, plan, args)
-        metadata_result = metadata_entry.result
-        problem_tensor = metadata_result.problem_sizes
-        starts_tensor = metadata_result.starts
-        real_groups_tensor = metadata_result.real_groups
-        direct_pointers_tensor = metadata_result.direct_pointers
-        direct_strides_tensor = metadata_result.direct_strides
-        total_clusters = metadata_result.total_clusters
-        grouped_static_metadata.append(metadata_entry)
-        layout = _tcgen05_grouped_static_layout_arg(plan, args)
-        for name, tensor in (
-            (_plan_str_value(plan, "problem_sizes_arg"), problem_tensor),
-            (_plan_str_value(plan, "starts_arg"), starts_tensor),
-            *(
-                ((_plan_str_value(plan, "real_groups_arg"), real_groups_tensor),)
-                if real_groups_tensor is not None
-                else ()
-            ),
-        ):
-            append_wrapper_tensor(name, tensor)
+    def append_grouped_tensormap_workspace(
+        plan: dict[str, object],
+        layout: torch.Tensor,
+    ) -> None:
         workspace_name: str | None = None
         tensormap_count = 0
         if bool(plan.get("dynamic_ab_tensormaps")):
@@ -3462,6 +3562,38 @@ def _build_cute_schema_and_args(
                 tensormap_count=tensormap_count,
             )
             append_wrapper_tensor(workspace_name, workspace, owned=True)
+
+    for plan in _tcgen05_grouped_static_plans(cute_kernel):
+        layout = _tcgen05_grouped_static_layout_arg(plan, args)
+        if _tcgen05_grouped_device_split_sizes(plan):
+            _validate_tcgen05_grouped_tensor_devices(layout, args)
+            _validate_tcgen05_grouped_device_split_sizes(plan, layout)
+            append_grouped_tensormap_workspace(plan, layout)
+            total_name = _plan_str_value(plan, "total_clusters_arg")
+            schema.append(("wrapper_host_scalar", total_name, "int"))
+            launch_args.append(_tcgen05_grouped_device_split_total_clusters(plan))
+            continue
+
+        metadata_entry = _build_tcgen05_grouped_static_metadata(cute_kernel, plan, args)
+        metadata_result = metadata_entry.result
+        problem_tensor = metadata_result.problem_sizes
+        starts_tensor = metadata_result.starts
+        real_groups_tensor = metadata_result.real_groups
+        direct_pointers_tensor = metadata_result.direct_pointers
+        direct_strides_tensor = metadata_result.direct_strides
+        total_clusters = metadata_result.total_clusters
+        grouped_static_metadata.append(metadata_entry)
+        for name, tensor in (
+            (_plan_str_value(plan, "problem_sizes_arg"), problem_tensor),
+            (_plan_str_value(plan, "starts_arg"), starts_tensor),
+            *(
+                ((_plan_str_value(plan, "real_groups_arg"), real_groups_tensor),)
+                if real_groups_tensor is not None
+                else ()
+            ),
+        ):
+            append_wrapper_tensor(name, tensor)
+        append_grouped_tensormap_workspace(plan, layout)
         if direct_pointers_tensor is not None and direct_strides_tensor is not None:
             append_wrapper_tensor(
                 _plan_str_value(plan, "direct_pointers_arg"),
@@ -3565,6 +3697,8 @@ def _cute_last_launch_arg_guard(
         )
     grouped_mutation_guards: list[_CuteLastGroupedMutationGuard] = []
     for plan in _tcgen05_grouped_static_plans(cute_kernel):
+        if _tcgen05_grouped_device_split_sizes(plan):
+            continue
         for index in (
             _plan_int_value(plan, "layout_idx"),
             plan.get("n_sizes_idx"),

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -8162,6 +8162,58 @@ class TestCuteBackend(TestCase):
         self.assertEqual(second, ("launched", (context_b, "stream-B")))
         self.assertEqual(third, ("launched", (context_b, "stream-C")))
 
+    def test_grouped_static_metadata_match_filters_device_plans(self) -> None:
+        launcher = importlib.import_module("helion.runtime.cute.launcher")
+        host_plan = {"kind": "tcgen05_grouped_static_persistent"}
+        device_plan = {
+            "kind": "tcgen05_grouped_static_persistent",
+            "device_split_sizes": True,
+        }
+        unrelated_plan = {"kind": "unrelated"}
+        cute_kernel = type("DummyCuteKernel", (), {})()
+
+        class Entry:
+            has_m_tail = False
+            has_n_tail = False
+
+            def __init__(self, matches: bool = True) -> None:
+                self._matches = matches
+
+            def matches(self, *_args: object) -> bool:
+                return self._matches
+
+        def metadata_matches(entries: tuple[Entry, ...]) -> bool:
+            return launcher._cute_grouped_static_metadata_matches(
+                entries,
+                cute_kernel,
+                (),
+            )
+
+        with (
+            patch.object(
+                launcher,
+                "_tcgen05_grouped_static_layout_arg",
+                return_value=object(),
+            ),
+            patch.object(
+                launcher,
+                "_tcgen05_grouped_static_size_arg",
+                return_value=None,
+            ),
+        ):
+            for plans in ([], [unrelated_plan], [device_plan]):
+                cute_kernel._helion_cute_wrapper_plans = plans
+                self.assertTrue(metadata_matches(()))
+
+            for plans in (
+                [host_plan, device_plan],
+                [device_plan, unrelated_plan, host_plan],
+            ):
+                cute_kernel._helion_cute_wrapper_plans = plans
+                self.assertTrue(metadata_matches((Entry(),)))
+                self.assertFalse(metadata_matches(()))
+                self.assertFalse(metadata_matches((Entry(matches=False),)))
+
     def test_grouped_capture_retains_generated_tensors_beyond_launch_lru(
         self,
     ) -> None:
@@ -8368,6 +8420,48 @@ class TestCuteBackend(TestCase):
                     torch.empty((0, 64, 64), dtype=torch.bfloat16, device=DEVICE),
                     layout,
                 ),
+            )
+
+    def test_grouped_device_split_cluster_bound_uses_source_profile(self) -> None:
+        launcher = importlib.import_module("helion.runtime.cute.launcher")
+        common_plan = {
+            "group_count": 8,
+            "m_size": 2048,
+            "n_size": 512,
+        }
+
+        self.assertEqual(
+            launcher._tcgen05_grouped_device_split_total_clusters(
+                {**common_plan, "source_m_tile": 224}
+            ),
+            160,
+        )
+        self.assertEqual(
+            launcher._tcgen05_grouped_device_split_total_clusters(
+                {**common_plan, "source_m_tile": 256}
+            ),
+            128,
+        )
+
+    def test_grouped_device_split_dimensions_must_fit_int32(self) -> None:
+        launcher = importlib.import_module("helion.runtime.cute.launcher")
+        plan = {
+            "group_count": 1,
+            "orientation": "nm",
+            "bk": 128,
+            "source_m_tile": 256,
+            "m_size": torch.iinfo(torch.int32).max + 1,
+            "n_size": 512,
+            "k_total_size": 128,
+            "dynamic_ab_tensormaps": True,
+            "dynamic_ab_tensormap_rank": 2,
+            "dynamic_d_tensormap": True,
+        }
+
+        with self.assertRaisesRegex(BackendUnsupported, "positive signed Int32"):
+            launcher._validate_tcgen05_grouped_device_split_sizes(
+                plan,
+                torch.empty(1, dtype=torch.int32),
             )
 
     def test_grouped_inference_metadata_tracks_value_mutation(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3314
 * __->__#3313
 * #3312

--- --- ---

### [cute] Prepare grouped scheduler for device split sizes

## Summary

Prepare the existing tcgen05 grouped N,M scheduler and CuTe launcher for grouped GEMMs whose `split_sizes[G]` remain on the GPU. This PR defines the scheduler/runtime contract used by #3314; it deliberately does not add the compiler matcher that selects the new path.

The current grouped path builds scheduler metadata on the host and caches it using the input tensors' mutation versions. That model cannot support CUDA-graph replay with device-mutated split sizes: reading the values on the host would synchronize, and reusing host-derived metadata would become stale. The device-split path instead treats the split tensor as a kernel input, rebuilds `problem_sizes` and `starts` in shared memory on every launch or replay, and keeps only value-independent launch metadata on the host.

## Scheduler changes

- Extend `CuteTcgen05GroupedPlan` with the packed-M extent. Its presence identifies device-split mode and restricts that mode to the N,M orientation.
- Derive `valid_m` and `store_m` from each device-built group problem size rather than loading tail lengths from a host-prepared `[W, 4]` worklist.
- Use the metadata index as the real group index when no host `real_groups` remapping tensor exists.
- Use ceiling division for source-M tiles in device mode so non-tile-aligned split tails remain schedulable; the existing host-worklist path keeps its exact-division behavior.
- Preserve the shared loop whenever device split metadata construction contains observable work. The more permissive omission rules remain limited to host-prepared worklists, preventing split loads or metadata stores from being optimized away.

## Launcher changes

- Separate host-metadata plans from device-split plans when matching launch-cache entries. Host plans continue to build and own `problem_sizes`, `starts`, and optional remapping tensors; device plans pass the original rank-1 split tensor through and allocate only the dynamic TensorMap workspace.
- Validate the complete device-plan contract before launch: `[G]` int32/int64 split tensor, matching group count, N,M orientation, positive signed-Int32 G/M/N/K extents, supported BK/source-M profiles, N/K divisibility, and rank-2 dynamic A/B plus dynamic D TensorMaps.
- Compute a value-independent logical cluster bound without reading split values: `ceil(N / mma_tile) * G * ceil(M / source_m_tile)`. Each raw group interval is clipped to `[0, M)`, so this remains safe for tails, negative values, oversized values, and overlapping raw prefixes. The physical grid is still capped by the active-cluster limit.
- Exclude device split tensors from value-mutation guards. Pointer, shape, and stride guards still protect the wrapper ABI; value changes are intentionally consumed by the in-kernel metadata rebuild and therefore work during CUDA graph replay.
- Share dynamic TensorMap workspace setup between the existing host path and the new device path, leaving host-generated grouped metadata behavior unchanged.

## Why this is separate

#3312 establishes the validated BK64/BK128 and source-M scheduling profiles. This PR then adds the scheduler and launcher invariants for device-resident metadata without changing kernel selection. #3314 adds the IR recognition, semantic proof, and in-kernel metadata materialization that activate the path.

Keeping this layer separate makes launch-cache behavior, wrapper ABI, and grid-safety rules reviewable independently from the larger compiler matcher.

## Performance

There is no standalone leaderboard result for this commit because it does not yet emit a device-split plan; existing kernels continue down the host-metadata path. End-to-end KernelGen Problem 18 performance for the completed stack is reported in #3314.

## Safety and tests

Focused coverage verifies:

- filtering device plans out of host-generated metadata cache matching, including mixed plan order;
- conservative cluster-bound arithmetic for both 224-row and 256-row source profiles; and
- fail-closed rejection when static dimensions exceed signed Int32.
