### PR TITLE
[Pallas] Overlap read-only input DMAs with weight streams

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -155,6 +155,9 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         self.grouped_fori_dma_resource_cache: dict[
             tuple[object, ...], DmaResources
         ] = {}
+        self.pallas_immediate_hbm_dma_resource_cache: dict[
+            tuple[object, ...], DmaResources
+        ] = {}
         self._statements_by_owner_node_id: dict[
             int, list[tuple[list[ast.AST], ast.AST]]
         ] = {}

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import ast
 from typing import TYPE_CHECKING
+from typing import cast
 
 import torch
 
 from helion._compiler.ast_extension import expr_from_string
+from helion._compiler.ast_extension import statement_from_string
 from helion._compiler.pallas.dma import DmaTransfer
 from helion._compiler.pallas.dma import allocate_dma_resources
 from helion._compiler.pallas.dma import async_copy_statements
@@ -74,6 +76,7 @@ def load_expr(
         and device_fn.pallas_memory_space.get(id(tensor)) == PallasMemorySpace.HBM
         and (
             device_fn.is_pallas_remote_copy_operand(tensor)
+            or device_fn.is_pallas_direct_hbm_load(tensor)
             or any(
                 isinstance(pattern, ContiguousRangeIndexPattern) for pattern in patterns
             )
@@ -114,6 +117,7 @@ def _hbm_load_expr(
     preserves ordering with nearby remote-copy waits and avoids changing the
     placement of unrelated tensor arguments.
     """
+    device_fn = state.device_function
     assert state.fx_node is not None
     value = state.fx_node.meta.get("val")
     if not isinstance(value, torch.Tensor):
@@ -128,35 +132,98 @@ def _hbm_load_expr(
         pipeline_scalar_indices_local=False,
         raw_hbm_ref=True,
     )
-    scratch_shape = list(value.shape)
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    scratch_shape: list[int | torch.SymInt] = list(value.shape)
     for dim in reversed(none_dims):
         scratch_shape.pop(dim)
     if not scratch_shape:
         raise NotImplementedError("Pallas cannot DMA a scalar HBM load into VMEM")
+    for dimension, size in enumerate(scratch_shape):
+        block_id = env.resolve_block_id(size)
+        if block_id is not None:
+            resolved = state.device_function.resolved_block_size(block_id)
+            if resolved is not None:
+                scratch_shape[dimension] = resolved
+        elif isinstance(size, torch.SymInt):
+            scratch_shape[dimension] = env.size_hint(size)
+    if not all(isinstance(size, int) for size in scratch_shape):
+        raise RuntimeError(f"Pallas HBM load has unresolved shape {scratch_shape}")
+    concrete_scratch_shape = cast("tuple[int, ...]", tuple(scratch_shape))
 
     transfer = DmaTransfer(
         tensor=tensor,
         subscript=tuple(subscript),
         direction="load",
     )
-    resources = allocate_dma_resources(
-        state.device_function,
-        transfer,
-        vmem_shape=tuple(scratch_shape),
-        buffer_count=1,
-        scratch_hint=f"{name}_load",
-        semaphore_hint=f"{name}_load_sem",
+    from helion._compiler.pallas.plan_tiling import ContiguousRangeIndexPattern
+
+    reusable_window = not device_fn.is_pallas_direct_hbm_load(tensor) and any(
+        isinstance(pattern, ContiguousRangeIndexPattern) for pattern in patterns
     )
+    resource_key = (name, concrete_scratch_shape, tensor.dtype)
+    resources = (
+        state.codegen.pallas_immediate_hbm_dma_resource_cache.get(resource_key)
+        if reusable_window
+        else None
+    )
+    if resources is None:
+        resources = allocate_dma_resources(
+            state.device_function,
+            transfer,
+            vmem_shape=concrete_scratch_shape,
+            buffer_count=1,
+            scratch_hint=f"{name}_load",
+            semaphore_hint=f"{name}_load_sem",
+        )
+        if reusable_window:
+            state.codegen.pallas_immediate_hbm_dma_resource_cache[resource_key] = (
+                resources
+            )
     source = f"{name}.at[{', '.join(parts)}]"
-    for statement in async_copy_statements(
-        state,
-        source,
-        resources.scratch,
-        resources.semaphore,
-        ("start", "wait"),
-        f"{name}_load_copy",
-    ):
-        state.codegen.add_statement(statement)
+    if device_fn.is_pallas_direct_hbm_load(tensor):
+        from helion._compiler.tile_strategy import DeviceGridState
+
+        grid_state = state.codegen.current_grid_state
+        if isinstance(grid_state, DeviceGridState):
+            start_statements = async_copy_statements(
+                state,
+                source,
+                resources.scratch,
+                resources.semaphore,
+                ("start",),
+                f"{name}_load_copy",
+            )
+            copy_assignment = start_statements[0]
+            assert isinstance(copy_assignment, ast.Assign)
+            copy_target = copy_assignment.targets[0]
+            assert isinstance(copy_target, ast.Name)
+            device_fn.pallas_hoisted_direct_dma_copy_names.add(copy_target.id)
+            grid_state.outer_prefix.extend(start_statements)
+            state.codegen.add_statement(
+                statement_from_string(f"{copy_target.id}.wait()")
+            )
+        else:
+            for statement in async_copy_statements(
+                state,
+                source,
+                resources.scratch,
+                resources.semaphore,
+                ("start", "wait"),
+                f"{name}_load_copy",
+            ):
+                state.codegen.add_statement(statement)
+    else:
+        for statement in async_copy_statements(
+            state,
+            source,
+            resources.scratch,
+            resources.semaphore,
+            ("start", "wait"),
+            f"{name}_load_copy",
+        ):
+            state.codegen.add_statement(statement)
 
     result = expr_from_string(f"{resources.scratch}[...]")
     mask_expr = _load_mask_expr(state, subscript, tensor)

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -115,6 +115,134 @@ def plan_tiling(
             graph_info, graph_lookup, parent_ids
         )
         _analyze_indexing_expressions(graph_info, config, local_access_keys)
+    _plan_overlapped_direct_hbm_loads(graphs, config)
+
+
+def _plan_overlapped_direct_hbm_loads(
+    graphs: list[GraphInfo],
+    config: Config,
+) -> None:
+    """Stage aligned read-only inputs inside distributed projection kernels.
+
+    Launcher-managed VMEM BlockSpecs complete before the kernel body starts.
+    When a kernel also streams dynamic HBM windows and performs remote copies,
+    keeping independent inputs in HBM lets their local DMAs overlap those
+    streams instead of serializing the input prologue.
+    """
+    from ...language import distributed_ops
+    from ...language import memory_ops
+    from ...language.atomic_ops import ATOMIC_OPS
+    from ..compile_environment import CompileEnvironment
+    from ..device_function import DeviceFunction
+    from ..device_function import PallasMemorySpace
+    from ..host_function import HostFunction
+    from .dma import is_tpu_dma_aligned_shape
+
+    nodes = [node for graph in graphs for node in graph.graph.nodes]
+    if not any(
+        node.op == "call_function"
+        and node.target is distributed_ops.make_async_remote_copy
+        for node in nodes
+    ):
+        return
+    if not any(
+        node.op == "call_function"
+        and node.target is memory_ops.load
+        and any(
+            isinstance(pattern, ContiguousRangeIndexPattern)
+            for pattern in node.meta.get("indexing_patterns", ())
+        )
+        for node in nodes
+    ):
+        return
+
+    written_keys: set[str | int] = set()
+    loads_by_key: dict[str | int, list[tuple[torch.Tensor, torch.fx.Node]]] = {}
+    for node in nodes:
+        if node.op != "call_function":
+            continue
+        tensor_arg = node.args[0] if node.args else None
+        tensor = (
+            tensor_arg.meta.get("val")
+            if isinstance(tensor_arg, torch.fx.Node)
+            else None
+        )
+        if not isinstance(tensor, torch.Tensor):
+            continue
+        key = _tensor_origin_key(tensor)
+        if node.target is memory_ops.load:
+            loads_by_key.setdefault(key, []).append((tensor, node))
+        elif node.target is memory_ops.store or node.target in ATOMIC_OPS:
+            written_keys.add(key)
+
+    env = CompileEnvironment.current()
+    device_fn = DeviceFunction.current()
+    host_inputs = HostFunction.current().tensor_to_origin
+
+    def load_shape(node: torch.fx.Node) -> tuple[int, ...] | None:
+        value = node.meta.get("val")
+        if not isinstance(value, torch.Tensor):
+            return None
+        patterns = node.meta.get("indexing_patterns", ())
+        shape = list(value.shape)
+        for dimension in reversed(
+            [
+                index
+                for index, pattern in enumerate(patterns)
+                if isinstance(pattern, NonePattern)
+            ]
+        ):
+            shape.pop(dimension)
+        resolved: list[int] = []
+        for size in shape:
+            block_id = env.resolve_block_id(size)
+            concrete = (
+                env.block_sizes[block_id].from_config(config)
+                if block_id is not None
+                else size
+            )
+            if not isinstance(concrete, int):
+                return None
+            resolved.append(concrete)
+        return tuple(resolved)
+
+    for key, loads in loads_by_key.items():
+        if key in written_keys:
+            continue
+        if any(
+            any(
+                isinstance(pattern, ContiguousRangeIndexPattern)
+                for pattern in node.meta.get("indexing_patterns", ())
+            )
+            for _tensor, node in loads
+        ):
+            # Dynamic windows already have a loop-aware DMA pipeline.  This
+            # pass only overlaps independent full-input loads with that stream.
+            continue
+        tensor = loads[0][0]
+        if tensor not in host_inputs:
+            continue
+        if any(
+            not isinstance(value := node.meta.get("val"), torch.Tensor)
+            or not all(isinstance(size, int) for size in value.shape)
+            for _loaded_tensor, node in loads
+        ):
+            continue
+        shapes = [load_shape(node) for _tensor, node in loads]
+        if not shapes or any(
+            shape is None
+            or not shape
+            or not is_tpu_dma_aligned_shape(shape, tensor.dtype)
+            for shape in shapes
+        ):
+            continue
+        # Hoisting is only safe for one source-level load. Repeated windows from
+        # the same input intentionally reuse one immediate DMA scratch buffer.
+        if len(loads) != 1:
+            continue
+        for loaded_tensor, _node in loads:
+            device_fn.pallas_direct_hbm_load_tensor_ids.add(id(loaded_tensor))
+            device_fn.pallas_memory_space[id(loaded_tensor)] = PallasMemorySpace.HBM
 
 
 def _tensor_origin_key(tensor: torch.Tensor) -> str | int:

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1507,9 +1507,9 @@ def _hoist_initial_dma_before_pure_outer_compute(
     A buffered inner loop normally starts its first load immediately before
     entering the loop. If the address depends only on kernel arguments and
     constants, starting it before preceding elementwise root computation
-    exposes useful DMA/compute overlap. Stay conservative: cross only plain
-    assignments and compiler-owned scratch initialization, never user-visible
-    stores, structured control flow, or a producer of a value read by the DMA.
+    exposes useful DMA/compute overlap. The intervening work may itself contain
+    communication or stores; moving a read-only DMA across it is safe as long
+    as none of that work produces a value or mutates a ref read by the DMA.
     """
     from ..ast_read_writes import ReadWrites
 
@@ -1521,14 +1521,18 @@ def _hoist_initial_dma_before_pure_outer_compute(
     # ``outer`` produces it. Keep the prime inside that loop body in this case.
     if dma_reads.intersection(loop_local_names):
         return False
-    scratch_names = {scratch.name for scratch in state.device_function._scratch_args}
     for statement in outer:
-        if not isinstance(statement, ast.Assign):
-            return False
         rw = ReadWrites.from_ast(statement)
-        if set(rw.writes) & dma_reads or set(rw.inplace_writes) - scratch_names:
+        if (set(rw.writes) | set(rw.inplace_writes)) & dma_reads:
             return False
-    outer[:0] = statements
+    grid_state = state.codegen.current_grid_state
+    if (
+        state.device_function.pallas_hoisted_direct_dma_copy_names
+        and grid_state is not None
+    ):
+        grid_state.outer_prefix.extend(statements)
+    else:
+        outer[:0] = statements
     return True
 
 

--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -517,6 +517,38 @@ def _pipelined_remote_hbm_consume(
 
 
 @helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(block_sizes=[], pallas_loop_type="fori_loop"),
+)
+def _overlap_read_only_input_dma(
+    lhs: torch.Tensor,
+    weight: torch.Tensor,
+    gain: torch.Tensor,
+    starts: torch.Tensor,
+    peers: torch.Tensor,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    """Overlap a read-only input load with a dynamic weight-window stream."""
+    for _program in hl.grid(1):
+        scaled = lhs[:, :] * gain[None, :]
+        for step in hl.tile(1, block_size=1):
+            begin = starts[step.begin] * 128
+            panel = weight[:, begin + hl.arange(128)]
+            projected = torch.matmul(scaled, panel)
+            copy = hl.make_async_remote_copy(
+                projected,
+                [],
+                peers[0],
+                dst=output,
+                dst_index=[0],
+            )
+            copy.start()
+            copy.wait()
+    return output
+
+
+@helion.kernel(
     static_shapes=True,
     config=helion.Config(block_sizes=[]),
 )
@@ -1323,6 +1355,61 @@ class TestRemoteCopyJaxRuntime(TestCase):
         for _invocation in range(2):
             _stage, result = jax.block_until_ready(copy(*inputs))
             np.testing.assert_array_equal(np.asarray(result), expected)
+
+    @skipIfPallasInterpret("remote copies require physical TPU devices")
+    def test_read_only_input_dma_overlap_computes_correctly(self) -> None:
+        import jax
+        import jax.numpy as jnp
+
+        devices = [device for device in jax.local_devices() if device.platform == "tpu"]
+        if len(devices) < 2:
+            self.skipTest("requires at least two TPU devices")
+        mesh = jax.make_mesh((2,), ("peer",), devices=devices[:2])
+        partition = jax.sharding.PartitionSpec
+        input_specs = (
+            partition("peer", None),
+            partition(None, None),
+            partition(None),
+            partition("peer"),
+            partition("peer"),
+            partition("peer", None, None),
+        )
+        run = jax.jit(
+            jax.shard_map(
+                _overlap_read_only_input_dma.jax_fn,
+                mesh=mesh,
+                in_specs=input_specs,
+                out_specs=partition("peer", None, None),
+                check_vma=False,
+            )
+        )
+        lhs = jnp.arange(2 * 16 * 256, dtype=jnp.bfloat16).reshape(32, 256)
+        weight = (
+            jnp.arange(256 * 256, dtype=jnp.float32).reshape(256, 256) % 17
+        ).astype(jnp.bfloat16)
+        gain = (1 + jnp.arange(256, dtype=jnp.float32) % 5).astype(jnp.bfloat16)
+        starts = jnp.arange(2, dtype=jnp.int32)
+        peers = jnp.arange(2, dtype=jnp.int32)
+        output = jnp.zeros((2, 16, 128), dtype=jnp.bfloat16)
+        values = (lhs, weight, gain, starts, peers, output)
+        inputs = tuple(
+            jax.device_put(value, jax.sharding.NamedSharding(mesh, spec))
+            for value, spec in zip(values, input_specs, strict=True)
+        )
+        result = jax.block_until_ready(run(*inputs))
+        expected = jnp.stack(
+            [
+                jnp.matmul(
+                    (lhs[rank * 16 : (rank + 1) * 16] * gain[None, :]).astype(
+                        jnp.bfloat16
+                    ),
+                    weight[:, rank * 128 : (rank + 1) * 128],
+                    preferred_element_type=jnp.float32,
+                ).astype(jnp.bfloat16)
+                for rank in range(2)
+            ]
+        )
+        np.testing.assert_array_equal(np.asarray(result), np.asarray(expected))
 
     @skipIfPallasInterpret("computed FP8 sends require TPU VMEM lowering")
     def test_computed_fp8_source(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3405
 * #3396
 * #3394
 * #3402
 * #3401
 * #3407
 * __->__#3403
 * #3399
 * #3397
 * #3408
 * #3387
 * #3392
 * #3391


--- --- ---

### [Pallas] Overlap read-only input DMAs with weight streams


A distributed projection can consume a read-only activation or gain while also streaming a dynamic weight panel:

    scaled = lhs[:, :] * gain[None, :]
    panel = weight[:, starts[step] * 128 + hl.arange(128)]
    projected = torch.matmul(scaled, panel)
    copy = hl.make_async_remote_copy(projected, ..., dst=output)

Previously lhs and gain used launcher-managed VMEM BlockSpecs, so those transfers completed before the kernel body could start the weight DMA. The program paid the input prologue and the first weight transfer serially.

For distributed kernels that already contain an aligned dynamic HBM stream, identify single-site, read-only, DMA-aligned host inputs and keep them in HBM. Generate explicit local copies in the root prefix:

    lhs_load_copy.start()
    gain_load_copy.start()
    weight_copy.start()
    lhs_load_copy.wait()
    gain_load_copy.wait()
    ...
    weight_copy.wait()
    projected = lax.dot_general(...)

The analysis rejects written aliases, repeated load sites, dynamic-window operands, non-host tensors, unresolved shapes, and unaligned transfers. Site-local dynamic windows share compiler-owned scratch only when shape and dtype match.

The test executes the complete two-device BF16 matmul plus self-directed remote DMA and compares every output with a JAX reference.
