### PR TITLE
[CuTe] Add SM103 flash primitives and stat-release topology

### DIFF
--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -306,6 +306,49 @@ def named_barrier_wait_unaligned(
     )
 
 
+@dsl_user_op
+def exp2_approx_f16x2_to_f32(
+    x: object,
+    y: object,
+    *,
+    loc: object = None,
+    ip: object = None,
+) -> tuple[Float32, Float32]:
+    """Evaluate two approximate exp2 values through one packed-f16x2 XU op."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal(  # pyrefly: ignore[missing-attribute]
+            [Float32.mlir_type, Float32.mlir_type]
+        ),
+        [
+            Float32(x).ir_value(loc=loc, ip=ip),  # pyrefly: ignore[bad-argument-type]
+            Float32(y).ir_value(loc=loc, ip=ip),  # pyrefly: ignore[bad-argument-type]
+        ],
+        """
+        {
+          .reg .b16 lo, hi;
+          .reg .b32 packed;
+          cvt.rn.f16.f32 lo, $2;
+          cvt.rn.f16.f32 hi, $3;
+          mov.b32 packed, {lo, hi};
+          ex2.approx.f16x2 packed, packed;
+          mov.b32 {lo, hi}, packed;
+          cvt.f32.f16 $0, lo;
+          cvt.f32.f16 $1, hi;
+        }
+        """,
+        "=f,=f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(Float32.mlir_type, result, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(Float32.mlir_type, result, [1], loc=loc, ip=ip)),
+    )
+
+
 # ===========================================================================
 # FA4 ex2_emulation_2: degree-3 minimax poly software-exp2 on the FMA/ALU
 # pipe (packed-f32x2). Ported from flash_attn.cute.utils.py. STRING rounding
@@ -977,6 +1020,31 @@ def fa4_disc_rowmax_balanced(
     return row_max
 
 
+def disc_rowmax_ldred(
+    tiled_ld: object,
+    tLDtS: cute.Tensor,
+    tLDcS: cute.Tensor,
+    row_max: Float32,
+    ld_chunks: int,
+) -> Float32:
+    """Chunked row-max using ``tcgen05.ld.red``.
+
+    ``LdRed32x32bOp`` returns the loaded score fragment plus one hardware
+    maximum for each 32-column TMEM tile.  Folding only those reduction
+    registers removes the software FMNMX tree while preserving the disc
+    path's one-chunk register footprint.
+    """
+    ld_shape = tLDcS[None, 0, None, None].shape  # pyrefly: ignore[missing-attribute]
+    for ci in range(ld_chunks):
+        frg = cute.make_rmem_tensor(ld_shape, cutlass.Float32)
+        red = cute.make_rmem_tensor(((1, 1), *frg.shape[1:]), cutlass.Float32)
+        cute.copy(tiled_ld, tLDtS[None, ci, None, None], (frg, red))
+        for i in range(cute.size(red.shape)):
+            row_max = cute.arch.fmax(row_max, red[i])
+    cute.arch.fence_view_async_tmem_load()
+    return row_max
+
+
 def fa4_disc_rowmax_causal_balanced(
     tiled_ld: object,
     tLDtS: cute.Tensor,
@@ -1156,6 +1224,7 @@ def _disc_chunk_exp(
     emu_batch: int = 1,
     degree2: bool = False,
     degree1: bool = False,
+    f16x2_xu: bool = False,
 ) -> None:
     """In-place packed scale-subtract then exp2(pipe-split) over ONE 32-elem chunk.
 
@@ -1177,8 +1246,11 @@ def _disc_chunk_exp(
             )
             use_xu = ((i + e2e_offset) % e2e_freq) < (e2e_freq - e2e_res) or last_frag
             if use_xu:
-                frg[i] = cute.arch.exp2(r0)
-                frg[i + 1] = cute.arch.exp2(r1)
+                if f16x2_xu:
+                    frg[i], frg[i + 1] = exp2_approx_f16x2_to_f32(r0, r1)
+                else:
+                    frg[i] = cute.arch.exp2(r0)
+                    frg[i + 1] = cute.arch.exp2(r1)
             elif degree1:
                 frg[i], frg[i + 1] = ex2_emulation_deg1_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
             elif degree2:
@@ -1203,8 +1275,11 @@ def _disc_chunk_exp(
         pending_values = []
         for i, r0, r1, use_xu in scaled:
             if use_xu:
-                frg[i] = cute.arch.exp2(r0)
-                frg[i + 1] = cute.arch.exp2(r1)
+                if f16x2_xu:
+                    frg[i], frg[i + 1] = exp2_approx_f16x2_to_f32(r0, r1)
+                else:
+                    frg[i] = cute.arch.exp2(r0)
+                    frg[i + 1] = cute.arch.exp2(r1)
             elif emu_batch == 1:
                 if degree1:
                     frg[i], frg[i + 1] = ex2_emulation_deg1_2(r0, r1)  # pyrefly: ignore[bad-argument-type]
@@ -2365,6 +2440,7 @@ def _fa4_sp_exp_convert_store_impl(
     emu_batch: int = 1,
     degree2: bool = False,
     degree1: bool = False,
+    f16x2_xu: bool = False,
     *,
     loc: object = None,
     ip: object = None,
@@ -2391,6 +2467,7 @@ def _fa4_sp_exp_convert_store_impl(
                 emu_batch,
                 degree2,
                 degree1,
+                f16x2_xu,
             )
             cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
         for ci in range(p_store_split):
@@ -2411,6 +2488,7 @@ def _fa4_sp_exp_convert_store_impl(
                 emu_batch,
                 degree2,
                 degree1,
+                f16x2_xu,
             )
             cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
         for ci in range(p_store_split, p_store_chunks):
@@ -2432,6 +2510,7 @@ def _fa4_sp_exp_convert_store_impl(
                 emu_batch,
                 degree2,
                 degree1,
+                f16x2_xu,
             )
             cast("cute.Tensor", dst[None, ci]).store(frg.load().to(io_dtype))
         for ci in range(p_store_chunks):
@@ -2478,6 +2557,7 @@ def fa4_sp_exp_convert_store(
     emu_batch: int = 1,
     degree2: bool = False,
     degree1: bool = False,
+    f16x2_xu: bool = False,
     *,
     loc: object = None,
     ip: object = None,
@@ -2506,6 +2586,7 @@ def fa4_sp_exp_convert_store(
         emu_batch,
         degree2,
         degree1,
+        f16x2_xu,
     )
 
 
@@ -2532,6 +2613,7 @@ def fa4_sp_exp_convert_store_whole_rowsum(
     emu_batch: int = 1,
     degree2: bool = False,
     degree1: bool = False,
+    f16x2_xu: bool = False,
     *,
     loc: object = None,
     ip: object = None,
@@ -2560,6 +2642,7 @@ def fa4_sp_exp_convert_store_whole_rowsum(
         emu_batch,
         degree2,
         degree1,
+        f16x2_xu,
     )
 
 
@@ -2808,6 +2891,7 @@ def fa4_disc_exp_convert_store_pipe(
     emu_batch: int = 1,
     degree2: bool = False,
     degree1: bool = False,
+    f16x2_xu: bool = False,
 ) -> Float32:
     """SOFTWARE-PIPELINED chunked-t2r PASS 2 (the L1 lever). Same numerics + staged-P
     handshake + zero-spill peak (ONE chunk + a bounded pipeline window) as the serial
@@ -2872,6 +2956,7 @@ def fa4_disc_exp_convert_store_pipe(
             emu_batch,
             degree2,
             degree1,
+            f16x2_xu,
         )
         _disc_chunk_convert_store(cur, tiled_st, tSTtS, tSTcS, ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(cur)
@@ -2913,6 +2998,7 @@ def fa4_disc_exp_convert_store_pipe_causal(
     emu_batch: int = 1,
     degree2: bool = False,
     degree1: bool = False,
+    f16x2_xu: bool = False,
 ) -> Float32:
     """Causal variant of ``fa4_disc_exp_convert_store_pipe``."""
     p_sum = cutlass.Float32(0.0)
@@ -2953,6 +3039,7 @@ def fa4_disc_exp_convert_store_pipe_causal(
             emu_batch,
             degree2,
             degree1,
+            f16x2_xu,
         )
         _disc_chunk_convert_store(cur, tiled_st, tSTtS, tSTcS, ci, io_dtype)
         p_sum = p_sum + _disc_chunk_rowsum(cur)

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -43,6 +43,7 @@ from ...runtime.config import Config
 from ..device_function import TensorArg
 from .attention_plan import ALIBI_BIAS_KIND
 from .attention_plan import CAUSAL_MASK_KIND
+from .attention_plan import DENSE_SCORE_KIND
 from .attention_plan import DOCUMENT_MASK_KIND
 from .attention_plan import PREFIX_LM_MASK_KIND
 from .attention_plan import RELATIVE_BIAS_KIND
@@ -58,6 +59,7 @@ from .flash_policy import get_flash_target_policy
 from .flash_schedule import FlashScheduleSpec
 from .flash_schedule import build_fa4_schedule
 from .flash_schedule import verify_flash_schedule
+from .flash_tuning import FlashPackedExp2Mode
 
 _T = TypeVar("_T")
 
@@ -3963,6 +3965,34 @@ def _flash_causal_tuning_values(
     return values
 
 
+def _flash_config_matches_tuning_values(
+    cfg: FlashAttentionConfig,
+    expected: Mapping[str, object],
+) -> bool:
+    actual = flash_effective_config_values(cfg)
+    return all(actual.get(key) == value for key, value in expected.items())
+
+
+def _flash_dense_resident_seed_matches(
+    cfg: FlashAttentionConfig,
+    num_kv: int,
+    target_device_capability: tuple[int, int] | None,
+) -> bool:
+    """Return whether ``cfg`` is the validated target-promoted dense seed."""
+    policy = get_flash_target_policy(target_device_capability).tuning.dense_policy(
+        num_kv
+    )
+    expected = (
+        {
+            **_flash_dense_tuning_overrides(policy),
+            FLASH_Q_TILE_COUNT_KEY: policy.q_tile_count,
+        }
+        if policy is not None
+        else {}
+    )
+    return policy is not None and _flash_config_matches_tuning_values(cfg, expected)
+
+
 def _flash_tuning_seed_config(
     tuning_policy: FlashTuningPolicy,
     head_dim: int,
@@ -5438,7 +5468,7 @@ if TYPE_CHECKING:
 # ``_flash_runtime`` (a real module compiled WITHOUT ``from __future__ import
 # annotations``); the generated module imports them. The remaining cute / utils
 # / pipeline symbols are imported under flash-local aliases.
-_FLASH_RUNTIME_ABI = 2
+_FLASH_RUNTIME_ABI = 3
 
 # This literal is part of generated source and therefore the CuTe disk-cache
 # key. Bump it whenever an imported flash runtime helper changes semantics.
@@ -7306,6 +7336,7 @@ def emit_flash_fa4_device_body(
     score_plan: AttentionScorePlan,
     tensor_4d_batch: int = 0,
     tensor_4d_heads: int = 0,
+    target_device_capability: tuple[int, int] | None = None,
 ) -> list[ast.stmt]:
     """FA4-topology device body: faithful transcription of the validated 16-warp /
     512-thread spike kernel (sp single-pass softmax body), adapted for Helion's
@@ -7339,6 +7370,19 @@ def emit_flash_fa4_device_body(
     is_causal = score_plan.is_causal
     if is_causal:
         assert not cfg.persistent
+    target_policy = get_flash_target_policy(target_device_capability)
+    hardware_capabilities = target_policy.hardware
+    tuning_policy = target_policy.tuning
+    tmem_row_reduce_min_kv = tuning_policy.tmem_row_reduce_min_kv
+    use_tmem_row_reduce = (
+        hardware_capabilities.supports_tmem_row_reduce
+        and tmem_row_reduce_min_kv is not None
+        and hd == 64
+        and num_kv >= tmem_row_reduce_min_kv
+        and io_dtype == "cutlass.Float16"
+        and cfg.s_load_repetition == 32
+        and score_plan.modifier_kinds in ((DENSE_SCORE_KIND,), (CAUSAL_MASK_KIND,))
+    )
     causal_desc_kv = is_causal and cfg.causal_kv_order == "descending"
     desc_kv = causal_desc_kv or (not is_causal and cfg.kv_order == "descending")
     num_m_pairs = total_tiles // num_bh
@@ -7347,6 +7391,16 @@ def emit_flash_fa4_device_body(
         num_query_tiles=num_m_pairs * (4 if cfg.causal_two_cta else 2),
         num_kv_tiles=num_kv,
         score_plan=score_plan,
+    )
+    dense_tuning = tuning_policy.dense_policy(num_kv)
+    probability_log2_shift = (
+        dense_tuning.probability_log2_shift if dense_tuning is not None else 0
+    )
+    probability_shift_safe = probability_log2_shift + cfg.rescale_threshold < math.log2(
+        torch.finfo(torch.float16).max
+    )
+    use_whole_row_tmem_reduce = (
+        use_tmem_row_reduce and not is_causal and not cfg.softmax_disc
     )
     persistent = cfg.persistent
     use_tensor_4d_tma = (
@@ -7358,6 +7412,36 @@ def emit_flash_fa4_device_body(
     if not use_tensor_4d_tma:
         tensor_4d_heads = 0
     use_2cta_instrs = cfg.use_2cta_instrs
+    dense_packed_exp2_mode = (
+        dense_tuning.packed_exp2_mode
+        if dense_tuning is not None
+        else FlashPackedExp2Mode.DISABLED
+    )
+    use_packed_f16x2_xu = (
+        dense_packed_exp2_mode is not FlashPackedExp2Mode.DISABLED
+        and hardware_capabilities.supports_packed_f16x2_exp2
+        and probability_shift_safe
+        and hd == 64
+        and io_dtype == "cutlass.Float16"
+        and not has_lse
+        and cfg.exp2_impl == "split"
+        and cfg.p_store_repetition == 16
+        and cfg.s_load_repetition == 32
+        and not is_causal
+        and _flash_dense_resident_seed_matches(cfg, num_kv, target_device_capability)
+        and score_plan.modifier_kinds == (DENSE_SCORE_KIND,)
+        and use_2cta_instrs
+        and not cfg.softmax_disc
+        and cfg.exp2_packet in _FLASH_DEG1_EXP2_PACKETS
+    )
+    use_all_packed_f16x2_xu = (
+        use_packed_f16x2_xu
+        and dense_packed_exp2_mode is FlashPackedExp2Mode.ALL_XU
+        and probability_shift_safe
+    )
+    effective_probability_log2_shift = (
+        probability_log2_shift if use_all_packed_f16x2_xu else 0
+    )
     use_cga2_local_cta = cfg.use_cga2_local_cta
     use_clc_scheduler = cfg.use_clc_scheduler
     separate_kv_rings = cfg.separate_kv_rings
@@ -7458,6 +7542,8 @@ def emit_flash_fa4_device_body(
     exp2_codegen = _flash_disc_exp2_codegen_params(
         cfg.exp2_packet, cfg.e2e_freq, cfg.e2e_res
     )
+    if use_all_packed_f16x2_xu:
+        exp2_codegen = exp2_codegen._replace(e2e_res=0)
     if exp2_codegen.degree2:
         assert hd == 64
         assert io_dtype == "cutlass.Float16"
@@ -7972,12 +8058,28 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     tScoreSTtS0 = flash_thr_score_st0.partition_D(tStS0)
     tScoreSTtS1 = flash_thr_score_st1.partition_D(tStS1)
 """
+    flash_ld_op = "LdRed32x32bOp" if use_whole_row_tmem_reduce else "Ld32x32bOp"
+    disc_ldred_setup = (
+        f"""    flash_ldred_atom = cute.make_copy_atom(
+        cute_tcgen05_flash.LdRed32x32bOp(cute_tcgen05_flash.Repetition({cfg.s_load_repetition})), cutlass.Float32)
+    flash_tiled_ldred0 = cute_tcgen05_flash.make_tmem_copy(flash_ldred_atom, tStS0)
+    flash_tiled_ldred1 = cute_tcgen05_flash.make_tmem_copy(flash_ldred_atom, tStS1)
+    flash_thr_ldred0 = flash_tiled_ldred0.get_slice(flash_local_tidx)
+    flash_thr_ldred1 = flash_tiled_ldred1.get_slice(flash_local_tidx)
+    tLDRedtS0 = flash_thr_ldred0.partition_S(tStS0)
+    tLDRedtS1 = flash_thr_ldred1.partition_S(tStS1)
+"""
+        if use_tmem_row_reduce and cfg.softmax_disc
+        else ""
+    )
     tmem_softmax_setup = (
         tmem_base_setup
         + f"""    cS = cute.make_identity_tensor((128, 128))
     tScS = flash_qkt.partition_C(cS)
     flash_ld_atom = cute.make_copy_atom(
-        cute_tcgen05_flash.Ld32x32bOp(cute_tcgen05_flash.Repetition({cfg.s_load_repetition})), cutlass.Float32)
+        cute_tcgen05_flash.{flash_ld_op}(cute_tcgen05_flash.Repetition({
+            cfg.s_load_repetition
+        })), cutlass.Float32)
     flash_tiled_ld0 = cute_tcgen05_flash.make_tmem_copy(flash_ld_atom, tStS0)
     flash_tiled_ld1 = cute_tcgen05_flash.make_tmem_copy(flash_ld_atom, tStS1)
     flash_thr_ld0 = flash_tiled_ld0.get_slice(flash_local_tidx)
@@ -7985,6 +8087,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     tLDtS0 = flash_thr_ld0.partition_S(tStS0)
     tLDtS1 = flash_thr_ld1.partition_S(tStS1)
     tLDcS = flash_thr_ld0.partition_D(tScS)
+{disc_ldred_setup.rstrip()}
 {score_store_setup.rstrip()}
 
     # Staged-P store atom repetition is autotuned. Rep16 preserves the original
@@ -7998,7 +8101,9 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
         tScS.layout, cute.make_layout((128, flash_tilePlikeFP32)))
     tScS_P = cute.make_tensor(tScS.iterator, flash_tScS_P_layout)
     flash_st_atom = cute.make_copy_atom(
-        cute_tcgen05_flash.St32x32bOp(cute_tcgen05_flash.Repetition({p_store_repetition})), cutlass.Float32)
+        cute_tcgen05_flash.St32x32bOp(cute_tcgen05_flash.Repetition({
+            p_store_repetition
+        })), cutlass.Float32)
     flash_tiled_st0 = cute_tcgen05_flash.make_tmem_copy(flash_st_atom, tStS0_P)
     flash_tiled_st1 = cute_tcgen05_flash.make_tmem_copy(flash_st_atom, tStS1_P)
     flash_thr_st0 = flash_tiled_st0.get_slice(flash_local_tidx)
@@ -8058,6 +8163,17 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     tLDcS = flash_thr_ld_coord.partition_D(tScS)
 """
         )
+        stage_ldred_setup = (
+            f"""    flash_ldred_atom = cute.make_copy_atom(
+        cute_tcgen05_flash.LdRed32x32bOp(cute_tcgen05_flash.Repetition({cfg.s_load_repetition})), cutlass.Float32)
+    flash_tiled_ldred{stage} = cute_tcgen05_flash.make_tmem_copy(
+        flash_ldred_atom, tStS{stage})
+    flash_thr_ldred{stage} = flash_tiled_ldred{stage}.get_slice(flash_local_tidx)
+    tLDRedtS{stage} = flash_thr_ldred{stage}.partition_S(tStS{stage})
+"""
+            if use_tmem_row_reduce and cfg.softmax_disc
+            else ""
+        )
         return f"""    _helion_flash_rt.named_barrier_wait_unaligned(
         2, 13 * 32)
     flash_tmem_ptr = flash_tmem.retrieve_ptr(cutlass.Float32)
@@ -8067,12 +8183,15 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     cS = cute.make_identity_tensor((128, 128))
     tScS = flash_qkt.partition_C(cS)
     flash_ld_atom = cute.make_copy_atom(
-        cute_tcgen05_flash.Ld32x32bOp(cute_tcgen05_flash.Repetition({cfg.s_load_repetition})), cutlass.Float32)
+        cute_tcgen05_flash.{flash_ld_op}(cute_tcgen05_flash.Repetition({
+            cfg.s_load_repetition
+        })), cutlass.Float32)
     flash_tiled_ld{stage} = cute_tcgen05_flash.make_tmem_copy(
         flash_ld_atom, tStS{stage})
     flash_thr_ld{stage} = flash_tiled_ld{stage}.get_slice(flash_local_tidx)
     tLDtS{stage} = flash_thr_ld{stage}.partition_S(tStS{stage})
 {coord_setup.rstrip()}
+{stage_ldred_setup.rstrip()}
 {stage_score_store_setup.rstrip()}
 
     # Staged-P store atom repetition is autotuned. Rep16 preserves the original
@@ -8085,7 +8204,9 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
         tScS.layout, cute.make_layout((128, flash_tilePlikeFP32)))
     tScS_P = cute.make_tensor(tScS.iterator, flash_tScS_P_layout)
     flash_st_atom = cute.make_copy_atom(
-        cute_tcgen05_flash.St32x32bOp(cute_tcgen05_flash.Repetition({p_store_repetition})), cutlass.Float32)
+        cute_tcgen05_flash.St32x32bOp(cute_tcgen05_flash.Repetition({
+            p_store_repetition
+        })), cutlass.Float32)
     flash_tiled_st{stage} = cute_tcgen05_flash.make_tmem_copy(
         flash_st_atom, tStS{stage}_P)
     flash_thr_st{stage} = flash_tiled_st{stage}.get_slice(flash_local_tidx)
@@ -8948,6 +9069,18 @@ if warp_idx == 15:
     # PRE-exp block (decide alpha + pin the max) so the kept-old max feeds the exp
     # PASS via flash_minus_max_scale, and an empty POST-exp piece (no second alpha
     # compute). threshold==0.0 keeps the prior pre/post split byte-identically.
+    if effective_probability_log2_shift:
+        # Keep P, the running denominator, and the output accumulator in the same
+        # power-of-two scaled domain.  The online-softmax recurrence preserves that
+        # common scale across iterations and the final O / l normalization cancels
+        # it.  Folding the offset into the existing scalar bias extends the packed
+        # f16x2 exp2 tail range without a per-element scale-back instruction.
+        sp_minus_max_scale = (
+            f"(cutlass.Float32({float(effective_probability_log2_shift)!r})"
+            " - flash_row_max_safe * _flash_scale_log2)"
+        )
+    else:
+        sp_minus_max_scale = "(0.0 - flash_row_max_safe) * _flash_scale_log2"
     if cfg.rescale_threshold > 0.0:
         sp_pin_condition = (
             f"({softmax_not_first}) & (flash_acc_log >= -{cfg.rescale_threshold})"
@@ -8958,13 +9091,10 @@ if warp_idx == 15:
                 flash_row_max = flash_old_row_max
                 flash_row_max_safe = flash_old_row_max
                 flash_alpha = cutlass.Float32(1.0)
-            flash_minus_max_scale = (0.0 - flash_row_max_safe) * _flash_scale_log2"""
+            flash_minus_max_scale = {sp_minus_max_scale}"""
         _sp_alpha_post = ""
     else:
-        _sp_alpha_pre = (
-            "            flash_minus_max_scale ="
-            " (0.0 - flash_row_max_safe) * _flash_scale_log2"
-        )
+        _sp_alpha_pre = f"            flash_minus_max_scale = {sp_minus_max_scale}"
         _sp_alpha_post = """            flash_alpha = cute.math.exp2(
                 _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe), fastmath=True)"""
 
@@ -9068,6 +9198,8 @@ if warp_idx == 15:
                 args.append("degree1=True")
             elif disc_exp2_codegen.degree2:
                 args.append("degree2=True")
+            if use_packed_f16x2_xu:
+                args.append("f16x2_xu=True")
             return f"_helion_flash_rt.{name}(" + ", ".join(args) + ")"
 
         pass2_call = _format_disc_pass2(_disc_pass2_name, causal=False)
@@ -9202,7 +9334,11 @@ if warp_idx == 15:
             flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum
 {final_corr_publish_rowsum}"""
             rowmax_dense_call = (
-                f"_helion_flash_rt.fa4_disc_rowmax_balanced("
+                f"_helion_flash_rt.disc_rowmax_ldred("
+                f"flash_tiled_ldred{stage}, tLDRedtS{stage}, tLDcS, "
+                "flash_row_max, flash_LD_CHUNKS)"
+                if use_tmem_row_reduce
+                else f"_helion_flash_rt.fa4_disc_rowmax_balanced("
                 f"{ld}, {ldt}, tLDcS, flash_row_max, flash_LD_CHUNKS)"
             )
             direct_dense_rowmax = f"            flash_row_max = {rowmax_dense_call}"
@@ -9370,6 +9506,11 @@ if warp_idx == 15:
             _helion_flash_rt.mbarrier_arrive(
                 flash_pfor_ptr + {stage}{pfor_peer_arg})"""
         if cfg.exp2_impl == "split":
+            sp_e2e_offset = (
+                "0"
+                if exp2_codegen.e2e_res == 0
+                else str(cfg.e2e_offset0 if stage == "0" else cfg.e2e_offset)
+            )
             if mixed_p_store:
                 sp_pass2_name = (
                     "fa4_sp_exp_convert_store_rep32_split_whole_rowsum"
@@ -9386,9 +9527,9 @@ if warp_idx == 15:
                     "tSTcS",
                     "_flash_scale_log2",
                     "flash_minus_max_scale",
-                    str(cfg.e2e_freq),
-                    str(cfg.e2e_res),
-                    str(cfg.e2e_offset0 if stage == "0" else cfg.e2e_offset),
+                    str(exp2_codegen.e2e_freq),
+                    str(exp2_codegen.e2e_res),
+                    sp_e2e_offset,
                     f"flash_pfor_ptr + {stage}",
                     f"flash_pfor2_ptr + {stage}",
                     io_dtype,
@@ -9406,9 +9547,9 @@ if warp_idx == 15:
                     "tSTcS",
                     "_flash_scale_log2",
                     "flash_minus_max_scale",
-                    str(cfg.e2e_freq),
-                    str(cfg.e2e_res),
-                    str(cfg.e2e_offset0 if stage == "0" else cfg.e2e_offset),
+                    str(exp2_codegen.e2e_freq),
+                    str(exp2_codegen.e2e_res),
+                    sp_e2e_offset,
                     f"flash_pfor_ptr + {stage}",
                     f"flash_pfor2_ptr + {stage}" if split_p_arrive else "None",
                     "flash_P_STORE_SPLIT",
@@ -9430,6 +9571,8 @@ if warp_idx == 15:
                 sp_pass2_args.append("degree1=True")
             elif exp2_codegen.degree2:
                 sp_pass2_args.append("degree2=True")
+            if use_packed_f16x2_xu:
+                sp_pass2_args.append("f16x2_xu=True")
             sp_exp_block = (
                 f"            flash_p_sum = _helion_flash_rt.{sp_pass2_name}("
                 + ", ".join(sp_pass2_args)
@@ -9475,6 +9618,26 @@ if warp_idx == 15:
             if acknowledged_stat_pipeline
             else ""
         )
+        sp_score_load = (
+            f"""            tLDrS_red = cute.make_rmem_tensor(
+                ((1, 1), *tLDrS.shape[1:]), cutlass.Float32)
+            cute.copy({ld}, {ldt}, (tLDrS, tLDrS_red))
+            cute.arch.fence_view_async_tmem_load()
+            flash_hw_row_max = cutlass.Float32(-cutlass.Float32.inf)
+            for flash_red_i in cutlass.range_constexpr(cute.size(tLDrS_red.shape)):
+                flash_hw_row_max = cute.arch.fmax(
+                    flash_hw_row_max, tLDrS_red[flash_red_i])"""
+            if use_whole_row_tmem_reduce
+            else f"""            cute.copy({ld}, {ldt}, tLDrS)
+            cute.arch.fence_view_async_tmem_load(){score_transform}"""
+        )
+        sp_rowmax = (
+            "            flash_row_max = cute.arch.fmax("
+            "flash_row_max, flash_hw_row_max)"
+            if use_whole_row_tmem_reduce
+            else "            flash_row_max = "
+            "_helion_flash_rt.fmax_reduce_packed(tLDrS, flash_row_max)"
+        )
         return f"""{
             fa4_entry_stat_acquire
         }        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
@@ -9486,9 +9649,8 @@ if warp_idx == 15:
             flash_s_full_phase ^= 1
             flash_old_row_max = flash_row_max
             tLDrS = cute.make_rmem_tensor(tLDcS.shape, cutlass.Float32)
-            cute.copy({ld}, {ldt}, tLDrS)
-            cute.arch.fence_view_async_tmem_load(){score_transform}
-            flash_row_max = _helion_flash_rt.fmax_reduce_packed(tLDrS, flash_row_max)
+{sp_score_load}
+{sp_rowmax}
             flash_row_max_safe = flash_row_max
             if flash_row_max == -cutlass.Float32.inf:
                 flash_row_max_safe = cutlass.Float32(0.0)
@@ -10723,6 +10885,8 @@ def codegen_attention_flash(cg: GenerateAST) -> bool:
                 )
             )
     elif cfg.topology == "fa4":
+        from ..compile_environment import CompileEnvironment
+
         df.cute_state.attention_flash_threads = 512
         df.body = list(
             emit_flash_fa4_device_body(
@@ -10738,6 +10902,9 @@ def codegen_attention_flash(cg: GenerateAST) -> bool:
                 score_plan=score_plan,
                 tensor_4d_batch=plan.tensor_4d_batch if use_tensor_4d_tma else 0,
                 tensor_4d_heads=plan.tensor_4d_heads if use_tensor_4d_tma else 0,
+                target_device_capability=(
+                    CompileEnvironment.current().config_spec.target_device_capability
+                ),
             )
         )
     else:

--- a/helion/_compiler/cute/flash_schedule.py
+++ b/helion/_compiler/cute/flash_schedule.py
@@ -46,6 +46,11 @@ class FlashOutputOrder(enum.Enum):
     CTA_CONTIGUOUS = "cta_contiguous"
 
 
+class FlashStatReleaseMapping(enum.Enum):
+    CROSS_SLOT = "cross_slot"
+    SAME_SLOT = "same_slot"
+
+
 @dataclasses.dataclass(frozen=True)
 class FlashScheduleSpec:
     head_dim: int
@@ -66,6 +71,8 @@ class FlashScheduleSpec:
     stat_depth: int = 2
     pipelined_stat_handoff: bool = False
     final_only_stat_handoff: bool = False
+    stat_release_mapping: FlashStatReleaseMapping = FlashStatReleaseMapping.CROSS_SLOT
+    query_slots_have_equal_kv_iterations: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -181,6 +188,30 @@ def _output_tile(spec: FlashScheduleSpec, cta_rank: int, query_slot: int) -> int
     return query_slot * spec.cta_count + cta_rank
 
 
+def _pipelined_stat_release(
+    spec: FlashScheduleSpec, source_slot: int
+) -> tuple[int, int]:
+    if spec.stat_release_mapping is FlashStatReleaseMapping.SAME_SLOT:
+        return source_slot, 1
+    # The acknowledged correction loop visits slot 0 before slot 1. Slot 0
+    # releases slot 1's held prologue value in the current loop iteration;
+    # slot 1 then releases slot 0 for the next iteration.
+    return source_slot ^ 1, source_slot
+
+
+def _pipelined_stat_releaser(
+    spec: FlashScheduleSpec, target_slot: int
+) -> tuple[int, int]:
+    source_slot = (
+        target_slot
+        if spec.stat_release_mapping is FlashStatReleaseMapping.SAME_SLOT
+        else target_slot ^ 1
+    )
+    mapped_target, iteration_delta = _pipelined_stat_release(spec, source_slot)
+    assert mapped_target == target_slot
+    return source_slot, iteration_delta
+
+
 def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
     """Build the structural graph for an FA4-style local schedule.
 
@@ -205,13 +236,30 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
         raise FlashScheduleError("a private causal tail requires causal K/V multicast")
     if not isinstance(spec.output_order, FlashOutputOrder):
         raise FlashScheduleError("output order is invalid")
+    if not isinstance(spec.stat_release_mapping, FlashStatReleaseMapping):
+        raise FlashScheduleError("stat release mapping is invalid")
     if spec.dtype_bytes <= 0:
         raise FlashScheduleError("dtype size must be positive")
     if spec.stat_depth not in (1, 2):
         raise FlashScheduleError("stat transport depth must be one or two")
-    if spec.pipelined_stat_handoff and (spec.stat_depth != 1 or spec.causal):
+    if spec.pipelined_stat_handoff and spec.stat_depth != 1:
+        raise FlashScheduleError("pipelined stat handoff requires depth one")
+    if (
+        spec.pipelined_stat_handoff
+        and spec.causal
+        and spec.stat_release_mapping is FlashStatReleaseMapping.CROSS_SLOT
+        and not spec.query_slots_have_equal_kv_iterations
+    ):
         raise FlashScheduleError(
-            "pipelined stat handoff requires depth one and a noncausal schedule"
+            "causal cross-slot stat releases require proof of equal query-slot "
+            "K/V iteration counts"
+        )
+    if (
+        not spec.pipelined_stat_handoff
+        and spec.stat_release_mapping is FlashStatReleaseMapping.SAME_SLOT
+    ):
+        raise FlashScheduleError(
+            "same-slot stat releases require pipelined stat handoff"
         )
     if spec.final_only_stat_handoff and (spec.stat_depth != 1 or spec.causal):
         raise FlashScheduleError(
@@ -489,12 +537,18 @@ def build_fa4_schedule(spec: FlashScheduleSpec) -> FlashSchedule:
                 ]
             )
             if not spec.final_only_stat_handoff:
+                stat_release_slot = slot
+                stat_release_delta = spec.stat_depth
+                if spec.pipelined_stat_handoff:
+                    stat_release_slot, stat_release_delta = _pipelined_stat_release(
+                        spec, slot
+                    )
                 edges.append(
                     FlashEdge(
                         correction,
-                        stat,
-                        iteration_delta=spec.stat_depth,
-                        barrier=stat_empty,
+                        _node_name("stat", rank, stat_release_slot),
+                        iteration_delta=stat_release_delta,
+                        barrier=f"stat_empty_r{rank}_q{stat_release_slot}",
                         arrival_count=1,
                     )
                 )
@@ -906,6 +960,34 @@ def verify_flash_schedule(
                 f"barrier {barrier.name} expected {barrier.expected_arrivals} "
                 f"arrivals, got {arrivals[barrier.name]}"
             )
+    if schedule.spec.pipelined_stat_handoff:
+        expected_releases = {
+            FlashEdge(
+                _node_name("correction", rank, source_slot),
+                _node_name("stat", rank, target_slot),
+                iteration_delta,
+                f"stat_empty_r{rank}_q{target_slot}",
+                1,
+            )
+            for rank in range(schedule.spec.cta_count)
+            for source_slot in range(schedule.spec.query_slots_per_cta)
+            for target_slot, iteration_delta in (
+                (_pipelined_stat_release(schedule.spec, source_slot),)
+            )
+        }
+        release_edges = [
+            edge
+            for edge in schedule.edges
+            if edge.barrier is not None and edge.barrier.startswith("stat_empty_")
+        ]
+        if (
+            len(release_edges) != len(expected_releases)
+            or set(release_edges) != expected_releases
+        ):
+            raise FlashScheduleError(
+                "pipelined stat releases do not match the selected "
+                f"{schedule.spec.stat_release_mapping.value} mapping"
+            )
     if schedule.spec.final_only_stat_handoff:
         edge_keys = {
             (edge.source, edge.target, edge.iteration_delta, edge.barrier)
@@ -1048,11 +1130,34 @@ def verify_flash_schedule(
                         f"memory region {region.name} is reused before all consumers"
                     )
             if region.reuse_barrier is not None:
-                for consumer in region.consumers:
+                reuse_releases = tuple(
+                    (consumer, region.reuse_distance) for consumer in region.consumers
+                )
+                writer = node_by_name[region.writer]
+                if (
+                    schedule.spec.pipelined_stat_handoff
+                    and writer.kind is FlashNodeKind.STAT_PUBLISH
+                ):
+                    assert writer.cta_rank is not None
+                    assert writer.query_slot is not None
+                    source_slot, iteration_delta = _pipelined_stat_releaser(
+                        schedule.spec, writer.query_slot
+                    )
+                    reuse_releases = (
+                        (
+                            _node_name(
+                                "correction",
+                                writer.cta_rank,
+                                source_slot,
+                            ),
+                            iteration_delta,
+                        ),
+                    )
+                for release_source, iteration_delta in reuse_releases:
                     if not any(
-                        edge.source == consumer
+                        edge.source == release_source
                         and edge.target == region.writer
-                        and edge.iteration_delta == region.reuse_distance
+                        and edge.iteration_delta == iteration_delta
                         and edge.barrier == region.reuse_barrier
                         for edge in schedule.edges
                     ):

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -21,6 +21,8 @@ import torch
 
 import helion
 from helion._compiler.cute.attention_plan import causal_score_plan
+from helion._compiler.cute.flash_policy import get_flash_target_policy
+from helion._compiler.cute.flash_tuning import FlashPackedExp2Mode
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
 from helion._testing import TestCase
@@ -2825,6 +2827,192 @@ class TestCuteBackend(TestCase):
         torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
         torch.testing.assert_close(lse, expected_lse, atol=2e-2, rtol=2e-2)
 
+    def test_flash_attention_sm103_ldred_codegen(self) -> None:
+        q, k, v = (
+            torch.empty(1, 1, 32768, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        dense_bound = cute_dense_attention.bind((q, k, v))
+        dense_config = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4",
+            cute_flash_softmax_disc=False,
+            cute_flash_s_load_rep=32,
+        )
+        with patch.object(
+            dense_bound.env.config_spec, "target_device_capability", (10, 3)
+        ):
+            dense_code = dense_bound.to_triton_code(dense_config)
+        self.assertIn("LdRed32x32bOp", dense_code)
+        self.assertIn("flash_hw_row_max", dense_code)
+        self.assertNotIn("fmax_reduce_packed(tLDrS, flash_row_max)", dense_code)
+
+        with patch.object(
+            dense_bound.env.config_spec, "target_device_capability", (10, 0)
+        ):
+            b200_code = dense_bound.to_triton_code(dense_config)
+        self.assertNotIn("LdRed32x32bOp", b200_code)
+        self.assertIn("fmax_reduce_packed(tLDrS, flash_row_max)", b200_code)
+
+        causal_bound = cute_causal_attention.bind((q, k, v))
+        causal_config = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4",
+            cute_flash_causal_kv_order="descending",
+            cute_flash_causal_loop_split=True,
+            cute_flash_s_load_rep=32,
+        )
+        with patch.object(
+            causal_bound.env.config_spec, "target_device_capability", (10, 3)
+        ):
+            causal_code = causal_bound.to_triton_code(causal_config)
+        self.assertIn("LdRed32x32bOp", causal_code)
+        self.assertIn("disc_rowmax_ldred", causal_code)
+        self.assertIn("fa4_disc_rowmax_causal_balanced", causal_code)
+
+        modified_bound = cute_softcap_attention.bind((q, k, v))
+        with patch.object(
+            modified_bound.env.config_spec, "target_device_capability", (10, 3)
+        ):
+            modified_code = modified_bound.to_triton_code(dense_config)
+        self.assertNotIn("LdRed32x32bOp", modified_code)
+
+    def test_flash_attention_sm103_f16x2_exp2_codegen_gates(self) -> None:
+        q, k, v = (
+            torch.empty(1, 1, 262144, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        config = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_2cta",
+            cute_flash_persistent=False,
+            cute_flash_exp2_packet="deg1_16x8",
+            cute_flash_e2e_schedule="16/8",
+            cute_flash_e2e_offset=0,
+            cute_flash_e2e_offset0=10,
+            cute_flash_kv_stage=6,
+            cute_flash_stat_transport="single_final",
+        )
+        dense_bound = cute_dense_attention.bind((q, k, v))
+        with patch.object(
+            dense_bound.env.config_spec, "target_device_capability", (10, 3)
+        ):
+            sm103_code = dense_bound.to_triton_code(config)
+        self.assertIn("f16x2_xu=True", sm103_code)
+
+        with patch.object(
+            dense_bound.env.config_spec, "target_device_capability", (10, 0)
+        ):
+            b200_code = dense_bound.to_triton_code(config)
+        self.assertNotIn("f16x2_xu=True", b200_code)
+
+        lse_bound = cute_dense_attention_with_lse.bind((q, k, v))
+        lse_config = helion.Config(
+            **{**config.config, "cute_flash_stat_transport": "single"}
+        )
+        with patch.object(
+            lse_bound.env.config_spec, "target_device_capability", (10, 3)
+        ):
+            lse_code = lse_bound.to_triton_code(lse_config)
+        self.assertNotIn("f16x2_xu=True", lse_code)
+
+    def test_flash_attention_target_packed_exp2_preserves_256k_tail(self) -> None:
+        capability = torch.cuda.get_device_capability()
+        target_policy = get_flash_target_policy(capability)
+        dense_policy = target_policy.tuning.dense_policy(2048)
+        if (
+            not target_policy.hardware.supports_packed_f16x2_exp2
+            or dense_policy is None
+            or dense_policy.packed_exp2_mode is not FlashPackedExp2Mode.ALL_XU
+        ):
+            self.skipTest("target has no packed f16x2 exp2 lowering")
+
+        sequence_length = 262_144
+        q = torch.zeros((1, 1, sequence_length, 64), dtype=torch.float16, device=DEVICE)
+        k = torch.zeros_like(q)
+        v = torch.full_like(q, -2.0)
+        q[..., 0] = 1.0
+        k[..., 0] = -26.0 * math.sqrt(64) / math.log2(math.e)
+        k[..., 0, 0] = 0.0
+        v[..., 0, :] = 2.0
+        seed = _cute_flash.flash_attention_seed_config(
+            64,
+            2048,
+            standard_dense_output=True,
+            target_device_capability=capability,
+        )
+        assert seed is not None
+        config = helion.Config(**seed.config)
+        bound = cute_dense_attention.bind((q, k, v))
+        code = bound.to_triton_code(config)
+        compiled = bound.compile_config(config)
+        self.assertIn("f16x2_xu=True", code)
+
+        out = compiled(q, k, v)
+        repeated = compiled(q, k, v)
+        effective_tail_log2 = (
+            k[0, 0, 1, 0].float().item() / math.sqrt(64) * math.log2(math.e)
+        )
+        tail_mass = (sequence_length - 1) * 2.0**effective_tail_log2
+        expected = (2.0 - 2.0 * tail_mass) / (1.0 + tail_mass)
+
+        self.assertTrue(torch.equal(out, repeated))
+        self.assertTrue(torch.isfinite(out).all())
+        self.assertLess((out.float() - expected).abs().max().item(), 5e-5)
+
+    def test_flash_attention_target_ldred_matches_sdpa(self) -> None:
+        capability = torch.cuda.get_device_capability()
+        target_policy = get_flash_target_policy(capability)
+        if (
+            not target_policy.hardware.supports_tmem_row_reduce
+            or target_policy.tuning.tmem_row_reduce_min_kv is None
+        ):
+            self.skipTest("target has no tcgen05.ld.red flash lowering")
+        q, k, v = (
+            torch.randn(1, 1, 32768, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        dense_config = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4",
+            cute_flash_softmax_disc=False,
+            cute_flash_s_load_rep=32,
+        )
+        dense_bound = cute_dense_attention.bind((q, k, v))
+        with patch.object(
+            dense_bound.env.config_spec, "target_device_capability", capability
+        ):
+            dense_code = dense_bound.to_triton_code(dense_config)
+            dense_out = dense_bound.compile_config(dense_config)(q, k, v)
+        self.assertIn("LdRed32x32bOp", dense_code)
+        torch.testing.assert_close(
+            dense_out,
+            torch.nn.functional.scaled_dot_product_attention(q, k, v),
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+        causal_config = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4",
+            cute_flash_causal_kv_order="descending",
+            cute_flash_causal_loop_split=True,
+            cute_flash_s_load_rep=32,
+        )
+        causal_bound = cute_causal_attention.bind((q, k, v))
+        with patch.object(
+            causal_bound.env.config_spec, "target_device_capability", capability
+        ):
+            causal_code = causal_bound.to_triton_code(causal_config)
+            causal_out, _lse = causal_bound.compile_config(causal_config)(q, k, v)
+        self.assertIn("disc_rowmax_ldred", causal_code)
+        torch.testing.assert_close(
+            causal_out,
+            torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True),
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
     def test_flash_attention_ring2_stat_handoff_persistent_matches_sdpa(self) -> None:
         q, k, v = (
             torch.randn(1, 64, 768, 64, dtype=torch.float16, device=DEVICE)
@@ -3446,12 +3634,18 @@ class TestCuteBackend(TestCase):
                     bound.config_spec._cute_flash_standard_dense_output,
                     expected_standard,
                 )
-                self.assertFalse(
-                    any(
-                        seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY)
-                        in {"deg1_8x2_corr10", "deg1_16x8"}
-                        for seed in bound.config_spec.compiler_seed_configs
-                    )
+                has_degree1_seed = any(
+                    seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY)
+                    in {"deg1_8x2_corr10", "deg1_16x8"}
+                    for seed in bound.config_spec.compiler_seed_configs
+                )
+                target_policy = get_flash_target_policy(
+                    bound.config_spec.target_device_capability
+                )
+                self.assertEqual(
+                    has_degree1_seed,
+                    expected_standard
+                    and target_policy.tuning.dense_policy(2048) is not None,
                 )
                 has_degree2_seed = any(
                     seed.config.get(_cute_flash.FLASH_EXP2_PACKET_KEY) == "deg2_16x6"

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -14,6 +14,7 @@ import torch
 import helion
 from helion._compiler.backend import CuteBackend
 from helion._compiler.cute import cute_flash
+from helion._compiler.cute.attention_plan import AttentionScorePlan
 from helion._compiler.cute.attention_plan import causal_score_plan
 from helion._compiler.cute.attention_plan import dense_score_plan
 from helion._testing import DEVICE
@@ -160,6 +161,53 @@ def _hybrid_runtime_config() -> dict[str, object]:
     }
 
 
+def _emit_dense_resident_value_graph_source(
+    *,
+    capability: tuple[int, int] = (10, 3),
+    has_lse: bool = False,
+    score_plan: AttentionScorePlan | None = None,
+    num_kv: int = 256,
+    config_overrides: dict[str, object] | None = None,
+) -> str:
+    if score_plan is None:
+        score_plan = dense_score_plan(64)
+    with patch.dict(os.environ, {}, clear=True):
+        seed = cute_flash.flash_attention_seed_config(
+            64,
+            num_kv,
+            dtype=torch.float16,
+            is_causal=False,
+            standard_dense_output=True,
+            target_device_capability=(10, 3),
+        )
+        assert seed is not None
+        manual_overrides = dict(seed.config)
+        if config_overrides is not None:
+            manual_overrides.update(config_overrides)
+        config = cute_flash.resolve_flash_config(
+            64,
+            num_kv,
+            manual_overrides,
+            dtype=torch.float16,
+            is_causal=False,
+            standard_dense_output=True,
+        )
+    body = cute_flash.emit_flash_fa4_device_body(
+        cast("DeviceFunction", None),
+        head_dim=64,
+        num_kv=num_kv,
+        sequence_extent=num_kv * 128,
+        num_bh=64,
+        total_tiles=num_kv * 16,
+        cfg=config,
+        has_lse=has_lse,
+        io_dtype="cutlass.Float16",
+        score_plan=score_plan,
+        target_device_capability=capability,
+    )
+    return ast.unparse(ast.Module(body=body, type_ignores=[]))
+
+
 def test_degree2_polynomial_relative_error_bound() -> None:
     x = torch.linspace(0.0, 1.0, 100_001, dtype=torch.float32)
     c0, c1, c2 = _flash_runtime._POLY_EX2_DEG2
@@ -298,6 +346,86 @@ def test_degree2_packet_emits_exact_causal_pass2_arguments() -> None:
         )
 
 
+def test_sm103_packed_f16x2_rewrite_requires_exact_promoted_seed() -> None:
+    intermediate_source = _emit_dense_resident_value_graph_source(
+        num_kv=384,
+        config_overrides={
+            cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta",
+            cute_flash.FLASH_PERSISTENT_KEY: False,
+            cute_flash.FLASH_EXP2_PACKET_KEY: _DEG1_SHORT_PACKET,
+            cute_flash.FLASH_Q_TILE_COUNT_KEY: 2,
+        },
+    )
+    manual_source = _emit_dense_resident_value_graph_source(
+        num_kv=2048,
+        config_overrides={cute_flash.FLASH_E2E_OFFSET0_KEY: 9},
+    )
+    promoted_source = _emit_dense_resident_value_graph_source(num_kv=2048)
+
+    assert "f16x2_xu=True" not in intermediate_source
+    assert "f16x2_xu=True" not in manual_source
+    assert "f16x2_xu=True" in promoted_source
+
+
+def test_sm103_scaled_all_xu_codegen_covers_256k() -> None:
+    all_xu_source = _emit_dense_resident_value_graph_source(num_kv=2048)
+    overflow_source = _emit_dense_resident_value_graph_source(
+        num_kv=2048,
+        config_overrides={cute_flash.FLASH_RESCALE_THRESHOLD_KEY: 9.0},
+    )
+    all_xu_module = ast.parse(all_xu_source)
+    overflow_module = ast.parse(overflow_source)
+
+    def _pass2_calls(module: ast.Module) -> list[ast.Call]:
+        return [
+            node
+            for node in ast.walk(module)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "fa4_sp_exp_convert_store_whole_rowsum"
+        ]
+
+    all_xu_calls = _pass2_calls(all_xu_module)
+    overflow_calls = _pass2_calls(overflow_module)
+    assert len(all_xu_calls) == len(overflow_calls) == 2
+    for call in all_xu_calls:
+        assert [ast.literal_eval(call.args[index]) for index in (6, 7, 8)] == [
+            16,
+            0,
+            0,
+        ]
+        assert any(
+            keyword.arg == "f16x2_xu" and ast.literal_eval(keyword.value)
+            for keyword in call.keywords
+        )
+    assert (
+        "cutlass.Float32(7.0) - flash_row_max_safe * _flash_scale_log2" in all_xu_source
+    )
+    for call in overflow_calls:
+        assert [ast.literal_eval(call.args[index]) for index in (6, 7)] == [16, 8]
+        assert not any(keyword.arg == "f16x2_xu" for keyword in call.keywords)
+    assert "cutlass.Float32(7.0)" not in overflow_source
+
+
+def test_dense_target_lowering_match_is_environment_independent() -> None:
+    dense_seed = cute_flash.flash_attention_seed_config(
+        64,
+        256,
+        standard_dense_output=True,
+        target_device_capability=(10, 3),
+    )
+    assert dense_seed is not None
+    dense_cfg = cute_flash.resolve_flash_config(
+        64,
+        256,
+        dense_seed.config,
+        standard_dense_output=True,
+    )
+
+    with patch.dict(os.environ, {"HELION_CUTE_FLASH_WAIT_HINT": "0"}):
+        assert cute_flash._flash_dense_resident_seed_matches(dense_cfg, 256, (10, 3))
+
+
 def test_hybrid_packet_uses_degree1_only_for_unmasked_pass2() -> None:
     with patch.dict(os.environ, {}, clear=True):
         config = cute_flash.resolve_flash_config(
@@ -400,6 +528,7 @@ def test_polynomial_packet_uses_whole_row_dense_pass2(
         has_lse=False,
         io_dtype="cutlass.Float16",
         score_plan=dense_score_plan(64),
+        target_device_capability=(10, 0),
     )
     module = ast.Module(body=body, type_ignores=[])
     pass2_calls = [
@@ -458,6 +587,7 @@ def test_short_degree1_packet_reverses_steady_correction_order(
         has_lse=False,
         io_dtype="cutlass.Float16",
         score_plan=dense_score_plan(64),
+        target_device_capability=(10, 3),
     )
     correction_loop = next(
         node
@@ -520,6 +650,7 @@ def _emit_dense_single_stat_source(
             has_lse=False,
             io_dtype="cutlass.Float16",
             score_plan=dense_score_plan(64),
+            target_device_capability=(10, 3),
         )
     return ast.unparse(ast.Module(body=body, type_ignores=[]))
 
@@ -927,6 +1058,7 @@ def test_dense_ring2_emits_two_slot_stat_protocol() -> None:
             has_lse=False,
             io_dtype="cutlass.Float16",
             score_plan=dense_score_plan(64),
+            target_device_capability=(10, 3),
         )
         return ast.unparse(ast.Module(body=body, type_ignores=[]))
 

--- a/test/test_cute_flash_schedule.py
+++ b/test/test_cute_flash_schedule.py
@@ -9,6 +9,7 @@ from helion._compiler.cute.flash_schedule import FlashOutputOrder
 from helion._compiler.cute.flash_schedule import FlashSchedule
 from helion._compiler.cute.flash_schedule import FlashScheduleError
 from helion._compiler.cute.flash_schedule import FlashScheduleSpec
+from helion._compiler.cute.flash_schedule import FlashStatReleaseMapping
 from helion._compiler.cute.flash_schedule import FlashSyncScope
 from helion._compiler.cute.flash_schedule import build_fa4_schedule
 from helion._compiler.cute.flash_schedule import verify_flash_schedule
@@ -527,9 +528,17 @@ def test_persistent_phase_continuity_at_work_boundary(
     assert cycles["pfor_q0"].phases == (0, middle_phase, 0)
 
 
+@pytest.mark.parametrize(
+    "stat_release_mapping",
+    (
+        FlashStatReleaseMapping.CROSS_SLOT,
+        FlashStatReleaseMapping.SAME_SLOT,
+    ),
+)
 @pytest.mark.parametrize("kv_iterations", (3, 4))
 def test_pipelined_stat_handoff_models_dummy_and_final_events(
     kv_iterations: int,
+    stat_release_mapping: FlashStatReleaseMapping,
 ) -> None:
     schedule = build_fa4_schedule(
         FlashScheduleSpec(
@@ -539,12 +548,26 @@ def test_pipelined_stat_handoff_models_dummy_and_final_events(
             kv_iterations=kv_iterations,
             stat_depth=1,
             pipelined_stat_handoff=True,
+            stat_release_mapping=stat_release_mapping,
         )
     )
 
     verify_flash_schedule(schedule)
 
     cycles = {cycle.barrier: cycle for cycle in schedule.phase_cycles}
+    barriers = {barrier.name: barrier for barrier in schedule.barriers}
+    for slot in range(2):
+        for kind in ("ready", "empty"):
+            barrier = barriers[f"stat_{kind}_r0_q{slot}"]
+            assert barrier.expected_arrivals == 1
+            assert (
+                sum(
+                    edge.arrival_count
+                    for edge in schedule.edges
+                    if edge.barrier == barrier.name
+                )
+                == 1
+            )
     assert cycles["s_full_r0_q0"].uses_per_work == kv_iterations
     assert cycles["s_full_r0_q0"].phases == (
         0,
@@ -565,23 +588,176 @@ def test_pipelined_stat_handoff_models_dummy_and_final_events(
     )
 
 
-@pytest.mark.parametrize(
-    "spec",
-    (
-        FlashScheduleSpec(64, 2, stat_depth=2, pipelined_stat_handoff=True),
+def test_pipelined_stat_handoff_defaults_to_cross_slot_releases() -> None:
+    schedule = build_fa4_schedule(
         FlashScheduleSpec(
-            64, 2, causal=True, stat_depth=1, pipelined_stat_handoff=True
+            64,
+            2,
+            stat_depth=1,
+            pipelined_stat_handoff=True,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    assert schedule.spec.stat_release_mapping is FlashStatReleaseMapping.CROSS_SLOT
+    assert {
+        (edge.source, edge.target, edge.iteration_delta, edge.barrier)
+        for edge in schedule.edges
+        if edge.barrier is not None and edge.barrier.startswith("stat_empty_")
+    } == {
+        ("correction_r0_q0", "stat_r0_q1", 0, "stat_empty_r0_q1"),
+        ("correction_r0_q1", "stat_r0_q0", 1, "stat_empty_r0_q0"),
+    }
+
+
+def test_causal_pipelined_stat_handoff_uses_same_slot_releases() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            causal=True,
+            stat_depth=1,
+            pipelined_stat_handoff=True,
+            stat_release_mapping=FlashStatReleaseMapping.SAME_SLOT,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    assert {
+        (edge.source, edge.target, edge.iteration_delta, edge.barrier)
+        for edge in schedule.edges
+        if edge.barrier is not None and edge.barrier.startswith("stat_empty_")
+    } == {
+        ("correction_r0_q0", "stat_r0_q0", 1, "stat_empty_r0_q0"),
+        ("correction_r0_q1", "stat_r0_q1", 1, "stat_empty_r0_q1"),
+    }
+
+
+@pytest.mark.parametrize(
+    ("selected", "corrupt"),
+    (
+        (
+            FlashStatReleaseMapping.CROSS_SLOT,
+            FlashStatReleaseMapping.SAME_SLOT,
+        ),
+        (
+            FlashStatReleaseMapping.SAME_SLOT,
+            FlashStatReleaseMapping.CROSS_SLOT,
         ),
     ),
+)
+def test_pipelined_stat_release_mapping_corruption_is_rejected(
+    selected: FlashStatReleaseMapping,
+    corrupt: FlashStatReleaseMapping,
+) -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            stat_depth=1,
+            pipelined_stat_handoff=True,
+            stat_release_mapping=selected,
+        )
+    )
+    corrupt_release = {
+        FlashStatReleaseMapping.CROSS_SLOT: (
+            ("stat_r0_q1", 0, "stat_empty_r0_q1"),
+            ("stat_r0_q0", 1, "stat_empty_r0_q0"),
+        ),
+        FlashStatReleaseMapping.SAME_SLOT: (
+            ("stat_r0_q0", 1, "stat_empty_r0_q0"),
+            ("stat_r0_q1", 1, "stat_empty_r0_q1"),
+        ),
+    }[corrupt]
+    source_slot = {
+        "correction_r0_q0": 0,
+        "correction_r0_q1": 1,
+    }
+    schedule = dataclasses.replace(
+        schedule,
+        edges=tuple(
+            dataclasses.replace(
+                edge,
+                target=corrupt_release[source_slot[edge.source]][0],
+                iteration_delta=corrupt_release[source_slot[edge.source]][1],
+                barrier=corrupt_release[source_slot[edge.source]][2],
+            )
+            if edge.source in source_slot
+            and edge.barrier is not None
+            and edge.barrier.startswith("stat_empty_")
+            else edge
+            for edge in schedule.edges
+        ),
+    )
+
+    with pytest.raises(
+        FlashScheduleError,
+        match=f"selected {selected.value} mapping",
+    ):
+        verify_flash_schedule(schedule)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    (FlashScheduleSpec(64, 2, stat_depth=2, pipelined_stat_handoff=True),),
 )
 def test_pipelined_stat_handoff_rejects_unsupported_schedules(
     spec: FlashScheduleSpec,
 ) -> None:
     with pytest.raises(
         FlashScheduleError,
-        match="pipelined stat handoff requires depth one and a noncausal schedule",
+        match="pipelined stat handoff requires depth one",
     ):
         build_fa4_schedule(spec)
+
+
+def test_causal_cross_slot_stat_releases_are_rejected() -> None:
+    with pytest.raises(
+        FlashScheduleError,
+        match="require proof of equal query-slot K/V iteration counts",
+    ):
+        build_fa4_schedule(
+            FlashScheduleSpec(
+                64,
+                2,
+                causal=True,
+                stat_depth=1,
+                pipelined_stat_handoff=True,
+            )
+        )
+
+
+def test_causal_cross_slot_stat_releases_accept_equal_iteration_proof() -> None:
+    schedule = build_fa4_schedule(
+        FlashScheduleSpec(
+            64,
+            2,
+            causal=True,
+            stat_depth=1,
+            pipelined_stat_handoff=True,
+            query_slots_have_equal_kv_iterations=True,
+        )
+    )
+
+    verify_flash_schedule(schedule)
+
+    assert schedule.spec.stat_release_mapping is FlashStatReleaseMapping.CROSS_SLOT
+
+
+def test_same_slot_stat_releases_require_pipelined_handoff() -> None:
+    with pytest.raises(
+        FlashScheduleError,
+        match="same-slot stat releases require pipelined stat handoff",
+    ):
+        build_fa4_schedule(
+            FlashScheduleSpec(
+                64,
+                2,
+                stat_release_mapping=FlashStatReleaseMapping.SAME_SLOT,
+            )
+        )
 
 
 def test_final_only_stat_handoff_uses_transitive_reuse_ordering() -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3423
 * #3420
 * #3419
 * #3418
 * __->__#3417


--- --- ---

## Summary

Add the hardware primitives and synchronization model needed by the SM103 resident-softmax lowerings.

- Add SM103 row reduction and packed FP16x2 exp2 helpers.
- Gate them on an exact promoted target seed, retaining generic fallbacks.
- Preserve the 256K packed-reduction tail path.
- Model stat release as an explicit same-slot/cross-slot mapping and use the same mapping for schedule verification and emitted releases.

Depends on #3416. This is PR 2/6.

## Critical tests

```bash
HELION_BACKEND=cute pytest test/test_cute_flash_schedule.py \
  test/test_cute_flash_exp2.py test/test_cute_backend.py
```

Coverage includes corrupted release mappings, unsupported schedules, packed-exp2 gates, 256K tails, LdRed codegen, and GPU comparison against SDPA.

The complete stacked verification and GB300 performance report are in PR 5.