### PR TITLE
[Pallas] Refill single-buffer matmul windows after use

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -359,6 +359,14 @@ class DeviceFunction:
         # nested control-flow graphs.
         self.pallas_remote_copy_tensor_ids: set[int] = set()
         self.pallas_remote_copy_storage_ids: set[int] = set()
+        # Read-only inputs selected for explicit local HBM-to-VMEM DMA at
+        # their load sites, rather than launcher-managed VMEM BlockSpecs.
+        self.pallas_direct_hbm_load_tensor_ids: set[int] = set()
+        self.pallas_hoisted_direct_dma_copy_names: set[str] = set()
+        # Body-local ``torch.empty`` tensors that are read and written but do
+        # not escape the kernel return can live entirely in compiler-managed
+        # VMEM scratch instead of becoming hidden HBM in/out arguments.
+        self.pallas_internal_scratch_storage_names: dict[int, str] = {}
         # Pallas: id(fake_tensor) → memory space, determined during
         # tracing (HBM for pipeline) and codegen (SMEM for scalar access).
         # NOTE: Currently each tensor can only have one memory space.
@@ -392,6 +400,18 @@ class DeviceFunction:
             id(tensor) in self.pallas_remote_copy_tensor_ids
             or id(tensor.untyped_storage()) in self.pallas_remote_copy_storage_ids
         )
+
+    def is_pallas_direct_hbm_load(self, tensor: torch.Tensor) -> bool:
+        return id(tensor) in self.pallas_direct_hbm_load_tensor_ids
+
+    def pallas_internal_scratch_name(self, tensor: torch.Tensor) -> str | None:
+        return self.pallas_internal_scratch_storage_names.get(
+            id(tensor.untyped_storage())
+        )
+
+    def pallas_tensor_ref_name(self, tensor: torch.Tensor) -> str:
+        scratch = self.pallas_internal_scratch_name(tensor)
+        return scratch if scratch is not None else self.tensor_arg(tensor).name
 
     def allocate_store_index(self) -> int:
         """Bump store counters and return the indexing strategy slot."""
@@ -878,7 +898,14 @@ class DeviceFunction:
 
     def sorted_args(self) -> list[Argument]:
         self.arguments.sort(key=lambda arg: arg.sort_key())
-        return self.arguments
+        return [
+            arg
+            for arg in self.arguments
+            if not (
+                isinstance(arg, TensorArg)
+                and self.pallas_internal_scratch_name(arg.fake_value) is not None
+            )
+        ]
 
     def codegen_function_def(self) -> list[ast.stmt]:
         prefix = []

--- a/helion/_compiler/helper_function.py
+++ b/helion/_compiler/helper_function.py
@@ -20,6 +20,7 @@ from .ast_extension import statement_from_string
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from collections.abc import Sequence
     import types
 
     from torch.fx.node import Node
@@ -33,6 +34,8 @@ class CodegenInterface(ABC):
 
     def __init__(self, device_function: DeviceFunction) -> None:
         self.device_function = device_function
+        self._pre_node_statements: dict[int, list[ast.AST]] = {}
+        self._post_node_statements: dict[int, list[ast.AST]] = {}
 
     @abstractmethod
     def add_statement(self, stmt: ast.AST | str | None) -> None:
@@ -41,6 +44,20 @@ class CodegenInterface(ABC):
     @contextlib.contextmanager
     def statement_owner_node(self, node: Node) -> Iterator[None]:
         yield
+
+    def add_pre_node_statements(
+        self, node: Node, statements: Sequence[ast.AST]
+    ) -> None:
+        self._pre_node_statements.setdefault(id(node), []).extend(statements)
+
+    def add_post_node_statement(self, node: Node, statement: ast.AST) -> None:
+        self._post_node_statements.setdefault(id(node), []).append(statement)
+
+    def pop_pre_node_statements(self, node: Node) -> list[ast.AST]:
+        return self._pre_node_statements.pop(id(node), [])
+
+    def pop_post_node_statements(self, node: Node) -> list[ast.AST]:
+        return self._post_node_statements.pop(id(node), [])
 
     def tmpvar(self, *, dce: bool = False, prefix: str = "v") -> str:
         """Generate a temporary variable name."""

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -1482,6 +1482,8 @@ class GraphInterpreter(LoweringContext, Interpreter):
                 V.set_current_node(n),
             ):
                 try:
+                    for statement in self.cg.pop_pre_node_statements(n):
+                        self.cg.add_statement(statement)
                     cute_state = self.cg.device_function.cute_state
                     if cute_state.has_tcgen05_fragment_epilogue_plan:
                         if cute_state.is_deferred_tcgen05_fragment_epilogue_node(n):
@@ -1544,6 +1546,8 @@ class GraphInterpreter(LoweringContext, Interpreter):
                                 self.cg.device_function.expr_to_var_info[expr] = (
                                     VarInfo(repr(result.value), n)
                                 )
+                        for statement in self.cg.pop_post_node_statements(n):
+                            self.cg.add_statement(statement)
                         return result
                     if not isinstance(result, (ast.Name, ast.Constant)):
                         self.cg.add_statement(create(ast.Expr, value=result))

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -1501,6 +1501,8 @@ class GraphInterpreter(LoweringContext, Interpreter):
                 V.set_current_node(n),
             ):
                 try:
+                    for statement in self.cg.pop_pre_node_statements(n):
+                        self.cg.add_statement(statement)
                     cute_state = self.cg.device_function.cute_state
                     if cute_state.has_tcgen05_pair_epilogue_plan:
                         if cute_state.is_deferred_tcgen05_pair_epilogue_node(n):
@@ -1563,6 +1565,8 @@ class GraphInterpreter(LoweringContext, Interpreter):
                                 self.cg.device_function.expr_to_var_info[expr] = (
                                     VarInfo(repr(result.value), n)
                                 )
+                        for statement in self.cg.pop_post_node_statements(n):
+                            self.cg.add_statement(statement)
                         return result
                     if not isinstance(result, (ast.Name, ast.Constant)):
                         self.cg.add_statement(create(ast.Expr, value=result))

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1518,6 +1518,9 @@ class PallasBackend(Backend):
 
         env = CompileEnvironment.current()
 
+        from .internal_scratch import plan_internal_remote_scratch
+
+        plan_internal_remote_scratch()
         plan_tiling(graphs, config, tile_strategy)
         build_tensorcore_plans(graphs, config)
 

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -360,9 +360,15 @@ class PallasBackend(Backend):
         tensor_host_args: list[str],
     ) -> str:
         from ..device_function import SymbolArgument
+        from ..device_function import TensorArg
         from ..device_function import TensorSizeArg
         from ..device_function import TensorStrideArg
 
+        if isinstance(arg, TensorArg) and arg.fake_value.ndim == 0:
+            # Mosaic requires every Pallas input to have rank >= 1. Preserve a
+            # host scalar tensor as a one-element input; its device users load
+            # element zero explicitly.
+            return f"{host_str}.reshape(1)"
         if isinstance(arg, (SymbolArgument, TensorSizeArg, TensorStrideArg)):
             from ..compile_environment import CompileEnvironment
 

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 def _load_route(
     state: CodegenState, tensor: torch.Tensor
 ) -> tuple[str, str, list[object]]:
-    arg_name = state.device_function.tensor_arg(tensor).name
+    arg_name = state.device_function.pallas_tensor_ref_name(tensor)
     active_name = vmem_name(state, arg_name)
     state.device_function.device_load_index += 1
     state.device_function.device_memory_op_index += 1

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -755,6 +755,10 @@ def _generated_index_code(
     if isinstance(pattern, TensorIndexPattern):
         if tensor_indices_are_scalars:
             return _index_expr_from_ast(state, subscript_index, ast_subscripts)
+        if pattern.index_ndim == 0:
+            assert isinstance(idx, torch.Tensor)
+            scalar_arg = state.device_function.tensor_arg(idx)
+            return f"{scalar_arg.name}[0]"
         from helion._compiler.pallas.tensorcore_plan import TENSORCORE_PLAN_META
         from helion._compiler.pallas.tensorcore_plan import TensorCorePlan
 

--- a/helion/_compiler/pallas/distributed_ops.py
+++ b/helion/_compiler/pallas/distributed_ops.py
@@ -162,7 +162,7 @@ def _remote_ref_expr(
     assert isinstance(proxy_index, (list, tuple))
     assert isinstance(ast_index, list)
     try:
-        name = state.device_function.tensor_arg(tensor).name
+        name = state.device_function.pallas_tensor_ref_name(tensor)
     except KeyError:
         if not materialize_device_value:
             raise exc.TypeInferenceError(

--- a/helion/_compiler/pallas/internal_scratch.py
+++ b/helion/_compiler/pallas/internal_scratch.py
@@ -1,0 +1,158 @@
+"""Plan body-local tensors that can remain entirely in TPU VMEM."""
+
+from __future__ import annotations
+
+import ast
+
+import torch
+
+from ... import exc
+from ...language import distributed_ops
+from ...language import memory_ops
+from ...language.atomic_ops import ATOMIC_OPS
+from ..compile_environment import CompileEnvironment
+from ..device_function import DeviceFunction
+from ..host_function import HostFunction
+
+_EMPTY_FACTORIES = frozenset({"empty", "empty_like", "new_empty"})
+
+
+def _top_level_empty_names(host: HostFunction) -> set[str]:
+    names: set[str] = set()
+    for statement in host.body:
+        if (
+            isinstance(statement, ast.Assign)
+            and len(statement.targets) == 1
+            and isinstance(statement.targets[0], ast.Name)
+            and isinstance(statement.value, ast.Call)
+            and isinstance(statement.value.func, ast.Attribute)
+            and statement.value.func.attr in _EMPTY_FACTORIES
+        ):
+            names.add(statement.targets[0].id)
+    return names
+
+
+def _returned_name_dependencies(host: HostFunction) -> set[str]:
+    """Conservatively find every host name that can feed the return value."""
+    escaped: set[str] = set()
+    dependencies: dict[str, set[str]] = {}
+    module = ast.Module(body=host.body, type_ignores=[])
+    for node in ast.walk(module):
+        if isinstance(node, ast.Return) and node.value is not None:
+            escaped.update(
+                child.id
+                for child in ast.walk(node.value)
+                if isinstance(child, ast.Name)
+            )
+        elif (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            dependencies.setdefault(node.targets[0].id, set()).update(
+                child.id
+                for child in ast.walk(node.value)
+                if isinstance(child, ast.Name)
+            )
+
+    pending = list(escaped)
+    while pending:
+        name = pending.pop()
+        for dependency in dependencies.get(name, ()):
+            if dependency not in escaped:
+                escaped.add(dependency)
+                pending.append(dependency)
+    return escaped
+
+
+def _tensor_storage(node: object) -> int | None:
+    if not isinstance(node, torch.fx.Node):
+        return None
+    value = node.meta.get("val")
+    return id(value.untyped_storage()) if isinstance(value, torch.Tensor) else None
+
+
+def _accessed_storages(
+    device_fn: DeviceFunction,
+) -> tuple[set[int], set[int], set[int]]:
+    read: set[int] = set()
+    written: set[int] = set()
+    remote: set[int] = set()
+    for graph_info in device_fn.codegen.codegen_graphs:
+        for node in graph_info.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target is memory_ops.load:
+                if (storage := _tensor_storage(node.args[0])) is not None:
+                    read.add(storage)
+            elif node.target is memory_ops.store:
+                if (storage := _tensor_storage(node.args[0])) is not None:
+                    written.add(storage)
+            elif node.target in ATOMIC_OPS:
+                if (storage := _tensor_storage(node.args[0])) is not None:
+                    read.add(storage)
+                    written.add(storage)
+            elif node.target is distributed_ops.make_async_remote_copy:
+                if len(node.args) != 5:
+                    raise exc.InternalError(
+                        RuntimeError(
+                            "remote copy was not normalized to its five-argument form"
+                        )
+                    )
+                if (storage := _tensor_storage(node.args[0])) is not None:
+                    read.add(storage)
+                    remote.add(storage)
+                if (storage := _tensor_storage(node.args[3])) is not None:
+                    written.add(storage)
+                    remote.add(storage)
+    return read, written, remote
+
+
+def plan_internal_remote_scratch() -> None:
+    """Place private, body-local remote-copy buffers in VMEM scratch.
+
+    The transformation is intentionally narrow. An allocation must be a
+    top-level ``torch.empty``-family call, have a fully static shape, be both
+    read and written, participate in remote DMA, and not feed the host return.
+    """
+    host = HostFunction.current()
+    device_fn = DeviceFunction.current()
+    allocation_names = _top_level_empty_names(host) - _returned_name_dependencies(host)
+    if not allocation_names:
+        return
+
+    read, written, remote = _accessed_storages(device_fn)
+    eligible_storages = read & written & remote
+    if not eligible_storages:
+        return
+
+    input_storages = {
+        id(tensor.untyped_storage())
+        for tensor in CompileEnvironment.current().input_sources
+    }
+    tensors_by_storage: dict[int, list[torch.Tensor]] = {}
+    names_by_storage: dict[int, str] = {}
+    for tensor, origin in host.tensor_to_origin.items():
+        try:
+            name = origin.host_str()
+        except RuntimeError:
+            continue
+        storage = id(tensor.untyped_storage())
+        if (
+            name not in allocation_names
+            or storage in input_storages
+            or storage not in eligible_storages
+            or not all(isinstance(size, int) for size in tensor.shape)
+        ):
+            continue
+        tensors_by_storage.setdefault(storage, []).append(tensor)
+        names_by_storage[storage] = name
+
+    for storage, tensors in tensors_by_storage.items():
+        representative = max(tensors, key=lambda tensor: (tensor.ndim, tensor.numel()))
+        scratch_name = device_fn.register_scratch(
+            tuple(representative.shape),
+            representative.dtype,
+            name_hint=names_by_storage[storage],
+        )
+        device_fn.pallas_internal_scratch_storage_names[storage] = scratch_name

--- a/helion/_compiler/pallas/memory_access.py
+++ b/helion/_compiler/pallas/memory_access.py
@@ -111,11 +111,14 @@ def indirect_access(access: MemoryAccess) -> IndirectAccess | None:
 
 
 def tensor_index_positions(access: MemoryAccess) -> tuple[int, ...]:
-    """Return all tensor-indexed subscript positions."""
+    """Return positions that require an indirect tensor access plan.
+
+    Rank-zero tensor indices are scalar addresses and use ordinary Ref indexing.
+    """
     from .plan_tiling import TensorIndexPattern
 
     return tuple(
         position
         for position, pattern in enumerate(access.patterns)
-        if isinstance(pattern, TensorIndexPattern)
+        if isinstance(pattern, TensorIndexPattern) and pattern.index_ndim > 0
     )

--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -39,7 +39,8 @@ def _(state: CodegenState) -> None:
     value = state.ast_arg(2)
     assert isinstance(tensor, torch.Tensor)
     arg_name = state.device_function.tensor_arg(tensor).name
-    name = pallas_codegen.vmem_name(state, arg_name)
+    name = state.device_function.pallas_tensor_ref_name(tensor)
+    name = pallas_codegen.vmem_name(state, name)
     # Increment memory op index to stay in sync with triton backend
     device_fn = state.device_function
     device_fn.device_store_index += 1

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -75,6 +75,8 @@ class NonePattern(IndexingPattern):
 class TensorIndexPattern(IndexingPattern):
     """Tensor-valued index - no tiling. Resolved for indirect load/store codegen."""
 
+    index_ndim: int = 1
+
 
 @dataclass
 class ContiguousRangeIndexPattern(IndexingPattern):
@@ -735,7 +737,7 @@ def _detect_indexing_pattern(
         # A tensor-valued index that didn't match any arithmetic-of-tile
         # pattern is an indirect gather (e.g. table[idx, :]).
         if isinstance(idx_val, torch.Tensor):
-            return TensorIndexPattern()
+            return TensorIndexPattern(index_ndim=idx_val.ndim)
         # Indices produced by other FX nodes, such as indices[tile] used in
         # tensor-indexed atomics, are legal but cannot participate in Pallas
         # tiling.

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3377,6 +3377,12 @@ def _classify_pipelined_tensors(
     for (fake, sub_meta, direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
+        if state.device_function.pallas_internal_scratch_name(fake) is not None:
+            # This tensor already names a VMEM allocation owned by the kernel.
+            # Routing it through the inner-loop HBM DMA path would allocate a
+            # second VMEM buffer and emit pointless copies from an HBM argument
+            # that no longer exists.
+            continue
         if direction == "load":
             first_load = loaded_tensors[id(fake)][1]
             if int(first_load.meta.get(_PALLAS_LOOP_LOAD_COUNT_META, 1)) > 1:

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3708,6 +3708,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     dma_stores: list[ScheduledDmaTransfer] = []
     scheduled_by_hbm_name: dict[str, ScheduledDmaTransfer] = {}
     memory_op_to_dma_scratch: dict[torch.fx.Node, DmaResources] = {}
+    refilled_load_tensors: set[str] = set()
+    refilled_loads: list[tuple[ScheduledDmaTransfer, torch.fx.Node, torch.fx.Node]] = []
     # compact_worklist shares this lowering but keeps its compact/resident routes.
     # Ordinary fori loops and explicitly buffered static unrolls honor the
     # per-input depth; other callers keep the historical single-buffer route.
@@ -3841,6 +3843,22 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             prefetched_loads.append(scheduled)
         elif isinstance(transfer, IndirectDmaTransfer):
             immediate_loads.append(scheduled)
+        elif (
+            load_buffer_counts_active
+            and transfer.direction == "load"
+            and len(block_ids) == 1
+            and id(fake) in contiguous_ranges
+        ):
+            load_node = loaded_tensors[id(fake)][1]
+            users = list(load_node.users)
+            if (
+                len(users) == 1
+                and users[0].op == "call_function"
+                and users[0].target
+                in (torch.ops.aten.mm.default, torch.ops.aten.bmm.default)
+            ):
+                refilled_load_tensors.add(hbm_name)
+                refilled_loads.append((scheduled, load_node, users[0]))
 
     # ``all_tensor_info`` represents a read-modify-write tensor only by its
     # store record so that its load and store share one VMEM buffer. Build
@@ -3849,7 +3867,11 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     for fake, _tensor_node, sub_meta in loaded_tensors.values():
         hbm_name = state.device_function.tensor_arg(fake).name
         scheduled = scheduled_by_hbm_name.get(hbm_name)
-        if scheduled is None or hbm_name in prefetched_load_tensors:
+        if (
+            scheduled is None
+            or hbm_name in prefetched_load_tensors
+            or hbm_name in refilled_load_tensors
+        ):
             continue
         immediate_loads.append(
             ScheduledDmaTransfer(
@@ -4236,7 +4258,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     prime_statements: list[ast.stmt] = []
     body_prefetch: ast.FunctionDef | None = None
     body_current_stage_waits: list[ast.stmt] = []
-    if prefetched_loads:
+    if prefetched_loads or refilled_loads:
         num_iterations = state.device_function.new_var("_num_iterations")
         prime_statements.append(
             statement_from_string(f"{num_iterations} = {grid_parts[-1]}")
@@ -4249,6 +4271,15 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             prime_starts.extend(
                 _dma_transfer_statements(transfer, prime_indices, "0", ("start",))
             )
+        for transfer, _load_node, _consumer in refilled_loads:
+            prime_starts.extend(
+                _dma_transfer_statements(
+                    transfer,
+                    prime_indices,
+                    None,
+                    ("start",),
+                )
+            )
         prime_statements.append(
             _guarded_statements(
                 f"{num_iterations} > 0", "_prime_fori_loads", prime_starts
@@ -4259,22 +4290,47 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         next_iteration = f"({stage_loop_var} + 1)"
         next_indices = [*loop_vars]
         next_indices[-1] = next_iteration
-        next_stage = f"{next_iteration} % 2"
-        next_starts: list[ast.stmt] = []
-        for transfer in prefetched_loads:
-            next_starts.extend(
-                _dma_transfer_statements(transfer, next_indices, next_stage, ("start",))
+        if prefetched_loads:
+            next_stage = f"{next_iteration} % 2"
+            next_starts: list[ast.stmt] = []
+            for transfer in prefetched_loads:
+                next_starts.extend(
+                    _dma_transfer_statements(
+                        transfer, next_indices, next_stage, ("start",)
+                    )
+                )
+            body_prefetch = _guarded_statements(
+                f"{next_iteration} < {num_iterations}",
+                "_prefetch_fori_loads",
+                next_starts,
             )
-        body_prefetch = _guarded_statements(
-            f"{next_iteration} < {num_iterations}",
-            "_prefetch_fori_loads",
-            next_starts,
-        )
 
-        current_stage = f"{stage_loop_var} % 2"
-        for transfer in prefetched_loads:
-            body_current_stage_waits.extend(
-                _dma_transfer_statements(transfer, loop_vars, current_stage, ("wait",))
+            current_stage = f"{stage_loop_var} % 2"
+            for transfer in prefetched_loads:
+                body_current_stage_waits.extend(
+                    _dma_transfer_statements(
+                        transfer, loop_vars, current_stage, ("wait",)
+                    )
+                )
+
+        for transfer, load_node, consumer in refilled_loads:
+            state.codegen.add_pre_node_statements(
+                load_node,
+                _dma_transfer_statements(transfer, loop_vars, None, ("wait",)),
+            )
+            refill_starts = _dma_transfer_statements(
+                transfer,
+                next_indices,
+                None,
+                ("start",),
+            )
+            state.codegen.add_post_node_statement(
+                consumer,
+                _guarded_statements(
+                    f"{next_iteration} < {num_iterations}",
+                    "_refill_fori_load",
+                    refill_starts,
+                ),
             )
 
     # For loop-carried state, remap args to scratch reads inside the body

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -53,6 +53,8 @@ from .tensorcore_plan import build_dma_access_candidates
 
 log = logging.getLogger(__name__)
 
+_PALLAS_LOOP_LOAD_COUNT_META = "_helion_pallas_loop_load_count"
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterator
@@ -66,6 +68,7 @@ if TYPE_CHECKING:
     from ..tile_strategy import TileStrategy
     from .compact_worklist import ResidentPrepHoist
     from .dma import DmaDirection
+    from .plan_tiling import ContiguousRangeIndexPattern
 
 
 @_decorators.codegen(_not, "pallas")
@@ -616,7 +619,13 @@ def _classify_loop_tensors(
                 key = id(fake)
                 if key not in loaded_tensors:
                     sub_vals = _extract_subscript_vals(subscript)
-                    loaded_tensors[key] = (fake, tensor_node, sub_vals)
+                    loaded_tensors[key] = (fake, node, sub_vals)
+                    node.meta[_PALLAS_LOOP_LOAD_COUNT_META] = 1
+                else:
+                    first_load = loaded_tensors[key][1]
+                    first_load.meta[_PALLAS_LOOP_LOAD_COUNT_META] = (
+                        int(first_load.meta[_PALLAS_LOOP_LOAD_COUNT_META]) + 1
+                    )
         elif node.target is _store_op:
             tensor_node = node.args[0]
             subscript = node.args[1]
@@ -867,6 +876,131 @@ def _get_dim_block_ids(
         elif isinstance(idx, slice) and idx == slice(None):
             pass
     return dim_to_bid
+
+
+def _contiguous_range_patterns(
+    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+) -> dict[int, dict[int, ContiguousRangeIndexPattern]]:
+    """Return direct HBM range patterns keyed by tensor and tensor dimension."""
+    from .plan_tiling import ContiguousRangeIndexPattern
+    from .plan_tiling import NonePattern
+
+    result: dict[int, dict[int, ContiguousRangeIndexPattern]] = {}
+    for fake, load_node, _subscript in loaded_tensors.values():
+        tensor_dim = 0
+        ranges: dict[int, ContiguousRangeIndexPattern] = {}
+        for pattern in load_node.meta.get("indexing_patterns", ()):
+            if isinstance(pattern, NonePattern):
+                continue
+            if isinstance(pattern, ContiguousRangeIndexPattern):
+                ranges[tensor_dim] = pattern
+            tensor_dim += 1
+        if ranges:
+            result[id(fake)] = ranges
+    return result
+
+
+def _contiguous_range_base_expr(
+    value: object,
+    *,
+    state: CodegenState,
+    block_ids: list[int],
+    begin_exprs: list[str],
+    iter_step_exprs: list[str],
+    iteration_indices: list[str],
+) -> str | None:
+    """Render a supported scalar address expression for one loop iteration."""
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, torch.SymInt):
+        return state.device_function.literal_expr(value)
+    if not isinstance(value, torch.fx.Node) or value.op != "call_function":
+        return None
+
+    from ...language import memory_ops
+    from ...language.tile_ops import tile_begin
+
+    if value.target is tile_begin:
+        symbolic_value = value.meta.get("val")
+        if not isinstance(symbolic_value, torch.SymInt):
+            return None
+        block_id = CompileEnvironment.current().get_block_id(symbolic_value)
+        if block_id is None or block_id not in block_ids:
+            return None
+        position = block_ids.index(block_id)
+        return (
+            f"({begin_exprs[position]}) + ({iteration_indices[position]}) * "
+            f"({iter_step_exprs[position]})"
+        )
+
+    binary_operators = {
+        operator.add: "+",
+        operator.floordiv: "//",
+        operator.mod: "%",
+        operator.mul: "*",
+        operator.sub: "-",
+        torch.ops.aten.add.Scalar: "+",
+        torch.ops.aten.add.Tensor: "+",
+        torch.ops.aten.mul.Scalar: "*",
+        torch.ops.aten.mul.Tensor: "*",
+        torch.ops.aten.sub.Scalar: "-",
+        torch.ops.aten.sub.Tensor: "-",
+    }
+    if value.target in binary_operators and len(value.args) >= 2:
+        if (
+            value.target
+            in (
+                torch.ops.aten.add.Scalar,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.sub.Scalar,
+                torch.ops.aten.sub.Tensor,
+            )
+            and value.kwargs.get("alpha", 1) != 1
+        ):
+            return None
+        lhs = _contiguous_range_base_expr(
+            value.args[0],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        rhs = _contiguous_range_base_expr(
+            value.args[1],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        if lhs is None or rhs is None:
+            return None
+        return f"({lhs}) {binary_operators[value.target]} ({rhs})"
+
+    if value.target is memory_ops.load:
+        tensor_node, subscript = value.args[:2]
+        if not isinstance(tensor_node, torch.fx.Node):
+            return None
+        tensor = tensor_node.meta.get("val")
+        if not isinstance(tensor, torch.Tensor):
+            return None
+        if not isinstance(subscript, (list, tuple)) or len(subscript) != 1:
+            return None
+        index = _contiguous_range_base_expr(
+            subscript[0],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        if index is None:
+            return None
+        name = state.device_function.tensor_arg(tensor).name
+        return f"{name}[{index}]"
+
+    return None
 
 
 def _find_strategy(
@@ -3092,16 +3226,20 @@ def _compute_vmem_shapes(
     slice_size_exprs: list[str],
     env: CompileEnvironment,
     state: CodegenState,
+    contiguous_ranges: dict[int, dict[int, ContiguousRangeIndexPattern]],
 ) -> list[tuple[int, ...]]:
     """Compute VMEM buffer shapes for each tensor in the fori_loop body."""
     vmem_shapes: list[tuple[int, ...]] = []
     for fake, sub_meta, _direction in all_tensor_info:
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
         tensor_subscripts = _tensor_dim_subscripts(sub_meta)
+        range_dims = contiguous_ranges.get(id(fake), {})
         parts: list[int] = []
         for dim_idx in range(len(fake.shape)):
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid in block_ids:
+            if dim_idx in range_dims:
+                parts.append(range_dims[dim_idx].length)
+            elif bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
                 block_value_sym = sympy.sympify(slice_size_exprs[bid_idx])
                 if isinstance(block_value_sym, sympy.Integer):
@@ -3193,8 +3331,14 @@ def _classify_pipelined_tensors(
     outer_access_targets = ATOMIC_OPS | {_load_op, _store_op}
 
     all_tensor_info = _resident_loop_tensor_info(loaded_tensors, stored_tensors)
+    contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     vmem_shapes = _compute_vmem_shapes(
-        all_tensor_info, block_ids, slice_size_exprs, env, state
+        all_tensor_info,
+        block_ids,
+        slice_size_exprs,
+        env,
+        state,
+        contiguous_ranges,
     )
     device_ir = HostFunction.current().device_ir
 
@@ -3233,6 +3377,21 @@ def _classify_pipelined_tensors(
     for (fake, sub_meta, direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
+        if direction == "load":
+            first_load = loaded_tensors[id(fake)][1]
+            if int(first_load.meta.get(_PALLAS_LOOP_LOAD_COUNT_META, 1)) > 1:
+                # Tensor-level prefetching is keyed by input tensor, not load
+                # site. Dynamic ranges can remain in HBM so each load site
+                # stages its own exact window. Ordinary tiled loads must keep
+                # their outer BlockSpec: raw HBM load-site staging is defined
+                # only for dynamic ranges and remote-copy operands.
+                if id(fake) in contiguous_ranges:
+                    from ..device_function import PallasMemorySpace
+
+                    state.device_function.pallas_memory_space[id(fake)] = (
+                        PallasMemorySpace.HBM
+                    )
+                    continue
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
         if state.device_function.is_pallas_remote_copy_operand(fake) and not set(
             dim_to_bid.values()
@@ -3250,6 +3409,23 @@ def _classify_pipelined_tensors(
             continue
         if id(fake.untyped_storage()) in atomic_storages:
             continue
+        if range_patterns := contiguous_ranges.get(id(fake)):
+            can_render_ranges = all(
+                _contiguous_range_base_expr(
+                    pattern.base,
+                    state=state,
+                    block_ids=block_ids,
+                    begin_exprs=["0"] * len(block_ids),
+                    iter_step_exprs=["1"] * len(block_ids),
+                    iteration_indices=["0"] * len(block_ids),
+                )
+                is not None
+                for pattern in range_patterns.values()
+            )
+            if not can_render_ranges:
+                # The load-site lowering can still stage this window, but the
+                # loop prefetcher cannot safely synthesize its next address.
+                continue
         pipelined_ids.add(id(fake))
     return all_tensor_info, vmem_shapes, pipelined_ids
 
@@ -3427,6 +3603,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
 
     loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
+    contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
         state, block_ids, block_size_vars
     )
@@ -3783,7 +3960,28 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 vmem_parts.append(":")
                 continue
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid in block_ids:
+            range_pattern = contiguous_ranges.get(id(fake), {}).get(dim_idx)
+            if range_pattern is not None:
+                base_expr = _contiguous_range_base_expr(
+                    range_pattern.base,
+                    state=state,
+                    block_ids=block_ids,
+                    begin_exprs=begin_exprs,
+                    iter_step_exprs=iter_step_exprs,
+                    iteration_indices=iteration_indices,
+                )
+                if base_expr is None:
+                    raise RuntimeError(
+                        "Pallas could not render a planned contiguous HBM range"
+                    )
+                hbm_parts.append(
+                    "pl.ds(pl.multiple_of("
+                    f"{base_expr}, {range_pattern.alignment}), "
+                    f"{range_pattern.length})"
+                )
+                vmem_parts.append(":")
+                hbm_needs_slice = True
+            elif bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3417,6 +3417,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     immediate_loads: list[ScheduledDmaTransfer] = []
     dma_stores: list[ScheduledDmaTransfer] = []
     scheduled_by_hbm_name: dict[str, ScheduledDmaTransfer] = {}
+    refilled_load_tensors: set[str] = set()
+    refilled_loads: list[tuple[ScheduledDmaTransfer, torch.fx.Node, torch.fx.Node]] = []
     # compact_worklist shares this lowering but keeps its compact/resident routes.
     # Ordinary fori loops and explicitly buffered static unrolls honor the
     # per-input depth; other callers keep the historical single-buffer route.
@@ -3523,6 +3525,22 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         elif uses_load_prefetch:
             prefetched_load_tensors.add(hbm_name)
             prefetched_loads.append(scheduled)
+        elif (
+            load_buffer_counts_active
+            and transfer.direction == "load"
+            and len(block_ids) == 1
+            and id(fake) in contiguous_ranges
+        ):
+            load_node = loaded_tensors[id(fake)][1]
+            users = list(load_node.users)
+            if (
+                len(users) == 1
+                and users[0].op == "call_function"
+                and users[0].target
+                in (torch.ops.aten.mm.default, torch.ops.aten.bmm.default)
+            ):
+                refilled_load_tensors.add(hbm_name)
+                refilled_loads.append((scheduled, load_node, users[0]))
 
     # ``all_tensor_info`` represents a read-modify-write tensor only by its
     # store record so that its load and store share one VMEM buffer. Rebuild
@@ -3531,7 +3549,11 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     for fake, _tensor_node, sub_meta in loaded_tensors.values():
         hbm_name = state.device_function.tensor_arg(fake).name
         scheduled = scheduled_by_hbm_name.get(hbm_name)
-        if scheduled is None or hbm_name in prefetched_load_tensors:
+        if (
+            scheduled is None
+            or hbm_name in prefetched_load_tensors
+            or hbm_name in refilled_load_tensors
+        ):
             continue
         immediate_loads.append(
             ScheduledDmaTransfer(
@@ -3787,7 +3809,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     prime_statements: list[ast.stmt] = []
     body_prefetch: ast.FunctionDef | None = None
     body_current_stage_waits: list[ast.stmt] = []
-    if prefetched_loads:
+    if prefetched_loads or refilled_loads:
         num_iterations = state.device_function.new_var("_num_iterations")
         prime_statements.append(
             statement_from_string(f"{num_iterations} = {grid_parts[-1]}")
@@ -3801,6 +3823,15 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             prime_starts.extend(
                 _dma_copy_statements(transfer, prime_indices, "0", ("start",))
             )
+        for transfer, _load_node, _consumer in refilled_loads:
+            prime_starts.extend(
+                _dma_copy_statements(
+                    transfer,
+                    prime_indices,
+                    None,
+                    ("start",),
+                )
+            )
         prime_statements.append(
             _guarded_statements(
                 f"{num_iterations} > 0", "_prime_fori_loads", prime_starts
@@ -3811,22 +3842,43 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         next_iteration = f"({stage_loop_var} + 1)"
         next_indices = [*loop_vars]
         next_indices[-1] = next_iteration
-        next_stage = f"{next_iteration} % 2"
-        next_starts: list[ast.stmt] = []
-        for transfer in prefetched_loads:
-            next_starts.extend(
-                _dma_copy_statements(transfer, next_indices, next_stage, ("start",))
+        if prefetched_loads:
+            next_stage = f"{next_iteration} % 2"
+            next_starts: list[ast.stmt] = []
+            for transfer in prefetched_loads:
+                next_starts.extend(
+                    _dma_copy_statements(transfer, next_indices, next_stage, ("start",))
+                )
+            body_prefetch = _guarded_statements(
+                f"{next_iteration} < {num_iterations}",
+                "_prefetch_fori_loads",
+                next_starts,
             )
-        body_prefetch = _guarded_statements(
-            f"{next_iteration} < {num_iterations}",
-            "_prefetch_fori_loads",
-            next_starts,
-        )
 
-        current_stage = f"{stage_loop_var} % 2"
-        for transfer in prefetched_loads:
-            body_current_stage_waits.extend(
-                _dma_copy_statements(transfer, loop_vars, current_stage, ("wait",))
+            current_stage = f"{stage_loop_var} % 2"
+            for transfer in prefetched_loads:
+                body_current_stage_waits.extend(
+                    _dma_copy_statements(transfer, loop_vars, current_stage, ("wait",))
+                )
+
+        for transfer, load_node, consumer in refilled_loads:
+            state.codegen.add_pre_node_statements(
+                load_node,
+                _dma_copy_statements(transfer, loop_vars, None, ("wait",)),
+            )
+            refill_starts = _dma_copy_statements(
+                transfer,
+                next_indices,
+                None,
+                ("start",),
+            )
+            state.codegen.add_post_node_statement(
+                consumer,
+                _guarded_statements(
+                    f"{next_iteration} < {num_iterations}",
+                    "_refill_fori_load",
+                    refill_starts,
+                ),
             )
 
     # For loop-carried state, remap args to scratch reads inside the body

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -32,6 +32,7 @@ from ...language._tracing_ops import _new_var
 from ...language._tracing_ops import _not
 from ...language._tracing_ops import _phi
 from ...language._tracing_ops import _pre_broadcast_tile
+from ..ast_extension import create
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
 from ..compile_environment import CompileEnvironment
@@ -195,6 +196,14 @@ def _raise_unsupported_dynamic_unroll() -> None:
     )
 
 
+def _uses_buffered_static_unroll(state: CodegenState) -> bool:
+    """Whether a static loop requested the existing depth-two load route."""
+    if state.config.get("pallas_loop_type", "unroll") != "unroll":
+        return False
+    counts = state.config.get("pallas_load_buffer_count", ())
+    return isinstance(counts, (list, tuple)) and 2 in counts
+
+
 def _extract_subscript_vals(subscript: object) -> list[object]:
     """Extract meta values from a subscript argument in an FX graph.
 
@@ -243,6 +252,8 @@ def _(state: CodegenState) -> object:
         return _codegen_dynamic_unroll(state)
     if _has_dynamic_unroll_bound(state):
         _raise_unsupported_dynamic_unroll()
+    if _uses_buffered_static_unroll(state):
+        return _codegen_fori_loop(state, static_unroll=True)
     # unroll: fall through to common codegen path
     # pyrefly: ignore[bad-return]
     return state.get_graph(state.proxy_arg(0)).codegen(state)
@@ -281,6 +292,9 @@ def _(state: CodegenState) -> None:
         return None
     if _has_dynamic_unroll_bound(state):
         _raise_unsupported_dynamic_unroll()
+    if _uses_buffered_static_unroll(state):
+        _codegen_fori_loop(state, static_unroll=True)
+        return None
     # pyrefly: ignore[bad-return]
     return state.get_graph(state.proxy_arg(0)).codegen(state)
 
@@ -3381,12 +3395,13 @@ def _codegen_dynamic_unroll(state: CodegenState) -> object:
     return [expr_from_string(f"{result_var}[{i}]") for i in range(len(carried))]
 
 
-def _codegen_fori_loop(state: CodegenState) -> object:
+def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> object:
     """Emit inner device loops using jax.lax.fori_loop.
 
     Tensors admitted by the existing streaming classifier use explicit DMA.
     Selected read-only input tensors use two DMA buffers; all other routes keep
-    their existing single-buffered lowering.
+    their existing single-buffered lowering. ``static_unroll`` retains that DMA
+    schedule while using Python ``range`` so JAX traces a straight-line program.
     """
     from ..device_ir import ForLoopGraphInfo
     from ..device_ir import LiftTensorArgs
@@ -3510,9 +3525,13 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     dma_stores: list[ScheduledDmaTransfer] = []
     scheduled_by_hbm_name: dict[str, ScheduledDmaTransfer] = {}
     memory_op_to_dma_scratch: dict[torch.fx.Node, DmaResources] = {}
-    # compact_worklist shares this lowering but keeps its compact/resident routes;
-    # only an actual fori_loop config enables depth-two staging.
-    load_buffer_counts_active = state.config.get("pallas_loop_type") == "fori_loop"
+    # compact_worklist shares this lowering but keeps its compact/resident routes.
+    # Ordinary fori loops and explicitly buffered static unrolls honor the
+    # per-input depth; other callers keep the historical single-buffer route.
+    load_buffer_counts_active = state.config.get("pallas_loop_type") in (
+        "fori_loop",
+        "unroll",
+    )
 
     input_tensors = cast(
         "list[torch.Tensor]",
@@ -3711,6 +3730,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         block_id_to_info=block_id_to_info,
         body_fn_name="_fori_body_0",
         loop_var_name=loop_vars[-1],
+        static_unroll=static_unroll,
         inner_statements=body_stmts,
         _tensor_to_dma_scratch=tensor_to_dma_scratch,
         _tensor_to_sem=tensor_to_sem,
@@ -4116,7 +4136,8 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             state.add_statement(stmt)
         return None
 
-    _emit_nonlocal_scratch_declarations(state, body_stmts)
+    if not static_unroll:
+        _emit_nonlocal_scratch_declarations(state, body_stmts)
 
     # Emit nested fori_loop calls — one per dimension.
     # Build inside-out: innermost function wraps body_stmts, each outer
@@ -4127,6 +4148,23 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     # not affect correctness; for loop-carried state the user's source order
     # (block_ids order) is the correct semantic order.
     current_body = body_stmts or [ast.Pass()]  # pyrefly: ignore[bad-assignment]
+    if static_unroll:
+        for dim in reversed(range(len(loop_vars))):
+            loop = statement_from_string(
+                f"for {loop_vars[dim]} in range({grid_parts[dim]}):\n    pass"
+            )
+            assert isinstance(loop, ast.For)
+            loop.body = current_body  # pyrefly: ignore[bad-assignment]
+            if dim == len(loop_vars) - 1:
+                current_body = [*prime_statements, loop]
+            else:
+                current_body = [loop]
+        for statement in current_body:
+            state.add_statement(statement)
+        if has_loop_state:
+            return _read_final_loop_state(state, result_vars)
+        return None
+
     for dim in reversed(range(len(loop_vars))):
         fn_name = state.device_function.new_var(f"_fori_body_{dim}")
         fn_def = statement_from_string(f"def {fn_name}({loop_vars[dim]}, _): pass")
@@ -4150,6 +4188,46 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     if has_loop_state:
         return _read_final_loop_state(state, result_vars)
     return None
+
+
+def _is_static_unroll_predicate(state: CodegenState) -> bool:
+    """Whether this predicate is resolved by a surrounding Python tile loop."""
+    test = state.proxy_arg(0)
+    if isinstance(test, (bool, int)):
+        return True
+    if not isinstance(test, torch.SymBool):
+        return False
+
+    from ..tile_strategy import ForiLoopState
+    from ..variable_origin import BlockSizeOrigin
+    from ..variable_origin import GridOrigin
+
+    static_block_ids: set[int] = set()
+    for loops in state.codegen.active_device_loops.values():
+        for loop in loops:
+            if isinstance(loop, ForiLoopState) and loop.static_unroll:
+                static_block_ids.update(loop.block_ids)
+    if not static_block_ids:
+        return False
+
+    expr = test._sympy_()
+    if not isinstance(expr, sympy.Basic):
+        return False
+    origins = HostFunction.current().expr_to_origin
+    for symbol in expr.free_symbols:
+        origin_info = origins.get(symbol)
+        if origin_info is None:
+            return False
+        origin = origin_info.origin
+        base_type = origin.base_type()
+        if issubclass(base_type, BlockSizeOrigin):
+            continue
+        if not issubclass(base_type, GridOrigin):
+            return False
+        block_id = getattr(origin, "block_id", None)
+        if block_id not in static_block_ids:
+            return False
+    return True
 
 
 @_decorators.codegen(_if, "pallas")
@@ -4207,6 +4285,20 @@ def _(state: CodegenState) -> list[object]:
     if_return_names, else_return_names = graph_info.get_branches_return_names(
         state, if_outputs, else_outputs
     )
+
+    if (
+        _is_static_unroll_predicate(state)
+        and not if_return_names
+        and not else_return_names
+    ):
+        if_node = create(
+            ast.If,
+            test=test,
+            body=if_body_stmts or [ast.Pass()],
+            orelse=else_body_stmts or [ast.Pass()],
+        )
+        state.add_statement(if_node)
+        return []
 
     if_arg_ids = {arg.id for arg in if_args}
     union_args = if_args + [a for a in else_args if a.id not in if_arg_ids]

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1878,6 +1878,7 @@ class ForiLoopState(DeviceLoopOrGridState):
 
     body_fn_name: str
     loop_var_name: str  # The fori_loop index variable (e.g., "_j")
+    static_unroll: bool = False
     inner_statements: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2631,7 +2631,7 @@ class ConfigSpec:
         if (
             self.supports_config_key("pallas_load_buffer_count")
             and self.has_pallas_inner_loops
-            and config.get("pallas_loop_type") == "fori_loop"
+            and config.get("pallas_loop_type") in ("fori_loop", "unroll")
         ):
             values = config.setdefault(
                 "pallas_load_buffer_count", self.pallas_load_buffer_count.default()

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -232,6 +232,12 @@ class TestPallasLoadBufferCountConfig(TestCase):
         spec.normalize(config)
         self.assertEqual(config.pallas_load_buffer_count, [2, 1])
 
+        unroll_config = helion.Config(
+            pallas_loop_type="unroll", pallas_load_buffer_count=[2, 1]
+        )
+        spec.normalize(unroll_config)
+        self.assertEqual(unroll_config.pallas_load_buffer_count, [2, 1])
+
     def test_inactive_field_is_ignored(self) -> None:
         cases = (
             (self._config_spec(2), "emit_pipeline", [2], True),

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2512,6 +2512,30 @@ class TestPallas(TestCase):
         expected[indices.to(torch.int64)] = values
         torch.testing.assert_close(result, expected)
 
+    def test_scalar_tensor_index_store(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scalar_tensor_index_store(
+            values: torch.Tensor, output_row: torch.Tensor
+        ) -> torch.Tensor:
+            m, n = values.size()
+            out = torch.zeros([4, m, n], dtype=values.dtype, device=values.device)
+            row = output_row[0]
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[row, tile_m, tile_n] = values[tile_m, tile_n]
+            return out
+
+        values = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        output_row = torch.tensor([2], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            scalar_tensor_index_store,
+            (values, output_row),
+            block_sizes=[8, 128],
+        )
+
+        expected = torch.zeros(4, 8, 128, device=DEVICE)
+        expected[2] = values
+        torch.testing.assert_close(result, expected)
+
     def test_tensor_index_atomic_add_raises(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def atomic_add_tensor_index(

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -704,6 +704,43 @@ def pallas_fixed_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_prefetched_aligned_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for _ in hl.grid(1):
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            out[tile, :, :] = table[:, begin + hl.arange(128)][None, :, :]
+    return out
+
+
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(pallas_loop_type="fori_loop"),
+)
+def pallas_two_aligned_dynamic_windows(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    """Read two distinct aligned windows from one HBM tensor per iteration."""
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for _ in hl.grid(1):
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            first = table[:, begin + hl.arange(128)]
+            second = table[:, begin + 128 + hl.arange(128)]
+            out[tile, :, :] = (first + second)[None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
     rows = x.size(0)
     out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
@@ -913,6 +950,37 @@ class TestPallas(TestCase):
                 )
                 expected = x[3 : 3 + extent].sum(dim=0, keepdim=True)
                 torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_aligned_dynamic_window_prefetch(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        expected = torch.stack(
+            [table[:, begin : begin + 128] for begin in range(0, 512, 128)]
+        )
+
+        for loop_type in ("fori_loop", "unroll"):
+            with self.subTest(pallas_loop_type=loop_type):
+                _, result = code_and_output(
+                    pallas_prefetched_aligned_dynamic_window,
+                    (table, starts),
+                    pallas_load_buffer_count=[2, 1],
+                    pallas_loop_type=loop_type,
+                )
+                torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_two_aligned_dynamic_windows(self) -> None:
+        table = torch.randn(8, 640, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(pallas_two_aligned_dynamic_windows, (table, starts))
+        expected = torch.stack(
+            [
+                table[:, begin : begin + 128] + table[:, begin + 128 : begin + 256]
+                for begin in range(0, 512, 128)
+            ]
+        )
+        torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_computed_static_slice(self) -> None:
         x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -3620,6 +3620,51 @@ class TestPallas(TestCase):
         self.assertGreaterEqual(sum(i < compute for i in waits), 2)
         torch.testing.assert_close(result, args[0] + args[1])
 
+    def test_static_unroll_tensor_load_buffering(self) -> None:
+        """Static unroll retains the selected depth-two DMA pipeline."""
+        args = (
+            torch.randn(64, 256, device=DEVICE, dtype=torch.float32),
+            torch.randn(64, 256, device=DEVICE, dtype=torch.float32),
+        )
+        _, result = code_and_output(
+            pallas_inner_loop_add,
+            args,
+            block_sizes=[8, 128],
+            pallas_loop_type="unroll",
+            pallas_load_buffer_count=[2, 1],
+        )
+
+        torch.testing.assert_close(result.cpu(), (args[0] + args[1]).cpu())
+
+    def test_static_unroll_uses_python_if_for_tile_predicate(self) -> None:
+        """A static tile predicate does not leave a side-effectful lax.cond."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def alternating_add(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    if tile_n.begin == 0:
+                        out[tile_m, tile_n] = x[tile_m, tile_n] + 1
+                    else:
+                        out[tile_m, tile_n] = x[tile_m, tile_n] + 2
+            return out
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        _, result = code_and_output(
+            alternating_add,
+            (x,),
+            block_sizes=[8, 128],
+            pallas_loop_type="unroll",
+            pallas_load_buffer_count=[2],
+        )
+
+        expected = x.clone()
+        expected[:, :128] += 1
+        expected[:, 128:] += 2
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
     def test_fori_loop_repeated_loads_share_buffer(self) -> None:
         """Repeated loads of one input reuse its tensor-keyed DMA route."""
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -740,6 +740,28 @@ def pallas_two_aligned_dynamic_windows(
     return out
 
 
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(pallas_loop_type="fori_loop"),
+)
+def pallas_refilled_dynamic_matmul(
+    lhs: torch.Tensor, table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    """Multiply by one dynamic HBM weight window per loop iteration."""
+    rows = hl.specialize(lhs.size(0))
+    hl.specialize(table.size(0))
+    out = torch.empty([starts.size(0), rows, 128], dtype=lhs.dtype, device=lhs.device)
+    for _ in hl.grid(1):
+        local_lhs = lhs[:, :]
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            weight = table[:, begin + hl.arange(128)]
+            projected = torch.matmul(local_lhs, weight)
+            out[tile, :, :] = projected[None, :, :]
+    return out
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
     rows = x.size(0)
@@ -980,6 +1002,22 @@ class TestPallas(TestCase):
                 for begin in range(0, 512, 128)
             ]
         )
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_single_buffer_dynamic_matmul_refill(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_refilled_dynamic_matmul, (lhs, table, starts)
+        )
+        expected = torch.stack(
+            [
+                torch.matmul(lhs.float(), table[:, begin : begin + 128].float())
+                for begin in range(0, 512, 128)
+            ]
+        ).to(torch.bfloat16)
         torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_computed_static_slice(self) -> None:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -707,6 +707,28 @@ def pallas_two_aligned_dynamic_windows(
     return out
 
 
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(pallas_loop_type="fori_loop"),
+)
+def pallas_refilled_dynamic_matmul(
+    lhs: torch.Tensor, table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    """Multiply by one dynamic HBM weight window per loop iteration."""
+    rows = hl.specialize(lhs.size(0))
+    hl.specialize(table.size(0))
+    out = torch.empty([starts.size(0), rows, 128], dtype=lhs.dtype, device=lhs.device)
+    for _ in hl.grid(1):
+        local_lhs = lhs[:, :]
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            weight = table[:, begin + hl.arange(128)]
+            projected = torch.matmul(local_lhs, weight)
+            out[tile, :, :] = projected[None, :, :]
+    return out
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
     """Exercise a compound modulo operand whose parentheses are significant."""
@@ -964,6 +986,39 @@ class TestPallas(TestCase):
                 for begin in range(0, 512, 128)
             ]
         )
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_single_buffer_dynamic_matmul_refill_codegen(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        code = pallas_refilled_dynamic_matmul.bind(
+            (lhs, table, starts)
+        ).to_triton_code()
+        self.assertIn("def _prime_fori_loads", code)
+        self.assertIn("def _refill_fori_load", code)
+        self.assertNotIn("table_buf.at[", code)
+        table_copy_position = code.index("make_async_copy(table.at[")
+        wait_position = code.index(".wait()", table_copy_position)
+        matmul_position = code.index("lax.dot_general")
+        refill_position = code.index("def _refill_fori_load")
+        self.assertLess(wait_position, matmul_position)
+        self.assertLess(matmul_position, refill_position)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_single_buffer_dynamic_matmul_refill(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_refilled_dynamic_matmul, (lhs, table, starts)
+        )
+        expected = torch.stack(
+            [
+                torch.matmul(lhs.float(), table[:, begin : begin + 128].float())
+                for begin in range(0, 512, 128)
+            ]
+        ).to(torch.bfloat16)
         torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_shifted_modulo_preserves_expression_precedence(self) -> None:

--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -379,6 +379,68 @@ def _route_forward_then_consume(
 
 
 @helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(block_sizes=[]),
+)
+def _body_local_remote_scratch(
+    src: torch.Tensor,
+    peers: torch.Tensor,
+) -> torch.Tensor:
+    """Exchange through a private VMEM buffer that does not escape the kernel."""
+    output = torch.empty_like(src)
+    scratch = torch.empty(
+        [2, 1, 128],
+        dtype=src.dtype,
+        device=src.device,
+    )
+    for _program in hl.grid(1):
+        scratch[0, :, :] = src[0, :, :]
+        hl.remote_barrier(peers[0, 0])
+        copy = hl.make_async_remote_copy(
+            scratch,
+            [0],
+            peers[0, 0],
+            dst=scratch,
+            dst_index=[1],
+        )
+        copy.start()
+        copy.wait()
+        output[0, :, :] = scratch[1, :, :] + 1
+    return output
+
+
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(block_sizes=[]),
+)
+def _returned_remote_scratch_alias(
+    src: torch.Tensor,
+    peers: torch.Tensor,
+) -> torch.Tensor:
+    """Return an alias of a remote-copy buffer; it must remain an output."""
+    scratch = torch.empty(
+        [2, 1, 128],
+        dtype=src.dtype,
+        device=src.device,
+    )
+    for _program in hl.grid(1):
+        scratch[0, :, :] = src[0, :, :]
+        copy = hl.make_async_remote_copy(
+            scratch,
+            [0],
+            peers[0, 0],
+            dst=scratch,
+            dst_index=[1],
+        )
+        copy.start()
+        copy.wait()
+    result = scratch
+    return result  # noqa: RET504 - exercise return-alias escape analysis
+
+
+@helion.kernel(
     static_shapes=False,
     config=helion.Config(block_sizes=[_HBM_TILE]),
 )
@@ -867,6 +929,20 @@ class TestRemoteCopyGPU(TestCase, MultiProcessTestCase):
 @onlyBackends(["pallas"])
 class TestRemoteCopyJaxRuntime(TestCase):
     @staticmethod
+    def _body_local_remote_scratch_source() -> str:
+        return _body_local_remote_scratch.bind(
+            (
+                torch.zeros(1, 1, _WIDTH),
+                torch.zeros(1, 1, dtype=torch.int32),
+            )
+        ).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+
+    @staticmethod
     def _run_one_shot_copy(mesh, mesh_axis, kernel_fn) -> None:
         import jax
         import jax.numpy as jnp
@@ -1129,6 +1205,73 @@ class TestRemoteCopyJaxRuntime(TestCase):
         world_size = 2
         mesh = jax.make_mesh((world_size,), ("peer",), devices=devices[:world_size])
         self._run_ring_all_gather(mesh)
+
+    def test_returned_remote_scratch_alias_remains_an_output(self) -> None:
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "wrapper-created in-place outputs",
+        ):
+            _returned_remote_scratch_alias.bind(
+                (
+                    torch.zeros(1, 1, _WIDTH),
+                    torch.zeros(1, 1, dtype=torch.int32),
+                )
+            ).to_code(
+                options=helion.OutputCodeOptions(
+                    allow_helion_deps=False,
+                    jax_fn=True,
+                )
+            )
+
+    @skipIfPallasInterpret("body-local remote scratch requires physical TPU devices")
+    def test_body_local_remote_scratch(self) -> None:
+        import types
+
+        import jax
+        import jax.numpy as jnp
+
+        devices = [device for device in jax.local_devices() if device.platform == "tpu"]
+        if len(devices) < 2:
+            self.skipTest("requires at least two TPU devices")
+
+        source = self._body_local_remote_scratch_source()
+
+        name = "precompiled_body_local_remote_scratch_test"
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+        self.addCleanup(sys.modules.pop, name, None)
+        exec(compile(source, name, "exec"), module.__dict__)
+
+        world_size = 2
+        mesh = jax.make_mesh((world_size,), ("peer",), devices=devices[:world_size])
+        partition = jax.sharding.PartitionSpec
+        src_spec = partition("peer", None, None)
+        peer_spec = partition("peer", None)
+        ranks = jnp.arange(world_size, dtype=jnp.float32)[:, None, None]
+        columns = jnp.arange(_WIDTH, dtype=jnp.float32)[None, None, :]
+        src = ranks * 1000 + columns
+        peers = (1 - jnp.arange(world_size, dtype=jnp.int32))[:, None]
+        inputs = tuple(
+            jax.device_put(value, jax.sharding.NamedSharding(mesh, spec))
+            for value, spec in zip(
+                (src, peers),
+                (src_spec, peer_spec),
+                strict=True,
+            )
+        )
+        exchange = jax.jit(
+            jax.shard_map(
+                module._body_local_remote_scratch,
+                mesh=mesh,
+                in_specs=(src_spec, peer_spec),
+                out_specs=src_spec,
+                check_vma=False,
+            )
+        )
+        expected = np.asarray(src)[::-1] + 1
+        for _invocation in range(2):
+            result = np.asarray(jax.block_until_ready(exchange(*inputs)))
+            np.testing.assert_array_equal(result, expected)
 
     @skipIfPallasInterpret("remote-copy pipelines require TPU VMEM lowering")
     def test_computed_pipeline_copy(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3405
 * #3396
 * #3394
 * #3402
 * #3401
 * #3407
 * #3403
 * #3399
 * __->__#3397
 * #3408
 * #3387
 * #3392
 * #3391


--- --- ---

### [Pallas] Refill single-buffer matmul windows after use


Dynamic aligned HBM windows were staged with a start and wait at the beginning
of every loop iteration. For a weight window consumed by a matmul, that
serialized the entire DMA latency before MXU work.

Representative Helion source:

```python
for tile in hl.tile(starts.size(0), block_size=1):
    begin = starts[tile.begin] * 128
    weight = table[:, begin + hl.arange(128)]
    projected = torch.matmul(local_lhs, weight)
    out[tile, :, :] = projected[None, :, :]
```

Previously generated Pallas/JAX performed the complete copy before each dot:

```python
copy = pltpu.make_async_copy(
    table.at[:, pl.ds(current_begin, 128)],
    table_buf,
    table_sem,
)
copy.start()
copy.wait()
weight = table_buf[:, :]
projected = lax.dot_general(local_lhs, weight, ...)
```

Recognize the conservative case where the loop is one-dimensional, the load is
one contiguous HBM range, the buffer depth is one, and the loaded value has one
`aten.mm` or `aten.bmm` consumer. Prime the first transfer once, wait immediately
before the load, and start the next transfer immediately after the consuming
matmul:

```python
@pl.when(num_iterations > 0)
def prime():
    copy = pltpu.make_async_copy(first_window, table_buf, table_sem)
    copy.start()

for j in range(num_iterations):
    current = pltpu.make_async_copy(current_window, table_buf, table_sem)
    current.wait()
    weight = table_buf[:, :]
    projected = lax.dot_general(local_lhs, weight, ...)

    @pl.when(j + 1 < num_iterations)
    def refill():
        next_copy = pltpu.make_async_copy(next_window, table_buf, table_sem)
        next_copy.start()
```

Starting the refill after the dot makes the single-buffer lifetime explicit:
the current matmul has consumed `table_buf` before the next DMA can overwrite it.
The transfer overlaps the remaining loop body and independent work without a
second weight buffer or extra VMEM. Other loads and consumers retain the
existing start-plus-wait behavior.

The TPU computation test runs four BF16 matmuls through the single-buffer
schedule and was bit-identical to the reference on both hosts.

For the fused 8K RMSNorm/QKVOG/epilogue/all-to-all workload, device latency fell
from 1660.54 us to 935.06 us (-43.7%, 1.78x faster). Correctness remained
`allclose=true`, `repeat_exact_fraction=1.0`, and `exact_fraction=0.999628`; the
0.25 maximum absolute difference is in the FP8 K/V output.

`pre-commit run --all-files` and `./lint.sh check` pass.
