### PR TITLE
[ROCm] Switch ROCm CI runner label from gfx950 to ecosystem.mi350

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -106,7 +106,7 @@
       "triton-pin": "5fcc14d918045eb2c866336b55229d1253d6d60c"
     },
     {
-      "runner": "linux.rocm.gpu.ecosystem.gfx950.1",
+      "runner": "linux.rocm.gpu.ecosystem.mi350.1",
       "python-version": "3.12",
       "ref-eager": false,
       "image": "rocm/dev-ubuntu-24.04:7.0-complete",

--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -181,7 +181,7 @@ jobs:
       id-token: write
       contents: read
     with:
-      runner: linux.rocm.gpu.ecosystem.gfx950.1
+      runner: linux.rocm.gpu.ecosystem.mi350.1
       python-version: "3.12"
       image: rocm/dev-ubuntu-24.04:7.1.1-complete
       runtime-version: rocm7.1


### PR DESCRIPTION
## Summary
- Switch ROCm CI runner label from `linux.rocm.gpu.ecosystem.gfx950.1` to `linux.rocm.gpu.ecosystem.mi350.1` in `.github/workflows/benchmark_dispatch.yml` and `.github/matrix.json`