### PR TITLE
[benchmark] Extend attention backend comparison

### DIFF
--- a/benchmarks/cute/compare_attention_backends.py
+++ b/benchmarks/cute/compare_attention_backends.py
@@ -18,6 +18,8 @@ Impls:
                   supports causal too.
     helion-triton examples.attention attention kernels with the DEFAULT
                   (triton) backend.
+    helion-tileir examples.attention attention kernels with NVIDIA's
+                  Triton-to-Tile-IR backend (ENABLE_TILE=1).
     helion-cute   examples.attention attention kernels with
                   HELION_BACKEND=cute. By default this uses output-only
                   variants for dense, causal, and biased attention so Helion
@@ -27,9 +29,26 @@ Impls:
                   a cute correctness mismatch (accuracy=FAIL) but still reports
                   timing -- it never crashes on cute's current state.
     flexattention torch.nn.attention.flex_attention.flex_attention under
-                  torch.compile(fullgraph=True). Causal uses a BlockMask;
-                  biased uses score_mod.
-
+                  torch.compile(fullgraph=True), forced to Inductor's Triton
+                  template. Causal uses a BlockMask; biased uses score_mod.
+    flexattention-cute
+                  The same PyTorch FlexAttention API forced to its experimental
+                  CuTeDSL/FA4 FLASH backend.
+    gluon        The Triton Gluon Blackwell attention-forward example loaded
+                 from HELION_GLUON_ATTENTION_PATH (or TRITON_ROOT). Supports
+                 dense and causal softmax attention.
+    tlx          Meta TLX's Blackwell warp-specialized, pipelined persistent
+                 attention tutorial. Loaded from an isolated TLX Triton runtime
+                 selected with HELION_TLX_RUNTIME_ROOT.
+    kernelagent-1x / kernelagent-2x / kernelagent-10x
+                 Shape-specific kernels produced by KernelAgent with one or
+                 more times the corresponding Helion full-autotune wall-clock
+                 time. Loaded from --kernelagent-results-root.
+    kernelagent-closed-1x / kernelagent-closed-2x
+                 Shape-specific CuTeDSL kernels produced by KernelAgent Closed
+                 v3-20260730 with the corresponding Helion full-autotune
+                 wall-clock time. Loaded from
+                 --kernelagent-closed-results-root.
 Each impl runs in a fresh subprocess (so the HELION_BACKEND env mutation and
 example imports do not leak between impls), with steady-state methodology
 (10 s thermal warmup, do_bench warmup=1 s + rep=500 ms, 5 runs) and reports
@@ -65,7 +84,13 @@ from __future__ import annotations
 import argparse
 import contextlib
 import csv
+import hashlib
+import importlib
+import importlib.machinery
+import importlib.metadata
+import importlib.util
 import json
+import math
 import os
 from pathlib import Path
 import statistics
@@ -84,9 +109,31 @@ import torch
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-DEFAULT_IMPLS = ("helion-triton", "helion-cute", "flexattention", "sdpa", "fa4")
-ALL_IMPLS = ("helion-triton", "helion-cute", "flexattention", "sdpa", "fa4")
-HELION_IMPLS = ("helion-cute", "helion-triton")
+DEFAULT_IMPLS = (
+    "helion-triton",
+    "helion-cute",
+    "flexattention",
+    "flexattention-cute",
+    "sdpa",
+    "fa4",
+)
+ALL_IMPLS = (
+    "helion-triton",
+    "helion-cute",
+    "helion-tileir",
+    "gluon",
+    "tlx",
+    "flexattention",
+    "flexattention-cute",
+    "sdpa",
+    "fa4",
+    "kernelagent-1x",
+    "kernelagent-2x",
+    "kernelagent-10x",
+    "kernelagent-closed-1x",
+    "kernelagent-closed-2x",
+)
+HELION_IMPLS = ("helion-cute", "helion-tileir", "helion-triton")
 
 
 class _ConfigLike(Protocol):
@@ -113,7 +160,17 @@ _FA4_AUTO_DOWNLOAD_ENV = "HELION_FA4_AUTO_DOWNLOAD"
 _TRITONBENCH_ROOT = REPO_ROOT / "benchmarks" / "tritonbench"
 _FA4_TRITONBENCH_ROOT = _TRITONBENCH_ROOT / "submodules" / "flash-attention"
 _FA4_STANDALONE_ROOT = REPO_ROOT / "benchmarks" / "flash-attention"
-
+_GLUON_ATTENTION_PATH_ENV = "HELION_GLUON_ATTENTION_PATH"
+_GLUON_VERSION_ENV = "HELION_GLUON_VERSION"
+_TLX_ATTENTION_MODULE = (
+    "triton.language.extra.tlx.tutorials.blackwell_fa_ws_pipelined_persistent"
+)
+_TLX_ATTENTION_PATH_ENV = "HELION_TLX_ATTENTION_PATH"
+_TLX_RUNTIME_ROOT_ENV = "HELION_TLX_RUNTIME_ROOT"
+_TLX_REVISION_ENV = "HELION_TLX_REVISION"
+_HELION_VERSION_ENV = "HELION_BENCHMARK_HELION_VERSION"
+_KERNELAGENT_RESULTS_ROOT_ENV = "HELION_KERNELAGENT_RESULTS_ROOT"
+_KERNELAGENT_CLOSED_RESULTS_ROOT_ENV = "HELION_KERNELAGENT_CLOSED_RESULTS_ROOT"
 # (z, h, seq_len, head_dim, dtype, causal, biased)
 _REPRESENTATIVE_SHAPES: tuple[tuple[int, int, int, int, str, int, int], ...] = (
     (1, 4, 512, 64, "float16", 0, 0),
@@ -153,20 +210,68 @@ _SHAPE_SUITES = {
     "dense_causal8": _DENSE_CAUSAL8_SHAPES,
 }
 
-_DISPLAY_IMPLS = ("helion-triton", "helion-cute", "flexattention", "sdpa", "fa4")
+_DISPLAY_IMPLS = (
+    "helion-triton",
+    "helion-tileir",
+    "flexattention",
+    "gluon",
+    "tlx",
+    "flexattention-cute",
+    "fa4",
+    "sdpa",
+    "helion-cute",
+    "kernelagent-1x",
+    "kernelagent-2x",
+    "kernelagent-10x",
+    "kernelagent-closed-1x",
+    "kernelagent-closed-2x",
+)
 _IMPL_LABELS = {
-    "helion-triton": "Helion+Triton",
-    "helion-cute": "Helion+CuTe",
-    "flexattention": "FlexAttention",
+    "helion-triton": "Helion (backend=Triton)",
+    "helion-tileir": "Helion (backend=TileIR)",
+    "helion-cute": "Helion (backend=CuTe)",
+    "gluon": "Gluon attention",
+    "tlx": "TLX attention",
+    "flexattention": "FlexAttention (backend=Triton)",
+    "flexattention-cute": "FlexAttention (backend=CuTe)",
     "sdpa": "torch SDPA",
     "fa4": "FA4",
+    "kernelagent-1x": "KernelAgent Public (1x Helion tuning time)",
+    "kernelagent-2x": "KernelAgent Public (2x Helion tuning time)",
+    "kernelagent-10x": "KernelAgent Public (10x Helion tuning time)",
+    "kernelagent-closed-1x": "KernelAgent Closed (1x Helion tuning time)",
+    "kernelagent-closed-2x": "KernelAgent Closed (2x Helion tuning time)",
 }
 _IMPL_KEYS = {
     "helion-triton": "helion_triton",
+    "helion-tileir": "helion_tileir",
     "helion-cute": "helion_cute",
-    "flexattention": "flexattention",
+    "gluon": "gluon",
+    "tlx": "tlx",
+    "flexattention": "flexattention_triton",
+    "flexattention-cute": "flexattention_cute",
     "sdpa": "torch_sdpa",
     "fa4": "fa4",
+    "kernelagent-1x": "kernelagent_1x",
+    "kernelagent-2x": "kernelagent_2x",
+    "kernelagent-10x": "kernelagent_10x",
+    "kernelagent-closed-1x": "kernelagent_closed_1x",
+    "kernelagent-closed-2x": "kernelagent_closed_2x",
+}
+_FLEXATTENTION_BACKENDS = {
+    "flexattention": "TRITON",
+    "flexattention-cute": "FLASH",
+}
+_KERNELAGENT_BUDGET_LABELS = {
+    "kernelagent-1x": "1x",
+    "kernelagent-2x": "2x",
+    "kernelagent-10x": "10x",
+    "kernelagent-closed-1x": "1x",
+    "kernelagent-closed-2x": "2x",
+}
+_KERNELAGENT_CLOSED_IMPLS = {
+    "kernelagent-closed-1x",
+    "kernelagent-closed-2x",
 }
 
 _ALLOWED_PHYSICAL_GPUS_ENV = "HELION_BENCHMARK_ALLOWED_PHYSICAL_GPUS"
@@ -188,8 +293,70 @@ def _parse_config_override(value: str) -> tuple[str, object]:
     return key, parsed_value
 
 
+def _parse_plot_impl_label(value: str) -> tuple[str, str]:
+    impl, label = _parse_key_value(value)
+    if impl not in _IMPL_LABELS:
+        raise argparse.ArgumentTypeError(
+            f"unknown implementation {impl!r}; expected one of "
+            f"{', '.join(_IMPL_LABELS)}"
+        )
+    if not label:
+        raise argparse.ArgumentTypeError(f"plot label must not be empty for {impl!r}")
+    return impl, label
+
+
 def _dtype_from_name(name: str) -> torch.dtype:
     return {"float16": torch.float16, "bfloat16": torch.bfloat16}[name]
+
+
+def _gpu_name() -> str:
+    if not torch.cuda.is_available():
+        return "unavailable"
+    return torch.cuda.get_device_name()
+
+
+def _physical_gpu_selection() -> str:
+    return os.environ.get("CUDA_VISIBLE_DEVICES", "")
+
+
+def _verify_power_cap_w(requested: int | None) -> int | None:
+    """Return the measured power limit, rejecting mislabeled benchmark runs."""
+    if requested is None:
+        return None
+
+    visible = _physical_gpu_selection()
+    physical_gpu = visible.split(",", 1)[0].strip()
+    if not physical_gpu:
+        if not torch.cuda.is_available():
+            raise SystemExit("cannot verify a GPU power cap without CUDA")
+        physical_gpu = str(torch.cuda.current_device())
+    try:
+        proc = subprocess.run(
+            [
+                "nvidia-smi",
+                "-i",
+                physical_gpu,
+                "--query-gpu=power.limit",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        output_lines = [
+            line.strip() for line in proc.stdout.splitlines() if line.strip()
+        ]
+        actual = float(output_lines[0])
+    except (IndexError, OSError, subprocess.CalledProcessError, ValueError) as exc:
+        raise SystemExit(
+            f"failed to verify the power limit for physical GPU {physical_gpu}"
+        ) from exc
+    if abs(actual - requested) > 0.5:
+        raise SystemExit(
+            f"physical GPU {physical_gpu} has a {actual:g} W power limit; "
+            f"requested benchmark label is {requested} W"
+        )
+    return int(round(actual))
 
 
 def _attention_flops(args: argparse.Namespace) -> float:
@@ -383,6 +550,284 @@ def _resolve_fa4_root() -> Path:
     return _ensure_fa4_checkout(_FA4_STANDALONE_ROOT)
 
 
+def _package_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _git_describe(root: Path) -> str | None:
+    try:
+        proc = subprocess.run(
+            [
+                "git",
+                "-c",
+                f"safe.directory={root}",
+                "describe",
+                "--tags",
+                "--always",
+                "--dirty",
+            ],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return proc.stdout.strip() or None
+
+
+def _format_git_development_version(git_describe: str) -> str:
+    """Convert ``v1.2.3-4-gabc`` into ``1.2.3.dev4+gabc``."""
+    dirty = git_describe.endswith("-dirty")
+    version = git_describe.removesuffix("-dirty").removeprefix("v")
+    parts = version.rsplit("-", 2)
+    if (
+        len(parts) == 3
+        and parts[1].isdigit()
+        and parts[2].startswith("g")
+        and len(parts[2]) > 1
+    ):
+        base, commit_count, commit = parts
+        version = f"{base}.dev{commit_count}+{commit}"
+    if dirty:
+        return f"{version}.dirty" if "+" in version else f"{version}+dirty"
+    return version
+
+
+def _cudnn_version() -> str:
+    version = torch.backends.cudnn.version()
+    if version is None:
+        return "unknown"
+    major, remainder = divmod(version, 10000)
+    minor, patch = divmod(remainder, 100)
+    return f"{major}.{minor}.{patch}"
+
+
+def _tileir_toolchain_version() -> str:
+    try:
+        tileir_conf = importlib.import_module("triton.backends.tileir.conf")
+        tileiras = tileir_conf.TileIREnvConf.get_tileiras_path()
+        proc = subprocess.run(
+            [tileiras, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (ImportError, OSError, subprocess.CalledProcessError):
+        return "unknown"
+    for line in proc.stdout.splitlines():
+        prefix = "Cuda compilation tools, release "
+        if line.startswith(prefix):
+            return line.removeprefix(prefix).split(",", 1)[0]
+    return "unknown"
+
+
+def _resolve_gluon_attention_path() -> Path:
+    configured = os.environ.get(_GLUON_ATTENTION_PATH_ENV)
+    if configured:
+        path = Path(configured).expanduser().resolve()
+        if path.is_file():
+            return path
+        raise SystemExit(f"{_GLUON_ATTENTION_PATH_ENV}={path} is not a file")
+
+    triton_root = os.environ.get("TRITON_ROOT")
+    if triton_root:
+        path = (
+            Path(triton_root).expanduser().resolve()
+            / "python"
+            / "examples"
+            / "gluon"
+            / "01-attention-forward.py"
+        )
+        if path.is_file():
+            return path
+    raise SystemExit(
+        "Gluon attention example not found; set "
+        f"{_GLUON_ATTENTION_PATH_ENV}=<triton/python/examples/gluon/"
+        "01-attention-forward.py> or TRITON_ROOT=<triton checkout>"
+    )
+
+
+def _resolve_tlx_attention_path() -> Path:
+    configured = os.environ.get(_TLX_ATTENTION_PATH_ENV)
+    if configured:
+        path = Path(configured).expanduser().resolve()
+        if path.is_file():
+            return path
+        raise SystemExit(f"{_TLX_ATTENTION_PATH_ENV}={path} is not a file")
+
+    runtime_root = os.environ.get(_TLX_RUNTIME_ROOT_ENV)
+    if runtime_root:
+        path = (
+            Path(runtime_root).expanduser().resolve()
+            / "triton"
+            / "language"
+            / "extra"
+            / "tlx"
+            / "tutorials"
+            / "blackwell_fa_ws_pipelined_persistent.py"
+        )
+        if path.is_file():
+            return path
+
+    try:
+        spec = importlib.util.find_spec(_TLX_ATTENTION_MODULE)
+    except (ImportError, ModuleNotFoundError):
+        spec = None
+    if spec is not None and spec.origin is not None:
+        path = Path(spec.origin).resolve()
+        if path.is_file():
+            return path
+    raise SystemExit(
+        "TLX attention example not found; set "
+        f"{_TLX_RUNTIME_ROOT_ENV}=<isolated TLX runtime> or "
+        f"{_TLX_ATTENTION_PATH_ENV}=<blackwell attention source>"
+    )
+
+
+def _implementation_version(
+    impl: str, *, resolve_external_sources: bool = True
+) -> dict[str, str]:
+    helion_version = os.environ.get(_HELION_VERSION_ENV)
+    if helion_version is None:
+        helion_describe = _git_describe(REPO_ROOT)
+        helion_version = (
+            _format_git_development_version(helion_describe)
+            if helion_describe is not None
+            else "unknown"
+        )
+    triton_version = _package_version("triton")
+    triton_label_version = triton_version.split("+", 1)[0]
+    torch_version = torch.__version__
+    torch_label_version = torch_version.split("+", 1)[0]
+    if impl in _KERNELAGENT_BUDGET_LABELS:
+        return {
+            "version": "KernelAgent metadata is supplied by the run manifest",
+            "version_label": "run manifest metadata",
+        }
+    if impl == "helion-cute":
+        cute_version = _package_version("nvidia-cutlass-dsl")
+        return {
+            "version": f"Helion {helion_version}; CuTe {cute_version}",
+            "version_label": f"Helion {helion_version} / CuTe {cute_version}",
+        }
+    if impl == "helion-triton":
+        return {
+            "version": f"Helion {helion_version}; Triton {triton_version}",
+            "version_label": (
+                f"Helion {helion_version} / Triton {triton_label_version}"
+            ),
+        }
+    if impl == "helion-tileir":
+        nvtriton_version = _package_version("nvtriton")
+        tileir_version = _tileir_toolchain_version()
+        return {
+            "version": (
+                f"Helion {helion_version}; nvtriton {nvtriton_version}; "
+                f"TileIR {tileir_version}"
+            ),
+            "version_label": (
+                f"Helion {helion_version} / nvtriton {nvtriton_version} / "
+                f"TileIR {tileir_version}"
+            ),
+        }
+    if impl == "gluon":
+        revision = os.environ.get(_GLUON_VERSION_ENV, triton_version)
+        if not resolve_external_sources:
+            return {
+                "version": (
+                    f"Triton {triton_version}; example {revision}; "
+                    "source not resolved (implementation skipped)"
+                ),
+                "version_label": f"Triton {triton_label_version}",
+            }
+        source_path = _resolve_gluon_attention_path()
+        source_hash = hashlib.sha256(source_path.read_bytes()).hexdigest()
+        return {
+            "version": (
+                f"Triton {triton_version}; example {revision}; "
+                f"source sha256 {source_hash}"
+            ),
+            "version_label": f"Triton {triton_label_version}",
+        }
+    if impl == "tlx":
+        if not resolve_external_sources:
+            return {
+                "version": "TLX version not resolved (implementation skipped)",
+                "version_label": "version not resolved",
+            }
+        source_path = _resolve_tlx_attention_path()
+        source_hash = hashlib.sha256(source_path.read_bytes()).hexdigest()
+        triton_module = importlib.import_module("triton")
+        meta_triton_version = str(getattr(triton_module, "__version__", triton_version))
+        revision = os.environ.get(_TLX_REVISION_ENV)
+        revision_text = f"; revision {revision}" if revision else ""
+        return {
+            "version": (
+                f"Meta Triton {meta_triton_version}; integrated TLX; "
+                f"package {triton_version}"
+                f"{revision_text}; source sha256 {source_hash}"
+            ),
+            "version_label": f"Meta Triton {meta_triton_version}",
+        }
+    if impl in _FLEXATTENTION_BACKENDS:
+        backend = _FLEXATTENTION_BACKENDS[impl]
+        backend_version = (
+            f"Triton {triton_version}"
+            if backend == "TRITON"
+            else (
+                f"FA4 {_git_describe(_resolve_fa4_root()) or 'unknown'}; "
+                f"CuTe {_package_version('nvidia-cutlass-dsl')}"
+            )
+        )
+        backend_version_label = (
+            f"Triton {triton_label_version}"
+            if backend == "TRITON"
+            else (
+                f"FA4 {_git_describe(_resolve_fa4_root()) or 'unknown'}; "
+                f"CuTe {_package_version('nvidia-cutlass-dsl')}"
+            )
+        )
+        return {
+            "version": f"PyTorch {torch_version}; {backend_version}",
+            "version_label": (
+                f"PyTorch {torch_label_version}; {backend_version_label}"
+            ),
+        }
+    if impl == "sdpa":
+        cudnn_version = _cudnn_version()
+        cudnn_package_version = _package_version("nvidia-cudnn-cu13")
+        cudnn_label = (
+            cudnn_package_version
+            if cudnn_package_version != "unknown"
+            else cudnn_version
+        )
+        return {
+            "version": (
+                f"PyTorch {torch_version}; cuDNN runtime {cudnn_version}; "
+                f"nvidia-cudnn-cu13 {cudnn_package_version}"
+            ),
+            "version_label": f"cuDNN {cudnn_label}",
+        }
+    if impl == "fa4":
+        if not resolve_external_sources:
+            return {
+                "version": "FlashAttention version not resolved (implementation skipped)",
+                "version_label": "version not resolved",
+            }
+        root = _resolve_fa4_root()
+        revision = _git_describe(root) or (_git_commit(root, "HEAD") or "unknown")[:12]
+        cute_version = _package_version("nvidia-cutlass-dsl")
+        return {
+            "version": f"FlashAttention {revision}; CuTe {cute_version}",
+            "version_label": f"{revision}; CuTe {cute_version}",
+        }
+    raise ValueError(f"unknown implementation {impl!r}")
+
+
 def _uses_bias(args: argparse.Namespace) -> bool:
     return bool(getattr(args, "biased", 0))
 
@@ -419,6 +864,108 @@ def _make_inputs(
     k = torch.randn(shape, device="cuda", dtype=dtype)
     v = torch.randn(shape, device="cuda", dtype=dtype)
     return q, k, v
+
+
+def _check_kernelagent_output(
+    actual: object, expected: torch.Tensor, *, chunk_rows: int = 4096
+) -> bool:
+    if not isinstance(actual, torch.Tensor):
+        return False
+    if (
+        actual.shape != expected.shape
+        or actual.dtype is not torch.float16
+        or actual.device.type != "cuda"
+    ):
+        return False
+    for start in range(0, actual.shape[-2], chunk_rows):
+        stop = min(start + chunk_rows, actual.shape[-2])
+        actual_float = actual[..., start:stop, :].float()
+        expected_float = expected[..., start:stop, :].float()
+        if not bool(
+            torch.all(
+                torch.isclose(
+                    actual_float,
+                    expected_float,
+                    atol=5e-2,
+                    rtol=2e-2,
+                )
+            ).item()
+        ):
+            return False
+    return True
+
+
+def _check_kernelagent_repeat(first: object, repeated: object) -> bool:
+    return (
+        isinstance(first, torch.Tensor)
+        and isinstance(repeated, torch.Tensor)
+        and first.shape == repeated.shape
+        and first.dtype is repeated.dtype
+        and first.device == repeated.device
+        and bool(torch.equal(first, repeated))
+    )
+
+
+def _check_kernelagent_stress_case(
+    run: Callable[..., torch.Tensor], args: argparse.Namespace, dtype: torch.dtype
+) -> bool:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(args.seed + 1)
+    shape = (args.z, args.h, args.seq_len, args.head_dim)
+    q = torch.randn(shape, device="cuda", dtype=dtype, generator=generator)
+    k = torch.randn(shape, device="cuda", dtype=dtype, generator=generator)
+    v = torch.randn(shape, device="cuda", dtype=dtype, generator=generator)
+    q.mul_(2.0)
+    k.mul_(2.0)
+    v.add_(
+        torch.randn(
+            (args.z, args.h, 1, args.head_dim),
+            device="cuda",
+            dtype=dtype,
+            generator=generator,
+        )
+    )
+    with torch.nn.attention.sdpa_kernel(
+        [torch.nn.attention.SDPBackend.CUDNN_ATTENTION]
+    ):
+        expected = _sdpa_reference(q, k, v, causal=bool(args.causal))
+    actual = run(q, k, v)
+    repeated = run(q, k, v)
+    return (
+        _check_kernelagent_output(actual, expected)
+        and _check_kernelagent_output(repeated, expected)
+        and _check_kernelagent_repeat(actual, repeated)
+    )
+
+
+def _kernelagent_evaluation_note(
+    backend_name: str,
+    selection_version: str,
+    evaluation_version: str,
+    *,
+    standard_executed: bool,
+    repeat_executed: bool,
+    stress_executed: bool,
+    passed: bool,
+    measured: bool,
+) -> str:
+    prefix = (
+        f"Source selected with {backend_name} {selection_version}; recompiled with "
+        f"{backend_name} {evaluation_version}. Performance was "
+        f"{'measured' if measured else 'not measured'}."
+    )
+    if not standard_executed:
+        return f"{prefix} Final-harness correctness checks were skipped."
+    if not repeat_executed:
+        return f"{prefix} The standard full-output check failed; repeat and stress were not run."
+    if not stress_executed:
+        return f"{prefix} The standard check passed, but exact repeatability failed."
+    if not passed:
+        return f"{prefix} Standard and repeat checks passed, but stress failed."
+    return (
+        f"{prefix} Standard and stress full-output checks passed with exact "
+        "repeatability."
+    )
 
 
 def _make_bias(args: argparse.Namespace, dtype: torch.dtype) -> torch.Tensor | None:
@@ -538,7 +1085,7 @@ def _bench_steady(
 def _result(
     impl: str,
     args: argparse.Namespace,
-    stats: dict[str, Any],
+    stats: dict[str, Any] | None,
     *,
     accuracy: str,
     benchmark_timer: str,
@@ -546,22 +1093,33 @@ def _result(
     codegen: dict[str, bool] | None = None,
     helion_overrides: dict[str, Any] | None = None,
     notes: list[str] | None = None,
+    version_info: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "impl": impl,
+        **(version_info if version_info is not None else _implementation_version(impl)),
         "shape": _shape_dict(args),
+        "gpu": _gpu_name(),
+        "physical_gpu": _physical_gpu_selection(),
+        "power_cap_w": getattr(args, "power_cap_w", None),
+        "flop_model": "softmax_attention_forward",
         "accuracy": accuracy,
         "benchmark_timer": benchmark_timer,
-        "best_ms": stats["best_ms"],
-        "median_ms": stats["median_ms"],
-        "mom_median_ms": stats["median_ms"],
-        "mean_ms": stats["mean_ms"],
-        "std_ms": stats["std_ms"],
-        "runs_ms": stats["runs_ms"],
-        "best_tflops": _tflops(args, stats["best_ms"]),
-        "median_tflops": _tflops(args, stats["median_ms"]),
-        "mom_median_tflops": _tflops(args, stats["median_ms"]),
     }
+    if stats is not None:
+        payload.update(
+            {
+                "best_ms": stats["best_ms"],
+                "median_ms": stats["median_ms"],
+                "mom_median_ms": stats["median_ms"],
+                "mean_ms": stats["mean_ms"],
+                "std_ms": stats["std_ms"],
+                "runs_ms": stats["runs_ms"],
+                "best_tflops": _tflops(args, stats["best_ms"]),
+                "median_tflops": _tflops(args, stats["median_ms"]),
+                "mom_median_tflops": _tflops(args, stats["median_ms"]),
+            }
+        )
     if config is not None:
         payload["config"] = config
     if codegen is not None:
@@ -571,6 +1129,21 @@ def _result(
     if notes:
         payload["notes"] = notes
     return payload
+
+
+def _skipped_result(impl: str, args: argparse.Namespace, reason: str) -> dict[str, Any]:
+    return {
+        "impl": impl,
+        **_implementation_version(impl, resolve_external_sources=False),
+        "shape": _shape_dict(args),
+        "gpu": _gpu_name(),
+        "physical_gpu": _physical_gpu_selection(),
+        "power_cap_w": getattr(args, "power_cap_w", None),
+        "flop_model": "not_comparable",
+        "accuracy": "SKIP",
+        "skipped_reason": reason,
+        "notes": [reason],
+    }
 
 
 def _shape_dict(args: argparse.Namespace) -> dict[str, Any]:
@@ -604,6 +1177,8 @@ def _helion_override_args(args: argparse.Namespace) -> list[str]:
         result.extend(["--helion-env", f"{key}={value}"])
     for key, value in getattr(args, "helion_config", ()):
         result.extend(["--helion-config", f"{key}={json.dumps(value)}"])
+    for key, value in getattr(args, "helion_seed_config", ()):
+        result.extend(["--helion-seed-config", f"{key}={json.dumps(value)}"])
     return result
 
 
@@ -706,15 +1281,420 @@ def _benchmark_sdpa(args: argparse.Namespace) -> dict[str, Any]:
     causal = bool(args.causal)
     fn = lambda: _sdpa_reference(q, k, v, causal=causal, bias=bias)  # noqa: E731
     # sdpa is the reference, so it is "PASS" by definition.
-    stats = _bench_steady(
-        fn,
-        num_runs=args.num_runs,
-        warmup_ms=args.warmup_ms,
-        rep_ms=args.rep_ms,
-    )
+    with torch.nn.attention.sdpa_kernel(
+        [torch.nn.attention.SDPBackend.CUDNN_ATTENTION]
+    ):
+        stats = _bench_steady(
+            fn,
+            num_runs=args.num_runs,
+            warmup_ms=args.warmup_ms,
+            rep_ms=args.rep_ms,
+        )
     return _result(
-        "sdpa", args, stats, accuracy="PASS", benchmark_timer="event", config=None
+        "sdpa",
+        args,
+        stats,
+        accuracy="PASS",
+        benchmark_timer="event",
+        config=None,
+        notes=["Forced torch SDPBackend.CUDNN_ATTENTION."],
     )
+
+
+def _manifest_text(manifest: dict[str, Any], key: str) -> str:
+    value = manifest.get(key)
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"KernelAgent manifest is missing nonempty {key!r}")
+    return value
+
+
+def _kernelagent_version_info(
+    impl: str,
+    manifest: dict[str, Any],
+    *,
+    evaluation_backend_version: str | None,
+) -> dict[str, str]:
+    model = _manifest_text(manifest, "model")
+    display_version = _manifest_text(manifest, "kernelagent_display_version")
+    model_display_name = _manifest_text(manifest, "model_display_name")
+    if impl in _KERNELAGENT_CLOSED_IMPLS:
+        agent_version = _manifest_text(manifest, "kernelagent_version")
+        selected_backend_version = _manifest_text(manifest, "cutlass_dsl_version")
+        backend_name = "CuTe"
+    else:
+        agent_version = manifest.get("kernelagent_version")
+        if not isinstance(agent_version, str) or not agent_version:
+            commit = _manifest_text(manifest, "kernelagent_commit")
+            agent_version = f"commit {commit[:8]}"
+        selected_backend_version = _manifest_text(manifest, "triton_version")
+        backend_name = "Triton"
+
+    measured_backend_version = evaluation_backend_version or selected_backend_version
+    backend_label_version = (
+        measured_backend_version.split("+", 1)[0]
+        if backend_name == "Triton"
+        else measured_backend_version
+    )
+    selection_suffix = (
+        f"; selected with {backend_name} {selected_backend_version}"
+        if selected_backend_version != measured_backend_version
+        else ""
+    )
+    return {
+        "version": (
+            f"KernelAgent {agent_version}; model {model}; {backend_name} "
+            f"{measured_backend_version}{selection_suffix}"
+        ),
+        "version_label": (
+            f"KernelAgent {display_version} / {model_display_name} / {backend_name} "
+            f"{backend_label_version}"
+        ),
+    }
+
+
+def _declared_kernelagent_source_hashes(
+    manifest: dict[str, Any],
+) -> dict[str, str]:
+    declared: dict[str, str] = {}
+    for field, container in (
+        ("source_sha256", manifest),
+        ("selection.source_sha256", manifest.get("selection")),
+        (
+            "posthoc_correctness_validation.source_sha256",
+            manifest.get("posthoc_correctness_validation"),
+        ),
+    ):
+        if isinstance(container, dict):
+            value = container.get("source_sha256")
+            if isinstance(value, str) and value:
+                declared[field] = value
+    return declared
+
+
+def _validate_kernelagent_manifest(
+    impl: str,
+    manifest: object,
+    args: argparse.Namespace,
+    run_dir: Path,
+) -> dict[str, Any]:
+    if not isinstance(manifest, dict):
+        raise SystemExit(f"KernelAgent manifest is not an object in {run_dir}")
+
+    budget_label = _KERNELAGENT_BUDGET_LABELS[impl]
+    physical_gpu = _physical_gpu_selection()
+    power_cap_w = getattr(args, "power_cap_w", None)
+    if not physical_gpu:
+        raise SystemExit("KernelAgent evaluation requires CUDA_VISIBLE_DEVICES")
+    if power_cap_w is None:
+        raise SystemExit("KernelAgent evaluation requires --power-cap-w")
+    expected_manifest: dict[str, object] = {
+        "budget_label": budget_label,
+        "shape": _shape_dict(args),
+        "physical_gpu": physical_gpu,
+        "power_cap_w": power_cap_w,
+        "seed": args.seed,
+    }
+    if impl in _KERNELAGENT_CLOSED_IMPLS:
+        expected_manifest["kernelagent_family"] = "closed_binary"
+
+    mismatches: dict[str, tuple[object, object]] = {}
+    for key, expected in expected_manifest.items():
+        actual = manifest.get(key)
+        if key == "physical_gpu" and actual is not None:
+            actual = str(actual)
+        exact_shape_match = (
+            key != "shape"
+            or isinstance(actual, dict)
+            and isinstance(expected, dict)
+            and actual.keys() == expected.keys()
+            and all(
+                type(actual[field]) is type(expected[field])
+                and actual[field] == expected[field]
+                for field in expected
+            )
+        )
+        if actual != expected or not exact_shape_match:
+            mismatches[key] = (actual, expected)
+    if mismatches:
+        raise SystemExit(f"KernelAgent manifest mismatch in {run_dir}: {mismatches}")
+
+    _manifest_text(manifest, "kernelagent_display_version")
+    _manifest_text(manifest, "model_display_name")
+    return manifest
+
+
+def _kernelagent_run_dir(args: argparse.Namespace) -> Path:
+    if args.impl in _KERNELAGENT_CLOSED_IMPLS:
+        root_value = args.kernelagent_closed_results_root or os.environ.get(
+            _KERNELAGENT_CLOSED_RESULTS_ROOT_ENV
+        )
+        option = "--kernelagent-closed-results-root"
+        environment_variable = _KERNELAGENT_CLOSED_RESULTS_ROOT_ENV
+    else:
+        root_value = args.kernelagent_results_root or os.environ.get(
+            _KERNELAGENT_RESULTS_ROOT_ENV
+        )
+        option = "--kernelagent-results-root"
+        environment_variable = _KERNELAGENT_RESULTS_ROOT_ENV
+    if not root_value:
+        raise SystemExit(
+            f"KernelAgent results root is required; pass {option} or set "
+            f"{environment_variable}"
+        )
+    variant = "causal" if args.causal else "dense"
+    budget_label = _KERNELAGENT_BUDGET_LABELS[args.impl]
+    return Path(root_value).expanduser().resolve() / (
+        f"{variant}_{args.seq_len}_{budget_label}"
+    )
+
+
+def _benchmark_kernelagent(args: argparse.Namespace) -> dict[str, Any]:
+    impl = str(args.impl)
+    if (
+        args.z != 2
+        or args.h != 32
+        or args.head_dim != 64
+        or args.dtype != "float16"
+        or _uses_bias(args)
+    ):
+        return _skipped_result(
+            impl,
+            args,
+            "KernelAgent artifacts cover only output-only FP16 B=2 H=32 D=64",
+        )
+
+    run_dir = _kernelagent_run_dir(args)
+    source_path = run_dir / "selected_kernel.py"
+    if not source_path.is_file():
+        source_path = run_dir / "selected_kernel.py.txt"
+    manifest_path = run_dir / "manifest.json"
+    if not manifest_path.is_file():
+        raise SystemExit(f"incomplete KernelAgent result directory: {run_dir}")
+
+    manifest = _validate_kernelagent_manifest(
+        impl,
+        json.loads(manifest_path.read_text()),
+        args,
+        run_dir,
+    )
+    budget_label = _KERNELAGENT_BUDGET_LABELS[impl]
+
+    selection_version_info = _kernelagent_version_info(
+        impl, manifest, evaluation_backend_version=None
+    )
+
+    if impl in _KERNELAGENT_CLOSED_IMPLS and manifest.get("status") == "FAIL":
+        reason = str(manifest.get("failure_reason", "KernelAgent campaign failed"))
+        selection_cute_version = str(manifest.get("cutlass_dsl_version", "unknown"))
+        return {
+            "impl": impl,
+            **selection_version_info,
+            "shape": _shape_dict(args),
+            "gpu": _gpu_name(),
+            "physical_gpu": _physical_gpu_selection(),
+            "power_cap_w": getattr(args, "power_cap_w", None),
+            "flop_model": "softmax_attention_forward",
+            "accuracy": "FAIL",
+            "error": reason,
+            "config": {
+                "budget_label": budget_label,
+                "budget_seconds": manifest["budget_seconds"],
+                "elapsed_seconds": manifest["elapsed_seconds"],
+                "selection_cute_version": selection_cute_version,
+                "evaluation_cute_version": None,
+            },
+            "notes": [
+                reason,
+                (
+                    f"Campaign ran with CuTe {selection_cute_version}; no source "
+                    "was selected, so there was no kernel to re-evaluate."
+                ),
+            ],
+        }
+    if not source_path.is_file():
+        raise SystemExit(f"incomplete KernelAgent result directory: {run_dir}")
+
+    source_hash = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    declared_hashes = _declared_kernelagent_source_hashes(manifest)
+    if not declared_hashes:
+        raise SystemExit(
+            f"KernelAgent manifest has no declared source hash in {run_dir}"
+        )
+    hash_mismatches = {
+        field: declared_hash
+        for field, declared_hash in declared_hashes.items()
+        if declared_hash != source_hash
+    }
+    if hash_mismatches:
+        raise SystemExit(
+            f"KernelAgent source hash mismatch in {run_dir}: loaded {source_hash}, "
+            f"manifest declares {hash_mismatches}"
+        )
+    family = "closed" if impl in _KERNELAGENT_CLOSED_IMPLS else "public"
+    module_name = (
+        f"_kernelagent_{family}_{budget_label}_{args.seq_len}_{source_hash[:12]}"
+    )
+    if source_path.suffix == ".txt":
+        loader = importlib.machinery.SourceFileLoader(module_name, str(source_path))
+        spec = importlib.util.spec_from_loader(module_name, loader)
+    else:
+        spec = importlib.util.spec_from_file_location(module_name, source_path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"unable to load KernelAgent kernel: {source_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    with _scrubbed_argv():
+        spec.loader.exec_module(module)
+
+    dtype = _dtype_from_name(args.dtype)
+    q, k, v = _make_inputs(args, dtype)
+    run = cast("Callable[..., torch.Tensor]", module.kernel_function)
+    evaluation_backend_version = _package_version(
+        "nvidia-cutlass-dsl" if impl in _KERNELAGENT_CLOSED_IMPLS else "triton"
+    )
+    version_info = _kernelagent_version_info(
+        impl,
+        manifest,
+        evaluation_backend_version=evaluation_backend_version,
+    )
+
+    def fn() -> torch.Tensor:
+        return run(q, k, v)
+
+    standard_correctness_executed = False
+    repeat_determinism_executed = False
+    stress_correctness_executed = False
+    with _scrubbed_argv():
+        accuracy = "PASS"
+        if not args.skip_correctness:
+            with torch.nn.attention.sdpa_kernel(
+                [torch.nn.attention.SDPBackend.CUDNN_ATTENTION]
+            ):
+                expected = _sdpa_reference(q, k, v, causal=bool(args.causal))
+            standard_correctness_executed = True
+            actual = fn()
+            accuracy = "PASS" if _check_kernelagent_output(actual, expected) else "FAIL"
+            if accuracy == "PASS":
+                repeat_determinism_executed = True
+                repeated = fn()
+                accuracy = (
+                    "PASS"
+                    if _check_kernelagent_output(repeated, expected)
+                    and _check_kernelagent_repeat(actual, repeated)
+                    else "FAIL"
+                )
+            if accuracy == "PASS":
+                stress_correctness_executed = True
+                accuracy = (
+                    "PASS"
+                    if _check_kernelagent_stress_case(run, args, dtype)
+                    else "FAIL"
+                )
+        stats = None
+        if accuracy == "PASS":
+            stats = _bench_steady(
+                fn,
+                num_runs=args.num_runs,
+                warmup_ms=args.warmup_ms,
+                rep_ms=args.rep_ms,
+            )
+
+    selection = manifest.get("selection", {})
+    evaluation_provenance: dict[str, object] = {
+        "standard_correctness_executed": standard_correctness_executed,
+        "repeat_determinism_executed": repeat_determinism_executed,
+        "stress_correctness_executed": stress_correctness_executed,
+    }
+    if impl in _KERNELAGENT_CLOSED_IMPLS:
+        selection_cute_version = str(manifest.get("cutlass_dsl_version", "unknown"))
+        evaluation_cute_version = evaluation_backend_version
+        evaluation_provenance.update(
+            {
+                "selection_cute_version": selection_cute_version,
+                "evaluation_cute_version": evaluation_cute_version,
+            }
+        )
+        selection_name = f"candidate {selection.get('candidate_id', 'unknown')}"
+        internal_time = selection.get("median_ms", "unknown")
+        notes = [
+            (
+                "KernelAgent Closed wall-clock tuning budget "
+                f"{manifest['budget_seconds']:.1f}s ({budget_label}); elapsed "
+                f"{manifest['elapsed_seconds']:.1f}s."
+            ),
+            (
+                f"Selected source sha256 {source_hash}; {selection_name}; "
+                f"internal search time {internal_time} ms."
+            ),
+            _kernelagent_evaluation_note(
+                "CuTe",
+                selection_cute_version,
+                evaluation_cute_version,
+                standard_executed=standard_correctness_executed,
+                repeat_executed=repeat_determinism_executed,
+                stress_executed=stress_correctness_executed,
+                passed=accuracy == "PASS",
+                measured=stats is not None,
+            ),
+        ]
+    else:
+        selection_triton_version = _manifest_text(manifest, "triton_version")
+        evaluation_provenance.update(
+            {
+                "selection_triton_version": selection_triton_version,
+                "evaluation_triton_version": evaluation_backend_version,
+            }
+        )
+        notes = [
+            (
+                f"KernelAgent Public wall-clock tuning budget "
+                f"{manifest['budget_seconds']:.1f}s ({budget_label}); elapsed "
+                f"{manifest['elapsed_seconds']:.1f}s."
+            ),
+            (
+                f"Selected source sha256 {source_hash}; program "
+                f"{selection.get('program_id', 'unknown')}; internal time "
+                f"{selection.get('internal_time_ms', 'unknown')} ms."
+            ),
+            _kernelagent_evaluation_note(
+                "Triton",
+                selection_triton_version,
+                evaluation_backend_version,
+                standard_executed=standard_correctness_executed,
+                repeat_executed=repeat_determinism_executed,
+                stress_executed=stress_correctness_executed,
+                passed=accuracy == "PASS",
+                measured=stats is not None,
+            ),
+        ]
+    result = _result(
+        impl,
+        args,
+        stats,
+        accuracy=accuracy,
+        benchmark_timer="event",
+        config={
+            "budget_label": budget_label,
+            "budget_seconds": manifest["budget_seconds"],
+            "elapsed_seconds": manifest["elapsed_seconds"],
+            "selection": selection,
+            "source_sha256": source_hash,
+            **evaluation_provenance,
+        },
+        notes=notes,
+        version_info=version_info,
+    )
+    if accuracy == "FAIL":
+        if impl in _KERNELAGENT_CLOSED_IMPLS:
+            result["error"] = (
+                "Selected KernelAgent source failed final-harness correctness "
+                f"under CuTe {evaluation_backend_version}."
+            )
+        else:
+            result["error"] = (
+                "Selected KernelAgent source failed final-harness correctness."
+            )
+    return result
 
 
 def _benchmark_flexattention(args: argparse.Namespace) -> dict[str, Any]:
@@ -725,82 +1705,227 @@ def _benchmark_flexattention(args: argparse.Namespace) -> dict[str, Any]:
     q, k, v = _make_inputs(args, dtype)
     bias = _make_bias(args, dtype)
     causal = bool(args.causal)
-    compiled = cast(
-        "Callable[..., torch.Tensor]", torch.compile(flex_attention, fullgraph=True)
-    )
-
-    if causal:
-
-        def causal_mask(
-            b: torch.Tensor,
-            h: torch.Tensor,
-            q_idx: torch.Tensor,
-            kv_idx: torch.Tensor,
-        ) -> torch.Tensor:
-            return q_idx >= kv_idx
-
-        block_mask = create_block_mask(
-            causal_mask,
-            None,
-            None,
-            args.seq_len,
-            args.seq_len,
-            device=q.device,
-            BLOCK_SIZE=128,
+    impl = str(args.impl)
+    backend = _FLEXATTENTION_BACKENDS[impl]
+    with _scrubbed_argv():
+        if backend == "FLASH":
+            _import_fa4()
+        compiled = cast(
+            "Callable[..., torch.Tensor]",
+            torch.compile(flex_attention, fullgraph=True),
         )
-        fn = lambda: compiled(q, k, v, block_mask=block_mask)  # noqa: E731
-    elif bias is not None:
-        bias_tensor = bias
+        kernel_options = {"BACKEND": backend}
 
-        def bias_score_mod(
-            score: torch.Tensor,
-            b: torch.Tensor,
-            h: torch.Tensor,
-            q_idx: torch.Tensor,
-            kv_idx: torch.Tensor,
-        ) -> torch.Tensor:
-            return score + bias_tensor[b, h, q_idx, kv_idx]
+        if causal:
+            compiled_create_block_mask = torch.compile(create_block_mask)
 
-        fn = lambda: compiled(q, k, v, score_mod=bias_score_mod)  # noqa: E731
-    else:
-        fn = lambda: compiled(q, k, v)  # noqa: E731
+            def causal_mask(
+                b: torch.Tensor,
+                h: torch.Tensor,
+                q_idx: torch.Tensor,
+                kv_idx: torch.Tensor,
+            ) -> torch.Tensor:
+                return q_idx >= kv_idx
 
-    accuracy = "PASS"
-    if not args.skip_correctness:
-        expected = _sdpa_reference(q, k, v, causal=causal, bias=bias)
-        out = fn()
-        accuracy = "PASS" if _check_close(out, expected, dtype) else "FAIL"
-    stats = _bench_steady(
-        fn,
-        num_runs=args.num_runs,
-        warmup_ms=args.warmup_ms,
-        rep_ms=args.rep_ms,
-    )
+            # Eager mask creation materializes the full token-level mask before
+            # reducing it to blocks, which is infeasible for the long suite.
+            block_mask = compiled_create_block_mask(
+                causal_mask,
+                None,
+                None,
+                args.seq_len,
+                args.seq_len,
+                device=q.device,
+                BLOCK_SIZE=256 if backend == "FLASH" else 128,
+            )
+            fn = lambda: compiled(  # noqa: E731
+                q, k, v, block_mask=block_mask, kernel_options=kernel_options
+            )
+        elif bias is not None:
+            bias_tensor = bias
+
+            def bias_score_mod(
+                score: torch.Tensor,
+                b: torch.Tensor,
+                h: torch.Tensor,
+                q_idx: torch.Tensor,
+                kv_idx: torch.Tensor,
+            ) -> torch.Tensor:
+                return score + bias_tensor[b, h, q_idx, kv_idx]
+
+            fn = lambda: compiled(  # noqa: E731
+                q,
+                k,
+                v,
+                score_mod=bias_score_mod,
+                kernel_options=kernel_options,
+            )
+        else:
+            fn = lambda: compiled(  # noqa: E731
+                q, k, v, kernel_options=kernel_options
+            )
+
+        accuracy = "PASS"
+        if not args.skip_correctness:
+            expected = _sdpa_reference(q, k, v, causal=causal, bias=bias)
+            out = fn()
+            accuracy = "PASS" if _check_close(out, expected, dtype) else "FAIL"
+        stats = _bench_steady(
+            fn,
+            num_runs=args.num_runs,
+            warmup_ms=args.warmup_ms,
+            rep_ms=args.rep_ms,
+        )
     return _result(
-        "flexattention",
+        impl,
         args,
         stats,
         accuracy=accuracy,
         benchmark_timer="event",
         config=None,
+        notes=[f"Forced PyTorch FlexAttention BACKEND={backend!r}."],
+    )
+
+
+def _import_gluon_attention() -> types.ModuleType:
+    path = _resolve_gluon_attention_path()
+    module_name = "_helion_gluon_attention_forward"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"unable to load Gluon attention example from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    with _scrubbed_argv():
+        spec.loader.exec_module(module)
+    return module
+
+
+def _import_tlx_attention() -> types.ModuleType:
+    configured = os.environ.get(_TLX_ATTENTION_PATH_ENV)
+    if configured:
+        path = _resolve_tlx_attention_path()
+        module_name = "_helion_tlx_blackwell_attention"
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            raise SystemExit(f"unable to load TLX attention example from {path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        with _scrubbed_argv():
+            spec.loader.exec_module(module)
+        return module
+    with _scrubbed_argv():
+        return importlib.import_module(_TLX_ATTENTION_MODULE)
+
+
+def _benchmark_gluon(args: argparse.Namespace) -> dict[str, Any]:
+    if _uses_bias(args):
+        return _skipped_result(
+            "gluon",
+            args,
+            "Gluon attention example does not support additive score bias",
+        )
+
+    module = _import_gluon_attention()
+    dtype = _dtype_from_name(args.dtype)
+    q, k, v = _make_inputs(args, dtype)
+    causal = bool(args.causal)
+    sm_scale = args.head_dim**-0.5
+
+    def run() -> torch.Tensor:
+        out, _lse = module.attention_forward(
+            q, k, v, causal, sm_scale, use_tmem_red=False
+        )
+        return out
+
+    accuracy = "PASS"
+    if not args.skip_correctness:
+        expected = _sdpa_reference(q, k, v, causal=causal)
+        accuracy = "PASS" if _check_close(run(), expected, dtype) else "FAIL"
+    stats = _bench_steady(
+        run,
+        num_runs=args.num_runs,
+        warmup_ms=args.warmup_ms,
+        rep_ms=args.rep_ms,
+    )
+    return _result(
+        "gluon",
+        args,
+        stats,
+        accuracy=accuracy,
+        benchmark_timer="event",
+        notes=[
+            (
+                "The referenced Gluon entry point returns both output and LSE; its "
+                "timing therefore includes the auxiliary LSE write."
+            )
+        ],
+    )
+
+
+def _benchmark_tlx(args: argparse.Namespace) -> dict[str, Any]:
+    if _uses_bias(args):
+        return _skipped_result(
+            "tlx",
+            args,
+            "TLX Blackwell attention does not support additive score bias",
+        )
+
+    module = _import_tlx_attention()
+    dtype = _dtype_from_name(args.dtype)
+    q, k, v = _make_inputs(args, dtype)
+    causal = bool(args.causal)
+    sm_scale = args.head_dim**-0.5
+
+    def run() -> torch.Tensor:
+        return cast("torch.Tensor", module.attention(q, k, v, sm_scale, causal))
+
+    accuracy = "PASS"
+    if not args.skip_correctness:
+        expected = _sdpa_reference(q, k, v, causal=causal)
+        accuracy = "PASS" if _check_close(run(), expected, dtype) else "FAIL"
+    stats = _bench_steady(
+        run,
+        num_runs=args.num_runs,
+        warmup_ms=args.warmup_ms,
+        rep_ms=args.rep_ms,
+    )
+    best_config = getattr(module._attn_fwd_ws, "best_config", None)
+    return _result(
+        "tlx",
+        args,
+        stats,
+        accuracy=accuracy,
+        benchmark_timer="event",
+        config=str(best_config) if best_config is not None else None,
+        notes=[
+            (
+                "Meta TLX Blackwell ws_pipelined_persistent attention used its "
+                "upstream shape-keyed autotuner."
+            ),
+            (
+                "The forward kernel writes FP32 softmax state for backward even "
+                "though the wrapper returns only the attention output; timing "
+                "includes that auxiliary write."
+            ),
+        ],
     )
 
 
 def _import_fa4() -> types.ModuleType:
     """Import FlashAttention-4 (``flash_attn.cute.flash_attn_func``) in this env.
 
-    FA4 v2.8.3 targets the CUDA-12.9 cutlass DSL; Helion's env ships the CUDA-13
-    cutlass 4.5.1 build. The checkout is resolved lazily from HELION_FA4_ROOT, an
-    existing tritonbench submodule, or, when HELION_FA4_AUTO_DOWNLOAD=1, an
-    auto-cloned benchmarks/flash-attention tree. Three things must be adapted to
-    bridge the cutlass skew, and the
-    top-level package must be bypassed:
+    The FA4 checkout and its Quack dependency use CuTe APIs that moved across
+    the 4.5 and 4.6 releases. The checkout is resolved lazily from
+    HELION_FA4_ROOT, an existing tritonbench submodule, or, when
+    HELION_FA4_AUTO_DOWNLOAD=1, an auto-cloned benchmarks/flash-attention tree.
+    The compatibility aliases below bridge that API skew, and the top-level
+    package must be bypassed:
 
     * The top-level ``flash_attn/__init__`` eagerly imports the unbuilt FA2 CUDA
       extension (``flash_attn_2_cuda``); register a bare ``flash_attn`` namespace
       package first so only the independent ``flash_attn.cute`` subpackage loads.
-    * 4.5.1 only re-exports the nvvm enums (``ProxyKind`` etc.) from
-      ``cute.arch`` on the 12.9 wheel -- inject them from ``_mlir.dialects.nvvm``.
+    * Inject missing nvvm enums (``ProxyKind`` etc.) into ``cute.arch`` and
+      expose ``ThrMma`` and ``ThrCopy`` through their former ``cute.core`` path.
     * FA4's primitive wrappers use the old binding ABI: ``nvvm.fmax`` takes an
       explicit result-type first arg (4.5.1 infers it), the packed-f32x2 ops take
       a ``RoundingModeKind`` enum (4.5.1 wants the ``'rn'`` string), and
@@ -814,6 +1939,9 @@ def _import_fa4() -> types.ModuleType:
     import cutlass.cute as cute
 
     fa4_root = _resolve_fa4_root()
+    for sym in ("ThrMma", "ThrCopy"):
+        if not hasattr(cute.core, sym):
+            setattr(cute.core, sym, getattr(cute, sym))
     for sym in (
         "ProxyKind",
         "SharedSpace",
@@ -888,12 +2016,9 @@ def _benchmark_fa4(args: argparse.Namespace) -> dict[str, Any]:
     (the SDPA convention), so we transpose in and out. FA4 returns ``(out, lse)``.
     """
     if _uses_bias(args):
-        return {
-            "impl": "fa4",
-            "shape": _shape_dict(args),
-            "accuracy": "SKIP",
-            "skipped_reason": "FA4 harness does not support additive score bias",
-        }
+        return _skipped_result(
+            "fa4", args, "FA4 harness does not support additive score bias"
+        )
     fc = _import_fa4()
     dtype = _dtype_from_name(args.dtype)
     q, k, v = _make_inputs(args, dtype)
@@ -961,7 +2086,7 @@ def _scrubbed_argv() -> Iterator[None]:
 def _benchmark_helion(args: argparse.Namespace) -> dict[str, Any]:
     """Helion attention via examples/attention.py.
 
-    Backend is determined by ``args.helion_backend`` (cute or triton). The cute
+    Backend is determined by ``args.helion_backend``. The cute
     path may currently be numerically wrong; we never let that crash the
     harness -- we record accuracy=FAIL and still report timing.
 
@@ -1000,11 +2125,28 @@ def _benchmark_helion(args: argparse.Namespace) -> dict[str, Any]:
         kernel = attention
         kernel_args = (q, k, v)
 
+    seed_config_overrides = dict(getattr(args, "helion_seed_config", ()))
+    kernel.settings.autotune_seed_configs = (
+        [seed_config_overrides] if seed_config_overrides else None
+    )
+
     with _scrubbed_argv():
         bound = kernel.bind(kernel_args)
         compiler_seed_config = _compiler_flash_seed_config(bound, backend)
         fixed_config, config_overrides = _make_helion_config(args, compiler_seed_config)
         notes: list[str] = []
+        if backend == "tileir":
+            notes.append(
+                "TileIR ran with "
+                f"TILEIR_ENABLE_APPROX={os.environ.get('TILEIR_ENABLE_APPROX', '')} "
+                f"and TILEIR_ENABLE_FTZ={os.environ.get('TILEIR_ENABLE_FTZ', '')}."
+            )
+            if env_overrides.get("HELION_AUTOTUNE_BENCHMARK_SUBPROCESS") == "0":
+                notes.append(
+                    "TileIR autotune measurements ran in the parent process; "
+                    "spawned benchmark workers cannot inherit the isolated "
+                    "toolchain runtime."
+                )
         if bias is not None and backend == "cute":
             biased_seed_config = cast(
                 "dict[str, object]",
@@ -1056,6 +2198,7 @@ def _benchmark_helion(args: argparse.Namespace) -> dict[str, Any]:
         helion_overrides={
             "env_overrides": env_overrides,
             "config_overrides": config_overrides,
+            "seed_config_overrides": seed_config_overrides,
             "autotuned": autotuned,
             "benchmark_timer": benchmark_timer,
             "force_autotune": bool(args.helion_force_autotune),
@@ -1072,9 +2215,18 @@ def _run_impl(args: argparse.Namespace) -> dict[str, Any]:
     if args.impl == "helion-triton":
         args.helion_backend = "triton"
         return _benchmark_helion(args)
+    if args.impl == "helion-tileir":
+        args.helion_backend = "tileir"
+        return _benchmark_helion(args)
     if args.impl == "sdpa":
         return _benchmark_sdpa(args)
-    if args.impl == "flexattention":
+    if args.impl in _KERNELAGENT_BUDGET_LABELS:
+        return _benchmark_kernelagent(args)
+    if args.impl == "gluon":
+        return _benchmark_gluon(args)
+    if args.impl == "tlx":
+        return _benchmark_tlx(args)
+    if args.impl in _FLEXATTENTION_BACKENDS:
         return _benchmark_flexattention(args)
     if args.impl == "fa4":
         return _benchmark_fa4(args)
@@ -1121,6 +2273,22 @@ def _build_subprocess_cmd(args: argparse.Namespace, impl: str) -> list[str]:
         str(getattr(args, "helion_cute_benchmark_timer", "wall")),
         "--json",
     ]
+    power_cap_w = getattr(args, "power_cap_w", None)
+    if power_cap_w is not None:
+        cmd.extend(["--power-cap-w", str(power_cap_w)])
+    kernelagent_results_root = getattr(args, "kernelagent_results_root", None)
+    if kernelagent_results_root:
+        cmd.extend(["--kernelagent-results-root", str(kernelagent_results_root)])
+    kernelagent_closed_results_root = getattr(
+        args, "kernelagent_closed_results_root", None
+    )
+    if kernelagent_closed_results_root:
+        cmd.extend(
+            [
+                "--kernelagent-closed-results-root",
+                str(kernelagent_closed_results_root),
+            ]
+        )
     cmd.extend(_helion_override_args(args))
     return cmd
 
@@ -1128,6 +2296,18 @@ def _build_subprocess_cmd(args: argparse.Namespace, impl: str) -> list[str]:
 def _run_json_subprocess(
     cmd: list[str], args: argparse.Namespace
 ) -> tuple[int, dict[str, Any] | None, str, str]:
+    env = None
+    impl_index = cmd.index("--impl") if "--impl" in cmd else -1
+    impl = cmd[impl_index + 1] if impl_index >= 0 else None
+    tlx_runtime_root = os.environ.get(_TLX_RUNTIME_ROOT_ENV)
+    if impl == "tlx" and tlx_runtime_root:
+        env = os.environ.copy()
+        current_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            f"{tlx_runtime_root}{os.pathsep}{current_pythonpath}"
+            if current_pythonpath
+            else tlx_runtime_root
+        )
     if args.stream_subprocesses:
         with tempfile.TemporaryDirectory() as tmpdir:
             json_path = Path(tmpdir) / "result.json"
@@ -1135,6 +2315,7 @@ def _run_json_subprocess(
                 [*cmd, "--json-output", str(json_path)],
                 cwd=REPO_ROOT,
                 check=False,
+                env=env,
             )
             if proc.returncode != 0:
                 return proc.returncode, None, "", ""
@@ -1149,6 +2330,7 @@ def _run_json_subprocess(
         check=False,
         capture_output=True,
         text=True,
+        env=env,
     )
     if proc.returncode != 0:
         return proc.returncode, None, proc.stdout, proc.stderr
@@ -1280,7 +2462,9 @@ _MARKDOWN_COLUMNS = (
     "causal",
     "biased",
     "impl",
+    "version",
     "acc",
+    "reason",
     "timer",
     "best_ms",
     "mom_med_ms",
@@ -1309,7 +2493,9 @@ def _markdown_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
                     "causal": shape["causal"],
                     "biased": shape.get("biased", 0),
                     "impl": impl,
+                    "version": r.get("version", ""),
                     "acc": acc,
+                    "reason": r.get("skipped_reason", r.get("error", "")),
                     "timer": r.get("benchmark_timer", ""),
                     "best_ms": "",
                     "mom_med_ms": "",
@@ -1331,7 +2517,9 @@ def _markdown_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
                 "causal": shape["causal"],
                 "biased": shape.get("biased", 0),
                 "impl": impl,
+                "version": r.get("version", ""),
                 "acc": acc,
+                "reason": "",
                 "timer": r.get("benchmark_timer", ""),
                 "best_ms": f"{r['best_ms']:.4f}",
                 "mom_med_ms": f"{mom_ms:.4f}",
@@ -1357,6 +2545,7 @@ def _render_markdown_table(rows: list[dict[str, Any]]) -> str:
 
 def _render_report_notes(payloads: list[dict[str, Any]]) -> str:
     error_rows: list[str] = []
+    skipped_rows: list[str] = []
     fixed_config_rows: list[str] = []
     for payload in payloads:
         shape = payload["shape"]
@@ -1366,6 +2555,12 @@ def _render_report_notes(payloads: list[dict[str, Any]]) -> str:
             impl = result.get("impl", "<unknown>")
             if result.get("accuracy") == "ERROR":
                 error_rows.append(f"- {variant} {shape_str} {impl}")
+                continue
+            if result.get("accuracy") == "SKIP":
+                skipped_rows.append(
+                    f"- {variant} {shape_str} {impl}: "
+                    f"{result.get('skipped_reason', 'unsupported')}"
+                )
                 continue
             helion_overrides = result.get("helion_overrides")
             if (
@@ -1378,6 +2573,11 @@ def _render_report_notes(payloads: list[dict[str, Any]]) -> str:
         sections.append(
             "Rows marked `ERROR` did not produce timing data and are omitted "
             "from the bar graph:\n" + "\n".join(error_rows)
+        )
+    if skipped_rows:
+        sections.append(
+            "Rows marked `SKIP` are not comparable and are omitted from the bar "
+            "graph:\n" + "\n".join(skipped_rows)
         )
     if fixed_config_rows:
         sections.append(
@@ -1392,7 +2592,9 @@ def _render_report_notes(payloads: list[dict[str, Any]]) -> str:
 def _append_csv(path: Path, rows: list[dict[str, Any]]) -> None:
     file_exists = path.exists()
     with path.open("a", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=list(_MARKDOWN_COLUMNS))
+        writer = csv.DictWriter(
+            handle, fieldnames=list(_MARKDOWN_COLUMNS), lineterminator="\n"
+        )
         if not file_exists:
             writer.writeheader()
         writer.writerows(rows)
@@ -1422,12 +2624,27 @@ def _wide_rows(payloads: list[dict[str, Any]]) -> list[dict[str, Any]]:
             "biased": shape.get("biased", 0),
         }
         results_by_impl = {r.get("impl"): r for r in payload["results"]}
+        environment_result = next(
+            (result for result in payload["results"] if result.get("gpu")), {}
+        )
+        row["gpu"] = environment_result.get("gpu", "")
+        row["physical_gpu"] = environment_result.get("physical_gpu", "")
+        row["power_cap_w"] = environment_result.get("power_cap_w", "")
         sdpa_mom = results_by_impl.get("sdpa", {}).get("mom_median_tflops")
         for impl in _DISPLAY_IMPLS:
             key = _IMPL_KEYS[impl]
             result = results_by_impl.get(impl, {})
             row[f"{key}_acc"] = result.get("accuracy", "")
+            row[f"{key}_version"] = result.get("version", "")
+            row[f"{key}_reason"] = result.get("skipped_reason", result.get("error", ""))
+            row[f"{key}_flop_model"] = result.get("flop_model", "")
             row[f"{key}_timer"] = result.get("benchmark_timer", "")
+            notes = result.get("notes")
+            row[f"{key}_notes"] = json.dumps(notes, sort_keys=True) if notes else ""
+            helion_overrides = result.get("helion_overrides")
+            row[f"{key}_helion_overrides"] = (
+                json.dumps(helion_overrides, sort_keys=True) if helion_overrides else ""
+            )
             if "best_ms" not in result:
                 row[f"{key}_best_ms"] = ""
                 row[f"{key}_mom_med_ms"] = ""
@@ -1460,6 +2677,9 @@ def _write_wide_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "dtype",
         "causal",
         "biased",
+        "gpu",
+        "physical_gpu",
+        "power_cap_w",
     )
     impl_columns: list[str] = []
     for impl in _DISPLAY_IMPLS:
@@ -1467,7 +2687,12 @@ def _write_wide_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         impl_columns.extend(
             [
                 f"{key}_acc",
+                f"{key}_version",
+                f"{key}_reason",
+                f"{key}_flop_model",
                 f"{key}_timer",
+                f"{key}_notes",
+                f"{key}_helion_overrides",
                 f"{key}_best_ms",
                 f"{key}_mom_med_ms",
                 f"{key}_best_tflops",
@@ -1476,7 +2701,11 @@ def _write_wide_csv(path: Path, rows: list[dict[str, Any]]) -> None:
             ]
         )
     with path.open("w", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=[*base_columns, *impl_columns])
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[*base_columns, *impl_columns],
+            lineterminator="\n",
+        )
         writer.writeheader()
         writer.writerows(rows)
 
@@ -1495,12 +2724,198 @@ def _format_plot_cell(result: dict[str, Any]) -> str:
 
 def _shape_plot_label(shape: dict[str, Any]) -> str:
     variant = _variant_label(shape)
+    seq_len = int(shape["seq_len"])
+    seq_label = f"{seq_len // 1024}K" if seq_len % 1024 == 0 else str(seq_len)
+    return f"{variant}\n{shape['z']}x{shape['h']}\n{seq_label}x{shape['head_dim']}"
+
+
+def _versioned_impl_label(
+    impl: str,
+    payloads: list[dict[str, Any]],
+    label_overrides: dict[str, str] | None = None,
+) -> str:
+    versions: list[str] = []
+    fallback_versions: list[str] = []
+    for payload in payloads:
+        for result in payload["results"]:
+            if result.get("impl") != impl:
+                continue
+            version = result.get("version_label") or result.get("version")
+            if version and version not in fallback_versions:
+                fallback_versions.append(str(version))
+            if result.get("accuracy") == "PASS" and version and version not in versions:
+                versions.append(str(version))
+    if not versions:
+        versions = fallback_versions
+    impl_label = (
+        label_overrides.get(impl, _IMPL_LABELS[impl])
+        if label_overrides is not None
+        else _IMPL_LABELS[impl]
+    )
+    if not versions:
+        return impl_label
+    return f"{impl_label}\n{' / '.join(versions)}"
+
+
+def _benchmark_setup_label(payloads: list[dict[str, Any]]) -> str:
+    gpu, power_cap_w = _validate_report_environment(payloads)
+    if gpu is None:
+        return "GPU setup not recorded"
+    if power_cap_w is None:
+        return gpu
+    return f"{gpu} | {power_cap_w} W power cap"
+
+
+def _benchmark_dtype_label(payloads: list[dict[str, Any]]) -> str:
+    dtypes = {str(payload["shape"]["dtype"]) for payload in payloads}
+    labels = {
+        "float16": "FP16",
+        "bfloat16": "BF16",
+        "float32": "FP32",
+    }
+    if len(dtypes) == 1:
+        dtype = next(iter(dtypes))
+        return labels.get(dtype, dtype)
+    return "mixed dtypes"
+
+
+def _report_shape_key(shape: object, *, context: str) -> tuple[object, ...]:
+    if not isinstance(shape, dict):
+        raise ValueError(f"{context} has no shape object")
+    required = ("z", "h", "seq_len", "head_dim", "dtype", "causal")
+    missing = [field for field in required if field not in shape]
+    if missing:
+        raise ValueError(f"{context} shape is missing fields {missing}")
     return (
-        f"{variant}\n{shape['z']}x{shape['h']}x{shape['seq_len']}x{shape['head_dim']}"
+        shape["z"],
+        shape["h"],
+        shape["seq_len"],
+        shape["head_dim"],
+        shape["dtype"],
+        int(shape["causal"]),
+        int(shape.get("biased", 0)),
     )
 
 
-def _write_matplotlib_bar_graph(path: Path, payloads: list[dict[str, Any]]) -> None:
+def _validate_report_payloads(payloads: list[dict[str, Any]]) -> None:
+    successful_metadata: dict[tuple[str, str], set[str]] = {}
+    for payload_index, payload in enumerate(payloads):
+        payload_shape = _report_shape_key(
+            payload.get("shape"), context=f"payload {payload_index}"
+        )
+        results = payload.get("results")
+        if not isinstance(results, list):
+            raise ValueError(f"payload {payload_index} has no results list")
+        for result_index, result in enumerate(results):
+            context = f"payload {payload_index} result {result_index}"
+            if not isinstance(result, dict):
+                raise ValueError(f"{context} is not an object")
+            result_shape = _report_shape_key(result.get("shape"), context=context)
+            if result_shape != payload_shape:
+                raise ValueError(
+                    f"{context} shape {result_shape} does not match payload shape "
+                    f"{payload_shape}"
+                )
+            if result.get("accuracy") != "PASS":
+                continue
+            impl = result.get("impl")
+            if not isinstance(impl, str) or not impl:
+                raise ValueError(f"{context} has no implementation name")
+            for field in ("gpu", "physical_gpu"):
+                value = result.get(field)
+                if not isinstance(value, str) or not value:
+                    raise ValueError(f"{context} has no {field} metadata")
+            power_cap_w = result.get("power_cap_w")
+            if (
+                isinstance(power_cap_w, bool)
+                or not isinstance(power_cap_w, (int, float))
+                or not math.isfinite(power_cap_w)
+                or power_cap_w <= 0
+            ):
+                raise ValueError(f"{context} has no power_cap_w metadata")
+            for field in ("version", "benchmark_timer", "flop_model"):
+                value = result.get(field)
+                if value is None or value == "":
+                    raise ValueError(f"{context} has no {field} metadata")
+                successful_metadata.setdefault((impl, field), set()).add(str(value))
+
+    for (impl, field), values in successful_metadata.items():
+        if len(values) > 1:
+            raise ValueError(
+                f"report mixes {field} metadata for {impl}: {sorted(values)}"
+            )
+
+
+def _validate_report_environment(
+    payloads: list[dict[str, Any]],
+) -> tuple[str | None, int | float | None]:
+    _validate_report_payloads(payloads)
+    gpu_names: set[str] = set()
+    power_caps: set[int | float | None] = set()
+    for payload in payloads:
+        physical_gpus: set[str] = set()
+        for result in payload["results"]:
+            gpu = result.get("gpu")
+            if not gpu:
+                continue
+            gpu_names.add(str(gpu))
+            raw_power_cap = result.get("power_cap_w")
+            if raw_power_cap is None:
+                power_caps.add(None)
+            else:
+                power_cap = float(raw_power_cap)
+                power_caps.add(int(power_cap) if power_cap.is_integer() else power_cap)
+            physical_gpu = result.get("physical_gpu")
+            if physical_gpu:
+                physical_gpus.add(str(physical_gpu))
+        if len(physical_gpus) > 1:
+            raise ValueError(
+                "one shape contains results from multiple physical GPU selections: "
+                f"{sorted(physical_gpus)}"
+            )
+    if len(gpu_names) > 1:
+        raise ValueError(f"report mixes GPU models: {sorted(gpu_names)}")
+    if len(power_caps) > 1:
+        raise ValueError(
+            "report mixes GPU power limits: "
+            f"{sorted(str(power_cap) for power_cap in power_caps)}"
+        )
+    gpu = next(iter(gpu_names), None)
+    power_cap_w = next(iter(power_caps), None)
+    return gpu, power_cap_w
+
+
+def _impls_by_average_performance(
+    values_by_impl: dict[str, list[float]],
+) -> list[str]:
+    successful_impls = [
+        impl
+        for impl, values in values_by_impl.items()
+        if any(map(math.isfinite, values))
+    ]
+    return sorted(
+        successful_impls,
+        key=lambda impl: statistics.fmean(
+            value for value in values_by_impl[impl] if math.isfinite(value)
+        ),
+    )
+
+
+def _geomean_performance_by_impl(
+    values_by_impl: dict[str, list[float]],
+) -> dict[str, float]:
+    return {
+        impl: statistics.geometric_mean(values)
+        for impl, values in values_by_impl.items()
+        if values and all(math.isfinite(value) and value > 0.0 for value in values)
+    }
+
+
+def _write_matplotlib_bar_graph(
+    path: Path,
+    payloads: list[dict[str, Any]],
+    label_overrides: dict[str, str] | None = None,
+) -> None:
     import matplotlib  # pyrefly: ignore[missing-import]
 
     matplotlib.use("Agg")
@@ -1520,27 +2935,144 @@ def _write_matplotlib_bar_graph(path: Path, payloads: list[dict[str, Any]]) -> N
             else:
                 values_by_impl[impl].append(np.nan)
 
-    x = np.arange(len(labels))
-    width = 0.15
-    fig_width = max(13.5, 1.45 * len(labels) + 4.0)
-    fig, ax = plt.subplots(figsize=(fig_width, 6.5))
-    for index, impl in enumerate(_DISPLAY_IMPLS):
-        offsets = x + (index - (len(_DISPLAY_IMPLS) - 1) / 2) * width
-        ax.bar(offsets, values_by_impl[impl], width, label=_IMPL_LABELS[impl])
+    plot_impls = _impls_by_average_performance(values_by_impl)
+    if not plot_impls:
+        raise ValueError("no successful benchmark results to plot")
 
-    ax.set_ylabel("TFLOP/s")
-    ax.set_title("TFLOP/s")
+    x = np.arange(len(labels))
+    width = 0.82 / len(plot_impls)
+    fig_width = max(19.0, 1.8 * len(labels) + 7.5)
+    fig, ax = plt.subplots(figsize=(fig_width, 8.2))
+    colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    for index, impl in enumerate(plot_impls):
+        offsets = x + (index - (len(plot_impls) - 1) / 2) * width
+        color = colors[index % len(colors)]
+        ax.bar(
+            offsets,
+            values_by_impl[impl],
+            width,
+            label=_versioned_impl_label(impl, payloads, label_overrides),
+            color=color,
+        )
+        for offset, value in zip(offsets, values_by_impl[impl], strict=True):
+            if not math.isfinite(value):
+                ax.scatter(offset, 0, marker="x", s=20, color=color, clip_on=False)
+                ax.annotate(
+                    "FAIL",
+                    (offset, 0),
+                    xytext=(0, 5),
+                    textcoords="offset points",
+                    ha="center",
+                    va="bottom",
+                    rotation=90,
+                    fontsize=9,
+                    color=color,
+                )
+
+    ax.set_ylabel("Throughput (TFLOP/s)", fontsize=13)
+    ax.set_title(
+        f"Attention forward throughput ({_benchmark_dtype_label(payloads)}) | "
+        f"{_benchmark_setup_label(payloads)}",
+        fontsize=15,
+    )
     ax.set_xticks(x)
-    ax.set_xticklabels(labels, rotation=0, ha="center")
-    ax.legend(ncols=1, loc="upper left")
+    ax.set_xticklabels(labels, rotation=0, ha="center", fontsize=12)
+    ax.tick_params(axis="y", labelsize=12)
+    ax.legend(ncols=1, loc="upper left", bbox_to_anchor=(1.01, 1), fontsize=10)
     ax.grid(axis="y", alpha=0.25)
     ax.set_axisbelow(True)
-    fig.tight_layout()
-    fig.savefig(path, dpi=180)
+    fig.tight_layout(rect=(0, 0, 0.78, 1))
+    fig.savefig(path, dpi=180, bbox_inches="tight")
     plt.close(fig)
 
 
-def _write_matplotlib_table(path: Path, payloads: list[dict[str, Any]]) -> None:
+def _write_matplotlib_geomean_bar_graph(
+    path: Path,
+    payloads: list[dict[str, Any]],
+    label_overrides: dict[str, str] | None = None,
+) -> None:
+    import matplotlib  # pyrefly: ignore[missing-import]
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt  # pyrefly: ignore[missing-import]
+
+    values_by_impl: dict[str, list[float]] = {impl: [] for impl in _DISPLAY_IMPLS}
+    for payload in payloads:
+        results_by_impl = {r.get("impl"): r for r in payload["results"]}
+        for impl in _DISPLAY_IMPLS:
+            result = results_by_impl.get(impl, {})
+            if result.get("accuracy") == "PASS" and "mom_median_tflops" in result:
+                values_by_impl[impl].append(float(result["mom_median_tflops"]))
+            else:
+                values_by_impl[impl].append(math.nan)
+
+    geomean_by_impl = _geomean_performance_by_impl(values_by_impl)
+    if not geomean_by_impl:
+        raise ValueError("no complete successful benchmark series to plot")
+    plot_impls = sorted(
+        _impls_by_average_performance(values_by_impl),
+        key=lambda impl: (
+            impl in geomean_by_impl,
+            geomean_by_impl.get(impl, 0.0),
+        ),
+    )
+
+    color_order = _impls_by_average_performance(values_by_impl)
+    colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    color_by_impl = {
+        impl: colors[index % len(colors)] for index, impl in enumerate(color_order)
+    }
+
+    fig_height = max(8.2, 0.9 * len(plot_impls))
+    fig, ax = plt.subplots(figsize=(18.5, fig_height))
+    bars = ax.barh(
+        range(len(plot_impls)),
+        [geomean_by_impl.get(impl, 0.0) for impl in plot_impls],
+        color=[color_by_impl[impl] for impl in plot_impls],
+    )
+    ax.set_yticks(range(len(plot_impls)))
+    ax.set_yticklabels(
+        [_versioned_impl_label(impl, payloads, label_overrides) for impl in plot_impls],
+        fontsize=11,
+    )
+    value_labels = []
+    for impl in plot_impls:
+        if impl in geomean_by_impl:
+            value_labels.append(f"{geomean_by_impl[impl]:.1f}")
+            continue
+        completed = sum(math.isfinite(value) for value in values_by_impl[impl])
+        value_labels.append(f"INCOMPLETE ({completed}/{len(payloads)})")
+    ax.bar_label(bars, labels=value_labels, padding=4, fontsize=12)
+    for index, impl in enumerate(plot_impls):
+        if impl not in geomean_by_impl:
+            ax.scatter(
+                0,
+                index,
+                marker="x",
+                s=35,
+                color=color_by_impl[impl],
+                clip_on=False,
+            )
+    ax.set_xlim(0, max(geomean_by_impl.values()) * 1.1)
+    ax.tick_params(axis="x", labelsize=12)
+    ax.set_xlabel("Geometric mean throughput (TFLOP/s)", fontsize=13)
+    ax.set_title(
+        f"Attention forward geometric-mean throughput across {len(payloads)} shapes "
+        f"({_benchmark_dtype_label(payloads)}) | {_benchmark_setup_label(payloads)}",
+        fontsize=15,
+    )
+    ax.grid(axis="x", alpha=0.25)
+    ax.set_axisbelow(True)
+    fig.tight_layout()
+    fig.savefig(path, dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _write_matplotlib_table(
+    path: Path,
+    payloads: list[dict[str, Any]],
+    label_overrides: dict[str, str] | None = None,
+) -> None:
     import matplotlib  # pyrefly: ignore[missing-import]
 
     matplotlib.use("Agg")
@@ -1550,7 +3082,10 @@ def _write_matplotlib_table(path: Path, payloads: list[dict[str, Any]]) -> None:
         "Variant",
         "Shape\nzxhxSxD",
         "dtype",
-        *(_IMPL_LABELS[impl] for impl in _DISPLAY_IMPLS),
+        *(
+            _versioned_impl_label(impl, payloads, label_overrides)
+            for impl in _DISPLAY_IMPLS
+        ),
     ]
     cell_text: list[list[str]] = []
     for payload in payloads:
@@ -1588,7 +3123,9 @@ def _write_matplotlib_table(path: Path, payloads: list[dict[str, Any]]) -> None:
         elif row % 2 == 0:
             cell.set_facecolor("#f7f7f7")
     ax.set_title(
-        "Attention backend performance: TFLOP/s (ms)",
+        f"Attention backend performance: TFLOP/s, "
+        f"{_benchmark_dtype_label(payloads)} "
+        f"({_benchmark_setup_label(payloads)})",
         fontsize=12,
         pad=18,
     )
@@ -1640,8 +3177,24 @@ def _run_shape_subprocess(
         str(getattr(args, "helion_cute_benchmark_timer", "wall")),
         "--json",
     ]
+    power_cap_w = getattr(args, "power_cap_w", None)
+    if power_cap_w is not None:
+        cmd.extend(["--power-cap-w", str(power_cap_w)])
     if args.impls:
         cmd.extend(["--impls", *args.impls])
+    kernelagent_results_root = getattr(args, "kernelagent_results_root", None)
+    if kernelagent_results_root:
+        cmd.extend(["--kernelagent-results-root", kernelagent_results_root])
+    kernelagent_closed_results_root = getattr(
+        args, "kernelagent_closed_results_root", None
+    )
+    if kernelagent_closed_results_root:
+        cmd.extend(
+            [
+                "--kernelagent-closed-results-root",
+                kernelagent_closed_results_root,
+            ]
+        )
     if args.stream_subprocesses:
         cmd.append("--stream-subprocesses")
     cmd.extend(_helion_override_args(args))
@@ -1677,6 +3230,7 @@ def _run_shape_subprocess(
 def _write_sweep_outputs(
     args: argparse.Namespace, payloads: list[dict[str, Any]]
 ) -> None:
+    _validate_report_environment(payloads)
     all_rows: list[dict[str, Any]] = []
     for payload in payloads:
         all_rows.extend(_markdown_rows(payload))
@@ -1697,10 +3251,19 @@ def _write_sweep_outputs(
     if args.csv_output:
         _write_wide_csv(Path(args.csv_output), wide_rows)
         print(f"Wrote wide CSV table to {args.csv_output}", file=sys.stderr)
+    label_overrides = dict(args.plot_impl_label)
     if args.plot_output:
-        _write_matplotlib_bar_graph(Path(args.plot_output), payloads)
+        _write_matplotlib_bar_graph(Path(args.plot_output), payloads, label_overrides)
         print(
             f"Wrote matplotlib TFLOP/s bar graph to {args.plot_output}", file=sys.stderr
+        )
+    if args.summary_plot_output:
+        _write_matplotlib_geomean_bar_graph(
+            Path(args.summary_plot_output), payloads, label_overrides
+        )
+        print(
+            f"Wrote matplotlib geomean TFLOP/s bar graph to {args.summary_plot_output}",
+            file=sys.stderr,
         )
 
 
@@ -1755,7 +3318,30 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--warmup-ms", type=int, default=1000)
     parser.add_argument("--rep-ms", type=int, default=500)
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--power-cap-w",
+        type=int,
+        default=None,
+        help="Record the verified GPU power cap in JSON, CSV, and plot titles.",
+    )
     parser.add_argument("--skip-correctness", type=int, choices=(0, 1), default=0)
+    parser.add_argument(
+        "--kernelagent-results-root",
+        default=None,
+        help=(
+            "Root containing shape-specific KernelAgent run directories. "
+            f"Defaults to {_KERNELAGENT_RESULTS_ROOT_ENV}."
+        ),
+    )
+    parser.add_argument(
+        "--kernelagent-closed-results-root",
+        default=None,
+        help=(
+            "Root containing shape-specific KernelAgent Closed run "
+            "directories. Defaults to "
+            f"{_KERNELAGENT_CLOSED_RESULTS_ROOT_ENV}."
+        ),
+    )
     parser.add_argument(
         "--json",
         action="store_true",
@@ -1788,8 +3374,8 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help=(
             "Merge saved per-shape JSON payloads from --impl all into the "
-            "--output/--append-csv/--csv-output/--plot-output reports without "
-            "rerunning benchmarks."
+            "--output/--append-csv/--csv-output/--plot-output/"
+            "--summary-plot-output reports without rerunning benchmarks."
         ),
     )
     parser.add_argument(
@@ -1817,6 +3403,25 @@ def parse_args() -> argparse.Namespace:
         "--plot-output",
         default=None,
         help="(--all-shapes) Write a matplotlib-rendered TFLOP/s bar graph to this file.",
+    )
+    parser.add_argument(
+        "--summary-plot-output",
+        default=None,
+        help=(
+            "(--all-shapes) Write one geometric-mean TFLOP/s bar per complete "
+            "implementation series to this file."
+        ),
+    )
+    parser.add_argument(
+        "--plot-impl-label",
+        action="append",
+        type=_parse_plot_impl_label,
+        default=[],
+        metavar="IMPL=LABEL",
+        help=(
+            "Override an implementation's display label in generated plots. "
+            "Repeat for multiple implementations."
+        ),
     )
     # Internal: backend selector threaded through the helion dispatch.
     parser.add_argument("--helion-backend", default="triton", help=argparse.SUPPRESS)
@@ -1941,6 +3546,17 @@ def parse_args() -> argparse.Namespace:
             "prospective knobs, e.g. --helion-config block_sizes='[1,128,128]'."
         ),
     )
+    parser.add_argument(
+        "--helion-seed-config",
+        action="append",
+        type=_parse_config_override,
+        default=[],
+        metavar="KEY=JSON",
+        help=(
+            "Seed a Helion autotune candidate without fixing the search space. "
+            "Repeat for each helion.Config field."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -1949,6 +3565,9 @@ def main() -> None:
     if args.merge_json:
         _run_merge_json(args)
         return
+
+    _check_gpu_policy()
+    args.power_cap_w = _verify_power_cap_w(args.power_cap_w)
 
     if args.causal and _uses_bias(args):
         raise SystemExit("--biased 1 is not compatible with --causal 1")

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 from types import SimpleNamespace
 
@@ -108,6 +110,7 @@ def _attention_subprocess_args(**overrides):
         warmup_ms=25,
         rep_ms=100,
         seed=123,
+        power_cap_w=750,
         skip_correctness=0,
         helion_force_flash_config=1,
         helion_force_autotune=0,
@@ -122,6 +125,7 @@ def _attention_subprocess_args(**overrides):
         helion_autotune_accuracy_check=None,
         helion_autotuner_initial_population=None,
         helion_config=[],
+        helion_seed_config=[],
         impls=[],
         stream_subprocesses=False,
     )
@@ -257,12 +261,19 @@ def test_attention_compiler_flash_seed_config_skips_nonflash_default():
 
 
 def test_attention_subprocess_forwards_helion_cute_timer():
-    args = _attention_subprocess_args(helion_cute_benchmark_timer="event")
+    args = _attention_subprocess_args(
+        helion_cute_benchmark_timer="event",
+        helion_seed_config=[("block_sizes", [1, 64, 128])],
+    )
 
     cmd = compare_attention_backends._build_subprocess_cmd(args, "helion-cute")
 
     flag_index = cmd.index("--helion-cute-benchmark-timer")
     assert cmd[flag_index + 1] == "event"
+    power_index = cmd.index("--power-cap-w")
+    assert cmd[power_index + 1] == "750"
+    seed_index = cmd.index("--helion-seed-config")
+    assert cmd[seed_index + 1] == "block_sizes=[1, 64, 128]"
 
 
 def test_attention_shape_subprocess_forwards_helion_cute_timer(monkeypatch):
@@ -283,6 +294,8 @@ def test_attention_shape_subprocess_forwards_helion_cute_timer(monkeypatch):
 
     flag_index = seen_cmds[0].index("--helion-cute-benchmark-timer")
     assert seen_cmds[0][flag_index + 1] == "event"
+    power_index = seen_cmds[0].index("--power-cap-w")
+    assert seen_cmds[0][power_index + 1] == "750"
 
 
 def test_attention_helion_cute_timer_selects_bench_fn():
@@ -339,7 +352,7 @@ PipelineTmaUmma.create()
     }
 
 
-def test_attention_markdown_and_wide_csv_include_timer():
+def test_attention_markdown_and_wide_csv_include_timer(tmp_path):
     payload = {
         "shape": {
             "z": 1,
@@ -353,8 +366,16 @@ def test_attention_markdown_and_wide_csv_include_timer():
         "results": [
             {
                 "impl": "helion-cute",
+                "version": "Helion test-version",
+                "version_label": "test-version",
+                "flop_model": "softmax_attention_forward",
+                "gpu": "NVIDIA B200",
+                "physical_gpu": "7",
+                "power_cap_w": 750,
                 "accuracy": "PASS",
                 "benchmark_timer": "event",
+                "notes": ["test note"],
+                "helion_overrides": {"autotuned": True},
                 "best_ms": 0.1,
                 "median_ms": 0.1,
                 "mom_median_ms": 0.1,
@@ -369,7 +390,1351 @@ def test_attention_markdown_and_wide_csv_include_timer():
     wide_rows = compare_attention_backends._wide_rows([payload])
 
     assert markdown_rows[0]["timer"] == "event"
+    assert markdown_rows[0]["version"] == "Helion test-version"
     assert wide_rows[0]["helion_cute_timer"] == "event"
+    assert wide_rows[0]["helion_cute_version"] == "Helion test-version"
+    assert wide_rows[0]["helion_cute_flop_model"] == "softmax_attention_forward"
+    assert json.loads(wide_rows[0]["helion_cute_notes"]) == ["test note"]
+    assert json.loads(wide_rows[0]["helion_cute_helion_overrides"]) == {
+        "autotuned": True
+    }
+    assert wide_rows[0]["gpu"] == "NVIDIA B200"
+    assert wide_rows[0]["physical_gpu"] == "7"
+    assert wide_rows[0]["power_cap_w"] == 750
+
+    csv_path = tmp_path / "attention.csv"
+    compare_attention_backends._write_wide_csv(csv_path, wide_rows)
+    assert b"\r\n" not in csv_path.read_bytes()
+
+
+def test_attention_versioned_plot_label():
+    payloads = [
+        {
+            "results": [
+                {
+                    "impl": "sdpa",
+                    "version": "PyTorch test; cuDNN 9.20.0",
+                    "version_label": "cuDNN 9.20.0",
+                }
+            ]
+        }
+    ]
+
+    assert compare_attention_backends._versioned_impl_label("sdpa", payloads) == (
+        "torch SDPA\ncuDNN 9.20.0"
+    )
+
+
+def test_attention_versioned_plot_label_supports_generic_override():
+    payloads = [
+        {
+            "results": [
+                {
+                    "impl": "kernelagent-1x",
+                    "accuracy": "PASS",
+                    "version_label": "KernelAgent test version",
+                }
+            ]
+        }
+    ]
+
+    assert (
+        compare_attention_backends._versioned_impl_label(
+            "kernelagent-1x",
+            payloads,
+            {"kernelagent-1x": "Archived campaign label ($123 tokens)"},
+        )
+        == "Archived campaign label ($123 tokens)\nKernelAgent test version"
+    )
+
+
+def test_attention_plot_impl_label_parser_is_generic():
+    assert compare_attention_backends._parse_plot_impl_label(
+        "sdpa=Reference implementation"
+    ) == ("sdpa", "Reference implementation")
+
+    with pytest.raises(
+        compare_attention_backends.argparse.ArgumentTypeError,
+        match="unknown implementation",
+    ):
+        compare_attention_backends._parse_plot_impl_label("unknown=label")
+    with pytest.raises(
+        compare_attention_backends.argparse.ArgumentTypeError,
+        match="must not be empty",
+    ):
+        compare_attention_backends._parse_plot_impl_label("sdpa=")
+
+
+@pytest.mark.parametrize(
+    ("impl", "version_label"),
+    [
+        (
+            "kernelagent-1x",
+            "KernelAgent v2+archived / Opus-5.0 / Triton 3.7.0",
+        ),
+        (
+            "kernelagent-closed-1x",
+            "KernelAgent v3-archived / GPT-5.6 / CuTe 4.5.1",
+        ),
+    ],
+)
+def test_attention_kernelagent_plot_uses_archived_version_label(
+    impl, version_label, monkeypatch
+):
+    payloads = [{"results": [{"impl": impl, "version_label": version_label}]}]
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_implementation_version",
+        lambda impl: pytest.fail(f"unexpected live version lookup for {impl}"),
+    )
+
+    assert compare_attention_backends._versioned_impl_label(impl, payloads) == (
+        f"{compare_attention_backends._IMPL_LABELS[impl]}\n{version_label}"
+    )
+
+
+def test_attention_backend_plot_labels_are_consistent():
+    assert compare_attention_backends._IMPL_LABELS["helion-triton"] == (
+        "Helion (backend=Triton)"
+    )
+    assert compare_attention_backends._IMPL_LABELS["helion-cute"] == (
+        "Helion (backend=CuTe)"
+    )
+    assert compare_attention_backends._IMPL_LABELS["helion-tileir"] == (
+        "Helion (backend=TileIR)"
+    )
+    assert compare_attention_backends._IMPL_LABELS["flexattention"] == (
+        "FlexAttention (backend=Triton)"
+    )
+    assert compare_attention_backends._IMPL_LABELS["flexattention-cute"] == (
+        "FlexAttention (backend=CuTe)"
+    )
+    assert compare_attention_backends._IMPL_LABELS["tlx"] == "TLX attention"
+    assert compare_attention_backends._KERNELAGENT_BUDGET_LABELS == {
+        "kernelagent-1x": "1x",
+        "kernelagent-2x": "2x",
+        "kernelagent-10x": "10x",
+        "kernelagent-closed-1x": "1x",
+        "kernelagent-closed-2x": "2x",
+    }
+    assert (
+        "KernelAgent Public"
+        in compare_attention_backends._IMPL_LABELS["kernelagent-1x"]
+    )
+    assert compare_attention_backends._IMPL_LABELS["kernelagent-closed-1x"] == (
+        "KernelAgent Closed (1x Helion tuning time)"
+    )
+    assert compare_attention_backends._IMPL_LABELS["kernelagent-1x"] == (
+        "KernelAgent Public (1x Helion tuning time)"
+    )
+
+
+def test_attention_kernelagent_version_labels_come_from_manifests():
+    public = {
+        "kernelagent_commit": "abcdef0123456789",
+        "kernelagent_display_version": "v2+abcdef01",
+        "model": "claude-opus-next",
+        "model_display_name": "Opus-5.0",
+        "triton_version": "3.7.0+selection",
+    }
+    closed = {
+        "kernelagent_version": "v4-test",
+        "kernelagent_display_version": "v4-test",
+        "model": "gpt-test",
+        "model_display_name": "GPT-5.6",
+        "cutlass_dsl_version": "4.5.1",
+    }
+
+    assert compare_attention_backends._kernelagent_version_info(
+        "kernelagent-1x", public, evaluation_backend_version="3.8.0+evaluation"
+    ) == {
+        "version": (
+            "KernelAgent commit abcdef01; model claude-opus-next; "
+            "Triton 3.8.0+evaluation; selected with Triton 3.7.0+selection"
+        ),
+        "version_label": "KernelAgent v2+abcdef01 / Opus-5.0 / Triton 3.8.0",
+    }
+    assert compare_attention_backends._kernelagent_version_info(
+        "kernelagent-closed-1x", closed, evaluation_backend_version="4.6.1"
+    ) == {
+        "version": (
+            "KernelAgent v4-test; model gpt-test; CuTe 4.6.1; selected with CuTe 4.5.1"
+        ),
+        "version_label": "KernelAgent v4-test / GPT-5.6 / CuTe 4.6.1",
+    }
+
+
+def test_attention_kernelagent_version_without_manifest_is_generic():
+    assert compare_attention_backends._implementation_version("kernelagent-1x") == {
+        "version": "KernelAgent metadata is supplied by the run manifest",
+        "version_label": "run manifest metadata",
+    }
+
+
+def test_attention_kernelagent_manifest_validates_complete_campaign_identity(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        compare_attention_backends, "_physical_gpu_selection", lambda: "7"
+    )
+    args = SimpleNamespace(
+        impl="kernelagent-1x",
+        z=2,
+        h=32,
+        seq_len=32768,
+        head_dim=64,
+        dtype="float16",
+        causal=0,
+        biased=0,
+        power_cap_w=750,
+        seed=123,
+    )
+    manifest = {
+        "budget_label": "1x",
+        "shape": compare_attention_backends._shape_dict(args),
+        "physical_gpu": 7,
+        "power_cap_w": 750,
+        "seed": 123,
+        "kernelagent_display_version": "v2+abcdef01",
+        "model_display_name": "Opus-5.0",
+    }
+
+    assert (
+        compare_attention_backends._validate_kernelagent_manifest(
+            args.impl, manifest, args, tmp_path
+        )
+        is manifest
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    (
+        (
+            "shape",
+            {
+                "z": 2,
+                "h": 32,
+                "seq_len": 32768,
+                "head_dim": 64,
+                "dtype": "float16",
+                "causal": False,
+                "biased": 0,
+            },
+        ),
+        ("physical_gpu", 6),
+        ("power_cap_w", 700),
+        ("seed", 456),
+    ),
+)
+def test_attention_kernelagent_manifest_rejects_campaign_mismatch(
+    tmp_path, monkeypatch, field, bad_value
+):
+    monkeypatch.setattr(
+        compare_attention_backends, "_physical_gpu_selection", lambda: "7"
+    )
+    args = SimpleNamespace(
+        impl="kernelagent-1x",
+        z=2,
+        h=32,
+        seq_len=32768,
+        head_dim=64,
+        dtype="float16",
+        causal=0,
+        biased=0,
+        power_cap_w=750,
+        seed=123,
+    )
+    manifest = {
+        "budget_label": "1x",
+        "shape": compare_attention_backends._shape_dict(args),
+        "physical_gpu": 7,
+        "power_cap_w": 750,
+        "seed": 123,
+        "kernelagent_display_version": "v2+abcdef01",
+        "model_display_name": "Opus-5.0",
+    }
+    manifest[field] = bad_value
+
+    with pytest.raises(SystemExit, match="manifest mismatch"):
+        compare_attention_backends._validate_kernelagent_manifest(
+            args.impl, manifest, args, tmp_path
+        )
+
+
+def test_attention_plot_version_labels_are_concise(tmp_path, monkeypatch):
+    monkeypatch.setenv("HELION_BENCHMARK_HELION_VERSION", "1.4.0.dev38+g016ad645")
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_package_version",
+        lambda package: {
+            "triton": "3.7.0+git88b227e2",
+            "nvidia-cutlass-dsl": "4.5.1",
+        }[package],
+    )
+    monkeypatch.setattr(
+        compare_attention_backends.torch,
+        "__version__",
+        "2.13.0.dev20260506+cu130",
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_resolve_fa4_root", lambda: tmp_path
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_git_describe",
+        lambda root: "fa4-v4.0.0.beta23",
+    )
+
+    assert (
+        compare_attention_backends._implementation_version("helion-triton")[
+            "version_label"
+        ]
+        == "Helion 1.4.0.dev38+g016ad645 / Triton 3.7.0"
+    )
+    assert (
+        compare_attention_backends._implementation_version("helion-cute")[
+            "version_label"
+        ]
+        == "Helion 1.4.0.dev38+g016ad645 / CuTe 4.5.1"
+    )
+    assert (
+        compare_attention_backends._implementation_version(
+            "gluon", resolve_external_sources=False
+        )["version_label"]
+        == "Triton 3.7.0"
+    )
+    assert (
+        compare_attention_backends._implementation_version("flexattention")[
+            "version_label"
+        ]
+        == "PyTorch 2.13.0.dev20260506; Triton 3.7.0"
+    )
+    assert compare_attention_backends._implementation_version("flexattention-cute")[
+        "version_label"
+    ] == ("PyTorch 2.13.0.dev20260506; FA4 fa4-v4.0.0.beta23; CuTe 4.5.1")
+    assert (
+        compare_attention_backends._implementation_version("fa4")["version_label"]
+        == "fa4-v4.0.0.beta23; CuTe 4.5.1"
+    )
+
+
+def test_attention_closed_kernelagent_failure_does_not_require_source(
+    tmp_path, monkeypatch
+):
+    run_dir = tmp_path / "dense_32768_1x"
+    run_dir.mkdir()
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "kernelagent_family": "closed_binary",
+                "kernelagent_version": "v3-20260730",
+                "kernelagent_display_version": "v3-20260730",
+                "model_display_name": "GPT-5.6",
+                "shape": {
+                    "z": 2,
+                    "h": 32,
+                    "seq_len": 32768,
+                    "head_dim": 64,
+                    "dtype": "float16",
+                    "causal": 0,
+                    "biased": 0,
+                },
+                "seq_len": 32768,
+                "causal": False,
+                "physical_gpu": 7,
+                "power_cap_w": 750,
+                "seed": 123,
+                "budget_label": "1x",
+                "budget_seconds": 708.6,
+                "elapsed_seconds": 708.6,
+                "model": "gpt-5.6-sol",
+                "cutlass_dsl_version": "4.5.1",
+                "status": "FAIL",
+                "failure_reason": "No verified candidate.",
+            }
+        )
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_implementation_version",
+        lambda impl: {"version": impl, "version_label": impl},
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_package_version", lambda package: "evaluation"
+    )
+    monkeypatch.setattr(compare_attention_backends, "_gpu_name", lambda: "B200")
+    monkeypatch.setattr(
+        compare_attention_backends, "_physical_gpu_selection", lambda: "7"
+    )
+    args = SimpleNamespace(
+        impl="kernelagent-closed-1x",
+        kernelagent_closed_results_root=str(tmp_path),
+        kernelagent_results_root=None,
+        z=2,
+        h=32,
+        seq_len=32768,
+        head_dim=64,
+        dtype="float16",
+        causal=0,
+        biased=0,
+        power_cap_w=750,
+        seed=123,
+    )
+
+    result = compare_attention_backends._benchmark_kernelagent(args)
+
+    assert result["accuracy"] == "FAIL"
+    assert result["error"] == "No verified candidate."
+    assert result["config"]["selection_cute_version"] == "4.5.1"
+    assert result["config"]["evaluation_cute_version"] is None
+    assert "best_ms" not in result
+
+
+def test_attention_successful_kernelagent_requires_declared_source_hash(
+    tmp_path, monkeypatch
+):
+    run_dir = tmp_path / "dense_32768_1x"
+    run_dir.mkdir()
+    (run_dir / "selected_kernel.py.txt").write_text(
+        "def kernel_function(q, k, v):\n    return q\n"
+    )
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "kernelagent_commit": "abcdef0123456789",
+                "kernelagent_display_version": "v2+abcdef01",
+                "model": "claude-opus-next",
+                "model_display_name": "Opus-5.0",
+                "triton_version": "3.7.0+selection",
+                "shape": {
+                    "z": 2,
+                    "h": 32,
+                    "seq_len": 32768,
+                    "head_dim": 64,
+                    "dtype": "float16",
+                    "causal": 0,
+                    "biased": 0,
+                },
+                "physical_gpu": 7,
+                "power_cap_w": 750,
+                "seed": 123,
+                "budget_label": "1x",
+                "budget_seconds": 1.0,
+                "elapsed_seconds": 1.0,
+            }
+        )
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_physical_gpu_selection", lambda: "7"
+    )
+    args = SimpleNamespace(
+        impl="kernelagent-1x",
+        kernelagent_closed_results_root=None,
+        kernelagent_results_root=str(tmp_path),
+        z=2,
+        h=32,
+        seq_len=32768,
+        head_dim=64,
+        dtype="float16",
+        causal=0,
+        biased=0,
+        power_cap_w=750,
+        seed=123,
+    )
+
+    with pytest.raises(SystemExit, match="no declared source hash"):
+        compare_attention_backends._benchmark_kernelagent(args)
+
+
+def test_attention_kernelagent_rejects_manifest_source_hash_mismatch(
+    tmp_path, monkeypatch
+):
+    run_dir = tmp_path / "dense_32768_1x"
+    run_dir.mkdir()
+    (run_dir / "selected_kernel.py.txt").write_text(
+        "def kernel_function(q, k, v):\n    return q\n"
+    )
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "kernelagent_family": "closed_binary",
+                "kernelagent_version": "v4-test",
+                "kernelagent_display_version": "v4-test",
+                "model_display_name": "GPT-test",
+                "shape": {
+                    "z": 2,
+                    "h": 32,
+                    "seq_len": 32768,
+                    "head_dim": 64,
+                    "dtype": "float16",
+                    "causal": 0,
+                    "biased": 0,
+                },
+                "seq_len": 32768,
+                "causal": False,
+                "physical_gpu": 7,
+                "power_cap_w": 750,
+                "seed": 123,
+                "budget_label": "1x",
+                "budget_seconds": 1.0,
+                "elapsed_seconds": 1.0,
+                "model": "gpt-test",
+                "cutlass_dsl_version": "4.6.1",
+                "selection": {"source_sha256": "0" * 64},
+            }
+        )
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_physical_gpu_selection", lambda: "7"
+    )
+    args = SimpleNamespace(
+        impl="kernelagent-closed-1x",
+        kernelagent_closed_results_root=str(tmp_path),
+        kernelagent_results_root=None,
+        z=2,
+        h=32,
+        seq_len=32768,
+        head_dim=64,
+        dtype="float16",
+        causal=0,
+        biased=0,
+        power_cap_w=750,
+        seed=123,
+    )
+
+    with pytest.raises(SystemExit, match="source hash mismatch"):
+        compare_attention_backends._benchmark_kernelagent(args)
+
+
+def test_attention_public_kernelagent_rejects_invalid_output_contract(
+    tmp_path, monkeypatch
+):
+    run_dir = tmp_path / "dense_32768_1x"
+    run_dir.mkdir()
+    source = "def kernel_function(q, k, v):\n    return None\n"
+    (run_dir / "selected_kernel.py.txt").write_text(source)
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "kernelagent_commit": "abcdef0123456789",
+                "kernelagent_display_version": "v2+abcdef01",
+                "model_display_name": "Opus-test",
+                "shape": {
+                    "z": 2,
+                    "h": 32,
+                    "seq_len": 32768,
+                    "head_dim": 64,
+                    "dtype": "float16",
+                    "causal": 0,
+                    "biased": 0,
+                },
+                "seq_len": 32768,
+                "causal": False,
+                "physical_gpu": 7,
+                "power_cap_w": 750,
+                "seed": 123,
+                "budget_label": "1x",
+                "budget_seconds": 1.0,
+                "elapsed_seconds": 1.0,
+                "model": "claude-opus-next",
+                "triton_version": "3.7.0+selection",
+                "source_sha256": hashlib.sha256(source.encode()).hexdigest(),
+                "selection": {},
+            }
+        )
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_make_inputs", lambda args, dtype: (None,) * 3
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_sdpa_reference",
+        lambda q, k, v, *, causal: "expected",
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_package_version", lambda package: "evaluation"
+    )
+    monkeypatch.setattr(compare_attention_backends, "_gpu_name", lambda: "B200")
+    monkeypatch.setattr(
+        compare_attention_backends, "_physical_gpu_selection", lambda: "7"
+    )
+    args = SimpleNamespace(
+        impl="kernelagent-1x",
+        kernelagent_closed_results_root=None,
+        kernelagent_results_root=str(tmp_path),
+        z=2,
+        h=32,
+        seq_len=32768,
+        head_dim=64,
+        dtype="float16",
+        causal=0,
+        biased=0,
+        power_cap_w=750,
+        skip_correctness=False,
+        num_runs=1,
+        warmup_ms=0,
+        rep_ms=0,
+        seed=123,
+    )
+
+    result = compare_attention_backends._benchmark_kernelagent(args)
+
+    assert result["accuracy"] == "FAIL"
+    assert result["error"] == (
+        "Selected KernelAgent source failed final-harness correctness."
+    )
+    assert "best_ms" not in result
+    assert "abcdef01" in result["version"]
+
+
+@pytest.mark.parametrize("stress_passes", (True, False))
+def test_attention_kernelagent_execution_scrubs_cli_argv(
+    tmp_path, monkeypatch, stress_passes
+):
+    run_dir = tmp_path / "causal_65536_1x"
+    run_dir.mkdir()
+    source = "import sys\ndef kernel_function(q, k, v):\n    return tuple(sys.argv)\n"
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "kernelagent_family": "closed_binary",
+                "kernelagent_version": "v3-20260730",
+                "kernelagent_display_version": "v3-20260730",
+                "model_display_name": "GPT-5.6",
+                "shape": {
+                    "z": 2,
+                    "h": 32,
+                    "seq_len": 65536,
+                    "head_dim": 64,
+                    "dtype": "float16",
+                    "causal": 1,
+                    "biased": 0,
+                },
+                "seq_len": 65536,
+                "causal": True,
+                "physical_gpu": 6,
+                "power_cap_w": 750,
+                "seed": 123,
+                "budget_label": "1x",
+                "budget_seconds": 3732.2,
+                "elapsed_seconds": 3732.2,
+                "model": "gpt-5.6-sol",
+                "cutlass_dsl_version": "4.5.1",
+                "status": "PASS",
+                "selection": {
+                    "candidate_id": 1,
+                    "median_ms": 1.0,
+                    "source_sha256": hashlib.sha256(source.encode()).hexdigest(),
+                },
+            }
+        )
+    )
+    (run_dir / "selected_kernel.py.txt").write_text(source)
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_implementation_version",
+        lambda impl: {"version": impl, "version_label": impl},
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_package_version", lambda package: "evaluation"
+    )
+    monkeypatch.setattr(compare_attention_backends, "_gpu_name", lambda: "B200")
+    monkeypatch.setattr(
+        compare_attention_backends, "_physical_gpu_selection", lambda: "6"
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_make_inputs", lambda args, dtype: (None,) * 3
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_sdpa_reference",
+        lambda q, k, v, *, causal: "expected",
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_check_kernelagent_output",
+        lambda actual, expected: True,
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_check_kernelagent_repeat",
+        lambda first, repeated: True,
+    )
+    stress_checks = []
+
+    def check_stress(run, args, dtype):
+        assert compare_attention_backends.sys.argv == ["attention-benchmark"]
+        stress_checks.append((run, args, dtype))
+        return stress_passes
+
+    monkeypatch.setattr(
+        compare_attention_backends, "_check_kernelagent_stress_case", check_stress
+    )
+
+    benchmark_calls = []
+
+    def bench(fn, **kwargs):
+        benchmark_calls.append((fn, kwargs))
+        assert fn() == ("attention-benchmark",)
+        return {
+            "best_ms": 1.0,
+            "median_ms": 1.0,
+            "mean_ms": 1.0,
+            "std_ms": 0.0,
+            "runs_ms": [1.0],
+        }
+
+    monkeypatch.setattr(compare_attention_backends, "_bench_steady", bench)
+    monkeypatch.setattr(
+        compare_attention_backends.sys,
+        "argv",
+        ["attention-benchmark", "--h", "32"],
+    )
+    args = SimpleNamespace(
+        impl="kernelagent-closed-1x",
+        kernelagent_closed_results_root=str(tmp_path),
+        kernelagent_results_root=None,
+        z=2,
+        h=32,
+        seq_len=65536,
+        head_dim=64,
+        dtype="float16",
+        causal=1,
+        biased=0,
+        power_cap_w=750,
+        skip_correctness=False,
+        num_runs=1,
+        warmup_ms=0,
+        rep_ms=0,
+        seed=123,
+    )
+
+    result = compare_attention_backends._benchmark_kernelagent(args)
+
+    assert result["accuracy"] == ("PASS" if stress_passes else "FAIL")
+    assert result["config"]["selection_cute_version"] == "4.5.1"
+    assert result["config"]["evaluation_cute_version"] == "evaluation"
+    assert result["config"]["standard_correctness_executed"] is True
+    assert result["config"]["repeat_determinism_executed"] is True
+    assert result["config"]["stress_correctness_executed"] is True
+    assert len(stress_checks) == 1
+    assert len(benchmark_calls) == int(stress_passes)
+    assert ("best_ms" in result) is stress_passes
+    assert compare_attention_backends.sys.argv == [
+        "attention-benchmark",
+        "--h",
+        "32",
+    ]
+
+
+def test_attention_public_kernelagent_runs_repeat_and_stress_checks(
+    tmp_path, monkeypatch
+):
+    run_dir = tmp_path / "dense_32768_1x"
+    run_dir.mkdir()
+    source = "def kernel_function(q, k, v):\n    return 'output'\n"
+    source_hash = hashlib.sha256(source.encode()).hexdigest()
+    (run_dir / "selected_kernel.py.txt").write_text(source)
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "kernelagent_commit": "abcdef0123456789",
+                "kernelagent_display_version": "v2+abcdef01",
+                "model": "claude-opus-next",
+                "model_display_name": "Opus-5.0",
+                "triton_version": "3.7.0+selection",
+                "shape": {
+                    "z": 2,
+                    "h": 32,
+                    "seq_len": 32768,
+                    "head_dim": 64,
+                    "dtype": "float16",
+                    "causal": 0,
+                    "biased": 0,
+                },
+                "physical_gpu": 7,
+                "power_cap_w": 750,
+                "seed": 123,
+                "budget_label": "1x",
+                "budget_seconds": 1.0,
+                "elapsed_seconds": 1.0,
+                "source_sha256": source_hash,
+                "selection": {},
+            }
+        )
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_physical_gpu_selection", lambda: "7"
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_make_inputs", lambda args, dtype: (None,) * 3
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_sdpa_reference",
+        lambda q, k, v, *, causal: "expected",
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_check_kernelagent_output",
+        lambda actual, expected: True,
+    )
+    repeat_calls = []
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_check_kernelagent_repeat",
+        lambda first, repeated: repeat_calls.append((first, repeated)) or True,
+    )
+    stress_calls = []
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_check_kernelagent_stress_case",
+        lambda run, args, dtype: stress_calls.append((run, args, dtype)) or True,
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_bench_steady",
+        lambda fn, **kwargs: {
+            "best_ms": 1.0,
+            "median_ms": 1.0,
+            "mean_ms": 1.0,
+            "std_ms": 0.0,
+            "runs_ms": [1.0],
+        },
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_package_version", lambda package: "evaluation"
+    )
+    monkeypatch.setattr(compare_attention_backends, "_gpu_name", lambda: "B200")
+    args = SimpleNamespace(
+        impl="kernelagent-1x",
+        kernelagent_closed_results_root=None,
+        kernelagent_results_root=str(tmp_path),
+        z=2,
+        h=32,
+        seq_len=32768,
+        head_dim=64,
+        dtype="float16",
+        causal=0,
+        biased=0,
+        power_cap_w=750,
+        seed=123,
+        skip_correctness=False,
+        num_runs=1,
+        warmup_ms=0,
+        rep_ms=0,
+    )
+
+    result = compare_attention_backends._benchmark_kernelagent(args)
+
+    assert result["accuracy"] == "PASS"
+    assert len(repeat_calls) == 1
+    assert len(stress_calls) == 1
+    assert result["config"]["repeat_determinism_executed"] is True
+    assert result["config"]["stress_correctness_executed"] is True
+    assert result["config"]["selection_triton_version"] == "3.7.0+selection"
+
+
+def test_attention_kernelagent_evaluation_notes_match_executed_checks():
+    note = compare_attention_backends._kernelagent_evaluation_note
+
+    assert "correctness checks were skipped" in note(
+        "CuTe",
+        "4.5.1",
+        "4.6.1",
+        standard_executed=False,
+        repeat_executed=False,
+        stress_executed=False,
+        passed=False,
+        measured=True,
+    )
+    assert "repeat and stress were not run" in note(
+        "CuTe",
+        "4.5.1",
+        "4.6.1",
+        standard_executed=True,
+        repeat_executed=False,
+        stress_executed=False,
+        passed=False,
+        measured=False,
+    )
+    assert "exact repeatability failed" in note(
+        "CuTe",
+        "4.5.1",
+        "4.6.1",
+        standard_executed=True,
+        repeat_executed=True,
+        stress_executed=False,
+        passed=False,
+        measured=False,
+    )
+    assert "stress failed" in note(
+        "CuTe",
+        "4.5.1",
+        "4.6.1",
+        standard_executed=True,
+        repeat_executed=True,
+        stress_executed=True,
+        passed=False,
+        measured=False,
+    )
+    assert "exact repeatability" in note(
+        "CuTe",
+        "4.5.1",
+        "4.6.1",
+        standard_executed=True,
+        repeat_executed=True,
+        stress_executed=True,
+        passed=True,
+        measured=True,
+    )
+
+
+def test_attention_kernelagent_output_contract_rejects_non_cuda_outputs():
+    expected = torch.empty((1, 1, 2, 2), dtype=torch.float16)
+
+    assert not compare_attention_backends._check_kernelagent_output(None, expected)
+    assert not compare_attention_backends._check_kernelagent_output(expected, expected)
+
+
+def test_attention_tileir_version_includes_each_toolchain_component(monkeypatch):
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_git_describe",
+        lambda root: "v1.4.0-38-g016ad645",
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_package_version",
+        lambda package: {"triton": "3.6.0", "nvtriton": "3.6.0"}[package],
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_tileir_toolchain_version", lambda: "13.3"
+    )
+
+    version = compare_attention_backends._implementation_version("helion-tileir")
+
+    assert version == {
+        "version": ("Helion 1.4.0.dev38+g016ad645; nvtriton 3.6.0; TileIR 13.3"),
+        "version_label": (
+            "Helion 1.4.0.dev38+g016ad645 / nvtriton 3.6.0 / TileIR 13.3"
+        ),
+    }
+
+
+def test_attention_helion_version_can_be_supplied_for_isolated_runtime(monkeypatch):
+    monkeypatch.setenv("HELION_BENCHMARK_HELION_VERSION", "1.4.0.dev38+g016ad645")
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_package_version",
+        lambda package: {"triton": "3.6.0", "nvtriton": "3.6.0"}[package],
+    )
+    monkeypatch.setattr(
+        compare_attention_backends, "_tileir_toolchain_version", lambda: "13.3"
+    )
+
+    version = compare_attention_backends._implementation_version("helion-tileir")
+
+    assert version["version"].startswith("Helion 1.4.0.dev38+g016ad645;")
+
+
+@pytest.mark.parametrize(
+    ("git_describe", "expected"),
+    (
+        ("v1.4.0-38-g016ad645", "1.4.0.dev38+g016ad645"),
+        ("v1.4.0", "1.4.0"),
+        ("016ad645", "016ad645"),
+        ("v1.4.0-38-g016ad645-dirty", "1.4.0.dev38+g016ad645.dirty"),
+        ("v1.4.0-dirty", "1.4.0+dirty"),
+    ),
+)
+def test_attention_helion_git_version_is_explicitly_development(
+    git_describe: str, expected: str
+):
+    assert (
+        compare_attention_backends._format_git_development_version(git_describe)
+        == expected
+    )
+
+
+def test_attention_git_version_marks_dirty_worktrees(tmp_path, monkeypatch):
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(stdout="v1.4.0-1-gabcdef01-dirty\n")
+
+    monkeypatch.setattr(compare_attention_backends.subprocess, "run", run)
+
+    assert compare_attention_backends._git_describe(tmp_path) == (
+        "v1.4.0-1-gabcdef01-dirty"
+    )
+    assert calls[0][0][-1] == "--dirty"
+
+
+def test_attention_power_cap_is_verified(monkeypatch):
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(stdout="750.00\n")
+
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "6")
+    monkeypatch.setattr(compare_attention_backends.subprocess, "run", run)
+
+    assert compare_attention_backends._verify_power_cap_w(750) == 750
+    assert calls[0][0][1:3] == ["-i", "6"]
+    assert calls[0][1] == {
+        "check": True,
+        "capture_output": True,
+        "text": True,
+    }
+
+
+def test_attention_power_cap_mismatch_is_rejected(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "7")
+    monkeypatch.setattr(
+        compare_attention_backends.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="850.00\n"),
+    )
+
+    with pytest.raises(SystemExit, match="requested benchmark label is 750 W"):
+        compare_attention_backends._verify_power_cap_w(750)
+
+
+def test_attention_report_rejects_mixed_power_caps():
+    shape = {
+        "z": 2,
+        "h": 32,
+        "seq_len": 65536,
+        "head_dim": 64,
+        "dtype": "float16",
+        "causal": 1,
+        "biased": 0,
+    }
+    payloads = [
+        {
+            "shape": shape,
+            "results": [
+                {
+                    "impl": "sdpa",
+                    "shape": shape,
+                    "accuracy": "FAIL",
+                    "gpu": "NVIDIA B200",
+                    "physical_gpu": str(6 + index),
+                    "power_cap_w": power_cap_w,
+                }
+            ],
+        }
+        for index, power_cap_w in enumerate((750, 850))
+    ]
+
+    with pytest.raises(ValueError, match="mixes GPU power limits"):
+        compare_attention_backends._benchmark_setup_label(payloads)
+
+
+def test_attention_report_rejects_mismatched_result_shape():
+    shape = {
+        "z": 2,
+        "h": 32,
+        "seq_len": 65536,
+        "head_dim": 64,
+        "dtype": "float16",
+        "causal": 1,
+        "biased": 0,
+    }
+    result_shape = {**shape, "seq_len": 131072}
+    payloads = [
+        {
+            "shape": shape,
+            "results": [
+                {
+                    "impl": "sdpa",
+                    "shape": result_shape,
+                    "accuracy": "PASS",
+                }
+            ],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="does not match payload shape"):
+        compare_attention_backends._validate_report_payloads(payloads)
+
+
+@pytest.mark.parametrize("field", ("version", "benchmark_timer", "flop_model"))
+def test_attention_report_rejects_mixed_successful_metadata(field):
+    shape = {
+        "z": 2,
+        "h": 32,
+        "seq_len": 65536,
+        "head_dim": 64,
+        "dtype": "float16",
+        "causal": 1,
+        "biased": 0,
+    }
+    payloads = []
+    for value in ("first", "second"):
+        result = {
+            "impl": "helion-cute",
+            "shape": shape,
+            "accuracy": "PASS",
+            "version": "same-version",
+            "benchmark_timer": "event",
+            "flop_model": "softmax_attention_forward",
+            "gpu": "NVIDIA B200",
+            "physical_gpu": "6",
+            "power_cap_w": 750,
+        }
+        result[field] = value
+        payloads.append({"shape": shape, "results": [result]})
+
+    with pytest.raises(ValueError, match=f"mixes {field} metadata"):
+        compare_attention_backends._validate_report_payloads(payloads)
+
+
+@pytest.mark.parametrize("field", ("version", "benchmark_timer", "flop_model"))
+def test_attention_report_requires_successful_metadata(field):
+    shape = {
+        "z": 2,
+        "h": 32,
+        "seq_len": 65536,
+        "head_dim": 64,
+        "dtype": "float16",
+        "causal": 1,
+        "biased": 0,
+    }
+    result = {
+        "impl": "helion-cute",
+        "shape": shape,
+        "accuracy": "PASS",
+        "version": "1.4.0.dev1+gabcdef01",
+        "benchmark_timer": "event",
+        "flop_model": "softmax_attention_forward",
+        "gpu": "NVIDIA B200",
+        "physical_gpu": "6",
+        "power_cap_w": 750,
+    }
+    del result[field]
+
+    with pytest.raises(ValueError, match=f"has no {field} metadata"):
+        compare_attention_backends._validate_report_payloads(
+            [{"shape": shape, "results": [result]}]
+        )
+
+
+@pytest.mark.parametrize("field", ("gpu", "physical_gpu", "power_cap_w"))
+def test_attention_report_requires_successful_environment_metadata(field):
+    shape = {
+        "z": 2,
+        "h": 32,
+        "seq_len": 65536,
+        "head_dim": 64,
+        "dtype": "float16",
+        "causal": 1,
+        "biased": 0,
+    }
+    result = {
+        "impl": "helion-cute",
+        "shape": shape,
+        "accuracy": "PASS",
+        "version": "1.4.0.dev1+gabcdef01",
+        "benchmark_timer": "event",
+        "flop_model": "softmax_attention_forward",
+        "gpu": "NVIDIA B200",
+        "physical_gpu": "6",
+        "power_cap_w": 750,
+    }
+    del result[field]
+
+    with pytest.raises(ValueError, match=f"has no {field} metadata"):
+        compare_attention_backends._validate_report_payloads(
+            [{"shape": shape, "results": [result]}]
+        )
+
+
+def test_attention_gluon_path_uses_explicit_file(tmp_path, monkeypatch):
+    source = tmp_path / "attention_forward.py"
+    source.write_text("# test\n")
+    monkeypatch.setenv("HELION_GLUON_ATTENTION_PATH", str(source))
+
+    assert compare_attention_backends._resolve_gluon_attention_path() == source
+
+
+def test_attention_tlx_path_uses_isolated_runtime(tmp_path, monkeypatch):
+    source = (
+        tmp_path
+        / "triton"
+        / "language"
+        / "extra"
+        / "tlx"
+        / "tutorials"
+        / "blackwell_fa_ws_pipelined_persistent.py"
+    )
+    source.parent.mkdir(parents=True)
+    source.write_text("# test\n")
+    monkeypatch.setenv("HELION_TLX_RUNTIME_ROOT", str(tmp_path))
+
+    assert compare_attention_backends._resolve_tlx_attention_path() == source
+
+
+def test_attention_tlx_version_identifies_meta_triton(tmp_path, monkeypatch):
+    source = tmp_path / "attention.py"
+    source.write_text("# test\n")
+    monkeypatch.setenv("HELION_BENCHMARK_HELION_VERSION", "test")
+    monkeypatch.setenv("HELION_TLX_ATTENTION_PATH", str(source))
+    monkeypatch.setenv("HELION_TLX_REVISION", "abc123")
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_package_version",
+        lambda package: "3.7.4",
+    )
+    monkeypatch.setattr(
+        compare_attention_backends.importlib,
+        "import_module",
+        lambda module: SimpleNamespace(__version__="3.7.4+fb"),
+    )
+
+    version = compare_attention_backends._implementation_version("tlx")
+
+    assert version["version_label"] == "Meta Triton 3.7.4+fb"
+    assert version["version"].startswith(
+        "Meta Triton 3.7.4+fb; integrated TLX; package 3.7.4; revision abc123;"
+    )
+
+
+def test_attention_tlx_subprocess_uses_isolated_runtime(tmp_path, monkeypatch):
+    seen_env = None
+
+    def run(cmd, **kwargs):
+        nonlocal seen_env
+        seen_env = kwargs["env"]
+        return SimpleNamespace(returncode=0, stdout='{"impl": "tlx"}\n', stderr="")
+
+    monkeypatch.setenv("HELION_TLX_RUNTIME_ROOT", str(tmp_path))
+    monkeypatch.setenv("PYTHONPATH", "existing-pythonpath")
+    monkeypatch.setattr(compare_attention_backends.subprocess, "run", run)
+    args = SimpleNamespace(stream_subprocesses=False)
+
+    returncode, payload, _, _ = compare_attention_backends._run_json_subprocess(
+        ["python", "benchmark.py", "--impl", "tlx"], args
+    )
+
+    assert returncode == 0
+    assert payload == {"impl": "tlx"}
+    assert seen_env is not None
+    assert seen_env["PYTHONPATH"] == f"{tmp_path}:existing-pythonpath"
+
+
+@pytest.mark.parametrize("impl", ("fa4", "gluon", "tlx"))
+def test_attention_skipped_optional_impl_does_not_resolve_source(monkeypatch, impl):
+    def unexpected_resolve():
+        pytest.fail("skipped implementation resolved its optional source tree")
+
+    monkeypatch.setattr(
+        compare_attention_backends, "_resolve_fa4_root", unexpected_resolve
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_resolve_gluon_attention_path",
+        unexpected_resolve,
+    )
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_resolve_tlx_attention_path",
+        unexpected_resolve,
+    )
+    args = _attention_subprocess_args(impl=impl, biased=1)
+
+    result = getattr(compare_attention_backends, f"_benchmark_{impl}")(args)
+
+    assert result["accuracy"] == "SKIP"
+    assert "implementation skipped" in result["version"]
+
+
+def test_attention_flexattention_backends_are_explicit():
+    assert compare_attention_backends._FLEXATTENTION_BACKENDS == {
+        "flexattention": "TRITON",
+        "flexattention-cute": "FLASH",
+    }
+
+
+def test_attention_plot_version_labels_ignore_failed_results():
+    payloads = [
+        {
+            "results": [
+                {
+                    "impl": "kernelagent-closed-1x",
+                    "accuracy": "FAIL",
+                    "version_label": "CuTe 4.5.1",
+                },
+                {
+                    "impl": "kernelagent-closed-1x",
+                    "accuracy": "PASS",
+                    "version_label": "CuTe 4.6.1",
+                },
+            ]
+        }
+    ]
+
+    assert compare_attention_backends._versioned_impl_label(
+        "kernelagent-closed-1x", payloads
+    ).endswith("\nCuTe 4.6.1")
+
+
+def test_attention_plot_impls_are_ordered_by_increasing_average():
+    values = {
+        "fast": [8.0, 10.0],
+        "partial": [float("nan"), 5.0],
+        "slow": [1.0, 3.0],
+        "missing": [float("nan"), float("nan")],
+    }
+
+    assert compare_attention_backends._impls_by_average_performance(values) == [
+        "slow",
+        "partial",
+        "fast",
+    ]
+
+
+def test_attention_plot_geomean_requires_a_complete_positive_series():
+    values = {
+        "complete": [4.0, 16.0],
+        "partial": [float("nan"), 5.0],
+        "invalid": [1.0, 0.0],
+        "missing": [],
+    }
+
+    assert compare_attention_backends._geomean_performance_by_impl(values) == {
+        "complete": pytest.approx(8.0)
+    }
+
+
+def test_attention_plot_shape_label_compacts_sequence_length():
+    shape = {
+        "z": 2,
+        "h": 32,
+        "seq_len": 131072,
+        "head_dim": 64,
+        "causal": 1,
+    }
+    assert (
+        compare_attention_backends._shape_plot_label(shape) == "causal\n2x32\n128Kx64"
+    )
+
+    shape["seq_len"] = 1536
+    assert (
+        compare_attention_backends._shape_plot_label(shape) == "causal\n2x32\n1536x64"
+    )
+
+
+def test_attention_plot_dtype_label():
+    payloads = [{"shape": {"dtype": "float16"}}]
+    assert compare_attention_backends._benchmark_dtype_label(payloads) == "FP16"
+
+    payloads.append({"shape": {"dtype": "bfloat16"}})
+    assert compare_attention_backends._benchmark_dtype_label(payloads) == "mixed dtypes"
 
 
 def test_attention_dense_causal8_suite_uses_larger_shapes():


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3344
 * #3343
 * #3342
 * #3341


--- --- ---

[benchmark] Extend attention backend comparison

Add reproducible attention baselines for Helion backends, FlexAttention, FA4, Gluon, TLX, SDPA, and public and closed KernelAgent outputs.

Record implementation metadata, enforce GPU and power-cap provenance, support paired CuTe measurements, and generate ordered per-shape and geomean plots from explicit result roots.