### PR TITLE
[Pallas] Lower torch.cat to JAX concatenate

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from ..runtime.config import Config
     from ..runtime.kernel import BoundKernel
     from ..runtime.settings import DotPrecision
+    from .aten_lowering import Lowering
     from .compile_environment import CompileEnvironment
     from .cute.cute_mma import _CuteMmaNode
     from .device_function import Argument
@@ -897,6 +898,15 @@ class Backend(abc.ABC):
         Called after static loop unrolling but before type propagation
         and tracing.  Backends can override this to rewrite the user's
         AST for algorithmic transformations that change loop structure.
+        """
+        return None
+
+    def pre_inductor_lowering(self, node: torch.fx.Node) -> Lowering | None:
+        """Return a backend-owned lowering that must bypass Inductor IR.
+
+        Most ATen operations use Helion's shared Inductor lowering. Backends may
+        override this for operations whose Inductor representation cannot be
+        consumed by that shared path.
         """
         return None
 

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -126,6 +126,11 @@ def prepare_node_lowering(
         node.meta["lowering"] = APIFuncLowering(api)
         return
 
+    backend_lowering = CompileEnvironment.current().backend.pre_inductor_lowering(node)
+    if backend_lowering is not None:
+        node.meta["lowering"] = backend_lowering
+        return
+
     if node.target in aten_lowering_dispatch:
         if node.target in {
             torch.ops.aten.argmax.default,

--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -21,6 +21,7 @@ from torch.fx.node import map_arg
 
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
+from ..aten_lowering import AtenLowering
 from ..aten_lowering import _env_arg
 from ..aten_lowering import _node_dtype_kwarg
 from ..aten_lowering import _pallas_argreduce
@@ -48,6 +49,35 @@ from ..matmul_utils import _needs_f32_accumulator
 
 if TYPE_CHECKING:
     from ..aten_lowering import LoweringContext
+
+
+cat_lowering_pallas = AtenLowering(target=torch.ops.aten.cat.default)
+
+
+@cat_lowering_pallas.register_codegen("pallas")
+def codegen_cat_pallas(ctx: LoweringContext, node: Node) -> ast.AST:
+    tensors = map_arg(node.args[0], lambda arg: _env_arg(ctx, arg))
+    assert isinstance(tensors, (list, tuple)) and tensors
+    assert all(isinstance(tensor, ast.AST) for tensor in tensors)
+    dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
+    assert isinstance(dim, int)
+    output = node.meta["val"]
+    assert isinstance(output, torch.Tensor)
+    if dim < 0:
+        dim += output.ndim
+    assert 0 <= dim < output.ndim
+
+    placeholders: dict[str, ast.AST] = {
+        f"tensor_{index}": cast("ast.AST", tensor)
+        for index, tensor in enumerate(tensors)
+    }
+    values = ", ".join(f"{{tensor_{index}}}" for index in range(len(tensors)))
+    if len(tensors) == 1:
+        values += ","
+    return expr_from_string(
+        f"jnp.concatenate(({values}), axis={dim})",
+        **placeholders,
+    )
 
 
 @argmax_lowering.register_codegen("pallas")

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from ...runtime.config import Config
     from ...runtime.kernel import BoundKernel
     from ...runtime.settings import DotPrecision
+    from ..aten_lowering import Lowering
     from ..device_function import Argument
     from ..device_ir import GraphInfo
     from ..host_function import HostFunction
@@ -1480,6 +1481,13 @@ class PallasBackend(Backend):
         except NoCurrentFunction:
             return self.default_launcher_name
         return self.build_launcher_name(device_fn.config)
+
+    def pre_inductor_lowering(self, node: torch.fx.Node) -> Lowering | None:
+        from .aten_lowering import cat_lowering_pallas
+
+        if node.target is torch.ops.aten.cat.default:
+            return cat_lowering_pallas
+        return None
 
     def pre_codegen(
         self,

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from ...runtime.config import Config
     from ...runtime.kernel import BoundKernel
     from ...runtime.settings import DotPrecision
+    from ..aten_lowering import Lowering
     from ..device_function import Argument
     from ..device_ir import GraphInfo
     from ..host_function import HostFunction
@@ -1481,6 +1482,13 @@ class PallasBackend(Backend):
         except NoCurrentFunction:
             return self.default_launcher_name
         return self.build_launcher_name(device_fn.config)
+
+    def pre_inductor_lowering(self, node: torch.fx.Node) -> Lowering | None:
+        from .aten_lowering import cat_lowering_pallas
+
+        if node.target is torch.ops.aten.cat.default:
+            return cat_lowering_pallas
+        return None
 
     def pre_codegen(
         self,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -619,6 +619,19 @@ def pallas_chunked_add(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_cat_columns(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    rows = x.size(0)
+    out = torch.empty(
+        [rows, x.size(1) + y.size(1)],
+        dtype=x.dtype,
+        device=x.device,
+    )
+    for tile_rows in hl.tile(rows):
+        out[tile_rows, :] = torch.cat((x[tile_rows, :], y[tile_rows, :]), dim=1)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_rand_add(x: torch.Tensor, seed: int) -> torch.Tensor:
     """Kernel that uses hl.rand to generate random values and add them to x."""
     out = torch.empty_like(x)
@@ -716,6 +729,17 @@ def _constant_pad_neg_inf_pallas_kernel(x: torch.Tensor) -> torch.Tensor:
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
+    def test_cat_columns(self) -> None:
+        x = torch.randn(128, 64, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(128, 64, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_cat_columns,
+            (x, y),
+            block_sizes=[128],
+        )
+        self.assertIn("jnp.concatenate((", code)
+        torch.testing.assert_close(result.cpu(), torch.cat((x, y), dim=1).cpu())
+
     def test_rsqrt_uses_native_lax_op(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def rsqrt_kernel(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -618,6 +618,19 @@ def pallas_chunked_add(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_cat_columns(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    rows = x.size(0)
+    out = torch.empty(
+        [rows, x.size(1) + y.size(1)],
+        dtype=x.dtype,
+        device=x.device,
+    )
+    for tile_rows in hl.tile(rows):
+        out[tile_rows, :] = torch.cat((x[tile_rows, :], y[tile_rows, :]), dim=1)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_rand_add(x: torch.Tensor, seed: int) -> torch.Tensor:
     """Kernel that uses hl.rand to generate random values and add them to x."""
     out = torch.empty_like(x)
@@ -715,6 +728,17 @@ def _constant_pad_neg_inf_pallas_kernel(x: torch.Tensor) -> torch.Tensor:
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
+    def test_cat_columns(self) -> None:
+        x = torch.randn(128, 64, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(128, 64, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_cat_columns,
+            (x, y),
+            block_sizes=[128],
+        )
+        self.assertIn("jnp.concatenate((", code)
+        torch.testing.assert_close(result.cpu(), torch.cat((x, y), dim=1).cpu())
+
     def test_rsqrt_uses_native_lax_op(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def rsqrt_kernel(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stacked PRs:
 * #3408
 * #3407
 * #3406
 * #3405
 * #3404
 * #3403
 * #3402
 * #3401
 * #3387
 * #3399
 * #3398
 * #3397
 * #3396
 * #3395
 * #3394
 * #3393
 * #3392
 * #3391
 * #3390
 * #3389
 * __->__#3388


--- --- ---

### [Pallas] Lower torch.cat to JAX concatenate


Pallas kernels can naturally assemble adjacent projected fields with ordinary Helion source:

```python
joined = torch.cat((left[tile_rows, :], right[tile_rows, :]), dim=1)
out[tile_rows, :] = joined
```

Before this change, Inductor represents `aten.cat.default` with a `ConcatKernel`, while the generic Helion lowering path requires a `ComputedBuffer`. Compilation therefore stops before Pallas code generation:

```text
InductorLoweringError: Lowering aten.cat.default returned buffer type
<class torch._inductor.ir.ConcatKernel>, expected ComputedBuffer
```

Handle this operation in the Pallas backend before generic Inductor lowering and emit the equivalent JAX value expression directly:

```python
joined = jnp.concatenate((left, right), axis=1)
out[:, :] = joined
```

The lowering normalizes negative dimensions against the output rank and preserves the dtype and shape already established by FakeTensor propagation. It changes no Helion API and does not affect Triton or other backends.

Add a computation test that concatenates two BF16 column tiles, checks the generated `jnp.concatenate`, and compares the complete result with PyTorch. Validation:

- `HELION_PALLAS_INTERPRET=1 pytest test/test_pallas.py -k test_cat_columns`: pass
- two-host TPU7x standalone generated-JAX execution: `(128, 128) bfloat16 True` on both hosts
- `./lint.sh`: pass
