### PR TITLE
[pallas] support ordered jagged carry under fori_loop

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -358,7 +358,7 @@ class DeviceFunction:
         # using pl.ds() that may need host-side padding.
         self.pallas_pad_info: dict[int, dict[int, tuple[int, int]]] = {}
         # Pallas ordered carry: jagged row block_id -> CarryBoundaryTile.  Filled by
-        # the emit_pipeline codegen when the tile is a legal map axis; read by
+        # the inner-loop codegen when the tile is a legal map axis; read by
         # the store codegen to stitch the boundary across neighbouring groups.
         self.carry_tiles: dict[int, CarryBoundaryTile] = {}
         # Pallas: jagged tile block_id -> proven runtime-window alignment.

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -533,8 +533,8 @@ class PallasBackend(Backend):
     def sublane_tiling(self, dtype: torch.dtype) -> int:
         """Native sublane (2nd-minor) tile for ``dtype``: f32->8, bf16->16, i8->32.
 
-        The jagged carry slices its emit_pipeline VMEM refs at this
-        granularity, and such a ref must be accessed as a *whole* native tile:
+        Aligned jagged windows slice their VMEM refs at this granularity, and
+        such a ref must be accessed as a *whole* native tile:
         a smaller slice (e.g. 8 rows of a bf16 ref, whose tile is 16) is
         rejected by Mosaic ("E2003: unproven memory access alignment"),
         independent of offset.

--- a/helion/_compiler/pallas/ordered_carry.py
+++ b/helion/_compiler/pallas/ordered_carry.py
@@ -1,4 +1,4 @@
-"""Ordered carry for jagged row tiles on the Pallas emit_pipeline path.
+"""Ordered carry for jagged row tiles on Pallas streaming loop paths.
 
 A ``hl.tile(s, e)`` with runtime bounds rounds its rows out to a sublane-aligned
 window and masks the extra.  Neighbouring groups then share one boundary,

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3330,15 +3330,12 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     assert isinstance(proxy_args, list)
     has_loop_state = len(args) > 0
 
-    grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
-
-    loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
-    (
-        begin_exprs,
-        iter_step_exprs,
-        slice_size_exprs,
-        _,
-    ) = _pallas_loop_begin_and_step_exprs(state, block_ids, block_size_vars)
+    # Jagged row tiles read (and store) an S-aligned enclosing window, exactly as
+    # on the emit_pipeline path: Mosaic cannot slice a tiled dim at an arbitrary
+    # offset, and the ordered carry stitches the boundary two groups share.
+    window = _plan_inner_loop_window(state, graph_info, block_ids, env)
+    # Prefetching shortens the final loop extent, so mutate a derived copy.
+    grid_parts = list(window.grid_parts)
 
     # --- Handle loop-carried state as scratch VMEM buffers ---
     scratch_names: list[str] = []
@@ -3369,10 +3366,10 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     # non-pipelined tensor is present (which would load full outer-block
     # tiles into VMEM and may OOM at large shapes).
     all_tensor_info, vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
-        loaded_tensors,
-        stored_tensors,
+        window.loaded,
+        window.stored,
         block_ids,
-        slice_size_exprs,
+        window.slice_size_exprs,
         env,
         state,
     )
@@ -3442,7 +3439,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             id(input_tensor.untyped_storage()), []
         ).append(input_slot)
     stored_tensor_storages = {
-        id(fake.untyped_storage()) for fake, _node, _sub_meta in stored_tensors.values()
+        id(fake.untyped_storage()) for fake, _node, _sub_meta in window.stored.values()
     }
 
     for (fake, sub_meta, direction), vmem_shape in zip(
@@ -3538,9 +3535,9 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         state,
         strategy,
         block_ids,
-        block_size_vars,
-        begin_exprs,
-        iter_step_exprs,
+        window.block_size_vars,
+        window.begin_exprs,
+        window.iter_step_exprs,
         dim_idx_exprs,
         env,
         body_stmts,
@@ -3550,7 +3547,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         state,
         strategy,
         block_ids,
-        block_size_vars,
+        window.block_size_vars,
         env,
         body_stmts,
         # fori_loop has direct access to the loop variable
@@ -3591,7 +3588,10 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         ``min(block_size, end - offset)`` and the VMEM side sliced to match, so
         only live rows are written instead of overrunning adjacent regions
         packed in the same tensor; with ``clamp=False`` (loads, dense stores)
-        the VMEM side stays the bare buffer.
+        the VMEM side stays the bare buffer.  A jagged dim that reads an
+        S-aligned window (``aligned_tiles``) keeps its full block on both sides
+        and advertises the alignment with
+        ``_annotate_provable_sublane_alignment``.
         """
         from helion._compiler.pallas.ordered_carry import is_dynamic_bound_tile
 
@@ -3607,16 +3607,26 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             bid = dim_to_bid.get(dim_idx)
             if bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
-                begin_expr = begin_exprs[bid_idx]
-                iter_step_expr = iter_step_exprs[bid_idx]
-                slice_size_expr = slice_size_exprs[bid_idx]
+                begin_expr = window.begin_exprs[bid_idx]
+                iter_step_expr = window.iter_step_exprs[bid_idx]
+                slice_size_expr = window.slice_size_exprs[bid_idx]
                 dim_idx_expr = iteration_indices[bid_idx]
                 offset_expr = f"({begin_expr}) + ({dim_idx_expr}) * ({iter_step_expr})"
+                annotated_offset_expr = (
+                    _annotate_provable_sublane_alignment(state, bid, offset_expr)
+                    if window.steps_by_block[bid_idx]
+                    else offset_expr
+                )
                 # Mosaic requires the lane (/128) and sublane (/8) VMEM dims to
                 # stay tile-aligned, so only clamp dims outside the last two; a
                 # ragged store on a last-two dim can't clamp and is rejected.
-                if clamp and dim_idx < len(shape) - 2:
-                    end_expr = _get_loop_begin_and_end(state, bid_idx)[1]
+                if clamp and bid in state.device_function.carry_tiles:
+                    # Ordered carry: the window is S-aligned and fixed-size, and
+                    # the store value already has its unowned rows zeroed and the
+                    # shared boundary folded in, so the whole block goes out.
+                    vmem_parts.append(":")
+                elif clamp and dim_idx < len(shape) - 2:
+                    end_expr = window.end_exprs[bid_idx]
                     slice_size_expr = f"jnp.minimum({slice_size_expr}, ({end_expr}) - ({offset_expr}))"
                     vmem_parts.append(f"pl.ds(0, {slice_size_expr})")
                     vmem_needs_slice = True
@@ -3632,14 +3642,16 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                     )
                 else:
                     vmem_parts.append(":")
-                hbm_parts.append(f"pl.ds({offset_expr}, {slice_size_expr})")
+                hbm_parts.append(f"pl.ds({annotated_offset_expr}, {slice_size_expr})")
                 hbm_needs_slice = True
                 _record_loop_pad(state, fake, dim_idx, bid, begin_expr)
             elif bid is not None and bid not in block_ids:
                 # Outer grid dim: use grid offset
                 grid_loops = state.codegen.active_device_loops.get(bid)
                 if grid_loops:
-                    offset = state.codegen.offset_var(bid)
+                    offset = _annotate_provable_sublane_alignment(
+                        state, bid, state.codegen.offset_var(bid)
+                    )
                     bs_var = state.device_function.block_size_var(bid)
                     if bs_var:
                         hbm_parts.append(f"pl.ds({offset}, {bs_var})")
@@ -3780,15 +3792,15 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                 offset_name = strategy.offset_var(bid)
                 state.codegen.add_statement(
                     statement_from_string(
-                        f"{offset_name} = ({begin_exprs[i]}) + "
-                        f"({dim_idx_exprs[i]}) * ({iter_step_exprs[i]})"
+                        f"{offset_name} = ({window.begin_exprs[i]}) + "
+                        f"({dim_idx_exprs[i]}) * ({window.iter_step_exprs[i]})"
                     )
                 )
 
         if body_prefetch is not None:
             state.codegen.add_statement(body_prefetch)
 
-        for fake, _tensor_node, sub_meta in loaded_tensors.values():
+        for fake, _tensor_node, sub_meta in window.loaded.values():
             hbm_name = state.device_function.tensor_arg(fake).name
             if (
                 hbm_name not in tensor_to_dma_scratch
@@ -3817,7 +3829,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         if has_loop_state:
             _write_back_loop_carried(state, scratch_names, carried, graph_results)
 
-        for fake, _tensor_node, sub_meta in stored_tensors.values():
+        for fake, _tensor_node, sub_meta in window.stored.values():
             hbm_name = state.device_function.tensor_arg(fake).name
             if hbm_name not in tensor_to_dma_scratch:
                 continue

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -5980,7 +5980,10 @@ class TestPallas(TestCase):
         H, D = 4, 16
         offsets = torch.tensor([0, 10], device=DEVICE, dtype=torch.int32)
         torch.manual_seed(0)
-        y = torch.randn(H, 10, D, device=DEVICE, dtype=torch.bfloat16)
+        # Keep this mask-placement test directly addressable. A bf16 load
+        # would need a rounded-down window, and the major-dim output store
+        # cannot carry its head rows, so this commit rejects that shape.
+        y = torch.randn(H, 10, D, device=DEVICE, dtype=torch.float32)
 
         code, out = code_and_output(
             opposite,

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import torch
 from torch.testing._internal.common_utils import instantiate_parametrized_tests
 from torch.testing._internal.common_utils import parametrize
+from torch.testing._internal.common_utils import subtest
 
 import helion
 from helion import exc
@@ -23,6 +24,28 @@ _XFAIL_INTERPRET = (
     "emit_pipeline dynamic pl.ds / program_id BlockSpecs unsupported in JAX "
     "Pallas interpret mode"
 )
+
+# Both inner-loop lowerings build the same sublane-aligned window and carry, so
+# both must stay correct: fori_loop is what the default config picks (and what
+# the autotuner's baseline compiles), emit_pipeline is a tuned alternative.
+_LOOP_TYPES = ["fori_loop", "emit_pipeline"]
+
+# Same pair for tests that RUN the kernel: only emit_pipeline hits the
+# interpret-mode gap above, since fori_loop's plain DMA slices do trace there.
+_RUN_LOOP_TYPES = [
+    subtest("fori_loop", name="fori_loop"),
+    subtest(
+        "emit_pipeline",
+        name="emit_pipeline",
+        decorators=[xfailIfPallasInterpret(_XFAIL_INTERPRET)],
+    ),
+]
+
+# Proof the kernel really lowered through the requested loop type.
+_LOOP_MARKER = {
+    "fori_loop": "jax.lax.fori_loop",
+    "emit_pipeline": "pltpu.emit_pipeline",
+}
 
 
 # out[s:e] = jagged[s:e] @ dense[g] for each group g delimited by seq_offsets.
@@ -65,6 +88,12 @@ def jagged_dense_bmm_2d_loop(
     return out
 
 
+_BMM_KERNELS = [
+    jagged_dense_bmm,
+    jagged_dense_bmm_2d_loop,
+]
+
+
 def _ref_jagged_bmm(
     seq_offsets: torch.Tensor, jagged: torch.Tensor, dense: torch.Tensor
 ) -> torch.Tensor:
@@ -87,12 +116,12 @@ def _inputs(offsets: list[int], D: int, K: int, dtype: torch.dtype):
     return seq_offsets, jagged, dense
 
 
-def _run(seq_offsets, jagged, dense, block_sizes, kernel=jagged_dense_bmm):
+def _run(seq_offsets, jagged, dense, block_sizes, loop_type, kernel=jagged_dense_bmm):
     return code_and_output(
         kernel,
         (seq_offsets, jagged, dense),
         block_sizes=block_sizes,
-        pallas_loop_type="emit_pipeline",
+        pallas_loop_type=loop_type,
     )
 
 
@@ -103,29 +132,45 @@ def _run(seq_offsets, jagged, dense, block_sizes, kernel=jagged_dense_bmm):
 class TestPallasJaggedCarrySimple(TestCase):
     """Minimal kernels that isolate one carry behaviour each."""
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
+    @parametrize("kernel", _BMM_KERNELS)
+    def test_default_config(self, kernel) -> None:
+        # No pinned config: data-dependent bounds make the default loop type
+        # fori_loop, which is also what HELION_AUTOTUNE_EFFORT=none and the
+        # autotuner's baseline compile, so the carry has to work there.
+        seq_offsets, jagged, dense = _inputs([0, 13, 25], 128, 128, torch.bfloat16)
+        code, out = code_and_output(kernel, (seq_offsets, jagged, dense))
+        self.assertIn(_LOOP_MARKER["fori_loop"], code)
+        torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
+
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_single_group(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_single_group(self, dtype: torch.dtype, kernel, loop_type: str) -> None:
         # One group: exercises the aligned-enclosing read and the tail mask,
         # with no carry between groups.
         seq_offsets, jagged, dense = _inputs([0, 20], 128, 128, dtype)
-        _code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        _code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_aligned_groups_carry_dormant(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_aligned_groups_carry_dormant(
+        self, dtype: torch.dtype, kernel, loop_type: str
+    ) -> None:
         # Aligned boundaries: carry path is emitted but its runtime guard never fires.
         seq_offsets, jagged, dense = _inputs([0, 16, 32], 128, 128, dtype)
-        code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         self.assertIn("pl.program_id(0) != 0", code)
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_carry_keeps_both_groups(self, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_carry_keeps_both_groups(self, kernel, loop_type: str) -> None:
         # Two groups [0, 3) and [3, 16) share the [0, 16) boundary.  With
         # identity weights out == jagged, so a clobbered carry would be obvious.
         seq_offsets = torch.tensor([0, 3, 16], dtype=torch.int32, device=DEVICE)
@@ -136,13 +181,18 @@ class TestPallasJaggedCarrySimple(TestCase):
         )
         eye = torch.eye(128, dtype=torch.bfloat16, device=DEVICE)
         _code, out = _run(
-            seq_offsets, jagged, torch.stack([eye, eye]), [16, 128, 128], kernel=kernel
+            seq_offsets,
+            jagged,
+            torch.stack([eye, eye]),
+            [16, 128, 128],
+            loop_type,
+            kernel=kernel,
         )
         torch.testing.assert_close(out, jagged)
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    def test_carry_masks_bias_add(self, dtype: torch.dtype) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_carry_masks_bias_add(self, dtype: torch.dtype, loop_type: str) -> None:
         # Additive map across a shared boundary: groups [0, 3) and [3, 16) over-
         # read each other's rows (loaded as 0).  Unless the store value is masked,
         # those rows write 0 + 1.0 and the carry folds a stray 1.0 into the result.
@@ -164,13 +214,13 @@ class TestPallasJaggedCarrySimple(TestCase):
             jagged_add_one,
             (seq_offsets, jagged),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         torch.testing.assert_close(out, jagged + 1.0)
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    def test_carry_separate_outputs(self, dtype: torch.dtype) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_carry_separate_outputs(self, dtype: torch.dtype, loop_type: str) -> None:
         # Two stores share one jagged tile: each must carry into its own scratch,
         # otherwise out2's boundary save clobbers out1's.
         @helion.kernel(backend="pallas")
@@ -194,14 +244,16 @@ class TestPallasJaggedCarrySimple(TestCase):
             jagged_add_two,
             (seq_offsets, jagged),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         torch.testing.assert_close(o1, jagged + 1.0)
         torch.testing.assert_close(o2, jagged + 2.0)
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    def test_carry_scalar_branch_store(self, dtype: torch.dtype) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_carry_scalar_branch_store(
+        self, dtype: torch.dtype, loop_type: str
+    ) -> None:
         # Two groups take different if/else branches across a shared boundary.
         @helion.kernel(backend="pallas")
         def jagged_branch(seq_offsets, jagged):
@@ -226,7 +278,7 @@ class TestPallasJaggedCarrySimple(TestCase):
             jagged_branch,
             (seq_offsets, jagged),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         self.assertIn("lax.cond", code)
         expected = torch.empty_like(jagged)
@@ -244,7 +296,6 @@ class TestPallasJaggedCarryBmm(TestCase):
     """The carry across the full configuration matrix (group counts, block vs
     group size, multiple column tiles, the non-matmul map-axis form)."""
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
     @parametrize(
         "offsets",
@@ -254,46 +305,56 @@ class TestPallasJaggedCarryBmm(TestCase):
             [0, 3, 7, 16],  # several tiny groups in one boundary (cumulative carry)
         ],
     )
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
     def test_bmm_block_eq_sublane(
-        self, dtype: torch.dtype, offsets: list[int], kernel
+        self, dtype: torch.dtype, offsets: list[int], kernel, loop_type: str
     ) -> None:
         seq_offsets, jagged, dense = _inputs(offsets, 128, 128, dtype)
-        code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
-        self.assertIn("pltpu.emit_pipeline", code)
+        code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
+        self.assertIn(_LOOP_MARKER[loop_type], code)
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_bmm_block_gt_group(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_bmm_block_gt_group(
+        self, dtype: torch.dtype, kernel, loop_type: str
+    ) -> None:
         # Two groups (13 rows) are smaller than block_row=32, total L=200 >> block_row.
         seq_offsets, jagged, dense = _inputs([0, 13, 100, 113, 200], 128, 128, dtype)
-        _code, out = _run(seq_offsets, jagged, dense, [32, 128, 128], kernel=kernel)
+        _code, out = _run(
+            seq_offsets, jagged, dense, [32, 128, 128], loop_type, kernel=kernel
+        )
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_bmm_multi_k_tile(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_bmm_multi_k_tile(self, dtype: torch.dtype, kernel, loop_type: str) -> None:
         # K=256 with block_col=128 gives two output-column tiles; the carry stacks
         # the per-column-tile boundaries along its scratch row dim.
         seq_offsets, jagged, dense = _inputs([0, 17, 40, 71], 128, 256, dtype)
-        _code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        _code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_bmm_many_groups(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_bmm_many_groups(self, dtype: torch.dtype, kernel, loop_type: str) -> None:
         # 50 unaligned groups; carry scratch is per column-tile, not per group.
         offsets = list(range(0, 13 * 51, 13))  # 50 groups
         seq_offsets, jagged, dense = _inputs(offsets, 128, 128, dtype)
-        code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         self.assertIn("carry", code)
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
     @parametrize(
         "offsets",
@@ -303,17 +364,20 @@ class TestPallasJaggedCarryBmm(TestCase):
             [0, 16, 16],  # trailing empty
         ],
     )
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
     def test_bmm_empty_groups(
-        self, dtype: torch.dtype, offsets: list[int], kernel
+        self, dtype: torch.dtype, offsets: list[int], kernel, loop_type: str
     ) -> None:
         # Zero-length groups (s == e) iterate no tiles; carry threads the neighbours.
         seq_offsets, jagged, dense = _inputs(offsets, 128, 128, dtype)
-        _code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        _code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
-    def test_elementwise_map_axis(self) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_elementwise_map_axis(self, loop_type: str) -> None:
         # The non-matmul map-axis store from commit 2 now runs: out[st] = 2 *
         # jagged[st], carried across the shared boundary like the matmul case.
         @helion.kernel(backend="pallas")
@@ -337,13 +401,13 @@ class TestPallasJaggedCarryBmm(TestCase):
             jagged_scale,
             (seq_offsets, jagged),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         torch.testing.assert_close(out, jagged * 2)
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dynamic_cols", [True, False])
-    def test_dynamic_rows(self, dynamic_cols: bool) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_dynamic_rows(self, dynamic_cols: bool, loop_type: str) -> None:
         @helion.kernel(backend="pallas", static_shapes=False)
         def jagged_scale_dyn(
             seq_offsets: torch.Tensor, jagged: torch.Tensor, dynamic_cols: hl.constexpr
@@ -367,7 +431,7 @@ class TestPallasJaggedCarryBmm(TestCase):
             jagged_scale_dyn,
             (seq_offsets, jagged, dynamic_cols),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         self.assertIn("(B,)", code)
         torch.testing.assert_close(out, jagged * 2)
@@ -412,17 +476,157 @@ class TestPallasJaggedCarryRejects(TestCase):
         ref[1] = jagged[13:25].float().sum(0)
         torch.testing.assert_close(out, ref)
 
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_block_not_multiple_of_sublane_raises(self, kernel) -> None:
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_direct_store_under_aligned_window_rejected(self, loop_type: str) -> None:
+        @helion.kernel(backend="pallas")
+        def mixed_dtype_row_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.empty((L, D), dtype=torch.float32, device=jagged.device)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    out[st, :] = jagged[st, :].to(torch.float32) * 2
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 25], dtype=torch.int32)
+        jagged = torch.randn((25, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            mixed_dtype_row_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_nested_direct_store_under_aligned_window_rejected(
+        self, loop_type: str
+    ) -> None:
+        @helion.kernel(backend="pallas")
+        def nested_mixed_dtype_row_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.empty((L, 1, D), dtype=torch.float32, device=jagged.device)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    for ct in hl.tile(0, D):
+                        out[st, 0, ct] = jagged[st, ct].to(torch.float32)
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 25], dtype=torch.int32)
+        jagged = torch.randn((25, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            nested_mixed_dtype_row_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16, 128], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_store_below_while_rejected(self, loop_type: str) -> None:
+        @helion.kernel(backend="pallas")
+        def while_nested_row_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.empty((L, 1, D), dtype=torch.float32, device=jagged.device)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    step = torch.zeros([], dtype=torch.int32, device=jagged.device)
+                    while step < 1:
+                        for ct in hl.tile(0, D):
+                            out[st, 0, ct] = jagged[st, ct].to(torch.float32)
+                        step = step + 1
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 25], dtype=torch.int32)
+        jagged = torch.randn((25, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            while_nested_row_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16, 128], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_shifted_store_through_row_rejected(self, loop_type: str) -> None:
+        # bf16 forces the aligned window, and the row leaves through the store --
+        # but shifted by one, so it is not the straight map the carry can stitch
+        # and the window's extra rows would land on a neighbour. Reject it here
+        # rather than let Mosaic (or the device) fail further down.
+        @helion.kernel(backend="pallas")
+        def jagged_shift_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.zeros((L, D), dtype=jagged.dtype, device=jagged.device)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    for dt in hl.tile(0, D):
+                        out[st.index + 1, dt] = jagged[st, dt] * 2
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32)
+        jagged = torch.randn((32, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            jagged_shift_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16, 128], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_atomic_write_through_row_rejected(self, loop_type: str) -> None:
+        @helion.kernel(backend="pallas")
+        def jagged_atomic_write(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor, out: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    for dt in hl.tile(0, D):
+                        hl.atomic_xchg(out, [st, dt], jagged[st, dt] + 1.0)
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32)
+        jagged = torch.randn((32, 128), dtype=torch.bfloat16)
+        out = torch.zeros_like(jagged)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            jagged_atomic_write.bind((seq_offsets, jagged, out)).to_triton_code(
+                helion.Config(block_sizes=[16, 128], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_block_not_multiple_of_sublane_raises(self, kernel, loop_type: str) -> None:
         # bf16 sublane S=16; block_row=8 is not a multiple, so the carry rejects it
         # loudly instead of clobbering the boundary with a plain store.
         seq_offsets, jagged, dense = _inputs([0, 13, 25], 128, 128, torch.bfloat16)
         with self.assertRaisesRegex(
             exc.InductorLoweringError, "block_row .* must be a multiple"
         ):
-            _run(seq_offsets, jagged, dense, [8, 128, 128], kernel=kernel)
+            _run(seq_offsets, jagged, dense, [8, 128, 128], loop_type, kernel=kernel)
 
-    def test_untiled_column_store_rejected(self) -> None:
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_untiled_column_store_rejected(self, loop_type: str) -> None:
         # With offsets [0, 13, 32] and a 16-row bf16 block, the second group
         # logically starts at row 13 but its aligned window starts at row 0.
         # The load mask zeroes rows [0, 13), so a full store would overwrite the
@@ -448,10 +652,11 @@ class TestPallasJaggedCarryRejects(TestCase):
             exc.InductorLoweringError, "ordered carry can stitch"
         ):
             jagged_full_row_store.bind((seq_offsets, jagged)).to_triton_code(
-                helion.Config(block_sizes=[16], pallas_loop_type="emit_pipeline")
+                helion.Config(block_sizes=[16], pallas_loop_type=loop_type)
             )
 
-    def test_multi_grid_group_rejected(self) -> None:
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_multi_grid_group_rejected(self, loop_type: str) -> None:
         # The fold guard keys seq_offsets program_id(0), so a second grid dimension is
         # refused rather than folding against the wrong program id.
         @helion.kernel(backend="pallas")
@@ -478,7 +683,7 @@ class TestPallasJaggedCarryRejects(TestCase):
                 two_grid_bmm,
                 (seq_offsets, jagged, dense),
                 block_sizes=[16, 128, 128],
-                pallas_loop_type="emit_pipeline",
+                pallas_loop_type=loop_type,
             )
 
     def test_non_jagged_emit_pipeline_unaffected(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * __->__#3373
 * #3375
 * #3570
 * #3569
 * #3372
 * #3371
 * #3568
 * #3370
 * #3369
 * #3368
 * #3367
 * #3567


--- --- ---

### [pallas] support ordered jagged carry under fori_loop


Data-dependent tiles default to fori_loop, but aligned jagged windows and
ordered carry are only supported under emit_pipeline.

Add support under fori_loop by routing fori_loop through
InnerLoopWindow so both lowerings use the same aligned bounds and
validity masks. Its DMA slices use proven sublane alignment, and
carried stores transfer the whole block so neighboring groups can
preserve their shared boundary rows.

With fori_loop now recording aligned windows, remove the remaining pl.ds
block-size fallback for missing or unknown loop begins. A runtime begin
without a recorded window no longer receives an unproven alignment promise.
This removal must accompany the new window handling: the flex attention
example test fails otherwise with a Mosaic alignment check.

Tests: exercise the jagged carry, indexing, reduction, and invalid-write cases
under both lowerings, and check that unknown begins without a recorded
window receive no promise. As a drive-by change, update the stale "from
commit 2" test comment.
