### PR TITLE
[CuTe] Generalize FA4 online softmax code generation

### DIFF
--- a/helion/_compiler/cute/_flash_runtime.py
+++ b/helion/_compiler/cute/_flash_runtime.py
@@ -3293,11 +3293,10 @@ def _fmax_reduce_packed_ssa(
 @cute.jit
 def _fadd_reduce_packed_ssa(
     values: cute.TensorSSA,
-    init_val: object = None,
 ) -> Float32:
     values_rmem = cute.make_rmem_tensor(values.shape, Float32)
     values_rmem.store(values)
-    return fadd_reduce_packed(values_rmem, init_val)
+    return fadd_reduce_packed(values_rmem)
 
 
 @cute.jit

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -3958,6 +3958,7 @@ def _flash_dense_tuning_overrides(
         FLASH_E2E_OFFSET0_KEY: policy.e2e_offset0,
         FLASH_EXP2_PACKET_KEY: policy.exp2_packet,
         FLASH_STAT_TRANSPORT_KEY: policy.stat_transport,
+        FLASH_RESCALE_THRESHOLD_KEY: policy.rescale_threshold,
     }
     if policy.corr_regs is not None:
         values[FLASH_CORR_REGS_KEY] = policy.corr_regs
@@ -3999,20 +4000,20 @@ def _flash_config_matches_tuning_values(
     return all(actual.get(key) == value for key, value in expected.items())
 
 
-def _flash_dense_resident_seed_matches(
+def _flash_dense_target_seed_matches(
     cfg: FlashAttentionConfig,
     policy: FlashDenseTuningPolicy | None,
 ) -> bool:
     """Return whether ``cfg`` is the validated target-promoted dense seed."""
-    expected = (
+    if policy is None:
+        return False
+    return _flash_config_matches_tuning_values(
+        cfg,
         {
             **_flash_dense_tuning_overrides(policy),
             FLASH_Q_TILE_COUNT_KEY: 2,
-        }
-        if policy is not None
-        else {}
+        },
     )
-    return policy is not None and _flash_config_matches_tuning_values(cfg, expected)
 
 
 def _flash_resident_softmax_config(
@@ -5523,7 +5524,10 @@ def flash_autotune_fragments(
         if value not in fragment.choices:
             search_choices = fragment.search_choices
             if search_choices is None:
-                search_choices = (fragment.default(),)
+                # ``None`` means every existing choice is searched.  The target
+                # value is accepted as a fixed seed without narrowing that
+                # pre-existing search surface.
+                search_choices = fragment.choices
             fragments[key] = EnumFragment((*fragment.choices, value), search_choices)
     return fragments
 
@@ -6074,16 +6078,110 @@ def _flash_fa4_causal_split_equal_iteration_proof(
         return CausalRangeProof(False, split_range_proof.reason)
     if query_slots_per_cta != 2:
         return CausalRangeProof(False, "FA4 resident path requires two query slots")
-    # For each query tile, the descending split executes ``num_kv - m_tile``
-    # masked iterations followed by ``m_tile`` unmasked iterations.  The range
-    # proof guarantees both bounds describe the same complete KV interval, so
-    # their sum is exactly ``num_kv`` for both resident query slots.
-    return CausalRangeProof(True, "masked and unmasked loop bounds sum to num_kv")
+    # Each resident query slot shares ``flash_num_active_kv``.  Its descending
+    # split executes ``flash_num_active_kv - m_tile`` masked iterations followed
+    # by ``m_tile`` unmasked iterations, so both slots execute the same active
+    # KV count while traversing different mask-free suffix lengths.
+    return CausalRangeProof(
+        True, "resident query slots share the same active KV iteration count"
+    )
 
 
-def _flash_runtime_range_header(loop_var: str, loop_bound: str) -> str:
-    """Emit a runtime CuTe loop header; causal splitting must not unroll it."""
-    return f"for {loop_var} in cutlass.range({loop_bound}, unroll=1):"
+@dataclasses.dataclass(frozen=True)
+class _FlashSoftmaxLoopSegment:
+    """Runtime loop domain and phase facts for one online-softmax segment."""
+
+    loop_var: str
+    loop_bound: str
+    kv_expr: str | None = None
+    continues_previous_segment: bool = False
+
+    @property
+    def not_first_condition(self) -> str:
+        """Return the loop-local expression proving this is not the first KV tile."""
+        if self.continues_previous_segment:
+            return f"{self.loop_var} >= cutlass.Int32(0)"
+        return f"{self.loop_var} != 0"
+
+
+_FLASH_ONLINE_STATISTICS_UPDATE = (
+    "            flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum"
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class _FlashOnlineSoftmaxIteration:
+    """Ordered source blocks for one statically specialized softmax iteration.
+
+    The final row-sum publication is deliberately not part of this plan because
+    it occurs after the complete loop (or masked/unmasked loop pair).
+    """
+
+    load_and_reduce: str
+    alpha_pre_probability: str
+    alpha_publish_pre_probability: str
+    probability_update: str
+    alpha_post_probability: str = ""
+    alpha_publish_post_probability: str = ""
+    statistics_acquire: str = ""
+    statistics_update: str = _FLASH_ONLINE_STATISTICS_UPDATE
+    post_statistics: str = ""
+
+
+def _flash_causal_split_softmax_segments(
+    kv_loop_bound: str,
+    stage: str,
+    *,
+    split_range_proof: CausalRangeProof,
+) -> tuple[_FlashSoftmaxLoopSegment, _FlashSoftmaxLoopSegment]:
+    """Return the proof-backed masked prefix and unmasked causal suffix."""
+    if not split_range_proof.proven:
+        raise AssertionError(
+            "causal softmax split requires a proven complete masked/unmasked range"
+        )
+    return (
+        _FlashSoftmaxLoopSegment(
+            loop_var="flash_kv_mask_iter",
+            loop_bound=f"{kv_loop_bound} - flash_m_tile{stage}",
+            kv_expr=(f"{kv_loop_bound} - cutlass.Int32(1) - flash_kv_mask_iter"),
+        ),
+        _FlashSoftmaxLoopSegment(
+            loop_var="flash_kv_unmask_iter",
+            loop_bound=f"flash_m_tile{stage}",
+            kv_expr=(f"flash_m_tile{stage} - cutlass.Int32(1) - flash_kv_unmask_iter"),
+            continues_previous_segment=True,
+        ),
+    )
+
+
+def _format_fa4_online_softmax_loop(
+    segment: _FlashSoftmaxLoopSegment,
+    iteration: _FlashOnlineSoftmaxIteration,
+    *,
+    stage: str,
+    wait_hint: int,
+) -> str:
+    """Render the common FA4 wait/max/alpha/P/row-sum iteration order."""
+    kv_assignment = (
+        f"\n            flash_kv = {segment.kv_expr}" if segment.kv_expr else ""
+    )
+    return f"""        for {segment.loop_var} in cutlass.range({segment.loop_bound}, unroll=1):{kv_assignment}
+            _helion_flash_rt.mbar_spin_wait(
+                flash_s_full_ptr + {stage}, flash_s_full_phase, {wait_hint})
+            flash_s_full_phase ^= 1
+            flash_old_row_max = flash_row_max
+{iteration.load_and_reduce}
+            flash_row_max_safe = flash_row_max
+            if flash_row_max == -cutlass.Float32.inf:
+                flash_row_max_safe = cutlass.Float32(0.0)
+{iteration.alpha_pre_probability}
+{iteration.alpha_publish_pre_probability}
+{iteration.probability_update}
+{iteration.alpha_post_probability}
+{iteration.alpha_publish_post_probability}
+{iteration.statistics_acquire}
+{iteration.statistics_update}
+{iteration.post_statistics}"""
 
 
 def _flash_kv_iteration(
@@ -7515,12 +7613,18 @@ def emit_flash_fa4_device_body(
     probability_log2_shift = (
         dense_tuning.probability_log2_shift if dense_tuning is not None else 0
     )
-    probability_shift_safe = probability_log2_shift + cfg.rescale_threshold < math.log2(
-        torch.finfo(torch.float16).max
+    dense_seed_matches = _flash_dense_target_seed_matches(cfg, dense_tuning)
+    dense_softmax_lowering = (
+        dense_tuning.softmax_lowering
+        if dense_tuning is not None
+        else FlashSoftmaxLowering.STANDARD
     )
-    dense_seed_matches = _flash_dense_resident_seed_matches(cfg, dense_tuning)
-    dense_resident_value_graph_candidate = False
-    if (
+    dense_packed_exp2_mode = (
+        dense_tuning.packed_exp2_mode
+        if dense_tuning is not None
+        else FlashPackedExp2Mode.DISABLED
+    )
+    dense_target_lowering_applies = (
         dense_tuning is not None
         and dense_seed_matches
         and not is_causal
@@ -7528,23 +7632,16 @@ def emit_flash_fa4_device_body(
         and cfg.use_2cta_instrs
         and not cfg.separate_kv_rings
         and not cfg.softmax_disc
-        and cfg.split_p_arrive
         and cfg.p_store_repetition == 16
         and cfg.s_load_repetition == 32
-        and cfg.rescale_threshold > 0.0
-        and probability_shift_safe
         and score_plan.modifier_kinds == (DENSE_SCORE_KIND,)
-    ):
-        dense_softmax_family = dense_tuning.softmax_lowering
-        if dense_softmax_family is FlashSoftmaxLowering.STANDARD:
-            pass
-        elif dense_softmax_family is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH:
-            dense_resident_value_graph_candidate = True
-        else:
-            raise AssertionError(
-                "unsupported dense resident softmax lowering family: "
-                f"{dense_softmax_family!r}"
-            )
+    )
+    dense_resident_value_graph_candidate = (
+        dense_target_lowering_applies
+        and cfg.split_p_arrive
+        and cfg.rescale_threshold > 0.0
+        and dense_softmax_lowering is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+    )
     causal_tuning = (
         tuning_policy.causal_policy(num_kv) if tuning_policy is not None else None
     )
@@ -7585,8 +7682,8 @@ def emit_flash_fa4_device_body(
             )
     if use_causal_resident_native:
         # Use the architecture-selected resident softmax lowering only for the
-        # validated rank-0 schedule. Other manual/autotuned configs retain their
-        # explicit exp2, disc, and statistics choices.
+        # validated rank-0 schedule. Other manual/autotuned configs remain on
+        # their resolved standard lowering.
         cfg = _flash_resident_softmax_config(cfg)
     stat_release_mapping = (
         FlashStatReleaseMapping.SAME_SLOT
@@ -7606,24 +7703,11 @@ def emit_flash_fa4_device_body(
     if not use_tensor_4d_tma:
         tensor_4d_heads = 0
     use_2cta_instrs = cfg.use_2cta_instrs
-    dense_packed_exp2_mode = (
-        dense_tuning.packed_exp2_mode
-        if dense_tuning is not None
-        else FlashPackedExp2Mode.DISABLED
-    )
     use_packed_f16x2_xu = (
         dense_packed_exp2_mode is FlashPackedExp2Mode.ALL_XU
         and hardware_capabilities.supports_packed_f16x2_exp2
-        and probability_shift_safe
-        and not has_lse
+        and dense_target_lowering_applies
         and cfg.exp2_impl == "split"
-        and cfg.p_store_repetition == 16
-        and cfg.s_load_repetition == 32
-        and not is_causal
-        and dense_seed_matches
-        and score_plan.modifier_kinds == (DENSE_SCORE_KIND,)
-        and use_2cta_instrs
-        and not cfg.softmax_disc
         and cfg.exp2_packet in _FLASH_DEG1_EXP2_PACKETS
     )
     effective_probability_log2_shift = (
@@ -7659,11 +7743,8 @@ def emit_flash_fa4_device_body(
         fa4_stat_pipeline and cfg.stat_transport == "single_final"
     )
     acknowledged_stat_pipeline = fa4_stat_pipeline and not final_only_stat_pipeline
-    use_dense_resident_value_graph = (
-        dense_resident_value_graph_candidate and acknowledged_stat_pipeline
-    )
     if dense_resident_value_graph_candidate:
-        assert use_dense_resident_value_graph
+        assert acknowledged_stat_pipeline
     if use_causal_stateful_softmax:
         assert acknowledged_stat_pipeline
     verified_shared_memory_bytes: int | None = None
@@ -7723,7 +7804,7 @@ def emit_flash_fa4_device_body(
         verified_shared_memory_bytes = verified_schedule.schedule.shared_memory_bytes
     elif use_causal_resident_native:
         assert causal_split_equal_iteration_proof.proven
-        verify_flash_schedule(
+        verified_schedule = verify_flash_schedule(
             build_fa4_schedule(
                 FlashScheduleSpec(
                     head_dim=head_dim,
@@ -7742,6 +7823,7 @@ def emit_flash_fa4_device_body(
                 )
             )
         )
+        verified_shared_memory_bytes = verified_schedule.schedule.shared_memory_bytes
     use_local_tma_partition = (
         cfg.local_tma_partition
         and persistent
@@ -8355,9 +8437,8 @@ flash_pvt = _flash_pv_mma.get_slice(flash_mma_tile_coord_v)
         and not has_lse
         and not score_plan.modifiers
     )
-    policy_stage_local_softmax_setup = use_causal_stateful_softmax
     stage_local_softmax_setup = (
-        policy_stage_local_softmax_setup
+        use_causal_stateful_softmax
         or _flash_bool_env(
             "HELION_CUTE_FLASH_STAGE_LOCAL_SOFTMAX_SETUP",
             default_stage_local_softmax_setup,
@@ -9227,13 +9308,14 @@ if warp_idx == 15:
     else:
         _disc_pass2_name = "fa4_disc_exp_convert_store"
         _disc_pass2_causal_name = "fa4_disc_exp_convert_store_causal"
-    softmax_loop_var = "flash_kv_iter" if desc_kv else "flash_kv"
-    softmax_actual_kv = (
-        f"\n            flash_kv = {kv_loop_bound} - cutlass.Int32(1) - flash_kv_iter"
-        if desc_kv
-        else ""
+    softmax_segment = _FlashSoftmaxLoopSegment(
+        loop_var="flash_kv_iter" if desc_kv else "flash_kv",
+        loop_bound=kv_loop_bound,
+        kv_expr=(
+            f"{kv_loop_bound} - cutlass.Int32(1) - flash_kv_iter" if desc_kv else None
+        ),
     )
-    softmax_not_first = "flash_kv_iter != 0" if desc_kv else "flash_kv != 0"
+    softmax_not_first = softmax_segment.not_first_condition
     defer_causal_minus_scale = (
         is_causal and _flash_fa4_runtime_disc_score_plan_supported(score_plan)
     )
@@ -9328,9 +9410,6 @@ if warp_idx == 15:
             f"flash_s_full_ptr + {stage}, flash_s_full_phase, {cfg.wait_hint})"
         )
 
-    def _softmax_release_p_ready(stage: str) -> str:
-        return ""
-
     def _softmax_inner(
         stage: str,
         ld: str,
@@ -9422,8 +9501,6 @@ if warp_idx == 15:
                 args.append("degree1=True")
             elif disc_exp2_codegen.degree2:
                 args.append("degree2=True")
-            if use_packed_f16x2_xu:
-                args.append("f16x2_xu=True")
             return f"_helion_flash_rt.{name}(" + ", ".join(args) + ")"
 
         pass2_call = _format_disc_pass2(_disc_pass2_name, causal=False)
@@ -9517,7 +9594,6 @@ if warp_idx == 15:
         {corr_rowsum_advance}"""
         # The correction warp consumes per-KV alpha handoffs during the loop and
         # one final row-sum handoff after the loop.
-        final_corr_publish_rowsum = corr_publish_rowsum
         if cfg.softmax_disc:
             if not _flash_fa4_runtime_disc_score_plan_supported(score_plan):
                 score_transform = _flash_score_transform_block(
@@ -9546,22 +9622,23 @@ if warp_idx == 15:
                     else f"""            if {softmax_not_first}:
 {corr_publish_alpha}"""
                 )
+                iteration = _FlashOnlineSoftmaxIteration(
+                    load_and_reduce=rowmax_block,
+                    alpha_pre_probability=_disc_alpha_block,
+                    alpha_publish_pre_probability=alpha_publish,
+                    probability_update=f"""{_disc_minus_scale_block}
+{pass2_block}""",
+                )
+                loop = _format_fa4_online_softmax_loop(
+                    softmax_segment,
+                    iteration,
+                    stage=stage,
+                    wait_hint=cfg.wait_hint,
+                )
                 return f"""        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)
-        for {softmax_loop_var} in cutlass.range({kv_loop_bound}, unroll=1):{softmax_actual_kv}
-            _helion_flash_rt.mbar_spin_wait(flash_s_full_ptr + {stage}, flash_s_full_phase, {cfg.wait_hint})
-            flash_s_full_phase ^= 1
-            flash_old_row_max = flash_row_max
-{rowmax_block}
-            flash_row_max_safe = flash_row_max
-            if flash_row_max == -cutlass.Float32.inf:
-                flash_row_max_safe = cutlass.Float32(0.0)
-{_disc_alpha_block}
-{alpha_publish}
-{_disc_minus_scale_block}
-{pass2_block}
-            flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum
-{final_corr_publish_rowsum}"""
+{loop}
+{corr_publish_rowsum}"""
             rowmax_dense_call = (
                 f"_helion_flash_rt.disc_rowmax_ldred("
                 f"flash_tiled_ldred{stage}, tLDRedtS{stage}, tLDcS, "
@@ -9574,51 +9651,44 @@ if warp_idx == 15:
             direct_dense_pass2 = f"            flash_p_sum = {pass2_call}"
 
             def _format_disc_loop(
-                loop_var: str,
-                loop_bound: str,
-                actual_kv: str,
-                not_first: str,
+                segment: _FlashSoftmaxLoopSegment,
                 loop_rowmax_block: str,
                 loop_pass2_block: str,
                 *,
-                publish_rowsum: bool = True,
                 zero_first_tile: bool = False,
-                known_not_first: bool = False,
             ) -> str:
-                rowsum_publish = final_corr_publish_rowsum if publish_rowsum else ""
                 if cfg.skip_rescale_stats:
                     alpha_publish = ""
-                elif known_not_first:
+                elif segment.continues_previous_segment:
                     alpha_publish = _corr_publish_alpha("            ")
                 else:
-                    alpha_publish = f"""            if {not_first}:
+                    alpha_publish = f"""            if {segment.not_first_condition}:
 {corr_publish_alpha}"""
                 if zero_first_tile:
-                    loop_rowmax_block = f"""            if {not_first}:
+                    loop_rowmax_block = f"""            if {segment.not_first_condition}:
 {textwrap.indent(loop_rowmax_block, "    ")}"""
-                    loop_pass2_block = f"""            if {not_first}:
+                    loop_pass2_block = f"""            if {segment.not_first_condition}:
 {textwrap.indent(loop_pass2_block, "    ")}
             else:
                 flash_p_sum = {zero_pass2_call}"""
                 alpha_block, minus_scale_block = _disc_alpha_blocks_for(
-                    not_first, known_not_first=known_not_first
+                    segment.not_first_condition,
+                    known_not_first=segment.continues_previous_segment,
                 )
-                loop_header = _flash_runtime_range_header(loop_var, loop_bound)
-                return f"""        {loop_header}{actual_kv}
-            _helion_flash_rt.mbar_spin_wait(flash_s_full_ptr + {stage}, flash_s_full_phase, {cfg.wait_hint})
-            flash_s_full_phase ^= 1
-            flash_old_row_max = flash_row_max
-{loop_rowmax_block}
-            flash_row_max_safe = flash_row_max
-            if flash_row_max == -cutlass.Float32.inf:
-                flash_row_max_safe = cutlass.Float32(0.0)
-{alpha_block}
-{alpha_publish}
-{minus_scale_block}
+                iteration = _FlashOnlineSoftmaxIteration(
+                    load_and_reduce=loop_rowmax_block,
+                    alpha_pre_probability=alpha_block,
+                    alpha_publish_pre_probability=alpha_publish,
+                    probability_update=f"""{minus_scale_block}
             flash_p_sum = cutlass.Float32(0.0)
-{loop_pass2_block}
-            flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum
-{rowsum_publish}"""
+{loop_pass2_block}""",
+                )
+                return _format_fa4_online_softmax_loop(
+                    segment,
+                    iteration,
+                    stage=stage,
+                    wait_hint=cfg.wait_hint,
+                )
 
             if is_causal:
                 mask_m_tile = score_m_tile_expr
@@ -9636,37 +9706,31 @@ if warp_idx == 15:
                     and cfg.causal_loop_split
                     and causal_split_proof.proven
                 ):
+                    masked_segment, unmasked_segment = (
+                        _flash_causal_split_softmax_segments(
+                            kv_loop_bound,
+                            stage,
+                            split_range_proof=causal_split_proof,
+                        )
+                    )
                     masked_loop = _format_disc_loop(
-                        "flash_kv_mask_iter",
-                        f"{kv_loop_bound} - flash_m_tile{stage}",
-                        (
-                            f"\n            flash_kv = {kv_loop_bound} - "
-                            "cutlass.Int32(1) - flash_kv_mask_iter"
-                        ),
-                        "flash_kv_mask_iter != 0",
+                        masked_segment,
                         direct_causal_rowmax,
                         direct_causal_pass2,
-                        publish_rowsum=False,
                         zero_first_tile=stage == "0",
                     )
                     # The proven split always executes a nonempty masked prefix
                     # before entering its unmasked suffix.
                     unmasked_loop = _format_disc_loop(
-                        "flash_kv_unmask_iter",
-                        f"flash_m_tile{stage}",
-                        (
-                            f"\n            flash_kv = flash_m_tile{stage} - "
-                            "cutlass.Int32(1) - flash_kv_unmask_iter"
-                        ),
-                        "flash_kv_unmask_iter >= cutlass.Int32(0)",
+                        unmasked_segment,
                         direct_dense_rowmax,
                         direct_dense_pass2,
-                        known_not_first=True,
                     )
                     return f"""        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)
 {masked_loop}
-{unmasked_loop}"""
+{unmasked_loop}
+{corr_publish_rowsum}"""
                 rowmax_block = f"""            if flash_kv >= flash_m_tile{stage}:
                 flash_row_max = {rowmax_causal_call}
             else:
@@ -9686,29 +9750,22 @@ if warp_idx == 15:
             # fold + the staged-P pfor/pfor2 arrives, freeing each chunk before the
             # next. Peak live = ONE 32-elem fragment -> fits the 200-grant zero-spill.
             loop = _format_disc_loop(
-                softmax_loop_var,
-                kv_loop_bound,
-                softmax_actual_kv,
-                softmax_not_first,
+                softmax_segment,
                 rowmax_block,
                 pass2_block,
                 zero_first_tile=is_causal and causal_desc_kv and stage == "0",
             )
             return f"""        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)
-{loop}"""
-        score_transform_m_tile = (
-            f"flash_q_mma_tile{stage} * cutlass.Int32(2)"
-            if use_2cta_instrs
-            else f"flash_m_tile{stage}"
-        )
+{loop}
+{corr_publish_rowsum}"""
         score_transform = _flash_score_transform_block(
             score_plan,
             indent="            ",
             score_tensor="tLDrS",
             coord_tensor="tLDcS",
             bh_expr="flash_bh",
-            m_tile_expr=score_transform_m_tile,
+            m_tile_expr=score_m_tile_expr,
             kv_tile_expr="flash_kv",
         )
         if split_p_arrive:
@@ -9735,8 +9792,9 @@ if warp_idx == 15:
             _helion_flash_rt.mbarrier_arrive(
                 flash_pfor_ptr + {stage}{pfor_peer_arg})"""
         use_resident_value_graph = (
-            use_causal_resident_value_graph or use_dense_resident_value_graph
+            use_causal_resident_value_graph or dense_resident_value_graph_candidate
         )
+        sp_corr_publish_alpha = ""
         if use_resident_value_graph:
             assert split_p_arrive
             assert not mixed_p_store
@@ -9744,7 +9802,7 @@ if warp_idx == 15:
                 f""",
                 pfor_peer_cta_rank=cutlass.Int32(0),
                 pfor_self_cta_rank={pfor_self_cta_rank}"""
-                if use_dense_resident_value_graph
+                if dense_resident_value_graph_candidate
                 else ""
             )
             sp_exp_block = f"""            flash_row_sum = _helion_flash_rt.resident_softmax_value_graph(
@@ -9755,7 +9813,6 @@ if warp_idx == 15:
                 flash_s_corr_prod_phase, flash_row_sum * flash_alpha,
                 {cfg.wait_hint}{resident_pfor_args})"""
             sp_p_store_block = ""
-            sp_corr_publish_alpha = ""
         elif cfg.exp2_impl == "split" or use_causal_resident_native:
             sp_e2e_offset = (
                 "0"
@@ -9823,18 +9880,18 @@ if warp_idx == 15:
             elif exp2_codegen.degree2:
                 sp_pass2_args.append("degree2=True")
             if use_packed_f16x2_xu:
+                assert not mixed_p_store
                 sp_pass2_args.append("f16x2_xu=True")
-            sp_pass2_call = (
-                f"_helion_flash_rt.{sp_pass2_name}(" + ", ".join(sp_pass2_args) + ")"
+            sp_exp_block = (
+                f"            flash_p_sum = _helion_flash_rt.{sp_pass2_name}("
+                + ", ".join(sp_pass2_args)
+                + ")"
             )
-            sp_exp_block = f"            flash_p_sum = {sp_pass2_call}"
             sp_p_store_block = ""
-            sp_corr_publish_alpha = ""
         else:
             sp_exp_block = softmax_exp_block
             sp_p_store_block = p_store_block
-            sp_corr_publish_alpha = ""
-        if not sp_corr_publish_alpha and not cfg.skip_rescale_stats:
+        if not cfg.skip_rescale_stats:
             if acknowledged_stat_pipeline:
                 sp_corr_publish_alpha = f"""            if {softmax_not_first}:
 {corr_publish_alpha}
@@ -9868,6 +9925,8 @@ if warp_idx == 15:
             if acknowledged_stat_pipeline
             else ""
         )
+        if use_whole_row_tmem_reduce:
+            assert not score_transform
         sp_score_load = (
             f"""            tLDrS_red = cute.make_rmem_tensor(
                 ((1, 1), *tLDrS.shape[1:]), cutlass.Float32)
@@ -9893,20 +9952,15 @@ if warp_idx == 15:
             assert cfg.exp2_impl == "xu"
 
             def _format_resident_causal_loop(
-                loop_var: str,
-                loop_bound: str,
-                actual_kv: str,
-                not_first: str,
+                segment: _FlashSoftmaxLoopSegment,
                 score_load: str,
                 rowmax_update: str,
-                *,
-                publish_rowsum: bool,
-                known_not_first: bool = False,
             ) -> str:
                 pin_condition = (
                     f"flash_acc_log >= -{cfg.rescale_threshold}"
-                    if known_not_first
-                    else f"({not_first}) & (flash_acc_log >= -{cfg.rescale_threshold})"
+                    if segment.continues_previous_segment
+                    else f"({segment.not_first_condition}) & "
+                    f"(flash_acc_log >= -{cfg.rescale_threshold})"
                 )
                 alpha_pre = f"""            flash_acc_log = _flash_scale_log2 * (flash_old_row_max - flash_row_max_safe)
             flash_alpha = cute.math.exp2(flash_acc_log, fastmath=True)
@@ -9917,43 +9971,40 @@ if warp_idx == 15:
             flash_minus_max_scale = (0.0 - flash_row_max_safe) * _flash_scale_log2"""
                 if cfg.skip_rescale_stats:
                     alpha_publish = ""
-                elif known_not_first:
+                elif segment.continues_previous_segment:
                     alpha_publish = _corr_publish_alpha("            ")
                 else:
-                    alpha_publish = f"""            if {not_first}:
+                    alpha_publish = f"""            if {segment.not_first_condition}:
 {_corr_publish_alpha("                ")}
             else:
                 _helion_flash_rt.named_barrier_arrive_unaligned(
                     {3 + int(stage) * 4} + warp_idx % 4, 64)"""
-                rowsum_publish = final_corr_publish_rowsum if publish_rowsum else ""
-                loop_header = _flash_runtime_range_header(loop_var, loop_bound)
                 post_p_stat_acquire = (
                     ""
                     if use_causal_resident_value_graph
                     else fa4_post_p_stat_acquire.rstrip()
                 )
-                row_sum_update = (
+                statistics_update = (
                     "            flash_s_corr_prod_phase ^= 1"
                     if use_causal_resident_value_graph
-                    else "            flash_row_sum = "
-                    "flash_row_sum * flash_alpha + flash_p_sum"
+                    else _FLASH_ONLINE_STATISTICS_UPDATE
                 )
-                return f"""        {loop_header}{actual_kv}
-            {_softmax_wait_s_ready(stage)}
-            flash_s_full_phase ^= 1
-            flash_old_row_max = flash_row_max
-            tLDrS = cute.make_rmem_tensor(tLDcS.shape, cutlass.Float32)
+                iteration = _FlashOnlineSoftmaxIteration(
+                    load_and_reduce=f"""            tLDrS = cute.make_rmem_tensor(tLDcS.shape, cutlass.Float32)
 {score_load}
-{rowmax_update}
-            flash_row_max_safe = flash_row_max
-            if flash_row_max == -cutlass.Float32.inf:
-                flash_row_max_safe = cutlass.Float32(0.0)
-{alpha_pre}
-{alpha_publish}
-{sp_exp_block}
-{post_p_stat_acquire}
-{row_sum_update}
-{rowsum_publish}"""
+{rowmax_update}""",
+                    alpha_pre_probability=alpha_pre,
+                    alpha_publish_pre_probability=alpha_publish,
+                    probability_update=sp_exp_block,
+                    statistics_acquire=post_p_stat_acquire,
+                    statistics_update=statistics_update,
+                )
+                return _format_fa4_online_softmax_loop(
+                    segment,
+                    iteration,
+                    stage=stage,
+                    wait_hint=cfg.wait_hint,
+                )
 
             masked_score_load = f"""            cute.copy({ld}, {ldt}, tLDrS)
             cute.arch.fence_view_async_tmem_load(){score_transform}"""
@@ -10003,7 +10054,7 @@ if warp_idx == 15:
 {indent}flash_softmax.scale_subtract_rowmax(tLDrS, flash_row_max_safe)
 {indent}flash_tSrP_f32 = cute.make_rmem_tensor(tSTcS.shape, cutlass.Float32)
 {indent}flash_tSrP = cute.make_tensor(
-{indent}    cute.recast_ptr(flash_tSrP_f32.iterator, dtype=cutlass.Float16),
+{indent}    cute.recast_ptr(flash_tSrP_f32.iterator, dtype={io_dtype}),
 {indent}    tLDrS.layout)
 {indent}flash_softmax.apply_exp2_convert(tLDrS, flash_tSrP)
 {indent}for flash_ci in cutlass.range_constexpr(flash_P_STORE_SPLIT):
@@ -10052,70 +10103,62 @@ if warp_idx == 15:
         for flash_kv_unmask_iter in cutlass.range(flash_m_tile{stage}, unroll=1):
             flash_kv = flash_m_tile{stage} - cutlass.Int32(1) - flash_kv_unmask_iter
 {unmasked_step}
-{final_corr_publish_rowsum}"""
+{corr_publish_rowsum}"""
+            masked_segment, unmasked_segment = _flash_causal_split_softmax_segments(
+                kv_loop_bound,
+                stage,
+                split_range_proof=causal_split_proof,
+            )
             masked_loop = _format_resident_causal_loop(
-                "flash_kv_mask_iter",
-                f"{kv_loop_bound} - flash_m_tile{stage}",
-                (
-                    f"\n            flash_kv = {kv_loop_bound} - "
-                    "cutlass.Int32(1) - flash_kv_mask_iter"
-                ),
-                "flash_kv_mask_iter != 0",
+                masked_segment,
                 masked_score_load,
                 masked_rowmax,
-                publish_rowsum=False,
             )
             unmasked_loop = _format_resident_causal_loop(
-                "flash_kv_unmask_iter",
-                f"flash_m_tile{stage}",
-                (
-                    f"\n            flash_kv = flash_m_tile{stage} - "
-                    "cutlass.Int32(1) - flash_kv_unmask_iter"
-                ),
-                "flash_kv_unmask_iter >= cutlass.Int32(0)",
+                unmasked_segment,
                 unmasked_score_load,
                 unmasked_rowmax,
-                publish_rowsum=True,
-                known_not_first=True,
             )
             return f"""{fa4_entry_stat_acquire}        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)
 {masked_loop}
-{unmasked_loop}"""
+{unmasked_loop}
+{corr_publish_rowsum}"""
         post_p_stat_acquire = (
-            "" if use_dense_resident_value_graph else fa4_post_p_stat_acquire.rstrip()
+            ""
+            if dense_resident_value_graph_candidate
+            else fa4_post_p_stat_acquire.rstrip()
         )
-        row_sum_update = (
+        statistics_update = (
             "            flash_s_corr_prod_phase ^= 1"
-            if use_dense_resident_value_graph
-            else "            flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum"
+            if dense_resident_value_graph_candidate
+            else _FLASH_ONLINE_STATISTICS_UPDATE
+        )
+        iteration = _FlashOnlineSoftmaxIteration(
+            load_and_reduce=f"""            tLDrS = cute.make_rmem_tensor(tLDcS.shape, cutlass.Float32)
+{sp_score_load}
+{sp_rowmax}""",
+            alpha_pre_probability=_sp_alpha_pre,
+            alpha_publish_pre_probability=sp_alpha_publish_pre,
+            probability_update=sp_exp_block,
+            alpha_post_probability=_sp_alpha_post,
+            alpha_publish_post_probability=sp_alpha_publish_post,
+            statistics_acquire=post_p_stat_acquire,
+            statistics_update=statistics_update,
+            post_statistics=sp_p_store_block,
+        )
+        loop = _format_fa4_online_softmax_loop(
+            softmax_segment,
+            iteration,
+            stage=stage,
+            wait_hint=cfg.wait_hint,
         )
         return f"""{
             fa4_entry_stat_acquire
         }        flash_row_max = cutlass.Float32(-cutlass.Float32.inf)
         flash_row_sum = cutlass.Float32(0.0)
-        for {softmax_loop_var} in cutlass.range({kv_loop_bound}, unroll=1):{
-            softmax_actual_kv
-        }
-            {_softmax_wait_s_ready(stage)}
-            flash_s_full_phase ^= 1
-            flash_old_row_max = flash_row_max
-            tLDrS = cute.make_rmem_tensor(tLDcS.shape, cutlass.Float32)
-{sp_score_load}
-{sp_rowmax}
-            flash_row_max_safe = flash_row_max
-            if flash_row_max == -cutlass.Float32.inf:
-                flash_row_max_safe = cutlass.Float32(0.0)
-{_sp_alpha_pre}
-{sp_alpha_publish_pre}
-{sp_exp_block}
-{_softmax_release_p_ready(stage)}
-{_sp_alpha_post}
-{sp_alpha_publish_post}
-{post_p_stat_acquire}
-{row_sum_update}
-{sp_p_store_block}
-{final_corr_publish_rowsum}"""
+{loop}
+{corr_publish_rowsum}"""
 
     softmax0_setup = (
         _tmem_softmax_setup_stage("0")
@@ -10486,7 +10529,7 @@ if warp_idx == 15:
         f"{corr_stage1}\n{corr_stage0}"
         if (
             cfg.exp2_packet == _FLASH_DEG1_SHORT_CORR10_EXP2_PACKET
-            and not use_dense_resident_value_graph
+            and not acknowledged_stat_pipeline
         )
         else f"{corr_stage0}\n{corr_stage1}"
     )

--- a/helion/_compiler/cute/flash_policy.py
+++ b/helion/_compiler/cute/flash_policy.py
@@ -27,20 +27,15 @@ class FlashTargetPolicy:
         if len(set(workloads)) != len(workloads):
             raise ValueError("flash target tuning workloads must be unique")
         for tuning in self.tunings:
-            uses_specialized_lowering = any(
-                policy.softmax_lowering is not FlashSoftmaxLowering.STANDARD
-                or policy.packed_exp2_mode is not FlashPackedExp2Mode.DISABLED
-                for policy in tuning.dense_policies
-            ) or any(
-                policy.softmax_lowering is not FlashSoftmaxLowering.STANDARD
-                for policy in tuning.causal_policies
-            )
-            if uses_specialized_lowering and (
+            requires_fp16_hd64 = any(
+                policy.requires_fp16_hd64 for policy in tuning.dense_policies
+            ) or any(policy.requires_fp16_hd64 for policy in tuning.causal_policies)
+            if requires_fp16_hd64 and (
                 tuning.workload.head_dim != 64
                 or tuning.workload.dtype is not FlashTuningDType.FLOAT16
             ):
                 raise ValueError(
-                    "specialized flash lowerings require the FP16 head-dim-64 workload"
+                    "flash target tuning currently requires the FP16 head-dim-64 workload"
                 )
             if (
                 tuning.tmem_row_reduce_min_kv is not None

--- a/helion/_compiler/cute/flash_tuning.py
+++ b/helion/_compiler/cute/flash_tuning.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import enum
+import math
 
 _FLASH_POLICY_EXP2_PACKETS = frozenset(
     {
@@ -37,7 +38,20 @@ _FLASH_POLICY_PIPELINE_FAMILIES = frozenset(
         "fa4_clc_local_tma_4d",
     }
 )
+_FLASH_POLICY_FP16_HD64_PIPELINE_FAMILIES = frozenset(
+    {
+        "fa4_tma_4d",
+        "fa4_local_tma_4d",
+        "fa4_cga2_local_tma_4d",
+        "fa4_2cta_tma_4d",
+        "fa4_clc_tma_4d",
+        "fa4_clc_local_tma_4d",
+    }
+)
 _FLASH_POLICY_ROLE_MAPS = frozenset({"helion", "fa4"})
+_FLASH_POLICY_BASE_EXP2_PACKETS = frozenset({"1x1", "4x1", "4x2", "8x1", "8x2"})
+_FLASH_POLICY_DEGREE1_EXP2_PACKETS = frozenset({"deg1_16x8", "deg1_8x2_corr10"})
+_FLASH_FLOAT16_MAX_LOG2 = math.log2(65504.0)
 
 
 def _validate_policy_choice(name: str, value: str, choices: frozenset[str]) -> None:
@@ -106,6 +120,7 @@ class FlashDenseTuningPolicy:
     pipeline_family: str = "fa4_2cta"
     kv_stage: int = 6
     persistent: bool = False
+    rescale_threshold: float = 8.0
     packed_exp2_mode: FlashPackedExp2Mode = FlashPackedExp2Mode.DISABLED
     probability_log2_shift: int = 0
     softmax_lowering: FlashSoftmaxLowering = FlashSoftmaxLowering.STANDARD
@@ -137,11 +152,31 @@ class FlashDenseTuningPolicy:
         )
         if self.kv_stage <= 0:
             raise ValueError("dense KV stage must be positive")
-        if self.probability_log2_shift < 0:
-            raise ValueError("probability log2 shift must be nonnegative")
-        if self.softmax_lowering is FlashSoftmaxLowering.STATEFUL:
+        if not math.isfinite(self.rescale_threshold):
+            raise ValueError("dense rescale threshold must be finite")
+        if self.rescale_threshold < 0:
+            raise ValueError("dense rescale threshold must be nonnegative")
+        if (
+            type(self.probability_log2_shift) is not int
+            or self.probability_log2_shift < 0
+        ):
+            raise ValueError("probability log2 shift must be a nonnegative integer")
+        if type(self.softmax_lowering) is not FlashSoftmaxLowering or (
+            self.softmax_lowering
+            not in (
+                FlashSoftmaxLowering.STANDARD,
+                FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+            )
+        ):
             raise ValueError(
-                "stateful softmax lowering is unsupported for dense policy"
+                f"unsupported dense softmax lowering: {self.softmax_lowering!r}"
+            )
+        if type(self.packed_exp2_mode) is not FlashPackedExp2Mode or (
+            self.packed_exp2_mode
+            not in (FlashPackedExp2Mode.DISABLED, FlashPackedExp2Mode.ALL_XU)
+        ):
+            raise ValueError(
+                f"unsupported dense packed exp2 mode: {self.packed_exp2_mode!r}"
             )
         if (
             self.softmax_lowering is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
@@ -150,6 +185,43 @@ class FlashDenseTuningPolicy:
             raise ValueError(
                 "dense resident value-graph lowering requires single statistics transport"
             )
+        uses_resident_softmax = (
+            self.softmax_lowering is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+        )
+        uses_packed_exp2 = self.packed_exp2_mode is FlashPackedExp2Mode.ALL_XU
+        if uses_resident_softmax and uses_packed_exp2:
+            raise ValueError(
+                "dense resident softmax and packed exp2 lowerings are mutually exclusive"
+            )
+        if uses_resident_softmax or uses_packed_exp2:
+            if self.rescale_threshold <= 0:
+                raise ValueError(
+                    "specialized dense lowerings require a positive rescale threshold"
+                )
+            if self.pipeline_family != "fa4_2cta" or self.persistent:
+                raise ValueError(
+                    "specialized dense lowerings require the nonpersistent fa4_2cta pipeline"
+                )
+            if self.e2e_schedule == "xu":
+                raise ValueError(
+                    "specialized dense lowerings require a split end-to-end schedule"
+                )
+            if (
+                self.probability_log2_shift + self.rescale_threshold
+                >= _FLASH_FLOAT16_MAX_LOG2
+            ):
+                raise ValueError(
+                    "dense probability shift and rescale threshold exceed fp16 range"
+                )
+        elif self.probability_log2_shift:
+            raise ValueError(
+                "dense probability shift requires a resident or packed exp2 lowering"
+            )
+        if (
+            uses_packed_exp2
+            and self.exp2_packet not in _FLASH_POLICY_DEGREE1_EXP2_PACKETS
+        ):
+            raise ValueError("packed exp2 lowering requires a degree-1 exp2 packet")
         if (self.corr_regs is None) != (self.other_regs is None):
             raise ValueError(
                 "dense correction and other register counts must be set together"
@@ -164,6 +236,16 @@ class FlashDenseTuningPolicy:
             raise ValueError(
                 "dense other register count must be at least 24 and a multiple of 8"
             )
+
+    @property
+    def requires_fp16_hd64(self) -> bool:
+        """Whether this policy selects an implementation limited to FP16/hd64."""
+        return (
+            self.pipeline_family in _FLASH_POLICY_FP16_HD64_PIPELINE_FAMILIES
+            or self.exp2_packet not in _FLASH_POLICY_BASE_EXP2_PACKETS
+            or self.softmax_lowering is not FlashSoftmaxLowering.STANDARD
+            or self.packed_exp2_mode is not FlashPackedExp2Mode.DISABLED
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -190,6 +272,23 @@ class FlashCausalTuningPolicy:
             raise ValueError("causal KV stage must be positive")
         if self.e2e_offset < 0 or self.e2e_offset0 < 0:
             raise ValueError("causal end-to-end offsets must be nonnegative")
+        if type(self.seed_template) is not FlashCausalSeedTemplate or (
+            self.seed_template is not FlashCausalSeedTemplate.DEGREE2_V1
+        ):
+            raise ValueError(
+                f"unsupported causal seed template: {self.seed_template!r}"
+            )
+        if type(self.softmax_lowering) is not FlashSoftmaxLowering or (
+            self.softmax_lowering
+            not in (
+                FlashSoftmaxLowering.STANDARD,
+                FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+                FlashSoftmaxLowering.STATEFUL,
+            )
+        ):
+            raise ValueError(
+                f"unsupported causal softmax lowering: {self.softmax_lowering!r}"
+            )
         _validate_policy_choice(
             "causal role map", self.role_map, _FLASH_POLICY_ROLE_MAPS
         )
@@ -207,6 +306,13 @@ class FlashCausalTuningPolicy:
             not self.causal_loop_split or self.causal_kv_order != "descending"
         ):
             raise ValueError("causal resident softmax requires a descending split loop")
+
+    @property
+    def requires_fp16_hd64(self) -> bool:
+        """Whether this policy's seed template is limited to FP16/hd64."""
+        # DEGREE2_V1 is currently the only implemented causal seed template and
+        # its emitter is specialized to the FP16/head-dim-64 workload.
+        return self.seed_template is FlashCausalSeedTemplate.DEGREE2_V1
 
 
 @dataclasses.dataclass(frozen=True)

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -2804,6 +2804,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 dataclasses.replace(
                     policy,
                     softmax_lowering=FlashSoftmaxLowering.STANDARD,
+                    probability_log2_shift=0,
                 )
                 if policy.num_kv == 1024
                 else policy

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -2947,16 +2947,59 @@ class TestCuteBackend(TestCase):
             b200_code = dense_bound.to_triton_code(config)
         self.assertNotIn("f16x2_xu=True", b200_code)
 
+        packed_lse_bound = cute_dense_attention_with_lse.bind((q, k, v))
+        target_policy = get_flash_target_policy((10, 3))
+        lse_tuning = dataclasses.replace(
+            target_policy.tuning,
+            dense_policies=tuple(
+                dataclasses.replace(policy, stat_transport="single")
+                if policy.num_kv == 2048
+                else policy
+                for policy in target_policy.tuning.dense_policies
+            ),
+        )
+        lse_config = helion.Config(
+            **{**config.config, "cute_flash_stat_transport": "single"}
+        )
+        with (
+            patch.object(
+                dense_bound.env.config_spec,
+                "target_device_capability",
+                (10, 3),
+            ),
+            patch.object(
+                _cute_flash,
+                "get_flash_target_policy",
+                return_value=dataclasses.replace(target_policy, tuning=lse_tuning),
+            ),
+        ):
+            packed_control_code = dense_bound.to_triton_code(lse_config)
+        self.assertIn("f16x2_xu=True", packed_control_code)
+        with (
+            patch.object(
+                packed_lse_bound.env.config_spec,
+                "target_device_capability",
+                (10, 3),
+            ),
+            patch.object(
+                _cute_flash,
+                "get_flash_target_policy",
+                return_value=dataclasses.replace(target_policy, tuning=lse_tuning),
+            ),
+        ):
+            packed_lse_code = packed_lse_bound.to_triton_code(lse_config)
+        self.assertNotIn("f16x2_xu=True", packed_lse_code)
+
         lse_bound = cute_dense_attention_with_lse.bind(
             (resident_q, resident_k, resident_v)
         )
-        lse_config = helion.Config(
+        resident_lse_config = helion.Config(
             **{**resident_config.config, "cute_flash_stat_transport": "single"}
         )
         with patch.object(
             lse_bound.env.config_spec, "target_device_capability", (10, 3)
         ):
-            lse_code = lse_bound.to_triton_code(lse_config)
+            lse_code = lse_bound.to_triton_code(resident_lse_config)
         self.assertNotIn("f16x2_xu=True", lse_code)
         self.assertNotIn("resident_softmax_value_graph", lse_code)
 
@@ -2969,7 +3012,9 @@ class TestCuteBackend(TestCase):
             modified_code = modified_bound.to_triton_code(resident_config)
         self.assertNotIn("resident_softmax_value_graph", modified_code)
 
-    def test_flash_attention_target_packed_exp2_preserves_256k_tail(self) -> None:
+    def test_flash_attention_target_packed_exp2_matches_sdpa_and_preserves_tail(
+        self,
+    ) -> None:
         capability = torch.cuda.get_device_capability()
         target_policy = get_flash_target_policy(capability)
         dense_policy = target_policy.tuning.dense_policy(2048)
@@ -2981,9 +3026,11 @@ class TestCuteBackend(TestCase):
             self.skipTest("target has no packed f16x2 exp2 lowering")
 
         sequence_length = 262_144
-        q = torch.zeros((1, 1, sequence_length, 64), dtype=torch.float16, device=DEVICE)
-        k = torch.zeros_like(q)
-        v = torch.full_like(q, -2.0)
+        kv_shape = (1, 1, sequence_length, 64)
+        q_shape = kv_shape
+        q = torch.zeros(q_shape, dtype=torch.float16, device=DEVICE)
+        k = torch.zeros(kv_shape, dtype=torch.float16, device=DEVICE)
+        v = torch.full(kv_shape, -2.0, dtype=torch.float16, device=DEVICE)
         q[..., 0] = 1.0
         k[..., 0] = -26.0 * math.sqrt(64) / math.log2(math.e)
         k[..., 0, 0] = 0.0
@@ -3012,6 +3059,16 @@ class TestCuteBackend(TestCase):
         self.assertTrue(torch.equal(out, repeated))
         self.assertTrue(torch.isfinite(out).all())
         self.assertLess((out.float() - expected).abs().max().item(), 5e-5)
+
+        torch.manual_seed(2048)
+        random_q = torch.randn(q_shape, dtype=torch.float16, device=DEVICE)
+        random_k = torch.randn(kv_shape, dtype=torch.float16, device=DEVICE)
+        random_v = torch.randn(kv_shape, dtype=torch.float16, device=DEVICE)
+        random_out = compiled(random_q, random_k, random_v)
+        random_expected = torch.nn.functional.scaled_dot_product_attention(
+            random_q, random_k, random_v
+        )
+        torch.testing.assert_close(random_out, random_expected, atol=0.002, rtol=0.02)
 
     def _check_flash_attention_target_dense_resident(
         self, num_kv: int, seed_value: int

--- a/test/test_cute_causal_range.py
+++ b/test/test_cute_causal_range.py
@@ -8,7 +8,6 @@ from helion._compiler.cute.causal_range import TileLayout
 from helion._compiler.cute.causal_range import prove_causal_tile_range_unmasked
 from helion._compiler.cute.causal_range import prove_descending_causal_prefix_unmasked
 from helion._compiler.cute.cute_flash import _flash_fa4_descending_causal_split_proof
-from helion._compiler.cute.cute_flash import _flash_runtime_range_header
 
 
 @pytest.fixture
@@ -87,17 +86,6 @@ def test_causal_range_handles_distinct_tile_geometries() -> None:
         kv_layout=TileLayout(extent=512, stride=64, width=64),
     )
     assert proof.proven
-
-
-def test_causal_split_loop_header_stays_runtime() -> None:
-    source = _flash_runtime_range_header(
-        "flash_kv_unmask_iter",
-        "flash_m_tile0",
-    )
-    assert source == (
-        "for flash_kv_unmask_iter in cutlass.range(flash_m_tile0, unroll=1):"
-    )
-    assert "range_constexpr" not in source
 
 
 def test_fa4_split_proof_requires_exact_static_sequence_coverage() -> None:

--- a/test/test_cute_flash_arch.py
+++ b/test/test_cute_flash_arch.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import ast
+import dataclasses
+from typing import TYPE_CHECKING
+from typing import cast
 from unittest.mock import patch
 
 import pytest
+import torch
 
+from helion._compiler.cute import cute_flash
+from helion._compiler.cute import flash_tuning
+from helion._compiler.cute.attention_plan import dense_score_plan
 from helion._compiler.cute.flash_arch import FlashHardwareCapabilities
 from helion._compiler.cute.flash_policy import FlashTargetPolicy
 from helion._compiler.cute.flash_policy import flash_target_policy_cache_identity
@@ -17,6 +25,9 @@ from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
 from helion._compiler.cute.flash_tuning import FlashTuningDType
 from helion._compiler.cute.flash_tuning import FlashTuningPolicy
 from helion._compiler.cute.flash_tuning import FlashTuningWorkload
+
+if TYPE_CHECKING:
+    from helion._compiler.device_function import DeviceFunction
 
 
 def test_sm103_flash_target_policy() -> None:
@@ -47,12 +58,24 @@ def test_sm103_flash_target_policy() -> None:
         )
         is None
     )
+    bfloat_dense_policy = FlashDenseTuningPolicy(
+        512,
+        "1x1",
+        "8/2",
+        0,
+        0,
+        "ring2",
+        pipeline_family="fa4_2cta",
+        kv_stage=3,
+        rescale_threshold=0,
+    )
     bfloat_tuning = FlashTuningPolicy(
         workload=FlashTuningWorkload(
             head_dim=128,
             dtype=FlashTuningDType.BFLOAT16,
         ),
         tmem_row_reduce_min_kv=512,
+        dense_policies=(bfloat_dense_policy,),
     )
     multi_workload_policy = FlashTargetPolicy(
         hardware=capabilities,
@@ -63,6 +86,43 @@ def test_sm103_flash_target_policy() -> None:
     assert (
         multi_workload_policy.tuning_for_cute(128, "cutlass.BFloat16") is bfloat_tuning
     )
+    with patch.object(
+        cute_flash, "get_flash_target_policy", return_value=multi_workload_policy
+    ):
+        bfloat_seed = cute_flash.flash_attention_seed_config(
+            128,
+            512,
+            dtype=torch.bfloat16,
+            standard_dense_output=True,
+            target_device_capability=(10, 3),
+        )
+    assert bfloat_seed is not None
+    bfloat_config = cute_flash.resolve_flash_config(
+        128,
+        512,
+        bfloat_seed.config,
+        dtype=torch.bfloat16,
+        is_causal=False,
+        standard_dense_output=True,
+    )
+    with patch.object(
+        cute_flash, "get_flash_target_policy", return_value=multi_workload_policy
+    ):
+        bfloat_body = cute_flash.emit_flash_fa4_device_body(
+            cast("DeviceFunction", None),
+            head_dim=128,
+            num_kv=512,
+            sequence_extent=65_536,
+            num_bh=64,
+            total_tiles=8192,
+            cfg=bfloat_config,
+            has_lse=False,
+            io_dtype="cutlass.BFloat16",
+            score_plan=dense_score_plan(128),
+            target_device_capability=(10, 3),
+        )
+    bfloat_source = ast.unparse(ast.Module(body=bfloat_body, type_ignores=[]))
+    assert "LdRed32x32bOp" in bfloat_source
     with patch(
         "helion._compiler.cute.flash_policy.get_flash_target_policy",
         return_value=multi_workload_policy,
@@ -70,19 +130,15 @@ def test_sm103_flash_target_policy() -> None:
         bfloat_identity = flash_target_policy_cache_identity(
             (10, 3), head_dim=128, torch_dtype="bfloat16", num_kv=512
         )
-    changed_bfloat_policy = FlashTargetPolicy(
-        hardware=capabilities,
-        tuning=policy,
-        additional_tunings=(
-            FlashTuningPolicy(
-                workload=bfloat_tuning.workload,
-                tmem_row_reduce_min_kv=1024,
-            ),
-        ),
+    changed_bfloat_tuning = dataclasses.replace(
+        bfloat_tuning,
+        tmem_row_reduce_min_kv=1024,
     )
     with patch(
         "helion._compiler.cute.flash_policy.get_flash_target_policy",
-        return_value=changed_bfloat_policy,
+        return_value=dataclasses.replace(
+            multi_workload_policy, additional_tunings=(changed_bfloat_tuning,)
+        ),
     ):
         changed_bfloat_identity = flash_target_policy_cache_identity(
             (10, 3), head_dim=128, torch_dtype="bfloat16", num_kv=512
@@ -99,6 +155,7 @@ def test_sm103_flash_target_policy() -> None:
             "fa4_2cta",
             6,
             False,
+            8.0,
             FlashPackedExp2Mode.DISABLED,
             7,
             FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
@@ -114,6 +171,7 @@ def test_sm103_flash_target_policy() -> None:
             "fa4_2cta",
             6,
             False,
+            8.0,
             FlashPackedExp2Mode.DISABLED,
             7,
             FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
@@ -129,6 +187,7 @@ def test_sm103_flash_target_policy() -> None:
             "fa4_2cta",
             6,
             False,
+            8.0,
             FlashPackedExp2Mode.DISABLED,
             7,
             FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
@@ -144,6 +203,7 @@ def test_sm103_flash_target_policy() -> None:
             "fa4_2cta",
             6,
             False,
+            8.0,
             FlashPackedExp2Mode.ALL_XU,
             7,
             FlashSoftmaxLowering.STANDARD,
@@ -164,6 +224,7 @@ def test_sm103_flash_target_policy() -> None:
             shape.pipeline_family,
             shape.kv_stage,
             shape.persistent,
+            shape.rescale_threshold,
             shape.packed_exp2_mode,
             shape.probability_log2_shift,
             shape.softmax_lowering,
@@ -280,10 +341,28 @@ def test_flash_policy_rejects_invalid_field_combinations() -> None:
         FlashTargetPolicy(additional_tunings=(FlashTuningPolicy(),))
     with pytest.raises(ValueError, match="TMEM row-reduce minimum KV size"):
         FlashTuningPolicy(tmem_row_reduce_min_kv=0)
-    with pytest.raises(ValueError, match="probability log2 shift"):
-        FlashDenseTuningPolicy(
-            256, "1x1", "8/2", 0, 0, "single", probability_log2_shift=-1
-        )
+    for shift in (-1, 1.5, float("nan"), True):
+        with pytest.raises(ValueError, match="probability log2 shift"):
+            FlashDenseTuningPolicy(
+                256,
+                "1x1",
+                "8/2",
+                0,
+                0,
+                "single",
+                probability_log2_shift=cast("int", shift),
+            )
+    for threshold in (float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="rescale threshold must be finite"):
+            FlashDenseTuningPolicy(
+                256,
+                "1x1",
+                "8/2",
+                0,
+                0,
+                "single",
+                rescale_threshold=threshold,
+            )
     with pytest.raises(ValueError, match="register counts must be set together"):
         FlashDenseTuningPolicy(
             512,
@@ -314,7 +393,13 @@ def test_flash_policy_rejects_invalid_field_combinations() -> None:
         )
     with pytest.raises(ValueError, match="role map"):
         FlashCausalTuningPolicy(512, 8, role_map="unknown")
-    with pytest.raises(ValueError, match="unsupported for dense"):
+    with pytest.raises(ValueError, match="unsupported causal softmax lowering"):
+        FlashCausalTuningPolicy(
+            512,
+            8,
+            softmax_lowering=cast("FlashSoftmaxLowering", "standard"),
+        )
+    with pytest.raises(ValueError, match="unsupported dense softmax lowering"):
         FlashDenseTuningPolicy(
             256,
             "1x1",
@@ -323,6 +408,26 @@ def test_flash_policy_rejects_invalid_field_combinations() -> None:
             0,
             "single",
             softmax_lowering=FlashSoftmaxLowering.STATEFUL,
+        )
+    with pytest.raises(ValueError, match="unsupported dense softmax lowering"):
+        FlashDenseTuningPolicy(
+            256,
+            "1x1",
+            "8/2",
+            0,
+            0,
+            "single",
+            softmax_lowering=cast("FlashSoftmaxLowering", "standard"),
+        )
+    with pytest.raises(ValueError, match="unsupported dense packed exp2 mode"):
+        FlashDenseTuningPolicy(
+            256,
+            "1x1",
+            "8/2",
+            0,
+            0,
+            "single",
+            packed_exp2_mode=cast("FlashPackedExp2Mode", "disabled"),
         )
     with pytest.raises(ValueError, match="single statistics transport"):
         FlashDenseTuningPolicy(
@@ -333,6 +438,38 @@ def test_flash_policy_rejects_invalid_field_combinations() -> None:
             0,
             "ring2",
             softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+        )
+    with pytest.raises(ValueError, match="nonpersistent fa4_2cta"):
+        FlashDenseTuningPolicy(
+            256,
+            "deg1_8x2_corr10",
+            "8/2",
+            0,
+            0,
+            "single",
+            pipeline_family="fa4",
+            softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+        )
+    with pytest.raises(ValueError, match="degree-1 exp2 packet"):
+        FlashDenseTuningPolicy(
+            2048,
+            "8x2",
+            "8/2",
+            0,
+            0,
+            "single_final",
+            packed_exp2_mode=FlashPackedExp2Mode.ALL_XU,
+        )
+    with pytest.raises(ValueError, match="exceed fp16 range"):
+        FlashDenseTuningPolicy(
+            2048,
+            "deg1_16x8",
+            "16/8",
+            0,
+            0,
+            "single_final",
+            probability_log2_shift=8,
+            packed_exp2_mode=FlashPackedExp2Mode.ALL_XU,
         )
     with pytest.raises(ValueError, match="descending split loop"):
         FlashCausalTuningPolicy(
@@ -359,8 +496,8 @@ def test_target_policy_rejects_tuning_without_hardware_support() -> None:
                 dense_policies=(
                     FlashDenseTuningPolicy(
                         256,
-                        "1x1",
-                        "8/2",
+                        "deg1_16x8",
+                        "16/8",
                         0,
                         0,
                         "single",
@@ -413,6 +550,47 @@ def test_target_policy_rejects_tuning_without_hardware_support() -> None:
                 ),
             ),
         )
+    FlashTargetPolicy(
+        hardware=FlashHardwareCapabilities(supports_tmem_row_reduce=True),
+        tuning=FlashTuningPolicy(
+            workload=FlashTuningWorkload(
+                head_dim=128,
+                dtype=FlashTuningDType.BFLOAT16,
+            ),
+            tmem_row_reduce_min_kv=256,
+        ),
+    )
+    with pytest.raises(ValueError, match="FP16 head-dim-64"):
+        FlashTargetPolicy(
+            tuning=FlashTuningPolicy(
+                workload=FlashTuningWorkload(
+                    head_dim=128,
+                    dtype=FlashTuningDType.BFLOAT16,
+                ),
+                causal_policies=(FlashCausalTuningPolicy(512, 8),),
+            )
+        )
+    with pytest.raises(ValueError, match="FP16 head-dim-64"):
+        FlashTargetPolicy(
+            tuning=FlashTuningPolicy(
+                workload=FlashTuningWorkload(
+                    head_dim=128,
+                    dtype=FlashTuningDType.BFLOAT16,
+                ),
+                dense_policies=(
+                    FlashDenseTuningPolicy(
+                        512,
+                        "1x1",
+                        "8/2",
+                        0,
+                        0,
+                        "ring2",
+                        pipeline_family="fa4_tma_4d",
+                        rescale_threshold=0,
+                    ),
+                ),
+            )
+        )
 
     FlashTargetPolicy(
         hardware=FlashHardwareCapabilities(
@@ -424,8 +602,8 @@ def test_target_policy_rejects_tuning_without_hardware_support() -> None:
             dense_policies=(
                 FlashDenseTuningPolicy(
                     256,
-                    "1x1",
-                    "8/2",
+                    "deg1_16x8",
+                    "16/8",
                     0,
                     0,
                     "single",
@@ -440,4 +618,36 @@ def test_target_policy_rejects_tuning_without_hardware_support() -> None:
                 ),
             ),
         ),
+    )
+
+
+def test_flash_policy_choice_tables_match_codegen_schema() -> None:
+    assert (
+        frozenset(cute_flash.FLASH_PIPELINE_FAMILY_FLAGS)
+        == flash_tuning._FLASH_POLICY_PIPELINE_FAMILIES
+    )
+    assert (
+        frozenset(
+            (
+                *cute_flash._FLASH_EXP2_PACKET_PARAMS,
+                *cute_flash._FLASH_MANUAL_EXP2_PACKET_PARAMS,
+            )
+        )
+        == flash_tuning._FLASH_POLICY_EXP2_PACKETS
+    )
+    assert (
+        frozenset(cute_flash._FLASH_EXP2_PACKET_PARAMS)
+        == flash_tuning._FLASH_POLICY_BASE_EXP2_PACKETS
+    )
+    assert (
+        cute_flash._FLASH_DEG1_EXP2_PACKETS
+        == flash_tuning._FLASH_POLICY_DEGREE1_EXP2_PACKETS
+    )
+    assert (
+        frozenset(
+            family
+            for family, flags in cute_flash.FLASH_PIPELINE_FAMILY_FLAGS.items()
+            if flags.tensor_4d_tma
+        )
+        == flash_tuning._FLASH_POLICY_FP16_HD64_PIPELINE_FAMILIES
     )

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import dataclasses
 import importlib
+import inspect
 import math
 import os
 from typing import TYPE_CHECKING
@@ -268,6 +269,75 @@ def _emit_dense_resident_value_graph_source(
     return ast.unparse(ast.Module(body=body, type_ignores=[]))
 
 
+def _assert_source_markers_in_order(source: str, markers: tuple[str, ...]) -> None:
+    offsets = [source.index(marker) for marker in markers]
+    assert offsets == sorted(offsets)
+
+
+def test_causal_split_softmax_segments_require_proof() -> None:
+    with pytest.raises(AssertionError, match="requires a proven"):
+        cute_flash._flash_causal_split_softmax_segments(
+            "flash_bound",
+            "1",
+            split_range_proof=CausalRangeProof(False, "not proven"),
+        )
+    masked, unmasked = cute_flash._flash_causal_split_softmax_segments(
+        "flash_bound",
+        "1",
+        split_range_proof=CausalRangeProof(True, "proven"),
+    )
+    assert masked.loop_bound == "flash_bound - flash_m_tile1"
+    assert masked.kv_expr == ("flash_bound - cutlass.Int32(1) - flash_kv_mask_iter")
+    assert masked.not_first_condition == "flash_kv_mask_iter != 0"
+    assert not masked.continues_previous_segment
+    assert unmasked.loop_bound == "flash_m_tile1"
+    assert unmasked.kv_expr == (
+        "flash_m_tile1 - cutlass.Int32(1) - flash_kv_unmask_iter"
+    )
+    assert unmasked.not_first_condition == ("flash_kv_unmask_iter >= cutlass.Int32(0)")
+    assert unmasked.continues_previous_segment
+
+
+def test_online_softmax_codegen_preserves_target_alpha_schedules() -> None:
+    b200_source = _emit_causal_resident_native_source(
+        capability=(10, 0),
+        num_kv=512,
+    )
+    b200_masked_start = b200_source.index("for flash_kv_mask_iter")
+    b200_unmasked_start = b200_source.index(
+        "for flash_kv_unmask_iter", b200_masked_start
+    )
+    b200_masked = b200_source[b200_masked_start:b200_unmasked_start]
+    b200_markers = (
+        "mbar_spin_wait(flash_s_full_ptr + 0",
+        "flash_s_full_phase ^= 1",
+        "flash_scale_t[flash_s_corr_prod_index, 0, flash_local_tidx] = flash_alpha",
+        "flash_minus_max_scale =",
+        "fa4_disc_exp_convert_store_pipe_causal",
+        "flash_row_sum = flash_row_sum * flash_alpha + flash_p_sum",
+    )
+    _assert_source_markers_in_order(b200_masked, b200_markers)
+
+    gb300_source = _emit_causal_resident_native_source(
+        capability=(10, 3),
+        num_kv=1024,
+    )
+    gb300_masked_start = gb300_source.index("for flash_kv_mask_iter")
+    gb300_unmasked_start = gb300_source.index(
+        "for flash_kv_unmask_iter", gb300_masked_start
+    )
+    gb300_masked = gb300_source[gb300_masked_start:gb300_unmasked_start]
+    gb300_markers = (
+        "mbar_spin_wait(flash_s_full_ptr + 0",
+        "flash_s_full_phase ^= 1",
+        "flash_minus_max_scale =",
+        "flash_scale_t[0 * 128 + flash_local_tidx] = flash_alpha",
+        "resident_softmax_value_graph",
+        "flash_s_corr_prod_phase ^= 1",
+    )
+    _assert_source_markers_in_order(gb300_masked, gb300_markers)
+
+
 def test_causal_split_equal_iteration_proof_is_explicit() -> None:
     failed = cute_flash._flash_fa4_causal_split_equal_iteration_proof(
         split_range_proof=CausalRangeProof(False, "range failed"),
@@ -303,12 +373,34 @@ def test_registered_causal_shape_selects_requested_resident_lowering() -> None:
         target_policy.tuning,
         causal_policies=(*target_policy.tuning.causal_policies, extra_policy),
     )
+    base_fragments = cute_flash.flash_autotune_fragments(
+        64,
+        768,
+        dtype=torch.float16,
+        is_causal=True,
+        standard_causal_output=True,
+    )
     with patch(
         "helion._compiler.cute.cute_flash.get_flash_target_policy",
         return_value=dataclasses.replace(target_policy, tuning=extended_tuning),
     ):
+        target_fragments = cute_flash.flash_autotune_fragments(
+            64,
+            768,
+            dtype=torch.float16,
+            is_causal=True,
+            standard_causal_output=True,
+            target_device_capability=(10, 3),
+        )
         source = _emit_causal_resident_native_source(num_kv=768)
 
+    base_kv_stage = cast("EnumFragment", base_fragments[cute_flash.FLASH_KV_STAGE_KEY])
+    target_kv_stage = cast(
+        "EnumFragment", target_fragments[cute_flash.FLASH_KV_STAGE_KEY]
+    )
+    assert extra_policy.kv_stage not in base_kv_stage.choices
+    assert extra_policy.kv_stage in target_kv_stage.choices
+    assert target_kv_stage.search_choices == base_kv_stage.choices
     assert "resident_softmax_value_graph" in source
 
 
@@ -432,6 +524,11 @@ def test_degree2_packet_emits_exact_causal_pass2_arguments() -> None:
     ]
     assert len(unmasked_loops) == 2
     for loop in unmasked_loops:
+        assert isinstance(loop.iter, ast.Call)
+        assert ast.unparse(loop.iter.func) == "cutlass.range"
+        assert len(loop.iter.keywords) == 1
+        assert loop.iter.keywords[0].arg == "unroll"
+        assert ast.literal_eval(loop.iter.keywords[0].value) == 1
         assert not any(
             "flash_kv_unmask_iter" in ast.unparse(node.test)
             for node in ast.walk(loop)
@@ -471,7 +568,7 @@ def test_sm103_packed_f16x2_rewrite_requires_exact_promoted_seed() -> None:
     assert "f16x2_xu=True" in promoted_source
 
 
-def test_sm103_scaled_all_xu_codegen_covers_256k() -> None:
+def test_sm103_scaled_all_xu_codegen_requires_exact_rescale_threshold() -> None:
     all_xu_source = _emit_dense_resident_value_graph_source(num_kv=2048)
     overflow_source = _emit_dense_resident_value_graph_source(
         num_kv=2048,
@@ -511,24 +608,25 @@ def test_sm103_scaled_all_xu_codegen_covers_256k() -> None:
     assert "cutlass.Float32(7.0)" not in overflow_source
 
 
-def test_dense_target_lowering_match_is_environment_independent() -> None:
-    dense_seed = cute_flash.flash_attention_seed_config(
-        64,
-        256,
-        standard_dense_output=True,
-        target_device_capability=(10, 3),
-    )
+def test_dense_target_seed_match_ignores_conflicting_environment() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        dense_seed = cute_flash.flash_attention_seed_config(
+            64,
+            256,
+            standard_dense_output=True,
+            target_device_capability=(10, 3),
+        )
     assert dense_seed is not None
-    dense_cfg = cute_flash.resolve_flash_config(
-        64,
-        256,
-        dense_seed.config,
-        standard_dense_output=True,
-    )
-
-    with patch.dict(os.environ, {"HELION_CUTE_FLASH_WAIT_HINT": "0"}):
+    with patch.dict(os.environ, {"HELION_CUTE_FLASH_WAIT_HINT": "0"}, clear=True):
+        dense_cfg = cute_flash.resolve_flash_config(
+            64,
+            256,
+            dense_seed.config,
+            standard_dense_output=True,
+        )
         policy = get_flash_target_policy((10, 3)).tuning.dense_policy(256)
-        assert cute_flash._flash_dense_resident_seed_matches(dense_cfg, policy)
+        assert dense_cfg.wait_hint == 10000000
+        assert cute_flash._flash_dense_target_seed_matches(dense_cfg, policy)
 
 
 def test_dense_resident_value_graph_codegen_and_barrier_protocol() -> None:
@@ -543,10 +641,16 @@ def test_dense_resident_value_graph_codegen_and_barrier_protocol() -> None:
     ]
 
     assert len(value_graph_calls) == 2
+    parameter_names = tuple(
+        inspect.signature(_flash_runtime.resident_softmax_value_graph).parameters
+    )
     for call in value_graph_calls:
-        assert ast.unparse(call.args[9]).endswith("_corr_empty_ptr + 0")
-        assert ast.unparse(call.args[10]) == "flash_s_corr_prod_phase"
-        assert ast.unparse(call.args[11]) == "flash_row_sum * flash_alpha"
+        arguments = dict(zip(parameter_names, call.args, strict=False))
+        assert ast.unparse(arguments["stats_empty_ptr_stage"]).endswith(
+            "_corr_empty_ptr + 0"
+        )
+        assert ast.unparse(arguments["stats_empty_phase"]) == "flash_s_corr_prod_phase"
+        assert ast.unparse(arguments["row_sum_init"]) == "flash_row_sum * flash_alpha"
         assert {
             keyword.arg: ast.unparse(keyword.value) for keyword in call.keywords
         } == {
@@ -664,6 +768,7 @@ def test_dense_resident_softmax_lowering_dispatch_is_exhaustive() -> None:
             dataclasses.replace(
                 shape_policy,
                 softmax_lowering=FlashSoftmaxLowering.STANDARD,
+                probability_log2_shift=0,
             ),
             *policy.dense_policies[1:],
         ),
@@ -680,29 +785,12 @@ def test_dense_resident_softmax_lowering_dispatch_is_exhaustive() -> None:
     assert "fa4_sp_exp_convert_store_whole_rowsum" in standard_source
 
 
-def test_dense_probability_shift_fails_closed_before_fp16_overflow() -> None:
+def test_dense_probability_shift_is_rejected_before_fp16_overflow() -> None:
     target_policy = get_flash_target_policy((10, 3))
     dense_policy = target_policy.tuning.dense_policy(256)
     assert dense_policy is not None
-    unsafe_tuning = dataclasses.replace(
-        target_policy.tuning,
-        dense_policies=tuple(
-            dataclasses.replace(policy, probability_log2_shift=16)
-            if policy.num_kv == 256
-            else policy
-            for policy in target_policy.tuning.dense_policies
-        ),
-    )
-    with patch.object(
-        cute_flash,
-        "get_flash_target_policy",
-        return_value=dataclasses.replace(target_policy, tuning=unsafe_tuning),
-    ):
-        source = _emit_dense_resident_value_graph_source()
-
-    assert "resident_softmax_value_graph" not in source
-    assert "f16x2_xu=True" not in source
-    assert "cutlass.Float32(16.0)" not in source
+    with pytest.raises(ValueError, match="exceed fp16 range"):
+        dataclasses.replace(dense_policy, probability_log2_shift=16)
 
 
 def test_causal_resident_native_codegen_and_single_stat_protocol() -> None:
@@ -1018,9 +1106,12 @@ def test_causal_resident_cross_stage_matches_sdpa_without_deadlock(
     capability = torch.cuda.get_device_capability()
     policy = get_flash_target_policy(capability).tuning
     shape_policy = policy.causal_policy(num_kv)
-    if shape_policy is None:
+    if (
+        shape_policy is None
+        or shape_policy.softmax_lowering
+        is not FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+    ):
         pytest.skip("causal resident native softmax is unsupported on this target")
-    assert shape_policy.softmax_lowering is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
 
     torch.manual_seed(109 + num_kv)
     sequence_length = num_kv * 128
@@ -1058,24 +1149,27 @@ def test_causal_resident_cross_stage_matches_sdpa_without_deadlock(
     torch.testing.assert_close(out, expected, atol=0.01, rtol=0.02)
 
 
-def test_causal_target_lowering_match_is_environment_independent() -> None:
-    causal_seed = cute_flash.flash_attention_seed_config(
-        64,
-        512,
-        is_causal=True,
-        standard_causal_output=True,
-        target_device_capability=(10, 3),
-    )
+def test_causal_target_seed_match_ignores_conflicting_environment() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        causal_seed = cute_flash.flash_attention_seed_config(
+            64,
+            512,
+            is_causal=True,
+            standard_causal_output=True,
+            target_device_capability=(10, 3),
+        )
     assert causal_seed is not None
-    causal_cfg = cute_flash.resolve_flash_config(
-        64,
-        512,
-        causal_seed.config,
-        is_causal=True,
-    )
-
-    with patch.dict(os.environ, {"HELION_CUTE_FLASH_WAIT_HINT": "0"}):
+    with patch.dict(
+        os.environ, {"HELION_CUTE_FLASH_WAIT_HINT": "10000000"}, clear=True
+    ):
+        causal_cfg = cute_flash.resolve_flash_config(
+            64,
+            512,
+            causal_seed.config,
+            is_causal=True,
+        )
         policy = get_flash_target_policy((10, 3)).tuning.causal_policy(512)
+        assert causal_cfg.wait_hint == 0
         assert cute_flash._flash_causal_resident_native_seed_matches(causal_cfg, policy)
 
     effective = cute_flash._flash_resident_softmax_config(causal_cfg)

--- a/test/test_cute_flash_schedule.py
+++ b/test/test_cute_flash_schedule.py
@@ -529,8 +529,17 @@ def test_persistent_phase_continuity_at_work_boundary(
 
 
 @pytest.mark.parametrize("kv_iterations", (3, 4))
+@pytest.mark.parametrize(
+    ("causal", "mapping"),
+    (
+        (False, FlashStatReleaseMapping.CROSS_SLOT),
+        (True, FlashStatReleaseMapping.SAME_SLOT),
+    ),
+)
 def test_pipelined_stat_handoff_models_dummy_and_final_events(
     kv_iterations: int,
+    causal: bool,
+    mapping: FlashStatReleaseMapping,
 ) -> None:
     schedule = build_fa4_schedule(
         FlashScheduleSpec(
@@ -538,8 +547,10 @@ def test_pipelined_stat_handoff_models_dummy_and_final_events(
             2,
             persistent=True,
             kv_iterations=kv_iterations,
+            causal=causal,
             stat_depth=1,
             pipelined_stat_handoff=True,
+            stat_release_mapping=mapping,
         )
     )
 
@@ -618,17 +629,19 @@ def test_pipelined_stat_release_mappings(
 
     verify_flash_schedule(schedule)
 
-    if mapping is FlashStatReleaseMapping.CROSS_SLOT:
-        assert (
-            FlashScheduleSpec(64, 2).stat_release_mapping
-            is FlashStatReleaseMapping.CROSS_SLOT
-        )
     assert schedule.spec.stat_release_mapping is mapping
     assert {
         (edge.source, edge.target, edge.iteration_delta, edge.barrier)
         for edge in schedule.edges
         if edge.barrier is not None and edge.barrier.startswith("stat_empty_")
     } == expected_releases
+
+
+def test_default_stat_release_mapping_is_cross_slot() -> None:
+    assert (
+        FlashScheduleSpec(64, 2).stat_release_mapping
+        is FlashStatReleaseMapping.CROSS_SLOT
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Stacked PRs:
 * __->__#3423
 * #3420
 * #3419
 * #3418
 * #3417


--- --- ---

## Summary

Factor the duplicated FA4 online-softmax loop emitter into a small typed plan and one shared renderer.

- Model loop-domain facts separately from ordered iteration phases.
- Derive KV assignment and continuation guards from the segment model instead of accepting contradictory preformatted strings.
- Keep the terminal row-sum publication outside the loop renderer, making per-iteration versus post-loop scope explicit rather than indentation-dependent.
- Share the wait, phase, max, alpha, probability, statistics, and row-sum skeleton across the existing B200 path and the new GB300 non-stateful resident paths.
- Keep the stateful causal lowering separate because it peels the first iteration and owns a different state/statistics protocol.
- Remove four duplicated loop skeletons, dead plumbing, and repeated recurrence strings.
- Keep architecture selection outside the renderer: no SM100/SM103 capability checks are embedded in the common formatting layer.
- Harden target registration so specialized lowerings fail closed, while workload-generic TMEM row reduction remains reusable by future BF16/head-dim-128 targets.

Depends on #3420. This is PR 6/6 in the GB300 FlashAttention stack.

## Generated-code preservation

This is intended to preserve device code. I directly compared complete emitted source and selected seed configurations for 16 cases:

- SM100 and SM103;
- dense and causal;
- four promoted long-sequence shapes for each mode.

All 16 selected configurations are identical. Twelve generated sources are byte-for-byte identical; the four SM103 causal sources differ only by one new host-side compile-time assertion that the generated shared-storage size matches the verified schedule. The emitted kernel body is otherwise unchanged.

Committed tests check semantic invariants rather than source hashes:

- proof-gated masked/unmasked causal segments;
- wait -> phase -> load/reduce -> alpha -> probability -> statistics -> row-sum ordering;
- masked iterations retain their row-sum update while suppressing only final publication;
- representative B200 and GB300 schedules preserve their intentionally different alpha/minus-scale order;
- policy, cache identity, seed selection, and codegen agree for additional workload envelopes.

This PR also pins the rescale threshold in exact target-seed matching and preserves the complete existing search choices when a registered target value must be admitted. Manual/nonmatching configurations continue to use the standard lowering.

## GB300 performance

NVIDIA GB300, verified 1400 W power limit, FP16, `z=2`, `h=32`, head dimension 64. Values are median-of-medians; lower latency is better.

| Shape | Helion ms | FA4 ms | Helion lead |
|---|---:|---:|---:|
| dense 32K | 13.4479 | 14.1902 | 5.5198% |
| dense 64K | 53.3787 | 56.6861 | 6.1961% |
| dense 128K | 212.9516 | 226.3153 | 6.2755% |
| dense 256K | 893.4257 | 910.3799 | 1.8977% |
| causal 64K | 26.7214 | 26.8559 | 0.5033% |
| causal 128K | 104.9567 | 106.3606 | 1.3376% |
| causal 256K | 415.7419 | 423.9771 | 1.9808% |
| causal 512K | 1658.5634 | 1695.0671 | 2.2009% |

Helion wins all 8 shapes with a **3.2156% geometric-mean latency lead over FA4**. Relative to the pre-refactor run, Helion improved by 0.31% geomean; FA4 moved similarly, so there is no measurable refactor regression.

All 40 backend/shape correctness checks passed.

## Benchmark methodology

- Five implementations: Helion CuTe, FlexAttention/Triton, FlexAttention/CuTe, cuDNN SDPA, and FA4.
- Fresh subprocesses and isolated Helion, CuTe, and Inductor caches.
- Five timed runs after thermal warmup; CUDA-event timing for Helion.
- `--helion-force-flash-config 1` selects the compiler-promoted seed rather than running a full autotune.
- `--power-cap-w 1400` verifies and records the existing GPU power limit; it does not change the power limit.

```bash
run_dir=$(mktemp -d /tmp/helion-gb300-attention-pr6-final.XXXXXX)
CUDA_VISIBLE_DEVICES=0 \
HELION_FA4_ROOT=/home/jongsokchoi/helion_2/benchmarks/flash-attention \
HELION_CACHE_DIR="$run_dir/helion-cache" \
CUTE_DSL_CACHE_DIR="$run_dir/cute-cache" \
TORCHINDUCTOR_CACHE_DIR="$run_dir/inductor-cache" \
.venv/bin/python benchmarks/cute/compare_attention_backends.py \
  --all-shapes --shape-suite dense_causal8 \
  --impls helion-cute flexattention flexattention-cute sdpa fa4 \
  --num-runs 5 --warmup-ms 1000 --rep-ms 500 \
  --power-cap-w 1400 --skip-correctness 0 \
  --helion-force-flash-config 1 \
  --helion-cute-benchmark-timer event \
  --stream-subprocesses \
  --output "$run_dir/results.md" \
  --csv-output "$run_dir/results.csv" \
  --plot-output "$run_dir/results.png" \
  --summary-plot-output "$run_dir/results-geomean.png"
```

## B200 performance (physical A/B)

On NVIDIA B200 at a verified **750 W** power limit, physical same-GPU A/B timing of the full six-PR stack (`1a90b0b6` → `4cf46a7e`) found **no measurable attention regression** across the eight dense/causal long-sequence shapes. Geometric-mean Helion latency changed by **-0.001%** raw and **-0.006%** after normalization to same-run cuDNN SDPA; the worst per-shape change was **+0.366%** raw (**+0.507%** normalized), within B200 run-to-run noise.

All **16/16 Helion** and **16/16 SDPA** correctness checks passed. Selected configurations and codegen markers matched for all eight shapes, and emitted B200 sources were identical aside from the intentional runtime ABI marker change.

Timing was collected on `d4864b3a`; the final `4cf46a7e` force-push changes only `test/test_cute_flash_exp2.py`, with an identical production tree. This physical measurement supersedes the earlier source-identity-only B200 preservation note above.