### PR TITLE
[CuTe] Model flash target policy and promote SM103 attention seeds

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -747,6 +747,9 @@ class CuteFlashAttentionHeuristic(AutotunerHeuristic):
             has_kv_tile_pruning=spec._cute_flash_has_kv_tile_pruning,
             requires_ws_overlap=spec._cute_flash_requires_ws_overlap,
             small_biased_candidate=spec._cute_flash_small_biased_candidate,
+            standard_dense_output=spec._cute_flash_standard_dense_output,
+            standard_causal_output=spec._cute_flash_standard_causal_output,
+            target_device_capability=spec.target_device_capability,
             block_size_targets=spec._cute_flash_block_size_target_list(),
         )
         if seed is not None:

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -54,6 +54,7 @@ from .causal_range import CausalRangeProof
 from .causal_range import IntegerInterval
 from .causal_range import TileLayout
 from .causal_range import prove_descending_causal_prefix_unmasked
+from .flash_policy import get_flash_target_policy
 from .flash_schedule import FlashScheduleSpec
 from .flash_schedule import build_fa4_schedule
 from .flash_schedule import verify_flash_schedule
@@ -64,6 +65,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Mapping
     from collections.abc import Sequence
+
+    from .flash_tuning import FlashCausalTuningPolicy
+    from .flash_tuning import FlashDenseTuningPolicy
+    from .flash_tuning import FlashTuningPolicy
 
 
 class FlashGraphOutputPlan(NamedTuple):
@@ -3864,6 +3869,7 @@ def _flash_causal_degree2_seed_config(
     requires_ws_overlap: bool,
     small_biased_candidate: bool,
     standard_causal_output: bool,
+    target_device_capability: tuple[int, int] | None = None,
     block_size_targets: Sequence[int],
 ) -> Config | None:
     """Return a validated causal degree-2 seed."""
@@ -3891,10 +3897,23 @@ def _flash_causal_degree2_seed_config(
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
         small_biased_candidate=small_biased_candidate,
+        standard_causal_output=standard_causal_output,
+        target_device_capability=target_device_capability,
         pipeline_family_override="fa4",
     )
     values = {key: fragment.default() for key, fragment in fragments.items()}
-    overrides: dict[str, object] = {
+    overrides = _flash_causal_degree2_seed_overrides(num_kv)
+    if not _flash_seed_set_all(values, fragments, overrides):
+        return None
+    return Config.from_dict({"block_sizes": block_sizes, **values})
+
+
+def _flash_causal_degree2_seed_overrides(num_kv: int) -> dict[str, object]:
+    """Return the versioned causal degree-2 template's explicit values."""
+    seed_params = _flash_causal_degree2_seed_params(num_kv)
+    assert seed_params is not None
+    return {
+        FLASH_PIPELINE_FAMILY_KEY: "fa4",
         FLASH_E2E_SCHEDULE_KEY: "16/6",
         FLASH_MASKED_E2E_SCHEDULE_KEY: "16/6",
         FLASH_E2E_OFFSET_KEY: seed_params.e2e_offset,
@@ -3907,9 +3926,148 @@ def _flash_causal_degree2_seed_config(
         FLASH_CAUSAL_LPT_SWIZZLE_KEY: 0,
         FLASH_ROLE_MAP_KEY: seed_params.role_map,
     }
+
+
+def _flash_dense_tuning_overrides(
+    policy: FlashDenseTuningPolicy,
+) -> dict[str, object]:
+    values: dict[str, object] = {
+        FLASH_PIPELINE_FAMILY_KEY: policy.pipeline_family,
+        FLASH_KV_STAGE_KEY: policy.kv_stage,
+        FLASH_PERSISTENT_KEY: policy.persistent,
+        FLASH_E2E_SCHEDULE_KEY: policy.e2e_schedule,
+        FLASH_E2E_OFFSET_KEY: policy.e2e_offset,
+        FLASH_E2E_OFFSET0_KEY: policy.e2e_offset0,
+        FLASH_EXP2_PACKET_KEY: policy.exp2_packet,
+        FLASH_STAT_TRANSPORT_KEY: policy.stat_transport,
+    }
+    if policy.corr_regs is not None:
+        values[FLASH_CORR_REGS_KEY] = policy.corr_regs
+    if policy.other_regs is not None:
+        values[FLASH_OTHER_REGS_KEY] = policy.other_regs
+    return values
+
+
+def _flash_causal_tuning_values(
+    policy: FlashCausalTuningPolicy,
+) -> dict[str, object]:
+    values = {
+        **_flash_causal_degree2_seed_overrides(policy.num_kv),
+        FLASH_KV_STAGE_KEY: policy.kv_stage,
+        FLASH_Q_TILE_COUNT_KEY: policy.q_tile_count,
+    }
+    if policy.softmax_regs is not None:
+        values[FLASH_SOFTMAX_REGS_KEY] = policy.softmax_regs
+    if policy.first_load_order is not None:
+        values[FLASH_FIRST_LOAD_ORDER_KEY] = policy.first_load_order
+    return values
+
+
+def _flash_tuning_seed_config(
+    tuning_policy: FlashTuningPolicy,
+    head_dim: int,
+    num_kv: int,
+    *,
+    dtype: torch.dtype,
+    is_causal: bool,
+    has_kv_tile_pruning: bool,
+    requires_ws_overlap: bool,
+    small_biased_candidate: bool,
+    standard_dense_output: bool,
+    standard_causal_output: bool,
+    target_device_capability: tuple[int, int] | None,
+    block_size_targets: Sequence[int],
+) -> Config | None:
+    if (
+        dtype is not torch.float16
+        or head_dim != 64
+        or has_kv_tile_pruning
+        or requires_ws_overlap
+        or small_biased_candidate
+    ):
+        return None
+
+    if is_causal:
+        causal_policy = tuning_policy.causal_policy(num_kv)
+        if not standard_causal_output or causal_policy is None:
+            return None
+        seed = _flash_causal_degree2_seed_config(
+            head_dim,
+            num_kv,
+            dtype=dtype,
+            is_causal=True,
+            has_kv_tile_pruning=False,
+            requires_ws_overlap=False,
+            small_biased_candidate=False,
+            standard_causal_output=True,
+            target_device_capability=target_device_capability,
+            block_size_targets=block_size_targets,
+        )
+        if seed is None:
+            return None
+        config = {**seed.config, **_flash_causal_tuning_values(causal_policy)}
+        return Config.from_dict(config)
+
+    dense_policy = tuning_policy.dense_policy(num_kv)
+    if not standard_dense_output or dense_policy is None:
+        return None
+    block_sizes = _flash_seed_block_sizes(block_size_targets)
+    if block_sizes is None:
+        return None
+    fragments = flash_autotune_fragments(
+        head_dim,
+        num_kv,
+        dtype=dtype,
+        is_causal=False,
+        has_kv_tile_pruning=False,
+        requires_ws_overlap=False,
+        small_biased_candidate=False,
+        standard_dense_output=True,
+        target_device_capability=target_device_capability,
+        pipeline_family_override=dense_policy.pipeline_family,
+    )
+    values = {key: fragment.default() for key, fragment in fragments.items()}
+    overrides = _flash_dense_tuning_overrides(dense_policy)
     if not _flash_seed_set_all(values, fragments, overrides):
         return None
-    return Config.from_dict({"block_sizes": block_sizes, **values})
+    return Config.from_dict(
+        {
+            "block_sizes": block_sizes,
+            **values,
+            FLASH_Q_TILE_COUNT_KEY: dense_policy.q_tile_count,
+        }
+    )
+
+
+def _flash_target_seed_config(
+    head_dim: int,
+    num_kv: int,
+    *,
+    dtype: torch.dtype,
+    is_causal: bool,
+    has_kv_tile_pruning: bool,
+    requires_ws_overlap: bool,
+    small_biased_candidate: bool,
+    standard_dense_output: bool,
+    standard_causal_output: bool,
+    target_device_capability: tuple[int, int] | None,
+    block_size_targets: Sequence[int],
+) -> Config | None:
+    tuning_policy = get_flash_target_policy(target_device_capability).tuning
+    return _flash_tuning_seed_config(
+        tuning_policy,
+        head_dim,
+        num_kv,
+        dtype=dtype,
+        is_causal=is_causal,
+        has_kv_tile_pruning=has_kv_tile_pruning,
+        requires_ws_overlap=requires_ws_overlap,
+        small_biased_candidate=small_biased_candidate,
+        standard_dense_output=standard_dense_output,
+        standard_causal_output=standard_causal_output,
+        target_device_capability=target_device_capability,
+        block_size_targets=block_size_targets,
+    )
 
 
 def flash_attention_seed_config(
@@ -3921,18 +4079,36 @@ def flash_attention_seed_config(
     has_kv_tile_pruning: bool = False,
     requires_ws_overlap: bool = False,
     small_biased_candidate: bool = False,
+    standard_dense_output: bool = False,
+    standard_causal_output: bool = False,
+    target_device_capability: tuple[int, int] | None = None,
     block_size_targets: Sequence[int] = _FLASH_SEED_BLOCK_SIZE_TARGETS,
     seed_kind: str = "default",
 ) -> Config | None:
     """Return a fragment-valid seed config for the detected flash surface.
 
-    The seed policy is shape-family based rather than exact sequence-length
-    based. ``block_size_targets`` comes from the flash detector's search-surface
-    facts; this helper only emits a seed for the fused 1x128x128 envelope.
+    Target-specific seeds may be exact-length policies. ``block_size_targets``
+    comes from the flash detector's search-surface facts; this helper only emits
+    a seed for the fused 1x128x128 envelope.
     """
     if num_kv is None:
         return None
     if seed_kind == "default":
+        target_seed = _flash_target_seed_config(
+            head_dim,
+            num_kv,
+            dtype=dtype,
+            is_causal=is_causal,
+            has_kv_tile_pruning=has_kv_tile_pruning,
+            requires_ws_overlap=requires_ws_overlap,
+            small_biased_candidate=small_biased_candidate,
+            standard_dense_output=standard_dense_output,
+            standard_causal_output=standard_causal_output,
+            target_device_capability=target_device_capability,
+            block_size_targets=block_size_targets,
+        )
+        if target_seed is not None:
+            return target_seed
         return _flash_default_seed_config(
             head_dim,
             num_kv,
@@ -4046,6 +4222,7 @@ def flash_attention_seed_configs(
     small_biased_candidate: bool = False,
     standard_dense_output: bool = False,
     standard_causal_output: bool = False,
+    target_device_capability: tuple[int, int] | None = None,
     block_size_targets: Sequence[int] = _FLASH_SEED_BLOCK_SIZE_TARGETS,
 ) -> tuple[Config, ...]:
     seeds: list[Config] = []
@@ -4057,6 +4234,9 @@ def flash_attention_seed_configs(
         has_kv_tile_pruning=has_kv_tile_pruning,
         requires_ws_overlap=requires_ws_overlap,
         small_biased_candidate=small_biased_candidate,
+        standard_dense_output=standard_dense_output,
+        standard_causal_output=standard_causal_output,
+        target_device_capability=target_device_capability,
         block_size_targets=block_size_targets,
     )
     if default_seed is not None:
@@ -4124,7 +4304,14 @@ def flash_attention_seed_configs(
             block_size_targets=block_size_targets,
         )
         if causal_degree2_seed is not None:
-            seeds.append(causal_degree2_seed)
+            causal_degree2_identity = Config.from_dict(
+                {
+                    **causal_degree2_seed.config,
+                    FLASH_Q_TILE_COUNT_KEY: 2,
+                }
+            )
+            if causal_degree2_identity not in seeds:
+                seeds.append(causal_degree2_seed)
     for family_seed in _flash_canonical_family_seed_configs(
         head_dim,
         num_kv,
@@ -4152,6 +4339,7 @@ def flash_autotune_fragments(
     small_biased_candidate: bool = False,
     standard_dense_output: bool = False,
     standard_causal_output: bool = False,
+    target_device_capability: tuple[int, int] | None = None,
     topology_override: str | None = None,
     pipeline_family_override: str | None = None,
 ) -> dict[str, ConfigSpecFragment]:
@@ -4267,6 +4455,9 @@ def flash_autotune_fragments(
         and _flash_causal_hd64_seed_num_kv_supported(num_kv)
         and defaults.topology == "fa4"
     )
+    target_tuning_policy = get_flash_target_policy(target_device_capability).tuning
+    dense_tuning_policy = target_tuning_policy.dense_policy(num_kv)
+    causal_tuning_policy = target_tuning_policy.causal_policy(num_kv)
     long_causal_hd64_seeded_fa4 = (
         causal_hd64_seeded_fa4 and num_kv >= _FLASH_CAUSAL_HD64_LONG_AUTOTUNE_MIN_KV
     )
@@ -5084,7 +5275,7 @@ def flash_autotune_fragments(
     else:
         stat_transport_choices = ("ring2",)
         stat_transport_search_choices = None
-    return {
+    fragments: dict[str, ConfigSpecFragment] = {
         FLASH_S_STAGE_KEY: EnumFragment(s_stage_choices, s_stage_search_choices),
         FLASH_KV_STAGE_KEY: EnumFragment(kv_stage_choices, kv_stage_search_choices),
         FLASH_PERSISTENT_KEY: EnumFragment(
@@ -5194,6 +5385,21 @@ def flash_autotune_fragments(
             causal_loop_split_choices, causal_loop_split_search_choices
         ),
     }
+    policy_values: dict[str, object] = {}
+    if not is_causal and standard_dense_output and dense_tuning_policy is not None:
+        policy_values = _flash_dense_tuning_overrides(dense_tuning_policy)
+    elif is_causal and standard_causal_output and causal_tuning_policy is not None:
+        policy_values = _flash_causal_tuning_values(causal_tuning_policy)
+    for key, value in policy_values.items():
+        if key not in fragments:
+            continue
+        fragment = cast("EnumFragment", fragments[key])
+        if value not in fragment.choices:
+            search_choices = fragment.search_choices
+            if search_choices is None:
+                search_choices = (fragment.default(),)
+            fragments[key] = EnumFragment((*fragment.choices, value), search_choices)
+    return fragments
 
 
 def flash_config_from_config(

--- a/helion/_compiler/cute/flash_arch.py
+++ b/helion/_compiler/cute/flash_arch.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashHardwareCapabilities:
+    """Hardware features used by CuTe flash-attention lowerings."""
+
+    supports_tmem_row_reduce: bool = False
+    supports_packed_f16x2_exp2: bool = False

--- a/helion/_compiler/cute/flash_policy.py
+++ b/helion/_compiler/cute/flash_policy.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import dataclasses
+import enum
+
+from .flash_arch import FlashHardwareCapabilities
+from .flash_tuning import FlashCausalTuningPolicy
+from .flash_tuning import FlashDenseTuningPolicy
+from .flash_tuning import FlashPackedExp2Mode
+from .flash_tuning import FlashSoftmaxLowering
+from .flash_tuning import FlashTuningPolicy
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashTargetPolicy:
+    """Hardware capabilities and exact tuning choices for one target."""
+
+    hardware: FlashHardwareCapabilities = dataclasses.field(
+        default_factory=FlashHardwareCapabilities
+    )
+    tuning: FlashTuningPolicy = dataclasses.field(default_factory=FlashTuningPolicy)
+
+    def __post_init__(self) -> None:
+        if (
+            self.tuning.tmem_row_reduce_min_kv is not None
+            and not self.hardware.supports_tmem_row_reduce
+        ):
+            raise ValueError("TMEM row-reduce tuning requires hardware support")
+        causal_resident_policies = tuple(
+            policy
+            for policy in self.tuning.causal_policies
+            if policy.softmax_lowering is not FlashSoftmaxLowering.STANDARD
+        )
+        if causal_resident_policies and not self.hardware.supports_tmem_row_reduce:
+            raise ValueError("causal resident softmax requires TMEM row-reduce support")
+        row_reduce_min_kv = self.tuning.tmem_row_reduce_min_kv
+        if causal_resident_policies and (
+            row_reduce_min_kv is None
+            or any(
+                policy.num_kv < row_reduce_min_kv for policy in causal_resident_policies
+            )
+        ):
+            raise ValueError(
+                "causal resident softmax requires an enabled TMEM row-reduce range"
+            )
+        if (
+            any(
+                policy.packed_exp2_mode is not FlashPackedExp2Mode.DISABLED
+                for policy in self.tuning.dense_policies
+            )
+            and not self.hardware.supports_packed_f16x2_exp2
+        ):
+            raise ValueError("packed exp2 tuning requires hardware support")
+
+
+_GENERIC_FLASH_TARGET_POLICY = FlashTargetPolicy()
+_FLASH_TARGET_POLICIES = {
+    (10, 3): FlashTargetPolicy(
+        hardware=FlashHardwareCapabilities(
+            supports_tmem_row_reduce=True,
+            supports_packed_f16x2_exp2=True,
+        ),
+        tuning=FlashTuningPolicy(
+            tmem_row_reduce_min_kv=256,
+            dense_policies=(
+                FlashDenseTuningPolicy(
+                    num_kv=256,
+                    exp2_packet="deg1_8x2_corr10",
+                    e2e_schedule="8/2",
+                    e2e_offset=5,
+                    e2e_offset0=1,
+                    stat_transport="single",
+                    probability_log2_shift=7,
+                    softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                ),
+                FlashDenseTuningPolicy(
+                    num_kv=512,
+                    exp2_packet="deg1_8x2_corr10",
+                    e2e_schedule="8/2",
+                    e2e_offset=2,
+                    e2e_offset0=1,
+                    stat_transport="single",
+                    probability_log2_shift=7,
+                    softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                    corr_regs=72,
+                    other_regs=40,
+                ),
+                FlashDenseTuningPolicy(
+                    num_kv=1024,
+                    exp2_packet="deg1_8x2_corr10",
+                    e2e_schedule="8/2",
+                    e2e_offset=2,
+                    e2e_offset0=1,
+                    stat_transport="single",
+                    probability_log2_shift=7,
+                    softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                ),
+                FlashDenseTuningPolicy(
+                    num_kv=2048,
+                    exp2_packet="deg1_16x8",
+                    e2e_schedule="16/8",
+                    e2e_offset=0,
+                    e2e_offset0=10,
+                    stat_transport="single_final",
+                    packed_exp2_mode=FlashPackedExp2Mode.ALL_XU,
+                    probability_log2_shift=7,
+                ),
+            ),
+            causal_policies=(
+                FlashCausalTuningPolicy(
+                    num_kv=512,
+                    kv_stage=8,
+                    softmax_lowering=FlashSoftmaxLowering.STATEFUL,
+                    softmax_regs=200,
+                    first_load_order=2,
+                ),
+                FlashCausalTuningPolicy(
+                    num_kv=1024,
+                    kv_stage=3,
+                    softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                ),
+                FlashCausalTuningPolicy(
+                    num_kv=2048,
+                    kv_stage=3,
+                    softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                ),
+                FlashCausalTuningPolicy(
+                    num_kv=4096,
+                    kv_stage=6,
+                    softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                ),
+            ),
+        ),
+    ),
+}
+
+
+def get_flash_target_policy(
+    capability: tuple[int, int] | None,
+) -> FlashTargetPolicy:
+    """Return flash-attention hardware and tuning policy for a target."""
+    if capability is None:
+        return _GENERIC_FLASH_TARGET_POLICY
+    return _FLASH_TARGET_POLICIES.get(capability, _GENERIC_FLASH_TARGET_POLICY)
+
+
+def _cache_identity_value(value: object) -> object:
+    if isinstance(value, enum.Enum):
+        return value.value
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return tuple(
+            (field.name, _cache_identity_value(getattr(value, field.name)))
+            for field in dataclasses.fields(value)
+        )
+    if isinstance(value, tuple):
+        return tuple(_cache_identity_value(item) for item in value)
+    return value
+
+
+def flash_target_policy_cache_identity(
+    capability: tuple[int, int] | None,
+) -> object | None:
+    """Return a stable cache salt for non-generic target policy choices."""
+    policy = get_flash_target_policy(capability)
+    if policy is _GENERIC_FLASH_TARGET_POLICY:
+        return None
+    return _cache_identity_value(policy)

--- a/helion/_compiler/cute/flash_tuning.py
+++ b/helion/_compiler/cute/flash_tuning.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import dataclasses
+import enum
+
+
+class FlashSoftmaxLowering(str, enum.Enum):
+    """Available resident-softmax implementation strategies."""
+
+    STANDARD = "standard"
+    RESIDENT_VALUE_GRAPH = "resident_value_graph"
+    STATEFUL = "stateful"
+
+
+class FlashPackedExp2Mode(str, enum.Enum):
+    """Dense packed-f16x2 exponential strategy."""
+
+    DISABLED = "disabled"
+    ALL_XU = "all_xu"
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashDenseTuningPolicy:
+    """Exact dense seed and optional lowering choices for one KV size."""
+
+    num_kv: int
+    exp2_packet: str
+    e2e_schedule: str
+    e2e_offset: int
+    e2e_offset0: int
+    stat_transport: str
+    pipeline_family: str = "fa4_2cta"
+    kv_stage: int = 6
+    persistent: bool = False
+    q_tile_count: int = 2
+    packed_exp2_mode: FlashPackedExp2Mode = FlashPackedExp2Mode.DISABLED
+    probability_log2_shift: int = 0
+    softmax_lowering: FlashSoftmaxLowering = FlashSoftmaxLowering.STANDARD
+    corr_regs: int | None = None
+    other_regs: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.num_kv <= 0:
+            raise ValueError("dense KV size must be positive")
+        if not self.exp2_packet:
+            raise ValueError("dense exp2 packet must not be empty")
+        if not self.e2e_schedule:
+            raise ValueError("dense end-to-end schedule must not be empty")
+        if self.e2e_offset < 0 or self.e2e_offset0 < 0:
+            raise ValueError("dense end-to-end offsets must be nonnegative")
+        if not self.stat_transport:
+            raise ValueError("dense statistics transport must not be empty")
+        if not self.pipeline_family:
+            raise ValueError("dense pipeline family must not be empty")
+        if self.kv_stage <= 0:
+            raise ValueError("dense KV stage must be positive")
+        if self.q_tile_count != 2:
+            raise ValueError("dense query tile count must be 2")
+        if self.probability_log2_shift < 0:
+            raise ValueError("probability log2 shift must be nonnegative")
+        if self.softmax_lowering is FlashSoftmaxLowering.STATEFUL:
+            raise ValueError(
+                "stateful softmax lowering is unsupported for dense policy"
+            )
+        if (self.corr_regs is None) != (self.other_regs is None):
+            raise ValueError(
+                "dense correction and other register counts must be set together"
+            )
+        if self.corr_regs is not None and (self.corr_regs <= 0 or self.corr_regs % 8):
+            raise ValueError(
+                "dense correction register count must be a positive multiple of 8"
+            )
+        if self.other_regs is not None and (
+            self.other_regs < 24 or self.other_regs % 8
+        ):
+            raise ValueError(
+                "dense other register count must be at least 24 and a multiple of 8"
+            )
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashCausalTuningPolicy:
+    """Exact causal seed and resident-softmax choices for one KV size."""
+
+    num_kv: int
+    kv_stage: int
+    q_tile_count: int = 2
+    softmax_lowering: FlashSoftmaxLowering = FlashSoftmaxLowering.STANDARD
+    softmax_regs: int | None = None
+    first_load_order: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.num_kv <= 0:
+            raise ValueError("causal KV size must be positive")
+        if self.kv_stage <= 0:
+            raise ValueError("causal KV stage must be positive")
+        if self.q_tile_count != 2:
+            raise ValueError("causal query tile count must be 2")
+        if self.softmax_regs is not None and (
+            self.softmax_regs <= 0 or self.softmax_regs % 8
+        ):
+            raise ValueError(
+                "causal softmax register count must be a positive multiple of 8"
+            )
+        if self.first_load_order is not None and self.first_load_order not in range(5):
+            raise ValueError("causal first-load order must be 0-4")
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashTuningPolicy:
+    """Architecture-specific flash-attention seeds and lowering choices."""
+
+    tmem_row_reduce_min_kv: int | None = None
+    dense_policies: tuple[FlashDenseTuningPolicy, ...] = ()
+    causal_policies: tuple[FlashCausalTuningPolicy, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.tmem_row_reduce_min_kv is not None and self.tmem_row_reduce_min_kv <= 0:
+            raise ValueError("TMEM row-reduce minimum KV size must be positive")
+        dense_num_kv = [policy.num_kv for policy in self.dense_policies]
+        if len(set(dense_num_kv)) != len(dense_num_kv):
+            raise ValueError("dense KV sizes must be unique")
+        causal_num_kv = [policy.num_kv for policy in self.causal_policies]
+        if len(set(causal_num_kv)) != len(causal_num_kv):
+            raise ValueError("causal KV sizes must be unique")
+
+    def dense_policy(self, num_kv: int) -> FlashDenseTuningPolicy | None:
+        """Return the exact dense policy for ``num_kv``, if one exists."""
+        return next(
+            (policy for policy in self.dense_policies if policy.num_kv == num_kv),
+            None,
+        )
+
+    def causal_policy(self, num_kv: int) -> FlashCausalTuningPolicy | None:
+        """Return the exact causal policy for ``num_kv``, if one exists."""
+        return next(
+            (policy for policy in self.causal_policies if policy.num_kv == num_kv),
+            None,
+        )

--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -135,7 +135,9 @@ class LooseAutotuneCacheKey(BoundKernelInMemoryCacheKey):
     hardware: Hardware of the input device
     runtime_name: Version of the cuda/rocm arch
     backend: Kernel backend (e.g. triton, pallas)
-    config_spec_hash: Hash of the config spec (available knobs and their ranges)
+    config_spec_hash: Hash of the config spec's persistent-cache identity
+        (available knobs and their ranges, plus any compiler-owned default and
+        ordered seed configs)
     extra_cache_key: Optional extra cache key from the kernel (e.g. fusion context hash)
     best_of_k: Number of autotune trials run with different random seeds; the
         winning config across trials is the one cached. Default ``1`` (the

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -792,7 +792,7 @@ class BaseSearch(BaseAutotuner):
         if current_hardware is None or current_spec_key is None:
             return []
 
-        current_fingerprint_hash = self.config_spec.structural_fingerprint_hash(
+        current_fingerprint_hash = self.config_spec.cache_fingerprint_hash(
             advanced_controls_files=self.settings.autotune_search_acf or None
         )
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -4,6 +4,7 @@ import enum
 import functools
 import hashlib
 import itertools
+import json
 import logging
 import math
 import operator
@@ -1037,6 +1038,7 @@ class ConfigSpec:
             small_biased_candidate=self._cute_flash_small_biased_candidate,
             standard_dense_output=self._cute_flash_standard_dense_output,
             standard_causal_output=self._cute_flash_standard_causal_output,
+            target_device_capability=self.target_device_capability,
             topology_override=cast("str | None", topology_override),
             pipeline_family_override=pipeline_family_override,
         )
@@ -1517,6 +1519,7 @@ class ConfigSpec:
                     small_biased_candidate=self._cute_flash_small_biased_candidate,
                     standard_dense_output=self._cute_flash_standard_dense_output,
                     standard_causal_output=self._cute_flash_standard_causal_output,
+                    target_device_capability=self.target_device_capability,
                     block_size_targets=self._cute_flash_block_size_target_list(),
                 )
             )
@@ -2540,6 +2543,7 @@ class ConfigSpec:
                         standard_causal_output=(
                             self._cute_flash_standard_causal_output
                         ),
+                        target_device_capability=self.target_device_capability,
                         pipeline_family_override=_flash_pipeline_family_override,
                     )
                 )
@@ -2711,6 +2715,64 @@ class ConfigSpec:
             repr(
                 self.structural_fingerprint(
                     advanced_controls_files=advanced_controls_files
+                )
+            ).encode("utf-8")
+        ).hexdigest()
+
+    def cache_fingerprint_hash(
+        self, *, advanced_controls_files: list[str] | None = None
+    ) -> str:
+        """Return the ConfigSpec identity used by persistent autotune caches.
+
+        Compiler-owned defaults and seeds affect which configs are tried first,
+        but are intentionally absent from :meth:`structural_fingerprint`: two
+        shapes with different promoted seeds can still share the same flat
+        layout during multi-shape autotuning.  Persistent cache reuse is
+        different: a result selected under an old compiler seed policy must not
+        bypass a newly promoted policy, so include the ordered compiler configs
+        in that identity.
+
+        Target lowering policy also affects generated code even when its
+        promoted seed is unchanged, so include its stable identity.  Generic
+        targets with no compiler default or seed retain the historical
+        structural hash verbatim.
+        """
+        structural_hash = self.structural_fingerprint_hash(
+            advanced_controls_files=advanced_controls_files
+        )
+        target_policy_identity: object | None = None
+        if self.backend_name == "cute" and self.cute_flash_search_enabled:
+            from .._compiler.cute.flash_policy import flash_target_policy_cache_identity
+
+            target_policy_identity = flash_target_policy_cache_identity(
+                self.target_device_capability
+            )
+        if (
+            self.compiler_default_config is None
+            and not self.compiler_seed_configs
+            and target_policy_identity is None
+        ):
+            return structural_hash
+
+        def canonical_config(config: helion.Config | None) -> str | None:
+            if config is None:
+                return None
+            return json.dumps(
+                config.config,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+
+        compiler_config_identity = (
+            canonical_config(self.compiler_default_config),
+            tuple(canonical_config(config) for config in self.compiler_seed_configs),
+        )
+        return hashlib.sha256(
+            repr(
+                (
+                    structural_hash,
+                    compiler_config_identity,
+                    target_policy_identity,
                 )
             ).encode("utf-8")
         ).hexdigest()

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -195,7 +195,7 @@ class LocalAutotuneCache(AutotuneCacheBase):
                 runtime_name = "unknown"
 
         assert hardware is not None and runtime_name is not None
-        config_spec_hash = self.kernel.config_spec.structural_fingerprint_hash(
+        config_spec_hash = self.kernel.config_spec.cache_fingerprint_hash(
             advanced_controls_files=self.autotuner.settings.autotune_search_acf or None
         )
         return LooseAutotuneCacheKey(

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import dataclasses
 import math
 import os
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -92,6 +94,8 @@ from helion._compiler.cute.cute_flash import flash_attention_seed_configs
 from helion._compiler.cute.cute_flash import flash_autotune_fragments
 from helion._compiler.cute.cute_flash import flash_effective_config_values
 from helion._compiler.cute.cute_flash import resolve_flash_config
+from helion._compiler.cute.flash_policy import get_flash_target_policy
+from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY
@@ -2574,6 +2578,393 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                         {"ring2", "single_final"},
                     )
 
+    def test_cute_flash_sm103_rank0_seed_policy(self) -> None:
+        dense_params = {
+            256: ("deg1_8x2_corr10", "8/2", 5, 1, "single"),
+            512: ("deg1_8x2_corr10", "8/2", 2, 1, "single"),
+            1024: ("deg1_8x2_corr10", "8/2", 2, 1, "single"),
+            2048: ("deg1_16x8", "16/8", 0, 10, "single_final"),
+        }
+        causal_kv_stages = {512: 8, 1024: 3, 2048: 3, 4096: 6}
+        dense_inherited = {
+            256: (64, 40, 200, 0, "helion", True),
+            512: (72, 40, 200, 4, "fa4", True),
+            1024: (72, 40, 200, 0, "helion", True),
+            2048: (80, 32, 192, 4, "helion", True),
+        }
+        causal_inherited = {
+            512: (15, 3, 200, 2, "fa4", True),
+            1024: (1, 14, 184, 0, "fa4", False),
+            2048: (14, 12, 184, 0, "fa4", False),
+            4096: (14, 12, 184, 0, "helion", False),
+        }
+        sm103_policy = get_flash_target_policy((10, 3)).tuning
+        self.assertEqual(
+            {
+                shape_policy.num_kv: shape_policy.kv_stage
+                for shape_policy in sm103_policy.causal_policies
+            },
+            causal_kv_stages,
+        )
+
+        cases = [(False, num_kv) for num_kv in dense_params] + [
+            (True, num_kv) for num_kv in causal_kv_stages
+        ]
+        for is_causal, num_kv in cases:
+            with self.subTest(is_causal=is_causal, num_kv=num_kv):
+                seed_kwargs = {
+                    "dtype": torch.float16,
+                    "is_causal": is_causal,
+                    "standard_dense_output": not is_causal,
+                    "standard_causal_output": is_causal,
+                }
+                seed = flash_attention_seed_config(
+                    64,
+                    num_kv,
+                    target_device_capability=(10, 3),
+                    **seed_kwargs,
+                )
+                assert seed is not None
+
+                self.assertEqual(seed.config[FLASH_P_STORE_REP_KEY], 16)
+                self.assertEqual(seed.config[FLASH_S_LOAD_REP_KEY], 32)
+                self.assertTrue(seed.config[FLASH_SPLIT_P_ARRIVE_KEY])
+                self.assertEqual(seed.config[FLASH_RESCALE_THRESHOLD_KEY], 8.0)
+
+                if is_causal:
+                    self.assertEqual(seed.config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
+                    self.assertFalse(seed.config[FLASH_PERSISTENT_KEY])
+                    self.assertEqual(seed.config[FLASH_E2E_SCHEDULE_KEY], "16/6")
+                    self.assertEqual(seed.config[FLASH_MASKED_E2E_SCHEDULE_KEY], "16/6")
+                    self.assertEqual(seed.config[FLASH_EXP2_PACKET_KEY], "deg2_16x6")
+                    self.assertEqual(seed.config[FLASH_STAT_TRANSPORT_KEY], "ring2")
+                    self.assertEqual(seed.config[FLASH_Q_TILE_COUNT_KEY], 2)
+                    self.assertEqual(seed.config[FLASH_CORR_REGS_KEY], 64)
+                    self.assertEqual(seed.config[FLASH_OTHER_REGS_KEY], 48)
+                    self.assertEqual(
+                        (
+                            seed.config[FLASH_E2E_OFFSET_KEY],
+                            seed.config[FLASH_E2E_OFFSET0_KEY],
+                            seed.config[FLASH_SOFTMAX_REGS_KEY],
+                            seed.config[FLASH_FIRST_LOAD_ORDER_KEY],
+                            seed.config[FLASH_ROLE_MAP_KEY],
+                            seed.config[FLASH_EPI_TMA_KEY],
+                        ),
+                        causal_inherited[num_kv],
+                    )
+                    baseline_degree2 = next(
+                        candidate
+                        for candidate in flash_attention_seed_configs(
+                            64,
+                            num_kv,
+                            **seed_kwargs,
+                        )
+                        if candidate.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
+                    )
+                    expected = {
+                        **baseline_degree2.config,
+                        FLASH_KV_STAGE_KEY: causal_kv_stages[num_kv],
+                        FLASH_Q_TILE_COUNT_KEY: 2,
+                    }
+                    resident_policy = sm103_policy.causal_policy(num_kv)
+                    assert resident_policy is not None
+                    if resident_policy.softmax_regs is not None:
+                        expected[FLASH_SOFTMAX_REGS_KEY] = resident_policy.softmax_regs
+                    if resident_policy.first_load_order is not None:
+                        expected[FLASH_FIRST_LOAD_ORDER_KEY] = (
+                            resident_policy.first_load_order
+                        )
+                else:
+                    self.assertEqual(
+                        (
+                            seed.config[FLASH_CORR_REGS_KEY],
+                            seed.config[FLASH_OTHER_REGS_KEY],
+                            seed.config[FLASH_SOFTMAX_REGS_KEY],
+                            seed.config[FLASH_FIRST_LOAD_ORDER_KEY],
+                            seed.config[FLASH_ROLE_MAP_KEY],
+                            seed.config[FLASH_PRECOMPUTE_QK_DESC_KEY],
+                        ),
+                        dense_inherited[num_kv],
+                    )
+                    fragments = flash_autotune_fragments(
+                        64,
+                        num_kv,
+                        dtype=torch.float16,
+                        standard_dense_output=True,
+                        pipeline_family_override="fa4_2cta",
+                    )
+                    packet, schedule, offset, offset0, stat_transport = dense_params[
+                        num_kv
+                    ]
+                    expected_values = {
+                        key: fragment.default() for key, fragment in fragments.items()
+                    }
+                    expected_values.update(
+                        {
+                            FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta",
+                            FLASH_KV_STAGE_KEY: 6,
+                            FLASH_PERSISTENT_KEY: False,
+                            FLASH_E2E_SCHEDULE_KEY: schedule,
+                            FLASH_E2E_OFFSET_KEY: offset,
+                            FLASH_E2E_OFFSET0_KEY: offset0,
+                            FLASH_EXP2_PACKET_KEY: packet,
+                            FLASH_STAT_TRANSPORT_KEY: stat_transport,
+                        }
+                    )
+                    dense_resident_policy = sm103_policy.dense_policy(num_kv)
+                    if (
+                        dense_resident_policy is not None
+                        and dense_resident_policy.corr_regs is not None
+                    ):
+                        assert dense_resident_policy.other_regs is not None
+                        expected_values[FLASH_CORR_REGS_KEY] = (
+                            dense_resident_policy.corr_regs
+                        )
+                        expected_values[FLASH_OTHER_REGS_KEY] = (
+                            dense_resident_policy.other_regs
+                        )
+                    expected = {
+                        "block_sizes": [1, 128, 128],
+                        **expected_values,
+                        FLASH_Q_TILE_COUNT_KEY: 2,
+                    }
+                self.assertEqual(seed.config, expected)
+
+                ranked = flash_attention_seed_configs(
+                    64,
+                    num_kv,
+                    target_device_capability=(10, 3),
+                    **seed_kwargs,
+                )
+                self.assertEqual(ranked[0], seed)
+                if is_causal and num_kv == 1024:
+                    self.assertEqual(
+                        sum(
+                            candidate.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
+                            and candidate.config.get(FLASH_KV_STAGE_KEY) == 2
+                            for candidate in ranked
+                        ),
+                        1,
+                    )
+
+                if (is_causal, num_kv) not in ((False, 512), (True, 512)):
+                    continue
+
+                spec = ConfigSpec(
+                    backend=CuteBackend(),
+                    target_device_capability=(10, 3),
+                )
+                for block_id, target in enumerate((1, 128, 128)):
+                    spec.block_sizes.append(
+                        BlockSizeSpec(block_id=block_id, size_hint=target)
+                    )
+                spec.enable_cute_flash_search(
+                    head_dim=64,
+                    num_kv=num_kv,
+                    block_size_targets={0: 1, 1: 128, 2: 128},
+                    **seed_kwargs,
+                )
+                env = MagicMock()
+                env.backend_name = "cute"
+                env.config_spec = spec
+                env.settings = Settings()
+                with patch(
+                    "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                    {
+                        "cute": (
+                            CuteFlashAttentionHeuristic,
+                            CuteFlashAttentionCausalLptHeuristic,
+                        )
+                    },
+                ):
+                    compiler_seeds = compiler_seed_configs(env, MagicMock())
+                self.assertEqual(compiler_seeds[0], seed)
+                self.assertIsNone(spec.compiler_default_config)
+                self.assertEqual(spec.autotune_seed_configs()[0], seed)
+
+                spec.compiler_seed_configs = compiler_seeds
+                config_gen = ConfigGeneration(spec)
+                roundtrip = config_gen.unflatten(config_gen.flatten(seed))
+                self.assertEqual(roundtrip, seed)
+
+    def test_cute_flash_sm103_seed_policy_changes_cache_identity(self) -> None:
+        def make_spec(target: tuple[int, int]) -> ConfigSpec:
+            spec = ConfigSpec(
+                backend=CuteBackend(),
+                target_device_capability=target,
+            )
+            for block_id, size_hint in enumerate((1, 128, 128)):
+                spec.block_sizes.append(
+                    BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+                )
+            spec.enable_cute_flash_search(
+                head_dim=64,
+                num_kv=1024,
+                block_size_targets={0: 1, 1: 128, 2: 128},
+                dtype=torch.float16,
+                standard_dense_output=True,
+            )
+            spec.compiler_seed_configs = list(
+                flash_attention_seed_configs(
+                    64,
+                    1024,
+                    dtype=torch.float16,
+                    standard_dense_output=True,
+                    target_device_capability=target,
+                )
+            )
+            return spec
+
+        sm100 = make_spec((10, 0))
+        sm103 = make_spec((10, 3))
+
+        self.assertEqual(sm100.structural_fingerprint(), sm103.structural_fingerprint())
+        self.assertNotEqual(
+            sm100.compiler_seed_configs,
+            sm103.compiler_seed_configs,
+        )
+        self.assertNotEqual(
+            sm100.cache_fingerprint_hash(),
+            sm103.cache_fingerprint_hash(),
+        )
+
+        original_hash = sm103.cache_fingerprint_hash()
+        target_policy = get_flash_target_policy((10, 3))
+        dense_policy = target_policy.tuning.dense_policy(1024)
+        assert dense_policy is not None
+        changed_tuning = dataclasses.replace(
+            target_policy.tuning,
+            dense_policies=tuple(
+                dataclasses.replace(
+                    policy,
+                    softmax_lowering=FlashSoftmaxLowering.STANDARD,
+                )
+                if policy.num_kv == 1024
+                else policy
+                for policy in target_policy.tuning.dense_policies
+            ),
+        )
+        with patch(
+            "helion._compiler.cute.flash_policy.get_flash_target_policy",
+            return_value=dataclasses.replace(target_policy, tuning=changed_tuning),
+        ):
+            self.assertNotEqual(sm103.cache_fingerprint_hash(), original_hash)
+
+    def test_cute_flash_target_policy_preserves_b200_fragment_surface(self) -> None:
+        def fragment_signature(
+            target: tuple[int, int] | None, *, is_causal: bool
+        ) -> tuple[tuple[object, ...], ...]:
+            fragments = flash_autotune_fragments(
+                64,
+                512,
+                dtype=torch.float16,
+                is_causal=is_causal,
+                standard_dense_output=not is_causal,
+                standard_causal_output=is_causal,
+                target_device_capability=target,
+            )
+            return tuple(
+                (
+                    key,
+                    fragment.fingerprint(),
+                    tuple(cast("EnumFragment", fragment).choices),
+                    cast("EnumFragment", fragment).search_choices,
+                )
+                for key, fragment in fragments.items()
+            )
+
+        for is_causal in (False, True):
+            baseline = fragment_signature(None, is_causal=is_causal)
+            self.assertEqual(baseline, fragment_signature((10, 0), is_causal=is_causal))
+            self.assertEqual(baseline, fragment_signature((10, 4), is_causal=is_causal))
+
+        sm103_fragments = flash_autotune_fragments(
+            64,
+            512,
+            dtype=torch.float16,
+            is_causal=True,
+            standard_causal_output=True,
+            target_device_capability=(10, 3),
+        )
+        first_load = cast("EnumFragment", sm103_fragments[FLASH_FIRST_LOAD_ORDER_KEY])
+        self.assertEqual(first_load.choices, (0, 2))
+        self.assertEqual(first_load.search_choices, (0,))
+
+    def test_cute_flash_non_sm103_seed_order_is_unchanged(self) -> None:
+        targets = (None, (10, 0), (10, 2), (10, 4), (11, 0))
+        cases = (
+            {
+                "num_kv": 1024,
+                "is_causal": False,
+                "standard_dense_output": True,
+            },
+            {
+                "num_kv": 2048,
+                "is_causal": True,
+                "standard_causal_output": True,
+            },
+        )
+        for case in cases:
+            baseline = flash_attention_seed_configs(
+                64,
+                case["num_kv"],
+                dtype=torch.float16,
+                is_causal=case["is_causal"],
+                standard_dense_output=case.get("standard_dense_output", False),
+                standard_causal_output=case.get("standard_causal_output", False),
+            )
+            for target in targets:
+                with self.subTest(case=case, target=target):
+                    actual = flash_attention_seed_configs(
+                        64,
+                        case["num_kv"],
+                        dtype=torch.float16,
+                        is_causal=case["is_causal"],
+                        standard_dense_output=case.get("standard_dense_output", False),
+                        standard_causal_output=case.get(
+                            "standard_causal_output", False
+                        ),
+                        target_device_capability=target,
+                    )
+                    self.assertEqual(actual, baseline)
+
+    def test_cute_flash_sm103_seed_policy_gates(self) -> None:
+        cases = (
+            {"standard_dense_output": False},
+            {"standard_causal_output": False, "is_causal": True, "num_kv": 512},
+            {"standard_dense_output": True, "dtype": torch.bfloat16},
+            {"standard_dense_output": True, "head_dim": 128},
+            {"standard_dense_output": True, "has_kv_tile_pruning": True},
+            {"standard_dense_output": True, "requires_ws_overlap": True},
+            {"standard_dense_output": True, "small_biased_candidate": True},
+            {"standard_dense_output": True, "num_kv": 768},
+            {
+                "standard_dense_output": True,
+                "block_size_targets": (1, 64, 128),
+            },
+        )
+        for raw_case in cases:
+            case = dict(raw_case)
+            head_dim = int(case.pop("head_dim", 64))
+            num_kv = int(case.pop("num_kv", 256))
+            subtest_case = {
+                key: str(value) if isinstance(value, torch.dtype) else value
+                for key, value in raw_case.items()
+            }
+            with self.subTest(case=subtest_case):
+                baseline = flash_attention_seed_config(
+                    head_dim,
+                    num_kv,
+                    **case,
+                )
+                actual = flash_attention_seed_config(
+                    head_dim,
+                    num_kv,
+                    target_device_capability=(10, 3),
+                    **case,
+                )
+                self.assertEqual(actual, baseline)
+
     def test_cute_flash_dense_degree2_seed_uses_validated_schedule(self) -> None:
         degree1_packets = {"deg1_8x2_corr10", "deg1_16x8"}
         for num_kv in (252, 256, 258, 260, 512, 516, 768, 1024, 1536, 2048, 2052, 4096):
@@ -3382,7 +3773,15 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         causal_65536_degree2_normalized = quick_search.config_gen.unflatten(
             quick_search.config_gen.flatten(causal_65536_degree2)
         )
-        self.assertEqual(len(quick_configs), 4)
+        expected_quick_configs = [
+            config for _flat, config in quick_search.config_gen.seed_flat_config_pairs()
+        ]
+        default_config = quick_search.config_gen.unflatten(
+            quick_search.config_gen.default_flat()
+        )
+        if default_config not in expected_quick_configs:
+            expected_quick_configs.append(default_config)
+        self.assertEqual(quick_configs, expected_quick_configs)
         self.assertIn(causal_65536_degree2_normalized, quick_configs)
         self.assertIsNone(causal_65536_bound.config_spec.compiler_default_config)
         causal_65536_gen = ConfigGeneration(causal_65536_bound.config_spec)

--- a/test/test_best_available.py
+++ b/test/test_best_available.py
@@ -484,7 +484,7 @@ class TestCacheMatching(unittest.TestCase):
                 return_value=("NVIDIA GeForce RTX 4090", "('tensor_spec',)")
             )
             mock_search.config_spec = MagicMock()
-            mock_search.config_spec.structural_fingerprint_hash = MagicMock(
+            mock_search.config_spec.cache_fingerprint_hash = MagicMock(
                 return_value=fp_hash
             )
 
@@ -499,6 +499,59 @@ class TestCacheMatching(unittest.TestCase):
             self.assertEqual(len(entries), 2)
             self.assertEqual(entries[0].config.config["block_sizes"], [32, 64])
             self.assertEqual(entries[1].config.config["block_sizes"], [64, 128])
+
+    def test_find_similar_rejects_old_compiler_seed_policy(self):
+        config_spec = ConfigSpec(backend=TritonBackend())
+        config_spec.block_sizes.append(
+            BlockSizeSpec(block_id=0, size_hint=64, min_size=16, max_size=256)
+        )
+        historical_hash = config_spec.structural_fingerprint_hash()
+        config_spec.compiler_seed_configs = [Config(block_sizes=[64], num_warps=4)]
+        current_hash = config_spec.cache_fingerprint_hash()
+        self.assertNotEqual(current_hash, historical_hash)
+
+        with tempfile.TemporaryDirectory() as cache_dir:
+            self._write_best_config(
+                cache_dir,
+                "old-policy.best_config",
+                hardware="NVIDIA GeForce RTX 4090",
+                spec_key="('tensor_spec',)",
+                source_hash="old",
+                config_dict={"block_sizes": [32], "num_warps": 8},
+                config_spec_hash=historical_hash,
+                flat_config=[32, 8],
+            )
+            self._write_best_config(
+                cache_dir,
+                "current-policy.best_config",
+                hardware="NVIDIA GeForce RTX 4090",
+                spec_key="('tensor_spec',)",
+                source_hash="current",
+                config_dict={"block_sizes": [64], "num_warps": 4},
+                config_spec_hash=current_hash,
+                flat_config=[64, 4],
+            )
+
+            mock_search = MagicMock()
+            mock_search._skip_cache = False
+            mock_search.settings = MagicMock()
+            mock_search.settings.autotune_best_available_max_cache_scan = 500
+            mock_search.settings.autotune_search_acf = None
+            mock_search._get_current_hardware_and_specialization = MagicMock(
+                return_value=("NVIDIA GeForce RTX 4090", "('tensor_spec',)")
+            )
+            mock_search.config_spec = config_spec
+
+            with patch(
+                "helion.autotuner.local_cache.get_helion_cache_dir",
+                return_value=Path(cache_dir),
+            ):
+                entries = PopulationBasedSearch._find_similar_cached_configs(
+                    mock_search, max_configs=10
+                )
+
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0].config.config["block_sizes"], [64])
 
     def test_find_similar_cached_configs_respects_max_configs(self):
         """Test that _find_similar_cached_configs respects max_configs limit."""
@@ -527,7 +580,7 @@ class TestCacheMatching(unittest.TestCase):
                 return_value=("NVIDIA GeForce RTX 4090", "('tensor_spec',)")
             )
             mock_search.config_spec = MagicMock()
-            mock_search.config_spec.structural_fingerprint_hash = MagicMock(
+            mock_search.config_spec.cache_fingerprint_hash = MagicMock(
                 return_value=fp_hash
             )
 
@@ -616,7 +669,7 @@ class TestCacheMatching(unittest.TestCase):
                 return_value=("NVIDIA GeForce RTX 5090", current_normalized)
             )
             mock_search.config_spec = MagicMock()
-            mock_search.config_spec.structural_fingerprint_hash = MagicMock(
+            mock_search.config_spec.cache_fingerprint_hash = MagicMock(
                 return_value=fp_hash
             )
 
@@ -666,7 +719,7 @@ class TestCacheMatching(unittest.TestCase):
             mock_search.settings.autotune_best_available_max_cache_scan = 500
             mock_search.args = [torch.tensor([1.0], device=DEVICE)]
             mock_search.config_spec = MagicMock()
-            mock_search.config_spec.structural_fingerprint_hash = MagicMock(
+            mock_search.config_spec.cache_fingerprint_hash = MagicMock(
                 return_value=fp_hash
             )
 
@@ -737,9 +790,7 @@ class TestRemoteCacheMerging(unittest.TestCase):
             return_value=(hardware, spec_key)
         )
         mock_search.config_spec = MagicMock()
-        mock_search.config_spec.structural_fingerprint_hash = MagicMock(
-            return_value=fp_hash
-        )
+        mock_search.config_spec.cache_fingerprint_hash = MagicMock(return_value=fp_hash)
         return mock_search
 
     def test_remote_entries_returned_when_local_empty(self):
@@ -1163,7 +1214,7 @@ class TestSpecKeyNormalization(unittest.TestCase):
                 hardware="test_hw",
                 runtime_name="1.0",
                 backend="triton",
-                config_spec_hash=config_spec.structural_fingerprint_hash(
+                config_spec_hash=config_spec.cache_fingerprint_hash(
                     advanced_controls_files=acf_files
                 ),
             )
@@ -1232,6 +1283,101 @@ class TestStructuralFingerprint(unittest.TestCase):
         self.assertEqual(
             spec_a.structural_fingerprint(), spec_b.structural_fingerprint()
         )
+
+    def test_cache_fingerprint_tracks_ordered_compiler_configs(self):
+        def make_spec() -> ConfigSpec:
+            spec = ConfigSpec(backend=TritonBackend())
+            spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=64))
+            return spec
+
+        seed_a = Config(block_sizes=[64], num_warps=4)
+        seed_b = Config(block_sizes=[128], num_warps=8)
+
+        baseline = make_spec()
+        baseline.compiler_seed_configs = [seed_a, seed_b]
+
+        changed_value = make_spec()
+        changed_value.compiler_seed_configs = [
+            Config(block_sizes=[64], num_warps=2),
+            seed_b,
+        ]
+
+        changed_order = make_spec()
+        changed_order.compiler_seed_configs = [seed_b, seed_a]
+
+        changed_default = make_spec()
+        changed_default.compiler_seed_configs = [seed_a, seed_b]
+        changed_default.compiler_default_config = seed_a
+
+        changed_default_value = make_spec()
+        changed_default_value.compiler_seed_configs = [seed_a, seed_b]
+        changed_default_value.compiler_default_config = seed_b
+
+        equivalent_key_order = make_spec()
+        equivalent_key_order.compiler_seed_configs = [
+            Config.from_dict({"num_warps": 4, "block_sizes": [64]}),
+            seed_b,
+        ]
+
+        specs = (
+            changed_value,
+            changed_order,
+            changed_default,
+            changed_default_value,
+            equivalent_key_order,
+        )
+        for spec in specs:
+            self.assertEqual(
+                baseline.structural_fingerprint(), spec.structural_fingerprint()
+            )
+
+        baseline_hash = baseline.cache_fingerprint_hash()
+        self.assertNotEqual(baseline_hash, changed_value.cache_fingerprint_hash())
+        self.assertNotEqual(baseline_hash, changed_order.cache_fingerprint_hash())
+        self.assertNotEqual(baseline_hash, changed_default.cache_fingerprint_hash())
+        self.assertNotEqual(
+            changed_default.cache_fingerprint_hash(),
+            changed_default_value.cache_fingerprint_hash(),
+        )
+        self.assertEqual(baseline_hash, equivalent_key_order.cache_fingerprint_hash())
+
+        default_only_a = make_spec()
+        default_only_a.compiler_default_config = seed_a
+        default_only_b = make_spec()
+        default_only_b.compiler_default_config = seed_b
+        self.assertNotEqual(
+            default_only_a.cache_fingerprint_hash(),
+            default_only_b.cache_fingerprint_hash(),
+        )
+
+    def test_cache_fingerprint_without_compiler_configs_is_byte_compatible(self):
+        spec = ConfigSpec(backend=TritonBackend())
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=64))
+        historical_hash = hashlib.sha256(
+            repr(spec.structural_fingerprint()).encode("utf-8")
+        ).hexdigest()
+
+        self.assertEqual(spec.structural_fingerprint_hash(), historical_hash)
+        self.assertEqual(spec.cache_fingerprint_hash(), historical_hash)
+
+        key_kwargs = {
+            "specialization_key": ("tensor_spec",),
+            "extra_results": (),
+            "kernel_source_hash": "source",
+            "hardware": "hardware",
+            "runtime_name": "runtime",
+            "backend": "triton",
+        }
+        historical_key = LooseAutotuneCacheKey(
+            **key_kwargs,
+            config_spec_hash=historical_hash,
+        )
+        current_key = LooseAutotuneCacheKey(
+            **key_kwargs,
+            config_spec_hash=spec.cache_fingerprint_hash(),
+        )
+        self.assertEqual(repr(current_key), repr(historical_key))
+        self.assertEqual(current_key.stable_hash(), historical_key.stable_hash())
 
     def test_enum_choices_change_fingerprint(self):
         """Enum search-space changes should invalidate exact-cache entries."""

--- a/test/test_cute_flash_arch.py
+++ b/test/test_cute_flash_arch.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import pytest
+
+from helion._compiler.cute.flash_arch import FlashHardwareCapabilities
+from helion._compiler.cute.flash_policy import FlashTargetPolicy
+from helion._compiler.cute.flash_policy import get_flash_target_policy
+from helion._compiler.cute.flash_tuning import FlashCausalTuningPolicy
+from helion._compiler.cute.flash_tuning import FlashDenseTuningPolicy
+from helion._compiler.cute.flash_tuning import FlashPackedExp2Mode
+from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
+from helion._compiler.cute.flash_tuning import FlashTuningPolicy
+
+
+def test_sm103_flash_hardware_capabilities() -> None:
+    capabilities = get_flash_target_policy((10, 3)).hardware
+
+    assert capabilities.supports_tmem_row_reduce
+    assert capabilities.supports_packed_f16x2_exp2
+
+
+@pytest.mark.parametrize(
+    "capability",
+    [None, (10, 0), (10, 2), (10, 4), (11, 0)],
+)
+def test_unknown_and_b200_flash_hardware_capabilities_are_generic(
+    capability: tuple[int, int] | None,
+) -> None:
+    capabilities = get_flash_target_policy(capability).hardware
+
+    assert not capabilities.supports_tmem_row_reduce
+    assert not capabilities.supports_packed_f16x2_exp2
+
+
+def test_sm103_flash_tuning_policy() -> None:
+    policy = get_flash_target_policy((10, 3)).tuning
+
+    assert policy.tmem_row_reduce_min_kv == 256
+
+    expected_dense = {
+        256: (
+            "deg1_8x2_corr10",
+            "8/2",
+            5,
+            1,
+            "single",
+            "fa4_2cta",
+            6,
+            False,
+            2,
+            FlashPackedExp2Mode.DISABLED,
+            7,
+            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            None,
+            None,
+        ),
+        512: (
+            "deg1_8x2_corr10",
+            "8/2",
+            2,
+            1,
+            "single",
+            "fa4_2cta",
+            6,
+            False,
+            2,
+            FlashPackedExp2Mode.DISABLED,
+            7,
+            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            72,
+            40,
+        ),
+        1024: (
+            "deg1_8x2_corr10",
+            "8/2",
+            2,
+            1,
+            "single",
+            "fa4_2cta",
+            6,
+            False,
+            2,
+            FlashPackedExp2Mode.DISABLED,
+            7,
+            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            None,
+            None,
+        ),
+        2048: (
+            "deg1_16x8",
+            "16/8",
+            0,
+            10,
+            "single_final",
+            "fa4_2cta",
+            6,
+            False,
+            2,
+            FlashPackedExp2Mode.ALL_XU,
+            7,
+            FlashSoftmaxLowering.STANDARD,
+            None,
+            None,
+        ),
+    }
+    assert {shape.num_kv for shape in policy.dense_policies} == set(expected_dense)
+    for num_kv, expected in expected_dense.items():
+        shape = policy.dense_policy(num_kv)
+        assert shape is not None
+        assert (
+            shape.exp2_packet,
+            shape.e2e_schedule,
+            shape.e2e_offset,
+            shape.e2e_offset0,
+            shape.stat_transport,
+            shape.pipeline_family,
+            shape.kv_stage,
+            shape.persistent,
+            shape.q_tile_count,
+            shape.packed_exp2_mode,
+            shape.probability_log2_shift,
+            shape.softmax_lowering,
+            shape.corr_regs,
+            shape.other_regs,
+        ) == expected
+    assert policy.dense_policy(4096) is None
+
+    expected_causal = {
+        512: (
+            8,
+            2,
+            FlashSoftmaxLowering.STATEFUL,
+            200,
+            2,
+        ),
+        1024: (
+            3,
+            2,
+            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            None,
+            None,
+        ),
+        2048: (
+            3,
+            2,
+            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            None,
+            None,
+        ),
+        4096: (
+            6,
+            2,
+            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            None,
+            None,
+        ),
+    }
+    assert {shape.num_kv for shape in policy.causal_policies} == set(expected_causal)
+    for num_kv, expected in expected_causal.items():
+        shape = policy.causal_policy(num_kv)
+        assert shape is not None
+        assert (
+            shape.kv_stage,
+            shape.q_tile_count,
+            shape.softmax_lowering,
+            shape.softmax_regs,
+            shape.first_load_order,
+        ) == expected
+    assert policy.causal_policy(256) is None
+
+
+@pytest.mark.parametrize(
+    "capability",
+    [None, (10, 0), (10, 2), (10, 4), (11, 0)],
+)
+def test_unknown_and_b200_flash_tuning_policy_is_generic(
+    capability: tuple[int, int] | None,
+) -> None:
+    policy = get_flash_target_policy(capability).tuning
+
+    assert policy.tmem_row_reduce_min_kv is None
+    assert not policy.dense_policies
+    assert policy.dense_policy(256) is None
+    assert not policy.causal_policies
+    assert policy.causal_policy(512) is None
+
+
+def test_flash_policy_rejects_duplicate_shapes() -> None:
+    dense = FlashDenseTuningPolicy(256, "packet", "8/2", 0, 0, "single")
+    causal = FlashCausalTuningPolicy(512, 3)
+
+    with pytest.raises(ValueError, match="dense KV sizes must be unique"):
+        FlashTuningPolicy(dense_policies=(dense, dense))
+    with pytest.raises(ValueError, match="causal KV sizes must be unique"):
+        FlashTuningPolicy(causal_policies=(causal, causal))
+
+
+def test_flash_policy_rejects_invalid_field_combinations() -> None:
+    with pytest.raises(ValueError, match="TMEM row-reduce minimum KV size"):
+        FlashTuningPolicy(tmem_row_reduce_min_kv=0)
+    with pytest.raises(ValueError, match="probability log2 shift"):
+        FlashDenseTuningPolicy(
+            256, "packet", "8/2", 0, 0, "single", probability_log2_shift=-1
+        )
+    with pytest.raises(ValueError, match="register counts must be set together"):
+        FlashDenseTuningPolicy(
+            512,
+            "packet",
+            "8/2",
+            0,
+            0,
+            "single",
+            corr_regs=72,
+        )
+    with pytest.raises(ValueError, match="first-load order must be 0-4"):
+        FlashCausalTuningPolicy(512, 8, first_load_order=5)
+    with pytest.raises(ValueError, match="positive multiple of 8"):
+        FlashCausalTuningPolicy(512, 8, softmax_regs=199)
+    with pytest.raises(ValueError, match="query tile count must be 2"):
+        FlashDenseTuningPolicy(256, "packet", "8/2", 0, 0, "single", q_tile_count=1)
+    with pytest.raises(ValueError, match="query tile count must be 2"):
+        FlashCausalTuningPolicy(512, 8, q_tile_count=1)
+    with pytest.raises(ValueError, match="unsupported for dense"):
+        FlashDenseTuningPolicy(
+            256,
+            "packet",
+            "8/2",
+            0,
+            0,
+            "single",
+            softmax_lowering=FlashSoftmaxLowering.STATEFUL,
+        )
+
+
+def test_target_policy_rejects_tuning_without_hardware_support() -> None:
+    with pytest.raises(ValueError, match="TMEM row-reduce tuning"):
+        FlashTargetPolicy(tuning=FlashTuningPolicy(tmem_row_reduce_min_kv=256))
+    with pytest.raises(ValueError, match="packed exp2 tuning"):
+        FlashTargetPolicy(
+            tuning=FlashTuningPolicy(
+                dense_policies=(
+                    FlashDenseTuningPolicy(
+                        256,
+                        "packet",
+                        "8/2",
+                        0,
+                        0,
+                        "single",
+                        packed_exp2_mode=FlashPackedExp2Mode.ALL_XU,
+                    ),
+                )
+            )
+        )
+    with pytest.raises(ValueError, match="causal resident softmax"):
+        FlashTargetPolicy(
+            tuning=FlashTuningPolicy(
+                causal_policies=(
+                    FlashCausalTuningPolicy(
+                        512,
+                        8,
+                        softmax_lowering=FlashSoftmaxLowering.STATEFUL,
+                    ),
+                )
+            )
+        )
+    with pytest.raises(ValueError, match="enabled TMEM row-reduce range"):
+        FlashTargetPolicy(
+            hardware=FlashHardwareCapabilities(supports_tmem_row_reduce=True),
+            tuning=FlashTuningPolicy(
+                tmem_row_reduce_min_kv=1024,
+                causal_policies=(
+                    FlashCausalTuningPolicy(
+                        512,
+                        8,
+                        softmax_lowering=FlashSoftmaxLowering.STATEFUL,
+                    ),
+                ),
+            ),
+        )
+
+    FlashTargetPolicy(
+        hardware=FlashHardwareCapabilities(
+            supports_tmem_row_reduce=True,
+            supports_packed_f16x2_exp2=True,
+        ),
+        tuning=FlashTuningPolicy(
+            tmem_row_reduce_min_kv=256,
+            dense_policies=(
+                FlashDenseTuningPolicy(
+                    256,
+                    "packet",
+                    "8/2",
+                    0,
+                    0,
+                    "single",
+                    packed_exp2_mode=FlashPackedExp2Mode.ALL_XU,
+                ),
+            ),
+            causal_policies=(
+                FlashCausalTuningPolicy(
+                    512,
+                    8,
+                    softmax_lowering=FlashSoftmaxLowering.STATEFUL,
+                ),
+            ),
+        ),
+    )

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -216,6 +216,11 @@ class _RuntimeConfigSpec:
     ) -> str:
         return "fake-config-spec"
 
+    def cache_fingerprint_hash(
+        self, *, advanced_controls_files: list[str] | None
+    ) -> str:
+        return "fake-config-spec"
+
     def normalize(self, config: Config) -> None:
         config.config.setdefault("num_warps", 4)
 
@@ -293,6 +298,12 @@ class TestMultiShapeRuntime(unittest.TestCase):
     ) -> None:
         settings = _runtime_settings()
         bound = _RuntimeBoundKernel(_RuntimeBackend(), settings)
+        bound.config_spec.cache_fingerprint_hash = Mock(  # pyrefly: ignore[bad-assignment]
+            return_value="cache-policy-fingerprint"
+        )
+        bound.config_spec.structural_fingerprint_hash = Mock(  # pyrefly: ignore[bad-assignment]
+            side_effect=AssertionError("structural-only cache key used")
+        )
         workload_key = (
             "multi_shape:v1",
             "max",
@@ -314,6 +325,11 @@ class TestMultiShapeRuntime(unittest.TestCase):
 
         self.assertEqual(key.specialization_key, workload_key)
         self.assertEqual(key.extra_results, ())
+        self.assertEqual(key.config_spec_hash, "cache-policy-fingerprint")
+        bound.config_spec.cache_fingerprint_hash.assert_called_once_with(  # pyrefly: ignore[missing-attribute]
+            advanced_controls_files=None
+        )
+        bound.config_spec.structural_fingerprint_hash.assert_not_called()  # pyrefly: ignore[missing-attribute]
         bound.kernel._base_specialization_key.assert_not_called()
         bound.kernel._create_bound_kernel_cache_key.assert_not_called()
 


### PR DESCRIPTION
Stacked PRs:
 * #3423
 * #3420
 * #3419
 * #3418
 * #3417
 * __->__#3416


--- --- ---

## Summary

Introduce a target-policy layer for CuTe flash attention and promote the exact SM103/GB300 dense and causal seed configurations.

- Keep hardware capabilities, supported workloads, and per-shape tuning in dedicated policy/tuning modules.
- Preserve the existing generic/B200 fallback instead of scattering SM103 checks through lowering code.
- Include compiler-owned seed policy in autotuner cache identity so an old cached result cannot outlive a compiler policy change.
- Validate duplicate shapes, unsupported capability/tuning combinations, and seed selection/fallback behavior.

This is PR 1/6 and is based directly on `main`.

## Critical tests

```bash
pytest test/test_cute_flash_arch.py test/test_autotuner_heuristics.py \
  test/test_best_available.py test/test_multi_shape_autotune.py
```

The complete stacked verification and GB300 performance report are in PR 5.