### PR TITLE
[Pallas] Support scalar stores to resident VMEM outputs

### DIFF
--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -38,7 +38,7 @@ def _(state: CodegenState) -> None:
     device_fn = state.device_function
     device_fn.device_store_index += 1
     device_fn.device_memory_op_index += 1
-    parts, _ = pallas_codegen.index_parts(state, subscript, tensor)
+    parts, none_dims = pallas_codegen.index_parts(state, subscript, tensor)
     value = pallas_codegen.sliced_value_for_store(
         state, tensor, subscript, parts, value
     )
@@ -46,11 +46,27 @@ def _(state: CodegenState) -> None:
     from .gather import emit_scatter_store
     from .tensorcore_plan import TENSORCORE_PLAN_META
     from .tensorcore_plan import OneHotScatterPlan
+    from .vmem_scalar_load import VMEM_SCALAR_STORE_PLAN
+    from .vmem_scalar_load import VmemScalarStorePlan
+    from .vmem_scalar_load import emit_vmem_scalar_store
+    from .vmem_scalar_load import materialize_vmem_scalar_store
 
     plan = state.fx_node.meta.get(TENSORCORE_PLAN_META) if state.fx_node else None
     is_scatter = isinstance(plan, OneHotScatterPlan)
     if is_scatter:
         value = emit_scatter_store(state, plan.plan, name, idx_str, value)
+    elif not none_dims and state.fx_node is not None:
+        scalar_store_plan = state.fx_node.meta.get(VMEM_SCALAR_STORE_PLAN)
+        if isinstance(scalar_store_plan, VmemScalarStorePlan):
+            scalar_store = materialize_vmem_scalar_store(
+                state, tensor, parts, scalar_store_plan
+            )
+            value_var = device_fn.new_var("store_value", dce=True)
+            for stmt in emit_vmem_scalar_store(
+                tensor, name, parts, value, value_var, scalar_store
+            ):
+                state.codegen.add_statement(stmt)
+            return
     from .ordered_carry import emit_carry_store
 
     if not is_scatter and state.device_function.carry_tiles:

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -99,6 +99,35 @@ def plan_tiling(
             graph_info, graph_lookup, parent_ids
         )
         _analyze_indexing_expressions(graph_info, config, local_access_keys)
+    _plan_vmem_scalar_stores(graphs)
+
+
+def _plan_vmem_scalar_stores(graphs: list[GraphInfo]) -> None:
+    """Attach scalar-store plans after tensor memory spaces are final."""
+    from ...language import memory_ops
+    from ..device_function import DeviceFunction
+    from .vmem_scalar_load import VMEM_SCALAR_STORE_PLAN
+    from .vmem_scalar_load import plan_vmem_scalar_store
+
+    device_fn = DeviceFunction.current()
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            node.meta.pop(VMEM_SCALAR_STORE_PLAN, None)
+            if node.op != "call_function" or node.target is not memory_ops.store:
+                continue
+            tensor_arg = node.args[0]
+            if not isinstance(tensor_arg, torch.fx.Node):
+                continue
+            tensor = tensor_arg.meta.get("val")
+            if not isinstance(tensor, torch.Tensor):
+                continue
+            plan = plan_vmem_scalar_store(
+                tensor,
+                list(node.meta.get("indexing_patterns") or ()),
+                device_fn.pallas_memory_space.get(id(tensor)),
+            )
+            if plan is not None:
+                node.meta[VMEM_SCALAR_STORE_PLAN] = plan
 
 
 def _tensor_origin_key(tensor: torch.Tensor) -> str | int:

--- a/helion/_compiler/pallas/vmem_scalar_load.py
+++ b/helion/_compiler/pallas/vmem_scalar_load.py
@@ -1,4 +1,4 @@
-"""Lower scalar-indexed loads from TPU VMEM-resident tensor references.
+"""Lower scalar-indexed accesses to TPU VMEM-resident tensor references.
 
 TPU VMEM is physically tiled in the two minor dimensions, and Mosaic cannot
 project a runtime scalar index out of either one directly. For 32-bit dtypes
@@ -7,24 +7,40 @@ itself (``ref[i, :]``); the lane dimension is then selected with a static
 index after the load. Packed dtypes and dynamic lane indices instead load
 the window, pad it to the physical tile, rotate the requested element to
 index zero, widen to a 32-bit register type, and extract statically.
+Stores use an aligned full-window read-modify-write with a one-hot mask.
 
-``classify_vmem_scalar_load`` decides whether a load needs this lowering;
-``emit_vmem_scalar_load`` generates it.
+``classify_vmem_scalar_load`` classifies both loads and stores; the emitters
+generate the operation-specific lowering.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from typing import Literal
 
 import torch
 
 from helion._compiler.ast_extension import expr_from_string
+from helion._compiler.ast_extension import statement_from_string
 
 if TYPE_CHECKING:
     import ast
 
     from helion._compiler.inductor_lowering import CodegenState
+
+
+VMEM_SCALAR_STORE_PLAN = "pallas_vmem_scalar_store_plan"
+
+
+@dataclass(frozen=True)
+class VmemScalarStorePlan:
+    """Compiler-visible plan for an aligned resident scalar store."""
+
+    scalar_dims: tuple[int, ...]
+    scalar_block_ids: frozenset[int]
+    patterns: tuple[object, ...]
+    lowering: Literal["aligned_rmw"] = "aligned_rmw"
 
 
 @dataclass(frozen=True)
@@ -62,6 +78,64 @@ def _is_32bit(dtype: torch.dtype) -> bool:
     return dtype.itemsize == 4
 
 
+def _is_runtime_index_pattern(pattern: object) -> bool:
+    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+
+    if isinstance(pattern, TileBeginWithOffsetPattern):
+        return True
+    return isinstance(pattern, ArbitraryIndexPattern) and not isinstance(
+        pattern.index, int
+    )
+
+
+def plan_vmem_scalar_store(
+    tensor: torch.Tensor,
+    indexing_patterns: list[object],
+    memory_space: object,
+) -> VmemScalarStorePlan | None:
+    """Plan stores that require an aligned one-hot VMEM update."""
+    from helion._compiler.device_function import PallasMemorySpace
+    from helion._compiler.pallas.plan_tiling import NonePattern
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+
+    patterns = tuple(indexing_patterns)
+    if (
+        tensor.dtype.itemsize > 4
+        or memory_space != PallasMemorySpace.VMEM
+        or any(isinstance(pattern, NonePattern) for pattern in patterns)
+        or len(patterns) != tensor.ndim
+    ):
+        return None
+
+    scalar_dims = tuple(
+        dim
+        for dim in range(max(0, tensor.ndim - 2), tensor.ndim)
+        if _is_scalar_index_pattern(patterns[dim])
+    )
+    if not scalar_dims:
+        return None
+
+    runtime_dims = {
+        dim for dim in scalar_dims if _is_runtime_index_pattern(patterns[dim])
+    }
+    if _is_32bit(tensor.dtype) and (
+        not runtime_dims
+        or (tensor.ndim - 2 in runtime_dims and tensor.ndim - 1 not in runtime_dims)
+    ):
+        return None
+
+    return VmemScalarStorePlan(
+        scalar_dims=scalar_dims,
+        scalar_block_ids=frozenset(
+            pattern.block_id
+            for dim in scalar_dims
+            if isinstance(pattern := patterns[dim], TileBeginWithOffsetPattern)
+        ),
+        patterns=patterns,
+    )
+
+
 def _resident_extent(state: CodegenState, tensor: torch.Tensor, dim: int) -> int:
     """Return the extent of one dimension in the kernel's resident VMEM window."""
     from helion._compiler.compile_environment import CompileEnvironment
@@ -69,7 +143,7 @@ def _resident_extent(state: CodegenState, tensor: torch.Tensor, dim: int) -> int
     dim_size = tensor.shape[dim]
     if not isinstance(dim_size, int):
         raise NotImplementedError(
-            "Pallas VMEM scalar load requires a static resident extent"
+            "Pallas VMEM scalar access requires a static resident extent"
         )
 
     tiling = state.device_function.pallas_tensor_dim_tilings[id(tensor)][dim]
@@ -81,7 +155,7 @@ def _resident_extent(state: CodegenState, tensor: torch.Tensor, dim: int) -> int
         )
         if not isinstance(block_size, int):
             raise NotImplementedError(
-                "Pallas VMEM scalar load requires a static block size"
+                "Pallas VMEM scalar access requires a static block size"
             )
         return min(dim_size, block_size)
     return dim_size
@@ -101,9 +175,9 @@ def classify_vmem_scalar_load(
     index_parts: list[str],
     indexing_patterns: list[object],
 ) -> VmemScalarLoad | None:
-    """Decide whether a load needs the VMEM scalar-load lowering.
+    """Decide whether an access needs the VMEM scalar-index lowering.
 
-    ``None`` means an ordinary load: no runtime scalar index on the two minor
+    ``None`` means an ordinary access: no runtime scalar index on the two minor
     dims, or a form Mosaic already lowers (static 32-bit extracts).
     """
     from helion._compiler.device_function import PallasMemorySpace
@@ -249,3 +323,74 @@ def emit_vmem_scalar_load(
     if _sublane_load_applies(tensor, load):
         return _sublane_load_expr(tensor, ref_name, index_parts, load)
     return _roll_load_expr(tensor, ref_name, index_parts, load)
+
+
+def materialize_vmem_scalar_store(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    index_parts: list[str],
+    plan: VmemScalarStorePlan,
+) -> VmemScalarLoad:
+    """Add codegen-time extents and literal indices to a store plan."""
+    extents = {dim: _resident_extent(state, tensor, dim) for dim in plan.scalar_dims}
+    return VmemScalarLoad(
+        scalar_dims=list(plan.scalar_dims),
+        extents=extents,
+        static_indices={
+            dim: _static_index(index_parts[dim], extents[dim])
+            for dim in plan.scalar_dims
+        },
+        patterns=plan.patterns,
+    )
+
+
+def emit_vmem_scalar_store(
+    tensor: torch.Tensor,
+    ref_name: str,
+    index_parts: list[str],
+    value: ast.AST,
+    value_var: str,
+    access: VmemScalarLoad,
+) -> list[ast.stmt]:
+    """Store through a runtime scalar index on a tiled minor dim.
+
+    Reads the full minor-dim window, selects the target slice with a one-hot
+    mask, and writes the window back. The window stays aligned, so Mosaic
+    accepts it; correctness relies on the window being resident in VMEM.
+    """
+    window_parts = [*index_parts]
+    for dim in access.scalar_dims:
+        window_parts[dim] = ":"
+    window = f"{ref_name}[{', '.join(window_parts)}]"
+
+    window_dims = [
+        d
+        for d in range(tensor.ndim)
+        if d in access.scalar_dims or not _is_scalar_index_pattern(access.patterns[d])
+    ]
+    rank = len(window_dims)
+    value_expr = "{value}"
+    masks: list[str] = []
+    for dim in access.scalar_dims:
+        axis = window_dims.index(dim)
+        value_expr = f"jnp.expand_dims({value_expr}, axis={axis})"
+        extent = access.extents[dim]
+        if extent == 1:
+            continue
+        static = access.static_indices[dim]
+        index = str(static) if static is not None else f"({index_parts[dim]})"
+        shape = ", ".join(
+            str(extent) if i == axis else f"{value_var}.shape[{i}]" for i in range(rank)
+        )
+        masks.append(
+            f"(lax.broadcasted_iota(jnp.int32, ({shape},), {axis}) == {index})"
+        )
+    statements = [statement_from_string(f"{value_var} = {value_expr}", value=value)]
+    if not masks:
+        statements.append(statement_from_string(f"{window} = {value_var}"))
+        return statements
+    mask = " & ".join(masks)
+    statements.append(
+        statement_from_string(f"{window} = jnp.where({mask}, {value_var}, {window})")
+    )
+    return statements

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4248,16 +4248,29 @@ class TestPallas(TestCase):
         )
         torch.testing.assert_close(result, x * 2.0)
 
-    @xfailIfPallasTpu(
-        "Mixed scalar write + slice needs tensor duplication into SMEM and VMEM"
-    )
-    def test_mixed_scalar_write_and_slice_access(self) -> None:
-        """Tensor with both scalar write and slice access is unsupported.
+    def test_packed_scalar_row_store(self) -> None:
+        """Packed VMEM stores merge a row into the resident output window."""
 
-        SMEM only supports scalar access; VMEM doesn't support scalar writes.
-        A tensor that needs both would require duplication into SMEM (for the
-        scalar write) and VMEM (for the slice access), which is not yet
-        implemented.
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scalar_row_store(x: torch.Tensor) -> torch.Tensor:
+            b, n = x.shape
+            out = torch.empty_like(x)
+            for tile_b, tile_n in hl.tile([b, n], block_size=[1, None]):
+                out[tile_b.begin, tile_n] = x[tile_b.begin, tile_n]
+            return out
+
+        # One column tile keeps this independent of shared-output grid ordering.
+        x = torch.randn(4, 128, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(scalar_row_store, (x,), block_sizes=[128])
+        self.assertIn("lax.broadcasted_iota", code)
+        torch.testing.assert_close(result, x)
+
+    @xfailIfPallasTpu("32-bit runtime sublane stores need an aligned VMEM lowering")
+    def test_mixed_scalar_write_and_slice_access(self) -> None:
+        """A 32-bit runtime sublane store mixed with slice access is unsupported.
+
+        Packed scalar stores use an aligned one-hot merge. The 32-bit sublane
+        form currently takes the direct-store path, which Mosaic rejects.
         """
 
         @helion.kernel(


### PR DESCRIPTION
Stacked PRs:
 * #3432
 * __->__#3431

--- --- ---

Mosaic cannot lower a runtime scalar store into either tiled minor VMEM dimension. For BF16, the direct form fails alignment validation:

```python
def kernel(out_ref, head_ref, value_ref):  # out_ref: (64, 8, 32) bf16 in VMEM
    head = head_ref[0]
    out_ref[:, head, :] = value_ref[...]   # E2003: unproven memory alignment
```

For output blocks already resident in VMEM, lower this to an aligned one-hot read-modify-write:

```python
def kernel(out_ref, head_ref, value_ref):
    head = head_ref[0]
    value = jnp.expand_dims(value_ref[...], axis=1)
    mask = lax.broadcasted_iota(jnp.int32, (64, 8, 32), 1) == head
    out_ref[...] = jnp.where(mask, value, out_ref[...])
```

The physical load/store remains aligned while the select updates one logical lane. A masked BF16 store cannot be used here because Mosaic only supports masked swaps for 32-bit values.

The lowering decision is recorded once as a compiler-visible scalar-store plan after VMEM placement is final. Codegen consumes that plan directly; the follow-up uses the same metadata for scheduling.

Adds a focused single-output-block BF16 scalar-row regression. Scheduling programs that share the resident window remains separate.

Test:

```bash
HELION_BACKEND=pallas HELION_SKIP_CACHE=1 \
  pytest test/test_pallas.py::TestPallas::test_packed_scalar_row_store -x -q
```
