### PR TITLE
Fix backend codegen registration

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -62,16 +62,18 @@ class AtenLowering(Lowering):
         self, backend: str
     ) -> Callable[[CodegenHandler], CodegenHandler]:
         def decorator(handler: CodegenHandler) -> CodegenHandler:
-            # Idempotent: repair_backend_codegen() may reload this codegen module
-            # (see CodegenDict.__missing__), re-running this decorator. Overwrite
-            # rather than assert so the repair reload is safe.
-            self.codegen_impls[backend] = handler
+            from ..language._decorators import _register_codegen_handler
+
+            _register_codegen_handler(self.codegen_impls, backend, handler)
             return handler
 
         return decorator
 
     def codegen(self, ctx: LoweringContext, node: Node) -> object:
         env = CompileEnvironment.current()
+        from .backend_registry import repair_backend_codegen
+
+        repair_backend_codegen(env.codegen_name)
         handler = self.codegen_impls.get(env.codegen_name)
         if handler is None:
             handler = self.codegen_impls.get("common")

--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -62,9 +62,9 @@ class AtenLowering(Lowering):
         self, backend: str
     ) -> Callable[[CodegenHandler], CodegenHandler]:
         def decorator(handler: CodegenHandler) -> CodegenHandler:
-            assert backend not in self.codegen_impls, (
-                f"codegen already registered for backend {backend!r}"
-            )
+            # Idempotent: repair_backend_codegen() may reload this codegen module
+            # (see CodegenDict.__missing__), re-running this decorator. Overwrite
+            # rather than assert so the repair reload is safe.
             self.codegen_impls[backend] = handler
             return handler
 

--- a/helion/_compiler/backend_registry.py
+++ b/helion/_compiler/backend_registry.py
@@ -102,6 +102,54 @@ def import_backend_codegen() -> None:
                 raise
 
 
+def repair_backend_codegen() -> None:
+    """Force-complete backend codegen registrations skipped due to partial import.
+
+    :func:`import_backend_codegen` relies on ``importlib.import_module`` to run
+    each backend's ``@_decorators.codegen`` / ``register_codegen`` handlers. When
+    a codegen module is already present in ``sys.modules`` in a partially
+    initialized state -- a circular import during package init cached it before
+    its module-scope registrations ran -- ``import_module`` returns the
+    incomplete module and the registrations are silently skipped, leaving
+    ``APIFunc._codegen`` empty for that backend. That surfaces later as
+    :class:`~helion.exc.BackendImplementationMissing` at codegen time (notably
+    under ``torch.compile`` in a packaged runtime, where the init import order
+    differs).
+
+    This reloads each backend's codegen leaf modules so their registrations run.
+    It is only safe once imports are settled (i.e. at codegen time, not during
+    package init) and relies on codegen registration being idempotent (see
+    ``_decorators.codegen`` and ``aten_lowering.register_codegen``).
+    """
+    import types
+
+    if not _REGISTRY:
+        for _cls in _BUILTIN_BACKENDS:
+            register_compiler_backend(_cls)
+    seen: set[str] = set()
+    for backend_cls in _REGISTRY.values():
+        package = backend_cls.__module__.rsplit(".", 1)[0]
+        if package in seen:
+            continue
+        seen.add(package)
+        module_name = f"{package}._codegen_modules"
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as e:
+            if e.name != module_name:
+                raise
+            continue
+        # ``_codegen_modules`` may itself be cached partial; reloading it re-binds
+        # its leaf submodule attributes, and reloading each leaf re-runs the
+        # module-scope registration decorators (idempotently).
+        importlib.reload(module)
+        for value in list(vars(module).values()):
+            if isinstance(value, types.ModuleType) and value.__name__.startswith(
+                package + "."
+            ):
+                importlib.reload(value)
+
+
 # register built-in backends
 for _cls in _BUILTIN_BACKENDS:
     register_compiler_backend(_cls)

--- a/helion/_compiler/backend_registry.py
+++ b/helion/_compiler/backend_registry.py
@@ -6,6 +6,9 @@ All backend lookup and instantiation should go through this module.
 from __future__ import annotations
 
 import importlib
+import sys
+import threading
+import types
 from typing import TYPE_CHECKING
 
 from .backend import CuteBackend
@@ -26,6 +29,8 @@ _BUILTIN_BACKENDS: list[type[Backend]] = [
 ]
 
 _REGISTRY: dict[str, type[Backend]] = {}
+_CODEGEN_REPAIR_LOCK = threading.RLock()
+_REPAIRED_CODEGEN_NAMES: frozenset[str] = frozenset()
 
 
 def register_compiler_backend(backend_class: type[Backend]) -> None:
@@ -37,7 +42,13 @@ def register_compiler_backend(backend_class: type[Backend]) -> None:
     Args:
         backend_class: A :class:`Backend` subclass.
     """
-    _REGISTRY[backend_class().name] = backend_class
+    global _REPAIRED_CODEGEN_NAMES
+
+    backend = backend_class()
+    with _CODEGEN_REPAIR_LOCK:
+        _REGISTRY[backend.name] = backend_class
+        codegen_names, _ = _codegen_repair_scope(backend.codegen_name)
+        _REPAIRED_CODEGEN_NAMES = _REPAIRED_CODEGEN_NAMES.difference(codegen_names)
 
 
 def get_backend_class(name: str) -> type[Backend]:
@@ -102,7 +113,69 @@ def import_backend_codegen() -> None:
                 raise
 
 
-def repair_backend_codegen() -> None:
+def _codegen_repair_scope(
+    codegen_name: str,
+) -> tuple[frozenset[str], frozenset[str]]:
+    entries = [
+        (
+            backend_class().codegen_name,
+            backend_class.__module__.rsplit(".", 1)[0],
+        )
+        for backend_class in _REGISTRY.values()
+    ]
+    codegen_names = {codegen_name}
+    packages: set[str] = set()
+    while True:
+        next_packages = packages.union(
+            package for name, package in entries if name in codegen_names
+        )
+        next_codegen_names = codegen_names.union(
+            name for name, package in entries if package in next_packages
+        )
+        if next_packages == packages and next_codegen_names == codegen_names:
+            return frozenset(codegen_names), frozenset(packages)
+        packages = next_packages
+        codegen_names = next_codegen_names
+
+
+def _reload_backend_codegen(codegen_name: str) -> None:
+    if not _REGISTRY:
+        for _cls in _BUILTIN_BACKENDS:
+            register_compiler_backend(_cls)
+
+    _, packages = _codegen_repair_scope(codegen_name)
+    preexisting_modules = frozenset(sys.modules)
+    seen_packages: set[str] = set()
+    for backend_cls in _REGISTRY.values():
+        package = backend_cls.__module__.rsplit(".", 1)[0]
+        if package not in packages or package in seen_packages:
+            continue
+        seen_packages.add(package)
+        module_name = f"{package}._codegen_modules"
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as e:
+            if e.name != module_name:
+                raise
+            continue
+
+        # Reload the registry module first so all of its leaf modules are bound,
+        # then rerun each leaf module's registration decorators.
+        if module_name in preexisting_modules:
+            importlib.reload(module)
+        reloaded_modules: set[str] = set()
+        for value in list(vars(module).values()):
+            if (
+                isinstance(value, types.ModuleType)
+                and value.__name__.startswith(package + ".")
+                and value.__name__ in preexisting_modules
+                and value.__name__ not in reloaded_modules
+            ):
+                reloaded_modules.add(value.__name__)
+                importlib.reload(value)
+
+
+def repair_backend_codegen(codegen_name: str) -> None:
     """Force-complete backend codegen registrations skipped due to partial import.
 
     :func:`import_backend_codegen` relies on ``importlib.import_module`` to run
@@ -116,38 +189,36 @@ def repair_backend_codegen() -> None:
     under ``torch.compile`` in a packaged runtime, where the init import order
     differs).
 
-    This reloads each backend's codegen leaf modules so their registrations run.
-    It is only safe once imports are settled (i.e. at codegen time, not during
-    package init) and relies on codegen registration being idempotent (see
-    ``_decorators.codegen`` and ``aten_lowering.register_codegen``).
+    This reloads the requested backend's codegen leaf modules so their
+    registrations run. Repairs are serialized across compilation threads and a
+    backend is marked repaired only after a successful reload, allowing a failed
+    attempt to be retried. Every backend dispatch crosses this barrier before
+    reading a handler, so no compiler thread can use a handler while its module
+    is being reloaded.
     """
-    import types
+    global _REPAIRED_CODEGEN_NAMES
 
-    if not _REGISTRY:
-        for _cls in _BUILTIN_BACKENDS:
-            register_compiler_backend(_cls)
-    seen: set[str] = set()
-    for backend_cls in _REGISTRY.values():
-        package = backend_cls.__module__.rsplit(".", 1)[0]
-        if package in seen:
-            continue
-        seen.add(package)
-        module_name = f"{package}._codegen_modules"
+    if codegen_name in _REPAIRED_CODEGEN_NAMES:
+        return
+    with _CODEGEN_REPAIR_LOCK:
+        from ..language._decorators import _begin_codegen_repair
+        from ..language._decorators import _codegen_repair_in_progress
+        from ..language._decorators import _end_codegen_repair
+
+        if codegen_name in _REPAIRED_CODEGEN_NAMES:
+            return
+        if _codegen_repair_in_progress():
+            return
+        if not _REGISTRY:
+            for _cls in _BUILTIN_BACKENDS:
+                register_compiler_backend(_cls)
+        codegen_names, _ = _codegen_repair_scope(codegen_name)
+        _begin_codegen_repair(codegen_names)
         try:
-            module = importlib.import_module(module_name)
-        except ModuleNotFoundError as e:
-            if e.name != module_name:
-                raise
-            continue
-        # ``_codegen_modules`` may itself be cached partial; reloading it re-binds
-        # its leaf submodule attributes, and reloading each leaf re-runs the
-        # module-scope registration decorators (idempotently).
-        importlib.reload(module)
-        for value in list(vars(module).values()):
-            if isinstance(value, types.ModuleType) and value.__name__.startswith(
-                package + "."
-            ):
-                importlib.reload(value)
+            _reload_backend_codegen(codegen_name)
+            _REPAIRED_CODEGEN_NAMES = _REPAIRED_CODEGEN_NAMES.union(codegen_names)
+        finally:
+            _end_codegen_repair()
 
 
 # register built-in backends

--- a/helion/language/_decorators.py
+++ b/helion/language/_decorators.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+import threading
 from typing import TYPE_CHECKING
 from typing import Generic
 from typing import Literal
@@ -36,30 +37,62 @@ if TYPE_CHECKING:
         def __call__(self, fn: Callable[..., _T]) -> object: ...
 
 
+_CodegenT = TypeVar("_CodegenT")
+_CODEGEN_REPAIR_STATE = threading.local()
+
+
+def _codegen_repair_in_progress() -> bool:
+    return getattr(_CODEGEN_REPAIR_STATE, "codegen_names", None) is not None
+
+
+def _begin_codegen_repair(codegen_names: frozenset[str]) -> None:
+    assert not _codegen_repair_in_progress()
+    _CODEGEN_REPAIR_STATE.codegen_names = codegen_names
+    _CODEGEN_REPAIR_STATE.registrations = set()
+
+
+def _end_codegen_repair() -> None:
+    del _CODEGEN_REPAIR_STATE.codegen_names
+    del _CODEGEN_REPAIR_STATE.registrations
+
+
+def _register_codegen_handler(
+    implementations: dict[str, _CodegenT], backend: str, handler: _CodegenT
+) -> None:
+    codegen_names: frozenset[str] | None = getattr(
+        _CODEGEN_REPAIR_STATE, "codegen_names", None
+    )
+    if codegen_names is None:
+        assert backend not in implementations, (
+            f"codegen already registered for backend {backend!r}"
+        )
+    else:
+        if backend not in codegen_names:
+            return
+        key = (id(implementations), backend)
+        registrations: set[tuple[int, str]] = _CODEGEN_REPAIR_STATE.registrations
+        assert key not in registrations, (
+            f"codegen already registered for backend {backend!r}"
+        )
+        registrations.add(key)
+    implementations[backend] = handler
+
+
 class CodegenDict(dict[str, "Callable[[CodegenState], object]"]):
     """A dict subclass that falls back to the 'common' key when a backend key is missing."""
 
-    # Set once the (global) codegen-registration repair has been attempted, so a
-    # genuinely-unregistered backend does not re-trigger the (expensive) reload on
-    # every lookup. See __missing__ / backend_registry.repair_backend_codegen.
-    _repaired: bool = False
+    def __getitem__(self, key: str) -> Callable[[CodegenState], object]:
+        if key != "common":
+            from .._compiler.backend_registry import repair_backend_codegen
+
+            # Exact hits also wait: a partial module may have registered a
+            # handler before defining helpers that it calls.
+            repair_backend_codegen(key)
+        return dict.__getitem__(self, key)
 
     def __missing__(self, key: str) -> Callable[[CodegenState], object]:
         if key != "common" and "common" in self:
-            return self["common"]
-        # A backend codegen can be absent because its codegen module was cached
-        # partially-initialized during a circular import at package-init time, so
-        # its module-scope @codegen registrations never ran (import_backend_codegen's
-        # importlib.import_module is a no-op on a partially cached module, leaving
-        # this dict empty). By codegen time imports are settled, so force-complete
-        # the registrations once and retry before giving up.
-        if key != "common" and not CodegenDict._repaired:
-            CodegenDict._repaired = True
-            from .._compiler.backend_registry import repair_backend_codegen
-
-            repair_backend_codegen()
-            if dict.__contains__(self, key):
-                return dict.__getitem__(self, key)
+            return dict.__getitem__(self, "common")
         raise KeyError(key)
 
     # pyrefly: ignore[bad-override]
@@ -300,10 +333,7 @@ def codegen(
         assert is_api_func(original_fn), (
             f"{type_propagation.__qualname__} can only be used on API functions"
         )
-        # Idempotent: repair_backend_codegen() may reload this codegen module (see
-        # CodegenDict.__missing__), re-running this decorator. Overwrite rather than
-        # assert so the repair reload is safe.
-        original_fn._codegen[backend] = codegen_fn
+        _register_codegen_handler(original_fn._codegen, backend, codegen_fn)
         return _no_call
 
     # pyrefly: ignore [bad-return]

--- a/helion/language/_decorators.py
+++ b/helion/language/_decorators.py
@@ -39,9 +39,27 @@ if TYPE_CHECKING:
 class CodegenDict(dict[str, "Callable[[CodegenState], object]"]):
     """A dict subclass that falls back to the 'common' key when a backend key is missing."""
 
+    # Set once the (global) codegen-registration repair has been attempted, so a
+    # genuinely-unregistered backend does not re-trigger the (expensive) reload on
+    # every lookup. See __missing__ / backend_registry.repair_backend_codegen.
+    _repaired: bool = False
+
     def __missing__(self, key: str) -> Callable[[CodegenState], object]:
         if key != "common" and "common" in self:
             return self["common"]
+        # A backend codegen can be absent because its codegen module was cached
+        # partially-initialized during a circular import at package-init time, so
+        # its module-scope @codegen registrations never ran (import_backend_codegen's
+        # importlib.import_module is a no-op on a partially cached module, leaving
+        # this dict empty). By codegen time imports are settled, so force-complete
+        # the registrations once and retry before giving up.
+        if key != "common" and not CodegenDict._repaired:
+            CodegenDict._repaired = True
+            from .._compiler.backend_registry import repair_backend_codegen
+
+            repair_backend_codegen()
+            if dict.__contains__(self, key):
+                return dict.__getitem__(self, key)
         raise KeyError(key)
 
     # pyrefly: ignore[bad-override]
@@ -282,9 +300,9 @@ def codegen(
         assert is_api_func(original_fn), (
             f"{type_propagation.__qualname__} can only be used on API functions"
         )
-        assert backend not in original_fn._codegen, (
-            f"codegen already registered for backend {backend!r}"
-        )
+        # Idempotent: repair_backend_codegen() may reload this codegen module (see
+        # CodegenDict.__missing__), re-running this decorator. Overwrite rather than
+        # assert so the repair reload is safe.
         original_fn._codegen[backend] = codegen_fn
         return _no_call
 

--- a/test/test_backend_registry.py
+++ b/test/test_backend_registry.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from types import ModuleType
 from types import SimpleNamespace
 from typing import cast
 import unittest
@@ -117,117 +116,6 @@ class TestBackendCodegenRepair(unittest.TestCase):
 
         self.assertEqual(reload_mock.call_count, 2)
 
-    def test_reload_is_scoped_to_requested_codegen_backend(self) -> None:
-        class TritonBackend:
-            __module__ = "test_backends.triton.backend"
-            codegen_name = "triton"
-
-        class PallasBackend:
-            __module__ = "test_backends.pallas.backend"
-            codegen_name = "pallas"
-
-        registry_module = ModuleType("test_backends.triton._codegen_modules")
-        leaf_module = ModuleType("test_backends.triton.memory_ops")
-        vars(registry_module)["memory_ops"] = leaf_module
-
-        with (
-            mock.patch.object(
-                backend_registry,
-                "_REGISTRY",
-                {"triton": TritonBackend, "pallas": PallasBackend},
-            ),
-            mock.patch.object(
-                backend_registry.importlib,
-                "import_module",
-                return_value=registry_module,
-            ) as import_module,
-            mock.patch.dict(
-                backend_registry.sys.modules,
-                {
-                    registry_module.__name__: registry_module,
-                    leaf_module.__name__: leaf_module,
-                },
-            ),
-            mock.patch.object(backend_registry.importlib, "reload") as reload_module,
-        ):
-            backend_registry._reload_backend_codegen("triton")
-
-        import_module.assert_called_once_with("test_backends.triton._codegen_modules")
-        self.assertEqual(
-            reload_module.call_args_list,
-            [mock.call(registry_module), mock.call(leaf_module)],
-        )
-
-    def test_repair_scope_includes_shared_names_and_packages(self) -> None:
-        class TritonBackend:
-            __module__ = "test_backends.shared.backend"
-            codegen_name = "triton"
-
-        class SharedBackend:
-            __module__ = "test_backends.shared.backend"
-            codegen_name = "shared"
-
-        class ExtraTritonBackend:
-            __module__ = "test_backends.extra.backend"
-            codegen_name = "triton"
-
-        with mock.patch.object(
-            backend_registry,
-            "_REGISTRY",
-            {
-                "triton": TritonBackend,
-                "shared": SharedBackend,
-                "extra": ExtraTritonBackend,
-            },
-        ):
-            codegen_names, packages = backend_registry._codegen_repair_scope("triton")
-
-        self.assertEqual(codegen_names, frozenset(("triton", "shared")))
-        self.assertEqual(
-            packages,
-            frozenset(("test_backends.shared", "test_backends.extra")),
-        )
-
-    def test_cross_package_import_stays_fresh_for_entire_repair(self) -> None:
-        class FirstBackend:
-            __module__ = "test_backends.first.backend"
-            codegen_name = "shared"
-
-        class SecondBackend:
-            __module__ = "test_backends.second.backend"
-            codegen_name = "shared"
-
-        first_registry = ModuleType("test_backends.first._codegen_modules")
-        second_registry = ModuleType("test_backends.second._codegen_modules")
-        second_leaf = ModuleType("test_backends.second.memory_ops")
-        vars(second_registry)["memory_ops"] = second_leaf
-
-        def import_module(name: str) -> ModuleType:
-            if name == first_registry.__name__:
-                backend_registry.sys.modules[second_registry.__name__] = second_registry
-                backend_registry.sys.modules[second_leaf.__name__] = second_leaf
-                return first_registry
-            self.assertEqual(name, second_registry.__name__)
-            return second_registry
-
-        with (
-            mock.patch.object(
-                backend_registry,
-                "_REGISTRY",
-                {"first": FirstBackend, "second": SecondBackend},
-            ),
-            mock.patch.dict(backend_registry.sys.modules),
-            mock.patch.object(
-                backend_registry.importlib,
-                "import_module",
-                side_effect=import_module,
-            ),
-            mock.patch.object(backend_registry.importlib, "reload") as reload_module,
-        ):
-            backend_registry._reload_backend_codegen("shared")
-
-        reload_module.assert_not_called()
-
     def test_controlled_repair_allows_reregistration(self) -> None:
         @api()
         def op() -> None:
@@ -254,34 +142,6 @@ class TestBackendCodegenRepair(unittest.TestCase):
 
         self.assertIs(
             dict.__getitem__(cast("APIFunc", op)._codegen, "triton"), replacement
-        )
-
-    def test_repair_does_not_overwrite_unrelated_backend(self) -> None:
-        @api()
-        def op() -> None:
-            return None
-
-        def original(state: object) -> str:
-            return "pallas"
-
-        def reloaded(state: object) -> str:
-            return "reloaded"
-
-        codegen(op, "pallas")(original)
-
-        def reload_backend(codegen_name: str) -> None:
-            self.assertEqual(codegen_name, "triton")
-            codegen(op, "pallas")(reloaded)
-
-        with mock.patch.object(
-            backend_registry,
-            "_reload_backend_codegen",
-            side_effect=reload_backend,
-        ):
-            repair_backend_codegen("triton")
-
-        self.assertIs(
-            dict.__getitem__(cast("APIFunc", op)._codegen, "pallas"), original
         )
 
     def test_repair_rejects_second_registration_for_same_slot(self) -> None:

--- a/test/test_backend_registry.py
+++ b/test/test_backend_registry.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
+from types import ModuleType
+from types import SimpleNamespace
+from typing import cast
 import unittest
+from unittest import mock
 
+from helion._compiler import backend_registry
+from helion._compiler.aten_lowering import AtenLowering
 from helion._compiler.backend import Backend
 from helion._compiler.backend_registry import _REGISTRY
 from helion._compiler.backend_registry import all_reserved_launch_param_names
 from helion._compiler.backend_registry import get_backend_class
 from helion._compiler.backend_registry import list_backends
 from helion._compiler.backend_registry import register_compiler_backend
+from helion._compiler.backend_registry import repair_backend_codegen
+from helion._compiler.compile_environment import CompileEnvironment
+import helion.language as hl
+from helion.language._decorators import APIFunc
+from helion.language._decorators import api
+from helion.language._decorators import codegen
 
 
 class TestBackendRegistry(unittest.TestCase):
@@ -47,9 +59,11 @@ class TestBackendRegistry(unittest.TestCase):
             def constexpr_type(self) -> str:
                 return ""
 
+            @property
             def function_decorator(self) -> str:
                 return ""
 
+            @property
             def library_imports(self) -> dict[str, str]:
                 return {}
 
@@ -71,6 +85,302 @@ class TestBackendRegistry(unittest.TestCase):
         # must be the union of all backends
         for cls in _REGISTRY.values():
             self.assertTrue(cls.reserved_launch_param_names().issubset(result))
+
+
+class TestBackendCodegenRepair(unittest.TestCase):
+    def setUp(self) -> None:
+        patcher = mock.patch.object(
+            backend_registry, "_REPAIRED_CODEGEN_NAMES", frozenset()
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_repair_runs_once_per_codegen_backend(self) -> None:
+        with mock.patch.object(
+            backend_registry, "_reload_backend_codegen"
+        ) as reload_mock:
+            repair_backend_codegen("triton")
+            repair_backend_codegen("triton")
+
+        reload_mock.assert_called_once_with("triton")
+
+    def test_failed_repair_can_be_retried(self) -> None:
+        with mock.patch.object(
+            backend_registry,
+            "_reload_backend_codegen",
+            side_effect=[RuntimeError("broken import"), None],
+        ) as reload_mock:
+            with self.assertRaisesRegex(RuntimeError, "broken import"):
+                repair_backend_codegen("triton")
+            repair_backend_codegen("triton")
+            repair_backend_codegen("triton")
+
+        self.assertEqual(reload_mock.call_count, 2)
+
+    def test_reload_is_scoped_to_requested_codegen_backend(self) -> None:
+        class TritonBackend:
+            __module__ = "test_backends.triton.backend"
+            codegen_name = "triton"
+
+        class PallasBackend:
+            __module__ = "test_backends.pallas.backend"
+            codegen_name = "pallas"
+
+        registry_module = ModuleType("test_backends.triton._codegen_modules")
+        leaf_module = ModuleType("test_backends.triton.memory_ops")
+        vars(registry_module)["memory_ops"] = leaf_module
+
+        with (
+            mock.patch.object(
+                backend_registry,
+                "_REGISTRY",
+                {"triton": TritonBackend, "pallas": PallasBackend},
+            ),
+            mock.patch.object(
+                backend_registry.importlib,
+                "import_module",
+                return_value=registry_module,
+            ) as import_module,
+            mock.patch.dict(
+                backend_registry.sys.modules,
+                {
+                    registry_module.__name__: registry_module,
+                    leaf_module.__name__: leaf_module,
+                },
+            ),
+            mock.patch.object(backend_registry.importlib, "reload") as reload_module,
+        ):
+            backend_registry._reload_backend_codegen("triton")
+
+        import_module.assert_called_once_with("test_backends.triton._codegen_modules")
+        self.assertEqual(
+            reload_module.call_args_list,
+            [mock.call(registry_module), mock.call(leaf_module)],
+        )
+
+    def test_repair_scope_includes_shared_names_and_packages(self) -> None:
+        class TritonBackend:
+            __module__ = "test_backends.shared.backend"
+            codegen_name = "triton"
+
+        class SharedBackend:
+            __module__ = "test_backends.shared.backend"
+            codegen_name = "shared"
+
+        class ExtraTritonBackend:
+            __module__ = "test_backends.extra.backend"
+            codegen_name = "triton"
+
+        with mock.patch.object(
+            backend_registry,
+            "_REGISTRY",
+            {
+                "triton": TritonBackend,
+                "shared": SharedBackend,
+                "extra": ExtraTritonBackend,
+            },
+        ):
+            codegen_names, packages = backend_registry._codegen_repair_scope("triton")
+
+        self.assertEqual(codegen_names, frozenset(("triton", "shared")))
+        self.assertEqual(
+            packages,
+            frozenset(("test_backends.shared", "test_backends.extra")),
+        )
+
+    def test_cross_package_import_stays_fresh_for_entire_repair(self) -> None:
+        class FirstBackend:
+            __module__ = "test_backends.first.backend"
+            codegen_name = "shared"
+
+        class SecondBackend:
+            __module__ = "test_backends.second.backend"
+            codegen_name = "shared"
+
+        first_registry = ModuleType("test_backends.first._codegen_modules")
+        second_registry = ModuleType("test_backends.second._codegen_modules")
+        second_leaf = ModuleType("test_backends.second.memory_ops")
+        vars(second_registry)["memory_ops"] = second_leaf
+
+        def import_module(name: str) -> ModuleType:
+            if name == first_registry.__name__:
+                backend_registry.sys.modules[second_registry.__name__] = second_registry
+                backend_registry.sys.modules[second_leaf.__name__] = second_leaf
+                return first_registry
+            self.assertEqual(name, second_registry.__name__)
+            return second_registry
+
+        with (
+            mock.patch.object(
+                backend_registry,
+                "_REGISTRY",
+                {"first": FirstBackend, "second": SecondBackend},
+            ),
+            mock.patch.dict(backend_registry.sys.modules),
+            mock.patch.object(
+                backend_registry.importlib,
+                "import_module",
+                side_effect=import_module,
+            ),
+            mock.patch.object(backend_registry.importlib, "reload") as reload_module,
+        ):
+            backend_registry._reload_backend_codegen("shared")
+
+        reload_module.assert_not_called()
+
+    def test_controlled_repair_allows_reregistration(self) -> None:
+        @api()
+        def op() -> None:
+            return None
+
+        def original(state: object) -> str:
+            return "original"
+
+        def replacement(state: object) -> str:
+            return "replacement"
+
+        codegen(op, "triton")(original)
+
+        def reload_backend(codegen_name: str) -> None:
+            self.assertEqual(codegen_name, "triton")
+            codegen(op, "triton")(replacement)
+
+        with mock.patch.object(
+            backend_registry,
+            "_reload_backend_codegen",
+            side_effect=reload_backend,
+        ):
+            repair_backend_codegen("triton")
+
+        self.assertIs(
+            dict.__getitem__(cast("APIFunc", op)._codegen, "triton"), replacement
+        )
+
+    def test_repair_does_not_overwrite_unrelated_backend(self) -> None:
+        @api()
+        def op() -> None:
+            return None
+
+        def original(state: object) -> str:
+            return "pallas"
+
+        def reloaded(state: object) -> str:
+            return "reloaded"
+
+        codegen(op, "pallas")(original)
+
+        def reload_backend(codegen_name: str) -> None:
+            self.assertEqual(codegen_name, "triton")
+            codegen(op, "pallas")(reloaded)
+
+        with mock.patch.object(
+            backend_registry,
+            "_reload_backend_codegen",
+            side_effect=reload_backend,
+        ):
+            repair_backend_codegen("triton")
+
+        self.assertIs(
+            dict.__getitem__(cast("APIFunc", op)._codegen, "pallas"), original
+        )
+
+    def test_repair_rejects_second_registration_for_same_slot(self) -> None:
+        @api()
+        def op() -> None:
+            return None
+
+        def first(state: object) -> str:
+            return "first"
+
+        def second(state: object) -> str:
+            return "second"
+
+        def reload_backend(codegen_name: str) -> None:
+            codegen(op, codegen_name)(first)
+            codegen(op, codegen_name)(second)
+
+        with (
+            mock.patch.object(
+                backend_registry,
+                "_reload_backend_codegen",
+                side_effect=reload_backend,
+            ),
+            self.assertRaisesRegex(
+                AssertionError, "codegen already registered for backend 'triton'"
+            ),
+        ):
+            repair_backend_codegen("triton")
+
+    def test_real_reload_restores_missing_handler(self) -> None:
+        codegen_impls = cast("APIFunc", hl.load)._codegen
+        original = dict.__getitem__(codegen_impls, "triton")
+        del codegen_impls["triton"]
+        self.addCleanup(codegen_impls.__setitem__, "triton", original)
+
+        restored = codegen_impls["triton"]
+
+        self.assertEqual(restored.__module__, "helion._compiler.triton.memory_ops")
+        self.assertIsNot(restored, original)
+
+
+class TestAtenCodegenRepair(unittest.TestCase):
+    def test_exact_backend_passes_repair_barrier(self) -> None:
+        def triton(ctx: object, node: object) -> str:
+            return "triton"
+
+        lowering = AtenLowering(codegen_impls={"triton": triton})
+        env = SimpleNamespace(codegen_name="triton", backend_name="triton")
+
+        with (
+            mock.patch.object(CompileEnvironment, "current", return_value=env),
+            mock.patch(
+                "helion._compiler.backend_registry.repair_backend_codegen"
+            ) as repair_mock,
+        ):
+            result = lowering.codegen(mock.Mock(), mock.Mock())
+
+        self.assertEqual(result, "triton")
+        repair_mock.assert_called_once_with("triton")
+
+    def test_missing_backend_repairs_before_common_fallback(self) -> None:
+        def common(ctx: object, node: object) -> str:
+            return "common"
+
+        def triton(ctx: object, node: object) -> str:
+            return "triton"
+
+        lowering = AtenLowering(codegen_impls={"common": common})
+        env = SimpleNamespace(codegen_name="triton", backend_name="triton")
+
+        def repair(codegen_name: str) -> None:
+            lowering.codegen_impls[codegen_name] = triton
+
+        with (
+            mock.patch.object(CompileEnvironment, "current", return_value=env),
+            mock.patch(
+                "helion._compiler.backend_registry.repair_backend_codegen",
+                side_effect=repair,
+            ) as repair_mock,
+        ):
+            result = lowering.codegen(mock.Mock(), mock.Mock())
+
+        self.assertEqual(result, "triton")
+        repair_mock.assert_called_once_with("triton")
+
+    def test_rejects_duplicate_registration_outside_repair(self) -> None:
+        lowering = AtenLowering()
+
+        def first(ctx: object, node: object) -> None:
+            return None
+
+        def second(ctx: object, node: object) -> None:
+            return None
+
+        lowering.register_codegen("triton")(first)
+        with self.assertRaisesRegex(
+            AssertionError, "codegen already registered for backend 'triton'"
+        ):
+            lowering.register_codegen("triton")(second)
 
 
 if __name__ == "__main__":

--- a/test/test_codegen_dict.py
+++ b/test/test_codegen_dict.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+import threading
+from typing import cast
 import unittest
+from unittest import mock
 
+from helion._compiler import backend_registry
+from helion.language._decorators import APIFunc
 from helion.language._decorators import CodegenDict
+from helion.language._decorators import api
+from helion.language._decorators import codegen
 
 
 def _stub_common(state: object) -> str:
@@ -18,14 +26,31 @@ def _stub_pallas(state: object) -> str:
 
 
 class TestCodegenDict(unittest.TestCase):
+    def setUp(self) -> None:
+        patcher = mock.patch("helion._compiler.backend_registry.repair_backend_codegen")
+        self.repair_backend_codegen = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_getitem_exact_match(self) -> None:
         d = CodegenDict({"triton": _stub_triton, "common": _stub_common})
         self.assertIs(d["triton"], _stub_triton)
         self.assertIs(d["common"], _stub_common)
+        self.repair_backend_codegen.assert_called_once_with("triton")
 
     def test_getitem_falls_back_to_common(self) -> None:
         d = CodegenDict({"common": _stub_common})
         self.assertIs(d["pallas"], _stub_common)
+        self.repair_backend_codegen.assert_called_once_with("pallas")
+
+    def test_getitem_repairs_before_falling_back_to_common(self) -> None:
+        d = CodegenDict({"common": _stub_common})
+
+        def repair(key: str) -> None:
+            d[key] = _stub_triton
+
+        self.repair_backend_codegen.side_effect = repair
+        self.assertIs(d["triton"], _stub_triton)
+        self.repair_backend_codegen.assert_called_once_with("triton")
 
     def test_getitem_raises_when_empty(self) -> None:
         d: CodegenDict = CodegenDict()
@@ -41,6 +66,7 @@ class TestCodegenDict(unittest.TestCase):
         d: CodegenDict = CodegenDict()
         with self.assertRaises(KeyError):
             d["common"]
+        self.repair_backend_codegen.assert_not_called()
 
     def test_get_falls_back_to_common(self) -> None:
         d = CodegenDict({"common": _stub_common})
@@ -73,6 +99,81 @@ class TestCodegenDict(unittest.TestCase):
         d["triton"] = _stub_triton
         self.assertIs(d["triton"], _stub_triton)
         self.assertIs(d["pallas"], _stub_common)
+
+    def test_codegen_rejects_duplicate_registration(self) -> None:
+        @api()
+        def op() -> None:
+            return None
+
+        codegen(op, "triton")(_stub_triton)
+        with self.assertRaisesRegex(
+            AssertionError, "codegen already registered for backend 'triton'"
+        ):
+            codegen(op, "triton")(_stub_common)
+
+
+class TestCodegenRepairConcurrency(unittest.TestCase):
+    def test_exact_lookup_waits_for_active_repair(self) -> None:
+        @api()
+        def op() -> None:
+            return None
+
+        def original(state: object) -> str:
+            return "triton"
+
+        def replacement(state: object) -> str:
+            return "replacement"
+
+        codegen(op, "triton")(original)
+        codegen_impls = cast("APIFunc", op)._codegen
+
+        registration_published = threading.Event()
+        release_repair = threading.Event()
+        second_waiting = threading.Event()
+
+        class TrackingRLock:
+            def __init__(self) -> None:
+                self.lock = threading.RLock()
+
+            def __enter__(self) -> None:
+                if registration_published.is_set():
+                    second_waiting.set()
+                self.lock.acquire()
+
+            def __exit__(self, *args: object) -> None:
+                self.lock.release()
+
+        def reload_backend(codegen_name: str) -> None:
+            self.assertEqual(codegen_name, "triton")
+            codegen(op, codegen_name)(replacement)
+            self.assertIs(dict.__getitem__(codegen_impls, codegen_name), replacement)
+            registration_published.set()
+            self.assertTrue(release_repair.wait(timeout=5))
+
+        with (
+            mock.patch.object(backend_registry, "_REPAIRED_CODEGEN_NAMES", frozenset()),
+            mock.patch.object(
+                backend_registry, "_CODEGEN_REPAIR_LOCK", TrackingRLock()
+            ),
+            mock.patch.object(
+                backend_registry,
+                "_reload_backend_codegen",
+                side_effect=reload_backend,
+            ) as reload_mock,
+            ThreadPoolExecutor(max_workers=2) as pool,
+        ):
+            first_future = pool.submit(codegen_impls.__getitem__, "triton")
+            self.assertTrue(registration_published.wait(timeout=5))
+            second_future = pool.submit(codegen_impls.__getitem__, "triton")
+            self.assertTrue(second_waiting.wait(timeout=5))
+            try:
+                self.assertFalse(second_future.done())
+            finally:
+                release_repair.set()
+            self.assertIs(first_future.result(timeout=5), replacement)
+            self.assertIs(second_future.result(timeout=5), replacement)
+
+        reload_mock.assert_called_once_with("triton")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Supersedes #3286.

Under `torch.compile` in packaged runtimes, circular import ordering can leave backend codegen modules partially cached before their registration decorators run. Later, codegen fails with errors such as:

`BackendImplementationMissing: Backend 'triton' is missing required implementation: codegen for API function load`

This change:
  - Repairs backend registrations before API or Aten dispatch.
  - Reloads cached backend registry and leaf modules such as `triton.memory_ops`.
  - Serializes repair across compilation threads and permits retry after failure.
  - Allows one registration replay during repair while preserving normal duplicate detection.
  - Avoids selecting a `common` fallback before a backend-specific handler can be restored.