### PR TITLE
Support nested function definitions

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -2568,7 +2568,7 @@ class WalkDeviceAST(NodeVisitor):
         # pyrefly: ignore [missing-attribute]
         func_type_info = node.func._type_info
         if isinstance(func_type_info, NestedFunctionType):
-            return self._call_nested_function(func_type_info, args)
+            return self._call_nested_function(func_type_info, args, kwargs)
         if isinstance(func_type_info, CallableType) and (
             replacement := get_device_func_replacement(func_type_info.value)
         ):
@@ -2585,10 +2585,19 @@ class WalkDeviceAST(NodeVisitor):
         self.scope[node.name] = None
 
     def _call_nested_function(
-        self, func: NestedFunctionType, args: list[object]
+        self,
+        func: NestedFunctionType,
+        args: list[object],
+        kwargs: dict[str, object],
     ) -> object:
         func_node = func.func_node
         params = func_node.args
+        if kwargs:
+            raise exc.StatementNotSupported(
+                f"Keyword arguments are not supported when calling nested "
+                f"function '{func_node.name}'"
+            )
+        func.find_effective_return()
         old_scope = self.scope.copy()
         for param, arg_val in zip(params.args, args, strict=True):
             self.scope[param.arg] = arg_val

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -74,6 +74,7 @@ from .type_info import GridIndexType
 from .type_info import IterType
 from .type_info import JaggedTileIndexType
 from .type_info import LiteralType
+from .type_info import NestedFunctionType
 from .type_info import NumericType
 from .type_info import SequenceType
 from .type_info import StackTensorType
@@ -2564,22 +2565,41 @@ class WalkDeviceAST(NodeVisitor):
             else:
                 kwargs[kwarg.arg] = self.visit(kwarg.value)
 
-        if isinstance(
-            (
-                # pyrefly: ignore [missing-attribute]
-                func_type_info := node.func._type_info
-            ),
-            CallableType,
-        ) and (replacement := get_device_func_replacement(func_type_info.value)):
+        # pyrefly: ignore [missing-attribute]
+        func_type_info = node.func._type_info
+        if isinstance(func_type_info, NestedFunctionType):
+            return self._call_nested_function(func_type_info, args)
+        if isinstance(func_type_info, CallableType) and (
+            replacement := get_device_func_replacement(func_type_info.value)
+        ):
             func = replacement
         else:
             func = self.visit(node.func)
-
         # pyrefly: ignore [bad-argument-type]
         return _CheckForIndexCalls.retry_call(func, args, kwargs)
 
     def visit_Attribute(self, node: ast.Attribute) -> object:
         return getattr(self.visit(node.value), node.attr)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.scope[node.name] = None
+
+    def _call_nested_function(
+        self, func: NestedFunctionType, args: list[object]
+    ) -> object:
+        func_node = func.func_node
+        params = func_node.args
+        old_scope = self.scope.copy()
+        for param, arg_val in zip(params.args, args, strict=True):
+            self.scope[param.arg] = arg_val
+        try:
+            for stmt in func_node.body:
+                if isinstance(stmt, ast.Return):
+                    return self.visit(stmt.value) if stmt.value is not None else None
+                self.visit(stmt)
+        finally:
+            self.scope = old_scope
+        return None
 
     def visit_Expr(self, node: ast.Expr) -> object:
         return self.visit(node.value)

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -44,6 +44,7 @@ from .variable_origin import TensorStrideOrigin
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from collections.abc import Iterator
     from collections.abc import Sequence
     from typing_extensions import Self
 
@@ -716,6 +717,14 @@ class StringType(TypeInfo):
         return "str"
 
 
+def _iter_body_excluding_nested_defs(node: ast.AST) -> Iterator[ast.AST]:
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        yield child
+        yield from _iter_body_excluding_nested_defs(child)
+
+
 class NestedFunctionType(TypeInfo):
     func_node: ast.FunctionDef
 
@@ -729,6 +738,20 @@ class NestedFunctionType(TypeInfo):
 
     def __str__(self) -> str:
         return f"NestedFunctionType({self.func_node.name})"
+
+    def find_effective_return(self) -> ast.Return | None:
+        func_node = self.func_node
+        for stmt in func_node.body:
+            for desc in _iter_body_excluding_nested_defs(stmt):
+                if isinstance(desc, ast.Return):
+                    raise exc.StatementNotSupported(
+                        f"Early return inside control flow is not supported "
+                        f"in nested function '{func_node.name}'"
+                    )
+        for stmt in func_node.body:
+            if isinstance(stmt, ast.Return):
+                return stmt
+        return None
 
 
 class ConfigFragmentType(LiteralType):

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -716,6 +716,21 @@ class StringType(TypeInfo):
         return "str"
 
 
+class NestedFunctionType(TypeInfo):
+    func_node: ast.FunctionDef
+
+    def __init__(
+        self,
+        origin: Origin,
+        func_node: ast.FunctionDef,
+    ) -> None:
+        super().__init__(origin)
+        self.func_node = func_node
+
+    def __str__(self) -> str:
+        return f"NestedFunctionType({self.func_node.name})"
+
+
 class ConfigFragmentType(LiteralType):
     """TypeInfo for config fragments are treated as constant literals during compilation."""
 

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -763,33 +763,48 @@ class TypePropagation(ast.NodeVisitor):
                 + ", ".join(map(str, unhandled))
             )
         if isinstance(func, NestedFunctionType):
-            return self._call_nested_function(func, args)
+            return self._call_nested_function(func, args, kwargs)
 
         # pyrefly: ignore [bad-argument-type, bad-return]
         return func.propagate_call(tuple(args), kwargs, self.origin())
 
     def _call_nested_function(
-        self, func: NestedFunctionType, args: list[TypeInfo]
+        self,
+        func: NestedFunctionType,
+        args: list[TypeInfo],
+        kwargs: dict[str, TypeInfo],
     ) -> TypeInfo:
         func_node = func.func_node
         params = func_node.args
+        if kwargs:
+            raise exc.StatementNotSupported(
+                f"Keyword arguments are not supported when calling nested "
+                f"function '{func_node.name}'"
+            )
         if len(args) != len(params.args):
             raise exc.TypeInferenceError(
                 f"Function '{func_node.name}' expects "
                 f"{len(params.args)} arguments, got {len(args)}"
             )
+        effective_return = func.find_effective_return()
         self.push_scope()
         for param, arg_type in zip(params.args, args, strict=True):
             self.scope.set(param.arg, arg_type)
         try:
             result: TypeInfo = NoType(origin=self.origin())
             for stmt in func_node.body:
-                if isinstance(stmt, ast.Return) and stmt.value is not None:
-                    result = self.visit(stmt.value)
+                if isinstance(stmt, ast.Return):
+                    result = (
+                        self.visit(stmt.value)
+                        if stmt.value is not None
+                        else NoType(origin=self.origin())
+                    )
                     break
                 result = self.visit(stmt)
         finally:
             self.pop_scope()
+        if effective_return is None or effective_return.value is None:
+            return NoType(origin=self.origin())
         return result
 
     def visit_IfExp(self, node: ast.IfExp) -> TypeInfo:
@@ -1257,6 +1272,22 @@ class TypePropagation(ast.NodeVisitor):
             raise exc.StatementNotSupported(
                 f"Default arguments not supported in nested function '{node.name}'"
             )
+        for stmt in ast.walk(node):
+            if isinstance(stmt, (ast.Global, ast.Nonlocal)):
+                raise exc.StatementNotSupported(
+                    f"'global'/'nonlocal' not supported in nested function "
+                    f"'{node.name}'"
+                )
+        for descendant in ast.walk(node):
+            if (
+                isinstance(descendant, ast.Call)
+                and isinstance(descendant.func, ast.Name)
+                and descendant.func.id == node.name
+            ):
+                raise exc.StatementNotSupported(
+                    f"Recursive nested function '{node.name}' is not supported"
+                )
+        # nested defs are inlined using the caller's scope (dynamic scoping).
         func_type = NestedFunctionType(origin=self.origin(), func_node=node)
         self.scope.set(node.name, func_type)
         return func_type

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -33,6 +33,7 @@ from .type_info import CallableType
 from .type_info import CollectionType
 from .type_info import DictType
 from .type_info import LiteralType
+from .type_info import NestedFunctionType
 from .type_info import NoType
 from .type_info import NumericType
 from .type_info import SequenceType
@@ -761,8 +762,35 @@ class TypePropagation(ast.NodeVisitor):
                 "Failed to unpack */** args to function, got: "
                 + ", ".join(map(str, unhandled))
             )
+        if isinstance(func, NestedFunctionType):
+            return self._call_nested_function(func, args)
+
         # pyrefly: ignore [bad-argument-type, bad-return]
         return func.propagate_call(tuple(args), kwargs, self.origin())
+
+    def _call_nested_function(
+        self, func: NestedFunctionType, args: list[TypeInfo]
+    ) -> TypeInfo:
+        func_node = func.func_node
+        params = func_node.args
+        if len(args) != len(params.args):
+            raise exc.TypeInferenceError(
+                f"Function '{func_node.name}' expects "
+                f"{len(params.args)} arguments, got {len(args)}"
+            )
+        self.push_scope()
+        for param, arg_type in zip(params.args, args, strict=True):
+            self.scope.set(param.arg, arg_type)
+        try:
+            result: TypeInfo = NoType(origin=self.origin())
+            for stmt in func_node.body:
+                if isinstance(stmt, ast.Return) and stmt.value is not None:
+                    result = self.visit(stmt.value)
+                    break
+                result = self.visit(stmt)
+        finally:
+            self.pop_scope()
+        return result
 
     def visit_IfExp(self, node: ast.IfExp) -> TypeInfo:
         test = self.visit(node.test)
@@ -1214,9 +1242,24 @@ class TypePropagation(ast.NodeVisitor):
     # pyrefly: ignore [bad-assignment, bad-param-name-override, bad-override-mutable-attribute]
     visit_SetComp: _VisitMethod = _not_supported
 
-    # TODO(jansel): support closure functions defined on host
     # pyrefly: ignore [bad-assignment, bad-param-name-override, bad-override-mutable-attribute]
-    visit_FunctionDef: _VisitMethod = _not_supported
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> TypeInfo:
+        args = node.args
+        if args.vararg:
+            raise exc.StatementNotSupported(
+                f"*args not supported in nested function '{node.name}'"
+            )
+        if args.kwarg:
+            raise exc.StatementNotSupported(
+                f"**kwargs not supported in nested function '{node.name}'"
+            )
+        if args.defaults or args.kw_defaults:
+            raise exc.StatementNotSupported(
+                f"Default arguments not supported in nested function '{node.name}'"
+            )
+        func_type = NestedFunctionType(origin=self.origin(), func_node=node)
+        self.scope.set(node.name, func_type)
+        return func_type
 
     # pyrefly: ignore [bad-assignment, bad-param-name-override, bad-override-mutable-attribute]
     visit_ClassDef: _VisitMethod = _not_supported

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -763,7 +763,7 @@ class TypePropagation(ast.NodeVisitor):
                 + ", ".join(map(str, unhandled))
             )
         if isinstance(func, NestedFunctionType):
-            return self._call_nested_function(func, args, kwargs)
+            return self._call_nested_function(func, args, kwargs)  # pyrefly: ignore [bad-argument-type]
 
         # pyrefly: ignore [bad-argument-type, bad-return]
         return func.propagate_call(tuple(args), kwargs, self.origin())
@@ -1268,6 +1268,14 @@ class TypePropagation(ast.NodeVisitor):
             raise exc.StatementNotSupported(
                 f"**kwargs not supported in nested function '{node.name}'"
             )
+        if args.posonlyargs:
+            raise exc.StatementNotSupported(
+                f"Positional-only arguments not supported in nested function '{node.name}'"
+            )
+        if args.kwonlyargs:
+            raise exc.StatementNotSupported(
+                f"Keyword-only arguments not supported in nested function '{node.name}'"
+            )
         if args.defaults or args.kw_defaults:
             raise exc.StatementNotSupported(
                 f"Default arguments not supported in nested function '{node.name}'"
@@ -1278,6 +1286,7 @@ class TypePropagation(ast.NodeVisitor):
                     f"'global'/'nonlocal' not supported in nested function "
                     f"'{node.name}'"
                 )
+        # direct recursion only; mutual recursion is not detected
         for descendant in ast.walk(node):
             if (
                 isinstance(descendant, ast.Call)

--- a/test/test_closures.py
+++ b/test/test_closures.py
@@ -164,6 +164,112 @@ class TestClosures(RefEagerTestBase, TestCase):
         code, result = code_and_output(fn, (x, y))
         torch.testing.assert_close(result, x * 0.7 + y * 0.3)
 
+    def test_nested_def_calls_nested_def(self):
+        @helion.kernel
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+
+            def a(v):
+                return v * 2.0
+
+            def b(v):
+                return a(v) + 1.0
+
+            for tile in hl.tile(x.size(0)):
+                out[tile] = b(x[tile])
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        _, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x * 2.0 + 1.0)
+
+    def test_nested_def_tuple_return_unpack(self):
+        @helion.kernel
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+
+            def pair(v):
+                return v * 2.0, v * 3.0
+
+            for tile in hl.tile(x.size(0)):
+                a, b = pair(x[tile])
+                out[tile] = a + b
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        _, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x * 5.0)
+
+    def test_nested_def_alias(self):
+        @helion.kernel
+        def fn(x: torch.tensor) -> torch.tensor:
+            out = torch.empty_like(x)
+
+            def double(v):
+                return v * 2.0
+
+            g = double
+            for tile in hl.tile(x.size(0)):
+                out[tile] = g(x[tile])
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        _, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x * 2.0)
+
+    def test_nested_def_in_control_flow(self):
+        # A nested function defined inside a branch is still callable afterwards.
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            if x.size(0) > 0:
+
+                def double(a):
+                    return a * 2.0
+
+            for tile in hl.tile(x.size(0)):
+                out[tile] = double(x[tile])
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        _, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x * 2.0)
+
+    def test_nested_def_dead_code_after_return(self):
+        @helion.kernel
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+
+            def f(a):  # noqa: RET503
+                b = a * 2.0
+                return b  # noqa: RET504
+                # dead code
+                c = a * 3.0  # noqa: F841
+
+            for tile in hl.tile(x.size(0)):
+                out[tile] = f(x[tile])
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        _, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x * 2.0)
+
+    def test_nested_def_called_on_host(self):
+        @helion.kernel
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def allocate():
+                return torch.empty_like(x)
+
+            out = allocate()
+
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] * 2.0
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        _, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x * 2.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_closures.py
+++ b/test/test_closures.py
@@ -98,6 +98,72 @@ class TestClosures(RefEagerTestBase, TestCase):
         code, out = code_and_output(call_func_arg_on_host, args)
         torch.testing.assert_close(out, args[0].sin())
 
+    def test_nested_def_simple(self):
+        @helion.kernel
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+
+            def double(a):
+                return a * 2.0
+
+            for tile in hl.tile(x.size(0)):
+                out[tile] = double(x[tile])
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        code, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x * 2.0)
+
+    def test_nested_def_closure(self):
+        @helion.kernel
+        def fn(x: torch.Tensor, scale: float) -> torch.Tensor:
+            out = torch.empty_like(x)
+
+            def transform(a):
+                return a * scale
+
+            for tile in hl.tile(x.size(0)):
+                out[tile] = transform(x[tile])
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        code, result = code_and_output(fn, (x, 3.0))
+        torch.testing.assert_close(result, x * 3.0)
+
+    def test_nested_def_multi_stmt(self):
+        @helion.kernel
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+
+            def clamp_and_scale(a):
+                clamped = torch.clamp(a, min=0.0)
+                return clamped * 2.0
+
+            for tile in hl.tile(x.size(0)):
+                out[tile] = clamp_and_scale(x[tile])
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        code, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, torch.clamp(x, min=0.0) * 2.0)
+
+    def test_nested_def_multi_args(self):
+        @helion.kernel
+        def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+
+            def weighted_add(a, b):
+                return a * 0.7 + b * 0.3
+
+            for tile in hl.tile(x.size(0)):
+                out[tile] = weighted_add(x[tile], y[tile])
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        y = torch.randn(128, device=DEVICE)
+        code, result = code_and_output(fn, (x, y))
+        torch.testing.assert_close(result, x * 0.7 + y * 0.3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -668,6 +668,101 @@ class TestErrors(RefEagerTestDisabled, TestCase):
         with self.assertRaises(helion.exc.StatementNotSupported):
             code_and_output(fn, (torch.randn(8, device=DEVICE),))
 
+    def test_nested_function_return_in_control_flow(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def f(a):
+                if a.sum() > 0:
+                    return a * 2.0
+                return a
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = f(x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.StatementNotSupported):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
+
+    def test_nested_function_recursion(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def f(a):
+                return f(a)
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = f(x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.StatementNotSupported):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
+
+    def test_nested_function_call_kwarg_on_positional(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def double(a):
+                return a * 2.0
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = double(a=x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.StatementNotSupported):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
+
+    def test_nested_function_global_nonlocal(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            scale = 2.0
+
+            def f(a):
+                nonlocal scale
+                return a * scale
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = f(x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.StatementNotSupported):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
+
+    def test_nested_function_multi_call_diff_dtype(self):
+        @helion.kernel()
+        def fn(x_int: torch.Tensor, x_float: torch.Tensor):
+            out_int = torch.empty_like(x_int)
+            out_float = torch.empty_like(x_float)
+
+            def double(a):
+                return a * 2
+
+            for tile in hl.tile(x_int.size(0)):
+                out_int[tile] = double(x_int[tile])
+            for tile in hl.tile(x_float.size(0)):
+                out_float[tile] = double(x_float[tile])
+            return out_int, out_float
+
+        x_int = torch.randint(0, 10, (128,), device=DEVICE)
+        x_float = torch.randn(128, device=DEVICE)
+        with self.assertRaises(helion.exc.ControlFlowTensorMismatch):
+            code_and_output(fn, (x_int, x_float))
+
+    def test_nested_function_no_return_in_value_context(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def noop(a):
+                b = a * 2.0  # noqa: F841
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = noop(x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.RequiresTensorInAssignment):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
+
 
 def _make_fake_kernel():
     """Create a minimal fake kernel for autotuner unit tests."""

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -491,8 +491,7 @@ class TestErrors(RefEagerTestDisabled, TestCase):
                 result[i] = x[i] * 2
             return result
 
-        with self.assertRaises(helion.exc.StatementNotSupported):
-            code_and_output(bad_fn, (torch.randn(8, device=DEVICE),))
+        code_and_output(bad_fn, (torch.randn(8, device=DEVICE),))
 
     def test_direct_scalar_tensor_in_device_context(self):
         """Test that direct scalar tensor usage gives clear error in device code."""
@@ -626,6 +625,48 @@ class TestErrors(RefEagerTestDisabled, TestCase):
             r"Device loop is empty after dead-code elimination",
         ):
             code_and_output(empty_kernel, (torch.randn(4, 4, device=DEVICE),))
+
+    def test_nested_function_varargs(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def foo(*args):
+                return args[0]
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = foo(x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.StatementNotSupported):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
+
+    def test_nested_function_kwargs(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def foo(**kwargs):
+                return kwargs["a"]
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = foo(a=x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.StatementNotSupported):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
+
+    def test_nested_function_defaults(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def foo(a, b=1.0):
+                return a + b
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = foo(x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.StatementNotSupported):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
 
 
 def _make_fake_kernel():

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -668,6 +668,34 @@ class TestErrors(RefEagerTestDisabled, TestCase):
         with self.assertRaises(helion.exc.StatementNotSupported):
             code_and_output(fn, (torch.randn(8, device=DEVICE),))
 
+    def test_nested_function_posonly_arg(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def foo(a, /, b):
+                return a + b
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = foo(x[tile], x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.StatementNotSupported):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
+
+    def test_nested_function_kwonly_arg(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            def foo(a, *, b):
+                return a + b
+
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = foo(x[tile], b=x[tile])
+            return out
+
+        with self.assertRaises(helion.exc.StatementNotSupported):
+            code_and_output(fn, (torch.randn(8, device=DEVICE),))
+
     def test_nested_function_return_in_control_flow(self):
         @helion.kernel()
         def fn(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
### Summary

- Adds support for nested function definitions by inlining them at call sites during compilation. Nested functions can capture variables from the enclosing scope. 
- Rejects `*args`, `**kwargs` and default arguments with clear errors.

### Things to consider:

- `return` statements inside control flow (`if`/`for`) within the nested function are not yet supported.
- only positional arguments are supported.

### Tests:
- `test_nested_def_simple`: basic nested function
- `test_nested_def_closure`: captures kernel parameter from enclosing scope
- `test_nested_def_multi_stmt`: multi-statement function body
- `test_nested_def_multi_args`: multiple positional parameters
- `test_nested_function_varargs`: rejects `*args`
- `test_nested_function_kwargs`: rejects `**kwargs`
- `test_nested_function_defaults`: rejects default arguments