### PR TITLE
[CuTe] Add grouped-GEMM runtime schedulers

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -51,11 +51,13 @@ from .cute_epilogue import find_tcgen05_grouped_tail_epilogue_for_mma
 from .cutedsl_compat import CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION
 from .cutedsl_compat import emit_pipeline_advance
 from .cutedsl_compat import tcgen05_runtime_n_ptx_compatible
+from .cutedsl_compat import warn_tcgen05_runtime_n_ptx_fallback
 from .device_state import CuteDeviceFunctionState
 from .device_state import CuteTcgen05GroupedPlan
 from .device_state import CuteTcgen05MatmulPlan
 from .device_state import CuteTcgen05StoreValue
 from .device_state import Tcgen05GroupedDMode
+from .device_state import Tcgen05GroupedSchedulerMode
 from .device_state import Tcgen05Orientation
 from .fragment_epilogue import Tcgen05FragmentEpiloguePlan
 from .fragment_epilogue import _tcgen05_fragment_dtype_supported
@@ -68,6 +70,7 @@ from .matmul_utils import analyze_direct_grouped_n_loads
 from .mma_support import get_cute_mma_support
 from .strategies import TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY
 from .strategies import TCGEN05_LEGAL_SMEM_SWIZZLE_BYTES
+from .strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
 from .strategies import Tcgen05LayoutStrategy
 from .strategies import Tcgen05PersistenceModel
 from .strategies import is_pure_matmul_role_lifecycle_config
@@ -121,6 +124,7 @@ from .tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
 from .tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
 from .tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
 from .tcgen05_constants import TCGEN05_GROUPED_MODES
+from .tcgen05_constants import TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_BLOCK_K_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
@@ -6934,6 +6938,16 @@ def _emit_mma_pipeline(
     tcgen05_grouped_sched_params: str | None = None
     tcgen05_grouped_problem_sizes: str | None = None
     tcgen05_grouped_starts: str | None = None
+    tcgen05_grouped_runtime_tile_records: str | None = None
+    tcgen05_grouped_runtime_nm_direct = False
+    tcgen05_grouped_use_runtime_n_ptx = False
+    tcgen05_grouped_scheduler_mode = Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH
+    tcgen05_grouped_runtime_nm_clc_requested = (
+        df.config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY, False) is True
+        and df.config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+        == Tcgen05PersistenceModel.CLC_PERSISTENT.value
+    )
+    tcgen05_l2_swizzle_size_value = 1
     tcgen05_grouped_static_quota_args: tuple[str, ...] = ()
     tcgen05_grouped_real_groups: str | None = None
     tcgen05_grouped_metadata_idx: str | None = None
@@ -7150,8 +7164,15 @@ def _emit_mma_pipeline(
                     and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
                 )
             ),
-            "no_scheduler_warp": (
-                grouped_warp_spec is not None and grouped_warp_spec.scheduler_warps == 0
+            "supported_scheduler_warp": (
+                grouped_warp_spec is not None
+                and (
+                    grouped_warp_spec.scheduler_warps == 0
+                    or (
+                        tcgen05_grouped_runtime_nm_clc_requested
+                        and grouped_warp_spec.scheduler_warps == 1
+                    )
+                )
             ),
             "no_c_input_warp": (
                 grouped_warp_spec is not None and grouped_warp_spec.c_input_warps == 0
@@ -7171,10 +7192,14 @@ def _emit_mma_pipeline(
                 "persistent_interleaved static-full 128x(64|128)x(16|32|64|128) "
                 "TMA-load + TMA-store kernels, or the generated segment "
                 "worklist BK64/BK128 or direct BK64 dynamic-TensorMap variant "
-                "(including the CtaGroup.TWO 256x(64|128)x(64|128) worklist "
-                "shape), with no "
-                "scheduler/C-input/store warp variants; failed checks: "
-                + ", ".join(failed_grouped_checks),
+                f"(including CtaGroup.TWO physical 256x"
+                f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES}x"
+                f"{TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES} and CtaGroup.ONE "
+                f"physical {TCGEN05_ONE_CTA_MAX_BLOCK_M}x"
+                f"{TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE}x"
+                f"{TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES} worklist shapes), "
+                "with optional one-warp CLC scheduling and no C-input/store "
+                "warp variants; failed checks: " + ", ".join(failed_grouped_checks),
             )
         grouped_count_value = (
             int(rhs_info.source_fake.shape[0])
@@ -7366,6 +7391,70 @@ def _emit_mma_pipeline(
             # starts and valid extents remain scheduler metadata, but no longer
             # require rebasing A/B/D descriptors in the kernel.
             tcgen05_grouped_d_mode = Tcgen05GroupedDMode.NONE
+        # Generic runtime-variable-M N,M worklists can bypass both the grouped
+        # scheduler search and its scheduler-warp/SMEM-mailbox broadcast.  The
+        # launcher expands the current worklist into one record per logical
+        # output tile; every role replays that runtime table directly without
+        # specializing on the current per-group M sizes.
+        tcgen05_grouped_runtime_nm_direct_requested = (
+            df.config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY, False) is True
+        )
+        tcgen05_grouped_runtime_nm_direct = (
+            requested_schedule is Tcgen05Orientation.NM
+            and tcgen05_grouped_worklist_persistent
+            and not tcgen05_grouped_device_split_sizes
+            and tcgen05_grouped_runtime_nm_direct_requested
+            # Direct replay remains an explicit profile opt-in for both CTA
+            # group sizes.  The host table must use the physical MMA width,
+            # which is 128 for CTA-group::1 and 256 for CTA-group::2.
+            and (tcgen05_is_two_cta or grouped_worklist_one_cta)
+            and tcgen05_grouped_dynamic_ab_tensormap_rank is not None
+        )
+        if (
+            tcgen05_grouped_runtime_nm_direct_requested
+            and not tcgen05_grouped_runtime_nm_direct
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped runtime-direct was explicitly requested but "
+                "the kernel is not an eligible generic worklist_nm launch; it "
+                "requires persistent worklist metadata, no device split sizes "
+                "or static problem signature, a supported CTA-group tile, and "
+                "dynamic grouped A/B TensorMaps",
+            )
+        if (
+            tcgen05_grouped_runtime_nm_clc_requested
+            and not tcgen05_grouped_runtime_nm_direct
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped CLC persistence is supported only by the "
+                "worklist_nm runtime-direct path with an exact host-expanded "
+                "tile table and no static problem signature",
+            )
+        if (
+            tcgen05_grouped_runtime_nm_clc_requested
+            and not tcgen05_grouped_fixed_tensormaps
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped runtime-direct CLC currently requires fixed "
+                "full-allocation TensorMaps; dynamic TensorMap workspaces are "
+                "sized for the resident persistent grid, not the exact full "
+                "CLC request grid",
+            )
+        if tcgen05_grouped_runtime_nm_direct:
+            tcgen05_grouped_scheduler_mode = (
+                Tcgen05GroupedSchedulerMode.RUNTIME_CLC
+                if tcgen05_grouped_runtime_nm_clc_requested
+                else Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT
+            )
+            tcgen05_grouped_use_runtime_n_ptx = tcgen05_runtime_n_ptx_compatible()
+            if not tcgen05_grouped_use_runtime_n_ptx:
+                # Static-width typed MMA is the pre-existing correctness path:
+                # padded A rows are independent, and the epilogue zeros rows
+                # outside valid_m. Raw runtime-N only narrows that tail work.
+                warn_tcgen05_runtime_n_ptx_fallback()
         nm_deep_ab = (
             requested_schedule is not None
             and grouped_worklist_supported
@@ -7423,6 +7512,10 @@ def _emit_mma_pipeline(
         tcgen05_grouped_sched_params = df.new_var("tcgen05_grouped_tile_sched_params")
         tcgen05_grouped_problem_sizes = df.new_var("tcgen05_grouped_problem_sizes")
         tcgen05_grouped_starts = df.new_var("tcgen05_grouped_starts")
+        if tcgen05_grouped_runtime_nm_direct:
+            tcgen05_grouped_runtime_tile_records = df.new_var(
+                "tcgen05_grouped_runtime_tile_records"
+            )
         if (
             tcgen05_grouped_static_problem_shapes is not None
             and len(tcgen05_grouped_static_problem_shapes)
@@ -7491,6 +7584,13 @@ def _emit_mma_pipeline(
             problem_n=cast("str", tcgen05_grouped_problem_n),
             problem_k=cast("str", tcgen05_grouped_problem_k),
             global_m_start=cast("str", tcgen05_grouped_global_m_start),
+            scheduler_mode=tcgen05_grouped_scheduler_mode,
+            runtime_tile_records=tcgen05_grouped_runtime_tile_records,
+            runtime_total_clusters=(
+                tcgen05_grouped_total_clusters
+                if tcgen05_grouped_runtime_nm_direct
+                else None
+            ),
             static_problem_shapes=tcgen05_grouped_static_problem_shapes,
             static_group_quota_args=tcgen05_grouped_static_quota_args,
             real_groups=tcgen05_grouped_real_groups,
@@ -7511,6 +7611,7 @@ def _emit_mma_pipeline(
         or (
             tcgen05_grouped_plan.real_groups is None
             and not tcgen05_grouped_plan.device_split_sizes
+            and not tcgen05_grouped_plan.uses_runtime_tile_table
         )
         or tcgen05_grouped_plan.orientation is not requested_schedule
     ):
@@ -7766,14 +7867,16 @@ def _emit_mma_pipeline(
         and tcgen05_nm_orientation
         and tcgen05_grouped_plan is not None
         and tcgen05_grouped_worklist_persistent
-        and TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY in df.config
+        and tcgen05_grouped_runtime_nm_direct
+        and tcgen05_grouped_use_runtime_n_ptx
     )
     if tcgen05_runtime_n_specialization:
         assert tcgen05_worklist_source_m_tile is not None
-        # Runtime UMMA-N specialization is a correctness path for ragged
-        # source-M tails, not a tunable choice. The exact BF16/FP32 shape
-        # envelope below fails closed; the pinned CuTe/CUTLASS environment is
-        # validation provenance, and upgrades require revalidating raw PTX.
+        # Runtime UMMA-N narrows ragged runtime-direct source-M tails. Mailbox
+        # scheduling and the newer-DSL fallback retain public typed static-width
+        # MMA. The exact BF16/FP32 shape envelope below fails closed; the pinned
+        # CuTe/CUTLASS environment is validation provenance, and upgrades require
+        # revalidating raw PTX.
         runtime_n_shape_supported = (
             input_dtype == torch.bfloat16
             and input_dtype_str == "cutlass.BFloat16"
@@ -8124,6 +8227,7 @@ def _emit_mma_pipeline(
             and tcgen05_warp_spec.scheduler_warps == 0
             and tcgen05_warp_spec.c_input_warps == 0
             and tcgen05_warp_spec.store_warps == 0
+            and not tcgen05_grouped_runtime_nm_direct
         )
         tcgen05_effective_scheduler_warps = (
             1 if nm_scheduler_decode else tcgen05_warp_spec.scheduler_warps
@@ -8741,20 +8845,16 @@ def _emit_mma_pipeline(
             # tolerated by hardware because the CTA shape has only
             # warps 4 and 5 (no warps 6/7 to disagree with).
             #
-            # Under ``ROLE_LOCAL_WITH_SCHEDULER`` the launched CTA
-            # has 7 warps (4 epi + 1 exec + 1 tma_load + 1 sched).
-            # If we kept the MONOLITHIC consumer predicate the
-            # warpgroup-1 warps would split as
-            # exec=increase / tma=decrease / sched=decrease, which
-            # is a real warpgroup-uniformity violation that triggers
-            # ``CUDA_ERROR_LAUNCH_FAILED`` at launch on sm_100a.
-            # Match Quack's pattern: only the 4 epi warps are
-            # consumers; exec joins the producer warpgroup (lower
-            # register budget) so warpgroup 1 is uniformly
-            # decrease.
+            # Under ``ROLE_LOCAL_WITH_SCHEDULER`` the launched CTA has 7 warps
+            # (4 epi + 1 exec + 1 tma_load + 1 sched). Scheduler-free
+            # runtime-direct has the same role split minus the scheduler warp.
+            # In both cases only the four epi warps are consumers; exec joins
+            # the producer warpgroup (lower register budget), keeping
+            # warpgroup 1 uniformly decreased.
             if (
                 tcgen05_matmul_plan.has_scheduler_warp
                 or tcgen05_use_flat_role_coordinates
+                or tcgen05_grouped_runtime_nm_direct
             ):
                 consumer_predicate = epi_active
             else:
@@ -9680,15 +9780,24 @@ def _emit_mma_pipeline(
                         )
                     )
                 grouped_wrapper_params: list[str] = []
-                if not grouped_plan.device_split_sizes:
+                if (
+                    not grouped_plan.device_split_sizes
+                    and not grouped_plan.uses_runtime_tile_table
+                ):
                     grouped_wrapper_params.extend(
                         [
                             grouped_plan.problem_sizes,
                             grouped_plan.starts,
                         ]
                     )
-                if grouped_plan.real_groups is not None:
+                if (
+                    grouped_plan.real_groups is not None
+                    and not grouped_plan.uses_runtime_tile_table
+                ):
                     grouped_wrapper_params.append(grouped_plan.real_groups)
+                if grouped_plan.uses_runtime_tile_table:
+                    assert grouped_plan.runtime_tile_records is not None
+                    grouped_wrapper_params.append(grouped_plan.runtime_tile_records)
                 if tcgen05_grouped_ab_tensormaps is not None:
                     grouped_wrapper_params.append(tcgen05_grouped_ab_tensormaps)
                 elif grouped_plan.d_tensormap is not None:
@@ -9703,12 +9812,17 @@ def _emit_mma_pipeline(
                             grouped_plan.direct_strides,
                         ]
                     )
-                grouped_wrapper_params.append(grouped_plan.sched_params)
+                if not grouped_plan.uses_runtime_tile_table:
+                    grouped_wrapper_params.append(grouped_plan.sched_params)
+                else:
+                    assert grouped_plan.runtime_total_clusters is not None
+                    grouped_wrapper_params.append(grouped_plan.runtime_total_clusters)
                 grouped_wrapper_params.extend(grouped_plan.static_group_quota_args)
                 df.wrapper_only_params.extend(grouped_wrapper_params)
                 cg.cute_wrapper_plans.append(
                     {
                         "kind": "tcgen05_grouped_static_persistent",
+                        "scheduler_mode": grouped_plan.scheduler_mode.value,
                         "layout_name": grouped_plan.layout,
                         **(
                             {"n_sizes_name": tcgen05_grouped_n_sizes_arg_name}
@@ -9760,6 +9874,7 @@ def _emit_mma_pipeline(
                         ),
                         "cluster_m": tcgen05_cluster_m,
                         "cluster_n": tcgen05_cluster_n,
+                        "l2_swizzle_size": tcgen05_l2_swizzle_size_value,
                         **(
                             {
                                 TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY: (
@@ -9779,15 +9894,31 @@ def _emit_mma_pipeline(
                             else {}
                         ),
                         "k_total_size": k_total_size,
-                        "problem_sizes_arg": grouped_plan.problem_sizes,
-                        "starts_arg": grouped_plan.starts,
+                        **(
+                            {
+                                "problem_sizes_arg": grouped_plan.problem_sizes,
+                                "starts_arg": grouped_plan.starts,
+                            }
+                            if not grouped_plan.uses_runtime_tile_table
+                            else {}
+                        ),
                         **(
                             {"real_groups_arg": grouped_plan.real_groups}
                             if grouped_plan.real_groups is not None
+                            and not grouped_plan.uses_runtime_tile_table
                             else {}
                         ),
                         "sched_params_arg": grouped_plan.sched_params,
                         "total_clusters_arg": tcgen05_grouped_total_clusters,
+                        **(
+                            {
+                                "runtime_tile_records_arg": (
+                                    grouped_plan.runtime_tile_records
+                                )
+                            }
+                            if grouped_plan.uses_runtime_tile_table
+                            else {}
+                        ),
                         **(
                             {
                                 "static_group_quota_args": (

--- a/helion/_compiler/cute/cutedsl_compat.py
+++ b/helion/_compiler/cute/cutedsl_compat.py
@@ -54,6 +54,32 @@ def tcgen05_runtime_n_ptx_compatible() -> bool:
 
 
 @lru_cache(maxsize=1)
+def warn_tcgen05_runtime_n_ptx_fallback() -> None:
+    """Warn once when a grouped worklist needs the newer-DSL fallback.
+
+    This is intentionally separate from the side-effect-free compatibility
+    probe. Callers invoke the warning only after proving a grouped N,M worklist
+    candidate or selecting its explicit runtime-direct codegen path.
+    """
+
+    installed = _installed_cute_dsl_version().version
+    if installed is None:
+        return
+    if installed > CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION:
+        log.warning(
+            "Installed nvidia-cutlass-dsl %s is newer than the exact %s version "
+            "validated for grouped tcgen05 runtime-N PTX. Grouped runtime-N "
+            "compiler seeds and promoted defaults are disabled; explicit "
+            "runtime-direct worklist configs fall back to typed static-width "
+            "MMA, including for ragged source-M tails. Use %s for the validated "
+            "narrow runtime-N path.",
+            installed,
+            CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION,
+            CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION,
+        )
+
+
+@lru_cache(maxsize=1)
 def _cute_backend_requirement_error() -> str | None:
     """Return why the cute backend cannot run here, or ``None`` if it can.
 

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -38,6 +38,14 @@ class Tcgen05GroupedDMode(enum.Enum):
     EDGE_ONLY = enum.auto()
 
 
+class Tcgen05GroupedSchedulerMode(enum.Enum):
+    """How a grouped persistent kernel selects its next logical tile."""
+
+    DEVICE_GROUP_SEARCH = "device_group_search"
+    RUNTIME_DIRECT = "runtime_direct"
+    RUNTIME_CLC = "runtime_clc"
+
+
 @dataclasses.dataclass(frozen=True)
 class CuteTcgen05GroupedPlan:
     orientation: Tcgen05Orientation
@@ -54,6 +62,17 @@ class CuteTcgen05GroupedPlan:
     problem_n: str
     problem_k: str
     global_m_start: str
+    scheduler_mode: Tcgen05GroupedSchedulerMode = (
+        Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH
+    )
+    # Host-expanded per-logical-tile records for the runtime N,M worklist
+    # direct scheduler.  Unlike ``static_problem_shapes``, this table is built
+    # from the current worklist values by the launcher and is therefore reusable
+    # by one compiled kernel across routing vectors.  ``total_clusters`` is a
+    # runtime scalar because the table row count is launch metadata, not an AOT
+    # problem signature.
+    runtime_tile_records: str | None = None
+    runtime_total_clusters: str | None = None
     static_problem_shapes: tuple[tuple[int, int, int], ...] | None = None
     static_group_quota_args: tuple[str, ...] = ()
     real_groups: str | None = None
@@ -82,14 +101,37 @@ class CuteTcgen05GroupedPlan:
         assert (self.direct_pointers is None) == (self.direct_strides is None)
         assert (self.d_mode is Tcgen05GroupedDMode.NONE) == (self.d_tensormap is None)
         assert not self.device_split_sizes or self.orientation is Tcgen05Orientation.NM
+        assert (self.runtime_tile_records is None) == (
+            self.runtime_total_clusters is None
+        )
+        if self.scheduler_mode is Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH:
+            assert self.runtime_tile_records is None
+            assert self.runtime_total_clusters is None
+        elif self.scheduler_mode in (
+            Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+            Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
+        ):
+            assert self.runtime_tile_records is not None
+            assert self.runtime_total_clusters is not None
+            assert self.orientation is Tcgen05Orientation.NM
+            assert not self.device_split_sizes
+            assert self.static_problem_shapes is None
+            if self.scheduler_mode is Tcgen05GroupedSchedulerMode.RUNTIME_CLC:
+                assert self.fixed_tensormaps
+        else:
+            raise AssertionError(
+                f"unhandled grouped scheduler mode: {self.scheduler_mode!r}"
+            )
         if self.orientation is Tcgen05Orientation.NM:
-            assert self.real_groups is not None or self.device_split_sizes
+            assert (
+                self.uses_runtime_tile_table
+                or self.real_groups is not None
+                or self.device_split_sizes
+            )
             assert self.fixed_tensormaps == (self.d_mode is Tcgen05GroupedDMode.NONE)
         if self.fixed_tensormaps:
             assert self.orientation is Tcgen05Orientation.NM
             assert not self.device_split_sizes
-            assert self.d_mode is Tcgen05GroupedDMode.NONE
-            assert self.d_tensormap is None
             assert self.direct_pointers is None
         if self.static_problem_shapes is not None:
             assert self.orientation is Tcgen05Orientation.MN
@@ -101,6 +143,13 @@ class CuteTcgen05GroupedPlan:
     @property
     def device_split_sizes(self) -> bool:
         return self.m_size is not None
+
+    @property
+    def uses_runtime_tile_table(self) -> bool:
+        return self.scheduler_mode in (
+            Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+            Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
+        )
 
 
 class _CuteTcgen05Orientation(Protocol):
@@ -284,6 +333,28 @@ class CuteTcgen05MatmulPlan(_CuteTcgen05OrientationMixin):
     aux_tensor_descriptors: tuple[Tcgen05AuxTensorDescriptor, ...] = dataclasses.field(
         default=(), compare=False
     )
+
+    def __post_init__(self) -> None:
+        if self.grouped is None:
+            return
+        scheduler_mode = self.grouped.scheduler_mode
+        if scheduler_mode is Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH:
+            if self.grouped.orientation is Tcgen05Orientation.NM:
+                assert self.uses_role_local_persistent_body
+                assert self.has_scheduler_warp
+                assert not self.is_clc_persistent
+            return
+        if scheduler_mode is Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT:
+            assert self.uses_role_local_persistent_body
+            assert not self.has_scheduler_warp
+            assert not self.is_clc_persistent
+            return
+        if scheduler_mode is Tcgen05GroupedSchedulerMode.RUNTIME_CLC:
+            assert self.uses_role_local_persistent_body
+            assert self.has_scheduler_warp
+            assert self.is_clc_persistent
+            return
+        raise AssertionError(f"unhandled grouped scheduler mode: {scheduler_mode!r}")
 
     @property
     def orientation(self) -> Tcgen05Orientation:

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -87,6 +87,7 @@ from .tcgen05_constants import TCGEN05_C_STORE_MODES
 from .tcgen05_constants import TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CHOICES
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_CONSUMER_REGS_DEFAULT
 from .tcgen05_constants import TCGEN05_CUBIN_LINEINFO_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_DIAGNOSTIC_INVALID_OUTPUT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY
@@ -101,11 +102,13 @@ from .tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
 from .tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
 from .tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
 from .tcgen05_constants import TCGEN05_GROUPED_MODES
+from .tcgen05_constants import TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
@@ -144,7 +147,7 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
 from .tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
-from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_shape
+from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_profile
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_c_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_default_epilogue_tile_size
@@ -227,6 +230,7 @@ CUTE_TCGEN05_DIAGNOSTIC_CONFIG_KEYS: frozenset[str] = frozenset(
         TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY,
         TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY,
         TCGEN05_GROUPED_MODE_CONFIG_KEY,
+        TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
         TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY,
         TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
         TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
@@ -905,6 +909,23 @@ class CuteTcgen05Config:
         # their sub-paths; doing it once here covers the full-tile and
         # small-grid paths too.
         config.pop("epilogue_subtile", None)
+        if (
+            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            and config.get("tcgen05_cluster_n", 1) == 1
+            and block_sizes[m_index] == TCGEN05_TWO_CTA_BLOCK_M
+            and block_sizes[n_index] == 128
+            and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+            and config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+            in (
+                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+                TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+            )
+        ):
+            # Worklist configs keep their 256x128 logical DSL tile. Their
+            # source-M metadata selects the physical 256x224/256 MMA profile
+            # through ``resolve_tcgen05_grouped_worklist_mma_profile``.
+            return
         # fp8 small-grid family: a sampled bm<=128 routes to the fp8-validated
         # per-CTA 64xbn 2-CTA tile (bm=128/bn=128) instead of the bm=256 full
         # tile, which underfills the device on small/wave-limited fp8 GEMMs. The
@@ -963,6 +984,41 @@ class CuteTcgen05Config:
                 raise InvalidConfig(
                     "tcgen05 grouped kernels require num_sm_multiplier=1"
                 )
+        grouped_clc = (
+            grouped_mode in TCGEN05_GROUPED_MODES
+            and config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+            == Tcgen05PersistenceModel.CLC_PERSISTENT.value
+        )
+        if grouped_clc and (
+            config.get(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, 0) != 0
+        ):
+            if fix_invalid:
+                config.pop(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, None)
+            else:
+                raise InvalidConfig(
+                    "tcgen05 grouped CLC launches its exact full tile-record grid; "
+                    "reserved_sms cannot limit that grid"
+                )
+        if grouped_clc and not (
+            grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            and config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
+            and TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY not in config
+        ):
+            if fix_invalid:
+                config.pop(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY, None)
+                config[TCGEN05_STRATEGY_CONFIG_KEY] = (
+                    Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value
+                )
+                config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 0
+            else:
+                raise InvalidConfig(
+                    "tcgen05 grouped CLC persistence requires "
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r}, "
+                    f"{TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY}=True, and no "
+                    f"{TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY}; the "
+                    "launcher must build an exact one-record-per-cluster tile table"
+                )
         source_m_tile_key = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
         source_m_tile = config.get(source_m_tile_key)
         if source_m_tile_key in config and (
@@ -982,6 +1038,37 @@ class CuteTcgen05Config:
                     f"{source_m_tile!r}"
                 )
         signature_key = TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
+        runtime_direct_key = TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY
+        if config.get(runtime_direct_key) is True and (
+            grouped_mode != TCGEN05_GROUPED_MODE_WORKLIST_NM or signature_key in config
+        ):
+            if fix_invalid:
+                config.pop(runtime_direct_key)
+            else:
+                raise InvalidConfig(
+                    f"{runtime_direct_key}=True requires "
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} and no "
+                    f"{signature_key}; unsupported requests must not silently "
+                    "fall back to the legacy grouped scheduler"
+                )
+        l2_swizzle_size = config.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY, 1)
+        if (
+            grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            and type(l2_swizzle_size) is int
+            and l2_swizzle_size > 1
+            and config.get(runtime_direct_key) is not True
+        ):
+            if fix_invalid:
+                config[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = 1
+            else:
+                raise InvalidConfig(
+                    f"{TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY}>1 for "
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} requires "
+                    f"{runtime_direct_key}=True so the host runtime tile table "
+                    "owns panel rastering"
+                )
         if signature_key in config:
             try:
                 parse_tcgen05_grouped_static_problem_signature(config[signature_key])
@@ -1235,31 +1322,23 @@ class CuteTcgen05Config:
             and all(config.get(key) is None for key in TCGEN05_LAYOUT_OVERRIDES_KEYS)
         )
 
-    def _grouped_worklist_nm_deep_ab_config_matches(
+    def _grouped_worklist_nm_ab_config_matches(
         self, config: dict[str, object], ab_stages: object
     ) -> bool:
         block_sizes = config.get("block_sizes")
-        cluster_m = config.get("tcgen05_cluster_m")
-        source_m_tile = config.get(
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-        )
         block_k = (
             block_sizes[2]
             if isinstance(block_sizes, list) and len(block_sizes) >= 3
             else None
         )
-        physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
-            cluster_m=cluster_m,
+        profile = resolve_tcgen05_grouped_worklist_mma_profile(
+            config,
             block_k=block_k,
-            source_m_tile=source_m_tile,
         )
         if not (
             type(ab_stages) is int
             and 2 <= ab_stages <= 7
-            and config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
-            == TCGEN05_GROUPED_MODE_WORKLIST_NM
-            and physical_shape is not None
+            and profile is not None
             and config.get("tcgen05_cluster_n", 1) == 1
             and config.get("tcgen05_acc_stages", 2) == 2
             and config.get("tcgen05_c_stages", 2) == 2
@@ -1275,13 +1354,12 @@ class CuteTcgen05Config:
         sched_stage_count = config.get(TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY, 1)
         if type(sched_stage_count) is not int or sched_stage_count <= 0:
             return False
-        physical_bm, physical_bn = physical_shape
+        physical_bm, physical_bn = profile.mma_m, profile.mma_n
         # The generic AB search budget reserves 28 KiB, which is deliberately
         # conservative for general matmuls but would reject the valid
         # BK64/source-224/AB7 worklist at B200's exact 227-KiB cap. Reconstruct
-        # the raw target cap and account for this path's full ordered allocation.
-        # Use the same conservative ordered allocation as codegen. Current
-        # scheduler modes all round to the same final 1024-byte C-ring boundary.
+        # the raw target cap and apply the same conservative worklist upper bound
+        # across scheduler modes as codegen.
         required_bytes = tcgen05_grouped_worklist_smem_bytes(
             group_count=1,
             device_split_sizes=False,
@@ -1293,7 +1371,7 @@ class CuteTcgen05Config:
             ab_stages=ab_stages,
             acc_stages=2,
             c_stages=2,
-            cluster_m=cast("int", cluster_m),
+            cluster_m=profile.cluster_m,
         )
         target_capacity_bytes = (
             constraints.per_cta_smem_budget_bytes
@@ -1786,11 +1864,11 @@ class CuteTcgen05Config:
             return
         if self._grouped_dynamic_deep_config_matches(config):
             return
-        if self._grouped_worklist_nm_deep_ab_config_matches(config, ab_stages):
+        if self._grouped_worklist_nm_ab_config_matches(config, ab_stages):
             return
-        # ab>3 is only valid on the TVM-FFI direct-entry path, and only for the
-        # (bk, ab, c) stage tuples the direct-entry codegen accepts (bk=64
-        # admits (ab=6, c=4)). Everything else clamps (or rejects) to ab=3.
+        # After the grouped dynamic/worklist exceptions above, ab>3 is only valid
+        # on the TVM-FFI direct-entry path and for its accepted (bk, ab, c) tuples
+        # (bk=64 admits (ab=6, c=4)). Everything else clamps or rejects to ab=3.
         block_sizes = config.get("block_sizes")
         k_block_index = self._direct_entry_k_block_index()
         bk = (
@@ -2376,8 +2454,16 @@ class CuteTcgen05Config:
             fragments[TCGEN05_GROUPED_MODE_CONFIG_KEY] = EnumFragment(
                 TCGEN05_GROUPED_MODES
             )
+            fragments[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = BooleanFragment()
             fragments[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = EnumFragment(
-                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+                (
+                    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+                    *(
+                        choice
+                        for choice in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+                        if choice != TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+                    ),
+                )
             )
         direct_entry_seed_eligible = self.full_tile_direct_entry_seed_eligible()
         if direct_entry_seed_eligible or (
@@ -2502,8 +2588,26 @@ class CuteTcgen05Config:
         even though ``_aux_tma_search_enabled`` was widened (see
         ``aux_stages_autotune_fragments``).
         """
+        seed_choices = tuple(
+            dict.fromkeys(
+                value
+                for config in self.config_spec.compiler_seed_configs
+                if (value := config.config.get(TCGEN05_CONSUMER_REGS_CONFIG_KEY))
+                in TCGEN05_CONSUMER_REGS_CHOICES
+            )
+        )
         if not self._aux_tma_edge_search_enabled():
-            return {}
+            if not seed_choices:
+                return {}
+            choices = tuple(
+                dict.fromkeys((TCGEN05_CONSUMER_REGS_DEFAULT, *seed_choices))
+            )
+            return {
+                TCGEN05_CONSUMER_REGS_CONFIG_KEY: EnumFragment(
+                    choices,
+                    search_choices=(TCGEN05_CONSUMER_REGS_DEFAULT,),
+                )
+            }
         return {
             TCGEN05_CONSUMER_REGS_CONFIG_KEY: EnumFragment(
                 TCGEN05_CONSUMER_REGS_CHOICES
@@ -2511,11 +2615,32 @@ class CuteTcgen05Config:
         }
 
     def persistence_model_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
-        if not self._clc_persistence_search_enabled():
-            return {}
         default_model = derive_persistence_model_from_pid_type(
             self.allowed_pid_types[0]
         ).value
+        seed_override_models = tuple(
+            dict.fromkeys(
+                model
+                for config in self.config_spec.compiler_seed_configs
+                if isinstance(
+                    model := config.config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY),
+                    str,
+                )
+                and model in {item.value for item in Tcgen05PersistenceModel}
+                and model
+                != self.persistence_model_default_from_config(config.config).value
+            )
+        )
+        if not self._clc_persistence_search_enabled():
+            if not seed_override_models:
+                return {}
+            choices = tuple(dict.fromkeys((default_model, *seed_override_models)))
+            return {
+                TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: EnumFragment(
+                    choices,
+                    search_choices=(default_model,),
+                )
+            }
         choices = tuple(
             dict.fromkeys(
                 (
@@ -2544,6 +2669,36 @@ class CuteTcgen05Config:
             strategy_choices = (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,)
             scheduler_warps_choices = (0,)
             c_input_warps_choices = (0,)
+        strategy_seed_choices = tuple(
+            dict.fromkeys(
+                strategy
+                for config in self.config_spec.compiler_seed_configs
+                if isinstance(
+                    strategy := config.config.get(TCGEN05_STRATEGY_CONFIG_KEY),
+                    str,
+                )
+                and strategy in {item.value for item in Tcgen05Strategy}
+            )
+        )
+        scheduler_seed_choices = tuple(
+            dict.fromkeys(
+                scheduler_warps
+                for config in self.config_spec.compiler_seed_configs
+                if type(
+                    scheduler_warps := config.config.get(
+                        TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
+                    )
+                )
+                is int
+                and scheduler_warps in (0, 1)
+            )
+        )
+        all_strategy_choices = tuple(
+            dict.fromkeys((*strategy_choices, *strategy_seed_choices))
+        )
+        all_scheduler_warps_choices = tuple(
+            dict.fromkeys((*scheduler_warps_choices, *scheduler_seed_choices))
+        )
         # The store-warp slot stays narrowed to ``0`` in the autotune surface —
         # only an explicit ``helion.Config(tcgen05_warp_spec_store_warps=1)``
         # activates it. Cycle 93 (Workstream A Stage 4) landed the productive
@@ -2560,13 +2715,25 @@ class CuteTcgen05Config:
         else:
             layout_choices = (Tcgen05LayoutStrategy.DEFAULT.value,)
         return {
-            TCGEN05_STRATEGY_CONFIG_KEY: EnumFragment(strategy_choices),
+            TCGEN05_STRATEGY_CONFIG_KEY: EnumFragment(
+                all_strategy_choices,
+                search_choices=(
+                    strategy_choices
+                    if all_strategy_choices != strategy_choices
+                    else None
+                ),
+            ),
             TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: EnumFragment(layout_choices),
             TCGEN05_WARP_SPEC_MMA_WARPS_KEY: EnumFragment((1,)),
             TCGEN05_WARP_SPEC_AB_LOAD_WARPS_KEY: EnumFragment((1,)),
             TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY: EnumFragment((0,)),
             TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: EnumFragment(
-                scheduler_warps_choices
+                all_scheduler_warps_choices,
+                search_choices=(
+                    scheduler_warps_choices
+                    if all_scheduler_warps_choices != scheduler_warps_choices
+                    else None
+                ),
             ),
             TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: EnumFragment(c_input_warps_choices),
             TCGEN05_WARP_SPEC_STORE_WARPS_KEY: EnumFragment(store_warps_choices),
@@ -2668,6 +2835,15 @@ class CuteTcgen05Config:
         raise InvalidConfig(f"tcgen05 strategy invariants violated: {message}")
 
     def _clamp_l2_swizzle_size_to_shape(self, config: dict[str, object]) -> None:
+        if (
+            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            == TCGEN05_GROUPED_MODE_WORKLIST_NM
+        ):
+            # Runtime-direct grouped N,M builds the panel raster from each
+            # group's host-visible tile count, so there is no single static
+            # shape to clamp against here. ``prepare_normalization`` already
+            # forces the legacy device-search scheduler to use swizzle 1.
+            return
         # CuTe layout construction assumes the L2 swizzle does not exceed the
         # number of N tile-clusters; clamp before layout objects are built.
         swizzle_value = config.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
@@ -2724,9 +2900,13 @@ class CuteTcgen05Config:
                 if key in config:
                     if key == "tcgen05_ab_stages" and (
                         self._grouped_dynamic_deep_config_matches(config)
-                        or self._grouped_worklist_nm_deep_ab_config_matches(
-                            config,
-                            config[key],
+                        or (
+                            type(config[key]) is int
+                            and config[key] > 3
+                            and self._grouped_worklist_nm_ab_config_matches(
+                                config,
+                                config[key],
+                            )
                         )
                     ):
                         config[key] = int(cast("Any", config[key]))
@@ -3184,6 +3364,28 @@ class CuteTcgen05Config:
         ):
             fields["loop_orders"] = self.config_spec.loop_orders
         fields.update(self.optional_fragments(for_search=True))
+        seed_l2_swizzles = tuple(
+            dict.fromkeys(
+                value
+                for config in self.config_spec.compiler_seed_configs
+                if type(value := config.config.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY))
+                is int
+                and value in TCGEN05_LEGAL_L2_SWIZZLE_SIZES
+            )
+        )
+        l2_swizzle_fragment = fields.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
+        if seed_l2_swizzles and isinstance(l2_swizzle_fragment, EnumFragment):
+            choices = tuple(
+                dict.fromkeys((*l2_swizzle_fragment.choices, *seed_l2_swizzles))
+            )
+            if choices != l2_swizzle_fragment.choices:
+                fields[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = EnumFragment(
+                    choices,
+                    search_choices=(
+                        l2_swizzle_fragment.search_choices
+                        or l2_swizzle_fragment.choices
+                    ),
+                )
         grouped_seed_modes = tuple(
             dict.fromkeys(
                 mode
@@ -3196,8 +3398,30 @@ class CuteTcgen05Config:
             mode in TCGEN05_GROUPED_DYNAMIC_MODES for mode in grouped_seed_modes
         )
         if has_grouped_dynamic_seed:
+            seed_reserved_sms = tuple(
+                dict.fromkeys(
+                    reserved_sms
+                    for config in self.config_spec.compiler_seed_configs
+                    if type(
+                        reserved_sms := config.config.get(
+                            TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+                        )
+                    )
+                    is int
+                    and 0 <= reserved_sms <= TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
+                )
+            )
+            reserved_sms_choices = tuple(
+                dict.fromkeys(
+                    (
+                        *TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
+                        *seed_reserved_sms,
+                    )
+                )
+            )
             fields[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = EnumFragment(
-                TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
+                reserved_sms_choices,
+                search_choices=TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
             )
         if grouped_seed_modes:
             # Seed-only encoding: random/default search stays off the grouped
@@ -3205,6 +3429,14 @@ class CuteTcgen05Config:
             fields[TCGEN05_GROUPED_MODE_CONFIG_KEY] = EnumFragment(
                 (None, *grouped_seed_modes),
                 search_choices=(None,),
+            )
+        if any(
+            config.config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
+            for config in self.config_spec.compiler_seed_configs
+        ):
+            fields[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = EnumFragment(
+                (False, True),
+                search_choices=(False,),
             )
         grouped_source_m_tiles = tuple(
             dict.fromkeys(

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+from enum import IntEnum
+from typing import TYPE_CHECKING
+from typing import NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 # Validated CtaGroup.TWO autotune/runtime envelope for the B200 CuTe path.
 # Re-verify the K-cap runtime and guard-boundary tests before raising the
 # K-tile threshold or broadening the tile shape.
@@ -497,6 +504,14 @@ TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY = (
 TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY = (
     "tcgen05_grouped_worklist_source_m_tile"
 )
+# Reviewed runtime-variable-M profiles may opt into the host-expanded direct
+# tile table.  Absence or explicit ``False`` retains the established
+# scheduler-warp/SMEM-mailbox path, so profiles can choose between the two
+# generic schedulers without specializing on the runtime M vector.
+TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY = "tcgen05_grouped_runtime_direct"
+# CUDA exposes grid.z as an unsigned 16-bit launch dimension. Runtime-direct
+# CLC emits one exact tile record per cluster into that dimension.
+TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS = (1 << 16) - 1
 # Compact source rows avoid padding small-M experts to the historical 224-row
 # default while retaining the 32-row granularity of the validated store wave.
 TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE = 32
@@ -504,8 +519,8 @@ TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT = 224
 TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE = 256
 TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES = (64, 128)
 TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES = (
-    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
     TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
     TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
 )
 # N,M orientation maps the packed source-M tile onto the physical MMA-N mode.
@@ -517,6 +532,26 @@ TCGEN05_GROUPED_WORKLIST_STORE_SHAPE = (128, 32, 32)
 # The grouped scheduler publishes CTA M/N, validity, metadata/group indices,
 # problem M/N/K, and the packed-output row start through one Int32 mailbox.
 TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT = 9
+
+
+# Runtime-direct N,M scheduling expands one row per logical output tile on the
+# host. It deliberately contains no validity sentinel: the runtime
+# ``total_clusters`` scalar bounds every role-local loop. This shared enum is
+# the schema contract between the host table builder and generated device loads.
+class Tcgen05GroupedRuntimeTileField(IntEnum):
+    CTA_M = 0
+    CTA_N = 1
+    METADATA_IDX = 2
+    GROUP_IDX = 3
+    PROBLEM_M = 4
+    PROBLEM_N = 5
+    PROBLEM_K = 6
+    GLOBAL_M_START = 7
+    VALID_M = 8
+    STORE_M = 9
+
+
+TCGEN05_GROUPED_RUNTIME_TILE_FIELD_COUNT = len(Tcgen05GroupedRuntimeTileField)
 
 
 TCGEN05_LARGE_BN_PROOF_PROBLEM_SHAPE = (64, 512, 16)
@@ -569,6 +604,41 @@ def resolve_tcgen05_grouped_worklist_mma_shape(
     return None
 
 
+class Tcgen05GroupedWorklistMmaProfile(NamedTuple):
+    cluster_m: int
+    source_m_tile: int
+    mma_m: int
+    mma_n: int
+
+
+def resolve_tcgen05_grouped_worklist_mma_profile(
+    config: Mapping[str, object],
+    *,
+    block_k: object,
+) -> Tcgen05GroupedWorklistMmaProfile | None:
+    """Resolve one normalized worklist config to its physical MMA profile."""
+    if config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) != TCGEN05_GROUPED_MODE_WORKLIST_NM:
+        return None
+    cluster_m = config.get("tcgen05_cluster_m", 1)
+    source_m_tile = config.get(
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+    )
+    shape = resolve_tcgen05_grouped_worklist_mma_shape(
+        cluster_m=cluster_m,
+        block_k=block_k,
+        source_m_tile=source_m_tile,
+    )
+    if shape is None:
+        return None
+    assert type(cluster_m) is int and type(source_m_tile) is int
+    return Tcgen05GroupedWorklistMmaProfile(
+        cluster_m,
+        source_m_tile,
+        *shape,
+    )
+
+
 def _append_aligned_tcgen05_smem(offset: int, size: int, alignment: int) -> int:
     assert offset >= 0 and size >= 0 and alignment > 0
     return ((offset + alignment - 1) // alignment) * alignment + size
@@ -588,13 +658,11 @@ def tcgen05_grouped_worklist_smem_bytes(
     c_stages: int,
     cluster_m: int,
 ) -> int:
-    """Return the conservative ordered SMEM footprint of an N,M worklist.
+    """Return a conservative SMEM upper bound across all worklist modes.
 
     Charge the device-search dynamic-TensorMap allocation, the largest current
-    worklist mode. Runtime-direct and fixed-map modes omit some of these objects,
-    but every validated profile rounds to the same total at the final 1024-byte
-    C-ring alignment. Keeping one allocation model avoids coupling resource
-    admission to scheduler implementation details.
+    allocation set. Other scheduler modes may omit objects; sharing this upper
+    bound keeps resource admission independent of scheduler implementation.
     Keep allocation ordering synchronized with codegen because alignment padding
     makes reordering observable at the admission boundary.
     """

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -17,6 +17,7 @@ from .ast_extension import expr_from_string
 from .ast_extension import statement_from_string
 from .compile_environment import CompileEnvironment
 from .cute.cutedsl_compat import emit_pipeline_advance
+from .cute.device_state import Tcgen05GroupedSchedulerMode
 from .cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_DEFAULT
 from .cute.strategies import l2_swizzle_size_from_config
 from .cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_SPECIALIZATION_MAX_GROUPS
@@ -26,6 +27,7 @@ from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_NORMAL
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_WARP_LEADER
 from .cute.tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .cute.tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
+from .cute.tcgen05_constants import Tcgen05GroupedRuntimeTileField
 from .device_function import DeviceFunction
 from .device_function import TensorArg
 from .host_function import HostFunction
@@ -202,6 +204,7 @@ _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_M = 5
 _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_N = 6
 _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_K = 7
 _TCGEN05_GROUPED_SELECTED_MAILBOX_GLOBAL_M_START = 8
+
 if TYPE_CHECKING:
     import sympy
 
@@ -1213,6 +1216,36 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             and plan.accumulator_view == "nm"
             and plan.has_scheduler_warp
             and plan.uses_role_local_persistent_body
+            and plan.grouped is not None
+            and plan.grouped.scheduler_mode
+            is Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH
+        )
+
+    def _tcgen05_uses_grouped_worklist_nm_runtime_table(self) -> bool:
+        plan = self._tcgen05_plan()
+        return bool(
+            plan is not None
+            and plan.accumulator_view == "nm"
+            and plan.uses_role_local_persistent_body
+            and plan.grouped is not None
+            and plan.grouped.uses_runtime_tile_table
+        )
+
+    def _tcgen05_uses_grouped_worklist_nm_runtime_direct(self) -> bool:
+        plan = self._tcgen05_plan()
+        return bool(
+            plan is not None
+            and plan.grouped is not None
+            and plan.grouped.scheduler_mode
+            is Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT
+        )
+
+    def _tcgen05_uses_grouped_worklist_nm_runtime_clc(self) -> bool:
+        plan = self._tcgen05_plan()
+        return bool(
+            plan is not None
+            and plan.grouped is not None
+            and plan.grouped.scheduler_mode is Tcgen05GroupedSchedulerMode.RUNTIME_CLC
         )
 
     def _tcgen05_sched_pipeline_plan(self) -> _Tcgen05SchedPipelinePlan | None:
@@ -2593,6 +2626,25 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                         "cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(0) "
                         "and cute.arch.lane_idx() == cutlass.Int32(0)"
                     ),
+                    # ``PipelineAsync.create(..., defer_sync=True)`` initializes
+                    # the mailbox mbarriers on each CTA's warp 0.  The cluster
+                    # leader's scheduler warp can publish to a peer CTA
+                    # immediately below, so a CTA-local sync is insufficient:
+                    # every peer must finish its local mbarrier initialization
+                    # before any remote arrive-and-expect-tx.  The main MMA
+                    # pipelines perform their own later rendezvous after their
+                    # setup; this earlier one protects the PID mailbox alone.
+                    statement_from_string(
+                        "cutlass.pipeline.pipeline_init_arrive("
+                        "cluster_shape_mn=cute.make_layout("
+                        f"({layout.cluster_m}, {layout.cluster_n}, 1)), "
+                        "is_relaxed=True)"
+                    ),
+                    statement_from_string(
+                        "cutlass.pipeline.pipeline_init_wait("
+                        "cluster_shape_mn=cute.make_layout("
+                        f"({layout.cluster_m}, {layout.cluster_n}, 1)))"
+                    ),
                 ]
             )
         else:
@@ -2783,11 +2835,14 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         # The per-role ``StaticPersistentTileScheduler.create`` is
         # *not* emitted in this mode — the scheduler warp owns the
         # only tile scheduler.
-        if self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox():
-            return self._build_grouped_static_role_local_while_with_scheduler(
+        if (
+            self._tcgen05_uses_grouped_worklist_nm_runtime_clc()
+            or self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox()
+        ):
+            return self._build_grouped_worklist_nm_role_local_while(
                 device_function,
-                layout,
                 role_block,
+                layout=layout,
                 scheduler_var_prefix=scheduler_var_prefix,
                 dependency_stmts=dependency_stmts,
                 role_prelude_stmts=role_prelude_stmts,
@@ -2814,6 +2869,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 scheduler_var_prefix=scheduler_var_prefix,
                 dependency_stmts=dependency_stmts,
                 role_prelude_stmts=role_prelude_stmts,
+                emit_pdl_wait=emit_pdl_wait,
                 initialize_tile_counter=initialize_tile_counter,
             )
         assert store_aux_per_tile_stmts is None, (
@@ -2978,8 +3034,6 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
     def _grouped_worklist_nm_valid_store_m_stmts(
         self,
         device_function: DeviceFunction,
-        *,
-        include_store_m: bool = True,
     ) -> list[ast.stmt]:
         plan = self._tcgen05_plan()
         assert plan is not None and plan.accumulator_view == "nm"
@@ -3007,7 +3061,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             remaining_m = (
                 f"max({grouped.problem_m} - {tile_start_var}, cutlass.Int32(0))"
             )
-            stmts = [
+            return [
                 statement_from_string(
                     f"{tile_start_var} = {grouped_cta_tile_idx_m} * "
                     f"cutlass.Int32({source_tile_m})"
@@ -3016,16 +3070,12 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                     f"{grouped_valid_m} = min(cutlass.Int32({source_tile_m}), "
                     f"{remaining_m})"
                 ),
+                statement_from_string(
+                    f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
+                    f"{remaining_m})"
+                ),
             ]
-            if include_store_m:
-                stmts.append(
-                    statement_from_string(
-                        f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
-                        f"{remaining_m})"
-                    )
-                )
-            return stmts
-        stmts = [
+        return [
             statement_from_string(
                 f"{tile_start_var} = {grouped_cta_tile_idx_m} * "
                 f"cutlass.Int32({source_tile_m})"
@@ -3034,15 +3084,11 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 f"{grouped_valid_m} = min(cutlass.Int32({source_tile_m}), "
                 f"max({metadata_load_expr(2)} - {tile_start_var}, cutlass.Int32(0)))"
             ),
+            statement_from_string(
+                f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
+                f"{metadata_load_expr(3)} - {tile_start_var})"
+            ),
         ]
-        if include_store_m:
-            stmts.append(
-                statement_from_string(
-                    f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
-                    f"{metadata_load_expr(3)} - {tile_start_var})"
-                )
-            )
-        return stmts
 
     def _build_specialized_grouped_static_role_local_while(
         self,
@@ -3208,6 +3254,267 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             orelse=[],
         )
 
+    def _build_grouped_worklist_nm_role_local_while(
+        self,
+        device_function: DeviceFunction,
+        role_block: Tcgen05PersistentProgramIDs._PersistentRoleBlock,
+        *,
+        layout: Tcgen05PersistentProgramIDs._Tcgen05PersistentLayout | None = None,
+        scheduler_var_prefix: str,
+        dependency_stmts: list[ast.stmt] | None,
+        role_prelude_stmts: list[ast.stmt] | None,
+        initialize_tile_counter: bool,
+        emit_pdl_wait: bool,
+    ) -> ast.stmt:
+        """Consume N,M worklist tiles from the selected runtime scheduler."""
+        assert role_block.role_predicate is not None
+        plan = self._tcgen05_plan()
+        assert plan is not None and plan.grouped is not None
+        grouped = plan.grouped
+        assert grouped.valid_m is not None and grouped.store_m is not None
+        runtime_table = self._tcgen05_uses_grouped_worklist_nm_runtime_table()
+        scheduler_mailbox = self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox()
+        runtime_clc = self._tcgen05_uses_grouped_worklist_nm_runtime_clc()
+        uses_pipeline = scheduler_mailbox or runtime_clc
+        assert runtime_table or scheduler_mailbox
+        assert (layout is not None) == uses_pipeline
+
+        linear_idx: str | None = None
+        grid_stride: str | None = None
+        records = grouped.runtime_tile_records
+        total_clusters = grouped.runtime_total_clusters
+        if runtime_table:
+            assert records is not None and total_clusters is not None
+            linear_idx = device_function.new_var(
+                f"{scheduler_var_prefix}_runtime_direct_linear_idx"
+            )
+            if not uses_pipeline:
+                grid_stride = device_function.new_var(
+                    f"{scheduler_var_prefix}_runtime_direct_grid_stride"
+                )
+
+        sched_pipeline: str | None = None
+        sched_consumer_state: str | None = None
+        valid_var: str | None = None
+        work_tile_stage_index: str | None = None
+        if uses_pipeline:
+            sched_pipeline_plan = self._tcgen05_sched_pipeline_plan()
+            assert sched_pipeline_plan is not None
+            sched_pipeline = sched_pipeline_plan.pipeline
+            sched_consumer_state = sched_pipeline_plan.consumer_state
+            valid_var = device_function.new_var(f"{scheduler_var_prefix}_valid")
+            work_tile_stage_index = (
+                f"{sched_consumer_state}.index"
+                if self._tcgen05_uses_staged_work_tile_mailbox()
+                else None
+            )
+
+        def consumer_wait_block() -> list[ast.stmt]:
+            assert layout is not None
+            assert sched_pipeline is not None and sched_consumer_state is not None
+            assert valid_var is not None
+            return _build_sched_pipeline_consumer_wait_block(
+                sched_pipeline=sched_pipeline,
+                sched_consumer_state=sched_consumer_state,
+                work_tile_smem=layout.work_tile_smem,
+                valid_var=valid_var,
+                valid_slot_index=(
+                    _TCGEN05_GROUPED_SELECTED_MAILBOX_VALID
+                    if scheduler_mailbox
+                    else _TCGEN05_WORK_TILE_MAILBOX_VALID
+                ),
+                work_tile_stage_index=work_tile_stage_index,
+            )
+
+        def consumer_release_block() -> list[ast.stmt]:
+            assert sched_pipeline is not None and sched_consumer_state is not None
+            return _build_sched_pipeline_consumer_release_block(
+                sched_pipeline=sched_pipeline,
+                sched_consumer_state=sched_consumer_state,
+            )
+
+        prelude: list[ast.stmt] = []
+        if (
+            emit_pdl_wait
+            and plan.is_two_cta
+            and role_block.role_predicate == self._tcgen05_tma_load_role_predicate()
+        ):
+            prelude.append(statement_from_string("cute.arch.griddepcontrol_wait()"))
+        if not uses_pipeline:
+            assert linear_idx is not None and grid_stride is not None
+            prelude.extend(
+                (
+                    statement_from_string(
+                        f"{linear_idx} = cutlass.Int32(cute.arch.block_idx()[2])"
+                    ),
+                    statement_from_string(
+                        f"{grid_stride} = cutlass.Int32(cute.arch.grid_dim()[2])"
+                    ),
+                )
+            )
+        tile_counter_var, increment_tile_counter_per_tile = (
+            self._finish_role_local_prelude(
+                device_function,
+                role_block,
+                prelude,
+                role_prelude_stmts=role_prelude_stmts,
+                initialize_tile_counter=initialize_tile_counter,
+            )
+        )
+        if uses_pipeline:
+            prelude.extend(consumer_wait_block())
+
+        epi_role = role_block.role_predicate == self._tcgen05_epi_role_predicate()
+        mma_exec_role = (
+            role_block.role_predicate == self._tcgen05_mma_exec_role_predicate()
+        )
+        tma_load_role = (
+            role_block.role_predicate == self._tcgen05_tma_load_role_predicate()
+        )
+        metadata_stmts: list[ast.stmt] = []
+        if runtime_table:
+            assert records is not None and linear_idx is not None
+
+            def record_load(field: int) -> str:
+                return (
+                    f"({records}.iterator + {linear_idx} * "
+                    f"cutlass.Int32({records}.layout.stride[0]) + "
+                    f"cutlass.Int32({field}) * "
+                    f"cutlass.Int32({records}.layout.stride[1])).load()"
+                )
+
+            if runtime_clc:
+                assert layout is not None
+                metadata_stmts.append(
+                    statement_from_string(
+                        f"{linear_idx} = {self._tcgen05_work_tile_slot(layout, 2)}"
+                    )
+                )
+                metadata_stmts.extend(consumer_release_block())
+            fields = (
+                (grouped.cta_tile_idx_m, Tcgen05GroupedRuntimeTileField.CTA_M),
+                (grouped.cta_tile_idx_n, Tcgen05GroupedRuntimeTileField.CTA_N),
+                (grouped.metadata_idx, Tcgen05GroupedRuntimeTileField.METADATA_IDX),
+                (grouped.group_idx, Tcgen05GroupedRuntimeTileField.GROUP_IDX),
+                (grouped.problem_m, Tcgen05GroupedRuntimeTileField.PROBLEM_M),
+                (grouped.problem_n, Tcgen05GroupedRuntimeTileField.PROBLEM_N),
+                (grouped.problem_k, Tcgen05GroupedRuntimeTileField.PROBLEM_K),
+                (
+                    grouped.global_m_start,
+                    Tcgen05GroupedRuntimeTileField.GLOBAL_M_START,
+                ),
+            )
+            metadata_stmts.extend(
+                statement_from_string(f"{name} = {record_load(field)}")
+                for name, field in fields
+            )
+            metadata_stmts.extend(
+                (
+                    statement_from_string(f"pid_0 = {grouped.cta_tile_idx_m}"),
+                    statement_from_string(f"pid_1 = {grouped.cta_tile_idx_n}"),
+                    statement_from_string(
+                        f"tile_offset_0 = {grouped.global_m_start} + "
+                        f"{grouped.cta_tile_idx_m} * "
+                        f"cutlass.Int32({plan.source_tile_m})"
+                    ),
+                    statement_from_string(
+                        f"tile_offset_1 = {grouped.cta_tile_idx_n} * "
+                        f"cutlass.Int32({plan.source_tile_n})"
+                    ),
+                )
+            )
+            if epi_role or mma_exec_role or (tma_load_role and plan.is_two_cta):
+                metadata_stmts.append(
+                    statement_from_string(
+                        f"{grouped.valid_m} = "
+                        f"{record_load(Tcgen05GroupedRuntimeTileField.VALID_M)}"
+                    )
+                )
+            if epi_role:
+                metadata_stmts.append(
+                    statement_from_string(
+                        f"{grouped.store_m} = "
+                        f"{record_load(Tcgen05GroupedRuntimeTileField.STORE_M)}"
+                    )
+                )
+        else:
+            assert layout is not None
+
+            def slot(field: int) -> str:
+                return self._tcgen05_work_tile_slot(layout, field)
+
+            mailbox_fields = (
+                (grouped.cta_tile_idx_m, _TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_M),
+                (grouped.cta_tile_idx_n, _TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_N),
+                (grouped.metadata_idx, _TCGEN05_GROUPED_SELECTED_MAILBOX_METADATA_IDX),
+                (grouped.group_idx, _TCGEN05_GROUPED_SELECTED_MAILBOX_GROUP_IDX),
+                (grouped.problem_m, _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_M),
+                (grouped.problem_n, _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_N),
+                (grouped.problem_k, _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_K),
+                (
+                    grouped.global_m_start,
+                    _TCGEN05_GROUPED_SELECTED_MAILBOX_GLOBAL_M_START,
+                ),
+            )
+            metadata_stmts.extend(
+                statement_from_string(f"{name} = {slot(field)}")
+                for name, field in mailbox_fields
+            )
+            if epi_role:
+                metadata_stmts.extend(
+                    self._grouped_worklist_nm_valid_store_m_stmts(device_function)
+                )
+            metadata_stmts.extend(
+                (
+                    statement_from_string(f"pid_0 = {grouped.cta_tile_idx_m}"),
+                    statement_from_string(f"pid_1 = {grouped.cta_tile_idx_n}"),
+                )
+            )
+            metadata_stmts.extend(consumer_release_block())
+
+        per_tile_body = [
+            *metadata_stmts,
+            *(
+                _clone_stmt(stmt)
+                for stmt in self._grouped_static_dependency_stmts(dependency_stmts)
+            ),
+            *(_clone_stmt(stmt) for stmt in role_block.stmts),
+        ]
+        if tile_counter_var is not None and increment_tile_counter_per_tile:
+            per_tile_body.append(
+                statement_from_string(
+                    f"{tile_counter_var} = {tile_counter_var} + cutlass.Int32(1)"
+                )
+            )
+        if uses_pipeline:
+            assert valid_var is not None
+            per_tile_body.extend(consumer_wait_block())
+            loop_test = valid_var
+        else:
+            assert linear_idx is not None
+            assert grid_stride is not None
+            assert total_clusters is not None
+            per_tile_body.append(
+                statement_from_string(f"{linear_idx} = {linear_idx} + {grid_stride}")
+            )
+            loop_test = f"{linear_idx} < {total_clusters}"
+        prelude.append(
+            create(
+                ast.While,
+                test=expr_from_string(loop_test),
+                body=per_tile_body,
+                orelse=[],
+            )
+        )
+        if uses_pipeline:
+            prelude.extend(consumer_release_block())
+        return create(
+            ast.If,
+            test=expr_from_string(role_block.role_predicate),
+            body=prelude,
+            orelse=[],
+        )
+
     def _build_generic_grouped_static_role_local_while(
         self,
         device_function: DeviceFunction,
@@ -3352,10 +3659,21 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         scheduler_var_prefix: str,
         dependency_stmts: list[ast.stmt] | None,
         role_prelude_stmts: list[ast.stmt] | None = None,
+        emit_pdl_wait: bool = True,
         initialize_tile_counter: bool = True,
     ) -> ast.stmt:
         plan = self._tcgen05_plan()
         assert plan is not None and plan.grouped is not None
+        if self._tcgen05_uses_grouped_worklist_nm_runtime_direct():
+            return self._build_grouped_worklist_nm_role_local_while(
+                device_function,
+                role_block,
+                scheduler_var_prefix=scheduler_var_prefix,
+                dependency_stmts=dependency_stmts,
+                role_prelude_stmts=role_prelude_stmts,
+                initialize_tile_counter=initialize_tile_counter,
+                emit_pdl_wait=emit_pdl_wait,
+            )
         shapes = plan.grouped.static_problem_shapes
         if (
             shapes is None
@@ -3397,142 +3715,6 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             ),
             body=[specialized],
             orelse=[generic],
-        )
-
-    def _build_grouped_static_role_local_while_with_scheduler(
-        self,
-        device_function: DeviceFunction,
-        layout: Tcgen05PersistentProgramIDs._Tcgen05PersistentLayout,
-        role_block: Tcgen05PersistentProgramIDs._PersistentRoleBlock,
-        *,
-        scheduler_var_prefix: str,
-        dependency_stmts: list[ast.stmt] | None,
-        role_prelude_stmts: list[ast.stmt] | None = None,
-        emit_pdl_wait: bool = True,
-        initialize_tile_counter: bool = True,
-    ) -> ast.stmt:
-        assert role_block.role_predicate is not None
-        assert self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox()
-        plan = self._tcgen05_plan()
-        assert plan is not None
-        grouped = plan.grouped
-        assert grouped is not None
-        sched_pipeline_plan = self._tcgen05_sched_pipeline_plan()
-        assert sched_pipeline_plan is not None
-
-        sched_pipeline = sched_pipeline_plan.pipeline
-        sched_consumer_state = sched_pipeline_plan.consumer_state
-        valid_var = device_function.new_var(f"{scheduler_var_prefix}_valid")
-
-        prelude: list[ast.stmt] = []
-        if (
-            emit_pdl_wait
-            and self._tcgen05_is_two_cta()
-            and role_block.role_predicate == self._tcgen05_tma_load_role_predicate()
-        ):
-            prelude.append(statement_from_string("cute.arch.griddepcontrol_wait()"))
-
-        tile_counter_var, increment_tile_counter_per_tile = (
-            self._finish_role_local_prelude(
-                device_function,
-                role_block,
-                prelude,
-                role_prelude_stmts=role_prelude_stmts,
-                initialize_tile_counter=initialize_tile_counter,
-            )
-        )
-
-        work_tile_stage_index = (
-            f"{sched_consumer_state}.index"
-            if self._tcgen05_uses_staged_work_tile_mailbox()
-            else None
-        )
-
-        def slot(i: int) -> str:
-            return self._tcgen05_work_tile_slot(layout, i)
-
-        def _consumer_wait_block() -> list[ast.stmt]:
-            return _build_sched_pipeline_consumer_wait_block(
-                sched_pipeline=sched_pipeline,
-                sched_consumer_state=sched_consumer_state,
-                work_tile_smem=layout.work_tile_smem,
-                valid_var=valid_var,
-                valid_slot_index=_TCGEN05_GROUPED_SELECTED_MAILBOX_VALID,
-                work_tile_stage_index=work_tile_stage_index,
-            )
-
-        def _consumer_release_block() -> list[ast.stmt]:
-            return _build_sched_pipeline_consumer_release_block(
-                sched_pipeline=sched_pipeline,
-                sched_consumer_state=sched_consumer_state,
-            )
-
-        epi_role = role_block.role_predicate == self._tcgen05_epi_role_predicate()
-        mma_exec_role = (
-            role_block.role_predicate == self._tcgen05_mma_exec_role_predicate()
-        )
-        tma_load_role = (
-            role_block.role_predicate == self._tcgen05_tma_load_role_predicate()
-        )
-        grouped_valid_store_m_stmts = (
-            self._grouped_worklist_nm_valid_store_m_stmts(
-                device_function,
-                include_store_m=epi_role,
-            )
-            if epi_role or mma_exec_role or tma_load_role
-            else []
-        )
-        mailbox_fields = (
-            (grouped.cta_tile_idx_m, _TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_M),
-            (grouped.cta_tile_idx_n, _TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_N),
-            (grouped.metadata_idx, _TCGEN05_GROUPED_SELECTED_MAILBOX_METADATA_IDX),
-            (grouped.group_idx, _TCGEN05_GROUPED_SELECTED_MAILBOX_GROUP_IDX),
-            (grouped.problem_m, _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_M),
-            (grouped.problem_n, _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_N),
-            (grouped.problem_k, _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_K),
-            (
-                grouped.global_m_start,
-                _TCGEN05_GROUPED_SELECTED_MAILBOX_GLOBAL_M_START,
-            ),
-        )
-        grouped_metadata_read_stmts = [
-            statement_from_string(f"{name} = {slot(field)}")
-            for name, field in mailbox_fields
-        ]
-        grouped_metadata_read_stmts.extend(grouped_valid_store_m_stmts)
-        grouped_metadata_read_stmts.extend(
-            [
-                statement_from_string(f"pid_0 = {grouped.cta_tile_idx_m}"),
-                statement_from_string(f"pid_1 = {grouped.cta_tile_idx_n}"),
-            ]
-        )
-
-        prelude.extend(_consumer_wait_block())
-        per_tile_body: list[ast.stmt] = grouped_metadata_read_stmts
-        per_tile_body.extend(_consumer_release_block())
-        per_tile_body.extend(self._grouped_static_dependency_stmts(dependency_stmts))
-        per_tile_body.extend(role_block.stmts)
-        if tile_counter_var is not None and increment_tile_counter_per_tile:
-            per_tile_body.append(
-                statement_from_string(
-                    f"{tile_counter_var} = {tile_counter_var} + cutlass.Int32(1)"
-                )
-            )
-        per_tile_body.extend(_consumer_wait_block())
-        prelude.append(
-            create(
-                ast.While,
-                test=expr_from_string(valid_var),
-                body=per_tile_body,
-                orelse=[],
-            )
-        )
-        prelude.extend(_consumer_release_block())
-        return create(
-            ast.If,
-            test=expr_from_string(role_block.role_predicate),
-            body=prelude,
-            orelse=[],
         )
 
     def _build_role_local_while_with_scheduler(
@@ -3747,7 +3929,6 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         source_m_fast_linear_var = device_function.new_var(
             "tcgen05_grouped_selected_source_m_fast_linear"
         )
-
         leader_predicate = "cute.arch.lane_idx() == cutlass.Int32(0)"
 
         def slot(i: int) -> str:
@@ -3799,15 +3980,22 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                     f"cutlass.Int32({source_tile_m})"
                 )
             )
-            return [
+            tile_count_stmts = [
                 statement_from_string(f"{source_n_tiles_var} = {source_n_tiles_expr}"),
                 statement_from_string(f"{source_m_tiles_var} = {source_m_tiles_expr}"),
+            ]
+            return [
+                *tile_count_stmts,
                 create(
                     ast.If,
                     test=expr_from_string(
-                        f"{source_m_tiles_var} <= {source_n_tiles_var}"
+                        f"cutlass.Int32(0) < {source_m_tiles_var} <= "
+                        f"{source_n_tiles_var}"
                     ),
                     body=[
+                        # The CUTLASS group search excludes zero-tile groups;
+                        # retain an explicit positive-divisor guard so that
+                        # source-M rasterization cannot regress to modulo zero.
                         # For wide compact rows, walk source-M fastest to keep
                         # adjacent CTAs on nearby packed-A rows.
                         statement_from_string(
@@ -3971,6 +4159,10 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         """
         plan = self._tcgen05_plan()
         assert plan is not None and plan.has_scheduler_warp
+        if self._tcgen05_uses_grouped_worklist_nm_runtime_clc():
+            return self._build_scheduler_warp_role_local_while_clc(
+                device_function, layout
+            )
         if self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox():
             return self._build_grouped_worklist_nm_scheduler_warp_role_local_while(
                 device_function, layout
@@ -4228,6 +4420,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         """
         plan = self._tcgen05_plan()
         assert plan is not None and plan.has_scheduler_warp and plan.is_clc_persistent
+        runtime_table_clc = self._tcgen05_uses_grouped_worklist_nm_runtime_clc()
         sched_plan = self._tcgen05_sched_pipeline_plan()
         assert sched_plan is not None
         sched_pipeline = sched_plan.pipeline
@@ -4297,41 +4490,63 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         # ``valid_var`` is Int32 because ``cute.arch.clc_response``
         # returns Int32 for the valid flag. The CuTe DSL's while-region
         # type-checker rejects type changes between iterations.
-        sched_params_var = device_function.new_var("tcgen05_clc_initial_sched_params")
-        sched_var = device_function.new_var("tcgen05_clc_initial_sched")
-        work_tile_var = device_function.new_var("tcgen05_clc_initial_work_tile")
-        clc_initial_block = [
-            # Build the persistent tile-scheduler params for the
-            # initial decode. ``layout.cluster_m/n`` agrees with the
-            # launch grid's cluster shape ``(cluster_m, cluster_n, 1)``.
-            statement_from_string(
-                f"{sched_params_var} = cutlass.utils.PersistentTileSchedulerParams("
-                f"{self._tcgen05_persistent_tile_sched_params_args(cluster_m=layout.cluster_m, cluster_n=layout.cluster_n)})"
-            ),
-            statement_from_string(
-                f"{sched_var} = cutlass.utils.StaticPersistentTileScheduler.create("
-                f"{sched_params_var}, cute.arch.block_idx(), cute.arch.grid_dim())"
-            ),
-            statement_from_string(
-                f"{work_tile_var} = {sched_var}.initial_work_tile_info()"
-            ),
-            # Bind the initial cluster coords from the static
-            # scheduler's decode. ``tile_idx[0]`` is already the
-            # per-CTA M coordinate (= cluster_id_m * cluster_m +
-            # cta_in_cluster_m) since the static scheduler folds the
-            # cta_in_cluster offset in via
-            # ``_get_current_work_for_linear_idx``.
-            statement_from_string(f"{cluster_bidx_var} = {work_tile_var}.tile_idx[0]"),
-            statement_from_string(f"{cluster_bidy_var} = {work_tile_var}.tile_idx[1]"),
-            statement_from_string(f"{cluster_bidz_var} = {work_tile_var}.tile_idx[2]"),
-            # Initial valid flag: the scheduler warp only runs if
-            # the launcher placed it on a valid cluster. The CLC
-            # query handles invalidation for subsequent waves.
-            statement_from_string(
-                f"{valid_var} = cutlass.Int32(1) "
-                f"if {work_tile_var}.is_valid_tile else cutlass.Int32(0)"
-            ),
-        ]
+        sched_var: str | None = None
+        if runtime_table_clc:
+            clc_initial_block = [
+                # The runtime table has exactly one row per launched cluster.
+                # Keep the raw z CTAID as the record index; the x CTAID differs
+                # between the two peers and must not participate in table lookup.
+                statement_from_string(f"{cluster_bidx_var} = cutlass.Int32(0)"),
+                statement_from_string(f"{cluster_bidy_var} = cutlass.Int32(0)"),
+                statement_from_string(
+                    f"{cluster_bidz_var} = cutlass.Int32(cute.arch.block_idx()[2])"
+                ),
+                statement_from_string(f"{valid_var} = cutlass.Int32(1)"),
+            ]
+        else:
+            sched_params_var = device_function.new_var(
+                "tcgen05_clc_initial_sched_params"
+            )
+            sched_var = device_function.new_var("tcgen05_clc_initial_sched")
+            work_tile_var = device_function.new_var("tcgen05_clc_initial_work_tile")
+            clc_initial_block = [
+                # Build the persistent tile-scheduler params for the
+                # initial decode. ``layout.cluster_m/n`` agrees with the
+                # launch grid's cluster shape ``(cluster_m, cluster_n, 1)``.
+                statement_from_string(
+                    f"{sched_params_var} = cutlass.utils.PersistentTileSchedulerParams("
+                    f"{self._tcgen05_persistent_tile_sched_params_args(cluster_m=layout.cluster_m, cluster_n=layout.cluster_n)})"
+                ),
+                statement_from_string(
+                    f"{sched_var} = cutlass.utils.StaticPersistentTileScheduler.create("
+                    f"{sched_params_var}, cute.arch.block_idx(), cute.arch.grid_dim())"
+                ),
+                statement_from_string(
+                    f"{work_tile_var} = {sched_var}.initial_work_tile_info()"
+                ),
+                # Bind the initial cluster coords from the static
+                # scheduler's decode. ``tile_idx[0]`` is already the
+                # per-CTA M coordinate (= cluster_id_m * cluster_m +
+                # cta_in_cluster_m) since the static scheduler folds the
+                # cta_in_cluster offset in via
+                # ``_get_current_work_for_linear_idx``.
+                statement_from_string(
+                    f"{cluster_bidx_var} = {work_tile_var}.tile_idx[0]"
+                ),
+                statement_from_string(
+                    f"{cluster_bidy_var} = {work_tile_var}.tile_idx[1]"
+                ),
+                statement_from_string(
+                    f"{cluster_bidz_var} = {work_tile_var}.tile_idx[2]"
+                ),
+                # Initial valid flag: the scheduler warp only runs if
+                # the launcher placed it on a valid cluster. The CLC
+                # query handles invalidation for subsequent waves.
+                statement_from_string(
+                    f"{valid_var} = cutlass.Int32(1) "
+                    f"if {work_tile_var}.is_valid_tile else cutlass.Int32(0)"
+                ),
+            ]
 
         # Per-tile publish: write (bidx, bidy, bidz, valid) into the
         # work-tile mailbox.
@@ -4467,7 +4682,6 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         # would have computed for the same cluster id, so the
         # consumer's ``virtual_pid = work_tile_smem[0] // cluster_m``
         # collapse continues to work.
-        next_work_tile_var = device_function.new_var("tcgen05_clc_next_work_tile")
         clc_helper_call = "_cute_issue_clc_query_nomulticast"
         clc_query_block = [
             statement_from_string("cute.arch.sync_warp()"),
@@ -4498,20 +4712,37 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 f"cute.arch.clc_response({clc_response_smem_ptr})"
             ),
             statement_from_string("cute.arch.fence_view_async_shared()"),
-            statement_from_string(f"{sched_var}._current_work_linear_idx = {bidz_var}"),
-            statement_from_string(
-                f"{next_work_tile_var} = {sched_var}.get_current_work()"
-            ),
-            statement_from_string(
-                f"{cluster_bidx_var} = {next_work_tile_var}.tile_idx[0]"
-            ),
-            statement_from_string(
-                f"{cluster_bidy_var} = {next_work_tile_var}.tile_idx[1]"
-            ),
-            statement_from_string(
-                f"{cluster_bidz_var} = {next_work_tile_var}.tile_idx[2]"
-            ),
         ]
+        if runtime_table_clc:
+            clc_query_block.extend(
+                [
+                    statement_from_string(f"{cluster_bidx_var} = {bidx_var}"),
+                    statement_from_string(f"{cluster_bidy_var} = {bidy_var}"),
+                    statement_from_string(f"{cluster_bidz_var} = {bidz_var}"),
+                ]
+            )
+        else:
+            assert sched_var is not None
+            next_work_tile_var = device_function.new_var("tcgen05_clc_next_work_tile")
+            clc_query_block.extend(
+                [
+                    statement_from_string(
+                        f"{sched_var}._current_work_linear_idx = {bidz_var}"
+                    ),
+                    statement_from_string(
+                        f"{next_work_tile_var} = {sched_var}.get_current_work()"
+                    ),
+                    statement_from_string(
+                        f"{cluster_bidx_var} = {next_work_tile_var}.tile_idx[0]"
+                    ),
+                    statement_from_string(
+                        f"{cluster_bidy_var} = {next_work_tile_var}.tile_idx[1]"
+                    ),
+                    statement_from_string(
+                        f"{cluster_bidz_var} = {next_work_tile_var}.tile_idx[2]"
+                    ),
+                ]
+            )
 
         # ``per_tile_publish_warp`` already does its own per-lane
         # gating internally (lane-0-only commit for cluster_m=1, the
@@ -5927,11 +6158,16 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             and plan.grouped.device_split_sizes
         )
         if device_split_sizes:
+            # Device-split N,M derives group coordinates from the runtime split
+            # tensor rather than replacing a host segment-worklist scaffold.
+            # Keep the original fail-closed omission allowlist for this path;
+            # only host worklists/runtime tables may discard the extra segment
+            # coordinate writes below.
             return self._tcgen05_unsafe_shared_stmts(partition)
         worklist_metadata = bool(
             plan is not None
             and plan.grouped is not None
-            and plan.grouped.real_groups is not None
+            and plan.accumulator_view == "nm"
         )
         allowed_coord_writes = {
             "virtual_pid",

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -33,9 +33,14 @@ import weakref
 import torch
 
 from ... import exc
+from ..._compiler.cute.device_state import Tcgen05GroupedSchedulerMode
 from ..._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from ..._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from ..._compiler.cute.strategies import tcgen05_smem_layout_expr
+from ..._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS,
+)
+from ..._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_RUNTIME_TILE_FIELD_COUNT
 from ..._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
 )
@@ -44,6 +49,7 @@ from ..._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES,
 )
 from ..._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
+from ..._compiler.cute.tcgen05_constants import Tcgen05GroupedRuntimeTileField
 from ..triton.launcher import get_num_sm
 
 if TYPE_CHECKING:
@@ -215,6 +221,47 @@ def _tcgen05_grouped_dynamic_ab_tensormap_rank(plan: dict[str, object]) -> int:
             "requires dynamic or fixed full-allocation A/B TensorMaps",
         )
     return rank
+
+
+def _tcgen05_grouped_scheduler_mode(
+    plan: dict[str, object],
+) -> Tcgen05GroupedSchedulerMode:
+    value = plan.get("scheduler_mode", Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH)
+    mode: Tcgen05GroupedSchedulerMode | None = None
+    if isinstance(value, Tcgen05GroupedSchedulerMode):
+        mode = value
+    elif isinstance(value, str):
+        with suppress(ValueError):
+            mode = Tcgen05GroupedSchedulerMode(value)
+    if mode is None:
+        choices = ", ".join(
+            candidate.value for candidate in Tcgen05GroupedSchedulerMode
+        )
+        raise exc.BackendUnsupported(
+            "cute",
+            f"tcgen05 grouped scheduler mode must be one of: {choices}",
+        )
+    uses_runtime_table = mode in (
+        Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+        Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
+    )
+    has_runtime_table = isinstance(plan.get("runtime_tile_records_arg"), str)
+    if uses_runtime_table != has_runtime_table:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped runtime scheduler state requires matching tile-table metadata",
+        )
+    if uses_runtime_table and _tcgen05_plan_orientation(plan) != "nm":
+        raise exc.BackendUnsupported(
+            "cute", "tcgen05 grouped runtime scheduling requires N,M orientation"
+        )
+    if mode is Tcgen05GroupedSchedulerMode.RUNTIME_CLC and not bool(
+        plan.get("fixed_tensormaps")
+    ):
+        raise exc.BackendUnsupported(
+            "cute", "grouped runtime CLC requires fixed full-allocation TensorMaps"
+        )
+    return mode
 
 
 def _append_cute_wrapper_plan(
@@ -705,12 +752,19 @@ def _append_cute_wrapper_plan(
             )
         )
         quotas: tuple[int, ...] = ()
+        scheduler_mode = _tcgen05_grouped_scheduler_mode(plan)
+        runtime_direct_tile_table = scheduler_mode in (
+            Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+            Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
+        )
+        runtime_direct_clc = scheduler_mode is Tcgen05GroupedSchedulerMode.RUNTIME_CLC
         if quota_args:
-            assert cluster_m == 1 and cluster_n == 1
             problem_shapes = cast(
                 "tuple[tuple[int, int, int], ...]", plan["static_problem_shapes"]
             )
             assert len(quota_args) == len(problem_shapes)
+            assert _tcgen05_plan_orientation(plan) != "nm"
+            assert cluster_m == 1 and cluster_n == 1
             quotas = _tcgen05_grouped_static_quotas(
                 problem_shapes,
                 bm=plan_int("bm"),
@@ -718,24 +772,40 @@ def _append_cute_wrapper_plan(
                 bk=plan_int("bk"),
                 max_active_clusters=max_active_clusters,
             )
-        body.extend(
-            (
+        if runtime_direct_clc:
+            # The host table is exact: one real output record per z cluster, with
+            # no padded/phantom tail. Launching the full request grid lets CLC
+            # cancel each pending z cluster at most once and makes response bidz
+            # the record index consumed identically by every CTA in the cluster.
+            body.extend(
                 (
-                    f"    {sched_params_arg} = cutlass.utils.PersistentTileSchedulerParams("
-                    f"({cluster_m}, {cluster_n}, {total_clusters_arg}), "
-                    f"({cluster_m}, {cluster_n}, 1))"
-                ),
-                (
-                    "    _tcgen05_grouped_grid = "
-                    "cutlass.utils.StaticPersistentGroupTileScheduler.get_grid_shape("
-                    f"{sched_params_arg}, cutlass.Int32({max_active_clusters}))"
-                ),
-                "    grid_x = _tcgen05_grouped_grid[0]",
-                "    grid_y = _tcgen05_grouped_grid[1]",
-                "    grid_z = _tcgen05_grouped_grid[2]",
+                    f"    grid_x = cutlass.Int32({cluster_m})",
+                    f"    grid_y = cutlass.Int32({cluster_n})",
+                    f"    grid_z = {total_clusters_arg}",
+                )
             )
-        )
-        call_args.append(sched_params_arg)
+        else:
+            body.append(
+                f"    {sched_params_arg} = cutlass.utils.PersistentTileSchedulerParams("
+                f"({cluster_m}, {cluster_n}, {total_clusters_arg}), "
+                f"({cluster_m}, {cluster_n}, 1))"
+            )
+            body.extend(
+                (
+                    (
+                        "    _tcgen05_grouped_grid = "
+                        "cutlass.utils.StaticPersistentGroupTileScheduler.get_grid_shape("
+                        f"{sched_params_arg}, cutlass.Int32({max_active_clusters}))"
+                    ),
+                    "    grid_x = _tcgen05_grouped_grid[0]",
+                    "    grid_y = _tcgen05_grouped_grid[1]",
+                    "    grid_z = _tcgen05_grouped_grid[2]",
+                )
+            )
+            if not runtime_direct_tile_table:
+                call_args.append(sched_params_arg)
+        if runtime_direct_tile_table:
+            call_args.append(total_clusters_arg)
         call_args.extend(f"cutlass.Int32({quota})" for quota in quotas)
         return
     if kind != "tcgen05_ab_tma":
@@ -1174,6 +1244,39 @@ def _create_cute_wrapper(
                 f"({stride_literals[0]},)"
                 if rank == 1
                 else f"({', '.join(stride_literals)})"
+            )
+            body.append(
+                f"    {name} = cute.make_tensor({ptr_name}, layout=cute.make_layout({shape_tuple}, stride={stride_tuple}))"
+            )
+            call_args.append(name)
+            continue
+
+        if kind == "wrapper_tensor_runtime_leading_extent":
+            (_, name, _dtype, rank, tail_sizes, strides) = entry
+            assert isinstance(name, str)
+            assert isinstance(rank, int)
+            assert isinstance(tail_sizes, tuple) and len(tail_sizes) == rank - 1
+            assert isinstance(strides, tuple) and len(strides) == rank
+            ptr_name = f"{name}_ptr"
+            leading_extent_name = f"{name}_shape0"
+            params.extend(
+                (
+                    f"{ptr_name}: cute.Pointer",
+                    f"{leading_extent_name}: cutlass.Int64",
+                )
+            )
+            shape_values = [
+                leading_extent_name,
+                *(repr(int(size)) for size in tail_sizes),
+            ]
+            stride_values = [repr(int(stride)) for stride in strides]
+            shape_tuple = (
+                f"({shape_values[0]},)" if rank == 1 else f"({', '.join(shape_values)})"
+            )
+            stride_tuple = (
+                f"({stride_values[0]},)"
+                if rank == 1
+                else f"({', '.join(stride_values)})"
             )
             body.append(
                 f"    {name} = cute.make_tensor({ptr_name}, layout=cute.make_layout({shape_tuple}, stride={stride_tuple}))"
@@ -1792,18 +1895,24 @@ def cute_cuda_graph(
 
 @dataclass(frozen=True)
 class _Tcgen05GroupedStaticMetadataResult:
-    problem_sizes: torch.Tensor
-    starts: torch.Tensor
+    problem_sizes: torch.Tensor | None
+    starts: torch.Tensor | None
     total_clusters: int
     real_groups: torch.Tensor | None = None
+    runtime_tile_records: torch.Tensor | None = None
     direct_pointers: torch.Tensor | None = None
     direct_strides: torch.Tensor | None = None
 
     def tensors(self) -> tuple[torch.Tensor, ...]:
         return (
-            self.problem_sizes,
-            self.starts,
+            *((self.problem_sizes,) if self.problem_sizes is not None else ()),
+            *((self.starts,) if self.starts is not None else ()),
             *((self.real_groups,) if self.real_groups is not None else ()),
+            *(
+                (self.runtime_tile_records,)
+                if self.runtime_tile_records is not None
+                else ()
+            ),
             *((self.direct_pointers,) if self.direct_pointers is not None else ()),
             *((self.direct_strides,) if self.direct_strides is not None else ()),
         )
@@ -2669,6 +2778,11 @@ def _validate_tcgen05_grouped_dynamic_ab_tensormaps(
         and rhs.stride(2) == rhs.size(1)
         and rhs.stride(0) == rhs.size(1) * rhs.size(2)
     )
+    if rhs_mn_contiguous and _tcgen05_plan_orientation(plan) != "nm":
+        raise exc.BackendUnsupported(
+            "cute",
+            "MN-major grouped B is validated only for the N,M worklist path",
+        )
     if not (rhs_k_contiguous or rhs_mn_contiguous):
         raise exc.BackendUnsupported(
             "cute",
@@ -2835,6 +2949,30 @@ def _validate_tcgen05_grouped_worklist_nm(
                 "tcgen05 N,M worklist requires group starts aligned "
                 f"to {source_m_tile} rows",
             )
+        if actual_m < 0 or actual_m > aligned_m:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist requires 0 <= actual_m <= aligned_m",
+            )
+        if aligned_m < 0 or aligned_m % source_m_tile != 0:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist requires aligned_m to be a "
+                f"nonnegative multiple of {source_m_tile}",
+            )
+        if (actual_m == 0) != (aligned_m == 0):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist requires actual_m and aligned_m to be "
+                "zero together",
+            )
+        if start + aligned_m > int(lhs.size(0)):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist aligned extent exceeds A extent",
+            )
+        if aligned_m == 0:
+            continue
         if start < expected_store_end:
             raise exc.BackendUnsupported(
                 "cute",
@@ -2844,22 +2982,6 @@ def _validate_tcgen05_grouped_worklist_nm(
             raise exc.BackendUnsupported(
                 "cute",
                 "tcgen05 N,M worklist has row holes",
-            )
-        if actual_m <= 0 or actual_m > aligned_m:
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist requires 0 < actual_m <= aligned_m",
-            )
-        if aligned_m <= 0 or aligned_m % source_m_tile != 0:
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist requires aligned_m to be a "
-                f"positive multiple of {source_m_tile}",
-            )
-        if start + aligned_m > int(lhs.size(0)):
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist aligned extent exceeds A extent",
             )
         expected_store_end = start + aligned_m
     if expected_store_end != int(lhs.size(0)):
@@ -2872,6 +2994,124 @@ def _validate_tcgen05_grouped_worklist_nm(
             "cute",
             "tcgen05 N,M worklist requires dense real group ids",
         )
+
+
+def _validate_tcgen05_grouped_runtime_direct_clc_grid(total_clusters: int) -> None:
+    if total_clusters > TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped runtime-direct CLC requires at most "
+            f"{TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS} exact tile "
+            "records because CUDA grid.z is "
+            "limited to 65535",
+        )
+
+
+def _tcgen05_grouped_runtime_nm_tile_records(
+    worklist_rows: list[list[int]],
+    problem_sizes: list[tuple[int, int, int, int]],
+    *,
+    source_tile_m: int,
+    source_tile_n: int,
+    l2_swizzle_size: int,
+) -> torch.Tensor:
+    """Expand runtime per-group worklist rows into logical N,M tile records."""
+    metadata: list[tuple[int, ...]] = []
+    tile_counts: list[int] = []
+    for row, problem_size in zip(worklist_rows, problem_sizes, strict=True):
+        real_group, global_m_start, actual_m, aligned_m = (int(value) for value in row)
+        problem_n, problem_m, problem_k, batch = problem_size
+        if batch != 1 or problem_m != aligned_m:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped runtime N,M tile records require batch 1 and "
+                "problem M matching the aligned worklist extent",
+            )
+        m_tiles = aligned_m // source_tile_m
+        n_tiles = (problem_n + source_tile_n - 1) // source_tile_n
+        metadata.append(
+            (
+                real_group,
+                global_m_start,
+                actual_m,
+                aligned_m,
+                problem_n,
+                problem_k,
+                m_tiles,
+                n_tiles,
+            )
+        )
+        tile_counts.append(m_tiles * n_tiles)
+
+    total_tiles = sum(tile_counts)
+    metadata_tensor = torch.tensor(metadata, dtype=torch.int32)
+    counts = torch.tensor(tile_counts, dtype=torch.int64)
+    metadata_idx = torch.repeat_interleave(
+        torch.arange(len(metadata), dtype=torch.int64), counts
+    )
+    group_starts = torch.repeat_interleave(counts.cumsum(0) - counts, counts)
+    local_idx = torch.arange(total_tiles, dtype=torch.int64) - group_starts
+    selected = metadata_tensor[metadata_idx]
+    (
+        real_group,
+        global_m_start,
+        actual_m,
+        aligned_m,
+        problem_n,
+        problem_k,
+        m_tiles,
+        n_tiles,
+    ) = (selected[:, field] for field in range(8))
+    # CUTLASS scheduling excludes zero-tile groups: repeat_interleave omits their
+    # zero-count rows, so every source-M raster divisor below is strictly positive.
+    if l2_swizzle_size > 1:
+        panel_size = torch.minimum(torch.full_like(n_tiles, l2_swizzle_size), n_tiles)
+        panel_span = panel_size * m_tiles
+        panel_idx = torch.div(local_idx, panel_span, rounding_mode="floor")
+        panel_linear = local_idx % panel_span
+        panel_width = torch.minimum(panel_size, n_tiles - panel_idx * panel_size)
+        cta_tile_idx_m = torch.div(panel_linear, panel_width, rounding_mode="floor")
+        cta_tile_idx_n = panel_idx * panel_size + panel_linear % panel_width
+        cta_tile_idx_m = torch.where(
+            panel_idx % 2 == 1,
+            m_tiles - 1 - cta_tile_idx_m,
+            cta_tile_idx_m,
+        )
+    else:
+        m_first = m_tiles <= n_tiles
+        cta_tile_idx_m = torch.where(
+            m_first,
+            local_idx % m_tiles,
+            torch.div(local_idx, n_tiles, rounding_mode="floor"),
+        )
+        cta_tile_idx_n = torch.where(
+            m_first,
+            torch.div(local_idx, m_tiles, rounding_mode="floor"),
+            local_idx % n_tiles,
+        )
+    tile_start = cta_tile_idx_m * source_tile_m
+    # STORE_M remains explicit for parity with the mailbox/device schema.
+    # Host-expanded rows always reserve one full physical source tile.
+    columns = {
+        Tcgen05GroupedRuntimeTileField.CTA_M: cta_tile_idx_m,
+        Tcgen05GroupedRuntimeTileField.CTA_N: cta_tile_idx_n,
+        Tcgen05GroupedRuntimeTileField.METADATA_IDX: metadata_idx,
+        Tcgen05GroupedRuntimeTileField.GROUP_IDX: real_group,
+        Tcgen05GroupedRuntimeTileField.PROBLEM_M: aligned_m,
+        Tcgen05GroupedRuntimeTileField.PROBLEM_N: problem_n,
+        Tcgen05GroupedRuntimeTileField.PROBLEM_K: problem_k,
+        Tcgen05GroupedRuntimeTileField.GLOBAL_M_START: global_m_start,
+        Tcgen05GroupedRuntimeTileField.VALID_M: (actual_m - tile_start).clamp(
+            0, source_tile_m
+        ),
+        Tcgen05GroupedRuntimeTileField.STORE_M: torch.full_like(
+            cta_tile_idx_m, source_tile_m
+        ),
+    }
+    return torch.stack(
+        tuple(columns[field] for field in Tcgen05GroupedRuntimeTileField),
+        dim=1,
+    ).to(torch.int32)
 
 
 def _tcgen05_grouped_static_metadata_cache_key(
@@ -3085,6 +3325,11 @@ def _build_tcgen05_grouped_static_metadata(
     else:
         worklist_m_tile = scheduler_bm = bm
         scheduler_bn = bn
+    scheduler_mode = _tcgen05_grouped_scheduler_mode(plan)
+    runtime_direct_tile_table = scheduler_mode in (
+        Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+        Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
+    )
     dynamic_ab_tensormaps = bool(plan.get("dynamic_ab_tensormaps"))
     dynamic_d_tensormap = bool(plan.get("dynamic_d_tensormap"))
     fixed_tensormaps = bool(plan.get("fixed_tensormaps"))
@@ -3190,6 +3435,7 @@ def _build_tcgen05_grouped_static_metadata(
     sizes: list[int] = []
     has_m_tail = False
     real_groups: list[int] | None = [] if worklist_metadata else None
+    worklist_rows: list[list[int]] | None = None
     if worklist_metadata:
         if int(layout.size(0)) != group_count:
             raise exc.BackendUnsupported(
@@ -3203,9 +3449,9 @@ def _build_tcgen05_grouped_static_metadata(
             )
         lhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A")
         rhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B")
-        rows = cast("list[list[int]]", layout.detach().cpu().tolist())
-        _validate_tcgen05_grouped_worklist_nm(plan, args, rows)
-        for row in rows:
+        worklist_rows = cast("list[list[int]]", layout.detach().cpu().tolist())
+        _validate_tcgen05_grouped_worklist_nm(plan, args, worklist_rows)
+        for row in worklist_rows:
             real_group, start, valid_m, reserved_or_store_m = (
                 int(value) for value in row
             )
@@ -3301,6 +3547,13 @@ def _build_tcgen05_grouped_static_metadata(
                 "last ordered group",
             )
 
+    if not any(sizes):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped scheduler does not launch an all-empty worklist; "
+            "all groups are empty, so the caller must skip the GEMM invocation",
+        )
+
     problem_sizes = []
     total_clusters = 0
     has_n_tail = False
@@ -3360,6 +3613,8 @@ def _build_tcgen05_grouped_static_metadata(
         raise exc.BackendUnsupported(
             "cute", "tcgen05 grouped scheduler found zero work clusters"
         )
+    if scheduler_mode is Tcgen05GroupedSchedulerMode.RUNTIME_CLC:
+        _validate_tcgen05_grouped_runtime_direct_clc_grid(total_clusters)
     expected_has_m_tail = plan.get("grouped_static_has_m_tail")
     if isinstance(expected_has_m_tail, bool) and has_m_tail != expected_has_m_tail:
         raise exc.BackendUnsupported(
@@ -3498,18 +3753,52 @@ def _build_tcgen05_grouped_static_metadata(
             direct_strides_tensor = torch.tensor(
                 direct_stride_rows, dtype=torch.int32, device=device
             )
-    problem_tensor = torch.tensor(problem_sizes, dtype=torch.int32, device=device)
-    starts_tensor = torch.tensor(starts, dtype=torch.int32, device=device)
-    real_groups_tensor = (
-        torch.tensor(real_groups, dtype=torch.int32, device=device)
-        if real_groups is not None
-        else None
-    )
+    problem_tensor: torch.Tensor | None = None
+    starts_tensor: torch.Tensor | None = None
+    real_groups_tensor: torch.Tensor | None = None
+    if not runtime_direct_tile_table:
+        problem_tensor = torch.tensor(problem_sizes, dtype=torch.int32, device=device)
+        starts_tensor = torch.tensor(starts, dtype=torch.int32, device=device)
+        if real_groups is not None:
+            real_groups_tensor = torch.tensor(
+                real_groups, dtype=torch.int32, device=device
+            )
+    runtime_tile_records_tensor: torch.Tensor | None = None
+    if runtime_direct_tile_table:
+        if not worklist_nm or worklist_rows is None:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped runtime tile tables require N,M worklist metadata",
+            )
+        l2_swizzle_size = _plan_int_value(plan, "l2_swizzle_size")
+        runtime_tile_records = _tcgen05_grouped_runtime_nm_tile_records(
+            worklist_rows,
+            problem_sizes,
+            source_tile_m=worklist_m_tile,
+            source_tile_n=scheduler_bm,
+            l2_swizzle_size=l2_swizzle_size,
+        )
+        if len(runtime_tile_records) != total_clusters:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 runtime N,M tile table row count does not match "
+                "the grouped launch cluster count",
+            )
+        if (
+            runtime_tile_records.ndim != 2
+            or runtime_tile_records.size(1) != TCGEN05_GROUPED_RUNTIME_TILE_FIELD_COUNT
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 runtime N,M tile table does not match the shared field schema",
+            )
+        runtime_tile_records_tensor = runtime_tile_records.to(device=device)
     result = _Tcgen05GroupedStaticMetadataResult(
         problem_sizes=problem_tensor,
         starts=starts_tensor,
         total_clusters=total_clusters,
         real_groups=real_groups_tensor,
+        runtime_tile_records=runtime_tile_records_tensor,
         direct_pointers=direct_pointers_tensor,
         direct_strides=direct_strides_tensor,
     )
@@ -3775,6 +4064,7 @@ def _build_cute_schema_and_args(
         tensor: torch.Tensor,
         *,
         owned: bool = False,
+        runtime_leading_extent: bool = False,
     ) -> None:
         _validate_cute_launcher_tensor(tensor)
         sizes = tuple(int(tensor.size(d)) for d in range(tensor.ndim))
@@ -3787,16 +4077,29 @@ def _build_cute_schema_and_args(
                 assumed_align=16,
             )
         )
-        schema.append(
-            (
-                "wrapper_tensor",
-                name,
-                str(tensor.dtype),
-                tensor.ndim,
-                sizes,
-                strides,
+        if runtime_leading_extent:
+            schema.append(
+                (
+                    "wrapper_tensor_runtime_leading_extent",
+                    name,
+                    str(tensor.dtype),
+                    tensor.ndim,
+                    sizes[1:],
+                    strides,
+                )
             )
-        )
+            launch_args.append(sizes[0])
+        else:
+            schema.append(
+                (
+                    "wrapper_tensor",
+                    name,
+                    str(tensor.dtype),
+                    tensor.ndim,
+                    sizes,
+                    strides,
+                )
+            )
         if owned:
             owned_tensors.append(tensor)
 
@@ -3837,20 +4140,26 @@ def _build_cute_schema_and_args(
         problem_tensor = metadata_result.problem_sizes
         starts_tensor = metadata_result.starts
         real_groups_tensor = metadata_result.real_groups
+        runtime_tile_records_tensor = metadata_result.runtime_tile_records
         direct_pointers_tensor = metadata_result.direct_pointers
         direct_strides_tensor = metadata_result.direct_strides
         total_clusters = metadata_result.total_clusters
         grouped_static_metadata.append(metadata_entry)
-        for name, tensor in (
-            (_plan_str_value(plan, "problem_sizes_arg"), problem_tensor),
-            (_plan_str_value(plan, "starts_arg"), starts_tensor),
-            *(
-                ((_plan_str_value(plan, "real_groups_arg"), real_groups_tensor),)
-                if real_groups_tensor is not None
-                else ()
-            ),
-        ):
-            append_wrapper_tensor(name, tensor)
+        if problem_tensor is not None and starts_tensor is not None:
+            append_wrapper_tensor(
+                _plan_str_value(plan, "problem_sizes_arg"), problem_tensor
+            )
+            append_wrapper_tensor(_plan_str_value(plan, "starts_arg"), starts_tensor)
+        if real_groups_tensor is not None:
+            append_wrapper_tensor(
+                _plan_str_value(plan, "real_groups_arg"), real_groups_tensor
+            )
+        if runtime_tile_records_tensor is not None:
+            append_wrapper_tensor(
+                _plan_str_value(plan, "runtime_tile_records_arg"),
+                runtime_tile_records_tensor,
+                runtime_leading_extent=True,
+            )
         append_grouped_tensormap_workspace(plan, layout)
         if direct_pointers_tensor is not None and direct_strides_tensor is not None:
             append_wrapper_tensor(

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -4,6 +4,7 @@ import importlib
 import inspect
 import os
 import pickle
+from typing import TYPE_CHECKING
 from typing import Any
 import unittest
 from unittest.mock import patch
@@ -18,6 +19,7 @@ from helion import exc
 from helion._compiler.backend import PallasBackend
 from helion._compiler.backend import TritonBackend
 from helion._compiler.compile_environment import CompileEnvironment
+from helion._compiler.cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_config import Tcgen05AbStagesThreeSearchConstraints
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN,
@@ -30,6 +32,9 @@ from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DIRECT
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+)
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY,
 )
@@ -69,8 +74,12 @@ from helion._testing import TestCase
 from helion._testing import onlyBackends
 from helion._testing import skipIfXPU
 from helion._testing import skipUnlessCuteAvailable
+from helion.autotuner.config_fragment import EnumFragment
 from helion.autotuner.config_spec import ConfigSpec
 import helion.language as hl
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 def _json_safe_values() -> st.SearchStrategy[Any]:
@@ -1058,7 +1067,13 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
     def test_grouped_worklist_source_tile_normalization(self) -> None:
         spec = self._make_cute_tcgen05_spec()
         self.assertEqual(
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES[0],
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES,
+            tuple(sorted(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES)),
+        )
+        self.assertEqual(
+            spec._tcgen05_optional_fragments()[
+                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+            ].default(),
             TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
         )
         for source_m_tile in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES:
@@ -1101,32 +1116,198 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             invalid.config,
         )
 
-    def test_grouped_worklist_source_tile_seed_round_trip(self) -> None:
-        from helion.autotuner.config_generation import ConfigGeneration
-
+    def test_grouped_runtime_direct_normalization(self) -> None:
         spec = self._make_cute_tcgen05_spec()
-        seed = helion.Config(
+        spec.target_device_capability = (10, 0)
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                config = helion.Config(
+                    block_sizes=[256, 128, 128],
+                    pid_type="persistent_interleaved",
+                    tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                    tcgen05_grouped_runtime_direct=enabled,
+                )
+                spec.normalize(config)
+                self.assertIs(
+                    config.config[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY],
+                    enabled,
+                )
+
+        invalid = helion.Config(
             block_sizes=[256, 128, 128],
             pid_type="persistent_interleaved",
             tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-            tcgen05_grouped_worklist_source_m_tile=(
-                TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+            tcgen05_grouped_runtime_direct=True,
+        )
+        invalid.config[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = 1
+        with self.assertRaisesRegex(exc.InvalidConfig, "must be a boolean"):
+            spec.normalize(invalid)
+
+        def unsupported_runtime_direct(
+            *,
+            grouped_mode: str = TCGEN05_GROUPED_MODE_DYNAMIC,
+            static_signature: bool = False,
+        ) -> helion.Config:
+            config = helion.Config(
+                block_sizes=[256, 128, 64],
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=grouped_mode,
+                tcgen05_grouped_runtime_direct=True,
+            )
+            if static_signature:
+                config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+                    1,
+                    256,
+                    128,
+                    64,
+                ]
+            return config
+
+        unsupported_cases = (
+            (TCGEN05_GROUPED_MODE_DYNAMIC, False),
+            (TCGEN05_GROUPED_MODE_WORKLIST_NM, True),
+        )
+        for grouped_mode, static_signature in unsupported_cases:
+            unsupported = unsupported_runtime_direct(
+                grouped_mode=grouped_mode,
+                static_signature=static_signature,
+            )
+            with (
+                self.subTest(config=unsupported.config),
+                self.assertRaisesRegex(
+                    exc.InvalidConfig,
+                    "must not silently fall back",
+                ),
+            ):
+                spec.normalize(unsupported)
+            repaired = unsupported_runtime_direct(
+                grouped_mode=grouped_mode,
+                static_signature=static_signature,
+            )
+            spec.normalize(repaired, _fix_invalid=True)
+            self.assertNotIn(
+                TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+                repaired.config,
+            )
+
+        def clc_config(
+            *,
+            grouped_mode: str = TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            runtime_direct: bool = True,
+            static_signature: bool = False,
+        ) -> helion.Config:
+            config = helion.Config(
+                block_sizes=[256, 128, 64],
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=grouped_mode,
+                tcgen05_grouped_runtime_direct=runtime_direct,
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+                tcgen05_persistence_model="clc_persistent",
+            )
+            if static_signature:
+                config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+                    1,
+                    256,
+                    128,
+                    64,
+                ]
+            return config
+
+        valid_clc = clc_config()
+        spec.normalize(valid_clc)
+        self.assertEqual(
+            valid_clc.config["tcgen05_persistence_model"], "clc_persistent"
+        )
+        self.assertEqual(valid_clc.config["tcgen05_warp_spec_scheduler_warps"], 1)
+
+        invalid_clc_configs = (
+            clc_config(runtime_direct=False),
+            clc_config(grouped_mode=TCGEN05_GROUPED_MODE_DYNAMIC),
+            clc_config(static_signature=True),
+        )
+        for invalid_clc in invalid_clc_configs:
+            with (
+                self.subTest(config=invalid_clc.config),
+                self.assertRaisesRegex(
+                    exc.InvalidConfig,
+                    "exact one-record-per-cluster tile table",
+                ),
+            ):
+                spec.normalize(invalid_clc)
+
+    def test_grouped_worklist_panel_requires_runtime_direct(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+
+        def panel_config(*, runtime_direct: bool | None = None) -> helion.Config:
+            config = helion.Config(
+                block_sizes=[256, 128, 64],
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                tcgen05_l2_swizzle_size=8,
+            )
+            if runtime_direct is not None:
+                config.config[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = (
+                    runtime_direct
+                )
+            return config
+
+        for runtime_direct in (None, False):
+            with (
+                self.subTest(runtime_direct=runtime_direct),
+                self.assertRaisesRegex(
+                    exc.InvalidConfig,
+                    "requires tcgen05_grouped_runtime_direct=True",
+                ),
+            ):
+                spec.normalize(panel_config(runtime_direct=runtime_direct))
+
+            repaired = panel_config(runtime_direct=runtime_direct)
+            spec.normalize(repaired, _fix_invalid=True)
+            self.assertEqual(
+                repaired.config[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY],
+                1,
+            )
+
+        runtime_direct = panel_config(runtime_direct=True)
+        spec.normalize(runtime_direct)
+        self.assertEqual(
+            runtime_direct.config[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY],
+            8,
+        )
+
+    def test_grouped_worklist_seed_fields_round_trip(self) -> None:
+        from helion.autotuner.config_generation import ConfigGeneration
+
+        cases = (
+            (
+                "source_m_tile",
+                128,
+                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+                TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+            ),
+            (
+                "runtime_direct",
+                64,
+                TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+                True,
             ),
         )
-        spec.compiler_seed_configs = [seed]
-
-        generation = ConfigGeneration(spec)
-        [(flat, normalized)] = generation.seed_flat_config_pairs()
-        self.assertEqual(
-            normalized.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY],
-            TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
-        )
-        generation.encode_config(flat)
-        round_trip = generation.unflatten(flat)
-        self.assertEqual(
-            round_trip.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY],
-            TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
-        )
+        for name, block_k, key, expected in cases:
+            with self.subTest(name=name):
+                spec = self._make_cute_tcgen05_spec()
+                seed = helion.Config(
+                    block_sizes=[256, 128, block_k],
+                    pid_type="persistent_interleaved",
+                    tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                )
+                seed.config[key] = expected
+                spec.compiler_seed_configs = [seed]
+                generation = ConfigGeneration(spec)
+                [(flat, normalized)] = generation.seed_flat_config_pairs()
+                self.assertEqual(normalized.config[key], expected)
+                generation.encode_config(flat)
+                self.assertEqual(generation.unflatten(flat).config[key], expected)
 
     def test_grouped_worklist_one_cta_accepts_bk128_ab5(self) -> None:
         spec = self._make_cute_tcgen05_spec()
@@ -1153,6 +1334,45 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         self.assertEqual(config.block_sizes[:3], [256, 128, 128])
         self.assertEqual(config.config["tcgen05_ab_stages"], 5)
         self.assertEqual(config.config["tcgen05_consumer_regs"], 256)
+
+    def test_grouped_worklist_two_cta_fix_preserves_logical_tile(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+        spec.register_cute_tcgen05_mma_analysis(
+            m_block_id=0,
+            n_block_id=1,
+            k_block_id=2,
+            input_dtype=torch.bfloat16,
+            has_leading_passthrough=False,
+            explicit_epi_tile_compatible=True,
+        )
+        spec.allow_tcgen05_cluster_m2_search(static_k=128)
+
+        for source_m_tile in (
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+        ):
+            for block_k in (64, 128):
+                with self.subTest(
+                    source_m_tile=source_m_tile,
+                    block_k=block_k,
+                ):
+                    config = helion.Config(
+                        block_sizes=[256, 128, block_k],
+                        pid_type="persistent_interleaved",
+                        tcgen05_cluster_m=2,
+                        tcgen05_cluster_n=1,
+                        tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                        tcgen05_grouped_worklist_source_m_tile=source_m_tile,
+                    )
+
+                    spec.normalize(config, _fix_invalid=True)
+
+                    self.assertEqual(config.block_sizes[:3], [256, 128, block_k])
+                    self.assertEqual(config.config["tcgen05_cluster_m"], 2)
+                    self.assertEqual(
+                        config.config["pid_type"],
+                        "persistent_interleaved",
+                    )
 
     def test_tcgen05_search_fields_do_not_leak_to_other_backends(self) -> None:
         from helion._compiler.backend import MetalBackend
@@ -1315,20 +1535,61 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
     def test_grouped_rejects_num_sm_multiplier(self) -> None:
         spec = self._make_cute_tcgen05_spec()
 
-        def make_config() -> helion.Config:
+        def make_config(grouped_mode: str) -> helion.Config:
             return helion.Config(
                 block_sizes=[256, 128, 64],
                 num_sm_multiplier=2,
                 pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                tcgen05_grouped_mode=grouped_mode,
             )
 
-        with self.assertRaisesRegex(exc.InvalidConfig, "num_sm_multiplier=1"):
+        for grouped_mode in (
+            TCGEN05_GROUPED_MODE_STATIC,
+            TCGEN05_GROUPED_MODE_DYNAMIC,
+            TCGEN05_GROUPED_MODE_DIRECT,
+            TCGEN05_GROUPED_MODE_WORKLIST_NM,
+        ):
+            with self.subTest(grouped_mode=grouped_mode):
+                with self.assertRaisesRegex(exc.InvalidConfig, "num_sm_multiplier=1"):
+                    spec.normalize(make_config(grouped_mode))
+
+                repaired = make_config(grouped_mode)
+                spec.normalize(repaired, _fix_invalid=True)
+                self.assertNotIn("num_sm_multiplier", repaired.config)
+
+    def test_grouped_clc_rejects_ignored_occupancy_limits(self) -> None:
+        from helion._compiler.cute.strategies import (
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY,
+        )
+        from helion._compiler.cute.strategies import Tcgen05PersistenceModel
+
+        spec = self._make_cute_tcgen05_spec()
+
+        def make_config() -> helion.Config:
+            return helion.Config(
+                block_sizes=[256, 128, 64],
+                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+                **{
+                    TCGEN05_GROUPED_MODE_CONFIG_KEY: (TCGEN05_GROUPED_MODE_WORKLIST_NM),
+                    TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY: True,
+                    TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY: 4,
+                    TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
+                        Tcgen05PersistenceModel.CLC_PERSISTENT.value
+                    ),
+                },
+            )
+
+        with self.assertRaisesRegex(exc.InvalidConfig, "exact full tile-record grid"):
             spec.normalize(make_config())
 
         repaired = make_config()
         spec.normalize(repaired, _fix_invalid=True)
-        self.assertNotIn("num_sm_multiplier", repaired.config)
+        self.assertNotIn(
+            TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+            repaired.config,
+        )
 
     def test_grouped_static_problem_signature_envelope(self) -> None:
         spec = self._make_cute_tcgen05_spec()
@@ -1377,10 +1638,7 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                 spec.normalize(fixed, _fix_invalid=True)
                 self.assertNotIn(key, fixed.config)
 
-        for mode in (
-            None,
-            TCGEN05_GROUPED_MODE_WORKLIST_NM,
-        ):
+        for mode in (None, TCGEN05_GROUPED_MODE_WORKLIST_NM):
             with self.subTest(mode=mode):
                 invalid = make_config(signature, mode)
                 with self.assertRaisesRegex(exc.InvalidConfig, key):
@@ -1617,17 +1875,28 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         spec = self._make_cute_tcgen05_spec()
         tcgen05_config = spec._cute_tcgen05_config
 
+        def choices(fragments: Mapping[str, object], key: str) -> tuple[object, ...]:
+            fragment = fragments[key]
+            self.assertIsInstance(fragment, EnumFragment)
+            assert isinstance(fragment, EnumFragment)
+            return fragment.choices
+
         narrow = tcgen05_config.strategy_autotune_fragments()
-        self.assertEqual(narrow["tcgen05_strategy"].choices, ("role_local_monolithic",))
-        self.assertEqual(narrow["tcgen05_warp_spec_c_input_warps"].choices, (0,))
+        self.assertEqual(
+            choices(narrow, "tcgen05_strategy"), ("role_local_monolithic",)
+        )
+        self.assertEqual(choices(narrow, "tcgen05_warp_spec_c_input_warps"), (0,))
 
         tcgen05_config.aux_kernel_detected = True
         widened = tcgen05_config.strategy_autotune_fragments()
         self.assertEqual(
-            widened["tcgen05_strategy"].choices,
+            choices(widened, "tcgen05_strategy"),
             ("role_local_monolithic", "role_local_with_scheduler"),
         )
-        self.assertEqual(widened["tcgen05_warp_spec_c_input_warps"].choices, (0, 1))
+        self.assertEqual(
+            choices(widened, "tcgen05_warp_spec_c_input_warps"),
+            (0, 1),
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6,6 +6,7 @@ import dataclasses
 from dataclasses import dataclass
 import gc
 import importlib
+import linecache
 import math
 import os
 from pathlib import Path
@@ -22,6 +23,7 @@ import torch
 
 import helion
 from helion._compiler.cute.attention_plan import causal_score_plan
+from helion._compiler.cute.device_state import Tcgen05GroupedSchedulerMode
 from helion._compiler.cute.flash_policy import get_flash_target_policy
 from helion._compiler.cute.flash_tuning import FlashPackedExp2Mode
 from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
@@ -8390,6 +8392,26 @@ class TestCuteBackend(TestCase):
 
         self.assertNotEqual(wrapper_default, wrapper_lineinfo)
 
+    def test_grouped_static_active_clusters_honors_reserved_sms(self) -> None:
+        launcher = importlib.import_module("helion.runtime.cute.launcher")
+
+        self.assertEqual(
+            launcher._tcgen05_grouped_static_active_clusters(
+                num_sm=148,
+                cluster_m=1,
+                reserved_sms=0,
+            ),
+            148,
+        )
+        self.assertEqual(
+            launcher._tcgen05_grouped_static_active_clusters(
+                num_sm=148,
+                cluster_m=2,
+                reserved_sms=4,
+            ),
+            72,
+        )
+
     def test_cute_launcher_reuses_compiled_wrapper(self) -> None:
         cute_kernel = type("DummyCuteKernel", (), {})()
         schema_key = (("tensor", 2, "float32"),)
@@ -8427,6 +8449,185 @@ class TestCuteBackend(TestCase):
         self.assertEqual(launched_args, [(1, 2, 3), (4, 5, 6)])
         self.assertEqual(first, ("launched", (1, 2, 3)))
         self.assertEqual(second, ("launched", (4, 5, 6)))
+
+    def test_cute_runtime_leading_extent_wrapper_bakes_tail_layout(self) -> None:
+        launcher = importlib.import_module("helion.runtime.cute.launcher")
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        captured_source: list[str] = []
+        wrapper = object()
+
+        def fake_exec(code: Any, namespace: dict[str, Any]) -> None:
+            source = "".join(linecache.getlines(code.co_filename))
+            captured_source.append(source)
+            definition = next(
+                line for line in source.splitlines() if line.startswith("def ")
+            )
+            namespace[definition[4:].split("(", 1)[0]] = wrapper
+
+        schema = (
+            (
+                "wrapper_tensor_runtime_leading_extent",
+                "runtime_tile_records",
+                "torch.int32",
+                2,
+                (10,),
+                (10, 1),
+            ),
+        )
+        with patch("builtins.exec", side_effect=fake_exec):
+            created = launcher._create_cute_wrapper(
+                cute_kernel,
+                schema,
+                (32, 1, 1),
+            )
+
+        self.assertIs(created, wrapper)
+        self.assertEqual(len(captured_source), 1)
+        source = captured_source[0]
+        self.assertIn("runtime_tile_records_shape0: cutlass.Int64", source)
+        self.assertNotIn("runtime_tile_records_shape1:", source)
+        self.assertNotIn("runtime_tile_records_stride0:", source)
+        self.assertNotIn("runtime_tile_records_stride1:", source)
+        self.assertIn(
+            "cute.make_layout((runtime_tile_records_shape0, 10), stride=(10, 1))",
+            source,
+        )
+
+    def test_grouped_runtime_tile_record_rows_reuse_compiled_launcher(self) -> None:
+        launcher = importlib.import_module("helion.runtime.cute.launcher")
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        cute_kernel._helion_cute_disable_bake_tensor_shapes = True
+        plan = {
+            "kind": "tcgen05_grouped_static_persistent",
+            "scheduler_mode": Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT.value,
+            "orientation": "nm",
+            "layout_idx": 0,
+            "problem_sizes_arg": "problem_sizes",
+            "starts_arg": "starts",
+            "runtime_tile_records_arg": "runtime_tile_records",
+            "total_clusters_arg": "total_clusters",
+        }
+        cute_kernel._helion_cute_wrapper_plans = [plan]
+        layout = torch.empty(2, dtype=torch.int32)
+        runtime_record_tensors = iter(
+            (
+                torch.empty((2, 10), dtype=torch.int32),
+                torch.empty((5, 10), dtype=torch.int32),
+                torch.empty((2, 11), dtype=torch.int32),
+                torch.empty((2, 20), dtype=torch.int32)[:, ::2],
+            )
+        )
+
+        class FakeMetadataResult:
+            def __init__(self, runtime_tile_records: torch.Tensor) -> None:
+                self.problem_sizes = torch.empty((2, 4), dtype=torch.int32)
+                self.starts = torch.empty(2, dtype=torch.int32)
+                self.real_groups = None
+                self.runtime_tile_records = runtime_tile_records
+                self.direct_pointers = None
+                self.direct_strides = None
+                self.total_clusters = int(runtime_tile_records.size(0))
+
+            def tensors(self) -> tuple[torch.Tensor, ...]:
+                return (
+                    self.problem_sizes,
+                    self.starts,
+                    self.runtime_tile_records,
+                )
+
+        class FakeMetadataEntry:
+            def __init__(self, runtime_tile_records: torch.Tensor) -> None:
+                self.result = FakeMetadataResult(runtime_tile_records)
+
+        def fake_metadata(*_args: object) -> FakeMetadataEntry:
+            return FakeMetadataEntry(next(runtime_record_tensors))
+
+        def fake_imports() -> tuple[object, object, object]:
+            def make_ptr(
+                _dtype: object,
+                data_ptr: int,
+                _space: object,
+                *,
+                assumed_align: int,
+            ) -> tuple[str, int]:
+                self.assertEqual(assumed_align, 16)
+                return ("ptr", data_ptr)
+
+            return object(), make_ptr, object()
+
+        with (
+            patch.object(launcher, "_validate_cute_launcher_tensor"),
+            patch.object(
+                launcher,
+                "_tcgen05_grouped_static_layout_arg",
+                return_value=layout,
+            ),
+            patch.object(
+                launcher,
+                "_build_tcgen05_grouped_static_metadata",
+                side_effect=fake_metadata,
+            ),
+            patch.object(
+                launcher,
+                "_get_cute_launcher_imports",
+                side_effect=fake_imports,
+            ),
+            patch.object(launcher, "_torch_dtype_to_cutlass", side_effect=str),
+        ):
+            first = launcher._build_cute_schema_and_args(
+                cute_kernel, (layout,), (1, 1, 1)
+            )
+            second = launcher._build_cute_schema_and_args(
+                cute_kernel, (layout,), (1, 1, 1)
+            )
+            changed_tail = launcher._build_cute_schema_and_args(
+                cute_kernel, (layout,), (1, 1, 1)
+            )
+            changed_stride = launcher._build_cute_schema_and_args(
+                cute_kernel, (layout,), (1, 1, 1)
+            )
+
+        self.assertEqual(first.schema, second.schema)
+        self.assertIn(
+            (
+                "wrapper_tensor_runtime_leading_extent",
+                "runtime_tile_records",
+                "torch.int32",
+                2,
+                (10,),
+                (10, 1),
+            ),
+            first.schema,
+        )
+        self.assertEqual(first.launch_args[-5], 2)
+        self.assertEqual(second.launch_args[-5], 5)
+        self.assertNotEqual(first.schema, changed_tail.schema)
+        self.assertNotEqual(first.schema, changed_stride.schema)
+        first_key = launcher._cute_compiled_launcher_discriminator(
+            first.schema, (32, 1, 1), None, None
+        )[0]
+        second_key = launcher._cute_compiled_launcher_discriminator(
+            second.schema, (32, 1, 1), None, None
+        )[0]
+        self.assertEqual(first_key, second_key)
+
+        with patch.object(launcher, "_create_cute_wrapper", return_value=object()):
+            first_compiled = launcher._get_compiled_cute_launcher(
+                cute_kernel, first.schema, (32, 1, 1)
+            )
+            second_compiled = launcher._get_compiled_cute_launcher(
+                cute_kernel, second.schema, (32, 1, 1)
+            )
+            tail_compiled = launcher._get_compiled_cute_launcher(
+                cute_kernel, changed_tail.schema, (32, 1, 1)
+            )
+            stride_compiled = launcher._get_compiled_cute_launcher(
+                cute_kernel, changed_stride.schema, (32, 1, 1)
+            )
+        self.assertIs(first_compiled, second_compiled)
+        self.assertIsNot(first_compiled, tail_compiled)
+        self.assertIsNot(first_compiled, stride_compiled)
+        self.assertEqual(len(cute_kernel._helion_cute_compiled_launchers), 3)
 
     def test_cute_launcher_passes_compile_options(self) -> None:
         cute_kernel = type("DummyCuteKernel", (), {})()
@@ -8650,6 +8851,9 @@ class TestCuteBackend(TestCase):
         cute_kernel._helion_cute_wrapper_plans = [
             {
                 "kind": "tcgen05_grouped_static_persistent",
+                "scheduler_mode": (
+                    Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value
+                ),
                 "layout_idx": 0,
                 "dynamic_ab_tensormaps": True,
             }
@@ -8707,7 +8911,13 @@ class TestCuteBackend(TestCase):
             self.skipTest("grouped capture context test needs CUDA")
         cute_kernel = type("DummyCuteKernel", (), {})()
         cute_kernel._helion_cute_wrapper_plans = [
-            {"kind": "tcgen05_grouped_static_persistent", "layout_idx": 0}
+            {
+                "kind": "tcgen05_grouped_static_persistent",
+                "scheduler_mode": (
+                    Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value
+                ),
+                "layout_idx": 0,
+            }
         ]
         layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
 
@@ -8728,6 +8938,9 @@ class TestCuteBackend(TestCase):
         cute_kernel._helion_cute_wrapper_plans = [
             {
                 "kind": "tcgen05_grouped_static_persistent",
+                "scheduler_mode": (
+                    Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value
+                ),
                 "layout_idx": 0,
                 "dynamic_ab_tensormaps": True,
             }
@@ -8883,9 +9096,13 @@ class TestCuteBackend(TestCase):
 
     def test_grouped_static_metadata_match_filters_device_plans(self) -> None:
         launcher = importlib.import_module("helion.runtime.cute.launcher")
-        host_plan = {"kind": "tcgen05_grouped_static_persistent"}
+        host_plan = {
+            "kind": "tcgen05_grouped_static_persistent",
+            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
+        }
         device_plan = {
             "kind": "tcgen05_grouped_static_persistent",
+            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "device_split_sizes": True,
         }
         unrelated_plan = {"kind": "unrelated"}
@@ -8942,6 +9159,7 @@ class TestCuteBackend(TestCase):
         cute_kernel = type("DummyCuteKernel", (), {})()
         plan = {
             "kind": "tcgen05_grouped_static_persistent",
+            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "layout_idx": 0,
             "n_sizes_idx": 1,
             "group_count": 2,
@@ -9094,6 +9312,7 @@ class TestCuteBackend(TestCase):
         runtime_mod = importlib.import_module("helion.runtime")
         plan = {
             "kind": "tcgen05_grouped_static_persistent",
+            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "layout_idx": 2,
             "lhs_idx": 0,
             "rhs_idx": 1,
@@ -9196,6 +9415,7 @@ class TestCuteBackend(TestCase):
         runtime_mod = importlib.import_module("helion.runtime")
         base_plan = {
             "kind": "tcgen05_grouped_static_persistent",
+            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "layout_idx": 0,
             "n_sizes_idx": 1,
             "group_count": 2,
@@ -9250,6 +9470,7 @@ class TestCuteBackend(TestCase):
         kernel_mod = importlib.import_module("helion.runtime.kernel")
         plan = {
             "kind": "tcgen05_grouped_static_persistent",
+            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "layout_idx": 0,
             "n_sizes_idx": 1,
             "group_count": 2,
@@ -9839,6 +10060,63 @@ class TestCuteBackend(TestCase):
         self.assertEqual(build_calls[0][3], build_calls[1][3])
         self.assertNotEqual(build_calls[1][3], build_calls[2][3])
 
+    def test_grouped_scheduler_mode_requires_complete_runtime_state(self) -> None:
+        launcher = importlib.import_module("helion.runtime.cute.launcher")
+        direct_plan = {
+            "scheduler_mode": Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT.value,
+            "orientation": "nm",
+            "runtime_tile_records_arg": "runtime_tile_records",
+        }
+        self.assertIs(
+            launcher._tcgen05_grouped_scheduler_mode(direct_plan),
+            Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+        )
+        self.assertIs(
+            launcher._tcgen05_grouped_scheduler_mode(
+                {
+                    **direct_plan,
+                    "scheduler_mode": Tcgen05GroupedSchedulerMode.RUNTIME_CLC.value,
+                    "fixed_tensormaps": True,
+                }
+            ),
+            Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
+        )
+
+        invalid_plans = (
+            (
+                {"scheduler_mode": (Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT.value)},
+                "matching tile-table",
+            ),
+            (
+                {
+                    **direct_plan,
+                    "scheduler_mode": (
+                        Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value
+                    ),
+                },
+                "matching tile-table",
+            ),
+            ({**direct_plan, "orientation": "mn"}, "requires N,M orientation"),
+            (
+                {
+                    **direct_plan,
+                    "scheduler_mode": Tcgen05GroupedSchedulerMode.RUNTIME_CLC.value,
+                },
+                "requires fixed full-allocation TensorMaps",
+            ),
+        )
+        for invalid_plan, message in invalid_plans:
+            with (
+                self.subTest(plan=invalid_plan),
+                self.assertRaisesRegex(BackendUnsupported, message),
+            ):
+                launcher._tcgen05_grouped_scheduler_mode(invalid_plan)
+
+        self.assertIs(
+            launcher._tcgen05_grouped_scheduler_mode({}),
+            Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH,
+        )
+
     def test_kernel_late_cute_specialization_rekeys_bound_kernel(self) -> None:
         identity = _runtime_identity_kernel()
         x = torch.empty(1)
@@ -9848,6 +10126,7 @@ class TestCuteBackend(TestCase):
         signature = identity._base_specialization_key(args)
         plan: dict[str, object] = {
             "kind": "tcgen05_grouped_static_persistent",
+            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "layout_bind_idx": 1,
             "group_count": 1,
             "bm": 128,

--- a/test/test_cute_deepgemm_selected.py
+++ b/test/test_cute_deepgemm_selected.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import os
 from typing import TYPE_CHECKING
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -10,10 +11,21 @@ import torch
 
 import helion
 from helion._compat import requires_cuda_version
+from helion._compiler.cute.device_state import Tcgen05GroupedSchedulerMode
+from helion._compiler.cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
 from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT,
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
@@ -29,8 +41,13 @@ from helion._testing import matchesBackends
 from helion._testing import patch_cute_mma_support
 from helion._testing import skipUnlessBackends
 import helion.language as hl
+from helion.runtime.cute.launcher import _append_cute_wrapper_plan
+from helion.runtime.cute.launcher import _tcgen05_grouped_runtime_nm_tile_records
 from helion.runtime.cute.launcher import _validate_tcgen05_grouped_dynamic_ab_tensormaps
 from helion.runtime.cute.launcher import _validate_tcgen05_grouped_fixed_tensormaps
+from helion.runtime.cute.launcher import (
+    _validate_tcgen05_grouped_runtime_direct_clc_grid,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -55,6 +72,8 @@ def _selected_config(
     ab_stages: int | None = None,
     cluster_m: int = 2,
     consumer_regs: int | None = None,
+    runtime_direct: bool | None = None,
+    clc: bool = False,
 ) -> helion.Config:
     if source_m_tile is None:
         source_m_tile = (
@@ -90,6 +109,18 @@ def _selected_config(
     config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = source_m_tile
     if consumer_regs is not None:
         config.config["tcgen05_consumer_regs"] = consumer_regs
+    if runtime_direct is not None:
+        config.config[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = runtime_direct
+    if clc:
+        if runtime_direct is not True:
+            raise ValueError("grouped CLC test config requires runtime_direct=True")
+        config.config.update(
+            {
+                "tcgen05_strategy": "role_local_with_scheduler",
+                "tcgen05_warp_spec_scheduler_warps": 1,
+                "tcgen05_persistence_model": "clc_persistent",
+            }
+        )
     return config
 
 
@@ -195,19 +226,25 @@ def _configured_bound(
     source_m_tile: int | None = None,
     cluster_m: int = 2,
     consumer_regs: int | None = None,
+    l2_swizzle_size: int | None = None,
+    runtime_direct: bool | None = None,
+    clc: bool = False,
 ):
     _selected_kernel.reset()
     bound = _selected_kernel.bind(args)
     bound.env.config_spec.cute_tcgen05_search_enabled = True
-    bound.set_config(
-        _selected_config(
-            block_k,
-            source_m_tile,
-            ab_stages=ab_stages,
-            cluster_m=cluster_m,
-            consumer_regs=consumer_regs,
-        )
+    config = _selected_config(
+        block_k,
+        source_m_tile,
+        ab_stages=ab_stages,
+        cluster_m=cluster_m,
+        consumer_regs=consumer_regs,
+        runtime_direct=runtime_direct,
+        clc=clc,
     )
+    if l2_swizzle_size is not None:
+        config.config[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = l2_swizzle_size
+    bound.set_config(config)
     return bound
 
 
@@ -216,7 +253,7 @@ def _code_for(
     config: helion.Config | None = None,
 ) -> str:
     if config is None:
-        config = _selected_config()
+        config = _selected_config(runtime_direct=True)
     _selected_kernel.reset()
     bound = _selected_kernel.bind(args)
     bound.env.config_spec.cute_tcgen05_search_enabled = True
@@ -257,6 +294,120 @@ def _call_count(
         )
         for node in ast.walk(tree)
     )
+
+
+def _expected_panel_coords(
+    *,
+    m_tiles: int,
+    n_tiles: int,
+    configured_panel_size: int,
+) -> list[tuple[int, int]]:
+    result: list[tuple[int, int]] = []
+    panel_size = min(configured_panel_size, n_tiles)
+    panel_span = panel_size * m_tiles
+    for linear in range(m_tiles * n_tiles):
+        panel = linear // panel_span
+        within = linear % panel_span
+        width = min(panel_size, n_tiles - panel * panel_size)
+        tile_m = within // width
+        tile_n = panel * panel_size + within % width
+        if panel % 2 == 1:
+            tile_m = m_tiles - 1 - tile_m
+        result.append((tile_m, tile_n))
+    return result
+
+
+def test_grouped_worklist_nm_runtime_tile_table_mapping() -> None:
+    rows = [[2, 0, 257, 448], [0, 448, 513, 672], [1, 1120, 65, 224]]
+    problem_sizes = [(2560, row[3], 128, 1) for row in rows]
+    records = _tcgen05_grouped_runtime_nm_tile_records(
+        rows,
+        problem_sizes,
+        source_tile_m=224,
+        source_tile_n=256,
+        l2_swizzle_size=8,
+    )
+
+    cursor = 0
+    for metadata_idx, (real_group, start, actual_m, aligned_m) in enumerate(rows):
+        m_tiles = aligned_m // 224
+        n_tiles = 10
+        count = m_tiles * n_tiles
+        group_records = records[cursor : cursor + count].tolist()
+        assert [(record[0], record[1]) for record in group_records] == (
+            _expected_panel_coords(
+                m_tiles=m_tiles,
+                n_tiles=n_tiles,
+                configured_panel_size=8,
+            )
+        )
+        for record in group_records:
+            tile_m = record[0]
+            assert record[2:8] == [
+                metadata_idx,
+                real_group,
+                aligned_m,
+                2560,
+                128,
+                start,
+            ]
+            assert record[8] == min(224, max(actual_m - tile_m * 224, 0))
+            assert record[9] == min(224, aligned_m - tile_m * 224)
+        cursor += count
+    assert cursor == len(records)
+
+
+@pytest.mark.parametrize("l2_swizzle_size", (1, 8))
+def test_grouped_worklist_nm_tile_table_excludes_zero_tile_groups(
+    l2_swizzle_size: int,
+) -> None:
+    records = _tcgen05_grouped_runtime_nm_tile_records(
+        [[0, 0, 0, 0], [1, 0, 33, 224]],
+        [(256, 0, 128, 1), (256, 224, 128, 1)],
+        source_tile_m=224,
+        source_tile_n=256,
+        l2_swizzle_size=l2_swizzle_size,
+    )
+
+    # The zero-tile row is absent before either raster path performs division
+    # or modulo; the surviving row retains its original metadata index.
+    assert records.tolist() == [[0, 0, 1, 1, 224, 256, 128, 0, 33, 224]]
+
+
+@pytest.mark.parametrize(
+    "problem_size",
+    (
+        (128, 64, 64, 2),
+        (128, 32, 64, 1),
+    ),
+)
+def test_grouped_worklist_nm_runtime_tile_table_rejects_invalid_problem_shape(
+    problem_size: tuple[int, int, int, int],
+) -> None:
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="require batch 1 and problem M matching",
+    ):
+        _tcgen05_grouped_runtime_nm_tile_records(
+            [[0, 0, 33, 64]],
+            [problem_size],
+            source_tile_m=32,
+            source_tile_n=128,
+            l2_swizzle_size=1,
+        )
+
+
+def test_grouped_worklist_nm_runtime_direct_clc_checks_grid_z_limit() -> None:
+    _validate_tcgen05_grouped_runtime_direct_clc_grid(
+        TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS
+    )
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="requires at most 65535 exact tile records",
+    ):
+        _validate_tcgen05_grouped_runtime_direct_clc_grid(
+            TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS + 1
+        )
 
 
 def _assert_output(
@@ -307,6 +458,9 @@ def _run_graph_replay(
     source_m_tile: int | None = None,
     cluster_m: int = 2,
     consumer_regs: int | None = None,
+    l2_swizzle_size: int | None = None,
+    runtime_direct: bool | None = None,
+    clc: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
         bound = _configured_bound(
@@ -316,6 +470,9 @@ def _run_graph_replay(
             source_m_tile=source_m_tile,
             cluster_m=cluster_m,
             consumer_regs=consumer_regs,
+            l2_swizzle_size=l2_swizzle_size,
+            runtime_direct=runtime_direct,
+            clc=clc,
         )
         warmup = bound(*args)
         torch.cuda.synchronize()
@@ -326,6 +483,31 @@ def _run_graph_replay(
     assert bool(torch.isfinite(captured).all().item())
     _assert_output(captured, args)
     return warmup, captured
+
+
+def _refresh_worklist_without_recompile(
+    bound: Any,
+    args: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    m_sizes: tuple[int, ...],
+    group_ids: tuple[int, ...],
+    source_m_tile: int,
+) -> None:
+    cached_path = bound.get_cached_path()
+    compile_cache_size = len(bound._compile_cache)
+    metadata = []
+    start = 0
+    for group, actual_m in zip(group_ids, m_sizes, strict=True):
+        store_m = _aligned_m(actual_m, source_m_tile)
+        metadata.append([group, start, actual_m, store_m])
+        start += store_m
+    assert start == args[0].size(0)
+    args[0].normal_()
+    args[2].copy_(torch.tensor(metadata, device=DEVICE, dtype=torch.int32))
+    refreshed = bound(*args)
+    torch.cuda.synchronize()
+    _assert_output(refreshed, args)
+    assert len(bound._compile_cache) == compile_cache_size
+    assert bound.get_cached_path() == cached_path
 
 
 def _require_codegen_cuda() -> None:
@@ -352,15 +534,13 @@ def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
 
     code = _code_for(_make_args((1, 127, 224, 256), n=224, k=128))
 
-    assert code.count("StaticPersistentGroupTileScheduler.create") == 1
+    assert "StaticPersistentGroupTileScheduler.create" not in code
+    assert "tcgen05_grouped_runtime_tile_records.iterator" in code
     assert "TensorMapManager" in code
     assert "update_tensormap" in code
     assert "cute.nvgpu.tcgen05.CtaGroup.TWO" in code
-    assert "(256, 256)" in code
     assert "cute.local_tile(tma_tensor_a, (256, 128)" in code
     assert "cute.local_tile(tcgen05_tma_tensor_b_tail, (256, 128)" in code
-    assert "StMatrix8x8x16bOp(transpose=True, num_matrices=4)" in code
-    assert "cute.arch.alloc_smem(cutlass.Int32, 9" in code
 
     plan = next(
         plan
@@ -372,79 +552,244 @@ def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
         "worklist_metadata": plan["worklist_metadata"],
         "dynamic_ab_tensormaps": plan["dynamic_ab_tensormaps"],
         "dynamic_d_tensormap": plan["dynamic_d_tensormap"],
+        "scheduler_mode": plan["scheduler_mode"],
+        "bm": plan["bm"],
     } == {
         "orientation": "nm",
         "worklist_metadata": True,
         "dynamic_ab_tensormaps": True,
         "dynamic_d_tensormap": True,
+        "scheduler_mode": Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT.value,
+        "bm": 256,
     }
+    assert not {
+        "problem_sizes_arg",
+        "starts_arg",
+        "real_groups_arg",
+    }.intersection(plan)
+    wrapper_body: list[str] = []
+    wrapper_call_args: list[str] = []
+    _append_cute_wrapper_plan(wrapper_body, wrapper_call_args, plan, num_sm=148)
+    assert plan["sched_params_arg"] not in wrapper_call_args
 
 
-def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
+def test_grouped_worklist_nm_runtime_direct_clc_uses_exact_record_ids() -> None:
     _require_codegen_cuda()
 
-    config = _selected_config(64)
-    config.config.pop(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+    config = _selected_config(
+        block_k=64,
+        source_m_tile=256,
+        ab_stages=6,
+        consumer_regs=256,
+        runtime_direct=True,
+        clc=True,
+    )
+    config.config[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = 8
+    code = _code_for(
+        _make_args((1, 127, 256, 256), n=512, k=128),
+        config,
+    )
+
+    assert "_cute_issue_clc_query_nomulticast" in code
+    assert "StaticPersistentGroupTileScheduler.create" not in code
+    assert "tcgen05_grouped_runtime_tile_records.iterator" in code
+    assert (
+        "_runtime_direct_linear_idx = tcgen05_work_tile_smem[cutlass.Int32(2)]" in code
+    )
+    assert (
+        "tcgen05_clc_cluster_bidz = cutlass.Int32(cute.arch.block_idx()[2])"
+    ) in code
+    plans = _wrapper_plans(code)
+    grouped_plan = next(
+        plan for plan in plans if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert (
+        grouped_plan["scheduler_mode"] == Tcgen05GroupedSchedulerMode.RUNTIME_CLC.value
+    )
+    wrapper_body: list[str] = []
+    wrapper_call_args: list[str] = []
+    _append_cute_wrapper_plan(
+        wrapper_body,
+        wrapper_call_args,
+        grouped_plan,
+        num_sm=148,
+    )
+    assert "    grid_z = tcgen05_grouped_total_clusters" in wrapper_body
+    assert grouped_plan["sched_params_arg"] not in wrapper_call_args
+    assert not any(
+        "StaticPersistentGroupTileScheduler.get_grid_shape" in line
+        for line in wrapper_body
+    )
+    ab_plan = next(plan for plan in plans if plan["kind"] == "tcgen05_ab_tma")
+    assert ab_plan["use_pdl"] is True
+
+
+def test_grouped_worklist_nm_k_major_b_swizzle_override_is_load_bearing() -> None:
+    _require_codegen_cuda()
+
+    config = _selected_config(
+        block_k=64,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+        cluster_m=1,
+        runtime_direct=True,
+    )
+    config.config["tcgen05_layout_overrides_smem_swizzle_b"] = 128
     code = _code_for(
         _make_args(
-            (1, 127, 224, 256),
-            n=224,
-            k=64,
-            source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+            (1, 17),
+            n=256,
+            k=128,
+            source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
         ),
         config,
     )
 
-    assert "(256, 224, 64)" in code
-    assert "cute.local_tile(tma_tensor_a, (256, 64)" in code
-    assert "tcgen05_tma_tensor_b_tail" not in code
-    assert "cute.local_tile(tma_tensor_b, (224, 64)" in code
+    device_b_layouts = [
+        line.strip()
+        for line in code.splitlines()
+        if line.strip().startswith("sB_layout = ")
+    ]
+    assert device_b_layouts
+    assert all("SmemLayoutAtomKind.K_SW128" in line for line in device_b_layouts)
+    assert all("order=(1, 2, 3)" in line for line in device_b_layouts)
+
+    ab_plan = next(
+        plan for plan in _wrapper_plans(code) if plan["kind"] == "tcgen05_ab_tma"
+    )
+    assert ab_plan["b_k_major"] is True
+    assert ab_plan["smem_swizzle_b"] == 128
+    wrapper_body: list[str] = []
+    wrapper_call_args: list[str] = []
+    _append_cute_wrapper_plan(wrapper_body, wrapper_call_args, ab_plan)
+    wrapper_source = "\n".join(wrapper_body)
+    assert "SmemLayoutAtomKind.K_SW128" in wrapper_source
+    assert "order=(1, 2, 3)" in wrapper_source
+
+
+def test_grouped_worklist_nm_runtime_direct_clc_rejects_dynamic_tensormaps() -> None:
+    _require_codegen_cuda()
+
+    config = _selected_config(
+        block_k=64,
+        source_m_tile=256,
+        ab_stages=6,
+        consumer_regs=256,
+        runtime_direct=True,
+        clc=True,
+    )
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="requires fixed full-allocation TensorMaps",
+    ):
+        # N=224 is a valid worklist extent, but it is not a whole 256-wide
+        # CtaGroup.TWO MMA tile and therefore needs per-CTA dynamic TensorMaps.
+        _code_for(_make_args((1, 127, 256), n=224, k=128), config)
+
+
+def test_grouped_worklist_nm_can_retain_scheduler_mailbox() -> None:
+    _require_codegen_cuda()
+
+    with (
+        patch(
+            "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+            return_value=True,
+        ) as compatible,
+        patch(
+            "helion._compiler.cute.cute_mma.warn_tcgen05_runtime_n_ptx_fallback"
+        ) as warn_fallback,
+    ):
+        code = _code_for(
+            _make_args((1, 127, 224, 256), n=224, k=128),
+            _selected_config(runtime_direct=False),
+        )
+
+    assert "StaticPersistentGroupTileScheduler.create" in code
+    assert "tcgen05_grouped_runtime_tile_records.iterator" not in code
+    assert "cutlass.experimental.primitives.inline_ptx(" not in code
+    assert "cute.gemm(" in code
+    compatible.assert_not_called()
+    warn_fallback.assert_not_called()
+    assert "tcgen05_work_tile_smem" in code
+    assert (
+        "cutlass.Int32(0) < tcgen05_grouped_selected_source_m_tiles <= "
+        "tcgen05_grouped_selected_source_n_tiles"
+    ) in code
+    assert TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT == 9
+    assert (
+        "cute.arch.alloc_smem(cutlass.Int32, "
+        f"{TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT},"
+    ) in code
+    role_sources = {
+        ast.unparse(node.test): ast.unparse(node)
+        for node in ast.walk(ast.parse(code))
+        if isinstance(node, ast.If) and "while tcgen05_role_local_" in ast.unparse(node)
+    }
+    for predicate in (
+        "cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(4)",
+        "cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(5)",
+    ):
+        role_source = role_sources[predicate]
+        assert "tcgen05_grouped_selected_tile_start" not in role_source
+        assert "tcgen05_grouped_valid_m" not in role_source
+        assert "tcgen05_grouped_store_m" not in role_source
+    epi_source = role_sources[
+        "cute.arch.make_warp_uniform(cute.arch.warp_idx()) < cutlass.Int32(4)"
+    ]
+    assert "tcgen05_grouped_selected_tile_start" in epi_source
+    assert "tcgen05_grouped_valid_m =" in epi_source
+    assert "tcgen05_grouped_store_m =" in epi_source
     plan = next(
         plan
         for plan in _wrapper_plans(code)
         if plan["kind"] == "tcgen05_grouped_static_persistent"
     )
-    assert plan["bk"] == 64
-    assert plan["source_m_tile"] == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    assert (
+        plan["scheduler_mode"] == Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value
+    )
 
 
-def test_grouped_worklist_nm_rejects_over_budget_host_metadata_profile() -> None:
+def test_grouped_worklist_nm_runtime_direct_falls_back_without_runtime_n_ptx() -> None:
     _require_codegen_cuda()
 
-    config = _selected_config(64)
-    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = (
-        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+    config = _selected_config(
+        128,
+        source_m_tile,
+        ab_stages=3,
+        runtime_direct=True,
     )
-    args = _make_args(
-        (224, 256),
-        n=224,
-        k=64,
-        source_m_tile=TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
-    )
-    with pytest.raises(
-        helion.exc.BackendUnsupported,
-        match="grouped N,M worklist generated allocations require",
-    ):
-        _code_for(args, config)
-
-
-def test_grouped_worklist_nm_rejects_alpha_scaled_row() -> None:
-    _require_codegen_cuda()
-
-    args = (*_make_args((224, 256), n=224, k=128), 2)
-    _selected_kernel.reset()
-    bound = _selected_kernel.bind(args)
-    assert not bound.env.config_spec.cute_tcgen05_search_enabled
-    bound.env.config_spec.cute_tcgen05_search_enabled = True
     with (
-        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
-        patch_cute_mma_support(),
-        pytest.raises(
-            helion.exc.BackendUnsupported,
-            match="rank3 grouped semantic proof failed",
+        patch(
+            "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+            return_value=False,
         ),
+        patch(
+            "helion._compiler.cute.cute_mma.warn_tcgen05_runtime_n_ptx_fallback"
+        ) as warn_fallback,
     ):
-        bound.to_triton_code(_selected_config())
+        code = _code_for(
+            _make_args(
+                (1, 257),
+                n=512,
+                k=256,
+                dirty_padding=True,
+                source_m_tile=source_m_tile,
+            ),
+            config,
+        )
+
+    assert "cutlass.experimental.primitives.inline_ptx(" not in code
+    assert "cute.gemm(" in code
+    assert "cute.local_tile(tma_tensor_b, (256, 128)" in code
+    assert "if tcgen05_grouped_valid_m == cutlass.Int32(256):" in code
+    assert "cute.where(tcgen05_selected_valid_row_mask" in code
+    plan = next(
+        plan
+        for plan in _wrapper_plans(code)
+        if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert plan["scheduler_mode"] == Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT.value
+    warn_fallback.assert_called_once_with()
 
 
 @pytest.mark.parametrize(
@@ -464,11 +809,15 @@ def test_grouped_worklist_nm_runtime_n_tail_descriptors_codegen(
 ) -> None:
     _require_codegen_cuda()
 
-    config = _selected_config(block_k, source_m_tile)
-    code = _code_for(
-        _make_args((1, 257), n=512, k=128, source_m_tile=source_m_tile),
-        config,
-    )
+    config = _selected_config(block_k, source_m_tile, runtime_direct=True)
+    with patch(
+        "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+        return_value=True,
+    ):
+        code = _code_for(
+            _make_args((1, 257), n=512, k=128, source_m_tile=source_m_tile),
+            config,
+        )
 
     assert "cutlass.experimental.primitives.inline_ptx(" in code
     assert (
@@ -521,24 +870,6 @@ def test_grouped_worklist_nm_runtime_n_tail_descriptors_codegen(
     assert "Tcgen05InstrDesc.build" not in ast.unparse(tma_guard)
     assert "tcgen05_tma_b_peer_delta" not in ast.unparse(mma_guard)
 
-    # Keep both sides of the dynamic tail branch on the same CuTe pytree by
-    # normalizing the full-N TensorMap with a DSL-typed zero domain offset.
-    normalized_tail_runs = []
-    for node in ast.walk(tree):
-        body = getattr(node, "body", None)
-        if not isinstance(body, list):
-            continue
-        for index in range(len(body) - 2):
-            run = body[index : index + 3]
-            if (
-                "tcgen05_tma_b_peer_delta = cutlass.Int32(0)" in ast.unparse(run[0])
-                and "tcgen05_tma_tensor_b_tail = cute.domain_offset("
-                in ast.unparse(run[1])
-                and run[2] is tma_guard
-            ):
-                normalized_tail_runs.append(run)
-    assert len(normalized_tail_runs) == 1
-
 
 @pytest.mark.parametrize(
     ("block_k", "source_m_tile"),
@@ -560,9 +891,6 @@ def test_grouped_worklist_nm_fixed_full_allocation_tensormaps_codegen(
 
     assert "TensorMapManager" not in code
     assert "update_tensormap" not in code
-    assert "tcgen05_grouped_tensormap" not in code
-    assert "tcgen05_grouped_d_tensormap" not in code
-    assert "tcgen05_tma_full_tile =" not in code
 
     plans = _wrapper_plans(code)
     grouped_plan = next(
@@ -650,16 +978,8 @@ def test_grouped_worklist_nm_one_cta_codegen() -> None:
         config,
     )
 
-    assert config.block_sizes[:3] == [256, 128, 64]
     assert "cute.nvgpu.tcgen05.CtaGroup.ONE" in code
     assert "cute.nvgpu.tcgen05.CtaGroup.TWO" not in code
-    assert "tcgen05_tma_b_peer_delta" not in code
-    assert "tcgen05_tma_tensor_b_tail" not in code
-    assert "cute.gemm(" in code
-    assert "cutlass.experimental.primitives.inline_ptx(" in code
-    assert "tcgen05.mma.cta_group::1.kind::f16" in code
-    assert "tcgen05.mma.cta_group::2.kind::f16" not in code
-    assert "StaticPersistentGroupTileScheduler.create" in code
     assert "cute.local_tile(tma_tensor_a, (128, 64)" in code
     assert f"cute.local_tile(tma_tensor_b, ({source_m_tile}, 64)" in code
 
@@ -696,6 +1016,36 @@ def test_grouped_worklist_nm_one_cta_codegen() -> None:
     assert (d_plan["bm"], d_plan["bn"]) == (128, source_m_tile)
 
 
+def test_grouped_worklist_nm_one_cta_runtime_direct_uses_physical_n_tile() -> None:
+    _require_codegen_cuda()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+    config = _selected_config(
+        64,
+        source_m_tile,
+        cluster_m=1,
+        runtime_direct=True,
+    )
+    code = _code_for(
+        _make_args((24, 23, 19, 17, 20, 15), n=4096, k=128),
+        config,
+    )
+
+    assert "cute.nvgpu.tcgen05.CtaGroup.ONE" in code
+    assert "StaticPersistentGroupTileScheduler.create" not in code
+    assert "tcgen05_grouped_runtime_tile_records.iterator" in code
+    grouped_plan = next(
+        plan
+        for plan in _wrapper_plans(code)
+        if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert (
+        grouped_plan["scheduler_mode"]
+        == Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT.value
+    )
+    assert grouped_plan["bm"] == 128
+
+
 @pytest.mark.parametrize(
     ("block_k", "ab_stages", "consumer_regs"),
     ((64, 7, 240), (128, 5, 256)),
@@ -727,6 +1077,10 @@ def test_grouped_worklist_nm_one_cta_fixed_tensormap_mn_major_b_codegen(
     )
 
     assert "cute.nvgpu.tcgen05.CtaGroup.ONE" in code
+    assert (
+        "cutlass.BFloat16, cutlass.BFloat16, "
+        "cute.nvgpu.OperandMajorMode.MN, cute.nvgpu.OperandMajorMode.K"
+    ) in code
     assert f"cute.local_tile(tma_tensor_a, (128, {block_k}, 1)" in code
     assert "tcgen05_grouped_cta_tile_idx_n, None, tcgen05_grouped_group_idx" in code
 
@@ -745,6 +1099,57 @@ def test_grouped_worklist_nm_one_cta_fixed_tensormap_mn_major_b_codegen(
     )
     assert ab_plan["fixed_ab_tensormaps"] is True
     assert ab_plan["fixed_grouped_b_rank3"] is True
+    assert ab_plan["a_k_major"] is False
+    assert ab_plan["b_k_major"] is True
+
+
+def test_grouped_worklist_nm_one_cta_runtime_direct_upper_n_record_count() -> None:
+    rows = [
+        [group, group * 32, actual_m, 32]
+        for group, actual_m in enumerate((24, 23, 19, 17, 20, 15))
+    ]
+    records = _tcgen05_grouped_runtime_nm_tile_records(
+        rows,
+        [(4096, 32, 2048, 1)] * len(rows),
+        source_tile_m=32,
+        source_tile_n=128,
+        l2_swizzle_size=1,
+    )
+
+    assert len(records) == 6 * 32
+    for metadata_idx in range(6):
+        group_records = records[metadata_idx * 32 : (metadata_idx + 1) * 32]
+        assert group_records[:, 1].tolist() == list(range(32))
+        assert set(group_records[:, 2].tolist()) == {metadata_idx}
+
+
+def test_grouped_worklist_nm_panel_raster_codegen_and_mapping() -> None:
+    _require_codegen_cuda()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    args = _make_args(
+        (257, 513),
+        n=2560,
+        k=128,
+        source_m_tile=source_m_tile,
+    )
+    runtime_panel_config = _selected_config(
+        64,
+        source_m_tile,
+        runtime_direct=True,
+    )
+    runtime_panel_config.config[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = 8
+    runtime_panel_code = _code_for(args, runtime_panel_config)
+    grouped_plan = next(
+        plan
+        for plan in _wrapper_plans(runtime_panel_code)
+        if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert (
+        grouped_plan["scheduler_mode"]
+        == Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT.value
+    )
+    assert grouped_plan["l2_swizzle_size"] == 8
 
 
 def test_grouped_worklist_nm_fixed_tensormap_rejects_misaligned_d() -> None:
@@ -804,6 +1209,7 @@ def test_grouped_worklist_nm_validator_accepts_exact_mn_major_b_only() -> None:
     plan: dict[str, object] = {
         "fixed_ab_tensormaps": True,
         "dynamic_ab_tensormap_rank": 2,
+        "orientation": "nm",
         "lhs_idx": 0,
         "rhs_idx": 1,
     }
@@ -820,6 +1226,73 @@ def test_grouped_worklist_nm_validator_accepts_exact_mn_major_b_only() -> None:
             plan,
             (a_packed, padded_mn_major_b),
         )
+
+
+def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
+    _require_codegen_cuda()
+
+    config = _selected_config(64)
+    config.config.pop(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+    code = _code_for(
+        _make_args(
+            (1, 127, 224, 256),
+            n=224,
+            k=64,
+            source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        ),
+        config,
+    )
+
+    assert "(256, 224, 64)" in code
+    assert "cute.local_tile(tma_tensor_a, (256, 64)" in code
+    assert "tcgen05_tma_tensor_b_tail" not in code
+    assert "cute.local_tile(tma_tensor_b, (224, 64)" in code
+    plan = next(
+        plan
+        for plan in _wrapper_plans(code)
+        if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert plan["bk"] == 64
+    assert plan["source_m_tile"] == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+
+
+def test_grouped_worklist_nm_rejects_over_budget_host_metadata_profile() -> None:
+    _require_codegen_cuda()
+
+    config = _selected_config(64)
+    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = (
+        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+    )
+    args = _make_args(
+        (224, 256),
+        n=224,
+        k=64,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+    )
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="grouped N,M worklist generated allocations require",
+    ):
+        _code_for(args, config)
+
+
+def test_grouped_worklist_nm_rejects_alpha_scaled_row() -> None:
+    _require_codegen_cuda()
+
+    args = (*_make_args((224, 256), n=224, k=128), 2)
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    assert not bound.env.config_spec.cute_tcgen05_search_enabled
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+        pytest.raises(
+            helion.exc.BackendUnsupported,
+            match="rank3 grouped semantic proof failed",
+        ),
+    ):
+        bound.to_triton_code(_selected_config())
 
 
 @pytest.mark.parametrize(
@@ -882,23 +1355,294 @@ def test_grouped_worklist_nm_runtime_and_graph_replay(
         expected_metadata.append([group, start, actual_m, store_m])
         start += store_m
     assert args[2].cpu().tolist() == expected_metadata
+    panel8_shape_profile = (
+        block_k == 64
+        and source_m_tile == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    )
     with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
-        bound = _configured_bound(args, block_k)
+        bound = _configured_bound(
+            args,
+            block_k,
+            source_m_tile=source_m_tile,
+            consumer_regs=256 if panel8_shape_profile else None,
+            l2_swizzle_size=8 if panel8_shape_profile else None,
+            runtime_direct=True,
+        )
         warmup = bound(*args)
         torch.cuda.synchronize()
         _assert_output(warmup, args)
+        # Reuse the same bound kernel with different runtime group boundaries
+        # and a non-identity metadata-row-to-group mapping.  Total aligned M is
+        # unchanged, so this exercises the scheduler metadata refresh rather
+        # than recompilation or a new allocation shape.
+        mutated_m_sizes = (
+            (225, 224, 449)
+            if source_m_tile == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+            else (257, 224, 256)
+        )
+        mutated_group_ids = (2, 0, 1)
+        _refresh_worklist_without_recompile(
+            bound,
+            args,
+            mutated_m_sizes,
+            mutated_group_ids,
+            source_m_tile,
+        )
 
         args[0].normal_()
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
-            captured = bound(*args)
-        torch.cuda.synchronize()
-
-        captured.fill_(-7.0)
-        graph.replay()
-        torch.cuda.synchronize()
+        captured = _capture_and_replay(bound, args, poison=-7.0)
 
     _assert_output(captured, args)
+
+
+@pytest.mark.parametrize("runtime_direct", (False, True))
+def test_grouped_worklist_nm_zero_token_groups_runtime_and_graph_replay(
+    runtime_direct: bool,
+) -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    args = _make_args(
+        (0, 224, 0, 449),
+        n=512,
+        k=128,
+        dirty_padding=True,
+        source_m_tile=source_m_tile,
+    )
+    args[2][2, 1] = 0
+    assert args[2].cpu().tolist() == [
+        [0, 0, 0, 0],
+        [1, 0, 224, 224],
+        [2, 0, 0, 0],
+        [3, 224, 449, 672],
+    ]
+    _run_graph_replay(
+        args,
+        64,
+        source_m_tile=source_m_tile,
+        runtime_direct=runtime_direct,
+    )
+
+
+def test_grouped_worklist_nm_zero_valid_tail_runtime_and_graph_replay() -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    n = 256
+    k = 128
+    aligned_m = 2 * source_m_tile
+    args = (
+        torch.randn((aligned_m, k), device=DEVICE, dtype=torch.bfloat16),
+        torch.randn((1, n, k), device=DEVICE, dtype=torch.bfloat16),
+        torch.tensor(
+            [[0, 0, 1, aligned_m]],
+            device=DEVICE,
+            dtype=torch.int32,
+        ),
+    )
+    records = _tcgen05_grouped_runtime_nm_tile_records(
+        args[2].cpu().tolist(),
+        [(n, aligned_m, k, 1)],
+        source_tile_m=source_m_tile,
+        source_tile_n=256,
+        l2_swizzle_size=1,
+    )
+    assert records[:, [0, 8, 9]].tolist() == [
+        [0, 1, source_m_tile],
+        [1, 0, source_m_tile],
+    ]
+
+    config = _selected_config(
+        64,
+        source_m_tile,
+        ab_stages=3,
+        runtime_direct=True,
+    )
+    code = _code_for(args, config)
+    assert "max(tcgen05_grouped_valid_m, cutlass.Int32(1))" in code
+    assert "tcgen05_runtime_mma_n = cutlass.Int32(0)" not in code
+    assert f"tcgen05_tma_runtime_mma_n = cutlass.Int32({source_m_tile})" in code
+    _run_graph_replay(
+        args,
+        64,
+        ab_stages=3,
+        source_m_tile=source_m_tile,
+        runtime_direct=True,
+    )
+
+
+def test_grouped_worklist_nm_nonzero_overlap_is_rejected_at_launch() -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    args = _make_args(
+        (224, 224),
+        n=512,
+        k=128,
+        source_m_tile=source_m_tile,
+    )
+    args[2][1, 1] = 0
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _configured_bound(
+            args,
+            64,
+            ab_stages=3,
+            source_m_tile=source_m_tile,
+            runtime_direct=True,
+        )
+        with pytest.raises(
+            helion.exc.BackendUnsupported,
+            match="overlapping A rows",
+        ):
+            bound(*args)
+
+
+def test_grouped_worklist_nm_all_empty_is_rejected_at_launch() -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    args = _make_args(
+        (0, 0),
+        n=512,
+        k=128,
+        source_m_tile=source_m_tile,
+    )
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _configured_bound(
+            args,
+            64,
+            source_m_tile=source_m_tile,
+            runtime_direct=True,
+        )
+        with pytest.raises(
+            helion.exc.BackendUnsupported,
+            match="all-empty worklist",
+        ):
+            bound(*args)
+
+
+def test_grouped_worklist_nm_runtime_direct_clc_runtime_and_graph_replay() -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+    m_sizes = (1024, 1024, 1024)
+    n = 4096
+    args = _make_args(
+        m_sizes,
+        n=n,
+        k=128,
+        dirty_padding=True,
+        source_m_tile=source_m_tile,
+    )
+    logical_clusters = sum(
+        _aligned_m(actual_m, source_m_tile) // source_m_tile for actual_m in m_sizes
+    ) * (n // 256)
+    assert (
+        logical_clusters
+        > torch.cuda.get_device_properties(DEVICE).multi_processor_count // 2
+    )
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _configured_bound(
+            args,
+            64,
+            ab_stages=6,
+            source_m_tile=source_m_tile,
+            consumer_regs=256,
+            l2_swizzle_size=8,
+            runtime_direct=True,
+            clc=True,
+        )
+        warmup = bound(*args)
+        torch.cuda.synchronize()
+        _assert_output(warmup, args)
+        mutated_m_sizes = (767, 1024, 1280)
+        mutated_group_ids = (2, 0, 1)
+        _refresh_worklist_without_recompile(
+            bound,
+            args,
+            mutated_m_sizes,
+            mutated_group_ids,
+            source_m_tile,
+        )
+
+        args[0].normal_()
+        captured = _capture_and_replay(bound, args)
+
+    assert bool(torch.isfinite(captured).all().item())
+    _assert_output(captured, args)
+
+
+def test_grouped_worklist_nm_panel_raster_runtime_and_graph_replay() -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    args = _make_args(
+        (257, 513),
+        n=2560,
+        k=128,
+        dirty_padding=True,
+        source_m_tile=source_m_tile,
+    )
+    warmup, captured = _run_graph_replay(
+        args,
+        64,
+        source_m_tile=source_m_tile,
+        l2_swizzle_size=8,
+        runtime_direct=True,
+    )
+    torch.testing.assert_close(captured, warmup, rtol=0, atol=0)
+
+
+def test_grouped_worklist_nm_bk128_ab2_runtime_and_graph_replay() -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    args = _make_args(
+        (224, 449, 256),
+        n=512,
+        k=256,
+        dirty_padding=True,
+        source_m_tile=source_m_tile,
+    )
+    _run_graph_replay(
+        args,
+        128,
+        ab_stages=2,
+        source_m_tile=source_m_tile,
+    )
+
+
+def test_grouped_worklist_nm_small_source_public_profile_graph_replay() -> None:
+    _require_runtime_cuda13_sm100()
+
+    args = _make_args(
+        (24, 23, 19, 17, 20, 18),
+        n=4096,
+        k=2048,
+        dirty_padding=True,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+    )
+    assert args[2].cpu().tolist() == [
+        [0, 0, 24, 32],
+        [1, 32, 23, 32],
+        [2, 64, 19, 32],
+        [3, 96, 17, 32],
+        [4, 128, 20, 32],
+        [5, 160, 18, 32],
+    ]
+    _, captured = _run_graph_replay(
+        args,
+        64,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+    )
+    a_packed, b_grouped, work_tile_metadata = args
+    for group, start, valid_m, _store_m in work_tile_metadata.cpu().tolist():
+        oracle = a_packed[start : start + valid_m].float() @ b_grouped[group].float().T
+        actual = captured[start : start + valid_m].double()
+        oracle = oracle.double()
+        denominator = (actual.square() + oracle.square()).sum()
+        diff = 1 - 2 * (actual * oracle).sum() / denominator
+        assert float(diff.item()) <= 1e-5
 
 
 def test_grouped_worklist_nm_one_cta_mn_major_legacy_graph_replay() -> None:
@@ -922,3 +1666,95 @@ def test_grouped_worklist_nm_one_cta_mn_major_legacy_graph_replay() -> None:
         cluster_m=1,
         consumer_regs=240,
     )
+
+
+def test_grouped_worklist_nm_one_cta_direct_graph_replay() -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+    # Include a <=16-row group so CTA-group::1 exercises its runtime UMMA-N=16
+    # descriptor path in addition to the full physical N=32 path.
+    actual_ms = (24, 23, 19, 17, 20, 15)
+    args = _make_args(
+        actual_ms,
+        n=4096,
+        k=2048,
+        dirty_padding=True,
+        source_m_tile=source_m_tile,
+    )
+    expected_metadata = []
+    start = 0
+    for group, actual_m in enumerate(actual_ms):
+        expected_metadata.append([group, start, actual_m, source_m_tile])
+        start += source_m_tile
+    assert args[2].cpu().tolist() == expected_metadata
+    _run_graph_replay(
+        args,
+        64,
+        source_m_tile=source_m_tile,
+        cluster_m=1,
+        runtime_direct=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("block_k", "ab_stages", "consumer_regs", "mn_major_b"),
+    (
+        pytest.param(128, 5, 256, False, id="k-major-bk128"),
+        pytest.param(64, 7, 240, True, id="mn-major-bk64"),
+    ),
+)
+def test_grouped_worklist_nm_one_cta_promoted_profiles_graph_replay(
+    block_k: int,
+    ab_stages: int,
+    consumer_regs: int,
+    mn_major_b: bool,
+) -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+    args = _make_args(
+        (24, 23, 19, 17, 20, 18),
+        n=512,
+        k=2 * block_k,
+        dirty_padding=True,
+        mn_major_b=mn_major_b,
+        source_m_tile=source_m_tile,
+    )
+    n, k = args[1].shape[1:]
+    expected_b_stride = (n * k, 1, n) if mn_major_b else (n * k, k, 1)
+    assert tuple(args[1].stride()) == expected_b_stride
+    warmup, captured = _run_graph_replay(
+        args,
+        block_k,
+        ab_stages=ab_stages,
+        source_m_tile=source_m_tile,
+        cluster_m=1,
+        consumer_regs=consumer_regs,
+        runtime_direct=True,
+    )
+    torch.testing.assert_close(captured, warmup, rtol=0, atol=0)
+
+
+def test_grouped_worklist_nm_one_cta_multitile_dynamic_graph_replay() -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+    args = _make_args(
+        (65, 33),
+        n=160,
+        k=128,
+        dirty_padding=True,
+        source_m_tile=source_m_tile,
+    )
+    assert args[2].cpu().tolist() == [
+        [0, 0, 65, 96],
+        [1, 96, 33, 64],
+    ]
+    warmup, captured = _run_graph_replay(
+        args,
+        64,
+        source_m_tile=source_m_tile,
+        cluster_m=1,
+    )
+    torch.testing.assert_close(captured, warmup, rtol=0, atol=0)

--- a/test/test_cute_device_state.py
+++ b/test/test_cute_device_state.py
@@ -17,8 +17,11 @@ from helion._compiler.ast_extension import statement_from_string
 from helion._compiler.cute.cute_mma import _collective_load_dependency_nodes
 from helion._compiler.cute.cutedsl_compat import emit_pipeline_advance
 from helion._compiler.cute.device_state import CuteDeviceFunctionState
+from helion._compiler.cute.device_state import CuteTcgen05GroupedPlan
 from helion._compiler.cute.device_state import CuteTcgen05MatmulPlan
 from helion._compiler.cute.device_state import CuteTcgen05StoreValue
+from helion._compiler.cute.device_state import Tcgen05GroupedDMode
+from helion._compiler.cute.device_state import Tcgen05GroupedSchedulerMode
 from helion._compiler.cute.device_state import Tcgen05Orientation
 from helion._compiler.cute.tcgen05_lifecycle import Tcgen05LifecycleContext
 from helion._compiler.cute.tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
@@ -54,6 +57,27 @@ def _plan(**overrides: object) -> CuteTcgen05MatmulPlan:
     }
     kwargs.update(overrides)
     return CuteTcgen05MatmulPlan(**kwargs)
+
+
+def _grouped_plan(**overrides: object) -> CuteTcgen05GroupedPlan:
+    kwargs: dict[str, Any] = {
+        "orientation": Tcgen05Orientation.MN,
+        "layout": "layout",
+        "count": "2",
+        "sched_params": "sched_params",
+        "problem_sizes": "problem_sizes",
+        "starts": "starts",
+        "metadata_idx": "metadata_idx",
+        "group_idx": "group_idx",
+        "cta_tile_idx_m": "cta_tile_idx_m",
+        "cta_tile_idx_n": "cta_tile_idx_n",
+        "problem_m": "problem_m",
+        "problem_n": "problem_n",
+        "problem_k": "problem_k",
+        "global_m_start": "global_m_start",
+    }
+    kwargs.update(overrides)
+    return CuteTcgen05GroupedPlan(**kwargs)
 
 
 def _lifecycle(**overrides: object) -> Tcgen05LifecycleContext:
@@ -151,6 +175,92 @@ class _StatementCaptureGenerateAST(GenerateAST):
 
 @onlyBackends(["cute"])
 class TestCuteDeviceFunctionState(unittest.TestCase):
+    def test_grouped_scheduler_modes_enforce_complete_state(self) -> None:
+        device_search = _grouped_plan()
+        self.assertFalse(device_search.uses_runtime_tile_table)
+
+        runtime_direct = _grouped_plan(
+            orientation=Tcgen05Orientation.NM,
+            scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+            runtime_tile_records="runtime_tile_records",
+            runtime_total_clusters="runtime_total_clusters",
+            real_groups="real_groups",
+            valid_m="valid_m",
+            store_m="store_m",
+            source_m_tile=32,
+            d_mode=Tcgen05GroupedDMode.ALL_TILES,
+            d_tensormap="d_tensormap",
+        )
+        self.assertTrue(runtime_direct.uses_runtime_tile_table)
+
+        with self.assertRaises(AssertionError):
+            dataclasses.replace(
+                runtime_direct,
+                scheduler_mode=Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH,
+            )
+        with self.assertRaises(AssertionError):
+            _grouped_plan(
+                scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+            )
+        with self.assertRaises(AssertionError):
+            _grouped_plan(fixed_tensormaps=True)
+        with self.assertRaises(AssertionError):
+            dataclasses.replace(
+                runtime_direct,
+                scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
+            )
+
+        runtime_clc = dataclasses.replace(
+            runtime_direct,
+            scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
+            fixed_tensormaps=True,
+            d_mode=Tcgen05GroupedDMode.NONE,
+            d_tensormap=None,
+        )
+        self.assertTrue(runtime_clc.uses_runtime_tile_table)
+
+    def test_grouped_runtime_mode_matches_parent_warp_topology(self) -> None:
+        runtime_direct = _grouped_plan(
+            orientation=Tcgen05Orientation.NM,
+            scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+            runtime_tile_records="runtime_tile_records",
+            runtime_total_clusters="runtime_total_clusters",
+            real_groups="real_groups",
+            valid_m="valid_m",
+            store_m="store_m",
+            source_m_tile=32,
+            d_mode=Tcgen05GroupedDMode.ALL_TILES,
+            d_tensormap="d_tensormap",
+        )
+        _plan(grouped=runtime_direct)
+        with self.assertRaises(AssertionError):
+            _plan(grouped=runtime_direct, scheduler_warp_count=1)
+
+        device_search_nm = dataclasses.replace(
+            runtime_direct,
+            scheduler_mode=Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH,
+            runtime_tile_records=None,
+            runtime_total_clusters=None,
+        )
+        _plan(grouped=device_search_nm, scheduler_warp_count=1)
+        with self.assertRaises(AssertionError):
+            _plan(grouped=device_search_nm)
+
+        runtime_clc = dataclasses.replace(
+            runtime_direct,
+            scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
+            fixed_tensormaps=True,
+            d_mode=Tcgen05GroupedDMode.NONE,
+            d_tensormap=None,
+        )
+        _plan(
+            grouped=runtime_clc,
+            scheduler_warp_count=1,
+            persistence_model="clc_persistent",
+        )
+        with self.assertRaises(AssertionError):
+            _plan(grouped=runtime_clc, persistence_model="clc_persistent")
+
     def test_tcgen05_store_value_d_store_layout_uses_output_layout(self) -> None:
         value = CuteTcgen05StoreValue(
             lifecycle_context=_lifecycle(), output_block_ids=(0, 1)

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -20453,6 +20453,25 @@ class TestPersistentLoopSplitter(unittest.TestCase):
             work_tile_release_stmts=[],
         )
 
+    def test_clustered_pid_mailbox_rendezvous_precedes_first_acquire(self) -> None:
+        """Peer mailbox mbarriers must be initialized cluster-wide first."""
+        _stub_df, splitter = self._make_role_local_stubs(num_pid_dims=2)
+        splitter._tcgen05_l2_swizzle_size = lambda: 1  # type: ignore[attr-defined]
+        layout = self._make_minimal_layout(cluster_m=2)
+        layout.work_tile_publish_stmts = [self._stmt("sp.producer_acquire(ps)")]
+
+        emitted = splitter._build_tcgen05_persistent_prelude(layout)
+        source = "\n".join(ast.unparse(stmt) for stmt in emitted)
+        create = source.index("sp = cutlass.pipeline.PipelineAsync.create(")
+        arrive = source.index("cutlass.pipeline.pipeline_init_arrive(")
+        wait = source.index("cutlass.pipeline.pipeline_init_wait(")
+        acquire = source.index("sp.producer_acquire(ps)")
+
+        self.assertLess(create, arrive)
+        self.assertLess(arrive, wait)
+        self.assertLess(wait, acquire)
+        self.assertIn("cute.make_layout((2, 1, 1))", source)
+
     def test_tcgen05_persistent_foreach_multi_root_keeps_host_guard(self) -> None:
         """Multi-root tcgen05 role-local codegen is guarded as unvalidated.
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3447 (`6a16fe28`)
 * #3446 (`68226540`)
 * #3445 (`1c012826`)
 * __->__ #3444 (`e9ca9174`)
 * #3443 (`27b2ad77`, base `main`)

--- --- ---

## Summary

- Add device-search, runtime-direct, and runtime-CLC grouped-GEMM scheduler modes with fail-closed legality checks.
- Normalize runtime tile records and generate exact output-tile worklists with M/N rasterization and optional snaking L2 panels.
- Validate group IDs, coverage, empty groups, all-empty calls, and CUDA's CLC grid limit.
- Reuse compiled launchers across dynamic record counts and retain CUDA graph replay metadata.
- Keep runtime-table kernel signatures minimal: only runtime tile records and total clusters are passed, with no legacy grouped metadata arguments.
- Consume runtime records directly in each role while preserving the synchronized mailbox fallback.

## Test plan

- `./lint.sh check`
- `HELION_BACKEND=cute pytest -q test/test_config_api.py test/test_cute_backend.py test/test_cute_deepgemm_selected.py test/test_cute_device_state.py test/test_cute_lowerings.py`
- The definitive stack collected 3,304 tests. Focused boundary validation completed 376 passes, 84 expected backend-gated skips, and 179 subtests with no failures; Ruff, codespell, and Pyrefly were clean.

## Exact-head performance regression check

Performance was measured from the clean definitive five-PR head `6a16fe28` (tree `b11260a4`) on an idle NVIDIA B200. Three fresh-process/fresh-cache DeepGEMM replicates per selection mode produced:

| Helion selection | DeepGEMM/Helion geomean | Rows won (3-replicate geomean) | Worst row geomean |
|---|---:|---:|---:|
| Reviewed AOT | `1.0160×` | 7/8 | `0.9945×` |
| Compiler heuristic | `1.0177×` | 7/8 | `0.9922×` |

All 48 row-replicate comparisons passed correctness, and every selected-config hash exactly matched the prior validated set. Both results clear the predeclared 98%-of-historical-median no-regression gates. Each worker used a 10 s warmup and 102 balanced, rotated/reversed cold-L2 samples. Telemetry showed only the previously observed idle/software-power-cap reason classes; no thermal or hardware slowdown reason appeared.

## Historical five-provider complete-stack benchmark

These are one-replicate B200 smoke results from the earlier complete-stack source `2e4f90a5` (tree `c255c018`), retained as five-provider coverage rather than an isolated claim for this PR. All 80 comparisons passed correctness. Each cell is `provider_time / Helion_time`; values above `1.0×` mean Helion is faster. `M/group` is nominal; exact ragged per-group `M` values were used internally.

### Reviewed AOT

| Case `(groups × nominal M/group × N × K)` | DeepGEMM | QuACK | cuDNN | cuBLASLt | CUTLASS |
|---|---:|---:|---:|---:|---:|
| 4 × 8192 × 6144 × 7168 | `1.0315×` | `1.0118×` | `1.0148×` | `1.1544×` | `1.2356×` |
| 4 × 8192 × 7168 × 3072 | `0.9926×` | `1.0032×` | `1.0183×` | `1.2015×` | `1.3605×` |
| 4 × 8192 × 4096 × 4096 | `1.0165×` | `0.9922×` | `1.0256×` | `1.0922×` | `1.4075×` |
| 4 × 8192 × 4096 × 2048 | `1.0017×` | `1.0041×` | `1.0192×` | `1.2004×` | `1.3832×` |
| 8 × 4096 × 6144 × 7168 | `1.0277×` | `1.0141×` | `1.0370×` | `1.1517×` | `1.1984×` |
| 8 × 4096 × 7168 × 3072 | `1.0137×` | `0.9984×` | `1.0249×` | `1.1892×` | `1.3604×` |
| 8 × 4096 × 4096 × 4096 | `0.9986×` | `1.0046×` | `1.0433×` | `1.1630×` | `1.3657×` |
| 8 × 4096 × 4096 × 2048 | `1.0165×` | `1.0167×` | `1.0870×` | `1.2704×` | `1.3454×` |
| **Geomean** | **`1.0122×`** | **`1.0056×`** | **`1.0335×`** | **`1.1769×`** | **`1.3302×`** |

### Compiler heuristics

| Case `(groups × nominal M/group × N × K)` | DeepGEMM | QuACK | cuDNN | cuBLASLt | CUTLASS |
|---|---:|---:|---:|---:|---:|
| 4 × 8192 × 6144 × 7168 | `1.0308×` | `1.0102×` | `1.0270×` | `1.1456×` | `1.2321×` |
| 4 × 8192 × 7168 × 3072 | `0.9912×` | `0.9934×` | `1.0211×` | `1.1920×` | `1.4093×` |
| 4 × 8192 × 4096 × 4096 | `1.0175×` | `0.9930×` | `1.0248×` | `1.1496×` | `1.4426×` |
| 4 × 8192 × 4096 × 2048 | `1.0025×` | `1.0026×` | `1.0342×` | `1.2408×` | `1.3849×` |
| 8 × 4096 × 6144 × 7168 | `1.0178×` | `1.0121×` | `1.0350×` | `1.1541×` | `1.1979×` |
| 8 × 4096 × 7168 × 3072 | `1.0125×` | `0.9996×` | `1.0266×` | `1.1859×` | `1.3272×` |
| 8 × 4096 × 4096 × 4096 | `0.9987×` | `1.0095×` | `1.0520×` | `1.1655×` | `1.3990×` |
| 8 × 4096 × 4096 × 2048 | `1.0175×` | `1.0229×` | `1.0869×` | `1.3012×` | `1.2869×` |
| **Geomean** | **`1.0110×`** | **`1.0054×`** | **`1.0383×`** | **`1.1908×`** | **`1.3323×`** |

The historical campaign used one GPU, shared logical B values, the reviewed physical B layout where each provider supports it, fixed shapes, and selected public/default provider paths; it did not exhaust provider candidate spaces. It is retained to show all five provider paths, while the exact-head three-replicate check above covers the final code against DeepGEMM. Neither result supports SOTA, beats-all, or unqualified-fastest claims.
