### PR TITLE
Fix Pallas TPU info import for JAX 0.11.1

### DIFF
--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -1338,12 +1338,12 @@ def _ensure_cpu_tpu_info() -> None:
     """
     try:
         from jax._src.pallas.mosaic.tpu_info import ChipVersion
-        from jax._src.pallas.mosaic.tpu_info import _get_tpu_info_impl
+        from jax._src.pallas.mosaic.tpu_info import get_tpu_info_for_chip
         from jax._src.pallas.mosaic.tpu_info import registry
     except ImportError:
         return
     if "cpu" not in registry:
-        registry["cpu"] = lambda: _get_tpu_info_impl(ChipVersion.TPU_7X, 1)
+        registry["cpu"] = lambda: get_tpu_info_for_chip(ChipVersion.TPU_7X, 1)
 
 
 def _pallas_apply_ds_padding(


### PR DESCRIPTION
Fix the main-branch Pyrefly failure caused by JAX 0.11.1 no longer forwarding the private `_get_tpu_info_impl` symbol from `jax._src.pallas.mosaic.tpu_info`.

Use the public `get_tpu_info_for_chip` helper instead, which is available in both JAX 0.11.0 and 0.11.1.

Testing:
- `python3 -m py_compile helion/runtime/pallas/launcher.py`
- `git diff --check`