### PR TITLE
[dashboard] publish grouped GEMM references

### DIFF
--- a/.github/dashboard/README.md
+++ b/.github/dashboard/README.md
@@ -1,10 +1,10 @@
 # Helion Benchmark Dashboard
 
-Interactive dashboard for visualizing Helion benchmark results across GPU platforms (H100, B200, B200 CuTe, MI325X, MI350X). Tracks kernel latency, speedup vs eager, compile time, and accuracy over time.
+Interactive dashboard for visualizing Helion benchmark results across GPU platforms (H100, B200, B200 CuTe, MI325X, MI350X). Tracks kernel latency, speedup against each benchmark's baseline, compile time, and accuracy over time.
 
 Deployed at https://helionlang.com/dashboard/ alongside the main docs. The docs-deploy workflow runs `build_dashboard_data.py` after each docs push or Benchmark Dispatch completion, generating `dashboard-data.json` that `index.html` fetches at runtime.
 
-The **Pretuned** tab is fed by a separate pipeline: the nightly **Benchmark Pretuned Dispatch** workflow runs every kernel under `pretuned_kernels/` (via `pretuned_kernels/run.py`) against its checked-in heuristic and uploads aggregate `SUMMARY` metrics or an error for each kernel. `build_pretuned_dashboard_data.py` aggregates those into `pretuned-dashboard-data.json`, which `index.html` lazily fetches when the Pretuned tab is opened. It tracks the latest CI status plus geomean speedup vs PyTorch eager, win counts, and best speedup per kernel/platform over time.
+The **Pretuned** tab is fed by a separate pipeline: the nightly **Benchmark Pretuned Dispatch** workflow runs every kernel under `pretuned_kernels/` (via `pretuned_kernels/run.py`) with its checked-in heuristic and named reference baselines, then uploads aggregate metrics or an error for each kernel. `build_pretuned_dashboard_data.py` aggregates those into `pretuned-dashboard-data.json`, which `index.html` lazily fetches when the Pretuned tab is opened. It tracks the latest CI status plus geomean speedup, win counts, and best speedup per kernel/platform over time; the headline compares with the fastest available baseline and the per-kernel dropdown shows each baseline separately.
 
 ## Local development
 

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -1164,8 +1164,8 @@ function renderPretuned() {
   const lr = D.latest_run || {};
   const ciPass = failedEntries.length === 0;
   let html = '';
-  html += '<h2 style="margin-bottom:4px">Pretuned Kernels vs PyTorch Eager</h2>';
-  html += '<p style="font-size:13px;color:var(--text-dim);margin-bottom:16px">Nightly run of every kernel under <code>pretuned_kernels/</code> against its checked-in heuristic. Speedup is geomean over each kernel\'s shape sweep; higher = faster than eager.</p>';
+  html += '<h2 style="margin-bottom:4px">Pretuned Kernels vs Best Baseline</h2>';
+  html += '<p style="font-size:13px;color:var(--text-dim);margin-bottom:16px">Nightly run of every kernel under <code>pretuned_kernels/</code> with its checked-in heuristic and reference baselines. Speedup is geomean over each kernel\'s shape sweep; higher = faster than the fastest available baseline.</p>';
   html += '<div class="filter-bar"><select id="pt-plat-filter"><option value="all">All Platforms</option>';
   shorts.forEach(p => { html += `<option value="${p}"${p === pretunedPlatform ? ' selected' : ''}>${platName(p)}</option>`; });
   html += '</select></div>';

--- a/.github/workflows/benchmark_pretuned.yml
+++ b/.github/workflows/benchmark_pretuned.yml
@@ -1,8 +1,9 @@
 name: Benchmark Pretuned
 
-# Reusable workflow: runs every kernel under pretuned_kernels/ against its
-# checked-in heuristic on a single GPU runner and uploads the aggregate
-# SUMMARY metrics as a pretuned-results-<alias> artifact. The Pretuned tab of
+# Reusable workflow: runs every kernel under pretuned_kernels/ with its
+# checked-in heuristic and reference baselines on a single GPU runner,
+# then uploads aggregate JSON metrics as a pretuned-results-<alias> artifact.
+# The Pretuned tab of
 # the dashboard is built from these artifacts by
 # .github/dashboard/build_pretuned_dashboard_data.py.
 
@@ -98,7 +99,7 @@ jobs:
       - name: Install Helion
         run: |
           source .venv/bin/activate
-          uv pip install setuptools ninja
+          uv pip install setuptools ninja wheel
           SETUPTOOLS_SCM_PRETEND_VERSION="0.0.0" uv pip install -e .'[dev]'
           python -c "import helion; print(helion.__name__)"
 
@@ -138,6 +139,86 @@ jobs:
           print("Helion CuTe backend requirements OK")
           PY
 
+      - name: Select grouped GEMM references
+        id: grouped-gemm-references
+        if: inputs.alias == 'b200'
+        env:
+          SELECTED_KERNELS: ${{ inputs.kernels }}
+        run: |
+          source .venv/bin/activate
+          python - <<'PY'
+          import os
+
+          from pretuned_kernels.run import grouped_reference_requirements
+
+          outputs = grouped_reference_requirements(os.environ["SELECTED_KERNELS"])
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              for name, enabled in outputs.items():
+                  print(f"{name}={str(enabled).lower()}", file=output)
+          PY
+
+      - name: Fetch pinned CUTLASS grouped GEMM reference
+        if: steps.grouped-gemm-references.outputs.cutlass == 'true'
+        # If GitHub is temporarily unavailable, run.py records grouped_gemm as
+        # an error while preserving results for every other B200 kernel.
+        continue-on-error: true
+        env:
+          CUTLASS_GROUPED_GEMM_COMMIT: db1c288993354c88e551c40c19a8fb93a774a241
+          CUTLASS_GROUPED_GEMM_SHA256: 05b74a05682c024557d83284e32f973ed5be4f0d1a1a12c72fe7824c29f7e94f
+        run: |
+          source .venv/bin/activate
+          python - <<'PY'
+          import hashlib
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          commit = os.environ["CUTLASS_GROUPED_GEMM_COMMIT"]
+          expected = os.environ["CUTLASS_GROUPED_GEMM_SHA256"]
+          url = (
+              "https://raw.githubusercontent.com/NVIDIA/cutlass/"
+              f"{commit}/examples/python/CuTeDSL/cute/blackwell/kernel/"
+              "grouped_gemm/grouped_gemm.py"
+          )
+          with urllib.request.urlopen(url, timeout=60) as response:
+              source = response.read()
+          actual = hashlib.sha256(source).hexdigest()
+          if actual != expected:
+              raise RuntimeError(
+                  f"CUTLASS grouped_gemm.py SHA256 mismatch: {actual} != {expected}"
+              )
+          output = Path(os.environ["RUNNER_TEMP"]) / "cutlass-grouped-gemm.py"
+          output.write_bytes(source)
+          with Path(os.environ["GITHUB_ENV"]).open("a") as env_file:
+              print(
+                  f"HELION_CUTLASS_GROUPED_GEMM_SOURCE={output}",
+                  file=env_file,
+              )
+          print(f"Verified CUTLASS grouped GEMM reference: {output}")
+          PY
+
+      - name: Build pinned DeepGEMM grouped GEMM reference
+        if: steps.grouped-gemm-references.outputs.deepgemm == 'true'
+        # Keep the rest of the B200 dashboard useful if the external checkout
+        # or build is temporarily unavailable; run.py will record only the
+        # grouped_gemm_deepgemm row as failed.
+        continue-on-error: true
+        env:
+          DEEPGEMM_COMMIT: 559d79fb6994a58b8a15b4b93bf13ccc16edf247
+        run: |
+          source .venv/bin/activate
+          DEEPGEMM_CHECKOUT=$(mktemp -d "$RUNNER_TEMP/deepgemm.XXXXXX")
+          git -C "$DEEPGEMM_CHECKOUT" init
+          git -C "$DEEPGEMM_CHECKOUT" remote add origin \
+            https://github.com/deepseek-ai/DeepGEMM.git
+          git -C "$DEEPGEMM_CHECKOUT" fetch --depth=1 origin "$DEEPGEMM_COMMIT"
+          git -C "$DEEPGEMM_CHECKOUT" checkout --detach FETCH_HEAD
+          git -C "$DEEPGEMM_CHECKOUT" submodule update --init --recursive
+          "$DEEPGEMM_CHECKOUT/develop.sh"
+          echo "HELION_DEEPGEMM_ROOT=$DEEPGEMM_CHECKOUT" >> "$GITHUB_ENV"
+          PYTHONPATH="$DEEPGEMM_CHECKOUT" python -c \
+            "import deep_gemm; print('DeepGEMM reference build OK')"
+
       - name: CUDA Compute Check
         if: startsWith(inputs.image, 'nvidia')
         run: |
@@ -168,16 +249,23 @@ jobs:
           python -c "from tritonbench.components.do_bench.run import _do_bench_cudagraph_with_cache_clear; print('tritonbench cudagraph timer OK')"
 
       - name: Run pretuned kernel benchmarks
+        env:
+          SELECTED_KERNELS: ${{ inputs.kernels }}
         run: |
           source .venv/bin/activate
 
           TEST_REPORTS_DIR=$(pwd)/test/test-reports
           mkdir -p "$TEST_REPORTS_DIR"
 
+          KERNEL_ARGS=()
+          if [[ -n "$SELECTED_KERNELS" ]]; then
+            KERNEL_ARGS=(--kernels "$SELECTED_KERNELS")
+          fi
+
           ${{ inputs.env-vars }} python pretuned_kernels/run.py \
             --output "$TEST_REPORTS_DIR/pretuned-bench.json" \
             --hardware "${{ inputs.alias }}" \
-            ${{ inputs.kernels != '' && format('--kernels {0}', inputs.kernels) || '' }}
+            "${KERNEL_ARGS[@]}"
 
           echo "----- pretuned-bench.json -----"
           cat "$TEST_REPORTS_DIR/pretuned-bench.json"

--- a/.github/workflows/benchmark_pretuned_dispatch.yml
+++ b/.github/workflows/benchmark_pretuned_dispatch.yml
@@ -1,11 +1,11 @@
 name: Benchmark Pretuned Dispatch
 
-# On-demand benchmark of every kernel under pretuned_kernels/ against its
-# checked-in heuristic. Mirrors Benchmark Dispatch but for the pretuned-kernel
-# suite: it fans out to GPU runners via benchmark_pretuned.yml and then triggers
-# the docs deploy, which rebuilds the dashboard's Pretuned tab from the uploaded
-# artifacts. The nightly cron lives in benchmark_pretuned_nightly.yml, which
-# dispatches this workflow with run_h100/run_b200 set.
+# On-demand benchmark of every kernel under pretuned_kernels/ with its
+# checked-in heuristic and reference baselines. Mirrors Benchmark Dispatch
+# for the pretuned-kernel suite: it fans out via benchmark_pretuned.yml and
+# triggers the docs deploy, which rebuilds the dashboard's Pretuned tab from
+# uploaded artifacts. The nightly cron lives in benchmark_pretuned_nightly.yml,
+# which dispatches this workflow with run_h100/run_b200 set.
 
 on:
   workflow_dispatch:

--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -12,7 +12,8 @@ copy the kernel and its local `_helion_aot_*` heuristic into your code, then
 retune when your target shapes or hardware differ materially from the included
 sweep.
 
-Each kernel module has a `main()` that benchmarks against PyTorch eager.
+Each kernel module has a `main()` that benchmarks against one or more named
+reference baselines.
 
 ## File structure
 
@@ -30,6 +31,8 @@ pretuned_kernels/
 ├── rope/
 ├── scaled_mm/
 ├── scale_mm_cute/                    # B200 CuTe (tcgen05) rowwise FP8 GEMM
+├── grouped_gemm/                     # B200 grouped FP16 GEMM vs CuTeDSL
+├── grouped_gemm_deepgemm/            # B200 grouped BF16 vs DeepGEMM + cuBLAS
 ├── nvfp4_gemv/                       # B200 Triton NVFP4 (W4A4 / W4A16) decode GEMV
 ├── nvfp4_gemv_cute/                  # B200 Helion CuTe NVFP4 decode GEMV
 ├── silu_mul_fp8/                     # ported from vLLM (vllm/kernels/helion/ops)
@@ -44,7 +47,7 @@ pretuned_kernels/
 Each kernel ships with one heuristic file per supported compute capability.
 At runtime Helion picks the file matching the current GPU.
 
-| Kernel | Shape sweep | PyTorch baseline |
+| Kernel | Shape sweep | Reference baseline |
 |---|---|---|
 | `vector_add` | `2**i for i in range(19, 29)` | `x + y` |
 | `softmax` | Triton tutorial `M=4096, N=128*i for i in range(2, 100)` + realistic long-context shapes | `F.softmax` |
@@ -54,6 +57,8 @@ At runtime Helion picks the file matching the current GPU.
 | `rope` | TritonBench RoPE `(H, T)` defaults with exact shape buckets and `H8192_T2048` fallback | eager RoPE reference |
 | `scaled_mm` | vLLM Qwen3 FP8 `(K, N)` weight shapes at small token counts `M in {16, 64}` | `torch._scaled_mm` |
 | `scale_mm_cute` | Skinny-M FP8 decode + decoder-layer FP8 W8A8 serving `(M, K, N)` shapes (B200 CuTe backend only) | `torch._scaled_mm` (rowwise) + vLLM CUTLASS |
+| `grouped_gemm` | Seven CUTLASS-example-derived heterogeneous FP16 grouped-NT cases (3--4 GEMMs, including M/N tails; B200 CuTe only) | pinned NVIDIA CUTLASS CuTeDSL kernel |
+| `grouped_gemm_deepgemm` | Eight official DeepGEMM BF16 grouped-NT shapes with deterministic heterogeneous per-group M (B200 CuTe only) | pinned DeepGEMM `m_grouped_bf16_gemm_nt_contiguous` + CUDA's `cublasGemmGroupedBatchedEx` |
 | `nvfp4_gemv` | Decode (M=1) NVFP4 GEMV `(N, K)` weight shapes (Llama-3 / Qwen projections), W4A4 + W4A16 (B200 Triton backend) | NVFP4 dequant reference + vLLM CUTLASS `cutlass_scaled_fp4_mm` |
 | `nvfp4_gemv_cute` | Decode (M=1) NVFP4 GEMV `(N, K)` weight shapes, W4A4 + W4A16, using Helion kernels compiled with the CuTe backend on B200 | NVFP4 dequant reference + vLLM CUTLASS `cutlass_scaled_fp4_mm` |
 | `silu_mul_fp8` | vLLM `(num_tokens, intermediate)` decode shapes | torch-native silu-and-mul + fp8 quant |
@@ -64,12 +69,25 @@ At runtime Helion picks the file matching the current GPU.
 | `silu_and_mul_per_block_quant` | vLLM `(num_tokens, intermediate, group)` shapes | torch-native silu-and-mul + per-block fp8 quant |
 | `fused_qk_norm_rope` | vLLM `(num_tokens, q_heads, kv_heads)` shapes | torch-native fused QK-RMSNorm + RoPE |
 
-Every kernel additionally benchmarks against `torch.compile` of the listed
+Most kernels additionally benchmark against `torch.compile` of the listed
 PyTorch baseline (a speedup-comparison baseline only -- correctness is checked
-against the eager reference). The headline speedup is Helion vs the *fastest*
-available baseline, and the dashboard's per-kernel dropdown breaks down Helion's
-speedup over each baseline (`torch`, `torch_compile`, and the vLLM op when
-installed in the nightly).
+against the eager reference). The grouped-GEMM entries instead use the named
+CUDA references in the table. The headline speedup is Helion vs the *fastest*
+available baseline, and the per-kernel dropdown reports every baseline.
+
+`grouped_gemm` compares Helion with the same pinned CUTLASS kernel. Required
+device pointer tables are initialized before graph capture, and both
+implementations are checked against the same pointer-target outputs before
+timing.
+
+`grouped_gemm_deepgemm` is separate because it follows DeepGEMM's BF16 packed-A
+layout and official shape suite rather than the CUTLASS FP16 heterogeneous-M/N/K
+suite. Its AOT flow searches only valid 4--7-stage `worklist_nm` schedules and
+checks them against a PyTorch reference. It also reports cuBLAS on each logical
+group while excluding aligned padding from the common correctness contract.
+Both grouped benchmarks replay pre-captured graphs, clear L2 before every
+measurement, warm the GPU before each case, and rotate/reverse implementation
+order to reduce clock and ordering bias.
 
 The kernels ported from vLLM (`vllm/kernels/helion/ops`) benchmark each fused
 Helion kernel under CUDA graphs against a torch-native (unfused, eager)
@@ -91,13 +109,26 @@ falls back to older compatible CUDA/ROCm capabilities.  For example, on
 
 ## Running benchmarks
 
-Each kernel module has a `main()` that benchmarks the Helion kernel against
-PyTorch eager across the included shape set:
+Each kernel module has a `main()` that benchmarks the Helion kernel against its
+named reference baselines across the included shape set:
 
 ```bash
 cd pretuned_kernels/softmax
 python softmax.py
 ```
+
+The external grouped-GEMM references need explicit pinned checkouts:
+
+```bash
+export HELION_CUTLASS_GROUPED_GEMM_SOURCE=/path/to/CUTLASS/.../grouped_gemm.py
+python -m pretuned_kernels.grouped_gemm.grouped_gemm
+
+export HELION_DEEPGEMM_ROOT=/path/to/built/DeepGEMM
+python -m pretuned_kernels.grouped_gemm_deepgemm.grouped_gemm_deepgemm
+```
+
+The modules report the required commits when either variable is missing; the
+nightly workflow fetches, builds, and verifies those revisions automatically.
 
 ## Adding a heuristic for new hardware
 

--- a/pretuned_kernels/run.py
+++ b/pretuned_kernels/run.py
@@ -2,17 +2,18 @@
 """Run every pretuned kernel's benchmark sweep and emit aggregate metrics as JSON.
 
 Drives the nightly pretuned-kernel dashboard pipeline. Each kernel module under
-``pretuned_kernels/<name>/<name>.py`` defines a ``main()`` that benchmarks the
-Helion kernel against PyTorch eager across its checked-in shape sweep and prints
-a machine-parseable line::
+``pretuned_kernels/<name>/<name>.py`` defines a ``main()`` that benchmarks its
+checked-in Helion heuristic against one or more reference baselines and returns
+aggregate metrics::
 
-    SUMMARY: helion_wins=.. total=.. geomean=.. best_speedup=..
+    {"helion_wins": .., "total": .., "geomean": .., "best_speedup": ..,
+     "baselines": {"name": {..}}}
 
-This script runs each ``main()``, parses that line, and writes a JSON list of
-per-kernel records that ``.github/dashboard/build_pretuned_dashboard_data.py``
-aggregates for the dashboard's Pretuned tab. A kernel that crashes (e.g. no
-heuristic for the current GPU) is recorded with an ``error`` field so the rest
-of the sweep still reports.
+This script runs each ``main()`` and writes a JSON list of per-kernel records
+that ``.github/dashboard/build_pretuned_dashboard_data.py`` aggregates for the
+dashboard's Pretuned tab. A kernel that crashes (e.g. no heuristic for the
+current GPU) is recorded with an ``error`` field so the rest of the sweep still
+reports.
 """
 
 from __future__ import annotations
@@ -31,6 +32,9 @@ if TYPE_CHECKING:
     from types import ModuleType
 
 PRETUNED_KERNELS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = PRETUNED_KERNELS_DIR.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 # Kernel directory == module file stem == kernel name. Ordered cheap-to-expensive
 # so a partial run (e.g. timeout) still captures the quick kernels.
@@ -53,11 +57,28 @@ KERNELS = [
     "rms_norm_per_block_quant",
     "silu_and_mul_per_block_quant",
     "fused_qk_norm_rope",
+    # External grouped references compile substantial CuTe/DeepGEMM code.
+    "grouped_gemm",
+    "grouped_gemm_deepgemm",
 ]
 
 # Map a compute capability (heuristic file suffix) to a hardware alias. The
 # nightly runs one GPU per alias.
 _HARDWARE_BY_COMPUTE = {"sm90": "h100", "sm100": "b200"}
+
+
+def parse_kernel_names(value: str) -> list[str]:
+    """Parse the comma-separated kernel input used by CLI and CI dispatches."""
+    return [name.strip() for name in value.split(",") if name.strip()]
+
+
+def grouped_reference_requirements(value: str) -> dict[str, bool]:
+    """Return which external grouped references a selected sweep requires."""
+    selected = set(parse_kernel_names(value))
+    return {
+        "cutlass": not selected or "grouped_gemm" in selected,
+        "deepgemm": not selected or "grouped_gemm_deepgemm" in selected,
+    }
 
 
 def _supported_hardware(name: str) -> set[str]:
@@ -155,7 +176,7 @@ def main() -> None:
     current_hardware = args.hardware or _HARDWARE_BY_COMPUTE.get(compute, compute)
     print(f"GPU: {device} ({compute}); hardware={current_hardware}")
 
-    kernels = [k.strip() for k in args.kernels.split(",") if k.strip()]
+    kernels = parse_kernel_names(args.kernels)
     records = []
     for name in kernels:
         print(f"\n{'=' * 60}\nBenchmarking pretuned kernel: {name}\n{'=' * 60}")

--- a/test/test_cute_grouped_gemm_benchmark.py
+++ b/test/test_cute_grouped_gemm_benchmark.py
@@ -16,6 +16,12 @@ import torch
 
 BENCHMARK_DIR = Path(__file__).resolve().parents[1] / "benchmarks" / "cute"
 PRETUNED_DIR = Path(__file__).resolve().parents[1] / "pretuned_kernels"
+PRETUNED_WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "benchmark_pretuned.yml"
+)
 
 
 def _load_path(path: Path, module_name: str) -> Any:
@@ -135,6 +141,11 @@ def deepgemm_heuristic() -> Any:
 @pytest.fixture(scope="module")
 def pretuned_bench() -> Any:
     return _load_path(PRETUNED_DIR / "_bench.py", "helion_test_pretuned_bench")
+
+
+@pytest.fixture(scope="module")
+def pretuned_runner() -> Any:
+    return _load_path(PRETUNED_DIR / "run.py", "helion_test_pretuned_runner")
 
 
 def test_cutlass_timings_use_shared_timer(
@@ -421,6 +432,49 @@ def test_deepgemm_tuner_validates_captured_replay(
     captured = provider._capture_validated_replay(config, candidate)
     assert (captured is not None) is replay_writes_output
     assert failures == ([] if replay_writes_output else [config])
+
+
+def test_pretuned_grouped_kernels_are_registered_for_b200(
+    pretuned_runner: Any,
+) -> None:
+    for name in ("grouped_gemm", "grouped_gemm_deepgemm"):
+        assert name in pretuned_runner.KERNELS
+        assert pretuned_runner._supported_hardware(name) == {"b200"}
+
+
+@pytest.mark.parametrize(
+    ("selected", "expected"),
+    (
+        ("", {"cutlass": True, "deepgemm": True}),
+        ("grouped_gemm", {"cutlass": True, "deepgemm": False}),
+        ("grouped_gemm_deepgemm", {"cutlass": False, "deepgemm": True}),
+        (
+            "grouped_gemm, grouped_gemm_deepgemm",
+            {"cutlass": True, "deepgemm": True},
+        ),
+    ),
+)
+def test_grouped_reference_selection(
+    pretuned_runner: Any,
+    selected: str,
+    expected: dict[str, bool],
+) -> None:
+    assert pretuned_runner.grouped_reference_requirements(selected) == expected
+
+
+def test_grouped_reference_workflow_pins_match_benchmarks(
+    cutlass_benchmark: Any,
+    deepgemm_benchmark: Any,
+) -> None:
+    workflow = PRETUNED_WORKFLOW.read_text()
+    for pin in (
+        cutlass_benchmark.CUTLASS_COMMIT,
+        cutlass_benchmark.CUTLASS_SHA256,
+        deepgemm_benchmark.DEEPGEMM_COMMIT,
+    ):
+        assert pin in workflow
+    assert 'KERNEL_ARGS=(--kernels "$SELECTED_KERNELS")' in workflow
+    assert '"${KERNEL_ARGS[@]}"' in workflow
 
 
 def test_grouped_gemm_aot_training_does_not_load_cutlass(


### PR DESCRIPTION
Stacked PRs:
 * __->__#3320
 * #3319
 * #3318
 * #3317
 * #3316


--- --- ---

### [dashboard] publish grouped GEMM references

## What

- Register the FP16 CUTLASS and BF16 DeepGEMM grouped benchmarks in the pretuned-kernel runner and dashboard metadata.
- Teach the B200 workflow to provision each pinned external reference only when the selected kernel requires it.
- Parse comma-separated kernel selections in one shared helper and pass the original selection through a quoted Bash array.
- Add pin-drift tests tying workflow revisions to the benchmark constants.
- Document the two benchmark contracts and their shared cold-L2 CUDA-graph methodology.

## Why

The benchmark kernels are useful only if CI can run and publish them reproducibly. Conditional setup avoids imposing CUTLASS/DeepGEMM checkout and build costs on unrelated pretuned kernels, while shared parsing prevents the dispatch UI and workflow from disagreeing about comma-plus-space selections.

## Published performance

On clean, idle B200 runs with pre-captured graphs and L2 cleared before every replay:

- FP16 Helion versus pinned CUTLASS: **1.2116x geomean speedup**, 6 wins and 1 tie across 7 cases.
- BF16 Helion versus pinned DeepGEMM: **0.9947x geomean speedup** (effective tie), 4/8 wins; **4.5288x** versus cuBLAS.

This PR changes publishing/provisioning only; it does not change the timed kernels.

## Testing

- Per-commit lint: Ruff 0.15.14 format/check and codespell; this commit adds no files in the repository's Pyrefly include set.
- `test/test_cute_grouped_gemm_benchmark.py`: **26 passed** at this commit boundary.
- Critical tests cover empty/CUTLASS-only/DeepGEMM-only/comma-plus-space selection, conditional requirements, safe quoted argument forwarding, registry entries, dashboard metadata, and workflow/benchmark revision-pin agreement.
- Full-stack default suite: 2,216 passed, 1,504 skipped, 289 subtests passed; its sole failure reproduces on `origin/main`.
- Full-stack CuTe suite: 2,393 passed, 1,299 skipped, 8 xfailed, 410 subtests passed; all eight failures reproduce on `origin/main`.