### PR TITLE
[autotuner][cute] tests for the _fix pipeline rework

### DIFF
--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1193,6 +1193,69 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         self.assertEqual(new_config["indexing"], "tensor_descriptor")
         self.assertEqual(mutated[indexing_index], "pointer")
 
+    @patch.object(_compat, "_supports_tensor_descriptor", lambda: True)
+    def test_config_generation_overrides_pinned_in_the_drawn_vector(self):
+        """A frozen key must not be NOISE in the surrogate's training data.
+
+        ``autotune_config_overrides`` freezes a key: it is stamped into every decoded
+        config and the mutation operators skip its slot. But the random samplers used to
+        draw into that slot freely, and the LFBO / DE surrogates build ``train_x`` from
+        the VECTOR, not the config (``encode_config(member.flat_values)``). So a frozen
+        key contributed a VARYING one-hot block while every benchmarked kernel ran with
+        the SAME value -- a column of pure label noise a tree surrogate can split on.
+
+        Measured before the fix (this kernel, 200 members): **8** distinct encoded
+        patterns for the frozen slot against ``indexing='tensor_descriptor'`` in
+        200/200 configs. The two training entry points also disagreed, because
+        ``seed_training_data`` re-encodes from the Config
+        (``flatten(result.config)``) and so carried the override value.
+
+        Both random-draw entry points must pin, and the pin must go through the slot's
+        own fragment: ``indexing`` is a ``ListOf`` occupying ONE slot and holding a
+        LIST, while its override is the SCALAR ``'tensor_descriptor'`` meaning "every
+        element". A naive scalar stamp puts a bare ``str`` in that slot, and
+        ``ListOf.encode`` asserts ``isinstance(value, list)`` -- i.e. it breaks the
+        exact consumer this pin exists to serve.
+        """
+        args = (
+            torch.randn([8, 512, 512], device=DEVICE),
+            torch.randn([8, 512, 512], device=DEVICE),
+        )
+        spec = basic_kernels.add.bind(args).config_spec
+        gen = ConfigGeneration(spec, overrides={"indexing": "tensor_descriptor"})
+        (slot,) = sorted(gen.overridden_flat_indices)
+        expected = ["tensor_descriptor"] * gen.flat_spec[slot].length
+
+        # BOTH random entry points pin the slot, and the value is BROADCAST to the
+        # ListOf's length rather than stamped as a scalar.
+        for draw in (gen.random_flat, gen.biased_random_flat):
+            for _ in range(20):
+                flat = draw()
+                self.assertEqual(
+                    flat[slot],
+                    expected,
+                    msg=f"{draw.__name__} left a non-override value in a frozen slot",
+                )
+                # the surrogate's own encoder must accept it
+                gen.encode_config(flat)
+
+        # ...so the surrogate sees a CONSTANT feature column for the frozen key.
+        encoded = [tuple(gen.encode_config(gen.random_flat())) for _ in range(20)]
+        start = sum(gen.flat_spec[i].dim() for i in range(slot))
+        width = gen.flat_spec[slot].dim()
+        self.assertEqual(
+            len({row[start : start + width] for row in encoded}),
+            1,
+            msg="frozen key still varies in train_x; the surrogate sees label noise",
+        )
+
+        # And the pin must not disturb the round-trip invariant the sibling test pins:
+        # a slot the CALLER writes keeps the caller's value.
+        mutated = gen.random_flat()
+        mutated[slot] = ["pointer"] * gen.flat_spec[slot].length
+        self.assertEqual(gen.unflatten(mutated)["indexing"], "tensor_descriptor")
+        self.assertEqual(mutated[slot], ["pointer"] * gen.flat_spec[slot].length)
+
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     def test_save_load_config(self):
         config = helion.Config(

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1808,11 +1808,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             if config.config["tcgen05_cluster_m"] == 2
         ]
         # FFI-eligible shapes have both DEFAULT-layout and direct-entry seeds, and
-        # the two no longer share a K rung: the widened ``bk`` draw bound lets the
-        # DEFAULT-layout seed sit at 256 while the FFI direct-entry seed stays at
-        # its validated 128. Callers decide which K rungs are expected; every
-        # cluster_m=2 seed must still match the common 256x256 tile envelope at one
-        # of them.
+        # the formula matmul heuristic contributes its own bk. Callers decide which
+        # K rungs are expected; every cluster_m=2 seed must still match the common
+        # 256x256 tile envelope at one of them.
         self.assertGreaterEqual(len(seeded), 1)
         for seed in seeded:
             self.assertIn(
@@ -3272,11 +3270,10 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             for_search=True
         )["tcgen05_ab_stages"]
         self.assertIsInstance(search_ab_stages_fragment, IntegerFragment)
-        # Cycle 97: the for_search ab cap is BUDGET-AWARE — lifted to the 16-bit
-        # dtype hard cap of 8 wherever a deep AB ring is admissible (the SMEM-budget
-        # constraints were recorded at bind time, i.e. bf16/fp16 on a B200-class
-        # optin cap), else 2. Conditioning on the recorded constraints keeps the
-        # assertion deterministic across hosts.
+        # The for_search ab cap is now the DTYPE HARD CAP (8 for 16-bit) wherever the
+        # SMEM-budget constraints were recorded at bind time, else 2 — the per-tile
+        # budget walk, not the cap, trims a drawn depth that does not fit.
+        # Conditioning on the recorded constraints keeps this deterministic per host.
         expected_search_ab_high = (
             8
             if bound.config_spec._cute_tcgen05_config.ab_stages_search_constraints
@@ -3731,11 +3728,11 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
-        # The measured CLC aux-TMA perf ROW is carried by the wide-N SEED (asserted
-        # above) and is no longer re-imposed on a drawn candidate, so the mutated l2
-        # grouping / acc depth / range knobs stay as they were set. Only
-        # ``scheduler_warps`` is still DERIVED, because it is strategy-determined (a
-        # biconditional, not a tuned value).
+        # COMPLETE-OR-DECLINE: the measured CLC aux-TMA perf ROW is carried by the
+        # wide-N SEED (asserted above) and is no longer re-imposed on a drawn
+        # candidate, so the mutated l2 grouping / acc depth / range knobs stay as
+        # they were set. Only ``scheduler_warps`` is still DERIVED, because it is
+        # strategy-determined (a biconditional, not a tuned value).
         self.assertEqual(
             projected_wide_clc_aux_tma_config["l2_groupings"],
             [TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_GROUPING],
@@ -3885,8 +3882,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         # The K-range knob triple has NO flat slot on the tcgen05 path, so it cannot
         # survive the flatten/unflatten round trip now that normalize no longer
-        # re-imposes the CLC aux-TMA perf row. The RAW seed asserted above still
-        # carries it; the normalized seed reads neutral.
+        # re-imposes the CLC aux-TMA perf row (complete-or-decline). The RAW seed
+        # asserted above still carries it; the normalized seed reads neutral.
         self.assertEqual(
             normalized_wide_clc_aux_tma_seed["range_flattens"],
             [None] * len(expected_clc_aux_tma_range_flattens),
@@ -3956,9 +3953,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 seed["indexing"], ["tensor_descriptor"] * spec.indexing.length
             )
 
-        # 9 = the 7 seeds (the cluster_m=1 universal default + 7 cluster_m=2 rows,
-        # one of which dedups against the default) plus random draws; sized so the
-        # population is not truncated before the narrow-N row asserted just below.
+        # 9 = the 8 seeds (2 cluster_m=1 defaults + 7 cluster_m=2 rows, one of which
+        # dedups against a default) plus a random draw; sized so the population is
+        # not truncated before the narrow-N row asserted just below.
         configs = config_gen.random_population(9)
         self.assertEqual(configs[0].config["tcgen05_cluster_m"], 1)
         cluster_m2_population = [
@@ -3966,9 +3963,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             for config in configs
             if config.config["tcgen05_cluster_m"] == 2
         ]
-        # >=, not ==: every cluster_m=2 SEED row must be present, and the random
-        # draws padding the population out to 9 may legitimately add more.
-        self.assertGreaterEqual(len(cluster_m2_population), 7)
+        self.assertEqual(len(cluster_m2_population), 7)
         self.assertTrue(
             any(
                 config["block_sizes"][1] == TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
@@ -4129,12 +4124,11 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
             ],
         )
-        # The measured CLC aux-TMA perf ROW (l2_grouping=8 plus the K-range
-        # flatten/multi-buffer/warp-specialize triple) is no longer projected onto a
-        # drawn candidate -- ``_fix_cluster_m2_search_config`` completes a request
-        # rather than enumerating the tuples it recognizes -- so this candidate keeps
-        # its own (default) l2 grouping and neutral range knobs. The row still enters
-        # the population as the wide-N/narrow-N SEEDS asserted in the edge/K-tail test.
+        # COMPLETE-OR-DECLINE: the measured CLC aux-TMA perf ROW (l2_grouping=8 plus
+        # the K-range flatten/multi-buffer/warp-specialize triple) is no longer
+        # projected onto a drawn candidate — it now enters the population only as the
+        # wide-N/narrow-N SEEDS asserted in the edge/K-tail test. So this candidate
+        # keeps its own (default) l2 grouping and neutral range knobs.
         self.assertEqual(minimal_preprojection_clc_aux_tma_config["l2_groupings"], [1])
         neutral_range_knobs = [None] * len(expected_clc_aux_tma_range_flattens)
         self.assertNotEqual(neutral_range_knobs, expected_clc_aux_tma_range_flattens)
@@ -5264,10 +5258,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             config_dict["tcgen05_ab_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES,
         )
-        # The edge/K-tail perf regime is no longer IMPOSED on a drawn candidate (the
-        # stage completes a cluster_m=2 request rather than enumerating the tuples it
-        # recognizes), so this config keeps the pipeline knobs and the L2 grouping it
-        # drew, and gains no placement keys.
+        # The edge/K-tail perf regime is no longer IMPOSED on a drawn candidate (it
+        # is a seed now), so this config keeps the pipeline knobs it drew and gains
+        # no placement keys.
         self.assertEqual(
             config_dict["tcgen05_acc_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES,
@@ -5307,10 +5300,11 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             bound.config_spec.autotuner_heuristics,
         )
 
-        # fp16 4096³ is a full-wave compute shape, so the leading compiler seed is
-        # the promote-to-default formula heuristic's cluster_m=2 compute tile. The
-        # generalized TVM-FFI direct-entry seed and the DEFAULT-layout cluster_m=2
-        # seed are also emitted and remain distinct after normalization.
+        # fp16 4096³ is now FFI-eligible, so the leading compiler seed is the
+        # generalized TVM-FFI direct-entry cluster_m=2 seed (previously fp16 was
+        # bf16-only for the FFI seed, so the leading seed was the cluster_m=1
+        # universal default). The DEFAULT-layout cluster_m=2 seed is also
+        # emitted and remains distinct after normalization.
         config_gen = bound.config_spec.create_config_generation()
         zero_flat = config_gen.random_population_flat(0)
         self.assertEqual(len(zero_flat), 1)
@@ -5326,6 +5320,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         seeded_configs = config_gen.random_population(3)
         self._assert_cute_tcgen05_cluster_m2_seeded(
             seeded_configs,
+            # The formula matmul heuristic seeds bk=64 alongside the FFI/DEFAULT
+            # bk=128 seeds, so the population spans both validated K rungs.
             expected_block_ks=(64, 128),
             expected_indexing_length=3,
         )

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6181,10 +6181,11 @@ class TestCuteBackend(TestCase):
                 "tcgen05_cluster_m": 2,
             }
             bound.config_spec.normalize(projected, _fix_invalid=True)
-            # The generic DEFAULT-layout bn=128 cluster_m=2 tile is searchable for
-            # the batched leading-passthrough family now, so the sampled block_n=128
-            # (index 2) SURVIVES at 128 instead of snapping to the canonical 256.
-            # block_m (index 1) is still pinned to 256.
+            # Stage 2b made a generic DEFAULT-layout bn=128 cluster_m=2 tile
+            # searchable for the batched leading-passthrough family, so the
+            # sampled block_n=128 (index 2) now SURVIVES at 128 instead of
+            # snapping to the canonical 256. block_m (index 1) is still pinned
+            # to 256.
             self.assertEqual(projected["block_sizes"], [1, 256, 128, 64])
             self.assertEqual(projected["pid_type"], "persistent_interleaved")
 
@@ -6243,11 +6244,11 @@ class TestCuteBackend(TestCase):
             # The wave-quant gate multiplies the per-batch output-cluster count
             # by the batch (``leading_work_multiplier``); cluster_m=2 search is
             # only admitted once that product clears ``num_sms // 4`` (= 37).
-            # The batched leading-passthrough family searches a bn=128 cluster_m=2
-            # tile now, so the count is taken at the narrow tile (256x128 ->
-            # 256//256 * 256//128 = 2 clusters per batch), moving the threshold to
-            # batch >= 19 (2 * 19 = 38 >= 37). A small batch that underfills stays
-            # cluster_m=1; a large batch enables cluster_m=2.
+            # Stage 2b made the batched leading-passthrough family search a
+            # bn=128 cluster_m=2 tile, so the count is taken at the narrow tile
+            # (256x128 -> 256//256 * 256//128 = 2 clusters per batch), moving the
+            # threshold to batch >= 19 (2 * 19 = 38 >= 37). A small batch that
+            # underfills stays cluster_m=1; a large batch enables cluster_m=2.
             # If the batch factor were NOT counted the product would be a
             # batch-independent 2 and cluster_m=2 would never enable -- so this
             # boundary is what proves batch clusters are counted.

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -145,6 +145,7 @@ from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_ACC_WAIT_PLACEMENT_SUBTILE_LOOP,
 )
 from helion._compiler.cute.tcgen05_constants import TCGEN05_AUX_LOAD_MODE_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_AUX_LOAD_MODE_SIMT
 from helion._compiler.cute.tcgen05_constants import TCGEN05_AUX_LOAD_MODE_TMA
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
@@ -202,6 +203,7 @@ from helion._compiler.cute.tcgen05_constants import (
 )
 from helion._compiler.cute.tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES,
 )
@@ -257,7 +259,8 @@ from helion.runtime import _append_cute_wrapper_plan
 # (ab=6, c=4) A/B pipeline. The per-target constants were removed when the
 # direct-entry admission became structural; these tests still drive the
 # bk=64 (6, 4) stage tuple, which remains in
-# ``TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK``.
+# the direct-entry path, whose admission is now ``TCGEN05_DIRECT_ENTRY_LEGAL_BK``
+# plus the per-tile SMEM budget rather than an enumerated ``(ab, c)`` table.
 TCGEN05_TARGET1_TVM_FFI_AB_STAGES = 6
 TCGEN05_TARGET1_TVM_FFI_C_STAGES = 4
 
@@ -18023,7 +18026,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             instead of a deep ``ptxas: uses too much shared
             data`` raise; and
           - the autotune search-time fixup
-            (``_fix_tcgen05_with_scheduler_search_config``)
+            (``_fix_tcgen05_ab_stages_search_config``)
             can demote affected ``ab=3`` candidates rather
             than aborting tuning at ptxas.
 
@@ -18806,19 +18809,20 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             config_dict["tcgen05_ab_stages"],
             TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES,
         )
-        # ⚠ THE FOUR PROJECTED-VALUE ASSERTIONS BECAME SURVIVAL ASSERTIONS. They
-        # required the 6-key blanket
-        # ``config.update(tcgen05_two_cta_edge_k_tail_seed_overrides())`` to have
-        # rewritten this DRAWN config onto the measured WIDE-N edge row:
-        # ``acc_stages`` 2 -> 1, ``l2_groupings``, ``l2_swizzle_size``, and the two
-        # ``*_placement`` keys added from scratch. The drawn ``block_n=128`` now
-        # settles as its OWN valid cluster_m=2 tile instead of snapping to 256, so
-        # this candidate is no longer in the wide-N row's scope and keeps what it
-        # drew. The measured row is still in the population, as a seed.
+        # ⚠ THE FOUR PROJECTED-VALUE ASSERTIONS BECAME SURVIVAL ASSERTIONS (2026-08-07).
+        # They required the 6-key blanket
+        # ``config.update(tcgen05_two_cta_edge_k_tail_seed_overrides())`` to have rewritten
+        # this DRAWN config onto the measured edge row: ``acc_stages`` 2 -> 1, ``c_stages``,
+        # and the two ``*_placement`` keys added from scratch. That dict was deleted from the
+        # fix-up path -- every constant behind it is a throughput claim, so it was steering,
+        # and it was the last writer clobbering this family's own seeds.
+        #
+        # So the DRAWN values must now survive, and absent keys must stay absent. The seed
+        # builders still call the dict, so the measured row is in the population as a seed.
         self.assertEqual(
             config_dict["tcgen05_acc_stages"],
             2,
-            msg="the drawn acc_stages was re-projected onto the wide-N edge row",
+            msg="the drawn acc_stages was re-projected; that perf write was deleted",
         )
         self.assertEqual(
             config_dict["tcgen05_c_stages"],
@@ -18826,20 +18830,27 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         )
         self.assertNotIn(TCGEN05_ACC_WAIT_PLACEMENT_CONFIG_KEY, config_dict)
         self.assertNotIn(TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY, config_dict)
-        # The drawn swizzle (8) and grouping ([4]) survive for the same reason.
+        # SURVIVES AS DRAWN (2026-08-05) -- see the note in
+        # ``test_aux_edge_autotune_fixup_uses_validated_edge_paths``. The two
+        # projecting writers were removed together; the tuned values live in the
+        # seed builders. The drawn value here is 8.
         self.assertEqual(config_dict["tcgen05_l2_swizzle_size"], 8)
+        # ⚠ ``l2_groupings`` SURVIVES AS DRAWN TOO (2026-08-07). Same cause as the swizzle
+        # note above, one writer later: the 6-key blanket override dict used to force
+        # ``[TCGEN05_TWO_CTA_EDGE_K_TAIL_L2_GROUPING]`` (= [2]) here, and it was deleted from
+        # the fix-up path as steering. The drawn value is [4].
         self.assertEqual(
             config_dict["l2_groupings"],
             [4],
-            msg="the drawn l2_groupings was re-projected onto the wide-N edge row",
+            msg="the drawn l2_groupings was re-projected; that perf write was deleted",
         )
         self.assertEqual(
             config_dict["indexing"],
             ["tensor_descriptor"] * spec.indexing.length,
         )
-        # A sampled block_n=128 survives as its own valid cm2 tile for the
-        # edge-K-tail family (block_m still pinned to 256), instead of snapping to
-        # the canonical block_n=256.
+        # Stage 2b: a sampled block_n=128 now survives as its own valid cm2 tile
+        # for the edge-K-tail family (block_m still pinned to 256), instead of
+        # snapping to the canonical block_n=256.
         self.assertEqual(
             config_dict["block_sizes"],
             [
@@ -18850,6 +18861,99 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         )
         self.assertEqual(config_dict["pid_type"], "persistent_interleaved")
         self.assertNotIn("epilogue_subtile", config_dict)
+
+    def test_aux_tma_demotes_cluster_n2_to_simt_on_every_family(self) -> None:
+        """LEDGER C018: ``cluster_n=2 + aux_load_mode=tma`` must never reach codegen.
+
+        Mechanism: the CLC scheduler warp publishes work through a DSMEM mailbox
+        and iterates lanes ``< cluster_m`` only, so at ``cluster_n > 1`` the extra
+        N-direction CTAs never receive the publish and block forever on
+        ``producer_acquire``. Observed: silently WRONG output plus a ~7.5 minute
+        GPU hang. This test asserts the demotion, never the combination -- it
+        deliberately does NOT compile or execute anything.
+
+        Why it exists: the guard used to be one of ~11 clauses inside
+        ``_fix_aux_tma_search_config``'s arm-4 tile-shape envelope, which probe P2
+        classified as coverage, so a cleanup of the coverage clauses could have
+        deleted the hang guard by accident. It is now a single explicit clause.
+
+        BOTH families are covered on purpose. The old envelope was NOT a complete
+        guard: only its full-tile helper had a ``cluster_n`` clause, while
+        ``_is_validated_cluster_m2_edge_search_candidate`` has none -- so on the
+        edge/K-tail family a ``cluster_n=2 + tma`` config SURVIVED normalize
+        (measured 2026-08-01). The edge arm below is therefore a regression guard
+        for a hazard that was live, not a restatement of prior behaviour.
+        """
+        from helion._compiler.cute.strategies import Tcgen05Strategy
+
+        kernel = self._residual_kernel()
+        for label, dim, tile_n in (
+            ("edge_k_tail", 5000, TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N),
+            ("full_tile", 6144, TCGEN05_TWO_CTA_BLOCK_N),
+        ):
+            with self.subTest(family=label):
+                kernel._bound_kernels.clear()
+                args = tuple(
+                    torch.empty([dim, dim], device=DEVICE, dtype=torch.bfloat16)
+                    for _ in range(3)
+                )
+                with patch_cute_mma_support():
+                    bound = kernel.bind(args)
+                spec = bound.env.config_spec
+                constraints = spec._tcgen05_cluster_m2_search_constraints
+                assert constraints is not None
+                self.assertEqual(
+                    constraints.allow_edge_k_tail_family, label == "edge_k_tail"
+                )
+
+                def _cfg(
+                    cluster_n: int,
+                    *,
+                    tile_n: int = tile_n,
+                    indexing_length: int = spec.indexing.length,
+                ) -> dict[str, object]:
+                    return {
+                        "block_sizes": [256, tile_n, 128],
+                        "indexing": ["tensor_descriptor"] * indexing_length,
+                        "l2_groupings": [1],
+                        "pid_type": "persistent_interleaved",
+                        "tcgen05_cluster_m": 2,
+                        "tcgen05_cluster_n": cluster_n,
+                        "tcgen05_ab_stages": 2,
+                        "tcgen05_acc_stages": 2,
+                        "tcgen05_c_stages": 2,
+                        "tcgen05_strategy": (
+                            Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+                        ),
+                        "tcgen05_warp_spec_scheduler_warps": 1,
+                        "tcgen05_warp_spec_c_input_warps": 1,
+                        TCGEN05_AUX_LOAD_MODE_CONFIG_KEY: TCGEN05_AUX_LOAD_MODE_TMA,
+                    }
+
+                # cluster_n=1 KEEPS tma -- proves the arm below is not demoting
+                # everything, i.e. the cluster_n=2 assertion is not vacuous.
+                keeps = _cfg(1)
+                spec.normalize(keeps, _fix_invalid=True)
+                self.assertEqual(
+                    keeps[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY],
+                    TCGEN05_AUX_LOAD_MODE_TMA,
+                    msg=(
+                        "cluster_n=1 aux-TMA candidate was demoted, so the "
+                        "cluster_n=2 assertion below proves nothing"
+                    ),
+                )
+
+                demoted = _cfg(2)
+                spec.normalize(demoted, _fix_invalid=True)
+                self.assertEqual(
+                    demoted[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY],
+                    TCGEN05_AUX_LOAD_MODE_SIMT,
+                    msg=(
+                        f"[{label}] cluster_n=2 kept aux_load_mode=tma. This is "
+                        f"ledger C018: silently wrong output plus a ~7.5 min GPU "
+                        f"hang. Full config: {demoted}"
+                    ),
+                )
 
     def test_aux_autotune_surface_widens_for_hldot_residual_kernel(self) -> None:
         """Detector recognizes ``hl.dot`` MMA anchors in

--- a/test/test_cute_matmul_formula_heuristic.py
+++ b/test/test_cute_matmul_formula_heuristic.py
@@ -1,0 +1,298 @@
+"""Emission tests for the CuTe tcgen05 formula matmul seed heuristic.
+
+These exercise the pure formula logic (regime classification -> collective -> depth-fill)
+against the hill-climbed / pretuned answer keys, with a stubbed MatmulFact/ConfigSpec so
+no GPU is required. B200 sm100 geometry: num_sm=148, per-CTA AB-SMEM budget 203776 bytes.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from helion._compiler.autotuner_heuristics import cute_matmul_formula as F
+
+_NUM_SM = 148
+_BUDGET = 232448 - 28 * 1024  # 203776 (B200 per-CTA AB-SMEM budget)
+
+_FP8 = torch.float8_e4m3fn
+_BF16 = torch.bfloat16
+_FP16 = torch.float16
+
+
+def _fact(m, k, n, dtype):
+    return SimpleNamespace(
+        static_m=m,
+        static_k=k,
+        static_n=n,
+        lhs_dtype=dtype,
+        rhs_dtype=dtype,
+        lhs_ndim=2,
+        rhs_ndim=2,
+        m_block_id=0,
+        n_block_id=1,
+        k_block_id=2,
+    )
+
+
+def _spec(indexing_length=3):
+    return SimpleNamespace(indexing=SimpleNamespace(length=indexing_length))
+
+
+def _seed(m, k, n, dtype, indexing_length=3, aux_rank=0):
+    # aux_rank (0 transparent / 2 source-C residual) is computed from the live env by
+    # _epilogue_aux_rank in the heuristic; the pure formula takes it as a parameter, so the
+    # tests pass it directly (aux-rank detection itself is covered by the compile/run tests).
+    return F._formula_seed(
+        _fact(m, k, n, dtype), _spec(indexing_length), _NUM_SM, _BUDGET, aux_rank
+    )
+
+
+def _knobs(seed):
+    return (
+        tuple(seed["block_sizes"]),
+        seed["tcgen05_cluster_m"],
+        seed["tcgen05_ab_stages"],
+        seed["pid_type"],
+    )
+
+
+def test_fp8_decode_key():
+    # R1 M1 answer key: [64,64,128] cluster_m=1 ab=12 persistent_blocked.
+    assert _knobs(_seed(64, 8192, 8192, _FP8)) == (
+        (64, 64, 128),
+        1,
+        12,
+        "persistent_blocked",
+    )
+
+
+def test_fp8_medium_m_key():
+    # Climbed key (§1.2): [256,128,128] cluster_m=2 ab=8 persistent_interleaved.
+    assert _knobs(_seed(512, 2048, 4096, _FP8)) == (
+        (256, 128, 128),
+        2,
+        8,
+        "persistent_interleaved",
+    )
+
+
+def test_bf16_compute_key():
+    # R2 #11: bf16 compute fills the isobar to the deep bk64/ab6 pipeline on the DEFAULT path
+    # (the bf16-deep-AB prerequisite removed the old ab<=3 cap; measured +1-4% over ab3).
+    seed = _seed(4096, 8192, 8192, _BF16)
+    assert _knobs(seed) == ((256, 256, 64), 2, 6, "persistent_interleaved")
+    assert seed["l2_groupings"] == [1]  # many-wave
+
+
+def test_fp8_compute_key():
+    # R2 #3 / #4: fp8 compute square/flip-point -> [256,256,128] cluster_m=2 ab=6.
+    assert _knobs(_seed(4096, 4096, 4096, _FP8)) == (
+        (256, 256, 128),
+        2,
+        6,
+        "persistent_interleaved",
+    )
+    assert _knobs(_seed(2048, 4096, 4096, _FP8)) == (
+        (256, 256, 128),
+        2,
+        6,
+        "persistent_interleaved",
+    )
+
+
+def test_fp8_decode_pretuned_rows():
+    # Pretuned AOT table decode rows: bn=32/bk=256/ab=8 (medium K/N) and bn=64/bk=128/ab=12.
+    assert _knobs(_seed(64, 2048, 4096, _FP8)) == (
+        (64, 32, 256),
+        1,
+        8,
+        "persistent_blocked",
+    )
+    assert _knobs(_seed(64, 4096, 4096, _FP8)) == (
+        (64, 32, 256),
+        1,
+        8,
+        "persistent_blocked",
+    )
+    assert _knobs(_seed(64, 5120, 5120, _FP8)) == (
+        (64, 64, 128),
+        1,
+        12,
+        "persistent_blocked",
+    )
+
+
+def test_bf16_decode_deep_ab_key():
+    """BF16 decode fills the isobar at bk=128/ab=8 — MEASURED faster than the old key.
+
+    This used to pin the recorded R3 #8 key ``[64,32,256] ab=4``. Both points sit at
+    exactly 196 608 AB-SMEM bytes, so the isobar is a TIE and the tie-break decides.
+    Measured on bf16 64x4096x4096 with a calibrated cold-L2 timer (the legacy per-replay
+    timer cannot resolve this — it carries a 4-6 us additive bias), two fresh processes,
+    null spread 0.01-0.2%:
+
+        [64,32,128] ab8 = 197.7 / 198.0 TF/s   <- what this test now pins
+        [64,32,256] ab4 = 189.4 / 189.3 TF/s   <- the old recorded key
+
+    So the new emission is 4.6% FASTER, ~10x the null spread. The recorded key is not
+    necessarily wrong at whatever N/K it was measured on; what is refuted is its
+    TRANSFER to this shape, and a tie-break that generalised it.
+
+    ``bn=32`` remains the right decode tile in bf16 (measured [64,32]/[64,64] = 1.143 at
+    bk=256, 1.088 at bk=128) — the INVERSE of fp8, where the same ratio is 0.719. Do not
+    "fix" the bf16 decode bn by copying the fp8 answer.
+    """
+    assert _knobs(_seed(64, 4096, 4096, _BF16)) == (
+        (64, 32, 128),
+        1,
+        8,
+        "persistent_blocked",
+    )
+
+
+def test_sixteen_bit_ab_cap_reaches_the_deep_ledger_winners():
+    """The 16-bit ab cap must not exclude a MEASURED winner from being seeded.
+
+    ``_DTYPE_AB_CAP[2]`` was 6, which could not express two ledger winners that sit at
+    their own tile's SMEM ceiling -- at cap=6 the isobar fill emitted ``bk=128/ab=4`` for
+    both, a tied byte count at half the depth:
+
+        M-B5  [256,128] cluster_m=2 -> bk=64/ab=8
+        M-A3  [128, 64] cluster_m=1 -> bk=64/ab=8
+
+    Pinned as ``(bk, ab)`` from ``_pick_bk_ab`` directly rather than through a whole seed,
+    so the assertion is about the depth-fill and cannot be perturbed by an unrelated
+    regime-classification change. Lowering the cap back to 6 fails this test.
+    """
+    assert F._pick_bk_ab(2, 2, 256, 128, _BUDGET, 4096) == (64, 8)  # M-B5
+    assert F._pick_bk_ab(2, 1, 128, 64, _BUDGET, 4096) == (64, 8)  # M-A3
+
+
+def test_isobar_tie_break_is_deepest_ab_everywhere():
+    """ONE global tie-break: deepest ab. A per-regime exception was tried and REFUTED.
+
+    Raising the 16-bit cap to 8 manufactured a tie on the narrow-decode tile
+    (``bk=128/ab=8`` == ``bk=256/ab=4`` == 196 608 B). I added a narrow-decode exception
+    preferring the LARGER bk, to preserve the recorded R3 #8 key. It was then measured on
+    bf16 64x4096x4096 with a calibrated cold-L2 timer, two fresh processes, null spread
+    0.01-0.2%:
+
+        [64,32,128] ab8 = 197.7 / 198.0 TF/s   <- plain "deepest ab"
+        [64,32,256] ab4 = 189.4 / 189.3 TF/s   <- what the exception emitted
+
+    The exception emitted the config that is 4.6% SLOWER, ~10x the null spread. Removed.
+
+    Pinned as a SINGLE rule, across both dtypes and every decode bn, so the exception
+    cannot creep back unmeasured. If you are tempted to re-add a per-regime tie-break,
+    measure it first with a calibrated timer -- the legacy per-replay cudaEvent timer
+    carries a 4-6 us additive bias and cannot resolve a 4.6% delta on these cells.
+    """
+    # 16-bit decode: tie -> deepest ab. The refuted exception gave (256, 4) here.
+    assert F._pick_bk_ab(2, 1, 64, 32, _BUDGET, 4096) == (128, 8)
+    assert F._pick_bk_ab(2, 1, 64, 16, _BUDGET, 4096) == (128, 8)
+    assert F._pick_bk_ab(2, 1, 64, 64, _BUDGET, 4096) == (128, 6)
+    # fp8's tied wide-decode case keeps the deepest ab (R1 M1) -- same rule, no exception.
+    assert F._pick_bk_ab(1, 1, 64, 64, _BUDGET, 4096) == (128, 12)
+    # fp8 narrow decode has only ONE isobar point, so no tie-break applies at all. This is
+    # the pretuned fp8 key and it must not move.
+    assert F._pick_bk_ab(1, 1, 64, 32, _BUDGET, 4096) == (256, 8)
+
+
+def test_isobar_invariant():
+    # Every Bucket-A key lands at the ~196608-byte AB-SMEM isobar.
+    for m, k, n, dt in [
+        (64, 8192, 8192, _FP8),
+        (512, 2048, 4096, _FP8),
+        (4096, 8192, 8192, _BF16),
+        (4096, 4096, 4096, _FP8),
+        (64, 4096, 4096, _BF16),
+    ]:
+        seed = _seed(m, k, n, dt)
+        bm, bn, bk = seed["block_sizes"]
+        b = F.tcgen05_ab_smem_bytes_per_cta(
+            bm=bm,
+            bn=bn,
+            bk=bk,
+            dtype_bytes=F._itemsize(dt),
+            ab_stages=seed["tcgen05_ab_stages"],
+            cluster_m=seed["tcgen05_cluster_m"],
+        )
+        assert b == 196608, (m, k, n, dt, b)
+
+
+def test_transparent_epilogue_keeps_deep_ab():
+    # A transparent epilogue (aux_rank=0: unary act, rank-1 rowvec bias, OR an fp8/16-bit
+    # rowwise [M,1]/[1,N] scale) must NOT clamp the pipeline: fp8 decode ab stays 12.
+    # (Distinguishing an [M,1] scale from an [M,N] residual is done dtype-AGNOSTICALLY by
+    # the graph detector in _epilogue_aux_rank — covered end-to-end by the compile/run test.)
+    assert _seed(64, 8192, 8192, _FP8, aux_rank=0)["tcgen05_ab_stages"] == 12
+
+
+def test_rank2_residual_caps_ab_at_2():
+    # A rank-2 exact-shape [M,N] source-C residual (residual_add / bias_residual_gelu) caps
+    # ab at 2 — the C2/C5 aux-TMA ceiling. Dtype-agnostic (the cap is physical, not fp8-vs-16bit).
+    assert _seed(8192, 8192, 8192, _BF16, aux_rank=2)["tcgen05_ab_stages"] == 2
+    assert _seed(4096, 4096, 4096, _FP8, aux_rank=2)["tcgen05_ab_stages"] == 2
+
+
+def test_fp16_shares_16bit_path():
+    # fp16 shares the bf16 16-bit path (compute cluster_m=2, deep bk64/ab6 default path).
+    assert _knobs(_seed(4096, 8192, 8192, _FP16)) == (
+        (256, 256, 64),
+        2,
+        6,
+        "persistent_interleaved",
+    )
+
+
+def test_decode_regime_boundary():
+    # M<=128 is decode (cluster_m=1); M>=256 that fills a wave is compute (cluster_m=2).
+    assert _seed(128, 4096, 4096, _FP8)["tcgen05_cluster_m"] == 1
+    assert _seed(4096, 4096, 4096, _FP8)["tcgen05_cluster_m"] == 2
+
+
+def test_fp8_medium_m_small_grid_vs_rect():
+    # fp8 medium-M: the small-grid [128,128,128]/ab12 wins when it fills ~one wave
+    # (clusters <= num_sm//2 = 74); else the rectangular tile is kept. Measured head-to-head.
+    # 512x2048x2048: 4*16=64 clusters <= 74 -> small-grid
+    assert _knobs(_seed(512, 2048, 2048, _FP8))[:3] == ((128, 128, 128), 2, 12)
+    # 256x4096x4096: 2*32=64 clusters <= 74 -> small-grid
+    assert _knobs(_seed(256, 4096, 4096, _FP8))[:3] == ((128, 128, 128), 2, 12)
+    # 512x8192x2048: 4*16=64 clusters <= 74 -> small-grid
+    assert _knobs(_seed(512, 8192, 2048, _FP8))[:3] == ((128, 128, 128), 2, 12)
+    # 512x2048x4096: 4*32=128 clusters > 74 -> rectangular [256,128,128]/ab8 (the climbed key)
+    assert _knobs(_seed(512, 2048, 4096, _FP8))[:3] == ((256, 128, 128), 2, 8)
+
+
+def test_regime_declines_outside_static_tile_envelope():
+    # Non-pow2 decode M (96) and below-floor M (32) decline (return None tile).
+    assert F._regime_tile(96, 4096, _NUM_SM, 1) is None
+    assert F._regime_tile(32, 4096, _NUM_SM, 1) is None
+    # M not a multiple of 256 for cluster_m=2 (e.g. 384) declines.
+    assert F._regime_tile(384, 4096, _NUM_SM, 1) is None
+    # Valid decode M and compute M return a tile.
+    assert F._regime_tile(64, 4096, _NUM_SM, 1) is not None
+    assert F._regime_tile(4096, 4096, _NUM_SM, 1) is not None
+
+
+def test_compute_branch_n_guard_never_emits_bn_gt_n():
+    # A tall+narrow shape (huge M, N<256) can clear the 256² occupancy bar on M-tiles alone, but
+    # must NOT emit a bn=256 tile over a narrow-N output — the n>=256 guard routes it to the
+    # rectangular medium-M tile, which caps bn<=N. (Regression for the review-found safety hole.)
+    for m, n in [(16384, 64), (16384, 128), (32768, 192)]:
+        cluster_m, bm, bn, _pid = F._regime_tile(m, n, _NUM_SM, 2)  # bf16
+        assert bn <= n, (m, n, bn)
+        assert (cluster_m, bm) == (2, 256)
+
+
+def test_decode_fallback_picks_narrowest_bn():
+    # In the fallback regime (tiny N: even bn=16 < 0.5 waves at M=64) the decode bn picker must
+    # return the NARROWEST bn (max occupancy), not the old bn=64 mid-point. Measured: bn=16
+    # ties-or-beats bn=64 on every probed tiny-N shape. Consistent with the loop's shrink premise.
+    for n in (256, 512, 1024):
+        assert _knobs(_seed(64, 4096, n, _FP8))[0][1] == 16, n
+    # And the answer-key decode shapes are unchanged by the fallback edit.
+    assert _knobs(_seed(64, 8192, 8192, _FP8))[0][1] == 64
+    assert _knobs(_seed(64, 4096, 4096, _FP8))[0][1] == 32

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import random
 from types import SimpleNamespace
 from typing import cast
 import unittest
@@ -12,6 +13,10 @@ import helion
 from helion import _compat
 from helion._compiler.autotuner_heuristics.cute import CuteTcgen05ClusterM2Heuristic
 from helion._compiler.cute.strategies import ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC
+from helion._compiler.cute.strategies import TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY
+from helion._compiler.cute.strategies import TCGEN05_STRATEGY_CONFIG_KEY
+from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY
+from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
 from helion._compiler.cute.strategies import Tcgen05LayoutOverrides
 from helion._compiler.cute.strategies import Tcgen05LayoutStrategy
 from helion._compiler.cute.strategies import Tcgen05PersistenceModel
@@ -19,6 +24,11 @@ from helion._compiler.cute.strategies import Tcgen05Strategy
 from helion._compiler.cute.strategies import Tcgen05WarpSpec
 from helion._compiler.cute.strategies import validate_tcgen05_strategy_invariants
 from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+from helion._compiler.cute.tcgen05_constants import TCGEN05_AUX_LOAD_MODE_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_AUX_LOAD_MODE_TMA
+from helion._compiler.cute.tcgen05_constants import TCGEN05_EXPLICIT_D_STORE_BOX_N
+from helion._compiler.cute.tcgen05_constants import TCGEN05_EXPLICIT_EPI_TILE_M
+from helion._compiler.cute.tcgen05_constants import TCGEN05_EXPLICIT_EPI_TILE_N
 from helion._compiler.cute.tcgen05_constants import TCGEN05_ONE_CTA_MAX_BLOCK_M
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
@@ -39,6 +49,7 @@ from helion._testing import onlyBackends
 from helion._testing import patch_cute_mma_support
 from helion._testing import skipIfMTIA
 from helion.autotuner import PowerOfTwoFragment
+from helion.autotuner.config_fragment import IntegerFragment
 from helion.autotuner.config_generation import ConfigGeneration
 from helion.autotuner.config_spec import MatmulFact
 from helion.exc import InvalidConfig
@@ -208,6 +219,146 @@ def _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(budget_bytes: int):
         return _cute_4096_matmul_kernel.bind(args)
 
 
+def _bind_cute_k384_matmul_kernel():
+    """Bind a plain bf16 4096x4096x384 matmul: the A5 illegal-``bk`` witness.
+
+    ``384 % 256 != 0``, so ``bk=256`` is an ILLEGAL cluster_m=2 K tile on this
+    shape -- while the K ``BlockSizeFragment``'s ``high`` is 256, so the sampler
+    draws it. That combination is what makes A5's arm live here and dead on
+    4096^3 (whose legal set is the whole drawable domain).
+    """
+    args = (
+        torch.empty([4096, 384], device=DEVICE, dtype=HALF_DTYPE),
+        torch.empty([384, 4096], device=DEVICE, dtype=HALF_DTYPE),
+    )
+    _cute_k384_matmul_kernel._bound_kernels.clear()
+    with patch_cute_mma_support():
+        return _cute_k384_matmul_kernel.bind(args)
+
+
+@helion.kernel(backend="cute")
+def _cute_k384_matmul_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = acc.to(x.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
+def _cute_2048x4096x4096_matmul_kernel(
+    x: torch.Tensor, y: torch.Tensor
+) -> torch.Tensor:
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = acc.to(x.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
+def _cute_batched_matmul_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """Batched bf16 matmul: the family where the FORMULA heuristic declines.
+
+    ``cute_matmul_formula._single_matmul_fact`` requires ``lhs_ndim == rhs_ndim == 2``,
+    so the only promoting tcgen05 producer skips this shape — which is what made the
+    no-autotune default here depend on a repair-stage side effect.
+    """
+    b, m, k = x.size()
+    _, _, n = y.size()
+    out = torch.empty([b, m, n], dtype=x.dtype, device=x.device)
+    for tile_b, tile_m, tile_n in hl.tile([b, m, n]):
+        acc = hl.zeros([tile_b, tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.baddbmm(
+                acc, x[tile_b, tile_m, tile_k], y[tile_b, tile_k, tile_n]
+            )
+        out[tile_b, tile_m, tile_n] = acc.to(x.dtype)
+    return out
+
+
+def _bind_cute_residual_full_tile_4096_kernel():
+    """Bind the 4096³ rank-2 residual kernel: the aux-TMA FULL-TILE family.
+
+    Distinct from ``_bind_cute_residual_5000_kernel`` in the one way that matters
+    here: 4096 is a multiple of every drawable tile, so ``allow_edge_k_tail_family``
+    is False and ``_aux_tma_full_tile_search_enabled()`` is the arm that admits it.
+    The edge family pins ``ab_stages`` to 2 through stage 3's override dict before
+    stage 6 runs, which would make the depth cap a vacuous no-op there.
+    """
+    args = (
+        torch.empty([4096, 4096], device=DEVICE, dtype=HALF_DTYPE),
+        torch.empty([4096, 4096], device=DEVICE, dtype=HALF_DTYPE),
+        torch.empty([4096, 4096], device=DEVICE, dtype=HALF_DTYPE),
+    )
+    _cute_residual_5000_kernel._bound_kernels.clear()
+    with patch_cute_mma_support():
+        return _cute_residual_5000_kernel.bind(args)
+
+
+def _bind_cute_residual_5000_kernel():
+    """Bind the 5000^3 bf16 rank-2 residual (source-C aux) kernel on the real device.
+
+    The SMEM budget is NOT mocked here: this family's gates key on
+    ``exact_shape_aux_kernel_detected`` and on the real per-CTA budget, and the
+    tile-infeasibility case being tested only exists at the true 203 776 B value.
+    """
+    args = (
+        torch.empty([5000, 5000], device=DEVICE, dtype=HALF_DTYPE),
+        torch.empty([5000, 5000], device=DEVICE, dtype=HALF_DTYPE),
+        torch.empty([5000, 5000], device=DEVICE, dtype=HALF_DTYPE),
+    )
+    _cute_residual_5000_kernel._bound_kernels.clear()
+    with patch_cute_mma_support():
+        return _cute_residual_5000_kernel.bind(args)
+
+
+@helion.kernel(backend="cute")
+def _cute_rowvec_bias_kernel(
+    x: torch.Tensor, y: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    """Row-vector-bias matmul: BROAD aux detector True, PRECISE detector False.
+
+    The family where ``aux_kernel_detected`` and
+    ``exact_shape_aux_kernel_detected`` disagree, which is what makes it the right
+    witness for the C-ring SMEM model (item 11). A rank-1 bias broadcast over N has
+    no source-C tile to load, yet the emitted epilogue still builds the
+    with-source-C ``(128, 64)`` tile.
+    """
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = (acc + bias[tile_n]).to(x.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
+def _cute_residual_5000_kernel(
+    x: torch.Tensor, y: torch.Tensor, c: torch.Tensor
+) -> torch.Tensor:
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=HALF_DTYPE, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = (acc + c[tile_m, tile_n].to(torch.float32)).to(HALF_DTYPE)
+    return out
+
+
 def _bind_cute_strategy_kernel():
     """Shared bind helper for the G2-A strategy data-model tests.
 
@@ -322,10 +473,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(spec.default_config().config["l2_groupings"], [4])
         # The small-N shape cannot form the validated 256x256 CtaGroup.TWO tile, so
         # the SEARCH keeps cluster_m narrowed to 1. The formula seed is orthogonal
-        # to that search restriction: it promotes the best genuinely-valid config,
-        # which here is the rectangular cluster_m=2 tile [256,64,64] (bn shrunk to
-        # N=64). So the promoted default is cluster_m=2 even though the search arm
-        # stays cluster_m=1.
+        # to that search restriction (cute-seed-orthogonal-to-search): it promotes
+        # the best genuinely-valid config, which here is the rectangular cluster_m=2
+        # tile [256,64,64] (bn shrunk to N=64) -- GPU-verified to compile and match
+        # x@y exactly. So the promoted default is cluster_m=2 even though the search
+        # arm stays cluster_m=1.
         self.assertEqual(spec.default_config().config["tcgen05_cluster_m"], 2)
         self.assertEqual(spec.default_config().config["block_sizes"][:2], [256, 64])
         self.assertEqual(spec._tcgen05_cluster_m_search_choices, (1,))
@@ -380,21 +532,27 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         # on cluster_m=2, and the search exposes both arms.
         self.assertEqual(spec.default_config().config["tcgen05_cluster_m"], 2)
         self.assertEqual(spec._tcgen05_cluster_m_search_choices, (1, 2))
-        # An over-K-tile-cap ``bk`` is now REPAIRED, not demoted. ``bk=16`` at
-        # K=8192 needs 512 K-tiles against a 256 cap, so the stage used to answer
-        # "not a legal cluster_m=2 bk" by setting cluster_m=1 -- which additionally
-        # cost the tile, because the cluster_m=1 clamp then pinned ``bm`` to 128
-        # (measured: this config came out as ``[128,256,256] cm1``). The stage snaps
+        # An over-K-tile-cap ``bk`` is now REPAIRED, not demoted (item 9,
+        # 2026-08-01). ``bk=16`` at K=8192 needs 512 K-tiles against a 256 cap, so
+        # A5 used to answer "not a legal cluster_m=2 bk" by setting cluster_m=1 --
+        # which additionally cost the tile, because stage 4 then clamped ``bm`` to
+        # 128 (measured: this config came out as ``[128,256,256] cm1``). A5 snaps
         # ``bk`` to a legal value instead, and keeps the tile.
         #
-        # The repaired value is the NEAREST legal ``bk``, not the largest: at K=8192
-        # the legal set is {32, 64, 128, 256} and ``bk=32`` gives exactly 256
-        # K-tiles, right at the cap. So this asserts the repair POLICY, not
-        # legality -- nearest-legal moves the key as little as possible.
+        # ⚠ THE REPAIRED VALUE IS NOW 32, NOT 256 (2026-08-10). A5 used to take the
+        # LARGEST legal ``bk``; it now takes the NEAREST to the drawn one. Both are
+        # legal here -- at K=8192 the legal set is {32, 64, 128, 256} and ``bk=32``
+        # gives exactly 256 K-tiles, right at the cap -- so this asserts the repair
+        # POLICY, not legality. Nearest-legal moves the key as little as possible
+        # ("change only the knobs that must change"), and it is what made the
+        # edge-family K pin redundant: on that family every repairable drawn value
+        # is below the legal set, so largest-legal answered 256 while the family's
+        # measured tile is 128, and a separate pin existed to overwrite it.
         #
         # THE CAP ITSELF IS UNCHANGED AND STILL BINDING -- it is enforced inside
         # ``cluster_m2_bk_is_valid``, which the repair consults, so the repaired
-        # value satisfies it by construction whichever candidate is chosen.
+        # value satisfies it by construction whichever candidate is chosen. See
+        # ``test_cute_tcgen05_a5_repairs_bk_and_keeps_the_tile_count_cap``.
         over_cap_config = {
             "block_sizes": [256, 256, 16],
             "pid_type": "flat",
@@ -631,17 +789,24 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         is narrowed for shapes whose cluster_m=2 work-cluster count
         cannot saturate even a quarter-wave of cluster slots.
 
-        The gate measures ``(M / 256) * (N / 256)`` cluster_m=2 work
-        clusters and compares against ``num_sms // 4``. The threshold
-        was lowered from ``num_sms // 2`` (one full wave of 2-SM cluster
-        slots) because the generalized TVM-FFI direct entry has a much
-        lower launch/epilogue overhead and wins at ~64 work clusters
-        (0.86 of a wave on a 148-SM B200). With the SM count mocked to
-        B200's 148 the threshold is 37 cluster slots: 1024^3 sits at 16
-        clusters (< 37) and narrows to ``cluster_m=1`` only, while 2048^3
-        sits at 64 clusters (>= 37) and now KEEPS cluster_m=2 search
-        exposed. The 4096^3 G2 closure baseline (256 clusters) also keeps
-        cluster_m=2 search (covered by
+        Stage 2: the gate counts work clusters at the NARROWEST N tile
+        the full-tile cluster_m=2 search admits — ``(M / 256) * (N / 128)``
+        (block_n=128, a 256x128 output tile) rather than the 256x256
+        artifact ``(M / 256) * (N / 256)``. A block_n=128 cm2 tile produces
+        2x the clusters and fills the device where a 256x256 cm2 would
+        underfill, so counting at the tile the search can actually pick
+        keeps the gate honest for the bn=128 default-layout cm2 path (the
+        +8.3% 512x4096x4096 win). The comparison is against ``num_sms // 4``
+        (lowered from ``num_sms // 2`` because the generalized TVM-FFI
+        direct entry wins at ~0.86 of a wave). With the SM count mocked to
+        B200's 148 the threshold is 37 cluster slots: 1024^3 sits at 32
+        clusters ((1024/256)*(1024/128) = 4*8) < 37 and narrows to
+        ``cluster_m=1`` only, while 2048^3 sits at 128 clusters (>= 37) and
+        KEEPS cluster_m=2 search exposed. The 512x4096x4096 medium-M shape
+        now sits at 64 clusters ((512/256)*(4096/128) = 2*32) >= 37 and is
+        ADMITTED (it was suppressed under the old 256x256 count at 32
+        clusters) — the Stage-2 behavior change. The 4096^3 G2 closure
+        baseline (512 clusters) also keeps cluster_m=2 search (covered by
         ``test_cute_tcgen05_two_cta_enters_validated_search_space``).
 
         Mocking ``_cuda_num_sms_or_zero`` keeps the test hermetic:
@@ -661,10 +826,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                 out[tile_m, tile_n] = acc.to(x.dtype)
             return out
 
-        def bind_at(size: int):
+        def bind_at(size: int, n: int | None = None):
+            n = size if n is None else n
             args = (
                 torch.empty([size, size], device=DEVICE, dtype=HALF_DTYPE),
-                torch.empty([size, size], device=DEVICE, dtype=HALF_DTYPE),
+                torch.empty([size, n], device=DEVICE, dtype=HALF_DTYPE),
             )
             with (
                 patch_cute_mma_support(),
@@ -675,10 +841,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             ):
                 return cute_matmul_mma.bind(args).config_spec
 
-        # Suppressed: 1024^3 = 16 cluster slots < 148 // 4 = 37. cluster_m=2
-        # search is suppressed and the cluster_m2 seed / fixup machinery is
-        # disabled so the autotuner never spends budget on the cluster_m=2 seed
-        # for a shape where it has no productive lever.
+        # Suppressed: 1024^3 = (1024/256)*(1024/128) = 32 cluster slots < 148 // 4
+        # = 37 (counted at the narrow-N block_n=128 tile). cluster_m=2 search is
+        # suppressed and the cluster_m2 seed / fixup machinery is disabled so the
+        # autotuner never spends budget on the cluster_m=2 seed for a shape where
+        # it has no productive lever.
         suppressed_spec = bind_at(1024)
         self.assertEqual(suppressed_spec._tcgen05_cluster_m_search_choices, (1,))
         self.assertIsNone(suppressed_spec._tcgen05_cluster_m2_search_constraints)
@@ -693,15 +860,29 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertIn("persistent_interleaved", suppressed_spec.allowed_pid_types)
         self.assertIn("persistent_blocked", suppressed_spec.allowed_pid_types)
 
-        # Admitted (positive control for the lowered // 4 boundary): 2048^3 = 64
-        # cluster slots >= 37. cluster_m=2 search stays exposed, its constraints
-        # are recorded, and the cluster_m=2 seed heuristic is registered.
+        # Admitted (positive control for the lowered // 4 boundary): 2048^3 =
+        # (2048/256)*(2048/128) = 128 cluster slots >= 37. cluster_m=2 search
+        # stays exposed, its constraints are recorded, and the cluster_m=2 seed
+        # heuristic is registered.
         admitted_spec = bind_at(2048)
         self.assertEqual(admitted_spec._tcgen05_cluster_m_search_choices, (1, 2))
         self.assertIsNotNone(admitted_spec._tcgen05_cluster_m2_search_constraints)
         self.assertIn(
             CuteTcgen05ClusterM2Heuristic.name,
             admitted_spec.autotuner_heuristics,
+        )
+
+        # Stage 2 behavior change: the 512x4096x4096 medium-M shape sits at
+        # (512/256)*(4096/128) = 64 clusters counted at the narrow-N tile
+        # (>= 37, ADMITTED), where the old 256x256 count put it at
+        # (512/256)*(4096/256) = 32 (< 37, suppressed). This is the shape whose
+        # bn=128 cm2 + ab4 config runs +8.3% over the cm1 winner.
+        s2_spec = bind_at(512, n=4096)
+        self.assertEqual(s2_spec._tcgen05_cluster_m_search_choices, (1, 2))
+        self.assertIsNotNone(s2_spec._tcgen05_cluster_m2_search_constraints)
+        self.assertIn(
+            CuteTcgen05ClusterM2Heuristic.name,
+            s2_spec.autotuner_heuristics,
         )
 
     @onlyBackends(["cute"])
@@ -777,6 +958,47 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             ],
         )
 
+        # ⚠ ``bn`` IS NOT PINNED ON THIS ARM ANY MORE (2026-08-10). The case above
+        # draws ``bn=128`` and so cannot tell a pin from a floor -- it passes either
+        # way. This case draws ``bn=256`` and pins the actual change: the fp8 arm
+        # used to write ``block_sizes[n_index] = 128`` unconditionally, and now
+        # leaves ``bn`` to the stage's SETTLE, which is the same rule the non-fp8
+        # arm gets (``bn <= 128`` snaps to 128, otherwise 256).
+        #
+        # The deleted write was wave-quantisation steering, not legality: the tuned
+        # 128x128 tile is ALREADY SEEDED (asserted below), so it competes on merit
+        # either way, and measured 2026-08-10 the seed producer emits
+        # ``[128,128,128] cm=2 ab=12`` identically with the write present or gone.
+        # What it cost was reach -- on fp8 512x2048x4096 / 512x6144x2048 / 1024^3,
+        # 600 pre-fix draws each: the fp8 arm's ``bn`` distribution went
+        # ``{128: 149}`` -> ``{128: 119, 256: 30}`` and distinct tiles 4 -> 8, with
+        # ``block_sizes`` the ONLY key that changed. All 30 newly-reachable configs
+        # emit real tcgen05 (grepped for ``CtaGroup``, not merely compiled) and are
+        # BIT-EXACT under the integer-data oracle.
+        #
+        # Deliberately NOT freed below 128: the SETTLE's floor stands. At ``bm=128``
+        # a ``bn=16`` raises ``OpError: expects the N-mode to satisfy 32 <= ...``,
+        # and narrow N measured badly on cm2 generally (``bn=64`` is -40% vs 128 on
+        # a wave-saturated bf16 4096^3, and +0.2% -- inside a 0.2% null-arm floor --
+        # on the wave-starved shape that most favours it).
+        small_grid_wide_n = {
+            "block_sizes": [128, 256, 128],
+            "l2_groupings": [1],
+            "pid_type": "flat",
+            "tcgen05_cluster_m": 2,
+        }
+        spec.normalize(small_grid_wide_n, _fix_invalid=True)
+        self.assertEqual(small_grid_wide_n["tcgen05_cluster_m"], 2)
+        self.assertEqual(
+            small_grid_wide_n["block_sizes"][:2],
+            [TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N],
+            msg=(
+                "a drawn bn=256 on the fp8 small-grid arm was re-pinned to 128; the "
+                "arm must leave bn to the stage's SETTLE so the 256-wide tile "
+                "competes (measured bit-exact, 30/600 draws reach it)"
+            ),
+        )
+
         # The full-tile cluster_m=2 path drops epilogue_subtile for the same
         # reason.
         full_tile_epi = {
@@ -813,6 +1035,46 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                 TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M,
                 TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N,
             ],
+        )
+
+        # THE LEGAL-bm INVARIANT (2026-08-01). Every cluster_m=2 config that
+        # leaves normalize must carry bm in {128, 256}. This is a hard legality
+        # property, not a preference: ``_tcgen05_use_2cta_instrs``
+        # (``cute_mma.py``) returns a *bool*, so at bm < 128 with cluster_m=2 it
+        # returns False and codegen SILENTLY emits ``CtaGroup.ONE`` -- bit-exact
+        # output, wrong kernel, no warning, no raise. bm=128 is additionally
+        # fp8-only there (bf16 bm=128 cm2 is the legacy CtaGroup.ONE family).
+        #
+        # Asserted over DRAWN configs, not hand-built ones: 50% of cm2 draws on
+        # this family arrive with bm of 16/32/64 and depend on
+        # ``_fix_cluster_m2_search_config`` to establish a legal bm before it
+        # returns. Two safeguards do that independently -- ``min_search_m = 128``
+        # (a fragment bound) and the stage's own explicit write -- and this test
+        # covers the composition, so moving either one cannot silently produce a
+        # non-CTA-pair kernel.
+        config_gen = ConfigGeneration(spec)
+        random.seed(20260801)
+        cm2_seen = 0
+        for _ in range(400):
+            drawn = config_gen.random_config()
+            if drawn.config.get("tcgen05_cluster_m") != 2:
+                continue
+            cm2_seen += 1
+            drawn_bm = drawn.block_sizes[0]
+            self.assertIn(
+                drawn_bm,
+                (
+                    TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M,
+                    TCGEN05_TWO_CTA_BLOCK_M,
+                ),
+                msg=(
+                    f"cluster_m=2 config left normalize with block_m={drawn_bm}, "
+                    f"which is not a CtaGroup.TWO tile -- codegen will silently "
+                    f"emit CtaGroup.ONE. Full config: {drawn.config}"
+                ),
+            )
+        self.assertGreater(
+            cm2_seen, 0, "no cluster_m=2 config was drawn, so this proves nothing"
         )
 
     @onlyBackends(["cute"])
@@ -912,20 +1174,26 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                     [TCGEN05_ONE_CTA_MAX_BLOCK_M, 32, 16],
                 )
 
-        # ⚠ THE NON-PERSISTENT ARM IS NOW CLAMPED TOO. This block used to assert
-        # ``[256, 32, 16]`` survives at ``pid_type='flat'`` — i.e. it PINNED the
+        # ⚠ THE NON-PERSISTENT ARM IS NOW CLAMPED TOO (2026-08-07). This block used to
+        # assert ``[256, 32, 16]`` survives at ``pid_type='flat'`` — i.e. it PINNED the
         # defect. ``bm=256`` at ``cluster_m=1`` fails
         # ``_mma_impl_matches_problem_shape`` (which admits ``bm in {64,128}``, or
-        # ``bm==256`` only with ``cluster_m==2``), so ``_choose_mma_impl`` fell
-        # through to the non-tensor-core ``universal`` scalar path: numerically
-        # correct, ~1500-2000x slower, and emitted with NO warning (the
-        # SMEM-downgrade warning is gated on ``tcgen05_ok``, which that path never
-        # reaches).
+        # ``bm==256`` only with ``cluster_m==2``), so ``_choose_mma_impl`` fell through to
+        # the non-tensor-core ``universal`` scalar path: numerically correct, ~1500-2000x
+        # slower, and emitted with NO warning (the SMEM-downgrade warning is gated on
+        # ``tcgen05_ok``, which that path never reaches).
+        #
+        # It was reachable by the SAMPLER, not just by explicit configs. Measured over
+        # 600 post-pipeline draws per shape: plain 4096³ 53/600 (8.8%), rowvec-bias 53/600,
+        # resid 41/600, 2048x4096x4096 53/600, 8192x1024x1024 51/600, 512x4096x4096 53/600
+        # — all at ``pid_type='flat'``. Only the 5000³ edge shape was immune, because
+        # ``max_search_m`` clamps to 128 there. Each such draw spent a compile plus a
+        # benchmark on a kernel that can never win.
         #
         # The clamp itself was always correct; the STAGE was gated on a persistent
-        # ``pid_type``, so it never ran on these. That gate term is gone. ``xyz``
-        # behaves identically to ``flat`` (both non-persistent), which is why the
-        # hazard is stated as "non-persistent" rather than "flat".
+        # ``pid_type``, so it never ran on these. That gate term is gone. ``xyz`` behaves
+        # identically to ``flat`` (both non-persistent), which is why the hazard is stated
+        # as "non-persistent" rather than "flat".
         for non_persistent_pid in ("flat", "xyz"):
             with self.subTest(pid_type=non_persistent_pid):
                 non_persistent_config = {
@@ -1033,177 +1301,6 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(config["l2_groupings"], [1])
 
     @onlyBackends(["cute"])
-    def test_cute_tcgen05_ab_stages_three_smem_budget_gate(self) -> None:
-        """SMEM-budget gate validates explicit ``tcgen05_ab_stages=3`` configs.
-
-        The 4096^3 BF16 matmul binding records the SMEM-budget gate so
-        search-time normalization can demote sampled ``ab=3`` candidates
-        whose ``(bm, bn, bk, cluster_m)`` per-CTA AB-SMEM cost exceeds the
-        device's optin SMEM cap minus the non-AB reservation (see
-        ``cute_plan.md`` §7.0). Cycle 97 made ``ab=3`` BUDGET-AWARE-SEARCHABLE:
-        the broad random search fragment is now lifted to ``ab=3`` wherever
-        the SMEM-budget constraints are recorded (B200-class optin, bf16/fp16),
-        and ``_fix_ab_stages_search_config`` demotes a sampled ab=3 that does
-        not fit (over-budget bare AB, or the real source-C ring overflow) — so
-        the autotuner can reach the ab=3 winner directly instead of only via the
-        per-shape seeds. The validation surface stays unchanged: explicit
-        ``helion.Config(tcgen05_ab_stages=3)`` always round-trips for
-        explicit user configs.
-
-        The gate is purely deterministic given a budget value, so we
-        pin the per-CTA AB-SMEM budget to B200's nominal value via
-        ``_bind_cute_4096_matmul_kernel_with_mocked_smem_budget`` —
-        that keeps coverage live on any host regardless of the live
-        GPU's optin SMEM cap.
-        """
-        # B200's optin reports 232 448 bytes = 227 KiB; subtract the
-        # 28 KiB non-AB reservation to match what
-        # ``CuteTcgen05Config.per_cta_ab_smem_budget_bytes`` produces in production
-        # (203 776 bytes). Tracking the production value exactly is
-        # what makes the over-budget vs in-budget boundary in this
-        # test mirror the running gate.
-        b200_budget_bytes = 227 * 1024 - 28 * 1024
-        bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(b200_budget_bytes)
-        spec = bound.config_spec
-
-        constraints = spec._tcgen05_ab_stages_search_constraints
-        self.assertIsNotNone(constraints)
-        # ``itemsize`` for BF16/FP16 is 2 bytes — matches the matmul
-        # binding's ``lhs.dtype.itemsize`` argument.
-        self.assertEqual(constraints.dtype_bytes, HALF_DTYPE.itemsize)
-        self.assertEqual(constraints.per_cta_smem_budget_bytes, b200_budget_bytes)
-
-        search_fragments = spec._tcgen05_optional_fragments(for_search=True)
-        # Cycle 97: a deep AB ring is BUDGET-AWARE-SEARCHABLE — the for_search cap is
-        # lifted to the 16-bit dtype hard cap of 8 wherever the SMEM-budget
-        # constraints were recorded (here: the mocked B200 budget), so the autotuner
-        # can SAMPLE ab=3 directly. A sampled ab=3 that does not fit is then demoted
-        # by ``_fix_ab_stages_search_config`` (the over-budget cases below). The
-        # validation surface is independently 3 for explicit configs.
-        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 8)
-        validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
-        # The validation surface tracks the same 16-bit dtype hard cap as the search
-        # surface: an explicit ``helion.Config`` at ab=4..8 on a 16-bit cluster_m=2
-        # DEFAULT-layout tile is exactly what the search now draws and runs, so
-        # rejecting it would put the two surfaces out of agreement. Both are still
-        # gated per tile by ``max_ab_stages_that_fit``.
-        self.assertEqual(validation_fragments["tcgen05_ab_stages"].high, 8)
-
-        # cluster_m=2 256x256x128 ab=3: the canonical 4096^3 fast config —
-        # fits the per-CTA budget (196 608 bytes vs B200's 203 776-byte
-        # budget). Search-time fixup keeps it.
-        keep_config = {
-            "block_sizes": [256, 256, 128],
-            "l2_groupings": [4],
-            "pid_type": "persistent_interleaved",
-            "tcgen05_cluster_m": 2,
-            "tcgen05_ab_stages": 3,
-        }
-        spec.normalize(keep_config, _fix_invalid=True)
-        self.assertEqual(keep_config["tcgen05_ab_stages"], 3)
-        self.assertEqual(keep_config["tcgen05_cluster_m"], 2)
-
-        # ab=3 over-budget shapes get demoted to ab=2. The cute_dsl
-        # ptxas failure is the loud backstop for explicit user configs
-        # that bypass autotune; the search-side fixup keeps the
-        # autotuner from blowing the GPU context mid-tuning. The two
-        # cases below exercise distinct post-fixup shapes:
-        #   * persistent + cluster_m=1 with bm=128: 294 912 bytes — the
-        #     ``_fix_tcgen05_cluster_m1_persistent_search_config`` path
-        #     already clamps bm to ``TCGEN05_ONE_CTA_MAX_BLOCK_M``;
-        #     bm=128 is at the cap, so it survives unchanged.
-        #   * flat + cluster_m=1 with bm=256: 393 216 bytes — flat
-        #     pid_type bypasses the cluster_m1 cap (the cap only
-        #     applies under persistent pid_types) so the unmolested
-        #     256x256x128 single-CTA path reaches the new fixup.
-        over_budget_cases = (
-            ("persistent_interleaved", [128, 256, 128]),  # 294 912 bytes
-            ("flat", [256, 256, 128]),  # 393 216 bytes
-        )
-        for pid_type, over_budget_block_sizes in over_budget_cases:
-            with self.subTest(pid_type=pid_type, block_sizes=over_budget_block_sizes):
-                config = {
-                    "block_sizes": list(over_budget_block_sizes),
-                    "pid_type": pid_type,
-                    "tcgen05_cluster_m": 1,
-                    "tcgen05_ab_stages": 3,
-                }
-                spec.normalize(config, _fix_invalid=True)
-                self.assertEqual(config["tcgen05_ab_stages"], 2)
-
-        # cluster_m=1 ab=3 in-budget shape stays at ab=3.
-        in_budget = {
-            "block_sizes": [128, 128, 128],
-            "pid_type": "persistent_interleaved",
-            "tcgen05_cluster_m": 1,
-            "tcgen05_ab_stages": 3,
-        }
-        spec.normalize(in_budget, _fix_invalid=True)
-        self.assertEqual(in_budget["tcgen05_ab_stages"], 3)
-
-        # Validation surface always accepts ab=3 (no _fix_invalid).
-        user_config = {
-            "block_sizes": [128, 256, 128],
-            "pid_type": "persistent_interleaved",
-            "tcgen05_cluster_m": 1,
-            "tcgen05_ab_stages": 3,
-        }
-        spec.normalize(user_config)
-        self.assertEqual(user_config["tcgen05_ab_stages"], 3)
-
-    @onlyBackends(["cute"])
-    def test_cute_tcgen05_ab_stages_three_gate_off_below_b200(self) -> None:
-        """Gate stays off when target device's SMEM optin is sub-B200.
-
-        Mocking the budget helper to return 0 — the value the helper
-        produces for non-CUDA hosts and any device whose optin cap sits
-        below ``TCGEN05_AB_STAGES_MIN_DEVICE_SMEM_OPTIN`` — must
-        keep ``_tcgen05_ab_stages_search_constraints`` ``None`` so
-        the search surface stays at ``ab_stages_max=2`` and the
-        canonical seed does not carry ``ab=3``. This guards against
-        broadening the search past the hardware's known-good envelope
-        on heterogeneous / multi-GPU setups.
-        """
-        bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(0)
-        spec = bound.config_spec
-
-        self.assertIsNone(spec._tcgen05_ab_stages_search_constraints)
-        search_fragments = spec._tcgen05_optional_fragments(for_search=True)
-        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 2)
-        # Validation surface stays at 3 so explicit user configs still
-        # round-trip even on a device the gate is off for.
-        validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
-        self.assertEqual(validation_fragments["tcgen05_ab_stages"].high, 3)
-        # The cluster_m2 seed exists but does *not* carry ab=3.
-        seeds = spec.compiler_seed_configs
-        self.assertEqual(len(seeds), 1)
-        self.assertNotIn("tcgen05_ab_stages", seeds[0].config)
-
-    @onlyBackends(["cute"])
-    def test_cute_tcgen05_ab_stages_three_uses_analyzed_block_indices(
-        self,
-    ) -> None:
-        """Extra config slots do not hide the analyzed M/N/K axes."""
-        b200_budget_bytes = 227 * 1024 - 28 * 1024
-        bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(b200_budget_bytes)
-        spec = bound.config_spec
-
-        self.assertIsNotNone(spec._tcgen05_ab_stages_search_constraints)
-        with patch.object(type(spec.block_sizes), "__len__", lambda self: 9):
-            with patch.object(
-                CuteTcgen05Config,
-                "per_cta_ab_smem_budget_bytes",
-                staticmethod(lambda device: b200_budget_bytes),
-            ):
-                spec.allow_tcgen05_ab_stages_search(
-                    dtype_bytes=2,
-                    device=torch.device("cuda:0"),
-                )
-            self.assertIsNotNone(spec._tcgen05_ab_stages_search_constraints)
-            search_fragments = spec._tcgen05_optional_fragments(for_search=True)
-            self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 8)
-
-    @onlyBackends(["cute"])
     def test_cute_tcgen05_ab_stages_three_seeded_in_initial_population(
         self,
     ) -> None:
@@ -1219,7 +1316,7 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
 
         Pins the per-CTA AB-SMEM budget to B200's nominal value so the
         seed-path coverage runs on any host (see
-        ``test_cute_tcgen05_ab_stages_three_smem_budget_gate``).
+        ``test_cute_tcgen05_ab_stages_smem_budget_gate``).
         """
         # B200 production value: 227 KiB optin minus 28 KiB non-AB
         # reservation (see CuteTcgen05Config.per_cta_ab_smem_budget_bytes).
@@ -1228,13 +1325,15 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         spec = bound.config_spec
 
         # 16-bit 4096^3 is FFI-eligible (fp16 == bf16 parity). The initial
-        # population carries the DEFAULT-layout cluster_m=2 seed and the
-        # generalized TVM-FFI direct-entry seed, and the two no longer share a K
-        # rung: the widened ``bk`` draw bound lets the DEFAULT-layout seed sit at
-        # 256 while the FFI seed keeps its validated 128. So this test asserts the
-        # canonical ab=3 envelope is PRESENT among the cluster_m=2 seeds (the point
-        # of the test — ab=3 is seeded rather than discovered by mutation) rather
-        # than requiring every cluster_m=2 seed to be it.
+        # population carries the DEFAULT-layout cluster_m=2 ab=3 seed and the
+        # generalized TVM-FFI direct-entry seed, both on the canonical ab=3
+        # fast-config envelope. The formula matmul heuristic additionally emits
+        # a deep-AB compute seed for this shape ([256,256,64] ab=6, which fills
+        # the AB-SMEM isobar and runs faster than the ab=3 tile); that extra seed
+        # is legitimate, so this test asserts the canonical ab=3 envelope is
+        # PRESENT among the cluster_m=2 seeds (the point of the test — ab=3 is
+        # seeded rather than discovered by mutation) rather than requiring every
+        # cluster_m=2 seed to be it.
         cluster_m2_seeds = [
             config.config
             for config in spec.compiler_seed_configs
@@ -3277,6 +3376,17 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             spec.allowed_pid_types,
             ("persistent_blocked", "persistent_interleaved"),
         )
+        # This test guards the persistence-model derivation round-trip on the
+        # SEARCH representation. The promote-to-default formula heuristic pins a
+        # cluster_m=2 [256,256,*] compute config in ``compiler_default_config``,
+        # which ``default_flat()`` would flatten as the baseline; that promoted
+        # config is not flat-round-trip-identity in this force-persistent narrowed
+        # spec (its block_m=256 projects back to the flat block_m default of 128),
+        # which is a general promoted-seed property, not the persistence-model
+        # invariant under test. Clear the promoted seed so ``default_flat()`` uses
+        # the search-view fragment default (verified idempotent: fragment-default
+        # default_flat DOES round-trip to identity).
+        spec.compiler_default_config = None
         cg = ConfigGeneration(spec)
         default_flat = cg.default_flat()
         round_tripped = cg.flatten(cg.unflatten(default_flat))
@@ -3401,6 +3511,511 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             self.assertIn("PipelineUmmaAsync.create", code)
             self.assertIn("PipelineTmaUmma.create", code)
             self.assertIn("PipelineTmaStore.create", code)
+
+    # ------------------------------------------------------------------
+    # Search-surface widening acceptance tests.
+    #
+    # These prove three things about the tcgen05 search space, using only
+    # bind + normalize (no kernel compile, no benchmark):
+    #   * the domain widened (what CAN be drawn),
+    #   * draws actually reach the new values (what IS drawn),
+    #   * the SMEM budget still refuses what overflows (the negative test).
+    #
+    # Plus the structural invariant that ties them together: NO DAYLIGHT
+    # between what a seed may hold and what the search may draw. A value the
+    # search can draw but ``normalize`` rejects wastes draws on configs that
+    # die in validation; a value a seed can hold but the search cannot draw
+    # makes the seed a silent single point of failure, because the search
+    # cannot improve on it or correct it.
+    # ------------------------------------------------------------------
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_ab_stages_no_daylight_between_surfaces(self) -> None:
+        """Every numeric search fragment is bounded by its validation fragment.
+
+        The invariant: ``search.high <= validation.high`` and
+        ``search.low >= validation.low`` for every shared numeric knob. If the
+        search bound were the wider of the two, the sampler would spend draws on
+        values ``normalize`` then rejects outright (measured: before the AB caps
+        were unified, a 16-bit shape with no direct-entry structure drew
+        ``tcgen05_ab_stages=4`` against a validation bound of ``[1, 3]``).
+
+        Written as a LOOP over every numeric fragment rather than a one-off
+        assertion on the knob that happened to be wrong, so a future widening of
+        one surface cannot silently reintroduce the gap on a different key.
+        """
+        b200_budget_bytes = 227 * 1024 - 28 * 1024
+        bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(b200_budget_bytes)
+        spec = bound.config_spec
+        search = spec._tcgen05_optional_fragments(for_search=True)
+        validation = spec._tcgen05_optional_fragments(for_search=False)
+
+        checked = 0
+        for key, search_fragment in search.items():
+            validation_fragment = validation.get(key)
+            if not isinstance(search_fragment, IntegerFragment) or not isinstance(
+                validation_fragment, IntegerFragment
+            ):
+                continue
+            checked += 1
+            self.assertLessEqual(
+                search_fragment.high,
+                validation_fragment.high,
+                msg=(
+                    f"{key}: search high {search_fragment.high} exceeds validation "
+                    f"high {validation_fragment.high} — the search can draw a value "
+                    f"normalize will reject"
+                ),
+            )
+            self.assertGreaterEqual(
+                search_fragment.low,
+                validation_fragment.low,
+                msg=(
+                    f"{key}: search low {search_fragment.low} is below validation "
+                    f"low {validation_fragment.low}"
+                ),
+            )
+        # Guard against the loop silently checking nothing.
+        self.assertGreater(checked, 0)
+        self.assertIn("tcgen05_ab_stages", search)
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_a5_repairs_bk_and_keeps_the_tile_count_cap(self) -> None:
+        """A5 snaps an illegal ``bk`` to a legal one instead of demoting to cm1.
+
+        Item 9. The old A5 was ``if not cluster_m2_bk_is_valid(bk): cluster_m = 1``,
+        inconsistent with the same function snapping ``bm``, snapping ``bn``, and
+        re-tuning ``(bn, bk, ab, c)`` in the joint solve -- and the demote cost MORE
+        than cluster_m, because stage 4 then clamps ``bm`` to <= 128, so the
+        candidate lost its tile too.
+
+        K=384 is the witness: ``384 % 256 != 0`` makes ``bk=256`` illegal for
+        cluster_m=2 while the K fragment's ``high`` is 256, so the sampler draws it.
+        (On 4096^3 every drawable ``bk`` is legal, so A5 never fires there -- which is
+        why this test does not use the usual shape.)
+
+        THE TILE-COUNT CAP IS THE HARD BOUND AND MUST SURVIVE THE REPAIR.
+        ``cluster_m2_bk_is_valid`` enforces ``ceil(static_k / bk) <= max_k_tiles``
+        internally, so a repaired ``bk`` satisfies it by construction -- the repair
+        can only pick a value the predicate already accepts. That cap is GPU-measured
+        (512 K-tiles -> runtime ``RuntimeError``), unlike the edge family's
+        ``bk in {128, 256}`` whitelist which is coverage. This test asserts the
+        post-repair tile count against the cap directly, so a future "repair" that
+        picked a ``bk`` outside the predicate would fail here rather than at runtime.
+        """
+        bound = _bind_cute_k384_matmul_kernel()
+        spec = bound.config_spec
+        tcgen05 = spec._cute_tcgen05_config
+        constraints = spec._tcgen05_cluster_m2_search_constraints
+        self.assertIsNotNone(constraints)
+        assert constraints is not None
+        # Precondition: bk=256 must actually be illegal here, or the test is vacuous.
+        self.assertFalse(tcgen05.cluster_m2_bk_is_valid(256, constraints))
+        self.assertTrue(tcgen05.cluster_m2_bk_is_valid(128, constraints))
+
+        config = {
+            "block_sizes": [256, 256, 256],
+            "l2_groupings": [1],
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 2,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_ab_stages": 2,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": 2,
+        }
+        spec.normalize(config, _fix_invalid=True)
+        # REPAIRED, not demoted: cluster_m=2 survives and bm keeps 256 (the demote
+        # path would have let stage 4 clamp it to <= 128).
+        self.assertEqual(
+            config["tcgen05_cluster_m"],
+            2,
+            msg=f"illegal bk demoted to cluster_m=1 instead of being repaired: {config}",
+        )
+        block_sizes = cast("list[int]", config["block_sizes"])
+        self.assertEqual(block_sizes[0], TCGEN05_TWO_CTA_BLOCK_M)
+        self.assertNotEqual(block_sizes[2], 256)
+        self.assertTrue(
+            tcgen05.cluster_m2_bk_is_valid(block_sizes[2], constraints),
+            msg=f"repaired bk={block_sizes[2]} is not legal for this shape",
+        )
+        # The cap, asserted directly rather than trusted.
+        k_tiles = -(-constraints.static_k // block_sizes[2])
+        self.assertLessEqual(
+            k_tiles,
+            constraints.max_k_tiles,
+            msg=(
+                f"repaired bk={block_sizes[2]} needs {k_tiles} K-tiles, over the "
+                f"{constraints.max_k_tiles} cap (512 K-tiles is a GPU-measured "
+                f"runtime RuntimeError)"
+            ),
+        )
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_deep_ab_stages_are_settable(self) -> None:
+        """A deep 16-bit ``ab_stages`` no longer fails validation outright.
+
+        Before the caps were unified, ``set_config``/``normalize`` on a 16-bit
+        shape rejected ``tcgen05_ab_stages=8`` with
+        ``InvalidConfig: tcgen05_ab_stages must be in [1, 6], got 8``. The depth
+        is now admitted by the fragment and bounded per TILE instead: on this
+        canonical 256x256 tile it is clamped down to what the per-CTA SMEM budget
+        actually fits, rather than being refused for the whole dtype.
+        """
+        b200_budget_bytes = 227 * 1024 - 28 * 1024
+        bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(b200_budget_bytes)
+        spec = bound.config_spec
+
+        deep = {
+            "block_sizes": [256, 256, 128],
+            "l2_groupings": [4],
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 2,
+            "tcgen05_ab_stages": 8,
+        }
+        # No raise: the validation fragment admits the depth.
+        spec.normalize(deep, _fix_invalid=True)
+        # ...and the tile-level budget still binds. [256,256,128] cm2 bf16 costs
+        # 65536 B/stage, so only ab=3 fits the 203776 B budget (196608 B); ab=4
+        # would be 262144 B.
+        self.assertEqual(deep["tcgen05_ab_stages"], 3)
+        self.assertEqual(deep["block_sizes"], [256, 256, 128])
+
+        # A tile where the deep pipeline genuinely fits keeps it: bk=32 quarters
+        # the per-stage cost, so [256,256,32] cm2 ab8 is 131072 B <= budget.
+        # This is the regime the cap used to amputate -- ab8 is reached by a
+        # SMALLER bk, not by a deeper pipeline on the same tile.
+        deep_small_bk = {
+            "block_sizes": [256, 256, 32],
+            "l2_groupings": [4],
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 2,
+            "tcgen05_ab_stages": 8,
+        }
+        spec.normalize(deep_small_bk, _fix_invalid=True)
+        self.assertEqual(deep_small_bk["tcgen05_ab_stages"], 8)
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_block_k_256_is_two_way(self) -> None:
+        """The ``bk=256`` neighbourhood is not a one-way street.
+
+        The compiler ships pretuned fp8 entries at ``bk=256``, so the seed can emit
+        it. With the fragment capped at 128 the neighbourhood was one-way --
+        ``pattern_neighbors(256)`` clamped to ``[128]``, so the hill-climber could
+        only ever walk AWAY from such a seed and never back.
+        """
+        pow2_fragment = PowerOfTwoFragment(16, 256, 64)
+        self.assertIn(128, pow2_fragment.pattern_neighbors(256))
+        self.assertIn(256, pow2_fragment.pattern_neighbors(128))
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_cluster_m1_applies_both_legality_clamps(self) -> None:
+        """The cluster_m=1 stage applies its ``bm`` clamp AND its pid redirect.
+
+        These are two independent legality clamps on different keys, and they used
+        to sit in an if/else: on an edge-K-tail-family shape the ``pid_type``
+        redirect ``return``ed before the ``block_m`` clamp could run. A
+        cluster_m=1 config carrying ``bm=256`` therefore kept it, which is outside
+        the CtaGroup.ONE validated envelope (that MMA covers 64/128 M tiles) --
+        and the recorded failure mode is silent: ``block_m=256`` with
+        ``cluster_m=1`` emits plain Triton instead of erroring, so the search
+        would benchmark a different BACKEND than the one it believed it measured.
+
+        Reachable through public ``normalize(..., _fix_invalid=True)``; a random
+        draw cannot produce it, because the M fragment is ``[128, 128]`` on such
+        shapes, so the exposure is explicit configs, cache entries and seeds.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_edge(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        # 5000 % 256 != 0 on all three axes, which is what admits the
+        # edge-K-tail family and so selects the pid-redirect arm.
+        args = (
+            torch.empty([5000, 5000], device=DEVICE, dtype=HALF_DTYPE),
+            torch.empty([5000, 5000], device=DEVICE, dtype=HALF_DTYPE),
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_edge.bind(args)
+        spec = bound.config_spec
+        constraints = spec._tcgen05_cluster_m2_search_constraints
+        self.assertIsNotNone(constraints)
+        self.assertTrue(
+            constraints.allow_edge_k_tail_family,
+            msg="shape must admit the edge-K-tail family for this test to bite",
+        )
+
+        config = {
+            "block_sizes": [256, 128, 128],
+            "l2_groupings": [1],
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 1,
+        }
+        spec.normalize(config, _fix_invalid=True)
+        # BOTH clamps: the pid redirect (which used to be the only one) and the
+        # bm clamp (which used to be skipped).
+        self.assertEqual(config["pid_type"], "flat")
+        self.assertEqual(config["block_sizes"][0], TCGEN05_ONE_CTA_MAX_BLOCK_M)
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_explicit_epi_tile_declines_aux_tma_producer(self) -> None:
+        """explicit epilogue tile × productive aux-TMA producer = ILLEGAL MEMORY ACCESS.
+
+        GPU-verified 2026-08-05 on a 4096³ bf16 rank-2 residual, ``[256,256,32]`` cm2,
+        one config per process, integer-data oracle:
+
+        | layout | aux_load_mode | c_input_warps | result |
+        |---|---|---|---|
+        | `explicit_epi_tile` | **tma** | **1** | **CUDA ILLEGAL MEMORY ACCESS** |
+        | `explicit_epi_tile` | simt | 1 | bit-exact |
+        | `explicit_epi_tile` | simt | 0 | bit-exact |
+        | `DEFAULT` | tma | 1 | bit-exact |
+        | `DEFAULT` | simt | 1 | bit-exact |
+
+        Root cause is stated in ``cute_mma.py``'s own comment: the explicit-epi-tile
+        family admits a rank-2 exact-shape residual *because* "``c_input_warps == 0``
+        is enforced below, so the aux-TMA productive body never fires" — but that
+        conjunct lives in the **flat-role** guard, so a plain ``explicit_epi_tile``
+        config with ``flat_role=False`` never met it. With a productive aux producer
+        the aux-TMA body DOES fire, against a D-store box built for the ``(128, 32)``
+        explicit tile.
+
+        **PRE-EXISTING**: the same config faults identically on base ``95ec8eb79``. It
+        was unreachable there only because ``explicit_epi_tile`` was drawable but
+        never survived repair (0/300 draws) — so making that axis reachable turned a
+        latent trap into a live one. Guarded in two places, both asserted here:
+
+        1. ``cute_mma.py`` raises ``BackendUnsupported`` (the honest diagnostic for an
+           explicit user config);
+        2. ``_aux_tma_request_is_satisfiable`` declines, so a DRAW is demoted to SIMT
+           and never spends a compile on a config that faults inside the timed
+           benchmark.
+
+        ⚠ The guard is narrowed to ``aux_load_mode=tma``, deliberately. ``simt`` +
+        ``c_input_warps=1`` under the explicit tile is the cooperative-SIMT producer
+        and is bit-exact; guarding on ``c_input_warps`` alone would delete a working
+        regime. An earlier, wider version of this guard did exactly that and was
+        caught by re-running the 8-combination table above.
+        """
+        bound = _bind_cute_residual_full_tile_4096_kernel()
+        cute_config = bound.config_spec._cute_tcgen05_config
+
+        def candidate(layout: str, aux: str) -> dict[str, object]:
+            return {
+                "block_sizes": [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, 32],
+                "l2_groupings": [2],
+                "pid_type": "persistent_interleaved",
+                "tcgen05_cluster_m": 2,
+                "tcgen05_cluster_n": 1,
+                "tcgen05_ab_stages": 2,
+                "tcgen05_c_stages": 2,
+                TCGEN05_AUX_LOAD_MODE_CONFIG_KEY: aux,
+                TCGEN05_STRATEGY_CONFIG_KEY: (
+                    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+                ),
+                TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: 1,
+                TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: 1,
+                "tcgen05_warp_spec_store_warps": 0,
+                TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: layout,
+            }
+
+        # The faulting pair is DECLINED, and the drawn warp key is left alone.
+        faulting = candidate(Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value, "tma")
+        cute_config._fix_aux_tma_search_config(faulting)
+        self.assertEqual(
+            faulting[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY],
+            "simt",
+            msg=(
+                "explicit_epi_tile + aux_load_mode=tma + a productive aux producer "
+                "is a CUDA ILLEGAL MEMORY ACCESS; the search must decline it"
+            ),
+        )
+
+        # ...and the DEFAULT-layout pair, which is bit-exact, still SURVIVES.
+        working = candidate(Tcgen05LayoutStrategy.DEFAULT.value, "tma")
+        cute_config._fix_aux_tma_search_config(working)
+        self.assertEqual(
+            working[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY],
+            TCGEN05_AUX_LOAD_MODE_TMA,
+            msg=(
+                "the guard is too wide: DEFAULT layout + aux-TMA + c_input=1 is "
+                "bit-exact and must not be declined"
+            ),
+        )
+
+        # No DRAWN config may carry the faulting pair.
+        config_gen = ConfigGeneration(bound.config_spec)
+        random.seed(20260805)
+        offenders = 0
+        for _ in range(300):
+            config = config_gen.random_config().config
+            if (
+                config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
+                == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+                and config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
+                == TCGEN05_AUX_LOAD_MODE_TMA
+                and config.get(TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY) == 1
+            ):
+                offenders += 1
+        self.assertEqual(
+            offenders,
+            0,
+            msg=(
+                f"{offenders}/300 drawn configs carry the faulting "
+                f"explicit_epi_tile + aux-TMA producer combination"
+            ),
+        )
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_layout_overrides_are_derived_not_drawn(self) -> None:
+        """The 3 epi-tile overrides are DERIVED from ``layout_strategy`` (§1 tier 2).
+
+        Each has exactly ONE legal non-``None`` value — ``(128, 32, 32)``, the only
+        triple ``cute_mma.py``'s D-descriptor codegen accepts. Their determinator is
+        ``layout_strategy``: ``explicit_epi_tile`` requires all three set,
+        ``DEFAULT`` requires all three ``None``, both enforced by
+        ``validate_tcgen05_strategy_invariants``.
+
+        **The derivation is the whole mechanism, and it is what this pins.**
+        ``_derive_layout_override_bundle`` overwrites all three from the determinator
+        UNCONDITIONALLY — it does not merely fill ``None`` — so the drawn value cannot
+        affect the emitted kernel. That is what makes the drawn ``layout_strategy``
+        axis coherent (measured 0/300 -> 24/300 reach) rather than an incoherent state
+        the validator rejects.
+
+        ⚠ SEARCH AND VALIDATION ARE DELIBERATELY EQUAL HERE, and this test asserts
+        that rather than the reverse. These keys briefly carried
+        ``search_choices=(None,)``, justified by the OLD stage 1, where the ONLY exit
+        for an incoherent bundle was the strip back to DEFAULT.
+
+        The strip arm still EXISTS and still fires often (``:3652``; measured 216/300
+        draws) — what changed is that it is no longer reachable BY INCOHERENCE.
+        ``_settle_layout_group`` runs first and completes the bundle, so by the time
+        the strip is considered the overrides already agree with ``layout_strategy``;
+        a config now reaches it for a *different* reason (off the seed's envelope and
+        off ``_fix_towards_explicit_epi_tile_envelope``'s preconditions), and it takes
+        that path identically whether the draw was ``(128,32,32)`` or
+        ``(None,None,None)``. Hence both draws normalize to the SAME config and the
+        narrowing protects nothing. Withholding a REDUNDANT value from the search is
+        not the same as withholding an ILLEGAL one (contrast ``cluster_n``, whose
+        ``2`` is search-withheld because it HANGS); parity is the default absent a
+        legality reason.
+
+        Also pins the constant-sharing: the derivation, the seed and
+        ``cute_mma.py``'s ``_TCGEN05_EXPLICIT_EPI_TILE_VALIDATED_SHAPE`` must read
+        ONE definition, or a future re-validation moves one and not the others.
+        """
+        from helion._compiler.cute.cute_mma import (
+            _TCGEN05_EXPLICIT_EPI_TILE_VALIDATED_SHAPE,
+        )
+
+        self.assertEqual(
+            _TCGEN05_EXPLICIT_EPI_TILE_VALIDATED_SHAPE,
+            (
+                TCGEN05_EXPLICIT_EPI_TILE_M,
+                TCGEN05_EXPLICIT_EPI_TILE_N,
+                TCGEN05_EXPLICIT_D_STORE_BOX_N,
+            ),
+            msg="codegen's validated shape and the derivation constants diverged",
+        )
+
+        bound = _bind_cute_4096_matmul_kernel_with_mocked_smem_budget(
+            227 * 1024 - 28 * 1024
+        )
+        spec = bound.config_spec
+        cute_config = spec._cute_tcgen05_config
+        self.assertTrue(
+            cute_config.explicit_epi_tile_family_exists(),
+            msg="shape not direct-entry eligible, so the layout group is absent",
+        )
+        override_keys = (
+            "tcgen05_layout_overrides_epi_tile_m",
+            "tcgen05_layout_overrides_epi_tile_n",
+            "tcgen05_layout_overrides_d_store_box_n",
+        )
+
+        # (1) SEARCH AND VALIDATION SURFACES ARE EQUAL. The derivation, not a narrowed
+        # draw surface, is what keeps the group coherent -- so there is no legality
+        # reason to withhold the concrete value from the search, and a key an explicit
+        # ``helion.Config`` may set is one the search may set.
+        search = cute_config.optional_fragments(for_search=True)
+        validation = cute_config.optional_fragments(for_search=False)
+        for key in override_keys:
+            with self.subTest(key=key, surface="search"):
+                self.assertEqual(
+                    search[key]._active_choices(),
+                    validation[key]._active_choices(),
+                    msg=(
+                        f"{key} diverges between the search and validation surfaces. "
+                        f"The drawn value is overwritten by "
+                        f"_derive_layout_override_bundle either way, so narrowing "
+                        f"buys no coherence -- only a parity gap and a "
+                        f"fingerprint()/cache-key change"
+                    ),
+                )
+            with self.subTest(key=key, surface="validation"):
+                self.assertEqual(
+                    len(validation[key]._active_choices()),
+                    2,
+                    msg=(
+                        f"{key} lost its concrete value on the validation surface, "
+                        f"so an explicit config / the seed can no longer round-trip"
+                    ),
+                )
+
+        # (2) the derivation makes both layout values coherent, in both directions.
+        for layout, expected in (
+            (
+                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value,
+                (
+                    TCGEN05_EXPLICIT_EPI_TILE_M,
+                    TCGEN05_EXPLICIT_EPI_TILE_N,
+                    TCGEN05_EXPLICIT_D_STORE_BOX_N,
+                ),
+            ),
+            (Tcgen05LayoutStrategy.DEFAULT.value, (None, None, None)),
+        ):
+            config: dict[str, object] = {
+                TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: layout,
+                # Deliberately start from the WRONG values for this layout, so a
+                # no-op implementation cannot pass.
+                override_keys[0]: None if expected[0] is not None else 128,
+                override_keys[1]: None if expected[1] is not None else 32,
+                override_keys[2]: None if expected[2] is not None else 32,
+            }
+            cute_config._derive_layout_override_bundle(config)
+            with self.subTest(layout=layout):
+                self.assertEqual(
+                    tuple(config[key] for key in override_keys),
+                    expected,
+                    msg=f"overrides do not follow layout_strategy={layout!r}",
+                )
+
+        # (3) A DERIVATION MUST NOT INTRODUCE A KEY. On a non-matmul kernel the
+        # tcgen05 keys are absent by design and ``normalize_strategy`` raises
+        # ``InvalidConfig`` for any that appears -- presence, not value, is what it
+        # tests. Writing None here would break 12 pointwise tests.
+        absent: dict[str, object] = {
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (Tcgen05LayoutStrategy.DEFAULT.value)
+        }
+        cute_config._derive_layout_override_bundle(absent)
+        for key in override_keys:
+            self.assertNotIn(
+                key,
+                absent,
+                msg=(
+                    f"the derivation INTRODUCED {key} into a config that did not "
+                    f"have it; on a non-matmul kernel that is an InvalidConfig"
+                ),
+            )
 
 
 @onlyBackends(["pallas"])


### PR DESCRIPTION
Stacked PRs:
 * __->__#3358
 * #3357
 * #3356
 * #3355
 * #3354
 * #3353
 * #3352
 * #3351
 * #3350


--- --- ---

### [autotuner][cute] tests for the _fix pipeline rework


Unit coverage for the stack, in the two shapes this file already uses: a named
validator rejects illegal input, and a data model round-trips.

  * ``test_cute_tcgen05_ab_stages_gate_off_below_b200`` /
    ``_uses_analyzed_block_indices`` / ``_no_daylight_between_surfaces`` --
    the AB-depth gate is off without the B200 budget, reads the analyzed block
    indices, and every search fragment stays inside its validation fragment.
  * ``test_cute_tcgen05_deep_ab_stages_are_settable`` /
    ``_block_k_256_is_drawable_and_two_way`` -- the widened ``ab_stages`` and
    ``bk`` domains accept an explicit config and hill-climb in both directions.
  * ``test_cute_tcgen05_a5_repairs_bk_and_keeps_the_tile_count_cap`` -- an
    illegal ``bk`` snaps to the nearest legal value, and the repaired value
    still satisfies the K-tile cap.
  * ``test_cute_tcgen05_cluster_m1_applies_both_legality_clamps`` -- the
    ``bm`` clamp and the pid redirect are independent, and both fire.
  * ``test_cute_tcgen05_explicit_epi_tile_declines_aux_tma_producer`` -- the
    pairing that faults at runtime is refused at config level and at codegen.
  * ``test_cute_tcgen05_layout_overrides_are_derived_not_drawn`` -- the three
    epi-tile overrides follow ``layout_strategy`` and are never introduced into
    a config that lacks them.

``test_cute_matmul_formula_heuristic.py`` pins the formula's analytical output
per regime against its answer key; ``test_cute_lowerings.py`` gains bit-exactness
coverage for the scalar-fallback UMMA drain and the ``bk=256`` K-tail A atom,
plus two builder-level asserts, and ``test_autotuner.py`` covers overrides being
pinned in the drawn vector.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>