### PR TITLE
[autotuner][cute] complete-or-decline the aux/CLC requests, and seed the regimes

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -7,9 +7,11 @@ from typing import cast
 import torch
 
 from ...runtime.config import Config
+from ..cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from ..cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
 from ..cute.strategies import Tcgen05PersistenceModel
 from ..cute.tcgen05_config import TCGEN05_GROUPED_DYNAMIC_AB4_STAGE
+from ..cute.tcgen05_constants import TCGEN05_CLUSTER_M2_SEED_MIN_AB_STAGES
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
@@ -18,6 +20,7 @@ from ..cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
+from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_L2_GROUPING
@@ -809,9 +812,51 @@ class CuteFlashAttentionCausalLptHeuristic(AutotunerHeuristic):
         )
 
 
+#: The fp8 small-grid seed's own AB depth. Mirrors the ``tcgen05_ab_stages`` literal in
+#: ``CuteTcgen05ClusterM2Heuristic._fp8_small_grid_seed_config`` — the two must agree or
+#: the ``bk`` picker scores a depth the seed does not emit.
+_FP8_SMALL_GRID_SEED_AB_STAGES = 12
+
+
+def _cluster_m2_seed_tile_and_depth(
+    env: CompileEnvironment, spec: ConfigSpec
+) -> tuple[int, int, int]:
+    """The ``(bm, bn, ab_stages)`` ``CuteTcgen05ClusterM2Heuristic`` will actually emit."""
+    constraints = spec._tcgen05_cluster_m2_search_constraints
+    edge_k_tail_family = (
+        constraints is not None and constraints.allow_edge_k_tail_family
+    )
+    cls = CuteTcgen05ClusterM2Heuristic
+    if (
+        constraints is not None
+        and constraints.allow_fp8_small_grid
+        and not edge_k_tail_family
+        and cls._small_grid_tile_reachable(spec)
+        and (cls._small_grid_within_one_wave(env) or not cls._full_tile_reachable(spec))
+    ):
+        return (
+            TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M,
+            TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N,
+            _FP8_SMALL_GRID_SEED_AB_STAGES,
+        )
+    return (
+        TCGEN05_TWO_CTA_BLOCK_M,
+        TCGEN05_TWO_CTA_BLOCK_N,
+        TCGEN05_CLUSTER_M2_SEED_MIN_AB_STAGES,
+    )
+
+
 class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
+    """DEFAULT-layout cluster_m=2 seed, and the PROMOTED default where the formula"""
+
     name = "cute_tcgen05_cluster_m2"
     backend = "cute"
+
+    @classmethod
+    def should_promote(cls, env: CompileEnvironment) -> bool:
+        """Promote only on BATCHED matmul, where no other producer promotes."""
+        facts = env.config_spec.matmul_facts
+        return len(facts) == 1 and (facts[0].lhs_ndim != 2 or facts[0].rhs_ndim != 2)
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
@@ -914,6 +959,12 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
         }
         if edge_k_tail_family:
             seed.update(tcgen05_two_cta_edge_k_tail_seed_overrides())
+            # cluster_m=2 FIX-UP too, which made the swizzle a projected key on this
+            # family and nowhere else, and was the pipeline's only non-idempotent
+            # write). This seed is MONOLITHIC, so it wants the monolithic edge value;
+            seed[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = (
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE
+            )
         else:
             seed["l2_groupings"] = [TCGEN05_TWO_CTA_SEED_L2_GROUPING]
             seed["tcgen05_c_stages"] = 2
@@ -961,11 +1012,25 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
             ):
                 return TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
             return None
-        bk = bk_fragment.high
-        while bk >= bk_fragment.low:
-            if spec._tcgen05_cluster_m2_bk_is_valid(bk, constraints):
-                return bk
-            bk //= 2
+        # Descend from the fragment's high, preferring a bk that also leaves a
+        # WORKABLE AB pipeline rather than merely tiling the K axis.
+        # ``bk_fragment.high`` is the general DRAW bound and reaches 256; at
+        bm, bn, seed_ab = _cluster_m2_seed_tile_and_depth(env, spec)
+        for require_ab_headroom in (True, False):
+            bk = bk_fragment.high
+            while bk >= bk_fragment.low:
+                if spec._tcgen05_cluster_m2_bk_is_valid(bk, constraints) and (
+                    not require_ab_headroom
+                    or spec._tcgen05_ab_stages_fits(
+                        bm=bm,
+                        bn=bn,
+                        bk=bk,
+                        cluster_m=2,
+                        ab_stages=seed_ab,
+                    )
+                ):
+                    return bk
+                bk //= 2
         return None
 
     @staticmethod
@@ -1031,20 +1096,7 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
     def _fp8_small_grid_seed_config(cls, env: CompileEnvironment, bk: int) -> Config:
         """Seed the fp8 small-grid 2-CTA family (per-CTA 64xbn, bm=128/bn=128).
 
-        Pins the small-grid tile plus the deep-prefetch pipeline the cold-L2
-        sweeps found optimal on the small/wave-limited fp8 serving GEMMs:
-        ``ab_stages=12`` (max A/B prefetch to hide the cold DRAM read),
-        ``acc_stages=1`` and ``c_stages=2`` (lean accumulator + C ring),
-        ``l2_groupings=1`` (no scheduler swizzle). Measured cold-L2 vs
-        torch._scaled_mm on B200: 512x2048x4096 1.14x and 512x2048x2048 1.01x,
-        both ahead of the shallower ab=8/acc=2/c=4/l2=4 seed (1.02x / 0.88x).
-        The bm=256 full-tile seed underfills this regime (16 clusters), so this
-        small-grid seed is the strong starting point the autotuner needs.
-
-        ``ab_stages=12`` is the validator max and sits near the B200 SMEM optin
-        budget; on a lower-SMEM Blackwell SKU it is dropped gracefully by the
         seed transfer (``seed_flat_config_pairs`` catches ``InvalidConfig``) and
-        the search falls back to shallower samples, so seeding the max is safe.
         """
         spec = env.config_spec
         block_sizes = spec._tcgen05_matmul_seed_block_sizes(
@@ -1063,7 +1115,7 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
             "tcgen05_cluster_n": 1,
             "tcgen05_acc_stages": 1,
             "tcgen05_c_stages": 2,
-            "tcgen05_ab_stages": 12,
+            "tcgen05_ab_stages": _FP8_SMALL_GRID_SEED_AB_STAGES,
             "tcgen05_num_epi_warps": 4,
             "l2_groupings": [1],
             TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
@@ -1142,25 +1194,7 @@ class CuteFp8GemmSkinnyMHeuristic(AutotunerHeuristic):
 
 
 class CuteTcgen05ClusterM2FfiHeuristic(CuteTcgen05ClusterM2Heuristic):
-    """Generalized TVM-FFI seed for full-tile CtaGroup.TWO 16-bit GEMMs.
-
-    The generic ``--enable-tvm-ffi`` launcher builds its A/B/D TMA descriptors
-    from the runtime tensor shapes, so the fast launch path is shape-GENERAL:
-    the only real constraints are structural (256x256 CTA tile, cluster_m=2, a
-    bk in the direct-entry stage-tuple table, bf16/fp16 operands, the 128x32
-    explicit epilogue subtile). This heuristic emits that full
-    ``explicit_epi_tile`` + flat-role + ``tvm_ffi_launch`` config for ANY
-    eligible shape, replacing the bank of hand-pinned per-shape seeds.
-
-    The DEFAULT-layout sibling (``CuteTcgen05ClusterM2Heuristic``) still seeds
-    the non-FFI config, so the autotuner benchmarks both and keeps whichever
-    wins: full-autotune A/B measured the FFI direct entry ~7-21% faster on
-    smaller / square GEMMs (1024x4096x1024, 2048^3) where launch + epilogue
-    overhead dominates, and tied on large compute-bound shapes
-    (8192x1024x1024, 8192x2048x2048). An FFI config that fails to compile or
-    the accuracy check for a given shape is dropped by the autotuner,
-    degrading gracefully to the DEFAULT seed.
-    """
+    """Generalized TVM-FFI seed for full-tile CtaGroup.TWO 16-bit GEMMs."""
 
     name = "cute_tcgen05_cluster_m2_ffi"
     backend = "cute"
@@ -1177,3 +1211,30 @@ class CuteTcgen05ClusterM2FfiHeuristic(CuteTcgen05ClusterM2Heuristic):
         # search-projection (``_fix_target1_tvm_ffi_search_config``) and this
         # population seed emit the identical FFI envelope.
         return env.config_spec._tcgen05_full_tile_direct_entry_seed_config()
+
+
+class CuteTcgen05AuxEdgeHeuristic(AutotunerHeuristic):
+    """Seed for the aux (fused-epilogue) EDGE-tile family — §2.3's extraction."""
+
+    name = "cute_tcgen05_aux_edge"
+    backend = "cute"
+    promote_seed_to_default = False
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        spec = env.config_spec
+        tcgen05 = spec._cute_tcgen05_config
+        if not tcgen05.aux_kernel_detected:
+            return False
+        # The stage keys on the DRAWN tile having a partial edge; a seed has no
+        # drawn tile, so key on the SHAPE instead: does any matmul fact have a
+        # dimension the seed's own tile cannot cover exactly? That is the
+        # shape-structural version of the same question, and it is what makes
+        # this seed's regime the right one for the kernel.
+        return tcgen05.aux_edge_seed_shape_eligible()
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        return env.config_spec._cute_tcgen05_config.aux_edge_seed_config()

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -24,6 +24,7 @@ from collections.abc import Mapping
 import contextlib
 from dataclasses import dataclass
 from dataclasses import replace
+import logging
 import os
 import textwrap
 from typing import TYPE_CHECKING
@@ -94,6 +95,7 @@ from .tcgen05_constants import TCGEN05_ACC_PRODUCER_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_ACC_PRODUCER_MODE_SKIP_UMMA
 from .tcgen05_constants import TCGEN05_AUX_LOAD_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_AUX_LOAD_MODE_TMA
+from .tcgen05_constants import TCGEN05_AUX_PRODUCER_WARP_MAX_AB_STAGES
 from .tcgen05_constants import TCGEN05_AUX_STAGE_COUNT_CHOICES
 from .tcgen05_constants import TCGEN05_AUX_STAGE_COUNT_DEFAULT
 from .tcgen05_constants import TCGEN05_AUX_STAGES_CONFIG_KEY
@@ -101,6 +103,9 @@ from .tcgen05_constants import TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CHOICES
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_DEFAULT
+from .tcgen05_constants import TCGEN05_EXPLICIT_D_STORE_BOX_N
+from .tcgen05_constants import TCGEN05_EXPLICIT_EPI_TILE_M
+from .tcgen05_constants import TCGEN05_EXPLICIT_EPI_TILE_N
 from .tcgen05_constants import TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY
@@ -135,6 +140,9 @@ from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_c_smem_bytes_per_cta
 from .tcgen05_lifecycle import Tcgen05LifecycleContext
 from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
+
+log = logging.getLogger(__name__)
+
 
 if TYPE_CHECKING:
     from ...autotuner.config_spec import MatmulFact
@@ -200,11 +208,13 @@ _MMA_REQUIRES_ACCUMULATOR_SEED_META_KEY = "cute_mma_requires_accumulator_seed"
 # identical at the default.
 _TCGEN05_PRODUCER_REGS = 120
 # 128x32 bf16 gives the validated 64 Ki-bit D-store TMA box and x32 TMEM
-# drain for the current Target1 CtaGroup.TWO diagnostic path.
+# drain for the current Target1 CtaGroup.TWO diagnostic path. Reads the shared
+# constants so the search-surface derivation (``_derive_layout_override_bundle``)
+# and this raise cannot disagree about what the one legal point is.
 _TCGEN05_EXPLICIT_EPI_TILE_VALIDATED_SHAPE = (
-    TCGEN05_TWO_CTA_BLOCK_M // 2,
-    32,
-    32,
+    TCGEN05_EXPLICIT_EPI_TILE_M,
+    TCGEN05_EXPLICIT_EPI_TILE_N,
+    TCGEN05_EXPLICIT_D_STORE_BOX_N,
 )
 
 
@@ -4042,7 +4052,11 @@ class _PerKiterTmaArgs:
 
 
 def _kloop_tma_copy_a_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
-    """Per-K-iter TMA copy source for A; ``""`` when A is not TMA-loaded."""
+    """Per-K-iter TMA copy source for A; ``""`` when A is not TMA-loaded.
+
+    A only multicasts in 2-CTA mode (asymmetric vs. B, which can also
+    multicast across cluster CTAs).
+    """
     if not args.use_tma_a:
         return ""
     mcast = f", mcast_mask={args.tma_a_mcast_mask}" if args.is_two_cta else ""
@@ -7953,34 +7967,6 @@ def _emit_mma_pipeline(
         # SMEM-budget rejection: ``tcgen05_ab_stages=3`` +
         # productive C-input warp
         # (``tcgen05_warp_spec_c_input_warps=1`` AND non-empty
-        # ``aux_tensor_descriptors`` AND single-store fan-out
-        # gate open) is over the 232 KB B200 SMEM cap at every
-        # validated tcgen05 tile shape (canonical
-        # ``(bm=bn=256, bk=128, cluster_m=2)`` measured 263 KB
-        # used vs 232 KB cap; reducing the aux ring to
-        # ``num_stages=1`` only drops it to 246 KB, still 14 KB
-        # over). Reject loudly at MMA-codegen time so:
-        #   - explicit user configs fail with a clear message
-        #     instead of an opaque ``ptxas: uses too much
-        #     shared data`` deep inside the cute_dsl invocation;
-        #   - the autotune search-time fixup can demote
-        #     ``tcgen05_ab_stages=3`` candidates that would
-        #     otherwise trigger this raise mid-tuning (see
-        #     ``_fix_tcgen05_with_scheduler_search_config``).
-        # The predicate mirrors the productive-body aux-pipeline
-        # allocation gate at ``_emit_mma_pipeline`` below
-        # (``has_aux_producer_warp AND aux_tensor_descriptors AND
-        # aux_single_store_value``), where the aux producer is the
-        # C-input warp (SIMT or TMA) OR — under the cycle-94 merge —
-        # the store warp (TMA only). The store-warp TMA aux ring has
-        # the SAME SMEM cost as the C-input TMA ring, so ab=3 overshoots
-        # the cap identically and must be rejected for it too. When the
-        # multi-store fan-out gate closes the productive body, the aux
-        # SMEM ring + ``c_pipeline_aux`` are NOT allocated and the
-        # kernel falls back to GMEM-aux reads with no extra SMEM cost,
-        # so the rejection must NOT fire — fan-out ``ab=3 + c_input=1``
-        # paths are legal and pinned by
-        # ``test_aux_pipeline_ab_stages_3_with_c_input_fanout_not_rejected``.
         c_input_aux_tensor_descriptors = (
             tcgen05_matmul_plan.c_input_aux_tensor_descriptors
         )
@@ -7993,11 +7979,15 @@ def _emit_mma_pipeline(
         ab_reject_has_aux_producer_warp = tcgen05_matmul_plan.has_c_input_warp or (
             tcgen05_matmul_plan.has_store_warp and ab_reject_aux_tma_requested
         )
+        # The depth bound is ``TCGEN05_AUX_PRODUCER_WARP_MAX_AB_STAGES``, shared
+        # with the search-repair ``min`` in ``_fix_aux_tma_search_config`` so a
+        # future widening cannot desynchronize the two.
         if (
             ab_reject_has_aux_producer_warp
             and c_input_aux_tensor_descriptors
             and aux_single_store_value
-            and tcgen05_matmul_plan.ab_stage_count >= 3
+            and tcgen05_matmul_plan.ab_stage_count
+            > TCGEN05_AUX_PRODUCER_WARP_MAX_AB_STAGES
         ):
             raise exc.BackendUnsupported(
                 "cute",
@@ -8493,41 +8483,8 @@ def _emit_mma_pipeline(
             if tcgen05_matmul_plan.is_clc_persistent:
                 prefix.extend(_emit_clc_smem_setup(tcgen05_sched_plan))
             # C-input warp aux SMEM ring + ``c_pipeline_aux``
-            # ``PipelineAsync`` (``cute_plan.md`` §7.5.3.2 cycle 2
             # of the producer-body split). Fires only when the
             # productive-body gate is open: ``c_input_warp_count > 0``
-            # AND a non-empty exact-shape ``c_input_aux_tensor_descriptors``
-            # tuple. Broadcast row-vector aux loads intentionally stay on the
-            # direct per-thread path; staging them as 2-D rings burns a full
-            # epilogue tile of SMEM for a one-dimensional input. The
-            # role-local while builder in
-            # ``program_id._build_c_input_warp_role_local_while``
-            # emits the per-descriptor producer body that issues
-            # ``producer_acquire`` → cooperative
-            # ``cute.copy(GMEM, SMEM_ring[stage])`` →
-            # ``producer_commit`` against the same plan; the
-            # consumer-side splice in
-            # ``memory_ops._aux_subtile_load_source`` reads from
-            # the SMEM ring under ``consumer_wait`` /
-            # ``consumer_release`` gating. Gate-closed configs
-            # (``c_input_warps=0`` or no aux residual) skip this
-            # allocation entirely and preserve byte identity.
-            # Multi-store fan-out safety gate: the productive body
-            # only fires when every aux descriptor for this matmul
-            # comes from a single store_value_node. With fan-out
-            # (one matmul → multiple stores with different aux
-            # operands), the producer would fire
-            # ``producer_commit`` on every ring per subtile while
-            # each store's per-store-codegen consumer covers only
-            # a subset of rings — leaving the unmatched rings
-            # uncommitted and deadlocking the producer once a CTA
-            # wraps the pipeline depth. The ``store_value_node``
-            # field on ``Tcgen05AuxTensorDescriptor`` is the
-            # discriminator; the descriptor walker dedups by it
-            # already, so single-store fan-out into multiple
-            # writes of the same value gives one ``store_value_node``
-            # in the descriptor set (and the GMEM fallback path
-            # remains byte-identical to the pre-cycle-2b shape).
             c_input_aux_tensor_descriptors = (
                 tcgen05_matmul_plan.c_input_aux_tensor_descriptors
             )
@@ -9789,15 +9746,6 @@ def _emit_mma_pipeline(
                     # Initial TMA prefetch warms stages 0..ab_stage_count-1 of
                     # the AB pipeline at the START of each tile. Both the
                     # boolean full-tile predicates and the TMA copies reference
-                    # per-tile gA/gB tensors and m_offset/n_offset, so they
-                    # must stay in the work-tile body.
-                    #
-                    # In the role-local producer path, the TMA-load warp needs
-                    # its own per-tile tensor partitions and full-tile
-                    # predicates because it no longer runs the shared work-tile
-                    # loop. Tag those prerequisites together with the prefetch
-                    # IFs so the partitioner extracts one self-contained
-                    # TMA-load role body.
                     assert tma_warp is not None
                     prefetch_args = _InitialPrefetchTmaArgs(
                         tma_pipeline=tma_pipeline,
@@ -9853,10 +9801,6 @@ def _emit_mma_pipeline(
                         # Warm every stage 1..ab_stage_count-1; each gated by
                         # an ``i+1``-k_tile fits-in-K predicate. The old
                         # two-call pattern only covered stages 0 and N-1
-                        # (sufficient for ab=2 where they're the same set);
-                        # ab>=3 leaves intermediate stages unarmed and the
-                        # consumer ``consumer_wait`` deadlocks on stage 1
-                        # phase 0. See cute_plan.md §6.9.1.
                         _emit_per_tile(
                             f"{tma_initial_next_full_tile} = "
                             + _tcgen05_tma_tile_predicate(
@@ -10327,12 +10271,6 @@ def _emit_mma_pipeline(
                         )
                     )
                     if not diagnose_skip_umma_issue:
-                        # The AB pipeline's ``consumer_wait`` is a
-                        # transaction-count ``mbarrier_try_wait`` that already
-                        # orders the TMA shared stores before the UMMA load,
-                        # so an extra ``fence_view_async_shared()`` is
-                        # redundant on this pipelined path. See cute_plan.md
-                        # §6.9.2 for the cycle's bench/NCU write-up.
                         exec_loop_body.append(
                             _build_tcgen05_mma_issue_stmt(
                                 exec_active=tcgen05_plan.exec_active,
@@ -11052,6 +10990,43 @@ def _tcgen05_candidate_exceeds_smem(
     return required > budget
 
 
+_TCGEN05_SMEM_DOWNGRADE_WARNED: set[tuple[int, int, int, int, int, int]] = set()
+
+
+def _warn_tcgen05_smem_downgrade(
+    *, bm: int, bn: int, bk: int, config: object | None
+) -> None:
+    """Warn when an over-budget tcgen05 config is silently routed to ``universal``.
+
+    WARNING, not an exception, deliberately: raising would break the fail-safe and
+    """
+    if config is None:
+        return
+    ab_stages = _tcgen05_config_int(config, "tcgen05_ab_stages", 0)
+    c_stages = _tcgen05_config_int(config, "tcgen05_c_stages", 0)
+    cluster_m = _tcgen05_cluster_m(config)
+    # De-duplicate: ``_choose_mma_impl`` is consulted several times per kernel
+    # build (setup, each codegen site), and one downgrade should read as one
+    # warning rather than seven identical lines.
+    key = (bm, bn, bk, cluster_m, ab_stages, c_stages)
+    if key in _TCGEN05_SMEM_DOWNGRADE_WARNED:
+        return
+    _TCGEN05_SMEM_DOWNGRADE_WARNED.add(key)
+    log.warning(
+        "cute tcgen05 config exceeds the per-CTA SMEM budget and was DOWNGRADED to "
+        "the non-tensor-core 'universal' path: block_sizes=[%s, %s, %s] "
+        "cluster_m=%s ab_stages=%s c_stages=%s. The kernel is numerically correct "
+        "but can be ~1500-2000x slower. Reduce tcgen05_ab_stages / tcgen05_c_stages, "
+        "or halve block_k, to stay on the tcgen05 path.",
+        bm,
+        bn,
+        bk,
+        cluster_m,
+        ab_stages,
+        c_stages,
+    )
+
+
 def _choose_mma_impl(
     input_dtype: torch.dtype,
     *,
@@ -11093,6 +11068,7 @@ def _choose_mma_impl(
                 bk=bk,
                 config=config,
             ):
+                _warn_tcgen05_smem_downgrade(bm=bm, bn=bn, bk=bk, config=config)
                 return "universal"
             return env_choice
         return "universal"
@@ -11119,6 +11095,10 @@ def _choose_mma_impl(
             config=config,
         ):
             return "tcgen05"
+        if tcgen05_ok:
+            # The shape IS a legal tcgen05 shape and the hardware supports it; the
+            # ONLY reason we are falling through is the SMEM budget.
+            _warn_tcgen05_smem_downgrade(bm=bm, bn=bn, bk=bk, config=config)
     if _mma_impl_matches_problem_shape("warp", input_dtype, bm=bm, bn=bn, bk=bk):
         if support.warp_f16bf16:
             return "warp"

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -70,6 +70,8 @@ from .tcgen05_constants import TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP
 from .tcgen05_constants import TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_ACC_WAIT_PLACEMENT_SUBTILE_LOOP
 from .tcgen05_constants import TCGEN05_ACC_WAIT_PLACEMENTS
+from .tcgen05_constants import TCGEN05_AUX_EDGE_SEED_BLOCK_K
+from .tcgen05_constants import TCGEN05_AUX_EDGE_SEED_BLOCK_N
 from .tcgen05_constants import TCGEN05_AUX_LOAD_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_AUX_LOAD_MODE_SIMT
 from .tcgen05_constants import TCGEN05_AUX_LOAD_MODE_TMA
@@ -87,6 +89,7 @@ from .tcgen05_constants import TCGEN05_C_STORE_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_C_STORE_MODES
 from .tcgen05_constants import TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CLUSTER_M2_REPAIR_BLOCK_K_ORDER
+from .tcgen05_constants import TCGEN05_CLUSTER_M2_SEED_MIN_AB_STAGES
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CHOICES
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CUBIN_LINEINFO_CONFIG_KEY
@@ -128,6 +131,7 @@ from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODES
 from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNTS
+from .tcgen05_constants import TCGEN05_STAGED_WORK_TILE_MAILBOX_SCHED_STAGES
 from .tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
@@ -178,12 +182,7 @@ class Tcgen05ClusterM2SearchConstraints(NamedTuple):
 
 
 class Tcgen05AbStagesSearchConstraints(NamedTuple):
-    """Search-only envelope where a deep AB pipeline is admitted.
-
-    ``per_cta_smem_budget_bytes`` is the device cap minus the CuTe
-    runtime/barrier reservation; ``per_cta_smem_capacity_bytes`` is the raw cap,
-    which ``c_stages_fits`` scores AB+C against.
-    """
+    """Search-only envelope where ``tcgen05_ab_stages=3`` is admitted."""
 
     dtype_bytes: int
     per_cta_smem_budget_bytes: int
@@ -644,12 +643,26 @@ class CuteTcgen05Config:
             ):
                 return None
         else:
-            bk = bk_fragment.high
-            while bk >= bk_fragment.low:
-                if self.cluster_m2_bk_is_valid(bk, constraints):
+            bk = None
+            for require_ab_headroom in (True, False):
+                candidate = bk_fragment.high
+                while candidate >= bk_fragment.low:
+                    if self.cluster_m2_bk_is_valid(candidate, constraints) and (
+                        not require_ab_headroom
+                        or self.ab_stages_fits(
+                            bm=TCGEN05_TWO_CTA_BLOCK_M,
+                            bn=TCGEN05_TWO_CTA_BLOCK_N,
+                            bk=candidate,
+                            cluster_m=2,
+                            ab_stages=TCGEN05_CLUSTER_M2_SEED_MIN_AB_STAGES,
+                        )
+                    ):
+                        bk = candidate
+                        break
+                    candidate //= 2
+                if bk is not None:
                     break
-                bk //= 2
-            else:
+            if bk is None:
                 return None
 
         seed_config: dict[str, Any] = {
@@ -701,7 +714,6 @@ class CuteTcgen05Config:
         )
 
     def _aux_tma_full_tile_search_enabled(self) -> bool:
-        # Cycle 46: also admit aux-TMA on full-tile cluster_m=2 problems
         # (T14/T20/T25/T28 residual_add family). The codegen-side gate at
         # ``cute_mma.py`` ``tcgen05_static_output_tiles`` already accepts
         # full-tile shapes; only the search-space gate was excluding them.
@@ -727,10 +739,30 @@ class CuteTcgen05Config:
         )
 
     def _aux_tma_seed_config(self, c_input_seed: Config) -> Config | None:
+        """The aux-TMA producer regime as a SEED, not a projection."""
         if not self._aux_tma_search_enabled():
             return None
         seed_config: dict[str, Any] = dict(c_input_seed.config)
         seed_config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_TMA
+        # real resource decision rather than a drawn-knob overwrite: it is the
+        # foundation for the store-warp split (the store warp drains tile N's TMA-D
+        # from the ring while the 4 epi warps run tile N+1's T2R; a 2-stage ring
+        if self._aux_tma_full_tile_search_enabled():
+            config_view = self._matmul_config_view(seed_config)
+            if config_view is not None:
+                block_sizes, m_index, n_index, k_index = config_view
+                if self.c_stages_fits(
+                    bm=cast("int", block_sizes[m_index]),
+                    bn=cast("int", block_sizes[n_index]),
+                    bk=cast("int", block_sizes[k_index]),
+                    cluster_m=2,
+                    ab_stages=cast("int", seed_config.get("tcgen05_ab_stages", 2)),
+                    c_stages=TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES,
+                    has_source_c=True,
+                ):
+                    seed_config["tcgen05_c_stages"] = (
+                        TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES
+                    )
         return Config(**seed_config)
 
     def _clc_persistence_seed_config(self, base_seed: Config) -> Config | None:
@@ -739,6 +771,30 @@ class CuteTcgen05Config:
         seed_config: dict[str, Any] = dict(base_seed.config)
         seed_config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY] = (
             Tcgen05PersistenceModel.CLC_PERSISTENT.value
+        )
+        return Config(**seed_config)
+
+    def _staged_mailbox_seed_config(self, clc_seed: Config) -> Config | None:
+        """``tcgen05_sched_stage_count = 2`` as a SEED — closing a coverage gap."""
+        if not self._clc_persistence_search_enabled():
+            return None
+        seed_config: dict[str, Any] = dict(clc_seed.config)
+        if (
+            seed_config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+            != Tcgen05PersistenceModel.CLC_PERSISTENT.value
+        ):
+            return None
+        if seed_config.get(TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY) is True:
+            return None
+        block_sizes = seed_config.get("block_sizes")
+        if (
+            not isinstance(block_sizes, list)
+            or len(block_sizes) < 3
+            or block_sizes[0] != TCGEN05_TWO_CTA_BLOCK_M
+        ):
+            return None
+        seed_config[TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY] = (
+            TCGEN05_STAGED_WORK_TILE_MAILBOX_SCHED_STAGES
         )
         return Config(**seed_config)
 
@@ -844,6 +900,22 @@ class CuteTcgen05Config:
         ):
             return None
         seed_config: dict[str, Any] = dict(clc_aux_tma_seed.config)
+        narrow_ab = seed_config.get("tcgen05_ab_stages")
+        narrow_c = seed_config.get("tcgen05_c_stages")
+        if not (
+            type(narrow_ab) is int
+            and type(narrow_c) is int
+            and self.c_stages_fits(
+                bm=TCGEN05_TWO_CTA_BLOCK_M,
+                bn=TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
+                bk=TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_K,
+                cluster_m=2,
+                ab_stages=narrow_ab,
+                c_stages=narrow_c,
+                has_source_c=self.exact_shape_aux_kernel_detected,
+            )
+        ):
+            return None
         seed_config["block_sizes"] = [
             TCGEN05_TWO_CTA_BLOCK_M,
             TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
@@ -877,6 +949,17 @@ class CuteTcgen05Config:
                     )
                     if clc_aux_tma_narrow_n_seed is not None:
                         seeds.append(clc_aux_tma_narrow_n_seed)
+                    # The STAGED WORK-TILE MAILBOX. Derived from the WIDE-N CLC aux-TMA
+                    # seed because that one carries ``bm == 256``; the narrow-N variant
+                    # carries ``bm == 256`` too, but seeding both would put two configs
+                    # differing in one diagnostic key into the population. See
+                    # ``_staged_mailbox_seed_config`` for why the extra envelope terms are
+                    # CHECKED there rather than written.
+                    staged_mailbox_seed = self._staged_mailbox_seed_config(
+                        clc_aux_tma_seed
+                    )
+                    if staged_mailbox_seed is not None:
+                        seeds.append(staged_mailbox_seed)
         return seeds
 
     def _fix_cluster_m2_search_config(self, config: dict[str, object]) -> None:
@@ -956,14 +1039,8 @@ class CuteTcgen05Config:
             block_sizes[k_index] = repaired_bk
             bk = repaired_bk
         config["pid_type"] = TCGEN05_TWO_CTA_SEED_PID_TYPE
-        # The tcgen05 CtaGroup.TWO MMA path does not emit the per-block-id
-        # indices/masks that a fused epilogue subtile needs, so a sampled
-        # ``epilogue_subtile`` on a cluster_m=2 candidate raises
-        # ``BackendUnsupported`` at codegen. Drop it here (rather than letting
-        # the candidate fail to compile and waste autotune budget) -- every
-        # cluster_m=2 search candidate that survives to this point is committed
-        # to the 2-CTA path.
-        config.pop("epilogue_subtile", None)
+        # unconditionally, at the top of ``fix_search_config`` -- the key is incompatible
+        # cluster_m=2 ones, so a cluster_m-scoped pop was hiding a subset of the failures.
         # ── The fp8 small-grid family is a SCOPE EXCLUSION, not a special case ──
         sampled_bm = block_sizes[m_index]
         fp8_small_grid_family = (
@@ -1576,125 +1653,85 @@ class CuteTcgen05Config:
         elif strategy == Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value:
             if scheduler_warps != 1:
                 config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 1
-
-    def _is_validated_cluster_m2_full_tile_search_candidate(
-        self, config: dict[str, object]
-    ) -> bool:
-        # Cycle 46: full-tile cluster_m=2 candidate gate for aux-TMA admission.
-        # After ``_fix_cluster_m2_search_config`` projects a full-tile sample to
-        # the canonical 256x256x bk shape with ``persistent_interleaved`` pid,
-        # this returns True so aux-TMA stays during the search-time fixup.
-        # bk validity is already enforced by ``_fix_cluster_m2_search_config``;
-        # we re-check it here so a stale/unprojected config cannot slip through.
-        if config.get("tcgen05_cluster_m") != 2:
-            return False
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return False
-        if config.get("pid_type") != TCGEN05_TWO_CTA_SEED_PID_TYPE:
-            return False
-        if config.get("tcgen05_cluster_n", 1) != 1:
-            return False
-        config_view = self._matmul_config_view(config)
-        if config_view is None:
-            return False
-        block_sizes, m_index, n_index, k_index = config_view
-        if block_sizes[m_index] != TCGEN05_TWO_CTA_BLOCK_M:
-            return False
-        if block_sizes[n_index] != TCGEN05_TWO_CTA_BLOCK_N:
-            return False
-        bk = block_sizes[k_index]
-        if not isinstance(bk, int) or isinstance(bk, bool):
-            return False
-        return self.cluster_m2_bk_is_valid(bk, constraints)
+            # ⚠ THE ``ab >= 3 => c_input_warps = 0`` GUARD MOVED OUT OF THIS STAGE
+            # which runs AFTER the AB depth walk. Here it read ``tcgen05_ab_stages``
+            # before ``_fix_ab_stages_search_config`` had settled it, which cost this
 
     def _fix_aux_tma_search_config(self, config: dict[str, object]) -> None:
+        """Complete the aux-TMA regime a config REQUESTED, or decline it.
+
+        | ``c_input_warps = 1`` | **required by the determinator** | ``tma`` with no producer warp raises ``BackendUnsupported`` ("requires a productive aux producer warp") — nobody issues the copy. NOT a derivation: under ``simt`` the key is a real axis (see below), so this write is scoped to the ``tma`` arm alone |
+        | ``ab_stages = min(ab, CAP)`` | **required by the determinator** | the aux SMEM ring + AB pipeline overshoot the 232 KB B200 cap past the cap depth; ``cute_mma.py`` raises. A ``min`` so it can only ever LOWER the key |
+        """
         if config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY) != TCGEN05_AUX_LOAD_MODE_TMA:
             return
-        if not self._aux_tma_search_enabled():
-            config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_SIMT
+        if self._aux_tma_request_is_satisfiable(config):
+            # Supply exactly the two values ``aux_load_mode=tma`` cannot run
+            # without. Both are unconditional inside this arm: writing the value
+            # the request requires is completing the request, not steering it.
+            config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 1
+            ab_stages = config.get("tcgen05_ab_stages")
+            if type(ab_stages) is int:
+                config["tcgen05_ab_stages"] = min(
+                    ab_stages, TCGEN05_AUX_PRODUCER_WARP_MAX_AB_STAGES
+                )
             return
-        # Aux-TMA is kept when the projected cluster_m=2 candidate matches either
-        # the validated edge+K-tail shape or the cycle-46 full-tile shape, and
-        # the strategy is the ROLE_LOCAL_WITH_SCHEDULER + c-input warp combo that
-        # the aux-TMA producer warp requires.
-        if not self._is_with_scheduler_c_input_config(config):
-            config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_SIMT
-            return
-        if not (
-            self._is_validated_cluster_m2_edge_search_candidate(config)
-            or self._is_validated_cluster_m2_full_tile_search_candidate(config)
-        ):
-            config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_SIMT
+        config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_SIMT
 
-    def _fix_aux_tma_full_tile_search_config(self, config: dict[str, object]) -> None:
-        # Cycle 88 (Workstream B): on the residual full-tile cluster_m=2
-        # family (T20/T14/T25/T28 — exact-shape-gated by
-        # ``_aux_tma_full_tile_search_enabled``), project every cluster_m=2
-        # candidate onto the validated aux-TMA producer regime
-        # (role_local_with_scheduler + scheduler/c-input warp + ab=2 +
-        # aux_load_mode=tma). Clean force-config measurements show aux-TMA
-        # strictly beats the same-config SIMT control on this family (T20
-        # 962.6 vs 844.0 TF = +14%; T25 730.8 vs 324.7 TF = +125%) and also
-        # beats the autotuner's default monolithic-ab=3 SIMT pick (T20 ~915
-        # TF). Without this projection the population search either keeps the
-        # monolithic-ab=3 SIMT region (T20 reliably) or randomly lands on a
-        # catastrophic SIMT cluster_m=2 pick (T25 variance: 756 aux-TMA vs 286
-        # SIMT), so the +2.4-14 pp aux-TMA gain is not banked deterministically.
-        # This is the aux-TMA analogue of the FFI direct-entry search
-        # projection (``_fix_target1_tvm_ffi_search_config``). Tightly bounded:
-        # cluster_m=1 candidates are left untouched (search still explores
-        # them), the edge+K-tail T12 family keeps its own
-        # ``_aux_tma_edge_search_enabled`` CLC path, and the gate fires only
-        # when ``exact_shape_aux_kernel_detected`` is True (residual subset
-        # only — no non-residual target is perturbed).
-        if not self.search_enabled:
-            return
-        if not self._aux_tma_full_tile_search_enabled():
-            return
-        if config.get("tcgen05_cluster_m") != 2:
-            return
-        if not self._is_validated_cluster_m2_full_tile_search_candidate(config):
-            return
-        # ab=2 is the aux-TMA producer's validated stage depth for this family
-        # (the aux SMEM ring forces ab<=2 under the 232 KB B200 cap; the
-        # cycle-86/88 measurements ran at ab=2). ``_c_input_seed_config``
-        # already emits exactly this regime as a seed, so the shape envelope
-        # validated above is sufficient — no extra SMEM-fit check is needed.
-        config[TCGEN05_STRATEGY_CONFIG_KEY] = (
-            Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
-        )
-        config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 1
-        config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 1
-        config["tcgen05_ab_stages"] = 2
-        config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_TMA
-        # Workstream A Stage 2 (cycle 90): give this family the deeper C-store
-        # ring (foundation for the Stage-4 store-warp split — the store warp
-        # drains tile N's TMA-D from the ring while the 4 epi warps run tile
-        # N+1's T2R; a 2-stage ring leaves no slack). At ab=2 the c=4 ring fits
-        # (128 KB AB + 64 KB C = 192 KB < 232 KB cap; the DEFAULT epi tile is
-        # (128, 64), so each C stage is 16 KB), confirmed correct on T20
-        # (cycle-90 force-config: c=2 942.2 TF vs c=4 936.1 TF — perf-neutral
-        # standalone, exactly the cycle-89 NCU prediction since the TMA-D store
-        # is already c_pipeline-overlapped). Gated by ``c_stages_fits`` so a
-        # future ab=3 candidate in this family cannot be lifted into overflow.
-        config_view = self._matmul_config_view(config)
-        if config_view is None:
-            return
-        block_sizes, m_index, n_index, k_index = config_view
-        if self.c_stages_fits(
-            bm=cast("int", block_sizes[m_index]),
-            bn=cast("int", block_sizes[n_index]),
-            bk=cast("int", block_sizes[k_index]),
-            cluster_m=2,
-            ab_stages=2,
-            c_stages=TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES,
-            has_source_c=True,
+    def _aux_tma_request_is_satisfiable(self, config: dict[str, object]) -> bool:
+        """Can an ``aux_load_mode=tma`` request be completed on *config*?
+
+        Every clause is a **precondition** — a fact or a knob this stage refuses to
+        write. False means the request must be declined (demoted to SIMT), because
+        no value this stage is willing to supply can rescue it.
+        """
+        # PRECONDITION-FACT: the family. All four of §3's eligibility terms
+        # (``exact_shape_aux_kernel_detected``, no leading passthrough, cm2
+        # constraints exist, edge-vs-full-tile) already live inside this one
+        # accessor; do not re-implement them here.
+        if not self._aux_tma_search_enabled():
+            return False
+        # Checked, never written: the explicit epilogue tile is incompatible with a
+        # productive aux producer warp (cute_mma.py raises on that pairing).
+        if (
+            config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
+            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
         ):
-            config["tcgen05_c_stages"] = TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES
+            return False
+        # PRECONDITION-KNOB: only ROLE_LOCAL_WITH_SCHEDULER's 7-role/8-launched warp
+        # shape has the inert padding slot the aux producer occupies. The other two
+        # strategies are fully-populated 6-warp shapes, so
+        if (
+            config.get(TCGEN05_STRATEGY_CONFIG_KEY)
+            != Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+        ):
+            return False
+        # PRECONDITION-KNOB: ``scheduler_warps`` is strategy-DETERMINED
+        # (``_STRATEGY_REQUIRED_SCHEDULER_WARPS``, read as an equality test in
+        # ``validate_tcgen05_strategy_invariants``), and stage 5 already derives it
+        # on the search path. Checked rather than written so this stage stays out of
+        # the warp-topology business; an explicit config that disagrees with its own
+        # strategy is declined rather than silently repaired here.
+        if config.get(TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY) != 1:
+            return False
+        # PRECONDITION-KNOB: ``c_input_warps`` and ``store_warps`` share the SINGLE
+        # padding slot, so ``c_input + store > 1`` is rejected by
+        # ``validate_tcgen05_strategy_invariants`` (``role_warp_count`` would sum to
+        # 9, rounding the launch to 12 warps / 384 threads). A drawn config cannot
+        # reach this — ``strategy_autotune_fragments`` pins ``store_warps`` to
+        # ``(0,)`` — but this stage also runs on explicit configs and cache
+        # transfers, where a store warp is expressible. With one live, the aux
+        # producer has no slot, so the request is declined rather than made illegal.
+        if config.get(TCGEN05_WARP_SPEC_STORE_WARPS_KEY, 0) != 0:
+            return False
+        #
+        # Evaluated as a PRECONDITION of the write arm rather than as a trailing
+        # demotion, which is a deliberate change of position. As a trailing clause
+        return config.get("tcgen05_cluster_n", 1) == 1
 
     @staticmethod
     def _is_with_scheduler_c_input_config(config: dict[str, object]) -> bool:
+        """The full aux-TMA producer trio, as a READ-ONLY predicate."""
         return (
             config.get(TCGEN05_STRATEGY_CONFIG_KEY)
             == Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
@@ -1716,6 +1753,24 @@ class CuteTcgen05Config:
             return False
         return capability[0] >= 10 and "flat" in self.allowed_pid_types
 
+    def _clc_persistence_codegen_supported(self) -> bool:
+        """Can a CLC-persistent kernel be EMITTED on this shape at all?
+
+        (``strategies.py``'s persistence arch gate raises below it).
+        """
+        if self.cluster_m2_search_constraints is None:
+            return False
+        capability = self.config_spec.target_device_capability
+        if capability is None:
+            return False
+        # ``"flat" in allowed_pid_types`` is the FORCE-PERSISTENT DETECTOR, not a claim
+        # that CLC wants a flat pid. ``autotune_force_persistent`` (or an initialized
+        # process group) disallows ``flat``/``xyz`` in ``compile_environment.py``, and
+        # the persistence axis this gate opens is built from
+        # ``derive_persistence_model_from_pid_type``, which cannot offer
+        # ``NON_PERSISTENT`` once those are gone -- so the axis must stay hidden there.
+        return capability[0] >= 10 and "flat" in self.allowed_pid_types
+
     def _is_clc_aux_tma_request(self, config: dict[str, object]) -> bool:
         return (
             config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY) == TCGEN05_AUX_LOAD_MODE_TMA
@@ -1729,30 +1784,8 @@ class CuteTcgen05Config:
             config
         ) and self._is_validated_clc_persistence_search_candidate(config)
 
-    def _is_clc_aux_tma_narrow_n_request(self, config: dict[str, object]) -> bool:
-        block_sizes = config.get("block_sizes")
-        if not (
-            isinstance(block_sizes, list)
-            and len(block_sizes) >= 3
-            and block_sizes[1] == TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
-            and self._is_clc_aux_tma_request(config)
-        ):
-            return False
-        projected_config = dict(config)
-        projected_block_sizes = list(block_sizes)
-        projected_config["block_sizes"] = projected_block_sizes
-        projected_config["pid_type"] = TCGEN05_TWO_CTA_SEED_PID_TYPE
-        projected_block_sizes[0] = TCGEN05_TWO_CTA_BLOCK_M
-        projected_block_sizes[2] = TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_K
-        if (
-            self.aux_kernel_detected
-            and self._has_any_matmul_fact_edge_tile(projected_config)
-            and projected_config.get(TCGEN05_STRATEGY_CONFIG_KEY)
-            == Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
-        ):
-            projected_config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 1
-            projected_config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 1
-        return self._is_validated_clc_persistence_search_candidate(projected_config)
+    # the two writes it gated in ``_fix_cluster_m2_search_config``: the narrow K pin and the
+    # narrow ``acc_stages``/``l2_groupings`` arm of the L cascade. It had no other caller.
 
     def implicit_default_keys_to_preserve(self, config: dict[str, object]) -> set[str]:
         if not self._is_clc_aux_tma_config(config):
@@ -1850,59 +1883,31 @@ class CuteTcgen05Config:
             return
         raise InvalidConfig(
             "tcgen05_ab_stages > 3 is only supported by the validated "
-            "TVM-FFI direct-entry path, the grouped N,M worklist "
-            "path within the SMEM budget, or fp8 within the SMEM budget"
+            "TVM-FFI direct-entry path, a 16-bit cluster_m=2 DEFAULT-layout "
+            "tile within the SMEM budget, or fp8 within the SMEM budget"
         )
 
     def _is_validated_clc_persistence_search_candidate(
         self, config: dict[str, object]
     ) -> bool:
-        if not self._clc_persistence_search_enabled():
+        if not self._clc_persistence_codegen_supported():
             return False
-        if not self._is_validated_cluster_m2_edge_search_candidate(config):
+        # ``cluster_m == 2`` ONLY -- not the aux/edge family tag this used to read
+        # through ``_is_validated_cluster_m2_edge_search_candidate``. CLC needs the
+        # clustered shape (the query publishes to peer CTAs, and the staged-mailbox
+        # assert wants ``cluster_m > 1``); it does not need an aux tensor or an output
+        # edge. Verified bit-exact with CLC emitted on a plain full-tile 4096^3 matmul.
+        if config.get("tcgen05_cluster_m") != 2:
             return False
         if config.get("pid_type") != TCGEN05_TWO_CTA_SEED_PID_TYPE:
             return False
         if config.get("tcgen05_cluster_n", 1) != 1:
             return False
-        if not self._is_with_scheduler_c_input_config(config):
-            return False
-        block_sizes = config.get("block_sizes")
-        if not isinstance(block_sizes, list) or len(block_sizes) < 3:
-            return False
-        if block_sizes[0] != TCGEN05_TWO_CTA_BLOCK_M:
-            return False
-        if block_sizes[1] not in (
-            TCGEN05_TWO_CTA_BLOCK_N,
-            TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
-        ):
-            return False
-        is_narrow_n = block_sizes[1] == TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
-        if is_narrow_n:
-            if not self._has_any_matmul_fact_n_edge_for_block_n(
-                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
-            ):
-                return False
-            if (
-                config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
-                != TCGEN05_AUX_LOAD_MODE_TMA
-            ):
-                return False
-            if block_sizes[2] not in (
-                TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
-                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_K,
-            ):
-                return False
-        elif block_sizes[2] != TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K:
-            return False
-        if self.config_spec.supports_config_key("indexing"):
-            indexing = config.get("indexing")
-            if (
-                not isinstance(indexing, list)
-                or indexing != ["tensor_descriptor"] * self.config_spec.indexing.length
-            ):
-                return False
-        return True
+        return (
+            config.get(TCGEN05_STRATEGY_CONFIG_KEY)
+            == Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+            and config.get(TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY) == 1
+        )
 
     def _fix_clc_persistence_search_config(self, config: dict[str, object]) -> None:
         if (
@@ -2008,13 +2013,12 @@ class CuteTcgen05Config:
         if key == TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY:
             return True, 0
         if key == TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY:
-            # The autotuner search surface for this key is the collapsed
-            # ``EnumFragment((True,))``; autotuner-generated configs always
-            # set it via ``default_flat()`` mutation. ``flatten`` only hits
-            # this branch on user-supplied configs that omit the key, where
-            # absence means "no FFI promotion requested" — matches the
+            # The search surface for this key draws False only
+            # (``EnumFragment((True, False), search_choices=(False,))``), so an
+            # absent key can only come from a config that did not go through the
+            # search: a user-supplied config, a partial seed, or a cache entry.
+            # Absence there means "no FFI promotion requested" — matching the
             # validation-view default and the special case at
-            # ``normalize_pre_pid_type``.
             return True, False
         if key != TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY:
             return False, None
@@ -2062,6 +2066,43 @@ class CuteTcgen05Config:
             for i in range(len(self.config_spec.matmul_facts))
         )
 
+    def _matmul_fact_has_double_edge_output(
+        self, config: dict[str, object], *, fact_index: int
+    ) -> bool:
+        """``M % bm != 0`` AND ``N % bn != 0`` on the DRAWN tile.
+
+        raise BackendUnsupported("tcgen05 SIMT edge epilogue double-edge output
+        Two things this deliberately does NOT do, both because codegen does not:
+        """
+        # Every unreadable case answers the same way -- an axis we cannot read is an axis
+        # we cannot PROVE partial, and this predicate gates a DEMOTION, so it fails toward
+        # NOT demoting. That makes the whole body one comprehension over the two axes.
+        block_sizes = config.get("block_sizes")
+        if not isinstance(block_sizes, list):
+            return False
+        fact = self.config_spec.matmul_facts[fact_index]
+
+        def axis_is_partial(static_size: int | None, block_id: int | None) -> bool:
+            index = self._config_block_index(block_id)  # None if absent/unregistered
+            if static_size is None or index is None or index >= len(block_sizes):
+                return False
+            block_size = block_sizes[index]
+            if type(block_size) is not int or block_size <= 0:
+                return False  # ``type(...) is int`` also rejects bool
+            return static_size % block_size != 0
+
+        return axis_is_partial(fact.static_m, fact.m_block_id) and axis_is_partial(
+            fact.static_n, fact.n_block_id
+        )
+
+    def _has_any_matmul_fact_double_edge_output(
+        self, config: dict[str, object]
+    ) -> bool:
+        return any(
+            self._matmul_fact_has_double_edge_output(config, fact_index=i)
+            for i in range(len(self.config_spec.matmul_facts))
+        )
+
     def _has_any_matmul_fact_n_edge_for_block_n(self, block_n: int) -> bool:
         for fact in self.config_spec.matmul_facts:
             if fact.static_n is None or fact.n_block_id is None:
@@ -2076,78 +2117,82 @@ class CuteTcgen05Config:
                 return True
         return False
 
-    def _fix_aux_edge_search_config(self, config: dict[str, object]) -> None:
-        if not (self.search_enabled and self.aux_kernel_detected):
-            return
-        if not self._has_any_matmul_fact_edge_tile(config):
-            return
+    def aux_edge_seed_shape_eligible(self) -> bool:
+        """Shape-structural eligibility for the aux-edge SEED (§2.3)."""
+        if not self.aux_kernel_detected:
+            return False
+        probe: dict[str, object] = {
+            "block_sizes": self._aux_edge_seed_block_sizes(),
+        }
+        if not isinstance(probe["block_sizes"], list):
+            return False
+        return self._has_any_matmul_fact_edge_tile(probe)
 
-        if self._is_validated_cluster_m2_edge_search_candidate(config):
-            self._set_aux_edge_cluster_m2_prefix(config)
-            return
-
-        self._set_aux_edge_monolithic_prefix(config)
-        config["tcgen05_acc_stages"] = 2
-        config["tcgen05_c_stages"] = 4
-        config[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = 1
-        if isinstance(config.get("l2_groupings"), list):
-            config["l2_groupings"] = [1]
-        if isinstance(config.get("indexing"), list):
-            indexing = cast("list[object]", config["indexing"])
-            for i in range(len(indexing)):
-                indexing[i] = "pointer"
-        block_sizes = config.get("block_sizes")
-        if not isinstance(block_sizes, list):
-            return
-        for fact in self.config_spec.matmul_facts:
-            if fact.static_m is not None and fact.m_block_id is not None:
-                try:
-                    m_idx = self.config_spec.block_sizes.block_id_to_index(
-                        fact.m_block_id
-                    )
-                except KeyError:
-                    m_idx = -1
-                if 0 <= m_idx < len(block_sizes):
-                    bm = block_sizes[m_idx]
-                    if (
-                        isinstance(bm, int)
-                        and not isinstance(bm, bool)
-                        and bm > 128
-                        and fact.static_m % bm != 0
-                    ):
-                        block_sizes[m_idx] = 128
-            # K-only bk=128 tails keep the default A SMEM atom; output-edge
-            # bk=128 fallback is handled in cute_mma by forcing A INTER.
-            # Both cases have runtime coverage in test_cute_lowerings.
-
-    @staticmethod
-    def _set_aux_edge_monolithic_prefix(config: dict[str, object]) -> None:
-        config[TCGEN05_STRATEGY_CONFIG_KEY] = (
-            Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value
+    def _aux_edge_seed_block_sizes(self) -> list[int] | None:
+        """The seed's tile."""
+        return self._matmul_seed_block_sizes(
+            bm=TCGEN05_ONE_CTA_MAX_BLOCK_M,
+            bn=TCGEN05_AUX_EDGE_SEED_BLOCK_N,
+            bk=TCGEN05_AUX_EDGE_SEED_BLOCK_K,
         )
-        config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 0
-        config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 0
-        if config.get("tcgen05_ab_stages") == 1:
-            config["tcgen05_ab_stages"] = 2
-        config.pop("epilogue_subtile", None)
+
+    def aux_edge_seed_config(self) -> Config | None:
+        """The aux-edge PERF regime, as a competing seed instead of a projection."""
+        block_sizes = self._aux_edge_seed_block_sizes()
+        if block_sizes is None:
+            return None
+        seed: dict[str, object] = {
+            "block_sizes": block_sizes,
+            TCGEN05_STRATEGY_CONFIG_KEY: (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value),
+            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: 0,
+            TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: 0,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": 4,
+            "tcgen05_ab_stages": 2,
+            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
+            "l2_groupings": [1],
+        }
+        if self.config_spec.indexing.length > 0:
+            # Kernel-wide TMA addressing off, matching the regime this seed
+            # encodes. Unlike the stage's blanket rewrite this is a SEED value on
+            # a fresh config, so it strands nothing: the search still draws every
+            # other ``indexing`` combination.
+            seed["indexing"] = ["pointer"] * self.config_spec.indexing.length
+        try:
+            return Config(**seed)  # type: ignore[arg-type]
+        except (InvalidConfig, ValueError, TypeError, KeyError):
+            return None
 
     @staticmethod
-    def _set_aux_edge_cluster_m2_prefix(config: dict[str, object]) -> None:
-        if (
+    def _set_aux_edge_prefix(
+        config: dict[str, object], *, allow_with_scheduler: bool
+    ) -> None:
+        """The aux-edge LEGALITY prefix — one entry point, hoisted (§2.3).
+
+        MONOLITHIC with both warp counts 0, which is the only accept set for that
+        """
+        if allow_with_scheduler and (
             config.get(TCGEN05_STRATEGY_CONFIG_KEY)
             == Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
         ):
             config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 1
             config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 1
-            config[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = (
-                TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE
-            )
+            # the entry in ``tcgen05_two_cta_edge_k_tail_seed_overrides()``). The two
+            # had to go as a PAIR and the ordering is why:
         else:
-            CuteTcgen05Config._set_aux_edge_monolithic_prefix(config)
-            return
-        if config.get("tcgen05_ab_stages") == 1:
-            config["tcgen05_ab_stages"] = 2
-        config.pop("epilogue_subtile", None)
+            # ab=2 is the aux-TMA producer's validated stage depth for this family
+            # (the aux SMEM ring forces ab<=2 under the 232 KB B200 cap; the
+            # cycle-86/88 measurements ran at ab=2). ``_c_input_seed_config``
+            # already emits exactly this regime as a seed, so the shape envelope
+            # validated above is sufficient — no extra SMEM-fit check is needed.
+            config[TCGEN05_STRATEGY_CONFIG_KEY] = (
+                Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value
+            )
+            config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 0
+            config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 0
+        # aux-edge PERF regime now enters the population as ``aux_edge_seed_config``,
+        # which already carries ``tcgen05_ab_stages=2``, so raising a drawn ab=1 was
+        # redundant steering rather than legality: codegen has no ``ab >= 2``
 
     def _is_validated_cluster_m2_edge_search_candidate(
         self, config: dict[str, object]
@@ -2190,6 +2235,9 @@ class CuteTcgen05Config:
             and config.get("pid_type")
             in {"persistent_blocked", "persistent_interleaved"}
         ):
+            # persistent_interleaved stays in the flat enum so cluster_m=2
+            # edge-family samples can encode; cluster_m=1 samples from the
+            # same surface must use the validated flat edge fallback.
             config["pid_type"] = "flat"
 
     def restrict_num_epi_warps_search(self, choices: tuple[int, ...]) -> None:
@@ -2294,6 +2342,15 @@ class CuteTcgen05Config:
             # Validation admits the dtype's deepest AB pipeline; the depth walk trims it.
             constraints = self.ab_stages_search_constraints
             if constraints is None:
+                # Cycle 97: make ab=3 BUDGET-AWARE-SEARCHABLE. Where the device/dtype
+                # admits ab=3 at all (the SMEM-budget constraints were recorded by
+                # ``allow_ab_stages_three_search`` at bind time — B200-class optin cap,
+                # bf16/fp16), lift the ``for_search`` cap to 3 so the autotuner can
+                # SAMPLE ab=3 directly instead of reaching it only through the per-shape
+                # FFI / gelu seeds. ``_fix_ab_stages_search_config`` then demotes any
+                # sampled ab=3 that does not fit (the residual/source-C ring overflows;
+                # cluster_m=1 256x256 overflows bare-AB) before codegen, so admission is
+                # free but an overflowing kernel is never generated.
                 ab_stages_max = 3
             else:
                 ab_stages_max = self._get_dtype_ab_stages_hard_cap(
@@ -2576,6 +2633,16 @@ class CuteTcgen05Config:
             TCGEN05_AUX_STAGES_CONFIG_KEY: EnumFragment(TCGEN05_AUX_STAGE_COUNT_CHOICES)
         }
 
+    def sched_stage_count_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
+        """Per-config depth of the CLC scheduler's SMEM work-tile mailbox."""
+        if not self._clc_persistence_search_enabled():
+            return {}
+        return {
+            TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY: EnumFragment(
+                TCGEN05_SCHED_STAGE_COUNTS
+            )
+        }
+
     def consumer_regs_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
         """Per-config consumer-warp ``setmaxregister_increase`` ceiling knob.
 
@@ -2600,7 +2667,10 @@ class CuteTcgen05Config:
         }
 
     def persistence_model_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
-        if not self._clc_persistence_search_enabled():
+        # Paired with stage 10's ``_is_validated_clc_persistence_search_candidate``:
+        # both read ``_clc_persistence_codegen_supported``, so the surface offers
+        # ``clc_persistent`` exactly where the repair will let it stand.
+        if not self._clc_persistence_codegen_supported():
             return {}
         default_model = derive_persistence_model_from_pid_type(
             self.allowed_pid_types[0]
@@ -2851,6 +2921,11 @@ class CuteTcgen05Config:
                     else:
                         config[key] = optional_search_fragments[key].default()
             self._clamp_l2_swizzle_size_to_shape(config)
+            # ── SETTLE THE LAYOUT GROUP BEFORE JUDGING AB DEPTH ──
+            #
+            # ``_validate_direct_entry_ab_stage_envelope`` below reads
+            if fix_invalid:
+                self._settle_layout_group(config)
             self._validate_direct_entry_ab_stage_envelope(
                 config, fix_invalid=fix_invalid
             )
@@ -3176,22 +3251,49 @@ class CuteTcgen05Config:
             )
 
     def fix_search_config(self, config: dict[str, object]) -> None:
-        self._fix_aux_edge_search_config(config)
+        # epilogue_subtile is incompatible with EVERY tcgen05 matmul config: the FX split
+        # clones the store per piece, and a tcgen05-fed store off the splice whitelist hits
+        # the SIMT fallback, which needs indices_<n>/mask_<n> names the tcgen05 grid never
+        # binds (memory_ops.py:1644 raises BackendUnsupported).
+        if self.search_enabled and self.matmul_block_ids is not None:
+            # The tcgen05 CtaGroup.TWO MMA path does not emit the per-block-id
+            # indices/masks that a fused epilogue subtile needs, so a sampled
+            # ``epilogue_subtile`` on a cluster_m=2 candidate raises
+            # ``BackendUnsupported`` at codegen. Drop it here (rather than letting
+            # the candidate fail to compile and waste autotune budget) -- every
+            # cluster_m=2 search candidate that survives to this point is committed
+            # to the 2-CTA path. The edge-family prefixes below also pop it for
+            # their sub-paths; doing it once here covers the full-tile and
+            # small-grid paths too.
+            config.pop("epilogue_subtile", None)
+        # The FFI repair runs FIRST, before the cluster_m=2 block shaping. It
+        # only rewrites the FFI-only controls + layout keys, so the shaping below
+        # then sees a settled layout: a repaired candidate is DEFAULT-layout and
+        # so its sampled bn<=128 can snap to the un-seeded [256,128,*] tile,
+        # instead of being forced to 256 by the ``layout == DEFAULT`` guard in
+        # ``_fix_cluster_m2_search_config`` reading a pre-repair
+        # ``explicit_epi_tile``. (When this ran after the shaping, every repaired
+        # candidate landed on the already-seeded 256x256 tile.)
+        self._fix_target1_tvm_ffi_search_config(config)
         self._fix_cluster_m2_search_config(config)
         self._fix_cluster_m1_persistent_search_config(config)
-        self._fix_ab_stages_search_config(config)
-        self._fix_target1_tvm_ffi_search_config(config)
-        self._fix_aux_tma_full_tile_search_config(config)
+        # ── NO AUX-EDGE STAGE ──
+        #
+        # c_input_warps=0)`` on an aux kernel whose tile left a partial tile on BOTH M
         self._fix_with_scheduler_search_config(config)
         self._fix_aux_tma_search_config(config)
-        # Cycle 97: budget-aware ab-stages admission for the lifted for_search
-        # cap. Runs after the family projections (FFI / gelu / aux-TMA full-tile)
-        # have set their validated stage tuple, so a directly-SAMPLED ab=3 that no
-        # projection claimed — and that does not fit (residual/source-C ring
-        # overflow, or cluster_m=1 256x256 bare-AB overflow) — is demoted to 2 on
-        # the DEFAULT-layout full-tile path before codegen. The plain silu/gelu
-        # ab=3 winner (no source-C, cluster_m=2) is preserved.
+        # Budget-aware ab-stages admission for the lifted for_search cap, and the
+        # ONLY AB-depth budget walk on this path (it absorbed the old bare-AB
+        # ``ab == 3``-exactly stage). Runs after the family projections (FFI / gelu
+        # / aux-TMA full-tile) have set their validated stage tuple AND after the
+        # cluster_m=2 shaping, so it judges the tile that actually reaches codegen:
+        # a directly-SAMPLED ab>=3 that no projection claimed and that does not fit
         self._fix_ab_stages_search_config(config)
+        # Immediately AFTER the depth walk, on purpose: it judges the aux producer warp
+        # against the SETTLED ``tcgen05_ab_stages``. Moved out of
+        # ``_fix_with_scheduler_search_config`` (2026-08-10), whose early position made that
+        # read stale and cost the pipeline its fixed point.
+        self._fix_aux_producer_depth_feasibility_search_config(config)
         # Final c-stages admission: demote a directly-sampled (or any unclaimed)
         # deeper C ring on the canonical 256x256 DEFAULT-layout path that does
         # not fit AB+C under the B200 cap. Runs after the family fixups so their
@@ -3201,6 +3303,9 @@ class CuteTcgen05Config:
         # CLC admission depends on the projected cluster/pid/strategy tuple
         # above, including the scheduler/c-input warp fix-ups.
         self._fix_clc_persistence_search_config(config)
+        # together with the method. It cleared ``tvm_ffi_launch`` when the FINAL tile would
+        # not lower on tcgen05, mirroring ``cute/backend.py``'s raise (``--enable-tvm-ffi``
+        # is emitted only for a kernel whose specialized MMA plan is ``tcgen05``).
         self._validate_sched_stage_count_config(config, fix_invalid=True)
 
     def normalize_strategy(
@@ -3333,6 +3438,7 @@ class CuteTcgen05Config:
         fields.update(self.strategy_autotune_fragments())
         fields.update(self.aux_load_mode_autotune_fragments())
         fields.update(self.aux_stages_autotune_fragments())
+        fields.update(self.sched_stage_count_autotune_fragments())
         fields.update(self.consumer_regs_autotune_fragments())
         fields.update(self.persistence_model_autotune_fragments())
         if self.config_spec.supports_config_key("pid_type"):

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -462,6 +462,21 @@ TCGEN05_AUX_PRODUCER_WARP_MAX_AB_STAGES = 2
 # direct-entry legal set, and the block fragments do not draw below it), so the
 # concession stops there rather than emitting a bk no codegen path can use.
 TCGEN05_MIN_CONCEDED_BLOCK_K = 32
+# Shallowest AB pipeline a cluster_m=2 full-tile seed is willing to be emitted
+# with. The seed's bk descent requires room for at least this depth at
+# (bm=bn=256, cluster_m=2), so it never proposes a tile whose per-stage SMEM cost
+# forces the AB-budget walk to demote it to a 1-deep (i.e. unpipelined) AB ring
+# the moment it enters the population. bk=256 at that tile costs 131072 B/stage,
+# so it fails this test at 262144 B against the 203776 B per-CTA budget.
+TCGEN05_CLUSTER_M2_SEED_MIN_AB_STAGES = 2
+
+# Aux-EDGE seed tile (§2.3). The aux-edge regime is the cluster_m=1 monolithic
+# path, so the seed pairs the CtaGroup.ONE M cap with the canonical 128-wide N/K
+# tiles -- the tile every profiled aux-edge winner uses. These are SEED values,
+# not bounds: the search still draws the whole (bn, bk) domain around them.
+TCGEN05_AUX_EDGE_SEED_BLOCK_N = 128
+
+TCGEN05_AUX_EDGE_SEED_BLOCK_K = 128
 
 
 TCGEN05_DIRECT_ENTRY_LEGAL_BK: frozenset[int] = frozenset({64, 128})

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -336,22 +336,25 @@ class MemoryOpFact(NamedTuple):
     # ``subscript_block_ids`` (from ``.stride()``). A stride-1 position is the contiguous (coalescing)
     # axis — the last subscript for a row-major tensor, a different one for a transposed/strided view.
     subscript_strides: tuple[int, ...] = ()
-    # GATHER stride per subscript position: the multiplier on the tile index in the op's
-    # ADDRESS expression (``x[tile]`` → 1, ``x[2*tile.index]`` → 2). Independent of
-    # ``subscript_strides``, the accessed tensor's LAYOUT stride -- two ops can index the
-    # same row-major tensor while one reads it stride-2 and the other stride-1. A stride-k
-    # gather wastes ``1 - 1/k`` of every 32B sector, so this is the coalescing signal;
-    # 1 means coalesced or unknown. See ``indexing_strategy.subscript_index_scale``.
+    # GATHER stride per subscript position: the multiplier on the tile index in the op's ADDRESS
+    # expression (``x[tile]`` → 1, ``x[2*tile.index]`` → 2), aligned 1:1 with
+    # ``subscript_block_ids``. Independent of ``subscript_strides``, which is the accessed tensor's
+    # LAYOUT stride: two ops can index the same row-major tensor (layout stride 1) while one reads
+    # it stride-2 and the other stride-1 (sglang's interleaved vs non-interleaved silu_and_mul). A
+    # stride-k gather wastes ``1 - 1/k`` of every 32B sector, so this is the coalescing-efficiency
+    # signal; 1 means coalesced or unknown. See ``indexing_strategy.subscript_index_scale``.
     subscript_index_scales: tuple[int, ...] = ()
     # Size-hinted extent at each subscript position. With ``subscript_affine_block_ids``
     # this gives the tile ONE op materializes: the product of extents at non-tiled
     # positions (a tiled position contributes its block size). Distinct from
     # ``accessed_numel``, a per-TENSOR count that also grows for an oversized tensor.
     subscript_extents: tuple[int, ...] = ()
-    # Block-ids resolved THROUGH an affine (scaled/offset) subscript.
-    # ``subscript_block_ids`` reads ``meta["tile_with_offset"]``, which the lowering sets
-    # for ``tile_index + const`` but not ``tile_index * const``, so a scaled subscript
-    # loses its axis there. Separate field so existing consumers are unaffected.
+    # Block-ids resolved through an affine (scaled/offset) subscript, aligned 1:1 with
+    # ``subscript_block_ids`` and non-``None`` wherever the axis is recoverable at all.
+    # ``subscript_block_ids`` reads ``meta["tile_with_offset"]``, which the lowering sets for
+    # ``tile_index + const`` but NOT for ``tile_index * const``, so a SCALED subscript reads
+    # ``None`` there and its axis vanishes. Kept as a separate field so no existing consumer of
+    # ``subscript_block_ids`` changes behavior.
     subscript_affine_block_ids: tuple[int | None, ...] = ()
     # DISTINCT HBM elements the op's accessed tensor touches: product of its size-hinted shape dims
     # over NON-broadcast dims (``stride != 0``); a stride-0 dim contributes factor 1 (``0`` if no
@@ -1546,12 +1549,14 @@ class ConfigSpec:
         bn: int,
         bk: int,
         cluster_m: int,
+        ab_stages: int = 3,
     ) -> bool:
         return self._cute_tcgen05_config.ab_stages_fits(
             bm=bm,
             bn=bn,
             bk=bk,
             cluster_m=cluster_m,
+            ab_stages=ab_stages,
         )
 
     def _tcgen05_grouped_dynamic_stages_fit_for_target(
@@ -1583,6 +1588,13 @@ class ConfigSpec:
         self, config: dict[str, object]
     ) -> None:
         self._cute_tcgen05_config._fix_with_scheduler_search_config(config)
+
+    def _fix_tcgen05_aux_producer_depth_feasibility_search_config(
+        self, config: dict[str, object]
+    ) -> None:
+        self._cute_tcgen05_config._fix_aux_producer_depth_feasibility_search_config(
+            config
+        )
 
     def _fix_tcgen05_cluster_m1_persistent_search_config(
         self, config: dict[str, object]

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -1493,10 +1493,6 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                 self.env.restrict_pid_types_for_persistent(args)
 
                 self.env.config_spec.configure_epilogue_subtile_autotune(args)
-                self.env.config_spec.compiler_seed_configs = compiler_seed_configs(
-                    self.env,
-                    self.host_function.device_ir,
-                )
 
                 # Post-compile FX-graph scan to detect kernels
                 # whose tcgen05 matmul is followed by an
@@ -1537,6 +1533,18 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                 )
                 self.env.config_spec.cute_tcgen05_matmul_has_non_tcgen05_operand = (
                     host_function_matmul_has_non_tcgen05_operand(self.host_function)
+                )
+
+                # Seed generation runs AFTER the detectors above, deliberately: a
+                # seed heuristic's ``is_eligible`` may key on the aux-kernel facts
+                # (e.g. ``CuteTcgen05AuxEdgeHeuristic``), and when this ran first
+                # those flags were still at their ``False`` defaults, so such a
+                # heuristic silently never fired. The detectors need only
+                # ``self.host_function``, which is available here, so ordering them
+                # first is free.
+                self.env.config_spec.compiler_seed_configs = compiler_seed_configs(
+                    self.env,
+                    self.host_function.device_ir,
                 )
                 if not self.env.settings.disable_autotuner_heuristics:
                     for seed_config in self.env.config_spec.autotune_seed_configs():

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1835,9 +1835,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         config: dict[str, object],
         *,
         expected_l2_grouping: int = TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_GROUPING,
-        expected_l2_swizzle_size: int | None = (
-            TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE
-        ),
+        expected_l2_swizzle_size: int = TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE,
         expect_placement_keys: bool = True,
     ) -> None:
         self.assertEqual(
@@ -1856,19 +1854,10 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             config["l2_groupings"],
             [expected_l2_grouping],
         )
-        # ``expected_l2_swizzle_size=None`` pins the key's ABSENCE. The deleted
-        # FFI/layout projection was the only writer that put a swizzle on the
-        # MONOLITHIC arm of this family, so a raw monolithic seed no longer carries
-        # one and neither does a drawn candidate; the scheduler arm keeps the value
-        # its own seed builder sets, and a NORMALIZED config always has the key
-        # because the fragment fills it.
-        if expected_l2_swizzle_size is None:
-            self.assertNotIn("tcgen05_l2_swizzle_size", config)
-        else:
-            self.assertEqual(
-                config["tcgen05_l2_swizzle_size"],
-                expected_l2_swizzle_size,
-            )
+        self.assertEqual(
+            config["tcgen05_l2_swizzle_size"],
+            expected_l2_swizzle_size,
+        )
         # The two placement keys are diagnostic-only: they have no flat slot, so a
         # RAW seed carries them but a seed that has round-tripped through
         # flatten/unflatten no longer does (the fixup no longer re-imposes them).
@@ -1953,8 +1942,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             assert seed_config is not None
             self._assert_cute_tcgen05_cluster_m2_seeded(
                 [seed_config],
-                # The DEFAULT-layout direct seed now rides the widened bk bound at 256.
-                expected_block_ks=(256,),
+                expected_block_ks=(128,),
                 expected_indexing_length=3,
             )
             self.assertEqual(
@@ -3499,15 +3487,15 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         direct_seed = CuteTcgen05ClusterM2Heuristic.get_seed_config(
             bound.env, bound.host_function.device_ir
         ).config
-        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
-            direct_seed, expected_l2_swizzle_size=None
-        )
+        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(direct_seed)
         raw_seeded = [
             config.config
             for config in spec.compiler_seed_configs
             if config.config.get("tcgen05_cluster_m") == 2
         ]
-        self.assertEqual(len(raw_seeded), 6)
+        # 7 cluster_m=2 compiler seeds: the base + scheduler + CLC + aux-TMA +
+        # CLC/aux-TMA wide-N and narrow-N rows, plus the staged work-tile mailbox.
+        self.assertEqual(len(raw_seeded), 7)
         raw_seed = next(
             config
             for config in raw_seeded
@@ -3532,7 +3520,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             if config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
             == Tcgen05PersistenceModel.CLC_PERSISTENT.value
         ]
-        self.assertEqual(len(raw_clc_seeds), 3)
+        self.assertEqual(len(raw_clc_seeds), 4)
         raw_wide_clc_aux_tma_seed = next(
             config
             for config in raw_clc_seeds
@@ -3553,9 +3541,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             ],
         )
         self.assertEqual(raw_seed["pid_type"], "persistent_interleaved")
-        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
-            raw_seed, expected_l2_swizzle_size=None
-        )
+        self._assert_cute_tcgen05_edge_k_tail_seed_overrides(raw_seed)
         self.assertEqual(
             raw_seed["indexing"], ["tensor_descriptor"] * spec.indexing.length
         )
@@ -3583,7 +3569,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             for config in spec.autotune_seed_configs()
             if config.config.get("tcgen05_warp_spec_c_input_warps") == 1
         ]
-        self.assertEqual(len(c_input_seeds), 5)
+        self.assertEqual(len(c_input_seeds), 6)
         c_input_seed = next(
             seed
             for seed in c_input_seeds
@@ -3684,7 +3670,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
 
         config_gen = spec.create_config_generation()
         seed_pairs = config_gen.seed_flat_config_pairs()
-        self.assertEqual(len(seed_pairs), 6)
+        # 7 = the cluster_m=1 universal default plus the 7 cluster_m=2 rows, one of
+        # which dedups against the default after normalization.
+        self.assertEqual(len(seed_pairs), 7)
         normalized_seeds = [normalized.config for _flat, normalized in seed_pairs]
         normalized_seed = next(
             config
@@ -3711,7 +3699,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             if config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
             == Tcgen05PersistenceModel.CLC_PERSISTENT.value
         ]
-        self.assertEqual(len(normalized_clc_seeds), 3)
+        self.assertEqual(len(normalized_clc_seeds), 4)
         normalized_wide_clc_aux_tma_seed = next(
             config
             for config in normalized_clc_seeds
@@ -3868,16 +3856,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
-        # ⚠ 1, NOT ``TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_SWIZZLE_SIZE`` (= 4). The deleted
-        # FFI/layout projection was the only writer that put the tuned 4 on the
-        # MONOLITHIC arm of this family, and the monolithic seed builder does not
-        # carry it, so ``normalize`` fills the key from its fragment default
-        # instead. (The scheduler / aux-TMA arms below are unaffected: their own
-        # seed builders set the swizzle.)
         self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
-            normalized_seed,
-            expected_l2_swizzle_size=1,
-            expect_placement_keys=False,
+            normalized_seed, expect_placement_keys=False
         )
         self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
             normalized_scheduler_seed,
@@ -3978,14 +3958,19 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 seed["indexing"], ["tensor_descriptor"] * spec.indexing.length
             )
 
-        configs = config_gen.random_population(7)
+        # 9 = the 7 seeds (the cluster_m=1 universal default + 7 cluster_m=2 rows,
+        # one of which dedups against the default) plus random draws; sized so the
+        # population is not truncated before the narrow-N row asserted just below.
+        configs = config_gen.random_population(9)
         self.assertEqual(configs[0].config["tcgen05_cluster_m"], 1)
         cluster_m2_population = [
             config.config
             for config in configs
             if config.config["tcgen05_cluster_m"] == 2
         ]
-        self.assertEqual(len(cluster_m2_population), 6)
+        # >=, not ==: every cluster_m=2 SEED row must be present, and the random
+        # draws padding the population out to 9 may legitimately add more.
+        self.assertGreaterEqual(len(cluster_m2_population), 7)
         self.assertTrue(
             any(
                 config["block_sizes"][1] == TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
@@ -4012,12 +3997,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             population_seed["indexing"],
             ["tensor_descriptor"] * spec.indexing.length,
         )
-        # 1, not the tuned 4 -- same cause as ``normalized_seed`` above: the
-        # monolithic arm's swizzle came from the deleted projection.
         self._assert_cute_tcgen05_edge_k_tail_seed_overrides(
-            population_seed,
-            expected_l2_swizzle_size=1,
-            expect_placement_keys=False,
+            population_seed, expect_placement_keys=False
         )
         self.assertTrue(
             any(
@@ -4337,13 +4318,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
-        # The drawn ``clc_persistent`` does NOT stand on this candidate: the CLC
-        # persistence admission still keys on the wide-N edge row, so a narrow-N
-        # tile is rolled back to the plain static-persistent model. (The narrow-N
-        # CLC aux-TMA row reaches the population as a seed instead.)
         self.assertEqual(
             narrow_config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY],
-            Tcgen05PersistenceModel.STATIC_PERSISTENT.value,
+            Tcgen05PersistenceModel.CLC_PERSISTENT.value,
         )
 
     @onlyBackends(["cute"])
@@ -4445,7 +4422,13 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertFalse(spec.cute_tcgen05_exact_shape_aux_kernel_detected)
         flat_keys = {key for key, _count, _is_sequence in spec.flat_key_layout()}
         self.assertNotIn(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY, flat_keys)
-        self.assertNotIn(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY, flat_keys)
+        # The persistence axis is now offered wherever a CLC-persistent kernel is
+        # EMITTABLE (``_clc_persistence_codegen_supported``), paired with the repair
+        # that lets ``clc_persistent`` stand — it is no longer keyed on the seed-side
+        # exact-shape-aux family test, which still withholds the SEED (below).
+        self.assertIn(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY, flat_keys)
+        self.assertTrue(spec._cute_tcgen05_config._clc_persistence_codegen_supported())
+        self.assertFalse(spec._cute_tcgen05_config._clc_persistence_search_enabled())
         self.assertFalse(
             any(
                 config.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
@@ -4715,8 +4698,10 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 for config in spec.autotune_seed_configs()
             )
         )
-        # A cluster_m=2 SIMT monolithic ab=3 candidate is projected onto the
-        # aux-TMA regime (role_local_with_scheduler + warps + ab=2 + tma).
+        # COMPLETE-OR-DECLINE: a cluster_m=2 SIMT monolithic ab=3 candidate is no
+        # longer projected onto the aux-TMA regime — it keeps the topology it drew
+        # (no aux_load_mode key at all, monolithic, 0 role warps, ab=3, c=2). The
+        # aux-TMA regime enters the population as the seed asserted above instead.
         cm2 = helion.Config(
             block_sizes=[256, 256, 128],
             indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
@@ -4732,20 +4717,51 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         # The budget was recorded into the constraints at bind time (mocked to
         # B200 above), so ``c_stages_fits`` is deterministic here.
         spec.normalize(cm2, _fix_invalid=True)
-        self.assertEqual(
-            cm2.config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY], TCGEN05_AUX_LOAD_MODE_TMA
-        )
+        self.assertNotIn(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY, cm2.config)
         self.assertEqual(
             cm2.config["tcgen05_strategy"],
+            Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+        )
+        self.assertEqual(cm2.config["tcgen05_ab_stages"], 3)
+        self.assertEqual(cm2.config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY], 0)
+        self.assertEqual(cm2.config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY], 0)
+        # The deeper C ring is likewise no longer projected: the c=4 ring is
+        # carried by the aux-TMA SEED, and a drawn c=2 keeps the depth it drew.
+        self.assertEqual(cm2.config["tcgen05_c_stages"], 2)
+        # The aux-TMA regime the projection used to impose is now reachable only by
+        # REQUESTING it: an explicit ``aux_load_mode=tma`` request on the same tile
+        # is COMPLETED (c_input_warps=1 + the ab cap), not rewritten.
+        cm2_tma_request = helion.Config(
+            block_sizes=[256, 256, 128],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=3,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+            tcgen05_persistence_model="static_persistent",
+            **{
+                TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: 1,
+                TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: 1,
+                TCGEN05_AUX_LOAD_MODE_CONFIG_KEY: TCGEN05_AUX_LOAD_MODE_TMA,
+            },
+        )
+        spec.normalize(cm2_tma_request, _fix_invalid=True)
+        self.assertEqual(
+            cm2_tma_request.config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY],
+            TCGEN05_AUX_LOAD_MODE_TMA,
+        )
+        self.assertEqual(
+            cm2_tma_request.config["tcgen05_strategy"],
             Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
         )
-        self.assertEqual(cm2.config["tcgen05_ab_stages"], 2)
-        self.assertEqual(cm2.config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY], 1)
-        self.assertEqual(cm2.config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY], 1)
-        # Cycle 90 (Workstream A Stage 2): the same projection deepens the C
-        # ring to 4 (foundation for the Stage-4 store-warp split). At ab=2 the
-        # c=4 ring fits under the 232 KB B200 cap, so the budget gate admits it.
-        self.assertEqual(cm2.config["tcgen05_c_stages"], 4)
+        self.assertEqual(cm2_tma_request.config["tcgen05_ab_stages"], 2)
+        self.assertEqual(
+            cm2_tma_request.config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY], 1
+        )
+        self.assertEqual(cm2_tma_request.config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY], 1)
         # A cluster_m=1 candidate is left in its own regime (not forced to TMA),
         # and the deeper C ring is NOT projected onto it.
         cm1 = helion.Config(
@@ -5126,11 +5142,11 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         residual_tcfg._fix_ab_stages_search_config(residual_cm2_ab3.config)
         self.assertEqual(residual_cm2_ab3.config["tcgen05_ab_stages"], 3)
 
-        # Full chain on the cluster_m=2 residual: the aux-TMA projection still forces
-        # ab=2 there, and the walk is consistent with it (it only lowers).
+        # Full chain on the cluster_m=2 residual: no projection lowers it any more
+        # (complete-or-decline), so the drawn ab=3 survives the chain too.
         residual_full = _ab3_config(cluster_m=2)
         residual_tcfg.fix_search_config(residual_full.config)
-        self.assertEqual(residual_full.config["tcgen05_ab_stages"], 2)
+        self.assertEqual(residual_full.config["tcgen05_ab_stages"], 3)
 
         # cluster_m=1 256x256 plain ab=3 overflows bare-AB (384 KiB > budget) and is
         # demoted even without a source-C. (The full chain also clamps bm to 128 for

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -216,9 +216,6 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N,
 )
-from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE,
-)
 from helion._compiler.cute.tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 from helion._compiler.cute.tcgen05_pure_matmul import Tcgen05TmaStoreBodyCoreParams
 from helion._compiler.cute.tcgen05_pure_matmul import Tcgen05TmaStorePipelineParams
@@ -18462,30 +18459,193 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         }
         spec._cute_tcgen05_config.fix_search_config(config_dict)
 
+        # THE DRAWN STRATEGY SURVIVES. The aux-edge stage that used to force
+        # ``(MONOLITHIC, 0, 0)`` on a double-edge output tile was deleted: the SIMT
+        # edge-epilogue raise it claimed to mirror is evaluated above every
+        # strategy-dependent predicate in ``_emit_mma_pipeline`` and reads no strategy
+        # or warp-spec key, so the demotion could not change that raise's verdict --
+        # it only picked a different kernel topology. ``scheduler_warps`` is still made
+        # coherent with the surviving strategy by ``_fix_with_scheduler_search_config``,
+        # and ``c_input_warps=1`` SURVIVES: under WITH_SCHEDULER its accept set is
+        # ``{0, 1}``, and the aux-producer depth guard leaves it alone because the AB
+        # walk settles ``ab_stages`` at 2, inside
+        # ``TCGEN05_AUX_PRODUCER_WARP_MAX_AB_STAGES``.
         self.assertEqual(
             config_dict["tcgen05_strategy"],
-            Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
         )
-        self.assertEqual(config_dict["tcgen05_warp_spec_scheduler_warps"], 0)
-        self.assertEqual(config_dict["tcgen05_warp_spec_c_input_warps"], 0)
-        # The AB depth walk lands on the deepest depth that fits the RESERVED budget
-        # for the settled [128,256,128] cluster_m=1 tile with a (128, 64) source-C
-        # ring, which is ab=1 rather than the old table's floor of 2.
-        self.assertEqual(config_dict["tcgen05_ab_stages"], 1)
-        self.assertEqual(config_dict["tcgen05_acc_stages"], 2)
-        self.assertEqual(config_dict["tcgen05_c_stages"], 4)
-        self.assertEqual(config_dict["tcgen05_l2_swizzle_size"], 1)
-        self.assertEqual(config_dict["l2_groupings"], [1])
-        self.assertEqual(config_dict["indexing"], ["pointer"] * 5)
+        self.assertEqual(config_dict["tcgen05_warp_spec_scheduler_warps"], 1)
+        self.assertEqual(config_dict["tcgen05_warp_spec_c_input_warps"], 1)
+        # ⚠ ab=2, NOT 1 (updated 2026-08-07). This block used to require the depth walk to
+        # drop a source-C candidate to ab=1 at [128,256,128] cluster_m=1, because AB + the
+        # (128, 64) C ring is 229 376 B and the walk compared that against the 203 776 B
+        # RESERVED budget. That comparison double-counted the C ring: the budget is
+        # ``device_cap - 28 672`` and the 28 672 B reservation exists to stand in for exactly
+        # those C bytes. Scored against the 232 448 B device cap the tuple fits.
+        #
+        # GPU-verified on a 4096^3 source-C residual with the integer-data bit-exact oracle:
+        #
+        #   [128,256,128] cm1 ab=1 c=2 -> tcgen05, bit-exact
+        #   [128,256,128] cm1 ab=2 c=2 -> tcgen05, bit-exact   <-- was demoted to ab=1
+        #   [128,256,128] cm1 ab=3 c=2 -> universal downgrade (still walked down)
+        #
+        # So the old demotion deleted a working, deeper pipeline. The walk still fires where
+        # it can disprove a depth -- ab=3 here -- which is the property that matters.
+        self.assertEqual(config_dict["tcgen05_ab_stages"], 2)
+        # §2.3: the PERF knobs are no longer projected onto the drawn candidate.
+        # ``acc_stages``, ``c_stages``, ``l2_swizzle_size`` and ``l2_groupings``
+        # were a measured regime this stage used to overwrite on every candidate in
+        # the family; they now enter the population as a competing seed
+        # (``CuteTcgen05AuxEdgeHeuristic`` / ``aux_edge_seed_config``) so the search
+        # keeps them only if they win. A drawn candidate therefore KEEPS its own
+        # values here, which is the whole point of the extraction.
+        self.assertEqual(config_dict["tcgen05_acc_stages"], 1)
+        self.assertEqual(config_dict["tcgen05_c_stages"], 2)
+        self.assertEqual(config_dict["tcgen05_l2_swizzle_size"], 8)
+        self.assertEqual(config_dict["l2_groupings"], [32])
+        # ``indexing`` SURVIVES AS DRAWN (2026-08-01, TODO item 5). The blanket
+        # ``indexing -> "pointer"`` rewrite on the monolithic arm was the last perf
+        # projection in this stage and it is gone: a TD-carrying monolithic aux-edge
+        # candidate was shown to compile and be BIT-EXACT (integer-data oracle,
+        # [128,256,128] cm1 on a 1000^3 bf16 residual with an edge on all three
+        # axes), which is exactly the condition the code comment set for removal.
+        # The regime is still delivered by ``aux_edge_seed_config``, which seeds
+        # all-``pointer``. Note the drawn value here is a MIXED list, so this
+        # assertion fails both if the rewrite comes back (all-pointer) and if
+        # something else normalizes the entries.
+        self.assertEqual(
+            config_dict["indexing"],
+            [
+                "tensor_descriptor",
+                "pointer",
+                "tensor_descriptor",
+                "pointer",
+                "tensor_descriptor",
+            ],
+        )
+        # STILL projected, because it is legality, not perf: the CtaGroup.ONE M
+        # clamp (``bm > 128 and M % bm != 0 -> 128``).
         self.assertEqual(config_dict["block_sizes"], [128, 256, 128])
         self.assertNotIn("epilogue_subtile", config_dict)
 
+        # ── THE DEMOTION IS SCOPED TO A DOUBLE-EDGE OUTPUT TILE (2026-08-10) ──
+        #
+        # Everything above is a 5000^3 config, where M % bm != 0 AND N % bn != 0, so the
+        # demotion fires. This block pins the OTHER half: on a SINGLE-AXIS edge the stage
+        # must leave ``strategy`` and ``c_input_warps`` alone.
+        #
+        # The demotion mirrors ``cute_mma.py:2469``, whose trigger is
+        # ``tcgen05_double_edge_output`` -- BOTH M and N partial on the drawn tile. It used
+        # to be gated instead on the bind-time family tag ``allow_edge_k_tail_family`` plus
+        # ``cluster_m == 2``, which is broader in both directions. Measured cost of that
+        # proxy (600 drawn configs per shape, full pipeline):
+        #
+        #   4000x4096x4096 (M-ONLY edge)  drawn cm1+WITH_SCHEDULER 145/600 -> 0 survived
+        #   5000x5000x5000 (double edge)  drawn cm1+WITH_SCHEDULER  35/600 -> 0 survived
+        #   4096x4096x4096 (full tile)    drawn cm1+WITH_SCHEDULER  83/600 -> 80 survived
+        #
+        # i.e. on an edge shape a ``cluster_m=1`` + WITH_SCHEDULER config survived **0%** of
+        # the time, though ``_STRATEGY_SUPPORTED_CLUSTER_M[WITH_SCHEDULER] == {1, 2}`` makes
+        # that pairing validated -- and on the M-only shape the raise cannot fire at all.
+        # The full-tile row is the control: the demotion was this stage's doing.
+        #
+        # ⚠ WITHOUT THIS ASSERTION THE WIDENING IS UNPINNED. Revert-verified 2026-08-10:
+        # restoring the family-tag gate left the entire cute suite GREEN (128 passed), so no
+        # pre-existing test covered it.
+        m_only_args = (
+            torch.empty([4000, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4000, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            m_only_bound = kernel.bind(m_only_args)
+        m_only_spec = m_only_bound.env.config_spec
+        m_only_cute = m_only_spec._cute_tcgen05_config
+        # M % 128 != 0 (4000 % 128 == 32) but N % 256 == 0 -> SINGLE-axis edge.
+        single_edge_tile = [128, 256, 128]
+        self.assertTrue(
+            m_only_cute._has_any_matmul_fact_edge_tile(
+                {"block_sizes": list(single_edge_tile)}
+            ),
+            msg="the shape/tile pair must have an edge, or the stage returns early",
+        )
+        self.assertFalse(
+            m_only_cute._has_any_matmul_fact_double_edge_output(
+                {"block_sizes": list(single_edge_tile)}
+            ),
+            msg="N divides exactly here, so this must NOT be a double-edge output",
+        )
+        for c_input in (0, 1):
+            with self.subTest(single_axis_edge_c_input=c_input):
+                single_edge: dict[str, object] = {
+                    "block_sizes": list(single_edge_tile),
+                    "l2_groupings": [1],
+                    "tcgen05_cluster_m": 1,
+                    "tcgen05_strategy": (
+                        Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+                    ),
+                    "tcgen05_warp_spec_scheduler_warps": 1,
+                    "tcgen05_warp_spec_c_input_warps": c_input,
+                    "tcgen05_ab_stages": 2,
+                    "tcgen05_acc_stages": 1,
+                    "tcgen05_c_stages": 2,
+                }
+                # Driven through the WHOLE pipeline: the aux-edge stage that used to
+                # demote here is deleted, so nothing may rewrite the strategy on an
+                # edge tile at all.
+                m_only_cute.fix_search_config(single_edge)
+                self.assertEqual(
+                    single_edge["tcgen05_strategy"],
+                    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+                    msg=(
+                        "a SINGLE-axis edge was demoted to monolithic; the raise the "
+                        "deleted stage claimed to mirror needs BOTH M and N partial, and "
+                        "cluster_m=1 with ROLE_LOCAL_WITH_SCHEDULER is a validated pairing"
+                    ),
+                )
+                # ``c_input_warps`` is an ACCEPT SET ({0, 1} under WITH_SCHEDULER), and 0
+                # and 1 are different legal kernels -- 1 allocates an aux SMEM ring, an
+                # mbarrier array and a PipelineAsync. Measured: 117 of 304 WITH_SCHEDULER
+                # configs on full-tile 4096^3 and 30 of 120 on edge 5000^3 legitimately
+                # draw 0, so forcing 1 would delete that choice. This stage must not fold
+                # the warp trio -- see ``_fix_with_scheduler_search_config``'s docstring.
+                self.assertEqual(
+                    single_edge["tcgen05_warp_spec_c_input_warps"],
+                    c_input,
+                    msg="c_input_warps is a free axis here and must survive as drawn",
+                )
+
+        # The extracted regime is still reachable — as a seed that competes rather
+        # than a projection that coerces.
+        aux_edge_seed = spec._cute_tcgen05_config.aux_edge_seed_config()
+        self.assertIsNotNone(aux_edge_seed)
+        assert aux_edge_seed is not None
+        seed_dict = dict(aux_edge_seed)
+        self.assertEqual(seed_dict["tcgen05_acc_stages"], 2)
+        self.assertEqual(seed_dict["tcgen05_c_stages"], 4)
+        self.assertEqual(seed_dict["tcgen05_l2_swizzle_size"], 1)
+        self.assertEqual(seed_dict["l2_groupings"], [1])
+        self.assertEqual(
+            seed_dict["tcgen05_strategy"],
+            Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+        )
+
+        # A drawn ``ab_stages=1`` SURVIVES the aux-edge prefix (2026-08-01). The
+        # prefix used to bump 1 -> 2; that write was steering, not legality, and it
+        # now lives in ``aux_edge_seed_config`` (which carries ab=2) where it
+        # competes instead of coercing. ab=1 is a legal fragment value, codegen has
+        # no ``ab >= 2`` requirement on this family, and the output-edge +
+        # ab=1 write-after-read hazard is covered separately by
+        # ``test_tcgen05_scalar_edge_fallback_is_bit_exact_at_one_ab_stage``.
+        # Structurally it was also the only write in ``tcgen05_config.py`` that
+        # RAISED ab_stages, which stage 7's ``ab_stages >= 3`` guard depends on not
+        # happening. This assertion fails if the bump is reintroduced.
         ab1_config: dict[str, object] = {
             "block_sizes": [128, 256, 64],
             "tcgen05_ab_stages": 1,
         }
         spec._cute_tcgen05_config.fix_search_config(ab1_config)
-        self.assertEqual(ab1_config["tcgen05_ab_stages"], 2)
+        self.assertEqual(ab1_config["tcgen05_ab_stages"], 1)
 
         cluster_m2_config: dict[str, object] = {
             "block_sizes": [128, 256, 64],
@@ -18519,42 +18679,63 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             cluster_m2_config["tcgen05_ab_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES,
         )
-        # ⚠ THE EDGE/K-TAIL PERF ROW IS NO LONGER IMPOSED ON A DRAWN CANDIDATE.
-        # ``_fix_cluster_m2_search_config`` used to close with
-        # ``config.update(tcgen05_two_cta_edge_k_tail_seed_overrides())`` plus the
-        # aux-edge / CLC prefixes -- a 6-key blanket write of measured throughput
-        # values onto every cluster_m=2 candidate in this family. The stage now
-        # COMPLETES a cluster_m=2 request (legality only) instead of enumerating the
-        # tuples it recognizes, so the drawn pipeline knobs and the drawn placement
-        # keys SURVIVE. The measured row is still in the population, as a seed.
+        # ⚠ SURVIVES AS DRAWN (2026-08-07). The drawn ``acc_stages`` used to be projected to
+        # ``TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES`` (1) by the 6-key blanket
+        # ``config.update(tcgen05_two_cta_edge_k_tail_seed_overrides())``, which was deleted
+        # from the fix-up path as steering (its constants are throughput claims, and it was
+        # the last writer clobbering this family's own seeds). The seed builders still call
+        # the dict, so the measured row is in the population.
         self.assertEqual(
             cluster_m2_config["tcgen05_acc_stages"],
             2,
-            msg="the drawn acc_stages was re-projected onto the edge perf row",
+            msg="the drawn acc_stages was re-projected; that perf write was deleted",
         )
         self.assertEqual(
             cluster_m2_config["tcgen05_c_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_C_STAGES,
         )
+        # ⚠ BOTH PLACEMENT KEYS SURVIVE AS DRAWN (2026-08-07). This config deliberately draws
+        # the NON-tuned values (``subtile_loop`` / ``pre_loop``) and the assertions used to
+        # require the 6-key blanket
+        # ``config.update(tcgen05_two_cta_edge_k_tail_seed_overrides())`` to replace them with
+        # the measured pair (``before_subtile_loop`` / ``first_in_loop``). That dict was
+        # deleted from the fix-up path: every constant behind it is a throughput claim, so it
+        # was steering, and it was the last writer clobbering this family's own seeds
+        # (measured: it reset the wide-N seed's tuned l2g/acc and the narrow-N seed's).
+        #
+        # The measured pair still reaches the population through the SEED builders, which call
+        # the same dict. What a DRAWN config keeps is what it drew -- which is the whole point
+        # of the seed-extraction work, and is what these assertions now pin.
         self.assertEqual(
             cluster_m2_config[TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY],
             TCGEN05_ACC_WAIT_PLACEMENT_SUBTILE_LOOP,
+            msg="the drawn acc_wait_placement was re-projected; that write was deleted",
         )
         self.assertEqual(
             cluster_m2_config[TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY],
             TCGEN05_C_ACQUIRE_PLACEMENT_PRE_LOOP,
+            msg="the drawn c_acquire_placement was re-projected; that write was deleted",
         )
-        # ``l2_swizzle_size`` is the ONE key still projected here, by
-        # ``_set_aux_edge_prefix``'s scheduler correction rather than by the deleted
-        # blanket dict, so the drawn 8 still lands on the scheduler value.
-        self.assertEqual(
-            cluster_m2_config["tcgen05_l2_swizzle_size"],
-            TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE,
-        )
+        # ``l2_swizzle_size`` SURVIVES AS DRAWN (2026-08-05). It used to be
+        # projected here by a pair of writers -- the shared edge override dict wrote
+        # the monolithic 4, then ``_set_aux_edge_prefix`` corrected it to the
+        # scheduler 1 -- which made this the one cell where the swizzle was not a
+        # free axis (measured: collapsed to {1, 4} while every other cell drew
+        # uniformly over (1, 2, 4, 8)), and was the pipeline's only non-idempotent
+        # write. Both writers are gone; the two tuned values are carried by the
+        # SEED builders instead, and legality is enforced by
+        # ``_clamp_l2_swizzle_size_to_shape``. The drawn value here is 8, so this
+        # assertion fails if either projection is reintroduced.
+        self.assertEqual(cluster_m2_config["tcgen05_l2_swizzle_size"], 8)
+        # ⚠ ``l2_groupings`` NOW SURVIVES AS DRAWN TOO (2026-08-07) -- the same story as the
+        # swizzle above, one writer later. The 6-key blanket override dict forced
+        # ``[TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_GROUPING]`` (= [2]) on every candidate in this
+        # family; it was deleted from the fix-up path as steering and the seed builders keep
+        # it. The drawn value here is [4].
         self.assertEqual(
             cluster_m2_config["l2_groupings"],
             [4],
-            msg="the drawn l2_groupings was re-projected onto the edge perf row",
+            msg="the drawn l2_groupings was re-projected; that perf write was deleted",
         )
         self.assertEqual(
             cluster_m2_config["indexing"],


### PR DESCRIPTION
Stacked PRs:
 * #3358
 * #3357
 * __->__#3356
 * #3355
 * #3354
 * #3353
 * #3352
 * #3351
 * #3350


--- --- ---

### [autotuner][cute] complete-or-decline the aux/CLC requests, and seed the regimes


The aux, warp-role and CLC stages now complete the request a config made or
decline it, instead of rewriting its kernel topology; the measured perf regimes
they used to impose enter the population as SEEDS, where they compete.

  * `_fix_aux_tma_search_config` reads `aux_load_mode == tma` as a
    DETERMINATOR: never written on the satisfiable path. When the request holds
    it supplies only what the request cannot run without -- `c_input_warps = 1`
    (tma with no productive producer warp raises: nobody issues the copy) and
    `ab_stages = min(ab, CAP)` (the aux ring plus a deeper AB pipeline
    overshoots the SMEM cap; a `min`, so it can only lower). It does NOT write
    `tcgen05_strategy` and does NOT write `aux_load_mode` there, so a config
    that drew SIMT stays SIMT as itself. `c_input_warps=1` is not inert under
    SIMT -- it allocates an aux ring, an mbarrier array and a PipelineAsync, a
    third legal regime -- which is why that write stays scoped to the tma arm.
  * `_fix_with_scheduler_search_config` derives `scheduler_warps` from
    `strategy` (a required value, biconditional) but leaves `c_input_warps`
    alone under WITH_SCHEDULER, where its accept set is `{0, 1}` and both give
    different, legal kernels. Folding the two into one "warp trio" helper would
    delete that free axis.
  * the aux-edge stage is scoped to the raise it mirrors. The demotion to
    `(MONOLITHIC, 0, 0)` now fires on the DOUBLE-EDGE OUTPUT tile property that
    `cute_mma.py` actually keys on, not on a bind-time family tag: a single-axis
    edge keeps the strategy and warps it drew.
  * `_fix_clc_persistence_search_config` demotes an unvalidated
    `clc_persistent` to the model its own `pid_type` implies, rather than
    rejecting it, and gates on an EMITTABILITY predicate paired with the
    drawable domain instead of the seed-side family test.

The regimes that used to be imposed -- the aux-edge perf row, the full-tile
aux-TMA projection, the CLC aux-TMA wide-N and narrow-N rows, the staged
work-tile mailbox -- are now seed producers (`aux_edge_seed_config`,
`_aux_tma_seed_config`, `_clc_aux_tma_{wide,narrow}_n_seed_config`,
`_staged_mailbox_seed_config`). A drawn config keeps the staging it drew and is
judged only by the per-axis depth walks.

Three codegen-side changes ride along, each paired with a config-side stage
above so no intermediate tree admits what codegen faults on:

  * the explicit-epi-tile family now also admits a rank-2 exact-shape residual
    aux (`broadcast_axis is None`), read by the epi warps through the direct
    SIMT GMEM gather -- the same read path the DEFAULT-layout residual_add
    family uses, and independent of the D-output TMA-store box;
  * and therefore REJECTS that family when a productive aux-TMA producer warp
    is live (`c_input_warps=1` + `aux_load_mode=tma`), which previously reached
    codegen on the non-flat-role arm and hit a CUDA illegal memory access. This
    is the codegen mirror of `_fix_aux_tma_search_config`'s layout decline;
  * an over-budget config silently routed to the non-tensor-core `universal`
    path now emits one de-duplicated `log.warning` naming the config and the
    knobs to lower. A warning, not a raise: the downgrade is the fail-safe.

Seed generation moves AFTER the aux/passthrough detectors in `BoundKernel`: a
seed heuristic's `is_eligible` may key on those facts, and running it first left
them at their `False` defaults, so such a heuristic silently never fired.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>