### PR TITLE
[Pallas] Pass TPU VMEM capacity to Mosaic

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from ..runtime.config import Config
     from ..runtime.kernel import BoundKernel
     from ..runtime.settings import DotPrecision
+    from .aten_lowering import Lowering
     from .compile_environment import CompileEnvironment
     from .cute.cute_mma import _CuteMmaNode
     from .device_function import Argument
@@ -897,6 +898,15 @@ class Backend(abc.ABC):
         Called after static loop unrolling but before type propagation
         and tracing.  Backends can override this to rewrite the user's
         AST for algorithmic transformations that change loop structure.
+        """
+        return None
+
+    def pre_inductor_lowering(self, node: torch.fx.Node) -> Lowering | None:
+        """Return a backend-owned lowering that must bypass Inductor IR.
+
+        Most ATen operations use Helion's shared Inductor lowering. Backends may
+        override this for operations whose Inductor representation cannot be
+        consumed by that shared path.
         """
         return None
 

--- a/helion/_compiler/helper_function.py
+++ b/helion/_compiler/helper_function.py
@@ -20,6 +20,7 @@ from .ast_extension import statement_from_string
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from collections.abc import Sequence
     import types
 
     from torch.fx.node import Node
@@ -33,6 +34,8 @@ class CodegenInterface(ABC):
 
     def __init__(self, device_function: DeviceFunction) -> None:
         self.device_function = device_function
+        self._pre_node_statements: dict[int, list[ast.AST]] = {}
+        self._post_node_statements: dict[int, list[ast.AST]] = {}
 
     @abstractmethod
     def add_statement(self, stmt: ast.AST | str | None) -> None:
@@ -41,6 +44,20 @@ class CodegenInterface(ABC):
     @contextlib.contextmanager
     def statement_owner_node(self, node: Node) -> Iterator[None]:
         yield
+
+    def add_pre_node_statements(
+        self, node: Node, statements: Sequence[ast.AST]
+    ) -> None:
+        self._pre_node_statements.setdefault(id(node), []).extend(statements)
+
+    def add_post_node_statement(self, node: Node, statement: ast.AST) -> None:
+        self._post_node_statements.setdefault(id(node), []).append(statement)
+
+    def pop_pre_node_statements(self, node: Node) -> list[ast.AST]:
+        return self._pre_node_statements.pop(id(node), [])
+
+    def pop_post_node_statements(self, node: Node) -> list[ast.AST]:
+        return self._post_node_statements.pop(id(node), [])
 
     def tmpvar(self, *, dce: bool = False, prefix: str = "v") -> str:
         """Generate a temporary variable name."""

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -1501,6 +1501,8 @@ class GraphInterpreter(LoweringContext, Interpreter):
                 V.set_current_node(n),
             ):
                 try:
+                    for statement in self.cg.pop_pre_node_statements(n):
+                        self.cg.add_statement(statement)
                     cute_state = self.cg.device_function.cute_state
                     if cute_state.has_tcgen05_pair_epilogue_plan:
                         if cute_state.is_deferred_tcgen05_pair_epilogue_node(n):
@@ -1563,6 +1565,8 @@ class GraphInterpreter(LoweringContext, Interpreter):
                                 self.cg.device_function.expr_to_var_info[expr] = (
                                     VarInfo(repr(result.value), n)
                                 )
+                        for statement in self.cg.pop_post_node_statements(n):
+                            self.cg.add_statement(statement)
                         return result
                     if not isinstance(result, (ast.Name, ast.Constant)):
                         self.cg.add_statement(create(ast.Expr, value=result))

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -126,6 +126,11 @@ def prepare_node_lowering(
         node.meta["lowering"] = APIFuncLowering(api)
         return
 
+    backend_lowering = CompileEnvironment.current().backend.pre_inductor_lowering(node)
+    if backend_lowering is not None:
+        node.meta["lowering"] = backend_lowering
+        return
+
     if node.target in aten_lowering_dispatch:
         if node.target in {
             torch.ops.aten.argmax.default,

--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -21,6 +21,7 @@ from torch.fx.node import map_arg
 
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
+from ..aten_lowering import AtenLowering
 from ..aten_lowering import _env_arg
 from ..aten_lowering import _node_dtype_kwarg
 from ..aten_lowering import _pallas_argreduce
@@ -48,6 +49,35 @@ from ..matmul_utils import _needs_f32_accumulator
 
 if TYPE_CHECKING:
     from ..aten_lowering import LoweringContext
+
+
+cat_lowering_pallas = AtenLowering(target=torch.ops.aten.cat.default)
+
+
+@cat_lowering_pallas.register_codegen("pallas")
+def codegen_cat_pallas(ctx: LoweringContext, node: Node) -> ast.AST:
+    tensors = map_arg(node.args[0], lambda arg: _env_arg(ctx, arg))
+    assert isinstance(tensors, (list, tuple)) and tensors
+    assert all(isinstance(tensor, ast.AST) for tensor in tensors)
+    dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
+    assert isinstance(dim, int)
+    output = node.meta["val"]
+    assert isinstance(output, torch.Tensor)
+    if dim < 0:
+        dim += output.ndim
+    assert 0 <= dim < output.ndim
+
+    placeholders: dict[str, ast.AST] = {
+        f"tensor_{index}": cast("ast.AST", tensor)
+        for index, tensor in enumerate(tensors)
+    }
+    values = ", ".join(f"{{tensor_{index}}}" for index in range(len(tensors)))
+    if len(tensors) == 1:
+        values += ","
+    return expr_from_string(
+        f"jnp.concatenate(({values}), axis={dim})",
+        **placeholders,
+    )
 
 
 @argmax_lowering.register_codegen("pallas")

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from ...runtime.config import Config
     from ...runtime.kernel import BoundKernel
     from ...runtime.settings import DotPrecision
+    from ..aten_lowering import Lowering
     from ..device_function import Argument
     from ..device_ir import GraphInfo
     from ..host_function import HostFunction
@@ -1480,6 +1481,13 @@ class PallasBackend(Backend):
         except NoCurrentFunction:
             return self.default_launcher_name
         return self.build_launcher_name(device_fn.config)
+
+    def pre_inductor_lowering(self, node: torch.fx.Node) -> Lowering | None:
+        from .aten_lowering import cat_lowering_pallas
+
+        if node.target is torch.ops.aten.cat.default:
+            return cat_lowering_pallas
+        return None
 
     def pre_codegen(
         self,

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -54,13 +54,19 @@ def load_expr(
         return emit_gather(state, plan.plan, active_name)
 
     from helion._compiler.device_function import PallasMemorySpace
+    from helion._compiler.pallas.plan_tiling import ContiguousRangeIndexPattern
 
     if (
         active_name == arg_name
         and device_fn.pallas_memory_space.get(id(tensor)) == PallasMemorySpace.HBM
-        and device_fn.is_pallas_remote_copy_operand(tensor)
+        and (
+            device_fn.is_pallas_remote_copy_operand(tensor)
+            or any(
+                isinstance(pattern, ContiguousRangeIndexPattern) for pattern in patterns
+            )
+        )
     ):
-        return _remote_hbm_load_expr(state, subscript, tensor, arg_name)
+        return _hbm_load_expr(state, subscript, tensor, arg_name)
 
     parts, none_dims = index_parts(state, subscript, tensor)
     scalar_load = classify_vmem_scalar_load(state, tensor, parts, patterns)
@@ -81,19 +87,19 @@ def load_expr(
     return result
 
 
-def _remote_hbm_load_expr(
+def _hbm_load_expr(
     state: CodegenState,
     subscript: list[object],
     tensor: torch.Tensor,
     name: str,
 ) -> ast.AST:
-    """Stage one directly accessed remote-DMA HBM region into VMEM.
+    """Stage one directly accessed HBM region into VMEM.
 
-    Remote-copy destinations can intentionally remain in HBM so their address is
-    stable across program iterations. Mosaic cannot load an HBM Ref directly, so
-    materialize the selected region at the exact source-level load. Emitting the
-    DMA here preserves ordering with nearby remote-copy waits and avoids changing
-    the placement of unrelated tensor arguments.
+    Remote-copy destinations and dynamic contiguous windows can intentionally
+    remain in HBM. Mosaic cannot load an HBM Ref directly, so materialize the
+    selected region at the exact source-level load. Emitting the DMA here
+    preserves ordering with nearby remote-copy waits and avoids changing the
+    placement of unrelated tensor arguments.
     """
     assert state.fx_node is not None
     value = state.fx_node.meta.get("val")
@@ -660,6 +666,7 @@ def _generated_index_code(
     """Generate index code based on the indexing pattern."""
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
     from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+    from helion._compiler.pallas.plan_tiling import ContiguousRangeIndexPattern
     from helion._compiler.pallas.plan_tiling import TensorIndexPattern
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
@@ -706,6 +713,18 @@ def _generated_index_code(
             in_pipeline,
             ast_subscripts,
             pipeline_scalar_indices_local,
+        )
+
+    if isinstance(pattern, ContiguousRangeIndexPattern):
+        if in_pipeline:
+            return ":"
+        if not raw_hbm_ref:
+            raise RuntimeError(
+                "a contiguous dynamic range must address its raw HBM source"
+            )
+        index = _index_expr_from_ast(state, subscript_index, ast_subscripts)
+        return (
+            f"pl.ds(pl.multiple_of({index}[0], {pattern.alignment}), {pattern.length})"
         )
 
     if isinstance(pattern, TensorIndexPattern):

--- a/helion/_compiler/pallas/distributed_ops.py
+++ b/helion/_compiler/pallas/distributed_ops.py
@@ -52,7 +52,7 @@ def _automatic_collective_id(fn: Callable[..., object]) -> int:
 @dataclass
 class _PallasRemoteCopyInfo:
     op_name: str
-    source_materialization: tuple[str, ast.AST] | None
+    source_materialization: tuple[ast.AST, ast.AST] | None
 
 
 @_decorators.codegen(remote_barrier, "pallas")
@@ -148,6 +148,133 @@ def _direct_ref_expr(tensor: ast.AST, ast_index: list[object]) -> ast.AST:
     return expr_from_string(f"{{tensor}}.at[{', '.join(parts)}]", **placeholders)
 
 
+def _direct_value_expr(tensor: ast.AST, ast_index: list[object]) -> ast.AST:
+    """Index an ordinary JAX value with the same leading indices as a Ref."""
+    if not ast_index:
+        return tensor
+    placeholders: dict[str, ast.AST] = {"tensor": tensor}
+    parts = []
+    for index, value in enumerate(ast_index):
+        if isinstance(value, int):
+            value = expr_from_string(repr(value))
+        assert isinstance(value, ast.AST)
+        key = f"index_{index}"
+        placeholders[key] = value
+        parts.append(f"{{{key}}}")
+    return expr_from_string(f"{{tensor}}[{', '.join(parts)}]", **placeholders)
+
+
+def _materialized_source_value(
+    state: CodegenState,
+    tensor_ast: ast.AST,
+    ast_index: list[object],
+) -> ast.AST:
+    """Select a computed source region without dynamic value slicing.
+
+    A send-ring is commonly spelled by expanding one computed tile across a
+    leading slot dimension and indexing that dimension with the current slot.
+    The selected value is independent of the slot, so materialize the original
+    pre-broadcast tile directly. Pallas otherwise sees a dynamic slice of an
+    ordinary JAX value, which TPU lowering does not support.
+    """
+    if not ast_index or state.fx_node is None:
+        return _direct_value_expr(tensor_ast, ast_index)
+    src_node = state.fx_node.args[0]
+    if (
+        not isinstance(src_node, torch.fx.Node)
+        or src_node.op != "call_function"
+        or src_node.target is not torch.ops.aten.expand.default
+        or not src_node.args
+        or not isinstance(src_node.args[0], torch.fx.Node)
+    ):
+        return _direct_value_expr(tensor_ast, ast_index)
+
+    expanded_input = src_node.args[0]
+    expanded = src_node.meta.get("val")
+    unexpanded = expanded_input.meta.get("val")
+    if not isinstance(expanded, torch.Tensor) or not isinstance(
+        unexpanded, torch.Tensor
+    ):
+        return _direct_value_expr(tensor_ast, ast_index)
+    indexed_dims = len(ast_index)
+    if expanded.ndim != unexpanded.ndim or indexed_dims > expanded.ndim:
+        return _direct_value_expr(tensor_ast, ast_index)
+
+    from ..compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    if not all(
+        env.known_equal(unexpanded.shape[dim], 1)
+        and (env.known_equal(expanded.shape[dim], 1) or expanded.stride(dim) == 0)
+        for dim in range(indexed_dims)
+    ):
+        return _direct_value_expr(tensor_ast, ast_index)
+    if not all(
+        env.known_equal(unexpanded.shape[dim], expanded.shape[dim])
+        for dim in range(indexed_dims, expanded.ndim)
+    ):
+        return _direct_value_expr(tensor_ast, ast_index)
+
+    from ...language import view_ops
+
+    if (
+        expanded_input.op == "call_function"
+        and expanded_input.target is view_ops.subscript
+        and len(expanded_input.args) >= 2
+        and isinstance(expanded_input.args[0], torch.fx.Node)
+        and isinstance(expanded_input.args[1], (list, tuple))
+    ):
+        base_node = expanded_input.args[0]
+        indices = expanded_input.args[1]
+        if (
+            len(indices) == expanded.ndim
+            and all(index is None for index in indices[:indexed_dims])
+            and all(
+                isinstance(index, slice)
+                and index.start is None
+                and index.stop is None
+                and index.step is None
+                for index in indices[indexed_dims:]
+            )
+        ):
+            base_ast = state.env.get(base_node)
+            if isinstance(base_ast, ast.AST):
+                return base_ast
+
+    unexpanded_ast = state.env.get(expanded_input)
+    if isinstance(unexpanded_ast, ast.AST):
+        return _direct_value_expr(unexpanded_ast, [0] * indexed_dims)
+    return _direct_value_expr(tensor_ast, ast_index)
+
+
+def _physical_tile_shape(
+    state: CodegenState, tensor: torch.Tensor
+) -> tuple[int | torch.SymInt, ...]:
+    """Resolve block-symbol dimensions to this config's physical tile sizes."""
+    from ..compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    shape: list[int | torch.SymInt] = []
+    for size in tensor.shape:
+        block_id = env.resolve_block_id(size)
+        resolved = (
+            state.device_function.resolved_block_size(block_id)
+            if block_id is not None
+            else None
+        )
+        shape.append(resolved if resolved is not None else size)
+    return tuple(shape)
+
+
+def _tensor_argument_name(state: CodegenState, tensor: torch.Tensor) -> str | None:
+    """Return a kernel argument name, or ``None`` for a computed device value."""
+    from ..host_function import HostFunction
+
+    if tensor not in HostFunction.current().tensor_to_origin:
+        return None
+    return state.device_function.tensor_arg(tensor).name
+
+
 def _remote_ref_expr(
     state: CodegenState,
     tensor: torch.Tensor,
@@ -161,23 +288,29 @@ def _remote_ref_expr(
     """Resolve a logical remote-copy region against the active VMEM block."""
     assert isinstance(proxy_index, (list, tuple))
     assert isinstance(ast_index, list)
-    try:
-        name = state.device_function.tensor_arg(tensor).name
-    except KeyError:
+    name = _tensor_argument_name(state, tensor)
+    if name is None:
         if not materialize_device_value:
             raise exc.TypeInferenceError(
                 "Pallas remote-copy destinations must be kernel tensor arguments"
-            ) from None
+            )
         # A computed tile is a JAX value, while TPU DMA requires a Ref. Allocate
         # one reusable VMEM slot now, but defer populating it until descriptor
         # start so a preceding wait can safely release the previous transfer.
         assert isinstance(tensor_ast, ast.AST)
         name = state.device_function.register_scratch(
-            tuple(tensor.shape), tensor.dtype, name_hint="remote_src"
+            _physical_tile_shape(state, tensor),
+            tensor.dtype,
+            name_hint="remote_src",
         )
+        scratch_ref = _direct_ref_expr(expr_from_string(name), ast_index)
+        source_value = _materialized_source_value(state, tensor_ast, ast_index)
         assert state.fx_node is not None
-        state.fx_node.meta[_PALLAS_SRC_MATERIALIZATION_META] = (name, tensor_ast)
-        return _direct_ref_expr(expr_from_string(name), ast_index)
+        state.fx_node.meta[_PALLAS_SRC_MATERIALIZATION_META] = (
+            scratch_ref,
+            source_value,
+        )
+        return scratch_ref
 
     from ..device_function import PallasMemorySpace
 
@@ -234,24 +367,48 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
 
     device_fn = state.device_function
     device_fn.requires_remote_copy = True
-    send_sem = device_fn.register_dma_semaphore(name_hint="remote_send_sem")
-    recv_sem = device_fn.register_dma_semaphore(name_hint="remote_recv_sem")
-    op_name = device_fn.new_var("remote_copy", dce=False)
+    proxy_src_index = state.proxy_arg(1)
+    ast_src_index = state.ast_args[1]
+    assert isinstance(proxy_src_index, (list, tuple))
+    assert isinstance(ast_src_index, list)
 
     assert state.fx_node is not None
     descriptor_id = state.fx_node.meta.get(_REMOTE_COPY_DESCRIPTOR_ID_META)
     if not isinstance(descriptor_id, int):
         raise exc.InternalError(RuntimeError("remote-copy descriptor has no ID"))
 
+    computed_source = _tensor_argument_name(state, src) is None
+    send_slot_shape: tuple[int, ...] = ()
+    if computed_source and ast_src_index:
+        try:
+            indexed_shape = tuple(int(size) for size in src.shape[: len(ast_src_index)])
+        except (TypeError, ValueError):
+            indexed_shape = ()
+        if indexed_shape and all(size > 0 for size in indexed_shape):
+            send_slot_shape = indexed_shape
+    send_sem_name = device_fn.register_dma_semaphore(
+        name_hint="remote_send_sem",
+        shape=send_slot_shape,
+    )
+    send_sem = (
+        _direct_ref_expr(expr_from_string(send_sem_name), ast_src_index)
+        if send_slot_shape
+        else expr_from_string(send_sem_name)
+    )
+    recv_sem = device_fn.register_dma_semaphore(name_hint="remote_recv_sem")
     src_ref = _remote_ref_expr(
         state,
         src,
         state.ast_args[0],
-        state.proxy_arg(1),
-        state.ast_args[1],
+        proxy_src_index,
+        ast_src_index,
         REMOTE_SRC_INDEXING_PATTERNS,
         materialize_device_value=True,
     )
+    materialization = state.fx_node.meta.get(_PALLAS_SRC_MATERIALIZATION_META)
+    if materialization is not None:
+        assert isinstance(materialization, tuple)
+    op_name = device_fn.new_var("remote_copy", dce=False)
     dst_ref = _remote_ref_expr(
         state,
         dst,
@@ -269,17 +426,16 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
         statement_from_string(
             f"{op_name} = pltpu.make_async_remote_copy("
             "{src_ref}, {dst_ref}, "
-            f"{send_sem}, {recv_sem}, "
+            "{send_sem}, "
+            f"{recv_sem}, "
             "device_id={device_id}, "
             "device_id_type=pl.DeviceIdType.LOGICAL)",
             src_ref=src_ref,
             dst_ref=dst_ref,
+            send_sem=send_sem,
             device_id=device_id,
         )
     )
-    materialization = state.fx_node.meta.get(_PALLAS_SRC_MATERIALIZATION_META)
-    if materialization is not None:
-        assert isinstance(materialization, tuple)
     device_fn.remote_copy_descriptors[descriptor_id] = _PallasRemoteCopyInfo(
         op_name=op_name,
         source_materialization=materialization,
@@ -314,14 +470,15 @@ def _emit_source_materialization(
     materialization = info.source_materialization
     if materialization is None:
         return False
-    scratch, value = materialization
-    assert isinstance(scratch, str)
+    target, value = materialization
+    assert isinstance(target, ast.AST)
     assert isinstance(value, ast.AST)
     state.codegen.add_statement(
         statement_from_string(
-            f"{scratch}[...] = jnp.pad("
+            "{target}[...] = jnp.pad("
             "{value}, tuple((0, dst - src) for src, dst in "
-            f"zip({{value}}.shape, {scratch}.shape, strict=True)))",
+            "zip({value}.shape, {target}.shape, strict=True)))",
+            target=target,
             value=value,
         )
     )

--- a/helion/_compiler/pallas/distributed_ops.py
+++ b/helion/_compiler/pallas/distributed_ops.py
@@ -28,6 +28,8 @@ from .plan_tiling import REMOTE_SRC_INDEXING_PATTERNS
 
 if TYPE_CHECKING:
     from ..inductor_lowering import CodegenState
+    from ..tile_strategy import ForiLoopState
+    from ..tile_strategy import RemoteRecvDrain
 
 
 _PALLAS_SRC_MATERIALIZATION_META = "_helion_pallas_remote_copy_src_materialization"
@@ -53,6 +55,7 @@ def _automatic_collective_id(fn: Callable[..., object]) -> int:
 class _PallasRemoteCopyInfo:
     op_name: str
     source_materialization: tuple[ast.AST, ast.AST] | None
+    deferred_recv: RemoteRecvDrain | None = None
 
 
 @_decorators.codegen(remote_barrier, "pallas")
@@ -162,6 +165,48 @@ def _direct_value_expr(tensor: ast.AST, ast_index: list[object]) -> ast.AST:
         placeholders[key] = value
         parts.append(f"{{{key}}}")
     return expr_from_string(f"{{tensor}}[{', '.join(parts)}]", **placeholders)
+
+
+def _canonical_recv_ref(dst_ref: ast.AST, indexed_dims: int) -> ast.AST | None:
+    """Return a fixed same-shaped destination region for a receive drain."""
+    if not isinstance(dst_ref, ast.Subscript):
+        return None
+    raw_parts = (
+        dst_ref.slice.elts if isinstance(dst_ref.slice, ast.Tuple) else [dst_ref.slice]
+    )
+    if len(raw_parts) < indexed_dims:
+        return None
+    placeholders: dict[str, ast.AST] = {"base": dst_ref.value}
+    rendered: list[str] = []
+    for index, part in enumerate(raw_parts):
+        key = f"part_{index}"
+        if index < indexed_dims:
+            if (
+                isinstance(part, ast.Call)
+                and isinstance(part.func, ast.Attribute)
+                and part.func.attr == "ds"
+                and len(part.args) >= 2
+            ):
+                part = expr_from_string("pl.ds(0, {size})", size=part.args[1])
+            else:
+                part = expr_from_string("0")
+        placeholders[key] = part
+        rendered.append(f"{{{key}}}")
+    return expr_from_string(f"{{base}}[{', '.join(rendered)}]", **placeholders)
+
+
+def _active_fori_loop(state: CodegenState) -> ForiLoopState | None:
+    from ..tile_strategy import ForiLoopState
+
+    return next(
+        (
+            loop
+            for loops in state.codegen.active_device_loops.values()
+            for loop in loops
+            if isinstance(loop, ForiLoopState)
+        ),
+        None,
+    )
 
 
 def _materialized_source_value(
@@ -395,7 +440,26 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
         if send_slot_shape
         else expr_from_string(send_sem_name)
     )
-    recv_sem = device_fn.register_dma_semaphore(name_hint="remote_recv_sem")
+    try:
+        payload_shape = tuple(int(size) for size in src.shape[len(proxy_src_index) :])
+    except (TypeError, ValueError):
+        payload_shape = ()
+    fori_loop = _active_fori_loop(state)
+    dst_name: str | None = None
+    drain_key: tuple[str, tuple[int, ...]] | None = None
+    deferred_recv: RemoteRecvDrain | None = None
+    if fori_loop is not None and payload_shape:
+        dst_name = _tensor_argument_name(state, dst)
+        if dst_name is not None:
+            read_names, _ = device_fn.get_tensor_read_write_names()
+            if dst_name not in read_names:
+                drain_key = (dst_name, payload_shape)
+                deferred_recv = fori_loop._remote_recv_drains.get(drain_key)
+    recv_sem = (
+        deferred_recv.semaphore
+        if deferred_recv is not None
+        else device_fn.register_dma_semaphore(name_hint="remote_recv_sem")
+    )
     src_ref = _remote_ref_expr(
         state,
         src,
@@ -417,6 +481,15 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
         state.ast_args[4],
         REMOTE_DST_INDEXING_PATTERNS,
     )
+    if fori_loop is not None and drain_key is not None and deferred_recv is None:
+        ast_dst_index = state.ast_args[4]
+        assert isinstance(ast_dst_index, list)
+        canonical_ref = _canonical_recv_ref(dst_ref, len(ast_dst_index))
+        if canonical_ref is not None:
+            from ..tile_strategy import RemoteRecvDrain
+
+            deferred_recv = RemoteRecvDrain(recv_sem, canonical_ref)
+            fori_loop._remote_recv_drains[drain_key] = deferred_recv
     device_id = state.ast_args[2]
     if isinstance(device_id, int):
         device_id = expr_from_string(repr(device_id))
@@ -439,6 +512,7 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
     device_fn.remote_copy_descriptors[descriptor_id] = _PallasRemoteCopyInfo(
         op_name=op_name,
         source_materialization=materialization,
+        deferred_recv=deferred_recv,
     )
     return expr_from_string(op_name)
 
@@ -489,7 +563,34 @@ def _emit_wait(state: CodegenState, method: str) -> ast.AST:
     info = _paired_copy_info(state)
     if method == "start":
         _emit_source_materialization(state, info)
-    state.codegen.add_statement(statement_from_string(f"{info.op_name}.{method}()"))
+        if info.deferred_recv is not None:
+            fori_loop = _active_fori_loop(state)
+            if fori_loop is None:
+                info.deferred_recv = None
+            elif state.codegen.statements_stack[-1] is fori_loop.inner_statements:
+                info.deferred_recv.starts_per_iteration += 1
+            else:
+                counter = info.deferred_recv.dynamic_start_counter
+                if counter is None:
+                    counter = state.device_function.register_scratch(
+                        (128,), torch.int32, name_hint="remote_recv_count"
+                    )
+                    info.deferred_recv.dynamic_start_counter = counter
+                    fori_loop.outer_prefix.append(
+                        statement_from_string(
+                            f"{counter}[...] = jnp.zeros_like({counter}[...])"
+                        )
+                    )
+                state.codegen.add_statement(
+                    statement_from_string(
+                        f"{counter}[...] = {counter}[...] + "
+                        f"jnp.ones_like({counter}[...])"
+                    )
+                )
+    if method == "wait_recv" and info.deferred_recv is not None:
+        info.deferred_recv.waits_deferred = True
+    else:
+        state.codegen.add_statement(statement_from_string(f"{info.op_name}.{method}()"))
     return expr_from_string("None")
 
 

--- a/helion/_compiler/pallas/dma.py
+++ b/helion/_compiler/pallas/dma.py
@@ -20,6 +20,16 @@ if TYPE_CHECKING:
 DmaDirection = Literal["load", "store"]
 
 
+def is_tpu_dma_aligned_shape(shape: tuple[int, ...], dtype: torch.dtype) -> bool:
+    """Whether a concrete VMEM shape satisfies TPU local-DMA alignment."""
+    if len(shape) >= 2:
+        return shape[-1] % 128 == 0 and shape[-2] % 8 == 0
+    if len(shape) == 1:
+        bitwidth = min(dtype.itemsize * 8, 32)
+        return shape[0] % (128 * (32 // bitwidth)) == 0
+    return True
+
+
 @dataclass(frozen=True, eq=False)
 class DmaTransfer:
     """One local HBM/VMEM transfer before resources are allocated."""

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+import operator
 from typing import TYPE_CHECKING
 
 import sympy
@@ -69,6 +70,15 @@ class NonePattern(IndexingPattern):
 @dataclass
 class TensorIndexPattern(IndexingPattern):
     """Tensor-valued index - no tiling. Resolved for indirect load/store codegen."""
+
+
+@dataclass
+class ContiguousRangeIndexPattern(IndexingPattern):
+    """Aligned ``base + arange(length)`` index addressable as one HBM window."""
+
+    base: int | torch.SymInt | torch.fx.Node
+    length: int
+    alignment: int
 
 
 @dataclass
@@ -316,9 +326,18 @@ def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
         isinstance(p, (ArbitraryIndexPattern, TileBeginWithOffsetPattern, NonePattern))
         for p in indexing_patterns
     )
+    has_contiguous_hbm_window = any(
+        isinstance(pattern, ContiguousRangeIndexPattern)
+        for pattern in indexing_patterns
+    )
     tid = id(tensor_val)
     current = device_fn.pallas_memory_space.get(tid)
-    if is_all_scalar:
+    if has_contiguous_hbm_window:
+        # A dynamic contiguous range cannot be represented by a static
+        # BlockSpec. Keep the source argument in HBM and stage exactly the
+        # selected range at its load site.
+        device_fn.pallas_memory_space[tid] = PallasMemorySpace.HBM
+    elif is_all_scalar:
         # Only mark for SMEM if not already assigned to VMEM or HBM
         if current is None:
             device_fn.pallas_memory_space[tid] = PallasMemorySpace.SMEM
@@ -384,6 +403,126 @@ def _is_supported_slice(idx: slice) -> bool:
     return True
 
 
+def _is_scalar_value(value: object) -> bool:
+    if isinstance(value, (int, torch.SymInt)):
+        return True
+    if isinstance(value, torch.fx.Node):
+        value = value.meta.get("val")
+    return isinstance(value, torch.Tensor) and value.ndim == 0
+
+
+def _constant_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, torch.fx.Node):
+        node_value = value.meta.get("val")
+        if isinstance(node_value, int):
+            return node_value
+    return None
+
+
+def _is_proven_multiple(value: object, alignment: int) -> bool:
+    """Conservatively prove that a scalar FX expression is alignment-multiple."""
+    constant = _constant_int(value)
+    if constant is not None:
+        return constant % alignment == 0
+    if not isinstance(value, torch.fx.Node) or value.op != "call_function":
+        return False
+
+    if value.target in (
+        operator.add,
+        torch.ops.aten.add.Scalar,
+        torch.ops.aten.add.Tensor,
+    ):
+        if value.kwargs.get("alpha", 1) != 1:
+            return False
+        return all(_is_proven_multiple(arg, alignment) for arg in value.args[:2])
+    if value.target in (
+        operator.sub,
+        torch.ops.aten.sub.Scalar,
+        torch.ops.aten.sub.Tensor,
+    ):
+        if value.kwargs.get("alpha", 1) != 1:
+            return False
+        return all(_is_proven_multiple(arg, alignment) for arg in value.args[:2])
+    if value.target in (
+        operator.mul,
+        torch.ops.aten.mul.Scalar,
+        torch.ops.aten.mul.Tensor,
+    ):
+        lhs, rhs = value.args[:2]
+        lhs_constant = _constant_int(lhs)
+        rhs_constant = _constant_int(rhs)
+        return (lhs_constant is not None and lhs_constant % alignment == 0) or (
+            rhs_constant is not None and rhs_constant % alignment == 0
+        )
+    return False
+
+
+def _iota_length(node: object) -> int | None:
+    if (
+        not isinstance(node, torch.fx.Node)
+        or node.op != "call_function"
+        or node.target is not torch.ops.prims.iota.default
+    ):
+        return None
+    start = node.kwargs.get("start", 0)
+    step = node.kwargs.get("step", 1)
+    if start != 0 or step != 1 or len(node.args) != 1:
+        return None
+    length = node.args[0]
+    return length if isinstance(length, int) and length > 0 else None
+
+
+def _match_contiguous_range_index(
+    node: torch.fx.Node,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+    load_value: object,
+) -> ContiguousRangeIndexPattern | None:
+    """Match an aligned scalar base plus an explicit unit-stride ``hl.arange``."""
+    if (
+        tensor_dim != tensor.ndim - 1
+        or node.op != "call_function"
+        or node.target
+        not in (operator.add, torch.ops.aten.add.Scalar, torch.ops.aten.add.Tensor)
+        or len(node.args) != 2
+        or node.kwargs.get("alpha", 1) != 1
+    ):
+        return None
+    if not isinstance(load_value, torch.Tensor) or not all(
+        isinstance(size, int) for size in load_value.shape
+    ):
+        return None
+    from .dma import is_tpu_dma_aligned_shape
+
+    if not is_tpu_dma_aligned_shape(tuple(load_value.shape), tensor.dtype):
+        return None
+    bitwidth = min(tensor.dtype.itemsize * 8, 32)
+    alignment = 128 if tensor.ndim > 1 else 128 * (32 // bitwidth)
+    lhs, rhs = node.args
+    for base, iota in ((lhs, rhs), (rhs, lhs)):
+        length = _iota_length(iota)
+        if length is None or length % alignment != 0:
+            continue
+        if not isinstance(base, (int, torch.SymInt, torch.fx.Node)):
+            continue
+        if not _is_scalar_value(base) or not _is_proven_multiple(base, alignment):
+            continue
+        value = node.meta.get("val")
+        if (
+            isinstance(value, torch.Tensor)
+            and value.ndim == 1
+            and value.shape[0] == length
+        ):
+            return ContiguousRangeIndexPattern(
+                base=base,
+                length=length,
+                alignment=alignment,
+            )
+    return None
+
+
 def _detect_indexing_pattern(
     idx: object,
     tensor: torch.Tensor,
@@ -421,6 +560,18 @@ def _detect_indexing_pattern(
                 block_id=tile_begin_with_offset.block_id,
                 offset=tile_begin_with_offset.offset,
             )
+        from ...language import memory_ops
+
+        if node.target is memory_ops.load:
+            contiguous_range = _match_contiguous_range_index(
+                idx,
+                tensor,
+                tensor_dim,
+                node.meta.get("val"),
+            )
+            if contiguous_range is not None:
+                return contiguous_range
+
         # A tensor-valued index that didn't match any arithmetic-of-tile
         # pattern is an indirect gather (e.g. table[idx, :]).
         if isinstance(idx_val, torch.Tensor):
@@ -485,7 +636,10 @@ def _update_tiling_decision(
             # bounded slice: fixed subrange of the dim, must stay untiled
             _disallow_tiling()
 
-    elif isinstance(pattern, (ArbitraryIndexPattern, TensorIndexPattern)):
+    elif isinstance(
+        pattern,
+        (ArbitraryIndexPattern, ContiguousRangeIndexPattern, TensorIndexPattern),
+    ):
         _disallow_tiling()
 
     elif isinstance(pattern, NonePattern):
@@ -527,8 +681,8 @@ def resident_block_elements(
         ``block_size``, clamped to the full dim extent.
       - ``TileBeginWithOffsetPattern`` / ``ArbitraryIndexPattern``: scalar
         index, contributes 1.
-      - Anything else (full slice, indirect tensor index): the full dim
-        extent.
+      - ``ContiguousRangeIndexPattern``: its fixed range length.
+      - Anything else (full slice, indirect tensor index): the full dim extent.
 
     Returns ``None`` if any consumed dim is symbolic.
     """
@@ -550,6 +704,8 @@ def resident_block_elements(
                 dim_size = min(bs, dim_size)
         elif isinstance(p, (TileBeginWithOffsetPattern, ArbitraryIndexPattern)):
             dim_size = 1
+        elif isinstance(p, ContiguousRangeIndexPattern):
+            dim_size = p.length
         elements *= dim_size
         # Advance only on patterns that consume a tensor dim; NonePattern doesn't.
         tdim += 1

--- a/helion/_compiler/pallas/printer.py
+++ b/helion/_compiler/pallas/printer.py
@@ -8,6 +8,9 @@ to emit plain Python operators instead of Triton runtime helpers.  Moved out of
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import cast
+
+from torch.utils._sympy.printers import PRECEDENCE
 
 from ..triton.printer import HelionTritonPrinter
 
@@ -20,13 +23,17 @@ class HelionPallasPrinter(HelionTritonPrinter):
 
     def _print_FloorDiv(self, expr: sympy.Expr) -> str:
         lhs, rhs = expr.args
-        # pyrefly: ignore [missing-attribute]
-        return f"({self._print(lhs)} // {self._print(rhs)})"
+        level = PRECEDENCE["Atom"] - 0.5
+        lhs_expr = cast("sympy.Expr", lhs)
+        rhs_expr = cast("sympy.Expr", rhs)
+        return f"({self.parenthesize(lhs_expr, level)} // {self.parenthesize(rhs_expr, level)})"
 
     def _print_PythonMod(self, expr: sympy.Expr) -> str:
         lhs, rhs = expr.args
-        # pyrefly: ignore [missing-attribute]
-        return f"({self._print(lhs)} % {self._print(rhs)})"
+        level = PRECEDENCE["Atom"] - 0.5
+        lhs_expr = cast("sympy.Expr", lhs)
+        rhs_expr = cast("sympy.Expr", rhs)
+        return f"({self.parenthesize(lhs_expr, level)} % {self.parenthesize(rhs_expr, level)})"
 
 
 def pallas_texpr(expr: sympy.Expr) -> str:

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -42,6 +42,7 @@ from .dma import DmaTransfer
 from .dma import ScheduledDmaTransfer
 from .dma import allocate_dma_resources
 from .dma import async_copy_statements
+from .dma import is_tpu_dma_aligned_shape
 
 log = logging.getLogger(__name__)
 
@@ -2711,26 +2712,6 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     return None
 
 
-def _check_dma_alignment(vmem_shape: tuple[int, ...]) -> bool:
-    """Check if a VMEM buffer shape satisfies TPU DMA alignment.
-
-    DMA requires last dim % 128 == 0 and second-to-last dim % 8 == 0
-    for 2D+ tensors. Note that these rules are currently optimized for
-    bf16 sublanes; they are overly conservative for f32 (no constraint)
-    and too lenient for 1D (which should be % 1024).
-
-    These rules differ from outer BlockSpec constraints where 1D is
-    dtype-dependent: 128 * (32 / bitwidth(dtype)). Unlike outer BlockSpecs,
-    emit_pipeline/fori_loop inner DMA does NOT have a ``block == tensor_dim``
-    exception.
-    """
-    if len(vmem_shape) >= 2:
-        return vmem_shape[-1] % 128 == 0 and vmem_shape[-2] % 8 == 0
-    if len(vmem_shape) == 1:
-        return vmem_shape[0] % 128 == 0
-    return True
-
-
 def _is_supported_contiguous_row_slab_dma(
     fake: torch.Tensor,
     sub_meta: list[object],
@@ -2807,7 +2788,7 @@ def _can_stream_inner_tile(
     state: CodegenState,
 ) -> bool:
     """Return whether a loop-local tensor should use the inner streaming path."""
-    if _check_dma_alignment(vmem_shape):
+    if is_tpu_dma_aligned_shape(vmem_shape, fake.dtype):
         return True
     if direction != "load":
         return False

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -47,6 +47,8 @@ from .dma import is_tpu_dma_aligned_shape
 
 log = logging.getLogger(__name__)
 
+_PALLAS_LOOP_LOAD_COUNT_META = "_helion_pallas_loop_load_count"
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterator
@@ -59,6 +61,7 @@ if TYPE_CHECKING:
     from ..tile_strategy import TileStrategy
     from .compact_worklist import ResidentPrepHoist
     from .dma import DmaDirection
+    from .plan_tiling import ContiguousRangeIndexPattern
 
 
 @_decorators.codegen(_not, "pallas")
@@ -609,7 +612,13 @@ def _classify_loop_tensors(
                 key = id(fake)
                 if key not in loaded_tensors:
                     sub_vals = _extract_subscript_vals(subscript)
-                    loaded_tensors[key] = (fake, tensor_node, sub_vals)
+                    loaded_tensors[key] = (fake, node, sub_vals)
+                    node.meta[_PALLAS_LOOP_LOAD_COUNT_META] = 1
+                else:
+                    first_load = loaded_tensors[key][1]
+                    first_load.meta[_PALLAS_LOOP_LOAD_COUNT_META] = (
+                        int(first_load.meta[_PALLAS_LOOP_LOAD_COUNT_META]) + 1
+                    )
         elif node.target is _store_op:
             tensor_node = node.args[0]
             subscript = node.args[1]
@@ -651,6 +660,131 @@ def _get_dim_block_ids(
         elif isinstance(idx, slice) and idx == slice(None):
             pass
     return dim_to_bid
+
+
+def _contiguous_range_patterns(
+    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+) -> dict[int, dict[int, ContiguousRangeIndexPattern]]:
+    """Return direct HBM range patterns keyed by tensor and tensor dimension."""
+    from .plan_tiling import ContiguousRangeIndexPattern
+    from .plan_tiling import NonePattern
+
+    result: dict[int, dict[int, ContiguousRangeIndexPattern]] = {}
+    for fake, load_node, _subscript in loaded_tensors.values():
+        tensor_dim = 0
+        ranges: dict[int, ContiguousRangeIndexPattern] = {}
+        for pattern in load_node.meta.get("indexing_patterns", ()):
+            if isinstance(pattern, NonePattern):
+                continue
+            if isinstance(pattern, ContiguousRangeIndexPattern):
+                ranges[tensor_dim] = pattern
+            tensor_dim += 1
+        if ranges:
+            result[id(fake)] = ranges
+    return result
+
+
+def _contiguous_range_base_expr(
+    value: object,
+    *,
+    state: CodegenState,
+    block_ids: list[int],
+    begin_exprs: list[str],
+    iter_step_exprs: list[str],
+    iteration_indices: list[str],
+) -> str | None:
+    """Render a supported scalar address expression for one loop iteration."""
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, torch.SymInt):
+        return state.device_function.literal_expr(value)
+    if not isinstance(value, torch.fx.Node) or value.op != "call_function":
+        return None
+
+    from ...language import memory_ops
+    from ...language.tile_ops import tile_begin
+
+    if value.target is tile_begin:
+        symbolic_value = value.meta.get("val")
+        if not isinstance(symbolic_value, torch.SymInt):
+            return None
+        block_id = CompileEnvironment.current().get_block_id(symbolic_value)
+        if block_id is None or block_id not in block_ids:
+            return None
+        position = block_ids.index(block_id)
+        return (
+            f"({begin_exprs[position]}) + ({iteration_indices[position]}) * "
+            f"({iter_step_exprs[position]})"
+        )
+
+    binary_operators = {
+        operator.add: "+",
+        operator.floordiv: "//",
+        operator.mod: "%",
+        operator.mul: "*",
+        operator.sub: "-",
+        torch.ops.aten.add.Scalar: "+",
+        torch.ops.aten.add.Tensor: "+",
+        torch.ops.aten.mul.Scalar: "*",
+        torch.ops.aten.mul.Tensor: "*",
+        torch.ops.aten.sub.Scalar: "-",
+        torch.ops.aten.sub.Tensor: "-",
+    }
+    if value.target in binary_operators and len(value.args) >= 2:
+        if (
+            value.target
+            in (
+                torch.ops.aten.add.Scalar,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.sub.Scalar,
+                torch.ops.aten.sub.Tensor,
+            )
+            and value.kwargs.get("alpha", 1) != 1
+        ):
+            return None
+        lhs = _contiguous_range_base_expr(
+            value.args[0],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        rhs = _contiguous_range_base_expr(
+            value.args[1],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        if lhs is None or rhs is None:
+            return None
+        return f"({lhs}) {binary_operators[value.target]} ({rhs})"
+
+    if value.target is memory_ops.load:
+        tensor_node, subscript = value.args[:2]
+        if not isinstance(tensor_node, torch.fx.Node):
+            return None
+        tensor = tensor_node.meta.get("val")
+        if not isinstance(tensor, torch.Tensor):
+            return None
+        if not isinstance(subscript, (list, tuple)) or len(subscript) != 1:
+            return None
+        index = _contiguous_range_base_expr(
+            subscript[0],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
+        if index is None:
+            return None
+        name = state.device_function.tensor_arg(tensor).name
+        return f"{name}[{index}]"
+
+    return None
 
 
 def _find_strategy(
@@ -2817,16 +2951,20 @@ def _compute_vmem_shapes(
     slice_size_exprs: list[str],
     env: CompileEnvironment,
     state: CodegenState,
+    contiguous_ranges: dict[int, dict[int, ContiguousRangeIndexPattern]],
 ) -> list[tuple[int, ...]]:
     """Compute VMEM buffer shapes for each tensor in the fori_loop body."""
     vmem_shapes: list[tuple[int, ...]] = []
     for fake, sub_meta, _direction in all_tensor_info:
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
         tensor_subscripts = _tensor_dim_subscripts(sub_meta)
+        range_dims = contiguous_ranges.get(id(fake), {})
         parts: list[int] = []
         for dim_idx in range(len(fake.shape)):
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid in block_ids:
+            if dim_idx in range_dims:
+                parts.append(range_dims[dim_idx].length)
+            elif bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
                 block_value_sym = sympy.sympify(slice_size_exprs[bid_idx])
                 if isinstance(block_value_sym, sympy.Integer):
@@ -2918,8 +3056,14 @@ def _classify_pipelined_tensors(
     outer_access_targets = ATOMIC_OPS | {_load_op, _store_op}
 
     all_tensor_info = _resident_loop_tensor_info(loaded_tensors, stored_tensors)
+    contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     vmem_shapes = _compute_vmem_shapes(
-        all_tensor_info, block_ids, slice_size_exprs, env, state
+        all_tensor_info,
+        block_ids,
+        slice_size_exprs,
+        env,
+        state,
+        contiguous_ranges,
     )
     device_ir = HostFunction.current().device_ir
 
@@ -2958,6 +3102,21 @@ def _classify_pipelined_tensors(
     for (fake, sub_meta, direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
+        if direction == "load":
+            first_load = loaded_tensors[id(fake)][1]
+            if int(first_load.meta.get(_PALLAS_LOOP_LOAD_COUNT_META, 1)) > 1:
+                # Tensor-level prefetching is keyed by input tensor, not load
+                # site. Dynamic ranges can remain in HBM so each load site
+                # stages its own exact window. Ordinary tiled loads must keep
+                # their outer BlockSpec: raw HBM load-site staging is defined
+                # only for dynamic ranges and remote-copy operands.
+                if id(fake) in contiguous_ranges:
+                    from ..device_function import PallasMemorySpace
+
+                    state.device_function.pallas_memory_space[id(fake)] = (
+                        PallasMemorySpace.HBM
+                    )
+                    continue
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
         if state.device_function.is_pallas_remote_copy_operand(fake) and not set(
             dim_to_bid.values()
@@ -2975,6 +3134,23 @@ def _classify_pipelined_tensors(
             continue
         if id(fake.untyped_storage()) in atomic_storages:
             continue
+        if range_patterns := contiguous_ranges.get(id(fake)):
+            can_render_ranges = all(
+                _contiguous_range_base_expr(
+                    pattern.base,
+                    state=state,
+                    block_ids=block_ids,
+                    begin_exprs=["0"] * len(block_ids),
+                    iter_step_exprs=["1"] * len(block_ids),
+                    iteration_indices=["0"] * len(block_ids),
+                )
+                is not None
+                for pattern in range_patterns.values()
+            )
+            if not can_render_ranges:
+                # The load-site lowering can still stage this window, but the
+                # loop prefetcher cannot safely synthesize its next address.
+                continue
         pipelined_ids.add(id(fake))
     return all_tensor_info, vmem_shapes, pipelined_ids
 
@@ -3152,6 +3328,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
 
     loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
+    contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
         state, block_ids, block_size_vars
     )
@@ -3462,7 +3639,28 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         vmem_needs_slice = False
         for dim_idx in range(len(shape)):
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid in block_ids:
+            range_pattern = contiguous_ranges.get(id(fake), {}).get(dim_idx)
+            if range_pattern is not None:
+                base_expr = _contiguous_range_base_expr(
+                    range_pattern.base,
+                    state=state,
+                    block_ids=block_ids,
+                    begin_exprs=begin_exprs,
+                    iter_step_exprs=iter_step_exprs,
+                    iteration_indices=iteration_indices,
+                )
+                if base_expr is None:
+                    raise RuntimeError(
+                        "Pallas could not render a planned contiguous HBM range"
+                    )
+                hbm_parts.append(
+                    "pl.ds(pl.multiple_of("
+                    f"{base_expr}, {range_pattern.alignment}), "
+                    f"{range_pattern.length})"
+                )
+                vmem_parts.append(":")
+                hbm_needs_slice = True
+            elif bid is not None and bid in block_ids:
                 bid_idx = block_ids.index(bid)
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1227,11 +1227,66 @@ def _pipeline_begin_alignment(
     return None
 
 
+def _fixed_loop_extent(state: CodegenState, loop_dim_index: int) -> int | None:
+    """Return a direct ``end = begin + constant`` loop extent, if present.
+
+    Device-loop bounds that come from scalar tensor arithmetic are no longer
+    symbolic integers by codegen time. Their generated names therefore do not
+    retain enough information for SymPy simplification, but the enclosing
+    ``_for_loop`` FX node still records the original relationship. Keep this
+    matcher deliberately narrow: it proves only a direct, positive constant
+    addition (or the equivalent subtraction on the begin).
+    """
+    node = state.fx_node
+    if node is None or len(node.args) < 3:
+        return None
+    raw_begins, raw_ends = node.args[1:3]
+    begins = list(raw_begins) if isinstance(raw_begins, (list, tuple)) else [raw_begins]
+    ends = list(raw_ends) if isinstance(raw_ends, (list, tuple)) else [raw_ends]
+    if loop_dim_index >= len(begins) or loop_dim_index >= len(ends):
+        return None
+    begin = begins[loop_dim_index]
+    end = ends[loop_dim_index]
+
+    def _positive_int(value: object) -> int | None:
+        if isinstance(value, (int, sympy.Integer)) and int(value) > 0:
+            return int(value)
+        return None
+
+    if isinstance(begin, (int, sympy.Integer)) and isinstance(
+        end, (int, sympy.Integer)
+    ):
+        return _positive_int(int(end) - int(begin))
+
+    if isinstance(end, torch.fx.Node) and end.op == "call_function":
+        if (
+            end.target
+            in (operator.add, torch.ops.aten.add.Tensor, torch.ops.aten.add.Scalar)
+            and len(end.args) >= 2
+            and end.kwargs.get("alpha", 1) == 1
+        ):
+            if end.args[0] is begin:
+                return _positive_int(end.args[1])
+            if end.args[1] is begin:
+                return _positive_int(end.args[0])
+    if isinstance(begin, torch.fx.Node) and begin.op == "call_function":
+        if (
+            begin.target
+            in (operator.sub, torch.ops.aten.sub.Tensor, torch.ops.aten.sub.Scalar)
+            and len(begin.args) >= 2
+            and begin.kwargs.get("alpha", 1) == 1
+        ):
+            if begin.args[0] is end:
+                return _positive_int(begin.args[1])
+    return None
+
+
 def _compute_pipeline_or_dma_extra_pad(
     begin_expr: str,
     bid: int,
     env: CompileEnvironment,
     state: CodegenState,
+    loop_dim_index: int | None = None,
 ) -> int:
     """Return extra host-side padding for a pipeline/DMA dim with a non-zero begin.
 
@@ -1247,6 +1302,10 @@ def _compute_pipeline_or_dma_extra_pad(
     bs_val = state.device_function.resolved_block_size(bid)
     if not isinstance(bs_val, int):
         return 0
+    if loop_dim_index is not None:
+        extent = _fixed_loop_extent(state, loop_dim_index)
+        if extent is not None and extent % bs_val == 0:
+            return 0
     alignment = _pipeline_begin_alignment(begin_expr, state)
     if alignment is not None and alignment % bs_val == 0:
         return 0
@@ -2460,7 +2519,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 from ...language.memory_ops import _record_pad_info
 
                 extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
+                    begin_expr, bid, env, state, bid_idx
                 )
                 _record_pad_info(state, fake, dim_idx, bid, extra_pad)
                 begin_is_zero = begin_expr == "0"
@@ -3714,7 +3773,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 from ...language.memory_ops import _record_pad_info
 
                 extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
+                    begin_expr, bid, env, state, bid_idx
                 )
                 _record_pad_info(state, fake, dim_idx, bid, extra_pad)
             elif bid is not None and bid not in block_ids:

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -32,6 +32,7 @@ from ...language._tracing_ops import _new_var
 from ...language._tracing_ops import _not
 from ...language._tracing_ops import _phi
 from ...language._tracing_ops import _pre_broadcast_tile
+from ..ast_extension import create
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
 from ..compile_environment import CompileEnvironment
@@ -188,6 +189,14 @@ def _raise_unsupported_dynamic_unroll() -> None:
     )
 
 
+def _uses_buffered_static_unroll(state: CodegenState) -> bool:
+    """Whether a static loop requested the existing depth-two load route."""
+    if state.config.get("pallas_loop_type", "unroll") != "unroll":
+        return False
+    counts = state.config.get("pallas_load_buffer_count", ())
+    return isinstance(counts, (list, tuple)) and 2 in counts
+
+
 def _extract_subscript_vals(subscript: object) -> list[object]:
     """Extract meta values from a subscript argument in an FX graph.
 
@@ -236,6 +245,8 @@ def _(state: CodegenState) -> object:
         return _codegen_dynamic_unroll(state)
     if _has_dynamic_unroll_bound(state):
         _raise_unsupported_dynamic_unroll()
+    if _uses_buffered_static_unroll(state):
+        return _codegen_fori_loop(state, static_unroll=True)
     # unroll: fall through to common codegen path
     # pyrefly: ignore[bad-return]
     return state.get_graph(state.proxy_arg(0)).codegen(state)
@@ -274,6 +285,9 @@ def _(state: CodegenState) -> None:
         return None
     if _has_dynamic_unroll_bound(state):
         _raise_unsupported_dynamic_unroll()
+    if _uses_buffered_static_unroll(state):
+        _codegen_fori_loop(state, static_unroll=True)
+        return None
     # pyrefly: ignore[bad-return]
     return state.get_graph(state.proxy_arg(0)).codegen(state)
 
@@ -3106,12 +3120,13 @@ def _codegen_dynamic_unroll(state: CodegenState) -> object:
     return [expr_from_string(f"{result_var}[{i}]") for i in range(len(carried))]
 
 
-def _codegen_fori_loop(state: CodegenState) -> object:
+def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> object:
     """Emit inner device loops using jax.lax.fori_loop.
 
     Tensors admitted by the existing streaming classifier use explicit DMA.
     Selected read-only input tensors use two DMA buffers; all other routes keep
-    their existing single-buffered lowering.
+    their existing single-buffered lowering. ``static_unroll`` retains that DMA
+    schedule while using Python ``range`` so JAX traces a straight-line program.
     """
     from ..device_ir import ForLoopGraphInfo
     from ..device_ir import LiftTensorArgs
@@ -3225,9 +3240,13 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     immediate_loads: list[ScheduledDmaTransfer] = []
     dma_stores: list[ScheduledDmaTransfer] = []
     scheduled_by_hbm_name: dict[str, ScheduledDmaTransfer] = {}
-    # compact_worklist shares this lowering but keeps its compact/resident routes;
-    # only an actual fori_loop config enables depth-two staging.
-    load_buffer_counts_active = state.config.get("pallas_loop_type") == "fori_loop"
+    # compact_worklist shares this lowering but keeps its compact/resident routes.
+    # Ordinary fori loops and explicitly buffered static unrolls honor the
+    # per-input depth; other callers keep the historical single-buffer route.
+    load_buffer_counts_active = state.config.get("pallas_loop_type") in (
+        "fori_loop",
+        "unroll",
+    )
 
     input_tensors = cast(
         "list[torch.Tensor]",
@@ -3399,6 +3418,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         block_id_to_info=block_id_to_info,
         body_fn_name="_fori_body_0",
         loop_var_name=loop_vars[-1],
+        static_unroll=static_unroll,
         inner_statements=body_stmts,
         _tensor_to_dma_scratch=tensor_to_dma_scratch,
         _tensor_to_sem=tensor_to_sem,
@@ -3680,7 +3700,8 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             state.add_statement(stmt)
         return None
 
-    _emit_nonlocal_scratch_declarations(state, body_stmts)
+    if not static_unroll:
+        _emit_nonlocal_scratch_declarations(state, body_stmts)
 
     # Emit nested fori_loop calls — one per dimension.
     # Build inside-out: innermost function wraps body_stmts, each outer
@@ -3691,6 +3712,23 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     # not affect correctness; for loop-carried state the user's source order
     # (block_ids order) is the correct semantic order.
     current_body = body_stmts or [ast.Pass()]  # pyrefly: ignore[bad-assignment]
+    if static_unroll:
+        for dim in reversed(range(len(loop_vars))):
+            loop = statement_from_string(
+                f"for {loop_vars[dim]} in range({grid_parts[dim]}):\n    pass"
+            )
+            assert isinstance(loop, ast.For)
+            loop.body = current_body  # pyrefly: ignore[bad-assignment]
+            if dim == len(loop_vars) - 1:
+                current_body = [*prime_statements, loop]
+            else:
+                current_body = [loop]
+        for statement in current_body:
+            state.add_statement(statement)
+        if has_loop_state:
+            return _read_final_loop_state(state, result_vars)
+        return None
+
     for dim in reversed(range(len(loop_vars))):
         fn_name = state.device_function.new_var(f"_fori_body_{dim}")
         fn_def = statement_from_string(f"def {fn_name}({loop_vars[dim]}, _): pass")
@@ -3714,6 +3752,46 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     if has_loop_state:
         return _read_final_loop_state(state, result_vars)
     return None
+
+
+def _is_static_unroll_predicate(state: CodegenState) -> bool:
+    """Whether this predicate is resolved by a surrounding Python tile loop."""
+    test = state.proxy_arg(0)
+    if isinstance(test, (bool, int)):
+        return True
+    if not isinstance(test, torch.SymBool):
+        return False
+
+    from ..tile_strategy import ForiLoopState
+    from ..variable_origin import BlockSizeOrigin
+    from ..variable_origin import GridOrigin
+
+    static_block_ids: set[int] = set()
+    for loops in state.codegen.active_device_loops.values():
+        for loop in loops:
+            if isinstance(loop, ForiLoopState) and loop.static_unroll:
+                static_block_ids.update(loop.block_ids)
+    if not static_block_ids:
+        return False
+
+    expr = test._sympy_()
+    if not isinstance(expr, sympy.Basic):
+        return False
+    origins = HostFunction.current().expr_to_origin
+    for symbol in expr.free_symbols:
+        origin_info = origins.get(symbol)
+        if origin_info is None:
+            return False
+        origin = origin_info.origin
+        base_type = origin.base_type()
+        if issubclass(base_type, BlockSizeOrigin):
+            continue
+        if not issubclass(base_type, GridOrigin):
+            return False
+        block_id = getattr(origin, "block_id", None)
+        if block_id not in static_block_ids:
+            return False
+    return True
 
 
 @_decorators.codegen(_if, "pallas")
@@ -3771,6 +3849,20 @@ def _(state: CodegenState) -> list[object]:
     if_return_names, else_return_names = graph_info.get_branches_return_names(
         state, if_outputs, else_outputs
     )
+
+    if (
+        _is_static_unroll_predicate(state)
+        and not if_return_names
+        and not else_return_names
+    ):
+        if_node = create(
+            ast.If,
+            test=test,
+            body=if_body_stmts or [ast.Pass()],
+            orelse=else_body_stmts or [ast.Pass()],
+        )
+        state.add_statement(if_node)
+        return []
 
     if_arg_ids = {arg.id for arg in if_args}
     union_args = if_args + [a for a in else_args if a.id not in if_arg_ids]

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3417,6 +3417,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     immediate_loads: list[ScheduledDmaTransfer] = []
     dma_stores: list[ScheduledDmaTransfer] = []
     scheduled_by_hbm_name: dict[str, ScheduledDmaTransfer] = {}
+    refilled_load_tensors: set[str] = set()
+    refilled_loads: list[tuple[ScheduledDmaTransfer, torch.fx.Node, torch.fx.Node]] = []
     # compact_worklist shares this lowering but keeps its compact/resident routes.
     # Ordinary fori loops and explicitly buffered static unrolls honor the
     # per-input depth; other callers keep the historical single-buffer route.
@@ -3523,6 +3525,22 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         elif uses_load_prefetch:
             prefetched_load_tensors.add(hbm_name)
             prefetched_loads.append(scheduled)
+        elif (
+            load_buffer_counts_active
+            and transfer.direction == "load"
+            and len(block_ids) == 1
+            and id(fake) in contiguous_ranges
+        ):
+            load_node = loaded_tensors[id(fake)][1]
+            users = list(load_node.users)
+            if (
+                len(users) == 1
+                and users[0].op == "call_function"
+                and users[0].target
+                in (torch.ops.aten.mm.default, torch.ops.aten.bmm.default)
+            ):
+                refilled_load_tensors.add(hbm_name)
+                refilled_loads.append((scheduled, load_node, users[0]))
 
     # ``all_tensor_info`` represents a read-modify-write tensor only by its
     # store record so that its load and store share one VMEM buffer. Rebuild
@@ -3531,7 +3549,11 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     for fake, _tensor_node, sub_meta in loaded_tensors.values():
         hbm_name = state.device_function.tensor_arg(fake).name
         scheduled = scheduled_by_hbm_name.get(hbm_name)
-        if scheduled is None or hbm_name in prefetched_load_tensors:
+        if (
+            scheduled is None
+            or hbm_name in prefetched_load_tensors
+            or hbm_name in refilled_load_tensors
+        ):
             continue
         immediate_loads.append(
             ScheduledDmaTransfer(
@@ -3787,7 +3809,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     prime_statements: list[ast.stmt] = []
     body_prefetch: ast.FunctionDef | None = None
     body_current_stage_waits: list[ast.stmt] = []
-    if prefetched_loads:
+    if prefetched_loads or refilled_loads:
         num_iterations = state.device_function.new_var("_num_iterations")
         prime_statements.append(
             statement_from_string(f"{num_iterations} = {grid_parts[-1]}")
@@ -3801,6 +3823,15 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             prime_starts.extend(
                 _dma_copy_statements(transfer, prime_indices, "0", ("start",))
             )
+        for transfer, _load_node, _consumer in refilled_loads:
+            prime_starts.extend(
+                _dma_copy_statements(
+                    transfer,
+                    prime_indices,
+                    None,
+                    ("start",),
+                )
+            )
         prime_statements.append(
             _guarded_statements(
                 f"{num_iterations} > 0", "_prime_fori_loads", prime_starts
@@ -3811,22 +3842,43 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         next_iteration = f"({stage_loop_var} + 1)"
         next_indices = [*loop_vars]
         next_indices[-1] = next_iteration
-        next_stage = f"{next_iteration} % 2"
-        next_starts: list[ast.stmt] = []
-        for transfer in prefetched_loads:
-            next_starts.extend(
-                _dma_copy_statements(transfer, next_indices, next_stage, ("start",))
+        if prefetched_loads:
+            next_stage = f"{next_iteration} % 2"
+            next_starts: list[ast.stmt] = []
+            for transfer in prefetched_loads:
+                next_starts.extend(
+                    _dma_copy_statements(transfer, next_indices, next_stage, ("start",))
+                )
+            body_prefetch = _guarded_statements(
+                f"{next_iteration} < {num_iterations}",
+                "_prefetch_fori_loads",
+                next_starts,
             )
-        body_prefetch = _guarded_statements(
-            f"{next_iteration} < {num_iterations}",
-            "_prefetch_fori_loads",
-            next_starts,
-        )
 
-        current_stage = f"{stage_loop_var} % 2"
-        for transfer in prefetched_loads:
-            body_current_stage_waits.extend(
-                _dma_copy_statements(transfer, loop_vars, current_stage, ("wait",))
+            current_stage = f"{stage_loop_var} % 2"
+            for transfer in prefetched_loads:
+                body_current_stage_waits.extend(
+                    _dma_copy_statements(transfer, loop_vars, current_stage, ("wait",))
+                )
+
+        for transfer, load_node, consumer in refilled_loads:
+            state.codegen.add_pre_node_statements(
+                load_node,
+                _dma_copy_statements(transfer, loop_vars, None, ("wait",)),
+            )
+            refill_starts = _dma_copy_statements(
+                transfer,
+                next_indices,
+                None,
+                ("start",),
+            )
+            state.codegen.add_post_node_statement(
+                consumer,
+                _guarded_statements(
+                    f"{next_iteration} < {num_iterations}",
+                    "_refill_fori_load",
+                    refill_starts,
+                ),
             )
 
     # For loop-carried state, remap args to scratch reads inside the body

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3883,6 +3883,56 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             ):
                 state.codegen.add_statement(statement)
 
+    for drain in fori_state._remote_recv_drains.values():
+        if not drain.waits_deferred:
+            continue
+        assert drain.starts_per_iteration > 0 or drain.dynamic_start_counter is not None
+        recv_copy = state.device_function.new_var("_recv_drain", dce=False)
+        recv_index = state.device_function.new_var("_recv_index", dce=False)
+        loop_iterations = " * ".join(f"({part})" for part in grid_parts)
+        static_receive_count = (
+            "0"
+            if drain.starts_per_iteration == 0
+            else loop_iterations
+            if drain.starts_per_iteration == 1
+            else f"{drain.starts_per_iteration} * ({loop_iterations})"
+        )
+        receive_count = static_receive_count
+        if drain.dynamic_start_counter is not None:
+            dynamic_receive_count = f"{drain.dynamic_start_counter}[0]"
+            receive_count = (
+                dynamic_receive_count
+                if static_receive_count == "0"
+                else f"({static_receive_count}) + {dynamic_receive_count}"
+            )
+        fori_state.outer_suffix.append(
+            statement_from_string(
+                f"{recv_copy} = pltpu.make_async_copy({{reference}}, "
+                f"{{reference}}, {drain.semaphore})",
+                reference=drain.reference,
+            )
+        )
+        if drain.dynamic_start_counter is None:
+            fori_state.outer_suffix.append(
+                statement_from_string(
+                    f"for {recv_index} in range({receive_count}):\n"
+                    f"    {recv_copy}.wait()"
+                )
+            )
+        else:
+            recv_wait_body = state.device_function.new_var("_recv_wait_body", dce=False)
+            fori_state.outer_suffix.extend(
+                (
+                    statement_from_string(
+                        f"def {recv_wait_body}({recv_index}, _):\n"
+                        f"    {recv_copy}.wait()"
+                    ),
+                    statement_from_string(
+                        f"jax.lax.fori_loop(0, {receive_count}, {recv_wait_body}, None)"
+                    ),
+                )
+            )
+
     # Compact-worklist outer tile: it IS the grid (exactly one static compact
     # body per work item), so emit the body
     # straight-line with the loop var bound to 0 -- no fori_loop wrapper (which
@@ -3896,6 +3946,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         state.add_statement(statement_from_string(f"{loop_vars[0]} = 0"))
         for stmt in body_stmts or [ast.Pass()]:
             state.add_statement(stmt)
+        for statement in fori_state.outer_suffix:
+            state.add_statement(statement)
         return None
 
     if not static_unroll:
@@ -3923,6 +3975,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 current_body = [loop]
         for statement in current_body:
             state.add_statement(statement)
+        for statement in fori_state.outer_suffix:
+            state.add_statement(statement)
         if has_loop_state:
             return _read_final_loop_state(state, result_vars)
         return None
@@ -3945,6 +3999,9 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
         else:
             # Inner: wrap in the next outer function's body
             current_body = [fn_def, *call_prefix, fori_call]
+
+    for statement in fori_state.outer_suffix:
+        state.add_statement(statement)
 
     # After fori_loop: read final loop-carried state from scratch
     if has_loop_state:

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1281,6 +1281,41 @@ def _fixed_loop_extent(state: CodegenState, loop_dim_index: int) -> int | None:
     return None
 
 
+def _hoist_initial_dma_before_pure_outer_compute(
+    state: CodegenState,
+    statements: list[ast.stmt],
+    loop_local_names: list[str],
+) -> bool:
+    """Move an independent initial DMA to the start of the current root body.
+
+    A buffered inner loop normally starts its first load immediately before
+    entering the loop. If the address depends only on kernel arguments and
+    constants, starting it before preceding elementwise root computation
+    exposes useful DMA/compute overlap. Stay conservative: cross only plain
+    assignments and compiler-owned scratch initialization, never user-visible
+    stores, structured control flow, or a producer of a value read by the DMA.
+    """
+    from ..ast_read_writes import ReadWrites
+
+    outer = state.codegen.statements_stack[-1]
+    dma_reads = set(ReadWrites.from_list(statements).reads)
+    # A nested loop's initial DMA can depend on an enclosing device-loop
+    # induction variable. That variable is an argument of the not-yet-emitted
+    # loop body, so it is unavailable in ``outer`` even though no assignment in
+    # ``outer`` produces it. Keep the prime inside that loop body in this case.
+    if dma_reads.intersection(loop_local_names):
+        return False
+    scratch_names = {scratch.name for scratch in state.device_function._scratch_args}
+    for statement in outer:
+        if not isinstance(statement, ast.Assign):
+            return False
+        rw = ReadWrites.from_ast(statement)
+        if set(rw.writes) & dma_reads or set(rw.inplace_writes) - scratch_names:
+            return False
+    outer[:0] = statements
+    return True
+
+
 def _compute_pipeline_or_dma_extra_pad(
     begin_expr: str,
     bid: int,
@@ -3891,11 +3926,16 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                     ("start",),
                 )
             )
-        prime_statements.append(
-            _guarded_statements(
-                f"{num_iterations} > 0", "_prime_fori_loads", prime_starts
-            )
+        fixed_extent = _fixed_loop_extent(state, len(block_ids) - 1)
+        prime_was_hoisted = fixed_extent is not None and (
+            _hoist_initial_dma_before_pure_outer_compute(state, prime_starts, loop_vars)
         )
+        if not prime_was_hoisted:
+            prime_statements.append(
+                _guarded_statements(
+                    f"{num_iterations} > 0", "_prime_fori_loads", prime_starts
+                )
+            )
 
         stage_loop_var = loop_vars[-1]
         next_iteration = f"({stage_loop_var} + 1)"

--- a/helion/_compiler/pallas/view_ops.py
+++ b/helion/_compiler/pallas/view_ops.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 
 
 RESIDENT_PLAN_META = "pallas_resident_ref_plan"
+STATIC_BASIC_VALUE_SUBSCRIPT_META = "pallas_static_basic_value_subscript"
 
 # These Aten operations may preserve the address interpretation of a resident
 # Ref. Membership only permits planning; ``_reshape_variants`` still proves the
@@ -123,6 +124,127 @@ def _narrowed_dims(indices: object) -> list[int]:
         for dim, index in enumerate(indices)
         if index is not None and index != slice(None)
     ]
+
+
+class _StaticIndexRange(NamedTuple):
+    """A compile-time contiguous tensor index represented as a Python slice."""
+
+    start: int
+    length: int
+
+
+def _static_index(
+    value: object, seen: set[torch.fx.Node] | None = None
+) -> int | _StaticIndexRange | None:
+    """Evaluate a scalar or contiguous compile-time tensor index.
+
+    Mosaic does not implement general advanced indexing on materialized VMEM
+    values. Helion's ``hl.arange`` commonly traces as an iota, however, and an
+    iota shifted by a constant is exactly a basic Python slice. Recognize that
+    deliberately small subset so Pallas codegen can retain basic indexing
+    semantics without introducing a gather.
+    """
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if not isinstance(value, torch.fx.Node):
+        return None
+    seen = set() if seen is None else seen
+    if value in seen:
+        return None
+    seen.add(value)
+    if value.op != "call_function":
+        return None
+    if value.target is torch.ops.prims.iota.default:
+        length = value.args[0]
+        start = value.kwargs.get("start", 0)
+        step = value.kwargs.get("step", 1)
+        if not isinstance(length, int) or isinstance(length, bool):
+            return None
+        if not isinstance(start, int) or isinstance(start, bool):
+            return None
+        if not isinstance(step, int) or isinstance(step, bool):
+            return None
+        if length < 0 or start < 0 or step != 1:
+            return None
+        return _StaticIndexRange(start=start, length=length)
+
+    shift_arithmetic = {
+        torch.ops.aten.add.Scalar,
+        torch.ops.aten.add.Tensor,
+        torch.ops.aten.sub.Scalar,
+        torch.ops.aten.sub.Tensor,
+    }
+    if value.target not in shift_arithmetic or value.kwargs.get("alpha", 1) != 1:
+        return None
+    if len(value.args) != 2:
+        return None
+    lhs = _static_index(value.args[0], seen)
+    rhs = _static_index(value.args[1], seen)
+    if value.target in {torch.ops.aten.add.Scalar, torch.ops.aten.add.Tensor}:
+        if isinstance(lhs, _StaticIndexRange) and isinstance(rhs, int):
+            start = lhs.start + rhs
+            return _StaticIndexRange(start, lhs.length) if start >= 0 else None
+        if isinstance(lhs, int) and isinstance(rhs, _StaticIndexRange):
+            start = lhs + rhs.start
+            return _StaticIndexRange(start, rhs.length) if start >= 0 else None
+        if isinstance(lhs, int) and isinstance(rhs, int):
+            return lhs + rhs
+        return None
+    if isinstance(lhs, _StaticIndexRange) and isinstance(rhs, int):
+        start = lhs.start - rhs
+        return _StaticIndexRange(start, lhs.length) if start >= 0 else None
+    if isinstance(lhs, int) and isinstance(rhs, int):
+        return lhs - rhs
+    return None
+
+
+def _is_static_basic_value_subscript(node: torch.fx.Node, config: Config) -> bool:
+    """Whether static narrowing can use ordinary JAX basic indexing."""
+    indices = node.args[1]
+    if not isinstance(indices, (list, tuple)):
+        return False
+    if not all(
+        index is None or index == slice(None) or _static_index(index) is not None
+        for index in indices
+    ):
+        return False
+
+    input_value = _node_value(node.args[0])
+    if not isinstance(input_value, torch.Tensor):
+        return False
+    tensor_dim = 0
+    for index in indices:
+        if index is None:
+            continue
+        if tensor_dim >= input_value.ndim:
+            return False
+        if index != slice(None):
+            static_index = _static_index(index)
+            assert static_index is not None
+            size = _concrete_size(input_value.shape[tensor_dim], config, 1)
+            if size is None:
+                return False
+            if isinstance(static_index, _StaticIndexRange):
+                if static_index.start + static_index.length > size:
+                    return False
+            elif not -size <= static_index < size:
+                return False
+        tensor_dim += 1
+
+    source = node.args[0]
+    seen: set[torch.fx.Node] = set()
+    while isinstance(source, torch.fx.Node) and source not in seen:
+        seen.add(source)
+        if source.op != "call_function":
+            return False
+        if source.target in _RESIDENT_REF_ATEN_VIEW_TARGETS:
+            source = source.args[0]
+            continue
+        # An earlier narrowing subscript may still carry a resident Ref and its
+        # boundary-mask invariants. A root load, by contrast, can materialize as
+        # an ordinary value before applying this compile-time basic index.
+        return source.target is not subscript
+    return False
 
 
 def _resident_plan(node: torch.fx.Node) -> _ResidentPlan | None:
@@ -1089,7 +1211,11 @@ def plan_resident_ref_views(graphs: list[GraphInfo], config: Config) -> None:
     # so only this completeness pass decides whether a recorded failure is fatal.
     for info in graphs:
         for node in info.graph.find_nodes(op="call_function", target=subscript):
+            node.meta.pop(STATIC_BASIC_VALUE_SUBSCRIPT_META, None)
             if _resident_plan(node) is not None or not _narrowed_dims(node.args[1]):
+                continue
+            if _is_static_basic_value_subscript(node, config):
+                node.meta[STATIC_BASIC_VALUE_SUBSCRIPT_META] = True
                 continue
             failure = context.failures.get(node)
             if failure is None:
@@ -1179,6 +1305,29 @@ def _(state: CodegenState) -> ast.AST:
     assert state.fx_node is not None
     if _resident_plan(state.fx_node) is not None:
         return _codegen_resident_subscript(state)
+    indices = state.fx_node.args[1]
+    if state.fx_node.meta.get(STATIC_BASIC_VALUE_SUBSCRIPT_META):
+        assert isinstance(indices, (list, tuple))
+        placeholders: dict[str, ast.AST] = {"base": state.ast_arg(0)}
+        rendered: list[str] = []
+        for index in indices:
+            if index is None:
+                rendered.append("None")
+            elif index == slice(None):
+                rendered.append(":")
+            else:
+                static_index = _static_index(index)
+                assert static_index is not None
+                if isinstance(static_index, _StaticIndexRange):
+                    rendered.append(
+                        f"{static_index.start}:{static_index.start + static_index.length}"
+                    )
+                else:
+                    rendered.append(repr(static_index))
+        return expr_from_string(
+            f"{{base}}[{', '.join(rendered)}]",
+            **placeholders,
+        )
     # pyrefly: ignore [missing-attribute]
     return subscript._codegen["common"](state)
 

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1877,6 +1877,7 @@ class ForiLoopState(DeviceLoopOrGridState):
 
     body_fn_name: str
     loop_var_name: str  # The fori_loop index variable (e.g., "_j")
+    static_unroll: bool = False
     inner_statements: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1864,6 +1864,17 @@ class EmitPipelineLoopState(DeviceLoopOrGridState):
 
 
 @dataclasses.dataclass
+class RemoteRecvDrain:
+    """Deferred receive completions for one looped destination payload."""
+
+    semaphore: str
+    reference: ast.AST
+    starts_per_iteration: int = 0
+    dynamic_start_counter: str | None = None
+    waits_deferred: bool = False
+
+
+@dataclasses.dataclass
 class ForiLoopState(DeviceLoopOrGridState):
     """State for fori_loop-based loops on TPU (Pallas backend).
 
@@ -1884,6 +1895,9 @@ class ForiLoopState(DeviceLoopOrGridState):
     _tensor_to_dma_scratch: dict[str, str] = dataclasses.field(default_factory=dict)
     _tensor_to_sem: dict[str, str] = dataclasses.field(default_factory=dict)
     _prefetched_load_tensors: set[str] = dataclasses.field(default_factory=set)
+    _remote_recv_drains: dict[tuple[str, tuple[int, ...]], RemoteRecvDrain] = (
+        dataclasses.field(default_factory=dict)
+    )
 
 
 @dataclasses.dataclass

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2059,7 +2059,7 @@ class ConfigSpec:
         if (
             self.supports_config_key("pallas_load_buffer_count")
             and self.has_pallas_inner_loops
-            and config.get("pallas_loop_type") == "fori_loop"
+            and config.get("pallas_loop_type") in ("fori_loop", "unroll")
         ):
             values = config.setdefault(
                 "pallas_load_buffer_count", self.pallas_load_buffer_count.default()

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -644,6 +644,7 @@ def _pallas_jnp_dtype_map() -> dict[str, object]:
         "jnp.int8": jnp.int8,
         "jnp.uint8": jnp.uint8,
         "jnp.bool_": jnp.bool_,
+        "jnp.float8_e4m3fn": jnp.float8_e4m3fn,
     }
 
 

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -1648,10 +1648,14 @@ def _pallas_pl_kernel_jit_fn(
             )(*pipe_any)
 
         kernel_kwargs: dict[str, object] = {scratch_kw: scratch_shapes}
-        if collective_id is not None:
-            kernel_kwargs["compiler_params"] = pltpu.CompilerParams(  # type: ignore[union-attr]
-                collective_id=collective_id
-            )
+        # The VMEM estimator above uses the capacity reported by this TPU. Pass
+        # the same value to Mosaic; otherwise ``pl.kernel`` keeps its platform
+        # default and may compile a schedule that does not use the capacity
+        # Helion already proved is available.
+        kernel_kwargs["compiler_params"] = pltpu.CompilerParams(  # type: ignore[union-attr, bad-instantiation]
+            vmem_limit_bytes=_get_vmem_limit_bytes(pltpu, interpret),
+            collective_id=collective_id,
+        )
         return pl.kernel(  # type: ignore[union-attr]
             kernel_body,
             kernel_out_shape,

--- a/test/test_bound_kernel.py
+++ b/test/test_bound_kernel.py
@@ -413,6 +413,7 @@ class TestToCodePallas(TestCase):
         # Reuses the real pl.kernel compile core via the inlined _pallas_jax_call.
         self.assertIn("def _pallas_jax_call(", code)
         self.assertIn("pl.kernel(", code)
+        self.assertIn("vmem_limit_bytes=_get_vmem_limit_bytes", code)
         self.assertIn("def pallas_add(", code)
         with tempfile.TemporaryDirectory() as tmp:
             name = "pallas_add_jax_test"

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -191,6 +191,12 @@ class TestPallasLoadBufferCountConfig(TestCase):
         spec.normalize(config)
         self.assertEqual(config.pallas_load_buffer_count, [2, 1])
 
+        unroll_config = helion.Config(
+            pallas_loop_type="unroll", pallas_load_buffer_count=[2, 1]
+        )
+        spec.normalize(unroll_config)
+        self.assertEqual(unroll_config.pallas_load_buffer_count, [2, 1])
+
     def test_inactive_field_is_ignored(self) -> None:
         cases = (
             (self._config_spec(2), "emit_pipeline", [2], True),

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -708,6 +708,26 @@ def pallas_two_aligned_dynamic_windows(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
+    """Exercise a compound modulo operand whose parentheses are significant."""
+    out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
+    for _ in hl.grid(1):
+        for tile in hl.tile(4, block_size=1):
+            out[tile.begin, :] = x[(tile.begin - 1) % 4, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_shifted_floor_divide_row_index(x: torch.Tensor) -> torch.Tensor:
+    """Exercise a compound floor-division operand with significant grouping."""
+    out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
+    for _ in hl.grid(1):
+        for tile in hl.tile(4, block_size=1):
+            out[tile.begin, :] = x[(tile.begin + 1) // 2, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
     rows = x.size(0)
     out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
@@ -945,6 +965,28 @@ class TestPallas(TestCase):
             ]
         )
         torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_shifted_modulo_preserves_expression_precedence(self) -> None:
+        x = torch.randn(5, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_shifted_modulo_row_index,
+            (x,),
+            pallas_loop_type="unroll",
+        )
+        self.assertRegex(code, r"\(-1 \+ .*\) % 4")
+        self.assertNotRegex(code, r"= -1 \+ [A-Za-z0-9_]+ % 4")
+        torch.testing.assert_close(result.cpu(), x[[3, 0, 1, 2]].cpu())
+
+    def test_shifted_floor_divide_preserves_expression_precedence(self) -> None:
+        x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_shifted_floor_divide_row_index,
+            (x,),
+            pallas_loop_type="unroll",
+        )
+        self.assertRegex(code, r"\(1 \+ .*\) // 2")
+        self.assertNotRegex(code, r"= 1 \+ [A-Za-z0-9_]+ // 2")
+        torch.testing.assert_close(result.cpu(), x[[0, 1, 1, 2]].cpu())
 
     def test_computed_static_slice(self) -> None:
         x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -631,6 +631,46 @@ def pallas_cat_columns(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_aligned_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for tile in hl.tile(starts.size(0), block_size=1):
+        begin = starts[tile.begin] * 128
+        out[tile, :, :] = table[:, begin + hl.arange(128)][None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_bf16_dynamic_window_1d(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    out = torch.empty([starts.size(0), 128], dtype=table.dtype, device=table.device)
+    for tile in hl.tile(starts.size(0), block_size=1):
+        begin = starts[tile.begin] * 128
+        out[tile, :] = table[begin + hl.arange(128)][None, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_scaled_add_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for tile in hl.tile(starts.size(0), block_size=1):
+        begin = starts[tile.begin] * 128
+        indices = torch.add(hl.arange(128), begin, alpha=2)
+        out[tile, :, :] = table[:, indices][None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_rand_add(x: torch.Tensor, seed: int) -> torch.Tensor:
     """Kernel that uses hl.rand to generate random values and add them to x."""
     out = torch.empty_like(x)
@@ -738,6 +778,48 @@ class TestPallas(TestCase):
         )
         self.assertIn("jnp.concatenate((", code)
         torch.testing.assert_close(result.cpu(), torch.cat((x, y), dim=1).cpu())
+
+    def test_aligned_dynamic_window_uses_direct_hbm_dma(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_aligned_dynamic_window,
+            (table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("pltpu.make_async_copy(table.at[:, pl.ds(pl.multiple_of(", code)
+        self.assertNotIn("one_hot", code)
+        expected = torch.stack(
+            [table[:, begin : begin + 128] for begin in range(0, 512, 128)]
+        )
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_dynamic_window_declines_unaligned_1d_dma(self) -> None:
+        table = torch.randn(512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_bf16_dynamic_window_1d,
+            (table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        self.assertNotIn("pltpu.make_async_copy(table.at[", code)
+        self.assertIn("one_hot", code)
+        expected = torch.stack((table[:128], table[128:256]))
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_dynamic_window_declines_scaled_add(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_scaled_add_dynamic_window,
+            (table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        self.assertNotIn("pltpu.make_async_copy(table.at[", code)
+        self.assertIn("one_hot", code)
+        lanes = torch.arange(128, device=DEVICE)
+        expected = torch.stack((table[:, lanes], table[:, 256 + lanes]))
+        torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_rsqrt_uses_native_lax_op(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -750,6 +750,28 @@ def pallas_fixed_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_overlap_initial_dma_with_normalization(
+    lhs: torch.Tensor,
+    table: torch.Tensor,
+    starts: torch.Tensor,
+) -> torch.Tensor:
+    """Normalize rows while the first dynamic matmul window is loading."""
+    rows = hl.specialize(lhs.size(0))
+    hl.specialize(table.size(0))
+    out = torch.empty([starts.size(0), rows, 128], dtype=lhs.dtype, device=lhs.device)
+    for _ in hl.grid(1):
+        lhs_f32 = lhs[:, :].to(torch.float32)
+        inverse_rms = torch.rsqrt(lhs_f32.pow(2).mean(dim=-1, keepdim=True) + 1e-5)
+        normalized = (lhs_f32 * inverse_rms).to(lhs.dtype)
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            weight = table[:, begin + hl.arange(128)]
+            projected = torch.matmul(normalized, weight)
+            out[tile, :, :] = projected[None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
     """Exercise a compound modulo operand whose parentheses are significant."""
     out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
@@ -960,11 +982,15 @@ class TestPallas(TestCase):
                     )
                 )
                 self.assertIn(loop_marker, code)
-                self.assertIn("def _prime_fori_loads", code)
+                self.assertNotIn("def _prime_fori_loads", code)
                 self.assertIn("def _prefetch_fori_loads", code)
                 self.assertIn(
                     "pltpu.make_async_copy(table.at[:, pl.ds(pl.multiple_of(",
                     code,
+                )
+                self.assertLess(
+                    code.index("pltpu.make_async_copy(table.at["),
+                    code.index(loop_marker),
                 )
                 self.assertRegex(code, r"table_buf\.at\[\(_j \+ 1\) % 2\]")
                 self.assertNotIn("one_hot", code)
@@ -1015,10 +1041,11 @@ class TestPallas(TestCase):
         code = pallas_refilled_dynamic_matmul.bind(
             (lhs, table, starts)
         ).to_triton_code()
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
         self.assertIn("def _refill_fori_load", code)
         self.assertNotIn("table_buf.at[", code)
         table_copy_position = code.index("make_async_copy(table.at[")
+        self.assertLess(table_copy_position, code.index("jax.lax.fori_loop"))
         wait_position = code.index(".wait()", table_copy_position)
         matmul_position = code.index("lax.dot_general")
         refill_position = code.index("def _refill_fori_load")
@@ -3692,7 +3719,7 @@ class TestPallas(TestCase):
             pallas_load_buffer_count=[2, 1],
         )
 
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
         self.assertIn("def _prefetch_fori_loads", code)
         self.assertIn("((2, 8, 128), 'jnp.float32', 'vmem')", code)
         self.assertIn("((2,), None, 'dma_semaphore')", code)
@@ -3703,9 +3730,9 @@ class TestPallas(TestCase):
         # does not wait. The body starts the next stage before any current-stage
         # wait, then waits for both the ordinary depth-one load and selected load
         # before consuming the selected stage.
-        prime_start = code.index("def _prime_fori_loads")
-        fori_call = code.index("jax.lax.fori_loop", prime_start)
-        prime = code[prime_start:fori_call]
+        prime_start = code.index("pltpu.make_async_copy(x.at[")
+        body_definition = code.index("def _fori_body_0", prime_start)
+        prime = code[prime_start:body_definition]
         self.assertIn(".start()", prime)
         self.assertNotIn(".wait()", prime)
 
@@ -3747,9 +3774,13 @@ class TestPallas(TestCase):
             pallas_load_buffer_count=[2, 1],
         )
 
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
         self.assertIn("def _prefetch_fori_loads", code)
         self.assertIn("for _j in range(", code)
+        self.assertLess(
+            code.index("pltpu.make_async_copy(x.at["),
+            code.index("for _j in range("),
+        )
         self.assertNotIn("jax.lax.fori_loop", code)
         self.assertIn("((2, 8, 128), 'jnp.float32', 'vmem')", code)
         self.assertIn("((2,), None, 'dma_semaphore')", code)
@@ -4267,7 +4298,11 @@ class TestPallas(TestCase):
         )
         self.assertIn("jax.lax.fori_loop", code)
         self.assertIn("pltpu.make_async_copy", code)
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
+        self.assertLess(
+            code.index("pltpu.make_async_copy(k_view.at["),
+            code.index("jax.lax.fori_loop"),
+        )
         # The first three entries are pre-broadcast loop-carried state. K and V
         # then receive two VMEM stages and two semaphore slots each.
         self.assertIn(
@@ -4608,7 +4643,11 @@ class TestPallas(TestCase):
             pallas_loop_type="fori_loop",
             pallas_load_buffer_count=[2],
         )
-        self.assertIn("def _prime_fori_loads", code)
+        self.assertNotIn("def _prime_fori_loads", code)
+        self.assertLess(
+            code.index("pltpu.make_async_copy(x.at["),
+            code.index("jax.lax.fori_loop"),
+        )
         self.assertIn("((2, 256, 128), 'jnp.float32', 'vmem')", code)
         self.assertIn("((2,), None, 'dma_semaphore')", code)
         torch.testing.assert_close(result, x + 1.0)
@@ -5472,6 +5511,47 @@ class TestPallas(TestCase):
                 self.assertEqual(pad_dims, [(1, 0, 16, expected_extra_pad)])
                 expected = x[3 : 3 + extent].sum(dim=0, keepdim=True)
                 torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    def test_initial_dma_overlaps_outer_normalization_codegen(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        code = pallas_overlap_initial_dma_with_normalization.bind(
+            (lhs, table, starts)
+        ).to_triton_code(helion.Config(pallas_loop_type="fori_loop"))
+        first_dma = code.index("pltpu.make_async_copy(table.at[")
+        normalization = code.index("lax.rsqrt")
+        first_wait = code.index(".wait()", first_dma)
+        matmul = code.index("lax.dot_general")
+        self.assertLess(first_dma, normalization)
+        self.assertLess(normalization, first_wait)
+        self.assertLess(first_wait, matmul)
+        self.assertNotIn("def _prime_fori_loads", code)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_initial_dma_overlaps_outer_normalization(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_overlap_initial_dma_with_normalization,
+            (lhs, table, starts),
+            pallas_loop_type="fori_loop",
+        )
+        lhs_f32 = lhs.float()
+        normalized = (
+            lhs_f32 * torch.rsqrt(lhs_f32.pow(2).mean(-1, keepdim=True) + 1e-5)
+        ).to(lhs.dtype)
+        expected = torch.stack(
+            [
+                torch.matmul(
+                    normalized.float(),
+                    table[:, begin : begin + 128].float(),
+                )
+                for begin in range(0, 512, 128)
+            ]
+        ).to(lhs.dtype)
+        torch.testing.assert_close(result, expected)
 
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -730,6 +730,26 @@ def pallas_refilled_dynamic_matmul(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_fixed_dynamic_window(
+    x: torch.Tensor,
+    starts: torch.Tensor,
+    EXTENT: hl.constexpr,
+) -> torch.Tensor:
+    """Sum a fixed-size window whose starting row is selected at runtime."""
+    A = hl.specialize(x.size(1))
+    B = hl.specialize(x.size(2))
+    out = torch.empty([1, A, B], dtype=torch.float32, device=x.device)
+    for owner in hl.grid(1):
+        start = starts[owner]
+        end = start + EXTENT
+        acc = hl.zeros([A, B], dtype=torch.float32)
+        for tile in hl.tile(start, end):
+            acc = acc + x[tile, :, :].to(torch.float32).sum(dim=0)
+        out[owner, :, :] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
     """Exercise a compound modulo operand whose parentheses are significant."""
     out = torch.empty([4, x.size(1)], dtype=x.dtype, device=x.device)
@@ -5432,6 +5452,26 @@ class TestPallas(TestCase):
             all(extra_pad == 0 for *_, extra_pad in pad_dims),
             f"block-aligned begin should skip the pad (extra_pad==0), got {pad_dims}",
         )
+
+    def test_dynamic_begin_fixed_extent_pad(self) -> None:
+        """A block-divisible fixed window needs no worst-case boundary pad."""
+        x = torch.randn(256, 8, 128, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([3], device=DEVICE, dtype=torch.int32)
+        cases = ((128, 0), (127, 15))
+        for extent, expected_extra_pad in cases:
+            with self.subTest(extent=extent):
+                code, result = code_and_output(
+                    pallas_fixed_dynamic_window,
+                    (x, starts, extent),
+                    block_sizes=[16],
+                    pallas_loop_type="fori_loop",
+                )
+                match = re.search(r"_ds_pad_dims=(\[[^\]]*\])", code)
+                self.assertIsNotNone(match, "expected _ds_pad_dims in launcher call")
+                pad_dims = ast.literal_eval(match.group(1))
+                self.assertEqual(pad_dims, [(1, 0, 16, expected_extra_pad)])
+                expected = x[3 : 3 + extent].sum(dim=0, keepdim=True)
+                torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -618,6 +618,19 @@ def pallas_chunked_add(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_cat_columns(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    rows = x.size(0)
+    out = torch.empty(
+        [rows, x.size(1) + y.size(1)],
+        dtype=x.dtype,
+        device=x.device,
+    )
+    for tile_rows in hl.tile(rows):
+        out[tile_rows, :] = torch.cat((x[tile_rows, :], y[tile_rows, :]), dim=1)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_rand_add(x: torch.Tensor, seed: int) -> torch.Tensor:
     """Kernel that uses hl.rand to generate random values and add them to x."""
     out = torch.empty_like(x)
@@ -715,6 +728,17 @@ def _constant_pad_neg_inf_pallas_kernel(x: torch.Tensor) -> torch.Tensor:
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
+    def test_cat_columns(self) -> None:
+        x = torch.randn(128, 64, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(128, 64, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_cat_columns,
+            (x, y),
+            block_sizes=[128],
+        )
+        self.assertIn("jnp.concatenate((", code)
+        torch.testing.assert_close(result.cpu(), torch.cat((x, y), dim=1).cpu())
+
     def test_rsqrt_uses_native_lax_op(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def rsqrt_kernel(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -671,6 +671,43 @@ def pallas_scaled_add_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_prefetched_aligned_dynamic_window(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for _ in hl.grid(1):
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            out[tile, :, :] = table[:, begin + hl.arange(128)][None, :, :]
+    return out
+
+
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(pallas_loop_type="fori_loop"),
+)
+def pallas_two_aligned_dynamic_windows(
+    table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    """Read two distinct aligned windows from one HBM tensor per iteration."""
+    rows = hl.specialize(table.size(0))
+    out = torch.empty(
+        [starts.size(0), rows, 128], dtype=table.dtype, device=table.device
+    )
+    for _ in hl.grid(1):
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            first = table[:, begin + hl.arange(128)]
+            second = table[:, begin + 128 + hl.arange(128)]
+            out[tile, :, :] = (first + second)[None, :, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
     rows = x.size(0)
     out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
@@ -841,6 +878,72 @@ class TestPallas(TestCase):
         self.assertIn("one_hot", code)
         lanes = torch.arange(128, device=DEVICE)
         expected = torch.stack((table[:, lanes], table[:, 256 + lanes]))
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_aligned_dynamic_window_prefetch_codegen(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+
+        for loop_type, loop_marker in (
+            ("fori_loop", "jax.lax.fori_loop"),
+            ("unroll", "for _j in range("),
+        ):
+            with self.subTest(pallas_loop_type=loop_type):
+                code = pallas_prefetched_aligned_dynamic_window.bind(
+                    (table, starts)
+                ).to_triton_code(
+                    helion.Config(
+                        pallas_load_buffer_count=[2, 1],
+                        pallas_loop_type=loop_type,
+                    )
+                )
+                self.assertIn(loop_marker, code)
+                self.assertIn("def _prime_fori_loads", code)
+                self.assertIn("def _prefetch_fori_loads", code)
+                self.assertIn(
+                    "pltpu.make_async_copy(table.at[:, pl.ds(pl.multiple_of(",
+                    code,
+                )
+                self.assertRegex(code, r"table_buf\.at\[\(_j \+ 1\) % 2\]")
+                self.assertNotIn("one_hot", code)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_aligned_dynamic_window_prefetch_correctness(self) -> None:
+        table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        expected = torch.stack(
+            [table[:, begin : begin + 128] for begin in range(0, 512, 128)]
+        )
+
+        for loop_type in ("fori_loop", "unroll"):
+            with self.subTest(pallas_loop_type=loop_type):
+                code, result = code_and_output(
+                    pallas_prefetched_aligned_dynamic_window,
+                    (table, starts),
+                    pallas_load_buffer_count=[2, 1],
+                    pallas_loop_type=loop_type,
+                )
+                self.assertIn("def _prefetch_fori_loads", code)
+                torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_two_aligned_dynamic_windows_codegen(self) -> None:
+        table = torch.randn(8, 640, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        code = pallas_two_aligned_dynamic_windows.bind((table, starts)).to_triton_code()
+        self.assertNotIn("def _prime_fori_loads", code)
+        self.assertGreaterEqual(code.count("pltpu.make_async_copy(table.at["), 2)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_two_aligned_dynamic_windows(self) -> None:
+        table = torch.randn(8, 640, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(pallas_two_aligned_dynamic_windows, (table, starts))
+        expected = torch.stack(
+            [
+                table[:, begin : begin + 128] + table[:, begin + 128 : begin + 256]
+                for begin in range(0, 512, 128)
+            ]
+        )
         torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_computed_static_slice(self) -> None:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -707,6 +707,28 @@ def pallas_two_aligned_dynamic_windows(
     return out
 
 
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(pallas_loop_type="fori_loop"),
+)
+def pallas_refilled_dynamic_matmul(
+    lhs: torch.Tensor, table: torch.Tensor, starts: torch.Tensor
+) -> torch.Tensor:
+    """Multiply by one dynamic HBM weight window per loop iteration."""
+    rows = hl.specialize(lhs.size(0))
+    hl.specialize(table.size(0))
+    out = torch.empty([starts.size(0), rows, 128], dtype=lhs.dtype, device=lhs.device)
+    for _ in hl.grid(1):
+        local_lhs = lhs[:, :]
+        for tile in hl.tile(starts.size(0), block_size=1):
+            begin = starts[tile.begin] * 128
+            weight = table[:, begin + hl.arange(128)]
+            projected = torch.matmul(local_lhs, weight)
+            out[tile, :, :] = projected[None, :, :]
+    return out
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def pallas_shifted_modulo_row_index(x: torch.Tensor) -> torch.Tensor:
     """Exercise a compound modulo operand whose parentheses are significant."""
@@ -964,6 +986,39 @@ class TestPallas(TestCase):
                 for begin in range(0, 512, 128)
             ]
         )
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_single_buffer_dynamic_matmul_refill_codegen(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        code = pallas_refilled_dynamic_matmul.bind(
+            (lhs, table, starts)
+        ).to_triton_code()
+        self.assertIn("def _prime_fori_loads", code)
+        self.assertIn("def _refill_fori_load", code)
+        self.assertNotIn("table_buf.at[", code)
+        table_copy_position = code.index("make_async_copy(table.at[")
+        wait_position = code.index(".wait()", table_copy_position)
+        matmul_position = code.index("lax.dot_general")
+        refill_position = code.index("def _refill_fori_load")
+        self.assertLess(wait_position, matmul_position)
+        self.assertLess(matmul_position, refill_position)
+
+    @skipIfPallasInterpret("dynamic HBM DMA offsets require a real TPU")
+    def test_single_buffer_dynamic_matmul_refill(self) -> None:
+        lhs = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        table = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        starts = torch.tensor([0, 1, 2, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_refilled_dynamic_matmul, (lhs, table, starts)
+        )
+        expected = torch.stack(
+            [
+                torch.matmul(lhs.float(), table[:, begin : begin + 128].float())
+                for begin in range(0, 512, 128)
+            ]
+        ).to(torch.bfloat16)
         torch.testing.assert_close(result.cpu(), expected.cpu())
 
     def test_shifted_modulo_preserves_expression_precedence(self) -> None:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -3513,6 +3513,61 @@ class TestPallas(TestCase):
         self.assertGreaterEqual(sum(i < compute for i in waits), 2)
         torch.testing.assert_close(result, args[0] + args[1])
 
+    def test_static_unroll_tensor_load_buffering_codegen(self) -> None:
+        """Static unroll retains the selected depth-two DMA pipeline."""
+        args = (
+            torch.randn(64, 256, device=DEVICE, dtype=torch.float32),
+            torch.randn(64, 256, device=DEVICE, dtype=torch.float32),
+        )
+        code, result = code_and_output(
+            pallas_inner_loop_add,
+            args,
+            block_sizes=[8, 128],
+            pallas_loop_type="unroll",
+            pallas_load_buffer_count=[2, 1],
+        )
+
+        self.assertIn("def _prime_fori_loads", code)
+        self.assertIn("def _prefetch_fori_loads", code)
+        self.assertIn("for _j in range(", code)
+        self.assertNotIn("jax.lax.fori_loop", code)
+        self.assertIn("((2, 8, 128), 'jnp.float32', 'vmem')", code)
+        self.assertIn("((2,), None, 'dma_semaphore')", code)
+        self.assertRegex(code, r"\.at\[\(_j(?:_\d+)? \+ 1\) % 2\]")
+        self.assertRegex(code, r"\.at\[_j(?:_\d+)? % 2\]")
+        torch.testing.assert_close(result.cpu(), (args[0] + args[1]).cpu())
+
+    def test_static_unroll_uses_python_if_for_tile_predicate(self) -> None:
+        """A static tile predicate does not leave a side-effectful lax.cond."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def alternating_add(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    if tile_n.begin == 0:
+                        out[tile_m, tile_n] = x[tile_m, tile_n] + 1
+                    else:
+                        out[tile_m, tile_n] = x[tile_m, tile_n] + 2
+            return out
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            alternating_add,
+            (x,),
+            block_sizes=[8, 128],
+            pallas_loop_type="unroll",
+            pallas_load_buffer_count=[2],
+        )
+
+        self.assertIn("for _j in range(", code)
+        self.assertNotIn("lax.cond", code)
+        expected = x.clone()
+        expected[:, :128] += 1
+        expected[:, 128:] += 2
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
     def test_fori_loop_repeated_loads_share_buffer(self) -> None:
         """Repeated loads of one input reuse its tensor-keyed DMA route."""
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -671,6 +671,28 @@ def pallas_scaled_add_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
+    rows = x.size(0)
+    out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
+    for tile_rows in hl.tile(rows):
+        computed = x[tile_rows, :] + 1
+        heads = computed.reshape(computed.size(0), 4, 64)
+        middle = heads[:, 1 + hl.arange(2), :]
+        out[tile_rows, :] = middle.reshape(computed.size(0), 128)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_loaded_static_slice(x: torch.Tensor) -> torch.Tensor:
+    rows = x.size(0)
+    out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
+    for tile_rows in hl.tile(rows):
+        loaded = x[tile_rows, :]
+        out[tile_rows, :] = loaded[:, 64 + hl.arange(128)]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_rand_add(x: torch.Tensor, seed: int) -> torch.Tensor:
     """Kernel that uses hl.rand to generate random values and add them to x."""
     out = torch.empty_like(x)
@@ -820,6 +842,27 @@ class TestPallas(TestCase):
         lanes = torch.arange(128, device=DEVICE)
         expected = torch.stack((table[:, lanes], table[:, 256 + lanes]))
         torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_computed_static_slice(self) -> None:
+        x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_computed_static_slice,
+            (x,),
+            block_sizes=[128],
+        )
+        self.assertIn("heads[:, 1:3, :]", code)
+        expected = (x + 1).reshape(128, 4, 64)[:, 1:3, :].reshape(128, 128)
+        torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    def test_loaded_static_slice(self) -> None:
+        x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_loaded_static_slice,
+            (x,),
+            block_sizes=[128],
+        )
+        self.assertIn("64:192", code)
+        torch.testing.assert_close(result.cpu(), x[:, 64:192].cpu())
 
     def test_rsqrt_uses_native_lax_op(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)

--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -52,6 +52,7 @@ else:
 _WIDTH = 128
 _REMOTE_SLOT = 1
 _PIPELINE_STEPS = 4
+_COMPUTED_SEND_SLOTS = 2
 _GATHER_ROWS = 8
 _HBM_TILE = 8
 
@@ -294,6 +295,40 @@ def _pipeline_remote_copy(
             copy.start()
             copy.wait()
     return stage, dst
+
+
+@helion.kernel(
+    static_shapes=True,
+    config=helion.Config(block_sizes=[]),
+)
+def _indexed_computed_pipeline_copy(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    peers: torch.Tensor,
+    positions: torch.Tensor,
+    send_slots: hl.constexpr,
+) -> torch.Tensor:
+    """Pipeline computed sends through an explicitly indexed source ring."""
+    num_steps = hl.specialize(src.size(1))
+    for _program in hl.grid(1):
+        for step in hl.tile(num_steps, block_size=1):
+            reduced = torch.sum(src[:, step, :, :], dim=2)
+            send_slot = step.begin % send_slots
+            send_ring = reduced.expand(send_slots, -1, -1)
+            copy = hl.make_async_remote_copy(
+                send_ring,
+                [send_slot],
+                peers[0, step.begin],
+                dst=dst,
+                dst_index=[0, positions[0, step.begin], step.begin],
+            )
+            if step.begin >= send_slots:
+                copy.wait_send()
+            copy.start()
+            copy.wait_recv()
+            if step.begin + send_slots >= num_steps:
+                copy.wait_send()
+    return dst
 
 
 @helion.kernel(
@@ -1155,6 +1190,112 @@ class TestRemoteCopyJaxRuntime(TestCase):
         for _invocation in range(2):
             _stage, result = jax.block_until_ready(copy(*inputs))
             np.testing.assert_array_equal(np.asarray(result), expected)
+
+    def test_indexed_computed_source_ring_codegen(self) -> None:
+        args = (
+            torch.zeros(1, _PIPELINE_STEPS, 3, _WIDTH),
+            torch.zeros(1, 2, _PIPELINE_STEPS, 1, _WIDTH),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+            _COMPUTED_SEND_SLOTS,
+        )
+        source = _indexed_computed_pipeline_copy.bind(args).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        self.assertIn("remote_send_sem.at[", source)
+        self.assertIn("remote_src.at[", source)
+        self.assertNotIn("remote_src[...] =", source)
+        self.assertIn(
+            "_scratch_shapes = [((2,), None, 'dma_semaphore'), "
+            "((), None, 'dma_semaphore'), "
+            "((2, 1, 128), 'jnp.float32', 'vmem')]",
+            source,
+        )
+
+    @skipIfPallasInterpret("indexed computed sends require TPU VMEM lowering")
+    def test_indexed_computed_source_ring(self) -> None:
+        import types
+
+        import jax
+        import jax.numpy as jnp
+
+        devices = [device for device in jax.local_devices() if device.platform == "tpu"]
+        if len(devices) < 2:
+            self.skipTest("requires at least two TPU devices")
+
+        args = (
+            torch.zeros(1, _PIPELINE_STEPS, 3, _WIDTH),
+            torch.zeros(1, 2, _PIPELINE_STEPS, 1, _WIDTH),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+            _COMPUTED_SEND_SLOTS,
+        )
+        source = _indexed_computed_pipeline_copy.bind(args).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        name = "precompiled_indexed_computed_pipeline_copy_test"
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+        self.addCleanup(sys.modules.pop, name, None)
+        exec(compile(source, name, "exec"), module.__dict__)
+
+        world_size = 2
+        mesh = jax.make_mesh((world_size,), ("peer",), devices=devices[:world_size])
+        partition = jax.sharding.PartitionSpec
+        src_spec = partition("peer", None, None, None)
+        dst_spec = partition("peer", None, None, None, None)
+        metadata_spec = partition("peer", None)
+
+        ranks = jnp.arange(world_size, dtype=jnp.float32)[:, None, None, None]
+        steps = jnp.arange(_PIPELINE_STEPS, dtype=jnp.float32)[None, :, None, None]
+        channels = jnp.arange(3, dtype=jnp.float32)[None, None, :, None]
+        columns = jnp.arange(_WIDTH, dtype=jnp.float32)[None, None, None, :]
+        src = ranks * 1000 + steps * 100 + channels * 10 + columns
+        dst = jnp.full(
+            (world_size, world_size, _PIPELINE_STEPS, 1, _WIDTH),
+            -7.0,
+            dtype=jnp.float32,
+        )
+        peers = jnp.broadcast_to(
+            (1 - jnp.arange(world_size, dtype=jnp.int32))[:, None],
+            (world_size, _PIPELINE_STEPS),
+        )
+        positions = jnp.broadcast_to(
+            jnp.arange(world_size, dtype=jnp.int32)[:, None],
+            (world_size, _PIPELINE_STEPS),
+        )
+        specs = (src_spec, dst_spec, metadata_spec, metadata_spec)
+        inputs = tuple(
+            jax.device_put(value, jax.sharding.NamedSharding(mesh, spec))
+            for value, spec in zip((src, dst, peers, positions), specs, strict=True)
+        )
+        copy = jax.jit(
+            jax.shard_map(
+                module._indexed_computed_pipeline_copy,
+                mesh=mesh,
+                in_specs=specs,
+                out_specs=dst_spec,
+                check_vma=False,
+            )
+        )
+
+        reduced = np.asarray(src).sum(axis=2, keepdims=True)
+        expected = np.full(
+            (world_size, world_size, _PIPELINE_STEPS, 1, _WIDTH),
+            -7.0,
+            dtype=np.float32,
+        )
+        expected[0, 1] = reduced[1]
+        expected[1, 0] = reduced[0]
+        for _invocation in range(2):
+            result = np.asarray(jax.block_until_ready(copy(*inputs)))
+            np.testing.assert_array_equal(result, expected)
 
     @skipIfPallasInterpret("nested remote copies require TPU DMA lowering")
     def test_parent_store_nested_remote_copy(self) -> None:

--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -335,6 +335,31 @@ def _indexed_computed_pipeline_copy(
     static_shapes=True,
     config=helion.Config(block_sizes=[]),
 )
+def _computed_fp8_remote_copy(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    peers: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Send one computed FP8 payload through a VMEM source scratch."""
+    for _program in hl.grid(1):
+        payload = (src[:, 0, :] + 1).to(torch.float8_e4m3fn)
+        copy = hl.make_async_remote_copy(
+            payload,
+            [],
+            peers[0, 0],
+            dst=dst,
+            dst_index=[0, positions[0, 0]],
+        )
+        copy.start()
+        copy.wait()
+    return dst
+
+
+@helion.kernel(
+    static_shapes=True,
+    config=helion.Config(block_sizes=[]),
+)
 def _parent_store_nested_remote_copy(
     src: torch.Tensor,
     exchange: torch.Tensor,
@@ -1295,6 +1320,94 @@ class TestRemoteCopyJaxRuntime(TestCase):
         expected[1, 0] = reduced[0]
         for _invocation in range(2):
             result = np.asarray(jax.block_until_ready(copy(*inputs)))
+            np.testing.assert_array_equal(result, expected)
+
+    def test_computed_fp8_source_codegen(self) -> None:
+        args = (
+            torch.zeros(1, 1, _WIDTH),
+            torch.zeros(1, 2, 1, _WIDTH, dtype=torch.float8_e4m3fn),
+            torch.zeros(1, 1, dtype=torch.int32),
+            torch.zeros(1, 1, dtype=torch.int32),
+        )
+        source = _computed_fp8_remote_copy.bind(args).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        self.assertIn("'jnp.float8_e4m3fn', 'vmem'", source)
+        self.assertIn("'jnp.float8_e4m3fn': jnp.float8_e4m3fn", source)
+
+    @skipIfPallasInterpret("computed FP8 sends require TPU VMEM lowering")
+    def test_computed_fp8_source(self) -> None:
+        import types
+
+        import jax
+        import jax.numpy as jnp
+
+        devices = [device for device in jax.local_devices() if device.platform == "tpu"]
+        if len(devices) < 2:
+            self.skipTest("requires at least two TPU devices")
+
+        args = (
+            torch.zeros(1, 1, _WIDTH),
+            torch.zeros(1, 2, 1, _WIDTH, dtype=torch.float8_e4m3fn),
+            torch.zeros(1, 1, dtype=torch.int32),
+            torch.zeros(1, 1, dtype=torch.int32),
+        )
+        source = _computed_fp8_remote_copy.bind(args).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        name = "precompiled_computed_fp8_remote_copy_test"
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+        self.addCleanup(sys.modules.pop, name, None)
+        exec(compile(source, name, "exec"), module.__dict__)
+
+        world_size = 2
+        mesh = jax.make_mesh((world_size,), ("peer",), devices=devices[:world_size])
+        partition = jax.sharding.PartitionSpec
+        src_spec = partition("peer", None, None)
+        dst_spec = partition("peer", None, None, None)
+        metadata_spec = partition("peer", None)
+        ranks = jnp.arange(world_size, dtype=jnp.float32)[:, None, None]
+        columns = jnp.arange(_WIDTH, dtype=jnp.float32)[None, None, :] / 16
+        src = ranks * 16 + columns
+        dst = jnp.full(
+            (world_size, world_size, 1, _WIDTH),
+            -7.0,
+            dtype=jnp.float8_e4m3fn,
+        )
+        peers = (1 - jnp.arange(world_size, dtype=jnp.int32))[:, None]
+        positions = jnp.arange(world_size, dtype=jnp.int32)[:, None]
+        specs = (src_spec, dst_spec, metadata_spec, metadata_spec)
+        inputs = tuple(
+            jax.device_put(value, jax.sharding.NamedSharding(mesh, spec))
+            for value, spec in zip((src, dst, peers, positions), specs, strict=True)
+        )
+        copy = jax.jit(
+            jax.shard_map(
+                module._computed_fp8_remote_copy,
+                mesh=mesh,
+                in_specs=specs,
+                out_specs=dst_spec,
+                check_vma=False,
+            )
+        )
+
+        expected = np.full(
+            (world_size, world_size, 1, _WIDTH),
+            -7.0,
+            dtype=np.float32,
+        )
+        payload = np.asarray((src + 1).astype(jnp.float8_e4m3fn)).astype(np.float32)
+        expected[0, 1] = payload[1]
+        expected[1, 0] = payload[0]
+        for _invocation in range(2):
+            result = np.asarray(jax.block_until_ready(copy(*inputs))).astype(np.float32)
             np.testing.assert_array_equal(result, expected)
 
     @skipIfPallasInterpret("nested remote copies require TPU DMA lowering")

--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -358,6 +358,39 @@ def _computed_fp8_remote_copy(
 
 @helion.kernel(
     static_shapes=True,
+    config=helion.Config(
+        block_sizes=[],
+        pallas_load_buffer_count=[1, 1, 1, 2],
+        pallas_loop_type="unroll",
+    ),
+)
+def _conditional_tail_receive_copy(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    peers: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Start conditionally but request receive completion only at the tail."""
+    num_steps = hl.specialize(src.size(1))
+    for _program in hl.grid(1):
+        for step in hl.tile(num_steps, block_size=1):
+            if step.begin > 0:
+                copy = hl.make_async_remote_copy(
+                    src,
+                    [0, step.begin],
+                    peers[0, step.begin],
+                    dst=dst,
+                    dst_index=[0, positions[0, step.begin], step.begin],
+                )
+                copy.start()
+                copy.wait_send()
+                if step.begin + 2 >= num_steps:
+                    copy.wait_recv()
+    return dst
+
+
+@helion.kernel(
+    static_shapes=True,
     config=helion.Config(block_sizes=[]),
 )
 def _parent_store_nested_remote_copy(
@@ -1408,6 +1441,110 @@ class TestRemoteCopyJaxRuntime(TestCase):
         expected[1, 0] = payload[0]
         for _invocation in range(2):
             result = np.asarray(jax.block_until_ready(copy(*inputs))).astype(np.float32)
+            np.testing.assert_array_equal(result, expected)
+
+    def test_conditional_tail_receive_drain_codegen(self) -> None:
+        args = (
+            torch.zeros(1, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, 2, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+        )
+        source = _conditional_tail_receive_copy.bind(args).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        self.assertIn("remote_recv_count", source)
+        self.assertIn("jnp.zeros_like(remote_recv_count", source)
+        self.assertIn("def _recv_wait_body", source)
+        self.assertRegex(
+            source,
+            r"jax\.lax\.fori_loop\(0, remote_recv_count(?:_\d+)?\[0\]",
+        )
+        self.assertNotRegex(
+            source,
+            r"remote_copy(?:_\d+)?\.wait_recv\(\)",
+        )
+
+    @skipIfPallasInterpret("deferred receive drains require TPU DMA lowering")
+    def test_conditional_tail_receive_drain(self) -> None:
+        import types
+
+        import jax
+        import jax.numpy as jnp
+
+        devices = [device for device in jax.local_devices() if device.platform == "tpu"]
+        if len(devices) < 2:
+            self.skipTest("requires at least two TPU devices")
+
+        args = (
+            torch.zeros(1, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, 2, _PIPELINE_STEPS, _WIDTH),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+            torch.zeros(1, _PIPELINE_STEPS, dtype=torch.int32),
+        )
+        source = _conditional_tail_receive_copy.bind(args).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+        name = "precompiled_conditional_tail_receive_copy_test"
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+        self.addCleanup(sys.modules.pop, name, None)
+        exec(compile(source, name, "exec"), module.__dict__)
+
+        world_size = 2
+        mesh = jax.make_mesh((world_size,), ("peer",), devices=devices[:world_size])
+        partition = jax.sharding.PartitionSpec
+        src_spec = partition("peer", None, None)
+        dst_spec = partition("peer", None, None, None)
+        metadata_spec = partition("peer", None)
+        ranks = jnp.arange(world_size, dtype=jnp.float32)[:, None, None]
+        steps = jnp.arange(_PIPELINE_STEPS, dtype=jnp.float32)[None, :, None]
+        columns = jnp.arange(_WIDTH, dtype=jnp.float32)[None, None, :]
+        src = ranks * 1000 + steps * 100 + columns
+        dst = jnp.full(
+            (world_size, world_size, _PIPELINE_STEPS, _WIDTH),
+            -7.0,
+            dtype=jnp.float32,
+        )
+        peers = jnp.broadcast_to(
+            (1 - jnp.arange(world_size, dtype=jnp.int32))[:, None],
+            (world_size, _PIPELINE_STEPS),
+        )
+        positions = jnp.broadcast_to(
+            jnp.arange(world_size, dtype=jnp.int32)[:, None],
+            (world_size, _PIPELINE_STEPS),
+        )
+        specs = (src_spec, dst_spec, metadata_spec, metadata_spec)
+        inputs = tuple(
+            jax.device_put(value, jax.sharding.NamedSharding(mesh, spec))
+            for value, spec in zip((src, dst, peers, positions), specs, strict=True)
+        )
+        copy = jax.jit(
+            jax.shard_map(
+                module._conditional_tail_receive_copy,
+                mesh=mesh,
+                in_specs=specs,
+                out_specs=dst_spec,
+                check_vma=False,
+            )
+        )
+
+        expected = np.full(
+            (world_size, world_size, _PIPELINE_STEPS, _WIDTH),
+            -7.0,
+            dtype=np.float32,
+        )
+        src_host = np.asarray(src)
+        expected[0, 1, 1:] = src_host[1, 1:]
+        expected[1, 0, 1:] = src_host[0, 1:]
+        for _invocation in range(2):
+            result = np.asarray(jax.block_until_ready(copy(*inputs)))
             np.testing.assert_array_equal(result, expected)
 
     @skipIfPallasInterpret("nested remote copies require TPU DMA lowering")


### PR DESCRIPTION
Stacked PRs:
 * #3408
 * #3407
 * #3406
 * #3405
 * #3404
 * #3403
 * #3402
 * #3401
 * #3387
 * __->__#3400
 * #3399
 * #3398
 * #3397
 * #3396
 * #3395
 * #3394
 * #3393
 * #3392
 * #3391
 * #3390
 * #3389
 * #3388


--- --- ---

### [Pallas] Pass TPU VMEM capacity to Mosaic


Thread the same TPU VMEM capacity used by Helion's scratch estimator into
Mosaic's `pl.kernel` compiler parameters. This keeps Helion's resource proof and
Mosaic's scheduling budget consistent.

Even a simple exported Helion kernel uses the shared compile path:

```python
@helion.kernel(backend="pallas", static_shapes=True)
def pallas_add(x, y):
    out = torch.empty_like(x)
    for tile in hl.tile(out.size()):
        out[tile] = x[tile] + y[tile]
    return out
```

Previously, generated JAX only supplied compiler parameters when a distributed
collective ID was present:

```python
kernel_kwargs = {scratch_kw: scratch_shapes}
if collective_id is not None:
    kernel_kwargs["compiler_params"] = pltpu.CompilerParams(
        collective_id=collective_id,
    )
return pl.kernel(kernel_body, kernel_out_shape, **kernel_kwargs)
```

Thus an ordinary kernel left `vmem_limit_bytes=None`, allowing Mosaic's platform
default to differ from the real capacity already queried by Helion. The kernel
body and scratch layout were unchanged, but Mosaic could choose a less effective
schedule for a VMEM-heavy program.

Generated JAX now always carries the measured capacity while preserving the
collective ID:

```python
kernel_kwargs = {scratch_kw: scratch_shapes}
kernel_kwargs["compiler_params"] = pltpu.CompilerParams(
    vmem_limit_bytes=_get_vmem_limit_bytes(pltpu, interpret),
    collective_id=collective_id,
)
return pl.kernel(kernel_body, kernel_out_shape, **kernel_kwargs)
```

This has a measurable effect on the fused TP16 RMSNorm/QKVOG/A2A program even
though its generated Pallas body is otherwise byte-for-byte identical. A
20-call 8K-token device profile improved from 933.16 us to 919.56 us
(-13.60 us, -1.46%). The same-contract JAX reference measured 744.83 us.
Correctness was unchanged: allclose=true, repeat_exact_fraction=1.0,
exact_fraction=0.999628, and max_abs=0.25 in FP8 K/V.

`test_pallas_jax_fn_standalone_runs` now checks that the standalone JAX module
contains the VMEM limit, then imports and executes the generated `pallas_add`
computation against its reference. The full fused computation also passed on a
two-host TPU v7 slice. `./lint.sh` passes.