### PR TITLE
[Pallas] Keep aligned static resident slices as Ref views

### DIFF
--- a/helion/_compiler/pallas/view_ops.py
+++ b/helion/_compiler/pallas/view_ops.py
@@ -571,6 +571,7 @@ def _apply_selector_to_variants(
     config: Config,
 ) -> _ResidentTransform:
     """Validate and apply a logical selector to every physical Ref variant."""
+    from .backend import PallasBackend
     from .backend import SliceAddressing
     from .backend import _slice_addressing
 
@@ -581,15 +582,6 @@ def _apply_selector_to_variants(
             logical_dim, variant.squeezed_dims, len(variant.shape)
         )
         lane_block = variant.shape[-1]
-        if (
-            _slice_addressing(input_value, logical_dim, lane_block)
-            is not SliceAddressing.DIRECT
-        ):
-            raise exc.BackendUnsupported(
-                "pallas",
-                f"the selector at {location} does not have direct VMEM "
-                "addressing for this config",
-            )
         width = (
             _variant_block_size(
                 selector.local_block_id, config, variant.worklist_factor
@@ -603,6 +595,28 @@ def _apply_selector_to_variants(
                 f"the selector at {location} has no concrete positive width "
                 "for this config",
             )
+        addressing = _slice_addressing(input_value, logical_dim, lane_block)
+        if addressing is not SliceAddressing.DIRECT:
+            dim_from_end = input_value.ndim - logical_dim - 1
+            bitwidth = input_value.dtype.itemsize * 8
+            backend = CompileEnvironment.current().backend
+            assert isinstance(backend, PallasBackend)
+            alignment = backend._get_pallas_required_alignment(
+                dim_from_end,
+                input_value.ndim,
+                bitwidth,
+            )
+            if (
+                selector.kind != "static"
+                or not isinstance(selector.begin, int)
+                or selector.begin % alignment
+                or width % alignment
+            ):
+                raise exc.BackendUnsupported(
+                    "pallas",
+                    f"the selector at {location} is not aligned for direct "
+                    "VMEM addressing in this config",
+                )
         if squeeze and width != 1:
             raise exc.BackendUnsupported(
                 "pallas",

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1878,6 +1878,25 @@ class TestPallas(TestCase):
         self.assertNarrowingIsResident(code)
         torch.testing.assert_close(actual, torch.full_like(actual, 8))
 
+    def test_resident_subview_aligned_lane_slice(self) -> None:
+        """An aligned static lane slice remains an address-only Ref view."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def select_panel(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty([1, 4, 128], device=x.device, dtype=x.dtype)
+            for _request in hl.grid(1):
+                state = hl.zeros([4, 128], dtype=torch.float32)
+                for outer in hl.tile(x.size(0), block_size=4):
+                    x_block = x[outer, :, :]
+                    state += x_block[:, :, 128:256].float().sum(dim=0)
+                out[0, :, :] = state.to(out.dtype)
+            return out
+
+        x = torch.randn(8, 4, 256, device=DEVICE, dtype=torch.bfloat16)
+        expected = x[:, :, 128:256].float().sum(dim=0, keepdim=True).bfloat16()
+        _, actual = code_and_output(select_panel, (x,), pallas_loop_type="fori_loop")
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
     def test_resident_subview_composed_views(self) -> None:
         """Subview and reshape transforms compose without materializing."""
 


### PR DESCRIPTION
Stacked PRs:
 * #3408
 * #3405
 * #3396
 * #3394
 * #3402
 * #3401
 * #3387
 * #3407
 * #3403
 * #3399
 * #3398
 * #3397
 * #3392
 * #3391
 * __->__#3406


--- --- ---

### [Pallas] Keep aligned static resident slices as Ref views


Helion kernels can select a fixed, aligned lane panel from a tensor that is already resident in VMEM. For example:

    panel = x_block[:, :, 128:256]

Previously, resident-view planning rejected this selector because narrowing the innermost lane dimension was classified as non-direct:

    BackendUnsupported: selector ... does not have direct VMEM addressing

That classification is too conservative for a static interval whose start and width both satisfy Mosaic's DMA alignment. Such an interval is still one contiguous address transform and does not require a gather or materialization.

After this change the same source stays a Ref view:

    panel_ref = x_block.at[:, :, pl.ds(128, 128)]

Only static slices are admitted through this exception. Dynamic, misaligned, padded, and out-of-bounds selectors retain the existing rejection paths.

The new Pallas test executes the reduction and compares its complete numerical result with PyTorch.
