### PR TITLE
Add Helion technical charter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,12 @@ Meta has a [bounty program](https://bugbounty.meta.com/) for the safe
 disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.
 
+## Governance
+
+The project's Maintainers and other technical roles are documented in
+[GOVERNANCE.md](GOVERNANCE.md). Technical oversight and TSC voting are governed
+by the [Technical Charter](technical-charter.md).
+
 ## Coding Style
 * Code is formatted and checked using [ruff](https://docs.astral.sh/ruff/formatter/).
 * All files must be typed with [pyrefly](https://pyrefly.org/).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,6 @@
+Helion's technical governance is defined by the
+[Technical Charter](technical-charter.md).
+
 ### Core Maintainers:
 - Jason Ansel, https://github.com/jansel
 - Oguz Ulgen, https://github.com/oulgen

--- a/README.md
+++ b/README.md
@@ -419,6 +419,9 @@ Note: You can still run the underlying tools directly via `./lint.sh [fix|check|
 
 Questions or feedback? Join us on the [GPU MODE Discord](https://discord.gg/gpumode) in the `#helion` channel.
 
+- [Project governance and maintainers](GOVERNANCE.md)
+- [Technical charter](technical-charter.md)
+
 ## License
 
 Helion is BSD-style licensed, as found in the LICENSE file.

--- a/technical-charter.md
+++ b/technical-charter.md
@@ -1,0 +1,185 @@
+# Technical Charter (the “Charter”)
+
+## for Helion a Series of LF Projects, LLC
+
+**Adopted March 25, 2026**
+
+This Charter sets forth the responsibilities and procedures for technical
+contribution to, and oversight of, the Helion open source project, which has
+been established as Helion a Series of LF Projects, LLC (the “Project”). LF
+Projects, LLC (“LF Projects”) is a Delaware series limited liability company.
+All contributors (including committers, maintainers, and other technical
+positions) and other participants in the Project (collectively,
+“Collaborators”) must comply with the terms of this Charter.
+
+## 1. Mission and Scope of the Project
+
+**a.** The mission of the Project is to develop a Python-embedded
+domain-specific language (DSL) that makes it easy to write fast, scalable ML
+kernels with minimal boilerplate.
+
+**b.** The scope of the Project includes collaborative development under the
+Project License (as defined herein) supporting the mission, including
+documentation, testing, integration and the creation of other artifacts that
+aid the development, deployment, operation or adoption of the open source
+project.
+
+## 2. Technical Steering Committee
+
+**a.** The Technical Steering Committee (the “TSC”) will be responsible for all
+technical oversight of the open source Project.
+
+**b.** The TSC voting members are initially the Project’s Maintainers. At the
+inception of the project, the Maintainers of the Project will be as set forth
+within the “CONTRIBUTING” file within the Project’s code repository. The TSC
+may choose an alternative approach for determining the voting members of the
+TSC, and any such alternative approach will be documented in the CONTRIBUTING
+file. Any meetings of the Technical Steering Committee are intended to be open
+to the public, and can be conducted electronically, via teleconference, or in
+person.
+
+**c.** TSC projects generally will involve Contributors and Maintainers. The TSC
+may adopt or modify roles so long as the roles are documented in the
+CONTRIBUTING file. Unless otherwise documented:
+
+**i.** Contributors include anyone in the technical community that contributes
+code, documentation, or other technical artifacts to the Project;
+
+**ii.** Maintainers are Contributors who have earned the ability to modify
+(“commit”) source code, documentation or other technical artifacts in a
+project’s repository; and
+
+## 3. TSC Voting
+
+**a.** While the Project aims to operate as a consensus-based community, if any
+TSC decision requires a vote to move the Project forward, the voting members
+of the TSC will vote on a one vote per voting member basis.
+
+**b.** Quorum for TSC meetings requires at least fifty percent of all voting
+members of the TSC to be present. The TSC may continue to meet if quorum is not
+met but will be prevented from making any decisions at the meeting.
+
+**c.** Except as provided in Section 7.c. and 8.a, decisions by vote at a meeting
+require a majority vote of those in attendance, provided quorum is met.
+Decisions made by electronic vote without a meeting require a majority vote of
+all voting members of the TSC.
+
+**d.** In the event a vote cannot be resolved by the TSC, any voting member of
+the TSC may refer the matter to the Series Manager for assistance in reaching a
+resolution.
+
+## 4. Compliance with Policies
+
+**a.** This Charter is subject to the Series Agreement for the Project and the
+Operating Agreement of LF Projects. Contributors will comply with the policies
+of LF Projects as may be adopted and amended by LF Projects, including, without
+limitation the policies listed at <https://lfprojects.org/policies/>.
+
+**b.** The TSC may adopt a code of conduct (“CoC”) for the Project, which is
+subject to approval by the Series Manager. In the event that a Project-specific
+CoC has not been approved, the LF Projects Code of Conduct listed at
+<https://lfprojects.org/policies> will apply for all Collaborators in the
+Project.
+
+**c.** When amending or adopting any policy applicable to the Project, LF
+Projects will publish such policy, as to be amended or adopted, on its web site
+at least 30 days prior to such policy taking effect; provided, however, that in
+the case of any amendment of the Trademark Policy or Terms of Use of LF
+Projects, any such amendment is effective upon publication on LF Project’s web
+site.
+
+**d.** All Collaborators must allow open participation from any individual or
+organization meeting the requirements for contributing under this Charter and
+any policies adopted for all Collaborators by the TSC, regardless of
+competitive interests. Put another way, the Project community must not seek to
+exclude any participant based on any criteria, requirement, or reason other
+than those that are reasonable and applied on a non-discriminatory basis to all
+Collaborators in the Project community.
+
+**e.** The Project will operate in a transparent, open, collaborative, and
+ethical manner at all times. The output of all Project discussions, proposals,
+timelines, decisions, and status should be made open and easily visible to all.
+Any potential violations of this requirement should be reported immediately to
+the Series Manager.
+
+## 5. Community Assets
+
+**a.** LF Projects (or an associated hosting entity) will hold title to all
+trade or service marks used by the Project (“Project Trademarks”), whether
+based on common law or registered rights. Project Trademarks will be
+transferred and assigned to LF Projects (or, where applicable, the associated
+hosting entity) to hold on behalf of the Project. Any use of any Project
+Trademarks by Collaborators in the Project will (a) either be (i) in a way that
+constitutes fair use or (ii) in accordance with the license from LF Projects to
+the Project and the applicable trademark usage guidelines and (b) inure to the
+benefit of LF Projects (or the associated hosting entity).
+
+**b.** The Project will, as permitted and in accordance with such license from
+LF Projects, develop and own all Project GitHub and social media accounts, and
+domain name registrations created by the Project community.
+
+**c.** Under no circumstances will LF Projects be expected or required to
+undertake any action on behalf of the Project that is inconsistent with the
+tax-exempt status or purpose, as applicable, of the Joint Development
+Foundation or LF Projects, LLC.
+
+## 6. General Rules and Operations
+
+**a.** The Project will:
+
+**i.** engage in the work of the Project in a professional manner consistent
+with maintaining a cohesive community, while also maintaining the goodwill and
+esteem of LF Projects, Joint Development Foundation and other partner
+organizations in the open source community; and
+
+**ii.** respect the rights of all trademark owners, including any branding and
+trademark usage guidelines.
+
+## 7. Intellectual Property Policy
+
+**a.** Collaborators acknowledge that the copyright in all new contributions
+will be retained by the copyright holder as independent works of authorship and
+that no contributor or copyright holder will be required to assign copyrights
+to the Project.
+
+**b.** Except as described in Section 7.c., all contributions to the Project are
+subject to the following:
+
+**i.** All new inbound code contributions to the Project must be made using
+BSD-3-Clause license available at <https://opensource.org/licenses/BSD-3-Clause>
+(the “Project License”).
+
+**ii.** All new inbound code contributions must also be accompanied by a
+Developer Certificate of Origin (<http://developercertificate.org>) sign-off in
+the source code system that is submitted through a TSC-approved contribution
+process which will bind the authorized contributor and, if not self-employed,
+their employer to the applicable license;
+
+**iii.** All outbound code will be made available under the Project License.
+
+**iv.** Documentation will be received and made available by the Project under
+the Creative Commons Attribution 4.0 International License (available at
+<http://creativecommons.org/licenses/by/4.0/>).
+
+**v.** The Project may seek to integrate and contribute back to other open
+source projects (“Upstream Projects”). In such cases, the Project will conform
+to all license requirements of the Upstream Projects, including dependencies,
+leveraged by the Project. Upstream Project code contributions not stored within
+the Project’s main code repository will comply with the contribution process
+and license terms for the applicable Upstream Project.
+
+**c.** The TSC may approve the use of an alternative license or licenses for
+inbound or outbound contributions on an exception basis. To request an
+exception, please describe the contribution, the alternative open source
+license(s), and the justification for using an alternative open source license
+for the Project. License exceptions must be approved by a two-thirds vote of
+the entire TSC.
+
+**d.** Contributed files should contain license information, such as SPDX short
+form identifiers, indicating the open source license or licenses pertaining to
+the file.
+
+## 8. Amendments
+
+**a.** This charter may be amended by a two-thirds vote of the entire TSC and is
+subject to approval by LF Projects.


### PR DESCRIPTION
## Summary

- Add the adopted LF Projects technical charter as `technical-charter.md`.
- Keep governance documents at the repository root and cross-link them.
- Link the governance documents from `README.md` and `CONTRIBUTING.md`.

## Source

Imported from the [approved Google Doc](https://docs.google.com/document/d/10qHsANqCewOXA6xf44xE5vrVDzLaoQjZL6zLNyeEh3I/edit?tab=t.0). The exported list numbering restarted partway through the document, so section numbering was normalized to 1–8, consistent with the internal references to Sections 7.c and 8.a.

## Validation

- `git diff --check`
- Documentation-only change

## Follow-up

The charter requires Developer Certificate of Origin sign-off, while `CONTRIBUTING.md` currently documents the Meta CLA process. This PR does not change contribution-policy enforcement.