### PR TITLE
runtime: restore late-specialized eager dispatch performance

### DIFF
--- a/helion/_compiler/_dynamo/variables.py
+++ b/helion/_compiler/_dynamo/variables.py
@@ -26,6 +26,9 @@ import helion.exc as exc
 from helion.runtime.kernel import Kernel
 
 _SYM_SCALAR_TYPES = (torch.SymInt, torch.SymFloat)
+_HOST_SEMANTIC_FINGERPRINT = "_host_semantic_fingerprint"
+_HOST_SEMANTIC_INPUT_NORMALIZATION = "_host_semantic_input_normalization"
+_REQUIRES_ISOLATED_LOWERING = "_requires_isolated_lowering"
 
 if TYPE_CHECKING:
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
@@ -138,10 +141,20 @@ def infer_output_spec(
         n: v for n, v in zip(names, args, strict=True) if isinstance(v, torch.Tensor)
     }
 
-    bound = kernel.bind(args)
-    assert bound.host_function, "kernel.bind() succeeded but host_function is None"
+    # Dynamo capture must not publish fake-tensor-derived bounds into eager caches.
+    bound = kernel._bind_isolated(args)
+    assert bound.host_function, "kernel binding succeeded but host_function is None"
+    # Any user global can be rebound or mutated between capture and lowering.
+    # The host fingerprint is intentionally conservative rather than a complete
+    # serializer for arbitrary Python state, so such bounds lower in isolation.
+    requires_isolated_lowering = bool(bound.host_function.global_imports)
 
     flat_leaves, tree_spec, return_value = _get_flat_output(bound.host_function)
+    host_semantic_input_normalization = bound._get_host_semantic_input_normalization()
+    host_semantic_fingerprint = bound._get_host_semantic_fingerprint(
+        flat_leaves,
+        input_normalization=host_semantic_input_normalization,
+    )
 
     if tree_spec is None:
         return {
@@ -150,6 +163,9 @@ def infer_output_spec(
             "mutated_inputs": _detect_mutated_inputs(
                 bound.host_function.body, set(param_tensors.keys())
             ),
+            _HOST_SEMANTIC_FINGERPRINT: host_semantic_fingerprint,
+            _HOST_SEMANTIC_INPUT_NORMALIZATION: host_semantic_input_normalization,
+            _REQUIRES_ISOLATED_LOWERING: requires_isolated_lowering,
         }
 
     assert return_value is not None
@@ -187,7 +203,7 @@ def infer_output_spec(
             )
 
     # Remap helion-internal SymInts back to the caller's values.
-    # kernel.bind() creates FakeTensors in helion's own ShapeEnv, so output
+    # Kernel binding creates FakeTensors in Helion's own ShapeEnv, so output
     # SymInts aren't tracked by external tracers (make_fx, Dynamo). Build a
     # mapping from helion's input symbols to the caller's original values
     # (which may be tracer SymInts or concrete ints), then substitute.
@@ -268,6 +284,9 @@ def infer_output_spec(
         "tree_spec_str": pytree.treespec_dumps(tree_spec),
         "mutated_inputs": mutated,
         "direct_aliases": direct_aliases,
+        _HOST_SEMANTIC_FINGERPRINT: host_semantic_fingerprint,
+        _HOST_SEMANTIC_INPUT_NORMALIZATION: host_semantic_input_normalization,
+        _REQUIRES_ISOLATED_LOWERING: requires_isolated_lowering,
     }
 
 

--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -1071,9 +1071,9 @@ def lower_helion_kernel(
             )
         if actual_semantic_fingerprint != expected_semantic_fingerprint:
             raise RuntimeError(
-                "Helion kernel trace changed between Dynamo capture and Inductor "
-                f"lowering for kernel {kernel.fn.__name__!r}; keep ambient Python "
-                "and PyTorch state stable while torch.compile is running"
+                "Helion kernel trace or compile environment differed between "
+                "Dynamo capture and Inductor lowering for kernel "
+                f"{kernel.fn.__name__!r}; this configuration cannot be lowered safely"
             )
 
     # Derive output structure from bound kernel using inductor-time input layouts.

--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -5,6 +5,7 @@ from contextlib import nullcontext
 import dataclasses
 import functools
 import hashlib
+import logging
 from typing import TYPE_CHECKING
 from typing import cast
 
@@ -39,6 +40,9 @@ from .._dynamo.higher_order_ops import _rebuild_container_args
 from .._dynamo.higher_order_ops import get_helion_kernel
 from .._dynamo.higher_order_ops import helion_kernel_wrapper_functional
 from .._dynamo.higher_order_ops import helion_kernel_wrapper_mutation
+from .._dynamo.variables import _HOST_SEMANTIC_FINGERPRINT
+from .._dynamo.variables import _HOST_SEMANTIC_INPUT_NORMALIZATION
+from .._dynamo.variables import _REQUIRES_ISOLATED_LOWERING
 from .._dynamo.variables import _get_flat_output
 from ..ast_extension import unparse
 from ..generate_ast import generate_ast
@@ -60,6 +64,9 @@ if TYPE_CHECKING:
     from ..inductor_lowering import CodegenState
     from helion.runtime.kernel import BoundKernel
     from helion.runtime.kernel import Kernel
+
+
+log = logging.getLogger(__name__)
 
 
 class _CodeExpr(str):
@@ -944,8 +951,15 @@ def _flatten_return_ast(
 
 
 def _bind_kernel_for_lowering(kernel: Kernel, args: tuple[object, ...]) -> BoundKernel:
-    """Reuse eager state unless its lock is held by a concurrent bind."""
+    """Reuse eager state without waiting for a concurrent eager bind."""
+    # Inductor owns Dynamo's compile lock here. Eager binding can hold
+    # _bind_lock while waiting for that lock, so blocking would form an ABBA
+    # deadlock. Contention is rare; keep the fallback private and diagnosable.
     if not kernel._bind_lock.acquire(blocking=False):
+        log.debug(
+            "kernel bind lock busy while lowering %s; using an isolated bind",
+            kernel.name,
+        )
         return kernel._bind_isolated(args)
     try:
         return kernel._bind(args)
@@ -1014,15 +1028,56 @@ def lower_helion_kernel(
         for n, p in kernel.signature.parameters.items()
         if n in all_args or p.default is not p.empty
     ]
-    # Dynamo and eager binding acquire their compile/bind locks in opposite order.
-    bound = _bind_kernel_for_lowering(kernel, tuple(fake_tensors))
-
-    # Derive output structure from bound kernel using inductor-time input layouts.
-    # This gives correct strides even when inductor changes input memory layouts.
+    bind_args = tuple(fake_tensors)
+    if output_spec.get(_REQUIRES_ISOLATED_LOWERING):
+        bound = kernel._bind_isolated(bind_args)
+    else:
+        bound = _bind_kernel_for_lowering(kernel, bind_args)
+    expected_semantic_fingerprint = output_spec.get(_HOST_SEMANTIC_FINGERPRINT)
+    input_normalization = output_spec.get(_HOST_SEMANTIC_INPUT_NORMALIZATION)
+    if not isinstance(input_normalization, tuple):
+        input_normalization = ()
     host_function = bound.host_function
     assert host_function is not None
     flat_leaves, tree_spec, return_ast = _get_flat_output(host_function)
+    actual_semantic_fingerprint: str | None = None
+    needs_isolated_bind = bound._cache_managed and bool(host_function.global_imports)
+    if isinstance(expected_semantic_fingerprint, str) and not needs_isolated_bind:
+        actual_semantic_fingerprint = bound._get_host_semantic_fingerprint(
+            flat_leaves,
+            input_normalization=input_normalization,
+        )
+        needs_isolated_bind = (
+            bound._cache_managed
+            and actual_semantic_fingerprint != expected_semantic_fingerprint
+        )
+    if needs_isolated_bind:
+        log.debug(
+            "cached bound for %s depends on external state or does not match "
+            "the Dynamo host trace; using an isolated bind",
+            kernel.name,
+        )
+        bound = kernel._bind_isolated(bind_args)
+        host_function = bound.host_function
+        assert host_function is not None
+        flat_leaves, tree_spec, return_ast = _get_flat_output(host_function)
+        actual_semantic_fingerprint = None
 
+    if isinstance(expected_semantic_fingerprint, str):
+        if actual_semantic_fingerprint is None:
+            actual_semantic_fingerprint = bound._get_host_semantic_fingerprint(
+                flat_leaves,
+                input_normalization=input_normalization,
+            )
+        if actual_semantic_fingerprint != expected_semantic_fingerprint:
+            raise RuntimeError(
+                "Helion kernel trace changed between Dynamo capture and Inductor "
+                f"lowering for kernel {kernel.fn.__name__!r}; keep ambient Python "
+                "and PyTorch state stable while torch.compile is running"
+            )
+
+    # Derive output structure from bound kernel using inductor-time input layouts.
+    # This gives correct strides even when inductor changes input memory layouts.
     if not flat_leaves:
         # No outputs — create still creates the buffer for mutations.
         buf, _ = HelionTemplateBuffer.create(

--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -943,6 +943,16 @@ def _flatten_return_ast(
     return result
 
 
+def _bind_kernel_for_lowering(kernel: Kernel, args: tuple[object, ...]) -> BoundKernel:
+    """Reuse eager state unless its lock is held by a concurrent bind."""
+    if not kernel._bind_lock.acquire(blocking=False):
+        return kernel._bind_isolated(args)
+    try:
+        return kernel._bind(args)
+    finally:
+        kernel._bind_lock.release()
+
+
 @register_lowering(helion_kernel_wrapper_mutation, type_promotion_kind=None)
 def lower_helion_kernel(
     *,
@@ -1004,7 +1014,8 @@ def lower_helion_kernel(
         for n, p in kernel.signature.parameters.items()
         if n in all_args or p.default is not p.empty
     ]
-    bound = kernel.bind(tuple(fake_tensors))
+    # Dynamo and eager binding acquire their compile/bind locks in opposite order.
+    bound = _bind_kernel_for_lowering(kernel, tuple(fake_tensors))
 
     # Derive output structure from bound kernel using inductor-time input layouts.
     # This gives correct strides even when inductor changes input memory layouts.

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -10,7 +10,6 @@ import threading
 import types
 import typing
 from typing import TYPE_CHECKING
-from typing import Protocol
 import warnings
 
 import sympy
@@ -207,11 +206,12 @@ if TYPE_CHECKING:
     from .pallas.compact_worklist import ResidentCacheDecision
     from .pallas.compact_worklist import ResidentPrepHoist
 
-    class _TLS(Protocol):
-        env: CompileEnvironment | None
+
+class _TLS(threading.local):
+    env: CompileEnvironment | None = None
 
 
-tls: _TLS = typing.cast("_TLS", threading.local())
+tls = _TLS()
 
 
 class HelionKernelSource(EphemeralSource):
@@ -305,6 +305,12 @@ class CompileEnvironment:
         self.cute_resolved_wrapper_plans: list[dict[str, object]] = []
         self.block_sizes: list[BlockSizeInfo] = []
         self.debug_shape_renames: dict[sympy.Basic, sympy.Basic] = {}
+        self._debug_shape_rename_override: contextvars.ContextVar[
+            dict[sympy.Basic, sympy.Basic] | None
+        ] = contextvars.ContextVar(
+            f"helion_debug_shape_renames_{id(self)}",
+            default=None,
+        )
         try:
             from ..runtime import get_num_sm
 
@@ -465,6 +471,26 @@ class CompileEnvironment:
             yield
         finally:
             self._runtime_arg_values_by_name.reset(token)
+
+    @property
+    def active_debug_shape_renames(self) -> dict[sympy.Basic, sympy.Basic]:
+        return self._debug_shape_rename_override.get() or self.debug_shape_renames
+
+    @property
+    def has_debug_shape_rename_override(self) -> bool:
+        return self._debug_shape_rename_override.get() is not None
+
+    @contextlib.contextmanager
+    def use_debug_shape_renames(
+        self, values: dict[sympy.Basic, sympy.Basic]
+    ) -> typing.Iterator[None]:
+        token = self._debug_shape_rename_override.set(
+            {**self.debug_shape_renames, **values}
+        )
+        try:
+            yield
+        finally:
+            self._debug_shape_rename_override.reset(token)
 
     def specialize_expr(self, expr: sympy.Expr) -> sympy.Expr:
         """Substitute any specialized vars with their concrete values."""
@@ -1298,10 +1324,10 @@ class CompileEnvironment:
         return self.index_type()
 
     def sympy_debug(self, expr: sympy.Basic) -> str:
-        return str(expr.xreplace(self.debug_shape_renames))
+        return str(expr.xreplace(self.active_debug_shape_renames))
 
     def __enter__(self) -> Self:
-        assert getattr(tls, "env", None) is None, "CompileEnvironment already active"
+        assert tls.env is None, "CompileEnvironment already active"
         self.fake_mode.__enter__()
         tls.env = self
         return self
@@ -1317,20 +1343,13 @@ class CompileEnvironment:
 
     @staticmethod
     def current() -> CompileEnvironment:
-        try:
-            if (env := tls.env) is not None:
-                return env
-        except AttributeError:
-            pass
+        if (env := tls.env) is not None:
+            return env
         raise NoCurrentEnvironment from None
 
     @staticmethod
     def has_current() -> bool:
-        try:
-            CompileEnvironment.current()
-            return True
-        except NoCurrentEnvironment:
-            return False
+        return tls.env is not None
 
     def get_block_id(self, size: int | torch.SymInt | sympy.Basic) -> int | None:
         """

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -805,6 +805,14 @@ class DeviceIR:
         # Normalize indentation to 4 spaces to handle both PyTorch 2.9 and nightly formatting
         return re.sub(r" *(# File:\s+).*/([^/:]+:\d+)", r"    \1.../\2", result)
 
+    def semantic_debug_str(self) -> str:
+        """Render graph operations without layout-dependent FX metadata."""
+        return "\n\n".join(
+            f"{type(graph_info).__name__} {graph_info.name}\n"
+            f"{graph_info.graph.python_code('self').src}"
+            for graph_info in self.graphs
+        )
+
     def add_graph(
         self,
         graph: torch.fx.Graph,

--- a/helion/_compiler/host_function.py
+++ b/helion/_compiler/host_function.py
@@ -290,14 +290,21 @@ class HostFunction:
             return "(" + ", ".join(self.literal_expr(x) for x in expr) + ")"
         return repr(expr)
 
+    def host_debug_str(self) -> str:
+        return print_ast(
+            self.location.to_ast(
+                ast.FunctionDef(self.name, self.args, self.body, [], None)
+            )
+        )
+
+    def semantic_debug_str(self) -> str:
+        result = [self.host_debug_str()]
+        if self._device_ir is not None:
+            result.append(self._device_ir.semantic_debug_str())
+        return "\n\n".join(result)
+
     def debug_str(self) -> str:
-        result = [
-            print_ast(
-                self.location.to_ast(
-                    ast.FunctionDef(self.name, self.args, self.body, [], None)
-                )
-            ),
-        ]
+        result = [self.host_debug_str()]
         if self._device_ir is not None:
             result.append(self._device_ir.debug_str())
         return "\n\n".join(result)

--- a/helion/_compiler/inductor_lowering_extra.py
+++ b/helion/_compiler/inductor_lowering_extra.py
@@ -2,16 +2,22 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import threading
 from typing import Any
 from typing import Callable
 from typing import Generator
 
 import torch
 from torch._inductor.ir import TensorBox
-from torch._inductor.lowering import lowerings as original_lowerings
 from torch._inductor.lowering import to_dtype
 
 inductor_lowering_dispatch: dict[Callable[..., Any] | str, Callable[..., Any]] = {}
+
+_MISSING_LOWERING = object()
+_patch_lock = threading.Lock()
+_patch_users = 0
+_patch_table: dict[Any, Any] | None = None
+_patch_entries: dict[Any, tuple[object, object]] = {}
 
 
 def create_fp16_to_fp32_unary_fallback_lowering(
@@ -21,6 +27,13 @@ def create_fp16_to_fp32_unary_fallback_lowering(
 
     @functools.wraps(original_op)
     def fp32_fallback_lowering(x: object) -> object:
+        from .compile_environment import CompileEnvironment
+
+        if (
+            not CompileEnvironment.has_current()
+            or CompileEnvironment.current().backend_name == "pallas"
+        ):
+            return original_op(x)
         if isinstance(x, TensorBox) and (original_dtype := x.get_dtype()) in (
             torch.float16,
             torch.bfloat16,
@@ -32,6 +45,42 @@ def create_fp16_to_fp32_unary_fallback_lowering(
         return original_op(x)
 
     return fp32_fallback_lowering
+
+
+def _compile_environment_lowering(
+    op: Callable[..., Any] | str,
+    patched: Callable[..., Any],
+    previous: object,
+) -> Callable[..., Any]:
+    """Use a Helion override only in the thread compiling a Helion kernel."""
+
+    @functools.wraps(patched)
+    def scoped(*args: object, **kwargs: object) -> object:
+        from .compile_environment import CompileEnvironment
+
+        if CompileEnvironment.has_current():
+            return patched(*args, **kwargs)
+        if previous is _MISSING_LOWERING:
+            raise KeyError(f"no Inductor lowering registered for {op!r}")
+        return previous(*args, **kwargs)  # pyrefly: ignore [not-callable]
+
+    return scoped
+
+
+def _restore_inductor_lowerings() -> None:
+    """Restore Helion-owned entries without disturbing concurrent registrations."""
+    global _patch_table
+
+    assert _patch_table is not None
+    for op, (previous, installed) in _patch_entries.items():
+        if _patch_table.get(op, _MISSING_LOWERING) is not installed:
+            continue
+        if previous is _MISSING_LOWERING:
+            _patch_table.pop(op, None)
+        else:
+            _patch_table[op] = previous
+    _patch_entries.clear()
+    _patch_table = None
 
 
 # Operations that need fp32 fallbacks due to libdevice/tl_math limitations
@@ -47,16 +96,6 @@ FP32_FALLBACK_OPS_UNARY = [
     torch.ops.aten.exp.default,
 ]
 
-# Register fp32 fallback lowerings in a separate dict so that
-# `patch_inductor_lowerings` can skip them on backends (Pallas) where
-# Mosaic handles bf16 transcendentals natively and the round-trip would
-# only double per-element VMEM working-set.
-fp32_fallback_dispatch: dict[Callable[..., Any] | str, Callable[..., Any]] = {}
-for op in FP32_FALLBACK_OPS_UNARY:
-    fp32_fallback_dispatch[op] = create_fp16_to_fp32_unary_fallback_lowering(
-        original_lowerings[op]
-    )
-
 
 @contextlib.contextmanager
 def patch_inductor_lowerings() -> Generator[None, Any, Any]:
@@ -66,28 +105,40 @@ def patch_inductor_lowerings() -> Generator[None, Any, Any]:
     affecting the global state, especially in cases where Helion
     is missing support for a specific lowering.
     """
-    from .compile_environment import CompileEnvironment
+    global _patch_table, _patch_users
 
-    # pyrefly: ignore [implicit-import]
-    original_lowerings = torch._inductor.lowering.lowerings.copy()
-    try:
-        # pyrefly: ignore [implicit-import]
-        torch._inductor.lowering.lowerings.update(inductor_lowering_dispatch)
-        # The fp32 round-trip is a Triton/CUDA workaround for libdevice
-        # /tl_math bf16 limitations. Mosaic on TPU handles bf16
-        # transcendentals natively, so installing the fallback there
-        # would only double per-element VMEM working-set.
-        is_pallas = (
-            CompileEnvironment.has_current()
-            and CompileEnvironment.current().backend_name == "pallas"
-        )
-        if not is_pallas:
+    with _patch_lock:
+        if _patch_users == 0:
+            # Mutate the existing table: register_lowering() captures this dict
+            # object, and replacing it disconnects later registrations.
             # pyrefly: ignore [implicit-import]
-            torch._inductor.lowering.lowerings.update(fp32_fallback_dispatch)
+            _patch_table = torch._inductor.lowering.lowerings
+            try:
+                for op, patched in inductor_lowering_dispatch.items():
+                    previous = _patch_table.get(op, _MISSING_LOWERING)
+                    installed = _compile_environment_lowering(op, patched, previous)
+                    _patch_entries[op] = (previous, installed)
+                    _patch_table[op] = installed
+                for op in FP32_FALLBACK_OPS_UNARY:
+                    current = _patch_table.get(op, _MISSING_LOWERING)
+                    if current is _MISSING_LOWERING or not callable(current):
+                        raise KeyError(f"no Inductor lowering registered for {op!r}")
+                    existing = _patch_entries.get(op)
+                    previous = current if existing is None else existing[0]
+                    installed = create_fp16_to_fp32_unary_fallback_lowering(current)
+                    _patch_entries[op] = (previous, installed)
+                    _patch_table[op] = installed
+            except Exception:
+                _restore_inductor_lowerings()
+                raise
+        _patch_users += 1
+    try:
         yield
     finally:
-        # pyrefly: ignore [implicit-import]
-        torch._inductor.lowering.lowerings = original_lowerings
+        with _patch_lock:
+            _patch_users -= 1
+            if _patch_users == 0:
+                _restore_inductor_lowerings()
 
 
 # pyrefly: ignore [implicit-import]

--- a/helion/_compiler/inductor_lowering_extra.py
+++ b/helion/_compiler/inductor_lowering_extra.py
@@ -99,11 +99,11 @@ FP32_FALLBACK_OPS_UNARY = [
 
 @contextlib.contextmanager
 def patch_inductor_lowerings() -> Generator[None, Any, Any]:
-    """Context manager to temporarily patch the inductor lowering table.
+    """Temporarily install lowering overrides needed by Helion compilation.
 
-    This is useful for overwriting specific Inductor lowerings without
-    affecting the global state, especially in cases where Helion
-    is missing support for a specific lowering.
+    Inductor's lowering table is process-global, so the installed wrappers
+    apply Helion behavior only with an active compile environment and delegate
+    to the prior lowerings in all other threads.
     """
     global _patch_table, _patch_users
 

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -306,16 +306,11 @@ class TensorType(TypeInfo):
             )
 
     def __str__(self) -> str:
+        env = CompileEnvironment.current()
         shape: list[str] = []
         for s in self.fake_value.size():
             if isinstance(s, torch.SymInt):
-                shape.append(
-                    str(
-                        s._sympy_().xreplace(
-                            CompileEnvironment.current().debug_shape_renames
-                        )
-                    )
-                )
+                shape.append(env.sympy_debug(s._sympy_()))
             else:
                 shape.append(str(s))
         dtype = self.fake_value.dtype
@@ -918,7 +913,13 @@ class NumericType(TypeInfo):
         raise NotImplementedError
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}({self.value})"
+        env = CompileEnvironment.current()
+        value = (
+            env.sympy_debug(self.value._sympy_())
+            if env.has_debug_shape_rename_override
+            else self.value
+        )
+        return f"{type(self).__name__}({value})"
 
     def proxy(self) -> torch.SymInt | torch.SymBool | torch.SymFloat | int:
         return self.value

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -914,6 +914,8 @@ class NumericType(TypeInfo):
 
     def __str__(self) -> str:
         env = CompileEnvironment.current()
+        # Preserve the existing debug/golden rendering except while semantic
+        # fingerprinting supplies canonical symbolic-shape names.
         value = (
             env.sympy_debug(self.value._sympy_())
             if env.has_debug_shape_rename_override

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 import contextlib
 import dataclasses
 import functools
+import hashlib
 import inspect
 import itertools
 import logging
@@ -28,6 +29,7 @@ from typing import overload
 from typing_extensions import Protocol
 import weakref
 
+import sympy
 import torch
 from torch._dynamo.source import GetItemSource
 from torch._dynamo.source import LocalSource
@@ -42,12 +44,14 @@ from torch.utils._pytree import tree_map_only
 from torch.utils.weak import WeakIdKeyDictionary
 
 from .. import exc
+from .._compat import shape_env_size_hint
 from .._compat import target_device_capability
 from .._compile_time import measure
 from .._compiler.ast_extension import unparse
 from .._compiler.autotuner_heuristics import compiler_seed_configs
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.compile_environment import TensorDescriptorLayoutGuard
+from .._compiler.compile_environment import _is_supported_tensor_input_source
 from .._compiler.compile_environment import _symint_free_symbols
 from .._compiler.compile_environment import (
     tensor_descriptor_layout_signature_from_strides,
@@ -118,6 +122,8 @@ _graph_module_hash_cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
 
 _INT32_INDEX_LIMIT = torch.iinfo(torch.int32).max
 _CUSTOM_KEY_UNSET = object()
+
+_HostSemanticInputNormalization = tuple[tuple[int, str, int, int], ...]
 
 
 class _FastDispatchEntry(NamedTuple):
@@ -459,6 +465,7 @@ class Kernel(Generic[_R]):
             for config in configs or []
         ]
         self._bind_lock = threading.RLock()
+        self._specialize_extra_lock = threading.Lock()
         self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
         # Fast dispatch cache: maps a cheap, fine-grained argument key (exact
         # dtype/shape/stride/device per tensor) directly to a BoundKernel,
@@ -537,11 +544,31 @@ class Kernel(Generic[_R]):
     ) -> BoundKernelInMemoryCacheKey | None:
         from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
 
-        extra_fns = self._specialize_extra.get(signature)
-        if extra_fns is not None:
-            extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
-            return BoundKernelInMemoryCacheKey(signature, extra_results)
-        return None
+        extra_results = self._stable_specialization_extra_results(args, signature)
+        if extra_results is None:
+            return None
+        return BoundKernelInMemoryCacheKey(signature, extra_results)
+
+    def _stable_specialization_extra_results(
+        self,
+        args: Sequence[object],
+        signature: tuple[Hashable, ...],
+    ) -> tuple[Hashable, ...] | None:
+        # Evaluate outside the schema lock because some backend extractors may
+        # synchronize device data. Schema changes are finite and retry here.
+        while True:
+            with self._specialize_extra_lock:
+                extra_fns = self._specialize_extra.get(signature)
+                generation = self._specialization_generation
+            extra_results = (
+                None if extra_fns is None else tuple(fn(args) for fn in extra_fns)
+            )
+            with self._specialize_extra_lock:
+                if (
+                    self._specialization_generation == generation
+                    and self._specialize_extra.get(signature) is extra_fns
+                ):
+                    return extra_results
 
     def _create_bound_kernel_cache_key(
         self,
@@ -555,12 +582,43 @@ class Kernel(Generic[_R]):
 
         if extra_fns is None:
             extra_fns = bound_kernel._specialize_extra()
-        if bound_kernel._cache_managed:
-            self._specialize_extra[signature] = extra_fns
-            if extra_fns:
-                self._has_specialization_extras = True
-        extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
-        return BoundKernelInMemoryCacheKey(signature, extra_results)
+        if not bound_kernel._cache_managed:
+            extra_results = tuple(s(args) for s in extra_fns)
+            return BoundKernelInMemoryCacheKey(signature, extra_results)
+
+        # Autotune cache keys can be generated outside eager binding, so
+        # schema synchronization must not wait for the eager bind lock or hold
+        # the schema lock while backend extractors run.
+        while True:
+            with self._specialize_extra_lock:
+                if bound_kernel._reset_generation != self._reset_generation:
+                    active_extra_fns = extra_fns
+                    generation = None
+                else:
+                    published_extra_fns = self._specialize_extra.get(signature)
+                    if published_extra_fns is None:
+                        self._specialize_extra[signature] = extra_fns
+                        if extra_fns:
+                            self._has_specialization_extras = True
+                    else:
+                        # Late specialization can extend this schema after the
+                        # bound is constructed. The published list is the
+                        # authoritative schema.
+                        extra_fns = published_extra_fns
+                    generation = self._specialization_generation
+                    active_extra_fns = extra_fns
+            extra_results = tuple(s(args) for s in active_extra_fns)
+            cache_key = BoundKernelInMemoryCacheKey(signature, extra_results)
+            if generation is None:
+                return cache_key
+            with self._specialize_extra_lock:
+                if bound_kernel._reset_generation != self._reset_generation:
+                    return cache_key
+                if (
+                    self._specialization_generation == generation
+                    and self._specialize_extra.get(signature) is active_extra_fns
+                ):
+                    return cache_key
 
     def _extend_bound_kernel_specializations(
         self,
@@ -578,41 +636,52 @@ class Kernel(Generic[_R]):
             if bound_kernel._reset_generation != self._reset_generation:
                 return False
             full_args = tuple(args)
-            updated_extractors = [
-                *self._specialize_extra.get(signature, []),
-                *extractors,
-            ]
             aliases = {
                 alias_signature: alias
                 for alias_signature, alias in self._specialization_aliases.items()
                 if alias.canonical_signature == signature
             }
-            with unset_fake_temporarily():
-                current_results = tuple(
-                    extractor(full_args) for extractor in updated_extractors
-                )
-                updated_cache_key = BoundKernelInMemoryCacheKey(
-                    signature, current_results
-                )
-                hash(updated_cache_key)
-                for alias_signature, alias in aliases.items():
-                    alias_arg_count = len(full_args) - len(alias.trailing_defaults)
-                    alias_args = full_args[:alias_arg_count]
-                    alias_normalized_args = (*alias_args, *alias.trailing_defaults)
-                    alias_results = tuple(
-                        extractor(alias_normalized_args)
-                        for extractor in updated_extractors
+            # Keep cache-key generation from snapshotting the old schema while
+            # this extension is being validated and published.
+            with self._specialize_extra_lock:
+                updated_extractors = [
+                    *self._specialize_extra.get(signature, []),
+                    *extractors,
+                ]
+                with unset_fake_temporarily():
+                    current_results = tuple(
+                        extractor(full_args) for extractor in updated_extractors
                     )
-                    hash(BoundKernelInMemoryCacheKey(alias_signature, (alias_results,)))
+                    updated_cache_key = BoundKernelInMemoryCacheKey(
+                        signature, current_results
+                    )
+                    hash(updated_cache_key)
+                    for alias_signature, alias in aliases.items():
+                        alias_arg_count = len(full_args) - len(alias.trailing_defaults)
+                        alias_args = full_args[:alias_arg_count]
+                        alias_normalized_args = (
+                            *alias_args,
+                            *alias.trailing_defaults,
+                        )
+                        alias_results = tuple(
+                            extractor(alias_normalized_args)
+                            for extractor in updated_extractors
+                        )
+                        hash(
+                            BoundKernelInMemoryCacheKey(
+                                alias_signature,
+                                (alias_results,),
+                            )
+                        )
 
-            # Publish the extended specialization only after every extractor
-            # succeeds. Otherwise a failed extension could leave a prepared
-            # call guarding an already-mutated extractor list.
-            self._has_specialization_extras = True
-            self._specialize_extra[signature] = updated_extractors
-            for alias_signature, alias in aliases.items():
-                self._specialize_extra[alias_signature] = [alias]
-            self._specialization_generation += 1
+                # Publish the extended specialization only after every extractor
+                # succeeds. Otherwise a failed extension could leave a prepared
+                # call guarding an already-mutated extractor list.
+                self._has_specialization_extras = True
+                self._specialize_extra[signature] = updated_extractors
+                for alias_signature, alias in aliases.items():
+                    self._specialize_extra[alias_signature] = [alias]
+                self._specialization_generation += 1
 
             affected_signatures = {signature, *aliases}
             stale_keys = [
@@ -762,10 +831,9 @@ class Kernel(Generic[_R]):
                 return None
             if bound._reset_generation != self._reset_generation:
                 return None
-            normalized_args = self.normalize_args(*args)
             dist_initialized = dist.is_initialized()
             is_distributed = self._compute_is_distributed(
-                normalized_args, dist_initialized=dist_initialized
+                args, dist_initialized=dist_initialized
             )
             if fast_entry.key[len(args)] != is_distributed:
                 return None
@@ -830,8 +898,21 @@ class Kernel(Generic[_R]):
         with self._bind_lock:
             return self._bind(args)
 
+    def _validate_bind_args(
+        self, args: tuple[object, ...] | list[object]
+    ) -> tuple[object, ...]:
+        if not isinstance(args, tuple):
+            assert isinstance(args, list), "args must be a tuple or list"
+            args = tuple(args)
+        if len(args) > self._num_params:
+            raise TypeError(
+                f"Too many arguments passed to the kernel, expected: {self._num_params} got: {len(args)}."
+            )
+        return args
+
     def _bind_isolated(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         """Construct a canonical bound without reading or publishing shared caches."""
+        args = self._validate_bind_args(args)
         args = self.normalize_args(*args)
         dist_initialized = dist.is_initialized()
         is_distributed = self._compute_is_distributed(
@@ -848,13 +929,7 @@ class Kernel(Generic[_R]):
 
     def _bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         with measure("Kernel.bind"):
-            if not isinstance(args, tuple):
-                assert isinstance(args, list), "args must be a tuple or list"
-                args = tuple(args)
-            if len(args) > self._num_params:
-                raise TypeError(
-                    f"Too many arguments passed to the kernel, expected: {self._num_params} got: {len(args)}."
-                )
+            args = self._validate_bind_args(args)
             dist_initialized = dist.is_initialized()
             is_distributed = self._compute_is_distributed(
                 args, dist_initialized=dist_initialized
@@ -957,10 +1032,8 @@ class Kernel(Generic[_R]):
             Hashable: A hashable key representing the specialization of the arguments.
         """
         base = self._base_specialization_key(args)
-        extra_fns = self._specialize_extra.get(base)
-        if extra_fns is not None:
-            return base + tuple([s(args) for s in extra_fns])
-        return base
+        extra_results = self._stable_specialization_extra_results(args, base)
+        return base if extra_results is None else (*base, *extra_results)
 
     def _specialization_key(self, obj: object) -> Hashable:
         """
@@ -1434,8 +1507,18 @@ class Kernel(Generic[_R]):
             self._bound_kernels.clear()
             self._dispatch_cache.clear()
             self._prepared_call = None
-            self._specialization_generation += 1
-            self._reset_generation += 1
+            # Specialization extractors are discovered by tracing the host
+            # function and can change after an explicit reset. Keeping the old
+            # schema could hide newly discovered hl.specialize() calls.
+            with self._specialize_extra_lock:
+                # Replace rather than clear: in-flight omitted-default aliases
+                # retain the old schema mapping while new work starts fresh.
+                self._specialize_extra = {}
+                self._specialization_aliases = {}
+                self._cute_grouped_static_tail_extra_descriptors = {}
+                self._has_specialization_extras = False
+                self._specialization_generation += 1
+                self._reset_generation += 1
 
     @property
     def jax_fn(self) -> Callable[..., Any]:
@@ -1508,6 +1591,9 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         self._config: Config | None = None
         self._compile_cache: dict[Config, CompiledConfig] = {}
         self._cache_path_map: dict[Config, str | None] = {}
+        self._host_semantic_fingerprints: dict[
+            tuple[_HostSemanticInputNormalization, tuple[object, ...]], str
+        ] = {}
         # Direct to_code() has no call arguments, so keep this bound kernel's
         # construction-time tensor values as its stable weak fallback.
         self._runtime_tensor_refs_by_name = {
@@ -1932,6 +2018,168 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             return f"<BoundKernel {self.kernel.fn.__name__} in ref mode>"
         with self.env:
             return self.host_function.debug_str()
+
+    def _get_host_semantic_input_normalization(
+        self,
+    ) -> _HostSemanticInputNormalization:
+        """Return capture-time equivalence classes for dynamic input symbols."""
+        if self.settings.static_shapes:
+            return ()
+
+        canonical_by_expr: dict[sympy.Expr, int] = {}
+        normalization: list[tuple[int, str, int, int]] = []
+        with self.env:
+            tensor_args = self._host_semantic_input_tensors()
+            for tensor_index, arg in enumerate(tensor_args):
+                for property_name, values in (
+                    ("size", arg.size()),
+                    ("stride", arg.stride()),
+                ):
+                    for index, value in enumerate(values):
+                        if not isinstance(value, torch.SymInt):
+                            continue
+                        expr = self.env.shape_env.simplify(value._sympy_())
+                        if isinstance(expr, sympy.Integer):
+                            continue
+                        canonical = canonical_by_expr.get(expr)
+                        if canonical is None:
+                            canonical = len(canonical_by_expr)
+                            canonical_by_expr[expr] = canonical
+                        normalization.append(
+                            (tensor_index, property_name, index, canonical)
+                        )
+        return tuple(normalization)
+
+    def _host_semantic_debug_renames(
+        self,
+        normalization: _HostSemanticInputNormalization,
+    ) -> tuple[dict[sympy.Basic, sympy.Basic], bool]:
+        tensor_args = self._host_semantic_input_tensors()
+        renames: dict[sympy.Basic, sympy.Basic] = {}
+        class_by_expr: dict[sympy.Basic, int] = {}
+        compatible = True
+        for tensor_index, property_name, index, canonical in normalization:
+            # A missing or concretized property is left unnormalized. If it is
+            # semantically used, the rendered host/device trace still differs.
+            if tensor_index >= len(tensor_args):
+                continue
+            tensor = tensor_args[tensor_index]
+            values = tensor.size() if property_name == "size" else tensor.stride()
+            if index >= len(values):
+                continue
+            value = values[index]
+            if not isinstance(value, torch.SymInt):
+                continue
+            expr = self.env.shape_env.simplify(value._sympy_())
+            existing = class_by_expr.get(expr)
+            if existing is not None and existing != canonical:
+                compatible = False
+                continue
+            class_by_expr[expr] = canonical
+            renames[expr] = sympy.Symbol(
+                f"<helion_input_symbol_{canonical}>",
+                integer=True,
+            )
+        return renames, compatible
+
+    def _host_semantic_input_tensors(self) -> list[torch.Tensor]:
+        return [
+            tensor
+            for tensor, source in self.env.input_sources.items()
+            if _is_supported_tensor_input_source(source)
+        ]
+
+    def _host_semantic_external_tensor_keys(self) -> tuple[object, ...]:
+        return tuple(
+            (
+                type(source).__name__,
+                tuple(self._semantic_dimension_key(dim) for dim in tensor.shape),
+                tuple(self._semantic_dimension_key(dim) for dim in tensor.stride()),
+                str(tensor.dtype),
+                str(tensor.device),
+                str(tensor.layout),
+                tensor.requires_grad,
+            )
+            for tensor, source in self.env.input_sources.items()
+            if not _is_supported_tensor_input_source(source)
+        )
+
+    def _get_host_semantic_fingerprint(
+        self,
+        outputs: Sequence[object],
+        *,
+        input_normalization: _HostSemanticInputNormalization | None = None,
+    ) -> str:
+        assert self.host_function is not None
+        if input_normalization is None:
+            input_normalization = self._get_host_semantic_input_normalization()
+
+        output_keys: list[object] = []
+        for output in outputs:
+            if isinstance(output, torch.Tensor):
+                if self.settings.static_shapes:
+                    shape = tuple(
+                        self._semantic_dimension_key(dim) for dim in output.shape
+                    )
+                else:
+                    shape = ("rank", output.ndim)
+                output_keys.append(
+                    (
+                        "tensor",
+                        shape,
+                        str(output.dtype),
+                        str(output.device),
+                        str(output.layout),
+                    )
+                )
+            elif isinstance(output, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+                output_keys.append((type(output).__name__,))
+            elif output is None or type(output) in (bool, float, int, str):
+                output_type = type(output)
+                output_keys.append(
+                    (
+                        f"{output_type.__module__}.{output_type.__qualname__}",
+                        repr(output),
+                    )
+                )
+            else:
+                raise TypeError(
+                    f"Unsupported Helion host output in semantic fingerprint: "
+                    f"{type(output).__name__}"
+                )
+
+        output_key = tuple(output_keys)
+        cache_key = (input_normalization, output_key)
+        fingerprint = self._host_semantic_fingerprints.get(cache_key)
+        if fingerprint is not None:
+            return fingerprint
+
+        normalization_compatible = True
+        with self.env:
+            if input_normalization:
+                renames, normalization_compatible = self._host_semantic_debug_renames(
+                    input_normalization
+                )
+                with self.env.use_debug_shape_renames(renames):
+                    host_source = self.host_function.semantic_debug_str()
+            else:
+                host_source = self.host_function.semantic_debug_str()
+
+        payload = (
+            input_normalization,
+            normalization_compatible,
+            self._host_semantic_external_tensor_keys(),
+            host_source,
+            output_key,
+        )
+        fingerprint = hashlib.sha256(repr(payload).encode()).hexdigest()
+        self._host_semantic_fingerprints[cache_key] = fingerprint
+        return fingerprint
+
+    def _semantic_dimension_key(self, dim: object) -> object:
+        if isinstance(dim, torch.SymInt) and dim.node.shape_env is self.env.shape_env:
+            return shape_env_size_hint(self.env.shape_env, dim.node.expr)
+        return dim
 
     def autotune(
         self,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -271,8 +271,8 @@ class _PreparedCall:
             or kernel._key_fn is not None
         ):
             return None
-        # Both call sites already obtained a non-None ``_fast_dispatch_key``,
-        # which proves every argument has an exact supported type.
+        # The caller already obtained a non-None ``_fast_dispatch_key``, which
+        # proves every argument has an exact supported type.
         try:
             return cls(
                 bound,
@@ -2168,6 +2168,8 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         payload = (
             input_normalization,
             normalization_compatible,
+            self.env.backend_name,
+            str(self.env.index_dtype),
             self._host_semantic_external_tensor_keys(),
             host_source,
             output_key,
@@ -2375,28 +2377,35 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         )
         if not descriptors:
             return
-        seen = self.kernel._cute_grouped_static_tail_extra_descriptors.setdefault(
-            signature,
-            set(),
-        )
-        new_descriptors: list[Hashable] = []
-        new_extractors: list[Callable[[Sequence[object]], Hashable]] = []
-        for descriptor in descriptors:
-            if descriptor in seen:
-                continue
-            new_descriptors.append(descriptor)
-            new_extractors.append(_make_cute_grouped_static_tail_extractor(descriptor))
-        runtime_args = tuple(
-            self.env.runtime_arg_values_by_name.get(name)
-            for name in self.kernel.signature.parameters
-        )
-        if self.kernel._extend_bound_kernel_specializations(
-            self,
-            signature,
-            new_extractors,
-            runtime_args,
-        ):
-            seen.update(new_descriptors)
+        # Serialize descriptor discovery with schema extension so concurrent
+        # code generation cannot publish duplicate equivalent extractors.
+        with self.kernel._bind_lock:
+            if self._reset_generation != self.kernel._reset_generation:
+                return
+            seen = self.kernel._cute_grouped_static_tail_extra_descriptors.setdefault(
+                signature,
+                set(),
+            )
+            new_descriptors: list[Hashable] = []
+            new_extractors: list[Callable[[Sequence[object]], Hashable]] = []
+            for descriptor in descriptors:
+                if descriptor in seen:
+                    continue
+                new_descriptors.append(descriptor)
+                new_extractors.append(
+                    _make_cute_grouped_static_tail_extractor(descriptor)
+                )
+            runtime_args = tuple(
+                self.env.runtime_arg_values_by_name.get(name)
+                for name in self.kernel.signature.parameters
+            )
+            if self.kernel._extend_bound_kernel_specializations(
+                self,
+                signature,
+                new_extractors,
+                runtime_args,
+            ):
+                seen.update(new_descriptors)
 
     def _fixed_config_for_td_layout_guards(self) -> Config | None:
         """Return the fixed config if TD layout guards can be filtered safely."""

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -21,6 +21,7 @@ from typing import Callable
 from typing import Generic
 from typing import Hashable
 from typing import Literal
+from typing import NamedTuple
 from typing import TypeVar
 from typing import cast
 from typing import overload
@@ -117,6 +118,37 @@ _graph_module_hash_cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
 
 _INT32_INDEX_LIMIT = torch.iinfo(torch.int32).max
 _CUSTOM_KEY_UNSET = object()
+
+
+class _FastDispatchEntry(NamedTuple):
+    """A dispatch key together with the state used to build it."""
+
+    key: tuple[Hashable, ...]
+    extra_guards: tuple[tuple[Callable[[Sequence[object]], Hashable], Hashable], ...]
+    specialization_generation: int
+
+
+class _SpecializationAlias:
+    """An omitted-default signature backed by a normalized signature."""
+
+    __slots__ = ("schemas", "canonical_signature", "trailing_defaults")
+
+    def __init__(
+        self,
+        schemas: dict[Hashable, list[Callable[[Sequence[object]], Hashable]]],
+        canonical_signature: tuple[Hashable, ...],
+        trailing_defaults: tuple[object, ...],
+    ) -> None:
+        self.schemas = schemas
+        self.canonical_signature = canonical_signature
+        self.trailing_defaults = trailing_defaults
+
+    def __call__(self, values: Sequence[object]) -> Hashable:
+        normalized = (*values, *self.trailing_defaults)
+        return tuple(
+            extractor(normalized)
+            for extractor in self.schemas[self.canonical_signature]
+        )
 
 
 def _make_prepared_arg_guard(
@@ -436,6 +468,11 @@ class Kernel(Generic[_R]):
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
+        self._specialization_aliases: dict[
+            tuple[Hashable, ...], _SpecializationAlias
+        ] = {}
+        self._specialization_generation = 0
+        self._reset_generation = 0
         self._has_specialization_extras = False
         self._cute_grouped_static_tail_extra_descriptors: dict[
             Hashable, set[Hashable]
@@ -511,12 +548,17 @@ class Kernel(Generic[_R]):
         bound_kernel: BoundKernel,
         args: tuple[object, ...],
         signature: tuple[Hashable, ...],
+        *,
+        extra_fns: list[Callable[[Sequence[object]], Hashable]] | None = None,
     ) -> BoundKernelInMemoryCacheKey:
         from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
 
-        self._specialize_extra[signature] = extra_fns = bound_kernel._specialize_extra()
-        if extra_fns:
-            self._has_specialization_extras = True
+        if extra_fns is None:
+            extra_fns = bound_kernel._specialize_extra()
+        if bound_kernel._cache_managed:
+            self._specialize_extra[signature] = extra_fns
+            if extra_fns:
+                self._has_specialization_extras = True
         extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
         return BoundKernelInMemoryCacheKey(signature, extra_results)
 
@@ -526,33 +568,57 @@ class Kernel(Generic[_R]):
         signature: tuple[Hashable, ...],
         extractors: list[Callable[[Sequence[object]], Hashable]],
         args: Sequence[object],
-    ) -> None:
+    ) -> bool:
         if not extractors:
-            return
+            return False
 
         from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
 
         with self._bind_lock:
-            existing_extractors = self._specialize_extra.get(signature, [])
-            updated_extractors = [*existing_extractors, *extractors]
+            if bound_kernel._reset_generation != self._reset_generation:
+                return False
+            full_args = tuple(args)
+            updated_extractors = [
+                *self._specialize_extra.get(signature, []),
+                *extractors,
+            ]
+            aliases = {
+                alias_signature: alias
+                for alias_signature, alias in self._specialization_aliases.items()
+                if alias.canonical_signature == signature
+            }
             with unset_fake_temporarily():
                 current_results = tuple(
-                    extractor(args) for extractor in updated_extractors
+                    extractor(full_args) for extractor in updated_extractors
                 )
-            updated_cache_key = BoundKernelInMemoryCacheKey(signature, current_results)
-            hash(updated_cache_key)
+                updated_cache_key = BoundKernelInMemoryCacheKey(
+                    signature, current_results
+                )
+                hash(updated_cache_key)
+                for alias_signature, alias in aliases.items():
+                    alias_arg_count = len(full_args) - len(alias.trailing_defaults)
+                    alias_args = full_args[:alias_arg_count]
+                    alias_normalized_args = (*alias_args, *alias.trailing_defaults)
+                    alias_results = tuple(
+                        extractor(alias_normalized_args)
+                        for extractor in updated_extractors
+                    )
+                    hash(BoundKernelInMemoryCacheKey(alias_signature, (alias_results,)))
 
             # Publish the extended specialization only after every extractor
             # succeeds. Otherwise a failed extension could leave a prepared
             # call guarding an already-mutated extractor list.
-            self._specialize_extra[signature] = updated_extractors
             self._has_specialization_extras = True
+            self._specialize_extra[signature] = updated_extractors
+            for alias_signature, alias in aliases.items():
+                self._specialize_extra[alias_signature] = [alias]
+            self._specialization_generation += 1
 
+            affected_signatures = {signature, *aliases}
             stale_keys = [
                 key
                 for key in self._bound_kernels
-                if key.specialization_key == signature
-                and len(key.extra_results) < len(updated_extractors)
+                if key.specialization_key in affected_signatures
             ]
             for stale_key in stale_keys:
                 self._bound_kernels.pop(stale_key)
@@ -561,6 +627,7 @@ class Kernel(Generic[_R]):
                     self._dispatch_cache.pop(fast_key)
             self._prepared_call = None
             self._bound_kernels[updated_cache_key] = bound_kernel
+            return True
 
     def _compute_is_distributed(
         self,
@@ -590,49 +657,11 @@ class Kernel(Generic[_R]):
         *,
         is_distributed: bool | None = None,
         signature: tuple[Hashable, ...] | None = None,
-    ) -> Hashable | None:
-        entry = self._fast_dispatch_key_and_guards(
-            args,
-            is_distributed=is_distributed,
-            signature=signature,
-        )
-        return None if entry is None else entry[0]
-
-    def _fast_dispatch_key_and_guards(
-        self,
-        args: tuple[object, ...],
-        *,
-        is_distributed: bool | None = None,
-        signature: tuple[Hashable, ...] | None = None,
-    ) -> (
-        tuple[
-            Hashable,
-            tuple[tuple[Callable[[Sequence[object]], Hashable], Hashable], ...],
-        ]
-        | None
-    ):
-        """
-        Build a cheap dispatch key for the fast-path cache in ``__call__``.
-
-        The key records exact per-argument metadata (dtype/shape/stride/device
-        for tensors, type and value for scalars), which is strictly finer than
-        the full specialization key: any two argument lists that produce
-        different full keys also produce different fast keys.  That makes it
-        safe to map a fast key directly to the BoundKernel that a full
-        ``bind()`` resolved for the same arguments.
-
-        If a base signature has extra specialization extractors, their results
-        are appended to preserve the same no-collision invariant for
-        value-based specializations.
-
-        Returns None when an argument type is not handled (tensor subclasses,
-        containers, ...), or when there is no tensor argument to pin down the
-        device; callers must then take the regular ``bind()`` path.
-        """
+        _extra_guards: list[tuple[Callable[[Sequence[object]], Hashable], Hashable]]
+        | None = None,
+    ) -> tuple[Hashable, ...] | None:
+        """Build the exact eager dispatch key, optionally collecting its guards."""
         key: list[Hashable] = []
-        extra_guards: tuple[
-            tuple[Callable[[Sequence[object]], Hashable], Hashable], ...
-        ] = ()
         has_tensor = False
         for a in args:
             t = type(a)
@@ -671,135 +700,114 @@ class Kernel(Generic[_R]):
         if signature is not None:
             extra_fns = self._specialize_extra.get(signature)
             if extra_fns:
-                extra_guards = tuple(
-                    (extractor, extractor(args)) for extractor in extra_fns
-                )
-                key.append(tuple(expected for _, expected in extra_guards))
-        return tuple(key), extra_guards
+                extra_results: list[Hashable] = []
+                for extractor in extra_fns:
+                    result = extractor(args)
+                    extra_results.append(result)
+                    if _extra_guards is not None:
+                        _extra_guards.append((extractor, result))
+                key.append(tuple(extra_results))
+        return tuple(key)
+
+    def _fast_dispatch_key_and_guards(
+        self,
+        args: tuple[object, ...],
+        *,
+        is_distributed: bool | None = None,
+        signature: tuple[Hashable, ...] | None = None,
+    ) -> _FastDispatchEntry | None:
+        """
+        Build a cheap dispatch key for the fast-path cache in ``__call__``.
+
+        The key records exact per-argument metadata (dtype/shape/stride/device
+        for tensors, type and value for scalars), which is strictly finer than
+        the full specialization key: any two argument lists that produce
+        different full keys also produce different fast keys.  That makes it
+        safe to map a fast key directly to the BoundKernel that a full
+        ``bind()`` resolved for the same arguments.
+
+        If a base signature has extra specialization extractors, their results
+        are appended to preserve the same no-collision invariant for
+        value-based specializations.
+
+        Returns None when an argument type is not handled (tensor subclasses,
+        containers, ...), or when there is no tensor argument to pin down the
+        device; callers must then take the regular ``bind()`` path.
+        """
+        specialization_generation = self._specialization_generation
+        extra_guards: list[tuple[Callable[[Sequence[object]], Hashable], Hashable]] = []
+        key = self._fast_dispatch_key(
+            args,
+            is_distributed=is_distributed,
+            signature=signature,
+            _extra_guards=extra_guards,
+        )
+        if key is None:
+            return None
+        return _FastDispatchEntry(
+            key,
+            tuple(extra_guards),
+            specialization_generation,
+        )
 
     def _prepare_dispatch_entry(
         self,
         args: tuple[object, ...],
         bound: BoundKernel[_R],
-        known_fast_key: Hashable | None = None,
-    ) -> tuple[Hashable, _PreparedCall | None] | None:
+        fast_entry: _FastDispatchEntry,
+    ) -> tuple[_PreparedCall | None, bool] | None:
         """Validate and construct eager fast paths from one runtime snapshot."""
-        if known_fast_key is not None and self._key_fn is not None:
-            # Validate the already-evaluated custom-key hit without invoking
-            # user code a second time.  In particular, do not let a process-
-            # group transition reuse a bound kernel compiled for the old state.
-            try:
-                normalized_args = self.normalize_args(*args)
-                dist_initialized = dist.is_initialized()
-                is_distributed = self._compute_is_distributed(
-                    normalized_args, dist_initialized=dist_initialized
-                )
-                if (
-                    not isinstance(known_fast_key, tuple)
-                    or len(known_fast_key) < len(args) + 2
-                ):
-                    return None
-                custom_key = known_fast_key[len(args) + 1]
-                signature = self._base_specialization_key(
-                    normalized_args,
-                    is_distributed=is_distributed,
-                    custom_key=custom_key,
-                )
-                if signature != bound._base_spec_key:
-                    return None
-                current_entry = self._fast_dispatch_key_and_guards(
-                    args,
-                    is_distributed=is_distributed,
-                    signature=signature,
-                )
-                if current_entry is None or current_entry[0] != known_fast_key:
-                    return None
-                extra_guards = current_entry[1]
-
-                from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
-
-                cache_key = BoundKernelInMemoryCacheKey(
-                    signature,
-                    tuple(expected for _, expected in extra_guards),
-                )
-                if (
-                    self._bound_kernels.get(cache_key) is not bound
-                    or dist.is_initialized() != dist_initialized
-                ):
-                    return None
-                return known_fast_key, None
-            except Exception:
-                return None
         try:
+            if fast_entry.specialization_generation != self._specialization_generation:
+                return None
+            if bound._reset_generation != self._reset_generation:
+                return None
             normalized_args = self.normalize_args(*args)
             dist_initialized = dist.is_initialized()
             is_distributed = self._compute_is_distributed(
                 normalized_args, dist_initialized=dist_initialized
             )
-            signature = self._base_specialization_key(
-                normalized_args, is_distributed=is_distributed
-            )
-            if signature != bound._base_spec_key:
+            if fast_entry.key[len(args)] != is_distributed:
                 return None
-            fast_key = known_fast_key
-            can_prepare = True
-            extra_guards: tuple[
-                tuple[Callable[[Sequence[object]], Hashable], Hashable], ...
-            ] = ()
-            if fast_key is None:
-                current_entry = self._fast_dispatch_key_and_guards(
+            if self._key_fn is None:
+                raw_signature = self._base_specialization_key(
+                    args, is_distributed=is_distributed
+                )
+            else:
+                # Reuse the custom key captured by the dispatch lookup; user
+                # key functions must execute exactly once per launch.
+                raw_signature = self._base_specialization_key(
                     args,
                     is_distributed=is_distributed,
-                    signature=signature,
+                    custom_key=fast_entry.key[len(args) + 1],
                 )
-                if current_entry is None:
-                    return None
-                fast_key, extra_guards = current_entry
-            elif self._has_specialization_extras:
-                # The dispatch lookup already evaluated every late guard. A
-                # second evaluation is only needed before retaining those
-                # values in a prepared call; failure must not reject the valid
-                # dispatch hit that was just obtained.
-                try:
-                    current_entry = self._fast_dispatch_key_and_guards(
-                        args,
-                        is_distributed=is_distributed,
-                        signature=signature,
-                    )
-                except Exception:
-                    can_prepare = False
-                else:
-                    if current_entry is None:
-                        return None
-                    current_fast_key, extra_guards = current_entry
-                    if current_fast_key != fast_key:
-                        return None
-            if can_prepare:
-                from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
+            alias = self._specialization_aliases.get(raw_signature)
+            signature = raw_signature if alias is None else alias.canonical_signature
+            if signature != bound._base_spec_key:
+                return None
 
-                current_cache_key = BoundKernelInMemoryCacheKey(
-                    signature,
-                    tuple(expected for _, expected in extra_guards),
-                )
-                if self._bound_kernels.get(current_cache_key) is not bound:
-                    return None
-            prepared = (
-                _PreparedCall.build(
+            if self._key_fn is None:
+                prepared = _PreparedCall.build(
                     self,
                     bound,
                     args,
                     dist_initialized=dist_initialized,
-                    extra_guards=extra_guards,
+                    extra_guards=fast_entry.extra_guards,
                     is_distributed=is_distributed,
                 )
-                if can_prepare
-                else None
-            )
+                keyed_direct_dispatch = False
+            else:
+                prepared = None
+                keyed_direct_dispatch = (
+                    not self.settings.distributed
+                    and not self._declares_process_group
+                    and not bound._env._is_distributed
+                )
             # Process-group initialization is external to ``_bind_lock``. Do
             # not publish a key assembled across a state transition.
             if dist.is_initialized() != dist_initialized:
                 return None
-            return fast_key, prepared
+            return prepared, keyed_direct_dispatch
         except Exception:
             # Fast-path publication is optional and must not add a failure
             # after the compiled kernel has already run successfully.
@@ -816,11 +824,27 @@ class Kernel(Generic[_R]):
             BoundKernel: A BoundKernel object with the given arguments bound.
         """
         # Dynamo executes bind while capturing the call but cannot trace an RLock.
-        # Eager binds, including all cache mutations, remain serialized.
+        # Capture only needs an independent host function and compile environment.
         if torch.compiler.is_compiling():
-            return self._bind(args)
+            return self._bind_isolated(args)
         with self._bind_lock:
             return self._bind(args)
+
+    def _bind_isolated(self, args: tuple[object, ...]) -> BoundKernel[_R]:
+        """Construct a canonical bound without reading or publishing shared caches."""
+        args = self.normalize_args(*args)
+        dist_initialized = dist.is_initialized()
+        is_distributed = self._compute_is_distributed(
+            args, dist_initialized=dist_initialized
+        )
+        signature = self._base_specialization_key(args, is_distributed=is_distributed)
+        return BoundKernel(
+            self,
+            args,
+            base_spec_key=signature,
+            is_distributed=is_distributed,
+            cache_managed=False,
+        )
 
     def _bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         with measure("Kernel.bind"):
@@ -844,9 +868,25 @@ class Kernel(Generic[_R]):
             )
             if bound_kernel is None:
                 normalized_args: tuple[object, ...] = self.normalize_args(*args)
+                extra_fns: list[Callable[[Sequence[object]], Hashable]] | None = None
                 if len(normalized_args) != len(args):
                     # we had default args that needed to be applied
-                    bound_kernel = self.bind(normalized_args)
+                    bound_kernel = self._bind(normalized_args)
+                    canonical_signature = bound_kernel._base_spec_key
+                    alias = self._specialization_aliases.get(signature)
+                    if alias is None:
+                        trailing_defaults = normalized_args[len(args) :]
+                        alias = _SpecializationAlias(
+                            self._specialize_extra,
+                            canonical_signature,
+                            trailing_defaults,
+                        )
+                        self._specialization_aliases[signature] = alias
+                    extra_fns = (
+                        [alias]
+                        if self._specialize_extra.get(canonical_signature)
+                        else []
+                    )
                 else:
                     bound_kernel = BoundKernel(
                         self,
@@ -856,7 +896,10 @@ class Kernel(Generic[_R]):
                     )
                 if cache_key is None:
                     cache_key = self._create_bound_kernel_cache_key(
-                        bound_kernel, args, signature
+                        bound_kernel,
+                        args,
+                        signature,
+                        extra_fns=extra_fns,
                     )
                 self._bound_kernels[cache_key] = bound_kernel
             return bound_kernel
@@ -1275,27 +1318,51 @@ class Kernel(Generic[_R]):
             # path below, so hitting it cannot skip autotuning/compilation.
             # (The cache stays empty under TPU compile capture, so this
             # cannot bypass auto_capture_call below.)
-            fast_key = self._fast_dispatch_key(args)
-            if fast_key is not None:
+            fast_entry: _FastDispatchEntry | None = None
+            if (
+                self._key_fn is not None
+                and not self.settings.distributed
+                and not self._declares_process_group
+            ):
+                # Keyed kernels cannot use a prepared call. Build their legacy
+                # exact key without allocating guard metadata on every launch.
+                specialization_generation = self._specialization_generation
+                dist_initialized = dist.is_initialized()
+                is_distributed = self._compute_is_distributed(
+                    args, dist_initialized=dist_initialized
+                )
+                fast_key = self._fast_dispatch_key(args, is_distributed=is_distributed)
+                if fast_key is not None:
+                    bound = self._dispatch_cache.get(fast_key)
+                    if bound is not None and bound._run is not None:
+                        run = bound._run
+                        if is_compiling:
+                            return run(*args)
+                        if (
+                            bound._dispatch_generation == specialization_generation
+                            and bound._run is run
+                            and self._specialization_generation
+                            == specialization_generation
+                            and dist.is_initialized() == dist_initialized
+                        ):
+                            return run(*args)
+                    fast_entry = _FastDispatchEntry(
+                        fast_key,
+                        (),
+                        specialization_generation,
+                    )
+            if fast_entry is None:
+                fast_entry = self._fast_dispatch_key_and_guards(args)
+            if fast_entry is not None:
+                fast_key = fast_entry.key
                 bound = self._dispatch_cache.get(fast_key)
                 if bound is not None and bound._run is not None:
                     run = bound._run
                     if is_compiling:
                         return run(*args)
-                    # Keyed calls cannot produce a prepared call.  The exact
-                    # dispatch key is sufficient when no late or distributed
-                    # guards require the locked revalidation below.
-                    if (
-                        self._key_fn is not None
-                        and not self._has_specialization_extras
-                        and not self.settings.distributed
-                        and not self._declares_process_group
-                        and not bound._env._is_distributed
-                    ):
-                        return run(*args)
                     # A compilation can discover a late specialization while a
-                    # different thread is reading this cache. Publish a prepared
-                    # entry only while the mapping is still current; the same
+                    # different thread is reading this cache. Revalidate fast-
+                    # path state while the mapping is still current; the same
                     # lock protects specialization-driven invalidation.
                     with self._bind_lock:
                         if (
@@ -1303,10 +1370,16 @@ class Kernel(Generic[_R]):
                             and bound._run is run
                         ):
                             entry = self._prepare_dispatch_entry(
-                                args, bound, known_fast_key=fast_key
+                                args,
+                                bound,
+                                fast_entry,
                             )
-                            if entry is not None and entry[0] == fast_key:
-                                self._prepared_call = entry[1]
+                            if entry is not None:
+                                self._prepared_call = entry[0]
+                                if entry[1]:
+                                    bound._dispatch_generation = (
+                                        fast_entry.specialization_generation
+                                    )
                             else:
                                 run = None
                         else:
@@ -1326,29 +1399,30 @@ class Kernel(Generic[_R]):
         bound = self.bind(args)
         result = bound(*args)
         if is_compiling:
-            if self._has_specialization_extras:
-                bound = self.bind(args)
-            if bound._run is not None:
-                fast_key = self._fast_dispatch_key(args)
-                if fast_key is not None:
-                    self._dispatch_cache[fast_key] = bound
-        else:
-            # Avoid a second bind for signatures the fast paths cannot support.
-            # This cheap key check also captures a custom key exactly once.
-            fast_key = self._fast_dispatch_key(args)
-            if fast_key is not None:
-                # Resolve any late specialization and publish both fast paths as
-                # one atomic update with respect to discovery and reset.
-                with self._bind_lock:
-                    if self._has_specialization_extras:
-                        bound = self._bind(args)
-                    if bound._run is not None:
-                        entry = self._prepare_dispatch_entry(
-                            args, bound, known_fast_key=fast_key
-                        )
-                        if entry is not None and entry[0] == fast_key:
-                            self._dispatch_cache[fast_key] = bound
-                            self._prepared_call = entry[1]
+            return result
+        # Avoid a second bind for signatures the fast paths cannot support.
+        # This cheap key check also captures a custom key exactly once.
+        fast_entry = self._fast_dispatch_key_and_guards(args)
+        if fast_entry is not None:
+            fast_key = fast_entry.key
+            # Resolve any late specialization and publish both fast paths as
+            # one atomic update with respect to discovery and reset.
+            with self._bind_lock:
+                if self._has_specialization_extras:
+                    bound = self._bind(args)
+                if bound._run is not None:
+                    entry = self._prepare_dispatch_entry(
+                        args,
+                        bound,
+                        fast_entry,
+                    )
+                    if entry is not None:
+                        self._dispatch_cache[fast_key] = bound
+                        self._prepared_call = entry[0]
+                        if entry[1]:
+                            bound._dispatch_generation = (
+                                fast_entry.specialization_generation
+                            )
         return result
 
     def reset(self) -> None:
@@ -1360,6 +1434,8 @@ class Kernel(Generic[_R]):
             self._bound_kernels.clear()
             self._dispatch_cache.clear()
             self._prepared_call = None
+            self._specialization_generation += 1
+            self._reset_generation += 1
 
     @property
     def jax_fn(self) -> Callable[..., Any]:
@@ -1392,6 +1468,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         *,
         base_spec_key: tuple[Hashable, ...] | None = None,
         is_distributed: bool | None = None,
+        cache_managed: bool = True,
     ) -> None:
         """
         Initialize a BoundKernel object.
@@ -1402,9 +1479,15 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         Args:
             kernel: The Kernel object to bind.
             args: A tuple of arguments to bind to the kernel.
+            cache_managed: Whether this bound participates in the kernel's shared
+                specialization and bound caches.
         """
         super().__init__()
         self.kernel = kernel
+        self._reset_generation = kernel._reset_generation
+        # Extending this bound's schema evicts all of its dispatch mappings.
+        self._dispatch_generation: int | None = None
+        self._cache_managed = cache_managed
         if is_distributed is None:
             dist_initialized = dist.is_initialized()
             is_distributed = kernel._compute_is_distributed(
@@ -2036,7 +2119,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             yield
 
     def _register_cute_grouped_static_tail_specializations(self) -> None:
-        if self.kernel.settings.backend != "cute":
+        if self.kernel.settings.backend != "cute" or not self._cache_managed:
             return
         signature = self._base_spec_key
         descriptors = _cute_grouped_static_tail_extra_descriptors(
@@ -2059,13 +2142,13 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             self.env.runtime_arg_values_by_name.get(name)
             for name in self.kernel.signature.parameters
         )
-        self.kernel._extend_bound_kernel_specializations(
+        if self.kernel._extend_bound_kernel_specializations(
             self,
             signature,
             new_extractors,
             runtime_args,
-        )
-        seen.update(new_descriptors)
+        ):
+            seen.update(new_descriptors)
 
     def _fixed_config_for_td_layout_guards(self) -> Config | None:
         """Return the fixed config if TD layout guards can be filtered safely."""
@@ -2162,7 +2245,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         Returns:
             _R: The result of the kernel execution.
         """
-        if self.kernel._has_specialization_extras:
+        if self._cache_managed and self.kernel._has_specialization_extras:
             rebound = self.kernel.bind(args)
             if rebound is not self:
                 return rebound(*args)
@@ -2171,7 +2254,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             with self._first_compile_lock:
                 # Another caller may have discovered a late specialization while
                 # this caller waited for the first compile.
-                if self.kernel._has_specialization_extras:
+                if self._cache_managed and self.kernel._has_specialization_extras:
                     rebound = self.kernel.bind(args)
                     if rebound is not self:
                         return rebound(*args)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -9282,6 +9282,28 @@ class TestCuteBackend(TestCase):
         self.assertNotEqual(key0, key1)
         self.assertIsNot(identity.bind(args), bound)
 
+    def test_isolated_bound_does_not_publish_cute_specializations(self) -> None:
+        identity = _runtime_identity_kernel()
+        args = (torch.empty(1), torch.zeros(128, dtype=torch.int64))
+        bound = identity._bind_isolated(args)
+        kernel_mod = importlib.import_module("helion.runtime.kernel")
+
+        with (
+            patch.object(
+                kernel_mod,
+                "_cute_grouped_static_tail_extra_descriptors",
+                return_value=(("cute_grouped_static_tail", 1, 1, 128, None, None),),
+            ),
+            patch.object(
+                identity,
+                "_extend_bound_kernel_specializations",
+                side_effect=AssertionError("isolated bind published specialization"),
+            ),
+        ):
+            bound._register_cute_grouped_static_tail_specializations()
+
+        self.assertFalse(identity._cute_grouped_static_tail_extra_descriptors)
+
     def test_kernel_growing_late_specialization_evicts_all_stale_keys(self) -> None:
         identity = _runtime_identity_kernel()
         x = torch.empty(1)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -40,6 +40,7 @@ from helion.runtime import default_cute_launcher
 if TYPE_CHECKING:
     from collections.abc import Hashable
     from collections.abc import Sequence
+    from typing_extensions import Self
 
     from helion.autotuner.config_spec import ConfigSpec
 
@@ -9303,6 +9304,93 @@ class TestCuteBackend(TestCase):
             bound._register_cute_grouped_static_tail_specializations()
 
         self.assertFalse(identity._cute_grouped_static_tail_extra_descriptors)
+
+    def test_concurrent_cute_specialization_registration_deduplicates(self) -> None:
+        identity = _runtime_identity_kernel()
+        args = (torch.empty(1), torch.zeros(128, dtype=torch.int64))
+        bound = identity.bind(args)
+        descriptor = ("cute_grouped_static_tail", 1, 1, 128, None, None)
+        extractor_entered = threading.Event()
+        release_extractor = threading.Event()
+
+        class TrackedRLock:
+            def __init__(self) -> None:
+                self._lock = threading.RLock()
+                self._state_lock = threading.Lock()
+                self._owner: int | None = None
+                self._depth = 0
+                self.contended = threading.Event()
+
+            def __enter__(self) -> Self:
+                thread_id = threading.get_ident()
+                with self._state_lock:
+                    if self._owner is not None and self._owner != thread_id:
+                        self.contended.set()
+                self._lock.acquire()
+                with self._state_lock:
+                    if self._owner == thread_id:
+                        self._depth += 1
+                    else:
+                        self._owner = thread_id
+                        self._depth = 1
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                with self._state_lock:
+                    self._depth -= 1
+                    if self._depth == 0:
+                        self._owner = None
+                self._lock.release()
+
+        tracked_lock = TrackedRLock()
+        extractor_calls = 0
+        extractor_calls_lock = threading.Lock()
+
+        def blocking_extractor(_args: object) -> Hashable:
+            nonlocal extractor_calls
+            with extractor_calls_lock:
+                extractor_calls += 1
+                first_call = extractor_calls == 1
+            if first_call:
+                extractor_entered.set()
+                self.assertTrue(release_extractor.wait(5))
+            return (1,)
+
+        kernel_mod = importlib.import_module("helion.runtime.kernel")
+        with (
+            patch.object(identity, "_bind_lock", tracked_lock),
+            patch.object(
+                kernel_mod,
+                "_cute_grouped_static_tail_extra_descriptors",
+                return_value=(descriptor,),
+            ),
+            patch.object(
+                kernel_mod,
+                "_make_cute_grouped_static_tail_extractor",
+                return_value=blocking_extractor,
+            ),
+            ThreadPoolExecutor(max_workers=2) as pool,
+        ):
+            first = pool.submit(
+                bound._register_cute_grouped_static_tail_specializations
+            )
+            self.assertTrue(extractor_entered.wait(5))
+            second = pool.submit(
+                bound._register_cute_grouped_static_tail_specializations
+            )
+            try:
+                self.assertTrue(tracked_lock.contended.wait(5))
+            finally:
+                release_extractor.set()
+            first.result(timeout=5)
+            second.result(timeout=5)
+
+        signature = bound._base_spec_key
+        self.assertEqual(len(identity._specialize_extra[signature]), 1)
+        self.assertEqual(
+            identity._cute_grouped_static_tail_extra_descriptors[signature],
+            {descriptor},
+        )
 
     def test_kernel_growing_late_specialization_evicts_all_stale_keys(self) -> None:
         identity = _runtime_identity_kernel()

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from collections import namedtuple
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 import math
 import os
@@ -9,6 +10,7 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
+import threading
 from typing import cast
 import unittest
 from unittest.mock import patch
@@ -204,28 +206,33 @@ class TestMisc(RefEagerTestBase, TestCase):
         def foo(x: torch.Tensor) -> torch.Tensor:
             return x
 
-        # Case 1: Register new lowering for the custom op
-        @register_inductor_lowering(
-            torch.ops.helion_test.foo, lowering_dict=inductor_lowering_dispatch
-        )
-        def foo_lowering(x):
-            return x
-
-        # Case 2: Register a patched lowering for add.Tensor
-        @register_inductor_lowering(
-            torch.ops.aten.add.Tensor, lowering_dict=inductor_lowering_dispatch
-        )
-        def add_lowering(*args, **kwargs):
-            pass
-
-        # Check that within `patch_inductor_lowerings()` context manager, the patched lowerings are used.
-        with patch_inductor_lowerings():
-            assert torch.ops.helion_test.foo in torch._inductor.lowering.lowerings
-            assert torch.ops.aten.add.Tensor in torch._inductor.lowering.lowerings
-            assert (
-                torch._inductor.lowering.lowerings[torch.ops.aten.add.Tensor]
-                != inductor_lowerings_orig[torch.ops.aten.add.Tensor]
+        with patch.dict(inductor_lowering_dispatch):
+            # Case 1: Register new lowering for the custom op
+            @register_inductor_lowering(
+                torch.ops.helion_test.foo, lowering_dict=inductor_lowering_dispatch
             )
+            def foo_lowering(x):
+                return x
+
+            # Case 2: Register a patched lowering for add.Tensor
+            @register_inductor_lowering(
+                torch.ops.aten.add.Tensor, lowering_dict=inductor_lowering_dispatch
+            )
+            def add_lowering(*args, **kwargs):
+                pass
+
+            # Check that the patched lowerings are installed only in the context.
+            with patch_inductor_lowerings():
+                assert torch.ops.helion_test.foo in torch._inductor.lowering.lowerings
+                assert torch.ops.aten.add.Tensor in torch._inductor.lowering.lowerings
+                assert (
+                    torch._inductor.lowering.lowerings[torch.ops.aten.add.Tensor]
+                    != inductor_lowerings_orig[torch.ops.aten.add.Tensor]
+                )
+                with pytest.raises(KeyError):
+                    torch._inductor.lowering.lowerings[torch.ops.helion_test.foo](
+                        object()
+                    )
 
         # Check that outside the context manager, the original lowerings are restored.
         assert len(torch._inductor.lowering.lowerings.keys()) == len(
@@ -233,6 +240,136 @@ class TestMisc(RefEagerTestBase, TestCase):
         )
         for op in torch._inductor.lowering.lowerings:
             assert torch._inductor.lowering.lowerings[op] == inductor_lowerings_orig[op]
+
+    @skipIfRefEager("Inductor lowering tests not applicable in ref eager mode")
+    def test_overlapping_inductor_lowering_patches_restore_once(self):
+        from helion._compiler.inductor_lowering_extra import patch_inductor_lowerings
+
+        lowerings = torch._inductor.lowering.lowerings
+        restored_op = torch.ops.aten.rsqrt.default
+        replaced_op = torch.ops.aten.sqrt.default
+        restored_original = lowerings[restored_op]
+        replaced_original = lowerings[replaced_op]
+
+        def replacement_lowering() -> None:
+            pass
+
+        entered = [threading.Event(), threading.Event()]
+        release = [threading.Event(), threading.Event()]
+
+        def use_patch(index: int) -> None:
+            with patch_inductor_lowerings():
+                entered[index].set()
+                self.assertTrue(release[index].wait(5))
+                if index == 0:
+                    raise RuntimeError("test exceptional cleanup")
+
+        try:
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [pool.submit(use_patch, index) for index in range(2)]
+                try:
+                    self.assertTrue(entered[0].wait(5))
+                    self.assertTrue(entered[1].wait(5))
+                    installed = lowerings[restored_op]
+                    self.assertIsNot(installed, restored_original)
+                    lowerings[replaced_op] = replacement_lowering
+
+                    release[0].set()
+                    with self.assertRaisesRegex(
+                        RuntimeError, "test exceptional cleanup"
+                    ):
+                        futures[0].result(timeout=5)
+                    self.assertIs(lowerings[restored_op], installed)
+                    self.assertIs(lowerings[replaced_op], replacement_lowering)
+
+                    release[1].set()
+                    futures[1].result(timeout=5)
+                finally:
+                    release[0].set()
+                    release[1].set()
+
+            self.assertIs(torch._inductor.lowering.lowerings, lowerings)
+            self.assertIs(lowerings[restored_op], restored_original)
+            self.assertIs(lowerings[replaced_op], replacement_lowering)
+        finally:
+            lowerings[restored_op] = restored_original
+            lowerings[replaced_op] = replaced_original
+
+    @skipIfRefEager("Inductor lowering tests not applicable in ref eager mode")
+    def test_inductor_lowering_override_is_helion_scoped(self):
+        from helion._compiler.compile_environment import CompileEnvironment
+        from helion._compiler.inductor_lowering_extra import (
+            _compile_environment_lowering,
+        )
+
+        previous_result = object()
+        patched_result = object()
+        scoped = _compile_environment_lowering(
+            "test_op",
+            lambda: patched_result,
+            lambda: previous_result,
+        )
+
+        self.assertIs(scoped(), previous_result)
+        with patch.object(CompileEnvironment, "has_current", return_value=True):
+            self.assertIs(scoped(), patched_result)
+
+    @skipIfRefEager("Inductor lowering tests not applicable in ref eager mode")
+    def test_fp32_fallback_is_scoped_to_helion_triton(self):
+        from helion._compiler import inductor_lowering_extra
+        from helion._compiler.compile_environment import CompileEnvironment
+
+        class FakeTensorBox:
+            def __init__(self, dtype: torch.dtype) -> None:
+                self.dtype = dtype
+
+            def get_dtype(self) -> torch.dtype:
+                return self.dtype
+
+        value = FakeTensorBox(torch.bfloat16)
+        fp32_value = FakeTensorBox(torch.float32)
+        fp32_result = FakeTensorBox(torch.float32)
+        final_result = FakeTensorBox(torch.bfloat16)
+        bypass_result = object()
+        calls: list[FakeTensorBox] = []
+
+        def original(arg: object) -> object:
+            assert isinstance(arg, FakeTensorBox)
+            calls.append(arg)
+            return fp32_result if arg is fp32_value else bypass_result
+
+        with (
+            patch.object(inductor_lowering_extra, "TensorBox", FakeTensorBox),
+            patch.object(
+                inductor_lowering_extra,
+                "to_dtype",
+                side_effect=(fp32_value, final_result),
+            ) as to_dtype,
+        ):
+            fallback = (
+                inductor_lowering_extra.create_fp16_to_fp32_unary_fallback_lowering(
+                    original
+                )
+            )
+            self.assertIs(fallback(value), bypass_result)
+            with (
+                patch.object(CompileEnvironment, "has_current", return_value=True),
+                patch.object(CompileEnvironment, "current") as current,
+            ):
+                current.return_value.backend_name = "pallas"
+                self.assertIs(fallback(value), bypass_result)
+
+                current.return_value.backend_name = "triton"
+                self.assertIs(fallback(value), final_result)
+
+        self.assertEqual(calls, [value, value, fp32_value])
+        self.assertEqual(
+            to_dtype.call_args_list,
+            [
+                unittest.mock.call(value, torch.float32),
+                unittest.mock.call(fp32_result, torch.bfloat16),
+            ],
+        )
 
     @skipIfRefEager("Inductor config tests not applicable in ref eager mode")
     def test_patched_inductor_config(self):

--- a/test/test_prepared_call.py
+++ b/test/test_prepared_call.py
@@ -23,6 +23,7 @@ from helion._testing import onlyBackends
 import helion.language as hl
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Sequence
     from typing import Hashable
 
@@ -42,6 +43,21 @@ def _make_add_one(*, distributed: bool = False) -> helion.Kernel:
         return out
 
     return add_one
+
+
+def _make_aot_scale(*, distributed: bool = False) -> helion.Kernel:
+    @helion.aot_kernel(
+        config=helion.Config(block_sizes=[64]),
+        distributed=distributed,
+    )
+    def aot_scale(x: torch.Tensor, value: int) -> torch.Tensor:
+        value = hl.specialize(value)
+        out = torch.empty_like(x)
+        for tile in hl.tile(x.size(0)):
+            out[tile] = x[tile] * value
+        return out
+
+    return aot_scale
 
 
 def _tensor_size(values: Sequence[object]) -> int:
@@ -69,11 +85,20 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
                 kernel,
                 "_prepare_dispatch_entry",
                 side_effect=AssertionError("AOT cache hit tried to prepare"),
-            ) as prepare,
+            ),
+            patch.object(
+                kernel,
+                "_fast_dispatch_key_and_guards",
+                side_effect=AssertionError("AOT cache hit built guard metadata"),
+            ),
+            patch.object(
+                kernel,
+                "_bind",
+                side_effect=AssertionError("AOT cache hit rebound the kernel"),
+            ),
         ):
             torch.testing.assert_close(kernel(*args), expected)
         key_fn.assert_called_once_with(*args)
-        prepare.assert_not_called()
 
     def test_fresh_tensor_bypasses_dispatch_key(self) -> None:
         add_one = _make_add_one()
@@ -85,7 +110,7 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         with (
             patch.object(
                 add_one,
-                "_fast_dispatch_key",
+                "_fast_dispatch_key_and_guards",
                 side_effect=AssertionError("prepared call rebuilt its dispatch key"),
             ),
             patch.object(
@@ -125,8 +150,8 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
                 ),
                 patch.object(
                     add_one,
-                    "_fast_dispatch_key",
-                    wraps=add_one._fast_dispatch_key,  # type: ignore[attr-defined]
+                    "_fast_dispatch_key_and_guards",
+                    wraps=add_one._fast_dispatch_key_and_guards,  # type: ignore[attr-defined]
                 ) as fast_key,
             ):
                 out = add_one(value)
@@ -171,7 +196,7 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         torch.testing.assert_close(scale(x, 2.0), x * 2.0)
         with patch.object(
             scale,
-            "_fast_dispatch_key",
+            "_fast_dispatch_key_and_guards",
             side_effect=AssertionError("runtime scalar rebuilt its dispatch key"),
         ):
             torch.testing.assert_close(scale(x, 3.0), x * 3.0)
@@ -184,8 +209,8 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             torch.testing.assert_close(kernel(x, first_value), x * first_value)
             with patch.object(
                 kernel,
-                "_fast_dispatch_key",
-                wraps=kernel._fast_dispatch_key,  # type: ignore[attr-defined]
+                "_fast_dispatch_key_and_guards",
+                wraps=kernel._fast_dispatch_key_and_guards,  # type: ignore[attr-defined]
             ) as fast_key:
                 torch.testing.assert_close(kernel(x, second_value), x * second_value)
             fast_key.assert_called()
@@ -220,12 +245,13 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         bound = next(iter(add_one._dispatch_cache.values()))  # type: ignore[attr-defined]
         different_shape = torch.randn(65, device=DEVICE)
         calls = 0
-        fast_key = add_one._fast_dispatch_key((different_shape,))  # type: ignore[attr-defined]
-        self.assertIsNotNone(fast_key)
+        fast_entry = add_one._fast_dispatch_key_and_guards(  # type: ignore[attr-defined]
+            (different_shape,)
+        )
+        self.assertIsNotNone(fast_entry)
+        assert fast_entry is not None
         self.assertIsNone(  # type: ignore[attr-defined]
-            add_one._prepare_dispatch_entry(
-                (different_shape,), bound, known_fast_key=fast_key
-            )
+            add_one._prepare_dispatch_entry((different_shape,), bound, fast_entry)
         )
         self.assertEqual(calls, 1)
 
@@ -270,6 +296,29 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         torch.testing.assert_close(aot_add_value(x), x + 1)
         self._assert_aot_repeat_uses_direct_dispatch_cache(aot_add_value, (x,), x + 1)
 
+    def test_omitted_specialized_default_uses_prepared_call(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def add_default(x: torch.Tensor, value: int = 2) -> torch.Tensor:
+            value = hl.specialize(value)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + value
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(add_default(x), x + 2)
+        self.assertIsNotNone(add_default._prepared_call)  # type: ignore[attr-defined]
+
+        with patch.object(
+            add_default,
+            "_fast_dispatch_key_and_guards",
+            side_effect=AssertionError("prepared call rebuilt its dispatch key"),
+        ):
+            torch.testing.assert_close(add_default(x), x + 2)
+
     def test_user_key_aot_repeat_uses_direct_dispatch_cache(self) -> None:
         calls = 0
 
@@ -297,6 +346,335 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         )
         self.assertEqual(calls, 1)
 
+    def test_aot_late_specialization_repeat_uses_dispatch_generation(self) -> None:
+        aot_scale = _make_aot_scale()
+
+        class ForbiddenLock:
+            def __enter__(self) -> None:
+                raise AssertionError("stable AOT hit acquired the bind lock")
+
+            def __exit__(self, *args: object) -> None:
+                raise AssertionError("stable AOT hit exited the bind lock")
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(aot_scale(x, 2), x * 2)
+        self.assertTrue(aot_scale._has_specialization_extras)  # type: ignore[attr-defined]
+
+        bound = next(iter(aot_scale._dispatch_cache.values()))  # type: ignore[attr-defined]
+        self.assertEqual(
+            bound._dispatch_generation,
+            aot_scale._specialization_generation,  # type: ignore[attr-defined]
+        )
+        calls = [0, 0]
+
+        def tensor_size(values: Sequence[object]) -> int:
+            calls[0] += 1
+            return _tensor_size(values)
+
+        def scalar_value(values: Sequence[object]) -> int:
+            calls[1] += 1
+            return cast("int", values[1])
+
+        aot_scale._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
+            bound,
+            bound._base_spec_key,
+            [tensor_size, scalar_value],
+            (x, 2),
+        )
+        torch.testing.assert_close(aot_scale(x, 2), x * 2)
+        self.assertEqual(
+            bound._dispatch_generation,
+            aot_scale._specialization_generation,  # type: ignore[attr-defined]
+        )
+        calls[:] = [0, 0]
+        with (
+            patch.object(
+                aot_scale,
+                "_key_fn",
+                wraps=aot_scale._key_fn,  # type: ignore[attr-defined]
+            ) as key_fn,
+            patch.object(
+                aot_scale,
+                "_prepare_dispatch_entry",
+                side_effect=AssertionError("stable AOT hit re-prepared dispatch"),
+            ),
+            patch.object(
+                aot_scale,
+                "_bind",
+                side_effect=AssertionError("stable AOT hit rebound the kernel"),
+            ),
+            patch.object(aot_scale, "_bind_lock", ForbiddenLock()),
+        ):
+            torch.testing.assert_close(aot_scale(x, 2), x * 2)
+
+        key_fn.assert_called_once_with(x, 2)
+        self.assertEqual(calls, [1, 1])
+
+    def test_omitted_default_aot_specializations_follow_canonical_schema(
+        self,
+    ) -> None:
+        @helion.aot_kernel(
+            config=helion.Config(block_sizes=[64]),
+        )
+        def aot_add_default(x: torch.Tensor, value: int = 1) -> torch.Tensor:
+            value = hl.specialize(value)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + value
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(aot_add_default(x, 1), x + 1)
+        bound = next(iter(aot_add_default._dispatch_cache.values()))  # type: ignore[attr-defined]
+
+        def default_value(values: Sequence[object]) -> int:
+            return cast("int", values[1])
+
+        # The raw omitted-default alias does not exist yet. Its first bind must
+        # still include this extension and normalize values for every extractor.
+        aot_add_default._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
+            bound,
+            bound._base_spec_key,
+            [default_value],
+            (x, 1),
+        )
+        torch.testing.assert_close(aot_add_default(x), x + 1)
+
+        with (
+            patch.object(
+                aot_add_default,
+                "normalize_args",
+                side_effect=AssertionError("stable AOT hit normalized defaults"),
+            ),
+            patch.object(
+                aot_add_default,
+                "_prepare_dispatch_entry",
+                side_effect=AssertionError("stable AOT hit re-prepared dispatch"),
+            ),
+        ):
+            torch.testing.assert_close(aot_add_default(x), x + 1)
+
+        def first_value(values: Sequence[object]) -> float:
+            return float(cast("torch.Tensor", values[0])[0].item())
+
+        def last_value(values: Sequence[object]) -> float:
+            return float(cast("torch.Tensor", values[0])[-1].item())
+
+        # Consecutive extensions occur before the evicted raw alias is rebound.
+        # The persistent proxy must pick up both additions.
+        aot_add_default._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
+            bound,
+            bound._base_spec_key,
+            [first_value],
+            (x, 1),
+        )
+        aot_add_default._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
+            bound,
+            bound._base_spec_key,
+            [last_value],
+            (x, 1),
+        )
+
+        raw_bound = aot_add_default.bind((x,))
+        x[0] = x[0] + 1
+        first_changed_bound = aot_add_default.bind((x,))
+        self.assertIsNot(first_changed_bound, raw_bound)
+        x[-1] = x[-1] + 1
+        self.assertIsNot(aot_add_default.bind((x,)), first_changed_bound)
+        torch.testing.assert_close(aot_add_default(x), x + 1)
+        with patch.object(
+            aot_add_default,
+            "_prepare_dispatch_entry",
+            side_effect=AssertionError("extended omitted-default hit re-prepared"),
+        ):
+            torch.testing.assert_close(aot_add_default(x), x + 1)
+
+    def test_compiler_bind_is_isolated_from_eager_caches(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def add_default(x: torch.Tensor, value: int = 1) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + value
+            return out
+
+        x = torch.zeros(64, device=DEVICE)
+        bound = add_default.bind((x, 1))
+        shared_state = (
+            tuple(add_default._bound_kernels.items()),  # type: ignore[attr-defined]
+            tuple(add_default._specialization_aliases.items()),  # type: ignore[attr-defined]
+            tuple(add_default._specialize_extra.items()),  # type: ignore[attr-defined]
+        )
+        with patch.object(torch.compiler, "is_compiling", return_value=True):
+            isolated = add_default.bind((x,))
+        self.assertIsNot(isolated, bound)
+        self.assertFalse(isolated._cache_managed)
+        self.assertEqual(
+            (
+                tuple(add_default._bound_kernels.items()),  # type: ignore[attr-defined]
+                tuple(add_default._specialization_aliases.items()),  # type: ignore[attr-defined]
+                tuple(add_default._specialize_extra.items()),  # type: ignore[attr-defined]
+            ),
+            shared_state,
+        )
+
+    def test_isolated_bind_with_existing_specializations_is_read_only(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def scale(x: torch.Tensor, value: int) -> torch.Tensor:
+            value = hl.specialize(value)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] * value
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        expected = scale(x, 2)
+        self.assertTrue(scale._has_specialization_extras)  # type: ignore[attr-defined]
+        managed_bound = scale._prepared_call.bound  # type: ignore[attr-defined]
+        scale._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
+            managed_bound,
+            managed_bound._base_spec_key,
+            [_tensor_size],
+            (x, 2),
+        )
+        schemas = {  # type: ignore[attr-defined]
+            signature: tuple(extractors)
+            for signature, extractors in scale._specialize_extra.items()
+        }
+        scale.reset()
+
+        bound = scale._bind_isolated((x, 2))  # type: ignore[attr-defined]
+        self.assertFalse(bound._cache_managed)
+        scale._create_bound_kernel_cache_key(  # type: ignore[attr-defined]
+            bound,
+            (x, 2),
+            bound._base_spec_key,
+        )
+        torch.testing.assert_close(bound(x, 2), expected)
+
+        self.assertFalse(scale._bound_kernels)  # type: ignore[attr-defined]
+        self.assertFalse(scale._dispatch_cache)  # type: ignore[attr-defined]
+        self.assertEqual(  # type: ignore[attr-defined]
+            {
+                signature: tuple(extractors)
+                for signature, extractors in scale._specialize_extra.items()
+            },
+            schemas,
+        )
+
+    def test_inductor_lowering_bind_falls_back_when_cache_lock_is_busy(self) -> None:
+        from helion._compiler._inductor.template_buffer import _bind_kernel_for_lowering
+
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        lock_held = threading.Event()
+        release_lock = threading.Event()
+
+        def hold_bind_lock() -> None:
+            with add_one._bind_lock:  # type: ignore[attr-defined]
+                lock_held.set()
+                self.assertTrue(release_lock.wait(5))
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            holder = pool.submit(hold_bind_lock)
+            try:
+                self.assertTrue(lock_held.wait(5))
+                isolated = _bind_kernel_for_lowering(add_one, (x,))
+            finally:
+                release_lock.set()
+            holder.result(timeout=5)
+
+        self.assertFalse(isolated._cache_managed)
+        self.assertFalse(add_one._bound_kernels)  # type: ignore[attr-defined]
+        managed = _bind_kernel_for_lowering(add_one, (x,))
+        self.assertTrue(managed._cache_managed)
+        self.assertIn(managed, add_one._bound_kernels.values())  # type: ignore[attr-defined]
+
+    def test_stale_keyed_dispatch_generation_is_rebuilt(self) -> None:
+        aot_scale = _make_aot_scale()
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(aot_scale(x, 2), x * 2)
+        bound = next(iter(aot_scale._dispatch_cache.values()))  # type: ignore[attr-defined]
+        stale_entry = aot_scale._fast_dispatch_key_and_guards((x, 2))  # type: ignore[attr-defined]
+        assert stale_entry is not None
+        with aot_scale._bind_lock:  # type: ignore[attr-defined]
+            aot_scale._specialization_generation += 1  # type: ignore[attr-defined]
+        self.assertIsNone(  # type: ignore[attr-defined]
+            aot_scale._prepare_dispatch_entry((x, 2), bound, stale_entry)
+        )
+
+        with patch.object(
+            aot_scale,
+            "_prepare_dispatch_entry",
+            wraps=aot_scale._prepare_dispatch_entry,  # type: ignore[attr-defined]
+        ) as prepare:
+            torch.testing.assert_close(aot_scale(x, 2), x * 2)
+
+        prepare.assert_called_once()
+        self.assertEqual(  # type: ignore[attr-defined]
+            bound._dispatch_generation,
+            aot_scale._specialization_generation,
+        )
+
+        with patch.object(
+            aot_scale,
+            "_prepare_dispatch_entry",
+            side_effect=AssertionError("rebuilt generation was not reused"),
+        ):
+            torch.testing.assert_close(aot_scale(x, 2), x * 2)
+
+        aot_scale.reset()
+        self.assertNotEqual(
+            bound._dispatch_generation,
+            aot_scale._specialization_generation,  # type: ignore[attr-defined]
+        )
+
+    def test_distributed_aot_late_specialization_stays_locked(self) -> None:
+        aot_scale = _make_aot_scale(distributed=True)
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(aot_scale(x, 2), x * 2)
+        bound = next(iter(aot_scale._dispatch_cache.values()))  # type: ignore[attr-defined]
+        self.assertIsNone(bound._dispatch_generation)
+
+        with patch.object(
+            aot_scale,
+            "_prepare_dispatch_entry",
+            wraps=aot_scale._prepare_dispatch_entry,  # type: ignore[attr-defined]
+        ) as prepare:
+            torch.testing.assert_close(aot_scale(x, 2), x * 2)
+
+        prepare.assert_called_once()
+        self.assertIsNone(bound._dispatch_generation)
+
+    def test_process_group_aot_dispatch_stays_locked(self) -> None:
+        @helion.aot_kernel(
+            config=helion.Config(block_sizes=[64]),
+            key=lambda _x, _group_name: 0,
+        )
+        def add_one(x: torch.Tensor, group_name: hl.ProcessGroupName) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + 1
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(add_one(x, "unused"), x + 1)
+        bound = next(iter(add_one._dispatch_cache.values()))  # type: ignore[attr-defined]
+        self.assertIsNone(bound._dispatch_generation)
+        with patch.object(
+            add_one,
+            "_prepare_dispatch_entry",
+            wraps=add_one._prepare_dispatch_entry,  # type: ignore[attr-defined]
+        ) as prepare:
+            torch.testing.assert_close(add_one(x, "unused"), x + 1)
+
+        prepare.assert_called_once()
+
     def test_compiler_capture_does_not_inspect_prepared_guard(self) -> None:
         add_one = _make_add_one()
         x = torch.randn(64, device=DEVICE)
@@ -315,6 +693,74 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             out = add_one(x)
         is_compiling.assert_called_once_with()
         torch.testing.assert_close(out, x + 1)
+
+    def test_fullgraph_capture_preserves_eager_caches(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def add_default(x: torch.Tensor, value: int = 1) -> torch.Tensor:
+            value = hl.specialize(value)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + value
+            return out
+
+        def snapshot() -> tuple[object, ...]:
+            return (
+                tuple(add_default._bound_kernels.items()),  # type: ignore[attr-defined]
+                tuple(add_default._dispatch_cache.items()),  # type: ignore[attr-defined]
+                tuple(add_default._specialization_aliases.items()),  # type: ignore[attr-defined]
+                tuple(  # type: ignore[attr-defined]
+                    (key, tuple(extractors))
+                    for key, extractors in add_default._specialize_extra.items()
+                ),
+            )
+
+        cold_states: list[tuple[object, ...]] = []
+
+        def cold_backend(
+            graph: torch.fx.GraphModule,
+            _example_inputs: list[torch.Tensor],
+        ) -> Callable[..., object]:
+            cold_states.append(snapshot())
+            return graph.forward
+
+        def cold_call(x: torch.Tensor) -> torch.Tensor:
+            return add_default(x)
+
+        x = torch.randn(64, device=DEVICE)
+        compiled_cold = torch.compile(
+            cold_call,
+            backend=cold_backend,
+            fullgraph=True,
+        )
+        torch.testing.assert_close(compiled_cold(x), x + 1)
+        empty_state = ((), (), (), ())
+        self.assertEqual(cold_states, [empty_state])
+
+        eager_state = snapshot()
+        self.assertNotEqual(eager_state, empty_state)
+        warm_states: list[tuple[object, ...]] = []
+
+        def warm_backend(
+            graph: torch.fx.GraphModule,
+            _example_inputs: list[torch.Tensor],
+        ) -> Callable[..., object]:
+            warm_states.append(snapshot())
+            return graph.forward
+
+        def warm_call(x: torch.Tensor) -> torch.Tensor:
+            return add_default(x)
+
+        compiled_warm = torch.compile(
+            warm_call,
+            backend=warm_backend,
+            fullgraph=True,
+        )
+        torch.testing.assert_close(compiled_warm(x), x + 1)
+        self.assertEqual(warm_states, [eager_state])
+        self.assertEqual(snapshot(), eager_state)
 
     def test_unsupported_signature_does_not_rebind_after_run(self) -> None:
         @helion.kernel(
@@ -344,12 +790,44 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             patch.object(kernel_module, "kernel_uses_symm_mem", return_value=False),
             patch.object(
                 add_one,
-                "_fast_dispatch_key",
-                wraps=add_one._fast_dispatch_key,  # type: ignore[attr-defined]
+                "_fast_dispatch_key_and_guards",
+                wraps=add_one._fast_dispatch_key_and_guards,  # type: ignore[attr-defined]
             ) as fast_key,
         ):
             out = add_one(x)
         fast_key.assert_called()
+        torch.testing.assert_close(out, x + 1)
+
+    def test_direct_keyed_hit_rechecks_distributed_transition(self) -> None:
+        @helion.aot_kernel(
+            config=helion.Config(block_sizes=[64]),
+            key=lambda _x: 0,
+        )
+        def add_one(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + 1
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(add_one(x), x + 1)
+
+        with (
+            patch.object(
+                kernel_module.dist,
+                "is_initialized",
+                side_effect=(False, True, True, True),
+            ),
+            patch.object(kernel_module, "kernel_uses_symm_mem", return_value=False),
+            patch.object(
+                add_one,
+                "_prepare_dispatch_entry",
+                wraps=add_one._prepare_dispatch_entry,  # type: ignore[attr-defined]
+            ) as prepare,
+        ):
+            out = add_one(x)
+
+        prepare.assert_called_once()
         torch.testing.assert_close(out, x + 1)
 
     def test_publication_rejects_distributed_state_transition(self) -> None:
@@ -357,6 +835,8 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         x = torch.randn(64, device=DEVICE)
         add_one(x)
         bound = add_one._prepared_call.bound  # type: ignore[attr-defined]
+        fast_entry = add_one._fast_dispatch_key_and_guards((x,))  # type: ignore[attr-defined]
+        assert fast_entry is not None
 
         with patch.object(
             kernel_module.dist,
@@ -364,13 +844,13 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             side_effect=(False, True),
         ) as is_initialized:
             self.assertIsNone(  # type: ignore[attr-defined]
-                add_one._prepare_dispatch_entry((x,), bound)
+                add_one._prepare_dispatch_entry((x,), bound, fast_entry)
             )
         self.assertEqual(is_initialized.call_count, 2)
 
         with patch.object(kernel_module.dist, "is_initialized", return_value=True):
             self.assertIsNone(  # type: ignore[attr-defined]
-                add_one._prepare_dispatch_entry((x,), bound)
+                add_one._prepare_dispatch_entry((x,), bound, fast_entry)
             )
 
     def test_custom_key_hit_rejects_distributed_state_transition(self) -> None:
@@ -397,15 +877,15 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         add_one(x)
         bound = next(iter(add_one._dispatch_cache.values()))  # type: ignore[attr-defined]
         calls = 0
+        fast_entry = add_one._fast_dispatch_key_and_guards((x,))  # type: ignore[attr-defined]
+        assert fast_entry is not None
         with patch.object(
             kernel_module.dist,
             "is_initialized",
             side_effect=(False, True),
         ):
-            fast_key = add_one._fast_dispatch_key((x,))  # type: ignore[attr-defined]
-            assert fast_key is not None
             self.assertIsNone(  # type: ignore[attr-defined]
-                add_one._prepare_dispatch_entry((x,), bound, known_fast_key=fast_key)
+                add_one._prepare_dispatch_entry((x,), bound, fast_entry)
             )
         self.assertEqual(calls, 1)
 
@@ -422,20 +902,19 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             return out
 
         x = torch.randn(64, device=DEVICE)
-        add_one(x)
-        fast_key, bound = next(iter(add_one._dispatch_cache.items()))  # type: ignore[attr-defined]
-        # Model a bound produced by automatic symmetric-memory detection rather
-        # than an explicit distributed setting or ProcessGroupName argument.
-        bound._env._is_distributed = True
+        with patch.object(kernel_module, "kernel_uses_symm_mem", return_value=True):
+            torch.testing.assert_close(add_one(x), x + 1)
+            bound = next(iter(add_one._dispatch_cache.values()))  # type: ignore[attr-defined]
+            self.assertTrue(bound._env._is_distributed)
+            self.assertIsNone(bound._dispatch_generation)
+            with patch.object(
+                add_one,
+                "_prepare_dispatch_entry",
+                wraps=add_one._prepare_dispatch_entry,  # type: ignore[attr-defined]
+            ) as prepare:
+                out = add_one(x)
 
-        with patch.object(
-            add_one,
-            "_prepare_dispatch_entry",
-            return_value=(fast_key, None),
-        ) as prepare:
-            out = add_one(x)
-
-        prepare.assert_called_once_with((x,), bound, known_fast_key=fast_key)
+        prepare.assert_called_once()
         torch.testing.assert_close(out, x + 1)
 
     def test_alternating_cached_specializations_prepare_latest(self) -> None:
@@ -448,8 +927,8 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         first_64 = torch.randn_like(x64)
         with patch.object(
             add_one,
-            "_fast_dispatch_key",
-            wraps=add_one._fast_dispatch_key,  # type: ignore[attr-defined]
+            "_fast_dispatch_key_and_guards",
+            wraps=add_one._fast_dispatch_key_and_guards,  # type: ignore[attr-defined]
         ) as fast_key:
             torch.testing.assert_close(add_one(first_64), first_64 + 1)
         fast_key.assert_called()
@@ -457,36 +936,36 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         second_64 = torch.randn_like(x64)
         with patch.object(
             add_one,
-            "_fast_dispatch_key",
+            "_fast_dispatch_key_and_guards",
             side_effect=AssertionError("latest specialization was not prepared"),
         ):
             torch.testing.assert_close(add_one(second_64), second_64 + 1)
 
-    def test_preparation_failure_falls_back_after_dispatch_hit(self) -> None:
+    def test_dispatch_hit_prepares_without_repeating_extractors(self) -> None:
         add_one = _make_add_one()
         x = torch.randn(64, device=DEVICE)
         add_one(x)
         bound = add_one._prepared_call.bound  # type: ignore[attr-defined]
         calls = 0
 
-        def flaky_extractor(_args: Sequence[object]) -> int:
+        def counting_extractor(_args: Sequence[object]) -> int:
             nonlocal calls
             calls += 1
-            if calls % 2 == 0:
-                raise RuntimeError("second evaluation failed")
             return 1
 
-        add_one._specialize_extra[bound._base_spec_key] = [flaky_extractor]  # type: ignore[attr-defined]
-        add_one._has_specialization_extras = True  # type: ignore[attr-defined]
-        fast_key = add_one._fast_dispatch_key((x,))  # type: ignore[attr-defined]
-        assert fast_key is not None
-        add_one._dispatch_cache = {fast_key: bound}  # type: ignore[attr-defined]
+        add_one._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
+            bound,
+            bound._base_spec_key,
+            [counting_extractor],
+            (x,),
+        )
+        torch.testing.assert_close(add_one(x), x + 1)
         add_one._prepared_call = None  # type: ignore[attr-defined]
         calls = 0
 
         torch.testing.assert_close(add_one(x), x + 1)
-        self.assertEqual(calls, 2)
-        self.assertIsNone(add_one._prepared_call)  # type: ignore[attr-defined]
+        self.assertEqual(calls, 1)
+        self.assertIsNotNone(add_one._prepared_call)  # type: ignore[attr-defined]
 
     def test_specialization_extension_cannot_leave_stale_preparation(self) -> None:
         add_one = _make_add_one()
@@ -540,6 +1019,7 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         add_one(x)
         prepared = add_one._prepared_call  # type: ignore[attr-defined]
         assert prepared is not None
+        generation = add_one._specialization_generation  # type: ignore[attr-defined]
         signature = prepared.bound._base_spec_key
         original_extractors = tuple(  # type: ignore[attr-defined]
             add_one._specialize_extra[signature]
@@ -570,10 +1050,11 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         self.assertEqual(  # type: ignore[attr-defined]
             tuple(add_one._specialize_extra[signature]), original_extractors
         )
+        self.assertEqual(add_one._specialization_generation, generation)  # type: ignore[attr-defined]
         self.assertIs(add_one._prepared_call, prepared)  # type: ignore[attr-defined]
         with patch.object(
             add_one,
-            "_fast_dispatch_key",
+            "_fast_dispatch_key_and_guards",
             side_effect=AssertionError("transaction invalidated prepared call"),
         ):
             torch.testing.assert_close(add_one(x), x + 1)
@@ -591,7 +1072,11 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         bound_type = type(bound)
         original_call = bound_type.__call__
 
-        def blocking_call(current: object, *args: object, **kwargs: object) -> object:
+        def blocking_call(
+            current: object,
+            *args: object,
+            **kwargs: object,
+        ) -> object:
             result = original_call(current, *args, **kwargs)
             call_finished_kernel.set()
             self.assertTrue(release_call.wait(5))
@@ -602,13 +1087,33 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             ThreadPoolExecutor(max_workers=1) as pool,
         ):
             call = pool.submit(add_one, x)
-            self.assertTrue(call_finished_kernel.wait(5))
-            add_one.reset()
-            release_call.set()
+            try:
+                self.assertTrue(call_finished_kernel.wait(5))
+                add_one.reset()
+            finally:
+                release_call.set()
             torch.testing.assert_close(call.result(timeout=5), x + 1)
 
         self.assertIsNone(add_one._prepared_call)  # type: ignore[attr-defined]
         self.assertFalse(add_one._dispatch_cache)  # type: ignore[attr-defined]
+        self.assertFalse(add_one._bound_kernels)  # type: ignore[attr-defined]
+
+    def test_reset_rejects_late_specialization_from_old_bound(self) -> None:
+        add_one = _make_add_one()
+        x = torch.randn(64, device=DEVICE)
+        add_one(x)
+        bound = add_one._prepared_call.bound  # type: ignore[attr-defined]
+
+        add_one.reset()
+        self.assertFalse(  # type: ignore[attr-defined]
+            add_one._extend_bound_kernel_specializations(
+                bound,
+                bound._base_spec_key,
+                [_tensor_size],
+                (x,),
+            )
+        )
+        self.assertFalse(add_one._bound_kernels)  # type: ignore[attr-defined]
 
     def test_backend_capability_is_explicit_and_inherited(self) -> None:
         self.assertTrue(TritonBackend().supports_eager_prepared_call)

--- a/test/test_prepared_call.py
+++ b/test/test_prepared_call.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import torch
 
 import helion
+from helion._compiler._dynamo.variables import infer_output_spec
 from helion._compiler.cute.backend import CuteBackend
 from helion._compiler.pallas.backend import PallasBackend
 from helion._compiler.triton.backend import TileIRBackend
@@ -26,8 +27,17 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Sequence
     from typing import Hashable
+    from typing_extensions import Self
 
 kernel_module = importlib.import_module("helion.runtime.kernel")
+
+_RESET_SPECIALIZATION_USES_X = False
+
+
+def _select_reset_specialization_tensor(
+    x: torch.Tensor, y: torch.Tensor
+) -> torch.Tensor:
+    return x if _RESET_SPECIALIZATION_USES_X else y
 
 
 def _make_add_one(*, distributed: bool = False) -> helion.Kernel:
@@ -58,6 +68,21 @@ def _make_aot_scale(*, distributed: bool = False) -> helion.Kernel:
         return out
 
     return aot_scale
+
+
+def _make_scale() -> helion.Kernel:
+    @helion.kernel(
+        static_shapes=True,
+        config=helion.Config(block_sizes=[64]),
+    )
+    def scale(x: torch.Tensor, value: int) -> torch.Tensor:
+        value = hl.specialize(value)
+        out = torch.empty_like(x)
+        for tile in hl.tile(x.size(0)):
+            out[tile] = x[tile] * value
+        return out
+
+    return scale
 
 
 def _tensor_size(values: Sequence[object]) -> int:
@@ -181,16 +206,7 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
                 out[tile] = x[tile] * value
             return out
 
-        @helion.kernel(
-            static_shapes=True,
-            config=helion.Config(block_sizes=[64]),
-        )
-        def scale_specialized(x: torch.Tensor, value: int) -> torch.Tensor:
-            value = hl.specialize(value)
-            out = torch.empty_like(x)
-            for tile in hl.tile(x.size(0)):
-                out[tile] = x[tile] * value
-            return out
+        scale_specialized = _make_scale()
 
         x = torch.randn(64, device=DEVICE)
         torch.testing.assert_close(scale(x, 2.0), x * 2.0)
@@ -489,7 +505,7 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         ):
             torch.testing.assert_close(aot_add_default(x), x + 1)
 
-    def test_compiler_bind_is_isolated_from_eager_caches(self) -> None:
+    def test_compiler_binds_are_isolated_from_eager_caches(self) -> None:
         @helion.kernel(
             static_shapes=True,
             config=helion.Config(block_sizes=[64]),
@@ -511,6 +527,8 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             isolated = add_default.bind((x,))
         self.assertIsNot(isolated, bound)
         self.assertFalse(isolated._cache_managed)
+        output_spec = infer_output_spec(add_default, (x, 1))
+        self.assertEqual(output_spec["leaf_specs"][0]["shape"], [64])
         self.assertEqual(
             (
                 tuple(add_default._bound_kernels.items()),  # type: ignore[attr-defined]
@@ -520,33 +538,9 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             shared_state,
         )
 
-    def test_isolated_bind_with_existing_specializations_is_read_only(self) -> None:
-        @helion.kernel(
-            static_shapes=True,
-            config=helion.Config(block_sizes=[64]),
-        )
-        def scale(x: torch.Tensor, value: int) -> torch.Tensor:
-            value = hl.specialize(value)
-            out = torch.empty_like(x)
-            for tile in hl.tile(x.size(0)):
-                out[tile] = x[tile] * value
-            return out
-
+    def test_isolated_bind_cache_key_is_read_only(self) -> None:
+        scale = _make_scale()
         x = torch.randn(64, device=DEVICE)
-        expected = scale(x, 2)
-        self.assertTrue(scale._has_specialization_extras)  # type: ignore[attr-defined]
-        managed_bound = scale._prepared_call.bound  # type: ignore[attr-defined]
-        scale._extend_bound_kernel_specializations(  # type: ignore[attr-defined]
-            managed_bound,
-            managed_bound._base_spec_key,
-            [_tensor_size],
-            (x, 2),
-        )
-        schemas = {  # type: ignore[attr-defined]
-            signature: tuple(extractors)
-            for signature, extractors in scale._specialize_extra.items()
-        }
-        scale.reset()
 
         bound = scale._bind_isolated((x, 2))  # type: ignore[attr-defined]
         self.assertFalse(bound._cache_managed)
@@ -555,45 +549,376 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             (x, 2),
             bound._base_spec_key,
         )
-        torch.testing.assert_close(bound(x, 2), expected)
+        torch.testing.assert_close(bound(x, 2), x * 2)
 
         self.assertFalse(scale._bound_kernels)  # type: ignore[attr-defined]
         self.assertFalse(scale._dispatch_cache)  # type: ignore[attr-defined]
-        self.assertEqual(  # type: ignore[attr-defined]
-            {
-                signature: tuple(extractors)
-                for signature, extractors in scale._specialize_extra.items()
-            },
-            schemas,
+        self.assertFalse(scale._specialize_extra)  # type: ignore[attr-defined]
+
+    def test_reset_rediscovers_conditional_specialization_schema(self) -> None:
+        global _RESET_SPECIALIZATION_USES_X
+
+        @helion.kernel(
+            static_shapes=False,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def conditional_scale(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            selected = _select_reset_specialization_tensor(x, y)
+            value = hl.specialize(selected.size(0))
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + value
+            return out
+
+        x32 = torch.randn(32, device=DEVICE)
+        x48 = torch.randn(48, device=DEVICE)
+        y64 = torch.randn(64, device=DEVICE)
+        try:
+            _RESET_SPECIALIZATION_USES_X = False
+            old = conditional_scale.bind((x32, y64))
+            signature = old._base_spec_key
+            old_extractors = conditional_scale._specialize_extra[signature]  # type: ignore[attr-defined]
+            self.assertEqual(tuple(fn((x32, y64)) for fn in old_extractors), (64,))
+
+            conditional_scale.reset()
+            _RESET_SPECIALIZATION_USES_X = True
+            first = conditional_scale.bind((x32, y64))
+            new_extractors = conditional_scale._specialize_extra[signature]  # type: ignore[attr-defined]
+            self.assertEqual(tuple(fn((x32, y64)) for fn in new_extractors), (32,))
+
+            second = conditional_scale.bind((x48, y64))
+            self.assertEqual(first._base_spec_key, second._base_spec_key)
+            self.assertIsNot(first, second)
+            self.assertEqual(len(conditional_scale._bound_kernels), 2)  # type: ignore[attr-defined]
+        finally:
+            _RESET_SPECIALIZATION_USES_X = False
+            conditional_scale.reset()
+
+    def test_stale_bound_does_not_republish_schema_after_reset(self) -> None:
+        scale = _make_scale()
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(scale(x, 2), x * 2)
+        stale_bound = scale._prepared_call.bound  # type: ignore[attr-defined]
+        signature = stale_bound._base_spec_key
+
+        scale.reset()
+        cache_key = scale._create_bound_kernel_cache_key(  # type: ignore[attr-defined]
+            stale_bound,
+            (x, 2),
+            signature,
         )
 
-    def test_inductor_lowering_bind_falls_back_when_cache_lock_is_busy(self) -> None:
+        self.assertEqual(cache_key.extra_results, (2,))
+        self.assertFalse(scale._specialize_extra)  # type: ignore[attr-defined]
+        self.assertFalse(scale._has_specialization_extras)  # type: ignore[attr-defined]
+
+    def test_reset_preserves_inflight_omitted_default_alias(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def add_default(x: torch.Tensor, value: int = 2) -> torch.Tensor:
+            value = hl.specialize(value)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + value
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        add_default.bind((x, 2))
+        add_default.bind((x,))
+        signature = add_default._base_specialization_key((x,))  # type: ignore[attr-defined]
+        alias = add_default._specialization_aliases[signature]  # type: ignore[attr-defined]
+        alias_type = type(alias)
+        original_call = alias_type.__call__
+        alias_entered = threading.Event()
+        release_alias = threading.Event()
+
+        def blocking_call(current, values):
+            alias_entered.set()
+            self.assertTrue(release_alias.wait(5))
+            return original_call(current, values)
+
+        with (
+            patch.object(alias_type, "__call__", new=blocking_call),
+            ThreadPoolExecutor(max_workers=1) as pool,
+        ):
+            key = pool.submit(
+                add_default._get_bound_kernel_cache_key,  # type: ignore[attr-defined]
+                (x,),
+                signature,
+            )
+            try:
+                self.assertTrue(alias_entered.wait(5))
+                add_default.reset()
+            finally:
+                release_alias.set()
+            self.assertIsNone(key.result(timeout=5))
+
+        self.assertFalse(add_default._specialize_extra)  # type: ignore[attr-defined]
+        self.assertFalse(add_default._specialization_aliases)  # type: ignore[attr-defined]
+
+    def test_isolated_bind_rejects_too_many_args_without_caching(self) -> None:
+        add_one = _make_add_one()
+        x = torch.empty(1, device=DEVICE)
+
+        with self.assertRaisesRegex(
+            TypeError,
+            r"Too many arguments passed to the kernel, expected: 1 got: 2\.",
+        ):
+            add_one._bind_isolated((x, x))
+
+        self.assertFalse(add_one._bound_kernels)
+
+    def test_inductor_lowering_bind_does_not_wait_for_bind_lock(self) -> None:
         from helion._compiler._inductor.template_buffer import _bind_kernel_for_lowering
 
         add_one = _make_add_one()
         x = torch.randn(64, device=DEVICE)
+        isolated_bound = add_one._bind_isolated((x,))
+        self.assertFalse(isolated_bound._cache_managed)
         lock_held = threading.Event()
         release_lock = threading.Event()
 
         def hold_bind_lock() -> None:
-            with add_one._bind_lock:  # type: ignore[attr-defined]
+            with add_one._bind_lock:
                 lock_held.set()
                 self.assertTrue(release_lock.wait(5))
 
-        with ThreadPoolExecutor(max_workers=1) as pool:
+        with (
+            patch.object(
+                add_one,
+                "_bind_isolated",
+                return_value=isolated_bound,
+            ) as isolated_bind,
+            ThreadPoolExecutor(max_workers=2) as pool,
+        ):
             holder = pool.submit(hold_bind_lock)
+            self.assertTrue(lock_held.wait(5))
+            binding = pool.submit(_bind_kernel_for_lowering, add_one, (x,))
             try:
-                self.assertTrue(lock_held.wait(5))
-                isolated = _bind_kernel_for_lowering(add_one, (x,))
+                self.assertIs(binding.result(timeout=2), isolated_bound)
+            finally:
+                release_lock.set()
+            holder.result(timeout=5)
+            isolated_bind.assert_called_once_with((x,))
+
+        self.assertFalse(add_one._bound_kernels)
+
+        managed_bound = _bind_kernel_for_lowering(add_one, (x,))
+        self.assertTrue(managed_bound._cache_managed)
+        self.assertIn(managed_bound, add_one._bound_kernels.values())
+
+    def test_cache_key_generation_preserves_late_specializations(self) -> None:
+        scale = _make_scale()
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(scale(x, 2), x * 2)
+        prepared = scale._prepared_call
+        assert prepared is not None
+        bound = prepared.bound
+        signature = bound._base_spec_key
+        scale._extend_bound_kernel_specializations(
+            bound,
+            signature,
+            [_tensor_size],
+            (x, 2),
+        )
+        schema = tuple(scale._specialize_extra[signature])
+        self.assertLess(len(bound._specialize_extra()), len(schema))
+
+        cache_key = scale._create_bound_kernel_cache_key(
+            bound,
+            (x, 2),
+            signature,
+        )
+
+        self.assertEqual(tuple(scale._specialize_extra[signature]), schema)
+        self.assertEqual(cache_key.extra_results, (2, 64))
+
+    def test_cache_key_generation_waits_for_specialization_extension(self) -> None:
+        scale = _make_scale()
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(scale(x, 2), x * 2)
+        prepared = scale._prepared_call
+        assert prepared is not None
+        bound = prepared.bound
+        signature = bound._base_spec_key
+        extension_entered = threading.Event()
+        release_extension = threading.Event()
+        key_lock_attempted = threading.Event()
+        lock = threading.Lock()
+
+        class TrackedLock:
+            def __enter__(self) -> Self:
+                if lock.locked():
+                    key_lock_attempted.set()
+                lock.acquire()
+                return self
+
+            def __exit__(
+                self,
+                exc_type: object,
+                exc_value: object,
+                traceback: object,
+            ) -> None:
+                lock.release()
+
+        def blocking_size(values: Sequence[object]) -> int:
+            extension_entered.set()
+            self.assertTrue(release_extension.wait(5))
+            return _tensor_size(values)
+
+        with (
+            patch.object(scale, "_specialize_extra_lock", TrackedLock()),
+            ThreadPoolExecutor(max_workers=2) as pool,
+        ):
+            extension = pool.submit(
+                scale._extend_bound_kernel_specializations,
+                bound,
+                signature,
+                [blocking_size],
+                (x, 2),
+            )
+            cache_key = None
+            try:
+                self.assertTrue(extension_entered.wait(5))
+                cache_key = pool.submit(
+                    scale._create_bound_kernel_cache_key,
+                    bound,
+                    (x, 2),
+                    signature,
+                )
+                self.assertTrue(key_lock_attempted.wait(5))
+                self.assertFalse(cache_key.done())
+            finally:
+                release_extension.set()
+
+            self.assertTrue(extension.result(timeout=5))
+            assert cache_key is not None
+            result = cache_key.result(timeout=5)
+
+        self.assertEqual(result.extra_results, (2, 64))
+
+    def test_cache_key_generation_retries_after_specialization_extension(self) -> None:
+        scale = _make_scale()
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(scale(x, 2), x * 2)
+        prepared = scale._prepared_call
+        assert prepared is not None
+        bound = prepared.bound
+        signature = bound._base_spec_key
+        key_entered = threading.Event()
+        release_key = threading.Event()
+        key_thread_id: int | None = None
+
+        def blocking_value(values: Sequence[object]) -> int:
+            nonlocal key_thread_id
+            if key_thread_id is None:
+                key_thread_id = threading.get_ident()
+                key_entered.set()
+            if threading.get_ident() == key_thread_id:
+                self.assertTrue(release_key.wait(5))
+            return cast("int", values[1])
+
+        scale._specialize_extra[signature] = [blocking_value]
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            cache_key = pool.submit(
+                scale._create_bound_kernel_cache_key,
+                bound,
+                (x, 2),
+                signature,
+            )
+            try:
+                self.assertTrue(key_entered.wait(5))
+                extension = pool.submit(
+                    scale._extend_bound_kernel_specializations,
+                    bound,
+                    signature,
+                    [_tensor_size],
+                    (x, 2),
+                )
+                self.assertTrue(extension.result(timeout=5))
+                self.assertFalse(cache_key.done())
+            finally:
+                release_key.set()
+
+            result = cache_key.result(timeout=5)
+
+        self.assertEqual(result.extra_results, (2, 64))
+
+    def test_specialization_key_retries_after_specialization_extension(self) -> None:
+        scale = _make_scale()
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(scale(x, 2), x * 2)
+        prepared = scale._prepared_call
+        assert prepared is not None
+        bound = prepared.bound
+        signature = bound._base_spec_key
+        key_entered = threading.Event()
+        release_key = threading.Event()
+        key_thread_id: int | None = None
+
+        def blocking_value(values: Sequence[object]) -> int:
+            nonlocal key_thread_id
+            if key_thread_id is None:
+                key_thread_id = threading.get_ident()
+                key_entered.set()
+            if threading.get_ident() == key_thread_id:
+                self.assertTrue(release_key.wait(5))
+            return cast("int", values[1])
+
+        scale._specialize_extra[signature] = [blocking_value]
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            specialization_key = pool.submit(scale.specialization_key, (x, 2))
+            try:
+                self.assertTrue(key_entered.wait(5))
+                extension = pool.submit(
+                    scale._extend_bound_kernel_specializations,
+                    bound,
+                    signature,
+                    [_tensor_size],
+                    (x, 2),
+                )
+                self.assertTrue(extension.result(timeout=5))
+                self.assertFalse(specialization_key.done())
+            finally:
+                release_key.set()
+
+            result = specialization_key.result(timeout=5)
+
+        self.assertEqual(result[-2:], (2, 64))
+
+    def test_cache_key_generation_does_not_wait_for_bind_lock(self) -> None:
+        scale = _make_scale()
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(scale(x, 2), x * 2)
+        prepared = scale._prepared_call
+        assert prepared is not None
+        bound = prepared.bound
+        lock_held = threading.Event()
+        release_lock = threading.Event()
+
+        def hold_bind_lock() -> None:
+            with scale._bind_lock:
+                lock_held.set()
+                self.assertTrue(release_lock.wait(5))
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            holder = pool.submit(hold_bind_lock)
+            self.assertTrue(lock_held.wait(5))
+            cache_key = pool.submit(
+                scale._create_bound_kernel_cache_key,
+                bound,
+                (x, 2),
+                bound._base_spec_key,
+            )
+            try:
+                result = cache_key.result(timeout=2)
             finally:
                 release_lock.set()
             holder.result(timeout=5)
 
-        self.assertFalse(isolated._cache_managed)
-        self.assertFalse(add_one._bound_kernels)  # type: ignore[attr-defined]
-        managed = _bind_kernel_for_lowering(add_one, (x,))
-        self.assertTrue(managed._cache_managed)
-        self.assertIn(managed, add_one._bound_kernels.values())  # type: ignore[attr-defined]
+        self.assertEqual(result.extra_results, (2,))
 
     def test_stale_keyed_dispatch_generation_is_rebuilt(self) -> None:
         aot_scale = _make_aot_scale()
@@ -852,6 +1177,48 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
             self.assertIsNone(  # type: ignore[attr-defined]
                 add_one._prepare_dispatch_entry((x,), bound, fast_entry)
             )
+
+    def test_omitted_default_publication_rechecks_raw_args(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def add_default(x: torch.Tensor, value: int = 1) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + value
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(add_default(x), x + 1)
+        prepared = add_default._prepared_call
+        assert prepared is not None
+        fast_entry = add_default._fast_dispatch_key_and_guards((x,))
+        assert fast_entry is not None
+        calls: list[tuple[tuple[object, ...], bool | None]] = []
+
+        def require_raw_args(
+            args: Sequence[object], *, dist_initialized: bool | None = None
+        ) -> bool:
+            calls.append((tuple(args), dist_initialized))
+            self.assertEqual(len(args), 1)
+            self.assertIs(args[0], x)
+            return False
+
+        with patch.object(
+            add_default,
+            "_compute_is_distributed",
+            side_effect=require_raw_args,
+        ):
+            entry = add_default._prepare_dispatch_entry(
+                (x,), prepared.bound, fast_entry
+            )
+
+        self.assertIsNotNone(entry)
+        assert entry is not None
+        self.assertIsNotNone(entry[0])
+        self.assertFalse(entry[1])
+        self.assertEqual(len(calls), 1)
 
     def test_custom_key_hit_rejects_distributed_state_transition(self) -> None:
         calls = 0

--- a/test/test_torch_compile.py
+++ b/test/test_torch_compile.py
@@ -13,6 +13,8 @@ import torch
 from torch._inductor import config as inductor_config
 from torch._inductor.codecache import FxGraphCache
 from torch._inductor.codecache import PyCodeCache
+from torch._inductor.compile_fx import compile_fx
+from torch._inductor.exc import InductorError
 from torch._inductor.ir import MutationOutput
 from torch._inductor.utils import fresh_cache
 from torch._inductor.utils import run_and_get_code
@@ -430,6 +432,15 @@ def k_create_return_view_ref(x, y):
 
 
 GLOBAL_SCALE_FACTOR = 2.5
+LOWERING_STATE_TENSOR = torch.empty(0)
+
+
+def _select_input_for_default_dtype(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    return x if torch.get_default_dtype() == torch.float32 else y
+
+
+def _apply_global_scale(value: torch.Tensor) -> torch.Tensor:
+    return value * GLOBAL_SCALE_FACTOR
 
 
 @helion.kernel(autotune_effort="none")
@@ -443,6 +454,19 @@ def k_scale_with_global_var(x: torch.Tensor) -> torch.Tensor:
 
 def k_scale_with_global_var_ref(x):
     return x * GLOBAL_SCALE_FACTOR
+
+
+@helion.kernel(
+    static_shapes=True,
+    config=helion.Config(block_sizes=[64]),
+    torch_compile_fusion=True,
+)
+def k_default_dtype_output(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty([x.size(0)], device=x.device)
+    value = 2.0 if out.dtype == torch.float64 else 1.0
+    for tile in hl.tile(out.size(0)):
+        out[tile] = value
+    return out
 
 
 # =============================================================================
@@ -3090,6 +3114,291 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
             kernels_ref=[k_scale_with_global_var_ref],
             expected_num_kernels_ref=1,
         )
+
+    @requires_fusion_support
+    @skipIfTileIR("torch.compile missing kernel metadata on tileir")
+    def test_fused_lowering_revalidates_eager_bound_host_trace(self):
+        def f(x: torch.Tensor) -> torch.Tensor:
+            return k_default_dtype_output(x)
+
+        original_default_dtype = torch.get_default_dtype()
+        x = torch.randn(8, device=DEVICE, dtype=torch.float32)
+        try:
+            torch.set_default_dtype(torch.float32)
+            k_default_dtype_output.reset()
+            warm = k_default_dtype_output(x)
+            self.assertEqual(warm.dtype, torch.float32)
+            warm_bound = next(iter(k_default_dtype_output._bound_kernels.values()))
+
+            torch.set_default_dtype(torch.float64)
+            torch._dynamo.reset()
+            with fresh_cache():
+                actual = torch.compile(f, fullgraph=True, backend="inductor")(x)
+
+            torch.testing.assert_close(
+                actual,
+                torch.full((8,), 2.0, device=DEVICE, dtype=torch.float64),
+            )
+            self.assertIs(
+                next(iter(k_default_dtype_output._bound_kernels.values())),
+                warm_bound,
+            )
+        finally:
+            torch.set_default_dtype(original_default_dtype)
+            k_default_dtype_output.reset()
+            torch._dynamo.reset()
+
+    @requires_fusion_support
+    @skipIfTileIR("torch.compile missing kernel metadata on tileir")
+    @parametrize("static_shapes", (True, False))
+    def test_fused_lowering_rejects_host_trace_change_during_compile(
+        self, static_shapes
+    ):
+        @helion.kernel(
+            static_shapes=static_shapes,
+            config=helion.Config(block_sizes=[64]),
+            torch_compile_fusion=True,
+        )
+        def default_dtype_output(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            selected = _select_input_for_default_dtype(x, y)
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size(0)):
+                out[tile] = selected[tile]
+            return out
+
+        def f(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return default_dtype_output(x, y)
+
+        def backend(gm, example_inputs):
+            self.assertEqual(torch.get_default_dtype(), torch.float32)
+            torch.set_default_dtype(torch.float64)
+            try:
+                return compile_fx(gm, example_inputs)
+            finally:
+                torch.set_default_dtype(torch.float32)
+
+        original_default_dtype = torch.get_default_dtype()
+        x = torch.randn(7, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(11, device=DEVICE, dtype=torch.float32)
+        try:
+            torch.set_default_dtype(torch.float32)
+            torch._dynamo.reset()
+            with fresh_cache():
+                compiled = torch.compile(
+                    f,
+                    fullgraph=True,
+                    backend=backend,
+                    dynamic=not static_shapes,
+                )
+                with self.assertRaisesRegex(
+                    InductorError,
+                    "Helion kernel trace changed",
+                ):
+                    compiled(x, y)
+        finally:
+            torch.set_default_dtype(original_default_dtype)
+            default_dtype_output.reset()
+            torch._dynamo.reset()
+
+    @requires_fusion_support
+    @skipIfTileIR("torch.compile missing kernel metadata on tileir")
+    def test_fused_lowering_rejects_container_argument_alias_change(self):
+        @helion.kernel(
+            static_shapes=False,
+            config=helion.Config(block_sizes=[64]),
+            torch_compile_fusion=True,
+        )
+        def default_dtype_output(
+            tensors: tuple[torch.Tensor, torch.Tensor],
+        ) -> torch.Tensor:
+            selected = _select_input_for_default_dtype(tensors[0], tensors[1])
+            out = torch.empty_like(tensors[0])
+            for tile in hl.tile(out.size(0)):
+                out[tile] = selected[tile]
+            return out
+
+        def f(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return default_dtype_output((x, y))
+
+        def backend(gm, example_inputs):
+            self.assertEqual(torch.get_default_dtype(), torch.float32)
+            torch.set_default_dtype(torch.float64)
+            try:
+                return compile_fx(gm, example_inputs)
+            finally:
+                torch.set_default_dtype(torch.float32)
+
+        original_default_dtype = torch.get_default_dtype()
+        x = torch.randn(7, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(11, device=DEVICE, dtype=torch.float32)
+        try:
+            torch.set_default_dtype(torch.float32)
+            torch._dynamo.reset()
+            with fresh_cache():
+                compiled = torch.compile(
+                    f,
+                    fullgraph=True,
+                    backend=backend,
+                    dynamic=True,
+                )
+                with self.assertRaisesRegex(
+                    InductorError,
+                    "Helion kernel trace changed",
+                ):
+                    compiled(x, y)
+        finally:
+            torch.set_default_dtype(original_default_dtype)
+            default_dtype_output.reset()
+            torch._dynamo.reset()
+
+    @requires_fusion_support
+    @skipIfTileIR("torch.compile missing kernel metadata on tileir")
+    def test_fused_lowering_isolates_user_global_bound(self):
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+            torch_compile_fusion=True,
+        )
+        def global_size_output(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                [LOWERING_STATE_TENSOR.size(0)],
+                dtype=x.dtype,
+                device=x.device,
+            )
+            for tile in hl.tile(out.size(0)):
+                out[tile] = 1.0
+            return out
+
+        def f(x: torch.Tensor) -> torch.Tensor:
+            return global_size_output(x)
+
+        original_state_size = LOWERING_STATE_TENSOR.size(0)
+        x = torch.randn(8, device=DEVICE, dtype=torch.float32)
+        try:
+            LOWERING_STATE_TENSOR.resize_(3)
+            warm = global_size_output(x)
+            self.assertEqual(warm.shape, torch.Size([3]))
+            warm_bound = next(iter(global_size_output._bound_kernels.values()))
+
+            LOWERING_STATE_TENSOR.resize_(5)
+            torch._dynamo.reset()
+            with fresh_cache():
+                actual = torch.compile(f, fullgraph=True, backend="inductor")(x)
+
+            torch.testing.assert_close(
+                actual,
+                torch.ones(5, device=DEVICE, dtype=x.dtype),
+            )
+            self.assertIs(
+                next(iter(global_size_output._bound_kernels.values())),
+                warm_bound,
+            )
+        finally:
+            LOWERING_STATE_TENSOR.resize_(original_state_size)
+            global_size_output.reset()
+            torch._dynamo.reset()
+
+    @requires_fusion_support
+    @skipIfTileIR("torch.compile missing kernel metadata on tileir")
+    def test_fused_lowering_rejects_dynamic_user_global_change(self):
+        @helion.kernel(
+            static_shapes=False,
+            config=helion.Config(block_sizes=[64]),
+            torch_compile_fusion=True,
+        )
+        def global_size_output(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                [LOWERING_STATE_TENSOR.size(0)],
+                dtype=x.dtype,
+                device=x.device,
+            )
+            for tile in hl.tile(out.size(0)):
+                out[tile] = 1.0
+            return out
+
+        def f(x: torch.Tensor) -> torch.Tensor:
+            return global_size_output(x)
+
+        def backend(gm, example_inputs):
+            self.assertEqual(LOWERING_STATE_TENSOR.size(0), 3)
+            LOWERING_STATE_TENSOR.resize_(5)
+            try:
+                return compile_fx(gm, example_inputs)
+            finally:
+                LOWERING_STATE_TENSOR.resize_(3)
+
+        original_state_size = LOWERING_STATE_TENSOR.size(0)
+        x = torch.randn(8, device=DEVICE, dtype=torch.float32)
+        try:
+            LOWERING_STATE_TENSOR.resize_(3)
+            torch._dynamo.reset()
+            with fresh_cache():
+                compiled = torch.compile(
+                    f,
+                    fullgraph=True,
+                    backend=backend,
+                    dynamic=True,
+                )
+                with self.assertRaisesRegex(
+                    InductorError,
+                    "Helion kernel trace changed",
+                ):
+                    compiled(x)
+        finally:
+            LOWERING_STATE_TENSOR.resize_(original_state_size)
+            global_size_output.reset()
+            torch._dynamo.reset()
+
+    @requires_fusion_support
+    @skipIfTileIR("torch.compile missing kernel metadata on tileir")
+    def test_fused_lowering_rejects_device_constant_change(self):
+        global GLOBAL_SCALE_FACTOR
+
+        @helion.kernel(
+            static_shapes=False,
+            config=helion.Config(block_sizes=[64]),
+            torch_compile_fusion=True,
+        )
+        def scale_with_global(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = _apply_global_scale(x[tile])
+            return out
+
+        def f(x: torch.Tensor) -> torch.Tensor:
+            return scale_with_global(x)
+
+        def backend(gm, example_inputs):
+            global GLOBAL_SCALE_FACTOR
+
+            self.assertEqual(GLOBAL_SCALE_FACTOR, 2.5)
+            GLOBAL_SCALE_FACTOR = 3.5
+            try:
+                return compile_fx(gm, example_inputs)
+            finally:
+                GLOBAL_SCALE_FACTOR = 2.5
+
+        original_scale = GLOBAL_SCALE_FACTOR
+        x = torch.randn(8, device=DEVICE, dtype=torch.float32)
+        try:
+            GLOBAL_SCALE_FACTOR = 2.5
+            torch._dynamo.reset()
+            with fresh_cache():
+                compiled = torch.compile(
+                    f,
+                    fullgraph=True,
+                    backend=backend,
+                    dynamic=True,
+                )
+                with self.assertRaisesRegex(
+                    InductorError,
+                    "Helion kernel trace changed",
+                ):
+                    compiled(x)
+        finally:
+            GLOBAL_SCALE_FACTOR = original_scale
+            scale_with_global.reset()
+            torch._dynamo.reset()
 
     @parametrize("allow_torch_compile_fusion", (True, False))
     @skipIfTileIR("torch.compile missing kernel metadata on tileir")

--- a/test/test_torch_compile.py
+++ b/test/test_torch_compile.py
@@ -3150,6 +3150,46 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
 
     @requires_fusion_support
     @skipIfTileIR("torch.compile missing kernel metadata on tileir")
+    def test_fused_lowering_revalidates_changed_index_dtype(self):
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+            index_dtype=torch.int32,
+            torch_compile_fusion=True,
+        )
+        def add_one(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + 1
+            return out
+
+        def f(x: torch.Tensor) -> torch.Tensor:
+            return add_one(x)
+
+        x = torch.randn(128, device=DEVICE)
+        try:
+            add_one(x)
+            warm_bound = next(iter(add_one._bound_kernels.values()))
+            self.assertEqual(warm_bound.env.index_dtype, torch.int32)
+
+            add_one.settings.index_dtype = torch.int64
+            torch._dynamo.reset()
+            with fresh_cache():
+                actual, (code,) = run_and_get_code(
+                    torch.compile(f, fullgraph=True, backend="inductor"),
+                    x,
+                )
+
+            torch.testing.assert_close(actual, x + 1)
+            self.assertIn("tl.program_id(0).to(tl.int64)", code)
+            self.assertIs(next(iter(add_one._bound_kernels.values())), warm_bound)
+        finally:
+            add_one.settings.index_dtype = torch.int32
+            add_one.reset()
+            torch._dynamo.reset()
+
+    @requires_fusion_support
+    @skipIfTileIR("torch.compile missing kernel metadata on tileir")
     @parametrize("static_shapes", (True, False))
     def test_fused_lowering_rejects_host_trace_change_during_compile(
         self, static_shapes
@@ -3192,7 +3232,7 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
                 )
                 with self.assertRaisesRegex(
                     InductorError,
-                    "Helion kernel trace changed",
+                    "Helion kernel trace or compile environment differed",
                 ):
                     compiled(x, y)
         finally:
@@ -3243,7 +3283,7 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
                 )
                 with self.assertRaisesRegex(
                     InductorError,
-                    "Helion kernel trace changed",
+                    "Helion kernel trace or compile environment differed",
                 ):
                     compiled(x, y)
         finally:
@@ -3341,7 +3381,7 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
                 )
                 with self.assertRaisesRegex(
                     InductorError,
-                    "Helion kernel trace changed",
+                    "Helion kernel trace or compile environment differed",
                 ):
                     compiled(x)
         finally:
@@ -3392,7 +3432,7 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
                 )
                 with self.assertRaisesRegex(
                     InductorError,
-                    "Helion kernel trace changed",
+                    "Helion kernel trace or compile environment differed",
                 ):
                     compiled(x)
         finally:


### PR DESCRIPTION
## Why

#3347 removed the redundant resolved-native Triton launcher and restored the
no-extra keyed/AOT path, but keyed AOT kernels with late size, reduction, or
descriptor specializations still re-enter `_prepare_dispatch_entry()` under the
dispatch lock on every eager call. This is the remaining fixed host cost behind
the August 11 regression in launch-bound reductions such as rms norm, layer
norm, and softmax.

The exact dispatch key already identifies the resolved late-specialization
schema and values. Revalidating and rebuilding that same entry under a lock on
every stable hit adds overhead without changing generated GPU kernels.

## What

- cache an exact keyed dispatch entry with its guards and specialization
  generation, allowing stable late-specialized AOT hits to launch directly;
- make specialization extension transactional and invalidate all aliases by
  generation, including omitted-default signatures;
- retain safe fallback for changed keys, guards, distributed settings, process
  groups, symmetric-memory state, resets, and failed specialization extension;
- evaluate custom keys and specialization extractors once per call;
- isolate Dynamo/compiler binds from eager caches, while preserving managed
  lowering binds when uncontended and using an isolated fallback on lock
  contention;
- keep isolated CuTe binds from publishing grouped-tail specializations; and
- make temporary Inductor lowering overrides refcounted, identity-preserving,
  and scoped to a Helion compile so overlapping compiles restore safely.

The tests cover each distinct invalidation and concurrency boundary, including
compiler capture, reset races, distributed gates, omitted defaults, lowering
overlap/exception cleanup, and the CuTe-only specialization-publication branch.

## Why this is better than reverting the original stack

This keeps the useful prepared-call work from #3321 and the shared AOT runtime
from #3323. A separate non-keyed prepared-call measurement remains 0.971 us of
host overhead versus 4.584 us before that stack (-78.8%). The existing keyed
path without late-specialization extras also remains at parity:

| GB300 host overhead | `main` | this PR |
| --- | ---: | ---: |
| Triton, keyed/no extras | 4.513 us | 4.469 us |
| CuTe, keyed/no extras | 4.266 us | 4.375 us |

This is therefore a targeted completion of #3347 rather than a rollback of the
prepared-call architecture.

## GB300 performance

Measured against a separate worktree at fresh `main` (`092309e7`) with the same
late-specialized AOT scale kernel. Host-only measurements replace the generated
runner with a no-op (median of 9 x 20,000 calls); synchronized call latency is
the median of 7 x 5,000 real launches.

| Backend / measurement | `main` | this PR | change |
| --- | ---: | ---: | ---: |
| Triton host dispatch | 19.017 us | 7.996 us | -58.0% |
| Triton synchronized call | 47.717 us | 30.972 us | -35.1% |
| CuTe host dispatch | 18.995 us | 8.026 us | -57.7% |
| CuTe synchronized call | 55.780 us | 37.839 us | -32.2% |

Forcing this PR back through locked revalidation confirms the mechanism: direct
hits save 7.603 us of Triton host time and 7.714 us of CuTe host time. Generated
GPU kernels are unchanged.

## Validation

- three independent adversarial reviews: correctness/races, line-level
  minimality, and test necessity/nonredundancy;
- focused dispatch/lowering tests: Triton 35 passed + 5 subtests; CuTe 36 passed
  + 5 subtests;
- full CuTe suite: 2,659 passed, 1,346 skipped, 5 expected xfails, 499 subtests;
- full Triton suite: 2,455 passed, 1,550 skipped, 342 subtests; the same 18
  host-infrastructure failures reproduced on fresh main (12 OpenAI certificate
  failures and 6 distributed/NVSHMEM/tooling failures);
- Ruff format/check and codespell pass; Pyrefly reports 0 errors when the
  unavailable optional JAX imports are ignored; and
- `git diff --check` passes.

Follow-up to #3321, #3322, #3323, and #3347. The open #3359 is orthogonal: it
fixes the Triton native runner ABI and does not touch Helion dispatch generation
or late specialization.
