### PR TITLE
[cute] Overlap SIMT-edge auxiliary loads with tcgen05 MMA

### DIFF
--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -226,9 +226,17 @@ TCGEN05_ACC_WAIT_PLACEMENTS = (
     TCGEN05_ACC_WAIT_PLACEMENT_SUBTILE_LOOP,
     TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP,
 )
-# Placement of per-subtile auxiliary-tensor loads relative to the accumulator
-# consumer wait. Post-wait is the conservative default; pre-wait is available
-# for full output tiles and is selected by the measured scale_mm configs.
+# Placement of independent per-subtile auxiliary-tensor loads (for example,
+# scales, bias, or residuals) relative to the accumulator pipeline's consumer
+# wait. Both TMA-store and full-tile SIMT epilogues honor this setting. The
+# pre-wait form issues the auxiliary loads while tcgen05 MMA may still be
+# producing the accumulator, hiding their latency; the TMEM-to-register copy
+# and all accumulator-dependent epilogue arithmetic remain after the wait.
+# Keeping auxiliary fragments live across the wait can increase register
+# pressure, so post-wait is the conservative default in most cases.
+# SIMT edge-only fallback loads are scheduled early
+# independently of this setting because that path has been validated as a
+# family.
 TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY = "tcgen05_aux_load_placement"
 TCGEN05_AUX_LOAD_PLACEMENT_PRE_ACC_WAIT = "pre_acc_wait"
 TCGEN05_AUX_LOAD_PLACEMENT_POST_ACC_WAIT = "post_acc_wait"

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2827,6 +2827,56 @@ def _codegen_cute_store_tcgen05_tile(
                     + "\n",
                 ]
             )
+        # Broadcast auxiliaries are partitioned against the same accumulator
+        # carrier, so their fragments share an index domain, coordinates, and
+        # validity predicate. Load all of them in one scalar edge loop instead
+        # of traversing that coordinate fragment once per auxiliary tensor.
+        if (
+            force_simt_edge_aux
+            and len(aux_step_records) >= 2
+            and all(rec.broadcast_axis is not None for rec in aux_step_records)
+        ):
+            for rec in aux_step_records:
+                lines.extend(
+                    [
+                        (
+                            f"{prelude_indent}{rec.ttr_aux_subtile} = "
+                            f"{rec.ttr_aux_grouped}[(None, None, None, "
+                            "cutlass.Int32(_tcgen05_subtile))]\n"
+                        ),
+                        (
+                            f"{prelude_indent}{rec.aux_rmem} = "
+                            f"cute.make_rmem_tensor({rec.ttr_aux_subtile}.shape, "
+                            f"{rec.aux_dtype})\n"
+                        ),
+                        f"{prelude_indent}{rec.aux_rmem}.fill(0)\n",
+                    ]
+                )
+            first_rec = aux_step_records[0]
+            lines.extend(
+                [
+                    _simt_edge_coord_subtile_source(prelude_indent),
+                    (
+                        f"{prelude_indent}for _edge_i in range(cute.size("
+                        f"{first_rec.ttr_aux_subtile}.shape)):\n"
+                    ),
+                    f"{prelude_indent}    _coord = {ttr_cc_subtile}[_edge_i]\n",
+                    (
+                        f"{prelude_indent}    if cute.elem_less("
+                        f"_coord, ({m_size}, {n_size})):\n"
+                    ),
+                ]
+            )
+            for rec in aux_step_records:
+                lines.append(
+                    f"{prelude_indent}        {rec.aux_rmem}[_edge_i] = "
+                    f"{rec.ttr_aux_subtile}[_edge_i]\n"
+                )
+            for rec in aux_step_records:
+                lines.append(
+                    f"{prelude_indent}{rec.aux_loaded} = {rec.aux_rmem}.load()\n"
+                )
+            return "".join(lines)
         for aux_idx, rec in enumerate(aux_step_records):
             rowvec_stage = rowvec_aux_stage_records[aux_idx]
             if (
@@ -3489,6 +3539,26 @@ def _codegen_cute_store_tcgen05_tile(
         force_simt_edge_aux=simt_edge_only,
     )
     simt_acc_vec_prelude = simt_early_aux + simt_late_prelude
+    # SIMT auxiliary loads are independent of the accumulator. Edge-only
+    # stores always issue them early; full-tile SIMT stores do so when the
+    # placement config explicitly requests it. In either case their GMEM
+    # latency overlaps the MMA tail, and TMEM is copied only after the wait.
+    prefetch_simt_aux = (
+        (
+            simt_edge_only
+            or (
+                tcgen05_aux_load_placement == TCGEN05_AUX_LOAD_PLACEMENT_PRE_ACC_WAIT
+                and not tcgen05_value.use_tma_store_epilogue
+            )
+        )
+        and bool(aux_steps_in_chain)
+        and not is_secondary_store
+    )
+    simt_acc_wait = (
+        "        if _tcgen05_subtile == 0:\n"
+        f"            {tcgen05_lifecycle.acc_pipeline}.consumer_wait("
+        f"{tcgen05_lifecycle.acc_consumer_state})\n"
+    )
     if tcgen05_value.use_tma_store_epilogue:
         tma_static_store_setup, tma_tile_store_setup = store_common_setup(
             tcgen05_value.tma_store_tensor,
@@ -3701,14 +3771,14 @@ def _codegen_cute_store_tcgen05_tile(
             f"(None, None, None, None, None, {tcgen05_acc_stage_index_expr})]"
         ),
         *(
-            []
-            if is_secondary_store
-            else [
+            [
                 (
                     f"if {tcgen05_lifecycle.epi_active}:\n"
                     f"    {tcgen05_lifecycle.acc_pipeline}.consumer_wait({tcgen05_lifecycle.acc_consumer_state})"
                 )
             ]
+            if not (is_secondary_store or prefetch_simt_aux)
+            else []
         ),
         f"{ttr_tacc} = cute.group_modes({ttr_tacc_stage}, 3, cute.rank({ttr_tacc_stage}))",
         f"{ttr_gc_grouped} = cute.group_modes({ttr_gc}, 3, cute.rank({ttr_gc}))",
@@ -3763,9 +3833,14 @@ def _codegen_cute_store_tcgen05_tile(
             f"    if {tcgen05_lifecycle.epi_active}:\n"
             f"        {ttr_tacc_mn} = {ttr_tacc}[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
             f"        {ttr_gc_subtile} = {ttr_gc_grouped}[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
-            f"        cute.copy({tiled_copy_t2r}, {ttr_tacc_mn}, {ttr_racc})\n"
-            f"{simt_acc_vec_prelude}"
-            f"        {acc_vec} = {simt_acc_vec_rhs}\n"
+            + (f"{simt_early_aux}{simt_acc_wait}" if prefetch_simt_aux else "")
+            + f"        cute.copy({tiled_copy_t2r}, {ttr_tacc_mn}, {ttr_racc})\n"
+            + (
+                f"{simt_late_prelude}"
+                if prefetch_simt_aux
+                else f"{simt_acc_vec_prelude}"
+            )
+            + f"        {acc_vec} = {simt_acc_vec_rhs}\n"
             f"        {ttr_rd}.store({acc_vec})\n"
             # The secondary fan-out store reuses the still-live accumulator and
             # must not release it; the primary store owns the release + advance.

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -111,7 +111,7 @@ def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
         if (m, k, n) == (2, 4096, 256)
         else "persistent_blocked"
     )
-    return {
+    config = {
         "block_sizes": block_sizes,
         "l2_groupings": [1],
         "indexing": ["tensor_descriptor"] * 5,
@@ -125,6 +125,9 @@ def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
         "tcgen05_l2_swizzle_size": 1,
         "tcgen05_persistence_model": "static_persistent",
     }
+    if m in (16, 32):
+        config["tcgen05_aux_load_placement"] = "pre_acc_wait"
+    return config
 
 
 _KEYS_scale_mm_cute_swap_ab = _SMALL_M_SWAP_KEYS

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -26,6 +26,7 @@ from helion._testing import HALF_DTYPE
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import patch_cute_mma_support
 from helion.exc import BackendUnsupported
 from helion.exc import CuteBackendUnavailable
 from helion.exc import InvalidConfig
@@ -598,6 +599,29 @@ def cute_matmul_mma_fp8_rowwise_colwise_scale(
         for tile_k in hl.tile(k):
             acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
         acc = acc * scale_m[tile_m, tile_n] * scale_n[tile_n]
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def cute_matmul_mma_fp8_three_broadcast_scales(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_m: torch.Tensor,
+    scale_n0: torch.Tensor,
+    scale_n1: torch.Tensor,
+) -> torch.Tensor:
+    """FP8 matmul with three separately chained broadcast auxiliaries."""
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        acc = acc * scale_m[tile_m, tile_n]
+        acc = acc * scale_n0[tile_n]
+        acc = acc * scale_n1[tile_n]
         out[tile_m, tile_n] = acc.to(torch.bfloat16)
     return out
 
@@ -6947,6 +6971,50 @@ class TestCuteBackend(TestCase):
         torch.testing.assert_close(out.float(), ref, atol=2.0, rtol=5e-2)
         self.assertFalse(out.float().isnan().any().item())
         self.assertIn("cute.nvgpu.tcgen05", code)
+
+    def test_matmul_mma_tcgen05_fuses_three_broadcast_edge_loads(self) -> None:
+        m, k, n = 64, 256, 8
+        x = torch.empty((m, k), device=DEVICE, dtype=torch.float8_e4m3fn)
+        y = torch.empty((k, n), device=DEVICE, dtype=torch.float8_e4m3fn)
+        scale_m = torch.empty((m, 1), device=DEVICE).expand(m, n)
+        scale_n0 = torch.empty(n, device=DEVICE)
+        scale_n1 = torch.empty(n, device=DEVICE)
+        args = (x, y, scale_m, scale_n0, scale_n1)
+        config = helion.Config(
+            block_sizes=[64, 16, 256],
+            indexing=["tensor_descriptor"] * len(args),
+            l2_groupings=[1],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=1,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=4,
+            tcgen05_acc_stages=1,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_l2_swizzle_size=1,
+            tcgen05_persistence_model="static_persistent",
+        )
+        with patch_cute_mma_support():
+            code = cute_matmul_mma_fp8_three_broadcast_scales.bind(args).to_triton_code(
+                config
+            )
+
+        self.assertIn(
+            "for _edge_i in range(cute.size(tcgen05_tTR_gAux_subtile_0.shape))",
+            code,
+        )
+        for aux_idx in (1, 2):
+            self.assertNotIn(
+                f"for _edge_i in range(cute.size("
+                f"tcgen05_tTR_gAux_subtile_{aux_idx}.shape))",
+                code,
+            )
+        for aux_idx in range(3):
+            self.assertIn(
+                f"tcgen05_aux_rmem_{aux_idx}[_edge_i] = "
+                f"tcgen05_tTR_gAux_subtile_{aux_idx}[_edge_i]",
+                code,
+            )
 
     def _run_colvec_scale_row_dependent(
         self,

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -488,6 +488,31 @@ class TestPretunedCuteCodegen(TestCase):
                     (64, 64, 64),
                 )
 
+    def test_scale_mm_pretuned_swap_ab_aux_load_placement(self) -> None:
+        """Checked-in M=16/32 configs opt into pre-wait auxiliary loads."""
+
+        path = (
+            PRETUNED_KERNELS_DIR
+            / "scale_mm_cute"
+            / "_helion_aot_scale_mm_cute_cuda_sm100.py"
+        )
+        spec = importlib.util.spec_from_file_location("_scale_mm_cute_aot", path)
+        assert spec is not None and spec.loader is not None
+        heuristic = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(heuristic)
+
+        configs = dict(
+            zip(
+                heuristic._KEYS_scale_mm_cute_swap_ab,
+                heuristic._CONFIGS_scale_mm_cute_swap_ab,
+                strict=True,
+            )
+        )
+        selected = [config for (m, _k, _n), config in configs.items() if m in (16, 32)]
+        self.assertTrue(selected)
+        for config in selected:
+            self.assertEqual(config["tcgen05_aux_load_placement"], "pre_acc_wait")
+
     def test_scale_mm_explicit_epilogue_tile(self) -> None:
         module = _import_pretuned_kernel_module("scale_mm_cute")
         args = module._make_inputs(64, 128, 64)
@@ -534,8 +559,42 @@ class TestPretunedCuteCodegen(TestCase):
 
         module = _import_pretuned_kernel_module("scale_mm_cute")
         x, y, scale_a, scale_b = module._make_inputs(2, 4096, 256)
+        swap_args = (x, y, scale_a[:, 0], scale_b)
+        config = helion.Config(
+            block_sizes=[64, 16, 256],
+            l2_groupings=[1],
+            indexing=["tensor_descriptor"] * 5,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=1,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=9,
+            tcgen05_acc_stages=1,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_l2_swizzle_size=1,
+            tcgen05_persistence_model="static_persistent",
+        )
+        code = module.scale_mm_cute_swap_ab.bind(swap_args).to_triton_code(config)
         actual = module._scale_mm_cute(x, y, scale_a, scale_b)
         expected = module._scale_mm_torch(x, y, scale_a, scale_b)
+
+        aux0_loaded = code.index("tcgen05_aux_loaded_0 = tcgen05_aux_rmem_0.load()")
+        aux1_loaded = code.index("tcgen05_aux_loaded_1 = tcgen05_aux_rmem_1.load()")
+        acc_wait = code.index("if _tcgen05_subtile == 0:")
+        tmem_copy = code.index("cute.copy(tcgen05_tiled_copy_t2r")
+        self.assertLess(aux0_loaded, acc_wait)
+        self.assertLess(aux1_loaded, acc_wait)
+        self.assertLess(acc_wait, tmem_copy)
+        self.assertEqual(
+            code.count(
+                "for _edge_i in range(cute.size(tcgen05_tTR_gAux_subtile_0.shape))"
+            ),
+            1,
+        )
+        self.assertNotIn(
+            "for _edge_i in range(cute.size(tcgen05_tTR_gAux_subtile_1.shape))",
+            code,
+        )
         torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     def test_scale_mm_one_shot_uses_target_sm_count(self) -> None:
@@ -588,6 +647,52 @@ class TestPretunedCuteCodegen(TestCase):
         )
         self.assertNotIn("while tcgen05_work_tile_valid", one_shot_code)
         self.assertNotIn("while tcgen05_work_tile_valid", persistent_code)
+
+    def test_scale_mm_swap_ab_aux_load_placement(self) -> None:
+        """The placement config hoists full-tile SIMT scale loads."""
+
+        module = _import_pretuned_kernel_module("scale_mm_cute")
+        x, y, scale_a, scale_b = module._make_inputs(16, 4096, 256)
+        swap_args = (x, y, scale_a[:, 0], scale_b)
+        base = {
+            "block_sizes": [64, 16, 256],
+            "l2_groupings": [1],
+            "indexing": ["tensor_descriptor"] * 5,
+            "pid_type": "persistent_blocked",
+            "tcgen05_cluster_m": 1,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_ab_stages": 9,
+            "tcgen05_acc_stages": 1,
+            "tcgen05_c_stages": 2,
+            "tcgen05_num_epi_warps": 4,
+            "tcgen05_l2_swizzle_size": 1,
+            "tcgen05_persistence_model": "static_persistent",
+        }
+        with patch_cute_mma_support():
+            bound = module.scale_mm_cute_swap_ab.bind(swap_args)
+            codes = {
+                placement: bound.to_triton_code(
+                    helion.Config(
+                        **base,
+                        tcgen05_aux_load_placement=placement,
+                    )
+                )
+                for placement in ("pre_acc_wait", "post_acc_wait")
+            }
+
+        for placement, code in codes.items():
+            loop = code.index("for _tcgen05_subtile in cutlass.range")
+            aux_load = code.index("tcgen05_aux_loaded_0", loop)
+            tmem_copy = code.index("cute.copy(tcgen05_tiled_copy_t2r", loop)
+            if placement == "pre_acc_wait":
+                acc_wait = code.index("tcgen05_acc_pipeline.consumer_wait", loop)
+                self.assertLess(aux_load, acc_wait)
+                self.assertLess(acc_wait, tmem_copy)
+            else:
+                acc_wait = code.index("tcgen05_acc_pipeline.consumer_wait")
+                self.assertLess(acc_wait, loop)
+                self.assertLess(acc_wait, tmem_copy)
+                self.assertLess(tmem_copy, aux_load)
 
 
 @onlyBackends(["triton"])


### PR DESCRIPTION
Stacked PRs:
 * #3377
 * #3376
 * #3363
 * __->__#3362


--- --- ---

### [cute] Overlap SIMT-edge auxiliary loads with tcgen05 MMA


For partial output tiles using the SIMT store path, issue independent auxiliary GMEM loads before the accumulator consumer wait so their latency overlaps the tail of the MMA mainloop. Keep the TMEM-to-register copy after the wait.

Honor tcgen05_aux_load_placement=pre_acc_wait for full-tile SIMT tcgen05 epilogues as well. The opt-in placement applies the same overlap without changing the conservative post-wait default; edge-only SIMT fallback remains unconditionally early.

When an epilogue uses multiple broadcast auxiliary tensors, load all compatible fragments in one predicated scalar edge loop. They share the output-coordinate fragment and validity predicate, so traversing it once per auxiliary only adds edge overhead.

B200 performance with CUDA graphs and cold L2 for (M, K, N) = (M, 4096, 256):
- M=2: 5.961 -> 5.443 us (1.095x)
- M=8: 6.664 -> 5.528 us (1.205x)
- M=16: 5.371 -> 5.362 us (unchanged; full BN tile)
- M=32: 5.961 -> 5.980 us (unchanged; full BN tile)

Across seven weight families, opting full-tile M=16/32 kernels into pre-wait placement improves cold-L2 CUDA-graph latency by 1.080x geomean for M=16 and 1.065x for M=32.

Add generated-code coverage for fused pre-wait load order, sharing one edge loop across three broadcast auxiliaries, and both full-tile placement values. Retain exact FP8 runtime coverage; existing single-edge, double-edge, hybrid-TMA, and partial-TMA auxiliary epilogue runtime tests pass.
