### PR TITLE
FlyDSL: minimal elementwise-only backend

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -390,6 +390,16 @@ class Backend(abc.ABC):
         """
         return requested
 
+    def reduction_block_size_is_inlined_constexpr(self) -> bool:
+        """Whether the reduction-loop block size is inlined as a module-level
+        literal instead of a constexpr kernel param.
+
+        FlyDSL's scf.for step must be a value produced inside the loop, not an
+        external constexpr param, so it inlines the block size as a literal.
+        Other backends return False and use a constexpr kernel param.
+        """
+        return False
+
     def create_synthetic_reduction_lanes(
         self,
         thread_count: int,
@@ -835,6 +845,26 @@ class Backend(abc.ABC):
             self.cast_expr("{x}", self.dtype_str(target_dtype)),
             x=x,
         )
+
+    def cast_scalar_ast(self, x: ast.AST, target_dtype: torch.dtype) -> ast.AST:
+        """Cast a plain scalar (e.g. a bare number lifted from an index expr) to
+        ``target_dtype``.
+
+        Defaults to ``cast_ast``. Backends that write casts as ``value.to(dtype)``
+        must override this, because a bare number has no ``.to()`` method --
+        FlyDSL, for example, uses ``fx.Float16(5)`` instead.
+        """
+        return self.cast_ast(x, target_dtype)
+
+    def expands_broadcast_dims(self) -> bool:
+        """Whether the backend needs Triton-style ``[None, :]`` broadcast-expand
+        of sub-rank tensors.
+
+        Tile-level backends (Triton, etc.) broadcast-expand a sub-rank operand up
+        to the output rank. Backends whose per-thread vectors carry the tile/row
+        axis implicitly (e.g. FlyDSL) return False to skip the expansion.
+        """
+        return True
 
     @property
     @abc.abstractmethod

--- a/helion/_compiler/backend_registry.py
+++ b/helion/_compiler/backend_registry.py
@@ -16,6 +16,7 @@ from .backend import MetalBackend
 from .backend import PallasBackend
 from .backend import TileIRBackend
 from .backend import TritonBackend
+from .flydsl.backend import FlyDSLBackend
 
 if TYPE_CHECKING:
     from .backend import Backend
@@ -26,6 +27,7 @@ _BUILTIN_BACKENDS: list[type[Backend]] = [
     CuteBackend,
     TileIRBackend,
     MetalBackend,
+    FlyDSLBackend,
 ]
 
 _REGISTRY: dict[str, type[Backend]] = {}

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -407,6 +407,10 @@ class DeviceFunction:
             tuple[str, tuple[str, ...], tuple[ast.stmt, ...], bool]
         ] = []
         self.triton_outlined_helper_constexprs: dict[str, int] = {}
+        # FlyDSL: (tensor_name, is_vec, is_rolled_col) → loop-invariant buffer/
+        # div/copy-atom setup, memoized per generated function so load and store
+        # reuse the same lifted AST vars.
+        self._flydsl_setup: dict[tuple[object, ...], dict[str, int | str]] = {}
         # Pallas: id(fake_tensor) → [DimensionTiling], recorded during `plan_tiling`
         self.pallas_tensor_dim_tilings: dict[int, list[DimensionTiling]] = {}
         # Track Pallas remote-copy operands by tensor and storage identity. The

--- a/helion/_compiler/flydsl/__init__.py
+++ b/helion/_compiler/flydsl/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/helion/_compiler/flydsl/_codegen_modules.py
+++ b/helion/_compiler/flydsl/_codegen_modules.py
@@ -1,0 +1,12 @@
+"""FlyDSL-backend codegen module registry.
+
+Importing this module imports every FlyDSL-backend codegen module, so their
+``@_decorators.codegen(op, "flydsl")`` handlers register onto the op objects
+they extend.
+"""
+
+from __future__ import annotations
+
+from . import memory_ops  # noqa: F401
+from . import tracing_ops  # noqa: F401
+from . import view_ops  # noqa: F401

--- a/helion/_compiler/flydsl/backend.py
+++ b/helion/_compiler/flydsl/backend.py
@@ -1,0 +1,552 @@
+"""FlyDSLBackend backend class, moved out of the backend-neutral
+helion/_compiler/backend.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import ClassVar
+from typing import Sequence
+
+import torch
+
+from ... import exc
+from ..ast_extension import expr_from_string
+from ..backend import Backend
+
+if TYPE_CHECKING:
+    import ast
+
+    from torch._inductor.ops_handler import OpsHandler
+
+    from ...runtime.config import Config
+    from ...runtime.kernel import BoundKernel
+    from ..device_ir import GraphInfo
+    from ..tile_dispatch import TileStrategyDispatch
+
+    InductorOpOverrides = OpsHandler[Any]
+
+
+class FlyDSLBackend(Backend):
+    """FlyDSL (ROCm) code generation backend."""
+
+    _DTYPE_MAP: ClassVar[dict[torch.dtype, str]] = {
+        torch.float16: "fx.Float16",
+        torch.bfloat16: "fx.BFloat16",
+        torch.float32: "fx.Float32",
+        torch.float64: "fx.Float64",
+        torch.int32: "fx.Int32",
+        torch.int64: "fx.Int64",
+        torch.bool: "fx.Bool",
+    }
+
+    _ACC_TYPE: ClassVar[dict[torch.dtype, str]] = {
+        torch.float16: "fx.Float32",
+        torch.bfloat16: "fx.Float32",
+        torch.float32: "fx.Float32",
+        torch.float64: "fx.Float64",
+        torch.int32: "fx.Int32",
+        torch.int64: "fx.Int64",
+        torch.bool: "fx.Int32",
+    }
+
+    _SUPPORTED_CONFIG_KEYS: frozenset[str] = frozenset(
+        {
+            "block_sizes",
+            "num_warps",
+            "num_threads",
+            "reduction_loops",
+        }
+    )
+
+    @property
+    def name(self) -> str:
+        return "flydsl"
+
+    @property
+    def experimental(self) -> bool:
+        return True
+
+    def validate_environment(self) -> None:
+        try:
+            import flydsl  # noqa: F401  # pyrefly: ignore[missing-import]
+        except ImportError as e:
+            raise exc.BackendUnsupported(
+                self.name,
+                "flydsl is not installed; install it with: pip install flydsl",
+            ) from e
+
+    def dtype_str(self, dtype: torch.dtype) -> str:
+        if dtype not in self._DTYPE_MAP:
+            raise exc.BackendUnsupported(self.name, f"dtype: {dtype}")
+        return self._DTYPE_MAP[dtype]
+
+    def acc_type(self, dtype: torch.dtype) -> str:
+        if dtype not in self._ACC_TYPE:
+            raise exc.BackendUnsupported(self.name, f"acc_type for: {dtype}")
+        return self._ACC_TYPE[dtype]
+
+    @property
+    def function_decorator(self) -> str:
+        n_threads = getattr(self, "_flydsl_num_threads", 64)
+        return f"flyc.kernel(known_block_size=[{n_threads}, 1, 1])"
+
+    @property
+    def constexpr_type(self) -> str:
+        return "fx.Constexpr"
+
+    @property
+    def default_launcher_name(self) -> str:
+        return "_default_flydsl_launcher"
+
+    def max_reduction_threads(self) -> int | None:
+        return 64
+
+    def max_reduction_loop(self) -> int | None:
+        return 64
+
+    @property
+    def library_imports(self) -> dict[str, str]:
+        return {
+            "torch": "import torch",
+            "flyc": "import flydsl.compiler as flyc",
+            "fx": "import flydsl.expr as fx",
+            "fmath": "from flydsl.expr import math as fmath",
+            "arith": "from flydsl.expr import arith",
+            "rocdl": "from flydsl.expr import rocdl",
+            "gpu": "from flydsl.expr import gpu",
+            "full": "from flydsl.expr.vector import full",
+            "helion": "import helion",
+            "hl": "import helion.language as hl",
+            "_default_flydsl_launcher": (
+                "from helion.runtime import default_flydsl_launcher"
+                " as _default_flydsl_launcher"
+            ),
+        }
+
+    def program_id_expr(self, dim: int, *, index_dtype: str) -> str:
+        return f"fx.block_idx.{'xyz'[dim]}"
+
+    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+        # Elementwise: block = 64*bm (bm warps, one warp per row).
+        # AMD caps a workgroup at 1024 threads.
+        bs = config.block_sizes
+        bm = int(bs[0])
+        n_threads = 64 * bm
+        if n_threads > 1024:
+            raise exc.BackendUnsupported(
+                self.name, f"block too large: {n_threads} threads"
+            )
+        return [f"_num_threads={n_threads}"]
+
+    def cast_expr(self, expr_str: str, dtype_str: str) -> str:
+        return f"{expr_str}.to({dtype_str})"
+
+    def cast_scalar_ast(self, x: ast.AST, target_dtype: torch.dtype) -> ast.AST:
+        # A bare scalar has no ``.to``; use the fx dtype constructor instead.
+        # Only index_expr scalars route here, never Vector casts.
+        return expr_from_string(f"{self.dtype_str(target_dtype)}({{x}})", x=x)
+
+    def expands_broadcast_dims(self) -> bool:
+        # FlyDSL per-thread vectors carry the tile/row axis implicitly, so a
+        # Triton-style [None, :] broadcast-expand is both unsupported and
+        # unnecessary -- skip it.
+        return False
+
+    def reduction_block_size_is_inlined_constexpr(self) -> bool:
+        return True
+
+    def inline_constexpr(self, name: str, value: str) -> str:
+        return f"{name} = {value}"
+
+    def supports_config_key(self, key: str) -> bool:
+        return key in self._SUPPORTED_CONFIG_KEYS
+
+    def supports_precompile(self) -> bool:
+        return False
+
+    def adjust_block_size_constraints(
+        self,
+        block_specs: list[object],
+        ndim: int,
+        block_sizes: list[object] | None = None,
+        kernel_tensor_sizes: dict[tuple[object, ...], int] | None = None,
+        min_element_bits: int = 32,
+    ) -> None:
+        # Warp-per-row: row tile -> warps, column tile -> lanes. Cap bm at 16
+        # (64*bm <= 1024 AMD max). Pin the column block to 256 (64 lanes x
+        # vec_width 4); bn>256 drops columns, bn<256 underfills the warp.
+        from ...autotuner.config_spec import BlockSizeSpec
+
+        specs = [s for s in block_specs if isinstance(s, BlockSizeSpec)]
+        if not specs:
+            return
+        specs[0].update_max(16)
+        if ndim >= 2:
+            # Pin ALL column dims (1..ndim-1) to [256, 2048]. Kernels with
+            # multiple inner hl.tile(n) loops otherwise default some dims to 16,
+            # which OOBs in the lane-index formula.
+            for col in specs[1:]:
+                col.update_min(256)
+                col.update_max(
+                    2048
+                )  # allow bn = W*256 for W in {1,2,4,8}; autotune restricts
+
+    def autotune(
+        self,
+        bound_kernel: BoundKernel[Any],
+        args: Sequence[object],
+        *,
+        force: bool = True,
+        **kwargs: object,
+    ) -> Config:
+        # Sole free knob is bm (rows/block = warps); columns are pinned to 256
+        # and bm capped at 16. FlyDSL has no precompile, so enumerate the few
+        # valid configs and FiniteSearch them in-process.
+        from ...runtime.config import Config
+
+        spec = bound_kernel.config_spec
+        default = spec.default_config()
+        default_bs = default.config.get("block_sizes")
+        if not isinstance(default_bs, list) or not default_bs:
+            return default
+        block_sizes = [int(b) for b in default_bs]
+
+        row_hint = spec.block_sizes[0].size_hint if spec.block_sizes else 1
+        candidates: list[Config] = []
+        seen: set[tuple[int, ...]] = set()
+        for bm in (1, 2, 4, 8, 16):
+            if bm > max(row_hint, 1):
+                continue
+            bs = list(block_sizes)
+            bs[0] = bm
+            key = tuple(bs)
+            if key in seen:
+                continue
+            seen.add(key)
+            candidates.append(Config(block_sizes=list(bs)))
+
+        if not candidates:
+            return default
+        if len(candidates) == 1:
+            return candidates[0]
+
+        # Benchmark in-process: FlyDSL's JIT/HIP-stream state does not survive
+        # the precompile/benchmark subprocess workers, so disable both paths.
+        bound_kernel.settings.autotune_precompile = None
+        bound_kernel.settings.autotune_benchmark_subprocess = False
+
+        from ...autotuner import FiniteSearch
+
+        return FiniteSearch(bound_kernel, args, candidates).autotune()
+
+    def pre_codegen(
+        self,
+        graphs: list[GraphInfo],
+        config: Config,
+        tile_strategy: TileStrategyDispatch,
+    ) -> None:
+        from ...language import memory_ops
+
+        _BITS: dict[torch.dtype, int] = {
+            torch.float16: 16,
+            torch.bfloat16: 16,
+            torch.float32: 32,
+            torch.float64: 64,
+            torch.int32: 32,
+            torch.int64: 64,
+        }
+
+        # Reset per-compilation state so helpers are re-emitted on each compile.
+        self._flydsl_helpers_emitted = False
+        # Elementwise regime: block_sizes = [bm] (or [bm, 256]) -> bm rows/block,
+        # one warp (64 lanes) per row, block = 64*bm threads.
+        bs = getattr(config, "block_sizes", None) or [1]
+        bm = int(bs[0]) if bs else 1
+
+        self._flydsl_bm = bm
+        self._flydsl_num_threads = 64 * bm
+
+        self._tensor_use_buffer: dict[int, bool] = {}
+        self._tensor_vec_width: dict[int, int] = {}
+
+        for graph_info in graphs:
+            for node in graph_info.graph.nodes:
+                if node.op != "call_function":
+                    continue
+                if node.target not in (memory_ops.load, memory_ops.store):
+                    continue
+
+                tensor_node = node.args[0]
+                if not isinstance(tensor_node, torch.fx.Node):
+                    continue
+                tensor = tensor_node.meta.get("val")
+                if not isinstance(tensor, torch.Tensor):
+                    continue
+
+                tid = id(tensor)
+                self._tensor_use_buffer[tid] = True  # always vectorized buffer path
+                bits = _BITS.get(tensor.dtype, 32)
+                self._tensor_vec_width[tid] = 128 // bits
+
+    def grid_index_expr(
+        self, offset_var: str, block_size_var: str, dtype: str, *, axis: int
+    ) -> str:
+        # Row (grid) tile -> warps: warp w = thread_idx.x // 64 owns its row.
+        # Always dim x (flat block), regardless of the axis Helion assigns.
+        if block_size_var == "1":
+            return offset_var
+        return f"({offset_var}) + fx.thread_idx.x // 64"
+
+    def loop_index_expr(
+        self, offset_var: str, block_size_var: str, dtype: str, *, axis: int
+    ) -> str:
+        # Column (loop) tile -> lanes. chunk = col_offset//vec + lane_id;
+        # one warp (64 lanes) per row so lane_id = thread_idx.x % 64.
+        if block_size_var == "1":
+            return offset_var
+        return f"({offset_var}) // 4 + fx.thread_idx.x % 64"
+
+    def arange_expr(
+        self,
+        offsets_var: str,
+        lid: str,
+        block_size_var: str,
+        dtype: str,
+        *,
+        axis: int = 0,
+    ) -> str:
+        # Column lane chunk: element_offset//vec + lane_id (one warp/row).
+        return f"{offsets_var} = ({lid}) // 4 + fx.thread_idx.x % 64"
+
+    def thread_in_tile_mask_expr(
+        self, block_size_var: str, *, axis: int = 0
+    ) -> str | None:
+        # Lane mask (flat block, dim x): one warp (64 lanes) per row.
+        return f"fx.thread_idx.x % 64 < ({block_size_var})"
+
+    def lane_index_expr(
+        self, offset_var: str, elements_per_thread: int, *, axis: int
+    ) -> str:
+        dim = "xyz"[axis]
+        return f"fx.thread_idx.{dim} * {elements_per_thread} + fx.Int32({offset_var})"
+
+    def lane_offset_expr(self, lane_var: str) -> str:
+        return f"fx.Int32({lane_var})"
+
+    def scalar_load_expr(self, tensor_name: str, index_expr: str | None = None) -> str:
+        if index_expr is None:
+            return f"{tensor_name}[0]"
+        return f"{tensor_name}[{index_expr}]"
+
+    def reduction_index_expr(
+        self, block_size_var: str, dtype: str, block_idx: int, *, axis: int
+    ) -> str:
+        # Lane index for the column (``:``) mapping: one warp per row -> lane =
+        # thread_idx.x % 64.
+        return "fx.thread_idx.x % 64"
+
+    def reduction_index_zero_expr(self, dtype: str) -> str:
+        return "fx.Int32(0)"
+
+    def inductor_op_overrides(self) -> InductorOpOverrides:
+        from torch._inductor.codegen.triton import TritonOverrides
+
+        backend_name = self.name
+        fly_dtype_str = self.dtype_str
+
+        class FlyDSLOpOverrides(TritonOverrides):
+            @staticmethod
+            def constant(value: object, dtype: torch.dtype) -> str:
+                import math as _math
+
+                if isinstance(value, float) and _math.isinf(value):
+                    v = "float('inf')" if value > 0 else "float('-inf')"
+                elif isinstance(value, float) and _math.isnan(value):
+                    v = "float('nan')"
+                else:
+                    v = repr(value)
+                # flydsl scalar constants use the fx dtype constructor, not
+                # Triton's tl.full(...).
+                return f"{fly_dtype_str(dtype)}({v})"
+
+            @staticmethod
+            def exp(x: str) -> str:
+                return f"fmath.exp({x})"
+
+            @staticmethod
+            def exp2(x: str) -> str:
+                return f"fmath.exp2({x})"
+
+            @staticmethod
+            def expm1(x: str) -> str:
+                return f"fmath.expm1({x})"
+
+            @staticmethod
+            def log(x: str) -> str:
+                return f"fmath.log({x})"
+
+            @staticmethod
+            def log2(x: str) -> str:
+                return f"fmath.log2({x})"
+
+            @staticmethod
+            def log10(x: str) -> str:
+                return f"fmath.log10({x})"
+
+            @staticmethod
+            def log1p(x: str) -> str:
+                return f"fmath.log1p({x})"
+
+            @staticmethod
+            def sqrt(x: str) -> str:
+                return f"fmath.sqrt({x})"
+
+            @staticmethod
+            def rsqrt(x: str) -> str:
+                return f"fmath.rsqrt({x})"
+
+            @staticmethod
+            def cbrt(x: str) -> str:
+                return f"fmath.cbrt({x})"
+
+            @staticmethod
+            def abs(x: str) -> str:
+                return f"fmath.absf({x})"
+
+            @staticmethod
+            def sin(x: str) -> str:
+                return f"fmath.sin({x})"
+
+            @staticmethod
+            def cos(x: str) -> str:
+                return f"fmath.cos({x})"
+
+            @staticmethod
+            def tan(x: str) -> str:
+                return f"fmath.tan({x})"
+
+            @staticmethod
+            def asin(x: str) -> str:
+                return f"fmath.asin({x})"
+
+            @staticmethod
+            def acos(x: str) -> str:
+                return f"fmath.acos({x})"
+
+            @staticmethod
+            def atan(x: str) -> str:
+                return f"fmath.atan({x})"
+
+            @staticmethod
+            def atan2(x: str, y: str) -> str:
+                return f"fmath.atan2({x}, {y})"
+
+            @staticmethod
+            def sinh(x: str) -> str:
+                return f"fmath.sinh({x})"
+
+            @staticmethod
+            def cosh(x: str) -> str:
+                return f"fmath.cosh({x})"
+
+            @staticmethod
+            def tanh(x: str) -> str:
+                return f"fmath.tanh({x})"
+
+            @staticmethod
+            def asinh(x: str) -> str:
+                return f"fmath.asinh({x})"
+
+            @staticmethod
+            def acosh(x: str) -> str:
+                return f"fmath.acosh({x})"
+
+            @staticmethod
+            def atanh(x: str) -> str:
+                return f"fmath.atanh({x})"
+
+            @staticmethod
+            def erf(x: str) -> str:
+                return f"fmath.erf({x})"
+
+            @staticmethod
+            def erfc(x: str) -> str:
+                return f"fmath.erfc({x})"
+
+            @staticmethod
+            def sigmoid(x: str) -> str:
+                # fmath has no sigmoid; express it via exp.
+                return f"(1.0 / (1.0 + fmath.exp(-({x}))))"
+
+            @staticmethod
+            def floor(x: str) -> str:
+                return f"fmath.floor({x})"
+
+            @staticmethod
+            def ceil(x: str) -> str:
+                return f"fmath.ceil({x})"
+
+            @staticmethod
+            def trunc(x: str) -> str:
+                return f"fmath.trunc({x})"
+
+            @staticmethod
+            def round(x: str) -> str:
+                return f"fmath.round({x})"
+
+            @staticmethod
+            def copysign(x: str, y: str) -> str:
+                return f"fmath.copysign({x}, {y})"
+
+            @staticmethod
+            def isnan(x: str) -> str:
+                return f"fmath.isnan({x})"
+
+            @staticmethod
+            def isinf(x: str) -> str:
+                return f"fmath.isinf({x})"
+
+            @staticmethod
+            def maximum(a: str, b: str) -> str:
+                return f"({a}).maximumf({b})"
+
+            @staticmethod
+            def minimum(a: str, b: str) -> str:
+                # flydsl Vector has no ``.minimumf``; min(a,b) = -max(-a,-b).
+                return f"(-((-({a})).maximumf((-({b})))))"
+
+            @staticmethod
+            def where(a: str, b: str, c: str) -> str:
+                return f"({a}).select({b}, {c})"
+
+            def __getattr__(self, name: str) -> object:
+                # Any un-overridden op would fall through to Triton syntax
+                # (tl.libdevice.*) and fail at trace time. Fail loudly instead.
+                if name.startswith("_"):
+                    raise AttributeError(name)
+                raise exc.BackendUnsupported(backend_name, f"op {name!r}")
+
+        return FlyDSLOpOverrides()
+
+    def reshape_expr(self, expr: str, shape: str) -> str:
+        return expr
+
+    def broadcast_to_expr(self, expr: str, shape: str) -> str:
+        return expr
+
+    def zeros_expr(self, shape: str, dtype: str) -> str:
+        return f"{dtype}(0)"
+
+    def full_expr(
+        self, shape_dims: list[str], value_expr: str, dtype: torch.dtype
+    ) -> str:
+        dtype_str = self.dtype_str(dtype)
+        return f"{dtype_str}({value_expr})"
+
+    def where_expr(self, mask: str, true_val: str, false_val: str) -> str:
+        return f"({mask}).select({true_val}, {false_val})"
+
+    def minimum_expr(self, a: str, b: str) -> str:
+        # flydsl Vector has no ``.minimumf``; min(a,b) = -max(-a,-b).
+        return f"(-((-({a})).maximumf((-({b})))))"

--- a/helion/_compiler/flydsl/backend.py
+++ b/helion/_compiler/flydsl/backend.py
@@ -27,6 +27,11 @@ if TYPE_CHECKING:
     InductorOpOverrides = OpsHandler[Any]
 
 
+def _flydsl_minimum_expr(a: str, b: str) -> str:
+    # flydsl Vector has no ``.minimumf``; min(a,b) = -max(-a,-b).
+    return f"(-((-({a})).maximumf((-({b})))))"
+
+
 class FlyDSLBackend(Backend):
     """FlyDSL (ROCm) code generation backend."""
 
@@ -59,6 +64,13 @@ class FlyDSLBackend(Backend):
         }
     )
 
+    def __init__(self) -> None:
+        super().__init__()
+        # Set per-compile by pre_codegen; initialized here so function_decorator
+        # and the memory-op codegen can read them directly without defaults.
+        self._flydsl_num_threads: int = 64
+        self._tensor_use_buffer: dict[int, bool] = {}
+
     @property
     def name(self) -> str:
         return "flydsl"
@@ -88,7 +100,7 @@ class FlyDSLBackend(Backend):
 
     @property
     def function_decorator(self) -> str:
-        n_threads = getattr(self, "_flydsl_num_threads", 64)
+        n_threads = self._flydsl_num_threads
         return f"flyc.kernel(known_block_size=[{n_threads}, 1, 1])"
 
     @property
@@ -233,6 +245,7 @@ class FlyDSLBackend(Backend):
 
         # Benchmark in-process: FlyDSL's JIT/HIP-stream state does not survive
         # the precompile/benchmark subprocess workers, so disable both paths.
+        # In-place mutation of per-bind settings mirrors the base autotune().
         bound_kernel.settings.autotune_precompile = None
         bound_kernel.settings.autotune_benchmark_subprocess = False
 
@@ -248,28 +261,14 @@ class FlyDSLBackend(Backend):
     ) -> None:
         from ...language import memory_ops
 
-        _BITS: dict[torch.dtype, int] = {
-            torch.float16: 16,
-            torch.bfloat16: 16,
-            torch.float32: 32,
-            torch.float64: 64,
-            torch.int32: 32,
-            torch.int64: 64,
-        }
-
-        # Reset per-compilation state so helpers are re-emitted on each compile.
-        self._flydsl_helpers_emitted = False
         # Elementwise regime: block_sizes = [bm] (or [bm, 256]) -> bm rows/block,
         # one warp (64 lanes) per row, block = 64*bm threads.
-        bs = getattr(config, "block_sizes", None) or [1]
-        bm = int(bs[0]) if bs else 1
-
-        self._flydsl_bm = bm
+        bs = config.block_sizes or [1]
+        bm = int(bs[0])
         self._flydsl_num_threads = 64 * bm
 
-        self._tensor_use_buffer: dict[int, bool] = {}
-        self._tensor_vec_width: dict[int, int] = {}
-
+        # Reset per-compile; every load/store tensor takes the vectorized buffer path.
+        self._tensor_use_buffer = {}
         for graph_info in graphs:
             for node in graph_info.graph.nodes:
                 if node.op != "call_function":
@@ -284,10 +283,7 @@ class FlyDSLBackend(Backend):
                 if not isinstance(tensor, torch.Tensor):
                     continue
 
-                tid = id(tensor)
-                self._tensor_use_buffer[tid] = True  # always vectorized buffer path
-                bits = _BITS.get(tensor.dtype, 32)
-                self._tensor_vec_width[tid] = 128 // bits
+                self._tensor_use_buffer[id(tensor)] = True
 
     def grid_index_expr(
         self, offset_var: str, block_size_var: str, dtype: str, *, axis: int
@@ -513,8 +509,7 @@ class FlyDSLBackend(Backend):
 
             @staticmethod
             def minimum(a: str, b: str) -> str:
-                # flydsl Vector has no ``.minimumf``; min(a,b) = -max(-a,-b).
-                return f"(-((-({a})).maximumf((-({b})))))"
+                return _flydsl_minimum_expr(a, b)
 
             @staticmethod
             def where(a: str, b: str, c: str) -> str:
@@ -548,5 +543,4 @@ class FlyDSLBackend(Backend):
         return f"({mask}).select({true_val}, {false_val})"
 
     def minimum_expr(self, a: str, b: str) -> str:
-        # flydsl Vector has no ``.minimumf``; min(a,b) = -max(-a,-b).
-        return f"(-((-({a})).maximumf((-({b})))))"
+        return _flydsl_minimum_expr(a, b)

--- a/helion/_compiler/flydsl/backend.py
+++ b/helion/_compiler/flydsl/backend.py
@@ -283,6 +283,10 @@ class FlyDSLBackend(Backend):
                 if not isinstance(tensor, torch.Tensor):
                     continue
 
+                # Invariant: codegen looks this up by id(state.proxy_arg(0)),
+                # which must be the SAME FakeTensor object as node.meta["val"]
+                # here. If that ever breaks, the lookup misses and the load/store
+                # silently takes the scalar path (wrong indexing, not an error).
                 self._tensor_use_buffer[id(tensor)] = True
 
     def grid_index_expr(
@@ -299,6 +303,8 @@ class FlyDSLBackend(Backend):
     ) -> str:
         # Column (loop) tile -> lanes. chunk = col_offset//vec + lane_id;
         # one warp (64 lanes) per row so lane_id = thread_idx.x % 64.
+        # The literal 4 is the fp16 vec width; fp32 columns would need the width
+        # derived from element bits (see _flydsl_buffer_setup). fp16-only for now.
         if block_size_var == "1":
             return offset_var
         return f"({offset_var}) // 4 + fx.thread_idx.x % 64"
@@ -313,6 +319,8 @@ class FlyDSLBackend(Backend):
         axis: int = 0,
     ) -> str:
         # Column lane chunk: element_offset//vec + lane_id (one warp/row).
+        # The literal 4 is the fp16 vec width (fp16-only; fp32 needs the derived
+        # width, see _flydsl_buffer_setup).
         return f"{offsets_var} = ({lid}) // 4 + fx.thread_idx.x % 64"
 
     def thread_in_tile_mask_expr(

--- a/helion/_compiler/flydsl/memory_ops.py
+++ b/helion/_compiler/flydsl/memory_ops.py
@@ -1,0 +1,580 @@
+"""FlyDSL-backend codegen for ops defined in ``helion.language.memory_ops``.
+
+Backend-specific codegen bodies live here (not in the backend-neutral language
+module).  Importing this module runs the ``@_decorators.codegen(op, "flydsl")``
+registrations; ``_codegen_modules`` imports it so registration keeps the same
+eager timing as before.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from ... import exc
+from ...language import _decorators
+from ...language.memory_ops import load
+from ...language.memory_ops import store
+from ..ast_extension import expr_from_string
+from ..ast_extension import statement_from_string
+
+if TYPE_CHECKING:
+    import ast
+
+    from ..compile_environment import CompileEnvironment
+    from ..inductor_lowering import CodegenState
+
+
+def _flydsl_rolled_col_block(
+    env: CompileEnvironment,
+    state: CodegenState,
+    tensor: torch.Tensor,
+    subscript: list[object] | tuple[object, ...],
+) -> int | None:
+    """Block id of the rolled column loop a ``:`` slice iterates over.
+
+    A whole-column ``:`` (e.g. ``x[tile_m, :]``) is wider than one wavefront (64
+    threads), so Helion rolls it into a runtime loop over 64-wide chunks. Map the
+    ``:`` to that loop's block id so the column is indexed by the loop element
+    (``roffset + lane``, one element/thread, correct for any N) rather than a bare
+    ``thread_idx.x`` that only covers the first 64 lanes.
+    """
+    loop_blocks = [
+        bs.block_id
+        for bs in env.block_sizes
+        if bs.reduction and state.codegen.active_device_loops.get(bs.block_id)
+    ]
+    if not loop_blocks:
+        return None
+
+    for ax, idx in enumerate(subscript):
+        if isinstance(idx, slice) and idx == slice(None):
+            try:
+                ax_hint = env.size_hint(tensor.size(ax))
+            except Exception:
+                continue
+            for bid in loop_blocks:
+                if env.block_sizes[bid].size_hint() == ax_hint:
+                    return bid
+    return None
+
+
+_FLYDSL_COPY_CLS = {
+    8: "BufferCopy8b",
+    16: "BufferCopy16b",
+    32: "BufferCopy32b",
+    64: "BufferCopy64b",
+    128: "BufferCopy128b",
+}
+
+
+def _flydsl_copy_cls(bits: int) -> str:
+    """BufferCopy class for a ``bits``-wide transaction, else BackendUnsupported.
+
+    A single BufferCopy tops out at 128 bits (e.g. fp32 V=8 = 256b is not
+    representable); reject it cleanly instead of a raw KeyError.
+    """
+    cls = _FLYDSL_COPY_CLS.get(bits)
+    if cls is None:
+        raise exc.BackendUnsupported(
+            "flydsl", f"vector copy width {bits} bits (max 128; reduce vec width V)"
+        )
+    return cls
+
+
+def _flydsl_col_tail_pred(
+    state: CodegenState, offset_var: str, vec: int, n_expr: str, lane_mod: int = 64
+) -> str:
+    """Per-element column predicate that masks the rolled column-loop tail."""
+
+    _elems = ", ".join(str(j) for j in range(vec))
+    iota = f"fx.Vector.from_elements([{_elems}], fx.Int32)"
+    col_base = f"({offset_var} + (fx.thread_idx.x % {lane_mod}) * {vec})"
+    return f"(({col_base}) + {iota}) < ({n_expr})"
+
+
+def _flydsl_buffer_setup(
+    env: CompileEnvironment,
+    state: CodegenState,
+    tensor: torch.Tensor,
+    tensor_name: str,
+    subscript: list[object] | tuple[object, ...],
+) -> dict:
+    """Build the cached buffer/div/copy-atom setup shared by load and store.
+
+    The loop-invariant prologue both need: find row/column block ids, detect a
+    rolled ``:`` loop, derive the per-thread vec width and (for a tail) the mask
+    predicate, then build the buffer/logical_divide/copy_atom trio (memoized per
+    ``(tensor, is_vec, is_rolled_col)``). Only tail handling differs by caller.
+    """
+    row_block_id = 0
+    col_block_id = None
+    seen_row = False
+    if tensor.ndim == 1:
+        # A 1-D tensor (e.g. weight[tile_n]) is indexed along its column and
+        # broadcasts across rows, so its sole block id is the column, not the
+        # row -- route it through the vectorized path like the 2-D operands.
+        for idx in subscript:
+            if isinstance(idx, torch.SymInt):
+                bid = env.get_block_id(idx)
+                if bid is not None:
+                    col_block_id = bid
+                    break
+    else:
+        for idx in subscript:
+            if isinstance(idx, torch.SymInt):
+                bid = env.get_block_id(idx)
+                if bid is not None:
+                    if not seen_row:
+                        row_block_id = bid
+                        seen_row = True
+                    else:
+                        col_block_id = bid
+                        break
+
+    # Rolled column ``:``: a whole-column slice rolled into a loop over 64-wide
+    # chunks. Only when no explicit tile-n block id was found in the subscript.
+    is_rolled_col = False
+    if col_block_id is None:
+        _rc = _flydsl_rolled_col_block(env, state, tensor, subscript)
+        if _rc is not None:
+            col_block_id = _rc
+            is_rolled_col = True
+    # Per-thread vec width for a rolled loop = chunk / threads (V contiguous
+    # elems/thread), read from the loop strategy. rolled_col_offset is the loop's
+    # element offset; the chunk index is ``offset // V + lane``.
+    rolled_col_vec = 1
+    rolled_col_offset: str | None = None
+    _tc = 0
+    _lb = 0
+    if is_rolled_col:
+        assert col_block_id is not None
+        _rs = state.device_function.tile_strategy.block_id_to_strategy.get(
+            (col_block_id,)
+        )
+        _tc = getattr(_rs, "_thread_count", 0) or 0
+        _lb = getattr(_rs, "_loop_block_size", 0) or 0
+
+        if _rs is not None and _tc > 0 and _lb >= _tc:
+            rolled_col_vec = max(1, _lb // _tc)
+            rolled_col_offset = _rs.offset_var(col_block_id)
+    # Column tail: when N is not a multiple of the chunk (64*V), the last pass
+    # runs past column N. Build a per-element predicate to drop those columns.
+    rolled_col_pred: str | None = None
+    if is_rolled_col and rolled_col_offset is not None:
+        assert col_block_id is not None
+        _numel = env.block_sizes[col_block_id].numel
+        if not env.known_multiple(_numel, _lb):
+            rolled_col_pred = _flydsl_col_tail_pred(
+                state,
+                rolled_col_offset,
+                rolled_col_vec,
+                state.sympy_expr(_numel),
+                lane_mod=_tc if _tc > 0 else 64,
+            )
+    # Scalar path (col_block_id None): thread t loads column t, M must equal 64.
+    # Vectorized path (not None): 4 elems/thread, 256/tile. Separate div/atom per
+    # (tensor, mode) so both paths can coexist for the same tensor.
+    is_vec = col_block_id is not None
+
+    device_fn = state.device_function
+    if not hasattr(device_fn, "_flydsl_setup"):
+        device_fn._flydsl_setup = {}  # pyrefly: ignore[missing-attribute]
+
+    setup_key = (tensor_name, is_vec, is_rolled_col)
+    setup = device_fn._flydsl_setup.get(setup_key)  # pyrefly: ignore[missing-attribute]
+    if setup is None:
+        _hoist = None
+        # A rolled ``:`` column that fits in one wavefront (N <= 64) has a loop
+        # that is never emitted, so its outer_prefix is dead and hoisting setup
+        # there drops it. Keep _hoist None so setup emits inline in the live body.
+        _degenerate_rolled_col = is_rolled_col and rolled_col_offset is None
+        if (
+            col_block_id is not None
+            and not _degenerate_rolled_col
+            and state.codegen.active_device_loops[col_block_id]
+        ):
+            _loop = state.codegen.active_device_loops[col_block_id][-1]
+            _hoist = _loop.outer_prefix  # pyrefly: ignore[missing-attribute]
+        # Under a runtime scf.for the loop body is lifted into its own function,
+        # so setup emitted inside it is invisible to a sibling body (NameError).
+        # Redirect these lifts to the loop's outer_prefix (enclosing scope) so
+        # both bodies can close over them; a no-op (None) otherwise.
+        with state.codegen.set_statements(_hoist):
+            bid_expr = state.codegen.index_var(
+                row_block_id
+            )  # pid*bm + warp_id (warp-per-row)
+            buf = state.codegen.lift(
+                expr_from_string(
+                    f"fx.rocdl.make_buffer_tensor({tensor_name})",
+                ),
+                prefix="flydsl_buf",
+                dce=True,
+            )
+            if tensor.ndim == 1:
+                # 1-D load: the whole rank-1 buffer is the vector, no row to
+                # slice. Slicing a rank-1 memref with a 2-tuple fails flydsl's
+                # profile check.
+                row = buf
+            else:
+                row = state.codegen.lift(
+                    expr_from_string(
+                        f"fx.slice({buf.id}, ({bid_expr}, None))",
+                    ),
+                    prefix="flydsl_row",
+                    dce=True,
+                )
+            if is_vec:
+                # Vectorized path tiles 256 columns/warp across 64 threads = 4
+                # elems/thread (design invariant). Not 8: that would leave half
+                # the warp idle and give wrong fp16 results.
+                vec_width = rolled_col_vec if is_rolled_col else 4
+            else:
+                # Scalar path: vec_width = col // 64 threads (1/2/4).
+                # M=64 -> 1x32b, M=128 -> 2x64b, M>=256 -> 4x128b.
+                _col = tensor.shape[-1]
+                vec_width = max(1, min(4, _col // 64))
+                if vec_width == 3:
+                    vec_width = 2
+            # Copy width = vec_width * element bits (dtype-aware), NOT vec_width *
+            # 32 -- the latter pairs a 128-bit copy with a 64-bit fp16 register
+            # (invalid ``bitcast i128 -> vector<4xf16>``).
+            _elem_bits = tensor.element_size() * 8
+            _bits = vec_width * _elem_bits
+
+            _copy_cls = _flydsl_copy_cls(_bits)
+            div = state.codegen.lift(
+                expr_from_string(
+                    f"fx.logical_divide({row.id}, fx.make_layout({vec_width}, 1))",
+                ),
+                prefix="flydsl_div",
+                dce=True,
+            )
+            atom = state.codegen.lift(
+                expr_from_string(f"fx.make_copy_atom(fx.rocdl.{_copy_cls}(), {_bits})"),
+                prefix="flydsl_atom",
+                dce=True,
+            )
+
+        setup = {"div": div.id, "atom": atom.id, "vec": vec_width, "row": row.id}
+        device_fn._flydsl_setup[setup_key] = setup  # pyrefly: ignore[missing-attribute]
+
+    return {
+        "setup": setup,
+        "col_block_id": col_block_id,
+        "is_vec": is_vec,
+        "is_rolled_col": is_rolled_col,
+        "rolled_col_offset": rolled_col_offset,
+        "rolled_col_vec": rolled_col_vec,
+        "rolled_col_pred": rolled_col_pred,
+        "tc": _tc,
+        "lb": _lb,
+    }
+
+
+@_decorators.codegen(store, "flydsl")
+def _(state: CodegenState) -> None:
+    from ..compile_environment import CompileEnvironment
+    from ..compile_environment import _symint_sympy_expr
+
+    tensor = state.proxy_arg(0)
+    subscript = state.proxy_arg(1)
+    value = state.ast_arg(2)
+    assert isinstance(tensor, torch.Tensor)
+    assert isinstance(subscript, (list, tuple))
+
+    env = CompileEnvironment.current()
+    backend = env.backend
+    tensor_name = state.device_function.tensor_arg(tensor).name
+    use_buffer = getattr(backend, "_tensor_use_buffer", {}).get(id(tensor), False)
+
+    if use_buffer:
+        _info = _flydsl_buffer_setup(env, state, tensor, tensor_name, subscript)
+        setup = _info["setup"]
+        col_block_id = _info["col_block_id"]
+        is_vec = _info["is_vec"]
+        is_rolled_col = _info["is_rolled_col"]
+        rolled_col_offset = _info["rolled_col_offset"]
+        rolled_col_pred = _info["rolled_col_pred"]
+        _tc = _info["tc"]
+
+        dtype_str = backend.dtype_str(tensor.dtype)
+        vec_width = setup["vec"]
+        r_var = f"_r_{tensor_name}_s"
+        state.add_statement(
+            statement_from_string(
+                f"{r_var} = fx.make_rmem_tensor({vec_width}, {dtype_str})"
+            )
+        )
+        state.add_statement(
+            statement_from_string(
+                f"fx.memref_store_vec({{value}}, {r_var})", value=value
+            )
+        )
+
+        if is_rolled_col and rolled_col_offset is not None:
+            # V contiguous elems/thread at chunk index ``offset // V + lane``.
+            # Lane spans the column loop's thread_count (= 64*W waves/row), not 64.
+            _lane_mod = _tc if _tc > 0 else 64
+            chunk_idx_s = (
+                f"({rolled_col_offset}) // {vec_width} + fx.thread_idx.x % {_lane_mod}"
+            )
+        elif is_vec:
+            chunk_idx_s = state.codegen.index_var(col_block_id)
+        else:
+            chunk_idx_s = "fx.thread_idx.x"
+
+        _atom_name = setup["atom"]
+        _div_name = setup["div"]
+        # Store vs load are ASYMMETRIC in the tail: a STORE always uses guarded
+        # per-element scalar stores (``if col < N``), never a wide write into the
+        # tail, so it can't touch the next row or memory past the tensor -- no
+        # page-fault guard needed. A LOAD instead issues a wide read and masks
+        # after (faster for the common small tail), so it needs the extra
+        # ``_rolled_col_large_oob`` guard for reads that cross an unmapped page.
+        #
+        # Explicit hl.tile(n) tail: N not a multiple of the per-pass span (4*64)
+        # -> the last chunk's high lanes address past column N.
+        _expl_tail = (
+            is_vec
+            and not is_rolled_col
+            and not env.known_multiple(
+                env.block_sizes[col_block_id].numel,
+                4 * 64,
+            )
+        )
+        if rolled_col_pred is not None:
+            # Rolled tail: the wide BufferCopy can't be predicated per element,
+            # so emit one guarded scalar store per element. Element j is column
+            # ``offset + lane*V + j``; store only when in range.
+            _n_expr = state.sympy_expr(env.block_sizes[col_block_id].numel)
+            _row = setup["row"]
+            _lane_mod = _tc if _tc > 0 else 64
+            for _j in range(vec_width):
+                _colj = (
+                    f"{rolled_col_offset} + (fx.thread_idx.x % {_lane_mod}) "
+                    f"* {vec_width} + {_j}"
+                )
+                state.add_statement(
+                    statement_from_string(
+                        f"if ({_colj}) < ({_n_expr}):\n"
+                        f"    fx.memref_store(fx.memref_load({r_var}, {_j}), {_row}, {_colj})"
+                    )
+                )
+        elif _expl_tail:
+            # Explicit-tile tail: guarded scalar stores. Element j is column
+            # ``chunk_idx * V + j``; store only when in range.
+            _n_expr = state.sympy_expr(env.block_sizes[col_block_id].numel)
+            _row = setup["row"]
+            for _j in range(vec_width):
+                _colj = f"(({chunk_idx_s}) * {vec_width}) + {_j}"
+                state.add_statement(
+                    statement_from_string(
+                        f"if ({_colj}) < ({_n_expr}):\n"
+                        f"    fx.memref_store(fx.memref_load({r_var}, {_j}), {_row}, {_colj})"
+                    )
+                )
+        else:
+            state.add_statement(
+                statement_from_string(
+                    f"fx.copy_atom_call({_atom_name}, {r_var}, fx.slice({_div_name}, (None, {chunk_idx_s})))"
+                )
+            )
+        return None
+    # simple element-wise store
+    parts = []
+    for idx in subscript:
+        if idx is None:
+            continue
+        if isinstance(idx, slice) and idx == slice(None):
+            parts.append("fx.thread_idx.x")
+        elif isinstance(idx, torch.SymInt):
+            bid = env.get_block_id(idx)
+            if bid is not None:
+                parts.append(state.codegen.index_var(bid))
+            else:
+                parts.append(state.sympy_expr(_symint_sympy_expr(idx)))
+        elif isinstance(idx, int):
+            parts.append(str(idx))
+    idx_str = ", ".join(parts)
+    state.add_statement(
+        statement_from_string(f"{tensor_name}[{idx_str}] = {{value}}", value=value)
+    )
+    return None
+
+
+@_decorators.codegen(load, "flydsl")
+def _(state: CodegenState) -> ast.AST:
+    from ..compile_environment import CompileEnvironment
+    from ..compile_environment import _symint_sympy_expr
+
+    tensor = state.proxy_arg(0)
+    subscript = state.proxy_arg(1)
+    assert isinstance(tensor, torch.Tensor)
+    assert isinstance(subscript, (list, tuple))
+
+    env = CompileEnvironment.current()
+    backend = env.backend
+    tensor_name = state.device_function.tensor_arg(tensor).name
+    use_buffer = getattr(backend, "_tensor_use_buffer", {}).get(id(tensor), False)
+
+    if use_buffer:
+        # buffer tensor path for both x[tile_n,:] and x[tile_m,tile_n].
+        _info = _flydsl_buffer_setup(env, state, tensor, tensor_name, subscript)
+        setup = _info["setup"]
+        col_block_id = _info["col_block_id"]
+        is_vec = _info["is_vec"]
+        is_rolled_col = _info["is_rolled_col"]
+        rolled_col_offset = _info["rolled_col_offset"]
+        rolled_col_pred = _info["rolled_col_pred"]
+        _tc = _info["tc"]
+        _lb = _info["lb"]
+
+        dtype_str = backend.dtype_str(tensor.dtype)
+        vec_width = setup["vec"]
+        r_var = f"_r_{tensor_name}"
+
+        if is_rolled_col and rolled_col_offset is not None:
+            # V contiguous elems/thread at chunk index ``offset // V + lane``.
+            # Lane spans the column loop's thread_count (= 64*W waves/row), not 64.
+            _lane_mod = _tc if _tc > 0 else 64
+            chunk_idx = (
+                f"({rolled_col_offset}) // {vec_width} + fx.thread_idx.x % {_lane_mod}"
+            )
+        elif is_vec:
+            chunk_idx = state.codegen.index_var(col_block_id)
+        else:
+            chunk_idx = "fx.thread_idx.x"
+
+        # Explicit hl.tile(n) tail: N not a multiple of the per-pass span (4*64)
+        # -> the last chunk's high lanes would read past column N. The AMD buffer
+        # descriptor should return 0 for OOB reads but in practice still page-
+        # faults once the byte address crosses the tensor's allocation. Use
+        # guarded scalar loads so no access goes past the last valid column.
+        _expl_tail = (
+            is_vec
+            and not is_rolled_col
+            and not env.known_multiple(
+                env.block_sizes[col_block_id].numel,
+                4 * 64,
+            )
+        )
+
+        state.add_statement(
+            statement_from_string(
+                f"{r_var} = fx.make_rmem_tensor({vec_width}, {dtype_str})"
+            )
+        )
+        _atom_name = setup["atom"]
+        _div_name = setup["div"]
+        _row = setup["row"]
+
+        if _expl_tail:
+            # Explicit-tile tail: guarded scalar loads to avoid reading past the
+            # allocation. Element j is column ``chunk_idx * V + j``; load when in
+            # range, else write the zero identity into r_var.
+            _n_expr = state.sympy_expr(env.block_sizes[col_block_id].numel)
+            _zero = f"{dtype_str}(0)"
+            for _j in range(vec_width):
+                _colj = f"(({chunk_idx}) * {vec_width}) + {_j}"
+                state.add_statement(
+                    statement_from_string(
+                        f"if ({_colj}) < ({_n_expr}):\n"
+                        f"    fx.memref_store(fx.memref_load({_row}, {_colj}), {r_var}, {_j})\n"
+                        f"else:\n"
+                        f"    fx.memref_store({_zero}, {r_var}, {_j})"
+                    )
+                )
+            return expr_from_string(f"fx.memref_load_vec({r_var})")
+
+        # Rolled tail with large OOB: when the wide read overshoots N by more than
+        # AMD's buffer-descriptor slack (~512 bytes), copy_atom_call page-faults
+        # even though the predicate would zero the result after. Fall back to
+        # guarded scalar loads. (No store counterpart: store never reads/writes
+        # the tail wide.) OOB distance = chunk//V + thread_count - 1 - numel//V.
+        _rolled_col_large_oob = False
+        if (
+            is_rolled_col
+            and rolled_col_pred is not None
+            and _tc > 0
+            and _lb > 0
+            and vec_width > 0
+        ):
+            import contextlib as _cl
+
+            _numel_int: int | None = None
+            _numel_sym = env.block_sizes[col_block_id].numel
+            with _cl.suppress(TypeError, ValueError):
+                _numel_int = int(_numel_sym)
+            if _numel_int is not None:
+                _chunk_idx_max = _lb // vec_width + _tc - 1
+                _div_layout_size = (_numel_int + vec_width - 1) // vec_width
+                _oob_elems = _chunk_idx_max - _div_layout_size
+                # Compare in BYTES against ROCm's allocator rounding slack (512).
+                # The descriptor returns 0 for OOB reads within mapped pages but
+                # faults once the address crosses an unmapped page. Bytes (not
+                # elements) makes the threshold dtype-agnostic: fp16 256, fp32
+                # 128, int64 64.
+                _elem_bytes = tensor.element_size()
+                _SAFE_OOB_BYTES = 512
+                if _oob_elems * _elem_bytes > _SAFE_OOB_BYTES:
+                    _rolled_col_large_oob = True
+
+        if _rolled_col_large_oob:
+            # Guarded scalar loads: element j is column
+            # rolled_col_offset + lane*V + j (same as _colj in the store).
+            _n_expr_rl = state.sympy_expr(env.block_sizes[col_block_id].numel)
+            _lane_mod_rl = _tc if _tc > 0 else 64
+            _zero_rl = f"{dtype_str}(0)"
+            for _j in range(vec_width):
+                _colj_rl = (
+                    f"({rolled_col_offset}) + (fx.thread_idx.x % {_lane_mod_rl}) "
+                    f"* {vec_width} + {_j}"
+                )
+                state.add_statement(
+                    statement_from_string(
+                        f"if ({_colj_rl}) < ({_n_expr_rl}):\n"
+                        f"    fx.memref_store(fx.memref_load({_row}, {_colj_rl}), {r_var}, {_j})\n"
+                        f"else:\n"
+                        f"    fx.memref_store({_zero_rl}, {r_var}, {_j})"
+                    )
+                )
+            return expr_from_string(f"fx.memref_load_vec({r_var})")
+
+        state.add_statement(
+            statement_from_string(
+                f"fx.copy_atom_call({_atom_name}, fx.slice({_div_name}, (None, {chunk_idx})), {r_var})"
+            )
+        )
+
+        if rolled_col_pred is not None:
+            # Zero out-of-range tail columns so masked lanes contribute the
+            # identity (0). Use a shape-only zero (``filled_like(_lv, 0)``) NOT
+            # ``_lv - _lv``: a garbage tail read can be nan, and nan-nan is nan,
+            # which ``.select`` would keep.
+            _lv = f"_lv_{r_var}"
+            state.add_statement(
+                statement_from_string(f"{_lv} = fx.memref_load_vec({r_var})")
+            )
+            return expr_from_string(
+                f"({rolled_col_pred}).select({_lv}, fx.Vector.filled_like({_lv}, 0))"
+            )
+        return expr_from_string(f"fx.memref_load_vec({r_var})")
+
+    # simple element-wise path: x[tile_m, tile_n]
+    parts = []
+    for idx in subscript:
+        if idx is None:
+            continue
+        if isinstance(idx, slice) and idx == slice(None):
+            parts.append("fx.thread_idx.x")
+        elif isinstance(idx, torch.SymInt):
+            bid = env.get_block_id(idx)
+            if bid is not None:
+                parts.append(state.codegen.index_var(bid))
+            else:
+                parts.append(state.sympy_expr(_symint_sympy_expr(idx)))
+        elif isinstance(idx, int):
+            parts.append(str(idx))
+    return expr_from_string(f"{tensor_name}[{', '.join(parts)}]")

--- a/helion/_compiler/flydsl/memory_ops.py
+++ b/helion/_compiler/flydsl/memory_ops.py
@@ -182,11 +182,8 @@ def _flydsl_buffer_setup(
     is_vec = col_block_id is not None
 
     device_fn = state.device_function
-    if not hasattr(device_fn, "_flydsl_setup"):
-        device_fn._flydsl_setup = {}  # pyrefly: ignore[missing-attribute]
-
     setup_key = (tensor_name, is_vec, is_rolled_col)
-    setup = device_fn._flydsl_setup.get(setup_key)  # pyrefly: ignore[missing-attribute]
+    setup = device_fn._flydsl_setup.get(setup_key)
     if setup is None:
         _hoist = None
         # A rolled ``:`` column that fits in one wavefront (N <= 64) has a loop
@@ -261,7 +258,7 @@ def _flydsl_buffer_setup(
             )
 
         setup = {"div": div.id, "atom": atom.id, "vec": vec_width, "row": row.id}
-        device_fn._flydsl_setup[setup_key] = setup  # pyrefly: ignore[missing-attribute]
+        device_fn._flydsl_setup[setup_key] = setup
 
     return {
         "setup": setup,

--- a/helion/_compiler/flydsl/memory_ops.py
+++ b/helion/_compiler/flydsl/memory_ops.py
@@ -9,6 +9,7 @@ eager timing as before.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import cast
 
 import torch
 
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 
     from ..compile_environment import CompileEnvironment
     from ..inductor_lowering import CodegenState
+    from .backend import FlyDSLBackend
 
 
 def _flydsl_rolled_col_block(
@@ -50,10 +52,7 @@ def _flydsl_rolled_col_block(
 
     for ax, idx in enumerate(subscript):
         if isinstance(idx, slice) and idx == slice(None):
-            try:
-                ax_hint = env.size_hint(tensor.size(ax))
-            except Exception:
-                continue
+            ax_hint = env.size_hint(tensor.size(ax))
             for bid in loop_blocks:
                 if env.block_sizes[bid].size_hint() == ax_hint:
                     return bid
@@ -149,16 +148,20 @@ def _flydsl_buffer_setup(
     _tc = 0
     _lb = 0
     if is_rolled_col:
+        from ..reduction_strategy import LoopedReductionStrategy
+
         assert col_block_id is not None
         _rs = state.device_function.tile_strategy.block_id_to_strategy.get(
             (col_block_id,)
         )
-        _tc = getattr(_rs, "_thread_count", 0) or 0
-        _lb = getattr(_rs, "_loop_block_size", 0) or 0
-
-        if _rs is not None and _tc > 0 and _lb >= _tc:
-            rolled_col_vec = max(1, _lb // _tc)
-            rolled_col_offset = _rs.offset_var(col_block_id)
+        # A rolled ``:`` column resolves to a LoopedReductionStrategy, the only
+        # strategy carrying _thread_count / _loop_block_size.
+        if isinstance(_rs, LoopedReductionStrategy):
+            _tc = _rs._thread_count
+            _lb = _rs._loop_block_size
+            if _tc > 0 and _lb >= _tc:
+                rolled_col_vec = max(1, _lb // _tc)
+                rolled_col_offset = _rs.offset_var(col_block_id)
     # Column tail: when N is not a multiple of the chunk (64*V), the last pass
     # runs past column N. Build a per-element predicate to drop those columns.
     rolled_col_pred: str | None = None
@@ -285,9 +288,9 @@ def _(state: CodegenState) -> None:
     assert isinstance(subscript, (list, tuple))
 
     env = CompileEnvironment.current()
-    backend = env.backend
+    backend = cast("FlyDSLBackend", env.backend)
     tensor_name = state.device_function.tensor_arg(tensor).name
-    use_buffer = getattr(backend, "_tensor_use_buffer", {}).get(id(tensor), False)
+    use_buffer = backend._tensor_use_buffer.get(id(tensor), False)
 
     if use_buffer:
         _info = _flydsl_buffer_setup(env, state, tensor, tensor_name, subscript)
@@ -415,9 +418,9 @@ def _(state: CodegenState) -> ast.AST:
     assert isinstance(subscript, (list, tuple))
 
     env = CompileEnvironment.current()
-    backend = env.backend
+    backend = cast("FlyDSLBackend", env.backend)
     tensor_name = state.device_function.tensor_arg(tensor).name
-    use_buffer = getattr(backend, "_tensor_use_buffer", {}).get(id(tensor), False)
+    use_buffer = backend._tensor_use_buffer.get(id(tensor), False)
 
     if use_buffer:
         # buffer tensor path for both x[tile_n,:] and x[tile_m,tile_n].

--- a/helion/_compiler/flydsl/tracing_ops.py
+++ b/helion/_compiler/flydsl/tracing_ops.py
@@ -1,0 +1,114 @@
+"""FlyDSL-backend codegen for ops defined in ``helion.language._tracing_ops``.
+
+Backend-specific codegen bodies live here (not in the backend-neutral language
+module).  Importing this module runs the ``@_decorators.codegen(op, "flydsl")``
+registrations; ``_codegen_modules`` imports it so registration keeps the same
+eager timing as before.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from torch._inductor.codegen.simd import constant_repr
+
+from ...language import _decorators
+from ...language._tracing_ops import _mask_to
+from ..ast_extension import expr_from_string
+from ..ast_extension import statement_from_string
+from ..compile_environment import CompileEnvironment
+
+if TYPE_CHECKING:
+    import ast
+
+    from ..inductor_lowering import CodegenState
+
+
+@_decorators.codegen(_mask_to, "flydsl")
+def _(state: CodegenState) -> ast.AST:
+    tensor = state.proxy_arg(0)
+    assert isinstance(tensor, torch.Tensor)
+    other = state.proxy_arg(1)
+    assert isinstance(other, (int, float, bool))
+
+    from .memory_ops import _flydsl_col_tail_pred
+
+    env = CompileEnvironment.current()
+    df = state.device_function
+    # Bind the value to a var so mask/select can reference it several times.
+    # ``expr`` is a per-thread vector (length V).
+    e_var = df.new_var("_maskin", dce=True)
+    state.add_statement(
+        statement_from_string(f"{e_var} = {{expr}}", expr=state.ast_arg(0))
+    )
+
+    # Build a per-element bool VECTOR mask matching ``expr``. The vectorized
+    # column dim (V=4 elems/thread, the last dim with a block id) needs a
+    # per-element predicate; row dims broadcast one scalar mask across the vector.
+    _col_index = None
+    for size in tensor.size():
+        _bi = env.resolve_block_id(size)
+        if _bi is not None:
+            _col_index = _bi
+
+    mask_terms: list[str] = []
+    for size in tensor.size():
+        index = env.resolve_block_id(size)
+        if index is None:
+            continue
+        strategy = df.tile_strategy.block_id_to_strategy.get((index,))
+        _tc = getattr(strategy, "_thread_count", 0) or 0
+        _lb = getattr(strategy, "_loop_block_size", 0) or 0
+        mask_var = state.codegen.mask_var(index)
+        if (
+            env.block_sizes[index].reduction
+            and strategy is not None
+            and _tc > 0
+            and _lb >= _tc
+            and not env.known_multiple(env.block_sizes[index].numel, _lb)
+        ):
+            _v = max(1, _lb // _tc)
+            _pred = _flydsl_col_tail_pred(
+                state,
+                strategy.offset_var(index),
+                _v,
+                state.sympy_expr(env.block_sizes[index].numel),
+                lane_mod=_tc,
+            )
+            mask_terms.append(_pred)
+        elif index == _col_index and _tc == 0 and mask_var is not None:
+            # Explicit ``hl.tile(n)`` reduction column: vectorized V=4
+            # elems/thread, element j at column ``index_var*4 + j``. The scalar
+            # ``mask_var`` is only correct at V=1, so build a per-element pred.
+            _ci = state.codegen.index_var(index)
+            _v = 4
+            _elems = ", ".join(str(j) for j in range(_v))
+            _iota = f"fx.Vector.from_elements([{_elems}], fx.Int32)"
+            mask_terms.append(
+                f"((({_ci}) * {_v}) + {_iota}) "
+                f"< ({state.sympy_expr(env.block_sizes[index].numel)})"
+            )
+        elif mask_var is not None:
+            # Broadcast the scalar mask to a bool vector: ``filled`` needs a
+            # constant fill, so AND the scalar into an all-true vector
+            # (``&`` promotes scalar->vector).
+            mask_terms.append(
+                f"(fx.Vector.filled_like({e_var}, True, dtype=fx.Boolean) "
+                f"& ({mask_var}))"
+            )
+
+    if not mask_terms:
+        return expr_from_string(e_var)
+
+    mask_expr = (
+        mask_terms[0]
+        if len(mask_terms) == 1
+        else " & ".join(f"({m})" for m in mask_terms)
+    )
+    dtype_str = env.backend.dtype_str(tensor.dtype)
+    other_typed = f"{dtype_str}({constant_repr(other)})"
+    # Broadcast the fill via a shape-only zero vector (NaN-safe, unlike (e)-(e)).
+    return expr_from_string(
+        f"({mask_expr}).select({e_var}, (fx.Vector.filled_like({e_var}, 0) + ({other_typed})))"
+    )

--- a/helion/_compiler/flydsl/tracing_ops.py
+++ b/helion/_compiler/flydsl/tracing_ops.py
@@ -32,6 +32,7 @@ def _(state: CodegenState) -> ast.AST:
     other = state.proxy_arg(1)
     assert isinstance(other, (int, float, bool))
 
+    from ..reduction_strategy import LoopedReductionStrategy
     from .memory_ops import _flydsl_col_tail_pred
 
     env = CompileEnvironment.current()
@@ -58,12 +59,18 @@ def _(state: CodegenState) -> ast.AST:
         if index is None:
             continue
         strategy = df.tile_strategy.block_id_to_strategy.get((index,))
-        _tc = getattr(strategy, "_thread_count", 0) or 0
-        _lb = getattr(strategy, "_loop_block_size", 0) or 0
+        # Only a LoopedReductionStrategy (the rolled ``:`` column) carries
+        # _thread_count / _loop_block_size; other dims leave _tc/_lb at 0.
+        _tc = 0
+        _lb = 0
+        looped = strategy if isinstance(strategy, LoopedReductionStrategy) else None
+        if looped is not None:
+            _tc = looped._thread_count
+            _lb = looped._loop_block_size
         mask_var = state.codegen.mask_var(index)
         if (
-            env.block_sizes[index].reduction
-            and strategy is not None
+            looped is not None
+            and env.block_sizes[index].reduction
             and _tc > 0
             and _lb >= _tc
             and not env.known_multiple(env.block_sizes[index].numel, _lb)
@@ -71,7 +78,7 @@ def _(state: CodegenState) -> ast.AST:
             _v = max(1, _lb // _tc)
             _pred = _flydsl_col_tail_pred(
                 state,
-                strategy.offset_var(index),
+                looped.offset_var(index),
                 _v,
                 state.sympy_expr(env.block_sizes[index].numel),
                 lane_mod=_tc,

--- a/helion/_compiler/flydsl/view_ops.py
+++ b/helion/_compiler/flydsl/view_ops.py
@@ -1,0 +1,25 @@
+"""FlyDSL-backend codegen for ops defined in ``helion.language.view_ops``.
+
+Backend-specific codegen bodies live here (not in the backend-neutral language
+module).  Importing this module runs the ``@_decorators.codegen(op, "flydsl")``
+registrations; ``_codegen_modules`` imports it so registration keeps the same
+eager timing as before.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...language import _decorators
+from ...language.view_ops import subscript
+
+if TYPE_CHECKING:
+    import ast
+
+    from ..inductor_lowering import CodegenState
+
+
+@_decorators.codegen(subscript, "flydsl")
+def _(state: CodegenState) -> ast.AST:
+    # FlyDSL per-thread scalars: shape-only subscripts like [:, None] are no-ops.
+    return state.ast_arg(0)

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -394,7 +394,13 @@ class InductorLowering(Lowering):
             if isinstance(fake_val := n.meta["val"], torch.Tensor):
                 # Don't expand scalars (0-D tensors) - let Triton handle broadcasting naturally
                 # Expanding scalars with [None, None] creates incorrect broadcast shapes
-                if fake_val.ndim < ndim and fake_val.ndim > 0:
+                # The expands_broadcast_dims() check lets FlyDSL skip the
+                # Triton-style [None, :] expand its per-thread vectors don't need.
+                if (
+                    fake_val.ndim < ndim
+                    and fake_val.ndim > 0
+                    and CompileEnvironment.current().backend.expands_broadcast_dims()
+                ):
                     expand = tile_strategy.broadcast_expand_dims(
                         tuple(fake_val.shape), output_shape
                     )
@@ -1100,6 +1106,13 @@ class GenerateASTFromInductor(DefaultHandler):
         backend = CompileEnvironment.current().backend
         return backend.cast_ast(x, target_dtype)
 
+    def _cast_scalar_ast(self, x: ast.AST, target_dtype: torch.dtype) -> ast.AST:
+        # Cast a bare scalar (e.g. lifted from an index expr). Backends whose
+        # cast syntax needs a runtime object override cast_scalar_ast; the base
+        # default uses cast_ast.
+        backend = CompileEnvironment.current().backend
+        return backend.cast_scalar_ast(x, target_dtype)
+
     def _to_ast(self, x: object) -> ast.AST:
         if isinstance(x, ast.AST):
             return x
@@ -1308,7 +1321,7 @@ class GenerateASTFromInductor(DefaultHandler):
         if name in self.cg.device_function._constexpr_args:
             return name
 
-        return self._lift(self._create_cast_expr(expr_from_string(name), dtype))
+        return self._lift(self._cast_scalar_ast(expr_from_string(name), dtype))
 
 
 def _unpack_opsvalue(value: object) -> str:

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -1623,6 +1623,20 @@ class LoopedReductionStrategy(ReductionStrategy):
         )
         return result_var
 
+    def _register_block_size_constexpr(
+        self, state: CodegenState, block_size_var: str
+    ) -> None:
+        # Register the loop block size as a constexpr kernel param, defined host-side.
+        if CompileEnvironment.current().backend.reduction_block_size_is_inlined_constexpr():
+            # FlyDSL's scf.for step must be a value inside the loop, not an
+            # external constexpr param, so inline the block size as a literal.
+            state.device_function.constexpr_arg(block_size_var, self._loop_block_size)
+            return
+        if state.device_function.constexpr_arg(block_size_var):
+            state.codegen.host_statements.append(
+                statement_from_string(f"{block_size_var} = {self._loop_block_size!r}")
+            )
+
     def codegen_device_loop(self, state: CodegenState) -> DeviceLoopState:
         env = CompileEnvironment.current()
         self._maybe_apply_cute_rolled_cluster(state)
@@ -1632,10 +1646,7 @@ class LoopedReductionStrategy(ReductionStrategy):
         index_var = self.index_var(block_index)
         block_size_var = self.block_size_var(block_index)
         assert block_size_var is not None
-        if state.device_function.constexpr_arg(block_size_var):
-            state.codegen.host_statements.append(
-                statement_from_string(f"{block_size_var} = {self._loop_block_size!r}")
-            )
+        self._register_block_size_constexpr(state, block_size_var)
         inner_body: list[ast.AST] = [
             statement_from_string(
                 f"{index_var} = {offset_var} + {self._index_init_expr(f'({block_size_var})', env.index_type(), block_index)}"

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -171,3 +171,92 @@ def default_metal_launcher(
     total_threads = (gx * bx, gy * by, gz * bz)
     group_size = (bx, by, bz)
     dispatch_fn(*tensor_args, threads=total_threads, group_size=group_size)
+
+
+_flydsl_jit_cache: dict = {}
+_flydsl_compiled_cache: dict = {}  # cache_key -> flyc.CompiledFunction
+_flydsl_stream: object = None  # one persistent HIP stream, reused across launches
+
+
+def default_flydsl_launcher(
+    flydsl_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    _num_threads: int = 64,
+    **kwargs: object,
+) -> None:
+    """Default launcher for FlyDSL kernels on ROCm devices.
+
+    @flyc.kernel can only run inside @flyc.jit, so generate a temp Python file
+    wrapping it in @flyc.jit with explicit fx.Tensor params.
+    """
+    import importlib.util
+    import tempfile
+
+    kwargs.pop("num_warps", None)
+    kwargs.pop("num_stages", None)
+    if kwargs:
+        from .. import exc
+
+        raise exc.BackendUnsupported(
+            "flydsl", f"unexpected launcher kwargs: {sorted(kwargs)}"
+        )
+
+    n = len(args)
+    gx = grid[0] if len(grid) > 0 else 1
+    gy = grid[1] if len(grid) > 1 else 1
+    gz = grid[2] if len(grid) > 2 else 1
+
+    # _num_threads = 64*bm from launcher_keyword_args; default 64 = bm=1.
+    cache_key = (id(flydsl_kernel), n, gx, gy, gz, _num_threads)
+    if cache_key not in _flydsl_jit_cache:
+        params = ", ".join(f"_a{i}: fx.Tensor" for i in range(n))
+        call = ", ".join(f"_a{i}" for i in range(n))
+        src = f"""
+import flydsl.expr as fx
+import flydsl.compiler as flyc
+
+def _make(kernel):
+    @flyc.jit
+    def _launch({params}, _s: fx.Stream):
+        kernel({call}).launch(
+            grid=({gx}, {gy}, {gz}),
+            block=({_num_threads}, 1, 1),
+            stream=_s,
+        )
+    return _launch
+"""
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", mode="w", delete=False, prefix="_flydsl_jit_"
+        ) as tf:
+            tf.write(src)
+            fname = tf.name
+
+        try:
+            spec = importlib.util.spec_from_file_location(
+                f"_flydsl_jit_{abs(hash(cache_key))}", fname
+            )
+            mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+            _flydsl_jit_cache[cache_key] = mod._make(flydsl_kernel)
+        finally:
+            import os as _os
+
+            _os.unlink(fname)
+
+    # Persistent null stream (fx.Stream(None) -> stream 0), reused across launches.
+    global _flydsl_stream
+    if _flydsl_stream is None:
+        import flydsl.expr as _fx  # pyrefly: ignore[missing-import]
+
+        _flydsl_stream = _fx.Stream(None)
+
+    # Cache a directly-callable flyc.CompiledFunction instead of re-entering the
+    # @flyc.jit wrapper on every launch.
+    compiled = _flydsl_compiled_cache.get(cache_key)
+    if compiled is None:
+        import flydsl.compiler as _flyc  # pyrefly: ignore[missing-import]
+
+        compiled = _flyc.compile(_flydsl_jit_cache[cache_key], *args, _flydsl_stream)
+        _flydsl_compiled_cache[cache_key] = compiled
+    compiled(*args, _flydsl_stream)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -173,8 +173,12 @@ def default_metal_launcher(
     dispatch_fn(*tensor_args, threads=total_threads, group_size=group_size)
 
 
+# cache_key -> @flyc.jit-wrapped launcher / flyc.CompiledFunction. Both grow
+# unbounded across distinct (kernel, nargs, grid, threads) keys; acceptable for
+# the experimental backend, but revisit with eviction if a long-lived process
+# autotunes many shapes.
 _flydsl_jit_cache: dict = {}
-_flydsl_compiled_cache: dict = {}  # cache_key -> flyc.CompiledFunction
+_flydsl_compiled_cache: dict = {}
 _flydsl_stream: object = None  # one persistent HIP stream, reused across launches
 
 
@@ -187,11 +191,13 @@ def default_flydsl_launcher(
 ) -> None:
     """Default launcher for FlyDSL kernels on ROCm devices.
 
-    @flyc.kernel can only run inside @flyc.jit, so generate a temp Python file
-    wrapping it in @flyc.jit with explicit fx.Tensor params.
+    @flyc.kernel can only run inside @flyc.jit, so build a launcher wrapping it in
+    @flyc.jit with explicit fx.Tensor params. flyc's ASTRewriter re-parses the
+    wrapper via ``inspect.getsource``, so its source must be retrievable -- we
+    register it in ``linecache`` under a synthetic name rather than writing a temp
+    file (no disk I/O, nothing to leak if the process dies mid-compile).
     """
-    import importlib.util
-    import tempfile
+    import linecache
 
     kwargs.pop("num_warps", None)
     kwargs.pop("num_stages", None)
@@ -208,12 +214,14 @@ def default_flydsl_launcher(
     gz = grid[2] if len(grid) > 2 else 1
 
     # _num_threads = 64*bm from launcher_keyword_args; default 64 = bm=1.
+    # id(flydsl_kernel) is safe as a key component only because the cached closure
+    # (_make(flydsl_kernel)) keeps the kernel object alive, so its id can't be
+    # recycled for a different kernel while the entry lives.
     cache_key = (id(flydsl_kernel), n, gx, gy, gz, _num_threads)
     if cache_key not in _flydsl_jit_cache:
         params = ", ".join(f"_a{i}: fx.Tensor" for i in range(n))
         call = ", ".join(f"_a{i}" for i in range(n))
-        src = f"""
-import flydsl.expr as fx
+        src = f"""import flydsl.expr as fx
 import flydsl.compiler as flyc
 
 def _make(kernel):
@@ -226,23 +234,13 @@ def _make(kernel):
         )
     return _launch
 """
-        with tempfile.NamedTemporaryFile(
-            suffix=".py", mode="w", delete=False, prefix="_flydsl_jit_"
-        ) as tf:
-            tf.write(src)
-            fname = tf.name
-
-        try:
-            spec = importlib.util.spec_from_file_location(
-                f"_flydsl_jit_{abs(hash(cache_key))}", fname
-            )
-            mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
-            spec.loader.exec_module(mod)  # type: ignore[union-attr]
-            _flydsl_jit_cache[cache_key] = mod._make(flydsl_kernel)
-        finally:
-            import os as _os
-
-            _os.unlink(fname)
+        fname = f"<flydsl_jit_{abs(hash(cache_key))}>"
+        # Register the source so inspect.getsource (used by flyc's ASTRewriter)
+        # can retrieve it from the in-memory string.
+        linecache.cache[fname] = (len(src), None, src.splitlines(keepends=True), fname)
+        mod_ns: dict = {}
+        exec(compile(src, fname, "exec"), mod_ns)
+        _flydsl_jit_cache[cache_key] = mod_ns["_make"](flydsl_kernel)
 
     # Persistent null stream (fx.Stream(None) -> stream 0), reused across launches.
     global _flydsl_stream

--- a/test/test_flydsl_elementwise.py
+++ b/test/test_flydsl_elementwise.py
@@ -1,0 +1,90 @@
+"""Unit tests for the flydsl backend's elementwise (non-reduction) path.
+
+Covers the minimal flydsl backend: grid mapping, per-thread vector load/store,
+elementwise math, and column-tail masking -- no whole-row reductions.
+
+flydsl is AMD/ROCm-only and experimental, so the whole module is skipped when
+it is not importable.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+import helion.language as hl
+
+pytest.importorskip("flydsl")
+
+
+@helion.kernel(backend="flydsl")
+def elementwise_double(x: torch.Tensor) -> torch.Tensor:
+    # Pure elementwise map: no reduction (grid mapping + load/store/mul only).
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(x.size(0)):
+        out[tile_m, :] = x[tile_m, :] * 2.0
+    return out
+
+
+@helion.kernel(backend="flydsl")
+def elementwise_min(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    # Elementwise torch.minimum (exercises the minimum op override, which has
+    # no native flydsl Vector method and uses -max(-a,-b)).
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(x.size(0)):
+        out[tile_m, :] = torch.minimum(x[tile_m, :], y[tile_m, :])
+    return out
+
+
+class TestFlydslElementwise(TestCase):
+    def test_elementwise_map_no_reduction(self) -> None:
+        # Non-reduction path: grid mapping + elementwise + load/store, no fold.
+        for bm, dt in ((1, torch.float16), (4, torch.float16), (1, torch.float32)):
+            x = torch.randn(16, 512, device=DEVICE, dtype=dt)
+            _, out = code_and_output(elementwise_double, (x,), block_sizes=[bm])
+            torch.testing.assert_close(out, x * 2.0)
+
+    def test_elementwise_map_column_tail(self) -> None:
+        # Non-reduction path with N not a multiple of the vector width.
+        x = torch.randn(8, 300, device=DEVICE, dtype=torch.float16)
+        _, out = code_and_output(elementwise_double, (x,), block_sizes=[1])
+        torch.testing.assert_close(out, x * 2.0)
+
+    def test_elementwise_single_wavefront_row(self) -> None:
+        # Whole-row ``:`` that fits in one wavefront (N <= 64): the column loop is
+        # degenerate (single pass), so the buffer setup must emit inline in the
+        # live body rather than into the never-emitted loop prefix. Regression for
+        # the N<=64 dangling-reference / empty-launcher-arg codegen bug.
+        for n in (16, 32, 64):
+            for dt in (torch.float16, torch.float32):
+                x = torch.randn(8, n, device=DEVICE, dtype=dt)
+                _, out = code_and_output(elementwise_double, (x,), block_sizes=[1])
+                torch.testing.assert_close(out, x * 2.0)
+
+    def test_elementwise_minimum(self) -> None:
+        # torch.minimum override (no native flydsl min method; -max(-a,-b)).
+        x = torch.randn(8, 512, device=DEVICE, dtype=torch.float16)
+        y = torch.randn(8, 512, device=DEVICE, dtype=torch.float16)
+        _, out = code_and_output(elementwise_min, (x, y), block_sizes=[1])
+        torch.testing.assert_close(out, torch.minimum(x, y))
+
+    def test_autotune_elementwise(self) -> None:
+        # The flydsl autotuner enumerates the bm (rows/block) knob and
+        # FiniteSearch-picks a valid, correct config in-process (no subprocess
+        # benchmark workers, which the flydsl JIT cannot survive).
+        x = torch.randn(64, 512, device=DEVICE, dtype=torch.float16)
+        bk = elementwise_double.bind((x,))
+        cfg = bk.autotune((x,), force=True)
+        self.assertIn("block_sizes", cfg.config)
+        out = bk.compile_config(cfg)(x)
+        torch.testing.assert_close(out, x * 2.0)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/test_flydsl_elementwise.py
+++ b/test/test_flydsl_elementwise.py
@@ -50,6 +50,15 @@ class TestFlydslElementwise(TestCase):
             _, out = code_and_output(elementwise_double, (x,), block_sizes=[bm])
             torch.testing.assert_close(out, x * 2.0)
 
+    def test_generated_code_uses_buffer_ops(self) -> None:
+        # Codegen-only assertion (no kernel run): the elementwise buffer path
+        # must emit flydsl's vectorized load/store ops, not a scalar fallback.
+        x = torch.randn(16, 512, device=DEVICE, dtype=torch.float16)
+        bound = elementwise_double.bind((x,))
+        code = bound.to_triton_code(bound.config_spec.default_config())
+        self.assertIn("make_buffer_tensor", code)
+        self.assertIn("copy_atom_call", code)
+
     def test_elementwise_map_column_tail(self) -> None:
         # Non-reduction path with N not a multiple of the vector width.
         x = torch.randn(8, 300, device=DEVICE, dtype=torch.float16)

--- a/test/test_flydsl_elementwise.py
+++ b/test/test_flydsl_elementwise.py
@@ -16,6 +16,7 @@ import helion
 from helion._testing import DEVICE
 from helion._testing import TestCase
 from helion._testing import code_and_output
+from helion._testing import onlyBackends
 import helion.language as hl
 
 pytest.importorskip("flydsl")
@@ -40,6 +41,7 @@ def elementwise_min(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@onlyBackends(["flydsl"])
 class TestFlydslElementwise(TestCase):
     def test_elementwise_map_no_reduction(self) -> None:
         # Non-reduction path: grid mapping + elementwise + load/store, no fold.


### PR DESCRIPTION
This PR is a first minimal change to add the flyDSL backend to Helion as a self-contained package under helion/_compiler/flydsl/ (mirroring cute/triton/pallas/metal).
This is currently only supporting elementwise kernels; subsequent PRs will add support for reduction kernels and then flash attention. 
The unit tests are added to test elementwise operations and autotuning, however there are no autotuning config knobs as part of this PR, the intent is to only test the autotuning path not to enable autotuning completely.  