### PR TITLE
[Pallas] Prefetch aligned dynamic HBM windows

### DIFF
--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -47,6 +47,8 @@ from .dma import is_tpu_dma_aligned_shape
 
 log = logging.getLogger(__name__)
 
+_PALLAS_LOOP_LOAD_COUNT_META = "_helion_pallas_loop_load_count"
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterator
@@ -59,6 +61,7 @@ if TYPE_CHECKING:
     from ..tile_strategy import TileStrategy
     from .compact_worklist import ResidentPrepHoist
     from .dma import DmaDirection
+    from .plan_tiling import ContiguousRangeIndexPattern
 
 
 @_decorators.codegen(_not, "pallas")
@@ -609,7 +612,13 @@ def _classify_loop_tensors(
                 key = id(fake)
                 if key not in loaded_tensors:
                     sub_vals = _extract_subscript_vals(subscript)
-                    loaded_tensors[key] = (fake, tensor_node, sub_vals)
+                    loaded_tensors[key] = (fake, node, sub_vals)
+                    node.meta[_PALLAS_LOOP_LOAD_COUNT_META] = 1
+                else:
+                    first_load = loaded_tensors[key][1]
+                    first_load.meta[_PALLAS_LOOP_LOAD_COUNT_META] = (
+                        int(first_load.meta[_PALLAS_LOOP_LOAD_COUNT_META]) + 1
+                    )
         elif node.target is _store_op:
             tensor_node = node.args[0]
             subscript = node.args[1]
@@ -651,6 +660,131 @@ def _get_dim_block_ids(
         elif isinstance(idx, slice) and idx == slice(None):
             pass
     return dim_to_bid
+
+
+def _contiguous_range_patterns(
+    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+) -> dict[int, dict[int, ContiguousRangeIndexPattern]]:
+    """Return direct HBM range patterns keyed by tensor and tensor dimension."""
+    from .plan_tiling import ContiguousRangeIndexPattern
+    from .plan_tiling import NonePattern
+
+    result: dict[int, dict[int, ContiguousRangeIndexPattern]] = {}
+    for fake, load_node, _subscript in loaded_tensors.values():
+        tensor_dim = 0
+        ranges: dict[int, ContiguousRangeIndexPattern] = {}
+        for pattern in load_node.meta.get("indexing_patterns", ()):
+            if isinstance(pattern, NonePattern):
+                continue
+            if isinstance(pattern, ContiguousRangeIndexPattern):
+                ranges[tensor_dim] = pattern
+            tensor_dim += 1
+        if ranges:
+            result[id(fake)] = ranges
+    return result
+
+
+def _contiguous_range_base_expr(
+    value: object,
+    *,
+    state: CodegenState,
+    block_ids: list[int],
+    begin_exprs: list[str],
+    iter_step_exprs: list[str],
+    iteration_indices: list[str],
+) -> str | None:
+    """Render a supported scalar address expression for one loop iteration."""
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, torch.SymInt):
+        return state.device_function.literal_expr(value)
+    if not isinstance(value, torch.fx.Node) or value.op != "call_function":
+        return None
+
+    from ...language import memory_ops
+    from ...language.tile_ops import tile_begin
+
+    if value.target is tile_begin:
+        symbolic_value = value.meta.get("val")
+        if not isinstance(symbolic_value, torch.SymInt):
+            return None
+        block_id = CompileEnvironment.current().get_block_id(symbolic_value)
+        if block_id is None or block_id not in block_ids:
+            return None
+        position = block_ids.index(block_id)
+        return (
+            f"({begin_exprs[position]}) + ({iteration_indices[position]}) * "
+            f"({iter_step_exprs[position]})"
+        )
+
+    binary_operators = {
+        operator.add: "+",
+        operator.floordiv: "//",
+        operator.mod: "%",
+        operator.mul: "*",
+        operator.sub: "-",
+        torch.ops.aten.add.Scalar: "+",
+        torch.ops.aten.add.Tensor: "+",
+        torch.ops.aten.mul.Scalar: "*",
+        torch.ops.aten.mul.Tensor: "*",
+        torch.ops.aten.sub.Scalar: "-",
+        torch.ops.aten.sub.Tensor: "-",
+    }
+    if value.target in binary_operators and len(value.args) >= 2:
+        if (
+            value.target
+            in (
+                torch.ops.aten.add.Scalar,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.sub.Scalar,
+                torch.ops.aten.sub.Tensor,
+            )
+            and value.kwargs.get("alpha", 1) != 1
+        ):
+            return None
+        lhs = _contiguous_range_base_expr(
+            value.args[0],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        rhs = _contiguous_range_base_expr(
+            value.args[1],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        if lhs is None or rhs is None:
+            return None
+        return f"({lhs}) {binary_operators[value.target]} ({rhs})"
+
+    if value.target is memory_ops.load:
+        tensor_node, subscript = value.args[:2]
+        if not isinstance(tensor_node, torch.fx.Node):
+            return None
+        tensor = tensor_node.meta.get("val")
+        if not isinstance(tensor, torch.Tensor):
+            return None
+        if not isinstance(subscript, (list, tuple)) or len(subscript) != 1:
+            return None
+        index = _contiguous_range_base_expr(
+            subscript[0],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        if index is None:
+            return None
+        name = state.device_function.tensor_arg(tensor).name
+        return f"{name}[{index}]"
+
+    return None
 
 
 def _find_strategy(
@@ -2817,16 +2951,20 @@ def _compute_vmem_shapes(
     slice_size_exprs: list[str],
     env: CompileEnvironment,
     state: CodegenState,
+    contiguous_ranges: dict[int, dict[int, ContiguousRangeIndexPattern]],
 ) -> list[tuple[int, ...]]:
     """Compute VMEM buffer shapes for each tensor in the fori_loop body."""
     vmem_shapes: list[tuple[int, ...]] = []
     for fake, sub_meta, _direction in all_tensor_info:
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
         tensor_subscripts = _tensor_dim_subscripts(sub_meta)
+        range_dims = contiguous_ranges.get(id(fake), {})
         parts: list[int] = []
         for dim_idx in range(len(fake.shape)):
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid in block_ids:
+            if dim_idx in range_dims:
+                parts.append(range_dims[dim_idx].length)
+            elif bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
                 block_value_sym = sympy.sympify(slice_size_exprs[bid_idx])
                 if isinstance(block_value_sym, sympy.Integer):
@@ -2918,8 +3056,14 @@ def _classify_pipelined_tensors(
     outer_access_targets = ATOMIC_OPS | {_load_op, _store_op}
 
     all_tensor_info = _resident_loop_tensor_info(loaded_tensors, stored_tensors)
+    contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     vmem_shapes = _compute_vmem_shapes(
-        all_tensor_info, block_ids, slice_size_exprs, env, state
+        all_tensor_info,
+        block_ids,
+        slice_size_exprs,
+        env,
+        state,
+        contiguous_ranges,
     )
     device_ir = HostFunction.current().device_ir
 
@@ -2958,6 +3102,21 @@ def _classify_pipelined_tensors(
     for (fake, sub_meta, direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
+        if direction == "load":
+            first_load = loaded_tensors[id(fake)][1]
+            if int(first_load.meta.get(_PALLAS_LOOP_LOAD_COUNT_META, 1)) > 1:
+                # Tensor-level prefetching is keyed by input tensor, not load
+                # site. Dynamic ranges can remain in HBM so each load site
+                # stages its own exact window. Ordinary tiled loads must keep
+                # their outer BlockSpec: raw HBM load-site staging is defined
+                # only for dynamic ranges and remote-copy operands.
+                if id(fake) in contiguous_ranges:
+                    from ..device_function import PallasMemorySpace
+
+                    state.device_function.pallas_memory_space[id(fake)] = (
+                        PallasMemorySpace.HBM
+                    )
+                    continue
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
         if state.device_function.is_pallas_remote_copy_operand(fake) and not set(
             dim_to_bid.values()
@@ -2975,6 +3134,23 @@ def _classify_pipelined_tensors(
             continue
         if id(fake.untyped_storage()) in atomic_storages:
             continue
+        if range_patterns := contiguous_ranges.get(id(fake)):
+            can_render_ranges = all(
+                _contiguous_range_base_expr(
+                    pattern.base,
+                    state=state,
+                    block_ids=block_ids,
+                    begin_exprs=["0"] * len(block_ids),
+                    iter_step_exprs=["1"] * len(block_ids),
+                    iteration_indices=["0"] * len(block_ids),
+                )
+                is not None
+                for pattern in range_patterns.values()
+            )
+            if not can_render_ranges:
+                # The load-site lowering can still stage this window, but the
+                # loop prefetcher cannot safely synthesize its next address.
+                continue
         pipelined_ids.add(id(fake))
     return all_tensor_info, vmem_shapes, pipelined_ids
 
@@ -3152,6 +3328,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
 
     loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
+    contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
         state, block_ids, block_size_vars
     )
@@ -3462,7 +3639,28 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         vmem_needs_slice = False
         for dim_idx in range(len(shape)):
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid in block_ids:
+            range_pattern = contiguous_ranges.get(id(fake), {}).get(dim_idx)
+            if range_pattern is not None:
+                base_expr = _contiguous_range_base_expr(
+                    range_pattern.base,
+                    state=state,
+                    block_ids=block_ids,
+                    begin_exprs=begin_exprs,
+                    iter_step_exprs=iter_step_exprs,
+                    iteration_indices=iteration_indices,
+                )
+                if base_expr is None:
+                    raise RuntimeError(
+                        "Pallas could not render a planned contiguous HBM range"
+                    )
+                hbm_parts.append(
+                    "pl.ds(pl.multiple_of("
+                    f"{base_expr}, {range_pattern.alignment}), "
+                    f"{range_pattern.length})"
+                )
+                vmem_parts.append(":")
+                hbm_needs_slice = True
+            elif bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -53,6 +53,8 @@ from .tensorcore_plan import build_dma_access_candidates
 
 log = logging.getLogger(__name__)
 
+_PALLAS_LOOP_LOAD_COUNT_META = "_helion_pallas_loop_load_count"
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterator
@@ -66,6 +68,7 @@ if TYPE_CHECKING:
     from ..tile_strategy import TileStrategy
     from .compact_worklist import ResidentPrepHoist
     from .dma import DmaDirection
+    from .plan_tiling import ContiguousRangeIndexPattern
 
 
 @_decorators.codegen(_not, "pallas")
@@ -616,7 +619,13 @@ def _classify_loop_tensors(
                 key = id(fake)
                 if key not in loaded_tensors:
                     sub_vals = _extract_subscript_vals(subscript)
-                    loaded_tensors[key] = (fake, tensor_node, sub_vals)
+                    loaded_tensors[key] = (fake, node, sub_vals)
+                    node.meta[_PALLAS_LOOP_LOAD_COUNT_META] = 1
+                else:
+                    first_load = loaded_tensors[key][1]
+                    first_load.meta[_PALLAS_LOOP_LOAD_COUNT_META] = (
+                        int(first_load.meta[_PALLAS_LOOP_LOAD_COUNT_META]) + 1
+                    )
         elif node.target is _store_op:
             tensor_node = node.args[0]
             subscript = node.args[1]
@@ -867,6 +876,131 @@ def _get_dim_block_ids(
         elif isinstance(idx, slice) and idx == slice(None):
             pass
     return dim_to_bid
+
+
+def _contiguous_range_patterns(
+    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+) -> dict[int, dict[int, ContiguousRangeIndexPattern]]:
+    """Return direct HBM range patterns keyed by tensor and tensor dimension."""
+    from .plan_tiling import ContiguousRangeIndexPattern
+    from .plan_tiling import NonePattern
+
+    result: dict[int, dict[int, ContiguousRangeIndexPattern]] = {}
+    for fake, load_node, _subscript in loaded_tensors.values():
+        tensor_dim = 0
+        ranges: dict[int, ContiguousRangeIndexPattern] = {}
+        for pattern in load_node.meta.get("indexing_patterns", ()):
+            if isinstance(pattern, NonePattern):
+                continue
+            if isinstance(pattern, ContiguousRangeIndexPattern):
+                ranges[tensor_dim] = pattern
+            tensor_dim += 1
+        if ranges:
+            result[id(fake)] = ranges
+    return result
+
+
+def _contiguous_range_base_expr(
+    value: object,
+    *,
+    state: CodegenState,
+    block_ids: list[int],
+    begin_exprs: list[str],
+    iter_step_exprs: list[str],
+    iteration_indices: list[str],
+) -> str | None:
+    """Render a supported scalar address expression for one loop iteration."""
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, torch.SymInt):
+        return state.device_function.literal_expr(value)
+    if not isinstance(value, torch.fx.Node) or value.op != "call_function":
+        return None
+
+    from ...language import memory_ops
+    from ...language.tile_ops import tile_begin
+
+    if value.target is tile_begin:
+        symbolic_value = value.meta.get("val")
+        if not isinstance(symbolic_value, torch.SymInt):
+            return None
+        block_id = CompileEnvironment.current().get_block_id(symbolic_value)
+        if block_id is None or block_id not in block_ids:
+            return None
+        position = block_ids.index(block_id)
+        return (
+            f"({begin_exprs[position]}) + ({iteration_indices[position]}) * "
+            f"({iter_step_exprs[position]})"
+        )
+
+    binary_operators = {
+        operator.add: "+",
+        operator.floordiv: "//",
+        operator.mod: "%",
+        operator.mul: "*",
+        operator.sub: "-",
+        torch.ops.aten.add.Scalar: "+",
+        torch.ops.aten.add.Tensor: "+",
+        torch.ops.aten.mul.Scalar: "*",
+        torch.ops.aten.mul.Tensor: "*",
+        torch.ops.aten.sub.Scalar: "-",
+        torch.ops.aten.sub.Tensor: "-",
+    }
+    if value.target in binary_operators and len(value.args) >= 2:
+        if (
+            value.target
+            in (
+                torch.ops.aten.add.Scalar,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.sub.Scalar,
+                torch.ops.aten.sub.Tensor,
+            )
+            and value.kwargs.get("alpha", 1) != 1
+        ):
+            return None
+        lhs = _contiguous_range_base_expr(
+            value.args[0],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        rhs = _contiguous_range_base_expr(
+            value.args[1],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        if lhs is None or rhs is None:
+            return None
+        return f"({lhs}) {binary_operators[value.target]} ({rhs})"
+
+    if value.target is memory_ops.load:
+        tensor_node, subscript = value.args[:2]
+        if not isinstance(tensor_node, torch.fx.Node):
+            return None
+        tensor = tensor_node.meta.get("val")
+        if not isinstance(tensor, torch.Tensor):
+            return None
+        if not isinstance(subscript, (list, tuple)) or len(subscript) != 1:
+            return None
+        index = _contiguous_range_base_expr(
+            subscript[0],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        if index is None:
+            return None
+        name = state.device_function.tensor_arg(tensor).name
+        return f"{name}[{index}]"
+
+    return None
 
 
 def _find_strategy(
@@ -3092,16 +3226,20 @@ def _compute_vmem_shapes(
     slice_size_exprs: list[str],
     env: CompileEnvironment,
     state: CodegenState,
+    contiguous_ranges: dict[int, dict[int, ContiguousRangeIndexPattern]],
 ) -> list[tuple[int, ...]]:
     """Compute VMEM buffer shapes for each tensor in the fori_loop body."""
     vmem_shapes: list[tuple[int, ...]] = []
     for fake, sub_meta, _direction in all_tensor_info:
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
         tensor_subscripts = _tensor_dim_subscripts(sub_meta)
+        range_dims = contiguous_ranges.get(id(fake), {})
         parts: list[int] = []
         for dim_idx in range(len(fake.shape)):
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid in block_ids:
+            if dim_idx in range_dims:
+                parts.append(range_dims[dim_idx].length)
+            elif bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
                 block_value_sym = sympy.sympify(slice_size_exprs[bid_idx])
                 if isinstance(block_value_sym, sympy.Integer):
@@ -3193,8 +3331,14 @@ def _classify_pipelined_tensors(
     outer_access_targets = ATOMIC_OPS | {_load_op, _store_op}
 
     all_tensor_info = _resident_loop_tensor_info(loaded_tensors, stored_tensors)
+    contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     vmem_shapes = _compute_vmem_shapes(
-        all_tensor_info, block_ids, slice_size_exprs, env, state
+        all_tensor_info,
+        block_ids,
+        slice_size_exprs,
+        env,
+        state,
+        contiguous_ranges,
     )
     device_ir = HostFunction.current().device_ir
 
@@ -3233,6 +3377,21 @@ def _classify_pipelined_tensors(
     for (fake, sub_meta, direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
+        if direction == "load":
+            first_load = loaded_tensors[id(fake)][1]
+            if int(first_load.meta.get(_PALLAS_LOOP_LOAD_COUNT_META, 1)) > 1:
+                # Tensor-level prefetching is keyed by input tensor, not load
+                # site. Dynamic ranges can remain in HBM so each load site
+                # stages its own exact window. Ordinary tiled loads must keep
+                # their outer BlockSpec: raw HBM load-site staging is defined
+                # only for dynamic ranges and remote-copy operands.
+                if id(fake) in contiguous_ranges:
+                    from ..device_function import PallasMemorySpace
+
+                    state.device_function.pallas_memory_space[id(fake)] = (
+                        PallasMemorySpace.HBM
+                    )
+                    continue
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
         if state.device_function.is_pallas_remote_copy_operand(fake) and not set(
             dim_to_bid.values()
@@ -3250,6 +3409,23 @@ def _classify_pipelined_tensors(
             continue
         if id(fake.untyped_storage()) in atomic_storages:
             continue
+        if range_patterns := contiguous_ranges.get(id(fake)):
+            can_render_ranges = all(
+                _contiguous_range_base_expr(
+                    pattern.base,
+                    state=state,
+                    block_ids=block_ids,
+                    begin_exprs=["0"] * len(block_ids),
+                    iter_step_exprs=["1"] * len(block_ids),
+                    iteration_indices=["0"] * len(block_ids),
+                )
+                is not None
+                for pattern in range_patterns.values()
+            )
+            if not can_render_ranges:
+                # The load-site lowering can still stage this window, but the
+                # loop prefetcher cannot safely synthesize its next address.
+                continue
         pipelined_ids.add(id(fake))
     return all_tensor_info, vmem_shapes, pipelined_ids
 
@@ -3427,6 +3603,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
 
     loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
+    contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
         state, block_ids, block_size_vars
     )
@@ -3783,7 +3960,28 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 vmem_parts.append(":")
                 continue
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid in block_ids:
+            range_pattern = contiguous_ranges.get(id(fake), {}).get(dim_idx)
+            if range_pattern is not None:
+                base_expr = _contiguous_range_base_expr(
+                    range_pattern.base,
+                    state=state,
+                    block_ids=block_ids,
+                    begin_exprs=begin_exprs,
+                    iter_step_exprs=iter_step_exprs,
+                    iteration_indices=iteration_indices,
+                )
+                if base_expr is None:
+                    raise RuntimeError(
+                        "Pallas could not render a planned contiguous HBM range"
+                    )
+                hbm_parts.append(
+                    "pl.ds(pl.multiple_of("
+                    f"{base_expr}, {range_pattern.alignment}), "
+                    f"{range_pattern.length})"
+                )
+                vmem_parts.append(":")
+                hbm_needs_slice = True
+            elif bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]
@@ -3795,7 +3993,13 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 # ragged store on a last-two dim can't clamp and is rejected.
                 if clamp and dim_idx < len(shape) - 2:
                     end_expr = _get_loop_begin_and_end(state, bid_idx)[1]
-                    slice_size_expr = f"jnp.minimum({slice_size_expr}, ({end_expr}) - ({offset_expr}))"
+                    # Static unroll resolves the iteration in Python. Keep the
+                    # DMA extent static too: a traced jnp.minimum here creates
+                    # a dynamic HBM subview that Mosaic cannot place reliably.
+                    minimum = "min" if static_unroll else "jnp.minimum"
+                    slice_size_expr = (
+                        f"{minimum}({slice_size_expr}, ({end_expr}) - ({offset_expr}))"
+                    )
                     vmem_parts.append(f"pl.ds(0, {slice_size_expr})")
                     vmem_needs_slice = True
                 elif clamp and is_dynamic_bound_tile(state, bid):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -704,6 +704,43 @@ def pallas_fixed_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_prefetched_aligned_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for _ in hl.grid(1):
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            out[tile, :, :] = table[:, begin + hl.arange(128)][None, :, :]
+    return out
+
+
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(pallas_loop_type="fori_loop"),
+)
+def pallas_two_aligned_dynamic_windows(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    """Read two distinct aligned windows from one HBM tensor per iteration."""
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for _ in hl.grid(1):
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            first = table[:, begin + hl.arange(128)]
+            second = table[:, begin + 128 + hl.arange(128)]
+            out[tile, :, :] = (first + second)[None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
     rows = x.size(0)
     out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
@@ -913,6 +950,37 @@ class TestPallas(TestCase):
                 )
                 expected = x[3 : 3 + extent].sum(dim=0, keepdim=True)
                 torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_aligned_dynamic_window_prefetch(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        expected = torch.stack(
+            [table[:, begin : begin + 128] for begin in range(0, 512, 128)]
+        )
+
+        for loop_type in ("fori_loop", "unroll"):
+            with self.subTest(pallas_loop_type=loop_type):
+                _, result = code_and_output(
+                    pallas_prefetched_aligned_dynamic_window,
+                    (table, starts),
+                    pallas_load_buffer_count=[2, 1],
+                    pallas_loop_type=loop_type,
+                )
+                torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_two_aligned_dynamic_windows(self) -> None:
+        table = torch.randn(8, 640, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(pallas_two_aligned_dynamic_windows, (table, starts))
+        expected = torch.stack(
+            [
+                table[:, begin : begin + 128] + table[:, begin + 128 : begin + 256]
+                for begin in range(0, 512, 128)
+            ]
+        )
+        torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_computed_static_slice(self) -> None:
         x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -671,6 +671,43 @@ def pallas_scaled_add_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_prefetched_aligned_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for _ in hl.grid(1):
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            out[tile, :, :] = table[:, begin + hl.arange(128)][None, :, :]
+    return out
+
+
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(pallas_loop_type="fori_loop"),
+)
+def pallas_two_aligned_dynamic_windows(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    """Read two distinct aligned windows from one HBM tensor per iteration."""
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for _ in hl.grid(1):
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            first = table[:, begin + hl.arange(128)]
+            second = table[:, begin + 128 + hl.arange(128)]
+            out[tile, :, :] = (first + second)[None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
     rows = x.size(0)
     out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
@@ -841,6 +878,72 @@ class TestPallas(TestCase):
         self.assertIn("one_hot", code)
         lanes = torch.arange(128, device=DEVICE)
         expected = torch.stack((table[:, lanes], table[:, 256 + lanes]))
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_aligned_dynamic_window_prefetch_codegen(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+
+        for loop_type, loop_marker in (
+            ("fori_loop", "jax.lax.fori_loop"),
+            ("unroll", "for _j in range("),
+        ):
+            with self.subTest(pallas_loop_type=loop_type):
+                code = pallas_prefetched_aligned_dynamic_window.bind(
+                    (table, starts)
+                ).to_triton_code(
+                    helion.Config(
+                        pallas_load_buffer_count=[2, 1],
+                        pallas_loop_type=loop_type,
+                    )
+                )
+                self.assertIn(loop_marker, code)
+                self.assertIn("def _prime_fori_loads", code)
+                self.assertIn("def _prefetch_fori_loads", code)
+                self.assertIn(
+                    "pltpu.make_async_copy(table.at[:, pl.ds(pl.multiple_of(",
+                    code,
+                )
+                self.assertRegex(code, r"table_buf\.at\[\(_j \+ 1\) % 2\]")
+                self.assertNotIn("one_hot", code)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_aligned_dynamic_window_prefetch_correctness(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        expected = torch.stack(
+            [table[:, begin : begin + 128] for begin in range(0, 512, 128)]
+        )
+
+        for loop_type in ("fori_loop", "unroll"):
+            with self.subTest(pallas_loop_type=loop_type):
+                code, result = code_and_output(
+                    pallas_prefetched_aligned_dynamic_window,
+                    (table, starts),
+                    pallas_load_buffer_count=[2, 1],
+                    pallas_loop_type=loop_type,
+                )
+                self.assertIn("def _prefetch_fori_loads", code)
+                torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_two_aligned_dynamic_windows_codegen(self) -> None:
+        table = torch.randn(8, 640, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        code = pallas_two_aligned_dynamic_windows.bind((table, starts)).to_triton_code()
+        self.assertNotIn("def _prime_fori_loads", code)
+        self.assertGreaterEqual(code.count("pltpu.make_async_copy(table.at["), 2)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_two_aligned_dynamic_windows(self) -> None:
+        table = torch.randn(8, 640, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(pallas_two_aligned_dynamic_windows, (table, starts))
+        expected = torch.stack(
+            [
+                table[:, begin : begin + 128] + table[:, begin + 128 : begin + 256]
+                for begin in range(0, 512, 128)
+            ]
+        )
         torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_computed_static_slice(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3408
 * #3387
 * __->__#3392


--- --- ---

### [Pallas] Prefetch aligned dynamic HBM windows


The aligned dynamic-window lowering can stage a source expression such as
`base + hl.arange(128)` directly from HBM, but the inner-loop DMA planner did
not retain the load site's indexing metadata. Selecting a depth-two pipeline
therefore sized and copied the full tensor rather than the requested window.

For example:

```python
for _ in hl.grid(1):
    for tile in hl.tile(starts.size(0), block_size=1):
        begin = starts[tile.begin] * 128
        out[tile, :, :] = table[:, begin + hl.arange(128)][None, :, :]

helion.Config(
    pallas_loop_type="unroll",
    pallas_load_buffer_count=[2, 1],
)
```

For a `[8, 512]` table, the old Pallas/JAX discarded the dynamic range while
building loop-level DMA buffers:

```python
@pl.when(num_iterations > 0)
def prime():
    copy = pltpu.make_async_copy(table, table_buf.at[0], table_sem.at[0])
    copy.start()

for j in range(num_iterations):
    @pl.when(j + 1 < num_iterations)
    def prefetch():
        copy = pltpu.make_async_copy(
            table,
            table_buf.at[(j + 1) % 2],
            table_sem.at[(j + 1) % 2],
        )
        copy.start()
```

This transferred all 512 columns per iteration and made large projection-weight
buffers impractical. Keep the FX load node in the loop access record, carry its
proven `ContiguousRangeIndexPattern` into the DMA planner, and size the VMEM
stage from the range length. Prime and prefetch now preserve the exact address:

```python
@pl.when(num_iterations > 0)
def prime():
    copy = pltpu.make_async_copy(
        table.at[:, pl.ds(pl.multiple_of(starts[0] * 128, 128), 128)],
        table_buf.at[0],
        table_sem.at[0],
    )
    copy.start()

for j in range(num_iterations):
    @pl.when(j + 1 < num_iterations)
    def prefetch():
        copy = pltpu.make_async_copy(
            table.at[:, pl.ds(
                pl.multiple_of(starts[j + 1] * 128, 128), 128
            )],
            table_buf.at[(j + 1) % 2],
            table_sem.at[(j + 1) % 2],
        )
        copy.start()
```

The example transfers and buffers 4x fewer elements while retaining overlap.
The address renderer supports constants, tile begins, scalar-tensor loads, and
ordinary integer arithmetic. If it cannot render every range base for an
arbitrary iteration, the load stays on the existing site-local staging path.

Tensor-level prefetch is keyed by input tensor, so two different dynamic load
sites from the same argument must not share the first site's buffer. This source
used to silently read the first window twice:

```python
first = table[:, begin + hl.arange(128)]
second = table[:, begin + 128 + hl.arange(128)]
out[tile, :, :] = (first + second)[None, :, :]
```

Count loop load sites per tensor. Repeated dynamic ranges remain in HBM and each
site emits its own exact DMA; ordinary tiled repeated loads retain their existing
BlockSpec/tensor-buffer route. The corrected dynamic code has two independent
transfers and values:

```python
first_copy = pltpu.make_async_copy(table.at[:, pl.ds(first_begin, 128)], ...)
first_copy.start()
first_copy.wait()
second_copy = pltpu.make_async_copy(table.at[:, pl.ds(second_begin, 128)], ...)
second_copy.start()
second_copy.wait()
```

Buffered static unroll also makes each loop index and tail size a Python value.
The old output DMA nevertheless converted that fixed extent into a traced JAX
scalar:

```python
live = jnp.minimum(block_size, end - (begin + j * step))
copy = pltpu.make_async_copy(
    out_buf.at[pl.ds(0, live)],
    out.at[pl.ds(begin + j * step, live)],
    out_sem,
)
```

Under the TPU CI pins—JAX/JAXlib 0.11.1 and libtpu 0.0.46—Mosaic cannot
propagate the HBM memory space through the resulting dynamically shaped
`memref.cast`. Preserve the static extent for the unrolled form while leaving
the dynamic `fori_loop` form unchanged:

```python
live = min(block_size, end - (begin + j * step))
```

No API changes. The optimization composes with `fori_loop` and buffered static
unroll.

Tests execute both loop forms and two distinct dynamic-window loads, comparing
the complete results with the reference. The runtime tests also ran through
generated Pallas/JAX on both TPU hosts and were bit-identical to the reference.
`pre-commit run --all-files` and `./lint.sh check` pass.
