### PR TITLE
runtime: add guarded prepared kernel calls

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -141,6 +141,17 @@ class Backend(abc.ABC):
         return True
 
     @property
+    def supports_eager_prepared_call(self) -> bool:
+        """Whether eager calls may reuse a resolved ``BoundKernel`` directly.
+
+        The prepared call still enters the backend's generated host wrapper; it
+        only bypasses Helion's repeated binding and specialization lookup.  The
+        default is conservative because some backends own call-time behavior in
+        :meth:`Kernel.__call__` before the wrapper is reached.
+        """
+        return False
+
+    @property
     def max_tensor_numel(self) -> int | None:
         """Per-tile maximum tensor element count enforced during config search.
 

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -773,6 +773,10 @@ class CuteBackend(Backend):
     def name(self) -> str:
         return "cute"
 
+    @property
+    def supports_eager_prepared_call(self) -> bool:
+        return True
+
     def validate_environment(self) -> None:
         from .cutedsl_compat import check_cute_backend_requirements
 

--- a/helion/_compiler/triton/backend.py
+++ b/helion/_compiler/triton/backend.py
@@ -57,6 +57,10 @@ class TritonBackend(Backend):
     def experimental(self) -> bool:
         return False
 
+    @property
+    def supports_eager_prepared_call(self) -> bool:
+        return True
+
     def transform_host_arg(
         self,
         arg: Argument,

--- a/helion/_dist_utils.py
+++ b/helion/_dist_utils.py
@@ -93,7 +93,11 @@ def is_symm_mem_tensor(t: Tensor, process_group_name: str | None = None) -> bool
         return False
 
 
-def kernel_uses_symm_mem(args: tuple[object, ...]) -> bool:
+def kernel_uses_symm_mem(
+    args: tuple[object, ...],
+    *,
+    dist_initialized: bool | None = None,
+) -> bool:
     """Return True if this is a distributed kernel operating on symmetric memory.
 
     Helion's distributed-only compilation behavior (persistent-only PID types,
@@ -103,7 +107,9 @@ def kernel_uses_symm_mem(args: tuple[object, ...]) -> bool:
     that merely run inside a process where torch.distributed happens to be
     initialized (e.g. vLLM). See GitHub issue #3024.
     """
-    if not dist.is_initialized():
+    if dist_initialized is None:
+        dist_initialized = dist.is_initialized()
+    if not dist_initialized:
         return False
     if not hasattr(symm_mem, "is_symm_mem_tensor"):
         # Older PyTorch cannot cheaply detect symmetric-memory tensors without a

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -116,6 +116,162 @@ _TPU_COMPILE_CAPTURE = os.environ.get("HELION_TPU_COMPILE_CAPTURE", "0") == "1"
 _graph_module_hash_cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
 
 _INT32_INDEX_LIMIT = torch.iinfo(torch.int32).max
+_CUSTOM_KEY_UNSET = object()
+
+
+def _make_prepared_arg_guard(
+    kernel: Kernel,
+    args: tuple[object, ...],
+) -> Callable[[tuple[object, ...]], bool]:
+    namespace: dict[str, object] = {}
+    checks = [f"len(args) == {len(args)}"]
+    for index, arg in enumerate(args):
+        prefix = f"args[{index}]"
+        namespace[f"type_{index}"] = type(arg)
+        checks.append(f"type({prefix}) is type_{index}")
+        if type(arg) in (torch.Tensor, torch.nn.Parameter):
+            assert isinstance(arg, torch.Tensor)
+            namespace[f"dtype_{index}"] = arg.dtype
+            namespace[f"shape_{index}"] = arg.shape
+            namespace[f"stride_{index}"] = arg.stride()
+            namespace[f"device_{index}"] = arg.device
+            checks.extend(
+                (
+                    f"{prefix}.dtype is dtype_{index}",
+                    f"{prefix}.shape == shape_{index}",
+                    f"{prefix}.stride() == stride_{index}",
+                    f"{prefix}.device == device_{index}",
+                )
+            )
+            static_indices = getattr(arg, "_dynamo_static_indices", None)
+            if static_indices is None:
+                checks.append(
+                    f"getattr({prefix}, '_dynamo_static_indices', None) is None"
+                )
+            else:
+                namespace[f"static_indices_{index}"] = frozenset(static_indices)
+                checks.extend(
+                    (
+                        f"getattr({prefix}, '_dynamo_static_indices', None) is not None",
+                        f"frozenset({prefix}._dynamo_static_indices) == static_indices_{index}",
+                    )
+                )
+        elif type(arg) in (bool, int, float):
+            # Ordinary numeric arguments are runtime values in Helion's base
+            # specialization.  A constexpr annotation is the one exception;
+            # hl.specialize() constraints are covered by ``_extra_guards``.
+            if kernel._annotations[index] is ConstExpr:
+                if type(arg) is float and arg != arg:
+                    # Python's equality/hash behavior does not provide a stable
+                    # equivalence class for constexpr NaNs.  Keep those calls on
+                    # the regular specialization path rather than weakening its
+                    # semantics in the prepared guard.
+                    raise TypeError("constexpr NaN cannot use a prepared call")
+                namespace[f"value_{index}"] = arg.hex() if type(arg) is float else arg
+                checks.append(
+                    f"{prefix}.hex() == value_{index}"
+                    if type(arg) is float
+                    else f"{prefix} == value_{index}"
+                )
+        elif type(arg) in (str, type(None), torch.dtype, torch.device):
+            namespace[f"value_{index}"] = arg
+            checks.append(f"{prefix} == value_{index}")
+        else:
+            raise TypeError(f"unsupported prepared-call argument: {type(arg)!r}")
+    return eval(f"lambda args: {' and '.join(checks)}", namespace)
+
+
+class _PreparedCall:
+    """Monomorphic eager-call guard for a compiled ``BoundKernel``.
+
+    ``Kernel._dispatch_cache`` remains the general multi-specialization cache.
+    This object only makes its most recently used entry cheap to revisit: it
+    compares argument metadata without rebuilding and hashing a nested cache
+    key, then calls the already-compiled host wrapper directly.
+    """
+
+    __slots__ = (
+        "_dist_initialized",
+        "_extra_guards",
+        "_is_distributed",
+        "_matches_args",
+        "bound",
+    )
+
+    def __init__(
+        self,
+        bound: BoundKernel,
+        args: tuple[object, ...],
+        *,
+        dist_initialized: bool,
+        extra_guards: tuple[
+            tuple[Callable[[Sequence[object]], Hashable], Hashable], ...
+        ],
+        is_distributed: bool,
+    ) -> None:
+        self._matches_args = _make_prepared_arg_guard(bound.kernel, args)
+        self._dist_initialized = dist_initialized
+        self._is_distributed = is_distributed
+        self._extra_guards = extra_guards
+        self.bound = bound
+
+    @classmethod
+    def build(
+        cls,
+        kernel: Kernel,
+        bound: BoundKernel,
+        args: tuple[object, ...],
+        *,
+        dist_initialized: bool,
+        extra_guards: tuple[
+            tuple[Callable[[Sequence[object]], Hashable], Hashable], ...
+        ],
+        is_distributed: bool,
+    ) -> _PreparedCall | None:
+        if (
+            not bound.env.backend.supports_eager_prepared_call
+            or kernel._key_fn is not None
+        ):
+            return None
+        # Both call sites already obtained a non-None ``_fast_dispatch_key``,
+        # which proves every argument has an exact supported type.
+        try:
+            return cls(
+                bound,
+                args,
+                dist_initialized=dist_initialized,
+                extra_guards=extra_guards,
+                is_distributed=is_distributed,
+            )
+        except Exception:
+            # Preparation is optional and must not introduce a new user-visible
+            # failure after a kernel has run successfully.
+            return None
+
+    def matches(self, kernel: Kernel, args: tuple[object, ...]) -> bool:
+        try:
+            if not self._matches_args(args):
+                return False
+            dist_initialized = dist.is_initialized()
+            # ``kernel_uses_symm_mem`` and declared distributed intent are both
+            # false before process-group initialization. If that state changes,
+            # reject the prepared call before rechecking it.
+            if dist_initialized != self._dist_initialized or (
+                dist_initialized
+                and kernel._compute_is_distributed(
+                    args, dist_initialized=dist_initialized
+                )
+                != self._is_distributed
+            ):
+                return False
+            for extractor, expected in self._extra_guards:
+                if extractor(args) != expected:
+                    return False
+            return True
+        except Exception:
+            # Guard evaluation is an optional fast path. Falling through lets
+            # the normal dispatch machinery preserve its own error semantics.
+            return False
 
 
 def _current_device_index(device_type: str) -> int:
@@ -276,6 +432,7 @@ class Kernel(Generic[_R]):
         # dtype/shape/stride/device per tensor) directly to a BoundKernel,
         # skipping the full specialization-key machinery on repeat calls.
         self._dispatch_cache: dict[Hashable, BoundKernel] = {}
+        self._prepared_call: _PreparedCall | None = None
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
@@ -376,30 +533,41 @@ class Kernel(Generic[_R]):
         from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
 
         with self._bind_lock:
-            existing_extractors = self._specialize_extra.setdefault(signature, [])
-            existing_extractors.extend(extractors)
-            self._has_specialization_extras = True
+            existing_extractors = self._specialize_extra.get(signature, [])
+            updated_extractors = [*existing_extractors, *extractors]
             with unset_fake_temporarily():
                 current_results = tuple(
-                    extractor(args) for extractor in existing_extractors
+                    extractor(args) for extractor in updated_extractors
                 )
+            updated_cache_key = BoundKernelInMemoryCacheKey(signature, current_results)
+            hash(updated_cache_key)
+
+            # Publish the extended specialization only after every extractor
+            # succeeds. Otherwise a failed extension could leave a prepared
+            # call guarding an already-mutated extractor list.
+            self._specialize_extra[signature] = updated_extractors
+            self._has_specialization_extras = True
 
             stale_keys = [
                 key
                 for key in self._bound_kernels
                 if key.specialization_key == signature
-                and len(key.extra_results) < len(existing_extractors)
+                and len(key.extra_results) < len(updated_extractors)
             ]
             for stale_key in stale_keys:
                 self._bound_kernels.pop(stale_key)
             for fast_key, cached_bound in list(self._dispatch_cache.items()):
                 if cached_bound._base_spec_key == signature:
                     self._dispatch_cache.pop(fast_key)
-            self._bound_kernels[
-                BoundKernelInMemoryCacheKey(signature, current_results)
-            ] = bound_kernel
+            self._prepared_call = None
+            self._bound_kernels[updated_cache_key] = bound_kernel
 
-    def _compute_is_distributed(self, args: Sequence[object]) -> bool:
+    def _compute_is_distributed(
+        self,
+        args: Sequence[object],
+        *,
+        dist_initialized: bool | None = None,
+    ) -> bool:
         """Whether this call should compile as a distributed kernel.
 
         True when the arguments carry symmetric-memory tensors, or the author
@@ -409,12 +577,40 @@ class Kernel(Generic[_R]):
         and an identically-shaped ordinary call never share a compiled kernel.
         See GitHub issue #3024.
         """
-        return kernel_uses_symm_mem(tuple(args)) or (
-            dist.is_initialized()
+        if dist_initialized is None:
+            dist_initialized = dist.is_initialized()
+        return kernel_uses_symm_mem(tuple(args), dist_initialized=dist_initialized) or (
+            dist_initialized
             and (self.settings.distributed or self._declares_process_group)
         )
 
-    def _fast_dispatch_key(self, args: tuple[object, ...]) -> Hashable | None:
+    def _fast_dispatch_key(
+        self,
+        args: tuple[object, ...],
+        *,
+        is_distributed: bool | None = None,
+        signature: tuple[Hashable, ...] | None = None,
+    ) -> Hashable | None:
+        entry = self._fast_dispatch_key_and_guards(
+            args,
+            is_distributed=is_distributed,
+            signature=signature,
+        )
+        return None if entry is None else entry[0]
+
+    def _fast_dispatch_key_and_guards(
+        self,
+        args: tuple[object, ...],
+        *,
+        is_distributed: bool | None = None,
+        signature: tuple[Hashable, ...] | None = None,
+    ) -> (
+        tuple[
+            Hashable,
+            tuple[tuple[Callable[[Sequence[object]], Hashable], Hashable], ...],
+        ]
+        | None
+    ):
         """
         Build a cheap dispatch key for the fast-path cache in ``__call__``.
 
@@ -434,6 +630,9 @@ class Kernel(Generic[_R]):
         device; callers must then take the regular ``bind()`` path.
         """
         key: list[Hashable] = []
+        extra_guards: tuple[
+            tuple[Callable[[Sequence[object]], Hashable], Hashable], ...
+        ] = ()
         has_tensor = False
         for a in args:
             t = type(a)
@@ -460,19 +659,154 @@ class Kernel(Generic[_R]):
                 return None
         if not has_tensor:
             return None
-        key.append(self._compute_is_distributed(args))
-        signature = (
-            self._base_specialization_key(args)
-            if self._has_specialization_extras
-            else None
-        )
+        if is_distributed is None:
+            is_distributed = self._compute_is_distributed(args)
+        key.append(is_distributed)
+        if signature is None and (
+            self._has_specialization_extras or self._key_fn is not None
+        ):
+            signature = self._base_specialization_key(
+                args, is_distributed=is_distributed
+            )
         if self._key_fn is not None:
-            key.append(signature[-1] if signature is not None else self._key_fn(*args))
+            assert signature is not None
+            key.append(signature[-1])
         if signature is not None:
             extra_fns = self._specialize_extra.get(signature)
             if extra_fns is not None:
-                key.append(tuple(s(args) for s in extra_fns))
-        return tuple(key)
+                extra_guards = tuple(
+                    (extractor, extractor(args)) for extractor in extra_fns
+                )
+                key.append(tuple(expected for _, expected in extra_guards))
+        return tuple(key), extra_guards
+
+    def _prepare_dispatch_entry(
+        self,
+        args: tuple[object, ...],
+        bound: BoundKernel[_R],
+        known_fast_key: Hashable | None = None,
+    ) -> tuple[Hashable, _PreparedCall | None] | None:
+        """Validate and construct eager fast paths from one runtime snapshot."""
+        if known_fast_key is not None and self._key_fn is not None:
+            # Validate the already-evaluated custom-key hit without invoking
+            # user code a second time.  In particular, do not let a process-
+            # group transition reuse a bound kernel compiled for the old state.
+            try:
+                normalized_args = self.normalize_args(*args)
+                dist_initialized = dist.is_initialized()
+                is_distributed = self._compute_is_distributed(
+                    normalized_args, dist_initialized=dist_initialized
+                )
+                if (
+                    not isinstance(known_fast_key, tuple)
+                    or len(known_fast_key) < len(args) + 2
+                ):
+                    return None
+                custom_key = known_fast_key[len(args) + 1]
+                signature = self._base_specialization_key(
+                    normalized_args,
+                    is_distributed=is_distributed,
+                    custom_key=custom_key,
+                )
+                if signature != bound._base_spec_key:
+                    return None
+                current_entry = self._fast_dispatch_key_and_guards(
+                    args,
+                    is_distributed=is_distributed,
+                    signature=signature,
+                )
+                if current_entry is None or current_entry[0] != known_fast_key:
+                    return None
+                extra_guards = current_entry[1]
+
+                from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
+
+                cache_key = BoundKernelInMemoryCacheKey(
+                    signature,
+                    tuple(expected for _, expected in extra_guards),
+                )
+                if (
+                    self._bound_kernels.get(cache_key) is not bound
+                    or dist.is_initialized() != dist_initialized
+                ):
+                    return None
+                return known_fast_key, None
+            except Exception:
+                return None
+        try:
+            normalized_args = self.normalize_args(*args)
+            dist_initialized = dist.is_initialized()
+            is_distributed = self._compute_is_distributed(
+                normalized_args, dist_initialized=dist_initialized
+            )
+            signature = self._base_specialization_key(
+                normalized_args, is_distributed=is_distributed
+            )
+            if signature != bound._base_spec_key:
+                return None
+            fast_key = known_fast_key
+            can_prepare = True
+            extra_guards: tuple[
+                tuple[Callable[[Sequence[object]], Hashable], Hashable], ...
+            ] = ()
+            if fast_key is None:
+                current_entry = self._fast_dispatch_key_and_guards(
+                    args,
+                    is_distributed=is_distributed,
+                    signature=signature,
+                )
+                if current_entry is None:
+                    return None
+                fast_key, extra_guards = current_entry
+            elif self._has_specialization_extras:
+                # The dispatch lookup already evaluated every late guard. A
+                # second evaluation is only needed before retaining those
+                # values in a prepared call; failure must not reject the valid
+                # dispatch hit that was just obtained.
+                try:
+                    current_entry = self._fast_dispatch_key_and_guards(
+                        args,
+                        is_distributed=is_distributed,
+                        signature=signature,
+                    )
+                except Exception:
+                    can_prepare = False
+                else:
+                    if current_entry is None:
+                        return None
+                    current_fast_key, extra_guards = current_entry
+                    if current_fast_key != fast_key:
+                        return None
+            if can_prepare:
+                from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
+
+                current_cache_key = BoundKernelInMemoryCacheKey(
+                    signature,
+                    tuple(expected for _, expected in extra_guards),
+                )
+                if self._bound_kernels.get(current_cache_key) is not bound:
+                    return None
+            prepared = (
+                _PreparedCall.build(
+                    self,
+                    bound,
+                    args,
+                    dist_initialized=dist_initialized,
+                    extra_guards=extra_guards,
+                    is_distributed=is_distributed,
+                )
+                if can_prepare
+                else None
+            )
+            # Process-group initialization is external to ``_bind_lock``. Do
+            # not publish a key assembled across a state transition.
+            if dist.is_initialized() != dist_initialized:
+                return None
+            return fast_key, prepared
+        except Exception:
+            # Fast-path publication is optional and must not add a failure
+            # after the compiled kernel has already run successfully.
+            return None
 
     def bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         """
@@ -500,7 +834,13 @@ class Kernel(Generic[_R]):
                 raise TypeError(
                     f"Too many arguments passed to the kernel, expected: {self._num_params} got: {len(args)}."
                 )
-            signature = self._base_specialization_key(args)
+            dist_initialized = dist.is_initialized()
+            is_distributed = self._compute_is_distributed(
+                args, dist_initialized=dist_initialized
+            )
+            signature = self._base_specialization_key(
+                args, is_distributed=is_distributed
+            )
             cache_key = self._get_bound_kernel_cache_key(args, signature)
             bound_kernel = (
                 None if cache_key is None else self._bound_kernels.get(cache_key, None)
@@ -511,7 +851,12 @@ class Kernel(Generic[_R]):
                     # we had default args that needed to be applied
                     bound_kernel = self.bind(normalized_args)
                 else:
-                    bound_kernel = BoundKernel(self, args)
+                    bound_kernel = BoundKernel(
+                        self,
+                        args,
+                        base_spec_key=signature,
+                        is_distributed=is_distributed,
+                    )
                 if cache_key is None:
                     cache_key = self._create_bound_kernel_cache_key(
                         bound_kernel, args, signature
@@ -519,7 +864,13 @@ class Kernel(Generic[_R]):
                 self._bound_kernels[cache_key] = bound_kernel
             return bound_kernel
 
-    def _base_specialization_key(self, args: Sequence[object]) -> tuple[Hashable, ...]:
+    def _base_specialization_key(
+        self,
+        args: Sequence[object],
+        *,
+        is_distributed: bool | None = None,
+        custom_key: object = _CUSTOM_KEY_UNSET,
+    ) -> tuple[Hashable, ...]:
         """
         Generate the base specialization key from input argument metadata only,
         using the per-type extractor functions defined in `_specialization_extractors`,
@@ -536,14 +887,17 @@ class Kernel(Generic[_R]):
             else:
                 result.append(self._specialization_key(value))
         device_type, device_capability = _device_specialization_key(args)
-        is_distributed = self._compute_is_distributed(args)
+        if is_distributed is None:
+            is_distributed = self._compute_is_distributed(args)
         if self._key_fn is not None:
+            if custom_key is _CUSTOM_KEY_UNSET:
+                custom_key = self._key_fn(*args)
             return (
                 *result,
                 device_type,
                 device_capability,
                 is_distributed,
-                self._key_fn(*args),
+                cast("Hashable", custom_key),
             )
         return (*result, device_type, device_capability, is_distributed)
 
@@ -910,7 +1264,14 @@ class Kernel(Generic[_R]):
         """
         if kwargs:
             args = self.normalize_args(*args, **kwargs)
-        elif self._dispatch_cache:
+        if (
+            not torch.compiler.is_compiling()
+            and (prepared := self._prepared_call) is not None
+            and prepared.matches(self, args)
+            and prepared.bound._run is not None
+        ):
+            return prepared.bound._run(*args)
+        if self._dispatch_cache:
             # Fast path: repeat call with argument metadata seen before. The
             # cache is only populated by calls that already took the slow
             # path below, so hitting it cannot skip autotuning/compilation.
@@ -920,7 +1281,29 @@ class Kernel(Generic[_R]):
             if fast_key is not None:
                 bound = self._dispatch_cache.get(fast_key)
                 if bound is not None and bound._run is not None:
-                    return bound._run(*args)
+                    run = bound._run
+                    if torch.compiler.is_compiling():
+                        return run(*args)
+                    # A compilation can discover a late specialization while a
+                    # different thread is reading this cache. Publish a prepared
+                    # entry only while the mapping is still current; the same
+                    # lock protects specialization-driven invalidation.
+                    with self._bind_lock:
+                        if (
+                            self._dispatch_cache.get(fast_key) is bound
+                            and bound._run is run
+                        ):
+                            entry = self._prepare_dispatch_entry(
+                                args, bound, known_fast_key=fast_key
+                            )
+                            if entry is not None and entry[0] == fast_key:
+                                self._prepared_call = entry[1]
+                            else:
+                                run = None
+                        else:
+                            run = None
+                    if run is not None:
+                        return run(*args)
         if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
             # Local import: _tpu_compile_capture pulls in the dynamo HOP machinery,
             # not ready when kernel.py first loads during ``import helion``.
@@ -933,15 +1316,30 @@ class Kernel(Generic[_R]):
             return self.bind(args)(*args)
         bound = self.bind(args)
         result = bound(*args)
-        if self._has_specialization_extras:
-            # A concurrent first compile can discover a late specialization and
-            # make BoundKernel.__call__ rebind internally. Resolve it again so
-            # the fast-dispatch key never points at the pre-specialization bound.
-            bound = self.bind(args)
-        if bound._run is not None:
+        if torch.compiler.is_compiling():
+            if self._has_specialization_extras:
+                bound = self.bind(args)
+            if bound._run is not None:
+                fast_key = self._fast_dispatch_key(args)
+                if fast_key is not None:
+                    self._dispatch_cache[fast_key] = bound
+        else:
+            # Avoid a second bind for signatures the fast paths cannot support.
+            # This cheap key check also captures a custom key exactly once.
             fast_key = self._fast_dispatch_key(args)
             if fast_key is not None:
-                self._dispatch_cache[fast_key] = bound
+                # Resolve any late specialization and publish both fast paths as
+                # one atomic update with respect to discovery and reset.
+                with self._bind_lock:
+                    if self._has_specialization_extras:
+                        bound = self._bind(args)
+                    if bound._run is not None:
+                        entry = self._prepare_dispatch_entry(
+                            args, bound, known_fast_key=fast_key
+                        )
+                        if entry is not None and entry[0] == fast_key:
+                            self._dispatch_cache[fast_key] = bound
+                            self._prepared_call = entry[1]
         return result
 
     def reset(self) -> None:
@@ -949,8 +1347,10 @@ class Kernel(Generic[_R]):
         Clears the cache of bound kernels, meaning subsequent calls will
         recompile and re-autotune.
         """
-        self._bound_kernels.clear()
-        self._dispatch_cache.clear()
+        with self._bind_lock:
+            self._bound_kernels.clear()
+            self._dispatch_cache.clear()
+            self._prepared_call = None
 
     @property
     def jax_fn(self) -> Callable[..., Any]:
@@ -980,6 +1380,9 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         self,
         kernel: Kernel[_R],
         args: tuple[object, ...],
+        *,
+        base_spec_key: tuple[Hashable, ...] | None = None,
+        is_distributed: bool | None = None,
     ) -> None:
         """
         Initialize a BoundKernel object.
@@ -993,13 +1396,22 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         """
         super().__init__()
         self.kernel = kernel
+        if is_distributed is None:
+            dist_initialized = dist.is_initialized()
+            is_distributed = kernel._compute_is_distributed(
+                args, dist_initialized=dist_initialized
+            )
         # Base specialization key from the REAL args (the same key bind() uses to
         # distinguish BoundKernels).  Reused in compile_config as the PyCodeCache
         # ``extra`` discriminator for backends that cache shape-specific module state
         # (Backend.requires_shape_specialized_module).  Must be computed on the real
         # args: fake_args turn scalar int/float/bool into SymInt/SymFloat/SymBool,
         # which the specialization extractors reject.
-        self._base_spec_key = kernel._base_specialization_key(args)
+        self._base_spec_key = (
+            kernel._base_specialization_key(args, is_distributed=is_distributed)
+            if base_spec_key is None
+            else base_spec_key
+        )
         self._run: Callable[..., _R] | None = None
         self._config: Config | None = None
         self._compile_cache: dict[Config, CompiledConfig] = {}
@@ -1019,7 +1431,6 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         # specialization cache key and CompileEnvironment gating; that keeps a
         # symmetric-memory call from ever aliasing a non-distributed compiled
         # kernel of the same shape. See GitHub issue #3024.
-        is_distributed = self.kernel._compute_is_distributed(args)
         self._env = CompileEnvironment(
             _find_device(args),
             self.kernel.settings,

--- a/test/test_prepared_call.py
+++ b/test/test_prepared_call.py
@@ -1,0 +1,509 @@
+"""Tests for the shared Triton/CuTe monomorphic prepared-call path."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import importlib
+import threading
+from typing import TYPE_CHECKING
+from typing import cast
+from unittest.mock import patch
+
+import torch
+
+import helion
+from helion._compiler.cute.backend import CuteBackend
+from helion._compiler.pallas.backend import PallasBackend
+from helion._compiler.triton.backend import TileIRBackend
+from helion._compiler.triton.backend import TritonBackend
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import onlyBackends
+import helion.language as hl
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Hashable
+
+kernel_module = importlib.import_module("helion.runtime.kernel")
+
+
+def _make_add_one(*, distributed: bool = False) -> helion.Kernel:
+    @helion.kernel(
+        static_shapes=True,
+        config=helion.Config(block_sizes=[64]),
+        distributed=distributed,
+    )
+    def add_one(x: torch.Tensor) -> torch.Tensor:
+        out = torch.empty_like(x)
+        for tile in hl.tile(x.size(0)):
+            out[tile] = x[tile] + 1
+        return out
+
+    return add_one
+
+
+def _tensor_size(values: Sequence[object]) -> int:
+    value = values[0]
+    assert isinstance(value, torch.Tensor)
+    return value.size(0)
+
+
+@onlyBackends(["triton", "cute"])
+class TestPreparedCall(RefEagerTestDisabled, TestCase):
+    def test_fresh_tensor_bypasses_dispatch_key(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        first = add_one(x)
+        self.assertIsNotNone(add_one._prepared_call)  # type: ignore[attr-defined]
+
+        other = torch.randn_like(x)
+        with (
+            patch.object(
+                add_one,
+                "_fast_dispatch_key",
+                side_effect=AssertionError("prepared call rebuilt its dispatch key"),
+            ),
+            patch.object(
+                add_one,
+                "bind",
+                side_effect=AssertionError("prepared call rebound the kernel"),
+            ),
+        ):
+            second = add_one(x=other)
+
+        self.assertNotEqual(first.data_ptr(), second.data_ptr())
+        torch.testing.assert_close(first, x + 1)
+        torch.testing.assert_close(second, other + 1)
+
+    def test_tensor_metadata_changes_use_dispatch(self) -> None:
+        add_one = _make_add_one()
+        add_one(torch.randn(64, device=DEVICE))
+        static_indices = torch.randn(64, device=DEVICE)
+        static_indices._dynamo_static_indices = {0}  # type: ignore[attr-defined]
+        changed_static_indices = torch.randn_like(static_indices)
+        changed_static_indices._dynamo_static_indices = set()  # type: ignore[attr-defined]
+        variants = (
+            torch.randn(128, device=DEVICE)[::2],
+            torch.randn(64, device=DEVICE, dtype=torch.float16),
+            torch.randn(65, device=DEVICE),
+            static_indices,
+            changed_static_indices,
+        )
+
+        for value in variants:
+            with (
+                self.subTest(
+                    shape=value.shape,
+                    stride=value.stride(),
+                    dtype=value.dtype,
+                    static_indices=getattr(value, "_dynamo_static_indices", None),
+                ),
+                patch.object(
+                    add_one,
+                    "_fast_dispatch_key",
+                    wraps=add_one._fast_dispatch_key,  # type: ignore[attr-defined]
+                ) as fast_key,
+            ):
+                out = add_one(value)
+                fast_key.assert_called()
+                torch.testing.assert_close(out, value + 1)
+
+    def test_runtime_scalars_reuse_preparation_but_specialized_values_do_not(
+        self,
+    ) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def scale(x: torch.Tensor, value: float) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] * value
+            return out
+
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def scale_constexpr(x: torch.Tensor, value: hl.constexpr) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] * value
+            return out
+
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def scale_specialized(x: torch.Tensor, value: int) -> torch.Tensor:
+            value = hl.specialize(value)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] * value
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(scale(x, 2.0), x * 2.0)
+        with patch.object(
+            scale,
+            "_fast_dispatch_key",
+            side_effect=AssertionError("runtime scalar rebuilt its dispatch key"),
+        ):
+            torch.testing.assert_close(scale(x, 3.0), x * 3.0)
+            self.assertTrue(torch.isnan(scale(x, float("nan"))).all())
+
+        for kernel, first_value, second_value in (
+            (scale_constexpr, 2.0, 3.0),
+            (scale_specialized, 2, 3),
+        ):
+            torch.testing.assert_close(kernel(x, first_value), x * first_value)
+            with patch.object(
+                kernel,
+                "_fast_dispatch_key",
+                wraps=kernel._fast_dispatch_key,  # type: ignore[attr-defined]
+            ) as fast_key:
+                torch.testing.assert_close(kernel(x, second_value), x * second_value)
+            fast_key.assert_called()
+
+        constexpr_nan = float("nan")
+        self.assertTrue(torch.isnan(scale_constexpr(x, constexpr_nan)).all())
+        self.assertIsNone(scale_constexpr._prepared_call)  # type: ignore[attr-defined]
+
+    def test_custom_key_is_evaluated_once_and_disables_preparation(self) -> None:
+        state = {"key": 0}
+        calls = 0
+
+        def key(_x: torch.Tensor) -> int:
+            nonlocal calls
+            calls += 1
+            return state["key"]
+
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+            key=key,
+        )
+        def add_one(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + 1
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(add_one(x), x + 1)
+        self.assertIsNone(add_one._prepared_call)  # type: ignore[attr-defined]
+        bound = next(iter(add_one._dispatch_cache.values()))  # type: ignore[attr-defined]
+        different_shape = torch.randn(65, device=DEVICE)
+        calls = 0
+        fast_key = add_one._fast_dispatch_key((different_shape,))  # type: ignore[attr-defined]
+        self.assertIsNotNone(fast_key)
+        self.assertIsNone(  # type: ignore[attr-defined]
+            add_one._prepare_dispatch_entry(
+                (different_shape,), bound, known_fast_key=fast_key
+            )
+        )
+        self.assertEqual(calls, 1)
+
+        calls = 0
+        torch.testing.assert_close(add_one(x), x + 1)
+        self.assertEqual(calls, 1)
+        self.assertIsNone(add_one._prepared_call)  # type: ignore[attr-defined]
+
+        state["key"] = 1
+        torch.testing.assert_close(add_one(x), x + 1)
+        self.assertIsNone(add_one._prepared_call)  # type: ignore[attr-defined]
+
+    def test_compiler_capture_does_not_inspect_prepared_guard(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+
+        with (
+            patch.object(torch.compiler, "is_compiling", return_value=True),
+            patch.object(
+                kernel_module._PreparedCall,
+                "matches",
+                side_effect=AssertionError("capture inspected prepared state"),
+            ),
+        ):
+            out = add_one(x)
+        torch.testing.assert_close(out, x + 1)
+
+    def test_unsupported_signature_does_not_rebind_after_run(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def add_list(xs: list[torch.Tensor]) -> torch.Tensor:
+            out = torch.empty_like(xs[0])
+            for tile in hl.tile(xs[0].size(0)):
+                out[tile] = xs[0][tile] + xs[1][tile]
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        y = torch.randn_like(x)
+        with patch.object(add_list, "_bind", wraps=add_list._bind) as bind:  # type: ignore[attr-defined]
+            out = add_list([x, y])
+        self.assertEqual(bind.call_count, 1)
+        torch.testing.assert_close(out, x + y)
+
+    def test_distributed_state_change_rechecks_dispatch(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+
+        with (
+            patch.object(kernel_module.dist, "is_initialized", return_value=True),
+            patch.object(kernel_module, "kernel_uses_symm_mem", return_value=False),
+            patch.object(
+                add_one,
+                "_fast_dispatch_key",
+                wraps=add_one._fast_dispatch_key,  # type: ignore[attr-defined]
+            ) as fast_key,
+        ):
+            out = add_one(x)
+        fast_key.assert_called()
+        torch.testing.assert_close(out, x + 1)
+
+    def test_publication_rejects_distributed_state_transition(self) -> None:
+        add_one = _make_add_one(distributed=True)
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        bound = add_one._prepared_call.bound  # type: ignore[attr-defined]
+
+        with patch.object(
+            kernel_module.dist,
+            "is_initialized",
+            side_effect=(False, True),
+        ) as is_initialized:
+            self.assertIsNone(  # type: ignore[attr-defined]
+                add_one._prepare_dispatch_entry((x,), bound)
+            )
+        self.assertEqual(is_initialized.call_count, 2)
+
+        with patch.object(kernel_module.dist, "is_initialized", return_value=True):
+            self.assertIsNone(  # type: ignore[attr-defined]
+                add_one._prepare_dispatch_entry((x,), bound)
+            )
+
+    def test_custom_key_hit_rejects_distributed_state_transition(self) -> None:
+        calls = 0
+
+        def key(_x: torch.Tensor) -> int:
+            nonlocal calls
+            calls += 1
+            return 0
+
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+            distributed=True,
+            key=key,
+        )
+        def add_one(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + 1
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        bound = next(iter(add_one._dispatch_cache.values()))  # type: ignore[attr-defined]
+        calls = 0
+        with patch.object(
+            kernel_module.dist,
+            "is_initialized",
+            side_effect=(False, True),
+        ):
+            fast_key = add_one._fast_dispatch_key((x,))  # type: ignore[attr-defined]
+            assert fast_key is not None
+            self.assertIsNone(  # type: ignore[attr-defined]
+                add_one._prepare_dispatch_entry((x,), bound, known_fast_key=fast_key)
+            )
+        self.assertEqual(calls, 1)
+
+    def test_alternating_cached_specializations_prepare_latest(self) -> None:
+        add_one = _make_add_one()
+        x64 = torch.randn(64, device=DEVICE)
+        x65 = torch.randn(65, device=DEVICE)
+        add_one(x64)
+        add_one(x65)
+
+        first_64 = torch.randn_like(x64)
+        with patch.object(
+            add_one,
+            "_fast_dispatch_key",
+            wraps=add_one._fast_dispatch_key,  # type: ignore[attr-defined]
+        ) as fast_key:
+            torch.testing.assert_close(add_one(first_64), first_64 + 1)
+        fast_key.assert_called()
+
+        second_64 = torch.randn_like(x64)
+        with patch.object(
+            add_one,
+            "_fast_dispatch_key",
+            side_effect=AssertionError("latest specialization was not prepared"),
+        ):
+            torch.testing.assert_close(add_one(second_64), second_64 + 1)
+
+    def test_preparation_failure_falls_back_after_dispatch_hit(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        bound = add_one._prepared_call.bound  # type: ignore[attr-defined]
+        calls = 0
+
+        def flaky_extractor(_args: Sequence[object]) -> int:
+            nonlocal calls
+            calls += 1
+            if calls % 2 == 0:
+                raise RuntimeError("second evaluation failed")
+            return 1
+
+        add_one._specialize_extra[bound._base_spec_key] = [flaky_extractor]  # type: ignore[attr-defined]
+        add_one._has_specialization_extras = True  # type: ignore[attr-defined]
+        fast_key = add_one._fast_dispatch_key((x,))  # type: ignore[attr-defined]
+        assert fast_key is not None
+        add_one._dispatch_cache = {fast_key: bound}  # type: ignore[attr-defined]
+        add_one._prepared_call = None  # type: ignore[attr-defined]
+        calls = 0
+
+        torch.testing.assert_close(add_one(x), x + 1)
+        self.assertEqual(calls, 2)
+        self.assertIsNone(add_one._prepared_call)  # type: ignore[attr-defined]
+
+    def test_specialization_extension_cannot_leave_stale_preparation(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        bound = add_one._prepared_call.bound  # type: ignore[attr-defined]
+        add_one._prepared_call = None  # type: ignore[attr-defined]
+
+        build_entered = threading.Event()
+        release_build = threading.Event()
+        extension_started = threading.Event()
+        extension_done = threading.Event()
+        original_build = kernel_module._PreparedCall.build
+
+        def blocking_build(*args: object, **kwargs: object) -> object:
+            build_entered.set()
+            self.assertTrue(release_build.wait(5))
+            return original_build(*args, **kwargs)  # type: ignore[arg-type]
+
+        def extend() -> None:
+            extension_started.set()
+            add_one._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
+                bound,
+                bound._base_spec_key,
+                [_tensor_size],
+                (x,),
+            )
+            extension_done.set()
+
+        with (
+            patch.object(
+                kernel_module._PreparedCall, "build", side_effect=blocking_build
+            ),
+            ThreadPoolExecutor(max_workers=2) as pool,
+        ):
+            call = pool.submit(add_one, x)
+            self.assertTrue(build_entered.wait(5))
+            extension = pool.submit(extend)
+            self.assertTrue(extension_started.wait(5))
+            self.assertFalse(extension_done.wait(0.05))
+            release_build.set()
+            torch.testing.assert_close(call.result(timeout=5), x + 1)
+            extension.result(timeout=5)
+
+        self.assertIsNone(add_one._prepared_call)  # type: ignore[attr-defined]
+        self.assertFalse(add_one._dispatch_cache)  # type: ignore[attr-defined]
+
+    def test_failing_specialization_extension_is_transactional(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        prepared = add_one._prepared_call  # type: ignore[attr-defined]
+        assert prepared is not None
+        signature = prepared.bound._base_spec_key
+        original_extractors = tuple(  # type: ignore[attr-defined]
+            add_one._specialize_extra[signature]
+        )
+
+        def fail(_args: Sequence[object]) -> int:
+            raise RuntimeError("late specialization failed")
+
+        with self.assertRaisesRegex(RuntimeError, "late specialization failed"):
+            add_one._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
+                prepared.bound,
+                signature,
+                [fail],
+                (x,),
+            )
+
+        def unhashable(_args: Sequence[object]) -> Hashable:
+            return cast("Hashable", [])
+
+        with self.assertRaisesRegex(TypeError, "unhashable"):
+            add_one._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
+                prepared.bound,
+                signature,
+                [unhashable],
+                (x,),
+            )
+
+        self.assertEqual(  # type: ignore[attr-defined]
+            tuple(add_one._specialize_extra[signature]), original_extractors
+        )
+        self.assertIs(add_one._prepared_call, prepared)  # type: ignore[attr-defined]
+        with patch.object(
+            add_one,
+            "_fast_dispatch_key",
+            side_effect=AssertionError("transaction invalidated prepared call"),
+        ):
+            torch.testing.assert_close(add_one(x), x + 1)
+
+    def test_concurrent_reset_cannot_republish_old_bound(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        bound = add_one._prepared_call.bound  # type: ignore[attr-defined]
+        add_one._prepared_call = None  # type: ignore[attr-defined]
+        add_one._dispatch_cache.clear()  # type: ignore[attr-defined]
+
+        call_finished_kernel = threading.Event()
+        release_call = threading.Event()
+        bound_type = type(bound)
+        original_call = bound_type.__call__
+
+        def blocking_call(current: object, *args: object, **kwargs: object) -> object:
+            result = original_call(current, *args, **kwargs)
+            call_finished_kernel.set()
+            self.assertTrue(release_call.wait(5))
+            return result
+
+        with (
+            patch.object(bound_type, "__call__", new=blocking_call),
+            ThreadPoolExecutor(max_workers=1) as pool,
+        ):
+            call = pool.submit(add_one, x)
+            self.assertTrue(call_finished_kernel.wait(5))
+            add_one.reset()
+            release_call.set()
+            torch.testing.assert_close(call.result(timeout=5), x + 1)
+
+        self.assertIsNone(add_one._prepared_call)  # type: ignore[attr-defined]
+        self.assertFalse(add_one._dispatch_cache)  # type: ignore[attr-defined]
+
+    def test_backend_capability_is_explicit_and_inherited(self) -> None:
+        self.assertTrue(TritonBackend().supports_eager_prepared_call)
+        self.assertTrue(TileIRBackend().supports_eager_prepared_call)
+        self.assertTrue(CuteBackend().supports_eager_prepared_call)
+        self.assertFalse(PallasBackend().supports_eager_prepared_call)
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()


### PR DESCRIPTION
Stacked PRs:
 * #3323
 * #3322
 * __->__#3321


--- --- ---

### runtime: add guarded prepared kernel calls


Add a backend-neutral eager prepared-call layer that remembers the most recently resolved BoundKernel and re-enters its generated host wrapper when exact guards still match. Keep the existing multi-specialization dispatch cache as the fallback, opt backends in explicitly, and validate tensor metadata, constexpr values, late specialization guards, distributed state, custom keys, and cache membership before reuse.

This removes repeated Helion binding and specialization work for stable eager calls without bypassing backend-native launch semantics. Unsupported argument types and state transitions fail closed.

Tests cover Triton and CuTe reuse, metadata and scalar invalidation, custom keys, distributed transitions, specialization races, reset concurrency, compiler capture, and backend capability.
