### PR TITLE
aot: share the dependency-free runtime launcher

### DIFF
--- a/helion/_compiler/output_code_utils.py
+++ b/helion/_compiler/output_code_utils.py
@@ -184,6 +184,13 @@ def _runtime_shim_statements(info: LauncherInfo) -> list[ast.stmt]:
     return module.body
 
 
+def dependency_free_runtime_source(info: LauncherInfo) -> str:
+    """Render the canonical dependency-free runtime shim as module source."""
+    module = ast.Module(body=_runtime_shim_statements(info), type_ignores=[])
+    ast.fix_missing_locations(module)
+    return ast.unparse(module)
+
+
 def _is_future_import(node: ast.stmt) -> bool:
     """True for a ``from __future__ import ...`` statement."""
     return isinstance(node, ast.ImportFrom) and node.module == "__future__"

--- a/helion/autotuner/aot_compile.py
+++ b/helion/autotuner/aot_compile.py
@@ -16,76 +16,15 @@ Writes ``<source>_<kernel>_standalone.py`` next to each kernel source file.
 
 from __future__ import annotations
 
+import ast
 import logging
 from pathlib import Path
 import re
 
+from .._compiler.output_code_utils import _check_kernel_name_not_shadowed
+from .._compiler.output_code_utils import dependency_free_runtime_source
+
 log: logging.Logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Helion runtime helpers inlined into standalone output
-# ---------------------------------------------------------------------------
-
-_INLINED_LAUNCHER = """
-def _default_launcher(
-    triton_kernel,
-    grid,
-    *args,
-    num_warps,
-    num_stages,
-    launch_cooperative_grid=False,
-    **kwargs,
-):
-    return triton_kernel.run(
-        *args,
-        grid=grid,
-        warmup=False,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        launch_cooperative_grid=launch_cooperative_grid,
-        **kwargs,
-    )
-"""
-
-_INLINED_GET_NUM_SM = """
-def _get_num_sm(device, reserved_sms=0):
-    if device.type == "cuda":
-        available = torch.cuda.get_device_properties(device.index).multi_processor_count
-    elif device.type == "xpu":
-        available = torch.xpu.get_device_properties(device.index).gpu_subslice_count
-    else:
-        raise NotImplementedError(f"_get_num_sm not implemented for {device.type}")
-    if reserved_sms <= 0:
-        return available
-    return max(available - reserved_sms, 1)
-"""
-
-_INLINED_GET_NUM_XCD = """
-_CUS_PER_XCD = {"gfx942": 38, "gfx950": 32, "gfx951": 32}
-
-
-def _get_num_xcd(device=None):
-    if not torch.cuda.is_available():
-        return 1
-    try:
-        props = torch.cuda.get_device_properties(
-            device if device is not None else torch.cuda.current_device()
-        )
-    except Exception:
-        return 1
-    arch = getattr(props, "gcnArchName", None)
-    if not arch:
-        return 1
-    cus_per_xcd = _CUS_PER_XCD.get(arch.split(":")[0])
-    if cus_per_xcd is None:
-        return 1
-    cu = props.multi_processor_count
-    n = round(cu / cus_per_xcd)
-    if n < 1 or abs(n * cus_per_xcd - cu) > cus_per_xcd // 4:
-        return 1
-    return n
-"""
 
 
 # ---------------------------------------------------------------------------
@@ -110,10 +49,27 @@ def _split_imports_and_body(code: str) -> tuple[list[str], str]:
     return imports, "\n".join(lines[body_start:])
 
 
-def _replace_helion_deps(body: str) -> str:
-    """Replace inlined Helion runtime helpers with their standalone versions."""
-    body = body.replace("helion.runtime.get_num_sm(", "_get_num_sm(")
-    return body.replace("helion.runtime.get_num_xcd(", "_get_num_xcd(")
+def _is_supported_helion_import(import_line: str) -> bool:
+    """Whether an import matches the generated Triton wrapper contract."""
+    return import_line in {
+        "import helion",
+        "from helion.runtime import default_launcher as _default_launcher",
+    }
+
+
+def _runtime_references(body: str) -> set[str]:
+    """Collect direct ``helion.runtime.<name>`` references from generated code."""
+    result: set[str] = set()
+    for node in ast.walk(ast.parse(body)):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "runtime"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "helion"
+        ):
+            result.add(node.attr)
+    return result
 
 
 def _rename_config_symbols(body: str, kernel_name: str, config_idx: int) -> str:
@@ -245,24 +201,42 @@ def generate_standalone_file(
     # -- collect imports & bodies -------------------------------------------
     all_imports: set[str] = set()
     bodies: list[str] = []
-    needs_launcher = False
-    needs_get_num_sm = False
-    needs_get_num_xcd = False
+    needs_runtime = False
+    runtime_source: str | None = None
+    runtime_references: set[str] = set()
 
     for i, code in enumerate(triton_codes):
         imports, body = _split_imports_and_body(code)
         for imp in imports:
             if "helion" in imp:
+                if not _is_supported_helion_import(imp):
+                    raise ValueError(
+                        f"unsupported Helion import in standalone AOT input: {imp!r}"
+                    )
                 if "default_launcher" in imp:
-                    needs_launcher = True
+                    needs_runtime = True
                 continue
             all_imports.add(imp)
-        if "helion.runtime.get_num_sm(" in body:
-            needs_get_num_sm = True
-        if "helion.runtime.get_num_xcd(" in body:
-            needs_get_num_xcd = True
-        body = _replace_helion_deps(body)
+        references = _runtime_references(body)
+        runtime_references.update(references)
+        needs_runtime = needs_runtime or bool(references)
         bodies.append(_rename_config_symbols(body, kernel_name, i))
+
+    if needs_runtime:
+        from .._compiler.triton.backend import TritonBackend
+
+        launcher_info = TritonBackend().dependency_free_launcher_info
+        supported_runtime_names = {
+            launcher_info.launcher_symbol,
+            *launcher_info.runtime_helper_names,
+        }
+        if unknown := runtime_references - supported_runtime_names:
+            raise ValueError(
+                "unsupported Helion runtime helper in standalone AOT input: "
+                f"{', '.join(sorted(unknown))}"
+            )
+        runtime_source = dependency_free_runtime_source(launcher_info)
+        all_imports.add("import types")
 
     # -- assemble -----------------------------------------------------------
     parts: list[str] = [
@@ -276,12 +250,8 @@ def generate_standalone_file(
             parts.append(imp)
     parts.append("")
 
-    if needs_launcher:
-        parts.append(_INLINED_LAUNCHER)
-    if needs_get_num_sm:
-        parts.append(_INLINED_GET_NUM_SM)
-    if needs_get_num_xcd:
-        parts.append(_INLINED_GET_NUM_XCD)
+    if runtime_source is not None:
+        parts.append(runtime_source)
 
     sep = "=" * 65
     for i, body in enumerate(bodies):
@@ -304,6 +274,7 @@ def generate_standalone_file(
     parts.extend([f"    ][{select_expr}](*args, **kwargs)", ""])
 
     content = "\n".join(parts)
+    _check_kernel_name_not_shadowed(ast.parse(content), [], kernel_name)
 
     # -- write --------------------------------------------------------------
     if kernel_source_file is not None:

--- a/test/test_amd_cdna.py
+++ b/test/test_amd_cdna.py
@@ -341,7 +341,6 @@ class TestXCDRemapCodegen(TestCase):
     @skipUnlessMultiXCD("Requires a multi-XCD AMD CDNA GPU")
     def test_aot_standalone_inlines_get_num_xcd(self) -> None:
         # AOT standalone output must inline get_num_xcd (no Helion runtime dep).
-        import ast
         from pathlib import Path
         import tempfile
 
@@ -354,9 +353,10 @@ class TestXCDRemapCodegen(TestCase):
         self.assertIn("helion.runtime.get_num_xcd(", code)
         out = generate_standalone_file("add", [code], "", Path(tempfile.mkdtemp()))
         txt = out.read_text()
-        self.assertIn("def _get_num_xcd", txt)
-        self.assertNotIn("helion.runtime.get_num_xcd(", txt)
-        ast.parse(txt)
+        self.assertIn("get_num_xcd=get_num_xcd", txt)
+        self.assertIn("helion.runtime.get_num_xcd(", txt)
+        self.assertNotIn("import helion", txt)
+        self.assertNotIn("from helion", txt)
 
     @skipUnlessMultiXCD("Requires a multi-XCD AMD CDNA GPU")
     def test_direct_configspec_derives_num_sm(self) -> None:

--- a/test/test_aot_compile.py
+++ b/test/test_aot_compile.py
@@ -1,0 +1,150 @@
+"""Tests for canonical runtime embedding in autotuner AOT output."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+from unittest.mock import patch
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import onlyBackends
+from helion._testing import skipIfNotCUDA
+from helion.autotuner.aot_compile import generate_standalone_file
+import helion.language as hl
+
+
+def _synthetic_code(kernel_name: str = "add") -> str:
+    return f"""from helion.runtime import default_launcher as _default_launcher
+import torch
+
+def _helion_{kernel_name}():
+    pass
+
+def {kernel_name}(x):
+    helion.runtime.set_triton_allocator()
+    helion.runtime.get_num_sm(x)
+    helion.runtime.get_num_xcd(x)
+    return _default_launcher
+"""
+
+
+@onlyBackends(["triton"])
+class TestAOTRuntimeEmbedding(TestCase):
+    def test_invalid_runtime_contract_is_rejected(self) -> None:
+        cases = (
+            (
+                "alias",
+                "add",
+                _synthetic_code().replace("as _default_launcher", "as launch"),
+                "unsupported Helion import",
+            ),
+            (
+                "helper",
+                "add",
+                _synthetic_code().replace("get_num_xcd", "unknown_helper"),
+                "unsupported Helion runtime helper",
+            ),
+            ("collision", "helion", _synthetic_code("helion"), "collides"),
+        )
+        for name, kernel_name, code, error in cases:
+            with (
+                self.subTest(name=name),
+                tempfile.TemporaryDirectory() as tmp,
+                self.assertRaisesRegex(ValueError, error),
+            ):
+                generate_standalone_file(
+                    kernel_name,
+                    [code],
+                    "",
+                    Path(tmp),
+                )
+
+
+@helion.kernel(
+    static_shapes=True,
+    config=helion.Config(block_sizes=[64], num_warps=4, num_stages=1),
+)
+def _aot_add_one(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + 1
+    return out
+
+
+@onlyBackends(["triton"])
+@skipIfNotCUDA()
+class TestAOTPreparedLauncher(RefEagerTestDisabled, TestCase):
+    def test_multiple_configs_share_and_execute_canonical_runtime(self) -> None:
+        heuristic = "def key_add(*args):\n    return 0\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = generate_standalone_file(
+                "add",
+                [_synthetic_code(), _synthetic_code()],
+                heuristic,
+                Path(tmp),
+            )
+            source = path.read_text()
+            self.assertEqual(source.count("def _make_helion_runtime"), 1)
+            self.assertEqual(source.count("def default_launcher("), 1)
+            self.assertNotIn("import helion", source)
+            self.assertNotIn("from helion", source)
+
+            name = "_helion_aot_runtime_test"
+            spec = importlib.util.spec_from_file_location(name, path)
+            assert spec is not None and spec.loader is not None
+            module = importlib.util.module_from_spec(spec)
+            with patch.dict(sys.modules, {name: module}):
+                spec.loader.exec_module(module)
+                self.assertIs(
+                    module.add(torch.device(DEVICE)), module._default_launcher
+                )
+
+    def test_generated_aot_uses_prepared_launcher(self) -> None:
+        x = torch.randn(64, device=DEVICE)
+        bound = _aot_add_one.bind((x,))
+        code = bound.to_triton_code()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = generate_standalone_file(
+                "_aot_add_one",
+                [code],
+                "",
+                Path(tmp),
+            )
+            source = path.read_text()
+            self.assertNotIn("import helion", source)
+            self.assertNotIn("from helion", source)
+
+            name = "_helion_aot_prepared_test"
+            spec = importlib.util.spec_from_file_location(name, path)
+            assert spec is not None and spec.loader is not None
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+            try:
+                spec.loader.exec_module(module)
+                first = module._aot_add_one(x)
+                torch.testing.assert_close(first, x + 1)
+                jit_fn = module._helion__aot_add_one_c0
+
+                other = torch.randn_like(x)
+                with patch.object(
+                    jit_fn,
+                    "run",
+                    side_effect=AssertionError("AOT repeated JITFunction.run"),
+                ):
+                    second = module._aot_add_one(other)
+                torch.testing.assert_close(second, other + 1)
+            finally:
+                sys.modules.pop(name, None)
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests()


### PR DESCRIPTION
Stacked PRs:
 * __->__#3323
 * #3322
 * #3321


--- --- ---

### aot: share the dependency-free runtime launcher


Make standalone AOT export embed the same dependency-free Triton launcher and runtime-helper shim used by generated in-process code, once per output file. Validate canonical generated Helion imports and runtime references, rejecting contracts that the exporter cannot safely rewrite.

Standalone kernels therefore gain prepared-launch behavior without retaining a Helion runtime dependency, while multi-config exports share one runtime and keep their generated symbols isolated.

Tests execute the shared multi-config shim, reject unsupported aliases and helpers, preserve kernel-name collision checks, and verify that a real generated AOT kernel bypasses JITFunction.run after preparation.
