### PR TITLE
[cute] Retune the M512 scaled FP8 kernel

### DIFF
--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -9,12 +9,13 @@ own best config (best of the wall-clock and cudagraph autotune sweeps, chosen
 by a per-shape cudagraph microbenchmark). Benchmarks clear the L2 cache before
 every replay (cold L2), matching pretuned_kernels/_bench.py.
 
-The two 512-M shapes were re-tuned (ncu-guided, not autotune) onto the fp8
-small-grid 2-CTA cluster (bm=128, cluster_m=2, deep ab=12): NCU showed the old
-cluster_m=1 bm=128 tile ran at 0.86 waves (128 tiles on 148 SMs) and was
-barrier/occupancy bound; cluster_m=2 doubles the CTA count and multicasts A
-across the CTA pair (halving its cold DRAM read), lifting 512x2048x4096 from
-0.73x to 0.80x and 512x2048x2048 from 0.86x to 0.91x vs the best baseline.
+The 512x2048x4096 shape uses a four-CTA bm=256/cluster-(2,2) specialization
+with c_stages=2. NCU showed that the previous bm=128/cluster-(2,1) path issued
+18,432 global-load instructions for the broadcast scales, versus 1,024 after
+per-warp row-vector staging and tile-lifetime column-vector scalar reuse. The
+four-CTA tile plus one-shot schedule reduced cold-L2 CUDA-graph latency from
+8.79 to 8.08 us (1.088x) on B200 and reached 1.007x versus the local CUTLASS
+baseline. The other M512 shape retains its existing generic schedule.
 
 The twelve M=64 shapes (vLLM Qwen3 FP8 (K, N) sweep) use cluster_m=1 bm=64 tiles.
 ncu showed the main loop dominates the gap to cutlass and was barrier-bound (5 of
@@ -224,13 +225,9 @@ _KEYS_scale_mm_cute = [
 _CONFIGS_scale_mm_cute = [
     # (M, K, N) = (4096, 4096, 4096)
     {'block_sizes': [256, 256, 128], 'l2_groupings': [4], 'indexing': ['pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 8, 'tcgen05_strategy': 'role_local_monolithic', 'tcgen05_layout_strategy': 'default', 'tcgen05_warp_spec_mma_warps': 1, 'tcgen05_warp_spec_ab_load_warps': 1, 'tcgen05_warp_spec_epi_load_warps': 0, 'tcgen05_warp_spec_scheduler_warps': 0, 'tcgen05_warp_spec_c_input_warps': 0, 'tcgen05_warp_spec_store_warps': 0, 'tcgen05_warp_spec_register_decrease': 120, 'tcgen05_warp_spec_register_increase': 256, 'cute_vector_widths': [1, 1, 1], 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_layout_overrides_epi_tile_m': None, 'tcgen05_layout_overrides_epi_tile_n': None, 'tcgen05_layout_overrides_smem_swizzle_a': None, 'tcgen05_layout_overrides_smem_swizzle_b': None, 'tcgen05_layout_overrides_d_store_box_n': None},
-    # (M, K, N) = (512, 2048, 4096)
-    # Re-tuned to the fp8 small-grid 2-CTA cluster (bm=128, cluster_m=2, per-CTA
-    # 64xbn) with a deep ab=12 prefetch. cluster_m=2 doubles the CTA count to 256
-    # (fills the 148-SM B200; the old cluster_m=1 bm=128 tile ran at 0.86 waves)
-    # and multicasts A across the CTA pair, halving its cold DRAM read. Cold-L2
-    # cudagraph vs best baseline (cutlass): 0.73x -> 0.80x on B200.
-    {'block_sizes': [128, 128, 128], 'l2_groupings': [1], 'num_warps': 8, 'num_stages': 4, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_ab_stages': 12, 'tcgen05_num_epi_warps': 4, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
+    # (M, K, N) = (512, 2048, 4096) -- four-CTA specialization with broadcast
+    # scale reuse and a grouped scale product overlapped with the MMA tail.
+    {'block_sizes': [256, 128, 128], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_blocked', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 1, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_aux_load_placement': 'pre_acc_wait'},
     # (M, K, N) = (512, 2048, 2048)
     # Same fp8 small-grid 2-CTA cluster as (512, 2048, 4096): device-filling
     # cluster_m=2 + A-multicast + deep ab=12 beats the old cluster_m=1 bn=64 tile.

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -10,7 +10,8 @@ W8A8 serving shapes that back the nightly B200 CuTe benchmark dashboard.
 
 Specialized kernels include:
 
-* :func:`scale_mm_cute` tiles over both M and N.
+* :func:`scale_mm_cute` tiles over both M and N and specializes its epilogue
+  for the four-CTA M512 schedule.
 * :func:`scale_mm_cute_skinny_m` keeps the full (small) M resident and tiles
   only over N for single-token decode.
 * :func:`scale_mm_cute_swap_ab` swaps M/N so small-M shapes can use efficient
@@ -50,6 +51,7 @@ _M64_SWAP_SHAPES = {
     (64, 25600, 5120),
 }
 _SWAP_AB_SHAPES = _SMALL_M_SWAP_SHAPES | _M64_SWAP_SHAPES
+_M512_OPT_SHAPE = (512, 2048, 4096)
 
 
 @helion.aot_kernel(backend="cute", static_shapes=True)
@@ -64,13 +66,22 @@ def scale_mm_cute(
     k2, n = y.size()
     assert k == k2, f"size mismatch {k} != {k2}"
     out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    use_grouped_scale = hl.constexpr(m == 512 and k == 2048 and n == 4096)
     for tile_m, tile_n in hl.tile([m, n]):
         acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
         for tile_k in hl.tile(k):
             acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
-        # RowWise scale in the epilogue (per-row scale_a x per-column scale_b).
-        acc = acc * scale_a[tile_m, tile_n] * scale_b[tile_n]
-        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+        if use_grouped_scale:
+            # This shape gate exists because it is currently the only pretuned
+            # shape using the four-CTA schedule, which overlaps the independent
+            # scale product with its MMA tail. Keep the sequential form elsewhere:
+            # grouping spills at the 255-register limit, e.g. 4096^3 schedule.
+            tile_scale = scale_a[tile_m, tile_n] * scale_b[tile_n]
+            out[tile_m, tile_n] = (acc * tile_scale).to(torch.bfloat16)
+        else:
+            # RowWise scale in the epilogue (per-row scale_a x per-column scale_b).
+            acc = acc * scale_a[tile_m, tile_n] * scale_b[tile_n]
+            out[tile_m, tile_n] = acc.to(torch.bfloat16)
     return out
 
 

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -535,6 +535,33 @@ class TestPretunedCuteCodegen(TestCase):
         )
         self.assertEqual(set(configs), module._SWAP_AB_SHAPES)
 
+    def test_scale_mm_pretuned_m512_config(self) -> None:
+        """The static M512 branch selects the validated four-CTA schedule."""
+        path = (
+            PRETUNED_KERNELS_DIR
+            / "scale_mm_cute"
+            / "_helion_aot_scale_mm_cute_cuda_sm100.py"
+        )
+        spec = importlib.util.spec_from_file_location("_scale_mm_cute_aot_m512", path)
+        assert spec is not None and spec.loader is not None
+        heuristic = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(heuristic)
+        module = _import_pretuned_kernel_module("scale_mm_cute")
+
+        configs = dict(
+            zip(
+                heuristic._KEYS_scale_mm_cute,
+                heuristic._CONFIGS_scale_mm_cute,
+                strict=True,
+            )
+        )
+        config = configs[module._M512_OPT_SHAPE]
+        self.assertEqual(config["block_sizes"], [256, 128, 128])
+        self.assertEqual(config["tcgen05_cluster_m"], 2)
+        self.assertEqual(config["tcgen05_cluster_n"], 2)
+        self.assertEqual(config["tcgen05_c_stages"], 2)
+        self.assertEqual(config["tcgen05_aux_load_placement"], "pre_acc_wait")
+
     def test_scale_mm_explicit_epilogue_tile(self) -> None:
         module = _import_pretuned_kernel_module("scale_mm_cute")
         args = module._make_inputs(64, 128, 64)


### PR DESCRIPTION
Stacked PRs:
 * __->__#3378
 * #3377
 * #3376
 * #3363
 * #3362


--- --- ---

### [cute] Retune the M512 scaled FP8 kernel


Route 512x2048x4096 through a specialized scale_mm_cute kernel that keeps the row-scale times column-scale product explicit. Select a legal c_stages=2 four-CTA schedule with bm256/bn128, cluster-(2,2), ab_stages=8, acc_stages=1, identity L2 swizzling, pre-wait auxiliary loads, and one-shot role scheduling.

On B200 with cold-L2 CUDA-graph timing, the checked-in path improves from 8.79 us with the previous bm128/cluster-(2,1) config to 8.08 us, a 1.088x speedup. It also measures 1.007x faster than the local CUTLASS baseline at 8.14 us. Output matches torch._scaled_mm at atol=0.2/rtol=0.01; the observed maximum absolute difference was 1.22e-4.

Keep the other M512 shape on its existing generic schedule and add a heuristic-table test pinning the optimized shape and its c_stages=2 configuration.
