### PR TITLE
Bound tile threads to their tile in the ND strategy

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -368,6 +368,10 @@ class Backend(abc.ABC):
         """Whether tile strategies must emit explicit masks for all tiles."""
         return False
 
+    def launches_surplus_tile_threads(self) -> bool:
+        """Whether an axis may be launched wider than the tile it indexes."""
+        return False
+
     def supports_config_key(self, key: str) -> bool:
         from ..autotuner.config_spec import BACKEND_SPECIFIC_KEYS
 

--- a/helion/_compiler/metal/backend.py
+++ b/helion/_compiler/metal/backend.py
@@ -150,6 +150,11 @@ class MetalBackend(Backend):
     def force_tile_mask(self) -> bool:
         return True
 
+    def launches_surplus_tile_threads(self) -> bool:
+        # MPP requires num_warps * 32 threads on tid[0], which is independent
+        # of the row block size; see the base docstring.
+        return True
+
     def inductor_op_overrides(self) -> InductorOpOverrides:
         from .metal_overrides import MetalOverrides
 

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -3327,7 +3327,13 @@ class _BaseNDTileStrategy(BlockSizeTileStrategy):
             state.add_statement(f"{index_var} = {idx_expr}")
             # pyrefly: ignore [missing-attribute]
             mask_statement = self._setup_mask(
-                state, block_idx, block_size, index_var, end
+                state,
+                block_idx,
+                block_size,
+                index_var,
+                end,
+                thread_axis=axis if uses_thread_axis else None,
+                block_size_var=bs if uses_thread_axis else None,
             )
             if mask_statement is not None:
                 state.add_statement(mask_statement)
@@ -3482,7 +3488,13 @@ class _BaseNDTileStrategy(BlockSizeTileStrategy):
             ]
             # pyrefly: ignore [missing-attribute]
             mask_statement = self._setup_mask(
-                state, block_idx, block_size, index_var, end
+                state,
+                block_idx,
+                block_size,
+                index_var,
+                end,
+                thread_axis=axis if uses_thread_axis else None,
+                block_size_var=bs if uses_thread_axis else None,
             )
             if mask_statement is not None:
                 extra_body.append(mask_statement)
@@ -3529,7 +3541,11 @@ class NDTileStrategy(_BaseNDTileStrategy):
         block_size: SymIntLike,
         index_var: str,
         end: object,
+        *,
+        thread_axis: int | None = None,
+        block_size_var: str | None = None,
     ) -> ast.stmt | None:
+        """Build the bounds mask for one tile axis."""
         env = CompileEnvironment.current()
         if (
             not env.backend.force_tile_mask()
@@ -3574,8 +3590,19 @@ class NDTileStrategy(_BaseNDTileStrategy):
                 parent=self._to_ast(jagged_tile_parent),
             )
 
+        mask_terms = [f"({index_var}) < {{end}}"]
+        if (
+            thread_axis is not None
+            and block_size_var is not None
+            and env.backend.launches_surplus_tile_threads()
+        ):
+            thread_mask = env.backend.thread_in_tile_mask_expr(
+                block_size_var, axis=thread_axis
+            )
+            if thread_mask is not None:
+                mask_terms.insert(0, f"({thread_mask})")
         return statement_from_string(
-            f"{mask_var} = ({index_var}) < {{end}}", end=self._to_ast(end)
+            f"{mask_var} = {' and '.join(mask_terms)}", end=self._to_ast(end)
         )
 
     def select_pid_strategy(self) -> ProgramIDs:
@@ -3904,6 +3931,7 @@ class CuteNDTileStrategy(NDTileStrategy):
                 block_idx, block_size
             )
             axis = thread_axis_offset + thread_axis_map[block_idx]
+            static_extent: int | None = None
             if uses_thread_axis:
                 idx_expr = env.backend.lane_index_expr(
                     offset_var, elements_per_thread, axis=axis
@@ -3930,8 +3958,19 @@ class CuteNDTileStrategy(NDTileStrategy):
                 target = outer_setup_statements
             target.append(statement_from_string(f"{index_var} = {idx_expr}"))
 
+            # Bound by the *thread* extent rather than the block size: this
+            # axis advances ``elements_per_thread`` per thread, so the threads
+            # belonging to the tile number block_size / that stride.
             mask_statement = self._setup_mask(
-                state, block_idx, block_size, index_var, end
+                state,
+                block_idx,
+                block_size,
+                index_var,
+                end,
+                thread_axis=axis if isinstance(static_extent, int) else None,
+                block_size_var=(
+                    str(static_extent) if isinstance(static_extent, int) else None
+                ),
             )
             if mask_statement is not None:
                 target.append(mask_statement)
@@ -4107,6 +4146,7 @@ class CuteNDTileStrategy(NDTileStrategy):
                 block_idx, block_size
             )
             axis = thread_axis_offset + thread_axis_map[block_idx]
+            static_extent: int | None = None
             if uses_thread_axis:
                 idx_expr = env.backend.lane_index_expr(
                     offset_var, elements_per_thread, axis=axis
@@ -4160,8 +4200,18 @@ class CuteNDTileStrategy(NDTileStrategy):
                 else:
                     idx_expr = f"{idx_expr} + {env.backend.lane_offset_expr(lane_var)}"
             index_setup.append(statement_from_string(f"{index_var} = {idx_expr}"))
+            # Same thread-extent bound as the grid lane path: a device loop is
+            # equally able to be launched wider than the tile it indexes.
             mask_statement = self._setup_mask(
-                state, block_idx, block_size, index_var, end
+                state,
+                block_idx,
+                block_size,
+                index_var,
+                end,
+                thread_axis=axis if isinstance(static_extent, int) else None,
+                block_size_var=(
+                    str(static_extent) if isinstance(static_extent, int) else None
+                ),
             )
             if mask_statement is not None:
                 index_setup.append(mask_statement)

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -397,6 +397,25 @@ class TestMetalBoundsMasking(unittest.TestCase):
             "OOB store detected in vector_add sentinel region",
         )
 
+    def test_tile_mask_bounds_threads_to_the_tile(self) -> None:
+        """The emitted mask must bound threads to their tile."""
+
+        @helion.kernel(
+            backend="metal",
+            configs=[helion.Config(block_sizes=[32, 32], num_warps=4)],
+        )
+        def add2d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tm, tn in hl.tile([x.size(0), x.size(1)]):
+                out[tm, tn] = x[tm, tn] + y[tm, tn]
+            return out
+
+        x = torch.randn(128, 128, device=DEVICE)
+        y = torch.randn(128, 128, device=DEVICE)
+        msl = _get_msl(add2d, (x, y))
+        self.assertIn("(tid[0] < _BLOCK_SIZE_0)", msl)
+        self.assertIn("(tid[1] < _BLOCK_SIZE_1)", msl)
+
 
 # ---------------------------------------------------------------------------
 # Tests – arithmetic
@@ -1164,6 +1183,41 @@ class TestMetalMatmul(unittest.TestCase):
         msl = _get_msl(matmul_dot_relu, (x, y))
         self.assertIn("matmul2d", msl, "MPP matmul2d not found in MSL (hl.dot)")
         self.assertIn("_coop.begin()", msl, "Epilogue loop not found in MSL (hl.dot)")
+
+    def test_matmul_bias_epilogue_is_correct(self) -> None:
+        """Surplus MPP threads must not race with the scalar bias epilogue."""
+
+        def matmul_bias(
+            x: torch.Tensor, y: torch.Tensor, bias: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _k, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc + bias[None, tile_n]
+            return out
+
+        n = 256
+        x = torch.randn(n, n, device=DEVICE)
+        y = torch.randn(n, n, device=DEVICE)
+        bias = torch.randn(n, device=DEVICE)
+        expected = x @ y + bias
+
+        for block_m, warps in [(16, 4), (16, 1), (32, 4), (64, 8), (128, 8), (64, 2)]:
+            with self.subTest(block_m=block_m, num_warps=warps):
+                kernel = helion.kernel(
+                    matmul_bias,
+                    backend="metal",
+                    configs=[
+                        helion.Config(block_sizes=[block_m, 16, 16], num_warps=warps)
+                    ],
+                )
+                torch.testing.assert_close(
+                    kernel(x, y, bias), expected, rtol=2e-3, atol=2e-3
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

A thread axis is normally exactly as wide as the tile it indexes, so
offset + thread_idx is always inside that tile. A backend where something other
than the tile dictates the launch shape breaks that assumption, and
NDTileStrategy masked each axis only against the tensor bound, so surplus
threads addressed a neighbouring tile's elements. Harmless for an idempotent
store; corrupting for a read-modify-write.

Metal hits this because MPP's cooperative matmul requires num_warps * 32
threads on tid[0] whatever the row block size is. relu(x @ y + bias) returned
nondeterministic garbage -- errors of order 1e2 on a 512^3 fp32 product, varying
run to run -- because the bias epilogue reloads the product and each element was
updated by several threadgroups. A device loop is affected the same way.

The mask now also carries the thread_idx < tile_threads term the flattened
strategies already emit, bounded by the thread extent on lane-loop axes since
those advance by more than one element per thread. It is gated on
Backend.launches_surplus_tile_threads, which only Metal enables, so generated
code for other backends does not change.