### PR TITLE
[pallas] centralize and complete dynamic-slice padding

### DIFF
--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1076,7 +1076,6 @@ def _pipeline_begin_alignment(
 def _compute_pipeline_or_dma_extra_pad(
     begin_expr: str,
     bid: int,
-    env: CompileEnvironment,
     state: CodegenState,
 ) -> int:
     """Return extra host-side padding for a pipeline/DMA dim with a non-zero begin.
@@ -1097,6 +1096,28 @@ def _compute_pipeline_or_dma_extra_pad(
     if alignment is not None and alignment % bs_val == 0:
         return 0
     return bs_val - 1
+
+
+def _record_loop_pad(
+    state: CodegenState,
+    fake: torch.Tensor,
+    dim_idx: int,
+    bid: int,
+    begin_expr: str | None = None,
+) -> None:
+    """Record the host-side pad this dim's ``pl.ds`` slice needs.
+
+    ``begin_expr`` defaults to the enclosing loop's begin, which is what the
+    outer-dim branches want; an inner loop passes its own begin instead.  The
+    BlockSpec and DMA paths must agree here -- a dim padded on one path and not
+    the other reads off the end of the tensor.
+    """
+    from ...language.memory_ops import _record_pad_info
+
+    if begin_expr is None:
+        begin_expr = _active_loop_begin_expr(state, bid)
+    extra_pad = _compute_pipeline_or_dma_extra_pad(begin_expr, bid, state)
+    _record_pad_info(state, fake, dim_idx, bid, extra_pad)
 
 
 def _active_loop_begin_expr(state: CodegenState, block_id: int) -> str:
@@ -2341,12 +2362,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 slice_size_expr = slice_size_exprs[bid_idx]
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]
-                from ...language.memory_ops import _record_pad_info
-
-                extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
-                )
-                _record_pad_info(state, fake, dim_idx, bid, extra_pad)
+                _record_loop_pad(state, fake, dim_idx, bid, begin_expr)
                 begin_is_zero = begin_expr == "0"
                 end_expr = end_exprs[bid_idx]
                 dim_size = shape[dim_idx]
@@ -2422,12 +2438,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 bs_var = state.device_function.block_size_var(bid)
                 if bs_var:
                     block_shape_parts.append(bs_var)
-                    from ...language.memory_ops import _record_pad_info
-
-                    extra_pad = _compute_pipeline_or_dma_extra_pad(
-                        _active_loop_begin_expr(state, bid), bid, env, state
-                    )
-                    _record_pad_info(state, fake, dim_idx, bid, extra_pad)
+                    _record_loop_pad(state, fake, dim_idx, bid)
                 else:
                     block_shape_parts.append(str(int(shape[dim_idx])))
                 lambda_parts.append(pid_var)
@@ -2441,6 +2452,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 )
                 block_shape_parts.append(f"pl.BoundedSlice({block_m})")
                 lambda_parts.append(f"pl.ds({start_expr}, {block_m})")
+                _record_loop_pad(state, fake, dim_idx, bid)
             elif bid is not None and state.codegen.active_device_loops.get(bid):
                 # Outer non-grid device loop -- the HBM ref is pre-sliced via
                 # ``.at[pl.ds(offset, bs)]`` (see _make_hbm_slice), so the
@@ -3482,12 +3494,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                     vmem_parts.append(":")
                 hbm_parts.append(f"pl.ds({offset_expr}, {slice_size_expr})")
                 hbm_needs_slice = True
-                from ...language.memory_ops import _record_pad_info
-
-                extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
-                )
-                _record_pad_info(state, fake, dim_idx, bid, extra_pad)
+                _record_loop_pad(state, fake, dim_idx, bid, begin_expr)
             elif bid is not None and bid not in block_ids:
                 # Outer grid dim: use grid offset
                 grid_loops = state.codegen.active_device_loops.get(bid)
@@ -3497,12 +3504,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                     if bs_var:
                         hbm_parts.append(f"pl.ds({offset}, {bs_var})")
                         hbm_needs_slice = True
-                        from ...language.memory_ops import _record_pad_info
-
-                        extra_pad = _compute_pipeline_or_dma_extra_pad(
-                            _active_loop_begin_expr(state, bid), bid, env, state
-                        )
-                        _record_pad_info(state, fake, dim_idx, bid, extra_pad)
+                        _record_loop_pad(state, fake, dim_idx, bid)
                     else:
                         hbm_parts.append(":")
                 else:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -5004,6 +5004,37 @@ class TestPallas(TestCase):
         self.assertIn("_hbm_arg_indices=", code)
         torch.testing.assert_close(result, x * r)
 
+    def test_nested_pipeline_blockspec_records_dynamic_row_padding(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def nested_pipeline_copy(
+            offsets: torch.Tensor, x: torch.Tensor
+        ) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty_like(x)
+            for group in hl.grid(offsets.size(0) - 1):
+                begin = offsets[group]
+                end = offsets[group + 1]
+                for tile_m in hl.tile(begin, end):
+                    for tile_n in hl.tile(n):
+                        out[tile_m, tile_n] = x[tile_m, tile_n] * 2
+            return out
+
+        offsets = torch.tensor([0, 13, 25], device=DEVICE, dtype=torch.int32)
+        x = torch.randn(25, 128, device=DEVICE, dtype=torch.bfloat16)
+        code = nested_pipeline_copy.bind((offsets, x)).to_code(
+            helion.Config(
+                block_sizes=[16, 128],
+                pallas_loop_type="emit_pipeline",
+            )
+        )
+        match = re.search(r"_ds_pad_dims=(\[[^\]]*\])", code)
+        self.assertIsNotNone(match, "expected _ds_pad_dims in the launcher call")
+        pad_dims = ast.literal_eval(match.group(1))
+        # Both the input and output row dims are sliced only by the nested
+        # pipeline BlockSpec. A dynamic begin requires block_size - 1 extra rows.
+        self.assertIn((1, 0, 16, 15), pad_dims)
+        self.assertIn((2, 0, 16, 15), pad_dims)
+
     def test_pipeline_begin_aligned_skips_pad(self) -> None:
         # A block-aligned inner begin (the outer tile's offset) needs no boundary
         # pad, so _ds_pad_dims must report extra_pad == 0 rather than block_size-1.


### PR DESCRIPTION
Stacked PRs:
 * #3373
 * #3375
 * #3570
 * #3569
 * #3372
 * #3371
 * #3568
 * #3370
 * __->__#3369
 * #3368
 * #3367
 * #3567


--- --- ---

### [pallas] centralize and complete dynamic-slice padding


Currently a jagged row tile sliced by an inner emit_pipeline does not record
the pad its pl.ds needs, so the kernel reads past the end of the tensor.

That pad is needed because a pl.ds with a runtime begin can make its final
block extend past HBM, so the host has to allocate the extra rows before the
launch. The pad is the worst case, block_size - 1 rows, on top of the usual
round-up to a whole block:

- offsets: [0, 13, 25]
- row block size: 16
- tensor rows: 25
- rounded up to whole blocks: 32 rows
- plus the runtime-begin worst case: 47 rows

Add the missing pl.ds padding for the inner emit_pipeline by using a helper,
and consolidate all inner-loop dynamic-slice pad operations via that
same helper. While at it, drop an unused env parameter in pad computation,
which is called by the added helper.

This paves the way for further code sharing between the lowerings of
emit_pipeline and fori_loop.
