### PR TITLE
[Pallas] Enable Mamba2 chunk scan on TPU

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2731,7 +2731,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             rtol=0.1,
         )
 
-    @xfailIfPallasTpu("BlockSpec tiling failure")
     def test_mamba2_chunk_scan(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (
             2,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3430
* #3429

With the scalar-store lowering in the previous PR, the Mamba2 chunk-scan epilogue can write one runtime-selected head into the resident output block:

```python
store_value = jnp.expand_dims(acc_o.astype(jnp.bfloat16), axis=1)
window = out_ref[0, pl.ds(chunk_offset, block_m), :, :]
head_mask = (
    lax.broadcasted_iota(
        jnp.int32,
        (store_value.shape[0], 8, store_value.shape[2]),
        1,
    )
    == head
)
out_ref[0, pl.ds(chunk_offset, block_m), :, :] = jnp.where(
    head_mask, store_value, window
)
```

Remove the Pallas TPU xfail. Keep the recurrence inputs deterministic and nonzero so stale or uninitialized resident output cannot accidentally pass the test.

Test:

```bash
HELION_BACKEND=pallas HELION_SKIP_CACHE=1 \
  pytest test/test_examples.py::TestExamples::test_mamba2_chunk_scan -x -q
```