### PR TITLE
[cute] Retune scale_mm_cute serving configs

### DIFF
--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -95,10 +95,27 @@ _SMALL_M_SWAP_KEYS = [
         (4096, 6144),
     )
 ]
+_SMALL_M_SWAP_KEYS.extend(
+    (m, k, n)
+    for m in (2, 8, 16, 32)
+    for k, n in (
+        (2048, 12288),
+        (5120, 5120),
+        (6144, 2048),
+    )
+)
 
 
 def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
-    if m == 32:
+    if m == 32 and (k, n) in {
+        (2048, 12288),
+        (5120, 5120),
+        (6144, 2048),
+    }:
+        block_sizes = [64, 32, 256]
+        ab_stages = 7
+        acc_stages = 1
+    elif m == 32:
         block_sizes = [64, 32, 128]
         ab_stages = 12
         acc_stages = 1
@@ -111,7 +128,7 @@ def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
         if (m, k, n) == (2, 4096, 256)
         else "persistent_blocked"
     )
-    return {
+    config = {
         "block_sizes": block_sizes,
         "l2_groupings": [1],
         "indexing": ["tensor_descriptor"] * 5,
@@ -125,13 +142,65 @@ def _small_m_swap_config(m: int, k: int, n: int) -> dict[str, Any]:
         "tcgen05_l2_swizzle_size": 1,
         "tcgen05_persistence_model": "static_persistent",
     }
+    # A one-shot role schedule is profitable when all swapped tiles fit in one
+    # wave on the 148-SM B200. The N=12288 cases need persistent reassignment.
+    if m in (2, 8) and math.ceil(n / block_sizes[0]) <= 148:
+        config["tcgen05_one_shot_role_scheduler"] = True
+    if m in (16, 32):
+        config["tcgen05_aux_load_placement"] = "pre_acc_wait"
+    return config
 
 
-_KEYS_scale_mm_cute_swap_ab = _SMALL_M_SWAP_KEYS
+_M64_SWAP_CONFIGS = {
+    (64, 4096, 24576): {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 2,
+        "tcgen05_persistence_model": "static_persistent",
+    },
+    (64, 5120, 51200): {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_blocked",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 4,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 8,
+        "tcgen05_persistence_model": "static_persistent",
+    },
+    (64, 25600, 5120): {
+        "block_sizes": [128, 64, 256],
+        "l2_groupings": [1],
+        "indexing": ["tensor_descriptor"] * 5,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": 2,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": 8,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        "tcgen05_l2_swizzle_size": 1,
+        "tcgen05_persistence_model": "static_persistent",
+    },
+}
+
+_KEYS_scale_mm_cute_swap_ab = [*_SMALL_M_SWAP_KEYS, *_M64_SWAP_CONFIGS]
 
 _CONFIGS_scale_mm_cute_swap_ab = [
     _small_m_swap_config(*key) for key in _SMALL_M_SWAP_KEYS
-]
+] + list(_M64_SWAP_CONFIGS.values())
 
 
 def key_scale_mm_cute_swap_ab(*args) -> int:
@@ -195,8 +264,9 @@ _CONFIGS_scale_mm_cute = [
     # bn=64/bk=128/ab=12 for large-K or very-wide-N (deepest prefetch that fits SMEM).
     # (M, K, N) = (64, 2048, 4096) -- persistent bn=32 bk=256; 0.97x vs cutlass.
     {'block_sizes': [64, 32, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
-    # (M, K, N) = (64, 2048, 2048) -- non-persistent bn=16 bk=256 still wins here; 0.97x.
-    {'block_sizes': [64, 16, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor'], 'pid_type': 'flat', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 1, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'non_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
+    # (M, K, N) = (64, 2048, 2048) -- persistent bn=32 bk=256 with an
+    # explicit 64x32 epilogue; 1.061x faster than the prior flat bn=16 config.
+    {'block_sizes': [64, 32, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait', 'tcgen05_layout_strategy': 'explicit_epi_tile', 'tcgen05_layout_overrides_epi_tile_m': 64, 'tcgen05_layout_overrides_epi_tile_n': 32, 'tcgen05_layout_overrides_d_store_box_n': 32},
     # (M, K, N) = (64, 2048, 12288) -- persistent bn=32 bk=256; 0.92x vs cutlass (was 0.82).
     {'block_sizes': [64, 32, 256], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
     # (M, K, N) = (64, 6144, 2048) -- persistent bn=32 bk=256; 1.00x vs cutlass (was 0.96).

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -13,7 +13,7 @@ Specialized kernels include:
 * :func:`scale_mm_cute` tiles over both M and N.
 * :func:`scale_mm_cute_skinny_m` keeps the full (small) M resident and tiles
   only over N for single-token decode.
-* :func:`scale_mm_cute_swap_ab` swaps M/N so M=2/8/16/32 can use efficient
+* :func:`scale_mm_cute_swap_ab` swaps M/N so small-M shapes can use efficient
   Blackwell tensor-core tiles.
 
 :func:`_scale_mm_cute` dispatches each pretuned shape to its specialized kernel.
@@ -31,7 +31,7 @@ import helion.language as hl
 # Only single-token decode uses the scalar skinny-M kernel. Wider small-M
 # shapes use the swapped tensor-core kernel below.
 _SKINNY_M_MAX = 1
-_SWAP_AB_SHAPES = {
+_SMALL_M_SWAP_SHAPES = {
     (m, k, n)
     for m in (2, 8, 16, 32)
     for k, n in (
@@ -39,8 +39,17 @@ _SWAP_AB_SHAPES = {
         (4096, 256),
         (2048, 4096),
         (4096, 6144),
+        (2048, 12288),
+        (5120, 5120),
+        (6144, 2048),
     )
 }
+_M64_SWAP_SHAPES = {
+    (64, 4096, 24576),
+    (64, 5120, 51200),
+    (64, 25600, 5120),
+}
+_SWAP_AB_SHAPES = _SMALL_M_SWAP_SHAPES | _M64_SWAP_SHAPES
 
 
 @helion.aot_kernel(backend="cute", static_shapes=True)
@@ -203,6 +212,8 @@ def use_cudagraph() -> bool:
 
 # Skinny-M (decode / small-batch) + small decoder-layer FP8 W8A8 serving shapes
 # that back the nightly B200 CuTe dashboard (benchmarks/run.py, PR #2788).
+# The M=2/8/16/32 additions include weight shapes from vLLM's H100 scaled_mm
+# config in vllm-project/vllm#46522.
 # The M=64 rows mirror the vLLM Qwen3 FP8 serving (K, N) weight shapes at a
 # small-batch token count.
 SHAPES = [  # (M, K, N)
@@ -223,6 +234,11 @@ SHAPES = [  # (M, K, N)
     (32, 4096, 256),
     (32, 2048, 4096),
     (32, 4096, 6144),
+    *sorted(
+        (m, k, n)
+        for m, k, n in _SMALL_M_SWAP_SHAPES
+        if (k, n) in {(2048, 12288), (5120, 5120), (6144, 2048)}
+    ),
     (4096, 4096, 4096),
     (1, 4096, 256),
     (512, 2048, 4096),

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -462,10 +462,11 @@ class TestPretunedCuteCodegen(TestCase):
         heuristic = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(heuristic)
 
-        expected_shapes = {
-            (64, 4096, 6144),
-            (64, 5120, 10240),
-            (64, 5120, 5120),
+        expected_layouts = {
+            (64, 2048, 2048): (64, 32, 32),
+            (64, 4096, 6144): (64, 64, 64),
+            (64, 5120, 10240): (64, 64, 64),
+            (64, 5120, 5120): (64, 64, 64),
         }
         explicit_configs = {
             tuple(shape): config
@@ -476,7 +477,7 @@ class TestPretunedCuteCodegen(TestCase):
             )
             if config.get("tcgen05_layout_strategy") == "explicit_epi_tile"
         }
-        self.assertEqual(set(explicit_configs), expected_shapes)
+        self.assertEqual(set(explicit_configs), set(expected_layouts))
         for shape, config in explicit_configs.items():
             with self.subTest(shape=shape):
                 self.assertEqual(
@@ -485,8 +486,38 @@ class TestPretunedCuteCodegen(TestCase):
                         config["tcgen05_layout_overrides_epi_tile_n"],
                         config["tcgen05_layout_overrides_d_store_box_n"],
                     ),
-                    (64, 64, 64),
+                    expected_layouts[shape],
                 )
+
+    def test_scale_mm_pretuned_swapped_configs(self) -> None:
+        path = (
+            PRETUNED_KERNELS_DIR
+            / "scale_mm_cute"
+            / "_helion_aot_scale_mm_cute_cuda_sm100.py"
+        )
+        spec = importlib.util.spec_from_file_location("_scale_mm_cute_aot", path)
+        assert spec is not None and spec.loader is not None
+        heuristic = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(heuristic)
+        module = _import_pretuned_kernel_module("scale_mm_cute")
+
+        configs = dict(
+            zip(
+                heuristic._KEYS_scale_mm_cute_swap_ab,
+                heuristic._CONFIGS_scale_mm_cute_swap_ab,
+                strict=True,
+            )
+        )
+        self.assertEqual(set(configs), module._SWAP_AB_SHAPES)
+        for (m, _k, n), config in configs.items():
+            if m in (2, 8):
+                one_shot_fits = math.ceil(n / config["block_sizes"][0]) <= 148
+                self.assertEqual(
+                    config.get("tcgen05_one_shot_role_scheduler", False),
+                    one_shot_fits,
+                )
+            elif m in (16, 32):
+                self.assertEqual(config["tcgen05_aux_load_placement"], "pre_acc_wait")
 
     def test_scale_mm_explicit_epilogue_tile(self) -> None:
         module = _import_pretuned_kernel_module("scale_mm_cute")


### PR DESCRIPTION
Stacked PRs:
 * #3378
 * #3377
 * #3376
 * __->__#3365
 * #3364
 * #3363
 * #3362
 * #3307


--- --- ---

### [cute] Retune scale_mm_cute serving configs


Use the new explicit scheduling controls in the checked-in B200 serving configs. Eligible swapped M=2/8 shapes force a one-shot role schedule when their full grid fits in one 148-SM wave, while M=16/32 shapes hoist SIMT scale loads ahead of the accumulator wait.

Restore the twelve additional small-M serving shapes and port only the stack86 configs that remain valid and faster on the current compiler. This adds three independently profitable swapped M=64 configs and retunes the direct 64x2048x2048 case; configs requiring c_stages=3, cluster_m=4, scheduler cluster caps, or the stack86 M=512 output-store lowering are intentionally omitted.

B200 cold-L2 CUDA-graph results on the current stack:

- forced one-shot M=2/8: 1.031x geomean over persistent scheduling across 12 eligible shapes

- pre-wait M=16: 1.080x geomean across 7 shapes

- pre-wait M=32: 1.065x geomean across 7 shapes

- M=64 config-only gains: 1.061x (2048x2048), 1.033x (4096x24576), 1.033x (5120x51200), and 1.072x (25600x5120)

The resulting complete sweep is faster than the best torch/CUTLASS baseline on 38/45 shapes, with 1.031x geomean speedup.
