### PR TITLE
[Pallas] Keep private remote-copy buffers in VMEM

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -359,6 +359,14 @@ class DeviceFunction:
         # nested control-flow graphs.
         self.pallas_remote_copy_tensor_ids: set[int] = set()
         self.pallas_remote_copy_storage_ids: set[int] = set()
+        # Read-only inputs selected for explicit local HBM-to-VMEM DMA at
+        # their load sites, rather than launcher-managed VMEM BlockSpecs.
+        self.pallas_direct_hbm_load_tensor_ids: set[int] = set()
+        self.pallas_hoisted_direct_dma_copy_names: set[str] = set()
+        # Body-local ``torch.empty`` tensors that are read and written but do
+        # not escape the kernel return can live entirely in compiler-managed
+        # VMEM scratch instead of becoming hidden HBM in/out arguments.
+        self.pallas_internal_scratch_storage_names: dict[int, str] = {}
         # Pallas: id(fake_tensor) → memory space, determined during
         # tracing (HBM for pipeline) and codegen (SMEM for scalar access).
         # NOTE: Currently each tensor can only have one memory space.
@@ -392,6 +400,18 @@ class DeviceFunction:
             id(tensor) in self.pallas_remote_copy_tensor_ids
             or id(tensor.untyped_storage()) in self.pallas_remote_copy_storage_ids
         )
+
+    def is_pallas_direct_hbm_load(self, tensor: torch.Tensor) -> bool:
+        return id(tensor) in self.pallas_direct_hbm_load_tensor_ids
+
+    def pallas_internal_scratch_name(self, tensor: torch.Tensor) -> str | None:
+        return self.pallas_internal_scratch_storage_names.get(
+            id(tensor.untyped_storage())
+        )
+
+    def pallas_tensor_ref_name(self, tensor: torch.Tensor) -> str:
+        scratch = self.pallas_internal_scratch_name(tensor)
+        return scratch if scratch is not None else self.tensor_arg(tensor).name
 
     def allocate_store_index(self) -> int:
         """Bump store counters and return the indexing strategy slot."""
@@ -878,7 +898,14 @@ class DeviceFunction:
 
     def sorted_args(self) -> list[Argument]:
         self.arguments.sort(key=lambda arg: arg.sort_key())
-        return self.arguments
+        return [
+            arg
+            for arg in self.arguments
+            if not (
+                isinstance(arg, TensorArg)
+                and self.pallas_internal_scratch_name(arg.fake_value) is not None
+            )
+        ]
 
     def codegen_function_def(self) -> list[ast.stmt]:
         prefix = []

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1518,6 +1518,9 @@ class PallasBackend(Backend):
 
         env = CompileEnvironment.current()
 
+        from .internal_scratch import plan_internal_remote_scratch
+
+        plan_internal_remote_scratch()
         plan_tiling(graphs, config, tile_strategy)
         build_tensorcore_plans(graphs, config)
 

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 def _load_route(
     state: CodegenState, tensor: torch.Tensor
 ) -> tuple[str, str, list[object]]:
-    arg_name = state.device_function.tensor_arg(tensor).name
+    arg_name = state.device_function.pallas_tensor_ref_name(tensor)
     active_name = vmem_name(state, arg_name)
     state.device_function.device_load_index += 1
     state.device_function.device_memory_op_index += 1

--- a/helion/_compiler/pallas/distributed_ops.py
+++ b/helion/_compiler/pallas/distributed_ops.py
@@ -162,7 +162,7 @@ def _remote_ref_expr(
     assert isinstance(proxy_index, (list, tuple))
     assert isinstance(ast_index, list)
     try:
-        name = state.device_function.tensor_arg(tensor).name
+        name = state.device_function.pallas_tensor_ref_name(tensor)
     except KeyError:
         if not materialize_device_value:
             raise exc.TypeInferenceError(

--- a/helion/_compiler/pallas/internal_scratch.py
+++ b/helion/_compiler/pallas/internal_scratch.py
@@ -1,0 +1,158 @@
+"""Plan body-local tensors that can remain entirely in TPU VMEM."""
+
+from __future__ import annotations
+
+import ast
+
+import torch
+
+from ... import exc
+from ...language import distributed_ops
+from ...language import memory_ops
+from ...language.atomic_ops import ATOMIC_OPS
+from ..compile_environment import CompileEnvironment
+from ..device_function import DeviceFunction
+from ..host_function import HostFunction
+
+_EMPTY_FACTORIES = frozenset({"empty", "empty_like", "new_empty"})
+
+
+def _top_level_empty_names(host: HostFunction) -> set[str]:
+    names: set[str] = set()
+    for statement in host.body:
+        if (
+            isinstance(statement, ast.Assign)
+            and len(statement.targets) == 1
+            and isinstance(statement.targets[0], ast.Name)
+            and isinstance(statement.value, ast.Call)
+            and isinstance(statement.value.func, ast.Attribute)
+            and statement.value.func.attr in _EMPTY_FACTORIES
+        ):
+            names.add(statement.targets[0].id)
+    return names
+
+
+def _returned_name_dependencies(host: HostFunction) -> set[str]:
+    """Conservatively find every host name that can feed the return value."""
+    escaped: set[str] = set()
+    dependencies: dict[str, set[str]] = {}
+    module = ast.Module(body=host.body, type_ignores=[])
+    for node in ast.walk(module):
+        if isinstance(node, ast.Return) and node.value is not None:
+            escaped.update(
+                child.id
+                for child in ast.walk(node.value)
+                if isinstance(child, ast.Name)
+            )
+        elif (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            dependencies.setdefault(node.targets[0].id, set()).update(
+                child.id
+                for child in ast.walk(node.value)
+                if isinstance(child, ast.Name)
+            )
+
+    pending = list(escaped)
+    while pending:
+        name = pending.pop()
+        for dependency in dependencies.get(name, ()):
+            if dependency not in escaped:
+                escaped.add(dependency)
+                pending.append(dependency)
+    return escaped
+
+
+def _tensor_storage(node: object) -> int | None:
+    if not isinstance(node, torch.fx.Node):
+        return None
+    value = node.meta.get("val")
+    return id(value.untyped_storage()) if isinstance(value, torch.Tensor) else None
+
+
+def _accessed_storages(
+    device_fn: DeviceFunction,
+) -> tuple[set[int], set[int], set[int]]:
+    read: set[int] = set()
+    written: set[int] = set()
+    remote: set[int] = set()
+    for graph_info in device_fn.codegen.codegen_graphs:
+        for node in graph_info.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target is memory_ops.load:
+                if (storage := _tensor_storage(node.args[0])) is not None:
+                    read.add(storage)
+            elif node.target is memory_ops.store:
+                if (storage := _tensor_storage(node.args[0])) is not None:
+                    written.add(storage)
+            elif node.target in ATOMIC_OPS:
+                if (storage := _tensor_storage(node.args[0])) is not None:
+                    read.add(storage)
+                    written.add(storage)
+            elif node.target is distributed_ops.make_async_remote_copy:
+                if len(node.args) != 5:
+                    raise exc.InternalError(
+                        RuntimeError(
+                            "remote copy was not normalized to its five-argument form"
+                        )
+                    )
+                if (storage := _tensor_storage(node.args[0])) is not None:
+                    read.add(storage)
+                    remote.add(storage)
+                if (storage := _tensor_storage(node.args[3])) is not None:
+                    written.add(storage)
+                    remote.add(storage)
+    return read, written, remote
+
+
+def plan_internal_remote_scratch() -> None:
+    """Place private, body-local remote-copy buffers in VMEM scratch.
+
+    The transformation is intentionally narrow. An allocation must be a
+    top-level ``torch.empty``-family call, have a fully static shape, be both
+    read and written, participate in remote DMA, and not feed the host return.
+    """
+    host = HostFunction.current()
+    device_fn = DeviceFunction.current()
+    allocation_names = _top_level_empty_names(host) - _returned_name_dependencies(host)
+    if not allocation_names:
+        return
+
+    read, written, remote = _accessed_storages(device_fn)
+    eligible_storages = read & written & remote
+    if not eligible_storages:
+        return
+
+    input_storages = {
+        id(tensor.untyped_storage())
+        for tensor in CompileEnvironment.current().input_sources
+    }
+    tensors_by_storage: dict[int, list[torch.Tensor]] = {}
+    names_by_storage: dict[int, str] = {}
+    for tensor, origin in host.tensor_to_origin.items():
+        try:
+            name = origin.host_str()
+        except RuntimeError:
+            continue
+        storage = id(tensor.untyped_storage())
+        if (
+            name not in allocation_names
+            or storage in input_storages
+            or storage not in eligible_storages
+            or not all(isinstance(size, int) for size in tensor.shape)
+        ):
+            continue
+        tensors_by_storage.setdefault(storage, []).append(tensor)
+        names_by_storage[storage] = name
+
+    for storage, tensors in tensors_by_storage.items():
+        representative = max(tensors, key=lambda tensor: (tensor.ndim, tensor.numel()))
+        scratch_name = device_fn.register_scratch(
+            tuple(representative.shape),
+            representative.dtype,
+            name_hint=names_by_storage[storage],
+        )
+        device_fn.pallas_internal_scratch_storage_names[storage] = scratch_name

--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -39,7 +39,8 @@ def _(state: CodegenState) -> None:
     value = state.ast_arg(2)
     assert isinstance(tensor, torch.Tensor)
     arg_name = state.device_function.tensor_arg(tensor).name
-    name = pallas_codegen.vmem_name(state, arg_name)
+    name = state.device_function.pallas_tensor_ref_name(tensor)
+    name = pallas_codegen.vmem_name(state, name)
     # Increment memory op index to stay in sync with triton backend
     device_fn = state.device_function
     device_fn.device_store_index += 1

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3377,6 +3377,12 @@ def _classify_pipelined_tensors(
     for (fake, sub_meta, direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
+        if state.device_function.pallas_internal_scratch_name(fake) is not None:
+            # This tensor already names a VMEM allocation owned by the kernel.
+            # Routing it through the inner-loop HBM DMA path would allocate a
+            # second VMEM buffer and emit pointless copies from an HBM argument
+            # that no longer exists.
+            continue
         if direction == "load":
             first_load = loaded_tensors[id(fake)][1]
             if int(first_load.meta.get(_PALLAS_LOOP_LOAD_COUNT_META, 1)) > 1:

--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -379,6 +379,68 @@ def _route_forward_then_consume(
 
 
 @helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(block_sizes=[]),
+)
+def _body_local_remote_scratch(
+    src: torch.Tensor,
+    peers: torch.Tensor,
+) -> torch.Tensor:
+    """Exchange through a private VMEM buffer that does not escape the kernel."""
+    output = torch.empty_like(src)
+    scratch = torch.empty(
+        [2, 1, 128],
+        dtype=src.dtype,
+        device=src.device,
+    )
+    for _program in hl.grid(1):
+        scratch[0, :, :] = src[0, :, :]
+        hl.remote_barrier(peers[0, 0])
+        copy = hl.make_async_remote_copy(
+            scratch,
+            [0],
+            peers[0, 0],
+            dst=scratch,
+            dst_index=[1],
+        )
+        copy.start()
+        copy.wait()
+        output[0, :, :] = scratch[1, :, :] + 1
+    return output
+
+
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(block_sizes=[]),
+)
+def _returned_remote_scratch_alias(
+    src: torch.Tensor,
+    peers: torch.Tensor,
+) -> torch.Tensor:
+    """Return an alias of a remote-copy buffer; it must remain an output."""
+    scratch = torch.empty(
+        [2, 1, 128],
+        dtype=src.dtype,
+        device=src.device,
+    )
+    for _program in hl.grid(1):
+        scratch[0, :, :] = src[0, :, :]
+        copy = hl.make_async_remote_copy(
+            scratch,
+            [0],
+            peers[0, 0],
+            dst=scratch,
+            dst_index=[1],
+        )
+        copy.start()
+        copy.wait()
+    result = scratch
+    return result  # noqa: RET504 - exercise return-alias escape analysis
+
+
+@helion.kernel(
     static_shapes=False,
     config=helion.Config(block_sizes=[_HBM_TILE]),
 )
@@ -867,6 +929,20 @@ class TestRemoteCopyGPU(TestCase, MultiProcessTestCase):
 @onlyBackends(["pallas"])
 class TestRemoteCopyJaxRuntime(TestCase):
     @staticmethod
+    def _body_local_remote_scratch_source() -> str:
+        return _body_local_remote_scratch.bind(
+            (
+                torch.zeros(1, 1, _WIDTH),
+                torch.zeros(1, 1, dtype=torch.int32),
+            )
+        ).to_code(
+            options=helion.OutputCodeOptions(
+                allow_helion_deps=False,
+                jax_fn=True,
+            )
+        )
+
+    @staticmethod
     def _run_one_shot_copy(mesh, mesh_axis, kernel_fn) -> None:
         import jax
         import jax.numpy as jnp
@@ -1129,6 +1205,73 @@ class TestRemoteCopyJaxRuntime(TestCase):
         world_size = 2
         mesh = jax.make_mesh((world_size,), ("peer",), devices=devices[:world_size])
         self._run_ring_all_gather(mesh)
+
+    def test_returned_remote_scratch_alias_remains_an_output(self) -> None:
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "wrapper-created in-place outputs",
+        ):
+            _returned_remote_scratch_alias.bind(
+                (
+                    torch.zeros(1, 1, _WIDTH),
+                    torch.zeros(1, 1, dtype=torch.int32),
+                )
+            ).to_code(
+                options=helion.OutputCodeOptions(
+                    allow_helion_deps=False,
+                    jax_fn=True,
+                )
+            )
+
+    @skipIfPallasInterpret("body-local remote scratch requires physical TPU devices")
+    def test_body_local_remote_scratch(self) -> None:
+        import types
+
+        import jax
+        import jax.numpy as jnp
+
+        devices = [device for device in jax.local_devices() if device.platform == "tpu"]
+        if len(devices) < 2:
+            self.skipTest("requires at least two TPU devices")
+
+        source = self._body_local_remote_scratch_source()
+
+        name = "precompiled_body_local_remote_scratch_test"
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+        self.addCleanup(sys.modules.pop, name, None)
+        exec(compile(source, name, "exec"), module.__dict__)
+
+        world_size = 2
+        mesh = jax.make_mesh((world_size,), ("peer",), devices=devices[:world_size])
+        partition = jax.sharding.PartitionSpec
+        src_spec = partition("peer", None, None)
+        peer_spec = partition("peer", None)
+        ranks = jnp.arange(world_size, dtype=jnp.float32)[:, None, None]
+        columns = jnp.arange(_WIDTH, dtype=jnp.float32)[None, None, :]
+        src = ranks * 1000 + columns
+        peers = (1 - jnp.arange(world_size, dtype=jnp.int32))[:, None]
+        inputs = tuple(
+            jax.device_put(value, jax.sharding.NamedSharding(mesh, spec))
+            for value, spec in zip(
+                (src, peers),
+                (src_spec, peer_spec),
+                strict=True,
+            )
+        )
+        exchange = jax.jit(
+            jax.shard_map(
+                module._body_local_remote_scratch,
+                mesh=mesh,
+                in_specs=(src_spec, peer_spec),
+                out_specs=src_spec,
+                check_vma=False,
+            )
+        )
+        expected = np.asarray(src)[::-1] + 1
+        for _invocation in range(2):
+            result = np.asarray(jax.block_until_ready(exchange(*inputs)))
+            np.testing.assert_array_equal(result, expected)
 
     @skipIfPallasInterpret("remote-copy pipelines require TPU VMEM lowering")
     def test_computed_pipeline_copy(self) -> None:


### PR DESCRIPTION

Distributed Helion kernels often need a body-local routing buffer:

```python
gathered = torch.empty([8, rows, hidden], ...)
gathered[0, :, :] = local_value
copy = hl.make_async_remote_copy(
    gathered, [0], peer, dst=gathered, dst_index=[1]
)
...
return output
```

Although `gathered` never escapes the kernel, the old lowering registered it as a hidden tensor argument. Standalone JAX consequently reconstructed uninitialized HBM buffers and treated them as in-place outputs:

```python
slots[gathered_pos] = jnp.empty(...)
_OUTPUT_INDICES = [output_pos, gathered_pos, ...]
_INPLACE_INDICES = [gathered_pos, ...]
```

Inner-loop lowering then allocated another VMEM staging buffer, adding unnecessary HBM prologue loads, epilogue writes, and duplicate VMEM storage.

This change recognizes a deliberately narrow class of private allocations: top-level `torch.empty`-family tensors with static shapes that are read, written, used by remote DMA, and proven not to feed the host return. Their storage is registered directly as compiler-owned VMEM scratch. Normal loads, stores, remote-copy refs, loop streaming, launcher arguments, and the generated kernel signature all resolve the same scratch name.

Generated standalone code now has only the real output:

```python
_OUTPUT_INDICES = [output_pos]
_INPLACE_INDICES = []
_scratch_shapes = [VMEM(gathered_shape), ...]
```

Escape analysis follows host aliases conservatively. A regression test returns an alias of a remote-copy buffer and verifies that it remains an output rather than being hidden.

Tests generate standalone JAX, execute a two-device exchange twice on physical TPU, and compare every element. The fused TP16 production benchmark also passed full Q/K/V/OG correctness and determinism. Removing three hidden HBM temporaries reduced the 1K kernel from 103.49 us to 86.93 us; the same run measured 176.20 us for the best complete JAX baseline and 98.57 us for the handwritten Pallas implementation.
