### PR TITLE
[cute] Skip negative-indexing tests that poison CUDA contexts

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -22,6 +22,7 @@ from helion._testing import TestCase
 from helion._testing import _get_backend
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfCute
 from helion._testing import skipIfLowVRAM
 from helion._testing import skipIfNormalMode
 from helion._testing import skipIfRefEager
@@ -1806,7 +1807,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src2_result, expected_src2)
         torch.testing.assert_close(dst2_result, expected_dst2)
 
-    @xfailIfCute("InternalError: Negative indexes")
+    @skipIfCute("CuTe negative indexes can poison the CUDA context")
     def test_negative_indexing(self):
         """Test both setter from scalar and getter for [-1]"""
 
@@ -1832,7 +1833,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src_result, expected_src)
         torch.testing.assert_close(dst_result, expected_dst)
 
-    @xfailIfCute("InternalError: Negative indexes")
+    @skipIfCute("CuTe negative indexes can poison the CUDA context")
     def test_negative_indexing_multidim(self):
         """Test negative indexing on multiple dimensions: x[-1, -1]"""
 
@@ -1850,7 +1851,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         expected[-1, -1] = 42.0
         torch.testing.assert_close(result, expected)
 
-    @xfailIfCute("InternalError: Negative indexes")
+    @skipIfCute("CuTe negative indexes can poison the CUDA context")
     def test_negative_indexing_with_tile(self):
         """Test mixed tile and negative index: x[tile, -1]"""
 


### PR DESCRIPTION
The CuTe negative-indexing tests are expected failures, but executing them triggers an illegal memory access and leaves the pytest-xdist worker CUDA context poisoned. This causes hundreds of unrelated tests after them to fail on the same worker.

example: https://github.com/pytorch/helion/actions/runs/31534219634/job/93921380605

Skip these three unsupported tests for CuTe instead of executing them as expected failures. They continue to run normally under Triton.

Validation:
- HELION_BACKEND=cute pytest test/test_indexing.py -x -q -ra: 79 passed, 18 skipped, 5 xfailed
- HELION_BACKEND=triton targeted negative-indexing tests: 3 passed
- git diff --check