### PR TITLE
[Pallas] Enable Mamba2 chunk scan on TPU

### DIFF
--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1489,6 +1489,7 @@ class PallasBackend(Backend):
     ) -> None:
         from ...autotuner.config_spec import VALID_PALLAS_WORKLIST_GROUPINGS
         from ..compile_environment import CompileEnvironment
+        from .plan_tiling import order_grid_for_shared_scalar_stores
         from .plan_tiling import plan_tiling
         from .tensorcore_plan import build_tensorcore_plans
 
@@ -1504,6 +1505,7 @@ class PallasBackend(Backend):
         env = CompileEnvironment.current()
 
         plan_tiling(graphs, config, tile_strategy)
+        order_grid_for_shared_scalar_stores(graphs, config, tile_strategy)
         build_tensorcore_plans(graphs, config)
 
         # compact_worklist_* is per-CONFIG state, but one CompileEnvironment is

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -130,6 +130,109 @@ def _plan_vmem_scalar_stores(graphs: list[GraphInfo]) -> None:
                 node.meta[VMEM_SCALAR_STORE_PLAN] = plan
 
 
+def order_grid_for_shared_scalar_stores(
+    graphs: list[GraphInfo], config: Config, tile_strategy: TileStrategyDispatch
+) -> None:
+    """Keep programs updating one resident output window consecutive.
+
+    An aligned scalar RMW updates a full VMEM window. Grid dimensions omitted
+    by that tensor's BlockSpec must therefore be faster than every dimension
+    selecting the window, so each window is completed before it is flushed.
+    """
+    from ..compile_environment import CompileEnvironment
+    from ..device_function import DeviceFunction
+    from ..host_function import HostFunction
+    from .vmem_scalar_load import VMEM_SCALAR_STORE_PLAN
+    from .vmem_scalar_load import VmemScalarStorePlan
+
+    device_fn = DeviceFunction.current()
+    env = CompileEnvironment.current()
+    stores: list[tuple[torch.Tensor, VmemScalarStorePlan]] = []
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            plan = node.meta.get(VMEM_SCALAR_STORE_PLAN)
+            if not isinstance(plan, VmemScalarStorePlan):
+                continue
+            tensor_arg = node.args[0]
+            if not isinstance(tensor_arg, torch.fx.Node):
+                continue
+            tensor = tensor_arg.meta.get("val")
+            if isinstance(tensor, torch.Tensor):
+                stores.append((tensor, plan))
+
+    for grid_block_ids in HostFunction.current().device_ir.grid_block_ids:
+        if len(grid_block_ids) <= 1:
+            continue
+        strategy = tile_strategy.block_id_to_strategy.get(tuple(grid_block_ids))
+        order = getattr(strategy, "loop_order", None)
+        if not isinstance(order, list) or len(order) != len(grid_block_ids):
+            continue
+
+        grid_ids = frozenset(grid_block_ids)
+        edges: set[tuple[int, int]] = set()
+        for tensor, plan in stores:
+            tilings = device_fn.pallas_tensor_dim_tilings.get(id(tensor))
+            if tilings is None:
+                continue
+            key_ids: set[int] = set()
+            for dim, tiling in enumerate(tilings):
+                # Composite-index dimensions cannot be BlockSpec-tiled and
+                # therefore remain part of the fully resident window.
+                if not tiling.can_tile or len(tiling.block_ids) != 1:
+                    continue
+                block_id = tiling.block_ids[0]
+                if block_id not in grid_ids:
+                    continue
+                block_size = env.block_sizes[block_id].from_config(config)
+                dim_size = tensor.shape[dim]
+                if isinstance(block_size, int) and (
+                    not isinstance(dim_size, int) or dim_size > block_size
+                ):
+                    key_ids.add(block_id)
+
+            shared_ids = grid_ids - key_ids
+            if not (plan.scalar_block_ids & shared_ids):
+                continue
+            edges.update(
+                (key_id, shared_id) for key_id in key_ids for shared_id in shared_ids
+            )
+
+        if edges:
+            ordered_ids = [grid_block_ids[position] for position in order]
+            new_order = [
+                grid_block_ids.index(block_id)
+                for block_id in _stable_topological_order(ordered_ids, edges)
+            ]
+            # The original list belongs to Config; install an effective copy.
+            strategy.loop_order = new_order  # type: ignore[attr-defined]
+
+
+def _stable_topological_order(
+    order: list[int], edges: set[tuple[int, int]]
+) -> list[int]:
+    """Satisfy ordering constraints while preserving unrelated order."""
+    remaining = list(order)
+    result: list[int] = []
+    while remaining:
+        ready = next(
+            (
+                block_id
+                for block_id in remaining
+                if not any(
+                    before in remaining for before, after in edges if after == block_id
+                )
+            ),
+            None,
+        )
+        if ready is None:
+            raise exc.InvalidConfig(
+                "Pallas resident scalar stores require incompatible grid orders"
+            )
+        result.append(ready)
+        remaining.remove(ready)
+    return result
+
+
 def _tensor_origin_key(tensor: torch.Tensor) -> str | int:
     from ..host_function import HostFunction
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2731,10 +2731,9 @@ class TestExamples(RefEagerTestBase, TestCase):
             rtol=0.1,
         )
 
-    @xfailIfPallasTpu("BlockSpec tiling failure")
     def test_mamba2_chunk_scan(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (
-            2,
+            3,
             8,
             1,
             256,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4265,6 +4265,30 @@ class TestPallas(TestCase):
         self.assertIn("lax.broadcasted_iota", code)
         torch.testing.assert_close(result, x)
 
+    def test_shared_output_scalar_store_grid_order(self) -> None:
+        """Programs updating one resident output window stay consecutive."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scalar_row_store(x: torch.Tensor) -> torch.Tensor:
+            b, n = x.shape
+            out = torch.empty_like(x)
+            for tile_b, tile_n in hl.tile([b, n], block_size=[1, None]):
+                out[tile_b.begin, tile_n] = x[tile_b.begin, tile_n]
+            return out
+
+        # Three column windows exceed the two output buffers. Without the grid
+        # constraint, revisiting the first window loses its earlier row stores.
+        x = torch.randn(4, 384, device=DEVICE, dtype=torch.bfloat16)
+        loop_orders = [[0, 1]]
+        _, result = code_and_output(
+            scalar_row_store,
+            (x,),
+            block_sizes=[128],
+            loop_orders=loop_orders,
+        )
+        self.assertEqual(loop_orders, [[0, 1]])
+        torch.testing.assert_close(result, x)
+
     @xfailIfPallasTpu("32-bit runtime sublane stores need an aligned VMEM lowering")
     def test_mixed_scalar_write_and_slice_access(self) -> None:
         """A 32-bit runtime sublane store mixed with slice access is unsupported.


### PR DESCRIPTION
Stacked PRs:
 * __->__#3432
 * #3431

--- --- ---

With the scalar-store lowering in the previous PR, the Mamba2 chunk-scan epilogue can write one runtime-selected head into the resident output block:

```python
store_value = jnp.expand_dims(acc_o.astype(jnp.bfloat16), axis=1)
window = out_ref[0, pl.ds(chunk_offset, block_m), :, :]
head_mask = (
    lax.broadcasted_iota(
        jnp.int32,
        (store_value.shape[0], 8, store_value.shape[2]),
        1,
    )
    == head
)
out_ref[0, pl.ds(chunk_offset, block_m), :, :] = jnp.where(
    head_mask, store_value, window
)
```

Several head programs share that output BlockSpec. An output-only VMEM window is flushed when its BlockSpec index changes and is not reloaded when revisited, so the head grid dimension must be innermost:

```text
(chunk0, head0), ..., (chunk0, head7), (chunk1, head0), ...
```

The pass consumes the aligned-RMW plans from the previous PR and derives each output window's key dimensions from its BlockSpec tiling. Dimensions selecting a window must precede dimensions omitted by that BlockSpec. A stable topological sort preserves the requested order where unconstrained, leaves the caller's config unchanged, and rejects cycles.

Adds a dedicated three-output-window ordering regression and removes the Mamba2 Pallas TPU xfail. Three batch windows exercise the same buffer-revisit hazard in Mamba; deterministic nonzero recurrence inputs prevent stale or uninitialized output from accidentally passing.

Test:

```bash
HELION_BACKEND=pallas HELION_SKIP_CACHE=1 \
  pytest \
    test/test_pallas.py::TestPallas::test_shared_output_scalar_store_grid_order \
    test/test_examples.py::TestExamples::test_mamba2_chunk_scan \
    -x -q
```
