### PR TITLE
[pallas] test aligned read-only jagged reductions

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -361,6 +361,8 @@ class DeviceFunction:
         # the emit_pipeline codegen when the tile is a legal map axis; read by
         # the store codegen to stitch the boundary across neighbouring groups.
         self.carry_tiles: dict[int, CarryBoundaryTile] = {}
+        # Pallas: jagged tile block_id -> proven runtime-window alignment.
+        self.aligned_tiles: dict[int, int] = {}
         # CarryScratchKey(row block_id, output name) -> carry scratch var name.
         # One scratch per output buffer (a tile may feed several stores),
         # allocated at the store.

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -358,7 +358,7 @@ class DeviceFunction:
         # using pl.ds() that may need host-side padding.
         self.pallas_pad_info: dict[int, dict[int, tuple[int, int]]] = {}
         # Pallas ordered carry: jagged row block_id -> CarryBoundaryTile.  Filled by
-        # the emit_pipeline codegen when the tile is a legal map axis; read by
+        # the inner-loop codegen when the tile is a legal map axis; read by
         # the store codegen to stitch the boundary across neighbouring groups.
         self.carry_tiles: dict[int, CarryBoundaryTile] = {}
         # Pallas: jagged tile block_id -> proven runtime-window alignment.

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -533,8 +533,8 @@ class PallasBackend(Backend):
     def sublane_tiling(self, dtype: torch.dtype) -> int:
         """Native sublane (2nd-minor) tile for ``dtype``: f32->8, bf16->16, i8->32.
 
-        The jagged carry slices its emit_pipeline VMEM refs at this
-        granularity, and such a ref must be accessed as a *whole* native tile:
+        Aligned jagged windows slice their VMEM refs at this granularity, and
+        such a ref must be accessed as a *whole* native tile:
         a smaller slice (e.g. 8 rows of a bf16 ref, whose tile is 16) is
         rejected by Mosaic ("E2003: unproven memory access alignment"),
         independent of offset.

--- a/helion/_compiler/pallas/ordered_carry.py
+++ b/helion/_compiler/pallas/ordered_carry.py
@@ -1,4 +1,4 @@
-"""Ordered carry for jagged row tiles on the Pallas emit_pipeline path.
+"""Ordered carry for jagged row tiles on Pallas streaming loop paths.
 
 A ``hl.tile(s, e)`` with runtime bounds rounds its rows out to a sublane-aligned
 window and masks the extra.  Neighbouring groups then share one boundary,

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3330,15 +3330,12 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     assert isinstance(proxy_args, list)
     has_loop_state = len(args) > 0
 
-    grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
-
-    loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
-    (
-        begin_exprs,
-        iter_step_exprs,
-        slice_size_exprs,
-        _,
-    ) = _pallas_loop_begin_and_step_exprs(state, block_ids, block_size_vars)
+    # Jagged row tiles read (and store) an S-aligned enclosing window, exactly as
+    # on the emit_pipeline path: Mosaic cannot slice a tiled dim at an arbitrary
+    # offset, and the ordered carry stitches the boundary two groups share.
+    window = _plan_inner_loop_window(state, graph_info, block_ids, env)
+    # Prefetching shortens the final loop extent, so mutate a derived copy.
+    grid_parts = list(window.grid_parts)
 
     # --- Handle loop-carried state as scratch VMEM buffers ---
     scratch_names: list[str] = []
@@ -3369,10 +3366,10 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     # non-pipelined tensor is present (which would load full outer-block
     # tiles into VMEM and may OOM at large shapes).
     all_tensor_info, vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
-        loaded_tensors,
-        stored_tensors,
+        window.loaded,
+        window.stored,
         block_ids,
-        slice_size_exprs,
+        window.slice_size_exprs,
         env,
         state,
     )
@@ -3442,7 +3439,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             id(input_tensor.untyped_storage()), []
         ).append(input_slot)
     stored_tensor_storages = {
-        id(fake.untyped_storage()) for fake, _node, _sub_meta in stored_tensors.values()
+        id(fake.untyped_storage()) for fake, _node, _sub_meta in window.stored.values()
     }
 
     for (fake, sub_meta, direction), vmem_shape in zip(
@@ -3538,9 +3535,9 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         state,
         strategy,
         block_ids,
-        block_size_vars,
-        begin_exprs,
-        iter_step_exprs,
+        window.block_size_vars,
+        window.begin_exprs,
+        window.iter_step_exprs,
         dim_idx_exprs,
         env,
         body_stmts,
@@ -3550,7 +3547,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         state,
         strategy,
         block_ids,
-        block_size_vars,
+        window.block_size_vars,
         env,
         body_stmts,
         # fori_loop has direct access to the loop variable
@@ -3591,7 +3588,10 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         ``min(block_size, end - offset)`` and the VMEM side sliced to match, so
         only live rows are written instead of overrunning adjacent regions
         packed in the same tensor; with ``clamp=False`` (loads, dense stores)
-        the VMEM side stays the bare buffer.
+        the VMEM side stays the bare buffer.  A jagged dim that reads an
+        S-aligned window (``aligned_tiles``) keeps its full block on both sides
+        and advertises the alignment with
+        ``_annotate_provable_sublane_alignment``.
         """
         from helion._compiler.pallas.ordered_carry import is_dynamic_bound_tile
 
@@ -3607,16 +3607,26 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             bid = dim_to_bid.get(dim_idx)
             if bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
-                begin_expr = begin_exprs[bid_idx]
-                iter_step_expr = iter_step_exprs[bid_idx]
-                slice_size_expr = slice_size_exprs[bid_idx]
+                begin_expr = window.begin_exprs[bid_idx]
+                iter_step_expr = window.iter_step_exprs[bid_idx]
+                slice_size_expr = window.slice_size_exprs[bid_idx]
                 dim_idx_expr = iteration_indices[bid_idx]
                 offset_expr = f"({begin_expr}) + ({dim_idx_expr}) * ({iter_step_expr})"
+                annotated_offset_expr = (
+                    _annotate_provable_sublane_alignment(state, bid, offset_expr)
+                    if window.steps_by_block[bid_idx]
+                    else offset_expr
+                )
                 # Mosaic requires the lane (/128) and sublane (/8) VMEM dims to
                 # stay tile-aligned, so only clamp dims outside the last two; a
                 # ragged store on a last-two dim can't clamp and is rejected.
-                if clamp and dim_idx < len(shape) - 2:
-                    end_expr = _get_loop_begin_and_end(state, bid_idx)[1]
+                if clamp and bid in state.device_function.carry_tiles:
+                    # Ordered carry: the window is S-aligned and fixed-size, and
+                    # the store value already has its unowned rows zeroed and the
+                    # shared boundary folded in, so the whole block goes out.
+                    vmem_parts.append(":")
+                elif clamp and dim_idx < len(shape) - 2:
+                    end_expr = window.end_exprs[bid_idx]
                     slice_size_expr = f"jnp.minimum({slice_size_expr}, ({end_expr}) - ({offset_expr}))"
                     vmem_parts.append(f"pl.ds(0, {slice_size_expr})")
                     vmem_needs_slice = True
@@ -3632,14 +3642,16 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                     )
                 else:
                     vmem_parts.append(":")
-                hbm_parts.append(f"pl.ds({offset_expr}, {slice_size_expr})")
+                hbm_parts.append(f"pl.ds({annotated_offset_expr}, {slice_size_expr})")
                 hbm_needs_slice = True
                 _record_loop_pad(state, fake, dim_idx, bid, begin_expr)
             elif bid is not None and bid not in block_ids:
                 # Outer grid dim: use grid offset
                 grid_loops = state.codegen.active_device_loops.get(bid)
                 if grid_loops:
-                    offset = state.codegen.offset_var(bid)
+                    offset = _annotate_provable_sublane_alignment(
+                        state, bid, state.codegen.offset_var(bid)
+                    )
                     bs_var = state.device_function.block_size_var(bid)
                     if bs_var:
                         hbm_parts.append(f"pl.ds({offset}, {bs_var})")
@@ -3780,15 +3792,15 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                 offset_name = strategy.offset_var(bid)
                 state.codegen.add_statement(
                     statement_from_string(
-                        f"{offset_name} = ({begin_exprs[i]}) + "
-                        f"({dim_idx_exprs[i]}) * ({iter_step_exprs[i]})"
+                        f"{offset_name} = ({window.begin_exprs[i]}) + "
+                        f"({dim_idx_exprs[i]}) * ({window.iter_step_exprs[i]})"
                     )
                 )
 
         if body_prefetch is not None:
             state.codegen.add_statement(body_prefetch)
 
-        for fake, _tensor_node, sub_meta in loaded_tensors.values():
+        for fake, _tensor_node, sub_meta in window.loaded.values():
             hbm_name = state.device_function.tensor_arg(fake).name
             if (
                 hbm_name not in tensor_to_dma_scratch
@@ -3817,7 +3829,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         if has_loop_state:
             _write_back_loop_carried(state, scratch_names, carried, graph_results)
 
-        for fake, _tensor_node, sub_meta in stored_tensors.values():
+        for fake, _tensor_node, sub_meta in window.stored.values():
             hbm_name = state.device_function.tensor_arg(fake).name
             if hbm_name not in tensor_to_dma_scratch:
                 continue

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -2157,16 +2157,24 @@ def _aligned_dim(
 
     # Strictest addressing each row needs over the tensors it slices.
     addressing: dict[int, SliceAddressing] = {}
-    for fake, _node, sub_meta in (*loaded_tensors.values(), *stored_tensors.values()):
-        if not (isinstance(fake, torch.Tensor) and fake.is_floating_point()):
-            continue
-        dim_to_bid = _get_dim_block_ids(sub_meta, env)
-        lane_block = _lane_tile(state, fake, dim_to_bid)
-        for dim, dim_bid in dim_to_bid.items():
-            if _slice_addressing(fake, dim, lane_block) is SliceAddressing.ALIGNED:
-                addressing[dim_bid] = SliceAddressing.ALIGNED
-            else:
-                addressing.setdefault(dim_bid, SliceAddressing.DIRECT)
+    stored_bids: set[int] = set()
+    for tensors, is_store in (
+        (loaded_tensors, False),
+        (stored_tensors, True),
+    ):
+        for fake, _node, sub_meta in tensors.values():
+            dim_to_bid = _get_dim_block_ids(sub_meta, env)
+            if is_store:
+                stored_bids.update(dim_to_bid.values())
+            if not (isinstance(fake, torch.Tensor) and fake.is_floating_point()):
+                continue
+            lane_block = _lane_tile(state, fake, dim_to_bid)
+            for dim, dim_bid in dim_to_bid.items():
+                access_addressing = _slice_addressing(fake, dim, lane_block)
+                if access_addressing is SliceAddressing.ALIGNED:
+                    addressing[dim_bid] = SliceAddressing.ALIGNED
+                else:
+                    addressing.setdefault(dim_bid, SliceAddressing.DIRECT)
 
     sublane = max(sublanes)
     aligned_dim: dict[int, int] = {}
@@ -2177,15 +2185,21 @@ def _aligned_dim(
         direct = addressing.get(bid, SliceAddressing.ALIGNED) is SliceAddressing.DIRECT
         if direct and not carry:
             continue  # reads any offset; a plain clamped slice suffices
-        if not carry and not is_row_map_axis(state, bid):
-            # ALIGNED but not a map axis: a bf16 reduction over the row.  Its
-            # dense bf16 output store can't be proven aligned for Mosaic (E2003),
-            # so reject it cleanly here instead.  f32 reductions are DIRECT and
-            # already skipped above.
-            raise NotImplementedError(
-                "Pallas: bf16 reduction over a jagged row is not supported yet "
-                "(its dense bf16 output store cannot be proven sublane-aligned)."
-            )
+        if not carry:
+            if bid in stored_bids:
+                raise NotImplementedError(
+                    "Pallas: a jagged row tile whose slices must be "
+                    "sublane-aligned and that is written through its row dim is "
+                    "only supported when ordered carry can stitch the store."
+                )
+            if not is_row_map_axis(state, bid):
+                # ALIGNED but not a map axis: a bf16 reduction over the row. Its
+                # dense bf16 output store cannot be proven aligned for Mosaic, so
+                # reject it cleanly here instead. f32 reductions are DIRECT above.
+                raise NotImplementedError(
+                    "Pallas: bf16 reduction over a jagged row is not supported yet "
+                    "(its dense bf16 output store cannot be proven sublane-aligned)."
+                )
         aligned_dim[bid] = sublane
         state.device_function.aligned_tiles[bid] = sublane
         if carry:
@@ -2384,9 +2398,13 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                         )
                     else:
                         size_expr = slice_size_expr
-                    if bid in state.device_function.carry_tiles:
-                        sublane = state.device_function.carry_tiles[bid].sublane
-                        start_expr = f"pl.multiple_of({start_expr}, {sublane})"
+                    # Carried tiles are aligned tiles, so this covers them too.
+                    start_expr = _annotate_provable_sublane_alignment(
+                        state,
+                        bid,
+                        start_expr,
+                        steps_by_block=iter_step_expr == block_size_vars[bid_idx],
+                    )
                     lambda_parts.append(f"pl.ds({start_expr}, {size_expr})")
                 else:
                     # Static, from-zero loop: a block-aligned index is exact.

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -2187,6 +2187,7 @@ def _aligned_dim(
                 "(its dense bf16 output store cannot be proven sublane-aligned)."
             )
         aligned_dim[bid] = sublane
+        state.device_function.aligned_tiles[bid] = sublane
         if carry:
             begin, end = _get_loop_begin_and_end(state, i)
             state.device_function.carry_tiles[bid] = CarryBoundaryTile(
@@ -2196,6 +2197,29 @@ def _aligned_dim(
                 sublane=sublane,
             )
     return aligned_dim
+
+
+def _annotate_provable_sublane_alignment(
+    state: CodegenState,
+    block_id: int,
+    offset_expr: str,
+) -> str:
+    """Annotate ``offset_expr`` with its provable sublane alignment, if any.
+
+    ``pl.multiple_of`` is assume_multiple: Mosaic skips its tiled-row alignment
+    check instead of verifying the claim, so only a dim whose window really
+    rounded its begin down -- and whose block size steps by a multiple of that
+    sublane -- may be annotated.  Every other offset comes back unchanged.
+    """
+    sublane_alignment = state.device_function.aligned_tiles.get(block_id)
+    block = state.device_function.resolved_block_size(block_id)
+    if (
+        sublane_alignment is None
+        or not isinstance(block, int)
+        or block % sublane_alignment != 0
+    ):
+        return offset_expr
+    return f"pl.multiple_of({offset_expr}, {sublane_alignment})"
 
 
 def _codegen_emit_pipeline(state: CodegenState) -> object:
@@ -2390,19 +2414,15 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     block_shape_parts.append(str(int(shape[dim_idx])))
                 lambda_parts.append(pid_var)
             elif bid is not None and is_dynamic_bound_tile(state, bid):
-                # Jagged row tile from an inner pipeline.  pl.multiple_of is
-                # assume_multiple: it suppresses the tiled-row alignment check.
-                # Safe because the begin is rounded to the sublane in the dim's
-                # own loop, and a DIRECT f32 single-lane-tile row reads
-                # contiguously.  Always emitted, as sibling loops reference the
-                # same jagged dim.  Must precede the outer-non-grid branch.
+                # Jagged row tile from an inner pipeline.  Always emitted, as
+                # sibling loops reference the same jagged dim.  Must precede the
+                # outer-non-grid branch.
                 block_m = state.device_function.block_size_var(bid)
-                offset_v = state.codegen.offset_var(bid)
-                sublane = env.backend.sublane_tiling(fake.dtype)  # pyrefly: ignore[missing-attribute]
-                block_shape_parts.append(f"pl.BoundedSlice({block_m})")
-                lambda_parts.append(
-                    f"pl.ds(pl.multiple_of({offset_v}, {sublane}), {block_m})"
+                start_expr = _annotate_provable_sublane_alignment(
+                    state, bid, state.codegen.offset_var(bid)
                 )
+                block_shape_parts.append(f"pl.BoundedSlice({block_m})")
+                lambda_parts.append(f"pl.ds({start_expr}, {block_m})")
             elif bid is not None and state.codegen.active_device_loops.get(bid):
                 # Outer non-grid device loop -- the HBM ref is pre-sliced via
                 # ``.at[pl.ds(offset, bs)]`` (see _make_hbm_slice), so the

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -2232,7 +2232,6 @@ def _aligned_dim(
     from .backend import _slice_addressing
     from .memory_access import MemoryAccessKind
     from helion._compiler.pallas.ordered_carry import CarryBoundaryTile
-    from helion._compiler.pallas.ordered_carry import is_row_map_axis
     from helion._compiler.pallas.ordered_carry import needs_ordered_carry
 
     sublanes = [
@@ -2286,14 +2285,6 @@ def _aligned_dim(
                     "Pallas: a jagged row tile whose slices must be "
                     "sublane-aligned and that is written through its row dim is "
                     "only supported when ordered carry can stitch the store."
-                )
-            if not is_row_map_axis(state, bid):
-                # ALIGNED but not a map axis: a bf16 reduction over the row. Its
-                # dense bf16 output store cannot be proven aligned for Mosaic, so
-                # reject it cleanly here instead. f32 reductions are DIRECT above.
-                raise NotImplementedError(
-                    "Pallas: bf16 reduction over a jagged row is not supported yet "
-                    "(its dense bf16 output store cannot be proven sublane-aligned)."
                 )
         state.device_function.aligned_tiles[bid] = sublane
         if carry:

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1076,7 +1076,6 @@ def _pipeline_begin_alignment(
 def _compute_pipeline_or_dma_extra_pad(
     begin_expr: str,
     bid: int,
-    env: CompileEnvironment,
     state: CodegenState,
 ) -> int:
     """Return extra host-side padding for a pipeline/DMA dim with a non-zero begin.
@@ -1097,6 +1096,28 @@ def _compute_pipeline_or_dma_extra_pad(
     if alignment is not None and alignment % bs_val == 0:
         return 0
     return bs_val - 1
+
+
+def _record_loop_pad(
+    state: CodegenState,
+    fake: torch.Tensor,
+    dim_idx: int,
+    bid: int,
+    begin_expr: str | None = None,
+) -> None:
+    """Record the host-side pad this dim's ``pl.ds`` slice needs.
+
+    ``begin_expr`` defaults to the enclosing loop's begin, which is what the
+    outer-dim branches want; an inner loop passes its own begin instead.  The
+    BlockSpec and DMA paths must agree here -- a dim padded on one path and not
+    the other reads off the end of the tensor.
+    """
+    from ...language.memory_ops import _record_pad_info
+
+    if begin_expr is None:
+        begin_expr = _active_loop_begin_expr(state, bid)
+    extra_pad = _compute_pipeline_or_dma_extra_pad(begin_expr, bid, state)
+    _record_pad_info(state, fake, dim_idx, bid, extra_pad)
 
 
 def _active_loop_begin_expr(state: CodegenState, block_id: int) -> str:
@@ -2341,12 +2362,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 slice_size_expr = slice_size_exprs[bid_idx]
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]
-                from ...language.memory_ops import _record_pad_info
-
-                extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
-                )
-                _record_pad_info(state, fake, dim_idx, bid, extra_pad)
+                _record_loop_pad(state, fake, dim_idx, bid, begin_expr)
                 begin_is_zero = begin_expr == "0"
                 end_expr = end_exprs[bid_idx]
                 dim_size = shape[dim_idx]
@@ -2422,12 +2438,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 bs_var = state.device_function.block_size_var(bid)
                 if bs_var:
                     block_shape_parts.append(bs_var)
-                    from ...language.memory_ops import _record_pad_info
-
-                    extra_pad = _compute_pipeline_or_dma_extra_pad(
-                        _active_loop_begin_expr(state, bid), bid, env, state
-                    )
-                    _record_pad_info(state, fake, dim_idx, bid, extra_pad)
+                    _record_loop_pad(state, fake, dim_idx, bid)
                 else:
                     block_shape_parts.append(str(int(shape[dim_idx])))
                 lambda_parts.append(pid_var)
@@ -2441,6 +2452,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 )
                 block_shape_parts.append(f"pl.BoundedSlice({block_m})")
                 lambda_parts.append(f"pl.ds({start_expr}, {block_m})")
+                _record_loop_pad(state, fake, dim_idx, bid)
             elif bid is not None and state.codegen.active_device_loops.get(bid):
                 # Outer non-grid device loop -- the HBM ref is pre-sliced via
                 # ``.at[pl.ds(offset, bs)]`` (see _make_hbm_slice), so the
@@ -3482,12 +3494,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                     vmem_parts.append(":")
                 hbm_parts.append(f"pl.ds({offset_expr}, {slice_size_expr})")
                 hbm_needs_slice = True
-                from ...language.memory_ops import _record_pad_info
-
-                extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
-                )
-                _record_pad_info(state, fake, dim_idx, bid, extra_pad)
+                _record_loop_pad(state, fake, dim_idx, bid, begin_expr)
             elif bid is not None and bid not in block_ids:
                 # Outer grid dim: use grid offset
                 grid_loops = state.codegen.active_device_loops.get(bid)
@@ -3497,12 +3504,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                     if bs_var:
                         hbm_parts.append(f"pl.ds({offset}, {bs_var})")
                         hbm_needs_slice = True
-                        from ...language.memory_ops import _record_pad_info
-
-                        extra_pad = _compute_pipeline_or_dma_extra_pad(
-                            _active_loop_begin_expr(state, bid), bid, env, state
-                        )
-                        _record_pad_info(state, fake, dim_idx, bid, extra_pad)
+                        _record_loop_pad(state, fake, dim_idx, bid)
                     else:
                         hbm_parts.append(":")
                 else:

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from ..tile_strategy import LoopDimInfo
     from ..tile_strategy import TileStrategy
     from .compact_worklist import ResidentPrepHoist
+    from .memory_access import MemoryAccess
 
 
 @_decorators.codegen(_not, "pallas")
@@ -557,6 +558,7 @@ def _emit_resident_prep_refill_once(
 
 LoopTensor = tuple[torch.Tensor, torch.fx.Node, tuple[object, ...]]
 LoopTensors = Mapping[int, LoopTensor]
+LoopAccesses = list["MemoryAccess"]
 
 
 def _classify_loop_tensors(
@@ -608,6 +610,61 @@ def _classify_loop_tensors(
                     stored_tensors[key] = (fake, tensor_node, sub_vals)
 
     return MappingProxyType(loaded_tensors), MappingProxyType(stored_tensors)
+
+
+def _graph_memory_accesses(graph_info: object) -> LoopAccesses:
+    """Every analyzed memory access directly in ``graph_info``."""
+    from .memory_access import MEMORY_ACCESS_META
+    from .memory_access import MemoryAccess
+
+    return [
+        access
+        for node in graph_info.graph.nodes  # type: ignore[union-attr]
+        if isinstance((access := node.meta.get(MEMORY_ACCESS_META)), MemoryAccess)
+    ]
+
+
+def _descendant_memory_accesses(
+    graph_info: object,
+    state: CodegenState,
+) -> LoopAccesses:
+    """Every memory access in control-flow graphs below ``graph_info``.
+
+    ``_classify_loop_tensors`` walks one graph and stops at nested control flow,
+    so a tile whose tensors are all sliced one graph deeper looks like it touches
+    nothing at all.  Alignment is not a per-graph question: a descendant slice
+    of an outer tile still lands wherever the outer loop's window put it.
+
+    DMA and BlockSpec plumbing must stay strictly per-loop, which is why this is
+    a separate walk rather than an option on ``_classify_loop_tensors``.
+    """
+    from ...language._tracing_ops import _while_loop
+    from ...language._tracing_ops import is_for_loop_target
+
+    accesses: LoopAccesses = []
+    seen: set[int] = set()
+    pending: list[object] = [graph_info]
+    while pending:
+        info = pending.pop()
+        for node in info.graph.nodes:  # type: ignore[union-attr]
+            if node.op != "call_function":
+                continue
+            if is_for_loop_target(node.target):
+                child_ids = node.args[:1]
+            elif node.target is _if:
+                child_ids = node.args[1:3]
+            elif node.target is _while_loop:
+                child_ids = (node.args[0], node.args[1], node.args[3])
+            else:
+                continue
+            for graph_id in child_ids:
+                if not isinstance(graph_id, int) or graph_id in seen:
+                    continue
+                seen.add(graph_id)
+                child = state.get_graph(graph_id)
+                accesses.extend(_graph_memory_accesses(child))
+                pending.append(child)
+    return accesses
 
 
 def _tensor_dim_subscripts(subscript_meta: Sequence[object]) -> list[object]:
@@ -2155,8 +2212,7 @@ def _aligned_dim(
     state: CodegenState,
     env: CompileEnvironment,
     block_ids: list[int],
-    loaded_tensors: LoopTensors,
-    stored_tensors: LoopTensors,
+    accesses: LoopAccesses,
 ) -> None:
     """Record jagged row tiles that read an aligned-enclosing window.
 
@@ -2167,9 +2223,14 @@ def _aligned_dim(
     A DIRECT row that does not carry is omitted: it reads at the exact offset.  S
     is the largest float-tensor sublane (bf16 forces 16); tiles that carry are
     also registered for the store fold/save.
+
+    ``accesses`` spans this loop and every loop nested inside it: a tile can
+    slice nothing itself and still owe its window an alignment or contain a
+    write, because the nested loop uses the offset this loop selected.
     """
     from .backend import SliceAddressing
     from .backend import _slice_addressing
+    from .memory_access import MemoryAccessKind
     from helion._compiler.pallas.ordered_carry import CarryBoundaryTile
     from helion._compiler.pallas.ordered_carry import is_row_map_axis
     from helion._compiler.pallas.ordered_carry import needs_ordered_carry
@@ -2184,35 +2245,43 @@ def _aligned_dim(
 
     # Strictest addressing each row needs over the tensors it slices.
     addressing: dict[int, SliceAddressing] = {}
-    stored_bids: set[int] = set()
-    for tensors, is_store in (
-        (loaded_tensors, False),
-        (stored_tensors, True),
-    ):
-        for fake, _node, sub_meta in tensors.values():
-            dim_to_bid = _get_dim_block_ids(sub_meta, env)
-            if is_store:
-                stored_bids.update(dim_to_bid.values())
-            if not (isinstance(fake, torch.Tensor) and fake.is_floating_point()):
-                continue
-            lane_block = _lane_tile(state, fake, dim_to_bid)
-            for dim, dim_bid in dim_to_bid.items():
-                access_addressing = _slice_addressing(fake, dim, lane_block)
-                if access_addressing is SliceAddressing.ALIGNED:
-                    addressing[dim_bid] = SliceAddressing.ALIGNED
-                else:
-                    addressing.setdefault(dim_bid, SliceAddressing.DIRECT)
+    written_bids: set[int] = set()
+    for access in accesses:
+        fake = access.tensor
+        dim_to_bid = {
+            dim: bid
+            for dim, pattern in enumerate(access.patterns)
+            if isinstance((bid := getattr(pattern, "block_id", None)), int)
+        }
+        if access.kind is not MemoryAccessKind.LOAD:
+            written_bids.update(dim_to_bid.values())
+        if not (isinstance(fake, torch.Tensor) and fake.is_floating_point()):
+            continue
+        lane_block = _lane_tile(state, fake, dim_to_bid)
+        for dim, dim_bid in dim_to_bid.items():
+            access_addressing = _slice_addressing(fake, dim, lane_block)
+            if access_addressing is SliceAddressing.ALIGNED:
+                addressing[dim_bid] = SliceAddressing.ALIGNED
+            else:
+                addressing.setdefault(dim_bid, SliceAddressing.DIRECT)
 
     sublane = max(sublanes)
     for i, bid in enumerate(block_ids):
         if not _loop_dim_is_dynamic(state, i):
             continue  # static begin or end: not a fully-dynamic jagged tile
         carry = needs_ordered_carry(state, bid)
-        direct = addressing.get(bid, SliceAddressing.ALIGNED) is SliceAddressing.DIRECT
-        if direct and not carry:
-            continue  # reads any offset; a plain clamped slice suffices
         if not carry:
-            if bid in stored_bids:
+            addr = addressing.get(bid)
+            if addr is None or addr is SliceAddressing.DIRECT:
+                # Nothing in or below this loop slices the dim (no window to
+                # align), or it reads at any offset and a clamped slice suffices.
+                continue
+            if bid in written_bids:
+                # Some access rounded the window begin down, so every store on
+                # this dim would write the head rows [aligned_begin, begin),
+                # regardless of whether the store itself is DIRECT or ALIGNED.
+                # TODO(cota): Support a separate DIRECT store window that starts
+                # at begin, crops the value's aligned head, and clamps at end.
                 raise NotImplementedError(
                     "Pallas: a jagged row tile whose slices must be "
                     "sublane-aligned and that is written through its row dim is "
@@ -2271,7 +2340,15 @@ def _plan_inner_loop_window(
     rejects ordered carry explicitly rather than assembling a partial window.
     """
     loaded, stored = _classify_loop_tensors(graph_info, state)
-    _aligned_dim(state, env, block_ids, loaded, stored)
+    _aligned_dim(
+        state,
+        env,
+        block_ids,
+        [
+            *_graph_memory_accesses(graph_info),
+            *_descendant_memory_accesses(graph_info, state),
+        ],
+    )
     grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
     (
         begin_exprs,

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -9,9 +9,12 @@ the same eager timing as before.
 from __future__ import annotations
 
 import ast
+from collections.abc import Mapping
 import contextlib
+import dataclasses
 import logging
 import operator
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 from typing import cast
 
@@ -552,13 +555,14 @@ def _emit_resident_prep_refill_once(
     state.codegen.grouped_resident_prep_refill_cache[refill_key] = "emitted"
 
 
+LoopTensor = tuple[torch.Tensor, torch.fx.Node, tuple[object, ...]]
+LoopTensors = Mapping[int, LoopTensor]
+
+
 def _classify_loop_tensors(
     graph_info: object,
     state: object,
-) -> tuple[
-    dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-]:
+) -> tuple[LoopTensors, LoopTensors]:
     """Classify tensors accessed in an inner loop body into loaded/stored.
 
     Returns (loaded_tensors, stored_tensors) dicts keyed by id(fake_tensor).
@@ -572,8 +576,8 @@ def _classify_loop_tensors(
             if "val" in node.meta and isinstance(node.meta["val"], torch.Tensor):
                 host_tensor_nodes[node] = node.meta["val"]
 
-    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]] = {}
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]] = {}
+    loaded_tensors: dict[int, LoopTensor] = {}
+    stored_tensors: dict[int, LoopTensor] = {}
 
     for node in graph_info.graph.nodes:  # type: ignore[union-attr]
         if node.op != "call_function":
@@ -588,7 +592,7 @@ def _classify_loop_tensors(
                 fake = host_tensor_nodes[tensor_node]
                 key = id(fake)
                 if key not in loaded_tensors:
-                    sub_vals = _extract_subscript_vals(subscript)
+                    sub_vals = tuple(_extract_subscript_vals(subscript))
                     loaded_tensors[key] = (fake, tensor_node, sub_vals)
         elif node.target is _store_op:
             tensor_node = node.args[0]
@@ -600,13 +604,13 @@ def _classify_loop_tensors(
                 fake = host_tensor_nodes[tensor_node]
                 key = id(fake)
                 if key not in stored_tensors:
-                    sub_vals = _extract_subscript_vals(subscript)
+                    sub_vals = tuple(_extract_subscript_vals(subscript))
                     stored_tensors[key] = (fake, tensor_node, sub_vals)
 
-    return loaded_tensors, stored_tensors
+    return MappingProxyType(loaded_tensors), MappingProxyType(stored_tensors)
 
 
-def _tensor_dim_subscripts(subscript_meta: list[object]) -> list[object]:
+def _tensor_dim_subscripts(subscript_meta: Sequence[object]) -> list[object]:
     """Drop rank-expanding ``None`` entries from a tensor subscript."""
     return [index for index in subscript_meta if index is not None]
 
@@ -616,7 +620,7 @@ def _subscript_at_dim(subscripts: list[object], dim: int) -> object:
 
 
 def _get_dim_block_ids(
-    subscript_meta: list[object],
+    subscript_meta: Sequence[object],
     env: CompileEnvironment,
 ) -> dict[int, int]:
     """Map tensor dimension index -> block_id from subscript metadata."""
@@ -980,10 +984,9 @@ def _compute_grid_and_block_sizes(
     state: CodegenState,
     block_ids: list[int],
     env: CompileEnvironment,
-    aligned_dim: dict[int, int] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Compute grid dimensions and block size vars for the given block_ids."""
-    aligned_dim = aligned_dim or {}
+    aligned_tiles = state.device_function.aligned_tiles
     grid_parts: list[str] = []
     block_size_vars: list[str] = []
     for i, block_id in enumerate(block_ids):
@@ -993,10 +996,10 @@ def _compute_grid_and_block_sizes(
         block_value = state.device_function.resolved_block_size(block_id)
         if block_value is not None:
             state.device_function.constexpr_arg(block_size_var, block_value)
-        if block_id in aligned_dim:
+        if block_id in aligned_tiles:
             # Aligned-enclosing span: ceil(end/S)*S - floor(begin/S)*S.
             begin, end = _get_loop_begin_and_end(state, i)
-            sublane = aligned_dim[block_id]
+            sublane = aligned_tiles[block_id]
             a_start = f"(({begin}) - ({begin}) % {sublane})"
             a_end = f"((({end}) + {sublane} - 1) // {sublane} * {sublane})"
             numel_expr = f"({a_end} - {a_start})"
@@ -1012,10 +1015,9 @@ def _pallas_loop_begin_and_step_exprs(
     state: CodegenState,
     block_ids: list[int],
     block_size_vars: list[str],
-    aligned_dim: dict[int, int] | None = None,
-) -> tuple[list[str], list[str], list[str]]:
+) -> tuple[list[str], list[str], list[str], list[bool]]:
     """Return begin, per-iteration step, and slice-size expressions for loop dims."""
-    aligned_dim = aligned_dim or {}
+    aligned_tiles = state.device_function.aligned_tiles
     steps = state.proxy_arg(4) if len(state.proxy_args) > 4 else None
 
     if not isinstance(steps, (list, tuple)):
@@ -1024,13 +1026,14 @@ def _pallas_loop_begin_and_step_exprs(
     begin_exprs: list[str] = []
     iter_step_exprs: list[str] = []
     slice_size_exprs: list[str] = []
+    steps_by_block: list[bool] = []
 
     for i in range(len(block_ids)):
         step = steps[i]
         begin_expr, _ = _get_loop_begin_and_end(state, i)
-        if block_ids[i] in aligned_dim:
+        if block_ids[i] in aligned_tiles:
             # Align the tile begin DOWN to the sublane (aligned-enclosing).
-            sublane = aligned_dim[block_ids[i]]
+            sublane = aligned_tiles[block_ids[i]]
             begin_expr = f"(({begin_expr}) - ({begin_expr}) % {sublane})"
         if step is None or sympy.sympify(step) in (
             sympy.Integer(0),
@@ -1038,14 +1041,17 @@ def _pallas_loop_begin_and_step_exprs(
         ):
             iter_step_expr = block_size_vars[i]
             slice_size_expr = block_size_vars[i]
+            step_is_block = True
         else:
             iter_step_expr = state.sympy_expr(sympy.sympify(step))
             slice_size_expr = "1"
+            step_is_block = False
         begin_exprs.append(begin_expr)
         iter_step_exprs.append(iter_step_expr)
         slice_size_exprs.append(slice_size_expr)
+        steps_by_block.append(step_is_block)
 
-    return begin_exprs, iter_step_exprs, slice_size_exprs
+    return begin_exprs, iter_step_exprs, slice_size_exprs, steps_by_block
 
 
 def _pipeline_begin_alignment(
@@ -1326,10 +1332,10 @@ def _emit_inner_loop_offset_indices(
     state: CodegenState,
     strategy: object,
     block_ids: list[int],
-    block_size_vars: list[str],
-    begin_exprs: list[str],
-    iter_step_exprs: list[str],
-    loop_index_exprs: list[str],
+    block_size_vars: Sequence[str],
+    begin_exprs: Sequence[str],
+    iter_step_exprs: Sequence[str],
+    loop_index_exprs: Sequence[str],
     env: CompileEnvironment,
     body_stmts: list[ast.AST],
 ) -> None:
@@ -1369,11 +1375,10 @@ def _setup_inner_loop_masks(
     state: CodegenState,
     strategy: object,
     block_ids: list[int],
-    block_size_vars: list[str],
+    block_size_vars: Sequence[str],
     env: CompileEnvironment,
     body_stmts: list[ast.AST],
     offset_expr_fn: Callable[[int, str], str],
-    aligned_dim: dict[int, int] | None = None,
 ) -> bool:
     """Set up mask variables for inner-loop block_ids.
 
@@ -1383,16 +1388,16 @@ def _setup_inner_loop_masks(
 
     Returns True if any mask requires explicit indices.
     """
-    aligned_dim = aligned_dim or {}
+    aligned_tiles = state.device_function.aligned_tiles
     needs_explicit = False
     if hasattr(strategy, "_setup_mask"):
         for i, bid in enumerate(block_ids):
             offset_var = state.device_function.new_var(f"offset_{bid}")
-            if bid in aligned_dim:
+            if bid in aligned_tiles:
                 # Two-sided validity mask for an aligned-enclosing dynamic row
                 # tile: the load over-reads [a_start, begin) and [end, a_end), so
                 # mask both ends.  The relative offset is measured from a_start.
-                sublane = aligned_dim[bid]
+                sublane = aligned_tiles[bid]
                 begin, end = _get_loop_begin_and_end(state, i)
                 a_start = f"(({begin}) - ({begin}) % {sublane})"
                 mask_var = strategy.fn.new_var(f"mask_{bid}", dce=True)  # pyrefly: ignore[missing-attribute]
@@ -2150,12 +2155,13 @@ def _aligned_dim(
     state: CodegenState,
     env: CompileEnvironment,
     block_ids: list[int],
-    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-) -> dict[int, int]:
-    """Jagged row tiles (runtime end) that read an aligned-enclosing window.
+    loaded_tensors: LoopTensors,
+    stored_tensors: LoopTensors,
+) -> None:
+    """Record jagged row tiles that read an aligned-enclosing window.
 
-    Maps each to the sublane S its range rounds down to.  A row aligns when a
+    ``device_function.aligned_tiles`` is the single source of truth, mapping each
+    aligned block id to the sublane S its range rounds down to. A row aligns when a
     tensor it slices must land on a sublane tile (bf16, or f32 spanning more than
     one lane tile), or when a per-row map store carries its shared boundary.
     A DIRECT row that does not carry is omitted: it reads at the exact offset.  S
@@ -2174,7 +2180,7 @@ def _aligned_dim(
         if isinstance(t, torch.Tensor) and t.is_floating_point()
     ]
     if not sublanes:
-        return {}
+        return
 
     # Strictest addressing each row needs over the tensors it slices.
     addressing: dict[int, SliceAddressing] = {}
@@ -2198,7 +2204,6 @@ def _aligned_dim(
                     addressing.setdefault(dim_bid, SliceAddressing.DIRECT)
 
     sublane = max(sublanes)
-    aligned_dim: dict[int, int] = {}
     for i, bid in enumerate(block_ids):
         if not _loop_dim_is_dynamic(state, i):
             continue  # static begin or end: not a fully-dynamic jagged tile
@@ -2221,7 +2226,6 @@ def _aligned_dim(
                     "Pallas: bf16 reduction over a jagged row is not supported yet "
                     "(its dense bf16 output store cannot be proven sublane-aligned)."
                 )
-        aligned_dim[bid] = sublane
         state.device_function.aligned_tiles[bid] = sublane
         if carry:
             begin, end = _get_loop_begin_and_end(state, i)
@@ -2231,7 +2235,63 @@ def _aligned_dim(
                 end_var=end,
                 sublane=sublane,
             )
-    return aligned_dim
+
+
+@dataclasses.dataclass(frozen=True)
+class InnerLoopWindow:
+    """The iteration window an inner tile loop generates code against.
+
+    The expressions below are one decision, not independent lists: an aligned
+    jagged window must use the same grid extent, begin, step, slice size, and
+    logical end. All collections are immutable so a lowering cannot rewrite the
+    shared plan while preparing DMA state.
+    """
+
+    loaded: LoopTensors
+    stored: LoopTensors
+    grid_parts: tuple[str, ...]
+    block_size_vars: tuple[str, ...]
+    begin_exprs: tuple[str, ...]
+    iter_step_exprs: tuple[str, ...]
+    slice_size_exprs: tuple[str, ...]
+    end_exprs: tuple[str, ...]
+    steps_by_block: tuple[bool, ...]
+
+
+def _plan_inner_loop_window(
+    state: CodegenState,
+    graph_info: object,
+    block_ids: list[int],
+    env: CompileEnvironment,
+) -> InnerLoopWindow:
+    """Build the window ``_codegen_emit_pipeline`` and ``_codegen_fori_loop`` share.
+
+    Compact-worklist dispatch handles supported data-dependent ``unroll``
+    configurations before the streaming paths. The ordinary dynamic-unroll path
+    rejects ordered carry explicitly rather than assembling a partial window.
+    """
+    loaded, stored = _classify_loop_tensors(graph_info, state)
+    _aligned_dim(state, env, block_ids, loaded, stored)
+    grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
+    (
+        begin_exprs,
+        iter_step_exprs,
+        slice_size_exprs,
+        steps_by_block,
+    ) = _pallas_loop_begin_and_step_exprs(state, block_ids, block_size_vars)
+    return InnerLoopWindow(
+        loaded=loaded,
+        stored=stored,
+        grid_parts=tuple(grid_parts),
+        block_size_vars=tuple(block_size_vars),
+        begin_exprs=tuple(begin_exprs),
+        iter_step_exprs=tuple(iter_step_exprs),
+        slice_size_exprs=tuple(slice_size_exprs),
+        end_exprs=tuple(
+            _get_loop_begin_and_end(state, i)[1] for i in range(len(block_ids))
+        ),
+        steps_by_block=tuple(steps_by_block),
+    )
 
 
 def _annotate_provable_sublane_alignment(
@@ -2285,24 +2345,18 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     assert isinstance(proxy_args, list)
     has_loop_state = len(args) > 0
 
-    loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
-
-    aligned_dim = _aligned_dim(state, env, block_ids, loaded_tensors, stored_tensors)
-
-    grid_parts, block_size_vars = _compute_grid_and_block_sizes(
-        state, block_ids, env, aligned_dim
-    )
-    begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
-        state, block_ids, block_size_vars, aligned_dim
-    )
-    # Loop end expressions (used to clamp store extents for data-dependent begins).
-    end_exprs = [_get_loop_begin_and_end(state, i)[1] for i in range(len(block_ids))]
+    window = _plan_inner_loop_window(state, graph_info, block_ids, env)
 
     # Pipelined tensors flow through emit_pipeline's per-iter Buffered
     # BlockSpec; the rest stay on the outer pallas_call BlockSpec
     # (escape clause `bs == as`) and are closure-read from the body.
     all_tensor_info, _vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
-        loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
+        window.loaded,
+        window.stored,
+        block_ids,
+        window.slice_size_exprs,
+        env,
+        state,
     )
 
     # Build in_specs and out_specs
@@ -2333,7 +2387,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             _bid_to_pid_var[pid.block_id] = pid_var
 
     def _make_block_spec(
-        fake: torch.Tensor, subscript_meta: list[object], is_store: bool = False
+        fake: torch.Tensor, subscript_meta: Sequence[object], is_store: bool = False
     ) -> str:
         """Build a BlockSpec string for a tensor accessed in the pipeline body.
 
@@ -2359,12 +2413,12 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             if bid is not None and bid in block_ids:
                 # Inner pipeline dim -- tiled by pipeline grid
                 bid_idx = block_ids.index(bid)
-                slice_size_expr = slice_size_exprs[bid_idx]
-                begin_expr = begin_exprs[bid_idx]
-                iter_step_expr = iter_step_exprs[bid_idx]
+                slice_size_expr = window.slice_size_exprs[bid_idx]
+                begin_expr = window.begin_exprs[bid_idx]
+                iter_step_expr = window.iter_step_exprs[bid_idx]
                 _record_loop_pad(state, fake, dim_idx, bid, begin_expr)
                 begin_is_zero = begin_expr == "0"
-                end_expr = end_exprs[bid_idx]
+                end_expr = window.end_exprs[bid_idx]
                 dim_size = shape[dim_idx]
                 # Whether this loop spans the ENTIRE backing tensor dim, i.e.
                 # ``[0, dim_size)`` with a compile-time-constant extent. Only
@@ -2410,17 +2464,14 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                         # unowned rows is safely handled by the ordered carry logic.
                         size_expr = (
                             f"jnp.minimum({slice_size_expr}, "
-                            f"({end_exprs[bid_idx]}) - ({start_expr}))"
+                            f"({window.end_exprs[bid_idx]}) - ({start_expr}))"
                         )
                     else:
                         size_expr = slice_size_expr
-                    # Carried tiles are aligned tiles, so this covers them too.
-                    start_expr = _annotate_provable_sublane_alignment(
-                        state,
-                        bid,
-                        start_expr,
-                        steps_by_block=iter_step_expr == block_size_vars[bid_idx],
-                    )
+                    if window.steps_by_block[bid_idx]:
+                        start_expr = _annotate_provable_sublane_alignment(
+                            state, bid, start_expr
+                        )
                     lambda_parts.append(f"pl.ds({start_expr}, {size_expr})")
                 else:
                     # Static, from-zero loop: a block-aligned index is exact.
@@ -2490,16 +2541,20 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             f"pipeline_mode=pl.Buffered(buffer_count=2))"
         )
 
-    def _make_load_block_spec(fake: torch.Tensor, subscript_meta: list[object]) -> str:
+    def _make_load_block_spec(
+        fake: torch.Tensor, subscript_meta: Sequence[object]
+    ) -> str:
         """BlockSpec for a pipelined input (full-block ``pl.ds``; mask zeroes over-read)."""
         return _make_block_spec(fake, subscript_meta, is_store=False)
 
-    def _make_store_block_spec(fake: torch.Tensor, subscript_meta: list[object]) -> str:
+    def _make_store_block_spec(
+        fake: torch.Tensor, subscript_meta: Sequence[object]
+    ) -> str:
         """BlockSpec for a pipelined output (clamped ``pl.ds`` extent on dynamic bounds)."""
         return _make_block_spec(fake, subscript_meta, is_store=True)
 
     def _make_hbm_slice(
-        fake: torch.Tensor, hbm_name: str, subscript_meta: list[object]
+        fake: torch.Tensor, hbm_name: str, subscript_meta: Sequence[object]
     ) -> str:
         """Slice the HBM ref for outer non-grid device loop dims.
 
@@ -2566,15 +2621,15 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
 
     from ..device_function import PallasMemorySpace
 
-    for fake, _tensor_node, _sub_meta in loaded_tensors.values():
+    for fake, _tensor_node, _sub_meta in window.loaded.values():
         if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
-    for fake, _tensor_node, _sub_meta in stored_tensors.values():
+    for fake, _tensor_node, _sub_meta in window.stored.values():
         if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
 
-    for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
-        if key in stored_tensors:
+    for key, (fake, _tensor_node, sub_meta) in window.loaded.items():
+        if key in window.stored:
             continue  # Handle as output instead
         if id(fake) not in pipelined_tensor_ids:
             continue
@@ -2587,7 +2642,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         body_params.append(vmem_name)
         pipeline_in_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
 
-    for fake, _tensor_node, sub_meta in stored_tensors.values():
+    for fake, _tensor_node, sub_meta in window.stored.values():
         if id(fake) not in pipelined_tensor_ids:
             continue
         hbm_name = state.device_function.tensor_arg(fake).name
@@ -2623,9 +2678,9 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         state,
         strategy,
         block_ids,
-        block_size_vars,
-        begin_exprs,
-        iter_step_exprs,
+        window.block_size_vars,
+        window.begin_exprs,
+        window.iter_step_exprs,
         [f"_helion_compat_pipeline_indices[{i}]" for i in range(len(block_ids))],
         env,
         body_stmts,
@@ -2635,14 +2690,13 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         state,
         strategy,
         block_ids,
-        block_size_vars,
+        window.block_size_vars,
         env,
         body_stmts,
         # emit_pipeline passes indices as a single tuple arg
         offset_expr_fn=lambda i, bs: (
             f"_helion_compat_pipeline_indices[{i}] * {bs} + jnp.arange({bs})"
         ),
-        aligned_dim=aligned_dim,
     )
 
     # Emit absolute offset assignments inside the pipeline body so any
@@ -2669,8 +2723,9 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             offset_name = strategy.offset_var(bid)
             body_stmts.append(
                 statement_from_string(
-                    f"{offset_name} = ({begin_exprs[i]}) + "
-                    f"(_helion_compat_pipeline_indices[{i}]) * ({iter_step_exprs[i]})"
+                    f"{offset_name} = ({window.begin_exprs[i]}) + "
+                    f"(_helion_compat_pipeline_indices[{i}]) * "
+                    f"({window.iter_step_exprs[i]})"
                 )
             )
 
@@ -2721,7 +2776,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     fn_def.body = body_stmts or [ast.Pass()]  # pyrefly: ignore[bad-assignment]
 
     # Build the emit_pipeline call
-    grid_str = ", ".join(grid_parts)
+    grid_str = ", ".join(window.grid_parts)
     in_specs_str = ", ".join(in_specs) if in_specs else ""
     out_specs_str = ", ".join(out_specs) if out_specs else ""
 
@@ -2778,7 +2833,7 @@ def _check_dma_alignment(vmem_shape: tuple[int, ...]) -> bool:
 
 def _is_supported_contiguous_row_slab_dma(
     fake: torch.Tensor,
-    sub_meta: list[object],
+    sub_meta: Sequence[object],
     block_ids: list[int],
     vmem_shape: tuple[int, ...],
     env: CompileEnvironment,
@@ -2844,7 +2899,7 @@ def _is_supported_contiguous_row_slab_dma(
 
 def _can_stream_inner_tile(
     fake: torch.Tensor,
-    sub_meta: list[object],
+    sub_meta: Sequence[object],
     direction: str,
     block_ids: list[int],
     vmem_shape: tuple[int, ...],
@@ -2862,9 +2917,9 @@ def _can_stream_inner_tile(
 
 
 def _compute_vmem_shapes(
-    all_tensor_info: list[tuple[torch.Tensor, list[object], str]],
+    all_tensor_info: Sequence[tuple[torch.Tensor, tuple[object, ...], str]],
     block_ids: list[int],
-    slice_size_exprs: list[str],
+    slice_size_exprs: Sequence[str],
     env: CompileEnvironment,
     state: CodegenState,
 ) -> list[tuple[int, ...]]:
@@ -2932,14 +2987,16 @@ def _runtime_vmem_shape_sources(
 
 
 def _classify_pipelined_tensors(
-    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    loaded_tensors: LoopTensors,
+    stored_tensors: LoopTensors,
     block_ids: list[int],
-    slice_size_exprs: list[str],
+    slice_size_exprs: Sequence[str],
     env: CompileEnvironment,
     state: CodegenState,
 ) -> tuple[
-    list[tuple[torch.Tensor, list[object], str]], list[tuple[int, ...]], set[int]
+    list[tuple[torch.Tensor, tuple[object, ...], str]],
+    list[tuple[int, ...]],
+    set[int],
 ]:
     """Build (all_tensor_info, vmem_shapes, pipelined_ids) for an inner loop.
 
@@ -3030,9 +3087,9 @@ def _classify_pipelined_tensors(
 
 
 def _resident_loop_tensor_info(
-    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-) -> list[tuple[torch.Tensor, list[object], str]]:
+    loaded_tensors: LoopTensors,
+    stored_tensors: LoopTensors,
+) -> list[tuple[torch.Tensor, tuple[object, ...], str]]:
     """Tensor access records needed by optional resident prep lowering."""
     result = [
         (fake, sub_meta, "load")
@@ -3061,6 +3118,13 @@ def _codegen_dynamic_unroll(state: CodegenState) -> object:
         raise InvalidConfig(
             "dynamic pallas unroll currently supports one inner tile dimension"
         )
+    from helion._compiler.pallas.ordered_carry import needs_ordered_carry
+
+    if any(needs_ordered_carry(state, bid) for bid in block_ids):
+        raise InvalidConfig(
+            "pallas_loop_type='unroll' does not support ordered carry; use "
+            "'fori_loop' or 'emit_pipeline'"
+        )
 
     args = state.ast_args[-1]
     assert isinstance(args, list)
@@ -3068,7 +3132,7 @@ def _codegen_dynamic_unroll(state: CodegenState) -> object:
 
     env = CompileEnvironment.current()
     grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
-    begin_exprs, iter_step_exprs, _ = _pallas_loop_begin_and_step_exprs(
+    begin_exprs, iter_step_exprs, _, _ = _pallas_loop_begin_and_step_exprs(
         state, block_ids, block_size_vars
     )
     strategy = _find_strategy(state, block_ids)
@@ -3201,9 +3265,12 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
 
     loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
-    begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
-        state, block_ids, block_size_vars
-    )
+    (
+        begin_exprs,
+        iter_step_exprs,
+        slice_size_exprs,
+        _,
+    ) = _pallas_loop_begin_and_step_exprs(state, block_ids, block_size_vars)
 
     # --- Handle loop-carried state as scratch VMEM buffers ---
     scratch_names: list[str] = []
@@ -3234,7 +3301,12 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     # non-pipelined tensor is present (which would load full outer-block
     # tiles into VMEM and may OOM at large shapes).
     all_tensor_info, vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
-        loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
+        loaded_tensors,
+        stored_tensors,
+        block_ids,
+        slice_size_exprs,
+        env,
+        state,
     )
 
     # Compact worklist: the compact-tile aligned_load and exact_store tensors use
@@ -3285,7 +3357,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     tensor_to_dma_scratch: dict[str, str] = {}
     tensor_to_sem: dict[str, str] = {}
     prefetched_load_tensors: set[str] = set()
-    prefetched_loads: list[tuple[torch.Tensor, list[object], str, str]] = []
+    prefetched_loads: list[tuple[torch.Tensor, tuple[object, ...], str, str]] = []
     # compact_worklist shares this lowering but keeps its compact/resident routes;
     # only an actual fori_loop config enables depth-two staging.
     load_buffer_counts_active = state.config.get("pallas_loop_type") == "fori_loop"
@@ -3438,7 +3510,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         fake: torch.Tensor,
         vmem_name: str,
         hbm_name: str,
-        subscript_meta: list[object],
+        subscript_meta: Sequence[object],
         *,
         clamp: bool,
         iteration_indices: list[str],
@@ -3537,7 +3609,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
 
     def _dma_copy_statements(
         fake: torch.Tensor,
-        sub_meta: list[object],
+        sub_meta: Sequence[object],
         vmem_name: str,
         sem_name: str,
         iteration_indices: list[str],
@@ -3640,7 +3712,8 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                 offset_name = strategy.offset_var(bid)
                 state.codegen.add_statement(
                     statement_from_string(
-                        f"{offset_name} = ({begin_exprs[i]}) + ({dim_idx_exprs[i]}) * ({iter_step_exprs[i]})"
+                        f"{offset_name} = ({begin_exprs[i]}) + "
+                        f"({dim_idx_exprs[i]}) * ({iter_step_exprs[i]})"
                     )
                 )
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -5004,6 +5004,37 @@ class TestPallas(TestCase):
         self.assertIn("_hbm_arg_indices=", code)
         torch.testing.assert_close(result, x * r)
 
+    def test_nested_pipeline_blockspec_records_dynamic_row_padding(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def nested_pipeline_copy(
+            offsets: torch.Tensor, x: torch.Tensor
+        ) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty_like(x)
+            for group in hl.grid(offsets.size(0) - 1):
+                begin = offsets[group]
+                end = offsets[group + 1]
+                for tile_m in hl.tile(begin, end):
+                    for tile_n in hl.tile(n):
+                        out[tile_m, tile_n] = x[tile_m, tile_n] * 2
+            return out
+
+        offsets = torch.tensor([0, 13, 25], device=DEVICE, dtype=torch.int32)
+        x = torch.randn(25, 128, device=DEVICE, dtype=torch.bfloat16)
+        code = nested_pipeline_copy.bind((offsets, x)).to_code(
+            helion.Config(
+                block_sizes=[16, 128],
+                pallas_loop_type="emit_pipeline",
+            )
+        )
+        match = re.search(r"_ds_pad_dims=(\[[^\]]*\])", code)
+        self.assertIsNotNone(match, "expected _ds_pad_dims in the launcher call")
+        pad_dims = ast.literal_eval(match.group(1))
+        # Both the input and output row dims are sliced only by the nested
+        # pipeline BlockSpec. A dynamic begin requires block_size - 1 extra rows.
+        self.assertIn((1, 0, 16, 15), pad_dims)
+        self.assertIn((2, 0, 16, 15), pad_dims)
+
     def test_pipeline_begin_aligned_skips_pad(self) -> None:
         # A block-aligned inner begin (the outer tile's offset) needs no boundary
         # pad, so _ds_pad_dims must report extra_pad == 0 rather than block_size-1.

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -17,6 +17,7 @@ from torch.testing._internal.common_utils import instantiate_parametrized_tests
 from torch.testing._internal.common_utils import parametrize
 
 import helion
+from helion import exc
 from helion._testing import DEVICE
 from helion._testing import TestCase
 from helion._testing import _bound_test_config
@@ -4848,6 +4849,25 @@ class TestPallas(TestCase):
         self.assertIn("def _dynamic_unroll_body", code)
         self.assertNotIn("pltpu.make_async_copy", code)
         torch.testing.assert_close(result, x * r)
+
+    def test_dynamic_unroll_rejects_ordered_carry(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def dependent_row_map(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty_like(x)
+            for mb_cta in hl.tile(m, block_size=8):
+                for mb in hl.tile(mb_cta.begin, mb_cta.end):
+                    for nb in hl.tile(n):
+                        out[mb, nb] = x[mb, nb] * 2
+            return out
+
+        x = torch.randn(16, 128, dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InvalidConfig, "does not support ordered carry"
+        ):
+            dependent_row_map.bind((x,)).to_triton_code(
+                helion.Config(block_sizes=[8, 128], pallas_loop_type="unroll")
+            )
 
     def test_dependent_tile_end_composes_with_streaming_loop_types(self) -> None:
         x = torch.randn(192, 192, device=DEVICE, dtype=torch.float32)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -5980,7 +5980,10 @@ class TestPallas(TestCase):
         H, D = 4, 16
         offsets = torch.tensor([0, 10], device=DEVICE, dtype=torch.int32)
         torch.manual_seed(0)
-        y = torch.randn(H, 10, D, device=DEVICE, dtype=torch.bfloat16)
+        # Keep this mask-placement test directly addressable. A bf16 load
+        # would need a rounded-down window, and the major-dim output store
+        # cannot carry its head rows, so this commit rejects that shape.
+        y = torch.randn(H, 10, D, device=DEVICE, dtype=torch.float32)
 
         code, out = code_and_output(
             opposite,

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -11,7 +11,6 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipUnlessPallas
-from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
 import helion.language as hl
@@ -379,14 +378,10 @@ class TestPallasJaggedCarryBmm(TestCase):
 class TestPallasJaggedCarryRejects(TestCase):
     """Shapes the carry refuses (or routes elsewhere) rather than miscompiling."""
 
-    @xfailIfPallas(
-        "bf16 reduction over a jagged row falls through to the f32-only existing "
-        "path; the unaligned bf16 load can't compile yet"
-    )
     def test_jagged_reduction_over_row_bf16(self) -> None:
-        # A reduction over the jagged row (summed to a dense output) is not the
-        # carry's shape, so it falls through to the existing path.  That path is
-        # f32-only, so the bf16 case can't compile yet; the xfail tracks the gap.
+        # A reduction over the jagged row (summed to a dense output) writes
+        # nothing through that row, so its aligned window needs no carry and
+        # the over-read rows are masked away before the sum.
         @helion.kernel(backend="pallas")
         def jagged_row_sum(
             seq_offsets: torch.Tensor, jagged: torch.Tensor

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -437,15 +437,35 @@ class TestPallasJaggedCarryBmm(TestCase):
         torch.testing.assert_close(out, jagged * 2)
 
 
+def _ref_jagged_row_sum(seq_offsets: torch.Tensor, jagged: torch.Tensor):
+    ref = torch.zeros(
+        (seq_offsets.numel() - 1, jagged.shape[1]),
+        dtype=torch.float32,
+        device=jagged.device,
+    )
+    for g in range(ref.shape[0]):
+        s, e = int(seq_offsets[g]), int(seq_offsets[g + 1])
+        ref[g] = jagged[s:e].float().sum(0)
+    return ref
+
+
 @onlyBackends(["pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
-class TestPallasJaggedCarryRejects(TestCase):
-    """Shapes the carry refuses (or routes elsewhere) rather than miscompiling."""
+class TestPallasJaggedAlignedWindow(TestCase):
+    """Jagged rows summed away: an aligned window is needed, a carry is not.
 
-    def test_jagged_reduction_over_row_bf16(self) -> None:
-        # A reduction over the jagged row (summed to a dense output) writes
-        # nothing through that row, so its aligned window needs no carry and
-        # the over-read rows are masked away before the sum.
+    Nothing is stored through the row, so rounding its window out to the sublane
+    tile only over-READS and the two-sided mask zeroes the rows the group does
+    not own -- no boundary is shared, so no carry applies.  bf16 makes the
+    alignment mandatory (Mosaic rejects an unaligned tiled offset); group 0 ends
+    at 13, so group 1 starts mid-tile and the rounding really happens.
+
+    Both loop orders run the same reduction: the demand for an aligned window
+    belongs to the tile, not to whichever loop happens to slice it.
+    """
+
+    def _check_row_sum(self, dtype: torch.dtype, loop_type: str) -> None:
+        # The jagged loop is innermost and slices the tensor itself.
         @helion.kernel(backend="pallas")
         def jagged_row_sum(
             seq_offsets: torch.Tensor, jagged: torch.Tensor
@@ -463,18 +483,146 @@ class TestPallasJaggedCarryRejects(TestCase):
                     out[g, dt] = acc
             return out
 
-        seq_offsets = torch.tensor([0, 13, 25], dtype=torch.int32, device=DEVICE)
-        jagged = torch.randn((25, 128), dtype=torch.bfloat16, device=DEVICE)
-        _code, out = code_and_output(
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32, device=DEVICE)
+        jagged = torch.randn((32, 128), dtype=dtype, device=DEVICE)
+        code, out = code_and_output(
             jagged_row_sum,
             (seq_offsets, jagged),
             block_sizes=[128, 16],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
-        ref = torch.zeros(2, 128, device=DEVICE)
-        ref[0] = jagged[0:13].float().sum(0)
-        ref[1] = jagged[13:25].float().sum(0)
-        torch.testing.assert_close(out, ref)
+        self.assertIn(_LOOP_MARKER[loop_type], code)
+        torch.testing.assert_close(
+            out, _ref_jagged_row_sum(seq_offsets, jagged), rtol=1e-2, atol=1e-2
+        )
+
+    def _check_col_accum(self, dtype: torch.dtype, loop_type: str) -> None:
+        # Same reduction, loops swapped: the jagged loop is now the OUTER one and
+        # slices nothing itself -- every access lives in the nested column loop.
+        # Its window still has to be aligned, which it can only learn by looking
+        # through the nested loop.
+        @helion.kernel(backend="pallas")
+        def jagged_col_accum(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor, out: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    for dt in hl.tile(0, D):
+                        rows = jagged[st, dt].to(torch.float32)
+                        out[g, dt] = out[g, dt] + rows.sum(0)
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32, device=DEVICE)
+        jagged = torch.randn((32, 128), dtype=dtype, device=DEVICE)
+        out = torch.zeros((2, 128), dtype=torch.float32, device=DEVICE)
+        code, result = code_and_output(
+            jagged_col_accum,
+            (seq_offsets, jagged, out),
+            block_sizes=[16, 128],
+            pallas_loop_type=loop_type,
+        )
+        self.assertIn(_LOOP_MARKER[loop_type], code)
+        torch.testing.assert_close(
+            result, _ref_jagged_row_sum(seq_offsets, jagged), rtol=1e-2, atol=1e-2
+        )
+
+    def _check_conditional_col_accum(self, loop_type: str) -> None:
+        # The access is two control-flow graphs below the jagged loop: inside an
+        # if branch and then a nested column loop.  Alignment demand must cross
+        # both edges.
+        @helion.kernel(backend="pallas")
+        def jagged_conditional_accum(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor, out: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    if e - s > 8:
+                        for dt in hl.tile(0, D):
+                            rows = jagged[st, dt].to(torch.float32)
+                            out[g, dt] = out[g, dt] + rows.sum(0)
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32, device=DEVICE)
+        jagged = torch.randn((32, 128), dtype=torch.bfloat16, device=DEVICE)
+        out = torch.zeros((2, 128), dtype=torch.float32, device=DEVICE)
+        code, result = code_and_output(
+            jagged_conditional_accum,
+            (seq_offsets, jagged, out),
+            block_sizes=[16, 128],
+            pallas_loop_type=loop_type,
+        )
+        self.assertIn(_LOOP_MARKER[loop_type], code)
+        torch.testing.assert_close(
+            result, _ref_jagged_row_sum(seq_offsets, jagged), rtol=1e-2, atol=1e-2
+        )
+
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_reduction_jagged_loop_slices_float32(self, loop_type: str) -> None:
+        self._check_row_sum(torch.float32, loop_type)
+
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_reduction_jagged_loop_slices_bfloat16(self, loop_type: str) -> None:
+        self._check_row_sum(torch.bfloat16, loop_type)
+
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_reduction_jagged_loop_slices_nothing_float32(self, loop_type: str) -> None:
+        self._check_col_accum(torch.float32, loop_type)
+
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_reduction_jagged_loop_slices_nothing_bfloat16(
+        self, loop_type: str
+    ) -> None:
+        self._check_col_accum(torch.bfloat16, loop_type)
+
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_reduction_access_below_conditional(self, loop_type: str) -> None:
+        self._check_conditional_col_accum(loop_type)
+
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_reduction_remasks_after_pointwise(self, loop_type: str) -> None:
+        @helion.kernel(backend="pallas")
+        def jagged_plus_one_sum(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.zeros((B, D), dtype=torch.float32, device=jagged.device)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for dt in hl.tile(0, D):
+                    acc = hl.zeros([dt], dtype=torch.float32)
+                    for st in hl.tile(s, e):
+                        rows = jagged[st, dt].to(torch.float32) + 1.0
+                        acc = acc + rows.sum(0)
+                    out[g, dt] = acc
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32, device=DEVICE)
+        jagged = torch.randn((32, 128), dtype=torch.bfloat16, device=DEVICE)
+        _code, result = code_and_output(
+            jagged_plus_one_sum,
+            (seq_offsets, jagged),
+            block_sizes=[128, 16],
+            pallas_loop_type=loop_type,
+        )
+        expected = _ref_jagged_row_sum(seq_offsets, jagged)
+        lengths = (seq_offsets[1:] - seq_offsets[:-1]).to(torch.float32)[:, None]
+        torch.testing.assert_close(result, expected + lengths, rtol=1e-2, atol=1e-2)
+
+
+@onlyBackends(["pallas"])
+@skipUnlessPallas("JAX/Pallas TPU not available")
+class TestPallasJaggedCarryRejects(TestCase):
+    """Shapes the carry refuses (or routes elsewhere) rather than miscompiling."""
 
     @parametrize("loop_type", _LOOP_TYPES)
     def test_direct_store_under_aligned_window_rejected(self, loop_type: str) -> None:
@@ -1018,5 +1166,6 @@ class TestPallasClampedRefs(TestCase):
 
 instantiate_parametrized_tests(TestPallasJaggedCarrySimple)
 instantiate_parametrized_tests(TestPallasJaggedCarryBmm)
+instantiate_parametrized_tests(TestPallasJaggedAlignedWindow)
 instantiate_parametrized_tests(TestPallasJaggedCarryRejects)
 instantiate_parametrized_tests(TestPallasVmemScalarLoad)

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -427,6 +427,35 @@ class TestPallasJaggedCarryRejects(TestCase):
         ):
             _run(seq_offsets, jagged, dense, [8, 128, 128], kernel=kernel)
 
+    def test_untiled_column_store_rejected(self) -> None:
+        # With offsets [0, 13, 32] and a 16-row bf16 block, the second group
+        # logically starts at row 13 but its aligned window starts at row 0.
+        # The load mask zeroes rows [0, 13), so a full store would overwrite the
+        # first group with zeros. The untiled ``:`` column has no carry block
+        # with which to save those rows; reject instead of silently corrupting.
+        @helion.kernel(backend="pallas")
+        def jagged_full_row_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, _ = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.empty_like(jagged)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    out[st, :] = jagged[st, :] * 2
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32)
+        jagged = torch.randn((32, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            jagged_full_row_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type="emit_pipeline")
+            )
+
     def test_multi_grid_group_rejected(self) -> None:
         # The fold guard keys seq_offsets program_id(0), so a second grid dimension is
         # refused rather than folding against the wrong program id.

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import torch
 from torch.testing._internal.common_utils import instantiate_parametrized_tests
 from torch.testing._internal.common_utils import parametrize
+from torch.testing._internal.common_utils import subtest
 
 import helion
 from helion import exc
@@ -23,6 +24,28 @@ _XFAIL_INTERPRET = (
     "emit_pipeline dynamic pl.ds / program_id BlockSpecs unsupported in JAX "
     "Pallas interpret mode"
 )
+
+# Both inner-loop lowerings build the same sublane-aligned window and carry, so
+# both must stay correct: fori_loop is what the default config picks (and what
+# the autotuner's baseline compiles), emit_pipeline is a tuned alternative.
+_LOOP_TYPES = ["fori_loop", "emit_pipeline"]
+
+# Same pair for tests that RUN the kernel: only emit_pipeline hits the
+# interpret-mode gap above, since fori_loop's plain DMA slices do trace there.
+_RUN_LOOP_TYPES = [
+    subtest("fori_loop", name="fori_loop"),
+    subtest(
+        "emit_pipeline",
+        name="emit_pipeline",
+        decorators=[xfailIfPallasInterpret(_XFAIL_INTERPRET)],
+    ),
+]
+
+# Proof the kernel really lowered through the requested loop type.
+_LOOP_MARKER = {
+    "fori_loop": "jax.lax.fori_loop",
+    "emit_pipeline": "pltpu.emit_pipeline",
+}
 
 
 # out[s:e] = jagged[s:e] @ dense[g] for each group g delimited by seq_offsets.
@@ -65,6 +88,12 @@ def jagged_dense_bmm_2d_loop(
     return out
 
 
+_BMM_KERNELS = [
+    jagged_dense_bmm,
+    jagged_dense_bmm_2d_loop,
+]
+
+
 def _ref_jagged_bmm(
     seq_offsets: torch.Tensor, jagged: torch.Tensor, dense: torch.Tensor
 ) -> torch.Tensor:
@@ -87,12 +116,12 @@ def _inputs(offsets: list[int], D: int, K: int, dtype: torch.dtype):
     return seq_offsets, jagged, dense
 
 
-def _run(seq_offsets, jagged, dense, block_sizes, kernel=jagged_dense_bmm):
+def _run(seq_offsets, jagged, dense, block_sizes, loop_type, kernel=jagged_dense_bmm):
     return code_and_output(
         kernel,
         (seq_offsets, jagged, dense),
         block_sizes=block_sizes,
-        pallas_loop_type="emit_pipeline",
+        pallas_loop_type=loop_type,
     )
 
 
@@ -103,29 +132,45 @@ def _run(seq_offsets, jagged, dense, block_sizes, kernel=jagged_dense_bmm):
 class TestPallasJaggedCarrySimple(TestCase):
     """Minimal kernels that isolate one carry behaviour each."""
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
+    @parametrize("kernel", _BMM_KERNELS)
+    def test_default_config(self, kernel) -> None:
+        # No pinned config: data-dependent bounds make the default loop type
+        # fori_loop, which is also what HELION_AUTOTUNE_EFFORT=none and the
+        # autotuner's baseline compile, so the carry has to work there.
+        seq_offsets, jagged, dense = _inputs([0, 13, 25], 128, 128, torch.bfloat16)
+        code, out = code_and_output(kernel, (seq_offsets, jagged, dense))
+        self.assertIn(_LOOP_MARKER["fori_loop"], code)
+        torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
+
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_single_group(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_single_group(self, dtype: torch.dtype, kernel, loop_type: str) -> None:
         # One group: exercises the aligned-enclosing read and the tail mask,
         # with no carry between groups.
         seq_offsets, jagged, dense = _inputs([0, 20], 128, 128, dtype)
-        _code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        _code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_aligned_groups_carry_dormant(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_aligned_groups_carry_dormant(
+        self, dtype: torch.dtype, kernel, loop_type: str
+    ) -> None:
         # Aligned boundaries: carry path is emitted but its runtime guard never fires.
         seq_offsets, jagged, dense = _inputs([0, 16, 32], 128, 128, dtype)
-        code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         self.assertIn("pl.program_id(0) != 0", code)
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_carry_keeps_both_groups(self, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_carry_keeps_both_groups(self, kernel, loop_type: str) -> None:
         # Two groups [0, 3) and [3, 16) share the [0, 16) boundary.  With
         # identity weights out == jagged, so a clobbered carry would be obvious.
         seq_offsets = torch.tensor([0, 3, 16], dtype=torch.int32, device=DEVICE)
@@ -136,13 +181,18 @@ class TestPallasJaggedCarrySimple(TestCase):
         )
         eye = torch.eye(128, dtype=torch.bfloat16, device=DEVICE)
         _code, out = _run(
-            seq_offsets, jagged, torch.stack([eye, eye]), [16, 128, 128], kernel=kernel
+            seq_offsets,
+            jagged,
+            torch.stack([eye, eye]),
+            [16, 128, 128],
+            loop_type,
+            kernel=kernel,
         )
         torch.testing.assert_close(out, jagged)
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    def test_carry_masks_bias_add(self, dtype: torch.dtype) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_carry_masks_bias_add(self, dtype: torch.dtype, loop_type: str) -> None:
         # Additive map across a shared boundary: groups [0, 3) and [3, 16) over-
         # read each other's rows (loaded as 0).  Unless the store value is masked,
         # those rows write 0 + 1.0 and the carry folds a stray 1.0 into the result.
@@ -164,13 +214,13 @@ class TestPallasJaggedCarrySimple(TestCase):
             jagged_add_one,
             (seq_offsets, jagged),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         torch.testing.assert_close(out, jagged + 1.0)
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    def test_carry_separate_outputs(self, dtype: torch.dtype) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_carry_separate_outputs(self, dtype: torch.dtype, loop_type: str) -> None:
         # Two stores share one jagged tile: each must carry into its own scratch,
         # otherwise out2's boundary save clobbers out1's.
         @helion.kernel(backend="pallas")
@@ -194,14 +244,16 @@ class TestPallasJaggedCarrySimple(TestCase):
             jagged_add_two,
             (seq_offsets, jagged),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         torch.testing.assert_close(o1, jagged + 1.0)
         torch.testing.assert_close(o2, jagged + 2.0)
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    def test_carry_scalar_branch_store(self, dtype: torch.dtype) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_carry_scalar_branch_store(
+        self, dtype: torch.dtype, loop_type: str
+    ) -> None:
         # Two groups take different if/else branches across a shared boundary.
         @helion.kernel(backend="pallas")
         def jagged_branch(seq_offsets, jagged):
@@ -226,7 +278,7 @@ class TestPallasJaggedCarrySimple(TestCase):
             jagged_branch,
             (seq_offsets, jagged),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         self.assertIn("lax.cond", code)
         expected = torch.empty_like(jagged)
@@ -244,7 +296,6 @@ class TestPallasJaggedCarryBmm(TestCase):
     """The carry across the full configuration matrix (group counts, block vs
     group size, multiple column tiles, the non-matmul map-axis form)."""
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
     @parametrize(
         "offsets",
@@ -254,46 +305,56 @@ class TestPallasJaggedCarryBmm(TestCase):
             [0, 3, 7, 16],  # several tiny groups in one boundary (cumulative carry)
         ],
     )
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
     def test_bmm_block_eq_sublane(
-        self, dtype: torch.dtype, offsets: list[int], kernel
+        self, dtype: torch.dtype, offsets: list[int], kernel, loop_type: str
     ) -> None:
         seq_offsets, jagged, dense = _inputs(offsets, 128, 128, dtype)
-        code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
-        self.assertIn("pltpu.emit_pipeline", code)
+        code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
+        self.assertIn(_LOOP_MARKER[loop_type], code)
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_bmm_block_gt_group(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_bmm_block_gt_group(
+        self, dtype: torch.dtype, kernel, loop_type: str
+    ) -> None:
         # Two groups (13 rows) are smaller than block_row=32, total L=200 >> block_row.
         seq_offsets, jagged, dense = _inputs([0, 13, 100, 113, 200], 128, 128, dtype)
-        _code, out = _run(seq_offsets, jagged, dense, [32, 128, 128], kernel=kernel)
+        _code, out = _run(
+            seq_offsets, jagged, dense, [32, 128, 128], loop_type, kernel=kernel
+        )
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_bmm_multi_k_tile(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_bmm_multi_k_tile(self, dtype: torch.dtype, kernel, loop_type: str) -> None:
         # K=256 with block_col=128 gives two output-column tiles; the carry stacks
         # the per-column-tile boundaries along its scratch row dim.
         seq_offsets, jagged, dense = _inputs([0, 17, 40, 71], 128, 256, dtype)
-        _code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        _code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_bmm_many_groups(self, dtype: torch.dtype, kernel) -> None:
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_bmm_many_groups(self, dtype: torch.dtype, kernel, loop_type: str) -> None:
         # 50 unaligned groups; carry scratch is per column-tile, not per group.
         offsets = list(range(0, 13 * 51, 13))  # 50 groups
         seq_offsets, jagged, dense = _inputs(offsets, 128, 128, dtype)
-        code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         self.assertIn("carry", code)
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dtype", [torch.float32, torch.bfloat16])
     @parametrize(
         "offsets",
@@ -303,17 +364,20 @@ class TestPallasJaggedCarryBmm(TestCase):
             [0, 16, 16],  # trailing empty
         ],
     )
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
     def test_bmm_empty_groups(
-        self, dtype: torch.dtype, offsets: list[int], kernel
+        self, dtype: torch.dtype, offsets: list[int], kernel, loop_type: str
     ) -> None:
         # Zero-length groups (s == e) iterate no tiles; carry threads the neighbours.
         seq_offsets, jagged, dense = _inputs(offsets, 128, 128, dtype)
-        _code, out = _run(seq_offsets, jagged, dense, [16, 128, 128], kernel=kernel)
+        _code, out = _run(
+            seq_offsets, jagged, dense, [16, 128, 128], loop_type, kernel=kernel
+        )
         torch.testing.assert_close(out, _ref_jagged_bmm(seq_offsets, jagged, dense))
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
-    def test_elementwise_map_axis(self) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_elementwise_map_axis(self, loop_type: str) -> None:
         # The non-matmul map-axis store from commit 2 now runs: out[st] = 2 *
         # jagged[st], carried across the shared boundary like the matmul case.
         @helion.kernel(backend="pallas")
@@ -337,13 +401,13 @@ class TestPallasJaggedCarryBmm(TestCase):
             jagged_scale,
             (seq_offsets, jagged),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         torch.testing.assert_close(out, jagged * 2)
 
-    @xfailIfPallasInterpret(_XFAIL_INTERPRET)
     @parametrize("dynamic_cols", [True, False])
-    def test_dynamic_rows(self, dynamic_cols: bool) -> None:
+    @parametrize("loop_type", _RUN_LOOP_TYPES)
+    def test_dynamic_rows(self, dynamic_cols: bool, loop_type: str) -> None:
         @helion.kernel(backend="pallas", static_shapes=False)
         def jagged_scale_dyn(
             seq_offsets: torch.Tensor, jagged: torch.Tensor, dynamic_cols: hl.constexpr
@@ -367,7 +431,7 @@ class TestPallasJaggedCarryBmm(TestCase):
             jagged_scale_dyn,
             (seq_offsets, jagged, dynamic_cols),
             block_sizes=[16, 128],
-            pallas_loop_type="emit_pipeline",
+            pallas_loop_type=loop_type,
         )
         self.assertIn("(B,)", code)
         torch.testing.assert_close(out, jagged * 2)
@@ -412,17 +476,157 @@ class TestPallasJaggedCarryRejects(TestCase):
         ref[1] = jagged[13:25].float().sum(0)
         torch.testing.assert_close(out, ref)
 
-    @parametrize("kernel", [jagged_dense_bmm, jagged_dense_bmm_2d_loop])
-    def test_block_not_multiple_of_sublane_raises(self, kernel) -> None:
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_direct_store_under_aligned_window_rejected(self, loop_type: str) -> None:
+        @helion.kernel(backend="pallas")
+        def mixed_dtype_row_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.empty((L, D), dtype=torch.float32, device=jagged.device)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    out[st, :] = jagged[st, :].to(torch.float32) * 2
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 25], dtype=torch.int32)
+        jagged = torch.randn((25, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            mixed_dtype_row_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_nested_direct_store_under_aligned_window_rejected(
+        self, loop_type: str
+    ) -> None:
+        @helion.kernel(backend="pallas")
+        def nested_mixed_dtype_row_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.empty((L, 1, D), dtype=torch.float32, device=jagged.device)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    for ct in hl.tile(0, D):
+                        out[st, 0, ct] = jagged[st, ct].to(torch.float32)
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 25], dtype=torch.int32)
+        jagged = torch.randn((25, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            nested_mixed_dtype_row_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16, 128], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_store_below_while_rejected(self, loop_type: str) -> None:
+        @helion.kernel(backend="pallas")
+        def while_nested_row_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.empty((L, 1, D), dtype=torch.float32, device=jagged.device)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    step = torch.zeros([], dtype=torch.int32, device=jagged.device)
+                    while step < 1:
+                        for ct in hl.tile(0, D):
+                            out[st, 0, ct] = jagged[st, ct].to(torch.float32)
+                        step = step + 1
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 25], dtype=torch.int32)
+        jagged = torch.randn((25, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            while_nested_row_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16, 128], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_shifted_store_through_row_rejected(self, loop_type: str) -> None:
+        # bf16 forces the aligned window, and the row leaves through the store --
+        # but shifted by one, so it is not the straight map the carry can stitch
+        # and the window's extra rows would land on a neighbour. Reject it here
+        # rather than let Mosaic (or the device) fail further down.
+        @helion.kernel(backend="pallas")
+        def jagged_shift_store(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            out = torch.zeros((L, D), dtype=jagged.dtype, device=jagged.device)
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    for dt in hl.tile(0, D):
+                        out[st.index + 1, dt] = jagged[st, dt] * 2
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32)
+        jagged = torch.randn((32, 128), dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            jagged_shift_store.bind((seq_offsets, jagged)).to_triton_code(
+                helion.Config(block_sizes=[16, 128], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_atomic_write_through_row_rejected(self, loop_type: str) -> None:
+        @helion.kernel(backend="pallas")
+        def jagged_atomic_write(
+            seq_offsets: torch.Tensor, jagged: torch.Tensor, out: torch.Tensor
+        ) -> torch.Tensor:
+            L, D = jagged.shape
+            B = seq_offsets.shape[0] - 1
+            for g in hl.grid(B):
+                s = seq_offsets[g]
+                e = seq_offsets[g + 1]
+                for st in hl.tile(s, e):
+                    for dt in hl.tile(0, D):
+                        hl.atomic_xchg(out, [st, dt], jagged[st, dt] + 1.0)
+            return out
+
+        seq_offsets = torch.tensor([0, 13, 32], dtype=torch.int32)
+        jagged = torch.randn((32, 128), dtype=torch.bfloat16)
+        out = torch.zeros_like(jagged)
+        with self.assertRaisesRegex(
+            exc.InductorLoweringError, "ordered carry can stitch"
+        ):
+            jagged_atomic_write.bind((seq_offsets, jagged, out)).to_triton_code(
+                helion.Config(block_sizes=[16, 128], pallas_loop_type=loop_type)
+            )
+
+    @parametrize("kernel", _BMM_KERNELS)
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_block_not_multiple_of_sublane_raises(self, kernel, loop_type: str) -> None:
         # bf16 sublane S=16; block_row=8 is not a multiple, so the carry rejects it
         # loudly instead of clobbering the boundary with a plain store.
         seq_offsets, jagged, dense = _inputs([0, 13, 25], 128, 128, torch.bfloat16)
         with self.assertRaisesRegex(
             exc.InductorLoweringError, "block_row .* must be a multiple"
         ):
-            _run(seq_offsets, jagged, dense, [8, 128, 128], kernel=kernel)
+            _run(seq_offsets, jagged, dense, [8, 128, 128], loop_type, kernel=kernel)
 
-    def test_untiled_column_store_rejected(self) -> None:
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_untiled_column_store_rejected(self, loop_type: str) -> None:
         # With offsets [0, 13, 32] and a 16-row bf16 block, the second group
         # logically starts at row 13 but its aligned window starts at row 0.
         # The load mask zeroes rows [0, 13), so a full store would overwrite the
@@ -448,10 +652,11 @@ class TestPallasJaggedCarryRejects(TestCase):
             exc.InductorLoweringError, "ordered carry can stitch"
         ):
             jagged_full_row_store.bind((seq_offsets, jagged)).to_triton_code(
-                helion.Config(block_sizes=[16], pallas_loop_type="emit_pipeline")
+                helion.Config(block_sizes=[16], pallas_loop_type=loop_type)
             )
 
-    def test_multi_grid_group_rejected(self) -> None:
+    @parametrize("loop_type", _LOOP_TYPES)
+    def test_multi_grid_group_rejected(self, loop_type: str) -> None:
         # The fold guard keys seq_offsets program_id(0), so a second grid dimension is
         # refused rather than folding against the wrong program id.
         @helion.kernel(backend="pallas")
@@ -478,7 +683,7 @@ class TestPallasJaggedCarryRejects(TestCase):
                 two_grid_bmm,
                 (seq_offsets, jagged, dense),
                 block_sizes=[16, 128, 128],
-                pallas_loop_type="emit_pipeline",
+                pallas_loop_type=loop_type,
             )
 
     def test_non_jagged_emit_pipeline_unaffected(self) -> None:

--- a/test/test_pallas_memory_access.py
+++ b/test/test_pallas_memory_access.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from typing import cast
 from unittest.mock import patch
 
 import torch
@@ -14,8 +17,13 @@ from helion._compiler.pallas.plan_tiling import TilePattern
 from helion._compiler.pallas.tensorcore_plan import OneHotGatherPlan
 from helion._compiler.pallas.tensorcore_plan import OneHotScatterPlan
 from helion._compiler.pallas.tensorcore_plan import select_tensorcore_plan
+from helion._compiler.pallas.tracing_ops import _annotate_provable_sublane_alignment
+from helion._compiler.tile_strategy import LoopDimInfo
 from helion.language import memory_ops
 from helion.language.atomic_ops import atomic_add
+
+if TYPE_CHECKING:
+    from helion._compiler.inductor_lowering import CodegenState
 
 
 def _placeholder(
@@ -76,6 +84,51 @@ def test_store_and_atomic_memory_accesses_record_values() -> None:
     assert atomic_access.kind is MemoryAccessKind.ATOMIC
     assert store_access.value_node is value_node
     assert atomic_access.value_node is value_node
+
+
+# This test intentionally exercises compiler internals, which tests normally
+# avoid. Verifying alignment promises passed to Mosaic is worth that coupling:
+# an incorrect promise can cause undefined behavior.
+def test_loop_offset_uses_only_proven_window_alignment() -> None:
+    block_id = 3
+    loop = SimpleNamespace(
+        block_id_to_info={
+            block_id: LoopDimInfo(begin_var_name="runtime_begin", begin_expr=None)
+        }
+    )
+
+    def make_state(aligned_tiles: dict[int, int], block_size: int) -> CodegenState:
+        return cast(
+            "CodegenState",
+            SimpleNamespace(
+                device_function=SimpleNamespace(
+                    aligned_tiles=aligned_tiles,
+                    resolved_block_size=lambda _block_id: block_size,
+                ),
+                codegen=SimpleNamespace(active_device_loops={block_id: [loop]}),
+            ),
+        )
+
+    aligned_state = make_state({block_id: 16}, block_size=32)
+    assert (
+        _annotate_provable_sublane_alignment(aligned_state, block_id, "offset")
+        == "pl.multiple_of(offset, 16)"
+    )
+
+    # A block size that is not a multiple of the window alignment proves
+    # nothing: offsets 16, 40, 64, ... are not all multiples of 16.
+    unstepped_state = make_state({block_id: 16}, block_size=24)
+    assert (
+        _annotate_provable_sublane_alignment(unstepped_state, block_id, "offset")
+        == "offset"
+    )
+
+    # Without an aligned window, leave the offset unannotated.
+    unaligned_state = make_state({}, block_size=32)
+    assert (
+        _annotate_provable_sublane_alignment(unaligned_state, block_id, "offset")
+        == "offset"
+    )
 
 
 def test_tensorcore_plan_owns_indirect_fallbacks() -> None:

--- a/test/test_pallas_memory_access.py
+++ b/test/test_pallas_memory_access.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import torch
 
 from helion import Config
+from helion._compiler.pallas.memory_access import MEMORY_ACCESS_META
 from helion._compiler.pallas.memory_access import MemoryAccessKind
 from helion._compiler.pallas.memory_access import build_memory_access
 from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
@@ -18,8 +19,11 @@ from helion._compiler.pallas.tensorcore_plan import OneHotGatherPlan
 from helion._compiler.pallas.tensorcore_plan import OneHotScatterPlan
 from helion._compiler.pallas.tensorcore_plan import select_tensorcore_plan
 from helion._compiler.pallas.tracing_ops import _annotate_provable_sublane_alignment
+from helion._compiler.pallas.tracing_ops import _descendant_memory_accesses
+from helion._compiler.pallas.tracing_ops import _graph_memory_accesses
 from helion._compiler.tile_strategy import LoopDimInfo
 from helion.language import memory_ops
+from helion.language._tracing_ops import _while_loop
 from helion.language.atomic_ops import atomic_add
 
 if TYPE_CHECKING:
@@ -129,6 +133,66 @@ def test_loop_offset_uses_only_proven_window_alignment() -> None:
         _annotate_provable_sublane_alignment(unaligned_state, block_id, "offset")
         == "offset"
     )
+
+
+def test_alignment_accesses_keep_repeated_tensor_uses() -> None:
+    graph = torch.fx.Graph()
+    source = torch.empty(64, 256)
+    source_node = _placeholder(graph, "source", source)
+    first_subscript = (slice(None), slice(0, 128))
+    second_subscript = (slice(None), slice(None))
+    first = graph.call_function(memory_ops.load, (source_node, first_subscript))
+    second = graph.call_function(memory_ops.load, (source_node, second_subscript))
+    first.meta[MEMORY_ACCESS_META] = build_memory_access(
+        first,
+        source,
+        list(first_subscript),
+        [TilePattern(0), ArbitrarySlicePattern(slice(0, 128))],
+    )
+    second.meta[MEMORY_ACCESS_META] = build_memory_access(
+        second,
+        source,
+        list(second_subscript),
+        [TilePattern(0), TilePattern(1)],
+    )
+
+    accesses = _graph_memory_accesses(SimpleNamespace(graph=graph))
+
+    assert len(accesses) == 2
+    assert accesses[0].tensor is source
+    assert accesses[1].tensor is source
+    assert accesses[0].patterns != accesses[1].patterns
+
+
+def test_alignment_accesses_follow_every_while_graph() -> None:
+    parent_graph = torch.fx.Graph()
+    parent_graph.call_function(_while_loop, (1, 2, [], 3))
+
+    children: dict[int, SimpleNamespace] = {}
+    expected = []
+    for graph_id in (1, 2, 3):
+        graph = torch.fx.Graph()
+        source = torch.empty(64, 128)
+        source_node = _placeholder(graph, f"source_{graph_id}", source)
+        subscript = (slice(None), slice(None))
+        load = graph.call_function(memory_ops.load, (source_node, subscript))
+        access = build_memory_access(
+            load,
+            source,
+            list(subscript),
+            [TilePattern(0), ArbitrarySlicePattern(slice(None))],
+        )
+        load.meta[MEMORY_ACCESS_META] = access
+        children[graph_id] = SimpleNamespace(graph=graph)
+        expected.append(access)
+
+    state = cast(
+        "CodegenState",
+        SimpleNamespace(get_graph=lambda graph_id: children[graph_id]),
+    )
+    accesses = _descendant_memory_accesses(SimpleNamespace(graph=parent_graph), state)
+
+    assert accesses == expected
 
 
 def test_tensorcore_plan_owns_indirect_fallbacks() -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3375
 * __->__#3374
 * #3373
 * #3372
 * #3371
 * #3370
 * #3369
 * #3368
 * #3367


--- --- ---

### [pallas] test aligned read-only jagged reductions


Aligned read-only jagged windows are permitted under both streaming
lowerings, but only one bf16 row reduction and the carried row map cover them.

Add a case per shape that reaches the window without writing through the
jagged row: a loop whose slices are jagged, a loop that slices nothing
itself, an access below a conditional, and a reduction that remasks after a
pointwise op, each in f32 and bf16 and each under fori_loop and
emit_pipeline. The single bf16 row reduction they subsume goes away.

These run only once fori_loop rounds windows, which is why they land after
the ordered-carry commit rather than with the code that allows them.
