### PR TITLE
[Pallas] Hoist initial buffered DMAs over pure compute

### DIFF
--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1497,6 +1497,41 @@ def _fixed_loop_extent(state: CodegenState, loop_dim_index: int) -> int | None:
     return None
 
 
+def _hoist_initial_dma_before_pure_outer_compute(
+    state: CodegenState,
+    statements: list[ast.stmt],
+    loop_local_names: list[str],
+) -> bool:
+    """Move an independent initial DMA to the start of the current root body.
+
+    A buffered inner loop normally starts its first load immediately before
+    entering the loop. If the address depends only on kernel arguments and
+    constants, starting it before preceding elementwise root computation
+    exposes useful DMA/compute overlap. Stay conservative: cross only plain
+    assignments and compiler-owned scratch initialization, never user-visible
+    stores, structured control flow, or a producer of a value read by the DMA.
+    """
+    from ..ast_read_writes import ReadWrites
+
+    outer = state.codegen.statements_stack[-1]
+    dma_reads = set(ReadWrites.from_list(statements).reads)
+    # A nested loop's initial DMA can depend on an enclosing device-loop
+    # induction variable. That variable is an argument of the not-yet-emitted
+    # loop body, so it is unavailable in ``outer`` even though no assignment in
+    # ``outer`` produces it. Keep the prime inside that loop body in this case.
+    if dma_reads.intersection(loop_local_names):
+        return False
+    scratch_names = {scratch.name for scratch in state.device_function._scratch_args}
+    for statement in outer:
+        if not isinstance(statement, ast.Assign):
+            return False
+        rw = ReadWrites.from_ast(statement)
+        if set(rw.writes) & dma_reads or set(rw.inplace_writes) - scratch_names:
+            return False
+    outer[:0] = statements
+    return True
+
+
 def _compute_pipeline_or_dma_extra_pad(
     begin_expr: str,
     bid: int,
@@ -4280,11 +4315,16 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                     ("start",),
                 )
             )
-        prime_statements.append(
-            _guarded_statements(
-                f"{num_iterations} > 0", "_prime_fori_loads", prime_starts
-            )
+        fixed_extent = _fixed_loop_extent(state, len(block_ids) - 1)
+        prime_was_hoisted = fixed_extent is not None and (
+            _hoist_initial_dma_before_pure_outer_compute(state, prime_starts, loop_vars)
         )
+        if not prime_was_hoisted:
+            prime_statements.append(
+                _guarded_statements(
+                    f"{num_iterations} > 0", "_prime_fori_loads", prime_starts
+                )
+            )
 
         stage_loop_var = loop_vars[-1]
         next_iteration = f"({stage_loop_var} + 1)"

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1281,6 +1281,41 @@ def _fixed_loop_extent(state: CodegenState, loop_dim_index: int) -> int | None:
     return None
 
 
+def _hoist_initial_dma_before_pure_outer_compute(
+    state: CodegenState,
+    statements: list[ast.stmt],
+    loop_local_names: list[str],
+) -> bool:
+    """Move an independent initial DMA to the start of the current root body.
+
+    A buffered inner loop normally starts its first load immediately before
+    entering the loop. If the address depends only on kernel arguments and
+    constants, starting it before preceding elementwise root computation
+    exposes useful DMA/compute overlap. Stay conservative: cross only plain
+    assignments and compiler-owned scratch initialization, never user-visible
+    stores, structured control flow, or a producer of a value read by the DMA.
+    """
+    from ..ast_read_writes import ReadWrites
+
+    outer = state.codegen.statements_stack[-1]
+    dma_reads = set(ReadWrites.from_list(statements).reads)
+    # A nested loop's initial DMA can depend on an enclosing device-loop
+    # induction variable. That variable is an argument of the not-yet-emitted
+    # loop body, so it is unavailable in ``outer`` even though no assignment in
+    # ``outer`` produces it. Keep the prime inside that loop body in this case.
+    if dma_reads.intersection(loop_local_names):
+        return False
+    scratch_names = {scratch.name for scratch in state.device_function._scratch_args}
+    for statement in outer:
+        if not isinstance(statement, ast.Assign):
+            return False
+        rw = ReadWrites.from_ast(statement)
+        if set(rw.writes) & dma_reads or set(rw.inplace_writes) - scratch_names:
+            return False
+    outer[:0] = statements
+    return True
+
+
 def _compute_pipeline_or_dma_extra_pad(
     begin_expr: str,
     bid: int,
@@ -3891,11 +3926,16 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                     ("start",),
                 )
             )
-        prime_statements.append(
-            _guarded_statements(
-                f"{num_iterations} > 0", "_prime_fori_loads", prime_starts
-            )
+        fixed_extent = _fixed_loop_extent(state, len(block_ids) - 1)
+        prime_was_hoisted = fixed_extent is not None and (
+            _hoist_initial_dma_before_pure_outer_compute(state, prime_starts, loop_vars)
         )
+        if not prime_was_hoisted:
+            prime_statements.append(
+                _guarded_statements(
+                    f"{num_iterations} > 0", "_prime_fori_loads", prime_starts
+                )
+            )
 
         stage_loop_var = loop_vars[-1]
         next_iteration = f"({stage_loop_var} + 1)"

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -684,26 +684,6 @@ def pallas_scaled_add_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
-def pallas_fixed_dynamic_window(
-    x: torch.Tensor,
-    starts: torch.Tensor,
-    EXTENT: hl.constexpr,
-) -> torch.Tensor:
-    """Sum a fixed-size window whose starting row is selected at runtime."""
-    A = hl.specialize(x.size(1))
-    B = hl.specialize(x.size(2))
-    out = torch.empty([1, A, B], dtype=torch.float32, device=x.device)
-    for owner in hl.grid(1):
-        start = starts[owner]
-        end = start + EXTENT
-        acc = hl.zeros([A, B], dtype=torch.float32)
-        for tile in hl.tile(start, end):
-            acc = acc + x[tile, :, :].to(torch.float32).sum(dim=0)
-        out[owner, :, :] = acc
-    return out
-
-
-@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_prefetched_aligned_dynamic_window(
     table: torch.Tensor, starts: torch.Tensor
 ) -> torch.Tensor:
@@ -758,6 +738,48 @@ def pallas_refilled_dynamic_matmul(
             begin = starts[tile.begin] * 128
             weight = table[:, begin + hl.arange(128)]
             projected = torch.matmul(local_lhs, weight)
+            out[tile, :, :] = projected[None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_fixed_dynamic_window(
+    x: torch.Tensor,
+    starts: torch.Tensor,
+    EXTENT: hl.constexpr,
+) -> torch.Tensor:
+    """Sum a fixed-size window whose starting row is selected at runtime."""
+    A = hl.specialize(x.size(1))
+    B = hl.specialize(x.size(2))
+    out = torch.empty([1, A, B], dtype=torch.float32, device=x.device)
+    for owner in hl.grid(1):
+        start = starts[owner]
+        end = start + EXTENT
+        acc = hl.zeros([A, B], dtype=torch.float32)
+        for tile in hl.tile(start, end):
+            acc = acc + x[tile, :, :].to(torch.float32).sum(dim=0)
+        out[owner, :, :] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_overlap_initial_dma_with_normalization(
+    lhs: torch.Tensor,
+    table: torch.Tensor,
+    starts: torch.Tensor,
+) -> torch.Tensor:
+    """Normalize rows while the first dynamic matmul window is loading."""
+    rows = hl.specialize(lhs.size(0))
+    hl.specialize(table.size(0))
+    out = torch.empty([starts.size(0), rows, 128], dtype=lhs.dtype, device=lhs.device)
+    for _ in hl.grid(1):
+        lhs_f32 = lhs[:, :].to(torch.float32)
+        inverse_rms = torch.rsqrt(lhs_f32.pow(2).mean(dim=-1, keepdim=True) + 1e-5)
+        normalized = (lhs_f32 * inverse_rms).to(lhs.dtype)
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            weight = table[:, begin + hl.arange(128)]
+            projected = torch.matmul(normalized, weight)
             out[tile, :, :] = projected[None, :, :]
     return out
 
@@ -959,20 +981,6 @@ class TestPallas(TestCase):
         expected = torch.stack((table[:, lanes], table[:, 256 + lanes]))
         torch.testing.assert_close(result.cpu(), expected.cpu())
 
-    def test_dynamic_begin_fixed_extent(self) -> None:
-        x = torch.randn(256, 8, 128, device=DEVICE, dtype=torch.float32)
-        starts = torch.tensor([3], device=DEVICE, dtype=torch.int32)
-        for extent in (128, 127):
-            with self.subTest(extent=extent):
-                _, result = code_and_output(
-                    pallas_fixed_dynamic_window,
-                    (x, starts, extent),
-                    block_sizes=[16],
-                    pallas_loop_type="fori_loop",
-                )
-                expected = x[3 : 3 + extent].sum(dim=0, keepdim=True)
-                torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
-
     @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
     def test_aligned_dynamic_window_prefetch(self) -> None:
         table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
@@ -1019,6 +1027,45 @@ class TestPallas(TestCase):
             ]
         ).to(torch.bfloat16)
         torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_dynamic_begin_fixed_extent(self) -> None:
+        x = torch.randn(256, 8, 128, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([3], device=DEVICE, dtype=torch.int32)
+        for extent in (128, 127):
+            with self.subTest(extent=extent):
+                _, result = code_and_output(
+                    pallas_fixed_dynamic_window,
+                    (x, starts, extent),
+                    block_sizes=[16],
+                    pallas_loop_type="fori_loop",
+                )
+                expected = x[3 : 3 + extent].sum(dim=0, keepdim=True)
+                torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_initial_dma_overlaps_outer_normalization(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_overlap_initial_dma_with_normalization,
+            (lhs, table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        lhs_f32 = lhs.float()
+        normalized = (
+            lhs_f32 * torch.rsqrt(lhs_f32.pow(2).mean(-1, keepdim=True) + 1e-5)
+        ).to(lhs.dtype)
+        expected = torch.stack(
+            [
+                torch.matmul(
+                    normalized.float(),
+                    table[:, begin : begin + 128].float(),
+                )
+                for begin in range(0, 512, 128)
+            ]
+        ).to(lhs.dtype)
+        torch.testing.assert_close(result, expected)
 
     def test_computed_static_slice(self) -> None:
         x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
@@ -3690,64 +3737,19 @@ class TestPallas(TestCase):
         self.assertEqual(preferred, baseline)
         return preferred
 
-    def test_fori_loop_tensor_load_buffering_codegen(self) -> None:
+    def test_fori_loop_tensor_load_buffering(self) -> None:
         """A selected tensor is primed and prefetched on its existing DMA route."""
         args = (
             torch.randn(64, 256, device=DEVICE, dtype=torch.float32),
             torch.randn(64, 256, device=DEVICE, dtype=torch.float32),
         )
-        depth_one_code = self._assert_load_buffer_count_noop(
-            pallas_inner_loop_add, args, [8, 128], [1, 1]
-        )
-        self.assertNotIn("_prime_fori_loads", depth_one_code)
-        self.assertNotIn("_prefetch_fori_loads", depth_one_code)
-        code, result = code_and_output(
+        _, result = code_and_output(
             pallas_inner_loop_add,
             args,
             block_sizes=[8, 128],
             pallas_loop_type="fori_loop",
             pallas_load_buffer_count=[2, 1],
         )
-
-        self.assertIn("def _prime_fori_loads", code)
-        self.assertIn("def _prefetch_fori_loads", code)
-        self.assertIn("((2, 8, 128), 'jnp.float32', 'vmem')", code)
-        self.assertIn("((2,), None, 'dma_semaphore')", code)
-        self.assertRegex(code, r"\.at\[\(_j(?:_\d+)? \+ 1\) % 2\]")
-        self.assertRegex(code, r"\.at\[_j(?:_\d+)? % 2\]")
-
-        # The prime starts stage zero before entering the loop and deliberately
-        # does not wait. The body starts the next stage before any current-stage
-        # wait, then waits for both the ordinary depth-one load and selected load
-        # before consuming the selected stage.
-        prime_start = code.index("def _prime_fori_loads")
-        fori_call = code.index("jax.lax.fori_loop", prime_start)
-        prime = code[prime_start:fori_call]
-        self.assertIn(".start()", prime)
-        self.assertNotIn(".wait()", prime)
-
-        module = ast.parse(code)
-        body = next(
-            node
-            for node in ast.walk(module)
-            if isinstance(node, ast.FunctionDef)
-            and node.name.startswith("_fori_body_0")
-        )
-        statements = [ast.unparse(statement) for statement in body.body]
-        prefetch = next(
-            i
-            for i, statement in enumerate(body.body)
-            if isinstance(statement, ast.FunctionDef)
-            and statement.name.startswith("_prefetch_fori_loads")
-        )
-        compute = next(
-            i
-            for i, text in enumerate(statements)
-            if "% 2" in text and "_buf" in text and "make_async_copy" not in text
-        )
-        waits = [i for i, text in enumerate(statements) if ".wait()" in text]
-        self.assertLess(prefetch, min(waits))
-        self.assertGreaterEqual(sum(i < compute for i in waits), 2)
         torch.testing.assert_close(result, args[0] + args[1])
 
     def test_static_unroll_tensor_load_buffering(self) -> None:
@@ -4264,7 +4266,7 @@ class TestPallas(TestCase):
         ref = torch.nn.functional.scaled_dot_product_attention(
             query.float().cpu(), key.float().cpu(), val.float().cpu()
         ).to(device=DEVICE)
-        code, result = code_and_output(
+        _, result = code_and_output(
             pallas_attention,
             args,
             block_sizes=[4, 128, 128],
@@ -4272,24 +4274,6 @@ class TestPallas(TestCase):
             pallas_pre_broadcast=True,
             pallas_load_buffer_count=[2, 2, 2],
         )
-        self.assertIn("jax.lax.fori_loop", code)
-        self.assertIn("pltpu.make_async_copy", code)
-        self.assertIn("def _prime_fori_loads", code)
-        # The first three entries are pre-broadcast loop-carried state. K and V
-        # then receive two VMEM stages and two semaphore slots each.
-        self.assertIn(
-            "_scratch_shapes=["
-            "((4, 128, 128), 'jnp.float32', 'vmem'), "
-            "((4, 128, 128), 'jnp.float32', 'vmem'), "
-            "((4, 128, 128), 'jnp.float32', 'vmem'), "
-            "((2, 4, 128, 128), 'jnp.float32', 'vmem'), "
-            "((2,), None, 'dma_semaphore'), "
-            "((2, 4, 128, 128), 'jnp.float32', 'vmem'), "
-            "((2,), None, 'dma_semaphore')]",
-            code,
-        )
-        self.assertIn("_hbm_arg_indices=[1, 2]", code)
-        self.assertNotIn("q_view_buf", code)
         torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
 
     def test_attention_emit_pipeline_correctness_head_dim_256(self) -> None:
@@ -4608,16 +4592,13 @@ class TestPallas(TestCase):
         ``NameError: name 'indices_2' is not defined`` at trace time.
         """
         x = torch.randn(256, 128, device=DEVICE, dtype=torch.float32)
-        code, result = code_and_output(
+        _, result = code_and_output(
             pallas_chunked_add,
             (x,),
             block_sizes=[128],
             pallas_loop_type="fori_loop",
             pallas_load_buffer_count=[2],
         )
-        self.assertIn("def _prime_fori_loads", code)
-        self.assertIn("((2, 256, 128), 'jnp.float32', 'vmem')", code)
-        self.assertIn("((2,), None, 'dma_semaphore')", code)
         torch.testing.assert_close(result, x + 1.0)
 
     def test_mixed_scalar_and_slice_access(self) -> None:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -750,6 +750,28 @@ def pallas_fixed_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_overlap_initial_dma_with_normalization(
+    lhs: torch.Tensor,
+    table: torch.Tensor,
+    starts: torch.Tensor,
+) -> torch.Tensor:
+    """Normalize rows while the first dynamic matmul window is loading."""
+    rows = hl.specialize(lhs.size(0))
+    hl.specialize(table.size(0))
+    out = torch.empty([starts.size(0), rows, 128], dtype=lhs.dtype, device=lhs.device)
+    for _ in hl.grid(1):
+        lhs_f32 = lhs[:, :].to(torch.float32)
+        inverse_rms = torch.rsqrt(lhs_f32.pow(2).mean(dim=-1, keepdim=True) + 1e-5)
+        normalized = (lhs_f32 * inverse_rms).to(lhs.dtype)
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            weight = table[:, begin + hl.arange(128)]
+            projected = torch.matmul(normalized, weight)
+            out[tile, :, :] = projected[None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
     """Exercise a compound modulo operand whose parentheses are significant."""
     out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
@@ -960,11 +982,15 @@ class TestPallas(TestCase):
                     )
                 )
                 self.assertIn(loop_marker, code)
-                self.assertIn("def _prime_fori_loads", code)
+                self.assertNotIn("def _prime_fori_loads", code)
                 self.assertIn("def _prefetch_fori_loads", code)
                 self.assertIn(
                     "pltpu.make_async_copy(table.at[:, pl.ds(pl.multiple_of(",
                     code,
+                )
+                self.assertLess(
+                    code.index("pltpu.make_async_copy(table.at["),
+                    code.index(loop_marker),
                 )
                 self.assertRegex(code, r"table_buf\.at\[\(_j \+ 1\) % 2\]")
                 self.assertNotIn("one_hot", code)
@@ -1015,10 +1041,11 @@ class TestPallas(TestCase):
         code = pallas_refilled_dynamic_matmul.bind(
             (lhs, table, starts)
         ).to_triton_code()
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
         self.assertIn("def _refill_fori_load", code)
         self.assertNotIn("table_buf.at[", code)
         table_copy_position = code.index("make_async_copy(table.at[")
+        self.assertLess(table_copy_position, code.index("jax.lax.fori_loop"))
         wait_position = code.index(".wait()", table_copy_position)
         matmul_position = code.index("lax.dot_general")
         refill_position = code.index("def _refill_fori_load")
@@ -3692,7 +3719,7 @@ class TestPallas(TestCase):
             pallas_load_buffer_count=[2, 1],
         )
 
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
         self.assertIn("def _prefetch_fori_loads", code)
         self.assertIn("((2, 8, 128), 'jnp.float32', 'vmem')", code)
         self.assertIn("((2,), None, 'dma_semaphore')", code)
@@ -3703,9 +3730,9 @@ class TestPallas(TestCase):
         # does not wait. The body starts the next stage before any current-stage
         # wait, then waits for both the ordinary depth-one load and selected load
         # before consuming the selected stage.
-        prime_start = code.index("def _prime_fori_loads")
-        fori_call = code.index("jax.lax.fori_loop", prime_start)
-        prime = code[prime_start:fori_call]
+        prime_start = code.index("pltpu.make_async_copy(x.at[")
+        body_definition = code.index("def _fori_body_0", prime_start)
+        prime = code[prime_start:body_definition]
         self.assertIn(".start()", prime)
         self.assertNotIn(".wait()", prime)
 
@@ -3747,9 +3774,13 @@ class TestPallas(TestCase):
             pallas_load_buffer_count=[2, 1],
         )
 
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
         self.assertIn("def _prefetch_fori_loads", code)
         self.assertIn("for _j in range(", code)
+        self.assertLess(
+            code.index("pltpu.make_async_copy(x.at["),
+            code.index("for _j in range("),
+        )
         self.assertNotIn("jax.lax.fori_loop", code)
         self.assertIn("((2, 8, 128), 'jnp.float32', 'vmem')", code)
         self.assertIn("((2,), None, 'dma_semaphore')", code)
@@ -4267,7 +4298,11 @@ class TestPallas(TestCase):
         )
         self.assertIn("jax.lax.fori_loop", code)
         self.assertIn("pltpu.make_async_copy", code)
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
+        self.assertLess(
+            code.index("pltpu.make_async_copy(k_view.at["),
+            code.index("jax.lax.fori_loop"),
+        )
         # The first three entries are pre-broadcast loop-carried state. K and V
         # then receive two VMEM stages and two semaphore slots each.
         self.assertIn(
@@ -4608,7 +4643,11 @@ class TestPallas(TestCase):
             pallas_loop_type="fori_loop",
             pallas_load_buffer_count=[2],
         )
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
+        self.assertLess(
+            code.index("pltpu.make_async_copy(x.at["),
+            code.index("jax.lax.fori_loop"),
+        )
         self.assertIn("((2, 256, 128), 'jnp.float32', 'vmem')", code)
         self.assertIn("((2,), None, 'dma_semaphore')", code)
         torch.testing.assert_close(result, x + 1.0)
@@ -5472,6 +5511,47 @@ class TestPallas(TestCase):
                 self.assertEqual(pad_dims, [(1, 0, 16, expected_extra_pad)])
                 expected = x[3 : 3 + extent].sum(dim=0, keepdim=True)
                 torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    def test_initial_dma_overlaps_outer_normalization_codegen(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        code = pallas_overlap_initial_dma_with_normalization.bind(
+            (lhs, table, starts)
+        ).to_triton_code(helion.Config(pallas_loop_type="fori_loop"))
+        first_dma = code.index("pltpu.make_async_copy(table.at[")
+        normalization = code.index("lax.rsqrt")
+        first_wait = code.index(".wait()", first_dma)
+        matmul = code.index("lax.dot_general")
+        self.assertLess(first_dma, normalization)
+        self.assertLess(normalization, first_wait)
+        self.assertLess(first_wait, matmul)
+        self.assertNotIn("def _prime_fori_loads", code)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_initial_dma_overlaps_outer_normalization(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_overlap_initial_dma_with_normalization,
+            (lhs, table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        lhs_f32 = lhs.float()
+        normalized = (
+            lhs_f32 * torch.rsqrt(lhs_f32.pow(2).mean(-1, keepdim=True) + 1e-5)
+        ).to(lhs.dtype)
+        expected = torch.stack(
+            [
+                torch.matmul(
+                    normalized.float(),
+                    table[:, begin : begin + 128].float(),
+                )
+                for begin in range(0, 512, 128)
+            ]
+        ).to(lhs.dtype)
+        torch.testing.assert_close(result, expected)
 
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""


### PR DESCRIPTION
Stacked PRs:
 * #3405
 * #3396
 * #3394
 * #3402
 * #3401
 * #3407
 * #3403
 * __->__#3399
 * #3397
 * #3408
 * #3387
 * #3392
 * #3391


--- --- ---

### [Pallas] Hoist initial buffered DMAs over pure compute


Start the first buffered HBM load as early as its data and lexical scope permit,
so independent root computation can hide part of the initial DMA latency.

A representative Helion kernel normalizes its left-hand side before consuming a
dynamic weight window:

```python
lhs_f32 = lhs[:, :].to(torch.float32)
inverse_rms = torch.rsqrt(lhs_f32.pow(2).mean(dim=-1, keepdim=True) + 1e-5)
normalized = (lhs_f32 * inverse_rms).to(lhs.dtype)
for tile in hl.tile(starts.size(0), block_size=1):
    begin = starts[tile.begin] * 128
    weight = table[:, begin + hl.arange(128)]
    projected = torch.matmul(normalized, weight)
```

Previously all normalization work preceded the guarded initial transfer:

```python
v1 = v0 * v0
...
inverse_rms = lax.rsqrt(mean)
...
@pl.when(num_iterations > 0)
def prime():
    copy = pltpu.make_async_copy(first_window, table_buf, table_sem)
    copy.start()
for j in range(num_iterations):
    copy.wait()
    projected = lax.dot_general(normalized, table_buf, ...)
```

Use the preceding fixed-positive-extent proof to make the prime unconditional,
then move it across only proven-safe statements. Hoisting may cross plain
assignments and compiler-owned scratch initialization. It stops at structured
control flow, user-visible stores, an assignment producing a DMA address operand,
or a reference to a device-loop induction variable unavailable at the root.

That final scope check matters for nested loops. An inner prime such as
`x.at[..., pl.ds(j_outer * block, block)]` must remain inside the outer body;
moving it to kernel entry would generate an undefined `j_outer` and fail before
computation.

The accepted case now overlaps the first transfer with normalization while
retaining the wait immediately before the matmul consumes the buffer:

```python
copy = pltpu.make_async_copy(first_window, table_buf, table_sem)
copy.start()
v1 = v0 * v0
...
inverse_rms = lax.rsqrt(mean)
...
for j in range(num_iterations):
    copy.wait()
    projected = lax.dot_general(normalized, table_buf, ...)
```

The fused TP16 RMSNorm/QKVOG/all-to-all program starts both independent weight
streams before RMSNorm and RoPE setup. At 8K global tokens, a 20-call device
profile improved from 935.06 us to 933.16 us (-1.90 us, -0.20%). Correctness was
unchanged: `allclose=true`, `repeat_exact_fraction=1.0`,
`exact_fraction=0.999628`, and `max_abs=0.25` in FP8 K/V. The same-contract JAX
reference measured 744.35 us, so this is an incremental optimization rather than
handwritten-Pallas parity.

Tests execute the complete normalization plus four matmuls and exercise nested
partial-tile loops. Raw JAX/Pallas execution on both TPU hosts was bit-exact for
the overlap computation (`max_abs=0.0`). `pre-commit run --all-files` and
`./lint.sh check` pass.
