### PR TITLE
[autotuner] extend the B200 matmul heuristic to multi-matmul kernels

### DIFF
--- a/examples/linear/linear_attention_harness.py
+++ b/examples/linear/linear_attention_harness.py
@@ -524,6 +524,27 @@ def _fla_inputs(inputs: Inputs) -> Inputs:
     return out
 
 
+def _fla_benchmark_inputs(
+    harness: LinearAttentionExampleHarness, inputs: Inputs
+) -> tuple[Inputs, list[torch.Tensor]]:
+    """Build native-layout FLA inputs whose gradient targets are real leaves."""
+    out = dataclasses.replace(_fla_inputs(inputs))
+    grad_names = set(harness.grad_tensors)
+    leaves: list[torch.Tensor] = []
+    for f in dataclasses.fields(out):
+        val = getattr(out, f.name)
+        if not isinstance(val, torch.Tensor):
+            continue
+        val = val.detach()
+        val.requires_grad_(
+            f.name in grad_names and getattr(inputs, f.name).requires_grad
+        )
+        setattr(out, f.name, val)
+        if val.requires_grad:
+            leaves.append(val)
+    return out, leaves
+
+
 def _recurrent_error(
     harness: LinearAttentionExampleHarness, inputs: Inputs, C: int
 ) -> float:
@@ -670,7 +691,7 @@ def _time_config(
         **extra,
     )
     scale = inputs.scale
-    fla_inputs = _fla_inputs(inputs)
+    fla_inputs, fla_grads = _fla_benchmark_inputs(harness, inputs)
 
     fwd_ms = do_bench(lambda: harness.helion_fwd(inputs, C))
     fla_fwd_ms = do_bench(lambda: harness.fla_fwd(fla_inputs, scale))
@@ -691,7 +712,6 @@ def _time_config(
     grad_out = torch.randn(bi, hi, ti, dvi, device=DEVICE, dtype=DTYPE)
     go_t = _htf(grad_out)
     h_grads = [getattr(inputs, n) for n in harness.grad_tensors]
-    fla_grads = [getattr(fla_inputs, n) for n in harness.grad_tensors]
     fb_ms = do_bench(
         lambda: harness.helion_fb(inputs, grad_out, C),
         grad_to_none=h_grads,  # pyrefly: ignore[bad-argument-type]

--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -21,6 +21,7 @@ from .pallas import PallasMatmulF32NoTilingSeedHeuristic
 from .pallas import PallasMatmulNoTilingSeedHeuristic
 from .triton import TritonB200FormulaMatmulHeuristic
 from .triton import TritonB200MatmulHeuristic
+from .triton import TritonB200MultiMatmulHeuristic
 from .triton import TritonH100MatmulHeuristic
 from .triton import TritonMatmulReductionEpilogueHeuristic
 from .triton import TritonNarrowReductionHeuristic
@@ -64,6 +65,9 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         # The sm100 formula, promoted; registered after the table so it wins the
         # last-promote-wins compiler_default_config loop.
         TritonB200FormulaMatmulHeuristic,
+        # Front end 2: the seed-only multi-contraction path. It declines whenever
+        # front end 1 fires, so the two paths remain structurally disjoint.
+        TritonB200MultiMatmulHeuristic,
         TritonMatmulReductionEpilogueHeuristic,
         TritonStandardReductionHeuristicSM90,
         TritonStandardReductionHeuristicSM100,

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -15,6 +15,12 @@ import torch
 from ...autotuner.config_fragment import EnumFragment
 from ...autotuner.config_spec import FULL_EXTENT_CATEGORIES
 from ...autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
+from ...autotuner.config_spec import DotAxes
+from ...autotuner.config_spec import DotAxisKind
+from ...autotuner.config_spec import DotSite
+from ...autotuner.config_spec import KernelMatmulFact
+from ...autotuner.config_spec import LiveTile
+from ...autotuner.config_spec import LoopAxisFact
 from ...autotuner.config_spec import ReductionCategory
 from ...runtime.config import Config
 from .common import clamp_block_size_targets
@@ -42,6 +48,16 @@ _B200_MATMUL_HEURISTICS_PATH = Path(__file__).resolve().parent / "matmul_b200.js
 
 # Stand-in ceiling for an arch with no TMEM (sm90): makes a TMEM fit-check vacuously true.
 _INF = float("inf")
+
+
+class CandidateDotWork(NamedTuple):
+    """Tensor-core work executed by one candidate CTA."""
+
+    total: int
+    tcgen05_eligible: int
+    tcgen05_independent: int = 0
+    tcgen05_carried: int = 0
+    uncertain: bool = False
 
 
 # Heuristic was originally contributed by @umechand-amd
@@ -178,6 +194,86 @@ def _batched_static_matmul_fact(config_spec: ConfigSpec) -> MatmulFact | None:
         return None
     # Every tunable axis must be the dot's M/N/K or a batch/outer grid axis (pinnable to 1).
     allowed = set(mnk) | set(config_spec.grid_block_ids)
+    if any(bid not in allowed for bid in valid):
+        return None
+    return fact
+
+
+def _axis_roles(config_spec: ConfigSpec, index: int) -> DotAxes | None:
+    """The :class:`DotAxes` classification of one dot, from the composed whole-kernel
+    fact. ``None`` when the fact was not built (no contraction in this kernel)."""
+    mm = config_spec.kernel_matmul_fact
+    if mm is None or index >= len(mm.matmuls):
+        return None
+    return mm.matmuls[index].axes
+
+
+def _grid_group_for_site(
+    config_spec: ConfigSpec,
+    site: DotSite | None,
+) -> tuple[int, ...]:
+    """Root-grid axes for one dot site, with the flattened legacy fallback."""
+    grid_fact = getattr(config_spec, "kernel_grid_fact", None)
+    if grid_fact is not None and site is not None:
+        group = grid_fact.group_for_graph(site.graph_id)
+        if group:
+            return group
+    return tuple(config_spec.grid_block_ids)
+
+
+def _generalized_static_matmul_fact(config_spec: ConfigSpec) -> MatmulFact | None:
+    """Front end 1's eligibility, GENERALIZED over axis freedom.
+
+    ``_batched_static_matmul_fact`` requires all three of M/N/K to be independently
+    tunable. That is true of a GEMM and false of most contractions written inside a
+    chunked kernel, where the author ``hl.specialize``\\d one axis: it then has either no
+    block id or a block id that is not in ``valid_block_ids()``, and the gate declines a
+    kernel it could configure perfectly well.
+
+    A fixed axis is not a smaller problem, only a smaller set of knobs. So the
+    requirements become:
+
+      - exactly one ``MatmulFact`` with STATIC M/N/K (unchanged: nothing can be sized
+        without extents);
+      - each of M/N/K is either TUNABLE_TILED or FIXED_FULL_EXTENT, and the tunable ones
+        have DISTINCT block ids (two axes sharing one knob is a genuine conflict that
+        belongs to the multi-matmul ranking path, not here);
+      - every OTHER tunable axis is a batch/outer grid axis the seed pins to 1
+        (unchanged: the seed must never mis-pin an axis it does not model).
+
+    A kernel with ZERO tunable dot axes is admitted: it still wants ``num_warps``,
+    ``num_stages`` and the other scalar knobs, and the alternative is the bare fragment
+    default.
+    """
+    facts = config_spec.matmul_facts
+    if len(facts) != 1:
+        return None
+    fact = facts[0]
+    axes = _axis_roles(config_spec, 0)
+    if axes is None:
+        return None
+    # Sizing needs a per-program EXTENT per axis, which ``DotAxes`` supplies -- including for
+    # an axis the config cannot move whose total length is dynamic. Requiring
+    # ``MatmulFact.static_*`` instead declines those, and they are configurable exactly.
+    if DotAxisKind.UNKNOWN in (axes.m_kind, axes.n_kind, axes.k_kind):
+        return None
+    if any(axes.extent(a) is None for a in ("m", "n", "k")):
+        return None
+    valid = set(config_spec.block_sizes.valid_block_ids())
+    tunable_ids = [
+        bid
+        for axis, bid in (
+            ("m", fact.m_block_id),
+            ("n", fact.n_block_id),
+            ("k", fact.k_block_id),
+        )
+        if axes.kind(axis) is DotAxisKind.TUNABLE_TILED and bid is not None
+    ]
+    if len(set(tunable_ids)) != len(tunable_ids):
+        return None
+    if not set(tunable_ids) <= valid:
+        return None
+    allowed = set(tunable_ids) | set(config_spec.grid_block_ids)
     if any(bid not in allowed for bid in valid):
         return None
     return fact
@@ -332,8 +428,20 @@ def _h100_build_block_sizes(
     spec: ConfigSpec, fact: MatmulFact, bm: int, bn: int, bk: int
 ) -> list[int]:
     """Map ``(bm, bn, bk)`` onto the spec's block_sizes by the fact's M/N/K block-ids,
-    clamping each to its valid [min, max] (other axes — none for a clean 2-D fact — floored)."""
-    targets = {fact.m_block_id: bm, fact.n_block_id: bn, fact.k_block_id: bk}
+    clamping each to its valid [min, max] (other axes — none for a clean 2-D fact — floored).
+
+    A ``None`` block id means the axis is a fixed full extent with no block-size entry to
+    write, so it is dropped rather than used as a dict key: two such axes would otherwise
+    collide on the single ``None`` key and silently give one of them the other's size."""
+    targets = {
+        bid: value
+        for bid, value in (
+            (fact.m_block_id, bm),
+            (fact.n_block_id, bn),
+            (fact.k_block_id, bk),
+        )
+        if bid is not None
+    }
     out: list[int] = []
     for i in range(len(spec.block_sizes)):
         bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
@@ -346,18 +454,27 @@ def _h100_build_block_sizes(
     return out
 
 
-def _h100_pinned_grid(env: CompileEnvironment, fact: MatmulFact) -> int:
-    """Product of any PINNED (block_size=1) grid axes other than the dot's M/N tiles — 1 for a
-    bare GEMM, ``batch·nchunks·nheads`` for mamba's fused dot. These already saturate the SMs, so
-    the occupancy fill counts them (else it shrinks an already-grid-saturated dot's tile) and the
-    num_stages cap keys on them (the batched-dot signature)."""
+def _h100_pinned_grid(
+    env: CompileEnvironment,
+    fact: MatmulFact,
+    block_of: dict[int, int],
+    grid_block_ids: tuple[int, ...],
+) -> int:
+    """Programs contributed by this dot's non-M/N grid axes.
+
+    A grid axis may cover one config-derived tile rather than one scalar. Split-K,
+    for example, walks K=8192 in 64 fixed partitions of 128 elements. Counting its
+    full extent as 8192 programs makes every output tile look deeply saturated.
+    """
     pinned_grid = 1
-    for bid in env.config_spec.grid_block_ids:
+    for bid in grid_block_ids:
         if bid in (fact.m_block_id, fact.n_block_id):
             continue
         size = env.block_sizes[bid].size
         if isinstance(size, (int, torch.SymInt)):
-            pinned_grid *= max(1, env.size_hint(size))
+            extent = max(1, env.size_hint(size))
+            block = max(1, block_of.get(bid, 1))
+            pinned_grid *= max(1, -(-extent // block))
     return pinned_grid
 
 
@@ -422,6 +539,10 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
     )
     SAT_TILE_BM = 64  # saturated batched-dot occupancy tile cap (bm)
     SAT_TILE_BN = 128  # saturated batched-dot occupancy tile cap (bn)
+    # Optional tighter ceiling when the dot's K loop covers one partition of an
+    # enclosing grid tile. Inactive on the frozen sm90 path.
+    SAT_PARTITIONED_K_BM: int | None = None
+    SAT_PARTITIONED_K_BN: int | None = None
     SAT_NUM_WARPS = (
         None  # sm100 forces min-warps on a saturated tiny tile (None = use the ramp)
     )
@@ -459,6 +580,113 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
     TMEM_BUDGET = None
     # Smallest block_m that lowers to tcgen05 (below it the dot uses a non-TMEM path, so TMEM is free).
     TCGEN05_MIN_BM = 64
+    # --- whole-kernel resource accounting (see _tmem_columns / _warps_for_live_set) ---
+    # tcgen05 tensor memory is allocated as TMEM_LANES lanes x TMEM_COLUMN_BUDGET columns of 32
+    # bits, and a request is denominated in COLUMNS. None = the arch has no tensor memory, so the
+    # column check is inert (which is what keeps sm90 byte-identical).
+    TMEM_LANES = 128
+    TMEM_COLUMN_BUDGET: int | None = None
+    # Register-file bytes per thread available to the register-resident live set: the
+    # ARCHITECTURAL ceiling of 255 registers x 4 B. This budget answers "will this spill
+    # catastrophically", not "is occupancy ideal", so the hard ceiling is the right bound -- and it
+    # is the one the measured failure sits on (two live 64x64 fp32 accumulators = 32 KiB against
+    # 31.9 KiB at one warp, over budget before a single operand tile).
+    REG_BYTES_PER_THREAD = 255 * 4
+    # Warps in a tcgen05 warpgroup. Below this the MMA path is unavailable and the fp32
+    # accumulator falls back into the register file.
+    TCGEN05_WARPGROUP_WARPS = 4
+    MAX_NUM_WARPS = 8
+    MAX_THREADS_PER_SM = 2048
+    MAX_CTAS_PER_SM = 32
+    REGISTER_FILE_BYTES_PER_SM = 65536 * 4
+    TMEM_COLUMNS_PER_SM: int | None = None
+    # Where the register-driven warp ladder STOPS climbing -- see _warps_for_live_set for why an
+    # arch with tensor memory wants to stop at a warpgroup rather than at MAX_NUM_WARPS. Held as a
+    # per-arch class attribute (like ENFORCE_SMEM_BUDGET and TMEM_COLUMN_BUDGET) rather than
+    # branched on inside the ladder: hardware selection lives in is_eligible via HARDWARE_TARGETS,
+    # so a method body that re-derives the arch duplicates a dispatch that already happened.
+    #
+    # MAX_NUM_WARPS here leaves the sm90 ladder exactly as it was. That is a decision to hold the
+    # frozen sm90 emit still, NOT a claim about H100 physics -- the cap was measured on B200 only,
+    # and sm90 has no measurement either way. Note also that _register_live_bytes drops the
+    # accumulators at TCGEN05_WARPGROUP_WARPS UNCONDITIONALLY, without consulting
+    # TMEM_COLUMN_BUDGET, so on an arch with no tensor memory the two are already inconsistent
+    # about the same physical fact. That is pre-existing and is not repaired here, because
+    # repairing it would move the frozen sm90 emit; it is recorded so the next reader of this
+    # constant does not mistake MAX_NUM_WARPS for a measured sm90 answer.
+    REG_CLIMB_MAX_WARPS = MAX_NUM_WARPS
+    # Ceiling for the GRADED (sequential-pipeline) stage model. Measured over all 34 scored
+    # curriculum bodies, the optimum coincides with MAX_STAGES: 4, 6 and 12 land within 0.002
+    # geomean of each other (0.7813 / 0.7824 / 0.7804), so raising the ceiling to reach the
+    # ns=8 and ns=11 cells the hand-tuning chose at low outer parallelism buys nothing, and 6
+    # is kept for agreement with the non-graded path rather than for its own sake.
+    HW_MAX_STAGES = 6
+    # Floor for the stage knob. The incumbent formula never emits 1 -- right for a bare GEMM, where
+    # an unpipelined K-loop is a large regression -- but it makes a fifth of the answer space
+    # unreachable: 53 of the 251 hand-tuned B200 cells (21.1%), spanning 13 of 26 bodies, use
+    # num_stages=1. And when the operand ring only fits at one stage, the alternative is halving
+    # the tile repeatedly, which is strictly worse: measured, a kernel whose ring needs 152576 B per
+    # stage was pinned to its FLOOR tile because the fix-up refused to go below two stages, while
+    # the hand-tuned config for that cell is the full tile at one stage.
+    MIN_NUM_STAGES = 1
+    # When the per-CTA occupancy SHARE cannot be met at any depth, fall back to the deepest
+    # depth total CAPACITY allows instead of the floor of one stage.
+    #
+    # REFUTED and off by default, but kept switchable because it is the most obvious next move
+    # and someone will propose it again. The argument for it is sound-sounding -- once even one
+    # stage cannot meet the share, co-residency is already sacrificed and there is nothing left
+    # for the share to protect -- and the symptom it targets is real and large: 11 of the 15
+    # bodies still under the 0.80 bar emit ns=1 where the hand-tuning uses ns=2..8, and on two
+    # 18-case bodies that costs 0.43-0.64x per cell.
+    #
+    # It is nevertheless a net LOSS, measured twice on two different populations:
+    #   * 4 bodies, full case counts: +0.09 and +0.03 on the two that emit ns=1 at a big tile,
+    #     -0.12 and -0.18 on two others; bounding it to double buffering keeps most of the gain
+    #     and most of one loss back but is still negative overall;
+    #   * all 34 scored bodies, 2 cases each, variants compared within each case: 0.8632 with
+    #     17 bodies >= 0.90 against 0.8678 with 19 for the floor (and 0.8548/17 at a raised
+    #     ceiling), median null-arm spread 0.03%.
+    # So a body that wants depth here and a body that wants one stage here are not separated by
+    # anything this model currently sees. That is the largest single characterized residual in
+    # the B200 linear-attention curriculum, and it is a MISSING PROPERTY, not a missing constant.
+    GRADED_SHARE_FALLBACK = False
+    # Resident CTAs per SM the graded stage model will budget shared memory for. A grid far
+    # above the machine size does NOT demand a matching number of simultaneously-resident
+    # CTAs -- the excess queues -- so dividing the SMEM budget by the raw wave count collapses
+    # the pipeline to one stage on every large-grid kernel (measured: an outer grid of 8192 on
+    # 148 SMs gives 56 waves and a 4 KiB per-CTA share, which nothing fits). Occupancy past a
+    # few CTAs per SM buys little on a throughput-bound program, and the hand-tuned corpus
+    # accepts 1-2 resident CTAs in exchange for pipeline depth, so the divisor is clamped here.
+    GRADED_MAX_CTAS_PER_SM = 4
+    # Occupancy facts can prove that a deeper pipeline costs no additional CTA,
+    # but not that pipeline/barrier overhead is free. Allow that proof to recover
+    # triple buffering while preserving any depth the grid-only model already chose.
+    OCCUPANCY_RELAXED_MAX_STAGES = 3
+    # Master switches for the generalized/graded machinery, so an arch that has not been measured
+    # keeps its exact incumbent behavior (sm90 is a byte-identical freeze).
+    GENERALIZED_AXES = False
+    GRADED_STAGES = False
+    WORK_AWARE_WARPS = False
+    REGIME_AWARE_WARPS = False
+    SINGLE_ROLE_AWARE_KNOBS = False
+    # Candidate-work regime boundaries. Inactive unless REGIME_AWARE_WARPS is
+    # enabled by a measured architecture subclass.
+    SUBSTANTIAL_DOT_WORK = 1 << 20
+    TCGEN05_DOT_WORK = 1 << 20
+    # The tcgen work threshold may rise when entering a warpgroup reduces
+    # effective CTA residency, but never with the number of queued launch
+    # waves after that residency is saturated.
+    TCGEN_OCCUPANCY_PENALTY_MAX = 4.0
+    EIGHT_WARP_DOT_WORK = 1 << 26
+    NON_TCGEN_WIDE_N = 128
+    WARP1_SOFT_PRESSURE = 1.2
+    FORCED_MMA_SOFT_PRESSURE = 1.2
+    TCGEN_CATASTROPHIC_PRESSURE = 1.75
+    # With one enclosing trip, a second top-level stage can still overlap a
+    # dot's operand movement. Prefer it only while the one-stage tile retains
+    # register headroom; at higher pressure the measured compiler schedule
+    # turns the additional in-flight state into severe spilling.
+    ONE_TRIP_STAGE2_MAX_REGISTER_PRESSURE = 1.0
     BK_CAP = (
         256  # max block_k (deep K amortizes small-M; past this returns vanish / spill)
     )
@@ -548,6 +776,1042 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         ring = (bm * bk + bk * bn) * itemsize * num_stages
         epilogue = bm * bn * cls.EPILOGUE_ACC_ITEMSIZE
         return max(ring, epilogue) + cls.SMEM_SLACK
+
+    @classmethod
+    def _tmem_columns(cls, tiles: list[tuple[int, int, int]]) -> int:
+        """Tensor-memory COLUMNS a set of live fp32 accumulators reserves.
+
+        tcgen05 tensor memory is allocated as ``TMEM_LANES`` (128) lanes x N columns of
+        32 bits; a request is denominated in columns, not bytes. Measured on B200 over the
+        hand-tuned corpus, a kernel's ``tmem_size`` metadata equals the accumulator's N
+        extent exactly -- ``[64,64] -> 64``, ``[128,128] -> 128``, ``[128,256] -> 256`` --
+        i.e. a tile costs ``ceil(bm/128) * bn`` columns and an accumulator narrower than
+        128 rows costs the SAME as a full-lane one. A byte model divides that by the lanes
+        it does not use, so it under-charges every ``bm < 128`` accumulator.
+
+        Columns from separate live accumulators ADD. That is the term whose absence lets a
+        seed size a tile off ONE matmul while three are resident: measured, a three-dot
+        chunked kernel at chunk 256 emits a config that dies with
+        ``OutOfResources: tensor memory, Required: 768, limit 512`` -- exactly
+        ``3 x 256`` columns against the 512-column budget.
+
+        ``tiles`` is ``[(bm, bn, itemsize), ...]``. An accumulator whose ``bm`` is below
+        ``TCGEN05_MIN_BM`` is charged nothing: below that the dot lowers to a non-tcgen05
+        path that uses no tensor memory at all (measured ``tmem_size == 0``), and its cost
+        lands on the register file instead -- see ``_register_live_bytes``.
+        """
+        if cls.TMEM_COLUMN_BUDGET is None:
+            return 0
+        total = 0
+        for bm, bn, _itemsize in tiles:
+            if bm < cls.TCGEN05_MIN_BM:
+                continue
+            lane_groups = max(1, -(-bm // cls.TMEM_LANES))
+            total += lane_groups * bn
+        return total
+
+    @classmethod
+    def _warps_for_live_set(
+        cls,
+        num_warps: int,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+    ) -> int:
+        """Raise ``num_warps`` while the register-resident live set OVERSHOOTS the register file.
+
+        This is Section 3's register fix-up: "estimate registers per thread from the
+        register-resident live set and proposed warp count", then "for register pressure,
+        increase num_warps first". A fixed point rather than one shot, because the answer feeds
+        back -- raising the count both enlarges the file AND can move the accumulators out of
+        it entirely by making the tcgen05 warpgroup available, so the estimate is re-asked at
+        each rung.
+
+        The ladder climbs 1 -> 2 -> 4 -> 8. Losing tcgen05 below a warpgroup is confirmed in
+        PTX but is not itself a penalty -- at 16 KiB live, one warp on ``mma.sync`` beats four
+        on tcgen05 -- and two warps is the hand-tuned answer in 11 of 18 ``chunk_cumsum_gc``
+        cells, so skipping straight to a warpgroup would overshoot.
+
+        The fit test uses the ARCHITECTURAL 255 registers per thread: the question is whether a
+        config spills catastrophically, not whether occupancy is ideal. At one warp that is
+        31.9 KiB, which is the bound the measured failures sit on.
+
+        The ladder only ever RAISES, never lowers, and that direction is load-bearing rather than
+        incidental: the work-based warp count this rule receives emits one warp for 48 of 75
+        measured curriculum cells and scores 0.482 against the per-cell measured optimum, where
+        the same cells after this rule score 0.959. Over the 47 cells it raised, 33 got faster,
+        5 got slower, 9 tied, geomean 2.01x. So this is not a correction on the margin of a
+        good base -- it is where the warp count is actually decided, and a rule that also lowered
+        would have to re-derive the work term the ramp is trying to express.
+
+        WHERE IT STOPS is the other half of the rule, and it is not ``MAX_NUM_WARPS``. Registers
+        are a SOFT budget: overshooting them makes ptxas spill, which degrades, where
+        overshooting tensor or shared memory is a hard ``OutOfResources`` at launch. So relieving
+        pressure past the point where it is relieved has a real cost -- each warp doubling doubles
+        registers per CTA and so HALVES how many CTAs stay resident, and for a grid over
+        batch/head (every CTA an independent unit of work, barriers CTA-scoped) that buys less
+        than the spill costs. Measured on ``chunk_fwd_A_diag_anchored_varlen`` at its emitted
+        tile: two warps spills 38 B and holds 4 CTAs/SM, eight warps spills NOTHING and holds 1,
+        and two warps is 1.75x FASTER (325 us against 570). Thread occupancy is flat at 256
+        threads/SM across both, so it explains none of that gap.
+
+        The stopping point is a warpgroup, and it comes from this file's own model rather than
+        from a fitted constant: at and above one, ``_register_live_bytes`` hands the fp32
+        accumulators to tcgen05, so what remains of the estimate is the part it is loosest about
+        and cannot justify another doubling. Eight warps must be earned by the WORK term.
+
+        It is read from ``cls.REG_CLIMB_MAX_WARPS``, a per-arch class attribute, and NOT tested for
+        in this body: hardware selection already happened in ``is_eligible`` via
+        ``HARDWARE_TARGETS``, so re-deriving the arch here -- whether by reading it directly or by
+        proxying it through ``TMEM_COLUMN_BUDGET is not None`` -- duplicates a dispatch the class
+        hierarchy performs and adds a second place for the two to disagree. The sm90 carrier leaves
+        it at ``MAX_NUM_WARPS``, which holds that frozen emit still rather than asserting anything
+        about H100, where the cap is unmeasured.
+
+        Both halves are measured, by sweeping ``num_warps`` over 1/2/4/8 at the emitted tile for
+        75 curriculum cells and scoring against each cell's own measured optimum over the 53
+        where the knob moves time by at least 10% (``gate/warpsweep.py`` in the run tree):
+
+          * climbing to a fit, ladder to eight   0.8959   <- what this rule did before
+          * climbing to a fit, stop at warpgroup 0.9591
+          * the hand-tuned answer key            0.9363
+          * a flat overshoot tolerance of 1.35   0.9433
+
+        Note the third line: stopping at a warpgroup scores ABOVE the hand-tuned configs. And the
+        fourth is why the rule is a cap and not a tolerance -- tolerating overshoot helps, but
+        every tolerance that reaches the cells wanting two warps (2.4 and up) makes the cells that
+        must climb stop early and lose up to 2.1x, so the tolerance has no setting that beats
+        simply refusing to climb past the warpgroup. Capping is nearly free in the other
+        direction: of the 16 cells whose optimum IS eight warps, four reach it through the ramp
+        anyway and the rest give up at most 9.9% (worst cell 0.901), because four against eight is
+        almost flat wherever eight wins at all.
+
+        HISTORY, because it is the point of the rule. This fix-up was implemented first against
+        a live-set estimate that selected its peak step by RANK PROFILE, and that estimate could
+        not do the job: it under-counted a kernel spilling 540 registers at one warp (1.33x the
+        one-warp file) while over-counting one spilling none (1.51x), so the ordering inverted
+        and no threshold worked. Two patches were layered over that -- a calibration divisor,
+        then an unconditional two-warp floor for multi-contraction kernels -- before the defect
+        was found in the SELECTOR rather than in the rule. With the peak chosen by resolved bytes
+        the estimate separates cleanly (zero-spill cells at most 1.506x the one-warp file,
+        spilling cells at least 2.298x, measured over 12 curriculum cells), and both patches are
+        deleted: the floor's own predicate had become identical to this ladder's first rung, so
+        it could never raise anything the ladder did not already raise.
+        """
+        warps = max(1, num_warps)
+        while warps < cls.REG_CLIMB_MAX_WARPS:
+            need = cls._register_live_bytes(env, block_sizes, warps)
+            if need <= warps * 32 * cls.REG_BYTES_PER_THREAD:
+                return warps
+            warps *= 2
+        return warps
+
+    @classmethod
+    def _select_num_warps(
+        cls,
+        initial: int,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        *,
+        grid: int,
+        num_sm: int,
+        smem_bytes: int,
+    ) -> int:
+        """Choose a warp regime from dynamic work and soft register pressure.
+
+        The legacy path remains the raise-only register ladder. The B200 policy
+        instead solves from scratch, so a final projected or resource-shrunk tile
+        can move either upward or downward.
+        """
+        if not cls.REGIME_AWARE_WARPS:
+            return cls._warps_for_live_set(initial, env, block_sizes)
+
+        work = cls._candidate_dot_work(env, block_sizes)
+        if work.total <= 0:
+            return cls._warps_for_live_set(initial, env, block_sizes)
+
+        def pressure(warps: int) -> float:
+            capacity = warps * 32 * cls.REG_BYTES_PER_THREAD
+            return cls._register_live_bytes(env, block_sizes, warps) / max(1, capacity)
+
+        def resident_ctas(warps: int) -> int:
+            return cls._estimated_resident_ctas(
+                env,
+                block_sizes,
+                num_warps=warps,
+                smem_bytes=smem_bytes,
+                grid=grid,
+                num_sm=num_sm,
+            )
+
+        p1 = pressure(1)
+        p2 = pressure(2)
+        wide_register_accumulator = any(
+            rows < cls.TCGEN05_MIN_BM and cols >= cls.NON_TCGEN_WIDE_N
+            for rows, cols, _itemsize in cls._all_dot_acc_tiles(env, block_sizes)
+        )
+        mma_ctas = resident_ctas(2)
+        tcgen_ctas = resident_ctas(cls.TCGEN05_WARPGROUP_WARPS)
+        occupancy_penalty = cls._tcgen_occupancy_penalty(
+            mma_ctas,
+            tcgen_ctas,
+        )
+        if work.tcgen05_eligible >= cls.EIGHT_WARP_DOT_WORK:
+            warps = 8
+        elif work.tcgen05_eligible > cls.TCGEN05_DOT_WORK * occupancy_penalty or (
+            not work.tcgen05_eligible and wide_register_accumulator
+        ):
+            warps = 4
+        elif work.total >= cls.SUBSTANTIAL_DOT_WORK:
+            warps = 2
+        else:
+            warps = 1 if p1 <= cls.WARP1_SOFT_PRESSURE else 2
+
+        # Spill pressure is a guardrail, not the objective. With every dot forced
+        # onto register MMA, adding warps cannot accidentally cross into tcgen05,
+        # so relieve even a modest overshoot. A tcgen05-eligible tile has a much
+        # more expensive 2 -> 4 transition and crosses it only for enough work or
+        # genuinely catastrophic pressure.
+        if not work.tcgen05_eligible:
+            while (
+                warps < cls.MAX_NUM_WARPS
+                and pressure(warps) > cls.FORCED_MMA_SOFT_PRESSURE
+            ):
+                next_warps = warps * 2
+                if pressure(warps) <= cls.TCGEN_CATASTROPHIC_PRESSURE and resident_ctas(
+                    next_warps
+                ) < resident_ctas(warps):
+                    break
+                warps = next_warps
+        else:
+            if warps < cls.TCGEN05_WARPGROUP_WARPS and (
+                p2 > cls.TCGEN_CATASTROPHIC_PRESSURE
+            ):
+                warps = cls.TCGEN05_WARPGROUP_WARPS
+            if (
+                warps == cls.TCGEN05_WARPGROUP_WARPS
+                and pressure(warps) > cls.TCGEN_CATASTROPHIC_PRESSURE
+                and resident_ctas(warps * 2) >= resident_ctas(warps)
+            ):
+                warps *= 2
+        # An unresolved dynamic loop contributes only a proven one-invocation
+        # lower bound to ``work``. That is sufficient evidence to raise a
+        # provisional choice, never to lower one derived from the tile shape.
+        if work.uncertain:
+            warps = max(warps, initial)
+        return min(cls.MAX_NUM_WARPS, max(1, warps))
+
+    @classmethod
+    def _tcgen_occupancy_penalty(cls, mma_ctas: int, tcgen_ctas: int) -> float:
+        """Bounded tcgen work penalty for a real effective-residency loss.
+
+        ``mma_ctas`` and ``tcgen_ctas`` already include launch demand, so queued
+        waves beyond resident capacity cannot inflate this value.
+        """
+        ratio = max(1.0, max(1, mma_ctas) / max(1, tcgen_ctas))
+        return min(cls.TCGEN_OCCUPANCY_PENALTY_MAX, ratio)
+
+    @classmethod
+    def _full_block_map(
+        cls, env: CompileEnvironment, block_sizes: list[int]
+    ) -> dict[int, int]:
+        """``{block_id: per-program extent}`` for EVERY block id, under the config whose
+        ``block_sizes`` list is ``block_sizes``.
+
+        Asked of the compiler's own ``BlockSizeSource``, not inferred. That matters because
+        the three kinds of axis resolve completely differently and guessing any of them
+        wrong corrupts every footprint computed from it:
+
+        * a tunable loop axis resolves to the config's entry for it;
+        * an ``hl.grid`` axis is a fixed source of 1 -- one row per program -- even though
+          the axis's *extent* is the whole grid;
+        * a specialized axis is fixed at its full extent.
+
+        Inferring these from "does it have a ``block_sizes`` entry" gets the middle case
+        backwards, and the error is not small: reading a pinned outer grid axis at its full
+        extent (8192 rather than 1) makes every accumulator look astronomical, so the
+        resource fix-up shrinks every tile to the dot minimum. Measured, that is exactly
+        what happened -- a 6-dot kernel emitted ``[16, 16, 16, 16, 16]`` against a
+        hand-tuned ``[128, 128, 64, 256, 128]`` while sitting at 22 KiB of shared memory and
+        64 tensor-memory columns, i.e. nowhere near any limit.
+        """
+        spec = env.config_spec
+        out: dict[int, int] = {}
+        base_default = cast(
+            "Callable[[], Config] | None",
+            getattr(spec, "_base_default_config", None),
+        )
+        if base_default is not None:
+            config_dict = dict(base_default().config)
+            config_dict["block_sizes"] = list(block_sizes)
+            candidate = Config.from_dict(config_dict)
+        else:
+            candidate = Config(block_sizes=list(block_sizes))
+        # A TUNABLE axis's per-program extent is simply the entry the config carries for it.
+        # Read it straight from the list rather than round-tripping through the block-size
+        # source: ``LoopSpecBlockSizeSource.from_config`` reaches for
+        # ``CompileEnvironment.current()``, which is not guaranteed to be entered on every
+        # path that wants a footprint, and a silent failure there falls back to the axis's
+        # FULL extent -- reading a 16384-row grid axis as 16384 rather than 1 and inflating
+        # every footprint by four orders of magnitude.
+        for slot in range(len(spec.block_sizes)):
+            bs = cast("BlockSizeSpec", spec.block_sizes[slot])
+            if slot < len(block_sizes):
+                out[bs.block_id] = max(1, int(block_sizes[slot]))
+        # Everything else is fixed by its source: an ``hl.grid`` axis is one row per program
+        # even though its extent is the whole grid, and a specialized / persistent-reduction
+        # axis is its full extent.
+        for bid in range(len(env.block_sizes)):
+            if bid in out:
+                continue
+            info = env.block_sizes[bid]
+            value: object = None
+            try:
+                value = info.block_size_source.from_config(candidate, info)
+                if isinstance(value, torch.SymInt):
+                    expression = getattr(env, "config_value_expressions", {}).get(
+                        value._sympy_()
+                    )
+                    if expression is not None:
+                        value = expression.evaluate(candidate)
+            except Exception:
+                value = None
+            if value is None:
+                value = info.size if isinstance(info.size, (int, torch.SymInt)) else 1
+            try:
+                out[bid] = max(1, int(env.size_hint(value)))  # pyrefly: ignore
+            except Exception:
+                out[bid] = 1
+        return out
+
+    @classmethod
+    def _axis_extent(cls, env: CompileEnvironment, block_id: int) -> int:
+        """Full length of one block axis (not the per-program tile)."""
+        if 0 <= block_id < len(env.block_sizes):
+            size = env.block_sizes[block_id].size
+            if isinstance(size, (int, torch.SymInt)):
+                return max(1, env.size_hint(size))
+        return 1
+
+    @classmethod
+    def _launch_grid(cls, env: CompileEnvironment, block_sizes: list[int]) -> int:
+        """Logical programs in dot-bearing roots, or all roots without attribution."""
+        block_of = cls._full_block_map(env, block_sizes)
+        grid_fact = getattr(env.config_spec, "kernel_grid_fact", None)
+        mm = env.config_spec.kernel_matmul_fact
+        groups: tuple[tuple[int, ...], ...] = ()
+        if grid_fact is not None:
+            if mm is not None:
+                groups = grid_fact.groups_for_graphs(
+                    tuple(resolved.site.graph_id for resolved in mm.matmuls)
+                )
+            groups = groups or grid_fact.grid_groups
+        if not groups:
+            groups = (tuple(env.config_spec.grid_block_ids),)
+        grid = 0
+        for group in groups:
+            group_grid = 1
+            for bid in group:
+                extent = cls._axis_extent(env, bid)
+                group_grid *= max(
+                    1,
+                    -(-extent // max(1, block_of.get(bid, 1))),
+                )
+            grid += group_grid
+        return max(1, grid)
+
+    @classmethod
+    def _smem_from_map(
+        cls, env: CompileEnvironment, block_sizes: list[int], num_stages: int
+    ) -> int:
+        """Whole-kernel shared-memory ring under an emitted ``block_sizes`` list.
+
+        Region ring = SUM of the region's loads (the pipeliner gives each load in the body
+        its own multi-stage buffer, so within a stage they are all resident) x
+        ``num_stages``, PLUS the region's store staging when it stores from inside itself;
+        then MAX across regions, because separate loops run one after the other."""
+        mm = env.config_spec.kernel_matmul_fact
+        if mm is None or not (mm.pipelined_regions or mm.resident_regions):
+            return 0
+        block_of = cls._full_block_map(env, block_sizes)
+
+        def region_bytes(tiles: tuple[LiveTile, ...], stages: int) -> int:
+            staged_loads = sum(
+                cls._resolve_tile_bytes(t, block_of)
+                for t in tiles
+                if t.kind == "load" and t.stageable is not False
+            )
+            resident_loads = sum(
+                cls._resolve_tile_bytes(t, block_of)
+                for t in tiles
+                if t.kind == "load" and t.stageable is False
+            )
+            # A region that STORES inside itself (a state recurrence publishes each chunk
+            # from inside the sequential loop) holds its store staging at the same time as
+            # the ring, so those bytes ADD. A region with no store is a plain K-loop whose
+            # ring is dead by the time the epilogue converts, which is the liveness-packed
+            # case the incumbent ``max(ring, epilogue)`` already models.
+            stores = sum(
+                cls._resolve_tile_bytes(t, block_of) for t in tiles if t.kind == "store"
+            )
+            return staged_loads * max(1, stages) + resident_loads + stores
+
+        # MAX across regions: separate loops run one after the other, not together. A LOOP
+        # BODY's loads are multi-buffered ``num_stages`` deep; a load in a NON-loop graph is
+        # issued once, so charging it per stage over-states shared memory -- measured, that
+        # over-charge computed 325632 B for a kernel already at its floor tile and pinned it
+        # there for an overflow that cannot happen.
+        ring = 0
+        for region in mm.pipelined_regions:
+            trips = cls._resolved_loop_trips(
+                env,
+                block_sizes,
+                region.loop_axes,
+                fallback=max(1, num_stages),
+            )
+            ring = max(
+                ring,
+                region_bytes(region.tiles, min(max(1, num_stages), trips)),
+            )
+        for region in mm.resident_regions:
+            ring = max(ring, region_bytes(region.tiles, 1))
+        return ring
+
+    @classmethod
+    def _resolved_loop_trips(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        loop_axes: tuple[LoopAxisFact, ...],
+        *,
+        fallback: int,
+    ) -> int:
+        """Candidate-real product of enclosing sequential loop trip counts."""
+        trips, _exact = cls._resolved_loop_trips_detail(
+            env,
+            block_sizes,
+            loop_axes,
+            fallback=fallback,
+        )
+        return trips
+
+    @classmethod
+    def _resolved_loop_trips_detail(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        loop_axes: tuple[LoopAxisFact, ...],
+        *,
+        fallback: int,
+    ) -> tuple[int, bool]:
+        """Resolved trips and whether every enclosing extent was proven."""
+        if not loop_axes:
+            return max(1, fallback), True
+        block_of = cls._full_block_map(env, block_sizes)
+        trips = 1
+        for axis in loop_axes:
+            bound = getattr(axis, "bounded_by_block_id", None)
+            if bound is not None:
+                extent = getattr(axis, "bounded_extent", None)
+                if extent is None:
+                    extent = block_of.get(bound)
+                if extent is None:
+                    return max(1, fallback), False
+            else:
+                extent = axis.extent
+            if extent is None:
+                return max(1, fallback), False
+            block = max(1, block_of.get(axis.block_id, 1))
+            trips *= max(1, -(-extent // block))
+        return trips, True
+
+    @classmethod
+    def _pipelined_loop_trips(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        *,
+        fallback: int,
+    ) -> int:
+        """Longest useful pipeline among sibling regions for one global stage knob."""
+        mm = env.config_spec.kernel_matmul_fact
+        if mm is None or not mm.pipelined_regions:
+            return max(1, fallback)
+        return max(
+            cls._resolved_loop_trips(
+                env,
+                block_sizes,
+                region.loop_axes,
+                fallback=fallback,
+            )
+            for region in mm.pipelined_regions
+        )
+
+    @classmethod
+    def _all_dot_acc_tiles(
+        cls, env: CompileEnvironment, block_sizes: list[int]
+    ) -> list[tuple[int, int, int]]:
+        """EVERY dot's accumulator tile, for the tensor-memory budget.
+
+        Tensor memory is a static per-CTA reservation, and measured on B200 the compiler does
+        not always reuse it across the dots of one kernel: a 5-dot kernel whose PEAK-LIVE dot
+        outputs came to 512 columns raised
+        ``OutOfResources: tensor memory, Required: 704, limit 512`` at launch. So the peak-live
+        measure -- which is the right one for registers, where the backend really does reuse --
+        under-counts here, and the budget has to reserve for every dot.
+
+        Deliberately the same unconditional pessimism ``_tmem_bytes`` already applies to a
+        single dot's promoted LHS: this accounting is only allowed to err toward being too
+        strict, because the alternative is a config that dies at launch.
+        """
+        mm = env.config_spec.kernel_matmul_fact
+        if mm is None:
+            return []
+        block_of = cls._full_block_map(env, block_sizes)
+
+        def extent(bid: int | None, axes_extent: int | None, static: int | None) -> int:
+            if bid is not None and bid in block_of:
+                return max(1, block_of[bid])
+            return max(1, axes_extent or static or 1)
+
+        out: list[tuple[int, int, int]] = []
+        for resolved in mm.matmuls:
+            f = resolved.fact
+            ax = resolved.axes
+            rows = extent(f.m_block_id, ax.m_extent, f.static_m)
+            cols = extent(f.n_block_id, ax.n_extent, f.static_n)
+            out.append((rows, cols, max(1, f.lhs_dtype.itemsize)))
+        return out
+
+    @classmethod
+    def _candidate_dot_work(
+        cls, env: CompileEnvironment, block_sizes: list[int]
+    ) -> CandidateDotWork:
+        """Dynamic dot work performed by one CTA under ``block_sizes``.
+
+        Per-invocation dimensions use the candidate tile. Enclosing loop axes use
+        the matching candidate trip count, so an axis represented by both terms is
+        covered once as ``block * ceil(extent / block)`` rather than once at full
+        extent and again as an unresolved loop multiplier.
+        """
+        mm = env.config_spec.kernel_matmul_fact
+        if mm is None:
+            return CandidateDotWork(0, 0)
+        block_of = cls._full_block_map(env, block_sizes)
+        total = 0
+        tcgen05_eligible = 0
+        tcgen05_independent = 0
+        tcgen05_carried = 0
+        uncertain = False
+        for resolved in mm.matmuls:
+            fact = resolved.fact
+            axes = resolved.axes
+
+            def extent(
+                axis: str,
+                block_id: int | None,
+                static: int | None,
+                dot_axes: DotAxes = axes,
+            ) -> int:
+                if block_id is not None and block_id in block_of:
+                    return max(1, block_of[block_id])
+                return max(1, dot_axes.extent(axis) or static or 1)
+
+            m = extent("m", fact.m_block_id, fact.static_m)
+            n = extent("n", fact.n_block_id, fact.static_n)
+            k = extent("k", fact.k_block_id, fact.static_k)
+            site = resolved.site
+            fallback = max(1, site.loop_trips) if site is not None else 1
+            loop_axes = getattr(site, "loop_axes", ()) if site is not None else ()
+            exact_loop_trips = (
+                getattr(site, "exact_loop_trips", None) if site is not None else None
+            )
+            if exact_loop_trips is not None:
+                trips = max(1, exact_loop_trips)
+            elif site is not None:
+                resolved_trips, exact = cls._resolved_loop_trips_detail(
+                    env,
+                    block_sizes,
+                    loop_axes,
+                    fallback=fallback,
+                )
+                # An unresolved upper bound is safe for stages but is not positive
+                # evidence that tcgen05 setup can be amortized. Use one proven
+                # invocation as the work lower bound and retain the uncertainty.
+                trips = resolved_trips if exact else 1
+                uncertain = uncertain or not exact
+            else:
+                trips = fallback
+            work = m * n * k * trips
+            total += work
+            if m >= cls.TCGEN05_MIN_BM:
+                tcgen05_eligible += work
+                if site is not None and site.updates_carry:
+                    tcgen05_carried += work
+                else:
+                    tcgen05_independent += work
+        return CandidateDotWork(
+            total,
+            tcgen05_eligible,
+            tcgen05_independent,
+            tcgen05_carried,
+            uncertain,
+        )
+
+    @classmethod
+    def _register_live_bytes(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        num_warps: int,
+    ) -> int:
+        """Peak register-resident bytes, chosen by RESOLVED BYTES at this candidate config.
+
+        Section 3 asks for registers to be estimated "from the register-resident live set and
+        proposed warp count". The estimate this replaces did that from ``live_tiles``, a single
+        step selected by RANK PROFILE -- correct for a reduction's working set, where block
+        sizes are not yet known, and wrong here, where they are. Selecting by rank picked a
+        step holding several rank-2 loads over the step that actually holds the accumulators,
+        and the resulting estimate UNDER-counted a kernel that spills 540 registers at one warp
+        (43520 B against a 32640 B one-warp file) while OVER-counting one that spills none
+        (49152 B). With the ordering inverted, no threshold could separate them -- which is
+        what drove a calibration divisor and then a structural warp floor over a defect that
+        was in the selector.
+
+        So: resolve EVERY recorded step under ``block_sizes`` and take the max. Per step,
+
+          * a dot output is charged only when tensor memory cannot absorb it -- below a
+            warpgroup there is no tcgen05 path at all (confirmed in PTX: ``num_warps`` 1 or 2
+            emits zero ``tcgen05.mma`` and ``tmem_size = 0``), and below ``TCGEN05_MIN_BM``
+            the dot never reaches it at any warp count;
+          * loads are excluded: they are charged to the shared-memory ring, and charging them
+            here would put the same bytes in two budgets;
+          * a value larger than the largest register file a CTA can have is excluded, since it
+            lives in HBM and the graph merely names it (a varlen packed ``[T, C, D]`` buffer
+            measured 256 MiB).
+
+        Warp-count dependent, so it must be re-asked at each rung of the ladder.
+        """
+        mm = env.config_spec.kernel_matmul_fact
+        if mm is None or not mm.live_tile_steps:
+            return 0
+        block_of = cls._full_block_map(env, block_sizes)
+        ceiling = cls.MAX_NUM_WARPS * 32 * cls.REG_BYTES_PER_THREAD
+        tmem_absorbs = num_warps >= cls.TCGEN05_WARPGROUP_WARPS
+        peak = 0
+        for step in mm.live_tile_steps:
+            total = 0
+            for tile in step:
+                if tile.kind == "load":
+                    continue
+                nbytes = cls._resolve_tile_bytes(tile, block_of)
+                if nbytes > ceiling:
+                    continue
+                if tile.kind == "dot_out" and tmem_absorbs:
+                    rows = cls._tile_rows(tile, block_of)
+                    if rows >= cls.TCGEN05_MIN_BM:
+                        continue
+                total += nbytes
+            peak = max(peak, total)
+        return peak
+
+    @classmethod
+    def _tile_rows(cls, tile: object, block_of: dict[int, int]) -> int:
+        """The tile's M extent (its second-to-last dim), which decides tcgen05 eligibility."""
+        dims = [
+            max(1, block_of.get(blk, 1)) if blk is not None else max(1, static or 1)
+            for blk, static in zip(
+                tile.dim_block_ids,  # type: ignore[attr-defined]
+                tile.static_dims,  # type: ignore[attr-defined]
+                strict=False,
+            )
+        ]
+        if len(dims) == 1:
+            return 1
+        rows = dims[-2]
+        for lead in dims[:-2]:
+            rows *= lead
+        return rows
+
+    @classmethod
+    def _resolve_tile_bytes(cls, tile: object, block_of: dict[int, int]) -> int:
+        """Bytes one recorded live tile occupies once the candidate block sizes are known."""
+        elems = 1
+        for blk, static in zip(tile.dim_block_ids, tile.static_dims, strict=False):  # type: ignore[attr-defined]
+            if blk is not None:
+                elems *= max(1, block_of.get(blk, 1))
+            else:
+                elems *= max(1, static or 1)
+        return elems * max(1, tile.itemsize)  # type: ignore[attr-defined]
+
+    @classmethod
+    def _epilogue_smem(cls, env: CompileEnvironment, block_sizes: list[int]) -> int:
+        """Largest conservative fp32 accumulator-staging buffer in the kernel."""
+        return max(
+            (
+                rows * cols * cls.EPILOGUE_ACC_ITEMSIZE
+                for rows, cols, _itemsize in cls._all_dot_acc_tiles(env, block_sizes)
+            ),
+            default=0,
+        )
+
+    @classmethod
+    def _kernel_smem_bytes(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        num_stages: int,
+    ) -> int:
+        """Peak whole-kernel SMEM under one complete block-size candidate."""
+        region_peak = cls._smem_from_map(env, block_sizes, num_stages)
+        epilogue_peak = cls._epilogue_smem(env, block_sizes)
+        return max(region_peak, epilogue_peak) + cls.SMEM_SLACK
+
+    @classmethod
+    def _apply_knob_roles(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        block_sizes: list[int],
+        num_sm: int,
+    ) -> None:
+        """Architecture hook for role-aware block-size corrections."""
+
+    @classmethod
+    def _graded_stage_depth(
+        cls,
+        smem_of: Callable[[int], int],
+        *,
+        loop_trips: int,
+        grid: int,
+        num_sm: int,
+        resident_ctas: int | None = None,
+        allow_one_trip_stage2: bool = True,
+    ) -> int:
+        """Pipeline depth for a dot whose K axis is a FIXED full extent.
+
+        Such a dot has no K-loop: it consumes the whole extent in one shot, so the loop the
+        pipeline can actually cover is the enclosing SEQUENTIAL loop (the chunk walk), and
+        the existing ``_bk_and_stages`` cap ``k // bk`` degenerates. Worse, the incumbent
+        occupancy model is binary -- one threshold at ``SAT_WAVES * num_sm`` switches the
+        ceiling between ``SAT_MAX_STAGES`` and ``MAX_STAGES`` -- so every kernel on one side
+        of it gets the same depth. Measured over the hand-tuned corpus, the right depth
+        instead falls off GRADUALLY as outer parallelism rises (outer grid 32 -> 8-11
+        stages, 64 -> 6-8, 96 -> 3-4, 256 -> 2-4, and >=1024 -> 2), and it is NOT a function
+        of the loop length (a 16-iteration walk wants 8 while a 128-iteration walk wants
+        3-4).
+
+        The physics that produces that gradient is shared shared-memory capacity. Depth is
+        bought with SMEM per CTA, and SMEM per CTA is what limits how many CTAs an SM can
+        hold. When the grid cannot even fill the machine (``grid < num_sm``) there is no
+        co-residency to protect and the only latency hiding available is depth, so a CTA may
+        spend the whole capacity. When the grid supplies several CTAs per SM, concurrency
+        already hides the latency and every extra stage evicts a CTA. So:
+
+            share = SMEM_BUDGET / max(1, ceil(grid / num_sm))
+            depth = deepest ring that fits ``share``, capped by the loop length
+
+        This reproduces both ends of the measured range from one rule: an outer grid far
+        above the machine size (a per-chunk preprocessing kernel, 1024-16384 programs) gets
+        a share of a few KB and lands on the floor of 2 -- which is what the hand-tuning
+        chose there -- while a 32-program recurrence gets the whole capacity and lands deep.
+
+        The ceiling is ``HW_MAX_STAGES``, not ``MAX_STAGES``: the incumbent 6 is a hard
+        ceiling that cannot express the 8 and 11 the hand-tuning selected at low
+        parallelism, so leaving it in place would cap the model below the answer.
+        """
+        grid_ctas_per_sm = max(1, -(-max(1, grid) // max(1, num_sm)))
+        grid_ctas_per_sm = min(
+            grid_ctas_per_sm,
+            cls.GRADED_MAX_CTAS_PER_SM,
+        )
+        ctas_per_sm = resident_ctas if resident_ctas is not None else grid_ctas_per_sm
+        ctas_per_sm = min(ctas_per_sm, cls.GRADED_MAX_CTAS_PER_SM)
+        share = cls.SMEM_BUDGET // ctas_per_sm
+        # Even a one-trip enclosing loop can use the top-level stage knob to
+        # overlap the contraction's operand loads, but a tile already near the
+        # register limit may spill badly when that second stage is materialized.
+        # The caller resolves that one-trip choice from candidate resources.
+        one_trip_floor = 2 if allow_one_trip_stage2 else 1
+        ceiling = min(cls.HW_MAX_STAGES, max(one_trip_floor, loop_trips))
+        if resident_ctas is not None and ctas_per_sm < grid_ctas_per_sm:
+            grid_share = cls.SMEM_BUDGET // grid_ctas_per_sm
+            grid_depth = 1
+            for stages in range(ceiling, 0, -1):
+                if smem_of(stages) <= grid_share:
+                    grid_depth = stages
+                    break
+            ceiling = min(
+                ceiling,
+                max(grid_depth, cls.OCCUPANCY_RELAXED_MAX_STAGES),
+            )
+        for stages in range(ceiling, 0, -1):
+            if smem_of(stages) <= share:
+                return stages
+        # Nothing fits the per-CTA SHARE. ``GRADED_SHARE_FALLBACK`` chooses what that means:
+        # the floor (occupancy is the binding term and depth is not affordable), or the deepest
+        # depth total CAPACITY allows (co-residency is already sacrificed, so there is nothing
+        # left for the share to protect). Which is right is a measured question, not an
+        # argument -- see the constant.
+        if cls.GRADED_SHARE_FALLBACK:
+            for stages in range(ceiling, 0, -1):
+                if smem_of(stages) <= cls.SMEM_BUDGET:
+                    return stages
+        return 1
+
+    @classmethod
+    def _one_trip_stage2_allowed(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        *,
+        num_warps: int,
+        smem_of: Callable[[int], int],
+        grid: int,
+        num_sm: int,
+    ) -> bool:
+        """Whether a one-trip pipeline has enough headroom to prefer ``ns2``.
+
+        TMEM's all-dot reservation is a hard-safety upper bound, not a reliable
+        peak-residency estimate. Excluding it here prevents that pessimistic
+        bound from claiming residency is already one and hiding an SMEM-driven
+        ``>=2 -> 1`` transition.
+        """
+        stage2_smem = smem_of(2)
+        if stage2_smem > cls.SMEM_BUDGET:
+            return False
+
+        warps = max(1, num_warps)
+        capacity = warps * 32 * cls.REG_BYTES_PER_THREAD
+        pressure = cls._register_live_bytes(env, block_sizes, warps) / max(1, capacity)
+        if pressure > cls.ONE_TRIP_STAGE2_MAX_REGISTER_PRESSURE:
+            return False
+
+        stage1_ctas = cls._estimated_resident_ctas(
+            env,
+            block_sizes,
+            num_warps=warps,
+            smem_bytes=smem_of(1),
+            grid=grid,
+            num_sm=num_sm,
+            include_tmem=False,
+        )
+        stage2_ctas = cls._estimated_resident_ctas(
+            env,
+            block_sizes,
+            num_warps=warps,
+            smem_bytes=stage2_smem,
+            grid=grid,
+            num_sm=num_sm,
+            include_tmem=False,
+        )
+        return not (stage1_ctas >= 2 and stage2_ctas == 1)
+
+    @classmethod
+    def _estimated_resident_ctas(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        *,
+        num_warps: int,
+        smem_bytes: int,
+        grid: int,
+        num_sm: int,
+        include_tmem: bool = True,
+    ) -> int:
+        """Resident CTAs jointly achievable under the candidate's resources.
+
+        The register live-set is a pressure estimate, not an exact ptxas register
+        count. Clamp it to the physical per-CTA allocation: excess logical
+        liveness spills rather than allocating an impossible register file.
+        """
+        warps = max(1, num_warps)
+        threads = warps * 32
+        demand = max(1, -(-max(1, grid) // max(1, num_sm)))
+        limits = [
+            demand,
+            cls.MAX_CTAS_PER_SM,
+            max(1, cls.MAX_THREADS_PER_SM // threads),
+            max(1, cls.SMEM_BUDGET // max(1, smem_bytes)),
+        ]
+
+        logical_register_bytes = cls._register_live_bytes(env, block_sizes, warps)
+        if logical_register_bytes > 0:
+            physical_cta_register_bytes = warps * 32 * cls.REG_BYTES_PER_THREAD
+            allocated_register_bytes = min(
+                logical_register_bytes,
+                physical_cta_register_bytes,
+            )
+            limits.append(
+                max(
+                    1,
+                    cls.REGISTER_FILE_BYTES_PER_SM // max(1, allocated_register_bytes),
+                )
+            )
+
+        if (
+            include_tmem
+            and cls.TMEM_COLUMNS_PER_SM is not None
+            and warps >= cls.TCGEN05_WARPGROUP_WARPS
+        ):
+            columns = cls._tmem_columns(cls._all_dot_acc_tiles(env, block_sizes))
+            if columns > 0:
+                limits.append(max(1, cls.TMEM_COLUMNS_PER_SM // columns))
+
+        return max(1, min(limits))
+
+    @classmethod
+    def _solve_candidate_stages(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        *,
+        num_warps: int,
+        loop_trips: int,
+        num_sm: int,
+        stage_block_sizes: list[int] | None = None,
+    ) -> int:
+        """Run the graded stage model against a complete kernel candidate."""
+        stage_blocks = block_sizes if stage_block_sizes is None else stage_block_sizes
+        stage_grid = cls._launch_grid(env, stage_blocks)
+
+        def smem_of(stages: int) -> int:
+            return cls._kernel_smem_bytes(env, stage_blocks, stages)
+
+        resident_ctas = cls._estimated_resident_ctas(
+            env,
+            stage_blocks,
+            num_warps=num_warps,
+            smem_bytes=smem_of(1),
+            grid=stage_grid,
+            num_sm=num_sm,
+        )
+
+        def candidate_smem_of(stages: int) -> int:
+            return cls._kernel_smem_bytes(env, block_sizes, stages)
+
+        allow_one_trip_stage2 = loop_trips != 1 or cls._one_trip_stage2_allowed(
+            env,
+            block_sizes,
+            num_warps=num_warps,
+            smem_of=candidate_smem_of,
+            grid=cls._launch_grid(env, block_sizes),
+            num_sm=num_sm,
+        )
+        return cls._graded_stage_depth(
+            smem_of,
+            loop_trips=loop_trips,
+            grid=stage_grid,
+            num_sm=num_sm,
+            resident_ctas=resident_ctas,
+            allow_one_trip_stage2=allow_one_trip_stage2,
+        )
+
+    @classmethod
+    def _solve_candidate_warps(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        num_warps: int,
+        num_stages: int,
+        num_sm: int,
+    ) -> int:
+        """Refresh the warp count from a complete kernel candidate."""
+        if not cls.WORK_AWARE_WARPS:
+            return num_warps
+        return cls._select_num_warps(
+            num_warps,
+            env,
+            block_sizes,
+            grid=cls._launch_grid(env, block_sizes),
+            num_sm=num_sm,
+            smem_bytes=cls._kernel_smem_bytes(env, block_sizes, num_stages),
+        )
+
+    @classmethod
+    def _fixup_candidate_resources(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        num_stages: int,
+        num_warps: int,
+        *,
+        num_sm: int,
+        shrinkable: list[int],
+        largest_first: bool,
+        max_corrections: int,
+        extra_over_budget: Callable[[list[int], int], bool] | None = None,
+    ) -> tuple[int, int]:
+        """Reduce stages, then selected block knobs, until hard resources fit."""
+        slot_of: dict[int, int] = {}
+        floors: dict[int, int] = {}
+        for slot in range(len(env.config_spec.block_sizes)):
+            bs = cast("BlockSizeSpec", env.config_spec.block_sizes[slot])
+            slot_of[bs.block_id] = slot
+            floors[bs.block_id] = max(1, bs.min_size, bs.autotuner_min)
+
+        def smem_over() -> bool:
+            return cls.ENFORCE_SMEM_BUDGET and (
+                cls._kernel_smem_bytes(env, block_sizes, num_stages) > cls.SMEM_BUDGET
+            )
+
+        def tmem_over() -> bool:
+            return (
+                cls.TMEM_COLUMN_BUDGET is not None
+                and num_warps >= cls.TCGEN05_WARPGROUP_WARPS
+                and cls._tmem_columns(cls._all_dot_acc_tiles(env, block_sizes))
+                > cls.TMEM_COLUMN_BUDGET
+            )
+
+        def over_budget() -> bool:
+            return (
+                smem_over()
+                or tmem_over()
+                or (
+                    extra_over_budget is not None
+                    and extra_over_budget(block_sizes, num_warps)
+                )
+            )
+
+        guard = 0
+        while over_budget() and guard < max_corrections:
+            guard += 1
+            if num_stages > cls.MIN_NUM_STAGES and smem_over():
+                num_stages -= 1
+                continue
+            candidates = [
+                bid
+                for bid in shrinkable
+                if bid in slot_of
+                and block_sizes[slot_of[bid]] // 2
+                >= max(
+                    floors[bid],
+                    min(cls.DOT_MIN, block_sizes[slot_of[bid]]),
+                )
+            ]
+            if not candidates:
+                break
+            victim = (
+                max(candidates, key=lambda bid: block_sizes[slot_of[bid]])
+                if largest_first
+                else candidates[0]
+            )
+            block_sizes[slot_of[victim]] //= 2
+            num_warps = cls._solve_candidate_warps(
+                env,
+                block_sizes,
+                num_warps,
+                num_stages,
+                num_sm,
+            )
+
+        num_warps = cls._solve_candidate_warps(
+            env,
+            block_sizes,
+            num_warps,
+            num_stages,
+            num_sm,
+        )
+        return num_stages, num_warps
 
     @classmethod
     def _matmul_tile(
@@ -760,6 +2024,185 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         return bm, bn, bk, num_warps, num_stages, l2_grouping
 
     @classmethod
+    def _projected_tile_for_dot(
+        cls,
+        env: CompileEnvironment,
+        fact: MatmulFact,
+        axes: DotAxes | None,
+        itemsize: int,
+        num_sm: int,
+        pinned_grid: int,
+        site: DotSite | None = None,
+    ) -> tuple[int, int, int, int, int, int]:
+        """Project one dot-local formula proposal onto the axes the kernel exposes."""
+        m_extent = fact.static_m if fact.static_m is not None else None
+        n_extent = fact.static_n if fact.static_n is not None else None
+        if axes is not None:
+            m_extent = axes.m_extent if m_extent is None else m_extent
+            n_extent = axes.n_extent if n_extent is None else n_extent
+        if m_extent is None or n_extent is None:
+            return cls.DOT_MIN, cls.DOT_MIN, cls.DOT_MIN, 4, cls.MIN_NUM_STAGES, 1
+        mm = env.config_spec.kernel_matmul_fact
+        loop_trips = 1
+        if mm is not None:
+            loop_trips = max(1, mm.sequential_loop_trips)
+
+        k_logical = fact.static_k
+        k_fixed = axes is not None and axes.k_kind is DotAxisKind.FIXED_FULL_EXTENT
+        if k_fixed and axes is not None and axes.k_extent:
+            k_logical = axes.k_extent * loop_trips
+        elif k_logical is None and axes is not None and axes.k_extent:
+            k_logical = axes.k_extent
+
+        bm, bn, bk, num_warps, num_stages, l2 = cls._matmul_tile(
+            m_extent, n_extent, k_logical or cls.DOT_MIN, itemsize, num_sm, pinned_grid
+        )
+
+        if axes is None:
+            return bm, bn, bk, num_warps, num_stages, l2
+
+        # (2) project
+        spec = env.config_spec
+        bounds: dict[int, tuple[int, int]] = {}
+        for i in range(len(spec.block_sizes)):
+            bs = cast("BlockSizeSpec", spec.block_sizes[i])
+            bounds[bs.block_id] = (
+                max(1, bs.min_size, bs.autotuner_min),
+                bs.max_size,
+            )
+
+        def project(axis: str, value: int, bid: int | None) -> int:
+            if axes.kind(axis) is DotAxisKind.FIXED_FULL_EXTENT:
+                return max(1, axes.extent(axis) or value)
+            if bid is not None and bid in bounds:
+                lo, hi = bounds[bid]
+                return max(lo, min(hi, value))
+            return value
+
+        bm = project("m", bm, fact.m_block_id)
+        bn = project("n", bn, fact.n_block_id)
+        bk = project("k", bk, fact.k_block_id)
+
+        # A partitioned K loop exposes many independent partial-output CTAs.
+        site_loop_axes = getattr(site, "loop_axes", ()) if site is not None else ()
+        partitioned_k = any(
+            getattr(axis, "bounded_by_block_id", None) is not None
+            for axis in site_loop_axes
+        )
+        if (
+            partitioned_k
+            and cls.SAT_PARTITIONED_K_BM is not None
+            and cls.SAT_PARTITIONED_K_BN is not None
+        ):
+            bm = min(bm, cls.SAT_PARTITIONED_K_BM)
+            bn = min(bn, cls.SAT_PARTITIONED_K_BN)
+
+        return bm, bn, bk, num_warps, num_stages, l2
+
+    @classmethod
+    def _tile_for_dot(
+        cls,
+        env: CompileEnvironment,
+        fact: MatmulFact,
+        axes: DotAxes | None,
+        itemsize: int,
+        num_sm: int,
+        pinned_grid: int,
+        site: DotSite | None = None,
+    ) -> tuple[int, int, int, int, int, int]:
+        """Finalize one projected dot against its complete kernel block-size candidate."""
+        proposal = cls._projected_tile_for_dot(
+            env,
+            fact,
+            axes,
+            itemsize,
+            num_sm,
+            pinned_grid,
+            site=site,
+        )
+        if axes is None:
+            return proposal
+        bm, bn, bk, num_warps, num_stages, l2 = proposal
+        mm = env.config_spec.kernel_matmul_fact
+        loop_trips = max(1, mm.sequential_loop_trips) if mm is not None else 1
+        k_fixed = axes.k_kind is DotAxisKind.FIXED_FULL_EXTENT
+        site_loop_axes = getattr(site, "loop_axes", ()) if site is not None else ()
+        spec = env.config_spec
+        slot_of: dict[int, int] = {}
+        for slot in range(len(spec.block_sizes)):
+            bs = cast("BlockSizeSpec", spec.block_sizes[slot])
+            slot_of[bs.block_id] = slot
+
+        emitted = _h100_build_block_sizes(env.config_spec, fact, bm, bn, bk)
+        if cls.SINGLE_ROLE_AWARE_KNOBS and mm is not None:
+            cls._apply_knob_roles(env, mm, emitted, num_sm)
+        if site_loop_axes:
+            loop_trips = cls._resolved_loop_trips(
+                env,
+                emitted,
+                site_loop_axes,
+                fallback=loop_trips,
+            )
+
+        if cls.GRADED_STAGES and k_fixed:
+            num_stages = cls._solve_candidate_stages(
+                env,
+                emitted,
+                num_warps=num_warps,
+                loop_trips=loop_trips,
+                num_sm=num_sm,
+            )
+        num_warps = cls._solve_candidate_warps(
+            env,
+            emitted,
+            num_warps,
+            num_stages,
+            num_sm,
+        )
+
+        base_tile = bm, bn, bk
+
+        def dot_tile(block_sizes: list[int]) -> tuple[int, int, int]:
+            def value(block_id: int | None, fallback: int) -> int:
+                if block_id is None or block_id not in slot_of:
+                    return fallback
+                return block_sizes[slot_of[block_id]]
+
+            return (
+                value(fact.m_block_id, base_tile[0]),
+                value(fact.n_block_id, base_tile[1]),
+                value(fact.k_block_id, base_tile[2]),
+            )
+
+        def focal_tmem_over(block_sizes: list[int], warps: int) -> bool:
+            if warps < cls.TCGEN05_WARPGROUP_WARPS or cls.TMEM_BUDGET is None:
+                return False
+            tile_m, tile_n, tile_k = dot_tile(block_sizes)
+            return cls._tmem_bytes(tile_m, tile_n, tile_k, itemsize) > cls.TMEM_BUDGET
+
+        shrinkable = [
+            block_id
+            for axis, block_id in (
+                ("n", fact.n_block_id),
+                ("m", fact.m_block_id),
+            )
+            if block_id is not None and axes.kind(axis) is DotAxisKind.TUNABLE_TILED
+        ]
+        num_stages, num_warps = cls._fixup_candidate_resources(
+            env,
+            emitted,
+            num_stages,
+            num_warps,
+            num_sm=num_sm,
+            shrinkable=shrinkable,
+            largest_first=False,
+            max_corrections=40,
+            extra_over_budget=focal_tmem_over,
+        )
+        bm, bn, bk = dot_tile(emitted)
+        return bm, bn, bk, num_warps, num_stages, l2
+
+    @classmethod
     def _ranked_configs(cls, env: CompileEnvironment, fact: MatmulFact) -> list[Config]:
         """Ranked seed list: the budget primary (rank-0, Product A) + a couple of diverse alternates
         (transposed aspect, shallower num_stages) to seed the autotuner search. Deduped by the loader."""
@@ -772,16 +2215,30 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         spec = env.config_spec
         itemsize = max(1, fact.lhs_dtype.itemsize)
         num_sm = max(1, get_num_sm(env.device))
-        pinned_grid = _h100_pinned_grid(env, fact)
+        mm = env.config_spec.kernel_matmul_fact
+        site = mm.matmuls[0].site if mm is not None and mm.matmuls else None
+        base_blocks = list(
+            cast(
+                "list[int]",
+                spec._base_default_config().config.get("block_sizes", []),
+            )
+        )
+        block_of = cls._full_block_map(env, base_blocks)
+        grid_block_ids = _grid_group_for_site(spec, site)
+        pinned_grid = _h100_pinned_grid(
+            env,
+            fact,
+            block_of,
+            grid_block_ids,
+        )
         # The budget formula sizes the dot tile under a register/SMEM budget, keyed on
-        # (M, N, K, operand-width via itemsize) and the pinned batch grid.
-        bm, bn, bk, nw, ns, l2 = cls._matmul_tile(
-            fact.static_m,
-            fact.static_n,
-            fact.static_k,
-            itemsize,
-            num_sm,
-            pinned_grid,
+        # (M, N, K, operand-width via itemsize) and the pinned batch grid. ``_tile_for_dot``
+        # then projects that proposal onto the axes this kernel actually exposes and
+        # recomputes the scalar knobs and resource budgets from the real tile; with three
+        # tunable axes and one live accumulator it returns the proposal unchanged.
+        axes = _axis_roles(env.config_spec, 0) if cls.GENERALIZED_AXES else None
+        bm, bn, bk, nw, ns, l2 = cls._tile_for_dot(
+            env, fact, axes, itemsize, num_sm, pinned_grid, site=site
         )
 
         def _extra(
@@ -830,7 +2287,12 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             and cls._tmem_bytes(bm2, bn2, bk, itemsize) <= (cls.TMEM_BUDGET or _INF)
             and (
                 not conservative
-                or cls._smem_bytes(bm2, bn2, bk, itemsize, ns) <= cls.SMEM_BUDGET
+                or cls._kernel_smem_bytes(
+                    env,
+                    _h100_build_block_sizes(spec, fact, bm2, bn2, bk),
+                    ns,
+                )
+                <= cls.SMEM_BUDGET
             )
         ):
             nw2 = _warps(bm2, bn2)
@@ -866,10 +2328,19 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         return ranked
 
     @classmethod
+    def _eligible_fact(cls, config_spec: ConfigSpec) -> MatmulFact | None:
+        """The single-matmul precondition. ``GENERALIZED_AXES`` widens it to admit a
+        contraction whose M, N or K is a fixed full extent; without the switch it is the
+        exact incumbent gate, so an unmeasured arch is unaffected."""
+        if cls.GENERALIZED_AXES:
+            return _generalized_static_matmul_fact(config_spec)
+        return _batched_static_matmul_fact(config_spec)
+
+    @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
         if not matches_hardware(env, cls.HARDWARE_TARGETS):
             return False
-        fact = _batched_static_matmul_fact(env.config_spec)
+        fact = cls._eligible_fact(env.config_spec)
         if fact is None:
             return False
         # Decline fp8 (both operands 1-byte float). CAVEAT: this is disabled because of an fp8
@@ -903,7 +2374,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
 
     @classmethod
     def _ranked(cls, env: CompileEnvironment) -> list[Config]:
-        fact = _batched_static_matmul_fact(env.config_spec)
+        fact = cls._eligible_fact(env.config_spec)
         if fact is None:
             return []
         # The budget formula is the sole seed: the primary (Product A) + ranked Product-B alternates.
@@ -938,9 +2409,16 @@ class TritonB200FormulaMatmulHeuristic(TritonH100MatmulHeuristic):
     # num_sm (148) enters via get_num_sm, so the wave/saturation arithmetic self-adjusts; the rest
     # inherit the H100 formula, re-tuned per move below.
     SMEM_BUDGET = 232448  # B200 shared_memory_per_block_optin (bytes)
-    # A saturated batched dot on 148 SMs wants a smaller tile + min warps (more concurrent tiny CTAs).
-    SAT_TILE_BM = 32
-    SAT_TILE_BN = 64
+    # A shared ceiling for saturated B200 dots. It bounds the inherited 128x256
+    # base tile without using tile size to force either front end away from the
+    # tcgen05 regime; the final candidate-real warp solve decides that separately.
+    SAT_TILE_BM = 128
+    SAT_TILE_BN = 128
+    # A grid-partitioned K loop exposes many short, independent partial-output
+    # CTAs. The corrected physical grid plus a full tile sweep selects this
+    # smaller ceiling across both B200 front ends.
+    SAT_PARTITIONED_K_BM = 32
+    SAT_PARTITIONED_K_BN = 64
     SAT_NUM_WARPS = 1
     # Strict wave-fill shrink (see the shrink loop). A universal fix; gated to sm100 only to keep the
     # sm90 freeze byte-identical — the principled end-state is to flip the base default once H100 can
@@ -950,12 +2428,453 @@ class TritonB200FormulaMatmulHeuristic(TritonH100MatmulHeuristic):
     # Full tcgen05 tensor memory: 128 lanes x 512 columns x 32 bit = 262144 bytes. The [256,256] fp32
     # accumulator EXACTLY fills it, which is why a promoted A operand cannot coexist with that square.
     TMEM_BUDGET = 128 * 512 * 4
+    # The SAME tensor memory counted the way the hardware allocates it: 512 columns of 128 lanes.
+    # Kept alongside the byte budget rather than replacing it, because the column count is the
+    # faithful unit (a bm<128 accumulator costs full columns) and can therefore only ever REJECT a
+    # tile the byte model accepted -- never the reverse. With one live accumulator and the existing
+    # BASE_BN_CAP=256 it never binds, so the incumbent single-GEMM path is unaffected; it binds
+    # exactly where the byte model under-counts, on several simultaneously live accumulators.
+    TMEM_COLUMN_BUDGET = 512
+    TMEM_COLUMNS_PER_SM = 512
+    # The register-driven warp ladder stops at a warpgroup HERE, because here is where
+    # _register_live_bytes hands the accumulators to tcgen05 -- so above this rung the estimate
+    # holds only the part it is loosest about, and cannot justify a doubling that halves resident
+    # CTAs. Tied to the warpgroup constant by reference rather than spelled 4, so the stop and the
+    # absorption boundary it is derived from cannot drift apart. Measured: 0.9591 against a
+    # per-cell optimum over 53 cells where num_warps moves time, where climbing on to
+    # MAX_NUM_WARPS scores 0.8959. See _warps_for_live_set.
+    REG_CLIMB_MAX_WARPS = TritonH100MatmulHeuristic.TCGEN05_WARPGROUP_WARPS
     # EPILOGUE_ACC_ITEMSIZE is inherited (the term is arch-independent). What is sm100-specific is
     # ENFORCING it: only here can the tile reach bm*bn=65536, where the term actually exceeds the cap.
     ENFORCE_SMEM_BUDGET = True
     # 1 KiB covers the mbarrier allocations (8 B each) and any similarly small future allocation.
     # Measured: an otherwise byte-exact bound is violated by exactly 16 B without this.
     SMEM_SLACK = 1024
+    # --- Section 3 capabilities, enabled here because every measurement behind them is B200 ---
+    # Admit a contraction with a fixed full-extent axis, project the proposal onto the axes the
+    # kernel exposes, and recompute resources from the real tile.
+    GENERALIZED_AXES = True
+    # Graded occupancy for num_stages where the pipelined loop is a sequential outer loop rather
+    # than the dot's own K-loop (the binary saturation flag has no gradient there).
+    GRADED_STAGES = True
+    # Let live-accumulator register pressure override the grid-only one-warp draft.
+    WORK_AWARE_WARPS = True
+    # Select one/two-warp mma.sync versus tcgen05 from candidate-real dynamic
+    # work and soft spill pressure, rather than treating perfect register fit as
+    # the objective.
+    REGIME_AWARE_WARPS = True
+    # Correct single-contraction block sizes by the same structural roles used
+    # after multi-contraction draft assembly. The multi front end disables the
+    # per-dot invocation and applies the shared correction once to its merged draft.
+    SINGLE_ROLE_AWARE_KNOBS = True
+    ROLE_FLAT_OUTPUT = True
+    ROLE_GRID_FILL = True
+    # tcgen05 tensor memory is allocated by ``tcgen05.alloc``, whose column count is a
+    # power of two and AT LEAST 32. An accumulator narrower than 32 columns therefore
+    # reserves 32 columns anyway while issuing half the MMA work per instruction, so 32
+    # is a hardware floor on any knob that sizes an accumulator extent -- not a tuned
+    # constant. Measured: on a reuse-free output axis, 32 beats 16 on every case swept
+    # (wy_delta#2 1.209 vs 1.111, #10 1.192 vs 1.139, #15 1.179 vs 1.090,
+    # wy_delta_varlen#0 1.737 vs 1.460) and beats the un-corrected draft by 1.2-1.8x.
+    TMEM_ALLOC_COLUMNS = 32
+
+    @classmethod
+    def _knob_amortizes(cls, mm: KernelMatmulFact, block_id: int) -> bool:
+        """Does enlarging this knob buy arithmetic intensity?
+
+        Yes iff some pipelined region the knob appears in also stages a LOAD that the knob
+        does not span. Such a load is re-fetched once per iteration of this axis
+        regardless of the tile, so a bigger tile amortizes it over more work and the
+        classic tile-growth argument applies. If every load in the region spans the knob,
+        then bytes moved and MMA work both scale linearly with the tile and arithmetic
+        intensity is CONSTANT in it -- growth buys nothing at all.
+
+        This is a property of the kernel's dataflow, available for any workload: it is
+        read off the same per-region load tiles the shared-memory ring is charged from.
+        Measured on both sides. Reuse-free (``chunk_fwd_wy_delta``'s ``hl.tile(D)`` body,
+        which loads and stores only its own D slice): shrinking the tile 128 -> 32 is
+        1.18-1.74x FASTER. Reuse-bearing (``chunk_bwd_dqkw_delta``'s inner DV loop, which
+        re-loads ``do``/``v_new``/``dvni`` for every D tile): the same shrink 64 -> 32 is
+        0.79-0.96x, i.e. SLOWER, and growing it 64 -> 128 is 1.05x faster. Same axis
+        position, same dtype, opposite sign -- so the discriminator has to be the reuse,
+        not the axis.
+        """
+        for region in mm.pipelined_regions:
+            tiles = region.tiles
+            if not any(block_id in t.dim_block_ids for t in tiles):
+                continue
+            if any(t.kind == "load" and block_id not in t.dim_block_ids for t in tiles):
+                return True
+        return False
+
+    @classmethod
+    def _apply_knob_roles(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        block_sizes: list[int],
+        num_sm: int,
+    ) -> None:
+        """Correct a block-size candidate for what each knob's axis actually is.
+
+        ``_matmul_tile`` is a GEMM formula: it grows ``bm``/``bn`` toward an
+        arithmetic-intensity optimum under an accumulator budget, on two assumptions
+        that do not hold for every surrounding kernel -- that an M/N tile is a PARALLEL
+        PROGRAM, and that enlarging it AMORTIZES the other operand. Both failures push
+        the same way: the tile is grown for a benefit that does not exist.
+
+        * **reuse-free output knob** (claimed as some dot's M or N, not a grid axis, and
+          its loop region re-fetches nothing it does not span): arithmetic intensity is
+          constant in it, while the fp32 accumulator, the register-resident intermediates
+          and the store staging all scale with it. Growth is pure cost -> take the floor.
+        * **grid knob**: the tile divides the launch grid, so it IS occupancy. Shrink
+          while the launch is below one wave and the shrink strictly improves wave
+          utilization.
+
+        The floor is the same quantity in both cases, ``TMEM_ALLOC_COLUMNS``, because
+        it is a hardware allocation granularity rather than a policy choice.
+        """
+        spec = env.config_spec
+        grid_ids = set(spec.grid_block_ids)
+        slot_of: dict[int, int] = {}
+        lo_of: dict[int, int] = {}
+        for slot in range(len(spec.block_sizes)):
+            bs = cast("BlockSizeSpec", spec.block_sizes[slot])
+            slot_of[bs.block_id] = slot
+            lo_of[bs.block_id] = max(1, bs.min_size, bs.autotuner_min)
+
+        def claimed_as_output(users: tuple[tuple[int, str], ...]) -> bool:
+            return any(axis in ("m", "n") for _i, axis in users)
+
+        # (1) reuse-free output knobs -> the allocation floor.
+        for bid, users in mm.knob_users if cls.ROLE_FLAT_OUTPUT else ():
+            if bid not in slot_of or bid in grid_ids or not users:
+                continue
+            if not claimed_as_output(users) or cls._knob_amortizes(mm, bid):
+                continue
+            slot = slot_of[bid]
+            target = min(cls._axis_extent(env, bid), cls.TMEM_ALLOC_COLUMNS)
+            block_sizes[slot] = max(lo_of[bid], min(block_sizes[slot], target))
+
+        # (2) grid knobs -> fill one wave, but only across a favorable wave boundary.
+        # Compare g / ceil(g / num_sm) by integer cross-multiplication: a shrink like
+        # 86 -> 172 programs is rejected because 86/1 == 172/2, while 64 -> 128 is
+        # accepted because both launches occupy one wave and utilization doubles.
+        grid_knobs = [
+            bid
+            for bid, _users in mm.knob_users
+            if bid in slot_of and bid in grid_ids and cls.ROLE_GRID_FILL
+        ]
+        want_programs = max(1, int(num_sm * cls.WAVE_FULL))
+        guard = 0
+        while guard < 32:
+            current_grid = cls._launch_grid(env, block_sizes)
+            if current_grid >= want_programs:
+                break
+            current_waves = max(1, -(-current_grid // num_sm))
+            candidates: list[int] = []
+            for bid in grid_knobs:
+                slot = slot_of[bid]
+                if block_sizes[slot] // 2 < max(lo_of[bid], cls.TMEM_ALLOC_COLUMNS):
+                    continue
+                trial = list(block_sizes)
+                trial[slot] //= 2
+                trial_grid = cls._launch_grid(env, trial)
+                trial_waves = max(1, -(-trial_grid // num_sm))
+                if trial_grid * current_waves > current_grid * trial_waves:
+                    candidates.append(bid)
+            if not candidates:
+                break
+            guard += 1
+            victim = max(candidates, key=lambda b: block_sizes[slot_of[b]])
+            block_sizes[slot_of[victim]] //= 2
+
+
+class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
+    """B200 (sm100) seed for a kernel whose contraction structure is more than one clean
+    dot: FRONT END 2, consuming the composed :class:`KernelMatmulFact`.
+
+    The single-matmul front end configures one contraction against one budget. A kernel with
+    several contractions cannot be configured that way, for two independent measured reasons:
+
+    * **A knob is shared.** Two dots' axes frequently map onto the SAME ``block_size`` entry
+      (an intra-chunk kernel builds ``A = q @ k.T`` and then consumes ``A @ v``, so one knob
+      is dot 1's N and dot 2's K). Whichever dot the code happens to size first wins by
+      accident, so the choice has to be RANKED.
+    * **The resources are shared.** Several accumulators are live at once. Sizing the tile
+      off one of them under-counts tensor memory by a factor of the accumulator count:
+      measured, a three-dot chunked kernel at chunk extent 256 emits a config that dies with
+      ``OutOfResources: tensor memory, Required: 768, limit 512`` -- exactly three 256-column
+      accumulators against a 512-column budget. That is a correctness defect, not a missed
+      optimisation.
+
+    Two phases, as the plan prescribes:
+
+    1. **Draft construction.** Build one whole-kernel-conditioned prior per structurally
+       distinct dot; for every tunable block id, rank the dots whose axis maps onto it and
+       take the winner's corresponding value; then correct the kernel-global scalars
+       (``num_warps``, top-level ``num_stages``) against AGGREGATE work and occupancy rather
+       than any single dot's.
+    2. **Resource fix-up.** Re-validate the assembled draft against whole-kernel liveness and
+       spend knobs in cost order until it fits: ``num_stages`` first (pipeline depth is the
+       cheapest thing to give up), then the tunable tile axes. A fixed axis is not a knob and
+       is never shrunk.
+
+    Ranking is by ``(updates a loop-carried accumulator, dynamic work, output area)``. The
+    carry term leads because a dot feeding a loop-carried accumulator holds that accumulator
+    resident for the entire loop, so its tile sets the kernel's whole-loop footprint; but it
+    is a PREFERENCE, not an eligibility rule -- dimensions and execution count break every
+    tie, and a kernel with no carried accumulator ranks purely on work.
+
+    Registered after the single-matmul front end for deterministic seed ordering,
+    and it declines whenever front end 1 fires, so exactly one path seeds any given
+    kernel.
+    """
+
+    name = "triton_b200_multi_matmul"
+    HARDWARE_TARGETS = (("cuda", "sm100"),)
+    # A promoted config must compile before autotuning can start. Keep the
+    # broader multi-contraction policy as a search seed until its legality has
+    # been validated beyond the current corpora.
+    promote_seed_to_default = False
+    SINGLE_ROLE_AWARE_KNOBS = False
+
+    # --- knob-role tile sizing (see ``_apply_knob_roles``) ----------------------------
+    # Master switch, so the correction can be A/B'd against the plain ranked draft; the
+    # two roles are separately switchable because they are separately measurable.
+    ROLE_AWARE_KNOBS = True
+    # Compute pipeline facts from the tile that is actually emitted. Keeping the pre-role
+    # snapshot can compensate for a missing stage-benefit model, but it also derives loop
+    # trips, SMEM, and residency from block sizes the kernel will not use and can indirectly
+    # select the wrong warp regime. ``True`` remains available for controlled ablations.
+    ROLE_KEEP_STAGES = False
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        if not matches_hardware(env, cls.HARDWARE_TARGETS):
+            return False
+        mm = env.config_spec.kernel_matmul_fact
+        if mm is None or not mm.matmuls:
+            return False
+        # Front end 1 owns the clean single-contraction case (including the generalized
+        # fixed-axis form). Declining there keeps promotion ownership unambiguous.
+        if _generalized_static_matmul_fact(env.config_spec) is not None:
+            return False
+        # At least one dot must have a sizable per-program extent on every axis; nothing can
+        # be sized without them. Read off ``DotAxes`` rather than ``MatmulFact.static_*``,
+        # which reports UNKNOWN for a config-immovable axis over a dynamic-length sequence --
+        # measured, that alone left 26 curriculum cases with no seed at all, even though the
+        # per-program contraction there is a compile-time constant.
+        if not any(
+            all(
+                resolved.axes.kind(axis) is not DotAxisKind.UNKNOWN
+                and resolved.axes.extent(axis) is not None
+                for axis in ("m", "n", "k")
+            )
+            for resolved in mm.matmuls
+        ):
+            return False
+        # Decline fp8 for exactly the reason front end 1 does: Helion cannot force the
+        # full-precision fp8 accumulate today, and this heuristic promotes, so an eligible
+        # fp8 seed would become a silently reduced-precision autotune-off default.
+        return not any(_is_fp8_matmul_fact(resolved.fact) for resolved in mm.matmuls)
+
+    @classmethod
+    def _rank_key(cls, mm: KernelMatmulFact, index: int) -> tuple[int, int, int]:
+        """Dynamic importance of one dot. Higher wins.
+
+        ``updates_carry`` leads because a dot writing a loop-carried accumulator keeps that
+        accumulator resident for the whole loop; ``dot_work`` (``m*n*k`` times executions) is
+        the magnitude term; the dot's own output area breaks remaining ties toward the dot
+        with the most to lose from a bad tile. Untrusted attribution collapses the first term
+        for every dot equally, so ranking degrades to pure work rather than to an arbitrary
+        order."""
+        resolved = mm.matmuls[index]
+        carry = 1 if (mm.attribution_complete and resolved.site.updates_carry) else 0
+        f = resolved.fact
+        ax = resolved.axes
+        area = (f.static_m or ax.m_extent or 1) * (f.static_n or ax.n_extent or 1)
+        return (carry, mm.dot_work(index), area)
+
+    @classmethod
+    def _proposal_for(
+        cls, env: CompileEnvironment, mm: KernelMatmulFact, index: int, num_sm: int
+    ) -> tuple[int, int, int, int, int, int] | None:
+        """One dot's prior, projected and preconditioned against the whole kernel."""
+        resolved = mm.matmuls[index]
+        fact = resolved.fact
+        ax = resolved.axes
+        if any(
+            ax.kind(a) is DotAxisKind.UNKNOWN or ax.extent(a) is None
+            for a in ("m", "n", "k")
+        ):
+            return None
+        itemsize = max(1, fact.lhs_dtype.itemsize)
+        return cls._tile_for_dot(
+            env,
+            fact,
+            ax,
+            itemsize,
+            num_sm,
+            max(1, mm.outer_grid),
+            site=resolved.site,
+        )
+
+    @classmethod
+    def _draft(
+        cls, env: CompileEnvironment, mm: KernelMatmulFact
+    ) -> dict[str, Any] | None:
+        """Phase 1: assemble a whole-kernel draft from the per-dot proposals."""
+        from ...runtime import get_num_sm
+
+        spec = env.config_spec
+        num_sm = max(1, get_num_sm(env.device))
+        proposals: dict[int, tuple[int, int, int, int, int, int]] = {}
+        for i in range(len(mm.matmuls)):
+            p = cls._proposal_for(env, mm, i, num_sm)
+            if p is not None:
+                proposals[i] = p
+        if not proposals:
+            return None
+
+        order = sorted(proposals, key=lambda i: cls._rank_key(mm, i), reverse=True)
+        rank_of = {i: r for r, i in enumerate(order)}
+
+        # --- block sizes: the winning dot's value for each contested knob ---------------
+        # Start from the base default so an axis that is NO dot's M/N/K and no grid axis
+        # keeps exactly the size it has today, rather than being pinned by a rule that was
+        # never measured on it.
+        base = spec._base_default_config()
+        block_sizes = list(cast("list[int]", base.config.get("block_sizes", [])))
+        grid_ids = set(spec.grid_block_ids)
+        mn_ids = {resolved.fact.m_block_id for resolved in mm.matmuls} | {
+            resolved.fact.n_block_id for resolved in mm.matmuls
+        }
+        for slot in range(len(spec.block_sizes)):
+            bs = cast("BlockSizeSpec", spec.block_sizes[slot])
+            bid = bs.block_id
+            users = mm.users_of(bid)
+            lo = max(1, bs.min_size, bs.autotuner_min)
+            if users:
+                # Rank the competing dots and take the winner's corresponding axis.
+                winner, axis = min(
+                    users, key=lambda ua: (rank_of.get(ua[0], len(order)), ua[1])
+                )
+                p = proposals.get(winner)
+                value = (
+                    {"m": p[0], "n": p[1], "k": p[2]}[axis]
+                    if p is not None
+                    else (block_sizes[slot] if slot < len(block_sizes) else lo)
+                )
+            elif bid in grid_ids and bid not in mn_ids:
+                # A batch/outer parallel axis: pin to its floor, exactly as front end 1
+                # does, so the per-program budget the proposals were sized under holds.
+                value = lo
+            else:
+                value = block_sizes[slot] if slot < len(block_sizes) else lo
+            value = max(lo, min(bs.max_size, value))
+            if slot < len(block_sizes):
+                block_sizes[slot] = value
+            else:
+                block_sizes.append(value)
+
+        # The ranked draft sizes every knob as if it were a GEMM's output tile axis.
+        # Correct it for what each knob's axis actually is before anything derived from
+        # the emitted tile (the launch grid, the stage depth, the warp count) is computed.
+        # The pre-role snapshot is retained only for the ``ROLE_KEEP_STAGES`` ablation.
+        stage_ring = list(block_sizes)
+        if cls.ROLE_AWARE_KNOBS:
+            pre_role_ring = stage_ring
+            cls._apply_knob_roles(env, mm, block_sizes, num_sm)
+            stage_ring = pre_role_ring if cls.ROLE_KEEP_STAGES else list(block_sizes)
+
+        # --- kernel-global scalars: aggregate, not any single dot's ---------------------
+        num_warps = max(proposals[i][3] for i in proposals)
+        num_stages = max(proposals[i][4] for i in proposals)
+
+        if cls.GRADED_STAGES:
+            loop_trips = cls._pipelined_loop_trips(
+                env,
+                stage_ring,
+                fallback=max(1, mm.sequential_loop_trips),
+            )
+            num_stages = cls._solve_candidate_stages(
+                env,
+                block_sizes,
+                num_warps=num_warps,
+                loop_trips=loop_trips,
+                num_sm=num_sm,
+                stage_block_sizes=stage_ring,
+            )
+        num_warps = cls._solve_candidate_warps(
+            env,
+            block_sizes,
+            num_warps,
+            num_stages,
+            num_sm,
+        )
+
+        return {
+            "block_sizes": block_sizes,
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+            "_grid": cls._launch_grid(env, block_sizes),
+            "_num_sm": num_sm,
+        }
+
+    @classmethod
+    def _fixup(
+        cls, env: CompileEnvironment, mm: KernelMatmulFact, draft: dict[str, Any]
+    ) -> None:
+        """Phase 2: enforce hard budgets on the merged candidate."""
+        block_sizes: list[int] = draft["block_sizes"]
+        draft["num_stages"], draft["num_warps"] = cls._fixup_candidate_resources(
+            env,
+            block_sizes,
+            draft["num_stages"],
+            draft["num_warps"],
+            num_sm=draft["_num_sm"],
+            shrinkable=[bid for bid, _users in mm.knob_users],
+            largest_first=True,
+            max_corrections=64,
+        )
+        draft["_grid"] = cls._launch_grid(env, block_sizes)
+
+    @classmethod
+    def _multi_ranked(cls, env: CompileEnvironment) -> list[Config]:
+        mm = env.config_spec.kernel_matmul_fact
+        if mm is None:
+            return []
+        draft = cls._draft(env, mm)
+        if draft is None:
+            return []
+        cls._fixup(env, mm, draft)
+        primary: dict[str, Any] = {
+            "block_sizes": list(draft["block_sizes"]),
+            "num_warps": draft["num_warps"],
+            "num_stages": draft["num_stages"],
+        }
+        ranked = [Config(**primary)]
+        # One shallower-pipeline alternate, the same neighbour front end 1 plants: stage
+        # depth is the knob whose optimum the budget model resolves least sharply.
+        if draft["num_stages"] > 2:
+            alt = dict(primary)
+            alt["num_stages"] = draft["num_stages"] - 1
+            ranked.append(Config(**alt))
+        return dedupe_configs(ranked)
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        ranked = cls._multi_ranked(env)
+        return ranked[0] if ranked else None
+
+    @classmethod
+    def get_seed_configs(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> list[Config] | None:
+        return cls._multi_ranked(env) or None
 
 
 # Module-level shims delegating to the class (tests + lab harness call these by name).

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -50,6 +50,37 @@ log = logging.getLogger(__name__)
 TensorDescriptorLayoutSignature = tuple[int | None, tuple[bool, ...]]
 
 
+@dataclasses.dataclass(frozen=True)
+class ConfigValueExpression:
+    """Small integer expression whose leaves are emitted config values."""
+
+    operation: str
+    arguments: tuple[int | str | ConfigValueExpression, ...]
+
+    def evaluate(self, config: Config) -> int:
+        def value(arg: int | str | ConfigValueExpression) -> int:
+            if isinstance(arg, ConfigValueExpression):
+                return arg.evaluate(config)
+            if isinstance(arg, str):
+                result = config[arg]
+                if not isinstance(result, int):
+                    raise TypeError(f"config value {arg!r} is not an integer")
+                return result
+            return arg
+
+        args = tuple(value(arg) for arg in self.arguments)
+        if self.operation == "config":
+            assert len(self.arguments) == 1 and isinstance(self.arguments[0], str)
+            return value(self.arguments[0])
+        if self.operation == "cdiv":
+            assert len(args) == 2
+            return (args[0] + args[1] - 1) // args[1]
+        if self.operation == "next_power_of_2":
+            assert len(args) == 1
+            return next_power_of_2(args[0])
+        raise ValueError(f"unknown config expression operation {self.operation!r}")
+
+
 @dataclasses.dataclass
 class TensorDescriptorLayoutGuard:
     ndim: int
@@ -303,6 +334,11 @@ class CompileEnvironment:
             default=None,
         )
         self.cute_resolved_wrapper_plans: list[dict[str, object]] = []
+        # Host integer helpers such as cdiv/next_power_of_2 deliberately return
+        # unbacked SymInts during tracing. Preserve the config expression beside
+        # that symbol so a fixed block size derived from a user tunable can still
+        # be resolved for each candidate configuration.
+        self.config_value_expressions: dict[sympy.Expr, ConfigValueExpression] = {}
         self.block_sizes: list[BlockSizeInfo] = []
         self.debug_shape_renames: dict[sympy.Basic, sympy.Basic] = {}
         self._debug_shape_rename_override: contextvars.ContextVar[

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -54,8 +54,6 @@ from .ast_extension import expr_from_string
 from .ast_read_writes import ReadWrites
 from .compile_environment import CompileEnvironment
 from .host_function import HostFunction
-from .indexing_strategy import subscript_index_scale
-from .indexing_strategy import subscript_tile_info
 from .inductor_lowering import APIFuncLowering
 from .inductor_lowering import CodegenState
 from .inductor_lowering import codegen_call_with_graph
@@ -93,6 +91,7 @@ if TYPE_CHECKING:
     from ..autotuner.config_spec import ConfigSpec
     from ..autotuner.config_spec import MemoryOpFact
     from .cute.layout import CuTeGridExecutionPlan
+    from .device_ir_analysis import DeviceIRAnalysis
 
     class _TLS(Protocol):
         device_irs: list[DeviceIR]
@@ -717,65 +716,6 @@ def _fx_trace_tensor_arg_rw_names(
     return out2
 
 
-def _classify_load_dataflow(
-    load_node: torch.fx.Node, redset: set[int], env: CompileEnvironment
-) -> tuple[set[int], tuple[tuple[int | None, ...], ...]]:
-    """Trace a load's value forward over ``node.users``, cutting at BOTH reductions and
-    stores, and record the sinks it reaches:
-
-    - ``reductions_fed``: the ``redset`` reduction ids the value flows into (recorded,
-      not traversed through — we want where the row goes, not the reduced result).
-    - ``stores_fed``: the stores the value reaches WITHOUT passing through a reduction,
-      each keyed by the store's full subscript-axis tuple (``store[tile_m, tile_n]`` ->
-      ``(id_m, id_n)``). A non-empty set means the row is live across the reduction.
-    """
-    from ..language.memory_ops import store as _store_op
-
-    reductions_fed: set[int] = set()
-    stores_fed: set[tuple[int | None, ...]] = set()
-    seen: set[int] = set()
-    stack = list(load_node.users)
-    while stack:
-        u = stack.pop()
-        if id(u) in redset:
-            reductions_fed.add(id(u))
-            continue  # do not traverse THROUGH the reduction
-        if id(u) in seen:
-            continue
-        seen.add(id(u))
-        if u.op == "call_function" and u.target is _store_op:
-            stores_fed.add(_store_axis_key(env, u))
-            continue  # do not traverse THROUGH the store
-        stack.extend(u.users)
-    # deterministic order (None sorts low); only non-emptiness is consumed today
-    stores_sorted = tuple(
-        sorted(stores_fed, key=lambda t: tuple(-1 if b is None else b for b in t))
-    )
-    return reductions_fed, stores_sorted
-
-
-def _store_axis_key(
-    env: CompileEnvironment, store_node: torch.fx.Node
-) -> tuple[int | None, ...]:
-    """Full subscript-axis key of a store: the block-id each non-bare-int subscript indexes
-    (the faithful subscript provenance, falling back to the shape-resolved id for a plain-slice
-    subscript), one entry per dim. E.g. ``store[tile_m, tile_n]`` -> ``(id_m, id_n)``;
-    ``out[tile_m, :]`` -> ``(id_m, <shape-resolved id>)``."""
-    fake = _accessed_tensor_fake(store_node)
-    index_list = store_node.args[1] if len(store_node.args) >= 2 else None
-    if fake is None or not isinstance(index_list, (list, tuple)):
-        return ()
-    key: list[int | None] = []
-    for pos, sub in enumerate(index_list):
-        if isinstance(sub, int) or pos >= fake.ndim:
-            continue
-        bid = _subscript_block_id(env, sub)
-        if bid is None:
-            bid = env.resolve_block_id(fake.shape[pos])
-        key.append(bid)
-    return tuple(key)
-
-
 def _reduction_fx_inter_loop_rw_names(
     graph: torch.fx.Graph,
     host: HostFunction,
@@ -971,9 +911,9 @@ class DeviceIR:
 
         This is analysis-only: it runs the roller to determine which graphs can
         be rolled, records lightweight RolledReductionInfo entries, and registers
-        config_spec entries for the autotuner.  Sub-graphs created by the roller
-        (e.g. ReductionLoopGraphInfo) are kept so that _collect_memory_op_facts
-        can account for their loads/stores in the indexing config.
+        config_spec entries for the autotuner. Subgraphs created by the roller
+        (e.g. ReductionLoopGraphInfo) are kept so the analysis layer can account
+        for their loads/stores in the indexing config.
         """
         env = CompileEnvironment.current()
         rdims = [bs for bs in env.block_sizes if bs.reduction]
@@ -1129,39 +1069,6 @@ class DeviceIR:
                 )
             )
 
-    def _original_graph_reductions(self) -> list[tuple[int, int]]:
-        """Every reduction OCCURRENCE on the ORIGINAL (pre-roll) device graphs as
-        ``(graph_id, block_id)`` pairs, de-duplicated within a graph (one descriptor per
-        distinct rdim per original graph).
-
-        Rolled ``ReductionLoopGraphInfo`` subgraphs are EXCLUDED: they are copies the roller
-        creates for one config, so their ``graph_id`` is contingent on the autotuner flipping a
-        ``reduction_loops`` knob. The original graphs carry the faithful co-residency structure
-        (PROMPT §2.2 / §2.7): two distinct rdims sharing an original graph were fused by the
-        compiler -> co-resident; the same rdim in two original graphs is two sequential passes
-        (jsd's two V-reductions). Verified against the IR (``_lab/redesign/ir_*.json``): rolled
-        subgraphs are exactly ``ReductionLoopGraphInfo``.
-        """
-        from .inductor_lowering import ReductionLowering
-
-        seen: set[tuple[int, int]] = set()
-        out: list[tuple[int, int]] = []
-        for gi in self.graphs:
-            if isinstance(gi, ReductionLoopGraphInfo):
-                continue
-            for node in gi.graph.nodes:
-                lowering = node.meta.get("lowering")
-                if not isinstance(lowering, ReductionLowering):
-                    continue
-                bid = getattr(lowering, "block_index", None)
-                if bid is None:
-                    continue
-                key = (gi.graph_id, bid)
-                if key not in seen:
-                    seen.add(key)
-                    out.append(key)
-        return out
-
     def _categorize_reduction(
         self, block_id: int, grid_ids: set[int]
     ) -> ReductionCategory:
@@ -1207,134 +1114,11 @@ class DeviceIR:
             )
         return ReductionCategory.FULL_SLICE
 
-    def _group_live_tiles(
-        self, group_gids: list[int], env: CompileEnvironment
-    ) -> dict[int, list[tuple[int | None, ...]]]:
-        """Attribute the resident tile set to each co-residency group. Returns ``{group_gid:
-        [dim_block_ids, ...]}`` — the peak live set (``_graph_peak_live_tiles``) of the group's home
-        graph, combined with the for-loop bodies the group drives. Four attribution rules:
-
-        1. **Descend driven for-loop bodies to the ancestor group.** The heavy tiles often live in a
-           for-loop body the group's home graph drives (via a ``loop->child`` edge), not in the thin
-           home graph itself. A loop body is owned by the group whose reduction loops over its axis
-           (the loop's ``block_ids`` intersect the group's reduction axes).
-
-        2. **Skip ``ReductionLoopGraphInfo`` copies.** The roller's per-config duplicates carry a
-           strict subset of the original graph's pre-roll body, so the original graph the group is
-           keyed on already holds the peak.
-
-        3. **Do not cross ``_if`` edges.** If/Else branch subtrees are their own groups or mutually
-           exclusive with a sibling; a parent group never absorbs a branch's tiles. Branches combine
-           via rule 4's max, not by summing into an ancestor.
-
-        4. **Combine a group's owned graphs by max-by-profile, never sum.** Co-resident reductions
-           share one original graph by construction, so their simultaneous residency is already
-           inside that graph's peak snapshot. A group's other owned graphs are only ever nested
-           (home + driven body) or If/Else siblings (max picks the populated branch), never
-           simultaneously-additively resident, so max is both faithful and conservative.
-        """
-        from .inductor_lowering import ReductionLowering
-
-        def reds_in(gid: int) -> set[int]:
-            out: set[int] = set()
-            for node in self.graphs[gid].graph.nodes:
-                low = node.meta.get("lowering")
-                if isinstance(low, ReductionLowering) and isinstance(
-                    getattr(low, "block_index", None), int
-                ):
-                    out.add(low.block_index)
-            return out
-
-        # A group is keyed on its home (original) graph_id; its reduction axes come from that graph.
-        group_axes = {gid: reds_in(gid) for gid in group_gids}
-
-        # Peak live-tile snapshot per graph (skip rolled copies — rule 2).
-        peak_of: dict[int, list[tuple[int | None, ...]]] = {}
-        for gi in self.graphs:
-            if isinstance(gi, ReductionLoopGraphInfo):
-                continue
-            peak_of[gi.graph_id] = _graph_peak_live_tiles(gi.graph, env)
-
-        # For-loop child edges (loop->body), keyed by the loop's block_ids (rule 1). ``_if`` edges are
-        # deliberately NOT followed (rule 3) — see the helper.
-        child_loops = self._forloop_child_edges()
-
-        def max_by_profile(
-            a: list[tuple[int | None, ...]], b: list[tuple[int | None, ...]]
-        ) -> list[tuple[int | None, ...]]:
-            mr = max(
-                (_tile_rank(t) for t in a + b),
-                default=0,
-            )
-            ka = _tile_set_rank_profile(a, mr)
-            kb = _tile_set_rank_profile(b, mr)
-            return a if ka >= kb else b
-
-        group_key_set = set(group_gids)
-        result: dict[int, list[tuple[int | None, ...]]] = {}
-        for gid in group_gids:
-            axes = group_axes[gid]
-            tiles = list(peak_of.get(gid, []))
-            # Descend, transitively, the for-loop bodies this group drives (rule 1): a body whose
-            # loop axis is one of the group's reduction axes. Combine each by max-by-profile. Stop
-            # at any body that is itself another group's home (its own sequential group) and never
-            # cross ``_if`` (branch subtrees are handled by their own group keys — rule 3). A BFS so
-            # a home -> loop -> loop chain is fully covered, not just one level. ``not axes`` cannot
-            # happen for a real group key (its home graph holds >=1 reduction lowering).
-            seen_bodies: set[int] = {gid}
-            frontier = [gid]
-            while frontier:
-                cur = frontier.pop()
-                for body_gid, blk in child_loops.get(cur, []):
-                    if body_gid in seen_bodies or body_gid in group_key_set:
-                        continue
-                    if not axes or (blk & axes):
-                        seen_bodies.add(body_gid)
-                        tiles = max_by_profile(tiles, peak_of.get(body_gid, []))
-                        frontier.append(body_gid)
-            result[gid] = tiles
-        return result
-
-    def _forloop_child_edges(self) -> dict[int, list[tuple[int, frozenset[int]]]]:
-        """The for-loop child-edge map for ``_group_live_tiles`` rule 1: for each non-rolled graph,
-        the ``(body_graph_id, frozenset(body_block_ids))`` of every for-loop it drives. Keyed by the
-        parent graph_id; ``child_loops[gid] = [(body_gid, block_ids), ...]``.
-
-        A pure node scan over ``self.graphs`` (the SAME scan the CF walker uses): follows only
-        ``is_for_loop_target`` call_functions whose first arg is the body graph id. ``_if`` edges are
-        deliberately NOT collected (rule 3 — branch subtrees are their own groups). Rolled
-        (``ReductionLoopGraphInfo``) parents and bodies are skipped (rule 2)."""
-        n = len(self.graphs)
-        child_loops: dict[int, list[tuple[int, frozenset[int]]]] = {}
-        for gi in self.graphs:
-            if isinstance(gi, ReductionLoopGraphInfo):
-                continue
-            edges: list[tuple[int, frozenset[int]]] = []
-            for node in gi.graph.nodes:
-                if node.op != "call_function":
-                    continue
-                if (
-                    _tracing_ops.is_for_loop_target(node.target)
-                    and node.args
-                    and isinstance(node.args[0], int)
-                ):
-                    body_gid = node.args[0]
-                    if 0 <= body_gid < n and not isinstance(
-                        self.graphs[body_gid], ReductionLoopGraphInfo
-                    ):
-                        blk = frozenset(
-                            getattr(self.graphs[body_gid], "block_ids", []) or []
-                        )
-                        edges.append((body_gid, blk))
-            if edges:
-                child_loops[gi.graph_id] = edges
-        return child_loops
-
     def build_reduction_kernel_fact(
         self,
         memory_op_facts: list[MemoryOpFact],
         accumulator_facts: list[AccumulatorFact],
-        liveness_by_axis: dict[int, int] | None = None,
+        analysis: DeviceIRAnalysis,
     ) -> None:
         """Build the categorizing ``ReductionKernelFact`` — the list of reduction descriptors +
         their ``graph_id`` co-residency groups + the non-reduction loops + the parallel grid axes.
@@ -1342,10 +1126,9 @@ class DeviceIR:
         """
         env = CompileEnvironment.current()
         spec = env.config_spec
-        liveness_by_axis = liveness_by_axis or {}
         grid_ids = {b for bids in self.grid_block_ids for b in bids}
 
-        occurrences = self._original_graph_reductions()
+        occurrences = analysis.original_reductions()
         # carried-2D tiles: count of accumulators whose last dim is the rdim (per block_id,
         # kernel-wide -- an accumulator is carried across the whole inner loop, so it is not
         # graph-scoped). A count (not a bool) is load-bearing: the carried byte cap divides the
@@ -1364,16 +1147,14 @@ class DeviceIR:
             size_hint = (
                 info.size_hint() if isinstance(info.size, (int, torch.SymInt)) else 0
             )
-            per = self._per_reduction_memory_fields(
-                bid, gid, memory_op_facts, liveness_by_axis
-            )
+            per = self._per_reduction_memory_fields(bid, gid, memory_op_facts)
             descriptors.append(
                 ReductionDescriptor(
                     category=category,
                     block_id=bid,
                     graph_id=gid,
                     size_hint=size_hint,
-                    itemsize=self._reduction_input_itemsize(bid),
+                    itemsize=analysis.reduction_input_itemsize(bid),
                     input_load_itemsize=per["input_load_itemsize"],
                     carried_2d_count=carried_2d_by_bid.get(bid, 0),
                     row_reread=per["row_reread"],
@@ -1393,17 +1174,11 @@ class DeviceIR:
         # driven-loop-bodies, max'd across If/Else. Consumed by the Stage-2 footprint (which sums
         # ∏(dims) per actual tile).
         #
-        # The try/except is NECESSARY: ``_group_live_tiles`` walks the graphs through ``env`` (block
-        # id resolution in ``_graph_peak_live_tiles``), which a bare-spec unit test builds the fact
-        # WITHOUT -> the walk raises before producing tiles. The fallback degrades to empty tiles
-        # (the Stage-2 allocator then falls back to its extent-based footprint), so a missing env
-        # yields a valid-but-coarser fact rather than a crash. Trade-off to be aware of: the broad
-        # catch also swallows a genuine graph-structure bug INSIDE the walk as a silent empty-tiles
-        # perf regression (not a crash) — acceptable because the walk is best-effort attribution, but
-        # if this ever needs tightening, catch ``NoCurrentEnvironment`` specifically (the real no-env
-        # trigger) rather than the broad trio.
+        # Preserve the legacy best-effort fallback: incomplete graph metadata
+        # yields an extent-based footprint rather than failing fact construction.
+        # The focused reduction corpus keeps this liveness-derived field pinned.
         try:
-            group_live = self._group_live_tiles(sorted(groups_by_gid), env)
+            group_live = analysis.group_live_tiles(sorted(groups_by_gid))
         except (KeyError, AttributeError, TypeError):
             group_live = {}
         coresidency_groups = tuple(
@@ -1441,7 +1216,6 @@ class DeviceIR:
         red_block_id: int,
         graph_id: int,
         memory_op_facts: list[MemoryOpFact],
-        liveness_by_axis: dict[int, int],
     ) -> dict:
         """The memory-op-derived per-reduction fields, computed exactly as
         ``_assemble_reduction_fact`` does (so a descriptor is field-equal to the legacy fact),
@@ -1492,6 +1266,14 @@ class DeviceIR:
             "reread_eviction_index": reread_eviction_index,
             "input_load_itemsize": input_load_itemsize,
         }
+
+    def build_kernel_matmul_fact(self, analysis: DeviceIRAnalysis) -> None:
+        """Install the contraction fact derived by the analysis layer."""
+        env = CompileEnvironment.current()
+        env.config_spec.kernel_matmul_fact = analysis.kernel_matmul_fact(
+            env,
+            env.config_spec,
+        )
 
     def build_matmul_reduction_epilogue_facts(self) -> None:
         """Phase 4: compose a ``MatmulWithReductionEpilogueFact`` for a fused matmul +
@@ -1550,338 +1332,19 @@ class DeviceIR:
             )
         )
 
-    def build_pointwise_facts(self) -> None:
-        """Phase 5: record one ``PointwiseElementwiseFact`` for a PURE elementwise kernel.
-        Disjointness rule: if any reduction / matmul / accumulator fact fired, the kernel belongs
-        to that family and gets NO pointwise fact (the fact's meaning IS their absence). Derived
-        from the walker ``memory_op_facts`` + block-size specs, plus one graph walk for the widest
-        compute dtype and the SFU op count. Runs last, after the other facts exist."""
-        env = CompileEnvironment.current()
-        spec = env.config_spec
-        from ..autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
-        from ..autotuner.config_spec import PointwiseElementwiseFact
-        from ..language import memory_ops
-        from ..language.atomic_ops import ATOMIC_OPS
-        from ..language.inline_asm_ops import inline_asm_elementwise
-        from ..language.inline_triton_ops import inline_triton
-        from ..language.inline_triton_ops import triton_kernel
-        from ..language.reduce_ops import _reduce
-        from ..language.scan_ops import _associative_scan
+    def build_pointwise_facts(self, analysis: DeviceIRAnalysis) -> None:
+        """Install the pure-elementwise fact derived by the analysis layer."""
+        spec = CompileEnvironment.current().config_spec
+        fact = analysis.pointwise_fact(spec)
+        if fact is not None:
+            spec.pointwise_facts.append(fact)
 
-        # Disjointness: a kernel with any SIZED reduction (the Stage-1 kernel fact's
-        # FULL_SLICE/FULL_GRID/USER_TILE descriptors — the faithful successor to a non-empty
-        # ``reduction_facts`` list), any matmul, or any loop-carried accumulator belongs to that
-        # family and gets NO pointwise fact.
-        kf = spec.reduction_kernel_fact
-        has_sized_reduction = kf is not None and any(
-            d.category in SIZED_REDUCTION_CATEGORIES for d in kf.reductions
-        )
-        if has_sized_reduction or spec.matmul_facts or spec.accumulator_facts:
-            return
-        if not spec.memory_op_facts or not spec.block_sizes:
-            return
-        # Ops whose result is NOT an embarrassingly-parallel function of the tile, so the pointwise
-        # seed's core assumption (any tiling is equally correct) does not hold:
-        #  - a scan/reduce HOP carries a cross-element dependency along the tiled axis (shrinking it
-        #    splits the op);
-        #  - an opaque triton/asm body cannot be traced to prove tile-independence;
-        #  - an atomic is cross-program communication, not the bandwidth-bound elementwise workload
-        #    this seed models and was tuned on (and order-sensitive ones like cas/xchg additionally
-        #    shift with the tile). Exclude the whole atomic family rather than draw a fragile
-        #    commutativity line.
-        # None of these produce a reduction/matmul/accumulator fact, so without this guard they would
-        # fall through to a promoted large tile and silently change results. Exclude them like the
-        # other non-pointwise families above. (``_associative_scan`` is the single HOP that
-        # associative_scan/cumsum/cumprod all lower to.)
-        _unsafe_pointwise_ops = frozenset(
-            {
-                _associative_scan,
-                _reduce,
-                inline_triton,
-                triton_kernel,
-                inline_asm_elementwise,
-                *ATOMIC_OPS,
-            }
-        )
-        # The static problem element count = product of the tiled block dims' size_hints (the
-        # per-dim extents the seed needs for the tile distribution are read live off block_sizes).
-        total_numel = 1
-        for block_size in spec.block_sizes:
-            total_numel *= block_size.size_hint
-        # Guard a 0-extent (empty) problem: a 0 hint would make the slab fold below divide by zero.
-        total_numel = max(1, total_numel)
-        # Widest COMPUTE dtype (register-resident width): a memory op knows only its STORAGE dtype,
-        # but the math promotes to fp32, which sets register pressure. Max itemsize over every
-        # tensor-valued node in one graph walk (a hl.split val is a tuple of tensors, so recurse).
-
-        def _val_itemsizes(val: object) -> list[int]:
-            if isinstance(val, torch.Tensor):
-                return [val.dtype.itemsize]
-            if isinstance(val, (list, tuple)):
-                return [s for v in val for s in _val_itemsizes(v)]
-            return []
-
-        # The node set ``compute_itemsize`` may measure: DATA, excluding ADDRESSES.
-        #
-        # A load/store's index arguments are tensor-valued too, and index arithmetic is
-        # int64 once a tensor crosses the int32 indexing threshold -- so a plain bf16
-        # kernel reported width 8 purely because its tensors got large, halving ``reg_cap``
-        # on exactly the shapes that least want a smaller tile. The split is data vs
-        # address, NOT float vs integer: filtering to floats would leave a genuine
-        # int-compute kernel at the ``1`` initializer, over-estimating ``reg_cap`` instead.
-        # No cheaper proxy works -- a tile index is both a legal address and legal data, so
-        # dtype, node metadata and lowering class all fail to separate them.
-        #
-        # Walk BACKWARD from each store's value / mask, CUTTING at load nodes: a load is
-        # itself data, but its own index arithmetic is reachable backward through it. The
-        # cut also excludes a gather's loaded index, so this under-counts that case's true
-        # register pressure. One reverse-order pass suffices since FX order is topological.
-        #
-        # If nothing tensor-valued is reachable (a store of a bare scalar, or no store),
-        # fall back to the accessed buffer dtypes rather than the ``1`` initializer -- and
-        # only then, so a successful walk is never widened.
-        def _data_path_nodes() -> tuple[set[int], int]:
-            data: set[int] = set()
-            buffer_width = 1
-            for graph_info in self.graphs:
-                for node in reversed(list(graph_info.graph.nodes)):
-                    if node.op != "call_function":
-                        continue
-                    is_load = node.target is memory_ops.load
-                    if is_load or node.target is memory_ops.store:
-                        # Seed the data side: a store's value (arg 2) and either op's
-                        # extra_mask (store arg 3 / load arg 2).
-                        for pos in (2, 3) if not is_load else (2,):
-                            if len(node.args) > pos and isinstance(
-                                node.args[pos], torch.fx.Node
-                            ):
-                                data.add(id(node.args[pos]))
-                        accessed = _accessed_tensor_fake(node)
-                        if accessed is not None:
-                            buffer_width = max(buffer_width, accessed.dtype.itemsize)
-                        if is_load:
-                            continue  # CUT: args[1] is the ADDRESS, never an input
-                    if id(node) in data:
-                        data.update(id(arg) for arg in node.all_input_nodes)
-            return data, buffer_width
-
-        data_path_nodes, data_path_buffer_width = _data_path_nodes()
-
-        # SFU (transcendental) op count — the num_warps signal, counted in the same graph walk. SFU
-        # ops run on a distinct, low-throughput unit (~4 SFUs vs ~128 FP32 lanes/SM), so a
-        # transcendental-heavy tile is latency-bound and wants more warps; an all-FMA tile of the same
-        # op count is not. That is why SFU count, not total op count, is the key.
-        _SFU_OPS = frozenset(
-            {
-                "sin",
-                "cos",
-                "tan",
-                "tanh",
-                "asin",
-                "acos",
-                "atan",
-                "sinh",
-                "cosh",
-                "atanh",
-                "asinh",
-                "acosh",
-                "exp",
-                "exp2",
-                "expm1",
-                "log",
-                "log2",
-                "log10",
-                "log1p",
-                "sqrt",
-                "rsqrt",
-                "sigmoid",
-                "erf",
-                "erfc",
-                "pow",
-                "reciprocal",
-            }
-        )
-        compute_itemsize = 1
-        sfu_ops = 0
-        for graph_info in self.graphs:
-            for node in graph_info.graph.nodes:
-                # Data path only -- see ``_data_path_nodes``.
-                if id(node) in data_path_nodes:
-                    for size in _val_itemsizes(node.meta.get("val")):
-                        compute_itemsize = max(compute_itemsize, size)
-                if node.op == "call_function":
-                    if node.target in _unsafe_pointwise_ops:
-                        # Not tile-independent (see the set's comment above). Record no fact so the
-                        # seed does not fire and the base default (bs=32) is kept — the same no-fire
-                        # path the reduction/matmul/accumulator families take at the disjointness
-                        # gate above.
-                        return
-                    base = getattr(node.target, "__name__", str(node.target)).split(
-                        "."
-                    )[0]
-                    if base in _SFU_OPS:
-                        sfu_ops += 1
-        # Nothing tensor-valued reachable -> the buffer widths, never the 1 initializer.
-        if compute_itemsize == 1:
-            compute_itemsize = max(1, data_path_buffer_width)
-
-        # slab_numel = sum over FULL-EXTENT load/store ops (accessed_numel >= total_numel) of the
-        # untiled elements each drags per tiled element, accessed_numel // total_numel. Flat kernel:
-        # every quotient is 1 (slab_numel = op count); rope: heads*head_dim. The seed scales it by
-        # storage_itemsize (max storage width) for bandwidth and compute_itemsize (fp32) for registers.
-        # A BROADCAST operand (bias[N], [M,1], stride-0) has accessed_numel < total_numel → excluded.
-        # contig = TILED block-ids that are the stride-1 axis of some full-extent op (from each op's
-        # subscript_strides, no graph walk): a coalesced tile must give width to a stride-1 axis. Row-
-        # major → the last block dim (byte-identical); transposed/strided → a different dim (or >1, a
-        # load-vs-store conflict) that the seed roots the wide tile on instead of pinning to width 1.
-        tiled_ids = {bs.block_id for bs in spec.block_sizes}
-        contig: set[int] = set()
-        slab_numel = 0
-        max_op_slab_numel = 1
-        storage_itemsize = 1
-        gather_stride = 1
-        for memfact in spec.memory_op_facts:
-            if memfact.dtype is None or memfact.accessed_numel < total_numel:
-                continue
-            slab_numel += memfact.accessed_numel // total_numel
-            # The widest tile any ONE op materializes, per tiled element -- the same per-op
-            # quantity ``slab_numel`` sums, kept as a MAX because bytes add across ops but
-            # lanes do not (see ``PointwiseElementwiseFact``).
-            #
-            # Computed from the SUBSCRIPTS, not ``accessed_numel // total_numel``: that is a
-            # per-tensor ratio, so it also counts an op whose tensor is merely wider than
-            # the problem, overstating lanes. Product of extents at positions that are not
-            # a tiled axis; a tiled position contributes its block size, which the consumer
-            # supplies by scaling. Keyed on ``subscript_affine_block_ids`` so a scaled
-            # subscript counts as tiled rather than as fan-out.
-            op_slab = 1
-            for bid, extent in zip(
-                memfact.subscript_affine_block_ids,
-                memfact.subscript_extents,
-                strict=True,
-            ):
-                if bid is None or bid not in tiled_ids:
-                    op_slab *= max(1, extent)
-            max_op_slab_numel = max(max_op_slab_numel, op_slab)
-            storage_itemsize = max(storage_itemsize, memfact.dtype.itemsize)
-            for bid, stride in zip(
-                memfact.subscript_block_ids, memfact.subscript_strides, strict=True
-            ):
-                if bid is not None and stride == 1 and bid in tiled_ids:
-                    contig.add(bid)
-            # Widest address-expression scale on a tiled axis whose LAYOUT stride is 1 --
-            # gated there because that is where the sector-waste argument holds; a
-            # layout-strided fetch is already non-contiguous for other reasons. Keyed on
-            # ``subscript_affine_block_ids``, which resolves the axis through the scale.
-            for bid, scale, stride in zip(
-                memfact.subscript_affine_block_ids,
-                memfact.subscript_index_scales,
-                memfact.subscript_strides,
-                strict=True,
-            ):
-                if bid is not None and bid in tiled_ids and stride == 1:
-                    gather_stride = max(gather_stride, scale)
-        spec.pointwise_facts.append(
-            PointwiseElementwiseFact(
-                total_numel=total_numel,
-                slab_numel=slab_numel,
-                storage_itemsize=storage_itemsize,
-                compute_itemsize=compute_itemsize,
-                contig_block_ids=tuple(sorted(contig)),
-                sfu_ops=sfu_ops,
-                gather_stride=gather_stride,
-                max_op_slab_numel=max_op_slab_numel,
-            )
-        )
-
-    def build_accumulator_facts(self) -> list[AccumulatorFact]:
-        """One ``AccumulatorFact`` per loop-carried tensor accumulator in any loop —
-        reduction-AGNOSTIC, so it is built independently of (and before) the reduction
-        facts: a standalone fact layer any heuristic can read off
-        ``ConfigSpec.accumulator_facts``. Run unconditionally (matmul/elementwise kernels
-        simply get a list with no rdim-shaped tile). ``ReductionLoopGraphInfo`` is a
-        ``ForLoopGraphInfo`` subclass, so this also reaches standard's rolled loops (whose
-        ``[M_BLOCK]`` scalar carry yields ``num_carried_2d_tiles == 0`` naturally). Must
-        run after the reduction rolling so the rolled subgraphs exist.
-        """
-        from ..autotuner.config_spec import AccumulatorFact
-
-        facts: list[AccumulatorFact] = []
-        for gi in self.graphs:
-            if not isinstance(gi, ForLoopGraphInfo):
-                continue
-            for outer_node in gi.node_args:
-                val = getattr(outer_node, "meta", {}).get("val")
-                if isinstance(val, torch.Tensor):
-                    facts.append(
-                        AccumulatorFact(
-                            dim_block_ids=tuple(
-                                self._resolve_accumulator_dim_block_id(s)
-                                for s in val.shape
-                            ),
-                            itemsize=val.element_size(),
-                        )
-                    )
-        return facts
-
-    def _resolve_accumulator_dim_block_id(self, size: object) -> int | None:
-        """Resolve an accumulator dim to its block id, recovering the non-pow2 padded
-        case ``resolve_block_id`` misses. A grad-parameter buffer is padded to the
-        next power of two, so its extent matches neither the block's registered size
-        nor any block-size origin and ``resolve_block_id`` returns ``None``. Fall back
-        to matching the padded extent against a reduction block whose
-        ``next_power_of_2(size_hint)`` equals it -- but ONLY when UNIQUE. Two axes
-        padding to the same extent are indistinguishable, so DECLINE (return ``None``)
-        rather than mis-assign an identity the ``num_carried_2d_tiles`` and
-        ``per_feature_accumulator`` consumers would read.
-        """
-        from .._utils import next_power_of_2
-
-        env = CompileEnvironment.current()
-        block_id = env.resolve_block_id(size)
-        if block_id is not None:
-            return block_id
-        extent = env.size_hint(cast("int | torch.SymInt", size))
-        matches = [
-            info.block_id
-            for info in env.block_sizes
-            if info.reduction and next_power_of_2(info.size_hint()) == extent
-        ]
-        if len(matches) == 1:
-            return matches[0]
-        if len(matches) > 1:
-            log.warning(
-                "accumulator dim (padded extent %s) matches %d reduction axes %s; cannot "
-                "differentiate by extent -- left unresolved (per_feature_accumulator may miss it)",
-                extent,
-                len(matches),
-                matches,
-            )
-        return None
-
-    def _reduction_input_itemsize(self, red_block_id: int) -> int:
-        """Element size (bytes) of the tensor reduced over ``red_block_id`` — read from the
-        reduction node's INPUT (not its ``meta['val']`` output, which may differ in dtype,
-        e.g. argmax). Helion fp32-promotes the norm/softmax family, so this is 4 at both
-        bf16 and fp32 there. All reductions over one rdim share an input element size (last
-        wins). The byte caps key on ``size_hint * itemsize``.
-        """
-        from .inductor_lowering import ReductionLowering
-
-        itemsize = 0
-        for graph_info in self.graphs:
-            for node in graph_info.graph.nodes:
-                lowering = node.meta.get("lowering")
-                if (
-                    isinstance(lowering, ReductionLowering)
-                    and getattr(lowering, "block_index", None) == red_block_id
-                ):
-                    for inp in node.all_input_nodes:
-                        in_val = inp.meta.get("val")
-                        if isinstance(in_val, torch.Tensor):
-                            itemsize = in_val.element_size()
-                            break
-        return itemsize
+    def build_accumulator_facts(
+        self,
+        analysis: DeviceIRAnalysis,
+    ) -> list[AccumulatorFact]:
+        """Return loop-carried accumulator facts derived by the analysis layer."""
+        return analysis.accumulator_facts(CompileEnvironment.current())
 
     def _is_fully_resident_grid_axis(self, block_id: int) -> bool:
         """True iff a grid axis is tiled at its FULL extent (``block_size == extent`` =>
@@ -3187,392 +2650,6 @@ class WalkHostAST(NodeVisitor):
             self.current_phase_roots = []
 
 
-# Matmul/dot FX targets mapped to (lhs_arg_index, rhs_arg_index). Used to tag
-# which load nodes feed a matmul (and as which operand) at the recognition site,
-# instead of scanning every load's downstream users.
-def _matmul_operand_positions() -> dict[object, tuple[int, int]]:
-    from ..language import matmul_ops
-
-    return {
-        # mat1=0, mat1_scale=1, mat1_format=2, mat2=3 -> lhs/rhs matrices are 0/3
-        matmul_ops.dot_scaled: (0, 3),
-        matmul_ops.dot: (0, 1),
-        torch.ops.aten.mm.default: (0, 1),
-        torch.ops.aten.bmm.default: (0, 1),
-        torch.ops.aten.addmm.default: (1, 2),
-        torch.ops.aten.baddbmm.default: (1, 2),
-    }
-
-
-def _trace_back_to_load(arg: object, load_op: object) -> torch.fx.Node | None:
-    """Follow a matmul operand back through pass-through ops to its load node.
-
-    Only follows single-input pass-through ops (cast / transpose / view / unary
-    elementwise), so an operand that is a genuine computation of two loads (e.g.
-    ``a[...] + bias[...]``) is left untagged rather than mis-attributed to its
-    first input. Returns the producing ``hl.load`` node, or ``None``.
-    """
-    cur = arg
-    for _ in range(8):
-        if not isinstance(cur, torch.fx.Node):
-            return None
-        if cur.target is load_op:
-            return cur
-        tensor_inputs = [
-            a
-            for a in cur.args
-            if isinstance(a, torch.fx.Node)
-            and isinstance(a.meta.get("val"), torch.Tensor)
-        ]
-        if len(tensor_inputs) != 1:
-            return None
-        cur = tensor_inputs[0]
-    return None
-
-
-def _load_needs_eviction_tunable(node: torch.fx.Node) -> bool:
-    """A load gets an eviction-policy slot only when the user did not pass one."""
-    eviction_policy_arg = node.kwargs.get("eviction_policy")
-    if eviction_policy_arg is None and len(node.args) >= 4:
-        eviction_policy_arg = node.args[3]
-    return eviction_policy_arg is None
-
-
-def _accessed_tensor_fake(node: torch.fx.Node) -> torch.Tensor | None:
-    """Fake tensor of the buffer a load/store accesses (``args[0]``)."""
-    arg = node.args[0] if node.args else None
-    if isinstance(arg, torch.fx.Node):
-        val = arg.meta.get("val")
-        if isinstance(val, torch.Tensor):
-            return val
-    return None
-
-
-def _subscript_block_id(env: CompileEnvironment, sub: object) -> int | None:
-    """Return the block axis indexed by a tile-provenance subscript."""
-    info = subscript_tile_info(env, sub)
-    return info.block_id if info is not None else None
-
-
-def _tile_rank(dims: tuple[int | None, ...]) -> int:
-    """The number of BLOCK dims a tile spans (``None`` static/broadcast dims do not count) — the
-    block-size-free proxy for tile bytes used by the lexicographic peak selector."""
-    return sum(1 for d in dims if d is not None)
-
-
-def _tile_set_rank_profile(
-    tiles: list[tuple[int | None, ...]], max_rank: int
-) -> tuple[int, ...]:
-    """A tile set's RANK PROFILE as a lexicographic key over ABSOLUTE ranks, HIGHEST rank first:
-    index 0 is the count of rank-``max_rank`` tiles, ..., last is the count of rank-1 tiles. More
-    top-rank tiles wins; equal-top-rank falls through to the next rank down. Fixed length so the
-    same rank aligns when comparing two tile sets (a per-set-length key would compare one set's
-    rank-2 count against another's rank-1 count and mis-rank a scalar swarm as the winner)."""
-    by_rank: dict[int, int] = {}
-    for t in tiles:
-        r = _tile_rank(t)
-        if r:
-            by_rank[r] = by_rank.get(r, 0) + 1
-    return tuple(by_rank.get(k, 0) for k in range(max_rank, 0, -1))
-
-
-def _graph_peak_live_by_axis(
-    graph: torch.fx.Graph, env: CompileEnvironment
-) -> dict[int, int]:
-    """Peak count of simultaneously-live tensor values whose shape spans each
-    block-id axis, over ONE graph -- a liveness sweep in FX topo order.
-    Consumer-AGNOSTIC per-axis provenance keyed by block_id; a consumer reads its
-    own axis slice.
-
-    A value is live from definition through its last use in the graph. At each
-    step the sweep counts live values whose ``meta['val'].shape`` includes an axis
-    and tracks the per-axis peak. A CONSERVATIVE over-count of register pressure
-    (no remat / reuse beyond last-use modeled), so a heavy body is never
-    under-counted into an unsafe persistent spill.
-    """
-    nodes = list(graph.nodes)
-    last_use: dict[torch.fx.Node, int] = {}
-    for i, node in enumerate(nodes):
-        for inp in node.all_input_nodes:
-            last_use[inp] = i
-    axes_of: dict[torch.fx.Node, frozenset[int]] = {}
-    for node in nodes:
-        val = node.meta.get("val")
-        if isinstance(val, torch.Tensor):
-            axes = {
-                bid for s in val.shape if (bid := env.resolve_block_id(s)) is not None
-            }
-            if axes:
-                axes_of[node] = frozenset(axes)
-    peak: dict[int, int] = {}
-    live: set[torch.fx.Node] = set()
-    for i, node in enumerate(nodes):
-        if node in axes_of:
-            live.add(node)
-        per_axis: dict[int, int] = {}
-        for v in live:
-            for a in axes_of[v]:
-                per_axis[a] = per_axis.get(a, 0) + 1
-        for a, c in per_axis.items():
-            if c > peak.get(a, 0):
-                peak[a] = c
-        live = {v for v in live if last_use.get(v, -1) > i}
-    return peak
-
-
-def _graph_peak_live_tiles(
-    graph: torch.fx.Graph, env: CompileEnvironment
-) -> list[tuple[int | None, ...]]:
-    """The per-tile shapes of the simultaneously-live tensors at the graph's peak-live step.
-
-    Each live tile is recorded as its ``dim_block_ids`` tuple (one entry per shape dim: the block
-    id it spans, or ``None`` for a non-block/constant dim), the same representation as
-    ``AccumulatorFact.dim_block_ids``, so a footprint can sum ``∏(dims)`` per actual tile shape
-    rather than assuming every live tile is full-rank over all axes.
-
-    Which step is "peak"? Register/SRAM pressure is maximized at the step holding the most bytes,
-    but tile bytes depend on the not-yet-chosen block sizes. Rank is the block-size-free proxy for
-    "big": a rank-2 ``[m, r]`` tile is ``m_block × r_block`` elements vs ``m_block`` for a rank-1
-    ``[m]``, so one higher-rank tile outweighs any number of lower-rank tiles. We pick the step
-    whose live set is lexicographically greatest by rank profile — the tuple ``(#rank-D tiles,
-    #rank-(D-1) tiles, ..., #rank-1 tiles)`` compared most-dims-first — so a step with one ``[m, r]``
-    beats a step with many scalar ``[m]`` carries. Maximizing the top-rank count first captures the
-    most heavy R-scaling tiles (the term that prevents spills); lower-rank ties break to more
-    next-heaviest, then to the first such step.
-
-    Returns the actual co-resident live set at that one real step (never a per-shape union across
-    steps, which would stitch together shapes that never coexist). The "1 higher-rank beats any
-    number of lower-rank" tie-rule is not byte-exact in a pathological extreme (hundreds of rank-n
-    tiles vs one rank-(n+1)), but a higher-rank tile contains a lower-rank one as a factor and the
-    miss errs toward a slightly larger R (bounded by the persistence/chunk math) — a stated
-    heuristic, not a random choice.
-    """
-    nodes = list(graph.nodes)
-    last_use: dict[torch.fx.Node, int] = {}
-    for i, node in enumerate(nodes):
-        for inp in node.all_input_nodes:
-            last_use[inp] = i
-    shape_of: dict[torch.fx.Node, tuple[int | None, ...]] = {}
-    for node in nodes:
-        val = node.meta.get("val")
-        if isinstance(val, torch.Tensor) and val.shape:
-            dims = tuple(env.resolve_block_id(s) for s in val.shape)
-            # only tiles that span at least one block axis are register-resident reduction tiles
-            if any(d is not None for d in dims):
-                shape_of[node] = dims
-
-    # Graph-wide max rank -> a FIXED-length, absolute-rank-indexed profile so the lexicographic
-    # comparison aligns the same rank across steps (a per-step-length key would compare a step's
-    # rank-2 count against another's rank-1 count and mis-rank the scalar swarm as the winner).
-    max_rank = max((_tile_rank(d) for d in shape_of.values()), default=0)
-
-    best_key: tuple[int, ...] = ()
-    best_tiles: list[tuple[int | None, ...]] = []
-    live: set[torch.fx.Node] = set()
-    for i, node in enumerate(nodes):
-        if node in shape_of:
-            live.add(node)
-        cur = [shape_of[v] for v in live]
-        key = _tile_set_rank_profile(cur, max_rank)
-        if key > best_key:
-            best_key = key
-            best_tiles = cur
-        live = {v for v in live if last_use.get(v, -1) > i}
-    return best_tiles
-
-
-def _collect_memory_op_facts(
-    device_ir: DeviceIR,
-) -> tuple[list[MemoryOpFact], dict[int, int]]:
-    """Walk every device graph once and record per-load/store metadata.
-
-    Produces one ``MemoryOpFact`` per load/store in the order used to size
-    ``Config.indexing``, so ``memory_op_facts[i]`` describes ``config.indexing[i]``.
-    Single source of truth for load/store counts, eviction slots, and
-    ``store_indices`` (all derived from the result).
-
-    Per-op enrichment fields (``reductions_fed``/``stores_fed``/
-    ``indexed_block_ids``/``inner_extent``/``graph_id``) are computed here so the
-    reduction-fact builders need no bespoke walk. ``reductions_fed`` runs
-    ``_classify_load_dataflow`` once over ALL reduction axes, grouped by axis.
-
-    Returns ``(memory_op_facts, liveness_by_axis)`` -- the second is the per-axis
-    peak simultaneously-live rdim-shaped tile count (max over graphs), computed in
-    this SAME pass so the kernel-fact builder can read a per-axis slice.
-    """
-    from ..autotuner.config_spec import MemoryOpFact
-    from ..language import memory_ops
-    from .inductor_lowering import ReductionLowering
-
-    load_op = memory_ops.load
-    store_op = memory_ops.store
-    operand_positions = _matmul_operand_positions()
-
-    env = CompileEnvironment.current()
-    host = HostFunction.current()
-    # Matmul operands always precede their matmul in graph order, so `operands` is
-    # complete by the time we apply it to the (operand-less) facts below.
-    operands: dict[torch.fx.Node, str] = {}
-    records: list[tuple[torch.fx.Node, MemoryOpFact]] = []
-    memory_op_index = 0
-    eviction_index = 0
-    liveness_by_axis: dict[int, int] = {}
-
-    for graph_info in device_ir.graphs:
-        graph = graph_info.graph
-        # Reduction-body liveness (per-axis peak live tiles), merged max over graphs — part of
-        # this single collect pass, not a second traversal.
-        for axis, peak in _graph_peak_live_by_axis(graph, env).items():
-            if peak > liveness_by_axis.get(axis, 0):
-                liveness_by_axis[axis] = peak
-        # Axis (block_index) of every ReductionLowering node in this graph — the cut set
-        # for the dataflow classification, so a fed reduction maps to its axis.
-        red_axis_by_id: dict[int, int] = {
-            id(node): node.meta["lowering"].block_index
-            for node in graph.nodes
-            if isinstance(node.meta.get("lowering"), ReductionLowering)
-            and isinstance(getattr(node.meta["lowering"], "block_index", None), int)
-        }
-        redset = set(red_axis_by_id)
-        for node in graph.nodes:
-            if node.op != "call_function":
-                continue
-
-            positions = operand_positions.get(node.target)
-            if positions is not None:
-                for arg_index, operand in (
-                    (positions[0], "lhs"),
-                    (positions[1], "rhs"),
-                ):
-                    if arg_index < len(node.args):
-                        load = _trace_back_to_load(node.args[arg_index], load_op)
-                        if load is not None:
-                            operands.setdefault(load, operand)
-                continue
-
-            is_load = node.target is load_op
-            if not (is_load or node.target is store_op):
-                continue
-
-            this_eviction_index: int | None = None
-            if is_load and _load_needs_eviction_tunable(node):
-                this_eviction_index = eviction_index
-                eviction_index += 1
-
-            fake = _accessed_tensor_fake(node)
-            origin = host.tensor_to_origin.get(fake) if fake is not None else None
-
-            # reductions_fed (loads): per-axis count of the reductions this load's value
-            # flows into; stores_fed: the stores it reaches without passing a reduction,
-            # keyed by full axis tuple. Both reduction-AGNOSTIC (all axes at once).
-            reductions_fed: tuple[tuple[int, int], ...] = ()
-            stores_fed: tuple[tuple[int | None, ...], ...] = ()
-            if is_load:
-                feeds, stores_fed = _classify_load_dataflow(node, redset, env)
-                per_axis: dict[int, int] = {}
-                for fed_id in feeds:
-                    axis = red_axis_by_id[fed_id]
-                    per_axis[axis] = per_axis.get(axis, 0) + 1
-                reductions_fed = tuple(sorted(per_axis.items()))
-
-            # indexed_block_ids: shape-resolved block-id per non-bare-int subscript (None
-            # where unresolvable; the fallback). subscript_block_ids: the index-subscript
-            # block-id (the faithful axis key). inner_extent: inner-dim extent.
-            indexed_block_ids: tuple[int | None, ...] = ()
-            subscript_block_ids: tuple[int | None, ...] = ()
-            subscript_strides: tuple[int, ...] = ()
-            subscript_index_scales: tuple[int, ...] = ()
-            subscript_affine_block_ids: tuple[int | None, ...] = ()
-            subscript_extents: tuple[int, ...] = ()
-            inner_extent: int | None = None
-            accessed_numel = 0
-            if fake is not None:
-                # Distinct HBM elements the op touches = product of size-hinted shape dims over
-                # NON-broadcast dims (stride != 0). A stride-0 dim (an .expand()/broadcast — full
-                # SIZE but one underlying element, e.g. bias[N].expand_as(x) or a broadcast_tensors
-                # operand) contributes factor 1, so an expanded broadcast is NOT mistaken for
-                # full-extent traffic. size_hint (not int()) avoids specializing a SymInt dim. A
-                # broadcast operand thus has a strictly smaller numel than the problem numel — the
-                # faithful full-extent signal at any rank/stride (see MemoryOpFact.accessed_numel).
-                accessed_numel = 1
-                fake_strides = fake.stride()
-                for dim_index, dim_size in enumerate(fake.shape):
-                    if fake_strides[dim_index] != 0:
-                        accessed_numel *= env.size_hint(dim_size)
-                index_list = node.args[1] if len(node.args) >= 2 else None
-                if isinstance(index_list, (list, tuple)):
-                    # same positions for both tuples so [-1] aligns (drop bare-int / OOB)
-                    positions = [
-                        pos
-                        for pos, sub in enumerate(index_list)
-                        if not isinstance(sub, int) and pos < fake.ndim
-                    ]
-                    indexed_block_ids = tuple(
-                        env.resolve_block_id(fake.shape[pos]) for pos in positions
-                    )
-                    subscript_block_ids = tuple(
-                        _subscript_block_id(env, index_list[pos]) for pos in positions
-                    )
-                    # Element stride of the accessed tensor along each subscripted axis, aligned
-                    # 1:1 with subscript_block_ids (same `positions`). Raw provenance from the fake
-                    # tensor's .stride(); a stride-1 position is the contiguous/coalescing axis (the
-                    # last subscript for a row-major tensor, a DIFFERENT one for a transposed view).
-                    # size_hint (not int()) avoids specializing a SymInt stride to a constant: a
-                    # contiguous axis is a concrete 1, and a symbolic (outer) stride hints > 1 anyway,
-                    # so the stride==1 contiguity test is unaffected while dynamic shapes stay dynamic.
-                    subscript_strides = tuple(
-                        env.size_hint(fake_strides[pos]) for pos in positions
-                    )
-                    # Gather stride + affine-resolved axis, same ``positions`` so all the
-                    # tuples align. See ``MemoryOpFact.subscript_index_scales``.
-                    affine = [
-                        subscript_index_scale(env, index_list[pos]) for pos in positions
-                    ]
-                    subscript_affine_block_ids = tuple(bid for bid, _ in affine)
-                    subscript_index_scales = tuple(scale for _, scale in affine)
-                    # Extent per subscript position; size_hint, not int(), so a SymInt dim
-                    # is not specialized.
-                    subscript_extents = tuple(
-                        env.size_hint(fake.shape[pos]) for pos in positions
-                    )
-                if fake.ndim >= 2:
-                    # size_hint (not int()): int() would guard a SymInt inner dim to a
-                    # constant, over-specializing dynamic-shape kernels. inner_extent is a
-                    # heuristic signal, so a hint is sufficient and must not specialize.
-                    inner_extent = env.size_hint(fake.shape[-1])
-
-            records.append(
-                (
-                    node,
-                    MemoryOpFact(
-                        indexing_index=memory_op_index,
-                        kind="load" if is_load else "store",
-                        eviction_index=this_eviction_index,
-                        tensor_name=origin.root_rw_name() if origin else None,
-                        dtype=fake.dtype if fake is not None else None,
-                        ndim=fake.ndim if fake is not None else 0,
-                        num_reuses=len(node.users) if is_load else 0,
-                        matmul_operand=None,
-                        graph_id=graph_info.graph_id,
-                        reductions_fed=reductions_fed,
-                        stores_fed=stores_fed,
-                        indexed_block_ids=indexed_block_ids,
-                        inner_extent=inner_extent,
-                        subscript_block_ids=subscript_block_ids,
-                        subscript_strides=subscript_strides,
-                        subscript_index_scales=subscript_index_scales,
-                        subscript_affine_block_ids=subscript_affine_block_ids,
-                        subscript_extents=subscript_extents,
-                        accessed_numel=accessed_numel,
-                    ),
-                )
-            )
-            memory_op_index += 1
-
-    facts = [fact._replace(matmul_operand=operands.get(node)) for node, fact in records]
-    return facts, liveness_by_axis
-
-
 def _indexing_uses_tensor_descriptor(
     indexing_config: object,
     op_index: int,
@@ -3814,8 +2891,8 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         config_spec.epilogue_subtile_autotune_choices = None
 
         # Phase 1: roll + register the reduction_loops spec. The ReductionKernelFact is built
-        # in Phase 3 (build_reduction_kernel_fact, after _collect_memory_op_facts) so it can
-        # read the enriched memory_op_facts.
+        # in Phase 3 (after analysis derives memory_op_facts) so it can read the enriched
+        # load/store facts.
         device_ir.register_rollable_reductions()
         if CompileEnvironment.current().backend.name == "cute":
             _register_cute_lane_vector_width_specs(config_spec)
@@ -3959,9 +3036,17 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                         )
                 config_spec.allowed_pid_types = non_persistent_pid_types
 
-        # Collect per-load/store metadata once so heuristics can map each Config.indexing slot to its
-        # graph op; the same pass returns the reduction-body liveness (per-axis peak live tiles).
-        memory_op_facts, liveness_by_axis = _collect_memory_op_facts(device_ir)
+        # Build structural and liveness observations once, after reduction rolling has
+        # finalized the graph set. Specialized fact passes consume this shared analysis.
+        from .device_ir_analysis import DeviceIRAnalysis
+
+        env = CompileEnvironment.current()
+        analysis = DeviceIRAnalysis.build(device_ir, env)
+        config_spec.kernel_grid_fact = analysis.kernel_grid_fact
+
+        # Collect per-load/store metadata so heuristics can map each Config.indexing
+        # slot to its graph op.
+        memory_op_facts = analysis.memory_op_facts(env, func)
         config_spec.memory_op_facts = memory_op_facts
         if config_spec.supports_config_key("pallas_load_buffer_count"):
             config_spec.pallas_load_buffer_count.length = len(
@@ -3986,20 +3071,25 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         # Accumulator facts are a standalone, reduction-agnostic fact layer (any heuristic
         # may read them), so build them independently of the reduction facts. Must run
         # after the rolling (it walks the rolled loop subgraphs).
-        config_spec.accumulator_facts = device_ir.build_accumulator_facts()
+        config_spec.accumulator_facts = device_ir.build_accumulator_facts(analysis)
         # Phase 3 (PROMPT §2.1/§2.2): build the categorizing ReductionKernelFact — the first-class
         # reduction-descriptor list + co-residency groups the reduction seed + allocator consume.
-        # liveness_by_axis supplies each descriptor's per-axis liveness slice.
         device_ir.build_reduction_kernel_fact(
-            memory_op_facts, config_spec.accumulator_facts, liveness_by_axis
+            memory_op_facts,
+            config_spec.accumulator_facts,
+            analysis,
         )
+        # Phase 3b: compose the whole-kernel contraction fact for ANY kernel with a matmul,
+        # so both matmul front ends read one description of the workload (axis roles, knob
+        # competition, per-dot placement/work, peak liveness).
+        device_ir.build_kernel_matmul_fact(analysis)
         # Phase 4: compose a matmul + reduction-over-output epilogue fact when a matmul AND a
         # register-resident epilogue reduction co-occur (matmul_rms_norm etc.).
         device_ir.build_matmul_reduction_epilogue_facts()
         # Phase 5: record a PointwiseElementwiseFact for a PURE elementwise kernel (no
         # reduction/matmul/accumulator fact) so the pointwise seed can size a BW-saturating
         # tile instead of the starved block_size=32 default.
-        device_ir.build_pointwise_facts()
+        device_ir.build_pointwise_facts(analysis)
 
         return device_ir
 

--- a/helion/_compiler/device_ir_analysis.py
+++ b/helion/_compiler/device_ir_analysis.py
@@ -1,0 +1,1471 @@
+from __future__ import annotations
+
+import dataclasses
+from itertools import starmap
+import logging
+import operator
+from typing import TYPE_CHECKING
+from typing import cast
+
+import torch
+
+from ..autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
+from ..autotuner.config_spec import AccumulatorFact
+from ..autotuner.config_spec import DotAxes
+from ..autotuner.config_spec import DotAxisKind
+from ..autotuner.config_spec import DotSite
+from ..autotuner.config_spec import KernelGridFact
+from ..autotuner.config_spec import KernelMatmulFact
+from ..autotuner.config_spec import LiveTile
+from ..autotuner.config_spec import LoopAxisFact
+from ..autotuner.config_spec import MemoryOpFact
+from ..autotuner.config_spec import PipelinedRegion
+from ..autotuner.config_spec import PointwiseElementwiseFact
+from ..autotuner.config_spec import ResidentRegion
+from ..autotuner.config_spec import ResolvedMatmulFact
+from ..autotuner.config_spec import RootGridFact
+from ..language import _tracing_ops
+from .compile_environment import FixedBlockSizeSource
+from .indexing_strategy import subscript_index_scale
+from .indexing_strategy import subscript_tile_info
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from ..autotuner.config_spec import ConfigSpec
+    from .compile_environment import CompileEnvironment
+    from .device_ir import DeviceIR
+    from .device_ir import GraphInfo
+    from .host_function import HostFunction
+
+
+log = logging.getLogger(__name__)
+
+
+def matmul_operand_positions() -> dict[object, tuple[int, int]]:
+    """Matmul/dot FX targets mapped to their lhs/rhs argument positions."""
+    from ..language import matmul_ops
+
+    return {
+        matmul_ops.dot_scaled: (0, 3),
+        matmul_ops.dot: (0, 1),
+        torch.ops.aten.mm.default: (0, 1),
+        torch.ops.aten.bmm.default: (0, 1),
+        torch.ops.aten.addmm.default: (1, 2),
+        torch.ops.aten.baddbmm.default: (1, 2),
+    }
+
+
+def trace_back_to_load(arg: object, load_op: object) -> torch.fx.Node | None:
+    """Follow a matmul operand through pass-through ops to one load node."""
+    cur = arg
+    for _ in range(8):
+        if not isinstance(cur, torch.fx.Node):
+            return None
+        if cur.target is load_op:
+            return cur
+        tensor_inputs = [
+            value
+            for value in cur.args
+            if isinstance(value, torch.fx.Node)
+            and isinstance(value.meta.get("val"), torch.Tensor)
+        ]
+        if len(tensor_inputs) != 1:
+            return None
+        cur = tensor_inputs[0]
+    return None
+
+
+def _immovable_extent(
+    env: CompileEnvironment,
+    spec: ConfigSpec,
+    block_id: int,
+) -> int | None:
+    """Return the per-program extent of an axis the config cannot move."""
+    if not (0 <= block_id < len(env.block_sizes)):
+        return None
+    info = env.block_sizes[block_id]
+    if not isinstance(info.block_size_source, FixedBlockSizeSource):
+        return None
+    try:
+        value = info.block_size_source.from_config(
+            spec._base_default_config(),
+            info,
+        )
+    except Exception:
+        return None
+    if value is None:
+        return None
+    try:
+        return max(1, int(env.size_hint(value)))
+    except Exception:
+        return None
+
+
+def _load_needs_eviction_tunable(node: torch.fx.Node) -> bool:
+    """A load gets an eviction-policy slot only when the user did not pass one."""
+    eviction_policy_arg = node.kwargs.get("eviction_policy")
+    if eviction_policy_arg is None and len(node.args) >= 4:
+        eviction_policy_arg = node.args[3]
+    return eviction_policy_arg is None
+
+
+def _accessed_tensor_fake(node: torch.fx.Node) -> torch.Tensor | None:
+    """Fake tensor of the buffer a load/store accesses."""
+    arg = node.args[0] if node.args else None
+    if isinstance(arg, torch.fx.Node):
+        value = arg.meta.get("val")
+        if isinstance(value, torch.Tensor):
+            return value
+    return None
+
+
+def _subscript_block_id(env: CompileEnvironment, subscript: object) -> int | None:
+    """Return the block axis indexed by a tile-provenance subscript."""
+    info = subscript_tile_info(env, subscript)
+    return info.block_id if info is not None else None
+
+
+def _store_axis_key(
+    env: CompileEnvironment,
+    store_node: torch.fx.Node,
+) -> tuple[int | None, ...]:
+    """Return the full block-axis key of one store subscript."""
+    fake = _accessed_tensor_fake(store_node)
+    index_list = store_node.args[1] if len(store_node.args) >= 2 else None
+    if fake is None or not isinstance(index_list, (list, tuple)):
+        return ()
+    key: list[int | None] = []
+    for position, subscript in enumerate(index_list):
+        if isinstance(subscript, int) or position >= fake.ndim:
+            continue
+        block_id = _subscript_block_id(env, subscript)
+        if block_id is None:
+            block_id = env.resolve_block_id(fake.shape[position])
+        key.append(block_id)
+    return tuple(key)
+
+
+def _classify_load_dataflow(
+    load_node: torch.fx.Node,
+    reduction_nodes: set[int],
+    env: CompileEnvironment,
+) -> tuple[set[int], tuple[tuple[int | None, ...], ...]]:
+    """Trace a load forward to reductions and stores without crossing either."""
+    from ..language import memory_ops
+
+    reductions_fed: set[int] = set()
+    stores_fed: set[tuple[int | None, ...]] = set()
+    seen: set[int] = set()
+    stack = list(load_node.users)
+    while stack:
+        user = stack.pop()
+        if id(user) in reduction_nodes:
+            reductions_fed.add(id(user))
+            continue
+        if id(user) in seen:
+            continue
+        seen.add(id(user))
+        if user.op == "call_function" and user.target is memory_ops.store:
+            stores_fed.add(_store_axis_key(env, user))
+            continue
+        stack.extend(user.users)
+    return reductions_fed, tuple(
+        sorted(
+            stores_fed,
+            key=lambda axes: tuple(-1 if axis is None else axis for axis in axes),
+        )
+    )
+
+
+def tile_rank(dims: tuple[int | None, ...]) -> int:
+    """Number of block dimensions spanned by a tile."""
+    return sum(dim is not None for dim in dims)
+
+
+def tile_set_rank_profile(
+    tiles: Iterable[tuple[int | None, ...]],
+    max_rank: int,
+) -> tuple[int, ...]:
+    """Block-size-free lexicographic footprint key, highest rank first."""
+    by_rank: dict[int, int] = {}
+    for tile in tiles:
+        rank = tile_rank(tile)
+        if rank:
+            by_rank[rank] = by_rank.get(rank, 0) + 1
+    return tuple(by_rank.get(rank, 0) for rank in range(max_rank, 0, -1))
+
+
+def _live_tile_kind(node: torch.fx.Node, dot_targets: frozenset[object]) -> str:
+    from ..language import memory_ops
+
+    if node.op == "placeholder":
+        return "carry"
+    if node.op == "call_function":
+        if node.target in dot_targets:
+            return "dot_out"
+        if node.target is memory_ops.load:
+            return "load"
+    return "other"
+
+
+def _tile_from_tensor(
+    value: object,
+    env: CompileEnvironment,
+    *,
+    kind: str,
+    stageable: bool | None = None,
+) -> LiveTile | None:
+    if not (isinstance(value, torch.Tensor) and value.shape):
+        return None
+    dims = tuple(env.resolve_block_id(size) for size in value.shape)
+    static_dims: list[int | None] = []
+    for size, block_id in zip(value.shape, dims, strict=False):
+        if block_id is not None:
+            static_dims.append(None)
+            continue
+        try:
+            static_dims.append(int(env.size_hint(size)))
+        except Exception:
+            static_dims.append(None)
+    return LiveTile(
+        dim_block_ids=dims,
+        static_dims=tuple(static_dims),
+        itemsize=value.dtype.itemsize,
+        kind=kind,
+        stageable=stageable,
+    )
+
+
+def _index_depends_on_loop(
+    obj: object,
+    env: CompileEnvironment,
+    loop_block_ids: frozenset[int],
+    seen: set[torch.fx.Node] | None = None,
+) -> bool | None:
+    """Whether an FX index is proven to depend on an enclosing loop axis."""
+    if isinstance(obj, (list, tuple)):
+        states = [
+            _index_depends_on_loop(item, env, loop_block_ids, seen) for item in obj
+        ]
+        if any(state is True for state in states):
+            return True
+        if any(state is None for state in states):
+            return None
+        return False
+    if isinstance(obj, dict):
+        return _index_depends_on_loop(tuple(obj.values()), env, loop_block_ids, seen)
+    if isinstance(obj, torch.fx.Node):
+        seen = set() if seen is None else seen
+        if obj in seen:
+            return False
+        seen.add(obj)
+        value = obj.meta.get("val")
+        known_origin = False
+        try:
+            block_id = env.resolve_block_id(value)
+        except Exception:
+            block_id = None
+        if block_id is not None:
+            known_origin = True
+            if block_id in loop_block_ids:
+                return True
+        if isinstance(value, torch.Tensor):
+            for dim in value.shape:
+                try:
+                    dim_block_id = env.resolve_block_id(dim)
+                except Exception:
+                    dim_block_id = None
+                if dim_block_id is not None:
+                    known_origin = True
+                    if dim_block_id in loop_block_ids:
+                        return True
+        if obj.op == "placeholder":
+            return False if known_origin else None
+        children = (*obj.args, *obj.kwargs.values())
+        if children:
+            state = _index_depends_on_loop(children, env, loop_block_ids, seen)
+            if state is not False:
+                return state
+            return False
+        if obj.op == "get_attr":
+            return False
+        return False if known_origin else None
+    if isinstance(obj, torch.SymInt):
+        try:
+            block_id = env.resolve_block_id(obj)
+        except Exception:
+            return None
+        return block_id in loop_block_ids if block_id is not None else None
+    if isinstance(obj, torch.Tensor):
+        return None
+    return False
+
+
+@dataclasses.dataclass
+class GraphAnalysis:
+    """Shared structural and liveness observations for one DeviceIR graph."""
+
+    graph_id: int
+    nodes: tuple[torch.fx.Node, ...]
+    is_reduction_loop: bool
+    block_ids: frozenset[int]
+    block_id_order: tuple[int, ...]
+    live_tile_steps: tuple[tuple[LiveTile, ...], ...]
+    peak_live_tiles: tuple[LiveTile, ...]
+    peak_dot_output_tiles: tuple[LiveTile, ...]
+    dot_nodes: tuple[torch.fx.Node, ...]
+    reduction_occurrences: tuple[int, ...]
+    reduction_axis_by_node_id: dict[int, int]
+    reduction_input_itemsizes: tuple[tuple[int, int], ...]
+    memory_tiles: tuple[tuple[torch.fx.Node, LiveTile], ...]
+    _memory_tiles_by_loop_axes: dict[frozenset[int], tuple[LiveTile, ...]] = (
+        dataclasses.field(
+            default_factory=dict,
+            repr=False,
+        )
+    )
+
+    @classmethod
+    def build(
+        cls,
+        graph_info: GraphInfo,
+        env: CompileEnvironment,
+        *,
+        is_reduction_loop: bool,
+        dot_targets: frozenset[object],
+    ) -> GraphAnalysis:
+        from ..language import memory_ops
+        from .inductor_lowering import ReductionLowering
+
+        graph = graph_info.graph
+        nodes = tuple(graph.nodes)
+        last_use: dict[torch.fx.Node, int] = {}
+        tile_details: dict[torch.fx.Node, LiveTile] = {}
+        dot_nodes: list[torch.fx.Node] = []
+        reduction_occurrences: list[int] = []
+        seen_reductions: set[int] = set()
+        reduction_axis_by_node_id: dict[int, int] = {}
+        reduction_input_itemsizes: list[tuple[int, int]] = []
+        memory_tiles: list[tuple[torch.fx.Node, LiveTile]] = []
+
+        for index, node in enumerate(nodes):
+            for input_node in node.all_input_nodes:
+                last_use[input_node] = index
+
+            kind = _live_tile_kind(node, dot_targets)
+            tile = _tile_from_tensor(node.meta.get("val"), env, kind=kind)
+            if tile is not None and any(
+                block_id is not None for block_id in tile.dim_block_ids
+            ):
+                tile_details[node] = tile
+
+            if node.op == "call_function" and node.target in dot_targets:
+                dot_nodes.append(node)
+
+            lowering = node.meta.get("lowering")
+            if isinstance(lowering, ReductionLowering):
+                block_id = getattr(lowering, "block_index", None)
+                if isinstance(block_id, int):
+                    reduction_axis_by_node_id[id(node)] = block_id
+                    if block_id not in seen_reductions:
+                        seen_reductions.add(block_id)
+                        reduction_occurrences.append(block_id)
+                    for input_node in node.all_input_nodes:
+                        input_value = input_node.meta.get("val")
+                        if isinstance(input_value, torch.Tensor):
+                            reduction_input_itemsizes.append(
+                                (block_id, input_value.element_size())
+                            )
+                            break
+
+            if node.op != "call_function":
+                continue
+            if node.target is memory_ops.load:
+                memory_tile = _tile_from_tensor(
+                    node.meta.get("val"),
+                    env,
+                    kind="load",
+                )
+            elif node.target is memory_ops.store:
+                stored_value = None
+                for arg in node.args:
+                    if isinstance(arg, torch.fx.Node):
+                        candidate = arg.meta.get("val")
+                        if isinstance(candidate, torch.Tensor) and candidate.shape:
+                            stored_value = candidate
+                memory_tile = _tile_from_tensor(stored_value, env, kind="store")
+            else:
+                memory_tile = None
+            if memory_tile is not None:
+                memory_tiles.append((node, memory_tile))
+
+        live_tile_steps: list[tuple[LiveTile, ...]] = []
+        seen_steps: set[frozenset[int]] = set()
+        max_rank = max(
+            (tile_rank(tile.dim_block_ids) for tile in tile_details.values()),
+            default=0,
+        )
+        best_key: tuple[int, ...] = ()
+        peak_live_tiles: tuple[LiveTile, ...] = ()
+        live: set[torch.fx.Node] = set()
+        for index, node in enumerate(nodes):
+            if node in tile_details:
+                live.add(node)
+            if live:
+                step_key = frozenset(id(value) for value in live)
+                step = tuple(tile_details[value] for value in live)
+                if step_key not in seen_steps:
+                    seen_steps.add(step_key)
+                    live_tile_steps.append(step)
+                key = tile_set_rank_profile(
+                    (tile_details[value].dim_block_ids for value in live),
+                    max_rank,
+                )
+                if key > best_key:
+                    best_key = key
+                    peak_live_tiles = step
+            live = {value for value in live if last_use.get(value, -1) > index}
+
+        dot_details = {
+            node: tile
+            for node in dot_nodes
+            if (
+                tile := _tile_from_tensor(
+                    node.meta.get("val"),
+                    env,
+                    kind="dot_out",
+                )
+            )
+            is not None
+        }
+        best_dot_key = (-1, -1)
+        peak_dot_output_tiles: tuple[LiveTile, ...] = ()
+        live_dots: set[torch.fx.Node] = set()
+        for index, node in enumerate(nodes):
+            if node in dot_details:
+                live_dots.add(node)
+            if live_dots:
+                tiles = tuple(dot_details[value] for value in live_dots)
+                key = (
+                    sum(tile_rank(tile.dim_block_ids) for tile in tiles),
+                    len(tiles),
+                )
+                if key > best_dot_key:
+                    best_dot_key = key
+                    peak_dot_output_tiles = tiles
+            live_dots = {
+                value for value in live_dots if last_use.get(value, len(nodes)) > index
+            }
+
+        return cls(
+            graph_id=graph_info.graph_id,
+            nodes=nodes,
+            is_reduction_loop=is_reduction_loop,
+            block_ids=frozenset(getattr(graph_info, "block_ids", ()) or ()),
+            block_id_order=tuple(getattr(graph_info, "block_ids", ()) or ()),
+            live_tile_steps=tuple(live_tile_steps),
+            peak_live_tiles=peak_live_tiles,
+            peak_dot_output_tiles=peak_dot_output_tiles,
+            dot_nodes=tuple(dot_nodes),
+            reduction_occurrences=tuple(reduction_occurrences),
+            reduction_axis_by_node_id=reduction_axis_by_node_id,
+            reduction_input_itemsizes=tuple(reduction_input_itemsizes),
+            memory_tiles=tuple(memory_tiles),
+        )
+
+    def reaches_output(self, node: torch.fx.Node, limit: int = 64) -> bool:
+        """Whether a value reaches the graph output under the legacy bounded walk."""
+        frontier = [node]
+        seen: set[torch.fx.Node] = {node}
+        steps = 0
+        while frontier and steps < limit:
+            steps += 1
+            current = frontier.pop()
+            for user in current.users:
+                if user.op == "output":
+                    return True
+                if user not in seen:
+                    seen.add(user)
+                    frontier.append(user)
+        return False
+
+    def memory_tiles_for_loop_axes(
+        self,
+        env: CompileEnvironment,
+        loop_block_ids: frozenset[int] = frozenset(),
+    ) -> tuple[LiveTile, ...]:
+        """Memory tiles with load stageability resolved for the given loop axes."""
+        cached = self._memory_tiles_by_loop_axes.get(loop_block_ids)
+        if cached is not None:
+            return cached
+        out: list[LiveTile] = []
+        for node, tile in self.memory_tiles:
+            if tile.kind == "load":
+                stageable = (
+                    _index_depends_on_loop(node.args[1], env, loop_block_ids)
+                    if len(node.args) > 1 and loop_block_ids
+                    else False
+                )
+            else:
+                stageable = False
+            out.append(tile._replace(stageable=stageable))
+        result = tuple(out)
+        self._memory_tiles_by_loop_axes[loop_block_ids] = result
+        return result
+
+
+@dataclasses.dataclass
+class DeviceIRAnalysis:
+    """Shared graph interpretation for all fact builders of one DeviceIR."""
+
+    graphs: tuple[GraphAnalysis, ...]
+    by_id: dict[int, GraphAnalysis]
+    child_loops: dict[int, tuple[tuple[int, frozenset[int]], ...]]
+    parent_of: dict[int, int]
+    loop_block_ids: dict[int, frozenset[int]]
+    loop_calls: dict[int, tuple[torch.fx.Node, ...]]
+    dot_nodes: tuple[tuple[int, torch.fx.Node], ...]
+    accumulator_inputs: tuple[torch.fx.Node, ...]
+    kernel_grid_fact: KernelGridFact
+
+    @classmethod
+    def build(
+        cls,
+        device_ir: DeviceIR,
+        env: CompileEnvironment,
+    ) -> DeviceIRAnalysis:
+        from .device_ir import ForLoopGraphInfo
+        from .device_ir import ReductionLoopGraphInfo
+
+        dot_targets = frozenset(matmul_operand_positions())
+        graphs = tuple(
+            GraphAnalysis.build(
+                graph_info,
+                env,
+                is_reduction_loop=isinstance(
+                    graph_info,
+                    ReductionLoopGraphInfo,
+                ),
+                dot_targets=dot_targets,
+            )
+            for graph_info in device_ir.graphs
+        )
+        by_id = {graph.graph_id: graph for graph in graphs}
+        child_loops: dict[int, tuple[tuple[int, frozenset[int]], ...]] = {}
+        loop_calls: dict[int, list[torch.fx.Node]] = {}
+        graph_parent_of: dict[int, int] = {}
+        for graph in graphs:
+            if graph.is_reduction_loop:
+                continue
+            edges: list[tuple[int, frozenset[int]]] = []
+            for node in graph.nodes:
+                if (
+                    node.op != "call_function"
+                    or not _tracing_ops.is_for_loop_target(node.target)
+                    or not node.args
+                    or not isinstance(node.args[0], int)
+                ):
+                    continue
+                body_id = node.args[0]
+                loop_calls.setdefault(body_id, []).append(node)
+                body = by_id.get(body_id)
+                if body is not None:
+                    graph_parent_of[body_id] = graph.graph_id
+                if body is not None and not body.is_reduction_loop:
+                    edges.append((body_id, body.block_ids))
+            if edges:
+                child_loops[graph.graph_id] = tuple(edges)
+
+        parent_of: dict[int, int] = {}
+        loop_block_ids: dict[int, frozenset[int]] = {}
+        for parent_id, loop_edges in child_loops.items():
+            for body_id, block_ids in loop_edges:
+                parent_of[body_id] = parent_id
+                loop_block_ids[body_id] = block_ids
+
+        dot_nodes = tuple(
+            (graph.graph_id, node)
+            for graph in graphs
+            if not graph.is_reduction_loop
+            for node in graph.dot_nodes
+        )
+        accumulator_inputs = tuple(
+            node
+            for graph_info in device_ir.graphs
+            if isinstance(graph_info, ForLoopGraphInfo)
+            for node in graph_info.node_args
+        )
+        roots = tuple(
+            RootGridFact(graph_id, tuple(block_ids))
+            for graph_id, block_ids in zip(
+                device_ir.root_ids,
+                device_ir.grid_block_ids,
+                strict=True,
+            )
+        )
+        root_ids = {root.root_graph_id for root in roots}
+        graph_to_root: list[tuple[int, int]] = []
+        for graph in graphs:
+            current = graph.graph_id
+            seen: set[int] = set()
+            while current not in root_ids and current not in seen:
+                seen.add(current)
+                current = graph_parent_of.get(current, -1)
+            if current in root_ids:
+                graph_to_root.append((graph.graph_id, current))
+        kernel_grid_fact = KernelGridFact(roots, tuple(graph_to_root))
+        return cls(
+            graphs=graphs,
+            by_id=by_id,
+            child_loops=child_loops,
+            parent_of=parent_of,
+            loop_block_ids=loop_block_ids,
+            loop_calls={
+                graph_id: tuple(calls) for graph_id, calls in loop_calls.items()
+            },
+            dot_nodes=dot_nodes,
+            accumulator_inputs=accumulator_inputs,
+            kernel_grid_fact=kernel_grid_fact,
+        )
+
+    @property
+    def non_reduction_graphs(self) -> tuple[GraphAnalysis, ...]:
+        return tuple(graph for graph in self.graphs if not graph.is_reduction_loop)
+
+    def original_reductions(self) -> tuple[tuple[int, int], ...]:
+        """Ordered, deduplicated reduction occurrences in original graphs."""
+        return tuple(
+            (graph.graph_id, block_id)
+            for graph in self.non_reduction_graphs
+            for block_id in graph.reduction_occurrences
+        )
+
+    def reduction_input_itemsize(self, block_id: int) -> int:
+        """Legacy last-occurrence input width for one reduction axis."""
+        itemsize = 0
+        for graph in self.graphs:
+            for axis, width in graph.reduction_input_itemsizes:
+                if axis == block_id:
+                    itemsize = width
+        return itemsize
+
+    def kernel_peak_live_tiles(self) -> tuple[LiveTile, ...]:
+        """Legacy max-by-rank-profile live set across original graphs."""
+        best: tuple[LiveTile, ...] = ()
+        best_key: tuple[int, ...] = ()
+        for graph in self.non_reduction_graphs:
+            tiles = graph.peak_live_tiles
+            max_rank = max(
+                (tile_rank(tile.dim_block_ids) for tile in tiles),
+                default=0,
+            )
+            key = tile_set_rank_profile(
+                (tile.dim_block_ids for tile in tiles),
+                max_rank,
+            )
+            if key > best_key:
+                best_key = key
+                best = tiles
+        return best
+
+    def kernel_live_tile_steps(self) -> tuple[tuple[LiveTile, ...], ...]:
+        return tuple(
+            step
+            for graph in self.non_reduction_graphs
+            for step in graph.live_tile_steps
+        )
+
+    def kernel_peak_dot_outputs(self) -> tuple[LiveTile, ...]:
+        """Peak dot-output set after adding accumulator ancestor chains."""
+        accumulator_of = {
+            graph.graph_id: graph.peak_dot_output_tiles
+            for graph in self.non_reduction_graphs
+        }
+        best: tuple[LiveTile, ...] = ()
+        best_key = (-1, -1)
+        for graph_id, own in accumulator_of.items():
+            chain = list(own)
+            current = self.parent_of.get(graph_id, -1)
+            seen = {graph_id}
+            while current in accumulator_of and current not in seen:
+                seen.add(current)
+                chain.extend(accumulator_of[current])
+                current = self.parent_of.get(current, -1)
+            key = (
+                sum(tile_rank(tile.dim_block_ids) for tile in chain),
+                len(chain),
+            )
+            if key > best_key:
+                best_key = key
+                best = tuple(chain)
+        return best
+
+    def group_live_tiles(
+        self,
+        group_graph_ids: list[int],
+    ) -> dict[int, list[tuple[int | None, ...]]]:
+        """Resident peak-live tiles attributed to reduction co-residency groups."""
+        group_axes = {
+            graph_id: set(self.by_id[graph_id].reduction_occurrences)
+            for graph_id in group_graph_ids
+        }
+        peak_of = {
+            graph.graph_id: [tile.dim_block_ids for tile in graph.peak_live_tiles]
+            for graph in self.non_reduction_graphs
+        }
+
+        def max_by_profile(
+            lhs: list[tuple[int | None, ...]],
+            rhs: list[tuple[int | None, ...]],
+        ) -> list[tuple[int | None, ...]]:
+            max_rank = max(
+                (tile_rank(tile) for tile in lhs + rhs),
+                default=0,
+            )
+            lhs_key = tile_set_rank_profile(lhs, max_rank)
+            rhs_key = tile_set_rank_profile(rhs, max_rank)
+            return lhs if lhs_key >= rhs_key else rhs
+
+        group_keys = set(group_graph_ids)
+        result: dict[int, list[tuple[int | None, ...]]] = {}
+        for graph_id in group_graph_ids:
+            axes = group_axes[graph_id]
+            tiles = list(peak_of.get(graph_id, ()))
+            seen_bodies = {graph_id}
+            frontier = [graph_id]
+            while frontier:
+                current = frontier.pop()
+                for body_id, block_ids in self.child_loops.get(current, ()):
+                    if body_id in seen_bodies or body_id in group_keys:
+                        continue
+                    if not axes or (block_ids & axes):
+                        seen_bodies.add(body_id)
+                        tiles = max_by_profile(tiles, peak_of.get(body_id, []))
+                        frontier.append(body_id)
+            result[graph_id] = tiles
+        return result
+
+    def accumulator_facts(
+        self,
+        env: CompileEnvironment,
+    ) -> list[AccumulatorFact]:
+        """Describe every loop-carried tensor accumulator."""
+        from .._utils import next_power_of_2
+
+        def resolve_dim(size: object) -> int | None:
+            block_id = env.resolve_block_id(size)
+            if block_id is not None:
+                return block_id
+            extent = env.size_hint(cast("int | torch.SymInt", size))
+            matches = [
+                info.block_id
+                for info in env.block_sizes
+                if info.reduction and next_power_of_2(info.size_hint()) == extent
+            ]
+            if len(matches) == 1:
+                return matches[0]
+            if len(matches) > 1:
+                log.warning(
+                    "accumulator dim (padded extent %s) matches %d reduction axes %s; "
+                    "cannot differentiate by extent -- left unresolved "
+                    "(per_feature_accumulator may miss it)",
+                    extent,
+                    len(matches),
+                    matches,
+                )
+            return None
+
+        facts: list[AccumulatorFact] = []
+        for node in self.accumulator_inputs:
+            value = node.meta.get("val")
+            if isinstance(value, torch.Tensor):
+                facts.append(
+                    AccumulatorFact(
+                        dim_block_ids=tuple(resolve_dim(size) for size in value.shape),
+                        itemsize=value.element_size(),
+                    )
+                )
+        return facts
+
+    def memory_op_facts(
+        self,
+        env: CompileEnvironment,
+        host: HostFunction,
+    ) -> list[MemoryOpFact]:
+        """Record one fact for every load/store in indexing-slot order."""
+        from ..language import memory_ops
+
+        load_op = memory_ops.load
+        store_op = memory_ops.store
+        operand_positions = matmul_operand_positions()
+        operands: dict[torch.fx.Node, str] = {}
+        records: list[tuple[torch.fx.Node, MemoryOpFact]] = []
+        memory_op_index = 0
+        eviction_index = 0
+
+        for graph_analysis in self.graphs:
+            reduction_axis_by_id = graph_analysis.reduction_axis_by_node_id
+            reduction_nodes = set(reduction_axis_by_id)
+            for node in graph_analysis.nodes:
+                if node.op != "call_function":
+                    continue
+
+                positions = operand_positions.get(node.target)
+                if positions is not None:
+                    for arg_index, operand in (
+                        (positions[0], "lhs"),
+                        (positions[1], "rhs"),
+                    ):
+                        if arg_index < len(node.args):
+                            load = trace_back_to_load(node.args[arg_index], load_op)
+                            if load is not None:
+                                operands.setdefault(load, operand)
+                    continue
+
+                is_load = node.target is load_op
+                if not (is_load or node.target is store_op):
+                    continue
+
+                this_eviction_index: int | None = None
+                if is_load and _load_needs_eviction_tunable(node):
+                    this_eviction_index = eviction_index
+                    eviction_index += 1
+
+                fake = _accessed_tensor_fake(node)
+                origin = host.tensor_to_origin.get(fake) if fake is not None else None
+
+                reductions_fed: tuple[tuple[int, int], ...] = ()
+                stores_fed: tuple[tuple[int | None, ...], ...] = ()
+                if is_load:
+                    feeds, stores_fed = _classify_load_dataflow(
+                        node,
+                        reduction_nodes,
+                        env,
+                    )
+                    per_axis: dict[int, int] = {}
+                    for fed_id in feeds:
+                        axis = reduction_axis_by_id[fed_id]
+                        per_axis[axis] = per_axis.get(axis, 0) + 1
+                    reductions_fed = tuple(sorted(per_axis.items()))
+
+                indexed_block_ids: tuple[int | None, ...] = ()
+                subscript_block_ids: tuple[int | None, ...] = ()
+                subscript_strides: tuple[int, ...] = ()
+                subscript_index_scales: tuple[int, ...] = ()
+                subscript_affine_block_ids: tuple[int | None, ...] = ()
+                subscript_extents: tuple[int, ...] = ()
+                inner_extent: int | None = None
+                accessed_numel = 0
+                if fake is not None:
+                    accessed_numel = 1
+                    fake_strides = fake.stride()
+                    for dim_index, dim_size in enumerate(fake.shape):
+                        if fake_strides[dim_index] != 0:
+                            accessed_numel *= env.size_hint(dim_size)
+                    index_list = node.args[1] if len(node.args) >= 2 else None
+                    if isinstance(index_list, (list, tuple)):
+                        indexed_positions = [
+                            position
+                            for position, subscript in enumerate(index_list)
+                            if not isinstance(subscript, int) and position < fake.ndim
+                        ]
+                        indexed_block_ids = tuple(
+                            env.resolve_block_id(fake.shape[position])
+                            for position in indexed_positions
+                        )
+                        subscript_block_ids = tuple(
+                            _subscript_block_id(env, index_list[position])
+                            for position in indexed_positions
+                        )
+                        subscript_strides = tuple(
+                            env.size_hint(fake_strides[position])
+                            for position in indexed_positions
+                        )
+                        affine = [
+                            subscript_index_scale(env, index_list[position])
+                            for position in indexed_positions
+                        ]
+                        subscript_affine_block_ids = tuple(
+                            block_id for block_id, _scale in affine
+                        )
+                        subscript_index_scales = tuple(
+                            scale for _block_id, scale in affine
+                        )
+                        subscript_extents = tuple(
+                            env.size_hint(fake.shape[position])
+                            for position in indexed_positions
+                        )
+                    if fake.ndim >= 2:
+                        inner_extent = env.size_hint(fake.shape[-1])
+
+                records.append(
+                    (
+                        node,
+                        MemoryOpFact(
+                            indexing_index=memory_op_index,
+                            kind="load" if is_load else "store",
+                            eviction_index=this_eviction_index,
+                            tensor_name=origin.root_rw_name() if origin else None,
+                            dtype=fake.dtype if fake is not None else None,
+                            ndim=fake.ndim if fake is not None else 0,
+                            num_reuses=len(node.users) if is_load else 0,
+                            matmul_operand=None,
+                            graph_id=graph_analysis.graph_id,
+                            reductions_fed=reductions_fed,
+                            stores_fed=stores_fed,
+                            indexed_block_ids=indexed_block_ids,
+                            inner_extent=inner_extent,
+                            subscript_block_ids=subscript_block_ids,
+                            subscript_strides=subscript_strides,
+                            subscript_index_scales=subscript_index_scales,
+                            subscript_affine_block_ids=subscript_affine_block_ids,
+                            subscript_extents=subscript_extents,
+                            accessed_numel=accessed_numel,
+                        ),
+                    )
+                )
+                memory_op_index += 1
+
+        return [
+            fact._replace(matmul_operand=operands.get(node)) for node, fact in records
+        ]
+
+    def pointwise_fact(
+        self,
+        spec: ConfigSpec,
+    ) -> PointwiseElementwiseFact | None:
+        """Build the fact for a pure, tile-independent elementwise kernel."""
+        from ..language import memory_ops
+        from ..language.atomic_ops import ATOMIC_OPS
+        from ..language.inline_asm_ops import inline_asm_elementwise
+        from ..language.inline_triton_ops import inline_triton
+        from ..language.inline_triton_ops import triton_kernel
+        from ..language.reduce_ops import _reduce
+        from ..language.scan_ops import _associative_scan
+
+        reduction_fact = spec.reduction_kernel_fact
+        has_sized_reduction = reduction_fact is not None and any(
+            descriptor.category in SIZED_REDUCTION_CATEGORIES
+            for descriptor in reduction_fact.reductions
+        )
+        if has_sized_reduction or spec.matmul_facts or spec.accumulator_facts:
+            return None
+        if not spec.memory_op_facts or not spec.block_sizes:
+            return None
+
+        unsafe_pointwise_ops = frozenset(
+            {
+                _associative_scan,
+                _reduce,
+                inline_triton,
+                triton_kernel,
+                inline_asm_elementwise,
+                *ATOMIC_OPS,
+            }
+        )
+        total_numel = 1
+        for block_size in spec.block_sizes:
+            total_numel *= block_size.size_hint
+        total_numel = max(1, total_numel)
+
+        def value_itemsizes(value: object) -> list[int]:
+            if isinstance(value, torch.Tensor):
+                return [value.dtype.itemsize]
+            if isinstance(value, (list, tuple)):
+                return [
+                    itemsize for item in value for itemsize in value_itemsizes(item)
+                ]
+            return []
+
+        data_nodes: set[int] = set()
+        data_path_buffer_width = 1
+        for graph in self.graphs:
+            for node in reversed(graph.nodes):
+                if node.op != "call_function":
+                    continue
+                is_load = node.target is memory_ops.load
+                if is_load or node.target is memory_ops.store:
+                    for position in (2, 3) if not is_load else (2,):
+                        if len(node.args) > position and isinstance(
+                            node.args[position],
+                            torch.fx.Node,
+                        ):
+                            data_nodes.add(id(node.args[position]))
+                    accessed = _accessed_tensor_fake(node)
+                    if accessed is not None:
+                        data_path_buffer_width = max(
+                            data_path_buffer_width,
+                            accessed.dtype.itemsize,
+                        )
+                    if is_load:
+                        continue
+                if id(node) in data_nodes:
+                    data_nodes.update(id(arg) for arg in node.all_input_nodes)
+
+        sfu_ops = frozenset(
+            {
+                "sin",
+                "cos",
+                "tan",
+                "tanh",
+                "asin",
+                "acos",
+                "atan",
+                "sinh",
+                "cosh",
+                "atanh",
+                "asinh",
+                "acosh",
+                "exp",
+                "exp2",
+                "expm1",
+                "log",
+                "log2",
+                "log10",
+                "log1p",
+                "sqrt",
+                "rsqrt",
+                "sigmoid",
+                "erf",
+                "erfc",
+                "pow",
+                "reciprocal",
+            }
+        )
+        compute_itemsize = 1
+        sfu_op_count = 0
+        for graph in self.graphs:
+            for node in graph.nodes:
+                if id(node) in data_nodes:
+                    for itemsize in value_itemsizes(node.meta.get("val")):
+                        compute_itemsize = max(compute_itemsize, itemsize)
+                if node.op == "call_function":
+                    if node.target in unsafe_pointwise_ops:
+                        return None
+                    base = getattr(node.target, "__name__", str(node.target)).split(
+                        "."
+                    )[0]
+                    if base in sfu_ops:
+                        sfu_op_count += 1
+        if compute_itemsize == 1:
+            compute_itemsize = max(1, data_path_buffer_width)
+
+        tiled_ids = {block_size.block_id for block_size in spec.block_sizes}
+        contiguous_block_ids: set[int] = set()
+        slab_numel = 0
+        max_op_slab_numel = 1
+        storage_itemsize = 1
+        gather_stride = 1
+        for memory_fact in spec.memory_op_facts:
+            if memory_fact.dtype is None or memory_fact.accessed_numel < total_numel:
+                continue
+            slab_numel += memory_fact.accessed_numel // total_numel
+            op_slab = 1
+            for block_id, extent in zip(
+                memory_fact.subscript_affine_block_ids,
+                memory_fact.subscript_extents,
+                strict=True,
+            ):
+                if block_id is None or block_id not in tiled_ids:
+                    op_slab *= max(1, extent)
+            max_op_slab_numel = max(max_op_slab_numel, op_slab)
+            storage_itemsize = max(storage_itemsize, memory_fact.dtype.itemsize)
+            for block_id, stride in zip(
+                memory_fact.subscript_block_ids,
+                memory_fact.subscript_strides,
+                strict=True,
+            ):
+                if block_id is not None and stride == 1 and block_id in tiled_ids:
+                    contiguous_block_ids.add(block_id)
+            for block_id, scale, stride in zip(
+                memory_fact.subscript_affine_block_ids,
+                memory_fact.subscript_index_scales,
+                memory_fact.subscript_strides,
+                strict=True,
+            ):
+                if block_id is not None and block_id in tiled_ids and stride == 1:
+                    gather_stride = max(gather_stride, scale)
+
+        return PointwiseElementwiseFact(
+            total_numel=total_numel,
+            slab_numel=slab_numel,
+            storage_itemsize=storage_itemsize,
+            compute_itemsize=compute_itemsize,
+            contig_block_ids=tuple(sorted(contiguous_block_ids)),
+            sfu_ops=sfu_op_count,
+            gather_stride=gather_stride,
+            max_op_slab_numel=max_op_slab_numel,
+        )
+
+    def kernel_matmul_fact(
+        self,
+        env: CompileEnvironment,
+        spec: ConfigSpec,
+    ) -> KernelMatmulFact | None:
+        """Compose the whole-kernel contraction fact from analyzed FX graphs."""
+        facts = spec.matmul_facts
+        if not facts:
+            return None
+
+        valid_block_ids = set(spec.block_sizes.valid_block_ids())
+
+        def classify_axis(
+            block_id: int | None,
+            static_extent: int | None,
+        ) -> tuple[DotAxisKind, int | None]:
+            if block_id is not None and block_id in valid_block_ids:
+                return DotAxisKind.TUNABLE_TILED, static_extent
+            if block_id is not None:
+                extent = _immovable_extent(env, spec, block_id)
+                if extent is not None:
+                    return DotAxisKind.FIXED_FULL_EXTENT, extent
+            if static_extent is None:
+                return DotAxisKind.UNKNOWN, None
+            return DotAxisKind.FIXED_FULL_EXTENT, static_extent
+
+        axes: list[DotAxes] = []
+        for fact in facts:
+            m_kind, m_extent = classify_axis(fact.m_block_id, fact.static_m)
+            n_kind, n_extent = classify_axis(fact.n_block_id, fact.static_n)
+            k_kind, k_extent = classify_axis(fact.k_block_id, fact.static_k)
+            axes.append(
+                DotAxes(
+                    m_kind,
+                    n_kind,
+                    k_kind,
+                    m_extent,
+                    n_extent,
+                    k_extent,
+                )
+            )
+
+        knob_users: dict[int, list[tuple[int, str]]] = {}
+        for index, fact in enumerate(facts):
+            for axis, block_id in (
+                ("m", fact.m_block_id),
+                ("n", fact.n_block_id),
+                ("k", fact.k_block_id),
+            ):
+                if block_id is not None and block_id in valid_block_ids:
+                    knob_users.setdefault(block_id, []).append((index, axis))
+
+        def axis_extent_or_none(block_id: int) -> int | None:
+            if 0 <= block_id < len(env.block_sizes):
+                size = env.block_sizes[block_id].size
+                if isinstance(size, (int, torch.SymInt)):
+                    try:
+                        return max(1, int(env.size_hint(size)))
+                    except Exception:
+                        return None
+            return None
+
+        def axis_extent(block_id: int) -> int:
+            return axis_extent_or_none(block_id) or 1
+
+        grid_block_ids = set(spec.grid_block_ids)
+        matmul_output_block_ids = {fact.m_block_id for fact in facts} | {
+            fact.n_block_id for fact in facts
+        }
+        outer_grid = 1
+        for block_id in spec.grid_block_ids:
+            if block_id not in matmul_output_block_ids:
+                outer_grid *= axis_extent(block_id)
+
+        bounded_by: dict[int, int] = {}
+        bounded_extent: dict[int, int] = {}
+        for slot in range(len(spec.block_sizes)):
+            block_spec = spec.block_sizes[slot]
+            parent = getattr(block_spec, "bounded_by_block_id", None)
+            if isinstance(parent, int):
+                bounded_by[block_spec.block_id] = parent
+                if 0 <= parent < len(env.block_sizes):
+                    source = env.block_sizes[parent].block_size_source
+                    value = getattr(source, "value", None)
+                    if isinstance(source, FixedBlockSizeSource) and isinstance(
+                        value,
+                        int,
+                    ):
+                        bounded_extent[block_spec.block_id] = max(1, value)
+
+        def loop_axes_for(graph_id: int) -> tuple[LoopAxisFact, ...]:
+            axes_out: list[LoopAxisFact] = []
+            seen_graphs: set[int] = set()
+            seen_axes: set[int] = set()
+            current = graph_id
+            while current in self.loop_block_ids and current not in seen_graphs:
+                seen_graphs.add(current)
+                for block_id in sorted(self.loop_block_ids[current]):
+                    if block_id in grid_block_ids or block_id in seen_axes:
+                        continue
+                    seen_axes.add(block_id)
+                    axes_out.append(
+                        LoopAxisFact(
+                            block_id,
+                            axis_extent_or_none(block_id),
+                            bounded_by.get(block_id),
+                            bounded_extent.get(block_id),
+                        )
+                    )
+                current = self.parent_of.get(current, -1)
+            return tuple(axes_out)
+
+        def trips_for(graph_id: int) -> int:
+            trips = 1
+            for axis in loop_axes_for(graph_id):
+                extent = axis.extent or 1
+                if axis.bounded_by_block_id is not None:
+                    extent = (
+                        axis.bounded_extent
+                        or _immovable_extent(
+                            env,
+                            spec,
+                            axis.bounded_by_block_id,
+                        )
+                        or axis_extent(axis.bounded_by_block_id)
+                    )
+                block = _immovable_extent(env, spec, axis.block_id)
+                trips *= max(1, -(-extent // block)) if block else extent
+            return trips
+
+        def strip_index_cast(value: object) -> object:
+            for _ in range(4):
+                if not isinstance(value, torch.fx.Node) or value.target not in (
+                    torch.ops.prims.convert_element_type.default,
+                    torch.ops.aten._to_copy.default,
+                ):
+                    break
+                value = value.args[0]
+            return value
+
+        def is_single_segment_loop(body_graph_id: int, block_id: int) -> bool:
+            calls = self.loop_calls.get(body_graph_id, ())
+            if len(calls) != 1:
+                return False
+            block_id_order = self.by_id[body_graph_id].block_id_order
+            if block_id not in block_id_order:
+                return False
+            position = block_id_order.index(block_id)
+            call = calls[0]
+            ends = call.args[2] if len(call.args) > 2 else None
+            if not isinstance(ends, (list, tuple)) or position >= len(ends):
+                return False
+
+            difference = strip_index_cast(ends[position])
+            if (
+                not isinstance(difference, torch.fx.Node)
+                or difference.target is not torch.ops.aten.sub.Tensor
+            ):
+                return False
+            end = strip_index_cast(difference.args[0])
+            begin = strip_index_cast(difference.args[1])
+
+            from ..language import memory_ops
+
+            if (
+                not isinstance(end, torch.fx.Node)
+                or end.target is not memory_ops.load
+                or not isinstance(begin, torch.fx.Node)
+                or begin.target is not memory_ops.load
+                or end.args[0] is not begin.args[0]
+            ):
+                return False
+            offsets = _accessed_tensor_fake(end)
+            if (
+                offsets is None
+                or offsets.ndim != 1
+                or env.size_hint(offsets.shape[0]) != 2
+            ):
+                return False
+            end_indices = end.args[1] if len(end.args) > 1 else None
+            begin_indices = begin.args[1] if len(begin.args) > 1 else None
+            if (
+                not isinstance(end_indices, (list, tuple))
+                or len(end_indices) != 1
+                or not isinstance(begin_indices, (list, tuple))
+                or len(begin_indices) != 1
+            ):
+                return False
+            end_index = strip_index_cast(end_indices[0])
+            begin_index = strip_index_cast(begin_indices[0])
+            if not isinstance(end_index, torch.fx.Node):
+                return False
+            if end_index.target not in (
+                operator.add,
+                torch.ops.aten.add.Tensor,
+                torch.ops.aten.add.Scalar,
+            ):
+                return False
+            lhs, rhs = end_index.args[:2]
+            return (lhs is begin_index and isinstance(rhs, int) and rhs == 1) or (
+                rhs is begin_index and isinstance(lhs, int) and lhs == 1
+            )
+
+        def direct_operand_trip_count(
+            node: torch.fx.Node,
+            operand_index: int,
+        ) -> tuple[int, int] | None:
+            from ..language import memory_ops
+
+            if operand_index >= len(node.args):
+                return None
+            operand = node.args[operand_index]
+            load = trace_back_to_load(operand, memory_ops.load)
+            if load is None or not isinstance(operand, torch.fx.Node):
+                return None
+            source = _accessed_tensor_fake(load)
+            operand_value = operand.meta.get("val")
+            if source is None or not isinstance(operand_value, torch.Tensor):
+                return None
+
+            source_numel = 1
+            for size, stride in zip(source.shape, source.stride(), strict=True):
+                if stride != 0:
+                    source_numel *= max(1, env.size_hint(size))
+            operand_numel = 1
+            for size in operand_value.shape:
+                operand_numel *= max(1, env.size_hint(size))
+            denominator = max(1, outer_grid) * operand_numel
+            if source_numel % denominator:
+                return None
+            return id(load), max(1, source_numel // denominator)
+
+        dot_targets = matmul_operand_positions()
+        dots_by_graph: dict[int, list[torch.fx.Node]] = {}
+        for graph_id, node in self.dot_nodes:
+            dots_by_graph.setdefault(graph_id, []).append(node)
+
+        inferred_work_trips: dict[tuple[int, int], int] = {}
+        for body_graph_id, block_ids in self.loop_block_ids.items():
+            unresolved = [
+                block_id
+                for block_id in block_ids
+                if block_id not in grid_block_ids
+                and axis_extent_or_none(block_id) is None
+                and block_id not in bounded_by
+            ]
+            enclosing_axes = loop_axes_for(body_graph_id)
+            if len(block_ids) != 1 or len(unresolved) != 1 or len(enclosing_axes) != 1:
+                continue
+            block_id = unresolved[0]
+            if not is_single_segment_loop(body_graph_id, block_id):
+                continue
+            block = _immovable_extent(env, spec, block_id)
+            if block is None:
+                continue
+            trip_by_load: dict[int, int] = {}
+            for node in dots_by_graph.get(body_graph_id, ()):
+                positions = dot_targets.get(node.target)
+                if positions is None:
+                    continue
+                for operand_index in positions:
+                    proof = direct_operand_trip_count(node, operand_index)
+                    if proof is not None:
+                        trip_by_load[proof[0]] = proof[1]
+            trips = set(trip_by_load.values())
+            if len(trip_by_load) >= 2 and len(trips) == 1:
+                inferred_work_trips[(body_graph_id, block_id)] = trips.pop()
+
+        n_dot_nodes = len(self.dot_nodes)
+        attribution_complete = n_dot_nodes == len(facts)
+        sites: list[DotSite] = []
+        if attribution_complete:
+            for index, (graph_id, node) in enumerate(self.dot_nodes):
+                value = node.meta.get("val")
+                if isinstance(value, torch.Tensor) and value.ndim >= 2:
+                    observed_extents: list[int] = []
+                    for dimension in value.shape[-2:]:
+                        block_id = env.resolve_block_id(dimension)
+                        if block_id is not None and 0 <= block_id < len(
+                            env.block_sizes
+                        ):
+                            dimension = env.block_sizes[block_id].size
+                        if not isinstance(dimension, (int, torch.SymInt)):
+                            observed_extents.append(-1)
+                            continue
+                        try:
+                            observed_extents.append(int(env.size_hint(dimension)))
+                        except Exception:
+                            observed_extents.append(-1)
+                    expected_extents = [
+                        facts[index].static_m,
+                        facts[index].static_n,
+                    ]
+                    if any(
+                        expected is not None and observed != -1 and expected != observed
+                        for expected, observed in zip(
+                            expected_extents,
+                            observed_extents,
+                            strict=False,
+                        )
+                    ):
+                        attribution_complete = False
+                updates_carry = (
+                    self.by_id[graph_id].reaches_output(node)
+                    and graph_id in self.loop_block_ids
+                )
+                loop_axes = loop_axes_for(graph_id)
+                exact_loop_trips = (
+                    inferred_work_trips.get((graph_id, loop_axes[0].block_id))
+                    if len(loop_axes) == 1
+                    else None
+                )
+                sites.append(
+                    DotSite(
+                        graph_id,
+                        trips_for(graph_id),
+                        updates_carry,
+                        loop_axes,
+                        exact_loop_trips,
+                    )
+                )
+        if not attribution_complete:
+            sites = [DotSite(-1, 1, False, (), None) for _ in facts]
+
+        sequential_loop_trips = 1
+        for body_graph_id, block_ids in self.loop_block_ids.items():
+            if any(block_id in spec.grid_block_ids for block_id in block_ids):
+                continue
+            sequential_loop_trips = max(
+                sequential_loop_trips,
+                trips_for(body_graph_id),
+            )
+
+        pipelined_regions: list[PipelinedRegion] = []
+        resident_regions: list[ResidentRegion] = []
+        for graph in self.non_reduction_graphs:
+            loop_axes = (
+                loop_axes_for(graph.graph_id)
+                if graph.graph_id in self.loop_block_ids
+                else ()
+            )
+            tiles = graph.memory_tiles_for_loop_axes(
+                env,
+                frozenset(axis.block_id for axis in loop_axes),
+            )
+            if not tiles:
+                continue
+            if graph.graph_id in self.loop_block_ids:
+                pipelined_regions.append(PipelinedRegion(loop_axes, tuple(tiles)))
+            else:
+                resident_regions.append(ResidentRegion(tuple(tiles)))
+
+        resolved = tuple(
+            starmap(ResolvedMatmulFact, zip(facts, axes, sites, strict=True))
+        )
+        return KernelMatmulFact(
+            matmuls=resolved,
+            knob_users=tuple(
+                (block_id, tuple(knob_users[block_id]))
+                for block_id in sorted(knob_users)
+            ),
+            outer_grid=outer_grid,
+            sequential_loop_trips=sequential_loop_trips,
+            live_tiles=tuple(self.kernel_peak_live_tiles()),
+            live_dot_outputs=tuple(self.kernel_peak_dot_outputs()),
+            live_tile_steps=tuple(self.kernel_live_tile_steps()),
+            pipelined_regions=tuple(pipelined_regions),
+            resident_regions=tuple(resident_regions),
+            n_dot_nodes=max(n_dot_nodes, len(facts)),
+            attribution_complete=attribution_complete,
+        )

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -26,6 +26,7 @@ from ..language.tile_proxy import _CheckForIndexCalls
 from .ast_extension import ExtendedAST
 from .compile_environment import AutoSize
 from .compile_environment import CompileEnvironment
+from .compile_environment import ConfigValueExpression
 from .compile_environment import FixedBlockSizeSource
 from .compile_environment import LoopSpecBlockSizeSource
 from .compile_environment import _symint_expr
@@ -814,7 +815,33 @@ class CallableType(LiteralType):
             for x in proxy_args
         ):
             if self.value in self._new_symint_on_host_fns() and origin.is_host():
-                return SymIntType.new_unbacked(origin)
+                result = SymIntType.new_unbacked(origin)
+                operation = self._config_value_operation()
+                derived_args: list[int | str | ConfigValueExpression] = []
+                for arg in proxy_args:
+                    if isinstance(arg, int):
+                        derived_args.append(arg)
+                    elif isinstance(arg, torch.SymInt):
+                        expr = _symint_expr(arg)
+                        if expr is None:
+                            break
+                        expression = env.config_value_expressions.get(expr)
+                        if expression is None:
+                            break
+                        derived_args.append(expression)
+                    else:
+                        break
+                else:
+                    result_expr = _symint_expr(result.value)
+                    if (
+                        operation is not None
+                        and not proxy_kwargs
+                        and result_expr is not None
+                    ):
+                        env.config_value_expressions[result_expr] = (
+                            ConfigValueExpression(operation, tuple(derived_args))
+                        )
+                return result
             if isinstance(self.value, type) and issubclass(
                 self.value, ConfigFragmentType
             ):
@@ -876,6 +903,23 @@ class CallableType(LiteralType):
         except ImportError:
             pass
         return cast("dict[object, None]", dict.fromkeys(fns))
+
+    def _config_value_operation(self) -> str | None:
+        from .._utils import cdiv
+        from .._utils import next_power_of_2
+
+        if self.value in (cdiv, next_power_of_2):
+            return self.value.__name__
+        try:
+            import triton as _triton
+
+            if self.value is _triton.cdiv:
+                return "cdiv"
+            if self.value is _triton.next_power_of_2:
+                return "next_power_of_2"
+        except ImportError:
+            pass
+        return None
 
 
 def _raise_shape_specializing(*args: object) -> None:
@@ -1157,14 +1201,27 @@ class TileIndexType(TypeInfo):
             if isinstance(numel, torch.SymInt):
                 maybe_bounded_by = _detect_outer_block_bound(numel, env)
                 if maybe_bounded_by is not None:
+                    bounded_by = maybe_bounded_by
                     try:
                         outer_spec = env.config_spec.block_sizes.block_id_lookup(
                             maybe_bounded_by
                         )
                     except KeyError:
-                        pass
+                        # A fixed outer tile has no autotuner BlockSizeSpec, but it
+                        # still bounds this inner loop. Retain the relationship and
+                        # use the fixed source's value as the search ceiling.
+                        if 0 <= maybe_bounded_by < len(env.block_sizes):
+                            outer_info = env.block_sizes[maybe_bounded_by]
+                            source = outer_info.block_size_source
+                            if isinstance(source, FixedBlockSizeSource):
+                                try:
+                                    outer_max = max(
+                                        1,
+                                        int(env.size_hint(source.value)),
+                                    )
+                                except Exception:
+                                    outer_max = None
                     else:
-                        bounded_by = maybe_bounded_by
                         outer_max = outer_spec.max_size
             env.config_spec.block_sizes.append(
                 BlockSizeSpec(

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -172,6 +172,305 @@ class MatmulFact(NamedTuple):
     rhs_dtype: torch.dtype
 
 
+class DotAxisKind(enum.Enum):
+    """How one M/N/K axis of a contraction maps onto the config surface.
+
+    A GEMM has three ``TUNABLE_TILED`` axes, which is what the historical matmul gate
+    assumed. A contraction written inside a chunked kernel very often has one axis the
+    kernel fixes at its full extent: the author ``hl.specialize``\\d it, so the axis has
+    either no block id at all or a block id that is not in ``valid_block_ids()``. That
+    is not a smaller problem, only a smaller set of knobs — the seed must adjust a
+    different axis or a scalar knob instead of declining.
+
+    - ``TUNABLE_TILED`` — a real, tunable ``block_size`` entry the seed may set.
+    - ``FIXED_FULL_EXTENT`` — statically known, not tunable: the tile extent along
+      this axis is the extent itself and cannot be moved.
+    - ``UNKNOWN`` — no static extent (dynamic / jagged); nothing can be sized.
+    """
+
+    TUNABLE_TILED = "tunable_tiled"
+    FIXED_FULL_EXTENT = "fixed_full_extent"
+    UNKNOWN = "unknown"
+
+
+class DotAxes(NamedTuple):
+    """The :class:`DotAxisKind` and the REAL per-program tile extent of one dot's
+    M/N/K axes.
+
+    ``*_extent`` is the extent the hardware sees along that axis for one program:
+    the (not-yet-chosen) block size for a ``TUNABLE_TILED`` axis — recorded here as
+    the axis's full static extent, an upper bound — and the fixed extent for a
+    ``FIXED_FULL_EXTENT`` one. ``*_iters`` is how many times the axis is traversed
+    per program (1 unless the axis is tiled and looped).
+    """
+
+    m_kind: DotAxisKind
+    n_kind: DotAxisKind
+    k_kind: DotAxisKind
+    m_extent: int | None
+    n_extent: int | None
+    k_extent: int | None
+
+    def kind(self, axis: str) -> DotAxisKind:
+        return {"m": self.m_kind, "n": self.n_kind, "k": self.k_kind}[axis]
+
+    def extent(self, axis: str) -> int | None:
+        return {"m": self.m_extent, "n": self.n_extent, "k": self.k_extent}[axis]
+
+    @property
+    def tunable_axes(self) -> tuple[str, ...]:
+        return tuple(
+            a for a in ("m", "n", "k") if self.kind(a) is DotAxisKind.TUNABLE_TILED
+        )
+
+    @property
+    def fixed_axes(self) -> tuple[str, ...]:
+        return tuple(
+            a for a in ("m", "n", "k") if self.kind(a) is DotAxisKind.FIXED_FULL_EXTENT
+        )
+
+
+class LiveTile(NamedTuple):
+    """One simultaneously-live tensor tile at a graph's peak-live step.
+
+    Extends the bare ``dim_block_ids`` liveness view with the two things a resource
+    estimate cannot be written without: how WIDE an element is, and WHO produced
+    the tile. A dot's fp32 output is charged to tensor memory on tcgen05 and to the
+    register file otherwise; a plain load is charged to the operand staging ring;
+    neither substitutes for the other.
+
+    - ``dim_block_ids`` — block id spanned per shape dim (``None`` for a static dim),
+      the same representation as :class:`AccumulatorFact`.
+    - ``static_dims`` — the extent at each ``None`` position, so a footprint can be
+      computed without re-resolving shapes (``None`` where unresolvable).
+    - ``itemsize`` — element width in bytes.
+    - ``kind`` — ``"dot_out"`` | ``"load"`` | ``"carry"`` | ``"other"``.
+    - ``stageable`` — for a loop-body load, whether its index is proven to
+      vary with the enclosing loop. ``None`` means uncertain and is charged
+      conservatively as stageable.
+    """
+
+    dim_block_ids: tuple[int | None, ...]
+    static_dims: tuple[int | None, ...]
+    itemsize: int
+    kind: str
+    stageable: bool | None = None
+
+
+class LoopAxisFact(NamedTuple):
+    """One tunable or fixed axis in an enclosing device loop.
+
+    ``extent`` is the full axis length. ``bounded_by_block_id`` records an inner
+    loop over exactly one outer tile (for example split-K's
+    ``tile(outer.begin, outer.end)``); in that case the candidate outer block is
+    the real extent, not the whole underlying axis. ``bounded_extent`` is set
+    only when that outer extent is a literal; a symbolic fixed parent remains
+    explicitly uncertain. The per-program block is deliberately not recorded
+    here: it is a candidate property and must be resolved from the emitted
+    ``block_sizes`` before the trip count is used.
+    """
+
+    block_id: int
+    extent: int | None
+    bounded_by_block_id: int | None = None
+    bounded_extent: int | None = None
+
+
+class PipelinedRegion(NamedTuple):
+    """Memory operations belonging to one sequential device-loop body.
+
+    Separate regions are siblings unless their loop descriptors explicitly contain
+    the same ancestor axes.  Loads are conservatively considered stageable for now;
+    the tuple representation keeps that uncertainty local to this fact boundary
+    while allowing useful depth to be capped by the candidate-real loop length.
+    """
+
+    loop_axes: tuple[LoopAxisFact, ...]
+    tiles: tuple[LiveTile, ...]
+
+
+class ResidentRegion(NamedTuple):
+    """Memory operations belonging to one non-loop graph."""
+
+    tiles: tuple[LiveTile, ...]
+
+
+class RootGridFact(NamedTuple):
+    """One top-level device grid before a candidate block size is selected."""
+
+    root_graph_id: int
+    block_ids: tuple[int, ...]
+
+
+class KernelGridFact(NamedTuple):
+    """Root-grid topology shared by every specialized kernel fact.
+
+    ``roots`` preserves the independent top-level grids in source order.
+    ``graph_to_root`` assigns nested device graphs to their owning root. Concrete
+    program counts are intentionally absent: they depend on the candidate block
+    sizes and must be recomputed while a heuristic edits its draft.
+    """
+
+    roots: tuple[RootGridFact, ...]
+    graph_to_root: tuple[tuple[int, int], ...]
+
+    @property
+    def grid_groups(self) -> tuple[tuple[int, ...], ...]:
+        return tuple(root.block_ids for root in self.roots)
+
+    def root_id_for_graph(self, graph_id: int) -> int | None:
+        for candidate, root_id in self.graph_to_root:
+            if candidate == graph_id:
+                return root_id
+        return None
+
+    def group_for_graph(self, graph_id: int) -> tuple[int, ...]:
+        root_id = self.root_id_for_graph(graph_id)
+        for root in self.roots:
+            if root.root_graph_id == root_id:
+                return root.block_ids
+        return ()
+
+    def groups_for_graphs(
+        self, graph_ids: tuple[int, ...]
+    ) -> tuple[tuple[int, ...], ...]:
+        groups: list[tuple[int, ...]] = []
+        for graph_id in graph_ids:
+            group = self.group_for_graph(graph_id)
+            if group and group not in groups:
+                groups.append(group)
+        return tuple(groups)
+
+
+class DotSite(NamedTuple):
+    """Where one contraction sits in the kernel, and how much work it does.
+
+    Attribution of a :class:`MatmulFact` (recorded at trace time, in source order) to
+    a graph node is a COMPUTED pairing validated by a post-condition, never an
+    assumed one: :attr:`KernelMatmulFact.attribution_complete` is False when the
+    pairing could not be proven, and a consumer that needs per-dot placement must
+    check it rather than trusting these fields.
+
+    - ``graph_id`` — the device graph the dot's node lives in.
+      :class:`KernelGridFact` maps that graph to its root grid; the topology is
+      intentionally not copied into each site.
+    - ``loop_trips`` — product of the sequential loop trip counts enclosing it, i.e.
+      how many times one program executes this dot.
+    - ``updates_carry`` — the dot writes into a value carried by an enclosing loop
+      (``acc=`` into a loop-carried accumulator). Such a dot's accumulator is
+      resident for the whole loop, which is why it gets ranking priority.
+    - ``loop_axes`` — the enclosing loop axes before a candidate block size is
+      selected. Consumers that need an exact execution count resolve these axes
+      against the candidate instead of treating ``loop_trips`` as exact.
+    - ``exact_loop_trips`` — an exact dynamic execution count proven independently
+      of the loop-bound expression. This is used for work estimation only; it does
+      not claim that the same loop is a useful software-pipeline opportunity.
+    """
+
+    graph_id: int
+    loop_trips: int
+    updates_carry: bool
+    loop_axes: tuple[LoopAxisFact, ...] = ()
+    exact_loop_trips: int | None = None
+
+
+class ResolvedMatmulFact(NamedTuple):
+    """One :class:`MatmulFact` interpreted in its graph and config context.
+
+    ``MatmulFact`` remains the trace-local description of the dot. This fact binds
+    it to the axis roles and execution site that consumers previously recovered
+    through parallel kernel-wide arrays.
+    """
+
+    fact: MatmulFact
+    axes: DotAxes
+    site: DotSite
+
+
+class KernelMatmulFact(NamedTuple):
+    """Every resolved matmul plus the shared facts needed to configure the kernel.
+
+    Built for any kernel with at least one contraction, so the single-matmul and
+    multi-matmul front ends read the same description of the workload and only their
+    POLICY differs. Kernel-name- and role-free by construction: every field is a
+    measured property of the contraction structure. Generic root-grid topology lives
+    in :class:`KernelGridFact` and is not duplicated here.
+
+    - ``matmuls`` — the contextual facts, one per dot.
+    - ``knob_users`` — for each tunable block id, the ``(dot_index, axis)`` pairs
+      whose axis maps onto it, i.e. which dots COMPETE for that knob.
+    - ``outer_grid`` — parallel programs contributed by grid axes that are no dot's
+      M or N tile: the occupancy the kernel already has before any tiling choice.
+    - ``sequential_loop_trips`` — product of the trip counts of the kernel's
+      sequential (non-grid) loops. For a chunked recurrence this is the number of
+      chunks, so ``sequential_loop_trips * fixed_k`` recovers the logical contraction
+      length even though each dot only sees one chunk.
+    - ``live_tiles`` — the peak simultaneously-live tile set over the whole kernel
+      (:class:`LiveTile`), from the same last-use liveness sweep the reduction fact
+      uses. The maximum simultaneously-live footprint, NOT the sum of every op.
+    - ``live_dot_outputs`` — the live set at the step holding the most simultaneously
+      live DOT OUTPUT tiles. A separate measurement from ``live_tiles`` because that
+      one's peak is chosen by rank profile (the right question for a reduction's
+      register working set, the wrong one for the accumulator budget: the rank peak can
+      be a step where the heavy loads are live and the accumulators are not). This is
+      what a sum-over-live-accumulators tensor-memory/register term is computed from.
+    - ``live_tile_steps`` — the live tile set at EVERY step of the kernel's graphs, deduped.
+      ``live_tiles`` above is one step chosen by RANK PROFILE, which is block-size-free and so
+      the right question when block sizes are unknown; a register estimate is asked later, when
+      the candidate block sizes ARE known, and should pick its peak by resolved BYTES. Keeping
+      every step is what lets it. Selecting by rank instead under-counted a kernel that spills
+      540 registers at one warp while over-counting one that spills none — the ordering
+      inverted, so no threshold on that estimate could separate them.
+    - ``pipelined_regions`` — the loads/stores and enclosing loop axes of each LOOP
+      BODY. The axes let a candidate cap useful pipeline depth by the iterations it
+      actually executes. The SMEM operand ring is charged over every conservatively
+      stageable load, not only the dot's own A and B: a sum within a region times its
+      useful stage count, and a max across regions (separate loops run one after the
+      other).
+    - ``resident_regions`` — the loads/stores of the NON-loop graphs. These are charged
+      ONCE, with no stage multiplier: a load outside a loop is not multi-buffered, and
+      charging it per stage over-states shared memory badly enough to shrink a tile to the
+      dot minimum for a phantom overflow.
+    - ``n_dot_nodes`` — contraction sites counted spelling-independently, so a kernel
+      whose dots are written as ``torch.matmul``/``@`` is not read as having none.
+    - ``attribution_complete`` — post-condition flag described above.
+    """
+
+    matmuls: tuple[ResolvedMatmulFact, ...]
+    knob_users: tuple[tuple[int, tuple[tuple[int, str], ...]], ...]
+    outer_grid: int
+    sequential_loop_trips: int
+    live_tiles: tuple[LiveTile, ...]
+    live_dot_outputs: tuple[LiveTile, ...]
+    live_tile_steps: tuple[tuple[LiveTile, ...], ...]
+    pipelined_regions: tuple[PipelinedRegion, ...]
+    resident_regions: tuple[ResidentRegion, ...]
+    n_dot_nodes: int
+    attribution_complete: bool
+
+    def users_of(self, block_id: int) -> tuple[tuple[int, str], ...]:
+        for bid, users in self.knob_users:
+            if bid == block_id:
+                return users
+        return ()
+
+    def dot_work(self, index: int) -> int:
+        """Dynamic work of one dot: ``m*n*k`` per execution times its executions.
+
+        Falls back to the axis classification's per-program extent when the fact's own
+        ``static_*`` is absent, which happens whenever the axis length is dynamic but the
+        per-program extent is not."""
+        resolved = self.matmuls[index]
+        f = resolved.fact
+        ax = resolved.axes
+        m = f.static_m or ax.m_extent or 1
+        n = f.static_n or ax.n_extent or 1
+        k = f.static_k or ax.k_extent or 1
+        site = resolved.site
+        trips = site.exact_loop_trips or site.loop_trips
+        return m * n * k * max(1, trips)
+
+
 class ReductionCategory(enum.Enum):
     """How a reduction axis maps onto the program grid — one category per reduction.
 
@@ -721,6 +1020,9 @@ class ConfigSpec:
         self.restriction_reasons: list[tuple[str, str]] = []
         self.max_num_sm_multiplier: int = MAX_NUM_SM_MULTIPLIER
         self.grid_block_ids: list[int] = []
+        # Ordered root grids and nested-graph ownership, independent of any
+        # specialized matmul/reduction policy.
+        self.kernel_grid_fact: KernelGridFact | None = None
         self.tensor_numel_constraints: list[TensorNumelConstraint] = []
         self.load_eviction_policies = ListOf(
             EnumFragment(choices=get_valid_eviction_policies(self.backend_name)),
@@ -777,6 +1079,10 @@ class ConfigSpec:
         self.compiler_seed_timeout_retry_repetitions: int | None = None
         self.autotuner_heuristics: list[str] = []
         self.matmul_facts: list[MatmulFact] = []
+        # Whole-kernel composed contraction fact (built for ANY kernel with >=1
+        # matmul fact); both matmul front ends read it so workload analysis is
+        # independent of which heuristic runs.
+        self.kernel_matmul_fact: KernelMatmulFact | None = None
         # The Stage-1 categorizing product the reduction seed + allocator consume.
         self.reduction_kernel_fact: ReductionKernelFact | None = None
         self.matmul_reduction_epilogue_facts: list[MatmulWithReductionEpilogueFact] = []

--- a/helion/language/tunable_ops.py
+++ b/helion/language/tunable_ops.py
@@ -12,6 +12,8 @@ from .._compiler.ast_extension import ExtendedAST
 from .._compiler.ast_extension import expr_from_string
 from .._compiler.compile_environment import AutoSize
 from .._compiler.compile_environment import CompileEnvironment
+from .._compiler.compile_environment import ConfigValueExpression
+from .._compiler.compile_environment import _symint_expr
 from .._compiler.type_info import TileIndexType
 from .._compiler.type_info import TypeInfo
 from .._compiler.type_info import _to_proxy
@@ -184,6 +186,12 @@ def _register_tunable_type(
     for symbol in result.value._sympy_().free_symbols:
         assert isinstance(symbol, sympy.Symbol)
         env.tunable_symbols.add(symbol)
+    if isinstance(result.value, torch.SymInt):
+        expr = _symint_expr(result.value)
+        if expr is not None:
+            env.config_value_expressions[expr] = ConfigValueExpression(
+                "config", (name_val,)
+            )
     return result
 
 

--- a/test/test_matmul_heuristics.py
+++ b/test/test_matmul_heuristics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from itertools import starmap
 import json
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -12,14 +13,26 @@ from helion._compiler.autotuner_heuristics.triton import (
     TritonB200FormulaMatmulHeuristic,
 )
 from helion._compiler.autotuner_heuristics.triton import TritonB200MatmulHeuristic
+from helion._compiler.autotuner_heuristics.triton import (
+    TritonB200MultiMatmulHeuristic as _MULTI,
+)
 from helion._compiler.autotuner_heuristics.triton import TritonH100MatmulHeuristic
+from helion._compiler.autotuner_heuristics.triton import _batched_static_matmul_fact
+from helion._compiler.autotuner_heuristics.triton import _generalized_static_matmul_fact
 from helion._compiler.autotuner_heuristics.triton import _seed_config_for_bucket
 from helion._compiler.autotuner_heuristics.triton import _seed_config_for_config_spec
 from helion.autotuner.config_fragment import EnumFragment
 from helion.autotuner.config_fragment import IntegerFragment
 from helion.autotuner.config_fragment import ListOf
 from helion.autotuner.config_fragment import PowerOfTwoFragment
+from helion.autotuner.config_spec import DotAxes
+from helion.autotuner.config_spec import DotAxisKind
+from helion.autotuner.config_spec import KernelGridFact
+from helion.autotuner.config_spec import LiveTile
+from helion.autotuner.config_spec import LoopAxisFact
 from helion.autotuner.config_spec import MatmulFact
+from helion.autotuner.config_spec import PipelinedRegion
+from helion.autotuner.config_spec import RootGridFact
 
 _SHAPE_BUCKET_KEYS = {
     "dtype",
@@ -184,6 +197,7 @@ def test_b200_formula_subsumes_table_promotion_wiring() -> None:
     # The sm100 FORMULA owns the compiler default; the TABLE is demoted to a search seed.
     assert TritonB200FormulaMatmulHeuristic.promote_seed_to_default is True
     assert TritonB200MatmulHeuristic.promote_seed_to_default is False
+    assert _MULTI.promote_seed_to_default is False
     assert TritonB200FormulaMatmulHeuristic.HARDWARE_TARGETS == (("cuda", "sm100"),)
     # The formula is a subclass of the H100 budget formula (inherits _matmul_tile).
     assert issubclass(TritonB200FormulaMatmulHeuristic, TritonH100MatmulHeuristic)
@@ -338,3 +352,941 @@ def test_sm90_conservative_accounting_is_inert() -> None:
 
     # And the sm90 tile is unchanged: still the register-budget [128, 256].
     assert cls._matmul_tile(4096, 4096, 4096, 2, 132, 1)[:3] == (128, 256, 64)
+
+
+# ---------------------------------------------------------------------------
+# Generalized axis freedom, graded occupancy, and whole-kernel resources.
+#
+# These pin the mandatory Section-3 capabilities individually, so a poor
+# curriculum result is attributable to policy rather than to an implementation
+# bug in the fact layer, the projection, the ranking, or the resource model.
+# ---------------------------------------------------------------------------
+
+_FML = TritonB200FormulaMatmulHeuristic
+_H100 = TritonH100MatmulHeuristic
+
+
+def _axes(
+    m: DotAxisKind = DotAxisKind.TUNABLE_TILED,
+    n: DotAxisKind = DotAxisKind.TUNABLE_TILED,
+    k: DotAxisKind = DotAxisKind.TUNABLE_TILED,
+    *,
+    m_extent: int | None = 1024,
+    n_extent: int | None = 1024,
+    k_extent: int | None = 1024,
+) -> DotAxes:
+    return DotAxes(m, n, k, m_extent, n_extent, k_extent)
+
+
+class _BlockSizesStub(list):
+    """A ``ConfigSpec.block_sizes`` stand-in: indexable + sized like the real one, plus
+    ``valid_block_ids()``."""
+
+    def __init__(self, block_ids: list[int]) -> None:
+        super().__init__(
+            SimpleNamespace(block_id=b, min_size=1, max_size=4096, autotuner_min=1)
+            for b in block_ids
+        )
+        self._ids = list(block_ids)
+
+    def valid_block_ids(self) -> list[int]:
+        return list(self._ids)
+
+
+def _block_sizes_stub(block_ids: list[int]) -> _BlockSizesStub:
+    return _BlockSizesStub(block_ids)
+
+
+def _generalized_spec(
+    fact: MatmulFact,
+    axes: DotAxes,
+    *,
+    valid_block_ids: list[int],
+    grid_block_ids: tuple[int, ...] = (),
+) -> SimpleNamespace:
+    loop_axes = (
+        (LoopAxisFact(fact.k_block_id, fact.static_k),)
+        if axes.k_kind is DotAxisKind.TUNABLE_TILED and fact.k_block_id is not None
+        else ()
+    )
+    mm = SimpleNamespace(
+        matmuls=(
+            SimpleNamespace(
+                fact=fact,
+                axes=axes,
+                site=SimpleNamespace(
+                    graph_id=0,
+                    loop_trips=max(1, fact.static_k or 1),
+                    updates_carry=False,
+                    loop_axes=loop_axes,
+                ),
+            ),
+        ),
+        knob_users=(),
+        outer_grid=1,
+        sequential_loop_trips=1,
+        live_tiles=(),
+        live_dot_outputs=(),
+        live_tile_steps=(),
+        pipelined_regions=(),
+        resident_regions=(),
+        n_dot_nodes=1,
+        attribution_complete=True,
+    )
+    return SimpleNamespace(
+        matmul_facts=[fact],
+        kernel_matmul_fact=mm,
+        block_sizes=_block_sizes_stub(valid_block_ids),
+        grid_block_ids=grid_block_ids,
+    )
+
+
+def test_generalized_gate_admits_a_fixed_contraction_axis() -> None:
+    """A dot whose K is a specialized full extent has no ``block_k`` to set. The incumbent
+    gate declines it for that reason alone; the generalized gate admits it, because a fixed
+    axis is a smaller set of knobs and not a smaller problem."""
+    fact = MatmulFact(
+        lhs_ndim=2,
+        rhs_ndim=2,
+        m_block_id=0,
+        n_block_id=1,
+        k_block_id=4,  # registered but NOT tunable
+        static_m=256,
+        static_n=256,
+        static_k=64,
+        lhs_dtype=torch.bfloat16,
+        rhs_dtype=torch.bfloat16,
+    )
+    spec = _generalized_spec(
+        fact,
+        _axes(k=DotAxisKind.FIXED_FULL_EXTENT, k_extent=64),
+        valid_block_ids=[0, 1],
+    )
+    assert _generalized_static_matmul_fact(spec) is fact
+    # ...and the incumbent gate still declines it, which is what made this widening needed.
+    assert _batched_static_matmul_fact(spec) is None
+
+
+def test_generalized_gate_admits_zero_tunable_dot_axes() -> None:
+    """A kernel that exposes no tile at all still wants num_warps / num_stages; the
+    alternative is the bare fragment default."""
+    fact = MatmulFact(
+        lhs_ndim=2,
+        rhs_ndim=2,
+        m_block_id=None,
+        n_block_id=None,
+        k_block_id=None,
+        static_m=64,
+        static_n=64,
+        static_k=64,
+        lhs_dtype=torch.bfloat16,
+        rhs_dtype=torch.bfloat16,
+    )
+    spec = _generalized_spec(
+        fact,
+        _axes(
+            DotAxisKind.FIXED_FULL_EXTENT,
+            DotAxisKind.FIXED_FULL_EXTENT,
+            DotAxisKind.FIXED_FULL_EXTENT,
+            m_extent=64,
+            n_extent=64,
+            k_extent=64,
+        ),
+        valid_block_ids=[],
+    )
+    assert _generalized_static_matmul_fact(spec) is fact
+
+
+def test_generalized_gate_declines_two_axes_sharing_one_knob() -> None:
+    """Two tunable axes on one block id is a genuine conflict that must be RANKED, which is
+    front end 2's job -- front end 1 has no way to arbitrate it."""
+    fact = MatmulFact(
+        lhs_ndim=2,
+        rhs_ndim=2,
+        m_block_id=0,
+        n_block_id=1,
+        k_block_id=1,  # same knob as N
+        static_m=256,
+        static_n=256,
+        static_k=256,
+        lhs_dtype=torch.bfloat16,
+        rhs_dtype=torch.bfloat16,
+    )
+    spec = _generalized_spec(fact, _axes(), valid_block_ids=[0, 1])
+    assert _generalized_static_matmul_fact(spec) is None
+
+
+def test_generalized_gate_declines_an_unknown_extent() -> None:
+    """No static extent means nothing can be sized; a dynamic/jagged dot must not be
+    silently configured from a guess."""
+    fact = MatmulFact(
+        lhs_ndim=2,
+        rhs_ndim=2,
+        m_block_id=0,
+        n_block_id=1,
+        k_block_id=2,
+        static_m=256,
+        static_n=256,
+        static_k=None,
+        lhs_dtype=torch.bfloat16,
+        rhs_dtype=torch.bfloat16,
+    )
+    spec = _generalized_spec(
+        fact, _axes(k=DotAxisKind.UNKNOWN, k_extent=None), valid_block_ids=[0, 1, 2]
+    )
+    assert _generalized_static_matmul_fact(spec) is None
+
+
+def test_tmem_is_counted_in_columns_and_sums_over_live_accumulators() -> None:
+    """tcgen05 tensor memory is allocated as 128 lanes x N columns of 32 bits, so a tile
+    costs ``ceil(bm/128) * bn`` COLUMNS and a bm<128 accumulator costs the same as a
+    full-lane one. Measured on B200: a kernel's ``tmem_size`` equals its accumulator's N
+    extent exactly ([64,64] -> 64, [128,128] -> 128, [128,256] -> 256)."""
+    assert _FML._tmem_columns([(64, 64, 2)]) == 64
+    assert _FML._tmem_columns([(128, 128, 2)]) == 128
+    assert _FML._tmem_columns([(128, 256, 2)]) == 256
+    # A byte model divides by the lanes a narrow accumulator does not use; the column model
+    # does not, which is the whole point.
+    assert _FML._tmem_columns([(64, 256, 2)]) == 256
+    # bm past a lane group needs a second one.
+    assert _FML._tmem_columns([(256, 256, 2)]) == 512
+    # Live accumulators ADD -- this is the measured failure
+    # (``tensor memory, Required: 768, limit 512``) reproduced as arithmetic.
+    assert _FML._tmem_columns([(128, 256, 2)] * 3) == 768
+    assert _FML._tmem_columns([(128, 256, 2)] * 3) > _FML.TMEM_COLUMN_BUDGET
+    # ...and one accumulator under the incumbent caps never binds, so the single-GEMM path
+    # is unaffected by adding this check.
+    assert _FML._tmem_columns([(128, _FML.BASE_BN_CAP, 2)]) <= _FML.TMEM_COLUMN_BUDGET
+    # Below the tcgen05 minimum the dot uses no tensor memory at all (measured
+    # ``tmem_size == 0``), so charging it would reject a tiny tile for a resource it never
+    # touches.
+    assert _FML._tmem_columns([(32, 256, 2)]) == 0
+    # sm90 has no tensor memory: the check must be completely inert there.
+    assert TritonH100MatmulHeuristic._tmem_columns([(128, 256, 2)] * 8) == 0
+
+
+def test_register_estimate_picks_its_peak_by_resolved_bytes() -> None:
+    """The register estimate must select its peak step by RESOLVED BYTES at the candidate
+    config, not by the block-size-free rank profile the reduction liveness machinery uses.
+
+    Selecting by rank picked a step holding several rank-2 loads over the step that actually
+    holds the accumulators. Measured against post-ptxas spills at one warp, that inverted the
+    ordering: a kernel spilling 540 registers estimated 1.33x the one-warp file while one
+    spilling none estimated 1.51x, so no threshold could separate them. With the byte-selected
+    peak the same 12 cells separate cleanly -- every zero-spill cell at or below 1.51x, every
+    spilling cell at or above 2.30x."""
+    from helion.autotuner.config_spec import LiveTile
+
+    def tile(kind: str, rows: int, cols: int, itemsize: int = 4) -> LiveTile:
+        return LiveTile(
+            dim_block_ids=(None, None),
+            static_dims=(rows, cols),
+            itemsize=itemsize,
+            kind=kind,
+        )
+
+    def env_with(steps: tuple) -> SimpleNamespace:
+        return SimpleNamespace(
+            config_spec=SimpleNamespace(
+                kernel_matmul_fact=SimpleNamespace(
+                    live_tile_steps=steps,
+                    matmuls=(),
+                ),
+                block_sizes=_block_sizes_stub([]),
+                _base_default_config=lambda: helion.Config(block_sizes=[]),
+            ),
+            block_sizes=[],
+        )
+
+    # The peak must be the BYTE-heaviest step, not the one with the most tiles: three small
+    # values must not outrank one large one.
+    many_small = tuple(tile("other", 8, 8) for _ in range(3))
+    one_large = (tile("other", 128, 128),)
+    env = env_with((many_small, one_large))
+    assert _FML._register_live_bytes(env, [], 4) == 128 * 128 * 4
+
+    # Loads are excluded: they are charged to the shared-memory ring, and charging them here
+    # would put the same bytes in two budgets.
+    assert _FML._register_live_bytes(env_with(((tile("load", 128, 128),),)), [], 4) == 0
+
+    # A value larger than the largest register file a CTA can have is not register-resident --
+    # it lives in HBM and the graph merely names it (a varlen packed buffer measured 256 MiB).
+    huge = (tile("other", 8192, 64),)
+    assert _FML._register_live_bytes(env_with((huge,)), [], 1) == 0
+
+    # A dot output is charged only where tensor memory cannot absorb it. Below a warpgroup
+    # there is no tcgen05 path at all (PTX: num_warps 1 or 2 emits zero tcgen05.mma and
+    # tmem_size 0), so the accumulator lands in registers; at 4 warps with bm >= the tcgen05
+    # minimum it does not.
+    acc = (tile("dot_out", 64, 64),)
+    assert _FML._register_live_bytes(env_with((acc,)), [], 1) == 64 * 64 * 4
+    assert _FML._register_live_bytes(env_with((acc,)), [], 2) == 64 * 64 * 4
+    assert _FML._register_live_bytes(env_with((acc,)), [], 4) == 0
+    # ...and a dot below the tcgen05 minimum stays register-resident at any warp count.
+    narrow = (tile("dot_out", 32, 64),)
+    assert _FML._register_live_bytes(env_with((narrow,)), [], 8) == 32 * 64 * 4
+
+
+def test_graded_stage_depth_falls_off_with_outer_parallelism() -> None:
+    """Depth is bought with shared memory per CTA, and shared memory per CTA is what limits
+    how many CTAs an SM holds. Below one wave there is no co-residency to protect and depth
+    is the only latency hiding available; above it, every extra stage evicts a CTA. So the
+    depth must fall off GRADUALLY with the grid -- which the incumbent single threshold at
+    ``SAT_WAVES * num_sm`` cannot express, and which matches the hand-tuned corpus (outer
+    grid 32 -> 8-11 stages, 96 -> 3-4, 256 -> 2-4, >=1024 -> 2)."""
+    per_stage = 16 * 1024
+
+    def smem_of(stages: int) -> int:
+        return per_stage * stages
+
+    depths = [
+        _FML._graded_stage_depth(smem_of, loop_trips=256, grid=grid, num_sm=148)
+        for grid in (32, 96, 148, 296, 1024, 16384)
+    ]
+    assert depths == sorted(depths, reverse=True), depths
+    assert depths[0] > depths[-1]
+    # The divisor is CLAMPED at GRADED_MAX_CTAS_PER_SM, so the gradient SATURATES rather
+    # than running to the floor: a grid far above the machine size does not demand a
+    # matching number of simultaneously-resident CTAs (the excess queues), and dividing by
+    # the raw wave count instead collapsed every large-grid kernel to a single stage
+    # (measured: an outer grid of 8192 on 148 SMs gives a 4 KiB per-CTA share).
+    assert depths[-1] == depths[-2]
+    assert (
+        _FML._graded_stage_depth(smem_of, loop_trips=256, grid=10**6, num_sm=148)
+        == depths[-1]
+    )
+    # An empty machine reaches depths the incumbent MAX_STAGES ceiling cannot express.
+    assert depths[0] > _FML.MAX_STAGES or _FML.HW_MAX_STAGES <= _FML.MAX_STAGES
+    assert depths[0] <= _FML.HW_MAX_STAGES
+
+
+def test_graded_stage_depth_is_capped_by_the_loop_it_pipelines() -> None:
+    """Real loop trips cap deep lookahead; one trip conditionally admits stage two."""
+
+    def cheap(stages: int) -> int:
+        return 1024 * stages
+
+    assert _FML._graded_stage_depth(cheap, loop_trips=3, grid=1, num_sm=148) == 3
+    assert _FML._graded_stage_depth(cheap, loop_trips=1, grid=1, num_sm=148) == 2
+    assert (
+        _FML._graded_stage_depth(
+            cheap,
+            loop_trips=1,
+            grid=1,
+            num_sm=148,
+            allow_one_trip_stage2=False,
+        )
+        == 1
+    )
+
+
+def test_tcgen_occupancy_penalty_uses_effective_residency() -> None:
+    """Queued waves do not increase the penalty after resident capacity is full."""
+    assert _FML._tcgen_occupancy_penalty(1, 1) == 1.0
+    assert _FML._tcgen_occupancy_penalty(4, 4) == 1.0
+    assert _FML._tcgen_occupancy_penalty(4, 2) == 2.0
+    assert _FML._tcgen_occupancy_penalty(32, 1) == _FML.TCGEN_OCCUPANCY_PENALTY_MAX
+
+
+def test_multi_matmul_ranking_prefers_a_carried_accumulator_then_work() -> None:
+    """A dot feeding a loop-carried accumulator holds that accumulator resident for the whole
+    loop, so its tile sets the kernel's whole-loop footprint -- hence ranking priority. But
+    it is a PREFERENCE: dimensions and execution count must also matter, and a kernel with no
+    carried accumulator has to rank purely on work."""
+    big = MatmulFact(2, 2, 0, 1, 2, 256, 256, 256, torch.bfloat16, torch.bfloat16)
+    small = MatmulFact(2, 2, 0, 1, 2, 64, 64, 64, torch.bfloat16, torch.bfloat16)
+
+    def mm(carry: tuple[bool, ...], trips: tuple[int, ...]) -> SimpleNamespace:
+        facts = (big, small)
+        sites = tuple(
+            SimpleNamespace(graph_id=0, loop_trips=t, updates_carry=c)
+            for c, t in zip(carry, trips, strict=True)
+        )
+        ns = SimpleNamespace(
+            matmuls=tuple(
+                SimpleNamespace(fact=fact, axes=axes, site=site)
+                for fact, axes, site in zip(
+                    facts,
+                    (_axes(), _axes()),
+                    sites,
+                    strict=True,
+                )
+            ),
+            attribution_complete=True,
+        )
+        ns.dot_work = lambda i: (
+            (facts[i].static_m or 1)
+            * (facts[i].static_n or 1)
+            * (facts[i].static_k or 1)
+            * max(1, ns.matmuls[i].site.loop_trips)
+        )
+        return ns
+
+    # The carried dot wins even though it does far less work.
+    f = mm((False, True), (1, 1))
+    assert _MULTI._rank_key(f, 1) > _MULTI._rank_key(f, 0)
+    # With no carry anywhere, work decides.
+    f = mm((False, False), (1, 1))
+    assert _MULTI._rank_key(f, 0) > _MULTI._rank_key(f, 1)
+    # Execution count is part of work, so a small dot run many times can outrank a big one.
+    f = mm((False, False), (1, 4096))
+    assert _MULTI._rank_key(f, 1) > _MULTI._rank_key(f, 0)
+    # Untrusted attribution must collapse the carry term for EVERY dot equally, so ranking
+    # degrades to pure work rather than to an arbitrary order.
+    f = mm((False, True), (1, 1))
+    f.attribution_complete = False
+    assert _MULTI._rank_key(f, 0) > _MULTI._rank_key(f, 1)
+
+
+def test_projection_is_a_no_op_for_a_clean_gemm() -> None:
+    """With three tunable axes and no extra live accumulator, ``_tile_for_dot`` must return
+    the incumbent proposal untouched -- that is what makes the whole widening safe for the
+    GEMM/BMM/split-K workloads it was not measured on."""
+    fact = _matmul_fact(static_m=4096, static_n=4096, static_k=4096)
+    spec = _generalized_spec(fact, _axes(), valid_block_ids=[0, 1, 2])
+    env = SimpleNamespace(config_spec=spec, block_sizes=[])
+    proposal = _FML._matmul_tile(4096, 4096, 4096, 2, 148, 1)
+    assert _FML._tile_for_dot(env, fact, _axes(), 2, 148, 1) == proposal
+
+
+def _kernel_smem_env(
+    facts: tuple[MatmulFact, ...],
+    *,
+    block_ids: list[int],
+    pipelined_regions: tuple[PipelinedRegion, ...] = (),
+) -> SimpleNamespace:
+    matmuls = tuple(
+        SimpleNamespace(fact=fact, axes=_axes(), site=SimpleNamespace(graph_id=0))
+        for fact in facts
+    )
+    spec = SimpleNamespace(
+        kernel_matmul_fact=SimpleNamespace(
+            matmuls=matmuls,
+            pipelined_regions=pipelined_regions,
+            resident_regions=(),
+        ),
+        block_sizes=_block_sizes_stub(block_ids),
+        _base_default_config=lambda: helion.Config(block_sizes=[1] * len(block_ids)),
+    )
+    return SimpleNamespace(config_spec=spec, block_sizes=[], size_hint=int)
+
+
+def test_kernel_smem_uses_region_peak_and_applies_slack_once() -> None:
+    fact = _matmul_fact()
+    loads = (
+        LiveTile((0, 2), (None, None), 2, "load"),
+        LiveTile((2, 1), (None, None), 2, "load"),
+    )
+    env = _kernel_smem_env(
+        (fact,),
+        block_ids=[0, 1, 2],
+        pipelined_regions=(PipelinedRegion((), loads),),
+    )
+    blocks = [64, 32, 16]
+    region_peak = (64 * 16 * 2 + 16 * 32 * 2) * 4
+
+    assert _FML._smem_from_map(env, blocks, 4) == region_peak
+    assert _FML._epilogue_smem(env, blocks) == 64 * 32 * 4
+    assert _FML._kernel_smem_bytes(env, blocks, 4) == region_peak + _FML.SMEM_SLACK
+
+
+def test_kernel_smem_uses_latest_complete_map_and_max_dot_epilogue() -> None:
+    first = _matmul_fact()
+    second = MatmulFact(
+        2,
+        2,
+        3,
+        4,
+        2,
+        1024,
+        1024,
+        1024,
+        torch.bfloat16,
+        torch.bfloat16,
+    )
+    env = _kernel_smem_env((first, second), block_ids=[0, 1, 2, 3, 4])
+
+    assert _FML._epilogue_smem(env, [16, 32, 8, 64, 64]) == 64 * 64 * 4
+    assert _FML._kernel_smem_bytes(env, [16, 32, 8, 32, 32], 3) == (
+        32 * 32 * 4 + _FML.SMEM_SLACK
+    )
+
+
+def test_multi_dot_proposal_preconditions_with_complete_kernel_smem_map() -> None:
+    fact = _matmul_fact()
+    spec = _generalized_spec(fact, _axes(), valid_block_ids=[0, 1, 2, 7])
+    env = SimpleNamespace(config_spec=spec, block_sizes=[])
+    seen: list[tuple[int, ...]] = []
+
+    def record_smem(_env: object, block_sizes: list[int], _stages: int) -> int:
+        seen.append(tuple(block_sizes))
+        return 0
+
+    with patch.object(
+        _MULTI,
+        "_kernel_smem_bytes",
+        side_effect=record_smem,
+    ):
+        assert _MULTI._proposal_for(env, spec.kernel_matmul_fact, 0, 148) is not None
+    assert seen
+    assert all(len(block_sizes) == len(spec.block_sizes) for block_sizes in seen)
+    assert all(block_sizes[3] == 1 for block_sizes in seen)
+
+
+def test_sm90_keeps_the_incumbent_gate_and_every_switch_off() -> None:
+    """Every measurement behind the generalized machinery is B200, so sm90 must be a
+    byte-identical freeze: same eligibility precondition, no graded stages, no work-aware
+    warps, no tensor-memory column budget."""
+    cls = TritonH100MatmulHeuristic
+    assert cls.GENERALIZED_AXES is False
+    assert cls.GRADED_STAGES is False
+    assert cls.WORK_AWARE_WARPS is False
+    assert cls.TMEM_COLUMN_BUDGET is None
+    fixed = MatmulFact(
+        lhs_ndim=2,
+        rhs_ndim=2,
+        m_block_id=0,
+        n_block_id=1,
+        k_block_id=4,
+        static_m=256,
+        static_n=256,
+        static_k=64,
+        lhs_dtype=torch.bfloat16,
+        rhs_dtype=torch.bfloat16,
+    )
+    spec = _generalized_spec(
+        fixed,
+        _axes(k=DotAxisKind.FIXED_FULL_EXTENT, k_extent=64),
+        valid_block_ids=[0, 1],
+    )
+    # sm90 routes through the incumbent gate, which declines the fixed-axis dot.
+    assert cls._eligible_fact(spec) is None
+    # ...while sm100 admits it.
+    assert _FML._eligible_fact(spec) is fixed
+
+
+def test_multi_matmul_front_end_declines_whatever_front_end_one_owns() -> None:
+    """Exactly one of the two front ends may own a kernel, so promotion is unambiguous
+    without either of them having to know the other's policy."""
+    fact = _matmul_fact()
+    spec = _generalized_spec(fact, _axes(), valid_block_ids=[0, 1, 2])
+    env = SimpleNamespace(
+        config_spec=spec,
+        device=torch.device("cuda"),
+        settings=SimpleNamespace(),
+    )
+    with patch(
+        "helion._compiler.autotuner_heuristics.triton.matches_hardware",
+        return_value=True,
+    ):
+        assert _MULTI.is_eligible(env, None) is False
+    # Keep single-contraction seeds ahead of the disjoint multi-contraction path.
+    from helion._compiler.autotuner_heuristics import HEURISTICS_BY_BACKEND
+
+    triton_order = HEURISTICS_BY_BACKEND["triton"]
+    assert triton_order.index(_MULTI) > triton_order.index(_FML)
+
+
+def _live(kind: str, *block_ids: int | None) -> LiveTile:
+    return LiveTile(
+        dim_block_ids=tuple(block_ids),
+        static_dims=tuple(None for _ in block_ids),
+        itemsize=2,
+        kind=kind,
+    )
+
+
+def _knob_spec(
+    *,
+    knob_users: tuple[tuple[int, tuple[tuple[int, str], ...]], ...],
+    block_ids: list[int],
+    extents: dict[int, int],
+    grid_block_ids: tuple[int, ...] = (),
+    pipelined_regions: tuple[PipelinedRegion, ...] = (),
+) -> SimpleNamespace:
+    """An ``env`` stub carrying just what ``_apply_knob_roles`` reads."""
+    mm = SimpleNamespace(
+        matmuls=(),
+        knob_users=knob_users,
+        outer_grid=1,
+        sequential_loop_trips=1,
+        live_tiles=(),
+        live_dot_outputs=(),
+        live_tile_steps=(),
+        pipelined_regions=pipelined_regions,
+        resident_regions=(),
+        n_dot_nodes=len(knob_users),
+        attribution_complete=True,
+    )
+    spec = SimpleNamespace(
+        matmul_facts=[],
+        kernel_matmul_fact=mm,
+        kernel_grid_fact=None,
+        block_sizes=_block_sizes_stub(block_ids),
+        grid_block_ids=grid_block_ids,
+        _base_default_config=lambda: SimpleNamespace(config={}),
+    )
+    env = SimpleNamespace(
+        config_spec=spec,
+        block_sizes=[
+            SimpleNamespace(
+                size=extents.get(b, 1),
+                block_size_source=SimpleNamespace(from_config=lambda *_a: None),
+            )
+            for b in range(max(extents or {0: 0}) + 1)
+        ],
+        size_hint=lambda v: int(v),
+    )
+    return env, mm
+
+
+def test_launch_grid_counts_only_grid_axes() -> None:
+    """A knob that is walked by a SEQUENTIAL loop contributes iterations, not programs. The
+    budget formula's wave model counts every M/N tile as a program, which reports a saturated
+    machine for a kernel that launches a handful of CTAs."""
+    env, _mm = _knob_spec(
+        knob_users=((0, ((0, "n"),)), (1, ((0, "m"),))),
+        block_ids=[0, 1],
+        extents={0: 128, 1: 128},
+        grid_block_ids=(1,),
+    )
+    # Only block id 1 is a grid axis: halving the LOOP axis 0 must not change the grid,
+    # halving the grid axis must double it.
+    assert _MULTI._launch_grid(env, [128, 128]) == 1
+    assert _MULTI._launch_grid(env, [32, 128]) == 1
+    assert _MULTI._launch_grid(env, [128, 32]) == 4
+
+
+def test_launch_grid_uses_only_dot_bearing_root_groups() -> None:
+    """Independent top-level loops add their grids, while a matmul policy sizes against
+    only roots that execute a dot. Nested dot graphs resolve through the generic kernel
+    grid fact rather than carrying a copied block-id tuple."""
+    env, mm = _knob_spec(
+        knob_users=(),
+        block_ids=[0, 1, 2, 4, 5],
+        extents={0: 128, 1: 128, 2: 128, 4: 256, 5: 256},
+        grid_block_ids=(0, 1, 2, 4, 5),
+    )
+    grid_fact = KernelGridFact(
+        roots=(
+            RootGridFact(100, (0, 1, 2)),
+            RootGridFact(200, (4, 5)),
+        ),
+        graph_to_root=((100, 100), (101, 100), (200, 200)),
+    )
+    env.config_spec.kernel_grid_fact = grid_fact
+    mm.matmuls = (SimpleNamespace(site=SimpleNamespace(graph_id=101)),)
+
+    # The nested dot belongs to root 100: 2 * 2 * 2 = 8 programs. Root 200's
+    # 4 * 4 = 16 programs do not execute the dot and must not inflate its waves.
+    assert grid_fact.group_for_graph(101) == (0, 1, 2)
+    assert _MULTI._launch_grid(env, [64, 64, 64, 64, 64]) == 8
+
+    # Without a dot-bearing subset, evaluate the complete independent-root grid
+    # as a sum, 8 + 16, never as a product of the flattened block-id list.
+    mm.matmuls = ()
+    assert _MULTI._launch_grid(env, [64, 64, 64, 64, 64]) == 24
+
+
+def test_knob_amortization_separates_reuse_free_from_reuse_bearing() -> None:
+    """The discriminator for whether growing a tile buys anything: does its loop region stage
+    a load the knob does NOT span? If every load spans the knob, bytes and MMA work both
+    scale with the tile and arithmetic intensity is constant in it."""
+    reuse_free = (_live("load", 9, 4), _live("store", 9, 4))
+    reuse_bearing = (_live("load", 9, 4), _live("load", 9, 3), _live("store", 9, 4))
+    _env, mm = _knob_spec(
+        knob_users=((4, ((0, "n"),)),),
+        block_ids=[4],
+        extents={4: 128},
+        pipelined_regions=(PipelinedRegion((), reuse_free),),
+    )
+    assert _MULTI._knob_amortizes(mm, 4) is False
+    _env, mm = _knob_spec(
+        knob_users=((4, ((0, "n"),)),),
+        block_ids=[4],
+        extents={4: 128},
+        pipelined_regions=(PipelinedRegion((), reuse_bearing),),
+    )
+    # Block id 3 is re-fetched for every iteration of 4, so growing 4 amortizes it.
+    assert _MULTI._knob_amortizes(mm, 4) is True
+    # ...and symmetrically, 3's own loop re-fetches the 4-spanning load, so 3 amortizes too.
+    assert _MULTI._knob_amortizes(mm, 3) is True
+
+
+def test_reuse_free_output_knob_drops_to_the_allocation_floor() -> None:
+    """A reuse-free knob that sizes a dot OUTPUT extent buys no arithmetic intensity while
+    the fp32 accumulator, the register-resident intermediates and the store staging all scale
+    with it, so it goes to the tcgen05 allocation granularity. A reuse-BEARING knob in the
+    same position must be left alone."""
+    env, _mm = _knob_spec(
+        knob_users=((4, ((0, "n"),)),),
+        block_ids=[4],
+        extents={4: 128},
+        pipelined_regions=(
+            PipelinedRegion((), (_live("load", 9, 4), _live("store", 9, 4))),
+        ),
+    )
+    block_sizes = [128]
+    _MULTI._apply_knob_roles(env, env.config_spec.kernel_matmul_fact, block_sizes, 148)
+    assert block_sizes == [_MULTI.TMEM_ALLOC_COLUMNS]
+
+    env, _mm = _knob_spec(
+        knob_users=((4, ((0, "n"),)),),
+        block_ids=[4],
+        extents={4: 128},
+        pipelined_regions=(
+            PipelinedRegion((), (_live("load", 9, 4), _live("load", 9, 3))),
+        ),
+    )
+    block_sizes = [128]
+    _MULTI._apply_knob_roles(env, env.config_spec.kernel_matmul_fact, block_sizes, 148)
+    assert block_sizes == [128]
+
+
+def test_grid_knob_shrinks_only_when_wave_utilization_improves() -> None:
+    """A knob that IS the grid trades tile area against occupancy, so it is sized by the
+    machine: shrink while the launch grid is under one wave and wave utilization strictly
+    improves, then stop at the allocation granularity rather than at the dot minimum."""
+    env, _mm = _knob_spec(
+        knob_users=((0, ((0, "m"), (1, "n"))),),
+        block_ids=[0],
+        extents={0: 8192},
+        grid_block_ids=(0,),
+        pipelined_regions=(
+            PipelinedRegion((), (_live("load", 9, 0), _live("load", 9, 7))),
+        ),
+    )
+    block_sizes = [8192]
+    _MULTI._apply_knob_roles(env, env.config_spec.kernel_matmul_fact, block_sizes, 148)
+    # 8192 / 64 = 128 programs >= 0.8 * 148, so the shrink stops there rather than
+    # continuing to the floor.
+    assert block_sizes == [64]
+    # When even the floor cannot fill a wave, the granularity floor wins: a narrower
+    # accumulator reserves the same tensor memory while issuing less MMA work.
+    env, _mm = _knob_spec(
+        knob_users=((0, ((0, "m"), (1, "n"))),),
+        block_ids=[0],
+        extents={0: 1024},
+        grid_block_ids=(0,),
+        pipelined_regions=(
+            PipelinedRegion((), (_live("load", 9, 0), _live("load", 9, 7))),
+        ),
+    )
+    block_sizes = [1024]
+    _MULTI._apply_knob_roles(env, env.config_spec.kernel_matmul_fact, block_sizes, 148)
+    assert block_sizes == [_MULTI.TMEM_ALLOC_COLUMNS]
+    # Do not cross into a second partial wave when that leaves utilization unchanged:
+    # 11008/128 = 86 programs in one wave, while 11008/64 = 172 in two waves.
+    env, _mm = _knob_spec(
+        knob_users=((0, ((0, "m"),)),),
+        block_ids=[0],
+        extents={0: 11008},
+        grid_block_ids=(0,),
+        pipelined_regions=(
+            PipelinedRegion((), (_live("load", 9, 0), _live("load", 9, 7))),
+        ),
+    )
+    block_sizes = [128]
+    _MULTI._apply_knob_roles(env, env.config_spec.kernel_matmul_fact, block_sizes, 148)
+    assert block_sizes == [128]
+    # A grid that already covers the machine is left alone.
+    env, _mm = _knob_spec(
+        knob_users=((0, ((0, "m"),)),),
+        block_ids=[0],
+        extents={0: 65536},
+        grid_block_ids=(0,),
+        pipelined_regions=(
+            PipelinedRegion((), (_live("load", 9, 0), _live("load", 9, 7))),
+        ),
+    )
+    block_sizes = [128]
+    _MULTI._apply_knob_roles(env, env.config_spec.kernel_matmul_fact, block_sizes, 148)
+    assert block_sizes == [128]
+
+
+def test_role_correction_runs_once_per_front_end() -> None:
+    """Front end 1 corrects its projected tile; front end 2 corrects only its merged draft."""
+    assert _FML.SINGLE_ROLE_AWARE_KNOBS is True
+    assert _MULTI.SINGLE_ROLE_AWARE_KNOBS is False
+
+
+def test_multi_stages_follow_the_emitted_tile_by_default() -> None:
+    """Stage facts must describe the role-corrected block sizes the kernel actually uses."""
+    assert _MULTI.ROLE_KEEP_STAGES is False
+
+
+def _steps_env(
+    steps: tuple[tuple[tuple[int, int, int, str], ...], ...],
+) -> SimpleNamespace:
+    """A stub env whose ``live_tile_steps`` are literal (rows, cols, itemsize, kind) tiles."""
+    mk = lambda r, c, isz, kind: LiveTile(  # noqa: E731
+        dim_block_ids=(None, None), static_dims=(r, c), itemsize=isz, kind=kind
+    )
+    return SimpleNamespace(
+        config_spec=SimpleNamespace(
+            kernel_matmul_fact=SimpleNamespace(
+                live_tile_steps=tuple(tuple(starmap(mk, step)) for step in steps)
+            ),
+            block_sizes=_block_sizes_stub([]),
+            _base_default_config=lambda: helion.Config(block_sizes=[]),
+        ),
+        block_sizes=[],
+    )
+
+
+def test_register_estimate_peaks_on_bytes_not_on_rank() -> None:
+    """The register estimate must select its peak step by RESOLVED BYTES, not by rank profile.
+
+    Rank profile is block-size-free, which is the right question for a reduction's working set
+    (block sizes are unknown there) and the wrong one here (they are known). Selecting by rank
+    picked a step holding several rank-2 loads over the step actually holding the accumulators:
+    it under-counted a kernel spilling 540 registers at one warp (1.33x the one-warp file) while
+    over-counting one spilling none (1.51x), so the ordering inverted and no threshold could
+    separate them. This pins the fix: a step with FEWER tiles but more bytes must win."""
+    many_small = tuple((8, 8, 4, "other") for _ in range(6))  # 6 tiles, 1536 B
+    one_big = ((128, 128, 4, "other"),)  # 1 tile, 65536 B
+    env = _steps_env((many_small, one_big))
+    assert _FML._register_live_bytes(env, [], 8) == 128 * 128 * 4
+
+
+def test_register_estimate_excludes_loads_and_unregisterable_values() -> None:
+    """Loads are charged to the shared-memory ring, so charging them here would put the same
+    bytes in two budgets. And a value larger than the largest register file a CTA can have is
+    not register-resident at all -- it lives in HBM and the graph merely names it. Without that
+    exclusion a varlen packed [T, C, D] buffer (measured 256 MiB) pinned every warp count to
+    the maximum."""
+    env = _steps_env((((64, 64, 4, "load"),),))
+    assert _FML._register_live_bytes(env, [], 8) == 0
+    huge = _FML.MAX_NUM_WARPS * 32 * _FML.REG_BYTES_PER_THREAD
+    env = _steps_env((((huge, 4, 4, "other"),),))
+    assert _FML._register_live_bytes(env, [], 8) == 0
+
+
+def test_register_estimate_lets_tensor_memory_absorb_wide_accumulators() -> None:
+    """A dot output is charged to the register file only when tensor memory cannot take it.
+    tcgen05 MMA issues per warpgroup -- confirmed in PTX, num_warps 1 or 2 emits zero
+    tcgen05.mma with tmem_size 0 -- and below TCGEN05_MIN_BM the dot never reaches that path at
+    any warp count. So the charge is warp-count dependent, which is why the ladder must re-ask
+    the estimate at every rung rather than compute it once."""
+    wide = (((128, 128, 4, "dot_out"),),)
+    assert _FML._register_live_bytes(_steps_env(wide), [], 1) == 128 * 128 * 4
+    assert _FML._register_live_bytes(_steps_env(wide), [], 2) == 128 * 128 * 4
+    assert _FML._register_live_bytes(_steps_env(wide), [], 4) == 0
+    narrow = (
+        ((32, 128, 4, "dot_out"),),
+    )  # below TCGEN05_MIN_BM: never in tensor memory
+    assert _FML._register_live_bytes(_steps_env(narrow), [], 8) == 32 * 128 * 4
+
+
+def test_warps_climb_the_ladder_while_the_live_set_overshoots() -> None:
+    """Section 3's register fix-up: estimate from the register-resident live set and the
+    proposed warp count, then increase num_warps first. A fixed point, because raising the count
+    both enlarges the file and can move the accumulators out of it entirely.
+
+    The ladder is 1 -> 2 -> 4 -> 8, not a jump to a warpgroup: losing tcgen05 below one is not
+    itself a penalty (at 16 KiB live, one warp on mma.sync beats four on tcgen05) and two warps
+    is the hand-tuned answer in 11 of 18 chunk_cumsum_gc cells."""
+    one_warp_file = 32 * _FML.REG_BYTES_PER_THREAD
+    fits_one = (((64, 64, 4, "other"),),)  # 16 KiB
+    assert _FML._register_live_bytes(_steps_env(fits_one), [], 1) <= one_warp_file
+    assert _FML._warps_for_live_set(1, _steps_env(fits_one), []) == 1
+    two = (((64, 64, 4, "other"), (64, 64, 4, "other")),)  # 32 KiB > 31.9 KiB
+    assert _FML._warps_for_live_set(1, _steps_env(two), []) == 2
+    four = tuple([tuple((64, 64, 4, "other") for _ in range(4))])
+    assert _FML._warps_for_live_set(1, _steps_env(four), []) == 4
+    # never lowers what the tile ramp asked for, and no opinion when nothing is recorded
+    assert _FML._warps_for_live_set(8, _steps_env(four), []) == 8
+    assert _FML._warps_for_live_set(1, _steps_env(()), []) == 1
+
+
+def test_register_climb_stops_at_a_warpgroup_not_at_max_warps() -> None:
+    """Registers are SOFT -- they spill, where tensor and shared memory raise OutOfResources at
+    launch -- so relieving pressure past the point where it is relieved has a real cost. Each warp
+    doubling halves resident CTAs, and for a grid over batch/head that buys less than the spill
+    costs: measured on chunk_fwd_A_diag_anchored_varlen, nw=2 spills 38 B holding 4 CTAs/SM while
+    nw=8 spills NOTHING holding 1, and nw=2 is 1.75x faster.
+
+    The stop is a warpgroup because that is where _register_live_bytes hands the accumulators to
+    tcgen05, so past it the estimate cannot justify another doubling. Over 75 swept cells scored
+    against each cell's measured optimum, climbing to a fit and on to eight scores 0.8959 and
+    stopping at a warpgroup scores 0.9591 -- above the hand-tuned key's 0.9363."""
+    # A live set far past ANY register file must still stop at a warpgroup, not run to eight.
+    huge = tuple([tuple((128, 128, 4, "other") for _ in range(8))])  # 512 KiB
+    assert (
+        _FML._warps_for_live_set(1, _steps_env(huge), [])
+        == _FML.TCGEN05_WARPGROUP_WARPS
+    )
+    assert _FML.TCGEN05_WARPGROUP_WARPS < _FML.MAX_NUM_WARPS
+    # Eight is still reachable -- it just has to come from the work term, which this rule keeps.
+    assert _FML._warps_for_live_set(8, _steps_env(huge), []) == 8
+    # The stop is a per-arch class attribute, not an arch test inside the ladder: hardware
+    # selection already happened in is_eligible via HARDWARE_TARGETS. Pin that the sm100 carrier
+    # ties it to the absorption boundary it is derived from, so the two cannot drift apart...
+    assert _FML.REG_CLIMB_MAX_WARPS == _FML.TCGEN05_WARPGROUP_WARPS
+    # ...and that the sm90 carrier is left where it was, holding that frozen emit still.
+    assert _H100.REG_CLIMB_MAX_WARPS == _H100.MAX_NUM_WARPS
+    assert _H100._warps_for_live_set(1, _steps_env(huge), []) == _H100.MAX_NUM_WARPS
+
+
+def test_no_structural_warp_floor_survives() -> None:
+    """The two-warp floor for multi-contraction kernels is DELETED, not disabled.
+
+    It was a patch over the rank-selected estimate. Once the peak is chosen by bytes, the
+    floor's own predicate became identical to the ladder's first rung, so it could never raise
+    anything the ladder did not already raise. Adversarial review had independently shown the
+    unconditional form cost +72% on a cell whose hand-tuned num_warps is 1 in all 10 of its
+    cases, and that a 4-contraction kernel with one live output is fastest at one warp."""
+    import inspect
+
+    src = inspect.getsource(_MULTI)
+    assert "MULTI_DOT_MIN_NUM_WARPS" not in src
+    assert "_needs_warp_floor" not in src
+
+
+def test_only_a_fixed_block_size_source_has_a_config_independent_extent() -> None:
+    """The per-program extent an axis reports to the fact layer, and which sources have one.
+
+    A ``FixedBlockSizeSource`` ignores the config, so its value IS the per-program extent and
+    can be recorded once. Every other source reads a config knob -- ``block_sizes`` for a loop
+    axis, ``reduction_loops`` for a reduction one -- so there is no config-independent extent
+    and the answer must be ``None``, leaving the axis classified as tunable.
+
+    This replaced a two-config PROBE (call ``from_config`` under block_sizes=16 and =128, and
+    call the axis immovable if the answer did not move). The probe perturbed only
+    ``block_sizes``, so a source movable solely via ``reduction_loops`` returned the same value
+    both times and was misreported as immovable.
+
+    The movable case uses a STUB source that returns a definite value, not a real
+    ``LoopSpecBlockSizeSource``. That is deliberate: a real one needs a live
+    ``CompileEnvironment`` and a spec with ``block_id_to_index``, and without them it returns
+    ``None`` through the exception path -- which made an earlier version of this test pass with
+    the ``isinstance`` guard DELETED. The stub is what makes the guard load-bearing here.
+    """
+    from helion._compiler.compile_environment import BlockSizeSource
+    from helion._compiler.compile_environment import FixedBlockSizeSource
+    from helion._compiler.device_ir_analysis import _immovable_extent
+
+    spec = _matmul_config_spec()
+
+    class _MovableSource(BlockSizeSource):
+        """Not a FixedBlockSizeSource, and yields a value the guard must still refuse."""
+
+        def from_config(self, config: object, block_size_info: object) -> int:
+            return 64
+
+    def env_with(source: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            block_sizes=[SimpleNamespace(block_size_source=source, size=8192)],
+            size_hint=lambda v: int(v),
+        )
+
+    # hl.tile(seqlen, block_size=64): the axis LENGTH is 8192, one program sees 64.
+    assert _immovable_extent(env_with(FixedBlockSizeSource(64)), spec, 0) == 64
+    # hl.grid: one scalar index per program, so the extent is 1 -- not the grid length.
+    assert _immovable_extent(env_with(FixedBlockSizeSource(1)), spec, 0) == 1
+    # Anything the config can move has NO config-independent extent, even though asking it
+    # would have produced a perfectly plausible number.
+    assert _MovableSource().from_config(None, None) == 64
+    assert _immovable_extent(env_with(_MovableSource()), spec, 0) is None
+    # Out-of-range ids are not an error, they simply have no extent.
+    assert _immovable_extent(env_with(FixedBlockSizeSource(64)), spec, 7) is None


### PR DESCRIPTION
Stacked PRs:
 * #3464
 * __->__#3409


--- --- ---

## Summary

Extend the existing formula-based B200 matmul seed from regular single
contractions to whole kernels containing multiple `hl.dot` operations.

This adds a whole-kernel matmul fact and a multi-matmul policy that:

- resolves tunable, fixed, full-extent, grid, and loop-carried dot axes;
- sizes shared block knobs according to their actual role across contractions;
- selects kernel-global `num_stages` and `num_warps`;
- models peak SMEM, TMEM, and register-resident live tiles across sequential
  regions; and
- applies a final hard-resource correction to the merged configuration.

The graph-derived analysis used to build these facts is centralized in
`DeviceIRAnalysis`, rather than rediscovered by each specialized fact builder.
The original single-matmul formula remains the specialized fast path where it
applies.

## B200 linear-attention performance

> **Headline across all 149 measured linear-attention matmul cells: default
> `1.0000x` -> new heuristic `1.5527x` -> exact pre-tuned config `1.8704x`.**

| Configuration | Geomean speedup vs. pre-change default |
|---|---:|
| Pre-change default | **1.0000x** |
| New heuristic | **1.5527x** |
| Exact pre-tuned config | **1.8704x** |

The exact pre-tuned configs remain `1.2046x` faster than the new heuristic.
The new heuristic wins by more than 1% on 111 cells and regresses by more than
1% on 23 cells.

The single-matmul formula path covers 20 cells at `1.9948x` geomean with no
regressions. The new multi-matmul path covers the remaining 129 cells at
`1.4935x` geomean.

### Per-kernel geomean

Pre-change is the `1.0000x` baseline. Ratios above one are speedups.

| Kernel | N | Pre | New heuristic | Pre-tuned | New regressions >1% |
|---|---:|---:|---:|---:|---:|
| `chunk_bwd_dh_diag_fused` | 5 | 1.0000x | 1.7744x | 2.0799x | 0 |
| `chunk_bwd_dk_delta` | 5 | 1.0000x | 0.8635x | 0.9981x | 5 |
| `chunk_bwd_dqk` | 5 | 1.0000x | 2.1640x | 2.9951x | 0 |
| `chunk_bwd_dqkg_scalar` | 5 | 1.0000x | 1.9238x | 2.3958x | 0 |
| `chunk_bwd_dqkw_delta` | 5 | 1.0000x | 1.6143x | 2.7357x | 1 |
| `chunk_bwd_dstate_delta` | 5 | 1.0000x | 1.7570x | 2.2190x | 0 |
| `chunk_bwd_dv` | 5 | 1.0000x | 3.0871x | 3.7680x | 0 |
| `chunk_bwd_gram2_kda` | 5 | 1.0000x | 1.0647x | 1.2434x | 0 |
| `chunk_bwd_o_kda` | 5 | 1.0000x | 1.8068x | 2.0208x | 0 |
| `chunk_bwd_state_du_kda` | 5 | 1.0000x | 1.0204x | 1.3511x | 3 |
| `chunk_bwd_state_dwk_kda` | 5 | 1.0000x | 1.5034x | 1.8587x | 0 |
| `chunk_bwd_wu_kda` | 5 | 1.0000x | 1.2443x | 1.3169x | 0 |
| `chunk_bwd_wy_dL_delta` | 5 | 1.0000x | 1.0785x | 1.4109x | 3 |
| `chunk_cumsum_gc` | 5 | 1.0000x | 1.7303x | 1.8221x | 0 |
| `chunk_cumsum_gc_varlen` | 5 | 1.0000x | 2.3525x | 2.7137x | 0 |
| `chunk_fwd_A_diag_anchored` | 5 | 1.0000x | 0.9390x | 1.0503x | 2 |
| `chunk_fwd_A_diag_anchored_varlen` | 4 | 1.0000x | 1.0000x | 1.0589x | 0 |
| `chunk_fwd_h_delta` | 5 | 1.0000x | 1.7694x | 2.1260x | 0 |
| `chunk_fwd_h_delta_varlen` | 5 | 1.0000x | 1.0501x | 1.4998x | 2 |
| `chunk_fwd_h_diag_fused` | 5 | 1.0000x | 2.1923x | 2.4724x | 0 |
| `chunk_fwd_o_diag_anchored` | 5 | 1.0000x | 3.3069x | 3.9768x | 0 |
| `chunk_fwd_o_diag_anchored_varlen` | 5 | 1.0000x | 1.0000x | 1.1523x | 0 |
| `chunk_fwd_o` | 5 | 1.0000x | 3.8856x | 4.5880x | 0 |
| `chunk_fwd_wy_delta` | 5 | 1.0000x | 1.0603x | 1.1666x | 1 |
| `chunk_fwd_wy_delta_varlen` | 5 | 1.0000x | 0.8905x | 1.0171x | 5 |
| SGLang `_chunk_output` | 5 | 1.0000x | 1.4240x | 1.4416x | 0 |
| SGLang `_chunk_state` | 5 | 1.0000x | 1.7242x | 2.0358x | 0 |
| SGLang `_intra_matrices_wide` | 5 | 1.0000x | 2.1442x | 3.1909x | 0 |
| SGLang `_intra_solve_recompute` | 5 | 1.0000x | 1.6397x | 1.6642x | 0 |
| SGLang `replayssm_decode_body` | 5 | 1.0000x | 1.3708x | 1.9064x | 1 |

Only three kernels regress in kernel-wide geomean:
`chunk_bwd_dk_delta` (`0.8635x`), `chunk_fwd_wy_delta_varlen`
(`0.8905x`), and `chunk_fwd_A_diag_anchored` (`0.9390x`). Stage depth
is the dominant remaining failure mode: 19 of the 23 regressing cells increase
`num_stages`, and some kernels do not expose enough useful overlapping load
work to repay the additional depth.

### Methodology

- NVIDIA B200, physical GPU 1.
- 149 `hl.dot` cells across 30 Helion linear-attention and SGLang KDA kernels.
- Scope includes only cells where `triton_b200_formula_matmul` or
  `triton_b200_multi_matmul` fired; 20 reduction-only cells were excluded.
- Every pre-change cell selected the literal default config.
- Pre-tuned comparisons use exact `known_good_config_key` or
  `shipped_helion_config` entries. No nearest-shape fallback was used.
- Same-process three-arm timing with cold L2, CUDA graphs when capture
  succeeded, rotated/interleaved CUDA events, and the median of five round
  medians.
- Measured revisions: pre-change `9c46dd311bcba596324fe5cba996495bda3e65fb`;
  post-change `ccfcfbdd86e3cda4667e92bc3225185e1d4df5a7`.


## End-to-end linear attention vs. FLA Triton

> **Headline across all 96 corrected B200 end-to-end cells: new heuristic
> `1.9050x`, exact pre-tuned config `2.1978x`, and FLA Triton `1.3991x` versus
> the pre-change default. Rebasing to FLA: new heuristic `1.3616x` and exact
> pre-tuned config `1.5708x`.**

| Scope | FLA Triton | New heuristic | Pre-tuned |
|---|---:|---:|---:|
| All operations | **1.0000x** | **1.3616x** | **1.5708x** |
| Forward | **1.0000x** | **1.3023x** | **1.4851x** |
| Forward + backward | **1.0000x** | **1.4418x** | **1.6883x** |

Each entry below is the geometric mean across six production shapes, rebased
to FLA. Values above `1.00x` are faster than FLA. `F+B` measures the complete
forward-plus-backward operation, not backward alone.

| Variant | FLA Fwd | FLA F+B | Heuristic Fwd | Heuristic F+B | Pre-tuned Fwd | Pre-tuned F+B |
|---|---:|---:|---:|---:|---:|---:|
| `vanilla_linear_attn` | 1.00x | 1.00x | 1.27x | 2.03x | 1.40x | 2.35x |
| `simple_gla` | 1.00x | 1.00x | 1.40x | 1.67x | 1.53x | 1.89x |
| `retention` | 1.00x | 1.00x | 1.80x | 2.17x | 1.95x | 2.44x |
| `full_gla` | 1.00x | 1.00x | 1.51x | 2.04x | 1.70x | 2.25x |
| `delta_rule` | 1.00x | 1.00x | 1.31x | 0.96x | 1.50x | 1.11x |
| `gated_delta_rule` | 1.00x | 1.00x | 1.08x | 0.82x | 1.34x | 1.16x |
| `kda` | 1.00x | 1.00x | 1.24x | 1.09x | 1.40x | 1.24x |
| `kda_fused` | 1.00x | n/a | 1.27x | n/a | 1.44x | n/a |
| `kda_varlen` | 1.00x | n/a | 1.01x | n/a | 1.22x | n/a |

Methodology: NVIDIA B200 physical GPU 1; 54 forward and 42
forward-plus-backward cells; complete operation timing with cold L2, normal
eager dispatch, three timing rounds, and timing processes pinned to a reserved
GPU-local CPU. Each Helion arm was measured in an isolated process and paired
with FLA 0.5.2. FLA used independent native-layout leaf inputs and cleared the
actual gradient targets between repetitions, avoiding layout-conversion
autograd work and gradient accumulation. All correctness, affinity, dispatch,
and selected-config gates passed. Measured revisions: pre-change
`9c46dd311bcba596324fe5cba996495bda3e65fb`; post-change
`375363d8663af60d71a0869003db7954f22c42ca`.
## Generality and scope

One multi-matmul heuristic handles 129 of the 149 measured `hl.dot` cells,
including nearly every nontrivial linear-attention kernel in the Helion and
SGLang curricula. The remaining 20 cells use the existing specialized
single-matmul formula.

This is intentionally a general whole-kernel analysis rather than a collection
of kernel-name special cases. However, the policy was developed and calibrated
primarily against linear-attention computation patterns. The analysis should
generalize to other multi-contraction kernels, but the policy may be overfit to
linear attention; broader off-corpus validation remains useful.

## Analysis-refactor equivalence

The graph-walking move into `DeviceIRAnalysis` was compared against
pre-refactor snapshots over:

- all 432 cases in the canonical linear-attention registry across 40 bodies,
  including 364 matmul cases and 141 reduction cases;
- all 20 production-shape vLLM-derived quantization cases across five bodies,
  including 16 reduction cases across four reduction bodies and four pointwise
  controls; and
- a six-case smoke corpus with two pointwise, two reduction, and two matmul
  kernels.

Generated facts, heuristic names, seed/default/normalized configs, and
config-spec fingerprints matched exactly. The canonical 101 MiB snapshots were
byte-identical (SHA-256
`a6a6add17940451f4166c504f6ebeae4b1511341aba0b3e70f779eed87fb0d90`) after
canonicalizing only the process-dependent ordering of pre-existing set-derived
live-tile fields. No fact or config values changed, so the performance results
above remain applicable to the ownership-only refactor.

## Tests

- `test/test_matmul_heuristics.py`: 40 passed.
- `test/test_memory_op_facts.py`: 6 passed.
- Focused pointwise/matmul fact tests: 9 passed, 4 subtests passed.
- `TestTritonReductionHeuristic`: 4 passed.

Overall: **59 passed, 4 subtests passed**.

Targeted Ruff formatting/checks, codespell, syntax compilation, diff checks,
and Pyrefly for `device_ir_analysis.py` also pass.