### PR TITLE
[CuTe] Generalize flash target registration and validate lowering contracts

### DIFF
--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -2429,7 +2429,6 @@ def resident_softmax_value_graph(
     pfor_ptr_stage: object,
     pfor2_ptr_stage: object,
     p_store_split: int,
-    p_store_chunks: int,
     stats_empty_ptr_stage: object,
     stats_empty_phase: object,
     row_sum_init: object,
@@ -2449,9 +2448,8 @@ def resident_softmax_value_graph(
     assert tLDrS.element_type is cutlass.Float32
     assert cute.size(tLDrS) % 32 == 0
     frag_count = cute.size(tLDrS) // 32
-    assert p_store_chunks == frag_count
-    assert cute.size(tSTtS, mode=[2]) == p_store_chunks
-    assert 0 < p_store_split < p_store_chunks
+    assert cute.size(tSTtS, mode=[2]) == frag_count
+    assert 0 < p_store_split < frag_count
 
     for i in range(0, cute.size(tLDrS), 2):
         tLDrS[i], tLDrS[i + 1] = cute.arch.fma_packed_f32x2(
@@ -2476,7 +2474,7 @@ def resident_softmax_value_graph(
             cast("cute.Tensor", src[None, ci]).load().to(cutlass.Float16)
         )
 
-    for ci in range(p_store_chunks):
+    for ci in range(frag_count):
         cute.copy(tiled_st, tSTrS[None, None, ci], tSTtS[None, None, ci])
         if ci == p_store_split - 1:
             cute.arch.fence_view_async_tmem_store()
@@ -3356,16 +3354,16 @@ class ResidentSoftmaxState:
         scale_log2: Float32,
         rescale_threshold: cutlass.Constexpr[float] = 0.0,
     ) -> "ResidentSoftmaxState":
+        row_max = cute.make_rmem_tensor(1, Float32)
+        row_sum = cute.make_rmem_tensor(1, Float32)
+        row_max.fill(Float32(-Float32.inf))
+        row_sum.fill(Float32(0.0))
         return ResidentSoftmaxState(
             scale_log2,
-            cute.make_rmem_tensor(1, Float32),
-            cute.make_rmem_tensor(1, Float32),
+            row_max,
+            row_sum,
             rescale_threshold,
         )
-
-    def reset(self) -> None:
-        self.row_max.fill(Float32(-Float32.inf))
-        self.row_sum.fill(Float32(0.0))
 
     @cute.jit
     def _update_row_max_from_local(
@@ -3451,15 +3449,6 @@ class ResidentSoftmaxState:
             converted_fragments[None, fragment].store(
                 score_fragments[None, fragment].load().to(converted.element_type)
             )
-
-    @cute.jit
-    def acquire_stats(
-        self,
-        stats_empty_ptr_stage: object,
-        stats_empty_phase: object,
-        wait_hint: int,
-    ) -> None:
-        mbar_spin_wait(stats_empty_ptr_stage, stats_empty_phase, wait_hint)
 
     @cute.jit
     def update_row_sum(

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -60,6 +60,7 @@ from .flash_schedule import FlashScheduleSpec
 from .flash_schedule import FlashStatReleaseMapping
 from .flash_schedule import build_fa4_schedule
 from .flash_schedule import verify_flash_schedule
+from .flash_tuning import FlashCausalSeedTemplate
 from .flash_tuning import FlashPackedExp2Mode
 from .flash_tuning import FlashSoftmaxLowering
 
@@ -72,7 +73,6 @@ if TYPE_CHECKING:
 
     from .flash_tuning import FlashCausalTuningPolicy
     from .flash_tuning import FlashDenseTuningPolicy
-    from .flash_tuning import FlashTuningPolicy
 
 
 class FlashGraphOutputPlan(NamedTuple):
@@ -3873,7 +3873,6 @@ def _flash_causal_degree2_seed_config(
     requires_ws_overlap: bool,
     small_biased_candidate: bool,
     standard_causal_output: bool,
-    target_device_capability: tuple[int, int] | None = None,
     block_size_targets: Sequence[int],
 ) -> Config | None:
     """Return a validated causal degree-2 seed."""
@@ -3902,7 +3901,6 @@ def _flash_causal_degree2_seed_config(
         requires_ws_overlap=requires_ws_overlap,
         small_biased_candidate=small_biased_candidate,
         standard_causal_output=standard_causal_output,
-        target_device_capability=target_device_capability,
         pipeline_family_override="fa4",
     )
     values = {key: fragment.default() for key, fragment in fragments.items()}
@@ -3912,24 +3910,40 @@ def _flash_causal_degree2_seed_config(
     return Config.from_dict({"block_sizes": block_sizes, **values})
 
 
-def _flash_causal_degree2_seed_overrides(num_kv: int) -> dict[str, object]:
-    """Return the versioned causal degree-2 template's explicit values."""
-    seed_params = _flash_causal_degree2_seed_params(num_kv)
-    assert seed_params is not None
+def _flash_causal_degree2_template_values(
+    *,
+    e2e_offset: int,
+    e2e_offset0: int,
+    role_map: str,
+    epi_tma: bool,
+) -> dict[str, object]:
+    """Return explicit values for the shared causal degree-2 seed template."""
     return {
         FLASH_PIPELINE_FAMILY_KEY: "fa4",
         FLASH_E2E_SCHEDULE_KEY: "16/6",
         FLASH_MASKED_E2E_SCHEDULE_KEY: "16/6",
-        FLASH_E2E_OFFSET_KEY: seed_params.e2e_offset,
-        FLASH_E2E_OFFSET0_KEY: seed_params.e2e_offset0,
+        FLASH_E2E_OFFSET_KEY: e2e_offset,
+        FLASH_E2E_OFFSET0_KEY: e2e_offset0,
         FLASH_EXP2_PACKET_KEY: _FLASH_DEG2_EXP2_PACKET,
         FLASH_WAIT_HINT_KEY: 0,
         FLASH_DISC_PIPE_KEY: 3,
-        FLASH_EPI_TMA_KEY: seed_params.epi_tma,
+        FLASH_EPI_TMA_KEY: epi_tma,
         FLASH_RESCALE_CHUNK_COLS_KEY: 16,
         FLASH_CAUSAL_LPT_SWIZZLE_KEY: 0,
-        FLASH_ROLE_MAP_KEY: seed_params.role_map,
+        FLASH_ROLE_MAP_KEY: role_map,
     }
+
+
+def _flash_causal_degree2_seed_overrides(num_kv: int) -> dict[str, object]:
+    """Return the baseline causal degree-2 seed's explicit values."""
+    seed_params = _flash_causal_degree2_seed_params(num_kv)
+    assert seed_params is not None
+    return _flash_causal_degree2_template_values(
+        e2e_offset=seed_params.e2e_offset,
+        e2e_offset0=seed_params.e2e_offset0,
+        role_map=seed_params.role_map,
+        epi_tma=seed_params.epi_tma,
+    )
 
 
 def _flash_dense_tuning_overrides(
@@ -3952,19 +3966,29 @@ def _flash_dense_tuning_overrides(
     return values
 
 
-def _flash_causal_tuning_values(
+def _flash_causal_tuning_overrides(
     policy: FlashCausalTuningPolicy,
 ) -> dict[str, object]:
-    values = {
-        **_flash_causal_degree2_seed_overrides(policy.num_kv),
+    if policy.seed_template is not FlashCausalSeedTemplate.DEGREE2_V1:
+        raise AssertionError(
+            f"unsupported causal seed template: {policy.seed_template!r}"
+        )
+    overrides = {
+        **_flash_causal_degree2_template_values(
+            e2e_offset=policy.e2e_offset,
+            e2e_offset0=policy.e2e_offset0,
+            role_map=policy.role_map,
+            epi_tma=policy.epi_tma,
+        ),
         FLASH_KV_STAGE_KEY: policy.kv_stage,
-        FLASH_Q_TILE_COUNT_KEY: policy.q_tile_count,
+        FLASH_CAUSAL_LOOP_SPLIT_KEY: policy.causal_loop_split,
+        FLASH_CAUSAL_KV_ORDER_KEY: policy.causal_kv_order,
     }
     if policy.softmax_regs is not None:
-        values[FLASH_SOFTMAX_REGS_KEY] = policy.softmax_regs
+        overrides[FLASH_SOFTMAX_REGS_KEY] = policy.softmax_regs
     if policy.first_load_order is not None:
-        values[FLASH_FIRST_LOAD_ORDER_KEY] = policy.first_load_order
-    return values
+        overrides[FLASH_FIRST_LOAD_ORDER_KEY] = policy.first_load_order
+    return overrides
 
 
 def _flash_config_matches_tuning_values(
@@ -3977,17 +4001,13 @@ def _flash_config_matches_tuning_values(
 
 def _flash_dense_resident_seed_matches(
     cfg: FlashAttentionConfig,
-    num_kv: int,
-    target_device_capability: tuple[int, int] | None,
+    policy: FlashDenseTuningPolicy | None,
 ) -> bool:
     """Return whether ``cfg`` is the validated target-promoted dense seed."""
-    policy = get_flash_target_policy(target_device_capability).tuning.dense_policy(
-        num_kv
-    )
     expected = (
         {
             **_flash_dense_tuning_overrides(policy),
-            FLASH_Q_TILE_COUNT_KEY: policy.q_tile_count,
+            FLASH_Q_TILE_COUNT_KEY: 2,
         }
         if policy is not None
         else {}
@@ -4019,20 +4039,53 @@ def _flash_resident_softmax_config(
 
 def _flash_causal_resident_native_seed_matches(
     cfg: FlashAttentionConfig,
-    num_kv: int,
-    target_device_capability: tuple[int, int] | None,
+    policy: FlashCausalTuningPolicy | None,
 ) -> bool:
     """Return whether ``cfg`` is the validated causal resident seed shape."""
-    policy = get_flash_target_policy(target_device_capability).tuning.causal_policy(
-        num_kv
-    )
     return policy is not None and _flash_config_matches_tuning_values(
-        cfg, _flash_causal_tuning_values(policy)
+        cfg,
+        {
+            **_flash_causal_tuning_overrides(policy),
+            FLASH_Q_TILE_COUNT_KEY: 2,
+        },
     )
 
 
-def _flash_tuning_seed_config(
-    tuning_policy: FlashTuningPolicy,
+def _flash_validated_target_seed(
+    *,
+    head_dim: int,
+    num_kv: int,
+    dtype: torch.dtype,
+    is_causal: bool,
+    standard_dense_output: bool,
+    values: Mapping[str, object],
+    expected: Mapping[str, object],
+) -> Config:
+    """Build a target seed and reject policies normalized by config resolution."""
+    seed = Config.from_dict(dict(values))
+    resolved = resolve_flash_config(
+        head_dim,
+        num_kv,
+        seed.config,
+        dtype=dtype,
+        is_causal=is_causal,
+        standard_dense_output=standard_dense_output,
+    )
+    actual = flash_effective_config_values(resolved)
+    mismatches = {
+        key: (value, actual.get(key))
+        for key, value in expected.items()
+        if actual.get(key) != value
+    }
+    if mismatches:
+        raise ValueError(
+            "flash target tuning policy does not round-trip through config "
+            f"resolution: {mismatches!r}"
+        )
+    return seed
+
+
+def _flash_target_seed_config(
     head_dim: int,
     num_kv: int,
     *,
@@ -4046,9 +4099,12 @@ def _flash_tuning_seed_config(
     target_device_capability: tuple[int, int] | None,
     block_size_targets: Sequence[int],
 ) -> Config | None:
+    target_policy = get_flash_target_policy(target_device_capability)
+    tuning_policy = target_policy.tuning_for_torch(
+        head_dim, str(dtype).removeprefix("torch.")
+    )
     if (
-        dtype is not torch.float16
-        or head_dim != 64
+        tuning_policy is None
         or has_kv_tile_pruning
         or requires_ws_overlap
         or small_biased_candidate
@@ -4059,7 +4115,12 @@ def _flash_tuning_seed_config(
         causal_policy = tuning_policy.causal_policy(num_kv)
         if not standard_causal_output or causal_policy is None:
             return None
-        seed = _flash_causal_degree2_seed_config(
+        block_sizes = _flash_seed_block_sizes(block_size_targets)
+        if block_sizes is None:
+            return None
+        causal_overrides = _flash_causal_tuning_overrides(causal_policy)
+        pipeline_family = cast("str", causal_overrides[FLASH_PIPELINE_FAMILY_KEY])
+        fragments = flash_autotune_fragments(
             head_dim,
             num_kv,
             dtype=dtype,
@@ -4069,12 +4130,24 @@ def _flash_tuning_seed_config(
             small_biased_candidate=False,
             standard_causal_output=True,
             target_device_capability=target_device_capability,
-            block_size_targets=block_size_targets,
+            pipeline_family_override=pipeline_family,
         )
-        if seed is None:
+        values = {key: fragment.default() for key, fragment in fragments.items()}
+        if not _flash_seed_set_all(values, fragments, causal_overrides):
             return None
-        config = {**seed.config, **_flash_causal_tuning_values(causal_policy)}
-        return Config.from_dict(config)
+        expected = {
+            **causal_overrides,
+            FLASH_Q_TILE_COUNT_KEY: 2,
+        }
+        return _flash_validated_target_seed(
+            head_dim=head_dim,
+            num_kv=num_kv,
+            dtype=dtype,
+            is_causal=True,
+            standard_dense_output=False,
+            values={"block_sizes": block_sizes, **values, FLASH_Q_TILE_COUNT_KEY: 2},
+            expected=expected,
+        )
 
     dense_policy = tuning_policy.dense_policy(num_kv)
     if not standard_dense_output or dense_policy is None:
@@ -4098,43 +4171,18 @@ def _flash_tuning_seed_config(
     overrides = _flash_dense_tuning_overrides(dense_policy)
     if not _flash_seed_set_all(values, fragments, overrides):
         return None
-    return Config.from_dict(
-        {
-            "block_sizes": block_sizes,
-            **values,
-            FLASH_Q_TILE_COUNT_KEY: dense_policy.q_tile_count,
-        }
-    )
-
-
-def _flash_target_seed_config(
-    head_dim: int,
-    num_kv: int,
-    *,
-    dtype: torch.dtype,
-    is_causal: bool,
-    has_kv_tile_pruning: bool,
-    requires_ws_overlap: bool,
-    small_biased_candidate: bool,
-    standard_dense_output: bool,
-    standard_causal_output: bool,
-    target_device_capability: tuple[int, int] | None,
-    block_size_targets: Sequence[int],
-) -> Config | None:
-    tuning_policy = get_flash_target_policy(target_device_capability).tuning
-    return _flash_tuning_seed_config(
-        tuning_policy,
-        head_dim,
-        num_kv,
+    expected = {
+        **overrides,
+        FLASH_Q_TILE_COUNT_KEY: 2,
+    }
+    return _flash_validated_target_seed(
+        head_dim=head_dim,
+        num_kv=num_kv,
         dtype=dtype,
-        is_causal=is_causal,
-        has_kv_tile_pruning=has_kv_tile_pruning,
-        requires_ws_overlap=requires_ws_overlap,
-        small_biased_candidate=small_biased_candidate,
-        standard_dense_output=standard_dense_output,
-        standard_causal_output=standard_causal_output,
-        target_device_capability=target_device_capability,
-        block_size_targets=block_size_targets,
+        is_causal=False,
+        standard_dense_output=True,
+        values={"block_sizes": block_sizes, **values, FLASH_Q_TILE_COUNT_KEY: 2},
+        expected=expected,
     )
 
 
@@ -4523,9 +4571,19 @@ def flash_autotune_fragments(
         and _flash_causal_hd64_seed_num_kv_supported(num_kv)
         and defaults.topology == "fa4"
     )
-    target_tuning_policy = get_flash_target_policy(target_device_capability).tuning
-    dense_tuning_policy = target_tuning_policy.dense_policy(num_kv)
-    causal_tuning_policy = target_tuning_policy.causal_policy(num_kv)
+    target_tuning_policy = get_flash_target_policy(
+        target_device_capability
+    ).tuning_for_torch(head_dim, str(dtype).removeprefix("torch."))
+    dense_tuning_policy = (
+        target_tuning_policy.dense_policy(num_kv)
+        if target_tuning_policy is not None
+        else None
+    )
+    causal_tuning_policy = (
+        target_tuning_policy.causal_policy(num_kv)
+        if target_tuning_policy is not None
+        else None
+    )
     long_causal_hd64_seeded_fa4 = (
         causal_hd64_seeded_fa4 and num_kv >= _FLASH_CAUSAL_HD64_LONG_AUTOTUNE_MIN_KV
     )
@@ -5457,7 +5515,7 @@ def flash_autotune_fragments(
     if not is_causal and standard_dense_output and dense_tuning_policy is not None:
         policy_values = _flash_dense_tuning_overrides(dense_tuning_policy)
     elif is_causal and standard_causal_output and causal_tuning_policy is not None:
-        policy_values = _flash_causal_tuning_values(causal_tuning_policy)
+        policy_values = _flash_causal_tuning_overrides(causal_tuning_policy)
     for key, value in policy_values.items():
         if key not in fragments:
             continue
@@ -7427,14 +7485,14 @@ def emit_flash_fa4_device_body(
         assert not cfg.persistent
     target_policy = get_flash_target_policy(target_device_capability)
     hardware_capabilities = target_policy.hardware
-    tuning_policy = target_policy.tuning
-    tmem_row_reduce_min_kv = tuning_policy.tmem_row_reduce_min_kv
+    tuning_policy = target_policy.tuning_for_cute(hd, io_dtype)
+    tmem_row_reduce_min_kv = (
+        tuning_policy.tmem_row_reduce_min_kv if tuning_policy is not None else None
+    )
     use_tmem_row_reduce = (
         hardware_capabilities.supports_tmem_row_reduce
         and tmem_row_reduce_min_kv is not None
-        and hd == 64
         and num_kv >= tmem_row_reduce_min_kv
-        and io_dtype == "cutlass.Float16"
         and cfg.s_load_repetition == 32
         and score_plan.modifier_kinds in ((DENSE_SCORE_KIND,), (CAUSAL_MASK_KIND,))
     )
@@ -7451,23 +7509,22 @@ def emit_flash_fa4_device_body(
         split_range_proof=causal_split_proof,
         query_slots_per_cta=q_stage,
     )
-    dense_tuning = tuning_policy.dense_policy(num_kv)
+    dense_tuning = (
+        tuning_policy.dense_policy(num_kv) if tuning_policy is not None else None
+    )
     probability_log2_shift = (
         dense_tuning.probability_log2_shift if dense_tuning is not None else 0
     )
     probability_shift_safe = probability_log2_shift + cfg.rescale_threshold < math.log2(
         torch.finfo(torch.float16).max
     )
+    dense_seed_matches = _flash_dense_resident_seed_matches(cfg, dense_tuning)
     dense_resident_value_graph_candidate = False
     if (
         dense_tuning is not None
-        and _flash_dense_resident_seed_matches(cfg, num_kv, target_device_capability)
+        and dense_seed_matches
         and not is_causal
-        and hd == 64
-        and io_dtype == "cutlass.Float16"
         and not has_lse
-        and cfg.pipeline_family == "fa4_2cta"
-        and cfg.q_tile_count == 2
         and cfg.use_2cta_instrs
         and not cfg.separate_kv_rings
         and not cfg.softmax_disc
@@ -7488,17 +7545,16 @@ def emit_flash_fa4_device_body(
                 "unsupported dense resident softmax lowering family: "
                 f"{dense_softmax_family!r}"
             )
-    causal_tuning = tuning_policy.causal_policy(num_kv)
+    causal_tuning = (
+        tuning_policy.causal_policy(num_kv) if tuning_policy is not None else None
+    )
+    causal_seed_matches = _flash_causal_resident_native_seed_matches(cfg, causal_tuning)
     use_causal_resident_native = (
         causal_tuning is not None
-        and _flash_causal_resident_native_seed_matches(
-            cfg, num_kv, target_device_capability
-        )
+        and causal_seed_matches
         and use_tmem_row_reduce
         and is_causal
         and not has_lse
-        and cfg.pipeline_family == "fa4"
-        and cfg.q_tile_count == 2
         and not cfg.use_2cta_instrs
         and not cfg.separate_kv_rings
         and cfg.causal_loop_split
@@ -7513,8 +7569,6 @@ def emit_flash_fa4_device_body(
     )
     use_causal_resident_value_graph = False
     use_causal_stateful_softmax = False
-    use_stage_local_stat_handoff = False
-    requested_cfg = cfg
     if use_causal_resident_native:
         assert causal_tuning is not None
         resident_softmax_family = causal_tuning.softmax_lowering
@@ -7524,7 +7578,6 @@ def emit_flash_fa4_device_body(
             use_causal_resident_value_graph = True
         elif resident_softmax_family is FlashSoftmaxLowering.STATEFUL:
             use_causal_stateful_softmax = True
-            use_stage_local_stat_handoff = True
         else:
             raise AssertionError(
                 "unsupported resident softmax lowering family: "
@@ -7534,11 +7587,15 @@ def emit_flash_fa4_device_body(
         # Use the architecture-selected resident softmax lowering only for the
         # validated rank-0 schedule. Other manual/autotuned configs retain their
         # explicit exp2, disc, and statistics choices.
-        cfg = _flash_resident_softmax_config(requested_cfg)
+        cfg = _flash_resident_softmax_config(cfg)
+    stat_release_mapping = (
+        FlashStatReleaseMapping.SAME_SLOT
+        if use_causal_stateful_softmax
+        else FlashStatReleaseMapping.CROSS_SLOT
+    )
     use_whole_row_tmem_reduce = (
         use_tmem_row_reduce and not is_causal and not cfg.softmax_disc
     )
-    use_causal_resident_ldred = use_causal_resident_native and use_tmem_row_reduce
     persistent = cfg.persistent
     use_tensor_4d_tma = (
         cfg.tensor_4d_tma
@@ -7555,30 +7612,23 @@ def emit_flash_fa4_device_body(
         else FlashPackedExp2Mode.DISABLED
     )
     use_packed_f16x2_xu = (
-        dense_packed_exp2_mode is not FlashPackedExp2Mode.DISABLED
+        dense_packed_exp2_mode is FlashPackedExp2Mode.ALL_XU
         and hardware_capabilities.supports_packed_f16x2_exp2
         and probability_shift_safe
-        and hd == 64
-        and io_dtype == "cutlass.Float16"
         and not has_lse
         and cfg.exp2_impl == "split"
         and cfg.p_store_repetition == 16
         and cfg.s_load_repetition == 32
         and not is_causal
-        and _flash_dense_resident_seed_matches(cfg, num_kv, target_device_capability)
+        and dense_seed_matches
         and score_plan.modifier_kinds == (DENSE_SCORE_KIND,)
         and use_2cta_instrs
         and not cfg.softmax_disc
         and cfg.exp2_packet in _FLASH_DEG1_EXP2_PACKETS
     )
-    use_all_packed_f16x2_xu = (
-        use_packed_f16x2_xu
-        and dense_packed_exp2_mode is FlashPackedExp2Mode.ALL_XU
-        and probability_shift_safe
-    )
     effective_probability_log2_shift = (
         probability_log2_shift
-        if use_all_packed_f16x2_xu or dense_resident_value_graph_candidate
+        if use_packed_f16x2_xu or dense_resident_value_graph_candidate
         else 0
     )
     use_cga2_local_cta = cfg.use_cga2_local_cta
@@ -7586,8 +7636,9 @@ def emit_flash_fa4_device_body(
     separate_kv_rings = cfg.separate_kv_rings
     fa4_stat_handoff = cfg.stat_transport in ("single", "single_final")
     # Match FA4's one-slot statistics pipeline: the softmax role acquires slot
-    # ownership after publishing P, while correction releases the opposite
-    # stage's slot. Unsupported schedules retain the conservative handoff below.
+    # ownership after publishing P, while correction releases the slot selected
+    # by the architecture policy. Unsupported schedules retain the conservative
+    # handoff below.
     fa4_stat_pipeline = (
         fa4_stat_handoff
         and (
@@ -7613,8 +7664,7 @@ def emit_flash_fa4_device_body(
     )
     if dense_resident_value_graph_candidate:
         assert use_dense_resident_value_graph
-    if use_stage_local_stat_handoff:
-        assert use_causal_stateful_softmax
+    if use_causal_stateful_softmax:
         assert acknowledged_stat_pipeline
     verified_shared_memory_bytes: int | None = None
     if separate_kv_rings:
@@ -7685,11 +7735,7 @@ def emit_flash_fa4_device_body(
                     split_p_arrive=cfg.split_p_arrive,
                     stat_depth=1,
                     pipelined_stat_handoff=True,
-                    stat_release_mapping=(
-                        FlashStatReleaseMapping.SAME_SLOT
-                        if use_stage_local_stat_handoff
-                        else FlashStatReleaseMapping.CROSS_SLOT
-                    ),
+                    stat_release_mapping=stat_release_mapping,
                     query_slots_have_equal_kv_iterations=(
                         causal_split_equal_iteration_proof.proven
                     ),
@@ -7719,7 +7765,7 @@ def emit_flash_fa4_device_body(
     exp2_codegen = _flash_disc_exp2_codegen_params(
         cfg.exp2_packet, cfg.e2e_freq, cfg.e2e_res
     )
-    if use_all_packed_f16x2_xu:
+    if use_packed_f16x2_xu:
         exp2_codegen = exp2_codegen._replace(e2e_res=0)
     if exp2_codegen.degree2:
         assert hd == 64
@@ -8246,7 +8292,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     tLDRedtS0 = flash_thr_ldred0.partition_S(tStS0)
     tLDRedtS1 = flash_thr_ldred1.partition_S(tStS1)
 """
-        if use_tmem_row_reduce and (cfg.softmax_disc or use_causal_resident_ldred)
+        if use_tmem_row_reduce and (cfg.softmax_disc or use_causal_resident_native)
         else ""
     )
     tmem_softmax_setup = (
@@ -8349,7 +8395,7 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
     flash_thr_ldred{stage} = flash_tiled_ldred{stage}.get_slice(flash_local_tidx)
     tLDRedtS{stage} = flash_thr_ldred{stage}.partition_S(tStS{stage})
 """
-            if use_tmem_row_reduce and (cfg.softmax_disc or use_causal_resident_ldred)
+            if use_tmem_row_reduce and (cfg.softmax_disc or use_causal_resident_native)
             else ""
         )
         return f"""    _helion_flash_rt.named_barrier_wait_unaligned(
@@ -9705,7 +9751,7 @@ if warp_idx == 15:
                 tLDrS, {st}, {stt}, tSTcS, _flash_scale_log2,
                 flash_minus_max_scale, flash_pfor_ptr + {stage},
                 flash_pfor2_ptr + {stage}, flash_P_STORE_SPLIT,
-                flash_P_STORE_CHUNKS, {corr_empty_ptr} + 0,
+                {corr_empty_ptr} + 0,
                 flash_s_corr_prod_phase, flash_row_sum * flash_alpha,
                 {cfg.wait_hint}{resident_pfor_args})"""
             sp_p_store_block = ""
@@ -9843,7 +9889,6 @@ if warp_idx == 15:
             "_helion_flash_rt.fmax_reduce_packed(tLDrS, flash_row_max)"
         )
         if use_causal_resident_native:
-            assert use_causal_resident_ldred
             assert acknowledged_stat_pipeline
             assert cfg.exp2_impl == "xu"
 
@@ -9972,7 +10017,7 @@ if warp_idx == 15:
 {indent}              {stt}[None, None, flash_ci])
 {indent}cute.arch.fence_view_async_tmem_store()
 {indent}_helion_flash_rt.mbarrier_arrive(flash_pfor2_ptr + {stage})
-{indent}flash_softmax.acquire_stats(
+{indent}_helion_flash_rt.mbar_spin_wait(
 {indent}    {corr_empty_ptr} + 0, flash_s_corr_prod_phase, {cfg.wait_hint})
 {indent}flash_softmax.update_row_sum(
 {indent}    tLDrS.load(), flash_alpha{row_sum_first_arg})
@@ -9998,7 +10043,6 @@ if warp_idx == 15:
                 )
                 return f"""{fa4_entry_stat_acquire}        flash_softmax = _helion_flash_rt.ResidentSoftmaxState.create(
             _flash_scale_log2, rescale_threshold={cfg.rescale_threshold})
-        flash_softmax.reset()
         flash_kv = {kv_loop_bound} - cutlass.Int32(1)
 {first_step}
         for flash_kv_mask_iter in cutlass.range(
@@ -10366,13 +10410,13 @@ if warp_idx == 15:
     )
     corr_cross_release0 = (
         "            cute.arch.mbarrier_arrive("
-        f"flash_s{'0' if use_stage_local_stat_handoff else '1'}_corr_empty_ptr + 0)"
+        f"flash_s{'0' if stat_release_mapping is FlashStatReleaseMapping.SAME_SLOT else '1'}_corr_empty_ptr + 0)"
         if acknowledged_stat_pipeline
         else ""
     )
     corr_cross_release1 = (
         "            cute.arch.mbarrier_arrive("
-        f"flash_s{'1' if use_stage_local_stat_handoff else '0'}_corr_empty_ptr + 0)"
+        f"flash_s{'1' if stat_release_mapping is FlashStatReleaseMapping.SAME_SLOT else '0'}_corr_empty_ptr + 0)"
         if acknowledged_stat_pipeline
         else ""
     )
@@ -10412,7 +10456,7 @@ if warp_idx == 15:
             7 + warp_idx % 4, 64)"""
         + (
             "\n        cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)"
-            if use_stage_local_stat_handoff
+            if stat_release_mapping is FlashStatReleaseMapping.SAME_SLOT
             else ""
         )
         + "\n"
@@ -10421,7 +10465,10 @@ if warp_idx == 15:
     )
     corr_stat_release_held = (
         "        cute.arch.mbarrier_arrive(flash_s1_corr_empty_ptr + 0)\n"
-        if acknowledged_stat_pipeline and not use_stage_local_stat_handoff
+        if (
+            acknowledged_stat_pipeline
+            and stat_release_mapping is FlashStatReleaseMapping.CROSS_SLOT
+        )
         else ""
     )
     corr_final_stat_release = (

--- a/helion/_compiler/cute/flash_policy.py
+++ b/helion/_compiler/cute/flash_policy.py
@@ -8,6 +8,7 @@ from .flash_tuning import FlashCausalTuningPolicy
 from .flash_tuning import FlashDenseTuningPolicy
 from .flash_tuning import FlashPackedExp2Mode
 from .flash_tuning import FlashSoftmaxLowering
+from .flash_tuning import FlashTuningDType
 from .flash_tuning import FlashTuningPolicy
 
 
@@ -19,38 +20,94 @@ class FlashTargetPolicy:
         default_factory=FlashHardwareCapabilities
     )
     tuning: FlashTuningPolicy = dataclasses.field(default_factory=FlashTuningPolicy)
+    additional_tunings: tuple[FlashTuningPolicy, ...] = ()
 
     def __post_init__(self) -> None:
-        if (
-            self.tuning.tmem_row_reduce_min_kv is not None
-            and not self.hardware.supports_tmem_row_reduce
-        ):
-            raise ValueError("TMEM row-reduce tuning requires hardware support")
-        causal_resident_policies = tuple(
-            policy
-            for policy in self.tuning.causal_policies
-            if policy.softmax_lowering is not FlashSoftmaxLowering.STANDARD
+        workloads = [tuning.workload for tuning in self.tunings]
+        if len(set(workloads)) != len(workloads):
+            raise ValueError("flash target tuning workloads must be unique")
+        for tuning in self.tunings:
+            uses_specialized_lowering = any(
+                policy.softmax_lowering is not FlashSoftmaxLowering.STANDARD
+                or policy.packed_exp2_mode is not FlashPackedExp2Mode.DISABLED
+                for policy in tuning.dense_policies
+            ) or any(
+                policy.softmax_lowering is not FlashSoftmaxLowering.STANDARD
+                for policy in tuning.causal_policies
+            )
+            if uses_specialized_lowering and (
+                tuning.workload.head_dim != 64
+                or tuning.workload.dtype is not FlashTuningDType.FLOAT16
+            ):
+                raise ValueError(
+                    "specialized flash lowerings require the FP16 head-dim-64 workload"
+                )
+            if (
+                tuning.tmem_row_reduce_min_kv is not None
+                and not self.hardware.supports_tmem_row_reduce
+            ):
+                raise ValueError("TMEM row-reduce tuning requires hardware support")
+            causal_resident_policies = tuple(
+                policy
+                for policy in tuning.causal_policies
+                if policy.softmax_lowering is not FlashSoftmaxLowering.STANDARD
+            )
+            if causal_resident_policies and not self.hardware.supports_tmem_row_reduce:
+                raise ValueError(
+                    "causal resident softmax requires TMEM row-reduce support"
+                )
+            row_reduce_min_kv = tuning.tmem_row_reduce_min_kv
+            if causal_resident_policies and (
+                row_reduce_min_kv is None
+                or any(
+                    policy.num_kv < row_reduce_min_kv
+                    for policy in causal_resident_policies
+                )
+            ):
+                raise ValueError(
+                    "causal resident softmax requires an enabled TMEM row-reduce range"
+                )
+            if (
+                any(
+                    policy.packed_exp2_mode is not FlashPackedExp2Mode.DISABLED
+                    for policy in tuning.dense_policies
+                )
+                and not self.hardware.supports_packed_f16x2_exp2
+            ):
+                raise ValueError("packed exp2 tuning requires hardware support")
+
+    @property
+    def tunings(self) -> tuple[FlashTuningPolicy, ...]:
+        """Return every workload-specific tuning table for this target."""
+        return (self.tuning, *self.additional_tunings)
+
+    def tuning_for_torch(
+        self, head_dim: int, torch_dtype: str
+    ) -> FlashTuningPolicy | None:
+        """Resolve a tuning table from host-side workload types."""
+        return next(
+            (
+                tuning
+                for tuning in self.tunings
+                if tuning.workload.head_dim == head_dim
+                and tuning.workload.dtype.value == torch_dtype
+            ),
+            None,
         )
-        if causal_resident_policies and not self.hardware.supports_tmem_row_reduce:
-            raise ValueError("causal resident softmax requires TMEM row-reduce support")
-        row_reduce_min_kv = self.tuning.tmem_row_reduce_min_kv
-        if causal_resident_policies and (
-            row_reduce_min_kv is None
-            or any(
-                policy.num_kv < row_reduce_min_kv for policy in causal_resident_policies
-            )
-        ):
-            raise ValueError(
-                "causal resident softmax requires an enabled TMEM row-reduce range"
-            )
-        if (
-            any(
-                policy.packed_exp2_mode is not FlashPackedExp2Mode.DISABLED
-                for policy in self.tuning.dense_policies
-            )
-            and not self.hardware.supports_packed_f16x2_exp2
-        ):
-            raise ValueError("packed exp2 tuning requires hardware support")
+
+    def tuning_for_cute(
+        self, head_dim: int, cute_dtype: str
+    ) -> FlashTuningPolicy | None:
+        """Resolve a tuning table from generated CuTe workload types."""
+        return next(
+            (
+                tuning
+                for tuning in self.tunings
+                if tuning.workload.head_dim == head_dim
+                and tuning.workload.dtype.cute_name == cute_dtype
+            ),
+            None,
+        )
 
 
 _GENERIC_FLASH_TARGET_POLICY = FlashTargetPolicy()
@@ -72,6 +129,8 @@ _FLASH_TARGET_POLICIES = {
                     stat_transport="single",
                     probability_log2_shift=7,
                     softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                    corr_regs=64,
+                    other_regs=40,
                 ),
                 FlashDenseTuningPolicy(
                     num_kv=512,
@@ -94,6 +153,8 @@ _FLASH_TARGET_POLICIES = {
                     stat_transport="single",
                     probability_log2_shift=7,
                     softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                    corr_regs=72,
+                    other_regs=40,
                 ),
                 FlashDenseTuningPolicy(
                     num_kv=2048,
@@ -104,12 +165,18 @@ _FLASH_TARGET_POLICIES = {
                     stat_transport="single_final",
                     packed_exp2_mode=FlashPackedExp2Mode.ALL_XU,
                     probability_log2_shift=7,
+                    corr_regs=80,
+                    other_regs=32,
                 ),
             ),
             causal_policies=(
                 FlashCausalTuningPolicy(
                     num_kv=512,
                     kv_stage=8,
+                    e2e_offset=15,
+                    e2e_offset0=3,
+                    role_map="fa4",
+                    epi_tma=True,
                     softmax_lowering=FlashSoftmaxLowering.STATEFUL,
                     softmax_regs=200,
                     first_load_order=2,
@@ -117,17 +184,31 @@ _FLASH_TARGET_POLICIES = {
                 FlashCausalTuningPolicy(
                     num_kv=1024,
                     kv_stage=3,
+                    e2e_offset=1,
+                    e2e_offset0=14,
+                    role_map="fa4",
                     softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                    softmax_regs=184,
+                    first_load_order=0,
                 ),
                 FlashCausalTuningPolicy(
                     num_kv=2048,
                     kv_stage=3,
+                    e2e_offset=14,
+                    e2e_offset0=12,
+                    role_map="fa4",
                     softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                    softmax_regs=184,
+                    first_load_order=0,
                 ),
                 FlashCausalTuningPolicy(
                     num_kv=4096,
                     kv_stage=6,
+                    e2e_offset=14,
+                    e2e_offset0=12,
                     softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                    softmax_regs=184,
+                    first_load_order=0,
                 ),
             ),
         ),
@@ -142,6 +223,13 @@ def get_flash_target_policy(
     if capability is None:
         return _GENERIC_FLASH_TARGET_POLICY
     return _FLASH_TARGET_POLICIES.get(capability, _GENERIC_FLASH_TARGET_POLICY)
+
+
+def registered_flash_target_policies() -> tuple[
+    tuple[tuple[int, int], FlashTargetPolicy], ...
+]:
+    """Return registered target policies in stable capability order."""
+    return tuple(sorted(_FLASH_TARGET_POLICIES.items()))
 
 
 def _cache_identity_value(value: object) -> object:
@@ -159,9 +247,35 @@ def _cache_identity_value(value: object) -> object:
 
 def flash_target_policy_cache_identity(
     capability: tuple[int, int] | None,
+    *,
+    head_dim: int | None = None,
+    torch_dtype: str | None = None,
+    num_kv: int | None = None,
+    is_causal: bool = False,
 ) -> object | None:
-    """Return a stable cache salt for non-generic target policy choices."""
+    """Return the stable cache salt for one target/workload policy."""
     policy = get_flash_target_policy(capability)
     if policy is _GENERIC_FLASH_TARGET_POLICY:
         return None
-    return _cache_identity_value(policy)
+    if head_dim is None or torch_dtype is None:
+        tuning = policy.tuning
+    else:
+        tuning = policy.tuning_for_torch(head_dim, torch_dtype)
+    if tuning is None:
+        return None
+    workload = tuning.workload
+    shape_policy = (
+        tuning.causal_policy(num_kv)
+        if is_causal and num_kv is not None
+        else tuning.dense_policy(num_kv)
+        if num_kv is not None
+        else None
+    )
+    return _cache_identity_value(
+        (
+            policy.hardware,
+            workload,
+            tuning.tmem_row_reduce_min_kv,
+            shape_policy,
+        )
+    )

--- a/helion/_compiler/cute/flash_tuning.py
+++ b/helion/_compiler/cute/flash_tuning.py
@@ -3,6 +3,47 @@ from __future__ import annotations
 import dataclasses
 import enum
 
+_FLASH_POLICY_EXP2_PACKETS = frozenset(
+    {
+        "1x1",
+        "4x1",
+        "4x2",
+        "8x1",
+        "8x2",
+        "deg2_16x6",
+        "hybrid_deg1_16x8",
+        "deg1_16x8",
+        "deg1_8x2_corr10",
+    }
+)
+_FLASH_POLICY_E2E_SCHEDULES = frozenset({"xu", "8/2", "16/2", "16/4", "16/6", "16/8"})
+_FLASH_POLICY_STAT_TRANSPORTS = frozenset({"ring2", "single", "single_final"})
+_FLASH_POLICY_PIPELINE_FAMILIES = frozenset(
+    {
+        "ws_overlap",
+        "fa4",
+        "fa4_deep_1cta",
+        "fa4_2cta_causal",
+        "fa4_tma_4d",
+        "fa4_local_tma",
+        "fa4_local_tma_4d",
+        "fa4_cga2_local",
+        "fa4_cga2_local_tma_4d",
+        "fa4_2cta",
+        "fa4_2cta_tma_4d",
+        "fa4_clc",
+        "fa4_clc_tma_4d",
+        "fa4_clc_local_tma",
+        "fa4_clc_local_tma_4d",
+    }
+)
+_FLASH_POLICY_ROLE_MAPS = frozenset({"helion", "fa4"})
+
+
+def _validate_policy_choice(name: str, value: str, choices: frozenset[str]) -> None:
+    if value not in choices:
+        raise ValueError(f"unsupported flash {name}: {value!r}")
+
 
 class FlashSoftmaxLowering(str, enum.Enum):
     """Available resident-softmax implementation strategies."""
@@ -19,6 +60,39 @@ class FlashPackedExp2Mode(str, enum.Enum):
     ALL_XU = "all_xu"
 
 
+class FlashCausalSeedTemplate(str, enum.Enum):
+    """Versioned causal seed implementation families."""
+
+    DEGREE2_V1 = "degree2_v1"
+
+
+class FlashTuningDType(str, enum.Enum):
+    """Element types supported by target flash tuning policies."""
+
+    FLOAT16 = "float16"
+    BFLOAT16 = "bfloat16"
+
+    @property
+    def cute_name(self) -> str:
+        if self is FlashTuningDType.FLOAT16:
+            return "cutlass.Float16"
+        if self is FlashTuningDType.BFLOAT16:
+            return "cutlass.BFloat16"
+        raise AssertionError(f"unsupported flash tuning dtype: {self!r}")
+
+
+@dataclasses.dataclass(frozen=True)
+class FlashTuningWorkload:
+    """Workload envelope supported by one target tuning table."""
+
+    head_dim: int = 64
+    dtype: FlashTuningDType = FlashTuningDType.FLOAT16
+
+    def __post_init__(self) -> None:
+        if self.head_dim <= 0:
+            raise ValueError("flash tuning head dimension must be positive")
+
+
 @dataclasses.dataclass(frozen=True)
 class FlashDenseTuningPolicy:
     """Exact dense seed and optional lowering choices for one KV size."""
@@ -32,7 +106,6 @@ class FlashDenseTuningPolicy:
     pipeline_family: str = "fa4_2cta"
     kv_stage: int = 6
     persistent: bool = False
-    q_tile_count: int = 2
     packed_exp2_mode: FlashPackedExp2Mode = FlashPackedExp2Mode.DISABLED
     probability_log2_shift: int = 0
     softmax_lowering: FlashSoftmaxLowering = FlashSoftmaxLowering.STANDARD
@@ -42,25 +115,40 @@ class FlashDenseTuningPolicy:
     def __post_init__(self) -> None:
         if self.num_kv <= 0:
             raise ValueError("dense KV size must be positive")
-        if not self.exp2_packet:
-            raise ValueError("dense exp2 packet must not be empty")
-        if not self.e2e_schedule:
-            raise ValueError("dense end-to-end schedule must not be empty")
+        _validate_policy_choice(
+            "dense exp2 packet", self.exp2_packet, _FLASH_POLICY_EXP2_PACKETS
+        )
+        _validate_policy_choice(
+            "dense end-to-end schedule",
+            self.e2e_schedule,
+            _FLASH_POLICY_E2E_SCHEDULES,
+        )
         if self.e2e_offset < 0 or self.e2e_offset0 < 0:
             raise ValueError("dense end-to-end offsets must be nonnegative")
-        if not self.stat_transport:
-            raise ValueError("dense statistics transport must not be empty")
-        if not self.pipeline_family:
-            raise ValueError("dense pipeline family must not be empty")
+        _validate_policy_choice(
+            "dense statistics transport",
+            self.stat_transport,
+            _FLASH_POLICY_STAT_TRANSPORTS,
+        )
+        _validate_policy_choice(
+            "dense pipeline family",
+            self.pipeline_family,
+            _FLASH_POLICY_PIPELINE_FAMILIES,
+        )
         if self.kv_stage <= 0:
             raise ValueError("dense KV stage must be positive")
-        if self.q_tile_count != 2:
-            raise ValueError("dense query tile count must be 2")
         if self.probability_log2_shift < 0:
             raise ValueError("probability log2 shift must be nonnegative")
         if self.softmax_lowering is FlashSoftmaxLowering.STATEFUL:
             raise ValueError(
                 "stateful softmax lowering is unsupported for dense policy"
+            )
+        if (
+            self.softmax_lowering is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+            and self.stat_transport != "single"
+        ):
+            raise ValueError(
+                "dense resident value-graph lowering requires single statistics transport"
             )
         if (self.corr_regs is None) != (self.other_regs is None):
             raise ValueError(
@@ -84,18 +172,27 @@ class FlashCausalTuningPolicy:
 
     num_kv: int
     kv_stage: int
-    q_tile_count: int = 2
+    seed_template: FlashCausalSeedTemplate = FlashCausalSeedTemplate.DEGREE2_V1
+    e2e_offset: int = 0
+    e2e_offset0: int = 0
+    role_map: str = "helion"
+    epi_tma: bool = False
     softmax_lowering: FlashSoftmaxLowering = FlashSoftmaxLowering.STANDARD
     softmax_regs: int | None = None
     first_load_order: int | None = None
+    causal_loop_split: bool = True
+    causal_kv_order: str = "descending"
 
     def __post_init__(self) -> None:
         if self.num_kv <= 0:
             raise ValueError("causal KV size must be positive")
         if self.kv_stage <= 0:
             raise ValueError("causal KV stage must be positive")
-        if self.q_tile_count != 2:
-            raise ValueError("causal query tile count must be 2")
+        if self.e2e_offset < 0 or self.e2e_offset0 < 0:
+            raise ValueError("causal end-to-end offsets must be nonnegative")
+        _validate_policy_choice(
+            "causal role map", self.role_map, _FLASH_POLICY_ROLE_MAPS
+        )
         if self.softmax_regs is not None and (
             self.softmax_regs <= 0 or self.softmax_regs % 8
         ):
@@ -104,12 +201,21 @@ class FlashCausalTuningPolicy:
             )
         if self.first_load_order is not None and self.first_load_order not in range(5):
             raise ValueError("causal first-load order must be 0-4")
+        if self.causal_kv_order not in ("ascending", "descending"):
+            raise ValueError("causal KV order must be ascending or descending")
+        if self.softmax_lowering is not FlashSoftmaxLowering.STANDARD and (
+            not self.causal_loop_split or self.causal_kv_order != "descending"
+        ):
+            raise ValueError("causal resident softmax requires a descending split loop")
 
 
 @dataclasses.dataclass(frozen=True)
 class FlashTuningPolicy:
     """Architecture-specific flash-attention seeds and lowering choices."""
 
+    workload: FlashTuningWorkload = dataclasses.field(
+        default_factory=FlashTuningWorkload
+    )
     tmem_row_reduce_min_kv: int | None = None
     dense_policies: tuple[FlashDenseTuningPolicy, ...] = ()
     causal_policies: tuple[FlashCausalTuningPolicy, ...] = ()

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2745,7 +2745,11 @@ class ConfigSpec:
             from .._compiler.cute.flash_policy import flash_target_policy_cache_identity
 
             target_policy_identity = flash_target_policy_cache_identity(
-                self.target_device_capability
+                self.target_device_capability,
+                head_dim=self._cute_flash_head_dim,
+                torch_dtype=str(self._cute_flash_dtype).removeprefix("torch."),
+                num_kv=self._cute_flash_num_kv,
+                is_causal=self._cute_flash_is_causal,
             )
         if (
             self.compiler_default_config is None

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -95,6 +95,8 @@ from helion._compiler.cute.cute_flash import flash_autotune_fragments
 from helion._compiler.cute.cute_flash import flash_effective_config_values
 from helion._compiler.cute.cute_flash import resolve_flash_config
 from helion._compiler.cute.flash_policy import get_flash_target_policy
+from helion._compiler.cute.flash_tuning import FlashCausalTuningPolicy
+from helion._compiler.cute.flash_tuning import FlashDenseTuningPolicy
 from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
@@ -2579,36 +2581,17 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     )
 
     def test_cute_flash_sm103_rank0_seed_policy(self) -> None:
-        dense_params = {
-            256: ("deg1_8x2_corr10", "8/2", 5, 1, "single"),
-            512: ("deg1_8x2_corr10", "8/2", 2, 1, "single"),
-            1024: ("deg1_8x2_corr10", "8/2", 2, 1, "single"),
-            2048: ("deg1_16x8", "16/8", 0, 10, "single_final"),
-        }
-        causal_kv_stages = {512: 8, 1024: 3, 2048: 3, 4096: 6}
-        dense_inherited = {
-            256: (64, 40, 200, 0, "helion", True),
-            512: (72, 40, 200, 4, "fa4", True),
-            1024: (72, 40, 200, 0, "helion", True),
-            2048: (80, 32, 192, 4, "helion", True),
-        }
-        causal_inherited = {
-            512: (15, 3, 200, 2, "fa4", True),
-            1024: (1, 14, 184, 0, "fa4", False),
-            2048: (14, 12, 184, 0, "fa4", False),
-            4096: (14, 12, 184, 0, "helion", False),
-        }
         sm103_policy = get_flash_target_policy((10, 3)).tuning
-        self.assertEqual(
-            {
-                shape_policy.num_kv: shape_policy.kv_stage
-                for shape_policy in sm103_policy.causal_policies
-            },
-            causal_kv_stages,
-        )
-
-        cases = [(False, num_kv) for num_kv in dense_params] + [
-            (True, num_kv) for num_kv in causal_kv_stages
+        dense_policies = {
+            shape_policy.num_kv: shape_policy
+            for shape_policy in sm103_policy.dense_policies
+        }
+        causal_policies = {
+            shape_policy.num_kv: shape_policy
+            for shape_policy in sm103_policy.causal_policies
+        }
+        cases = [(False, num_kv) for num_kv in dense_policies] + [
+            (True, num_kv) for num_kv in causal_policies
         ]
         for is_causal, num_kv in cases:
             with self.subTest(is_causal=is_causal, num_kv=num_kv):
@@ -2632,6 +2615,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 self.assertEqual(seed.config[FLASH_RESCALE_THRESHOLD_KEY], 8.0)
 
                 if is_causal:
+                    resident_policy = causal_policies[num_kv]
                     self.assertEqual(seed.config[FLASH_PIPELINE_FAMILY_KEY], "fa4")
                     self.assertFalse(seed.config[FLASH_PERSISTENT_KEY])
                     self.assertEqual(seed.config[FLASH_E2E_SCHEDULE_KEY], "16/6")
@@ -2643,6 +2627,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     self.assertEqual(seed.config[FLASH_OTHER_REGS_KEY], 48)
                     self.assertEqual(
                         (
+                            seed.config[FLASH_KV_STAGE_KEY],
                             seed.config[FLASH_E2E_OFFSET_KEY],
                             seed.config[FLASH_E2E_OFFSET0_KEY],
                             seed.config[FLASH_SOFTMAX_REGS_KEY],
@@ -2650,85 +2635,45 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                             seed.config[FLASH_ROLE_MAP_KEY],
                             seed.config[FLASH_EPI_TMA_KEY],
                         ),
-                        causal_inherited[num_kv],
+                        (
+                            resident_policy.kv_stage,
+                            resident_policy.e2e_offset,
+                            resident_policy.e2e_offset0,
+                            resident_policy.softmax_regs,
+                            resident_policy.first_load_order,
+                            resident_policy.role_map,
+                            resident_policy.epi_tma,
+                        ),
                     )
-                    baseline_degree2 = next(
-                        candidate
-                        for candidate in flash_attention_seed_configs(
-                            64,
-                            num_kv,
-                            **seed_kwargs,
-                        )
-                        if candidate.config.get(FLASH_EXP2_PACKET_KEY) == "deg2_16x6"
-                    )
-                    expected = {
-                        **baseline_degree2.config,
-                        FLASH_KV_STAGE_KEY: causal_kv_stages[num_kv],
-                        FLASH_Q_TILE_COUNT_KEY: 2,
-                    }
-                    resident_policy = sm103_policy.causal_policy(num_kv)
-                    assert resident_policy is not None
-                    if resident_policy.softmax_regs is not None:
-                        expected[FLASH_SOFTMAX_REGS_KEY] = resident_policy.softmax_regs
-                    if resident_policy.first_load_order is not None:
-                        expected[FLASH_FIRST_LOAD_ORDER_KEY] = (
-                            resident_policy.first_load_order
-                        )
                 else:
+                    resident_policy = dense_policies[num_kv]
                     self.assertEqual(
                         (
+                            seed.config[FLASH_EXP2_PACKET_KEY],
+                            seed.config[FLASH_E2E_SCHEDULE_KEY],
+                            seed.config[FLASH_E2E_OFFSET_KEY],
+                            seed.config[FLASH_E2E_OFFSET0_KEY],
+                            seed.config[FLASH_STAT_TRANSPORT_KEY],
+                            seed.config[FLASH_PIPELINE_FAMILY_KEY],
+                            seed.config[FLASH_KV_STAGE_KEY],
+                            seed.config[FLASH_PERSISTENT_KEY],
                             seed.config[FLASH_CORR_REGS_KEY],
                             seed.config[FLASH_OTHER_REGS_KEY],
-                            seed.config[FLASH_SOFTMAX_REGS_KEY],
-                            seed.config[FLASH_FIRST_LOAD_ORDER_KEY],
-                            seed.config[FLASH_ROLE_MAP_KEY],
-                            seed.config[FLASH_PRECOMPUTE_QK_DESC_KEY],
                         ),
-                        dense_inherited[num_kv],
+                        (
+                            resident_policy.exp2_packet,
+                            resident_policy.e2e_schedule,
+                            resident_policy.e2e_offset,
+                            resident_policy.e2e_offset0,
+                            resident_policy.stat_transport,
+                            resident_policy.pipeline_family,
+                            resident_policy.kv_stage,
+                            resident_policy.persistent,
+                            resident_policy.corr_regs,
+                            resident_policy.other_regs,
+                        ),
                     )
-                    fragments = flash_autotune_fragments(
-                        64,
-                        num_kv,
-                        dtype=torch.float16,
-                        standard_dense_output=True,
-                        pipeline_family_override="fa4_2cta",
-                    )
-                    packet, schedule, offset, offset0, stat_transport = dense_params[
-                        num_kv
-                    ]
-                    expected_values = {
-                        key: fragment.default() for key, fragment in fragments.items()
-                    }
-                    expected_values.update(
-                        {
-                            FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta",
-                            FLASH_KV_STAGE_KEY: 6,
-                            FLASH_PERSISTENT_KEY: False,
-                            FLASH_E2E_SCHEDULE_KEY: schedule,
-                            FLASH_E2E_OFFSET_KEY: offset,
-                            FLASH_E2E_OFFSET0_KEY: offset0,
-                            FLASH_EXP2_PACKET_KEY: packet,
-                            FLASH_STAT_TRANSPORT_KEY: stat_transport,
-                        }
-                    )
-                    dense_resident_policy = sm103_policy.dense_policy(num_kv)
-                    if (
-                        dense_resident_policy is not None
-                        and dense_resident_policy.corr_regs is not None
-                    ):
-                        assert dense_resident_policy.other_regs is not None
-                        expected_values[FLASH_CORR_REGS_KEY] = (
-                            dense_resident_policy.corr_regs
-                        )
-                        expected_values[FLASH_OTHER_REGS_KEY] = (
-                            dense_resident_policy.other_regs
-                        )
-                    expected = {
-                        "block_sizes": [1, 128, 128],
-                        **expected_values,
-                        FLASH_Q_TILE_COUNT_KEY: 2,
-                    }
-                self.assertEqual(seed.config, expected)
+                self.assertEqual(seed.config[FLASH_Q_TILE_COUNT_KEY], 2)
 
                 ranked = flash_attention_seed_configs(
                     64,
@@ -2788,7 +2733,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 self.assertEqual(roundtrip, seed)
 
     def test_cute_flash_sm103_seed_policy_changes_cache_identity(self) -> None:
-        def make_spec(target: tuple[int, int]) -> ConfigSpec:
+        def make_spec(
+            target: tuple[int, int], *, is_causal: bool = False
+        ) -> ConfigSpec:
             spec = ConfigSpec(
                 backend=CuteBackend(),
                 target_device_capability=target,
@@ -2802,14 +2749,18 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 num_kv=1024,
                 block_size_targets={0: 1, 1: 128, 2: 128},
                 dtype=torch.float16,
-                standard_dense_output=True,
+                is_causal=is_causal,
+                standard_dense_output=not is_causal,
+                standard_causal_output=is_causal,
             )
             spec.compiler_seed_configs = list(
                 flash_attention_seed_configs(
                     64,
                     1024,
                     dtype=torch.float16,
-                    standard_dense_output=True,
+                    is_causal=is_causal,
+                    standard_dense_output=not is_causal,
+                    standard_causal_output=is_causal,
                     target_device_capability=target,
                 )
             )
@@ -2830,6 +2781,21 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
 
         original_hash = sm103.cache_fingerprint_hash()
         target_policy = get_flash_target_policy((10, 3))
+        unrelated_tuning = dataclasses.replace(
+            target_policy.tuning,
+            dense_policies=tuple(
+                dataclasses.replace(policy, e2e_offset=policy.e2e_offset + 1)
+                if policy.num_kv == 256
+                else policy
+                for policy in target_policy.tuning.dense_policies
+            ),
+        )
+        with patch(
+            "helion._compiler.cute.flash_policy.get_flash_target_policy",
+            return_value=dataclasses.replace(target_policy, tuning=unrelated_tuning),
+        ):
+            self.assertEqual(sm103.cache_fingerprint_hash(), original_hash)
+
         dense_policy = target_policy.tuning.dense_policy(1024)
         assert dense_policy is not None
         changed_tuning = dataclasses.replace(
@@ -2849,6 +2815,110 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             return_value=dataclasses.replace(target_policy, tuning=changed_tuning),
         ):
             self.assertNotEqual(sm103.cache_fingerprint_hash(), original_hash)
+
+        causal_sm103 = make_spec((10, 3), is_causal=True)
+        causal_original_hash = causal_sm103.cache_fingerprint_hash()
+        with patch(
+            "helion._compiler.cute.flash_policy.get_flash_target_policy",
+            return_value=dataclasses.replace(target_policy, tuning=unrelated_tuning),
+        ):
+            self.assertEqual(
+                causal_sm103.cache_fingerprint_hash(), causal_original_hash
+            )
+
+        changed_causal_tuning = dataclasses.replace(
+            target_policy.tuning,
+            causal_policies=tuple(
+                dataclasses.replace(
+                    policy,
+                    softmax_lowering=FlashSoftmaxLowering.STANDARD,
+                )
+                if policy.num_kv == 1024
+                else policy
+                for policy in target_policy.tuning.causal_policies
+            ),
+        )
+        with patch(
+            "helion._compiler.cute.flash_policy.get_flash_target_policy",
+            return_value=dataclasses.replace(
+                target_policy, tuning=changed_causal_tuning
+            ),
+        ):
+            self.assertNotEqual(
+                causal_sm103.cache_fingerprint_hash(), causal_original_hash
+            )
+
+    def test_cute_flash_registered_causal_shape_builds_direct_target_seed(self) -> None:
+        target_policy = get_flash_target_policy((10, 3))
+        extra_policy = FlashCausalTuningPolicy(
+            num_kv=768,
+            kv_stage=4,
+            e2e_offset=2,
+            e2e_offset0=3,
+            softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            softmax_regs=184,
+        )
+        extended_tuning = dataclasses.replace(
+            target_policy.tuning,
+            causal_policies=(*target_policy.tuning.causal_policies, extra_policy),
+        )
+        with patch(
+            "helion._compiler.cute.cute_flash.get_flash_target_policy",
+            return_value=dataclasses.replace(
+                target_policy,
+                tuning=extended_tuning,
+            ),
+        ):
+            seed = flash_attention_seed_config(
+                64,
+                768,
+                dtype=torch.float16,
+                is_causal=True,
+                standard_causal_output=True,
+                target_device_capability=(10, 3),
+            )
+
+        assert seed is not None
+        self.assertEqual(seed.config[FLASH_KV_STAGE_KEY], 4)
+        self.assertEqual(seed.config[FLASH_E2E_OFFSET_KEY], 2)
+        self.assertEqual(seed.config[FLASH_E2E_OFFSET0_KEY], 3)
+        self.assertTrue(seed.config[FLASH_CAUSAL_LOOP_SPLIT_KEY])
+        self.assertEqual(seed.config[FLASH_CAUSAL_KV_ORDER_KEY], "descending")
+
+    def test_cute_flash_target_policy_seed_must_round_trip(self) -> None:
+        target_policy = get_flash_target_policy((10, 3))
+        invalid_dense_policy = FlashDenseTuningPolicy(
+            num_kv=256,
+            exp2_packet="deg1_16x8",
+            e2e_schedule="8/2",
+            e2e_offset=0,
+            e2e_offset0=0,
+            stat_transport="single",
+        )
+        invalid_tuning = dataclasses.replace(
+            target_policy.tuning,
+            dense_policies=(
+                invalid_dense_policy,
+                *target_policy.tuning.dense_policies[1:],
+            ),
+        )
+        with (
+            patch(
+                "helion._compiler.cute.cute_flash.get_flash_target_policy",
+                return_value=dataclasses.replace(
+                    target_policy,
+                    tuning=invalid_tuning,
+                ),
+            ),
+            self.assertRaisesRegex(ValueError, "does not round-trip"),
+        ):
+            flash_attention_seed_config(
+                64,
+                256,
+                dtype=torch.float16,
+                standard_dense_output=True,
+                target_device_capability=(10, 3),
+            )
 
     def test_cute_flash_target_policy_preserves_b200_fragment_surface(self) -> None:
         def fragment_signature(
@@ -2876,7 +2946,9 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         for is_causal in (False, True):
             baseline = fragment_signature(None, is_causal=is_causal)
             self.assertEqual(baseline, fragment_signature((10, 0), is_causal=is_causal))
-            self.assertEqual(baseline, fragment_signature((10, 4), is_causal=is_causal))
+            self.assertEqual(
+                baseline, fragment_signature((999, 999), is_causal=is_causal)
+            )
 
         sm103_fragments = flash_autotune_fragments(
             64,
@@ -2891,7 +2963,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertEqual(first_load.search_choices, (0,))
 
     def test_cute_flash_non_sm103_seed_order_is_unchanged(self) -> None:
-        targets = (None, (10, 0), (10, 2), (10, 4), (11, 0))
+        targets = (None, (10, 0), (999, 999))
         cases = (
             {
                 "num_kv": 1024,

--- a/test/test_cute_flash_arch.py
+++ b/test/test_cute_flash_arch.py
@@ -1,41 +1,93 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from helion._compiler.cute.flash_arch import FlashHardwareCapabilities
 from helion._compiler.cute.flash_policy import FlashTargetPolicy
+from helion._compiler.cute.flash_policy import flash_target_policy_cache_identity
 from helion._compiler.cute.flash_policy import get_flash_target_policy
+from helion._compiler.cute.flash_policy import registered_flash_target_policies
+from helion._compiler.cute.flash_tuning import FlashCausalSeedTemplate
 from helion._compiler.cute.flash_tuning import FlashCausalTuningPolicy
 from helion._compiler.cute.flash_tuning import FlashDenseTuningPolicy
 from helion._compiler.cute.flash_tuning import FlashPackedExp2Mode
 from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
+from helion._compiler.cute.flash_tuning import FlashTuningDType
 from helion._compiler.cute.flash_tuning import FlashTuningPolicy
+from helion._compiler.cute.flash_tuning import FlashTuningWorkload
 
 
-def test_sm103_flash_hardware_capabilities() -> None:
-    capabilities = get_flash_target_policy((10, 3)).hardware
+def test_sm103_flash_target_policy() -> None:
+    target_policy = get_flash_target_policy((10, 3))
+    capabilities = target_policy.hardware
+    policy = target_policy.tuning
 
+    assert dict(registered_flash_target_policies())[(10, 3)] == target_policy
     assert capabilities.supports_tmem_row_reduce
     assert capabilities.supports_packed_f16x2_exp2
-
-
-@pytest.mark.parametrize(
-    "capability",
-    [None, (10, 0), (10, 2), (10, 4), (11, 0)],
-)
-def test_unknown_and_b200_flash_hardware_capabilities_are_generic(
-    capability: tuple[int, int] | None,
-) -> None:
-    capabilities = get_flash_target_policy(capability).hardware
-
-    assert not capabilities.supports_tmem_row_reduce
-    assert not capabilities.supports_packed_f16x2_exp2
-
-
-def test_sm103_flash_tuning_policy() -> None:
-    policy = get_flash_target_policy((10, 3)).tuning
-
+    assert policy.workload == FlashTuningWorkload()
     assert policy.tmem_row_reduce_min_kv == 256
+    assert (
+        flash_target_policy_cache_identity(
+            (10, 3), head_dim=64, torch_dtype="float16", num_kv=256
+        )
+        is not None
+    )
+    assert (
+        flash_target_policy_cache_identity(
+            (10, 3), head_dim=128, torch_dtype="float16", num_kv=256
+        )
+        is None
+    )
+    assert (
+        flash_target_policy_cache_identity(
+            (10, 3), head_dim=64, torch_dtype="bfloat16", num_kv=256
+        )
+        is None
+    )
+    bfloat_tuning = FlashTuningPolicy(
+        workload=FlashTuningWorkload(
+            head_dim=128,
+            dtype=FlashTuningDType.BFLOAT16,
+        ),
+        tmem_row_reduce_min_kv=512,
+    )
+    multi_workload_policy = FlashTargetPolicy(
+        hardware=capabilities,
+        tuning=policy,
+        additional_tunings=(bfloat_tuning,),
+    )
+    assert multi_workload_policy.tuning_for_torch(128, "bfloat16") is bfloat_tuning
+    assert (
+        multi_workload_policy.tuning_for_cute(128, "cutlass.BFloat16") is bfloat_tuning
+    )
+    with patch(
+        "helion._compiler.cute.flash_policy.get_flash_target_policy",
+        return_value=multi_workload_policy,
+    ):
+        bfloat_identity = flash_target_policy_cache_identity(
+            (10, 3), head_dim=128, torch_dtype="bfloat16", num_kv=512
+        )
+    changed_bfloat_policy = FlashTargetPolicy(
+        hardware=capabilities,
+        tuning=policy,
+        additional_tunings=(
+            FlashTuningPolicy(
+                workload=bfloat_tuning.workload,
+                tmem_row_reduce_min_kv=1024,
+            ),
+        ),
+    )
+    with patch(
+        "helion._compiler.cute.flash_policy.get_flash_target_policy",
+        return_value=changed_bfloat_policy,
+    ):
+        changed_bfloat_identity = flash_target_policy_cache_identity(
+            (10, 3), head_dim=128, torch_dtype="bfloat16", num_kv=512
+        )
+    assert bfloat_identity != changed_bfloat_identity
 
     expected_dense = {
         256: (
@@ -47,12 +99,11 @@ def test_sm103_flash_tuning_policy() -> None:
             "fa4_2cta",
             6,
             False,
-            2,
             FlashPackedExp2Mode.DISABLED,
             7,
             FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
-            None,
-            None,
+            64,
+            40,
         ),
         512: (
             "deg1_8x2_corr10",
@@ -63,7 +114,6 @@ def test_sm103_flash_tuning_policy() -> None:
             "fa4_2cta",
             6,
             False,
-            2,
             FlashPackedExp2Mode.DISABLED,
             7,
             FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
@@ -79,12 +129,11 @@ def test_sm103_flash_tuning_policy() -> None:
             "fa4_2cta",
             6,
             False,
-            2,
             FlashPackedExp2Mode.DISABLED,
             7,
             FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
-            None,
-            None,
+            72,
+            40,
         ),
         2048: (
             "deg1_16x8",
@@ -95,12 +144,11 @@ def test_sm103_flash_tuning_policy() -> None:
             "fa4_2cta",
             6,
             False,
-            2,
             FlashPackedExp2Mode.ALL_XU,
             7,
             FlashSoftmaxLowering.STANDARD,
-            None,
-            None,
+            80,
+            32,
         ),
     }
     assert {shape.num_kv for shape in policy.dense_policies} == set(expected_dense)
@@ -116,7 +164,6 @@ def test_sm103_flash_tuning_policy() -> None:
             shape.pipeline_family,
             shape.kv_stage,
             shape.persistent,
-            shape.q_tile_count,
             shape.packed_exp2_mode,
             shape.probability_log2_shift,
             shape.softmax_lowering,
@@ -128,31 +175,55 @@ def test_sm103_flash_tuning_policy() -> None:
     expected_causal = {
         512: (
             8,
-            2,
+            FlashCausalSeedTemplate.DEGREE2_V1,
+            15,
+            3,
+            "fa4",
+            True,
             FlashSoftmaxLowering.STATEFUL,
             200,
             2,
+            True,
+            "descending",
         ),
         1024: (
             3,
-            2,
+            FlashCausalSeedTemplate.DEGREE2_V1,
+            1,
+            14,
+            "fa4",
+            False,
             FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
-            None,
-            None,
+            184,
+            0,
+            True,
+            "descending",
         ),
         2048: (
             3,
-            2,
+            FlashCausalSeedTemplate.DEGREE2_V1,
+            14,
+            12,
+            "fa4",
+            False,
             FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
-            None,
-            None,
+            184,
+            0,
+            True,
+            "descending",
         ),
         4096: (
             6,
-            2,
+            FlashCausalSeedTemplate.DEGREE2_V1,
+            14,
+            12,
+            "helion",
+            False,
             FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
-            None,
-            None,
+            184,
+            0,
+            True,
+            "descending",
         ),
     }
     assert {shape.num_kv for shape in policy.causal_policies} == set(expected_causal)
@@ -161,23 +232,30 @@ def test_sm103_flash_tuning_policy() -> None:
         assert shape is not None
         assert (
             shape.kv_stage,
-            shape.q_tile_count,
+            shape.seed_template,
+            shape.e2e_offset,
+            shape.e2e_offset0,
+            shape.role_map,
+            shape.epi_tma,
             shape.softmax_lowering,
             shape.softmax_regs,
             shape.first_load_order,
+            shape.causal_loop_split,
+            shape.causal_kv_order,
         ) == expected
     assert policy.causal_policy(256) is None
 
 
-@pytest.mark.parametrize(
-    "capability",
-    [None, (10, 0), (10, 2), (10, 4), (11, 0)],
-)
-def test_unknown_and_b200_flash_tuning_policy_is_generic(
+@pytest.mark.parametrize("capability", [None, (10, 0), (999, 999)])
+def test_unknown_and_b200_flash_target_policy_is_generic(
     capability: tuple[int, int] | None,
 ) -> None:
-    policy = get_flash_target_policy(capability).tuning
+    target_policy = get_flash_target_policy(capability)
+    capabilities = target_policy.hardware
+    policy = target_policy.tuning
 
+    assert not capabilities.supports_tmem_row_reduce
+    assert not capabilities.supports_packed_f16x2_exp2
     assert policy.tmem_row_reduce_min_kv is None
     assert not policy.dense_policies
     assert policy.dense_policy(256) is None
@@ -186,7 +264,7 @@ def test_unknown_and_b200_flash_tuning_policy_is_generic(
 
 
 def test_flash_policy_rejects_duplicate_shapes() -> None:
-    dense = FlashDenseTuningPolicy(256, "packet", "8/2", 0, 0, "single")
+    dense = FlashDenseTuningPolicy(256, "1x1", "8/2", 0, 0, "single")
     causal = FlashCausalTuningPolicy(512, 3)
 
     with pytest.raises(ValueError, match="dense KV sizes must be unique"):
@@ -196,16 +274,20 @@ def test_flash_policy_rejects_duplicate_shapes() -> None:
 
 
 def test_flash_policy_rejects_invalid_field_combinations() -> None:
+    with pytest.raises(ValueError, match="head dimension"):
+        FlashTuningWorkload(head_dim=0)
+    with pytest.raises(ValueError, match="workloads must be unique"):
+        FlashTargetPolicy(additional_tunings=(FlashTuningPolicy(),))
     with pytest.raises(ValueError, match="TMEM row-reduce minimum KV size"):
         FlashTuningPolicy(tmem_row_reduce_min_kv=0)
     with pytest.raises(ValueError, match="probability log2 shift"):
         FlashDenseTuningPolicy(
-            256, "packet", "8/2", 0, 0, "single", probability_log2_shift=-1
+            256, "1x1", "8/2", 0, 0, "single", probability_log2_shift=-1
         )
     with pytest.raises(ValueError, match="register counts must be set together"):
         FlashDenseTuningPolicy(
             512,
-            "packet",
+            "1x1",
             "8/2",
             0,
             0,
@@ -216,19 +298,55 @@ def test_flash_policy_rejects_invalid_field_combinations() -> None:
         FlashCausalTuningPolicy(512, 8, first_load_order=5)
     with pytest.raises(ValueError, match="positive multiple of 8"):
         FlashCausalTuningPolicy(512, 8, softmax_regs=199)
-    with pytest.raises(ValueError, match="query tile count must be 2"):
-        FlashDenseTuningPolicy(256, "packet", "8/2", 0, 0, "single", q_tile_count=1)
-    with pytest.raises(ValueError, match="query tile count must be 2"):
-        FlashCausalTuningPolicy(512, 8, q_tile_count=1)
+    with pytest.raises(ValueError, match="end-to-end offsets"):
+        FlashCausalTuningPolicy(512, 8, e2e_offset=-1)
+    with pytest.raises(ValueError, match="role map"):
+        FlashCausalTuningPolicy(512, 8, role_map="")
+    with pytest.raises(ValueError, match="exp2 packet"):
+        FlashDenseTuningPolicy(256, "unknown", "8/2", 0, 0, "single")
+    with pytest.raises(ValueError, match="end-to-end schedule"):
+        FlashDenseTuningPolicy(256, "1x1", "unknown", 0, 0, "single")
+    with pytest.raises(ValueError, match="statistics transport"):
+        FlashDenseTuningPolicy(256, "1x1", "8/2", 0, 0, "unknown")
+    with pytest.raises(ValueError, match="pipeline family"):
+        FlashDenseTuningPolicy(
+            256, "1x1", "8/2", 0, 0, "single", pipeline_family="unknown"
+        )
+    with pytest.raises(ValueError, match="role map"):
+        FlashCausalTuningPolicy(512, 8, role_map="unknown")
     with pytest.raises(ValueError, match="unsupported for dense"):
         FlashDenseTuningPolicy(
             256,
-            "packet",
+            "1x1",
             "8/2",
             0,
             0,
             "single",
             softmax_lowering=FlashSoftmaxLowering.STATEFUL,
+        )
+    with pytest.raises(ValueError, match="single statistics transport"):
+        FlashDenseTuningPolicy(
+            256,
+            "1x1",
+            "8/2",
+            0,
+            0,
+            "ring2",
+            softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+        )
+    with pytest.raises(ValueError, match="descending split loop"):
+        FlashCausalTuningPolicy(
+            768,
+            4,
+            softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            causal_loop_split=False,
+        )
+    with pytest.raises(ValueError, match="descending split loop"):
+        FlashCausalTuningPolicy(
+            768,
+            4,
+            softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            causal_kv_order="ascending",
         )
 
 
@@ -241,7 +359,7 @@ def test_target_policy_rejects_tuning_without_hardware_support() -> None:
                 dense_policies=(
                     FlashDenseTuningPolicy(
                         256,
-                        "packet",
+                        "1x1",
                         "8/2",
                         0,
                         0,
@@ -277,6 +395,24 @@ def test_target_policy_rejects_tuning_without_hardware_support() -> None:
                 ),
             ),
         )
+    with pytest.raises(ValueError, match="FP16 head-dim-64"):
+        FlashTargetPolicy(
+            hardware=FlashHardwareCapabilities(supports_tmem_row_reduce=True),
+            tuning=FlashTuningPolicy(
+                workload=FlashTuningWorkload(
+                    head_dim=128,
+                    dtype=FlashTuningDType.BFLOAT16,
+                ),
+                tmem_row_reduce_min_kv=256,
+                causal_policies=(
+                    FlashCausalTuningPolicy(
+                        512,
+                        8,
+                        softmax_lowering=FlashSoftmaxLowering.STATEFUL,
+                    ),
+                ),
+            ),
+        )
 
     FlashTargetPolicy(
         hardware=FlashHardwareCapabilities(
@@ -288,7 +424,7 @@ def test_target_policy_rejects_tuning_without_hardware_support() -> None:
             dense_policies=(
                 FlashDenseTuningPolicy(
                     256,
-                    "packet",
+                    "1x1",
                     "8/2",
                     0,
                     0,

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -22,6 +22,8 @@ from helion._compiler.cute.attention_plan import causal_score_plan
 from helion._compiler.cute.attention_plan import dense_score_plan
 from helion._compiler.cute.causal_range import CausalRangeProof
 from helion._compiler.cute.flash_policy import get_flash_target_policy
+from helion._compiler.cute.flash_policy import registered_flash_target_policies
+from helion._compiler.cute.flash_tuning import FlashCausalTuningPolicy
 from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
 from helion._testing import DEVICE
 from helion._testing import code_and_output
@@ -170,6 +172,7 @@ def _hybrid_runtime_config() -> dict[str, object]:
 def _emit_causal_resident_native_source(
     *,
     capability: tuple[int, int] = (10, 3),
+    seed_capability: tuple[int, int] | None = None,
     has_lse: bool = False,
     score_plan: AttentionScorePlan | None = None,
     num_kv: int = 512,
@@ -177,6 +180,8 @@ def _emit_causal_resident_native_source(
 ) -> str:
     if score_plan is None:
         score_plan = causal_score_plan(64)
+    if seed_capability is None:
+        seed_capability = capability
     with patch.dict(os.environ, {}, clear=True):
         seed = cute_flash.flash_attention_seed_config(
             64,
@@ -184,7 +189,7 @@ def _emit_causal_resident_native_source(
             dtype=torch.float16,
             is_causal=True,
             standard_causal_output=True,
-            target_device_capability=(10, 3),
+            target_device_capability=seed_capability,
         )
         assert seed is not None
         manual_overrides = dict(seed.config)
@@ -216,6 +221,7 @@ def _emit_causal_resident_native_source(
 def _emit_dense_resident_value_graph_source(
     *,
     capability: tuple[int, int] = (10, 3),
+    seed_capability: tuple[int, int] | None = None,
     has_lse: bool = False,
     score_plan: AttentionScorePlan | None = None,
     num_kv: int = 256,
@@ -223,6 +229,8 @@ def _emit_dense_resident_value_graph_source(
 ) -> str:
     if score_plan is None:
         score_plan = dense_score_plan(64)
+    if seed_capability is None:
+        seed_capability = capability
     with patch.dict(os.environ, {}, clear=True):
         seed = cute_flash.flash_attention_seed_config(
             64,
@@ -230,7 +238,7 @@ def _emit_dense_resident_value_graph_source(
             dtype=torch.float16,
             is_causal=False,
             standard_dense_output=True,
-            target_device_capability=(10, 3),
+            target_device_capability=seed_capability,
         )
         assert seed is not None
         manual_overrides = dict(seed.config)
@@ -279,6 +287,29 @@ def test_causal_split_equal_iteration_proof_is_explicit() -> None:
         False, "FA4 resident path requires two query slots"
     )
     assert proven.proven
+
+
+def test_registered_causal_shape_selects_requested_resident_lowering() -> None:
+    target_policy = get_flash_target_policy((10, 3))
+    extra_policy = FlashCausalTuningPolicy(
+        num_kv=768,
+        kv_stage=4,
+        e2e_offset=2,
+        e2e_offset0=3,
+        softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+        softmax_regs=184,
+    )
+    extended_tuning = dataclasses.replace(
+        target_policy.tuning,
+        causal_policies=(*target_policy.tuning.causal_policies, extra_policy),
+    )
+    with patch(
+        "helion._compiler.cute.cute_flash.get_flash_target_policy",
+        return_value=dataclasses.replace(target_policy, tuning=extended_tuning),
+    ):
+        source = _emit_causal_resident_native_source(num_kv=768)
+
+    assert "resident_softmax_value_graph" in source
 
 
 def test_degree2_polynomial_relative_error_bound() -> None:
@@ -496,12 +527,12 @@ def test_dense_target_lowering_match_is_environment_independent() -> None:
     )
 
     with patch.dict(os.environ, {"HELION_CUTE_FLASH_WAIT_HINT": "0"}):
-        assert cute_flash._flash_dense_resident_seed_matches(dense_cfg, 256, (10, 3))
+        policy = get_flash_target_policy((10, 3)).tuning.dense_policy(256)
+        assert cute_flash._flash_dense_resident_seed_matches(dense_cfg, policy)
 
 
-@pytest.mark.parametrize("num_kv", (256, 512, 1024))
-def test_dense_resident_value_graph_codegen_and_barrier_protocol(num_kv: int) -> None:
-    source = _emit_dense_resident_value_graph_source(num_kv=num_kv)
+def test_dense_resident_value_graph_codegen_and_barrier_protocol() -> None:
+    source = _emit_dense_resident_value_graph_source()
     module = ast.parse(source)
     value_graph_calls = [
         node
@@ -513,9 +544,9 @@ def test_dense_resident_value_graph_codegen_and_barrier_protocol(num_kv: int) ->
 
     assert len(value_graph_calls) == 2
     for call in value_graph_calls:
-        assert ast.unparse(call.args[10]).endswith("_corr_empty_ptr + 0")
-        assert ast.unparse(call.args[11]) == "flash_s_corr_prod_phase"
-        assert ast.unparse(call.args[12]) == "flash_row_sum * flash_alpha"
+        assert ast.unparse(call.args[9]).endswith("_corr_empty_ptr + 0")
+        assert ast.unparse(call.args[10]) == "flash_s_corr_prod_phase"
+        assert ast.unparse(call.args[11]) == "flash_row_sum * flash_alpha"
         assert {
             keyword.arg: ast.unparse(keyword.value) for keyword in call.keywords
         } == {
@@ -575,6 +606,28 @@ def test_dense_resident_value_graph_codegen_and_barrier_protocol(num_kv: int) ->
     assert alpha0 < pfor0 < release1 < alpha1 < pfor1 < release0
 
 
+@pytest.mark.parametrize(
+    ("capability", "num_kv"),
+    tuple(
+        (capability, shape_policy.num_kv)
+        for capability, target_policy in registered_flash_target_policies()
+        for tuning in target_policy.tunings
+        if tuning.workload.head_dim == 64 and tuning.workload.dtype.value == "float16"
+        for shape_policy in tuning.dense_policies
+        if shape_policy.softmax_lowering is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+    ),
+)
+def test_dense_resident_value_graph_selects_registered_shapes(
+    capability: tuple[int, int], num_kv: int
+) -> None:
+    source = _emit_dense_resident_value_graph_source(
+        capability=capability,
+        num_kv=num_kv,
+    )
+
+    assert "resident_softmax_value_graph" in source
+
+
 def test_dense_resident_value_graph_gate_preserves_fallbacks() -> None:
     base_plan = dense_score_plan(64)
     modified_plan = dataclasses.replace(
@@ -582,8 +635,12 @@ def test_dense_resident_value_graph_gate_preserves_fallbacks() -> None:
         modifiers=(AttentionScoreModifier(SOFTCAP_KIND, value_log2=2.0),),
     )
     fallback_sources = (
-        _emit_dense_resident_value_graph_source(capability=(10, 0)),
-        _emit_dense_resident_value_graph_source(capability=(10, 4)),
+        _emit_dense_resident_value_graph_source(
+            capability=(10, 0), seed_capability=(10, 3)
+        ),
+        _emit_dense_resident_value_graph_source(
+            capability=(999, 999), seed_capability=(10, 3)
+        ),
         _emit_dense_resident_value_graph_source(num_kv=2048),
         _emit_dense_resident_value_graph_source(has_lse=True),
         _emit_dense_resident_value_graph_source(score_plan=modified_plan),
@@ -594,32 +651,6 @@ def test_dense_resident_value_graph_gate_preserves_fallbacks() -> None:
     for fallback_source in fallback_sources:
         assert "resident_softmax_value_graph" not in fallback_source
         assert "fa4_sp_exp_convert_store_whole_rowsum" in fallback_source
-
-
-def test_sm103_dense64_register_policy_is_target_specific() -> None:
-    sm103_seed = cute_flash.flash_attention_seed_config(
-        64,
-        512,
-        dtype=torch.float16,
-        is_causal=False,
-        standard_dense_output=True,
-        target_device_capability=(10, 3),
-    )
-    sm100_seed = cute_flash.flash_attention_seed_config(
-        64,
-        512,
-        dtype=torch.float16,
-        is_causal=False,
-        standard_dense_output=True,
-        target_device_capability=(10, 0),
-    )
-
-    assert sm103_seed is not None
-    assert sm100_seed is not None
-    assert sm103_seed.config[cute_flash.FLASH_CORR_REGS_KEY] == 72
-    assert sm103_seed.config[cute_flash.FLASH_OTHER_REGS_KEY] == 40
-    assert sm100_seed.config[cute_flash.FLASH_CORR_REGS_KEY] == 80
-    assert sm100_seed.config[cute_flash.FLASH_OTHER_REGS_KEY] == 32
 
 
 def test_dense_resident_softmax_lowering_dispatch_is_exhaustive() -> None:
@@ -694,7 +725,7 @@ def test_causal_resident_native_codegen_and_single_stat_protocol() -> None:
     assert "flash_s_corr_cons_index" not in source
     assert source.count("flash_s_corr_prod_phase = cutlass.Int32(1)") == 2
     assert source.count("ResidentSoftmaxState.create") == 2
-    assert source.count("flash_softmax.reset()") == 2
+    assert "flash_softmax.reset()" not in source
     assert source.count("update_row_max_masked(tLDrS.load(), True)") == 2
     assert source.count("update_row_max_masked(tLDrS.load(), False)") == 2
     assert source.count("update_row_max_precomputed(flash_hw_row_max, False)") == 2
@@ -702,7 +733,6 @@ def test_causal_resident_native_codegen_and_single_stat_protocol() -> None:
     assert source.count("flash_softmax.apply_exp2_convert") == 6
     assert source.count("flash_tSrP_f32 = cute.make_rmem_tensor") == 6
     assert source.count("dtype=cutlass.Float16), tLDrS.layout") == 6
-    assert source.count("flash_softmax.acquire_stats") == 6
     assert source.count("flash_softmax.update_row_sum") == 6
     assert source.count("tLDrS.load(), flash_alpha, True") == 2
     assert source.count("tLDrS.load(), flash_alpha)") == 4
@@ -739,7 +769,11 @@ def test_causal_resident_native_codegen_and_single_stat_protocol() -> None:
     scale_subtract = masked.index("flash_softmax.scale_subtract_rowmax", alpha_ready)
     fresh_p = masked.index("flash_tSrP_f32 = cute.make_rmem_tensor", scale_subtract)
     early_pack = masked.index("flash_softmax.apply_exp2_convert", fresh_p)
-    stats_acquire = masked.index("flash_softmax.acquire_stats", early_pack)
+    stats_wait = (
+        "_helion_flash_rt.mbar_spin_wait(flash_s0_corr_empty_ptr + 0, "
+        "flash_s_corr_prod_phase, 0)"
+    )
+    stats_acquire = masked.index(stats_wait, early_pack)
     row_sum = masked.index("flash_softmax.update_row_sum", stats_acquire)
     phase_advance = masked.index("flash_s_corr_prod_phase ^= 1", row_sum)
     assert (
@@ -897,8 +931,12 @@ def test_causal_resident_native_gate_preserves_fallbacks() -> None:
         ),
     )
     fallback_sources = (
-        _emit_causal_resident_native_source(capability=(10, 0)),
-        _emit_causal_resident_native_source(capability=(10, 4)),
+        _emit_causal_resident_native_source(
+            capability=(10, 0), seed_capability=(10, 3)
+        ),
+        _emit_causal_resident_native_source(
+            capability=(999, 999), seed_capability=(10, 3)
+        ),
         _emit_causal_resident_native_source(has_lse=True),
         _emit_causal_resident_native_source(score_plan=modified_plan),
         _emit_causal_resident_native_source(num_kv=256),
@@ -969,6 +1007,7 @@ def test_causal_resident_native_matches_sdpa_without_deadlock() -> None:
     ("num_kv", "repeat_count"),
     (
         (1024, 31),
+        (2048, 3),
         (4096, 3),
     ),
 )
@@ -1036,9 +1075,8 @@ def test_causal_target_lowering_match_is_environment_independent() -> None:
     )
 
     with patch.dict(os.environ, {"HELION_CUTE_FLASH_WAIT_HINT": "0"}):
-        assert cute_flash._flash_causal_resident_native_seed_matches(
-            causal_cfg, 512, (10, 3)
-        )
+        policy = get_flash_target_policy((10, 3)).tuning.causal_policy(512)
+        assert cute_flash._flash_causal_resident_native_seed_matches(causal_cfg, policy)
 
     effective = cute_flash._flash_resident_softmax_config(causal_cfg)
     assert causal_cfg.exp2_packet == _DEG2_PACKET
@@ -1068,7 +1106,6 @@ def test_hybrid_packet_uses_degree1_only_for_unmasked_pass2() -> None:
         has_lse=False,
         io_dtype="cutlass.Float16",
         score_plan=causal_score_plan(64),
-        target_device_capability=(10, 3),
     )
     module = ast.Module(body=body, type_ignores=[])
     pass2_calls = [
@@ -1151,7 +1188,6 @@ def test_polynomial_packet_uses_whole_row_dense_pass2(
         has_lse=False,
         io_dtype="cutlass.Float16",
         score_plan=dense_score_plan(64),
-        target_device_capability=(10, 0),
     )
     module = ast.Module(body=body, type_ignores=[])
     pass2_calls = [
@@ -1210,7 +1246,6 @@ def test_short_degree1_packet_reverses_steady_correction_order(
         has_lse=False,
         io_dtype="cutlass.Float16",
         score_plan=dense_score_plan(64),
-        target_device_capability=(10, 3),
     )
     correction_loop = next(
         node
@@ -1273,7 +1308,6 @@ def _emit_dense_single_stat_source(
             has_lse=False,
             io_dtype="cutlass.Float16",
             score_plan=dense_score_plan(64),
-            target_device_capability=(10, 3),
         )
     return ast.unparse(ast.Module(body=body, type_ignores=[]))
 
@@ -1681,7 +1715,6 @@ def test_dense_ring2_emits_two_slot_stat_protocol() -> None:
             has_lse=False,
             io_dtype="cutlass.Float16",
             score_plan=dense_score_plan(64),
-            target_device_capability=(10, 3),
         )
         return ast.unparse(ast.Module(body=body, type_ignores=[]))
 

--- a/test/test_cute_flash_schedule.py
+++ b/test/test_cute_flash_schedule.py
@@ -528,17 +528,9 @@ def test_persistent_phase_continuity_at_work_boundary(
     assert cycles["pfor_q0"].phases == (0, middle_phase, 0)
 
 
-@pytest.mark.parametrize(
-    "stat_release_mapping",
-    (
-        FlashStatReleaseMapping.CROSS_SLOT,
-        FlashStatReleaseMapping.SAME_SLOT,
-    ),
-)
 @pytest.mark.parametrize("kv_iterations", (3, 4))
 def test_pipelined_stat_handoff_models_dummy_and_final_events(
     kv_iterations: int,
-    stat_release_mapping: FlashStatReleaseMapping,
 ) -> None:
     schedule = build_fa4_schedule(
         FlashScheduleSpec(
@@ -548,7 +540,6 @@ def test_pipelined_stat_handoff_models_dummy_and_final_events(
             kv_iterations=kv_iterations,
             stat_depth=1,
             pipelined_stat_handoff=True,
-            stat_release_mapping=stat_release_mapping,
         )
     )
 
@@ -588,51 +579,56 @@ def test_pipelined_stat_handoff_models_dummy_and_final_events(
     )
 
 
-def test_pipelined_stat_handoff_defaults_to_cross_slot_releases() -> None:
+@pytest.mark.parametrize(
+    ("causal", "mapping", "expected_releases"),
+    (
+        (
+            False,
+            FlashStatReleaseMapping.CROSS_SLOT,
+            {
+                ("correction_r0_q0", "stat_r0_q1", 0, "stat_empty_r0_q1"),
+                ("correction_r0_q1", "stat_r0_q0", 1, "stat_empty_r0_q0"),
+            },
+        ),
+        (
+            True,
+            FlashStatReleaseMapping.SAME_SLOT,
+            {
+                ("correction_r0_q0", "stat_r0_q0", 1, "stat_empty_r0_q0"),
+                ("correction_r0_q1", "stat_r0_q1", 1, "stat_empty_r0_q1"),
+            },
+        ),
+    ),
+)
+def test_pipelined_stat_release_mappings(
+    causal: bool,
+    mapping: FlashStatReleaseMapping,
+    expected_releases: set[tuple[str, str, int, str]],
+) -> None:
     schedule = build_fa4_schedule(
         FlashScheduleSpec(
             64,
             2,
+            causal=causal,
             stat_depth=1,
             pipelined_stat_handoff=True,
+            stat_release_mapping=mapping,
         )
     )
 
     verify_flash_schedule(schedule)
 
-    assert schedule.spec.stat_release_mapping is FlashStatReleaseMapping.CROSS_SLOT
-    assert {
-        (edge.source, edge.target, edge.iteration_delta, edge.barrier)
-        for edge in schedule.edges
-        if edge.barrier is not None and edge.barrier.startswith("stat_empty_")
-    } == {
-        ("correction_r0_q0", "stat_r0_q1", 0, "stat_empty_r0_q1"),
-        ("correction_r0_q1", "stat_r0_q0", 1, "stat_empty_r0_q0"),
-    }
-
-
-def test_causal_pipelined_stat_handoff_uses_same_slot_releases() -> None:
-    schedule = build_fa4_schedule(
-        FlashScheduleSpec(
-            64,
-            2,
-            causal=True,
-            stat_depth=1,
-            pipelined_stat_handoff=True,
-            stat_release_mapping=FlashStatReleaseMapping.SAME_SLOT,
+    if mapping is FlashStatReleaseMapping.CROSS_SLOT:
+        assert (
+            FlashScheduleSpec(64, 2).stat_release_mapping
+            is FlashStatReleaseMapping.CROSS_SLOT
         )
-    )
-
-    verify_flash_schedule(schedule)
-
+    assert schedule.spec.stat_release_mapping is mapping
     assert {
         (edge.source, edge.target, edge.iteration_delta, edge.barrier)
         for edge in schedule.edges
         if edge.barrier is not None and edge.barrier.startswith("stat_empty_")
-    } == {
-        ("correction_r0_q0", "stat_r0_q0", 1, "stat_empty_r0_q0"),
-        ("correction_r0_q1", "stat_r0_q1", 1, "stat_empty_r0_q1"),
-    }
+    } == expected_releases
 
 
 @pytest.mark.parametrize(
@@ -699,18 +695,14 @@ def test_pipelined_stat_release_mapping_corruption_is_rejected(
         verify_flash_schedule(schedule)
 
 
-@pytest.mark.parametrize(
-    "spec",
-    (FlashScheduleSpec(64, 2, stat_depth=2, pipelined_stat_handoff=True),),
-)
-def test_pipelined_stat_handoff_rejects_unsupported_schedules(
-    spec: FlashScheduleSpec,
-) -> None:
+def test_pipelined_stat_handoff_rejects_unsupported_schedules() -> None:
     with pytest.raises(
         FlashScheduleError,
         match="pipelined stat handoff requires depth one",
     ):
-        build_fa4_schedule(spec)
+        build_fa4_schedule(
+            FlashScheduleSpec(64, 2, stat_depth=2, pipelined_stat_handoff=True)
+        )
 
 
 def test_causal_cross_slot_stat_releases_are_rejected() -> None:


### PR DESCRIPTION
Stacked PRs:
 * #3423
 * __->__#3420
 * #3419
 * #3418
 * #3417


--- --- ---

## Summary

Finish the stack by generalizing target registration and simplifying the resident-lowering plumbing.

- Support multiple workload envelopes per target through `FlashTuningWorkload` and typed tuning dtypes.
- Make causal seed templates and all target-owned causal fields explicit.
- Build target seeds directly from registered fragments, including newly registered shapes outside the legacy whitelist.
- Scope cache identity by workload, dense/causal mode, shape, and selected lowering policy.
- Remove false/duplicate configurability and validate policy-to-seed-to-codegen contracts before emission.

Depends on #3419. This is PR 5/6.

## GB300 performance

NVIDIA GB300, verified 1400 W cap, FP16, `z=2`, `h=32`, head dimension 64. Values are median-of-medians; lower latency is better.

| shape | Helion ms | Helion TFLOP/s | FA4 ms | FA4 TFLOP/s | Helion lead |
|---|---:|---:|---:|---:|---:|
| dense 32K | 13.4782 | 1305.2 | 14.2186 | 1237.3 | 5.4933% |
| dense 64K | 53.5849 | 1313.2 | 56.7502 | 1240.0 | 5.9071% |
| dense 128K | 213.5547 | 1318.0 | 226.9318 | 1240.4 | 6.2640% |
| dense 256K | 895.4695 | 1257.3 | 912.5888 | 1233.7 | 1.9118% |
| causal 64K | 26.8351 | 1311.1 | 26.9695 | 1304.6 | 0.5008% |
| causal 128K | 105.1077 | 1339.0 | 106.7894 | 1317.9 | 1.6000% |
| causal 256K | 417.1358 | 1349.6 | 424.4296 | 1326.4 | 1.7485% |
| causal 512K | 1666.0634 | 1351.6 | 1703.3185 | 1322.0 | 2.2361% |

Helion ranks first on all 8 shapes and has a **3.1857% geometric-mean latency lead over FA4**. All 40 backend/shape correctness checks passed.

## Benchmark methodology

- Five backends: Helion CuTe, PyTorch FlexAttention/Triton, FlexAttention/CuTe, cuDNN SDPA, and FA4 beta26.
- Each implementation runs in a fresh subprocess with isolated Helion, CuTe, and Inductor caches.
- Five cache-warmup calls, a 10 s thermal warmup, then five `do_bench` runs with `warmup=1000 ms` and `rep=500 ms`.
- CUDA-event timing for Helion, matching the other backends.
- `--helion-force-flash-config 1` selects the compiler-promoted seed; this is not a full autotune run.
- `--power-cap-w 1400` verifies and records the already configured cap; it does not set GPU power.

```bash
run_dir=$(mktemp -d /tmp/helion-gb300-attention-modular-final.XXXXXX)
printf '%s\n' "$run_dir" | tee /tmp/helion-gb300-modular-final-run-dir
CUDA_VISIBLE_DEVICES=0 \
HELION_FA4_ROOT=/home/jongsokchoi/helion_2/benchmarks/flash-attention \
HELION_CACHE_DIR="$run_dir/helion-cache" \
CUTE_DSL_CACHE_DIR="$run_dir/cute-cache" \
TORCHINDUCTOR_CACHE_DIR="$run_dir/inductor-cache" \
.venv/bin/python benchmarks/cute/compare_attention_backends.py \
  --all-shapes --shape-suite dense_causal8 \
  --impls helion-cute flexattention flexattention-cute sdpa fa4 \
  --num-runs 5 --warmup-ms 1000 --rep-ms 500 \
  --power-cap-w 1400 --skip-correctness 0 \
  --helion-force-flash-config 1 \
  --helion-cute-benchmark-timer event \
  --stream-subprocesses \
  --output "$run_dir/results.md" \
  --csv-output "$run_dir/results.csv" \
  --plot-output "$run_dir/results.png" \
  --summary-plot-output "$run_dir/results-geomean.png"
```

## B200 preservation

No physical B200 was available for a fresh timing run. The preservation check is mechanical: all eight SM100/B200 generated sources are byte-identical to the corresponding base sources and their configurations are unchanged. This stack therefore makes no new physical B200 performance claim.

## Verification

- Current-main CuTe suite: 2,733 passed, 1,367 skipped, 5 expected xfails; two hardware failures reproduce on a clean `origin/main` checkout.
- Current-main default suite: 2,522 passed; 29 external-service/environment failures and one hardware failure that reproduces on clean `origin/main`.
- Post-stack-pr hardening critical checks: 219 default and 342 CuTe tests passed.
- Ruff and codespell clean; scoped Pyrefly reports 0 errors.
- Fresh-cache GB300 correctness: all 8 promoted shapes passed against SDPA.
- Two independent adversarial reviews completed with LGTM.