### PR TITLE
[autotuner][cute] widen and simplify the cluster_m=2 / cluster_m=1 tile shaping

### DIFF
--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -85,6 +85,7 @@ from .tcgen05_constants import TCGEN05_C_STORE_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_C_STORE_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_C_STORE_MODES
 from .tcgen05_constants import TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_CLUSTER_M2_REPAIR_BLOCK_K_ORDER
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CHOICES
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CUBIN_LINEINFO_CONFIG_KEY
@@ -144,7 +145,6 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_L2_GROUPING
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE
 from .tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
-from .tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
 from .tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
@@ -443,6 +443,33 @@ class CuteTcgen05Config:
             allow_fp8_small_grid=allow_fp8_small_grid,
         )
         self.restrict_cluster_m_search((1, 2))
+
+    def _cluster_m2_capability_holds(self, config: dict[str, object]) -> bool:
+        """Whether ``cluster_m=2`` is EMITTABLE for this config, ignoring search scope."""
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return False
+        config_view = self._matmul_config_view(config)
+        if config_view is None:
+            return False
+        block_sizes, m_index, _, k_index = config_view
+        bm = block_sizes[m_index]
+        if type(bm) is not int:
+            return False
+        if bm == TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M:
+            if self.matmul_input_dtype is not torch.float8_e4m3fn:
+                return False
+        elif bm != TCGEN05_TWO_CTA_BLOCK_M:
+            return False
+        bk = block_sizes[k_index]
+        if type(bk) is not int or bk <= 0:
+            return False
+        for fact in self.config_spec.matmul_facts:
+            static_k = fact.static_k
+            if static_k is None:
+                continue
+            if -(-static_k // bk) > TCGEN05_TWO_CTA_MAX_K_TILES:
+                return False
+        return True
 
     @staticmethod
     def cluster_m2_bk_is_valid(
@@ -849,11 +876,28 @@ class CuteTcgen05Config:
         return seeds
 
     def _fix_cluster_m2_search_config(self, config: dict[str, object]) -> None:
+        # ── A bm=256 EXPLICIT-EPI-TILE CONFIG IS CtaGroup.TWO ──
+        #
+        # This stage OWNS ``tcgen05_cluster_m``: the six demotes below plus this promotion
+        if (
+            self.search_enabled
+            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
+            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+        ):
+            explicit_view = self._matmul_config_view(config)
+            if explicit_view is not None:
+                explicit_block_sizes, explicit_m_index, _, _ = explicit_view
+                if explicit_block_sizes[explicit_m_index] == TCGEN05_TWO_CTA_BLOCK_M:
+                    config["tcgen05_cluster_m"] = 2
         if not (self.search_enabled and config.get("tcgen05_cluster_m") == 2):
             return
         constraints = self.cluster_m2_search_constraints
         if constraints is None:
-            config["tcgen05_cluster_m"] = 1
+            # ── SCOPE IS NOT CAPABILITY ──
+            #
+            # ``cluster_m2_search_constraints is None`` means the SAMPLER does not draw
+            if not self._cluster_m2_capability_holds(config):
+                config["tcgen05_cluster_m"] = 1
             return
         if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
             config["tcgen05_cluster_m"] = 1
@@ -864,20 +908,49 @@ class CuteTcgen05Config:
             return
         block_sizes, m_index, n_index, k_index = config_view
         edge_k_tail_family = constraints.allow_edge_k_tail_family
-        is_narrow_clc_aux_tma = self._is_clc_aux_tma_narrow_n_request(config)
-        if edge_k_tail_family:
-            block_sizes[k_index] = (
-                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_K
-                if is_narrow_clc_aux_tma
-                else TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
-            )
+        drawn_bn = block_sizes[n_index]
+        layout = config.get(
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY,
+            Tcgen05LayoutStrategy.DEFAULT.value,
+        )
+        if (
+            layout != Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+            and isinstance(drawn_bn, int)
+            and not isinstance(drawn_bn, bool)
+            and drawn_bn <= TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
+        ):
+            block_sizes[n_index] = TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
+        else:
+            block_sizes[n_index] = TCGEN05_TWO_CTA_BLOCK_N
+        # Derived from the SETTLED tile. Every read of this flag below is now reading
+        # a predicate over the same ``bn`` that will reach codegen, so a second pass
+        # computes the same value and the stage is idempotent by construction.
         bk = block_sizes[k_index]
         if not isinstance(bk, int) or isinstance(bk, bool):
             config["tcgen05_cluster_m"] = 1
             return
-        if not self.cluster_m2_bk_is_valid(bk, constraints):
-            config["tcgen05_cluster_m"] = 1
-            return
+        #
+        # was inconsistent with the function's own behaviour on every other axis:
+        # ``bm`` is snapped, ``bn`` is snapped, and the joint solve re-tunes
+        if bk not in TCGEN05_CLUSTER_M2_REPAIR_BLOCK_K_ORDER:
+            if not self.cluster_m2_bk_is_valid(bk, constraints):
+                config["tcgen05_cluster_m"] = 1
+                return
+        elif not self.cluster_m2_bk_is_valid(bk, constraints):
+            repaired_bk = min(
+                (
+                    candidate
+                    for candidate in TCGEN05_CLUSTER_M2_REPAIR_BLOCK_K_ORDER
+                    if self.cluster_m2_bk_is_valid(candidate, constraints)
+                ),
+                key=lambda candidate: (abs(candidate - bk), -candidate),
+                default=None,
+            )
+            if repaired_bk is None:
+                config["tcgen05_cluster_m"] = 1
+                return
+            block_sizes[k_index] = repaired_bk
+            bk = repaired_bk
         config["pid_type"] = TCGEN05_TWO_CTA_SEED_PID_TYPE
         # The tcgen05 CtaGroup.TWO MMA path does not emit the per-block-id
         # indices/masks that a fused epilogue subtile needs, so a sampled
@@ -885,53 +958,35 @@ class CuteTcgen05Config:
         # ``BackendUnsupported`` at codegen. Drop it here (rather than letting
         # the candidate fail to compile and waste autotune budget) -- every
         # cluster_m=2 search candidate that survives to this point is committed
-        # to the 2-CTA path. The edge-family prefixes below also pop it for
-        # their sub-paths; doing it once here covers the full-tile and
-        # small-grid paths too.
+        # to the 2-CTA path.
         config.pop("epilogue_subtile", None)
-        # fp8 small-grid family: a sampled bm<=128 routes to the fp8-validated
-        # per-CTA 64xbn 2-CTA tile (bm=128/bn=128) instead of the bm=256 full
-        # tile, which underfills the device on small/wave-limited fp8 GEMMs. The
-        # bm=256 full tile is still reachable from a sampled bm>128. The codegen
-        # + runtime own this tile via ``_tcgen05_use_2cta_instrs``
-        # (``bm == 128 and is_fp8``). Edge+K-tail candidates keep the bm=256
-        # double-edge family unconditionally.
+        # ── The fp8 small-grid family is a SCOPE EXCLUSION, not a special case ──
         sampled_bm = block_sizes[m_index]
-        if (
+        fp8_small_grid_family = (
             constraints.allow_fp8_small_grid
             and not edge_k_tail_family
             and isinstance(sampled_bm, int)
             and not isinstance(sampled_bm, bool)
             and sampled_bm <= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
-        ):
+        )
+        if fp8_small_grid_family:
+            # ``bm`` is LEGALITY and stays pinned: ``_tcgen05_use_2cta_instrs`` admits
+            # ``bm == 256`` at any 16-bit dtype but ``bm == 128`` only for fp8, and at
+            # bf16 that config point belongs to the legacy clustered ``CtaGroup.ONE``
+            # family. This is a family-ownership pin, not a tuned value. Note both ``bm``
+            # values already COMPETE on an fp8 shape: this branch keys on the DRAWN ``bm``,
+            # so a drawn 256 falls through to the main path below and gets the 256-wide
+            # 2-CTA tile (verified on fp8 512x2048x4096: drawn ``bm=256`` exits as
+            # ``[256, {64,128,256}, *]`` with ``use_2cta=True``).
             block_sizes[m_index] = TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
-            block_sizes[n_index] = TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
+            # the SETTLE above, which is the same rule the non-fp8 arm gets: ``bn <= 128``
+            # snaps to 128, otherwise 256. So the fp8 arm's band goes ``{128}`` ->
+            # ``{128, 256}`` and stops being a special case.
             return
         block_sizes[m_index] = TCGEN05_TWO_CTA_BLOCK_M
-        # Only the fully validated narrow-N CLC+aux-TMA seed may keep
-        # block_n=128; other candidates use the canonical block_n=256.
-        if is_narrow_clc_aux_tma:
-            block_sizes[n_index] = TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
-        else:
-            block_sizes[n_index] = TCGEN05_TWO_CTA_BLOCK_N
-        if edge_k_tail_family:
-            # This family is pinned to measured production stage/pipeline
-            # values after search projection.
-            # Placement keys remain available for non-edge diagnostic/search
-            # paths, but edge+K-tail candidates do not explore partially
-            # mutated placement variants.
-            config.update(tcgen05_two_cta_edge_k_tail_seed_overrides())
-            if self.aux_kernel_detected and self._has_any_matmul_fact_edge_tile(config):
-                self._set_aux_edge_cluster_m2_prefix(config)
-            if self._is_clc_aux_tma_config(config):
-                self._set_clc_aux_tma_edge_perf_knobs(config)
-            if is_narrow_clc_aux_tma:
-                config["tcgen05_acc_stages"] = (
-                    TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_ACC_STAGES
-                )
-                config["l2_groupings"] = [
-                    TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_L2_GROUPING
-                ]
+        # Block-N shaping for the surviving cluster_m=2 candidates. A CtaGroup.TWO
+        # matmul has exactly two validated N tiles: 128 (a 256x128 output tile)
+        # and 256. Both are hardware-legal because the 2-CTA MMA decision keys
 
     def prepare_normalization(
         self, config: dict[str, object], *, fix_invalid: bool
@@ -1554,6 +1609,37 @@ class CuteTcgen05Config:
         if ab_stages == 3 and config.get(TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY) == 1:
             config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 0
 
+    def _is_validated_cluster_m2_full_tile_search_candidate(
+        self, config: dict[str, object]
+    ) -> bool:
+        # Cycle 46: full-tile cluster_m=2 candidate gate for aux-TMA admission.
+        # After ``_fix_cluster_m2_search_config`` projects a full-tile sample to
+        # the canonical 256x256x bk shape with ``persistent_interleaved`` pid,
+        # this returns True so aux-TMA stays during the search-time fixup.
+        # bk validity is already enforced by ``_fix_cluster_m2_search_config``;
+        # we re-check it here so a stale/unprojected config cannot slip through.
+        if config.get("tcgen05_cluster_m") != 2:
+            return False
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None or constraints.allow_edge_k_tail_family:
+            return False
+        if config.get("pid_type") != TCGEN05_TWO_CTA_SEED_PID_TYPE:
+            return False
+        if config.get("tcgen05_cluster_n", 1) != 1:
+            return False
+        config_view = self._matmul_config_view(config)
+        if config_view is None:
+            return False
+        block_sizes, m_index, n_index, k_index = config_view
+        if block_sizes[m_index] != TCGEN05_TWO_CTA_BLOCK_M:
+            return False
+        if block_sizes[n_index] != TCGEN05_TWO_CTA_BLOCK_N:
+            return False
+        bk = block_sizes[k_index]
+        if not isinstance(bk, int) or isinstance(bk, bool):
+            return False
+        return self.cluster_m2_bk_is_valid(bk, constraints)
+
     def _fix_aux_tma_search_config(self, config: dict[str, object]) -> None:
         if config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY) != TCGEN05_AUX_LOAD_MODE_TMA:
             return
@@ -2092,61 +2178,38 @@ class CuteTcgen05Config:
             return False
         return constraints.allow_edge_k_tail_family
 
-    def _is_validated_cluster_m2_full_tile_search_candidate(
-        self, config: dict[str, object]
-    ) -> bool:
-        # Cycle 46: full-tile cluster_m=2 candidate gate for aux-TMA admission.
-        # After ``_fix_cluster_m2_search_config`` projects a full-tile sample to
-        # the canonical 256x256x bk shape with ``persistent_interleaved`` pid,
-        # this returns True so aux-TMA stays during the search-time fixup.
-        # bk validity is already enforced by ``_fix_cluster_m2_search_config``;
-        # we re-check it here so a stale/unprojected config cannot slip through.
-        if config.get("tcgen05_cluster_m") != 2:
-            return False
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return False
-        if config.get("pid_type") != TCGEN05_TWO_CTA_SEED_PID_TYPE:
-            return False
-        if config.get("tcgen05_cluster_n", 1) != 1:
-            return False
-        config_view = self._matmul_config_view(config)
-        if config_view is None:
-            return False
-        block_sizes, m_index, n_index, k_index = config_view
-        if block_sizes[m_index] != TCGEN05_TWO_CTA_BLOCK_M:
-            return False
-        if block_sizes[n_index] != TCGEN05_TWO_CTA_BLOCK_N:
-            return False
-        bk = block_sizes[k_index]
-        if not isinstance(bk, int) or isinstance(bk, bool):
-            return False
-        return self.cluster_m2_bk_is_valid(bk, constraints)
+    # ``_fix_aux_tma_search_config``'s arm-4 tile-shape envelope (8 clauses:
+    # cluster_m, constraints/edge-family, pid_type, cluster_n, config_view,
+    # bm == 256, bn == 256, bk validity) and that arm-4 call site was its ONLY
 
     def _fix_cluster_m1_persistent_search_config(
         self, config: dict[str, object]
     ) -> None:
-        if not (
-            self.search_enabled
-            and config.get("tcgen05_cluster_m", 1) == 1
-            and config.get("pid_type")
-            in {"persistent_blocked", "persistent_interleaved"}
-        ):
+        #
+        #     and config.get("pid_type") in {"persistent_blocked", "persistent_interleaved"}
+        if not (self.search_enabled and config.get("tcgen05_cluster_m", 1) == 1):
             return
         config_view = self._matmul_config_view(config)
         if config_view is None:
             return
         block_sizes, m_index, _, _ = config_view
-        constraints = self.cluster_m2_search_constraints
-        if constraints is not None and constraints.allow_edge_k_tail_family:
-            # persistent_interleaved stays in the flat enum so cluster_m=2
-            # edge-family samples can encode; cluster_m=1 samples from the
-            # same surface must use the validated flat edge fallback.
-            config["pid_type"] = "flat"
-            return
+        # TWO INDEPENDENT legality clamps. They must NOT sit in an if/else: they
+        # constrain different keys for different reasons, and either one being
+        # skipped is a defect.
         bm = block_sizes[m_index]
         if isinstance(bm, int) and not isinstance(bm, bool):
             block_sizes[m_index] = min(bm, TCGEN05_ONE_CTA_MAX_BLOCK_M)
+        # (2) pid_type: ``persistent_interleaved`` stays in the flat enum so
+        #     cluster_m=2 edge-family samples can encode; cluster_m=1 samples from
+        #     the same surface must use the validated flat edge fallback.
+        constraints = self.cluster_m2_search_constraints
+        if (
+            constraints is not None
+            and constraints.allow_edge_k_tail_family
+            and config.get("pid_type")
+            in {"persistent_blocked", "persistent_interleaved"}
+        ):
+            config["pid_type"] = "flat"
 
     def restrict_num_epi_warps_search(self, choices: tuple[int, ...]) -> None:
         assert choices, "tcgen05_num_epi_warps search must allow at least one value"
@@ -2247,44 +2310,17 @@ class CuteTcgen05Config:
         else:
             num_epi_warps_fragment = IntegerFragment(1, 4, 4)
         if not for_search:
-            # Validation admits what the direct-entry codegen supports: bk=64
-            # accepts the deep (ab=6, c=4) tuple (see
-            # ``TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK``), so the validation
-            # surface lifts the AB cap to 6 for structurally identified 16-bit
-            # direct-entry matmuls. The actual (bk, ab, c) tuple is gated by
-            # ``_validate_direct_entry_ab_stage_envelope``;
-            # SEARCH stays capped at 3 (budget-aware) since the generalized seed
-            # runs at ab=3 and deeper pipelines are not worth searching.
-            ab_stages_max = 6 if self.deep_direct_entry_validation_enabled else 3
-            # FP8 (1-byte) operands fit a deeper AB pipeline than the bf16-tuned
-            # cap; admit a frozen deep-staged fp8 config on the validation
-            # surface too (``_validate_direct_entry_ab_stage_envelope`` clamps it to
-            # the actual per-CTA SMEM budget for the chosen block sizes).
+            # Validation admits the dtype's deepest AB pipeline; the depth walk trims it.
             constraints = self.ab_stages_search_constraints
-            if constraints is not None and constraints.dtype_bytes == 1:  # FP8
+            if constraints is None:
+                ab_stages_max = 3
+            else:
                 ab_stages_max = self._get_dtype_ab_stages_hard_cap(
                     constraints.dtype_bytes
                 )
         elif self.ab_stages_search_constraints is not None:
-            # Cycle 97: make ab=3 BUDGET-AWARE-SEARCHABLE. Where the device/dtype
-            # admits ab=3 at all (the SMEM-budget constraints were recorded by
-            # ``allow_ab_stages_search`` at bind time — B200-class optin cap,
-            # bf16/fp16), lift the ``for_search`` cap to 3 so the autotuner can
-            # SAMPLE ab=3 directly instead of reaching it only through the per-shape
-            # FFI / gelu seeds. ``_fix_ab_stages_search_config`` then demotes any
-            # sampled ab=3 that does not fit (the residual/source-C ring overflows;
-            # cluster_m=1 256x256 overflows bare-AB) before codegen, so admission is
-            # free but an overflowing kernel is never generated.
-            ab_stages_max = 3
-            # FP8 (1-byte) operands fit a deeper AB pipeline; widen the
-            # validation range so an explicit deep-staged fp8 config is
-            # accepted (``_validate_direct_entry_ab_stage_envelope`` clamps it to
-            # the actual per-CTA SMEM budget for the chosen block sizes).
             constraints = self.ab_stages_search_constraints
-            if constraints is not None and constraints.dtype_bytes == 1:  # FP8
-                ab_stages_max = self._get_dtype_ab_stages_hard_cap(
-                    constraints.dtype_bytes
-                )
+            ab_stages_max = self._get_dtype_ab_stages_hard_cap(constraints.dtype_bytes)
         else:
             ab_stages_max = 2
         if for_search:
@@ -2321,7 +2357,7 @@ class CuteTcgen05Config:
             # configs. Layout overrides already have a generic validation path
             # below; only the seed/search surface narrows them to its fixed tile.
             tvm_ffi_launch_fragment: ConfigSpecFragment = (
-                EnumFragment((True,)) if for_search else BooleanFragment()
+                EnumFragment((False, True)) if for_search else BooleanFragment()
             )
             fragments.update(
                 {

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -429,6 +429,16 @@ TCGEN05_EXPLICIT_D_STORE_BOX_N = 32
 TCGEN05_DIRECT_ENTRY_SEED_AB_STAGES = 3
 
 TCGEN05_DIRECT_ENTRY_SEED_C_STAGES = 2
+# Candidate order for A5's illegal-``bk`` REPAIR in
+# ``_fix_cluster_m2_search_config`` (item 9). Descending, because a larger K tile
+# means fewer k-iterations and fewer per-stage boundaries, and it is what every
+# cluster_m=2 seed builder picks. This is a PREFERENCE ORDER over candidates, not a
+# legality set -- ``cluster_m2_bk_is_valid`` decides legality, and it enforces both
+# the divisibility/K-tail rule and the ``max_k_tiles`` cap, so a value taken from
+# this tuple is only ever accepted when that predicate already accepts it.
+# Bounded below by the tcgen05 MMA-K minimum (16), so no entry can be smaller than
+# a legal K tile.
+TCGEN05_CLUSTER_M2_REPAIR_BLOCK_K_ORDER: tuple[int, ...] = (256, 128, 64, 32, 16)
 
 
 TCGEN05_DIRECT_ENTRY_LEGAL_BK: frozenset[int] = frozenset({64, 128})

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -15,6 +15,9 @@ from .._compiler.cute.matmul_utils import cute_outer_accumulates_result
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
+from .._compiler.cute.tcgen05_constants import (
+    TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
+)
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
@@ -327,8 +330,13 @@ class CuteTcgen05SearchPlan:
     max_tcgen05_n: int
     max_search_m: int
     max_search_n: int
-    max_search_k: int
+    k_family_divisor: int
     min_search_m: int
+    # Upper bound for the K BlockSizeFragment only. Distinct from
+    # ``k_family_divisor``, which additionally drives the tiling-divisibility
+    # predicates below (full-tile persistent pid types, the cluster_m=2 K cap,
+    # the edge-K-tail family). See ``max_draw_k`` in ``plan_cute_tcgen05_search``.
+    max_draw_k: int
 
 
 def plan_cute_tcgen05_search(
@@ -371,7 +379,16 @@ def plan_cute_tcgen05_search(
     max_tcgen05_m = 256 if max_tcgen05_n >= 128 and static_m >= 256 else 128
     max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
     max_search_n = max_tcgen05_n
-    max_search_k = min(128, pow2_floor_at_least(static_k, mma_k))
+    # The K yardstick for the tiling-divisibility predicates: "does the K axis tile
+    # evenly at the largest tile this shape uses?" It bounds NOTHING searchable —
+    # ``max_draw_k`` below is the K ``BlockSizeFragment``'s ``high``. Named
+    # ``max_search_k`` until 2026-08-01, which read as a search cap and made the
+    # gates that consume it look wrong.
+    k_family_divisor = min(128, pow2_floor_at_least(static_k, mma_k))
+    # ``bk=256`` is DRAWABLE but does not participate in the tiling-divisibility
+    # predicates below. Two separate bounds, because the two jobs pull opposite ways:
+    #
+    max_draw_k = min(256, pow2_floor_at_least(static_k, mma_k))
     min_search_m = 128 if max_tcgen05_m >= 256 else 64
     leading_work_multiplier = 1
     if has_leading_passthrough:
@@ -383,8 +400,13 @@ def plan_cute_tcgen05_search(
             min_search_m = 64
         max_search_m = min(max_search_m, static_m & -static_m)
         max_search_n = min(max_search_n, static_n & -static_n)
-        max_search_k = min(max_search_k, static_k & -static_k)
-        if max_search_m < min_search_m or max_search_n < 8 or max_search_k < mma_k:
+        k_family_divisor = min(k_family_divisor, static_k & -static_k)
+        # The batched tcgen05 path has no K-edge predication, so the draw bound
+        # takes the same largest-power-of-two-divisor clamp as the search bound
+        # here. (This clamp is why ``max_draw_k`` cannot simply be a wider literal:
+        # for a batched shape it must stay a divisor of K.)
+        max_draw_k = min(max_draw_k, static_k & -static_k)
+        if max_search_m < min_search_m or max_search_n < 8 or k_family_divisor < mma_k:
             return None
     if static_m % max_search_m != 0 and static_n % max_search_n != 0:
         max_search_m = min(max_search_m, 128)
@@ -402,8 +424,9 @@ def plan_cute_tcgen05_search(
         max_tcgen05_n=max_tcgen05_n,
         max_search_m=max_search_m,
         max_search_n=max_search_n,
-        max_search_k=max_search_k,
+        k_family_divisor=k_family_divisor,
         min_search_m=min_search_m,
+        max_draw_k=max_draw_k,
     )
 
 
@@ -434,14 +457,14 @@ def enable_cute_tcgen05_search(
     static_k = plan.static_k
     max_search_m = plan.max_search_m
     max_search_n = plan.max_search_n
-    max_search_k = plan.max_search_k
+    k_family_divisor = plan.k_family_divisor
     spec.cute_tcgen05_search_enabled = True
     allow_full_tile_persistent_pid_types = (
         static_m % max_search_m == 0
         and static_n % max_search_n == 0
-        and static_k % max_search_k == 0
+        and static_k % k_family_divisor == 0
     )
-    max_cluster_m2_search_k = TCGEN05_TWO_CTA_MAX_K_TILES * max_search_k
+    max_cluster_m2_search_k = TCGEN05_TWO_CTA_MAX_K_TILES * k_family_divisor
     allow_full_tile_cluster_m2_search = (
         allow_full_tile_persistent_pid_types
         and max_search_m >= TCGEN05_TWO_CTA_BLOCK_M
@@ -459,7 +482,7 @@ def enable_cute_tcgen05_search(
         and static_k <= max_cluster_m2_search_k
         and static_m % TCGEN05_TWO_CTA_BLOCK_M != 0
         and static_n % TCGEN05_TWO_CTA_BLOCK_N != 0
-        and static_k % max_search_k != 0
+        and static_k % k_family_divisor != 0
     )
     allow_fp8_small_grid_cluster_m2_search = (
         not has_leading_passthrough
@@ -482,7 +505,15 @@ def enable_cute_tcgen05_search(
                 cluster_n = TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
             else:
                 cluster_m = TCGEN05_TWO_CTA_BLOCK_M
-                cluster_n = TCGEN05_TWO_CTA_BLOCK_N
+                # Count clusters at the narrowest tile these families can emit
+                # (block_n=128, a 256x128 output tile), not the 256x256 artifact:
+                # bn=128 yields 2x the clusters and fills where a 256x256 cm2 would
+                # underfill. Both non-fp8 families reaching here can emit bn=128
+                # (full-tile: the +8.3% S2 win; edge-K-tail: Stage 2b made its
+                # generic [256,128,128] tile searchable), so bn=128 is the honest
+                # best-fill count for both. fp8-small-grid counts at its own
+                # 128x128 tile in the branch above.
+                cluster_n = TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
             work_clusters = (
                 plan.leading_work_multiplier
                 * (static_m // cluster_m)
@@ -501,10 +532,15 @@ def enable_cute_tcgen05_search(
         ab_stages_device=lhs.device,
         reason="matmul kernel with CuTe tcgen05 backend",
     )
+    # The K axis uses ``max_draw_k`` (up to 256), NOT ``k_family_divisor`` (up to 128):
+    # the fragment bound is what may be DRAWN and climbed around, while
+    # ``k_family_divisor`` additionally drives the tiling-divisibility predicates above
+    # and must stay at the tile width those predicates were written for. See the
+    # ``max_draw_k`` comment in ``plan_cute_tcgen05_search``.
     for axis_name, shape, max_size in (
         ("m", plan.m, max_search_m),
         ("n", plan.n, max_search_n),
-        ("k", plan.k, max_search_k),
+        ("k", plan.k, plan.max_draw_k),
     ):
         block_idx = env.get_block_id(shape)
         if block_idx is None:

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1799,7 +1799,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self,
         configs: list[helion.Config],
         *,
-        expected_block_k: int,
+        expected_block_ks: tuple[int, ...],
         expected_indexing_length: int,
     ) -> dict[str, object]:
         seeded = [
@@ -1807,17 +1807,19 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             for config in configs
             if config.config["tcgen05_cluster_m"] == 2
         ]
-        # FFI-eligible shapes have both DEFAULT-layout and direct-entry seeds.
-        # Callers decide whether both are expected in the supplied population;
-        # every cluster_m=2 seed must still match the common tile envelope.
+        # FFI-eligible shapes have both DEFAULT-layout and direct-entry seeds, and
+        # the two no longer share a K rung: the widened ``bk`` draw bound lets the
+        # DEFAULT-layout seed sit at 256 while the FFI direct-entry seed stays at
+        # its validated 128. Callers decide which K rungs are expected; every
+        # cluster_m=2 seed must still match the common 256x256 tile envelope at one
+        # of them.
         self.assertGreaterEqual(len(seeded), 1)
         for seed in seeded:
-            self.assertEqual(
+            self.assertIn(
                 seed["block_sizes"][:3],
                 [
-                    TCGEN05_TWO_CTA_BLOCK_M,
-                    TCGEN05_TWO_CTA_BLOCK_N,
-                    expected_block_k,
+                    [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, block_k]
+                    for block_k in expected_block_ks
                 ],
             )
             self.assertEqual(
@@ -1836,6 +1838,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         expected_l2_swizzle_size: int | None = (
             TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE
         ),
+        expect_placement_keys: bool = True,
     ) -> None:
         self.assertEqual(
             config["tcgen05_ab_stages"],
@@ -1866,14 +1869,21 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 config["tcgen05_l2_swizzle_size"],
                 expected_l2_swizzle_size,
             )
-        self.assertEqual(
-            config[TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY],
-            TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP,
-        )
-        self.assertEqual(
-            config[TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY],
-            TCGEN05_C_ACQUIRE_PLACEMENT_FIRST_IN_LOOP,
-        )
+        # The two placement keys are diagnostic-only: they have no flat slot, so a
+        # RAW seed carries them but a seed that has round-tripped through
+        # flatten/unflatten no longer does (the fixup no longer re-imposes them).
+        if expect_placement_keys:
+            self.assertEqual(
+                config[TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY],
+                TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP,
+            )
+            self.assertEqual(
+                config[TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY],
+                TCGEN05_C_ACQUIRE_PLACEMENT_FIRST_IN_LOOP,
+            )
+        else:
+            self.assertNotIn(TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY, config)
+            self.assertNotIn(TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY, config)
 
     def _expected_clc_aux_tma_range_knobs(
         self, spec: ConfigSpec
@@ -1943,7 +1953,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             assert seed_config is not None
             self._assert_cute_tcgen05_cluster_m2_seeded(
                 [seed_config],
-                expected_block_k=128,
+                # The DEFAULT-layout direct seed now rides the widened bk bound at 256.
+                expected_block_ks=(256,),
                 expected_indexing_length=3,
             )
             self.assertEqual(
@@ -3273,12 +3284,13 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             for_search=True
         )["tcgen05_ab_stages"]
         self.assertIsInstance(search_ab_stages_fragment, IntegerFragment)
-        # Cycle 97: the for_search ab cap is BUDGET-AWARE — lifted to 3 wherever
-        # ab=3 is admissible (the SMEM-budget constraints were recorded at bind
-        # time, i.e. bf16/fp16 on a B200-class optin cap), else 2. Conditioning on
-        # the recorded constraints keeps the assertion deterministic across hosts.
+        # Cycle 97: the for_search ab cap is BUDGET-AWARE — lifted to the 16-bit
+        # dtype hard cap of 6 wherever a deep AB ring is admissible (the SMEM-budget
+        # constraints were recorded at bind time, i.e. bf16/fp16 on a B200-class
+        # optin cap), else 2. Conditioning on the recorded constraints keeps the
+        # assertion deterministic across hosts.
         expected_search_ab_high = (
-            3
+            6
             if bound.config_spec._cute_tcgen05_config.ab_stages_search_constraints
             is not None
             else 2
@@ -3723,21 +3735,28 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         ):
             projected_wide_clc_aux_tma_config.pop(key, None)
         spec._cute_tcgen05_config.fix_search_config(projected_wide_clc_aux_tma_config)
+        # bn=64 settles DOWN to the nearest validated rung (128) and the illegal
+        # bk=64 is repaired to the NEAREST legal value (128).
         self.assertEqual(
             projected_wide_clc_aux_tma_config["block_sizes"][:3],
             [
                 TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
+        # The measured CLC aux-TMA perf ROW is carried by the wide-N SEED (asserted
+        # above) and is no longer re-imposed on a drawn candidate, so the mutated l2
+        # grouping / acc depth / range knobs stay as they were set. Only
+        # ``scheduler_warps`` is still DERIVED, because it is strategy-determined (a
+        # biconditional, not a tuned value).
         self.assertEqual(
             projected_wide_clc_aux_tma_config["l2_groupings"],
-            [TCGEN05_TWO_CTA_EDGE_K_TAIL_CLC_AUX_TMA_L2_GROUPING],
+            [TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_GROUPING],
         )
         self.assertEqual(
             projected_wide_clc_aux_tma_config["tcgen05_acc_stages"],
-            TCGEN05_TWO_CTA_EDGE_K_TAIL_CLC_AUX_TMA_ACC_STAGES,
+            TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES,
         )
         self.assertEqual(
             projected_wide_clc_aux_tma_config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY],
@@ -3747,18 +3766,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             projected_wide_clc_aux_tma_config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY],
             1,
         )
-        self.assertEqual(
-            projected_wide_clc_aux_tma_config["range_flattens"],
-            expected_clc_aux_tma_range_flattens,
-        )
-        self.assertEqual(
-            projected_wide_clc_aux_tma_config["range_multi_buffers"],
-            expected_clc_aux_tma_range_multi_buffers,
-        )
-        self.assertEqual(
-            projected_wide_clc_aux_tma_config["range_warp_specializes"],
-            expected_clc_aux_tma_range_warp_specializes,
-        )
+        self.assertNotIn("range_flattens", projected_wide_clc_aux_tma_config)
+        self.assertNotIn("range_multi_buffers", projected_wide_clc_aux_tma_config)
+        self.assertNotIn("range_warp_specializes", projected_wide_clc_aux_tma_config)
         for flat_seed, _normalized_seed in seed_pairs:
             config_gen.encode_config(flat_seed)
         persistence_indices, _ = config_gen._key_to_flat_indices[
@@ -3865,19 +3875,23 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         # instead. (The scheduler / aux-TMA arms below are unaffected: their own
         # seed builders set the swizzle.)
         self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
-            normalized_seed, expected_l2_swizzle_size=1
+            normalized_seed,
+            expected_l2_swizzle_size=1,
+            expect_placement_keys=False,
         )
         self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
             normalized_scheduler_seed,
             expected_l2_swizzle_size=(
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE
             ),
+            expect_placement_keys=False,
         )
         self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
             normalized_aux_tma_seed,
             expected_l2_swizzle_size=(
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE
             ),
+            expect_placement_keys=False,
         )
         self.assertEqual(
             normalized_aux_tma_seed[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY],
@@ -3891,17 +3905,21 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             normalized_wide_clc_aux_tma_seed["tcgen05_acc_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_CLC_AUX_TMA_ACC_STAGES,
         )
+        # The K-range knob triple has NO flat slot on the tcgen05 path, so it cannot
+        # survive the flatten/unflatten round trip now that normalize no longer
+        # re-imposes the CLC aux-TMA perf row. The RAW seed asserted above still
+        # carries it; the normalized seed reads neutral.
         self.assertEqual(
             normalized_wide_clc_aux_tma_seed["range_flattens"],
-            expected_clc_aux_tma_range_flattens,
+            [None] * len(expected_clc_aux_tma_range_flattens),
         )
         self.assertEqual(
             normalized_wide_clc_aux_tma_seed["range_multi_buffers"],
-            expected_clc_aux_tma_range_multi_buffers,
+            [None] * len(expected_clc_aux_tma_range_multi_buffers),
         )
         self.assertEqual(
             normalized_wide_clc_aux_tma_seed["range_warp_specializes"],
-            expected_clc_aux_tma_range_warp_specializes,
+            [None] * len(expected_clc_aux_tma_range_warp_specializes),
         )
         normalized_narrow_clc_aux_tma_seed = next(
             config
@@ -3926,15 +3944,15 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         self.assertEqual(
             normalized_narrow_clc_aux_tma_seed["range_flattens"],
-            expected_clc_aux_tma_range_flattens,
+            [None] * len(expected_clc_aux_tma_range_flattens),
         )
         self.assertEqual(
             normalized_narrow_clc_aux_tma_seed["range_multi_buffers"],
-            expected_clc_aux_tma_range_multi_buffers,
+            [None] * len(expected_clc_aux_tma_range_multi_buffers),
         )
         self.assertEqual(
             normalized_narrow_clc_aux_tma_seed["range_warp_specializes"],
-            expected_clc_aux_tma_range_warp_specializes,
+            [None] * len(expected_clc_aux_tma_range_warp_specializes),
         )
         self.assertEqual(
             normalized_narrow_clc_aux_tma_seed[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY],
@@ -3997,7 +4015,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         # 1, not the tuned 4 -- same cause as ``normalized_seed`` above: the
         # monolithic arm's swizzle came from the deleted projection.
         self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
-            population_seed, expected_l2_swizzle_size=1
+            population_seed,
+            expected_l2_swizzle_size=1,
+            expect_placement_keys=False,
         )
         self.assertTrue(
             any(
@@ -4120,29 +4140,36 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             minimal_preprojection_clc_aux_tma_config,
             _fix_invalid=True,
         )
+        # bn=64 settles DOWN to the nearest validated rung (128, not 256) and the
+        # illegal bk=64 is repaired to the NEAREST legal value (128).
         self.assertEqual(
             minimal_preprojection_clc_aux_tma_config["block_sizes"][:3],
             [
                 TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
-        self.assertEqual(
-            minimal_preprojection_clc_aux_tma_config["l2_groupings"],
-            [TCGEN05_TWO_CTA_EDGE_K_TAIL_CLC_AUX_TMA_L2_GROUPING],
-        )
+        # The measured CLC aux-TMA perf ROW (l2_grouping=8 plus the K-range
+        # flatten/multi-buffer/warp-specialize triple) is no longer projected onto a
+        # drawn candidate -- ``_fix_cluster_m2_search_config`` completes a request
+        # rather than enumerating the tuples it recognizes -- so this candidate keeps
+        # its own (default) l2 grouping and neutral range knobs. The row still enters
+        # the population as the wide-N/narrow-N SEEDS asserted in the edge/K-tail test.
+        self.assertEqual(minimal_preprojection_clc_aux_tma_config["l2_groupings"], [1])
+        neutral_range_knobs = [None] * len(expected_clc_aux_tma_range_flattens)
+        self.assertNotEqual(neutral_range_knobs, expected_clc_aux_tma_range_flattens)
         self.assertEqual(
             minimal_preprojection_clc_aux_tma_config["range_flattens"],
-            expected_clc_aux_tma_range_flattens,
+            neutral_range_knobs,
         )
         self.assertEqual(
             minimal_preprojection_clc_aux_tma_config["range_multi_buffers"],
-            expected_clc_aux_tma_range_multi_buffers,
+            [None] * len(expected_clc_aux_tma_range_multi_buffers),
         )
         self.assertEqual(
             minimal_preprojection_clc_aux_tma_config["range_warp_specializes"],
-            expected_clc_aux_tma_range_warp_specializes,
+            [None] * len(expected_clc_aux_tma_range_warp_specializes),
         )
         unresolved_range_clc_aux_tma_config = (
             make_minimal_preprojection_clc_aux_tma_config()
@@ -4156,10 +4183,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 unresolved_range_clc_aux_tma_config,
                 _fix_invalid=True,
             )
-        self.assertEqual(
-            unresolved_range_clc_aux_tma_config["l2_groupings"],
-            [TCGEN05_TWO_CTA_EDGE_K_TAIL_CLC_AUX_TMA_L2_GROUPING],
-        )
+        self.assertEqual(unresolved_range_clc_aux_tma_config["l2_groupings"], [1])
         self.assertNotIn("range_flattens", unresolved_range_clc_aux_tma_config)
         self.assertNotIn("range_multi_buffers", unresolved_range_clc_aux_tma_config)
         self.assertNotIn("range_warp_specializes", unresolved_range_clc_aux_tma_config)
@@ -4182,11 +4206,13 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             TCGEN05_AUX_LOAD_MODE_TMA
         )
         bound.config_spec.normalize(narrow_invalid_cluster_n_config, _fix_invalid=True)
+        # bn=128 is a validated rung of its own now, so the tile is left alone; only
+        # the illegal cluster_n=2 costs this candidate its clc_persistent model.
         self.assertEqual(
             narrow_invalid_cluster_n_config["block_sizes"][:3],
             [
                 TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
@@ -4300,17 +4326,24 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             ),
         }
         spec.normalize(narrow_config, _fix_invalid=True)
+        # block_n now settles to the NEAREST validated rung, so a drawn bn=128
+        # STAYS at 128 (both 128 and 256 are hardware-legal at cluster_m=2); only
+        # the narrow-N SEED is kept out of this family, checked above.
         self.assertEqual(
             narrow_config["block_sizes"][:3],
             [
                 TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
+        # The drawn ``clc_persistent`` does NOT stand on this candidate: the CLC
+        # persistence admission still keys on the wide-N edge row, so a narrow-N
+        # tile is rolled back to the plain static-persistent model. (The narrow-N
+        # CLC aux-TMA row reaches the population as a seed instead.)
         self.assertEqual(
             narrow_config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY],
-            Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+            Tcgen05PersistenceModel.STATIC_PERSISTENT.value,
         )
 
     @onlyBackends(["cute"])
@@ -5018,11 +5051,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertTrue(residual_tcfg.aux_kernel_detected)
         self.assertTrue(residual_tcfg.exact_shape_aux_kernel_detected)
 
-        # The for_search ab fragment is lifted to 3 (the budget was recorded at
-        # bind via the mocked B200 cap) for every family.
+        # The for_search ab fragment is lifted to the 16-bit dtype hard cap of 6
+        # (the budget was recorded at bind via the mocked B200 cap) for every
+        # family; the per-tile budget gate trims a drawn depth that does not fit.
         for tcfg in (plain_tcfg, bias_tcfg, residual_tcfg):
             ab_fragment = tcfg.optional_fragments(for_search=True)["tcgen05_ab_stages"]
-            self.assertEqual(ab_fragment.high, 3)
+            self.assertEqual(ab_fragment.high, 6)
 
         def _ab3_config(cluster_m: int = 2) -> helion.Config:
             return helion.Config(
@@ -5203,11 +5237,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
 
         self.assertEqual(config_dict["tcgen05_cluster_m"], 2)
         self.assertEqual(config_dict["pid_type"], "persistent_interleaved")
+        # The drawn bn=128 settles to the nearest validated rung, i.e. stays 128.
         self.assertEqual(
             config_dict["block_sizes"][:3],
             [
                 TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
@@ -5215,12 +5250,23 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             config_dict["tcgen05_ab_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES,
         )
-        # ``tcgen05_l2_swizzle_size`` is no longer written onto a drawn candidate in
-        # this family: the deleted FFI/layout projection was its only writer on the
-        # monolithic arm, so the key stays absent.
-        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
-            config_dict, expected_l2_swizzle_size=None
+        # The edge/K-tail perf regime is no longer IMPOSED on a drawn candidate (the
+        # stage completes a cluster_m=2 request rather than enumerating the tuples it
+        # recognizes), so this config keeps the pipeline knobs and the L2 grouping it
+        # drew, and gains no placement keys.
+        self.assertEqual(
+            config_dict["tcgen05_acc_stages"],
+            TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES,
         )
+        self.assertEqual(
+            config_dict["tcgen05_c_stages"],
+            TCGEN05_TWO_CTA_EDGE_K_TAIL_C_STAGES,
+        )
+        self.assertEqual(
+            config_dict["l2_groupings"], [TCGEN05_TWO_CTA_SEED_L2_GROUPING]
+        )
+        self.assertNotIn(TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY, config_dict)
+        self.assertNotIn(TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY, config_dict)
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_two_cta_seeded_in_initial_populations(self) -> None:
@@ -5268,7 +5314,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         seeded_configs = config_gen.random_population(3)
         self._assert_cute_tcgen05_cluster_m2_seeded(
             seeded_configs,
-            expected_block_k=128,
+            expected_block_ks=(128, 256),
             expected_indexing_length=3,
         )
         expected_seed_modes = {
@@ -5303,7 +5349,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         self._assert_cute_tcgen05_cluster_m2_seeded(
             acf_seed_configs,
-            expected_block_k=128,
+            expected_block_ks=(128, 256),
             expected_indexing_length=3,
         )
 
@@ -5326,7 +5372,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertGreaterEqual(len(configs), 2)
         self._assert_cute_tcgen05_cluster_m2_seeded(
             configs,
-            expected_block_k=128,
+            expected_block_ks=(128, 256),
             expected_indexing_length=3,
         )
         best_available_modes = {

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6181,7 +6181,11 @@ class TestCuteBackend(TestCase):
                 "tcgen05_cluster_m": 2,
             }
             bound.config_spec.normalize(projected, _fix_invalid=True)
-            self.assertEqual(projected["block_sizes"], [1, 256, 256, 64])
+            # The generic DEFAULT-layout bn=128 cluster_m=2 tile is searchable for
+            # the batched leading-passthrough family now, so the sampled block_n=128
+            # (index 2) SURVIVES at 128 instead of snapping to the canonical 256.
+            # block_m (index 1) is still pinned to 256.
+            self.assertEqual(projected["block_sizes"], [1, 256, 128, 64])
             self.assertEqual(projected["pid_type"], "persistent_interleaved")
 
             def search_spec(m: int, n: int, k: int) -> ConfigSpec:
@@ -6236,8 +6240,19 @@ class TestCuteBackend(TestCase):
             "helion.language.matmul_ops._cuda_num_sms_or_zero",
             return_value=148,
         ):
-            self.assertEqual(cluster_choices(32), (1,))
-            self.assertEqual(cluster_choices(64), (1, 2))
+            # The wave-quant gate multiplies the per-batch output-cluster count
+            # by the batch (``leading_work_multiplier``); cluster_m=2 search is
+            # only admitted once that product clears ``num_sms // 4`` (= 37).
+            # The batched leading-passthrough family searches a bn=128 cluster_m=2
+            # tile now, so the count is taken at the narrow tile (256x128 ->
+            # 256//256 * 256//128 = 2 clusters per batch), moving the threshold to
+            # batch >= 19 (2 * 19 = 38 >= 37). A small batch that underfills stays
+            # cluster_m=1; a large batch enables cluster_m=2.
+            # If the batch factor were NOT counted the product would be a
+            # batch-independent 2 and cluster_m=2 would never enable -- so this
+            # boundary is what proves batch clusters are counted.
+            self.assertEqual(cluster_choices(16), (1,))
+            self.assertEqual(cluster_choices(32), (1, 2))
 
     def test_batched_direct_entry_seeds_match_epilogue_support(self) -> None:
         support = get_cute_mma_support()

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -205,9 +205,6 @@ from helion._compiler.cute.tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFI
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES,
 )
-from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES,
-)
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_C_STAGES
 from helion._compiler.cute.tcgen05_constants import (
@@ -215,6 +212,9 @@ from helion._compiler.cute.tcgen05_constants import (
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE,
@@ -18266,7 +18266,11 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             bound = kernel.bind(args)
         spec = bound.env.config_spec
         self.assertTrue(spec.cute_tcgen05_aux_kernel_detected)
-        self.assertEqual([item.max_size for item in spec.block_sizes], [128, 256, 128])
+        # bk DRAW bound is 256 (pretuned entries exist at bk=256, and a bound of
+        # 128 makes a seeded bk=256 a one-way dead end for the hill-climber). The
+        # tiling-divisibility gates keep the 128-based value, so the edge-family
+        # admission below is unaffected.
+        self.assertEqual([item.max_size for item in spec.block_sizes], [128, 256, 256])
 
         config_dict: dict[str, object] = {
             "block_sizes": [256, 256, 128],
@@ -18343,9 +18347,18 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             cluster_m2_config["tcgen05_ab_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES,
         )
+        # ⚠ THE EDGE/K-TAIL PERF ROW IS NO LONGER IMPOSED ON A DRAWN CANDIDATE.
+        # ``_fix_cluster_m2_search_config`` used to close with
+        # ``config.update(tcgen05_two_cta_edge_k_tail_seed_overrides())`` plus the
+        # aux-edge / CLC prefixes -- a 6-key blanket write of measured throughput
+        # values onto every cluster_m=2 candidate in this family. The stage now
+        # COMPLETES a cluster_m=2 request (legality only) instead of enumerating the
+        # tuples it recognizes, so the drawn pipeline knobs and the drawn placement
+        # keys SURVIVE. The measured row is still in the population, as a seed.
         self.assertEqual(
             cluster_m2_config["tcgen05_acc_stages"],
-            TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES,
+            2,
+            msg="the drawn acc_stages was re-projected onto the edge perf row",
         )
         self.assertEqual(
             cluster_m2_config["tcgen05_c_stages"],
@@ -18353,19 +18366,23 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         )
         self.assertEqual(
             cluster_m2_config[TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY],
-            TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP,
+            TCGEN05_ACC_WAIT_PLACEMENT_SUBTILE_LOOP,
         )
         self.assertEqual(
             cluster_m2_config[TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY],
-            TCGEN05_C_ACQUIRE_PLACEMENT_FIRST_IN_LOOP,
+            TCGEN05_C_ACQUIRE_PLACEMENT_PRE_LOOP,
         )
+        # ``l2_swizzle_size`` is the ONE key still projected here, by
+        # ``_set_aux_edge_prefix``'s scheduler correction rather than by the deleted
+        # blanket dict, so the drawn 8 still lands on the scheduler value.
         self.assertEqual(
             cluster_m2_config["tcgen05_l2_swizzle_size"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE,
         )
         self.assertEqual(
             cluster_m2_config["l2_groupings"],
-            [TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_GROUPING],
+            [4],
+            msg="the drawn l2_groupings was re-projected onto the edge perf row",
         )
         self.assertEqual(
             cluster_m2_config["indexing"],
@@ -18426,37 +18443,47 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             config_dict["tcgen05_ab_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES,
         )
+        # ⚠ THE FOUR PROJECTED-VALUE ASSERTIONS BECAME SURVIVAL ASSERTIONS. They
+        # required the 6-key blanket
+        # ``config.update(tcgen05_two_cta_edge_k_tail_seed_overrides())`` to have
+        # rewritten this DRAWN config onto the measured WIDE-N edge row:
+        # ``acc_stages`` 2 -> 1, ``l2_groupings``, ``l2_swizzle_size``, and the two
+        # ``*_placement`` keys added from scratch. The drawn ``block_n=128`` now
+        # settles as its OWN valid cluster_m=2 tile instead of snapping to 256, so
+        # this candidate is no longer in the wide-N row's scope and keeps what it
+        # drew. The measured row is still in the population, as a seed.
         self.assertEqual(
             config_dict["tcgen05_acc_stages"],
-            TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES,
+            2,
+            msg="the drawn acc_stages was re-projected onto the wide-N edge row",
         )
         self.assertEqual(
             config_dict["tcgen05_c_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_C_STAGES,
         )
-        self.assertEqual(
-            config_dict[TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY],
-            TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP,
-        )
-        self.assertEqual(
-            config_dict[TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY],
-            TCGEN05_C_ACQUIRE_PLACEMENT_FIRST_IN_LOOP,
-        )
-        self.assertEqual(
-            config_dict["tcgen05_l2_swizzle_size"],
-            TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE,
-        )
+        self.assertNotIn(TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY, config_dict)
+        self.assertNotIn(TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY, config_dict)
+        # The drawn swizzle (8) and grouping ([4]) survive for the same reason.
+        self.assertEqual(config_dict["tcgen05_l2_swizzle_size"], 8)
         self.assertEqual(
             config_dict["l2_groupings"],
-            [TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_GROUPING],
+            [4],
+            msg="the drawn l2_groupings was re-projected onto the wide-N edge row",
         )
         self.assertEqual(
             config_dict["indexing"],
             ["tensor_descriptor"] * spec.indexing.length,
         )
+        # A sampled block_n=128 survives as its own valid cm2 tile for the
+        # edge-K-tail family (block_m still pinned to 256), instead of snapping to
+        # the canonical block_n=256.
         self.assertEqual(
             config_dict["block_sizes"],
-            [256, 256, TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K],
+            [
+                256,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
+            ],
         )
         self.assertEqual(config_dict["pid_type"], "persistent_interleaved")
         self.assertNotIn("epilogue_subtile", config_dict)

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -346,9 +346,14 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             bound = cute_matmul_mma.bind(args)
         spec = bound.config_spec
         self.assertEqual([x.min_size for x in spec.block_sizes], [128, 8, 16])
-        # tile_k upper bound is now 128 (the static_k=8192 case; capped at 128
-        # to keep AB SMEM staging budget sane).
-        self.assertEqual([x.max_size for x in spec.block_sizes], [256, 256, 128])
+        # tile_k DRAW bound is 256: the compiler ships pretuned entries at bk=256
+        # that its own search could not otherwise reach, and with a bound of 128 a
+        # seeded bk=256 is a one-way dead end for the hill-climber
+        # (``pattern_neighbors(256)`` clamps to ``[128]``). Per-tile SMEM is what
+        # actually bounds bk, and it is enforced downstream. Note this is the DRAW
+        # bound only: the tiling-divisibility gates keep the old 128-based value,
+        # so cluster_m=2 eligibility and the persistent pid types do not move.
+        self.assertEqual([x.max_size for x in spec.block_sizes], [256, 256, 256])
         default_block_sizes = spec.default_config().config["block_sizes"]
         self.assertGreaterEqual(default_block_sizes[2], 16)
         self.assertLessEqual(default_block_sizes[2], 128)
@@ -366,14 +371,38 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         # only the default itself moved back to cluster_m=1.
         self.assertEqual(spec.default_config().config["tcgen05_cluster_m"], 1)
         self.assertEqual(spec._tcgen05_cluster_m_search_choices, (1, 2))
+        # An over-K-tile-cap ``bk`` is now REPAIRED, not demoted. ``bk=16`` at
+        # K=8192 needs 512 K-tiles against a 256 cap, so the stage used to answer
+        # "not a legal cluster_m=2 bk" by setting cluster_m=1 -- which additionally
+        # cost the tile, because the cluster_m=1 clamp then pinned ``bm`` to 128
+        # (measured: this config came out as ``[128,256,256] cm1``). The stage snaps
+        # ``bk`` to a legal value instead, and keeps the tile.
+        #
+        # The repaired value is the NEAREST legal ``bk``, not the largest: at K=8192
+        # the legal set is {32, 64, 128, 256} and ``bk=32`` gives exactly 256
+        # K-tiles, right at the cap. So this asserts the repair POLICY, not
+        # legality -- nearest-legal moves the key as little as possible.
+        #
+        # THE CAP ITSELF IS UNCHANGED AND STILL BINDING -- it is enforced inside
+        # ``cluster_m2_bk_is_valid``, which the repair consults, so the repaired
+        # value satisfies it by construction whichever candidate is chosen.
         over_cap_config = {
             "block_sizes": [256, 256, 16],
             "pid_type": "flat",
             "tcgen05_cluster_m": 2,
         }
         spec.normalize(over_cap_config, _fix_invalid=True)
-        self.assertEqual(over_cap_config["tcgen05_cluster_m"], 1)
-        self.assertEqual(over_cap_config["pid_type"], "flat")
+        self.assertEqual(over_cap_config["tcgen05_cluster_m"], 2)
+        self.assertEqual(over_cap_config["pid_type"], "persistent_interleaved")
+        over_cap_block_sizes = cast("list[int]", over_cap_config["block_sizes"])
+        self.assertEqual(over_cap_block_sizes[2], 32)
+        cluster_m2_constraints = spec._tcgen05_cluster_m2_search_constraints
+        assert cluster_m2_constraints is not None
+        self.assertLessEqual(
+            -(-cluster_m2_constraints.static_k // over_cap_block_sizes[2]),
+            cluster_m2_constraints.max_k_tiles,
+            msg=f"repair broke the K-tile cap: {over_cap_config}",
+        )
         valid_config = {
             "block_sizes": [128, 256, 32],
             "pid_type": "flat",
@@ -468,25 +497,64 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(config["l2_groupings"], [1])
         self.assertIs(config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY], False)
 
-        # ── AN EXPLICIT FFI REQUEST IS NO LONGER PROJECTED ONTO THE SEED ──
+        # ── ``tvm_ffi_launch=True`` NO LONGER PROJECTS ONTO THE SEED ──
         #
-        # These subtests used to assert the opposite: whatever pid_type / bk /
+        # These five subtests used to assert the opposite: whatever pid_type / bk /
         # l2_grouping was asked for, an ``ffi=True`` config came back as the seed's
-        # ``[256,256,128]`` tile with the seed's ``l2=[2]``. Repairing a partial
-        # request ONTO the seed is exactly what this commit stops doing, so the
-        # drawn ``bk`` and ``l2_groupings`` SURVIVE.
+        # ``[256,256,128] / l2=[2] / persistent_interleaved``. That behaviour was
+        # correct only while the flag was undrawable (``search_choices=(False,)``), so
+        # a True could only be a deliberate, partial request.
         #
-        # ``bm``/``bn`` still move, but that is a DIFFERENT stage
-        # (``_fix_cluster_m2_search_config``) snapping the tile onto the validated
-        # CtaGroup.TWO envelope, and it is unchanged here -- which is why the
-        # expected tile below is the 256x256 envelope carrying the REQUESTED bk
-        # rather than the seed's 128.
-        for override in (
-            {"pid_type": "flat"},
-            {"block_sizes": [128, 256, 16]},
-            {"block_sizes": [256, 128, 16]},
-            {"l2_groupings": [16]},
-            {"pid_type": "persistent_interleaved"},
+        # The flag is now a FREE SEARCH AXIS, and the projection is what made that
+        # worthless: measured, with the flag un-clamped and the projection still in
+        # place, 300 draws collapsed to **152 distinct** configs, the ~150 ``ffi=True``
+        # draws landing on ~2. The flag has no codegen dependencies *within* the
+        # tcgen05 family (bit-exact on 5 varied configs, and on 20 of the 30 sampled
+        # newly-reachable draws below), so there is nothing about an ``ffi=True``
+        # config on its own tile to repair.
+        #
+        # What IS enforced is the flag's one real precondition, per-config and at the
+        # END of the pipeline: the config must lower on the tcgen05 path, or
+        # ``cute/backend.py`` raises when it emits ``--enable-tvm-ffi``. So the
+        # assertions invert: the drawn tile SURVIVES, and the flag survives with it
+        # when the tile is tcgen05-emittable.
+        for override, tcgen05_emittable in (
+            ({"pid_type": "flat"}, True),
+            ({"block_sizes": [128, 256, 16]}, True),
+            ({"block_sizes": [256, 128, 16]}, True),
+            ({"l2_groupings": [16]}, True),
+            ({"pid_type": "persistent_interleaved"}, True),
+            # ⚠ THE OLD NEGATIVE WITNESS WAS RETIRED HERE (2026-08-07), and this comment
+            # block is why. It was ``[256,64,256]`` at ``cluster_m=1, pid_type='flat'``,
+            # expecting the flag CLEARED because that tile is not tcgen05-emittable
+            # (``bn=64`` with ``bk=256`` fails ``_mma_impl_matches_problem_shape``).
+            #
+            # The comment that used to sit here spelled out the mechanism it depended on:
+            # "``pid_type='flat'`` is load-bearing, not decoration: at
+            # ``persistent_blocked`` the cluster_m=1 persistent clamp rewrites bm
+            # 256 -> 128, and ``[128,64,256]`` IS emittable, so the flag correctly
+            # SURVIVES there." Exactly so — and the clamp is no longer gated on a
+            # persistent ``pid_type``, because that gate was letting ``bm=256 ∧
+            # cluster_m=1`` reach codegen on the non-tensor-core ``universal`` scalar
+            # path (~1500-2000x slower, silently, on 6.8-8.8% of draws across six
+            # measured shapes). So ``flat`` now takes the same clamp, the final tile is
+            # ``[128,64,256]``, and the flag correctly survives.
+            #
+            # The negative polarity did not disappear — it moved to
+            # ``test_cute_tcgen05_tvm_ffi_launch_is_a_free_searchable_axis``, which drives
+            # stage 10 directly on an off-envelope FINAL tile. That is the honest home
+            # for it: the property is "stage 10 clears the flag on a non-emittable final
+            # tile", and after the clamp NO drawable ``cluster_m=1`` tile on this shape is
+            # non-emittable (probed 10/10), so the public-``normalize`` route can no
+            # longer construct the witness at all.
+            (
+                {
+                    "block_sizes": [256, 64, 256],
+                    "tcgen05_cluster_m": 1,
+                    "pid_type": "flat",
+                },
+                True,
+            ),
         ):
             with self.subTest(override=override):
                 config = {
@@ -497,24 +565,57 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                     TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
                     **override,
                 }
+                requested_tile = list(cast("list[int]", config["block_sizes"]))
                 requested_l2 = list(cast("list[int]", config["l2_groupings"]))
-                requested_bk = cast("list[int]", config["block_sizes"])[2]
                 spec.normalize(config, _fix_invalid=True)
-                self.assertEqual(config["tcgen05_cluster_m"], 2)
-                self.assertEqual(config["pid_type"], "persistent_interleaved")
-                self.assertEqual(
-                    config["block_sizes"][:3],
-                    [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, requested_bk],
-                )
-                self.assertEqual(
-                    config["l2_groupings"],
-                    requested_l2,
+                self.assertIs(
+                    config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY],
+                    tcgen05_emittable,
                     msg=(
-                        "the FFI stage overwrote l2_groupings; a launch flag has no "
-                        "business touching the scheduler grouping"
+                        "tvm_ffi_launch must survive on a tcgen05-emittable tile and "
+                        "be cleared otherwise -- it is a free axis with exactly one "
+                        "precondition"
                     ),
                 )
-                self.assertIs(config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY], True)
+                if config["tcgen05_cluster_m"] == 2:
+                    # The cluster_m=2 shaping still owns the tile (bm=256, bn snapped
+                    # to {128,256}, bk pinned on the edge family) -- that is a
+                    # different stage and is unchanged here. What must NOT happen is
+                    # the FFI stage overwriting l2_groupings with the seed's value.
+                    self.assertEqual(
+                        config["l2_groupings"],
+                        requested_l2,
+                        msg=(
+                            f"the FFI stage overwrote l2_groupings "
+                            f"{requested_l2} -> {config['l2_groupings']}; a launch "
+                            f"flag has no business touching the scheduler grouping"
+                        ),
+                    )
+                else:
+                    # ⚠ ``bm`` is EXEMPT from this check at cluster_m=1 (2026-08-07).
+                    # The property under test is "the FFI/layout stage did not overwrite
+                    # the drawn tile", but ``_fix_cluster_m1_persistent_search_config``
+                    # (a DIFFERENT stage, and the one whose whole job this is) clamps
+                    # ``bm`` to ``TCGEN05_ONE_CTA_MAX_BLOCK_M`` on every cluster_m=1
+                    # candidate — it used to skip non-persistent ``pid_type`` values,
+                    # which is exactly the defect that let ``bm=256 ∧ cluster_m=1`` reach
+                    # the non-tensor-core ``universal`` path. Asserting the full tile here
+                    # would re-pin that hole from a test whose subject is a different
+                    # stage. ``bn``/``bk`` are still asserted, which is what the FFI stage
+                    # could plausibly touch.
+                    self.assertEqual(
+                        config["block_sizes"][1:3],
+                        requested_tile[1:3],
+                        msg="the FFI stage overwrote the drawn bn/bk",
+                    )
+                    self.assertLessEqual(
+                        cast("list[int]", config["block_sizes"])[0],
+                        TCGEN05_ONE_CTA_MAX_BLOCK_M,
+                        msg=(
+                            "bm exceeds the CtaGroup.ONE cap at cluster_m=1, so codegen "
+                            "will silently emit the non-tensor-core 'universal' path"
+                        ),
+                    )
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_small_shape_wave_quantization_gate(self) -> None:
@@ -803,13 +904,40 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                     [TCGEN05_ONE_CTA_MAX_BLOCK_M, 32, 16],
                 )
 
-        flat_config = {
-            "block_sizes": [256, 32, 16],
-            "pid_type": "flat",
-            "tcgen05_cluster_m": 1,
-        }
-        spec.normalize(flat_config, _fix_invalid=True)
-        self.assertEqual(flat_config["block_sizes"][:3], [256, 32, 16])
+        # ⚠ THE NON-PERSISTENT ARM IS NOW CLAMPED TOO. This block used to assert
+        # ``[256, 32, 16]`` survives at ``pid_type='flat'`` — i.e. it PINNED the
+        # defect. ``bm=256`` at ``cluster_m=1`` fails
+        # ``_mma_impl_matches_problem_shape`` (which admits ``bm in {64,128}``, or
+        # ``bm==256`` only with ``cluster_m==2``), so ``_choose_mma_impl`` fell
+        # through to the non-tensor-core ``universal`` scalar path: numerically
+        # correct, ~1500-2000x slower, and emitted with NO warning (the
+        # SMEM-downgrade warning is gated on ``tcgen05_ok``, which that path never
+        # reaches).
+        #
+        # The clamp itself was always correct; the STAGE was gated on a persistent
+        # ``pid_type``, so it never ran on these. That gate term is gone. ``xyz``
+        # behaves identically to ``flat`` (both non-persistent), which is why the
+        # hazard is stated as "non-persistent" rather than "flat".
+        for non_persistent_pid in ("flat", "xyz"):
+            with self.subTest(pid_type=non_persistent_pid):
+                non_persistent_config = {
+                    "block_sizes": [256, 32, 16],
+                    "pid_type": non_persistent_pid,
+                    "tcgen05_cluster_m": 1,
+                }
+                spec.normalize(non_persistent_config, _fix_invalid=True)
+                self.assertEqual(
+                    non_persistent_config["block_sizes"][:3],
+                    [TCGEN05_ONE_CTA_MAX_BLOCK_M, 32, 16],
+                    msg=(
+                        f"bm=256 at cluster_m=1 with pid_type={non_persistent_pid!r} was "
+                        "not clamped, so codegen will silently emit the non-tensor-core "
+                        "'universal' scalar path (~1500-2000x slower)"
+                    ),
+                )
+                # The redirect in clamp (2) is scoped to the persistent enum, so a
+                # non-persistent pid_type is left exactly as drawn.
+                self.assertEqual(non_persistent_config["pid_type"], non_persistent_pid)
 
         two_cta_config = {
             "block_sizes": [256, 32, 16],
@@ -820,8 +948,10 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(two_cta_config["tcgen05_cluster_m"], 2)
         self.assertEqual(two_cta_config["pid_type"], "persistent_interleaved")
         # The ordinary cluster_m=2 arm preserves its valid bk=16 sample instead
-        # of collapsing into the distinct bk=128 FFI direct-entry seed.
-        self.assertEqual(two_cta_config["block_sizes"][:3], [256, 256, 16])
+        # of collapsing into the distinct bk=128 FFI direct-entry seed. The
+        # sub-128 sampled block_n rounds UP to the narrow 128 cm2 tile (the
+        # un-seeded [256,128,*] tile that only search can reach), not to 256.
+        self.assertEqual(two_cta_config["block_sizes"][:3], [256, 128, 16])
         self.assertIs(two_cta_config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY], False)
 
     @onlyBackends(["cute"])
@@ -936,13 +1066,13 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(constraints.per_cta_smem_budget_bytes, b200_budget_bytes)
 
         search_fragments = spec._tcgen05_optional_fragments(for_search=True)
-        # Cycle 97: ab=3 is BUDGET-AWARE-SEARCHABLE — the for_search cap is lifted
-        # to 3 wherever the SMEM-budget constraints were recorded (here: the mocked
-        # B200 budget), so the autotuner can SAMPLE ab=3 directly. A sampled ab=3
-        # that does not fit is then demoted by ``_fix_ab_stages_search_config`` (the
-        # over-budget cases below). The validation surface is independently 3 for
-        # explicit configs.
-        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 3)
+        # Cycle 97: a deep AB ring is BUDGET-AWARE-SEARCHABLE — the for_search cap is
+        # lifted to the 16-bit dtype hard cap of 6 wherever the SMEM-budget
+        # constraints were recorded (here: the mocked B200 budget), so the autotuner
+        # can SAMPLE ab=3 directly. A sampled ab=3 that does not fit is then demoted
+        # by ``_fix_ab_stages_search_config`` (the over-budget cases below). The
+        # validation surface is independently 3 for explicit configs.
+        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 6)
         validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
         # 16-bit 4096^3 is FFI-eligible (fp16 == bf16 parity), so the validation
         # surface admits the deeper FFI direct-entry stage tuples — up to ab=6
@@ -1063,7 +1193,7 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                 )
             self.assertIsNotNone(spec._tcgen05_ab_stages_search_constraints)
             search_fragments = spec._tcgen05_optional_fragments(for_search=True)
-            self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 3)
+            self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 6)
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_ab_stages_three_seeded_in_initial_population(
@@ -1089,23 +1219,33 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(b200_budget_bytes)
         spec = bound.config_spec
 
-        # 16-bit 4096^3 is FFI-eligible (fp16 == bf16 parity), so the initial
-        # population now carries TWO cluster_m=2 seeds: the DEFAULT-layout
-        # cluster_m=2 ab=3 seed and the generalized TVM-FFI direct-entry seed.
-        # Both must carry the canonical ab=3 fast-config envelope (the point of
-        # this test — that ab=3 is seeded rather than discovered by mutation).
+        # 16-bit 4096^3 is FFI-eligible (fp16 == bf16 parity). The initial
+        # population carries the DEFAULT-layout cluster_m=2 seed and the
+        # generalized TVM-FFI direct-entry seed, and the two no longer share a K
+        # rung: the widened ``bk`` draw bound lets the DEFAULT-layout seed sit at
+        # 256 while the FFI seed keeps its validated 128. So this test asserts the
+        # canonical ab=3 envelope is PRESENT among the cluster_m=2 seeds (the point
+        # of the test — ab=3 is seeded rather than discovered by mutation) rather
+        # than requiring every cluster_m=2 seed to be it.
         cluster_m2_seeds = [
             config.config
             for config in spec.compiler_seed_configs
             if config.config.get("tcgen05_cluster_m") == 2
         ]
         self.assertGreaterEqual(len(cluster_m2_seeds), 1)
-        for seed in cluster_m2_seeds:
-            self.assertEqual(
-                seed["block_sizes"][:3],
-                [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, 128],
-            )
-            self.assertEqual(seed["tcgen05_ab_stages"], 3)
+        canonical_ab3_seeds = [
+            seed
+            for seed in cluster_m2_seeds
+            if seed["block_sizes"][:3]
+            == [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, 128]
+            and seed["tcgen05_ab_stages"] == 3
+        ]
+        self.assertGreaterEqual(
+            len(canonical_ab3_seeds),
+            1,
+            f"canonical [256,256,128] ab=3 seed missing from cluster_m=2 seeds: "
+            f"{[s['block_sizes'] for s in cluster_m2_seeds]}",
+        )
 
     @onlyBackends(["cute"])
     def test_cute_universal_matmul_lane_loop_correctness(self) -> None:
@@ -1626,7 +1766,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             bound = cute_matmul_mma.bind(args)
         spec = bound.config_spec
         self.assertTrue(spec.cute_tcgen05_search_enabled)
-        self.assertEqual([x.max_size for x in spec.block_sizes], [128, 256, 128])
+        # bk DRAW bound is 256 (see the widening note in
+        # ``test_cute_tcgen05_equal_dims_keep_default_within_max_bound``); the
+        # edge-family gates below still key on the 128-based divisibility value,
+        # which is why cluster_m=2 and persistent_interleaved survive here.
+        self.assertEqual([x.max_size for x in spec.block_sizes], [128, 256, 256])
         self.assertEqual(spec._tcgen05_cluster_m_search_choices, (1, 2))
         self.assertNotIn("persistent_blocked", spec.allowed_pid_types)
         self.assertIn("persistent_interleaved", spec.allowed_pid_types)


### PR DESCRIPTION
Stacked PRs:
 * #3358
 * #3357
 * #3356
 * #3355
 * #3354
 * #3353
 * __->__#3352
 * #3351
 * #3350


--- --- ---

### [autotuner][cute] widen and simplify the cluster_m=2 / cluster_m=1 tile shaping


`_fix_cluster_m2_search_config` completes a `tcgen05_cluster_m == 2` request
instead of enumerating the tuples it recognizes, and declines by writing
`cluster_m = 1` rather than by failing at codegen.

  * block_n: settle to one of two validated N tiles (`bn <= 128 -> 128`, else
    256) instead of pinning 256. Both are hardware-legal at cluster_m=2 -- the
    2-CTA MMA decision keys on `block_m` alone -- so `[256, 128, *]` becomes
    reachable. The narrow band snaps DOWN because the 256x256 tile is already
    emitted by every cluster_m=2 seed, so biasing the band at the un-seeded
    tile spends draws on discovery.
  * block_k: repair an illegal `bk` to the NEAREST legal value rather than
    demoting the whole candidate, moving the key as little as possible.
    Distance ties break toward the larger tile. A `bk` outside the drawable
    domain still demotes, deliberately: that value did not come from the
    sampler, and repairing it would silently rewrite a hand-written config's K
    tile. The `ceil(static_k / bk) <= max_k_tiles` cap is preserved by
    construction -- the repair can only pick a value the predicate accepts.
  * ab_stages: admit ab=4 at cluster_m=2 (see the depth-walk commit for the
    budget that bounds it).
  * `constraints is None` no longer demotes on its own. That field records
    whether the SAMPLER draws cluster_m=2 on this shape (its admission needs
    N-side room, the edge family, or fp8), which is a search-budget decision
    and not a statement about what codegen can emit. A cluster_m=2 config still
    arrives from producers orthogonal to that restriction -- a promoted seed
    reading the MatmulFact directly, a transferred cache entry -- so fall back
    to `_cluster_m2_capability_holds`: a persistent pid must be available, `bm`
    must be 256 (or 128 for fp8, mirroring `_tcgen05_use_2cta_instrs`), and the
    K-tile count must respect the 2-CTA cap. Demote only if one of those fails.
    Verified on M=256/N=64/K=128 bf16 with the integer-data oracle that
    `[256, 64, 64] cluster_m=2` compiles and is bit-exact, and that the search
    space is unchanged: 0/200 post-fix cluster_m=2 draws on every shape where
    the constraints are absent.

`_fix_cluster_m1_persistent_search_config` keeps two INDEPENDENT legality
clamps (not an if/else): `bm -> min(bm, 128)` for every entry, because
`bm=256 & cluster_m=1` fails the tcgen05 shape test and `_choose_mma_impl`
then silently returns "universal"; and `pid_type -> flat` on the edge/K-tail
family, whose widened pid enum the cluster_m=1 half cannot use. The `bm` clamp
no longer sits behind a `pid_type` gate -- the non-persistent draws are exactly
the ones that needed it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>