### PR TITLE
[Pallas] Stage aligned dynamic HBM windows

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -54,13 +54,19 @@ def load_expr(
         return emit_gather(state, plan.plan, active_name)
 
     from helion._compiler.device_function import PallasMemorySpace
+    from helion._compiler.pallas.plan_tiling import ContiguousRangeIndexPattern
 
     if (
         active_name == arg_name
         and device_fn.pallas_memory_space.get(id(tensor)) == PallasMemorySpace.HBM
-        and device_fn.is_pallas_remote_copy_operand(tensor)
+        and (
+            device_fn.is_pallas_remote_copy_operand(tensor)
+            or any(
+                isinstance(pattern, ContiguousRangeIndexPattern) for pattern in patterns
+            )
+        )
     ):
-        return _remote_hbm_load_expr(state, subscript, tensor, arg_name)
+        return _hbm_load_expr(state, subscript, tensor, arg_name)
 
     parts, none_dims = index_parts(state, subscript, tensor)
     scalar_load = classify_vmem_scalar_load(state, tensor, parts, patterns)
@@ -81,19 +87,19 @@ def load_expr(
     return result
 
 
-def _remote_hbm_load_expr(
+def _hbm_load_expr(
     state: CodegenState,
     subscript: list[object],
     tensor: torch.Tensor,
     name: str,
 ) -> ast.AST:
-    """Stage one directly accessed remote-DMA HBM region into VMEM.
+    """Stage one directly accessed HBM region into VMEM.
 
-    Remote-copy destinations can intentionally remain in HBM so their address is
-    stable across program iterations. Mosaic cannot load an HBM Ref directly, so
-    materialize the selected region at the exact source-level load. Emitting the
-    DMA here preserves ordering with nearby remote-copy waits and avoids changing
-    the placement of unrelated tensor arguments.
+    Remote-copy destinations and dynamic contiguous windows can intentionally
+    remain in HBM. Mosaic cannot load an HBM Ref directly, so materialize the
+    selected region at the exact source-level load. Emitting the DMA here
+    preserves ordering with nearby remote-copy waits and avoids changing the
+    placement of unrelated tensor arguments.
     """
     assert state.fx_node is not None
     value = state.fx_node.meta.get("val")
@@ -660,6 +666,7 @@ def _generated_index_code(
     """Generate index code based on the indexing pattern."""
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
     from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+    from helion._compiler.pallas.plan_tiling import ContiguousRangeIndexPattern
     from helion._compiler.pallas.plan_tiling import TensorIndexPattern
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
@@ -706,6 +713,18 @@ def _generated_index_code(
             in_pipeline,
             ast_subscripts,
             pipeline_scalar_indices_local,
+        )
+
+    if isinstance(pattern, ContiguousRangeIndexPattern):
+        if in_pipeline:
+            return ":"
+        if not raw_hbm_ref:
+            raise RuntimeError(
+                "a contiguous dynamic range must address its raw HBM source"
+            )
+        index = _index_expr_from_ast(state, subscript_index, ast_subscripts)
+        return (
+            f"pl.ds(pl.multiple_of({index}[0], {pattern.alignment}), {pattern.length})"
         )
 
     if isinstance(pattern, TensorIndexPattern):

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -67,13 +67,19 @@ def load_expr(
         return emit_gather(state, plan.plan, active_name)
 
     from helion._compiler.device_function import PallasMemorySpace
+    from helion._compiler.pallas.plan_tiling import ContiguousRangeIndexPattern
 
     if (
         active_name == arg_name
         and device_fn.pallas_memory_space.get(id(tensor)) == PallasMemorySpace.HBM
-        and device_fn.is_pallas_remote_copy_operand(tensor)
+        and (
+            device_fn.is_pallas_remote_copy_operand(tensor)
+            or any(
+                isinstance(pattern, ContiguousRangeIndexPattern) for pattern in patterns
+            )
+        )
     ):
-        return _remote_hbm_load_expr(state, subscript, tensor, arg_name)
+        return _hbm_load_expr(state, subscript, tensor, arg_name)
 
     parts, none_dims = index_parts(state, subscript, tensor)
     scalar_load = classify_vmem_scalar_load(state, tensor, parts, patterns)
@@ -94,19 +100,19 @@ def load_expr(
     return result
 
 
-def _remote_hbm_load_expr(
+def _hbm_load_expr(
     state: CodegenState,
     subscript: list[object],
     tensor: torch.Tensor,
     name: str,
 ) -> ast.AST:
-    """Stage one directly accessed remote-DMA HBM region into VMEM.
+    """Stage one directly accessed HBM region into VMEM.
 
-    Remote-copy destinations can intentionally remain in HBM so their address is
-    stable across program iterations. Mosaic cannot load an HBM Ref directly, so
-    materialize the selected region at the exact source-level load. Emitting the
-    DMA here preserves ordering with nearby remote-copy waits and avoids changing
-    the placement of unrelated tensor arguments.
+    Remote-copy destinations and dynamic contiguous windows can intentionally
+    remain in HBM. Mosaic cannot load an HBM Ref directly, so materialize the
+    selected region at the exact source-level load. Emitting the DMA here
+    preserves ordering with nearby remote-copy waits and avoids changing the
+    placement of unrelated tensor arguments.
     """
     assert state.fx_node is not None
     value = state.fx_node.meta.get("val")
@@ -685,6 +691,7 @@ def _generated_index_code(
     """Generate index code based on the indexing pattern."""
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
     from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+    from helion._compiler.pallas.plan_tiling import ContiguousRangeIndexPattern
     from helion._compiler.pallas.plan_tiling import TensorIndexPattern
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
@@ -731,6 +738,18 @@ def _generated_index_code(
             in_pipeline,
             ast_subscripts,
             pipeline_scalar_indices_local,
+        )
+
+    if isinstance(pattern, ContiguousRangeIndexPattern):
+        if in_pipeline:
+            return ":"
+        if not raw_hbm_ref:
+            raise RuntimeError(
+                "a contiguous dynamic range must address its raw HBM source"
+            )
+        index = _index_expr_from_ast(state, subscript_index, ast_subscripts)
+        return (
+            f"pl.ds(pl.multiple_of({index}[0], {pattern.alignment}), {pattern.length})"
         )
 
     if isinstance(pattern, TensorIndexPattern):

--- a/helion/_compiler/pallas/dma.py
+++ b/helion/_compiler/pallas/dma.py
@@ -21,6 +21,16 @@ if TYPE_CHECKING:
 DmaDirection = Literal["load", "store"]
 
 
+def is_tpu_dma_aligned_shape(shape: tuple[int, ...], dtype: torch.dtype) -> bool:
+    """Whether a concrete VMEM shape satisfies TPU local-DMA alignment."""
+    if len(shape) >= 2:
+        return shape[-1] % 128 == 0 and shape[-2] % 8 == 0
+    if len(shape) == 1:
+        bitwidth = min(dtype.itemsize * 8, 32)
+        return shape[0] % (128 * (32 // bitwidth)) == 0
+    return True
+
+
 @dataclass(frozen=True, eq=False)
 class DmaTransfer:
     """One local HBM/VMEM transfer before resources are allocated."""

--- a/helion/_compiler/pallas/dma.py
+++ b/helion/_compiler/pallas/dma.py
@@ -20,6 +20,16 @@ if TYPE_CHECKING:
 DmaDirection = Literal["load", "store"]
 
 
+def is_tpu_dma_aligned_shape(shape: tuple[int, ...], dtype: torch.dtype) -> bool:
+    """Whether a concrete VMEM shape satisfies TPU local-DMA alignment."""
+    if len(shape) >= 2:
+        return shape[-1] % 128 == 0 and shape[-2] % 8 == 0
+    if len(shape) == 1:
+        bitwidth = min(dtype.itemsize * 8, 32)
+        return shape[0] % (128 * (32 // bitwidth)) == 0
+    return True
+
+
 @dataclass(frozen=True, eq=False)
 class DmaTransfer:
     """One local HBM/VMEM transfer before resources are allocated."""

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+import operator
 from typing import TYPE_CHECKING
 
 import sympy
@@ -69,6 +70,15 @@ class NonePattern(IndexingPattern):
 @dataclass
 class TensorIndexPattern(IndexingPattern):
     """Tensor-valued index - no tiling. Resolved for indirect load/store codegen."""
+
+
+@dataclass
+class ContiguousRangeIndexPattern(IndexingPattern):
+    """Aligned ``base + arange(length)`` index addressable as one HBM window."""
+
+    base: int | torch.SymInt | torch.fx.Node
+    length: int
+    alignment: int
 
 
 @dataclass
@@ -316,9 +326,18 @@ def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
         isinstance(p, (ArbitraryIndexPattern, TileBeginWithOffsetPattern, NonePattern))
         for p in indexing_patterns
     )
+    has_contiguous_hbm_window = any(
+        isinstance(pattern, ContiguousRangeIndexPattern)
+        for pattern in indexing_patterns
+    )
     tid = id(tensor_val)
     current = device_fn.pallas_memory_space.get(tid)
-    if is_all_scalar:
+    if has_contiguous_hbm_window:
+        # A dynamic contiguous range cannot be represented by a static
+        # BlockSpec. Keep the source argument in HBM and stage exactly the
+        # selected range at its load site.
+        device_fn.pallas_memory_space[tid] = PallasMemorySpace.HBM
+    elif is_all_scalar:
         # Only mark for SMEM if not already assigned to VMEM or HBM
         if current is None:
             device_fn.pallas_memory_space[tid] = PallasMemorySpace.SMEM
@@ -384,6 +403,126 @@ def _is_supported_slice(idx: slice) -> bool:
     return True
 
 
+def _is_scalar_value(value: object) -> bool:
+    if isinstance(value, (int, torch.SymInt)):
+        return True
+    if isinstance(value, torch.fx.Node):
+        value = value.meta.get("val")
+    return isinstance(value, torch.Tensor) and value.ndim == 0
+
+
+def _constant_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, torch.fx.Node):
+        node_value = value.meta.get("val")
+        if isinstance(node_value, int):
+            return node_value
+    return None
+
+
+def _is_proven_multiple(value: object, alignment: int) -> bool:
+    """Conservatively prove that a scalar FX expression is alignment-multiple."""
+    constant = _constant_int(value)
+    if constant is not None:
+        return constant % alignment == 0
+    if not isinstance(value, torch.fx.Node) or value.op != "call_function":
+        return False
+
+    if value.target in (
+        operator.add,
+        torch.ops.aten.add.Scalar,
+        torch.ops.aten.add.Tensor,
+    ):
+        if value.kwargs.get("alpha", 1) != 1:
+            return False
+        return all(_is_proven_multiple(arg, alignment) for arg in value.args[:2])
+    if value.target in (
+        operator.sub,
+        torch.ops.aten.sub.Scalar,
+        torch.ops.aten.sub.Tensor,
+    ):
+        if value.kwargs.get("alpha", 1) != 1:
+            return False
+        return all(_is_proven_multiple(arg, alignment) for arg in value.args[:2])
+    if value.target in (
+        operator.mul,
+        torch.ops.aten.mul.Scalar,
+        torch.ops.aten.mul.Tensor,
+    ):
+        lhs, rhs = value.args[:2]
+        lhs_constant = _constant_int(lhs)
+        rhs_constant = _constant_int(rhs)
+        return (lhs_constant is not None and lhs_constant % alignment == 0) or (
+            rhs_constant is not None and rhs_constant % alignment == 0
+        )
+    return False
+
+
+def _iota_length(node: object) -> int | None:
+    if (
+        not isinstance(node, torch.fx.Node)
+        or node.op != "call_function"
+        or node.target is not torch.ops.prims.iota.default
+    ):
+        return None
+    start = node.kwargs.get("start", 0)
+    step = node.kwargs.get("step", 1)
+    if start != 0 or step != 1 or len(node.args) != 1:
+        return None
+    length = node.args[0]
+    return length if isinstance(length, int) and length > 0 else None
+
+
+def _match_contiguous_range_index(
+    node: torch.fx.Node,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+    load_value: object,
+) -> ContiguousRangeIndexPattern | None:
+    """Match an aligned scalar base plus an explicit unit-stride ``hl.arange``."""
+    if (
+        tensor_dim != tensor.ndim - 1
+        or node.op != "call_function"
+        or node.target
+        not in (operator.add, torch.ops.aten.add.Scalar, torch.ops.aten.add.Tensor)
+        or len(node.args) != 2
+        or node.kwargs.get("alpha", 1) != 1
+    ):
+        return None
+    if not isinstance(load_value, torch.Tensor) or not all(
+        isinstance(size, int) for size in load_value.shape
+    ):
+        return None
+    from .dma import is_tpu_dma_aligned_shape
+
+    if not is_tpu_dma_aligned_shape(tuple(load_value.shape), tensor.dtype):
+        return None
+    bitwidth = min(tensor.dtype.itemsize * 8, 32)
+    alignment = 128 if tensor.ndim > 1 else 128 * (32 // bitwidth)
+    lhs, rhs = node.args
+    for base, iota in ((lhs, rhs), (rhs, lhs)):
+        length = _iota_length(iota)
+        if length is None or length % alignment != 0:
+            continue
+        if not isinstance(base, (int, torch.SymInt, torch.fx.Node)):
+            continue
+        if not _is_scalar_value(base) or not _is_proven_multiple(base, alignment):
+            continue
+        value = node.meta.get("val")
+        if (
+            isinstance(value, torch.Tensor)
+            and value.ndim == 1
+            and value.shape[0] == length
+        ):
+            return ContiguousRangeIndexPattern(
+                base=base,
+                length=length,
+                alignment=alignment,
+            )
+    return None
+
+
 def _detect_indexing_pattern(
     idx: object,
     tensor: torch.Tensor,
@@ -421,6 +560,18 @@ def _detect_indexing_pattern(
                 block_id=tile_begin_with_offset.block_id,
                 offset=tile_begin_with_offset.offset,
             )
+        from ...language import memory_ops
+
+        if node.target is memory_ops.load:
+            contiguous_range = _match_contiguous_range_index(
+                idx,
+                tensor,
+                tensor_dim,
+                node.meta.get("val"),
+            )
+            if contiguous_range is not None:
+                return contiguous_range
+
         # A tensor-valued index that didn't match any arithmetic-of-tile
         # pattern is an indirect gather (e.g. table[idx, :]).
         if isinstance(idx_val, torch.Tensor):
@@ -485,7 +636,10 @@ def _update_tiling_decision(
             # bounded slice: fixed subrange of the dim, must stay untiled
             _disallow_tiling()
 
-    elif isinstance(pattern, (ArbitraryIndexPattern, TensorIndexPattern)):
+    elif isinstance(
+        pattern,
+        (ArbitraryIndexPattern, ContiguousRangeIndexPattern, TensorIndexPattern),
+    ):
         _disallow_tiling()
 
     elif isinstance(pattern, NonePattern):
@@ -527,8 +681,8 @@ def resident_block_elements(
         ``block_size``, clamped to the full dim extent.
       - ``TileBeginWithOffsetPattern`` / ``ArbitraryIndexPattern``: scalar
         index, contributes 1.
-      - Anything else (full slice, indirect tensor index): the full dim
-        extent.
+      - ``ContiguousRangeIndexPattern``: its fixed range length.
+      - Anything else (full slice, indirect tensor index): the full dim extent.
 
     Returns ``None`` if any consumed dim is symbolic.
     """
@@ -550,6 +704,8 @@ def resident_block_elements(
                 dim_size = min(bs, dim_size)
         elif isinstance(p, (TileBeginWithOffsetPattern, ArbitraryIndexPattern)):
             dim_size = 1
+        elif isinstance(p, ContiguousRangeIndexPattern):
+            dim_size = p.length
         elements *= dim_size
         # Advance only on patterns that consume a tensor dim; NonePattern doesn't.
         tdim += 1

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+import operator
 from typing import TYPE_CHECKING
 from typing import cast
 
@@ -73,6 +74,15 @@ class NonePattern(IndexingPattern):
 @dataclass
 class TensorIndexPattern(IndexingPattern):
     """Tensor-valued index - no tiling. Resolved for indirect load/store codegen."""
+
+
+@dataclass
+class ContiguousRangeIndexPattern(IndexingPattern):
+    """Aligned ``base + arange(length)`` index addressable as one HBM window."""
+
+    base: int | torch.SymInt | torch.fx.Node
+    length: int
+    alignment: int
 
 
 @dataclass
@@ -320,9 +330,18 @@ def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
         isinstance(p, (ArbitraryIndexPattern, TileBeginWithOffsetPattern, NonePattern))
         for p in indexing_patterns
     )
+    has_contiguous_hbm_window = any(
+        isinstance(pattern, ContiguousRangeIndexPattern)
+        for pattern in indexing_patterns
+    )
     tid = id(tensor_val)
     current = device_fn.pallas_memory_space.get(tid)
-    if is_all_scalar:
+    if has_contiguous_hbm_window:
+        # A dynamic contiguous range cannot be represented by a static
+        # BlockSpec. Keep the source argument in HBM and stage exactly the
+        # selected range at its load site.
+        device_fn.pallas_memory_space[tid] = PallasMemorySpace.HBM
+    elif is_all_scalar:
         # Only mark for SMEM if not already assigned to VMEM or HBM
         if current is None:
             device_fn.pallas_memory_space[tid] = PallasMemorySpace.SMEM
@@ -417,6 +436,126 @@ def _is_supported_slice(idx: slice) -> bool:
     return True
 
 
+def _is_scalar_value(value: object) -> bool:
+    if isinstance(value, (int, torch.SymInt)):
+        return True
+    if isinstance(value, torch.fx.Node):
+        value = value.meta.get("val")
+    return isinstance(value, torch.Tensor) and value.ndim == 0
+
+
+def _constant_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, torch.fx.Node):
+        node_value = value.meta.get("val")
+        if isinstance(node_value, int):
+            return node_value
+    return None
+
+
+def _is_proven_multiple(value: object, alignment: int) -> bool:
+    """Conservatively prove that a scalar FX expression is alignment-multiple."""
+    constant = _constant_int(value)
+    if constant is not None:
+        return constant % alignment == 0
+    if not isinstance(value, torch.fx.Node) or value.op != "call_function":
+        return False
+
+    if value.target in (
+        operator.add,
+        torch.ops.aten.add.Scalar,
+        torch.ops.aten.add.Tensor,
+    ):
+        if value.kwargs.get("alpha", 1) != 1:
+            return False
+        return all(_is_proven_multiple(arg, alignment) for arg in value.args[:2])
+    if value.target in (
+        operator.sub,
+        torch.ops.aten.sub.Scalar,
+        torch.ops.aten.sub.Tensor,
+    ):
+        if value.kwargs.get("alpha", 1) != 1:
+            return False
+        return all(_is_proven_multiple(arg, alignment) for arg in value.args[:2])
+    if value.target in (
+        operator.mul,
+        torch.ops.aten.mul.Scalar,
+        torch.ops.aten.mul.Tensor,
+    ):
+        lhs, rhs = value.args[:2]
+        lhs_constant = _constant_int(lhs)
+        rhs_constant = _constant_int(rhs)
+        return (lhs_constant is not None and lhs_constant % alignment == 0) or (
+            rhs_constant is not None and rhs_constant % alignment == 0
+        )
+    return False
+
+
+def _iota_length(node: object) -> int | None:
+    if (
+        not isinstance(node, torch.fx.Node)
+        or node.op != "call_function"
+        or node.target is not torch.ops.prims.iota.default
+    ):
+        return None
+    start = node.kwargs.get("start", 0)
+    step = node.kwargs.get("step", 1)
+    if start != 0 or step != 1 or len(node.args) != 1:
+        return None
+    length = node.args[0]
+    return length if isinstance(length, int) and length > 0 else None
+
+
+def _match_contiguous_range_index(
+    node: torch.fx.Node,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+    load_value: object,
+) -> ContiguousRangeIndexPattern | None:
+    """Match an aligned scalar base plus an explicit unit-stride ``hl.arange``."""
+    if (
+        tensor_dim != tensor.ndim - 1
+        or node.op != "call_function"
+        or node.target
+        not in (operator.add, torch.ops.aten.add.Scalar, torch.ops.aten.add.Tensor)
+        or len(node.args) != 2
+        or node.kwargs.get("alpha", 1) != 1
+    ):
+        return None
+    if not isinstance(load_value, torch.Tensor) or not all(
+        isinstance(size, int) for size in load_value.shape
+    ):
+        return None
+    from .dma import is_tpu_dma_aligned_shape
+
+    if not is_tpu_dma_aligned_shape(tuple(load_value.shape), tensor.dtype):
+        return None
+    bitwidth = min(tensor.dtype.itemsize * 8, 32)
+    alignment = 128 if tensor.ndim > 1 else 128 * (32 // bitwidth)
+    lhs, rhs = node.args
+    for base, iota in ((lhs, rhs), (rhs, lhs)):
+        length = _iota_length(iota)
+        if length is None or length % alignment != 0:
+            continue
+        if not isinstance(base, (int, torch.SymInt, torch.fx.Node)):
+            continue
+        if not _is_scalar_value(base) or not _is_proven_multiple(base, alignment):
+            continue
+        value = node.meta.get("val")
+        if (
+            isinstance(value, torch.Tensor)
+            and value.ndim == 1
+            and value.shape[0] == length
+        ):
+            return ContiguousRangeIndexPattern(
+                base=base,
+                length=length,
+                alignment=alignment,
+            )
+    return None
+
+
 def _detect_indexing_pattern(
     idx: object,
     tensor: torch.Tensor,
@@ -454,6 +593,18 @@ def _detect_indexing_pattern(
                 block_id=tile_begin_with_offset.block_id,
                 offset=tile_begin_with_offset.offset,
             )
+        from ...language import memory_ops
+
+        if node.target is memory_ops.load:
+            contiguous_range = _match_contiguous_range_index(
+                idx,
+                tensor,
+                tensor_dim,
+                node.meta.get("val"),
+            )
+            if contiguous_range is not None:
+                return contiguous_range
+
         # A tensor-valued index that didn't match any arithmetic-of-tile
         # pattern is an indirect gather (e.g. table[idx, :]).
         if isinstance(idx_val, torch.Tensor):
@@ -518,7 +669,10 @@ def _update_tiling_decision(
             # bounded slice: fixed subrange of the dim, must stay untiled
             _disallow_tiling()
 
-    elif isinstance(pattern, (ArbitraryIndexPattern, TensorIndexPattern)):
+    elif isinstance(
+        pattern,
+        (ArbitraryIndexPattern, ContiguousRangeIndexPattern, TensorIndexPattern),
+    ):
         _disallow_tiling()
 
     elif isinstance(pattern, NonePattern):
@@ -560,8 +714,8 @@ def resident_block_elements(
         ``block_size``, clamped to the full dim extent.
       - ``TileBeginWithOffsetPattern`` / ``ArbitraryIndexPattern``: scalar
         index, contributes 1.
-      - Anything else (full slice, indirect tensor index): the full dim
-        extent.
+      - ``ContiguousRangeIndexPattern``: its fixed range length.
+      - Anything else (full slice, indirect tensor index): the full dim extent.
 
     Returns ``None`` if any consumed dim is symbolic.
     """
@@ -646,6 +800,8 @@ def _resident_block_elements(
                 dim_size = min(bs, dim_size)
         elif isinstance(p, (TileBeginWithOffsetPattern, ArbitraryIndexPattern)):
             dim_size = 1
+        elif isinstance(p, ContiguousRangeIndexPattern):
+            dim_size = p.length
         elements *= dim_size
         # Advance only on patterns that consume a tensor dim; NonePattern doesn't.
         tdim += 1

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -42,6 +42,7 @@ from .dma import DmaTransfer
 from .dma import ScheduledDmaTransfer
 from .dma import allocate_dma_resources
 from .dma import async_copy_statements
+from .dma import is_tpu_dma_aligned_shape
 
 log = logging.getLogger(__name__)
 
@@ -2711,26 +2712,6 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     return None
 
 
-def _check_dma_alignment(vmem_shape: tuple[int, ...]) -> bool:
-    """Check if a VMEM buffer shape satisfies TPU DMA alignment.
-
-    DMA requires last dim % 128 == 0 and second-to-last dim % 8 == 0
-    for 2D+ tensors. Note that these rules are currently optimized for
-    bf16 sublanes; they are overly conservative for f32 (no constraint)
-    and too lenient for 1D (which should be % 1024).
-
-    These rules differ from outer BlockSpec constraints where 1D is
-    dtype-dependent: 128 * (32 / bitwidth(dtype)). Unlike outer BlockSpecs,
-    emit_pipeline/fori_loop inner DMA does NOT have a ``block == tensor_dim``
-    exception.
-    """
-    if len(vmem_shape) >= 2:
-        return vmem_shape[-1] % 128 == 0 and vmem_shape[-2] % 8 == 0
-    if len(vmem_shape) == 1:
-        return vmem_shape[0] % 128 == 0
-    return True
-
-
 def _is_supported_contiguous_row_slab_dma(
     fake: torch.Tensor,
     sub_meta: list[object],
@@ -2807,7 +2788,7 @@ def _can_stream_inner_tile(
     state: CodegenState,
 ) -> bool:
     """Return whether a loop-local tensor should use the inner streaming path."""
-    if _check_dma_alignment(vmem_shape):
+    if is_tpu_dma_aligned_shape(vmem_shape, fake.dtype):
         return True
     if direction != "load":
         return False

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -46,6 +46,7 @@ from .dma import allocate_dma_resources
 from .dma import allocate_indirect_dma_resources
 from .dma import async_copy_statements
 from .dma import indirect_group_statements
+from .dma import is_tpu_dma_aligned_shape
 from .tensorcore_plan import DmaAccessPlan
 from .tensorcore_plan import build_dma_access_candidates
 
@@ -2927,26 +2928,6 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     return None
 
 
-def _check_dma_alignment(vmem_shape: tuple[int, ...]) -> bool:
-    """Check if a VMEM buffer shape satisfies TPU DMA alignment.
-
-    DMA requires last dim % 128 == 0 and second-to-last dim % 8 == 0
-    for 2D+ tensors. Note that these rules are currently optimized for
-    bf16 sublanes; they are overly conservative for f32 (no constraint)
-    and too lenient for 1D (which should be % 1024).
-
-    These rules differ from outer BlockSpec constraints where 1D is
-    dtype-dependent: 128 * (32 / bitwidth(dtype)). Unlike outer BlockSpecs,
-    emit_pipeline/fori_loop inner DMA does NOT have a ``block == tensor_dim``
-    exception.
-    """
-    if len(vmem_shape) >= 2:
-        return vmem_shape[-1] % 128 == 0 and vmem_shape[-2] % 8 == 0
-    if len(vmem_shape) == 1:
-        return vmem_shape[0] % 128 == 0
-    return True
-
-
 def _is_supported_contiguous_row_slab_dma(
     fake: torch.Tensor,
     sub_meta: list[object],
@@ -3023,7 +3004,7 @@ def _can_stream_inner_tile(
     state: CodegenState,
 ) -> bool:
     """Return whether a loop-local tensor should use the inner streaming path."""
-    if _check_dma_alignment(vmem_shape):
+    if is_tpu_dma_aligned_shape(vmem_shape, fake.dtype):
         return True
     if direction != "load":
         return False

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -631,6 +631,46 @@ def pallas_cat_columns(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_aligned_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for tile in hl.tile(starts.size(0), block_size=1):
+        begin = starts[tile.begin] * 128
+        out[tile, :, :] = table[:, begin + hl.arange(128)][None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_bf16_dynamic_window_1d(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    out = torch.empty([starts.size(0), 128], dtype=table.dtype, device=table.device)
+    for tile in hl.tile(starts.size(0), block_size=1):
+        begin = starts[tile.begin] * 128
+        out[tile, :] = table[begin + hl.arange(128)][None, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_scaled_add_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for tile in hl.tile(starts.size(0), block_size=1):
+        begin = starts[tile.begin] * 128
+        indices = torch.add(hl.arange(128), begin, alpha=2)
+        out[tile, :, :] = table[:, indices][None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_rand_add(x: torch.Tensor, seed: int) -> torch.Tensor:
     """Kernel that uses hl.rand to generate random values and add them to x."""
     out = torch.empty_like(x)
@@ -738,6 +778,48 @@ class TestPallas(TestCase):
         )
         self.assertIn("jnp.concatenate((", code)
         torch.testing.assert_close(result.cpu(), torch.cat((x, y), dim=1).cpu())
+
+    def test_aligned_dynamic_window_uses_direct_hbm_dma(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_aligned_dynamic_window,
+            (table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("pltpu.make_async_copy(table.at[:, pl.ds(pl.multiple_of(", code)
+        self.assertNotIn("one_hot", code)
+        expected = torch.stack(
+            [table[:, begin : begin + 128] for begin in range(0, 512, 128)]
+        )
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_dynamic_window_declines_unaligned_1d_dma(self) -> None:
+        table = torch.randn(512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_bf16_dynamic_window_1d,
+            (table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        self.assertNotIn("pltpu.make_async_copy(table.at[", code)
+        self.assertIn("one_hot", code)
+        expected = torch.stack((table[:128], table[128:256]))
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_dynamic_window_declines_scaled_add(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_scaled_add_dynamic_window,
+            (table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        self.assertNotIn("pltpu.make_async_copy(table.at[", code)
+        self.assertIn("one_hot", code)
+        lanes = torch.arange(128, device=DEVICE)
+        expected = torch.stack((table[:, lanes], table[:, 256 + lanes]))
+        torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_rsqrt_uses_native_lax_op(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -632,6 +632,46 @@ def pallas_cat_columns(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_aligned_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for tile in hl.tile(starts.size(0), block_size=1):
+        begin = starts[tile.begin] * 128
+        out[tile, :, :] = table[:, begin + hl.arange(128)][None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_bf16_dynamic_window_1d(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    out = torch.empty([starts.size(0), 128], dtype=table.dtype, device=table.device)
+    for tile in hl.tile(starts.size(0), block_size=1):
+        begin = starts[tile.begin] * 128
+        out[tile, :] = table[begin + hl.arange(128)][None, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_scaled_add_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for tile in hl.tile(starts.size(0), block_size=1):
+        begin = starts[tile.begin] * 128
+        indices = torch.add(hl.arange(128), begin, alpha=2)
+        out[tile, :, :] = table[:, indices][None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
     """Exercise a compound modulo operand whose parentheses are significant."""
     out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
@@ -759,6 +799,42 @@ class TestPallas(TestCase):
         )
         self.assertIn("jnp.concatenate((", code)
         torch.testing.assert_close(result.cpu(), torch.cat((x, y), dim=1).cpu())
+
+    def test_aligned_dynamic_window_uses_direct_hbm_dma(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_aligned_dynamic_window,
+            (table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        expected = torch.stack(
+            [table[:, begin : begin + 128] for begin in range(0, 512, 128)]
+        )
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_dynamic_window_declines_unaligned_1d_dma(self) -> None:
+        table = torch.randn(512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_bf16_dynamic_window_1d,
+            (table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        expected = torch.stack((table[:128], table[128:256]))
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_dynamic_window_declines_scaled_add(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_scaled_add_dynamic_window,
+            (table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        lanes = torch.arange(128, device=DEVICE)
+        expected = torch.stack((table[:, lanes], table[:, 256 + lanes]))
+        torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_shifted_modulo_preserves_expression_precedence(self) -> None:
         x = torch.randn(5, 128, device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION
Stacked PRs:
 * #3408
 * #3405
 * #3396
 * #3394
 * #3402
 * #3401
 * #3387
 * #3407
 * #3403
 * #3399
 * #3398
 * #3397
 * #3392
 * #3391
 * #3406
 * #3404
 * #3390
 * __->__#3389


--- --- ---

### [Pallas] Stage aligned dynamic HBM windows


Projection kernels commonly select one aligned column panel with ordinary
Helion indexing:

```python
begin = starts[tile.begin] * 128
panel = table[:, begin + hl.arange(128)]
out[tile, :, :] = panel[None, :, :]
```

Previously, Pallas classified `begin + hl.arange(128)` as an arbitrary tensor
index and attempted a one-hot TensorCore gather. That route requires the whole
gather axis in VMEM, so large projection weights failed before code generation:

```text
NotImplementedError: Pallas gather: resident block is 301989888 bytes,
exceeds the 16777216 byte VMEM threshold
```

Recognize a deliberately narrow contiguous-window pattern and keep its source
in HBM. The pattern must satisfy all of these conditions:

- it indexes the tensor's final dimension;
- the index is `base + iota`, with a positive unit-stride iota;
- `aten.add` uses `alpha=1`;
- the base is statically proven to be a multiple of the DMA alignment; and
- the concrete loaded shape satisfies TPU local-DMA alignment.

The shared alignment helper requires the last two dimensions of a 2D-or-higher
transfer to be multiples of 128 and 8. For a 1D transfer it uses the dtype-aware
rule `128 * (32 / bitwidth)`, so a 128-element BF16 range correctly remains on
the existing gather fallback rather than attempting an invalid DMA.

The accepted source lowers to one exact HBM-to-VMEM transfer:

```python
copy = pltpu.make_async_copy(
    table.at[:, pl.ds(pl.multiple_of(begin, 128), 128)],
    table_load,
    table_load_sem,
)
copy.start()
copy.wait()
panel = table_load[...]
```

This removes the full-resident VMEM requirement and the one-hot MXU work.
Non-final-axis ranges, non-unit strides, unaligned shapes or bases, scaled adds,
and other tensor indices retain the prior lowering. No Helion API changes.

Tests execute the accepted direct-DMA case and both important fallbacks:

```text
HELION_BACKEND=pallas HELION_PALLAS_INTERPRET=1 python -m pytest -q \
  test/test_pallas.py::TestPallas::test_aligned_dynamic_window_uses_direct_hbm_dma \
  test/test_pallas.py::TestPallas::test_dynamic_window_declines_unaligned_1d_dma \
  test/test_pallas.py::TestPallas::test_dynamic_window_declines_scaled_add
```

Each test compares the complete computation with PyTorch. `pre-commit run --all-files` and `./lint.sh check`
pass.
