### PR TITLE
[cute] Automatically select one-shot tcgen05 role scheduling

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -8157,13 +8157,19 @@ def _emit_mma_pipeline(
         tcgen05_persistence_model_for_plan = tcgen05_persistence_model_str
 
         # When the entire grid fits in one wave, every persistent CTA receives
-        # exactly one tile.
-        one_shot_m_slots = (m_size // bm) * (2 if tcgen05_is_two_cta else 1)
-        one_shot_n_slots = n_size // bn
+        # exactly one tile. Use ceiling counts so the same proof covers both
+        # static-full grids and the validated FP8 role-local N-edge path.
+        one_shot_m_slots = ((m_size + bm - 1) // bm) * (2 if tcgen05_is_two_cta else 1)
+        one_shot_n_slots = (n_size + bn - 1) // bn
         one_shot_work_ctas = one_shot_m_slots * one_shot_n_slots
         tcgen05_one_shot_role_scheduler = (
             tcgen05_pid_is_persistent
-            and tcgen05_static_full_tiles
+            and (
+                tcgen05_static_full_tiles
+                or (
+                    tcgen05_role_local_n_edge_tma and input_dtype == torch.float8_e4m3fn
+                )
+            )
             and (analysis is None or not analysis.has_leading_passthrough)
             and one_shot_work_ctas <= env.config_spec.num_sm
             # A partial cluster could access out of bounds.

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -93,12 +93,23 @@ _SMALL_M_SWAP_KEYS = [
         (4096, 256),
         (2048, 4096),
         (4096, 6144),
+        (2048, 12288),
+        (5120, 5120),
+        (6144, 2048),
     )
 ]
 
 
 def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
-    if m == 32:
+    if m == 32 and (k, n) in {
+        (2048, 12288),
+        (5120, 5120),
+        (6144, 2048),
+    }:
+        block_sizes = [64, 32, 256]
+        ab_stages = 7
+        acc_stages = 1
+    elif m == 32:
         block_sizes = [64, 32, 128]
         ab_stages = 12
         acc_stages = 1
@@ -130,11 +141,56 @@ def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
     return config
 
 
-_KEYS_scale_mm_cute_swap_ab = _SMALL_M_SWAP_KEYS
+_M64_SWAP_CONFIGS = {
+    (64, 4096, 24576): {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 2,
+        "tcgen05_persistence_model": "static_persistent",
+    },
+    (64, 5120, 51200): {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_blocked",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 4,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 8,
+        "tcgen05_persistence_model": "static_persistent",
+    },
+    (64, 25600, 5120): {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 1,
+        "tcgen05_persistence_model": "static_persistent",
+    },
+}
+
+_KEYS_scale_mm_cute_swap_ab = [*_SMALL_M_SWAP_KEYS, *_M64_SWAP_CONFIGS]
 
 _CONFIGS_scale_mm_cute_swap_ab = [
     _small_m_swap_config(*key) for key in _SMALL_M_SWAP_KEYS
-]
+] + list(_M64_SWAP_CONFIGS.values())
 
 
 def key_scale_mm_cute_swap_ab(*args) -> int:
@@ -198,8 +254,9 @@ _CONFIGS_scale_mm_cute = [
     # bn=64/bk=128/ab=12 for large-K or very-wide-N (deepest prefetch that fits SMEM).
     # (M, K, N) = (64, 2048, 4096) -- persistent bn=32 bk=256; 0.97x vs cutlass.
     {'block_sizes': [64, 32, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
-    # (M, K, N) = (64, 2048, 2048) -- non-persistent bn=16 bk=256 still wins here; 0.97x.
-    {'block_sizes': [64, 16, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor'], 'pid_type': 'flat', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 1, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'non_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
+    # (M, K, N) = (64, 2048, 2048) -- persistent bn=32 bk=256 with an
+    # explicit 64x32 epilogue; 1.061x faster than the prior flat bn=16 config.
+    {'block_sizes': [64, 32, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait', 'tcgen05_layout_strategy': 'explicit_epi_tile', 'tcgen05_layout_overrides_epi_tile_m': 64, 'tcgen05_layout_overrides_epi_tile_n': 32, 'tcgen05_layout_overrides_d_store_box_n': 32},
     # (M, K, N) = (64, 2048, 12288) -- persistent bn=32 bk=256; 0.92x vs cutlass (was 0.82).
     {'block_sizes': [64, 32, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
     # (M, K, N) = (64, 6144, 2048) -- persistent bn=32 bk=256; 1.00x vs cutlass (was 0.96).

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -13,7 +13,7 @@ Specialized kernels include:
 * :func:`scale_mm_cute` tiles over both M and N.
 * :func:`scale_mm_cute_skinny_m` keeps the full (small) M resident and tiles
   only over N for single-token decode.
-* :func:`scale_mm_cute_swap_ab` swaps M/N so M=2/8/16/32 can use efficient
+* :func:`scale_mm_cute_swap_ab` swaps M/N so small-M shapes can use efficient
   Blackwell tensor-core tiles.
 
 :func:`_scale_mm_cute` dispatches each pretuned shape to its specialized kernel.
@@ -31,7 +31,7 @@ import helion.language as hl
 # Only single-token decode uses the scalar skinny-M kernel. Wider small-M
 # shapes use the swapped tensor-core kernel below.
 _SKINNY_M_MAX = 1
-_SWAP_AB_SHAPES = {
+_SMALL_M_SWAP_SHAPES = {
     (m, k, n)
     for m in (2, 8, 16, 32)
     for k, n in (
@@ -39,8 +39,17 @@ _SWAP_AB_SHAPES = {
         (4096, 256),
         (2048, 4096),
         (4096, 6144),
+        (2048, 12288),
+        (5120, 5120),
+        (6144, 2048),
     )
 }
+_M64_SWAP_SHAPES = {
+    (64, 4096, 24576),
+    (64, 5120, 51200),
+    (64, 25600, 5120),
+}
+_SWAP_AB_SHAPES = _SMALL_M_SWAP_SHAPES | _M64_SWAP_SHAPES
 
 
 @helion.aot_kernel(backend="cute", static_shapes=True)
@@ -203,6 +212,8 @@ def use_cudagraph() -> bool:
 
 # Skinny-M (decode / small-batch) + small decoder-layer FP8 W8A8 serving shapes
 # that back the nightly B200 CuTe dashboard (benchmarks/run.py, PR #2788).
+# The M=2/8/16/32 additions include weight shapes from vLLM's H100 scaled_mm
+# config in vllm-project/vllm#46522.
 # The M=64 rows mirror the vLLM Qwen3 FP8 serving (K, N) weight shapes at a
 # small-batch token count.
 SHAPES = [  # (M, K, N)
@@ -223,6 +234,11 @@ SHAPES = [  # (M, K, N)
     (32, 4096, 256),
     (32, 2048, 4096),
     (32, 4096, 6144),
+    *sorted(
+        (m, k, n)
+        for m, k, n in _SMALL_M_SWAP_SHAPES
+        if (k, n) in {(2048, 12288), (5120, 5120), (6144, 2048)}
+    ),
     (4096, 4096, 4096),
     (1, 4096, 256),
     (512, 2048, 4096),

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -462,10 +462,11 @@ class TestPretunedCuteCodegen(TestCase):
         heuristic = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(heuristic)
 
-        expected_shapes = {
-            (64, 4096, 6144),
-            (64, 5120, 10240),
-            (64, 5120, 5120),
+        expected_layouts = {
+            (64, 2048, 2048): (64, 32, 32),
+            (64, 4096, 6144): (64, 64, 64),
+            (64, 5120, 10240): (64, 64, 64),
+            (64, 5120, 5120): (64, 64, 64),
         }
         explicit_configs = {
             tuple(shape): config
@@ -476,7 +477,7 @@ class TestPretunedCuteCodegen(TestCase):
             )
             if config.get("tcgen05_layout_strategy") == "explicit_epi_tile"
         }
-        self.assertEqual(set(explicit_configs), expected_shapes)
+        self.assertEqual(set(explicit_configs), set(expected_layouts))
         for shape, config in explicit_configs.items():
             with self.subTest(shape=shape):
                 self.assertEqual(
@@ -485,7 +486,7 @@ class TestPretunedCuteCodegen(TestCase):
                         config["tcgen05_layout_overrides_epi_tile_n"],
                         config["tcgen05_layout_overrides_d_store_box_n"],
                     ),
-                    (64, 64, 64),
+                    expected_layouts[shape],
                 )
 
     def test_scale_mm_pretuned_swap_ab_aux_load_placement(self) -> None:
@@ -512,6 +513,27 @@ class TestPretunedCuteCodegen(TestCase):
         self.assertTrue(selected)
         for config in selected:
             self.assertEqual(config["tcgen05_aux_load_placement"], "pre_acc_wait")
+
+    def test_scale_mm_pretuned_swapped_configs(self) -> None:
+        path = (
+            PRETUNED_KERNELS_DIR
+            / "scale_mm_cute"
+            / "_helion_aot_scale_mm_cute_cuda_sm100.py"
+        )
+        spec = importlib.util.spec_from_file_location("_scale_mm_cute_aot", path)
+        assert spec is not None and spec.loader is not None
+        heuristic = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(heuristic)
+        module = _import_pretuned_kernel_module("scale_mm_cute")
+
+        configs = dict(
+            zip(
+                heuristic._KEYS_scale_mm_cute_swap_ab,
+                heuristic._CONFIGS_scale_mm_cute_swap_ab,
+                strict=True,
+            )
+        )
+        self.assertEqual(set(configs), module._SWAP_AB_SHAPES)
 
     def test_scale_mm_explicit_epilogue_tile(self) -> None:
         module = _import_pretuned_kernel_module("scale_mm_cute")
@@ -574,8 +596,10 @@ class TestPretunedCuteCodegen(TestCase):
             tcgen05_l2_swizzle_size=1,
             tcgen05_persistence_model="static_persistent",
         )
-        code = module.scale_mm_cute_swap_ab.bind(swap_args).to_triton_code(config)
-        actual = module._scale_mm_cute(x, y, scale_a, scale_b)
+        bound = module.scale_mm_cute_swap_ab.bind(swap_args)
+        code = bound.to_triton_code(config)
+        bound.set_config(config)
+        actual = bound(*swap_args)
         expected = module._scale_mm_torch(x, y, scale_a, scale_b)
 
         aux0_loaded = code.index("tcgen05_aux_loaded_0 = tcgen05_aux_rmem_0.load()")
@@ -595,6 +619,8 @@ class TestPretunedCuteCodegen(TestCase):
             "for _edge_i in range(cute.size(tcgen05_tTR_gAux_subtile_1.shape))",
             code,
         )
+        self.assertNotIn("while tcgen05_role_local_", code)
+        self.assertNotIn(".advance_to_next_work()", code)
         torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     def test_scale_mm_one_shot_uses_target_sm_count(self) -> None:
@@ -647,6 +673,47 @@ class TestPretunedCuteCodegen(TestCase):
         )
         self.assertNotIn("while tcgen05_work_tile_valid", one_shot_code)
         self.assertNotIn("while tcgen05_work_tile_valid", persistent_code)
+
+    def test_scale_mm_n_edge_one_shot_is_automatic(self) -> None:
+        """A one-wave FP8 N-edge grid automatically uses one-shot scheduling."""
+
+        module = _import_pretuned_kernel_module("scale_mm_cute")
+        x, y, scale_a, scale_b = module._make_inputs(2, 4096, 256)
+        args = (x, y, scale_a[:, 0], scale_b)
+        config_values = {
+            "block_sizes": [64, 16, 256],
+            "l2_groupings": [1],
+            "indexing": ["tensor_descriptor"] * 5,
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 1,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_ab_stages": 9,
+            "tcgen05_acc_stages": 1,
+            "tcgen05_c_stages": 2,
+            "tcgen05_num_epi_warps": 4,
+            "tcgen05_l2_swizzle_size": 1,
+            "tcgen05_persistence_model": "static_persistent",
+        }
+
+        with patch_cute_mma_support():
+            bound = module.scale_mm_cute_swap_ab.bind(args)
+            original_search_enabled = bound.env.config_spec.cute_tcgen05_search_enabled
+            original_num_sm = bound.env.config_spec.num_sm
+            try:
+                bound.env.config_spec.cute_tcgen05_search_enabled = True
+                bound.env.config_spec.num_sm = 4
+                one_shot_code = bound.to_triton_code(helion.Config(**config_values))
+                bound.env.config_spec.num_sm = 3
+                persistent_code = bound.to_triton_code(helion.Config(**config_values))
+            finally:
+                bound.env.config_spec.cute_tcgen05_search_enabled = (
+                    original_search_enabled
+                )
+                bound.env.config_spec.num_sm = original_num_sm
+
+        role_loop = "while tcgen05_role_local_0_work_tile.is_valid_tile"
+        self.assertNotIn(role_loop, one_shot_code)
+        self.assertIn(role_loop, persistent_code)
 
     def test_scale_mm_swap_ab_aux_load_placement(self) -> None:
         """The placement config hoists full-tile SIMT scale loads."""


### PR DESCRIPTION
Stacked PRs:
 * #3377
 * #3376
 * __->__#3363


--- --- ---

### [cute] Automatically select one-shot tcgen05 role scheduling


Extend automatic one-shot role-scheduler selection from static-full grids to the validated FP8 role-local N-edge path. Use ceiling tile counts so partial N tiles contribute to the grid, and select the loop-free schedule whenever every resident CTA receives at most one work tile.

Require the complete static proof: the compile target SM count must cover the grid, cluster dimensions must divide the CTA slots, the kernel must use the role-local persistent body without scheduler warps or a grouped plan, and L2 scheduler swizzling must remain identity. Static-full grids retain their existing automatic behavior.

Restore twelve additional small-M serving shapes and port only the stack86 configs that remain valid and faster on the current compiler. Eligible swapped M=2/8 shapes now select one-shot scheduling automatically when their grid fits in one 148-SM B200 wave, while M=16/32 shapes inherit the parent commit pre-wait SIMT auxiliary-load placement. Add three independently profitable swapped M=64 configs and retune the direct 64x2048x2048 case; omit configs requiring c_stages=3, cluster_m=4, scheduler cluster caps, or the stack86 M=512 output-store lowering.

B200 cold-L2 CUDA-graph results:
- automatic one-shot M=2/8: 1.031x geomean over persistent scheduling across 12 eligible shapes
- pre-wait M=16: 1.080x geomean across 7 shapes
- pre-wait M=32: 1.065x geomean across 7 shapes
- M=64 config-only gains: 1.061x (2048x2048), 1.033x (4096x24576), 1.033x (5120x51200), and 1.072x (25600x5120)

The complete sweep is faster than the best torch/CUTLASS baseline on 38/45 shapes, with 1.031x geomean speedup.

Add codegen coverage for automatic versus persistent selection at the target-SM boundary for static-full and FP8 N-edge grids, plus the checked-in serving config assignments.
