### PR TITLE
[Pallas] Drain computed-source sends after device loops

### DIFF
--- a/helion/_compiler/pallas/distributed_ops.py
+++ b/helion/_compiler/pallas/distributed_ops.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from ..inductor_lowering import CodegenState
     from ..tile_strategy import ForiLoopState
     from ..tile_strategy import RemoteRecvDrain
+    from ..tile_strategy import RemoteSendDrain
 
 
 _PALLAS_SRC_MATERIALIZATION_META = "_helion_pallas_remote_copy_src_materialization"
@@ -56,6 +57,8 @@ class _PallasRemoteCopyInfo:
     op_name: str
     source_materialization: tuple[ast.AST, ast.AST] | None
     deferred_recv: RemoteRecvDrain | None = None
+    deferred_send: RemoteSendDrain | None = None
+    started: bool = False
 
 
 @_decorators.codegen(remote_barrier, "pallas")
@@ -193,6 +196,19 @@ def _canonical_recv_ref(dst_ref: ast.AST, indexed_dims: int) -> ast.AST | None:
         placeholders[key] = part
         rendered.append(f"{{{key}}}")
     return expr_from_string(f"{{base}}[{', '.join(rendered)}]", **placeholders)
+
+
+def _static_send_slot_refs(
+    src_ref: ast.AST,
+    send_slot_shape: tuple[int, ...],
+) -> tuple[ast.AST, ...] | None:
+    """Enumerate the refs in a one-dimensional computed-source send ring."""
+    if len(send_slot_shape) != 1 or not isinstance(src_ref, ast.Subscript):
+        return None
+    return tuple(
+        expr_from_string(f"{{base}}[{slot}]", base=src_ref.value)
+        for slot in range(send_slot_shape[0])
+    )
 
 
 def _active_fori_loop(state: CodegenState) -> ForiLoopState | None:
@@ -475,6 +491,22 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
     materialization = state.fx_node.meta.get(_PALLAS_SRC_MATERIALIZATION_META)
     if materialization is not None:
         assert isinstance(materialization, tuple)
+    deferred_send: RemoteSendDrain | None = None
+    if fori_loop is not None and computed_source and send_slot_shape:
+        send_slot_refs = _static_send_slot_refs(src_ref, send_slot_shape)
+        if send_slot_refs is not None and len(ast_src_index) == 1:
+            slot = ast_src_index[0]
+            if isinstance(slot, int):
+                slot = expr_from_string(repr(slot))
+            assert isinstance(slot, ast.AST)
+            from ..tile_strategy import RemoteSendDrain
+
+            deferred_send = RemoteSendDrain(
+                semaphore=send_sem_name,
+                references=send_slot_refs,
+                slot=slot,
+            )
+            fori_loop._remote_send_drains.append(deferred_send)
     op_name = device_fn.new_var("remote_copy", dce=False)
     dst_ref = _remote_ref_expr(
         state,
@@ -516,6 +548,7 @@ def _make_remote_copy(state: CodegenState) -> ast.AST:
         op_name=op_name,
         source_materialization=materialization,
         deferred_recv=deferred_recv,
+        deferred_send=deferred_send,
     )
     return expr_from_string(op_name)
 
@@ -562,6 +595,32 @@ def _emit_source_materialization(
     return True
 
 
+def _defer_send_wait(state: CodegenState, drain: RemoteSendDrain) -> None:
+    fori_loop = _active_fori_loop(state)
+    assert fori_loop is not None
+    counter_size = ((len(drain.references) + 127) // 128) * 128
+    counter = drain.pending_counter
+    if counter is None:
+        counter = state.device_function.register_scratch(
+            (counter_size,),
+            torch.int32,
+            name_hint="remote_send_pending",
+        )
+        drain.pending_counter = counter
+        fori_loop.outer_prefix.append(
+            statement_from_string(f"{counter}[...] = jnp.zeros_like({counter}[...])")
+        )
+    state.codegen.add_statement(
+        statement_from_string(
+            f"{counter}[...] = jnp.maximum("
+            f"{counter}[...], jax.nn.one_hot({{slot}}, {counter_size}, "
+            "dtype=jnp.int32))",
+            slot=drain.slot,
+        )
+    )
+    drain.waits_deferred = True
+
+
 def _emit_wait(state: CodegenState, method: str) -> ast.AST:
     info = _paired_copy_info(state)
     if method == "start":
@@ -590,9 +649,14 @@ def _emit_wait(state: CodegenState, method: str) -> ast.AST:
                         f"jnp.ones_like({counter}[...])"
                     )
                 )
+        info.started = True
+    if method == "wait_send" and info.started and info.deferred_send is not None:
+        _defer_send_wait(state, info.deferred_send)
     if method == "wait_recv" and info.deferred_recv is not None:
         info.deferred_recv.waits_deferred = True
-    else:
+    elif not (
+        method == "wait_send" and info.started and info.deferred_send is not None
+    ):
         state.codegen.add_statement(statement_from_string(f"{info.op_name}.{method}()"))
     return expr_from_string("None")
 

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -4491,6 +4491,33 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             ):
                 state.codegen.add_statement(statement)
 
+    for drain in fori_state._remote_send_drains:
+        if not drain.waits_deferred:
+            continue
+        assert drain.pending_counter is not None
+        for slot, reference in enumerate(drain.references):
+            send_copy = state.device_function.new_var("_send_drain", dce=False)
+            send_index = state.device_function.new_var("_send_index", dce=False)
+            send_wait_body = state.device_function.new_var("_send_wait_body", dce=False)
+            fori_state.outer_suffix.extend(
+                (
+                    statement_from_string(
+                        f"{send_copy} = pltpu.make_async_copy("
+                        f"{{reference}}, {{reference}}, {drain.semaphore}.at[{slot}])",
+                        reference=reference,
+                    ),
+                    statement_from_string(
+                        f"def {send_wait_body}({send_index}, _):\n"
+                        f"    {send_copy}.wait()"
+                    ),
+                    statement_from_string(
+                        f"jax.lax.fori_loop(0, "
+                        f"{drain.pending_counter}[{slot}], "
+                        f"{send_wait_body}, None)"
+                    ),
+                )
+            )
+
     for drain in fori_state._remote_recv_drains.values():
         if not drain.waits_deferred:
             continue

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1876,6 +1876,17 @@ class RemoteRecvDrain:
 
 
 @dataclasses.dataclass
+class RemoteSendDrain:
+    """Deferred send completions for one looped computed-source ring."""
+
+    semaphore: str
+    references: tuple[ast.AST, ...]
+    slot: ast.AST
+    pending_counter: str | None = None
+    waits_deferred: bool = False
+
+
+@dataclasses.dataclass
 class ForiLoopState(DeviceLoopOrGridState):
     """State for fori_loop-based loops on TPU (Pallas backend).
 
@@ -1902,6 +1913,7 @@ class ForiLoopState(DeviceLoopOrGridState):
     _remote_recv_drains: dict[tuple[str, tuple[int, ...]], RemoteRecvDrain] = (
         dataclasses.field(default_factory=dict)
     )
+    _remote_send_drains: list[RemoteSendDrain] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Stacked PRs:
 * __->__#3405
 * #3396
 * #3394
 * #3402
 * #3401
 * #3407
 * #3403
 * #3399
 * #3397
 * #3408
 * #3387
 * #3392
 * #3391


--- --- ---

### [Pallas] Drain computed-source sends after device loops


A computed remote-copy ring normally waits before reusing an old slot, then requests completion for the final live slots at the loop tail:

    if step >= send_slots:
        copy.wait_send()
    copy.start()
    if step + send_slots >= num_steps:
        copy.wait_send()

The first wait is a true source-lifetime dependency. The tail wait is not: keeping it inside the fori body serializes final DMA completion with remaining loop work and makes descriptor scope awkward after lowering.

For one-dimensional computed-source rings, preserve pre-start reuse waits and replace post-start tail waits with one compiler-owned pending bit per static slot. After the loop, construct a canonical same-ref DMA descriptor for each used slot and drain its send semaphore:

    remote_send_pending[slot] = 1
    ...
    drain = pltpu.make_async_copy(src.at[slot], src.at[slot], send_sem.at[slot])
    jax.lax.fori_loop(0, remote_send_pending[slot], wait_body, None)

Non-ring sources, non-fori loops, waits issued before start, and unsupported source layouts retain their existing behavior. Receive draining remains independent.

The distributed computation test sends four reduced payloads through a two-slot ring twice and compares the complete result exactly.
