### PR TITLE
[triton] Fix prepared dispatcher launch ABI

### DIFF
--- a/helion/runtime/triton/launcher.py
+++ b/helion/runtime/triton/launcher.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import contextvars
 from typing import TYPE_CHECKING
+from typing import cast
 
 import torch
 
@@ -369,6 +370,64 @@ def _prepared_launch_cache(
     return cache
 
 
+def _wrap_prepared_launch_runner(
+    active: object,
+    compiled: object,
+    runner: Callable[..., object],
+    grid: tuple[int, ...],
+    num_args: int,
+) -> Callable[..., object]:
+    """Adapt Triton's dispatcher runner to the full JIT argument ABI."""
+    triton_module = triton
+    if triton_module is None or getattr(compiled, "_dispatcher", None) is None:
+        return runner
+
+    arg_indices = getattr(compiled, "_dispatch_arg_indices", None)
+    num_kernel_args = getattr(compiled, "_num_kernel_args", None)
+    if (
+        type(arg_indices) is not tuple
+        or type(num_kernel_args) is not int
+        or len(arg_indices) != num_kernel_args
+        or not all(
+            type(index) is int and 0 <= index < num_args for index in arg_indices
+        )
+    ):
+        raise TypeError("invalid Triton dispatcher argument indices")
+    dispatch_arg_indices = cast("tuple[int, ...]", arg_indices)
+
+    def run(*args: object) -> object:
+        runtime = triton_module.knobs.runtime
+        enter_hook = runtime.launch_enter_hook
+        exit_hook = runtime.launch_exit_hook
+        if not enter_hook and not exit_hook:
+            return runner(*(args[index] for index in dispatch_arg_indices))
+
+        # Dispatcher-backed runners bypass launch hooks.  Reproduce
+        # CompiledKernel's Python launch path while retaining the resolved
+        # binary and current stream whenever hooks become live after prepare.
+        device = active.get_current_device()  # pyrefly: ignore [missing-attribute]
+        stream = active.get_current_stream(  # pyrefly: ignore [missing-attribute]
+            device
+        )
+        launch_metadata = compiled.launch_metadata(  # pyrefly: ignore [missing-attribute]
+            grid, stream, *args
+        )
+        return compiled.run(  # pyrefly: ignore [missing-attribute, not-callable]
+            grid[0],
+            grid[1] if len(grid) > 1 else 1,
+            grid[2] if len(grid) > 2 else 1,
+            stream,
+            compiled.function,  # pyrefly: ignore [missing-attribute]
+            compiled.packed_metadata,  # pyrefly: ignore [missing-attribute]
+            launch_metadata,
+            enter_hook,
+            exit_hook,
+            *args,
+        )
+
+    return run
+
+
 def _is_future_kernel(compiled: object) -> bool:
     compiled_type = type(compiled)
     return (
@@ -527,12 +586,19 @@ def default_launcher(
                 grid[1] if len(grid) > 1 else 1,
                 grid[2] if len(grid) > 2 else 1,
             )
+            runner = _wrap_prepared_launch_runner(
+                active,
+                compiled,
+                compiled[normalized_grid],  # pyrefly: ignore [unsupported-operation]
+                grid,
+                len(args),
+            )
             cache.insert(
                 0,
                 (
                     guard,
                     (
-                        compiled[normalized_grid],  # pyrefly: ignore [unsupported-operation]
+                        runner,
                         compiled,
                     ),
                 ),

--- a/test/test_triton_prepared_launcher.py
+++ b/test/test_triton_prepared_launcher.py
@@ -30,6 +30,14 @@ if TYPE_CHECKING:
 _TRITON_PREPARED_GLOBAL = 1
 
 
+class _FakeDispatchRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def __call__(self, *args: object) -> None:
+        self.calls.append(args)
+
+
 class _FakeCompiled:
     def __init__(self) -> None:
         self.runner_calls: list[tuple[object, ...]] = []
@@ -122,6 +130,107 @@ def _launch(
 
 @onlyBackends(["triton"])
 class TestPreparedTritonLauncherUnit(TestCase):
+    def test_dispatch_runners_project_arguments(self) -> None:
+        fake_triton = _fake_triton()
+        active = fake_triton.runtime.driver.active
+        compiled = SimpleNamespace(
+            _dispatch_arg_indices=(0, 2),
+            _dispatcher=object(),
+            _num_kernel_args=2,
+        )
+        fallback_compiled = SimpleNamespace(_dispatcher=None)
+        dispatch_runner = _FakeDispatchRunner()
+        dispatcher_fallback_calls: list[tuple[object, ...]] = []
+        fallback_calls: list[tuple[object, ...]] = []
+
+        def dispatcher_fallback_runner(*args: object) -> None:
+            dispatcher_fallback_calls.append(args)
+
+        def fallback_runner(*args: object) -> None:
+            fallback_calls.append(args)
+
+        with patch.object(launcher, "triton", fake_triton):
+            wrapped_dispatch = launcher._wrap_prepared_launch_runner(
+                active,
+                compiled,
+                dispatch_runner,
+                (1, 1, 1),
+                3,
+            )
+            wrapped_dispatcher_fallback = launcher._wrap_prepared_launch_runner(
+                active,
+                compiled,
+                dispatcher_fallback_runner,
+                (1, 1, 1),
+                3,
+            )
+            wrapped_fallback = launcher._wrap_prepared_launch_runner(
+                active,
+                fallback_compiled,
+                fallback_runner,
+                (1, 1, 1),
+                3,
+            )
+            wrapped_dispatch("runtime_a", "constexpr", "runtime_b")
+            wrapped_dispatcher_fallback("runtime_a", "constexpr", "runtime_b")
+            wrapped_fallback("runtime_a", "constexpr", "runtime_b")
+
+        self.assertEqual(dispatch_runner.calls, [("runtime_a", "runtime_b")])
+        self.assertEqual(dispatcher_fallback_calls, [("runtime_a", "runtime_b")])
+        self.assertEqual(fallback_calls, [("runtime_a", "constexpr", "runtime_b")])
+
+    def test_dispatch_runner_observes_hooks_added_after_prepare(self) -> None:
+        fake_triton = _fake_triton()
+        active = fake_triton.runtime.driver.active
+        active.get_current_stream = lambda _device: 17
+        dispatch_runner = _FakeDispatchRunner()
+        function = object()
+        packed_metadata = object()
+        launch_metadata = object()
+        result = object()
+        compiled = SimpleNamespace(
+            _dispatch_arg_indices=(0, 2),
+            _dispatcher=object(),
+            _num_kernel_args=2,
+            function=function,
+            packed_metadata=packed_metadata,
+            launch_metadata=Mock(return_value=launch_metadata),
+            run=Mock(return_value=result),
+        )
+
+        with patch.object(launcher, "triton", fake_triton):
+            wrapped = launcher._wrap_prepared_launch_runner(
+                active,
+                compiled,
+                dispatch_runner,
+                (2, 3),
+                3,
+            )
+            enter_hook = object()
+            exit_hook = object()
+            fake_triton.knobs.runtime.launch_enter_hook = enter_hook
+            fake_triton.knobs.runtime.launch_exit_hook = exit_hook
+            self.assertIs(wrapped("runtime_a", "constexpr", "runtime_b"), result)
+
+        self.assertFalse(dispatch_runner.calls)
+        compiled.launch_metadata.assert_called_once_with(  # type: ignore[union-attr]
+            (2, 3), 17, "runtime_a", "constexpr", "runtime_b"
+        )
+        compiled.run.assert_called_once_with(  # type: ignore[union-attr]
+            2,
+            3,
+            1,
+            17,
+            function,
+            packed_metadata,
+            launch_metadata,
+            enter_hook,
+            exit_hook,
+            "runtime_a",
+            "constexpr",
+            "runtime_b",
+        )
+
     def test_kernel_cache_membership_invalidates_prepared_launch(self) -> None:
         jit_fn = _FakeJITFunction()
         fake_triton = _fake_triton()
@@ -387,6 +496,27 @@ class TestPreparedTritonLauncherCuda(RefEagerTestDisabled, TestCase):
             )
         self.assertEqual(jit_run.call_count, 1)
         torch.testing.assert_close(out[:32], x[:32] * 2.5)
+
+    def test_specialized_scalar_uses_native_runner_abi(self) -> None:
+        import triton
+        import triton.language as tl
+
+        @triton.jit
+        def fill(out, stride, value, block: tl.constexpr):
+            offsets = tl.arange(0, block)
+            tl.store(out + offsets * stride, value)
+
+        out = torch.empty(64, device=DEVICE)
+        launcher.default_launcher(fill, (1,), out, 1, 17, 64, num_warps=4, num_stages=1)
+        with patch.object(
+            fill,
+            "run",
+            side_effect=AssertionError("prepared launch called JITFunction.run"),
+        ):
+            launcher.default_launcher(
+                fill, (1,), out, 1, 19, 64, num_warps=4, num_stages=1
+            )
+        torch.testing.assert_close(out, torch.full_like(out, 19))
 
     def test_warmup_never_prepares_or_launches(self) -> None:
         import triton


### PR DESCRIPTION
Project cached dispatcher calls to Triton runtime arguments while preserving the full JIT argument list for non-dispatcher runners. Route dispatcher launches through the compiled Python path when live launch hooks are installed.
