### PR TITLE
[AOT] Make disabled mode inert and surface evaluate failures

### DIFF
--- a/docs/deployment_autotuning.md
+++ b/docs/deployment_autotuning.md
@@ -823,6 +823,12 @@ this order:
 If no file is found, the cache falls back to the kernel's default
 config and prints a one-time warning naming the AOT runner.
 
+> **Behavior change — `HELION_AOT_MODE=disabled`:** disabled mode no longer
+> loads checked-in heuristic files. It now bypasses every AOT artifact and uses
+> the kernel's compiler default config without starting a live autotuning
+> search. Use `evaluate` (the default when `HELION_AOT_MODE` is unset) to load a
+> deployed heuristic.
+
 ### Pretuning a kernel for new hardware
 
 A heuristic file is specific to one device kind + compute capability —

--- a/helion/autotuner/aot_cache.py
+++ b/helion/autotuner/aot_cache.py
@@ -278,7 +278,7 @@ class AOTAutotuneCache(AutotuneCacheBase):
     - collect: Tune each shape individually, record results
     - measure: Measure each shape with all observed configs
     - evaluate: Use heuristics to select configs, validate performance
-    - disabled: Fall through to underlying autotuner (default)
+    - disabled: Ignore AOT artifacts and return the compiler default config
 
     When collect_fn/measure_fn are set on the kernel:
     - collect_fn: In collect mode, only these inputs are autotuned
@@ -333,13 +333,14 @@ class AOTAutotuneCache(AutotuneCacheBase):
         if not isinstance(self.args, _MultiShapeAutotuneArgs):
             self.args = self.kernel.kernel.normalize_args(*self.args)
         self.mode = get_aot_mode()
+        self._verbose = is_aot_verbose()
+        if self.mode == "disabled":
+            return
         self.hardware_id = get_hardware_info().hardware_id
         self.data_dir = get_aot_data_dir()
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self._tuned_configs: dict[str, list[TunedConfig]] = self._load_tuned_configs()
         self.shape_key = self._create_shape_key()
-        self._verbose = is_aot_verbose()
-
         # Look up optional collect_fn/measure_fn from the Kernel object
         # These are set by @aot_kernel() decorator
         self._collect_fn = getattr(self.kernel.kernel, "_aot_collect_fn", None)
@@ -535,6 +536,9 @@ class AOTAutotuneCache(AutotuneCacheBase):
 
     def get(self) -> Config | None:
         """Get a cached config based on current mode."""
+        if self.mode == "disabled":
+            return self.autotuner.config_spec.default_config()
+
         if self.mode == "collect":
             # In collect mode, check if we already have a config for this exact shape
             kernel_name = self.kernel.kernel.name
@@ -553,7 +557,7 @@ class AOTAutotuneCache(AutotuneCacheBase):
             # In compile mode: use heuristic + generate standalone Triton code
             self._maybe_run_compile()
 
-        # For disabled/evaluate/compile modes: try heuristic, fall back to default config
+        # For evaluate/compile modes: try heuristic, fall back to default config
         # (never trigger autotuning for aot_kernel)
         config = self._get_heuristic_config(self.args)
         if config is not None:
@@ -1121,6 +1125,9 @@ class AOTAutotuneCache(AutotuneCacheBase):
 
     def autotune(self, *, skip_cache: bool = False) -> Config:
         """Perform autotuning based on current mode."""
+        if self.mode == "disabled":
+            return self.autotuner.config_spec.default_config()
+
         self._maybe_run_input_fn_workflows()
 
         if self.mode == "collect":

--- a/helion/autotuner/aot_runner.py
+++ b/helion/autotuner/aot_runner.py
@@ -398,7 +398,8 @@ def run_evaluate_phase(config: RunConfig) -> bool:
         )
 
         if return_code != 0:
-            log.warning(f"Evaluate benchmark failed with return code {return_code}")
+            log.error(f"Evaluate benchmark failed with return code {return_code}")
+            all_passed = False
 
     # Save evaluation results
     eval_file = config.run_dir / f"evaluation_{config.hardware_id}.json"

--- a/test/test_aot_autotuning.py
+++ b/test/test_aot_autotuning.py
@@ -39,6 +39,8 @@ from helion.autotuner.aot_compile import _standalone_call_key
 from helion.autotuner.aot_compile import generate_standalone_file
 from helion.autotuner.aot_kernel import aot_key
 from helion.autotuner.aot_kernel import extract_shape_features
+import helion.autotuner.aot_runner as aot_runner_module
+from helion.autotuner.aot_runner import RunConfig
 from helion.autotuner.heuristic_generator import PerformanceTarget
 from helion.autotuner.heuristic_generator import ShapeConfigData
 from helion.autotuner.heuristic_generator import compute_validity_partitions
@@ -256,6 +258,72 @@ class TestGetAOTMode:
             pytest.raises(ValueError),
         ):
             get_aot_mode()
+
+
+def test_disabled_mode_uses_default_without_initializing_or_loading_aot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = Config(block_sizes=[16])
+    kernel_api = SimpleNamespace(normalize_args=lambda *args: args)
+    bound_kernel = SimpleNamespace(kernel=kernel_api, is_cacheable=lambda: True)
+    autotuner = SimpleNamespace(
+        kernel=bound_kernel,
+        args=(torch.empty(1),),
+        config_spec=SimpleNamespace(default_config=lambda: expected),
+    )
+    monkeypatch.setenv("HELION_AOT_MODE", "disabled")
+    monkeypatch.setattr(
+        aot_cache_module,
+        "get_hardware_info",
+        lambda: pytest.fail("disabled mode must not inspect hardware"),
+    )
+    monkeypatch.setattr(
+        aot_cache_module,
+        "get_aot_data_dir",
+        lambda: pytest.fail("disabled mode must not inspect AOT storage"),
+    )
+
+    cache: Any = AOTAutotuneCache(autotuner)  # pyrefly: ignore [bad-argument-type]
+    cache._get_heuristic_config = lambda _args: pytest.fail(
+        "disabled mode must not load an AOT heuristic"
+    )
+    cache._maybe_run_input_fn_workflows = lambda: pytest.fail(
+        "disabled mode must not run an AOT workflow"
+    )
+
+    assert cache.get() is expected
+    assert cache.autotune(skip_cache=True) is expected
+
+
+def test_evaluate_benchmark_failure_fails_phase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = RunConfig(["benchmark"], tmp_path, "test-hardware", "run")
+    config.run_dir.mkdir()
+    results = {
+        "demo": {
+            "max_slowdown": 1.0,
+            "geomean_slowdown": 1.0,
+            "avg_slowdown": 1.0,
+        }
+    }
+    monkeypatch.setattr(
+        aot_runner_module,
+        "evaluate_heuristic",
+        lambda **_kwargs: results,
+    )
+    monkeypatch.setattr(
+        aot_runner_module,
+        "run_benchmark",
+        lambda *_args, **_kwargs: (23, "", ""),
+    )
+
+    assert not aot_runner_module.run_evaluate_phase(config)
+    assert (
+        json.loads((config.run_dir / "evaluation_test-hardware.json").read_text())
+        == results
+    )
 
 
 @onlyBackends(["triton", "cute"])


### PR DESCRIPTION
## Closed after scope review

This PR is intentionally no longer part of the grouped-GEMM stack.

It changed the global meaning of `HELION_AOT_MODE=disabled`, but the benchmark
does not require that behavior: compiler mode explicitly installs
`ConfigSpec.default_config()`, live mode uses `LocalAutotuneCache`, and reviewed
AOT remains evaluate-only. The remaining stack preserves the existing global
AOT contract and handles the new grouped kernel locally.

The independent `aot_runner` evaluate-exit propagation bug can be proposed as
a separate focused fix if desired.

The active stack now starts at #3443 and ends at #3447.
