### PR TITLE
[autotuner][cute] repair a partial FFI/layout candidate away from the seed, not onto it

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -1167,7 +1167,7 @@ class CuteTcgen05ClusterM2FfiHeuristic(CuteTcgen05ClusterM2Heuristic):
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
-        return env.config_spec._tcgen05_full_tile_direct_entry_seed_eligible()
+        return env.config_spec._tcgen05_full_tile_direct_entry_seed_emittable()
 
     @classmethod
     def get_seed_config(

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -89,8 +89,14 @@ from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CHOICES
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CUBIN_LINEINFO_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_DIAGNOSTIC_INVALID_OUTPUT_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_DIRECT_ENTRY_LEGAL_BK
+from .tcgen05_constants import TCGEN05_DIRECT_ENTRY_SEED_AB_STAGES
+from .tcgen05_constants import TCGEN05_DIRECT_ENTRY_SEED_C_STAGES
 from .tcgen05_constants import TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_EPILOGUE_LAYOUTS
+from .tcgen05_constants import TCGEN05_EXPLICIT_D_STORE_BOX_N
+from .tcgen05_constants import TCGEN05_EXPLICIT_EPI_TILE_M
+from .tcgen05_constants import TCGEN05_EXPLICIT_EPI_TILE_N
 from .tcgen05_constants import TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_DYNAMIC_MODES
 from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY
@@ -144,7 +150,6 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_c_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_default_epilogue_tile_size
-from .tcgen05_constants import tcgen05_direct_entry_stage_tuple_allowed
 from .tcgen05_constants import tcgen05_two_cta_edge_k_tail_seed_overrides
 
 if TYPE_CHECKING:
@@ -461,12 +466,7 @@ class CuteTcgen05Config:
         return False
 
     def full_tile_direct_entry_seed_bk(self) -> int | None:
-        """Largest valid full-tile direct-entry K tile for the live shape.
-
-        Mirrors the full-tile branch of the heuristic bk selection: the highest
-        power-of-two ``bk`` within the K block-size fragment that divides
-        ``static_k`` within the ``max_k_tiles`` cap.
-        """
+        """Largest valid full-tile direct-entry K tile for the live shape."""
         constraints = self.cluster_m2_search_constraints
         fragments = self._matmul_block_fragments()
         if (
@@ -476,29 +476,19 @@ class CuteTcgen05Config:
         ):
             return None
         bk_fragment = fragments[2]
-        bk = bk_fragment.high
+        bk = min(bk_fragment.high, max(TCGEN05_DIRECT_ENTRY_LEGAL_BK))
         while bk >= bk_fragment.low:
-            if self.cluster_m2_bk_is_valid(bk, constraints):
+            if bk in TCGEN05_DIRECT_ENTRY_LEGAL_BK and self.cluster_m2_bk_is_valid(
+                bk, constraints
+            ):
                 return bk
             bk //= 2
         return None
 
-    def full_tile_direct_entry_seed_eligible(self) -> bool:
-        """Structural eligibility for the generalized TVM-FFI direct-entry seed.
-
-        The direct-entry codegen + runtime validator build their A/B/D TMA
-        descriptors from the runtime tensor shapes, so the fast launch path is
-        shape-general; the constraints are purely structural: a full-tile (NOT
-        edge+K-tail) CtaGroup.TWO 16-bit (bf16/fp16) GEMM, the 256x256 CTA tile
-        reachable, a direct-entry-valid ``bk``, and the ``(ab=3, c=2)`` stage
-        tuple admitted
-        and SMEM-fitting. Both ``optional_fragments`` (to add the FFI search
-        surface) and ``CuteTcgen05ClusterM2FfiHeuristic`` (to gate the seed) use
-        this so they cannot disagree.
-        """
-        # A non-tcgen05-native matmul operand (e.g. an int16 tensor cast to
-        # bf16) forces the dot through the non-tcgen05 fallback, where the
-        # flat-role / FFI seed config is rejected.
+    def explicit_epi_tile_family_exists(self) -> bool:
+        """Bind-time facts: can the ``explicit_epi_tile`` family exist on this shape?"""
+        # A non-tcgen05-native operand forces the dot through the fallback, which
+        # rejects the flat-role / FFI config.
         if self.matmul_has_non_tcgen05_operand:
             return False
         constraints = self.cluster_m2_search_constraints
@@ -506,11 +496,7 @@ class CuteTcgen05Config:
             return False
         if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
             return False
-        # The direct-entry TMA descriptors, SMEM layout, and epilogue tile are
-        # dtype-general for any 16-bit operand (the byte math keys on
-        # ``dtype_bytes``, and bf16/fp16 are both 2 bytes), so admit bf16 and
-        # fp16 with matching operand dtypes. fp32 stays excluded (no tcgen05
-        # fp32 SMEM-staged MMA path).
+        # 16-bit only: there is no tcgen05 fp32 SMEM-staged MMA path.
         if self.matmul_input_dtype not in (torch.bfloat16, torch.float16):
             return False
         if self.matmul_explicit_epi_tile_compatible is not True:
@@ -526,29 +512,28 @@ class CuteTcgen05Config:
         bk = self.full_tile_direct_entry_seed_bk()
         if bk is None:
             return False
-        if not tcgen05_direct_entry_stage_tuple_allowed(
-            bk=bk, ab_stage_count=3, c_stage_count=2
-        ):
+        # cute_mma.py raises for any other bk: the flat-role launch shape and the
+        # D-descriptor box are built only for {64, 128}.
+        return bk in TCGEN05_DIRECT_ENTRY_LEGAL_BK
+
+    def full_tile_direct_entry_seed_emittable(self) -> bool:
+        """Can the FFI direct-entry SEED actually be emitted on this shape?"""
+        if not self.explicit_epi_tile_family_exists():
+            return False
+        bk = self.full_tile_direct_entry_seed_bk()
+        if bk is None:
             return False
         return self.ab_stages_fits(
             bm=TCGEN05_TWO_CTA_BLOCK_M,
             bn=TCGEN05_TWO_CTA_BLOCK_N,
             bk=bk,
             cluster_m=2,
+            ab_stages=TCGEN05_DIRECT_ENTRY_SEED_AB_STAGES,
         )
 
     def full_tile_direct_entry_seed_config(self) -> Config | None:
-        """Generalized TVM-FFI direct-entry seed config for the live shape.
-
-        Single source of truth for the FFI ``explicit_epi_tile`` + flat-role +
-        ``tvm_ffi_launch`` config: emitted into the autotuner population by
-        ``CuteTcgen05ClusterM2FfiHeuristic`` AND used by
-        ``_fix_target1_tvm_ffi_search_config`` to project FFI-requesting search
-        candidates onto the validated CtaGroup.TWO envelope (this is what the
-        per-shape ``_target{N}`` seeds used to do, generalized to any eligible
-        shape). Returns ``None`` for ineligible shapes.
-        """
-        if not self.full_tile_direct_entry_seed_eligible():
+        """Generalized TVM-FFI direct-entry seed config for the live shape."""
+        if not self.full_tile_direct_entry_seed_emittable():
             return None
         bk = self.full_tile_direct_entry_seed_bk()
         if bk is None:
@@ -568,9 +553,9 @@ class CuteTcgen05Config:
             "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
             "tcgen05_cluster_m": 2,
             "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": 3,
+            "tcgen05_ab_stages": TCGEN05_DIRECT_ENTRY_SEED_AB_STAGES,
             "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": 2,
+            "tcgen05_c_stages": TCGEN05_DIRECT_ENTRY_SEED_C_STAGES,
             TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
             "tcgen05_num_epi_warps": 4,
             TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
@@ -579,10 +564,14 @@ class CuteTcgen05Config:
             TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
                 Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
             ),
-            # The flat-role launch path uses this fixed explicit subtile.
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
+            # The flat-role launch path uses this fixed explicit subtile: it is the
+            # only triple the D-descriptor codegen accepts, so it is the same for
+            # every eligible shape.
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: TCGEN05_EXPLICIT_EPI_TILE_M,
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: TCGEN05_EXPLICIT_EPI_TILE_N,
+            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: (
+                TCGEN05_EXPLICIT_D_STORE_BOX_N
+            ),
             TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
             TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
         }
@@ -1747,21 +1736,31 @@ class CuteTcgen05Config:
             and k_block_index < len(block_sizes)
             else None
         )
+        # ``c_stages`` is read only to confirm the key is present and well-typed:
+        # its VALUE no longer gates admission (that was the enumerated ``(ab, c)``
+        # pairing), but a config missing a valid c_stages is still not a
+        # well-formed direct-entry config.
         c_stages = config.get("tcgen05_c_stages")
         if (
             config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
             and isinstance(bk, int)
             and not isinstance(bk, bool)
+            and bk in TCGEN05_DIRECT_ENTRY_LEGAL_BK
             and type(c_stages) is int
-            and tcgen05_direct_entry_stage_tuple_allowed(
-                bk=bk, ab_stage_count=ab_stages, c_stage_count=c_stages
-            )
         ):
-            return
-        # FP8 (1-byte) operands fit a deeper AB pipeline than the bf16-tuned
-        # cap of 3; admit ab_stages > 3 for fp8 as long as the AB SMEM fits the
-        # per-CTA budget. This lets Helion emit the same deeply-pipelined
-        # CtaGroup.TWO kernel CUTLASS uses for fp8 compute-bound GEMMs.
+            config_view = self._matmul_config_view(config)
+            if config_view is not None:
+                view_block_sizes, m_index, n_index, k_index = config_view
+                if self.ab_stages_fits(
+                    bm=cast("int", view_block_sizes[m_index]),
+                    bn=cast("int", view_block_sizes[n_index]),
+                    bk=cast("int", view_block_sizes[k_index]),
+                    cluster_m=cast("int", config.get("tcgen05_cluster_m", 1)),
+                    ab_stages=ab_stages,
+                ):
+                    return
+        # fp8 (1-byte) operands fit a deeper AB pipeline than the 16-bit cap of 3,
+        # so admit ab>3 there whenever the per-CTA AB SMEM fits the budget.
         constraints = self.ab_stages_search_constraints
         if constraints is not None and constraints.dtype_bytes == 1:  # FP8
             config_view = self._matmul_config_view(config)
@@ -2314,7 +2313,7 @@ class CuteTcgen05Config:
             fragments[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = EnumFragment(
                 TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
             )
-        direct_entry_seed_eligible = self.full_tile_direct_entry_seed_eligible()
+        direct_entry_seed_eligible = self.explicit_epi_tile_family_exists()
         if direct_entry_seed_eligible or (
             not for_search and self._direct_entry_k_block_index() is not None
         ):
@@ -2334,23 +2333,53 @@ class CuteTcgen05Config:
                 fragments.update(
                     {
                         TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: EnumFragment(
-                            (None, 128)
+                            (None, TCGEN05_EXPLICIT_EPI_TILE_M),
                         ),
                         TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: EnumFragment(
-                            (None, 32)
+                            (None, TCGEN05_EXPLICIT_EPI_TILE_N),
                         ),
                         TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: EnumFragment(
-                            (None, 32)
+                            (None, TCGEN05_EXPLICIT_D_STORE_BOX_N),
                         ),
                     }
                 )
         return fragments
 
+    def _derive_layout_override_bundle(self, config: dict[str, object]) -> None:
+        """Make the three epi-tile overrides agree with ``layout_strategy``."""
+        present = [
+            key
+            for key in (
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY,
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY,
+                TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY,
+            )
+            if key in config
+        ]
+        if not present:
+            return
+        if (
+            config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
+            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+        ):
+            derived = {
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: TCGEN05_EXPLICIT_EPI_TILE_M,
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: TCGEN05_EXPLICIT_EPI_TILE_N,
+                TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: (
+                    TCGEN05_EXPLICIT_D_STORE_BOX_N
+                ),
+            }
+            for key in present:
+                config[key] = derived[key]
+            return
+        for key in present:
+            config[key] = None
+
     @staticmethod
     def _target1_tvm_ffi_promotion_requested(config: dict[str, object]) -> bool:
+        """Does *config* request the LAYOUT family this stage governs?"""
         return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            or config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
+            config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
             or config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
             == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
             or config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) is not None
@@ -2358,39 +2387,147 @@ class CuteTcgen05Config:
             or config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) is not None
         )
 
-    @staticmethod
-    def _clear_target1_tvm_ffi_promotion_surface(config: dict[str, object]) -> None:
-        for key in list(config):
-            if key.startswith("tcgen05_") or key == "epilogue_subtile":
-                config.pop(key, None)
+    def _strip_target1_tvm_ffi_promotion_surface(
+        self, config: dict[str, object]
+    ) -> None:
+        """Repair a config AWAY from the LAYOUT envelope, in place.
+
+        has no reason to lose its launch mechanism. Clearing it here would silently
+        """
+        config[TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY] = False
+        if (
+            config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
+            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+        ):
+            config[TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY] = (
+                Tcgen05LayoutStrategy.DEFAULT.value
+            )
+        for key in (
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY,
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY,
+            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY,
+        ):
+            config[key] = None
+
+    # Keys that define the LAYOUT direct-entry envelope: the five promotion-request
+    _TARGET1_TVM_FFI_ENVELOPE_KEYS: tuple[str, ...] = (
+        TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY,
+        TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY,
+        TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY,
+        TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY,
+        TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY,
+        "block_sizes",
+        "tcgen05_cluster_m",
+        "tcgen05_cluster_n",
+    )
 
     def _fix_target1_tvm_ffi_search_config(self, config: dict[str, object]) -> None:
-        # The generalized direct-entry seed projects FFI-requesting search
-        # candidates onto the validated CtaGroup.TWO envelope for ANY eligible
-        # shape (returns None for ineligible shapes, in which case the
-        # promotion surface is stripped back to the DEFAULT layout below).
-        seed = self.full_tile_direct_entry_seed_config()
+        self._settle_layout_group(config)
         if not self._target1_tvm_ffi_promotion_requested(config):
             return
-        if seed is None:
-            config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY] = False
-            config[TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY] = False
-            if (
-                config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-                == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ):
-                config[TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY] = (
-                    Tcgen05LayoutStrategy.DEFAULT.value
-                )
-            for key in (
-                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY,
-                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY,
-                TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY,
-            ):
-                config[key] = None
+        #
+        # The remaining population asked for ``explicit_epi_tile`` (possibly with
+        # ``flat_role``) but does not match the seed's layout envelope. Stripping it
+        if self._fix_towards_explicit_epi_tile_envelope(config):
             return
-        self._clear_target1_tvm_ffi_promotion_surface(config)
-        config.update(seed.config)
+        self._strip_target1_tvm_ffi_promotion_surface(config)
+
+    def _fix_towards_explicit_epi_tile_envelope(
+        self, config: dict[str, object]
+    ) -> bool:
+        """Complete an ``explicit_epi_tile`` request in place. True if completed.
+
+        | ``cluster_m = 2`` | the envelope is CtaGroup.TWO (``tcgen05_is_two_cta``). At ``cluster_m=1`` a ``bm=256`` tile silently emits **Triton**, so this is legality, and it is derivable from a tile the draw already chose |
+        """
+        # PRECONDITION-FACT: the shape. ``static_full_tiles``, 16-bit dtype and
+        # aux-descriptor compatibility are bind-time facts no knob can repair.
+        if not self._flat_role_shape_facts_hold():
+            return False
+        config_view = self._matmul_config_view(config)
+        if config_view is None:
+            return False
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return False
+        block_sizes, m_index, n_index, k_index = config_view
+        # PRECONDITION-KNOB: the CTA tile. Checked, never written — see the
+        # docstring's measurement for why.
+        if (
+            block_sizes[m_index] != TCGEN05_TWO_CTA_BLOCK_M
+            or block_sizes[n_index] != TCGEN05_TWO_CTA_BLOCK_N
+        ):
+            return False
+        if config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True:
+            # flat-role's guard adds two TILE conjuncts over plain explicit-epi-tile:
+            # ``bk in {64, 128}`` and ``cluster_n == 1``. Both are drawn values, so
+            # both are checked here; a draw that misses either keeps ``flat_role``
+            # cleared by the caller rather than having its K tile rewritten.
+            #
+            # The guard's remaining config-dependent conjuncts — the FLAT warp topology
+            bk = block_sizes[k_index]
+            # ``_flat_role_shape_facts_hold`` above already requires the cm2
+            # constraints, so this narrowing is what makes that invariant explicit
+            # rather than an unstated non-local assumption.
+            cm2_constraints = self.cluster_m2_search_constraints
+            if not (
+                cm2_constraints is not None
+                and isinstance(bk, int)
+                and not isinstance(bk, bool)
+                and bk in TCGEN05_DIRECT_ENTRY_LEGAL_BK
+                and self.cluster_m2_bk_is_valid(bk, cm2_constraints)
+            ):
+                return False
+            if config.get("tcgen05_cluster_n", 1) != 1:
+                return False
+        # WRITES NOTHING. Every term above is a precondition, checked and never written,
+        # so this function only ever ANSWERS "is this request completable" — the layout
+        # keys were already settled by ``_settle_layout_group`` and the ``cluster_m = 2``
+        # the envelope needs is written by ``_fix_cluster_m2_search_config``, which owns
+        # that key (see its entry block). Returning True is what tells the caller to keep
+        # the request instead of stripping it.
+        return True
+
+    def _settle_layout_group(self, config: dict[str, object]) -> None:
+        """Settle the layout group: promote or demote flat_role, then derive the overrides."""
+        if config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True:
+            if self._flat_role_config_can_hold(config):
+                # COMPLETE the request: ``flat_role=True`` is what the draw asked for and
+                # is left alone; ``explicit_epi_tile`` is the value it REQUIRES.
+                config[TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY] = (
+                    Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+                )
+                # The flat WARP topology this request also needs is supplied at the top of
+                # ``_fix_with_scheduler_search_config`` (stage 5), keyed on the same
+                # ``flat_role is True`` test, so all four warp keys are written in one
+                # place. Nothing between here and there reads any of them.
+            else:
+                # DEMOTE. The unmet term is either a shape fact (static_full_tiles,
+                # 16-bit dtype, aux-descriptor compatibility) or the strategy, which this
+                # stage does not own, so the flag is what gives.
+                config[TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY] = False
+        # Tier 2, from the FINAL ``layout_strategy``. Keep this last, and keep its
+        # ``present`` guard: on a non-matmul kernel the override keys are absent by
+        # design and ``normalize_strategy`` raises ``InvalidConfig`` for any that
+        # appears, so writing ``None`` is not harmless (it broke 12 pointwise tests).
+        self._derive_layout_override_bundle(config)
+
+    def _flat_role_config_can_hold(self, config: dict[str, object]) -> bool:
+        """Can ``flat_role_coordinates=True`` hold for THIS CONFIG (not just this shape)?
+
+        Not checked here, deliberately: the tile terms (``bm``/``bn``/``bk``/
+        """
+        if not self._flat_role_shape_facts_hold():
+            return False
+        # The STRATEGY only. The warp keys it determines are verified at the end of
+        # ``_settle_layout_group``, once stage 5's derivation has had its say.
+        return config.get(TCGEN05_STRATEGY_CONFIG_KEY) in (
+            None,
+            Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            Tcgen05Strategy.PURE_MATMUL_ROLE_LIFECYCLE.value,
+        )
+
+    def _flat_role_shape_facts_hold(self) -> bool:
+        """Can ``flat_role_coordinates=True`` hold on THIS SHAPE at all?"""
+        return self.explicit_epi_tile_family_exists()
 
     def aux_load_mode_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
         if not self._aux_tma_search_enabled():
@@ -2467,7 +2604,7 @@ class CuteTcgen05Config:
         # Aux kernels are the only current trigger for scheduler/c_input warp
         # search. The surface is derived from aux_kernel_detected so repeated
         # detection or repeated fragment construction stays idempotent.
-        direct_entry_seed_eligible = self.full_tile_direct_entry_seed_eligible()
+        direct_entry_seed_eligible = self.explicit_epi_tile_family_exists()
         if self.aux_kernel_detected:
             strategy_choices: tuple[str, ...] = (
                 Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
@@ -2598,6 +2735,23 @@ class CuteTcgen05Config:
                     config[key] = None
                 else:
                     config[key] = self.strategy_field_default(key, pid_type=pid_type)
+            # The loop just put ``layout_strategy`` back to DEFAULT, and
+            # ``flat_role_coordinates=True`` is illegal there -- ``cute_mma.py`` raises
+            # ``BackendUnsupported`` for the flag outside the guarded explicit-epi-tile
+            # path, which is why ``_settle_layout_group`` promotes layout whenever the
+            # flag holds. The flag is NOT in ``TCGEN05_STRATEGY_CONFIG_KEYS`` (and
+            # ``strategy_field_default`` has no branch for it), so the loop cannot clear
+            # it. Clearing it here keeps the pair settled: left True, the next
+            # ``normalize`` pass re-promotes layout off the surviving flag and the
+            # pipeline has no fixed point -- which the post-fix write-back requires.
+            #
+            # Only rewritten when already PRESENT: the key is absent by design on a
+            # family that cannot draw it (``optional_fragments(for_search=True)`` omits
+            # it off the direct-entry surface), and introducing it there makes the
+            # config differ from what the same vector decodes to, which is what the
+            # write-back checks before adopting.
+            if TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY in config:
+                config[TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY] = False
             return
         message = "; ".join(errors)
         raise InvalidConfig(f"tcgen05 strategy invariants violated: {message}")

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -67,7 +67,9 @@ assert (
 # 512x2048x4096 -> 16 clusters on a 148-SM B200).
 TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M = 128
 TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N = 128
-# Best measured seed L2 grouping for the full-tile CtaGroup.TWO row.
+# ``bm=128`` the CuTe MMA atom raises ``OpError: expects the N-mode to satisfy
+# 512x2048x4096 with the integer-data bit-exact oracle at both ``bk=64`` and
+# ``bk=128``: ``bn=16`` raises, ``bn in {32, 64, 128, 256}`` are all bit-exact.
 TCGEN05_TWO_CTA_SEED_L2_GROUPING = 4
 # This pid order stays slightly ahead of persistent_blocked in the validated
 # CtaGroup.TWO envelope.
@@ -76,13 +78,6 @@ TCGEN05_TWO_CTA_SEED_PID_TYPE = "persistent_interleaved"
 # SMEM budget reserved for non-AB allocations on B200 when sampling the
 # ``tcgen05_ab_stages=3`` search arm. The role-local persistent kernel also
 # allocates space for the C accumulator stages, pipeline mailboxes, and TMEM
-# bookkeeping; the canonical 256x256x128 cluster_m=2 ab=3 path measured
-# 196 608 bytes (192 KiB) AB + ~24 KiB other under the 227 KiB optin cap.
-# Hold 28 KiB back from the per-CTA budget so candidates we admit keep a
-# comfortable margin against ptxas's hard limit. This is intentionally
-# conservative because the search space cannot enumerate every C-stage /
-# acc-stage variant cheaply and ``ptxas: shared > 232KB`` is bad UX during
-# tuning.
 TCGEN05_AB_STAGES_RESERVED_SMEM_BYTES = 28 * 1024
 # Hard floor on the per-CTA SMEM optin cap required to admit
 # ``tcgen05_ab_stages=3`` into autotune search. B200's optin reports
@@ -114,7 +109,7 @@ def tcgen05_ab_smem_bytes_per_cta(
     The autotune search-space gate uses this helper to admit
     ``tcgen05_ab_stages=3`` candidates only when the per-CTA cost fits
     the B200 SMEM optin budget after the non-AB reservation in
-    ``TCGEN05_AB_STAGES_RESERVED_SMEM_BYTES``. The numbers were
+    ``TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES``. The numbers were
     cross-checked against ``cute.cosize`` for the canonical tile shapes
     (256x256x128 CtaGroup.TWO ab=3 = 196 608 bytes; 128x256x128
     CtaGroup.ONE ab=3 = 294 912 bytes / overflows the 232 KB optin cap).
@@ -245,7 +240,6 @@ def tcgen05_two_cta_edge_k_tail_seed_overrides() -> dict[str, object]:
         "tcgen05_acc_stages": TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES,
         "tcgen05_c_stages": TCGEN05_TWO_CTA_EDGE_K_TAIL_C_STAGES,
         "l2_groupings": [TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_GROUPING],
-        "tcgen05_l2_swizzle_size": TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE,
         TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY: (
             TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP
         ),
@@ -363,6 +357,17 @@ TCGEN05_SCHED_CONSUMER_WAIT_MODES = (
 )
 TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY = "tcgen05_sched_stage_count"
 TCGEN05_SCHED_STAGE_COUNTS = (1, 2)
+# The depth the STAGED work-tile mailbox uses: the CLC scheduler warp publishes tile N+1
+# while the consumers still read tile N, instead of waiting for them to drain slot 0.
+# Named so the seed producer (``_staged_mailbox_seed_config``), the search fragment
+# (``sched_stage_count_autotune_fragments``) and the two raises that enforce the regime
+# (``_validate_sched_stage_count_config`` and ``program_id.py``'s
+# ``_tcgen05_uses_staged_work_tile_mailbox`` guard) all read one definition.
+TCGEN05_STAGED_WORK_TILE_MAILBOX_SCHED_STAGES = 2
+
+assert TCGEN05_STAGED_WORK_TILE_MAILBOX_SCHED_STAGES in TCGEN05_SCHED_STAGE_COUNTS, (
+    "the staged-mailbox depth must be a legal tcgen05_sched_stage_count"
+)
 TCGEN05_CUBIN_LINEINFO_CONFIG_KEY = "tcgen05_cubin_lineinfo"
 TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY = "tcgen05_tvm_ffi_launch"
 
@@ -404,27 +409,29 @@ TCGEN05_AUX_STAGE_COUNT_CHOICES = (2, 3)
 TCGEN05_CONSUMER_REGS_CONFIG_KEY = "tcgen05_consumer_regs"
 TCGEN05_CONSUMER_REGS_DEFAULT = 256
 TCGEN05_CONSUMER_REGS_CHOICES = (224, 232, 240, 256)
+# THE ONLY explicit-epilogue subtile the D-descriptor codegen accepts:
+# 128x32 bf16 gives the validated 64 Ki-bit D-store TMA box and x32 TMEM drain.
+# ``cute_mma.py`` raises ``BackendUnsupported`` on any other triple.
+#
+# Because there is exactly one legal value per key, the three
+# ``tcgen05_layout_overrides_*`` keys are NOT search axes: they are DERIVED from
+# ``tcgen05_layout_strategy`` (see ``_derive_layout_override_bundle``). Named here
+# so the derivation, the seed builders and ``cute_mma.py``'s
+# ``_TCGEN05_EXPLICIT_EPI_TILE_VALIDATED_SHAPE`` all read one definition.
+TCGEN05_EXPLICIT_EPI_TILE_M = TCGEN05_TWO_CTA_BLOCK_M // 2
 
-# Stage tuples that the TVM-FFI flat-role seed accepts, keyed by ``bk``. The
-# general FFI seed eligibility (``tcgen05_config.py``) consumes this table via
-# ``tcgen05_direct_entry_stage_tuple_allowed``. ``bk=64`` admits the shallow
-# ``(3, 2)`` and deep ``(6, 4)`` A/B pipelines; ``bk=128`` admits the
-# ``(3, 2)`` pipeline. The admission is otherwise structural (any CtaGroup.TWO
-# ``bm=bn=256`` shape) — these stage tuples are the only per-``bk`` constraint.
-TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK: dict[int, tuple[tuple[int, int], ...]] = {
-    64: ((3, 2), (6, 4)),
-    128: ((3, 2),),
-}
+TCGEN05_EXPLICIT_EPI_TILE_N = 32
+
+TCGEN05_EXPLICIT_D_STORE_BOX_N = 32
+
+# The shallow stage tuple the direct-entry seed itself emits. Used as the
+# seed's own depth, NOT as an admission filter.
+TCGEN05_DIRECT_ENTRY_SEED_AB_STAGES = 3
+
+TCGEN05_DIRECT_ENTRY_SEED_C_STAGES = 2
 
 
-def tcgen05_direct_entry_stage_tuple_allowed(
-    *, bk: int, ab_stage_count: int, c_stage_count: int
-) -> bool:
-    """Return True iff ``(ab_stage_count, c_stage_count)`` is admitted for ``bk``."""
-    return (
-        ab_stage_count,
-        c_stage_count,
-    ) in TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK.get(bk, ())
+TCGEN05_DIRECT_ENTRY_LEGAL_BK: frozenset[int] = frozenset({64, 128})
 
 
 # Diagnostic-only G4 admission proof. This key lets tests exercise the

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1432,8 +1432,8 @@ class ConfigSpec:
     ) -> None:
         self._cute_tcgen05_config.num_epi_warps_validation_choices = value
 
-    def _tcgen05_full_tile_direct_entry_seed_eligible(self) -> bool:
-        return self._cute_tcgen05_config.full_tile_direct_entry_seed_eligible()
+    def _tcgen05_full_tile_direct_entry_seed_emittable(self) -> bool:
+        return self._cute_tcgen05_config.full_tile_direct_entry_seed_emittable()
 
     def _tcgen05_full_tile_direct_entry_seed_bk(self) -> int | None:
         return self._cute_tcgen05_config.full_tile_direct_entry_seed_bk()

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1833,7 +1833,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         config: dict[str, object],
         *,
         expected_l2_grouping: int = TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_GROUPING,
-        expected_l2_swizzle_size: int = TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE,
+        expected_l2_swizzle_size: int | None = (
+            TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE
+        ),
     ) -> None:
         self.assertEqual(
             config["tcgen05_ab_stages"],
@@ -1851,10 +1853,19 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             config["l2_groupings"],
             [expected_l2_grouping],
         )
-        self.assertEqual(
-            config["tcgen05_l2_swizzle_size"],
-            expected_l2_swizzle_size,
-        )
+        # ``expected_l2_swizzle_size=None`` pins the key's ABSENCE. The deleted
+        # FFI/layout projection was the only writer that put a swizzle on the
+        # MONOLITHIC arm of this family, so a raw monolithic seed no longer carries
+        # one and neither does a drawn candidate; the scheduler arm keeps the value
+        # its own seed builder sets, and a NORMALIZED config always has the key
+        # because the fragment fills it.
+        if expected_l2_swizzle_size is None:
+            self.assertNotIn("tcgen05_l2_swizzle_size", config)
+        else:
+            self.assertEqual(
+                config["tcgen05_l2_swizzle_size"],
+                expected_l2_swizzle_size,
+            )
         self.assertEqual(
             config[TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY],
             TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP,
@@ -3112,7 +3123,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         ):
             bound = cute_matmul_mma.bind(args)
         spec = bound.config_spec
-        self.assertTrue(spec._tcgen05_full_tile_direct_entry_seed_eligible())
+        self.assertTrue(spec._tcgen05_full_tile_direct_entry_seed_emittable())
         seed_config = spec._tcgen05_full_tile_direct_entry_seed_config()
         self.assertIsNotNone(seed_config)
         seed = seed_config.config
@@ -3301,7 +3312,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         # With no recorded SMEM budget the generalized FFI seed is ineligible
         # (ab=3 cannot fit) and the for_search ab cap stays at 2.
         self.assertFalse(
-            no_ab3_budget_bound.config_spec._tcgen05_full_tile_direct_entry_seed_eligible()
+            no_ab3_budget_bound.config_spec._tcgen05_full_tile_direct_entry_seed_emittable()
         )
         no_budget_ab_stages_fragment = (
             no_ab3_budget_bound.config_spec._tcgen05_optional_fragments(
@@ -3325,7 +3336,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         ):
             fp16_bound = cute_matmul_mma.bind(fp16_args)
         self.assertTrue(
-            fp16_bound.config_spec._tcgen05_full_tile_direct_entry_seed_eligible()
+            fp16_bound.config_spec._tcgen05_full_tile_direct_entry_seed_emittable()
         )
         self.assertIsNotNone(
             fp16_bound.config_spec._tcgen05_full_tile_direct_entry_seed_config()
@@ -3336,7 +3347,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self,
     ) -> None:
         # The structural shape guard for the generalized FFI seed lives entirely
-        # in ``_tcgen05_full_tile_direct_entry_seed_eligible`` (the per-shape
+        # in ``_tcgen05_full_tile_direct_entry_seed_emittable`` (the per-shape
         # TargetN codegen gate and the runtime direct-entry validator were
         # removed). A shape whose N is not a multiple of the 256 CtaGroup.TWO
         # CTA tile is not a full-tile matmul, so the seed must be ineligible and
@@ -3365,7 +3376,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         ):
             invalid_bound = cute_matmul_mma.bind(invalid_args)
         spec = invalid_bound.config_spec
-        self.assertFalse(spec._tcgen05_full_tile_direct_entry_seed_eligible())
+        self.assertFalse(spec._tcgen05_full_tile_direct_entry_seed_emittable())
         self.assertIsNone(spec._tcgen05_full_tile_direct_entry_seed_config())
 
     @onlyBackends(["cute"])
@@ -3476,7 +3487,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         direct_seed = CuteTcgen05ClusterM2Heuristic.get_seed_config(
             bound.env, bound.host_function.device_ir
         ).config
-        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(direct_seed)
+        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
+            direct_seed, expected_l2_swizzle_size=None
+        )
         raw_seeded = [
             config.config
             for config in spec.compiler_seed_configs
@@ -3528,7 +3541,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             ],
         )
         self.assertEqual(raw_seed["pid_type"], "persistent_interleaved")
-        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(raw_seed)
+        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
+            raw_seed, expected_l2_swizzle_size=None
+        )
         self.assertEqual(
             raw_seed["indexing"], ["tensor_descriptor"] * spec.indexing.length
         )
@@ -3843,7 +3858,15 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
-        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(normalized_seed)
+        # ⚠ 1, NOT ``TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE`` (= 4). The deleted
+        # FFI/layout projection was the only writer that put the tuned 4 on the
+        # MONOLITHIC arm of this family, and the monolithic seed builder does not
+        # carry it, so ``normalize`` fills the key from its fragment default
+        # instead. (The scheduler / aux-TMA arms below are unaffected: their own
+        # seed builders set the swizzle.)
+        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
+            normalized_seed, expected_l2_swizzle_size=1
+        )
         self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
             normalized_scheduler_seed,
             expected_l2_swizzle_size=(
@@ -3971,7 +3994,11 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             population_seed["indexing"],
             ["tensor_descriptor"] * spec.indexing.length,
         )
-        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(population_seed)
+        # 1, not the tuned 4 -- same cause as ``normalized_seed`` above: the
+        # monolithic arm's swizzle came from the deleted projection.
+        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
+            population_seed, expected_l2_swizzle_size=1
+        )
         self.assertTrue(
             any(
                 config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
@@ -5188,7 +5215,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             config_dict["tcgen05_ab_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES,
         )
-        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(config_dict)
+        # ``tcgen05_l2_swizzle_size`` is no longer written onto a drawn candidate in
+        # this family: the deleted FFI/layout projection was its only writer on the
+        # monolithic arm, so the key stays absent.
+        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
+            config_dict, expected_l2_swizzle_size=None
+        )
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_two_cta_seeded_in_initial_populations(self) -> None:
@@ -5215,23 +5247,24 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             bound.config_spec.autotuner_heuristics,
         )
 
-        # fp16 4096³ is now FFI-eligible, so the leading compiler seed is the
-        # generalized TVM-FFI direct-entry cluster_m=2 seed (previously fp16 was
-        # bf16-only for the FFI seed, so the leading seed was the cluster_m=1
-        # universal default). The DEFAULT-layout cluster_m=2 seed is also
-        # emitted and remains distinct after normalization.
+        # The LEADING seed is ``default_config()``, and it is the cluster_m=1
+        # universal default again: the TVM-FFI direct-entry seed only reached the
+        # default because a partial FFI candidate was repaired ONTO the seed, which
+        # this commit stops doing. Both cluster_m=2 seeds (FFI direct-entry and
+        # DEFAULT-layout) still enter the population behind it, and remain distinct
+        # after normalization — which is what this test is actually for.
         config_gen = bound.config_spec.create_config_generation()
         zero_flat = config_gen.random_population_flat(0)
         self.assertEqual(len(zero_flat), 1)
         zero_config = config_gen.unflatten(zero_flat[0])
-        self.assertEqual(zero_config.config["tcgen05_cluster_m"], 2)
+        self.assertEqual(zero_config.config["tcgen05_cluster_m"], 1)
         one_flat = config_gen.random_population_flat(1)
         self.assertEqual(len(one_flat), 1)
         one_config = config_gen.unflatten(one_flat[0])
-        self.assertEqual(one_config.config["tcgen05_cluster_m"], 2)
+        self.assertEqual(one_config.config["tcgen05_cluster_m"], 1)
         one_config_population = config_gen.random_population(1)
         self.assertEqual(len(one_config_population), 1)
-        self.assertEqual(one_config_population[0].config["tcgen05_cluster_m"], 2)
+        self.assertEqual(one_config_population[0].config["tcgen05_cluster_m"], 1)
         seeded_configs = config_gen.random_population(3)
         self._assert_cute_tcgen05_cluster_m2_seeded(
             seeded_configs,

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 from types import SimpleNamespace
+from typing import cast
 import unittest
 from unittest.mock import patch
 
@@ -355,14 +356,15 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertLessEqual(default_block_sizes[0], 256)
         self.assertGreaterEqual(default_block_sizes[1], 8)
         self.assertLessEqual(default_block_sizes[1], 256)
-        # 16-bit 8192^3 is FFI-eligible (fp16 has full bf16 parity), so the
-        # default is now the validated TVM-FFI full-tile envelope: the FFI
-        # direct-entry seed's L2 grouping and the CtaGroup.TWO 256x256x128 tile.
-        self.assertEqual(spec.default_config().config["l2_groupings"], [2])
-        # K=8192 can form validated CtaGroup.TWO products at bk >= 32 even
-        # though bk=16 is over the K-tile cap. The FFI full-tile default lands
-        # on cluster_m=2, and the search exposes both arms.
-        self.assertEqual(spec.default_config().config["tcgen05_cluster_m"], 2)
+        # The FFI direct-entry seed no longer bleeds into ``default_config()`` (it
+        # got there by repairing a partial FFI candidate ONTO the seed, which this
+        # commit stops doing), so the default is the generic one again: L2 grouping
+        # 1 and the CtaGroup.ONE tile.
+        self.assertEqual(spec.default_config().config["l2_groupings"], [1])
+        # K=8192 can still form validated CtaGroup.TWO products at bk >= 32 even
+        # though bk=16 is over the K-tile cap, so the SEARCH exposes both arms --
+        # only the default itself moved back to cluster_m=1.
+        self.assertEqual(spec.default_config().config["tcgen05_cluster_m"], 1)
         self.assertEqual(spec._tcgen05_cluster_m_search_choices, (1, 2))
         over_cap_config = {
             "block_sizes": [256, 256, 16],
@@ -410,10 +412,13 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             bound = cute_matmul_mma.bind(args)
             config = bound.config_spec.default_config()
             code = bound.to_triton_code(config)
-        # 16-bit 8192^3 is FFI-eligible (fp16 == bf16 parity); the default is the
-        # validated TVM-FFI full-tile envelope whose bk is 128, not the old
-        # non-persistent bk=16 default. It still codegens on the tcgen05 path.
-        self.assertEqual(config.config["block_sizes"][2], 128)
+        # The TVM-FFI full-tile envelope no longer reaches ``default_config()``:
+        # promoting it was a side effect of repairing a partial FFI candidate ONTO
+        # the seed, which this commit stops doing. So the default falls back to the
+        # generic non-persistent bk=16 tile until a heuristic owns the default
+        # again. It still codegens on the tcgen05 path either way, which is what
+        # this test is for.
+        self.assertEqual(config.config["block_sizes"][2], 16)
         self.assertGreaterEqual(config.config["block_sizes"][0], 128)
         self.assertLessEqual(config.config["block_sizes"][0], 256)
         self.assertGreaterEqual(config.config["block_sizes"][1], 8)
@@ -463,8 +468,19 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(config["l2_groupings"], [1])
         self.assertIs(config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY], False)
 
-        # Regardless of the requested pid_type / bk / l2_grouping, an explicit
-        # FFI request is projected onto the same validated direct-entry envelope.
+        # ── AN EXPLICIT FFI REQUEST IS NO LONGER PROJECTED ONTO THE SEED ──
+        #
+        # These subtests used to assert the opposite: whatever pid_type / bk /
+        # l2_grouping was asked for, an ``ffi=True`` config came back as the seed's
+        # ``[256,256,128]`` tile with the seed's ``l2=[2]``. Repairing a partial
+        # request ONTO the seed is exactly what this commit stops doing, so the
+        # drawn ``bk`` and ``l2_groupings`` SURVIVE.
+        #
+        # ``bm``/``bn`` still move, but that is a DIFFERENT stage
+        # (``_fix_cluster_m2_search_config``) snapping the tile onto the validated
+        # CtaGroup.TWO envelope, and it is unchanged here -- which is why the
+        # expected tile below is the 256x256 envelope carrying the REQUESTED bk
+        # rather than the seed's 128.
         for override in (
             {"pid_type": "flat"},
             {"block_sizes": [128, 256, 16]},
@@ -481,11 +497,23 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                     TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
                     **override,
                 }
+                requested_l2 = list(cast("list[int]", config["l2_groupings"]))
+                requested_bk = cast("list[int]", config["block_sizes"])[2]
                 spec.normalize(config, _fix_invalid=True)
                 self.assertEqual(config["tcgen05_cluster_m"], 2)
                 self.assertEqual(config["pid_type"], "persistent_interleaved")
-                self.assertEqual(config["block_sizes"][:3], [256, 256, 128])
-                self.assertEqual(config["l2_groupings"], [2])
+                self.assertEqual(
+                    config["block_sizes"][:3],
+                    [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, requested_bk],
+                )
+                self.assertEqual(
+                    config["l2_groupings"],
+                    requested_l2,
+                    msg=(
+                        "the FFI stage overwrote l2_groupings; a launch flag has no "
+                        "business touching the scheduler grouping"
+                    ),
+                )
                 self.assertIs(config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY], True)
 
     @onlyBackends(["cute"])
@@ -2122,24 +2150,21 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
 
         spec = _bind_cute_strategy_kernel().config_spec
 
-        # The 256^2 16-bit shape is FFI-eligible (fp16 == bf16 parity), so the
-        # default is the validated TVM-FFI full-tile envelope: the
-        # ROLE_LOCAL_MONOLITHIC strategy is still the pin, but the FFI seed pins
-        # persistent_interleaved / static_persistent / explicit_epi_tile (vs the
-        # old non-eligible flat / non_persistent / default). The persistence
-        # model agrees with the persistent pid_type so the serialized config is
-        # still internally consistent.
+        # The TVM-FFI full-tile envelope no longer reaches ``default_config()`` --
+        # promoting it was a side effect of repairing a partial FFI candidate ONTO
+        # the seed, which this commit stops doing -- so the documented pre-FFI
+        # default is back: ROLE_LOCAL_MONOLITHIC on flat / non_persistent /
+        # DEFAULT layout. The persistence model agrees with the non-persistent
+        # pid_type, so the serialized config is still internally consistent.
         default_cfg = spec.default_config()
         self.assertEqual(
             default_cfg.config["tcgen05_strategy"], "role_local_monolithic"
         )
-        self.assertEqual(default_cfg.config["pid_type"], "persistent_interleaved")
+        self.assertEqual(default_cfg.config["pid_type"], "flat")
         self.assertEqual(
-            default_cfg.config["tcgen05_persistence_model"], "static_persistent"
+            default_cfg.config["tcgen05_persistence_model"], "non_persistent"
         )
-        self.assertEqual(
-            default_cfg.config["tcgen05_layout_strategy"], "explicit_epi_tile"
-        )
+        self.assertEqual(default_cfg.config["tcgen05_layout_strategy"], "default")
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_ab_load_warps"], 1)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_mma_warps"], 1)
         # ``epi_warps`` is the existing tcgen05_num_epi_warps knob.
@@ -2157,15 +2182,14 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_c_input_warps"], 0)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_register_decrease"], 120)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_register_increase"], 256)
-        # The FFI explicit_epi_tile default pins the epilogue-tile / D-store-box
-        # layout overrides (the validated 128/32/32 envelope); the SMEM swizzle
-        # overrides remain unset so the layout helper picks them.
-        self.assertEqual(default_cfg.config["tcgen05_layout_overrides_epi_tile_m"], 128)
-        self.assertEqual(default_cfg.config["tcgen05_layout_overrides_epi_tile_n"], 32)
-        self.assertEqual(
-            default_cfg.config["tcgen05_layout_overrides_d_store_box_n"], 32
-        )
+        # The DEFAULT-layout default leaves every layout override unset so the
+        # layout helper derives the epilogue tile / D-store box / SMEM swizzle (the
+        # FFI explicit_epi_tile 128/32/32 envelope ships on the FFI seed only, and
+        # the seed no longer bleeds into the default).
         for key in (
+            "tcgen05_layout_overrides_epi_tile_m",
+            "tcgen05_layout_overrides_epi_tile_n",
+            "tcgen05_layout_overrides_d_store_box_n",
             "tcgen05_layout_overrides_smem_swizzle_a",
             "tcgen05_layout_overrides_smem_swizzle_b",
         ):
@@ -2997,7 +3021,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             tcfg.validate_strategy_invariants(dict(config), fix_invalid=False)
         tcfg.validate_strategy_invariants(config, fix_invalid=True)
         self.assertEqual(config["tcgen05_strategy"], "role_local_monolithic")
-        self.assertEqual(config["tcgen05_persistence_model"], "static_persistent")
+        # The rollback derives the persistence model from the active pid_type, and
+        # the base config is the DEFAULT-layout default again (flat), so the
+        # rollback lands on ``non_persistent`` rather than the FFI seed's
+        # ``static_persistent``.
+        self.assertEqual(config["tcgen05_persistence_model"], "non_persistent")
         self.assertEqual(config["tcgen05_layout_strategy"], "default")
         self.assertIsNone(config["tcgen05_layout_overrides_epi_tile_m"])
 


### PR DESCRIPTION
Stacked PRs:
 * #3358
 * #3357
 * #3356
 * #3355
 * #3354
 * #3353
 * #3352
 * __->__#3351
 * #3350


--- --- ---

### [autotuner][cute] repair a partial FFI/layout candidate away from the seed, not onto it


The projection is deleted. ``_clear_..._surface`` popped every ``tcgen05_*`` key
and ``config.update(seed.config)`` then wrote 20 keys, only 6 of them layout --
so a config that merely TOUCHED the layout group came back as the seed. Measured
on 4096^3: 300 draws collapsed to **1 distinct config**, with ``flat_role=True``
forced on 300/300, making the legal ``flat_role=False`` + ``explicit_epi_tile``
config unreachable. After: 299 distinct configs, 33 distinct tiles.

``_settle_layout_group`` replaces it: promote ``layout_strategy`` to
``explicit_epi_tile`` when ``flat_role=True`` can hold, demote the flag when it
cannot, then derive the three epi-tile overrides from the settled layout. The
added ``_fix_towards_explicit_epi_tile_envelope`` is a CONFIG-level check that
replaces a guarantee the projection gave for free -- the old ``seed is None``
gate is a SHAPE test, and 209 of 227 requesting draws sit off the 256x256
envelope, so writing layout keys without a tile check would raise at codegen.

``validate_strategy_invariants``' ``fix_invalid`` reset clears ``flat_role``
alongside the rest of the group. The reset walks
``TCGEN05_STRATEGY_CONFIG_KEYS``, which carries ``layout_strategy`` but NOT the
flag, so a failure elsewhere in the group (e.g. ``persistence_model`` against
``pid_type``) returned ``layout_strategy`` to DEFAULT while leaving
``flat_role=True`` beside it -- the exact pair the promotion exists to prevent,
and one ``_settle_layout_group`` re-promotes on the next pass, so ``normalize``
had no fixed point. Written only when the key is already PRESENT: it is absent
by design on a family that cannot draw it, and introducing it there makes the
config disagree with what the same flat vector decodes to.

The direct-entry admission stops enumerating stage tuples.
``TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK`` listed the measured tuples the
TVM-FFI path was known to accept (``{64: ((3,2),(6,4)), 128: ((3,2),)}``) and
``tcgen05_direct_entry_stage_tuple_allowed`` tested exact membership. That
collapsed three degrees of freedom to three points and rejected configs while
admitting strictly larger ones: ``(ab=6, c=2)`` at bk=64 was rejected while
``(ab=6, c=4)`` -- the same AB bytes with a DEEPER C ring -- was admitted. It is
replaced by the path's two real constraints, kept separately:
``TCGEN05_DIRECT_ENTRY_LEGAL_BK = {64, 128}`` (a codegen limit -- ``cute_mma.py``
raises ``BackendUnsupported`` for any other bk, because the flat-role launch
shape and the D-descriptor box are only built for those two) and the per-CTA AB
SMEM budget, evaluated per TILE by the depth walk rather than per table row.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>