### PR TITLE
[pallas] use recorded window alignment for pl.ds promises

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -997,8 +997,9 @@ def _ds_expr(
                     dim_from_end, tensor.ndim, bitwidth
                 )
                 if alignment % required == 0:
-                    # e.g. pl.ds(pl.multiple_of(offset_3, _BLOCK_SIZE_3), _BLOCK_SIZE_3)
-                    offset = f"pl.multiple_of({offset}, {block_size})"
+                    # The loop begin and iteration step are both multiples of
+                    # `alignment`, so the promise holds for every offset.
+                    offset = f"pl.multiple_of({offset}, {alignment})"
 
     return f"pl.ds({offset}, {block_size})"
 
@@ -1039,9 +1040,11 @@ def _loop_offset_alignment(
 ) -> int | None:
     """Return the proven alignment of a loop's offset for *block_id*, or ``None``.
 
-    A loop with step ``block_size`` produces offsets ``begin + i * block_size``,
-    which are multiples of ``block_size`` iff ``begin`` is.  Returns
-    ``block_size`` (int) when provable, ``None`` otherwise.
+    A loop with step ``block_size`` produces offsets ``begin + i * block_size``.
+    An aligned jagged window proves only its recorded sublane alignment. For any
+    other loop, every offset is block-aligned iff its begin is block-aligned.
+    Return the strongest proven integer alignment, or ``None`` when a runtime
+    begin has no such proof.
     """
     import sympy
 
@@ -1049,16 +1052,22 @@ def _loop_offset_alignment(
     if not isinstance(bs_value, int):
         return None
 
-    # Check that the loop begins at a multiple of block_size.
+    window_alignment = state.device_function.aligned_tiles.get(block_id)
+    if isinstance(window_alignment, int):
+        return window_alignment if bs_value % window_alignment == 0 else None
+
+    # Without a recorded window alignment, prove block alignment from the
+    # active loop's begin.
     loops = state.codegen.active_device_loops.get(block_id)
     if loops:
         info = loops[-1].block_id_to_info.get(block_id)
-        if info is not None and info.begin_expr is not None:
-            begin = info.begin_expr
-            if not isinstance(begin, (int, sympy.Integer)):
-                return None  # symbolic begin — can't prove alignment
-            if int(begin) % bs_value != 0:
-                return None
+        if info is None or info.begin_expr is None:
+            return None
+        begin = info.begin_expr
+        if not isinstance(begin, (int, sympy.Integer)):
+            return None  # symbolic begin — can't prove alignment
+        if int(begin) % bs_value != 0:
+            return None
 
     return bs_value
 

--- a/test/test_pallas_memory_access.py
+++ b/test/test_pallas_memory_access.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import torch
 
 from helion import Config
+from helion._compiler.pallas.codegen import _loop_offset_alignment
 from helion._compiler.pallas.memory_access import MEMORY_ACCESS_META
 from helion._compiler.pallas.memory_access import MemoryAccessKind
 from helion._compiler.pallas.memory_access import build_memory_access
@@ -114,6 +115,7 @@ def test_loop_offset_uses_only_proven_window_alignment() -> None:
         )
 
     aligned_state = make_state({block_id: 16}, block_size=32)
+    assert _loop_offset_alignment(block_id, aligned_state) == 16
     assert (
         _annotate_provable_sublane_alignment(aligned_state, block_id, "offset")
         == "pl.multiple_of(offset, 16)"
@@ -122,6 +124,7 @@ def test_loop_offset_uses_only_proven_window_alignment() -> None:
     # A block size that is not a multiple of the window alignment proves
     # nothing: offsets 16, 40, 64, ... are not all multiples of 16.
     unstepped_state = make_state({block_id: 16}, block_size=24)
+    assert _loop_offset_alignment(block_id, unstepped_state) is None
     assert (
         _annotate_provable_sublane_alignment(unstepped_state, block_id, "offset")
         == "offset"
@@ -129,6 +132,7 @@ def test_loop_offset_uses_only_proven_window_alignment() -> None:
 
     # Without an aligned window, leave the offset unannotated.
     unaligned_state = make_state({}, block_size=32)
+    assert _loop_offset_alignment(block_id, unaligned_state) is None
     assert (
         _annotate_provable_sublane_alignment(unaligned_state, block_id, "offset")
         == "offset"


### PR DESCRIPTION
Stacked PRs:
 * #3373
 * __->__#3375
 * #3570
 * #3569
 * #3372
 * #3371
 * #3568
 * #3370
 * #3369
 * #3368
 * #3367
 * #3567


--- --- ---

### [pallas] use recorded window alignment for pl.ds promises


A jagged window's row offsets can be multiples of the sublane size without
being multiples of the iteration block size. For bf16 with block_size=32 and
a group starting at row 17, the window starts at row 16 and advances through
16, 48, 80, ... . Promising a multiple of 32 for those offsets is false and
can lead to undefined behavior.

Have _loop_offset_alignment consult the recorded window's
proven_sublane_alignment, and make pl.ds codegen emit that alignment instead
of the block size. Test both a valid window alignment and a step that cannot
preserve it.

Keep the existing fallback for loops without a recorded window. In
particular, fori_loop still needs that fallback for flex attention until the
next commit adds its aligned-window handling. Removing the fallback belongs
with that replacement, so this commit only changes recorded-window promises.
