### PR TITLE
[CuTe] Add SM103 dense resident softmax

### DIFF
--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -2417,6 +2417,75 @@ def fa4_correction_epilogue_handoff_to_smem_scoped_2cta(
     cute.arch.mbarrier_arrive(corr_epi_full_ptr_stage)
 
 
+@dsl_user_op
+def resident_softmax_value_graph(
+    tLDrS: cute.Tensor,
+    tiled_st: object,
+    tSTtS: cute.Tensor,
+    tSTcS: cute.Tensor,
+    scale: Float32,
+    minus_max_scale: Float32,
+    pfor_ptr_stage: object,
+    pfor2_ptr_stage: object,
+    p_store_split: int,
+    p_store_chunks: int,
+    stats_empty_ptr_stage: object,
+    stats_empty_phase: object,
+    row_sum_init: object,
+    wait_hint: int = 10_000_000,
+    *,
+    pfor_peer_cta_rank: object = None,
+    pfor_self_cta_rank: object = None,
+    loc: object = None,
+    ip: object = None,
+) -> Float32:
+    """Resident softmax lowering with a full-row value graph.
+
+    Keep scale, exp2/conversion, split-P publication, statistics acquire, and
+    row-sum reduction in one lowering unit.  The exp2 results remain fp32 in
+    ``tLDrS`` for the reducer while a distinct register tensor holds fp16 P.
+    """
+    assert tLDrS.element_type is cutlass.Float32
+    assert cute.size(tLDrS) % 32 == 0
+    frag_count = cute.size(tLDrS) // 32
+    assert p_store_chunks == frag_count
+    assert cute.size(tSTtS, mode=[2]) == p_store_chunks
+    assert 0 < p_store_split < p_store_chunks
+
+    for i in range(0, cute.size(tLDrS), 2):
+        tLDrS[i], tLDrS[i + 1] = cute.arch.fma_packed_f32x2(
+            (tLDrS[i], tLDrS[i + 1]),
+            (scale, scale),
+            (minus_max_scale, minus_max_scale),
+        )
+
+    tSTrS = cute.make_rmem_tensor(tSTcS.shape, cutlass.Float32)
+    tSTrS_e = cute.make_tensor(
+        cute.recast_ptr(tSTrS.iterator, dtype=cutlass.Float16), tLDrS.layout
+    )
+    src = cute.logical_divide(tLDrS, cute.make_layout(32))
+    dst = cute.logical_divide(tSTrS_e, cute.make_layout(32))
+    for ci in range(frag_count):
+        for i in range(0, 32, 2):
+            exp0 = cute.math.exp2(src[i, ci], fastmath=True)
+            exp1 = cute.math.exp2(src[i + 1, ci], fastmath=True)
+            src[i, ci] = exp0
+            src[i + 1, ci] = exp1
+        cast("cute.Tensor", dst[None, ci]).store(
+            cast("cute.Tensor", src[None, ci]).load().to(cutlass.Float16)
+        )
+
+    for ci in range(p_store_chunks):
+        cute.copy(tiled_st, tSTrS[None, None, ci], tSTtS[None, None, ci])
+        if ci == p_store_split - 1:
+            cute.arch.fence_view_async_tmem_store()
+            mbarrier_arrive(pfor_ptr_stage, pfor_peer_cta_rank, pfor_self_cta_rank)
+    cute.arch.fence_view_async_tmem_store()
+    mbarrier_arrive(pfor2_ptr_stage, pfor_peer_cta_rank, pfor_self_cta_rank)
+    mbar_spin_wait(stats_empty_ptr_stage, stats_empty_phase, wait_hint)
+    return fadd_reduce_packed(tLDrS, row_sum_init)
+
+
 def _fa4_sp_exp_convert_store_impl(
     tLDrS: cute.Tensor,
     tiled_st: object,

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -60,6 +60,7 @@ from .flash_schedule import FlashScheduleSpec
 from .flash_schedule import build_fa4_schedule
 from .flash_schedule import verify_flash_schedule
 from .flash_tuning import FlashPackedExp2Mode
+from .flash_tuning import FlashSoftmaxLowering
 
 _T = TypeVar("_T")
 
@@ -7399,6 +7400,36 @@ def emit_flash_fa4_device_body(
     probability_shift_safe = probability_log2_shift + cfg.rescale_threshold < math.log2(
         torch.finfo(torch.float16).max
     )
+    dense_resident_value_graph_candidate = False
+    if (
+        dense_tuning is not None
+        and _flash_dense_resident_seed_matches(cfg, num_kv, target_device_capability)
+        and not is_causal
+        and hd == 64
+        and io_dtype == "cutlass.Float16"
+        and not has_lse
+        and cfg.pipeline_family == "fa4_2cta"
+        and cfg.q_tile_count == 2
+        and cfg.use_2cta_instrs
+        and not cfg.separate_kv_rings
+        and not cfg.softmax_disc
+        and cfg.split_p_arrive
+        and cfg.p_store_repetition == 16
+        and cfg.s_load_repetition == 32
+        and cfg.rescale_threshold > 0.0
+        and probability_shift_safe
+        and score_plan.modifier_kinds == (DENSE_SCORE_KIND,)
+    ):
+        dense_softmax_family = dense_tuning.softmax_lowering
+        if dense_softmax_family is FlashSoftmaxLowering.STANDARD:
+            pass
+        elif dense_softmax_family is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH:
+            dense_resident_value_graph_candidate = True
+        else:
+            raise AssertionError(
+                "unsupported dense resident softmax lowering family: "
+                f"{dense_softmax_family!r}"
+            )
     use_whole_row_tmem_reduce = (
         use_tmem_row_reduce and not is_causal and not cfg.softmax_disc
     )
@@ -7440,7 +7471,9 @@ def emit_flash_fa4_device_body(
         and probability_shift_safe
     )
     effective_probability_log2_shift = (
-        probability_log2_shift if use_all_packed_f16x2_xu else 0
+        probability_log2_shift
+        if use_all_packed_f16x2_xu or dense_resident_value_graph_candidate
+        else 0
     )
     use_cga2_local_cta = cfg.use_cga2_local_cta
     use_clc_scheduler = cfg.use_clc_scheduler
@@ -7455,7 +7488,10 @@ def emit_flash_fa4_device_body(
         and cfg.exp2_impl == "split"
         and not cfg.softmax_disc
         and cfg.rescale_threshold > 0.0
-        and cfg.exp2_packet != _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
+        and (
+            cfg.exp2_packet != _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
+            or dense_resident_value_graph_candidate
+        )
     )
     # The MMA warp's PV -> next-QK order makes each alpha slot safe to reuse
     # without a per-iteration empty acknowledgement. Keep a single terminal
@@ -7464,6 +7500,11 @@ def emit_flash_fa4_device_body(
         fa4_stat_pipeline and cfg.stat_transport == "single_final"
     )
     acknowledged_stat_pipeline = fa4_stat_pipeline and not final_only_stat_pipeline
+    use_dense_resident_value_graph = (
+        dense_resident_value_graph_candidate and acknowledged_stat_pipeline
+    )
+    if dense_resident_value_graph_candidate:
+        assert use_dense_resident_value_graph
     verified_shared_memory_bytes: int | None = None
     if separate_kv_rings:
         assert not use_cga2_local_cta
@@ -9505,7 +9546,20 @@ if warp_idx == 15:
             cute.arch.fence_view_async_tmem_store()
             _helion_flash_rt.mbarrier_arrive(
                 flash_pfor_ptr + {stage}{pfor_peer_arg})"""
-        if cfg.exp2_impl == "split":
+        if use_dense_resident_value_graph:
+            assert split_p_arrive
+            assert not mixed_p_store
+            sp_exp_block = f"""            flash_row_sum = _helion_flash_rt.resident_softmax_value_graph(
+                tLDrS, {st}, {stt}, tSTcS, _flash_scale_log2,
+                flash_minus_max_scale, flash_pfor_ptr + {stage},
+                flash_pfor2_ptr + {stage}, flash_P_STORE_SPLIT,
+                flash_P_STORE_CHUNKS, {corr_empty_ptr} + 0,
+                flash_s_corr_prod_phase, flash_row_sum * flash_alpha,
+                {cfg.wait_hint}, pfor_peer_cta_rank=cutlass.Int32(0),
+                pfor_self_cta_rank={pfor_self_cta_rank})"""
+            sp_p_store_block = ""
+            sp_corr_publish_alpha = ""
+        elif cfg.exp2_impl == "split":
             sp_e2e_offset = (
                 "0"
                 if exp2_codegen.e2e_res == 0
@@ -9638,6 +9692,14 @@ if warp_idx == 15:
             else "            flash_row_max = "
             "_helion_flash_rt.fmax_reduce_packed(tLDrS, flash_row_max)"
         )
+        post_p_stat_acquire = (
+            "" if use_dense_resident_value_graph else fa4_post_p_stat_acquire.rstrip()
+        )
+        row_sum_update = (
+            "            flash_s_corr_prod_phase ^= 1"
+            if use_dense_resident_value_graph
+            else "            flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum"
+        )
         return f"""{
             fa4_entry_stat_acquire
         }        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
@@ -9660,8 +9722,8 @@ if warp_idx == 15:
 {_softmax_release_p_ready(stage)}
 {_sp_alpha_post}
 {sp_alpha_publish_post}
-{fa4_post_p_stat_acquire.rstrip()}
-            flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum
+{post_p_stat_acquire}
+{row_sum_update}
 {sp_p_store_block}
 {final_corr_publish_rowsum}"""
 
@@ -10022,7 +10084,10 @@ if warp_idx == 15:
     corr_output_m_tile1 = output_m_tile1 if not epi_smem else "flash_m_tile1"
     corr_steady_stages = (
         f"{corr_stage1}\n{corr_stage0}"
-        if cfg.exp2_packet == _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
+        if (
+            cfg.exp2_packet == _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
+            and not use_dense_resident_value_graph
+        )
         else f"{corr_stage0}\n{corr_stage1}"
     )
     if cfg.skip_rescale_stats:

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -23,6 +23,7 @@ import helion
 from helion._compiler.cute.attention_plan import causal_score_plan
 from helion._compiler.cute.flash_policy import get_flash_target_policy
 from helion._compiler.cute.flash_tuning import FlashPackedExp2Mode
+from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
 from helion._testing import TestCase
@@ -2878,6 +2879,46 @@ class TestCuteBackend(TestCase):
         self.assertNotIn("LdRed32x32bOp", modified_code)
 
     def test_flash_attention_sm103_f16x2_exp2_codegen_gates(self) -> None:
+        resident_q, resident_k, resident_v = (
+            torch.empty(1, 1, 32768, 64, dtype=torch.float16, device=DEVICE)
+            for _ in range(3)
+        )
+        resident_config = helion.Config(
+            block_sizes=[1, 128, 128],
+            cute_flash_pipeline_family="fa4_2cta",
+            cute_flash_persistent=False,
+            cute_flash_exp2_packet="deg1_8x2_corr10",
+            cute_flash_e2e_schedule="8/2",
+            cute_flash_e2e_offset=5,
+            cute_flash_e2e_offset0=1,
+            cute_flash_kv_stage=6,
+            cute_flash_stat_transport="single",
+        )
+        resident_bound = cute_dense_attention.bind((resident_q, resident_k, resident_v))
+        with patch.object(
+            resident_bound.env.config_spec, "target_device_capability", (10, 3)
+        ):
+            resident_code = resident_bound.to_triton_code(resident_config)
+        self.assertIn("resident_softmax_value_graph", resident_code)
+        self.assertNotIn("f16x2_xu=True", resident_code)
+        for fallback_target in ((10, 0), (10, 4)):
+            with patch.object(
+                resident_bound.env.config_spec,
+                "target_device_capability",
+                fallback_target,
+            ):
+                fallback_code = resident_bound.to_triton_code(resident_config)
+            self.assertNotIn("resident_softmax_value_graph", fallback_code)
+
+        nonpolicy_config = helion.Config(
+            **{**resident_config.config, "cute_flash_e2e_offset": 4}
+        )
+        with patch.object(
+            resident_bound.env.config_spec, "target_device_capability", (10, 3)
+        ):
+            nonpolicy_code = resident_bound.to_triton_code(nonpolicy_config)
+        self.assertNotIn("resident_softmax_value_graph", nonpolicy_code)
+
         q, k, v = (
             torch.empty(1, 1, 262144, 64, dtype=torch.float16, device=DEVICE)
             for _ in range(3)
@@ -2906,15 +2947,27 @@ class TestCuteBackend(TestCase):
             b200_code = dense_bound.to_triton_code(config)
         self.assertNotIn("f16x2_xu=True", b200_code)
 
-        lse_bound = cute_dense_attention_with_lse.bind((q, k, v))
+        lse_bound = cute_dense_attention_with_lse.bind(
+            (resident_q, resident_k, resident_v)
+        )
         lse_config = helion.Config(
-            **{**config.config, "cute_flash_stat_transport": "single"}
+            **{**resident_config.config, "cute_flash_stat_transport": "single"}
         )
         with patch.object(
             lse_bound.env.config_spec, "target_device_capability", (10, 3)
         ):
             lse_code = lse_bound.to_triton_code(lse_config)
         self.assertNotIn("f16x2_xu=True", lse_code)
+        self.assertNotIn("resident_softmax_value_graph", lse_code)
+
+        modified_bound = cute_softcap_attention.bind(
+            (resident_q, resident_k, resident_v)
+        )
+        with patch.object(
+            modified_bound.env.config_spec, "target_device_capability", (10, 3)
+        ):
+            modified_code = modified_bound.to_triton_code(resident_config)
+        self.assertNotIn("resident_softmax_value_graph", modified_code)
 
     def test_flash_attention_target_packed_exp2_preserves_256k_tail(self) -> None:
         capability = torch.cuda.get_device_capability()
@@ -2959,6 +3012,88 @@ class TestCuteBackend(TestCase):
         self.assertTrue(torch.equal(out, repeated))
         self.assertTrue(torch.isfinite(out).all())
         self.assertLess((out.float() - expected).abs().max().item(), 5e-5)
+
+    def _check_flash_attention_target_dense_resident(
+        self, num_kv: int, seed_value: int
+    ) -> None:
+        capability = torch.cuda.get_device_capability()
+        dense_policy = get_flash_target_policy(capability).tuning.dense_policy(num_kv)
+        if (
+            dense_policy is None
+            or dense_policy.softmax_lowering
+            is not FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+        ):
+            self.skipTest("target has no dense resident flash lowering")
+
+        torch.manual_seed(seed_value)
+        sequence_length = num_kv * 128
+        q, k, v = (
+            torch.randn(
+                1,
+                1,
+                sequence_length,
+                64,
+                dtype=torch.float16,
+                device=DEVICE,
+            )
+            for _ in range(3)
+        )
+        seed = _cute_flash.flash_attention_seed_config(
+            64,
+            num_kv,
+            dtype=torch.float16,
+            standard_dense_output=True,
+            target_device_capability=capability,
+        )
+        assert seed is not None
+        config = helion.Config(**seed.config)
+        bound = cute_dense_attention.bind((q, k, v))
+        code = bound.to_triton_code(config)
+        compiled = bound.compile_config(config)
+        self.assertIn("resident_softmax_value_graph", code)
+        self.assertNotIn("f16x2_xu=True", code)
+
+        out = compiled(q, k, v)
+        repeated = compiled(q, k, v)
+        torch.cuda.synchronize()
+        expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        diff = (out.float() - expected.float()).abs()
+        normalized_rmse = torch.sqrt(
+            (diff * diff).mean(dtype=torch.float64)
+        ) / torch.sqrt((expected.float() * expected.float()).mean(dtype=torch.float64))
+        self.assertTrue(torch.equal(out, repeated))
+        self.assertTrue(torch.isfinite(out).all())
+        self.assertLess(diff.max().item(), 0.015)
+        self.assertLess(normalized_rmse.item(), 0.004)
+        torch.testing.assert_close(out, expected, atol=0.01, rtol=0.02)
+
+        if num_kv == 1024:
+            tail_q = torch.zeros_like(q)
+            tail_k = torch.zeros_like(k)
+            tail_v = torch.full_like(v, -2.0)
+            tail_q[..., 0] = 1.0
+            tail_k[..., 0] = -26.0 * math.sqrt(64) / math.log2(math.e)
+            tail_k[..., 0, 0] = 0.0
+            tail_v[..., 0, :] = 2.0
+            tail_out = compiled(tail_q, tail_k, tail_v)
+            tail_repeated = compiled(tail_q, tail_k, tail_v)
+            effective_tail_log2 = (
+                tail_k[0, 0, 1, 0].float().item() / math.sqrt(64) * math.log2(math.e)
+            )
+            tail_mass = (sequence_length - 1) * 2.0**effective_tail_log2
+            tail_expected = (2.0 - 2.0 * tail_mass) / (1.0 + tail_mass)
+            self.assertTrue(torch.equal(tail_out, tail_repeated))
+            self.assertTrue(torch.isfinite(tail_out).all())
+            self.assertLess((tail_out.float() - tail_expected).abs().max().item(), 5e-5)
+
+    def test_flash_attention_target_dense32_resident_matches_sdpa(self) -> None:
+        self._check_flash_attention_target_dense_resident(256, 107)
+
+    def test_flash_attention_target_dense64_resident_matches_sdpa(self) -> None:
+        self._check_flash_attention_target_dense_resident(512, 111)
+
+    def test_flash_attention_target_dense128_resident_matches_sdpa(self) -> None:
+        self._check_flash_attention_target_dense_resident(1024, 113)
 
     def test_flash_attention_target_ldred_matches_sdpa(self) -> None:
         capability = torch.cuda.get_device_capability()

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import dataclasses
 import importlib
 import math
 import os
@@ -14,9 +15,13 @@ import torch
 import helion
 from helion._compiler.backend import CuteBackend
 from helion._compiler.cute import cute_flash
+from helion._compiler.cute.attention_plan import SOFTCAP_KIND
+from helion._compiler.cute.attention_plan import AttentionScoreModifier
 from helion._compiler.cute.attention_plan import AttentionScorePlan
 from helion._compiler.cute.attention_plan import causal_score_plan
 from helion._compiler.cute.attention_plan import dense_score_plan
+from helion._compiler.cute.flash_policy import get_flash_target_policy
+from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
 from helion._testing import DEVICE
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
@@ -424,6 +429,181 @@ def test_dense_target_lowering_match_is_environment_independent() -> None:
 
     with patch.dict(os.environ, {"HELION_CUTE_FLASH_WAIT_HINT": "0"}):
         assert cute_flash._flash_dense_resident_seed_matches(dense_cfg, 256, (10, 3))
+
+
+@pytest.mark.parametrize("num_kv", (256, 512, 1024))
+def test_dense_resident_value_graph_codegen_and_barrier_protocol(num_kv: int) -> None:
+    source = _emit_dense_resident_value_graph_source(num_kv=num_kv)
+    module = ast.parse(source)
+    value_graph_calls = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "resident_softmax_value_graph"
+    ]
+
+    assert len(value_graph_calls) == 2
+    for call in value_graph_calls:
+        assert ast.unparse(call.args[10]).endswith("_corr_empty_ptr + 0")
+        assert ast.unparse(call.args[11]) == "flash_s_corr_prod_phase"
+        assert ast.unparse(call.args[12]) == "flash_row_sum * flash_alpha"
+        assert {
+            keyword.arg: ast.unparse(keyword.value) for keyword in call.keywords
+        } == {
+            "pfor_peer_cta_rank": "cutlass.Int32(0)",
+            "pfor_self_cta_rank": "None",
+        }
+
+    assert "fa4_sp_exp_convert_store_whole_rowsum" not in source
+    assert "f16x2_xu=True" not in source
+    assert "cutlass.Float32(7.0) - flash_row_max_safe * _flash_scale_log2" in source
+    assert source.count("flash_s_corr_prod_phase = cutlass.Int32(1)") == 2
+
+    stage0_start = source.index("flash_s_corr_prod_phase = cutlass.Int32(1)")
+    stage1_start = source.index(
+        "flash_s_corr_prod_phase = cutlass.Int32(1)", stage0_start + 1
+    )
+    softmax0 = source[stage0_start:stage1_start]
+    empty_wait = (
+        "_helion_flash_rt.mbar_spin_wait(flash_s0_corr_empty_ptr + 0, "
+        "flash_s_corr_prod_phase, 10000000)"
+    )
+    assert softmax0.count(empty_wait) == 2
+    assert softmax0.count("flash_s_corr_prod_phase ^= 1") == 2
+    entry_wait = softmax0.index(empty_wait)
+    alpha_store = softmax0.index(
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_alpha"
+    )
+    value_graph = softmax0.index("resident_softmax_value_graph", alpha_store)
+    phase_advance = softmax0.index("flash_s_corr_prod_phase ^= 1", value_graph)
+    rowsum_store = softmax0.index(
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_row_sum",
+        phase_advance,
+    )
+    tail_wait = softmax0.index(empty_wait, rowsum_store)
+    assert (
+        entry_wait
+        < alpha_store
+        < value_graph
+        < phase_advance
+        < rowsum_store
+        < tail_wait
+    )
+    assert "flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum" not in softmax0
+
+    correction = source[source.index("(warp_idx >= 8) & (warp_idx < 12):") :]
+    steady_loop = correction.index("for flash_kv")
+    alpha0 = correction.index("flash_a0 =", steady_loop)
+    pfor0 = correction.index("flash_pfor_ptr + 0", alpha0)
+    release1 = correction.index(
+        "cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)", pfor0
+    )
+    alpha1 = correction.index("flash_a1 =", release1)
+    pfor1 = correction.index("flash_pfor_ptr + 1", alpha1)
+    release0 = correction.index(
+        "cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)", pfor1
+    )
+    assert alpha0 < pfor0 < release1 < alpha1 < pfor1 < release0
+
+
+def test_dense_resident_value_graph_gate_preserves_fallbacks() -> None:
+    base_plan = dense_score_plan(64)
+    modified_plan = dataclasses.replace(
+        base_plan,
+        modifiers=(AttentionScoreModifier(SOFTCAP_KIND, value_log2=2.0),),
+    )
+    fallback_sources = (
+        _emit_dense_resident_value_graph_source(capability=(10, 0)),
+        _emit_dense_resident_value_graph_source(capability=(10, 4)),
+        _emit_dense_resident_value_graph_source(num_kv=2048),
+        _emit_dense_resident_value_graph_source(has_lse=True),
+        _emit_dense_resident_value_graph_source(score_plan=modified_plan),
+        _emit_dense_resident_value_graph_source(
+            config_overrides={cute_flash.FLASH_E2E_OFFSET_KEY: 4}
+        ),
+    )
+    for fallback_source in fallback_sources:
+        assert "resident_softmax_value_graph" not in fallback_source
+        assert "fa4_sp_exp_convert_store_whole_rowsum" in fallback_source
+
+
+def test_sm103_dense64_register_policy_is_target_specific() -> None:
+    sm103_seed = cute_flash.flash_attention_seed_config(
+        64,
+        512,
+        dtype=torch.float16,
+        is_causal=False,
+        standard_dense_output=True,
+        target_device_capability=(10, 3),
+    )
+    sm100_seed = cute_flash.flash_attention_seed_config(
+        64,
+        512,
+        dtype=torch.float16,
+        is_causal=False,
+        standard_dense_output=True,
+        target_device_capability=(10, 0),
+    )
+
+    assert sm103_seed is not None
+    assert sm100_seed is not None
+    assert sm103_seed.config[cute_flash.FLASH_CORR_REGS_KEY] == 72
+    assert sm103_seed.config[cute_flash.FLASH_OTHER_REGS_KEY] == 40
+    assert sm100_seed.config[cute_flash.FLASH_CORR_REGS_KEY] == 80
+    assert sm100_seed.config[cute_flash.FLASH_OTHER_REGS_KEY] == 32
+
+
+def test_dense_resident_softmax_lowering_dispatch_is_exhaustive() -> None:
+    policy = get_flash_target_policy((10, 3)).tuning
+    shape_policy = policy.dense_policy(256)
+    assert shape_policy is not None
+
+    standard_policy = dataclasses.replace(
+        policy,
+        dense_policies=(
+            dataclasses.replace(
+                shape_policy,
+                softmax_lowering=FlashSoftmaxLowering.STANDARD,
+            ),
+            *policy.dense_policies[1:],
+        ),
+    )
+    with patch.object(
+        cute_flash,
+        "get_flash_target_policy",
+        return_value=dataclasses.replace(
+            get_flash_target_policy((10, 3)), tuning=standard_policy
+        ),
+    ):
+        standard_source = _emit_dense_resident_value_graph_source()
+    assert "resident_softmax_value_graph" not in standard_source
+    assert "fa4_sp_exp_convert_store_whole_rowsum" in standard_source
+
+
+def test_dense_probability_shift_fails_closed_before_fp16_overflow() -> None:
+    target_policy = get_flash_target_policy((10, 3))
+    dense_policy = target_policy.tuning.dense_policy(256)
+    assert dense_policy is not None
+    unsafe_tuning = dataclasses.replace(
+        target_policy.tuning,
+        dense_policies=tuple(
+            dataclasses.replace(policy, probability_log2_shift=16)
+            if policy.num_kv == 256
+            else policy
+            for policy in target_policy.tuning.dense_policies
+        ),
+    )
+    with patch.object(
+        cute_flash,
+        "get_flash_target_policy",
+        return_value=dataclasses.replace(target_policy, tuning=unsafe_tuning),
+    ):
+        source = _emit_dense_resident_value_graph_source()
+
+    assert "resident_softmax_value_graph" not in source
+    assert "f16x2_xu=True" not in source
+    assert "cutlass.Float32(16.0)" not in source
 
 
 def test_hybrid_packet_uses_degree1_only_for_unmasked_pass2() -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3423
 * #3420
 * #3419
 * __->__#3418
 * #3417


--- --- ---

## Summary

Add the SM103 dense resident-softmax value graph and dispatch it through the target policy introduced earlier in the stack.

- Keep probability fragments resident across the value graph.
- Derive fragment/chunk structure from the graph rather than duplicating configuration.
- Fail closed to the existing lowering when the target/shape/config contract is not satisfied.
- Test barrier protocol, dispatch exhaustiveness, overflow bounds, fallback preservation, and GPU correctness.

Depends on #3417. This is PR 3/6.

## GB300 performance

Median-of-medians, FP16, `z=2`, `h=32`, head dimension 64. Lower latency is better.

| shape | Helion ms | Helion TFLOP/s | FA4 ms | FA4 TFLOP/s | Helion lead |
|---|---:|---:|---:|---:|---:|
| dense 32K | 13.4782 | 1305.2 | 14.2186 | 1237.3 | 5.4933% |
| dense 64K | 53.5849 | 1313.2 | 56.7502 | 1240.0 | 5.9071% |
| dense 128K | 213.5547 | 1318.0 | 226.9318 | 1240.4 | 6.2640% |
| dense 256K | 895.4695 | 1257.3 | 912.5888 | 1233.7 | 1.9118% |

The exact full-stack command and methodology are in PR 5.

## Critical tests

```bash
HELION_BACKEND=cute pytest test/test_cute_backend.py test/test_cute_flash_exp2.py
```

Fresh-cache GB300 runtime coverage passed for dense 32K/64K/128K resident paths and the dense 256K packed-tail path.