### PR TITLE
[Pallas] Lower static advanced indices as basic slices

### DIFF
--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 
 
 cat_lowering_pallas = AtenLowering(target=torch.ops.aten.cat.default)
+static_index_lowering_pallas = AtenLowering(target=torch.ops.aten.index.Tensor)
 
 
 @cat_lowering_pallas.register_codegen("pallas")
@@ -77,6 +78,46 @@ def codegen_cat_pallas(ctx: LoweringContext, node: Node) -> ast.AST:
     return expr_from_string(
         f"jnp.concatenate(({values}), axis={dim})",
         **placeholders,
+    )
+
+
+def can_lower_static_index_pallas(node: Node) -> bool:
+    """Whether an ``aten.index`` is compile-time basic indexing in disguise."""
+    from .view_ops import _static_index
+
+    indices = node.args[1]
+    return isinstance(indices, (list, tuple)) and all(
+        index is None or _static_index(index) is not None for index in indices
+    )
+
+
+@static_index_lowering_pallas.register_codegen("pallas")
+def codegen_static_index_pallas(ctx: LoweringContext, node: Node) -> ast.AST:
+    """Render static advanced indices as ordinary JAX basic indexing."""
+    from .view_ops import _static_index
+    from .view_ops import _StaticIndexRange
+
+    tensor = _env_arg(ctx, cast("Node", node.args[0]))
+    assert isinstance(tensor, ast.AST)
+    indices = node.args[1]
+    assert isinstance(indices, (list, tuple))
+    rendered: list[str] = []
+    for index in indices:
+        # In aten.index, None means that this source dimension is not indexed.
+        if index is None:
+            rendered.append(":")
+            continue
+        static_index = _static_index(index)
+        assert static_index is not None
+        if isinstance(static_index, _StaticIndexRange):
+            rendered.append(
+                f"{static_index.start}:{static_index.start + static_index.length}"
+            )
+        else:
+            rendered.append(repr(static_index))
+    return expr_from_string(
+        f"{{tensor}}[{', '.join(rendered)}]",
+        tensor=tensor,
     )
 
 

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1490,10 +1490,16 @@ class PallasBackend(Backend):
         return self.build_launcher_name(device_fn.config)
 
     def pre_inductor_lowering(self, node: torch.fx.Node) -> Lowering | None:
+        from .aten_lowering import can_lower_static_index_pallas
         from .aten_lowering import cat_lowering_pallas
+        from .aten_lowering import static_index_lowering_pallas
 
         if node.target is torch.ops.aten.cat.default:
             return cat_lowering_pallas
+        if node.target is torch.ops.aten.index.Tensor and can_lower_static_index_pallas(
+            node
+        ):
+            return static_index_lowering_pallas
         return None
 
     def pre_codegen(

--- a/helion/_compiler/pallas/view_ops.py
+++ b/helion/_compiler/pallas/view_ops.py
@@ -245,6 +245,7 @@ def _is_static_basic_value_subscript(node: torch.fx.Node, config: Config) -> boo
 
     source = node.args[0]
     seen: set[torch.fx.Node] = set()
+    follows_static_subscript = False
     while isinstance(source, torch.fx.Node) and source not in seen:
         seen.add(source)
         if source.op != "call_function":
@@ -252,10 +253,20 @@ def _is_static_basic_value_subscript(node: torch.fx.Node, config: Config) -> boo
         if source.target in _RESIDENT_REF_ATEN_VIEW_TARGETS:
             source = source.args[0]
             continue
-        # An earlier narrowing subscript may still carry a resident Ref and its
-        # boundary-mask invariants. A root load, by contrast, can materialize as
-        # an ordinary value before applying this compile-time basic index.
-        return source.target is not subscript
+        if source.target is subscript and source.meta.get(
+            STATIC_BASIC_VALUE_SUBSCRIPT_META
+        ):
+            follows_static_subscript = True
+            source = source.args[0]
+            continue
+        # A direct root load may materialize before one compile-time basic
+        # index. Do not let that fallback chain into a second narrowing: the
+        # first selection may have lost resident-Ref padding invariants. Static
+        # indices may chain safely when their root is an ordinary computed
+        # value, such as a matrix multiplication result.
+        return source.target is not subscript and (
+            not follows_static_subscript or source.target is not load
+        )
     return False
 
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -796,6 +796,23 @@ def pallas_computed_static_slice(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+def _static_index_helper(value: torch.Tensor) -> torch.Tensor:
+    """Exercise ordinary Python helper indexing during Helion tracing."""
+    left = value[:, hl.arange(32)]
+    right = value[:, 32 + hl.arange(32)]
+    return left + 2 * right
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_static_index_helper(x: torch.Tensor) -> torch.Tensor:
+    rows = hl.specialize(x.size(0))
+    out = torch.empty([rows, 32], dtype=x.dtype, device=x.device)
+    for _program in hl.grid(1):
+        computed = x[:, :] + 1
+        out[:, :] = _static_index_helper(computed)
+    return out
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def pallas_loaded_static_slice(x: torch.Tensor) -> torch.Tensor:
     rows = x.size(0)
@@ -1489,6 +1506,18 @@ class TestPallas(TestCase):
         )
         self.assertIn("jnp.pad", code)
         expected = torch.nn.functional.pad(x, (0, 128), value=0.0)
+        torch.testing.assert_close(result, expected)
+
+    def test_static_index_in_python_helper_uses_basic_slices(self) -> None:
+        x = torch.randn(16, 64, device=DEVICE, dtype=torch.float32)
+        _, result = code_and_output(
+            pallas_static_index_helper,
+            (x,),
+            block_sizes=[],
+        )
+
+        computed = x + 1
+        expected = computed[:, :32] + 2 * computed[:, 32:64]
         torch.testing.assert_close(result, expected)
 
     def test_constant_pad_nd_non_finite_fill(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3405
 * #3396
 * #3394
 * __->__#3402
 * #3401
 * #3407
 * #3403
 * #3399
 * #3397
 * #3408
 * #3387
 * #3392
 * #3391


--- --- ---

### [Pallas] Lower static advanced indices as basic slices


A Python helper can express a compile-time field split with ordinary tensor indexing:

    left = value[:, hl.arange(32)]
    right = value[:, 32 + hl.arange(32)]

Tracing represents these helper-level expressions as aten.index.Tensor rather than Helion subscript nodes. The generic Inductor path either rejects that advanced-index buffer or routes it toward indirect one-hot indexing, even though both index tensors are statically proven unit-stride ranges.

Recognize only indices already accepted by the existing static-index proof and emit JAX basic slices directly:

    left = value[:, 0:32]
    right = value[:, 32:64]

Keep resident-Ref safety intact: chained narrowing remains structural when its root may carry padding or a boundary mask, while chains rooted in ordinary computed values can use basic slicing. Dynamic indices and non-unit ranges retain the existing lowering.

The computation test calls a normal Python helper from a Helion kernel, executes the generated Pallas program, and compares every element with PyTorch.
