### PR TITLE
[pallas] accept aligned jagged windows on read-only rows

### DIFF
--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -2232,7 +2232,6 @@ def _aligned_dim(
     from .backend import _slice_addressing
     from .memory_access import MemoryAccessKind
     from helion._compiler.pallas.ordered_carry import CarryBoundaryTile
-    from helion._compiler.pallas.ordered_carry import is_row_map_axis
     from helion._compiler.pallas.ordered_carry import needs_ordered_carry
 
     sublanes = [
@@ -2286,14 +2285,6 @@ def _aligned_dim(
                     "Pallas: a jagged row tile whose slices must be "
                     "sublane-aligned and that is written through its row dim is "
                     "only supported when ordered carry can stitch the store."
-                )
-            if not is_row_map_axis(state, bid):
-                # ALIGNED but not a map axis: a bf16 reduction over the row. Its
-                # dense bf16 output store cannot be proven aligned for Mosaic, so
-                # reject it cleanly here instead. f32 reductions are DIRECT above.
-                raise NotImplementedError(
-                    "Pallas: bf16 reduction over a jagged row is not supported yet "
-                    "(its dense bf16 output store cannot be proven sublane-aligned)."
                 )
         state.device_function.aligned_tiles[bid] = sublane
         if carry:

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -11,7 +11,6 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipUnlessPallas
-from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
 import helion.language as hl
@@ -379,14 +378,10 @@ class TestPallasJaggedCarryBmm(TestCase):
 class TestPallasJaggedCarryRejects(TestCase):
     """Shapes the carry refuses (or routes elsewhere) rather than miscompiling."""
 
-    @xfailIfPallas(
-        "bf16 reduction over a jagged row falls through to the f32-only existing "
-        "path; the unaligned bf16 load can't compile yet"
-    )
     def test_jagged_reduction_over_row_bf16(self) -> None:
-        # A reduction over the jagged row (summed to a dense output) is not the
-        # carry's shape, so it falls through to the existing path.  That path is
-        # f32-only, so the bf16 case can't compile yet; the xfail tracks the gap.
+        # A reduction over the jagged row (summed to a dense output) writes
+        # nothing through that row, so its aligned window needs no carry and
+        # the over-read rows are masked away before the sum.
         @helion.kernel(backend="pallas")
         def jagged_row_sum(
             seq_offsets: torch.Tensor, jagged: torch.Tensor


### PR DESCRIPTION
Stacked PRs:
 * #3373
 * #3375
 * #3570
 * #3569
 * __->__#3372
 * #3371
 * #3568
 * #3370
 * #3369
 * #3368
 * #3367
 * #3567


--- --- ---

### [pallas] accept aligned jagged windows on read-only rows


A jagged window over a bf16 row, or over an f32 row wider than one lane tile,
is rounded down to a tile boundary, since such a row cannot be sliced at an
arbitrary row index. A rounded window is accepted only for a "row map", which
ordered carry can stitch. A reduction over such a row is therefore rejected.
However, this rejection is now unnecessary: a reduction writes nothing
through the row, and reads are appropriately masked before the sum.

Accept an aligned window whenever nothing is written through the jagged row.
Written rows remain rejected.

Two earlier commits make this possible: (1) the alignment hint now emitted for
every recorded window lets the reduction compile in Mosaic, and (2) the write
rejection can now see stores from nested loops, so we correctly reject those
cases, instead of inaccurately rejecting them based on the check removed
by this change.

This also has to land before ordered carry extends fori_loop. Under
emit_pipeline, the rejection refuses the flex attention example, whose inner
reduction reads a jagged row. The example passes today only because tiles with
data-dependent bounds default to fori_loop, which plans no aligned window yet.

Replace the single xfailed bf16 reduction test with four bf16 shapes that
read a jagged row without writing through it: the access in the jagged loop
itself, in a nested loop, below a conditional, and a reduction that remasks
after a pointwise op.
