### PR TITLE
[autotuner] Add generic grouped-GEMM compiler heuristics

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -103,6 +103,7 @@ runtime
    triton_kernel
    register_block_size
    register_tunable
+   register_heuristic_metadata
    constexpr
    specialize
 ```

--- a/docs/api/language.md
+++ b/docs/api/language.md
@@ -246,6 +246,17 @@ def k(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 .. autofunction:: register_tunable
 ```
 
+### register_heuristic_metadata()
+
+```{eval-rst}
+.. autofunction:: register_heuristic_metadata
+```
+
+Metadata names are consumer-defined rather than a closed Helion enum, allowing
+out-of-tree compiler heuristics to add contracts without changing the language
+API. An unconsumed name is retained but intentionally has no effect, so callers
+should use the exact name documented by their heuristic.
+
 ## Tile Operations
 
 ### Tile Class

--- a/helion/_argument_device.py
+++ b/helion/_argument_device.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import cast
+from typing import overload
+
+import torch
+
+from . import exc
+
+
+def _current_device_index(device_type: str) -> int:
+    device_module = getattr(torch, device_type, None)
+    is_available = getattr(device_module, "is_available", None)
+    available = None if not callable(is_available) else is_available()
+    current_device = getattr(device_module, "current_device", None)
+    if available is not False and callable(current_device):
+        return cast("int", current_device())
+
+    accelerator_device = torch.accelerator.current_accelerator(check_available=True)
+    if accelerator_device is not None and accelerator_device.type == device_type:
+        return torch.accelerator.current_device_index()
+    raise exc.InvalidAPIUsage(
+        f"no current indexed accelerator is available for {device_type!r}"
+    )
+
+
+@overload
+def _canonicalize_argument_device(device: None) -> None: ...
+
+
+@overload
+def _canonicalize_argument_device(device: torch.device) -> torch.device: ...
+
+
+def _canonicalize_argument_device(
+    device: torch.device | None,
+) -> torch.device | None:
+    """Resolve an indexless accelerator while preserving discovery fallback."""
+    if device is None:
+        return None
+    if device.index is not None or device.type in ("cpu", "meta", "mps"):
+        return device
+    try:
+        index = _current_device_index(device.type)
+    except exc.InvalidAPIUsage:
+        # Preserve device kinds without PyTorch current-device support. Their
+        # existing backend-specific discovery remains authoritative.
+        return device
+    return torch.device(device.type, index)

--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,7 @@ from .cute import CuteTcgen05ClusterM2FfiHeuristic
 from .cute import CuteTcgen05ClusterM2Heuristic
 from .cute import CuteTcgen05GroupedDynamicBk64Heuristic
 from .cute import CuteTcgen05GroupedStaticCommonKHeuristic
+from .cute import CuteTcgen05GroupedWorklistHeuristic
 from .cute import CuteTcgen05ThreadLocalEpilogueHeuristic
 from .cute import CuteTileVecHeuristic
 from .cute import CuteTileVecWarpPerRowHeuristic
@@ -32,10 +34,13 @@ from .triton import TritonUserTiledReductionHeuristicSM90
 from .triton import TritonUserTiledReductionHeuristicSM100
 
 if TYPE_CHECKING:
+    import torch
+
     from ...runtime.config import Config
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
     from .registry import AutotunerHeuristicType
+    from .registry import CompilerHeuristicSpecializationFact
 
 # All active heuristics by backend
 HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
@@ -45,6 +50,7 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteFlashAttentionCausalLptHeuristic,
         CuteTcgen05ClusterM2FfiHeuristic,
         CuteTcgen05ClusterM2Heuristic,
+        CuteTcgen05GroupedWorklistHeuristic,
         CuteTcgen05GroupedStaticCommonKHeuristic,
         CuteTcgen05GroupedDynamicBk64Heuristic,
         CuteTcgen05ThreadLocalEpilogueHeuristic,
@@ -85,18 +91,133 @@ def get_heuristics(backend: str) -> tuple[AutotunerHeuristicType, ...]:
     return HEURISTICS_BY_BACKEND.get(backend, ())
 
 
+_PromotionRegistryState = tuple[tuple[str, bool, frozenset[str]], ...]
+_PromotionRegistrySignature = tuple[tuple[str, frozenset[str]], ...]
+
+
+def _promotion_registry_state(
+    heuristics: tuple[AutotunerHeuristicType, ...],
+) -> _PromotionRegistryState:
+    """Snapshot the mutable class policy used by promotion-key caching.
+
+    This snapshot is deliberately rebuilt: heuristic policy attributes may be
+    replaced at runtime by tests or downstream registries, while the derived
+    signature remains cached by the immutable snapshot value.
+    """
+    return tuple(
+        (
+            heuristic.name,
+            heuristic.promote_seed_to_default,
+            frozenset(heuristic.PROMOTE_HARDWARE_NAMES or ()),
+        )
+        for heuristic in heuristics
+    )
+
+
+@functools.cache
+def _promotion_registry_signature(
+    registry_state: _PromotionRegistryState,
+) -> _PromotionRegistrySignature:
+    """Return the immutable exact-name gate signature for one registry entry."""
+    return tuple(
+        (heuristic_name, hardware_names)
+        for heuristic_name, promote_seed_to_default, hardware_names in registry_state
+        if promote_seed_to_default and hardware_names
+    )
+
+
+@functools.cache
+def _promotion_key_from_identity(
+    hardware_name: str | None,
+    registry_signature: _PromotionRegistrySignature,
+) -> tuple[tuple[str, str | None], ...]:
+    """Map pure promotion-relevant identity to the bound-kernel cache key."""
+    return tuple(
+        (
+            heuristic_name,
+            hardware_name if hardware_name in hardware_names else None,
+        )
+        for heuristic_name, hardware_names in registry_signature
+    )
+
+
+def compiler_promotion_specialization_key(
+    backend: str,
+    device: torch.device,
+) -> tuple[tuple[str, str | None], ...]:
+    """Return exact-name facts that can change a promoted compiler default.
+
+    Compute capability is already part of the bound-kernel specialization key.
+    Only heuristics with an additional exact-name promotion fence need more
+    device identity.  Non-matching products share the ``None`` bucket because
+    they all decline that promotion; capability-only heuristics add no key at
+    all. Registry analysis and result construction are cached from immutable
+    signatures. ``get_hardware_info`` is cached per device; the resolver call
+    here selects that cached identity for the current device.
+    """
+    registry_signature = _promotion_registry_signature(
+        _promotion_registry_state(get_heuristics(backend))
+    )
+    if not registry_signature:
+        return ()
+
+    from ..._argument_device import _canonicalize_argument_device
+    from ..._hardware import get_hardware_info
+
+    try:
+        hardware_name = get_hardware_info(
+            _canonicalize_argument_device(device)
+        ).hardware_name
+    except RuntimeError:
+        hardware_name = None
+    return _promotion_key_from_identity(
+        hardware_name,
+        registry_signature,
+    )
+
+
+def compiler_seed_specialization_facts(
+    backend: str,
+    fired_heuristics: tuple[str, ...] | list[str],
+) -> frozenset[CompilerHeuristicSpecializationFact]:
+    """Return device facts needed by compiler seeds that actually fired.
+
+    Eligibility is known only after tracing the kernel.  Deferring this lookup
+    until then avoids putting SM count in every bound-kernel key merely because
+    one heuristic registered for the backend happens to depend on it.
+    """
+    fired = frozenset(fired_heuristics)
+    return frozenset(
+        fact
+        for heuristic in get_heuristics(backend)
+        if heuristic.name in fired
+        for fact in heuristic.CACHE_SPECIALIZATION_FACTS
+    )
+
+
 def compiler_seed_configs(
     env: CompileEnvironment,
     device_ir: DeviceIR,
 ) -> list[Config]:
     configs: list[Config] = []
+    heuristics = get_heuristics(env.backend_name)
+    registered_fact_specialization_facts: set[CompilerHeuristicSpecializationFact] = (
+        set()
+    )
+    for heuristic in heuristics:
+        registered_fact_specialization_facts.update(
+            heuristic.register_facts(env, device_ir)
+        )
+    env.compiler_fact_specialization_facts = frozenset(
+        registered_fact_specialization_facts
+    )
     env.config_spec.autotuner_heuristics = []
     env.config_spec.compiler_default_config = None
     env.config_spec.compiler_seed_timeout_retry_repetitions = None
     if env.settings.disable_autotuner_heuristics:
         return configs
 
-    for heuristic in get_heuristics(env.backend_name):
+    for heuristic in heuristics:
         try:
             if not heuristic.is_eligible(env, device_ir):
                 continue

--- a/helion/_compiler/autotuner_heuristics/common.py
+++ b/helion/_compiler/autotuner_heuristics/common.py
@@ -69,8 +69,11 @@ def dedupe_configs(configs: Iterable[Config]) -> list[Config]:
 
 def matches_hardware(
     env: CompileEnvironment,
-    targets: tuple[HardwareTarget, ...],
+    targets: tuple[HardwareTarget, ...] | None,
+    *,
+    hardware_names: frozenset[str] | None = None,
 ) -> bool:
+    from ..._argument_device import _canonicalize_argument_device
     from ..._hardware import get_hardware_info
 
     # A device Helion cannot classify raises RuntimeError here (e.g. MTIA, which
@@ -81,13 +84,15 @@ def matches_hardware(
     # is called outside the try/except that guards is_eligible, where an escaping
     # RuntimeError fails the whole compile.
     try:
-        hardware = get_hardware_info(env.device)
+        hardware = get_hardware_info(_canonicalize_argument_device(env.device))
     except RuntimeError:
         return False
-    return (hardware.device_kind, hardware.compute_capability) in targets or (
-        hardware.device_kind,
-        None,
-    ) in targets
+    if hardware_names is not None and hardware.hardware_name not in hardware_names:
+        return False
+    return targets is None or (
+        (hardware.device_kind, hardware.compute_capability) in targets
+        or (hardware.device_kind, None) in targets
+    )
 
 
 def clamp_block_size_targets(

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -2,19 +2,36 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Literal
 from typing import cast
 
 import torch
 
 from ...runtime.config import Config
+from ..cute.cutedsl_compat import tcgen05_runtime_n_ptx_compatible
+from ..cute.cutedsl_compat import warn_tcgen05_runtime_n_ptx_fallback
+from ..cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from ..cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
+from ..cute.strategies import TCGEN05_STRATEGY_CONFIG_KEY
+from ..cute.strategies import TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
 from ..cute.strategies import Tcgen05PersistenceModel
+from ..cute.strategies import Tcgen05Strategy
 from ..cute.tcgen05_config import TCGEN05_GROUPED_DYNAMIC_AB4_STAGE
+from ..cute.tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
@@ -23,16 +40,20 @@ from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_L2_GROUPING
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from ..cute.tcgen05_constants import tcgen05_two_cta_edge_k_tail_seed_overrides
+from .common import dedupe_configs
 from .common import is_canonical_row_reduction
 from .registry import AutotunerHeuristic
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from ...autotuner.config_fragment import BlockSizeFragment
     from ...autotuner.config_spec import ConfigSpec
     from ...autotuner.config_spec import MatmulFact
     from ...autotuner.config_spec import ReductionLoopSpec
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
+    from .registry import CompilerHeuristicSpecializationFact
 
 
 def _cute_seed_vec_width(
@@ -237,13 +258,8 @@ class CuteTileVecHeuristic(AutotunerHeuristic):
         # SM100 warp + L2 hit cadence) when reachable, else cap at the
         # inner tile's fragment.high.  ``num_threads`` is sized so the
         # lane_extent equals V (one vec load per thread per outer iter).
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
-        block_n: int
-        if isinstance(bn_high, int):
-            block_n = 1024 if bn_high >= 1024 else max(bn_high, vec)
-        else:
-            block_n = 1024
+        bn_high = spec.block_sizes[1]._fragment(spec).high
+        block_n = 1024 if bn_high >= 1024 else max(bn_high, vec)
         # Threads = block_n // V so each thread owns V contiguous elts.
         nt_n = max(1, block_n // vec)
         seed: dict[str, Any] = {
@@ -307,9 +323,8 @@ class CuteTileVecWarpReduceHeuristic(AutotunerHeuristic):
         # against the launch cost (and an autotuner-picked warp lattice
         # can hold the row).  We use the inner block fragment's high
         # bound as a proxy for the reduction extent.
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
-        return isinstance(bn_high, int) and bn_high >= vec * 32
+        bn_high = spec.block_sizes[1]._fragment(spec).high
+        return bn_high >= vec * 32
 
     @classmethod
     def get_seed_config(
@@ -330,10 +345,9 @@ class CuteTileVecWarpReduceHeuristic(AutotunerHeuristic):
         # Each thread owns V contiguous elements; one warp = 32 threads
         # = 32 * V elements per outer-tile iter. Cap by the fragment's
         # high bound so the seed is reachable for short reduction axes.
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
+        bn_high = spec.block_sizes[1]._fragment(spec).high
         block_n = vec * 32
-        if isinstance(bn_high, int) and bn_high < block_n:
+        if bn_high < block_n:
             return None
         seed: dict[str, Any] = {
             "block_sizes": [1, block_n],
@@ -397,18 +411,13 @@ class CuteTileVecWarpPerRowHeuristic(AutotunerHeuristic):
         vec = _cute_tile_seed_vec_width_for_dtype(dtype)
         if vec <= 1:
             return False
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
-        if not isinstance(bn_high, int) or bn_high < vec * 32:
+        bn_high = spec.block_sizes[1]._fragment(spec).high
+        if bn_high < vec * 32:
             return False
         # Outer (M) fragment must admit M=2 (warp-per-row launches 2
         # warps per CTA so each row is one warp).
-        bm_fragment = cast("Any", spec.block_sizes[0])._fragment(spec)
-        bm_low = getattr(bm_fragment, "low", 1)
-        bm_high = getattr(bm_fragment, "high", None)
-        if not isinstance(bm_high, int):
-            return False
-        return bm_low <= 2 <= bm_high
+        bm_fragment = spec.block_sizes[0]._fragment(spec)
+        return bm_fragment.low <= 2 <= bm_fragment.high
 
     @classmethod
     def get_seed_config(
@@ -426,10 +435,9 @@ class CuteTileVecWarpPerRowHeuristic(AutotunerHeuristic):
         vec = _cute_tile_seed_vec_width_for_dtype(dtype)
         if vec <= 1:
             return None
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
+        bn_high = spec.block_sizes[1]._fragment(spec).high
         block_n = vec * 32
-        if isinstance(bn_high, int) and bn_high < block_n:
+        if bn_high < block_n:
             return None
         seed: dict[str, Any] = {
             "block_sizes": [2, block_n],
@@ -500,10 +508,28 @@ def _block_size_value_reachable(
 ) -> bool:
     if block_index < 0 or block_index >= len(spec.block_sizes):
         return False
-    fragment = cast("Any", spec.block_sizes[block_index])._fragment(spec)
-    low = getattr(fragment, "low", None)
-    high = getattr(fragment, "high", None)
-    return isinstance(low, int) and isinstance(high, int) and low <= value <= high
+    fragment = spec.block_sizes[block_index]._fragment(spec)
+    return fragment.low <= value <= fragment.high
+
+
+def _filter_reachable_block_size_configs(
+    spec: ConfigSpec,
+    configs: Sequence[Config],
+) -> list[Config]:
+    """Keep seeds whose block sizes are reachable in the live config spec."""
+    result: list[Config] = []
+    for config in configs:
+        block_sizes = config.config.get("block_sizes")
+        if not isinstance(block_sizes, list) or len(block_sizes) != len(
+            spec.block_sizes
+        ):
+            continue
+        if all(
+            type(value) is int and _block_size_value_reachable(spec, index, value)
+            for index, value in enumerate(block_sizes)
+        ):
+            result.append(config)
+    return result
 
 
 def _tcgen05_grouped_fact(env: CompileEnvironment) -> MatmulFact | None:
@@ -542,6 +568,36 @@ def _tcgen05_grouped_fact(env: CompileEnvironment) -> MatmulFact | None:
     if fact.static_m % 128 != 0 or fact.static_n % 64 != 0:
         return None
     return fact
+
+
+def _tcgen05_grouped_worklist_structural_fact(
+    env: CompileEnvironment,
+) -> MatmulFact | None:
+    """Return structural grouped facts before dynamic shape hints are frozen."""
+    spec = env.config_spec
+    if len(spec.matmul_facts) != 1 or len(spec.block_sizes) != 3:
+        return None
+    fact = spec.matmul_facts[0]
+    if fact.lhs_dtype is not torch.bfloat16 or fact.rhs_dtype is not torch.bfloat16:
+        return None
+    if fact.m_block_id is None or fact.n_block_id is None or fact.k_block_id is None:
+        return None
+    try:
+        block_indices = tuple(
+            spec.block_sizes.block_id_to_index(block_id)
+            for block_id in (fact.m_block_id, fact.n_block_id, fact.k_block_id)
+        )
+    except KeyError:
+        return None
+    return fact if block_indices == (0, 1, 2) else None
+
+
+def _tcgen05_grouped_worklist_fact(
+    env: CompileEnvironment,
+) -> MatmulFact | None:
+    if not env.config_spec.cute_tcgen05_search_enabled:
+        return None
+    return _tcgen05_grouped_worklist_structural_fact(env)
 
 
 def _tcgen05_grouped_dynamic_bk64_fact(env: CompileEnvironment) -> MatmulFact | None:
@@ -622,6 +678,577 @@ def _tcgen05_grouped_seed_config(bk: int) -> Config:
         Tcgen05PersistenceModel.STATIC_PERSISTENT.value
     )
     return config
+
+
+GroupedBMajor = Literal["k", "n"]
+
+_TCGEN05_GROUPED_B200_REFERENCE_NUM_SMS = 148
+_TCGEN05_GROUPED_B200_LOW_RESERVED_SMS = 32
+_TCGEN05_GROUPED_B200_HIGH_RESERVED_SMS = 52
+_TCGEN05_GROUPED_B200_PANEL_RESERVED_SMS = 20
+# These measurements rank the initial seed population only. Other SM counts are
+# scaled proportionally, and live autotuning remains authoritative.
+
+# Exhaustive schema for the side-effect-free grouped-worklist config builder.
+_TCGEN05_GROUPED_WORKLIST_CONFIG_KEYS = frozenset(
+    {
+        "block_sizes",
+        "l2_groupings",
+        "loop_orders",
+        "num_stages",
+        "num_warps",
+        "pid_type",
+        "tcgen05_cluster_m",
+        "tcgen05_cluster_n",
+        "tcgen05_ab_stages",
+        "tcgen05_acc_stages",
+        "tcgen05_c_stages",
+        "tcgen05_num_epi_warps",
+        TCGEN05_CONSUMER_REGS_CONFIG_KEY,
+        TCGEN05_GROUPED_MODE_CONFIG_KEY,
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+        TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+        TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY,
+        TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+        TCGEN05_STRATEGY_CONFIG_KEY,
+        TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY,
+        TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY,
+    }
+)
+
+
+def tcgen05_grouped_worklist_config_values(
+    source_m_tile: int,
+    block_k: int,
+    ab_stages: int,
+    consumer_regs: int,
+    *,
+    runtime_direct: bool = True,
+    l2_swizzle_size: int | None = None,
+    reserved_sms: int | None = None,
+    clc: bool = False,
+) -> dict[str, object]:
+    """Return the exact values used by the grouped-worklist seed builder.
+
+    This side-effect-free seam exposes compiler seed values without depending on
+    the compiler's private builder.
+    """
+    if clc and not runtime_direct:
+        raise ValueError("grouped worklist CLC requires runtime_direct=True")
+    cluster_m = (
+        1 if source_m_tile == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE else 2
+    )
+    values: dict[str, object] = {
+        "block_sizes": [256, 128, block_k],
+        "l2_groupings": [1],
+        "loop_orders": [[0, 1, 2]],
+        "num_stages": 7,
+        "num_warps": 8,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": cluster_m,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": ab_stages,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        TCGEN05_CONSUMER_REGS_CONFIG_KEY: consumer_regs,
+        TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_WORKLIST_NM,
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY: source_m_tile,
+    }
+    if runtime_direct:
+        values[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = True
+    if l2_swizzle_size is not None:
+        values[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = l2_swizzle_size
+    if reserved_sms is not None:
+        values[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = reserved_sms
+    if clc:
+        values.update(
+            {
+                TCGEN05_STRATEGY_CONFIG_KEY: (
+                    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+                ),
+                TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: 1,
+                TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
+                    Tcgen05PersistenceModel.CLC_PERSISTENT.value
+                ),
+            }
+        )
+    if missing_schema_keys := values.keys() - _TCGEN05_GROUPED_WORKLIST_CONFIG_KEYS:
+        raise RuntimeError(
+            "grouped-worklist config builder emitted keys missing from its schema: "
+            f"{sorted(missing_schema_keys)!r}"
+        )
+    return values
+
+
+def _tcgen05_grouped_worklist_config(
+    source_m_tile: int,
+    block_k: int,
+    ab_stages: int,
+    consumer_regs: int,
+    *,
+    runtime_direct: bool = True,
+    l2_swizzle_size: int | None = None,
+    reserved_sms: int | None = None,
+    clc: bool = False,
+) -> Config:
+    return Config.from_dict(
+        tcgen05_grouped_worklist_config_values(
+            source_m_tile,
+            block_k,
+            ab_stages,
+            consumer_regs,
+            runtime_direct=runtime_direct,
+            l2_swizzle_size=l2_swizzle_size,
+            reserved_sms=reserved_sms,
+            clc=clc,
+        )
+    )
+
+
+def tcgen05_grouped_worklist_config_keys() -> frozenset[str]:
+    """Return the exhaustive grouped-worklist compiler-seed schema."""
+    return _TCGEN05_GROUPED_WORKLIST_CONFIG_KEYS
+
+
+def _tcgen05_grouped_scaled_reserved_sms(
+    num_sm: int,
+    b200_reserved_sms: int,
+) -> int:
+    value = round(num_sm * b200_reserved_sms / _TCGEN05_GROUPED_B200_REFERENCE_NUM_SMS)
+    # The reviewed B200 occupancy splits were selected on a two-SM reservation
+    # lattice.  Preserve that lattice after proportional scaling; an odd rounded
+    # value moves up so the seed never reserves less than the scaled reference.
+    value += value % 2
+    return min(
+        max(value, 0),
+        max(num_sm - 2, 0),
+        TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX,
+    )
+
+
+def _tcgen05_grouped_small_m_reserved_sms(
+    *,
+    groups: int,
+    work_clusters: int,
+    num_sm: int,
+) -> tuple[int, int]:
+    """Rank low/high reserved-SM seeds scaled from B200 occupancy splits."""
+    low = _tcgen05_grouped_scaled_reserved_sms(
+        num_sm,
+        _TCGEN05_GROUPED_B200_LOW_RESERVED_SMS,
+    )
+    high = _tcgen05_grouped_scaled_reserved_sms(
+        num_sm,
+        _TCGEN05_GROUPED_B200_HIGH_RESERVED_SMS,
+    )
+    active_high = num_sm - high
+    high_first = (
+        groups <= 8
+        and work_clusters > num_sm
+        and active_high > 0
+        and work_clusters % active_high == 0
+    )
+    return (high, low) if high_first else (low, high)
+
+
+def tcgen05_grouped_worklist_seed_configs(
+    *,
+    groups: int,
+    packed_m: int,
+    n: int,
+    k: int,
+    b_major: GroupedBMajor,
+    source_m_tile: int,
+    num_sm: int,
+) -> list[Config]:
+    """Build ranked, tile-compatible grouped-worklist compiler seeds."""
+    if any(
+        type(value) is not int or value <= 0
+        for value in (groups, packed_m, n, k, num_sm)
+    ):
+        raise ValueError("grouped seed dimensions and num_sm must be positive integers")
+    if b_major not in ("k", "n"):
+        raise ValueError(f"unsupported grouped B major {b_major!r}")
+    if source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES:
+        raise ValueError(f"unsupported grouped source M tile {source_m_tile!r}")
+    if packed_m % source_m_tile != 0:
+        raise ValueError("packed M extent must be divisible by source_m_tile")
+
+    if source_m_tile == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE:
+        logical_n_per_cluster = 128
+        work_clusters = (packed_m // source_m_tile) * (
+            (n + logical_n_per_cluster - 1) // logical_n_per_cluster
+        )
+        preferred_reservation, alternate_reservation = (
+            _tcgen05_grouped_small_m_reserved_sms(
+                groups=groups,
+                work_clusters=work_clusters,
+                num_sm=num_sm,
+            )
+        )
+        high_reservation = _tcgen05_grouped_scaled_reserved_sms(
+            num_sm,
+            _TCGEN05_GROUPED_B200_HIGH_RESERVED_SMS,
+        )
+        panel_reservation = _tcgen05_grouped_scaled_reserved_sms(
+            num_sm,
+            _TCGEN05_GROUPED_B200_PANEL_RESERVED_SMS,
+        )
+        bk128 = {
+            "preferred_reserved": _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                128,
+                5,
+                256,
+                reserved_sms=preferred_reservation,
+            ),
+            "alternate_reserved": _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                128,
+                5,
+                256,
+                reserved_sms=alternate_reservation,
+            ),
+            "unreserved": _tcgen05_grouped_worklist_config(source_m_tile, 128, 5, 256),
+        }
+        bk64 = {
+            "high_reserved": _tcgen05_grouped_worklist_config(
+                source_m_tile, 64, 7, 240, reserved_sms=high_reservation
+            ),
+            "direct": _tcgen05_grouped_worklist_config(source_m_tile, 64, 7, 240),
+            "panel4": _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                64,
+                7,
+                240,
+                l2_swizzle_size=4,
+                reserved_sms=panel_reservation,
+            ),
+            "panel8": _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                64,
+                7,
+                240,
+                l2_swizzle_size=8,
+                reserved_sms=panel_reservation,
+            ),
+            "mailbox": _tcgen05_grouped_worklist_config(
+                source_m_tile, 64, 7, 240, runtime_direct=False
+            ),
+        }
+        if groups >= 16:
+            if n > k:
+                primary = bk64["panel8"]
+            elif n < k:
+                primary = bk64["panel4"]
+            else:
+                primary = bk64["direct"]
+        elif n >= 9 * k // 4:
+            primary = bk128["alternate_reserved"]
+        elif n >= 2 * k:
+            primary = bk64["high_reserved"]
+        elif k > n:
+            primary = bk64["direct"]
+        else:
+            primary = bk128["preferred_reserved"]
+        return dedupe_configs([primary, *bk128.values(), *bk64.values()])
+
+    if source_m_tile == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT:
+        # Source-224 keeps the reviewed panel-8 direct config as its deterministic
+        # primary; the remaining mailbox/BK128 variants are fallback seeds.
+        panel8_direct = _tcgen05_grouped_worklist_config(
+            source_m_tile,
+            64,
+            7,
+            256,
+            l2_swizzle_size=8,
+        )
+        mailbox_by_ab_stages = {
+            ab_stages: _tcgen05_grouped_worklist_config(
+                source_m_tile, 64, ab_stages, 240, runtime_direct=False
+            )
+            for ab_stages in range(7, 3, -1)
+        }
+        bk128_direct = _tcgen05_grouped_worklist_config(source_m_tile, 128, 3, 240)
+        return dedupe_configs(
+            [panel8_direct, *mailbox_by_ab_stages.values(), bk128_direct]
+        )
+
+    logical_n_per_cluster = 256
+    work_clusters = (packed_m // source_m_tile) * (
+        (n + logical_n_per_cluster - 1) // logical_n_per_cluster
+    )
+    bk128 = {
+        "mailbox": _tcgen05_grouped_worklist_config(
+            source_m_tile, 128, 3, 240, runtime_direct=False
+        ),
+        "direct": _tcgen05_grouped_worklist_config(source_m_tile, 128, 3, 240),
+        "panel8": _tcgen05_grouped_worklist_config(
+            source_m_tile, 128, 3, 240, l2_swizzle_size=8
+        ),
+    }
+    bk64 = {
+        "mailbox_regs224": _tcgen05_grouped_worklist_config(
+            source_m_tile, 64, 6, 224, runtime_direct=False
+        ),
+        "mailbox_regs240": _tcgen05_grouped_worklist_config(
+            source_m_tile, 64, 6, 240, runtime_direct=False
+        ),
+        "direct_regs240": _tcgen05_grouped_worklist_config(source_m_tile, 64, 6, 240),
+        "panel16_regs224": _tcgen05_grouped_worklist_config(
+            source_m_tile, 64, 6, 224, l2_swizzle_size=16
+        ),
+        "panel8_stage5_regs224": _tcgen05_grouped_worklist_config(
+            source_m_tile, 64, 5, 224, l2_swizzle_size=8
+        ),
+    }
+    # Runtime CLC uses fixed full-allocation TensorMaps.  In N,M orientation,
+    # logical N is the physical MMA-M dimension, so the immutable descriptor
+    # path requires a whole 256-row physical tile.  Keep tail-N shapes on the
+    # dynamic-TensorMap runtime-direct or mailbox families.
+    clc_by_consumer_regs = (
+        {
+            consumer_regs: _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                64,
+                6,
+                consumer_regs,
+                l2_swizzle_size=8,
+                clc=True,
+            )
+            for consumer_regs in (240, 256)
+        }
+        if (
+            n % logical_n_per_cluster == 0
+            and work_clusters <= TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS
+        )
+        else {}
+    )
+    clc_configs = list(clc_by_consumer_regs.values())
+    # Ranking-only splits fitted from the reviewed B200 source-256 cases:
+    # 16 groups marks high fan-out, N/K=2 and 9/4 are aspect buckets, and
+    # 8/24 tiles per group separate short, medium, and long expert waves.
+    tiles_per_group = packed_m // source_m_tile // groups
+    clc_ready = bool(clc_configs) and work_clusters >= num_sm
+    if groups >= 16:
+        if k > n or n >= 9 * k // 4:
+            primary = bk128["mailbox"]
+        elif n >= 2 * k:
+            primary = bk64["direct_regs240"]
+        else:
+            primary = bk64["mailbox_regs224"]
+    elif tiles_per_group >= 8:
+        if k > n and clc_ready:
+            preferred_clc_consumer_regs = 256 if groups <= 4 else 240
+            primary = clc_by_consumer_regs[preferred_clc_consumer_regs]
+        elif n >= 9 * k // 4:
+            primary = bk64["panel16_regs224"] if b_major == "n" else bk128["panel8"]
+        elif n >= 2 * k:
+            primary = (
+                clc_by_consumer_regs[240]
+                if b_major == "n" and clc_ready
+                else bk64["direct_regs240"]
+            )
+        elif n == k:
+            primary = (
+                bk128["direct"]
+                if tiles_per_group >= 24
+                else bk64["panel8_stage5_regs224"]
+            )
+        else:
+            primary = bk64["mailbox_regs240"]
+    elif b_major == "n" and n >= 2 * k:
+        primary = bk64["direct_regs240"]
+    else:
+        primary = bk64["mailbox_regs240"]
+    return dedupe_configs([primary, *clc_configs, *bk64.values(), *bk128.values()])
+
+
+def _tcgen05_grouped_worklist_source_m_tile(spec: ConfigSpec) -> int | None:
+    value = spec.compiler_heuristic_metadata.get(
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+    )
+    return (
+        value
+        if type(value) is int
+        and value in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+        else None
+    )
+
+
+class CuteTcgen05GroupedWorklistHeuristic(AutotunerHeuristic):
+    """Rank general grouped-worklist configs while preserving live tuning."""
+
+    name = "cute_tcgen05_grouped_worklist"
+    backend = "cute"
+    promote_seed_to_default = True
+    PROMOTE_TARGETS = (("cuda", "sm100"),)
+    PROMOTE_HARDWARE_NAMES = frozenset({"NVIDIA B200"})
+    CACHE_SPECIALIZATION_FACTS = frozenset({"config_num_sm", "input_tensor_metadata"})
+
+    @classmethod
+    def register_facts(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> frozenset[CompilerHeuristicSpecializationFact]:
+        """Record grouped SMEM facts independently of seed generation.
+
+        Source-M metadata is the kernel's shape-independent semantic opt-in.
+        Publish its input specialization even when a zero/one first binding
+        cannot yet prove the grouped structure or register SMEM facts.
+        """
+        spec = env.config_spec
+        source_m_tile = _tcgen05_grouped_worklist_source_m_tile(spec)
+        if source_m_tile is None:
+            return frozenset()
+        specialization_facts: frozenset[CompilerHeuristicSpecializationFact] = (
+            frozenset({"input_tensor_metadata"})
+        )
+        fact = _tcgen05_grouped_worklist_structural_fact(env)
+        if fact is None:
+            return specialization_facts
+        from ..cute.cute_mma import tcgen05_grouped_worklist_seed_facts
+
+        seed_facts = tcgen05_grouped_worklist_seed_facts(
+            env,
+            device_ir,
+            fact,
+            source_m_tile=source_m_tile,
+        )
+        if seed_facts is not None:
+            spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+                group_count=seed_facts.groups_hint,
+                device_split_sizes=seed_facts.device_split_sizes,
+            )
+        return specialization_facts
+
+    @classmethod
+    def _eligible_inputs(
+        cls,
+        env: CompileEnvironment,
+        device_ir: DeviceIR,
+    ) -> tuple[MatmulFact, int] | None:
+        spec = env.config_spec
+        source_m_tile = _tcgen05_grouped_worklist_source_m_tile(spec)
+        fact = _tcgen05_grouped_worklist_fact(env)
+        if (
+            source_m_tile is None
+            or fact is None
+            or (fact.static_n is not None and fact.static_n % 32 != 0)
+            or spec.target_device_capability != (10, 0)
+            or not _block_size_value_reachable(spec, 0, 256)
+            or not _block_size_value_reachable(spec, 1, 128)
+            or not any(
+                _block_size_value_reachable(spec, 2, block_k)
+                for block_k in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+            )
+        ):
+            return None
+        if not tcgen05_runtime_n_ptx_compatible():
+            warn_tcgen05_runtime_n_ptx_fallback()
+            return None
+        return fact, source_m_tile
+
+    @classmethod
+    def _seed_configs(
+        cls,
+        env: CompileEnvironment,
+        device_ir: DeviceIR,
+    ) -> list[Config]:
+        eligible = cls._eligible_inputs(env, device_ir)
+        if eligible is None:
+            return []
+        fact, source_m_tile = eligible
+        spec = env.config_spec
+        from ..cute.cute_mma import tcgen05_grouped_worklist_seed_facts
+
+        seed_facts = tcgen05_grouped_worklist_seed_facts(
+            env,
+            device_ir,
+            fact,
+            source_m_tile=source_m_tile,
+        )
+        if seed_facts is None:
+            return []
+        # ``packed_m_hint`` remains the exact compiler fact. Seed selection only
+        # needs a tile-wave estimate, so round this local ranking input upward:
+        # ordinary worklists to one source tile, and device split-size kernels
+        # to one equal-share source tile per group. Runtime/codegen validation
+        # never consumes the rounded value.
+        ranking_quantum = (
+            seed_facts.groups_hint * source_m_tile
+            if seed_facts.device_split_sizes
+            else source_m_tile
+        )
+        ranking_packed_m = (
+            (seed_facts.packed_m_hint + ranking_quantum - 1) // ranking_quantum
+        ) * ranking_quantum
+        configs = tcgen05_grouped_worklist_seed_configs(
+            groups=seed_facts.groups_hint,
+            packed_m=ranking_packed_m,
+            n=seed_facts.n_hint,
+            k=seed_facts.k_hint,
+            b_major=seed_facts.b_major,
+            source_m_tile=source_m_tile,
+            num_sm=spec.num_sm,
+        )
+        if seed_facts.device_split_sizes:
+            # Runtime-direct expands a host worklist. Device split-size kernels
+            # instead derive their group rows on device and are supported only
+            # by the scheduler-mailbox family. Convert otherwise-compatible
+            # direct seeds rather than dropping useful BK/reservation variants;
+            # panel swizzles and CLC have no mailbox equivalent.
+            mailbox_configs: list[Config] = []
+            for config in configs:
+                values = dict(config.config)
+                l2_swizzle_size = values.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY, 1)
+                if values.get(
+                    TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
+                ) == Tcgen05PersistenceModel.CLC_PERSISTENT.value or (
+                    type(l2_swizzle_size) is int and l2_swizzle_size > 1
+                ):
+                    continue
+                values.pop(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY, None)
+                mailbox_configs.append(Config.from_dict(values))
+            configs = dedupe_configs(mailbox_configs)
+        if fact.static_k is not None:
+            configs = [
+                config
+                for config in configs
+                if fact.static_k % cast("list[int]", config.config["block_sizes"])[2]
+                == 0
+            ]
+        return _filter_reachable_block_size_configs(
+            spec,
+            configs,
+        )
+
+    @classmethod
+    def should_promote(cls, env: CompileEnvironment) -> bool:
+        fact = _tcgen05_grouped_worklist_fact(env)
+        return (
+            tcgen05_runtime_n_ptx_compatible()
+            and fact is not None
+            and fact.static_k is not None
+            and super().should_promote(env)
+        )
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return cls._eligible_inputs(env, device_ir) is not None
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        configs = cls._seed_configs(env, device_ir)
+        return configs[0] if configs else None
+
+    @classmethod
+    def get_seed_configs(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> list[Config] | None:
+        return cls._seed_configs(env, device_ir)
 
 
 class CuteTcgen05GroupedStaticCommonKHeuristic(AutotunerHeuristic):
@@ -886,6 +1513,7 @@ class CuteTcgen05ThreadLocalEpilogueHeuristic(AutotunerHeuristic):
 class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
     name = "cute_tcgen05_cluster_m2"
     backend = "cute"
+    CACHE_SPECIALIZATION_FACTS = frozenset({"device_num_sm"})
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:

--- a/helion/_compiler/autotuner_heuristics/registry.py
+++ b/helion/_compiler/autotuner_heuristics/registry.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import ClassVar
+from typing import Literal
 
 if TYPE_CHECKING:
     from ...runtime.config import Config
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
     from .common import HardwareTarget
+
+
+CompilerHeuristicSpecializationFact = Literal[
+    "config_num_sm",
+    "device_num_sm",
+    "input_tensor_metadata",
+]
 
 
 class AutotunerHeuristic:
@@ -24,6 +32,47 @@ class AutotunerHeuristic:
     # be offered everywhere as a search candidate but only defaulted on validated
     # arches.
     PROMOTE_TARGETS: ClassVar[tuple[HardwareTarget, ...] | None] = None
+    # Optional exact device-name fence layered on PROMOTE_TARGETS.  This is for
+    # seeds validated on one product that shares a compute capability with
+    # another (for example B200 and GB300); it never limits where a seed fires.
+    PROMOTE_HARDWARE_NAMES: ClassVar[frozenset[str] | None] = None
+    # Runtime facts that can change this heuristic's emitted seed configs.  The
+    # bound-kernel cache adds these facts only after the heuristic actually
+    # fires, so a shape- or SM-sensitive heuristic does not force unrelated
+    # kernels on the same backend to specialize on those facts.
+    #
+    # ``device_num_sm`` is the physical count returned by get_num_sm(device).
+    # ``config_num_sm`` is ConfigSpec.num_sm, which also applies the kernel's
+    # persistent_reserved_sms setting.
+    # ``input_tensor_metadata`` is the exact shape and stride of every input
+    # tensor. Dynamic kernels request it when first-binding shape/layout hints
+    # affect their seed population or the generated schedule's validity. It
+    # intentionally creates a distinct bound kernel for each metadata tuple;
+    # heuristics should request it only when coarser reuse would be unsound.
+    CACHE_SPECIALIZATION_FACTS: ClassVar[
+        frozenset[CompilerHeuristicSpecializationFact]
+    ] = frozenset()
+
+    @classmethod
+    def register_facts(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> frozenset[CompilerHeuristicSpecializationFact]:
+        """Register correctness facts before optional seed generation.
+
+        Overrides must be idempotent because callers may regenerate compiler
+        seeds for the same bound kernel. This hook runs even when autotuner
+        heuristics are disabled; it must not itself add or promote seed configs.
+        Exceptions intentionally propagate and fail binding because silently
+        dropping correctness facts could make later normalization unsound.
+
+        Return the runtime facts that can change either the registration
+        outcome or the registered correctness facts. An input-dependent hook
+        must return its requirements even when this binding registers nothing,
+        so a later binding that would register facts cannot reuse it. These
+        requirements are independent of ``CACHE_SPECIALIZATION_FACTS``, which
+        applies only when this heuristic actually emits seeds.
+        """
+        return frozenset()
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
@@ -42,11 +91,15 @@ class AutotunerHeuristic:
         promotion to ``PROMOTE_TARGETS`` without changing where the seed fires."""
         if not cls.promote_seed_to_default:
             return False
-        if cls.PROMOTE_TARGETS is None:
+        if cls.PROMOTE_TARGETS is None and cls.PROMOTE_HARDWARE_NAMES is None:
             return True
         from .common import matches_hardware
 
-        return matches_hardware(env, cls.PROMOTE_TARGETS)
+        return matches_hardware(
+            env,
+            cls.PROMOTE_TARGETS,
+            hardware_names=cls.PROMOTE_HARDWARE_NAMES,
+        )
 
     @classmethod
     def get_seed_configs(

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -403,6 +403,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
     name = "triton_h100_matmul"
     backend = "triton"
     promote_seed_to_default = True
+    CACHE_SPECIALIZATION_FACTS = frozenset({"device_num_sm"})
     # Annotated so a hardware-specific subclass may override the arch (e.g. sm100).
     HARDWARE_TARGETS: ClassVar[tuple[tuple[str, str], ...]] = (("cuda", "sm90"),)
 
@@ -983,6 +984,7 @@ class TritonPointwiseSeedHeuristic(AutotunerHeuristic):
 
     name = "triton_pointwise"
     backend = "triton"
+    CACHE_SPECIALIZATION_FACTS = frozenset({"device_num_sm"})
     # Fires arch-agnostically (is_eligible keys only on the pointwise fact), but
     # its byte/register constants were hill-climbed and validated on H100 (sm90).
     # Promote to the autotune-off default ONLY on the arches the correctness hunt
@@ -1382,6 +1384,7 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     """
 
     backend = "triton"
+    CACHE_SPECIALIZATION_FACTS = frozenset({"device_num_sm"})
     # Widen the declared type so the sm100 subclass can retarget it (the base is sm90-only).
     HARDWARE_TARGETS: ClassVar[tuple[HardwareTarget, ...]] = (("cuda", "sm90"),)
     # Promote the reduction seed to the compiler default (autotune off) for every tuned track

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -29,6 +29,9 @@ from .cute.attention_plan import SOFTCAP_KIND
 from .cute.attention_plan import TENSOR_BIAS_KIND
 from .cute.attention_plan import AttentionScoreModifier
 from .cute.attention_plan import AttentionScorePlan
+from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from .cute.tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_profile
 
 if TYPE_CHECKING:
     import ast
@@ -2972,13 +2975,6 @@ def _grouped_rank3_specialized_mma_plan(
     env: CompileEnvironment,
 ) -> _SpecializedMmaPlan | None:
     from .cute.cute_mma import _choose_mma_impl
-    from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
-    from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
-    from .cute.tcgen05_constants import (
-        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-    )
-    from .cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
-    from .cute.tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_shape
     from .host_function import HostFunction
 
     if node.target is not torch.ops.aten.addmm.default:
@@ -3024,19 +3020,17 @@ def _grouped_rank3_specialized_mma_plan(
         return None
     mma_bm = bm
     mma_bn = bn
-    if config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) == TCGEN05_GROUPED_MODE_WORKLIST_NM:
-        source_m_tile = config.get(
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-        )
-        physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
-            cluster_m=config.get("tcgen05_cluster_m", 1),
-            block_k=bk,
-            source_m_tile=source_m_tile,
-        )
-        if physical_shape is None:
-            return None
-        mma_bm, mma_bn = physical_shape
+    worklist_profile = resolve_tcgen05_grouped_worklist_mma_profile(
+        config,
+        block_k=bk,
+    )
+    if (
+        config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) == TCGEN05_GROUPED_MODE_WORKLIST_NM
+        and worklist_profile is None
+    ):
+        return None
+    if worklist_profile is not None:
+        mma_bm, mma_bn = worklist_profile.mma_m, worklist_profile.mma_n
     mma_impl = _choose_mma_impl(
         lhs_val.dtype,
         bm=mma_bm,
@@ -3044,6 +3038,7 @@ def _grouped_rank3_specialized_mma_plan(
         bk=bk,
         config=config,
         input_device=lhs_val.device,
+        defer_grouped_worklist_smem_check=worklist_profile is not None,
     )
     if mma_impl != "tcgen05":
         return None

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -201,6 +201,7 @@ if TYPE_CHECKING:
 
     from .. import Config
     from ..runtime.settings import Settings
+    from .autotuner_heuristics.registry import CompilerHeuristicSpecializationFact
     from .backend import Backend
     from .pallas.compact_worklist import CompactWorklistPlan
     from .pallas.compact_worklist import ResidentCacheDecision
@@ -324,6 +325,13 @@ class CompileEnvironment:
             num_sm=_num_sm,
             log_restrictions_verbose=settings.autotune_log_search_space_verbose,
         )
+        # Correctness facts registered by compiler heuristics can depend on
+        # dynamic runtime inputs even when seed generation is disabled or later
+        # found ineligible. Bound-kernel caching consumes this set separately
+        # from specialization requirements of heuristics that emitted seeds.
+        self.compiler_fact_specialization_facts: frozenset[
+            CompilerHeuristicSpecializationFact
+        ] = frozenset()
         # TODO(hinriksnaer): tracing state, not env config. move to CompilerState?
         self.kernel_tensor_sizes: dict[tuple[sympy.Expr, ...], int] = (
             collections.Counter()

--- a/helion/_compiler/cute/aux_tensor.py
+++ b/helion/_compiler/cute/aux_tensor.py
@@ -304,57 +304,19 @@ def discover_tcgen05_aux_tensor_descriptors(
 def host_function_has_tcgen05_aux_kernel_pattern(
     host_function: HostFunction,
 ) -> bool:
-    """Conservative pre-codegen detector for kernels whose tcgen05
-    matmul is followed by an aux-fused store
+    """Pre-codegen detector for kernels whose tcgen05 matmul is followed
+    by an aux-fused store
     (``out[tile] = (acc + residual[tile]).to(...)`` and the
     bias / rowvec variants — see :class:`_AuxiliaryTensorLoadExpr`
     for the accepted forms).
 
-    Runs at autotune-surface configuration time (post-FX-graph
-    build, pre-autotune-sample) where the
-    :func:`discover_tcgen05_aux_tensor_descriptors` walker is
-    unavailable — that walker requires a populated
-    ``DeviceFunction.cute_state.matmul_fx_nodes`` set, which
-    is only registered at MMA-codegen time per config sample.
-    The aux pipeline only fires when the productive-body gate
-    sees aux descriptors, so the autotune surface only needs
-    to widen ``tcgen05_warp_spec_c_input_warps`` when this
-    detector returns True; otherwise the C-input warp is
-    inert and sampling ``c_input_warps=1`` would be a strict
-    resource cost for pure-matmul kernels (the inert warp
-    occupies an SM slot without delivering work).
-
-    Implementation: walk every FX graph in
-    ``host_function.device_ir.graphs`` and look for the
-    coarse pattern "the kernel has at least one MMA-anchor
-    call AND at least one ``memory_ops.load`` call whose
-    result is NOT used as one of the MMA operands". MMA
-    anchors include both the aten paths
-    (``aten.addmm`` / ``aten.baddbmm`` / ``aten.mm`` /
-    ``aten.bmm``) AND the ``hl.dot`` HOP — both ends up
-    in the tcgen05 MMA lowering, and the canonical Helion
-    residual kernel uses ``hl.dot``. Operand resolution
-    traces through the same ``convert_element_type``
-    wrappers the MMA codegen accepts
-    (``cute_mma._trace_to_load`` /
-    ``_TRACE_THROUGH_TARGETS``); without this trace,
-    kernels written as ``lhs.to(dtype) @ rhs.to(dtype)``
-    would have their operand loads classified as aux and
-    the detector would over-fire on pure matmul.
-
-    The detector is **conservative**: a false positive
-    only widens the autotune search by one enum value
-    (the productive-body safety gates handle the resulting
-    invalid combinations at codegen time and the
-    inert-body fallback handles invalid runs); a false
-    negative would miss the residual c_input=1 win. The
-    chain analyzer at codegen time
-    (``analyze_tcgen05_unary_epilogue_chain``) remains the
-    source of truth for which aux shapes are *accepted*
-    by the productive-body codegen; this detector
-    intentionally over-approximates so the autotune surface
-    admits the productive shape whenever any aux load is
-    plausibly involved.
+    This runs after the FX graphs are built but before an autotune sample has
+    registered its MMA nodes in ``DeviceFunction.cute_state``. Use the MMA
+    anchors already present in the host graphs and the same store-chain
+    analyzer as codegen so only loads in an accepted per-subtile epilogue widen
+    the search surface. Unrelated loads used for scheduler metadata, indirect
+    indices, or masks must not expose aux-only knobs such as
+    ``tcgen05_aux_load_placement``.
 
     Caught patterns include:
 
@@ -369,22 +331,15 @@ def host_function_has_tcgen05_aux_kernel_pattern(
     if not graphs:
         return False
 
-    mma_nodes, operand_load_nodes = _tcgen05_aux_detector_mma_facts(graphs)
+    mma_nodes = _tcgen05_aux_detector_mma_nodes(graphs)
     if not mma_nodes:
         return False
-    # Second pass: any ``memory_ops.load`` call whose result
-    # is NOT a resolved MMA-operand load is treated as aux.
-    # Operand loads feed the dot directly (after optional
-    # casts); aux loads feed an arithmetic op that combines
-    # with the dot's result on the way to a store.
-    for graph_info in graphs:
-        for node in graph_info.graph.nodes:
-            if (
-                node.op == "call_function"
-                and node.target is memory_ops.load
-                and node not in operand_load_nodes
-            ):
-                return True
+    for mma_node in mma_nodes:
+        analyzed_stores = analyze_tcgen05_matmul_store_chains(graphs, mma_node)
+        if analyzed_stores is not None and any(
+            chain.auxiliary_tensor_loads for _, chain in analyzed_stores
+        ):
+            return True
     return False
 
 
@@ -415,7 +370,7 @@ def host_function_has_tcgen05_exact_shape_aux_kernel_pattern(
     if not graphs:
         return False
 
-    mma_nodes, _operand_load_nodes = _tcgen05_aux_detector_mma_facts(graphs)
+    mma_nodes = _tcgen05_aux_detector_mma_nodes(graphs)
     if not mma_nodes:
         return False
 
@@ -435,13 +390,11 @@ def host_function_has_tcgen05_exact_shape_aux_kernel_pattern(
     )
 
 
-def _tcgen05_aux_detector_mma_facts(
+def _tcgen05_aux_detector_mma_nodes(
     graphs: Sequence[GraphInfo],
-) -> tuple[set[torch.fx.Node], set[torch.fx.Node]]:
-    # MMA anchor targets: both the aten paths and the ``hl.dot`` HOP
-    # (the canonical Helion API entrypoint).
+) -> set[torch.fx.Node]:
+    """Return aten and ``hl.dot`` MMA anchors from the host FX graphs."""
     mma_nodes: set[torch.fx.Node] = set()
-    operand_load_nodes: set[torch.fx.Node] = set()
     for graph_info in graphs:
         for node in graph_info.graph.nodes:
             if (
@@ -450,14 +403,7 @@ def _tcgen05_aux_detector_mma_facts(
             ):
                 continue
             mma_nodes.add(node)
-            # Treat every positional arg that resolves through the same operand
-            # trace accepted by MMA codegen as an operand load.
-            for arg in node.args:
-                if isinstance(arg, torch.fx.Node):
-                    load_node = _trace_to_load_through_casts(arg)
-                    if load_node is not None:
-                        operand_load_nodes.add(load_node)
-    return mma_nodes, operand_load_nodes
+    return mma_nodes
 
 
 def host_function_matmul_has_non_tcgen05_operand(

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -28,6 +28,8 @@ import os
 import textwrap
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Literal
+from typing import NamedTuple
 from typing import cast
 
 import torch
@@ -135,7 +137,6 @@ from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_N_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
-from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
@@ -147,7 +148,7 @@ from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
-from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_shape
+from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_profile
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
 from .tcgen05_lifecycle import Tcgen05LifecycleContext
@@ -503,6 +504,21 @@ class _Rank3RhsGroupedProof:
     @property
     def is_worklist(self) -> bool:
         return self.worklist_lhs is not None
+
+
+class Tcgen05GroupedWorklistSeedFacts(NamedTuple):
+    """Structural proof plus first-binding hints for worklist seed ranking.
+
+    The integer fields are deliberately named ``*_hint``: they are not static
+    compiler facts and must not escape the grouped-worklist heuristic.
+    """
+
+    groups_hint: int
+    packed_m_hint: int
+    n_hint: int
+    k_hint: int
+    b_major: Literal["k", "n"]
+    device_split_sizes: bool
 
 
 @dataclass(frozen=True)
@@ -1734,6 +1750,7 @@ def _trace_rank3_grouped_rhs_nt_operand(
     *,
     m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_mn_major: bool = False,
 ) -> _MmaOperandInfo | None:
     """Recognize ``B_grouped[group, tile_n, tile_k].T`` as logical ``[K, N]``.
 
@@ -1847,7 +1864,8 @@ def _trace_rank3_grouped_rhs_nt_operand(
         (source_fake.shape[2], source_fake.shape[1]),
         (source_fake.stride(2), source_fake.stride(1)),
     )
-    if _tcgen05_tma_matrix_major(logical_fake) not in ("row", "col"):
+    matrix_major = _tcgen05_tma_matrix_major(logical_fake)
+    if matrix_major != "col" and not (allow_mn_major and matrix_major == "row"):
         return None
     return _MmaOperandInfo(
         load=load_node,
@@ -1874,6 +1892,7 @@ def _trace_to_mma_operand(
     cg: GenerateAST | None = None,
     rank3_rhs_m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_rank3_rhs_mn_major: bool = False,
 ) -> _MmaOperandInfo | None:
     if role == "rhs" and allow_rank3_rhs_nt:
         rank3_rhs = _trace_rank3_grouped_rhs_nt_operand(
@@ -1881,6 +1900,7 @@ def _trace_to_mma_operand(
             node,
             m_block_id=rank3_rhs_m_block_id,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_mn_major=allow_rank3_rhs_mn_major,
         )
         if rank3_rhs is not None:
             return rank3_rhs
@@ -2404,6 +2424,7 @@ def _has_mma_operands(
     cg: GenerateAST | None = None,
     rank3_rhs_m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_rank3_rhs_mn_major: bool = False,
 ) -> bool:
     """Check if lhs/rhs come from loads with MMA-compatible dtypes."""
     lhs_info = _trace_to_mma_operand(
@@ -2419,6 +2440,7 @@ def _has_mma_operands(
         cg=cg,
         rank3_rhs_m_block_id=rank3_rhs_m_block_id,
         allow_grouped_k_mask=allow_grouped_k_mask,
+        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
     )
     if lhs_info is None or rhs_info is None:
         return False
@@ -2777,6 +2799,9 @@ def _analyze_rank3_rhs_grouped_search_operands(
         rhs_node,
         role="rhs",
         allow_rank3_rhs_nt=True,
+        # This early DeviceIR pass only recovers axes. Mode-specific layout
+        # admission is repeated by ``_prove_rank3_rhs_grouped_mma``.
+        allow_rank3_rhs_mn_major=True,
         cg=graph_view,
         allow_grouped_k_mask=True,
     )
@@ -2792,6 +2817,16 @@ def _analyze_rank3_rhs_grouped_search_operands(
     canonical_block_id = env.canonical_block_id
     n_block_id = canonical_block_id(rhs.rhs_n_block_id)
     k_block_id = canonical_block_id(rhs.rhs_k_block_id)
+    lhs_indices = lhs.load.args[1] if len(lhs.load.args) > 1 else None
+    lhs_k_block_id = (
+        _rank3_rhs_exact_index_block_id(lhs_indices[-1], reduction=None)
+        if isinstance(lhs_indices, list | tuple)
+        and lhs_indices
+        and isinstance(lhs_indices[-1], Node)
+        else None
+    )
+    if lhs_k_block_id is None or canonical_block_id(lhs_k_block_id) != k_block_id:
+        return None
     if len(device_ir.grid_block_ids) != 1:
         return None
     root_grid_ids = device_ir.grid_block_ids[0]
@@ -2851,8 +2886,9 @@ def _analyze_rank3_rhs_grouped_search_operands(
     )
     if lhs.source_fake.dtype != rhs.source_fake.dtype:
         return None
-    if not env.known_equal(lhs.source_fake.size(-1), rhs.source_fake.size(-1)):
-        return None
+    # Dynamic inputs can carry distinct K symbols. Admission relies on the
+    # proven shared reduction block-id above, never coincidentally equal size
+    # hints; the host K-equality guard and full grouped proof stay authoritative.
     return _MmaOperandAnalysis(lhs=lhs, rhs=rhs)
 
 
@@ -2864,6 +2900,7 @@ def is_mma_compatible_aten(
     cg: GenerateAST | None = None,
     rank3_rhs_m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_rank3_rhs_mn_major: bool = False,
 ) -> bool:
     """Check if an aten addmm/mm node can use MMA."""
     args = node.args
@@ -2889,6 +2926,7 @@ def is_mma_compatible_aten(
         cg=cg,
         rank3_rhs_m_block_id=rank3_rhs_m_block_id,
         allow_grouped_k_mask=allow_grouped_k_mask,
+        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
     )
 
 
@@ -3095,6 +3133,7 @@ def can_codegen_cute_mma_aten(
     cg: GenerateAST | None = None,
     rank3_rhs_m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_rank3_rhs_mn_major: bool = False,
 ) -> bool:
     return (
         is_mma_compatible_aten(
@@ -3104,6 +3143,7 @@ def can_codegen_cute_mma_aten(
             cg=cg,
             rank3_rhs_m_block_id=rank3_rhs_m_block_id,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
         )
         and _mma_result_can_be_deferred(node)
         and _mma_loop_is_exclusive(node)
@@ -3174,6 +3214,35 @@ def analyze_cute_mma_node(
                         node,
                         worklist_lhs,
                         n_block_id=operands.n_block_id,
+                    )
+                    if worklist_store is not None:
+                        output_store_analysis = _analyze_packed_split_mma_output_store(
+                            node,
+                            operands,
+                            worklist_store,
+                            graphs=device_ir.graphs,
+                        )
+            elif (segment_group := operands.rhs.rhs_segment_group) is not None:
+                graph_view = cast(
+                    "GenerateAST",
+                    _MmaSearchGraphView(device_ir.graphs),
+                )
+                segment_lhs = _rank3_rhs_segment_lhs_info(
+                    graph_view,
+                    operands.lhs,
+                    operands.rhs,
+                    segment_block_id=segment_group.segment_block_id,
+                    m_block_id=operands.m_block_id,
+                    k_block_id=operands.k_block_id,
+                )
+                if segment_lhs is not None:
+                    worklist_store = _rank3_rhs_worklist_store_info(
+                        graph_view,
+                        node,
+                        segment_lhs,
+                        segment_group,
+                        n_block_id=operands.n_block_id,
+                        allow_store_extent_metadata=True,
                     )
                     if worklist_store is not None:
                         output_store_analysis = _analyze_packed_split_mma_output_store(
@@ -3259,6 +3328,7 @@ def _prove_rank3_rhs_grouped_mma(
     with_acc = True
     grouped_mode = _tcgen05_grouped_mode(config)
     allow_grouped_k_mask = grouped_mode is not None
+    allow_rank3_rhs_mn_major = grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
     if not can_codegen_cute_mma_aten(
         node,
         with_acc,
@@ -3266,6 +3336,7 @@ def _prove_rank3_rhs_grouped_mma(
         cg=cg,
         rank3_rhs_m_block_id=axes.m_block_id,
         allow_grouped_k_mask=allow_grouped_k_mask,
+        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
     ):
         return None
     lhs_node = node.args[1] if with_acc else node.args[0]
@@ -3287,6 +3358,7 @@ def _prove_rank3_rhs_grouped_mma(
         cg=cg,
         rank3_rhs_m_block_id=axes.m_block_id,
         allow_grouped_k_mask=allow_grouped_k_mask,
+        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
     )
     if lhs_info is None or rhs_info is None or not rhs_info.rhs_rank3_grouped_nt:
         return None
@@ -3300,10 +3372,11 @@ def _prove_rank3_rhs_grouped_mma(
         lhs_info.grouped_k_mask is not None or rhs_info.grouped_k_mask is not None
     ) and k_mask is None:
         return None
+    rhs_major = _tcgen05_tma_matrix_major(rhs_fake)
     if not (
         lhs_fake.dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and _tcgen05_tma_matrix_major(lhs_fake) == "row"
-        and _tcgen05_tma_matrix_major(rhs_fake) in ("row", "col")
+        and (rhs_major == "col" or (allow_rank3_rhs_mn_major and rhs_major == "row"))
         and rhs_info.rhs_n_block_id == canonical_block_id(axes.n_block_id)
         and rhs_info.rhs_k_block_id == canonical_block_id(axes.k_block_id)
         and (
@@ -3439,6 +3512,106 @@ def _prove_rank3_rhs_grouped_mma(
         worklist_store=worklist_store,
         packed_split=packed_split,
     )
+
+
+def tcgen05_grouped_worklist_seed_facts(
+    env: CompileEnvironment,
+    device_ir: DeviceIR,
+    fact: MatmulFact,
+    *,
+    source_m_tile: int,
+) -> Tcgen05GroupedWorklistSeedFacts | None:
+    """Prove a grouped N,M worklist and expose ranking-only shape hints.
+
+    The source-row tile is an explicit kernel constexpr.  Passing it into the
+    proof keeps compiler seeds tied to the physical A packing chosen by the
+    caller. Shape hints only rank shape-general seeds; config normalization and
+    the runtime worklist validator remain the correctness gates.
+    """
+    from ..compile_environment import CompileEnvironment
+
+    host_function = device_ir.host_function
+    if (
+        host_function is None
+        or fact.m_block_id is None
+        or fact.n_block_id is None
+        or fact.k_block_id is None
+        or source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+        or len(device_ir.root_ids) != 1
+        or len(device_ir.grid_block_ids) != 1
+    ):
+        return None
+    grid_block_ids = device_ir.grid_block_ids[0]
+    if len(grid_block_ids) != 3 or grid_block_ids[1:] != [
+        fact.m_block_id,
+        fact.n_block_id,
+    ]:
+        return None
+    cluster_m = (
+        1 if source_m_tile == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE else 2
+    )
+    axes = _GroupedMmaAxes(
+        m_block_id=fact.m_block_id,
+        n_block_id=fact.n_block_id,
+        k_block_id=fact.k_block_id,
+        segment_block_id=grid_block_ids[0],
+    )
+    # BK64 only makes this probe structurally valid; the proof is block-K
+    # agnostic, and seed ranking still emits both reviewed BK64/BK128 families.
+    probe_config = {
+        "block_sizes": [256, 128, 64],
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": cluster_m,
+        "tcgen05_cluster_n": 1,
+        TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_WORKLIST_NM,
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY: source_m_tile,
+    }
+    graph_view = _MmaSearchGraphView(device_ir.graphs)
+    if CompileEnvironment.has_current():
+        assert CompileEnvironment.current() is env, (
+            "grouped worklist seed proof must use the provided compile environment"
+        )
+        env_context = contextlib.nullcontext()
+    else:
+        env_context = env
+    with env_context, host_function:
+        for graph_info in device_ir.graphs:
+            for node in graph_info.graph.nodes:
+                if (
+                    node.op != "call_function"
+                    or node.target is not torch.ops.aten.addmm.default
+                ):
+                    continue
+                proof = _prove_rank3_rhs_grouped_mma(
+                    cast("GenerateAST", graph_view),
+                    node,
+                    config=probe_config,
+                    axes=axes,
+                )
+                if proof is None or not proof.is_worklist:
+                    continue
+                rhs_major = proof.rhs.matrix_major
+                if rhs_major == "col":
+                    b_major: Literal["k", "n"] = "k"
+                elif rhs_major == "row":
+                    b_major = "n"
+                else:
+                    continue
+                groups = env.size_hint(proof.rhs.source_fake.shape[0])
+                packed_m = env.size_hint(proof.lhs.source_fake.shape[0])
+                n = env.size_hint(proof.rhs.source_fake.shape[1])
+                k = env.size_hint(proof.rhs.source_fake.shape[2])
+                if min(groups, packed_m, n, k) <= 0:
+                    continue
+                return Tcgen05GroupedWorklistSeedFacts(
+                    groups,
+                    packed_m,
+                    n,
+                    k,
+                    b_major,
+                    proof.packed_split is not None,
+                )
+    return None
 
 
 def _tcgen05_grouped_static_seed_has_proof(
@@ -3913,7 +4086,9 @@ def prepare_cute_collective_lane_loop_suppression(
     env = CompileEnvironment.current()
     if env.backend_name != "cute":
         return
-    allow_grouped_k_mask = _tcgen05_grouped_mode(cg.device_function.config) is not None
+    grouped_mode = _tcgen05_grouped_mode(cg.device_function.config)
+    allow_grouped_k_mask = grouped_mode is not None
+    allow_rank3_rhs_mn_major = grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
     cute_state = cg.device_function.cute_state
     if not tcgen05_fragment_epilogue_has_unique_anchor(
         cg.codegen_graphs
@@ -4020,6 +4195,7 @@ def prepare_cute_collective_lane_loop_suppression(
                 allow_rank3_rhs_nt=True,
                 cg=cg,
                 allow_grouped_k_mask=allow_grouped_k_mask,
+                allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
             ):
                 continue
         elif node.target is torch.ops.aten.mm.default:
@@ -4032,6 +4208,7 @@ def prepare_cute_collective_lane_loop_suppression(
                 allow_rank3_rhs_nt=True,
                 cg=cg,
                 allow_grouped_k_mask=allow_grouped_k_mask,
+                allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
             ):
                 continue
         elif can_codegen_cute_mma_dot(node):
@@ -4055,6 +4232,7 @@ def prepare_cute_collective_lane_loop_suppression(
             allow_rank3_rhs_nt=True,
             cg=cg,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
         )
         if lhs_info is None or rhs_info is None:
             continue
@@ -4190,33 +4368,22 @@ def prepare_cute_collective_lane_loop_suppression(
                     is None
                 ):
                     continue
-        collective_bm = bm
-        collective_bn = bn
-        if (
+        worklist_lowering = (
             rhs_rank3_worklist_lhs_info is not None
-            and _requested_tcgen05_grouped_schedule(
-                cast(
-                    "str | None",
-                    cast("_ConfigLike", cg.device_function.config).get(
-                        TCGEN05_GROUPED_MODE_CONFIG_KEY
-                    ),
-                )
-            )
-            is Tcgen05Orientation.NM
-        ):
-            source_m_tile = _tcgen05_config_int(
+            and grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
+        )
+        worklist_profile = (
+            resolve_tcgen05_grouped_worklist_mma_profile(
                 cg.device_function.config,
-                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-            )
-            physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
-                cluster_m=_tcgen05_cluster_m(cg.device_function.config),
                 block_k=bk,
-                source_m_tile=source_m_tile,
             )
-            if physical_shape is None:
-                continue
-            collective_bm, collective_bn = physical_shape
+            if worklist_lowering
+            else None
+        )
+        if worklist_lowering and worklist_profile is None:
+            continue
+        collective_bm = worklist_profile.mma_m if worklist_profile is not None else bm
+        collective_bn = worklist_profile.mma_n if worklist_profile is not None else bn
         if (
             _choose_mma_impl(
                 lhs_fake.dtype,
@@ -4225,6 +4392,7 @@ def prepare_cute_collective_lane_loop_suppression(
                 bk=bk,
                 config=cg.device_function.config,
                 input_device=lhs_fake.device,
+                defer_grouped_worklist_smem_check=worklist_profile is not None,
             )
             != "tcgen05"
         ):
@@ -5797,6 +5965,7 @@ def _emit_mma_pipeline(
             allow_rank3_rhs_nt=lowering_ctx is not None,
             cg=cg,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_rank3_rhs_mn_major=(grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM),
         )
         if lhs_info is None or rhs_info is None:
             return _unsupported_schedule("MMA operand tracing failed")
@@ -6220,36 +6389,25 @@ def _emit_mma_pipeline(
     # B becomes physical operand A, while packed A becomes physical operand B.
     tcgen05_mma_a_k_major = not tcgen05_nm_orientation or tcgen05_b_k_major
     tcgen05_mma_b_k_major = True if tcgen05_nm_orientation else tcgen05_b_k_major
+    worklist_profile = None
     tcgen05_worklist_source_m_tile: int | None = None
     tcgen05_one_cta_worklist_shape = False
     if tcgen05_nm_orientation:
-        if bk not in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES:
-            return _unsupported_schedule("block_k must be 64 or 128")
-        tcgen05_worklist_source_m_tile = _tcgen05_config_int(
+        worklist_profile = resolve_tcgen05_grouped_worklist_mma_profile(
             df.config,
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-        )
-        if (
-            tcgen05_worklist_source_m_tile
-            not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
-        ):
-            return _unsupported_schedule(
-                f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY} must be "
-                f"one of {TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES}"
-            )
-        physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
-            cluster_m=tcgen05_cluster_m,
             block_k=bk,
-            source_m_tile=tcgen05_worklist_source_m_tile,
         )
-        if physical_shape is None:
+        if worklist_profile is None:
             return _unsupported_schedule(
-                "worklist N,M requires cluster_m=2, or cluster_m=1 with "
+                "worklist N,M requires block_k in (64, 128), cluster_m=2, "
+                "or cluster_m=1 with "
                 f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY}="
                 f"{TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE}"
             )
-        tcgen05_mma_bm, tcgen05_mma_bn = physical_shape
+        tcgen05_cluster_m = worklist_profile.cluster_m
+        tcgen05_worklist_source_m_tile = worklist_profile.source_m_tile
+        tcgen05_mma_bm = worklist_profile.mma_m
+        tcgen05_mma_bn = worklist_profile.mma_n
         tcgen05_one_cta_worklist_shape = tcgen05_cluster_m == 1
         tcgen05_source_bm = tcgen05_worklist_source_m_tile
         tcgen05_source_bn = tcgen05_mma_bm
@@ -6290,6 +6448,7 @@ def _emit_mma_pipeline(
         bk=bk,
         config=df.config,
         input_device=lhs_fake.device,
+        defer_grouped_worklist_smem_check=worklist_profile is not None,
     )
     if (
         mma_impl == "tcgen05"
@@ -6376,6 +6535,7 @@ def _emit_mma_pipeline(
                 bn=bn,
                 bk=bk,
                 config=df.config,
+                defer_grouped_worklist_smem_check=worklist_profile is not None,
             )
         )
     ):
@@ -6418,19 +6578,14 @@ def _emit_mma_pipeline(
             "tcgen05 matmul with a leading passthrough axis does not support "
             "tcgen05_cluster_n != 1",
         )
-    # The one-CTA N,M worklist keeps the public 256x128 logical tile for the
-    # scheduler, but its physical output tile is source_m_tile x 128.  Edge
-    # admission must use that physical orientation; otherwise an N tail such
-    # as N=160 is misclassified as a double edge against the logical tile.
+    # N,M worklists keep the public 256x128 logical scheduler tile, while their
+    # physical output tile is source_m_tile x physical_mma_m. Edge admission
+    # must use that physical orientation for both CTA-group sizes.
     tcgen05_output_bm = (
-        tcgen05_source_bm
-        if tcgen05_grouped_worklist_static_full_tiles and tcgen05_one_cta_worklist_shape
-        else bm
+        tcgen05_source_bm if tcgen05_grouped_worklist_static_full_tiles else bm
     )
     tcgen05_output_bn = (
-        tcgen05_source_bn
-        if tcgen05_grouped_worklist_static_full_tiles and tcgen05_one_cta_worklist_shape
-        else bn
+        tcgen05_source_bn if tcgen05_grouped_worklist_static_full_tiles else bn
     )
     tcgen05_static_output_tiles = (
         m_size % tcgen05_output_bm == 0 and n_size % tcgen05_output_bn == 0
@@ -7056,6 +7211,7 @@ def _emit_mma_pipeline(
         if (
             tcgen05_grouped_worklist_persistent
             and not tcgen05_grouped_device_split_sizes
+            and not tcgen05_grouped_runtime_nm_direct
         ):
             if grouped_layout_tensor.ndim != 2 or grouped_layout_tensor.shape[1] != 4:
                 raise exc.BackendUnsupported(
@@ -7669,7 +7825,6 @@ def _emit_mma_pipeline(
         # MMA-M tile and K to be a whole BK tile. Every A/B TMA transaction is
         # therefore full even when the logical valid-row mask zeros D padding.
         tcgen05_static_full_tma_fast_path = True
-    nm_worklist = tcgen05_nm_orientation
     rhs_rank3_tma_group_expr = rhs_rank3_group_expr
     rhs_rank3_tma_group_setup: list[str] = []
     if (
@@ -7872,7 +8027,7 @@ def _emit_mma_pipeline(
     )
     if tcgen05_runtime_n_specialization:
         assert tcgen05_worklist_source_m_tile is not None
-        # Runtime UMMA-N narrows ragged runtime-direct source-M tails. Mailbox
+        # Runtime UMMA-N narrows ragged runtime-direct source-M tails.  Mailbox
         # scheduling and the newer-DSL fallback retain public typed static-width
         # MMA. The exact BF16/FP32 shape envelope below fails closed; the pinned
         # CuTe/CUTLASS environment is validation provenance, and upgrades require
@@ -8212,8 +8367,7 @@ def _emit_mma_pipeline(
         tcgen05_warp_spec = warp_spec_from_config(df.config)
         # The public NM profile reserves its scheduler warp internally.
         nm_scheduler_decode = (
-            nm_worklist
-            and tcgen05_nm_orientation
+            tcgen05_nm_orientation
             and tcgen05_grouped_static_persistent
             and tcgen05_grouped_worklist_persistent
             and (
@@ -8480,7 +8634,7 @@ def _emit_mma_pipeline(
             )
             and explicit_epi_aux_supported
         )
-        if nm_worklist:
+        if tcgen05_nm_orientation:
             nm_worklist_metadata_checks = {
                 "supported_physical_store": nm_explicit_store_wave,
                 "dynamic_rank2_ab_tensormaps": (
@@ -9928,7 +10082,7 @@ def _emit_mma_pipeline(
                             if grouped_plan.static_group_quota_args
                             else {}
                         ),
-                        **({"orientation": "nm"} if nm_worklist else {}),
+                        **({"orientation": "nm"} if tcgen05_nm_orientation else {}),
                         **(
                             {"worklist_metadata": True}
                             if tcgen05_grouped_worklist_persistent
@@ -10015,7 +10169,7 @@ def _emit_mma_pipeline(
                 "k_total_size": k_total_size,
                 "kernel_args": [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b],
             }
-            if nm_worklist:
+            if tcgen05_nm_orientation:
                 ab_tma_plan["orientation"] = "nm"
             if tcgen05_grouped_fixed_tensormaps:
                 ab_tma_plan["fixed_ab_tensormaps"] = True
@@ -10392,7 +10546,8 @@ def _emit_mma_pipeline(
                 )
                 _emit_per_tile(
                     f"if {tcgen05_grouped_valid_m} <= "
-                    f"cutlass.Int32({tcgen05_mma_bn - 16}):\n"
+                    f"cutlass.Int32("
+                    f"{tcgen05_mma_bn - _TCGEN05_RUNTIME_MMA_N_GRANULARITY}):\n"
                     f"    {tma_runtime_mma_n} = "
                     f"{_tcgen05_runtime_mma_n_expr(tcgen05_grouped_valid_m, tcgen05_mma_bn)}\n"
                     f"    {tma_b_peer_delta} = {mma_slice_linear} * "
@@ -10955,7 +11110,7 @@ def _emit_mma_pipeline(
                 )
                 and tcgen05_static_full_tiles
                 and tcgen05_is_two_cta
-                and (bk == 64 or nm_worklist)
+                and (bk == 64 or tcgen05_nm_orientation)
             )
             tma_kloop_args = _PerKiterTmaArgs(
                 tma_pipeline=tma_pipeline,
@@ -11508,7 +11663,7 @@ def _emit_mma_pipeline(
             segment_store_actual_m = (
                 tcgen05_grouped_store_m
                 if (
-                    nm_worklist
+                    tcgen05_nm_orientation
                     and tcgen05_grouped_store_m
                     and rhs_rank3_worklist_store_info.uses_scheduler_store_extent
                 )
@@ -11516,7 +11671,7 @@ def _emit_mma_pipeline(
             )
             segment_store_valid_m_bound = (
                 tcgen05_grouped_valid_m
-                if nm_worklist and tcgen05_grouped_valid_m
+                if tcgen05_nm_orientation and tcgen05_grouped_valid_m
                 else rhs_rank3_worklist_lhs_info.group_m.name
             )
             segment_store_node = rhs_rank3_worklist_store_info.store_node
@@ -11832,19 +11987,27 @@ def _tcgen05_candidate_exceeds_smem(
     bn: int,
     bk: int,
     config: object | None,
+    defer_grouped_worklist_smem_check: bool = False,
 ) -> bool:
     """Whether tcgen05 A/B staging exceeds the device's per-CTA budget."""
     if input_device is None or config is None:
         return False
-    if (
-        cast("_ConfigLike", config).get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
-        == TCGEN05_GROUPED_MODE_WORKLIST_NM
+    worklist_profile = (
+        resolve_tcgen05_grouped_worklist_mma_profile(
+            cast("_ConfigLike", config), block_k=bk
+        )
+        if defer_grouped_worklist_smem_check
+        else None
+    )
+    if worklist_profile is not None and (bm, bn) == (
+        worklist_profile.mma_m,
+        worklist_profile.mma_n,
     ):
-        # The grouped worklist owns scheduler mailboxes, TensorMap storage,
-        # and an explicit C ring. Its exact ordered allocation is checked by
-        # ``tcgen05_grouped_worklist_smem_bytes`` after the physical N,M tile
-        # has been resolved; the generic AB-only reserve is too conservative
-        # for the source-224 AB7 profile.
+        # The grouped worklist owns scheduler mailboxes, TensorMap storage, and
+        # an explicit C ring. Its conservative allocation upper bound is checked
+        # by ``tcgen05_grouped_worklist_smem_bytes`` in the resolved worklist
+        # lowering. The explicit defer flag prevents unrelated MMA nodes that
+        # share this config from bypassing ordinary AB admission.
         return False
     env_choice = os.environ.get("HELION_CUTE_MMA_IMPL", "auto").strip().lower()
     if env_choice not in ("auto", "tcgen05"):
@@ -11895,6 +12058,7 @@ def _choose_mma_impl(
     bk: int,
     config: object | None = None,
     input_device: torch.device | None = None,
+    defer_grouped_worklist_smem_check: bool = False,
 ) -> str:
     tcgen05_cluster_m = 1
     if config is not None:
@@ -11927,6 +12091,7 @@ def _choose_mma_impl(
                 bn=bn,
                 bk=bk,
                 config=config,
+                defer_grouped_worklist_smem_check=defer_grouped_worklist_smem_check,
             ):
                 return "universal"
             return env_choice
@@ -11952,6 +12117,7 @@ def _choose_mma_impl(
             bn=bn,
             bk=bk,
             config=config,
+            defer_grouped_worklist_smem_check=defer_grouped_worklist_smem_check,
         ):
             return "tcgen05"
     if _mma_impl_matches_problem_shape("warp", input_dtype, bm=bm, bn=bn, bk=bk):
@@ -12663,8 +12829,8 @@ def _validate_tcgen05_smem_swizzle_override(
     """Reject illegal ``smem_swizzle_a/b`` overrides at codegen time.
 
     CuTe's ``make_smem_layout_atom`` requires the major-mode bytes-per-row
-    to be a multiple of the swizzle pattern's contiguous bytes. For
-    The resolved operand major mode determines the contiguous extent: K-major
+    to be a multiple of the swizzle pattern's contiguous bytes. The resolved
+    operand major mode determines the contiguous extent: K-major
     operands use ``bk``; MN-major A uses ``bm`` and MN-major B uses ``bn``.
 
     This helper computes the active bytes-per-row from the live tile
@@ -12759,6 +12925,7 @@ def codegen_cute_mma(
             allow_rank3_rhs_nt=True,
             cg=ctx.cg,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_rank3_rhs_mn_major=(grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM),
         )
         if rhs_info is None or not rhs_info.rhs_rank3_grouped_nt:
             return _unsupported_schedule("MMA RHS was not grouped rank-3")

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import NamedTuple
+from typing import TypeVar
 from typing import cast
 
 import torch
@@ -25,6 +27,7 @@ from .strategies import TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY
 from .strategies import TCGEN05_LEGAL_L2_SWIZZLE_SIZES
 from .strategies import TCGEN05_LEGAL_SMEM_SWIZZLE_BYTES
 from .strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
+from .strategies import TCGEN05_PERSISTENCE_MODEL_PID_TYPES
 from .strategies import TCGEN05_STRATEGY_CONFIG_KEY
 from .strategies import TCGEN05_STRATEGY_CONFIG_KEYS
 from .strategies import TCGEN05_WARP_SPEC_AB_LOAD_WARPS_KEY
@@ -108,7 +111,6 @@ from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
-from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
@@ -156,7 +158,9 @@ from .tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
 from .tcgen05_constants import tcgen05_two_cta_edge_k_tail_seed_overrides
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Mapping
+    from collections.abc import Sequence
 
     from ...autotuner.block_id_sequence import BlockIdSequence
     from ...autotuner.config_fragment import BlockSizeFragment
@@ -189,8 +193,121 @@ class Tcgen05AbStagesThreeSearchConstraints(NamedTuple):
     per_cta_smem_budget_bytes: int
 
 
+class Tcgen05GroupedWorklistSmemFacts(NamedTuple):
+    group_count: int
+    device_split_sizes: bool
+
+
 TCGEN05_GROUPED_DYNAMIC_AB4_STAGE = 4
 TCGEN05_GROUPED_DYNAMIC_STAGE_TUPLES = ((4, 2), (8, 4))
+
+
+_SeedValue = TypeVar("_SeedValue", bound=Hashable)
+
+
+def _compiler_seed_values(
+    seeds: Sequence[Config],
+    key: str,
+    value_type: type[_SeedValue],
+    is_valid: Callable[[_SeedValue], bool],
+    *,
+    exact_type: bool = True,
+    is_valid_for_seed: Callable[[Config, _SeedValue], bool] | None = None,
+) -> tuple[_SeedValue, ...]:
+    return tuple(
+        dict.fromkeys(
+            cast("_SeedValue", value)
+            for seed in seeds
+            for value in (seed.config.get(key),)
+            if (
+                type(value) is value_type
+                if exact_type
+                else isinstance(value, value_type)
+            )
+            and is_valid(cast("_SeedValue", value))
+            and (
+                is_valid_for_seed is None
+                or is_valid_for_seed(seed, cast("_SeedValue", value))
+            )
+        )
+    )
+
+
+def _integer_fragment_with_seed_values(
+    fragment: IntegerFragment,
+    seed_values: tuple[int, ...],
+) -> ConfigSpecFragment:
+    seed_only_values = tuple(
+        value
+        for value in dict.fromkeys(seed_values)
+        if value < fragment.low or value > fragment.high
+    )
+    return (
+        fragment
+        if not seed_only_values
+        else _CompilerSeedIntegerFragment(fragment, seed_only_values)
+    )
+
+
+class _CompilerSeedIntegerFragment(IntegerFragment):
+    """An integer search range that can also encode frozen compiler seeds."""
+
+    def __init__(
+        self,
+        fragment: IntegerFragment,
+        seed_only_values: tuple[int, ...],
+    ) -> None:
+        super().__init__(fragment.low, fragment.high, fragment.default_val)
+        self.seed_only_values = seed_only_values
+
+    def pattern_neighbors(self, current: object, radius: int = 1) -> list[object]:
+        if type(current) is not int:
+            raise TypeError(f"Expected int, got {type(current).__name__}")
+        if self.low <= current <= self.high:
+            return super().pattern_neighbors(current, radius)
+        if current not in self.seed_only_values:
+            raise ValueError(f"{current!r} is not a compiler-seed integer value")
+        boundary = self.clamp(current)
+        return [boundary, *super().pattern_neighbors(boundary, radius)]
+
+    def encode(self, value: object) -> list[float]:
+        if type(value) is not int:
+            raise TypeError(f"Expected int, got {type(value).__name__}")
+        if not (self.low <= value <= self.high or value in self.seed_only_values):
+            raise ValueError(f"{value!r} is not a compiler-seed integer value")
+        return [float(value)]
+
+    def fingerprint(self) -> tuple[str | int, ...]:
+        return (
+            "compiler_seed_integer",
+            self.low,
+            self.high,
+            self.default_val,
+            *self.seed_only_values,
+        )
+
+
+def _enum_fragment_with_seed_values(
+    base_choices: tuple[object, ...],
+    seed_values: tuple[Hashable, ...],
+    *,
+    search_choices: tuple[object, ...],
+    original: EnumFragment | None = None,
+    search_only_if_widened: bool = False,
+) -> EnumFragment:
+    choices = tuple(dict.fromkeys((*base_choices, *seed_values)))
+    if original is not None and choices == base_choices:
+        return original
+    return EnumFragment(
+        choices,
+        search_choices=(
+            None
+            if search_only_if_widened and choices == base_choices
+            else search_choices
+        ),
+    )
+
+
 # The generated grouped kernel's non-operand allocations are about 1.6 KiB
 # (pipeline barriers, TensorMap staging, and TMEM bookkeeping). Keep a small
 # margin while still admitting CUTLASS's max-fit AB8/C4 pipeline on B200.
@@ -296,6 +413,7 @@ class CuteTcgen05Config:
         self.ab_stages_three_search_constraints: (
             Tcgen05AbStagesThreeSearchConstraints | None
         ) = None
+        self.grouped_worklist_smem_facts: Tcgen05GroupedWorklistSmemFacts | None = None
         self.deep_direct_entry_validation_enabled: bool = False
         self.num_epi_warps_search_choices: tuple[int, ...] | None = None
         self.num_epi_warps_validation_choices: tuple[int, ...] | None = None
@@ -871,18 +989,40 @@ class CuteTcgen05Config:
     def _fix_cluster_m2_search_config(self, config: dict[str, object]) -> None:
         if not (self.search_enabled and config.get("tcgen05_cluster_m") == 2):
             return
+        config_view = self._matmul_config_view(config)
+        if config_view is None:
+            config["tcgen05_cluster_m"] = 1
+            return
+        block_sizes, m_index, n_index, k_index = config_view
+
+        def is_grouped_worklist_two_cta() -> bool:
+            return (
+                config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                and config.get("tcgen05_cluster_n", 1) == 1
+                and block_sizes[m_index] == TCGEN05_TWO_CTA_BLOCK_M
+                and block_sizes[n_index] == 128
+                and block_sizes[k_index] in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+                and config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+                in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+            )
+
         constraints = self.cluster_m2_search_constraints
+        if is_grouped_worklist_two_cta():
+            # Worklist source-M metadata owns the validated physical
+            # 256x32/224/256 MMA profile and its K envelope independently of
+            # the generic cluster-M2 policy. Compiler seeds widen the
+            # otherwise-narrow pid fragment, so keep this exact family even
+            # when generic constraints reject it or are absent.
+            config["pid_type"] = TCGEN05_TWO_CTA_SEED_PID_TYPE
+            config.pop("epilogue_subtile", None)
+            return
         if constraints is None:
             config["tcgen05_cluster_m"] = 1
             return
         if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
             config["tcgen05_cluster_m"] = 1
             return
-        config_view = self._matmul_config_view(config)
-        if config_view is None:
-            config["tcgen05_cluster_m"] = 1
-            return
-        block_sizes, m_index, n_index, k_index = config_view
         edge_k_tail_family = constraints.allow_edge_k_tail_family
         is_narrow_clc_aux_tma = self._is_clc_aux_tma_narrow_n_request(config)
         if edge_k_tail_family:
@@ -909,23 +1049,6 @@ class CuteTcgen05Config:
         # their sub-paths; doing it once here covers the full-tile and
         # small-grid paths too.
         config.pop("epilogue_subtile", None)
-        if (
-            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
-            == TCGEN05_GROUPED_MODE_WORKLIST_NM
-            and config.get("tcgen05_cluster_n", 1) == 1
-            and block_sizes[m_index] == TCGEN05_TWO_CTA_BLOCK_M
-            and block_sizes[n_index] == 128
-            and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
-            and config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
-            in (
-                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-                TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
-            )
-        ):
-            # Worklist configs keep their 256x128 logical DSL tile. Their
-            # source-M metadata selects the physical 256x224/256 MMA profile
-            # through ``resolve_tcgen05_grouped_worklist_mma_profile``.
-            return
         # fp8 small-grid family: a sampled bm<=128 routes to the fp8-validated
         # per-CTA 64xbn 2-CTA tile (bm=128/bn=128) instead of the bm=256 full
         # tile, which underfills the device on small/wave-limited fp8 GEMMs. The
@@ -970,6 +1093,90 @@ class CuteTcgen05Config:
                     TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_L2_GROUPING
                 ]
 
+    def _fix_grouped_worklist_search_config(self, config: dict[str, object]) -> None:
+        """Project worklist search neighbors onto the validated logical tile."""
+        if not self.search_enabled:
+            return
+        if (
+            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            != TCGEN05_GROUPED_MODE_WORKLIST_NM
+        ):
+            return
+        source_m_tile = config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+        if (
+            type(source_m_tile) is not int
+            or source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+        ):
+            return
+        config_view = self._matmul_config_view(config)
+        if config_view is None:
+            return
+        block_sizes, m_index, n_index, k_index = config_view
+        block_sizes[m_index] = TCGEN05_TWO_CTA_BLOCK_M
+        block_sizes[n_index] = 128
+        sampled_bk = block_sizes[k_index]
+        block_k_choices = TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+        assert self.matmul_block_ids is not None
+        semantic_k_block_id = self.matmul_block_ids[2]
+        known_static_ks = {
+            fact.static_k
+            for fact in self.config_spec.matmul_facts
+            if fact.k_block_id == semantic_k_block_id and fact.static_k is not None
+        }
+        constraints = self.cluster_m2_search_constraints
+        if constraints is not None:
+            known_static_ks.add(constraints.static_k)
+        if known_static_ks:
+            # Worklists require exact K divisibility but own an independent
+            # stage/tile-count envelope from generic cluster-M2 search. Filter
+            # only by that shared structural requirement: importing generic
+            # max-tile or edge-tail policy would rewrite valid worklist BKs.
+            constrained_choices = tuple(
+                block_k
+                for block_k in block_k_choices
+                if all(static_k % block_k == 0 for static_k in known_static_ks)
+            )
+            if not constrained_choices:
+                static_k_values = tuple(sorted(known_static_ks))
+                raise InvalidConfig(
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} has no supported "
+                    f"block_k in {TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES} "
+                    f"that divides every known static K in {static_k_values}"
+                )
+            block_k_choices = constrained_choices
+        block_sizes[k_index] = (
+            min(
+                block_k_choices,
+                key=lambda block_k: (abs(block_k - sampled_bk), block_k),
+            )
+            if type(sampled_bk) is int
+            else block_k_choices[0]
+        )
+        if source_m_tile != TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE:
+            # Only the compact source-32 profile supports CtaGroup.ONE. The
+            # reviewed source-224/256 profiles are CtaGroup.TWO even when a
+            # pattern neighbor independently mutates the cluster fragment.
+            config["tcgen05_cluster_m"] = 2
+
+    @staticmethod
+    def _is_grouped_clc_config(config: dict[str, object]) -> bool:
+        return (
+            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) in TCGEN05_GROUPED_MODES
+            and config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+            == Tcgen05PersistenceModel.CLC_PERSISTENT.value
+        )
+
+    @staticmethod
+    def _is_grouped_runtime_direct_clc_config(config: dict[str, object]) -> bool:
+        return (
+            CuteTcgen05Config._is_grouped_clc_config(config)
+            and config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            and config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
+            and TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY not in config
+        )
+
     def prepare_normalization(
         self, config: dict[str, object], *, fix_invalid: bool
     ) -> None:
@@ -984,26 +1191,8 @@ class CuteTcgen05Config:
                 raise InvalidConfig(
                     "tcgen05 grouped kernels require num_sm_multiplier=1"
                 )
-        grouped_clc = (
-            grouped_mode in TCGEN05_GROUPED_MODES
-            and config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
-            == Tcgen05PersistenceModel.CLC_PERSISTENT.value
-        )
-        if grouped_clc and (
-            config.get(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, 0) != 0
-        ):
-            if fix_invalid:
-                config.pop(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, None)
-            else:
-                raise InvalidConfig(
-                    "tcgen05 grouped CLC launches its exact full tile-record grid; "
-                    "reserved_sms cannot limit that grid"
-                )
-        if grouped_clc and not (
-            grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
-            and config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
-            and TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY not in config
-        ):
+        grouped_clc = self._is_grouped_clc_config(config)
+        if grouped_clc and not self._is_grouped_runtime_direct_clc_config(config):
             if fix_invalid:
                 config.pop(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY, None)
                 config[TCGEN05_STRATEGY_CONFIG_KEY] = (
@@ -1018,6 +1207,17 @@ class CuteTcgen05Config:
                     f"{TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY}=True, and no "
                     f"{TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY}; the "
                     "launcher must build an exact one-record-per-cluster tile table"
+                )
+        grouped_clc = self._is_grouped_clc_config(config)
+        if grouped_clc and (
+            config.get(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, 0) != 0
+        ):
+            if fix_invalid:
+                config.pop(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, None)
+            else:
+                raise InvalidConfig(
+                    "tcgen05 grouped CLC launches its exact full tile-record grid; "
+                    "reserved_sms cannot limit that grid"
                 )
         source_m_tile_key = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
         source_m_tile = config.get(source_m_tile_key)
@@ -1152,6 +1352,21 @@ class CuteTcgen05Config:
             dtype_bytes=dtype_bytes,
             per_cta_smem_budget_bytes=budget_bytes,
         )
+
+    def register_grouped_worklist_smem_facts(
+        self, *, group_count: int, device_split_sizes: bool
+    ) -> None:
+        if group_count <= 0:
+            raise ValueError(
+                "grouped worklist SMEM facts require a positive group count"
+            )
+        facts = Tcgen05GroupedWorklistSmemFacts(group_count, device_split_sizes)
+        if self.grouped_worklist_smem_facts not in (None, facts):
+            raise RuntimeError(
+                "conflicting grouped worklist SMEM facts were registered for one "
+                "ConfigSpec"
+            )
+        self.grouped_worklist_smem_facts = facts
 
     def allow_deep_direct_entry_validation(self, *, device: torch.device) -> None:
         self.deep_direct_entry_validation_enabled = (
@@ -1325,25 +1540,36 @@ class CuteTcgen05Config:
     def _grouped_worklist_nm_ab_config_matches(
         self, config: dict[str, object], ab_stages: object
     ) -> bool:
-        block_sizes = config.get("block_sizes")
-        block_k = (
-            block_sizes[2]
-            if isinstance(block_sizes, list) and len(block_sizes) >= 3
-            else None
-        )
+        config_view = self._matmul_config_view(config)
+        if config_view is None:
+            block_sizes = config.get("block_sizes")
+            if (
+                self.matmul_block_ids is not None
+                or not isinstance(block_sizes, list)
+                or len(block_sizes) != 3
+            ):
+                return False
+            # Reviewed/AOT configs can be normalized by a standalone ConfigSpec
+            # before compiler MMA analysis registers semantic block IDs.  That
+            # schema is exactly the canonical [M, N, K] triple.  Real kernels
+            # always use the registered semantic indices above, including when
+            # their block-size order is permuted.
+            config_view = (block_sizes, 0, 1, 2)
+        block_sizes, m_index, n_index, k_index = config_view
+        block_k = block_sizes[k_index]
         profile = resolve_tcgen05_grouped_worklist_mma_profile(
             config,
             block_k=block_k,
         )
         if not (
             type(ab_stages) is int
-            and 2 <= ab_stages <= 7
+            and 4 <= ab_stages <= 7
             and profile is not None
             and config.get("tcgen05_cluster_n", 1) == 1
             and config.get("tcgen05_acc_stages", 2) == 2
             and config.get("tcgen05_c_stages", 2) == 2
-            and isinstance(block_sizes, list)
-            and block_sizes[:2] == [TCGEN05_TWO_CTA_BLOCK_M, 128]
+            and block_sizes[m_index] == TCGEN05_TWO_CTA_BLOCK_M
+            and block_sizes[n_index] == 128
         ):
             return False
         constraints = self.ab_stages_three_search_constraints
@@ -1351,6 +1577,29 @@ class CuteTcgen05Config:
             # Fixed configs can be normalized before their input device is known.
             # CuTe MMA selection applies the real target's SMEM limit at codegen.
             return True
+        target_capacity_bytes = (
+            constraints.per_cta_smem_budget_bytes
+            + TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
+        )
+        smem_facts = self.grouped_worklist_smem_facts
+        if smem_facts is None:
+            # Compiler-owned seeds register scheduler-specific allocation facts
+            # and are rejected here when their exact footprint is too large.  An
+            # explicit config has no source-M metadata contract at bind time, so
+            # those facts can legitimately be absent.  Admit only when the
+            # physical AB ring itself fits the raw target capacity, then defer
+            # scheduler/mailbox allocations to the resolved worklist codegen
+            # check.  That check proves the single grouped matmul and computes
+            # its exact footprint before emitting any allocations.
+            required_ab_bytes = tcgen05_ab_smem_bytes_per_cta(
+                bm=profile.mma_m,
+                bn=profile.mma_n,
+                bk=cast("int", block_k),
+                dtype_bytes=constraints.dtype_bytes,
+                ab_stages=ab_stages,
+                cluster_m=profile.cluster_m,
+            )
+            return required_ab_bytes <= target_capacity_bytes
         sched_stage_count = config.get(TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY, 1)
         if type(sched_stage_count) is not int or sched_stage_count <= 0:
             return False
@@ -1361,8 +1610,8 @@ class CuteTcgen05Config:
         # the raw target cap and apply the same conservative worklist upper bound
         # across scheduler modes as codegen.
         required_bytes = tcgen05_grouped_worklist_smem_bytes(
-            group_count=1,
-            device_split_sizes=False,
+            group_count=smem_facts.group_count,
+            device_split_sizes=smem_facts.device_split_sizes,
             sched_stage_count=sched_stage_count,
             bm=physical_bm,
             bn=physical_bn,
@@ -1372,10 +1621,6 @@ class CuteTcgen05Config:
             acc_stages=2,
             c_stages=2,
             cluster_m=profile.cluster_m,
-        )
-        target_capacity_bytes = (
-            constraints.per_cta_smem_budget_bytes
-            + TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
         )
         return required_bytes <= target_capacity_bytes
 
@@ -1975,6 +2220,8 @@ class CuteTcgen05Config:
             != Tcgen05PersistenceModel.CLC_PERSISTENT.value
         ):
             return
+        if self._is_grouped_runtime_direct_clc_config(config):
+            return
         if self._is_validated_clc_persistence_search_candidate(config):
             return
         config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY] = (
@@ -2268,13 +2515,14 @@ class CuteTcgen05Config:
         config_view = self._matmul_config_view(config)
         if config_view is None:
             return
-        block_sizes, m_index, _, _ = config_view
+        block_sizes, m_index, n_index, k_index = config_view
         if (
             config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
             == TCGEN05_GROUPED_MODE_WORKLIST_NM
             and config.get("tcgen05_cluster_n", 1) == 1
-            and block_sizes[:2] == [TCGEN05_TWO_CTA_BLOCK_M, 128]
-            and block_sizes[2] in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+            and block_sizes[m_index] == TCGEN05_TWO_CTA_BLOCK_M
+            and block_sizes[n_index] == 128
+            and block_sizes[k_index] in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
             and config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
             == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
         ):
@@ -2588,24 +2836,23 @@ class CuteTcgen05Config:
         even though ``_aux_tma_search_enabled`` was widened (see
         ``aux_stages_autotune_fragments``).
         """
-        seed_choices = tuple(
-            dict.fromkeys(
-                value
-                for config in self.config_spec.compiler_seed_configs
-                if (value := config.config.get(TCGEN05_CONSUMER_REGS_CONFIG_KEY))
-                in TCGEN05_CONSUMER_REGS_CHOICES
-            )
+        seed_choices = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            TCGEN05_CONSUMER_REGS_CONFIG_KEY,
+            int,
+            lambda value: value in TCGEN05_CONSUMER_REGS_CHOICES,
         )
         if not self._aux_tma_edge_search_enabled():
-            if not seed_choices:
+            if not any(
+                choice != TCGEN05_CONSUMER_REGS_DEFAULT for choice in seed_choices
+            ):
                 return {}
-            choices = tuple(
-                dict.fromkeys((TCGEN05_CONSUMER_REGS_DEFAULT, *seed_choices))
-            )
             return {
-                TCGEN05_CONSUMER_REGS_CONFIG_KEY: EnumFragment(
-                    choices,
+                TCGEN05_CONSUMER_REGS_CONFIG_KEY: _enum_fragment_with_seed_values(
+                    (TCGEN05_CONSUMER_REGS_DEFAULT,),
+                    seed_choices,
                     search_choices=(TCGEN05_CONSUMER_REGS_DEFAULT,),
+                    search_only_if_widened=True,
                 )
             }
         return {
@@ -2615,36 +2862,61 @@ class CuteTcgen05Config:
         }
 
     def persistence_model_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
-        default_model = derive_persistence_model_from_pid_type(
-            self.allowed_pid_types[0]
-        ).value
-        seed_override_models = tuple(
+        pid_default_models = tuple(
             dict.fromkeys(
-                model
-                for config in self.config_spec.compiler_seed_configs
-                if isinstance(
-                    model := config.config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY),
-                    str,
-                )
-                and model in {item.value for item in Tcgen05PersistenceModel}
-                and model
-                != self.persistence_model_default_from_config(config.config).value
+                derive_persistence_model_from_pid_type(pid_type).value
+                for pid_type in self.allowed_pid_types
             )
         )
+        seed_pid_types = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            "pid_type",
+            str,
+            lambda pid_type: pid_type in TCGEN05_PERSISTENCE_MODEL_PID_TYPES,
+            exact_type=False,
+        )
+        seed_pid_default_models = tuple(
+            dict.fromkeys(
+                derive_persistence_model_from_pid_type(pid_type).value
+                for pid_type in seed_pid_types
+            )
+        )
+
+        def seed_default_model(seed: Config) -> str:
+            pid_type = seed.config.get("pid_type")
+            if (
+                isinstance(pid_type, str)
+                and pid_type in TCGEN05_PERSISTENCE_MODEL_PID_TYPES
+            ):
+                return derive_persistence_model_from_pid_type(pid_type).value
+            return self.persistence_model_default_from_config(seed.config).value
+
+        seed_override_models = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY,
+            str,
+            lambda model: model in {item.value for item in Tcgen05PersistenceModel},
+            exact_type=False,
+            is_valid_for_seed=lambda seed, model: model != seed_default_model(seed),
+        )
         if not self._clc_persistence_search_enabled():
-            if not seed_override_models:
+            seed_pid_defaults_widen_domain = any(
+                model not in pid_default_models for model in seed_pid_default_models
+            )
+            if not seed_override_models and not seed_pid_defaults_widen_domain:
                 return {}
-            choices = tuple(dict.fromkeys((default_model, *seed_override_models)))
             return {
-                TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: EnumFragment(
-                    choices,
-                    search_choices=(default_model,),
+                TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: _enum_fragment_with_seed_values(
+                    pid_default_models,
+                    (*seed_pid_default_models, *seed_override_models),
+                    search_choices=pid_default_models,
+                    search_only_if_widened=True,
                 )
             }
         choices = tuple(
             dict.fromkeys(
                 (
-                    default_model,
+                    *pid_default_models,
                     Tcgen05PersistenceModel.NON_PERSISTENT.value,
                     Tcgen05PersistenceModel.STATIC_PERSISTENT.value,
                     Tcgen05PersistenceModel.CLC_PERSISTENT.value,
@@ -2669,35 +2941,18 @@ class CuteTcgen05Config:
             strategy_choices = (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,)
             scheduler_warps_choices = (0,)
             c_input_warps_choices = (0,)
-        strategy_seed_choices = tuple(
-            dict.fromkeys(
-                strategy
-                for config in self.config_spec.compiler_seed_configs
-                if isinstance(
-                    strategy := config.config.get(TCGEN05_STRATEGY_CONFIG_KEY),
-                    str,
-                )
-                and strategy in {item.value for item in Tcgen05Strategy}
-            )
+        strategy_seed_choices = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            TCGEN05_STRATEGY_CONFIG_KEY,
+            str,
+            lambda strategy: strategy in {item.value for item in Tcgen05Strategy},
+            exact_type=False,
         )
-        scheduler_seed_choices = tuple(
-            dict.fromkeys(
-                scheduler_warps
-                for config in self.config_spec.compiler_seed_configs
-                if type(
-                    scheduler_warps := config.config.get(
-                        TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
-                    )
-                )
-                is int
-                and scheduler_warps in (0, 1)
-            )
-        )
-        all_strategy_choices = tuple(
-            dict.fromkeys((*strategy_choices, *strategy_seed_choices))
-        )
-        all_scheduler_warps_choices = tuple(
-            dict.fromkeys((*scheduler_warps_choices, *scheduler_seed_choices))
+        scheduler_seed_choices = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY,
+            int,
+            lambda scheduler_warps: scheduler_warps in (0, 1),
         )
         # The store-warp slot stays narrowed to ``0`` in the autotune surface —
         # only an explicit ``helion.Config(tcgen05_warp_spec_store_warps=1)``
@@ -2715,25 +2970,21 @@ class CuteTcgen05Config:
         else:
             layout_choices = (Tcgen05LayoutStrategy.DEFAULT.value,)
         return {
-            TCGEN05_STRATEGY_CONFIG_KEY: EnumFragment(
-                all_strategy_choices,
-                search_choices=(
-                    strategy_choices
-                    if all_strategy_choices != strategy_choices
-                    else None
-                ),
+            TCGEN05_STRATEGY_CONFIG_KEY: _enum_fragment_with_seed_values(
+                strategy_choices,
+                strategy_seed_choices,
+                search_choices=strategy_choices,
+                search_only_if_widened=True,
             ),
             TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: EnumFragment(layout_choices),
             TCGEN05_WARP_SPEC_MMA_WARPS_KEY: EnumFragment((1,)),
             TCGEN05_WARP_SPEC_AB_LOAD_WARPS_KEY: EnumFragment((1,)),
             TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY: EnumFragment((0,)),
-            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: EnumFragment(
-                all_scheduler_warps_choices,
-                search_choices=(
-                    scheduler_warps_choices
-                    if all_scheduler_warps_choices != scheduler_warps_choices
-                    else None
-                ),
+            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: _enum_fragment_with_seed_values(
+                scheduler_warps_choices,
+                scheduler_seed_choices,
+                search_choices=scheduler_warps_choices,
+                search_only_if_widened=True,
             ),
             TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: EnumFragment(c_input_warps_choices),
             TCGEN05_WARP_SPEC_STORE_WARPS_KEY: EnumFragment(store_warps_choices),
@@ -2900,13 +3151,9 @@ class CuteTcgen05Config:
                 if key in config:
                     if key == "tcgen05_ab_stages" and (
                         self._grouped_dynamic_deep_config_matches(config)
-                        or (
-                            type(config[key]) is int
-                            and config[key] > 3
-                            and self._grouped_worklist_nm_ab_config_matches(
-                                config,
-                                config[key],
-                            )
+                        or self._grouped_worklist_nm_ab_config_matches(
+                            config,
+                            config[key],
                         )
                     ):
                         config[key] = int(cast("Any", config[key]))
@@ -3250,6 +3497,7 @@ class CuteTcgen05Config:
             )
 
     def fix_search_config(self, config: dict[str, object]) -> None:
+        self._fix_grouped_worklist_search_config(config)
         self._fix_aux_edge_search_config(config)
         self._fix_cluster_m2_search_config(config)
         self._fix_cluster_m1_persistent_search_config(config)
@@ -3364,97 +3612,77 @@ class CuteTcgen05Config:
         ):
             fields["loop_orders"] = self.config_spec.loop_orders
         fields.update(self.optional_fragments(for_search=True))
-        seed_l2_swizzles = tuple(
-            dict.fromkeys(
-                value
-                for config in self.config_spec.compiler_seed_configs
-                if type(value := config.config.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY))
-                is int
-                and value in TCGEN05_LEGAL_L2_SWIZZLE_SIZES
+        seeds = self.config_spec.compiler_seed_configs
+        if isinstance(fragment := fields.get("tcgen05_ab_stages"), IntegerFragment):
+            fields["tcgen05_ab_stages"] = _integer_fragment_with_seed_values(
+                fragment,
+                _compiler_seed_values(
+                    seeds, "tcgen05_ab_stages", int, lambda value: value > 0
+                ),
             )
+        l2_key = TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
+        if isinstance(fragment := fields.get(l2_key), EnumFragment):
+            fields[l2_key] = _enum_fragment_with_seed_values(
+                fragment.choices,
+                _compiler_seed_values(
+                    seeds,
+                    l2_key,
+                    int,
+                    lambda value: value in TCGEN05_LEGAL_L2_SWIZZLE_SIZES,
+                ),
+                search_choices=fragment.search_choices or fragment.choices,
+                original=fragment,
+            )
+        modes = _compiler_seed_values(
+            seeds,
+            TCGEN05_GROUPED_MODE_CONFIG_KEY,
+            str,
+            lambda value: value in TCGEN05_GROUPED_MODES,
+            exact_type=False,
         )
-        l2_swizzle_fragment = fields.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
-        if seed_l2_swizzles and isinstance(l2_swizzle_fragment, EnumFragment):
-            choices = tuple(
-                dict.fromkeys((*l2_swizzle_fragment.choices, *seed_l2_swizzles))
-            )
-            if choices != l2_swizzle_fragment.choices:
-                fields[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = EnumFragment(
+        if any(mode in TCGEN05_GROUPED_DYNAMIC_MODES for mode in modes):
+            choices = TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
+            fields[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = (
+                _enum_fragment_with_seed_values(
                     choices,
-                    search_choices=(
-                        l2_swizzle_fragment.search_choices
-                        or l2_swizzle_fragment.choices
+                    _compiler_seed_values(
+                        seeds,
+                        TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+                        int,
+                        lambda value: (
+                            0 <= value <= TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
+                        ),
                     ),
+                    search_choices=choices,
                 )
-        grouped_seed_modes = tuple(
-            dict.fromkeys(
-                mode
-                for config in self.config_spec.compiler_seed_configs
-                if (mode := config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY))
-                in TCGEN05_GROUPED_MODES
             )
+        if modes:
+            fields[TCGEN05_GROUPED_MODE_CONFIG_KEY] = _enum_fragment_with_seed_values(
+                (None,), modes, search_choices=(None,)
+            )
+        runtime_direct = _compiler_seed_values(
+            seeds,
+            TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+            bool,
+            lambda value: value is True,
         )
-        has_grouped_dynamic_seed = any(
-            mode in TCGEN05_GROUPED_DYNAMIC_MODES for mode in grouped_seed_modes
+        if runtime_direct:
+            fields[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = (
+                _enum_fragment_with_seed_values(
+                    (False,), runtime_direct, search_choices=(False,)
+                )
+            )
+        source_m_tiles = _compiler_seed_values(
+            seeds,
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+            int,
+            lambda value: value in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES,
         )
-        if has_grouped_dynamic_seed:
-            seed_reserved_sms = tuple(
-                dict.fromkeys(
-                    reserved_sms
-                    for config in self.config_spec.compiler_seed_configs
-                    if type(
-                        reserved_sms := config.config.get(
-                            TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
-                        )
-                    )
-                    is int
-                    and 0 <= reserved_sms <= TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
+        if source_m_tiles:
+            fields[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = (
+                _enum_fragment_with_seed_values(
+                    (None,), source_m_tiles, search_choices=(None,)
                 )
-            )
-            reserved_sms_choices = tuple(
-                dict.fromkeys(
-                    (
-                        *TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
-                        *seed_reserved_sms,
-                    )
-                )
-            )
-            fields[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = EnumFragment(
-                reserved_sms_choices,
-                search_choices=TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
-            )
-        if grouped_seed_modes:
-            # Seed-only encoding: random/default search stays off the grouped
-            # path, while exact-proof compiler seeds survive flatten/unflatten.
-            fields[TCGEN05_GROUPED_MODE_CONFIG_KEY] = EnumFragment(
-                (None, *grouped_seed_modes),
-                search_choices=(None,),
-            )
-        if any(
-            config.config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
-            for config in self.config_spec.compiler_seed_configs
-        ):
-            fields[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = EnumFragment(
-                (False, True),
-                search_choices=(False,),
-            )
-        grouped_source_m_tiles = tuple(
-            dict.fromkeys(
-                source_m_tile
-                for config in self.config_spec.compiler_seed_configs
-                if (
-                    source_m_tile := config.config.get(
-                        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
-                    )
-                )
-                and type(source_m_tile) is int
-                and source_m_tile in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
-            )
-        )
-        if grouped_source_m_tiles:
-            fields[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = EnumFragment(
-                (None, *grouped_source_m_tiles),
-                search_choices=(None,),
             )
         fields.update(self.strategy_autotune_fragments())
         fields.update(self.aux_load_mode_autotune_fragments())
@@ -3462,21 +3690,17 @@ class CuteTcgen05Config:
         fields.update(self.consumer_regs_autotune_fragments())
         fields.update(self.persistence_model_autotune_fragments())
         if self.config_spec.supports_config_key("pid_type"):
-            seed_pid_types = tuple(
-                cast("PidTypeLiteral", pid_type)
-                for seed in self.config_spec.compiler_seed_configs
-                if isinstance(pid_type := seed.config.get("pid_type"), str)
-            )
-            pid_type_choices = tuple(
-                dict.fromkeys((*self.allowed_pid_types, *seed_pid_types))
-            )
-            pid_type_search_choices = (
-                self.allowed_pid_types
-                if pid_type_choices != self.allowed_pid_types
-                else None
-            )
-            fields["pid_type"] = EnumFragment(
-                pid_type_choices, search_choices=pid_type_search_choices
+            fields["pid_type"] = _enum_fragment_with_seed_values(
+                self.allowed_pid_types,
+                _compiler_seed_values(
+                    seeds,
+                    "pid_type",
+                    str,
+                    lambda _value: True,
+                    exact_type=False,
+                ),
+                search_choices=self.allowed_pid_types,
+                search_only_if_widened=True,
             )
         if (
             self.config_spec.supports_config_key("indexing")

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -3892,6 +3892,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                         supports_small_n_scalar_fallback=(
                             supports_small_n_scalar_fallback
                         ),
+                        allow_dynamic_hints=(
+                            candidate.operands.rhs.rhs_segment_group is not None
+                        ),
                     )
                     if search_plan is None:
                         continue

--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -118,10 +118,29 @@ class BoundKernelInMemoryCacheKey(CacheKeyBase):
     specialization_key: Information about all kernel inputs.
                         For tensors this means their device, shape, size etc.
     extra_results: Information regarding `hl.specialize` decisions
+    compiler_seed_results: Device facts consumed by compiler seed heuristics
+                           that fired for this bound kernel.
     """
 
     specialization_key: tuple[Hashable, ...]
     extra_results: tuple[Hashable, ...]
+    compiler_seed_results: tuple[Hashable, ...] = dataclasses.field(
+        default=(),
+        repr=False,
+        kw_only=True,
+    )
+
+    def _repr_body(self) -> str:
+        auto_fields = [field for field in dataclasses.fields(self) if field.repr]
+        body = ", ".join(
+            f"{field.name}={getattr(self, field.name)!r}" for field in auto_fields
+        )
+        if self.compiler_seed_results:
+            body = f"{body}, compiler_seed_results={self.compiler_seed_results!r}"
+        return body
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self._repr_body()})"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -157,20 +176,16 @@ class LooseAutotuneCacheKey(BoundKernelInMemoryCacheKey):
     best_of_k: int = dataclasses.field(default=1, repr=False)
 
     def __repr__(self) -> str:
-        # Reproduce the dataclass-generated repr for all auto-repr fields, then
-        # append ``best_of_k`` only when it is non-default. This preserves the
-        # byte-identical hash for K=1 entries written before the field existed.
-        auto_fields = [f for f in dataclasses.fields(self) if f.repr]
-        body = ", ".join(f"{f.name}={getattr(self, f.name)!r}" for f in auto_fields)
+        # Append ``best_of_k`` only when it is non-default. ``_repr_body`` does
+        # the same for compiler seed results, preserving historical hashes when
+        # both extensions have their defaults.
+        body = self._repr_body()
         if self.best_of_k != 1:
             body = f"{body}, best_of_k={self.best_of_k!r}"
         return f"{type(self).__name__}({body})"
 
-    def stable_hash(self) -> str:
-        return hashlib.sha256(repr(self).encode("utf-8")).hexdigest()
 
-
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, repr=False)
 class StrictAutotuneCacheKey(LooseAutotuneCacheKey):
     """
     Autotune Cache key to use for utmost strictness in terms of re-autotuning

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -503,6 +503,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._effective_source_results: dict[str, BenchmarkResult] = {}
         self._compiler_seed_configs: set[Config] = set()
         self._compiler_seed_source_hashes: set[str] = set()
+        self._has_compiled_search_config = False
         # budget_exceeded_fn inherits the class-level _never_exceeded default
         # until BaseSearch._prepare installs the search's real hook.
 
@@ -977,8 +978,17 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             try:
                 with capture_output() as captured:
                     compiled[i] = self.kernel.compile_config(config, allow_print=False)
+                    self._has_compiled_search_config = True
             except Exception as e:
-                if not compiled and i == len(all_configs) - 1:
+                # Surface an entirely broken initial search, but once a known-
+                # compilable config exists, an all-failed neighborhood is an
+                # ordinary exhausted search branch. This matches a mixed batch,
+                # where the same failures are skipped whenever one sibling compiles.
+                if (
+                    not compiled
+                    and i == len(all_configs) - 1
+                    and not self._has_compiled_search_config
+                ):
                     raise
                 maybe_dump_triton_failure(
                     self.kernel, config, e, captured_output=captured[0] or None

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -149,6 +149,17 @@ def _record_restriction(
 _TARGET_DEVICE_CAPABILITY_UNSET = object()
 
 
+def _copy_config_structure(value: object) -> object:
+    """Copy built-in config containers while preserving opaque leaf objects."""
+    if type(value) is dict:
+        return {key: _copy_config_structure(item) for key, item in value.items()}
+    if type(value) is list:
+        return [_copy_config_structure(item) for item in value]
+    if type(value) is tuple:
+        return tuple(_copy_config_structure(item) for item in value)
+    return value
+
+
 class TensorNumelConstraint(NamedTuple):
     """Tensor element count must stay within Triton's max numel limit."""
 
@@ -158,7 +169,11 @@ class TensorNumelConstraint(NamedTuple):
 
 
 class MatmulFact(NamedTuple):
-    """Shape facts recorded when matmul requirements are applied."""
+    """Shape facts recorded when matmul requirements are applied.
+
+    ``static_m``, ``static_n``, and ``static_k`` are proven compile-time
+    extents or ``None``. Runtime size hints must not be stored in these fields.
+    """
 
     lhs_ndim: int
     rhs_ndim: int
@@ -776,6 +791,7 @@ class ConfigSpec:
         # retry. ``None`` leaves all benchmark behavior unchanged.
         self.compiler_seed_timeout_retry_repetitions: int | None = None
         self.autotuner_heuristics: list[str] = []
+        self.compiler_heuristic_metadata: dict[str, object] = {}
         self.matmul_facts: list[MatmulFact] = []
         # The Stage-1 categorizing product the reduction seed + allocator consume.
         self.reduction_kernel_fact: ReductionKernelFact | None = None
@@ -1543,6 +1559,14 @@ class ConfigSpec:
             device=device,
         )
 
+    def register_cute_tcgen05_grouped_worklist_smem_facts(
+        self, *, group_count: int, device_split_sizes: bool
+    ) -> None:
+        self._cute_tcgen05_config.register_grouped_worklist_smem_facts(
+            group_count=group_count,
+            device_split_sizes=device_split_sizes,
+        )
+
     @staticmethod
     def _cute_per_cta_ab_smem_budget_bytes(device: torch.device) -> int:
         return CuteTcgen05Config.per_cta_ab_smem_budget_bytes(device)
@@ -1710,6 +1734,21 @@ class ConfigSpec:
 
     def is_supported_config(self, config: Mapping[str, object]) -> bool:
         return not self.unsupported_config_keys(config)
+
+    def normalized_config(
+        self,
+        config: helion.Config | Mapping[str, object],
+    ) -> helion.Config:
+        """Return a normalized copy without mutating the requested config."""
+        values = config.config if isinstance(config, helion.Config) else config
+        copied_values = {
+            key: _copy_config_structure(value) for key, value in values.items()
+        }
+        normalized = helion.Config(
+            **copied_values  # pyrefly: ignore[bad-argument-type]
+        )
+        self.normalize(normalized)
+        return normalized
 
     def normalize(
         self, config: helion.Config | dict[str, object], *, _fix_invalid: bool = False

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -149,10 +149,12 @@ class LocalAutotuneCache(AutotuneCacheBase):
             )
             specialization_key = in_memory_cache_key.specialization_key
             extra_results = in_memory_cache_key.extra_results
+            compiler_seed_results = in_memory_cache_key.compiler_seed_results
             dev = extract_device(self.args)
         else:
             specialization_key = multi_args.workload_key
             extra_results = ()
+            compiler_seed_results = ()
             dev = multi_args.cases[0][0].env.device
         kernel_source = textwrap.dedent(inspect.getsource(self.kernel.kernel.fn))
         kernel_source_hash = hashlib.sha256(kernel_source.encode("utf-8")).hexdigest()
@@ -201,6 +203,7 @@ class LocalAutotuneCache(AutotuneCacheBase):
         return LooseAutotuneCacheKey(
             specialization_key=specialization_key,
             extra_results=extra_results,
+            compiler_seed_results=compiler_seed_results,
             kernel_source_hash=kernel_source_hash,
             hardware=hardware,
             runtime_name=runtime_name,

--- a/helion/language/__init__.py
+++ b/helion/language/__init__.py
@@ -54,6 +54,7 @@ from .tile_ops import tile_id as tile_id
 from .tile_ops import tile_index as tile_index
 from .tile_proxy import Tile as Tile
 from .tunable_ops import register_block_size as register_block_size
+from .tunable_ops import register_heuristic_metadata as register_heuristic_metadata
 from .tunable_ops import register_tunable as register_tunable
 from .view_ops import join as join
 from .view_ops import split as split

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -312,14 +312,18 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
 
 @dataclasses.dataclass(frozen=True)
 class CuteTcgen05SearchPlan:
-    """Side-effect-free tcgen05 search limits for one MMA candidate."""
+    """Side-effect-free tcgen05 search limits for one MMA candidate.
+
+    ``static_*`` are proven compile-time extents. Dynamic size hints remain
+    local to admission and are not retained in the plan.
+    """
 
     m: int | torch.SymInt
     n: int | torch.SymInt
     k: int | torch.SymInt
-    static_m: int
-    static_n: int
-    static_k: int
+    static_m: int | None
+    static_n: int | None
+    static_k: int | None
     leading_work_multiplier: int
     is_fp8: bool
     is_small_n: bool
@@ -345,13 +349,22 @@ def plan_cute_tcgen05_search(
     has_leading_passthrough: bool,
     supports_small_n_role_local_tma: bool = False,
     supports_small_n_scalar_fallback: bool = False,
+    allow_dynamic_hints: bool = False,
 ) -> CuteTcgen05SearchPlan | None:
     """Return search limits without mutating the shared ``ConfigSpec``."""
     m, n, k = _dot_dimensions(lhs, rhs)
     env = CompileEnvironment.current()
+
     static_m = _static_problem_extent(env, m)
     static_n = _static_problem_extent(env, n)
     static_k = _static_problem_extent(env, k)
+    if not allow_dynamic_hints and (
+        static_m is None or static_n is None or static_k is None
+    ):
+        return None
+    m_hint = static_m if static_m is not None else env.size_hint(m)
+    n_hint = static_n if static_n is not None else env.size_hint(n)
+    k_hint = static_k if static_k is not None else env.size_hint(k)
     is_fp8 = lhs.dtype == torch.float8_e4m3fn
     mma_k = 32 if is_fp8 else 16
     min_tcgen05_n = 16 if is_fp8 else 8
@@ -360,20 +373,18 @@ def plan_cute_tcgen05_search(
         env.backend_name != "cute"
         or lhs.dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         or rhs.dtype != lhs.dtype
-        or static_m is None
-        or static_n is None
-        or static_k is None
-        or static_m < 64
+        or m_hint < 64
         # Size-one tile axes are fixed to block size one before this analysis,
         # so they cannot carry the minimum tcgen05 instruction tile.
-        or static_n < 2
+        or (static_n is not None and static_n < 2)
+        or (static_n is None and n_hint < min_tcgen05_n)
         or (
             is_small_n
             and not (
                 supports_small_n_role_local_tma or supports_small_n_scalar_fallback
             )
         )
-        or static_k < mma_k
+        or k_hint < mma_k
     ):
         return None
     small_n_requires_role_local_tma = (
@@ -389,13 +400,30 @@ def plan_cute_tcgen05_search(
     def pow2_floor_at_least(value: int, minimum: int) -> int:
         return 1 << (max(minimum, value).bit_length() - 1)
 
-    max_tcgen05_n = min(256, pow2_floor_at_least(static_n, min_tcgen05_n))
-    max_tcgen05_m = 256 if max_tcgen05_n >= 128 and static_m >= 256 else 128
-    max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
+    max_tcgen05_n = (
+        256
+        if static_n is None
+        else min(256, pow2_floor_at_least(static_n, min_tcgen05_n))
+    )
+    max_tcgen05_m = (
+        256 if max_tcgen05_n >= 128 and (static_m is None or static_m >= 256) else 128
+    )
+    max_search_m = (
+        max_tcgen05_m
+        if static_m is None
+        else min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
+    )
     max_search_n = max_tcgen05_n
-    max_search_k = min(128, pow2_floor_at_least(static_k, mma_k))
+    max_search_k = (
+        128 if static_k is None else min(128, pow2_floor_at_least(static_k, mma_k))
+    )
     min_search_m = 128 if max_tcgen05_m >= 256 else 64
-    if is_small_n and supports_small_n_scalar_fallback and not is_fp8:
+    if (
+        static_n is not None
+        and is_small_n
+        and supports_small_n_scalar_fallback
+        and not is_fp8
+    ):
         min_search_n = 1 << (static_n - 1).bit_length()
     else:
         min_search_n = min_tcgen05_n
@@ -405,21 +433,30 @@ def plan_cute_tcgen05_search(
         static_leading = _static_problem_extent(env, leading_operand.shape[0])
         if static_leading is not None:
             leading_work_multiplier = max(static_leading, 1)
-        if static_m % min_search_m != 0:
-            min_search_m = 64
-        max_search_m = min(max_search_m, static_m & -static_m)
-        max_search_n = min(max_search_n, static_n & -static_n)
-        max_search_k = min(max_search_k, static_k & -static_k)
-        if (
-            max_search_m < min_search_m
-            or max_search_n < min_search_n
-            or max_search_k < mma_k
-        ):
-            return None
-    if static_m % max_search_m != 0 and static_n % max_search_n != 0:
+        if static_m is not None and static_n is not None and static_k is not None:
+            if static_m % min_search_m != 0:
+                min_search_m = 64
+            max_search_m = min(max_search_m, static_m & -static_m)
+            max_search_n = min(max_search_n, static_n & -static_n)
+            max_search_k = min(max_search_k, static_k & -static_k)
+            if (
+                max_search_m < min_search_m
+                or max_search_n < min_search_n
+                or max_search_k < mma_k
+            ):
+                return None
+    if (
+        static_m is not None
+        and static_n is not None
+        and static_m % max_search_m != 0
+        and static_n % max_search_n != 0
+    ):
         max_search_m = min(max_search_m, 128)
     if small_n_requires_role_local_tma and (
-        static_m % max_search_m != 0 or static_k % max_search_k != 0
+        static_m is None
+        or static_k is None
+        or static_m % max_search_m != 0
+        or static_k % max_search_k != 0
     ):
         return None
     return CuteTcgen05SearchPlan(
@@ -474,52 +511,60 @@ def enable_cute_tcgen05_search(
     max_search_n = plan.max_search_n
     max_search_k = plan.max_search_k
     spec.cute_tcgen05_search_enabled = True
-    allow_full_tile_persistent_pid_types = (
-        static_m % max_search_m == 0
-        and static_n % max_search_n == 0
-        and static_k % max_search_k == 0
-    )
-    allow_small_n_persistent_pid_types = (
-        plan.is_small_n
-        and plan.small_n_supports_role_local_tma
-        and 0 < static_n < max_search_n
-        and static_m % max_search_m == 0
-        and static_k % max_search_k == 0
-    )
     max_cluster_m2_search_k = TCGEN05_TWO_CTA_MAX_K_TILES * max_search_k
-    allow_full_tile_cluster_m2_search = (
-        allow_full_tile_persistent_pid_types
-        and max_search_m >= TCGEN05_TWO_CTA_BLOCK_M
-        and max_search_n >= TCGEN05_TWO_CTA_BLOCK_N
-        and static_k <= max_cluster_m2_search_k
-    )
-    allow_edge_cluster_m2_search = (
-        not has_leading_passthrough
-        and not allow_full_tile_persistent_pid_types
-        and plan.max_tcgen05_m >= TCGEN05_TWO_CTA_BLOCK_M
-        and plan.max_tcgen05_n >= TCGEN05_TWO_CTA_BLOCK_N
-        and static_m >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
-        and static_n >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
-        and static_k >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
-        and static_k <= max_cluster_m2_search_k
-        and static_m % TCGEN05_TWO_CTA_BLOCK_M != 0
-        and static_n % TCGEN05_TWO_CTA_BLOCK_N != 0
-        and static_k % max_search_k != 0
-    )
-    allow_fp8_small_grid_cluster_m2_search = (
-        not has_leading_passthrough
-        and plan.is_fp8
-        and allow_full_tile_persistent_pid_types
-        and max_search_m >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
-        and max_search_n >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
-        and static_k <= max_cluster_m2_search_k
-    )
+    if static_m is None or static_n is None or static_k is None:
+        allow_full_tile_persistent_pid_types = False
+        allow_small_n_persistent_pid_types = False
+        allow_full_tile_cluster_m2_search = False
+        allow_edge_cluster_m2_search = False
+        allow_fp8_small_grid_cluster_m2_search = False
+    else:
+        allow_full_tile_persistent_pid_types = (
+            static_m % max_search_m == 0
+            and static_n % max_search_n == 0
+            and static_k % max_search_k == 0
+        )
+        allow_small_n_persistent_pid_types = (
+            plan.is_small_n
+            and plan.small_n_supports_role_local_tma
+            and 0 < static_n < max_search_n
+            and static_m % max_search_m == 0
+            and static_k % max_search_k == 0
+        )
+        allow_full_tile_cluster_m2_search = (
+            allow_full_tile_persistent_pid_types
+            and max_search_m >= TCGEN05_TWO_CTA_BLOCK_M
+            and max_search_n >= TCGEN05_TWO_CTA_BLOCK_N
+            and static_k <= max_cluster_m2_search_k
+        )
+        allow_edge_cluster_m2_search = (
+            not has_leading_passthrough
+            and not allow_full_tile_persistent_pid_types
+            and plan.max_tcgen05_m >= TCGEN05_TWO_CTA_BLOCK_M
+            and plan.max_tcgen05_n >= TCGEN05_TWO_CTA_BLOCK_N
+            and static_m >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
+            and static_n >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
+            and static_k >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
+            and static_k <= max_cluster_m2_search_k
+            and static_m % TCGEN05_TWO_CTA_BLOCK_M != 0
+            and static_n % TCGEN05_TWO_CTA_BLOCK_N != 0
+            and static_k % max_search_k != 0
+        )
+        allow_fp8_small_grid_cluster_m2_search = (
+            not has_leading_passthrough
+            and plan.is_fp8
+            and allow_full_tile_persistent_pid_types
+            and max_search_m >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
+            and max_search_n >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
+            and static_k <= max_cluster_m2_search_k
+        )
     allow_cluster_m2_search = (
         allow_full_tile_cluster_m2_search
         or allow_edge_cluster_m2_search
         or allow_fp8_small_grid_cluster_m2_search
     )
     if allow_cluster_m2_search:
+        assert static_m is not None and static_n is not None and static_k is not None
         num_sms = _cuda_num_sms_or_zero(lhs.device)
         if num_sms > 0:
             if allow_fp8_small_grid_cluster_m2_search:

--- a/helion/language/tunable_ops.py
+++ b/helion/language/tunable_ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import TypeVar
 
 import torch
 from torch._inductor.codegen.simd import constant_repr
@@ -30,8 +31,11 @@ if TYPE_CHECKING:
 
 __all__ = [
     "register_block_size",
+    "register_heuristic_metadata",
     "register_tunable",
 ]
+
+_T = TypeVar("_T")
 
 
 @_decorators.api(is_device_only=False, cache_type=True, tiles_as_sizes=True)
@@ -188,6 +192,56 @@ def _register_tunable_codegen(state: CodegenState) -> ast.AST:
     config_value = state.config[name]
     assert isinstance(config_value, (int, float, bool))
     return expr_from_string(constant_repr(config_value))
+
+
+@_decorators.api(is_device_only=False)
+def register_heuristic_metadata(name: str, value: _T) -> _T:
+    """Attach a compile-time semantic value for compiler heuristics.
+
+    The operation is an identity at runtime. ``name`` and ``value`` must both
+    be literals while tracing; registering the same name twice is allowed only
+    when the values agree. Names are intentionally open-ended so out-of-tree
+    compiler heuristics can declare their own metadata contracts. Metadata with
+    no active consumer is retained but has no effect.
+    """
+    raise NotInsideKernel
+
+
+@_decorators.type_propagation(register_heuristic_metadata)
+def _register_heuristic_metadata_type(
+    name: TypeInfo,
+    value: TypeInfo,
+    *,
+    origin: Origin,
+) -> TypeInfo:
+    try:
+        name_value = name.as_literal()
+        metadata_value = value.as_literal()
+    except NotImplementedError as error:
+        raise exc.TypeInferenceError(
+            "hl.register_heuristic_metadata() requires literal name and value"
+        ) from error
+    if not isinstance(name_value, str) or not name_value:
+        raise exc.TypeInferenceError(
+            "hl.register_heuristic_metadata() requires a nonempty literal name"
+        )
+    metadata = CompileEnvironment.current().config_spec.compiler_heuristic_metadata
+    if name_value in metadata and metadata[name_value] != metadata_value:
+        raise exc.TypeInferenceError(
+            f"conflicting compiler heuristic metadata for {name_value!r}"
+        )
+    metadata[name_value] = metadata_value
+    return value
+
+
+@_decorators.codegen(register_heuristic_metadata, "common")
+def _register_heuristic_metadata_codegen(state: CodegenState) -> ast.AST:
+    return state.ast_arg(1)
+
+
+@_decorators.ref(register_heuristic_metadata)
+def _(name: str, value: _T) -> _T:
+    return value
 
 
 @_decorators.ref(register_tunable)

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -44,11 +44,15 @@ from torch.utils._pytree import tree_map_only
 from torch.utils.weak import WeakIdKeyDictionary
 
 from .. import exc
+from .._argument_device import _canonicalize_argument_device
+from .._argument_device import _current_device_index
 from .._compat import shape_env_size_hint
 from .._compat import target_device_capability
 from .._compile_time import measure
 from .._compiler.ast_extension import unparse
+from .._compiler.autotuner_heuristics import compiler_promotion_specialization_key
 from .._compiler.autotuner_heuristics import compiler_seed_configs
+from .._compiler.autotuner_heuristics import compiler_seed_specialization_facts
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.compile_environment import TensorDescriptorLayoutGuard
 from .._compiler.compile_environment import _is_supported_tensor_input_source
@@ -76,10 +80,12 @@ from .settings import Settings
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from collections.abc import Hashable
 
     from torch._guards import Source
 
+    from .._compiler.autotuner_heuristics.registry import (
+        CompilerHeuristicSpecializationFact,
+    )
     from .._compiler.host_function import HostFunction
     from ..autotuner import ConfigSpec
     from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
@@ -132,6 +138,106 @@ class _FastDispatchEntry(NamedTuple):
     key: tuple[Hashable, ...]
     extra_guards: tuple[tuple[Callable[[Sequence[object]], Hashable], Hashable], ...]
     specialization_generation: int
+
+
+_TensorMetadataPathStep = (
+    tuple[Literal["sequence"], type[object], int]
+    | tuple[Literal["mapping"], type[object], type[object], Hashable]
+    | tuple[Literal["dataclass"], type[object], str]
+)
+
+
+def _mapping_metadata_sort_key(key: object) -> tuple[str, str, str]:
+    key_type = type(key)
+    return key_type.__module__, key_type.__qualname__, repr(key)
+
+
+def _input_tensor_metadata(values: Sequence[object]) -> tuple[Hashable, ...]:
+    """Return exact tensor metadata keyed by deterministic structural roles."""
+    metadata: list[Hashable] = []
+
+    def collect(
+        value: object,
+        path: tuple[_TensorMetadataPathStep, ...],
+    ) -> None:
+        if isinstance(value, torch.Tensor):
+            metadata.append(
+                (
+                    path,
+                    _hashable_dims(value.size()),
+                    _hashable_dims(value.stride()),
+                )
+            )
+            return
+        if isinstance(value, ConstExpr):
+            return
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            container_type = type(value)
+            for field in dataclasses.fields(value):
+                collect(
+                    getattr(value, field.name),
+                    (*path, ("dataclass", container_type, field.name)),
+                )
+        elif isinstance(value, (tuple, list)):
+            container_type = type(value)
+            for index, item in enumerate(value):
+                collect(item, (*path, ("sequence", container_type, index)))
+        elif isinstance(value, dict):
+            container_type = type(value)
+            for key, item in sorted(
+                value.items(),
+                key=lambda entry: _mapping_metadata_sort_key(entry[0]),
+            ):
+                collect(
+                    item,
+                    (
+                        *path,
+                        (
+                            "mapping",
+                            container_type,
+                            type(key),
+                            cast("Hashable", key),
+                        ),
+                    ),
+                )
+
+    collect(values, ())
+    return tuple(metadata)
+
+
+@dataclasses.dataclass(frozen=True)
+class _CompilerSeedSpecializationExtractor:
+    fact: CompilerHeuristicSpecializationFact
+    reserved_sms: int
+
+    def for_device(self, device: torch.device) -> Hashable:
+        from . import get_num_sm
+
+        if self.fact == "device_num_sm":
+            return self.fact, get_num_sm(device)
+        assert self.fact == "config_num_sm"
+        return self.fact, get_num_sm(device, reserved_sms=self.reserved_sms)
+
+    def __call__(self, values: Sequence[object]) -> Hashable:
+        if self.fact == "input_tensor_metadata":
+            return self.fact, _input_tensor_metadata(values)
+
+        device = _canonicalize_argument_device(_find_device(tuple(values)))
+        return self.for_device(device)
+
+
+def _compiler_seed_specialization_extractors(
+    facts: frozenset[CompilerHeuristicSpecializationFact],
+    reserved_sms: int,
+    *,
+    static_shapes: bool,
+) -> tuple[_CompilerSeedSpecializationExtractor, ...]:
+    if static_shapes:
+        facts = frozenset(fact for fact in facts if fact != "input_tensor_metadata")
+    return tuple(
+        _CompilerSeedSpecializationExtractor(fact, reserved_sms)
+        for fact in sorted(facts)
+    )
 
 
 class _SpecializationAlias:
@@ -312,24 +418,6 @@ class _PreparedCall:
             return False
 
 
-def _current_device_index(device_type: str) -> int:
-    device_module = getattr(torch, device_type, None)
-    current_device = getattr(device_module, "current_device", None)
-    if callable(current_device):
-        return cast("int", current_device())
-
-    accelerator = getattr(torch, "accelerator", None)
-    current_accelerator = getattr(accelerator, "current_accelerator", None)
-    current_device_index = getattr(accelerator, "current_device_index", None)
-    if callable(current_accelerator) and callable(current_device_index):
-        accelerator_device = cast("torch.device", current_accelerator())
-        if accelerator_device.type == device_type:
-            return cast("int", current_device_index())
-    raise exc.InvalidAPIUsage(
-        f"autotune_multi requires a current indexed accelerator, got {device_type!r}"
-    )
-
-
 def _canonicalize_multi_shape_device(device: torch.device) -> torch.device:
     if device.type in ("cpu", "meta", "mps"):
         raise exc.InvalidAPIUsage(
@@ -337,7 +425,14 @@ def _canonicalize_multi_shape_device(device: torch.device) -> torch.device:
         )
     if device.index is not None:
         return device
-    return torch.device(device.type, _current_device_index(device.type))
+    try:
+        index = _current_device_index(device.type)
+    except exc.InvalidAPIUsage as error:
+        raise exc.InvalidAPIUsage(
+            "autotune_multi requires a current indexed accelerator, "
+            f"got {device.type!r}"
+        ) from error
+    return torch.device(device.type, index)
 
 
 def _has_unspecialized_numeric_value(value: object) -> bool:
@@ -391,19 +486,33 @@ def _resolve_index_dtype(
 
 def _device_specialization_key(
     args: Sequence[object],
-) -> tuple[str | None, tuple[int, int] | None]:
+    *,
+    backend: str,
+    compiler_heuristics_enabled: bool,
+) -> tuple[
+    str | None,
+    tuple[int, int] | None,
+    tuple[tuple[str, str | None], ...],
+]:
     """Return the recursive argument device key used by bound-kernel caching.
 
     `_find_device` intentionally searches tensors and bare `torch.device`
     objects inside supported containers to match binding device selection.
-    Capability splits mixed-sm cache entries. Device index remains excluded so
-    same-capability devices share bound kernels, matching prior behavior.
+    Capability splits mixed-sm cache entries. Exact hardware identity is added
+    only when an active compiler heuristic uses it to gate default promotion.
+    Device index remains excluded so otherwise-compatible devices share bound
+    kernels, matching prior behavior.
     """
     try:
-        device = _find_device(tuple(args))
+        device = _canonicalize_argument_device(_find_device(tuple(args)))
     except exc.NoTensorArgs:
-        return None, None
-    return device.type, target_device_capability(device)
+        return None, None, ()
+    promotion_key = (
+        compiler_promotion_specialization_key(backend, device)
+        if compiler_heuristics_enabled
+        else ()
+    )
+    return device.type, target_device_capability(device), promotion_key
 
 
 @dataclasses.dataclass
@@ -474,6 +583,9 @@ class Kernel(Generic[_R]):
         self._prepared_call: _PreparedCall | None = None
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
+        ] = {}
+        self._compiler_seed_specialize_extra: dict[
+            Hashable, tuple[_CompilerSeedSpecializationExtractor, ...]
         ] = {}
         self._specialization_aliases: dict[
             tuple[Hashable, ...], _SpecializationAlias
@@ -547,7 +659,14 @@ class Kernel(Generic[_R]):
         extra_results = self._stable_specialization_extra_results(args, signature)
         if extra_results is None:
             return None
-        return BoundKernelInMemoryCacheKey(signature, extra_results)
+        compiler_seed_results = self._stable_compiler_seed_results(args, signature)
+        if compiler_seed_results is None:
+            return None
+        return BoundKernelInMemoryCacheKey(
+            signature,
+            extra_results,
+            compiler_seed_results=compiler_seed_results,
+        )
 
     def _stable_specialization_extra_results(
         self,
@@ -570,6 +689,28 @@ class Kernel(Generic[_R]):
                 ):
                     return extra_results
 
+    def _stable_compiler_seed_results(
+        self,
+        args: Sequence[object],
+        signature: tuple[Hashable, ...],
+    ) -> tuple[Hashable, ...] | None:
+        while True:
+            with self._specialize_extra_lock:
+                extractors = self._compiler_seed_specialize_extra.get(signature)
+                generation = self._specialization_generation
+            results = (
+                None
+                if extractors is None
+                else tuple(extractor(args) for extractor in extractors)
+            )
+            with self._specialize_extra_lock:
+                if (
+                    self._specialization_generation == generation
+                    and self._compiler_seed_specialize_extra.get(signature)
+                    is extractors
+                ):
+                    return results
+
     def _create_bound_kernel_cache_key(
         self,
         bound_kernel: BoundKernel,
@@ -582,9 +723,15 @@ class Kernel(Generic[_R]):
 
         if extra_fns is None:
             extra_fns = bound_kernel._specialize_extra()
+        compiler_seed_fns = bound_kernel._compiler_seed_specialization_extractors
         if not bound_kernel._cache_managed:
             extra_results = tuple(s(args) for s in extra_fns)
-            return BoundKernelInMemoryCacheKey(signature, extra_results)
+            compiler_seed_results = tuple(s(args) for s in compiler_seed_fns)
+            return BoundKernelInMemoryCacheKey(
+                signature,
+                extra_results,
+                compiler_seed_results=compiler_seed_results,
+            )
 
         # Autotune cache keys can be generated outside eager binding, so
         # schema synchronization must not wait for the eager bind lock or hold
@@ -593,11 +740,15 @@ class Kernel(Generic[_R]):
             with self._specialize_extra_lock:
                 if bound_kernel._reset_generation != self._reset_generation:
                     active_extra_fns = extra_fns
+                    active_compiler_seed_fns = compiler_seed_fns
                     generation = None
                 else:
                     published_extra_fns = self._specialize_extra.get(signature)
                     if published_extra_fns is None:
                         self._specialize_extra[signature] = extra_fns
+                        self._compiler_seed_specialize_extra[signature] = (
+                            compiler_seed_fns
+                        )
                         if extra_fns:
                             self._has_specialization_extras = True
                     else:
@@ -605,10 +756,23 @@ class Kernel(Generic[_R]):
                         # bound is constructed. The published list is the
                         # authoritative schema.
                         extra_fns = published_extra_fns
+                    active_compiler_seed_fns = self._compiler_seed_specialize_extra.get(
+                        signature
+                    )
+                    if active_compiler_seed_fns is None:
+                        active_compiler_seed_fns = compiler_seed_fns
+                        self._compiler_seed_specialize_extra[signature] = (
+                            active_compiler_seed_fns
+                        )
                     generation = self._specialization_generation
                     active_extra_fns = extra_fns
             extra_results = tuple(s(args) for s in active_extra_fns)
-            cache_key = BoundKernelInMemoryCacheKey(signature, extra_results)
+            compiler_seed_results = tuple(s(args) for s in active_compiler_seed_fns)
+            cache_key = BoundKernelInMemoryCacheKey(
+                signature,
+                extra_results,
+                compiler_seed_results=compiler_seed_results,
+            )
             if generation is None:
                 return cache_key
             with self._specialize_extra_lock:
@@ -617,6 +781,8 @@ class Kernel(Generic[_R]):
                 if (
                     self._specialization_generation == generation
                     and self._specialize_extra.get(signature) is active_extra_fns
+                    and self._compiler_seed_specialize_extra.get(signature)
+                    is active_compiler_seed_fns
                 ):
                     return cache_key
 
@@ -648,12 +814,21 @@ class Kernel(Generic[_R]):
                     *self._specialize_extra.get(signature, []),
                     *extractors,
                 ]
+                compiler_seed_fns = self._compiler_seed_specialize_extra.get(
+                    signature,
+                    (),
+                )
                 with unset_fake_temporarily():
                     current_results = tuple(
                         extractor(full_args) for extractor in updated_extractors
                     )
+                    current_compiler_seed_results = tuple(
+                        extractor(full_args) for extractor in compiler_seed_fns
+                    )
                     updated_cache_key = BoundKernelInMemoryCacheKey(
-                        signature, current_results
+                        signature,
+                        current_results,
+                        compiler_seed_results=current_compiler_seed_results,
                     )
                     hash(updated_cache_key)
                     for alias_signature, alias in aliases.items():
@@ -667,10 +842,15 @@ class Kernel(Generic[_R]):
                             extractor(alias_normalized_args)
                             for extractor in updated_extractors
                         )
+                        alias_compiler_seed_results = tuple(
+                            extractor(alias_normalized_args)
+                            for extractor in compiler_seed_fns
+                        )
                         hash(
                             BoundKernelInMemoryCacheKey(
                                 alias_signature,
                                 (alias_results,),
+                                compiler_seed_results=alias_compiler_seed_results,
                             )
                         )
 
@@ -681,6 +861,9 @@ class Kernel(Generic[_R]):
                 self._specialize_extra[signature] = updated_extractors
                 for alias_signature, alias in aliases.items():
                     self._specialize_extra[alias_signature] = [alias]
+                    self._compiler_seed_specialize_extra[alias_signature] = (
+                        compiler_seed_fns
+                    )
                 self._specialization_generation += 1
 
             affected_signatures = {signature, *aliases}
@@ -1001,7 +1184,16 @@ class Kernel(Generic[_R]):
                 result.append(value)
             else:
                 result.append(self._specialization_key(value))
-        device_type, device_capability = _device_specialization_key(args)
+        device_type, device_capability, promotion_hardware_key = (
+            _device_specialization_key(
+                args,
+                backend=self.settings.backend,
+                compiler_heuristics_enabled=(
+                    not self.settings.disable_autotuner_heuristics
+                ),
+            )
+        )
+        promotion_key = (promotion_hardware_key,) if promotion_hardware_key else ()
         if is_distributed is None:
             is_distributed = self._compute_is_distributed(args)
         if self._key_fn is not None:
@@ -1011,10 +1203,17 @@ class Kernel(Generic[_R]):
                 *result,
                 device_type,
                 device_capability,
+                *promotion_key,
                 is_distributed,
                 cast("Hashable", custom_key),
             )
-        return (*result, device_type, device_capability, is_distributed)
+        return (
+            *result,
+            device_type,
+            device_capability,
+            *promotion_key,
+            is_distributed,
+        )
 
     def specialization_key(self, args: Sequence[object]) -> tuple[Hashable, ...]:
         """
@@ -1033,7 +1232,13 @@ class Kernel(Generic[_R]):
         """
         base = self._base_specialization_key(args)
         extra_results = self._stable_specialization_extra_results(args, base)
-        return base if extra_results is None else (*base, *extra_results)
+        compiler_seed_results = self._stable_compiler_seed_results(args, base)
+        compiler_seed_key = (
+            ()
+            if compiler_seed_results is None or not compiler_seed_results
+            else (("compiler_seed_results", compiler_seed_results),)
+        )
+        return (*base, *compiler_seed_key, *(extra_results or ()))
 
     def _specialization_key(self, obj: object) -> Hashable:
         """
@@ -1329,7 +1534,11 @@ class Kernel(Generic[_R]):
                 relative_to,
                 cache_tag,
                 tuple(
-                    (case_key.specialization_key, case_key.extra_results)
+                    (
+                        case_key.specialization_key,
+                        case_key.extra_results,
+                        case_key.compiler_seed_results,
+                    )
                     for case_key in case_keys
                 ),
             ),
@@ -1514,6 +1723,7 @@ class Kernel(Generic[_R]):
                 # Replace rather than clear: in-flight omitted-default aliases
                 # retain the old schema mapping while new work starts fresh.
                 self._specialize_extra = {}
+                self._compiler_seed_specialize_extra = {}
                 self._specialization_aliases = {}
                 self._cute_grouped_static_tail_extra_descriptors = {}
                 self._has_specialization_extras = False
@@ -1589,6 +1799,17 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         )
         self._run: Callable[..., _R] | None = None
         self._config: Config | None = None
+        self._compiler_seed_specialization_extractors: tuple[
+            _CompilerSeedSpecializationExtractor, ...
+        ] = ()
+        self._compiler_seed_specialization_results: tuple[Hashable, ...] = ()
+        # Direct BoundKernel calls bypass Kernel's dispatch cache. Cache the
+        # immutable SM-derived facts per device so changing devices rebinds
+        # without querying device properties on every subsequent launch.
+        self._compiler_seed_device_results: dict[
+            torch.device,
+            tuple[Hashable | None, ...],
+        ] = {}
         self._compile_cache: dict[Config, CompiledConfig] = {}
         self._cache_path_map: dict[Config, str | None] = {}
         self._host_semantic_fingerprints: dict[
@@ -1610,7 +1831,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         # symmetric-memory call from ever aliasing a non-distributed compiled
         # kernel of the same shape. See GitHub issue #3024.
         self._env = CompileEnvironment(
-            _find_device(args),
+            _canonicalize_argument_device(_find_device(args)),
             self.kernel.settings,
             index_dtype=_resolve_index_dtype(self.kernel.settings, args),
             is_distributed=is_distributed,
@@ -1675,6 +1896,33 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     self.env,
                     self.host_function.device_ir,
                 )
+                self._compiler_seed_specialization_extractors = (
+                    _compiler_seed_specialization_extractors(
+                        compiler_seed_specialization_facts(
+                            self.env.backend_name,
+                            self.config_spec.autotuner_heuristics,
+                        )
+                        | self.env.compiler_fact_specialization_facts,
+                        self.settings.persistent_reserved_sms,
+                        static_shapes=self.settings.static_shapes,
+                    )
+                )
+                self._compiler_seed_specialization_results = tuple(
+                    extractor(args)
+                    for extractor in self._compiler_seed_specialization_extractors
+                )
+                if any(
+                    extractor.fact != "input_tensor_metadata"
+                    for extractor in self._compiler_seed_specialization_extractors
+                ):
+                    self._compiler_seed_device_results[self.env.device] = tuple(
+                        (None if extractor.fact == "input_tensor_metadata" else result)
+                        for extractor, result in zip(
+                            self._compiler_seed_specialization_extractors,
+                            self._compiler_seed_specialization_results,
+                            strict=True,
+                        )
+                    )
 
                 # Post-compile FX-graph scan to detect kernels
                 # whose tcgen05 matmul is followed by an
@@ -1776,10 +2024,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         return Config(**config)
 
     def _normalized_config_copy(self, config: ConfigLike) -> Config:
-        normalized = self._normalize_config(config)
-        normalized = Config(**normalized.config)  # pyrefly: ignore[bad-argument-type]
-        self.env.config_spec.normalize(normalized)
-        return normalized
+        return self.env.config_spec.normalized_config(self._normalize_config(config))
 
     def format_kernel_decorator(self, config: Config, settings: Settings) -> str:
         """Return the @helion.kernel decorator snippet capturing configs and settings that influence Triton code generation."""
@@ -2502,6 +2747,41 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         Returns:
             _R: The result of the kernel execution.
         """
+        if self._cache_managed and self._compiler_seed_specialization_extractors:
+            device_results: tuple[Hashable | None, ...] | None = None
+            new_compiler_seed_device = False
+            if self._compiler_seed_device_results:
+                device = _canonicalize_argument_device(_find_device(args))
+                device_results = self._compiler_seed_device_results.get(device)
+                if device_results is None:
+                    new_compiler_seed_device = True
+                    device_results = tuple(
+                        (
+                            None
+                            if extractor.fact == "input_tensor_metadata"
+                            else extractor.for_device(device)
+                        )
+                        for extractor in self._compiler_seed_specialization_extractors
+                    )
+                    self._compiler_seed_device_results[device] = device_results
+            compiler_seed_results = tuple(
+                (
+                    extractor(args)
+                    if extractor.fact == "input_tensor_metadata"
+                    else cast("tuple[Hashable | None, ...]", device_results)[index]
+                )
+                for index, extractor in enumerate(
+                    self._compiler_seed_specialization_extractors
+                )
+            )
+            if (
+                new_compiler_seed_device
+                or compiler_seed_results != self._compiler_seed_specialization_results
+            ):
+                rebound = self.kernel.bind(args)
+                if rebound is not self:
+                    return rebound(*args)
+
         if self._cache_managed and self.kernel._has_specialization_extras:
             rebound = self.kernel.bind(args)
             if rebound is not self:

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -762,8 +762,9 @@ class Settings(_Settings):
             "without constraining the search space."
         ),
         "disable_autotuner_heuristics": (
-            "If True, disable compiler/autotuner heuristics such as compiler seed "
-            "configs. User-provided autotune_seed_configs are unaffected. "
+            "If True, disable compiler seed generation and promotion. Correctness "
+            "fact hooks still run so explicit configs normalize safely. User-provided "
+            "autotune_seed_configs are unaffected. "
             "Set HELION_DISABLE_AUTOTUNER_HEURISTICS=1 to disable globally."
         ),
         "allow_warp_specialize": "If True, allow warp specialization for tl.range calls on CUDA devices.",

--- a/pretuned_kernels/grouped_gemm_deepgemm/grouped_gemm_deepgemm.py
+++ b/pretuned_kernels/grouped_gemm_deepgemm/grouped_gemm_deepgemm.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 
     from helion.runtime.kernel import BoundKernel
     from helion.runtime.kernel import CompiledConfig
+    from helion.runtime.kernel import Kernel
 
 
 OFFICIAL_SHAPES: tuple[OfficialShape, ...] = _HARNESS.OFFICIAL_SHAPES
@@ -159,16 +160,6 @@ def _deepgemm_aot_autotuner(
     return AOTAutotuneCache(make_search(), autotuner_factory=make_search)
 
 
-@helion.aot_kernel(
-    backend="cute",
-    key=_selected_key,
-    static_shapes=False,
-    autotuner_fn=_deepgemm_aot_autotuner,
-    autotune_precompile=None,
-    autotune_baseline_fn=_reference,
-    autotune_baseline_atol=3e-2,
-    autotune_baseline_rtol=3e-2,
-)
 def grouped_gemm_deepgemm(
     a_packed: torch.Tensor,
     b_grouped: torch.Tensor,
@@ -222,6 +213,30 @@ def grouped_gemm_deepgemm(
             extra_mask=store_rows[:, None],  # pyrefly: ignore[bad-index]
         )
     return out
+
+
+_GROUPED_GEMM_DEEPGEMM_BODY = grouped_gemm_deepgemm
+
+
+def create_grouped_gemm_deepgemm_kernel() -> Kernel[torch.Tensor]:
+    """Create an independent grouped-GEMM kernel and binding cache."""
+    return helion.aot_kernel(
+        _GROUPED_GEMM_DEEPGEMM_BODY,
+        backend="cute",
+        key=_selected_key,
+        static_shapes=False,
+        autotuner_fn=_deepgemm_aot_autotuner,
+        autotune_precompile=None,
+        autotune_baseline_fn=_reference,
+        autotune_baseline_atol=3e-2,
+        autotune_baseline_rtol=3e-2,
+    )
+
+
+grouped_gemm_deepgemm = cast(
+    "Kernel[torch.Tensor]",
+    create_grouped_gemm_deepgemm_kernel(),
+)
 
 
 @dataclass

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -262,6 +262,41 @@ class TestAutotuneIgnoreErrors(TestCase):
             search._prepare()
         return search
 
+    def _make_compile_failure_search(self) -> BaseSearch:
+        search = self._make_search(
+            Settings(
+                autotune_precompile=None,
+                autotune_log_level=logging.CRITICAL,
+            )
+        )
+        search.kernel.env = SimpleNamespace(process_group_name=None)
+        search.kernel.compile_config = None
+        return search
+
+    def _run_late_compile_failures(
+        self,
+        late_configs: Sequence[str],
+        error_for: Callable[[str], Exception],
+    ) -> tuple[list[object], list[object]]:
+        search = self._make_compile_failure_search()
+
+        def compile_config(config: str, **_kwargs: object) -> Callable[..., None]:
+            if config == "valid":
+                return lambda *args, **kwargs: None
+            raise error_for(config)
+
+        with (
+            patch.object(search.kernel, "compile_config", side_effect=compile_config),
+            patch.object(
+                search.benchmark_provider,
+                "_benchmark_function",
+                return_value=1.0,
+            ),
+        ):
+            initial = search.benchmark_batch(["valid"], desc="initial")
+            late = search.benchmark_batch(list(late_configs), desc="late")
+        return initial, late
+
     def test_settings_flag_from_env(self):
         with patch.dict(
             os.environ, {"HELION_AUTOTUNE_IGNORE_ERRORS": "1"}, clear=False
@@ -560,6 +595,57 @@ class TestAutotuneIgnoreErrors(TestCase):
         self.assertEqual(results[1].perf, float("inf"))
         self.assertEqual(results[1].status, "error")
         self.assertEqual(results[2].perf, 1.0)
+
+    def test_initial_compile_failures_raise(self) -> None:
+        cases: tuple[tuple[str, type[Exception], str, Exception], ...] = (
+            (
+                "invalid",
+                exc.InvalidConfig,
+                "invalid initial config",
+                exc.InvalidConfig("invalid initial config"),
+            ),
+            (
+                "runtime",
+                RuntimeError,
+                "initial compiler failure",
+                RuntimeError("initial compiler failure"),
+            ),
+        )
+        for config, error_type, message, error in cases:
+            with self.subTest(config=config):
+                search = self._make_compile_failure_search()
+                with (
+                    patch.object(
+                        search.kernel,
+                        "compile_config",
+                        side_effect=error,
+                    ),
+                    self.assertRaisesRegex(error_type, message),
+                ):
+                    search.benchmark_batch([config], desc="initial")
+
+    def test_late_compile_failures_are_skipped(self) -> None:
+        cases = (
+            (
+                "invalid",
+                lambda config: exc.InvalidConfig(f"invalid late neighbor: {config}"),
+            ),
+            ("runtime", lambda config: RuntimeError("late compiler failure")),
+            (
+                "unsupported",
+                lambda config: exc.BackendUnsupported(
+                    "cute", f"unsupported late neighbor {config}"
+                ),
+            ),
+        )
+        for prefix, error_for in cases:
+            with self.subTest(prefix=prefix):
+                initial, late = self._run_late_compile_failures(
+                    (f"{prefix}_a", f"{prefix}_b"), error_for
+                )
+                self.assertEqual(initial[0].perf, 1.0)
+                self.assertEqual([result.perf for result in late], [float("inf")] * 2)
+                self.assertEqual([result.status for result in late], ["error"] * 2)
 
     def test_autotune_log_sink_writes_csv_and_log(self):
         tmpdir = tempfile.TemporaryDirectory()
@@ -5736,6 +5822,37 @@ class TestAutotuneBestOfK(RefEagerTestDisabled, TestCase):
             best_of_k=5,
         )
         self.assertNotEqual(k1_aliased.stable_hash(), k5.stable_hash())
+
+    def test_strict_cache_key_tracks_nondefault_best_of_k(self) -> None:
+        from helion.autotuner.base_cache import StrictAutotuneCacheKey
+
+        common_kwargs = {
+            "specialization_key": (),
+            "extra_results": (),
+            "kernel_source_hash": "abc",
+            "hardware": "B200",
+            "runtime_name": "12.6",
+            "backend": "triton",
+            "config_spec_hash": "h1",
+            "extra_cache_key": "",
+            "helion_key": "helion",
+            "torch_key": "torch",
+            "triton_key": "triton",
+        }
+        k1 = StrictAutotuneCacheKey(**common_kwargs, best_of_k=1)
+        k5 = StrictAutotuneCacheKey(**common_kwargs, best_of_k=5)
+        expected_k1_repr = (
+            "StrictAutotuneCacheKey("
+            "specialization_key=(), extra_results=(), "
+            "kernel_source_hash='abc', hardware='B200', "
+            "runtime_name='12.6', backend='triton', "
+            "config_spec_hash='h1', extra_cache_key='', "
+            "helion_key='helion', torch_key='torch', triton_key='triton')"
+        )
+
+        self.assertEqual(repr(k1), expected_k1_repr)
+        self.assertIn("best_of_k=5", repr(k5))
+        self.assertNotEqual(k1.stable_hash(), k5.stable_hash())
 
     def test_best_of_k_gt_1_without_factory_raises(self) -> None:
         """The bare ``Cache(autotuner)`` constructor must reject K>1 at

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import dataclasses
 import math
 import os
+from typing import Any
+from typing import Callable
 from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -10,14 +12,31 @@ from unittest.mock import patch
 import torch
 
 import helion
+import helion._argument_device as argument_device_module
+from helion._compiler.autotuner_heuristics import compiler_promotion_specialization_key
 from helion._compiler.autotuner_heuristics import compiler_seed_configs
+from helion._compiler.autotuner_heuristics import compiler_seed_specialization_facts
 from helion._compiler.autotuner_heuristics.cute import (
     CuteFlashAttentionCausalLptHeuristic,
 )
 from helion._compiler.autotuner_heuristics.cute import CuteFlashAttentionHeuristic
 from helion._compiler.autotuner_heuristics.cute import CuteFp8GemmSkinnyMHeuristic
 from helion._compiler.autotuner_heuristics.cute import CuteTcgen05ClusterM2Heuristic
+from helion._compiler.autotuner_heuristics.cute import (
+    CuteTcgen05GroupedWorklistHeuristic,
+)
+from helion._compiler.autotuner_heuristics.cute import (
+    _filter_reachable_block_size_configs,
+)
+from helion._compiler.autotuner_heuristics.cute import _tcgen05_grouped_fact
+from helion._compiler.autotuner_heuristics.cute import _tcgen05_grouped_worklist_fact
+from helion._compiler.autotuner_heuristics.cute import (
+    tcgen05_grouped_worklist_seed_configs,
+)
 from helion._compiler.autotuner_heuristics.registry import AutotunerHeuristic
+from helion._compiler.autotuner_heuristics.registry import (
+    CompilerHeuristicSpecializationFact,
+)
 from helion._compiler.autotuner_heuristics.triton import TritonH100MatmulHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonNarrowReductionHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonPointwiseSeedHeuristic
@@ -30,6 +49,9 @@ from helion._compiler.autotuner_heuristics.triton import (
 )
 from helion._compiler.autotuner_heuristics.triton import (
     TritonUserTiledReductionHeuristicSM90,
+)
+from helion._compiler.autotuner_heuristics.triton import (
+    TritonUserTiledReductionHeuristicSM100,
 )
 from helion._compiler.autotuner_heuristics.triton import _h100_matmul_tile
 from helion._compiler.backend import CuteBackend
@@ -98,11 +120,13 @@ from helion._compiler.cute.flash_policy import get_flash_target_policy
 from helion._compiler.cute.flash_tuning import FlashCausalTuningPolicy
 from helion._compiler.cute.flash_tuning import FlashDenseTuningPolicy
 from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
+from helion._compiler.cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY
 from helion._compiler.cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
+from helion._compiler.cute.strategies import TCGEN05_STRATEGY_CONFIG_KEY
 from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY
 from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
 from helion._compiler.cute.strategies import Tcgen05LayoutStrategy
@@ -119,13 +143,34 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._compiler.cute.tcgen05_constants import TCGEN05_AUX_LOAD_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_AUX_LOAD_MODE_TMA
 from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY,
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_C_ACQUIRE_PLACEMENT_FIRST_IN_LOOP,
 )
+from helion._compiler.cute.tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
 )
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
@@ -187,6 +232,9 @@ from helion._testing import patch_cute_mma_support
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 from helion.autotuner import IntegerFragment
+from helion.autotuner.base_cache import BoundKernelInMemoryCacheKey
+from helion.autotuner.base_cache import LooseAutotuneCacheKey
+from helion.autotuner.base_cache import StrictAutotuneCacheKey
 from helion.autotuner.config_fragment import EnumFragment
 from helion.autotuner.config_generation import ConfigGeneration
 from helion.autotuner.config_spec import BlockSizeSpec
@@ -201,6 +249,7 @@ from helion.autotuner.effort_profile import get_effort_profile
 from helion.autotuner.pattern_search import InitialPopulationStrategy
 from helion.autotuner.pattern_search import PatternSearch
 import helion.language as hl
+from helion.runtime.kernel import _input_tensor_metadata
 from helion.runtime.settings import Settings
 
 HOPPER_HARDWARE = HardwareInfo(
@@ -221,6 +270,12 @@ BLACKWELL_HARDWARE = HardwareInfo(
     runtime_version="12.8",
     compute_capability="sm100",
 )
+GB300_HARDWARE = HardwareInfo(
+    device_kind="cuda",
+    hardware_name="NVIDIA GB300",
+    runtime_version="12.8",
+    compute_capability="sm100",
+)
 A100_HARDWARE = HardwareInfo(
     device_kind="cuda",
     hardware_name="NVIDIA A100",
@@ -229,7 +284,97 @@ A100_HARDWARE = HardwareInfo(
 )
 
 
+def _grouped_worklist_metadata_kernel(
+    a_packed: torch.Tensor,
+    b_grouped: torch.Tensor,
+    worklist: torch.Tensor,
+    source_m_tile: hl.constexpr,
+) -> torch.Tensor:
+    """Grouped test kernel with an explicit source-packing contract."""
+    source_m_tile = hl.register_heuristic_metadata(
+        "tcgen05_grouped_worklist_source_m_tile",
+        source_m_tile,
+    )
+    m_total, k = a_packed.shape
+    _groups, n, k2 = b_grouped.shape
+    assert k == k2
+    assert source_m_tile in (32, 224, 256)
+    block_m = hl.register_block_size(256)
+    block_n = hl.register_block_size(128)
+    block_k = hl.register_block_size(64, 128)
+    out = torch.empty([m_total, n], dtype=a_packed.dtype, device=a_packed.device)
+    for work_tile, tile_m, tile_n in hl.tile(
+        [worklist.size(0), 256, n],
+        block_size=[1, block_m, block_n],
+    ):
+        work_id = work_tile.begin
+        group_id = worklist[work_id, 0]
+        start = worklist[work_id, 1]
+        valid_m = worklist[work_id, 2]
+        store_m = worklist[work_id, 3]
+        local_m = tile_m.index
+        row = start + local_m
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k, block_size=block_k):
+            a_block = hl.load(
+                a_packed,
+                [row, tile_k],
+                extra_mask=(local_m < valid_m)[:, None],  # pyrefly: ignore[bad-index]
+            )
+            acc = torch.addmm(
+                acc,
+                a_block,
+                b_grouped[group_id, tile_n, tile_k].T,
+            )
+        hl.store(
+            out,
+            [row, tile_n],
+            acc.to(out.dtype),
+            extra_mask=(local_m < store_m)[:, None],  # pyrefly: ignore[bad-index]
+        )
+    return out
+
+
 class TestAutotunerHeuristic(TestCase):
+    @staticmethod
+    def _heuristic(name: str, **attributes: object) -> type[AutotunerHeuristic]:
+        return type(
+            f"_{name.title().replace('_', '')}",
+            (AutotunerHeuristic,),
+            {"name": name, "backend": "triton", **attributes},
+        )
+
+    @staticmethod
+    def _grouped_worklist_seed_families() -> dict[str, list[helion.Config]]:
+        def seeds(
+            groups: int, n: int, k: int, b_major: str, source_m_tile: int
+        ) -> list[helion.Config]:
+            return tcgen05_grouped_worklist_seed_configs(
+                groups=groups,
+                packed_m=groups * (32 if source_m_tile == 32 else 4096),
+                n=n,
+                k=k,
+                b_major=b_major,
+                source_m_tile=source_m_tile,
+                num_sm=148,
+            )
+
+        return {
+            "small_k": seeds(6, 4096, 4096, "k", 32),
+            "small_n": seeds(6, 4096, 4096, "n", 32),
+            "source224": tcgen05_grouped_worklist_seed_configs(
+                groups=6,
+                packed_m=6 * 224,
+                n=7168,
+                k=3072,
+                b_major="k",
+                source_m_tile=224,
+                num_sm=148,
+            ),
+            "source256_k": seeds(8, 4096, 2048, "k", 256),
+            "source256_n": seeds(8, 4096, 2048, "n", 256),
+        }
+
     def test_disable_autotuner_heuristics_setting_env(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HELION_DISABLE_AUTOTUNER_HEURISTICS", None)
@@ -333,6 +478,82 @@ class TestAutotunerHeuristic(TestCase):
         self.assertEqual(configs, [])
         self.assertEqual(env.config_spec.autotuner_heuristics, [])
 
+    def test_compiler_fact_hook_runs_once_before_disabled_return(self) -> None:
+        fact_calls: list[tuple[object, object]] = []
+
+        class FactOwningHeuristic(AutotunerHeuristic):
+            name = "fact_owning_heuristic"
+            backend = "synthetic"
+
+            @classmethod
+            def register_facts(
+                cls, env: object, device_ir: object
+            ) -> frozenset[CompilerHeuristicSpecializationFact]:
+                fact_calls.append((env, device_ir))
+                return frozenset({"input_tensor_metadata"})
+
+            @classmethod
+            def is_eligible(cls, env: object, device_ir: object) -> bool:
+                raise AssertionError("disabled heuristics should not be queried")
+
+        class PassiveHeuristic(AutotunerHeuristic):
+            name = "passive_heuristic"
+            backend = "synthetic"
+
+            @classmethod
+            def is_eligible(cls, env: object, device_ir: object) -> bool:
+                raise AssertionError("disabled heuristics should not be queried")
+
+        env = MagicMock()
+        env.backend_name = "synthetic"
+        env.config_spec = MagicMock()
+        env.settings = Settings(disable_autotuner_heuristics=True)
+        device_ir = MagicMock()
+
+        with patch(
+            "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+            {"synthetic": (FactOwningHeuristic, PassiveHeuristic)},
+        ):
+            self.assertEqual(compiler_seed_configs(env, device_ir), [])
+
+        self.assertEqual(fact_calls, [(env, device_ir)])
+        self.assertEqual(
+            env.compiler_fact_specialization_facts,
+            frozenset({"input_tensor_metadata"}),
+        )
+
+    def test_compiler_fact_hook_failure_propagates(self) -> None:
+        class FailingFactHeuristic(AutotunerHeuristic):
+            name = "failing_fact_heuristic"
+            backend = "synthetic"
+
+            @classmethod
+            def register_facts(
+                cls, env: object, device_ir: object
+            ) -> frozenset[CompilerHeuristicSpecializationFact]:
+                raise RuntimeError("synthetic correctness-fact failure")
+
+            @classmethod
+            def is_eligible(cls, env: object, device_ir: object) -> bool:
+                raise AssertionError("fact registration must fail first")
+
+        env = MagicMock()
+        env.backend_name = "synthetic"
+        env.config_spec = MagicMock()
+        env.settings = Settings(disable_autotuner_heuristics=True)
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"synthetic": (FailingFactHeuristic,)},
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "synthetic correctness-fact failure",
+            ),
+        ):
+            compiler_seed_configs(env, MagicMock())
+
     def test_cute_flash_disable_heuristics_keeps_value_priors(self) -> None:
         spec = ConfigSpec(backend=CuteBackend())
         self.assertIsNone(spec.compiler_seed_timeout_retry_repetitions)
@@ -422,40 +643,111 @@ class TestAutotunerHeuristic(TestCase):
         self.assertEqual(flat_default.config["num_warps"], 8)
         self.assertEqual(flat_default.config["num_stages"], 2)
 
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler heuristic metadata is not collected in ref eager mode")
+    def test_register_heuristic_metadata_is_literal_identity(self) -> None:
+        @helion.kernel(backend="triton")
+        def metadata_kernel(
+            x: torch.Tensor,
+            semantic_value: hl.constexpr,
+            label: hl.constexpr,
+            enabled: hl.constexpr,
+            threshold: hl.constexpr,
+        ) -> torch.Tensor:
+            value = hl.register_heuristic_metadata(
+                "test.semantic_value", semantic_value
+            )
+            hl.register_heuristic_metadata("test.semantic_value", value)
+            hl.register_heuristic_metadata("test.label", label)
+            hl.register_heuristic_metadata("test.enabled", enabled)
+            hl.register_heuristic_metadata("test.threshold", threshold)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.shape):
+                out[tile] = x[tile] + value  # pyrefly: ignore[unsupported-operation]
+            return out
+
+        bound = metadata_kernel.bind(
+            (
+                torch.empty([8], device=DEVICE, dtype=torch.float32),
+                7,
+                "layout-aware",
+                True,
+                float("-inf"),
+            )
+        )
+
+        self.assertEqual(
+            bound.config_spec.compiler_heuristic_metadata,
+            {
+                "test.semantic_value": 7,
+                "test.label": "layout-aware",
+                "test.enabled": True,
+                "test.threshold": float("-inf"),
+            },
+        )
+        bound.to_triton_code(bound.config_spec.default_config())
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler heuristic metadata is not collected in ref eager mode")
+    def test_register_heuristic_metadata_rejects_conflicting_duplicate(self) -> None:
+        @helion.kernel(backend="triton")
+        def conflicting_metadata(
+            x: torch.Tensor,
+            first: hl.constexpr,
+            second: hl.constexpr,
+        ) -> torch.Tensor:
+            hl.register_heuristic_metadata("test.semantic_value", first)
+            hl.register_heuristic_metadata("test.semantic_value", second)
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.shape):
+                out[tile] = x[tile]
+            return out
+
+        with self.assertRaisesRegex(
+            Exception,
+            "conflicting compiler heuristic metadata",
+        ):
+            conflicting_metadata.bind(
+                (torch.empty([8], device=DEVICE, dtype=torch.float32), 7, 8)
+            )
+
     def test_should_promote_gate(self) -> None:
         # should_promote() gates a seed's PROMOTION (becoming the autotune-off
         # default) on PROMOTE_TARGETS, independently of where the seed fires.
         env = MagicMock()
         env.device = "cuda"
-
-        class _AllArches(AutotunerHeuristic):
-            promote_seed_to_default = True
-            PROMOTE_TARGETS = None  # promote wherever it fires (back-compat)
-
-        class _Sm90Only(AutotunerHeuristic):
-            promote_seed_to_default = True
-            PROMOTE_TARGETS = (("cuda", "sm90"),)
-
-        class _NotPromoting(AutotunerHeuristic):
-            promote_seed_to_default = False
-            PROMOTE_TARGETS = (("cuda", "sm90"),)
+        all_arches = self._heuristic("all_arches", promote_seed_to_default=True)
+        sm90_only = self._heuristic(
+            "sm90_only",
+            promote_seed_to_default=True,
+            PROMOTE_TARGETS=(("cuda", "sm90"),),
+        )
+        not_promoting = self._heuristic(
+            "not_promoting",
+            promote_seed_to_default=False,
+            PROMOTE_TARGETS=(("cuda", "sm90"),),
+        )
+        b200_only = self._heuristic(
+            "b200_only",
+            promote_seed_to_default=True,
+            PROMOTE_TARGETS=(("cuda", "sm100"),),
+            PROMOTE_HARDWARE_NAMES=frozenset({"NVIDIA B200"}),
+        )
 
         # PROMOTE_TARGETS=None promotes without consulting hardware.
-        self.assertTrue(_AllArches.should_promote(env))
-
-        # A target list restricts promotion to the matching arch...
-        with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
-            self.assertTrue(_Sm90Only.should_promote(env))
-        # ...and declines on an off-target arch (seed still fires; only the
-        # promotion is gated).
-        with patch(
-            "helion._hardware.get_hardware_info", return_value=BLACKWELL_HARDWARE
+        self.assertTrue(all_arches.should_promote(env))
+        for name, heuristic, hardware, expected in (
+            ("matching arch", sm90_only, HOPPER_HARDWARE, True),
+            ("off-target arch", sm90_only, BLACKWELL_HARDWARE, False),
+            ("promotion disabled", not_promoting, HOPPER_HARDWARE, False),
+            ("matching hardware", b200_only, BLACKWELL_HARDWARE, True),
+            ("different hardware", b200_only, GB300_HARDWARE, False),
         ):
-            self.assertFalse(_Sm90Only.should_promote(env))
-
-        # promote_seed_to_default=False vetoes regardless of the target list.
-        with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
-            self.assertFalse(_NotPromoting.should_promote(env))
+            with (
+                self.subTest(name=name),
+                patch("helion._hardware.get_hardware_info", return_value=hardware),
+            ):
+                self.assertIs(heuristic.should_promote(env), expected)
 
     def test_should_promote_declines_on_unclassifiable_device(self) -> None:
         # On a device Helion cannot classify (e.g. MTIA), get_hardware_info raises
@@ -464,9 +756,11 @@ class TestAutotunerHeuristic(TestCase):
         env = MagicMock()
         env.device = "mtia"
 
-        class _Sm90Only(AutotunerHeuristic):
-            promote_seed_to_default = True
-            PROMOTE_TARGETS = (("cuda", "sm90"),)
+        sm90_only = self._heuristic(
+            "sm90_only",
+            promote_seed_to_default=True,
+            PROMOTE_TARGETS=(("cuda", "sm90"),),
+        )
 
         with patch(
             "helion._hardware.get_hardware_info",
@@ -475,7 +769,1718 @@ class TestAutotunerHeuristic(TestCase):
                 "Helion requires CUDA, ROCm, XPU, or TPU."
             ),
         ):
-            self.assertFalse(_Sm90Only.should_promote(env))
+            self.assertFalse(sm90_only.should_promote(env))
+
+    def test_promotion_specialization_key_tracks_only_exact_name_gates(self) -> None:
+        arch_only = self._heuristic(
+            "arch_only",
+            promote_seed_to_default=True,
+            PROMOTE_TARGETS=(("cuda", "sm100"),),
+        )
+        b200_only = self._heuristic(
+            "b200_only",
+            promote_seed_to_default=True,
+            PROMOTE_TARGETS=(("cuda", "sm100"),),
+            PROMOTE_HARDWARE_NAMES=frozenset({"NVIDIA B200"}),
+        )
+
+        device = torch.device("cuda:0")
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": (arch_only,)},
+            ),
+            patch("helion._hardware.get_hardware_info") as hardware_info,
+        ):
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device), ()
+            )
+            hardware_info.assert_not_called()
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": (arch_only, b200_only)},
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                side_effect=(
+                    BLACKWELL_HARDWARE,
+                    GB300_HARDWARE,
+                    BLACKWELL_HARDWARE,
+                ),
+            ) as hardware_info,
+        ):
+            b200_key = compiler_promotion_specialization_key("triton", device)
+            gb300_key = compiler_promotion_specialization_key("triton", device)
+            b200_key_again = compiler_promotion_specialization_key("triton", device)
+            self.assertEqual(hardware_info.call_count, 3)
+
+        self.assertEqual(b200_key, (("b200_only", "NVIDIA B200"),))
+        self.assertEqual(gb300_key, (("b200_only", None),))
+        self.assertEqual(b200_key_again, b200_key)
+
+    def test_promotion_key_canonicalizes_indexless_current_device(self) -> None:
+        b200_only = self._heuristic(
+            "b200_only",
+            promote_seed_to_default=True,
+            PROMOTE_TARGETS=(("cuda", "sm100"),),
+            PROMOTE_HARDWARE_NAMES=frozenset({"NVIDIA B200"}),
+        )
+
+        devices = (torch.device("cuda:0"), torch.device("cuda:1"))
+        hardware_by_device = {
+            devices[0]: BLACKWELL_HARDWARE,
+            devices[1]: GB300_HARDWARE,
+        }
+        observed_devices: list[torch.device] = []
+
+        def get_hardware_info(device: torch.device) -> HardwareInfo:
+            observed_devices.append(device)
+            return hardware_by_device[device]
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": (b200_only,)},
+            ),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.current_device", side_effect=(0, 1)),
+            patch(
+                "helion._hardware.get_hardware_info",
+                side_effect=get_hardware_info,
+            ),
+        ):
+            indexless = torch.device("cuda")
+            b200_key = compiler_promotion_specialization_key("triton", indexless)
+            gb300_key = compiler_promotion_specialization_key("triton", indexless)
+
+        self.assertEqual(b200_key, (("b200_only", "NVIDIA B200"),))
+        self.assertEqual(gb300_key, (("b200_only", None),))
+        self.assertEqual(observed_devices, list(devices))
+
+    def test_promotion_key_cache_tracks_mutated_registry_policy(self) -> None:
+        mutable_promotion = self._heuristic(
+            "mutable_promotion",
+            promote_seed_to_default=True,
+            PROMOTE_HARDWARE_NAMES=frozenset({"NVIDIA B200"}),
+        )
+
+        device = torch.device("cuda:0")
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": (mutable_promotion,)},
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                side_effect=(BLACKWELL_HARDWARE, GB300_HARDWARE),
+            ) as hardware_info,
+        ):
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device),
+                (("mutable_promotion", "NVIDIA B200"),),
+            )
+            mutable_promotion.PROMOTE_HARDWARE_NAMES = frozenset({"NVIDIA GB300"})
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device),
+                (("mutable_promotion", "NVIDIA GB300"),),
+            )
+            mutable_promotion.promote_seed_to_default = False
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device), ()
+            )
+            self.assertEqual(hardware_info.call_count, 2)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler seed specialization is not used in ref eager mode")
+    def test_compiler_seed_specialization_rebinds_only_eligible_kernels(
+        self,
+    ) -> None:
+        device_num_sm_sensitive = self._heuristic(
+            "device_num_sm_sensitive",
+            CACHE_SPECIALIZATION_FACTS=frozenset({"device_num_sm"}),
+        )
+        config_num_sm_sensitive = self._heuristic(
+            "config_num_sm_sensitive",
+            CACHE_SPECIALIZATION_FACTS=frozenset({"config_num_sm"}),
+        )
+        input_metadata_sensitive = self._heuristic(
+            "input_tensor_metadata_sensitive",
+            CACHE_SPECIALIZATION_FACTS=frozenset({"input_tensor_metadata"}),
+        )
+        unrelated = self._heuristic("unrelated")
+
+        self.assertEqual(
+            CuteTcgen05GroupedWorklistHeuristic.CACHE_SPECIALIZATION_FACTS,
+            frozenset({"config_num_sm", "input_tensor_metadata"}),
+        )
+        for heuristic in (
+            CuteTcgen05ClusterM2Heuristic,
+            TritonH100MatmulHeuristic,
+            TritonPointwiseSeedHeuristic,
+            TritonStandardReductionHeuristicSM90,
+            TritonStandardReductionHeuristicSM100,
+            TritonUserTiledReductionHeuristicSM90,
+            TritonUserTiledReductionHeuristicSM100,
+        ):
+            self.assertEqual(
+                heuristic.CACHE_SPECIALIZATION_FACTS,
+                frozenset({"device_num_sm"}),
+            )
+
+        heuristics = (
+            device_num_sm_sensitive,
+            config_num_sm_sensitive,
+            input_metadata_sensitive,
+            unrelated,
+        )
+        with patch(
+            "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+            {"triton": heuristics},
+        ):
+            for heuristic, expected in (
+                (device_num_sm_sensitive, frozenset({"device_num_sm"})),
+                (config_num_sm_sensitive, frozenset({"config_num_sm"})),
+                (
+                    input_metadata_sensitive,
+                    frozenset({"input_tensor_metadata"}),
+                ),
+                (unrelated, frozenset()),
+            ):
+                self.assertEqual(
+                    compiler_seed_specialization_facts("triton", [heuristic.name]),
+                    expected,
+                )
+
+        current_num_sm = 148
+
+        def get_num_sm(
+            _device: torch.device,
+            *,
+            reserved_sms: int = 0,
+        ) -> int:
+            return max(current_num_sm - reserved_sms, 1)
+
+        def make_kernel(
+            heuristic_name: str,
+            *,
+            persistent_reserved_sms: int = 0,
+            static_shapes: bool = True,
+        ) -> tuple[
+            helion.Kernel,
+            Callable[[MagicMock, object], list[helion.Config]],
+        ]:
+            @helion.kernel(
+                backend="triton",
+                persistent_reserved_sms=persistent_reserved_sms,
+                static_shapes=static_shapes,
+            )
+            def identity(x: torch.Tensor) -> torch.Tensor:
+                out = torch.empty_like(x)
+                for tile in hl.tile(x.shape):
+                    out[tile] = x[tile]
+                return out
+
+            def seed_configs(env: MagicMock, _device_ir: object) -> list[helion.Config]:
+                env.config_spec.autotuner_heuristics = [heuristic_name]
+                return []
+
+            return identity, seed_configs
+
+        x = torch.empty([8], device=DEVICE)
+        wider_x = torch.empty([16], device=DEVICE)
+
+        def bind_kernel(
+            heuristic_name: str,
+            cases: tuple[tuple[tuple[torch.Tensor, ...], int], ...],
+            *,
+            persistent_reserved_sms: int = 0,
+            static_shapes: bool = True,
+        ) -> tuple[helion.Kernel, list[Any]]:
+            nonlocal current_num_sm
+            kernel, seed_configs = make_kernel(
+                heuristic_name,
+                persistent_reserved_sms=persistent_reserved_sms,
+                static_shapes=static_shapes,
+            )
+            bounds = []
+            with patch(
+                "helion.runtime.kernel.compiler_seed_configs",
+                side_effect=seed_configs,
+            ):
+                for args, num_sm in cases:
+                    current_num_sm = num_sm
+                    bounds.append(kernel.bind(args))
+            return kernel, bounds
+
+        def specialization_values(kernel: helion.Kernel, fact: str) -> set[object]:
+            values = set()
+            for key in kernel._bound_kernels:
+                [(name, value)] = cast(
+                    "tuple[tuple[str, object], ...]",
+                    key.compiler_seed_results,
+                )
+                self.assertEqual(name, fact)
+                values.add(value)
+            return values
+
+        def assert_bind_case(
+            heuristic_name: str,
+            cases: tuple[tuple[tuple[torch.Tensor, ...], int], ...],
+            *,
+            same: tuple[tuple[int, int], ...] = (),
+            different: tuple[tuple[int, int], ...] = (),
+            fact: str | None = None,
+            expected_values: set[object] | None = None,
+            persistent_reserved_sms: int = 0,
+            static_shapes: bool = True,
+        ) -> tuple[helion.Kernel, list[Any]]:
+            kernel, bounds = bind_kernel(
+                heuristic_name,
+                cases,
+                persistent_reserved_sms=persistent_reserved_sms,
+                static_shapes=static_shapes,
+            )
+            for pairs, assertion in (
+                (same, self.assertIs),
+                (different, self.assertIsNot),
+            ):
+                for first_index, second_index in pairs:
+                    assertion(bounds[first_index], bounds[second_index])
+            if fact is None:
+                self.assertFalse(
+                    any(key.compiler_seed_results for key in kernel._bound_kernels)
+                )
+            else:
+                self.assertEqual(specialization_values(kernel, fact), expected_values)
+            return kernel, bounds
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": heuristics},
+            ),
+            patch(
+                "helion.runtime.get_num_sm", side_effect=get_num_sm
+            ) as get_num_sm_mock,
+        ):
+            sensitive, (first, second, rebound) = bind_kernel(
+                device_num_sm_sensitive.name,
+                (((x,), 148), ((x,), 132), ((x,), 148)),
+            )
+
+            self.assertIsNot(first, second)
+            self.assertIs(rebound, first)
+            self.assertEqual(len(sensitive._bound_kernels), 2)
+            self.assertEqual(
+                specialization_values(sensitive, "device_num_sm"),
+                {132, 148},
+            )
+            self.assertTrue(
+                all(not key.extra_results for key in sensitive._bound_kernels)
+            )
+            first._run = lambda value: value
+            second._run = lambda value: value
+            current_num_sm = 148
+            get_num_sm_calls = get_num_sm_mock.call_count
+            with patch.object(sensitive, "bind", wraps=sensitive.bind) as bind:
+                self.assertIs(first(x), x)
+                self.assertIs(first(x), x)
+            self.assertEqual(bind.call_count, 0)
+            self.assertEqual(get_num_sm_mock.call_count, get_num_sm_calls)
+
+            current_num_sm = 132
+            different_device = torch.device("cuda", (x.device.index or 0) + 1)
+            rebound_call = MagicMock(return_value=x)
+            with (
+                patch(
+                    "helion.runtime.kernel._find_device",
+                    return_value=different_device,
+                ),
+                patch.object(sensitive, "bind", return_value=rebound_call) as bind,
+            ):
+                self.assertIs(first(x), x)
+            bind.assert_called_once_with((x,))
+            rebound_call.assert_called_once_with(x)
+            self.assertEqual(get_num_sm_mock.call_count, get_num_sm_calls + 1)
+
+            current_num_sm = 148
+            same_num_sm_device = torch.device("cuda", (x.device.index or 0) + 2)
+            same_num_sm_calls = get_num_sm_mock.call_count
+            with (
+                patch(
+                    "helion.runtime.kernel._find_device",
+                    return_value=same_num_sm_device,
+                ),
+                patch.object(sensitive, "bind", return_value=first) as bind,
+            ):
+                self.assertIs(first(x), x)
+                calls_after_new_device = get_num_sm_mock.call_count
+                self.assertIs(first(x), x)
+            bind.assert_called_once_with((x,))
+            self.assertEqual(calls_after_new_device, same_num_sm_calls + 1)
+            self.assertEqual(get_num_sm_mock.call_count, calls_after_new_device)
+
+            assert_bind_case(
+                config_num_sm_sensitive.name,
+                (((x,), 148), ((x,), 132)),
+                different=((0, 1),),
+                fact="config_num_sm",
+                expected_values={124, 140},
+                persistent_reserved_sms=8,
+            )
+
+            _metadata_sensitive, metadata_bounds = assert_bind_case(
+                input_metadata_sensitive.name,
+                (
+                    ((x,), 148),
+                    ((wider_x,), 148),
+                    ((torch.empty_like(x),), 148),
+                ),
+                same=((0, 2),),
+                different=((0, 1),),
+                fact="input_tensor_metadata",
+                expected_values={
+                    (((("sequence", tuple, 0),), (8,), (1,)),),
+                    (((("sequence", tuple, 0),), (16,), (1,)),),
+                },
+                static_shapes=False,
+            )
+            first_metadata, second_metadata, _rebound_metadata = metadata_bounds
+            first_metadata._run = lambda _value: x
+            second_metadata._run = lambda _value: wider_x
+            self.assertIs(first_metadata(wider_x), wider_x)
+
+            assert_bind_case(
+                input_metadata_sensitive.name,
+                (((x,), 148), ((wider_x,), 148)),
+                different=((0, 1),),
+            )
+
+            for static_shapes, cases in (
+                (True, (((x,), 148), ((x,), 132))),
+                (False, (((x,), 148), ((wider_x,), 148))),
+            ):
+                with self.subTest(unrelated_static_shapes=static_shapes):
+                    kernel, _bounds = assert_bind_case(
+                        unrelated.name,
+                        cases,
+                        same=((0, 1),),
+                        static_shapes=static_shapes,
+                    )
+                    self.assertEqual(len(kernel._bound_kernels), 1)
+
+    def test_argument_device_uses_torch_accelerator_fallback(self) -> None:
+        def current_accelerator(*, check_available: bool = False) -> MagicMock:
+            self.assertTrue(check_available)
+            return MagicMock(type="privateuseone")
+
+        with (
+            patch.object(
+                torch,
+                "privateuseone",
+                MagicMock(is_available=MagicMock(return_value=False)),
+                create=True,
+            ),
+            patch.object(
+                torch.accelerator,
+                "current_accelerator",
+                side_effect=current_accelerator,
+            ),
+            patch.object(
+                torch.accelerator,
+                "current_device_index",
+                return_value=3,
+            ),
+        ):
+            self.assertEqual(
+                argument_device_module._current_device_index("privateuseone"),
+                3,
+            )
+
+    def test_argument_device_preserves_unavailable_indexless_device(self) -> None:
+        with (
+            patch.object(torch.cuda, "is_available", return_value=False),
+            patch.object(
+                torch.accelerator,
+                "current_accelerator",
+                return_value=None,
+            ) as current_accelerator,
+            patch.object(
+                torch.accelerator,
+                "current_device_index",
+                side_effect=AssertionError(
+                    "unavailable accelerators have no current device"
+                ),
+            ),
+        ):
+            indexless = torch.device("cuda")
+            self.assertEqual(
+                argument_device_module._canonicalize_argument_device(indexless),
+                indexless,
+            )
+
+        current_accelerator.assert_called_once_with(check_available=True)
+
+    def test_input_tensor_metadata_tracks_roles_not_mapping_order(self) -> None:
+        narrow = torch.empty_strided((8, 4), (4, 1))
+        wide = torch.empty_strided((16, 4), (5, 1))
+        original = _input_tensor_metadata(
+            ({"lhs": narrow, "rhs": wide},),
+        )
+        reordered = _input_tensor_metadata(
+            ({"rhs": wide, "lhs": narrow},),
+        )
+        swapped_roles = _input_tensor_metadata(
+            ({"rhs": narrow, "lhs": wide},),
+        )
+
+        self.assertEqual(original, reordered)
+        self.assertNotEqual(original, swapped_roles)
+        self.assertEqual(
+            {record[0][-1][-1] for record in original},
+            {"lhs", "rhs"},
+        )
+
+    def test_input_tensor_metadata_tracks_dataclass_field_roles(self) -> None:
+        @dataclasses.dataclass
+        class Inputs:
+            lhs: torch.Tensor
+            rhs: torch.Tensor
+
+        narrow = torch.empty_strided((8, 4), (4, 1))
+        wide = torch.empty_strided((16, 4), (5, 1))
+        original = _input_tensor_metadata((Inputs(narrow, wide),))
+        swapped_roles = _input_tensor_metadata((Inputs(wide, narrow),))
+
+        self.assertNotEqual(original, swapped_roles)
+        self.assertEqual(
+            {record[0][-1][-1] for record in original},
+            {"lhs", "rhs"},
+        )
+
+    def test_compiler_seed_specialization_is_in_cache_hash(self) -> None:
+        bound_keys = [
+            BoundKernelInMemoryCacheKey(
+                (),
+                (),
+                compiler_seed_results=(("config_num_sm", num_sm),),
+            )
+            for num_sm in (132, 148)
+        ]
+
+        self.assertNotEqual(bound_keys[0].stable_hash(), bound_keys[1].stable_hash())
+        self.assertIn("compiler_seed_results", repr(bound_keys[0]))
+        self.assertEqual(
+            repr(BoundKernelInMemoryCacheKey((), ())),
+            "BoundKernelInMemoryCacheKey(specialization_key=(), extra_results=())",
+        )
+
+        common = {
+            "specialization_key": (),
+            "extra_results": (),
+            "kernel_source_hash": "source",
+            "hardware": "NVIDIA B200",
+            "runtime_name": "13.0",
+            "backend": "cute",
+        }
+        keys = [
+            LooseAutotuneCacheKey(
+                **common,
+                compiler_seed_results=(
+                    ("config_num_sm", 148),
+                    (
+                        "input_tensor_metadata",
+                        (((("sequence", tuple, 0),), (size,), (1,)),),
+                    ),
+                ),
+            )
+            for size in (8, 16)
+        ]
+
+        self.assertNotEqual(keys[0].stable_hash(), keys[1].stable_hash())
+        self.assertIn("compiler_seed_results", repr(keys[0]))
+
+        strict_keys = [
+            StrictAutotuneCacheKey(
+                **common,
+                compiler_seed_results=(("config_num_sm", num_sm),),
+                helion_key="helion",
+                torch_key="torch",
+                triton_key="triton",
+            )
+            for num_sm in (132, 148)
+        ]
+        self.assertNotEqual(
+            strict_keys[0].stable_hash(),
+            strict_keys[1].stable_hash(),
+        )
+        self.assertIn("compiler_seed_results", repr(strict_keys[0]))
+
+    def test_grouped_worklist_seeds_are_packing_compatible_and_ranked(self) -> None:
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.cute_tcgen05_search_enabled = True
+        for block_id, size_hint in enumerate((256, 4096, 4096)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+            )
+        fact = MatmulFact(
+            lhs_ndim=2,
+            rhs_ndim=3,
+            m_block_id=0,
+            n_block_id=1,
+            k_block_id=2,
+            static_m=256,
+            static_n=4096,
+            static_k=4096,
+            lhs_dtype=torch.bfloat16,
+            rhs_dtype=torch.bfloat16,
+        )
+        spec.matmul_facts = [fact]
+        env = MagicMock(config_spec=spec)
+        self.assertIs(_tcgen05_grouped_fact(env), fact)
+        self.assertIs(_tcgen05_grouped_worklist_fact(env), fact)
+        dynamic_fact = fact._replace(static_n=None, static_k=None)
+        spec.matmul_facts = [dynamic_fact]
+        self.assertIsNone(_tcgen05_grouped_fact(env))
+        self.assertIs(_tcgen05_grouped_worklist_fact(env), dynamic_fact)
+        fp16_fact = fact._replace(
+            lhs_dtype=torch.float16,
+            rhs_dtype=torch.float16,
+        )
+        spec.matmul_facts = [fp16_fact]
+        self.assertIs(_tcgen05_grouped_fact(env), fp16_fact)
+        self.assertIsNone(_tcgen05_grouped_worklist_fact(env))
+
+        families = self._grouped_worklist_seed_families()
+        small = families["small_k"]
+        k_major = families["source256_k"]
+        legacy = families["source224"]
+        n_major = families["source256_n"]
+
+        for configs, key, expected in (
+            (small, TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, 52),
+            (k_major, TCGEN05_CONSUMER_REGS_CONFIG_KEY, 240),
+            (n_major, TCGEN05_CONSUMER_REGS_CONFIG_KEY, 240),
+            (legacy, TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY, 8),
+            (legacy, TCGEN05_CONSUMER_REGS_CONFIG_KEY, 256),
+        ):
+            self.assertEqual(configs[0].config[key], expected)
+        self.assertNotIn(
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY,
+            k_major[0].config,
+        )
+        self.assertEqual(
+            n_major[0].config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY],
+            Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+        )
+        for source_m_tile, configs in (
+            (32, small),
+            (224, legacy),
+            (256, k_major),
+            (256, n_major),
+        ):
+            self.assertTrue(configs)
+            self.assertTrue(
+                all(
+                    config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY]
+                    == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                    and config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY]
+                    == source_m_tile
+                    for config in configs
+                )
+            )
+
+    def test_grouped_worklist_seed_family_covers_reviewed_variants(self) -> None:
+        def block_k(values: dict[str, object]) -> int:
+            return cast("list[int]", values["block_sizes"])[2]
+
+        families = self._grouped_worklist_seed_families()
+        small = families["small_n"]
+        source224 = families["source224"]
+        source256 = families["source256_n"]
+
+        small_values = [config.config for config in small]
+        self.assertTrue(
+            {32, 52}.issubset(
+                {
+                    values.get(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY)
+                    for values in small_values
+                    if block_k(values) == 128
+                }
+            )
+        )
+        self.assertTrue(
+            any(
+                block_k(values) == 128
+                and TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY not in values
+                for values in small_values
+            )
+        )
+        self.assertTrue(
+            {4, 8}.issubset(
+                {
+                    values.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
+                    for values in small_values
+                    if values.get(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY) == 20
+                }
+            )
+        )
+        self.assertTrue(
+            any(
+                block_k(values) == 64
+                and values.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
+                and TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY not in values
+                for values in small_values
+            )
+        )
+        self.assertTrue(
+            any(
+                values.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is not True
+                for values in small_values
+            )
+        )
+
+        source224_values = [config.config for config in source224]
+        self.assertEqual(
+            {
+                values["tcgen05_ab_stages"]
+                for values in source224_values
+                if values.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is not True
+            },
+            {4, 5, 6, 7},
+        )
+        self.assertTrue(
+            any(
+                values.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY) == 8
+                and values.get(TCGEN05_CONSUMER_REGS_CONFIG_KEY) == 256
+                for values in source224_values
+            )
+        )
+        self.assertTrue(any(block_k(values) == 128 for values in source224_values))
+
+        source256_values = [config.config for config in source256]
+        self.assertEqual(
+            {
+                (block_k(values), values["tcgen05_ab_stages"])
+                for values in source256_values
+            },
+            {(64, 5), (64, 6), (128, 3)},
+        )
+        self.assertTrue(
+            {224, 240, 256}.issubset(
+                {
+                    values.get(TCGEN05_CONSUMER_REGS_CONFIG_KEY)
+                    for values in source256_values
+                }
+            )
+        )
+        self.assertTrue(
+            {8, 16}.issubset(
+                {
+                    values.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
+                    for values in source256_values
+                }
+            )
+        )
+        self.assertTrue(
+            any(
+                values.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+                == Tcgen05PersistenceModel.CLC_PERSISTENT.value
+                for values in source256_values
+            )
+        )
+
+    def test_grouped_worklist_clc_requires_full_physical_n_tile(self) -> None:
+        configs = tcgen05_grouped_worklist_seed_configs(
+            groups=8,
+            packed_m=20_480,
+            n=416,
+            k=192,
+            b_major="n",
+            source_m_tile=256,
+            num_sm=148,
+        )
+
+        self.assertTrue(configs)
+        self.assertTrue(
+            all(
+                config.config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+                != Tcgen05PersistenceModel.CLC_PERSISTENT.value
+                for config in configs
+            )
+        )
+        self.assertNotEqual(
+            configs[0].config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY),
+            Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+        )
+
+    def test_grouped_worklist_clc_respects_cuda_grid_z_limit(self) -> None:
+        for m_tiles, n_tiles, expect_clc in (
+            (257, 255, True),
+            (258, 255, False),
+        ):
+            with self.subTest(
+                m_tiles=m_tiles,
+                n_tiles=n_tiles,
+                expect_clc=expect_clc,
+            ):
+                configs = tcgen05_grouped_worklist_seed_configs(
+                    groups=1,
+                    packed_m=m_tiles * 256,
+                    n=n_tiles * 256,
+                    k=65_536,
+                    b_major="n",
+                    source_m_tile=256,
+                    num_sm=148,
+                )
+                clc_configs = [
+                    config
+                    for config in configs
+                    if config.config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+                    == Tcgen05PersistenceModel.CLC_PERSISTENT.value
+                ]
+
+                self.assertEqual(bool(clc_configs), expect_clc)
+                self.assertEqual(
+                    m_tiles * n_tiles
+                    <= TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS,
+                    expect_clc,
+                )
+                if expect_clc:
+                    self.assertEqual(
+                        configs[0].config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY),
+                        Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+                    )
+                else:
+                    self.assertNotEqual(
+                        configs[0].config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY),
+                        Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+                    )
+
+    def test_grouped_worklist_seeds_filter_unreachable_block_k(self) -> None:
+        configs = tcgen05_grouped_worklist_seed_configs(
+            groups=8,
+            packed_m=8 * 4096,
+            n=4096,
+            k=2048,
+            b_major="n",
+            source_m_tile=256,
+            num_sm=148,
+        )
+
+        for block_k in (64, 128):
+            spec = ConfigSpec(backend=CuteBackend())
+            for block_id, value in enumerate((256, 128, block_k)):
+                spec.block_sizes.append(
+                    BlockSizeSpec(
+                        block_id=block_id,
+                        size_hint=value,
+                        min_size=value,
+                        max_size=value,
+                    )
+                )
+            reachable = _filter_reachable_block_size_configs(spec, configs)
+            self.assertTrue(reachable)
+            self.assertTrue(
+                all(
+                    cast("list[int]", config.config["block_sizes"])[2] == block_k
+                    for config in reachable
+                )
+            )
+        bk128_only = ConfigSpec(
+            backend=CuteBackend(),
+            target_device_capability=(10, 0),
+        )
+        bk128_only.cute_tcgen05_search_enabled = True
+        for block_id, value in enumerate((256, 128, 128)):
+            bk128_only.block_sizes.append(
+                BlockSizeSpec(
+                    block_id=block_id,
+                    size_hint=value,
+                    min_size=value,
+                    max_size=value,
+                )
+            )
+        bk128_only.matmul_facts = [
+            MatmulFact(
+                lhs_ndim=2,
+                rhs_ndim=3,
+                m_block_id=0,
+                n_block_id=1,
+                k_block_id=2,
+                static_m=256,
+                static_n=None,
+                static_k=None,
+                lhs_dtype=torch.bfloat16,
+                rhs_dtype=torch.bfloat16,
+            )
+        ]
+        env = MagicMock(config_spec=bk128_only)
+        bk128_only.compiler_heuristic_metadata[
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+        ] = 224
+        with patch(
+            "helion._compiler.autotuner_heuristics.cute."
+            "tcgen05_runtime_n_ptx_compatible",
+            return_value=True,
+        ):
+            self.assertIsNotNone(
+                CuteTcgen05GroupedWorklistHeuristic._eligible_inputs(env, MagicMock())
+            )
+            bk128_only.matmul_facts = [bk128_only.matmul_facts[0]._replace(static_n=33)]
+            self.assertIsNone(
+                CuteTcgen05GroupedWorklistHeuristic._eligible_inputs(env, MagicMock())
+            )
+            bk128_only.matmul_facts = [
+                bk128_only.matmul_facts[0]._replace(static_n=None)
+            ]
+            bk128_only.compiler_heuristic_metadata[
+                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+            ] = 256
+            self.assertIsNotNone(
+                CuteTcgen05GroupedWorklistHeuristic._eligible_inputs(env, MagicMock())
+            )
+
+    def test_grouped_worklist_seed_only_controls_survive_flattening(self) -> None:
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.cute_tcgen05_search_enabled = True
+        spec.allowed_pid_types = ("flat",)
+        families = self._grouped_worklist_seed_families()
+        spec.compiler_seed_configs = [
+            *families["small_k"],
+            *families["source256_n"],
+            *families["source256_k"],
+        ]
+        fields = spec._cute_tcgen05_config.flat_fields()
+
+        def enum(key: str) -> EnumFragment:
+            fragment = fields[key]
+            self.assertIsInstance(fragment, EnumFragment)
+            return cast("EnumFragment", fragment)
+
+        ab_stages = cast("IntegerFragment", fields["tcgen05_ab_stages"])
+        self.assertIsInstance(ab_stages, IntegerFragment)
+        grouped_mode = enum(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+        runtime_direct = enum(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY)
+        reserved = enum(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY)
+        consumer_regs = enum(TCGEN05_CONSUMER_REGS_CONFIG_KEY)
+        strategy = enum(TCGEN05_STRATEGY_CONFIG_KEY)
+        persistence = enum(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+        scheduler_warps = enum(TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY)
+        source_m_tile = enum(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+        l2_swizzle = enum(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
+        pid_type = enum("pid_type")
+        seed_ab_stages = max(
+            cast("int", seed.config["tcgen05_ab_stages"])
+            for seed in spec.compiler_seed_configs
+        )
+        self.assertGreater(seed_ab_stages, ab_stages.high)
+        self.assertEqual(ab_stages.default(), 2)
+        self.assertEqual(ab_stages.cardinality(), 2)
+        self.assertEqual(ab_stages.search_values(), [1, 2])
+        self.assertEqual(ab_stages.dim(), 1)
+        self.assertEqual(ab_stages.encode(seed_ab_stages), [float(seed_ab_stages)])
+        self.assertEqual(ab_stages.pattern_neighbors(seed_ab_stages), [2, 1])
+        self.assertEqual(
+            ab_stages.differential_mutation(seed_ab_stages, 1, 1),
+            seed_ab_stages,
+        )
+        self.assertEqual(ab_stages.differential_mutation(seed_ab_stages, 1, 2), 2)
+        self.assertEqual(ab_stages.differential_mutation(seed_ab_stages, 2, 1), 2)
+        self.assertTrue(all(ab_stages.random() in (1, 2) for _ in range(32)))
+        self.assertEqual(grouped_mode.search_choices, (None,))
+        self.assertEqual(runtime_direct.search_choices, (False,))
+        self.assertIn(52, reserved.choices)
+        self.assertEqual(
+            reserved.search_choices,
+            TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
+        )
+        self.assertEqual(consumer_regs.search_choices, (256,))
+        self.assertEqual(
+            strategy.search_choices,
+            (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,),
+        )
+        self.assertIn(Tcgen05PersistenceModel.CLC_PERSISTENT.value, persistence.choices)
+        self.assertEqual(
+            scheduler_warps.search_choices,
+            (0,),
+        )
+        self.assertEqual(set(source_m_tile.choices), {None, 32, 256})
+        self.assertEqual(source_m_tile.search_choices, (None,))
+        self.assertIn(16, l2_swizzle.choices)
+        self.assertEqual(l2_swizzle.search_choices, (1, 2, 4, 8))
+        self.assertEqual(pid_type.search_choices, ("flat",))
+
+    def test_grouped_worklist_primary_promotes_only_on_b200(self) -> None:
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.cute_tcgen05_search_enabled = True
+        for block_id, size_hint in enumerate((256, 256, 128)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+            )
+        static_fact = MatmulFact(
+            lhs_ndim=2,
+            rhs_ndim=2,
+            m_block_id=0,
+            n_block_id=1,
+            k_block_id=2,
+            static_m=256,
+            static_n=256,
+            static_k=128,
+            lhs_dtype=torch.bfloat16,
+            rhs_dtype=torch.bfloat16,
+        )
+        spec.matmul_facts = [static_fact]
+        env = MagicMock(device=DEVICE, config_spec=spec)
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            self.assertTrue(CuteTcgen05GroupedWorklistHeuristic.should_promote(env))
+            spec.matmul_facts = [static_fact._replace(static_k=None)]
+            self.assertFalse(CuteTcgen05GroupedWorklistHeuristic.should_promote(env))
+            spec.matmul_facts = [
+                static_fact._replace(
+                    lhs_dtype=torch.float16,
+                    rhs_dtype=torch.float16,
+                )
+            ]
+            self.assertFalse(CuteTcgen05GroupedWorklistHeuristic.should_promote(env))
+        spec.matmul_facts = [static_fact]
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch("helion._hardware.get_hardware_info", return_value=GB300_HARDWARE),
+        ):
+            self.assertFalse(CuteTcgen05GroupedWorklistHeuristic.should_promote(env))
+
+    def test_grouped_worklist_seeds_require_validated_runtime_n_ptx(self) -> None:
+        spec = ConfigSpec(
+            backend=CuteBackend(),
+            target_device_capability=(10, 0),
+            num_sm=148,
+        )
+        spec.cute_tcgen05_search_enabled = True
+        for block_id, size_hint in enumerate((256, 256, 128)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+            )
+        spec.matmul_facts = [
+            MatmulFact(
+                lhs_ndim=2,
+                rhs_ndim=3,
+                m_block_id=0,
+                n_block_id=1,
+                k_block_id=2,
+                static_m=256,
+                static_n=256,
+                static_k=128,
+                lhs_dtype=torch.bfloat16,
+                rhs_dtype=torch.bfloat16,
+            )
+        ]
+        spec.compiler_heuristic_metadata[
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+        ] = 256
+        env = MagicMock(device=DEVICE, config_spec=spec)
+        device_ir = MagicMock()
+        grouped_fact = spec.matmul_facts[0]
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=False,
+            ),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "warn_tcgen05_runtime_n_ptx_fallback"
+            ) as warn_fallback,
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            spec.matmul_facts = []
+            self.assertFalse(
+                CuteTcgen05GroupedWorklistHeuristic.is_eligible(env, device_ir)
+            )
+            warn_fallback.assert_not_called()
+
+            spec.matmul_facts = [grouped_fact]
+            self.assertFalse(
+                CuteTcgen05GroupedWorklistHeuristic.is_eligible(env, device_ir)
+            )
+            warn_fallback.assert_called_once_with()
+            self.assertIsNone(
+                CuteTcgen05GroupedWorklistHeuristic.get_seed_config(env, device_ir)
+            )
+            self.assertEqual(
+                CuteTcgen05GroupedWorklistHeuristic.get_seed_configs(env, device_ir),
+                [],
+            )
+            self.assertFalse(CuteTcgen05GroupedWorklistHeuristic.should_promote(env))
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_dynamic_hints_do_not_narrow_search(self) -> None:
+        from helion.language.matmul_ops import plan_cute_tcgen05_search
+
+        def make_args(packed_m: int) -> tuple[object, ...]:
+            return (
+                torch.empty(
+                    [packed_m, 128],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.empty(
+                    [6, 256, 128],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.empty([6, 4], device=DEVICE, dtype=torch.int32),
+                32,
+            )
+
+        kernel = helion.kernel(
+            _grouped_worklist_metadata_kernel,
+            backend="cute",
+            static_shapes=False,
+        )
+        plans = []
+
+        def capture_plan(*args: object, **kwargs: object):
+            plan = plan_cute_tcgen05_search(*args, **kwargs)  # pyrefly: ignore
+            if plan is not None:
+                plans.append(plan)
+            return plan
+
+        first_args = make_args(6 * 32)
+        rebound_args = make_args(12 * 32)
+
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion.language.matmul_ops.plan_cute_tcgen05_search",
+                side_effect=capture_plan,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            first = kernel.bind(first_args)
+            rebound = kernel.bind(rebound_args)
+            first._run = lambda *_args: cast("torch.Tensor", first_args[0])
+            rebound._run = lambda *_args: cast("torch.Tensor", rebound_args[0])
+            self.assertIs(first(*rebound_args), rebound_args[0])
+
+        self.assertIsNot(rebound, first)
+        self.assertEqual(len(plans), 2)
+        for plan in plans:
+            self.assertEqual(
+                (plan.static_m, plan.static_n, plan.static_k),
+                (256, None, None),
+            )
+        fact = first.config_spec.matmul_facts[0]
+        self.assertEqual(
+            (fact.static_m, fact.static_n, fact.static_k),
+            (256, None, None),
+        )
+        self.assertEqual(first.config_spec.allowed_pid_types, ("flat",))
+        self.assertEqual(first.config_spec._tcgen05_cluster_m_search_choices, (1,))
+        self.assertIsNone(first.config_spec._tcgen05_cluster_m2_search_constraints)
+        self.assertIsNone(first.config_spec.compiler_default_config)
+        # The worklist's group/start/extent loads feed scheduling, indices, and
+        # masks rather than the matmul's store value. They must not be mistaken
+        # for per-subtile epilogue aux loads, which would expose a
+        # ``pre_acc_wait`` search point that every identity-store config rejects.
+        self.assertFalse(first.config_spec.cute_tcgen05_aux_kernel_detected)
+        self.assertNotIn(
+            TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+            first.config_spec._flat_fields(),
+        )
+        self.assertTrue(
+            any(
+                config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                for config in first.config_spec.compiler_seed_configs
+            )
+        )
+        transfer_errors: list[str] = []
+        generation = first.config_spec.create_config_generation()
+        seed_pairs = generation.seed_flat_config_pairs(transfer_errors.append)
+        self.assertFalse(transfer_errors)
+        self.assertTrue(seed_pairs)
+        for flat, normalized in seed_pairs:
+            self.assertEqual(generation.unflatten([*flat]), normalized)
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_dynamic_inputs_rebind_without_promotion(self) -> None:
+        def make_args(
+            *,
+            n: int = 256,
+            k: int = 256,
+            b_major: str = "k",
+        ) -> tuple[object, ...]:
+            if b_major == "k":
+                b_grouped = torch.empty(
+                    [6, n, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                )
+            else:
+                self.assertEqual(b_major, "n")
+                b_grouped = torch.empty(
+                    [6, k, n],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ).transpose(1, 2)
+            return (
+                torch.empty([6 * 32, k], device=DEVICE, dtype=torch.bfloat16),
+                b_grouped,
+                torch.empty([6, 4], device=DEVICE, dtype=torch.int32),
+                32,
+            )
+
+        kernel = helion.kernel(
+            _grouped_worklist_metadata_kernel,
+            backend="cute",
+            static_shapes=False,
+        )
+        current_num_sm = 148
+
+        def get_num_sm(
+            _device: torch.device,
+            *,
+            reserved_sms: int = 0,
+        ) -> int:
+            return max(current_num_sm - reserved_sms, 1)
+
+        first_args = make_args()
+        different_k_args = make_args(k=192)
+        different_n_args = make_args(n=240)
+        different_layout_args = make_args(b_major="n")
+
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+            patch("helion.runtime.get_num_sm", side_effect=get_num_sm),
+        ):
+            first = kernel.bind(first_args)
+            different_k = kernel.bind(different_k_args)
+            different_n = kernel.bind(different_n_args)
+            different_layout = kernel.bind(different_layout_args)
+
+            first_output = cast("torch.Tensor", first_args[0])
+            different_k_output = cast("torch.Tensor", different_k_args[0])
+            different_n_output = cast("torch.Tensor", different_n_args[0])
+            different_layout_output = cast("torch.Tensor", different_layout_args[0])
+            first._run = lambda *_args: first_output
+            different_k._run = lambda *_args: different_k_output
+            different_n._run = lambda *_args: different_n_output
+            different_layout._run = lambda *_args: different_layout_output
+            self.assertIs(first(*different_k_args), different_k_output)
+            self.assertIs(first(*different_n_args), different_n_output)
+            self.assertIs(first(*different_layout_args), different_layout_output)
+
+            current_num_sm = 132
+            smaller_sm = kernel.bind(different_k_args)
+
+        self.assertIsNot(different_k, first)
+        self.assertIsNot(different_n, first)
+        self.assertIsNot(different_layout, first)
+        self.assertIsNot(smaller_sm, first)
+        self.assertIsNot(smaller_sm, different_k)
+        self.assertEqual(len(kernel._bound_kernels), 5)
+
+        def specialization_results(bound: object) -> dict[str, object]:
+            matches = [
+                dict(
+                    cast(
+                        "tuple[tuple[str, object], ...]",
+                        key.compiler_seed_results,
+                    )
+                )
+                for key, candidate in kernel._bound_kernels.items()
+                if candidate is bound
+            ]
+            self.assertEqual(len(matches), 1)
+            return matches[0]
+
+        first_results = specialization_results(first)
+        different_k_results = specialization_results(different_k)
+        different_n_results = specialization_results(different_n)
+        different_layout_results = specialization_results(different_layout)
+        smaller_sm_results = specialization_results(smaller_sm)
+        self.assertEqual(first_results["config_num_sm"], 148)
+        self.assertEqual(different_k_results["config_num_sm"], 148)
+        self.assertEqual(different_n_results["config_num_sm"], 148)
+        self.assertEqual(different_layout_results["config_num_sm"], 148)
+        self.assertEqual(smaller_sm_results["config_num_sm"], 132)
+        first_metadata = first_results["input_tensor_metadata"]
+        self.assertNotEqual(
+            different_k_results["input_tensor_metadata"], first_metadata
+        )
+        self.assertNotEqual(
+            different_n_results["input_tensor_metadata"], first_metadata
+        )
+        self.assertNotEqual(
+            different_layout_results["input_tensor_metadata"], first_metadata
+        )
+        self.assertEqual(
+            smaller_sm_results["input_tensor_metadata"],
+            different_k_results["input_tensor_metadata"],
+        )
+        self.assertIsNone(first.config_spec.matmul_facts[0].static_k)
+        self.assertIsNone(first.config_spec.compiler_default_config)
+        self.assertEqual(
+            {
+                cast("list[int]", config.config["block_sizes"])[2]
+                for config in first.config_spec.compiler_seed_configs
+                if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            },
+            {64, 128},
+        )
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_smem_facts_register_with_heuristics_disabled(
+        self,
+    ) -> None:
+        source_m_tile = 224
+        k = 128
+
+        def make_args(groups: int, *, n: int = 256) -> tuple[object, ...]:
+            return (
+                torch.empty(
+                    [groups * source_m_tile, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.empty(
+                    [groups, n, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.empty([groups, 4], device=DEVICE, dtype=torch.int32),
+                source_m_tile,
+            )
+
+        groups = 6
+        empty_args = make_args(groups, n=0)
+        args = make_args(groups)
+        different_groups = 7
+        different_args = make_args(different_groups)
+        kernel = helion.kernel(
+            _grouped_worklist_metadata_kernel,
+            backend="cute",
+            static_shapes=False,
+            disable_autotuner_heuristics=True,
+        )
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            empty_bound = kernel.bind(empty_args)
+            bound = kernel.bind(args)
+            rebound = kernel.bind(different_args)
+
+        self.assertIsNone(
+            empty_bound.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts
+        )
+        self.assertIsNot(bound, empty_bound)
+        self.assertEqual(bound.config_spec.compiler_seed_configs, [])
+        self.assertEqual(bound.config_spec.autotuner_heuristics, [])
+        self.assertEqual(
+            compiler_seed_configs(bound.env, bound.host_function.device_ir),
+            [],
+        )
+        self.assertEqual(
+            bound.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts,
+            (groups, False),
+        )
+        self.assertIsNot(rebound, bound)
+        self.assertEqual(
+            rebound.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts,
+            (different_groups, False),
+        )
+        self.assertEqual(
+            [
+                extractor.fact
+                for extractor in empty_bound._compiler_seed_specialization_extractors
+            ],
+            ["input_tensor_metadata"],
+        )
+        bound_output = cast("torch.Tensor", args[0])
+        bound._run = lambda *_args: bound_output
+        self.assertIs(empty_bound(*args), bound_output)
+        rebound_output = cast("torch.Tensor", different_args[0])
+        rebound._run = lambda *_args: rebound_output
+        self.assertIs(bound(*different_args), rebound_output)
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_fact_registration_ignores_plain_matmul(self) -> None:
+        @helion.kernel(
+            backend="cute",
+            static_shapes=False,
+            disable_autotuner_heuristics=True,
+        )
+        def plain_matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(
+                        acc,
+                        x[tile_m, tile_k],
+                        y[tile_k, tile_n],
+                    )
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        def make_args(size: int) -> tuple[torch.Tensor, torch.Tensor]:
+            return (
+                torch.empty(
+                    [size, 128],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.empty(
+                    [128, size],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+            )
+
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            first = plain_matmul.bind(make_args(128))
+            rebound = plain_matmul.bind(make_args(256))
+
+        self.assertIs(rebound, first)
+        self.assertEqual(len(plain_matmul._bound_kernels), 1)
+        self.assertEqual(first._compiler_seed_specialization_extractors, ())
+        self.assertIsNone(
+            first.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts
+        )
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_bound_metadata_proof_and_effective_default(self) -> None:
+        from helion._compiler.cute.cute_mma import tcgen05_grouped_worklist_seed_facts
+
+        renamed_packing_kernel = helion.kernel(
+            _grouped_worklist_metadata_kernel,
+            backend="cute",
+            static_shapes=True,
+        )
+
+        def make_args(
+            source_m_tile: int,
+            b_major: str,
+            k: int = 128,
+            packed_m: int | None = None,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+            groups, n = 6, 256
+            a_packed = torch.empty(
+                [
+                    groups * source_m_tile if packed_m is None else packed_m,
+                    k,
+                ],
+                device=DEVICE,
+                dtype=torch.bfloat16,
+            )
+            if b_major == "k":
+                b_grouped = torch.empty(
+                    [groups, n, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                )
+            else:
+                b_grouped = torch.empty(
+                    [groups, k, n],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ).transpose(1, 2)
+            worklist = torch.empty(
+                [groups, 4],
+                device=DEVICE,
+                dtype=torch.int32,
+            )
+            return a_packed, b_grouped, worklist, source_m_tile
+
+        def grouped_seeds(spec: ConfigSpec, source_m_tile: int) -> list[helion.Config]:
+            return [
+                config
+                for config in spec.compiler_seed_configs
+                if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                and config.config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+                == source_m_tile
+            ]
+
+        def transferred_seed_pairs(spec: ConfigSpec) -> tuple[Any, list[Any]]:
+            transfer_errors: list[str] = []
+            generation = spec.create_config_generation()
+            transferred = generation.seed_flat_config_pairs(transfer_errors.append)
+            self.assertFalse(transfer_errors)
+            for flat, normalized in transferred:
+                self.assertEqual(generation.unflatten([*flat]), normalized)
+            return generation, transferred
+
+        def seed_pipeline(
+            bound: Any,
+            source_m_tile: int,
+            *,
+            clear_cluster_constraints: bool = False,
+            expected_block_k: int | None = None,
+            compile_default: bool = False,
+        ) -> tuple[ConfigSpec, list[helion.Config], helion.Config, Any, list[Any]]:
+            spec = bound.config_spec
+            self.assertTrue(spec.cute_tcgen05_search_enabled)
+            self.assertEqual(
+                spec.compiler_heuristic_metadata[
+                    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+                ],
+                source_m_tile,
+            )
+            self.assertIn(
+                CuteTcgen05GroupedWorklistHeuristic.name,
+                spec.autotuner_heuristics,
+            )
+            seeds = grouped_seeds(spec, source_m_tile)
+            self.assertTrue(seeds)
+            if expected_block_k is not None:
+                self.assertTrue(
+                    all(
+                        cast("list[int]", seed.config["block_sizes"])[2]
+                        == expected_block_k
+                        for seed in seeds
+                    )
+                )
+            if clear_cluster_constraints:
+                spec._cute_tcgen05_config.cluster_m2_search_constraints = None
+            generation, transferred = transferred_seed_pairs(spec)
+            self.assertGreaterEqual(len(transferred), len(seeds))
+            promoted = spec.compiler_default_config
+            self.assertIsNotNone(promoted)
+            assert promoted is not None
+            self.assertEqual(promoted, seeds[0])
+            self.assertIn(
+                generation.canonicalize_flat(generation.flatten(promoted)),
+                transferred,
+            )
+            effective = spec.default_config()
+            self.assertEqual(
+                effective.config["block_sizes"], promoted.config["block_sizes"]
+            )
+            if compile_default:
+                self.assertTrue(
+                    callable(bound.compile_config(effective, allow_print=False))
+                )
+            return spec, seeds, promoted, effective, transferred
+
+        bounds = []
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            for source_m_tile, b_major in (
+                (32, "k"),
+                (32, "n"),
+                (224, "k"),
+                (224, "n"),
+                (256, "k"),
+                (256, "n"),
+            ):
+                with self.subTest(source_m_tile=source_m_tile, b_major=b_major):
+                    bound = renamed_packing_kernel.bind(
+                        make_args(source_m_tile, b_major)
+                    )
+                    bounds.append(bound)
+                    expect_cluster2 = source_m_tile in (224, 256)
+                    spec, _seeds, promoted, effective, transferred = seed_pipeline(
+                        bound,
+                        source_m_tile,
+                        clear_cluster_constraints=expect_cluster2,
+                        compile_default=True,
+                    )
+                    for _flat, normalized in transferred:
+                        if expect_cluster2:
+                            self.assertEqual(
+                                normalized.config["tcgen05_cluster_m"],
+                                2,
+                            )
+                    self.assertIsNot(effective, promoted)
+                    self.assertGreater(len(effective.config), len(promoted.config))
+                    self.assertEqual(
+                        effective.config[
+                            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+                        ],
+                        source_m_tile,
+                    )
+                    self.assertEqual(
+                        effective.config["block_sizes"],
+                        promoted.config["block_sizes"],
+                    )
+                    self.assertEqual(
+                        cast("list[int]", effective.config["block_sizes"])[:2],
+                        [256, 128],
+                    )
+                    if expect_cluster2:
+                        self.assertIsNone(
+                            spec._cute_tcgen05_config.cluster_m2_search_constraints
+                        )
+                        self.assertEqual(promoted.config["tcgen05_cluster_m"], 2)
+                        self.assertEqual(effective.config["tcgen05_cluster_m"], 2)
+
+            b200_256_bound = bounds[-1]
+            self.assertIsNotNone(b200_256_bound.config_spec.compiler_default_config)
+
+            for source_m_tile in (32, 256):
+                with self.subTest(source_m_tile=source_m_tile, k=192):
+                    bound = renamed_packing_kernel.bind(
+                        make_args(source_m_tile, "n", k=192)
+                    )
+                    seed_pipeline(
+                        bound,
+                        source_m_tile,
+                        expected_block_k=64,
+                        compile_default=True,
+                    )
+
+            for source_m_tile in (224, 256):
+                with self.subTest(
+                    source_m_tile=source_m_tile,
+                    packed_m="non_aligned",
+                ):
+                    exact_packed_m = 6 * source_m_tile + 1
+                    bound = renamed_packing_kernel.bind(
+                        make_args(
+                            source_m_tile,
+                            "n",
+                            packed_m=exact_packed_m,
+                        )
+                    )
+                    spec, _seeds, _promoted, _effective, _transferred = seed_pipeline(
+                        bound,
+                        source_m_tile,
+                    )
+                    host_function = bound.host_function
+                    self.assertIsNotNone(host_function)
+                    assert host_function is not None
+                    seed_facts = tcgen05_grouped_worklist_seed_facts(
+                        bound.env,
+                        host_function.device_ir,
+                        spec.matmul_facts[0],
+                        source_m_tile=source_m_tile,
+                    )
+                    self.assertIsNotNone(seed_facts)
+                    assert seed_facts is not None
+                    self.assertEqual(seed_facts.packed_m_hint, exact_packed_m)
+
+        source32_host = bounds[0].host_function
+        self.assertIsNotNone(source32_host)
+        assert source32_host is not None
+        source32_facts = tcgen05_grouped_worklist_seed_facts(
+            bounds[0].env,
+            source32_host.device_ir,
+            bounds[0].config_spec.matmul_facts[0],
+            source_m_tile=32,
+        )
+        self.assertIsNotNone(source32_facts)
+        assert source32_facts is not None
+        self.assertEqual(source32_facts.packed_m_hint, 6 * 32)
+        with (
+            bounds[1].env,
+            self.assertRaisesRegex(
+                AssertionError,
+                "must use the provided compile environment",
+            ),
+        ):
+            tcgen05_grouped_worklist_seed_facts(
+                bounds[0].env,
+                source32_host.device_ir,
+                bounds[0].config_spec.matmul_facts[0],
+                source_m_tile=32,
+            )
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch("helion._hardware.get_hardware_info", return_value=GB300_HARDWARE),
+        ):
+            gb300_bound = renamed_packing_kernel.bind(make_args(256, "n"))
+        self.assertIsNot(gb300_bound, b200_256_bound)
+        self.assertTrue(grouped_seeds(gb300_bound.config_spec, 256))
+        self.assertIsNone(gb300_bound.config_spec.compiler_default_config)
 
     @onlyBackends(["triton"])
     @skipIfRefEager("Compiler pointwise facts are not collected in ref eager mode")
@@ -5310,8 +7315,14 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             bound = cute_matmul_and_elementwise_store.bind(args)
 
         spec = bound.config_spec
-        self.assertTrue(spec.cute_tcgen05_aux_kernel_detected)
+        # The residual load belongs to a separate elementwise store, not the
+        # matmul epilogue, so no aux-only matmul search axis is productive.
+        self.assertFalse(spec.cute_tcgen05_aux_kernel_detected)
         self.assertFalse(spec.cute_tcgen05_exact_shape_aux_kernel_detected)
+        self.assertNotIn(
+            TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+            {key for key, _count, _is_sequence in spec.flat_key_layout()},
+        )
         self.assertFalse(
             any(
                 config.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
@@ -5347,8 +7358,14 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             bound = cute_matmul_partial_residual.bind(args)
 
         spec = bound.config_spec
-        self.assertTrue(spec.cute_tcgen05_aux_kernel_detected)
+        # The partial rank-2 load is outside the accepted per-subtile epilogue
+        # contract, so codegen cannot use the C-input or placement controls.
+        self.assertFalse(spec.cute_tcgen05_aux_kernel_detected)
         self.assertFalse(spec.cute_tcgen05_exact_shape_aux_kernel_detected)
+        self.assertNotIn(
+            TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+            {key for key, _count, _is_sequence in spec.flat_key_layout()},
+        )
         self.assertFalse(
             any(
                 config.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
@@ -5386,8 +7403,14 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             bound = cute_matmul_scrambled_residual.bind(args)
 
         spec = bound.config_spec
-        self.assertTrue(spec.cute_tcgen05_aux_kernel_detected)
+        # Reordered tile indices are rejected by the same chain analyzer used
+        # at codegen, so they must not widen the aux search surface at bind.
+        self.assertFalse(spec.cute_tcgen05_aux_kernel_detected)
         self.assertFalse(spec.cute_tcgen05_exact_shape_aux_kernel_detected)
+        self.assertNotIn(
+            TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+            {key for key, _count, _is_sequence in spec.flat_key_layout()},
+        )
         self.assertFalse(
             any(
                 config.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -6,6 +6,8 @@ import os
 import pickle
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Callable
+from typing import cast
 import unittest
 from unittest.mock import patch
 
@@ -16,6 +18,9 @@ import torch
 
 import helion
 from helion import exc
+from helion._compiler.autotuner_heuristics.cute import (
+    tcgen05_grouped_worklist_seed_configs,
+)
 from helion._compiler.backend import PallasBackend
 from helion._compiler.backend import TritonBackend
 from helion._compiler.compile_environment import CompileEnvironment
@@ -67,7 +72,7 @@ from helion._compiler.cute.tcgen05_constants import (
 )
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from helion._compiler.cute.tcgen05_constants import (
-    resolve_tcgen05_grouped_worklist_mma_shape,
+    resolve_tcgen05_grouped_worklist_mma_profile,
 )
 from helion._compiler.cute.tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
 from helion._testing import TestCase
@@ -76,6 +81,8 @@ from helion._testing import skipIfXPU
 from helion._testing import skipUnlessCuteAvailable
 from helion.autotuner.config_fragment import EnumFragment
 from helion.autotuner.config_spec import ConfigSpec
+from helion.autotuner.config_spec import LoopOrderSpec
+from helion.autotuner.config_spec import MatmulFact
 import helion.language as hl
 
 if TYPE_CHECKING:
@@ -307,18 +314,48 @@ class TestConfigAPI(TestCase):
         # latter is memoized behind _target_device_capability, mirroring the
         # is_hip / _is_hip pattern where tests mock the public wrapper, not
         # the cached inner query.
-        with patch(
-            "helion.runtime.kernel.target_device_capability", return_value=(9, 0)
+        with (
+            patch(
+                "helion.runtime.kernel.target_device_capability", return_value=(9, 0)
+            ),
+            patch(
+                "helion.runtime.kernel.compiler_promotion_specialization_key",
+                return_value=(),
+            ),
         ):
             sm90_key = device_key_kernel._base_specialization_key((device,))
-        with patch(
-            "helion.runtime.kernel.target_device_capability", return_value=(10, 0)
+        with (
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch(
+                "helion.runtime.kernel.compiler_promotion_specialization_key",
+                return_value=(),
+            ),
         ):
             sm100_key = device_key_kernel._base_specialization_key((device,))
 
         self.assertEqual(sm90_key[-3:], ("cuda", (9, 0), False))
         self.assertEqual(sm100_key[-3:], ("cuda", (10, 0), False))
         self.assertNotEqual(sm90_key, sm100_key)
+
+        promotion = (("synthetic", "NVIDIA B200"),)
+        with (
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch(
+                "helion.runtime.kernel.compiler_promotion_specialization_key",
+                return_value=promotion,
+            ),
+        ):
+            promoted_key = device_key_kernel._base_specialization_key((device,))
+        self.assertEqual(
+            promoted_key[-4:],
+            ("cuda", (10, 0), promotion, False),
+        )
 
     def test_config_constructor_signature_contains_expected_kwargs(self) -> None:
         # Keep this list in sync with public kwargs; removal/rename should fail tests
@@ -1015,6 +1052,46 @@ class TestHardwareConfigSpecRanges(TestCase):
         self.assertEqual(nvidia_spec.store_cache_modifiers.inner.choices, ("",))
 
 
+class TestConfigSpecNormalizedCopy(TestCase):
+    def test_nested_containers_are_copied_without_copying_opaque_leaves(self) -> None:
+        class NonCopyable:
+            def __deepcopy__(self, memo: object) -> None:
+                raise AssertionError("opaque config leaves must not be deep-copied")
+
+        spec = ConfigSpec(
+            backend=TritonBackend(),
+            user_defined_tunables={"metadata": EnumFragment((None,))},
+        )
+        spec.loop_orders.append(LoopOrderSpec([0, 1]))
+        opaque = NonCopyable()
+        tensor = torch.empty(0)
+        requested = helion.Config(
+            loop_orders=[[0, 1]],
+            metadata={"nested": ([opaque, tensor],)},
+        )
+        requested_values = dict(requested.config)
+
+        normalized = spec.normalized_config(requested)
+
+        self.assertIsNot(normalized, requested)
+        self.assertEqual(requested.config, requested_values)
+        self.assertEqual(normalized.config["num_warps"], 4)
+        self.assertEqual(normalized.config["num_stages"], 1)
+        self.assertEqual(normalized.config["pid_type"], "flat")
+        normalized.loop_orders[0][0] = 1
+        normalized_metadata = cast("dict[str, object]", normalized["metadata"])
+        normalized_tuple = cast("tuple[object, ...]", normalized_metadata["nested"])
+        normalized_nested = cast("list[object]", normalized_tuple[0])
+        normalized_nested.append("normalized-only")
+        requested_metadata = cast("dict[str, object]", requested["metadata"])
+        requested_tuple = cast("tuple[object, ...]", requested_metadata["nested"])
+        requested_nested = cast("list[object]", requested_tuple[0])
+        self.assertEqual(requested.loop_orders, [[0, 1]])
+        self.assertEqual(len(requested_nested), 2)
+        self.assertIs(normalized_nested[0], opaque)
+        self.assertIs(normalized_nested[1], tensor)
+
+
 class TestCuteTcgen05ConfigSpecSplit(TestCase):
     @staticmethod
     def _make_cute_tcgen05_spec():
@@ -1033,6 +1110,135 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                 )
             )
         return spec
+
+    @staticmethod
+    def _make_permuted_cute_tcgen05_spec():
+        from helion._compiler.backend import CuteBackend
+        from helion.autotuner.config_spec import BlockSizeSpec
+        from helion.autotuner.config_spec import ConfigSpec
+
+        # Config order is [N, K, M], while semantic MMA axes are M=2, N=0, K=1.
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.cute_tcgen05_search_enabled = True
+        for block_id, max_size in enumerate((256, 128, 256)):
+            spec.block_sizes.append(
+                BlockSizeSpec(
+                    block_id=block_id,
+                    size_hint=4096,
+                    max_size=max_size,
+                )
+            )
+        spec.register_cute_tcgen05_mma_analysis(
+            m_block_id=2,
+            n_block_id=0,
+            k_block_id=1,
+            input_dtype=torch.bfloat16,
+            has_leading_passthrough=False,
+            explicit_epi_tile_compatible=True,
+        )
+        return spec
+
+    @staticmethod
+    def _register_default_cute_tcgen05_mma_analysis(spec):
+        spec.register_cute_tcgen05_mma_analysis(
+            m_block_id=0,
+            n_block_id=1,
+            k_block_id=2,
+            input_dtype=torch.bfloat16,
+            has_leading_passthrough=False,
+            explicit_epi_tile_compatible=True,
+        )
+        return spec
+
+    @staticmethod
+    def _add_cute_tcgen05_matmul_fact(
+        spec,
+        *,
+        static_k: int,
+        k_block_id: int = 2,
+    ) -> None:
+        spec.matmul_facts.append(
+            MatmulFact(
+                lhs_ndim=2,
+                rhs_ndim=3,
+                m_block_id=0,
+                n_block_id=1,
+                k_block_id=k_block_id,
+                static_m=256,
+                static_n=None,
+                static_k=static_k,
+                lhs_dtype=torch.bfloat16,
+                rhs_dtype=torch.bfloat16,
+            )
+        )
+
+    @staticmethod
+    def _grouped_worklist_config(
+        *,
+        block_sizes: tuple[int, int, int] | list[int] = (256, 128, 64),
+        source_m_tile: int = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        cluster_m: int = 2,
+        **overrides: Any,
+    ) -> helion.Config:
+        values: dict[str, Any] = {
+            "block_sizes": list(block_sizes),
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": cluster_m,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_grouped_mode": TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            "tcgen05_grouped_worklist_source_m_tile": source_m_tile,
+        }
+        values.update(overrides)
+        return helion.Config(**values)
+
+    def _grouped_worklist_generation(
+        self,
+        spec: Any,
+        *,
+        source_m_tile: int,
+        cluster_m: int = 2,
+    ) -> tuple[Any, list[Any], int, int, int]:
+        from helion.autotuner.config_generation import ConfigGeneration
+
+        spec.compiler_seed_configs = [
+            self._grouped_worklist_config(
+                source_m_tile=source_m_tile,
+                cluster_m=cluster_m,
+            )
+        ]
+        generation = ConfigGeneration(spec)
+        [(flat, _normalized)] = generation.seed_flat_config_pairs()
+        _m_flat, n_flat, k_flat = generation.block_size_indices[:3]
+        [cluster_flat], _ = generation._key_to_flat_indices["tcgen05_cluster_m"]
+        return generation, flat, n_flat, k_flat, cluster_flat
+
+    def _constrained_grouped_worklist_spec(self, smem_budget: int) -> Any:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        spec._cute_tcgen05_config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=2,
+                per_cta_smem_budget_bytes=smem_budget,
+            )
+        )
+        return spec
+
+    @staticmethod
+    def _enum_fragment(fragment: object) -> EnumFragment:
+        assert isinstance(fragment, EnumFragment)
+        return fragment
+
+    def test_normalized_config_drops_none_core_values(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+        requested = helion.Config.from_dict(
+            {"block_sizes": [256, 128, 128], "xcd_remap": None}
+        )
+
+        normalized = spec.normalized_config(requested)
+
+        self.assertNotIn("xcd_remap", normalized.config)
+        self.assertIsNone(requested.config["xcd_remap"])
 
     def test_grouped_static_seed_representation(self) -> None:
         from helion.autotuner.config_generation import ConfigGeneration
@@ -1100,7 +1306,10 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             wrong_type_config.config[
                 TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
             ] = invalid_value
-            with self.assertRaisesRegex(exc.InvalidConfig, "source_m_tile"):
+            with self.assertRaisesRegex(
+                exc.InvalidConfig,
+                r"source_m_tile.*\(32, 224, 256\)",
+            ):
                 spec.normalize(wrong_type_config)
 
         invalid = helion.Config(
@@ -1119,122 +1328,116 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
     def test_grouped_runtime_direct_normalization(self) -> None:
         spec = self._make_cute_tcgen05_spec()
         spec.target_device_capability = (10, 0)
+
+        def grouped_config(
+            *,
+            block_k: int = 64,
+            grouped_mode: str = TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            runtime_direct: bool = True,
+            clc: bool = False,
+            static_signature: bool = False,
+        ) -> helion.Config:
+            config = helion.Config(
+                block_sizes=[256, 128, block_k],
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=grouped_mode,
+                tcgen05_grouped_runtime_direct=runtime_direct,
+                **(
+                    {
+                        "tcgen05_strategy": "role_local_with_scheduler",
+                        "tcgen05_warp_spec_scheduler_warps": 1,
+                        "tcgen05_persistence_model": "clc_persistent",
+                    }
+                    if clc
+                    else {}
+                ),
+            )
+            if static_signature:
+                config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+                    1,
+                    256,
+                    128,
+                    64,
+                ]
+            return config
+
+        def rejected_and_repaired(
+            factory: Callable[[], helion.Config], message: str
+        ) -> helion.Config:
+            with self.assertRaisesRegex(exc.InvalidConfig, message):
+                spec.normalize(factory())
+            repaired = factory()
+            spec.normalize(repaired, _fix_invalid=True)
+            return repaired
+
         for enabled in (False, True):
             with self.subTest(enabled=enabled):
-                config = helion.Config(
-                    block_sizes=[256, 128, 128],
-                    pid_type="persistent_interleaved",
-                    tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-                    tcgen05_grouped_runtime_direct=enabled,
-                )
+                config = grouped_config(block_k=128, runtime_direct=enabled)
                 spec.normalize(config)
                 self.assertIs(
                     config.config[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY],
                     enabled,
                 )
 
-        invalid = helion.Config(
-            block_sizes=[256, 128, 128],
-            pid_type="persistent_interleaved",
-            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-            tcgen05_grouped_runtime_direct=True,
-        )
+        invalid = grouped_config(block_k=128)
         invalid.config[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = 1
         with self.assertRaisesRegex(exc.InvalidConfig, "must be a boolean"):
             spec.normalize(invalid)
 
-        def unsupported_runtime_direct(
-            *,
-            grouped_mode: str = TCGEN05_GROUPED_MODE_DYNAMIC,
-            static_signature: bool = False,
-        ) -> helion.Config:
-            config = helion.Config(
-                block_sizes=[256, 128, 64],
-                pid_type="persistent_interleaved",
-                tcgen05_grouped_mode=grouped_mode,
-                tcgen05_grouped_runtime_direct=True,
-            )
-            if static_signature:
-                config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
-                    1,
-                    256,
-                    128,
-                    64,
-                ]
-            return config
-
         unsupported_cases = (
-            (TCGEN05_GROUPED_MODE_DYNAMIC, False),
-            (TCGEN05_GROUPED_MODE_WORKLIST_NM, True),
+            {"grouped_mode": TCGEN05_GROUPED_MODE_DYNAMIC},
+            {"static_signature": True},
         )
-        for grouped_mode, static_signature in unsupported_cases:
-            unsupported = unsupported_runtime_direct(
-                grouped_mode=grouped_mode,
-                static_signature=static_signature,
-            )
-            with (
-                self.subTest(config=unsupported.config),
-                self.assertRaisesRegex(
-                    exc.InvalidConfig,
+        for case in unsupported_cases:
+            with self.subTest(unsupported=case):
+                repaired = rejected_and_repaired(
+                    lambda case=case: grouped_config(**case),
                     "must not silently fall back",
-                ),
-            ):
-                spec.normalize(unsupported)
-            repaired = unsupported_runtime_direct(
-                grouped_mode=grouped_mode,
-                static_signature=static_signature,
-            )
-            spec.normalize(repaired, _fix_invalid=True)
+                )
             self.assertNotIn(
                 TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
                 repaired.config,
             )
 
-        def clc_config(
-            *,
-            grouped_mode: str = TCGEN05_GROUPED_MODE_WORKLIST_NM,
-            runtime_direct: bool = True,
-            static_signature: bool = False,
-        ) -> helion.Config:
-            config = helion.Config(
-                block_sizes=[256, 128, 64],
-                pid_type="persistent_interleaved",
-                tcgen05_grouped_mode=grouped_mode,
-                tcgen05_grouped_runtime_direct=runtime_direct,
-                tcgen05_strategy="role_local_with_scheduler",
-                tcgen05_warp_spec_scheduler_warps=1,
-                tcgen05_persistence_model="clc_persistent",
+        for fix_invalid in (False, True):
+            valid_clc = grouped_config(clc=True)
+            spec.normalize(valid_clc, _fix_invalid=fix_invalid)
+            self.assertEqual(
+                valid_clc.config["tcgen05_persistence_model"], "clc_persistent"
             )
-            if static_signature:
-                config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
-                    1,
-                    256,
-                    128,
-                    64,
-                ]
-            return config
+            self.assertEqual(valid_clc.config["tcgen05_warp_spec_scheduler_warps"], 1)
 
-        valid_clc = clc_config()
-        spec.normalize(valid_clc)
-        self.assertEqual(
-            valid_clc.config["tcgen05_persistence_model"], "clc_persistent"
+        invalid_clc_cases = (
+            {"runtime_direct": False},
+            {"grouped_mode": TCGEN05_GROUPED_MODE_DYNAMIC},
+            {"static_signature": True},
         )
-        self.assertEqual(valid_clc.config["tcgen05_warp_spec_scheduler_warps"], 1)
-
-        invalid_clc_configs = (
-            clc_config(runtime_direct=False),
-            clc_config(grouped_mode=TCGEN05_GROUPED_MODE_DYNAMIC),
-            clc_config(static_signature=True),
-        )
-        for invalid_clc in invalid_clc_configs:
-            with (
-                self.subTest(config=invalid_clc.config),
-                self.assertRaisesRegex(
-                    exc.InvalidConfig,
+        for case in invalid_clc_cases:
+            with self.subTest(invalid_clc=case):
+                repaired_clc = rejected_and_repaired(
+                    lambda case=case: grouped_config(clc=True, **case),
                     "exact one-record-per-cluster tile table",
-                ),
-            ):
-                spec.normalize(invalid_clc)
+                )
+            self.assertNotEqual(
+                repaired_clc.config.get("tcgen05_persistence_model"),
+                "clc_persistent",
+            )
+
+        repaired_with_reservation = grouped_config(clc=True, runtime_direct=False)
+        repaired_with_reservation.config[
+            TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+        ] = 52
+        spec.normalize(repaired_with_reservation, _fix_invalid=True)
+        self.assertNotEqual(
+            repaired_with_reservation.config.get("tcgen05_persistence_model"),
+            "clc_persistent",
+        )
+        self.assertEqual(
+            repaired_with_reservation.config[
+                TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+            ],
+            52,
+        )
 
     def test_grouped_worklist_panel_requires_runtime_direct(self) -> None:
         spec = self._make_cute_tcgen05_spec()
@@ -1310,23 +1513,20 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                 self.assertEqual(generation.unflatten(flat).config[key], expected)
 
     def test_grouped_worklist_one_cta_accepts_bk128_ab5(self) -> None:
-        spec = self._make_cute_tcgen05_spec()
-        config = helion.Config(
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        config = self._grouped_worklist_config(
             block_sizes=[256, 128, 128],
+            source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+            cluster_m=1,
             num_stages=7,
             num_warps=8,
-            pid_type="persistent_interleaved",
-            tcgen05_cluster_m=1,
-            tcgen05_cluster_n=1,
             tcgen05_ab_stages=5,
             tcgen05_acc_stages=2,
             tcgen05_c_stages=2,
             tcgen05_num_epi_warps=4,
             tcgen05_consumer_regs=256,
-            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-            tcgen05_grouped_worklist_source_m_tile=(
-                TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
-            ),
         )
 
         spec.normalize(config)
@@ -1356,13 +1556,9 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                     source_m_tile=source_m_tile,
                     block_k=block_k,
                 ):
-                    config = helion.Config(
+                    config = self._grouped_worklist_config(
                         block_sizes=[256, 128, block_k],
-                        pid_type="persistent_interleaved",
-                        tcgen05_cluster_m=2,
-                        tcgen05_cluster_n=1,
-                        tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-                        tcgen05_grouped_worklist_source_m_tile=source_m_tile,
+                        source_m_tile=source_m_tile,
                     )
 
                     spec.normalize(config, _fix_invalid=True)
@@ -1373,6 +1569,274 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                         config.config["pid_type"],
                         "persistent_interleaved",
                     )
+
+    def test_grouped_worklist_search_fix_projects_semantic_tile(self) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        cases = (
+            (32, 1, [128, 256, 32], [256, 128, 64], 1),
+            (32, 2, [128, 256, 256], [256, 128, 128], 2),
+            # BK=96 is equidistant; the deterministic tie breaks toward 64.
+            (224, 1, [128, 256, 96], [256, 128, 64], 2),
+            # Exact canary family: a BN neighbor must return to logical BN=128.
+            (224, 2, [256, 256, 128], [256, 128, 128], 2),
+            (256, 1, [64, 64, 256], [256, 128, 128], 2),
+        )
+        for source_m_tile, cluster_m, block_sizes, expected, expected_cluster in cases:
+            with self.subTest(
+                source_m_tile=source_m_tile,
+                cluster_m=cluster_m,
+                block_sizes=block_sizes,
+            ):
+                config = self._grouped_worklist_config(
+                    block_sizes=[*block_sizes],
+                    source_m_tile=source_m_tile,
+                    cluster_m=cluster_m,
+                )
+
+                spec._cute_tcgen05_config.fix_search_config(config.config)
+
+                self.assertEqual(config.block_sizes[:3], expected)
+                self.assertEqual(config.config["tcgen05_cluster_m"], expected_cluster)
+
+    def test_grouped_worklist_search_fix_rejects_no_divisible_block_k(self) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        spec.allow_tcgen05_cluster_m2_search(static_k=96)
+        config = self._grouped_worklist_config(
+            block_sizes=[256, 256, 128],
+            source_m_tile=224,
+        )
+
+        with self.assertRaisesRegex(exc.InvalidConfig, "no supported block_k"):
+            spec.normalize(config, _fix_invalid=True)
+
+    def test_grouped_worklist_cluster_m1_fix_uses_semantic_axes(self) -> None:
+        spec = self._make_permuted_cute_tcgen05_spec()
+        config = self._grouped_worklist_config(
+            # Semantic [M, N, K] is [256, 128, 64].
+            block_sizes=[128, 64, 256],
+            source_m_tile=32,
+            cluster_m=1,
+        )
+
+        spec._cute_tcgen05_config.fix_search_config(config.config)
+
+        self.assertEqual(config.block_sizes, [128, 64, 256])
+        self.assertEqual(config.config["tcgen05_cluster_m"], 1)
+
+    def test_grouped_worklist_deep_ab_uses_semantic_axes(self) -> None:
+        spec = self._make_permuted_cute_tcgen05_spec()
+        config = self._grouped_worklist_config(
+            # Semantic [M, N, K] is [256, 128, 128].
+            block_sizes=[128, 128, 256],
+            source_m_tile=32,
+            cluster_m=1,
+            num_stages=7,
+            num_warps=8,
+            tcgen05_ab_stages=5,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_consumer_regs=256,
+        )
+
+        spec.normalize(config)
+
+        self.assertEqual(config.block_sizes, [128, 128, 256])
+        self.assertEqual(config.config["tcgen05_ab_stages"], 5)
+
+        positional_decoy = helion.Config.from_dict(config.config)
+        positional_decoy.config["block_sizes"] = [256, 128, 64]
+        with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
+            spec.normalize(positional_decoy)
+
+    def test_grouped_worklist_config_generation_canonicalizes_neighbors(
+        self,
+    ) -> None:
+        cases = (
+            (32, 1, 256, 32, 1, 64),
+            (32, 2, 256, 256, 2, 128),
+            (224, 1, 256, 32, 2, 64),
+            (224, 2, 256, 128, 2, 128),
+            (256, 1, 64, 256, 2, 128),
+        )
+        for (
+            source_m_tile,
+            sampled_cluster,
+            sampled_bn,
+            sampled_bk,
+            expected_cluster,
+            expected_bk,
+        ) in cases:
+            with self.subTest(
+                source_m_tile=source_m_tile,
+                sampled_cluster=sampled_cluster,
+                sampled_bk=sampled_bk,
+            ):
+                spec = self._register_default_cute_tcgen05_mma_analysis(
+                    self._make_cute_tcgen05_spec()
+                )
+                generation, flat, n_flat, k_flat, cluster_flat = (
+                    self._grouped_worklist_generation(
+                        spec,
+                        source_m_tile=source_m_tile,
+                    )
+                )
+                neighbor = [*flat]
+                neighbor[n_flat] = sampled_bn
+                neighbor[k_flat] = sampled_bk
+                neighbor[cluster_flat] = sampled_cluster
+
+                canonical_flat, normalized = generation.canonicalize_flat(neighbor)
+
+                self.assertEqual(normalized.block_sizes[:3], [256, 128, expected_bk])
+                self.assertEqual(
+                    normalized.config["tcgen05_cluster_m"], expected_cluster
+                )
+                self.assertEqual(canonical_flat[n_flat], 128)
+                self.assertEqual(canonical_flat[k_flat], expected_bk)
+                self.assertEqual(canonical_flat[cluster_flat], expected_cluster)
+
+    def test_grouped_worklist_config_generation_uses_fact_static_k(self) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        self._add_cute_tcgen05_matmul_fact(spec, static_k=192)
+        # A fact for another semantic K block must not constrain this MMA.
+        self._add_cute_tcgen05_matmul_fact(
+            spec,
+            static_k=96,
+            k_block_id=1,
+        )
+        self.assertIsNone(spec._cute_tcgen05_config.cluster_m2_search_constraints)
+        generation, flat, _n_flat, k_flat, _cluster_flat = (
+            self._grouped_worklist_generation(
+                spec,
+                source_m_tile=224,
+            )
+        )
+        neighbor = [*flat]
+        neighbor[k_flat] = 128
+
+        canonical_flat, normalized = generation.canonicalize_flat(neighbor)
+
+        self.assertEqual(normalized.block_sizes[:3], [256, 128, 64])
+        self.assertEqual(canonical_flat[k_flat], 64)
+
+    def test_grouped_worklist_fact_static_k_rejects_without_constraints(
+        self,
+    ) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        self._add_cute_tcgen05_matmul_fact(spec, static_k=96)
+        self.assertIsNone(spec._cute_tcgen05_config.cluster_m2_search_constraints)
+        config = self._grouped_worklist_config(source_m_tile=224)
+
+        with self.assertRaisesRegex(exc.InvalidConfig, "no supported block_k"):
+            spec.normalize(config, _fix_invalid=True)
+
+    def test_grouped_worklist_config_generation_respects_k_constraints(
+        self,
+    ) -> None:
+        cases = (
+            # BK128 does not divide K192, so choose the exact BK64 profile.
+            (192, None, False, 224, 2, 1, 128, 2, 64),
+            # Generic max-K-tile limits must not rewrite a valid one-CTA BK64.
+            (32768, None, False, 32, 1, 1, 64, 1, 64),
+            # Generic edge-tail policy must not select a non-dividing worklist BK.
+            (192, None, True, 224, 2, 2, 128, 2, 64),
+            # The source-32 two-CTA profile owns the same exact-divisibility rule.
+            (192, None, True, 32, 2, 2, 128, 2, 64),
+            # Generic constraints and matching semantic facts are intersected.
+            (256, 192, False, 224, 2, 2, 128, 2, 64),
+        )
+        for (
+            static_k,
+            fact_static_k,
+            allow_edge_k_tail_family,
+            source_m_tile,
+            seed_cluster,
+            sampled_cluster,
+            sampled_bk,
+            expected_cluster,
+            expected_bk,
+        ) in cases:
+            with self.subTest(
+                static_k=static_k,
+                allow_edge_k_tail_family=allow_edge_k_tail_family,
+                source_m_tile=source_m_tile,
+                sampled_cluster=sampled_cluster,
+            ):
+                spec = self._register_default_cute_tcgen05_mma_analysis(
+                    self._make_cute_tcgen05_spec()
+                )
+                if fact_static_k is not None:
+                    self._add_cute_tcgen05_matmul_fact(
+                        spec,
+                        static_k=fact_static_k,
+                    )
+                spec.allow_tcgen05_cluster_m2_search(
+                    static_k=static_k,
+                    allow_edge_k_tail_family=allow_edge_k_tail_family,
+                )
+                generation, flat, n_flat, k_flat, cluster_flat = (
+                    self._grouped_worklist_generation(
+                        spec,
+                        source_m_tile=source_m_tile,
+                        cluster_m=seed_cluster,
+                    )
+                )
+                neighbor = [*flat]
+                neighbor[n_flat] = 256
+                neighbor[k_flat] = sampled_bk
+                neighbor[cluster_flat] = sampled_cluster
+
+                canonical_flat, normalized = generation.canonicalize_flat(neighbor)
+
+                self.assertEqual(normalized.block_sizes[:3], [256, 128, expected_bk])
+                self.assertEqual(
+                    normalized.config["tcgen05_cluster_m"], expected_cluster
+                )
+                self.assertEqual(canonical_flat[n_flat], 128)
+                self.assertEqual(canonical_flat[k_flat], expected_bk)
+                self.assertEqual(canonical_flat[cluster_flat], expected_cluster)
+
+    def test_grouped_worklist_two_cta_seed_survives_without_generic_constraints(
+        self,
+    ) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        self.assertIsNone(spec._cute_tcgen05_config.cluster_m2_search_constraints)
+
+        for source_m_tile in (
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+        ):
+            with self.subTest(source_m_tile=source_m_tile):
+                generation, flat, _n_flat, _k_flat, _cluster_flat = (
+                    self._grouped_worklist_generation(
+                        spec,
+                        source_m_tile=source_m_tile,
+                    )
+                )
+                [seed] = spec.compiler_seed_configs
+                spec.compiler_default_config = seed
+
+                effective = spec.default_config()
+                self.assertEqual(effective.config["tcgen05_cluster_m"], 2)
+                self.assertEqual(effective.config["block_sizes"][:3], [256, 128, 64])
+
+                [(seed_flat, normalized)] = generation.seed_flat_config_pairs()
+                self.assertEqual(seed_flat, flat)
+                self.assertEqual(normalized.config["tcgen05_cluster_m"], 2)
+                unflattened = generation.unflatten([*flat])
+                self.assertEqual(unflattened.config["tcgen05_cluster_m"], 2)
+                self.assertEqual(unflattened.config["block_sizes"][:3], [256, 128, 64])
 
     def test_tcgen05_search_fields_do_not_leak_to_other_backends(self) -> None:
         from helion._compiler.backend import MetalBackend
@@ -1649,39 +2113,40 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
 
     def test_deep_ab_stage_mode_envelopes_and_stage7_roundtrip(self) -> None:
         def selected_config() -> helion.Config:
-            return helion.Config(
-                block_sizes=[256, 128, 64],
+            return self._grouped_worklist_config(
                 pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-                tcgen05_cluster_m=2,
+                num_stages=7,
+                num_warps=8,
                 tcgen05_ab_stages=7,
-                **{
-                    TCGEN05_GROUPED_MODE_CONFIG_KEY: (TCGEN05_GROUPED_MODE_WORKLIST_NM),
-                },
+                tcgen05_acc_stages=2,
+                tcgen05_c_stages=2,
+                tcgen05_num_epi_warps=4,
+                tcgen05_consumer_regs=240,
             )
 
-        spec = self._make_cute_tcgen05_spec()
-        grouped_ab4 = helion.Config(
-            block_sizes=[128, 64, 64],
-            pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            tcgen05_ab_stages=4,
-            **{
-                TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_DYNAMIC,
-            },
+        def dynamic_config(
+            ab_stages: int, c_stages: int | None = None
+        ) -> helion.Config:
+            config = helion.Config(
+                block_sizes=[128, 64, 64],
+                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+                tcgen05_ab_stages=ab_stages,
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_DYNAMIC,
+            )
+            if c_stages is not None:
+                config.config["tcgen05_c_stages"] = c_stages
+            return config
+
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
         )
+        grouped_ab4 = dynamic_config(4)
         spec.normalize(grouped_ab4)
         grouped_ab4.config["tcgen05_ab_stages"] = 4.0
         with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
             spec.normalize(grouped_ab4)
 
-        grouped_ab8 = helion.Config(
-            block_sizes=[128, 64, 64],
-            pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            tcgen05_ab_stages=8,
-            tcgen05_c_stages=4,
-            **{
-                TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_DYNAMIC,
-            },
-        )
+        grouped_ab8 = dynamic_config(8, 4)
         spec.normalize(grouped_ab8)
         self.assertEqual(grouped_ab8.config["tcgen05_ab_stages"], 8)
         minimized_ab8 = grouped_ab8.minimize(spec)
@@ -1690,15 +2155,7 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         self.assertEqual(minimized_ab8.config["tcgen05_c_stages"], 4)
 
         for ab_stages, c_stages in ((8, 2), (4, 4)):
-            mismatched = helion.Config(
-                block_sizes=[128, 64, 64],
-                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-                tcgen05_ab_stages=ab_stages,
-                tcgen05_c_stages=c_stages,
-            )
-            mismatched.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = (
-                TCGEN05_GROUPED_MODE_DYNAMIC
-            )
+            mismatched = dynamic_config(ab_stages, c_stages)
             with (
                 self.subTest(ab_stages=ab_stages, c_stages=c_stages),
                 self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"),
@@ -1707,6 +2164,8 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
 
         config = selected_config()
         spec.normalize(config)
+        self.assertEqual(config.block_sizes, [256, 128, 64])
+        self.assertEqual(config.config["tcgen05_ab_stages"], 7)
         minimized = config.minimize(spec)
         self.assertNotIn("tcgen05_cluster_n", minimized.config)
         self.assertNotIn("tcgen05_acc_stages", minimized.config)
@@ -1714,13 +2173,7 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         spec.normalize(minimized)
         self.assertEqual(minimized.config["tcgen05_ab_stages"], 7)
 
-        constrained_spec = self._make_cute_tcgen05_spec()
-        constrained_spec._cute_tcgen05_config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
-                dtype_bytes=2,
-                per_cta_smem_budget_bytes=1,
-            )
-        )
+        constrained_spec = self._constrained_grouped_worklist_spec(1)
         with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
             constrained_spec.normalize(selected_config())
 
@@ -1728,14 +2181,25 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         self,
     ) -> None:
         def selected_config(source_m_tile: int, ab_stages: int) -> helion.Config:
-            return helion.Config(
-                block_sizes=[256, 128, 64],
+            return self._grouped_worklist_config(
+                source_m_tile=source_m_tile,
                 pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-                tcgen05_cluster_m=2,
                 tcgen05_ab_stages=ab_stages,
-                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-                tcgen05_grouped_worklist_source_m_tile=source_m_tile,
             )
+
+        for invalid_cluster_m in (True, 4):
+            with self.subTest(invalid_cluster_m=invalid_cluster_m):
+                invalid = selected_config(
+                    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+                    7,
+                )
+                invalid.config["tcgen05_cluster_m"] = invalid_cluster_m
+                self.assertIsNone(
+                    resolve_tcgen05_grouped_worklist_mma_profile(
+                        invalid,
+                        block_k=64,
+                    )
+                )
 
         b200_capacity_bytes = TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN
         constrained_budget_bytes = (
@@ -1752,20 +2216,20 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                 ab_stages=ab_stages,
                 should_fit=should_fit,
             ):
-                physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
-                    cluster_m=2,
+                config = selected_config(source_m_tile, ab_stages)
+                profile = resolve_tcgen05_grouped_worklist_mma_profile(
+                    config,
                     block_k=64,
-                    source_m_tile=source_m_tile,
                 )
-                self.assertEqual(physical_shape, (256, source_m_tile))
-                assert physical_shape is not None
+                assert profile is not None
+                self.assertEqual((profile.mma_m, profile.mma_n), (256, source_m_tile))
                 self.assertEqual(
                     tcgen05_grouped_worklist_smem_bytes(
                         group_count=1,
                         device_split_sizes=False,
                         sched_stage_count=1,
-                        bm=physical_shape[0],
-                        bn=physical_shape[1],
+                        bm=profile.mma_m,
+                        bn=profile.mma_n,
                         bk=64,
                         dtype_bytes=2,
                         ab_stages=ab_stages,
@@ -1776,18 +2240,82 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                     required_bytes,
                 )
 
-                spec = self._make_cute_tcgen05_spec()
-                spec._cute_tcgen05_config.ab_stages_three_search_constraints = (
-                    Tcgen05AbStagesThreeSearchConstraints(
-                        dtype_bytes=2,
-                        per_cta_smem_budget_bytes=constrained_budget_bytes,
-                    )
+                spec = self._constrained_grouped_worklist_spec(constrained_budget_bytes)
+                spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+                    group_count=1,
+                    device_split_sizes=False,
                 )
                 if should_fit:
-                    spec.normalize(selected_config(source_m_tile, ab_stages))
+                    spec.normalize(config)
                 else:
                     with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
-                        spec.normalize(selected_config(source_m_tile, ab_stages))
+                        spec.normalize(config)
+
+    def test_grouped_worklist_deep_ab_normalization_uses_device_split_facts(
+        self,
+    ) -> None:
+        config = self._grouped_worklist_config(
+            pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            tcgen05_ab_stages=7,
+        )
+        constrained_budget_bytes = (
+            TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN
+            - TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
+        )
+        for group_count, should_fit in ((20, True), (21, False)):
+            with self.subTest(group_count=group_count, should_fit=should_fit):
+                spec = self._constrained_grouped_worklist_spec(constrained_budget_bytes)
+                spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+                    group_count=group_count,
+                    device_split_sizes=True,
+                )
+                if should_fit:
+                    spec.normalize(helion.Config.from_dict(config.config))
+                else:
+                    with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
+                        spec.normalize(helion.Config.from_dict(config.config))
+
+    def test_reviewed_grouped_worklist_seeds_fit_conservative_b200_smem(self) -> None:
+        seed_inputs = (
+            (6, 6 * 32, 4096, 4096, "k", 32),
+            (6, 6 * 224, 7168, 3072, "k", 224),
+            (8, 8 * 4096, 4096, 2048, "k", 256),
+            (8, 8 * 4096, 4096, 2048, "n", 256),
+        )
+        reviewed_configs = [
+            config
+            for groups, packed_m, n, k, b_major, source_m_tile in seed_inputs
+            for config in tcgen05_grouped_worklist_seed_configs(
+                groups=groups,
+                packed_m=packed_m,
+                n=n,
+                k=k,
+                b_major=b_major,
+                source_m_tile=source_m_tile,
+                num_sm=148,
+            )
+        ]
+        spec = self._constrained_grouped_worklist_spec(
+            TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN
+            - TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
+        )
+        spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+            group_count=8,
+            device_split_sizes=False,
+        )
+
+        for config in reviewed_configs:
+            with self.subTest(config=config.config):
+                ab_stages = config.config["tcgen05_ab_stages"]
+                assert isinstance(ab_stages, int)
+                # AB1-3 use the ordinary admission path; deeper reviewed seeds
+                # must pass the conservative all-scheduler SMEM upper bound.
+                self.assertTrue(
+                    ab_stages < 4
+                    or spec._cute_tcgen05_config._grouped_worklist_nm_ab_config_matches(
+                        config.config, ab_stages
+                    )
+                )
 
     def test_grouped_dynamic_deep_stage_smem_accounts_for_output_dtype(self) -> None:
         from helion._compiler.backend import CuteBackend
@@ -1876,10 +2404,7 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         tcgen05_config = spec._cute_tcgen05_config
 
         def choices(fragments: Mapping[str, object], key: str) -> tuple[object, ...]:
-            fragment = fragments[key]
-            self.assertIsInstance(fragment, EnumFragment)
-            assert isinstance(fragment, EnumFragment)
-            return fragment.choices
+            return self._enum_fragment(fragments[key]).choices
 
         narrow = tcgen05_config.strategy_autotune_fragments()
         self.assertEqual(
@@ -1897,6 +2422,174 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             choices(widened, "tcgen05_warp_spec_c_input_warps"),
             (0, 1),
         )
+
+    def test_compiler_seed_fragments_preserve_base_search_choices(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+        spec.compiler_seed_configs = [
+            helion.Config(
+                pid_type="flat",
+                tcgen05_consumer_regs=240,
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+                tcgen05_persistence_model="non_persistent",
+            ),
+            helion.Config(
+                pid_type="persistent_interleaved",
+                tcgen05_persistence_model="clc_persistent",
+            ),
+            helion.Config.from_dict(
+                {
+                    "tcgen05_consumer_regs": True,
+                    "tcgen05_strategy": "invalid",
+                    "tcgen05_warp_spec_scheduler_warps": True,
+                    "tcgen05_persistence_model": "invalid",
+                }
+            ),
+        ]
+        tcgen05_config = spec._cute_tcgen05_config
+
+        consumer = self._enum_fragment(
+            tcgen05_config.consumer_regs_autotune_fragments()["tcgen05_consumer_regs"]
+        )
+        strategy = tcgen05_config.strategy_autotune_fragments()
+        persistence = self._enum_fragment(
+            tcgen05_config.persistence_model_autotune_fragments()[
+                "tcgen05_persistence_model"
+            ]
+        )
+        strategy_fragment = self._enum_fragment(strategy["tcgen05_strategy"])
+        scheduler_fragment = self._enum_fragment(
+            strategy["tcgen05_warp_spec_scheduler_warps"]
+        )
+
+        self.assertEqual(consumer.choices, (256, 240))
+        self.assertEqual(consumer.search_choices, (256,))
+        self.assertEqual(
+            strategy_fragment.choices,
+            ("role_local_monolithic", "role_local_with_scheduler"),
+        )
+        self.assertEqual(strategy_fragment.search_choices, ("role_local_monolithic",))
+        self.assertEqual(scheduler_fragment.choices, (0, 1))
+        self.assertEqual(scheduler_fragment.search_choices, (0,))
+        self.assertEqual(
+            persistence.choices,
+            ("non_persistent", "static_persistent", "clc_persistent"),
+        )
+        self.assertEqual(
+            persistence.search_choices,
+            ("non_persistent", "static_persistent"),
+        )
+
+    def test_default_seed_values_do_not_add_degenerate_fragments(self) -> None:
+        baseline = self._make_cute_tcgen05_spec()
+        baseline_hash = baseline.structural_fingerprint_hash()
+
+        spec = self._make_cute_tcgen05_spec()
+        spec.compiler_seed_configs = [
+            helion.Config(
+                pid_type="flat",
+                tcgen05_consumer_regs=256,
+                tcgen05_persistence_model="non_persistent",
+            )
+        ]
+        fields = spec._cute_tcgen05_config.flat_fields()
+
+        self.assertNotIn("tcgen05_consumer_regs", fields)
+        self.assertNotIn("tcgen05_persistence_model", fields)
+        self.assertEqual(spec.structural_fingerprint_hash(), baseline_hash)
+
+        spec.compiler_seed_configs = [
+            helion.Config(
+                pid_type="flat",
+                tcgen05_persistence_model="static_persistent",
+            )
+        ]
+        persistence = self._enum_fragment(
+            spec._cute_tcgen05_config.flat_fields()["tcgen05_persistence_model"]
+        )
+        self.assertEqual(
+            persistence.choices,
+            ("non_persistent", "static_persistent"),
+        )
+        self.assertIsNone(persistence.search_choices)
+        self.assertNotEqual(spec.structural_fingerprint_hash(), baseline_hash)
+        self.assertIn(
+            (
+                "tcgen05_persistence_model",
+                "enum",
+                repr("non_persistent"),
+                repr("static_persistent"),
+            ),
+            spec.structural_fingerprint(),
+        )
+
+    def test_mixed_grouped_persistence_seed_search_domain(self) -> None:
+        from helion.autotuner.config_generation import ConfigGeneration
+
+        spec = self._make_cute_tcgen05_spec()
+        spec.target_device_capability = (10, 0)
+        spec.allowed_pid_types = ("flat",)
+        spec.compiler_seed_configs = [
+            helion.Config(
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                tcgen05_grouped_runtime_direct=True,
+            ),
+            helion.Config(
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                tcgen05_grouped_runtime_direct=True,
+                tcgen05_persistence_model="clc_persistent",
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+            ),
+        ]
+
+        generation = ConfigGeneration(spec)
+        [persistence_index], _ = generation._key_to_flat_indices[
+            "tcgen05_persistence_model"
+        ]
+        persistence = self._enum_fragment(generation.flat_spec[persistence_index])
+        self.assertEqual(
+            persistence.choices,
+            ("non_persistent", "static_persistent", "clc_persistent"),
+        )
+        self.assertEqual(
+            persistence.search_choices,
+            ("non_persistent",),
+        )
+        self.assertEqual(
+            persistence.search_values(),
+            ["non_persistent"],
+        )
+        self.assertIn(
+            (
+                "tcgen05_persistence_model",
+                "enum",
+                repr("non_persistent"),
+                repr("static_persistent"),
+                repr("clc_persistent"),
+                "search",
+                repr("non_persistent"),
+            ),
+            spec.structural_fingerprint(),
+        )
+
+        pairs = generation.seed_flat_config_pairs()
+        self.assertEqual(len(pairs), 2)
+        by_model = {
+            normalized.config["tcgen05_persistence_model"]: flat
+            for flat, normalized in pairs
+        }
+        self.assertEqual(set(by_model), {"static_persistent", "clc_persistent"})
+        feature_dim = sum(fragment.dim() for fragment in generation.flat_spec)
+        for flat in by_model.values():
+            self.assertEqual(len(generation.encode_config(flat)), feature_dim)
+        for model in ("static_persistent", "clc_persistent"):
+            self.assertEqual(
+                persistence.pattern_neighbors(by_model[model][persistence_index]),
+                ["non_persistent"],
+            )
 
 
 if __name__ == "__main__":

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6,7 +6,8 @@ import dataclasses
 from dataclasses import dataclass
 import gc
 import importlib
-import linecache
+import inspect
+import logging
 import math
 import os
 from pathlib import Path
@@ -2337,6 +2338,31 @@ def _launch_entry(
     return helion_runtime._CuteLaunchArgCacheEntry(
         schema, launch_args, (), owned_tensors
     )
+
+
+def _grouped_metadata_plan(**overrides: object) -> dict[str, object]:
+    plan: dict[str, object] = {
+        "kind": "tcgen05_grouped_static_persistent",
+        "layout_idx": 0,
+        "n_sizes_idx": 1,
+        "group_count": 2,
+        "bm": 128,
+        "bn": 64,
+        "bk": 128,
+        "n_size": 256,
+        "k_total_size": 128,
+        "problem_sizes_arg": "problem_sizes",
+        "starts_arg": "starts",
+        "total_clusters_arg": "total_clusters",
+    }
+    plan.update(overrides)
+    return plan
+
+
+def _cute_kernel_for_plan(plan: Any) -> Any:
+    kernel = type("DummyCuteKernel", (), {})()
+    kernel._helion_cute_wrapper_plans = [plan]
+    return kernel
 
 
 def _runtime_identity_kernel() -> Any:
@@ -7077,8 +7103,14 @@ class TestCuteBackend(TestCase):
             torch.randn(4, 64, 256, device=DEVICE, dtype=HALF_DTYPE),
             torch.randn(4, 64, 256, device=DEVICE, dtype=HALF_DTYPE),
         )
+        cute_batched_dot_tcgen05.reset()
         with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
-            clean_bound = cute_batched_dot_tcgen05.bind(clean)
+            with patch(
+                "helion._compiler.cute.cute_mma."
+                "_analyze_rank3_rhs_grouped_search_operands",
+                side_effect=AssertionError("grouped-RHS fallback must not run"),
+            ):
+                clean_bound = cute_batched_dot_tcgen05.bind(clean)
             rejected_bound = cute_transposed_operand_batched_dot_tcgen05.bind(rejected)
             shifted_bound = cute_shifted_batched_dot_tcgen05.bind(clean)
             # Same rank (3-D dot), opposite enablement -> the gate is structural.
@@ -8395,22 +8427,16 @@ class TestCuteBackend(TestCase):
     def test_grouped_static_active_clusters_honors_reserved_sms(self) -> None:
         launcher = importlib.import_module("helion.runtime.cute.launcher")
 
-        self.assertEqual(
-            launcher._tcgen05_grouped_static_active_clusters(
-                num_sm=148,
-                cluster_m=1,
-                reserved_sms=0,
-            ),
-            148,
-        )
-        self.assertEqual(
-            launcher._tcgen05_grouped_static_active_clusters(
-                num_sm=148,
-                cluster_m=2,
-                reserved_sms=4,
-            ),
-            72,
-        )
+        for cluster_m, reserved_sms, expected in ((1, 0, 148), (2, 4, 72)):
+            with self.subTest(cluster_m=cluster_m, reserved_sms=reserved_sms):
+                self.assertEqual(
+                    launcher._tcgen05_grouped_static_active_clusters(
+                        num_sm=148,
+                        cluster_m=cluster_m,
+                        reserved_sms=reserved_sms,
+                    ),
+                    expected,
+                )
 
     def test_cute_launcher_reuses_compiled_wrapper(self) -> None:
         cute_kernel = type("DummyCuteKernel", (), {})()
@@ -8453,17 +8479,6 @@ class TestCuteBackend(TestCase):
     def test_cute_runtime_leading_extent_wrapper_bakes_tail_layout(self) -> None:
         launcher = importlib.import_module("helion.runtime.cute.launcher")
         cute_kernel = type("DummyCuteKernel", (), {})()
-        captured_source: list[str] = []
-        wrapper = object()
-
-        def fake_exec(code: Any, namespace: dict[str, Any]) -> None:
-            source = "".join(linecache.getlines(code.co_filename))
-            captured_source.append(source)
-            definition = next(
-                line for line in source.splitlines() if line.startswith("def ")
-            )
-            namespace[definition[4:].split("(", 1)[0]] = wrapper
-
         schema = (
             (
                 "wrapper_tensor_runtime_leading_extent",
@@ -8474,16 +8489,8 @@ class TestCuteBackend(TestCase):
                 (10, 1),
             ),
         )
-        with patch("builtins.exec", side_effect=fake_exec):
-            created = launcher._create_cute_wrapper(
-                cute_kernel,
-                schema,
-                (32, 1, 1),
-            )
-
-        self.assertIs(created, wrapper)
-        self.assertEqual(len(captured_source), 1)
-        source = captured_source[0]
+        wrapper = launcher._create_cute_wrapper(cute_kernel, schema, (32, 1, 1))
+        source = inspect.getsource(wrapper)
         self.assertIn("runtime_tile_records_shape0: cutlass.Int64", source)
         self.assertNotIn("runtime_tile_records_shape1:", source)
         self.assertNotIn("runtime_tile_records_stride0:", source)
@@ -8492,142 +8499,6 @@ class TestCuteBackend(TestCase):
             "cute.make_layout((runtime_tile_records_shape0, 10), stride=(10, 1))",
             source,
         )
-
-    def test_grouped_runtime_tile_record_rows_reuse_compiled_launcher(self) -> None:
-        launcher = importlib.import_module("helion.runtime.cute.launcher")
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_disable_bake_tensor_shapes = True
-        plan = {
-            "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT.value,
-            "orientation": "nm",
-            "layout_idx": 0,
-            "problem_sizes_arg": "problem_sizes",
-            "starts_arg": "starts",
-            "runtime_tile_records_arg": "runtime_tile_records",
-            "total_clusters_arg": "total_clusters",
-        }
-        cute_kernel._helion_cute_wrapper_plans = [plan]
-        layout = torch.empty(2, dtype=torch.int32)
-        runtime_record_tensors = iter(
-            (
-                torch.empty((2, 10), dtype=torch.int32),
-                torch.empty((5, 10), dtype=torch.int32),
-                torch.empty((2, 11), dtype=torch.int32),
-                torch.empty((2, 20), dtype=torch.int32)[:, ::2],
-            )
-        )
-
-        class FakeMetadataResult:
-            def __init__(self, runtime_tile_records: torch.Tensor) -> None:
-                self.problem_sizes = torch.empty((2, 4), dtype=torch.int32)
-                self.starts = torch.empty(2, dtype=torch.int32)
-                self.real_groups = None
-                self.runtime_tile_records = runtime_tile_records
-                self.direct_pointers = None
-                self.direct_strides = None
-                self.total_clusters = int(runtime_tile_records.size(0))
-
-            def tensors(self) -> tuple[torch.Tensor, ...]:
-                return (
-                    self.problem_sizes,
-                    self.starts,
-                    self.runtime_tile_records,
-                )
-
-        class FakeMetadataEntry:
-            def __init__(self, runtime_tile_records: torch.Tensor) -> None:
-                self.result = FakeMetadataResult(runtime_tile_records)
-
-        def fake_metadata(*_args: object) -> FakeMetadataEntry:
-            return FakeMetadataEntry(next(runtime_record_tensors))
-
-        def fake_imports() -> tuple[object, object, object]:
-            def make_ptr(
-                _dtype: object,
-                data_ptr: int,
-                _space: object,
-                *,
-                assumed_align: int,
-            ) -> tuple[str, int]:
-                self.assertEqual(assumed_align, 16)
-                return ("ptr", data_ptr)
-
-            return object(), make_ptr, object()
-
-        with (
-            patch.object(launcher, "_validate_cute_launcher_tensor"),
-            patch.object(
-                launcher,
-                "_tcgen05_grouped_static_layout_arg",
-                return_value=layout,
-            ),
-            patch.object(
-                launcher,
-                "_build_tcgen05_grouped_static_metadata",
-                side_effect=fake_metadata,
-            ),
-            patch.object(
-                launcher,
-                "_get_cute_launcher_imports",
-                side_effect=fake_imports,
-            ),
-            patch.object(launcher, "_torch_dtype_to_cutlass", side_effect=str),
-        ):
-            first = launcher._build_cute_schema_and_args(
-                cute_kernel, (layout,), (1, 1, 1)
-            )
-            second = launcher._build_cute_schema_and_args(
-                cute_kernel, (layout,), (1, 1, 1)
-            )
-            changed_tail = launcher._build_cute_schema_and_args(
-                cute_kernel, (layout,), (1, 1, 1)
-            )
-            changed_stride = launcher._build_cute_schema_and_args(
-                cute_kernel, (layout,), (1, 1, 1)
-            )
-
-        self.assertEqual(first.schema, second.schema)
-        self.assertIn(
-            (
-                "wrapper_tensor_runtime_leading_extent",
-                "runtime_tile_records",
-                "torch.int32",
-                2,
-                (10,),
-                (10, 1),
-            ),
-            first.schema,
-        )
-        self.assertEqual(first.launch_args[-5], 2)
-        self.assertEqual(second.launch_args[-5], 5)
-        self.assertNotEqual(first.schema, changed_tail.schema)
-        self.assertNotEqual(first.schema, changed_stride.schema)
-        first_key = launcher._cute_compiled_launcher_discriminator(
-            first.schema, (32, 1, 1), None, None
-        )[0]
-        second_key = launcher._cute_compiled_launcher_discriminator(
-            second.schema, (32, 1, 1), None, None
-        )[0]
-        self.assertEqual(first_key, second_key)
-
-        with patch.object(launcher, "_create_cute_wrapper", return_value=object()):
-            first_compiled = launcher._get_compiled_cute_launcher(
-                cute_kernel, first.schema, (32, 1, 1)
-            )
-            second_compiled = launcher._get_compiled_cute_launcher(
-                cute_kernel, second.schema, (32, 1, 1)
-            )
-            tail_compiled = launcher._get_compiled_cute_launcher(
-                cute_kernel, changed_tail.schema, (32, 1, 1)
-            )
-            stride_compiled = launcher._get_compiled_cute_launcher(
-                cute_kernel, changed_stride.schema, (32, 1, 1)
-            )
-        self.assertIs(first_compiled, second_compiled)
-        self.assertIsNot(first_compiled, tail_compiled)
-        self.assertIsNot(first_compiled, stride_compiled)
-        self.assertEqual(len(cute_kernel._helion_cute_compiled_launchers), 3)
 
     def test_cute_launcher_passes_compile_options(self) -> None:
         cute_kernel = type("DummyCuteKernel", (), {})()
@@ -8847,8 +8718,7 @@ class TestCuteBackend(TestCase):
         if not torch.cuda.is_available():
             self.skipTest("dynamic TensorMap workspace test needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [
+        cute_kernel = _cute_kernel_for_plan(
             {
                 "kind": "tcgen05_grouped_static_persistent",
                 "scheduler_mode": (
@@ -8857,7 +8727,7 @@ class TestCuteBackend(TestCase):
                 "layout_idx": 0,
                 "dynamic_ab_tensormaps": True,
             }
-        ]
+        )
         layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
         streams = [
             torch.cuda.Stream(device=DEVICE)
@@ -8909,8 +8779,7 @@ class TestCuteBackend(TestCase):
     def test_grouped_static_capture_query_fails_closed(self) -> None:
         if DEVICE.type != "cuda":
             self.skipTest("grouped capture context test needs CUDA")
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [
+        cute_kernel = _cute_kernel_for_plan(
             {
                 "kind": "tcgen05_grouped_static_persistent",
                 "scheduler_mode": (
@@ -8918,7 +8787,7 @@ class TestCuteBackend(TestCase):
                 ),
                 "layout_idx": 0,
             }
-        ]
+        )
         layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
 
         with (
@@ -8934,8 +8803,7 @@ class TestCuteBackend(TestCase):
         if not torch.cuda.is_available():
             self.skipTest("dynamic TensorMap workspace test needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [
+        cute_kernel = _cute_kernel_for_plan(
             {
                 "kind": "tcgen05_grouped_static_persistent",
                 "scheduler_mode": (
@@ -8944,7 +8812,7 @@ class TestCuteBackend(TestCase):
                 "layout_idx": 0,
                 "dynamic_ab_tensormaps": True,
             }
-        ]
+        )
         layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
         args = (layout,)
         grid = (1, 1, 1)
@@ -9098,11 +8966,9 @@ class TestCuteBackend(TestCase):
         launcher = importlib.import_module("helion.runtime.cute.launcher")
         host_plan = {
             "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
         }
         device_plan = {
             "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "device_split_sizes": True,
         }
         unrelated_plan = {"kind": "unrelated"}
@@ -9156,23 +9022,12 @@ class TestCuteBackend(TestCase):
         if not torch.cuda.is_available():
             self.skipTest("grouped capture ownership test needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        plan = {
-            "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
-            "layout_idx": 0,
-            "n_sizes_idx": 1,
-            "group_count": 2,
-            "bm": 128,
-            "bn": 64,
-            "bk": 128,
-            "n_size": 256,
-            "k_total_size": 128,
-            "problem_sizes_arg": "tcgen05_grouped_problem_sizes_0",
-            "starts_arg": "tcgen05_grouped_starts_0",
-            "total_clusters_arg": "tcgen05_grouped_total_clusters_0",
-        }
-        cute_kernel._helion_cute_wrapper_plans = [plan]
+        plan = _grouped_metadata_plan(
+            problem_sizes_arg="tcgen05_grouped_problem_sizes_0",
+            starts_arg="tcgen05_grouped_starts_0",
+            total_clusters_arg="tcgen05_grouped_total_clusters_0",
+        )
+        cute_kernel = _cute_kernel_for_plan(plan)
 
         def make_args(signature: int) -> tuple[torch.Tensor, torch.Tensor]:
             first_group_size = 128 * (signature + 1)
@@ -9312,7 +9167,6 @@ class TestCuteBackend(TestCase):
         runtime_mod = importlib.import_module("helion.runtime")
         plan = {
             "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "layout_idx": 2,
             "lhs_idx": 0,
             "rhs_idx": 1,
@@ -9329,8 +9183,7 @@ class TestCuteBackend(TestCase):
             "real_groups_arg": "real_groups",
             "total_clusters_arg": "total_clusters",
         }
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [plan]
+        cute_kernel = _cute_kernel_for_plan(plan)
         layout = torch.tensor(((0, 0, 128, 0),), dtype=torch.int32, device=DEVICE)
         rhs = torch.empty((1, 64, 64), dtype=torch.bfloat16, device=DEVICE)
 
@@ -9369,24 +9222,14 @@ class TestCuteBackend(TestCase):
             "bm": 256,
         }
 
-        self.assertEqual(
-            launcher._tcgen05_grouped_device_split_total_clusters(
-                {**common_plan, "source_m_tile": 32}
-            ),
-            1024,
-        )
-        self.assertEqual(
-            launcher._tcgen05_grouped_device_split_total_clusters(
-                {**common_plan, "source_m_tile": 224}
-            ),
-            160,
-        )
-        self.assertEqual(
-            launcher._tcgen05_grouped_device_split_total_clusters(
-                {**common_plan, "source_m_tile": 256}
-            ),
-            128,
-        )
+        for source_m_tile, expected in ((32, 1024), (224, 160), (256, 128)):
+            with self.subTest(source_m_tile=source_m_tile):
+                self.assertEqual(
+                    launcher._tcgen05_grouped_device_split_total_clusters(
+                        {**common_plan, "source_m_tile": source_m_tile}
+                    ),
+                    expected,
+                )
 
     def test_grouped_device_split_dimensions_must_fit_int32(self) -> None:
         launcher = importlib.import_module("helion.runtime.cute.launcher")
@@ -9413,21 +9256,7 @@ class TestCuteBackend(TestCase):
         if DEVICE.type != "cuda":
             self.skipTest("grouped static problem-shape guard needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
-        base_plan = {
-            "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
-            "layout_idx": 0,
-            "n_sizes_idx": 1,
-            "group_count": 2,
-            "bm": 128,
-            "bn": 64,
-            "bk": 128,
-            "n_size": 256,
-            "k_total_size": 128,
-            "problem_sizes_arg": "problem_sizes",
-            "starts_arg": "starts",
-            "total_clusters_arg": "total_clusters",
-        }
+        base_plan = _grouped_metadata_plan()
         layout = torch.cat(
             (
                 torch.zeros(128, dtype=torch.int32, device=DEVICE),
@@ -9439,8 +9268,7 @@ class TestCuteBackend(TestCase):
         actual_shapes = ((128, 64, 128), (128, 256, 128))
 
         matching_plan = {**base_plan, "static_problem_shapes": actual_shapes}
-        matching_kernel = type("MatchingDummyCuteKernel", (), {})()
-        matching_kernel._helion_cute_wrapper_plans = [matching_plan]
+        matching_kernel = _cute_kernel_for_plan(matching_plan)
         runtime_mod._build_tcgen05_grouped_static_metadata(
             matching_kernel, matching_plan, args
         )
@@ -9453,8 +9281,7 @@ class TestCuteBackend(TestCase):
         for expected_shapes in mismatches:
             with self.subTest(expected_shapes=expected_shapes):
                 plan = {**base_plan, "static_problem_shapes": expected_shapes}
-                cute_kernel = type("MismatchedDummyCuteKernel", (), {})()
-                cute_kernel._helion_cute_wrapper_plans = [plan]
+                cute_kernel = _cute_kernel_for_plan(plan)
                 with self.assertRaisesRegex(
                     BackendUnsupported,
                     "static problem-shape specialization",
@@ -9468,23 +9295,8 @@ class TestCuteBackend(TestCase):
             self.skipTest("grouped inference metadata test needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
         kernel_mod = importlib.import_module("helion.runtime.kernel")
-        plan = {
-            "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
-            "layout_idx": 0,
-            "n_sizes_idx": 1,
-            "group_count": 2,
-            "bm": 128,
-            "bn": 64,
-            "bk": 128,
-            "n_size": 256,
-            "k_total_size": 128,
-            "problem_sizes_arg": "problem_sizes",
-            "starts_arg": "starts",
-            "total_clusters_arg": "total_clusters",
-        }
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [plan]
+        plan = _grouped_metadata_plan()
+        cute_kernel = _cute_kernel_for_plan(plan)
 
         with torch.inference_mode():
             layout = torch.cat(
@@ -10126,7 +9938,6 @@ class TestCuteBackend(TestCase):
         signature = identity._base_specialization_key(args)
         plan: dict[str, object] = {
             "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "layout_bind_idx": 1,
             "group_count": 1,
             "bm": 128,
@@ -10545,8 +10356,7 @@ class TestCuteBackend(TestCase):
         )
         for plan, disable_bake, expected_baked in cases:
             with self.subTest(plan=plan, disable_bake=disable_bake):
-                kernel = type("DummyCuteKernel", (), {})()
-                kernel._helion_cute_wrapper_plans = [plan]
+                kernel = _cute_kernel_for_plan(plan)
                 kernel._helion_cute_disable_bake_tensor_shapes = disable_bake
                 launch = helion_runtime._build_cute_schema_and_args(
                     kernel, (tensor,), (128, 2, 1)
@@ -11547,3 +11357,77 @@ class TestCuteBackendRequirements(TestCase):
         # The fixed tail names all three requirements so the user knows the set.
         self.assertIn("nvidia-cutlass-dsl >= 4.7.0", message)
         self.assertIn("CUDA >= 13", message)
+
+
+def test_newer_cute_dsl_warns_once_only_for_grouped_runtime_n_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from helion._compiler.cute import cutedsl_compat
+
+    cutedsl_compat._installed_cute_dsl_version.cache_clear()
+    cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback.cache_clear()
+    try:
+        with (
+            patch.object(
+                cutedsl_compat.importlib.metadata,
+                "version",
+                return_value="4.7.1",
+            ) as version_probe,
+            caplog.at_level(logging.WARNING, logger=cutedsl_compat.__name__),
+        ):
+            assert not cutedsl_compat.tcgen05_runtime_n_ptx_compatible()
+            assert not cutedsl_compat.tcgen05_runtime_n_ptx_compatible()
+            assert not caplog.records
+            cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback()
+            cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback()
+            assert version_probe.call_count == 1
+    finally:
+        cutedsl_compat._installed_cute_dsl_version.cache_clear()
+        cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback.cache_clear()
+
+    matching = [
+        record
+        for record in caplog.records
+        if "Grouped runtime-N compiler seeds and promoted defaults are disabled"
+        in record.getMessage()
+    ]
+    assert len(matching) == 1
+    assert "4.7.1" in matching[0].getMessage()
+    assert "4.7.0" in matching[0].getMessage()
+    assert "fall back to typed static-width MMA" in matching[0].getMessage()
+
+
+@pytest.mark.parametrize("failure", ("missing", "invalid"))
+def test_failed_cute_dsl_version_probe_is_shared_and_cached(failure: str) -> None:
+    from helion._compiler.cute import cutedsl_compat
+
+    error: Exception
+    expected: str
+    if failure == "missing":
+        error = cutedsl_compat.importlib.metadata.PackageNotFoundError(
+            "nvidia-cutlass-dsl"
+        )
+        expected = "the CuTe DSL is not installed"
+    else:
+        error = cutedsl_compat.InvalidVersion("not-a-version")
+        expected = "the installed CuTe DSL version is invalid"
+
+    cutedsl_compat._installed_cute_dsl_version.cache_clear()
+    cutedsl_compat._cute_backend_requirement_error.cache_clear()
+    cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback.cache_clear()
+    try:
+        with patch.object(
+            cutedsl_compat.importlib.metadata,
+            "version",
+            side_effect=error,
+        ) as version_probe:
+            assert not cutedsl_compat.tcgen05_runtime_n_ptx_compatible()
+            assert not cutedsl_compat.tcgen05_runtime_n_ptx_compatible()
+            cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback()
+            cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback()
+            assert expected in str(cutedsl_compat._cute_backend_requirement_error())
+            assert version_probe.call_count == 1
+    finally:
+        cutedsl_compat._installed_cute_dsl_version.cache_clear()
+        cutedsl_compat._cute_backend_requirement_error.cache_clear()
+        cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback.cache_clear()

--- a/test/test_cute_deepgemm_selected.py
+++ b/test/test_cute_deepgemm_selected.py
@@ -11,8 +11,11 @@ import torch
 
 import helion
 from helion._compat import requires_cuda_version
+from helion._compiler.cute.cute_mma import _TCGEN05_INSTR_DESC_N_FIELD_SHIFT
+from helion._compiler.cute.cute_mma import _TCGEN05_INSTR_DESC_N_LOW_BITS
 from helion._compiler.cute.device_state import Tcgen05GroupedSchedulerMode
 from helion._compiler.cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
+from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
 from helion._compiler.cute.tcgen05_constants import (
@@ -20,6 +23,9 @@ from helion._compiler.cute.tcgen05_constants import (
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_TILE_FIELD_COUNT,
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
@@ -36,6 +42,7 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
 )
+from helion._compiler.cute.tcgen05_constants import Tcgen05GroupedRuntimeTileField
 from helion._testing import DEVICE
 from helion._testing import matchesBackends
 from helion._testing import patch_cute_mma_support
@@ -83,14 +90,14 @@ def _selected_config(
         )
     # BK64/source-256 cannot fit the historical AB7 schedule in CTA SMEM.
     if ab_stages is None:
-        ab_stages = {
-            (64, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE): 7,
-            (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT): 7,
-            (64, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE): 6,
-            (128, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE): 3,
-            (128, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT): 3,
-            (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE): 3,
-        }[(block_k, source_m_tile)]
+        if block_k == 64:
+            ab_stages = (
+                6
+                if source_m_tile == TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+                else 7
+            )
+        else:
+            ab_stages = 3
     config = helion.Config(
         block_sizes=[256, 128, block_k],
         l2_groupings=[1],
@@ -250,10 +257,8 @@ def _configured_bound(
 
 def _code_for(
     args: tuple[torch.Tensor, ...],
-    config: helion.Config | None = None,
+    config: helion.Config,
 ) -> str:
-    if config is None:
-        config = _selected_config(runtime_direct=True)
     _selected_kernel.reset()
     bound = _selected_kernel.bind(args)
     bound.env.config_spec.cute_tcgen05_search_enabled = True
@@ -296,30 +301,9 @@ def _call_count(
     )
 
 
-def _expected_panel_coords(
-    *,
-    m_tiles: int,
-    n_tiles: int,
-    configured_panel_size: int,
-) -> list[tuple[int, int]]:
-    result: list[tuple[int, int]] = []
-    panel_size = min(configured_panel_size, n_tiles)
-    panel_span = panel_size * m_tiles
-    for linear in range(m_tiles * n_tiles):
-        panel = linear // panel_span
-        within = linear % panel_span
-        width = min(panel_size, n_tiles - panel * panel_size)
-        tile_m = within // width
-        tile_n = panel * panel_size + within % width
-        if panel % 2 == 1:
-            tile_m = m_tiles - 1 - tile_m
-        result.append((tile_m, tile_n))
-    return result
-
-
 def test_grouped_worklist_nm_runtime_tile_table_mapping() -> None:
     rows = [[2, 0, 257, 448], [0, 448, 513, 672], [1, 1120, 65, 224]]
-    problem_sizes = [(2560, row[3], 128, 1) for row in rows]
+    problem_sizes = [(12_800, row[3], 128, 1) for row in rows]
     records = _tcgen05_grouped_runtime_nm_tile_records(
         rows,
         problem_sizes,
@@ -327,51 +311,57 @@ def test_grouped_worklist_nm_runtime_tile_table_mapping() -> None:
         source_tile_n=256,
         l2_swizzle_size=8,
     )
+    assert records.shape[1] == TCGEN05_GROUPED_RUNTIME_TILE_FIELD_COUNT
 
     cursor = 0
     for metadata_idx, (real_group, start, actual_m, aligned_m) in enumerate(rows):
         m_tiles = aligned_m // 224
-        n_tiles = 10
+        n_tiles = 50
         count = m_tiles * n_tiles
         group_records = records[cursor : cursor + count].tolist()
-        assert [(record[0], record[1]) for record in group_records] == (
-            _expected_panel_coords(
-                m_tiles=m_tiles,
-                n_tiles=n_tiles,
-                configured_panel_size=8,
+        coords = [
+            (
+                record[Tcgen05GroupedRuntimeTileField.CTA_M],
+                record[Tcgen05GroupedRuntimeTileField.CTA_N],
             )
-        )
+            for record in group_records
+        ]
+        assert sorted(coords) == [
+            (tile_m, tile_n) for tile_m in range(m_tiles) for tile_n in range(n_tiles)
+        ]
+        if metadata_idx == 0:
+            assert coords[:32] == [
+                *((tile_m, tile_n) for tile_m in (0, 1) for tile_n in range(8)),
+                *((tile_m, tile_n) for tile_m in (1, 0) for tile_n in range(8, 16)),
+            ]
         for record in group_records:
-            tile_m = record[0]
-            assert record[2:8] == [
+            tile_m = record[Tcgen05GroupedRuntimeTileField.CTA_M]
+            assert [
+                record[field]
+                for field in (
+                    Tcgen05GroupedRuntimeTileField.METADATA_IDX,
+                    Tcgen05GroupedRuntimeTileField.GROUP_IDX,
+                    Tcgen05GroupedRuntimeTileField.PROBLEM_M,
+                    Tcgen05GroupedRuntimeTileField.PROBLEM_N,
+                    Tcgen05GroupedRuntimeTileField.PROBLEM_K,
+                    Tcgen05GroupedRuntimeTileField.GLOBAL_M_START,
+                )
+            ] == [
                 metadata_idx,
                 real_group,
                 aligned_m,
-                2560,
+                12_800,
                 128,
                 start,
             ]
-            assert record[8] == min(224, max(actual_m - tile_m * 224, 0))
-            assert record[9] == min(224, aligned_m - tile_m * 224)
+            assert record[Tcgen05GroupedRuntimeTileField.VALID_M] == min(
+                224, max(actual_m - tile_m * 224, 0)
+            )
+            assert record[Tcgen05GroupedRuntimeTileField.STORE_M] == min(
+                224, aligned_m - tile_m * 224
+            )
         cursor += count
     assert cursor == len(records)
-
-
-@pytest.mark.parametrize("l2_swizzle_size", (1, 8))
-def test_grouped_worklist_nm_tile_table_excludes_zero_tile_groups(
-    l2_swizzle_size: int,
-) -> None:
-    records = _tcgen05_grouped_runtime_nm_tile_records(
-        [[0, 0, 0, 0], [1, 0, 33, 224]],
-        [(256, 0, 128, 1), (256, 224, 128, 1)],
-        source_tile_m=224,
-        source_tile_n=256,
-        l2_swizzle_size=l2_swizzle_size,
-    )
-
-    # The zero-tile row is absent before either raster path performs division
-    # or modulo; the surviving row retains its original metadata index.
-    assert records.tolist() == [[0, 0, 1, 1, 224, 256, 128, 0, 33, 224]]
 
 
 @pytest.mark.parametrize(
@@ -395,6 +385,67 @@ def test_grouped_worklist_nm_runtime_tile_table_rejects_invalid_problem_shape(
             source_tile_n=128,
             l2_swizzle_size=1,
         )
+
+
+def test_grouped_worklist_nm_small_tile_table_matches_reference() -> None:
+    rows = [[2, 0, 33, 64], [0, 64, 65, 96]]
+    problem_sizes = [(896, row[3], 128, 1) for row in rows]
+    records = _tcgen05_grouped_runtime_nm_tile_records(
+        rows,
+        problem_sizes,
+        source_tile_m=32,
+        source_tile_n=128,
+        l2_swizzle_size=3,
+    )
+
+    expected: list[list[int]] = []
+    for metadata_idx, (real_group, start, actual_m, aligned_m) in enumerate(rows):
+        m_tiles = aligned_m // 32
+        n_tiles = 7
+        panel_size = 3
+        for local_idx in range(m_tiles * n_tiles):
+            panel_span = panel_size * m_tiles
+            panel_idx = local_idx // panel_span
+            panel_linear = local_idx % panel_span
+            panel_width = min(panel_size, n_tiles - panel_idx * panel_size)
+            tile_m = panel_linear // panel_width
+            tile_n = panel_idx * panel_size + panel_linear % panel_width
+            if panel_idx % 2:
+                tile_m = m_tiles - 1 - tile_m
+            expected.append(
+                [
+                    tile_m,
+                    tile_n,
+                    metadata_idx,
+                    real_group,
+                    aligned_m,
+                    896,
+                    128,
+                    start,
+                    min(32, max(actual_m - tile_m * 32, 0)),
+                    32,
+                ]
+            )
+
+    assert len(records) == 35
+    assert records.tolist() == expected
+
+
+@pytest.mark.parametrize("l2_swizzle_size", (1, 8))
+def test_grouped_worklist_nm_tile_table_excludes_zero_tile_groups(
+    l2_swizzle_size: int,
+) -> None:
+    records = _tcgen05_grouped_runtime_nm_tile_records(
+        [[0, 0, 0, 0], [1, 0, 33, 224]],
+        [(256, 0, 128, 1), (256, 224, 128, 1)],
+        source_tile_m=224,
+        source_tile_n=256,
+        l2_swizzle_size=l2_swizzle_size,
+    )
+
+    # The zero-tile row is absent before either raster path performs division
+    # or modulo; the surviving row retains its original metadata index.
+    assert records.tolist() == [[0, 0, 1, 1, 224, 256, 128, 0, 33, 224]]
 
 
 def test_grouped_worklist_nm_runtime_direct_clc_checks_grid_z_limit() -> None:
@@ -532,7 +583,10 @@ def _require_runtime_cuda13_sm100() -> None:
 def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
     _require_codegen_cuda()
 
-    code = _code_for(_make_args((1, 127, 224, 256), n=224, k=128))
+    code = _code_for(
+        _make_args((1, 127, 224, 256), n=224, k=128),
+        _selected_config(runtime_direct=True),
+    )
 
     assert "StaticPersistentGroupTileScheduler.create" not in code
     assert "tcgen05_grouped_runtime_tile_records.iterator" in code
@@ -541,6 +595,7 @@ def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
     assert "cute.nvgpu.tcgen05.CtaGroup.TWO" in code
     assert "cute.local_tile(tma_tensor_a, (256, 128)" in code
     assert "cute.local_tile(tcgen05_tma_tensor_b_tail, (256, 128)" in code
+    assert "StMatrix8x8x16bOp(transpose=True, num_matrices=4)" in code
 
     plan = next(
         plan
@@ -792,6 +847,32 @@ def test_grouped_worklist_nm_runtime_direct_falls_back_without_runtime_n_ptx() -
     warn_fallback.assert_called_once_with()
 
 
+def test_tcgen05_runtime_instr_desc_n_field_matches_cutlass() -> None:
+    import cutlass
+    from cutlass.experimental.primitives import Tcgen05InstrDesc
+
+    def build(n_dim: int) -> int:
+        # Mirror the pinned BF16/F32 K-major layout used by the grouped tail.
+        return int(
+            Tcgen05InstrDesc.build(
+                c_dtype=cutlass.Float32,
+                a_dtype=cutlass.BFloat16,
+                b_dtype=cutlass.BFloat16,
+                a_major=0,
+                b_major=0,
+                n_dim=n_dim,
+                m_dim=256,
+            )
+        )
+
+    runtime_n = 32
+    encoded = build(0) | (
+        (runtime_n >> _TCGEN05_INSTR_DESC_N_LOW_BITS)
+        << _TCGEN05_INSTR_DESC_N_FIELD_SHIFT
+    )
+    assert encoded == build(runtime_n)
+
+
 @pytest.mark.parametrize(
     ("block_k", "source_m_tile"),
     (
@@ -809,7 +890,15 @@ def test_grouped_worklist_nm_runtime_n_tail_descriptors_codegen(
 ) -> None:
     _require_codegen_cuda()
 
-    config = _selected_config(block_k, source_m_tile, runtime_direct=True)
+    config = _selected_config(
+        block_k,
+        source_m_tile,
+        ab_stages=3,
+        cluster_m=(
+            1 if source_m_tile == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE else 2
+        ),
+        runtime_direct=True,
+    )
     with patch(
         "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
         return_value=True,
@@ -819,23 +908,29 @@ def test_grouped_worklist_nm_runtime_n_tail_descriptors_codegen(
             config,
         )
 
+    is_two_cta = source_m_tile != TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
     assert "cutlass.experimental.primitives.inline_ptx(" in code
-    assert (
-        "tcgen05_tma_b_peer_delta = mma_slice_tidx * "
-        "(tcgen05_tma_runtime_mma_n // cutlass.Int32(2) - "
-        f"cutlass.Int32({source_m_tile // 2}))"
-    ) in code
-    assert (
-        "tcgen05_tma_tensor_b_tail = cute.domain_offset("
-        "(tcgen05_tma_b_peer_delta, 0), tma_tensor_b)"
-    ) in code
-    assert (
-        f"cute.local_tile(tcgen05_tma_tensor_b_tail, ({source_m_tile}, {block_k})"
-        in code
-    )
-    assert "n_dim=0, m_dim=256" in code
+    if is_two_cta:
+        assert (
+            "tcgen05_tma_b_peer_delta = mma_slice_tidx * "
+            "(tcgen05_tma_runtime_mma_n // cutlass.Int32(2) - "
+            f"cutlass.Int32({source_m_tile // 2}))"
+        ) in code
+        assert (
+            "tcgen05_tma_tensor_b_tail = cute.domain_offset("
+            "(tcgen05_tma_b_peer_delta, 0), tma_tensor_b)"
+        ) in code
+        assert (
+            f"cute.local_tile(tcgen05_tma_tensor_b_tail, "
+            f"({source_m_tile}, {block_k})" in code
+        )
+    else:
+        assert "tcgen05_tma_b_peer_delta" not in code
+        assert "tcgen05_tma_tensor_b_tail" not in code
+        assert f"cute.local_tile(tma_tensor_b, ({source_m_tile}, {block_k})" in code
+    assert f"n_dim=0, m_dim={256 if is_two_cta else 128}" in code
     assert f"if tcgen05_runtime_mma_n == cutlass.Int32({source_m_tile}):" in code
-    assert "tcgen05.mma.cta_group::2.kind::f16" in code
+    assert f"tcgen05.mma.cta_group::{2 if is_two_cta else 1}.kind::f16" in code
     tree = ast.parse(code)
     instr_desc_call = next(
         node
@@ -859,16 +954,19 @@ def test_grouped_worklist_nm_runtime_n_tail_descriptors_codegen(
         for node in ast.walk(tree)
         if isinstance(node, ast.If) and ast.unparse(node.test) == tail_predicate
     ]
-    assert len(tail_guards) == 2
-    tma_guard = next(
-        node for node in tail_guards if "tcgen05_tma_b_peer_delta" in ast.unparse(node)
-    )
+    assert len(tail_guards) == (2 if is_two_cta else 1)
     mma_guard = next(
         node for node in tail_guards if "Tcgen05InstrDesc.build" in ast.unparse(node)
     )
-    assert "tcgen05_tma_tensor_b_tail" in ast.unparse(tma_guard)
-    assert "Tcgen05InstrDesc.build" not in ast.unparse(tma_guard)
     assert "tcgen05_tma_b_peer_delta" not in ast.unparse(mma_guard)
+    if is_two_cta:
+        tma_guard = next(
+            node
+            for node in tail_guards
+            if "tcgen05_tma_b_peer_delta" in ast.unparse(node)
+        )
+        assert "tcgen05_tma_tensor_b_tail" in ast.unparse(tma_guard)
+        assert "Tcgen05InstrDesc.build" not in ast.unparse(tma_guard)
 
 
 @pytest.mark.parametrize(
@@ -968,11 +1066,17 @@ def test_grouped_worklist_nm_bk128_ab2_keeps_unsplit_tma_store_codegen(
     assert "cute.copy(tcgen05_tma_store_atom" in code
 
 
-def test_grouped_worklist_nm_one_cta_codegen() -> None:
+@pytest.mark.parametrize("runtime_direct", (False, True))
+def test_grouped_worklist_nm_one_cta_codegen(runtime_direct: bool) -> None:
     _require_codegen_cuda()
 
     source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
-    config = _selected_config(64, source_m_tile, cluster_m=1)
+    config = _selected_config(
+        64,
+        source_m_tile,
+        cluster_m=1,
+        runtime_direct=runtime_direct,
+    )
     code = _code_for(
         _make_args((24, 23), n=512, k=128, source_m_tile=source_m_tile),
         config,
@@ -982,11 +1086,31 @@ def test_grouped_worklist_nm_one_cta_codegen() -> None:
     assert "cute.nvgpu.tcgen05.CtaGroup.TWO" not in code
     assert "cute.local_tile(tma_tensor_a, (128, 64)" in code
     assert f"cute.local_tile(tma_tensor_b, ({source_m_tile}, 64)" in code
+    tma_role_predicate = (
+        "cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(5)"
+    )
+    tma_role_sources = [
+        ast.unparse(node)
+        for node in ast.walk(ast.parse(code))
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == tma_role_predicate
+        and "while tcgen05_role_local_0" in ast.unparse(node)
+    ]
+    assert len(tma_role_sources) == 1
+    assert "tcgen05_grouped_valid_m =" not in tma_role_sources[0]
 
     plans = _wrapper_plans(code)
     grouped_plan = next(
         plan for plan in plans if plan["kind"] == "tcgen05_grouped_static_persistent"
     )
+    expected_scheduler = (
+        Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT
+        if runtime_direct
+        else Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH
+    )
+    assert grouped_plan["scheduler_mode"] == expected_scheduler.value
+    assert ("StaticPersistentGroupTileScheduler.create" in code) is not runtime_direct
+    assert ("tcgen05_grouped_runtime_tile_records.iterator" in code) is runtime_direct
     assert "num_sm_multiplier" not in grouped_plan
     assert {
         "bm": grouped_plan["bm"],
@@ -1110,16 +1234,16 @@ def test_grouped_worklist_nm_one_cta_runtime_direct_upper_n_record_count() -> No
     ]
     records = _tcgen05_grouped_runtime_nm_tile_records(
         rows,
-        [(4096, 32, 2048, 1)] * len(rows),
+        [(7168, 32, 2048, 1)] * len(rows),
         source_tile_m=32,
         source_tile_n=128,
         l2_swizzle_size=1,
     )
 
-    assert len(records) == 6 * 32
+    assert len(records) == 6 * 56
     for metadata_idx in range(6):
-        group_records = records[metadata_idx * 32 : (metadata_idx + 1) * 32]
-        assert group_records[:, 1].tolist() == list(range(32))
+        group_records = records[metadata_idx * 56 : (metadata_idx + 1) * 56]
+        assert group_records[:, 1].tolist() == list(range(56))
         assert set(group_records[:, 2].tolist()) == {metadata_idx}
 
 
@@ -1149,7 +1273,8 @@ def test_grouped_worklist_nm_panel_raster_codegen_and_mapping() -> None:
         grouped_plan["scheduler_mode"]
         == Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT.value
     )
-    assert grouped_plan["l2_swizzle_size"] == 8
+    panel_l2_swizzle_size = grouped_plan["l2_swizzle_size"]
+    assert panel_l2_swizzle_size == 8
 
 
 def test_grouped_worklist_nm_fixed_tensormap_rejects_misaligned_d() -> None:
@@ -1160,32 +1285,33 @@ def test_grouped_worklist_nm_fixed_tensormap_rejects_misaligned_d() -> None:
     k = 128
     a_packed = torch.empty((m_total, k), dtype=torch.bfloat16, device=DEVICE)
     b_grouped = torch.empty((1, n, k), dtype=torch.bfloat16, device=DEVICE)
+    work_tile_metadata = torch.tensor(
+        [[0, 0, m_total, m_total]],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
     aligned_output = torch.empty((m_total, n), dtype=torch.bfloat16, device=DEVICE)
     d_storage = torch.empty(m_total * n + 1, dtype=torch.bfloat16, device=DEVICE)
     output = d_storage[1:].view(m_total, n)
     assert output.data_ptr() % 16 != 0
 
-    plan: dict[str, object] = {
-        "fixed_tensormaps": True,
-        "orientation": "nm",
-        "worklist_metadata": True,
-        "dynamic_ab_tensormap_rank": 2,
-        "lhs_idx": 0,
-        "rhs_idx": 1,
-        "n_size": n,
-        "k_total_size": k,
-        "bm": 256,
-        "bk": 64,
-    }
+    code = _code_for(
+        (a_packed, b_grouped, work_tile_metadata),
+        _selected_config(64, m_total),
+    )
+    plans = _wrapper_plans(code)
+    plan = next(
+        candidate
+        for candidate in plans
+        if candidate["kind"] == "tcgen05_grouped_static_persistent"
+    )
     cute_kernel = type("FixedTensorMapKernel", (), {})()
-    cute_kernel._helion_cute_wrapper_plans = [
-        {"kind": "tcgen05_d_tma", "fixed_tensormap": True, "d_idx": 2}
-    ]
+    cute_kernel._helion_cute_wrapper_plans = plans
 
     _validate_tcgen05_grouped_fixed_tensormaps(
         cute_kernel,
         plan,
-        (a_packed, b_grouped, aligned_output),
+        (work_tile_metadata, a_packed, b_grouped, aligned_output),
     )
     with pytest.raises(
         helion.exc.BackendUnsupported,
@@ -1194,7 +1320,7 @@ def test_grouped_worklist_nm_fixed_tensormap_rejects_misaligned_d() -> None:
         _validate_tcgen05_grouped_fixed_tensormaps(
             cute_kernel,
             plan,
-            (a_packed, b_grouped, output),
+            (work_tile_metadata, a_packed, b_grouped, output),
         )
 
 
@@ -1218,6 +1344,14 @@ def test_grouped_worklist_nm_validator_accepts_exact_mn_major_b_only() -> None:
         plan,
         (a_packed, mn_major_b),
     )
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="only for the N,M worklist path",
+    ):
+        _validate_tcgen05_grouped_dynamic_ab_tensormaps(
+            {**plan, "orientation": "mn"},
+            (a_packed, mn_major_b),
+        )
     with pytest.raises(
         helion.exc.BackendUnsupported,
         match="contiguous K-major or MN-major grouped B",
@@ -1259,9 +1393,13 @@ def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
 def test_grouped_worklist_nm_rejects_over_budget_host_metadata_profile() -> None:
     _require_codegen_cuda()
 
-    config = _selected_config(64)
-    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = (
-        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+    # Source-256/BK64/AB7 exceeds the exact B200 worklist footprint.  Compiler
+    # seeds register the host allocation facts, so normalization rejects this
+    # profile before the generated-allocation backstop.
+    config = _selected_config(
+        64,
+        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+        ab_stages=7,
     )
     args = _make_args(
         (224, 256),
@@ -1269,11 +1407,59 @@ def test_grouped_worklist_nm_rejects_over_budget_host_metadata_profile() -> None
         k=64,
         source_m_tile=TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
     )
-    with pytest.raises(
-        helion.exc.BackendUnsupported,
-        match="grouped N,M worklist generated allocations require",
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    bound.env.config_spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+        group_count=int(args[2].size(0)),
+        device_split_sizes=False,
+    )
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+        pytest.raises(
+            helion.exc.InvalidConfig,
+            match="tcgen05_ab_stages",
+        ),
     ):
-        _code_for(args, config)
+        bound.to_triton_code(config)
+
+
+def test_grouped_worklist_nm_codegen_backstop_rejects_generated_smem() -> None:
+    _require_codegen_cuda()
+
+    config = _selected_config(
+        64,
+        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+        ab_stages=7,
+    )
+    args = _make_args(
+        (224, 256),
+        n=224,
+        k=64,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+    )
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    bound.env.config_spec._tcgen05_ab_stages_three_search_constraints = None
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+        patch.object(
+            CuteTcgen05Config,
+            "per_cta_smem_capacity_bytes",
+            return_value=1,
+        ),
+        pytest.raises(
+            helion.exc.BackendUnsupported,
+            match=(
+                "tcgen05 grouped N,M worklist generated allocations require .* "
+                "exceeding the 1-byte capacity"
+            ),
+        ),
+    ):
+        bound.to_triton_code(config)
 
 
 def test_grouped_worklist_nm_rejects_alpha_scaled_row() -> None:
@@ -1324,7 +1510,7 @@ def test_grouped_worklist_nm_rejects_ineligible_inputs(case: str, match: str) ->
         args = (a_packed, strided_b, work_tile_metadata)
 
     with pytest.raises(helion.exc.BackendUnsupported, match=match):
-        _code_for(args)
+        _code_for(args, _selected_config())
 
 
 @pytest.mark.parametrize(
@@ -1332,6 +1518,7 @@ def test_grouped_worklist_nm_rejects_ineligible_inputs(case: str, match: str) ->
     (
         (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT),
         (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE),
+        (64, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE),
     ),
 )
 def test_grouped_worklist_nm_runtime_and_graph_replay(
@@ -1340,11 +1527,12 @@ def test_grouped_worklist_nm_runtime_and_graph_replay(
 ) -> None:
     _require_runtime_cuda13_sm100()
 
-    m_sizes = (224, 449, 256)
+    small_source = source_m_tile == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+    m_sizes = (24, 23, 19, 17, 20, 18) if small_source else (224, 449, 256)
     args = _make_args(
         m_sizes,
-        n=512,
-        k=2 * block_k,
+        n=4096 if small_source else 512,
+        k=2048 if small_source else 2 * block_k,
         dirty_padding=True,
         source_m_tile=source_m_tile,
     )
@@ -1375,12 +1563,16 @@ def test_grouped_worklist_nm_runtime_and_graph_replay(
         # and a non-identity metadata-row-to-group mapping.  Total aligned M is
         # unchanged, so this exercises the scheduler metadata refresh rather
         # than recompilation or a new allocation shape.
-        mutated_m_sizes = (
-            (225, 224, 449)
-            if source_m_tile == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
-            else (257, 224, 256)
-        )
-        mutated_group_ids = (2, 0, 1)
+        if small_source:
+            mutated_m_sizes = (15, 20, 17, 19, 23, 24)
+            mutated_group_ids = (5, 4, 3, 2, 1, 0)
+        else:
+            mutated_m_sizes = (
+                (225, 224, 449)
+                if source_m_tile == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+                else (257, 224, 256)
+            )
+            mutated_group_ids = (2, 0, 1)
         _refresh_worklist_without_recompile(
             bound,
             args,
@@ -1393,6 +1585,16 @@ def test_grouped_worklist_nm_runtime_and_graph_replay(
         captured = _capture_and_replay(bound, args, poison=-7.0)
 
     _assert_output(captured, args)
+    if small_source:
+        a_packed, b_grouped, work_tile_metadata = args
+        for group, start, valid_m, _store_m in work_tile_metadata.cpu().tolist():
+            oracle = (
+                a_packed[start : start + valid_m].float() @ b_grouped[group].float().T
+            ).double()
+            actual = captured[start : start + valid_m].double()
+            denominator = (actual.square() + oracle.square()).sum()
+            diff = 1 - 2 * (actual * oracle).sum() / denominator
+            assert float(diff.item()) <= 1e-5
 
 
 @pytest.mark.parametrize("runtime_direct", (False, True))
@@ -1486,7 +1688,6 @@ def test_grouped_worklist_nm_nonzero_overlap_is_rejected_at_launch() -> None:
         bound = _configured_bound(
             args,
             64,
-            ab_stages=3,
             source_m_tile=source_m_tile,
             runtime_direct=True,
         )
@@ -1511,6 +1712,7 @@ def test_grouped_worklist_nm_all_empty_is_rejected_at_launch() -> None:
         bound = _configured_bound(
             args,
             64,
+            ab_stages=3,
             source_m_tile=source_m_tile,
             runtime_direct=True,
         )
@@ -1610,39 +1812,6 @@ def test_grouped_worklist_nm_bk128_ab2_runtime_and_graph_replay() -> None:
         ab_stages=2,
         source_m_tile=source_m_tile,
     )
-
-
-def test_grouped_worklist_nm_small_source_public_profile_graph_replay() -> None:
-    _require_runtime_cuda13_sm100()
-
-    args = _make_args(
-        (24, 23, 19, 17, 20, 18),
-        n=4096,
-        k=2048,
-        dirty_padding=True,
-        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
-    )
-    assert args[2].cpu().tolist() == [
-        [0, 0, 24, 32],
-        [1, 32, 23, 32],
-        [2, 64, 19, 32],
-        [3, 96, 17, 32],
-        [4, 128, 20, 32],
-        [5, 160, 18, 32],
-    ]
-    _, captured = _run_graph_replay(
-        args,
-        64,
-        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
-    )
-    a_packed, b_grouped, work_tile_metadata = args
-    for group, start, valid_m, _store_m in work_tile_metadata.cpu().tolist():
-        oracle = a_packed[start : start + valid_m].float() @ b_grouped[group].float().T
-        actual = captured[start : start + valid_m].double()
-        oracle = oracle.double()
-        denominator = (actual.square() + oracle.square()).sum()
-        diff = 1 - 2 * (actual * oracle).sum() / denominator
-        assert float(diff.item()) <= 1e-5
 
 
 def test_grouped_worklist_nm_one_cta_mn_major_legacy_graph_replay() -> None:

--- a/test/test_cute_device_state.py
+++ b/test/test_cute_device_state.py
@@ -80,6 +80,20 @@ def _grouped_plan(**overrides: object) -> CuteTcgen05GroupedPlan:
     return CuteTcgen05GroupedPlan(**kwargs)
 
 
+def _runtime_direct_grouped_plan() -> CuteTcgen05GroupedPlan:
+    return _grouped_plan(
+        orientation=Tcgen05Orientation.NM,
+        scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+        runtime_tile_records="runtime_tile_records",
+        runtime_total_clusters="runtime_total_clusters",
+        valid_m="valid_m",
+        store_m="store_m",
+        source_m_tile=32,
+        d_mode=Tcgen05GroupedDMode.ALL_TILES,
+        d_tensormap="d_tensormap",
+    )
+
+
 def _lifecycle(**overrides: object) -> Tcgen05LifecycleContext:
     kwargs: dict[str, Any] = {
         "exec_active": "tcgen05_exec",
@@ -179,36 +193,26 @@ class TestCuteDeviceFunctionState(unittest.TestCase):
         device_search = _grouped_plan()
         self.assertFalse(device_search.uses_runtime_tile_table)
 
-        runtime_direct = _grouped_plan(
-            orientation=Tcgen05Orientation.NM,
-            scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
-            runtime_tile_records="runtime_tile_records",
-            runtime_total_clusters="runtime_total_clusters",
-            real_groups="real_groups",
-            valid_m="valid_m",
-            store_m="store_m",
-            source_m_tile=32,
-            d_mode=Tcgen05GroupedDMode.ALL_TILES,
-            d_tensormap="d_tensormap",
-        )
+        runtime_direct = _runtime_direct_grouped_plan()
         self.assertTrue(runtime_direct.uses_runtime_tile_table)
 
-        with self.assertRaises(AssertionError):
-            dataclasses.replace(
+        invalid_replacements = (
+            lambda: dataclasses.replace(
                 runtime_direct,
                 scheduler_mode=Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH,
-            )
-        with self.assertRaises(AssertionError):
-            _grouped_plan(
+            ),
+            lambda: _grouped_plan(
                 scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
-            )
-        with self.assertRaises(AssertionError):
-            _grouped_plan(fixed_tensormaps=True)
-        with self.assertRaises(AssertionError):
-            dataclasses.replace(
+            ),
+            lambda: _grouped_plan(fixed_tensormaps=True),
+            lambda: dataclasses.replace(
                 runtime_direct,
                 scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
-            )
+            ),
+        )
+        for make_invalid in invalid_replacements:
+            with self.assertRaises(AssertionError):
+                make_invalid()
 
         runtime_clc = dataclasses.replace(
             runtime_direct,
@@ -220,18 +224,7 @@ class TestCuteDeviceFunctionState(unittest.TestCase):
         self.assertTrue(runtime_clc.uses_runtime_tile_table)
 
     def test_grouped_runtime_mode_matches_parent_warp_topology(self) -> None:
-        runtime_direct = _grouped_plan(
-            orientation=Tcgen05Orientation.NM,
-            scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
-            runtime_tile_records="runtime_tile_records",
-            runtime_total_clusters="runtime_total_clusters",
-            real_groups="real_groups",
-            valid_m="valid_m",
-            store_m="store_m",
-            source_m_tile=32,
-            d_mode=Tcgen05GroupedDMode.ALL_TILES,
-            d_tensormap="d_tensormap",
-        )
+        runtime_direct = _runtime_direct_grouped_plan()
         _plan(grouped=runtime_direct)
         with self.assertRaises(AssertionError):
             _plan(grouped=runtime_direct, scheduler_warp_count=1)
@@ -241,6 +234,7 @@ class TestCuteDeviceFunctionState(unittest.TestCase):
             scheduler_mode=Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH,
             runtime_tile_records=None,
             runtime_total_clusters=None,
+            real_groups="real_groups",
         )
         _plan(grouped=device_search_nm, scheduler_warp_count=1)
         with self.assertRaises(AssertionError):

--- a/test/test_cute_grouped_gemm_split_sizes.py
+++ b/test/test_cute_grouped_gemm_split_sizes.py
@@ -9,8 +9,13 @@ import torch
 
 import helion
 from helion._compat import requires_cuda_version
+from helion._compiler.cute.cute_mma import tcgen05_grouped_worklist_seed_facts
+from helion._compiler.cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+)
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
 )
@@ -20,6 +25,7 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
 )
+from helion._hardware import HardwareInfo
 from helion._testing import DEVICE
 from helion._testing import matchesBackends
 from helion._testing import patch_cute_mma_support
@@ -77,6 +83,10 @@ def _device_split_sizes_kernel(
     assert k == k2
     assert groups == 8
     assert split_sizes.size(0) == 8
+    hl.register_heuristic_metadata(
+        "tcgen05_grouped_worklist_source_m_tile",
+        224,
+    )
     block_m = hl.register_block_size(256)
     block_n = hl.register_block_size(128)
     block_k = hl.register_block_size(64)
@@ -416,6 +426,14 @@ def _grouped_plan(code: str) -> dict[str, object]:
     )
 
 
+def _assert_plan_fields(plan: dict[str, object], **expected: object) -> None:
+    for name, value in expected.items():
+        if isinstance(value, bool):
+            assert plan[name] is value
+        else:
+            assert plan[name] == value
+
+
 def _bk64_device_split_smem_bytes(group_count: int) -> int:
     from helion._compiler.cute.tcgen05_constants import (
         tcgen05_grouped_worklist_smem_bytes,
@@ -441,6 +459,62 @@ def test_grouped_device_split_smem_accounting_includes_fixed_allocations() -> No
     # mailboxes, TensorMaps, barriers, and alignment are included.
     assert _bk64_device_split_smem_bytes(8) == 227 * 1024
     assert _bk64_device_split_smem_bytes(51) > 227 * 1024
+
+
+def test_grouped_device_split_compiler_seeds_use_mailbox_scheduler() -> None:
+    _require_codegen_cuda()
+    with torch.cuda.device(DEVICE):
+        if torch.cuda.get_device_capability(DEVICE) != (10, 0):
+            pytest.skip("grouped worklist compiler seeds require SM100")
+
+    args = _make_device_split_sizes_args(
+        (0, 1, 127, 224, 256, 449, 0, 991),
+        n=512,
+        k=64,
+    )
+    _device_split_sizes_kernel.reset()
+    with (
+        patch_cute_mma_support(),
+        patch(
+            "helion._hardware.get_hardware_info",
+            return_value=HardwareInfo(
+                device_kind="cuda",
+                hardware_name="NVIDIA B200",
+                runtime_version="13.0",
+                compute_capability="sm100",
+            ),
+        ),
+    ):
+        bound = _device_split_sizes_kernel.bind(args)
+
+    seed_facts = tcgen05_grouped_worklist_seed_facts(
+        bound.env,
+        bound.host_function.device_ir,
+        bound.config_spec.matmul_facts[0],
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+    )
+    assert seed_facts is not None
+    assert seed_facts.device_split_sizes
+    assert bound.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts == (
+        8,
+        True,
+    )
+    seeds = [
+        config
+        for config in bound.config_spec.compiler_seed_configs
+        if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+        == TCGEN05_GROUPED_MODE_WORKLIST_NM
+    ]
+    assert seeds
+    assert all(
+        config.config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is not True
+        for config in seeds
+    )
+    assert all(
+        config.config.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY, 1) == 1
+        for config in seeds
+    )
+    assert bound.config_spec.compiler_default_config == seeds[0]
 
 
 @pytest.mark.parametrize(
@@ -483,33 +557,21 @@ def test_grouped_device_split_sizes_codegen_and_wrapper_plan(
     assert "tcgen05_grouped_real_groups" not in kernel_args
 
     plan = _grouped_plan(code)
-    assert {
-        "device_split_sizes": plan["device_split_sizes"],
-        "group_count": plan["group_count"],
-        "bk": plan["bk"],
-        "source_m_tile": plan["source_m_tile"],
-        "cluster_m": plan["cluster_m"],
-        "cluster_n": plan["cluster_n"],
-        "m_size": plan["m_size"],
-        "orientation": plan["orientation"],
-        "worklist_metadata": plan["worklist_metadata"],
-        "dynamic_ab_tensormaps": plan["dynamic_ab_tensormaps"],
-        "dynamic_ab_tensormap_rank": plan["dynamic_ab_tensormap_rank"],
-        "dynamic_d_tensormap": plan["dynamic_d_tensormap"],
-    } == {
-        "device_split_sizes": True,
-        "group_count": 8,
-        "bk": block_k,
-        "source_m_tile": source_m_tile,
-        "cluster_m": 2,
-        "cluster_n": 1,
-        "m_size": args[0].size(0),
-        "orientation": "nm",
-        "worklist_metadata": True,
-        "dynamic_ab_tensormaps": True,
-        "dynamic_ab_tensormap_rank": 2,
-        "dynamic_d_tensormap": True,
-    }
+    _assert_plan_fields(
+        plan,
+        device_split_sizes=True,
+        group_count=8,
+        bk=block_k,
+        source_m_tile=source_m_tile,
+        cluster_m=2,
+        cluster_n=1,
+        m_size=args[0].size(0),
+        orientation="nm",
+        worklist_metadata=True,
+        dynamic_ab_tensormaps=True,
+        dynamic_ab_tensormap_rank=2,
+        dynamic_d_tensormap=True,
+    )
     assert "real_groups_arg" not in plan
     assert "iterator + cutlass.Int64(7) * cutlass.Int64(" in code
 
@@ -549,10 +611,13 @@ def test_grouped_device_split_sizes_two_group_codegen() -> None:
     code = _code_for(_device_split_sizes_two_groups_kernel, args)
 
     plan = _grouped_plan(code)
-    assert plan["device_split_sizes"] is True
-    assert plan["group_count"] == 2
-    assert plan["m_size"] == args[0].size(0)
-    assert plan["orientation"] == "nm"
+    _assert_plan_fields(
+        plan,
+        device_split_sizes=True,
+        group_count=2,
+        m_size=args[0].size(0),
+        orientation="nm",
+    )
 
 
 def test_grouped_device_split_sizes_without_grouped_mode_falls_back() -> None:
@@ -661,13 +726,16 @@ def test_grouped_device_split_sizes_runtime_edges_and_graph_replay(
             captured = bound(*args)
         torch.cuda.synchronize()
 
+        def replay(split_sizes: tuple[int, ...]) -> None:
+            args[0].normal_()
+            args[2].copy_(args[2].new_tensor(split_sizes))
+            captured.fill_(-7.0)
+            graph.replay()
+            torch.cuda.synchronize()
+
         new_split_sizes = (113, 0, 224, 200, 0, 1, 300, 1210)
         assert sum(new_split_sizes) == args[0].size(0)
-        args[0].normal_()
-        args[2].copy_(torch.tensor(new_split_sizes, device=DEVICE, dtype=args[2].dtype))
-        captured.fill_(-7.0)
-        graph.replay()
-        torch.cuda.synchronize()
+        replay(new_split_sizes)
 
         _assert_device_split_sizes_output(captured, args)
 
@@ -675,13 +743,7 @@ def test_grouped_device_split_sizes_runtime_edges_and_graph_replay(
         # length exceeds M.  The replacement scheduler must preserve that
         # finite extent rather than constructing an out-of-bounds TensorMap.
         oversized_split_sizes = (args[0].size(0) + 1, 0, 0, 0, 0, 0, 0, 0)
-        args[0].normal_()
-        args[2].copy_(
-            torch.tensor(oversized_split_sizes, device=DEVICE, dtype=args[2].dtype)
-        )
-        captured.fill_(-7.0)
-        graph.replay()
-        torch.cuda.synchronize()
+        replay(oversized_split_sizes)
 
         expected = (args[0].float() @ args[1][0].float().T).to(captured.dtype)
         torch.testing.assert_close(captured, expected, rtol=3e-2, atol=3e-2)
@@ -699,13 +761,7 @@ def test_grouped_device_split_sizes_runtime_edges_and_graph_replay(
             0,
             0,
         )
-        args[0].normal_()
-        args[2].copy_(
-            torch.tensor(negative_split_sizes, device=DEVICE, dtype=args[2].dtype)
-        )
-        captured.fill_(-7.0)
-        graph.replay()
-        torch.cuda.synchronize()
+        replay(negative_split_sizes)
 
         visible_rows = args[0].size(0) - 50
         expected = (args[0][:visible_rows].float() @ args[1][2].float().T).to(
@@ -735,13 +791,7 @@ def test_grouped_device_split_sizes_runtime_edges_and_graph_replay(
                 0,
                 0,
             )
-            args[0].normal_()
-            args[2].copy_(
-                torch.tensor(wide_split_sizes, device=DEVICE, dtype=args[2].dtype)
-            )
-            captured.fill_(-7.0)
-            graph.replay()
-            torch.cuda.synchronize()
+            replay(wide_split_sizes)
 
             expected = (args[0].float() @ args[1][0].float().T).to(captured.dtype)
             torch.testing.assert_close(captured, expected, rtol=3e-2, atol=3e-2)

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -14690,6 +14690,42 @@ class TestCuteLowerings(unittest.TestCase):
             block_sizes=[128, 128, 256],
             tcgen05_ab_stages=2,
         )
+        worklist_config = helion.Config(
+            block_sizes=[256, 128, 64],
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=7,
+        )
+        worklist_config.config.update(
+            {
+                "tcgen05_grouped_mode": "worklist_nm",
+                "tcgen05_grouped_worklist_source_m_tile": 224,
+            }
+        )
+        cases = (
+            (torch.float16, 128, 128, 256, config, 200 * 1024, False, "universal"),
+            (torch.float16, 128, 128, 128, config, 200 * 1024, False, "tcgen05"),
+            (torch.float16, 128, 128, 128, config, 100 * 1024, False, "universal"),
+            (
+                torch.bfloat16,
+                256,
+                224,
+                64,
+                worklist_config,
+                200 * 1024,
+                False,
+                "universal",
+            ),
+            (
+                torch.bfloat16,
+                256,
+                224,
+                64,
+                worklist_config,
+                200 * 1024,
+                True,
+                "tcgen05",
+            ),
+        )
         with (
             patch(
                 "helion._compiler.cute.cute_mma.get_cute_mma_support",
@@ -14702,40 +14738,26 @@ class TestCuteLowerings(unittest.TestCase):
             ) as smem_budget,
             patch.dict("os.environ", {"HELION_CUTE_MMA_IMPL": "auto"}, clear=False),
         ):
-            self.assertEqual(
-                _choose_mma_impl(
-                    torch.float16,
-                    bm=128,
-                    bn=128,
-                    bk=256,
-                    config=config,
-                    input_device=torch.device("cuda"),
-                ),
-                "universal",
-            )
-            self.assertEqual(
-                _choose_mma_impl(
-                    torch.float16,
-                    bm=128,
-                    bn=128,
-                    bk=128,
-                    config=config,
-                    input_device=torch.device("cuda"),
-                ),
-                "tcgen05",
-            )
-            smem_budget.return_value = 100 * 1024
-            self.assertEqual(
-                _choose_mma_impl(
-                    torch.float16,
-                    bm=128,
-                    bn=128,
-                    bk=128,
-                    config=config,
-                    input_device=torch.device("cuda"),
-                ),
-                "universal",
-            )
+            for dtype, bm, bn, bk, case_config, budget, defer, expected in cases:
+                with self.subTest(
+                    dtype=str(dtype),
+                    block_sizes=(bm, bn, bk),
+                    budget=budget,
+                    defer=defer,
+                ):
+                    smem_budget.return_value = budget
+                    self.assertEqual(
+                        _choose_mma_impl(
+                            dtype,
+                            bm=bm,
+                            bn=bn,
+                            bk=bk,
+                            config=case_config,
+                            input_device=torch.device("cuda"),
+                            defer_grouped_worklist_smem_check=defer,
+                        ),
+                        expected,
+                    )
 
     def test_tcgen05_thread_counts_match_participants_and_cta(self) -> None:
         # ``_tcgen05_epi_warp_count`` takes a ``Tcgen05WarpSpec`` (G2-B);
@@ -16964,7 +16986,35 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
 
         return cute_matmul_residual_c_input
 
-    def _canonical_c_input_config(self) -> helion.Config:
+    def _fanout_kernel(self):  # type: ignore[no-untyped-def]
+        @helion.kernel(backend="cute")
+        def cute_matmul_residual_fanout(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            residual_a: torch.Tensor,
+            residual_b: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            m, k = x.size()
+            _, n = y.size()
+            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
+                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
+            return out_a, out_b
+
+        return cute_matmul_residual_fanout
+
+    def _square_args(self, count: int) -> tuple[torch.Tensor, ...]:
+        return tuple(
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16)
+            for _ in range(count)
+        )
+
+    def _canonical_c_input_config(self, *, ab_stages: int = 2) -> helion.Config:
         return helion.Config(
             block_sizes=[256, 256, 128],
             l2_groupings=[1],
@@ -16972,7 +17022,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             num_sm_multiplier=1,
             pid_type="persistent_interleaved",
             tcgen05_cluster_m=2,
-            tcgen05_ab_stages=2,
+            tcgen05_ab_stages=ab_stages,
             tcgen05_acc_stages=2,
             tcgen05_c_stages=2,
             tcgen05_num_epi_warps=4,
@@ -17796,35 +17846,12 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
     def test_aux_tma_load_rejects_multi_store_fanout(self) -> None:
         """Explicit aux TMA rejects multi-store fan-out instead of falling back."""
 
-        @helion.kernel(backend="cute")
-        def cute_matmul_residual_fanout(
-            x: torch.Tensor,
-            y: torch.Tensor,
-            residual_a: torch.Tensor,
-            residual_b: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, k = x.size()
-            _, n = y.size()
-            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
-                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
-            return out_a, out_b
-
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        kernel = self._fanout_kernel()
+        args = self._square_args(4)
         config = self._canonical_c_input_config()
         config.config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_TMA
         with patch_cute_mma_support():
-            bound = cute_matmul_residual_fanout.bind(args)
+            bound = kernel.bind(args)
             bound.env.config_spec.cute_tcgen05_search_enabled = True
             with self.assertRaises(exc.BackendUnsupported) as cm:
                 bound.to_triton_code(config)
@@ -19274,34 +19301,11 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         directly.
         """
 
-        @helion.kernel(backend="cute")
-        def cute_matmul_residual_fanout(
-            x: torch.Tensor,
-            y: torch.Tensor,
-            residual_a: torch.Tensor,
-            residual_b: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, k = x.size()
-            _, n = y.size()
-            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
-                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
-            return out_a, out_b
-
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        kernel = self._fanout_kernel()
+        args = self._square_args(4)
         config = self._canonical_c_input_config()
         with patch_cute_mma_support():
-            bound = cute_matmul_residual_fanout.bind(args)
+            bound = kernel.bind(args)
             bound.env.config_spec.cute_tcgen05_search_enabled = True
             code = bound.to_triton_code(config)
 
@@ -19370,31 +19374,8 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         explicit rejection assertion.
         """
         kernel = self._residual_kernel()
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
-        config = helion.Config(
-            block_sizes=[256, 256, 128],
-            l2_groupings=[1],
-            num_warps=4,
-            num_sm_multiplier=1,
-            pid_type="persistent_interleaved",
-            tcgen05_cluster_m=2,
-            tcgen05_ab_stages=3,
-            tcgen05_acc_stages=2,
-            tcgen05_c_stages=2,
-            tcgen05_num_epi_warps=4,
-            tcgen05_strategy="role_local_with_scheduler",
-            tcgen05_warp_spec_scheduler_warps=1,
-            tcgen05_warp_spec_c_input_warps=1,
-            indexing=[
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-        )
+        args = self._square_args(3)
+        config = self._canonical_c_input_config(ab_stages=3)
         with patch_cute_mma_support():
             bound = kernel.bind(args)
             bound.env.config_spec.cute_tcgen05_search_enabled = True
@@ -19426,11 +19407,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         and silently disable the cycle 2b productive body.
         """
         kernel = self._residual_kernel()
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        args = self._square_args(3)
         # The canonical cycle 2b config from
         # ``_canonical_c_input_config`` already uses
         # ``ab_stages=2`` + ``c_input_warps=1``.
@@ -19490,58 +19467,16 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         rejection cannot have fired on this path).
         """
 
-        @helion.kernel(backend="cute")
-        def cute_matmul_residual_fanout(
-            x: torch.Tensor,
-            y: torch.Tensor,
-            residual_a: torch.Tensor,
-            residual_b: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, k = x.size()
-            _, n = y.size()
-            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
-                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
-            return out_a, out_b
-
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        kernel = self._fanout_kernel()
+        args = self._square_args(4)
         # Same canonical config as
         # ``test_aux_pipeline_ab_stages_3_with_c_input_rejected``
         # — only difference is the fan-out kernel shape, which
         # should close the productive-body gate and prevent
         # the rejection from firing.
-        config = helion.Config(
-            block_sizes=[256, 256, 128],
-            l2_groupings=[1],
-            num_warps=4,
-            num_sm_multiplier=1,
-            pid_type="persistent_interleaved",
-            tcgen05_cluster_m=2,
-            tcgen05_ab_stages=3,
-            tcgen05_acc_stages=2,
-            tcgen05_c_stages=2,
-            tcgen05_num_epi_warps=4,
-            tcgen05_strategy="role_local_with_scheduler",
-            tcgen05_warp_spec_scheduler_warps=1,
-            tcgen05_warp_spec_c_input_warps=1,
-            indexing=[
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-        )
+        config = self._canonical_c_input_config(ab_stages=3)
         with patch_cute_mma_support():
-            bound = cute_matmul_residual_fanout.bind(args)
+            bound = kernel.bind(args)
             bound.env.config_spec.cute_tcgen05_search_enabled = True
             # Must not raise BackendUnsupported on the fan-out
             # path despite carrying ``ab_stages=3`` +
@@ -19564,10 +19499,9 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
 
         The productive C-input warp is reachable from the
         normal Helion autotune path when the bound kernel's
-        FX graphs contain a tcgen05 matmul AND at least one
-        ``memory_ops.load`` whose target isn't one of the
-        matmul operands (the residual / bias / chained
-        residual_relu pattern). Pin:
+        FX graphs contain an accepted matmul-to-store chain with at least one
+        per-subtile auxiliary load (the residual / bias / chained
+        residual-relu pattern). Pin:
           - ``cute_tcgen05_aux_kernel_detected`` is True after
             bind.
           - ``tcgen05_strategy`` autotune fragment widens to
@@ -19580,11 +19514,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         from helion._compiler.cute.strategies import Tcgen05Strategy
 
         kernel = self._residual_kernel()
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        args = self._square_args(3)
         with patch_cute_mma_support():
             bound = kernel.bind(args)
         self.assertTrue(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
@@ -19672,37 +19602,13 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         codegen already prevents the over-budget compile.
         """
 
-        @helion.kernel(backend="cute")
-        def cute_matmul_residual_fanout(
-            x: torch.Tensor,
-            y: torch.Tensor,
-            residual_a: torch.Tensor,
-            residual_b: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, k = x.size()
-            _, n = y.size()
-            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
-                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
-            return out_a, out_b
-
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        kernel = self._fanout_kernel()
+        args = self._square_args(4)
         with patch_cute_mma_support():
-            bound = cute_matmul_residual_fanout.bind(args)
-        # Detector is intentionally coarse and DOES flag
-        # fan-out as aux (it has aux loads). The
-        # productive-body safety gate at codegen suppresses
-        # the productive body for fan-out specifically.
+            bound = kernel.bind(args)
+        # Both stores have accepted aux-fused chains, so the detector flags the
+        # kernel even though the productive-body safety gate suppresses the
+        # dedicated C-input pipeline for multi-store fan-out specifically.
         self.assertTrue(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
 
     def test_aux_autotune_fixup_demotes_ab3_c_input1(self) -> None:
@@ -19725,11 +19631,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         from helion._compiler.cute.strategies import Tcgen05Strategy
 
         kernel = self._residual_kernel()
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        args = self._square_args(3)
         with patch_cute_mma_support():
             bound = kernel.bind(args)
         # Manually craft the over-budget combo.
@@ -20010,25 +19912,11 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
     def test_aux_autotune_surface_stays_narrow_for_wrapped_cast_pure_matmul(
         self,
     ) -> None:
-        """Operand-cast wrappers (``lhs.to(dtype) @ rhs.to(dtype)``)
-        are traced through to the underlying ``memory_ops.load``
-        nodes so the detector classifies them as MMA-operand
-        loads, not aux loads.
+        """Operand-cast wrappers do not create an aux-fused store chain.
 
-        Without operand-trace, the detector's "every
-        ``memory_ops.load`` that isn't the exact node arg of
-        the MMA call is aux" rule misclassifies the underlying
-        load behind a ``convert_element_type`` wrapper as aux
-        and the autotune surface widens on a kernel where no
-        true aux load exists — autotune then samples the
-        strictly-worse inert C-input warp on pure matmul.
-
-        Pin: a pure matmul with explicit operand casts (fp32
-        operand tensors cast to bf16 before the dot) keeps
-        the detector flag False — the cast wrapper is walked
-        through to the underlying load via
-        ``_trace_to_load_through_casts`` and the load is
-        classified as an MMA operand, not an aux load.
+        Pin: a pure matmul with explicit fp32-to-bf16 operand casts keeps the
+        detector flag False because its accepted store chain is still an
+        identity epilogue with no auxiliary steps.
         """
         from helion._compiler.cute.strategies import Tcgen05Strategy
 

--- a/test/test_cute_rank3_rhs_b_tma.py
+++ b/test/test_cute_rank3_rhs_b_tma.py
@@ -424,6 +424,17 @@ def _make_non_k_contiguous_args() -> tuple[torch.Tensor, torch.Tensor, torch.Ten
     return a, b_grouped, layout
 
 
+def _make_mn_major_args() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    a, b_grouped, layout = _make_full_args()
+    b_grouped = b_grouped.transpose(1, 2).contiguous().transpose(1, 2)
+    assert b_grouped.stride() == (
+        b_grouped.size(1) * b_grouped.size(2),
+        1,
+        b_grouped.size(1),
+    )
+    return a, b_grouped, layout
+
+
 def _assert_mixed_result(
     out: torch.Tensor,
     args: tuple[torch.Tensor, ...],
@@ -522,6 +533,7 @@ def _seed_configs(
     args: tuple[torch.Tensor, ...],
     mode: str,
 ) -> tuple[Any, list[dict[str, Any]], list[dict[str, Any]]]:
+    kernel.reset()
     with (
         patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
         patch_cute_mma_support(),
@@ -1005,13 +1017,14 @@ def test_grouped_proof_rejects_unproven_aten_targets(target: Any) -> None:
     ("kernel", "args_fn", "config_fn"),
     [
         (_rank3_rhs_grouped_nt, _make_non_k_contiguous_args, _rank3_rhs_tma_config),
+        (_rank3_rhs_grouped_nt, _make_mn_major_args, _grouped_config),
         (
             _bad_mn_tail_zero_store,
             _make_mn_tail_args,
             lambda: _grouped_config(block_n=64, block_k=128),
         ),
     ],
-    ids=("strided-rhs", "non-preserving-tail-store"),
+    ids=("strided-rhs", "mn-major-outside-worklist", "non-preserving-tail-store"),
 )
 def test_rank3_rhs_unsafe_patterns_use_generic_fallback(
     kernel: Any, args_fn: Any, config_fn: Any

--- a/test/test_matmul_heuristics.py
+++ b/test/test_matmul_heuristics.py
@@ -166,9 +166,10 @@ def test_triton_b200_matmul_heuristic_gates_on_hardware() -> None:
     with patch(
         "helion._hardware.get_hardware_info",
         return_value=b200,
-    ):
+    ) as get_hardware_info:
         assert TritonB200MatmulHeuristic.is_eligible(env, SimpleNamespace())
         seed = TritonB200MatmulHeuristic.get_seed_config(env, SimpleNamespace())
+        get_hardware_info.assert_called_once_with(None)
 
     assert seed is not None
     assert dict(seed)["block_sizes"] == [128, 64, 64]
@@ -176,8 +177,9 @@ def test_triton_b200_matmul_heuristic_gates_on_hardware() -> None:
     with patch(
         "helion._hardware.get_hardware_info",
         return_value=h100,
-    ):
+    ) as get_hardware_info:
         assert not TritonB200MatmulHeuristic.is_eligible(env, SimpleNamespace())
+        get_hardware_info.assert_called_once_with(None)
 
 
 def test_b200_formula_subsumes_table_promotion_wiring() -> None:

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -424,8 +424,16 @@ class TestMultiShapeRuntime(unittest.TestCase):
             _RuntimeBoundKernel(backend, settings),
         ]
         case_keys = [
-            SimpleNamespace(specialization_key=("shape", 8), extra_results=()),
-            SimpleNamespace(specialization_key=("shape", 16), extra_results=()),
+            SimpleNamespace(
+                specialization_key=("shape", 8),
+                extra_results=(),
+                compiler_seed_results=(),
+            ),
+            SimpleNamespace(
+                specialization_key=("shape", 16),
+                extra_results=(),
+                compiler_seed_results=(),
+            ),
         ]
         kernel = object.__new__(Kernel)
         kernel.settings = settings  # pyrefly: ignore [bad-assignment]
@@ -452,7 +460,7 @@ class TestMultiShapeRuntime(unittest.TestCase):
                 "geomean",
                 None,
                 "numeric-shapes-v1",
-                ((("shape", 8), ()), (("shape", 16), ())),
+                ((("shape", 8), (), ()), (("shape", 16), (), ())),
             ),
         )
         self.assertEqual(backend.finalized, bounds)

--- a/test/test_specialize.py
+++ b/test/test_specialize.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 import math
+from typing import Any
+from typing import cast
 import unittest
 
 import torch
@@ -754,6 +756,32 @@ class TestMarkStatic(RefEagerTestBase, TestCase):
         key_a_after = fn.specialization_key((a,))
         key_b_after = fn.specialization_key((b,))
         self.assertNotEqual(key_a_after, key_b_after)
+
+    @skipIfRefEager("Specialization-key schemas are not used in ref eager mode")
+    def test_specialization_key_keeps_independent_extra_schemas(self) -> None:
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        a = torch.empty([8], device=DEVICE)
+        b = torch.empty([16], device=DEVICE)
+        signature = fn._base_specialization_key((a,))
+        dynamic_fn = cast("Any", fn)
+
+        dynamic_fn._specialize_extra[signature] = [
+            lambda values: cast("torch.Tensor", values[0]).size(0)
+        ]
+        dynamic_fn._compiler_seed_specialize_extra.pop(signature, None)
+        self.assertNotEqual(fn.specialization_key((a,)), fn.specialization_key((b,)))
+
+        dynamic_fn._specialize_extra.pop(signature)
+        dynamic_fn._compiler_seed_specialize_extra[signature] = (
+            lambda values: (
+                "config_num_sm",
+                cast("torch.Tensor", values[0]).size(0),
+            ),
+        )
+        self.assertNotEqual(fn.specialization_key((a,)), fn.specialization_key((b,)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3447 (`6a16fe28`)
 * #3446 (`68226540`)
 * __->__ #3445 (`1c012826`)
 * #3444 (`e9ca9174`)
 * #3443 (`27b2ad77`, base `main`)

--- --- ---

## Summary

- Add public trace-time heuristic metadata and correctness-fact hooks.
- Carry declared device and input specialization facts through binding and autotuner cache keys while preserving historical empty-key hashes.
- Canonicalize indexless accelerator devices and re-evaluate compiler seeds when a bound kernel is called on a different device, without the removed AOT path-resolver machinery.
- Add a B200 grouped-worklist compiler heuristic that proves eligibility and ranks compatible tile, staging, register, scheduler, panel, and SM-reservation seeds.
- Keep packing caller-owned and live autotuning authoritative; promote defaults only for exact NVIDIA B200 devices with static K.
- Add side-effect-free config construction, conservative fallbacks, and cached exact-name promotion analysis.
- Refactor the grouped kernel behind a factory so callers can use independent binding caches.

## Test plan

- `./lint.sh check`
- `pytest -q test/test_autotuner_heuristics.py test/test_autotuner.py test/test_config_api.py test/test_matmul_heuristics.py test/test_specialize.py`
- `HELION_BACKEND=cute pytest -q test/test_cute_backend.py test/test_cute_deepgemm_selected.py test/test_cute_grouped_gemm_split_sizes.py test/test_cute_lowerings.py`
- The definitive stack collected 3,304 tests. Focused boundary validation completed 376 passes, 84 expected backend-gated skips, and 179 subtests with no failures; Ruff, codespell, and Pyrefly were clean.

## Exact-head performance regression check

Performance was measured from the clean definitive five-PR head `6a16fe28` (tree `b11260a4`) on an idle NVIDIA B200. Three fresh-process/fresh-cache DeepGEMM replicates per selection mode produced:

| Helion selection | DeepGEMM/Helion geomean | Rows won (3-replicate geomean) | Worst row geomean |
|---|---:|---:|---:|
| Reviewed AOT | `1.0160×` | 7/8 | `0.9945×` |
| Compiler heuristic | `1.0177×` | 7/8 | `0.9922×` |

All 48 row-replicate comparisons passed correctness, and every selected-config hash exactly matched the prior validated set. Both results clear the predeclared 98%-of-historical-median no-regression gates. Each worker used a 10 s warmup and 102 balanced, rotated/reversed cold-L2 samples. Telemetry showed only the previously observed idle/software-power-cap reason classes; no thermal or hardware slowdown reason appeared.

## Historical five-provider complete-stack benchmark

These are one-replicate B200 smoke results from the earlier complete-stack source `2e4f90a5` (tree `c255c018`), retained as five-provider coverage rather than an isolated claim for this PR. All 80 comparisons passed correctness. Each cell is `provider_time / Helion_time`; values above `1.0×` mean Helion is faster. `M/group` is nominal; exact ragged per-group `M` values were used internally.

### Reviewed AOT

| Case `(groups × nominal M/group × N × K)` | DeepGEMM | QuACK | cuDNN | cuBLASLt | CUTLASS |
|---|---:|---:|---:|---:|---:|
| 4 × 8192 × 6144 × 7168 | `1.0315×` | `1.0118×` | `1.0148×` | `1.1544×` | `1.2356×` |
| 4 × 8192 × 7168 × 3072 | `0.9926×` | `1.0032×` | `1.0183×` | `1.2015×` | `1.3605×` |
| 4 × 8192 × 4096 × 4096 | `1.0165×` | `0.9922×` | `1.0256×` | `1.0922×` | `1.4075×` |
| 4 × 8192 × 4096 × 2048 | `1.0017×` | `1.0041×` | `1.0192×` | `1.2004×` | `1.3832×` |
| 8 × 4096 × 6144 × 7168 | `1.0277×` | `1.0141×` | `1.0370×` | `1.1517×` | `1.1984×` |
| 8 × 4096 × 7168 × 3072 | `1.0137×` | `0.9984×` | `1.0249×` | `1.1892×` | `1.3604×` |
| 8 × 4096 × 4096 × 4096 | `0.9986×` | `1.0046×` | `1.0433×` | `1.1630×` | `1.3657×` |
| 8 × 4096 × 4096 × 2048 | `1.0165×` | `1.0167×` | `1.0870×` | `1.2704×` | `1.3454×` |
| **Geomean** | **`1.0122×`** | **`1.0056×`** | **`1.0335×`** | **`1.1769×`** | **`1.3302×`** |

### Compiler heuristics

| Case `(groups × nominal M/group × N × K)` | DeepGEMM | QuACK | cuDNN | cuBLASLt | CUTLASS |
|---|---:|---:|---:|---:|---:|
| 4 × 8192 × 6144 × 7168 | `1.0308×` | `1.0102×` | `1.0270×` | `1.1456×` | `1.2321×` |
| 4 × 8192 × 7168 × 3072 | `0.9912×` | `0.9934×` | `1.0211×` | `1.1920×` | `1.4093×` |
| 4 × 8192 × 4096 × 4096 | `1.0175×` | `0.9930×` | `1.0248×` | `1.1496×` | `1.4426×` |
| 4 × 8192 × 4096 × 2048 | `1.0025×` | `1.0026×` | `1.0342×` | `1.2408×` | `1.3849×` |
| 8 × 4096 × 6144 × 7168 | `1.0178×` | `1.0121×` | `1.0350×` | `1.1541×` | `1.1979×` |
| 8 × 4096 × 7168 × 3072 | `1.0125×` | `0.9996×` | `1.0266×` | `1.1859×` | `1.3272×` |
| 8 × 4096 × 4096 × 4096 | `0.9987×` | `1.0095×` | `1.0520×` | `1.1655×` | `1.3990×` |
| 8 × 4096 × 4096 × 2048 | `1.0175×` | `1.0229×` | `1.0869×` | `1.3012×` | `1.2869×` |
| **Geomean** | **`1.0110×`** | **`1.0054×`** | **`1.0383×`** | **`1.1908×`** | **`1.3323×`** |

The historical campaign used one GPU, shared logical B values, the reviewed physical B layout where each provider supports it, fixed shapes, and selected public/default provider paths; it did not exhaust provider candidate spaces. It is retained to show all five provider paths, while the exact-head three-replicate check above covers the final code against DeepGEMM. Neither result supports SOTA, beats-all, or unqualified-fastest claims.
