### PR TITLE
[Pallas] Support in-place outputs from Pallas pure-Jax exports (jax_fn=True)

### DIFF
--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1599,13 +1599,12 @@ class PallasBackend(Backend):
 
 # Launcher kwargs that mark a kernel using a Pallas feature the pure-JAX
 # module doesn't emit yet (scratch/VMEM buffers, HBM pass-through, SMEM,
-# dynamic-shape padding, in-place aliasing, compact-worklist, matmul dot_general).
+# dynamic-shape padding, compact-worklist, matmul dot_general).
 _JAX_UNSUPPORTED_KWARGS = (
     "_scratch_shapes",
     "_hbm_arg_indices",
     "_smem_arg_indices",
     "_ds_pad_dims",
-    "_inplace_indices",
     "_compact_build_worklist",
     "_matmul_dot_general",
 )
@@ -1626,6 +1625,7 @@ class JaxLaunchMeta:
     kernel_name: str
     grid_exprs: list[str]
     output_indices: list[int]
+    inplace_indices: list[int]
     user_positions: list[int]
     const_slots: dict[int, str]
     block_spec_info: list[Any]
@@ -1815,9 +1815,10 @@ def capture_jax_launch_metadata(
     ``inputs[i].shape[d]`` expressions rather than baked sample constants. The AST
     builder (:func:`build_jax_fn_ast`) turns this into the emitted entrypoint.
 
-    Kernels using advanced Pallas features (scratch/pipeline/SMEM/ds-pad/in-place/
-    compact-worklist/matmul-dot-general) or int64/uint64/float64 args are not
-    supported yet and raise ``NotImplementedError``.
+    Kernels using unsupported advanced Pallas features (scratch/pipeline/SMEM,
+    dynamic-shape padding, compact-worklist, or matmul-dot-general) or
+    int64/uint64/float64 args raise ``NotImplementedError``. Caller-owned in-place
+    aliases are captured as static launch metadata.
 
     Must be called *outside* the fake-tensor env (the capture materializes and runs
     on real tensors).
@@ -1845,19 +1846,30 @@ def capture_jax_launch_metadata(
     # that records its arguments instead of executing the kernel.
     captured: dict[str, Any] = {}
 
+    def _launcher_return(
+        launch_args: tuple[object, ...], kw: dict[str, object]
+    ) -> object:
+        output_indices = cast("list[int]", kw.get("_output_indices") or [])
+        inplace_indices = set(cast("list[int]", kw.get("_inplace_indices") or []))
+        output_only_indices = [
+            index for index in output_indices if index not in inplace_indices
+        ]
+        if len(output_only_indices) > 1:
+            return tuple(launch_args[index] for index in output_only_indices)
+        if output_only_indices:
+            return launch_args[output_only_indices[0]]
+        return None
+
     def _capture(
         pallas_kernel: object, grid: object, *launch_args: object, **kw: object
     ) -> object:
         captured["grid"] = tuple(int(g) for g in cast("Any", grid))
         captured["args"] = launch_args
         captured["kwargs"] = kw
-        out_indices = cast("list[int]", kw.get("_output_indices") or [])
-        # Mirror the real launcher's return convention so the host wrapper's
-        # ``a, b = _launcher(...)`` unpack (multi-output kernels) succeeds: a
-        # tuple for >1 outputs, the bare tensor for one, None for zero.
-        if len(out_indices) > 1:
-            return tuple(launch_args[i] for i in out_indices)
-        return launch_args[out_indices[0]] if out_indices else None
+        # The real launcher returns only output-only tensors. In-place aliases
+        # are updated through their caller-owned arguments and the host wrapper
+        # reads those arguments directly when they are part of the user return.
+        return _launcher_return(launch_args, kw)
 
     compiled(*args, _launcher=_capture)
 
@@ -1885,14 +1897,24 @@ def capture_jax_launch_metadata(
                 f"to_code(jax_fn=True) does not support {a.dtype} tensors "
                 "(unsupported on TPU / narrowed by JAX x32)"
             )
-    # The host wrapper passes the kernel's own arguments first, then the values it
-    # creates itself: output buffers, lifted module-scalar constants (e.g.
-    # ``torch.tensor([_NEG])``), specialization scalars (e.g. a reduction dim size
-    # as a plain int), and shape-derived scalars (e.g. a reduction's row-count
-    # ``torch.tensor([t])``). The standalone entrypoint takes only the user inputs;
-    # every other launch arg is reconstructed inline.
-    n_user = len(args)
-    user_positions = [p for p in range(n_user) if p not in output_indices]
+    # The host wrapper may interleave its own output buffers with the kernel's user
+    # arguments, so recover user launch slots by identity instead of assuming the
+    # first ``len(args)`` positions correspond one-for-one. The standalone takes
+    # only user tensor inputs; wrapper-created buffers/constants are reconstructed.
+    user_positions: list[int] = []
+    for user_index, user_arg in enumerate(args):
+        if not isinstance(user_arg, torch.Tensor):
+            continue
+        position = next(
+            (p for p, launch_arg in enumerate(launch_args) if launch_arg is user_arg),
+            None,
+        )
+        if position is None:
+            raise NotImplementedError(
+                "to_code(jax_fn=True) cannot map user tensor input "
+                f"{user_index} to a Pallas launch argument"
+            )
+        user_positions.append(position)
     const_positions = [
         p
         for p in range(len(launch_args))
@@ -1933,10 +1955,7 @@ def capture_jax_launch_metadata(
         def _probe(pk: object, grid: object, *pa: object, **pkw: object) -> object:
             probe_cap["grid"] = tuple(int(g) for g in cast("Any", grid))
             probe_cap["args"] = pa
-            poi = cast("list[int]", pkw.get("_output_indices") or [])
-            if len(poi) > 1:
-                return tuple(pa[i] for i in poi)
-            return pa[poi[0]] if poi else None
+            return _launcher_return(pa, pkw)
 
         probe_args = _scaled_probe_args(args, dim_factor)
         compiled(*probe_args, _launcher=_probe)
@@ -1968,10 +1987,22 @@ def capture_jax_launch_metadata(
         for p in const_positions
     }
 
+    inplace_indices = list(cast("list[int] | None", kw.get("_inplace_indices")) or [])
+    wrapper_created_inplace = [
+        position for position in inplace_indices if position not in user_positions
+    ]
+    if wrapper_created_inplace:
+        raise NotImplementedError(
+            "to_code(jax_fn=True) cannot reconstruct wrapper-created in-place "
+            f"outputs at launch positions {wrapper_created_inplace}; pass the "
+            "initialized destination as a kernel input"
+        )
+
     return JaxLaunchMeta(
         kernel_name=kernel.name,
         grid_exprs=grid_exprs,
         output_indices=output_indices,
+        inplace_indices=inplace_indices,
         user_positions=user_positions,
         const_slots=const_slots,
         block_spec_info=cast("list[Any]", block_spec_info),
@@ -2163,6 +2194,7 @@ def build_jax_fn_ast(
     meta_nodes: list[ast.stmt] = [
         ast.parse(f"_BLOCK_SPEC_INFO = {meta.block_spec_info!r}").body[0],
         ast.parse(f"_OUTPUT_INDICES = {meta.output_indices!r}").body[0],
+        ast.parse(f"_INPLACE_INDICES = {meta.inplace_indices!r}").body[0],
         ast.parse(f"_USER_POSITIONS = {meta.user_positions!r}").body[0],
         ast.parse(f"_INTERPRET = {meta.interpret!r}").body[0],
         ast.parse(f"_N_ARGS = {meta.n_args}").body[0],
@@ -2183,10 +2215,12 @@ def _jax_entrypoint_source(meta: JaxLaunchMeta, device_kernel: str) -> str:
     ``inputs[i].shape[d]`` (see the two-probe in ``capture_jax_launch_metadata``), so
     a single standalone is correct at every dynamic shape -- then drives
     ``_pallas_jax_call``."""
+    user_position_set = set(meta.user_positions)
     out_lines = [
         f"    slots[{pos}] = jnp.empty("
         f"({', '.join(meta.out_shape_exprs[oi])},), {meta.out_dtypes[oi]})"
         for oi, pos in enumerate(meta.output_indices)
+        if pos not in user_position_set
     ]
     const_lines = [
         f"    slots[{p}] = {expr}" for p, expr in sorted(meta.const_slots.items())
@@ -2206,7 +2240,7 @@ def _jax_entrypoint_source(meta: JaxLaunchMeta, device_kernel: str) -> str:
         f'    """{doc}"""',
         f"    _grid = ({', '.join(meta.grid_exprs)},)",
         "    slots = [None] * _N_ARGS",
-        "    for pos, inp in zip(_USER_POSITIONS, inputs):",
+        "    for pos, inp in zip(_USER_POSITIONS, inputs, strict=True):",
         "        slots[pos] = inp",
         *out_lines,
         *const_lines,
@@ -2215,7 +2249,7 @@ def _jax_entrypoint_source(meta: JaxLaunchMeta, device_kernel: str) -> str:
         "        _grid,",
         "        tuple(slots),",
         "        output_indices=_OUTPUT_INDICES,",
-        "        inplace_indices=[],",
+        "        inplace_indices=_INPLACE_INDICES,",
         "        block_spec_info=_BLOCK_SPEC_INFO,",
         "        scratch_shapes=None,",
         "        hbm_arg_indices=None,",

--- a/helion/runtime/pallas/jax_export.py
+++ b/helion/runtime/pallas/jax_export.py
@@ -303,6 +303,8 @@ def default_pallas_jax_launcher(
     )
 
     output_indices = _output_indices if _output_indices is not None else []
+    inplace_indices = set(_inplace_indices or [])
+    wrapper_args = args
 
     # Capture original shapes BEFORE padding so output-only tensors can
     # be sliced back after the pallas_call.  ``_pallas_apply_ds_padding``
@@ -370,11 +372,26 @@ def default_pallas_jax_launcher(
         compact=compact,
         orig_shapes=orig_shapes,
         ds_pad_dims=_ds_pad_dims,
+        return_all_outputs=True,
     )
 
-    if len(output_results) == 1:
-        return _JaxExportTensor.from_jax(output_results[0], device=device)
-    return tuple(_JaxExportTensor.from_jax(r, device=device) for r in output_results)
+    for output_result, arg_index in zip(output_results, output_indices, strict=True):
+        if arg_index not in inplace_indices:
+            continue
+        adapter = wrapper_args[arg_index]
+        assert isinstance(adapter, _JaxExportTensor)
+        adapter._jax_arr = output_result
+
+    returned_results = [
+        output_result
+        for output_result, arg_index in zip(output_results, output_indices, strict=True)
+        if arg_index not in inplace_indices
+    ]
+    if not returned_results:
+        returned_results = output_results
+    if len(returned_results) == 1:
+        return _JaxExportTensor.from_jax(returned_results[0], device=device)
+    return tuple(_JaxExportTensor.from_jax(r, device=device) for r in returned_results)
 
 
 def make_jax_fn(kernel: Kernel) -> Callable[..., Any]:

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -1823,6 +1823,7 @@ def _pallas_jax_call(
     compact: dict[str, object] | None = None,
     orig_shapes: dict[int, tuple[int, ...]] | None = None,
     ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
+    return_all_outputs: bool = False,
 ) -> list[object]:
     """Drive the shared compile core (``pl.kernel``) + jit_fn on raw ``jax.Array``s
     and return the output JAX array(s).
@@ -1868,10 +1869,12 @@ def _pallas_jax_call(
     # In-place positions alias back into the caller's buffer on the torch path,
     # but JAX has no in-place mutation -- when every output is in-place, surface
     # them as fresh values (mirrors the torch fast-path descriptor list).
-    descriptors = _pallas_output_only_descriptors(
-        output_indices, result.arg_to_tensor_pos
-    )
-    if not descriptors:
+    descriptors = ()
+    if not return_all_outputs:
+        descriptors = _pallas_output_only_descriptors(
+            output_indices, result.arg_to_tensor_pos
+        )
+    if return_all_outputs or not descriptors:
         descriptors = tuple(enumerate(output_indices))
 
     output_results: list[object] = [jax_results[out_idx] for out_idx, _ in descriptors]

--- a/test/test_bound_kernel.py
+++ b/test/test_bound_kernel.py
@@ -336,6 +336,15 @@ def pallas_dynamic_row_sum(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_initialized_output(x: torch.Tensor) -> torch.Tensor:
+    """A wrapper-created initialized output cannot be rebuilt from launch metadata."""
+    out = torch.zeros_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] += x[tile]
+    return out
+
+
 def _pallas_to_code(
     kernel: Any, args: tuple[object, ...], options: helion.OutputCodeOptions
 ) -> str:
@@ -558,6 +567,13 @@ class TestToCodePallas(TestCase):
                     )
             finally:
                 sys.modules.pop(name, None)
+
+    def test_pallas_jax_fn_rejects_wrapper_created_inplace_output(self) -> None:
+        x = torch.zeros(128, device=DEVICE, dtype=torch.float32)
+        with self.assertRaisesRegex(
+            NotImplementedError, "wrapper-created in-place outputs"
+        ):
+            _pallas_to_code(pallas_initialized_output, (x,), _JAX)
 
     def test_jax_fn_with_helion_deps_imports_launcher(self) -> None:
         """``jax_fn`` is orthogonal to ``allow_helion_deps``: with deps allowed the

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -5808,6 +5808,64 @@ class TestPallasJaxFn(TestCase):
         ref = float(jnp.sum(ref_out))
         self.assertAlmostEqual(result, ref, places=2)
 
+    def test_jax_fn_rebinds_inplace_output(self) -> None:
+        """A mutated input must surface as a new JAX value after launch."""
+        jax, jnp = self._import_jax()
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[128, 128]),
+        )
+        def increment_inplace(x: torch.Tensor) -> torch.Tensor:
+            for tile in hl.tile(x.size()):
+                x[tile] = x[tile] + 1.0
+            return x
+
+        f = jax.jit(increment_inplace.jax_fn)
+        x = jnp.zeros((128, 128), dtype=jnp.float32)
+        result = jax.block_until_ready(f(x))
+        self.assertTrue(bool(jnp.all(result == 1.0)))
+
+    def test_jax_standalone_captures_inplace_scratch_and_output_only(self) -> None:
+        """Metadata capture mirrors the launcher's output-only return contract."""
+        import sys
+        import types
+
+        jax, jnp = self._import_jax()
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[128, 128]),
+        )
+        def mutate_and_scale(x: torch.Tensor, scratch: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                scratch[tile] = x[tile] + 1.0
+                out[tile] = scratch[tile] * 2.0
+            return out
+
+        sample = torch.zeros(128, 128, device=DEVICE)
+        code = mutate_and_scale.bind((sample, torch.empty_like(sample))).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        name = "precompiled_mixed_alias_test"
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+        try:
+            exec(compile(code, name, "exec"), module.__dict__)
+            x = jnp.zeros((128, 128), dtype=jnp.float32)
+            out = jax.block_until_ready(
+                jax.jit(module.mutate_and_scale)(x, jnp.empty_like(x))
+            )
+            self.assertTrue(bool(jnp.all(out == 2.0)))
+        finally:
+            sys.modules.pop(name, None)
+
 
 class TestPallasPrinter(TestCase):
     def test_pallas_texpr_mod(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3333
 * #3332
 * #3331
 * #3330
 * __->__#3329


--- --- ---

### [Pallas] Support in-place outputs from Pallas pure-Jax exports (jax_fn=True)


Pure-JAX exports previously discarded Pallas results associated with mutated
inputs. JAX arrays are immutable, so an in-place Helion write must instead
flow out of the Pallas call and rebind the exported wrapper's input value.

Target use pattern:

```py
@helion.kernel(
    backend="pallas",
    static_shapes=True,
    config=helion.Config(block_sizes=[128, 128]),
)
def increment_inplace(x: torch.Tensor) -> torch.Tensor:
    for tile in hl.tile(x.size()):
        x[tile] = x[tile] + 1
    return x

increment = jax.jit(increment_inplace.jax_fn)
result = increment(jnp.zeros((128, 128), dtype=jnp.float32))
```

Request all Pallas results from the shared JAX launch path, use aliased
results to update caller-owned wrapper values, and expose only the kernel's
ordinary outputs. In-place-only kernels continue to return their updated
value, matching the torch-flavored wrapper's observable contract.

Dependency-free `to_code(jax_fn=True)` exports also recover caller-owned
in-place launch slots by tensor identity and serialize their alias metadata.
This preserves interleaved in-place and output-only results. Reject
wrapper-created initialized aliases because a standalone cannot reconstruct
their initial contents; callers must pass such destinations explicitly.
