### PR TITLE
[bench] add grouped GEMM CUTLASS comparison

### DIFF
--- a/benchmarks/cute/compare_grouped_gemm_backends.py
+++ b/benchmarks/cute/compare_grouped_gemm_backends.py
@@ -1,18 +1,19 @@
-# ruff: noqa: ANN401
-"""Reproduce the Helion versus CUTLASS CuTeDSL grouped-GEMM comparison.
+# ruff: noqa: ANN401, E402
+"""Compare Helion with CUTLASS CuTeDSL grouped GEMM.
 
 The comparison is intentionally narrow: FP16 NT grouped GEMM, a 128x64 MMA
-tile, a 1x1 cluster, and the seven published workloads below.  Every workload
-runs in a fresh subprocess with fresh compiler caches.  Both implementations
-consume the same A/B tensors, write separate outputs, and are timed through
-CUDA graph replay.  The CUTLASS graph includes the pinned-host pointer-table
-upload performed by the published reference wrapper before each kernel launch.
+tile, a 1x1 cluster, and seven CUTLASS-example-derived heterogeneous validation
+cases (3--4 GEMMs, including M/N tails). Every case runs in a fresh subprocess
+with fresh compiler caches. Both implementations consume the same A/B tensors,
+write the same output buffers sequentially, and are timed through the shared
+cold-L2 CUDA graph-replay timer. The comparison times only device work, with
+every pointer table initialized before graph capture.
 
 Use ``grouped_gemm.py`` from NVIDIA/cutlass commit
 ``db1c288993354c88e551c40c19a8fb93a774a241``::
 
     CUDA_VISIBLE_DEVICES=0 python benchmarks/cute/compare_grouped_gemm_backends.py \
-      --cutlass-source /path/to/CUTLASS/examples/python/CuTeDSL/blackwell/grouped_gemm.py \
+      --cutlass-source /path/to/CUTLASS/examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/grouped_gemm.py \
       --out-dir grouped_gemm_cutlass_results --stream-subprocesses
 """
 
@@ -27,10 +28,8 @@ import linecache
 import math
 import os
 from pathlib import Path
-import statistics
 import subprocess
 import sys
-import time
 from types import ModuleType
 from typing import TYPE_CHECKING
 from typing import Any
@@ -45,57 +44,19 @@ if TYPE_CHECKING:
 hl: Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from pretuned_kernels._bench import bench_pre_captured_cudagraphs
+from pretuned_kernels._bench import thermal_warmup
+
 CUTLASS_COMMIT = "db1c288993354c88e551c40c19a8fb93a774a241"
 CUTLASS_SHA256 = "05b74a05682c024557d83284e32f973ed5be4f0d1a1a12c72fe7824c29f7e94f"
 HELION_CUTE_MMA_IMPL = "tcgen05"
 DEFAULT_OUT_DIR = Path("grouped_gemm_cutlass_results")
 CTA_M, CTA_N, CTA_K = 128, 64, 64
-
-
-@dataclass(frozen=True)
-class Case:
-    name: str
-    problems: tuple[tuple[int, int, int, int], ...]
-    reserved_sms: int
-    ab_stages: int | None
-
-    @property
-    def shape_label(self) -> str:
-        shapes = ", ".join(
-            f"g{i}: {m}x{n}x{k}" for i, (m, n, k, _l) in enumerate(self.problems)
-        )
-        return f"G{len(self.problems)} [{shapes}]"
-
-
-def _doc_case(name: str, m1: int, n3: int, *, reserved_sms: int = 0) -> Case:
-    return Case(
-        name,
-        (
-            (8192, 1280, 32, 1),
-            (m1, 384, 1536, 1),
-            (640, 1280, 16, 1),
-            (640, n3, 16, 1),
-        ),
-        reserved_sms=reserved_sms,
-        ab_stages=4,
-    )
-
-
-CASES = (
-    Case(
-        "default_small_parity",
-        ((128, 128, 128, 1), (512, 128, 128, 1), (128, 256, 128, 1)),
-        reserved_sms=0,
-        ab_stages=None,
-    ),
-    _doc_case("doc_no_mn_tail", 128, 128),
-    _doc_case("doc_no_mn_g3_192_extra_full", 128, 192),
-    _doc_case("doc_original", 16, 160, reserved_sms=3),
-    _doc_case("doc_mtail_g1_g3_192_extra_full", 16, 192, reserved_sms=3),
-    _doc_case("doc_mtail_g1_only", 16, 128),
-    _doc_case("doc_ntail_g3_160", 128, 160),
-)
-CASES_BY_NAME = {case.name: case for case in CASES}
+CUTLASS_KERNEL_BASELINE = "cutlass_cutedsl_kernel"
+STATIC_PROBLEM_SIGNATURE_CONFIG_KEY = "tcgen05_grouped_static_problem_signature"
 
 
 @dataclass
@@ -105,6 +66,55 @@ class PreparedLaunch:
 
     def __call__(self) -> object:
         return self.call()
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    problems: tuple[tuple[int, int, int, int], ...]
+    ab_stages: int
+    acc_stages: int
+    c_stages: int
+
+    @property
+    def shape_label(self) -> str:
+        shapes = ", ".join(
+            f"g{i}: {m}x{n}x{k}" for i, (m, n, k, _l) in enumerate(self.problems)
+        )
+        return f"G{len(self.problems)} [{shapes}]"
+
+
+def _doc_case(name: str, m1: int, n3: int) -> Case:
+    return Case(
+        name,
+        (
+            (8192, 1280, 32, 1),
+            (m1, 384, 1536, 1),
+            (640, 1280, 16, 1),
+            (640, n3, 16, 1),
+        ),
+        ab_stages=8,
+        acc_stages=2,
+        c_stages=4,
+    )
+
+
+CASES = (
+    Case(
+        "default_small_parity",
+        ((128, 128, 128, 1), (512, 128, 128, 1), (128, 256, 128, 1)),
+        ab_stages=2,
+        acc_stages=1,
+        c_stages=2,
+    ),
+    _doc_case("doc_no_mn_tail", 128, 128),
+    _doc_case("doc_no_mn_g3_192_extra_full", 128, 192),
+    _doc_case("doc_original", 16, 160),
+    _doc_case("doc_mtail_g1_g3_192_extra_full", 16, 192),
+    _doc_case("doc_mtail_g1_only", 16, 128),
+    _doc_case("doc_ntail_g3_160", 128, 160),
+)
+CASES_BY_NAME = {case.name: case for case in CASES}
 
 
 def _make_helion_kernel() -> tuple[Any, Any]:
@@ -218,20 +228,20 @@ def _prepare_helion(
         pid_type="persistent_interleaved",
         tcgen05_cluster_m=1,
         tcgen05_cluster_n=1,
-        tcgen05_acc_stages=2,
-        tcgen05_c_stages=2,
+        tcgen05_ab_stages=case.ab_stages,
+        tcgen05_acc_stages=case.acc_stages,
+        tcgen05_c_stages=case.c_stages,
         tcgen05_num_epi_warps=4,
         tcgen05_grouped_mode="direct",
         tcgen05_grouped_external_direct_pointers="direct_pointers",
         tcgen05_grouped_external_direct_strides="direct_strides",
-        **(
-            {"tcgen05_grouped_static_reserved_sms": case.reserved_sms}
-            if case.reserved_sms
-            else {}
-        ),
+        **{
+            STATIC_PROBLEM_SIGNATURE_CONFIG_KEY: [
+                len(problems),
+                *(size for m, n, k, _batch in problems for size in (m, n, k)),
+            ]
+        },
     )
-    if case.ab_stages is not None:
-        config.config["tcgen05_ab_stages"] = case.ab_stages
     bound = kernel.bind(kernel_args)
     bound.env.config_spec.cute_tcgen05_search_enabled = True
     bound.set_config(config)
@@ -244,12 +254,14 @@ def _prepare_helion(
     return PreparedLaunch(launch, owners), {
         "block_sizes": [CTA_M, CTA_N, CTA_K],
         "cluster_shape_mn": [1, 1],
-        "reserved_sms": case.reserved_sms,
         "ab_stages": case.ab_stages,
+        "acc_stages": case.acc_stages,
+        "c_stages": case.c_stages,
+        "scheduler": "shape_specialized_group_partitioned",
     }
 
 
-def _load_cutlass_source(source: Path) -> tuple[ModuleType, dict[str, str]]:
+def load_cutlass_source(source: Path) -> tuple[ModuleType, dict[str, str]]:
     """Hash and execute the retained bytes under an immutable synthetic name."""
     path = source.expanduser().resolve(strict=True)
     source_bytes = path.read_bytes()
@@ -285,7 +297,7 @@ def _load_cutlass_source(source: Path) -> tuple[ModuleType, dict[str, str]]:
     }
 
 
-def _prepare_cutlass(
+def prepare_cutlass(
     module: ModuleType,
     problems: tuple[tuple[int, int, int, int], ...],
     group_a: tuple[torch.Tensor, ...],
@@ -322,15 +334,14 @@ def _prepare_cutlass(
         assumed_align=16,
     )
     device = group_a[0].device
-    pointers_host = torch.tensor(
+    pointers_torch = torch.tensor(
         [
             (a.data_ptr(), b.data_ptr(), out.data_ptr())
             for a, b, out in zip(group_a, group_b, outputs, strict=True)
         ],
+        device=device,
         dtype=torch.int64,
-        pin_memory=True,
     )
-    pointers_torch = torch.empty_like(pointers_host, device=device)
     pointers = cutlass_torch.from_dlpack(pointers_torch, assumed_align=16)
     pointers.element_type = cutlass.Int64
     hardware = cutlass_utils.HardwareInfo()
@@ -372,7 +383,6 @@ def _prepare_cutlass(
     )
 
     def launch() -> object:
-        pointers_torch.copy_(pointers_host, non_blocking=True)
         return compiled(
             *initial,
             dims,
@@ -391,17 +401,17 @@ def _prepare_cutlass(
         tensormap,
         dims_torch,
         strides_torch,
-        pointers_host,
         pointers_torch,
         tensormap_torch,
         *group_a,
         *group_b,
         *outputs,
     )
+    torch.cuda.synchronize(device)
     return PreparedLaunch(launch, owners)
 
 
-def _make_inputs(
+def make_inputs(
     problems: Sequence[tuple[int, int, int, int]], device: torch.device
 ) -> tuple[
     tuple[torch.Tensor, ...], tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]
@@ -422,7 +432,7 @@ def _make_inputs(
     return group_a, group_b, expected
 
 
-def _outputs(
+def make_outputs(
     group_a: Sequence[torch.Tensor], group_b: Sequence[torch.Tensor]
 ) -> tuple[torch.Tensor, ...]:
     import torch
@@ -433,8 +443,8 @@ def _outputs(
     )
 
 
-def _capture(
-    launch: PreparedLaunch, warmups: int, *, track_cute: bool = False
+def capture_launch(
+    launch: Callable[[], object], warmups: int, *, track_cute: bool = False
 ) -> torch.cuda.CUDAGraph:
     import torch
 
@@ -454,7 +464,7 @@ def _capture(
     return graph
 
 
-def _correctness(
+def check_correctness(
     outputs: Sequence[torch.Tensor], expected: Sequence[torch.Tensor]
 ) -> dict[str, object]:
     import torch
@@ -466,57 +476,24 @@ def _correctness(
     return {"ok": True, "max_abs": max_abs}
 
 
-def _thermal_warmup(duration_ms: int) -> None:
-    import torch
-
-    if duration_ms <= 0:
-        return
-    value = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
-    end = time.monotonic() + duration_ms / 1000
-    while time.monotonic() < end:
-        for _ in range(50):
-            value = value @ value
-        torch.cuda.synchronize()
-
-
-def _do_bench(fn: Callable[[], object], args: argparse.Namespace) -> float:
-    from triton.testing import do_bench
-
-    value: Any = do_bench(
-        fn, warmup=args.warmup_ms, rep=args.rep_ms, return_mode="mean"
-    )
-    return float(value[0] if isinstance(value, tuple) else value)
-
-
 def _bench_pair(
     replays: Mapping[str, Callable[[], object]], args: argparse.Namespace
 ) -> dict[str, dict[str, Any]]:
-    import torch
-
-    if args.cache_warmup_calls:
-        for fn in replays.values():
-            for _ in range(args.cache_warmup_calls):
-                fn()
-        torch.cuda.synchronize()
-    _thermal_warmup(args.thermal_warmup_ms)
+    thermal_warmup(args.thermal_warmup_ms)
     names = tuple(replays)
-    samples = {name: [] for name in names}
-    for run in range(args.num_runs):
-        order = names if run % 2 == 0 else names[::-1]
-        for name in order:
-            samples[name].append(_do_bench(replays[name], args))
+    medians = bench_pre_captured_cudagraphs(
+        [replays[name] for name in names], rep=args.repetitions
+    )
     method = (
-        "one shared cache/thermal warmup phase, then paired external "
-        "triton.testing.do_bench CUDA-event runs alternating Helion/CUTLASS "
-        "and CUTLASS/Helion"
+        "shared cold-L2 CUDA-event graph-replay timer with balanced rotated "
+        "and reversed implementation order"
     )
     return {
         name: {
-            "median_ms": statistics.median(values),
-            "runs_ms": values,
+            "median_ms": median,
             "method": method,
         }
-        for name, values in samples.items()
+        for name, median in zip(names, medians, strict=True)
     }
 
 
@@ -566,37 +543,42 @@ def _run_case(args: argparse.Namespace) -> int:
     torch.cuda.set_device(0)
     torch.manual_seed(args.seed)
     device = torch.device("cuda", 0)
-    cutlass_module, provenance = _load_cutlass_source(args.cutlass_source)
-    group_a, group_b, expected = _make_inputs(case.problems, device)
-    helion_outputs = _outputs(group_a, group_b)
-    cutlass_outputs = _outputs(group_a, group_b)
+    cutlass_module, provenance = load_cutlass_source(args.cutlass_source)
+    group_a, group_b, expected = make_inputs(case.problems, device)
+    outputs = make_outputs(group_a, group_b)
 
-    helion_launch, helion_config = _prepare_helion(
-        case, group_a, group_b, helion_outputs
+    helion_launch, helion_config = _prepare_helion(case, group_a, group_b, outputs)
+    cutlass_launch = prepare_cutlass(
+        cutlass_module, case.problems, group_a, group_b, outputs
     )
-    cutlass_launch = _prepare_cutlass(
-        cutlass_module, case.problems, group_a, group_b, cutlass_outputs
-    )
-    helion_graph = _capture(helion_launch, args.compile_warmups, track_cute=True)
-    cutlass_graph = _capture(cutlass_launch, args.compile_warmups)
+    helion_graph = capture_launch(helion_launch, args.compile_warmups, track_cute=True)
+    cutlass_kernel_graph = capture_launch(cutlass_launch, args.compile_warmups)
 
-    helion_graph.replay()
-    cutlass_graph.replay()
-    torch.cuda.synchronize()
+    def replay_and_check(
+        graph: torch.cuda.CUDAGraph,
+        outputs: tuple[torch.Tensor, ...],
+    ) -> dict[str, object]:
+        for output in outputs:
+            output.fill_(float("nan"))
+        graph.replay()
+        torch.cuda.synchronize()
+        return check_correctness(outputs, expected)
+
     correctness = {
-        "helion_retained": _correctness(helion_outputs, expected),
-        "cutlass": _correctness(cutlass_outputs, expected),
+        "helion_retained": replay_and_check(helion_graph, outputs),
+        CUTLASS_KERNEL_BASELINE: replay_and_check(cutlass_kernel_graph, outputs),
     }
     replay = {
         "helion_retained": helion_graph.replay,
-        "cutlass": cutlass_graph.replay,
+        CUTLASS_KERNEL_BASELINE: cutlass_kernel_graph.replay,
     }
     timings = _bench_pair(replay, args)
-    ratio = float(timings["helion_retained"]["median_ms"]) / float(
-        timings["cutlass"]["median_ms"]
+    helion_ms = float(timings["helion_retained"]["median_ms"])
+    helion_over_cutlass_kernel = helion_ms / float(
+        timings[CUTLASS_KERNEL_BASELINE]["median_ms"]
     )
     result = {
-        "comparison": "cutlass_cutedsl_blackwell_grouped_gemm",
+        "comparison": "blackwell_grouped_gemm_backends",
         "case": case.name,
         "shape_label": case.shape_label,
         "problem_sizes": [list(problem) for problem in case.problems],
@@ -609,22 +591,28 @@ def _run_case(args: argparse.Namespace) -> int:
         "settings": {
             "seed": args.seed,
             "compile_warmups": args.compile_warmups,
-            "num_runs": args.num_runs,
-            "warmup_ms": args.warmup_ms,
-            "rep_ms": args.rep_ms,
-            "cache_warmup_calls": args.cache_warmup_calls,
+            "repetitions": args.repetitions,
             "thermal_warmup_ms": args.thermal_warmup_ms,
             "fresh_subprocess_per_case": True,
-            "cutlass_graph_includes_pointer_table_upload": True,
+            "shared_output_buffers": True,
+            "cutlass_kernel_graph_pointer_table_preloaded": True,
             "env": env,
         },
         "correctness": correctness,
         "timings": timings,
-        "ratios_to_cutlass": {"helion_retained": ratio},
+        "helion_over_cutlass_kernel": helion_over_cutlass_kernel,
     }
     output = case_dir / "result.json"
     output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
-    print(json.dumps({"case": case.name, "result": str(output), "ratio": ratio}))
+    print(
+        json.dumps(
+            {
+                "case": case.name,
+                "result": str(output),
+                "helion_over_cutlass_kernel": helion_over_cutlass_kernel,
+            }
+        )
+    )
     return 0
 
 
@@ -656,15 +644,13 @@ def _build_summary(
                 "problem_sizes": result["problem_sizes"],
                 "status": "ok",
                 "timings": result["timings"],
-                "retained_over_cutlass": result["ratios_to_cutlass"].get(
-                    "helion_retained"
-                ),
+                "helion_over_cutlass_kernel": result["helion_over_cutlass_kernel"],
             }
         )
-    ratios = [
+    kernel_ratios = [
         float(value)
         for row in rows
-        if isinstance((value := row.get("retained_over_cutlass")), int | float)
+        if isinstance((value := row.get("helion_over_cutlass_kernel")), int | float)
     ]
     return {
         "artifact_dir": str(args.out_dir),
@@ -679,15 +665,15 @@ def _build_summary(
             "benchmark_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
         },
         "methodology": (
-            "fresh subprocess/case; common inputs; paired external do_bench CUDA "
-            "graph replays; one shared cache/thermal warmup phase; alternate "
-            "Helion/CUTLASS then CUTLASS/Helion; CUTLASS graph includes "
-            "pinned-host pointer-table upload"
+            "fresh subprocess/case; common input and output buffers; paired "
+            "cold-L2 CUDA graph replays; one shared thermal warmup phase; "
+            "balanced rotate/reverse implementation order; CUTLASS uses a "
+            "device pointer table initialized before capture"
         ),
         "rows": rows,
-        "wins": sum(ratio < 1 for ratio in ratios),
-        "total": len(ratios),
-        "geomean_helion_over_cutlass": _geomean(ratios),
+        "total": len(kernel_ratios),
+        "wins_vs_cutlass_kernel": sum(ratio < 1 for ratio in kernel_ratios),
+        "geomean_helion_over_cutlass_kernel": _geomean(kernel_ratios),
         "commands": list(commands),
         "failures": list(failures),
     }
@@ -714,13 +700,6 @@ def _non_negative(text: str) -> int:
     return value
 
 
-def _positive_even(text: str) -> int:
-    value = _positive(text)
-    if value % 2:
-        raise argparse.ArgumentTypeError("expected a positive even integer")
-    return value
-
-
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     mode = parser.add_mutually_exclusive_group()
@@ -732,10 +711,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--cuda-visible-devices")
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--compile-warmups", type=_positive, default=2)
-    parser.add_argument("--num-runs", type=_positive_even, default=6)
-    parser.add_argument("--warmup-ms", type=_non_negative, default=1000)
-    parser.add_argument("--rep-ms", type=_positive, default=500)
-    parser.add_argument("--cache-warmup-calls", type=_non_negative, default=5)
+    parser.add_argument("--repetitions", type=_positive, default=204)
     parser.add_argument("--thermal-warmup-ms", type=_non_negative, default=10000)
     parser.add_argument("--stream-subprocesses", action="store_true")
     parser.add_argument(
@@ -761,10 +737,7 @@ def _worker_command(args: argparse.Namespace, case: Case) -> list[str]:
         ("out-dir", args.out_dir),
         ("seed", args.seed),
         ("compile-warmups", args.compile_warmups),
-        ("num-runs", args.num_runs),
-        ("warmup-ms", args.warmup_ms),
-        ("rep-ms", args.rep_ms),
-        ("cache-warmup-calls", args.cache_warmup_calls),
+        ("repetitions", args.repetitions),
         ("thermal-warmup-ms", args.thermal_warmup_ms),
     )
     for name, value in forwarded:

--- a/benchmarks/cute/cublas_grouped_gemm.py
+++ b/benchmarks/cute/cublas_grouped_gemm.py
@@ -1,0 +1,309 @@
+"""CUDA-graph-compatible cuBLAS grouped GEMM benchmark adapter."""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass
+from itertools import pairwise
+import os
+from typing import TYPE_CHECKING
+import weakref
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import torch
+
+CUBLAS_GROUPED_BASELINE = "cublas_grouped_batched_ex_operator"
+
+_CUBLAS_STATUS_SUCCESS = 0
+_CUBLAS_OP_N = 0
+_CUBLAS_OP_T = 1
+_CUDA_R_16F = 2
+_CUDA_R_16BF = 14
+_CUBLAS_COMPUTE_32F = 68
+_CUBLAS_POINTER_MODE_HOST = 0
+_CUBLAS_WORKSPACE_BYTES = 32 * 1024 * 1024
+_CUBLAS_WORKSPACE_ALIGNMENT = 256
+
+
+@dataclass
+class PreparedLaunch:
+    call: Callable[[], object]
+    owners: tuple[object, ...]
+
+    def __call__(self) -> object:
+        return self.call()
+
+
+def _check_cublas(status: int, operation: str) -> None:
+    if status != _CUBLAS_STATUS_SUCCESS:
+        raise RuntimeError(f"{operation} failed with cuBLAS status {status}")
+
+
+class _CublasGroupedGemm:
+    """Process-scoped cuBLAS grouped launch with persistent device metadata."""
+
+    def __init__(
+        self,
+        problems: tuple[tuple[int, int, int, int], ...],
+        group_a: tuple[torch.Tensor, ...],
+        group_b: tuple[torch.Tensor, ...],
+        outputs: tuple[torch.Tensor, ...],
+    ) -> None:
+        import torch
+
+        if not problems:
+            raise ValueError("cuBLAS comparison requires at least one group")
+        if any(batch != 1 for _m, _n, _k, batch in problems):
+            raise ValueError("cuBLAS comparison requires L=1 problems")
+        if not (len(problems) == len(group_a) == len(group_b) == len(outputs)):
+            raise ValueError("cuBLAS comparison requires one A/B/C tensor per group")
+        tensors = (*group_a, *group_b, *outputs)
+        if any(tensor.device.type != "cuda" for tensor in tensors):
+            raise ValueError("cuBLAS comparison requires CUDA tensors")
+        device = group_a[0].device
+        if any(tensor.device != device for tensor in tensors):
+            raise ValueError("cuBLAS comparison requires tensors on one CUDA device")
+        for (m, n, k, _batch), a, b, output in zip(
+            problems, group_a, group_b, outputs, strict=True
+        ):
+            if (a.shape, b.shape, output.shape) != ((m, k), (n, k), (m, n)):
+                raise ValueError(
+                    "cuBLAS comparison tensor shapes do not match problems"
+                )
+            if any(not tensor.is_contiguous() for tensor in (a, b, output)):
+                raise ValueError("cuBLAS comparison requires contiguous tensors")
+            if k % 8 or any(tensor.data_ptr() % 16 for tensor in (a, b, output)):
+                raise ValueError("cuBLAS comparison requires 16-byte alignment")
+        output_ranges = sorted(
+            (
+                output.data_ptr(),
+                output.data_ptr() + output.numel() * output.element_size(),
+            )
+            for output in outputs
+        )
+        if any(
+            previous_end > current_start
+            for (_previous_start, previous_end), (
+                current_start,
+                _current_end,
+            ) in pairwise(output_ranges)
+        ):
+            raise ValueError("cuBLAS comparison output tensors must not overlap")
+        common_dtype = group_a[0].dtype
+        if any(
+            tensor.dtype != common_dtype
+            for tensors in (group_a, group_b, outputs)
+            for tensor in tensors
+        ):
+            raise ValueError("cuBLAS comparison requires one common dtype")
+        data_types = {
+            torch.float16: _CUDA_R_16F,
+            torch.bfloat16: _CUDA_R_16BF,
+        }
+        if common_dtype not in data_types:
+            raise ValueError("cuBLAS comparison supports FP16 and BF16")
+        cuda_version = torch.version.cuda
+        if cuda_version is None:
+            raise RuntimeError("cuBLAS comparison requires a CUDA PyTorch build")
+        library_name = os.environ.get(
+            "HELION_CUBLAS_LIBRARY",
+            f"libcublas.so.{cuda_version.partition('.')[0]}",
+        )
+        library = ctypes.CDLL(library_name)
+        void_pointer = ctypes.c_void_p
+        int_pointer = ctypes.POINTER(ctypes.c_int)
+        library.cublasCreate_v2.argtypes = [ctypes.POINTER(void_pointer)]
+        library.cublasCreate_v2.restype = ctypes.c_int
+        library.cublasDestroy_v2.argtypes = [void_pointer]
+        library.cublasDestroy_v2.restype = ctypes.c_int
+        library.cublasSetStream_v2.argtypes = [void_pointer, void_pointer]
+        library.cublasSetStream_v2.restype = ctypes.c_int
+        library.cublasSetWorkspace_v2.argtypes = [
+            void_pointer,
+            void_pointer,
+            ctypes.c_size_t,
+        ]
+        library.cublasSetWorkspace_v2.restype = ctypes.c_int
+        library.cublasSetPointerMode_v2.argtypes = [void_pointer, ctypes.c_int]
+        library.cublasSetPointerMode_v2.restype = ctypes.c_int
+        library.cublasGetVersion_v2.argtypes = [
+            void_pointer,
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        library.cublasGetVersion_v2.restype = ctypes.c_int
+        grouped = library.cublasGemmGroupedBatchedEx
+        grouped.argtypes = [
+            void_pointer,
+            int_pointer,
+            int_pointer,
+            int_pointer,
+            int_pointer,
+            int_pointer,
+            void_pointer,
+            void_pointer,
+            ctypes.c_int,
+            int_pointer,
+            void_pointer,
+            ctypes.c_int,
+            int_pointer,
+            void_pointer,
+            void_pointer,
+            ctypes.c_int,
+            int_pointer,
+            ctypes.c_int,
+            int_pointer,
+            ctypes.c_int,
+        ]
+        grouped.restype = ctypes.c_int
+
+        handle = void_pointer()
+        _check_cublas(library.cublasCreate_v2(ctypes.byref(handle)), "cublasCreate")
+        _check_cublas(
+            library.cublasSetPointerMode_v2(handle, _CUBLAS_POINTER_MODE_HOST),
+            "cublasSetPointerMode",
+        )
+        version = ctypes.c_int()
+        _check_cublas(
+            library.cublasGetVersion_v2(handle, ctypes.byref(version)),
+            "cublasGetVersion",
+        )
+
+        group_count = len(problems)
+        int_array = ctypes.c_int * group_count
+        float_array = ctypes.c_float * group_count
+        # cuBLAS is column-major. Swapping A/B computes the transpose of each
+        # row-major A @ B.T into the row-major output buffer without copies.
+        self.transa = int_array(*(_CUBLAS_OP_T for _ in problems))
+        self.transb = int_array(*(_CUBLAS_OP_N for _ in problems))
+        self.m = int_array(*(n for _m, n, _k, _l in problems))
+        self.n = int_array(*(m for m, _n, _k, _l in problems))
+        self.k = int_array(*(k for _m, _n, k, _l in problems))
+        self.lda = int_array(*(k for _m, _n, k, _l in problems))
+        self.ldb = int_array(*(k for _m, _n, k, _l in problems))
+        self.ldc = int_array(*(n for _m, n, _k, _l in problems))
+        self.group_sizes = int_array(*(1 for _ in problems))
+        self.alpha = float_array(*(1.0 for _ in problems))
+        self.beta = float_array(*(0.0 for _ in problems))
+        # cublasGemmGroupedBatchedEx consumes device arrays of operand pointers.
+        self.a_pointers = torch.tensor(
+            [tensor.data_ptr() for tensor in group_b],
+            device=device,
+            dtype=torch.int64,
+        )
+        self.b_pointers = torch.tensor(
+            [tensor.data_ptr() for tensor in group_a],
+            device=device,
+            dtype=torch.int64,
+        )
+        self.c_pointers = torch.tensor(
+            [tensor.data_ptr() for tensor in outputs],
+            device=device,
+            dtype=torch.int64,
+        )
+        workspace_storage = torch.empty(
+            _CUBLAS_WORKSPACE_BYTES + _CUBLAS_WORKSPACE_ALIGNMENT - 1,
+            device=device,
+            dtype=torch.uint8,
+        )
+        workspace_offset = (-workspace_storage.data_ptr()) % _CUBLAS_WORKSPACE_ALIGNMENT
+        self.workspace_storage = workspace_storage
+        self.workspace = workspace_storage[
+            workspace_offset : workspace_offset + _CUBLAS_WORKSPACE_BYTES
+        ]
+        if self.workspace.data_ptr() % _CUBLAS_WORKSPACE_ALIGNMENT:
+            raise RuntimeError("failed to align cuBLAS workspace")
+        self.library = library
+        self.library_name = library_name
+        self.version = version.value
+        self.handle = handle
+        self.handle_finalizer = weakref.finalize(
+            self,
+            library.cublasDestroy_v2,
+            handle,
+        )
+        self.grouped = grouped
+        self.group_count = group_count
+        self.device = device
+        self.dtype = common_dtype
+        self.data_type = data_types[self.dtype]
+
+    def __call__(self) -> object:
+        import torch
+
+        with torch.cuda.device(self.device):
+            return self._call_on_current_device()
+
+    def _call_on_current_device(self) -> object:
+        import torch
+
+        stream = torch.cuda.current_stream(self.device).cuda_stream
+        _check_cublas(
+            self.library.cublasSetStream_v2(
+                self.handle,
+                ctypes.c_void_p(stream),
+            ),
+            "cublasSetStream",
+        )
+        # Setting a cuBLAS stream resets its workspace, so bind the dedicated
+        # Blackwell-sized workspace after the capture stream on every launch.
+        _check_cublas(
+            self.library.cublasSetWorkspace_v2(
+                self.handle,
+                ctypes.c_void_p(self.workspace.data_ptr()),
+                _CUBLAS_WORKSPACE_BYTES,
+            ),
+            "cublasSetWorkspace",
+        )
+        status = self.grouped(
+            self.handle,
+            self.transa,
+            self.transb,
+            self.m,
+            self.n,
+            self.k,
+            ctypes.cast(self.alpha, ctypes.c_void_p),
+            ctypes.c_void_p(self.a_pointers.data_ptr()),
+            self.data_type,
+            self.lda,
+            ctypes.c_void_p(self.b_pointers.data_ptr()),
+            self.data_type,
+            self.ldb,
+            ctypes.cast(self.beta, ctypes.c_void_p),
+            ctypes.c_void_p(self.c_pointers.data_ptr()),
+            self.data_type,
+            self.ldc,
+            self.group_count,
+            self.group_sizes,
+            _CUBLAS_COMPUTE_32F,
+        )
+        _check_cublas(status, "cublasGemmGroupedBatchedEx")
+        return None
+
+
+def prepare_cublas(
+    problems: tuple[tuple[int, int, int, int], ...],
+    group_a: tuple[torch.Tensor, ...],
+    group_b: tuple[torch.Tensor, ...],
+    outputs: tuple[torch.Tensor, ...],
+) -> tuple[PreparedLaunch, dict[str, object]]:
+    """Prepare CUDA-graph-compatible cuBLAS grouped GEMM device work."""
+    import torch
+
+    if not group_a:
+        raise ValueError("cuBLAS comparison requires at least one group")
+    with torch.cuda.device(group_a[0].device):
+        launch = _CublasGroupedGemm(problems, group_a, group_b, outputs)
+    torch.cuda.synchronize(group_a[0].device)
+    owners: tuple[object, ...] = (launch, *group_a, *group_b, *outputs)
+    return PreparedLaunch(launch, owners), {
+        "api": "cublasGemmGroupedBatchedEx",
+        "library": launch.library_name,
+        "version": launch.version,
+        "dtype": str(launch.dtype),
+        "pointer_mode": "host",
+        "workspace_bytes": _CUBLAS_WORKSPACE_BYTES,
+        "device_pointer_tables_preloaded": True,
+        "timing_scope": "full captured public-API device work",
+    }

--- a/pretuned_kernels/_bench.py
+++ b/pretuned_kernels/_bench.py
@@ -15,15 +15,31 @@ and via run.py's importlib loader.
 
 from __future__ import annotations
 
+import abc
 import math
+import statistics
+import time
 from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import cast
 
 import torch
-import triton.testing as tt
+
+from helion import exc
+from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
+from helion.autotuner.logger import classify_triton_exception
+from helion.autotuner.logger import match_unrecoverable_runtime_error
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterable
+    from collections.abc import Sequence
+
+    import helion
+    from helion.runtime.kernel import CompiledConfig
+
+
+ShapeT = TypeVar("ShapeT")
 
 
 def geomean(values: Iterable[float]) -> float:
@@ -41,9 +57,149 @@ def bench_cudagraph(call: Callable[[], object], rep: int = 100) -> float:
     numbers are always measured with cache clearing -- install it before running
     a cudagraph kernel's ``main()`` (the nightly benchmark workflow does).
     """
-    from tritonbench.components.do_bench.run import _do_bench_cudagraph_with_cache_clear
+    from tritonbench.components.do_bench.run import (  # pyrefly: ignore[missing-import]
+        _do_bench_cudagraph_with_cache_clear,
+    )
 
     return _do_bench_cudagraph_with_cache_clear(call, rep=rep, return_mode="median")
+
+
+def bench_pre_captured_cudagraphs(
+    calls: Sequence[Callable[[], object]], rep: int = 100
+) -> list[float]:
+    """Median graph device latencies (ms), with cold L2 and balanced ordering.
+
+    Some external references must be captured before benchmarking so their
+    graph nodes, including captured copies, are represented faithfully. CUDA
+    does not allow a graph replay inside the outer capture used by
+    ``bench_cudagraph``. Queue an L2 clear before every event pair, matching
+    ``triton.testing.do_bench``.
+
+    Do not synchronize between the clear and the start event. On an idle GPU,
+    doing so lets the start event execute while Python is still submitting the
+    graph, which incorrectly includes host-side graph wrapper work as idle time
+    in the CUDA-event interval. The clear keeps the GPU busy while the next
+    replay is submitted, so the events measure device execution consistently.
+    Calls rotate through every position, then reverse the rotations, so no
+    implementation always sees the hottest GPU clocks.
+    """
+    import triton
+
+    if not calls:
+        raise ValueError("calls must not be empty")
+    if rep <= 0:
+        raise ValueError("rep must be positive")
+
+    driver = triton.runtime.driver.active
+    device_interface = driver.get_device_interface()  # pyrefly: ignore[missing-attribute]
+    cache = driver.get_empty_cache_for_benchmark()  # pyrefly: ignore[missing-attribute]
+    cycle = 2 * len(calls)
+    repetitions = rep
+
+    def call_order(sample: int) -> tuple[int, ...]:
+        indices = tuple(range(len(calls)))
+        rotation = sample % len(indices)
+        order = indices[rotation:] + indices[:rotation]
+        return order[::-1] if (sample // len(indices)) % 2 else order
+
+    for sample in range(cycle):
+        for index in call_order(sample):
+            calls[index]()
+    device_interface.synchronize()
+
+    starts = [
+        [device_interface.Event(enable_timing=True) for _ in range(repetitions)]
+        for _ in calls
+    ]
+    ends = [
+        [device_interface.Event(enable_timing=True) for _ in range(repetitions)]
+        for _ in calls
+    ]
+    for sample in range(repetitions):
+        for index in call_order(sample):
+            driver.clear_cache(cache)  # pyrefly: ignore[missing-attribute]
+            starts[index][sample].record()
+            calls[index]()
+            ends[index][sample].record()
+    device_interface.synchronize()
+    return [
+        statistics.median(
+            start.elapsed_time(end)
+            for start, end in zip(call_starts, call_ends, strict=True)
+        )
+        for call_starts, call_ends in zip(starts, ends, strict=True)
+    ]
+
+
+def bench_pre_captured_cudagraph(call: Callable[[], object], rep: int = 100) -> float:
+    """Median latency for one graph; see the balanced multi-graph timer."""
+    return bench_pre_captured_cudagraphs([call], rep=rep)[0]
+
+
+def thermal_warmup(duration_ms: int) -> None:
+    """Raise GPU clocks with device work before a latency sweep."""
+    if duration_ms <= 0:
+        return
+    value = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
+    end = time.monotonic() + duration_ms / 1000
+    while time.monotonic() < end:
+        for _ in range(50):
+            value = value @ value
+        torch.cuda.synchronize()
+
+
+class CapturedCudagraphBenchmarkProvider(LocalBenchmarkProvider, abc.ABC):
+    """Shared error handling and cold-L2 timing for captured-graph tuning."""
+
+    def __init__(self, *args: object, repetitions: int, **kwargs: object) -> None:
+        self._repetitions = repetitions
+        super().__init__(*args, **kwargs)  # pyrefly: ignore[bad-argument-type]
+
+    @abc.abstractmethod
+    def _capture_validated_replay(
+        self, config: helion.Config, fn: CompiledConfig
+    ) -> Callable[[], object] | None: ...
+
+    def _benchmark_function(
+        self,
+        config: helion.Config,
+        fn: CompiledConfig,
+        *,
+        effective_source_hash: str | None = None,
+    ) -> float:
+        self._autotune_metrics.num_configs_tested += 1
+        try:
+            replay = self._capture_validated_replay(config, fn)
+            if replay is None:
+                return float("inf")
+            return bench_pre_captured_cudagraph(replay, rep=self._repetitions)
+        except Exception as error:
+            error.__traceback__ = None
+            if match_unrecoverable_runtime_error(error):
+                self.kernel.maybe_log_repro(self.log.error, self.args, config)
+                raise exc.TritonUnrecoverableRuntimeError(
+                    reason=str(error),
+                    decorator=self.kernel.format_kernel_decorator(
+                        config, self.settings
+                    ),
+                    error=f"{type(error).__qualname__}: {error}",
+                ) from error
+            backend = getattr(self.config_spec, "backend", None)
+            action = (
+                backend.classify_autotune_exception(error)
+                if backend is not None
+                else None
+            ) or classify_triton_exception(error)
+            if action == "raise" and not self.settings.autotune_ignore_errors:
+                raise
+            self.log.debug(
+                f"Skipping captured-graph candidate after "
+                f"{type(error).__name__}: {error}"
+            )
+            self._record_compile_failure(config)
+            return float("inf")
+        finally:
+            self._clear_jit_fast_path_caches(fn)
 
 
 def _bench(
@@ -51,17 +207,31 @@ def _bench(
 ) -> float:
     if use_cudagraph:
         return bench_cudagraph(call, rep=rep)
-    return tt.do_bench(call, warmup=warmup, rep=rep, return_mode="median")
+    from triton.testing import do_bench
+
+    return cast(
+        "float",
+        do_bench(call, warmup=warmup, rep=rep, return_mode="median"),
+    )
 
 
 def run_sweep(
-    shapes: Iterable[object],
-    make_calls: Callable[[object], tuple],
+    shapes: Iterable[ShapeT],
+    make_calls: Callable[
+        [ShapeT],
+        tuple[
+            Callable[[], object],
+            list[tuple[str, Callable[[], object]]],
+            str,
+        ],
+    ],
     *,
     use_cudagraph: bool,
+    pre_captured_cudagraph: bool = False,
     shape_header: str,
     warmup: int = 25,
     rep: int = 100,
+    thermal_warmup_ms: int = 0,
     verbose: bool = True,
 ) -> dict:
     """Benchmark helion vs baselines over ``shapes``; return metrics (print if verbose).
@@ -72,12 +242,17 @@ def run_sweep(
     The metrics dict is always returned; the per-shape table is printed only when
     ``verbose``.
     """
+    if use_cudagraph and pre_captured_cudagraph:
+        raise ValueError(
+            "use_cudagraph and pre_captured_cudagraph are mutually exclusive"
+        )
 
     def _p(*args: object) -> None:
         if verbose:
             print(*args)
 
-    _p(f"GPU: {torch.cuda.get_device_name()}")
+    if verbose:
+        _p(f"GPU: {torch.cuda.get_device_name()}")
     speedups_by_base: dict[str, list[float]] = {}
     best_speedups: list[float] = []
     helion_wins = 0
@@ -93,15 +268,25 @@ def run_sweep(
             _p(f"{shape_header}  {'helion (us)':>12s}  {base_hdr}  {'speedup':>8s}")
             header_printed = True
 
-        helion_call()  # warmup / compile
-        ms_helion = _bench(helion_call, use_cudagraph, warmup, rep)
-        base_ms: dict[str, float] = {}
-        for name, call in baseline_calls:
-            base_ms[name] = _bench(call, use_cudagraph, warmup, rep)
+        if pre_captured_cudagraph:
+            thermal_warmup(thermal_warmup_ms)
+            timings = bench_pre_captured_cudagraphs(
+                [helion_call, *(call for _name, call in baseline_calls)], rep=rep
+            )
+            ms_helion, *baseline_timings = timings
+            base_ms = dict(zip(names, baseline_timings, strict=True))
+        else:
+            helion_call()  # warmup / compile
+            ms_helion = _bench(helion_call, use_cudagraph, warmup, rep)
+            base_ms = {
+                name: _bench(call, use_cudagraph, warmup, rep)
+                for name, call in baseline_calls
+            }
+        for name in names:
             speedups_by_base[name].append(
                 base_ms[name] / ms_helion if ms_helion > 0 else float("nan")
             )
-        best_name = min(base_ms, key=base_ms.get)
+        best_name = min(base_ms, key=lambda name: base_ms[name])
         speedup = base_ms[best_name] / ms_helion if ms_helion > 0 else float("nan")
         best_speedups.append(speedup)
         if speedup > 1.0:

--- a/pretuned_kernels/grouped_gemm/_helion_aot_grouped_gemm_cuda_sm100.py
+++ b/pretuned_kernels/grouped_gemm/_helion_aot_grouped_gemm_cuda_sm100.py
@@ -1,0 +1,100 @@
+"""Checked-in B200 heuristic for the grouped FP16 benchmark."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+
+_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY = "tcgen05_grouped_static_problem_signature"
+_COMMON_CONFIG: dict[str, object] = {
+    "block_sizes": [128, 64, 64],
+    "loop_orders": [[0, 1]],
+    "l2_groupings": [1],
+    "num_warps": 8,
+    "num_stages": 2,
+    "pid_type": "persistent_interleaved",
+    "tcgen05_cluster_m": 1,
+    "tcgen05_cluster_n": 1,
+    "tcgen05_num_epi_warps": 4,
+    "tcgen05_grouped_mode": "direct",
+    "tcgen05_grouped_external_direct_pointers": "direct_pointers",
+    "tcgen05_grouped_external_direct_strides": "direct_strides",
+}
+_DEEP_CONFIG: dict[str, object] = {
+    **_COMMON_CONFIG,
+    "tcgen05_ab_stages": 8,
+    "tcgen05_acc_stages": 2,
+    "tcgen05_c_stages": 4,
+}
+_SMALL_CONFIG: dict[str, object] = {
+    **_COMMON_CONFIG,
+    "tcgen05_ab_stages": 2,
+    "tcgen05_acc_stages": 1,
+    "tcgen05_c_stages": 2,
+}
+
+_PROBLEM_SIGNATURES = (
+    (3, 128, 128, 128, 512, 128, 128, 128, 256, 128, 0, 0, 0),
+    (4, 8192, 1280, 32, 128, 384, 1536, 640, 1280, 16, 640, 128, 16),
+    (4, 8192, 1280, 32, 128, 384, 1536, 640, 1280, 16, 640, 192, 16),
+    (4, 8192, 1280, 32, 16, 384, 1536, 640, 1280, 16, 640, 160, 16),
+    (4, 8192, 1280, 32, 16, 384, 1536, 640, 1280, 16, 640, 192, 16),
+    (4, 8192, 1280, 32, 16, 384, 1536, 640, 1280, 16, 640, 128, 16),
+    (4, 8192, 1280, 32, 128, 384, 1536, 640, 1280, 16, 640, 160, 16),
+)
+_MEASURED_PIPELINES = (
+    _SMALL_CONFIG,
+    _DEEP_CONFIG,
+    _DEEP_CONFIG,
+    _DEEP_CONFIG,
+    _DEEP_CONFIG,
+    _DEEP_CONFIG,
+    _DEEP_CONFIG,
+)
+_DEEP_PIPELINE_MIN_OUTPUT_TILES = 128
+
+
+def _config_for_signature(
+    signature: tuple[int, ...], pipeline: dict[str, object]
+) -> dict[str, object]:
+    group_count = signature[0]
+    config = deepcopy(pipeline)
+    config[_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+        int(value) for value in signature[: 1 + 3 * group_count]
+    ]
+    return config
+
+
+CONFIGS = [
+    _config_for_signature(signature, pipeline)
+    for signature, pipeline in zip(
+        _PROBLEM_SIGNATURES, _MEASURED_PIPELINES, strict=True
+    )
+]
+_CONFIG_BY_SIGNATURE: dict[tuple[int, ...], dict[str, object]] = dict(
+    zip(_PROBLEM_SIGNATURES, CONFIGS, strict=True)
+)
+
+
+def _fallback_pipeline(signature: tuple[int, ...]) -> dict[str, object]:
+    """Choose a valid unmeasured pipeline from the static output-tile count."""
+    group_count = signature[0]
+    output_tiles = sum(
+        ((signature[offset] + 127) // 128)
+        * ((signature[offset + 1] + 63) // 64)
+        for offset in range(1, 1 + 3 * group_count, 3)
+    )
+    return (
+        _DEEP_CONFIG
+        if output_tiles >= _DEEP_PIPELINE_MIN_OUTPUT_TILES
+        else _SMALL_CONFIG
+    )
+
+
+def autotune_grouped_gemm(*args: int) -> dict[str, object]:
+    """Select the measured pipeline and embed its exact active group shapes."""
+    signature = tuple(args)
+    measured = _CONFIG_BY_SIGNATURE.get(signature)
+    if measured is not None:
+        return deepcopy(measured)
+    return _config_for_signature(signature, _fallback_pipeline(signature))

--- a/pretuned_kernels/grouped_gemm/grouped_gemm.py
+++ b/pretuned_kernels/grouped_gemm/grouped_gemm.py
@@ -1,0 +1,456 @@
+"""Pretuned B200 grouped FP16 GEMM versus CUTLASS CuTeDSL.
+
+This benchmark uses seven CUTLASS-example-derived heterogeneous FP16 NT
+validation cases (3--4 GEMMs, including M/N tails). Both implementations consume
+the same A/B tensors and write the same output buffers sequentially. Each passes
+correctness checks and is timed through CUDA-graph replay. CUTLASS initializes
+its device pointer table before graph capture, matching Helion's setup.
+
+The pretuned dashboard clears L2 before every replay and batches CUDA event
+pairs so host graph-submission work is not charged as device time. This matches
+the ``triton.testing.do_bench`` device-timing semantics used in PR #3033.
+
+The CUTLASS source is pinned by commit and SHA256 in the shared comparison
+harness. Before a manual run, export
+``HELION_CUTLASS_GROUPED_GEMM_SOURCE=/path/to/grouped_gemm.py`` from the pinned
+checkout. The nightly workflow downloads and verifies those exact bytes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
+from itertools import starmap
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import cast
+
+from benchmarks.cute import compare_grouped_gemm_backends as _COMPARE
+from pretuned_kernels import _bench as _BENCH
+import torch
+
+import helion
+from helion.autotuner import AOTAutotuneCache
+from helion.autotuner import FiniteSearch
+import helion.language as hl
+import helion.runtime as helion_runtime
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+    from types import ModuleType
+
+    from benchmarks.cute.compare_grouped_gemm_backends import Case
+    from benchmarks.cute.compare_grouped_gemm_backends import PreparedLaunch
+
+    from helion.runtime.kernel import BoundKernel
+    from helion.runtime.kernel import CompiledConfig
+
+
+CUTLASS_COMMIT: str = _COMPARE.CUTLASS_COMMIT
+CUTLASS_SHA256: str = _COMPARE.CUTLASS_SHA256
+CASES: tuple[Case, ...] = _COMPARE.CASES
+CTA_M: int = _COMPARE.CTA_M
+CTA_N: int = _COMPARE.CTA_N
+CTA_K: int = _COMPARE.CTA_K
+CUTLASS_SOURCE_ENV = "HELION_CUTLASS_GROUPED_GEMM_SOURCE"
+CUTLASS_KERNEL_BASELINE: str = _COMPARE.CUTLASS_KERNEL_BASELINE
+STATIC_PROBLEM_SIGNATURE_CONFIG_KEY = "tcgen05_grouped_static_problem_signature"
+_MAX_GROUPS = max(len(case.problems) for case in CASES)
+
+
+def _problem_signature(
+    problems: Sequence[tuple[int, int, int, int]],
+) -> tuple[int, ...]:
+    """Return a fixed-width AOT feature vector with every group's real M/N/K."""
+    if any(batch != 1 for _m, _n, _k, batch in problems):
+        raise ValueError("grouped_gemm only supports L=1 problems")
+    values = [len(problems)]
+    for m, n, k, _l in problems:
+        values.extend((m, n, k))
+    values.extend((0, 0, 0) * (_MAX_GROUPS - len(problems)))
+    return tuple(values)
+
+
+def _direct_config(ab_stages: int, acc_stages: int, c_stages: int) -> helion.Config:
+    config: dict[str, object] = {
+        "block_sizes": [CTA_M, CTA_N, CTA_K],
+        "l2_groupings": [1],
+        "loop_orders": [[0, 1]],
+        "num_stages": 2,
+        "num_warps": 8,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": 1,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": ab_stages,
+        "tcgen05_acc_stages": acc_stages,
+        "tcgen05_c_stages": c_stages,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_grouped_mode": "direct",
+        "tcgen05_grouped_external_direct_pointers": "direct_pointers",
+        "tcgen05_grouped_external_direct_strides": "direct_strides",
+    }
+    return helion.Config.from_dict(config)
+
+
+_PIPELINE_STAGE_TRIPLES = ((2, 1, 2), (8, 2, 4))
+_AOT_CONFIGS = tuple(starmap(_direct_config, _PIPELINE_STAGE_TRIPLES))
+_AOT_BENCH_REPETITIONS = 500
+
+
+def _configs_for_problem_signature(
+    signature: tuple[int, ...],
+) -> tuple[helion.Config, ...]:
+    active_signature = list(signature[: 1 + 3 * signature[0]])
+    return tuple(
+        helion.Config.from_dict(
+            {
+                **config.config,
+                STATIC_PROBLEM_SIGNATURE_CONFIG_KEY: active_signature,
+            }
+        )
+        for config in _AOT_CONFIGS
+    )
+
+
+@dataclass(frozen=True)
+class _GroupedValidation:
+    outputs: tuple[torch.Tensor, ...]
+    expected: tuple[torch.Tensor, ...]
+
+
+class _ColdCudagraphBenchmarkProvider(_BENCH.CapturedCudagraphBenchmarkProvider):
+    """Score direct-pointer candidates under the dashboard's cold-L2 protocol."""
+
+    def __init__(
+        self,
+        *args: object,
+        validation: _GroupedValidation | None,
+        **kwargs: object,
+    ) -> None:
+        if validation is None:
+            raise ValueError("grouped-GEMM autotuning requires validation context")
+        self._validation = validation
+        super().__init__(
+            *args,
+            repetitions=_AOT_BENCH_REPETITIONS,
+            **kwargs,
+        )
+
+    def _compute_baseline(self) -> tuple[object, Sequence[int], None]:
+        """Skip the generic clone, which cannot rebase the raw pointer table."""
+        return None, (), None
+
+    def _capture_validated_replay(
+        self, config: helion.Config, fn: CompiledConfig
+    ) -> Callable[[], object] | None:
+        for _ in range(2):
+            fn(*self.args)
+        torch.cuda.synchronize()
+        with helion_runtime.cute_cuda_graph() as graph:
+            fn(*self.args)
+        torch.cuda.synchronize()
+
+        if self.settings.autotune_accuracy_check:
+            for output in self._validation.outputs:
+                output.fill_(torch.nan)
+            graph.replay()
+            torch.cuda.synchronize()
+            try:
+                _COMPARE.check_correctness(
+                    self._validation.outputs, self._validation.expected
+                )
+            except AssertionError as error:
+                self._record_accuracy_failure(config)
+                if not self.settings.autotune_ignore_errors:
+                    self.log.warning(
+                        "Skipping grouped-GEMM config with accuracy mismatch: "
+                        f"{config!r}\n{error}"
+                    )
+                return None
+        return graph.replay
+
+
+def _grouped_aot_key(
+    a_placeholder: torch.Tensor,
+    b_placeholder: torch.Tensor,
+    layout: torch.Tensor,
+    n_sizes: torch.Tensor,
+    k_sizes: torch.Tensor,
+    out_placeholder: torch.Tensor,
+    direct_pointers: torch.Tensor,
+    direct_strides: torch.Tensor,
+    problem_signature: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Expose real per-group problem sizes instead of placeholder shapes."""
+    return problem_signature
+
+
+def _grouped_aot_autotuner(
+    bound_kernel: BoundKernel,
+    args: Sequence[object],
+    **kwargs: object,
+) -> AOTAutotuneCache:
+    """Use AOT caching around the direct path's finite valid config space."""
+    configs = _configs_for_problem_signature(cast("tuple[int, ...]", args[-1]))
+    provider = partial(
+        _ColdCudagraphBenchmarkProvider,
+        validation=cast("_GroupedValidation | None", kwargs.get("benchmark_context")),
+    )
+
+    def make_search() -> FiniteSearch:
+        return FiniteSearch(
+            bound_kernel,
+            args,
+            configs=configs,
+            benchmark_provider_cls=provider,
+        )
+
+    return AOTAutotuneCache(make_search(), autotuner_factory=make_search)
+
+
+@helion.aot_kernel(
+    backend="cute",
+    key=_grouped_aot_key,
+    static_shapes=True,
+    autotuner_fn=_grouped_aot_autotuner,
+    autotune_precompile=None,
+)
+def grouped_gemm(
+    a_placeholder: torch.Tensor,
+    b_placeholder: torch.Tensor,
+    layout: torch.Tensor,
+    n_sizes: torch.Tensor,
+    k_sizes: torch.Tensor,
+    out_placeholder: torch.Tensor,
+    direct_pointers: torch.Tensor,
+    direct_strides: torch.Tensor,
+    problem_signature: tuple[int, ...],
+) -> torch.Tensor:
+    """Grouped A[M,K] @ B[G,N,K].T with direct runtime metadata."""
+    m, max_k = a_placeholder.size()
+    _groups, max_n, _k = b_placeholder.size()
+    for tile_m, tile_n in hl.tile([m, max_n]):
+        group_id = layout[tile_m.begin]
+        safe_group_id = torch.where(group_id >= 0, group_id, 0)
+        valid_rows = layout[tile_m] == safe_group_id
+        valid_cols = tile_n.index < n_sizes[safe_group_id]
+        valid = valid_rows[:, None] & valid_cols[None, :]  # pyrefly: ignore[bad-index]
+        group_k = k_sizes[safe_group_id]
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(max_k):  # pyrefly: ignore[bad-assignment]
+            valid_k = (tile_k.index < group_k)[None, :]  # pyrefly: ignore[bad-index]
+            a_tile = a_placeholder[tile_m, tile_k]
+            b_tile = b_placeholder[safe_group_id, tile_n, tile_k]
+            a_tile = torch.where(valid_k, a_tile, torch.zeros_like(a_tile))
+            b_tile = torch.where(valid_k, b_tile, torch.zeros_like(b_tile))
+            acc = torch.addmm(acc, a_tile, b_tile.T)
+        old = out_placeholder[tile_m, tile_n]
+        out_placeholder[tile_m, tile_n] = torch.where(
+            valid, acc.to(out_placeholder.dtype), old
+        )
+    return out_placeholder
+
+
+def _placeholder(shape: tuple[int, ...], device: torch.device) -> torch.Tensor:
+    base = torch.empty(max(1, shape[-1]), device=device, dtype=torch.float16)
+    return torch.as_strided(base, shape, (0,) * (len(shape) - 1) + (1,))
+
+
+def _prepare_helion(
+    case: Case,
+    group_a: tuple[torch.Tensor, ...],
+    group_b: tuple[torch.Tensor, ...],
+    outputs: tuple[torch.Tensor, ...],
+    expected: tuple[torch.Tensor, ...],
+) -> PreparedLaunch:
+    problems = case.problems
+    device = group_a[0].device
+    aligned_m = tuple((m + CTA_M - 1) // CTA_M * CTA_M for m, _n, _k, _l in problems)
+    padded_m = sum(aligned_m)
+    max_n = max(n for _m, n, _k, _l in problems)
+    max_k = max(k for _m, _n, k, _l in problems)
+    layout = torch.empty(padded_m, device=device, dtype=torch.int32)
+    cursor = 0
+    for group, ((m, _n, _k, _l), padded) in enumerate(
+        zip(problems, aligned_m, strict=True)
+    ):
+        layout[cursor : cursor + m].fill_(group)
+        layout[cursor + m : cursor + padded].fill_(-1)
+        cursor += padded
+    n_sizes = torch.tensor([p[1] for p in problems], device=device, dtype=torch.int32)
+    k_sizes = torch.tensor([p[2] for p in problems], device=device, dtype=torch.int32)
+    direct_pointers = torch.tensor(
+        [
+            (a.data_ptr(), b.data_ptr(), out.data_ptr())
+            for a, b, out in zip(group_a, group_b, outputs, strict=True)
+        ],
+        device=device,
+        dtype=torch.int64,
+    )
+    direct_strides = torch.tensor(
+        [
+            (tuple(a.stride()), tuple(b.stride()), tuple(out.stride()))
+            for a, b, out in zip(group_a, group_b, outputs, strict=True)
+        ],
+        device=device,
+        dtype=torch.int32,
+    )
+    kernel_args = (
+        _placeholder((padded_m, max_k), device),
+        _placeholder((len(problems), max_n, max_k), device),
+        layout,
+        n_sizes,
+        k_sizes,
+        _placeholder((padded_m, max_n), device),
+        direct_pointers,
+        direct_strides,
+        _problem_signature(problems),
+    )
+
+    if os.environ.get("HELION_AOT_MODE", "evaluate").lower() in {
+        "collect",
+        "measure",
+    }:
+        grouped_gemm.autotune(
+            kernel_args,
+            force=False,
+            benchmark_context=_GroupedValidation(outputs, expected),
+        )
+
+    def launch() -> object:
+        with torch.cuda.device(device):
+            return grouped_gemm(*kernel_args)
+
+    owners: tuple[object, ...] = (*group_a, *group_b, *outputs, *kernel_args)
+    return _COMPARE.PreparedLaunch(launch, owners)
+
+
+def _cutlass_source_path() -> Path:
+    raw_path = os.environ.get(CUTLASS_SOURCE_ENV)
+    if not raw_path:
+        raise RuntimeError(
+            f"{CUTLASS_SOURCE_ENV} must point to CUTLASS commit {CUTLASS_COMMIT} "
+            "examples/python/CuTeDSL/cute/blackwell/kernel/grouped_gemm/"
+            "grouped_gemm.py"
+        )
+    path = Path(raw_path).expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"{CUTLASS_SOURCE_ENV} does not exist: {path}")
+    return path
+
+
+def _captured_calls(
+    case: Case,
+    cutlass_module: ModuleType,
+) -> tuple[Callable[[], object], list[tuple[str, Callable[[], object]]], str]:
+    torch.manual_seed(0)
+    device = torch.device("cuda", torch.cuda.current_device())
+    group_a, group_b, expected = _COMPARE.make_inputs(case.problems, device)
+    outputs = _COMPARE.make_outputs(group_a, group_b)
+    helion_launch = _prepare_helion(case, group_a, group_b, outputs, expected)
+    cutlass_launch = _COMPARE.prepare_cutlass(
+        cutlass_module, case.problems, group_a, group_b, outputs
+    )
+    helion_graph = _COMPARE.capture_launch(helion_launch, 2, track_cute=True)
+    cutlass_kernel_graph = _COMPARE.capture_launch(cutlass_launch, 2)
+
+    for graph in (helion_graph, cutlass_kernel_graph):
+        for output in outputs:
+            output.fill_(torch.nan)
+        graph.replay()
+        torch.cuda.synchronize()
+        _COMPARE.check_correctness(outputs, expected)
+
+    # Default arguments retain every TensorMap, pointer table, tensor, launch,
+    # and graph for the lifetime of the timed closure.
+    def helion_call(
+        graph: torch.cuda.CUDAGraph = helion_graph,
+        owners: tuple[object, ...] = (helion_launch, helion_graph),
+    ) -> object:
+        return graph.replay()
+
+    def cutlass_kernel_call(
+        graph: torch.cuda.CUDAGraph = cutlass_kernel_graph,
+        owners: tuple[object, ...] = (cutlass_launch, cutlass_kernel_graph),
+    ) -> object:
+        return graph.replay()
+
+    return (
+        helion_call,
+        [(CUTLASS_KERNEL_BASELINE, cutlass_kernel_call)],
+        case.shape_label,
+    )
+
+
+def use_cudagraph() -> bool:
+    """The timed closures replay pre-captured implementation CUDA graphs."""
+    return True
+
+
+def _run_aot_training(verbose: bool) -> dict[str, object]:
+    """Exercise every case once; the active AOT mode owns any tuning work."""
+    for case in CASES:
+        torch.manual_seed(0)
+        device = torch.device("cuda", torch.cuda.current_device())
+        group_a, group_b, expected = _COMPARE.make_inputs(case.problems, device)
+        outputs = _COMPARE.make_outputs(group_a, group_b)
+        launch = _prepare_helion(case, group_a, group_b, outputs, expected)
+        launch()
+        torch.cuda.synchronize()
+        _COMPARE.check_correctness(outputs, expected)
+        if verbose:
+            print(f"AOT {os.environ['HELION_AOT_MODE']}: {case.name} passed")
+    return {
+        "helion_wins": 0,
+        "total": 0,
+        "geomean": 0.0,
+        "best_speedup": 0.0,
+        "baselines": {},
+    }
+
+
+def main(verbose: bool = True) -> dict[str, object]:
+    """Benchmark seven CUTLASS-derived grouped-GEMM cases for the dashboard."""
+    previous_mma_impl = os.environ.get("HELION_CUTE_MMA_IMPL")
+    os.environ["HELION_CUTE_MMA_IMPL"] = "tcgen05"
+    try:
+        if os.environ.get("HELION_AOT_MODE", "evaluate").lower() in {
+            "collect",
+            "compile",
+            "measure",
+        }:
+            return _run_aot_training(verbose)
+
+        cutlass_module, _provenance = _COMPARE.load_cutlass_source(
+            _cutlass_source_path()
+        )
+
+        def make_calls(
+            case: Case,
+        ) -> tuple[Callable[[], object], list[tuple[str, Callable[[], object]]], str]:
+            return _captured_calls(case, cutlass_module)
+
+        # The closures replay already-captured graphs, so ``use_cudagraph`` is
+        # false here to avoid illegal nested capture. The dedicated timer still
+        # clears L2 before every replay and balances implementation order.
+        return _BENCH.run_sweep(
+            CASES,
+            make_calls,
+            use_cudagraph=False,
+            pre_captured_cudagraph=True,
+            rep=204,
+            thermal_warmup_ms=10_000,
+            verbose=verbose,
+            shape_header="shape",
+        )
+    finally:
+        if previous_mma_impl is None:
+            os.environ.pop("HELION_CUTE_MMA_IMPL", None)
+        else:
+            os.environ["HELION_CUTE_MMA_IMPL"] = previous_mma_impl
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_cute_grouped_gemm_benchmark.py
+++ b/test/test_cute_grouped_gemm_benchmark.py
@@ -1,19 +1,25 @@
 from __future__ import annotations
 
 import argparse
+import builtins
+from contextlib import AbstractContextManager
 import hashlib
 import importlib.util
+from itertools import starmap
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import torch
 
 BENCHMARK_DIR = Path(__file__).resolve().parents[1] / "benchmarks" / "cute"
+PRETUNED_DIR = Path(__file__).resolve().parents[1] / "pretuned_kernels"
 
 
-def _load_script(filename: str, module_name: str) -> Any:
-    spec = importlib.util.spec_from_file_location(module_name, BENCHMARK_DIR / filename)
+def _load_path(path: Path, module_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, path)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -22,18 +28,44 @@ def _load_script(filename: str, module_name: str) -> Any:
     return module
 
 
+def test_bench_module_import_does_not_require_triton(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import_module = builtins.__import__
+    import_module("helion")
+
+    def import_without_triton(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "triton" or name.startswith("triton."):
+            raise ModuleNotFoundError(name)
+        return import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_triton)
+    module_name = "helion_test_pretuned_bench_without_triton"
+    module = _load_path(PRETUNED_DIR / "_bench.py", module_name)
+    assert module.geomean((1.0, 4.0)) == 2.0
+    sys.modules.pop(module_name)
+
+
 @pytest.fixture(scope="module")
 def cutlass_benchmark() -> Any:
-    return _load_script(
-        "compare_grouped_gemm_backends.py",
+    return _load_path(
+        BENCHMARK_DIR / "compare_grouped_gemm_backends.py",
         "helion_test_compare_grouped_gemm_backends",
     )
 
 
 @pytest.fixture(scope="module")
+def cublas_adapter() -> Any:
+    return _load_path(
+        BENCHMARK_DIR / "cublas_grouped_gemm.py",
+        "helion_test_cublas_grouped_gemm",
+    )
+
+
+@pytest.fixture(scope="module")
 def deepgemm_benchmark() -> Any:
-    return _load_script(
-        "deepgemm_selected_path.py",
+    return _load_path(
+        BENCHMARK_DIR / "deepgemm_selected_path.py",
         "helion_test_deepgemm_selected_path",
     )
 
@@ -43,7 +75,13 @@ def test_published_manifests_are_fixed(
 ) -> None:
     manifest = (
         tuple(
-            (case.name, case.problems, case.reserved_sms, case.ab_stages)
+            (
+                case.name,
+                case.problems,
+                case.ab_stages,
+                case.acc_stages,
+                case.c_stages,
+            )
             for case in cutlass_benchmark.CASES
         ),
         tuple(tuple(shape) for shape in deepgemm_benchmark.OFFICIAL_SHAPES),
@@ -56,43 +94,59 @@ def test_published_manifests_are_fixed(
         deepgemm_benchmark.selected_config().config,
     )
     assert hashlib.sha256(repr(manifest).encode()).hexdigest() == (
-        "608089dc016171e07938f1a67c9c42ed56e292a2d99038b8a2410393d7aa8c74"
+        "5995339a3112d28f958a8a6bbe2f36fddae01e7c914feaeccd4ee3d394283efc"
     )
 
 
-def test_cutlass_timings_are_paired_and_balanced(
+@pytest.fixture(scope="module")
+def pretuned_grouped_gemm() -> Any:
+    return _load_path(
+        PRETUNED_DIR / "grouped_gemm" / "grouped_gemm.py",
+        "helion_test_pretuned_grouped_gemm",
+    )
+
+
+@pytest.fixture(scope="module")
+def grouped_gemm_heuristic() -> Any:
+    return _load_path(
+        PRETUNED_DIR / "grouped_gemm" / "_helion_aot_grouped_gemm_cuda_sm100.py",
+        "helion_test_pretuned_grouped_gemm_heuristic",
+    )
+
+
+@pytest.fixture(scope="module")
+def pretuned_bench() -> Any:
+    return _load_path(PRETUNED_DIR / "_bench.py", "helion_test_pretuned_bench")
+
+
+def test_cutlass_timings_use_shared_timer(
     cutlass_benchmark: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     order: list[str] = []
     thermal_warmups: list[int] = []
     args = cutlass_benchmark._parser().parse_args([])
-    assert (args.num_runs, args.cache_warmup_calls, args.thermal_warmup_ms) == (
-        6,
-        5,
-        10000,
-    )
-    args.num_runs = 2
-    args.cache_warmup_calls = args.thermal_warmup_ms = 0
+    args.repetitions = 12
+    args.thermal_warmup_ms = 0
 
-    def fake_bench(fn: Any, _args: argparse.Namespace) -> float:
-        fn()
-        return 1.0
+    def fake_bench(calls: list[Any], rep: int) -> list[float]:
+        assert rep == 12
+        order.extend(call() for call in calls)
+        return [1.0, 2.0]
 
-    monkeypatch.setattr(cutlass_benchmark, "_do_bench", fake_bench)
-    monkeypatch.setattr(cutlass_benchmark, "_thermal_warmup", thermal_warmups.append)
+    monkeypatch.setattr(cutlass_benchmark, "bench_pre_captured_cudagraphs", fake_bench)
+    monkeypatch.setattr(cutlass_benchmark, "thermal_warmup", thermal_warmups.append)
     timings = cutlass_benchmark._bench_pair(
         {
-            "helion_retained": lambda: order.append("H"),
-            "cutlass": lambda: order.append("C"),
+            "helion_retained": lambda: "H",
+            cutlass_benchmark.CUTLASS_KERNEL_BASELINE: lambda: "K",
         },
         args,
     )
 
-    assert order == list("HCCH")
+    assert order == ["H", "K"]
     assert thermal_warmups == [0]
-    assert timings["helion_retained"]["runs_ms"] == [1.0, 1.0]
-    with pytest.raises(argparse.ArgumentTypeError, match="positive even"):
-        cutlass_benchmark._positive_even("5")
+    assert timings["helion_retained"]["median_ms"] == 1.0
+    assert timings[cutlass_benchmark.CUTLASS_KERNEL_BASELINE]["median_ms"] == 2.0
 
 
 def test_cutlass_loader_verifies_and_retains_bytes(
@@ -101,7 +155,7 @@ def test_cutlass_loader_verifies_and_retains_bytes(
     source = tmp_path / "grouped_gemm.py"
     source.write_text("raise AssertionError('must not execute')\n")
     with pytest.raises(ValueError, match="CUTLASS source SHA256 mismatch"):
-        cutlass_benchmark._load_cutlass_source(source)
+        cutlass_benchmark.load_cutlass_source(source)
 
     source.write_text(
         "class GroupedGemmKernel:\n"
@@ -116,13 +170,308 @@ def test_cutlass_loader_verifies_and_retains_bytes(
         cutlass_benchmark.importlib.metadata, "version", lambda _name: "test"
     )
 
-    module, provenance = cutlass_benchmark._load_cutlass_source(source)
+    module, provenance = cutlass_benchmark.load_cutlass_source(source)
     source.write_text("raise AssertionError('changed after verification')\n")
 
     assert module.GroupedGemmKernel.marker == "verified"
     assert module.__file__ == f"<helion-cutlass-grouped-gemm-{digest}.py>"
     assert provenance["source_sha256"] == digest
     assert provenance["expected_cutlass_commit"] == cutlass_benchmark.CUTLASS_COMMIT
+
+
+def test_cutlass_summary_reports_kernel_baseline(
+    cutlass_benchmark: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    case = cutlass_benchmark.CASES[0]
+    case_dir = tmp_path / "cutlass" / case.name
+    case_dir.mkdir(parents=True)
+    (case_dir / "result.json").write_text(
+        '{"problem_sizes": [], "timings": {}, "helion_over_cutlass_kernel": 0.8}'
+    )
+    monkeypatch.setattr(cutlass_benchmark, "_git", lambda *_args: "test")
+    summary = cutlass_benchmark._build_summary(
+        argparse.Namespace(
+            out_dir=tmp_path,
+            cutlass_source=tmp_path / "grouped_gemm.py",
+        ),
+        [case],
+        [],
+        [],
+    )
+
+    assert summary["wins_vs_cutlass_kernel"] == 1
+    assert summary["geomean_helion_over_cutlass_kernel"] == 0.8
+
+
+@pytest.mark.parametrize("dtype", (torch.float16, torch.bfloat16))
+def test_cublas_grouped_adapter_matches_torch(
+    cublas_adapter: Any, dtype: torch.dtype
+) -> None:
+    if torch.version.cuda is None or not torch.cuda.is_available():
+        pytest.skip("cuBLAS grouped adapter requires an NVIDIA CUDA device")
+    device = torch.device("cuda", torch.cuda.current_device())
+    problems = ((3, 16, 8, 1), (5, 24, 16, 1))
+    group_a = tuple(
+        torch.randn((m, k), device=device, dtype=dtype) for m, _n, k, _batch in problems
+    )
+    group_b = tuple(
+        torch.randn((n, k), device=device, dtype=dtype) for _m, n, k, _batch in problems
+    )
+    outputs = tuple(
+        torch.empty((m, n), device=device, dtype=dtype) for m, n, _k, _batch in problems
+    )
+    expected = tuple(a @ b.T for a, b in zip(group_a, group_b, strict=True))
+
+    launch, _provenance = cublas_adapter.prepare_cublas(
+        problems, group_a, group_b, outputs
+    )
+    launch()
+    torch.cuda.synchronize(device)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+    for output in outputs:
+        output.fill_(torch.nan)
+    graph.replay()
+    torch.cuda.synchronize(device)
+
+    for actual, reference in zip(outputs, expected, strict=True):
+        torch.testing.assert_close(actual, reference, atol=3e-2, rtol=3e-2)
+
+
+def test_pretuned_grouped_gemm_configs(
+    pretuned_grouped_gemm: Any,
+    grouped_gemm_heuristic: Any,
+) -> None:
+    candidates = pretuned_grouped_gemm._AOT_CONFIGS
+    assert [
+        (
+            config["tcgen05_ab_stages"],
+            config["tcgen05_acc_stages"],
+            config["tcgen05_c_stages"],
+        )
+        for config in candidates
+    ] == [(2, 1, 2), (8, 2, 4)]
+
+    signatures = tuple(
+        pretuned_grouped_gemm._problem_signature(case.problems)
+        for case in pretuned_grouped_gemm.CASES
+    )
+    assert len(set(signatures)) == len(signatures)
+    static_key = pretuned_grouped_gemm.STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
+    selected = tuple(starmap(grouped_gemm_heuristic.autotune_grouped_gemm, signatures))
+    assert [
+        (config["tcgen05_ab_stages"], config["tcgen05_acc_stages"])
+        for config in selected
+    ] == [(2, 1), *((8, 2),) * 6]
+    for signature, config in zip(signatures, selected, strict=True):
+        assert config[static_key] == list(signature[: 1 + 3 * signature[0]])
+
+    unseen = (1, 256, 64, 64)
+    fallback = grouped_gemm_heuristic.autotune_grouped_gemm(*unseen)
+    assert fallback[static_key] == list(unseen)
+    assert fallback["tcgen05_ab_stages"] == 2
+
+
+@pytest.mark.parametrize("replay_writes_output", (True, False))
+def test_grouped_gemm_tuner_validates_pointer_targets(
+    pretuned_grouped_gemm: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    replay_writes_output: bool,
+) -> None:
+    output = torch.zeros(2)
+    expected = torch.tensor([1.0, 2.0])
+    failures: list[object] = []
+    cleared: list[object] = []
+
+    def replay() -> None:
+        if replay_writes_output:
+            output.copy_(expected)
+
+    class FakeCapture(AbstractContextManager[SimpleNamespace]):
+        def __enter__(self) -> SimpleNamespace:
+            return SimpleNamespace(replay=replay)
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    provider = pretuned_grouped_gemm._ColdCudagraphBenchmarkProvider.__new__(
+        pretuned_grouped_gemm._ColdCudagraphBenchmarkProvider
+    )
+    provider._validation = pretuned_grouped_gemm._GroupedValidation(
+        (output,), (expected,)
+    )
+    provider._repetitions = 6
+    provider.args = ()
+    provider.settings = SimpleNamespace(
+        autotune_accuracy_check=True,
+        autotune_ignore_errors=True,
+    )
+    provider._autotune_metrics = SimpleNamespace(num_configs_tested=0)
+    provider._record_accuracy_failure = failures.append
+    provider._clear_jit_fast_path_caches = cleared.append
+    provider.log = SimpleNamespace(warning=lambda _message: None)
+
+    monkeypatch.setattr(
+        pretuned_grouped_gemm.helion_runtime, "cute_cuda_graph", FakeCapture
+    )
+    monkeypatch.setattr(pretuned_grouped_gemm.torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        pretuned_grouped_gemm._BENCH,
+        "bench_pre_captured_cudagraph",
+        lambda _call, rep: 0.5,
+    )
+
+    def candidate() -> torch.Tensor:
+        output.copy_(expected)
+        return output
+
+    config = object()
+    perf = provider._benchmark_function(config, candidate)
+
+    assert perf == (0.5 if replay_writes_output else float("inf"))
+    assert failures == ([] if replay_writes_output else [config])
+    assert provider._autotune_metrics.num_configs_tested == 1
+    assert cleared == [candidate]
+
+
+def test_grouped_gemm_aot_training_does_not_load_cutlass(
+    pretuned_grouped_gemm: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = {
+        "helion_wins": 0,
+        "total": 0,
+        "geomean": 0.0,
+        "best_speedup": 0.0,
+        "baselines": {},
+    }
+    monkeypatch.setattr(
+        pretuned_grouped_gemm, "_run_aot_training", lambda _verbose: result
+    )
+    monkeypatch.setattr(
+        pretuned_grouped_gemm,
+        "_cutlass_source_path",
+        lambda: pytest.fail("AOT training loaded an external reference"),
+    )
+    for mode in ("collect", "compile", "measure"):
+        monkeypatch.setenv("HELION_AOT_MODE", mode)
+        assert pretuned_grouped_gemm.main(verbose=False) is result
+
+
+def test_pre_captured_graph_sweep_uses_shared_timer(
+    pretuned_bench: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[list[str], int]] = []
+
+    def timer(functions: list[Any], rep: int) -> list[float]:
+        calls.append(([function() for function in functions], rep))
+        return [1.0, 2.0]
+
+    monkeypatch.setattr(pretuned_bench, "bench_pre_captured_cudagraphs", timer)
+    metrics = pretuned_bench.run_sweep(
+        ["shape"],
+        lambda _shape: (
+            lambda: "helion",
+            [("cutlass", lambda: "cutlass")],
+            "shape",
+        ),
+        use_cudagraph=False,
+        pre_captured_cudagraph=True,
+        shape_header="case",
+        rep=7,
+        verbose=False,
+    )
+
+    assert calls == [(["helion", "cutlass"], 7)]
+    assert metrics["geomean"] == 2.0
+
+
+def test_grouped_gemm_dashboard_selects_shared_timer(
+    pretuned_grouped_gemm: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("HELION_AOT_MODE", "evaluate")
+    monkeypatch.setattr(pretuned_grouped_gemm, "_cutlass_source_path", lambda: tmp_path)
+    monkeypatch.setattr(
+        pretuned_grouped_gemm._COMPARE,
+        "load_cutlass_source",
+        lambda _path: (object(), {}),
+    )
+
+    recorded: dict[str, object] = {}
+    expected = {"ok": True}
+
+    def fake_run_sweep(*args: object, **kwargs: object) -> dict[str, bool]:
+        recorded["args"] = args
+        recorded.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(pretuned_grouped_gemm._BENCH, "run_sweep", fake_run_sweep)
+    assert pretuned_grouped_gemm.main(verbose=False) is expected
+    assert recorded["use_cudagraph"] is False
+    assert recorded["pre_captured_cudagraph"] is True
+    assert recorded["rep"] == 204
+    assert recorded["thermal_warmup_ms"] == 10_000
+
+
+def test_pre_captured_graph_timer_balances_and_clears(
+    pretuned_bench: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    operations: list[str] = []
+    event_count = 36
+    next_event = 0
+
+    class FakeEvent:
+        def __init__(self, *, enable_timing: bool) -> None:
+            nonlocal next_event
+            assert enable_timing
+            self.index = next_event
+            next_event += 1
+
+        def record(self) -> None:
+            operations.append("start" if self.index < event_count // 2 else "end")
+
+        def elapsed_time(self, _end: FakeEvent) -> float:
+            return float(self.index // 6 + 1)
+
+    class FakeDeviceInterface:
+        Event = FakeEvent
+
+        @staticmethod
+        def synchronize() -> None:
+            operations.append("sync")
+
+    driver = SimpleNamespace(
+        get_device_interface=lambda: FakeDeviceInterface,
+        get_empty_cache_for_benchmark=object,
+        clear_cache=lambda _cache: operations.append("clear"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "triton",
+        SimpleNamespace(runtime=SimpleNamespace(driver=SimpleNamespace(active=driver))),
+    )
+
+    names = ("A", "B", "C")
+    timings = pretuned_bench.bench_pre_captured_cudagraphs(
+        [lambda name=name: operations.append(name) for name in names], rep=6
+    )
+
+    order = ["A", "B", "C", "B", "C", "A", "C", "A", "B"]
+    order += ["C", "B", "A", "A", "C", "B", "B", "A", "C"]
+    assert operations[:18] == order
+    assert operations[18] == "sync"
+    measured: list[str] = []
+    for name in order:
+        measured.extend(("clear", "start", name, "end"))
+    assert operations[19:-1] == measured
+    assert operations[-1] == "sync"
+    assert timings == [1.0, 2.0, 3.0]
 
 
 def test_deepgemm_rows_and_single_rng_stream(deepgemm_benchmark: Any) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3320
 * #3319
 * __->__#3318
 * #3317
 * #3316


--- --- ---

### [bench] add grouped GEMM CUTLASS comparison

## What

- Add a pretuned FP16 grouped-GEMM kernel and checked-in SM100 AOT artifact.
- Add a pinned NVIDIA CUTLASS CuTeDSL kernel reference.
- Add seven heterogeneous G3/G4 validation cases covering the upstream example, full tiles, M tails, and N tails.
- Measure Helion and CUTLASS through one shared cold-L2 CUDA-event protocol using pre-captured graphs and balanced rotated/reversed execution order.
- Keep pointer-table owners alive through replay and initialize all device pointer metadata before capture.
- Add a reusable cuBLAS grouped-batched adapter for the DeepGEMM comparison in the following PR, without reporting cuBLAS in this benchmark.

## Why

The dashboard needs a reproducible kernel-level reference for the grouped-GEMM example. Timing the Python CUTLASS wrapper would include one-time pointer-table uploads and host submission that are outside Helion's generated kernel, so this benchmark compares the captured device operations directly. cuBLAS is omitted because its public grouped API is a different full-operator measurement rather than the pinned CUTLASS kernel being evaluated here.

## Methodology and performance

Clean-head run on an idle NVIDIA B200 (GPU 2, zero volatile ECC errors), CUTLASS commit `db1c288993354c88e551c40c19a8fb93a774a241`, source SHA-256 `05b74a05682c024557d83284e32f973ed5be4f0d1a1a12c72fe7824c29f7e94f`, 204 replays/case, and a 10-second thermal warmup:

- Helion/CUTLASS kernel-time geomean: **0.8254x** (**1.2116x speedup**), 6 wins and 1 tie across 7 cases.
- Representative large-case medians: Helion 16.35 us and CUTLASS 20.45 us.

The result artifact records a clean Git tree and the benchmark source hash.

## Testing

- Per-commit lint: Ruff 0.15.14 format/check, codespell, and strict Pyrefly on every changed typed file.
- `test/test_cute_grouped_gemm_benchmark.py`: **15 passed** at this commit boundary.
- Critical tests cover case definitions, pinned source validation, cold-L2 timer ordering, AOT contract/config selection, pointer ownership, Triton-free module import, and device-free timer logic. The reusable cuBLAS adapter is tested for FP16/BF16 correctness and real CUDA-graph capture because the next PR consumes it.