### PR TITLE
Support tensor value assignment in subscript indexing

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -2914,6 +2914,13 @@ class WalkDeviceAST(NodeVisitor):
             )
             raise exc.DeviceTensorSubscriptAssignmentNotAllowed(var_name)
         val = self.visit(node.value)
+        if (
+            isinstance(rhs_type, TensorType)
+            and rhs_type.origin.is_host()
+            and not isinstance(node.value, ast.Subscript)
+        ):
+            full_slices = [slice(None)] * rhs_type.fake_value.ndim
+            val = hl.load(val, full_slices)
         self._assign_subscript(target, val)
 
     def _assign_subscript(self, target: ast.Subscript, val: object) -> None:

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -2919,7 +2919,8 @@ class WalkDeviceAST(NodeVisitor):
             and rhs_type.origin.is_host()
             and not isinstance(node.value, ast.Subscript)
         ):
-            full_slices = [slice(None)] * rhs_type.fake_value.ndim
+            full_slices: list[object] = [slice(None)] * rhs_type.fake_value.ndim
+            # pyrefly: ignore [bad-argument-type]
             val = hl.load(val, full_slices)
         self._assign_subscript(target, val)
 

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -789,14 +789,7 @@ class TypePropagation(ast.NodeVisitor):
                 "an index can only have a single ellipsis (...)"
             )
         idx = ellipsis_indices[0]
-        dims_consumed = sum(
-            1
-            for elt in sl.elts
-            if not (
-                isinstance(elt, ast.Constant)
-                and (elt.value is ... or elt.value is None)
-            )
-        )
+        dims_consumed = _count_dims_in_subscript(sl.elts)
         n_expand = ndim - dims_consumed
         if n_expand < 0:
             raise exc.TypeInferenceError(
@@ -811,11 +804,7 @@ class TypePropagation(ast.NodeVisitor):
     def _pad_trailing_dims(self, node: ast.Subscript, ndim: int) -> None:
         sl = node.slice
         if isinstance(sl, ast.Tuple):
-            consumed = sum(
-                1
-                for elt in sl.elts
-                if not (isinstance(elt, ast.Constant) and elt.value is None)
-            )
+            consumed = _count_dims_in_subscript(sl.elts)
             missing = ndim - consumed
             if missing > 0:
                 sl.elts.extend(
@@ -823,7 +812,18 @@ class TypePropagation(ast.NodeVisitor):
                     for _ in range(missing)
                 )
         elif not isinstance(sl, ast.Slice):
-            missing = ndim - 1
+            slice_type = self.visit(sl)
+            if isinstance(slice_type, SequenceType):
+                consumed = sum(
+                    1
+                    for t in slice_type.element_types
+                    if not (isinstance(t, LiteralType) and t.value is None)
+                )
+            elif isinstance(slice_type, LiteralType) and slice_type.value is None:
+                consumed = 0
+            else:
+                consumed = 1
+            missing = ndim - consumed
             if missing > 0:
                 elts = [sl] + [
                     create(ast.Slice, lower=None, upper=None, step=None)
@@ -1218,6 +1218,16 @@ class TypePropagation(ast.NodeVisitor):
     visit_MatchAs: _VisitMethod = _not_supported
     # pyrefly: ignore [bad-assignment, bad-param-name-override, bad-override-mutable-attribute]
     visit_MatchOr: _VisitMethod = _not_supported
+
+
+def _count_dims_in_subscript(elts: list[ast.expr]) -> int:
+    return sum(
+        1
+        for elt in elts
+        if not (
+            isinstance(elt, ast.Constant) and (elt.value is ... or elt.value is None)
+        )
+    )
 
 
 def _is_barrier_stmt(statement: ast.stmt) -> bool:

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -761,6 +761,7 @@ class TypePropagation(ast.NodeVisitor):
         # ellipsis expansion not yet supported for StackTensorType.
         if isinstance(value_type, TensorType):
             self._expand_ellipsis_in_subscript(node, value_type.fake_value.ndim)
+            self._pad_trailing_dims(node, value_type.fake_value.ndim)
         slice_type = self.visit(node.slice)
         return value_type.propagate_getitem(slice_type, self.origin())
 
@@ -806,6 +807,29 @@ class TypePropagation(ast.NodeVisitor):
             for _ in range(n_expand)
         ]
         sl.elts[idx : idx + 1] = slices
+
+    def _pad_trailing_dims(self, node: ast.Subscript, ndim: int) -> None:
+        sl = node.slice
+        if isinstance(sl, ast.Tuple):
+            consumed = sum(
+                1
+                for elt in sl.elts
+                if not (isinstance(elt, ast.Constant) and elt.value is None)
+            )
+            missing = ndim - consumed
+            if missing > 0:
+                sl.elts.extend(
+                    create(ast.Slice, lower=None, upper=None, step=None)
+                    for _ in range(missing)
+                )
+        elif not isinstance(sl, ast.Slice):
+            missing = ndim - 1
+            if missing > 0:
+                elts = [sl] + [
+                    create(ast.Slice, lower=None, upper=None, step=None)
+                    for _ in range(missing)
+                ]
+                node.slice = create(ast.Tuple, elts=elts, ctx=ast.Load())
 
     def visit_Slice(self, node: ast.Slice) -> TypeInfo:
         lower = (

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -206,24 +206,6 @@ class TestErrors(RefEagerTestDisabled, TestCase):
                 (torch.randn(4, 8, 16, device=DEVICE),),
             )
 
-    def test_rank_mismatch_indexing(self):
-        """Test that RankMismatch shows tensor shapes in indexing errors."""
-
-        @helion.kernel()
-        def fn(x: torch.Tensor) -> torch.Tensor:
-            batch = x.size(0)
-            out = x.new_empty(batch)
-            for tile_batch in hl.tile([batch]):
-                scalar_val = x[tile_batch].sum()  # 1d index for 2d tensor
-                out = scalar_val
-            return out
-
-        with self.assertRaisesRegex(
-            helion.exc.RankMismatch,
-            r"Expected ndim=2, but got ndim=1.*You have too few indices",
-        ):
-            code_and_output(fn, (torch.randn(4, 8, device=DEVICE),))
-
     def test_rank_mismatch_indexing_too_many(self):
         @helion.kernel()
         def fn(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -2057,6 +2057,24 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src_result, expected_src)
         torch.testing.assert_close(dst_result, expected_dst)
 
+    def test_tensor_value_3d(self):
+
+        @helion.kernel(autotune_effort="none")
+        def kernel(dst: torch.Tensor, val: torch.Tensor) -> torch.Tensor:
+            N = dst.shape[0]
+            for i in hl.grid(N):
+                dst[i] = val
+            return dst
+
+        N = 8
+        dst = torch.zeros([N, 3, 4], device=DEVICE)
+        val = torch.ones([3, 4], device=DEVICE)
+
+        result = kernel(dst, val)
+
+        expected = val.expand(N, -1, -1)
+        torch.testing.assert_close(result, expected)
+
     def test_slice_to_slice(self):
         """buf[:] = zeros[:] - Full slice to slice assignment"""
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -2031,9 +2031,6 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src_result, expected_src)
         torch.testing.assert_close(dst_result, expected_dst)
 
-    @skipIfNormalMode(
-        "RankMismatch: Expected ndim=2, but got ndim=1 - tensor value assignment shape mismatch"
-    )
     def test_tensor_value(self):
         """Test both setter from tensor value and getter for [i]"""
 


### PR DESCRIPTION
### Summary:

- Pad missing trailing dimensions with full slices (eg: `x[i] -> x[i, :]` on 2D tensors)
- Unskip `test_tensor_value`  in test_indexing.py
