### PR TITLE
[autotuner][cute] rename ab_stages "three" symbols that are no longer 3-only

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -655,7 +655,7 @@ class CuteTcgen05GroupedStaticCommonKHeuristic(AutotunerHeuristic):
         if (
             static_k >= 3 * bk
             and static_k % bk == 0
-            and env.config_spec._tcgen05_ab_stages_three_fits(
+            and env.config_spec._tcgen05_ab_stages_fits(
                 bm=128,
                 bn=64,
                 bk=bk,
@@ -921,7 +921,7 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
             # shape, seed the canonical fast config family directly so it
             # reaches the autotuner's initial population without depending on a
             # search-stage mutation.
-            if spec._tcgen05_ab_stages_three_fits(
+            if spec._tcgen05_ab_stages_fits(
                 bm=TCGEN05_TWO_CTA_BLOCK_M,
                 bn=TCGEN05_TWO_CTA_BLOCK_N,
                 bk=bk,

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -58,8 +58,8 @@ from .tcgen05_constants import TCGEN05_AB_PRODUCER_ACQUIRE_MODES
 from .tcgen05_constants import TCGEN05_AB_PRODUCER_ADVANCE_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_AB_PRODUCER_ADVANCE_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_AB_PRODUCER_ADVANCE_MODES
-from .tcgen05_constants import TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN
-from .tcgen05_constants import TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
+from .tcgen05_constants import TCGEN05_AB_STAGES_MIN_DEVICE_SMEM_OPTIN
+from .tcgen05_constants import TCGEN05_AB_STAGES_RESERVED_SMEM_BYTES
 from .tcgen05_constants import TCGEN05_ACC_PRODUCER_ADVANCE_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_ACC_PRODUCER_ADVANCE_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_ACC_PRODUCER_ADVANCE_MODES
@@ -170,7 +170,7 @@ class Tcgen05ClusterM2SearchConstraints(NamedTuple):
     allow_fp8_small_grid: bool = False
 
 
-class Tcgen05AbStagesThreeSearchConstraints(NamedTuple):
+class Tcgen05AbStagesSearchConstraints(NamedTuple):
     """Search-only envelope where ``tcgen05_ab_stages=3`` is admitted.
 
     The 3-stage AB pipeline is only safe to search when its larger SMEM
@@ -284,9 +284,9 @@ class CuteTcgen05Config:
         self.cluster_m2_search_constraints: Tcgen05ClusterM2SearchConstraints | None = (
             None
         )
-        self.ab_stages_three_search_constraints: (
-            Tcgen05AbStagesThreeSearchConstraints | None
-        ) = None
+        self.ab_stages_search_constraints: Tcgen05AbStagesSearchConstraints | None = (
+            None
+        )
         self.deep_direct_entry_validation_enabled: bool = False
         self.num_epi_warps_search_choices: tuple[int, ...] | None = None
         self.num_epi_warps_validation_choices: tuple[int, ...] | None = None
@@ -530,7 +530,7 @@ class CuteTcgen05Config:
             bk=bk, ab_stage_count=3, c_stage_count=2
         ):
             return False
-        return self.ab_stages_three_fits(
+        return self.ab_stages_fits(
             bm=TCGEN05_TWO_CTA_BLOCK_M,
             bn=TCGEN05_TWO_CTA_BLOCK_N,
             bk=bk,
@@ -1031,7 +1031,7 @@ class CuteTcgen05Config:
         if not self._uses_grouped_static_reserved_sms(config):
             config.pop(reserved_sms_key, None)
 
-    def allow_ab_stages_three_search(
+    def allow_ab_stages_search(
         self,
         *,
         dtype_bytes: int,
@@ -1039,13 +1039,13 @@ class CuteTcgen05Config:
     ) -> None:
         assert dtype_bytes > 0, "dtype_bytes must be positive"
         if self._matmul_block_indices() is None:
-            self.ab_stages_three_search_constraints = None
+            self.ab_stages_search_constraints = None
             return
         budget_bytes = self.per_cta_ab_smem_budget_bytes(device)
         if budget_bytes <= 0:
-            self.ab_stages_three_search_constraints = None
+            self.ab_stages_search_constraints = None
             return
-        self.ab_stages_three_search_constraints = Tcgen05AbStagesThreeSearchConstraints(
+        self.ab_stages_search_constraints = Tcgen05AbStagesSearchConstraints(
             dtype_bytes=dtype_bytes,
             per_cta_smem_budget_bytes=budget_bytes,
         )
@@ -1067,18 +1067,18 @@ class CuteTcgen05Config:
     @classmethod
     def per_cta_smem_budget_bytes(cls, device: torch.device) -> int:
         device_cap = cls.per_cta_smem_capacity_bytes(device)
-        return max(0, device_cap - TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES)
+        return max(0, device_cap - TCGEN05_AB_STAGES_RESERVED_SMEM_BYTES)
 
     @classmethod
     def per_cta_ab_smem_budget_bytes(cls, device: torch.device) -> int:
         device_cap = cls.per_cta_smem_capacity_bytes(device)
-        if device_cap < TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN:
+        if device_cap < TCGEN05_AB_STAGES_MIN_DEVICE_SMEM_OPTIN:
             return 0
         # Keep a fixed headroom reservation: CuTe's raw opt-in limit does not
         # include every barrier/runtime byte the 3-stage AB pipeline needs.
-        return device_cap - TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
+        return device_cap - TCGEN05_AB_STAGES_RESERVED_SMEM_BYTES
 
-    def ab_stages_three_fits(
+    def ab_stages_fits(
         self,
         *,
         bm: int,
@@ -1088,7 +1088,7 @@ class CuteTcgen05Config:
         ab_stages: int = 3,
     ) -> bool:
         return self._ab_stages_fit_constraints(
-            constraints=self.ab_stages_three_search_constraints,
+            constraints=self.ab_stages_search_constraints,
             bm=bm,
             bn=bn,
             bk=bk,
@@ -1099,7 +1099,7 @@ class CuteTcgen05Config:
     @staticmethod
     def _ab_stages_fit_constraints(
         *,
-        constraints: Tcgen05AbStagesThreeSearchConstraints | None,
+        constraints: Tcgen05AbStagesSearchConstraints | None,
         bm: int,
         bn: int,
         bk: int,
@@ -1146,7 +1146,7 @@ class CuteTcgen05Config:
         # source-C (residual family) but ``(128, 32)`` WITHOUT one (plain
         # matmul) -- ``compute_epilogue_tile_size`` shrinks N when no C tile
         # competes for SMEM. ``has_source_c`` threads that distinction through.
-        constraints = self.ab_stages_three_search_constraints
+        constraints = self.ab_stages_search_constraints
         if constraints is None:
             return False
         if cluster_m not in (1, 2):
@@ -1236,11 +1236,11 @@ class CuteTcgen05Config:
             and block_sizes[:3] == [TCGEN05_TWO_CTA_BLOCK_M, 128, 64]
         ):
             return False
-        if self.ab_stages_three_search_constraints is None:
+        if self.ab_stages_search_constraints is None:
             # Fixed configs can be normalized before their input device is known.
             # CuTe MMA selection applies the real target's SMEM limit at codegen.
             return True
-        return self.ab_stages_three_fits(
+        return self.ab_stages_fits(
             bm=block_sizes[0],
             bn=block_sizes[1],
             bk=block_sizes[2],
@@ -1428,7 +1428,7 @@ class CuteTcgen05Config:
             >>> config.max_ab_stages_that_fit(bm=256, bn=256, bk=64, cluster_m=2)
             4  # BF16 fits only 4 stages
         """
-        constraints = self.ab_stages_three_search_constraints
+        constraints = self.ab_stages_search_constraints
         if constraints is None or bm <= 0 or bn <= 0 or bk <= 0:
             return 0
         if cluster_m not in (1, 2):
@@ -1462,7 +1462,7 @@ class CuteTcgen05Config:
         return max(1, min(max_from_budget, hard_cap))
 
     def _fix_ab_stages_three_search_config(self, config: dict[str, object]) -> None:
-        if self.ab_stages_three_search_constraints is None:
+        if self.ab_stages_search_constraints is None:
             return
         if not self.search_enabled:
             return
@@ -1474,7 +1474,7 @@ class CuteTcgen05Config:
             return
         block_sizes, m_index, n_index, k_index = config_view
         cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
-        if not self.ab_stages_three_fits(
+        if not self.ab_stages_fits(
             bm=cast("int", block_sizes[m_index]),
             bn=cast("int", block_sizes[n_index]),
             bk=cast("int", block_sizes[k_index]),
@@ -1533,9 +1533,9 @@ class CuteTcgen05Config:
         else:
             # Plain / rowvec-bias store (no source-C ring): the bare-AB gate is the
             # calibrated admission — the small no-source-C epilogue D ring rides the
-            # non-AB reservation. ``ab_stages_three_fits`` returns False with no
+            # non-AB reservation. ``ab_stages_fits`` returns False with no
             # budget recorded, so this also fails CLOSED.
-            fits = self.ab_stages_three_fits(
+            fits = self.ab_stages_fits(
                 bm=cast("int", block_sizes[m_index]),
                 bn=cast("int", block_sizes[n_index]),
                 bk=cast("int", block_sizes[k_index]),
@@ -1762,7 +1762,7 @@ class CuteTcgen05Config:
         # cap of 3; admit ab_stages > 3 for fp8 as long as the AB SMEM fits the
         # per-CTA budget. This lets Helion emit the same deeply-pipelined
         # CtaGroup.TWO kernel CUTLASS uses for fp8 compute-bound GEMMs.
-        constraints = self.ab_stages_three_search_constraints
+        constraints = self.ab_stages_search_constraints
         if constraints is not None and constraints.dtype_bytes == 1:  # FP8
             config_view = self._matmul_config_view(config)
             cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
@@ -2165,8 +2165,8 @@ class CuteTcgen05Config:
         cluster_m2_static_k: int | None = None,
         allow_cluster_m2_edge_k_tail_family: bool = False,
         allow_cluster_m2_fp8_small_grid: bool = False,
-        ab_stages_three_dtype_bytes: int | None = None,
-        ab_stages_three_device: torch.device | None = None,
+        ab_stages_dtype_bytes: int | None = None,
+        ab_stages_device: torch.device | None = None,
     ) -> None:
         # Keep the default tcgen05 surface to combinations with runtime
         # coverage. Some unvalidated combinations fail loudly at CuTe
@@ -2219,16 +2219,16 @@ class CuteTcgen05Config:
             self.restrict_cluster_m_search((1,))
         self.restrict_num_epi_warps_search((4,))
         self.restrict_num_epi_warps_validation((4,))
-        if ab_stages_three_dtype_bytes is not None:
-            assert ab_stages_three_device is not None, (
-                "ab_stages_three_dtype_bytes requires ab_stages_three_device "
+        if ab_stages_dtype_bytes is not None:
+            assert ab_stages_device is not None, (
+                "ab_stages_dtype_bytes requires ab_stages_device "
                 "so the SMEM-budget gate consults the operand's device, not "
                 "the host's current CUDA device"
             )
-            self.allow_deep_direct_entry_validation(device=ab_stages_three_device)
-            self.allow_ab_stages_three_search(
-                dtype_bytes=ab_stages_three_dtype_bytes,
-                device=ab_stages_three_device,
+            self.allow_deep_direct_entry_validation(device=ab_stages_device)
+            self.allow_ab_stages_search(
+                dtype_bytes=ab_stages_dtype_bytes,
+                device=ab_stages_device,
             )
 
     def optional_fragments(
@@ -2261,15 +2261,15 @@ class CuteTcgen05Config:
             # cap; admit a frozen deep-staged fp8 config on the validation
             # surface too (``_validate_direct_entry_ab_stage_envelope`` clamps it to
             # the actual per-CTA SMEM budget for the chosen block sizes).
-            constraints = self.ab_stages_three_search_constraints
+            constraints = self.ab_stages_search_constraints
             if constraints is not None and constraints.dtype_bytes == 1:  # FP8
                 ab_stages_max = self._get_dtype_ab_stages_hard_cap(
                     constraints.dtype_bytes
                 )
-        elif self.ab_stages_three_search_constraints is not None:
+        elif self.ab_stages_search_constraints is not None:
             # Cycle 97: make ab=3 BUDGET-AWARE-SEARCHABLE. Where the device/dtype
             # admits ab=3 at all (the SMEM-budget constraints were recorded by
-            # ``allow_ab_stages_three_search`` at bind time — B200-class optin cap,
+            # ``allow_ab_stages_search`` at bind time — B200-class optin cap,
             # bf16/fp16), lift the ``for_search`` cap to 3 so the autotuner can
             # SAMPLE ab=3 directly instead of reaching it only through the per-shape
             # FFI / gelu seeds. ``_fix_ab_stages_search_config`` then demotes any
@@ -2281,7 +2281,7 @@ class CuteTcgen05Config:
             # validation range so an explicit deep-staged fp8 config is
             # accepted (``_validate_direct_entry_ab_stage_envelope`` clamps it to
             # the actual per-CTA SMEM budget for the chosen block sizes).
-            constraints = self.ab_stages_three_search_constraints
+            constraints = self.ab_stages_search_constraints
             if constraints is not None and constraints.dtype_bytes == 1:  # FP8
                 ab_stages_max = self._get_dtype_ab_stages_hard_cap(
                     constraints.dtype_bytes

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -83,14 +83,14 @@ TCGEN05_TWO_CTA_SEED_PID_TYPE = "persistent_interleaved"
 # conservative because the search space cannot enumerate every C-stage /
 # acc-stage variant cheaply and ``ptxas: shared > 232KB`` is bad UX during
 # tuning.
-TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES = 28 * 1024
+TCGEN05_AB_STAGES_RESERVED_SMEM_BYTES = 28 * 1024
 # Hard floor on the per-CTA SMEM optin cap required to admit
 # ``tcgen05_ab_stages=3`` into autotune search. B200's optin reports
 # 232 448 bytes (= 227 * 1024). Devices below this threshold sit
 # outside the warp-specialized tcgen05 envelope this gate is designed
 # for, so admission stays off — explicit user configs still go through
 # the validation surface and get the loud cute_dsl ptxas error.
-TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN = 227 * 1024
+TCGEN05_AB_STAGES_MIN_DEVICE_SMEM_OPTIN = 227 * 1024
 
 
 def tcgen05_ab_smem_bytes_per_cta(
@@ -114,7 +114,7 @@ def tcgen05_ab_smem_bytes_per_cta(
     The autotune search-space gate uses this helper to admit
     ``tcgen05_ab_stages=3`` candidates only when the per-CTA cost fits
     the B200 SMEM optin budget after the non-AB reservation in
-    ``TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES``. The numbers were
+    ``TCGEN05_AB_STAGES_RESERVED_SMEM_BYTES``. The numbers were
     cross-checked against ``cute.cosize`` for the canonical tile shapes
     (256x256x128 CtaGroup.TWO ab=3 = 196 608 bytes; 128x256x128
     CtaGroup.ONE ab=3 = 294 912 bytes / overflows the 232 KB optin cap).

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -60,7 +60,7 @@ from .._compiler.cute.tcgen05_config import CUTE_TCGEN05_DIAGNOSTIC_CONFIG_KEYS
 from .._compiler.cute.tcgen05_config import CUTE_TCGEN05_STRATEGY_CONFIG_KEYS
 from .._compiler.cute.tcgen05_config import CUTE_TCGEN05_TUNABLE_KEYS
 from .._compiler.cute.tcgen05_config import CuteTcgen05Config
-from .._compiler.cute.tcgen05_config import Tcgen05AbStagesThreeSearchConstraints
+from .._compiler.cute.tcgen05_config import Tcgen05AbStagesSearchConstraints
 from .._compiler.cute.tcgen05_config import Tcgen05ClusterM2SearchConstraints
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
 from ..exc import InvalidConfig
@@ -1401,16 +1401,16 @@ class ConfigSpec:
         self._cute_tcgen05_config.cluster_m2_search_constraints = value
 
     @property
-    def _tcgen05_ab_stages_three_search_constraints(
+    def _tcgen05_ab_stages_search_constraints(
         self,
-    ) -> Tcgen05AbStagesThreeSearchConstraints | None:
-        return self._cute_tcgen05_config.ab_stages_three_search_constraints
+    ) -> Tcgen05AbStagesSearchConstraints | None:
+        return self._cute_tcgen05_config.ab_stages_search_constraints
 
-    @_tcgen05_ab_stages_three_search_constraints.setter
-    def _tcgen05_ab_stages_three_search_constraints(
-        self, value: Tcgen05AbStagesThreeSearchConstraints | None
+    @_tcgen05_ab_stages_search_constraints.setter
+    def _tcgen05_ab_stages_search_constraints(
+        self, value: Tcgen05AbStagesSearchConstraints | None
     ) -> None:
-        self._cute_tcgen05_config.ab_stages_three_search_constraints = value
+        self._cute_tcgen05_config.ab_stages_search_constraints = value
 
     @property
     def _tcgen05_num_epi_warps_search_choices(self) -> tuple[int, ...] | None:
@@ -1524,13 +1524,13 @@ class ConfigSpec:
     def _fix_tcgen05_cluster_m2_search_config(self, config: dict[str, object]) -> None:
         self._cute_tcgen05_config._fix_cluster_m2_search_config(config)
 
-    def allow_tcgen05_ab_stages_three_search(
+    def allow_tcgen05_ab_stages_search(
         self,
         *,
         dtype_bytes: int,
         device: torch.device,
     ) -> None:
-        self._cute_tcgen05_config.allow_ab_stages_three_search(
+        self._cute_tcgen05_config.allow_ab_stages_search(
             dtype_bytes=dtype_bytes,
             device=device,
         )
@@ -1539,7 +1539,7 @@ class ConfigSpec:
     def _cute_per_cta_ab_smem_budget_bytes(device: torch.device) -> int:
         return CuteTcgen05Config.per_cta_ab_smem_budget_bytes(device)
 
-    def _tcgen05_ab_stages_three_fits(
+    def _tcgen05_ab_stages_fits(
         self,
         *,
         bm: int,
@@ -1547,7 +1547,7 @@ class ConfigSpec:
         bk: int,
         cluster_m: int,
     ) -> bool:
-        return self._cute_tcgen05_config.ab_stages_three_fits(
+        return self._cute_tcgen05_config.ab_stages_fits(
             bm=bm,
             bn=bn,
             bk=bk,
@@ -1610,8 +1610,8 @@ class ConfigSpec:
         cluster_m2_static_k: int | None = None,
         allow_cluster_m2_edge_k_tail_family: bool = False,
         allow_cluster_m2_fp8_small_grid: bool = False,
-        ab_stages_three_dtype_bytes: int | None = None,
-        ab_stages_three_device: torch.device | None = None,
+        ab_stages_dtype_bytes: int | None = None,
+        ab_stages_device: torch.device | None = None,
         reason: str | None = None,
     ) -> None:
         self._cute_tcgen05_config.narrow_autotune_to_validated_configs(
@@ -1620,8 +1620,8 @@ class ConfigSpec:
             cluster_m2_static_k=cluster_m2_static_k,
             allow_cluster_m2_edge_k_tail_family=allow_cluster_m2_edge_k_tail_family,
             allow_cluster_m2_fp8_small_grid=allow_cluster_m2_fp8_small_grid,
-            ab_stages_three_dtype_bytes=ab_stages_three_dtype_bytes,
-            ab_stages_three_device=ab_stages_three_device,
+            ab_stages_dtype_bytes=ab_stages_dtype_bytes,
+            ab_stages_device=ab_stages_device,
         )
         _record_restriction(
             self.restriction_reasons,

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -497,8 +497,8 @@ def enable_cute_tcgen05_search(
         cluster_m2_static_k=static_k if allow_cluster_m2_search else None,
         allow_cluster_m2_edge_k_tail_family=allow_edge_cluster_m2_search,
         allow_cluster_m2_fp8_small_grid=allow_fp8_small_grid_cluster_m2_search,
-        ab_stages_three_dtype_bytes=lhs.dtype.itemsize,
-        ab_stages_three_device=lhs.device,
+        ab_stages_dtype_bytes=lhs.dtype.itemsize,
+        ab_stages_device=lhs.device,
         reason="matmul kernel with CuTe tcgen05 backend",
     )
     for axis_name, shape, max_size in (

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -3268,7 +3268,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         # the recorded constraints keeps the assertion deterministic across hosts.
         expected_search_ab_high = (
             3
-            if bound.config_spec._cute_tcgen05_config.ab_stages_three_search_constraints
+            if bound.config_spec._cute_tcgen05_config.ab_stages_search_constraints
             is not None
             else 2
         )
@@ -4630,7 +4630,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
         )
         # Mock the SMEM budget to the B200 value at bind time (when
-        # ``allow_ab_stages_three_search`` records the budget into the
+        # ``allow_ab_stages_search`` records the budget into the
         # constraints) so the c=4 lift's ``c_stages_fits`` gate is deterministic
         # on any cute host (``@onlyBackends`` does not imply B200).
         b200_budget = 232448 - 28 * 1024
@@ -4865,9 +4865,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         tcfg._fix_c_stages_search_config(ab2_c4.config)
         self.assertEqual(ab2_c4.config["tcgen05_c_stages"], 4)
         # Fail CLOSED: with no recorded SMEM budget (non-B200 / CPU host, where
-        # ``ab_stages_three_search_constraints`` is None) a sampled c=4 cannot be
+        # ``ab_stages_search_constraints`` is None) a sampled c=4 cannot be
         # proven to fit, so it is demoted to 2 rather than left to overflow.
-        tcfg.ab_stages_three_search_constraints = None
+        tcfg.ab_stages_search_constraints = None
         ab2_c4_no_budget = helion.Config(
             block_sizes=[256, 256, 128],
             indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
@@ -5081,7 +5081,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
 
         # Fail CLOSED: with no recorded SMEM budget the sampled plain ab=3 cannot be
         # proven to fit, so it is demoted to 2 rather than left to overflow.
-        plain_tcfg.ab_stages_three_search_constraints = None
+        plain_tcfg.ab_stages_search_constraints = None
         plain_ab3_no_budget = _ab3_config()
         plain_tcfg.fix_search_config(plain_ab3_no_budget.config)
         self.assertEqual(plain_ab3_no_budget.config["tcgen05_ab_stages"], 2)
@@ -5169,7 +5169,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         }
         with patch.object(
             spec._cute_tcgen05_config,
-            "ab_stages_three_fits",
+            "ab_stages_fits",
             return_value=False,
         ):
             spec._cute_tcgen05_config.fix_search_config(config_dict)

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -18,7 +18,7 @@ from helion import exc
 from helion._compiler.backend import PallasBackend
 from helion._compiler.backend import TritonBackend
 from helion._compiler.compile_environment import CompileEnvironment
-from helion._compiler.cute.tcgen05_config import Tcgen05AbStagesThreeSearchConstraints
+from helion._compiler.cute.tcgen05_config import Tcgen05AbStagesSearchConstraints
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DIRECT
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
@@ -1381,8 +1381,8 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         self.assertEqual(minimized.config["tcgen05_ab_stages"], 7)
 
         constrained_spec = self._make_cute_tcgen05_spec()
-        constrained_spec._cute_tcgen05_config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
+        constrained_spec._cute_tcgen05_config.ab_stages_search_constraints = (
+            Tcgen05AbStagesSearchConstraints(
                 dtype_bytes=2,
                 per_cta_smem_budget_bytes=1,
             )

--- a/test/test_deep_ab_staging.py
+++ b/test/test_deep_ab_staging.py
@@ -42,7 +42,7 @@ class TestMaxABStagesThatFit(TestCase):
         from helion._compiler.backend import CuteBackend
         from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
         from helion._compiler.cute.tcgen05_config import (
-            Tcgen05AbStagesThreeSearchConstraints,
+            Tcgen05AbStagesSearchConstraints,
         )
         from helion.autotuner.config_spec import ConfigSpec
 
@@ -51,21 +51,17 @@ class TestMaxABStagesThatFit(TestCase):
 
         # FP8 config (1 byte per element)
         fp8_config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
-        fp8_config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
-                dtype_bytes=1,
-                per_cta_smem_budget_bytes=smem_budget,
-            )
+        fp8_config.ab_stages_search_constraints = Tcgen05AbStagesSearchConstraints(
+            dtype_bytes=1,
+            per_cta_smem_budget_bytes=smem_budget,
         )
         fp8_config.search_enabled = True
 
         # BF16 config (2 bytes per element)
         bf16_config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
-        bf16_config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
-                dtype_bytes=2,
-                per_cta_smem_budget_bytes=smem_budget,
-            )
+        bf16_config.ab_stages_search_constraints = Tcgen05AbStagesSearchConstraints(
+            dtype_bytes=2,
+            per_cta_smem_budget_bytes=smem_budget,
         )
         bf16_config.search_enabled = True
 
@@ -95,16 +91,14 @@ class TestMaxABStagesThatFit(TestCase):
         from helion._compiler.backend import CuteBackend
         from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
         from helion._compiler.cute.tcgen05_config import (
-            Tcgen05AbStagesThreeSearchConstraints,
+            Tcgen05AbStagesSearchConstraints,
         )
         from helion.autotuner.config_spec import ConfigSpec
 
         config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
-        config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
-                dtype_bytes=1,
-                per_cta_smem_budget_bytes=100000,
-            )
+        config.ab_stages_search_constraints = Tcgen05AbStagesSearchConstraints(
+            dtype_bytes=1,
+            per_cta_smem_budget_bytes=100000,
         )
         config.search_enabled = True
 
@@ -128,16 +122,14 @@ class TestMaxABStagesThatFit(TestCase):
         from helion._compiler.backend import CuteBackend
         from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
         from helion._compiler.cute.tcgen05_config import (
-            Tcgen05AbStagesThreeSearchConstraints,
+            Tcgen05AbStagesSearchConstraints,
         )
         from helion.autotuner.config_spec import ConfigSpec
 
         config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
-        config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
-                dtype_bytes=1,
-                per_cta_smem_budget_bytes=100000,
-            )
+        config.ab_stages_search_constraints = Tcgen05AbStagesSearchConstraints(
+            dtype_bytes=1,
+            per_cta_smem_budget_bytes=100000,
         )
         config.search_enabled = True
 
@@ -163,7 +155,7 @@ class TestMaxABStagesThatFit(TestCase):
         from helion.autotuner.config_spec import ConfigSpec
 
         config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
-        config.ab_stages_three_search_constraints = None
+        config.ab_stages_search_constraints = None
         config.search_enabled = True
 
         result = config.max_ab_stages_that_fit(bm=256, bn=256, bk=64, cluster_m=1)
@@ -174,16 +166,14 @@ class TestMaxABStagesThatFit(TestCase):
         from helion._compiler.backend import CuteBackend
         from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
         from helion._compiler.cute.tcgen05_config import (
-            Tcgen05AbStagesThreeSearchConstraints,
+            Tcgen05AbStagesSearchConstraints,
         )
         from helion.autotuner.config_spec import ConfigSpec
 
         config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
-        config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
-                dtype_bytes=1,
-                per_cta_smem_budget_bytes=150000,
-            )
+        config.ab_stages_search_constraints = Tcgen05AbStagesSearchConstraints(
+            dtype_bytes=1,
+            per_cta_smem_budget_bytes=150000,
         )
         config.search_enabled = True
 
@@ -210,17 +200,15 @@ class TestMaxABStagesThatFit(TestCase):
         from helion._compiler.backend import CuteBackend
         from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
         from helion._compiler.cute.tcgen05_config import (
-            Tcgen05AbStagesThreeSearchConstraints,
+            Tcgen05AbStagesSearchConstraints,
         )
         from helion.autotuner.config_spec import ConfigSpec
 
         # Config with huge budget (should hit hard cap, not budget)
         config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
-        config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
-                dtype_bytes=1,
-                per_cta_smem_budget_bytes=10000000,  # 10MB (unrealistic)
-            )
+        config.ab_stages_search_constraints = Tcgen05AbStagesSearchConstraints(
+            dtype_bytes=1,
+            per_cta_smem_budget_bytes=10000000,  # 10MB (unrealistic)
         )
         config.search_enabled = True
 
@@ -239,17 +227,15 @@ class TestMaxABStagesThatFit(TestCase):
         from helion._compiler.backend import CuteBackend
         from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
         from helion._compiler.cute.tcgen05_config import (
-            Tcgen05AbStagesThreeSearchConstraints,
+            Tcgen05AbStagesSearchConstraints,
         )
         from helion.autotuner.config_spec import ConfigSpec
 
         # Small budget that only fits ab_stages=1 or 2
         config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
-        config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
-                dtype_bytes=2,  # BF16
-                per_cta_smem_budget_bytes=50000,  # Tight budget
-            )
+        config.ab_stages_search_constraints = Tcgen05AbStagesSearchConstraints(
+            dtype_bytes=2,  # BF16
+            per_cta_smem_budget_bytes=50000,  # Tight budget
         )
         config.search_enabled = True
 

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -900,7 +900,7 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(b200_budget_bytes)
         spec = bound.config_spec
 
-        constraints = spec._tcgen05_ab_stages_three_search_constraints
+        constraints = spec._tcgen05_ab_stages_search_constraints
         self.assertIsNotNone(constraints)
         # ``itemsize`` for BF16/FP16 is 2 bytes — matches the matmul
         # binding's ``lhs.dtype.itemsize`` argument.
@@ -991,8 +991,8 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
 
         Mocking the budget helper to return 0 — the value the helper
         produces for non-CUDA hosts and any device whose optin cap sits
-        below ``TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN`` — must
-        keep ``_tcgen05_ab_stages_three_search_constraints`` ``None`` so
+        below ``TCGEN05_AB_STAGES_MIN_DEVICE_SMEM_OPTIN`` — must
+        keep ``_tcgen05_ab_stages_search_constraints`` ``None`` so
         the search surface stays at ``ab_stages_max=2`` and the
         canonical seed does not carry ``ab=3``. This guards against
         broadening the search past the hardware's known-good envelope
@@ -1001,7 +1001,7 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(0)
         spec = bound.config_spec
 
-        self.assertIsNone(spec._tcgen05_ab_stages_three_search_constraints)
+        self.assertIsNone(spec._tcgen05_ab_stages_search_constraints)
         search_fragments = spec._tcgen05_optional_fragments(for_search=True)
         self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 2)
         # Validation surface stays at 3 so explicit user configs still
@@ -1022,18 +1022,18 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(b200_budget_bytes)
         spec = bound.config_spec
 
-        self.assertIsNotNone(spec._tcgen05_ab_stages_three_search_constraints)
+        self.assertIsNotNone(spec._tcgen05_ab_stages_search_constraints)
         with patch.object(type(spec.block_sizes), "__len__", lambda self: 9):
             with patch.object(
                 CuteTcgen05Config,
                 "per_cta_ab_smem_budget_bytes",
                 staticmethod(lambda device: b200_budget_bytes),
             ):
-                spec.allow_tcgen05_ab_stages_three_search(
+                spec.allow_tcgen05_ab_stages_search(
                     dtype_bytes=2,
                     device=torch.device("cuda:0"),
                 )
-            self.assertIsNotNone(spec._tcgen05_ab_stages_three_search_constraints)
+            self.assertIsNotNone(spec._tcgen05_ab_stages_search_constraints)
             search_fragments = spec._tcgen05_optional_fragments(for_search=True)
             self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 3)
 


### PR DESCRIPTION
Stacked PRs:
 * #3358
 * #3357
 * #3356
 * #3355
 * #3354
 * #3353
 * #3352
 * #3351
 * __->__#3350


--- --- ---

### [autotuner][cute] rename ab_stages "three" symbols that are no longer 3-only


Mechanical rename, no behaviour change. These symbols were named for an
`ab_stages == 3`-exactly gate that has since become a general depth walk, so
the "three" in each name is now misleading.

  TCGEN05_AB_STAGES_THREE_{RESERVED_SMEM_BYTES,MIN_DEVICE_SMEM_OPTIN}
    -> TCGEN05_AB_STAGES_{RESERVED_SMEM_BYTES,MIN_DEVICE_SMEM_OPTIN}
  Tcgen05AbStagesThreeSearchConstraints -> Tcgen05AbStagesSearchConstraints
  ab_stages_three_search_constraints    -> ab_stages_search_constraints
  allow_ab_stages_three_search          -> allow_ab_stages_search
  ab_stages_three_fits                  -> ab_stages_fits
  _tcgen05_ab_stages_three_fits         -> _tcgen05_ab_stages_fits
  ab_stages_three_{dtype_bytes,device}  -> ab_stages_{dtype_bytes,device}

106 occurrences across 11 files. This lands first in the stack because the
symbols cross file boundaries: keeping the rename inside one later commit
would break imports in the files not yet migrated.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>