### PR TITLE
[cute] specialize static grouped GEMM schedules

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -554,13 +554,15 @@ def _tcgen05_grouped_dynamic_bk64_fact(env: CompileEnvironment) -> MatmulFact | 
         and _block_size_value_reachable(spec, 2, 64)
     ):
         return None
-    if not spec._tcgen05_grouped_dynamic_ab4_fits_for_target(
+    if not spec._tcgen05_grouped_dynamic_stages_fit_for_target(
         dtype_bytes=fact.lhs_dtype.itemsize,
+        output_dtype_bytes=fact.lhs_dtype.itemsize,
         device=env.device,
         bm=128,
         bn=64,
         bk=64,
         cluster_m=1,
+        ab_stages=TCGEN05_GROUPED_DYNAMIC_AB4_STAGE,
         c_stages=2,
     ):
         return None

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -70,6 +70,7 @@ from .strategies import tcgen05_resolve_epilogue_tile
 from .strategies import tcgen05_smem_layout_expr
 from .strategies import warp_spec_from_config
 from .tcgen05_config import CuteTcgen05Config
+from .tcgen05_config import parse_tcgen05_grouped_static_problem_signature
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_PHASE1
@@ -111,7 +112,9 @@ from .tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
 from .tcgen05_constants import TCGEN05_GROUPED_MODES
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_BLOCK_K_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS
+from .tcgen05_constants import TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_STATIC_SPECIALIZATION_MAX_GROUPS
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
@@ -3888,6 +3891,7 @@ class _PerKiterTmaArgs:
     static_full_tiles: bool = False
     tma_desc_ptr_a: str | None = None
     tma_desc_ptr_b: str | None = None
+    tma_desc_acquire_fence_src: str | None = None
 
 
 def _kloop_tma_copy_a_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
@@ -4021,6 +4025,12 @@ def _build_kloop_pipeline_producer_if(
             f"    {args.tma_pipeline}.producer_acquire("
             f"{args.tma_producer_state}, {args.tma_producer_try_token})\n"
         )
+    if args.tma_desc_acquire_fence_src is not None:
+        assert load_current_tile, (
+            "dynamic TensorMap acquire fences belong to the grouped "
+            "current-tile producer"
+        )
+        src += textwrap.indent(args.tma_desc_acquire_fence_src, "    ") + "\n"
     src += (
         f"    {args.tma_barrier_ptr} = "
         f"{args.tma_pipeline}.producer_get_barrier({args.tma_producer_state})\n"
@@ -5264,6 +5274,16 @@ def _emit_mma_pipeline(
     )
     tcgen05_grouped_external_direct_pointers_arg_name: str | None = None
     tcgen05_grouped_external_direct_strides_arg_name: str | None = None
+    tcgen05_grouped_static_problem_shapes = (
+        parse_tcgen05_grouped_static_problem_signature(signature)
+        if (
+            signature := cg.device_function.config.get(
+                TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
+            )
+        )
+        is not None
+        else None
+    )
     tcgen05_grouped_static_reserved_sms = int(
         cast(
             "Any",
@@ -6280,6 +6300,7 @@ def _emit_mma_pipeline(
     tcgen05_grouped_sched_params: str | None = None
     tcgen05_grouped_problem_sizes: str | None = None
     tcgen05_grouped_starts: str | None = None
+    tcgen05_grouped_static_quota_args: tuple[str, ...] = ()
     tcgen05_grouped_real_groups: str | None = None
     tcgen05_grouped_metadata_idx: str | None = None
     tcgen05_grouped_group_idx: str | None = None
@@ -6485,8 +6506,9 @@ def _emit_mma_pipeline(
                 "only for FP16/BF16 rank3 RHS grouped-NT CtaGroup.ONE "
                 "persistent_interleaved static-full 128x(64|128)x(16|32|64|128) "
                 "TMA-load + TMA-store kernels, or the generated segment "
-                "worklist BK64/BK128 dynamic-TensorMap variant (including the "
-                "CtaGroup.TWO 256x(64|128)x(64|128) worklist shape), with no "
+                "worklist BK64/BK128 or direct BK64 dynamic-TensorMap variant "
+                "(including the CtaGroup.TWO 256x(64|128)x(64|128) worklist "
+                "shape), with no "
                 "scheduler/C-input/store warp variants; failed checks: "
                 + ", ".join(failed_grouped_checks),
             )
@@ -6531,6 +6553,16 @@ def _emit_mma_pipeline(
                     f"require {grouped_smem_required} bytes of per-CTA "
                     f"SMEM, exceeding the {grouped_smem_capacity}-byte capacity",
                 )
+        if (
+            tcgen05_grouped_static_problem_shapes is not None
+            and len(tcgen05_grouped_static_problem_shapes) != grouped_count_value
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY} describes "
+                f"{len(tcgen05_grouped_static_problem_shapes)} groups, but the "
+                f"grouped RHS has {grouped_count_value}",
+            )
         tcgen05_grouped_dynamic_ab_tensormap_rank = (
             3
             if tcgen05_grouped_dynamic_ab_tensormaps_requested
@@ -6679,44 +6711,44 @@ def _emit_mma_pipeline(
             )
             == 2
         )
-        if tcgen05_ab_stage_count_value > 3 and not (
-            nm_deep_ab
-            or (
-                tcgen05_ab_stage_count_value == 4
-                and tcgen05_grouped_dynamic_ab_tensormap_rank is not None
-                and tcgen05_grouped_d_mode is not Tcgen05GroupedDMode.NONE
-                and bm == 128
-                and bn == 64
-                and bk == 64
-                and tcgen05_cluster_m == 1
-                and tcgen05_cluster_n == 1
-                and not tcgen05_is_two_cta
-                and _tcgen05_config_int(
-                    df.config,
-                    "tcgen05_acc_stages",
-                    _tcgen05_acc_stage_count(tcgen05_mma_bn),
-                )
-                == 2
-                and tcgen05_c_stage_count_value == 2
-                and env.config_spec._tcgen05_grouped_dynamic_ab4_fits_for_target(
-                    dtype_bytes=input_dtype.itemsize,
-                    device=lhs_info.source_fake.device,
-                    bm=bm,
-                    bn=bn,
-                    bk=bk,
-                    cluster_m=tcgen05_cluster_m,
-                    c_stages=tcgen05_c_stage_count_value,
-                )
+        grouped_dynamic_deep_ab = (
+            tcgen05_grouped_dynamic_ab_tensormap_rank is not None
+            and tcgen05_grouped_d_mode is not Tcgen05GroupedDMode.NONE
+            and bm == 128
+            and bn == 64
+            and bk == 64
+            and tcgen05_cluster_m == 1
+            and tcgen05_cluster_n == 1
+            and not tcgen05_is_two_cta
+            and _tcgen05_config_int(
+                df.config,
+                "tcgen05_acc_stages",
+                _tcgen05_acc_stage_count(tcgen05_mma_bn),
             )
+            == 2
+            and env.config_spec._tcgen05_grouped_dynamic_stages_fit_for_target(
+                dtype_bytes=input_dtype.itemsize,
+                output_dtype_bytes=(epi_elem_dtype or input_dtype).itemsize,
+                device=lhs_info.source_fake.device,
+                bm=bm,
+                bn=bn,
+                bk=bk,
+                cluster_m=tcgen05_cluster_m,
+                ab_stages=tcgen05_ab_stage_count_value,
+                c_stages=tcgen05_c_stage_count_value,
+            )
+        )
+        if tcgen05_ab_stage_count_value > 3 and not (
+            nm_deep_ab or grouped_dynamic_deep_ab
         ):
             raise exc.BackendUnsupported(
                 "cute",
                 f"{TCGEN05_GROUPED_MODE_CONFIG_KEY} admits explicit "
                 "tcgen05_ab_stages>3 only for the generated N,M-oriented "
                 "worklist schedule up to 7 stages within target-device SMEM "
-                "headroom, or tcgen05_ab_stages=4 for the FP16/BF16 rank3 "
-                "grouped-NT dynamic TensorMap BK64 128x64x64 CtaGroup.ONE "
-                "path with cluster_m=cluster_n=1, acc_stages=2, c_stages=2, "
+                "headroom, or an admitted deep pipeline for the FP16/BF16 rank3 "
+                "grouped-NT dynamic TensorMap 128x64x64 CtaGroup.ONE "
+                "path with cluster_m=cluster_n=1, acc_stages=2, "
                 "dynamic D TensorMap, and target-device SMEM headroom",
             )
         tcgen05_grouped_count = str(grouped_count_value)
@@ -6724,6 +6756,15 @@ def _emit_mma_pipeline(
         tcgen05_grouped_sched_params = df.new_var("tcgen05_grouped_tile_sched_params")
         tcgen05_grouped_problem_sizes = df.new_var("tcgen05_grouped_problem_sizes")
         tcgen05_grouped_starts = df.new_var("tcgen05_grouped_starts")
+        if (
+            tcgen05_grouped_static_problem_shapes is not None
+            and len(tcgen05_grouped_static_problem_shapes)
+            <= TCGEN05_GROUPED_STATIC_SPECIALIZATION_MAX_GROUPS
+        ):
+            tcgen05_grouped_static_quota_args = tuple(
+                df.new_var("tcgen05_grouped_static_quota")
+                for _ in tcgen05_grouped_static_problem_shapes
+            )
         if (
             tcgen05_grouped_worklist_persistent
             and not tcgen05_grouped_device_split_sizes
@@ -6780,6 +6821,8 @@ def _emit_mma_pipeline(
             problem_n=cast("str", tcgen05_grouped_problem_n),
             problem_k=cast("str", tcgen05_grouped_problem_k),
             global_m_start=cast("str", tcgen05_grouped_global_m_start),
+            static_problem_shapes=tcgen05_grouped_static_problem_shapes,
+            static_group_quota_args=tcgen05_grouped_static_quota_args,
             real_groups=tcgen05_grouped_real_groups,
             valid_m=tcgen05_grouped_valid_m,
             store_m=tcgen05_grouped_store_m,
@@ -7421,6 +7464,24 @@ def _emit_mma_pipeline(
         # ``TCGEN05_LEGAL_L2_SWIZZLE_SIZES`` so it is always a positive
         # integer here.
         tcgen05_l2_swizzle_size_value = l2_swizzle_size_from_config(df.config)
+        if (
+            tcgen05_grouped_static_problem_shapes is not None
+            and tcgen05_l2_swizzle_size_value != 1
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY} requires "
+                "tcgen05_l2_swizzle_size=1",
+            )
+        if tcgen05_grouped_static_problem_shapes is not None and any(
+            grouping != 1
+            for grouping in cast("list[int]", df.config.get("l2_groupings", []))
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY} requires "
+                "l2_groupings entries to all equal 1",
+            )
         # Both production callers of ``_emit_mma_pipeline`` propagate
         # an FX node into this codepath (``codegen_cute_mma_dot``
         # passes ``state.fx_node``; the aten-style site passes the
@@ -8828,6 +8889,7 @@ def _emit_mma_pipeline(
                         ]
                     )
                 grouped_wrapper_params.append(grouped_plan.sched_params)
+                grouped_wrapper_params.extend(grouped_plan.static_group_quota_args)
                 df.wrapper_only_params.extend(grouped_wrapper_params)
                 cg.cute_wrapper_plans.append(
                     {
@@ -8864,6 +8926,15 @@ def _emit_mma_pipeline(
                             else {}
                         ),
                         "group_count": int(grouped_plan.count),
+                        **(
+                            {
+                                "static_problem_shapes": (
+                                    grouped_plan.static_problem_shapes
+                                )
+                            }
+                            if grouped_plan.static_problem_shapes is not None
+                            else {}
+                        ),
                         "bm": bm,
                         "bn": bn,
                         "bk": bk,
@@ -8902,6 +8973,15 @@ def _emit_mma_pipeline(
                         ),
                         "sched_params_arg": grouped_plan.sched_params,
                         "total_clusters_arg": tcgen05_grouped_total_clusters,
+                        **(
+                            {
+                                "static_group_quota_args": (
+                                    grouped_plan.static_group_quota_args
+                                )
+                            }
+                            if grouped_plan.static_group_quota_args
+                            else {}
+                        ),
                         **({"orientation": "nm"} if nm_worklist else {}),
                         **(
                             {"worklist_metadata": True}
@@ -9233,10 +9313,6 @@ def _emit_mma_pipeline(
                         f"{tcgen05_matmul_plan.tma_warp_id}, "
                         f"({grouped_tensormap_a_smem_ptr}, "
                         f"{grouped_tensormap_b_smem_ptr}))\n"
-                        f"    {grouped_tensormap_manager}.fence_tensormap_update("
-                        f"{grouped_tensormap_a_ptr})\n"
-                        f"    {grouped_tensormap_manager}.fence_tensormap_update("
-                        f"{grouped_tensormap_b_ptr})\n"
                         f"    {grouped_tensormap_last_group} = "
                         f"{grouped_tensormap_update_idx}"
                     ),
@@ -9880,6 +9956,18 @@ def _emit_mma_pipeline(
                 ),
                 tma_desc_ptr_b=(
                     grouped_tensormap_b_desc_ptr
+                    if tcgen05_grouped_dynamic_ab_tensormaps
+                    else None
+                ),
+                tma_desc_acquire_fence_src=(
+                    (
+                        f"if {grouped_tensormap_group_changed} and "
+                        f"{tma_k_tile} == cutlass.Int32(0):\n"
+                        f"    {grouped_tensormap_manager}.fence_tensormap_update("
+                        f"{grouped_tensormap_a_ptr})\n"
+                        f"    {grouped_tensormap_manager}.fence_tensormap_update("
+                        f"{grouped_tensormap_b_ptr})"
+                    )
                     if tcgen05_grouped_dynamic_ab_tensormaps
                     else None
                 ),

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -53,6 +53,8 @@ class CuteTcgen05GroupedPlan:
     problem_n: str
     problem_k: str
     global_m_start: str
+    static_problem_shapes: tuple[tuple[int, int, int], ...] | None = None
+    static_group_quota_args: tuple[str, ...] = ()
     real_groups: str | None = None
     valid_m: str | None = None
     store_m: str | None = None
@@ -78,6 +80,12 @@ class CuteTcgen05GroupedPlan:
         assert (self.direct_pointers is None) == (self.direct_strides is None)
         assert (self.d_mode is Tcgen05GroupedDMode.NONE) == (self.d_tensormap is None)
         assert not self.device_split_sizes or self.orientation is Tcgen05Orientation.NM
+        if self.static_problem_shapes is not None:
+            assert self.orientation is Tcgen05Orientation.MN
+            assert self.real_groups is None
+        if self.static_group_quota_args:
+            assert self.static_problem_shapes is not None
+            assert len(self.static_group_quota_args) == len(self.static_problem_shapes)
 
     @property
     def device_split_sizes(self) -> bool:

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -91,8 +91,12 @@ from .tcgen05_constants import TCGEN05_GROUPED_DYNAMIC_MODES
 from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_DIRECT
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
 from .tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
 from .tcgen05_constants import TCGEN05_GROUPED_MODES
+from .tcgen05_constants import TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
@@ -173,7 +177,11 @@ class Tcgen05AbStagesThreeSearchConstraints(NamedTuple):
 
 
 TCGEN05_GROUPED_DYNAMIC_AB4_STAGE = 4
-TCGEN05_GROUPED_DYNAMIC_AB4_RESERVED_SMEM_BYTES = 8 * 1024
+TCGEN05_GROUPED_DYNAMIC_STAGE_TUPLES = ((4, 2), (8, 4))
+# The generated grouped kernel's non-operand allocations are about 1.6 KiB
+# (pipeline barriers, TensorMap staging, and TMEM bookkeeping). Keep a small
+# margin while still admitting CUTLASS's max-fit AB8/C4 pipeline on B200.
+TCGEN05_GROUPED_DYNAMIC_RESERVED_SMEM_BYTES = 2 * 1024
 
 
 CUTE_TCGEN05_TUNABLE_KEYS: tuple[str, ...] = (
@@ -208,6 +216,7 @@ CUTE_TCGEN05_DIAGNOSTIC_CONFIG_KEYS: frozenset[str] = frozenset(
         TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY,
         TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY,
         TCGEN05_GROUPED_MODE_CONFIG_KEY,
+        TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY,
         TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
         TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
         TCGEN05_LARGE_BN_PROOF_CONFIG_KEY,
@@ -216,6 +225,32 @@ CUTE_TCGEN05_DIAGNOSTIC_CONFIG_KEYS: frozenset[str] = frozenset(
         TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY,
     }
 )
+
+
+def parse_tcgen05_grouped_static_problem_signature(
+    value: object,
+) -> tuple[tuple[int, int, int], ...]:
+    """Parse ``[group_count, M0, N0, K0, ...]`` from an AOT config."""
+    key = TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
+    if not isinstance(value, list) or not value:
+        raise InvalidConfig(f"{key} must be a non-empty list of integers")
+    if any(type(item) is not int for item in value):
+        raise InvalidConfig(f"{key} must contain only integers (not booleans)")
+    group_count = value[0]
+    if group_count <= 0 or len(value) != 1 + 3 * group_count:
+        raise InvalidConfig(
+            f"{key} must have the form [group_count, M0, N0, K0, ...] "
+            "with exactly three positive sizes per group"
+        )
+    shapes = tuple(
+        (value[offset], value[offset + 1], value[offset + 2])
+        for offset in range(1, len(value), 3)
+    )
+    if any(size <= 0 for shape in shapes for size in shape):
+        raise InvalidConfig(f"{key} requires every M/N/K size to be positive")
+    return shapes
+
+
 CUTE_TCGEN05_STRATEGY_CONFIG_KEYS: frozenset[str] = frozenset(
     TCGEN05_STRATEGY_CONFIG_KEYS
 )
@@ -926,6 +961,31 @@ class CuteTcgen05Config:
                     f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES}, got "
                     f"{source_m_tile!r}"
                 )
+        signature_key = TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
+        if signature_key in config:
+            try:
+                parse_tcgen05_grouped_static_problem_signature(config[signature_key])
+            except InvalidConfig:
+                if fix_invalid:
+                    config.pop(signature_key)
+                else:
+                    raise
+            else:
+                if config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) not in (
+                    TCGEN05_GROUPED_MODE_STATIC,
+                    TCGEN05_GROUPED_MODE_DIRECT,
+                    TCGEN05_GROUPED_MODE_DYNAMIC,
+                ):
+                    if fix_invalid:
+                        config.pop(signature_key)
+                    else:
+                        raise InvalidConfig(
+                            f"{signature_key} requires "
+                            f"{TCGEN05_GROUPED_MODE_CONFIG_KEY} to be "
+                            f"{TCGEN05_GROUPED_MODE_STATIC!r}, "
+                            f"{TCGEN05_GROUPED_MODE_DIRECT!r} or "
+                            f"{TCGEN05_GROUPED_MODE_DYNAMIC!r}"
+                        )
         reserved_sms_key = TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
         reserved_sms = config.get(reserved_sms_key)
         if reserved_sms_key in config and (
@@ -1121,13 +1181,12 @@ class CuteTcgen05Config:
         return ab_bytes + c_bytes <= constraints.per_cta_smem_budget_bytes
 
     @staticmethod
-    def _grouped_dynamic_ab4_config_matches(config: dict[str, object]) -> bool:
+    def _grouped_dynamic_deep_config_matches(config: dict[str, object]) -> bool:
         block_sizes = config.get("block_sizes")
         defaults: dict[str, object] = {
             "tcgen05_cluster_m": 1,
             "tcgen05_cluster_n": 1,
             "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": 2,
             "tcgen05_num_epi_warps": 4,
             TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
                 Tcgen05PersistenceModel.STATIC_PERSISTENT.value
@@ -1139,9 +1198,11 @@ class CuteTcgen05Config:
             TCGEN05_WARP_SPEC_STORE_WARPS_KEY: 0,
         }
         ab_stages = config.get("tcgen05_ab_stages")
+        c_stages = config.get("tcgen05_c_stages", 2)
         return (
             type(ab_stages) is int
-            and ab_stages == TCGEN05_GROUPED_DYNAMIC_AB4_STAGE
+            and type(c_stages) is int
+            and (ab_stages, c_stages) in TCGEN05_GROUPED_DYNAMIC_STAGE_TUPLES
             and config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
             in TCGEN05_GROUPED_DYNAMIC_MODES
             and isinstance(block_sizes, list)
@@ -1183,25 +1244,29 @@ class CuteTcgen05Config:
             ab_stages=ab_stages,
         )
 
-    def grouped_dynamic_ab4_fits_for_target(
+    def grouped_dynamic_stages_fit_for_target(
         self,
         *,
         dtype_bytes: int,
+        output_dtype_bytes: int,
         device: torch.device,
         bm: int,
         bn: int,
         bk: int,
         cluster_m: int,
+        ab_stages: int,
         c_stages: int,
     ) -> bool:
-        if dtype_bytes != 2:
+        if dtype_bytes != 2 or output_dtype_bytes <= 0:
             return False
-        if (bm, bn, bk, cluster_m, c_stages) != (128, 64, 64, 1, 2):
+        if (bm, bn, bk, cluster_m) != (128, 64, 64, 1):
+            return False
+        if (ab_stages, c_stages) not in TCGEN05_GROUPED_DYNAMIC_STAGE_TUPLES:
             return False
         cap_bytes = self.per_cta_smem_capacity_bytes(device)
         if cap_bytes <= 0:
             return False
-        elem_width = dtype_bytes * 8
+        elem_width = output_dtype_bytes * 8
         epi_tile_m, epi_tile_n = tcgen05_default_epilogue_tile_size(
             bm,
             bn,
@@ -1213,17 +1278,17 @@ class CuteTcgen05Config:
             bn=bn,
             bk=bk,
             dtype_bytes=dtype_bytes,
-            ab_stages=TCGEN05_GROUPED_DYNAMIC_AB4_STAGE,
+            ab_stages=ab_stages,
             cluster_m=cluster_m,
         )
         c_bytes = tcgen05_c_smem_bytes_per_cta(
             epi_tile_m=epi_tile_m,
             epi_tile_n=epi_tile_n,
-            dtype_bytes=dtype_bytes,
+            dtype_bytes=output_dtype_bytes,
             c_stages=c_stages,
         )
         return (
-            ab_bytes + c_bytes + TCGEN05_GROUPED_DYNAMIC_AB4_RESERVED_SMEM_BYTES
+            ab_bytes + c_bytes + TCGEN05_GROUPED_DYNAMIC_RESERVED_SMEM_BYTES
             <= cap_bytes
         )
 
@@ -1662,7 +1727,7 @@ class CuteTcgen05Config:
         ab_stages = config.get("tcgen05_ab_stages")
         if type(ab_stages) is not int or ab_stages <= 3:
             return
-        if self._grouped_dynamic_ab4_config_matches(config):
+        if self._grouped_dynamic_deep_config_matches(config):
             return
         if self._grouped_worklist_nm_deep_ab_config_matches(config, ab_stages):
             return
@@ -2585,7 +2650,7 @@ class CuteTcgen05Config:
             for key, fragment in optional_fragments.items():
                 if key in config:
                     if key == "tcgen05_ab_stages" and (
-                        self._grouped_dynamic_ab4_config_matches(config)
+                        self._grouped_dynamic_deep_config_matches(config)
                         or self._grouped_worklist_nm_deep_ab_config_matches(
                             config,
                             config[key],

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -454,6 +454,16 @@ TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS = (
 TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY = "tcgen05_grouped_static_reserved_sms"
 TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES = (0, 2, 3, 4, 5, 8, 16)
 TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX = 1024
+# Exact per-group M/N/K values embedded by an AOT specialization.  The runtime
+# validates these values against the scheduler metadata before launch; codegen
+# can then replace the generic warp-wide group search with constant branches.
+TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY = (
+    "tcgen05_grouped_static_problem_signature"
+)
+# The specialized scheduler emits one constant branch per group in each
+# warp-specialized role. Larger signatures use the generic scheduler to bound
+# generated source and compile time.
+TCGEN05_GROUPED_STATIC_SPECIALIZATION_MAX_GROUPS = 8
 # Direct pointer/stride metadata for grouped dynamic TensorMap updates. This
 # keeps A/B/D payload tensors in place and only passes small per-group metadata
 # tensors to generated tcgen05 code.

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -19,6 +19,7 @@ from .compile_environment import CompileEnvironment
 from .cute.cutedsl_compat import emit_pipeline_advance
 from .cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_DEFAULT
 from .cute.strategies import l2_swizzle_size_from_config
+from .cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_SPECIALIZATION_MAX_GROUPS
 from .cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_NORMAL
@@ -3031,7 +3032,171 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             ),
         ]
 
-    def _build_grouped_static_role_local_while(
+    def _build_specialized_grouped_static_role_local_while(
+        self,
+        device_function: DeviceFunction,
+        role_block: Tcgen05PersistentProgramIDs._PersistentRoleBlock,
+        *,
+        scheduler_var_prefix: str,
+        dependency_stmts: list[ast.stmt] | None,
+        role_prelude_stmts: list[ast.stmt] | None,
+        initialize_tile_counter: bool,
+    ) -> ast.stmt:
+        """Emit a constant grouped schedule guarded by runtime metadata checks."""
+        assert role_block.role_predicate is not None
+        plan = self._tcgen05_plan()
+        assert plan is not None and plan.grouped is not None
+        grouped = plan.grouped
+        shapes = grouped.static_problem_shapes
+        assert shapes is not None
+        assert grouped.real_groups is None
+        assert plan.accumulator_view == "mn"
+        assert plan.cluster_m == 1 and plan.cluster_n == 1
+        assert plan.l2_swizzle_size == 1
+
+        linear_idx = device_function.new_var(
+            f"{scheduler_var_prefix}_static_linear_idx"
+        )
+        local_idx = device_function.new_var(f"{scheduler_var_prefix}_static_local_idx")
+        prelude = [
+            statement_from_string(
+                f"{linear_idx} = cutlass.Int32(cute.arch.block_idx()[2])"
+            ),
+            statement_from_string(f"{local_idx} = cutlass.Int32(0)"),
+        ]
+        tile_counter_var, increment_tile_counter_per_tile = (
+            self._finish_role_local_prelude(
+                device_function,
+                role_block,
+                prelude,
+                role_prelude_stmts=role_prelude_stmts,
+                initialize_tile_counter=initialize_tile_counter,
+            )
+        )
+
+        source_tile_m = plan.source_tile_m
+        source_tile_n = plan.source_tile_n
+        global_m_start = 0
+        group_specs: list[tuple[int, int, int, int, int, int, int]] = []
+        for metadata_idx, (problem_m, problem_n, problem_k) in enumerate(shapes):
+            m_tiles = (problem_m + source_tile_m - 1) // source_tile_m
+            n_tiles = (problem_n + source_tile_n - 1) // source_tile_n
+            group_specs.append(
+                (
+                    metadata_idx,
+                    problem_m,
+                    problem_n,
+                    problem_k,
+                    m_tiles,
+                    n_tiles,
+                    global_m_start,
+                )
+            )
+            global_m_start += m_tiles * source_tile_m
+
+        tile_counts = [m_tiles * n_tiles for *_, m_tiles, n_tiles, _ in group_specs]
+        # Keep every CTA on one group so dynamic TensorMaps are programmed only
+        # once. The device-specific wrapper supplies host-computed quotas, so
+        # each CTA only performs the group dispatch and tile-stride loop.
+        quota_vars = list(grouped.static_group_quota_args)
+        assert len(quota_vars) == len(group_specs)
+
+        group_bodies: list[list[ast.stmt]] = []
+        quota_prefix: list[str] = []
+        for (
+            metadata_idx,
+            problem_m,
+            problem_n,
+            problem_k,
+            m_tiles,
+            _n_tiles,
+            group_m_start,
+        ), tile_count, quota in zip(group_specs, tile_counts, quota_vars, strict=True):
+            block_offset = " + ".join(quota_prefix)
+            local_expr = (
+                linear_idx if not block_offset else f"{linear_idx} - ({block_offset})"
+            )
+            group_prelude = [
+                f"{grouped.metadata_idx} = cutlass.Int32({metadata_idx})",
+                f"{grouped.group_idx} = cutlass.Int32({metadata_idx})",
+                f"{grouped.problem_m} = cutlass.Int32({problem_m})",
+                f"{grouped.problem_n} = cutlass.Int32({problem_n})",
+                f"{grouped.problem_k} = cutlass.Int32({problem_k})",
+                f"{grouped.global_m_start} = cutlass.Int32({group_m_start})",
+                f"{local_idx} = {local_expr}",
+            ]
+            per_tile_body = [
+                statement_from_string(
+                    f"{grouped.cta_tile_idx_m} = {local_idx} % cutlass.Int32({m_tiles})"
+                ),
+                statement_from_string(
+                    f"{grouped.cta_tile_idx_n} = {local_idx} // "
+                    f"cutlass.Int32({m_tiles})"
+                ),
+                statement_from_string(f"pid_0 = {grouped.cta_tile_idx_m}"),
+                statement_from_string(f"pid_1 = {grouped.cta_tile_idx_n}"),
+                statement_from_string(
+                    f"tile_offset_0 = {grouped.global_m_start} + "
+                    f"{grouped.cta_tile_idx_m} * cutlass.Int32({source_tile_m})"
+                ),
+                statement_from_string(
+                    f"tile_offset_1 = {grouped.cta_tile_idx_n} * "
+                    f"cutlass.Int32({source_tile_n})"
+                ),
+                *(
+                    _clone_stmt(stmt)
+                    for stmt in self._grouped_static_dependency_stmts(dependency_stmts)
+                ),
+                *(_clone_stmt(stmt) for stmt in role_block.stmts),
+            ]
+            if tile_counter_var is not None and increment_tile_counter_per_tile:
+                per_tile_body.append(
+                    statement_from_string(
+                        f"{tile_counter_var} = {tile_counter_var} + cutlass.Int32(1)"
+                    )
+                )
+            per_tile_body.append(
+                statement_from_string(f"{local_idx} = {local_idx} + {quota}")
+            )
+            group_bodies.append(
+                [
+                    *(statement_from_string(line) for line in group_prelude),
+                    create(
+                        ast.While,
+                        test=expr_from_string(
+                            f"{local_idx} < cutlass.Int32({tile_count})"
+                        ),
+                        body=per_tile_body,
+                        orelse=[],
+                    ),
+                ]
+            )
+            quota_prefix.append(quota)
+
+        if len(group_bodies) == 1:
+            prelude.extend(group_bodies[0])
+        else:
+            dispatch: list[ast.stmt] = group_bodies[-1]
+            for index in range(len(group_bodies) - 2, -1, -1):
+                quota_end = " + ".join(quota_vars[: index + 1])
+                dispatch = [
+                    create(
+                        ast.If,
+                        test=expr_from_string(f"{linear_idx} < {quota_end}"),
+                        body=group_bodies[index],
+                        orelse=dispatch,
+                    )
+                ]
+            prelude.extend(dispatch)
+
+        return create(
+            ast.If,
+            test=expr_from_string(role_block.role_predicate),
+            body=prelude,
+            orelse=[],
+        )
+
+    def _build_generic_grouped_static_role_local_while(
         self,
         device_function: DeviceFunction,
         role_block: Tcgen05PersistentProgramIDs._PersistentRoleBlock,
@@ -3165,6 +3330,61 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             test=expr_from_string(role_block.role_predicate),
             body=prelude,
             orelse=[],
+        )
+
+    def _build_grouped_static_role_local_while(
+        self,
+        device_function: DeviceFunction,
+        role_block: Tcgen05PersistentProgramIDs._PersistentRoleBlock,
+        *,
+        scheduler_var_prefix: str,
+        dependency_stmts: list[ast.stmt] | None,
+        role_prelude_stmts: list[ast.stmt] | None = None,
+        initialize_tile_counter: bool = True,
+    ) -> ast.stmt:
+        plan = self._tcgen05_plan()
+        assert plan is not None and plan.grouped is not None
+        shapes = plan.grouped.static_problem_shapes
+        if (
+            shapes is None
+            or len(shapes) > TCGEN05_GROUPED_STATIC_SPECIALIZATION_MAX_GROUPS
+        ):
+            return self._build_generic_grouped_static_role_local_while(
+                device_function,
+                role_block,
+                scheduler_var_prefix=scheduler_var_prefix,
+                dependency_stmts=dependency_stmts,
+                role_prelude_stmts=role_prelude_stmts,
+                initialize_tile_counter=initialize_tile_counter,
+            )
+
+        specialized = self._build_specialized_grouped_static_role_local_while(
+            device_function,
+            role_block,
+            scheduler_var_prefix=scheduler_var_prefix,
+            dependency_stmts=dependency_stmts,
+            role_prelude_stmts=role_prelude_stmts,
+            initialize_tile_counter=initialize_tile_counter,
+        )
+        generic = self._build_generic_grouped_static_role_local_while(
+            device_function,
+            role_block,
+            scheduler_var_prefix=scheduler_var_prefix,
+            dependency_stmts=dependency_stmts,
+            role_prelude_stmts=(
+                [_clone_stmt(stmt) for stmt in role_prelude_stmts]
+                if role_prelude_stmts is not None
+                else None
+            ),
+            initialize_tile_counter=initialize_tile_counter,
+        )
+        return create(
+            ast.If,
+            test=expr_from_string(
+                f"cute.arch.grid_dim()[2] >= cutlass.Int32({len(shapes)})"
+            ),
+            body=[specialized],
+            orelse=[generic],
         )
 
     def _build_grouped_static_role_local_while_with_scheduler(

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1554,24 +1554,28 @@ class ConfigSpec:
             cluster_m=cluster_m,
         )
 
-    def _tcgen05_grouped_dynamic_ab4_fits_for_target(
+    def _tcgen05_grouped_dynamic_stages_fit_for_target(
         self,
         *,
         dtype_bytes: int,
+        output_dtype_bytes: int,
         device: torch.device,
         bm: int,
         bn: int,
         bk: int,
         cluster_m: int,
+        ab_stages: int,
         c_stages: int,
     ) -> bool:
-        return self._cute_tcgen05_config.grouped_dynamic_ab4_fits_for_target(
+        return self._cute_tcgen05_config.grouped_dynamic_stages_fit_for_target(
             dtype_bytes=dtype_bytes,
+            output_dtype_bytes=output_dtype_bytes,
             device=device,
             bm=bm,
             bn=bn,
             bk=bk,
             cluster_m=cluster_m,
+            ab_stages=ab_stages,
             c_stages=c_stages,
         )
 

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -682,6 +682,26 @@ def _append_cute_wrapper_plan(
             cluster_m=max(1, cluster_m),
             reserved_sms=reserved_sms,
         )
+        quota_args = tuple(
+            str(arg)
+            for arg in cast(
+                "tuple[object, ...]", plan.get("static_group_quota_args", ())
+            )
+        )
+        quotas: tuple[int, ...] = ()
+        if quota_args:
+            assert cluster_m == 1 and cluster_n == 1
+            problem_shapes = cast(
+                "tuple[tuple[int, int, int], ...]", plan["static_problem_shapes"]
+            )
+            assert len(quota_args) == len(problem_shapes)
+            quotas = _tcgen05_grouped_static_quotas(
+                problem_shapes,
+                bm=plan_int("bm"),
+                bn=plan_int("bn"),
+                bk=plan_int("bk"),
+                max_active_clusters=max_active_clusters,
+            )
         body.extend(
             (
                 (
@@ -700,6 +720,7 @@ def _append_cute_wrapper_plan(
             )
         )
         call_args.append(sched_params_arg)
+        call_args.extend(f"cutlass.Int32({quota})" for quota in quotas)
         return
     if kind != "tcgen05_ab_tma":
         raise exc.BackendUnsupported("cute", f"wrapper plan kind: {kind}")
@@ -1967,6 +1988,51 @@ def _tcgen05_grouped_static_active_clusters(
     return max(1, active_sms // cluster_m)
 
 
+def _tcgen05_grouped_static_quotas(
+    problem_shapes: tuple[tuple[int, int, int], ...],
+    *,
+    bm: int,
+    bn: int,
+    bk: int,
+    max_active_clusters: int,
+) -> tuple[int, ...]:
+    """Balance each group's longest CTA without assigning idle CTAs.
+
+    If fewer CTAs than groups are active, the returned ones are unused because
+    the device selects the generic scheduler instead of the specialized path.
+    """
+    tile_counts = [
+        ((problem_m + bm - 1) // bm) * ((problem_n + bn - 1) // bn)
+        for problem_m, problem_n, _problem_k in problem_shapes
+    ]
+    k_tile_counts = [
+        (problem_k + bk - 1) // bk
+        for _problem_m, _problem_n, problem_k in problem_shapes
+    ]
+    quotas = [1] * len(problem_shapes)
+    grid_size = min(sum(tile_counts), max_active_clusters)
+    for _ in range(max(0, grid_size - len(quotas))):
+        candidates = [
+            index
+            for index, (quota, tile_count) in enumerate(
+                zip(quotas, tile_counts, strict=True)
+            )
+            if quota < tile_count
+        ]
+        group = max(
+            candidates,
+            key=lambda index: (
+                (tile_counts[index] + quotas[index] - 1)
+                // quotas[index]
+                * k_tile_counts[index],
+                tile_counts[index] * k_tile_counts[index],
+                -index,
+            ),
+        )
+        quotas[group] += 1
+    return tuple(quotas)
+
+
 def _plan_int_value(plan: dict[str, object], key: str) -> int:
     value = plan[key]
     assert isinstance(value, int)
@@ -3132,6 +3198,19 @@ def _build_tcgen05_grouped_static_metadata(
             "n_sizes metadata; rebind and prewarm the grouped kernel with the "
             "final metadata before launch or CUDA graph capture",
         )
+    if (expected_shapes := plan.get("static_problem_shapes")) is not None:
+        actual_shapes = tuple(
+            (problem_m, problem_n, problem_k)
+            for problem_m, problem_n, problem_k, _batch in problem_sizes
+        )
+        if actual_shapes != expected_shapes:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped static problem-shape specialization does not "
+                "match the current layout/n_sizes/k_sizes metadata; expected "
+                f"{expected_shapes!r}, got {actual_shapes!r}; rebind and prewarm "
+                "with the final grouped shapes before launch or CUDA graph capture",
+            )
 
     device = layout.device
     direct_pointers_tensor: torch.Tensor | None = None

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -20,9 +20,13 @@ from helion._compiler.backend import TritonBackend
 from helion._compiler.compile_environment import CompileEnvironment
 from helion._compiler.cute.tcgen05_config import Tcgen05AbStagesThreeSearchConstraints
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DIRECT
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY,
+)
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
 )
@@ -1250,6 +1254,65 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                 repaired.config,
             )
 
+    def test_grouped_static_problem_signature_envelope(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+        key = TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
+        signature = [2, 128, 64, 32, 16, 128, 1536]
+
+        def make_config(
+            value: object, mode: object = TCGEN05_GROUPED_MODE_DIRECT
+        ) -> helion.Config:
+            config = helion.Config(
+                block_sizes=[128, 64, 64],
+                pid_type="persistent_interleaved",
+            )
+            config.config[key] = value
+            if mode is not None:
+                config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = mode
+            return config
+
+        config = make_config(signature)
+        spec.normalize(config)
+        self.assertEqual(config.config[key], signature)
+        minimized = config.minimize(spec)
+        spec.normalize(minimized)
+        self.assertEqual(minimized.config[key], signature)
+
+        dynamic = make_config(signature, TCGEN05_GROUPED_MODE_DYNAMIC)
+        spec.normalize(dynamic)
+        self.assertEqual(dynamic.config[key], signature)
+
+        static = make_config(signature, TCGEN05_GROUPED_MODE_STATIC)
+        spec.normalize(static)
+        self.assertEqual(static.config[key], signature)
+
+        invalid_values = (
+            (2, 128, 64, 32, 16, 128, 1536),
+            [True, 128, 64, 32],
+            [2, 128, 64, 32],
+            [1, 128, 0, 32],
+        )
+        for value in invalid_values:
+            with self.subTest(value=value):
+                invalid = make_config(value)
+                with self.assertRaisesRegex(exc.InvalidConfig, key):
+                    spec.normalize(invalid)
+                fixed = make_config(value)
+                spec.normalize(fixed, _fix_invalid=True)
+                self.assertNotIn(key, fixed.config)
+
+        for mode in (
+            None,
+            TCGEN05_GROUPED_MODE_WORKLIST_NM,
+        ):
+            with self.subTest(mode=mode):
+                invalid = make_config(signature, mode)
+                with self.assertRaisesRegex(exc.InvalidConfig, key):
+                    spec.normalize(invalid)
+                fixed = make_config(signature, mode)
+                spec.normalize(fixed, _fix_invalid=True)
+                self.assertNotIn(key, fixed.config)
+
     def test_deep_ab_stage_mode_envelopes_and_stage7_roundtrip(self) -> None:
         def selected_config() -> helion.Config:
             return helion.Config(
@@ -1276,6 +1339,38 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
             spec.normalize(grouped_ab4)
 
+        grouped_ab8 = helion.Config(
+            block_sizes=[128, 64, 64],
+            pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            tcgen05_ab_stages=8,
+            tcgen05_c_stages=4,
+            **{
+                TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_DYNAMIC,
+            },
+        )
+        spec.normalize(grouped_ab8)
+        self.assertEqual(grouped_ab8.config["tcgen05_ab_stages"], 8)
+        minimized_ab8 = grouped_ab8.minimize(spec)
+        spec.normalize(minimized_ab8)
+        self.assertEqual(minimized_ab8.config["tcgen05_ab_stages"], 8)
+        self.assertEqual(minimized_ab8.config["tcgen05_c_stages"], 4)
+
+        for ab_stages, c_stages in ((8, 2), (4, 4)):
+            mismatched = helion.Config(
+                block_sizes=[128, 64, 64],
+                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+                tcgen05_ab_stages=ab_stages,
+                tcgen05_c_stages=c_stages,
+            )
+            mismatched.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = (
+                TCGEN05_GROUPED_MODE_DYNAMIC
+            )
+            with (
+                self.subTest(ab_stages=ab_stages, c_stages=c_stages),
+                self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"),
+            ):
+                spec.normalize(mismatched)
+
         config = selected_config()
         spec.normalize(config)
         minimized = config.minimize(spec)
@@ -1294,6 +1389,49 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         )
         with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
             constrained_spec.normalize(selected_config())
+
+    def test_grouped_dynamic_deep_stage_smem_accounts_for_output_dtype(self) -> None:
+        from helion._compiler.backend import CuteBackend
+        from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+
+        config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
+        with (
+            patch.object(
+                CuteTcgen05Config,
+                "per_cta_smem_capacity_bytes",
+                return_value=232448,
+            ),
+            patch(
+                "helion._compiler.cute.tcgen05_config.tcgen05_default_epilogue_tile_size",
+                return_value=(128, 32),
+            ),
+        ):
+            self.assertTrue(
+                config.grouped_dynamic_stages_fit_for_target(
+                    dtype_bytes=2,
+                    output_dtype_bytes=2,
+                    device=torch.device("cuda"),
+                    bm=128,
+                    bn=64,
+                    bk=64,
+                    cluster_m=1,
+                    ab_stages=8,
+                    c_stages=4,
+                )
+            )
+            self.assertFalse(
+                config.grouped_dynamic_stages_fit_for_target(
+                    dtype_bytes=2,
+                    output_dtype_bytes=4,
+                    device=torch.device("cuda"),
+                    bm=128,
+                    bn=64,
+                    bk=64,
+                    cluster_m=1,
+                    ab_stages=8,
+                    c_stages=4,
+                )
+            )
 
     def test_direct_cute_config_spec_enforces_clc_arch_gate(self) -> None:
         from helion._compiler.cute.strategies import (

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -8464,6 +8464,59 @@ class TestCuteBackend(TestCase):
                 torch.empty(1, dtype=torch.int32),
             )
 
+    def test_grouped_static_problem_shapes_runtime_guard(self) -> None:
+        if DEVICE.type != "cuda":
+            self.skipTest("grouped static problem-shape guard needs CUDA")
+        runtime_mod = importlib.import_module("helion.runtime")
+        base_plan = {
+            "kind": "tcgen05_grouped_static_persistent",
+            "layout_idx": 0,
+            "n_sizes_idx": 1,
+            "group_count": 2,
+            "bm": 128,
+            "bn": 64,
+            "bk": 128,
+            "n_size": 256,
+            "k_total_size": 128,
+            "problem_sizes_arg": "problem_sizes",
+            "starts_arg": "starts",
+            "total_clusters_arg": "total_clusters",
+        }
+        layout = torch.cat(
+            (
+                torch.zeros(128, dtype=torch.int32, device=DEVICE),
+                torch.ones(128, dtype=torch.int32, device=DEVICE),
+            )
+        )
+        n_sizes = torch.tensor((64, 256), dtype=torch.int32, device=DEVICE)
+        args = (layout, n_sizes)
+        actual_shapes = ((128, 64, 128), (128, 256, 128))
+
+        matching_plan = {**base_plan, "static_problem_shapes": actual_shapes}
+        matching_kernel = type("MatchingDummyCuteKernel", (), {})()
+        matching_kernel._helion_cute_wrapper_plans = [matching_plan]
+        runtime_mod._build_tcgen05_grouped_static_metadata(
+            matching_kernel, matching_plan, args
+        )
+
+        mismatches = (
+            ((64, 64, 128), (128, 256, 128)),
+            ((128, 64, 128), (128, 192, 128)),
+            ((128, 64, 64), (128, 256, 128)),
+        )
+        for expected_shapes in mismatches:
+            with self.subTest(expected_shapes=expected_shapes):
+                plan = {**base_plan, "static_problem_shapes": expected_shapes}
+                cute_kernel = type("MismatchedDummyCuteKernel", (), {})()
+                cute_kernel._helion_cute_wrapper_plans = [plan]
+                with self.assertRaisesRegex(
+                    BackendUnsupported,
+                    "static problem-shape specialization",
+                ):
+                    runtime_mod._build_tcgen05_grouped_static_metadata(
+                        cute_kernel, plan, args
+                    )
+
     def test_grouped_inference_metadata_tracks_value_mutation(self) -> None:
         if DEVICE.type != "cuda":
             self.skipTest("grouped inference metadata test needs CUDA")

--- a/test/test_cute_rank3_rhs_b_tma.py
+++ b/test/test_cute_rank3_rhs_b_tma.py
@@ -10,12 +10,16 @@ import pytest
 import torch
 
 import helion
+from helion import exc
 from helion._compiler.cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
 from helion._compiler.cute.strategies import Tcgen05PersistenceModel
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DIRECT
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY,
+)
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
 )
@@ -25,7 +29,9 @@ from helion._testing import patch_cute_mma_support
 from helion._testing import skipUnlessBackends
 from helion.autotuner.config_generation import ConfigGeneration
 import helion.language as hl
+import helion.runtime as helion_runtime
 from helion.runtime import _append_cute_wrapper_plan
+from helion.runtime.cute.launcher import _tcgen05_grouped_static_quotas
 
 pytestmark = skipUnlessBackends(["cute"])
 if matchesBackends(["cute"]):
@@ -374,7 +380,7 @@ def _make_documented_mixed_k_args(
 ]:
     k_values = (32, 1536, 16, 16)
     m_values = (128, 16, 128, 16)
-    n_values = (64, 128, 64, 64)
+    n_values = (64, 128, 64, 80)
     groups = len(k_values)
     padded_m = groups * 128
     max_n = max(n_values)
@@ -642,7 +648,7 @@ def test_rank3_rhs_grouped_static_dynamic_bk64_mixed_tail_direct_codegen() -> No
         "m_tail_preserve": True,
         "n_tail_preserve": True,
         "grouped_static_has_m_tail": True,
-        "grouped_static_has_n_tail": False,
+        "grouped_static_has_n_tail": True,
         "dynamic_ab_tensormaps": True,
         "dynamic_d_tensormap": True,
         "direct_pointer_metadata": True,
@@ -656,14 +662,221 @@ def test_rank3_rhs_grouped_static_dynamic_bk64_mixed_tail_direct_codegen() -> No
         "tma_desc_ptr=tcgen05_grouped_d_tensormap_desc_ptr",
         "tcgen05_grouped_direct_pointers",
         "tcgen05_grouped_direct_strides",
-        "tile_offset_2 < tcgen05_grouped_problem_k",
     ):
         assert marker in code
     assert code.count("cute.nvgpu.cpasync.prefetch_descriptor(") == 3
+    update_pos = code.index(".update_tensormap(")
+    partition_pos = code.index("cute.nvgpu.cpasync.tma_partition", update_pos)
+    try_acquire_pos = code.index(".producer_try_acquire(", partition_pos)
+    fence_pos = code.index(".fence_tensormap_update(", try_acquire_pos)
+    copy_pos = code.index("cute.copy(tma_atom_a", fence_pos)
+    assert update_pos < partition_pos < try_acquire_pos < fence_pos < copy_pos
+
     assert "tcgen05_tiled_copy_r2g" not in code
     assert "tcgen05_store_mask" not in code
     assert _wrapper_plan(code, "tcgen05_ab_tma")["dynamic_ab_tensormaps"] is True
     assert _wrapper_plan(code, "tcgen05_d_tma")["rank3_mnl_tensor"] is True
+
+
+def test_rank3_rhs_grouped_static_problem_signature_codegen() -> None:
+    _require_cuda("rank3 RHS B TMA codegen test needs CUDA fake inputs")
+    signature = [4, 128, 64, 32, 16, 128, 1536, 128, 64, 16, 16, 80, 16]
+    config = _dynamic_bk64_config(direct=True)
+    config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = signature
+    code = _code_for(
+        _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes,
+        _make_documented_mixed_k_args(),
+        config,
+    )
+
+    # The exact-shape fast path is used when every group can own at least one
+    # CTA. A uniform generic fallback handles more groups than active CTAs.
+    assert "cute.arch.grid_dim()[2] >= cutlass.Int32(4)" in code
+    assert "StaticPersistentGroupTileScheduler.create" in code
+    assert "create_initial_search_state" in code
+    assert ".group_search_result" in code
+    grouped_plan = _wrapper_plan(code, "tcgen05_grouped_static_persistent")
+    assert grouped_plan["static_problem_shapes"] == (
+        (128, 64, 32),
+        (16, 128, 1536),
+        (128, 64, 16),
+        (16, 80, 16),
+    )
+    quota_args = grouped_plan["static_group_quota_args"]
+    assert isinstance(quota_args, tuple)
+    assert len(quota_args) == 4
+
+
+def test_rank3_rhs_grouped_static_problem_signature_group_count_mismatch() -> None:
+    _require_cuda("rank3 RHS B TMA codegen test needs CUDA fake inputs")
+    config = _dynamic_bk64_config(direct=True)
+    config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+        3,
+        128,
+        64,
+        32,
+        16,
+        128,
+        1536,
+        128,
+        64,
+        16,
+    ]
+    with pytest.raises(exc.BackendUnsupported, match="describes 3 groups"):
+        _code_for(
+            _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes,
+            _make_documented_mixed_k_args(),
+            config,
+        )
+
+
+@pytest.mark.parametrize(
+    ("config_key", "value", "message"),
+    (
+        ("l2_groupings", [2], "l2_groupings"),
+        ("tcgen05_l2_swizzle_size", 2, "tcgen05_l2_swizzle_size=1"),
+    ),
+)
+def test_rank3_rhs_grouped_static_problem_signature_rejects_l2_swizzle(
+    config_key: str,
+    value: object,
+    message: str,
+) -> None:
+    _require_cuda("rank3 RHS B TMA codegen test needs CUDA fake inputs")
+    config = _dynamic_bk64_config(direct=True)
+    config.config[config_key] = value
+    config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+        4,
+        128,
+        64,
+        32,
+        16,
+        128,
+        1536,
+        128,
+        64,
+        16,
+        16,
+        80,
+        16,
+    ]
+    with pytest.raises(exc.BackendUnsupported, match=message):
+        _code_for(
+            _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes,
+            _make_documented_mixed_k_args(),
+            config,
+        )
+
+
+def test_grouped_problem_signature_many_groups_uses_generic_scheduler() -> None:
+    _require_cuda("rank3 RHS B TMA codegen test needs CUDA fake inputs")
+    group_count = 9
+    a, b_grouped, layout = _make_full_args(groups=group_count, n=64, k=64)
+    n_sizes = torch.full((group_count,), 64, device=DEVICE, dtype=torch.int32)
+    k_sizes = torch.full((group_count,), 64, device=DEVICE, dtype=torch.int32)
+    out = torch.empty_like(a)
+    config = _dynamic_bk64_config()
+    config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+        group_count,
+        *([128, 64, 64] * group_count),
+    ]
+    code = _code_for(
+        _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes,
+        (a, b_grouped, layout, n_sizes, k_sizes, out),
+        config,
+    )
+
+    plan = _assert_group_scheduler(code)
+    assert len(plan["static_problem_shapes"]) == group_count
+    assert "_static_group_quota" not in code
+    assert "cute.arch.grid_dim()[2] >= cutlass.Int32(9)" not in code
+
+
+@pytest.mark.parametrize(
+    ("problem_shapes", "max_active_clusters", "expected"),
+    (
+        (
+            ((128, 128, 128), (512, 128, 128), (128, 256, 128)),
+            148,
+            (2, 8, 4),
+        ),
+        (
+            (
+                (8192, 1280, 32),
+                (128, 384, 1536),
+                (640, 1280, 16),
+                (640, 128, 16),
+            ),
+            148,
+            (131, 6, 10, 1),
+        ),
+        (
+            (
+                (9 * 128, 64, 4 * 64),
+                (5 * 128, 64, 32 * 64),
+                (23 * 128, 64, 4 * 64),
+                (28 * 128, 64, 16 * 64),
+                (24 * 128, 64, 2 * 64),
+                (19 * 128, 64, 8 * 64),
+            ),
+            8,
+            (1, 1, 1, 3, 1, 1),
+        ),
+        (((128, 64, 64), (128, 64, 64), (128, 64, 64)), 2, (1, 1, 1)),
+    ),
+)
+def test_grouped_static_quota_allocation(
+    problem_shapes: tuple[tuple[int, int, int], ...],
+    max_active_clusters: int,
+    expected: tuple[int, ...],
+) -> None:
+    assert (
+        _tcgen05_grouped_static_quotas(
+            problem_shapes,
+            bm=128,
+            bn=64,
+            bk=64,
+            max_active_clusters=max_active_clusters,
+        )
+        == expected
+    )
+
+
+def test_rank3_rhs_grouped_direct_deep_pipeline_checks_target_smem() -> None:
+    from helion.autotuner.config_spec import ConfigSpec
+
+    _require_cuda("rank3 RHS B TMA codegen test needs CUDA fake inputs")
+    args = _make_documented_mixed_k_args()
+    config = _dynamic_bk64_config(direct=True)
+    config.config["tcgen05_ab_stages"] = 8
+    config.config["tcgen05_c_stages"] = 4
+
+    with (
+        patch.object(
+            ConfigSpec,
+            "_tcgen05_grouped_dynamic_stages_fit_for_target",
+            autospec=True,
+            return_value=False,
+        ) as fit,
+        pytest.raises(
+            helion.exc.BackendUnsupported,
+            match="target-device SMEM headroom",
+        ),
+    ):
+        _code_for(_rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes, args, config)
+
+    assert fit.called
+    assert fit.call_args.kwargs == {
+        "dtype_bytes": 2,
+        "output_dtype_bytes": 2,
+        "device": args[0].device,
+        "bm": 128,
+        "bn": 64,
+        "bk": 64,
+        "cluster_m": 1,
+        "ab_stages": 8,
+        "c_stages": 4,
+    }
 
 
 @pytest.mark.parametrize(
@@ -869,6 +1082,124 @@ def test_rank3_rhs_grouped_static_native_runtime() -> None:
     _assert_grouped_result(out, args)
 
 
+def test_rank3_rhs_grouped_static_exact_signature_runtime() -> None:
+    """Ordinary static mode uses the exact scheduler and survives graph replay."""
+    _require_tcgen05_runtime_test()
+    args = _make_full_args(
+        groups=3,
+        m_per_group=256,
+        n=64,
+        k=64,
+        dtype=torch.float16,
+    )
+    config = _grouped_config(block_n=64, block_k=64)
+    config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+        3,
+        *([256, 64, 64] * 3),
+    ]
+    code = _code_for(_rank3_rhs_grouped_nt, args, config)
+    assert "cute.arch.grid_dim()[2] >= cutlass.Int32(3)" in code
+    plan = _wrapper_plan(code, "tcgen05_grouped_static_persistent")
+    assert plan["static_problem_shapes"] == ((256, 64, 64),) * 3
+    assert "dynamic_ab_tensormaps" not in plan
+
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _rank3_rhs_grouped_nt.bind(args)
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(config)
+        out = bound(*args)
+        torch.cuda.synchronize()
+        _assert_grouped_result(out, args)
+
+        with helion_runtime.cute_cuda_graph() as graph:
+            captured = bound(*args)
+        torch.cuda.synchronize()
+        captured.fill_(-77.0)
+        graph.replay()
+        torch.cuda.synchronize()
+        _assert_grouped_result(captured, args)
+
+
+def test_rank3_rhs_grouped_exact_signature_low_capacity_fallback_runtime() -> None:
+    """Fewer active CTAs than groups executes the generic scheduler fallback."""
+    _require_tcgen05_runtime_test()
+    num_sm = torch.cuda.get_device_properties(DEVICE).multi_processor_count
+    if num_sm <= 2:
+        pytest.skip("low-capacity grouped fallback requires more than two SMs")
+
+    full_args = _make_documented_mixed_k_args()
+    args = (
+        full_args[0][:384],
+        full_args[1][:3],
+        full_args[2][:384],
+        full_args[3][:3],
+        full_args[4][:3],
+        full_args[5][:384],
+    )
+    config = _dynamic_bk64_config(direct=False)
+    config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+        3,
+        128,
+        64,
+        32,
+        16,
+        128,
+        1536,
+        128,
+        64,
+        16,
+    ]
+    config.config[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = num_sm - 2
+    code = _code_for(
+        _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes,
+        args,
+        config,
+    )
+    assert "cute.arch.grid_dim()[2] >= cutlass.Int32(3)" in code
+
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes.bind(args)
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(config)
+        out = bound(*args)
+        torch.cuda.synchronize()
+        _assert_mixed_result(out, args)
+
+        with helion_runtime.cute_cuda_graph() as graph:
+            captured = bound(*args)
+        torch.cuda.synchronize()
+        captured.fill_(-77.0)
+        graph.replay()
+        torch.cuda.synchronize()
+        _assert_mixed_result(captured, args)
+
+
+def test_rank3_rhs_grouped_static_native_runtime_multiple_iterations() -> None:
+    """Every role crosses group-search windows over multiple persistent waves."""
+    _require_tcgen05_runtime_test()
+    groups = 40
+    m_per_group = 1024
+    args = _make_full_args(
+        groups=groups,
+        m_per_group=m_per_group,
+        n=64,
+        k=16,
+        dtype=torch.float16,
+    )
+    work_clusters = groups * (m_per_group // 128)
+    assert (
+        work_clusters > torch.cuda.get_device_properties(DEVICE).multi_processor_count
+    )
+
+    out = _run_configured(
+        _rank3_rhs_grouped_nt,
+        args,
+        _grouped_config(block_n=64, block_k=16),
+    )
+
+    _assert_grouped_result(out, args)
+
+
 def test_rank3_rhs_unsafe_store_fallback_runtime() -> None:
     _require_tcgen05_runtime_test()
     args = _make_mn_tail_args()
@@ -892,3 +1223,55 @@ def test_rank3_rhs_grouped_static_dynamic_bk64_runtime(direct: bool) -> None:
     )
     assert out is args[-1]
     _assert_mixed_result(out, args)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "direct"),
+    ((torch.float16, True), (torch.bfloat16, False)),
+)
+def test_rank3_rhs_grouped_deep_pipeline_runtime(
+    dtype: torch.dtype,
+    direct: bool,
+) -> None:
+    """The CUTLASS-parity AB8/C4 pipeline survives repeated graph replay."""
+    _require_tcgen05_runtime_test()
+    args = _make_documented_mixed_k_args(dtype=dtype)
+    config = _dynamic_bk64_config(direct=direct)
+    config.config["tcgen05_ab_stages"] = 8
+    config.config["tcgen05_c_stages"] = 4
+    config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+        4,
+        128,
+        64,
+        32,
+        16,
+        128,
+        1536,
+        128,
+        64,
+        16,
+        16,
+        80,
+        16,
+    ]
+
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes.bind(args)
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(config)
+        out = bound(*args)
+        torch.cuda.synchronize()
+        _assert_mixed_result(out, args)
+
+        with helion_runtime.cute_cuda_graph() as graph:
+            captured = bound(*args)
+        torch.cuda.synchronize()
+
+        for _ in range(2):
+            captured.fill_(-77.0)
+            graph.replay()
+            torch.cuda.synchronize()
+            _assert_mixed_result(captured, args)
+
+    assert out is args[-1]
+    assert captured is args[-1]


### PR DESCRIPTION
Stacked PRs:
 * #3320
 * #3319
 * #3318
 * #3317
 * __->__#3316


--- --- ---

### [cute] specialize static grouped GEMM schedules

## What

- Add a `static` TCGen05 grouped-GEMM schedule that carries the exact group count and per-group M/N tile counts in the config.
- Emit constant role-local group schedules for eligible exact signatures, while preserving the existing generic scheduler for unsupported or low-capacity launches.
- Precompute workload-balanced CTA quotas in the device-specific launch wrapper, removing repeated per-CTA integer division from the hot scheduler path.
- Plumb the new mode through config normalization/minimization, autotuner heuristics, program-ID lowering, launcher metadata, and generated-code imports.

## Why

AOT grouped-GEMM workloads already know their group shapes. Reconstructing the same schedule independently in every CTA adds integer/control overhead that is material for small heterogeneous groups. Specializing only when the signature and launch capacity prove it is safe gives those workloads a cheaper scheduler without narrowing the generic grouped-GEMM path.

## Correctness and generality

- Runtime guards validate that the embedded group metadata still matches the call.
- Exact scheduling covers ordinary static TensorMap calls as well as direct operands and both FP16/BF16 output paths.
- L2 grouping and incompatible swizzle combinations are rejected during config validation.
- When active clusters are fewer than groups, or an exact signature is unavailable, code generation falls back to the generic scheduler; the fallback is tested with three groups and only two active clusters.

## Performance

Measured on an idle NVIDIA B200 (GPU 2, zero volatile ECC errors) using the seven-case CUTLASS comparison added later in this stack: 204 balanced, pre-captured CUDA-graph replays per case, L2 cleared before every replay, and a 10-second thermal warmup.

- Helion/CUTLASS kernel-time geomean: **0.8254x** (**1.2116x speedup**), with 6 wins and 1 tie.
- Large cases measured about 16.35 us for Helion versus 20.45 us for CUTLASS.

The CUTLASS reference is pinned to `db1c288993354c88e551c40c19a8fb93a774a241`.

## Testing

- Per-commit lint: Ruff 0.15.14 format/check, codespell, and strict Pyrefly on every changed typed file.
- Changed-file CuTe suite: 346 passed, 1 skipped, 137 subtests passed. Its one unrelated `test_pointwise_chain` failure reproduces on `origin/main` with the installed CUTLASS DSL.
- Critical coverage includes config round-trips, exact-signature codegen, static CUDA-graph replay, dynamic TensorMaps, L2/swizzle rejection, workload quota allocation, persistent multi-wave execution, and the low-capacity generic fallback.