### PR TITLE
[aot] dispatch static standalone variants by call

### DIFF
--- a/helion/autotuner/aot_cache.py
+++ b/helion/autotuner/aot_cache.py
@@ -25,10 +25,12 @@ import importlib.util
 import inspect
 import json
 import logging
+import marshal
 import operator
 import os
 from pathlib import Path
 import sys
+import threading
 import traceback
 from typing import TYPE_CHECKING
 from typing import Any
@@ -45,6 +47,7 @@ from .aot_kernel import extract_shape_features
 from .base_cache import AutotuneCacheBase
 from .base_cache import BoundKernelInMemoryCacheKey
 from .base_cache import LooseAutotuneCacheKey
+from .benchmark_provider import _MultiShapeAutotuneArgs
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -296,6 +299,15 @@ class AOTAutotuneCache(AutotuneCacheBase):
     _no_heuristic_warned: ClassVar[set[str]] = set()
     # Tracks which kernels have already been compiled in compile mode
     _compiled_kernels: ClassVar[set[str]] = set()
+    # Static-shape compile mode accumulates one source variant per normalized
+    # call signature and rewrites the dispatcher whenever a shape is observed.
+    _compiled_kernel_variants: ClassVar[
+        dict[
+            tuple[str, str, str, str, str],
+            dict[tuple[object, ...], tuple[str, str]],
+        ]
+    ] = {}
+    _compiled_kernel_variants_lock: ClassVar[Any] = threading.RLock()
 
     @classmethod
     def clear_caches(cls) -> None:
@@ -304,6 +316,8 @@ class AOTAutotuneCache(AutotuneCacheBase):
         cls._heuristic_results.clear()
         cls._no_heuristic_warned.clear()
         cls._compiled_kernels.clear()
+        with cls._compiled_kernel_variants_lock:
+            cls._compiled_kernel_variants.clear()
         clear_heuristic_cache()  # Clear module-level cache
         cls._mode_announced.clear()
         log.debug("Cleared AOTAutotuneCache caches")
@@ -315,6 +329,8 @@ class AOTAutotuneCache(AutotuneCacheBase):
         autotuner_factory: Callable[[], BaseSearch] | None = None,
     ) -> None:
         super().__init__(autotuner, autotuner_factory=autotuner_factory)
+        if not isinstance(self.args, _MultiShapeAutotuneArgs):
+            self.args = self.kernel.kernel.normalize_args(*self.args)
         self.mode = get_aot_mode()
         self.hardware_id = get_hardware_info().hardware_id
         self.data_dir = get_aot_data_dir()
@@ -538,7 +554,7 @@ class AOTAutotuneCache(AutotuneCacheBase):
 
         # For disabled/evaluate/compile modes: try heuristic, fall back to default config
         # (never trigger autotuning for aot_kernel)
-        config = self._get_heuristic_config()
+        config = self._get_heuristic_config(self.args)
         if config is not None:
             return config
 
@@ -788,16 +804,16 @@ class AOTAutotuneCache(AutotuneCacheBase):
 
     def _maybe_run_compile(self) -> None:
         """
-        In compile mode, generate Triton code for all heuristic-selected
-        configs and write a standalone ``.py`` file with zero Helion deps.
+        In compile mode, generate code for all heuristic-selected configs and
+        write a standalone ``.py`` file. Backends with a dependency-free
+        launcher need no Helion runtime; CuTe currently retains its launcher
+        import.
 
-        Runs at most once per kernel (tracked by ``_compiled_kernels``).
+        Dynamic-shape kernels compile every heuristic config once. Static-shape
+        kernels compile the selected config for each observed BoundKernel and
+        dispatch by a normalized call signature.
         """
         kernel_name = self.kernel.kernel.name
-        if kernel_name in AOTAutotuneCache._compiled_kernels:
-            return
-        AOTAutotuneCache._compiled_kernels.add(kernel_name)
-
         heuristic_file = self._find_heuristic_file()
         if heuristic_file is None:
             log.warning(
@@ -816,6 +832,10 @@ class AOTAutotuneCache(AutotuneCacheBase):
             spec.loader.exec_module(module)
             AOTAutotuneCache._heuristic_modules[heuristic_file] = module
 
+        if self.kernel.settings.static_shapes:
+            self._compile_current_static_shape(heuristic_file, kernel_name)
+            return
+
         # -- extract selected configs ---------------------------------------
         # nearest_neighbor backend: module-level CONFIGS
         # decision_tree backend: _C = [...] inside autotune_<kernel>
@@ -825,6 +845,10 @@ class AOTAutotuneCache(AutotuneCacheBase):
         if configs_list is None:
             log.warning("Cannot extract configs from heuristic for '%s'", kernel_name)
             return
+
+        if kernel_name in AOTAutotuneCache._compiled_kernels:
+            return
+        AOTAutotuneCache._compiled_kernels.add(kernel_name)
 
         # -- generate Triton code for each config --------------------------
         triton_codes: list[str] = []
@@ -854,6 +878,90 @@ class AOTAutotuneCache(AutotuneCacheBase):
             output_dir=self.data_dir,
             kernel_source_file=self.kernel.kernel.__code__.co_filename,
         )
+        print(f"[AOT] Standalone: {out_path}", file=sys.stderr)
+
+    def _compile_current_static_shape(
+        self,
+        heuristic_file: Path,
+        kernel_name: str,
+    ) -> None:
+        """Compile one observed static call and update its exact dispatcher."""
+        normalized_args = self.kernel.kernel.normalize_args(*self.args)
+        config = self._get_heuristic_config(normalized_args)
+        if config is None:
+            log.warning(
+                "No heuristic config for static kernel '%s', skipping standalone compile",
+                kernel_name,
+            )
+            return
+
+        from .aot_compile import _standalone_call_key
+        from .aot_compile import generate_standalone_file
+
+        call_key = _standalone_call_key(normalized_args)
+        code_object = self.kernel.kernel.__code__
+        source_path = Path(code_object.co_filename).resolve()
+        if source_path.is_file():
+            source_digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
+            kernel_source_file: str | None = str(source_path)
+            output_identity = str(
+                source_path.parent / f"{source_path.stem}_{kernel_name}_standalone.py"
+            )
+        else:
+            source_digest = hashlib.sha256(marshal.dumps(code_object)).hexdigest()
+            kernel_source_file = None
+            output_identity = str(
+                (self.data_dir / f"{kernel_name}_standalone.py").resolve()
+            )
+        variants_key = (
+            output_identity,
+            kernel_name,
+            self.hardware_id,
+            hashlib.sha256(heuristic_file.read_bytes()).hexdigest(),
+            source_digest,
+        )
+        config_fingerprint = json.dumps(dict(config), sort_keys=True, default=repr)
+        try:
+            code = self.kernel.to_triton_code(config)
+        except Exception as error:
+            raise RuntimeError(
+                f"static standalone variant failed to compile for {kernel_name}"
+            ) from error
+        if code is None:
+            raise RuntimeError(
+                f"static standalone variant emitted no code for {kernel_name}"
+            )
+
+        # The compile workflow runs in one process. Serialize concurrent calls
+        # in that process so two newly observed signatures cannot each rewrite
+        # an incomplete dispatcher. ``generate_standalone_file`` replaces the
+        # output atomically, so readers never observe a partial module.
+        with AOTAutotuneCache._compiled_kernel_variants_lock:
+            variants = AOTAutotuneCache._compiled_kernel_variants.setdefault(
+                variants_key, {}
+            )
+            existing = variants.get(call_key)
+            if existing is not None:
+                if existing != (config_fingerprint, code):
+                    raise RuntimeError(
+                        f"static standalone call-key collision for {kernel_name}: "
+                        "the normalized arguments do not distinguish all generated "
+                        "specializations; expose value-derived compile-time metadata "
+                        "as scalar or container kernel arguments"
+                    )
+                return
+
+            updated = {**variants, call_key: (config_fingerprint, code)}
+            ordered = sorted(updated.items(), key=lambda item: repr(item[0]))
+            out_path = generate_standalone_file(
+                kernel_name=kernel_name,
+                triton_codes=[variant[1][1] for variant in ordered],
+                heuristic_code=heuristic_file.read_text(),
+                output_dir=self.data_dir,
+                kernel_source_file=kernel_source_file,
+                dispatch_keys=[variant[0] for variant in ordered],
+            )
+            variants[call_key] = (config_fingerprint, code)
         print(f"[AOT] Standalone: {out_path}", file=sys.stderr)
 
     @staticmethod

--- a/helion/autotuner/aot_compile.py
+++ b/helion/autotuner/aot_compile.py
@@ -2,9 +2,10 @@
 AOT Standalone Compilation
 ==========================
 
-Generates a standalone ``.py`` file from Helion kernels that has zero
-Helion dependencies at runtime.  The output contains only Triton code,
-a heuristic dispatcher, and standard ``torch`` / ``triton`` imports.
+Generates a standalone ``.py`` file from Helion kernels. Triton output has no
+Helion dependency; backends without a dependency-free launcher export retain
+that launcher import. The output contains generated kernel code and a heuristic
+dispatcher.
 
 Usage::
 
@@ -12,19 +13,72 @@ Usage::
         -- python examples/aot_compile_example.py
 
 Writes ``<source>_<kernel>_standalone.py`` next to each kernel source file.
+Static dispatch keys include tensor dtype, shape, and stride, but never tensor
+contents. Any tensor-derived value that affects generated code must therefore
+also be exposed as a scalar/container argument or checked by the emitted runtime
+wrapper.
 """
 
 from __future__ import annotations
 
 import ast
+import inspect
 import logging
 from pathlib import Path
 import re
+import tempfile
+import textwrap
+
+import torch
 
 from .._compiler.output_code_utils import _check_kernel_name_not_shadowed
 from .._compiler.output_code_utils import dependency_free_runtime_source
 
 log: logging.Logger = logging.getLogger(__name__)
+
+
+def _standalone_value_key(value: object) -> tuple[object, ...]:
+    """Normalize one static call value into a deterministic literal-safe key."""
+    if isinstance(value, torch.Tensor):
+        return (
+            "tensor",
+            str(value.dtype),
+            tuple(value.shape),
+            tuple(value.stride()),
+        )
+    if value is None:
+        return ("none",)
+    if type(value) is bool:
+        return ("bool", value)
+    if type(value) is int:
+        return ("int", value)
+    if type(value) is float:
+        return ("float", value.hex())
+    if type(value) is str:
+        return ("str", value)
+    if isinstance(value, torch.dtype):
+        return ("dtype", str(value))
+    if isinstance(value, torch.device):
+        return ("device", str(value))
+    if type(value) is tuple:
+        return ("tuple", tuple(_standalone_value_key(item) for item in value))
+    if type(value) is list:
+        return ("list", tuple(_standalone_value_key(item) for item in value))
+    if type(value) is dict:
+        items = [
+            (_standalone_value_key(key), _standalone_value_key(item))
+            for key, item in value.items()
+        ]
+        return ("dict", tuple(sorted(items, key=repr)))
+    raise TypeError(
+        "standalone static dispatch does not support "
+        f"{type(value).__qualname__} arguments"
+    )
+
+
+def _standalone_call_key(args: tuple[object, ...]) -> tuple[object, ...]:
+    """Return the static key for signature-normalized positional arguments."""
+    return _standalone_value_key(args)
 
 
 # ---------------------------------------------------------------------------
@@ -179,12 +233,17 @@ def generate_standalone_file(
     heuristic_code: str,
     output_dir: Path,
     kernel_source_file: str | None = None,
+    dispatch_keys: list[tuple[object, ...]] | None = None,
 ) -> Path:
     """
-    Generate a single standalone ``.py`` file with no Helion dependencies.
+    Generate one standalone ``.py`` file containing every selected config.
 
-    Each config's symbols get a ``_c<N>`` suffix to avoid collisions.
-    A public ``<kernel>`` function dispatches to the right variant.
+    Backends with a dependency-free launcher produce Helion-free output. CuTe
+    currently retains its Helion runtime launcher import.
+
+    Each config's symbols get a ``_c<N>`` suffix to avoid collisions. Static
+    shape variants can provide ``dispatch_keys`` so the public function rejects
+    uncompiled call signatures instead of applying a shape-incompatible config.
 
     Args:
         kernel_name: Name of the kernel function.
@@ -192,10 +251,22 @@ def generate_standalone_file(
         heuristic_code: Generated heuristic Python source.
         output_dir: Fallback directory when *kernel_source_file* is ``None``.
         kernel_source_file: When set, writes next to the source file.
+        dispatch_keys: Optional static call keys parallel to *triton_codes*.
 
     Returns:
         Path to the generated file.
     """
+    if dispatch_keys is not None:
+        if len(dispatch_keys) != len(triton_codes):
+            raise ValueError("dispatch_keys must match triton_codes")
+        if len(set(dispatch_keys)) != len(dispatch_keys):
+            raise ValueError("dispatch_keys must be unique")
+        ordered = sorted(
+            zip(dispatch_keys, triton_codes, strict=True),
+            key=lambda item: repr(item[0]),
+        )
+        dispatch_keys = [key for key, _code in ordered]
+        triton_codes = [code for _key, code in ordered]
     n = len(triton_codes)
 
     # -- collect imports & bodies -------------------------------------------
@@ -204,11 +275,19 @@ def generate_standalone_file(
     needs_runtime = False
     runtime_source: str | None = None
     runtime_references: set[str] = set()
+    has_helion_deps = False
 
     for i, code in enumerate(triton_codes):
         imports, body = _split_imports_and_body(code)
         for imp in imports:
             if "helion" in imp:
+                if "default_cute_launcher" in imp:
+                    # CuTe does not yet expose a dependency-free launcher. Keep
+                    # its required runtime import instead of silently emitting
+                    # a module whose wrapper references an undefined name.
+                    all_imports.add(imp)
+                    has_helion_deps = True
+                    continue
                 if not _is_supported_helion_import(imp):
                     raise ValueError(
                         f"unsupported Helion import in standalone AOT input: {imp!r}"
@@ -221,6 +300,9 @@ def generate_standalone_file(
         runtime_references.update(references)
         needs_runtime = needs_runtime or bool(references)
         bodies.append(_rename_config_symbols(body, kernel_name, i))
+    if dispatch_keys is not None:
+        all_imports.add("import inspect")
+        all_imports.add("import torch")
 
     if needs_runtime:
         from .._compiler.triton.backend import TritonBackend
@@ -241,7 +323,11 @@ def generate_standalone_file(
     # -- assemble -----------------------------------------------------------
     parts: list[str] = [
         f"# Auto-generated standalone Triton kernel for '{kernel_name}'.",
-        "# No Helion dependency required at runtime.",
+        (
+            "# Uses Helion's CuTe runtime launcher."
+            if has_helion_deps
+            else "# No Helion dependency required at runtime."
+        ),
         "",
         "from __future__ import annotations\n",
     ]
@@ -252,26 +338,67 @@ def generate_standalone_file(
 
     if runtime_source is not None:
         parts.append(runtime_source)
+    if dispatch_keys is not None:
+        parts.extend(
+            [
+                textwrap.dedent(inspect.getsource(_standalone_value_key)),
+                textwrap.dedent(inspect.getsource(_standalone_call_key)),
+            ]
+        )
 
     sep = "=" * 65
     for i, body in enumerate(bodies):
         parts.extend([f"\n# {sep}", f"# Config {i}", f"# {sep}\n", body])
 
-    if n > 1:
+    if n > 1 and dispatch_keys is None:
         # Heuristic dispatch for multi-config
         parts.extend([f"\n# {sep}", "# Heuristic dispatch", f"# {sep}\n"])
         parts.append(_extract_heuristic_body(heuristic_code, kernel_name))
 
-    if n == 1:
-        select_expr = "0"
-    elif f"def key_{kernel_name}(" in heuristic_code:
-        select_expr = f"key_{kernel_name}(*args)"
+    if dispatch_keys is not None:
+        parts.extend([f"\n# {sep}", "# Static call dispatch", f"# {sep}\n"])
+        parts.append("_STANDALONE_VARIANTS = {")
+        for i, key in enumerate(dispatch_keys):
+            parts.append(f"    {key!r}: _{kernel_name}_c{i},")
+        parts.extend(
+            [
+                "}",
+                f"_STANDALONE_SIGNATURE = inspect.signature(_{kernel_name}_c0)",
+                "_STANDALONE_PARAMETER_NAMES = tuple(",
+                "    name",
+                "    for name, parameter in _STANDALONE_SIGNATURE.parameters.items()",
+                "    if parameter.kind in (",
+                "        inspect.Parameter.POSITIONAL_ONLY,",
+                "        inspect.Parameter.POSITIONAL_OR_KEYWORD,",
+                "    )",
+                ")",
+                f"\ndef {kernel_name}(*args, **kwargs):",
+                "    bound = _STANDALONE_SIGNATURE.bind(*args, **kwargs)",
+                "    bound.apply_defaults()",
+                "    key = _standalone_call_key(",
+                "        tuple(bound.arguments[name] for name in _STANDALONE_PARAMETER_NAMES)",
+                "    )",
+                "    try:",
+                "        fn = _STANDALONE_VARIANTS[key]",
+                "    except KeyError:",
+                "        raise ValueError(",
+                '            f"No standalone variant for call signature {key!r}"',
+                "        ) from None",
+                "    return fn(*args, **kwargs)",
+                "",
+            ]
+        )
     else:
-        select_expr = "_predict(_extract_features(*args))"
-    parts.extend([f"\ndef {kernel_name}(*args, **kwargs):", "    return ["])
-    for i in range(n):
-        parts.append(f"        _{kernel_name}_c{i},")
-    parts.extend([f"    ][{select_expr}](*args, **kwargs)", ""])
+        if n == 1:
+            select_expr = "0"
+        elif f"def key_{kernel_name}(" in heuristic_code:
+            select_expr = f"key_{kernel_name}(*args)"
+        else:
+            select_expr = "_predict(_extract_features(*args))"
+        parts.extend([f"\ndef {kernel_name}(*args, **kwargs):", "    return ["])
+        for i in range(n):
+            parts.append(f"        _{kernel_name}_c{i},")
+        parts.extend([f"    ][{select_expr}](*args, **kwargs)", ""])
 
     content = "\n".join(parts)
     _check_kernel_name_not_shadowed(ast.parse(content), [], kernel_name)
@@ -285,6 +412,22 @@ def generate_standalone_file(
     else:
         out_file = output_dir / f"{kernel_name}_standalone.py"
 
-    out_file.write_text(content)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=out_file.parent,
+            prefix=f".{out_file.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp:
+            temp_path = Path(temp.name)
+            temp.write(content)
+        temp_path.replace(out_file)
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
     log.info("Standalone file: %s", out_file)
     return out_file

--- a/helion/autotuner/aot_runner.py
+++ b/helion/autotuner/aot_runner.py
@@ -410,11 +410,14 @@ def run_evaluate_phase(config: RunConfig) -> bool:
 
 def run_compile_phase(config: RunConfig) -> bool:
     """
-    Run the compile phase: generate standalone Triton files with no Helion deps.
+    Run the compile phase: generate standalone kernel files. Triton outputs have
+    no Helion dependency; CuTe outputs currently import its runtime launcher.
 
-    Runs the benchmark once with ``HELION_AOT_MODE=compile``.  Each kernel
-    call generates Triton code for all heuristic-selected configs and writes
-    a ``<name>_standalone.py`` file next to the kernel source.
+    Runs the benchmark once with ``HELION_AOT_MODE=compile``. Dynamic kernels
+    export all heuristic-selected configs; static kernels accumulate the
+    selected config for each observed normalized call. The output is written
+    next to a file-backed kernel source, or to the AOT data directory for
+    interactive/non-file-backed kernels.
 
     Returns True if successful.
     """
@@ -511,9 +514,7 @@ def run_full_workflow(config: RunConfig) -> bool:
     log.info("=" * 60)
     log.info("AOT autotuning workflow completed successfully!")
     log.info("=" * 60)
-    log.info(
-        "To emit standalone Triton files (no helion deps), re-run with --standalone"
-    )
+    log.info("To emit standalone kernel files, re-run with --standalone")
     return True
 
 
@@ -552,7 +553,7 @@ Examples:
   python -m helion.autotuner.aot_runner --run-id 20241217_143022_abc123 --phase measure \\
     -- python benchmark.py
 
-  # Generate standalone Triton files (no helion dependency at runtime)
+  # Generate standalone kernel files (CuTe retains its Helion launcher import)
   python -m helion.autotuner.aot_runner --standalone -- python benchmark.py
 
   # Alternative: use --benchmark with quoted command (no -- needed)
@@ -590,9 +591,12 @@ Examples:
     parser.add_argument(
         "--standalone",
         action="store_true",
-        help="After the selected phase(s), generate standalone Triton files "
-        "with zero Helion dependencies. Requires heuristics from a prior "
-        "build phase. Written next to kernel source as <name>_standalone.py.",
+        help="After the selected phase(s), generate standalone kernel files. "
+        "Triton output has zero Helion dependencies; CuTe currently retains "
+        "its Helion launcher import. Requires heuristics from a prior build "
+        "phase. Written next to kernel source as <name>_standalone.py. Static "
+        "kernels must expose tensor-derived compile-time values as scalar or "
+        "container arguments, or validate them in their runtime wrapper.",
     )
 
     parser.add_argument(

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -251,7 +251,9 @@ class BaseSearch(BaseAutotuner):
         self,
         kernel: _AutotunableKernel,
         args: Sequence[object],
-        benchmark_provider_cls: type[BenchmarkProvider] = LocalBenchmarkProvider,
+        benchmark_provider_cls: Callable[
+            ..., BenchmarkProvider
+        ] = LocalBenchmarkProvider,
     ) -> None:
         """
         Initialize the BaseSearch object.

--- a/helion/autotuner/finite_search.py
+++ b/helion/autotuner/finite_search.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from ..runtime.config import Config
     from ..runtime.kernel import BoundKernel
     from .base_search import _AutotunableKernel
+    from .benchmark_provider import BenchmarkProvider
     from .config_generation import ConfigGeneration
 
 
@@ -27,8 +28,17 @@ class FiniteSearch(BaseSearch):
         kernel: _AutotunableKernel,
         args: Sequence[object],
         configs: Sequence[Config] | None = None,
+        *,
+        benchmark_provider_cls: Callable[..., BenchmarkProvider] | None = None,
     ) -> None:
-        super().__init__(kernel, args)
+        if benchmark_provider_cls is None:
+            super().__init__(kernel, args)
+        else:
+            super().__init__(
+                kernel,
+                args,
+                benchmark_provider_cls=benchmark_provider_cls,
+            )
         self.config_gen: ConfigGeneration = self.config_spec.create_config_generation(
             overrides=self.settings.autotune_config_overrides or None,
             advanced_controls_files=self.settings.autotune_search_acf or None,

--- a/test/test_aot_autotuning.py
+++ b/test/test_aot_autotuning.py
@@ -7,7 +7,17 @@ Tests for the collect/measure/evaluate workflow.
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+import importlib.util
+import inspect
 import os
+import sys
+import threading
+import time
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import NamedTuple
 from unittest.mock import patch
 
 import numpy as np
@@ -16,10 +26,14 @@ import torch
 
 from helion._hardware import HardwareInfo
 from helion._testing import onlyBackends
+import helion.autotuner.aot_cache as aot_cache_module
+from helion.autotuner.aot_cache import AOTAutotuneCache
 from helion.autotuner.aot_cache import ShapeKey
 from helion.autotuner.aot_cache import _deserialize_tuple
 from helion.autotuner.aot_cache import _serialize_tuple
 from helion.autotuner.aot_cache import get_aot_mode
+from helion.autotuner.aot_compile import _standalone_call_key
+from helion.autotuner.aot_compile import generate_standalone_file
 from helion.autotuner.aot_kernel import aot_key
 from helion.autotuner.aot_kernel import extract_shape_features
 from helion.autotuner.heuristic_generator import PerformanceTarget
@@ -27,6 +41,9 @@ from helion.autotuner.heuristic_generator import ShapeConfigData
 from helion.autotuner.heuristic_generator import compute_validity_partitions
 from helion.autotuner.heuristic_generator import select_config_subset
 from helion.runtime.config import Config
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @onlyBackends(["triton", "cute"])
@@ -501,6 +518,336 @@ class TestConfigValidityPartitioning:
         # autotune returns the actual config dicts
         assert autotune_fn(torch.randn(100, 200)) == dict(selected_configs[0])
         assert autotune_fn(torch.randn(10, 100, 200)) == dict(selected_configs[1])
+
+
+def _load_generated(path: Path, name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_static_standalone_call_key_covers_runtime_specialization() -> None:
+    class Point(NamedTuple):
+        x: int
+        y: int
+
+    tensor = torch.empty_strided((2, 3), (4, 1))
+    base = _standalone_call_key((tensor, (1, 2), torch.float16, torch.device("cpu")))
+
+    assert base != _standalone_call_key(
+        (
+            torch.empty_strided((3, 2), (2, 1)),
+            (1, 2),
+            torch.float16,
+            torch.device("cpu"),
+        )
+    )
+    assert base != _standalone_call_key(
+        (tensor.as_strided((2, 3), (3, 1)), (1, 2), torch.float16, torch.device("cpu"))
+    )
+    assert base != _standalone_call_key(
+        (tensor.to(torch.float64), (1, 2), torch.float16, torch.device("cpu"))
+    )
+    assert base != _standalone_call_key(
+        (tensor, (1, 3), torch.float16, torch.device("cpu"))
+    )
+    assert _standalone_call_key(({"a": 1, "b": 2},)) == _standalone_call_key(
+        ({"b": 2, "a": 1},)
+    )
+    with pytest.raises(TypeError, match="does not support object"):
+        _standalone_call_key((object(),))
+    with pytest.raises(TypeError, match="Point"):
+        _standalone_call_key((Point(1, 2),))
+
+
+def test_aot_cache_canonicalizes_defaults_for_compile_get(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tensor = torch.empty(2)
+    signature = inspect.signature(lambda x, metadata=(1, 2): x)
+
+    def normalize_args(*args: object) -> tuple[object, ...]:
+        bound = signature.bind(*args)
+        bound.apply_defaults()
+        return tuple(bound.args)
+
+    kernel_api = SimpleNamespace(
+        name="demo",
+        normalize_args=normalize_args,
+        specialization_key=lambda args: tuple(args),
+    )
+    bound_kernel = SimpleNamespace(kernel=kernel_api, is_cacheable=lambda: True)
+    autotuner = SimpleNamespace(kernel=bound_kernel, args=(tensor,))
+    monkeypatch.setenv("HELION_AOT_MODE", "compile")
+    monkeypatch.setattr(aot_cache_module, "get_aot_data_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        aot_cache_module,
+        "get_hardware_info",
+        lambda: SimpleNamespace(hardware_id="test-hardware"),
+    )
+
+    cache = AOTAutotuneCache(autotuner)
+    assert cache.args == (tensor, (1, 2))
+    compiled: list[bool] = []
+    selected_args: list[tuple[object, ...]] = []
+    config = Config(block_sizes=[16])
+    cache._maybe_run_compile = lambda: compiled.append(True)
+
+    def get_config(args: tuple[object, ...]) -> Config:
+        selected_args.append(args)
+        return config
+
+    cache._get_heuristic_config = get_config
+    assert cache.get() is config
+    assert compiled == [True]
+    assert selected_args == [(tensor, (1, 2))]
+
+
+def test_standalone_preserves_cute_launcher_import(tmp_path: Path) -> None:
+    output = generate_standalone_file(
+        "demo",
+        [
+            (
+                "from __future__ import annotations\n"
+                "from helion.runtime import default_cute_launcher as "
+                "_default_cute_launcher\n\n"
+                "def demo(x, *, _launcher=_default_cute_launcher):\n"
+                "    return x\n"
+            )
+        ],
+        "",
+        tmp_path,
+    )
+
+    source = output.read_text()
+    assert (
+        "from helion.runtime import default_cute_launcher as _default_cute_launcher"
+        in source
+    )
+
+
+def test_static_aot_compile_accumulates_observed_shapes(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "source.py"
+    source_path.write_text("def demo(x, metadata=(1, 2)):\n    return x\n")
+    namespace: dict[str, object] = {}
+    exec(compile(source_path.read_text(), str(source_path), "exec"), namespace)
+    kernel_function = namespace["demo"]
+    signature = inspect.signature(kernel_function)
+
+    def normalize_args(*args: object) -> tuple[object, ...]:
+        bound = signature.bind(*args)
+        bound.apply_defaults()
+        return tuple(bound.args)
+
+    heuristic_path = tmp_path / "_helion_aot_demo_cuda_sm100.py"
+    heuristic_path.write_text("def autotune_demo(*args):\n    return {}\n")
+    output_path = tmp_path / "source_demo_standalone.py"
+    config = Config(block_sizes=[16])
+
+    cache = object.__new__(AOTAutotuneCache)
+    cache.data_dir = tmp_path
+    cache.hardware_id = "test-hardware"
+    cache.args = (torch.empty(2),)
+
+    def get_heuristic_config(args: tuple[object, ...]) -> Config:
+        assert args[1] == (1, 2)
+        return config
+
+    cache._get_heuristic_config = get_heuristic_config
+
+    def to_triton_code(_config: Config) -> str:
+        size = cache.args[0].size(0)
+        return (
+            "from __future__ import annotations\n\n"
+            "def demo(x, metadata=(1, 2)):\n"
+            f"    return {size}\n"
+        )
+
+    cache.kernel = SimpleNamespace(
+        kernel=SimpleNamespace(
+            __code__=kernel_function.__code__,
+            name="demo",
+            normalize_args=normalize_args,
+        ),
+        to_triton_code=to_triton_code,
+    )
+
+    def compile_shapes(sizes: tuple[int, ...]) -> str:
+        AOTAutotuneCache.clear_caches()
+        for size in sizes:
+            cache.args = (torch.empty(size),)
+            cache._compile_current_static_shape(heuristic_path, "demo")
+            assert output_path.exists()
+        return output_path.read_text()
+
+    forward_source = compile_shapes((2, 3))
+    reverse_source = compile_shapes((3, 2))
+    assert forward_source == reverse_source
+    module = _load_generated(output_path, "test_static_aot_compile")
+    assert module.demo(torch.empty(2)) == 2
+    assert module.demo(x=torch.empty(2)) == 2
+    assert module.demo(torch.empty(3)) == 3
+    with pytest.raises(ValueError, match="No standalone variant"):
+        module.demo(torch.empty(4))
+
+    cache.kernel.to_triton_code = lambda _config: (
+        "from __future__ import annotations\n\ndef demo(x):\n    return 99\n"
+    )
+    with pytest.raises(RuntimeError, match="value-derived compile-time metadata"):
+        cache._compile_current_static_shape(heuristic_path, "demo")
+
+    prior_source = output_path.read_text()
+    cache.args = (torch.empty(4),)
+
+    def fail_compile(_config: Config) -> str:
+        raise ValueError("compile failed")
+
+    cache.kernel.to_triton_code = fail_compile
+    with pytest.raises(RuntimeError, match="variant failed to compile"):
+        cache._compile_current_static_shape(heuristic_path, "demo")
+    assert output_path.read_text() == prior_source
+    AOTAutotuneCache.clear_caches()
+
+
+def test_static_aot_compile_supports_non_file_kernel_source(tmp_path: Path) -> None:
+    namespace: dict[str, object] = {}
+    exec(compile("def demo(x):\n    return x\n", "<stdin>", "exec"), namespace)
+    kernel_function = namespace["demo"]
+    heuristic_path = tmp_path / "_helion_aot_demo_cuda_sm100.py"
+    heuristic_path.write_text("def autotune_demo(*args):\n    return {}\n")
+    config = Config(block_sizes=[16])
+
+    cache = object.__new__(AOTAutotuneCache)
+    cache.data_dir = tmp_path
+    cache.hardware_id = "test-hardware"
+    cache.args = (torch.empty(2),)
+    cache._get_heuristic_config = lambda _args: config
+    cache.kernel = SimpleNamespace(
+        kernel=SimpleNamespace(
+            __code__=kernel_function.__code__,
+            name="demo",
+            normalize_args=lambda *args: tuple(args),
+        ),
+        to_triton_code=lambda _config: (
+            "from __future__ import annotations\n\ndef demo(x):\n    return 2\n"
+        ),
+    )
+
+    AOTAutotuneCache.clear_caches()
+    cache._compile_current_static_shape(heuristic_path, "demo")
+    output_path = tmp_path / "demo_standalone.py"
+    assert output_path.exists()
+    module = _load_generated(output_path, "test_static_aot_non_file")
+    assert module.demo(torch.empty(2)) == 2
+
+    other_dir = tmp_path / "other"
+    cache.data_dir = other_dir
+    cache._compile_current_static_shape(heuristic_path, "demo")
+    other_output = other_dir / "demo_standalone.py"
+    assert other_output.exists()
+    AOTAutotuneCache.clear_caches()
+
+
+def test_static_aot_compile_serializes_concurrent_variants(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "source.py"
+    source_path.write_text("def demo(x):\n    return x\n")
+    namespace: dict[str, object] = {}
+    exec(compile(source_path.read_text(), str(source_path), "exec"), namespace)
+    kernel_function = namespace["demo"]
+    heuristic_path = tmp_path / "_helion_aot_demo_cuda_sm100.py"
+    heuristic_path.write_text("def autotune_demo(*args):\n    return {}\n")
+    config = Config(block_sizes=[16])
+    codegen_barrier = threading.Barrier(2)
+
+    def make_cache(size: int) -> AOTAutotuneCache:
+        cache = object.__new__(AOTAutotuneCache)
+        cache.data_dir = tmp_path
+        cache.hardware_id = "test-hardware"
+        cache.args = (torch.empty(size),)
+        cache._get_heuristic_config = lambda _args: config
+
+        def to_triton_code(_config: Config) -> str:
+            codegen_barrier.wait(timeout=5)
+            return (
+                "from __future__ import annotations\n\n"
+                f"def demo(x):\n    return {size}\n"
+            )
+
+        cache.kernel = SimpleNamespace(
+            kernel=SimpleNamespace(
+                __code__=kernel_function.__code__,
+                name="demo",
+                normalize_args=lambda *args: tuple(args),
+            ),
+            to_triton_code=to_triton_code,
+        )
+        return cache
+
+    import helion.autotuner.aot_compile as aot_compile
+
+    original_generate = aot_compile.generate_standalone_file
+    active_writers = 0
+    max_active_writers = 0
+    writers_lock = threading.Lock()
+
+    def tracked_generate(
+        kernel_name: str,
+        triton_codes: list[str],
+        heuristic_code: str,
+        output_dir: Path,
+        kernel_source_file: str | None = None,
+        dispatch_keys: list[tuple[object, ...]] | None = None,
+    ) -> Path:
+        nonlocal active_writers, max_active_writers
+        with writers_lock:
+            active_writers += 1
+            max_active_writers = max(max_active_writers, active_writers)
+        try:
+            time.sleep(0.05)
+            return original_generate(
+                kernel_name,
+                triton_codes,
+                heuristic_code,
+                output_dir,
+                kernel_source_file,
+                dispatch_keys,
+            )
+        finally:
+            with writers_lock:
+                active_writers -= 1
+
+    monkeypatch.setattr(aot_compile, "generate_standalone_file", tracked_generate)
+    AOTAutotuneCache.clear_caches()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(
+                make_cache(size)._compile_current_static_shape,
+                heuristic_path,
+                "demo",
+            )
+            for size in (2, 3)
+        ]
+        for future in futures:
+            future.result()
+
+    assert max_active_writers == 1
+    module = _load_generated(
+        tmp_path / "source_demo_standalone.py",
+        "test_static_aot_concurrent",
+    )
+    assert module.demo(torch.empty(2)) == 2
+    assert module.demo(torch.empty(3)) == 3
+    AOTAutotuneCache.clear_caches()
 
 
 if __name__ == "__main__":

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -6167,6 +6167,35 @@ class TestConfigFilter(TestCase):
         )
         return add, args
 
+    def test_finite_search_accepts_benchmark_provider_factory(self) -> None:
+        class CustomBenchmarkProvider(LocalBenchmarkProvider):
+            def __init__(
+                self, *args: object, context: object, **kwargs: object
+            ) -> None:
+                self.context = context
+                super().__init__(*args, **kwargs)  # pyrefly: ignore[bad-argument-type]
+
+        configs = [
+            helion.Config(block_sizes=[16], num_warps=4),
+            helion.Config(block_sizes=[32], num_warps=4),
+        ]
+        add, args = self._make_kernel_and_args()
+        context = object()
+        provider_factory = functools.partial(
+            CustomBenchmarkProvider,
+            context=context,
+        )
+        search = FiniteSearch(
+            add.bind(args),
+            args,
+            configs=configs,
+            benchmark_provider_cls=provider_factory,
+        )
+        search._prepare()
+
+        self.assertIsInstance(search.benchmark_provider, CustomBenchmarkProvider)
+        self.assertIs(search.benchmark_provider.context, context)
+
     def test_autotune_config_filter_skips_filtered_configs(self) -> None:
         """Filtered configs produce status='filtered' and perf=inf."""
         cfg1 = helion.Config(block_sizes=[16], num_warps=4)


### PR DESCRIPTION
Stacked PRs:
 * #3320
 * #3319
 * #3318
 * __->__#3317
 * #3316


--- --- ---

### [aot] dispatch static standalone variants by call


## What

- Canonicalize static AOT calls with the Python signature, including omitted defaults, positional/keyword equivalence, nested containers, and scalar metadata.
- Accumulate one selected standalone variant per distinct normalized call and generate an exact dispatcher instead of letting the first observed call silently win.
- Make standalone output generation atomic, retain CuTe launcher imports, support non-file-defined kernels, and serialize in-process variant merges.
- Propagate static compilation failures instead of leaving a stale artifact that appears successful.
- Let finite searches be recreated through a factory so each static call is selected and compiled independently.

## Why

Static AOT training previously keyed some calls before defaults were applied but generated dispatchers after defaults were applied. It could therefore emit an unreachable variant, overwrite a previous shape, or appear to succeed after a failed compile. Grouped GEMM needs several static shape families in one checked-in standalone module, so call identity and accumulation must be deterministic.

## Correctness and generality

- Call keys are derived from normalized arguments, not call syntax.
- Output destination is part of the variant key, so two data directories cannot suppress one another.
- Named tuples and unsupported container subclasses are rejected explicitly rather than being flattened ambiguously.
- Tensor contents are intentionally not part of a static key. Any value-derived code-generation metadata must be passed as scalar/container arguments or protected by a runtime guard; this contract is documented in the runner.
- Atomic same-directory replacement prevents readers from observing a partially written standalone module.

## Performance

This is compile/export infrastructure and does not change generated kernel device time. No runtime performance delta is expected.

## Testing

- Per-commit lint: Ruff 0.15.14 format/check, codespell, and strict Pyrefly on every changed typed file.
- `test/test_aot_autotuning.py test/test_autotuner.py`: **198 passed, 9 skipped, 11 subtests passed**.
- Critical tests cover default canonicalization, exact dispatch, container rejection, multi-variant accumulation, two output directories, non-file source definitions, concurrent writers, stale-artifact preservation, compile-error propagation, CuTe launcher imports, and finite-search recreation.