### PR TITLE
(bugfix) unify asserted shape symbols

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -267,9 +267,7 @@ class DeviceFunction:
         self._constexpr_host_defs: set[str] = set()
         self._scratch_args: list[ScratchArg] = []
         self.wrapper_only_params: list[str] = []
-        self._tensor_properties: dict[
-            tuple[type[TensorPropertyArg], torch.Tensor, int], TensorPropertyArg
-        ] = {}
+        self._tensor_properties: dict[tuple[object, ...], TensorPropertyArg] = {}
         self._unique_counter: dict[str, itertools.count[int]] = defaultdict(
             itertools.count
         )
@@ -793,8 +791,14 @@ class DeviceFunction:
         dim: int,
         prefix: str,
     ) -> _P:
-        # TODO(jansel): dedupe based on sympy expressions
-        key = (prop_cls, fake_value, dim)
+        key: tuple[object, ...] = (prop_cls, fake_value, dim)
+        if prop_cls is TensorSizeArg:
+            size = fake_value.size(dim)
+            assert isinstance(size, torch.SymInt)
+            key = (
+                prop_cls,
+                CompileEnvironment.current().shape_env.replace(size._sympy_()),
+            )
         if key not in self._tensor_properties:
             arg = self.tensor_arg(fake_value)
             prop = prop_cls(f"{arg.name}_{prefix}_{dim}", arg, dim)

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -5,6 +5,7 @@ import builtins
 import contextlib
 import dataclasses
 import functools
+import itertools
 import types
 from typing import TYPE_CHECKING
 from typing import NoReturn
@@ -687,7 +688,35 @@ class TypePropagation(ast.NodeVisitor):
                 comparators[i],
             )
             result = self._bool_op(ast.And(), result, new_result)
+        active_nodes = ExtendedAST.current()
+        if (
+            self.device_loop_count == 0
+            and len(active_nodes) == 2
+            and isinstance(active_nodes[0], ast.Assert)
+            and all(isinstance(op, ast.Eq) for op in node.ops)
+        ):
+            for left, right in itertools.pairwise(comparators):
+                self.constrain_assert_equal(left, right)
         return result
+
+    def constrain_assert_equal(self, left: TypeInfo, right: TypeInfo) -> None:
+        if isinstance(left, SymIntType) and isinstance(right, SymIntType):
+            left_symbol = left.to_sympy()
+            right_symbol = right.to_sympy()
+            env = CompileEnvironment.current()
+            if (
+                left_symbol.is_Symbol
+                and right_symbol.is_Symbol
+                and env.shape_env.replace(left_symbol)
+                != env.shape_env.replace(right_symbol)
+            ):
+                env.shape_env._constrain_unify(left.value, right.value)
+        elif isinstance(left, SequenceType) and isinstance(right, SequenceType):
+            if len(left.element_types) == len(right.element_types):
+                for left_element, right_element in zip(
+                    left.unpack(), right.unpack(), strict=True
+                ):
+                    self.constrain_assert_equal(left_element, right_element)
 
     def visit_Call(self, node: ast.Call) -> TypeInfo:
         func = self.visit(node.func)

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -690,9 +690,12 @@ class TypePropagation(ast.NodeVisitor):
             result = self._bool_op(ast.And(), result, new_result)
         active_nodes = ExtendedAST.current()
         if (
+            # Only the asserted test itself, at function scope and before the
+            # first kernel launch, is guaranteed to dominate that launch.
             self.device_loop_count == 0
             and len(active_nodes) == 2
             and isinstance(active_nodes[0], ast.Assert)
+            and active_nodes[0].test is node
             and all(isinstance(op, ast.Eq) for op in node.ops)
         ):
             for left, right in itertools.pairwise(comparators):

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -596,7 +596,11 @@ class TestMisc(RefEagerTestBase, TestCase):
         code, result = code_and_output(kernel, (a, b))
         torch.testing.assert_close(result, a + b + sum(b.shape))
 
-        if not static_shapes and _get_backend() == "triton":
+        if (
+            not static_shapes
+            and _get_backend() == "triton"
+            and not self._in_ref_eager_mode
+        ):
             self.assertIn("a_size_0", code)
             self.assertNotIn("b_size_", code)
             bound = kernel.bind((a, b))
@@ -607,21 +611,28 @@ class TestMisc(RefEagerTestBase, TestCase):
     def test_size_assert_unifies_symbols(self):
         @helion.kernel(static_shapes=False)
         def kernel(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-            assert a.size(0) == b.size(1)
+            # Equality expressions in messages and nested asserts must not unify.
+            assert a.size(0) == b.size(1), a.size(1) == b.size(0)
+            if a.size(0) > 0:
+                assert a.size(1) == b.size(0)
             out = torch.empty_like(a)
 
             for tile in hl.tile((b.size(1), a.size(1))):
-                out[tile] = a[tile] + a.size(0) + b.size(1)
+                out[tile] = a[tile] + a.size(0) + b.size(0) + b.size(1)
             return out
 
         a = torch.randn(16, 8, device=DEVICE)
-        b = torch.randn(4, 16, device=DEVICE)
+        b = torch.randn(8, 16, device=DEVICE)
         code, result = code_and_output(kernel, (a, b), block_size=[8, 8])
-        torch.testing.assert_close(result, a + a.size(0) + b.size(1))
+        torch.testing.assert_close(
+            result,
+            a + a.size(0) + b.size(0) + b.size(1),
+        )
 
         if _get_backend() == "triton":
             self.assertIn("a_size_0", code)
             self.assertNotIn("b_size_1", code)
+            self.assertIn("b_size_0", code)
 
     @skipIfRefEager("no code execution")
     def test_triton_repro_add(self):

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -584,16 +584,44 @@ class TestMisc(RefEagerTestBase, TestCase):
     def test_sequence_assert(self, static_shapes):
         @helion.kernel(static_shapes=static_shapes)
         def kernel(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-            assert a.size() == b.size()
+            assert a.shape == b.shape
             out = torch.empty_like(a)
 
             for tile in hl.tile(a.size()):
-                out[tile] = a[tile] + b[tile]
+                out[tile] = a[tile] + b[tile] + b.size(0) + b.size(1)
             return out
 
-        a = torch.randn(16, 1, device=DEVICE)
-        code, result = code_and_output(kernel, (a, a))
-        torch.testing.assert_close(result, a + a)
+        a = torch.randn(16, 8, device=DEVICE)
+        b = torch.randn_like(a)
+        code, result = code_and_output(kernel, (a, b))
+        torch.testing.assert_close(result, a + b + sum(b.shape))
+
+        if not static_shapes and _get_backend() == "triton":
+            self.assertIn("a_size_0", code)
+            self.assertNotIn("b_size_", code)
+            bound = kernel.bind((a, b))
+            compiled = bound.compile_config(bound.config_spec.default_config())
+            with self.assertRaises(AssertionError):
+                compiled(a, torch.randn(16, 7, device=DEVICE))
+
+    def test_size_assert_unifies_symbols(self):
+        @helion.kernel(static_shapes=False)
+        def kernel(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            assert a.size(0) == b.size(1)
+            out = torch.empty_like(a)
+
+            for tile in hl.tile((b.size(1), a.size(1))):
+                out[tile] = a[tile] + a.size(0) + b.size(1)
+            return out
+
+        a = torch.randn(16, 8, device=DEVICE)
+        b = torch.randn(4, 16, device=DEVICE)
+        code, result = code_and_output(kernel, (a, b), block_size=[8, 8])
+        torch.testing.assert_close(result, a + a.size(0) + b.size(1))
+
+        if _get_backend() == "triton":
+            self.assertIn("a_size_0", code)
+            self.assertNotIn("b_size_1", code)
 
     @skipIfRefEager("no code execution")
     def test_triton_repro_add(self):


### PR DESCRIPTION
Closes #1216 

Helion already checks assertions like assert x.size(0) == y.size(1) but does not perform this kind of check when doing codegen. it passes both sizes seperately. 

this pr applies the check to codegen so that when a equality assertion appears before thje first kernel launch, it treats the two dims as the same size. strides stay seperate bc equal shape != equal mem layout. 

Testing:
I repro'd the original bug on h100s and tested whole shape and cross axis equality, changing shapes across calls, non-contiguous inputs, chained assertions and mismatches.

