### PR TITLE
[CuTe] Add SM103 causal resident softmax

### DIFF
--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -6,6 +6,7 @@
 # generated Helion module DOES carry ``from __future__ import annotations`` at
 # its top, so the struct + the inline-traced rescale helper must live here, in a
 # real module compiled without that flag, and be imported by the generated code.
+from dataclasses import dataclass
 import functools
 from functools import partial
 from itertools import starmap
@@ -3279,6 +3280,200 @@ def fmax_reduce_packed(frg: cute.Tensor, init_val: object = None) -> Float32:
         local_max[3] = _fmax3(local_max[3], frg[i + 6], frg[i + 7])
     local_max[0] = _fmax3(local_max[0], local_max[1])
     return _fmax3(local_max[0], local_max[2], local_max[3])
+
+
+@cute.jit
+def _fmax_reduce_packed_ssa(
+    values: cute.TensorSSA,
+    init_val: object = None,
+) -> Float32:
+    values_rmem = cute.make_rmem_tensor(values.shape, Float32)
+    values_rmem.store(values)
+    return fmax_reduce_packed(values_rmem, init_val)
+
+
+@cute.jit
+def _fadd_reduce_packed_ssa(
+    values: cute.TensorSSA,
+    init_val: object = None,
+) -> Float32:
+    values_rmem = cute.make_rmem_tensor(values.shape, Float32)
+    values_rmem.store(values)
+    return fadd_reduce_packed(values_rmem, init_val)
+
+
+@cute.jit
+def _fadd_reduce_packed_ssa_scaled(
+    values: cute.TensorSSA,
+    row_sum: Float32,
+    acc_scale: Float32,
+) -> Float32:
+    values_rmem = cute.make_rmem_tensor(values.shape, Float32)
+    values_rmem.store(values)
+    n = cute.size(values_rmem)
+    assert n % 8 == 0
+    local_sum = [
+        cute.arch.fma_packed_f32x2(
+            (row_sum, 0.0),
+            (acc_scale, 0.0),
+            (values_rmem[0], values_rmem[1]),
+        ),
+        (values_rmem[2], values_rmem[3]),
+        (values_rmem[4], values_rmem[5]),
+        (values_rmem[6], values_rmem[7]),
+    ]
+    for i in cutlass.range_constexpr(8, n, 8):
+        local_sum[0] = _add_packed_f32x2(
+            local_sum[0], (values_rmem[i], values_rmem[i + 1])
+        )
+        local_sum[1] = _add_packed_f32x2(
+            local_sum[1], (values_rmem[i + 2], values_rmem[i + 3])
+        )
+        local_sum[2] = _add_packed_f32x2(
+            local_sum[2], (values_rmem[i + 4], values_rmem[i + 5])
+        )
+        local_sum[3] = _add_packed_f32x2(
+            local_sum[3], (values_rmem[i + 6], values_rmem[i + 7])
+        )
+    local_sum[0] = _add_packed_f32x2(local_sum[0], local_sum[1])
+    local_sum[2] = _add_packed_f32x2(local_sum[2], local_sum[3])
+    local_sum[0] = _add_packed_f32x2(local_sum[0], local_sum[2])
+    sum_lo, sum_hi = local_sum[0]
+    return Float32(sum_lo) + Float32(sum_hi)
+
+
+@dataclass
+class ResidentSoftmaxState:
+    """Register-backed online-softmax state for a causal resident lowering."""
+
+    scale_log2: Float32
+    row_max: cute.Tensor
+    row_sum: cute.Tensor
+    rescale_threshold: cutlass.Constexpr[float] = 0.0
+
+    @staticmethod
+    def create(
+        scale_log2: Float32,
+        rescale_threshold: cutlass.Constexpr[float] = 0.0,
+    ) -> "ResidentSoftmaxState":
+        return ResidentSoftmaxState(
+            scale_log2,
+            cute.make_rmem_tensor(1, Float32),
+            cute.make_rmem_tensor(1, Float32),
+            rescale_threshold,
+        )
+
+    def reset(self) -> None:
+        self.row_max.fill(Float32(-Float32.inf))
+        self.row_sum.fill(Float32(0.0))
+
+    @cute.jit
+    def _update_row_max_from_local(
+        self,
+        row_max_new: Float32,
+        is_first: cutlass.Constexpr[bool],
+    ) -> tuple[Float32, Float32]:
+        acc_scale: Float32
+        if cutlass.const_expr(is_first):
+            row_max_safe = row_max_new if row_max_new != -Float32.inf else Float32(0.0)
+            acc_scale = Float32(0.0)
+        else:
+            row_max_old = self.row_max[0]
+            assert isinstance(row_max_old, Float32)
+            row_max_safe = row_max_new if row_max_new != -Float32.inf else Float32(0.0)
+            acc_scale_log2 = (row_max_old - row_max_safe) * self.scale_log2
+            acc_scale = cute.math.exp2(acc_scale_log2, fastmath=True)
+            if cutlass.const_expr(self.rescale_threshold > 0.0):
+                if acc_scale_log2 >= -self.rescale_threshold:
+                    row_max_new = row_max_old
+                    row_max_safe = row_max_old
+                    acc_scale = Float32(1.0)
+        self.row_max[0] = row_max_new
+        return row_max_safe, acc_scale
+
+    @cute.jit
+    def update_row_max_precomputed(
+        self,
+        hw_row_max: Float32,
+        is_first: cutlass.Constexpr[bool],
+    ) -> tuple[Float32, Float32]:
+        row_max_new = (
+            hw_row_max
+            if cutlass.const_expr(is_first)
+            else cute.arch.fmax(hw_row_max, self.row_max[0])
+        )
+        return self._update_row_max_from_local(row_max_new, is_first)
+
+    @cute.jit
+    def update_row_max_masked(
+        self,
+        scores: cute.TensorSSA,
+        is_first: cutlass.Constexpr[bool],
+    ) -> tuple[Float32, Float32]:
+        row_max_new = _fmax_reduce_packed_ssa(
+            scores,
+            None if cutlass.const_expr(is_first) else self.row_max[0],
+        )
+        return self._update_row_max_from_local(row_max_new, is_first)
+
+    @cute.jit
+    def scale_subtract_rowmax(
+        self,
+        scores: cute.Tensor,
+        row_max: Float32,
+    ) -> None:
+        assert cute.size(scores) % 2 == 0
+        bias = Float32(0.0) - row_max * self.scale_log2
+        for i in cutlass.range(0, cute.size(scores), 2, unroll_full=True):
+            scores[i], scores[i + 1] = cute.arch.fma_packed_f32x2(
+                (scores[i], scores[i + 1]),
+                (self.scale_log2, self.scale_log2),
+                (bias, bias),
+            )
+
+    @cute.jit
+    def apply_exp2_convert(
+        self,
+        scores: cute.Tensor,
+        converted: cute.Tensor,
+    ) -> None:
+        assert cute.size(scores) % 32 == 0
+        score_fragments = cute.logical_divide(scores, cute.make_layout(32))
+        converted_fragments = cute.logical_divide(converted, cute.make_layout(32))
+        for fragment in cutlass.range_constexpr(cute.size(score_fragments, mode=[1])):
+            for i in cutlass.range_constexpr(0, 32, 2):
+                score_fragments[i, fragment] = cute.math.exp2(
+                    score_fragments[i, fragment], fastmath=True
+                )
+                score_fragments[i + 1, fragment] = cute.math.exp2(
+                    score_fragments[i + 1, fragment], fastmath=True
+                )
+            converted_fragments[None, fragment].store(
+                score_fragments[None, fragment].load().to(converted.element_type)
+            )
+
+    @cute.jit
+    def acquire_stats(
+        self,
+        stats_empty_ptr_stage: object,
+        stats_empty_phase: object,
+        wait_hint: int,
+    ) -> None:
+        mbar_spin_wait(stats_empty_ptr_stage, stats_empty_phase, wait_hint)
+
+    @cute.jit
+    def update_row_sum(
+        self,
+        scores_exp: cute.TensorSSA,
+        acc_scale: Float32,
+        is_first: cutlass.Constexpr[bool] = False,
+    ) -> None:
+        if cutlass.const_expr(is_first):
+            self.row_sum[0] = _fadd_reduce_packed_ssa(scores_exp)
+        else:
+            self.row_sum[0] = _fadd_reduce_packed_ssa_scaled(
+                scores_exp, self.row_sum[0], acc_scale
+            )
 
 
 # ===========================================================================

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -57,6 +57,7 @@ from .causal_range import TileLayout
 from .causal_range import prove_descending_causal_prefix_unmasked
 from .flash_policy import get_flash_target_policy
 from .flash_schedule import FlashScheduleSpec
+from .flash_schedule import FlashStatReleaseMapping
 from .flash_schedule import build_fa4_schedule
 from .flash_schedule import verify_flash_schedule
 from .flash_tuning import FlashPackedExp2Mode
@@ -3994,6 +3995,42 @@ def _flash_dense_resident_seed_matches(
     return policy is not None and _flash_config_matches_tuning_values(cfg, expected)
 
 
+def _flash_resident_softmax_config(
+    requested: FlashAttentionConfig,
+) -> FlashAttentionConfig:
+    """Return the effective config for the resident causal softmax lowering."""
+    return dataclasses.replace(
+        requested,
+        softmax_disc=False,
+        disc_pipe_depth=1,
+        exp2_impl="xu",
+        e2e_freq=8,
+        e2e_res=0,
+        e2e_schedule="xu",
+        masked_e2e_schedule="xu",
+        masked_e2e_freq=8,
+        masked_e2e_res=0,
+        e2e_offset=0,
+        e2e_offset0=0,
+        exp2_packet="1x1",
+        stat_transport="single",
+    )
+
+
+def _flash_causal_resident_native_seed_matches(
+    cfg: FlashAttentionConfig,
+    num_kv: int,
+    target_device_capability: tuple[int, int] | None,
+) -> bool:
+    """Return whether ``cfg`` is the validated causal resident seed shape."""
+    policy = get_flash_target_policy(target_device_capability).tuning.causal_policy(
+        num_kv
+    )
+    return policy is not None and _flash_config_matches_tuning_values(
+        cfg, _flash_causal_tuning_values(policy)
+    )
+
+
 def _flash_tuning_seed_config(
     tuning_policy: FlashTuningPolicy,
     head_dim: int,
@@ -5969,6 +6006,23 @@ def _flash_fa4_descending_causal_split_proof(
     )
 
 
+def _flash_fa4_causal_split_equal_iteration_proof(
+    *,
+    split_range_proof: CausalRangeProof,
+    query_slots_per_cta: int,
+) -> CausalRangeProof:
+    """Prove that every split causal query slot executes the same KV count."""
+    if not split_range_proof.proven:
+        return CausalRangeProof(False, split_range_proof.reason)
+    if query_slots_per_cta != 2:
+        return CausalRangeProof(False, "FA4 resident path requires two query slots")
+    # For each query tile, the descending split executes ``num_kv - m_tile``
+    # masked iterations followed by ``m_tile`` unmasked iterations.  The range
+    # proof guarantees both bounds describe the same complete KV interval, so
+    # their sum is exactly ``num_kv`` for both resident query slots.
+    return CausalRangeProof(True, "masked and unmasked loop bounds sum to num_kv")
+
+
 def _flash_runtime_range_header(loop_var: str, loop_bound: str) -> str:
     """Emit a runtime CuTe loop header; causal splitting must not unroll it."""
     return f"for {loop_var} in cutlass.range({loop_bound}, unroll=1):"
@@ -7393,6 +7447,10 @@ def emit_flash_fa4_device_body(
         num_kv_tiles=num_kv,
         score_plan=score_plan,
     )
+    causal_split_equal_iteration_proof = _flash_fa4_causal_split_equal_iteration_proof(
+        split_range_proof=causal_split_proof,
+        query_slots_per_cta=q_stage,
+    )
     dense_tuning = tuning_policy.dense_policy(num_kv)
     probability_log2_shift = (
         dense_tuning.probability_log2_shift if dense_tuning is not None else 0
@@ -7430,9 +7488,57 @@ def emit_flash_fa4_device_body(
                 "unsupported dense resident softmax lowering family: "
                 f"{dense_softmax_family!r}"
             )
+    causal_tuning = tuning_policy.causal_policy(num_kv)
+    use_causal_resident_native = (
+        causal_tuning is not None
+        and _flash_causal_resident_native_seed_matches(
+            cfg, num_kv, target_device_capability
+        )
+        and use_tmem_row_reduce
+        and is_causal
+        and not has_lse
+        and cfg.pipeline_family == "fa4"
+        and cfg.q_tile_count == 2
+        and not cfg.use_2cta_instrs
+        and not cfg.separate_kv_rings
+        and cfg.causal_loop_split
+        and causal_desc_kv
+        and causal_split_proof.proven
+        and causal_split_equal_iteration_proof.proven
+        and cfg.p_store_repetition == 16
+        and cfg.s_load_repetition == 32
+        and cfg.split_p_arrive
+        and cfg.rescale_threshold > 0.0
+        and score_plan.modifier_kinds == (CAUSAL_MASK_KIND,)
+    )
+    use_causal_resident_value_graph = False
+    use_causal_stateful_softmax = False
+    use_stage_local_stat_handoff = False
+    requested_cfg = cfg
+    if use_causal_resident_native:
+        assert causal_tuning is not None
+        resident_softmax_family = causal_tuning.softmax_lowering
+        if resident_softmax_family is FlashSoftmaxLowering.STANDARD:
+            pass
+        elif resident_softmax_family is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH:
+            use_causal_resident_value_graph = True
+        elif resident_softmax_family is FlashSoftmaxLowering.STATEFUL:
+            use_causal_stateful_softmax = True
+            use_stage_local_stat_handoff = True
+        else:
+            raise AssertionError(
+                "unsupported resident softmax lowering family: "
+                f"{resident_softmax_family!r}"
+            )
+    if use_causal_resident_native:
+        # Use the architecture-selected resident softmax lowering only for the
+        # validated rank-0 schedule. Other manual/autotuned configs retain their
+        # explicit exp2, disc, and statistics choices.
+        cfg = _flash_resident_softmax_config(requested_cfg)
     use_whole_row_tmem_reduce = (
         use_tmem_row_reduce and not is_causal and not cfg.softmax_disc
     )
+    use_causal_resident_ldred = use_causal_resident_native and use_tmem_row_reduce
     persistent = cfg.persistent
     use_tensor_4d_tma = (
         cfg.tensor_4d_tma
@@ -7484,8 +7590,10 @@ def emit_flash_fa4_device_body(
     # stage's slot. Unsupported schedules retain the conservative handoff below.
     fa4_stat_pipeline = (
         fa4_stat_handoff
-        and not is_causal
-        and cfg.exp2_impl == "split"
+        and (
+            (not is_causal and cfg.exp2_impl == "split")
+            or (use_causal_resident_native and cfg.exp2_impl == "xu")
+        )
         and not cfg.softmax_disc
         and cfg.rescale_threshold > 0.0
         and (
@@ -7505,6 +7613,9 @@ def emit_flash_fa4_device_body(
     )
     if dense_resident_value_graph_candidate:
         assert use_dense_resident_value_graph
+    if use_stage_local_stat_handoff:
+        assert use_causal_stateful_softmax
+        assert acknowledged_stat_pipeline
     verified_shared_memory_bytes: int | None = None
     if separate_kv_rings:
         assert not use_cga2_local_cta
@@ -7560,6 +7671,31 @@ def emit_flash_fa4_device_body(
         )
         kv_stage = verified_schedule.spec.kv_depth
         verified_shared_memory_bytes = verified_schedule.schedule.shared_memory_bytes
+    elif use_causal_resident_native:
+        assert causal_split_equal_iteration_proof.proven
+        verify_flash_schedule(
+            build_fa4_schedule(
+                FlashScheduleSpec(
+                    head_dim=head_dim,
+                    kv_depth=kv_stage,
+                    query_slots_per_cta=q_stage,
+                    causal=True,
+                    persistent=False,
+                    stage_output=cfg.epi_tma or cfg.epi_stg,
+                    split_p_arrive=cfg.split_p_arrive,
+                    stat_depth=1,
+                    pipelined_stat_handoff=True,
+                    stat_release_mapping=(
+                        FlashStatReleaseMapping.SAME_SLOT
+                        if use_stage_local_stat_handoff
+                        else FlashStatReleaseMapping.CROSS_SLOT
+                    ),
+                    query_slots_have_equal_kv_iterations=(
+                        causal_split_equal_iteration_proof.proven
+                    ),
+                )
+            )
+        )
     use_local_tma_partition = (
         cfg.local_tma_partition
         and persistent
@@ -7600,7 +7736,7 @@ def emit_flash_fa4_device_body(
         else:
             assert use_2cta_instrs
             assert not cfg.softmax_disc
-    sp_whole_row_sum = (
+    sp_whole_row_sum = use_causal_resident_native or (
         _FLASH_DENSE_HD64_VERY_LONG_MIN_KV <= num_kv <= 2048
         and not is_causal
         and hd == 64
@@ -8110,7 +8246,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     tLDRedtS0 = flash_thr_ldred0.partition_S(tStS0)
     tLDRedtS1 = flash_thr_ldred1.partition_S(tStS1)
 """
-        if use_tmem_row_reduce and cfg.softmax_disc
+        if use_tmem_row_reduce and (cfg.softmax_disc or use_causal_resident_ldred)
         else ""
     )
     tmem_softmax_setup = (
@@ -8173,13 +8309,14 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
         and not has_lse
         and not score_plan.modifiers
     )
+    policy_stage_local_softmax_setup = use_causal_stateful_softmax
     stage_local_softmax_setup = (
-        _flash_bool_env(
+        policy_stage_local_softmax_setup
+        or _flash_bool_env(
             "HELION_CUTE_FLASH_STAGE_LOCAL_SOFTMAX_SETUP",
             default_stage_local_softmax_setup,
         )
-        and not mixed_p_store
-    )
+    ) and not mixed_p_store
 
     def _tmem_softmax_setup_stage(stage: str) -> str:
         ptr_expr = "flash_tmem_ptr" if stage == "0" else "flash_tmem_ptr + 128"
@@ -8212,7 +8349,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     flash_thr_ldred{stage} = flash_tiled_ldred{stage}.get_slice(flash_local_tidx)
     tLDRedtS{stage} = flash_thr_ldred{stage}.partition_S(tStS{stage})
 """
-            if use_tmem_row_reduce and cfg.softmax_disc
+            if use_tmem_row_reduce and (cfg.softmax_disc or use_causal_resident_ldred)
             else ""
         )
         return f"""    _helion_flash_rt.named_barrier_wait_unaligned(
@@ -9322,7 +9459,12 @@ if warp_idx == 15:
             rowsum_producer_acquire = f"""        _helion_flash_rt.mbar_spin_wait(
             {corr_empty_ptr} + {corr_prod_index}, flash_s_corr_prod_phase, {cfg.wait_hint})
 """
-        corr_publish_rowsum = f"""{rowsum_producer_acquire}        {_scale_slot_expr(corr_prod_index, stage)} = flash_row_sum
+        softmax_row_sum_expr = (
+            "flash_softmax.row_sum[0]"
+            if use_causal_stateful_softmax
+            else "flash_row_sum"
+        )
+        corr_publish_rowsum = f"""{rowsum_producer_acquire}        {_scale_slot_expr(corr_prod_index, stage)} = {softmax_row_sum_expr}
         _helion_flash_rt.named_barrier_arrive_unaligned(
             {3 + int(stage) * 4} + warp_idx % 4, 64)
 {lse_store}
@@ -9546,20 +9688,29 @@ if warp_idx == 15:
             cute.arch.fence_view_async_tmem_store()
             _helion_flash_rt.mbarrier_arrive(
                 flash_pfor_ptr + {stage}{pfor_peer_arg})"""
-        if use_dense_resident_value_graph:
+        use_resident_value_graph = (
+            use_causal_resident_value_graph or use_dense_resident_value_graph
+        )
+        if use_resident_value_graph:
             assert split_p_arrive
             assert not mixed_p_store
+            resident_pfor_args = (
+                f""",
+                pfor_peer_cta_rank=cutlass.Int32(0),
+                pfor_self_cta_rank={pfor_self_cta_rank}"""
+                if use_dense_resident_value_graph
+                else ""
+            )
             sp_exp_block = f"""            flash_row_sum = _helion_flash_rt.resident_softmax_value_graph(
                 tLDrS, {st}, {stt}, tSTcS, _flash_scale_log2,
                 flash_minus_max_scale, flash_pfor_ptr + {stage},
                 flash_pfor2_ptr + {stage}, flash_P_STORE_SPLIT,
                 flash_P_STORE_CHUNKS, {corr_empty_ptr} + 0,
                 flash_s_corr_prod_phase, flash_row_sum * flash_alpha,
-                {cfg.wait_hint}, pfor_peer_cta_rank=cutlass.Int32(0),
-                pfor_self_cta_rank={pfor_self_cta_rank})"""
+                {cfg.wait_hint}{resident_pfor_args})"""
             sp_p_store_block = ""
             sp_corr_publish_alpha = ""
-        elif cfg.exp2_impl == "split":
+        elif cfg.exp2_impl == "split" or use_causal_resident_native:
             sp_e2e_offset = (
                 "0"
                 if exp2_codegen.e2e_res == 0
@@ -9627,11 +9778,10 @@ if warp_idx == 15:
                 sp_pass2_args.append("degree2=True")
             if use_packed_f16x2_xu:
                 sp_pass2_args.append("f16x2_xu=True")
-            sp_exp_block = (
-                f"            flash_p_sum = _helion_flash_rt.{sp_pass2_name}("
-                + ", ".join(sp_pass2_args)
-                + ")"
+            sp_pass2_call = (
+                f"_helion_flash_rt.{sp_pass2_name}(" + ", ".join(sp_pass2_args) + ")"
             )
+            sp_exp_block = f"            flash_p_sum = {sp_pass2_call}"
             sp_p_store_block = ""
             sp_corr_publish_alpha = ""
         else:
@@ -9692,6 +9842,202 @@ if warp_idx == 15:
             else "            flash_row_max = "
             "_helion_flash_rt.fmax_reduce_packed(tLDrS, flash_row_max)"
         )
+        if use_causal_resident_native:
+            assert use_causal_resident_ldred
+            assert acknowledged_stat_pipeline
+            assert cfg.exp2_impl == "xu"
+
+            def _format_resident_causal_loop(
+                loop_var: str,
+                loop_bound: str,
+                actual_kv: str,
+                not_first: str,
+                score_load: str,
+                rowmax_update: str,
+                *,
+                publish_rowsum: bool,
+                known_not_first: bool = False,
+            ) -> str:
+                pin_condition = (
+                    f"flash_acc_log >= -{cfg.rescale_threshold}"
+                    if known_not_first
+                    else f"({not_first}) & (flash_acc_log >= -{cfg.rescale_threshold})"
+                )
+                alpha_pre = f"""            flash_acc_log = _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe)
+            flash_alpha = cute.math.exp2(flash_acc_log, fastmath=True)
+            if {pin_condition}:
+                flash_row_max = flash_old_row_max
+                flash_row_max_safe = flash_old_row_max
+                flash_alpha = cutlass.Float32(1.0)
+            flash_minus_max_scale = (0.0 - flash_row_max_safe) * _flash_scale_log2"""
+                if cfg.skip_rescale_stats:
+                    alpha_publish = ""
+                elif known_not_first:
+                    alpha_publish = _corr_publish_alpha("            ")
+                else:
+                    alpha_publish = f"""            if {not_first}:
+{_corr_publish_alpha("                ")}
+            else:
+                _helion_flash_rt.named_barrier_arrive_unaligned(
+                    {3 + int(stage) * 4} + warp_idx % 4, 64)"""
+                rowsum_publish = final_corr_publish_rowsum if publish_rowsum else ""
+                loop_header = _flash_runtime_range_header(loop_var, loop_bound)
+                post_p_stat_acquire = (
+                    ""
+                    if use_causal_resident_value_graph
+                    else fa4_post_p_stat_acquire.rstrip()
+                )
+                row_sum_update = (
+                    "            flash_s_corr_prod_phase ^= 1"
+                    if use_causal_resident_value_graph
+                    else "            flash_row_sum = "
+                    "flash_row_sum * flash_alpha + flash_p_sum"
+                )
+                return f"""        {loop_header}{actual_kv}
+            {_softmax_wait_s_ready(stage)}
+            flash_s_full_phase ^= 1
+            flash_old_row_max = flash_row_max
+            tLDrS = cute.make_rmem_tensor(tLDcS.shape, cutlass.Float32)
+{score_load}
+{rowmax_update}
+            flash_row_max_safe = flash_row_max
+            if flash_row_max == -cutlass.Float32.inf:
+                flash_row_max_safe = cutlass.Float32(0.0)
+{alpha_pre}
+{alpha_publish}
+{sp_exp_block}
+{post_p_stat_acquire}
+{row_sum_update}
+{rowsum_publish}"""
+
+            masked_score_load = f"""            cute.copy({ld}, {ldt}, tLDrS)
+            cute.arch.fence_view_async_tmem_load(){score_transform}"""
+            masked_rowmax = (
+                "            flash_row_max = "
+                "_helion_flash_rt.fmax_reduce_packed(tLDrS, flash_row_max)"
+            )
+            unmasked_score_load = f"""            tLDrS_red = cute.make_rmem_tensor(
+                ((1, 1), *tLDrS.shape[1:]), cutlass.Float32)
+            cute.copy(
+                flash_tiled_ldred{stage}, tLDRedtS{stage}, (tLDrS, tLDrS_red))
+            cute.arch.fence_view_async_tmem_load()
+            flash_hw_row_max = cutlass.Float32(-cutlass.Float32.inf)
+            for flash_red_i in cutlass.range_constexpr(cute.size(tLDrS_red.shape)):
+                flash_hw_row_max = cute.arch.fmax(
+                    flash_hw_row_max, tLDrS_red[flash_red_i])"""
+            unmasked_rowmax = (
+                "            flash_row_max = "
+                "cute.arch.fmax(flash_row_max, flash_hw_row_max)"
+            )
+            if use_causal_stateful_softmax:
+                assert not use_causal_resident_value_graph
+
+                def _format_stateful_softmax_step(
+                    score_load: str,
+                    rowmax_call: str,
+                    *,
+                    indent: str,
+                    is_first: bool,
+                ) -> str:
+                    alpha_publish = (
+                        f"""{indent}_helion_flash_rt.named_barrier_arrive_unaligned(
+{indent}    {3 + int(stage) * 4} + warp_idx % 4, 64)"""
+                        if is_first
+                        else _corr_publish_alpha(indent)
+                    )
+                    row_sum_first_arg = ", True" if is_first else ""
+                    score_load_at_indent = textwrap.indent(
+                        textwrap.dedent(score_load), indent
+                    )
+                    return f"""{indent}{_softmax_wait_s_ready(stage)}
+{indent}flash_s_full_phase ^= 1
+{indent}tLDrS = cute.make_rmem_tensor(tLDcS.shape, cutlass.Float32)
+{score_load_at_indent}
+{indent}flash_row_max_safe, flash_alpha = flash_softmax.{rowmax_call}
+{alpha_publish}
+{indent}flash_softmax.scale_subtract_rowmax(tLDrS, flash_row_max_safe)
+{indent}flash_tSrP_f32 = cute.make_rmem_tensor(tSTcS.shape, cutlass.Float32)
+{indent}flash_tSrP = cute.make_tensor(
+{indent}    cute.recast_ptr(flash_tSrP_f32.iterator, dtype=cutlass.Float16),
+{indent}    tLDrS.layout)
+{indent}flash_softmax.apply_exp2_convert(tLDrS, flash_tSrP)
+{indent}for flash_ci in cutlass.range_constexpr(flash_P_STORE_SPLIT):
+{indent}    cute.copy({st}, flash_tSrP_f32[None, None, flash_ci],
+{indent}              {stt}[None, None, flash_ci])
+{indent}cute.arch.fence_view_async_tmem_store()
+{indent}_helion_flash_rt.mbarrier_arrive(flash_pfor_ptr + {stage})
+{indent}for flash_ci in cutlass.range_constexpr(
+{indent}        flash_P_STORE_SPLIT, flash_P_STORE_CHUNKS):
+{indent}    cute.copy({st}, flash_tSrP_f32[None, None, flash_ci],
+{indent}              {stt}[None, None, flash_ci])
+{indent}cute.arch.fence_view_async_tmem_store()
+{indent}_helion_flash_rt.mbarrier_arrive(flash_pfor2_ptr + {stage})
+{indent}flash_softmax.acquire_stats(
+{indent}    {corr_empty_ptr} + 0, flash_s_corr_prod_phase, {cfg.wait_hint})
+{indent}flash_softmax.update_row_sum(
+{indent}    tLDrS.load(), flash_alpha{row_sum_first_arg})
+{indent}flash_s_corr_prod_phase ^= 1"""
+
+                first_step = _format_stateful_softmax_step(
+                    masked_score_load,
+                    "update_row_max_masked(tLDrS.load(), True)",
+                    indent="        ",
+                    is_first=True,
+                )
+                masked_tail_step = _format_stateful_softmax_step(
+                    masked_score_load,
+                    "update_row_max_masked(tLDrS.load(), False)",
+                    indent="            ",
+                    is_first=False,
+                )
+                unmasked_step = _format_stateful_softmax_step(
+                    unmasked_score_load,
+                    "update_row_max_precomputed(flash_hw_row_max, False)",
+                    indent="            ",
+                    is_first=False,
+                )
+                return f"""{fa4_entry_stat_acquire}        flash_softmax = _helion_flash_rt.ResidentSoftmaxState.create(
+            _flash_scale_log2, rescale_threshold={cfg.rescale_threshold})
+        flash_softmax.reset()
+        flash_kv = {kv_loop_bound} - cutlass.Int32(1)
+{first_step}
+        for flash_kv_mask_iter in cutlass.range(
+                {kv_loop_bound} - flash_m_tile{stage} - cutlass.Int32(1), unroll=1):
+            flash_kv = {kv_loop_bound} - cutlass.Int32(2) - flash_kv_mask_iter
+{masked_tail_step}
+        for flash_kv_unmask_iter in cutlass.range(flash_m_tile{stage}, unroll=1):
+            flash_kv = flash_m_tile{stage} - cutlass.Int32(1) - flash_kv_unmask_iter
+{unmasked_step}
+{final_corr_publish_rowsum}"""
+            masked_loop = _format_resident_causal_loop(
+                "flash_kv_mask_iter",
+                f"{kv_loop_bound} - flash_m_tile{stage}",
+                (
+                    f"\n            flash_kv = {kv_loop_bound} - "
+                    "cutlass.Int32(1) - flash_kv_mask_iter"
+                ),
+                "flash_kv_mask_iter != 0",
+                masked_score_load,
+                masked_rowmax,
+                publish_rowsum=False,
+            )
+            unmasked_loop = _format_resident_causal_loop(
+                "flash_kv_unmask_iter",
+                f"flash_m_tile{stage}",
+                (
+                    f"\n            flash_kv = flash_m_tile{stage} - "
+                    "cutlass.Int32(1) - flash_kv_unmask_iter"
+                ),
+                "flash_kv_unmask_iter >= cutlass.Int32(0)",
+                unmasked_score_load,
+                unmasked_rowmax,
+                publish_rowsum=True,
+                known_not_first=True,
+            )
+            return f"""{fa4_entry_stat_acquire}        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
+        flash_row_sum = cutlass.Float32(0.0)
+{masked_loop}
+{unmasked_loop}"""
         post_p_stat_acquire = (
             "" if use_dense_resident_value_graph else fa4_post_p_stat_acquire.rstrip()
         )
@@ -10008,23 +10354,25 @@ if warp_idx == 15:
     )
     corr_empty0_late = (
         ""
-        if not is_causal
+        if not is_causal or fa4_stat_pipeline
         else "            cute.arch.mbarrier_arrive("
         "flash_s0_corr_empty_ptr + flash_s_corr_cons_index)"
     )
     corr_empty1_late = (
         ""
-        if not is_causal
+        if not is_causal or fa4_stat_pipeline
         else "            cute.arch.mbarrier_arrive("
         "flash_s1_corr_empty_ptr + flash_s_corr_cons_index)"
     )
     corr_cross_release0 = (
-        "            cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)"
+        "            cute.arch.mbarrier_arrive("
+        f"flash_s{'0' if use_stage_local_stat_handoff else '1'}_corr_empty_ptr + 0)"
         if acknowledged_stat_pipeline
         else ""
     )
     corr_cross_release1 = (
-        "            cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)"
+        "            cute.arch.mbarrier_arrive("
+        f"flash_s{'1' if use_stage_local_stat_handoff else '0'}_corr_empty_ptr + 0)"
         if acknowledged_stat_pipeline
         else ""
     )
@@ -10061,14 +10409,19 @@ if warp_idx == 15:
             3 + warp_idx % 4, 64)
         cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)
         _helion_flash_rt.named_barrier_wait_unaligned(
-            7 + warp_idx % 4, 64)
-"""
+            7 + warp_idx % 4, 64)"""
+        + (
+            "\n        cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)"
+            if use_stage_local_stat_handoff
+            else ""
+        )
+        + "\n"
         if acknowledged_stat_pipeline
         else ""
     )
     corr_stat_release_held = (
         "        cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)\n"
-        if acknowledged_stat_pipeline
+        if acknowledged_stat_pipeline and not use_stage_local_stat_handoff
         else ""
     )
     corr_final_stat_release = (

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -20,6 +20,7 @@ from helion._compiler.cute.attention_plan import AttentionScoreModifier
 from helion._compiler.cute.attention_plan import AttentionScorePlan
 from helion._compiler.cute.attention_plan import causal_score_plan
 from helion._compiler.cute.attention_plan import dense_score_plan
+from helion._compiler.cute.causal_range import CausalRangeProof
 from helion._compiler.cute.flash_policy import get_flash_target_policy
 from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
 from helion._testing import DEVICE
@@ -166,6 +167,52 @@ def _hybrid_runtime_config() -> dict[str, object]:
     }
 
 
+def _emit_causal_resident_native_source(
+    *,
+    capability: tuple[int, int] = (10, 3),
+    has_lse: bool = False,
+    score_plan: AttentionScorePlan | None = None,
+    num_kv: int = 512,
+    config_overrides: dict[str, object] | None = None,
+) -> str:
+    if score_plan is None:
+        score_plan = causal_score_plan(64)
+    with patch.dict(os.environ, {}, clear=True):
+        seed = cute_flash.flash_attention_seed_config(
+            64,
+            num_kv,
+            dtype=torch.float16,
+            is_causal=True,
+            standard_causal_output=True,
+            target_device_capability=(10, 3),
+        )
+        assert seed is not None
+        manual_overrides = dict(seed.config)
+        if config_overrides is not None:
+            manual_overrides.update(config_overrides)
+        config = cute_flash.resolve_flash_config(
+            64,
+            num_kv,
+            manual_overrides,
+            dtype=torch.float16,
+            is_causal=True,
+        )
+    body = cute_flash.emit_flash_fa4_device_body(
+        cast("DeviceFunction", None),
+        head_dim=64,
+        num_kv=num_kv,
+        sequence_extent=num_kv * 128,
+        num_bh=1,
+        total_tiles=num_kv // 2,
+        cfg=config,
+        has_lse=has_lse,
+        io_dtype="cutlass.Float16",
+        score_plan=score_plan,
+        target_device_capability=capability,
+    )
+    return ast.unparse(ast.Module(body=body, type_ignores=[]))
+
+
 def _emit_dense_resident_value_graph_source(
     *,
     capability: tuple[int, int] = (10, 3),
@@ -211,6 +258,27 @@ def _emit_dense_resident_value_graph_source(
         target_device_capability=capability,
     )
     return ast.unparse(ast.Module(body=body, type_ignores=[]))
+
+
+def test_causal_split_equal_iteration_proof_is_explicit() -> None:
+    failed = cute_flash._flash_fa4_causal_split_equal_iteration_proof(
+        split_range_proof=CausalRangeProof(False, "range failed"),
+        query_slots_per_cta=2,
+    )
+    wrong_slots = cute_flash._flash_fa4_causal_split_equal_iteration_proof(
+        split_range_proof=CausalRangeProof(True, "range proven"),
+        query_slots_per_cta=1,
+    )
+    proven = cute_flash._flash_fa4_causal_split_equal_iteration_proof(
+        split_range_proof=CausalRangeProof(True, "range proven"),
+        query_slots_per_cta=2,
+    )
+
+    assert failed == CausalRangeProof(False, "range failed")
+    assert wrong_slots == CausalRangeProof(
+        False, "FA4 resident path requires two query slots"
+    )
+    assert proven.proven
 
 
 def test_degree2_polynomial_relative_error_bound() -> None:
@@ -606,6 +674,380 @@ def test_dense_probability_shift_fails_closed_before_fp16_overflow() -> None:
     assert "cutlass.Float32(16.0)" not in source
 
 
+def test_causal_resident_native_codegen_and_single_stat_protocol() -> None:
+    source = _emit_causal_resident_native_source()
+    module = ast.parse(source)
+
+    value_graph_calls = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "resident_softmax_value_graph"
+    ]
+    assert not value_graph_calls
+
+    assert "fa4_disc_exp_convert_store" not in source
+    assert "fa4_sp_exp_convert_store_whole_rowsum" not in source
+    assert "f16x2_xu=True" not in source
+    assert "flash_s_corr_prod_index" not in source
+    assert "flash_s_corr_cons_index" not in source
+    assert source.count("flash_s_corr_prod_phase = cutlass.Int32(1)") == 2
+    assert source.count("ResidentSoftmaxState.create") == 2
+    assert source.count("flash_softmax.reset()") == 2
+    assert source.count("update_row_max_masked(tLDrS.load(), True)") == 2
+    assert source.count("update_row_max_masked(tLDrS.load(), False)") == 2
+    assert source.count("update_row_max_precomputed(flash_hw_row_max, False)") == 2
+    assert source.count("flash_softmax.scale_subtract_rowmax") == 6
+    assert source.count("flash_softmax.apply_exp2_convert") == 6
+    assert source.count("flash_tSrP_f32 = cute.make_rmem_tensor") == 6
+    assert source.count("dtype=cutlass.Float16), tLDrS.layout") == 6
+    assert source.count("flash_softmax.acquire_stats") == 6
+    assert source.count("flash_softmax.update_row_sum") == 6
+    assert source.count("tLDrS.load(), flash_alpha, True") == 2
+    assert source.count("tLDrS.load(), flash_alpha)") == 4
+    assert source.count("for flash_kv_mask_iter") == 2
+    assert source.count("for flash_kv_unmask_iter") == 2
+    assert source.count("- flash_m_tile0 - cutlass.Int32(1)") == 1
+    assert source.count("- flash_m_tile1 - cutlass.Int32(1)") == 1
+
+    stage0_start = source.index("flash_s_corr_prod_phase = cutlass.Int32(1)")
+    stage1_start = source.index(
+        "flash_s_corr_prod_phase = cutlass.Int32(1)", stage0_start + 1
+    )
+    softmax0 = source[stage0_start:stage1_start]
+    stage0_block = source[
+        source.index("if warp_idx < 4:") : source.index(
+            "if (warp_idx >= 4) & (warp_idx < 8):"
+        )
+    ]
+    assert "flash_tiled_ld0" in stage0_block
+    assert "flash_tiled_ld1" not in stage0_block
+    masked_start = softmax0.index("for flash_kv_mask_iter")
+    unmasked_start = softmax0.index("for flash_kv_unmask_iter")
+    masked = softmax0[masked_start:unmasked_start]
+    unmasked = softmax0[unmasked_start:]
+    assert "causal_mask_t2r" in masked
+    assert "flash_tiled_ldred0" not in masked
+    assert "flash_tiled_ldred0" in unmasked
+    assert "causal_mask_t2r" not in unmasked
+
+    alpha_store = masked.index(
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_alpha"
+    )
+    alpha_ready = masked.index("named_barrier_arrive_unaligned", alpha_store)
+    scale_subtract = masked.index("flash_softmax.scale_subtract_rowmax", alpha_ready)
+    fresh_p = masked.index("flash_tSrP_f32 = cute.make_rmem_tensor", scale_subtract)
+    early_pack = masked.index("flash_softmax.apply_exp2_convert", fresh_p)
+    stats_acquire = masked.index("flash_softmax.acquire_stats", early_pack)
+    row_sum = masked.index("flash_softmax.update_row_sum", stats_acquire)
+    phase_advance = masked.index("flash_s_corr_prod_phase ^= 1", row_sum)
+    assert (
+        alpha_store
+        < alpha_ready
+        < scale_subtract
+        < fresh_p
+        < early_pack
+        < stats_acquire
+        < row_sum
+        < phase_advance
+    )
+    assert "flash_row_sum * flash_alpha + flash_p_sum" not in masked
+    assert (
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_softmax.row_sum[0]"
+        in softmax0
+    )
+
+    correction = source[source.index("(warp_idx >= 8) & (warp_idx < 12):") :]
+    assert "flash_a0 = flash_scale_t[0 * 128 + flash_local_tidx]" in correction
+    assert "flash_a1 = flash_scale_t[1 * 128 + flash_local_tidx]" in correction
+    assert "cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)" in correction
+    assert "cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)" in correction
+
+
+def test_causal_resident_stage_local_stat_protocol() -> None:
+    source = _emit_causal_resident_native_source()
+    correction = source[source.index("(warp_idx >= 8) & (warp_idx < 12):") :]
+    ready0 = "_helion_flash_rt.named_barrier_wait_unaligned(3 + warp_idx % 4, 64)"
+    ready1 = "_helion_flash_rt.named_barrier_wait_unaligned(7 + warp_idx % 4, 64)"
+    empty0 = "cute.arch.mbarrier_arrive(flash_s0_corr_empty_ptr + 0)"
+    empty1 = "cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)"
+
+    dummy_ready0 = correction.index(ready0)
+    dummy_empty0 = correction.index(empty0, dummy_ready0)
+    dummy_ready1 = correction.index(ready1, dummy_empty0)
+    dummy_empty1 = correction.index(empty1, dummy_ready1)
+    steady_loop = correction.index("for flash_kv", dummy_empty1)
+    alpha0 = correction.index("flash_a0 =", steady_loop)
+    pfor0 = correction.index("flash_pfor_ptr + 0", alpha0)
+    steady_empty0 = correction.index(empty0, pfor0)
+    alpha1 = correction.index("flash_a1 =", steady_empty0)
+    pfor1 = correction.index("flash_pfor_ptr + 1", alpha1)
+    steady_empty1 = correction.index(empty1, pfor1)
+    final_ready0 = correction.index(ready0, steady_empty1)
+
+    assert (
+        dummy_ready0
+        < dummy_empty0
+        < dummy_ready1
+        < dummy_empty1
+        < steady_loop
+        < alpha0
+        < pfor0
+        < steady_empty0
+        < alpha1
+        < pfor1
+        < steady_empty1
+        < final_ready0
+    )
+
+    cross_source = _emit_causal_resident_native_source(num_kv=1024)
+    cross = cross_source[cross_source.index("(warp_idx >= 8) & (warp_idx < 12):") :]
+    cross_loop = cross.index("for flash_kv")
+    cross_alpha0 = cross.index("flash_a0 =", cross_loop)
+    cross_pfor0 = cross.index("flash_pfor_ptr + 0", cross_alpha0)
+    cross_empty1 = cross.index(empty1, cross_pfor0)
+    cross_alpha1 = cross.index("flash_a1 =", cross_empty1)
+    cross_pfor1 = cross.index("flash_pfor_ptr + 1", cross_alpha1)
+    cross_empty0 = cross.index(empty0, cross_pfor1)
+    held_empty1 = cross.index(empty1, cross_empty0)
+    cross_final_ready0 = cross.index(ready0, held_empty1)
+    assert (
+        cross_alpha0
+        < cross_pfor0
+        < cross_empty1
+        < cross_alpha1
+        < cross_pfor1
+        < cross_empty0
+        < held_empty1
+        < cross_final_ready0
+    )
+
+
+def test_causal_resident_softmax_lowering_dispatch_is_exhaustive() -> None:
+    policy = get_flash_target_policy((10, 3)).tuning
+    shape_policy = policy.causal_policy(512)
+    assert shape_policy is not None
+
+    standard_policy = dataclasses.replace(
+        policy,
+        causal_policies=(
+            dataclasses.replace(
+                shape_policy,
+                softmax_lowering=FlashSoftmaxLowering.STANDARD,
+            ),
+            *policy.causal_policies[1:],
+        ),
+    )
+    with patch.object(
+        cute_flash,
+        "get_flash_target_policy",
+        return_value=dataclasses.replace(
+            get_flash_target_policy((10, 3)), tuning=standard_policy
+        ),
+    ):
+        standard_source = _emit_causal_resident_native_source()
+    assert "resident_softmax_value_graph" not in standard_source
+    assert "fa4_sp_exp_convert_store_whole_rowsum" in standard_source
+
+    value_graph_policy = dataclasses.replace(
+        policy,
+        causal_policies=(
+            dataclasses.replace(
+                shape_policy,
+                softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            ),
+            *policy.causal_policies[1:],
+        ),
+    )
+    with patch.object(
+        cute_flash,
+        "get_flash_target_policy",
+        return_value=dataclasses.replace(
+            get_flash_target_policy((10, 3)), tuning=value_graph_policy
+        ),
+    ):
+        value_graph_source = _emit_causal_resident_native_source()
+    assert "ResidentSoftmaxState.create" not in value_graph_source
+    assert "resident_softmax_value_graph" in value_graph_source
+
+
+@pytest.mark.parametrize(("num_kv", "kv_stage"), ((1024, 3), (2048, 3), (4096, 6)))
+def test_causal_resident_native_additional_stage_codegen(
+    num_kv: int, kv_stage: int
+) -> None:
+    source = _emit_causal_resident_native_source(num_kv=num_kv)
+
+    assert f"num_stages={kv_stage}" in source
+    assert "resident_softmax_value_graph" in source
+    assert "fa4_sp_exp_convert_store_whole_rowsum" not in source
+    assert "fa4_disc_exp_convert_store" not in source
+    assert source.count("for flash_kv_mask_iter") == 2
+    assert source.count("for flash_kv_unmask_iter") == 2
+    assert source.count("flash_s_corr_prod_phase = cutlass.Int32(1)") == 2
+
+
+def test_causal_resident_native_gate_preserves_fallbacks() -> None:
+    base_plan = causal_score_plan(64)
+    modified_plan = dataclasses.replace(
+        base_plan,
+        modifiers=(
+            AttentionScoreModifier(SOFTCAP_KIND, value_log2=2.0),
+            *base_plan.modifiers,
+        ),
+    )
+    fallback_sources = (
+        _emit_causal_resident_native_source(capability=(10, 0)),
+        _emit_causal_resident_native_source(capability=(10, 4)),
+        _emit_causal_resident_native_source(has_lse=True),
+        _emit_causal_resident_native_source(score_plan=modified_plan),
+        _emit_causal_resident_native_source(num_kv=256),
+        _emit_causal_resident_native_source(
+            config_overrides={cute_flash.FLASH_EXP2_PACKET_KEY: "4x1"}
+        ),
+        _emit_causal_resident_native_source(
+            config_overrides={cute_flash.FLASH_SOFTMAX_REGS_KEY: 176}
+        ),
+    )
+    for fallback_source in fallback_sources:
+        assert "fa4_disc_exp_convert_store" in fallback_source
+        assert "resident_softmax_value_graph" not in fallback_source
+
+
+@onlyBackends(["cute"])
+def test_causal_resident_native_matches_sdpa_without_deadlock() -> None:
+    capability = torch.cuda.get_device_capability()
+    target_policy = get_flash_target_policy(capability)
+    hardware = target_policy.hardware
+    tuning = target_policy.tuning
+    causal_policy = tuning.causal_policy(512)
+    if (
+        not hardware.supports_tmem_row_reduce
+        or causal_policy is None
+        or causal_policy.softmax_lowering is not FlashSoftmaxLowering.STATEFUL
+    ):
+        pytest.skip("causal resident native softmax is unsupported on this target")
+
+    torch.manual_seed(109)
+    shape = (1, 1, 65_536, 64)
+    q = torch.randn(shape, dtype=torch.float16, device=DEVICE)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    seed = cute_flash.flash_attention_seed_config(
+        64,
+        512,
+        is_causal=True,
+        standard_causal_output=True,
+        target_device_capability=capability,
+    )
+    assert seed is not None
+    config = helion.Config(**seed.config)
+    bound = _causal_attention_output.bind((q, k, v))
+    code = bound.to_triton_code(config)
+    compiled = bound.compile_config(config)
+
+    assert "ResidentSoftmaxState.create" in code
+    assert "resident_softmax_value_graph" not in code
+    assert "flash_softmax.update_row_sum(tLDrS.load(), flash_alpha)" in code
+    assert "fa4_sp_exp_convert_store_whole_rowsum" not in code
+    assert "fa4_disc_exp_convert_store" not in code
+    assert "flash_s_corr_prod_index" not in code
+    assert "f16x2_xu=True" not in code
+
+    out = compiled(q, k, v)
+    for _ in range(31):
+        repeated = compiled(q, k, v)
+    torch.cuda.synchronize()
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+    assert torch.equal(out, repeated)
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, expected, atol=0.01, rtol=0.02)
+
+
+@pytest.mark.parametrize(
+    ("num_kv", "repeat_count"),
+    (
+        (1024, 31),
+        (4096, 3),
+    ),
+)
+@onlyBackends(["cute"])
+def test_causal_resident_cross_stage_matches_sdpa_without_deadlock(
+    num_kv: int, repeat_count: int
+) -> None:
+    capability = torch.cuda.get_device_capability()
+    policy = get_flash_target_policy(capability).tuning
+    shape_policy = policy.causal_policy(num_kv)
+    if shape_policy is None:
+        pytest.skip("causal resident native softmax is unsupported on this target")
+    assert shape_policy.softmax_lowering is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+
+    torch.manual_seed(109 + num_kv)
+    sequence_length = num_kv * 128
+    shape = (1, 1, sequence_length, 64)
+    q = torch.randn(shape, dtype=torch.float16, device=DEVICE)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    seed = cute_flash.flash_attention_seed_config(
+        64,
+        num_kv,
+        dtype=torch.float16,
+        is_causal=True,
+        standard_causal_output=True,
+        target_device_capability=capability,
+    )
+    assert seed is not None
+    config = helion.Config(**seed.config)
+    bound = _causal_attention_output.bind((q, k, v))
+    code = bound.to_triton_code(config)
+    compiled = bound.compile_config(config)
+
+    assert "resident_softmax_value_graph" in code
+    assert "fa4_sp_exp_convert_store_whole_rowsum" not in code
+    assert "fa4_disc_exp_convert_store" not in code
+
+    out = compiled(q, k, v)
+    repeated = out
+    for _ in range(repeat_count):
+        repeated = compiled(q, k, v)
+    torch.cuda.synchronize()
+    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+    assert torch.equal(out, repeated)
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, expected, atol=0.01, rtol=0.02)
+
+
+def test_causal_target_lowering_match_is_environment_independent() -> None:
+    causal_seed = cute_flash.flash_attention_seed_config(
+        64,
+        512,
+        is_causal=True,
+        standard_causal_output=True,
+        target_device_capability=(10, 3),
+    )
+    assert causal_seed is not None
+    causal_cfg = cute_flash.resolve_flash_config(
+        64,
+        512,
+        causal_seed.config,
+        is_causal=True,
+    )
+
+    with patch.dict(os.environ, {"HELION_CUTE_FLASH_WAIT_HINT": "0"}):
+        assert cute_flash._flash_causal_resident_native_seed_matches(
+            causal_cfg, 512, (10, 3)
+        )
+
+    effective = cute_flash._flash_resident_softmax_config(causal_cfg)
+    assert causal_cfg.exp2_packet == _DEG2_PACKET
+    assert causal_cfg.stat_transport == "ring2"
+    assert effective.exp2_packet == "1x1"
+    assert effective.stat_transport == "single"
+    assert effective.exp2_impl == "xu"
+
+
 def test_hybrid_packet_uses_degree1_only_for_unmasked_pass2() -> None:
     with patch.dict(os.environ, {}, clear=True):
         config = cute_flash.resolve_flash_config(
@@ -626,6 +1068,7 @@ def test_hybrid_packet_uses_degree1_only_for_unmasked_pass2() -> None:
         has_lse=False,
         io_dtype="cutlass.Float16",
         score_plan=causal_score_plan(64),
+        target_device_capability=(10, 3),
     )
     module = ast.Module(body=body, type_ignores=[])
     pass2_calls = [


### PR DESCRIPTION
Stacked PRs:
 * #3423
 * #3420
 * __->__#3419
 * #3418
 * #3417


--- --- ---

## Summary

Add the SM103 causal resident-softmax lowering, including explicit state and stage-local stat handoff.

- Use one resident-softmax state object for row max/sum and rescale state.
- Make the causal split-loop/equal-iteration proof explicit.
- Select the lowering through the target policy and preserve the generic fallback for unmatched configurations.
- Cover stage-local and cross-stage protocols, replay/deadlock behavior, dispatch exhaustiveness, and SDPA correctness.

Depends on #3418. This is PR 4/6.

## GB300 performance

Median-of-medians, FP16, `z=2`, `h=32`, head dimension 64. Lower latency is better.

| shape | Helion ms | Helion TFLOP/s | FA4 ms | FA4 TFLOP/s | Helion lead |
|---|---:|---:|---:|---:|---:|
| causal 64K | 26.8351 | 1311.1 | 26.9695 | 1304.6 | 0.5008% |
| causal 128K | 105.1077 | 1339.0 | 106.7894 | 1317.9 | 1.6000% |
| causal 256K | 417.1358 | 1349.6 | 424.4296 | 1326.4 | 1.7485% |
| causal 512K | 1666.0634 | 1351.6 | 1703.3185 | 1322.0 | 2.2361% |

The exact full-stack command and methodology are in PR 5.

## Critical tests

```bash
HELION_BACKEND=cute pytest test/test_cute_flash_exp2.py
```

Fresh-cache GB300 runtime coverage passed for causal 64K/128K and replay-heavy causal 256K/512K paths.