### PR TITLE
[cute] Extend epilogue analysis with auxiliary tensor expression steps

### DIFF
--- a/helion/_compiler/cute/aux_tensor.py
+++ b/helion/_compiler/cute/aux_tensor.py
@@ -33,7 +33,7 @@ from ...language import matmul_ops
 from ...language import memory_ops
 from ..compile_environment import CompileEnvironment
 from .cute_epilogue import Tcgen05UnaryEpilogueChain
-from .cute_epilogue import _AuxiliaryTensorStep
+from .cute_epilogue import _AuxiliaryTensorLoadExpr
 from .cute_epilogue import analyze_tcgen05_unary_epilogue_chain
 from .cute_fx_walk import build_inner_outputs_index_from_graphs
 from .cute_fx_walk import reach_matmul_anchors
@@ -84,7 +84,7 @@ class Tcgen05AuxTensorDescriptor:
 
     - ``load_node``: the FX node for the ``helion.language.load``
       call that reads the aux tensor inside the chain. Same node
-      :class:`_AuxiliaryTensorStep` already carries; preserved here
+      :class:`_AuxiliaryTensorLoadExpr` already carries; preserved here
       verbatim so the productive-body splice can recover the
       per-thread index expression.
     - ``host_tensor_fx_node``: the FX node for the aux tensor itself
@@ -97,7 +97,7 @@ class Tcgen05AuxTensorDescriptor:
     - ``broadcast_axis``: ``None`` for the exact-shape rank-2 form
       (``residual[tile_m, tile_n]``); ``1`` for the trailing-axis
       rowvec broadcast form (``bias[tile_n]``). Matches the field on
-      :class:`_AuxiliaryTensorStep` so the productive body uses the
+      :class:`_AuxiliaryTensorLoadExpr` so the productive body uses the
       same axis convention as the existing per-thread splice.
     - ``store_value_node``: the FX node of the store value whose
       chain produced this descriptor. One matmul may be consumed by
@@ -180,7 +180,7 @@ def analyze_tcgen05_matmul_store_chains(
 
 
 def _step_host_tensor(
-    step: _AuxiliaryTensorStep,
+    step: _AuxiliaryTensorLoadExpr,
 ) -> tuple[torch.fx.Node, torch.Tensor]:
     """Return ``(host_tensor_fx_node, host_tensor_val)`` for an aux step.
 
@@ -192,23 +192,23 @@ def _step_host_tensor(
     confusing downstream codegen error.
     """
     load_node = step.load_node
-    assert load_node.args, "_AuxiliaryTensorStep.load_node missing args"
+    assert load_node.args, "_AuxiliaryTensorLoadExpr.load_node missing args"
     host_tensor_fx_node = load_node.args[0]
     assert isinstance(host_tensor_fx_node, torch.fx.Node), (
-        "_AuxiliaryTensorStep.load_node.args[0] is not an FX node"
+        "_AuxiliaryTensorLoadExpr.load_node.args[0] is not an FX node"
     )
     host_tensor_val = host_tensor_fx_node.meta.get("val")
     assert isinstance(host_tensor_val, torch.Tensor), (
-        "_AuxiliaryTensorStep host-tensor FX node has no torch.Tensor meta"
+        "_AuxiliaryTensorLoadExpr host-tensor FX node has no torch.Tensor meta"
     )
     return host_tensor_fx_node, host_tensor_val
 
 
 def _aux_descriptor_from_step(
-    step: _AuxiliaryTensorStep, store_value_node: torch.fx.Node
+    step: _AuxiliaryTensorLoadExpr, store_value_node: torch.fx.Node
 ) -> Tcgen05AuxTensorDescriptor:
     """Build a :class:`Tcgen05AuxTensorDescriptor` from one
-    :class:`_AuxiliaryTensorStep` plus the store-value node whose
+    :class:`_AuxiliaryTensorLoadExpr` plus the store-value node whose
     chain produced it.
     """
     host_tensor_fx_node, host_tensor_val = _step_host_tensor(step)
@@ -296,7 +296,7 @@ def discover_tcgen05_aux_tensor_descriptors(
         if store_value in seen_values:
             continue
         seen_values.add(store_value)
-        for step in chain.auxiliary_tensor_steps:
+        for step in chain.auxiliary_tensor_loads:
             descriptors.append(_aux_descriptor_from_step(step, store_value))
     return tuple(descriptors)
 
@@ -307,7 +307,7 @@ def host_function_has_tcgen05_aux_kernel_pattern(
     """Conservative pre-codegen detector for kernels whose tcgen05
     matmul is followed by an aux-fused store
     (``out[tile] = (acc + residual[tile]).to(...)`` and the
-    bias / rowvec variants — see :class:`_AuxiliaryTensorStep`
+    bias / rowvec variants — see :class:`_AuxiliaryTensorLoadExpr`
     for the accepted forms).
 
     Runs at autotune-surface configuration time (post-FX-graph
@@ -559,7 +559,7 @@ def _has_tma_compatible_analyzed_aux_store(
             continue
         chain, _anchor = analyzed
         exact_steps = [
-            step for step in chain.auxiliary_tensor_steps if step.broadcast_axis is None
+            step for step in chain.auxiliary_tensor_loads if step.broadcast_axis is None
         ]
         if not exact_steps:
             continue

--- a/helion/_compiler/cute/cute_epilogue.py
+++ b/helion/_compiler/cute/cute_epilogue.py
@@ -21,11 +21,14 @@ expression for two cases:
   compile-time scalar arguments.
 - Auxiliary-tensor binary ops: same shape as above, but one or more
   steps are ``add/sub/mul/div`` with the chain carrier as one
-  operand and a ``helion.language.load(aux_tensor, [...])``
-  call as the other. Two aux load shapes are accepted: the
+  operand and an elementwise expression rooted in one or more
+  ``helion.language.load(aux_tensor, [...])`` calls as the other.
+  Auxiliary expressions may use the same whitelisted unary and
+  scalar-binary operations as the carrier chain without flattening
+  their floating-point association. Two aux load shapes are accepted: the
   exact-shape rank-2 form (``residual[tile_m, tile_n]``) and the
   rank-1 trailing-axis (rowvec) broadcast form (``bias[tile_n]``).
-  See :class:`_AuxiliaryTensorStep` for the canonical contract.
+  See :class:`_AuxiliaryTensorLoadExpr` for the canonical contract.
   Forms outside these two — 3-D underlying tensors with a static
   collapse, mismatched indices, leading-axis rank-1
   (``bias[tile_m]``), kwargs — are rejected to the loud-failure
@@ -78,7 +81,7 @@ if TYPE_CHECKING:
 
 
 @dataclasses.dataclass(frozen=True)
-class _UnaryStep:
+class _UnaryOp:
     """A single accepted op rendered as ``template.format(inner=...)``.
 
     ``op_name`` is the human-readable op name used in ``__repr__`` for
@@ -94,64 +97,6 @@ class _UnaryStep:
 
 
 @dataclasses.dataclass(frozen=True)
-class _AuxiliaryTensorStep:
-    """A binary scalar op fused as ``carrier <op> aux_load``.
-
-    Unlike ``_UnaryStep`` (whose other operand is a compile-time
-    scalar literal), this step's other operand is the result of a
-    ``helion.language.load`` call against an auxiliary GMEM tensor.
-    The splice site is responsible for emitting per-thread aux load
-    code from the ``load_node`` data captured here — including the
-    auxiliary tensor name, the index expressions, and the dtype.
-
-    ``op_name`` is the user-visible op name (``"add"`` / ``"sub"`` /
-    ``"mul"`` / ``"div"``) used in test diagnostics. ``op_template``
-    is the binary-op Python expression the splice renders, with
-    placeholders ``{carrier}`` (the chain carrier identifier) and
-    ``{aux}`` (the per-thread auxiliary load expression). Renderers
-    do **not** parenthesize ``{aux}`` because the splice site emits
-    ``aux`` as a bound local first — there is no precedence
-    ambiguity inside the rendered binary expression. The direction
-    (``carrier <op> aux`` vs ``aux <op> carrier``) is already baked
-    into ``op_template`` for non-commutative ops (``sub`` / ``div``).
-
-    ``load_node`` is the FX node for the ``helion.language.load``
-    call. The splice site reads ``load_node.args[0]`` (the auxiliary
-    tensor's host tensor FX node) and ``load_node.args[1]`` (the
-    index list, which the analyzer pins to exactly the carrier's
-    tile-id symbol nodes — broader index shapes are rejected at
-    classify time).
-
-    ``broadcast_axis`` is ``None`` when the aux tensor matches the
-    carrier rank exactly (``residual[tile_m, tile_n]``), ``1`` for
-    a trailing-axis (rowvec) broadcast aux load (``bias[tile_n]``
-    with shape ``(N,)``), or ``0`` for a leading-axis (row /
-    M-axis) broadcast aux load spelled explicitly as a ``(1, N)``
-    tensor indexed ``bias[tile_m, tile_n]``. A *bare* rank-1
-    operand on the RHS (``acc + bias[tile_m]``) is still rejected
-    because it aligns to the *last* dimension under PyTorch
-    broadcasting rules (it is either a shape error when BM ≠ BN or
-    a rowvec broadcast when BM == BN), so accepting it as a colvec
-    would silently rewrite the user's broadcast direction. The
-    ``(1, N)`` form is unambiguous: the user materialized the unit
-    M axis themselves, so row 0 broadcasts over every output row.
-    The splice site
-    (``memory_ops._codegen_cute_store_tcgen05_tile``) owns the
-    canonical broadcast-view contract — for both broadcast axes it
-    builds a 2-D logical view with stride 0 on the broadcast
-    (M) axis and stride 1 on the data (N) axis so the existing
-    ``partition_C → flat_divide → partition_D`` pipeline can run
-    unchanged. Mirrors Quack's ``RowVecLoad`` epilogue
-    (``quack/quack/epi_ops.py``).
-    """
-
-    op_name: str
-    op_template: str
-    load_node: torch.fx.Node
-    broadcast_axis: int | None = None
-
-
-@dataclasses.dataclass(frozen=True)
 class Tcgen05GroupedTailEpilogueMatch:
     """Exact grouped preserve-output M/N tail source match."""
 
@@ -162,6 +107,113 @@ class Tcgen05GroupedTailEpilogueMatch:
     safe_group_node: torch.fx.Node
     has_m_tail_mask: bool
     has_n_tail_mask: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class _CurrentTensorExpr:
+    """The current accumulator-derived value at one chain step."""
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class _AuxiliaryTensorLoadExpr:
+    """One identity-keyed aux-load leaf, including scalar/cast wrappers."""
+
+    load_node: torch.fx.Node
+    broadcast_axis: int | None
+    template: str
+
+
+@dataclasses.dataclass(frozen=True)
+class _UnaryTensorExpr:
+    """A whitelisted elementwise unary operation over an auxiliary expression."""
+
+    step: _UnaryOp
+    operand: _TensorExpr
+
+
+@dataclasses.dataclass(frozen=True)
+class _BinaryTensorExpr:
+    """A binary operation preserving the auxiliary FX tree's association."""
+
+    op_name: str
+    op_template: str
+    lhs: _TensorExpr
+    rhs: _TensorExpr
+
+
+_TensorExpr = (
+    _CurrentTensorExpr | _AuxiliaryTensorLoadExpr | _UnaryTensorExpr | _BinaryTensorExpr
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class _AuxiliaryTensorExprStep:
+    """One expression over the current carrier, scalars, and auxiliary loads."""
+
+    expr: _TensorExpr
+
+    @property
+    def operands(self) -> tuple[_AuxiliaryTensorLoadExpr, ...]:
+        return _auxiliary_tensor_expr_operands(self.expr)
+
+    @property
+    def hoistable_aux_expr(self) -> _TensorExpr | None:
+        """Return a nontrivial aux-only side of the root carrier binary op."""
+        if not isinstance(self.expr, _BinaryTensorExpr):
+            return None
+        if isinstance(self.expr.lhs, _CurrentTensorExpr) and not isinstance(
+            self.expr.rhs, _AuxiliaryTensorLoadExpr
+        ):
+            return self.expr.rhs
+        if isinstance(self.expr.rhs, _CurrentTensorExpr) and not isinstance(
+            self.expr.lhs, _AuxiliaryTensorLoadExpr
+        ):
+            return self.expr.lhs
+        return None
+
+    def render_hoistable_aux_prelude_and_expr(
+        self,
+        aux_locals_by_expr: dict[_AuxiliaryTensorLoadExpr, str],
+        local_name_factory: object,
+        prelude_indent: str,
+    ) -> tuple[str, str]:
+        aux_expr = self.hoistable_aux_expr
+        assert aux_expr is not None
+        assert len(aux_locals_by_expr) == len(self.operands)
+        assert all(operand in aux_locals_by_expr for operand in self.operands)
+        return _render_auxiliary_tensor_expr(
+            aux_expr,
+            "",
+            aux_locals_by_expr,
+            local_name_factory,
+            prelude_indent,
+        )
+
+    def render_with_hoisted_aux(self, carrier_name: str, aux_name: str) -> str:
+        assert isinstance(self.expr, _BinaryTensorExpr)
+        if isinstance(self.expr.lhs, _CurrentTensorExpr):
+            lhs, rhs = carrier_name, aux_name
+        else:
+            assert isinstance(self.expr.rhs, _CurrentTensorExpr)
+            lhs, rhs = aux_name, carrier_name
+        return self.expr.op_template.format(lhs=lhs, rhs=rhs)
+
+    def render_prelude_and_expr(
+        self,
+        carrier_name: str,
+        aux_locals_by_expr: dict[_AuxiliaryTensorLoadExpr, str],
+        local_name_factory: object,
+        prelude_indent: str,
+    ) -> tuple[str, str]:
+        """Render this step with an explicit local binding for each load leaf."""
+        assert all(operand in aux_locals_by_expr for operand in self.operands)
+        return _render_auxiliary_tensor_expr(
+            self.expr,
+            carrier_name,
+            aux_locals_by_expr,
+            local_name_factory,
+            prelude_indent,
+        )
 
 
 # The cute DSL surface for whitelisted unary operations. Renderings are
@@ -237,7 +289,32 @@ def _rdiv_const_template(scalar: float) -> str:
     return f"({scalar!r} / ({{inner}}))"
 
 
-# Mapping of accepted aten/prims targets to ``_UnaryStep`` rows. The
+def _scalar_binary_template(
+    target: object,
+    scalar: float,
+    *,
+    forward_form: bool,
+) -> str | None:
+    if target is torch.ops.aten.add.Tensor:
+        return _add_const_template(scalar)
+    if target is torch.ops.aten.mul.Tensor:
+        return _mul_const_template(scalar)
+    if target is torch.ops.aten.sub.Tensor:
+        return (
+            _sub_const_template(scalar)
+            if forward_form
+            else _rsub_const_template(scalar)
+        )
+    if target is torch.ops.aten.div.Tensor:
+        return (
+            _div_const_template(scalar)
+            if forward_form
+            else _rdiv_const_template(scalar)
+        )
+    return None
+
+
+# Mapping of accepted aten/prims targets to ``_UnaryOp`` rows. The
 # classifier looks the row up at match time and emits it directly;
 # binary scalar ops are handled separately below since their template
 # depends on the extracted constant.
@@ -252,29 +329,29 @@ def _rdiv_const_template(scalar: float) -> str:
 # ``helion/language/_gelu_tanh_approx.py`` for constants and
 # motivation. The renderer always passes a bound local for ``{inner}``,
 # so the four occurrences of ``x`` do not duplicate a complex expression.
-_ZERO_ARG_TARGETS: dict[object, _UnaryStep] = {
-    torch.ops.aten.relu.default: _UnaryStep(
+_ZERO_ARG_TARGETS: dict[object, _UnaryOp] = {
+    torch.ops.aten.relu.default: _UnaryOp(
         op_name="relu",
         template=_RELU_TEMPLATE,
     ),
-    torch.ops.aten.abs.default: _UnaryStep(op_name="abs", template=_ABS_TEMPLATE),
-    torch.ops.aten.neg.default: _UnaryStep(op_name="neg", template=_NEG_TEMPLATE),
-    torch.ops.aten.tanh.default: _UnaryStep(op_name="tanh", template=_TANH_TEMPLATE),
-    torch.ops.aten.exp.default: _UnaryStep(op_name="exp", template=_EXP_TEMPLATE),
-    torch.ops.aten.log.default: _UnaryStep(op_name="log", template=_LOG_TEMPLATE),
-    torch.ops.aten.sqrt.default: _UnaryStep(op_name="sqrt", template=_SQRT_TEMPLATE),
-    torch.ops.aten.erf.default: _UnaryStep(op_name="erf", template=_ERF_TEMPLATE),
+    torch.ops.aten.abs.default: _UnaryOp(op_name="abs", template=_ABS_TEMPLATE),
+    torch.ops.aten.neg.default: _UnaryOp(op_name="neg", template=_NEG_TEMPLATE),
+    torch.ops.aten.tanh.default: _UnaryOp(op_name="tanh", template=_TANH_TEMPLATE),
+    torch.ops.aten.exp.default: _UnaryOp(op_name="exp", template=_EXP_TEMPLATE),
+    torch.ops.aten.log.default: _UnaryOp(op_name="log", template=_LOG_TEMPLATE),
+    torch.ops.aten.sqrt.default: _UnaryOp(op_name="sqrt", template=_SQRT_TEMPLATE),
+    torch.ops.aten.erf.default: _UnaryOp(op_name="erf", template=_ERF_TEMPLATE),
     # ``aten.sigmoid.default`` is accepted as a standalone unary step so
     # ``out[tile] = sigmoid(acc).to(...)`` fuses end-to-end. The same
     # template is also embedded inside ``_SILU_TEMPLATE`` for the
     # ``x * sigmoid(x)`` fusion below — keeping both paths on the
     # ``cute.math.exp2`` form matches the inductor cutedsl pointwise
     # sigmoid lowering byte-for-byte.
-    torch.ops.aten.sigmoid.default: _UnaryStep(
+    torch.ops.aten.sigmoid.default: _UnaryOp(
         op_name="sigmoid",
         template=_SIGMOID_TEMPLATE,
     ),
-    _gelu_erf: _UnaryStep(
+    _gelu_erf: _UnaryOp(
         op_name="gelu_erf",
         template=gelu_erf_epilogue_unary_step_template(),
     ),
@@ -282,7 +359,7 @@ _ZERO_ARG_TARGETS: dict[object, _UnaryStep] = {
     # by the device_ir decomp) — single FX node folding the polynomial
     # which references ``x`` 4 times. The chain renderer already has a
     # bound carrier local, so the polynomial can reuse that local directly.
-    _gelu_tanh_approx: _UnaryStep(
+    _gelu_tanh_approx: _UnaryOp(
         op_name="gelu_tanh_approx",
         template=epilogue_unary_step_template(),
     ),
@@ -320,26 +397,18 @@ _SCALAR_BINARY_TARGETS: frozenset[object] = frozenset(
 )
 
 
-# Per-target ``op_template`` for the auxiliary-tensor renderer. The
-# placeholders ``{carrier}`` and ``{aux}`` are bound to splice-site
-# locals (the chain carrier and the per-thread aux load
-# respectively). The classifier picks ``_AUX_FORWARD_OP_TEMPLATES``
-# when the carrier is the *left* operand (``carrier <op> aux``) and
-# ``_AUX_REVERSE_OP_TEMPLATES`` when it is the right (``aux <op>
-# carrier``). For commutative ``add`` / ``mul`` the two tables are
-# value-equivalent; the symmetric handling keeps non-commutative
-# ``sub`` / ``div`` correct without a per-step branch.
-_AUX_FORWARD_OP_TEMPLATES: dict[object, str] = {
-    torch.ops.aten.add.Tensor: "(({carrier}) + ({aux}))",
-    torch.ops.aten.mul.Tensor: "(({carrier}) * ({aux}))",
-    torch.ops.aten.sub.Tensor: "(({carrier}) - ({aux}))",
-    torch.ops.aten.div.Tensor: "(({carrier}) / ({aux}))",
+_AUX_EXPR_BINARY_TEMPLATES: dict[object, str] = {
+    torch.ops.aten.add.Tensor: "{lhs} + {rhs}",
+    torch.ops.aten.mul.Tensor: "{lhs} * {rhs}",
+    torch.ops.aten.sub.Tensor: "{lhs} - {rhs}",
+    torch.ops.aten.div.Tensor: "{lhs} / {rhs}",
 }
-_AUX_REVERSE_OP_TEMPLATES: dict[object, str] = {
-    torch.ops.aten.add.Tensor: "(({aux}) + ({carrier}))",
-    torch.ops.aten.mul.Tensor: "(({aux}) * ({carrier}))",
-    torch.ops.aten.sub.Tensor: "(({aux}) - ({carrier}))",
-    torch.ops.aten.div.Tensor: "(({aux}) / ({carrier}))",
+
+_BINARY_OP_NAMES: dict[object, str] = {
+    torch.ops.aten.add.Tensor: "add",
+    torch.ops.aten.mul.Tensor: "mul",
+    torch.ops.aten.sub.Tensor: "sub",
+    torch.ops.aten.div.Tensor: "div",
 }
 
 
@@ -453,12 +522,147 @@ def _aux_load_operand(node: torch.fx.Node) -> tuple[torch.fx.Node, str]:
     load_node, inner_template = _canonical_aux_load_operand(inner)
     if load_node is inner and not _is_helion_load_node(load_node):
         return node, "{aux}"
+    load_dtype = _node_tensor_dtype(load_node)
+    if load_dtype is None or not load_dtype.is_floating_point:
+        return node, "{aux}"
     return load_node, f"(({inner_template}) * {scalar!r})"
 
 
-def _is_aux_load_operand_node(node: torch.fx.Node) -> bool:
+def _is_auxiliary_tensor_expr_node(node: torch.fx.Node, depth: int = 0) -> bool:
+    """Return whether ``node`` is structurally an aux-only expression."""
+    if depth >= 32:
+        return False
     load_node, _ = _aux_load_operand(node)
-    return _is_helion_load_node(load_node)
+    if _is_helion_load_node(load_node):
+        return True
+    if node.op != "call_function" or node.kwargs:
+        return False
+    unary_step = _ZERO_ARG_TARGETS.get(node.target)
+    unary_operand: torch.fx.Node | None = None
+    if unary_step is not None:
+        if len(node.args) != 1 or not isinstance(node.args[0], torch.fx.Node):
+            return False
+        unary_operand = node.args[0]
+    else:
+        silu = _classify_silu(node)
+        if silu is not None:
+            _, unary_operand = silu
+    if unary_operand is not None:
+        return _is_auxiliary_tensor_expr_node(unary_operand, depth + 1)
+    if node.target not in _SCALAR_BINARY_TARGETS or len(node.args) != 2:
+        return False
+    lhs, rhs = node.args
+    lhs_is_expr = isinstance(lhs, torch.fx.Node) and _is_auxiliary_tensor_expr_node(
+        lhs, depth + 1
+    )
+    rhs_is_expr = isinstance(rhs, torch.fx.Node) and _is_auxiliary_tensor_expr_node(
+        rhs, depth + 1
+    )
+    if lhs_is_expr and rhs_is_expr:
+        return True
+    if lhs_is_expr:
+        return _extract_scalar(rhs) is not None
+    if rhs_is_expr:
+        return _extract_scalar(lhs) is not None
+    return False
+
+
+def _auxiliary_tensor_expr_operands(
+    expr: _TensorExpr,
+) -> tuple[_AuxiliaryTensorLoadExpr, ...]:
+    if isinstance(expr, _CurrentTensorExpr):
+        return ()
+    if isinstance(expr, _AuxiliaryTensorLoadExpr):
+        return (expr,)
+    if isinstance(expr, _UnaryTensorExpr):
+        return _auxiliary_tensor_expr_operands(expr.operand)
+    if isinstance(expr, _BinaryTensorExpr):
+        return (
+            *_auxiliary_tensor_expr_operands(expr.lhs),
+            *_auxiliary_tensor_expr_operands(expr.rhs),
+        )
+    raise AssertionError(f"unexpected tensor expression: {type(expr).__name__}")
+
+
+def _tensor_expr_contains_current(expr: _TensorExpr) -> bool:
+    if isinstance(expr, _CurrentTensorExpr):
+        return True
+    if isinstance(expr, _AuxiliaryTensorLoadExpr):
+        return False
+    if isinstance(expr, _UnaryTensorExpr):
+        return _tensor_expr_contains_current(expr.operand)
+    if isinstance(expr, _BinaryTensorExpr):
+        return _tensor_expr_contains_current(expr.lhs) or _tensor_expr_contains_current(
+            expr.rhs
+        )
+    raise AssertionError(f"unexpected tensor expression: {type(expr).__name__}")
+
+
+def _render_auxiliary_tensor_expr(
+    expr: _TensorExpr,
+    carrier_name: str,
+    aux_locals_by_expr: dict[_AuxiliaryTensorLoadExpr, str],
+    local_name_factory: object,
+    prelude_indent: str,
+) -> tuple[str, str]:
+    """Render an expression tree into bound TensorSSA locals."""
+    if isinstance(expr, _CurrentTensorExpr):
+        return "", carrier_name
+    if isinstance(expr, _AuxiliaryTensorLoadExpr):
+        assert expr in aux_locals_by_expr, "auxiliary load leaf has no local binding"
+        aux_local = aux_locals_by_expr[expr]
+        if expr.template == "{aux}":
+            return "", aux_local
+        local = local_name_factory("tcgen05_aux_expr")  # type: ignore[operator]
+        assert isinstance(local, str)
+        rendered = expr.template.format(aux=aux_local)
+        return f"{prelude_indent}{local} = {rendered}\n", local
+    if isinstance(expr, _UnaryTensorExpr):
+        prelude, operand = _render_auxiliary_tensor_expr(
+            expr.operand,
+            carrier_name,
+            aux_locals_by_expr,
+            local_name_factory,
+            prelude_indent,
+        )
+        local_prefix = (
+            "tcgen05_chain_step"
+            if _tensor_expr_contains_current(expr)
+            else "tcgen05_aux_expr"
+        )
+        local = local_name_factory(local_prefix)  # type: ignore[operator]
+        assert isinstance(local, str)
+        rendered = expr.step.template.format(inner=operand)
+        return prelude + f"{prelude_indent}{local} = {rendered}\n", local
+    if isinstance(expr, _BinaryTensorExpr):
+        lhs_prelude, lhs = _render_auxiliary_tensor_expr(
+            expr.lhs,
+            carrier_name,
+            aux_locals_by_expr,
+            local_name_factory,
+            prelude_indent,
+        )
+        rhs_prelude, rhs = _render_auxiliary_tensor_expr(
+            expr.rhs,
+            carrier_name,
+            aux_locals_by_expr,
+            local_name_factory,
+            prelude_indent,
+        )
+        if _tensor_expr_contains_current(expr):
+            local_prefix = "tcgen05_chain_step"
+        elif expr.op_name == "mul":
+            local_prefix = "tcgen05_aux_product"
+        else:
+            local_prefix = "tcgen05_aux_expr"
+        local = local_name_factory(local_prefix)  # type: ignore[operator]
+        assert isinstance(local, str)
+        rendered = expr.op_template.format(lhs=lhs, rhs=rhs)
+        return (
+            lhs_prelude + rhs_prelude + f"{prelude_indent}{local} = {rendered}\n",
+            local,
+        )
+    raise AssertionError(f"unexpected tensor expression: {type(expr).__name__}")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -467,10 +671,8 @@ class Tcgen05UnaryEpilogueChain:
 
     ``steps`` is in *application order*: ``steps[0]`` is the op closest
     to the matmul; ``steps[-1]`` is the op closest to the optional store cast.
-    A step is either a
-    ``_UnaryStep`` (zero-arg unary or scalar binary) or an
-    ``_AuxiliaryTensorStep`` (binary op with the chain carrier +
-    a ``helion.language.load`` of an auxiliary GMEM tensor). The
+    Every step is an ``_AuxiliaryTensorExprStep`` whose expression can
+    reference the current carrier, scalar constants, and auxiliary loads. The
     classname (``Tcgen05UnaryEpilogueChain``) is preserved from the
     earlier unary-only implementation for byte-identity in goldens;
     conceptually the type is now a "tcgen05 epilogue chain" that
@@ -489,17 +691,18 @@ class Tcgen05UnaryEpilogueChain:
     templates.
 
     For auxiliary-tensor steps, the renderer expects the splice site
-    to provide a per-step pre-bound local for the ``aux`` operand;
-    the renderer just emits ``carrier <op> aux_local``. The aux load
+    to provide pre-bound locals for the auxiliary load leaves. It
+    renders any aux-only expression before emitting ``carrier <op>
+    aux_expr``. The aux load
     code (cute partition + per-thread read) is the splice site's
     responsibility because it depends on the per-subtile loop layout
     and the partitioned tile, neither of which this module knows about.
     """
 
-    steps: tuple[_UnaryStep | _AuxiliaryTensorStep, ...]
+    steps: tuple[_AuxiliaryTensorExprStep, ...]
 
     @property
-    def auxiliary_tensor_steps(self) -> tuple[_AuxiliaryTensorStep, ...]:
+    def auxiliary_tensor_loads(self) -> tuple[_AuxiliaryTensorLoadExpr, ...]:
         """All auxiliary-tensor steps in application order.
 
         Used by the splice site to request per-step ``aux_local``
@@ -507,14 +710,14 @@ class Tcgen05UnaryEpilogueChain:
         per-thread aux load setup runs once per output tile (outside
         the per-subtile chain rendering).
         """
-        return tuple(s for s in self.steps if isinstance(s, _AuxiliaryTensorStep))
+        return tuple(operand for step in self.steps for operand in step.operands)
 
     def render_prelude_and_expr(
         self,
         carrier_name: str,
         local_name_factory: object,
         prelude_indent: str,
-        aux_locals_by_step: tuple[str, ...] | None = None,
+        aux_locals_by_expr: dict[_AuxiliaryTensorLoadExpr, str] | None = None,
     ) -> tuple[str, str]:
         """Return ``(prelude, final_expr)``.
 
@@ -528,11 +731,9 @@ class Tcgen05UnaryEpilogueChain:
         practice the splice site passes ``df.new_var`` so each chain
         step gets a unique name even across multiple kernels.
 
-        ``aux_locals_by_step`` is required when any step is an
-        ``_AuxiliaryTensorStep`` and supplies, per-aux-step in
-        application order, the splice-side pre-bound local that
-        carries the per-thread auxiliary load value. Pure unary
-        chains pass ``None``.
+        ``aux_locals_by_expr`` is required when the chain has auxiliary-load
+        leaves and maps each identity-keyed leaf to the splice-side pre-bound
+        local carrying its per-thread value. Pure unary chains pass ``None``.
 
         Identity epilogues do not reach this method: the analyzer returns an
         empty chain for that case, and the splice site leaves it to the
@@ -544,52 +745,32 @@ class Tcgen05UnaryEpilogueChain:
             "least one step; identity epilogues should never reach the "
             "splice site (the ast.Name fast path handles them)"
         )
-        aux_steps = self.auxiliary_tensor_steps
+        aux_steps = self.auxiliary_tensor_loads
         if aux_steps:
-            assert aux_locals_by_step is not None and len(aux_locals_by_step) == len(
+            assert aux_locals_by_expr is not None and len(aux_locals_by_expr) == len(
                 aux_steps
             ), (
-                "auxiliary-tensor chain steps require one aux local per "
-                f"aux step; got {len(aux_locals_by_step) if aux_locals_by_step is not None else None} "
-                f"aux_locals for {len(aux_steps)} aux steps"
+                "auxiliary-tensor chains require one local binding per load leaf; "
+                f"got {len(aux_locals_by_expr) if aux_locals_by_expr is not None else None} "
+                f"bindings for {len(aux_steps)} leaves"
             )
+            assert all(step in aux_locals_by_expr for step in aux_steps)
         else:
-            assert aux_locals_by_step is None or aux_locals_by_step == (), (
-                "non-auxiliary chains must not be passed aux_locals_by_step"
+            assert aux_locals_by_expr is None or not aux_locals_by_expr, (
+                "non-auxiliary chains must not be passed aux_locals_by_expr"
             )
-        aux_local_iter = iter(aux_locals_by_step or ())
+        local_bindings = aux_locals_by_expr or {}
         prelude_lines: list[str] = []
         cur_expr = carrier_name
         local = carrier_name
         for step in self.steps:
-            if isinstance(step, _AuxiliaryTensorStep):
-                # Auxiliary-tensor binary op. The splice site has
-                # already bound the per-thread aux load to a local
-                # (so the renderer's job is just substituting the
-                # binary expression). The carrier is bound here as
-                # well, even though templates only reference it once
-                # — the symmetric handling with the unary path keeps
-                # the prelude shape uniform and CuTe CSEs the load
-                # reference at compile time.
-                aux_local = next(aux_local_iter)
-                local = local_name_factory(  # type: ignore[operator]
-                    "tcgen05_chain_step"
-                )
-                assert isinstance(local, str)
-                step_expr = step.op_template.format(carrier=cur_expr, aux=aux_local)
-                prelude_lines.append(f"{prelude_indent}{local} = {step_expr}\n")
-                cur_expr = local
-                continue
-            # ``cur_expr`` is always a bound local: the carrier starts as the
-            # splice site's loaded accumulator local, and every prior step
-            # stores into its own ``tcgen05_chain_step*`` local. Multi-reference
-            # templates can therefore reuse it directly without creating an
-            # extra vector alias such as ``tcgen05_chain_step_in = cur``.
-            inner_name = cur_expr
-            local = local_name_factory("tcgen05_chain_step")  # type: ignore[operator]
-            assert isinstance(local, str)
-            step_expr = step.template.format(inner=inner_name)
-            prelude_lines.append(f"{prelude_indent}{local} = {step_expr}\n")
+            step_prelude, local = step.render_prelude_and_expr(
+                cur_expr,
+                local_bindings,
+                local_name_factory,
+                prelude_indent,
+            )
+            prelude_lines.append(step_prelude)
             cur_expr = local
         return ("".join(prelude_lines), local)
 
@@ -674,7 +855,7 @@ def _is_one_plus_exp_neg_of(node: object, carrier: torch.fx.Node) -> bool:
 
 def _classify_silu(
     cur: torch.fx.Node,
-) -> tuple[_UnaryStep, torch.fx.Node] | None:
+) -> tuple[_UnaryOp, torch.fx.Node] | None:
     """Fold a decomposed silu activation into one chain step.
 
     Two FX shapes are accepted:
@@ -717,16 +898,16 @@ def _classify_silu(
         if not (isinstance(lhs, torch.fx.Node) and isinstance(rhs, torch.fx.Node)):
             return None
         if _is_sigmoid_of(rhs, lhs):
-            return _UnaryStep(op_name="silu", template=_SILU_TEMPLATE), lhs
+            return _UnaryOp(op_name="silu", template=_SILU_TEMPLATE), lhs
         if _is_sigmoid_of(lhs, rhs):
-            return _UnaryStep(op_name="silu", template=_SILU_TEMPLATE), rhs
+            return _UnaryOp(op_name="silu", template=_SILU_TEMPLATE), rhs
         return None
     # ``div(carrier, add(exp(neg(carrier)), 1))`` form — inductor decomp.
     if target is torch.ops.aten.div.Tensor:
         if not isinstance(lhs, torch.fx.Node):
             return None
         if _is_one_plus_exp_neg_of(rhs, lhs):
-            return _UnaryStep(op_name="silu", template=_SILU_TEMPLATE), lhs
+            return _UnaryOp(op_name="silu", template=_SILU_TEMPLATE), lhs
         return None
     return None
 
@@ -737,14 +918,14 @@ def _classify_binary(
     carrier_tile_shape: tuple[object, ...] | None,
     carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None = None,
     carrier_global_shape: tuple[object, ...] | None = None,
-) -> tuple[_UnaryStep | _AuxiliaryTensorStep, torch.fx.Node] | None:
+) -> tuple[_AuxiliaryTensorExprStep, torch.fx.Node] | None:
     """Classify ``cur`` (a ``call_function`` node whose target is on the
     binary whitelist) as a single chain step plus its FX carrier node.
 
     Returns ``None`` if the node cannot be folded — unexpected
     kwargs, multiple chain inputs, both args are scalars, both args
     are tensors but neither is a recognized auxiliary load, etc. The
-    ``_AuxiliaryTensorStep`` branch is gated on ``carrier_tile_shape``
+    ``_AuxiliaryTensorLoadExpr`` branch is gated on ``carrier_tile_shape``
     being available *and* matching the auxiliary load's tile shape;
     pass ``None`` when no carrier tile shape is known (e.g. the
     chain entry point) and the auxiliary branch will be skipped.
@@ -775,64 +956,46 @@ def _classify_binary(
     rhs_is_node = isinstance(rhs, torch.fx.Node)
     if lhs_is_node and rhs_is_node:
         assert isinstance(lhs, torch.fx.Node) and isinstance(rhs, torch.fx.Node)
-        # Both args are FX nodes. One must be a recognized auxiliary
-        # tensor load; the other is the chain carrier. If both look
-        # like aux loads or neither does, bail — the chain has no
-        # unique carrier.
-        lhs_load, lhs_aux_template = _aux_load_operand(lhs)
-        rhs_load, rhs_aux_template = _aux_load_operand(rhs)
-        lhs_kind = aux_tensor_load_kind(
-            lhs_load,
+        lhs_expr = _classify_auxiliary_tensor_expr(
+            lhs,
             carrier_tile_shape=carrier_tile_shape,
             carrier_tile_index_nodes=carrier_tile_index_nodes,
             carrier_global_shape=carrier_global_shape,
         )
-        rhs_kind = aux_tensor_load_kind(
-            rhs_load,
+        rhs_expr = _classify_auxiliary_tensor_expr(
+            rhs,
             carrier_tile_shape=carrier_tile_shape,
             carrier_tile_index_nodes=carrier_tile_index_nodes,
             carrier_global_shape=carrier_global_shape,
         )
-        aux_load: torch.fx.Node
+        aux_expr: _TensorExpr
         carrier: torch.fx.Node
         forward_form: bool
-        if lhs_kind is not None and rhs_kind is None:
-            aux_load = lhs_load
-            aux_template = lhs_aux_template
+        if lhs_expr is not None and rhs_expr is None:
+            aux_expr = lhs_expr
             carrier = rhs
             forward_form = False  # carrier is the right operand
-            aux_kind = lhs_kind
-        elif rhs_kind is not None and lhs_kind is None:
-            aux_load = rhs_load
-            aux_template = rhs_aux_template
+        elif rhs_expr is not None and lhs_expr is None:
+            aux_expr = rhs_expr
             carrier = lhs
             forward_form = True  # carrier is the left operand
-            aux_kind = rhs_kind
         else:
             return None
-        op_template_table: dict[object, str] = (
-            _AUX_FORWARD_OP_TEMPLATES if forward_form else _AUX_REVERSE_OP_TEMPLATES
-        )
-        op_template = op_template_table[target].replace("{aux}", aux_template)
-        op_name_table: dict[object, str] = {
-            torch.ops.aten.add.Tensor: "add",
-            torch.ops.aten.mul.Tensor: "mul",
-            torch.ops.aten.sub.Tensor: "sub",
-            torch.ops.aten.div.Tensor: "div",
-        }
-        op_name = op_name_table[target]
-        broadcast_axis = aux_kind[1] if aux_kind[0] == "broadcast" else None
+        op_name = _BINARY_OP_NAMES[target]
+        current_expr = _CurrentTensorExpr()
         return (
-            _AuxiliaryTensorStep(
-                op_name=op_name,
-                op_template=op_template,
-                load_node=aux_load,
-                broadcast_axis=broadcast_axis,
+            _AuxiliaryTensorExprStep(
+                expr=_BinaryTensorExpr(
+                    op_name=op_name,
+                    op_template=_AUX_EXPR_BINARY_TEMPLATES[target],
+                    lhs=current_expr if forward_form else aux_expr,
+                    rhs=aux_expr if forward_form else current_expr,
+                )
             ),
             carrier,
         )
     # One arg is a tensor and the other a scalar literal. Extract
-    # the scalar and render a ``_UnaryStep`` row.
+    # the scalar and render a unary expression over the current carrier.
     scalar: float | None
     forward_form_scalar: bool  # True => `carrier <op> scalar`
     scalar_carrier: torch.fx.Node
@@ -852,30 +1015,187 @@ def _classify_binary(
         return None
     if scalar is None:
         return None
-    if target is torch.ops.aten.add.Tensor:
-        return (
-            _UnaryStep(op_name="add", template=_add_const_template(scalar)),
-            scalar_carrier,
+    template = _scalar_binary_template(
+        target,
+        scalar,
+        forward_form=forward_form_scalar,
+    )
+    if template is None:
+        return None
+    return (
+        _AuxiliaryTensorExprStep(
+            expr=_UnaryTensorExpr(
+                step=_UnaryOp(
+                    op_name=_BINARY_OP_NAMES[target],
+                    template=template,
+                ),
+                operand=_CurrentTensorExpr(),
+            )
+        ),
+        scalar_carrier,
+    )
+
+
+def _classify_auxiliary_tensor_expr(
+    node: torch.fx.Node,
+    *,
+    carrier_tile_shape: tuple[object, ...] | None,
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    carrier_global_shape: tuple[object, ...] | None,
+) -> _TensorExpr | None:
+    """Recognize a whitelisted elementwise tree rooted in auxiliary loads."""
+    return _classify_auxiliary_tensor_expr_impl(
+        node,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        carrier_global_shape=carrier_global_shape,
+        depth=0,
+    )
+
+
+def _node_tensor_dtype(node: torch.fx.Node) -> torch.dtype | None:
+    val = node.meta.get("val")
+    return val.dtype if isinstance(val, torch.Tensor) else None
+
+
+def _classify_auxiliary_tensor_expr_impl(
+    node: torch.fx.Node,
+    *,
+    carrier_tile_shape: tuple[object, ...] | None,
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    carrier_global_shape: tuple[object, ...] | None,
+    depth: int,
+) -> _TensorExpr | None:
+    if depth >= 32:
+        return None
+
+    load_node, aux_template = _aux_load_operand(node)
+    kind = aux_tensor_load_kind(
+        load_node,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        carrier_global_shape=carrier_global_shape,
+    )
+    if kind is not None:
+        broadcast_axis = kind[1] if kind[0] == "broadcast" else None
+        return _AuxiliaryTensorLoadExpr(
+            load_node=load_node,
+            broadcast_axis=broadcast_axis,
+            template=aux_template,
         )
-    if target is torch.ops.aten.mul.Tensor:
-        return (
-            _UnaryStep(op_name="mul", template=_mul_const_template(scalar)),
-            scalar_carrier,
+
+    if node.op != "call_function" or node.kwargs:
+        return None
+    unary_step = _ZERO_ARG_TARGETS.get(node.target)
+    unary_operand: torch.fx.Node | None = None
+    if unary_step is not None:
+        if len(node.args) != 1 or not isinstance(node.args[0], torch.fx.Node):
+            return None
+        unary_operand = node.args[0]
+    else:
+        silu = _classify_silu(node)
+        if silu is not None:
+            unary_step, unary_operand = silu
+    if unary_step is not None and unary_operand is not None:
+        operand_dtype = _node_tensor_dtype(unary_operand)
+        if (
+            operand_dtype is None
+            or not operand_dtype.is_floating_point
+            or _node_tensor_dtype(node) != operand_dtype
+        ):
+            return None
+        operand_expr = _classify_auxiliary_tensor_expr_impl(
+            unary_operand,
+            carrier_tile_shape=carrier_tile_shape,
+            carrier_tile_index_nodes=carrier_tile_index_nodes,
+            carrier_global_shape=carrier_global_shape,
+            depth=depth + 1,
         )
-    if target is torch.ops.aten.sub.Tensor:
-        template = (
-            _sub_const_template(scalar)
-            if forward_form_scalar
-            else _rsub_const_template(scalar)
+        if operand_expr is None:
+            return None
+        return _UnaryTensorExpr(step=unary_step, operand=operand_expr)
+
+    if node.target not in _SCALAR_BINARY_TARGETS or len(node.args) != 2:
+        return None
+    lhs = node.args[0]
+    rhs = node.args[1]
+    lhs_expr = (
+        _classify_auxiliary_tensor_expr_impl(
+            lhs,
+            carrier_tile_shape=carrier_tile_shape,
+            carrier_tile_index_nodes=carrier_tile_index_nodes,
+            carrier_global_shape=carrier_global_shape,
+            depth=depth + 1,
         )
-        return _UnaryStep(op_name="sub", template=template), scalar_carrier
-    if target is torch.ops.aten.div.Tensor:
-        template = (
-            _div_const_template(scalar)
-            if forward_form_scalar
-            else _rdiv_const_template(scalar)
+        if isinstance(lhs, torch.fx.Node)
+        else None
+    )
+    rhs_expr = (
+        _classify_auxiliary_tensor_expr_impl(
+            rhs,
+            carrier_tile_shape=carrier_tile_shape,
+            carrier_tile_index_nodes=carrier_tile_index_nodes,
+            carrier_global_shape=carrier_global_shape,
+            depth=depth + 1,
         )
-        return _UnaryStep(op_name="div", template=template), scalar_carrier
+        if isinstance(rhs, torch.fx.Node)
+        else None
+    )
+    if lhs_expr is not None and rhs_expr is not None:
+        assert isinstance(lhs, torch.fx.Node) and isinstance(rhs, torch.fx.Node)
+        result_dtype = _node_tensor_dtype(node)
+        if (
+            result_dtype is None
+            or _node_tensor_dtype(lhs) != result_dtype
+            or _node_tensor_dtype(rhs) != result_dtype
+        ):
+            return None
+        return _BinaryTensorExpr(
+            op_name=_BINARY_OP_NAMES[node.target],
+            op_template=_AUX_EXPR_BINARY_TEMPLATES[node.target],
+            lhs=lhs_expr,
+            rhs=rhs_expr,
+        )
+    if lhs_expr is not None:
+        assert isinstance(lhs, torch.fx.Node)
+        scalar = _extract_scalar(rhs)
+        lhs_dtype = _node_tensor_dtype(lhs)
+        if (
+            scalar is None
+            or lhs_dtype is None
+            or not lhs_dtype.is_floating_point
+            or _node_tensor_dtype(node) != lhs_dtype
+        ):
+            return None
+        template = _scalar_binary_template(node.target, scalar, forward_form=True)
+        assert template is not None
+        return _UnaryTensorExpr(
+            step=_UnaryOp(
+                op_name=_BINARY_OP_NAMES[node.target],
+                template=template,
+            ),
+            operand=lhs_expr,
+        )
+    if rhs_expr is not None:
+        assert isinstance(rhs, torch.fx.Node)
+        scalar = _extract_scalar(lhs)
+        rhs_dtype = _node_tensor_dtype(rhs)
+        if (
+            scalar is None
+            or rhs_dtype is None
+            or not rhs_dtype.is_floating_point
+            or _node_tensor_dtype(node) != rhs_dtype
+        ):
+            return None
+        template = _scalar_binary_template(node.target, scalar, forward_form=False)
+        assert template is not None
+        return _UnaryTensorExpr(
+            step=_UnaryOp(
+                op_name=_BINARY_OP_NAMES[node.target],
+                template=template,
+            ),
+            operand=rhs_expr,
+        )
     return None
 
 
@@ -961,7 +1281,7 @@ def _carrier_tile_index_nodes(
         # aux tensor and never find ``hl.zeros``.
         chosen: torch.fx.Node | None = None
         for inp in cur.all_input_nodes:
-            if _is_aux_load_operand_node(inp):
+            if _is_auxiliary_tensor_expr_node(inp):
                 continue
             chosen = inp
             break
@@ -996,11 +1316,13 @@ def analyze_tcgen05_unary_epilogue_chain(
     Whitelisted ops are zero-arg unary (``relu`` / ``tanh`` / ``exp``
     / ``log`` / ``sqrt`` / ``abs`` / ``neg``), scalar binary
     (``add`` / ``sub`` / ``mul`` / ``div`` against a compile-time
-    Python literal), and auxiliary-tensor binary in two forms:
-    exact-shape (``residual[tile_m, tile_n]``, rank-2 aux matching
-    the carrier tile shape) and rank-1 trailing-axis (rowvec)
-    broadcast (``bias[tile_n]``, where the single load index
-    symbol matches the carrier's trailing tile-id symbol). Other
+    Python literal), and carrier binary ops whose other operand is
+    a whitelisted elementwise expression over auxiliary loads. The
+    auxiliary leaves accept exact-shape
+    (``residual[tile_m, tile_n]``, rank-2 matching the carrier tile)
+    and rank-1 trailing-axis (rowvec) broadcast forms
+    (``bias[tile_n]``, where the single load index symbol matches
+    the carrier's trailing tile-id symbol). Other
     shapes — 3-D collapsed loads, indices that are not exactly the
     carrier trailing tile-id symbol, leading-axis rank-1
     (``bias[tile_m]``), kwargs — are rejected so the loud-failure
@@ -1082,7 +1404,7 @@ def analyze_tcgen05_unary_epilogue_chain(
     carrier_tile_shape = _carrier_tile_shape(chain_input)
     carrier_tile_index_nodes = _carrier_tile_index_nodes(chain_input)
 
-    steps: list[_UnaryStep | _AuxiliaryTensorStep] = []
+    steps: list[_AuxiliaryTensorExprStep] = []
     cur: torch.fx.Node = chain_input
     # Bound the walk so a pathological FX graph cannot loop forever.
     # 32 unary ops between the matmul and the store is an absurd upper
@@ -1098,7 +1420,14 @@ def analyze_tcgen05_unary_epilogue_chain(
             arg = cur.args[0] if cur.args else None
             if not isinstance(arg, torch.fx.Node):
                 return None
-            steps.append(_ZERO_ARG_TARGETS[target])
+            steps.append(
+                _AuxiliaryTensorExprStep(
+                    expr=_UnaryTensorExpr(
+                        step=_ZERO_ARG_TARGETS[target],
+                        operand=_CurrentTensorExpr(),
+                    )
+                )
+            )
             anchor = walk_carrier_to_tcgen05_matmul(
                 arg, target_fx_nodes, inner_outputs_by_graph_id
             )
@@ -1117,8 +1446,15 @@ def analyze_tcgen05_unary_epilogue_chain(
         # FX shapes and the rationale for matching the inductor form.
         silu = _classify_silu(cur)
         if silu is not None:
-            step, carrier = silu
-            steps.append(step)
+            unary_op, carrier = silu
+            steps.append(
+                _AuxiliaryTensorExprStep(
+                    expr=_UnaryTensorExpr(
+                        step=unary_op,
+                        operand=_CurrentTensorExpr(),
+                    )
+                )
+            )
             anchor = walk_carrier_to_tcgen05_matmul(
                 carrier, target_fx_nodes, inner_outputs_by_graph_id
             )

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -5125,7 +5125,7 @@ def _analyze_mma_output_stores(
             return None
         explicit_epi_tile_compatible &= (
             tensor_fake.dtype == analysis.lhs.source_fake.dtype
-            and all(step.broadcast_axis == 1 for step in chain.auxiliary_tensor_steps)
+            and all(step.broadcast_axis == 1 for step in chain.auxiliary_tensor_loads)
         )
         store_major = _tcgen05_tma_matrix_major(tensor_fake)
         if store_major is None:

--- a/helion/language/_gelu_tanh_approx.py
+++ b/helion/language/_gelu_tanh_approx.py
@@ -19,7 +19,7 @@ node and splice the polynomial inline as one chain step against the
 already-bound carrier local.
 
 Inside the tcgen05 chain analyzer, ``_gelu_tanh_approx`` is registered
-as a ``_UnaryStep`` row in ``_ZERO_ARG_TARGETS`` keyed on the api
+as a ``_UnaryOp`` row in ``_ZERO_ARG_TARGETS`` keyed on the api
 wrapper itself (the FX target). The template references the carrier
 local four times in the standard polynomial; the renderer keeps that
 carrier bound before formatting the template.
@@ -60,7 +60,7 @@ GELU_ERF_INV_SQRT2: float = 0.7071067811865476
 # Templates for backend codegen.
 #
 # The cute template uses ``{inner}`` directly so it plugs into the
-# tcgen05 chain analyzer's ``_UnaryStep.template`` slot
+# tcgen05 chain analyzer's ``_UnaryOp.template`` slot
 # (``cute_epilogue.py`` substitutes ``{inner}`` with the current
 # carrier local). The cute-backend codegen below also calls
 # ``.format(inner=...)`` against the lifted local name to share the

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -73,7 +73,7 @@ from .stack_tensor import StackTensor
 if TYPE_CHECKING:
     from .._compiler.cute.cute_epilogue import Tcgen05GroupedTailEpilogueMatch
     from .._compiler.cute.cute_epilogue import Tcgen05UnaryEpilogueChain
-    from .._compiler.cute.cute_epilogue import _AuxiliaryTensorStep
+    from .._compiler.cute.cute_epilogue import _AuxiliaryTensorLoadExpr
     from .._compiler.cute.device_state import CuteTcgen05StoreValue
     from .._compiler.cute.fragment_epilogue import Tcgen05PairEpiloguePlan
     from .._compiler.inductor_lowering import CodegenState
@@ -99,6 +99,7 @@ class _AuxStepRecord:
     the per-output-tile setup and per-subtile load helpers.
     """
 
+    expr: _AuxiliaryTensorLoadExpr
     aux_tensor_name: str
     broadcast_axis: int | None
     has_leading_passthrough: bool
@@ -1873,7 +1874,7 @@ def _codegen_cute_store_tcgen05_tile(
         epi_warp_ids += ","
 
     # Per-aux-step plumbing: per-thread auxiliary tensor reads at
-    # the splice site. For each ``_AuxiliaryTensorStep`` in the
+    # the splice site. For each ``_AuxiliaryTensorLoadExpr`` in the
     # chain we register the auxiliary tensor as a kernel arg,
     # allocate fresh AST var names for the partitioning chain, and
     # later (inside each per-thread splice site) emit per-subtile
@@ -1882,8 +1883,8 @@ def _codegen_cute_store_tcgen05_tile(
     # ``ttr_aux_subtile.load()`` form. SIMT-store edge tiles use a
     # predicated GMEM-to-register copy first, so the aux read observes
     # the same runtime predicate as the output store.
-    aux_steps_in_chain: tuple[_AuxiliaryTensorStep, ...] = (
-        epilogue_chain.auxiliary_tensor_steps if epilogue_chain is not None else ()
+    aux_steps_in_chain: tuple[_AuxiliaryTensorLoadExpr, ...] = (
+        epilogue_chain.auxiliary_tensor_loads if epilogue_chain is not None else ()
     )
     tcgen05_aux_load_placement = df.config.get(
         TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
@@ -1929,6 +1930,7 @@ def _codegen_cute_store_tcgen05_tile(
         )
         aux_step_records.append(
             _AuxStepRecord(
+                expr=aux_step,
                 aux_tensor_name=aux_tensor_name,
                 broadcast_axis=aux_step.broadcast_axis,
                 has_leading_passthrough=aux_torch_tensor.ndim == 3,
@@ -2463,7 +2465,7 @@ def _codegen_cute_store_tcgen05_tile(
 
         For the broadcast form the helper first builds a 2-D view
         of the underlying rank-1 tensor with stride 0 on the
-        orthogonal axis (see :class:`_AuxiliaryTensorStep` for the
+        orthogonal axis (see :class:`_AuxiliaryTensorLoadExpr` for the
         canonical contract).
 
         When ``define_thr_copy_t2r`` is True the helper emits the
@@ -3118,12 +3120,35 @@ def _codegen_cute_store_tcgen05_tile(
             force_simt_edge_aux=force_simt_edge_aux,
             safe_direct_aux_with_full_tile=safe_direct_aux_with_full_tile,
         )
-        aux_locals: tuple[str, ...] = tuple(rec.aux_loaded for rec in aux_step_records)
+        aux_locals_by_expr = {rec.expr: rec.aux_loaded for rec in aux_step_records}
+        assert len(aux_locals_by_expr) == len(aux_step_records)
+        if (
+            len(epilogue_chain.steps) == 1
+            and epilogue_chain.steps[0].hoistable_aux_expr is not None
+        ):
+            # The auxiliary expression does not depend on the accumulator.
+            # Form it with the auxiliary-load prelude so pre-wait placement can
+            # overlap its loads and elementwise operations with the MMA tail.
+            expr_step = epilogue_chain.steps[0]
+            aux_expr_prelude, aux_expr = (
+                expr_step.render_hoistable_aux_prelude_and_expr(
+                    aux_locals_by_expr,
+                    df.new_var,
+                    prelude_indent,
+                )
+            )
+            final_expr = df.new_var("tcgen05_chain_step")
+            rendered_step = expr_step.render_with_hoisted_aux(loaded, aux_expr)
+            return (
+                early_aux_prelude + aux_expr_prelude,
+                prelude_load + f"{prelude_indent}{final_expr} = {rendered_step}\n",
+                f"({final_expr}).to({target_dtype})",
+            )
         chain_prelude, final_expr = epilogue_chain.render_prelude_and_expr(
             loaded,
             df.new_var,
             prelude_indent,
-            aux_locals_by_step=aux_locals or None,
+            aux_locals_by_expr=aux_locals_by_expr or None,
         )
         return (
             early_aux_prelude,

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -9,12 +9,13 @@ own best config (best of the wall-clock and cudagraph autotune sweeps, chosen
 by a per-shape cudagraph microbenchmark). Benchmarks clear the L2 cache before
 every replay (cold L2), matching pretuned_kernels/_bench.py.
 
-The two 512-M shapes were re-tuned (ncu-guided, not autotune) onto the fp8
-small-grid 2-CTA cluster (bm=128, cluster_m=2, deep ab=12): NCU showed the old
-cluster_m=1 bm=128 tile ran at 0.86 waves (128 tiles on 148 SMs) and was
-barrier/occupancy bound; cluster_m=2 doubles the CTA count and multicasts A
-across the CTA pair (halving its cold DRAM read), lifting 512x2048x4096 from
-0.73x to 0.80x and 512x2048x2048 from 0.86x to 0.91x vs the best baseline.
+The 512x2048x4096 shape uses a four-CTA bm=256/cluster-(2,2) specialization
+with c_stages=2. NCU showed that the previous bm=128/cluster-(2,1) path issued
+18,432 global-load instructions for the broadcast scales, versus 1,024 after
+per-warp row-vector staging and tile-lifetime column-vector scalar reuse. The
+four-CTA tile plus one-shot schedule reduced cold-L2 CUDA-graph latency from
+8.79 to 8.08 us (1.088x) on B200 and reached 1.007x versus the local CUTLASS
+baseline. The other M512 shape retains its existing generic schedule.
 
 The twelve M=64 shapes (vLLM Qwen3 FP8 (K, N) sweep) use cluster_m=1 bm=64 tiles.
 ncu showed the main loop dominates the gap to cutlass and was barrier-bound (5 of
@@ -224,13 +225,9 @@ _KEYS_scale_mm_cute = [
 _CONFIGS_scale_mm_cute = [
     # (M, K, N) = (4096, 4096, 4096)
     {'block_sizes': [256, 256, 128], 'l2_groupings': [4], 'indexing': ['pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 8, 'tcgen05_strategy': 'role_local_monolithic', 'tcgen05_layout_strategy': 'default', 'tcgen05_warp_spec_mma_warps': 1, 'tcgen05_warp_spec_ab_load_warps': 1, 'tcgen05_warp_spec_epi_load_warps': 0, 'tcgen05_warp_spec_scheduler_warps': 0, 'tcgen05_warp_spec_c_input_warps': 0, 'tcgen05_warp_spec_store_warps': 0, 'tcgen05_warp_spec_register_decrease': 120, 'tcgen05_warp_spec_register_increase': 256, 'cute_vector_widths': [1, 1, 1], 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_layout_overrides_epi_tile_m': None, 'tcgen05_layout_overrides_epi_tile_n': None, 'tcgen05_layout_overrides_smem_swizzle_a': None, 'tcgen05_layout_overrides_smem_swizzle_b': None, 'tcgen05_layout_overrides_d_store_box_n': None},
-    # (M, K, N) = (512, 2048, 4096)
-    # Re-tuned to the fp8 small-grid 2-CTA cluster (bm=128, cluster_m=2, per-CTA
-    # 64xbn) with a deep ab=12 prefetch. cluster_m=2 doubles the CTA count to 256
-    # (fills the 148-SM B200; the old cluster_m=1 bm=128 tile ran at 0.86 waves)
-    # and multicasts A across the CTA pair, halving its cold DRAM read. Cold-L2
-    # cudagraph vs best baseline (cutlass): 0.73x -> 0.80x on B200.
-    {'block_sizes': [128, 128, 128], 'l2_groupings': [1], 'num_warps': 8, 'num_stages': 4, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_ab_stages': 12, 'tcgen05_num_epi_warps': 4, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
+    # (M, K, N) = (512, 2048, 4096) -- four-CTA specialization with broadcast
+    # scale reuse and a grouped scale product overlapped with the MMA tail.
+    {'block_sizes': [256, 128, 128], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 1, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
     # (M, K, N) = (512, 2048, 2048)
     # Same fp8 small-grid 2-CTA cluster as (512, 2048, 4096): device-filling
     # cluster_m=2 + A-multicast + deep ab=12 beats the old cluster_m=1 bn=64 tile.

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -10,7 +10,8 @@ W8A8 serving shapes that back the nightly B200 CuTe benchmark dashboard.
 
 Specialized kernels include:
 
-* :func:`scale_mm_cute` tiles over both M and N.
+* :func:`scale_mm_cute` tiles over both M and N and specializes its epilogue
+  for the four-CTA M512 schedule.
 * :func:`scale_mm_cute_skinny_m` keeps the full (small) M resident and tiles
   only over N for single-token decode.
 * :func:`scale_mm_cute_swap_ab` swaps M/N so small-M shapes can use efficient
@@ -50,6 +51,7 @@ _M64_SWAP_SHAPES = {
     (64, 25600, 5120),
 }
 _SWAP_AB_SHAPES = _SMALL_M_SWAP_SHAPES | _M64_SWAP_SHAPES
+_M512_OPT_SHAPE = (512, 2048, 4096)
 
 
 @helion.aot_kernel(backend="cute", static_shapes=True)
@@ -64,13 +66,22 @@ def scale_mm_cute(
     k2, n = y.size()
     assert k == k2, f"size mismatch {k} != {k2}"
     out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    use_grouped_scale = hl.constexpr(m == 512 and k == 2048 and n == 4096)
     for tile_m, tile_n in hl.tile([m, n]):
         acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
         for tile_k in hl.tile(k):
             acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
-        # RowWise scale in the epilogue (per-row scale_a x per-column scale_b).
-        acc = acc * scale_a[tile_m, tile_n] * scale_b[tile_n]
-        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+        if use_grouped_scale:
+            # This shape gate exists because it is currently the only pretuned
+            # shape using the four-CTA schedule, which overlaps the independent
+            # scale product with its MMA tail. Keep the sequential form elsewhere:
+            # grouping spills at the 255-register limit, e.g. 4096^3 schedule.
+            tile_scale = scale_a[tile_m, tile_n] * scale_b[tile_n]
+            out[tile_m, tile_n] = (acc * tile_scale).to(torch.bfloat16)
+        else:
+            # RowWise scale in the epilogue (per-row scale_a x per-column scale_b).
+            acc = acc * scale_a[tile_m, tile_n] * scale_b[tile_n]
+            out[tile_m, tile_n] = acc.to(torch.bfloat16)
     return out
 
 

--- a/test/test_cute_epilogue.py
+++ b/test/test_cute_epilogue.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch.fx import Graph
+
+import helion
+from helion import exc
+from helion._compiler.cute import cute_epilogue
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_AUX_LOAD_PLACEMENT_PRE_ACC_WAIT,
+)
+from helion._testing import DEVICE
+from helion._testing import patch_cute_mma_support
+import helion.language as hl
+
+
+def _make_tcgen05_persistent_config(**overrides: object) -> helion.Config:
+    defaults: dict[str, object] = {
+        "block_sizes": [128, 256, 16],
+        "l2_groupings": [1],
+        "loop_orders": [[0, 1]],
+        "num_stages": 2,
+        "num_warps": 8,
+        "pid_type": "flat",
+        "tcgen05_cluster_m": 1,
+        "tcgen05_ab_stages": 2,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+    }
+    defaults.update(overrides)
+    return helion.Config(**defaults)  # type: ignore[arg-type]
+
+
+class TestCuteEpilogue(unittest.TestCase):
+    def test_auxiliary_tensor_expr_helpers(self) -> None:
+        """Expression helpers preserve structure and explicit leaf bindings."""
+        graph = Graph()
+        load_a = cute_epilogue._AuxiliaryTensorLoadExpr(
+            load_node=graph.placeholder("load_a"),
+            broadcast_axis=None,
+            template="{aux}",
+        )
+        load_b = cute_epilogue._AuxiliaryTensorLoadExpr(
+            load_node=graph.placeholder("load_b"),
+            broadcast_axis=1,
+            template="{aux}",
+        )
+        aux_product = cute_epilogue._BinaryTensorExpr(
+            op_name="mul",
+            op_template="{lhs} * {rhs}",
+            lhs=load_a,
+            rhs=load_b,
+        )
+        expr = cute_epilogue._BinaryTensorExpr(
+            op_name="mul",
+            op_template="{lhs} * {rhs}",
+            lhs=cute_epilogue._CurrentTensorExpr(),
+            rhs=aux_product,
+        )
+        step = cute_epilogue._AuxiliaryTensorExprStep(expr=expr)
+
+        self.assertEqual(
+            cute_epilogue._auxiliary_tensor_expr_operands(expr),
+            (load_a, load_b),
+        )
+        self.assertFalse(cute_epilogue._tensor_expr_contains_current(aux_product))
+        self.assertTrue(cute_epilogue._tensor_expr_contains_current(expr))
+        self.assertIs(step.hoistable_aux_expr, aux_product)
+
+        # Reverse insertion order demonstrates that rendering looks up each
+        # exact leaf instead of consuming locals positionally.
+        prelude, result = step.render_hoistable_aux_prelude_and_expr(
+            {load_b: "local_b", load_a: "local_a"},
+            lambda prefix: prefix,
+            "    ",
+        )
+        self.assertEqual(
+            prelude,
+            "    tcgen05_aux_product = local_a * local_b\n",
+        )
+        self.assertEqual(result, "tcgen05_aux_product")
+        self.assertEqual(
+            step.render_with_hoisted_aux("acc", result),
+            "acc * tcgen05_aux_product",
+        )
+
+        direct_load_step = cute_epilogue._AuxiliaryTensorExprStep(
+            expr=cute_epilogue._BinaryTensorExpr(
+                op_name="add",
+                op_template="{lhs} + {rhs}",
+                lhs=cute_epilogue._CurrentTensorExpr(),
+                rhs=load_a,
+            )
+        )
+        self.assertIsNone(direct_load_step.hoistable_aux_expr)
+
+    def test_auxiliary_tensor_expr_fx_helpers(self) -> None:
+        """The structural precheck and metadata-aware classifier stay distinct."""
+        graph = Graph()
+        load_a = graph.placeholder("load_a")
+        load_a.meta["val"] = torch.empty((4, 4), dtype=torch.float32)
+        load_b = graph.placeholder("load_b")
+        load_b.meta["val"] = torch.empty((4, 4), dtype=torch.float32)
+        product = graph.call_function(
+            torch.ops.aten.mul.Tensor,
+            args=(load_a, load_b),
+        )
+        product.meta["val"] = torch.empty((4, 4), dtype=torch.float32)
+        relu = graph.call_function(torch.ops.aten.relu.default, args=(product,))
+        relu.meta["val"] = torch.empty((4, 4), dtype=torch.float32)
+        unsupported = graph.call_function(torch.ops.aten.sum.default, args=(load_a,))
+        unsupported.meta["val"] = torch.empty((), dtype=torch.float32)
+
+        with patch.object(
+            cute_epilogue,
+            "_is_helion_load_node",
+            side_effect=lambda node: node is load_a or node is load_b,
+        ):
+            self.assertTrue(cute_epilogue._is_auxiliary_tensor_expr_node(relu))
+            self.assertFalse(cute_epilogue._is_auxiliary_tensor_expr_node(unsupported))
+
+        def load_kind(
+            node: torch.fx.Node,
+            **kwargs: object,
+        ) -> tuple[str, int | None] | None:
+            if node is load_a:
+                return "exact", None
+            if node is load_b:
+                return "broadcast", 1
+            return None
+
+        with patch.object(
+            cute_epilogue,
+            "aux_tensor_load_kind",
+            side_effect=load_kind,
+        ):
+            classified = cute_epilogue._classify_auxiliary_tensor_expr(
+                product,
+                carrier_tile_shape=(4, 4),
+                carrier_tile_index_nodes=None,
+                carrier_global_shape=(4, 4),
+            )
+            self.assertIsNone(
+                cute_epilogue._classify_auxiliary_tensor_expr(
+                    unsupported,
+                    carrier_tile_shape=(4, 4),
+                    carrier_tile_index_nodes=None,
+                    carrier_global_shape=(4, 4),
+                )
+            )
+
+        self.assertIsInstance(classified, cute_epilogue._BinaryTensorExpr)
+        assert isinstance(classified, cute_epilogue._BinaryTensorExpr)
+        self.assertIsInstance(classified.lhs, cute_epilogue._AuxiliaryTensorLoadExpr)
+        self.assertIsInstance(classified.rhs, cute_epilogue._AuxiliaryTensorLoadExpr)
+        assert isinstance(classified.lhs, cute_epilogue._AuxiliaryTensorLoadExpr)
+        assert isinstance(classified.rhs, cute_epilogue._AuxiliaryTensorLoadExpr)
+        self.assertIs(classified.lhs.load_node, load_a)
+        self.assertIsNone(classified.lhs.broadcast_axis)
+        self.assertIs(classified.rhs.load_node, load_b)
+        self.assertEqual(classified.rhs.broadcast_axis, 1)
+
+    def test_auxiliary_tensor_expr_helpers_reject_unknown_variant(self) -> None:
+        """Every recursive expression helper fails loudly on a new variant."""
+        unknown = cast("Any", object())
+        for helper in (
+            cute_epilogue._auxiliary_tensor_expr_operands,
+            cute_epilogue._tensor_expr_contains_current,
+        ):
+            with (
+                self.subTest(helper=helper.__name__),
+                self.assertRaisesRegex(
+                    AssertionError, "unexpected tensor expression: object"
+                ),
+            ):
+                helper(unknown)
+        with self.assertRaisesRegex(
+            AssertionError, "unexpected tensor expression: object"
+        ):
+            cute_epilogue._render_auxiliary_tensor_expr(
+                unknown,
+                "acc",
+                {},
+                lambda prefix: prefix,
+                "",
+            )
+
+    def test_tcgen05_fused_auxiliary_product_codegen(self) -> None:
+        """An explicitly grouped pair of scale loads stays one epilogue step."""
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def scaled_fp8(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale_m: torch.Tensor,
+            scale_n: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                tile_scale = scale_m[tile_m, tile_n] * scale_n[tile_n]
+                out[tile_m, tile_n] = (acc * tile_scale).to(torch.bfloat16)
+            return out
+
+        args = (
+            torch.empty([256, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([128, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([256, 1], device=DEVICE).expand(256, 128),
+            torch.empty([128], device=DEVICE),
+        )
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[128, 128, 128],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            indexing=["tensor_descriptor"] * 5,
+        )
+        with patch_cute_mma_support():
+            bound = scaled_fp8.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+
+        loop_pos = code.index("for _tcgen05_subtile in cutlass.range")
+        product_pos = code.index(
+            "tcgen05_aux_loaded_0 * tcgen05_aux_loaded_1", loop_pos
+        )
+        acc_pos = code.index("tcgen05_acc_loaded", loop_pos)
+        self.assertLess(product_pos, acc_pos)
+
+    def test_tcgen05_fused_reused_auxiliary_load_codegen(self) -> None:
+        """Repeated uses of one FX load retain distinct leaf-to-local bindings."""
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def scaled_fp8(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                tile_scale = scale[tile_m, tile_n]
+                acc = acc + tile_scale
+                out[tile_m, tile_n] = (acc + tile_scale).to(torch.bfloat16)
+            return out
+
+        args = (
+            torch.empty([256, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([128, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([256, 1], device=DEVICE).expand(256, 128),
+        )
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[128, 128, 128],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            indexing=["tensor_descriptor"] * 4,
+        )
+        with patch_cute_mma_support():
+            bound = scaled_fp8.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+
+        loop_pos = code.index("for _tcgen05_subtile in cutlass.range")
+        chain_lines = [
+            line
+            for line in code[loop_pos:].splitlines()
+            if "tcgen05_chain_step" in line and " = " in line
+        ]
+        self.assertGreaterEqual(len(chain_lines), 2)
+        self.assertIn("tcgen05_aux_loaded_0", chain_lines[0])
+        self.assertIn("tcgen05_aux_loaded_1", chain_lines[1])
+
+    def test_tcgen05_fused_auxiliary_unary_expr_codegen(self) -> None:
+        """Whitelisted unary ops can consume a grouped auxiliary expression."""
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def scaled_fp8(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale_m: torch.Tensor,
+            scale_n: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                tile_scale = torch.exp(scale_m[tile_m, tile_n] * scale_n[tile_n])
+                out[tile_m, tile_n] = (tile_scale - acc).to(torch.bfloat16)
+            return out
+
+        args = (
+            torch.empty([256, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([128, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([256, 1], device=DEVICE).expand(256, 128),
+            torch.empty([128], device=DEVICE),
+        )
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[128, 128, 128],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            indexing=["tensor_descriptor"] * 5,
+        )
+        with patch_cute_mma_support():
+            bound = scaled_fp8.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+
+        loop_pos = code.index("for _tcgen05_subtile in cutlass.range")
+        product_pos = code.index(
+            "tcgen05_aux_loaded_0 * tcgen05_aux_loaded_1", loop_pos
+        )
+        unary_pos = code.index("cute.math.exp(tcgen05_aux_product", product_pos)
+        acc_pos = code.index("tcgen05_acc_loaded", loop_pos)
+        carrier_line = next(
+            line
+            for line in code[acc_pos:].splitlines()
+            if "tcgen05_chain_step" in line and " = " in line
+        )
+        self.assertLess(product_pos, unary_pos)
+        self.assertLess(unary_pos, acc_pos)
+        self.assertIn("tcgen05_acc_loaded", carrier_line)
+        self.assertIn("tcgen05_aux_expr", carrier_line)
+        self.assertIn(" - ", carrier_line)
+        self.assertLess(
+            carrier_line.index("tcgen05_aux_expr"),
+            carrier_line.index("tcgen05_acc_loaded"),
+        )
+
+        int_args = (
+            args[0],
+            args[1],
+            torch.empty([256, 1], device=DEVICE, dtype=torch.int32).expand(256, 128),
+            torch.empty([128], device=DEVICE, dtype=torch.int32),
+        )
+        with patch_cute_mma_support():
+            int_bound = scaled_fp8.bind(int_args)
+            int_bound.env.config_spec.cute_tcgen05_search_enabled = True
+            with self.assertRaises(exc.BackendUnsupported):
+                int_bound.to_triton_code(cfg)
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def integer_scaled(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                out[tile_m, tile_n] = (acc + scale[tile_m, tile_n] * 2).to(
+                    torch.bfloat16
+                )
+            return out
+
+        int_scalar_cfg = _make_tcgen05_persistent_config(
+            block_sizes=[128, 128, 128],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            indexing=["tensor_descriptor"] * 4,
+        )
+        with patch_cute_mma_support():
+            int_scalar_bound = integer_scaled.bind((args[0], args[1], int_args[2]))
+            int_scalar_bound.env.config_spec.cute_tcgen05_search_enabled = True
+            with self.assertRaises(exc.BackendUnsupported):
+                int_scalar_bound.to_triton_code(int_scalar_cfg)
+
+    def test_tcgen05_bm256_broadcast_scales_reuse_auxiliary_loads(self) -> None:
+        """The four-CTA full-tile epilogue reuses both broadcast scales."""
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def scaled_fp8(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale_m: torch.Tensor,
+            scale_n: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                tile_scale = scale_m[tile_m, tile_n] * scale_n[tile_n]
+                out[tile_m, tile_n] = (acc * tile_scale).to(torch.bfloat16)
+            return out
+
+        args = (
+            torch.empty([512, 128], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([128, 256], device=DEVICE, dtype=torch.float8_e4m3fn),
+            torch.empty([512, 1], device=DEVICE).expand(512, 256),
+            torch.empty([256], device=DEVICE),
+        )
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[256, 128, 128],
+            pid_type="persistent_blocked",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=2,
+            tcgen05_acc_stages=1,
+            tcgen05_aux_load_placement=TCGEN05_AUX_LOAD_PLACEMENT_PRE_ACC_WAIT,
+            indexing=["tensor_descriptor"] * 5,
+        )
+        with patch_cute_mma_support():
+            bound = scaled_fp8.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+
+        self.assertIn(
+            "tcgen05_aux_rowvec_smem_layout_1 = "
+            "cute.make_layout((4, 128), stride=(128, 1))",
+            code,
+        )
+        self.assertIn(
+            "tcgen05_aux_rowvec_tiled_copy_1 = cute.make_tiled_copy_tv",
+            code,
+        )
+        self.assertIn(
+            "tcgen05_aux_rowvec_thr_copy_1 = "
+            "tcgen05_aux_rowvec_tiled_copy_1.get_slice("
+            "tcgen05_epi_tidx % cutlass.Int32(32))",
+            code,
+        )
+        self.assertIn(
+            "tcgen05_aux_rowvec_smem_1[tcgen05_epi_tidx // "
+            "cutlass.Int32(32), None].iterator",
+            code,
+        )
+        scalar_assignment = next(
+            line.strip()
+            for line in code.splitlines()
+            if "tcgen05_colvec_scalar_full" in line and " = " in line
+        )
+        self.assertIn("tcgen05_tTR_gAux_grouped_0[0, 0, 0, 0]", scalar_assignment)
+        scalar_name = scalar_assignment.split(" = ", 1)[0]
+        scalar_pos = code.index(scalar_assignment)
+        loop_pos = code.index("for _tcgen05_subtile in cutlass.range", scalar_pos)
+        scalar_use_pos = code.index(f"tcgen05_aux_loaded_0 = {scalar_name}", loop_pos)
+        product_pos = code.index("tcgen05_aux_product", scalar_use_pos)
+        wait_pos = code.index("tcgen05_acc_pipeline.consumer_wait", loop_pos)
+        self.assertLess(scalar_pos, loop_pos)
+        self.assertLess(scalar_use_pos, product_pos)
+        self.assertLess(product_pos, wait_pos)
+        self.assertNotIn("tcgen05_aux_rowvec_pred_1", code)

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -8548,7 +8548,7 @@ class TestCuteLowerings(unittest.TestCase):
         analyzer's linear-chain assumption (negative pinned by
         ``test_tcgen05_fused_gelu_tanh_approx_eager_polynomial_rejected``);
         the device_ir decomp folds the whole expression into a single
-        ``_UnaryStep`` row so the splice site emits the polynomial
+        ``_UnaryOp`` row so the splice site emits the polynomial
         against the already-bound carrier local.
         """
 


### PR DESCRIPTION
Stacked PRs:
 * #3377
 * __->__#3376
 * #3363


--- --- ---

### [cute] Extend epilogue analysis with auxiliary tensor expression steps


Retune scale_mm_cute for (M, K, N) = (512, 2048, 4096) and
generalize the tcgen05 fused-epilogue representation so the grouped scale
expression can be lowered without materializing an intermediate tensor.

The M512 kernel now uses a bm=256, bn=128, bk=128 four-CTA cluster-(2,2)
schedule with an eight-stage A/B pipeline, one accumulator stage, two output
stages, persistent-blocked scheduling, and pre-accumulator-wait auxiliary
loads. It replaces the previous bm=128 cluster-(2,1) schedule.

NCU showed that the previous schedule issued 18,432 global-load instructions
for the broadcast scales. Per-warp row-vector staging and tile-lifetime
column-vector scalar reuse reduce that to 1,024 instructions. Together with
the four-CTA tile and one-shot schedule, this reduces cold-L2 CUDA-graph
latency on B200 from 8.79 us to 8.08 us, a 1.088x speedup, and reaches 1.007x
of the local CUTLASS baseline.

Express the scale operation explicitly as:

    tile_scale = scale_a[tile_m, tile_n] * scale_b[tile_n]
    out[tile_m, tile_n] = (acc * tile_scale).to(torch.bfloat16)

This changes the arithmetic association from `(acc * scale_a) * scale_b` to
`acc * (scale_a * scale_b)`. The explicit grouping makes the auxiliary-only
product independent of the accumulator, allowing its loads and elementwise
work to overlap the MMA tail before the accumulator wait.

Replace the separate unary, auxiliary-load, and auxiliary-product step types
with `_AuxiliaryTensorExprStep`. A step is now one transition of the value
derived from the accumulator (the "carrier"), rather than one operation in
the complete FX expression. Each step owns a recursive expression tree whose
leaves can reference the current carrier or validated auxiliary loads and
whose internal nodes can contain whitelisted unary, scalar, and binary
operations. Operations entirely inside an auxiliary-only subtree do not add
carrier steps.

For example:

    value = acc * (scale_a * scale_b)
    value = value.relu()
    value = value + residual
    out[...] = value.to(torch.bfloat16)

This produces three carrier steps:

    1. acc -> acc * (scale_a * scale_b)
    2. value -> relu(value)
    3. value -> value + residual

Similarly:

    ((acc + 1.0) * 2.0).relu()       # 3 carrier steps
    exp(relu(acc))                    # 2 carrier steps
    exp(acc) * (scale_a * scale_b)   # 2 carrier steps
    acc * exp(scale_a * scale_b)     # 1 carrier step

In the final example, `exp(scale_a * scale_b)` remains an auxiliary-only
subtree within the single carrier multiplication. Consequently,
`len(epilogue_chain.steps) == 1` means that there is one carrier transition;
it does not mean that the expression contains only one operation.

For a single carrier step with a nontrivial auxiliary-only operand, emit the
auxiliary loads and expression prelude before the accumulator wait, then load
the accumulator and combine it with the precomputed auxiliary result. Keep
direct single-load epilogues on their existing path, preserve operand order
for noncommutative operations, preserve the user's expression association,
and reject unsafe dtype-changing auxiliary expressions.

Add code-generation coverage for grouped auxiliary products, unary operations
inside auxiliary expressions, reverse operand forms, integer-promotion
rejection, and the ordering of auxiliary work relative to the accumulator
wait.
