### PR TITLE
[pallas] restrict the BlockSpec sublane promise to recorded aligned windows

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -361,6 +361,8 @@ class DeviceFunction:
         # the emit_pipeline codegen when the tile is a legal map axis; read by
         # the store codegen to stitch the boundary across neighbouring groups.
         self.carry_tiles: dict[int, CarryBoundaryTile] = {}
+        # Pallas: jagged tile block_id -> proven runtime-window alignment.
+        self.aligned_tiles: dict[int, int] = {}
         # CarryScratchKey(row block_id, output name) -> carry scratch var name.
         # One scratch per output buffer (a tile may feed several stores),
         # allocated at the store.

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -2187,6 +2187,7 @@ def _aligned_dim(
                 "(its dense bf16 output store cannot be proven sublane-aligned)."
             )
         aligned_dim[bid] = sublane
+        state.device_function.aligned_tiles[bid] = sublane
         if carry:
             begin, end = _get_loop_begin_and_end(state, i)
             state.device_function.carry_tiles[bid] = CarryBoundaryTile(
@@ -2196,6 +2197,29 @@ def _aligned_dim(
                 sublane=sublane,
             )
     return aligned_dim
+
+
+def _annotate_provable_sublane_alignment(
+    state: CodegenState,
+    block_id: int,
+    offset_expr: str,
+) -> str:
+    """Annotate ``offset_expr`` with its provable sublane alignment, if any.
+
+    ``pl.multiple_of`` is assume_multiple: Mosaic skips its tiled-row alignment
+    check instead of verifying the claim, so only a dim whose window really
+    rounded its begin down -- and whose block size steps by a multiple of that
+    sublane -- may be annotated.  Every other offset comes back unchanged.
+    """
+    sublane_alignment = state.device_function.aligned_tiles.get(block_id)
+    block = state.device_function.resolved_block_size(block_id)
+    if (
+        sublane_alignment is None
+        or not isinstance(block, int)
+        or block % sublane_alignment != 0
+    ):
+        return offset_expr
+    return f"pl.multiple_of({offset_expr}, {sublane_alignment})"
 
 
 def _codegen_emit_pipeline(state: CodegenState) -> object:
@@ -2390,19 +2414,15 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     block_shape_parts.append(str(int(shape[dim_idx])))
                 lambda_parts.append(pid_var)
             elif bid is not None and is_dynamic_bound_tile(state, bid):
-                # Jagged row tile from an inner pipeline.  pl.multiple_of is
-                # assume_multiple: it suppresses the tiled-row alignment check.
-                # Safe because the begin is rounded to the sublane in the dim's
-                # own loop, and a DIRECT f32 single-lane-tile row reads
-                # contiguously.  Always emitted, as sibling loops reference the
-                # same jagged dim.  Must precede the outer-non-grid branch.
+                # Jagged row tile from an inner pipeline.  Always emitted, as
+                # sibling loops reference the same jagged dim.  Must precede the
+                # outer-non-grid branch.
                 block_m = state.device_function.block_size_var(bid)
-                offset_v = state.codegen.offset_var(bid)
-                sublane = env.backend.sublane_tiling(fake.dtype)  # pyrefly: ignore[missing-attribute]
-                block_shape_parts.append(f"pl.BoundedSlice({block_m})")
-                lambda_parts.append(
-                    f"pl.ds(pl.multiple_of({offset_v}, {sublane}), {block_m})"
+                start_expr = _annotate_provable_sublane_alignment(
+                    state, bid, state.codegen.offset_var(bid)
                 )
+                block_shape_parts.append(f"pl.BoundedSlice({block_m})")
+                lambda_parts.append(f"pl.ds({start_expr}, {block_m})")
             elif bid is not None and state.codegen.active_device_loops.get(bid):
                 # Outer non-grid device loop -- the HBM ref is pre-sliced via
                 # ``.at[pl.ds(offset, bs)]`` (see _make_hbm_slice), so the

--- a/test/test_pallas_memory_access.py
+++ b/test/test_pallas_memory_access.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from typing import cast
 from unittest.mock import patch
 
 import torch
@@ -14,8 +17,13 @@ from helion._compiler.pallas.plan_tiling import TilePattern
 from helion._compiler.pallas.tensorcore_plan import OneHotGatherPlan
 from helion._compiler.pallas.tensorcore_plan import OneHotScatterPlan
 from helion._compiler.pallas.tensorcore_plan import select_tensorcore_plan
+from helion._compiler.pallas.tracing_ops import _annotate_provable_sublane_alignment
+from helion._compiler.tile_strategy import LoopDimInfo
 from helion.language import memory_ops
 from helion.language.atomic_ops import atomic_add
+
+if TYPE_CHECKING:
+    from helion._compiler.inductor_lowering import CodegenState
 
 
 def _placeholder(
@@ -76,6 +84,51 @@ def test_store_and_atomic_memory_accesses_record_values() -> None:
     assert atomic_access.kind is MemoryAccessKind.ATOMIC
     assert store_access.value_node is value_node
     assert atomic_access.value_node is value_node
+
+
+# This test intentionally exercises compiler internals, which tests normally
+# avoid. Verifying alignment promises passed to Mosaic is worth that coupling:
+# an incorrect promise can cause undefined behavior.
+def test_loop_offset_uses_only_proven_window_alignment() -> None:
+    block_id = 3
+    loop = SimpleNamespace(
+        block_id_to_info={
+            block_id: LoopDimInfo(begin_var_name="runtime_begin", begin_expr=None)
+        }
+    )
+
+    def make_state(aligned_tiles: dict[int, int], block_size: int) -> CodegenState:
+        return cast(
+            "CodegenState",
+            SimpleNamespace(
+                device_function=SimpleNamespace(
+                    aligned_tiles=aligned_tiles,
+                    resolved_block_size=lambda _block_id: block_size,
+                ),
+                codegen=SimpleNamespace(active_device_loops={block_id: [loop]}),
+            ),
+        )
+
+    aligned_state = make_state({block_id: 16}, block_size=32)
+    assert (
+        _annotate_provable_sublane_alignment(aligned_state, block_id, "offset")
+        == "pl.multiple_of(offset, 16)"
+    )
+
+    # A block size that is not a multiple of the window alignment proves
+    # nothing: offsets 16, 40, 64, ... are not all multiples of 16.
+    unstepped_state = make_state({block_id: 16}, block_size=24)
+    assert (
+        _annotate_provable_sublane_alignment(unstepped_state, block_id, "offset")
+        == "offset"
+    )
+
+    # Without an aligned window, leave the offset unannotated.
+    unaligned_state = make_state({}, block_size=32)
+    assert (
+        _annotate_provable_sublane_alignment(unaligned_state, block_id, "offset")
+        == "offset"
+    )
 
 
 def test_tensorcore_plan_owns_indirect_fallbacks() -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3373
 * #3375
 * #3570
 * #3569
 * #3372
 * #3371
 * #3568
 * #3370
 * #3369
 * #3368
 * __->__#3367
 * #3567


--- --- ---

### [pallas] restrict the BlockSpec sublane promise to recorded aligned windows


The emit_pipeline BlockSpec of a jagged tile currently promises Mosaic
pl.multiple_of(offset, sublane) whenever the tile has runtime bounds.
This is unproven and often incorrect, e.g. if the block size is not a
multiple of the sublane.

Fix it by being more thorough on what alignment hints we can prove.
To do this, record jagged windows that need sublane alignment in
DeviceFunction.aligned_tiles, and establish a single criterion to emit
pl.multiple_of(offset, sublane) for them: emit it only for a dim listed
there whose block size is a multiple of the sublane.

This has the following consequences:

- This drops the unsound hint for recorded windows whose block size is
  not a multiple of their sublane. Now those kernels fail to compile
  with Mosaic vs. silently compiling with UB.

- This also drops a harmless although incorrect "pl.multiple_of(offset,
  sublane)" hint for jagged tiles that Mosaic can slice at any row anyway.

- A dim advancing by an explicit step is skipped: its window is neither
  rounded, recorded, nor carried, since rounding the begin proves nothing
  about begin + i * step unless the step is a multiple of the sublane.
  No such jagged loop lowers on Pallas today (the loop lowering asserts
  on a stepped dynamic range before this analysis runs), so this only
  guards the analysis against a future stepped form.

The window analysis this extends reads the loaded and stored tensors of one
loop graph. A later commit replaces that walk with a recursive, per-access
one. Keeping the simpler form here keeps this commit as small as possible.

The pl.ds codegen for subscripts inside the kernel body also promises a loop
offset its block size, which is just as unproven for a runtime begin. It is
left alone here: the bf16 mask-placement test in test_pallas.py
compiles only because of it. A later commit removes it once no kernel leans
on it.
