### PR TITLE
[Pallas] Lower scalar tensor indices as direct ref indices

### DIFF
--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -360,9 +360,15 @@ class PallasBackend(Backend):
         tensor_host_args: list[str],
     ) -> str:
         from ..device_function import SymbolArgument
+        from ..device_function import TensorArg
         from ..device_function import TensorSizeArg
         from ..device_function import TensorStrideArg
 
+        if isinstance(arg, TensorArg) and arg.fake_value.ndim == 0:
+            # Mosaic requires every Pallas input to have rank >= 1. Preserve a
+            # host scalar tensor as a one-element input; its device users load
+            # element zero explicitly.
+            return f"{host_str}.reshape(1)"
         if isinstance(arg, (SymbolArgument, TensorSizeArg, TensorStrideArg)):
             from ..compile_environment import CompileEnvironment
 

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -755,6 +755,10 @@ def _generated_index_code(
     if isinstance(pattern, TensorIndexPattern):
         if tensor_indices_are_scalars:
             return _index_expr_from_ast(state, subscript_index, ast_subscripts)
+        if pattern.index_ndim == 0:
+            assert isinstance(idx, torch.Tensor)
+            scalar_arg = state.device_function.tensor_arg(idx)
+            return f"{scalar_arg.name}[0]"
         from helion._compiler.pallas.tensorcore_plan import TENSORCORE_PLAN_META
         from helion._compiler.pallas.tensorcore_plan import TensorCorePlan
 

--- a/helion/_compiler/pallas/memory_access.py
+++ b/helion/_compiler/pallas/memory_access.py
@@ -111,11 +111,14 @@ def indirect_access(access: MemoryAccess) -> IndirectAccess | None:
 
 
 def tensor_index_positions(access: MemoryAccess) -> tuple[int, ...]:
-    """Return all tensor-indexed subscript positions."""
+    """Return positions that require an indirect tensor access plan.
+
+    Rank-zero tensor indices are scalar addresses and use ordinary Ref indexing.
+    """
     from .plan_tiling import TensorIndexPattern
 
     return tuple(
         position
         for position, pattern in enumerate(access.patterns)
-        if isinstance(pattern, TensorIndexPattern)
+        if isinstance(pattern, TensorIndexPattern) and pattern.index_ndim > 0
     )

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -75,6 +75,8 @@ class NonePattern(IndexingPattern):
 class TensorIndexPattern(IndexingPattern):
     """Tensor-valued index - no tiling. Resolved for indirect load/store codegen."""
 
+    index_ndim: int = 1
+
 
 @dataclass
 class ContiguousRangeIndexPattern(IndexingPattern):
@@ -735,7 +737,7 @@ def _detect_indexing_pattern(
         # A tensor-valued index that didn't match any arithmetic-of-tile
         # pattern is an indirect gather (e.g. table[idx, :]).
         if isinstance(idx_val, torch.Tensor):
-            return TensorIndexPattern()
+            return TensorIndexPattern(index_ndim=idx_val.ndim)
         # Indices produced by other FX nodes, such as indices[tile] used in
         # tensor-indexed atomics, are legal but cannot participate in Pallas
         # tiling.

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2512,6 +2512,30 @@ class TestPallas(TestCase):
         expected[indices.to(torch.int64)] = values
         torch.testing.assert_close(result, expected)
 
+    def test_scalar_tensor_index_store(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scalar_tensor_index_store(
+            values: torch.Tensor, output_row: torch.Tensor
+        ) -> torch.Tensor:
+            m, n = values.size()
+            out = torch.zeros([4, m, n], dtype=values.dtype, device=values.device)
+            row = output_row[0]
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[row, tile_m, tile_n] = values[tile_m, tile_n]
+            return out
+
+        values = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        output_row = torch.tensor([2], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            scalar_tensor_index_store,
+            (values, output_row),
+            block_sizes=[8, 128],
+        )
+
+        expected = torch.zeros(4, 8, 128, device=DEVICE)
+        expected[2] = values
+        torch.testing.assert_close(result, expected)
+
     def test_tensor_index_atomic_add_raises(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def atomic_add_tensor_index(


### PR DESCRIPTION
Stacked PRs:
 * #3408
 * __->__#3387


--- --- ---

### [Pallas] Lower scalar tensor indices as direct ref indices


A rank-zero tensor used as an index denotes one runtime scalar address. It is not an indirect gather or scatter map, but the Pallas planner previously sent every TensorIndexPattern through one-hot TensorCore planning.

The newly covered Helion pattern is:

```python
row = output_row[0]
for tile_m, tile_n in hl.tile(values.size()):
    out[row, tile_m, tile_n] = values[tile_m, tile_n]
```

Before this change, planning stopped with `NotImplementedError: Pallas scatter: only rank-1 tensor indices are supported`. Merely bypassing the one-hot plan is insufficient: the generic AST path renders the internal `_host_tensor` sentinel, which reaches the generated kernel as an undefined name.

Record the tensor index rank during tiling analysis. Rank-one and larger indices continue through the existing TensorCore plans. For rank-zero indices, register the scalar tensor as an ordinary Pallas input and emit element zero as the ref index. Mosaic requires every Pallas input to have rank at least one, so the host wrapper reshapes a zero-dimensional tensor to a one-element input before launch.

The generated store is therefore equivalent to:

```python
out[output_row[0], :, :] = values[:, :]
```

This keeps vector scatter behavior and duplicate-index handling unchanged, and adds no Helion API.

Testing:

- `test_scalar_tensor_index_store` executes the generated kernel in Pallas interpret mode, verifies the selected output plane exactly, and verifies all other planes remain zero.
- The focused test passes with `HELION_BACKEND=pallas HELION_PALLAS_INTERPRET=1`.
- `PATH=/home/dunfanlu/.venv/bin:$PATH ./lint.sh check` passes.
