### PR TITLE
[Pallas] Preserve computed scalar indices across loop lowering

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -984,10 +984,16 @@ def _generated_index_code(
         )
 
     if isinstance(pattern, TensorIndexPattern):
+        if in_pipeline and pipeline_scalar_indices_local and pattern.index_ndim == 0:
+            return "0"
         if tensor_indices_are_scalars:
             return _index_expr_from_ast(state, subscript_index, ast_subscripts)
         if pattern.index_ndim == 0:
             assert isinstance(idx, torch.Tensor)
+            from helion._compiler.host_function import HostFunction
+
+            if idx not in HostFunction.current().tensor_to_origin:
+                return _index_expr_from_ast(state, subscript_index, ast_subscripts)
             scalar_arg = state.device_function.tensor_arg(idx)
             return f"{scalar_arg.name}[0]"
         from helion._compiler.pallas.tensorcore_plan import TENSORCORE_PLAN_META

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -908,14 +908,30 @@ def _contiguous_range_base_expr(
     begin_exprs: list[str],
     iter_step_exprs: list[str],
     iteration_indices: list[str],
+    captured_exprs: dict[torch.fx.Node, str] | None = None,
 ) -> str | None:
     """Render a supported scalar address expression for one loop iteration."""
     if isinstance(value, int):
         return str(value)
     if isinstance(value, torch.SymInt):
         return state.device_function.literal_expr(value)
-    if not isinstance(value, torch.fx.Node) or value.op != "call_function":
+    if not isinstance(value, torch.fx.Node):
         return None
+    if value.op == "placeholder":
+        return captured_exprs.get(value) if captured_exprs is not None else None
+    if value.op != "call_function":
+        return None
+
+    if value.target is _new_var and value.args:
+        return _contiguous_range_base_expr(
+            value.args[0],
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+            captured_exprs=captured_exprs,
+        )
 
     from ...language import memory_ops
     from ...language.tile_ops import tile_begin
@@ -965,6 +981,7 @@ def _contiguous_range_base_expr(
             begin_exprs=begin_exprs,
             iter_step_exprs=iter_step_exprs,
             iteration_indices=iteration_indices,
+            captured_exprs=captured_exprs,
         )
         rhs = _contiguous_range_base_expr(
             value.args[1],
@@ -973,6 +990,7 @@ def _contiguous_range_base_expr(
             begin_exprs=begin_exprs,
             iter_step_exprs=iter_step_exprs,
             iteration_indices=iteration_indices,
+            captured_exprs=captured_exprs,
         )
         if lhs is None or rhs is None:
             return None
@@ -994,6 +1012,7 @@ def _contiguous_range_base_expr(
             begin_exprs=begin_exprs,
             iter_step_exprs=iter_step_exprs,
             iteration_indices=iteration_indices,
+            captured_exprs=captured_exprs,
         )
         if index is None:
             return None
@@ -3648,6 +3667,37 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
 
     loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
+    placeholders = list(graph_info.graph.find_nodes(op="placeholder"))
+    placeholder_exprs = {
+        placeholder: ast.unparse(arg)
+        for placeholder, arg in zip(placeholders, args, strict=True)
+    }
+    captured_scalar_exprs: dict[int, str] = {}
+    scalar_index_nodes: dict[int, torch.fx.Node] = {}
+    for _fake, load_node, _subscript in loaded_tensors.values():
+        load_indices = load_node.args[1]
+        if not isinstance(load_indices, (list, tuple)):
+            continue
+        for index_node in load_indices:
+            if not isinstance(index_node, torch.fx.Node):
+                continue
+            index_value = index_node.meta.get("val")
+            if not isinstance(index_value, torch.Tensor) or index_value.ndim != 0:
+                continue
+            scalar_index_nodes[id(index_value)] = index_node
+            source = index_node
+            seen: set[torch.fx.Node] = set()
+            while (
+                source not in seen
+                and source.op == "call_function"
+                and source.target is _new_var
+                and source.args
+                and isinstance(source.args[0], torch.fx.Node)
+            ):
+                seen.add(source)
+                source = source.args[0]
+            if source in placeholder_exprs:
+                captured_scalar_exprs[id(index_value)] = placeholder_exprs[source]
     contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
         state, block_ids, block_size_vars
@@ -4036,6 +4086,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                     begin_exprs=begin_exprs,
                     iter_step_exprs=iter_step_exprs,
                     iteration_indices=iteration_indices,
+                    captured_exprs=placeholder_exprs,
                 )
                 if base_expr is None:
                     raise RuntimeError(
@@ -4143,7 +4194,23 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 from helion._utils import is_scalar_index
 
                 if is_scalar_index(idx_meta):
-                    offset_expr = state.device_function.literal_expr(idx_meta)
+                    offset_expr = None
+                    if isinstance(idx_meta, torch.Tensor):
+                        index_node = scalar_index_nodes.get(id(idx_meta))
+                        if index_node is not None:
+                            offset_expr = _contiguous_range_base_expr(
+                                index_node,
+                                state=state,
+                                block_ids=block_ids,
+                                begin_exprs=begin_exprs,
+                                iter_step_exprs=iter_step_exprs,
+                                iteration_indices=iteration_indices,
+                                captured_exprs=placeholder_exprs,
+                            )
+                        if offset_expr is None:
+                            offset_expr = captured_scalar_exprs.get(id(idx_meta))
+                    if offset_expr is None:
+                        offset_expr = state.device_function.literal_expr(idx_meta)
                     hbm_parts.append(
                         offset_expr if resident_source else f"pl.ds({offset_expr}, 1)"
                     )
@@ -4156,7 +4223,6 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                             "Pallas DMA requires concrete bounded slice extents"
                         )
                     hbm_parts.append(f"pl.ds({start}, {stop - start})")
-                    hbm_needs_slice = True
                 else:
                     hbm_parts.append(":")
                 vmem_parts.append(":")

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2668,6 +2668,30 @@ class TestPallas(TestCase):
         expected[2] = values
         torch.testing.assert_close(result, expected)
 
+    def test_computed_scalar_tensor_index_store(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def computed_scalar_tensor_index_store(
+            values: torch.Tensor, output_row: torch.Tensor
+        ) -> torch.Tensor:
+            m, n = values.size()
+            out = torch.zeros([4, m, n], dtype=values.dtype, device=values.device)
+            row = (output_row[0] + 1) % 4
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[row, tile_m, tile_n] = values[tile_m, tile_n]
+            return out
+
+        values = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        output_row = torch.tensor([2], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            computed_scalar_tensor_index_store,
+            (values, output_row),
+            block_sizes=[8, 128],
+        )
+
+        expected = torch.zeros(4, 8, 128, device=DEVICE)
+        expected[3] = values
+        torch.testing.assert_close(result, expected)
+
     def test_tensor_index_atomic_add_raises(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def atomic_add_tensor_index(


### PR DESCRIPTION
Stacked PRs:
 * #3405
 * #3396
 * #3394
 * #3402
 * __->__#3401
 * #3407
 * #3403
 * #3399
 * #3397
 * #3408
 * #3387
 * #3392
 * #3391


--- --- ---

### [Pallas] Preserve computed scalar indices across loop lowering


Computed scalar indices are ordinary runtime addresses, not new tensor arguments. Helion source can derive one from an input and use it in a store or DMA window:

```python
row = (output_row[0] + 1) % 4
out[row, tile_m, tile_n] = values[tile_m, tile_n]
```

Previously the Pallas index renderer treated the computed rank-zero FakeTensor like a host tensor and tried to register it as a launcher argument. Direct stores failed with a missing tensor origin, while a scalar captured by an inner DMA loop could fall back to an unrenderable fake literal.

Keep host scalar inputs on the existing argument path, but render computed scalars from their generated AST expression. When an inner loop captures a scalar address, retain the placeholder-to-expression mapping and reconstruct the exact HBM slice. A loop-local scalar index addresses slot zero in the already-selected VMEM stage rather than indexing the stage a second time.

Generated code now keeps the scalar in the program:

```python
row = (output_row[0] + 1) % 4
out[row, :, :] = values[:, :]
```

The computation test executes the complete store in Pallas interpret mode and compares every output element with PyTorch. This changes no Helion API.
