### PR TITLE
[Pallas] Prove fixed scalar-derived loop extents

### DIFF
--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1227,11 +1227,66 @@ def _pipeline_begin_alignment(
     return None
 
 
+def _fixed_loop_extent(state: CodegenState, loop_dim_index: int) -> int | None:
+    """Return a direct ``end = begin + constant`` loop extent, if present.
+
+    Device-loop bounds that come from scalar tensor arithmetic are no longer
+    symbolic integers by codegen time. Their generated names therefore do not
+    retain enough information for SymPy simplification, but the enclosing
+    ``_for_loop`` FX node still records the original relationship. Keep this
+    matcher deliberately narrow: it proves only a direct, positive constant
+    addition (or the equivalent subtraction on the begin).
+    """
+    node = state.fx_node
+    if node is None or len(node.args) < 3:
+        return None
+    raw_begins, raw_ends = node.args[1:3]
+    begins = list(raw_begins) if isinstance(raw_begins, (list, tuple)) else [raw_begins]
+    ends = list(raw_ends) if isinstance(raw_ends, (list, tuple)) else [raw_ends]
+    if loop_dim_index >= len(begins) or loop_dim_index >= len(ends):
+        return None
+    begin = begins[loop_dim_index]
+    end = ends[loop_dim_index]
+
+    def _positive_int(value: object) -> int | None:
+        if isinstance(value, (int, sympy.Integer)) and int(value) > 0:
+            return int(value)
+        return None
+
+    if isinstance(begin, (int, sympy.Integer)) and isinstance(
+        end, (int, sympy.Integer)
+    ):
+        return _positive_int(int(end) - int(begin))
+
+    if isinstance(end, torch.fx.Node) and end.op == "call_function":
+        if (
+            end.target
+            in (operator.add, torch.ops.aten.add.Tensor, torch.ops.aten.add.Scalar)
+            and len(end.args) >= 2
+            and end.kwargs.get("alpha", 1) == 1
+        ):
+            if end.args[0] is begin:
+                return _positive_int(end.args[1])
+            if end.args[1] is begin:
+                return _positive_int(end.args[0])
+    if isinstance(begin, torch.fx.Node) and begin.op == "call_function":
+        if (
+            begin.target
+            in (operator.sub, torch.ops.aten.sub.Tensor, torch.ops.aten.sub.Scalar)
+            and len(begin.args) >= 2
+            and begin.kwargs.get("alpha", 1) == 1
+        ):
+            if begin.args[0] is end:
+                return _positive_int(begin.args[1])
+    return None
+
+
 def _compute_pipeline_or_dma_extra_pad(
     begin_expr: str,
     bid: int,
     env: CompileEnvironment,
     state: CodegenState,
+    loop_dim_index: int | None = None,
 ) -> int:
     """Return extra host-side padding for a pipeline/DMA dim with a non-zero begin.
 
@@ -1247,6 +1302,10 @@ def _compute_pipeline_or_dma_extra_pad(
     bs_val = state.device_function.resolved_block_size(bid)
     if not isinstance(bs_val, int):
         return 0
+    if loop_dim_index is not None:
+        extent = _fixed_loop_extent(state, loop_dim_index)
+        if extent is not None and extent % bs_val == 0:
+            return 0
     alignment = _pipeline_begin_alignment(begin_expr, state)
     if alignment is not None and alignment % bs_val == 0:
         return 0
@@ -2460,7 +2519,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 from ...language.memory_ops import _record_pad_info
 
                 extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
+                    begin_expr, bid, env, state, bid_idx
                 )
                 _record_pad_info(state, fake, dim_idx, bid, extra_pad)
                 begin_is_zero = begin_expr == "0"
@@ -3714,7 +3773,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 from ...language.memory_ops import _record_pad_info
 
                 extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
+                    begin_expr, bid, env, state, bid_idx
                 )
                 _record_pad_info(state, fake, dim_idx, bid, extra_pad)
             elif bid is not None and bid not in block_ids:

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1295,11 +1295,66 @@ def _pipeline_begin_alignment(
     return None
 
 
+def _fixed_loop_extent(state: CodegenState, loop_dim_index: int) -> int | None:
+    """Return a direct ``end = begin + constant`` loop extent, if present.
+
+    Device-loop bounds that come from scalar tensor arithmetic are no longer
+    symbolic integers by codegen time. Their generated names therefore do not
+    retain enough information for SymPy simplification, but the enclosing
+    ``_for_loop`` FX node still records the original relationship. Keep this
+    matcher deliberately narrow: it proves only a direct, positive constant
+    addition (or the equivalent subtraction on the begin).
+    """
+    node = state.fx_node
+    if node is None or len(node.args) < 3:
+        return None
+    raw_begins, raw_ends = node.args[1:3]
+    begins = list(raw_begins) if isinstance(raw_begins, (list, tuple)) else [raw_begins]
+    ends = list(raw_ends) if isinstance(raw_ends, (list, tuple)) else [raw_ends]
+    if loop_dim_index >= len(begins) or loop_dim_index >= len(ends):
+        return None
+    begin = begins[loop_dim_index]
+    end = ends[loop_dim_index]
+
+    def _positive_int(value: object) -> int | None:
+        if isinstance(value, (int, sympy.Integer)) and int(value) > 0:
+            return int(value)
+        return None
+
+    if isinstance(begin, (int, sympy.Integer)) and isinstance(
+        end, (int, sympy.Integer)
+    ):
+        return _positive_int(int(end) - int(begin))
+
+    if isinstance(end, torch.fx.Node) and end.op == "call_function":
+        if (
+            end.target
+            in (operator.add, torch.ops.aten.add.Tensor, torch.ops.aten.add.Scalar)
+            and len(end.args) >= 2
+            and end.kwargs.get("alpha", 1) == 1
+        ):
+            if end.args[0] is begin:
+                return _positive_int(end.args[1])
+            if end.args[1] is begin:
+                return _positive_int(end.args[0])
+    if isinstance(begin, torch.fx.Node) and begin.op == "call_function":
+        if (
+            begin.target
+            in (operator.sub, torch.ops.aten.sub.Tensor, torch.ops.aten.sub.Scalar)
+            and len(begin.args) >= 2
+            and begin.kwargs.get("alpha", 1) == 1
+        ):
+            if begin.args[0] is end:
+                return _positive_int(begin.args[1])
+    return None
+
+
 def _compute_pipeline_or_dma_extra_pad(
     begin_expr: str,
     bid: int,
     env: CompileEnvironment,
     state: CodegenState,
+    loop_dim_index: int | None = None,
 ) -> int:
     """Return extra host-side padding for a pipeline/DMA dim with a non-zero begin.
 
@@ -1315,6 +1370,10 @@ def _compute_pipeline_or_dma_extra_pad(
     bs_val = state.device_function.resolved_block_size(bid)
     if not isinstance(bs_val, int):
         return 0
+    if loop_dim_index is not None:
+        extent = _fixed_loop_extent(state, loop_dim_index)
+        if extent is not None and extent % bs_val == 0:
+            return 0
     alignment = _pipeline_begin_alignment(begin_expr, state)
     if alignment is not None and alignment % bs_val == 0:
         return 0
@@ -2528,7 +2587,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 from ...language.memory_ops import _record_pad_info
 
                 extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
+                    begin_expr, bid, env, state, bid_idx
                 )
                 _record_pad_info(state, fake, dim_idx, bid, extra_pad)
                 begin_is_zero = begin_expr == "0"
@@ -3736,7 +3795,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                 from ...language.memory_ops import _record_pad_info
 
                 extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
+                    begin_expr, bid, env, state, bid_idx
                 )
                 _record_pad_info(state, fake, dim_idx, bid, extra_pad)
             elif bid is not None and bid not in block_ids:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -730,6 +730,26 @@ def pallas_refilled_dynamic_matmul(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_fixed_dynamic_window(
+    x: torch.Tensor,
+    starts: torch.Tensor,
+    EXTENT: hl.constexpr,
+) -> torch.Tensor:
+    """Sum a fixed-size window whose starting row is selected at runtime."""
+    A = hl.specialize(x.size(1))
+    B = hl.specialize(x.size(2))
+    out = torch.empty([1, A, B], dtype=torch.float32, device=x.device)
+    for owner in hl.grid(1):
+        start = starts[owner]
+        end = start + EXTENT
+        acc = hl.zeros([A, B], dtype=torch.float32)
+        for tile in hl.tile(start, end):
+            acc = acc + x[tile, :, :].to(torch.float32).sum(dim=0)
+        out[owner, :, :] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
     """Exercise a compound modulo operand whose parentheses are significant."""
     out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
@@ -5432,6 +5452,26 @@ class TestPallas(TestCase):
             all(extra_pad == 0 for *_, extra_pad in pad_dims),
             f"block-aligned begin should skip the pad (extra_pad==0), got {pad_dims}",
         )
+
+    def test_dynamic_begin_fixed_extent_pad(self) -> None:
+        """A block-divisible fixed window needs no worst-case boundary pad."""
+        x = torch.randn(256, 8, 128, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([3], device=DEVICE, dtype=torch.int32)
+        cases = ((128, 0), (127, 15))
+        for extent, expected_extra_pad in cases:
+            with self.subTest(extent=extent):
+                code, result = code_and_output(
+                    pallas_fixed_dynamic_window,
+                    (x, starts, extent),
+                    block_sizes=[16],
+                    pallas_loop_type="fori_loop",
+                )
+                match = re.search(r"_ds_pad_dims=(\[[^\]]*\])", code)
+                self.assertIsNotNone(match, "expected _ds_pad_dims in launcher call")
+                pad_dims = ast.literal_eval(match.group(1))
+                self.assertEqual(pad_dims, [(1, 0, 16, expected_extra_pad)])
+                expected = x[3 : 3 + extent].sum(dim=0, keepdim=True)
+                torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -684,6 +684,26 @@ def pallas_scaled_add_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_fixed_dynamic_window(
+    x: torch.Tensor,
+    starts: torch.Tensor,
+    EXTENT: hl.constexpr,
+) -> torch.Tensor:
+    """Sum a fixed-size window whose starting row is selected at runtime."""
+    A = hl.specialize(x.size(1))
+    B = hl.specialize(x.size(2))
+    out = torch.empty([1, A, B], dtype=torch.float32, device=x.device)
+    for owner in hl.grid(1):
+        start = starts[owner]
+        end = start + EXTENT
+        acc = hl.zeros([A, B], dtype=torch.float32)
+        for tile in hl.tile(start, end):
+            acc = acc + x[tile, :, :].to(torch.float32).sum(dim=0)
+        out[owner, :, :] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
     rows = x.size(0)
     out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
@@ -879,6 +899,20 @@ class TestPallas(TestCase):
         lanes = torch.arange(128, device=DEVICE)
         expected = torch.stack((table[:, lanes], table[:, 256 + lanes]))
         torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_dynamic_begin_fixed_extent(self) -> None:
+        x = torch.randn(256, 8, 128, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([3], device=DEVICE, dtype=torch.int32)
+        for extent in (128, 127):
+            with self.subTest(extent=extent):
+                _, result = code_and_output(
+                    pallas_fixed_dynamic_window,
+                    (x, starts, extent),
+                    block_sizes=[16],
+                    pallas_loop_type="fori_loop",
+                )
+                expected = x[3 : 3 + extent].sum(dim=0, keepdim=True)
+                torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
     def test_computed_static_slice(self) -> None:
         x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION
Stacked PRs:
 * #3408
 * #3405
 * #3396
 * #3394
 * #3402
 * #3401
 * #3387
 * #3407
 * #3403
 * #3399
 * #3397
 * #3392
 * #3391
 * __->__#3398


--- --- ---

### [Pallas] Prove fixed scalar-derived loop extents


Dynamic loop bounds can be runtime scalar tensors even when their distance is
compile-time constant. Preserve that fact during Pallas lowering so a fixed,
block-divisible window does not pay for conservative host-side boundary
padding.

For example, this Helion source selects a runtime row but always visits exactly
128 rows:

```python
start = starts[owner]
end = start + 128
for tile in hl.tile(start, end):
    acc += x[tile, :, :].to(torch.float32).sum(dim=0)
```

Before this change, the generated launcher could no longer simplify the scalar
names used for `start` and `end`. With a 16-row block it therefore assumed the
worst possible misalignment and padded 15 extra rows:

```python
out = _launcher(
    _helion_pallas_fixed_dynamic_window,
    (1,), starts, x, out,
    _ds_pad_dims=[(1, 0, 16, 15)],
    ...,
)
```

That adds a `jnp.pad`/copy of 15 * 8 * 128 FP32 elements (60 KiB in this test)
on every launch even though `end - start` is exactly divisible by the block.

The lowering now inspects the original `_for_loop` FX operands and recognizes
only direct positive constant relationships:

* `end = begin + constant`;
* `end = constant + begin`; and
* `begin = end - constant`.

For the 128-row source above, generated code is now:

```python
out = _launcher(
    _helion_pallas_fixed_dynamic_window,
    (1,), starts, x, out,
    _ds_pad_dims=[(1, 0, 16, 0)],
    ...,
)
```

The proof is intentionally narrow. Unknown, indirect, non-positive, or
non-divisible extents retain the conservative padding; the 127-row test still
generates `extra_pad=15`.

`test_dynamic_begin_fixed_extent` executes both the 128-row optimized case
and the 127-row fallback and compares their numerical outputs with PyTorch. On
a two-host TPU v7 slice, the generated raw JAX/Pallas 128-row computation was
bit-exact on both hosts (`max_abs=0.0`). `./lint.sh` also passes.
