### PR TITLE
[Pallas] Drain looped remote receives after the loop

### DIFF
--- a/helion/_compiler/pallas/distributed_ops.py
+++ b/helion/_compiler/pallas/distributed_ops.py
@@ -28,6 +28,8 @@ from .plan_tiling import REMOTE_SRC_INDEXING_PATTERNS
 
 if TYPE_CHECKING:
     from ..inductor_lowering import CodegenState
+    from ..tile_strategy import ForiLoopState
+    from ..tile_strategy import RemoteRecvDrain
 
 
 _PALLAS_SRC_MATERIALIZATION_META = "_helion_pallas_remote_copy_src_materialization"
@@ -53,6 +55,7 @@ def _automatic_collective_id(fn: Callable[..., object]) -> int:
 class _PallasRemoteCopyInfo:
     op_name: str
     source_materialization: tuple[ast.AST, ast.AST] | None
+    deferred_recv: RemoteRecvDrain | None = None
 
 
 @_decorators.codegen(remote_barrier, "pallas")
@@ -162,6 +165,48 @@ def _direct_value_expr(tensor: ast.AST, ast_index: list[object]) -> ast.AST:
         placeholders[key] = value
         parts.append(f"{{{key}}}")
     return expr_from_string(f"{{tensor}}[{', '.join(parts)}]", **placeholders)
+
+
+def _canonical_recv_ref(dst_ref: ast.AST, indexed_dims: int) -> ast.AST | None:
+    """Return a fixed same-shaped destination region for a receive drain."""
+    if not isinstance(dst_ref, ast.Subscript):
+        return None
+    raw_parts = (
+        dst_ref.slice.elts if isinstance(dst_ref.slice, ast.Tuple) else [dst_ref.slice]
+    )
+    if len(raw_parts) < indexed_dims:
+        return None
+    placeholders: dict[str, ast.AST] = {"base": dst_ref.value}
+    rendered: list[str] = []
+    for index, part in enumerate(raw_parts):
+        key = f"part_{index}"
+        if index < indexed_dims:
+            if (
+                isinstance(part, ast.Call)
+                and isinstance(part.func, ast.Attribute)
+                and part.func.attr == "ds"
+                and len(part.args) >= 2
+            ):
+                part = expr_from_string("pl.ds(0, {size})", size=part.args[1])
+            else:
+                part = expr_from_string("0")
+        placeholders[key] = part
+        rendered.append(f"{{{key}}}")
+    return expr_from_string(f"{{base}}[{', '.join(rendered)}]", **placeholders)
+
+
+def _active_fori_loop(state: CodegenState) -> ForiLoopState | None:
+    from ..tile_strategy import ForiLoopState
+
+    return next(
+        (
+            loop
+            for loops in state.codegen.active_device_loops.values()
+            for loop in loops
+            if isinstance(loop, ForiLoopState)
+        ),
+        None,
+    )
 
 
 def _materialized_source_value(
@@ -398,7 +443,26 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
         if send_slot_shape
         else expr_from_string(send_sem_name)
     )
-    recv_sem = device_fn.register_dma_semaphore(name_hint="remote_recv_sem")
+    try:
+        payload_shape = tuple(int(size) for size in src.shape[len(proxy_src_index) :])
+    except (TypeError, ValueError):
+        payload_shape = ()
+    fori_loop = _active_fori_loop(state)
+    dst_name: str | None = None
+    drain_key: tuple[str, tuple[int, ...]] | None = None
+    deferred_recv: RemoteRecvDrain | None = None
+    if fori_loop is not None and payload_shape:
+        dst_name = _tensor_argument_name(state, dst)
+        if dst_name is not None:
+            read_names, _ = device_fn.get_tensor_read_write_names()
+            if dst_name not in read_names:
+                drain_key = (dst_name, payload_shape)
+                deferred_recv = fori_loop._remote_recv_drains.get(drain_key)
+    recv_sem = (
+        deferred_recv.semaphore
+        if deferred_recv is not None
+        else device_fn.register_dma_semaphore(name_hint="remote_recv_sem")
+    )
     src_ref = _remote_ref_expr(
         state,
         src,
@@ -420,6 +484,15 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
         state.ast_args[4],
         REMOTE_DST_INDEXING_PATTERNS,
     )
+    if fori_loop is not None and drain_key is not None and deferred_recv is None:
+        ast_dst_index = state.ast_args[4]
+        assert isinstance(ast_dst_index, list)
+        canonical_ref = _canonical_recv_ref(dst_ref, len(ast_dst_index))
+        if canonical_ref is not None:
+            from ..tile_strategy import RemoteRecvDrain
+
+            deferred_recv = RemoteRecvDrain(recv_sem, canonical_ref)
+            fori_loop._remote_recv_drains[drain_key] = deferred_recv
     device_id = state.ast_args[2]
     if isinstance(device_id, int):
         device_id = expr_from_string(repr(device_id))
@@ -442,6 +515,7 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
     device_fn.remote_copy_descriptors[descriptor_id] = _PallasRemoteCopyInfo(
         op_name=op_name,
         source_materialization=materialization,
+        deferred_recv=deferred_recv,
     )
     return expr_from_string(op_name)
 
@@ -492,7 +566,34 @@ def _emit_wait(state: CodegenState, method: str) -> ast.AST:
     info = _paired_copy_info(state)
     if method == "start":
         _emit_source_materialization(state, info)
-    state.codegen.add_statement(statement_from_string(f"{info.op_name}.{method}()"))
+        if info.deferred_recv is not None:
+            fori_loop = _active_fori_loop(state)
+            if fori_loop is None:
+                info.deferred_recv = None
+            elif state.codegen.statements_stack[-1] is fori_loop.inner_statements:
+                info.deferred_recv.starts_per_iteration += 1
+            else:
+                counter = info.deferred_recv.dynamic_start_counter
+                if counter is None:
+                    counter = state.device_function.register_scratch(
+                        (128,), torch.int32, name_hint="remote_recv_count"
+                    )
+                    info.deferred_recv.dynamic_start_counter = counter
+                    fori_loop.outer_prefix.append(
+                        statement_from_string(
+                            f"{counter}[...] = jnp.zeros_like({counter}[...])"
+                        )
+                    )
+                state.codegen.add_statement(
+                    statement_from_string(
+                        f"{counter}[...] = {counter}[...] + "
+                        f"jnp.ones_like({counter}[...])"
+                    )
+                )
+    if method == "wait_recv" and info.deferred_recv is not None:
+        info.deferred_recv.waits_deferred = True
+    else:
+        state.codegen.add_statement(statement_from_string(f"{info.op_name}.{method}()"))
     return expr_from_string("None")
 
 

--- a/helion/_compiler/pallas/distributed_ops.py
+++ b/helion/_compiler/pallas/distributed_ops.py
@@ -28,6 +28,8 @@ from .plan_tiling import REMOTE_SRC_INDEXING_PATTERNS
 
 if TYPE_CHECKING:
     from ..inductor_lowering import CodegenState
+    from ..tile_strategy import ForiLoopState
+    from ..tile_strategy import RemoteRecvDrain
 
 
 _PALLAS_SRC_MATERIALIZATION_META = "_helion_pallas_remote_copy_src_materialization"
@@ -53,6 +55,7 @@ def _automatic_collective_id(fn: Callable[..., object]) -> int:
 class _PallasRemoteCopyInfo:
     op_name: str
     source_materialization: tuple[ast.AST, ast.AST] | None
+    deferred_recv: RemoteRecvDrain | None = None
 
 
 @_decorators.codegen(remote_barrier, "pallas")
@@ -162,6 +165,48 @@ def _direct_value_expr(tensor: ast.AST, ast_index: list[object]) -> ast.AST:
         placeholders[key] = value
         parts.append(f"{{{key}}}")
     return expr_from_string(f"{{tensor}}[{', '.join(parts)}]", **placeholders)
+
+
+def _canonical_recv_ref(dst_ref: ast.AST, indexed_dims: int) -> ast.AST | None:
+    """Return a fixed same-shaped destination region for a receive drain."""
+    if not isinstance(dst_ref, ast.Subscript):
+        return None
+    raw_parts = (
+        dst_ref.slice.elts if isinstance(dst_ref.slice, ast.Tuple) else [dst_ref.slice]
+    )
+    if len(raw_parts) < indexed_dims:
+        return None
+    placeholders: dict[str, ast.AST] = {"base": dst_ref.value}
+    rendered: list[str] = []
+    for index, part in enumerate(raw_parts):
+        key = f"part_{index}"
+        if index < indexed_dims:
+            if (
+                isinstance(part, ast.Call)
+                and isinstance(part.func, ast.Attribute)
+                and part.func.attr == "ds"
+                and len(part.args) >= 2
+            ):
+                part = expr_from_string("pl.ds(0, {size})", size=part.args[1])
+            else:
+                part = expr_from_string("0")
+        placeholders[key] = part
+        rendered.append(f"{{{key}}}")
+    return expr_from_string(f"{{base}}[{', '.join(rendered)}]", **placeholders)
+
+
+def _active_fori_loop(state: CodegenState) -> ForiLoopState | None:
+    from ..tile_strategy import ForiLoopState
+
+    return next(
+        (
+            loop
+            for loops in state.codegen.active_device_loops.values()
+            for loop in loops
+            if isinstance(loop, ForiLoopState)
+        ),
+        None,
+    )
 
 
 def _materialized_source_value(
@@ -395,7 +440,26 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
         if send_slot_shape
         else expr_from_string(send_sem_name)
     )
-    recv_sem = device_fn.register_dma_semaphore(name_hint="remote_recv_sem")
+    try:
+        payload_shape = tuple(int(size) for size in src.shape[len(proxy_src_index) :])
+    except (TypeError, ValueError):
+        payload_shape = ()
+    fori_loop = _active_fori_loop(state)
+    dst_name: str | None = None
+    drain_key: tuple[str, tuple[int, ...]] | None = None
+    deferred_recv: RemoteRecvDrain | None = None
+    if fori_loop is not None and payload_shape:
+        dst_name = _tensor_argument_name(state, dst)
+        if dst_name is not None:
+            read_names, _ = device_fn.get_tensor_read_write_names()
+            if dst_name not in read_names:
+                drain_key = (dst_name, payload_shape)
+                deferred_recv = fori_loop._remote_recv_drains.get(drain_key)
+    recv_sem = (
+        deferred_recv.semaphore
+        if deferred_recv is not None
+        else device_fn.register_dma_semaphore(name_hint="remote_recv_sem")
+    )
     src_ref = _remote_ref_expr(
         state,
         src,
@@ -417,6 +481,15 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
         state.ast_args[4],
         REMOTE_DST_INDEXING_PATTERNS,
     )
+    if fori_loop is not None and drain_key is not None and deferred_recv is None:
+        ast_dst_index = state.ast_args[4]
+        assert isinstance(ast_dst_index, list)
+        canonical_ref = _canonical_recv_ref(dst_ref, len(ast_dst_index))
+        if canonical_ref is not None:
+            from ..tile_strategy import RemoteRecvDrain
+
+            deferred_recv = RemoteRecvDrain(recv_sem, canonical_ref)
+            fori_loop._remote_recv_drains[drain_key] = deferred_recv
     device_id = state.ast_args[2]
     if isinstance(device_id, int):
         device_id = expr_from_string(repr(device_id))
@@ -439,6 +512,7 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
     device_fn.remote_copy_descriptors[descriptor_id] = _PallasRemoteCopyInfo(
         op_name=op_name,
         source_materialization=materialization,
+        deferred_recv=deferred_recv,
     )
     return expr_from_string(op_name)
 
@@ -489,7 +563,34 @@ def _emit_wait(state: CodegenState, method: str) -> ast.AST:
     info = _paired_copy_info(state)
     if method == "start":
         _emit_source_materialization(state, info)
-    state.codegen.add_statement(statement_from_string(f"{info.op_name}.{method}()"))
+        if info.deferred_recv is not None:
+            fori_loop = _active_fori_loop(state)
+            if fori_loop is None:
+                info.deferred_recv = None
+            elif state.codegen.statements_stack[-1] is fori_loop.inner_statements:
+                info.deferred_recv.starts_per_iteration += 1
+            else:
+                counter = info.deferred_recv.dynamic_start_counter
+                if counter is None:
+                    counter = state.device_function.register_scratch(
+                        (128,), torch.int32, name_hint="remote_recv_count"
+                    )
+                    info.deferred_recv.dynamic_start_counter = counter
+                    fori_loop.outer_prefix.append(
+                        statement_from_string(
+                            f"{counter}[...] = jnp.zeros_like({counter}[...])"
+                        )
+                    )
+                state.codegen.add_statement(
+                    statement_from_string(
+                        f"{counter}[...] = {counter}[...] + "
+                        f"jnp.ones_like({counter}[...])"
+                    )
+                )
+    if method == "wait_recv" and info.deferred_recv is not None:
+        info.deferred_recv.waits_deferred = True
+    else:
+        state.codegen.add_statement(statement_from_string(f"{info.op_name}.{method}()"))
     return expr_from_string("None")
 
 

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -4491,6 +4491,56 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             ):
                 state.codegen.add_statement(statement)
 
+    for drain in fori_state._remote_recv_drains.values():
+        if not drain.waits_deferred:
+            continue
+        assert drain.starts_per_iteration > 0 or drain.dynamic_start_counter is not None
+        recv_copy = state.device_function.new_var("_recv_drain", dce=False)
+        recv_index = state.device_function.new_var("_recv_index", dce=False)
+        loop_iterations = " * ".join(f"({part})" for part in grid_parts)
+        static_receive_count = (
+            "0"
+            if drain.starts_per_iteration == 0
+            else loop_iterations
+            if drain.starts_per_iteration == 1
+            else f"{drain.starts_per_iteration} * ({loop_iterations})"
+        )
+        receive_count = static_receive_count
+        if drain.dynamic_start_counter is not None:
+            dynamic_receive_count = f"{drain.dynamic_start_counter}[0]"
+            receive_count = (
+                dynamic_receive_count
+                if static_receive_count == "0"
+                else f"({static_receive_count}) + {dynamic_receive_count}"
+            )
+        fori_state.outer_suffix.append(
+            statement_from_string(
+                f"{recv_copy} = pltpu.make_async_copy({{reference}}, "
+                f"{{reference}}, {drain.semaphore})",
+                reference=drain.reference,
+            )
+        )
+        if drain.dynamic_start_counter is None:
+            fori_state.outer_suffix.append(
+                statement_from_string(
+                    f"for {recv_index} in range({receive_count}):\n"
+                    f"    {recv_copy}.wait()"
+                )
+            )
+        else:
+            recv_wait_body = state.device_function.new_var("_recv_wait_body", dce=False)
+            fori_state.outer_suffix.extend(
+                (
+                    statement_from_string(
+                        f"def {recv_wait_body}({recv_index}, _):\n"
+                        f"    {recv_copy}.wait()"
+                    ),
+                    statement_from_string(
+                        f"jax.lax.fori_loop(0, {receive_count}, {recv_wait_body}, None)"
+                    ),
+                )
+            )
+
     # Compact-worklist outer tile: it IS the grid (exactly one static compact
     # body per work item), so emit the body
     # straight-line with the loop var bound to 0 -- no fori_loop wrapper (which
@@ -4504,6 +4554,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         state.add_statement(statement_from_string(f"{loop_vars[0]} = 0"))
         for stmt in body_stmts or [ast.Pass()]:
             state.add_statement(stmt)
+        for statement in fori_state.outer_suffix:
+            state.add_statement(statement)
         return None
 
     if not static_unroll:
@@ -4531,6 +4583,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 current_body = [loop]
         for statement in current_body:
             state.add_statement(statement)
+        for statement in fori_state.outer_suffix:
+            state.add_statement(statement)
         if has_loop_state:
             return _read_final_loop_state(state, result_vars)
         return None
@@ -4553,6 +4607,9 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         else:
             # Inner: wrap in the next outer function's body
             current_body = [fn_def, *call_prefix, fori_call]
+
+    for statement in fori_state.outer_suffix:
+        state.add_statement(statement)
 
     # After fori_loop: read final loop-carried state from scratch
     if has_loop_state:

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3883,6 +3883,56 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             ):
                 state.codegen.add_statement(statement)
 
+    for drain in fori_state._remote_recv_drains.values():
+        if not drain.waits_deferred:
+            continue
+        assert drain.starts_per_iteration > 0 or drain.dynamic_start_counter is not None
+        recv_copy = state.device_function.new_var("_recv_drain", dce=False)
+        recv_index = state.device_function.new_var("_recv_index", dce=False)
+        loop_iterations = " * ".join(f"({part})" for part in grid_parts)
+        static_receive_count = (
+            "0"
+            if drain.starts_per_iteration == 0
+            else loop_iterations
+            if drain.starts_per_iteration == 1
+            else f"{drain.starts_per_iteration} * ({loop_iterations})"
+        )
+        receive_count = static_receive_count
+        if drain.dynamic_start_counter is not None:
+            dynamic_receive_count = f"{drain.dynamic_start_counter}[0]"
+            receive_count = (
+                dynamic_receive_count
+                if static_receive_count == "0"
+                else f"({static_receive_count}) + {dynamic_receive_count}"
+            )
+        fori_state.outer_suffix.append(
+            statement_from_string(
+                f"{recv_copy} = pltpu.make_async_copy({{reference}}, "
+                f"{{reference}}, {drain.semaphore})",
+                reference=drain.reference,
+            )
+        )
+        if drain.dynamic_start_counter is None:
+            fori_state.outer_suffix.append(
+                statement_from_string(
+                    f"for {recv_index} in range({receive_count}):\n"
+                    f"    {recv_copy}.wait()"
+                )
+            )
+        else:
+            recv_wait_body = state.device_function.new_var("_recv_wait_body", dce=False)
+            fori_state.outer_suffix.extend(
+                (
+                    statement_from_string(
+                        f"def {recv_wait_body}({recv_index}, _):\n"
+                        f"    {recv_copy}.wait()"
+                    ),
+                    statement_from_string(
+                        f"jax.lax.fori_loop(0, {receive_count}, {recv_wait_body}, None)"
+                    ),
+                )
+            )
+
     # Compact-worklist outer tile: it IS the grid (exactly one static compact
     # body per work item), so emit the body
     # straight-line with the loop var bound to 0 -- no fori_loop wrapper (which
@@ -3896,6 +3946,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         state.add_statement(statement_from_string(f"{loop_vars[0]} = 0"))
         for stmt in body_stmts or [ast.Pass()]:
             state.add_statement(stmt)
+        for statement in fori_state.outer_suffix:
+            state.add_statement(statement)
         return None
 
     if not static_unroll:
@@ -3923,6 +3975,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 current_body = [loop]
         for statement in current_body:
             state.add_statement(statement)
+        for statement in fori_state.outer_suffix:
+            state.add_statement(statement)
         if has_loop_state:
             return _read_final_loop_state(state, result_vars)
         return None
@@ -3945,6 +3999,9 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         else:
             # Inner: wrap in the next outer function's body
             current_body = [fn_def, *call_prefix, fori_call]
+
+    for statement in fori_state.outer_suffix:
+        state.add_statement(statement)
 
     # After fori_loop: read final loop-carried state from scratch
     if has_loop_state:

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1865,6 +1865,17 @@ class EmitPipelineLoopState(DeviceLoopOrGridState):
 
 
 @dataclasses.dataclass
+class RemoteRecvDrain:
+    """Deferred receive completions for one looped destination payload."""
+
+    semaphore: str
+    reference: ast.AST
+    starts_per_iteration: int = 0
+    dynamic_start_counter: str | None = None
+    waits_deferred: bool = False
+
+
+@dataclasses.dataclass
 class ForiLoopState(DeviceLoopOrGridState):
     """State for fori_loop-based loops on TPU (Pallas backend).
 
@@ -1887,6 +1898,9 @@ class ForiLoopState(DeviceLoopOrGridState):
     _prefetched_load_tensors: set[str] = dataclasses.field(default_factory=set)
     _memory_op_to_dma_scratch: dict[torch.fx.Node, DmaResources] = dataclasses.field(
         default_factory=dict
+    )
+    _remote_recv_drains: dict[tuple[str, tuple[int, ...]], RemoteRecvDrain] = (
+        dataclasses.field(default_factory=dict)
     )
 
 

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1864,6 +1864,17 @@ class EmitPipelineLoopState(DeviceLoopOrGridState):
 
 
 @dataclasses.dataclass
+class RemoteRecvDrain:
+    """Deferred receive completions for one looped destination payload."""
+
+    semaphore: str
+    reference: ast.AST
+    starts_per_iteration: int = 0
+    dynamic_start_counter: str | None = None
+    waits_deferred: bool = False
+
+
+@dataclasses.dataclass
 class ForiLoopState(DeviceLoopOrGridState):
     """State for fori_loop-based loops on TPU (Pallas backend).
 
@@ -1884,6 +1895,9 @@ class ForiLoopState(DeviceLoopOrGridState):
     _tensor_to_dma_scratch: dict[str, str] = dataclasses.field(default_factory=dict)
     _tensor_to_sem: dict[str, str] = dataclasses.field(default_factory=dict)
     _prefetched_load_tensors: set[str] = dataclasses.field(default_factory=set)
+    _remote_recv_drains: dict[tuple[str, tuple[int, ...]], RemoteRecvDrain] = (
+        dataclasses.field(default_factory=dict)
+    )
 
 
 @dataclasses.dataclass

--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -358,6 +358,39 @@ def _computed_fp8_remote_copy(
 
 @helion.kernel(
     static_shapes=True,
+    config=helion.Config(
+        block_sizes=[],
+        pallas_load_buffer_count=[1, 1, 1, 2],
+        pallas_loop_type="unroll",
+    ),
+)
+def _conditional_tail_receive_copy(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    peers: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Start conditionally but request receive completion only at the tail."""
+    num_steps = hl.specialize(src.size(1))
+    for _program in hl.grid(1):
+        for step in hl.tile(num_steps, block_size=1):
+            if step.begin > 0:
+                copy = hl.make_async_remote_copy(
+                    src,
+                    [0, step.begin],
+                    peers[0, step.begin],
+                    dst=dst,
+                    dst_index=[0, positions[0, step.begin], step.begin],
+                )
+                copy.start()
+                copy.wait_send()
+                if step.begin + 2 >= num_steps:
+                    copy.wait_recv()
+    return dst
+
+
+@helion.kernel(
+    static_shapes=True,
     config=helion.Config(block_sizes=[]),
 )
 def _parent_store_nested_remote_copy(
@@ -1408,6 +1441,110 @@ class TestRemoteCopyJaxRuntime(TestCase):
         expected[1, 0] = payload[0]
         for _invocation in range(2):
             result = np.asarray(jax.block_until_ready(copy(*inputs))).astype(np.float32)
+            np.testing.assert_array_equal(result, expected)
+
+    def test_conditional_tail_receive_drain_codegen(self) -> None:
+        args = (
+            torch.zeros(1, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, 2, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+        )
+        source = _conditional_tail_receive_copy.bind(args).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        self.assertIn("remote_recv_count", source)
+        self.assertIn("jnp.zeros_like(remote_recv_count", source)
+        self.assertIn("def _recv_wait_body", source)
+        self.assertRegex(
+            source,
+            r"jax\.lax\.fori_loop\(0, remote_recv_count(?:_\d+)?\[0\]",
+        )
+        self.assertNotRegex(
+            source,
+            r"remote_copy(?:_\d+)?\.wait_recv\(\)",
+        )
+
+    @skipIfPallasInterpret("deferred receive drains require TPU DMA lowering")
+    def test_conditional_tail_receive_drain(self) -> None:
+        import types
+
+        import jax
+        import jax.numpy as jnp
+
+        devices = [device for device in jax.local_devices() if device.platform == "tpu"]
+        if len(devices) < 2:
+            self.skipTest("requires at least two TPU devices")
+
+        args = (
+            torch.zeros(1, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, 2, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+        )
+        source = _conditional_tail_receive_copy.bind(args).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        name = "precompiled_conditional_tail_receive_copy_test"
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+        self.addCleanup(sys.modules.pop, name, None)
+        exec(compile(source, name, "exec"), module.__dict__)
+
+        world_size = 2
+        mesh = jax.make_mesh((world_size,), ("peer",), devices=devices[:world_size])
+        partition = jax.sharding.PartitionSpec
+        src_spec = partition("peer", None, None)
+        dst_spec = partition("peer", None, None, None)
+        metadata_spec = partition("peer", None)
+        ranks = jnp.arange(world_size, dtype=jnp.float32)[:, None, None]
+        steps = jnp.arange(_PIPELINE_STEPS, dtype=jnp.float32)[None, :, None]
+        columns = jnp.arange(_WIDTH, dtype=jnp.float32)[None, None, :]
+        src = ranks * 1000 + steps * 100 + columns
+        dst = jnp.full(
+            (world_size, world_size, _PIPELINE_STEPS, _WIDTH),
+            -7.0,
+            dtype=jnp.float32,
+        )
+        peers = jnp.broadcast_to(
+            (1 - jnp.arange(world_size, dtype=jnp.int32))[:, None],
+            (world_size, _PIPELINE_STEPS),
+        )
+        positions = jnp.broadcast_to(
+            jnp.arange(world_size, dtype=jnp.int32)[:, None],
+            (world_size, _PIPELINE_STEPS),
+        )
+        specs = (src_spec, dst_spec, metadata_spec, metadata_spec)
+        inputs = tuple(
+            jax.device_put(value, jax.sharding.NamedSharding(mesh, spec))
+            for value, spec in zip((src, dst, peers, positions), specs, strict=True)
+        )
+        copy = jax.jit(
+            jax.shard_map(
+                module._conditional_tail_receive_copy,
+                mesh=mesh,
+                in_specs=specs,
+                out_specs=dst_spec,
+                check_vma=False,
+            )
+        )
+
+        expected = np.full(
+            (world_size, world_size, _PIPELINE_STEPS, _WIDTH),
+            -7.0,
+            dtype=np.float32,
+        )
+        src_host = np.asarray(src)
+        expected[0, 1, 1:] = src_host[1, 1:]
+        expected[1, 0, 1:] = src_host[0, 1:]
+        for _invocation in range(2):
+            result = np.asarray(jax.block_until_ready(copy(*inputs)))
             np.testing.assert_array_equal(result, expected)
 
     @skipIfPallasInterpret("nested remote copies require TPU DMA lowering")

--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -358,6 +358,39 @@ def _computed_fp8_remote_copy(
 
 @helion.kernel(
     static_shapes=True,
+    config=helion.Config(
+        block_sizes=[],
+        pallas_load_buffer_count=[1, 1, 1, 2],
+        pallas_loop_type="unroll",
+    ),
+)
+def _conditional_tail_receive_copy(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    peers: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Start conditionally but request receive completion only at the tail."""
+    num_steps = hl.specialize(src.size(1))
+    for _program in hl.grid(1):
+        for step in hl.tile(num_steps, block_size=1):
+            if step.begin > 0:
+                copy = hl.make_async_remote_copy(
+                    src,
+                    [0, step.begin],
+                    peers[0, step.begin],
+                    dst=dst,
+                    dst_index=[0, positions[0, step.begin], step.begin],
+                )
+                copy.start()
+                copy.wait_send()
+                if step.begin + 2 >= num_steps:
+                    copy.wait_recv()
+    return dst
+
+
+@helion.kernel(
+    static_shapes=True,
     config=helion.Config(block_sizes=[]),
 )
 def _parent_store_nested_remote_copy(
@@ -1598,6 +1631,85 @@ class TestRemoteCopyJaxRuntime(TestCase):
         expected[1, 0] = payload[0]
         for _invocation in range(2):
             result = np.asarray(jax.block_until_ready(copy(*inputs))).astype(np.float32)
+            np.testing.assert_array_equal(result, expected)
+
+    @skipIfPallasInterpret("deferred receive drains require TPU DMA lowering")
+    def test_conditional_tail_receive_drain(self) -> None:
+        import types
+
+        import jax
+        import jax.numpy as jnp
+
+        devices = [device for device in jax.local_devices() if device.platform == "tpu"]
+        if len(devices) < 2:
+            self.skipTest("requires at least two TPU devices")
+
+        args = (
+            torch.zeros(1, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, 2, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+        )
+        source = _conditional_tail_receive_copy.bind(args).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        name = "precompiled_conditional_tail_receive_copy_test"
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+        self.addCleanup(sys.modules.pop, name, None)
+        exec(compile(source, name, "exec"), module.__dict__)
+
+        world_size = 2
+        mesh = jax.make_mesh((world_size,), ("peer",), devices=devices[:world_size])
+        partition = jax.sharding.PartitionSpec
+        src_spec = partition("peer", None, None)
+        dst_spec = partition("peer", None, None, None)
+        metadata_spec = partition("peer", None)
+        ranks = jnp.arange(world_size, dtype=jnp.float32)[:, None, None]
+        steps = jnp.arange(_PIPELINE_STEPS, dtype=jnp.float32)[None, :, None]
+        columns = jnp.arange(_WIDTH, dtype=jnp.float32)[None, None, :]
+        src = ranks * 1000 + steps * 100 + columns
+        dst = jnp.full(
+            (world_size, world_size, _PIPELINE_STEPS, _WIDTH),
+            -7.0,
+            dtype=jnp.float32,
+        )
+        peers = jnp.broadcast_to(
+            (1 - jnp.arange(world_size, dtype=jnp.int32))[:, None],
+            (world_size, _PIPELINE_STEPS),
+        )
+        positions = jnp.broadcast_to(
+            jnp.arange(world_size, dtype=jnp.int32)[:, None],
+            (world_size, _PIPELINE_STEPS),
+        )
+        specs = (src_spec, dst_spec, metadata_spec, metadata_spec)
+        inputs = tuple(
+            jax.device_put(value, jax.sharding.NamedSharding(mesh, spec))
+            for value, spec in zip((src, dst, peers, positions), specs, strict=True)
+        )
+        copy = jax.jit(
+            jax.shard_map(
+                module._conditional_tail_receive_copy,
+                mesh=mesh,
+                in_specs=specs,
+                out_specs=dst_spec,
+                check_vma=False,
+            )
+        )
+
+        expected = np.full(
+            (world_size, world_size, _PIPELINE_STEPS, _WIDTH),
+            -7.0,
+            dtype=np.float32,
+        )
+        src_host = np.asarray(src)
+        expected[0, 1, 1:] = src_host[1, 1:]
+        expected[1, 0, 1:] = src_host[0, 1:]
+        for _invocation in range(2):
+            result = np.asarray(jax.block_until_ready(copy(*inputs)))
             np.testing.assert_array_equal(result, expected)
 
     @skipIfPallasInterpret("nested remote copies require TPU DMA lowering")


### PR DESCRIPTION
Stacked PRs:
 * #3405
 * __->__#3396
 * #3394
 * #3402
 * #3401
 * #3407
 * #3403
 * #3399
 * #3397
 * #3408
 * #3387
 * #3392
 * #3391


--- --- ---

### [Pallas] Drain looped remote receives after the loop


A remote-copy descriptor inside a device loop may start more transfers than the
source-level tail contains `wait_recv()` calls. Pallas receive semaphores retain
one payload signal per transfer, so waiting only on tail iterations leaves a
nonzero semaphore at kernel exit.

For example:

```python
for step in hl.tile(num_steps, block_size=1):
    if step.begin > 0:
        copy = hl.make_async_remote_copy(
            src,
            [0, step.begin],
            peers[0, step.begin],
            dst=dst,
            dst_index=[0, positions[0, step.begin], step.begin],
        )
        copy.start()
        copy.wait_send()
        if step.begin + 2 >= num_steps:
            copy.wait_recv()
```

With four steps, this starts three receives but executes only two receive waits.
The old generated code kept those waits in the tail branches and the TPU halted
at kernel exit:

```
Semaphore (scratch argument 2) has a nonzero value upon exit from a Mosaic
kernel. Make sure every DMA is awaited, and every semaphore signal is paired
with a wait.
```

For a write-only destination inside a fori/static-unroll lowering, track a
receive-completion stream by destination and payload shape. If the source asks
for receive completion, remove its in-loop `wait_recv()` calls and drain every
actual start after the loop.

An unconditional descriptor site records a static starts-per-iteration count.
A descriptor nested under control flow uses a small compiler-owned counter, so
only branches that execute contribute to the drain:

```python
remote_recv_count[...] = jnp.zeros_like(remote_recv_count[...])

for step in range(num_steps):
    if step > 0:
        copy.start()
        remote_recv_count[...] += jnp.ones_like(remote_recv_count[...])
        ...

recv_drain = pltpu.make_async_copy(
    canonical_destination,
    canonical_destination,
    remote_recv_sem,
)

def recv_wait_body(_, carry):
    recv_drain.wait()

jax.lax.fori_loop(0, remote_recv_count[0], recv_wait_body, None)
```

The canonical destination has the same payload shape but replaces loop-varying
scalar indices with zero, so the synthetic descriptor consumes the correct
number of receive bytes without depending on a descriptor variable scoped
inside the loop.

This both restores correctness and moves receive completion out of the steady
state, allowing the DMA tail to overlap the remaining loop computation. The
optimization is conservative:

* the destination must not be read by the kernel;
* payload shape must be statically known;
* the source must contain an explicit `wait_recv()` request;
* ordinary combined `wait()` calls and non-loop copies remain unchanged.

There is no API change. The fused RMSNorm/QKVOG/all-to-all source now generates
three dynamic post-loop drains, one for each Q, KV, and OG receive stream.

The distributed test executes the conditional receive pipeline twice and compares every output element exactly.

The generated standalone artifact was also executed twice across the full
two-host, 16-device TPU mesh. Each process validated all eight addressable
shards exactly, and every DMA semaphore was zero at kernel exit:

```
16 local_shards 8 exact True runs 2
```
