### PR TITLE
triton: cache resolved native launches safely

### DIFF
--- a/helion/_compiler/triton/backend.py
+++ b/helion/_compiler/triton/backend.py
@@ -205,6 +205,7 @@ class TritonBackend(Backend):
         )
         if triton_jit_fn is not None and hasattr(triton_jit_fn, "device_caches"):
             triton_jit_fn.device_caches.clear()
+            triton_jit_fn.__dict__.pop("_helion_prepared_launches", None)
 
     def compiled_cache_key(
         self, bound_kernel: BoundKernel[Any], compiled_fn: object

--- a/helion/runtime/triton/launcher.py
+++ b/helion/runtime/triton/launcher.py
@@ -21,13 +21,24 @@ CPU/TPU cases of :func:`get_num_sm`) lives in thin wrappers in
 from __future__ import annotations
 
 import contextvars
+from typing import TYPE_CHECKING
 
 import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 try:
     import triton
 except ImportError:
     triton = None  # type: ignore[assignment]
+
+try:
+    from triton._C.libtriton import (
+        native_specialize_impl,  # pyrefly: ignore [missing-module-attribute]
+    )
+except ImportError:
+    native_specialize_impl = None  # type: ignore[assignment]
 
 
 if triton is not None:
@@ -120,6 +131,251 @@ _CUS_PER_XCD: dict[str, int] = {
     "gfx951": 32,  # CDNA4 (MI355)
 }
 
+_MISSING_GLOBAL = object()
+_PREPARED_LAUNCH_CACHE_LIMIT = 8
+_RUNTIME_ONLY_OPTIONS = frozenset({"device", "device_type", "stream", "warmup"})
+
+
+def _prepared_key_value(value: object) -> object:
+    if type(value) is float:
+        if value != value:
+            raise TypeError("NaN cannot be a prepared-launch key")
+        return value.hex()
+    return value
+
+
+def _prepared_options_key(
+    ptx_options: str | None, kwargs: dict[str, object]
+) -> tuple[object, ...] | None:
+    """Return a conservative exact key for Triton compilation options."""
+    if ptx_options is None and not kwargs:
+        return ()
+    if ptx_options is not None and type(ptx_options) is not str:
+        return None
+    result: list[object] = [("ptx_options", type(ptx_options), ptx_options)]
+    supported_types = (
+        bool,
+        int,
+        float,
+        str,
+        type(None),
+        torch.dtype,
+        torch.device,
+    )
+    for name, value in sorted(kwargs.items()):
+        if type(value) not in supported_types:
+            return None
+        try:
+            keyed_value = _prepared_key_value(value)
+        except TypeError:
+            return None
+        result.append((name, type(value), keyed_value))
+    return tuple(result)
+
+
+def _prepared_launch_context(
+    triton_kernel: object, grid: tuple[int, ...]
+) -> tuple[object, object] | None:
+    """Return live launch state when bypassing ``JITFunction.run`` is safe."""
+    if triton is None or native_specialize_impl is None:
+        return None
+    runtime = triton.knobs.runtime
+    compilation = triton.knobs.compilation
+    pre_run_hooks = triton_kernel.pre_run_hooks  # type: ignore[union-attr]
+    effective_debug = triton_kernel.debug or runtime.debug  # type: ignore[union-attr]
+    if (
+        type(pre_run_hooks) is not list
+        or pre_run_hooks
+        or type(effective_debug) is not bool
+        or effective_debug
+        or runtime.add_stages_inspection_hook is not None
+        or type(compilation.instrumentation_mode) is not str
+        or compilation.instrumentation_mode != ""
+        # CompiledKernel.__getitem__ closes over a padded 3D grid. A custom
+        # metadata callback must continue to observe Triton's original grid.
+        or (len(grid) < 3 and triton_kernel.launch_metadata is not None)  # type: ignore[union-attr]
+    ):
+        return None
+    active = triton.runtime.driver.active
+    # pyrefly: ignore [missing-attribute]
+    return active, active.get_current_device()
+
+
+def _make_prepared_launch_guard(
+    triton_kernel: object,
+    active: object,
+    device: object,
+    device_cache: object,
+    backend: object,
+    kernel_cache: object,
+    kernel_key: object,
+    compiled: object,
+    grid: tuple[int, ...],
+    args: tuple[object, ...],
+    num_warps: int,
+    num_stages: int,
+    launch_cooperative_grid: bool,
+    option_key: tuple[object, ...],
+) -> Callable[..., bool]:
+    """Build an unrolled guard finer than Triton's specialization key."""
+    if len(args) != len(triton_kernel.params):  # type: ignore[union-attr]
+        raise TypeError("prepared launch requires every JIT parameter")
+    specialize_impl = native_specialize_impl
+    if specialize_impl is None:
+        raise TypeError("Triton specialization is unavailable")
+    namespace: dict[str, object] = {
+        "active": active,
+        "device": device,
+        "device_cache": device_cache,
+        "backend": backend,
+        "kernel_cache": kernel_cache,
+        "kernel_key": kernel_key,
+        "compiled": compiled,
+        "grid": grid,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "launch_cooperative_grid": launch_cooperative_grid,
+        "option_key": option_key,
+        "num_warps_type": type(num_warps),
+        "num_stages_type": type(num_stages),
+        "launch_cooperative_grid_type": type(launch_cooperative_grid),
+        "missing": _MISSING_GLOBAL,
+        "triton_kernel": triton_kernel,
+        "specialize_impl": specialize_impl,
+    }
+    checks = [
+        "current_active is active",
+        "current_device == device",
+        "current_device_cache is device_cache",
+        "kernel_cache.get(kernel_key, missing) is compiled",
+        "current_grid == grid",
+        "type(current_num_warps) is num_warps_type and current_num_warps == num_warps",
+        "type(current_num_stages) is num_stages_type and current_num_stages == num_stages",
+        (
+            "type(current_launch_cooperative_grid) is launch_cooperative_grid_type "
+            "and current_launch_cooperative_grid == launch_cooperative_grid"
+        ),
+        "current_option_key == option_key",
+        f"len(args) == {len(args)}",
+    ]
+    for index, arg in enumerate(args):
+        prefix = f"args[{index}]"
+        namespace[f"type_{index}"] = type(arg)
+        checks.append(f"type({prefix}) is type_{index}")
+        parameter = triton_kernel.params[index]  # type: ignore[union-attr]
+        namespace[f"is_const_{index}"] = parameter.is_const
+        namespace[f"specialize_{index}"] = not parameter.do_not_specialize
+        namespace[f"align_{index}"] = not parameter.do_not_specialize_on_alignment
+        if parameter.is_constexpr:
+            namespace[f"value_{index}"] = _prepared_key_value(arg)
+            checks.append(
+                f"{prefix}.hex() == value_{index}"
+                if type(arg) is float
+                else f"{prefix} == value_{index}"
+            )
+        else:
+            native_specialization = specialize_impl(
+                backend,
+                arg,
+                parameter.is_const,
+                not parameter.do_not_specialize,
+                not parameter.do_not_specialize_on_alignment,
+            )
+            annotation_type = parameter.annotation_type
+            if annotation_type:
+                specializes_annotation = not (
+                    parameter.do_not_specialize
+                    or annotation_type == "u1"
+                    or annotation_type.startswith(("fp", "bf"))
+                )
+                if specializes_annotation:
+                    namespace[f"specialization_{index}"] = native_specialization[1:]
+                    checks.append(
+                        f"specialize_impl(backend, {prefix}, is_const_{index}, "
+                        f"specialize_{index}, align_{index})[1:] "
+                        f"== specialization_{index}"
+                    )
+            else:
+                namespace[f"specialization_{index}"] = native_specialization
+                checks.append(
+                    f"specialize_impl(backend, {prefix}, is_const_{index}, "
+                    f"specialize_{index}, align_{index}) == specialization_{index}"
+                )
+
+        if type(arg) in (torch.Tensor, torch.nn.Parameter):
+            assert isinstance(arg, torch.Tensor)
+            namespace[f"device_{index}"] = arg.device
+            namespace[f"dtype_{index}"] = arg.dtype
+            checks.extend(
+                (
+                    f"{prefix}.device == device_{index}",
+                    f"{prefix}.dtype is dtype_{index}",
+                )
+            )
+        elif type(arg) in (
+            bool,
+            int,
+            float,
+            str,
+            type(None),
+            torch.dtype,
+            torch.device,
+        ):
+            pass
+        else:
+            raise TypeError(f"unsupported prepared-launch argument: {type(arg)!r}")
+    used_globals = triton_kernel.used_global_vals  # type: ignore[union-attr]
+    namespace["used_globals"] = used_globals
+    checks.extend(
+        (
+            "triton_kernel.used_global_vals is used_globals",
+            f"len(used_globals) == {len(used_globals)}",
+        )
+    )
+    for index, ((name, global_id), entry) in enumerate(used_globals.items()):
+        value, global_dict = entry
+        namespace[f"used_global_key_{index}"] = (name, global_id)
+        namespace[f"used_global_entry_{index}"] = entry
+        namespace[f"global_name_{index}"] = name
+        namespace[f"global_dict_{index}"] = global_dict
+        namespace[f"global_value_{index}"] = value
+        checks.extend(
+            (
+                (
+                    f"used_globals.get(used_global_key_{index}, missing) "
+                    f"is used_global_entry_{index}"
+                ),
+                (
+                    f"not (global_dict_{index}.get(global_name_{index}, missing) "
+                    f"!= global_value_{index})"
+                ),
+            )
+        )
+    parameters = (
+        "current_active, current_device, current_device_cache, current_grid, args, "
+        "current_num_warps, current_num_stages, current_launch_cooperative_grid, "
+        "current_option_key"
+    )
+    return eval(f"lambda {parameters}: {' and '.join(checks)}", namespace)
+
+
+def _prepared_launch_cache(
+    triton_kernel: object,
+) -> list[tuple[Callable[..., bool], tuple[object, ...]]]:
+    cache = triton_kernel.__dict__.get("_helion_prepared_launches")  # type: ignore[union-attr]
+    if cache is None:
+        cache = []
+        triton_kernel._helion_prepared_launches = cache  # type: ignore[union-attr]
+    return cache
+
+
+def _is_future_kernel(compiled: object) -> bool:
+    compiled_type = type(compiled)
+    return (
+        compiled_type.__name__ == "FutureKernel"
+        and compiled_type.__module__ == "triton.runtime._async_compile"
+    )
+
 
 def get_num_xcd(device: torch.device | int | None = None) -> int:
     """Number of XCDs visible for ``device`` on AMD CDNA, else ``1``.
@@ -161,10 +417,52 @@ def default_launcher(
     num_stages: int,
     ptx_options: str | None = None,
     launch_cooperative_grid: bool = False,
-    **kwargs: dict,
+    **kwargs: object,
 ) -> object:
-    """Default launcher function that executes the kernel immediately."""
-    # For both CUDA and MTIA, use the same kernel execution
+    """Launch through Triton, caching resolved binaries for repeat calls."""
+    option_key = _prepared_options_key(ptx_options, kwargs)
+    can_prepare = (
+        option_key is not None
+        and not _RUNTIME_ONLY_OPTIONS.intersection(kwargs)
+        and type(grid) is tuple
+        and 0 < len(grid) <= 3
+        and all(type(value) is int for value in grid)
+        and not torch.compiler.is_compiling()
+    )
+    prepared_context = None
+    if can_prepare:
+        prepared = None
+        try:
+            prepared_context = _prepared_launch_context(triton_kernel, grid)
+            cache = triton_kernel.__dict__.get(  # type: ignore[union-attr]
+                "_helion_prepared_launches"
+            )
+            if prepared_context is not None and cache:
+                active, device = prepared_context
+                device_cache = triton_kernel.device_caches.get(device)  # type: ignore[union-attr]
+                for index, (guard, cached) in enumerate(cache):
+                    if guard(
+                        active,
+                        device,
+                        device_cache,
+                        grid,
+                        args,
+                        num_warps,
+                        num_stages,
+                        launch_cooperative_grid,
+                        option_key,
+                    ):
+                        if index:
+                            cache.insert(0, cache.pop(index))
+                        prepared = cached
+                        break
+        except Exception:
+            pass
+        if prepared is not None:
+            runner, compiled = prepared
+            runner(*args)  # pyrefly: ignore [not-callable]
+            return compiled
+
     run_kwargs: dict = {
         "grid": grid,
         "warmup": False,
@@ -175,7 +473,72 @@ def default_launcher(
     }
     if ptx_options is not None:
         run_kwargs["ptx_options"] = ptx_options
-    return triton_kernel.run(  # type: ignore[union-attr]
-        *args,
-        **run_kwargs,
-    )
+    compiled = triton_kernel.run(*args, **run_kwargs)  # type: ignore[union-attr]
+    if (
+        can_prepare
+        and prepared_context is not None
+        and compiled is not None
+        and not _is_future_kernel(compiled)
+    ):
+        try:
+            assert option_key is not None
+            active, device = prepared_context
+            current_context = _prepared_launch_context(triton_kernel, grid)
+            if not (
+                current_context is not None
+                and current_context[0] is active
+                and current_context[1] == device
+            ):
+                return compiled
+            device_cache = triton_kernel.device_caches.get(device)  # type: ignore[union-attr]
+            if device_cache is None:
+                return compiled
+            kernel_cache = device_cache[0]  # pyrefly: ignore [unsupported-operation]
+            backend = device_cache[3]  # pyrefly: ignore [unsupported-operation]
+            kernel_key = next(
+                (
+                    key
+                    for key, value in kernel_cache.items()  # pyrefly: ignore [missing-attribute]
+                    if value is compiled
+                ),
+                _MISSING_GLOBAL,
+            )
+            if kernel_key is _MISSING_GLOBAL:
+                return compiled
+            guard = _make_prepared_launch_guard(
+                triton_kernel,
+                active,
+                device,
+                device_cache,
+                backend,
+                kernel_cache,
+                kernel_key,
+                compiled,
+                grid,
+                args,
+                num_warps,
+                num_stages,
+                launch_cooperative_grid,
+                option_key,
+            )
+            cache = _prepared_launch_cache(triton_kernel)
+            normalized_grid = (
+                grid[0],
+                grid[1] if len(grid) > 1 else 1,
+                grid[2] if len(grid) > 2 else 1,
+            )
+            cache.insert(
+                0,
+                (
+                    guard,
+                    (
+                        compiled[normalized_grid],  # pyrefly: ignore [unsupported-operation]
+                        compiled,
+                    ),
+                ),
+            )
+            if len(cache) > _PREPARED_LAUNCH_CACHE_LIMIT:
+                cache.pop()
+        except Exception:
+            pass
+    return compiled

--- a/test/test_triton_prepared_launcher.py
+++ b/test/test_triton_prepared_launcher.py
@@ -1,0 +1,666 @@
+"""Safety and integration tests for Triton's resolved launch cache."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from typing import cast
+import unittest
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import torch
+
+import helion
+from helion._compiler.triton.backend import TritonBackend
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import onlyBackends
+from helion._testing import skipIfNotCUDA
+import helion.language as hl
+from helion.runtime.triton import launcher
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from triton.runtime.jit import JITFunction
+
+
+_TRITON_PREPARED_GLOBAL = 1
+
+
+class _FakeCompiled:
+    def __init__(self) -> None:
+        self.runner_calls: list[tuple[object, ...]] = []
+        self.runner_error: BaseException | None = None
+
+    def __getitem__(self, _grid: tuple[int, int, int]) -> Callable[..., None]:
+        def run(*args: object) -> None:
+            self.runner_calls.append(args)
+            if self.runner_error is not None:
+                raise self.runner_error
+
+        return run
+
+
+class _FakeJITFunction:
+    def __init__(self) -> None:
+        self.params = [
+            SimpleNamespace(
+                is_const=False,
+                is_constexpr=False,
+                annotation_type="",
+                do_not_specialize=False,
+                do_not_specialize_on_alignment=False,
+            )
+        ]
+        self.pre_run_hooks: list[Callable[..., None]] = []
+        self.debug = None
+        self.launch_metadata = None
+        self.used_global_vals: dict[object, object] = {}
+        self.device_caches: dict[object, tuple[object, ...]] = {}
+        self.run_calls = 0
+        self.compiled: list[object] = []
+
+    def _device_cache(self) -> tuple[object, ...]:
+        cache = self.device_caches.get(0)
+        if cache is None:
+            cache = ({}, {}, object(), "cuda", object())
+            self.device_caches[0] = cache
+        return cache
+
+    def run(self, *_args: object, **_kwargs: object) -> object:
+        self.run_calls += 1
+        compiled = _FakeCompiled()
+        self.compiled.append(compiled)
+        kernel_cache = self._device_cache()[0]
+        kernel_cache[self.run_calls] = compiled  # type: ignore[index]
+        return compiled
+
+
+def _fake_triton() -> SimpleNamespace:
+    active = SimpleNamespace(get_current_device=lambda: 0)
+    runtime_knobs = SimpleNamespace(
+        debug=False,
+        add_stages_inspection_hook=None,
+        launch_enter_hook=None,
+        launch_exit_hook=None,
+    )
+    return SimpleNamespace(
+        knobs=SimpleNamespace(
+            runtime=runtime_knobs,
+            compilation=SimpleNamespace(instrumentation_mode=""),
+        ),
+        runtime=SimpleNamespace(driver=SimpleNamespace(active=active)),
+    )
+
+
+def _launch(
+    jit_fn: object,
+    value: object = 1,
+    *,
+    grid: tuple[int, ...] = (1,),
+    num_warps: int = 4,
+    num_stages: int = 1,
+    launch_cooperative_grid: bool = False,
+    ptx_options: str | None = None,
+    maxnreg: int | None = None,
+) -> object:
+    extra_options = {} if maxnreg is None else {"maxnreg": maxnreg}
+    return launcher.default_launcher(
+        jit_fn,
+        grid,
+        value,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        launch_cooperative_grid=launch_cooperative_grid,
+        ptx_options=ptx_options,
+        **extra_options,
+    )
+
+
+@onlyBackends(["triton"])
+class TestPreparedTritonLauncherUnit(TestCase):
+    def test_kernel_cache_membership_invalidates_prepared_launch(self) -> None:
+        jit_fn = _FakeJITFunction()
+        fake_triton = _fake_triton()
+        with patch.object(launcher, "triton", fake_triton):
+            first = cast("_FakeCompiled", _launch(jit_fn))
+            self.assertIs(_launch(jit_fn), first)
+            self.assertEqual(jit_fn.run_calls, 1)
+            self.assertEqual(first.runner_calls, [(1,)])
+
+            kernel_cache = jit_fn.device_caches[0][0]
+            kernel_cache.clear()  # type: ignore[union-attr]
+            second = _launch(jit_fn)
+            self.assertIsNot(second, first)
+            self.assertEqual(jit_fn.run_calls, 2)
+            self.assertEqual(first.runner_calls, [(1,)])
+
+            jit_fn.device_caches.clear()
+            third = _launch(jit_fn)
+            self.assertIsNot(third, second)
+            self.assertEqual(jit_fn.run_calls, 3)
+
+    def test_grid_and_launch_options_are_guarded(self) -> None:
+        cases: tuple[Callable[[_FakeJITFunction], object], ...] = (
+            lambda jit_fn: _launch(jit_fn, grid=(2,)),
+            lambda jit_fn: _launch(jit_fn, num_warps=8),
+            lambda jit_fn: _launch(jit_fn, num_stages=2),
+            lambda jit_fn: _launch(jit_fn, launch_cooperative_grid=True),
+            lambda jit_fn: _launch(jit_fn, ptx_options="--test"),
+            lambda jit_fn: _launch(jit_fn, maxnreg=64),
+        )
+        for changed_launch in cases:
+            with self.subTest(changed_launch=changed_launch):
+                jit_fn = _FakeJITFunction()
+                with patch.object(launcher, "triton", _fake_triton()):
+                    _launch(jit_fn)
+                    changed_launch(jit_fn)
+                self.assertEqual(jit_fn.run_calls, 2)
+
+    def test_dynamic_jit_modes_use_slow_path(self) -> None:
+        cases = (
+            ("jit_debug", True),
+            ("runtime_debug", True),
+            ("instrumentation", "profile"),
+            ("add_stages", lambda: ("key", "hash")),
+        )
+        for field, value in cases:
+            with self.subTest(field=field, value=value):
+                jit_fn = _FakeJITFunction()
+                fake_triton = _fake_triton()
+                with patch.object(launcher, "triton", fake_triton):
+                    _launch(jit_fn)
+                    if field == "jit_debug":
+                        jit_fn.debug = value
+                    elif field == "runtime_debug":
+                        fake_triton.knobs.runtime.debug = value
+                    elif field == "instrumentation":
+                        fake_triton.knobs.compilation.instrumentation_mode = value
+                    else:
+                        fake_triton.knobs.runtime.add_stages_inspection_hook = value
+                    _launch(jit_fn)
+                self.assertEqual(jit_fn.run_calls, 2)
+
+    def test_prepared_runner_exception_is_not_retried(self) -> None:
+        jit_fn = _FakeJITFunction()
+        with patch.object(launcher, "triton", _fake_triton()):
+            compiled = cast("_FakeCompiled", _launch(jit_fn))
+            compiled.runner_error = RuntimeError("launch failed")
+            with self.assertRaisesRegex(RuntimeError, "launch failed"):
+                _launch(jit_fn)
+        self.assertEqual(jit_fn.run_calls, 1)
+        self.assertEqual(compiled.runner_calls, [(1,)])
+
+    def test_cache_is_bounded(self) -> None:
+        jit_fn = _FakeJITFunction()
+        with patch.object(launcher, "triton", _fake_triton()):
+            for value in range(10):
+                _launch(jit_fn, grid=(value + 1,))
+        self.assertEqual(jit_fn.run_calls, 10)
+        self.assertEqual(len(jit_fn._helion_prepared_launches), 8)  # type: ignore[attr-defined]
+
+    def test_simple_options_can_prepare(self) -> None:
+        jit_fn = _FakeJITFunction()
+        with patch.object(launcher, "triton", _fake_triton()):
+            first = _launch(
+                jit_fn,
+                ptx_options="--target-option",
+                maxnreg=64,
+            )
+            self.assertIs(
+                _launch(
+                    jit_fn,
+                    ptx_options="--target-option",
+                    maxnreg=64,
+                ),
+                first,
+            )
+        self.assertEqual(jit_fn.run_calls, 1)
+
+    def test_backend_tensor_specialization_is_guarded(self) -> None:
+        jit_fn = _FakeJITFunction()
+
+        def specialize(
+            _backend: object,
+            value: object,
+            _is_const: bool,
+            _specialize: bool,
+            _align: bool,
+        ) -> tuple[str, str]:
+            assert isinstance(value, torch.Tensor)
+            storage_class = (
+                "small" if value.untyped_storage().nbytes() <= 64 else "large"
+            )
+            return str(value.dtype), storage_class
+
+        with (
+            patch.object(launcher, "triton", _fake_triton()),
+            patch.object(launcher, "native_specialize_impl", side_effect=specialize),
+        ):
+            first = _launch(jit_fn, torch.empty(16))
+            self.assertIs(_launch(jit_fn, torch.empty(16)), first)
+            second = _launch(jit_fn, torch.empty(32))
+
+        self.assertIsNot(second, first)
+        self.assertEqual(jit_fn.run_calls, 2)
+
+    def test_missing_native_specializer_uses_slow_path(self) -> None:
+        jit_fn = _FakeJITFunction()
+        with (
+            patch.object(launcher, "triton", _fake_triton()),
+            patch.object(launcher, "native_specialize_impl", None),
+        ):
+            _launch(jit_fn)
+            _launch(jit_fn)
+        self.assertEqual(jit_fn.run_calls, 2)
+        self.assertFalse(getattr(jit_fn, "_helion_prepared_launches", None))
+
+    def test_backend_cache_clear_removes_all_prepared_state(self) -> None:
+        config = object()
+        jit_fn = SimpleNamespace(
+            device_caches={0: ({"kernel": object()}, {}, None, None, None)},
+            _helion_prepared_launches=[object()],
+        )
+
+        def compiled_fn() -> None:
+            return None
+
+        key = "_helion_test_kernel"
+        compiled_fn.__globals__[key] = jit_fn
+        bound = SimpleNamespace(
+            _compile_cache={config: compiled_fn},
+            config_spec=Mock(),
+            kernel=SimpleNamespace(name="test_kernel"),
+        )
+        try:
+            TritonBackend()._clear_triton_jit_cache(bound, config)  # type: ignore[arg-type]
+        finally:
+            del compiled_fn.__globals__[key]
+
+        self.assertFalse(jit_fn.device_caches)
+        self.assertNotIn("_helion_prepared_launches", jit_fn.__dict__)
+
+
+def _make_add_one() -> helion.Kernel:
+    @helion.kernel(
+        static_shapes=True,
+        config=helion.Config(block_sizes=[64], num_warps=4, num_stages=1),
+    )
+    def add_one(x: torch.Tensor) -> torch.Tensor:
+        out = torch.empty_like(x)
+        for tile in hl.tile(x.size(0)):
+            out[tile] = x[tile] + 1
+        return out
+
+    return add_one
+
+
+def _get_triton_jit_function(kernel: helion.Kernel) -> JITFunction:
+    from triton.runtime.jit import JITFunction
+
+    bound = next(iter(kernel._bound_kernels.values()))  # type: ignore[attr-defined]
+    run = bound._run
+    assert run is not None
+    jit_fn = run.__globals__[f"_helion_{kernel.name}"]
+    assert isinstance(jit_fn, JITFunction)
+    return jit_fn
+
+
+@onlyBackends(["triton"])
+@skipIfNotCUDA()
+class TestPreparedTritonLauncherCuda(RefEagerTestDisabled, TestCase):
+    def test_pointer_alignment_change_reprepares_launch(self) -> None:
+        add_one = _make_add_one()
+        aligned = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(add_one(aligned), aligned + 1)
+        jit_fn = _get_triton_jit_function(add_one)
+
+        unaligned = torch.randn(65, device=DEVICE)[1:]
+        self.assertEqual(aligned.shape, unaligned.shape)
+        self.assertEqual(aligned.stride(), unaligned.stride())
+        self.assertEqual(aligned.data_ptr() % 16, 0)
+        self.assertNotEqual(unaligned.data_ptr() % 16, 0)
+        with patch.object(jit_fn, "run", wraps=jit_fn.run) as jit_run:
+            out = add_one(unaligned)
+        torch.testing.assert_close(out, unaligned + 1)
+        self.assertEqual(jit_run.call_count, 1)
+
+        another_unaligned = torch.randn(65, device=DEVICE)[1:]
+        with patch.object(
+            jit_fn,
+            "run",
+            side_effect=AssertionError("prepared launch called JITFunction.run"),
+        ):
+            out = add_one(another_unaligned)
+        torch.testing.assert_close(out, another_unaligned + 1)
+
+    def test_dynamic_scalars_reuse_matching_triton_specialization(self) -> None:
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def scale(x, out, value, block: tl.constexpr):
+            offsets = tl.arange(0, block)
+            tl.store(out + offsets, tl.load(x + offsets) * value)
+
+        x = torch.randn(64, device=DEVICE)
+        out = torch.empty_like(x)
+        launcher.default_launcher(
+            scale, (1,), x, out, 17, 64, num_warps=4, num_stages=1
+        )
+        with patch.object(
+            scale,
+            "run",
+            side_effect=AssertionError("dynamic integer called JITFunction.run"),
+        ):
+            launcher.default_launcher(
+                scale, (1,), x, out, 19, 64, num_warps=4, num_stages=1
+            )
+        torch.testing.assert_close(out, x * 19)
+
+        with patch.object(scale, "run", wraps=scale.run) as jit_run:
+            launcher.default_launcher(
+                scale, (1,), x, out, 16, 64, num_warps=4, num_stages=1
+            )
+        self.assertEqual(jit_run.call_count, 1)
+        torch.testing.assert_close(out, x * 16)
+
+        launcher.default_launcher(
+            scale, (1,), x, out, 1.5, 64, num_warps=4, num_stages=1
+        )
+        with patch.object(
+            scale,
+            "run",
+            side_effect=AssertionError("dynamic float called JITFunction.run"),
+        ):
+            launcher.default_launcher(
+                scale, (1,), x, out, 2.5, 64, num_warps=4, num_stages=1
+            )
+        torch.testing.assert_close(out, x * 2.5)
+
+        with patch.object(scale, "run", wraps=scale.run) as jit_run:
+            launcher.default_launcher(
+                scale, (1,), x, out, 2.5, 32, num_warps=4, num_stages=1
+            )
+        self.assertEqual(jit_run.call_count, 1)
+        torch.testing.assert_close(out[:32], x[:32] * 2.5)
+
+    def test_warmup_never_prepares_or_launches(self) -> None:
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def fill(out, block: tl.constexpr):
+            offsets = tl.arange(0, block)
+            tl.store(out + offsets, 1.0)
+
+        out = torch.zeros(64, device=DEVICE)
+        for _ in range(2):
+            launcher.default_launcher(
+                fill,
+                (1,),
+                out,
+                64,
+                num_warps=4,
+                num_stages=1,
+                warmup=True,
+            )
+        torch.testing.assert_close(out, torch.zeros_like(out))
+        self.assertFalse(getattr(fill, "_helion_prepared_launches", None))
+
+    def test_global_mutation_preserves_triton_error(self) -> None:
+        import triton
+        import triton.language as tl
+
+        global _TRITON_PREPARED_GLOBAL
+        original = _TRITON_PREPARED_GLOBAL
+        _TRITON_PREPARED_GLOBAL = tl.constexpr(1)
+
+        @triton.jit
+        def add_global(x, out, block: tl.constexpr):
+            offsets = tl.arange(0, block)
+            tl.store(
+                out + offsets,
+                tl.load(x + offsets) + _TRITON_PREPARED_GLOBAL,
+            )
+
+        x = torch.randn(64, device=DEVICE)
+        out = torch.empty_like(x)
+        try:
+            launcher.default_launcher(
+                add_global, (1,), x, out, 64, num_warps=4, num_stages=1
+            )
+            _TRITON_PREPARED_GLOBAL = tl.constexpr(2)
+            with self.assertRaisesRegex(RuntimeError, "Global variable"):
+                launcher.default_launcher(
+                    add_global, (1,), x, out, 64, num_warps=4, num_stages=1
+                )
+        finally:
+            _TRITON_PREPARED_GLOBAL = original
+
+    def test_helion_default_and_keyword_args_share_prepared_layers(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64], num_warps=4, num_stages=1),
+        )
+        def scale(x: torch.Tensor, value: float = 2.0) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] * value
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(scale(x), x * 2.0)
+        jit_fn = _get_triton_jit_function(scale)
+        other = torch.randn_like(x)
+        with (
+            patch.object(
+                scale,
+                "_fast_dispatch_key",
+                side_effect=AssertionError("omitted default rebuilt dispatch key"),
+            ),
+            patch.object(
+                jit_fn,
+                "run",
+                side_effect=AssertionError("omitted default called JITFunction.run"),
+            ),
+        ):
+            torch.testing.assert_close(scale(other), other * 2.0)
+
+        torch.testing.assert_close(scale(other, 2.0), other * 2.0)
+        with (
+            patch.object(
+                scale,
+                "_fast_dispatch_key",
+                side_effect=AssertionError("keyword call rebuilt dispatch key"),
+            ),
+            patch.object(
+                jit_fn,
+                "run",
+                side_effect=AssertionError("keyword call called JITFunction.run"),
+            ),
+        ):
+            torch.testing.assert_close(scale(x=other, value=3.0), other * 3.0)
+
+    def test_pre_run_hook_added_after_prepare_fires(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        jit_fn = _get_triton_jit_function(add_one)
+        calls: list[tuple[object, ...]] = []
+
+        def hook(*args: object, **_kwargs: object) -> None:
+            calls.append(args)
+
+        jit_fn.pre_run_hooks.append(hook)
+        try:
+            torch.testing.assert_close(add_one(x), x + 1)
+        finally:
+            jit_fn.pre_run_hooks.remove(hook)
+        self.assertEqual(len(calls), 1)
+
+    def test_launch_hooks_remain_live_on_prepared_path(self) -> None:
+        import triton
+
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        jit_fn = _get_triton_jit_function(add_one)
+        enter_calls: list[object] = []
+        exit_calls: list[object] = []
+
+        def enter(metadata: object) -> None:
+            enter_calls.append(metadata)
+
+        def exit_hook(metadata: object) -> None:
+            exit_calls.append(metadata)
+
+        triton.knobs.runtime.launch_enter_hook.add(enter)
+        triton.knobs.runtime.launch_exit_hook.add(exit_hook)
+        try:
+            with patch.object(
+                jit_fn,
+                "run",
+                side_effect=AssertionError("launch hook forced JITFunction.run"),
+            ):
+                torch.testing.assert_close(add_one(x), x + 1)
+        finally:
+            triton.knobs.runtime.launch_exit_hook.remove(exit_hook)
+            triton.knobs.runtime.launch_enter_hook.remove(enter)
+        self.assertEqual(len(enter_calls), 1)
+        self.assertEqual(len(exit_calls), 1)
+
+    def test_custom_launch_metadata_preserves_short_grid(self) -> None:
+        import triton
+        import triton.language as tl
+
+        observed_grids: list[tuple[int, ...]] = []
+
+        def metadata(
+            grid: tuple[int, ...], _metadata: object, _args: object
+        ) -> dict[str, object]:
+            observed_grids.append(grid)
+            return {}
+
+        @triton.jit(launch_metadata=metadata)
+        def copy(x, out, size: tl.constexpr):
+            offsets = tl.arange(0, size)
+            tl.store(out + offsets, tl.load(x + offsets))
+
+        def evaluate(metadata: object) -> None:
+            metadata.get()  # type: ignore[union-attr]
+
+        x = torch.randn(64, device=DEVICE)
+        out = torch.empty_like(x)
+        triton.knobs.runtime.launch_enter_hook.add(evaluate)
+        try:
+            for _ in range(2):
+                launcher.default_launcher(
+                    copy,
+                    (1,),
+                    x,
+                    out,
+                    64,
+                    num_warps=4,
+                    num_stages=1,
+                )
+        finally:
+            triton.knobs.runtime.launch_enter_hook.remove(evaluate)
+        torch.testing.assert_close(out, x)
+        self.assertEqual(observed_grids, [(1,), (1,)])
+        self.assertFalse(getattr(copy, "_helion_prepared_launches", None))
+
+    def test_prepared_launch_uses_current_stream(self) -> None:
+        add_one = _make_add_one()
+        x = torch.zeros(64, device=DEVICE)
+        add_one(x)
+        jit_fn = _get_triton_jit_function(add_one)
+        stream = torch.cuda.Stream()
+        with (
+            patch.object(
+                jit_fn,
+                "run",
+                side_effect=AssertionError("prepared launch called JITFunction.run"),
+            ),
+            torch.cuda.stream(stream),
+        ):
+            x.fill_(3)
+            out = add_one(x)
+        stream.synchronize()
+        torch.testing.assert_close(out, torch.full_like(out, 4))
+
+    def test_self_removing_hook_does_not_prepare_that_call(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        jit_fn = _get_triton_jit_function(add_one)
+        jit_fn.__dict__.pop("_helion_prepared_launches", None)
+        calls = 0
+
+        def remove_self(*_args: object, **_kwargs: object) -> None:
+            nonlocal calls
+            calls += 1
+            jit_fn.pre_run_hooks.remove(remove_self)
+
+        jit_fn.pre_run_hooks.append(remove_self)
+        torch.testing.assert_close(add_one(x), x + 1)
+        self.assertEqual(calls, 1)
+        self.assertFalse(getattr(jit_fn, "_helion_prepared_launches", None))
+
+        torch.testing.assert_close(add_one(x), x + 1)
+        self.assertTrue(jit_fn._helion_prepared_launches)  # type: ignore[attr-defined]
+
+    def test_defaulted_jit_parameter_uses_slow_launcher(self) -> None:
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def add_one(
+            x,
+            out,
+            block: tl.constexpr = 64,  # pyrefly: ignore [bad-function-definition]
+        ):
+            offsets = tl.arange(0, block)
+            tl.store(out + offsets, tl.load(x + offsets) + 1)
+
+        x = torch.randn(64, device=DEVICE)
+        out = torch.empty_like(x)
+        for _ in range(2):
+            launcher.default_launcher(
+                add_one,
+                (1,),
+                x,
+                out,
+                num_warps=4,
+                num_stages=1,
+            )
+        torch.testing.assert_close(out, x + 1)
+        self.assertFalse(getattr(add_one, "_helion_prepared_launches", None))
+
+
+@onlyBackends(["triton"])
+@unittest.skipUnless(torch.version.hip is not None, "requires ROCm")
+class TestPreparedTritonLauncherRocm(RefEagerTestDisabled, TestCase):
+    def test_matching_storage_specialization_reuses_prepared_launch(self) -> None:
+        add_one = _make_add_one()
+        first = torch.randn(16, device=DEVICE)
+        torch.testing.assert_close(add_one(first), first + 1)
+        jit_fn = _get_triton_jit_function(add_one)
+
+        same_shape = torch.randn(32, device=DEVICE)[:16]
+        with patch.object(
+            jit_fn,
+            "run",
+            side_effect=AssertionError("matching HIP specialization used slow path"),
+        ):
+            out = add_one(same_shape)
+        torch.testing.assert_close(out, same_shape + 1)
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()


### PR DESCRIPTION
Stacked PRs:
 * #3323
 * __->__#3322
 * #3321


--- --- ---

### triton: cache resolved native launches safely


Teach the dependency-free Triton launcher to cache a guarded resolved CompiledKernel runner after the normal JITFunction.run path. Reuse requires the same native specialization, live device-cache membership, grid and options, globals, hooks and debug state, and compatible runtime context; every mismatch falls back to Triton.

Warmup and runtime-only launch options never prepare. The bounded cache is invalidated whenever Helion clears the corresponding Triton device cache.

Tests cover native scalar and tensor specialization, CUDA and ROCm integration, warmup, globals and hooks, current-stream launches, option and grid guards, cache invalidation, and safe fallback behavior.
