### PR TITLE
[Pallas] Reuse aligned HBM windows as resident matmul Refs

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -1128,7 +1128,13 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                                     grid_state.outer_suffix
                                 )
                             else:
+                                self.statements_stack[-1].extend(
+                                    grid_state.outer_prefix
+                                )
                                 self.statements_stack[-1].extend(wrapped_body)
+                                self.statements_stack[-1].extend(
+                                    grid_state.outer_suffix
+                                )
                         else:
                             codegen_call_with_graph(self, root, [])
                 finally:

--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -268,6 +268,10 @@ def _pallas_dot(ctx: LoweringContext, node: Node, with_acc: bool) -> ast.AST:
 
     assert isinstance(lhs_node_arg, Node)
     assert isinstance(rhs_node_arg, Node)
+    from .view_ops import maybe_materialize_resident_value
+
+    lhs = maybe_materialize_resident_value(lhs_node_arg, lhs)
+    rhs = maybe_materialize_resident_value(rhs_node_arg, rhs)
     lhs_dtype = lhs_node_arg.meta["val"].dtype
     rhs_dtype = rhs_node_arg.meta["val"].dtype
     lhs_ndim = lhs_node_arg.meta["val"].ndim

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import operator
 from typing import TYPE_CHECKING
 from typing import cast
 
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
     from helion._compiler.aten_lowering import LoweringContext
     from helion._compiler.inductor_lowering import CodegenState
     from helion._compiler.pallas.dma import DmaResources
+    from helion._compiler.tile_strategy import DeviceGridState
     from helion._compiler.tile_strategy import DeviceLoopOrGridState
     from helion._compiler.tile_strategy import ForiLoopState
 
@@ -108,6 +110,8 @@ def _hbm_load_expr(
     subscript: list[object],
     tensor: torch.Tensor,
     name: str,
+    *,
+    return_ref: bool = False,
 ) -> ast.AST:
     """Stage one directly accessed HBM region into VMEM.
 
@@ -182,6 +186,31 @@ def _hbm_load_expr(
                 resources
             )
     source = f"{name}.at[{', '.join(parts)}]"
+    hoist_target: DeviceGridState | ForiLoopState | None = None
+    hoisted_source = source
+    if return_ref:
+        contiguous_dims = [
+            (dim, pattern)
+            for dim, pattern in enumerate(patterns)
+            if isinstance(pattern, ContiguousRangeIndexPattern)
+        ]
+        if len(contiguous_dims) == 1:
+            dim, pattern = contiguous_dims[0]
+            base = _hoistable_scalar_expr(state, pattern.base)
+            if base is not None:
+                from helion._compiler.tile_strategy import DeviceGridState
+
+                grid_state = state.codegen.current_grid_state
+                if isinstance(grid_state, DeviceGridState):
+                    hoist_target = grid_state
+                    hoisted_parts = [*parts]
+                    hoisted_parts[dim] = (
+                        f"pl.ds(pl.multiple_of({base}, {pattern.alignment}), "
+                        f"{pattern.length})"
+                    )
+                    hoisted_source = f"{name}.at[{', '.join(hoisted_parts)}]"
+    if hoist_target is None and return_ref:
+        hoist_target = _single_iteration_fori_loop(state)
     if device_fn.is_pallas_direct_hbm_load(tensor):
         from helion._compiler.tile_strategy import DeviceGridState
 
@@ -214,6 +243,21 @@ def _hbm_load_expr(
                 f"{name}_load_copy",
             ):
                 state.codegen.add_statement(statement)
+    elif hoist_target is not None:
+        start_statements = async_copy_statements(
+            state,
+            hoisted_source,
+            resources.scratch,
+            resources.semaphore,
+            ("start",),
+            f"{name}_load_copy",
+        )
+        copy_assignment = start_statements[0]
+        assert isinstance(copy_assignment, ast.Assign)
+        copy_target = copy_assignment.targets[0]
+        assert isinstance(copy_target, ast.Name)
+        hoist_target.outer_prefix.extend(start_statements)
+        state.codegen.add_statement(statement_from_string(f"{copy_target.id}.wait()"))
     else:
         for statement in async_copy_statements(
             state,
@@ -225,8 +269,15 @@ def _hbm_load_expr(
         ):
             state.codegen.add_statement(statement)
 
-    result = expr_from_string(f"{resources.scratch}[...]")
     mask_expr = _load_mask_expr(state, subscript, tensor)
+    if return_ref:
+        if none_dims or mask_expr is not None:
+            raise NotImplementedError(
+                "resident HBM windows do not support inserted dimensions or masks"
+            )
+        return expr_from_string(resources.scratch)
+
+    result = expr_from_string(f"{resources.scratch}[...]")
     if mask_expr is not None:
         result = expr_from_string(
             "{result} * ({mask})", result=result, mask=expr_from_string(mask_expr)
@@ -236,6 +287,102 @@ def _hbm_load_expr(
             f"jnp.expand_dims({{result}}, axis={dim})", result=result
         )
     return result
+
+
+def _single_iteration_fori_loop(state: CodegenState) -> ForiLoopState | None:
+    """Return the active Pallas loop when every tiled axis has one iteration."""
+    from helion._compiler.tile_strategy import ForiLoopState
+
+    loop = next(
+        (
+            candidate
+            for loops in state.codegen.active_device_loops.values()
+            for candidate in loops
+            if isinstance(candidate, ForiLoopState)
+        ),
+        None,
+    )
+    if loop is None:
+        return None
+    for block_id in loop.block_ids:
+        info = loop.block_id_to_info[block_id]
+        block_size = state.device_function.resolved_block_size(block_id)
+        if (
+            not isinstance(block_size, int)
+            or info.begin_expr != 0
+            or not info.is_end_matching(block_size)
+        ):
+            return None
+    return loop
+
+
+def _hoistable_scalar_expr(state: CodegenState, value: object) -> str | None:
+    """Render loop-invariant integer arithmetic over scalar input loads."""
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, torch.SymInt):
+        return state.device_function.literal_expr(value)
+    if not isinstance(value, torch.fx.Node) or value.op != "call_function":
+        return None
+
+    from helion.language import memory_ops
+    from helion.language._tracing_ops import _new_var
+
+    if value.target is _new_var and value.args:
+        return _hoistable_scalar_expr(state, value.args[0])
+
+    binary_operators = {
+        operator.add: "+",
+        operator.floordiv: "//",
+        operator.mul: "*",
+        operator.sub: "-",
+        torch.ops.aten.add.Scalar: "+",
+        torch.ops.aten.add.Tensor: "+",
+        torch.ops.aten.div.Tensor_mode: "//",
+        torch.ops.aten.mul.Scalar: "*",
+        torch.ops.aten.mul.Tensor: "*",
+        torch.ops.aten.sub.Scalar: "-",
+        torch.ops.aten.sub.Tensor: "-",
+    }
+    if value.target in binary_operators and len(value.args) >= 2:
+        if (
+            value.target is torch.ops.aten.div.Tensor_mode
+            and value.kwargs.get("rounding_mode") != "floor"
+        ):
+            return None
+        if (
+            value.target
+            in (
+                torch.ops.aten.add.Scalar,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.sub.Scalar,
+                torch.ops.aten.sub.Tensor,
+            )
+            and value.kwargs.get("alpha", 1) != 1
+        ):
+            return None
+        lhs = _hoistable_scalar_expr(state, value.args[0])
+        rhs = _hoistable_scalar_expr(state, value.args[1])
+        if lhs is None or rhs is None:
+            return None
+        return f"({lhs}) {binary_operators[value.target]} ({rhs})"
+
+    if value.target is memory_ops.load:
+        tensor_node, subscript = value.args[:2]
+        if not isinstance(tensor_node, torch.fx.Node):
+            return None
+        tensor = tensor_node.meta.get("val")
+        if not isinstance(tensor, torch.Tensor):
+            return None
+        if not isinstance(subscript, (list, tuple)) or len(subscript) != 1:
+            return None
+        index = _hoistable_scalar_expr(state, subscript[0])
+        if index is None:
+            return None
+        name = state.device_function.tensor_arg(tensor).name
+        return f"{name}[{index}]"
+
+    return None
 
 
 def resident_ref_load_expr(
@@ -251,10 +398,27 @@ def resident_ref_load_expr(
     from helion._compiler.pallas.tensorcore_plan import DmaGatherPlan
     from helion._compiler.pallas.tensorcore_plan import OneHotGatherPlan
 
-    arg_name, name, _patterns = _load_route(state, tensor)
+    arg_name, name, patterns = _load_route(state, tensor)
     device_fn = state.device_function
 
     assert state.fx_node is not None
+    from helion._compiler.pallas.plan_tiling import ContiguousRangeIndexPattern
+
+    if (
+        name == arg_name
+        and device_fn.pallas_memory_space.get(id(tensor)) is PallasMemorySpace.HBM
+        and any(
+            isinstance(pattern, ContiguousRangeIndexPattern) for pattern in patterns
+        )
+    ):
+        return _hbm_load_expr(
+            state,
+            subscript,
+            tensor,
+            arg_name,
+            return_ref=True,
+        )
+
     plan = state.fx_node.meta.get(TENSORCORE_PLAN_META)
     if isinstance(plan, DmaGatherPlan):
         dma_ref = memory_op_dma_scratch(state)

--- a/helion/_compiler/pallas/view_ops.py
+++ b/helion/_compiler/pallas/view_ops.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
 
 RESIDENT_PLAN_META = "pallas_resident_ref_plan"
+RESIDENT_VALUE_USE_META = "pallas_resident_ref_value_use"
 STATIC_BASIC_VALUE_SUBSCRIPT_META = "pallas_static_basic_value_subscript"
 
 # These Aten operations may preserve the address interpretation of a resident
@@ -61,6 +62,16 @@ _RESIDENT_REF_ATEN_VIEW_TARGETS = frozenset(
         torch.ops.aten.squeeze.dim,
         torch.ops.aten.unsqueeze.default,
         torch.ops.aten.view.default,
+    }
+)
+
+# Matrix multiplication consumes an array value, but may receive a resident Ref
+# through identity-only loop captures. Materialize only at the operation itself
+# so other users can keep composing addressable Ref views.
+_RESIDENT_REF_VALUE_TARGETS = frozenset(
+    {
+        torch.ops.aten.bmm.default,
+        torch.ops.aten.mm.default,
     }
 )
 
@@ -253,6 +264,13 @@ def _resident_plan(node: torch.fx.Node) -> _ResidentPlan | None:
     # can be an instance of the pre-reload NamedTuple class. The private metadata
     # key is the stable type boundary across that reload.
     return cast("_ResidentPlan | None", node.meta.get(RESIDENT_PLAN_META))
+
+
+def maybe_materialize_resident_value(node: torch.fx.Node, result: ast.AST) -> ast.AST:
+    """Load a Ref transported to an operation that requires an array value."""
+    if not node.meta.get(RESIDENT_VALUE_USE_META):
+        return result
+    return expr_from_string("{result}[...]", result=result)
 
 
 def _where(node: torch.fx.Node) -> str:
@@ -450,10 +468,6 @@ def _root_variants(
         raise exc.BackendUnsupported(
             "pallas", f"the source load at {location} has no tensor value metadata"
         )
-    if tensor.ndim != value.ndim:
-        raise exc.BackendUnsupported(
-            "pallas", f"the source load at {location} changes the tensor rank"
-        )
     if producer.args[2] is not None:
         raise exc.BackendUnsupported(
             "pallas", f"the source load at {location} has an explicit mask"
@@ -480,6 +494,34 @@ def _root_variants(
         )
 
     selected = _narrowed_dims(indices)
+    from .plan_tiling import ContiguousRangeIndexPattern
+
+    patterns = producer.meta.get("indexing_patterns", ())
+    has_narrowing_user = any(
+        user.target is subscript and _narrowed_dims(user.args[1])
+        for user, _transports in _effective_users(producer, context.captures)
+    )
+    contiguous_range_selection = (
+        tensor.ndim == value.ndim
+        and len(selected) == 1
+        and len(patterns) == tensor.ndim
+        and isinstance(patterns[selected[0]], ContiguousRangeIndexPattern)
+        and has_narrowing_user
+    )
+    if contiguous_range_selection:
+        shape = _physical_shape(value, context.config, 1)
+        if shape is None:
+            raise exc.BackendUnsupported(
+                "pallas",
+                f"the source load at {location} has no concrete physical shape "
+                "for this config",
+            )
+        return (_ResidentVariant(1, shape, (), None),)
+
+    if tensor.ndim != value.ndim:
+        raise exc.BackendUnsupported(
+            "pallas", f"the source load at {location} changes the tensor rank"
+        )
     if len(selected) != 1:
         raise exc.BackendUnsupported(
             "pallas",
@@ -1064,7 +1106,15 @@ def _record_descendant_failure(
             # Keep the first failure found below this node. Later transactional
             # rollback errors are broader and must not hide the local diagnostic.
             context.failures.setdefault(node, failure)
+        if node is not producer and node.target in _RESIDENT_REF_VALUE_TARGETS:
+            # A matrix multiplication result starts a new value chain; a
+            # failure on one input Ref must not leak into narrowing its output.
+            continue
         for user, _transports in _effective_users(node, context.captures):
+            if user.target is load and user.args and user.args[0] is not node:
+                # Address expressions do not carry the loaded tensor's Ref.
+                # The load is analyzed independently as a new resident root.
+                continue
             stack.append(user)
 
 
@@ -1093,6 +1143,7 @@ def _analyze_resident_chain(
         ],
     ] = {}
     unsupported: list[tuple[torch.fx.Node, exc.BackendUnsupported]] = []
+    value_boundaries: list[tuple[torch.fx.Node, tuple[torch.fx.Node, ...]]] = []
     for user, transports in users:
         user_info = context.graph_infos.get(user.graph)
         if user_info is None:
@@ -1111,15 +1162,25 @@ def _analyze_resident_chain(
                 context,
             )
         except exc.BackendUnsupported as failure:
+            if user.target in _RESIDENT_REF_VALUE_TARGETS and all(
+                variant.live_guard is None for variant in node_variants
+            ):
+                value_boundaries.append((user, transports))
+                continue
             unsupported.append((user, failure))
-            _record_descendant_failure(user, context, failure)
+            if (
+                root
+                or user.target is subscript
+                or user.target in _RESIDENT_REF_ATEN_VIEW_TARGETS
+            ):
+                _record_descendant_failure(user, context, failure)
         else:
             planned[user] = (transports, result.variants, result.selector)
 
     # A root load has one codegen representation. If any branch needs its ordinary
     # value, it cannot simultaneously remain a Ref for a narrowing branch.
-    if root and (unsupported or not planned):
-        if planned and unsupported:
+    if root and (unsupported or (not planned and not value_boundaries)):
+        if (planned or value_boundaries) and unsupported:
             blockers = [_where(user) for user, _failure in unsupported]
             reason = "the block is also consumed whole at " + ", ".join(blockers[:3])
             failure = exc.BackendUnsupported("pallas", reason)
@@ -1135,7 +1196,9 @@ def _analyze_resident_chain(
     # Past the root, an unsupported or terminal user is normally a legal boundary:
     # materialize this view and let ordinary Pallas codegen continue from its value.
     if not root and (
-        (selector is not None and selector.mask) or unsupported or not planned
+        (selector is not None and selector.mask)
+        or unsupported
+        or (not planned and not value_boundaries)
     ):
         masked_boundary = selector is not None and selector.mask and bool(planned)
         if masked_boundary:
@@ -1180,10 +1243,15 @@ def _analyze_resident_chain(
         return
 
     annotations[node] = _ResidentPlan(False, node_variants, selector)
+    transport_plan = _ResidentPlan(False, node_variants, None)
+    for _user, transports in value_boundaries:
+        for transport in transports:
+            annotations[transport] = transport_plan
+        value_node = transports[-1] if transports else node
+        value_node.meta[RESIDENT_VALUE_USE_META] = True
     for user, (transports, output, user_spec) in planned.items():
         # Identity transports retain the input physical state; the semantic user
         # receives the transformed state returned by _registered_transform.
-        transport_plan = _ResidentPlan(False, node_variants, None)
         for transport in transports:
             annotations[transport] = transport_plan
         _analyze_resident_chain(
@@ -1211,6 +1279,10 @@ def plan_resident_ref_views(graphs: list[GraphInfo], config: Config) -> None:
     for info in graphs:
         for producer in info.graph.find_nodes(op="call_function", target=load):
             tensor = _node_value(producer.args[0])
+            value = producer.meta.get("val")
+            if isinstance(value, torch.Tensor) and value.ndim == 0:
+                # Scalar loads are address values, not resident tensor blocks.
+                continue
             dma_plan = _indirect_dma_plan(producer)
             # Keeping a Ref defers the physical read until its consumer. A device
             # write through an alias could therefore change program semantics.

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2086,6 +2086,53 @@ class TestPallas(TestCase):
         _, actual = code_and_output(select_panel, (x,), pallas_loop_type="fori_loop")
         torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
 
+    def test_aligned_hbm_window_reused_by_matmul_and_static_slice(self) -> None:
+        """One staged HBM window remains a Ref across multiple matmuls."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def project_window(
+            lhs: torch.Tensor,
+            weight: torch.Tensor,
+            panel: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            rows = hl.specialize(lhs.size(0))
+            full = torch.empty([rows, 256], dtype=lhs.dtype, device=lhs.device)
+            half = torch.empty([rows, 128], dtype=lhs.dtype, device=lhs.device)
+            for tile_m in hl.tile(rows):
+                scaled = lhs[tile_m, :] + 1
+                begin = panel[0] * 128
+                local_weight = weight[:, begin + hl.arange(256)]
+                full[tile_m, :] = torch.matmul(scaled, local_weight)
+                half[tile_m, :] = torch.matmul(
+                    scaled,
+                    local_weight[:, 0:128],
+                )
+            return full, half
+
+        lhs = torch.randn(8, 128, device=DEVICE, dtype=torch.bfloat16)
+        weight = torch.randn(128, 512, device=DEVICE, dtype=torch.bfloat16)
+        panel = torch.tensor([1], device=DEVICE, dtype=torch.int32)
+        _, (full, half) = code_and_output(
+            project_window,
+            (lhs, weight, panel),
+            block_size=8,
+        )
+
+        scaled = lhs.float() + 1
+        selected = weight[:, 128:384].float()
+        torch.testing.assert_close(
+            full,
+            torch.matmul(scaled, selected).bfloat16(),
+            rtol=2e-2,
+            atol=0.25,
+        )
+        torch.testing.assert_close(
+            half,
+            torch.matmul(scaled, selected[:, :128]).bfloat16(),
+            rtol=2e-2,
+            atol=0.25,
+        )
+
     def test_resident_subview_composed_views(self) -> None:
         """Subview and reshape transforms compose without materializing."""
 


### PR DESCRIPTION
Stacked PRs:
 * #3405
 * #3396
 * #3394
 * #3402
 * #3401
 * __->__#3407
 * #3403
 * #3399
 * #3397
 * #3408
 * #3387
 * #3392
 * #3391


--- --- ---

### [Pallas] Reuse aligned HBM windows as resident matmul Refs


A projection may consume one aligned HBM window both as a complete matrix and through a later static subview:

```python
begin = panel[0] * 128
local_weight = weight[:, begin + hl.arange(256)]
full = torch.matmul(lhs, local_weight)
half = torch.matmul(lhs, local_weight[:, 0:128])
```

The aligned-window lowering could stage the first matmul, and resident-Ref lowering could preserve the static slice, but the two plans did not compose. Planning stopped with "the block is also consumed whole", or materialized the window before the static slice and lost direct Ref addressing.

Treat an aligned HBM window with a real narrowing user as one resident Ref. Start its exact DMA at the earliest loop-invariant point, keep the scratch as a Ref through identity captures, materialize it only at mm/bmm consumers, and derive aligned static subviews directly from the same scratch:

```python
weight_load_copy.start()
scaled = lhs + 1
weight_load_copy.wait()
full = lax.dot_general(scaled, weight_load[...], ...)
half = lax.dot_general(scaled, weight_load.at[:, pl.ds(0, 128)][...], ...)
```

The rule has no tensor-size threshold or model-specific shape. It activates only when the contiguous window has a narrowing user, so ordinary streamed matmul windows retain their existing pipeline code. Scalar address expressions stop at the load boundary instead of being mistaken for the loaded Ref. Device-grid prefix and suffix statements are emitted even when no lane-loop wrapper is needed, which preserves the hoisted DMA.

The computation test executes both matmuls in Pallas interpret mode and compares both complete outputs with PyTorch. No Helion API changes.
