### PR TITLE
[Pallas] Support scalar stores to resident VMEM outputs

### DIFF
--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1489,6 +1489,7 @@ class PallasBackend(Backend):
     ) -> None:
         from ...autotuner.config_spec import VALID_PALLAS_WORKLIST_GROUPINGS
         from ..compile_environment import CompileEnvironment
+        from .plan_tiling import order_grid_for_shared_outputs
         from .plan_tiling import plan_tiling
         from .tensorcore_plan import build_tensorcore_plans
 
@@ -1504,6 +1505,7 @@ class PallasBackend(Backend):
         env = CompileEnvironment.current()
 
         plan_tiling(graphs, config, tile_strategy)
+        order_grid_for_shared_outputs(graphs, tile_strategy)
         build_tensorcore_plans(graphs, config)
 
         # compact_worklist_* is per-CONFIG state, but one CompileEnvironment is

--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -38,7 +38,7 @@ def _(state: CodegenState) -> None:
     device_fn = state.device_function
     device_fn.device_store_index += 1
     device_fn.device_memory_op_index += 1
-    parts, _ = pallas_codegen.index_parts(state, subscript, tensor)
+    parts, none_dims = pallas_codegen.index_parts(state, subscript, tensor)
     value = pallas_codegen.sliced_value_for_store(
         state, tensor, subscript, parts, value
     )
@@ -46,11 +46,24 @@ def _(state: CodegenState) -> None:
     from .gather import emit_scatter_store
     from .tensorcore_plan import TENSORCORE_PLAN_META
     from .tensorcore_plan import OneHotScatterPlan
+    from .vmem_scalar_load import classify_vmem_scalar_load
+    from .vmem_scalar_load import emit_vmem_scalar_store
+    from .vmem_scalar_load import needs_vmem_scalar_store
 
     plan = state.fx_node.meta.get(TENSORCORE_PLAN_META) if state.fx_node else None
     is_scatter = isinstance(plan, OneHotScatterPlan)
     if is_scatter:
         value = emit_scatter_store(state, plan.plan, name, idx_str, value)
+    elif not none_dims and state.fx_node is not None:
+        patterns = list(state.fx_node.meta.get("indexing_patterns") or ())
+        scalar_store = classify_vmem_scalar_load(state, tensor, parts, patterns)
+        if scalar_store is not None and needs_vmem_scalar_store(tensor, scalar_store):
+            value_var = device_fn.new_var("store_value", dce=True)
+            for stmt in emit_vmem_scalar_store(
+                tensor, name, parts, value, value_var, scalar_store
+            ):
+                state.codegen.add_statement(stmt)
+            return
     from .ordered_carry import emit_carry_store
 
     if not is_scatter and state.device_function.carry_tiles:

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -101,6 +101,64 @@ def plan_tiling(
         _analyze_indexing_expressions(graph_info, config, local_access_keys)
 
 
+def order_grid_for_shared_outputs(
+    graphs: list[GraphInfo], tile_strategy: TileStrategyDispatch
+) -> None:
+    """Make grid dims a stored tensor's block does not index innermost.
+
+    The pipeline writes an output block back when its block index changes
+    and never reloads it, so programs sharing one block must run
+    consecutively. Shared dims move to the end of the strategy's
+    ``loop_order`` (last grid axis iterates fastest), relative order kept.
+    """
+    from ...language import memory_ops
+    from ...language.atomic_ops import ATOMIC_OPS
+    from ..device_function import DeviceFunction
+    from ..host_function import HostFunction
+
+    device_fn = DeviceFunction.current()
+    store_targets = ATOMIC_OPS | {memory_ops.store}
+    stored: dict[int, torch.Tensor] = {}
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            if node.op != "call_function" or node.target not in store_targets:
+                continue
+            tensor_arg = node.args[0]
+            if not isinstance(tensor_arg, torch.fx.Node):
+                continue
+            tensor_val = tensor_arg.meta.get("val")
+            if isinstance(tensor_val, torch.Tensor):
+                stored[id(tensor_val)] = tensor_val
+    if not stored:
+        return
+
+    for grid_block_ids in HostFunction.current().device_ir.grid_block_ids:
+        if len(grid_block_ids) <= 1:
+            continue
+        strategy = tile_strategy.block_id_to_strategy.get(tuple(grid_block_ids))
+        order = getattr(strategy, "loop_order", None)
+        if not isinstance(order, list) or len(order) != len(grid_block_ids):
+            continue
+        shared: set[int] = set()
+        for tid in stored:
+            tilings = device_fn.pallas_tensor_dim_tilings.get(tid)
+            if tilings is None:
+                continue
+            used = {
+                t.block_ids[0] for t in tilings if t.can_tile and len(t.block_ids) == 1
+            }
+            unused = [bid for bid in grid_block_ids if bid not in used]
+            if unused and len(unused) < len(grid_block_ids):
+                shared.update(unused)
+        if not shared:
+            continue
+        shared_pos = {i for i, bid in enumerate(grid_block_ids) if bid in shared}
+        new_order = [i for i in order if i not in shared_pos] + [
+            i for i in order if i in shared_pos
+        ]
+        order[:] = new_order
+
+
 def _tensor_origin_key(tensor: torch.Tensor) -> str | int:
     from ..host_function import HostFunction
 

--- a/helion/_compiler/pallas/vmem_scalar_load.py
+++ b/helion/_compiler/pallas/vmem_scalar_load.py
@@ -1,4 +1,4 @@
-"""Lower scalar-indexed loads from TPU VMEM-resident tensor references.
+"""Lower scalar-indexed accesses to TPU VMEM-resident tensor references.
 
 TPU VMEM is physically tiled in the two minor dimensions, and Mosaic cannot
 project a runtime scalar index out of either one directly. For 32-bit dtypes
@@ -7,9 +7,10 @@ itself (``ref[i, :]``); the lane dimension is then selected with a static
 index after the load. Packed dtypes and dynamic lane indices instead load
 the window, pad it to the physical tile, rotate the requested element to
 index zero, widen to a 32-bit register type, and extract statically.
+Stores use an aligned full-window read-modify-write with a one-hot mask.
 
-``classify_vmem_scalar_load`` decides whether a load needs this lowering;
-``emit_vmem_scalar_load`` generates it.
+``classify_vmem_scalar_load`` classifies both loads and stores; the emitters
+generate the operation-specific lowering.
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ from typing import TYPE_CHECKING
 import torch
 
 from helion._compiler.ast_extension import expr_from_string
+from helion._compiler.ast_extension import statement_from_string
 
 if TYPE_CHECKING:
     import ast
@@ -69,7 +71,7 @@ def _resident_extent(state: CodegenState, tensor: torch.Tensor, dim: int) -> int
     dim_size = tensor.shape[dim]
     if not isinstance(dim_size, int):
         raise NotImplementedError(
-            "Pallas VMEM scalar load requires a static resident extent"
+            "Pallas VMEM scalar access requires a static resident extent"
         )
 
     tiling = state.device_function.pallas_tensor_dim_tilings[id(tensor)][dim]
@@ -81,7 +83,7 @@ def _resident_extent(state: CodegenState, tensor: torch.Tensor, dim: int) -> int
         )
         if not isinstance(block_size, int):
             raise NotImplementedError(
-                "Pallas VMEM scalar load requires a static block size"
+                "Pallas VMEM scalar access requires a static block size"
             )
         return min(dim_size, block_size)
     return dim_size
@@ -101,9 +103,9 @@ def classify_vmem_scalar_load(
     index_parts: list[str],
     indexing_patterns: list[object],
 ) -> VmemScalarLoad | None:
-    """Decide whether a load needs the VMEM scalar-load lowering.
+    """Decide whether an access needs the VMEM scalar-index lowering.
 
-    ``None`` means an ordinary load: no runtime scalar index on the two minor
+    ``None`` means an ordinary access: no runtime scalar index on the two minor
     dims, or a form Mosaic already lowers (static 32-bit extracts).
     """
     from helion._compiler.device_function import PallasMemorySpace
@@ -249,3 +251,64 @@ def emit_vmem_scalar_load(
     if _sublane_load_applies(tensor, load):
         return _sublane_load_expr(tensor, ref_name, index_parts, load)
     return _roll_load_expr(tensor, ref_name, index_parts, load)
+
+
+def needs_vmem_scalar_store(tensor: torch.Tensor, access: VmemScalarLoad) -> bool:
+    """Whether a store needs the select-merge lowering.
+
+    32-bit dtypes can put a runtime sublane index in the ref subscript
+    directly; packed dtypes and runtime lane indices cannot.
+    """
+    return not _sublane_load_applies(tensor, access)
+
+
+def emit_vmem_scalar_store(
+    tensor: torch.Tensor,
+    ref_name: str,
+    index_parts: list[str],
+    value: ast.AST,
+    value_var: str,
+    access: VmemScalarLoad,
+) -> list[ast.stmt]:
+    """Store through a runtime scalar index on a tiled minor dim.
+
+    Reads the full minor-dim window, selects the target slice with a one-hot
+    mask, and writes the window back. The window stays aligned, so Mosaic
+    accepts it; correctness relies on the window being resident in VMEM.
+    """
+    window_parts = [*index_parts]
+    for dim in access.scalar_dims:
+        window_parts[dim] = ":"
+    window = f"{ref_name}[{', '.join(window_parts)}]"
+
+    window_dims = [
+        d
+        for d in range(tensor.ndim)
+        if d in access.scalar_dims or not _is_scalar_index_pattern(access.patterns[d])
+    ]
+    rank = len(window_dims)
+    value_expr = "{value}"
+    masks: list[str] = []
+    for dim in access.scalar_dims:
+        axis = window_dims.index(dim)
+        value_expr = f"jnp.expand_dims({value_expr}, axis={axis})"
+        extent = access.extents[dim]
+        if extent == 1:
+            continue
+        static = access.static_indices[dim]
+        index = str(static) if static is not None else f"({index_parts[dim]})"
+        shape = ", ".join(
+            str(extent) if i == axis else f"{value_var}.shape[{i}]" for i in range(rank)
+        )
+        masks.append(
+            f"(lax.broadcasted_iota(jnp.int32, ({shape},), {axis}) == {index})"
+        )
+    statements = [statement_from_string(f"{value_var} = {value_expr}", value=value)]
+    if not masks:
+        statements.append(statement_from_string(f"{window} = {value_var}"))
+        return statements
+    mask = " & ".join(masks)
+    statements.append(
+        statement_from_string(f"{window} = jnp.where({mask}, {value_var}, {window})")
+    )
+    return statements

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4248,16 +4248,28 @@ class TestPallas(TestCase):
         )
         torch.testing.assert_close(result, x * 2.0)
 
-    @xfailIfPallasTpu(
-        "Mixed scalar write + slice needs tensor duplication into SMEM and VMEM"
-    )
-    def test_mixed_scalar_write_and_slice_access(self) -> None:
-        """Tensor with both scalar write and slice access is unsupported.
+    def test_packed_scalar_row_store(self) -> None:
+        """Packed VMEM stores merge a row into the resident output window."""
 
-        SMEM only supports scalar access; VMEM doesn't support scalar writes.
-        A tensor that needs both would require duplication into SMEM (for the
-        scalar write) and VMEM (for the slice access), which is not yet
-        implemented.
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scalar_row_store(x: torch.Tensor) -> torch.Tensor:
+            b, n = x.shape
+            out = torch.empty_like(x)
+            for tile_b, tile_n in hl.tile([b, n], block_size=[1, None]):
+                out[tile_b.begin, tile_n] = x[tile_b.begin, tile_n]
+            return out
+
+        x = torch.randn(4, 256, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(scalar_row_store, (x,), block_sizes=[128])
+        self.assertIn("lax.broadcasted_iota", code)
+        torch.testing.assert_close(result, x)
+
+    @xfailIfPallasTpu("32-bit runtime sublane stores need an aligned VMEM lowering")
+    def test_mixed_scalar_write_and_slice_access(self) -> None:
+        """A 32-bit runtime sublane store mixed with slice access is unsupported.
+
+        Packed scalar stores use an aligned one-hot merge. The 32-bit sublane
+        form currently takes the direct-store path, which Mosaic rejects.
         """
 
         @helion.kernel(


### PR DESCRIPTION
## Summary

- lower packed and runtime-lane scalar stores to VMEM-resident tensor refs as aligned one-hot read-modify-writes
- order the software-pipeline grid so programs sharing an output BlockSpec run consecutively
- add a focused BF16 scalar-row store regression

This is PR 1 of 2. The follow-up is #3428.

## Test plan

```bash
HELION_BACKEND=pallas HELION_SKIP_CACHE=1 \
  pytest test/test_pallas.py::TestPallas::test_packed_scalar_row_store -x -q
```
