### PR TITLE
[pallas] annotate every aligned jagged window and reject unsafe writes

### DIFF
--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -2157,16 +2157,24 @@ def _aligned_dim(
 
     # Strictest addressing each row needs over the tensors it slices.
     addressing: dict[int, SliceAddressing] = {}
-    for fake, _node, sub_meta in (*loaded_tensors.values(), *stored_tensors.values()):
-        if not (isinstance(fake, torch.Tensor) and fake.is_floating_point()):
-            continue
-        dim_to_bid = _get_dim_block_ids(sub_meta, env)
-        lane_block = _lane_tile(state, fake, dim_to_bid)
-        for dim, dim_bid in dim_to_bid.items():
-            if _slice_addressing(fake, dim, lane_block) is SliceAddressing.ALIGNED:
-                addressing[dim_bid] = SliceAddressing.ALIGNED
-            else:
-                addressing.setdefault(dim_bid, SliceAddressing.DIRECT)
+    stored_bids: set[int] = set()
+    for tensors, is_store in (
+        (loaded_tensors, False),
+        (stored_tensors, True),
+    ):
+        for fake, _node, sub_meta in tensors.values():
+            dim_to_bid = _get_dim_block_ids(sub_meta, env)
+            if is_store:
+                stored_bids.update(dim_to_bid.values())
+            if not (isinstance(fake, torch.Tensor) and fake.is_floating_point()):
+                continue
+            lane_block = _lane_tile(state, fake, dim_to_bid)
+            for dim, dim_bid in dim_to_bid.items():
+                access_addressing = _slice_addressing(fake, dim, lane_block)
+                if access_addressing is SliceAddressing.ALIGNED:
+                    addressing[dim_bid] = SliceAddressing.ALIGNED
+                else:
+                    addressing.setdefault(dim_bid, SliceAddressing.DIRECT)
 
     sublane = max(sublanes)
     aligned_dim: dict[int, int] = {}
@@ -2177,15 +2185,21 @@ def _aligned_dim(
         direct = addressing.get(bid, SliceAddressing.ALIGNED) is SliceAddressing.DIRECT
         if direct and not carry:
             continue  # reads any offset; a plain clamped slice suffices
-        if not carry and not is_row_map_axis(state, bid):
-            # ALIGNED but not a map axis: a bf16 reduction over the row.  Its
-            # dense bf16 output store can't be proven aligned for Mosaic (E2003),
-            # so reject it cleanly here instead.  f32 reductions are DIRECT and
-            # already skipped above.
-            raise NotImplementedError(
-                "Pallas: bf16 reduction over a jagged row is not supported yet "
-                "(its dense bf16 output store cannot be proven sublane-aligned)."
-            )
+        if not carry:
+            if bid in stored_bids:
+                raise NotImplementedError(
+                    "Pallas: a jagged row tile whose slices must be "
+                    "sublane-aligned and that is written through its row dim is "
+                    "only supported when ordered carry can stitch the store."
+                )
+            if not is_row_map_axis(state, bid):
+                # ALIGNED but not a map axis: a bf16 reduction over the row. Its
+                # dense bf16 output store cannot be proven aligned for Mosaic, so
+                # reject it cleanly here instead. f32 reductions are DIRECT above.
+                raise NotImplementedError(
+                    "Pallas: bf16 reduction over a jagged row is not supported yet "
+                    "(its dense bf16 output store cannot be proven sublane-aligned)."
+                )
         aligned_dim[bid] = sublane
         state.device_function.aligned_tiles[bid] = sublane
         if carry:
@@ -2384,9 +2398,13 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                         )
                     else:
                         size_expr = slice_size_expr
-                    if bid in state.device_function.carry_tiles:
-                        sublane = state.device_function.carry_tiles[bid].sublane
-                        start_expr = f"pl.multiple_of({start_expr}, {sublane})"
+                    # Carried tiles are aligned tiles, so this covers them too.
+                    start_expr = _annotate_provable_sublane_alignment(
+                        state,
+                        bid,
+                        start_expr,
+                        steps_by_block=iter_step_expr == block_size_vars[bid_idx],
+                    )
                     lambda_parts.append(f"pl.ds({start_expr}, {size_expr})")
                 else:
                     # Static, from-zero loop: a block-aligned index is exact.

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -427,6 +427,35 @@ class TestPallasJaggedCarryRejects(TestCase):
         ):
             _run(seq_offsets, jagged, dense, [8, 128, 128], kernel=kernel)
 
+    def test_untiled_column_store_rejected(self) -> None:
+        # With offsets [0, 13, 32] and a 16-row bf16 block, the second group
+        # logically starts at row 13 but its aligned window starts at row 0.
+        # The load mask zeroes rows [0, 13), so a full store would overwrite the
+        # first group with zeros. The untiled ``:`` column has no carry block
+        # with which to save those rows; reject instead of silently corrupting.
+        @helion.kernel(backend="pallas")
+        def jagged_full_row_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, _ = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.empty_like(jagged)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    out[st, :] = jagged[st, :] * 2
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32)
+        jagged = torch.randn((32, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            jagged_full_row_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type="emit_pipeline")
+            )
+
     def test_multi_grid_group_rejected(self) -> None:
         # The fold guard keys seq_offsets program_id(0), so a second grid dimension is
         # refused rather than folding against the wrong program id.


### PR DESCRIPTION
Stacked PRs:
 * #3373
 * #3375
 * #3570
 * #3569
 * #3372
 * #3371
 * #3568
 * #3370
 * #3369
 * __->__#3368
 * #3367
 * #3567


--- --- ---

### [pallas] annotate every aligned jagged window and reject unsafe writes


Currently we only emit pl.multiple_of for jagged windows that use ordered
carry. Every other aligned window fails to compile, since Mosaic cannot
verify that its rounded-down offset is tile-aligned.

This commit addresses that in two parts:

1. Emit the hint for every recorded aligned window.

2. Because the hint would make these windows compile in Mosaic, in Helion
   we reject writes to aligned windows unless ordered carry can stitch them.
   This protects us from the following example:

   - offsets: [0, 13, 32]
   - dtype: bf16 (16-row sublane alignment)
   - row block size: 16
   - second group: owns [13, 32), but its first window is [0, 16)
   - store: out[st, :] writes masked values to rows [0, 13) --> first group
     is overwritten!

These changes have the following consequences:

- The example kernel above now reports a Helion error regarding ordered carry,
  rather than a Mosaic failure about an index not being divisible by the tile
  dimension.

- Every aligned window this newly annotates is still refused in Helion: either
  by the new check when the row is written, or by the existing bf16-reduction
  check, since a window that no store writes through cannot be a "row map
  axis". Note that a later commit lifts the bf16-reduction check.

- The analysis only sees the direct loop body, so a store nested one graph
  deeper goes undetected. A later commit makes the walk recursive to fix this.
