### PR TITLE
[CI] Test B200 Triton and TileIR with PyTorch 2.13

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -75,7 +75,7 @@
       "image": "nvidia/cuda:13.1.0-devel-ubuntu24.04",
       "runtime-version": "cu130",
       "container-options": "--gpus all",
-      "pytorch-version": "pytorch-2.11",
+      "pytorch-version": "pytorch-2.13",
       "alias": "b200",
       "backend": "triton"
     },
@@ -86,7 +86,7 @@
       "image": "nvidia/cuda:13.2.0-devel-ubuntu24.04",
       "runtime-version": "cu130",
       "container-options": "--gpus all",
-      "pytorch-version": "pytorch-2.11",
+      "pytorch-version": "pytorch-2.13",
       "alias": "b200",
       "backend": "tileir",
       "triton-repo": "https://github.com/triton-lang/Triton-to-tile-IR.git",


### PR DESCRIPTION
## Summary

Update the B200 Triton and TileIR CI lanes from PyTorch 2.11 to PyTorch 2.13.

This only changes the PyTorch version used to run Helion's existing tests. It does not add runners or change test scope. The B200 CuTe nightly lane and the A10G PyTorch 2.11 compatibility lane are unchanged.

## Why

PyTorch 2.11 is now an intermediate release and does not validate B200 against the current stable PyTorch release. PyTorch 2.13 CUDA 13.0 wheels are available, and Helion's nightly B200 pretuned benchmark already uses PyTorch 2.13.

## Risk

The Triton lane also moves to PyTorch 2.13's bundled Triton. The TileIR lane is the important compatibility check because it replaces bundled Triton with the pinned `Triton-to-tile-IR` fork at `0d9283bf49`.

## Validation

Before merging, require:

- lint and core GitHub checks
- `test-cu130-py3.12-pytorch-2.13-triton-b200`
- `test-cu130-py3.12-pytorch-2.13-tileir-b200`

If TileIR fails, we should fix or repin its toolchain rather than retaining the version bump without coverage.
