### PR TITLE
[Pallas] Lower torch.gather in Pallas kernels

### DIFF
--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -32,6 +32,7 @@ from ..aten_lowering import baddbmm_lowering
 from ..aten_lowering import bmm_lowering
 from ..aten_lowering import constant_pad_nd_lowering
 from ..aten_lowering import expand_lowering
+from ..aten_lowering import gather_lowering
 from ..aten_lowering import iota_lowering
 from ..aten_lowering import mm_lowering
 from ..aten_lowering import permute_lowering
@@ -164,6 +165,31 @@ def codegen_expand_pallas(ctx: LoweringContext, node: Node) -> object:
     return expr_from_string(
         f"jnp.broadcast_to({{tensor}}, {shape_str})",
         tensor=tensor,
+    )
+
+
+@gather_lowering.register_codegen("pallas")
+def codegen_gather_pallas(ctx: LoweringContext, node: Node) -> object:
+    """Lower ``torch.gather`` on resident tensors to ``take_along_axis``."""
+    tensor, dim, index = map_arg(node.args[:3], lambda arg: _env_arg(ctx, arg))
+    assert isinstance(tensor, ast.AST)
+    assert isinstance(index, ast.AST)
+    if not isinstance(dim, int):
+        raise TypeError(f"pallas gather requires a static dim, got {dim!r}")
+    ndim = node.meta["val"].ndim
+    if dim < 0:
+        dim += ndim
+    if not 0 <= dim < ndim:
+        raise IndexError(f"gather dim {dim} is out of range for rank {ndim}")
+    sparse_grad = (
+        node.args[3] if len(node.args) > 3 else node.kwargs.get("sparse_grad", False)
+    )
+    if sparse_grad:
+        raise NotImplementedError("pallas gather does not support sparse_grad=True")
+    return expr_from_string(
+        f"jnp.take_along_axis({{tensor}}, {{index}}, axis={dim})",
+        tensor=tensor,
+        index=index,
     )
 
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -986,6 +986,31 @@ class TestPallas(TestCase):
         )
         self.assertGreaterEqual(recall, 0.99)
 
+    def test_gather_matches_torch(self) -> None:
+        @helion.kernel(
+            backend="pallas",
+            config=helion.Config(block_sizes=[8]),
+        )
+        def gather_kernel(x: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(index, dtype=x.dtype)
+            for rows in hl.tile(x.size(0)):
+                out[rows, :] = torch.gather(x[rows, :], 1, index[rows, :])
+            return out
+
+        x_cpu = torch.arange(8 * 128, dtype=torch.float32).reshape(8, 128)
+        rows = torch.arange(8, dtype=torch.int32)[:, None]
+        columns = torch.arange(64, dtype=torch.int32)[None, :]
+        index_cpu = (rows * 37 + columns * 53) % 128
+        index_cpu[:, 0] = 0
+        index_cpu[:, 1] = 127
+        index_cpu[:, 2] = index_cpu[:, 3]
+
+        x = x_cpu.to(DEVICE)
+        index = index_cpu.to(DEVICE)
+        result = gather_kernel(x, index)
+        expected = torch.gather(x, 1, index.to(torch.int64))
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
     @skipIfPallasInterpret("topk bitonic path doesn't work in interpret mode")
     def test_topk_bf16_vocab_reduction(self) -> None:
         """bf16 input: the (rows, vocab) reduction buffer stays bf16 (halves the


### PR DESCRIPTION
Stacked PRs:
 * #3333
 * #3332
 * #3331
 * __->__#3330


--- --- ---

### [Pallas] Lower torch.gather in Pallas kernels


Add the Pallas lowering needed for Helion kernels that select values with
`torch.gather`. This is particularly useful after an exact top-k merge, where
the selected indices must be applied to the corresponding values.

Target use pattern:

```py
@helion.kernel(
    backend="pallas",
    config=helion.Config(block_sizes=[8]),
)
def gather_rows(x: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
    out = torch.empty_like(index, dtype=x.dtype)
    for rows in hl.tile(x.size(0)):
        out[rows, :] = torch.gather(x[rows, :], 1, index[rows, :])
    return out
```

Lower the operation to `jnp.take_along_axis`, normalize negative dimensions,
and reject dynamic or out-of-range dimensions and `sparse_grad=True`. This
keeps the familiar PyTorch frontend API while generating a native resident
Pallas operation.
