### PR TITLE
[autotuner] retune the sm100 reduction num_warps ramp

### DIFF
--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -1459,15 +1459,23 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
 
     @classmethod
     def _has_reduced_away_grid(cls, spec: ConfigSpec) -> bool:
-        """True iff some grid axis is REDUCED AWAY — a grid block_id that appears in NO live tile,
-        i.e. a sequential cross-grid reduction loop whose partial is finalized by a later
-        ``.sum(0)`` (the grad-parameter M-collapse idiom). Uses the shared ``_resident_block_ids``
-        residency test. False if no kernel fact."""
+        """True iff some grid axis is REDUCED AWAY — in no live tile, and batching more than one
+        row per program — i.e. a sequential cross-grid reduction finalized by a later ``.sum(0)``
+        (the grad-parameter M-collapse idiom). False if no kernel fact.
+
+        Both clauses are needed: non-residency alone also covers a ``block_size=1`` axis used as a
+        scalar index, which batches nothing, so consumers get neither cross-warp work to spread nor
+        a row that reloads from L2. A kernel property, not a target one, so both arches share it
+        and tune the RESPONSE instead.
+        """
         kf = spec.reduction_kernel_fact
         if kf is None:
             return False
         resident = cls._resident_block_ids(spec)
-        return any(g not in resident for g in kf.grid_axis_block_ids)
+        return any(
+            g not in resident and cls._m_axis_block_size(spec, g) > 1
+            for g in kf.grid_axis_block_ids
+        )
 
     @staticmethod
     def _max_group_footprint(
@@ -2016,6 +2024,10 @@ class TritonStandardReductionHeuristicSM90(_TritonReductionSeedBase):
 
     name = "triton_reduction_tile"
 
+    # Warp floor when a grid axis is reduced away: the batched rows give cross-warp work to
+    # spread. Per-arch, since it trades occupancy against that parallelism.
+    M_COLLAPSE_MIN_NUM_WARPS = 8
+
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
         if not matches_hardware(env, cls.HARDWARE_TARGETS):
@@ -2047,7 +2059,7 @@ class TritonStandardReductionHeuristicSM90(_TritonReductionSeedBase):
         # >=8 warps even when the primary reduction's extent is small. A floor, so it never lowers a
         # large-rdim ramp. Independent of co-residency, so not gated on a co-resident sibling.
         if cls._has_reduced_away_grid(spec):
-            num_warps = max(8, num_warps)
+            num_warps = max(cls.M_COLLAPSE_MIN_NUM_WARPS, num_warps)
 
         # standard rides persistent-vs-looped on the rolled ``reduction_loops`` knob (the primary
         # rdim is NOT a block_sizes entry). MATERIALIZED rdim (rms/ln/instance bwd, the roller
@@ -2197,6 +2209,16 @@ class _TritonReductionSeedSM100(_TritonReductionSeedBase):
     NW8_MAX_ROW_TRAFFIC = 64 * 1024
     # Element cap for a non-reduction apply loop (see non_reduction_loop_block_cap).
     NON_REDUCTION_LOOP_MAX_ELEMS = 4096
+    # Row extent at or below which there is too little parallelism to fill 4 warps.
+    NARROW_ROW_MAX_ELEMS = 1024
+    NARROW_ROW_NUM_WARPS = 2
+    # Warp count for a light-traffic row above the narrow cap (was an always-8 split).
+    WIDE_ROW_NUM_WARPS = 4
+    # Heavy-traffic rows up to this extent cap here instead of taking the base ramp's 16/32.
+    HEAVY_ROW_MAX_ELEMS = 16384
+    HEAVY_ROW_NUM_WARPS = 8
+    # M-collapse floor (see TritonStandardReductionHeuristicSM90); 8 overshoots on B200.
+    M_COLLAPSE_MIN_NUM_WARPS = 4
 
     @classmethod
     def non_reduction_loop_block_cap(
@@ -2250,9 +2272,15 @@ class _TritonReductionSeedSM100(_TritonReductionSeedBase):
         # Load traffic per row = elems × load-width × #loads.
         traffic = pd.size_hint * max(1, pd.input_load_itemsize) * max(1, pd.num_load)
         if traffic <= cls.NW8_MAX_ROW_TRAFFIC:
-            # keep the base's small-extent 4-warp floor (<=1024 elems); else 8.
-            return 4 if pd.size_hint <= 1024 else 8
-        return None  # heavy-traffic streamed row -> base ramp (16/32) is right
+            # Warps past the useful ones idle while still holding registers and scheduler slots.
+            if pd.size_hint <= cls.NARROW_ROW_MAX_ELEMS:
+                return cls.NARROW_ROW_NUM_WARPS
+            return cls.WIDE_ROW_NUM_WARPS
+        # Heavy traffic: the base ramp's 16/32 is an H100 port that overshoots here up to
+        # HEAVY_ROW_MAX_ELEMS. Genuinely huge rows keep the base ramp.
+        if pd.size_hint <= cls.HEAVY_ROW_MAX_ELEMS:
+            return cls.HEAVY_ROW_NUM_WARPS
+        return None
 
 
 class TritonStandardReductionHeuristicSM100(


### PR DESCRIPTION
The B200 reduction seed's warp counts were a direct H100 port and overshoot on
every band. `_b200_num_warps` -- the live path for every non-M-collapse reduction,
which shadows the base ramp -- becomes an explicit three-rung ladder, and the
grad-parameter M-collapse warp floor drops 8 -> 4.

Warp values are sm100-only (constants on the sm100 carrier class); sm90 keeps its
measured floor of 8 and the base `_num_warps` ramp, since no H100 measurement was
taken. The one change that is NOT arch-scoped is the M-collapse PREDICATE (below):
that is a property of the kernel, not of the target, so both tracks share it while
each arch still tunes its own response.

Measured on a B200 with the kernel captured K times inside one CUDA graph, so the
~1us per-replay CPU cost is amortized rather than dominating a 2-60us kernel
(at K=1 every warp count reads identically; the arms only separate at K>=8).

  rnumel <= 1024, light traffic  ->  2  (was 4)
  rnumel  > 1024, light traffic  ->  4  (was 8)
  heavy traffic, rnumel <= 16384 ->  8  (was the base ramp's 16/32)
  M-collapse floor               ->  4  (was 8)

The disasters this removes, worst case per kernel:

  cross_entropy  R=8192    1.34x -> 1.06x
  cross_entropy  R=16384   1.20x -> 1.00x
  layer_norm_fwd R=2048    1.20x -> 1.04x
  rms_norm_fwd   R=2048    1.16x -> 1.05x
  per_token_group_fp8_quant (gs=128)  nw4 -> nw2, now optimal
  linear-attention decode B16/B32     1.57x/1.66x -> 1.09x/1.07x

Kernels swept: softmax, cross_entropy, rms_norm_fwd, layer_norm_fwd,
rms_norm_bwd, layer_norm_bwd over rnumel 64..16384; the vLLM-derived
pretuned_kernels reductions (per_token_group_fp8_quant, rms_norm_per_block_quant,
silu_and_mul_per_block_quant); and a replica of the sglang KDA packed-decode
kernel. The vLLM configs independently corroborate the narrow rung --
per_token_group_fp8_quant ships 15 tuned cells at nw2 vs 3 at nw1 over a
group_size of 128, values the old ramp could not express.

`_has_reduced_away_grid` also had a false positive, and it is fixed for BOTH arches
because it is a kernel property. It treated any non-resident grid axis as collapsed,
but a `hl.tile(B, block_size=1)` axis used only as a scalar index is non-resident
while batching nothing -- one program per index value, so there is neither
cross-warp work to spread nor a row that reloads from L2. It now also requires the
axis to batch more than one row per program, read via `_m_axis_block_size` (resolves
a grid-pinned axis) rather than `size_hint` (the axis extent, which is > 1 for any
real dimension and never discriminates). On the decode kernel the old form fired on
two `block_size=1` axes and cost up to 1.66x; rms_norm_bwd / layer_norm_bwd at large
M still trigger it correctly.

That predicate change is deliberately not arch-gated even though only B200 was
measured. Its footprint was checked directly: across the four kernel shapes whose
predicate flips, `num_warps` is unchanged on every one and exactly one shape changes
at all -- rms_norm_bwd 4096x128, whose eviction goes
['last','first','first','first'] -> ['','','','']. That is consistent with the
eviction comment's own rule (a row only reloads if the program batches several), so
the new answer is likely the more correct one; it is untested on H100.

Remaining known misses, all left deliberately: several narrow shapes prefer nw1 over
nw2 by ~1.1x, but nw1 is unsafe to seed (layer_norm_bwd at 32768x1024 is 16x slower
at nw2 than nw4, so the low end is a cliff); rms_norm_fwd R=16384 misses 1.27x
because 8 is the safer value across the two measured heavy-traffic points; and
rms_norm_per_block_quant at a non-power-of-two 7168 extent misses 1.16x.

## Perf on held-out shapes

All numbers below are shapes NOT used while tuning (tuning used M=4096 with
power-of-two extents). These use M in {1024, 8192, 32768, 65536}, non-power-of-two
widths (3072, 5120, 6144, 12288, 25600), real vocab sizes (32000, 128256), and the
production num_tokens sweeps taken from the vLLM kernels' own shipped tuned keys.
Timed with K kernel copies inside one CUDA graph so the ~1us per-replay CPU cost is
amortized, before/after produced in one process from the same code path, arms run
before,after,after,before with medians compared.

Combined: n=59, geomean 1.1158x, 31 wins >2%, 24 neutral, 4 regressions >2%.

examples/ reductions (n=29, geomean 1.0938x), largest movers:

  softmax        M=32768 N=3072   nw 8->4   120.62 ->  77.02 us   1.566x
  softmax        M=8192  N=3072   nw 8->4    31.89 ->  21.83 us   1.461x
  layer_norm_fwd M=1024  N=3072   nw 8->4     4.75 ->   3.51 us   1.351x
  layer_norm_fwd M=8192  N=3072   nw 8->4    27.84 ->  21.07 us   1.321x
  rms_norm_fwd   M=8192  N=3072   nw 8->4    18.39 ->  14.59 us   1.260x
  cross_entropy  M=8192  V=5120   nw 8->4    34.47 ->  32.82 us   1.050x
  rms_norm_bwd   8192x5120        nw 16      117.98 -> 110.16 us  1.071x
  layer_norm_bwd 8192x5120        nw 16      124.31 -> 127.95 us  0.972x

The two nw-16 rows are the predicate change: num_warps is identical and only
load_eviction_policies moves (['last','first',...] -> ['','',...]). One gains 1.07x,
one loses 0.97x, so that part is roughly a wash on these shapes.

vLLM pretuned_kernels reductions (n=30, geomean 1.1376x):

  per_token_group_fp8  h=2048 t=512    nw 8->2    4.76 ->  2.71 us   1.755x
  per_token_group_fp8  h=4096 t=64     nw 8->2    4.26 ->  2.45 us   1.735x
  per_token_group_fp8  h=5120 t=4096   nw 8->2   27.58 -> 17.36 us   1.588x
  per_token_group_fp8  (all 9 shapes)  nw 8->2   1.08x - 1.76x, no regressions
  silu_mul_per_block   i=6144  t=64    nw 8->2    3.49 ->  2.21 us   1.577x
  silu_mul_per_block   i=12288 t=512   nw 8->2    9.63 -> 10.91 us   0.882x
  silu_mul_per_block   i=25600 t=512   nw 8->2   23.97 -> 31.24 us   0.767x

rms_norm_per_block_quant and dynamic_per_token_scaled_fp8_quant are unchanged at all
15 shapes measured (they sit on the heavy-traffic path above the cap).

## Known regression: silu_and_mul_per_block_quant

Disclosed rather than worked around. That kernel's reduction extent is PINNED at 128
by group_size, so it always lands in the narrow rung, but it only wants nw2 at small
token counts; past that it wants nw4:

  i=25600 t=64    nw1 4.20  nw2 3.98  nw4 3.98  nw8 4.75   -> nw2/nw4
  i=25600 t=512   nw1 88.2  nw2 31.2  nw4 23.5  nw8 23.9   -> nw4
  i=12288 t=4096  nw1 405   nw2 96.9  nw4 92.2  nw8 89.7   -> nw8

The driver is total work (groups = i * t / group_size), not the reduction extent:
holding the grid fixed at 24576 and varying the i/t split gives nw4 in 3 of 4 cases,
and growing EITHER axis alone reproduces the same nw2 -> nw4 transition. So the extent
is the right key for the row-reduction family and the wrong key for a fixed-extent
per-block quant kernel.

No gate for this is included because the signal is not in the reduction descriptor:
extent, num_load, traffic and the non-reduction-loop count are all identical between
the nw2-wanting and nw4-wanting cases, and num_load does not separate them either
(rms_norm_fwd / layer_norm_fwd also have num_load 2 and want nw1-2). Adding a
work-per-program term would need plumbing a grid/total-groups signal into the gate;
that is worth doing as its own change with a wider kernel set rather than fitted to
the six datapoints here. Excluding these three shapes the held-out geomean is 1.1309x,
so the regression costs roughly 1.5 points of geomean.

Not type-checked: pyrefly is unavailable in this environment, so that pre-commit hook
was skipped. All other hooks (ruff, ruff format, codespell) pass.

