### PR TITLE
[autotuner] Add bounded multi-config multi-shape tuning

### DIFF
--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -21,10 +21,12 @@ from torch._inductor.codecache import torch_key
 from .. import exc
 from .._utils import counters
 from .base_search import BaseAutotuner
+from .benchmark_provider import _format_selected_multi_shape_configs
 from .benchmark_provider import _format_selected_multi_shape_measurement
 from .benchmark_provider import _has_valid_multi_shape_measurement
 from .benchmark_provider import _materialize_multi_shape_config
 from .benchmark_provider import _MultiShapeAutotuneArgs
+from .benchmark_provider import _select_multi_shape_configs
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -345,7 +347,18 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
                 config,
             ):
                 raise exc.NoConfigFound
-            summary = _format_selected_multi_shape_measurement(self.args, config)
+            if self.args.num_config_limit > 1:
+                selection = _select_multi_shape_configs(self.args)
+                if not selection.configs:
+                    raise exc.NoConfigFound
+                self.args.selected_configs = selection.configs
+                self.args.selected_config_indices = selection.case_config_indices
+                config = selection.configs[0]
+                summary = _format_selected_multi_shape_configs(self.args, selection)
+            else:
+                self.args.selected_configs = (config,)
+                self.args.selected_config_indices = (0,) * len(self.args.cases)
+                summary = _format_selected_multi_shape_measurement(self.args, config)
             if summary is not None:
                 self._log_selected_multi_shape(summary)
 

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -5,6 +5,7 @@ import copy
 import dataclasses
 import datetime
 import functools
+from itertools import combinations
 from itertools import count
 from itertools import starmap
 import math
@@ -92,10 +93,14 @@ class _MultiShapeAutotuneArgs:
     relative_to: MultiShapeReference
     cache_tag: str | None
     workload_key: tuple[object, ...]
+    num_config_limit: int = 1
     reference_latencies: tuple[float, ...] | None = None
     measurements: dict[str, tuple[tuple[float, ...], float, tuple[str, ...]]] = (
         dataclasses.field(default_factory=dict)
     )
+    measured_configs: dict[str, Config] = dataclasses.field(default_factory=dict)
+    selected_configs: tuple[Config, ...] = ()
+    selected_config_indices: tuple[int, ...] = ()
     defer_selected_log: bool = False
     search_started: bool = False
     found_valid_config: bool = False
@@ -105,6 +110,13 @@ class _MultiShapeAutotuneArgs:
 
     def __getitem__(self, index: int | slice) -> object:
         return self.cases[0][1][index]
+
+
+@dataclasses.dataclass(frozen=True)
+class _MultiShapeConfigSelection:
+    configs: tuple[Config, ...]
+    case_config_indices: tuple[int, ...]
+    objective: float
 
 
 def _aggregate_values(
@@ -136,6 +148,158 @@ def _aggregate_multi_shape_timings(
         for timing, reference in zip(timings, references, strict=True)
     ]
     return _aggregate_values(ratios, aggregation)
+
+
+def _evaluate_multi_shape_config_selection(
+    args: _MultiShapeAutotuneArgs,
+    config_keys: Sequence[str],
+) -> tuple[float, tuple[int, ...]]:
+    """Evaluate a portfolio, respecting cases that share one specialization."""
+    if not config_keys:
+        return inf, ()
+
+    groups: list[list[int]] = []
+    group_by_kernel_id: dict[int, int] = {}
+    for case_index, (bound_kernel, _) in enumerate(args.cases):
+        kernel_id = id(bound_kernel)
+        group_index = group_by_kernel_id.get(kernel_id)
+        if group_index is None:
+            group_index = len(groups)
+            group_by_kernel_id[kernel_id] = group_index
+            groups.append([])
+        groups[group_index].append(case_index)
+
+    selected_timings = [inf] * len(args.cases)
+    case_config_indices = [0] * len(args.cases)
+    for case_indices in groups:
+        references = (
+            [args.reference_latencies[index] for index in case_indices]
+            if args.reference_latencies is not None
+            else None
+        )
+
+        group_objectives = [
+            _aggregate_multi_shape_timings(
+                [
+                    args.measurements[config_key][0][case_index]
+                    for case_index in case_indices
+                ],
+                aggregation=args.aggregation,
+                references=references,
+            )
+            for config_key in config_keys
+        ]
+        best_config_index = min(
+            range(len(config_keys)),
+            key=group_objectives.__getitem__,
+        )
+        timings = args.measurements[config_keys[best_config_index]][0]
+        for case_index in case_indices:
+            selected_timings[case_index] = timings[case_index]
+            case_config_indices[case_index] = best_config_index
+
+    objective = _aggregate_multi_shape_timings(
+        selected_timings,
+        aggregation=args.aggregation,
+        references=args.reference_latencies,
+    )
+    return objective, tuple(case_config_indices)
+
+
+def _select_multi_shape_configs(
+    args: _MultiShapeAutotuneArgs,
+) -> _MultiShapeConfigSelection:
+    """Select a bounded portfolio from all valid measured configs."""
+    candidate_keys = [
+        key
+        for key, (_, objective, _) in args.measurements.items()
+        if math.isfinite(objective) and key in args.measured_configs
+    ]
+    if not candidate_keys:
+        return _MultiShapeConfigSelection((), (), inf)
+
+    target_size = min(args.num_config_limit, len(candidate_keys))
+    if math.comb(len(candidate_keys), target_size) <= 50_000:
+        selected_keys = []
+        selected_objective = inf
+        selected_indices: tuple[int, ...] = ()
+        for key_tuple in combinations(candidate_keys, target_size):
+            objective, indices = _evaluate_multi_shape_config_selection(args, key_tuple)
+            if objective < selected_objective:
+                selected_keys = list(key_tuple)
+                selected_objective = objective
+                selected_indices = indices
+    else:
+        # Large searches use forward selection followed by swap-based local
+        # improvement. Exact subset search grows combinatorially with the number
+        # of benchmarked candidates.
+        selected_keys = []
+        selected_objective = inf
+        selected_indices = ()
+        while len(selected_keys) < target_size:
+            best_key: str | None = None
+            best_objective = selected_objective
+            best_indices = selected_indices
+            for key in candidate_keys:
+                if key in selected_keys:
+                    continue
+                objective, indices = _evaluate_multi_shape_config_selection(
+                    args, [*selected_keys, key]
+                )
+                if best_key is None or objective < best_objective:
+                    best_key = key
+                    best_objective = objective
+                    best_indices = indices
+            if best_key is None or (
+                selected_keys and not best_objective < selected_objective
+            ):
+                break
+            selected_keys.append(best_key)
+            selected_objective = best_objective
+            selected_indices = best_indices
+
+        while selected_keys:
+            best_replacement: tuple[int, str] | None = None
+            best_objective = selected_objective
+            best_indices = selected_indices
+            for selected_index in range(len(selected_keys)):
+                for key in candidate_keys:
+                    if key in selected_keys:
+                        continue
+                    replaced = list(selected_keys)
+                    replaced[selected_index] = key
+                    objective, indices = _evaluate_multi_shape_config_selection(
+                        args, replaced
+                    )
+                    if objective < best_objective:
+                        best_replacement = selected_index, key
+                        best_objective = objective
+                        best_indices = indices
+            if best_replacement is None:
+                break
+            selected_keys[best_replacement[0]] = best_replacement[1]
+            selected_objective = best_objective
+            selected_indices = best_indices
+
+    # Do not retain configs that make no contribution to the selected objective.
+    removed_redundant = True
+    while removed_redundant and len(selected_keys) > 1:
+        removed_redundant = False
+        for index in range(len(selected_keys)):
+            reduced = selected_keys[:index] + selected_keys[index + 1 :]
+            objective, indices = _evaluate_multi_shape_config_selection(args, reduced)
+            if objective <= selected_objective:
+                selected_keys = reduced
+                selected_objective = objective
+                selected_indices = indices
+                removed_redundant = True
+                break
+
+    return _MultiShapeConfigSelection(
+        tuple(copy.deepcopy(args.measured_configs[key]) for key in selected_keys),
+        selected_indices,
+        selected_objective,
+    )
 
 
 def _format_multi_shape_measurement(
@@ -209,6 +373,61 @@ def _format_selected_multi_shape_measurement(
         aggregate,
         selected=True,
         statuses=statuses,
+    )
+
+
+def _format_selected_multi_shape_configs(
+    args: _MultiShapeAutotuneArgs,
+    selection: _MultiShapeConfigSelection,
+) -> str:
+    """Format a selected portfolio and the config assigned to each case."""
+    config_rows = [
+        f"[{index}] {config}" for index, config in enumerate(selection.configs)
+    ]
+    case_rows = []
+    for case_index, config_index in enumerate(selection.case_config_indices):
+        config = selection.configs[config_index]
+        timings, _, statuses = args.measurements[repr(config)]
+        timing = timings[case_index]
+        status = statuses[case_index]
+        row = (
+            f"arg_sets[{case_index}]: config=[{config_index}], "
+            f"latency={timing:.6f} ms, status={status}"
+        )
+        if args.reference_latencies is not None:
+            reference = args.reference_latencies[case_index]
+            row += (
+                f", {args.relative_to} reference={reference:.6f} ms, "
+                f"ratio={timing / reference:.6f}x"
+            )
+        case_rows.append(row)
+
+    if args.reference_latencies is None:
+        objective = (
+            f"{args.aggregation}(selected latencies)={selection.objective:.6f} ms"
+        )
+    else:
+        objective = (
+            f"{args.aggregation}(selected latency ratios vs {args.relative_to})="
+            f"{selection.objective:.6f}x"
+        )
+    best_single = min(
+        measurement[1]
+        for measurement in args.measurements.values()
+        if math.isfinite(measurement[1])
+    )
+    speedup = best_single / selection.objective
+    details = "\n  ".join(
+        [
+            *config_rows,
+            *case_rows,
+            f"objective: {objective}",
+            f"speedup vs best single-config objective: {speedup:.6f}x",
+        ]
+    )
+    return (
+        f"Selected multi-shape config portfolio "
+        f"({len(selection.configs)} configs):\n  {details}"
     )
 
 
@@ -1933,6 +2152,9 @@ class MultiShapeBenchmarkProvider(BenchmarkProvider):
                 and math.isfinite(result.perf)
                 and result.perf > 0
                 for result in row
+            )
+            self.args.measured_configs[materialized_keys[child_config_index]] = (
+                copy.deepcopy(executed_configs[child_config_index])
             )
             perf = (
                 _aggregate_multi_shape_timings(

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -217,9 +217,44 @@ class LocalAutotuneCache(AutotuneCacheBase):
         path = self._get_local_cache_path()
         try:
             data = json.loads(path.read_text())
-            return Config.from_json(data["config"])
+            return self._load_cached_data(data)
         except Exception:
             return None
+
+    def _load_cached_data(self, data: dict[str, object]) -> Config | None:
+        """Load the primary config and any multi-shape portfolio metadata."""
+        config = Config.from_json(data["config"])  # type: ignore[arg-type]
+        from .benchmark_provider import _MultiShapeAutotuneArgs
+
+        if (
+            isinstance(self.args, _MultiShapeAutotuneArgs)
+            and self.args.num_config_limit > 1
+        ):
+            raw_configs = data.get("multi_shape_configs")
+            raw_indices = data.get("multi_shape_config_indices")
+            if (
+                not isinstance(raw_configs, list)
+                or not all(isinstance(value, str) for value in raw_configs)
+                or not isinstance(raw_indices, list)
+                or not all(
+                    isinstance(value, int) and not isinstance(value, bool)
+                    for value in raw_indices
+                )
+            ):
+                return None
+            configs = tuple(Config.from_json(value) for value in raw_configs)
+            indices = tuple(raw_indices)
+            if (
+                not configs
+                or len(configs) > self.args.num_config_limit
+                or len(indices) != len(self.args.cases)
+                or any(index < 0 or index >= len(configs) for index in indices)
+            ):
+                return None
+            self.args.selected_configs = configs
+            self.args.selected_config_indices = indices
+            config = configs[0]
+        return config
 
     def put(self, config: Config) -> None:
         path = self._get_local_cache_path()
@@ -236,6 +271,16 @@ class LocalAutotuneCache(AutotuneCacheBase):
             "config": config.to_json(),
             "key": key_dict,
         }
+        from .benchmark_provider import _MultiShapeAutotuneArgs
+
+        if (
+            isinstance(self.args, _MultiShapeAutotuneArgs)
+            and self.args.num_config_limit > 1
+        ):
+            data["multi_shape_configs"] = [
+                selected.to_json() for selected in self.args.selected_configs
+            ]
+            data["multi_shape_config_indices"] = list(self.args.selected_config_indices)
 
         config_gen = self.kernel.config_spec.create_config_generation(
             advanced_controls_files=self.autotuner.settings.autotune_search_acf or None

--- a/helion/autotuner/remote_cache.py
+++ b/helion/autotuner/remote_cache.py
@@ -7,7 +7,6 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-from ..runtime.config import Config
 from .local_cache import LocalAutotuneCache
 from .local_cache import StrictLocalAutotuneCache
 
@@ -15,6 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Callable
 
+    from ..runtime.config import Config
     from .base_search import BaseSearch
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -106,10 +106,14 @@ class RemoteAutotuneCache(LocalAutotuneCache):
         cache_hash = self.key.stable_hash()
         data = _remote_get(self._backend, cache_hash)
         if data is not None:
-            config = Config.from_json(json.loads(data)["config"])
-            super().put(config)
-            log.debug("remote cache hit: %s", cache_hash)
-            return config
+            try:
+                config = self._load_cached_data(json.loads(data))
+            except Exception:
+                config = None
+            if config is not None:
+                super().put(config)
+                log.debug("remote cache hit: %s", cache_hash)
+                return config
         return super().get()
 
     def put(self, config: Config) -> None:
@@ -143,10 +147,14 @@ class StrictRemoteAutotuneCache(StrictLocalAutotuneCache):
         cache_hash = self.key.stable_hash()
         data = _remote_get(self._backend, cache_hash)
         if data is not None:
-            config = Config.from_json(json.loads(data)["config"])
-            super().put(config)
-            log.debug("remote cache hit: %s", cache_hash)
-            return config
+            try:
+                config = self._load_cached_data(json.loads(data))
+            except Exception:
+                config = None
+            if config is not None:
+                super().put(config)
+                log.debug("remote cache hit: %s", cache_hash)
+                return config
         return super().get()
 
     def put(self, config: Config) -> None:

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -1004,15 +1004,18 @@ class Kernel(Generic[_R]):
         aggregation: Literal["geomean", "max"] = "geomean",
         relative_to: Literal["default", "baseline"] | None = None,
         cache_tag: str | None = None,
+        num_config_limit: int = 1,
         force: bool = True,
         **options: object,
-    ) -> Config:
-        """Find one config using an objective measured across several inputs.
+    ) -> list[Config]:
+        """Find a bounded config portfolio across several representative inputs.
 
         The first argument set anchors config generation. Each candidate is measured
-        on every set, then reduced with a geometric mean or maximum. ``relative_to``
-        optionally optimizes per-shape latency relative to each shape's default config
-        or custom baseline. Only the supplied bound specializations are configured.
+        on every set. With ``num_config_limit``, the measured candidates are selected
+        to minimize the geometric mean or maximum of the best available
+        per-specialization latency. ``relative_to`` optionally optimizes latency
+        relative to each shape's default config or custom baseline. Only the supplied
+        bound specializations are configured.
 
         Every argument set must bind normally to the same exact, current accelerator
         device. Distributed processes are not supported. A non-empty ``cache_tag`` is
@@ -1025,11 +1028,13 @@ class Kernel(Generic[_R]):
             relative_to: Optional ``"default"`` or ``"baseline"`` normalization.
             cache_tag: User-managed cache discriminator for dynamic shapes, runtime
                 numeric arguments, or callbacks.
+            num_config_limit: Maximum portfolio size. Defaults to one.
             force: If true, ignore pinned configs and cache reads during the search.
             options: Additional options forwarded to the registered autotuner.
 
         Returns:
-            The config selected for all supplied specializations.
+            The selected config portfolio, containing up to ``num_config_limit``
+            configs.
         """
         from ..autotuner.benchmark_provider import LocalBenchmarkProvider
         from ..autotuner.benchmark_provider import _has_valid_multi_shape_measurement
@@ -1048,6 +1053,14 @@ class Kernel(Generic[_R]):
         if cache_tag is not None and (not isinstance(cache_tag, str) or not cache_tag):
             raise exc.InvalidAPIUsage(
                 "autotune_multi cache_tag must be a non-empty string"
+            )
+        if (
+            not isinstance(num_config_limit, int)
+            or isinstance(num_config_limit, bool)
+            or num_config_limit <= 0
+        ):
+            raise exc.InvalidAPIUsage(
+                "autotune_multi num_config_limit must be a positive integer"
             )
         if (
             not isinstance(arg_sets, Sequence)
@@ -1211,15 +1224,17 @@ class Kernel(Generic[_R]):
             relative_to=relative_to,
             cache_tag=cache_tag,
             workload_key=(
-                "multi_shape:v1",
+                "multi_shape:v2",
                 aggregation,
                 relative_to,
                 cache_tag,
+                *((num_config_limit,) if num_config_limit > 1 else ()),
                 tuple(
                     (case_key.specialization_key, case_key.extra_results)
                     for case_key in case_keys
                 ),
             ),
+            num_config_limit=num_config_limit,
             reference_latencies=None,
         )
 
@@ -1241,15 +1256,48 @@ class Kernel(Generic[_R]):
         ):
             raise exc.NoConfigFound
         winner = _materialize_multi_shape_config(anchor.config_spec, config)
+        selected_configs = multi_args.selected_configs or (winner,)
+        portfolio: list[Config] = []
+        for selected in selected_configs:
+            materialized = _materialize_multi_shape_config(anchor.config_spec, selected)
+            if materialized not in portfolio:
+                portfolio.append(materialized)
+        if not portfolio or len(portfolio) > num_config_limit:
+            raise exc.NoConfigFound
+        if multi_args.search_started and any(
+            not _has_valid_multi_shape_measurement(
+                multi_args,
+                anchor.config_spec,
+                selected,
+            )
+            for selected in portfolio
+        ):
+            raise exc.NoConfigFound
+
+        case_config_indices = multi_args.selected_config_indices
+        if len(case_config_indices) != len(cases):
+            case_config_indices = (0,) * len(cases)
+        assigned_by_kernel_id: dict[int, Config] = {}
+        for case_index, (bound_kernel, _) in enumerate(cases):
+            config_index = case_config_indices[case_index]
+            if config_index < 0 or config_index >= len(portfolio):
+                raise exc.NoConfigFound
+            assigned = portfolio[config_index]
+            previous = assigned_by_kernel_id.setdefault(id(bound_kernel), assigned)
+            if previous != assigned:
+                raise exc.NoConfigFound
         if ephemeral is not None:
             for bound_kernel in unique_bound_kernels:
-                bound_kernel.env.backend.finalize_ephemeral_cache(bound_kernel, winner)
+                for selected in portfolio:
+                    bound_kernel.env.backend.finalize_ephemeral_cache(
+                        bound_kernel, selected
+                    )
 
         for bound_kernel in unique_bound_kernels:
-            bound_kernel.compile_config(winner)
+            bound_kernel.compile_config(assigned_by_kernel_id[id(bound_kernel)])
         for bound_kernel in unique_bound_kernels:
-            bound_kernel.set_config(winner)
-        return winner
+            bound_kernel.set_config(assigned_by_kernel_id[id(bound_kernel)])
+        return portfolio
 
     def __call__(self, *args: object, **kwargs: object) -> _R:
         """

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -32,6 +32,7 @@ from helion.autotuner.benchmark_provider import _aggregate_multi_shape_timings
 from helion.autotuner.benchmark_provider import _format_selected_multi_shape_measurement
 from helion.autotuner.benchmark_provider import _materialize_multi_shape_config
 from helion.autotuner.benchmark_provider import _MultiShapeAutotuneArgs
+from helion.autotuner.benchmark_provider import _select_multi_shape_configs
 from helion.autotuner.config_spec import BlockSizeSpec
 from helion.autotuner.config_spec import ConfigSpec
 from helion.autotuner.config_spec import LoopOrderSpec
@@ -97,6 +98,80 @@ class TestMultiShapeTimingAggregation(unittest.TestCase):
                     ),
                     math.inf,
                 )
+
+
+class TestMultiShapeConfigSelection(unittest.TestCase):
+    @staticmethod
+    def _add_measurement(
+        carrier: _MultiShapeAutotuneArgs,
+        config: Config,
+        timings: tuple[float, ...],
+    ) -> None:
+        key = repr(config)
+        carrier.measured_configs[key] = config
+        carrier.measurements[key] = (
+            timings,
+            _aggregate_multi_shape_timings(
+                timings,
+                aggregation=carrier.aggregation,
+                references=carrier.reference_latencies,
+            ),
+            ("ok",) * len(timings),
+        )
+
+    def test_selects_optimal_bounded_portfolio(self) -> None:
+        carrier = _make_carrier(
+            tuple((object(), ()) for _ in range(3)),
+        )
+        carrier.num_config_limit = 3
+        configs = [Config(num_warps=value) for value in (1, 2, 4, 8)]
+        for config, timings in zip(
+            configs,
+            (
+                (1.0, 10.0, 10.0),
+                (10.0, 1.0, 10.0),
+                (10.0, 10.0, 1.0),
+                (4.0, 4.0, 4.0),
+            ),
+            strict=True,
+        ):
+            self._add_measurement(carrier, config, timings)
+
+        selection = _select_multi_shape_configs(carrier)
+
+        self.assertEqual(selection.configs, tuple(configs[:3]))
+        self.assertEqual(selection.case_config_indices, (0, 1, 2))
+        self.assertAlmostEqual(selection.objective, 1.0)
+
+    def test_returns_fewer_configs_when_extras_do_not_improve(self) -> None:
+        carrier = _make_carrier(((object(), ()), (object(), ())))
+        carrier.num_config_limit = 3
+        configs = [Config(num_warps=value) for value in (1, 2, 4)]
+        for config, timings in zip(
+            configs,
+            ((1.0, 1.0), (2.0, 2.0), (3.0, 3.0)),
+            strict=True,
+        ):
+            self._add_measurement(carrier, config, timings)
+
+        selection = _select_multi_shape_configs(carrier)
+
+        self.assertEqual(selection.configs, (configs[0],))
+        self.assertEqual(selection.case_config_indices, (0, 0))
+
+    def test_shared_specialization_uses_one_config(self) -> None:
+        shared_bound = object()
+        carrier = _make_carrier(((shared_bound, ()), (shared_bound, ())))
+        carrier.num_config_limit = 2
+        first = Config(num_warps=2)
+        second = Config(num_warps=4)
+        self._add_measurement(carrier, first, (1.0, 10.0))
+        self._add_measurement(carrier, second, (10.0, 1.0))
+
+        selection = _select_multi_shape_configs(carrier)
+
+        self.assertEqual(len(selection.configs), 1)
+        self.assertEqual(selection.case_config_indices, (0, 0))
 
 
 def _make_config_spec() -> ConfigSpec:
@@ -294,7 +369,7 @@ class TestMultiShapeRuntime(unittest.TestCase):
         settings = _runtime_settings()
         bound = _RuntimeBoundKernel(_RuntimeBackend(), settings)
         workload_key = (
-            "multi_shape:v1",
+            "multi_shape:v2",
             "max",
             "default",
             "workload-v2",
@@ -323,6 +398,9 @@ class TestMultiShapeRuntime(unittest.TestCase):
             ({"relative_to": "fastest"}, "relative_to"),
             ({"cache_tag": ""}, "non-empty string"),
             ({"cache_tag": 1}, "non-empty string"),
+            ({"num_config_limit": 0}, "positive integer"),
+            ({"num_config_limit": True}, "positive integer"),
+            ({"num_config_limit": 1.5}, "positive integer"),
         )
         for kwargs, message in invalid_options:
             kernel = object.__new__(Kernel)
@@ -421,9 +499,11 @@ class TestMultiShapeRuntime(unittest.TestCase):
         )
         kernel._get_bound_kernel_cache_key = Mock(side_effect=case_keys)
 
-        winner = kernel.autotune_multi(
+        portfolio = kernel.autotune_multi(
             [("case-a", 8), ("case-b", 16)], cache_tag="numeric-shapes-v1"
         )
+        self.assertEqual(len(portfolio), 1)
+        winner = portfolio[0]
 
         self.assertEqual(winner.config, {"block_sizes": [64], "num_warps": 4})
         self.assertEqual(len(backend.autotune_calls), 1)
@@ -432,7 +512,7 @@ class TestMultiShapeRuntime(unittest.TestCase):
         self.assertEqual(
             carrier.workload_key,
             (
-                "multi_shape:v1",
+                "multi_shape:v2",
                 "geomean",
                 None,
                 "numeric-shapes-v1",
@@ -443,6 +523,78 @@ class TestMultiShapeRuntime(unittest.TestCase):
         for bound in bounds:
             bound.compile_config.assert_called_once_with(winner)
             bound.set_config.assert_called_once_with(winner)
+
+    @patch("helion.runtime.kernel.target_device_capability", return_value=(9, 0))
+    @patch("helion.runtime.kernel._current_device_index", return_value=0)
+    @patch("helion.runtime.kernel.dist.is_initialized", return_value=False)
+    def test_returns_portfolio_and_installs_per_shape_configs(
+        self,
+        distributed: object,
+        current: object,
+        capability: object,
+    ) -> None:
+        backend = _RuntimeBackend()
+        settings = _runtime_settings()
+        bounds = [
+            _RuntimeBoundKernel(backend, settings),
+            _RuntimeBoundKernel(backend, settings),
+        ]
+        case_keys = [
+            SimpleNamespace(specialization_key=("shape", 8), extra_results=()),
+            SimpleNamespace(specialization_key=("shape", 16), extra_results=()),
+        ]
+        kernel = object.__new__(Kernel)
+        kernel.settings = settings  # pyrefly: ignore[bad-assignment]
+        kernel._annotations = [object, object]
+        kernel.normalize_args = Mock(side_effect=lambda *args: tuple(args))
+        kernel.bind = Mock(side_effect=bounds)
+        kernel._base_specialization_key = Mock(
+            side_effect=[("shape", 8), ("shape", 16)]
+        )
+        kernel._get_bound_kernel_cache_key = Mock(side_effect=case_keys)
+        selected = (Config(block_sizes=[64]), Config(block_sizes=[128]))
+
+        def autotune(
+            bound_kernel: object,
+            args: _MultiShapeAutotuneArgs,
+            *,
+            force: bool,
+            **options: object,
+        ) -> Config:
+            args.selected_configs = selected
+            args.selected_config_indices = (0, 1)
+            return selected[0]
+
+        backend.autotune = Mock(side_effect=autotune)  # type: ignore[method-assign]
+
+        result = kernel.autotune_multi(
+            [("case-a", 8), ("case-b", 16)],
+            cache_tag="numeric-shapes-v1",
+            num_config_limit=2,
+        )
+
+        self.assertIsInstance(result, list)
+        assert isinstance(result, list)
+        self.assertEqual([config.block_sizes for config in result], [[64], [128]])
+        carrier = backend.autotune.call_args.args[1]
+        self.assertEqual(
+            carrier.workload_key,
+            (
+                "multi_shape:v2",
+                "geomean",
+                None,
+                "numeric-shapes-v1",
+                2,
+                ((("shape", 8), ()), (("shape", 16), ())),
+            ),
+        )
+        self.assertEqual(
+            backend.finalized, [bounds[0], bounds[0], bounds[1], bounds[1]]
+        )
+        bounds[0].compile_config.assert_called_once_with(result[0])
+        bounds[0].set_config.assert_called_once_with(result[0])
+        bounds[1].compile_config.assert_called_once_with(result[1])
+        bounds[1].set_config.assert_called_once_with(result[1])
 
 
 class _Log:
@@ -1177,6 +1329,53 @@ class TestMultiShapeCacheBoundary(unittest.TestCase):
         self.assertNotIn("block_size", result.config)
         cache.put.assert_called_once_with(result)
 
+    @patch("helion.autotuner.base_cache.should_skip_cache", return_value=False)
+    def test_selects_portfolio_before_cache_put(self, skip_cache: object) -> None:
+        carrier = _make_carrier(((object(), ()), (object(), ())))
+        carrier.num_config_limit = 2
+        carrier.search_started = True
+        carrier.found_valid_config = True
+        cache = self._make_cache(carrier)
+        first = _materialize_multi_shape_config(
+            cache.autotuner.config_spec, Config(block_size=64)
+        )
+        second = _materialize_multi_shape_config(
+            cache.autotuner.config_spec, Config(block_size=128)
+        )
+        for config, timings in ((first, (1.0, 10.0)), (second, (10.0, 1.0))):
+            carrier.measured_configs[repr(config)] = config
+            carrier.measurements[repr(config)] = (
+                timings,
+                math.sqrt(10.0),
+                ("ok", "ok"),
+            )
+
+        result = cache.autotune(skip_cache=True)
+
+        self.assertEqual(result, first)
+        self.assertEqual(carrier.selected_configs, (first, second))
+        self.assertEqual(carrier.selected_config_indices, (0, 1))
+        cache.put.assert_called_once_with(first)
+
+    def test_cache_payload_restores_portfolio_and_assignments(self) -> None:
+        carrier = _make_carrier(((object(), ()), (object(), ())))
+        carrier.num_config_limit = 2
+        cache = object.__new__(LocalAutotuneCache)
+        cache.args = carrier  # pyrefly: ignore[bad-assignment]
+        configs = (Config(num_warps=2), Config(num_warps=4))
+
+        result = cache._load_cached_data(
+            {
+                "config": configs[0].to_json(),
+                "multi_shape_configs": [config.to_json() for config in configs],
+                "multi_shape_config_indices": [1, 0],
+            }
+        )
+
+        self.assertEqual(result, configs[0])
+        self.assertEqual(carrier.selected_configs, configs)
+        self.assertEqual(carrier.selected_config_indices, (1, 0))
+
 
 class _TrialLog:
     def __call__(self, message: str, *args: object, **kwargs: object) -> None:
@@ -1363,14 +1562,32 @@ class TestMultiShapeAutotuneIntegration(unittest.TestCase):
     def test_finite_search_installs_one_config_for_two_shapes(self) -> None:
         add, arg_sets = self._make_add_case()
 
-        winner = add.autotune_multi(
+        portfolio = add.autotune_multi(
             arg_sets,
             aggregation="max",
             relative_to="default",
             force=False,
         )
 
+        self.assertEqual(len(portfolio), 1)
+        winner = portfolio[0]
         self.assertIn(winner.block_sizes[0], (64, 128))
+        for args in arg_sets:
+            torch.testing.assert_close(add(*args), args[0] + args[1])
+
+    def test_finite_search_installs_bounded_portfolio(self) -> None:
+        add, arg_sets = self._make_add_case()
+
+        portfolio = add.autotune_multi(
+            arg_sets,
+            aggregation="geomean",
+            relative_to="default",
+            num_config_limit=2,
+            force=False,
+        )
+
+        self.assertGreaterEqual(len(portfolio), 1)
+        self.assertLessEqual(len(portfolio), 2)
         for args in arg_sets:
             torch.testing.assert_close(add(*args), args[0] + args[1])
 


### PR DESCRIPTION
## Summary

Extends multi-shape autotuning to select a bounded portfolio of configurations instead of requiring one configuration to serve every shape.

```python
configs = kernel.autotune_multi(
    arg_sets,
    num_config_limit=3,
    aggregation="geomean",
)
```

`autotune_multi` always returns a `list[Config]`. `num_config_limit` defaults to 1, so callers that omit it receive a one-element portfolio. Larger limits return up to that many configs, and the selected config is installed for each supplied specialization.

## Selection algorithm

Each candidate is benchmarked across all supplied shapes to build a candidate-by-shape timing matrix. Portfolio quality is computed by taking the fastest selected config for each specialization and aggregating those latencies with the existing geometric-mean or maximum objective.

- Exhaustively searches portfolios when there are at most 50,000 combinations.
- Otherwise uses greedy forward selection followed by one-for-one config swaps until no swap improves the objective.
- Removes redundant configs, so the returned portfolio can contain fewer than the requested limit.
- Keeps shapes sharing the same bound specialization on the same config.
- Stores the portfolio and per-specialization assignments in both local and remote autotune caches.
- Uses the `multi_shape:v2` cache namespace for both one-config and multi-config portfolios.

## H100 benchmark

Measured on an NVIDIA H100 using the three kernels in `pretuned_kernels/`. Each run used 24 representative shapes, `autotune_effort="quick"`, seed 12345, `num_config_limit=3`, and the supplied single config as an autotune seed. Final measurements used `triton.testing.do_bench` with 10 warmups and 100 repetitions. Values are geometric-mean warm-cache latency across the shapes.

"Best of selected 3" independently chooses the fastest selected config for each shape. "Installed assignments" independently rebenchmarks the config assignment chosen from the timings collected during autotuning.

| Kernel | Supplied single | Best of selected 3 | Speedup | Installed assignments | Speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| PTGQ | 8.362 us | 6.822 us | **1.226x** | 7.017 us | **1.192x** |
| RMSNorm | 10.813 us | 10.663 us | **1.014x** | 10.814 us | 1.000x |
| SiLU | 12.958 us | 12.609 us | **1.028x** | 12.832 us | **1.010x** |

The gap between the best-of-three and installed-assignment columns reflects benchmark noise between portfolio search and the independent rebenchmark. PTGQ shows a clear benefit; RMSNorm and SiLU improvements are smaller and close to measurement noise.

### Selected configurations

| Kernel | Config | Block sizes | Loop order | L2 grouping | Warps | Stages |
| --- | --- | --- | --- | ---: | ---: | ---: |
| PTGQ | Supplied single | `[8]` | `[[2, 1, 0]]` | 8 | 4 | 2 |
| PTGQ | Multi 1 | `[8]` | `[[1, 2, 0]]` | 32 | 4 | 2 |
| PTGQ | Multi 2 | `[16]` | `[[1, 2, 0]]` | 8 | 4 | 2 |
| PTGQ | Multi 3 | `[8]` | `[[1, 0, 2]]` | 8 | 2 | 2 |
| RMSNorm | Supplied single / Multi 1 | `[2048, 16]` | `[[1, 0]]` | - | 8 | 1 |
| RMSNorm | Multi 2 | `[2048, 16]` | `[[0, 1]]` | - | 8 | 1 |
| RMSNorm | Multi 3 | `[1024, 16]` | `[[0, 1]]` | - | 4 | 1 |
| SiLU | Supplied single | `[8]` | `[[1, 0, 2]]` | 64 | 4 | 6 |
| SiLU | Multi 1 | `[4]` | `[[1, 2, 0]]` | 1 | 4 | 2 |
| SiLU | Multi 2 | `[16]` | `[[1, 0, 2]]` | 1 | 8 | 1 |
| SiLU | Multi 3 | `[16]` | `[[1, 2, 0]]` | 1 | 16 | 3 |

## Test plan

- `conda run -n pytorch-3.12 pytest test/test_multi_shape_autotune.py test/test_cache.py -x -q`
  - 82 passed, 1 skipped, 20 subtests passed
- Ruff formatting and checks on all changed files
- Pyrefly on the changed source files
- `git diff --check`
