### PR TITLE
[Pallas] Preserve modulo and floor-division precedence

### DIFF
--- a/helion/_compiler/pallas/printer.py
+++ b/helion/_compiler/pallas/printer.py
@@ -8,6 +8,9 @@ to emit plain Python operators instead of Triton runtime helpers.  Moved out of
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import cast
+
+from torch.utils._sympy.printers import PRECEDENCE
 
 from ..triton.printer import HelionTritonPrinter
 
@@ -20,13 +23,17 @@ class HelionPallasPrinter(HelionTritonPrinter):
 
     def _print_FloorDiv(self, expr: sympy.Expr) -> str:
         lhs, rhs = expr.args
-        # pyrefly: ignore [missing-attribute]
-        return f"({self._print(lhs)} // {self._print(rhs)})"
+        level = PRECEDENCE["Atom"] - 0.5
+        lhs_expr = cast("sympy.Expr", lhs)
+        rhs_expr = cast("sympy.Expr", rhs)
+        return f"({self.parenthesize(lhs_expr, level)} // {self.parenthesize(rhs_expr, level)})"
 
     def _print_PythonMod(self, expr: sympy.Expr) -> str:
         lhs, rhs = expr.args
-        # pyrefly: ignore [missing-attribute]
-        return f"({self._print(lhs)} % {self._print(rhs)})"
+        level = PRECEDENCE["Atom"] - 0.5
+        lhs_expr = cast("sympy.Expr", lhs)
+        rhs_expr = cast("sympy.Expr", rhs)
+        return f"({self.parenthesize(lhs_expr, level)} % {self.parenthesize(rhs_expr, level)})"
 
 
 def pallas_texpr(expr: sympy.Expr) -> str:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -708,6 +708,26 @@ def pallas_two_aligned_dynamic_windows(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
+    """Exercise a compound modulo operand whose parentheses are significant."""
+    out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
+    for _ in hl.grid(1):
+        for tile in hl.tile(4, block_size=1):
+            out[tile.begin, :] = x[(tile.begin - 1) % 4, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_shifted_floor_divide_row_index(x: torch.Tensor) -> torch.Tensor:
+    """Exercise a compound floor-division operand with significant grouping."""
+    out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
+    for _ in hl.grid(1):
+        for tile in hl.tile(4, block_size=1):
+            out[tile.begin, :] = x[(tile.begin + 1) // 2, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
     rows = x.size(0)
     out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
@@ -945,6 +965,28 @@ class TestPallas(TestCase):
             ]
         )
         torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_shifted_modulo_preserves_expression_precedence(self) -> None:
+        x = torch.randn(5, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_shifted_modulo_row_index,
+            (x,),
+            pallas_loop_type="unroll",
+        )
+        self.assertRegex(code, r"\(-1 \+ .*\) % 4")
+        self.assertNotRegex(code, r"= -1 \+ [A-Za-z0-9_]+ % 4")
+        torch.testing.assert_close(result.cpu(), x[[3, 0, 1, 2]].cpu())
+
+    def test_shifted_floor_divide_preserves_expression_precedence(self) -> None:
+        x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_shifted_floor_divide_row_index,
+            (x,),
+            pallas_loop_type="unroll",
+        )
+        self.assertRegex(code, r"\(1 \+ .*\) // 2")
+        self.assertNotRegex(code, r"= 1 \+ [A-Za-z0-9_]+ // 2")
+        torch.testing.assert_close(result.cpu(), x[[0, 1, 1, 2]].cpu())
 
     def test_computed_static_slice(self) -> None:
         x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -632,6 +632,26 @@ def pallas_cat_columns(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
+    """Exercise a compound modulo operand whose parentheses are significant."""
+    out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
+    for _ in hl.grid(1):
+        for tile in hl.tile(4, block_size=1):
+            out[tile.begin, :] = x[(tile.begin - 1) % 4, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_shifted_floor_divide_row_index(x: torch.Tensor) -> torch.Tensor:
+    """Exercise a compound floor-division operand with significant grouping."""
+    out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
+    for _ in hl.grid(1):
+        for tile in hl.tile(4, block_size=1):
+            out[tile.begin, :] = x[(tile.begin + 1) // 2, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_rand_add(x: torch.Tensor, seed: int) -> torch.Tensor:
     """Kernel that uses hl.rand to generate random values and add them to x."""
     out = torch.empty_like(x)
@@ -739,6 +759,24 @@ class TestPallas(TestCase):
         )
         self.assertIn("jnp.concatenate((", code)
         torch.testing.assert_close(result.cpu(), torch.cat((x, y), dim=1).cpu())
+
+    def test_shifted_modulo_preserves_expression_precedence(self) -> None:
+        x = torch.randn(5, 128, device=DEVICE, dtype=torch.float32)
+        _, result = code_and_output(
+            pallas_shifted_modulo_row_index,
+            (x,),
+            pallas_loop_type="unroll",
+        )
+        torch.testing.assert_close(result.cpu(), x[[3, 0, 1, 2]].cpu())
+
+    def test_shifted_floor_divide_preserves_expression_precedence(self) -> None:
+        x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
+        _, result = code_and_output(
+            pallas_shifted_floor_divide_row_index,
+            (x,),
+            pallas_loop_type="unroll",
+        )
+        torch.testing.assert_close(result.cpu(), x[[0, 1, 1, 2]].cpu())
 
     def test_rsqrt_uses_native_lax_op(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)


### PR DESCRIPTION
Stacked PRs:
 * #3408
 * #3405
 * #3396
 * #3394
 * #3402
 * #3401
 * #3387
 * #3407
 * #3403
 * #3399
 * #3398
 * #3397
 * #3392
 * #3391
 * #3406
 * #3404
 * #3390
 * #3389
 * __->__#3393


--- --- ---

### [Pallas] Preserve modulo and floor-division precedence


The Pallas SymPy printer emitted `%` and `//` by recursively printing each
operand without considering the operand's precedence. A compound operand could
therefore lose required parentheses and silently change the generated program.

This matters directly for pipelined distributed kernels, which commonly select
a ring slot with source such as:

```python
send_slot = (stage - 1) % SEND_SLOTS
```

A minimal Helion example is:

```python
for _ in hl.grid(1):
    for tile in hl.tile(4, block_size=1):
        out[tile.begin, :] = x[(tile.begin - 1) % 4, :]
```

The old generated Pallas/JAX changed the grouping:

```python
mod = -1 + offset_1 % 4
load = x[mod, :]
```

Python evaluates `%` before `+`, so this means `-1 + (offset_1 % 4)` rather
than `(-1 + offset_1) % 4`. With a five-row input, the first iteration reads
row 4 through negative indexing instead of the intended ring row 3. The
computation test reports a mismatching result.

Floor division had the same problem. This source:

```python
out[tile.begin, :] = x[(tile.begin + 1) // 2, :]
```

was emitted as:

```python
floordiv = 1 + offset_1 // 2
```

and selected rows `[1, 1, 2, 2]` rather than `[0, 1, 1, 2]`.

Use the inherited precedence-aware `parenthesize` helper for each operand while
retaining the Pallas printer's outer parentheses. Generated code is now:

```python
mod = (-1 + offset_1) % 4
floordiv = (1 + offset_1) // 2
```

Atomic operands keep the existing spelling, e.g. `(x % y)` and `(x // y)`.
There is no API change and no effect on expressions that do not need grouping.
The fused RMSNorm/QKVOG/all-to-all source now generates its send-ring index as
`(-1 + offset_1) % 4`.

Tests execute both affected index expressions and compare the complete results with PyTorch:

```
HELION_BACKEND=pallas HELION_PALLAS_INTERPRET=1 python -m pytest -q \
  test/test_pallas.py::TestPallas::test_shifted_modulo_preserves_expression_precedence \
  test/test_pallas.py::TestPallas::test_shifted_floor_divide_preserves_expression_precedence \
  test/test_pallas.py::TestPallasPrinter::test_pallas_texpr_mod

./lint.sh
```
