### PR TITLE
[cutedsl] Make long flash attention race-free and accurate

### DIFF
--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -270,6 +270,42 @@ def mbarrier_arrive(
 
 
 @dsl_user_op
+def named_barrier_arrive_unaligned(
+    barrier_id: object,
+    number_of_threads: object,
+    *,
+    loc: object = None,
+    ip: object = None,
+) -> None:
+    """Arrive at a named barrier from a divergent warp-role branch."""
+    cute.arch.barrier_arrive(
+        barrier_id=barrier_id,
+        number_of_threads=number_of_threads,
+        aligned=False,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def named_barrier_wait_unaligned(
+    barrier_id: object,
+    number_of_threads: object,
+    *,
+    loc: object = None,
+    ip: object = None,
+) -> None:
+    """Arrive and wait at a named barrier from a divergent warp-role branch."""
+    nvvm.barrier_cta_sync(
+        cutlass.Int32(barrier_id).ir_value(loc=loc, ip=ip),
+        thread_count=cutlass.Int32(number_of_threads).ir_value(loc=loc, ip=ip),
+        aligned=False,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
 def rcp_approx_ftz(x: object, *, loc: object = None, ip: object = None) -> Float32:
     """FA4-style approximate reciprocal that lowers to ``rcp.approx.ftz.f32``."""
     return cutlass.Float32(
@@ -312,10 +348,6 @@ _POLY_EX2_DEG2 = (
     1.0017247632060873,
     0.65763628,
     0.33718943,
-)
-_POLY_EX2_DEG1 = (
-    0.97017879,
-    0.97017879,
 )
 _FP32_ROUND_INT = float(2**23 + 2**22)
 
@@ -466,56 +498,13 @@ def ex2_emulation_deg2_batch(pairs: list[tuple]) -> list[tuple]:
 
 
 def ex2_emulation_deg1_2(x: Float32, y: Float32) -> tuple:
-    """Packed degree-1 software exp2 with a relative minimax approximation."""
-    # The linear polynomial starts below 1.0 (FP32 exponent 126), so clamping
-    # at -127 would wrap the reconstructed exponent field to 255.
-    xy_clamped = (cute.arch.fmax(x, -126.0), cute.arch.fmax(y, -126.0))
-    xy_rounded = cute.arch.add_packed_f32x2(
-        xy_clamped,
-        (_FP32_ROUND_INT, _FP32_ROUND_INT),
-        rnd="rm",
-    )
-    xy_rounded_back = _sub_packed_f32x2(xy_rounded, (_FP32_ROUND_INT, _FP32_ROUND_INT))
-    xy_frac = _sub_packed_f32x2(xy_clamped, xy_rounded_back)
-    xy_frac_ex2 = _evaluate_polynomial_2(xy_frac[0], xy_frac[1], _POLY_EX2_DEG1)
-    x_out = _combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0])
-    y_out = _combine_int_frac_ex2(xy_rounded[1], xy_frac_ex2[1])
-    return x_out, y_out
+    """Accurate compatibility route for legacy degree-1 packet schedules."""
+    return ex2_emulation_deg2_2(x, y)
 
 
 def ex2_emulation_deg1_batch(pairs: list[tuple]) -> list[tuple]:
-    """Level-schedule independent packed degree-1 software exp2 pairs."""
-    xy_clamped = [
-        (cute.arch.fmax(x, -126.0), cute.arch.fmax(y, -126.0)) for x, y in pairs
-    ]
-    xy_rounded = [
-        cute.arch.add_packed_f32x2(
-            pair,
-            (_FP32_ROUND_INT, _FP32_ROUND_INT),
-            rnd="rm",
-        )
-        for pair in xy_clamped
-    ]
-    xy_rounded_back = [
-        _sub_packed_f32x2(pair, (_FP32_ROUND_INT, _FP32_ROUND_INT))
-        for pair in xy_rounded
-    ]
-    xy_frac = list(
-        starmap(_sub_packed_f32x2, zip(xy_clamped, xy_rounded_back, strict=True))
-    )
-    xy_frac_ex2 = [(_POLY_EX2_DEG1[-1], _POLY_EX2_DEG1[-1]) for _ in pairs]
-    for coefficient in reversed(_POLY_EX2_DEG1[:-1]):
-        xy_frac_ex2 = [
-            _fma_packed_f32x2(poly, frac, (coefficient, coefficient))
-            for poly, frac in zip(xy_frac_ex2, xy_frac, strict=True)
-        ]
-    return [
-        (
-            _combine_int_frac_ex2(rounded[0], frac_ex2[0]),
-            _combine_int_frac_ex2(rounded[1], frac_ex2[1]),
-        )
-        for rounded, frac_ex2 in zip(xy_rounded, xy_frac_ex2, strict=True)
-    ]
+    """Accurate compatibility route for legacy degree-1 packet schedules."""
+    return ex2_emulation_deg2_batch(pairs)
 
 
 def exp2_split_inplace(
@@ -2389,6 +2378,7 @@ def _fa4_sp_exp_convert_store_impl(
     early_split_publish: bool = False,
     pair_batch: int = 1,
     emu_batch: int = 1,
+    degree2: bool = False,
     degree1: bool = False,
     *,
     loc: object = None,
@@ -2414,7 +2404,7 @@ def _fa4_sp_exp_convert_store_impl(
                 ci >= frag_count - 1,
                 pair_batch,
                 emu_batch,
-                False,
+                degree2,
                 degree1,
             )
             cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
@@ -2434,7 +2424,7 @@ def _fa4_sp_exp_convert_store_impl(
                 ci >= frag_count - 1,
                 pair_batch,
                 emu_batch,
-                False,
+                degree2,
                 degree1,
             )
             cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
@@ -2455,7 +2445,7 @@ def _fa4_sp_exp_convert_store_impl(
                 ci >= frag_count - 1,
                 pair_batch,
                 emu_batch,
-                False,
+                degree2,
                 degree1,
             )
             cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
@@ -2501,6 +2491,7 @@ def fa4_sp_exp_convert_store(
     early_split_publish: bool = False,
     pair_batch: int = 1,
     emu_batch: int = 1,
+    degree2: bool = False,
     degree1: bool = False,
     *,
     loc: object = None,
@@ -2528,6 +2519,7 @@ def fa4_sp_exp_convert_store(
         early_split_publish,
         pair_batch,
         emu_batch,
+        degree2,
         degree1,
     )
 
@@ -2553,6 +2545,7 @@ def fa4_sp_exp_convert_store_whole_rowsum(
     early_split_publish: bool = False,
     pair_batch: int = 1,
     emu_batch: int = 1,
+    degree2: bool = False,
     degree1: bool = False,
     *,
     loc: object = None,
@@ -2580,6 +2573,7 @@ def fa4_sp_exp_convert_store_whole_rowsum(
         early_split_publish,
         pair_batch,
         emu_batch,
+        degree2,
         degree1,
     )
 

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -1205,7 +1205,10 @@ class FlashAttentionConfig:
     # autotuner can refine the threshold for fa4 and ws_overlap shapes.
     rescale_threshold: float = 0.0
     # Statistics handoff between the softmax and correction roles. ``single``
-    # uses the named-barrier handoff; ``ring2`` uses the two-slot mbarrier ring.
+    # uses one slot with a named ready barrier and an mbarrier reuse
+    # acknowledgement; ``single_final`` relies on the MMA chain for steady-state
+    # reuse and acknowledges only the terminal row sum, once per work item;
+    # ``ring2`` uses the two-slot mbarrier ring.
     stat_transport: str = "ring2"
     # Experimental FA4_SKIP_RESCALE_STATS lever. The resolver currently clamps
     # this off because dropping per-KV alpha handoffs is only correct if every
@@ -1303,7 +1306,7 @@ def _flash_causal_hd64_seed_num_kv_supported(num_kv: int | None) -> bool:
 
 
 _FLASH_CAUSAL_HD64_LONG_AUTOTUNE_MIN_KV = 4096
-_FLASH_CAUSAL_HD64_HYBRID_SEED_MIN_KV = 512
+_FLASH_CAUSAL_DEG2_SEED_KV = 4096
 
 
 def _flash_causal_hd64_seed_params(num_kv: int) -> tuple[int, int, int, int]:
@@ -1423,6 +1426,7 @@ _FLASH_DEG1_EXP2_OFFSET0 = 10
 # aligned KV tiles to stay within their validated numerical envelope.
 _FLASH_DENSE_HD64_2CTA_MIN_KV = 256
 _FLASH_DENSE_DEG1_LONG_PACKET_MIN_KV = 2048
+_FLASH_DENSE_DEG2_SEED_KV = 2048
 _FLASH_MANUAL_EXP2_PACKET_PARAMS: dict[str, tuple[int, int]] = {
     _FLASH_DEG2_EXP2_PACKET: (8, 3),
     _FLASH_HYBRID_EXP2_PACKET: (8, 4),
@@ -2433,7 +2437,11 @@ def resolve_flash_config(
             and use_2cta_instrs
             and not softmax_disc
             and dense_degree1_eligible
-            and exp2_packet == dense_degree1_packet
+            and exp2_packet
+            in (
+                dense_degree1_packet,
+                _FLASH_DEG2_EXP2_PACKET,
+            )
         )
     )
     if exp2_packet in _FLASH_MANUAL_EXP2_PACKET_PARAMS:
@@ -2499,10 +2507,20 @@ def resolve_flash_config(
     stat_transport_cfg = _cfg(FLASH_STAT_TRANSPORT_KEY)
     if stat_transport_cfg is not None:
         stat_transport = str(stat_transport_cfg)
-    if stat_transport not in ("ring2", "single"):
+    if stat_transport not in ("ring2", "single", "single_final"):
         stat_transport = stat_transport_default
     if not stat_transport_eligible:
         stat_transport = "ring2"
+    single_final_stat_eligible = (
+        stat_transport_eligible
+        and standard_dense_output
+        and (not persistent or use_2cta_instrs)
+        and not softmax_disc
+        and rescale_threshold > 0.0
+        and exp2_packet != _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
+    )
+    if stat_transport == "single_final" and not single_final_stat_eligible:
+        stat_transport = "single"
     causal_loop_split_default = (
         causal_hd64_seeded_fa4 and causal_kv_order == "descending"
     )
@@ -3508,7 +3526,7 @@ def _flash_default_seed_config(
     return Config.from_dict(seed)
 
 
-def _flash_dense_degree1_seed_config(
+def _flash_dense_degree2_seed_config(
     head_dim: int,
     num_kv: int,
     *,
@@ -3520,7 +3538,7 @@ def _flash_dense_degree1_seed_config(
     standard_dense_output: bool,
     block_size_targets: Sequence[int],
 ) -> Config | None:
-    """Return a general dense degree-1 seed from ``fa4_2cta`` defaults."""
+    """Return the validated long-dense degree-2 seed."""
     if (
         not standard_dense_output
         or is_causal
@@ -3530,6 +3548,7 @@ def _flash_dense_degree1_seed_config(
         or requires_ws_overlap
         or small_biased_candidate
         or not _flash_dense_hd64_2cta_num_kv_supported(num_kv)
+        or num_kv != _FLASH_DENSE_DEG2_SEED_KV
     ):
         return None
     block_sizes = _flash_seed_block_sizes(block_size_targets)
@@ -3548,20 +3567,22 @@ def _flash_dense_degree1_seed_config(
         pipeline_family_override="fa4_2cta",
     )
     values = {key: fragment.default() for key, fragment in fragments.items()}
-    packet_values: dict[str, object]
-    if num_kv < _FLASH_DENSE_DEG1_LONG_PACKET_MIN_KV:
-        packet_values = {
-            FLASH_EXP2_PACKET_KEY: _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET,
-            FLASH_E2E_SCHEDULE_KEY: "8/2",
-        }
-    else:
-        packet_values = {
-            FLASH_EXP2_PACKET_KEY: _FLASH_DEG1_EXP2_PACKET,
-            FLASH_E2E_SCHEDULE_KEY: "16/8",
-            FLASH_E2E_OFFSET_KEY: _FLASH_DEG1_EXP2_OFFSET,
-            FLASH_E2E_OFFSET0_KEY: _FLASH_DEG1_EXP2_OFFSET0,
-            FLASH_KV_STAGE_KEY: 2,
-        }
+    packet_values: dict[str, object] = {
+        FLASH_EXP2_PACKET_KEY: _FLASH_DEG2_EXP2_PACKET,
+        FLASH_E2E_SCHEDULE_KEY: "16/6",
+        FLASH_E2E_OFFSET_KEY: 0,
+        FLASH_E2E_OFFSET0_KEY: 2,
+        FLASH_KV_STAGE_KEY: 2,
+        FLASH_PERSISTENT_KEY: False,
+        FLASH_STAT_TRANSPORT_KEY: "single_final",
+        FLASH_WAIT_HINT_KEY: 0,
+        FLASH_SOFTMAX_REGS_KEY: 192,
+        FLASH_CORR_REGS_KEY: 72,
+        FLASH_OTHER_REGS_KEY: 40,
+        FLASH_ROLE_MAP_KEY: "fa4",
+        FLASH_RESCALE_THRESHOLD_KEY: 8.0,
+        FLASH_RESCALE_CHUNK_COLS_KEY: 8,
+    }
     packet_values[FLASH_PIPELINE_FAMILY_KEY] = "fa4_2cta"
     if not _flash_seed_set_all(values, fragments, packet_values):
         return None
@@ -3812,7 +3833,7 @@ def _flash_causal_split_seed_config(
     return Config.from_dict(seed)
 
 
-def _flash_causal_hybrid_seed_config(
+def _flash_causal_degree2_seed_config(
     head_dim: int,
     num_kv: int,
     *,
@@ -3824,29 +3845,23 @@ def _flash_causal_hybrid_seed_config(
     standard_causal_output: bool,
     block_size_targets: Sequence[int],
 ) -> Config | None:
-    """Return the long-causal hybrid-exp2 compiler seed.
-
-    The hybrid packet uses degree 1 only in the unmasked suffix; diagonal tiles
-    retain degree 2. It remains a compiler seed because manual packet modes are
-    accepted by the fragments but excluded from random search.
-    """
+    """Return the validated 512K causal degree-2 seed."""
     if (
-        not is_causal
-        or head_dim != 64
+        not standard_causal_output
+        or not is_causal
         or dtype is not torch.float16
+        or head_dim != 64
+        or num_kv != _FLASH_CAUSAL_DEG2_SEED_KV
         or has_kv_tile_pruning
         or requires_ws_overlap
         or small_biased_candidate
-        or not standard_causal_output
-        or num_kv < _FLASH_CAUSAL_HD64_HYBRID_SEED_MIN_KV
-        or not _flash_causal_hd64_seed_num_kv_supported(num_kv)
     ):
         return None
     block_sizes = _flash_seed_block_sizes(block_size_targets)
     if block_sizes is None:
         return None
 
-    fragments = _flash_seed_fragments(
+    fragments = flash_autotune_fragments(
         head_dim,
         num_kv,
         dtype=dtype,
@@ -3854,36 +3869,23 @@ def _flash_causal_hybrid_seed_config(
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
         small_biased_candidate=small_biased_candidate,
-        topology_override="fa4",
+        pipeline_family_override="fa4",
     )
-    seed: dict[str, object] = {"block_sizes": block_sizes}
-    family_values: dict[str, object] = {
-        FLASH_PIPELINE_FAMILY_KEY: "fa4",
-        FLASH_S_STAGE_KEY: 2,
-        FLASH_KV_STAGE_KEY: 2,
-        FLASH_PERSISTENT_KEY: False,
-        FLASH_E2E_SCHEDULE_KEY: "16/8",
-        FLASH_MASKED_E2E_SCHEDULE_KEY: "16/8",
+    values = {key: fragment.default() for key, fragment in fragments.items()}
+    overrides: dict[str, object] = {
+        FLASH_E2E_SCHEDULE_KEY: "16/6",
+        FLASH_MASKED_E2E_SCHEDULE_KEY: "16/6",
         FLASH_E2E_OFFSET_KEY: 0,
-        FLASH_E2E_OFFSET0_KEY: 10,
+        FLASH_E2E_OFFSET0_KEY: 14,
+        FLASH_EXP2_PACKET_KEY: _FLASH_DEG2_EXP2_PACKET,
+        FLASH_WAIT_HINT_KEY: 0,
         FLASH_DISC_PIPE_KEY: 3,
-        FLASH_EXP2_PACKET_KEY: _FLASH_HYBRID_EXP2_PACKET,
-        FLASH_WAIT_HINT_KEY: 10_000_000,
-        FLASH_EPI_TMA_KEY: False,
-        FLASH_EPI_STG_KEY: False,
-        FLASH_EPI_STG_GMEM_KEY: "stage",
         FLASH_RESCALE_CHUNK_COLS_KEY: 16,
-        FLASH_ROLE_MAP_KEY: "helion",
-        FLASH_CAUSAL_LOOP_SPLIT_KEY: True,
-        FLASH_RESCALE_THRESHOLD_KEY: 8.0,
-        FLASH_PACKED_REDUCE_KEY: True,
         FLASH_CAUSAL_LPT_SWIZZLE_KEY: 0,
-        FLASH_CAUSAL_KV_ORDER_KEY: "descending",
-        FLASH_SOFTMAX_REGS_KEY: _flash_causal_hd64_seed_params(num_kv)[2],
     }
-    if not _flash_seed_set_all(seed, fragments, family_values):
+    if not _flash_seed_set_all(values, fragments, overrides):
         return None
-    return Config.from_dict(seed)
+    return Config.from_dict({"block_sizes": block_sizes, **values})
 
 
 def flash_attention_seed_config(
@@ -4036,7 +4038,7 @@ def flash_attention_seed_configs(
     if default_seed is not None:
         seeds.append(default_seed)
     if num_kv is not None:
-        dense_degree1_seed = _flash_dense_degree1_seed_config(
+        dense_degree2_seed = _flash_dense_degree2_seed_config(
             head_dim,
             num_kv,
             dtype=dtype,
@@ -4047,8 +4049,18 @@ def flash_attention_seed_configs(
             standard_dense_output=standard_dense_output,
             block_size_targets=block_size_targets,
         )
-        if dense_degree1_seed is not None:
-            seeds.append(dense_degree1_seed)
+        if dense_degree2_seed is not None:
+            seeds.extend(
+                (
+                    dense_degree2_seed,
+                    Config.from_dict(
+                        {
+                            **dense_degree2_seed.config,
+                            FLASH_STAT_TRANSPORT_KEY: "ring2",
+                        }
+                    ),
+                )
+            )
     causal_lpt_seed = flash_attention_seed_config(
         head_dim,
         num_kv,
@@ -4076,7 +4088,7 @@ def flash_attention_seed_configs(
     if causal_split_seed is not None:
         seeds.append(causal_split_seed)
     if num_kv is not None:
-        causal_hybrid_seed = _flash_causal_hybrid_seed_config(
+        causal_degree2_seed = _flash_causal_degree2_seed_config(
             head_dim,
             num_kv,
             dtype=dtype,
@@ -4087,8 +4099,8 @@ def flash_attention_seed_configs(
             standard_causal_output=standard_causal_output,
             block_size_targets=block_size_targets,
         )
-        if causal_hybrid_seed is not None:
-            seeds.append(causal_hybrid_seed)
+        if causal_degree2_seed is not None:
+            seeds.append(causal_degree2_seed)
     for family_seed in _flash_canonical_family_seed_configs(
         head_dim,
         num_kv,
@@ -4299,7 +4311,7 @@ def flash_autotune_fragments(
             defaults.persistent, (True, False)
         )
         persistent_search_choices: tuple[bool, ...] | None = (
-            _flash_choices_with_default(defaults.persistent, (True,))
+            _flash_choices_with_default(defaults.persistent, (True, False))
         )
         persistent_ctas_per_sm_choices = _flash_choices_with_default(
             defaults.persistent_ctas_per_sm, (1, 2, 3, 4)
@@ -5013,11 +5025,18 @@ def flash_autotune_fragments(
         exp2_packet_choices = ("1x1",)
         exp2_packet_search_choices = None
     if dense_hd64_fa4:
+        stat_transport_variants = (
+            ("ring2", "single", "single_final")
+            if standard_dense_output
+            else ("ring2", "single")
+        )
         stat_transport_choices = _flash_choices_with_default(
-            defaults.stat_transport, ("ring2", "single")
+            defaults.stat_transport, stat_transport_variants
         )
         stat_transport_search_choices: tuple[str, ...] | None = (
-            defaults.stat_transport,
+            _flash_choices_with_default(
+                defaults.stat_transport, stat_transport_variants
+            )
         )
     else:
         stat_transport_choices = ("ring2",)
@@ -5171,7 +5190,11 @@ if TYPE_CHECKING:
 # ``_flash_runtime`` (a real module compiled WITHOUT ``from __future__ import
 # annotations``); the generated module imports them. The remaining cute / utils
 # / pipeline symbols are imported under flash-local aliases.
-_FLASH_PREAMBLE_IMPORTS = """\
+_FLASH_RUNTIME_ABI = 2
+
+# This literal is part of generated source and therefore the CuTe disk-cache
+# key. Bump it whenever an imported flash runtime helper changes semantics.
+_FLASH_PREAMBLE_IMPORTS = f"""\
 import cutlass.utils as cutlass_utils_flash
 import cutlass.pipeline as cutlass_pipeline_flash
 from cutlass.cute.nvgpu import cpasync as cute_cpasync_flash
@@ -5179,6 +5202,7 @@ from cutlass.cute.nvgpu import tcgen05 as cute_tcgen05_flash
 import cutlass.utils.blackwell_helpers as sm100_utils_flash
 import helion._compiler.cute._flash_runtime as _helion_flash_rt
 import helion._compiler.cute._flash_gemm_ptx as _helion_flash_ptx
+_helion_flash_runtime_abi = {_FLASH_RUNTIME_ABI}
 """
 
 
@@ -7089,6 +7113,25 @@ def emit_flash_fa4_device_body(
     use_cga2_local_cta = cfg.use_cga2_local_cta
     use_clc_scheduler = cfg.use_clc_scheduler
     separate_kv_rings = cfg.separate_kv_rings
+    fa4_stat_handoff = cfg.stat_transport in ("single", "single_final")
+    # Match FA4's one-slot statistics pipeline: the softmax role acquires slot
+    # ownership after publishing P, while correction releases the opposite
+    # stage's slot. Unsupported schedules retain the conservative handoff below.
+    fa4_stat_pipeline = (
+        fa4_stat_handoff
+        and not is_causal
+        and cfg.exp2_impl == "split"
+        and not cfg.softmax_disc
+        and cfg.rescale_threshold > 0.0
+        and cfg.exp2_packet != _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
+    )
+    # The MMA warp's PV -> next-QK order makes each alpha slot safe to reuse
+    # without a per-iteration empty acknowledgement. Keep a single terminal
+    # handoff per work item before softmax overwrites alpha with row sum.
+    final_only_stat_pipeline = (
+        fa4_stat_pipeline and cfg.stat_transport == "single_final"
+    )
+    acknowledged_stat_pipeline = fa4_stat_pipeline and not final_only_stat_pipeline
     verified_shared_memory_bytes: int | None = None
     if separate_kv_rings:
         assert not use_cga2_local_cta
@@ -7112,6 +7155,9 @@ def emit_flash_fa4_device_body(
                     kv_iterations=num_kv if persistent else None,
                     stage_output=cfg.epi_tma or cfg.epi_stg,
                     split_p_arrive=cfg.split_p_arrive,
+                    stat_depth=1 if fa4_stat_handoff else 2,
+                    pipelined_stat_handoff=acknowledged_stat_pipeline,
+                    final_only_stat_handoff=final_only_stat_pipeline,
                 )
             )
         )
@@ -7133,6 +7179,9 @@ def emit_flash_fa4_device_body(
                     kv_iterations=num_kv if persistent else None,
                     stage_output=cfg.epi_tma or cfg.epi_stg,
                     split_p_arrive=cfg.split_p_arrive,
+                    stat_depth=1 if fa4_stat_handoff else 2,
+                    pipelined_stat_handoff=acknowledged_stat_pipeline,
+                    final_only_stat_handoff=final_only_stat_pipeline,
                 )
             )
         )
@@ -7162,17 +7211,20 @@ def emit_flash_fa4_device_body(
         cfg.exp2_packet, cfg.e2e_freq, cfg.e2e_res
     )
     if exp2_codegen.degree2:
-        assert is_causal
         assert hd == 64
         assert io_dtype == "cutlass.Float16"
         assert cfg.q_tile_count == 2
-        assert not use_2cta_instrs
         assert not use_cga2_local_cta
         assert not separate_kv_rings
-        assert cfg.softmax_disc
-        assert cfg.disc_pipe_depth >= 2
         assert cfg.p_store_repetition == 16
         assert cfg.s_load_repetition == 32
+        if is_causal:
+            assert not use_2cta_instrs
+            assert cfg.softmax_disc
+            assert cfg.disc_pipe_depth >= 2
+        else:
+            assert use_2cta_instrs
+            assert not cfg.softmax_disc
     sp_whole_row_sum = (
         _FLASH_DENSE_HD64_VERY_LONG_MIN_KV <= num_kv <= 2048
         and not is_causal
@@ -7523,7 +7575,6 @@ tVsV, tVgV_dkl = cute_cpasync_flash.tma_partition(
     _flash_tma_v, 0, cute.make_layout(1),
     cute.group_modes(sV, 0, 3), cute.group_modes(tOgV, 0, 3)){setup_gmem_slice}"""
     )
-    fa4_stat_handoff = cfg.stat_transport == "single"
     scale_layout = (
         f"cute.make_layout(({q_stage} * 128))"
         if fa4_stat_handoff
@@ -7639,7 +7690,8 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     flash_pv_acc_shape = flash_pvt.partition_shape_C(({mma_m}, {hd}))
     tOtO = flash_pvt.make_fragment_C(flash_pv_acc_shape)
 """
-    tmem_base_setup = f"""{tmem_fragment_setup}    flash_tmem.wait_for_alloc()
+    tmem_base_setup = f"""{tmem_fragment_setup}    _helion_flash_rt.named_barrier_wait_unaligned(
+        2, 13 * 32)
     flash_tmem_ptr = flash_tmem.retrieve_ptr(cutlass.Float32)
     tStS0_full = cute.make_tensor(flash_tmem_ptr, tStS.layout)
     tStS1_full = cute.make_tensor(flash_tmem_ptr + 128, tStS.layout)
@@ -7758,7 +7810,8 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     tLDcS = flash_thr_ld_coord.partition_D(tScS)
 """
         )
-        return f"""    flash_tmem.wait_for_alloc()
+        return f"""    _helion_flash_rt.named_barrier_wait_unaligned(
+        2, 13 * 32)
     flash_tmem_ptr = flash_tmem.retrieve_ptr(cutlass.Float32)
     flash_qk_acc_shape = flash_qkt.partition_shape_C(({mma_m}, 128))
     tStS = flash_qkt.make_fragment_C(flash_qk_acc_shape)
@@ -8529,7 +8582,7 @@ if warp_idx == 15:
         # parity matches the next work-item's correction pre-arrive (spike L1973-1977).
         flash_pfor_phase ^= 1"""
     mma_tmem_teardown = """    flash_tmem.relinquish_alloc_permit()
-    flash_tmem_user_bar.arrive_and_wait()
+    _helion_flash_rt.named_barrier_wait_unaligned(2, 13 * 32)
     flash_tmem.free(flash_tmem_ptr)"""
     mma_role_inner = mma_inner
     if use_2cta_instrs:
@@ -8793,10 +8846,12 @@ if warp_idx == 15:
         else:
             lse_store = ""
         corr_empty_ptr = f"flash_s{stage}_corr_empty_ptr"
-        corr_prod_index = "0" if not is_causal else "flash_s_corr_prod_index"
+        corr_prod_index = "0" if fa4_stat_handoff else "flash_s_corr_prod_index"
         corr_prod_advance = (
-            "flash_s_corr_prod_phase ^= 1"
-            if not is_causal
+            ""
+            if fa4_stat_pipeline
+            else "flash_s_corr_prod_phase ^= 1"
+            if fa4_stat_handoff
             else textwrap.dedent(
                 """\
                 flash_s_corr_prod_index ^= 1
@@ -8812,31 +8867,39 @@ if warp_idx == 15:
             publish_alpha_store = (
                 f"{indent}{_scale_slot_expr(corr_prod_index, stage)} = flash_alpha\n"
             )
-            if fa4_stat_handoff:
-                return f"""{publish_alpha_store.rstrip()}
-{indent}cute.arch.barrier_arrive(
-{indent}    barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)"""
             publish_alpha_advance = corr_prod_advance.replace("\n", f"\n{indent}")
-            return f"""{indent}_helion_flash_rt.mbar_spin_wait(
+            producer_acquire = (
+                ""
+                if fa4_stat_pipeline
+                else f"""{indent}_helion_flash_rt.mbar_spin_wait(
 {indent}    {corr_empty_ptr} + {corr_prod_index}, flash_s_corr_prod_phase, {cfg.wait_hint})
-{publish_alpha_store.rstrip()}
-{indent}cute.arch.barrier_arrive(
-{indent}    barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
+"""
+            )
+            return f"""{producer_acquire}{publish_alpha_store.rstrip()}
+{indent}_helion_flash_rt.named_barrier_arrive_unaligned(
+{indent}    {3 + int(stage) * 4} + warp_idx % 4, 64)
 {indent}{publish_alpha_advance}"""
 
         corr_publish_alpha = _corr_publish_alpha("                ")
+        corr_publish_dummy = f"""                _helion_flash_rt.named_barrier_arrive_unaligned(
+                    {3 + int(stage) * 4} + warp_idx % 4, 64)"""
         corr_rowsum_advance = corr_prod_advance.replace("\n", "\n        ")
-        if fa4_stat_handoff:
-            corr_publish_rowsum = f"""        {_scale_slot_expr(corr_prod_index, stage)} = flash_row_sum
-        cute.arch.barrier_arrive(
-            barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
-{lse_store}"""
+        if final_only_stat_pipeline:
+            final_only_phase_advance = (
+                "        flash_s_corr_prod_phase ^= 1\n" if persistent else ""
+            )
+            rowsum_producer_acquire = f"""        _helion_flash_rt.mbar_spin_wait(
+            {corr_empty_ptr} + 0, flash_s_corr_prod_phase, {cfg.wait_hint})
+{final_only_phase_advance}"""
+        elif acknowledged_stat_pipeline:
+            rowsum_producer_acquire = ""
         else:
-            corr_publish_rowsum = f"""        _helion_flash_rt.mbar_spin_wait(
+            rowsum_producer_acquire = f"""        _helion_flash_rt.mbar_spin_wait(
             {corr_empty_ptr} + {corr_prod_index}, flash_s_corr_prod_phase, {cfg.wait_hint})
-        {_scale_slot_expr(corr_prod_index, stage)} = flash_row_sum
-        cute.arch.barrier_arrive(
-            barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
+"""
+        corr_publish_rowsum = f"""{rowsum_producer_acquire}        {_scale_slot_expr(corr_prod_index, stage)} = flash_row_sum
+        _helion_flash_rt.named_barrier_arrive_unaligned(
+            {3 + int(stage) * 4} + warp_idx % 4, 64)
 {lse_store}
         {corr_rowsum_advance}"""
         # The correction warp consumes per-KV alpha handoffs during the loop and
@@ -9106,6 +9169,8 @@ if warp_idx == 15:
                 )
             if exp2_codegen.degree1_unmasked:
                 sp_pass2_args.append("degree1=True")
+            elif exp2_codegen.degree2:
+                sp_pass2_args.append("degree2=True")
             sp_exp_block = (
                 f"            flash_p_sum = _helion_flash_rt.{sp_pass2_name}("
                 + ", ".join(sp_pass2_args)
@@ -9118,16 +9183,42 @@ if warp_idx == 15:
             sp_p_store_block = p_store_block
             sp_corr_publish_alpha = ""
         if not sp_corr_publish_alpha and not cfg.skip_rescale_stats:
-            sp_corr_publish_alpha = f"""            if {softmax_not_first}:
+            if acknowledged_stat_pipeline:
+                sp_corr_publish_alpha = f"""            if {softmax_not_first}:
+{corr_publish_alpha}
+            else:
+{corr_publish_dummy}"""
+            else:
+                sp_corr_publish_alpha = f"""            if {softmax_not_first}:
 {corr_publish_alpha}"""
-        fa4_publish_alpha_before_exp = fa4_stat_handoff and cfg.rescale_threshold > 0.0
+        fa4_publish_alpha_before_exp = fa4_stat_handoff and (
+            cfg.rescale_threshold > 0.0 or fa4_stat_pipeline
+        )
         sp_alpha_publish_pre = (
             sp_corr_publish_alpha if fa4_publish_alpha_before_exp else ""
         )
         sp_alpha_publish_post = (
             "" if fa4_publish_alpha_before_exp else sp_corr_publish_alpha
         )
-        return f"""        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
+        fa4_entry_stat_acquire = (
+            f"""        _helion_flash_rt.mbar_spin_wait(
+            {corr_empty_ptr} + 0, flash_s_corr_prod_phase, {cfg.wait_hint})
+        flash_s_corr_prod_phase ^= 1
+"""
+            if acknowledged_stat_pipeline
+            else ""
+        )
+        fa4_post_p_stat_acquire = (
+            f"""            _helion_flash_rt.mbar_spin_wait(
+                {corr_empty_ptr} + 0, flash_s_corr_prod_phase, {cfg.wait_hint})
+            flash_s_corr_prod_phase ^= 1
+"""
+            if acknowledged_stat_pipeline
+            else ""
+        )
+        return f"""{
+            fa4_entry_stat_acquire
+        }        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)
         for {softmax_loop_var} in cutlass.range({kv_loop_bound}, unroll=1):{
             softmax_actual_kv
@@ -9148,6 +9239,7 @@ if warp_idx == 15:
 {_softmax_release_p_ready(stage)}
 {_sp_alpha_post}
 {sp_alpha_publish_post}
+{fa4_post_p_stat_acquire.rstrip()}
             flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum
 {sp_p_store_block}
 {final_corr_publish_rowsum}"""
@@ -9162,14 +9254,15 @@ if warp_idx == 15:
         if stage_local_softmax_setup
         else tmem_softmax_setup
     )
-    softmax_corr_prod_state = ""
+    softmax_corr_prod_state = (
+        "\n    flash_s_corr_prod_phase = cutlass.Int32(1)"
+        if acknowledged_stat_pipeline
+        else "\n    flash_s_corr_prod_phase = cutlass.Int32(0)"
+    )
     if not fa4_stat_handoff:
-        softmax_corr_prod_state = "\n    flash_s_corr_prod_phase = cutlass.Int32(0)"
-        if is_causal:
-            softmax_corr_prod_state = (
-                "\n    flash_s_corr_prod_index = cutlass.Int32(0)"
-                + softmax_corr_prod_state
-            )
+        softmax_corr_prod_state = (
+            "\n    flash_s_corr_prod_index = cutlass.Int32(0)" + softmax_corr_prod_state
+        )
     softmax0_head = f"""    cute.arch.setmaxregister_increase({cfg.softmax_regs})
 {softmax0_setup.rstrip()}
     flash_s_full_phase = cutlass.Int32(0){softmax_corr_prod_state}"""
@@ -9190,7 +9283,17 @@ if warp_idx == 15:
         )
     )
     softmax_prelude = "decode" if softmax_needs_tile_decode else "none"
-    tmem_dealloc_arrive = "    flash_tmem_user_bar.arrive()"
+    tmem_dealloc_arrive = (
+        "    _helion_flash_rt.named_barrier_arrive_unaligned(2, 13 * 32)"
+    )
+
+    def _softmax_tail(stage: str) -> str:
+        if not acknowledged_stat_pipeline:
+            return tmem_dealloc_arrive
+        return f"""    _helion_flash_rt.mbar_spin_wait(
+        flash_s{stage}_corr_empty_ptr + 0, flash_s_corr_prod_phase, {cfg.wait_hint})
+    _helion_flash_rt.named_barrier_arrive_unaligned(2, 13 * 32)"""
+
     softmax0_inner = _softmax_inner(
         "0",
         "flash_tiled_ld0",
@@ -9215,7 +9318,7 @@ if warp_idx == 15:
         softmax0_inner,
         persistent,
         prelude=softmax_prelude,
-        tail=tmem_dealloc_arrive,
+        tail=_softmax_tail("0"),
         total_tiles=total_tiles,
         num_m_pairs=num_m_pairs,
         use_2cta_instrs=use_2cta_instrs,
@@ -9231,7 +9334,7 @@ if warp_idx == 15:
         softmax1_inner,
         persistent,
         prelude=softmax_prelude,
-        tail=tmem_dealloc_arrive,
+        tail=_softmax_tail("1"),
         total_tiles=total_tiles,
         num_m_pairs=num_m_pairs,
         use_2cta_instrs=use_2cta_instrs,
@@ -9276,6 +9379,10 @@ if warp_idx == 15:
     )
     corr_stat_empty_init = (
         ""
+        if fa4_stat_pipeline
+        else """
+    cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)
+    cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)"""
         if fa4_stat_handoff
         else """
     cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)
@@ -9285,7 +9392,7 @@ if warp_idx == 15:
     )
     corr_cons_state = (
         "\n    flash_s_corr_cons_index = cutlass.Int32(0)"
-        if is_causal and not fa4_stat_handoff
+        if not fa4_stat_handoff
         else ""
     )
     corr_epi_empty_phase_head = (
@@ -9328,19 +9435,20 @@ if warp_idx == 15:
     )
 
     def _corr_epi(stage: str, mtile: str) -> str:
-        corr_cons_index = "0" if not is_causal else "flash_s_corr_cons_index"
+        corr_cons_index = "0" if fa4_stat_handoff else "flash_s_corr_cons_index"
         scale_expr = _scale_slot_expr(corr_cons_index, stage)
-        stat_empty_arrive = (
-            ""
-            if fa4_stat_handoff
-            else f"        cute.arch.mbarrier_arrive(flash_s{stage}_corr_empty_ptr + {corr_cons_index})\n"
-        )
+        stat_empty_arrive = ""
+        if not final_only_stat_pipeline:
+            stat_empty_arrive = (
+                f"        cute.arch.mbarrier_arrive("
+                f"flash_s{stage}_corr_empty_ptr + {corr_cons_index})\n"
+            )
         if not epi_smem:
             # Committed path: per-thread t2r (Ld32x32 Rep16) -> rescale -> cast ->
             # STG.E.128 straight to gmem (coord->linear address division per thread =
             # the epilogue IMAD/MOV overhead).
-            return f"""        cute.arch.barrier(
-            barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
+            return f"""        _helion_flash_rt.named_barrier_wait_unaligned(
+            {3 + int(stage) * 4} + warp_idx % 4, 64)
         flash_inv_sum{stage} = _helion_flash_rt.rcp_approx_ftz({scale_expr})
 {stat_empty_arrive}\
         {_corr_wait_o_ready(stage)}
@@ -9362,8 +9470,8 @@ if warp_idx == 15:
         # TMA-O or by vector STG.
         if scoped_corr_epi_smem:
             if split_corr_epi_handoff:
-                return f"""        cute.arch.barrier(
-            barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
+                return f"""        _helion_flash_rt.named_barrier_wait_unaligned(
+            {3 + int(stage) * 4} + warp_idx % 4, 64)
         flash_inv_sum{stage} = _helion_flash_rt.rcp_approx_ftz({scale_expr})
 {stat_empty_arrive}\
         {_corr_wait_o_ready(stage)}
@@ -9374,8 +9482,8 @@ if warp_idx == 15:
         cute.arch.fence_view_async_shared()
         {_corr_commit_epi_full(stage)}
 """
-            return f"""        cute.arch.barrier(
-            barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
+            return f"""        _helion_flash_rt.named_barrier_wait_unaligned(
+            {3 + int(stage) * 4} + warp_idx % 4, 64)
         flash_inv_sum{stage} = _helion_flash_rt.rcp_approx_ftz({scale_expr})
 {stat_empty_arrive}\
         _helion_flash_rt.{scoped_corr_epi_handoff_fn}(
@@ -9386,8 +9494,8 @@ if warp_idx == 15:
             flash_inv_sum{stage}, {hd}, {cfg.corr_tile_size}, {io_dtype},
             {cfg.wait_hint})
 """
-        return f"""        cute.arch.barrier(
-            barrier_id={3 + int(stage) * 4} + warp_idx % 4, number_of_threads=64)
+        return f"""        _helion_flash_rt.named_barrier_wait_unaligned(
+            {3 + int(stage) * 4} + warp_idx % 4, 64)
         flash_inv_sum{stage} = _helion_flash_rt.rcp_approx_ftz({scale_expr})
 {stat_empty_arrive}\
         _helion_flash_rt.fa4_correction_epilogue_handoff_to_smem(
@@ -9402,41 +9510,44 @@ if warp_idx == 15:
     corr_epi_empty_toggle = (
         "        flash_corr_epi_empty_phase ^= 1" if epi_smem else ""
     )
-    corr_cons_index = "0" if not is_causal else "flash_s_corr_cons_index"
+    corr_cons_index = "0" if fa4_stat_handoff else "flash_s_corr_cons_index"
     corr_empty0_early = (
-        ""
-        if fa4_stat_handoff
-        else (
-            "            cute.arch.mbarrier_arrive("
-            f"flash_s0_corr_empty_ptr + {corr_cons_index})"
-            if not is_causal
-            else ""
-        )
+        "            cute.arch.mbarrier_arrive("
+        f"flash_s0_corr_empty_ptr + {corr_cons_index})"
+        if not is_causal and not fa4_stat_pipeline
+        else ""
     )
     corr_empty1_early = (
-        ""
-        if fa4_stat_handoff
-        else (
-            "            cute.arch.mbarrier_arrive("
-            f"flash_s1_corr_empty_ptr + {corr_cons_index})"
-            if not is_causal
-            else ""
-        )
+        "            cute.arch.mbarrier_arrive("
+        f"flash_s1_corr_empty_ptr + {corr_cons_index})"
+        if not is_causal and not fa4_stat_pipeline
+        else ""
     )
     corr_empty0_late = (
         ""
-        if fa4_stat_handoff or not is_causal
+        if not is_causal
         else "            cute.arch.mbarrier_arrive("
         "flash_s0_corr_empty_ptr + flash_s_corr_cons_index)"
     )
     corr_empty1_late = (
         ""
-        if fa4_stat_handoff or not is_causal
+        if not is_causal
         else "            cute.arch.mbarrier_arrive("
         "flash_s1_corr_empty_ptr + flash_s_corr_cons_index)"
     )
-    corr_stage0 = f"""            cute.arch.barrier(
-                barrier_id=3 + warp_idx % 4, number_of_threads=64)
+    corr_cross_release0 = (
+        "            cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)"
+        if acknowledged_stat_pipeline
+        else ""
+    )
+    corr_cross_release1 = (
+        "            cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)"
+        if acknowledged_stat_pipeline
+        else ""
+    )
+
+    corr_stage0 = f"""            _helion_flash_rt.named_barrier_wait_unaligned(
+                3 + warp_idx % 4, 64)
             flash_a0 = {_scale_slot_expr(corr_cons_index, "0")}
 {corr_empty0_early}
             flash_need_rescale0 = cute.arch.vote_ballot_sync(flash_a0 < 1.0) != 0
@@ -9445,9 +9556,10 @@ if warp_idx == 15:
                     tOtO0, flash_a0, flash_local_tidx, {hd}, {cfg.rescale_chunk_cols})
                 cute.arch.fence_view_async_tmem_store()
             {_corr_release_p_ready("0")}
-{corr_empty0_late}"""
-    corr_stage1 = f"""            cute.arch.barrier(
-                barrier_id=7 + warp_idx % 4, number_of_threads=64)
+{corr_empty0_late}
+{corr_cross_release0}"""
+    corr_stage1 = f"""            _helion_flash_rt.named_barrier_wait_unaligned(
+                7 + warp_idx % 4, 64)
             flash_a1 = {_scale_slot_expr(corr_cons_index, "1")}
 {corr_empty1_early}
             flash_need_rescale1 = cute.arch.vote_ballot_sync(flash_a1 < 1.0) != 0
@@ -9456,10 +9568,31 @@ if warp_idx == 15:
                     tOtO1, flash_a1, flash_local_tidx, {hd}, {cfg.rescale_chunk_cols})
                 cute.arch.fence_view_async_tmem_store()
             {_corr_release_p_ready("1")}
-{corr_empty1_late}"""
+{corr_empty1_late}
+{corr_cross_release1}"""
     corr_cons_advance = (
-        "        flash_s_corr_cons_index ^= 1\n"
-        if is_causal and not fa4_stat_handoff
+        "        flash_s_corr_cons_index ^= 1\n" if not fa4_stat_handoff else ""
+    )
+    corr_stat_dummy = (
+        """        _helion_flash_rt.named_barrier_wait_unaligned(
+            3 + warp_idx % 4, 64)
+        cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)
+        _helion_flash_rt.named_barrier_wait_unaligned(
+            7 + warp_idx % 4, 64)
+"""
+        if acknowledged_stat_pipeline
+        else ""
+    )
+    corr_stat_release_held = (
+        "        cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)\n"
+        if acknowledged_stat_pipeline
+        else ""
+    )
+    corr_final_stat_release = (
+        """        cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)
+        cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)
+"""
+        if final_only_stat_pipeline
         else ""
     )
     # flash_pvt's direct-gmem partition already includes the CTA rank. Start it
@@ -9479,9 +9612,11 @@ if warp_idx == 15:
 {corr_cons_advance.rstrip()}
         flash_o_full_phase ^= 1"""
     else:
-        corr_inner = f"""        for flash_kv in cutlass.range({kv_loop_bound_minus_1}, unroll=1):
+        corr_inner = f"""{corr_stat_dummy}        for flash_kv in cutlass.range({kv_loop_bound_minus_1}, unroll=1):
 {corr_steady_stages}
 {textwrap.indent(corr_cons_advance.rstrip(), "    ")}
+{corr_stat_release_held.rstrip()}
+{corr_final_stat_release.rstrip()}
         # Final: divide by row_sum, cast, store (waits MMA's last-tile O_full).
 {_corr_epi("0", corr_output_m_tile0)}
         {_corr_release_p_ready("0")}

--- a/helion/_compiler/cute/flash_schedule.py
+++ b/helion/_compiler/cute/flash_schedule.py
@@ -17,6 +17,8 @@ class FlashNodeKind(enum.Enum):
     QK_MMA = "qk_mma"
     SOFTMAX = "softmax"
     STAT_PUBLISH = "stat_publish"
+    FINAL_STAT_PUBLISH = "final_stat_publish"
+    FINAL_STAT_CONSUME = "final_stat_consume"
     CORRECTION = "correction"
     PV_MMA = "pv_mma"
     OUTPUT_STAGE = "output_stage"
@@ -61,6 +63,9 @@ class FlashScheduleSpec:
     output_order: FlashOutputOrder = FlashOutputOrder.INTERLEAVED
     cooperative_mma: bool = False
     split_p_arrive: bool = True
+    stat_depth: int = 2
+    pipelined_stat_handoff: bool = False
+    final_only_stat_handoff: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -102,6 +107,7 @@ class FlashMemoryRegion:
     writer: str
     consumers: tuple[str, ...]
     reuse_distance: int | None = None
+    reuse_barrier: str | None = None
     alias_group: str | None = None
     cta_rank: int | None = None
     physical: bool = True
@@ -201,6 +207,18 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
         raise FlashScheduleError("output order is invalid")
     if spec.dtype_bytes <= 0:
         raise FlashScheduleError("dtype size must be positive")
+    if spec.stat_depth not in (1, 2):
+        raise FlashScheduleError("stat transport depth must be one or two")
+    if spec.pipelined_stat_handoff and (spec.stat_depth != 1 or spec.causal):
+        raise FlashScheduleError(
+            "pipelined stat handoff requires depth one and a noncausal schedule"
+        )
+    if spec.final_only_stat_handoff and (spec.stat_depth != 1 or spec.causal):
+        raise FlashScheduleError(
+            "final-only stat handoff requires depth one and a noncausal schedule"
+        )
+    if spec.pipelined_stat_handoff and spec.final_only_stat_handoff:
+        raise FlashScheduleError("stat handoff modes are mutually exclusive")
 
     nodes: list[FlashNode] = []
     edges: list[FlashEdge] = []
@@ -226,6 +244,7 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
     overhead_offset = output_offset + (
         spec.query_slots_per_cta * tile_bytes if spec.stage_output else 0
     )
+    stat_bytes_per_query = spec.stat_depth * 128 * 4
 
     load_nodes: set[str] = set()
     for rank in range(spec.cta_count):
@@ -352,6 +371,8 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
             qk = _node_name("qk", rank, slot)
             softmax = _node_name("softmax", rank, slot)
             stat = _node_name("stat", rank, slot)
+            final_stat_publish = _node_name("final_stat_publish", rank, slot)
+            final_stat_consume = _node_name("final_stat_consume", rank, slot)
             correction = _node_name("correction", rank, slot)
             pv = _node_name("pv", rank, slot)
             output_stage = _node_name("output_stage", rank, slot)
@@ -368,16 +389,35 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
                     FlashNode(output_store, FlashNodeKind.OUTPUT_STORE, rank, slot),
                 ]
             )
+            if spec.final_only_stat_handoff:
+                nodes.extend(
+                    [
+                        FlashNode(
+                            final_stat_publish,
+                            FlashNodeKind.FINAL_STAT_PUBLISH,
+                            rank,
+                            slot,
+                        ),
+                        FlashNode(
+                            final_stat_consume,
+                            FlashNodeKind.FINAL_STAT_CONSUME,
+                            rank,
+                            slot,
+                        ),
+                    ]
+                )
 
             q_ready = f"q_ready_r{rank}_q{slot}"
             s_full = f"s_full_r{rank}_q{slot}"
             stat_ready = f"stat_ready_r{rank}_q{slot}"
+            stat_empty = f"stat_empty_r{rank}_q{slot}"
             o_full = f"o_full_r{rank}_q{slot}"
             barriers.extend(
                 [
                     FlashBarrier(q_ready, 1, FlashSyncScope.CTA),
                     FlashBarrier(s_full, 1, FlashSyncScope.CTA),
                     FlashBarrier(stat_ready, 1, FlashSyncScope.CTA),
+                    FlashBarrier(stat_empty, 1, FlashSyncScope.CTA),
                     FlashBarrier(o_full, 1, FlashSyncScope.CTA),
                 ]
             )
@@ -448,6 +488,40 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
                     ),
                 ]
             )
+            if not spec.final_only_stat_handoff:
+                edges.append(
+                    FlashEdge(
+                        correction,
+                        stat,
+                        iteration_delta=spec.stat_depth,
+                        barrier=stat_empty,
+                        arrival_count=1,
+                    )
+                )
+            else:
+                edges.extend(
+                    [
+                        FlashEdge(
+                            correction,
+                            final_stat_publish,
+                            barrier=stat_empty,
+                            arrival_count=1,
+                        ),
+                        FlashEdge(
+                            final_stat_publish,
+                            final_stat_consume,
+                            resource=f"FINAL_STAT_r{rank}_q{slot}",
+                        ),
+                    ]
+                )
+                if spec.persistent:
+                    edges.append(
+                        FlashEdge(
+                            final_stat_consume,
+                            stat,
+                            iteration_delta=1,
+                        )
+                    )
             if slot + 1 == spec.query_slots_per_cta:
                 if spec.cooperative_mma and rank != 0:
                     reuse_ranks: tuple[int, ...] | range = ()
@@ -564,15 +638,42 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
                 FlashMemoryRegion(
                     f"STAT_r{rank}_q{slot}",
                     FlashMemorySpace.SMEM,
-                    overhead_offset + slot * 64,
-                    64,
+                    overhead_offset + slot * stat_bytes_per_query,
+                    stat_bytes_per_query,
                     16,
                     FlashVisibility.CTA_PRIVATE,
                     stat,
                     (correction,),
+                    reuse_distance=(
+                        1 if spec.final_only_stat_handoff else spec.stat_depth
+                    ),
+                    reuse_barrier=(
+                        None if spec.final_only_stat_handoff else stat_empty
+                    ),
+                    alias_group=(
+                        f"stat_terminal_r{rank}_q{slot}"
+                        if spec.final_only_stat_handoff
+                        else None
+                    ),
                     cta_rank=rank,
                 )
             )
+            if spec.final_only_stat_handoff:
+                regions.append(
+                    FlashMemoryRegion(
+                        f"FINAL_STAT_r{rank}_q{slot}",
+                        FlashMemorySpace.SMEM,
+                        overhead_offset + slot * stat_bytes_per_query,
+                        stat_bytes_per_query,
+                        16,
+                        FlashVisibility.CTA_PRIVATE,
+                        final_stat_publish,
+                        (final_stat_consume,),
+                        reuse_distance=1 if spec.persistent else None,
+                        alias_group=f"stat_terminal_r{rank}_q{slot}",
+                        cta_rank=rank,
+                    )
+                )
             if spec.stage_output:
                 regions.append(
                     FlashMemoryRegion(
@@ -651,8 +752,14 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
             )
         cycles = []
         for barrier in barriers:
+            stat_barrier = barrier.name.startswith(("stat_ready", "stat_empty"))
             uses_per_work = (
-                spec.kv_iterations
+                1
+                if spec.final_only_stat_handoff
+                and barrier.name.startswith("stat_empty")
+                else spec.kv_iterations + 1
+                if stat_barrier and spec.pipelined_stat_handoff
+                else spec.kv_iterations
                 if barrier.name.startswith(
                     (
                         "k_ready",
@@ -661,15 +768,25 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
                         "v_reuse",
                         "s_full",
                         "stat_ready",
+                        "stat_empty",
                         "pfor",
                     )
                 )
                 else 1
             )
+            initial_phase = (
+                1
+                if spec.pipelined_stat_handoff and barrier.name.startswith("stat_empty")
+                else 0
+            )
             cycles.append(
                 FlashPhaseCycle(
                     barrier.name,
-                    (0, uses_per_work & 1, 0),
+                    (
+                        initial_phase,
+                        initial_phase ^ (uses_per_work & 1),
+                        initial_phase,
+                    ),
                     uses_per_work,
                 )
             )
@@ -789,6 +906,29 @@ def verify_flash_schedule(
                 f"barrier {barrier.name} expected {barrier.expected_arrivals} "
                 f"arrivals, got {arrivals[barrier.name]}"
             )
+    if schedule.spec.final_only_stat_handoff:
+        edge_keys = {
+            (edge.source, edge.target, edge.iteration_delta, edge.barrier)
+            for edge in schedule.edges
+        }
+        for rank in range(schedule.spec.cta_count):
+            for slot in range(schedule.spec.query_slots_per_cta):
+                correction = _node_name("correction", rank, slot)
+                stat = _node_name("stat", rank, slot)
+                publish = _node_name("final_stat_publish", rank, slot)
+                consume = _node_name("final_stat_consume", rank, slot)
+                if (
+                    (correction, publish, 0, f"stat_empty_r{rank}_q{slot}")
+                    not in edge_keys
+                    or (publish, consume, 0, None) not in edge_keys
+                    or (
+                        schedule.spec.persistent
+                        and (consume, stat, 1, None) not in edge_keys
+                    )
+                ):
+                    raise FlashScheduleError(
+                        "final-only stat handoff is missing terminal ordering"
+                    )
     if schedule.spec.multicast_kv:
         for rank in range(schedule.spec.cta_count):
             for operand, consumer_kind in (("k", "qk"), ("v", "pv")):
@@ -907,6 +1047,20 @@ def verify_flash_schedule(
                     raise FlashScheduleError(
                         f"memory region {region.name} is reused before all consumers"
                     )
+            if region.reuse_barrier is not None:
+                for consumer in region.consumers:
+                    if not any(
+                        edge.source == consumer
+                        and edge.target == region.writer
+                        and edge.iteration_delta == region.reuse_distance
+                        and edge.barrier == region.reuse_barrier
+                        for edge in schedule.edges
+                    ):
+                        raise FlashScheduleError(
+                            f"memory region {region.name} is reused before all consumers"
+                        )
+        elif region.reuse_barrier is not None:
+            raise FlashScheduleError("reuse barrier requires a reuse distance")
 
     for rank in range(schedule.spec.cta_count):
         k_region = region_by_name.get(f"K_r{rank}")

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -4197,7 +4197,7 @@ class TestCuteAutotuner(TestCase):
         )
         self.assertEqual(
             set(flash_fragments[FLASH_STAT_TRANSPORT_KEY].choices),
-            {"ring2", "single"},
+            {"ring2", "single", "single_final"},
         )
         self.assertEqual(
             set(flash_fragments[FLASH_MMA_INTERLEAVE_KEY].choices), {False, True}
@@ -4206,7 +4206,12 @@ class TestCuteAutotuner(TestCase):
             flash_fragments[FLASH_MMA_INTERLEAVE_KEY].search_choices, (True,)
         )
         self.assertEqual(
-            flash_fragments[FLASH_STAT_TRANSPORT_KEY].search_choices, ("single",)
+            flash_fragments[FLASH_STAT_TRANSPORT_KEY].search_choices,
+            ("single", "ring2", "single_final"),
+        )
+        self.assertIn(
+            "ring2",
+            flash_fragments[FLASH_STAT_TRANSPORT_KEY].pattern_neighbors("single"),
         )
         self.assertEqual(
             set(flash_fragments[FLASH_EXP2_PACKET_KEY].search_choices or ()),
@@ -4735,6 +4740,7 @@ class TestCuteAutotuner(TestCase):
             ("stage",),
         )
         common_very_long_dense_search_choices = {
+            FLASH_PERSISTENT_KEY: (True, False),
             FLASH_PERSISTENT_CTAS_PER_SM_KEY: (1,),
             FLASH_CORR_TILE_SIZE_KEY: (8, 16),
             FLASH_SOFTMAX_DISC_KEY: (False,),
@@ -4915,7 +4921,8 @@ class TestCuteAutotuner(TestCase):
             long_dense_fragments[FLASH_SOFTMAX_DISC_KEY].search_choices, (True, False)
         )
         self.assertEqual(
-            long_dense_fragments[FLASH_PERSISTENT_KEY].search_choices, (True,)
+            long_dense_fragments[FLASH_PERSISTENT_KEY].search_choices,
+            (True, False),
         )
         self.assertEqual(
             long_dense_fragments[FLASH_P_STORE_REP_KEY].search_choices, (16, 32)
@@ -5300,7 +5307,10 @@ class TestCuteAutotuner(TestCase):
                 random_long[FLASH_EXP2_PACKET_KEY],
                 {"1x1", "4x1", "4x2", "8x1", "8x2"},
             )
-            self.assertIn(random_long[FLASH_STAT_TRANSPORT_KEY], {"ring2", "single"})
+            self.assertIn(
+                random_long[FLASH_STAT_TRANSPORT_KEY],
+                {"ring2", "single", "single_final"},
+            )
             self.assertIn(random_long[FLASH_MMA_INTERLEAVE_KEY], {False, True})
             self.assertEqual(
                 random_long[FLASH_Q_TILE_COUNT_KEY],
@@ -5310,7 +5320,7 @@ class TestCuteAutotuner(TestCase):
             self.assertIn(random_long[FLASH_RESCALE_CHUNK_COLS_KEY], {16, 32})
             self.assertEqual(random_long[FLASH_S_STAGE_KEY], 2)
             self.assertIn(random_long[FLASH_KV_STAGE_KEY], {2, 3, 4, 6, 8})
-            self.assertTrue(random_long[FLASH_PERSISTENT_KEY])
+            self.assertIn(random_long[FLASH_PERSISTENT_KEY], {False, True})
             self.assertIn(random_long[FLASH_PERSISTENT_CTAS_PER_SM_KEY], {1, 2, 3, 4})
             self.assertIn(random_long[FLASH_P_STORE_REP_KEY], {16, 32})
             self.assertIn(random_long[FLASH_S_LOAD_REP_KEY], {16, 32})
@@ -5328,7 +5338,12 @@ class TestCuteAutotuner(TestCase):
             )
             self.assertTrue(random_long[FLASH_PACKED_REDUCE_KEY])
             effective_values = flash_effective_config_values(
-                flash_config_from_config(random_long, 64, 64)
+                flash_config_from_config(
+                    random_long,
+                    64,
+                    64,
+                    standard_dense_output=True,
+                )
             )
             for key, value in effective_values.items():
                 self.assertEqual(random_long[key], value, key)

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -190,6 +190,7 @@ from helion.autotuner.config_spec import ReductionCategory
 from helion.autotuner.config_spec import ReductionDescriptor
 from helion.autotuner.config_spec import ReductionKernelFact
 from helion.autotuner.config_spec import ReductionLoopSpec
+from helion.autotuner.effort_profile import get_effort_profile
 from helion.autotuner.pattern_search import InitialPopulationStrategy
 from helion.autotuner.pattern_search import PatternSearch
 import helion.language as hl
@@ -2470,6 +2471,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         cases = (
             (64, 256, torch.float16, False, False, True),
             (64, 1024, torch.float16, False, False, True),
+            (64, 2048, torch.float16, False, False, True),
             (64, 512, torch.float16, True, False, False),
             (128, 256, torch.float16, False, False, True),
             (64, 256, torch.bfloat16, False, False, False),
@@ -2535,7 +2537,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 normalized_seeds = [
                     config for _flat, config in config_gen.seed_flat_config_pairs()
                 ]
-                self.assertLessEqual(len(normalized_seeds), 5)
+                self.assertLessEqual(len(normalized_seeds), 6)
                 self.assertLessEqual(
                     legal_families,
                     {
@@ -2549,8 +2551,29 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     )
                     family_default = family_gen.unflatten(family_gen.default_flat())
                     self.assertIn(family_default, normalized_seeds)
+                if (
+                    head_dim == 64
+                    and dtype is torch.float16
+                    and not is_causal
+                    and standard_dense_output
+                ):
+                    self.assertFalse(
+                        any(
+                            config.config[FLASH_EXP2_PACKET_KEY]
+                            in {"deg1_8x2_corr10", "deg1_16x8"}
+                            for config in normalized_seeds
+                        )
+                    )
+                    self.assertEqual(
+                        {
+                            config.config[FLASH_STAT_TRANSPORT_KEY]
+                            for config in normalized_seeds
+                            if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
+                        },
+                        {"ring2", "single_final"} if num_kv == 2048 else set(),
+                    )
 
-    def test_cute_flash_dense_degree1_seed_uses_family_defaults(self) -> None:
+    def test_cute_flash_dense_degree2_seed_uses_validated_schedule(self) -> None:
         degree1_packets = {"deg1_8x2_corr10", "deg1_16x8"}
         for num_kv in (256, 260, 512, 1024, 1536, 2044, 2048, 2052, 4096):
             with self.subTest(num_kv=num_kv):
@@ -2560,13 +2583,39 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     dtype=torch.float16,
                     standard_dense_output=True,
                 )
-                degree1_seeds = [
+                self.assertFalse(
+                    any(
+                        seed.config.get(FLASH_EXP2_PACKET_KEY) in degree1_packets
+                        for seed in seeds
+                    )
+                )
+                degree2_seeds = [
                     seed
                     for seed in seeds
-                    if seed.config.get(FLASH_EXP2_PACKET_KEY) in degree1_packets
+                    if seed.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
                 ]
-                self.assertEqual(len(degree1_seeds), 1)
-                config = degree1_seeds[0].config
+                if num_kv != 2048:
+                    self.assertFalse(degree2_seeds)
+                    continue
+                self.assertEqual(len(degree2_seeds), 2)
+                self.assertEqual(
+                    {seed.config[FLASH_STAT_TRANSPORT_KEY] for seed in degree2_seeds},
+                    {"ring2", "single_final"},
+                )
+                config = next(
+                    seed.config
+                    for seed in degree2_seeds
+                    if seed.config[FLASH_STAT_TRANSPORT_KEY] == "single_final"
+                )
+                ring2_config = next(
+                    seed.config
+                    for seed in degree2_seeds
+                    if seed.config[FLASH_STAT_TRANSPORT_KEY] == "ring2"
+                )
+                self.assertEqual(
+                    ring2_config,
+                    {**config, FLASH_STAT_TRANSPORT_KEY: "ring2"},
+                )
                 fragments = flash_autotune_fragments(
                     64,
                     num_kv,
@@ -2576,34 +2625,27 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 )
 
                 self.assertEqual(config[FLASH_PIPELINE_FAMILY_KEY], "fa4_2cta")
-                changed_keys = {FLASH_EXP2_PACKET_KEY, FLASH_E2E_SCHEDULE_KEY}
-                if num_kv < 2048:
-                    self.assertEqual(config[FLASH_EXP2_PACKET_KEY], "deg1_8x2_corr10")
-                    self.assertEqual(config[FLASH_E2E_SCHEDULE_KEY], "8/2")
-                    self.assertEqual(
-                        config[FLASH_E2E_OFFSET_KEY],
-                        fragments[FLASH_E2E_OFFSET_KEY].default(),
-                    )
-                    self.assertEqual(
-                        config[FLASH_E2E_OFFSET0_KEY],
-                        fragments[FLASH_E2E_OFFSET0_KEY].default(),
-                    )
-                else:
-                    self.assertEqual(config[FLASH_EXP2_PACKET_KEY], "deg1_16x8")
-                    self.assertEqual(config[FLASH_E2E_SCHEDULE_KEY], "16/8")
-                    self.assertEqual(config[FLASH_E2E_OFFSET_KEY], 0)
-                    self.assertEqual(config[FLASH_E2E_OFFSET0_KEY], 10)
-                    self.assertEqual(config[FLASH_KV_STAGE_KEY], 2)
-                    changed_keys.update(
-                        {
-                            FLASH_E2E_OFFSET_KEY,
-                            FLASH_E2E_OFFSET0_KEY,
-                            FLASH_KV_STAGE_KEY,
-                        }
-                    )
+                expected = {
+                    FLASH_EXP2_PACKET_KEY: "deg2_16x6",
+                    FLASH_E2E_SCHEDULE_KEY: "16/6",
+                    FLASH_E2E_OFFSET_KEY: 0,
+                    FLASH_E2E_OFFSET0_KEY: 2,
+                    FLASH_KV_STAGE_KEY: 2,
+                    FLASH_PERSISTENT_KEY: False,
+                    FLASH_STAT_TRANSPORT_KEY: "single_final",
+                    FLASH_WAIT_HINT_KEY: 0,
+                    FLASH_SOFTMAX_REGS_KEY: 192,
+                    FLASH_CORR_REGS_KEY: 72,
+                    FLASH_OTHER_REGS_KEY: 40,
+                    FLASH_ROLE_MAP_KEY: "fa4",
+                    FLASH_RESCALE_THRESHOLD_KEY: 8.0,
+                    FLASH_RESCALE_CHUNK_COLS_KEY: 8,
+                }
+                for key, value in expected.items():
+                    self.assertEqual(config[key], value)
 
                 for key, fragment in fragments.items():
-                    if key not in changed_keys:
+                    if key not in expected:
                         self.assertEqual(config[key], fragment.default())
                 packet_fragment = fragments[FLASH_EXP2_PACKET_KEY]
                 self.assertIsInstance(packet_fragment, EnumFragment)
@@ -2613,16 +2655,14 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     packet_fragment.search_choices or (),
                 )
 
-    def test_cute_flash_dense_degree1_seed_gates(self) -> None:
-        degree1_packets = {"deg1_8x2_corr10", "deg1_16x8"}
-
-        def has_degree1_seed(
+    def test_cute_flash_dense_degree2_seed_gates(self) -> None:
+        def has_degree2_seed(
             head_dim: int = 64,
-            num_kv: int = 512,
+            num_kv: int = 2048,
             **kwargs: object,
         ) -> bool:
             return any(
-                seed.config.get(FLASH_EXP2_PACKET_KEY) in degree1_packets
+                seed.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
                 for seed in flash_attention_seed_configs(
                     head_dim,
                     num_kv,
@@ -2642,6 +2682,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 "standard_dense_output": True,
                 "block_size_targets": (1, 64, 128),
             },
+            {"standard_dense_output": True, "num_kv": 2044},
+            {"standard_dense_output": True, "num_kv": 2052},
+            {"standard_dense_output": True, "num_kv": 4096},
             {"standard_dense_output": True, "num_kv": 252},
             {"standard_dense_output": True, "num_kv": 258},
             {"standard_dense_output": True, "num_kv": 2050},
@@ -2654,11 +2697,48 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             with self.subTest(case=subtest_case):
                 case = dict(case)
                 head_dim = int(case.pop("head_dim", 64))
-                num_kv = int(case.pop("num_kv", 512))
-                self.assertFalse(has_degree1_seed(head_dim, num_kv, **case))
+                num_kv = int(case.pop("num_kv", 2048))
+                self.assertFalse(has_degree2_seed(head_dim, num_kv, **case))
 
-    def test_cute_flash_long_causal_hybrid_seed(self) -> None:
-        for num_kv in (512, 4096, 8192):
+    def test_cute_flash_dense_degree2_seed_is_in_full_initial_population(
+        self,
+    ) -> None:
+        spec = ConfigSpec(backend=CuteBackend())
+        for block_id, target in enumerate((1, 128, 128)):
+            spec.block_sizes.append(BlockSizeSpec(block_id=block_id, size_hint=target))
+        spec.enable_cute_flash_search(
+            head_dim=64,
+            num_kv=2048,
+            block_size_targets={0: 1, 1: 128, 2: 128},
+            dtype=torch.float16,
+            is_causal=False,
+            standard_dense_output=True,
+        )
+        spec.compiler_seed_configs = list(
+            flash_attention_seed_configs(
+                64,
+                2048,
+                dtype=torch.float16,
+                standard_dense_output=True,
+            )
+        )
+        config_gen = ConfigGeneration(spec)
+        expected = next(
+            config
+            for _flat, config in config_gen.seed_flat_config_pairs()
+            if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
+            and config.config[FLASH_STAT_TRANSPORT_KEY] == "single_final"
+        )
+        profile = get_effort_profile("full").lfbo_pattern_search
+        assert profile is not None
+        self.assertEqual(profile.initial_population_strategy, "from_random")
+        population = config_gen.random_population(profile.initial_population)
+        self.assertEqual(population.count(expected), 1)
+
+    def test_cute_flash_does_not_automatically_seed_degree1_causal_packet(
+        self,
+    ) -> None:
+        for num_kv in (256, 512, 768, 4096, 8192):
             with self.subTest(num_kv=num_kv):
                 seeds = flash_attention_seed_configs(
                     64,
@@ -2666,29 +2746,10 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     is_causal=True,
                     standard_causal_output=True,
                 )
-                hybrid = [
-                    seed
-                    for seed in seeds
-                    if seed.config.get(FLASH_EXP2_PACKET_KEY) == "hybrid_deg1_16x8"
-                ]
-                self.assertEqual(len(hybrid), 1)
-                config = hybrid[0].config
-                self.assertEqual(config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
-                self.assertEqual(config[FLASH_E2E_SCHEDULE_KEY], "16/8")
-                self.assertEqual(config[FLASH_MASKED_E2E_SCHEDULE_KEY], "16/8")
-                self.assertTrue(config[FLASH_CAUSAL_LOOP_SPLIT_KEY])
-
-        for num_kv in (256, 768):
-            with self.subTest(num_kv=num_kv):
                 self.assertFalse(
                     any(
                         seed.config.get(FLASH_EXP2_PACKET_KEY) == "hybrid_deg1_16x8"
-                        for seed in flash_attention_seed_configs(
-                            64,
-                            num_kv,
-                            is_causal=True,
-                            standard_causal_output=True,
-                        )
+                        for seed in seeds
                     )
                 )
 
@@ -2714,7 +2775,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         normalized = [
             config for _flat, config in ConfigGeneration(spec).seed_flat_config_pairs()
         ]
-        self.assertEqual(len(normalized), 4)
+        self.assertEqual(len(normalized), 3)
         self.assertEqual(
             {
                 (
@@ -2726,10 +2787,114 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             {
                 ("fa4", "1x1"),
                 ("fa4", "4x1"),
-                ("fa4", "hybrid_deg1_16x8"),
                 ("ws_overlap", "1x1"),
             },
         )
+
+    def test_cute_flash_causal_degree2_seed_uses_validated_schedule(self) -> None:
+        for num_kv in (2048, 4096, 8192):
+            with self.subTest(num_kv=num_kv):
+                seeds = flash_attention_seed_configs(
+                    64,
+                    num_kv,
+                    is_causal=True,
+                    standard_causal_output=True,
+                )
+                degree2_seeds = [
+                    seed
+                    for seed in seeds
+                    if seed.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
+                ]
+                if num_kv != 4096:
+                    self.assertFalse(degree2_seeds)
+                    continue
+                self.assertEqual(len(degree2_seeds), 1)
+                config = degree2_seeds[0].config
+                expected = {
+                    FLASH_PIPELINE_FAMILY_KEY: "fa4",
+                    FLASH_E2E_SCHEDULE_KEY: "16/6",
+                    FLASH_MASKED_E2E_SCHEDULE_KEY: "16/6",
+                    FLASH_E2E_OFFSET_KEY: 0,
+                    FLASH_E2E_OFFSET0_KEY: 14,
+                    FLASH_WAIT_HINT_KEY: 0,
+                    FLASH_DISC_PIPE_KEY: 3,
+                    FLASH_RESCALE_CHUNK_COLS_KEY: 16,
+                    FLASH_CAUSAL_LPT_SWIZZLE_KEY: 0,
+                    FLASH_CAUSAL_KV_ORDER_KEY: "descending",
+                    FLASH_CAUSAL_LOOP_SPLIT_KEY: True,
+                    FLASH_SOFTMAX_REGS_KEY: 184,
+                    FLASH_CORR_REGS_KEY: 64,
+                    FLASH_OTHER_REGS_KEY: 48,
+                }
+                for key, value in expected.items():
+                    self.assertEqual(config[key], value)
+
+    def test_cute_flash_causal_degree2_seed_gates(self) -> None:
+        cases = (
+            {},
+            {"dtype": torch.bfloat16, "standard_causal_output": True},
+            {"head_dim": 128, "standard_causal_output": True},
+            {"has_kv_tile_pruning": True, "standard_causal_output": True},
+            {"requires_ws_overlap": True, "standard_causal_output": True},
+            {"small_biased_candidate": True, "standard_causal_output": True},
+            {
+                "block_size_targets": (1, 64, 128),
+                "standard_causal_output": True,
+            },
+        )
+        for case in cases:
+            subtest_case = {
+                key: str(value) if isinstance(value, torch.dtype) else value
+                for key, value in case.items()
+            }
+            with self.subTest(case=subtest_case):
+                case = dict(case)
+                head_dim = int(case.pop("head_dim", 64))
+                self.assertFalse(
+                    any(
+                        seed.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
+                        for seed in flash_attention_seed_configs(
+                            head_dim,
+                            4096,
+                            is_causal=True,
+                            **case,
+                        )
+                    )
+                )
+
+    def test_cute_flash_causal_degree2_seed_is_in_full_initial_population(
+        self,
+    ) -> None:
+        spec = ConfigSpec(backend=CuteBackend())
+        for block_id, target in enumerate((1, 128, 128)):
+            spec.block_sizes.append(BlockSizeSpec(block_id=block_id, size_hint=target))
+        spec.enable_cute_flash_search(
+            head_dim=64,
+            num_kv=4096,
+            block_size_targets={0: 1, 1: 128, 2: 128},
+            dtype=torch.float16,
+            is_causal=True,
+            standard_causal_output=True,
+        )
+        spec.compiler_seed_configs = list(
+            flash_attention_seed_configs(
+                64,
+                4096,
+                is_causal=True,
+                standard_causal_output=True,
+            )
+        )
+        config_gen = ConfigGeneration(spec)
+        expected = next(
+            config
+            for _flat, config in config_gen.seed_flat_config_pairs()
+            if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
+        )
+        profile = get_effort_profile("full").lfbo_pattern_search
+        assert profile is not None
+        population = config_gen.random_population(profile.initial_population)
+        seed_count = len(config_gen.seed_flat_config_pairs())
+        self.assertIn(expected, population[:seed_count])
 
     @onlyBackends(["cute"])
     def test_cute_flash_attention_seed_heuristic(self) -> None:
@@ -2994,12 +3159,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertIn(
             causal_65536_seed, causal_65536_bound.config_spec.compiler_seed_configs
         )
-        hybrid_seeds = [
-            seed
-            for seed in causal_65536_bound.config_spec.compiler_seed_configs
-            if seed.config.get(FLASH_EXP2_PACKET_KEY) == "hybrid_deg1_16x8"
-        ]
-        self.assertEqual(len(hybrid_seeds), 1)
+        self.assertFalse(
+            any(
+                seed.config.get(FLASH_EXP2_PACKET_KEY) == "hybrid_deg1_16x8"
+                for seed in causal_65536_bound.config_spec.compiler_seed_configs
+            )
+        )
         with patch.object(
             PatternSearch,
             "_find_similar_cached_configs",
@@ -3018,7 +3183,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 quick_search.config_gen.unflatten(flat)
                 for flat in quick_search._generate_initial_population_flat()
             ]
-        self.assertEqual(len(quick_configs), 4)
+        self.assertEqual(len(quick_configs), 3)
         self.assertIsNone(causal_65536_bound.config_spec.compiler_default_config)
         causal_65536_gen = ConfigGeneration(causal_65536_bound.config_spec)
         causal_65536_default = causal_65536_gen.unflatten(

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -2475,8 +2475,14 @@ class TestCuteBackend(TestCase):
                 if "flash_grid_m_pairs_delta" in code:
                     self.assertIn("flash_grid_m_pairs_delta", code)
                     self.assertIn("flash_tmem_dealloc_ptr", code)
-                    self.assertIn("flash_tmem_user_bar.arrive_and_wait()", code)
-                    self.assertIn("flash_tmem_user_bar.arrive()", code)
+                    self.assertIn(
+                        "_helion_flash_rt.named_barrier_wait_unaligned(2, 13 * 32)",
+                        code,
+                    )
+                    self.assertIn(
+                        "_helion_flash_rt.named_barrier_arrive_unaligned(2, 13 * 32)",
+                        code,
+                    )
                     self.assertNotIn("mbarrier_wait(flash_tmem_dealloc_ptr, 0)", code)
                     self.assertNotIn("mbarrier_arrive(flash_tmem_dealloc_ptr)", code)
                     self.assertNotIn("cute.arch.barrier()", code)
@@ -2614,12 +2620,99 @@ class TestCuteBackend(TestCase):
             cute_flash_stat_transport="single",
         )
         self.assertIn("while flash_tile_id < 192", code)
-        self.assertNotIn("flash_s_corr_prod_phase", code)
+        self.assertIn("flash_s_corr_prod_phase = cutlass.Int32(0)", code)
+        self.assertNotIn("flash_s_corr_prod_index", code)
+        for stage, barrier_id in ((0, 3), (1, 7)):
+            empty_arrive = (
+                f"cute.arch.mbarrier_arrive(flash_s{stage}_corr_empty_ptr + 0)"
+            )
+            self.assertIn(empty_arrive, code)
+            producer_wait_text = (
+                f"_helion_flash_rt.mbar_spin_wait("
+                f"flash_s{stage}_corr_empty_ptr + 0, flash_s_corr_prod_phase,"
+            )
+            producer_wait = code.index(producer_wait_text)
+            alpha_store = code.index(
+                f"flash_scale_t[{stage} * 128 + flash_local_tidx] = flash_alpha",
+                producer_wait,
+            )
+            producer_publish = code.index(
+                "_helion_flash_rt.named_barrier_arrive_unaligned(", alpha_store
+            )
+            producer_advance = code.index(
+                "flash_s_corr_prod_phase ^= 1", producer_publish
+            )
+            rowsum_wait = code.index(producer_wait_text, producer_advance)
+            rowsum_store = code.index(
+                f"flash_scale_t[{stage} * 128 + flash_local_tidx] = flash_row_sum",
+                rowsum_wait,
+            )
+            rowsum_publish = code.index(
+                "_helion_flash_rt.named_barrier_arrive_unaligned(", rowsum_store
+            )
+            rowsum_advance = code.index("flash_s_corr_prod_phase ^= 1", rowsum_publish)
+            consumer_wait = code.index(
+                f"_helion_flash_rt.named_barrier_wait_unaligned("
+                f"{barrier_id} + warp_idx % 4, 64)",
+                rowsum_advance,
+            )
+            alpha_load = code.index(
+                f"flash_a{stage} = flash_scale_t[{stage} * 128 + flash_local_tidx]",
+                consumer_wait,
+            )
+            consumer_release = code.index(empty_arrive, alpha_load)
+            final_wait = code.index(
+                f"_helion_flash_rt.named_barrier_wait_unaligned("
+                f"{barrier_id} + warp_idx % 4, 64)",
+                consumer_release,
+            )
+            rowsum_load = code.index(
+                f"flash_inv_sum{stage} = _helion_flash_rt.rcp_approx_ftz("
+                f"flash_scale_t[{stage} * 128 + flash_local_tidx])",
+                final_wait,
+            )
+            final_release = code.index(empty_arrive, rowsum_load)
+            self.assertLess(producer_wait, alpha_store)
+            self.assertLess(alpha_store, producer_publish)
+            self.assertLess(producer_publish, producer_advance)
+            self.assertLess(producer_advance, rowsum_wait)
+            self.assertLess(rowsum_wait, rowsum_store)
+            self.assertLess(rowsum_store, rowsum_publish)
+            self.assertLess(rowsum_publish, rowsum_advance)
+            self.assertLess(rowsum_advance, consumer_wait)
+            self.assertLess(consumer_wait, alpha_load)
+            self.assertLess(alpha_load, consumer_release)
+            self.assertLess(consumer_release, final_wait)
+            self.assertLess(final_wait, rowsum_load)
+            self.assertLess(rowsum_load, final_release)
         expected = torch.nn.functional.scaled_dot_product_attention(
             q, k, v, attn_mask=bias
         )
         torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
         self.assertTrue(torch.isfinite(lse).all())
+
+    def test_flash_attention_late_acquire_stat_handoff_persistent(self) -> None:
+        q, k, v = (
+            torch.randn(1, 64, 768, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        code, out = code_and_output(
+            cute_dense_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4",
+            cute_flash_persistent=True,
+            cute_flash_stat_transport="single",
+            cute_flash_exp2_packet="8x2",
+            cute_flash_softmax_disc=False,
+            cute_flash_rescale_threshold=8.0,
+        )
+
+        self.assertIn("while flash_tile_id < 192", code)
+        self.assertEqual(code.count("flash_s_corr_prod_phase = cutlass.Int32(1)"), 2)
+        self.assertNotIn("flash_s_corr_prod_phase = cutlass.Int32(0)", code)
+        expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
     def test_flash_attention_fa4_deep_one_cta_causal_split_matches_sdpa(
         self,
@@ -2706,6 +2799,30 @@ class TestCuteBackend(TestCase):
         self.assertIn("is_two_cta=True", code)
         torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
         torch.testing.assert_close(lse, expected_lse, atol=2e-2, rtol=2e-2)
+
+    def test_flash_attention_ring2_stat_handoff_persistent_matches_sdpa(self) -> None:
+        q, k, v = (
+            torch.randn(1, 64, 768, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        code, out = code_and_output(
+            cute_dense_attention,
+            (q, k, v),
+            block_sizes=[1, 128, 128],
+            # 192 work items exceed B200's 148-CTA persistent grid, forcing
+            # phase and ring-index state to carry into a second work item.
+            cute_flash_pipeline_family="fa4",
+            cute_flash_stat_transport="ring2",
+            cute_flash_persistent=True,
+            cute_flash_persistent_ctas_per_sm=1,
+        )
+
+        self.assertIn("flash_s_corr_prod_index = cutlass.Int32(0)", code)
+        self.assertIn("flash_s_corr_cons_index = cutlass.Int32(0)", code)
+        self.assertIn("flash_s_corr_prod_index ^= 1", code)
+        self.assertIn("flash_s_corr_cons_index ^= 1", code)
+        expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
     def test_flash_attention_fa4_causal_two_cta_modifier_matches_sdpa(self) -> None:
         q, k, v = (
@@ -2919,6 +3036,7 @@ class TestCuteBackend(TestCase):
                     cute_flash_persistent=True,
                     cute_flash_use_2cta=True,
                     cute_flash_epi_tma=True,
+                    cute_flash_stat_transport="single",
                 )
 
                 self.assertIn("cta_group=2", code)
@@ -2928,6 +3046,11 @@ class TestCuteBackend(TestCase):
                 self.assertIn("mbarrier_init(flash_pfor2_ptr + flash_st, 256)", code)
                 self.assertIn("fa4_correction_epilogue_to_smem_scoped_2cta", code)
                 self.assertIn("'use_2cta_instrs': True", code)
+                self.assertIn(
+                    "mbar_spin_wait(flash_s0_corr_empty_ptr + 0, "
+                    "flash_s_corr_prod_phase",
+                    code,
+                )
                 self.assertIn("gemm_ptx_precomputed_qk_static", code)
                 self.assertIn(
                     "early_split_publish=True, pair_batch=8, emu_batch=2", code
@@ -3162,7 +3285,8 @@ class TestCuteBackend(TestCase):
                         "flash_local_tidx] = flash_alpha"
                     )
                     alpha_publish = masked_stage0.index(
-                        "cute.arch.barrier_arrive(", alpha_store
+                        "_helion_flash_rt.named_barrier_arrive_unaligned(",
+                        alpha_store,
                     )
                     self.assertEqual(masked_stage0.count("flash_minus_max_scale ="), 1)
                     minus_scale = masked_stage0.index("flash_minus_max_scale =")
@@ -3283,7 +3407,7 @@ class TestCuteBackend(TestCase):
                 expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
                 torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)
 
-    def test_flash_attention_dense_degree1_seed_requires_standard_output(self) -> None:
+    def test_flash_attention_dense_degree2_seed_requires_standard_output(self) -> None:
         target = torch.empty(1, 1, 262_144, 64, dtype=torch.float16, device=DEVICE)
         cases = (
             (cute_dense_attention, True),
@@ -3297,14 +3421,22 @@ class TestCuteBackend(TestCase):
                     bound.config_spec._cute_flash_standard_dense_output,
                     expected_standard,
                 )
-                has_degree1_seed = any(
-                    seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY)
-                    in {"deg1_8x2_corr10", "deg1_16x8"}
+                self.assertFalse(
+                    any(
+                        seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY)
+                        in {"deg1_8x2_corr10", "deg1_16x8"}
+                        for seed in bound.config_spec.compiler_seed_configs
+                    )
+                )
+                has_degree2_seed = any(
+                    seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
                     for seed in bound.config_spec.compiler_seed_configs
                 )
-                self.assertEqual(has_degree1_seed, expected_standard)
+                self.assertEqual(has_degree2_seed, expected_standard)
 
-    def test_flash_attention_hybrid_seed_excludes_auxiliary_outputs(self) -> None:
+    def test_flash_attention_auxiliary_outputs_have_no_causal_degree1_seed(
+        self,
+    ) -> None:
         target = torch.empty(1, 1, 65_536, 64, dtype=torch.float16, device=DEVICE)
         slopes = torch.empty(1, dtype=torch.float32, device=DEVICE)
         cases = (
@@ -4726,19 +4858,16 @@ class TestCuteBackend(TestCase):
             dense_midrange = resolve_flash_config(64, 1536, force_two_cta)
             dense_long = resolve_flash_config(64, 2052, force_two_cta)
             dense_long_unaligned = resolve_flash_config(64, 2050, force_two_cta)
-            dense_long_seed = next(
-                seed
-                for seed in _cute_flash.flash_attention_seed_configs(
-                    64,
-                    2052,
-                    standard_dense_output=True,
-                )
-                if seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY) == "deg1_16x8"
-            )
             dense_long_degree1 = resolve_flash_config(
                 64,
                 2052,
-                dense_long_seed.config,
+                force_two_cta
+                | {
+                    _cute_flash.FLASH_EXP2_PACKET_KEY: "deg1_16x8",
+                    _cute_flash.FLASH_E2E_SCHEDULE_KEY: "16/8",
+                    _cute_flash.FLASH_E2E_OFFSET_KEY: 0,
+                    _cute_flash.FLASH_E2E_OFFSET0_KEY: 10,
+                },
                 standard_dense_output=True,
             )
             dense_bf16 = resolve_flash_config(

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -82,6 +82,43 @@ def _causal_attention_output(
     return out.view(q_in.size())
 
 
+@helion.kernel(backend="cute", static_shapes=True)
+def _dense_attention_output(
+    q_in: torch.Tensor, k_in: torch.Tensor, v_in: torch.Tensor
+) -> torch.Tensor:
+    m_dim = q_in.size(-2)
+    n_dim = k_in.size(-2)
+    head_dim = hl.specialize(q_in.size(-1))
+    q_view = q_in.reshape([-1, m_dim, head_dim])
+    v_view = v_in.reshape([-1, n_dim, head_dim])
+    k_view = k_in.reshape([-1, n_dim, head_dim])
+    out = torch.empty_like(q_view)
+    qk_scale = (1.0 / math.sqrt(head_dim)) * math.log2(math.e)
+    for tile_b, tile_m in hl.tile([q_view.size(0), m_dim]):
+        m_i = hl.full([tile_b, tile_m], float("-inf"), dtype=torch.float32)
+        l_i = torch.full_like(m_i, 1.0)
+        acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+        qt = q_view[tile_b, tile_m, :]
+        for tile_n in hl.tile(v_view.size(1)):
+            kt = k_view[tile_b, tile_n, :]
+            qk = torch.bmm(qt * qk_scale, kt.transpose(1, 2), torch.float32)
+            m_ij_keepdim = torch.maximum(
+                m_i[:, :, None], torch.amax(qk, -1, keepdim=True)
+            )
+            qk = qk - m_ij_keepdim
+            m_ij = m_ij_keepdim.squeeze(-1)
+            p = torch.exp2(qk)
+            l_ij = torch.sum(p, -1)
+            alpha = torch.exp2(m_i - m_ij)
+            l_i = l_i * alpha + l_ij
+            acc = acc * alpha[:, :, None]
+            vt = v_view[tile_b, tile_n, :]
+            acc = torch.baddbmm(acc, p.to(vt.dtype), vt)
+            m_i = m_ij
+        out[tile_b, tile_m, :] = (acc / l_i[:, :, None]).to(out.dtype)
+    return out.view(q_in.size())
+
+
 def _manual_config(
     packet: str = _DEG2_PACKET, **overrides: object
 ) -> dict[str, object]:
@@ -132,13 +169,21 @@ def test_degree2_polynomial_relative_error_bound() -> None:
     assert relative_error.max().item() < 0.00173
 
 
-def test_degree1_polynomial_relative_error_bound() -> None:
-    x = torch.linspace(0.0, 1.0, 100_001, dtype=torch.float32)
-    c0, c1 = _flash_runtime._POLY_EX2_DEG1
-    approximate = torch.tensor(c1) * x + torch.tensor(c0)
-    relative_error = (approximate / torch.exp2(x) - 1.0).abs()
+def test_legacy_degree1_packet_uses_degree2_evaluator() -> None:
+    pair_result = object()
+    with patch.object(
+        _flash_runtime, "ex2_emulation_deg2_2", return_value=pair_result
+    ) as pair_evaluator:
+        assert _flash_runtime.ex2_emulation_deg1_2("x", "y") is pair_result
+    pair_evaluator.assert_called_once_with("x", "y")
 
-    assert relative_error.max().item() < 0.02983
+    batch_result = object()
+    pairs = [("x0", "y0"), ("x1", "y1")]
+    with patch.object(
+        _flash_runtime, "ex2_emulation_deg2_batch", return_value=batch_result
+    ) as batch_evaluator:
+        assert _flash_runtime.ex2_emulation_deg1_batch(pairs) is batch_result
+    batch_evaluator.assert_called_once_with(pairs)
 
 
 def test_degree2_packet_codegen_route_is_exact_and_manual_only() -> None:
@@ -276,15 +321,25 @@ def test_hybrid_packet_uses_degree1_only_for_unmasked_pass2() -> None:
 
 
 @pytest.mark.parametrize(
-    ("packet", "num_kv", "sequence_extent", "total_tiles", "freq", "res", "emu"),
     (
-        (_DEG1_SHORT_PACKET, 256, 32_768, 4_096, 8, 2, 2),
-        (_DEG1_SHORT_PACKET, 512, 65_536, 8_192, 8, 2, 2),
-        (_DEG1_SHORT_PACKET, 1024, 131_072, 16_384, 8, 2, 2),
-        (_DEG1_PACKET, 2048, 262_144, 32_768, 16, 8, 4),
+        "packet",
+        "num_kv",
+        "sequence_extent",
+        "total_tiles",
+        "freq",
+        "res",
+        "emu",
+        "polynomial_keyword",
+    ),
+    (
+        (_DEG1_SHORT_PACKET, 256, 32_768, 4_096, 8, 2, 2, "degree1"),
+        (_DEG1_SHORT_PACKET, 512, 65_536, 8_192, 8, 2, 2, "degree1"),
+        (_DEG1_SHORT_PACKET, 1024, 131_072, 16_384, 8, 2, 2, "degree1"),
+        (_DEG1_PACKET, 2048, 262_144, 32_768, 16, 8, 4, "degree1"),
+        (_DEG2_PACKET, 2048, 262_144, 32_768, 16, 6, 3, "degree2"),
     ),
 )
-def test_degree1_packet_uses_whole_row_dense_pass2(
+def test_polynomial_packet_uses_whole_row_dense_pass2(
     packet: str,
     num_kv: int,
     sequence_extent: int,
@@ -292,6 +347,7 @@ def test_degree1_packet_uses_whole_row_dense_pass2(
     freq: int,
     res: int,
     emu: int,
+    polynomial_keyword: str,
 ) -> None:
     with patch.dict(os.environ, {}, clear=True):
         config = cute_flash.resolve_flash_config(
@@ -342,7 +398,7 @@ def test_degree1_packet_uses_whole_row_dense_pass2(
             "early_split_publish": True,
             "pair_batch": 8,
             "emu_batch": emu,
-            "degree1": True,
+            polynomial_keyword: True,
         }
 
 
@@ -396,6 +452,472 @@ def test_short_degree1_packet_reverses_steady_correction_order(
         if isinstance(target, ast.Name) and target.id in ("flash_a0", "flash_a1")
     ]
     assert alpha_stages == list(expected_alpha_stages)
+
+
+def _emit_dense_single_stat_source(
+    *,
+    pipeline_family: str = "fa4_2cta",
+    packet: str = "8x2",
+    softmax_disc: bool = False,
+    rescale_threshold: float = 8.0,
+    persistent: bool = True,
+    final_only_stat_pipeline: bool = False,
+) -> str:
+    with patch.dict(os.environ, {}, clear=True):
+        config = cute_flash.resolve_flash_config(
+            64,
+            256,
+            _manual_config(
+                packet,
+                **{
+                    cute_flash.FLASH_PIPELINE_FAMILY_KEY: pipeline_family,
+                    cute_flash.FLASH_STAT_TRANSPORT_KEY: (
+                        "single_final" if final_only_stat_pipeline else "single"
+                    ),
+                    cute_flash.FLASH_PERSISTENT_KEY: persistent,
+                    cute_flash.FLASH_SOFTMAX_DISC_KEY: softmax_disc,
+                    cute_flash.FLASH_RESCALE_THRESHOLD_KEY: rescale_threshold,
+                },
+            ),
+            dtype=torch.float16,
+            is_causal=False,
+            standard_dense_output=True,
+        )
+        body = cute_flash.emit_flash_fa4_device_body(
+            cast("DeviceFunction", None),
+            head_dim=64,
+            num_kv=256,
+            sequence_extent=32_768,
+            num_bh=64,
+            total_tiles=4_096 if config.use_2cta_instrs else 8_192,
+            cfg=config,
+            has_lse=False,
+            io_dtype="cutlass.Float16",
+            score_plan=dense_score_plan(64),
+        )
+    return ast.unparse(ast.Module(body=body, type_ignores=[]))
+
+
+def test_dense_single_stat_emits_fa4_late_acquire_protocol() -> None:
+    source = _emit_dense_single_stat_source()
+
+    assert source.count("flash_s_corr_prod_phase = cutlass.Int32(1)") == 2
+    assert "flash_s_corr_prod_phase = cutlass.Int32(0)" not in source
+
+    stage0_start = source.index("flash_s_corr_prod_phase = cutlass.Int32(1)")
+    stage1_start = source.index(
+        "flash_s_corr_prod_phase = cutlass.Int32(1)", stage0_start + 1
+    )
+    softmax0 = source[stage0_start:stage1_start]
+    empty_wait = (
+        "_helion_flash_rt.mbar_spin_wait(flash_s0_corr_empty_ptr + 0, "
+        "flash_s_corr_prod_phase, 10000000)"
+    )
+    empty_wait_lines = [line for line in softmax0.splitlines() if empty_wait in line]
+    # Entry and post-P acquires live inside each persistent work item. The final
+    # acquire drains the final row-sum handoff after the persistent loop.
+    assert [len(line) - len(line.lstrip()) for line in empty_wait_lines] == [8, 12, 4]
+    assert softmax0.count("flash_s_corr_prod_phase ^= 1") == 2
+    assert (
+        "else:\n"
+        "                _helion_flash_rt.named_barrier_arrive_unaligned("
+        "3 + warp_idx % 4, 64)"
+    ) in softmax0
+    entry_wait = softmax0.index(empty_wait)
+    alpha_store = softmax0.index(
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_alpha"
+    )
+    p_publication = softmax0.index("flash_pfor_ptr + 0", alpha_store)
+    post_p_wait = softmax0.index(empty_wait, p_publication)
+    row_sum_update = softmax0.index(
+        "flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum", post_p_wait
+    )
+    rowsum_store = softmax0.index(
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_row_sum", row_sum_update
+    )
+    tail_wait = softmax0.index(empty_wait, rowsum_store)
+    assert (
+        entry_wait
+        < alpha_store
+        < p_publication
+        < post_p_wait
+        < row_sum_update
+        < rowsum_store
+        < tail_wait
+    )
+
+    correction = source[source.index("(warp_idx >= 8) & (warp_idx < 12):") :]
+    work_loop = correction.index("for flash_tile_iter")
+    ready0 = "_helion_flash_rt.named_barrier_wait_unaligned(3 + warp_idx % 4, 64)"
+    ready1 = "_helion_flash_rt.named_barrier_wait_unaligned(7 + warp_idx % 4, 64)"
+    empty0 = "cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)"
+    empty1 = "cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)"
+
+    dummy_ready0 = correction.index(ready0, work_loop)
+    dummy_release0 = correction.index(empty0, dummy_ready0)
+    dummy_ready1 = correction.index(ready1, dummy_release0)
+    steady_loop = correction.index("for flash_kv", dummy_ready1)
+    alpha0 = correction.index("flash_a0 =", steady_loop)
+    pfor0 = correction.index(
+        "_helion_flash_rt.mbarrier_arrive(flash_pfor_ptr + 0", alpha0
+    )
+    cross_release1 = correction.index(empty1, pfor0)
+    alpha1 = correction.index("flash_a1 =", cross_release1)
+    pfor1 = correction.index(
+        "_helion_flash_rt.mbarrier_arrive(flash_pfor_ptr + 1", alpha1
+    )
+    cross_release0 = correction.index(empty0, pfor1)
+    held_release1 = correction.index(empty1, cross_release0)
+    final_ready0 = correction.index(ready0, held_release1)
+    final_rowsum0 = correction.index("flash_inv_sum0 =", final_ready0)
+    final_release0 = correction.index(empty0, final_rowsum0)
+    final_ready1 = correction.index(ready1, final_release0)
+    final_rowsum1 = correction.index("flash_inv_sum1 =", final_ready1)
+    final_release1 = correction.index(empty1, final_rowsum1)
+    assert (
+        dummy_ready0
+        < dummy_release0
+        < dummy_ready1
+        < steady_loop
+        < alpha0
+        < pfor0
+        < cross_release1
+        < alpha1
+        < pfor1
+        < cross_release0
+        < held_release1
+        < final_ready0
+        < final_rowsum0
+        < final_release0
+        < final_ready1
+        < final_rowsum1
+        < final_release1
+    )
+
+
+def test_dense_nonpersistent_final_only_stat_pipeline_protocol() -> None:
+    source = _emit_dense_single_stat_source(
+        persistent=False,
+        final_only_stat_pipeline=True,
+    )
+
+    assert source.count("flash_s_corr_prod_phase = cutlass.Int32(0)") == 2
+    assert "flash_s_corr_prod_phase = cutlass.Int32(1)" not in source
+    assert "flash_s_corr_prod_phase ^= 1" not in source
+
+    stage0_start = source.index("flash_s_corr_prod_phase = cutlass.Int32(0)")
+    stage1_start = source.index(
+        "flash_s_corr_prod_phase = cutlass.Int32(0)", stage0_start + 1
+    )
+    softmax0 = source[stage0_start:stage1_start]
+    empty_wait = (
+        "_helion_flash_rt.mbar_spin_wait(flash_s0_corr_empty_ptr + 0, "
+        "flash_s_corr_prod_phase, 10000000)"
+    )
+    ready_arrive = (
+        "_helion_flash_rt.named_barrier_arrive_unaligned(3 + warp_idx % 4, 64)"
+    )
+    assert softmax0.count(empty_wait) == 1
+    assert softmax0.count(ready_arrive) == 2
+    assert "else:\n            " + ready_arrive not in softmax0
+
+    alpha_store = softmax0.index(
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_alpha"
+    )
+    p_publication = softmax0.index("flash_pfor_ptr + 0", alpha_store)
+    row_sum_update = softmax0.index(
+        "flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum",
+        p_publication,
+    )
+    terminal_wait = softmax0.index(empty_wait, row_sum_update)
+    rowsum_store = softmax0.index(
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_row_sum",
+        terminal_wait,
+    )
+    rowsum_ready = softmax0.index(ready_arrive, rowsum_store)
+    dealloc = softmax0.index(
+        "_helion_flash_rt.named_barrier_arrive_unaligned(2, 13 * 32)",
+        rowsum_ready,
+    )
+    assert (
+        alpha_store
+        < p_publication
+        < row_sum_update
+        < terminal_wait
+        < rowsum_store
+        < rowsum_ready
+        < dealloc
+    )
+
+    correction = source[source.index("(warp_idx >= 8) & (warp_idx < 12):") :]
+    steady_loop = correction.index("for flash_kv")
+    empty0 = "cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)"
+    empty1 = "cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)"
+    assert correction.count(empty0) == 1
+    assert correction.count(empty1) == 1
+
+    alpha0 = correction.index("flash_a0 =", steady_loop)
+    pfor0 = correction.index(
+        "_helion_flash_rt.mbarrier_arrive(flash_pfor_ptr + 0", alpha0
+    )
+    alpha1 = correction.index("flash_a1 =", pfor0)
+    pfor1 = correction.index(
+        "_helion_flash_rt.mbarrier_arrive(flash_pfor_ptr + 1", alpha1
+    )
+    terminal_release0 = correction.index(empty0, pfor1)
+    terminal_release1 = correction.index(empty1, terminal_release0)
+    final_ready0 = correction.index(
+        "_helion_flash_rt.named_barrier_wait_unaligned(3 + warp_idx % 4, 64)",
+        terminal_release1,
+    )
+    final_rowsum0 = correction.index("flash_inv_sum0 =", final_ready0)
+    assert (
+        steady_loop
+        < alpha0
+        < pfor0
+        < alpha1
+        < pfor1
+        < terminal_release0
+        < terminal_release1
+        < final_ready0
+        < final_rowsum0
+    )
+    assert empty0 not in correction[steady_loop:terminal_release0]
+    assert empty1 not in correction[steady_loop:terminal_release0]
+    assert "cute.arch.barrier(" not in correction
+    assert (
+        correction.count("_helion_flash_rt.named_barrier_arrive_unaligned(2, 13 * 32)")
+        == 1
+    )
+
+
+@onlyBackends(["cute"])
+def test_dense_degree2_final_only_is_deterministic_on_peaky_inputs() -> None:
+    torch.manual_seed(104)
+    q, k, v = (
+        torch.randn(1, 1, 32_768, 64, dtype=torch.float16, device=DEVICE)
+        for _ in range(3)
+    )
+    q.mul_(2.0)
+    k.mul_(2.0)
+    config = {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_pipeline_family": "fa4_2cta",
+        "cute_flash_exp2_packet": _DEG2_PACKET,
+        "cute_flash_e2e_schedule": "16/6",
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 2,
+        "cute_flash_kv_stage": 2,
+        "cute_flash_persistent": False,
+        "cute_flash_stat_transport": "single_final",
+        "cute_flash_wait_hint": 0,
+    }
+
+    bound = _dense_attention_output.bind((q, k, v))
+    active_config = helion.Config(**config)
+    bound.set_config(active_config)
+    code = bound.to_triton_code(active_config)
+    out = bound(q, k, v)
+    repeated = bound(q, k, v)
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+    diff = (out.float() - expected.float()).abs()
+    strict_failures = diff > (0.002 + 0.01 * expected.float().abs())
+    normalized_rmse = torch.sqrt((diff * diff).mean(dtype=torch.float64)) / torch.sqrt(
+        (expected.float() * expected.float()).mean(dtype=torch.float64)
+    )
+
+    assert "degree2=True" in code
+    assert torch.equal(out, repeated)
+    assert torch.isfinite(out).all()
+    assert diff.max().item() < 0.01
+    assert normalized_rmse.item() < 0.002
+    assert strict_failures.count_nonzero().item() / out.numel() < 1e-5
+
+
+@onlyBackends(["cute"])
+def test_dense_bfloat16_final_only_stat_handoff_is_accurate() -> None:
+    torch.manual_seed(106)
+    q, k, v = (
+        torch.randn(1, 1, 1024, 64, dtype=torch.bfloat16, device=DEVICE)
+        for _ in range(3)
+    )
+    config = {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_pipeline_family": "fa4",
+        "cute_flash_persistent": False,
+        "cute_flash_softmax_disc": False,
+        "cute_flash_stat_transport": "single_final",
+        "cute_flash_rescale_threshold": 8.0,
+    }
+    resolved = cute_flash.resolve_flash_config(
+        64,
+        8,
+        config,
+        dtype=torch.bfloat16,
+        standard_dense_output=True,
+    )
+
+    bound = _dense_attention_output.bind((q, k, v))
+    active_config = helion.Config(**config)
+    bound.set_config(active_config)
+    code = bound.to_triton_code(active_config)
+    out = bound(q, k, v)
+    repeated = bound(q, k, v)
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+    assert resolved.stat_transport == "single_final"
+    assert "flash_s_corr_prod_phase" in code
+    assert torch.equal(out, repeated)
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, expected, atol=0.01, rtol=0.02)
+
+
+@onlyBackends(["cute"])
+def test_persistent_legacy_degree1_final_only_is_accurate_across_work() -> None:
+    torch.manual_seed(105)
+    q = torch.randn(1, 1, 262_144, 64, dtype=torch.float16, device=DEVICE)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    q.mul_(2.0)
+    k.mul_(2.0)
+    config = {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_pipeline_family": "fa4_2cta",
+        "cute_flash_exp2_packet": _DEG1_PACKET,
+        "cute_flash_e2e_schedule": "16/8",
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 2,
+        "cute_flash_kv_stage": 2,
+        "cute_flash_persistent": True,
+        "cute_flash_stat_transport": "single_final",
+        "cute_flash_wait_hint": 0,
+        "cute_flash_rescale_threshold": 8.0,
+        "cute_flash_rescale_chunk_cols": 8,
+    }
+
+    bound = _dense_attention_output.bind((q, k, v))
+    active_config = helion.Config(**config)
+    bound.set_config(active_config)
+    code = bound.to_triton_code(active_config)
+    out = bound(q, k, v)
+    repeated = bound(q, k, v)
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+    diff = (out.float() - expected.float()).abs()
+    strict_failures = diff > (0.002 + 0.01 * expected.float().abs())
+    normalized_rmse = torch.sqrt((diff * diff).mean(dtype=torch.float64)) / torch.sqrt(
+        (expected.float() * expected.float()).mean(dtype=torch.float64)
+    )
+
+    assert f"_helion_flash_runtime_abi = {cute_flash._FLASH_RUNTIME_ABI}" in code
+    assert "degree1=True" in code
+    assert "while flash_tile_id <" in code
+    assert torch.equal(out, repeated)
+    assert torch.isfinite(out).all()
+    assert diff.max().item() < 0.01
+    assert normalized_rmse.item() < 0.002
+    assert strict_failures.count_nonzero().item() / out.numel() < 1e-5
+
+
+def test_persistent_final_only_stat_transport_carries_terminal_phase() -> None:
+    source = _emit_dense_single_stat_source(final_only_stat_pipeline=True)
+    assert source != _emit_dense_single_stat_source()
+
+    stage0_start = source.index("flash_s_corr_prod_phase = cutlass.Int32(0)")
+    stage1_start = source.index(
+        "flash_s_corr_prod_phase = cutlass.Int32(0)", stage0_start + 1
+    )
+    softmax0 = source[stage0_start:stage1_start]
+    terminal_wait = (
+        "_helion_flash_rt.mbar_spin_wait(flash_s0_corr_empty_ptr + 0, "
+        "flash_s_corr_prod_phase, 10000000)"
+    )
+    assert softmax0.count(terminal_wait) == 1
+    assert softmax0.count("flash_s_corr_prod_phase ^= 1") == 1
+    wait_index = softmax0.index(terminal_wait)
+    phase_index = softmax0.index("flash_s_corr_prod_phase ^= 1", wait_index)
+    rowsum_index = softmax0.index(
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_row_sum",
+        phase_index,
+    )
+    assert wait_index < phase_index < rowsum_index
+
+    correction = source[source.index("(warp_idx >= 8) & (warp_idx < 12):") :]
+    for stage in (0, 1):
+        empty = f"cute.arch.mbarrier_arrive(flash_s{stage}_corr_empty_ptr + 0)"
+        assert correction.count(empty) == 1
+
+
+@pytest.mark.parametrize(
+    ("packet", "softmax_disc", "rescale_threshold"),
+    ((_DEG1_SHORT_PACKET, False, 8.0), ("8x2", True, 8.0), ("8x2", False, 0.0)),
+)
+def test_dense_single_stat_unsupported_schedules_use_conservative_protocol(
+    packet: str, softmax_disc: bool, rescale_threshold: float
+) -> None:
+    source = _emit_dense_single_stat_source(
+        pipeline_family="fa4" if softmax_disc else "fa4_2cta",
+        packet=packet,
+        softmax_disc=softmax_disc,
+        rescale_threshold=rescale_threshold,
+    )
+
+    assert source.count("flash_s_corr_prod_phase = cutlass.Int32(0)") == 2
+    assert "flash_s_corr_prod_phase = cutlass.Int32(1)" not in source
+    correction = source[source.index("(warp_idx >= 8) & (warp_idx < 12):") :]
+    first_empty = correction.index(
+        "cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)"
+    )
+    first_ready = correction.index(
+        "_helion_flash_rt.named_barrier_wait_unaligned(3 + warp_idx % 4, 64)"
+    )
+    assert first_empty < first_ready
+
+
+def test_dense_ring2_emits_two_slot_stat_protocol() -> None:
+    def emit(stat_transport: str) -> str:
+        with patch.dict(os.environ, {}, clear=True):
+            config = cute_flash.resolve_flash_config(
+                64,
+                4,
+                _manual_config(
+                    "8x2",
+                    **{
+                        cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta",
+                        cute_flash.FLASH_STAT_TRANSPORT_KEY: stat_transport,
+                        cute_flash.FLASH_PERSISTENT_KEY: True,
+                    },
+                ),
+                dtype=torch.float16,
+                is_causal=False,
+                standard_dense_output=True,
+            )
+        body = cute_flash.emit_flash_fa4_device_body(
+            cast("DeviceFunction", None),
+            head_dim=64,
+            num_kv=4,
+            sequence_extent=512,
+            num_bh=64,
+            total_tiles=128,
+            cfg=config,
+            has_lse=False,
+            io_dtype="cutlass.Float16",
+            score_plan=dense_score_plan(64),
+        )
+        return ast.unparse(ast.Module(body=body, type_ignores=[]))
+
+    ring2 = emit("ring2")
+    single = emit("single")
+
+    assert "flash_s_corr_prod_index = cutlass.Int32(0)" in ring2
+    assert "flash_s_corr_cons_index = cutlass.Int32(0)" in ring2
+    assert "flash_s_corr_prod_index ^= 1" in ring2
+    assert "flash_s_corr_cons_index ^= 1" in ring2
+    assert "if flash_s_corr_prod_index == 0:" in ring2
+    assert "flash_scale_t[flash_s_corr_prod_index, 0, flash_local_tidx]" in ring2
+    assert "flash_scale_t[flash_s_corr_cons_index, 0, flash_local_tidx]" in ring2
+    assert "flash_s_corr_prod_index" not in single
+    assert "flash_s_corr_cons_index" not in single
+    assert ring2 != single
 
 
 @onlyBackends(["cute"])
@@ -693,7 +1215,10 @@ def test_current_packets_keep_existing_normalization(packet: str) -> None:
 
 @pytest.mark.parametrize(
     ("packet", "schedule"),
-    ((_DEG2_PACKET, "16/6"), (_HYBRID_PACKET, "16/8")),
+    (
+        (_DEG2_PACKET, "16/6"),
+        (_HYBRID_PACKET, "16/8"),
+    ),
 )
 def test_manual_packet_config_spec_is_fixed_not_searched(
     packet: str, schedule: str

--- a/test/test_cute_flash_schedule.py
+++ b/test/test_cute_flash_schedule.py
@@ -148,6 +148,37 @@ def test_two_cta_memory_is_rank_local_and_output_is_interleaved() -> None:
     assert barriers["pfor_q0"].scope is FlashSyncScope.CLUSTER_LEADER
 
 
+@pytest.mark.parametrize("stat_depth", (1, 2))
+def test_two_cta_stat_transport_reuse(stat_depth: int) -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            cta_count=2,
+            multicast_kv=True,
+            cooperative_mma=True,
+            stat_depth=stat_depth,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    regions = {region.name: region for region in schedule.memory_regions}
+    for rank in range(2):
+        for slot in range(2):
+            region = regions[f"STAT_r{rank}_q{slot}"]
+            assert region.extent == stat_depth * 128 * 4
+            assert region.reuse_distance == stat_depth
+            assert region.reuse_barrier == f"stat_empty_r{rank}_q{slot}"
+            assert any(
+                edge.source == f"correction_r{rank}_q{slot}"
+                and edge.target == f"stat_r{rank}_q{slot}"
+                and edge.iteration_delta == stat_depth
+                and edge.barrier == region.reuse_barrier
+                for edge in schedule.edges
+            )
+
+
 def test_independent_cga_output_is_cta_contiguous() -> None:
     schedule = build_fa4_schedule(
         FlashScheduleSpec(
@@ -342,6 +373,27 @@ def test_missing_k_reuse_edge_is_rejected() -> None:
         verify_flash_schedule(schedule)
 
 
+def test_missing_stat_reuse_edge_is_rejected() -> None:
+    schedule = build_fa4_schedule(FlashScheduleSpec(64, 2))
+    schedule = dataclasses.replace(
+        schedule,
+        edges=tuple(
+            edge for edge in schedule.edges if edge.barrier != "stat_empty_r0_q0"
+        ),
+        barriers=tuple(
+            barrier
+            for barrier in schedule.barriers
+            if barrier.name != "stat_empty_r0_q0"
+        ),
+    )
+
+    with pytest.raises(
+        FlashScheduleError,
+        match="STAT_r0_q0 is reused before all consumers",
+    ):
+        verify_flash_schedule(schedule)
+
+
 def test_score_probability_alias_corruption_is_rejected() -> None:
     schedule = build_fa4_schedule(FlashScheduleSpec(64, 2))
     schedule = _replace_region_alias(schedule, "P_r0_q0", "wrong_alias")
@@ -473,6 +525,192 @@ def test_persistent_phase_continuity_at_work_boundary(
     assert cycles["s_full_r0_q0"].uses_per_work == kv_iterations
     assert cycles["s_full_r0_q0"].phases == (0, middle_phase, 0)
     assert cycles["pfor_q0"].phases == (0, middle_phase, 0)
+
+
+@pytest.mark.parametrize("kv_iterations", (3, 4))
+def test_pipelined_stat_handoff_models_dummy_and_final_events(
+    kv_iterations: int,
+) -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            persistent=True,
+            kv_iterations=kv_iterations,
+            stat_depth=1,
+            pipelined_stat_handoff=True,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    cycles = {cycle.barrier: cycle for cycle in schedule.phase_cycles}
+    assert cycles["s_full_r0_q0"].uses_per_work == kv_iterations
+    assert cycles["s_full_r0_q0"].phases == (
+        0,
+        kv_iterations & 1,
+        0,
+    )
+    assert cycles["stat_ready_r0_q0"].uses_per_work == kv_iterations + 1
+    assert cycles["stat_ready_r0_q0"].phases == (
+        0,
+        (kv_iterations + 1) & 1,
+        0,
+    )
+    assert cycles["stat_empty_r0_q0"].uses_per_work == kv_iterations + 1
+    assert cycles["stat_empty_r0_q0"].phases == (
+        1,
+        1 ^ ((kv_iterations + 1) & 1),
+        1,
+    )
+
+
+@pytest.mark.parametrize(
+    "spec",
+    (
+        FlashScheduleSpec(64, 2, stat_depth=2, pipelined_stat_handoff=True),
+        FlashScheduleSpec(
+            64, 2, causal=True, stat_depth=1, pipelined_stat_handoff=True
+        ),
+    ),
+)
+def test_pipelined_stat_handoff_rejects_unsupported_schedules(
+    spec: FlashScheduleSpec,
+) -> None:
+    with pytest.raises(
+        FlashScheduleError,
+        match="pipelined stat handoff requires depth one and a noncausal schedule",
+    ):
+        build_fa4_schedule(spec)
+
+
+def test_final_only_stat_handoff_uses_transitive_reuse_ordering() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            stat_depth=1,
+            final_only_stat_handoff=True,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    assert {
+        barrier.name
+        for barrier in schedule.barriers
+        if barrier.name.startswith("stat_empty")
+    } == {"stat_empty_r0_q0", "stat_empty_r0_q1"}
+    stat_regions = [
+        region for region in schedule.memory_regions if region.name.startswith("STAT_")
+    ]
+    assert stat_regions
+    assert all(
+        region.reuse_distance == 1 and region.reuse_barrier is None
+        for region in stat_regions
+    )
+    assert not any(
+        edge.source.startswith("correction_") and edge.target.startswith("stat_")
+        for edge in schedule.edges
+    )
+    assert any(
+        edge.source == "correction_r0_q0"
+        and edge.target == "final_stat_publish_r0_q0"
+        and edge.barrier == "stat_empty_r0_q0"
+        for edge in schedule.edges
+    )
+
+    # Diverting correction -> PV breaks the transitive proof that the
+    # correction reader finishes before softmax reuses the one-slot stat buffer.
+    schedule = dataclasses.replace(
+        schedule,
+        edges=tuple(
+            dataclasses.replace(edge, target="output_stage_r0_q0")
+            if edge.source == "correction_r0_q0" and edge.target == "pv_r0_q0"
+            else edge
+            for edge in schedule.edges
+        ),
+    )
+    with pytest.raises(
+        FlashScheduleError,
+        match="STAT_r0_q0 is reused before all consumers",
+    ):
+        verify_flash_schedule(schedule)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    (
+        FlashScheduleSpec(64, 2, stat_depth=2, final_only_stat_handoff=True),
+        FlashScheduleSpec(
+            64, 2, causal=True, stat_depth=1, final_only_stat_handoff=True
+        ),
+    ),
+)
+def test_final_only_stat_handoff_rejects_unsupported_schedules(
+    spec: FlashScheduleSpec,
+) -> None:
+    with pytest.raises(
+        FlashScheduleError,
+        match="final-only stat handoff requires depth one and a noncausal schedule",
+    ):
+        build_fa4_schedule(spec)
+
+
+@pytest.mark.parametrize("kv_iterations", (3, 4))
+def test_persistent_final_only_stat_handoff_has_one_terminal_cycle(
+    kv_iterations: int,
+) -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            cta_count=2,
+            persistent=True,
+            kv_iterations=kv_iterations,
+            stat_depth=1,
+            final_only_stat_handoff=True,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+    cycles = {cycle.barrier: cycle for cycle in schedule.phase_cycles}
+    for rank in range(2):
+        for slot in range(2):
+            assert cycles[f"stat_ready_r{rank}_q{slot}"].uses_per_work == kv_iterations
+            terminal = cycles[f"stat_empty_r{rank}_q{slot}"]
+            assert terminal.uses_per_work == 1
+            assert terminal.phases == (0, 1, 0)
+
+    schedule = dataclasses.replace(
+        schedule,
+        edges=tuple(
+            edge
+            for edge in schedule.edges
+            if not (
+                edge.source == "final_stat_consume_r0_q0"
+                and edge.target == "stat_r0_q0"
+            )
+        ),
+    )
+    with pytest.raises(
+        FlashScheduleError,
+        match="final-only stat handoff is missing terminal ordering",
+    ):
+        verify_flash_schedule(schedule)
+
+
+def test_stat_handoff_modes_are_mutually_exclusive() -> None:
+    with pytest.raises(FlashScheduleError, match="stat handoff modes are mutually"):
+        build_fa4_schedule(
+            FlashScheduleSpec(
+                64,
+                2,
+                stat_depth=1,
+                pipelined_stat_handoff=True,
+                final_only_stat_handoff=True,
+            )
+        )
 
 
 def test_persistent_phase_corruption_is_rejected() -> None:


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3344
 * #3343
 * __->__#3342
 * #3341


--- --- ---

[cutedsl] Make long flash attention race-free and accurate

Model statistic-buffer reuse and terminal handoff ordering explicitly in the FA4 schedule, including the barrier phases needed by persistent execution.

Replace inaccurate degree-1 seed paths with degree-2-compatible codegen, bump the generated runtime ABI, and expose only synchronization-safe transport and full-grid schedule choices.