### PR TITLE
[autotuner] Seed validated long CuTe attention schedules

### DIFF
--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -1306,7 +1306,28 @@ def _flash_causal_hd64_seed_num_kv_supported(num_kv: int | None) -> bool:
 
 
 _FLASH_CAUSAL_HD64_LONG_AUTOTUNE_MIN_KV = 4096
-_FLASH_CAUSAL_DEG2_SEED_KV = 4096
+
+
+class _FlashCausalDegree2SeedParams(NamedTuple):
+    role_map: str
+    e2e_offset: int
+    e2e_offset0: int
+    epi_tma: bool
+
+
+def _flash_causal_degree2_seed_params(
+    num_kv: int,
+) -> _FlashCausalDegree2SeedParams | None:
+    """Transfer validated causal schedules to neighboring power-of-two lengths."""
+    if not _flash_causal_hd64_seed_num_kv_supported(num_kv) or num_kv < 512:
+        return None
+    if num_kv == 512:
+        return _FlashCausalDegree2SeedParams("fa4", 15, 3, True)
+    if num_kv == 1024:
+        return _FlashCausalDegree2SeedParams("fa4", 1, 14, False)
+    if num_kv == 2048:
+        return _FlashCausalDegree2SeedParams("fa4", 14, 12, False)
+    return _FlashCausalDegree2SeedParams("helion", 14, 12, False)
 
 
 def _flash_causal_hd64_seed_params(num_kv: int) -> tuple[int, int, int, int]:
@@ -1426,7 +1447,6 @@ _FLASH_DEG1_EXP2_OFFSET0 = 10
 # aligned KV tiles to stay within their validated numerical envelope.
 _FLASH_DENSE_HD64_2CTA_MIN_KV = 256
 _FLASH_DENSE_DEG1_LONG_PACKET_MIN_KV = 2048
-_FLASH_DENSE_DEG2_SEED_KV = 2048
 _FLASH_MANUAL_EXP2_PACKET_PARAMS: dict[str, tuple[int, int]] = {
     _FLASH_DEG2_EXP2_PACKET: (8, 3),
     _FLASH_HYBRID_EXP2_PACKET: (8, 4),
@@ -3548,7 +3568,6 @@ def _flash_dense_degree2_seed_config(
         or requires_ws_overlap
         or small_biased_candidate
         or not _flash_dense_hd64_2cta_num_kv_supported(num_kv)
-        or num_kv != _FLASH_DENSE_DEG2_SEED_KV
     ):
         return None
     block_sizes = _flash_seed_block_sizes(block_size_targets)
@@ -3567,11 +3586,12 @@ def _flash_dense_degree2_seed_config(
         pipeline_family_override="fa4_2cta",
     )
     values = {key: fragment.default() for key, fragment in fragments.items()}
+    short_degree2_seed = num_kv <= 512
     packet_values: dict[str, object] = {
         FLASH_EXP2_PACKET_KEY: _FLASH_DEG2_EXP2_PACKET,
         FLASH_E2E_SCHEDULE_KEY: "16/6",
-        FLASH_E2E_OFFSET_KEY: 0,
-        FLASH_E2E_OFFSET0_KEY: 2,
+        FLASH_E2E_OFFSET_KEY: 14 if short_degree2_seed else 12,
+        FLASH_E2E_OFFSET0_KEY: 0 if short_degree2_seed else 2,
         FLASH_KV_STAGE_KEY: 2,
         FLASH_PERSISTENT_KEY: False,
         FLASH_STAT_TRANSPORT_KEY: "single_final",
@@ -3580,6 +3600,8 @@ def _flash_dense_degree2_seed_config(
         FLASH_CORR_REGS_KEY: 72,
         FLASH_OTHER_REGS_KEY: 40,
         FLASH_ROLE_MAP_KEY: "fa4",
+        FLASH_FIRST_LOAD_ORDER_KEY: 4,
+        FLASH_CORR_TILE_SIZE_KEY: 16 if short_degree2_seed else 8,
         FLASH_RESCALE_THRESHOLD_KEY: 8.0,
         FLASH_RESCALE_CHUNK_COLS_KEY: 8,
     }
@@ -3845,13 +3867,14 @@ def _flash_causal_degree2_seed_config(
     standard_causal_output: bool,
     block_size_targets: Sequence[int],
 ) -> Config | None:
-    """Return the validated 512K causal degree-2 seed."""
+    """Return a validated causal degree-2 seed."""
+    seed_params = _flash_causal_degree2_seed_params(num_kv)
     if (
         not standard_causal_output
         or not is_causal
         or dtype is not torch.float16
         or head_dim != 64
-        or num_kv != _FLASH_CAUSAL_DEG2_SEED_KV
+        or seed_params is None
         or has_kv_tile_pruning
         or requires_ws_overlap
         or small_biased_candidate
@@ -3875,13 +3898,15 @@ def _flash_causal_degree2_seed_config(
     overrides: dict[str, object] = {
         FLASH_E2E_SCHEDULE_KEY: "16/6",
         FLASH_MASKED_E2E_SCHEDULE_KEY: "16/6",
-        FLASH_E2E_OFFSET_KEY: 0,
-        FLASH_E2E_OFFSET0_KEY: 14,
+        FLASH_E2E_OFFSET_KEY: seed_params.e2e_offset,
+        FLASH_E2E_OFFSET0_KEY: seed_params.e2e_offset0,
         FLASH_EXP2_PACKET_KEY: _FLASH_DEG2_EXP2_PACKET,
         FLASH_WAIT_HINT_KEY: 0,
         FLASH_DISC_PIPE_KEY: 3,
+        FLASH_EPI_TMA_KEY: seed_params.epi_tma,
         FLASH_RESCALE_CHUNK_COLS_KEY: 16,
         FLASH_CAUSAL_LPT_SWIZZLE_KEY: 0,
+        FLASH_ROLE_MAP_KEY: seed_params.role_map,
     }
     if not _flash_seed_set_all(values, fragments, overrides):
         return None
@@ -4127,6 +4152,7 @@ def flash_autotune_fragments(
     requires_ws_overlap: bool = False,
     small_biased_candidate: bool = False,
     standard_dense_output: bool = False,
+    standard_causal_output: bool = False,
     topology_override: str | None = None,
     pipeline_family_override: str | None = None,
 ) -> dict[str, ConfigSpecFragment]:
@@ -5016,10 +5042,28 @@ def flash_autotune_fragments(
         if defaults.exp2_packet in _FLASH_MANUAL_EXP2_PACKET_PARAMS:
             exp2_packet_search_choices: tuple[str, ...] | None = (defaults.exp2_packet,)
         else:
-            exp2_packet_search_choices = (
-                _flash_choices_with_default(defaults.exp2_packet, ("8x2", "1x1"))
-                if defaults.use_2cta_instrs
-                else _flash_choices_with_default(defaults.exp2_packet, ("1x1", "4x1"))
+            ordinary_packet_choices = (
+                ("8x2", "1x1") if defaults.use_2cta_instrs else ("1x1", "4x1")
+            )
+            degree2_search_choices = (
+                (_FLASH_DEG2_EXP2_PACKET,)
+                if dtype is torch.float16
+                and (
+                    (standard_dense_output and dense_hd64_2cta_fa4)
+                    or (
+                        is_causal
+                        and standard_causal_output
+                        and _flash_causal_degree2_seed_params(num_kv) is not None
+                        and not has_kv_tile_pruning
+                        and not requires_ws_overlap
+                        and not small_biased_candidate
+                    )
+                )
+                else ()
+            )
+            exp2_packet_search_choices = _flash_choices_with_default(
+                defaults.exp2_packet,
+                (*ordinary_packet_choices, *degree2_search_choices),
             )
     else:
         exp2_packet_choices = ("1x1",)
@@ -8655,10 +8699,14 @@ if warp_idx == 15:
     # PASS2. Other paths retain their measured schedule; threshold==0.0 (fp8)
     # emits the prior block byte-identically.
     # Stage-parameterized, so one definition covers both softmax warpgroups (0/1).
-    def _disc_alpha_blocks_for(not_first: str) -> tuple[str, str]:
+    def _disc_alpha_blocks_for(
+        not_first: str, *, known_not_first: bool = False
+    ) -> tuple[str, str]:
         if cfg.rescale_threshold > 0.0:
             pin_condition = (
-                f"({not_first}) & (flash_acc_log >= -{cfg.rescale_threshold})"
+                f"flash_acc_log >= -{cfg.rescale_threshold}"
+                if known_not_first
+                else f"({not_first}) & (flash_acc_log >= -{cfg.rescale_threshold})"
             )
             if defer_causal_minus_scale:
                 return (
@@ -8966,14 +9014,16 @@ if warp_idx == 15:
                 *,
                 publish_rowsum: bool = True,
                 zero_first_tile: bool = False,
+                known_not_first: bool = False,
             ) -> str:
                 rowsum_publish = final_corr_publish_rowsum if publish_rowsum else ""
-                alpha_publish = (
-                    ""
-                    if cfg.skip_rescale_stats
-                    else f"""            if {not_first}:
+                if cfg.skip_rescale_stats:
+                    alpha_publish = ""
+                elif known_not_first:
+                    alpha_publish = _corr_publish_alpha("            ")
+                else:
+                    alpha_publish = f"""            if {not_first}:
 {corr_publish_alpha}"""
-                )
                 if zero_first_tile:
                     loop_rowmax_block = f"""            if {not_first}:
 {textwrap.indent(loop_rowmax_block, "    ")}"""
@@ -8981,7 +9031,9 @@ if warp_idx == 15:
 {textwrap.indent(loop_pass2_block, "    ")}
             else:
                 flash_p_sum = {zero_pass2_call}"""
-                alpha_block, minus_scale_block = _disc_alpha_blocks_for(not_first)
+                alpha_block, minus_scale_block = _disc_alpha_blocks_for(
+                    not_first, known_not_first=known_not_first
+                )
                 loop_header = _flash_runtime_range_header(loop_var, loop_bound)
                 return f"""        {loop_header}{actual_kv}
             _helion_flash_rt.mbar_spin_wait(flash_s_full_ptr + {stage}, flash_s_full_phase, {cfg.wait_hint})
@@ -9028,6 +9080,8 @@ if warp_idx == 15:
                         publish_rowsum=False,
                         zero_first_tile=stage == "0",
                     )
+                    # The proven split always executes a nonempty masked prefix
+                    # before entering its unmasked suffix.
                     unmasked_loop = _format_disc_loop(
                         "flash_kv_unmask_iter",
                         f"flash_m_tile{stage}",
@@ -9038,6 +9092,7 @@ if warp_idx == 15:
                         "flash_kv_unmask_iter >= cutlass.Int32(0)",
                         direct_dense_rowmax,
                         direct_dense_pass2,
+                        known_not_first=True,
                     )
                     return f"""        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -1121,6 +1121,49 @@ class PopulationBasedSearch(BaseSearch):
             return None
         return PopulationMember(_unset_fn, [], canonical_flat, config)
 
+    def _pad_initial_population_with_unique_random(
+        self,
+        population: Sequence[FlatConfig],
+        target: int,
+    ) -> list[FlatConfig]:
+        """Pad an initial population with normalized, unique random configs."""
+        result: list[FlatConfig] = []
+        seen: set[Config] = set()
+        invalid = 0
+        duplicate = 0
+
+        def append_if_valid(flat: FlatConfig) -> None:
+            nonlocal invalid, duplicate
+            try:
+                canonical_flat, config = self.config_gen.canonicalize_flat(flat)
+            except exc.InvalidConfig:
+                invalid += 1
+                return
+            if config in seen:
+                duplicate += 1
+                return
+            seen.add(config)
+            result.append(canonical_flat)
+
+        for flat in population:
+            append_if_valid(flat)
+
+        attempts = 0
+        max_attempts = max(64, max(0, target - len(result)) * 64)
+        while len(result) < target and attempts < max_attempts:
+            attempts += 1
+            append_if_valid(self.config_gen.random_flat())
+
+        if len(result) < target:
+            self.log(
+                "Generated only "
+                f"{len(result)}/{target} unique valid initial population configs "
+                f"after {attempts} random attempts "
+                f"({invalid} invalid, {duplicate} duplicate)."
+            )
+        self.log(f"Initial population after unique random padding: {len(result)} total")
+        return result
+
     def _generate_best_available_population_flat(self) -> list[FlatConfig]:
         """
         Generate initial population using default config, explicit seed configs,
@@ -1229,7 +1272,7 @@ class PopulationBasedSearch(BaseSearch):
         if duplicates > 0:
             self.log.debug(f"Discarded {duplicates} duplicate config(s)")
 
-        self.log(f"Initial population: {len(result)} total")
+        self.log(f"Seed/default/cache population: {len(result)} total")
 
         return result
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1036,6 +1036,7 @@ class ConfigSpec:
             requires_ws_overlap=self._cute_flash_requires_ws_overlap,
             small_biased_candidate=self._cute_flash_small_biased_candidate,
             standard_dense_output=self._cute_flash_standard_dense_output,
+            standard_causal_output=self._cute_flash_standard_causal_output,
             topology_override=cast("str | None", topology_override),
             pipeline_family_override=pipeline_family_override,
         )
@@ -2536,6 +2537,9 @@ class ConfigSpec:
                             self._cute_flash_small_biased_candidate
                         ),
                         standard_dense_output=self._cute_flash_standard_dense_output,
+                        standard_causal_output=(
+                            self._cute_flash_standard_causal_output
+                        ),
                         pipeline_family_override=_flash_pipeline_family_override,
                     )
                 )

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -123,8 +123,13 @@ class PatternSearch(PopulationBasedSearch):
         ):
             pop = self._generate_best_available_population_flat()
             if self.best_available_pad_random:
-                n_random = max(0, self.initial_population - len(pop))
-                pop.extend(self.config_gen.random_flat() for _ in range(n_random))
+                if self.config_gen.config_spec.cute_flash_search_enabled:
+                    pop = self._pad_initial_population_with_unique_random(
+                        pop, self.initial_population
+                    )
+                else:
+                    n_random = max(0, self.initial_population - len(pop))
+                    pop.extend(self.config_gen.random_flat() for _ in range(n_random))
             return pop
         return self.config_gen.random_population_flat(
             self.initial_population,

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -90,6 +90,7 @@ from helion._compiler.cute.cute_flash import FLASH_WAIT_HINT_KEY
 from helion._compiler.cute.cute_flash import flash_attention_seed_config
 from helion._compiler.cute.cute_flash import flash_attention_seed_configs
 from helion._compiler.cute.cute_flash import flash_autotune_fragments
+from helion._compiler.cute.cute_flash import flash_effective_config_values
 from helion._compiler.cute.cute_flash import resolve_flash_config
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
@@ -2570,12 +2571,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                             for config in normalized_seeds
                             if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
                         },
-                        {"ring2", "single_final"} if num_kv == 2048 else set(),
+                        {"ring2", "single_final"},
                     )
 
     def test_cute_flash_dense_degree2_seed_uses_validated_schedule(self) -> None:
         degree1_packets = {"deg1_8x2_corr10", "deg1_16x8"}
-        for num_kv in (256, 260, 512, 1024, 1536, 2044, 2048, 2052, 4096):
+        for num_kv in (252, 256, 258, 260, 512, 516, 768, 1024, 1536, 2048, 2052, 4096):
             with self.subTest(num_kv=num_kv):
                 seeds = flash_attention_seed_configs(
                     64,
@@ -2594,7 +2595,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     for seed in seeds
                     if seed.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
                 ]
-                if num_kv != 2048:
+                if num_kv < 256 or num_kv % 4:
                     self.assertFalse(degree2_seeds)
                     continue
                 self.assertEqual(len(degree2_seeds), 2)
@@ -2628,8 +2629,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 expected = {
                     FLASH_EXP2_PACKET_KEY: "deg2_16x6",
                     FLASH_E2E_SCHEDULE_KEY: "16/6",
-                    FLASH_E2E_OFFSET_KEY: 0,
-                    FLASH_E2E_OFFSET0_KEY: 2,
+                    FLASH_E2E_OFFSET_KEY: 14 if num_kv <= 512 else 12,
+                    FLASH_E2E_OFFSET0_KEY: 0 if num_kv <= 512 else 2,
                     FLASH_KV_STAGE_KEY: 2,
                     FLASH_PERSISTENT_KEY: False,
                     FLASH_STAT_TRANSPORT_KEY: "single_final",
@@ -2638,6 +2639,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     FLASH_CORR_REGS_KEY: 72,
                     FLASH_OTHER_REGS_KEY: 40,
                     FLASH_ROLE_MAP_KEY: "fa4",
+                    FLASH_FIRST_LOAD_ORDER_KEY: 4,
+                    FLASH_CORR_TILE_SIZE_KEY: 16 if num_kv <= 512 else 8,
                     FLASH_RESCALE_THRESHOLD_KEY: 8.0,
                     FLASH_RESCALE_CHUNK_COLS_KEY: 8,
                 }
@@ -2650,10 +2653,28 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 packet_fragment = fragments[FLASH_EXP2_PACKET_KEY]
                 self.assertIsInstance(packet_fragment, EnumFragment)
                 assert isinstance(packet_fragment, EnumFragment)
-                self.assertNotIn(
+                self.assertIn(
                     config[FLASH_EXP2_PACKET_KEY],
                     packet_fragment.search_choices or (),
                 )
+
+                effective_configs = {
+                    tuple(
+                        sorted(
+                            flash_effective_config_values(
+                                resolve_flash_config(
+                                    64,
+                                    num_kv,
+                                    seed.config,
+                                    dtype=torch.float16,
+                                    standard_dense_output=True,
+                                )
+                            ).items()
+                        )
+                    )
+                    for seed in degree2_seeds
+                }
+                self.assertEqual(len(effective_configs), 2)
 
     def test_cute_flash_dense_degree2_seed_gates(self) -> None:
         def has_degree2_seed(
@@ -2682,9 +2703,6 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 "standard_dense_output": True,
                 "block_size_targets": (1, 64, 128),
             },
-            {"standard_dense_output": True, "num_kv": 2044},
-            {"standard_dense_output": True, "num_kv": 2052},
-            {"standard_dense_output": True, "num_kv": 4096},
             {"standard_dense_output": True, "num_kv": 252},
             {"standard_dense_output": True, "num_kv": 258},
             {"standard_dense_output": True, "num_kv": 2050},
@@ -2700,40 +2718,130 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 num_kv = int(case.pop("num_kv", 2048))
                 self.assertFalse(has_degree2_seed(head_dim, num_kv, **case))
 
+    def test_cute_flash_degree2_packet_search_is_eligibility_gated(self) -> None:
+        def search_choices(
+            head_dim: int = 64,
+            num_kv: int = 260,
+            **kwargs: object,
+        ) -> tuple[object, ...]:
+            fragment = flash_autotune_fragments(
+                head_dim,
+                num_kv,
+                **kwargs,
+            )[FLASH_EXP2_PACKET_KEY]
+            self.assertIsInstance(fragment, EnumFragment)
+            assert isinstance(fragment, EnumFragment)
+            return fragment.search_choices or ()
+
+        self.assertIn(
+            "deg2_16x6",
+            search_choices(dtype=torch.float16, standard_dense_output=True),
+        )
+        self.assertIn(
+            "deg2_16x6",
+            search_choices(
+                num_kv=8192,
+                dtype=torch.float16,
+                is_causal=True,
+                standard_causal_output=True,
+            ),
+        )
+        excluded = (
+            {"dtype": torch.float16, "standard_dense_output": False},
+            {"dtype": torch.bfloat16, "standard_dense_output": True},
+            {"head_dim": 128, "dtype": torch.float16, "standard_dense_output": True},
+            {
+                "num_kv": 252,
+                "dtype": torch.float16,
+                "standard_dense_output": True,
+            },
+            {
+                "num_kv": 258,
+                "dtype": torch.float16,
+                "standard_dense_output": True,
+            },
+            {"num_kv": 768, "dtype": torch.float16, "is_causal": True},
+            {"num_kv": 8192, "dtype": torch.float16, "is_causal": True},
+            {
+                "num_kv": 256,
+                "dtype": torch.float16,
+                "is_causal": True,
+                "standard_causal_output": True,
+            },
+            {
+                "num_kv": 8192,
+                "dtype": torch.float16,
+                "is_causal": True,
+                "standard_causal_output": True,
+                "has_kv_tile_pruning": True,
+            },
+        )
+        for case in excluded:
+            subtest_case = {
+                key: str(value) if isinstance(value, torch.dtype) else value
+                for key, value in case.items()
+            }
+            with self.subTest(case=subtest_case):
+                case = dict(case)
+                head_dim = int(case.pop("head_dim", 64))
+                num_kv = int(case.pop("num_kv", 260))
+                self.assertNotIn(
+                    "deg2_16x6",
+                    search_choices(head_dim, num_kv, **case),
+                )
+
     def test_cute_flash_dense_degree2_seed_is_in_full_initial_population(
         self,
     ) -> None:
-        spec = ConfigSpec(backend=CuteBackend())
-        for block_id, target in enumerate((1, 128, 128)):
-            spec.block_sizes.append(BlockSizeSpec(block_id=block_id, size_hint=target))
-        spec.enable_cute_flash_search(
-            head_dim=64,
-            num_kv=2048,
-            block_size_targets={0: 1, 1: 128, 2: 128},
-            dtype=torch.float16,
-            is_causal=False,
-            standard_dense_output=True,
-        )
-        spec.compiler_seed_configs = list(
-            flash_attention_seed_configs(
-                64,
-                2048,
-                dtype=torch.float16,
-                standard_dense_output=True,
-            )
-        )
-        config_gen = ConfigGeneration(spec)
-        expected = next(
-            config
-            for _flat, config in config_gen.seed_flat_config_pairs()
-            if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
-            and config.config[FLASH_STAT_TRANSPORT_KEY] == "single_final"
-        )
-        profile = get_effort_profile("full").lfbo_pattern_search
-        assert profile is not None
-        self.assertEqual(profile.initial_population_strategy, "from_random")
-        population = config_gen.random_population(profile.initial_population)
-        self.assertEqual(population.count(expected), 1)
+        for num_kv in (256, 260, 516, 768, 1536, 2052, 4096):
+            with self.subTest(num_kv=num_kv):
+                spec = ConfigSpec(backend=CuteBackend())
+                for block_id, target in enumerate((1, 128, 128)):
+                    spec.block_sizes.append(
+                        BlockSizeSpec(block_id=block_id, size_hint=target)
+                    )
+                spec.enable_cute_flash_search(
+                    head_dim=64,
+                    num_kv=num_kv,
+                    block_size_targets={0: 1, 1: 128, 2: 128},
+                    dtype=torch.float16,
+                    is_causal=False,
+                    standard_dense_output=True,
+                )
+                spec.compiler_seed_configs = list(
+                    flash_attention_seed_configs(
+                        64,
+                        num_kv,
+                        dtype=torch.float16,
+                        standard_dense_output=True,
+                    )
+                )
+                config_gen = ConfigGeneration(spec)
+                expected = [
+                    config
+                    for _flat, config in config_gen.seed_flat_config_pairs()
+                    if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
+                ]
+                self.assertEqual(len(expected), 2)
+                self.assertEqual(
+                    {config.config[FLASH_STAT_TRANSPORT_KEY] for config in expected},
+                    {"ring2", "single_final"},
+                )
+                for config in expected:
+                    canonical_flat, canonical = config_gen.canonicalize_flat(
+                        config_gen.flatten(config)
+                    )
+                    self.assertEqual(canonical, config)
+                    self.assertEqual(config_gen.unflatten(canonical_flat), config)
+
+                profile = get_effort_profile("full").lfbo_pattern_search
+                assert profile is not None
+                self.assertEqual(profile.initial_population_strategy, "from_random")
+                population = config_gen.random_population(profile.initial_population)
+                seed_count = len(config_gen.seed_flat_config_pairs())
+                for config in expected:
+                    self.assertEqual(population.count(config), 1)
+                    self.assertIn(config, population[:seed_count])
 
     def test_cute_flash_does_not_automatically_seed_degree1_causal_packet(
         self,
@@ -2775,7 +2883,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         normalized = [
             config for _flat, config in ConfigGeneration(spec).seed_flat_config_pairs()
         ]
-        self.assertEqual(len(normalized), 3)
+        self.assertEqual(len(normalized), 4)
         self.assertEqual(
             {
                 (
@@ -2787,12 +2895,27 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             {
                 ("fa4", "1x1"),
                 ("fa4", "4x1"),
+                ("fa4", "deg2_16x6"),
                 ("ws_overlap", "1x1"),
             },
         )
 
     def test_cute_flash_causal_degree2_seed_uses_validated_schedule(self) -> None:
-        for num_kv in (2048, 4096, 8192):
+        expected_params = {
+            512: ("fa4", 15, 3, True),
+            1024: ("fa4", 1, 14, False),
+            2048: ("fa4", 14, 12, False),
+            4096: ("helion", 14, 12, False),
+            8192: ("helion", 14, 12, False),
+        }
+        common_configs: list[dict[str, object]] = []
+        shape_specific_keys = {
+            FLASH_ROLE_MAP_KEY,
+            FLASH_E2E_OFFSET_KEY,
+            FLASH_E2E_OFFSET0_KEY,
+            FLASH_EPI_TMA_KEY,
+        }
+        for num_kv in (256, *expected_params):
             with self.subTest(num_kv=num_kv):
                 seeds = flash_attention_seed_configs(
                     64,
@@ -2805,19 +2928,23 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     for seed in seeds
                     if seed.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
                 ]
-                if num_kv != 4096:
+                if num_kv < 512:
                     self.assertFalse(degree2_seeds)
                     continue
                 self.assertEqual(len(degree2_seeds), 1)
                 config = degree2_seeds[0].config
+                role_map, offset, offset0, epi_tma = expected_params[num_kv]
                 expected = {
                     FLASH_PIPELINE_FAMILY_KEY: "fa4",
+                    FLASH_EXP2_PACKET_KEY: "deg2_16x6",
                     FLASH_E2E_SCHEDULE_KEY: "16/6",
                     FLASH_MASKED_E2E_SCHEDULE_KEY: "16/6",
-                    FLASH_E2E_OFFSET_KEY: 0,
-                    FLASH_E2E_OFFSET0_KEY: 14,
+                    FLASH_E2E_OFFSET_KEY: offset,
+                    FLASH_E2E_OFFSET0_KEY: offset0,
                     FLASH_WAIT_HINT_KEY: 0,
                     FLASH_DISC_PIPE_KEY: 3,
+                    FLASH_EPI_TMA_KEY: epi_tma,
+                    FLASH_EPI_STG_KEY: False,
                     FLASH_RESCALE_CHUNK_COLS_KEY: 16,
                     FLASH_CAUSAL_LPT_SWIZZLE_KEY: 0,
                     FLASH_CAUSAL_KV_ORDER_KEY: "descending",
@@ -2825,9 +2952,21 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     FLASH_SOFTMAX_REGS_KEY: 184,
                     FLASH_CORR_REGS_KEY: 64,
                     FLASH_OTHER_REGS_KEY: 48,
+                    FLASH_ROLE_MAP_KEY: role_map,
                 }
                 for key, value in expected.items():
                     self.assertEqual(config[key], value)
+                self.assertNotIn(FLASH_USE_2CTA_KEY, config)
+                common_configs.append(
+                    {
+                        key: value
+                        for key, value in config.items()
+                        if key not in shape_specific_keys
+                    }
+                )
+        self.assertTrue(
+            all(config == common_configs[0] for config in common_configs[1:])
+        )
 
     def test_cute_flash_causal_degree2_seed_gates(self) -> None:
         cases = (
@@ -2865,36 +3004,85 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
     def test_cute_flash_causal_degree2_seed_is_in_full_initial_population(
         self,
     ) -> None:
-        spec = ConfigSpec(backend=CuteBackend())
-        for block_id, target in enumerate((1, 128, 128)):
-            spec.block_sizes.append(BlockSizeSpec(block_id=block_id, size_hint=target))
-        spec.enable_cute_flash_search(
-            head_dim=64,
-            num_kv=4096,
-            block_size_targets={0: 1, 1: 128, 2: 128},
-            dtype=torch.float16,
-            is_causal=True,
-            standard_causal_output=True,
-        )
-        spec.compiler_seed_configs = list(
-            flash_attention_seed_configs(
-                64,
-                4096,
-                is_causal=True,
-                standard_causal_output=True,
-            )
-        )
-        config_gen = ConfigGeneration(spec)
-        expected = next(
-            config
-            for _flat, config in config_gen.seed_flat_config_pairs()
-            if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
-        )
-        profile = get_effort_profile("full").lfbo_pattern_search
-        assert profile is not None
-        population = config_gen.random_population(profile.initial_population)
-        seed_count = len(config_gen.seed_flat_config_pairs())
-        self.assertIn(expected, population[:seed_count])
+        expected_params = {
+            512: ("fa4", 15, 3, True),
+            1024: ("fa4", 1, 14, False),
+            2048: ("fa4", 14, 12, False),
+            4096: ("helion", 14, 12, False),
+            8192: ("helion", 14, 12, False),
+        }
+        for num_kv, (role_map, offset, offset0, epi_tma) in expected_params.items():
+            with self.subTest(num_kv=num_kv):
+                spec = ConfigSpec(backend=CuteBackend())
+                for block_id, target in enumerate((1, 128, 128)):
+                    spec.block_sizes.append(
+                        BlockSizeSpec(block_id=block_id, size_hint=target)
+                    )
+                spec.enable_cute_flash_search(
+                    head_dim=64,
+                    num_kv=num_kv,
+                    block_size_targets={0: 1, 1: 128, 2: 128},
+                    dtype=torch.float16,
+                    is_causal=True,
+                    standard_causal_output=True,
+                )
+                spec.compiler_seed_configs = list(
+                    flash_attention_seed_configs(
+                        64,
+                        num_kv,
+                        is_causal=True,
+                        standard_causal_output=True,
+                    )
+                )
+                config_gen = ConfigGeneration(spec)
+                raw_seed = next(
+                    config
+                    for config in spec.compiler_seed_configs
+                    if config.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
+                )
+                roundtrip = config_gen.unflatten(config_gen.flatten(raw_seed))
+                self.assertEqual(
+                    config_gen.unflatten(config_gen.flatten(roundtrip)), roundtrip
+                )
+                expected = next(
+                    config
+                    for _flat, config in config_gen.seed_flat_config_pairs()
+                    if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
+                )
+                self.assertEqual(expected, roundtrip)
+                self.assertEqual(expected.config[FLASH_ROLE_MAP_KEY], role_map)
+                self.assertEqual(expected.config[FLASH_E2E_OFFSET_KEY], offset)
+                self.assertEqual(expected.config[FLASH_E2E_OFFSET0_KEY], offset0)
+                self.assertEqual(expected.config[FLASH_EPI_TMA_KEY], epi_tma)
+                profile = get_effort_profile("full").lfbo_pattern_search
+                assert profile is not None
+                search = PatternSearch.__new__(PatternSearch)
+                search.config_gen = config_gen
+                search.settings = Settings()
+                search.log = MagicMock()
+                search.initial_population_strategy = (
+                    InitialPopulationStrategy.FROM_BEST_AVAILABLE
+                )
+                search.best_available_pad_random = True
+                search.initial_population = profile.initial_population
+                search._best_available_seed_configs = []
+                search._pinned_finalist_configs = set()
+                search._autotune_seed_configs = lambda: ()
+                search._find_similar_cached_configs = lambda _max_configs: []
+                population = [
+                    config_gen.unflatten(flat)
+                    for flat in search._generate_initial_population_flat()
+                ]
+                seed_configs = [
+                    config for _flat, config in config_gen.seed_flat_config_pairs()
+                ]
+                seed_count = len(seed_configs)
+                self.assertEqual(population.count(expected), 1)
+                self.assertIn(expected, population[:seed_count])
+                self.assertEqual(population[:seed_count], seed_configs)
+                self.assertLessEqual(len(population), profile.initial_population)
+                self.assertEqual(len(set(population)), len(population))
+                self.assertIn(expected, search._pinned_finalist_configs)
 
     @onlyBackends(["cute"])
     def test_cute_flash_attention_seed_heuristic(self) -> None:
@@ -3165,6 +3353,14 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 for seed in causal_65536_bound.config_spec.compiler_seed_configs
             )
         )
+        causal_65536_degree2 = next(
+            seed
+            for seed in causal_65536_bound.config_spec.compiler_seed_configs
+            if seed.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
+        )
+        self.assertEqual(causal_65536_degree2.config[FLASH_E2E_OFFSET_KEY], 15)
+        self.assertEqual(causal_65536_degree2.config[FLASH_E2E_OFFSET0_KEY], 3)
+        self.assertTrue(causal_65536_degree2.config[FLASH_EPI_TMA_KEY])
         with patch.object(
             PatternSearch,
             "_find_similar_cached_configs",
@@ -3183,7 +3379,11 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 quick_search.config_gen.unflatten(flat)
                 for flat in quick_search._generate_initial_population_flat()
             ]
-        self.assertEqual(len(quick_configs), 3)
+        causal_65536_degree2_normalized = quick_search.config_gen.unflatten(
+            quick_search.config_gen.flatten(causal_65536_degree2)
+        )
+        self.assertEqual(len(quick_configs), 4)
+        self.assertIn(causal_65536_degree2_normalized, quick_configs)
         self.assertIsNone(causal_65536_bound.config_spec.compiler_default_config)
         causal_65536_gen = ConfigGeneration(causal_65536_bound.config_spec)
         causal_65536_default = causal_65536_gen.unflatten(

--- a/test/test_best_available.py
+++ b/test/test_best_available.py
@@ -32,6 +32,8 @@ from helion.autotuner.local_cache import LocalAutotuneCache
 from helion.autotuner.local_cache import SavedBestConfig
 from helion.autotuner.local_cache import iter_cache_entries
 from helion.autotuner.pattern_search import InitialPopulationStrategy
+from helion.autotuner.pattern_search import PatternSearch
+from helion.exc import InvalidConfig
 from helion.runtime.config import Config
 from helion.runtime.settings import Settings
 from helion.runtime.settings import _get_initial_population_strategy
@@ -1382,6 +1384,100 @@ class TestGenerateBestAvailablePopulation(unittest.TestCase):
         mock_search._autotune_seed_configs = MagicMock(return_value=[])
         mock_search._find_similar_cached_configs = MagicMock(return_value=entries)
         return mock_search
+
+    def test_unique_random_padding_retries_invalid_and_duplicate_configs(self):
+        config_gen = self._make_config_gen()
+        default_flat = config_gen.default_flat()
+        first_flat = config_gen.flatten(
+            Config(block_sizes=[32, 64], num_warps=8, num_stages=2)
+        )
+        second_flat = config_gen.flatten(
+            Config(block_sizes=[128, 256], num_warps=2, num_stages=4)
+        )
+        invalid_flat = [object()]
+        original_canonicalize = config_gen.canonicalize_flat
+
+        def canonicalize(flat):
+            if flat is invalid_flat:
+                raise InvalidConfig("synthetic invalid config")
+            return original_canonicalize(flat)
+
+        mock_search = self._make_mock_search(config_gen, cached_configs=[])
+        with (
+            patch.object(config_gen, "canonicalize_flat", side_effect=canonicalize),
+            patch.object(
+                config_gen,
+                "random_flat",
+                side_effect=(
+                    default_flat,
+                    invalid_flat,
+                    first_flat,
+                    first_flat,
+                    second_flat,
+                ),
+            ) as random_flat,
+        ):
+            population = (
+                PopulationBasedSearch._pad_initial_population_with_unique_random(
+                    mock_search, [default_flat], 3
+                )
+            )
+
+        configs = [config_gen.unflatten(flat) for flat in population]
+        self.assertEqual(len(configs), 3)
+        self.assertEqual(len(set(configs)), 3)
+        self.assertEqual(random_flat.call_count, 5)
+        mock_search.log.assert_called_once_with(
+            "Initial population after unique random padding: 3 total"
+        )
+
+    def test_unique_random_padding_stops_when_space_is_exhausted(self):
+        config_gen = self._make_config_gen()
+        default_flat = config_gen.default_flat()
+        mock_search = self._make_mock_search(config_gen, cached_configs=[])
+        with patch.object(
+            config_gen, "random_flat", return_value=default_flat
+        ) as random_flat:
+            population = (
+                PopulationBasedSearch._pad_initial_population_with_unique_random(
+                    mock_search, [default_flat], 3
+                )
+            )
+
+        self.assertEqual(population, [default_flat])
+        self.assertEqual(random_flat.call_count, 128)
+        self.assertEqual(
+            [call.args[0] for call in mock_search.log.call_args_list],
+            [
+                (
+                    "Generated only 1/3 unique valid initial population configs "
+                    "after 128 random attempts (0 invalid, 128 duplicate)."
+                ),
+                "Initial population after unique random padding: 1 total",
+            ],
+        )
+
+    def test_non_flash_best_available_padding_preserves_raw_random_behavior(self):
+        config_gen = self._make_config_gen()
+        default_flat = config_gen.default_flat()
+        search = PatternSearch.__new__(PatternSearch)
+        search.config_gen = config_gen
+        search.initial_population_strategy = (
+            InitialPopulationStrategy.FROM_BEST_AVAILABLE
+        )
+        search.best_available_pad_random = True
+        search.initial_population = 3
+        search._generate_best_available_population_flat = MagicMock(
+            return_value=[default_flat]
+        )
+
+        with patch.object(
+            config_gen, "random_flat", return_value=default_flat
+        ) as random_flat:
+            population = search._generate_initial_population_flat()
+
+        self.assertEqual(population, [default_flat, default_flat, default_flat])
+        self.assertEqual(random_flat.call_count, 2)
 
     def test_default_only_when_no_cached(self):
         """Population contains only default config when no cached configs found."""

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -271,6 +271,32 @@ def test_degree2_packet_emits_exact_causal_pass2_arguments() -> None:
         }
         assert keywords == {"pair_batch": 8, "emu_batch": 3, "degree2": True}
 
+    unmasked_loops = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.For)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "flash_kv_unmask_iter"
+    ]
+    assert len(unmasked_loops) == 2
+    for loop in unmasked_loops:
+        assert not any(
+            "flash_kv_unmask_iter" in ast.unparse(node.test)
+            for node in ast.walk(loop)
+            if isinstance(node, ast.If)
+        )
+        assert any(
+            isinstance(statement, ast.Assign)
+            and isinstance(statement.value, ast.Name)
+            and statement.value.id == "flash_alpha"
+            for statement in loop.body
+        )
+        assert any(
+            isinstance(node, ast.If)
+            and ast.unparse(node.test) == "flash_acc_log >= -8.0"
+            for node in ast.walk(loop)
+        )
+
 
 def test_hybrid_packet_uses_degree1_only_for_unmasked_pass2() -> None:
     with patch.dict(os.environ, {}, clear=True):
@@ -695,23 +721,22 @@ def test_dense_nonpersistent_final_only_stat_pipeline_protocol() -> None:
 def test_dense_degree2_final_only_is_deterministic_on_peaky_inputs() -> None:
     torch.manual_seed(104)
     q, k, v = (
-        torch.randn(1, 1, 32_768, 64, dtype=torch.float16, device=DEVICE)
+        torch.randn(1, 1, 33_280, 64, dtype=torch.float16, device=DEVICE)
         for _ in range(3)
     )
     q.mul_(2.0)
     k.mul_(2.0)
-    config = {
-        "block_sizes": [1, 128, 128],
-        "cute_flash_pipeline_family": "fa4_2cta",
-        "cute_flash_exp2_packet": _DEG2_PACKET,
-        "cute_flash_e2e_schedule": "16/6",
-        "cute_flash_e2e_offset": 0,
-        "cute_flash_e2e_offset0": 2,
-        "cute_flash_kv_stage": 2,
-        "cute_flash_persistent": False,
-        "cute_flash_stat_transport": "single_final",
-        "cute_flash_wait_hint": 0,
-    }
+    config = next(
+        seed.config
+        for seed in cute_flash.flash_attention_seed_configs(
+            64,
+            260,
+            dtype=torch.float16,
+            standard_dense_output=True,
+        )
+        if seed.config.get(cute_flash.FLASH_EXP2_PACKET_KEY) == _DEG2_PACKET
+        and seed.config.get(cute_flash.FLASH_STAT_TRANSPORT_KEY) == "single_final"
+    )
 
     bound = _dense_attention_output.bind((q, k, v))
     active_config = helion.Config(**config)
@@ -972,19 +997,26 @@ def test_hybrid_packet_runtime_matches_sdpa_at_long_causal_threshold() -> None:
 
 
 @onlyBackends(["cute"])
-def test_hybrid_packet_runtime_matches_sdpa_beyond_previous_seed_cap() -> None:
+def test_transferred_degree2_packet_matches_sdpa_beyond_previous_seed_cap() -> None:
     torch.manual_seed(103)
     q, k, v = (
         torch.randn(1, 1, 1_048_576, 64, dtype=torch.float16, device=DEVICE)
         for _ in range(3)
     )
 
-    code, out = code_and_output(
-        _causal_attention_output,
-        (q, k, v),
-        **_hybrid_runtime_config(),
+    config = next(
+        seed.config
+        for seed in cute_flash.flash_attention_seed_configs(
+            64,
+            8192,
+            dtype=torch.float16,
+            is_causal=True,
+            standard_causal_output=True,
+        )
+        if seed.config.get(cute_flash.FLASH_EXP2_PACKET_KEY) == _DEG2_PACKET
     )
-    assert "degree1=True" in code
+    code, out = code_and_output(_causal_attention_output, (q, k, v), **config)
+    assert "degree1=True" not in code
     assert "degree2=True" in code
     expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
     torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3344
 * __->__#3343
 * #3342
 * #3341


--- --- ---

[autotuner] Seed validated long CuTe attention schedules

Seed the validated dense and causal degree-2 schedules for supported long-attention buckets, including the safe causal phase offsets.

Canonicalize and deduplicate CuTe-flash initial candidates before random padding so full tuning evaluates a robust population without changing non-CuTe search behavior.