### PR TITLE
[benchmarks] Add reproducible grouped-GEMM provider-default validation

### DIFF
--- a/benchmarks/cute/compare_grouped_gemm_defaults.py
+++ b/benchmarks/cute/compare_grouped_gemm_defaults.py
@@ -1,0 +1,1472 @@
+"""Compare Helion grouped GEMM with selectable provider public defaults.
+
+The public command launches one fresh worker process per provider/replicate.
+Each worker validates and captures both implementations, performs a 10-second
+thermal warmup, and records 102 cold-L2 paired samples with balanced ordering.
+Compilation, packing, provider selection, and Helion selection stay outside
+the timed region.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from contextlib import suppress
+import importlib.metadata
+from itertools import accumulate
+import json
+import math
+from operator import itemgetter
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmCase
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+    from pretuned_kernels.grouped_gemm_deepgemm.reviewed_profiles import OfficialShape
+    from pretuned_kernels.grouped_gemm_deepgemm.reviewed_profiles import (
+        ReviewedWorklistProfile,
+    )
+    import torch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if __name__ == "__main__":
+    configured_pythonpath = os.environ.get("PYTHONPATH")
+    if configured_pythonpath is not None:
+        startup_directory = Path.cwd()
+        configured_paths = {
+            (startup_directory / configured_path).resolve()
+            for configured_path in configured_pythonpath.split(os.pathsep)
+        }
+        sys.path[:] = [
+            entry
+            for entry in sys.path
+            if (startup_directory / entry).resolve() not in configured_paths
+        ]
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.cute import grouped_gemm_benchmark as common  # noqa: E402
+
+RESULT_SCHEMA = "helion-grouped-gemm-provider-defaults-v2"
+SUMMARY_SCHEMA = "helion-grouped-gemm-provider-summary-v2"
+BENCHMARK_REPETITIONS = 102
+THERMAL_WARMUP_MS = 10_000
+CAPTURE_WARMUPS = 2
+TELEMETRY_INTERVAL_SECONDS = 5
+POST_WORKER_IDLE_GRACE_SECONDS = 5
+PROVIDERS = ("deepgemm", "quack", "cudnn", "cublaslt", "cutlass")
+PROVIDER_SELECTIONS = {
+    "deepgemm": "public_kmajor_nk_no_psum_zero_padding_off",
+    "quack": "public_tuned_false_config_none",
+    "cudnn": "public_a_fallback_build_execute",
+    "cublaslt": "heuristic_result_zero_requested_one",
+    "cutlass": "registry_first_no_timing_search",
+}
+HELION_SELECTIONS = (
+    "compiler_heuristic",
+    "live_autotune",
+    "final_reviewed_aot",
+)
+GROUPED_WORKLIST_HEURISTIC = "cute_tcgen05_grouped_worklist"
+HELION_SELECTION_ENVIRONMENT_VARIABLES = (
+    "HELION_AOT_MODE",
+    "HELION_AUTOTUNER",
+    "HELION_AUTOTUNE_EFFORT",
+    "HELION_AUTOTUNE_RANDOM_SEED",
+    "HELION_BACKEND",
+    "HELION_CAP_AUTOTUNE_NUM_NEIGHBORS",
+    "HELION_CUTE_MMA_IMPL",
+    "HELION_SKIP_CACHE",
+)
+HELION_SELECTION_STARTUP_ENVIRONMENT = {
+    name: os.environ.get(name) for name in HELION_SELECTION_ENVIRONMENT_VARIABLES
+}
+LIVE_AUTOTUNE_CACHE = "LocalAutotuneCache"
+LIVE_AUTOTUNE_SEARCH_POLICY = {
+    "algorithm": "LFBOTreeSearch",
+    "autotune_effort": "full",
+    "force": True,
+    "random_seed": 0,
+    "autotune_cache": LIVE_AUTOTUNE_CACHE,
+    "skip_cache_read_write": True,
+    "fresh_worker_cache": True,
+    "budget_seconds": None,
+    "max_generations_override": None,
+    "effective_max_generations": 20,
+    "best_of_k": 1,
+    "accuracy_check": True,
+    "benchmark_subprocess": True,
+    "benchmark_timeout_seconds": 30,
+    "configured_compile_timeout_seconds": 60,
+    "effective_compile_timeout_seconds": None,
+    "precompile_mode": None,
+    "adaptive_timeout": True,
+    "initial_population_strategy": "from_random",
+    "initial_population": 100,
+    "copies": 5,
+    "best_available_pad_random": True,
+    "finishing_rounds": 0,
+    "num_neighbors_cap": -1,
+    "config_overrides": {},
+    "advanced_controls_files": [],
+    "compiler_seed_candidates_enabled": True,
+}
+WORKER_CACHE_NAMES = {
+    "CUDA_CACHE_PATH": "cuda",
+    "CUTE_DSL_CACHE_DIR": "cute_dsl",
+    "DG_JIT_CACHE_DIR": "deepgemm_jit",
+    "HELION_CACHE_DIR": "helion",
+    "QUACK_CACHE_DIR": "quack",
+    "TORCHINDUCTOR_CACHE_DIR": "torchinductor",
+    "TORCH_EXTENSIONS_DIR": "torch_extensions",
+    "TRITON_CACHE_DIR": "triton",
+    "XDG_CACHE_HOME": "xdg",
+}
+WORKER_CONTROL_PREFIXES = (
+    "CUDA_",
+    "CUTE_DSL_",
+    "DG_",
+    "HELION_",
+    "LD_",
+    "QUACK_",
+    "TORCHINDUCTOR_",
+    "TRITON_",
+)
+COMPILER_AND_LOADER_CONTROLS = frozenset(
+    {
+        "CC",
+        "CFLAGS",
+        "CMAKE_CUDA_COMPILER",
+        "CMAKE_CXX_COMPILER",
+        "CMAKE_C_COMPILER",
+        "CMAKE_INCLUDE_PATH",
+        "CMAKE_LIBRARY_PATH",
+        "CMAKE_PREFIX_PATH",
+        "CMAKE_TOOLCHAIN_FILE",
+        "COMPILER_PATH",
+        "CPATH",
+        "CPPFLAGS",
+        "CPLUS_INCLUDE_PATH",
+        "CUDACXX",
+        "CUDNN_FRONTEND_CUDART_LIB_NAME",
+        "CUDAFLAGS",
+        "CUDAHOSTCXX",
+        "CXX",
+        "CXXFLAGS",
+        "C_INCLUDE_PATH",
+        "GCC_EXEC_PREFIX",
+        "GLIBC_TUNABLES",
+        "LDFLAGS",
+        "LIBRARY_PATH",
+        "NVIDIA_TF32_OVERRIDE",
+        "NVCC",
+        "NVCC_APPEND_FLAGS",
+        "NVCC_CCBIN",
+        "NVCC_PREPEND_FLAGS",
+        "OBJC_INCLUDE_PATH",
+        "PKG_CONFIG_LIBDIR",
+        "PKG_CONFIG_PATH",
+        "PKG_CONFIG_SYSROOT_DIR",
+        "SDKROOT",
+        "TORCH_ALLOW_TF32_CUBLAS_OVERRIDE",
+        "TORCH_CUDA_ARCH_LIST",
+        "CUBLAS_WORKSPACE_CONFIG",
+    }
+)
+TELEMETRY_FIELDS = (
+    "timestamp",
+    "uuid",
+    "pstate",
+    "clocks.sm",
+    "power.draw",
+    "power.limit",
+    "temperature.gpu",
+    "utilization.gpu",
+    "memory.used",
+    "clocks_event_reasons.active",
+)
+WORKER_TERMINATION_GRACE_SECONDS = 5
+NVIDIA_SMI_TIMEOUT_SECONDS = 10
+
+
+class _CampaignInterrupted(Exception):
+    def __init__(self, signum: int) -> None:
+        super().__init__(signum)
+        self.signum = signum
+
+
+def _require_live_autotuner_algorithm() -> str:
+    expected = cast("str", LIVE_AUTOTUNE_SEARCH_POLICY["algorithm"])
+    observed = os.environ.get("HELION_AUTOTUNER")
+    if observed != expected:
+        raise RuntimeError(
+            f"live autotune requires HELION_AUTOTUNER={expected!r}, got {observed!r}"
+        )
+    return expected
+
+
+def _layout_name(b_major: str) -> str:
+    if b_major == "k":
+        return "k_major"
+    if b_major == "n":
+        return "n_major"
+    raise ValueError(f"unsupported reviewed B major {b_major!r}")
+
+
+def make_exact_common_inputs(
+    case: GroupedGemmCase,
+    shape: OfficialShape,
+    device: torch.device,
+) -> tuple[GroupedGemmInputs, ReviewedWorklistProfile]:
+    """Generate the final benchmark's exact logical values for one row."""
+
+    from pretuned_kernels.grouped_gemm_deepgemm import (
+        _deepgemm_public_api as public_api,
+    )
+    from pretuned_kernels.grouped_gemm_deepgemm import reviewed_profiles
+    import torch
+
+    expected_shape = (
+        shape.groups,
+        shape.expected_m_per_group,
+        shape.n,
+        shape.k,
+    )
+    case_shape = (
+        case.groups,
+        case.expected_m_per_group,
+        case.n,
+        case.k,
+    )
+    if case_shape != expected_shape:
+        raise RuntimeError(f"workload shape mismatch: {case_shape} != {expected_shape}")
+    profile = reviewed_profiles.exact_reviewed_worklist_profile(*expected_shape)
+    packed_a, logical_b, _helion_b, _layout, reference, _worklist = (
+        public_api._make_reviewed_case(
+            shape,
+            case.actual_ms,
+            device,
+        )
+    )
+    stored_ms = tuple(
+        common.align(actual_m, profile.source_m_tile) for actual_m in case.actual_ms
+    )
+    starts = tuple(accumulate((0, *stored_ms)))[:-1]
+    compact_a = torch.cat(
+        tuple(
+            packed_a[start : start + actual_m]
+            for start, actual_m in zip(starts, case.actual_ms, strict=True)
+        )
+    )
+    oracle = tuple(
+        reference[start : start + actual_m]
+        for start, actual_m in zip(starts, case.actual_ms, strict=True)
+    )
+    b_n_major = logical_b.transpose(1, 2).contiguous().transpose(1, 2)
+    if not torch.equal(logical_b, b_n_major):
+        raise RuntimeError("grouped B layout conversion changed logical values")
+    offsets = torch.tensor(
+        (0, *accumulate(case.actual_ms)),
+        device=device,
+        dtype=torch.int32,
+    )
+    inputs = common.GroupedGemmInputs(
+        case=case,
+        compact_a=compact_a,
+        b=logical_b,
+        b_n_major=b_n_major,
+        offsets=offsets,
+        oracle=oracle,
+    )
+    return inputs, profile
+
+
+def prepare_helion(
+    inputs: GroupedGemmInputs,
+    profile: ReviewedWorklistProfile,
+    selection_mode: str,
+) -> PreparedImplementation:
+    """Bind Helion with compiler, live-autotune, or reviewed-AOT selection."""
+
+    from pretuned_kernels.grouped_gemm_deepgemm import (
+        _deepgemm_public_api as public_api,
+    )
+    from pretuned_kernels.grouped_gemm_deepgemm import grouped_gemm_deepgemm
+    from pretuned_kernels.grouped_gemm_deepgemm import reviewed_profiles
+    import torch
+
+    packed = common.pack_compact_rows(inputs, profile.source_m_tile)
+    b_layout = _layout_name(profile.b_major)
+    b = inputs.b_for_layout(b_layout)
+    kernel_args = (
+        packed.a,
+        b,
+        packed.worklist,
+        inputs.case.expected_m_per_group,
+        profile.source_m_tile,
+    )
+    kernel = grouped_gemm_deepgemm.create_grouped_gemm_deepgemm_kernel()
+    if selection_mode == "live_autotune":
+        kernel.settings.autotune_cache = LIVE_AUTOTUNE_CACHE
+    bound = kernel.bind(kernel_args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    if selection_mode == "final_reviewed_aot":
+        initial_output = bound(*kernel_args)
+        config = public_api._effective_reviewed_config(bound, profile)
+        selection_evidence: dict[str, object] = {
+            "selection_mode": selection_mode,
+            "reviewed_profile": {
+                "name": profile.config_name,
+                "manifest_sha256": (reviewed_profiles.REVIEWED_PROFILE_MANIFEST_SHA256),
+                "role": "selected_config_and_packing",
+                "b_layout": b_layout,
+                "source_m_tile": profile.source_m_tile,
+            },
+            "config": config,
+            "config_sha256": common.config_sha256(config["effective"]),
+            "a_layout": {
+                "kind": "aligned_contiguous_worklist",
+                "alignment": profile.source_m_tile,
+                "logical_values_bitwise_equal": True,
+            },
+        }
+    else:
+        config_spec = bound.config_spec
+        compiler_primary = config_spec.compiler_default_config
+        if compiler_primary is None:
+            raise RuntimeError(
+                "grouped GEMM compiler heuristics produced no primary config"
+            )
+        compiler_promoted = dict(compiler_primary.config)
+        fired_heuristics = list(config_spec.autotuner_heuristics)
+        ordered_seeds = [
+            dict(seed.config) for seed in config_spec.compiler_seed_configs
+        ]
+        promoted_indexes = [
+            index
+            for index, seed in enumerate(ordered_seeds)
+            if seed == compiler_promoted
+        ]
+        grouped_worklist_seed_indexes = [
+            index
+            for index, seed in enumerate(ordered_seeds)
+            if seed.get("tcgen05_grouped_mode") == "worklist_nm"
+            and seed.get("tcgen05_grouped_worklist_source_m_tile")
+            == profile.source_m_tile
+        ]
+        if (
+            fired_heuristics.count(GROUPED_WORKLIST_HEURISTIC) != 1
+            or not grouped_worklist_seed_indexes
+            or compiler_promoted.get("tcgen05_grouped_mode") != "worklist_nm"
+            or compiler_promoted.get("tcgen05_grouped_worklist_source_m_tile")
+            != profile.source_m_tile
+            or promoted_indexes != [grouped_worklist_seed_indexes[0]]
+        ):
+            raise RuntimeError(
+                "compiler primary is not the named grouped-worklist rank-zero promotion"
+            )
+        compiler_effective_config = config_spec.default_config()
+        compiler_effective = dict(compiler_effective_config.config)
+        compiler_evidence = {
+            "promoting_heuristic": GROUPED_WORKLIST_HEURISTIC,
+            "fired_heuristics": fired_heuristics,
+            "promoted": compiler_promoted,
+            "promoted_sha256": common.config_sha256(compiler_promoted),
+            "effective": compiler_effective,
+            "effective_sha256": common.config_sha256(compiler_effective),
+            "ordered_seeds": ordered_seeds,
+            "ordered_seed_sha256": [
+                common.config_sha256(seed) for seed in ordered_seeds
+            ],
+            "promoted_seed_index": promoted_indexes[0],
+            "grouped_worklist_seed_indexes": grouped_worklist_seed_indexes,
+            "promotion_policy": "named_heuristic_rank_zero_to_compiler_default",
+            "effective_config_source": "ConfigSpec.default_config",
+        }
+        if selection_mode == "compiler_heuristic":
+            selected_config = compiler_effective_config
+            bound.set_config(selected_config)
+            selection_api = "BoundKernel.set_config(ConfigSpec.default_config())"
+            live_search = None
+        elif selection_mode == "live_autotune":
+            from helion.autotuner.effort_profile import get_effort_profile
+
+            # CuTe compiles each candidate inline; make the backend's effective
+            # no-precompile policy explicit before recording and running search.
+            bound.settings.autotune_precompile = None
+            autotuner_algorithm = _require_live_autotuner_algorithm()
+            profile_settings = get_effort_profile(bound.settings.autotune_effort)
+            lfbo = profile_settings.lfbo_pattern_search
+            if lfbo is None:
+                raise RuntimeError("live autotune did not resolve a full LFBO profile")
+            live_search = {
+                "algorithm": autotuner_algorithm,
+                "autotune_effort": bound.settings.autotune_effort,
+                "force": True,
+                "random_seed": bound.settings.autotune_random_seed,
+                "autotune_cache": bound.settings.autotune_cache,
+                "skip_cache_read_write": os.environ.get("HELION_SKIP_CACHE") == "1",
+                "fresh_worker_cache": True,
+                "budget_seconds": bound.settings.autotune_budget_seconds,
+                "max_generations_override": bound.settings.autotune_max_generations,
+                "effective_max_generations": (
+                    bound.settings.autotune_max_generations or lfbo.max_generations
+                ),
+                "best_of_k": bound.settings.autotune_best_of_k,
+                "accuracy_check": bound.settings.autotune_accuracy_check,
+                "benchmark_subprocess": bound.settings.autotune_benchmark_subprocess,
+                "benchmark_timeout_seconds": (
+                    bound.settings.autotune_benchmark_timeout
+                ),
+                "configured_compile_timeout_seconds": (
+                    bound.settings.autotune_compile_timeout
+                ),
+                "effective_compile_timeout_seconds": None,
+                "precompile_mode": bound.settings.autotune_precompile,
+                "adaptive_timeout": bound.settings.autotune_adaptive_timeout,
+                "initial_population_strategy": (
+                    bound.settings.autotune_initial_population_strategy
+                    or lfbo.initial_population_strategy
+                ),
+                "initial_population": lfbo.initial_population,
+                "copies": lfbo.copies,
+                "best_available_pad_random": lfbo.best_available_pad_random,
+                "finishing_rounds": profile_settings.finishing_rounds,
+                "num_neighbors_cap": int(
+                    os.environ.get("HELION_CAP_AUTOTUNE_NUM_NEIGHBORS", "-1")
+                ),
+                "config_overrides": bound.settings.autotune_config_overrides,
+                "advanced_controls_files": bound.settings.autotune_search_acf,
+                "compiler_seed_candidates_enabled": bool(ordered_seeds)
+                and not bound.settings.disable_autotuner_heuristics,
+            }
+            if live_search != LIVE_AUTOTUNE_SEARCH_POLICY:
+                raise RuntimeError(
+                    "live autotune search policy differs from the publication contract"
+                )
+            selected_config = bound.autotune(kernel_args, force=True)
+            selection_api = "BoundKernel.autotune(force=True)"
+        else:
+            raise ValueError(f"unsupported Helion selection {selection_mode!r}")
+        initial_output = bound(*kernel_args)
+        selected_requested = dict(selected_config.config)
+        selected_effective = dict(
+            bound.config_spec.normalized_config(selected_config).config
+        )
+        if (
+            selected_effective.get("tcgen05_grouped_worklist_source_m_tile")
+            != profile.source_m_tile
+        ):
+            raise RuntimeError(
+                "Helion selection changed the fixed physical-A source tile"
+            )
+        selection_evidence = {
+            "selection_mode": selection_mode,
+            "autotuned": selection_mode == "live_autotune",
+            "reviewed_profile": {
+                "name": profile.config_name,
+                "manifest_sha256": (reviewed_profiles.REVIEWED_PROFILE_MANIFEST_SHA256),
+                "role": "packing_constraints_only",
+                "b_layout": b_layout,
+                "source_m_tile": profile.source_m_tile,
+            },
+            "compiler_heuristic": compiler_evidence,
+            "selection_api": selection_api,
+            "config": {
+                "requested": selected_requested,
+                "effective": selected_effective,
+            },
+            "config_sha256": common.config_sha256(selected_effective),
+            "live_search": live_search,
+            "a_layout": {
+                "kind": "aligned_contiguous_worklist",
+                "alignment": profile.source_m_tile,
+                "logical_values_bitwise_equal": True,
+            },
+        }
+    torch.cuda.synchronize()
+
+    def output_tensors(result: object) -> tuple[torch.Tensor, ...]:
+        if not isinstance(result, torch.Tensor):
+            raise TypeError("Helion grouped GEMM returned a non-tensor")
+        return (result,)
+
+    def logical_outputs(result: object) -> tuple[torch.Tensor, ...]:
+        if not isinstance(result, torch.Tensor):
+            raise TypeError("Helion grouped GEMM returned a non-tensor")
+        if not packed.output_padding_is_zero(result):
+            raise RuntimeError("Helion did not zero aligned output padding")
+        return packed.output_slices(result)
+
+    def call() -> torch.Tensor:
+        return bound(*kernel_args)
+
+    return common.PreparedImplementation(
+        name=f"helion-{selection_mode.replace('_', '-')}-{inputs.case.id}",
+        call=call,
+        output_tensors=output_tensors,
+        logical_outputs=logical_outputs,
+        config=selection_evidence,
+        owners=(
+            inputs,
+            packed,
+            b,
+            kernel,
+            bound,
+            initial_output,
+            *kernel_args,
+        ),
+        track_cute_graph=True,
+    )
+
+
+def prepare_provider_default(
+    provider: str,
+    inputs: GroupedGemmInputs,
+    profile: ReviewedWorklistProfile,
+    *,
+    cutlass_root: Path | None,
+    deepgemm_root: Path | None,
+) -> PreparedImplementation:
+    """Prepare exactly one provider-selected default implementation."""
+
+    reviewed_layout = _layout_name(profile.b_major)
+    if provider == "deepgemm":
+        from benchmarks.cute import grouped_gemm_deepgemm_support as support
+        from pretuned_kernels.grouped_gemm_deepgemm import (
+            _deepgemm_public_api as public_api,
+        )
+        import torch
+
+        if deepgemm_root is None:
+            raise ValueError("--deepgemm-root is required for the DeepGEMM provider")
+        deep_gemm, provenance = support.import_deepgemm(
+            deepgemm_root,
+            support.M_ALIGNMENT,
+        )
+        packed = common.pack_compact_rows(inputs, support.M_ALIGNMENT)
+        layout = torch.full(
+            (packed.a.size(0),),
+            -1,
+            device=packed.a.device,
+            dtype=torch.int32,
+        )
+        for group, (start, actual_m) in enumerate(
+            zip(packed.starts, packed.actual_ms, strict=True)
+        ):
+            layout[start : start + actual_m] = group
+        output = torch.empty(
+            (packed.a.size(0), inputs.case.n),
+            device=packed.a.device,
+            dtype=packed.a.dtype,
+        )
+
+        def call() -> torch.Tensor:
+            return public_api._launch_deepgemm(
+                deep_gemm,
+                packed.a,
+                inputs.b,
+                output,
+                layout,
+            )
+
+        prepared = common.PreparedImplementation(
+            name="deepgemm-public-default",
+            call=call,
+            output_tensors=lambda result: (cast("torch.Tensor", result),),
+            logical_outputs=lambda result: packed.output_slices(
+                cast("torch.Tensor", result)
+            ),
+            config={
+                "provider": "deepgemm",
+                "selection_mode": "public_api_fixed_no_tune",
+                "b_layout": "k_major",
+                "api": {
+                    "function": "m_grouped_bf16_gemm_nt_contiguous",
+                    "compiled_dims": "nk",
+                    "use_psum_layout": False,
+                    "ensure_zero_padding": False,
+                },
+                "a_layout": {
+                    "kind": "aligned_contiguous_layout",
+                    "alignment": support.M_ALIGNMENT,
+                    "logical_values_bitwise_equal": True,
+                },
+                "preprocessing_timed": False,
+                "provenance": provenance,
+            },
+            owners=(deep_gemm, inputs, packed, layout, output),
+        )
+    elif provider == "cutlass":
+        from benchmarks.cute.cutlass_contiguous_grouped_gemm import (
+            prepare_cutlass_default,
+        )
+
+        if cutlass_root is None:
+            raise ValueError("--cutlass-root is required for the CUTLASS provider")
+        prepared = prepare_cutlass_default(inputs, cutlass_root=cutlass_root)
+    elif provider == "quack":
+        from benchmarks.cute.quack_grouped_gemm import prepare_quack_default
+
+        prepared = prepare_quack_default(inputs, b_layout=reviewed_layout)
+    elif provider == "cudnn":
+        from benchmarks.cute.cudnn_grouped_gemm import prepare_cudnn_default
+
+        prepared = prepare_cudnn_default(inputs, b_layout=reviewed_layout)
+    elif provider == "cublaslt":
+        from benchmarks.cute.cublaslt_grouped_gemm import prepare_cublaslt_default
+
+        prepared = prepare_cublaslt_default(inputs, b_layout=reviewed_layout)
+    else:
+        raise ValueError(f"unsupported provider {provider!r}")
+    provider_layout = cast("str", prepared.config["b_layout"])
+    prepared.config.update(
+        {
+            "reviewed_helion_b_layout": reviewed_layout,
+            "physical_b_layout_matches_reviewed": provider_layout == reviewed_layout,
+            "logical_b_values_bitwise_equal": True,
+        }
+    )
+    return prepared
+
+
+def _validated_capture(
+    prepared: PreparedImplementation,
+    oracle: Sequence[torch.Tensor],
+) -> tuple[common.CapturedImplementation, dict[str, Any]]:
+    captured = common.capture_implementation(prepared, warmups=CAPTURE_WARMUPS)
+    correctness = common.validate_capture(captured, oracle)
+    if not correctness["ok"]:
+        raise RuntimeError(f"{prepared.name} failed correctness: {correctness}")
+    return captured, correctness
+
+
+def run_case(
+    provider: str,
+    case: GroupedGemmCase,
+    shape: OfficialShape,
+    device: torch.device,
+    *,
+    helion_selection: str,
+    cutlass_root: Path | None,
+    deepgemm_root: Path | None,
+) -> dict[str, object]:
+    """Validate and time one selected Helion/provider-default pair."""
+
+    from pretuned_kernels import _bench
+    import torch
+
+    inputs, profile = make_exact_common_inputs(case, shape, device)
+    # Provider imports, compilation, graph capture, and paired timing must not
+    # perturb later rows. Thermal warmup intentionally advances the continuous
+    # seed-0 public input stream once between the two isolated scopes.
+    with torch.random.fork_rng(devices=[device.index]):
+        helion = prepare_helion(inputs, profile, helion_selection)
+        provider_impl = prepare_provider_default(
+            provider,
+            inputs,
+            profile,
+            cutlass_root=cutlass_root,
+            deepgemm_root=deepgemm_root,
+        )
+        helion_capture, helion_correctness = _validated_capture(helion, inputs.oracle)
+        provider_capture, provider_correctness = _validated_capture(
+            provider_impl,
+            inputs.oracle,
+        )
+    _bench.thermal_warmup(THERMAL_WARMUP_MS)
+    with torch.random.fork_rng(devices=[device.index]):
+        helion_ms, provider_ms = _bench.bench_pre_captured_cudagraphs(
+            [helion_capture.replay, provider_capture.replay],
+            rep=BENCHMARK_REPETITIONS,
+        )
+    if not all(
+        math.isfinite(value) and value > 0.0 for value in (helion_ms, provider_ms)
+    ):
+        raise RuntimeError("benchmark timings must be finite and positive")
+    return {
+        "case": case.as_dict(),
+        "row_index": shape.row_index,
+        "configs": {
+            "helion": helion.config,
+            "provider": provider_impl.config,
+        },
+        "correctness": {
+            "passed": True,
+            "helion": helion_correctness,
+            "provider": provider_correctness,
+        },
+        "timings": {
+            "helion_ms": helion_ms,
+            "provider_ms": provider_ms,
+            "helion_us": helion_ms * 1000.0,
+            "provider_us": provider_ms * 1000.0,
+            "helion_speedup": provider_ms / helion_ms,
+        },
+    }
+
+
+def parse_providers(text: str) -> tuple[str, ...]:
+    providers = tuple(item.strip().lower() for item in text.split(",") if item.strip())
+    if not providers:
+        raise argparse.ArgumentTypeError("select at least one provider")
+    unknown = tuple(provider for provider in providers if provider not in PROVIDERS)
+    if unknown:
+        raise argparse.ArgumentTypeError(f"unknown providers: {', '.join(unknown)}")
+    if len(set(providers)) != len(providers):
+        raise argparse.ArgumentTypeError("provider list contains duplicates")
+    return providers
+
+
+def _positive_int(text: str) -> int:
+    value = int(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return value
+
+
+def _nonnegative_int(text: str) -> int:
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative integer")
+    return value
+
+
+def _existing_directory(text: str) -> Path:
+    path = Path(text).expanduser().resolve()
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError(f"directory does not exist: {path}")
+    return path
+
+
+def _git_value(*arguments: str) -> str:
+    completed = subprocess.run(
+        ("git", "-C", str(REPO_ROOT), *arguments),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(f"git {' '.join(arguments)} failed: {detail}")
+    return completed.stdout.strip()
+
+
+def _source_identity() -> dict[str, str]:
+    status = _git_value("status", "--porcelain=v1", "--untracked-files=all")
+    if status:
+        raise RuntimeError("benchmark requires a clean Helion checkout")
+    return {
+        "commit": _git_value("rev-parse", "HEAD"),
+        "tree": _git_value("rev-parse", "HEAD^{tree}"),
+    }
+
+
+def _device_info(device: torch.device) -> dict[str, object]:
+    import torch
+
+    properties = torch.cuda.get_device_properties(device)
+    capability = torch.cuda.get_device_capability(device)
+    if not common.is_canonical_b200(device.type, properties.name, capability):
+        raise RuntimeError(
+            "grouped-GEMM defaults benchmark requires NVIDIA B200/SM100, got "
+            f"{properties.name!r} capability {capability}"
+        )
+    uuid = str(properties.uuid)
+    return {
+        "visible": common.require_single_visible_device(),
+        "name": properties.name,
+        "capability": list(capability),
+        "uuid": uuid if uuid.startswith("GPU-") else f"GPU-{uuid}",
+        "multi_processor_count": properties.multi_processor_count,
+        "total_memory": properties.total_memory,
+    }
+
+
+def _worker_cache_directories(run_dir: Path) -> dict[str, str]:
+    caches = {}
+    for variable, relative in WORKER_CACHE_NAMES.items():
+        path = run_dir / "cache" / relative
+        path.mkdir(parents=True)
+        caches[variable] = str(path)
+    return caches
+
+
+def _selection_environment(selection: str) -> dict[str, str]:
+    environment = {
+        "HELION_AOT_MODE": (
+            "evaluate" if selection == "final_reviewed_aot" else "disabled"
+        ),
+        "HELION_AUTOTUNER": "LFBOTreeSearch",
+        "HELION_AUTOTUNE_EFFORT": "full",
+        "HELION_AUTOTUNE_RANDOM_SEED": "0",
+        "HELION_BACKEND": "cute",
+        "HELION_CAP_AUTOTUNE_NUM_NEIGHBORS": "-1",
+        "HELION_CUTE_MMA_IMPL": "tcgen05",
+    }
+    if selection == "live_autotune":
+        environment["HELION_SKIP_CACHE"] = "1"
+    return environment
+
+
+def _run_worker(args: argparse.Namespace) -> int:
+    selection_environment = _selection_environment(args.helion_selection)
+    expected_selection_environment = {
+        key: selection_environment.get(key)
+        for key in HELION_SELECTION_ENVIRONMENT_VARIABLES
+    }
+    if expected_selection_environment != HELION_SELECTION_STARTUP_ENVIRONMENT:
+        raise RuntimeError("Helion selection environment was not set before startup")
+    if os.environ.get("HELION_HEURISTIC_DIR"):
+        raise RuntimeError("--worker does not permit HELION_HEURISTIC_DIR")
+    run_dir = args.run_dir.expanduser().resolve()
+    if not run_dir.is_dir() or (run_dir / "result.json").exists():
+        raise RuntimeError(f"worker requires a fresh run directory: {run_dir}")
+
+    common.require_single_visible_device()
+    import torch
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+    device_info = _device_info(device)
+    oracle_precision = common.configure_oracle_precision()
+    from pretuned_kernels.grouped_gemm_deepgemm import reviewed_profiles
+
+    cases = common.official_cases()
+    if len(cases) != 8 or len(reviewed_profiles.OFFICIAL_SHAPES) != 8:
+        raise RuntimeError("benchmark requires exactly eight reviewed cases")
+    torch.manual_seed(0)
+    rows = [
+        run_case(
+            args.provider,
+            case,
+            shape,
+            device,
+            helion_selection=args.helion_selection,
+            cutlass_root=args.cutlass_root,
+            deepgemm_root=args.deepgemm_root,
+        )
+        for case, shape in zip(
+            cases,
+            reviewed_profiles.OFFICIAL_SHAPES,
+            strict=True,
+        )
+    ]
+    result = {
+        "schema": RESULT_SCHEMA,
+        "provider": args.provider,
+        "replicate": args.replicate,
+        "helion_selection": args.helion_selection,
+        "device": device_info,
+        "source": _source_identity(),
+        "versions": {
+            "python": sys.version.split()[0],
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+        },
+        "settings": {
+            "input_seed": 0,
+            "provider_selection": PROVIDER_SELECTIONS[args.provider],
+            "helion_selection_timed": False,
+            "provider_selection_timed": False,
+            "capture_warmups": CAPTURE_WARMUPS,
+            "repetitions": BENCHMARK_REPETITIONS,
+            "thermal_warmup_ms": THERMAL_WARMUP_MS,
+            "cold_l2": True,
+            "balanced_rotated_reversed_order": True,
+            "oracle_float32_matmul_precision": oracle_precision,
+        },
+        "rows": rows,
+    }
+    json.dumps(result, allow_nan=False)
+    common.write_result(run_dir / "result.json", result)
+    print(json.dumps({"result": str(run_dir / "result.json")}))
+    return 0
+
+
+def _provider_roots(args: argparse.Namespace) -> dict[str, Path]:
+    roots = {
+        provider: root
+        for provider, root in (
+            ("deepgemm", args.deepgemm_root),
+            ("cutlass", args.cutlass_root),
+        )
+        if root is not None
+    }
+    for provider in ("deepgemm", "cutlass"):
+        if provider in args.providers and provider not in roots:
+            raise ValueError(f"--{provider}-root is required for {provider}")
+        if provider not in args.providers and provider in roots:
+            raise ValueError(f"--{provider}-root requires selecting {provider}")
+    return roots
+
+
+def _worker_environment(
+    run_dir: Path,
+    *,
+    cuda_visible_devices: str,
+    helion_selection: str,
+) -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in tuple(environment):
+        if name.startswith((*WORKER_CONTROL_PREFIXES, "PYTHON")) or (
+            name in COMPILER_AND_LOADER_CONTROLS
+        ):
+            environment.pop(name)
+    cuda_home, cudart = _installed_cuda_runtime()
+    environment.update(_selection_environment(helion_selection))
+    environment.update(_worker_cache_directories(run_dir))
+    environment["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
+    environment["CUDA_HOME"] = str(cuda_home)
+    environment["CUDA_PATH"] = str(cuda_home)
+    environment["CUDNN_FRONTEND_CUDART_LIB_NAME"] = str(cudart)
+    environment["PYTHONHASHSEED"] = "0"
+    environment["PYTHONNOUSERSITE"] = "1"
+    environment["PYTHONSAFEPATH"] = "1"
+    environment["PYTHONUTF8"] = "1"
+    environment["PATH"] = os.pathsep.join(
+        (
+            str(cuda_home / "bin"),
+            str(Path(sys.executable).resolve().parent),
+            "/usr/local/sbin",
+            "/usr/local/bin",
+            "/usr/sbin",
+            "/usr/bin",
+            "/sbin",
+            "/bin",
+        )
+    )
+    environment["PYTHONPATH"] = str(REPO_ROOT)
+    return environment
+
+
+def _installed_cuda_runtime() -> tuple[Path, Path]:
+    distribution = importlib.metadata.distribution("nvidia-cuda-runtime")
+    candidates = [
+        Path(str(distribution.locate_file(path))).resolve(strict=True)
+        for path in distribution.files or ()
+        if Path(path).name == "libcudart.so.13"
+    ]
+    if len(candidates) != 1 or not candidates[0].is_file():
+        raise RuntimeError(
+            "installed nvidia-cuda-runtime must contain one libcudart.so.13"
+        )
+    cudart = candidates[0]
+    cuda_home = cudart.parents[1]
+    if not (cuda_home / "bin" / "nvcc").is_file():
+        raise RuntimeError(f"installed CUDA runtime has no nvcc: {cuda_home}")
+    return cuda_home, cudart
+
+
+def _worker_command(
+    args: argparse.Namespace,
+    provider: str,
+    replicate: int,
+    run_dir: Path,
+    roots: dict[str, Path],
+) -> list[str]:
+    command = [
+        sys.executable,
+        "-u",
+        "-X",
+        f"pycache_prefix={run_dir / 'cache' / 'pycache'}",
+        str(Path(__file__).resolve()),
+        "--worker",
+        "--provider",
+        provider,
+        "--replicate",
+        str(replicate),
+        "--run-dir",
+        str(run_dir),
+        "--output-dir",
+        str(args.output_dir),
+        "--helion-selection",
+        args.helion_selection,
+    ]
+    if provider in roots:
+        command.extend((f"--{provider}-root", str(roots[provider])))
+    return command
+
+
+def _nvidia_smi(*arguments: str) -> str:
+    completed = subprocess.run(
+        ("nvidia-smi", *arguments),
+        check=False,
+        capture_output=True,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        timeout=NVIDIA_SMI_TIMEOUT_SECONDS,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(f"nvidia-smi failed ({completed.returncode}): {detail}")
+    return completed.stdout
+
+
+def _resolve_target_gpu(cuda_visible_devices: str) -> str:
+    selector = common.require_single_visible_device(cuda_visible_devices)
+    output = _nvidia_smi(
+        "-i",
+        selector,
+        "--query-gpu=uuid",
+        "--format=csv,noheader,nounits",
+    )
+    rows = [line.strip() for line in output.splitlines() if line.strip()]
+    if len(rows) != 1 or not rows[0].startswith("GPU-"):
+        raise RuntimeError("target GPU UUID query did not return one physical GPU")
+    return rows[0]
+
+
+def _require_target_gpu_idle(target_gpu_uuid: str) -> None:
+    output = _nvidia_smi(
+        "--query-compute-apps=gpu_uuid,pid,process_name,used_memory",
+        "--format=csv,noheader,nounits",
+    )
+    for row in (line.strip() for line in output.splitlines() if line.strip()):
+        fields = tuple(field.strip() for field in row.split(",", maxsplit=3))
+        if len(fields) != 4:
+            raise RuntimeError("compute-application query returned malformed CSV")
+        if fields[0] == target_gpu_uuid:
+            raise RuntimeError(f"target GPU is not idle: {row}")
+
+
+def _query_telemetry(target_gpu_uuid: str) -> str:
+    fields = ",".join(TELEMETRY_FIELDS)
+    output = _nvidia_smi(
+        "-i",
+        target_gpu_uuid,
+        f"--query-gpu={fields}",
+        "--format=csv,noheader,nounits",
+    )
+    rows = [line.strip() for line in output.splitlines() if line.strip()]
+    if len(rows) != 1:
+        raise RuntimeError("nvidia-smi telemetry query did not return one row")
+    values = tuple(field.strip() for field in rows[0].split(","))
+    if len(values) != len(TELEMETRY_FIELDS) or values[1] != target_gpu_uuid:
+        raise RuntimeError("telemetry query did not return the target GPU UUID")
+    return ",".join(values)
+
+
+def _wait_for_target_gpu_idle(target_gpu_uuid: str) -> None:
+    deadline = time.monotonic() + POST_WORKER_IDLE_GRACE_SECONDS
+    while True:
+        try:
+            _require_target_gpu_idle(target_gpu_uuid)
+        except RuntimeError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.25)
+        else:
+            return
+
+
+def _summarize_telemetry(path: Path, target_gpu_uuid: str) -> dict[str, Any]:
+    lines = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    if not lines or tuple(lines[0].split(",")) != TELEMETRY_FIELDS:
+        raise RuntimeError(f"malformed telemetry header: {path}")
+    active_reasons: Counter[str] = Counter()
+    for line in lines[1:]:
+        fields = tuple(field.strip() for field in line.split(","))
+        if len(fields) != len(TELEMETRY_FIELDS) or fields[1] != target_gpu_uuid:
+            raise RuntimeError(f"telemetry is not bound to {target_gpu_uuid}: {path}")
+        try:
+            active = int(fields[-1], 0)
+        except ValueError as error:
+            raise RuntimeError(f"invalid active clock-event reason: {path}") from error
+        if active:
+            active_reasons[fields[-1]] += 1
+    return {
+        "sample_count": len(lines) - 1,
+        "active_clock_event_reason_sample_count": sum(active_reasons.values()),
+        "active_clock_event_reasons": dict(sorted(active_reasons.items())),
+    }
+
+
+def _process_group_exists(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
+    previous_interrupt = signal.signal(signal.SIGINT, signal.SIG_IGN)
+    previous_terminate = signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    try:
+        if not _process_group_exists(process.pid):
+            process.wait()
+            return
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGTERM)
+        deadline = time.monotonic() + WORKER_TERMINATION_GRACE_SECONDS
+        while _process_group_exists(process.pid) and time.monotonic() < deadline:
+            process.poll()
+            time.sleep(0.1)
+        if _process_group_exists(process.pid):
+            with suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+    finally:
+        signal.signal(signal.SIGINT, previous_interrupt)
+        signal.signal(signal.SIGTERM, previous_terminate)
+
+
+def _run_monitored_worker(
+    command: Sequence[str],
+    *,
+    environment: dict[str, str],
+    log_path: Path,
+    telemetry_path: Path,
+    target_gpu_uuid: str,
+) -> tuple[int, int]:
+    samples = 0
+    _require_target_gpu_idle(target_gpu_uuid)
+    try:
+        with log_path.open("xb") as log, telemetry_path.open("x") as telemetry:
+            telemetry.write(",".join(TELEMETRY_FIELDS) + "\n")
+            process = subprocess.Popen(
+                command,
+                cwd=REPO_ROOT,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            try:
+                next_sample = time.monotonic()
+                while process.poll() is None:
+                    now = time.monotonic()
+                    if now >= next_sample:
+                        telemetry.write(_query_telemetry(target_gpu_uuid) + "\n")
+                        telemetry.flush()
+                        samples += 1
+                        next_sample = now + TELEMETRY_INTERVAL_SECONDS
+                    time.sleep(min(0.25, max(0.0, next_sample - time.monotonic())))
+                telemetry.write(_query_telemetry(target_gpu_uuid) + "\n")
+                returncode = process.wait()
+                return returncode, samples + 1
+            finally:
+                _terminate_process(process)
+    finally:
+        _wait_for_target_gpu_idle(target_gpu_uuid)
+
+
+def _geomean(values: Sequence[float]) -> float:
+    if not values or any(not math.isfinite(value) or value <= 0 for value in values):
+        raise ValueError("geomean requires finite positive values")
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def summarize_results(
+    results: Sequence[dict[str, Any]],
+    *,
+    providers: Sequence[str],
+    replicates: int,
+    helion_selection: str,
+) -> dict[str, Any]:
+    row_count = len(common.official_cases())
+    provider_summaries = {}
+    config_hashes: list[list[str]] = [[] for _ in range(row_count)]
+    for provider in providers:
+        provider_results = sorted(
+            (result for result in results if result["provider"] == provider),
+            key=itemgetter("replicate"),
+        )
+        if len(provider_results) != replicates:
+            raise RuntimeError(f"{provider} produced an incomplete replicate set")
+        if [result.get("replicate") for result in provider_results] != list(
+            range(replicates)
+        ) or any(
+            result.get("schema") != RESULT_SCHEMA
+            or result.get("provider") != provider
+            or result.get("helion_selection") != helion_selection
+            for result in provider_results
+        ):
+            raise RuntimeError(f"{provider} result identity is inconsistent")
+        replicate_summaries = []
+        row_speedups: list[list[float]] = [[] for _ in range(row_count)]
+        for result in provider_results:
+            rows = result["rows"]
+            if len(rows) != row_count or [row.get("row_index") for row in rows] != list(
+                range(row_count)
+            ):
+                raise RuntimeError(
+                    f"{provider} result does not contain {row_count} rows"
+                )
+            speedups = [float(row["timings"]["helion_speedup"]) for row in rows]
+            for row_index, (row, speedup) in enumerate(
+                zip(rows, speedups, strict=True)
+            ):
+                row_speedups[row_index].append(speedup)
+                config_hashes[row_index].append(
+                    row["configs"]["helion"]["config_sha256"]
+                )
+            worst_index = min(range(row_count), key=speedups.__getitem__)
+            replicate_summaries.append(
+                {
+                    "replicate": result["replicate"],
+                    "geomean_speedup": _geomean(speedups),
+                    "wins": sum(speedup > 1.0 for speedup in speedups),
+                    "worst_row": worst_index,
+                    "worst_speedup": speedups[worst_index],
+                }
+            )
+        row_summaries = [
+            {
+                "row_index": row_index,
+                "geomean_speedup": _geomean(speedups),
+                "replicate_speedups": speedups,
+            }
+            for row_index, speedups in enumerate(row_speedups)
+        ]
+        all_speedups = [speedup for row in row_speedups for speedup in row]
+        worst_row = min(row_summaries, key=itemgetter("geomean_speedup"))
+        provider_summaries[provider] = {
+            "selection": PROVIDER_SELECTIONS[provider],
+            "cross_replicate_geomean": _geomean(all_speedups),
+            "row_wins": sum(row["geomean_speedup"] > 1.0 for row in row_summaries),
+            "row_count": row_count,
+            "worst_row": worst_row,
+            "replicates": replicate_summaries,
+            "rows": row_summaries,
+        }
+    distributions = [
+        {
+            "row_index": row_index,
+            "config_sha256_counts": dict(sorted(Counter(hashes).items())),
+            "invariant": len(set(hashes)) == 1,
+        }
+        for row_index, hashes in enumerate(config_hashes)
+    ]
+    if helion_selection != "live_autotune" and not all(
+        item["invariant"] for item in distributions
+    ):
+        raise RuntimeError("fixed Helion config changed across fresh workers")
+    return {
+        "schema": SUMMARY_SCHEMA,
+        "providers": list(providers),
+        "replicates": replicates,
+        "helion_selection": helion_selection,
+        "speedup_definition": "provider_ms / helion_ms; higher favors Helion",
+        "protocol": {
+            "fresh_process_and_caches_per_provider_replicate": True,
+            "provider_worker_order": "rotated_then_reversed",
+            "rows_per_replicate": row_count,
+            "thermal_warmup_ms": THERMAL_WARMUP_MS,
+            "paired_cold_l2_samples": BENCHMARK_REPETITIONS,
+            "balanced_rotated_reversed_order": True,
+        },
+        "helion_config_distributions": distributions,
+        "provider_results": provider_summaries,
+    }
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    row_count = summary["protocol"]["rows_per_replicate"]
+    print("\nprovider   geomean  wins  worst")
+    for provider in summary["providers"]:
+        result = summary["provider_results"][provider]
+        worst = result["worst_row"]
+        print(
+            f"{provider:<10} {result['cross_replicate_geomean']:>7.3f}x "
+            f"{result['row_wins']:>2}/{row_count}  row {worst['row_index']}: "
+            f"{worst['geomean_speedup']:.3f}x"
+        )
+    monitoring = summary["monitoring"]
+    if monitoring["active_clock_event_reason_sample_count"]:
+        print(
+            "active GPU clock-event reasons: "
+            f"{monitoring['active_clock_event_reasons']}"
+        )
+
+
+def _provider_order(providers: Sequence[str], replicate: int) -> tuple[str, ...]:
+    order = list(providers)
+    if not order:
+        return ()
+    offset = replicate % len(order)
+    order = order[offset:] + order[:offset]
+    if (replicate // len(order)) % 2:
+        order.reverse()
+    return tuple(order)
+
+
+def _run_campaign(args: argparse.Namespace) -> int:
+    roots = _provider_roots(args)
+    target_gpu_uuid = _resolve_target_gpu(args.cuda_visible_devices)
+    output_dir = args.output_dir.expanduser().resolve()
+    if output_dir.is_relative_to(REPO_ROOT):
+        raise ValueError("output directory must be outside the Helion checkout")
+    source = _source_identity()
+    output_dir.mkdir(parents=True, exist_ok=False)
+    results: list[dict[str, Any]] = []
+    runs: list[dict[str, Any]] = []
+    for replicate in range(args.replicates):
+        for provider in _provider_order(args.providers, replicate):
+            run_id = f"{provider}-r{replicate}"
+            run_dir = output_dir / run_id
+            run_dir.mkdir()
+            command = _worker_command(args, provider, replicate, run_dir, roots)
+            telemetry_path = run_dir / "telemetry.csv"
+            log_path = run_dir / "worker.log"
+            print(f"=== {run_id} ===", flush=True)
+            returncode, samples = _run_monitored_worker(
+                command,
+                environment=_worker_environment(
+                    run_dir,
+                    cuda_visible_devices=target_gpu_uuid,
+                    helion_selection=args.helion_selection,
+                ),
+                log_path=log_path,
+                telemetry_path=telemetry_path,
+                target_gpu_uuid=target_gpu_uuid,
+            )
+            if returncode:
+                tail = "".join(
+                    log_path.read_text(errors="replace").splitlines(True)[-30:]
+                )
+                raise RuntimeError(f"{run_id} failed with {returncode}:\n{tail}")
+            result_path = run_dir / "result.json"
+            if not result_path.is_file():
+                raise RuntimeError(f"{run_id} did not produce result.json")
+            result = json.loads(result_path.read_text())
+            if result.get("source") != source:
+                raise RuntimeError(f"{run_id} worker source identity changed")
+            device = result.get("device")
+            if not isinstance(device, dict) or (
+                device.get("uuid") != target_gpu_uuid
+                or device.get("visible") != target_gpu_uuid
+            ):
+                raise RuntimeError(f"{run_id} worker used the wrong GPU: {device}")
+            monitoring = _summarize_telemetry(telemetry_path, target_gpu_uuid)
+            if monitoring["sample_count"] != samples:
+                raise RuntimeError(f"{run_id} telemetry sample count changed")
+            results.append(result)
+            runs.append(
+                {
+                    "provider": provider,
+                    "replicate": replicate,
+                    "result": str(result_path.relative_to(output_dir)),
+                    "log": str(log_path.relative_to(output_dir)),
+                    "telemetry": str(telemetry_path.relative_to(output_dir)),
+                    "telemetry_samples": monitoring["sample_count"],
+                    "active_clock_event_reason_sample_count": monitoring[
+                        "active_clock_event_reason_sample_count"
+                    ],
+                    "active_clock_event_reasons": monitoring[
+                        "active_clock_event_reasons"
+                    ],
+                }
+            )
+            if _source_identity() != source:
+                raise RuntimeError("Helion checkout changed during the campaign")
+    summary = summarize_results(
+        results,
+        providers=args.providers,
+        replicates=args.replicates,
+        helion_selection=args.helion_selection,
+    )
+    summary["source"] = source
+    active_reasons: Counter[str] = Counter()
+    for run in runs:
+        active_reasons.update(run["active_clock_event_reasons"])
+    summary["monitoring"] = {
+        "target_gpu_uuid": target_gpu_uuid,
+        "target_gpu_idle_before_after_each_run": True,
+        "telemetry_sample_count": sum(run["telemetry_samples"] for run in runs),
+        "active_clock_event_reason_sample_count": sum(active_reasons.values()),
+        "active_clock_event_reasons": dict(sorted(active_reasons.items())),
+        "runs_with_active_clock_event_reasons": [
+            f"{run['provider']}-r{run['replicate']}"
+            for run in runs
+            if run["active_clock_event_reason_sample_count"]
+        ],
+        "caveat": (
+            "One or more telemetry samples reported active GPU clock-event reasons."
+            if active_reasons
+            else "No telemetry sample reported an active GPU clock-event reason."
+        ),
+    }
+    summary["runs"] = runs
+    common.write_result(output_dir / "summary.json", summary)
+    if _source_identity() != source:
+        raise RuntimeError("Helion checkout changed while writing the summary")
+    _print_summary(summary)
+    print(f"\nWrote {output_dir / 'summary.json'}")
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, allow_abbrev=False)
+    parser.add_argument(
+        "--providers",
+        type=parse_providers,
+        default=PROVIDERS,
+        help=f"comma-separated provider subset (default: {','.join(PROVIDERS)})",
+    )
+    parser.add_argument("--replicates", type=_positive_int, default=3)
+    parser.add_argument(
+        "--helion-selection",
+        choices=HELION_SELECTIONS,
+        default="final_reviewed_aot",
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--cuda-visible-devices",
+        default=os.environ.get("CUDA_VISIBLE_DEVICES"),
+        help="one CUDA_VISIBLE_DEVICES entry (GPU UUID or index)",
+    )
+    parser.add_argument("--cutlass-root", type=_existing_directory)
+    parser.add_argument("--deepgemm-root", type=_existing_directory)
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--provider", choices=PROVIDERS, help=argparse.SUPPRESS)
+    parser.add_argument("--replicate", type=_nonnegative_int, help=argparse.SUPPRESS)
+    parser.add_argument("--run-dir", type=Path, help=argparse.SUPPRESS)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    if args.worker:
+        if args.provider is None or args.replicate is None or args.run_dir is None:
+            raise ValueError(
+                "internal --worker requires provider, replicate, and run-dir"
+            )
+        return _run_worker(args)
+    if args.cuda_visible_devices is None:
+        raise ValueError("set CUDA_VISIBLE_DEVICES or --cuda-visible-devices")
+    common.require_single_visible_device(args.cuda_visible_devices)
+
+    def handle_signal(signum: int, _frame: object) -> None:
+        raise _CampaignInterrupted(signum)
+
+    previous_handlers = {
+        signum: signal.signal(signum, handle_signal)
+        for signum in (signal.SIGINT, signal.SIGTERM)
+    }
+    try:
+        return _run_campaign(args)
+    except _CampaignInterrupted as error:
+        return 128 + error.signum
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/cute/cublaslt_grouped_gemm.py
+++ b/benchmarks/cute/cublaslt_grouped_gemm.py
@@ -1,0 +1,586 @@
+from __future__ import annotations
+
+import ctypes
+from dataclasses import asdict
+from dataclasses import dataclass
+import functools
+import importlib.metadata
+from pathlib import Path
+from typing import TYPE_CHECKING
+import weakref
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+    import torch
+
+CUBLASLT_B_LAYOUTS = ("k_major", "n_major")
+CUBLASLT_DISTRIBUTION = "nvidia-cublas"
+CUBLASLT_DISTRIBUTION_VERSION = "13.6.1.10"
+CUBLASLT_LIBRARY_RELATIVE_PATH = Path("nvidia/cu13/lib/libcublasLt.so.13")
+# These ABI values are from the CUDA 13.6 cuBLASLt API shipped by the pinned
+# nvidia-cublas distribution below. The grouped extension is version-gated by
+# cublasLtGetVersion before any descriptor is created.
+_CUBLAS_STATUS_SUCCESS = 0
+_CUBLAS_OP_N = 0
+_CUBLAS_OP_T = 1
+_CUDA_R_32F = 0
+_CUDA_R_16BF = 14
+_CUBLAS_COMPUTE_32F = 68
+_CUBLASLT_POINTER_MODE_DEVICE = 1
+_CUBLASLT_MATMUL_DESC_POINTER_MODE = 2
+_CUBLASLT_MATMUL_DESC_TRANSA = 3
+_CUBLASLT_MATMUL_DESC_TRANSB = 4
+_CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES = 1
+_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_A_BYTES = 5
+_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_B_BYTES = 6
+_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES = 7
+_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES = 8
+_CUBLASLT_ALGO_CAP_POINTER_ARRAY_GROUPED_SUPPORT = 23
+_CUBLASLT_GROUPED_MATRIX_LAYOUT_ROWS_COLS_ARRAY_INTEGER_WIDTH = 12
+_CUBLASLT_GROUPED_MATRIX_LAYOUT_LD_ARRAY_INTEGER_WIDTH = 13
+_CUBLASLT_INTEGER_WIDTH_32 = 0
+_DEFAULT_WORKSPACE_BYTES = 64 * 1024 * 1024
+_WORKSPACE_ALIGNMENT = 256
+CUBLASLT_HEURISTIC_QUERY_CAPACITY = 1
+CUBLASLT_LIBRARY_VERSION = 130601
+
+
+def _distribution() -> importlib.metadata.Distribution:
+    try:
+        distribution = importlib.metadata.distribution(CUBLASLT_DISTRIBUTION)
+    except importlib.metadata.PackageNotFoundError as error:
+        raise RuntimeError(f"{CUBLASLT_DISTRIBUTION} is not installed") from error
+    if distribution.version != CUBLASLT_DISTRIBUTION_VERSION:
+        raise RuntimeError(
+            f"{CUBLASLT_DISTRIBUTION} is {distribution.version}, "
+            f"expected {CUBLASLT_DISTRIBUTION_VERSION}"
+        )
+    return distribution
+
+
+class _CublasLtMatmulAlgo(ctypes.Structure):
+    _fields_ = [("data", ctypes.c_uint64 * 8)]
+
+
+class _CublasLtHeuristicResult(ctypes.Structure):
+    _fields_ = [
+        ("algo", _CublasLtMatmulAlgo),
+        ("workspace_size", ctypes.c_size_t),
+        ("state", ctypes.c_int),
+        ("waves_count", ctypes.c_float),
+        ("reserved", ctypes.c_int * 4),
+    ]
+
+
+@dataclass(frozen=True, slots=True)
+class _CublasLtAlgorithm:
+    serialized_hex: str
+    workspace_bytes: int
+    waves_count: float
+    heuristic_rank: int
+
+
+def _check_cublas(status: int, operation: str) -> None:
+    if status != _CUBLAS_STATUS_SUCCESS:
+        raise RuntimeError(f"{operation} failed with cuBLAS status {status}")
+
+
+def _pointer_alignment(pointer: int) -> int:
+    return min(pointer & -pointer, 256)
+
+
+def _configure_library(library: ctypes.CDLL) -> None:
+    v, i, s = ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t
+    pv, pi, ps = ctypes.POINTER(v), ctypes.POINTER(i), ctypes.POINTER(s)
+    pa = ctypes.POINTER(_CublasLtMatmulAlgo)
+    ph = ctypes.POINTER(_CublasLtHeuristicResult)
+    signatures = (
+        ("cublasLtCreate", (pv,), i),
+        ("cublasLtDestroy", (v,), i),
+        ("cublasLtGetVersion", (), s),
+        ("cublasLtMatmulDescCreate", (pv, i, i), i),
+        ("cublasLtMatmulDescDestroy", (v,), i),
+        ("cublasLtMatmulDescSetAttribute", (v, i, v, s), i),
+        ("cublasLtGroupedMatrixLayoutCreate", (pv, i, i, v, v, v), i),
+        ("cublasLtMatrixLayoutSetAttribute", (v, i, v, s), i),
+        ("cublasLtMatrixLayoutDestroy", (v,), i),
+        ("cublasLtMatmulPreferenceCreate", (pv,), i),
+        ("cublasLtMatmulPreferenceDestroy", (v,), i),
+        ("cublasLtMatmulPreferenceSetAttribute", (v, i, v, s), i),
+        ("cublasLtMatmulAlgoGetHeuristicForStream", (v,) * 7 + (i, ph, pi, v), i),
+        ("cublasLtMatmulAlgoCapGetAttribute", (pa, i, v, s, ps), i),
+        ("cublasLtMatmul", (v,) * 12 + (pa, v, s, v), i),
+    )
+    for name, argtypes, restype in signatures:
+        function = getattr(library, name)
+        function.argtypes = list(argtypes)
+        function.restype = restype
+
+
+@functools.cache
+def _validated_cublaslt_library() -> tuple[ctypes.CDLL, dict[str, object]]:
+    distribution = _distribution()
+    path = Path(str(distribution.locate_file(CUBLASLT_LIBRARY_RELATIVE_PATH))).resolve(
+        strict=True
+    )
+    library = ctypes.CDLL(str(path))
+    _configure_library(library)
+    library_version = int(library.cublasLtGetVersion())
+    if library_version != CUBLASLT_LIBRARY_VERSION:
+        raise RuntimeError(
+            f"cuBLASLt library is {library_version}, "
+            f"expected {CUBLASLT_LIBRARY_VERSION}"
+        )
+    return library, {
+        "distribution": CUBLASLT_DISTRIBUTION,
+        "package_version": distribution.version,
+        "library_path": str(path),
+        "library_version": library_version,
+    }
+
+
+def _destroy_resources(
+    library: ctypes.CDLL,
+    matrix_layouts: tuple[ctypes.c_void_p, ...],
+    operation: ctypes.c_void_p,
+    handle: ctypes.c_void_p,
+) -> None:
+    for layout in reversed(matrix_layouts):
+        library.cublasLtMatrixLayoutDestroy(layout)
+    library.cublasLtMatmulDescDestroy(operation)
+    library.cublasLtDestroy(handle)
+
+
+def _set_attribute(
+    function: Callable[..., int],
+    descriptor: ctypes.c_void_p,
+    attribute: int,
+    value: ctypes.c_int | ctypes.c_uint32 | ctypes.c_uint64,
+    operation: str,
+) -> None:
+    _check_cublas(
+        function(descriptor, attribute, ctypes.byref(value), ctypes.sizeof(value)),
+        operation,
+    )
+
+
+def _create_grouped_matrix_layout(
+    library: ctypes.CDLL,
+    group_count: int,
+    rows: torch.Tensor,
+    columns: torch.Tensor,
+    leading_dimensions: torch.Tensor,
+) -> ctypes.c_void_p:
+    layout = ctypes.c_void_p()
+    _check_cublas(
+        library.cublasLtGroupedMatrixLayoutCreate(
+            ctypes.byref(layout),
+            _CUDA_R_16BF,
+            group_count,
+            ctypes.c_void_p(rows.data_ptr()),
+            ctypes.c_void_p(columns.data_ptr()),
+            ctypes.c_void_p(leading_dimensions.data_ptr()),
+        ),
+        "cublasLtGroupedMatrixLayoutCreate",
+    )
+    try:
+        for attribute, label in (
+            (
+                _CUBLASLT_GROUPED_MATRIX_LAYOUT_ROWS_COLS_ARRAY_INTEGER_WIDTH,
+                "rows/columns",
+            ),
+            (_CUBLASLT_GROUPED_MATRIX_LAYOUT_LD_ARRAY_INTEGER_WIDTH, "LD"),
+        ):
+            _set_attribute(
+                library.cublasLtMatrixLayoutSetAttribute,
+                layout,
+                attribute,
+                ctypes.c_int(_CUBLASLT_INTEGER_WIDTH_32),
+                f"set grouped matrix {label} integer width",
+            )
+    except Exception:
+        library.cublasLtMatrixLayoutDestroy(layout)
+        raise
+    return layout
+
+
+def _create_grouped_matrix_layouts(
+    library: ctypes.CDLL,
+    group_count: int,
+    dimension_arrays: dict[str, torch.Tensor],
+) -> tuple[ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]:
+    layouts: list[ctypes.c_void_p] = []
+    try:
+        for prefix in ("a", "b", "output"):
+            layouts.append(
+                _create_grouped_matrix_layout(
+                    library,
+                    group_count,
+                    dimension_arrays[f"{prefix}_rows"],
+                    dimension_arrays[f"{prefix}_columns"],
+                    dimension_arrays[f"{prefix}_leading_dimensions"],
+                )
+            )
+    except Exception:
+        for layout in reversed(layouts):
+            library.cublasLtMatrixLayoutDestroy(layout)
+        raise
+    return layouts[0], layouts[1], layouts[2]
+
+
+def _grouped_algorithm_supported(
+    library: ctypes.CDLL,
+    algorithm: _CublasLtMatmulAlgo,
+) -> bool:
+    value = ctypes.c_int32()
+    written = ctypes.c_size_t()
+    status = library.cublasLtMatmulAlgoCapGetAttribute(
+        ctypes.byref(algorithm),
+        _CUBLASLT_ALGO_CAP_POINTER_ARRAY_GROUPED_SUPPORT,
+        ctypes.byref(value),
+        ctypes.sizeof(value),
+        ctypes.byref(written),
+    )
+    return (
+        status == _CUBLAS_STATUS_SUCCESS
+        and written.value == ctypes.sizeof(value)
+        and value.value != 0
+    )
+
+
+def cublaslt_layout_values(
+    problems: tuple[tuple[int, int, int, int], ...],
+    b_layout: str,
+) -> tuple[int, dict[str, list[int]]]:
+    # cuBLASLt is column-major. Swap logical A/B so row-major A @ B.T becomes
+    # column-major B @ A.T, producing the same row-major output allocation.
+    if b_layout == "k_major":
+        transa = _CUBLAS_OP_T
+        a_rows = [k for _m, _n, k, _batch in problems]
+        a_columns = [n for _m, n, _k, _batch in problems]
+        a_ld = [k for _m, _n, k, _batch in problems]
+    elif b_layout == "n_major":
+        transa = _CUBLAS_OP_N
+        a_rows = [n for _m, n, _k, _batch in problems]
+        a_columns = [k for _m, _n, k, _batch in problems]
+        a_ld = [n for _m, n, _k, _batch in problems]
+    else:
+        raise ValueError(f"unsupported cuBLASLt B layout {b_layout!r}")
+    return transa, {
+        "a_rows": a_rows,
+        "a_columns": a_columns,
+        "a_leading_dimensions": a_ld,
+        "b_rows": [k for _m, _n, k, _batch in problems],
+        "b_columns": [m for m, _n, _k, _batch in problems],
+        "b_leading_dimensions": [k for _m, _n, k, _batch in problems],
+        "output_rows": [n for _m, n, _k, _batch in problems],
+        "output_columns": [m for m, _n, _k, _batch in problems],
+        "output_leading_dimensions": [n for _m, n, _k, _batch in problems],
+    }
+
+
+class _CublasLtGroupedGemm:
+    def __init__(
+        self,
+        inputs: GroupedGemmInputs,
+        b_layout: str,
+    ) -> None:
+        import torch
+
+        if b_layout not in CUBLASLT_B_LAYOUTS:
+            raise ValueError(f"unsupported cuBLASLt B layout {b_layout!r}")
+        if any(actual_m <= 0 for actual_m in inputs.case.actual_ms):
+            raise ValueError("cuBLASLt requires every group to contain a row")
+        _distribution()
+        problems = tuple(
+            (actual_m, inputs.case.n, inputs.case.k, 1)
+            for actual_m in inputs.case.actual_ms
+        )
+        group_a = inputs.compact_a_slices()
+        b = inputs.b_for_layout(b_layout)
+        group_b = tuple(
+            b[group] if b_layout == "k_major" else b[group].T
+            for group in range(inputs.case.groups)
+        )
+        outputs = tuple(
+            torch.empty(
+                (actual_m, inputs.case.n),
+                device=inputs.compact_a.device,
+                dtype=torch.bfloat16,
+            )
+            for actual_m in inputs.case.actual_ms
+        )
+        device = inputs.compact_a.device
+
+        workspace_storage = torch.empty(
+            _DEFAULT_WORKSPACE_BYTES + _WORKSPACE_ALIGNMENT - 1,
+            device=device,
+            dtype=torch.uint8,
+        )
+        offset = (-workspace_storage.data_ptr()) % _WORKSPACE_ALIGNMENT
+        workspace = workspace_storage[offset : offset + _DEFAULT_WORKSPACE_BYTES]
+        library, library_identity = _validated_cublaslt_library()
+
+        group_count = len(problems)
+        transa, dimension_values = cublaslt_layout_values(problems, b_layout)
+        with torch.cuda.device(device):
+            query_stream = torch.cuda.current_stream(device)
+            dimension_arrays = {
+                name: torch.tensor(values, device=device, dtype=torch.int32)
+                for name, values in dimension_values.items()
+            }
+            a_pointers = torch.tensor(
+                [tensor.data_ptr() for tensor in group_b],
+                device=device,
+                dtype=torch.int64,
+            )
+            b_pointers = torch.tensor(
+                [tensor.data_ptr() for tensor in group_a],
+                device=device,
+                dtype=torch.int64,
+            )
+            output_pointers = torch.tensor(
+                [tensor.data_ptr() for tensor in outputs],
+                device=device,
+                dtype=torch.int64,
+            )
+            alpha = torch.tensor(1.0, device=device, dtype=torch.float32)
+            beta = torch.tensor(0.0, device=device, dtype=torch.float32)
+            query_stream.synchronize()
+
+        handle = ctypes.c_void_p()
+        operation = ctypes.c_void_p()
+        preference = ctypes.c_void_p()
+        layouts: list[ctypes.c_void_p] = []
+        initialized = False
+        try:
+            _check_cublas(library.cublasLtCreate(ctypes.byref(handle)), "create")
+            _check_cublas(
+                library.cublasLtMatmulDescCreate(
+                    ctypes.byref(operation), _CUBLAS_COMPUTE_32F, _CUDA_R_32F
+                ),
+                "create matmul descriptor",
+            )
+            for attribute, value, label in (
+                (
+                    _CUBLASLT_MATMUL_DESC_POINTER_MODE,
+                    ctypes.c_int(_CUBLASLT_POINTER_MODE_DEVICE),
+                    "pointer mode",
+                ),
+                (_CUBLASLT_MATMUL_DESC_TRANSA, ctypes.c_int(transa), "TRANSA"),
+                (_CUBLASLT_MATMUL_DESC_TRANSB, ctypes.c_int(_CUBLAS_OP_N), "TRANSB"),
+            ):
+                _set_attribute(
+                    library.cublasLtMatmulDescSetAttribute,
+                    operation,
+                    attribute,
+                    value,
+                    f"set {label}",
+                )
+            _check_cublas(
+                library.cublasLtMatmulPreferenceCreate(ctypes.byref(preference)),
+                "create preference",
+            )
+            _set_attribute(
+                library.cublasLtMatmulPreferenceSetAttribute,
+                preference,
+                _CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                ctypes.c_uint64(_DEFAULT_WORKSPACE_BYTES),
+                "set workspace",
+            )
+            output_alignment = min(
+                _pointer_alignment(tensor.data_ptr()) for tensor in outputs
+            )
+            alignments = {
+                "A": min(_pointer_alignment(tensor.data_ptr()) for tensor in group_b),
+                "B": min(_pointer_alignment(tensor.data_ptr()) for tensor in group_a),
+                "C": output_alignment,
+                "D": output_alignment,
+            }
+            for attribute, operand in (
+                (_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_A_BYTES, "A"),
+                (_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_B_BYTES, "B"),
+                (_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES, "C"),
+                (_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES, "D"),
+            ):
+                _set_attribute(
+                    library.cublasLtMatmulPreferenceSetAttribute,
+                    preference,
+                    attribute,
+                    ctypes.c_uint32(alignments[operand]),
+                    f"set {operand} alignment",
+                )
+            created_layouts = _create_grouped_matrix_layouts(
+                library, group_count, dimension_arrays
+            )
+            layouts.extend(created_layouts)
+            a_layout, b_matrix_layout, output_layout = created_layouts
+            result = _CublasLtHeuristicResult()
+            returned_count = ctypes.c_int()
+            _check_cublas(
+                library.cublasLtMatmulAlgoGetHeuristicForStream(
+                    handle,
+                    operation,
+                    a_layout,
+                    b_matrix_layout,
+                    output_layout,
+                    output_layout,
+                    preference,
+                    CUBLASLT_HEURISTIC_QUERY_CAPACITY,
+                    ctypes.byref(result),
+                    ctypes.byref(returned_count),
+                    ctypes.c_void_p(query_stream.cuda_stream),
+                ),
+                "query grouped algorithms",
+            )
+            if returned_count.value != 1:
+                raise RuntimeError(
+                    "cuBLASLt did not return exactly one default heuristic result"
+                )
+            serialized = bytes(result.algo).hex()
+            if (
+                result.state != _CUBLAS_STATUS_SUCCESS
+                or result.workspace_size > _DEFAULT_WORKSPACE_BYTES
+                or not _grouped_algorithm_supported(library, result.algo)
+            ):
+                raise RuntimeError(
+                    "cuBLASLt rank-zero heuristic result is not usable for grouped GEMM"
+                )
+            selected_algorithm = _CublasLtAlgorithm(
+                serialized,
+                int(result.workspace_size),
+                float(result.waves_count),
+                0,
+            )
+            initialized = True
+        finally:
+            if preference:
+                library.cublasLtMatmulPreferenceDestroy(preference)
+            if not initialized:
+                for layout in reversed(layouts):
+                    library.cublasLtMatrixLayoutDestroy(layout)
+                if operation:
+                    library.cublasLtMatmulDescDestroy(operation)
+                if handle:
+                    library.cublasLtDestroy(handle)
+
+        self.library = library
+        self.library_identity = library_identity
+        self.handle = handle
+        self.operation = operation
+        self.a_layout = a_layout
+        self.b_layout_descriptor = b_matrix_layout
+        self.output_layout = output_layout
+        self._finalizer = weakref.finalize(
+            self,
+            _destroy_resources,
+            library,
+            tuple(layouts),
+            operation,
+            handle,
+        )
+        self.outputs = outputs
+        self.inputs = inputs
+        self.b_layout = b_layout
+        self.device = device
+        self.dimension_arrays = dimension_arrays
+        self.a_pointers = a_pointers
+        self.b_pointers = b_pointers
+        self.output_pointers = output_pointers
+        self.alpha = alpha
+        self.beta = beta
+        self.workspace_storage = workspace_storage
+        self.workspace = workspace
+        self.selected_algorithm = selected_algorithm
+
+    def prepared_implementation(
+        self,
+    ) -> PreparedImplementation:
+        from benchmarks.cute import grouped_gemm_benchmark as common
+
+        selected = self.selected_algorithm
+        algorithm = _CublasLtMatmulAlgo.from_buffer_copy(
+            bytes.fromhex(selected.serialized_hex)
+        )
+
+        def call() -> None:
+            self(algorithm, selected)
+
+        config: dict[str, object] = {
+            "provider": "cublaslt",
+            "baseline": "cublaslt_native_heterogeneous_grouped_matmul",
+            "api": "cublasLtGroupedMatrixLayoutCreate/cublasLtMatmul",
+            "library": self.library_identity,
+            "group_count": self.inputs.case.groups,
+            "b_layout": self.b_layout,
+            "selection_mode": "public_heuristic_rank_zero",
+            "workspace_bytes": _DEFAULT_WORKSPACE_BYTES,
+            "grouped_average_preferences": "library_defaults_zero",
+            "heuristic_query_capacity": CUBLASLT_HEURISTIC_QUERY_CAPACITY,
+            "selected_algorithm": asdict(selected),
+            "a_layout": {
+                "kind": "compact_group_views",
+                "shared_compact_allocation": True,
+                "logical_values_bitwise_equal": True,
+            },
+            "preprocessing_timed": False,
+            "numerics": "BF16 inputs, FP32 accumulation, BF16 output",
+        }
+        return common.PreparedImplementation(
+            name=(f"cublaslt-{self.b_layout}-rank-{selected.heuristic_rank}"),
+            call=call,
+            output_tensors=lambda _result: self.outputs,
+            logical_outputs=lambda _result: self.outputs,
+            config=config,
+            owners=(self, algorithm),
+        )
+
+    def __call__(
+        self,
+        algorithm: _CublasLtMatmulAlgo,
+        metadata: _CublasLtAlgorithm,
+    ) -> None:
+        import torch
+
+        with torch.cuda.device(self.device):
+            workspace_pointer = ctypes.c_void_p(self.workspace.data_ptr())
+            _check_cublas(
+                self.library.cublasLtMatmul(
+                    self.handle,
+                    self.operation,
+                    ctypes.c_void_p(self.alpha.data_ptr()),
+                    ctypes.c_void_p(self.a_pointers.data_ptr()),
+                    self.a_layout,
+                    ctypes.c_void_p(self.b_pointers.data_ptr()),
+                    self.b_layout_descriptor,
+                    ctypes.c_void_p(self.beta.data_ptr()),
+                    ctypes.c_void_p(self.output_pointers.data_ptr()),
+                    self.output_layout,
+                    ctypes.c_void_p(self.output_pointers.data_ptr()),
+                    self.output_layout,
+                    ctypes.byref(algorithm),
+                    workspace_pointer,
+                    _DEFAULT_WORKSPACE_BYTES,
+                    ctypes.c_void_p(torch.cuda.current_stream(self.device).cuda_stream),
+                ),
+                f"cublasLtMatmul grouped algorithm rank {metadata.heuristic_rank}",
+            )
+
+
+def prepare_cublaslt_default(
+    inputs: GroupedGemmInputs,
+    *,
+    b_layout: str,
+) -> PreparedImplementation:
+    """Use only cuBLASLt's rank-zero heuristic result for one B layout."""
+
+    import torch
+
+    with torch.cuda.device(inputs.compact_a.device):
+        core = _CublasLtGroupedGemm(inputs, b_layout)
+    if core.selected_algorithm.heuristic_rank != 0:
+        raise RuntimeError("cuBLASLt default result was not heuristic rank zero")
+    return core.prepared_implementation()

--- a/benchmarks/cute/cudnn_grouped_gemm.py
+++ b/benchmarks/cute/cudnn_grouped_gemm.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+import weakref
+
+if TYPE_CHECKING:
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+    import torch
+
+CUDNN_GROUPED_BASELINE = "cudnn_moe_grouped_matmul"
+CUDNN_B_LAYOUTS = ("k_major", "n_major")
+CUDNN_FRONTEND_VERSION = "1.27.0"
+CUDNN_BACKEND_VERSION = 92400
+CUDNN_REFERENCE_FRONTEND_COMMIT = "f77fbc3d21be3f24cd0286b9b368105f7c518b8a"
+CUDNN_CUDART_ENVIRONMENT_VARIABLE = "CUDNN_FRONTEND_CUDART_LIB_NAME"
+CUDA_RUNTIME_DISTRIBUTION = "nvidia-cuda-runtime"
+CUDA_RUNTIME_VERSION = "13.3.29"
+CUDNN_CUDART_RELATIVE_PATH = Path("nvidia/cu13/lib/libcudart.so.13")
+
+# cuDNN graph tensor UIDs are arbitrary, stable identifiers within this graph.
+_TOKEN_UID = 20
+_WEIGHT_UID = 21
+_FIRST_TOKEN_OFFSET_UID = 22
+_OUTPUT_UID = 100
+
+
+def configure_cudnn_cudart_library() -> Path:
+    """Select the CUDA runtime used by the frontend shim before import."""
+
+    distribution = importlib.metadata.distribution(CUDA_RUNTIME_DISTRIBUTION)
+    if distribution.version != CUDA_RUNTIME_VERSION:
+        raise RuntimeError(
+            f"{CUDA_RUNTIME_DISTRIBUTION} is {distribution.version}, "
+            f"expected {CUDA_RUNTIME_VERSION}"
+        )
+    default = Path(str(distribution.locate_file(CUDNN_CUDART_RELATIVE_PATH))).resolve(
+        strict=True
+    )
+    path = Path(os.environ.get(CUDNN_CUDART_ENVIRONMENT_VARIABLE, default)).resolve()
+    if path != default:
+        raise RuntimeError(
+            f"{CUDNN_CUDART_ENVIRONMENT_VARIABLE} must resolve to {default}"
+        )
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as error:
+        raise RuntimeError(f"cuDNN CUDA runtime does not exist: {path}") from error
+    if not resolved.is_file():
+        raise RuntimeError(f"cuDNN CUDA runtime is not a file: {resolved}")
+    os.environ[CUDNN_CUDART_ENVIRONMENT_VARIABLE] = str(resolved)
+    return resolved
+
+
+def _import_cudnn() -> object:
+    try:
+        return importlib.import_module("cudnn")
+    except (ImportError, OSError) as error:
+        raise RuntimeError("cuDNN frontend is unavailable") from error
+
+
+def _backend_version_string(version: int) -> str:
+    major, remainder = divmod(version, 10_000)
+    minor, patch = divmod(remainder, 100)
+    return f"{major}.{minor}.{patch}"
+
+
+def _validated_cudnn_runtime() -> tuple[Path, Any, str, int]:
+    cudart_path = configure_cudnn_cudart_library()
+    cudnn = cast("Any", _import_cudnn())
+    frontend_version = str(cudnn.__version__)
+    backend_version = int(cudnn.backend_version())
+    if frontend_version != CUDNN_FRONTEND_VERSION:
+        raise RuntimeError(
+            f"cuDNN frontend is {frontend_version}, expected {CUDNN_FRONTEND_VERSION}"
+        )
+    if backend_version != CUDNN_BACKEND_VERSION:
+        raise RuntimeError(
+            "cuDNN backend is "
+            f"{_backend_version_string(backend_version)}, expected "
+            f"{_backend_version_string(CUDNN_BACKEND_VERSION)}"
+        )
+    return cudart_path, cudnn, frontend_version, backend_version
+
+
+class _CudnnLaunch:
+    def __init__(
+        self,
+        inputs: GroupedGemmInputs,
+        b_layout: str,
+    ) -> None:
+        import torch
+
+        if b_layout not in CUDNN_B_LAYOUTS:
+            raise ValueError(f"unsupported cuDNN B layout {b_layout!r}")
+        cudart_path, cudnn, frontend_version, backend_version = (
+            _validated_cudnn_runtime()
+        )
+        self.inputs = inputs
+        self.b_layout = b_layout
+        a = inputs.compact_a
+        b = inputs.b_for_layout(b_layout)
+        self.output = torch.empty(
+            (inputs.case.total_m, inputs.case.n),
+            device=a.device,
+            dtype=torch.bfloat16,
+        )
+        self.device = a.device
+        self._cudnn = cudnn
+
+        with torch.cuda.device(self.device):
+            self.token = a.unsqueeze(0)
+            # The frontend ABI is [G,K,N]; this zero-copy transpose preserves
+            # whichever physical logical-B layout the common input selected.
+            self.weight = b.transpose(1, 2)
+            # The MOE descriptor consumes one start per group, not an indptr
+            # sentinel. Group extents come from the token tensor and next start.
+            self.first_token_offsets = inputs.offsets[:-1].view(
+                inputs.case.groups, 1, 1
+            )
+            self.output_3d = self.output.unsqueeze(0)
+            self.handle = cudnn.create_handle()
+            self._handle_finalizer = weakref.finalize(
+                self, cudnn.destroy_handle, self.handle
+            )
+            cudnn.set_stream(
+                handle=self.handle,
+                stream=torch.cuda.current_stream(self.device).cuda_stream,
+            )
+            graph = cudnn.pygraph(
+                intermediate_data_type=cudnn.data_type.FLOAT,
+                compute_data_type=cudnn.data_type.FLOAT,
+                handle=self.handle,
+            )
+            token_desc = graph.tensor(
+                name="token",
+                dim=list(self.token.shape),
+                stride=list(self.token.stride()),
+                data_type=cudnn.data_type.BFLOAT16,
+                uid=_TOKEN_UID,
+            )
+            weight_desc = graph.tensor(
+                name="weight",
+                dim=list(self.weight.shape),
+                stride=list(self.weight.stride()),
+                data_type=cudnn.data_type.BFLOAT16,
+                uid=_WEIGHT_UID,
+            )
+            offsets_desc = graph.tensor(
+                name="first_token_offset",
+                dim=list(self.first_token_offsets.shape),
+                stride=list(self.first_token_offsets.stride()),
+                data_type=cudnn.data_type.INT32,
+                uid=_FIRST_TOKEN_OFFSET_UID,
+            )
+            accum = graph.moe_grouped_matmul(
+                name="cudnn_moe_grouped_gemm",
+                token=token_desc,
+                weight=weight_desc,
+                first_token_offset=offsets_desc,
+                mode=cudnn.moe_grouped_matmul_mode.NONE,
+                compute_data_type=cudnn.data_type.FLOAT,
+            )
+            accum.set_uid(_OUTPUT_UID).set_output(True).set_data_type(
+                cudnn.data_type.BFLOAT16
+            )
+            graph.validate()
+            graph.build_operation_graph()
+            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+            graph.check_support()
+            graph.build_plans()
+            self.workspace_bytes = int(graph.get_workspace_size())
+            self.graph = graph
+            self.workspace = torch.empty(
+                self.workspace_bytes,
+                device=self.device,
+                dtype=torch.uint8,
+            )
+            self._variant_pack = {
+                _TOKEN_UID: self.token,
+                _WEIGHT_UID: self.weight,
+                _FIRST_TOKEN_OFFSET_UID: self.first_token_offsets,
+                _OUTPUT_UID: self.output_3d,
+            }
+        self.base_provenance: dict[str, object] = {
+            "baseline": CUDNN_GROUPED_BASELINE,
+            "frontend_version": frontend_version,
+            "backend_version": backend_version,
+            "backend_version_string": _backend_version_string(backend_version),
+            "frontend_release_commit": CUDNN_REFERENCE_FRONTEND_COMMIT,
+            "cudart_path": str(cudart_path),
+            "b_layout": b_layout,
+            "selection_mode": "public_default_a_fallback",
+            "preprocessing_timed": False,
+            "numerics": "BF16 inputs, FP32 accumulation, BF16 output",
+        }
+
+    def run(self) -> torch.Tensor:
+        import torch
+
+        with torch.cuda.device(self.device):
+            # A captured graph may replay on a different current stream than
+            # graph construction, so bind the frontend handle on every call.
+            self._cudnn.set_stream(
+                handle=self.handle,
+                stream=torch.cuda.current_stream(self.device).cuda_stream,
+            )
+            self.graph.execute(
+                self._variant_pack,
+                self.workspace,
+                handle=self.handle,
+            )
+        return self.output
+
+    def prepared_implementation(self) -> PreparedImplementation:
+        from benchmarks.cute import grouped_gemm_benchmark as common
+
+        return common.PreparedImplementation(
+            name=f"cudnn-{self.b_layout}-graph-default",
+            call=self.run,
+            output_tensors=lambda _result: (self.output,),
+            logical_outputs=lambda _result: self.inputs.compact_output_slices(
+                self.output
+            ),
+            config={
+                "provider": "cudnn",
+                **self.base_provenance,
+                "plan": {
+                    "selection": "graph_build_default",
+                    "heuristic_modes": ["A", "FALLBACK"],
+                    "workspace_bytes": self.workspace_bytes,
+                },
+                "a_layout": common.compact_contiguous_a_layout(),
+            },
+            owners=(self,),
+        )
+
+
+def prepare_cudnn_default(
+    inputs: GroupedGemmInputs,
+    *,
+    b_layout: str,
+) -> PreparedImplementation:
+    """Build and execute cuDNN's first buildable A/FALLBACK plan."""
+
+    return _CudnnLaunch(inputs, b_layout).prepared_implementation()

--- a/benchmarks/cute/cutlass_contiguous_grouped_gemm.py
+++ b/benchmarks/cute/cutlass_contiguous_grouped_gemm.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import dataclass
+import importlib
+import importlib.metadata
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from types import ModuleType
+
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+    import torch
+
+CUTLASS_REPOSITORY = "https://github.com/NVIDIA/cutlass"
+CUTLASS_TAG = "4.7.0"
+CUTLASS_COMMIT = "dcf215af68a2d08d305076c152a06f201728cd53"
+CUTLASS_DSL_VERSION = "4.7.0"
+CUTLASS_OPERATOR_API_VERSION = "0.2.0"
+CUTLASS_TARGET_SM = "100a"
+CUTLASS_OPERATOR_BASELINE = "cutlass_operator_contiguous_offset_bf16"
+_OPERATOR_MODULE = (
+    "cutlass.operators.providers.cutedsl.gemm.sm100_contiguous_offset_2d3d_dense_gemm"
+)
+_PINNED_DEPENDENCIES = {
+    "nvidia-cutlass-dsl": CUTLASS_DSL_VERSION,
+    "nvidia-cutlass-dsl-libs-base": CUTLASS_DSL_VERSION,
+    "nvidia-cutlass-dsl-libs-core": CUTLASS_DSL_VERSION,
+    "nvidia-cutlass-dsl-libs-cu13": CUTLASS_DSL_VERSION,
+    "apache-tvm-ffi": "0.1.13.post3",
+    "torch-c-dlpack-ext": "0.1.5",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _CutlassOperatorConfig:
+    use_2cta_mma: bool
+    tile_shape: tuple[int, int, int]
+    cluster_shape: tuple[int, int, int]
+
+
+def _int3(values: Sequence[int], name: str) -> tuple[int, int, int]:
+    result = tuple(int(value) for value in values)
+    if len(result) != 3 or any(value <= 0 for value in result):
+        raise RuntimeError(f"CUTLASS {name} must contain three positive integers")
+    first, second, third = result
+    return first, second, third
+
+
+def require_cutlass_dependencies() -> None:
+    """Require the exact package set used for publication."""
+
+    problems: list[str] = []
+    for name, expected in _PINNED_DEPENDENCIES.items():
+        try:
+            actual = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            problems.append(f"{name} is not installed")
+            continue
+        if actual != expected:
+            problems.append(f"{name} is {actual}, expected {expected}")
+    if problems:
+        raise RuntimeError(
+            "CUTLASS Operator adapter dependencies are unavailable: "
+            + "; ".join(problems)
+        )
+
+
+def verify_cutlass_checkout(cutlass_root: Path) -> dict[str, object]:
+    """Require the clean pinned CUTLASS source used by the public campaign."""
+
+    from benchmarks.cute import grouped_gemm_benchmark as common
+
+    checkout = common.clean_checkout(cutlass_root, CUTLASS_COMMIT, "CUTLASS")
+    root = Path(str(checkout["path"]))
+    if not (root / "operators" / "cutlass").is_dir():
+        raise RuntimeError(f"CUTLASS Operator API package is missing below {root}")
+    return {
+        "repository": CUTLASS_REPOSITORY,
+        "tag": CUTLASS_TAG,
+        **checkout,
+    }
+
+
+def _require_module_origin(module: ModuleType, package_root: Path, label: str) -> None:
+    module_file = cast("str | None", module.__file__)
+    if module_file is None:
+        raise RuntimeError(f"{label} has no import origin")
+    path = Path(module_file).resolve()
+    if not path.is_file() or not path.is_relative_to(package_root):
+        raise RuntimeError(
+            f"{label} resolved outside the pinned CUTLASS checkout: {path}"
+        )
+
+
+def _load_operator_api(cutlass_root: Path) -> tuple[Any, type[object]]:
+    package_root = (cutlass_root / "operators" / "cutlass").resolve()
+    cutlass = importlib.import_module("cutlass")
+    package_path = cutlass.__path__
+    value = str(package_root)
+    # Providers run in fresh subprocesses, so extending the installed CUTLASS
+    # namespace with the pinned source checkout is intentionally process-local.
+    cutlass.__path__ = [
+        value,
+        *(str(path) for path in package_path if str(Path(path).resolve()) != value),
+    ]
+    importlib.invalidate_caches()
+    try:
+        ops = cast("Any", importlib.import_module("cutlass.operators"))
+        module = importlib.import_module(_OPERATOR_MODULE)
+        _require_module_origin(ops, package_root, "cutlass.operators")
+        _require_module_origin(module, package_root, _OPERATOR_MODULE)
+        operator_class = cast(
+            "type[object]", module.ContiguousOffset2D3DGemmDenseOperator
+        )
+    except (AttributeError, ImportError, OSError) as error:
+        raise RuntimeError("failed to import CUTLASS grouped operators") from error
+    return ops, operator_class
+
+
+def _operator_config(metadata: object) -> _CutlassOperatorConfig:
+    metadata = cast("Any", metadata)
+    return _CutlassOperatorConfig(
+        bool(metadata.design.use_2cta_mma),
+        _int3(metadata.design.tile_shape, "operator tile_shape"),
+        _int3(metadata.design.cluster_shape, "operator cluster_shape"),
+    )
+
+
+def prepare_cutlass_default(
+    inputs: GroupedGemmInputs,
+    *,
+    cutlass_root: Path,
+) -> PreparedImplementation:
+    """Compile only the first operator returned by CUTLASS's public registry."""
+
+    from benchmarks.cute import grouped_gemm_benchmark as common
+    import torch
+
+    checkout = verify_cutlass_checkout(cutlass_root)
+    require_cutlass_dependencies()
+    device = inputs.compact_a.device
+    if torch.cuda.get_device_capability(device) != (10, 0):
+        raise RuntimeError("CUTLASS grouped adapter targets B200/SM100")
+    if inputs.case.k % 8 or inputs.case.n % 8:
+        raise ValueError("CUTLASS BF16 K and N must be multiples of 8")
+
+    a = inputs.compact_a
+    b_kn = inputs.b.transpose(1, 2)
+    offsets = inputs.offsets[1:]
+    output = torch.empty(
+        (inputs.case.total_m, inputs.case.n),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    ops, operator_class = _load_operator_api(cutlass_root)
+    operator_api_version = str(ops.__version__)
+    if operator_api_version != CUTLASS_OPERATOR_API_VERSION:
+        raise RuntimeError(
+            "CUTLASS Operator API version is "
+            f"{operator_api_version}, expected {CUTLASS_OPERATOR_API_VERSION}"
+        )
+    global_options = ops.GlobalOptions()
+    global_options.use_tvm_ffi = True
+    if ops.GlobalOptions().use_tvm_ffi is not True:
+        raise RuntimeError("CUTLASS global use_tvm_ffi option did not persist")
+    with torch.cuda.device(device):
+        args = ops.GroupedGemmArguments(
+            a,
+            b_kn,
+            output,
+            accumulator_type=torch.float32,
+            offsets=offsets,
+        )
+        discovered = ops.get_operators(
+            args,
+            metadata_filter=lambda metadata: metadata.operator_class is operator_class,
+            target_sm=CUTLASS_TARGET_SM,
+            providers=[ops.CuTeDSLProvider],
+        )
+    if not discovered:
+        raise RuntimeError(
+            f"CUTLASS returned no {operator_class.__name__} operator for the workload"
+        )
+    operator = discovered[0]
+    config = _operator_config(operator.metadata)
+    with torch.cuda.device(device):
+        artifact = operator.compile(args, target_sm=CUTLASS_TARGET_SM)
+
+    def call() -> torch.Tensor:
+        with torch.cuda.device(device):
+            operator.run(
+                args,
+                compiled_artifact=artifact,
+                stream=torch.cuda.current_stream(device),
+                assume_supported_args=True,
+            )
+        return output
+
+    return common.PreparedImplementation(
+        name=f"{CUTLASS_OPERATOR_BASELINE}_registry_first",
+        call=call,
+        output_tensors=lambda _result: (output,),
+        logical_outputs=lambda _result: inputs.compact_output_slices(output),
+        config={
+            "provider": "cutlass",
+            "selection_mode": "public_registry_first",
+            "baseline": CUTLASS_OPERATOR_BASELINE,
+            "repository": CUTLASS_REPOSITORY,
+            "tag": CUTLASS_TAG,
+            "checkout": checkout,
+            "operator_api_version": operator_api_version,
+            "global_options": {"use_tvm_ffi": True},
+            "target_sm": CUTLASS_TARGET_SM,
+            "b_layout": "k_major",
+            "selected_config": asdict(config),
+            "operator_name": str(operator.metadata.operator_name),
+            "compiled_for": str(artifact.compiled_for),
+            "a_layout": common.compact_contiguous_a_layout(),
+            "preprocessing_timed": False,
+            "numerics": "BF16 inputs, FP32 accumulation, BF16 output",
+        },
+        owners=(
+            inputs,
+            a,
+            b_kn,
+            offsets,
+            output,
+            global_options,
+            args,
+            operator,
+            artifact,
+        ),
+    )

--- a/benchmarks/cute/grouped_gemm_benchmark.py
+++ b/benchmarks/cute/grouped_gemm_benchmark.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import dataclass
+from hashlib import sha256
+from itertools import accumulate
+import json
+import math
+import os
+from typing import TYPE_CHECKING
+from typing import Any
+
+from benchmarks.cute import grouped_gemm_deepgemm_support as deepgemm_support
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Mapping
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+ORACLE_FLOAT32_MATMUL_PRECISION = "highest"
+CORRECTNESS_MAX_NORMALIZED_DIFF = 1e-5
+CANONICAL_DEVICE_NAME = "NVIDIA B200"
+CANONICAL_DEVICE_CAPABILITY = (10, 0)
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedGemmCase:
+    """One official BF16 variable-M grouped ``A @ B.T`` case."""
+
+    id: str
+    row_index: int
+    groups: int
+    expected_m_per_group: int
+    n: int
+    k: int
+    actual_ms: tuple[int, ...]
+
+    @property
+    def total_m(self) -> int:
+        return sum(self.actual_ms)
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def official_cases() -> tuple[GroupedGemmCase, ...]:
+    """Return the eight reviewed shapes and their deterministic seed-0 M values."""
+
+    from pretuned_kernels.grouped_gemm_deepgemm import reviewed_profiles
+
+    return tuple(
+        GroupedGemmCase(
+            id=(
+                f"deepgemm-large-g{shape.groups}-m{shape.expected_m_per_group}-"
+                f"n{shape.n}-k{shape.k}"
+            ),
+            row_index=shape.row_index,
+            groups=shape.groups,
+            expected_m_per_group=shape.expected_m_per_group,
+            n=shape.n,
+            k=shape.k,
+            actual_ms=actual_ms,
+        )
+        for shape, actual_ms in zip(
+            reviewed_profiles.OFFICIAL_SHAPES,
+            reviewed_profiles.official_actual_ms(seed=0),
+            strict=True,
+        )
+    )
+
+
+@dataclass(frozen=True)
+class GroupedGemmInputs:
+    """Deterministic compact logical BF16 inputs and their FP32 oracle."""
+
+    case: GroupedGemmCase
+    compact_a: torch.Tensor
+    b: torch.Tensor
+    b_n_major: torch.Tensor
+    offsets: torch.Tensor
+    oracle: tuple[torch.Tensor, ...]
+
+    def compact_a_slices(self) -> tuple[torch.Tensor, ...]:
+        ends = tuple(accumulate(self.case.actual_ms))
+        return tuple(
+            self.compact_a[start:end]
+            for start, end in zip((0, *ends[:-1]), ends, strict=True)
+        )
+
+    def compact_output_slices(self, output: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        expected_shape = (self.case.total_m, self.case.n)
+        if tuple(output.shape) != expected_shape:
+            raise ValueError(
+                f"compact output has shape {tuple(output.shape)}, "
+                f"expected {expected_shape}"
+            )
+        ends = tuple(accumulate(self.case.actual_ms))
+        return tuple(
+            output[start:end] for start, end in zip((0, *ends[:-1]), ends, strict=True)
+        )
+
+    def b_for_layout(self, layout: str) -> torch.Tensor:
+        if layout == "k_major":
+            return self.b
+        if layout == "n_major":
+            return self.b_n_major
+        raise ValueError(f"unsupported grouped B layout {layout!r}")
+
+
+@dataclass(frozen=True)
+class PackedRows:
+    """One aligned physical-A representation prepared outside timing."""
+
+    a: torch.Tensor
+    worklist: torch.Tensor
+    starts: tuple[int, ...]
+    actual_ms: tuple[int, ...]
+
+    def output_slices(self, output: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        if output.ndim != 2:
+            raise ValueError(f"packed output must be rank two, got {output.shape}")
+        return tuple(
+            output[start : start + valid_m]
+            for start, valid_m in zip(self.starts, self.actual_ms, strict=True)
+        )
+
+    def output_padding_is_zero(self, output: torch.Tensor) -> bool:
+        """Return whether every physical row outside the logical groups is zero."""
+
+        if output.ndim != 2:
+            raise ValueError(f"packed output must be rank two, got {output.shape}")
+        if output.size(0) != self.a.size(0):
+            raise ValueError(
+                f"packed output has {output.size(0)} rows, expected {self.a.size(0)}"
+            )
+        if not self.starts or self.starts[0] != 0:
+            raise ValueError("packed output row metadata must start at row zero")
+        group_ends = (*self.starts[1:], output.size(0))
+        for start, valid_m, stored_end in zip(
+            self.starts,
+            self.actual_ms,
+            group_ends,
+            strict=True,
+        ):
+            valid_end = start + valid_m
+            if not 0 <= start <= valid_end <= stored_end <= output.size(0):
+                raise ValueError("packed output row metadata is inconsistent")
+            padding = output[valid_end:stored_end]
+            if not torch.equal(padding, torch.zeros_like(padding)):
+                return False
+        return True
+
+
+@dataclass
+class PreparedImplementation:
+    """A compiled or compilable implementation with stable output mapping."""
+
+    name: str
+    call: Callable[[], object]
+    output_tensors: Callable[[object], tuple[torch.Tensor, ...]]
+    logical_outputs: Callable[[object], tuple[torch.Tensor, ...]]
+    config: dict[str, Any]
+    owners: tuple[object, ...] = ()
+    track_cute_graph: bool = False
+
+
+@dataclass
+class CapturedImplementation:
+    """A prepared implementation captured into one CUDA graph."""
+
+    prepared: PreparedImplementation
+    graph: torch.cuda.CUDAGraph
+    result: object
+    owners: tuple[object, ...]
+
+    def replay(self) -> None:
+        self.graph.replay()
+
+
+def configure_oracle_precision() -> str:
+    """Force IEEE FP32 internal matmul precision for the shared oracle."""
+
+    torch.set_float32_matmul_precision(ORACLE_FLOAT32_MATMUL_PRECISION)
+    actual = torch.get_float32_matmul_precision()
+    if actual != ORACLE_FLOAT32_MATMUL_PRECISION:
+        raise RuntimeError(
+            "FP32 oracle precision is "
+            f"{actual!r}, expected {ORACLE_FLOAT32_MATMUL_PRECISION!r}"
+        )
+    return actual
+
+
+align = deepgemm_support.align
+
+
+def compact_contiguous_a_layout() -> dict[str, str | bool]:
+    layout: dict[str, str | bool] = {"kind": "compact_contiguous"}
+    layout["shared_compact_allocation"] = True
+    layout["logical_values_bitwise_equal"] = True
+    return layout
+
+
+def pack_compact_rows(inputs: GroupedGemmInputs, alignment: int) -> PackedRows:
+    """Repack compact A into aligned physical rows without changing values."""
+
+    stored_ms = tuple(align(actual_m, alignment) for actual_m in inputs.case.actual_ms)
+    packed = torch.zeros(
+        (sum(stored_ms), inputs.case.k),
+        device=inputs.compact_a.device,
+        dtype=inputs.compact_a.dtype,
+    )
+    starts: list[int] = []
+    rows: list[tuple[int, int, int, int]] = []
+    compact_start = 0
+    packed_start = 0
+    for group, (actual_m, stored_m) in enumerate(
+        zip(inputs.case.actual_ms, stored_ms, strict=True)
+    ):
+        compact_end = compact_start + actual_m
+        packed[packed_start : packed_start + actual_m].copy_(
+            inputs.compact_a[compact_start:compact_end]
+        )
+        starts.append(packed_start)
+        rows.append((group, packed_start, actual_m, stored_m))
+        compact_start = compact_end
+        packed_start += stored_m
+    worklist = torch.tensor(
+        rows,
+        device=inputs.compact_a.device,
+        dtype=torch.int32,
+    )
+    return PackedRows(packed, worklist, tuple(starts), inputs.case.actual_ms)
+
+
+def capture_implementation(
+    prepared: PreparedImplementation,
+    *,
+    warmups: int,
+) -> CapturedImplementation:
+    """Warm, capture, and retain one implementation and all pointer owners."""
+
+    if warmups < 0:
+        raise ValueError("warmups must be non-negative")
+    for _ in range(warmups):
+        prepared.call()
+    torch.cuda.synchronize()
+    if prepared.track_cute_graph:
+        import helion.runtime as helion_runtime
+
+        with helion_runtime.cute_cuda_graph() as graph:
+            result = prepared.call()
+    else:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            result = prepared.call()
+    torch.cuda.synchronize()
+    return CapturedImplementation(
+        prepared=prepared,
+        graph=graph,
+        result=result,
+        owners=(*prepared.owners, result),
+    )
+
+
+def poison_and_replay(captured: CapturedImplementation) -> bool:
+    """Poison captured outputs and prove that replay rewrites logical rows."""
+
+    for output in captured.prepared.output_tensors(captured.result):
+        output.fill_(float("nan"))
+    captured.replay()
+    torch.cuda.synchronize()
+    logical = captured.prepared.logical_outputs(captured.result)
+    return all(not bool(torch.isnan(output).any().item()) for output in logical)
+
+
+normalized_difference = deepgemm_support.normalized_difference
+
+
+def check_correctness(
+    captured: CapturedImplementation,
+    oracle: Sequence[torch.Tensor],
+    *,
+    max_diff: float = CORRECTNESS_MAX_NORMALIZED_DIFF,
+) -> dict[str, Any]:
+    """Compare every logical group against the shared FP32 oracle."""
+
+    actual = captured.prepared.logical_outputs(captured.result)
+    if len(actual) != len(oracle):
+        raise ValueError(
+            f"implementation produced {len(actual)} groups, expected {len(oracle)}"
+        )
+    groups: list[dict[str, Any]] = []
+    passed = True
+    max_abs = 0.0
+    max_normalized_diff = 0.0
+    for group, (output, expected) in enumerate(zip(actual, oracle, strict=True)):
+        shape_ok = output.shape == expected.shape
+        dtype_ok = output.dtype is torch.bfloat16 and expected.dtype is torch.float32
+        device_ok = output.device == expected.device
+        if not (shape_ok and dtype_ok and device_ok):
+            groups.append(
+                {
+                    "group": group,
+                    "ok": False,
+                    "shape_ok": shape_ok,
+                    "dtype_ok": dtype_ok,
+                    "device_ok": device_ok,
+                    "normalized_diff": math.inf,
+                    "max_abs": math.inf,
+                }
+            )
+            passed = False
+            max_abs = math.inf
+            max_normalized_diff = math.inf
+            continue
+        output_fp32 = output.float()
+        difference = (output_fp32 - expected).abs()
+        group_max_abs = float(difference.max().item()) if difference.numel() else 0.0
+        finite = bool(
+            torch.isfinite(output_fp32).all().item()
+            and torch.isfinite(expected).all().item()
+        )
+        if not finite:
+            group_max_abs = math.inf
+        normalized_diff = (
+            normalized_difference(output_fp32, expected) if finite else math.inf
+        )
+        group_ok = normalized_diff <= max_diff
+        groups.append(
+            {
+                "group": group,
+                "ok": group_ok,
+                "shape_ok": shape_ok,
+                "dtype_ok": dtype_ok,
+                "device_ok": device_ok,
+                "normalized_diff": normalized_diff,
+                "max_abs": group_max_abs,
+            }
+        )
+        passed = passed and group_ok
+        max_abs = max(max_abs, group_max_abs)
+        max_normalized_diff = max(max_normalized_diff, normalized_diff)
+    return {
+        "ok": passed,
+        "max_normalized_diff": max_normalized_diff,
+        "max_abs": max_abs,
+        "groups": groups,
+    }
+
+
+def validate_capture(
+    captured: CapturedImplementation,
+    oracle: Sequence[torch.Tensor],
+) -> dict[str, Any]:
+    rewritten = poison_and_replay(captured)
+    correctness = check_correctness(captured, oracle)
+    return {
+        **correctness,
+        "poisoned_replay_rewrote_output": rewritten,
+        "ok": rewritten and bool(correctness["ok"]),
+    }
+
+
+def config_sha256(config: Mapping[str, Any]) -> str:
+    """Hash one canonical JSON provider configuration without timing metadata."""
+
+    identity = json.dumps(
+        config,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return sha256(identity.encode()).hexdigest()
+
+
+def require_single_visible_device(value: str | None = None) -> str:
+    """Require one explicit ``CUDA_VISIBLE_DEVICES`` entry."""
+
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES") if value is None else value
+    if visible is None:
+        raise RuntimeError("CUDA_VISIBLE_DEVICES must select exactly one GPU")
+    entries = tuple(item.strip() for item in visible.split(",") if item.strip())
+    if len(entries) != 1:
+        raise RuntimeError(
+            f"CUDA_VISIBLE_DEVICES must contain exactly one entry, got {visible!r}"
+        )
+    return entries[0]
+
+
+def is_canonical_b200(
+    device_kind: object,
+    name: object,
+    capability: object,
+) -> bool:
+    """Return whether identity exactly matches the validated CUDA B200 target."""
+
+    return (
+        name == CANONICAL_DEVICE_NAME
+        and device_kind == "cuda"
+        and isinstance(capability, list | tuple)
+        and tuple(capability) == CANONICAL_DEVICE_CAPABILITY
+    )
+
+
+def clean_checkout(root: Path, expected_commit: str, label: str) -> dict[str, object]:
+    """Record a provider checkout after requiring its expected clean commit."""
+
+    root = root.expanduser().resolve(strict=True)
+    head = deepgemm_support.clean_checkout(root, expected_commit, label)
+    return {"path": str(root), "commit": head, "clean": True}
+
+
+def write_result(path: Path, result: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")

--- a/benchmarks/cute/grouped_gemm_defaults.md
+++ b/benchmarks/cute/grouped_gemm_defaults.md
@@ -1,0 +1,83 @@
+# Grouped-GEMM provider benchmark
+
+`compare_grouped_gemm_defaults.py` compares Helion with selectable public
+defaults from DeepGEMM, QuACK, cuDNN, cuBLASLt, and CUTLASS on the eight
+reviewed BF16 grouped-GEMM shapes.
+
+Run the campaign from a dedicated Python 3.12 environment with the validated
+dependency set below; a normal development environment is not assumed to
+satisfy these pins. The benchmark fails closed on the provider versions,
+module origins, native ABI versions, and source commits it can verify, while
+the complete measured environment is recorded here for reproducibility.
+
+| Dependency | Validated version |
+|---|---:|
+| PyTorch | `2.13.0+cu130` |
+| `nvidia-cutlass-dsl` and its three DSL library packages | `4.7.0` |
+| `nvidia-cuda-runtime` | `13.3.29` |
+| `nvidia-cuda-nvcc` | `13.3.73` |
+| `nvidia-cublas` | `13.6.1.10` |
+| `nvidia-cudnn-frontend` | `1.27.0` |
+| `nvidia-cudnn-cu13` | `9.24.0.43` (backend `9.24.0`) |
+| `quack-kernels` | `0.6.4`, editable checkout at `60d88082272a256fa9b3b2ab631c82cfa78337c6` |
+
+The CUDA runtime and nvcc distributions must share the same installed
+`nvidia/cu13` prefix so `bin/nvcc` is beside the runtime package's `lib`
+directory. DeepGEMM must be a clean, built checkout at
+`559d79fb6994a58b8a15b4b93bf13ccc16edf247`; CUTLASS must be a clean checkout
+at `dcf215af68a2d08d305076c152a06f201728cd53`. Their nested dependency and
+module-origin checks are enforced by the benchmark.
+
+```bash
+CUDA_VISIBLE_DEVICES=0 nohup python \
+  benchmarks/cute/compare_grouped_gemm_defaults.py \
+  --providers deepgemm,quack,cudnn,cublaslt,cutlass \
+  --replicates 3 \
+  --helion-selection final_reviewed_aot \
+  --deepgemm-root /path/to/DeepGEMM \
+  --cutlass-root /path/to/cutlass \
+  --output-dir /tmp/grouped-gemm-results \
+  >/tmp/grouped-gemm.log 2>&1 </dev/null &
+```
+
+`--providers` accepts any nonempty ordered subset. The two source-root flags
+are required only when their provider is selected. Run the command detached
+for long campaigns, especially `live_autotune`.
+
+Helion modes are:
+
+- `final_reviewed_aot`: use the checked reviewed configuration.
+- `compiler_heuristic`: use `ConfigSpec.default_config()` after compiler
+  heuristic promotion.
+- `live_autotune`: run a fresh forced full compiler-config search for every
+  row. Packing and B layout remain fixed to the reviewed profile.
+
+Every provider/replicate gets a fresh process and fresh compiler caches. Each
+row uses identical logical inputs and a shared FP32 oracle. Both implementations
+are compiled, checked, and captured before timing. The worker then performs a
+10-second thermal warmup and calls
+`pretuned_kernels._bench.bench_pre_captured_cudagraphs(..., rep=102)`.
+That timer clears L2 before every replay and rotates then reverses ordering, so
+Helion and the provider each run first in exactly 51 samples.
+
+Run from a clean Helion checkout and write `--output-dir` outside that checkout.
+The controller records and rechecks the source commit/tree after every worker.
+
+The campaign resolves the selected GPU to its UUID, requires that GPU to have
+no compute applications immediately before and after every worker, and checks
+both worker results and telemetry against that UUID. Worker processes receive a
+clean set of Helion, provider, compiler, and CUDA loader controls; `CUDA_HOME`
+and cuDNN's CUDA runtime are resolved from the installed CUDA runtime package.
+SIGINT and SIGTERM terminate the active worker process group before the campaign
+exits.
+
+The output directory contains one `result.json`, `worker.log`, and
+`telemetry.csv` per provider/replicate plus `summary.json`. Telemetry is sampled
+with `nvidia-smi` every five seconds. The summary reports per-provider geometric
+mean speedup, wins, worst row, Helion config distributions, and any active GPU
+clock-event reason samples. A speedup above one favors Helion.
+
+Provider and Helion selection, autotuning, compilation, graph capture, input
+packing, and preprocessing are excluded from latency. Results therefore cover
+prepacked BF16 CUDA-graph replay on the recorded GPU; they are not end-to-end
+startup measurements or an unqualified SOTA claim.

--- a/benchmarks/cute/quack_grouped_gemm.py
+++ b/benchmarks/cute/quack_grouped_gemm.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import importlib
+import importlib.metadata
+import json
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING
+from typing import cast
+from urllib.parse import unquote
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+
+
+QUACK_B_LAYOUTS = ("k_major", "n_major")
+QUACK_REPOSITORY = "https://github.com/Dao-AILab/quack"
+QUACK_VERSION = "0.6.4"
+QUACK_COMMIT = "60d88082272a256fa9b3b2ab631c82cfa78337c6"
+
+
+def _editable_root(distribution: importlib.metadata.Distribution) -> Path:
+    direct_url_text = distribution.read_text("direct_url.json")
+    if direct_url_text is None:
+        raise RuntimeError("QuACK must be installed from an editable checkout")
+    try:
+        direct_url = json.loads(direct_url_text)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("QuACK direct_url.json is invalid") from error
+    url = direct_url.get("url") if isinstance(direct_url, dict) else None
+    parsed = urlparse(url) if isinstance(url, str) else None
+    if (
+        parsed is None
+        or parsed.scheme != "file"
+        or parsed.netloc not in ("", "localhost")
+    ):
+        raise RuntimeError("QuACK editable checkout path is unavailable")
+    return Path(unquote(parsed.path)).resolve(strict=True)
+
+
+def verify_quack_installation() -> dict[str, str]:
+    """Verify the pinned clean editable QuACK distribution and module origin."""
+
+    try:
+        distribution = importlib.metadata.distribution("quack-kernels")
+    except importlib.metadata.PackageNotFoundError as error:
+        raise RuntimeError("QuACK requires the quack-kernels distribution") from error
+    if distribution.version != QUACK_VERSION:
+        raise RuntimeError(
+            f"QuACK distribution is {distribution.version!r}, expected {QUACK_VERSION!r}"
+        )
+    root = _editable_root(distribution)
+    from benchmarks.cute import grouped_gemm_benchmark as common
+
+    checkout = common.clean_checkout(root, QUACK_COMMIT, "QuACK")
+    module = _import_quack_from_root(root)
+    origin = Path(str(module.__file__)).resolve(strict=True)
+    if not origin.is_relative_to(root):
+        raise RuntimeError("QuACK imported outside its editable checkout")
+
+    return {
+        "repository": QUACK_REPOSITORY,
+        "upstream_commit": str(checkout["commit"]),
+        "distribution_version": distribution.version,
+        "installation": "editable",
+        "module": origin.relative_to(root).as_posix(),
+    }
+
+
+def _import_quack_from_root(root: Path) -> ModuleType:
+    root_text = str(root)
+    sys.path.insert(0, root_text)
+    try:
+        return importlib.import_module("quack")
+    finally:
+        sys.path.remove(root_text)
+
+
+def _package_identity() -> dict[str, str]:
+    identity = verify_quack_installation()
+    import quack  # pyrefly: ignore [missing-import]
+
+    module_version = str(quack.__version__)
+    if module_version != QUACK_VERSION:
+        raise RuntimeError(
+            f"QuACK module is {module_version!r}, expected {QUACK_VERSION!r}"
+        )
+    return {
+        **identity,
+        "module_version": module_version,
+    }
+
+
+def prepare_quack_default(
+    inputs: GroupedGemmInputs,
+    *,
+    b_layout: str,
+) -> PreparedImplementation:
+    """Use QuACK's public GEMM with its untuned per-architecture default."""
+
+    from benchmarks.cute import grouped_gemm_benchmark as common
+    import torch
+
+    if b_layout not in QUACK_B_LAYOUTS:
+        raise ValueError(f"unsupported QuACK B layout {b_layout!r}")
+    package = _package_identity()
+    try:
+        from quack.gemm_interface import (  # pyrefly: ignore [missing-import]
+            default_config,
+        )
+        from quack.gemm_interface import gemm  # pyrefly: ignore [missing-import]
+    except ImportError as error:
+        raise RuntimeError(
+            "QuACK requires the optional quack-kernels package"
+        ) from error
+
+    b_kn = inputs.b_for_layout(b_layout).transpose(1, 2)
+    output = torch.empty(
+        (inputs.case.total_m, inputs.case.n),
+        device=inputs.compact_a.device,
+        dtype=torch.bfloat16,
+    )
+    resolved_config = default_config(inputs.compact_a.device)
+    if (
+        resolved_config.device_capacity != 10
+        or resolved_config.swap_ab
+        or resolved_config.use_tma_gather
+    ):
+        raise RuntimeError("QuACK's public SM100 default config changed")
+    serialized = asdict(resolved_config)
+    resolved_dynamic_scheduler = bool(resolved_config.is_dynamic_persistent)
+
+    def call() -> torch.Tensor:
+        # The public wrapper has no ``config`` keyword. ``tuned=False`` routes
+        # internally to ``gemm_tuned.fn(..., config=None)``.
+        result = gemm(
+            inputs.compact_a,
+            b_kn,
+            out=output,
+            cu_seqlens_m=inputs.offsets,
+            dynamic_scheduler=False,
+            tuned=False,
+            split_k=1,
+        )
+        if result is not output:
+            raise RuntimeError("QuACK public GEMM replaced the provided output")
+        return output
+
+    return common.PreparedImplementation(
+        name=f"quack-public-default-{b_layout}",
+        call=call,
+        output_tensors=lambda result: (cast("torch.Tensor", result),),
+        logical_outputs=lambda result: inputs.compact_output_slices(
+            cast("torch.Tensor", result)
+        ),
+        config={
+            "provider": "quack",
+            "selection_mode": "public_default_no_tune",
+            "b_layout": b_layout,
+            "requested_config": None,
+            "config": {**serialized, "b_layout": b_layout},
+            "requested_dynamic_scheduler": False,
+            "resolved_dynamic_scheduler": resolved_dynamic_scheduler,
+            "tuned": False,
+            "split_k": 1,
+            "package": package,
+            "a_layout": common.compact_contiguous_a_layout(),
+            "preprocessing_timed": False,
+            "numerics": "BF16 inputs, FP32 accumulation, BF16 output",
+        },
+        owners=(
+            inputs,
+            inputs.compact_a,
+            inputs.offsets,
+            b_kn,
+            output,
+            resolved_config,
+        ),
+    )

--- a/test/test_grouped_gemm_defaults_campaign.py
+++ b/test/test_grouped_gemm_defaults_campaign.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+import signal
+import subprocess
+from types import SimpleNamespace
+
+from benchmarks.cute import compare_grouped_gemm_defaults as benchmark
+import pytest
+
+SOURCE = {"commit": "source", "tree": "tree"}
+
+
+def _row(row_index: int, speedup: float, config_hash: str) -> dict[str, object]:
+    return {
+        "row_index": row_index,
+        "configs": {"helion": {"config_sha256": config_hash}},
+        "timings": {
+            "helion_ms": 1.0,
+            "provider_ms": speedup,
+            "helion_speedup": speedup,
+        },
+    }
+
+
+def _result(
+    provider: str,
+    replicate: int,
+    *,
+    speedup: float = 2.0,
+    row_speedups: tuple[float, ...] | None = None,
+    config_prefix: str = "fixed",
+    helion_selection: str = "compiler_heuristic",
+) -> dict[str, object]:
+    speedups = row_speedups or tuple(speedup + index / 100 for index in range(8))
+    assert len(speedups) == 8
+    return {
+        "schema": benchmark.RESULT_SCHEMA,
+        "provider": provider,
+        "replicate": replicate,
+        "helion_selection": helion_selection,
+        "device": {"uuid": "GPU-test", "visible": "GPU-test"},
+        "source": SOURCE,
+        "rows": [
+            _row(row_index, row_speedup, f"{config_prefix}-{row_index}")
+            for row_index, row_speedup in enumerate(speedups)
+        ],
+    }
+
+
+def _args(tmp_path: Path, **overrides: object) -> argparse.Namespace:
+    values: dict[str, object] = {
+        "providers": ("quack", "cudnn"),
+        "replicates": 2,
+        "helion_selection": "final_reviewed_aot",
+        "output_dir": tmp_path / "campaign",
+        "cuda_visible_devices": "GPU-test",
+        "deepgemm_root": None,
+        "cutlass_root": None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _mock_cuda_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cuda_home = tmp_path / "cuda-runtime"
+    monkeypatch.setattr(
+        benchmark,
+        "_installed_cuda_runtime",
+        lambda: (cuda_home, cuda_home / "lib" / "libcudart.so.13"),
+    )
+
+
+def test_parse_provider_subset_preserves_order_and_rejects_invalid() -> None:
+    assert benchmark.parse_providers("quack,cudnn,cublaslt") == (
+        "quack",
+        "cudnn",
+        "cublaslt",
+    )
+    for invalid in ("", "quack,quack", "unknown"):
+        with pytest.raises(argparse.ArgumentTypeError):
+            benchmark.parse_providers(invalid)
+
+
+def test_public_cli_requires_external_output_directory() -> None:
+    parser = benchmark.build_arg_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(("--cuda-visible-devices", "GPU-test"))
+    args = parser.parse_args(
+        (
+            "--cuda-visible-devices",
+            "GPU-test",
+            "--output-dir",
+            "/tmp/grouped-gemm-results",
+        )
+    )
+    assert args.output_dir == Path("/tmp/grouped-gemm-results")
+    assert args.providers == benchmark.PROVIDERS
+    assert args.replicates == 3
+    assert args.helion_selection == "final_reviewed_aot"
+    assert not args.worker
+    assert args.provider is args.replicate is args.run_dir is None
+
+
+@pytest.mark.parametrize("relative_pythonpath", (False, True))
+def test_direct_script_uses_helpers_from_its_checkout(
+    tmp_path: Path,
+    relative_pythonpath: bool,
+) -> None:
+    stale_root = tmp_path / "stale"
+    stale_module = stale_root / "benchmarks" / "cute" / "grouped_gemm_benchmark.py"
+    stale_module.parent.mkdir(parents=True)
+    (stale_root / "benchmarks" / "__init__.py").write_text("")
+    (stale_root / "benchmarks" / "cute" / "__init__.py").write_text("")
+    stale_module.write_text("raise RuntimeError('imported stale benchmark helper')\n")
+    completed = subprocess.run(
+        (benchmark.sys.executable, str(Path(benchmark.__file__)), "--help"),
+        check=False,
+        capture_output=True,
+        cwd=stale_root if relative_pythonpath else tmp_path,
+        env={
+            **os.environ,
+            "PYTHONPATH": "." if relative_pythonpath else str(stale_root),
+        },
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_provider_roots_are_required_only_when_selected(tmp_path: Path) -> None:
+    deepgemm = tmp_path / "deepgemm"
+    cutlass = tmp_path / "cutlass"
+    deepgemm.mkdir()
+    cutlass.mkdir()
+    args = _args(
+        tmp_path,
+        providers=("deepgemm", "cutlass"),
+        deepgemm_root=deepgemm,
+        cutlass_root=cutlass,
+    )
+    assert benchmark._provider_roots(args) == {
+        "deepgemm": deepgemm,
+        "cutlass": cutlass,
+    }
+    args.deepgemm_root = None
+    with pytest.raises(ValueError, match="deepgemm-root"):
+        benchmark._provider_roots(args)
+
+
+def test_source_identity_requires_clean_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        benchmark,
+        "_git_value",
+        lambda *args: "dirty.py" if args[0] == "status" else args[-1],
+    )
+    with pytest.raises(RuntimeError, match="clean Helion checkout"):
+        benchmark._source_identity()
+
+
+@pytest.mark.parametrize(
+    ("selection", "aot_mode", "skip_cache"),
+    (
+        ("final_reviewed_aot", "evaluate", False),
+        ("compiler_heuristic", "disabled", False),
+        ("live_autotune", "disabled", True),
+    ),
+)
+def test_worker_environment_sets_mode_and_fresh_caches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    selection: str,
+    aot_mode: str,
+    skip_cache: bool,
+) -> None:
+    _mock_cuda_runtime(monkeypatch, tmp_path)
+    stale = {
+        "CC": "/stale",
+        "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+        "CUDA_HOME": "/stale",
+        "DG_JIT_CACHE_DIR": "/stale",
+        "HELION_AOT_MODE": "stale",
+        "HELION_AUTOTUNE_BEST_OF_K": "99",
+        "HELION_BACKEND": "triton",
+        "HELION_CAP_AUTOTUNE_NUM_NEIGHBORS": "7",
+        "HELION_CUTE_MMA_IMPL": "stale",
+        "HELION_HEURISTIC_DIR": "/stale",
+        "HELION_SKIP_CACHE": "stale",
+        "LD_PRELOAD": "/stale",
+        "NVIDIA_TF32_OVERRIDE": "1",
+        "PYTHONHOME": "/stale",
+        "PYTHONPATH": "/stale",
+        "QUACK_CACHE_DIR": "/stale",
+        "TRITON_CACHE_DIR": "/stale",
+        "TORCH_ALLOW_TF32_CUBLAS_OVERRIDE": "1",
+    }
+    for name, value in stale.items():
+        monkeypatch.setenv(name, value)
+    run_dir = tmp_path / selection
+    environment = benchmark._worker_environment(
+        run_dir,
+        cuda_visible_devices="GPU-test",
+        helion_selection=selection,
+    )
+    other = benchmark._worker_environment(
+        tmp_path / f"{selection}-other",
+        cuda_visible_devices="GPU-test",
+        helion_selection=selection,
+    )
+    assert environment["HELION_AOT_MODE"] == aot_mode
+    assert ("HELION_SKIP_CACHE" in environment) is skip_cache
+    assert environment["HELION_BACKEND"] == "cute"
+    assert environment["HELION_CUTE_MMA_IMPL"] == "tcgen05"
+    assert environment["HELION_AUTOTUNER"] == "LFBOTreeSearch"
+    assert all(environment.get(name) != value for name, value in stale.items())
+    for name in (
+        "CUBLAS_WORKSPACE_CONFIG",
+        "HELION_AUTOTUNE_BEST_OF_K",
+        "HELION_HEURISTIC_DIR",
+        "NVIDIA_TF32_OVERRIDE",
+        "TORCH_ALLOW_TF32_CUBLAS_OVERRIDE",
+    ):
+        assert name not in environment
+    assert environment["HELION_CAP_AUTOTUNE_NUM_NEIGHBORS"] == "-1"
+    assert environment["CUDA_VISIBLE_DEVICES"] == "GPU-test"
+    assert environment["PYTHONPATH"] == str(benchmark.REPO_ROOT)
+    assert environment["PYTHONNOUSERSITE"] == "1"
+    cache_paths = {environment[name] for name in benchmark.WORKER_CACHE_NAMES}
+    other_cache_paths = {other[name] for name in benchmark.WORKER_CACHE_NAMES}
+    assert cache_paths.isdisjoint(other_cache_paths)
+    assert all(Path(path).is_dir() for path in cache_paths | other_cache_paths)
+
+
+def test_worker_command_reexecutes_same_script_with_fresh_pycache(
+    tmp_path: Path,
+) -> None:
+    args = _args(tmp_path, helion_selection="compiler_heuristic")
+    run_dir = tmp_path / "run"
+    command = benchmark._worker_command(args, "quack", 2, run_dir, {})
+    other_command = benchmark._worker_command(args, "quack", 2, tmp_path / "other", {})
+    assert command[:4] == [
+        benchmark.sys.executable,
+        "-u",
+        "-X",
+        f"pycache_prefix={run_dir / 'cache' / 'pycache'}",
+    ]
+    assert "--worker" in command
+    assert command[command.index("--provider") + 1] == "quack"
+    assert command[command.index("--replicate") + 1] == "2"
+    assert Path(command[command.index("--output-dir") + 1]) == args.output_dir
+    assert command[command.index("--helion-selection") + 1] == "compiler_heuristic"
+    assert other_command[3] != command[3]
+
+
+def test_monitored_worker_records_periodic_and_final_samples_then_cleans(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    polls = iter((None, 0))
+    events: list[object] = []
+    process = SimpleNamespace(
+        pid=1234,
+        poll=lambda: next(polls),
+        wait=lambda: events.append("wait") or 7,
+    )
+
+    def popen(command: object, **kwargs: object) -> object:
+        events.append((command, kwargs))
+        return process
+
+    samples = iter(("periodic", "final"))
+    idle_checks: list[tuple[str, str]] = []
+    monkeypatch.setattr(benchmark.subprocess, "Popen", popen)
+    monkeypatch.setattr(benchmark, "_query_telemetry", lambda _device: next(samples))
+    monkeypatch.setattr(benchmark, "_terminate_process", events.append)
+    monkeypatch.setattr(
+        benchmark,
+        "_require_target_gpu_idle",
+        lambda uuid: idle_checks.append(("before", uuid)),
+    )
+    monkeypatch.setattr(
+        benchmark,
+        "_wait_for_target_gpu_idle",
+        lambda uuid: idle_checks.append(("after", uuid)),
+    )
+    monkeypatch.setattr(benchmark.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(benchmark.time, "sleep", lambda _seconds: None)
+    telemetry_path = tmp_path / "telemetry.csv"
+
+    assert benchmark._run_monitored_worker(
+        ("worker",),
+        environment={"TEST": "1"},
+        log_path=tmp_path / "worker.log",
+        telemetry_path=telemetry_path,
+        target_gpu_uuid="GPU-test",
+    ) == (7, 2)
+    command, kwargs = events[0]
+    assert command == ("worker",)
+    assert kwargs == {
+        "cwd": benchmark.REPO_ROOT,
+        "env": {"TEST": "1"},
+        "stdin": subprocess.DEVNULL,
+        "stdout": kwargs["stdout"],
+        "stderr": subprocess.STDOUT,
+        "start_new_session": True,
+    }
+    assert events[1:] == ["wait", process]
+    assert idle_checks == [("before", "GPU-test"), ("after", "GPU-test")]
+    assert telemetry_path.read_text().splitlines() == [
+        ",".join(benchmark.TELEMETRY_FIELDS),
+        "periodic",
+        "final",
+    ]
+
+
+def test_terminate_process_escalates_and_waits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signals: list[tuple[int, signal.Signals]] = []
+    waits: list[bool] = []
+    process = SimpleNamespace(pid=1234, wait=lambda: waits.append(True))
+    monkeypatch.setattr(benchmark, "WORKER_TERMINATION_GRACE_SECONDS", 0)
+    monkeypatch.setattr(benchmark, "_process_group_exists", lambda _group: True)
+    monkeypatch.setattr(
+        benchmark.os,
+        "killpg",
+        lambda group, signum: signals.append((group, signum)),
+    )
+
+    benchmark._terminate_process(process)
+
+    assert signals == [(1234, signal.SIGTERM), (1234, signal.SIGKILL)]
+    assert waits == [True]
+
+
+def test_post_worker_idle_check_retries_context_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def require_idle(_uuid: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("CUDA context is still visible")
+
+    monkeypatch.setattr(benchmark, "_require_target_gpu_idle", require_idle)
+    monkeypatch.setattr(benchmark.time, "sleep", lambda _seconds: None)
+    benchmark._wait_for_target_gpu_idle("GPU-test")
+    assert attempts == 2
+
+
+def test_provider_order_reverses_pairs_and_rotates_later_pairs() -> None:
+    providers = ("a", "b", "c")
+    assert [
+        benchmark._provider_order(providers, replicate) for replicate in range(6)
+    ] == [
+        ("a", "b", "c"),
+        ("b", "c", "a"),
+        ("c", "a", "b"),
+        ("c", "b", "a"),
+        ("a", "c", "b"),
+        ("b", "a", "c"),
+    ]
+
+
+def test_summary_keeps_provider_geomeans_worst_rows_and_configs_separate() -> None:
+    results = [
+        _result("quack", 0, row_speedups=(0.25, *(1.0,) * 7)),
+        _result("cudnn", 0, row_speedups=(9.0,) * 8),
+        _result("quack", 1, row_speedups=(1.0, *(4.0,) * 7)),
+        _result("cudnn", 1, row_speedups=(9.0,) * 8),
+    ]
+    summary = benchmark.summarize_results(
+        results,
+        providers=("quack", "cudnn"),
+        replicates=2,
+        helion_selection="compiler_heuristic",
+    )
+    assert summary["providers"] == ["quack", "cudnn"]
+    quack = summary["provider_results"]["quack"]
+    cudnn = summary["provider_results"]["cudnn"]
+    assert quack["cross_replicate_geomean"] == pytest.approx(
+        math.prod((0.25, *(1.0,) * 8, *(4.0,) * 7)) ** (1 / 16)
+    )
+    assert quack["worst_row"] == {
+        "row_index": 0,
+        "geomean_speedup": 0.5,
+        "replicate_speedups": [0.25, 1.0],
+    }
+    assert quack["row_wins"] == 7
+    assert cudnn["cross_replicate_geomean"] == pytest.approx(9.0)
+    assert cudnn["worst_row"]["geomean_speedup"] == pytest.approx(9.0)
+    assert all(item["invariant"] for item in summary["helion_config_distributions"])
+    assert summary["protocol"] == {
+        "fresh_process_and_caches_per_provider_replicate": True,
+        "provider_worker_order": "rotated_then_reversed",
+        "rows_per_replicate": 8,
+        "thermal_warmup_ms": 10_000,
+        "paired_cold_l2_samples": 102,
+        "balanced_rotated_reversed_order": True,
+    }
+
+
+@pytest.mark.parametrize(
+    "fixed_selection", ("compiler_heuristic", "final_reviewed_aot")
+)
+def test_fixed_summary_requires_same_config_across_providers(
+    fixed_selection: str,
+) -> None:
+    results = [
+        _result(
+            "quack",
+            0,
+            config_prefix="first",
+            helion_selection="live_autotune",
+        ),
+        _result(
+            "cudnn",
+            0,
+            config_prefix="second",
+            helion_selection="live_autotune",
+        ),
+    ]
+    fixed_results = [
+        {**result, "helion_selection": fixed_selection} for result in results
+    ]
+    with pytest.raises(RuntimeError, match="fixed Helion config changed"):
+        benchmark.summarize_results(
+            fixed_results,
+            providers=("quack", "cudnn"),
+            replicates=1,
+            helion_selection=fixed_selection,
+        )
+    summary = benchmark.summarize_results(
+        results,
+        providers=("quack", "cudnn"),
+        replicates=1,
+        helion_selection="live_autotune",
+    )
+    distribution = summary["helion_config_distributions"][0]
+    assert distribution["invariant"] is False
+    assert distribution["config_sha256_counts"] == {"first-0": 1, "second-0": 1}
+
+
+def test_campaign_runs_sequential_provider_replicates_and_writes_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _mock_cuda_runtime(monkeypatch, tmp_path)
+    args = _args(tmp_path)
+    calls: list[tuple[str, int]] = []
+
+    def run_worker(
+        command: list[str],
+        *,
+        environment: dict[str, str],
+        log_path: Path,
+        telemetry_path: Path,
+        target_gpu_uuid: str,
+    ) -> tuple[int, int]:
+        provider = command[command.index("--provider") + 1]
+        replicate = int(command[command.index("--replicate") + 1])
+        run_dir = Path(command[command.index("--run-dir") + 1])
+        calls.append((provider, replicate))
+        assert environment["CUDA_VISIBLE_DEVICES"] == target_gpu_uuid
+        log_path.write_text("")
+        telemetry_path.write_text("timestamp,uuid\n")
+        (run_dir / "result.json").write_text(
+            json.dumps(
+                _result(
+                    provider,
+                    replicate,
+                    helion_selection=args.helion_selection,
+                )
+            )
+        )
+        return 0, 1
+
+    monkeypatch.setattr(benchmark, "_run_monitored_worker", run_worker)
+    monkeypatch.setattr(benchmark, "_resolve_target_gpu", lambda _selector: "GPU-test")
+    monkeypatch.setattr(
+        benchmark,
+        "_summarize_telemetry",
+        lambda _path, _uuid: {
+            "sample_count": 1,
+            "active_clock_event_reason_sample_count": 0,
+            "active_clock_event_reasons": {},
+        },
+    )
+    monkeypatch.setattr(benchmark, "_source_identity", lambda: SOURCE)
+    assert benchmark._run_campaign(args) == 0
+    assert calls == [
+        ("quack", 0),
+        ("cudnn", 0),
+        ("cudnn", 1),
+        ("quack", 1),
+    ]
+    summary = json.loads((args.output_dir / "summary.json").read_text())
+    assert summary["schema"] == benchmark.SUMMARY_SCHEMA
+    assert len(summary["runs"]) == 4

--- a/test/test_grouped_gemm_provider_defaults.py
+++ b/test/test_grouped_gemm_provider_defaults.py
@@ -1,0 +1,827 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextlib import nullcontext
+import ctypes
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+from typing import Any
+from typing import cast
+from unittest.mock import Mock
+
+from benchmarks.cute import compare_grouped_gemm_defaults as runner
+from benchmarks.cute import cublaslt_grouped_gemm
+from benchmarks.cute import cudnn_grouped_gemm
+from benchmarks.cute import cutlass_contiguous_grouped_gemm
+from benchmarks.cute import grouped_gemm_benchmark as common
+from benchmarks.cute import quack_grouped_gemm
+from pretuned_kernels import _bench
+from pretuned_kernels.grouped_gemm_deepgemm import grouped_gemm_deepgemm
+from pretuned_kernels.grouped_gemm_deepgemm import reviewed_profiles
+import pytest
+import torch
+
+
+@dataclass(frozen=True)
+class _QuackConfig:
+    tile_m: int = 256
+    tile_n: int = 256
+    tile_k: int | None = None
+    num_warps: int | None = None
+    pingpong: bool = False
+    is_dynamic_persistent: bool = True
+    cluster_m: int = 2
+    cluster_n: int = 1
+    cluster_k: int = 1
+    split_k: int = 1
+    swap_ab: bool = False
+    max_swizzle_size: int = 8
+    device_capacity: int = 10
+    use_tma_gather: bool = False
+
+
+class _Inputs:
+    def __init__(self, *, n: int = 3, k: int = 4) -> None:
+        self.case = SimpleNamespace(
+            total_m=3,
+            n=n,
+            k=k,
+            groups=2,
+            actual_ms=(1, 2),
+        )
+        self.compact_a = torch.arange(3 * k, dtype=torch.bfloat16).reshape(3, k)
+        self.b = torch.arange(2 * n * k, dtype=torch.bfloat16).reshape(2, n, k)
+        self.b_n_major = self.b.transpose(1, 2).contiguous().transpose(1, 2)
+        self.offsets = torch.tensor((0, 1, 3), dtype=torch.int32)
+
+    def b_for_layout(self, layout: str) -> torch.Tensor:
+        return self.b if layout == "k_major" else self.b_n_major
+
+    def compact_a_slices(self) -> tuple[torch.Tensor, ...]:
+        return self.compact_a[:1], self.compact_a[1:]
+
+    def compact_output_slices(self, output: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        return output[:1], output[1:]
+
+
+@pytest.mark.parametrize(
+    "foreign_module",
+    (
+        None,
+        "cutlass.operators",
+        cutlass_contiguous_grouped_gemm._OPERATOR_MODULE,
+    ),
+)
+def test_cutlass_loader_rejects_cached_operator_outside_checkout(
+    monkeypatch: Any,
+    tmp_path: Path,
+    foreign_module: str | None,
+) -> None:
+    package_root = tmp_path / "operators" / "cutlass"
+    operators_file = package_root / "operators" / "__init__.py"
+    operators_file.parent.mkdir(parents=True)
+    operators_file.write_text("")
+    operator_file = (
+        package_root
+        / "operators"
+        / "providers"
+        / "cutedsl"
+        / "gemm"
+        / "sm100_contiguous_offset_2d3d_dense_gemm.py"
+    )
+    operator_file.parent.mkdir(parents=True)
+    operator_file.write_text("")
+    outside_file = tmp_path / "installed" / "operator.py"
+    outside_file.parent.mkdir()
+    outside_file.write_text("")
+
+    cutlass = ModuleType("cutlass")
+    cutlass.__path__ = []
+    operators = ModuleType("cutlass.operators")
+    operators.__file__ = str(
+        outside_file if foreign_module == "cutlass.operators" else operators_file
+    )
+    operator_module = ModuleType(cutlass_contiguous_grouped_gemm._OPERATOR_MODULE)
+    operator_module.__file__ = str(
+        outside_file
+        if foreign_module == cutlass_contiguous_grouped_gemm._OPERATOR_MODULE
+        else operator_file
+    )
+    operator_class = type("Operator", (), {})
+    operator_module.ContiguousOffset2D3DGemmDenseOperator = operator_class
+    modules = {
+        "cutlass": cutlass,
+        "cutlass.operators": operators,
+        cutlass_contiguous_grouped_gemm._OPERATOR_MODULE: operator_module,
+    }
+    monkeypatch.setattr(
+        cutlass_contiguous_grouped_gemm.importlib,
+        "import_module",
+        modules.__getitem__,
+    )
+
+    if foreign_module is None:
+        assert cutlass_contiguous_grouped_gemm._load_operator_api(tmp_path) == (
+            operators,
+            operator_class,
+        )
+    else:
+        with pytest.raises(RuntimeError, match="outside the pinned CUTLASS checkout"):
+            cutlass_contiguous_grouped_gemm._load_operator_api(tmp_path)
+    assert cutlass.__path__[0] == str(package_root)
+
+
+def _prepared(provider: str, b_layout: str) -> common.PreparedImplementation:
+    output = torch.empty(1)
+    return common.PreparedImplementation(
+        name=provider,
+        call=lambda: output,
+        output_tensors=lambda result: (cast("torch.Tensor", result),),
+        logical_outputs=lambda result: (cast("torch.Tensor", result),),
+        config={"provider": provider, "b_layout": b_layout},
+    )
+
+
+def test_official_cases_match_reviewed_manifest() -> None:
+    cases = common.official_cases()
+    assert len(cases) == len(reviewed_profiles.OFFICIAL_SHAPES) == 8
+    assert reviewed_profiles.official_actual_ms() == tuple(
+        case.actual_ms for case in cases
+    )
+
+
+@pytest.mark.parametrize(
+    ("timings", "valid"),
+    (
+        ((1.0, 2.0), True),
+        ((0.0, 1.0), False),
+        ((1.0, float("inf")), False),
+    ),
+)
+def test_run_case_keeps_setup_outside_timing_and_rng_isolated(
+    monkeypatch: Any,
+    timings: tuple[float, float],
+    valid: bool,
+) -> None:
+    depth = 0
+    events: list[tuple[str, int]] = []
+
+    @contextmanager
+    def fork_rng(*, devices: list[int]):
+        nonlocal depth
+        assert devices == [0]
+        events.append(("fork_enter", depth))
+        depth += 1
+        try:
+            yield
+        finally:
+            depth -= 1
+            events.append(("fork_exit", depth))
+
+    inputs = SimpleNamespace(oracle=(object(),))
+    prepared = {
+        name: SimpleNamespace(name=name, config={"kind": name})
+        for name in ("helion", "provider")
+    }
+    captured = {
+        name: SimpleNamespace(replay=lambda name=name: events.append((name, depth)))
+        for name in ("helion", "provider")
+    }
+
+    def capture(implementation: object, _oracle: object) -> tuple[object, object]:
+        name = cast("Any", implementation).name
+        events.append((f"capture_{name}", depth))
+        return captured[name], {"ok": True}
+
+    def make_inputs(*_args: object) -> tuple[object, object]:
+        events.append(("make_inputs", depth))
+        return inputs, object()
+
+    monkeypatch.setattr(torch.random, "fork_rng", fork_rng)
+    monkeypatch.setattr(runner, "make_exact_common_inputs", make_inputs)
+    monkeypatch.setattr(
+        runner,
+        "prepare_helion",
+        lambda *_args: events.append(("prepare_helion", depth)) or prepared["helion"],
+    )
+    monkeypatch.setattr(
+        runner,
+        "prepare_provider_default",
+        lambda *_args, **_kwargs: (
+            events.append(("prepare_provider", depth)) or prepared["provider"]
+        ),
+    )
+    monkeypatch.setattr(runner, "_validated_capture", capture)
+    monkeypatch.setattr(
+        _bench,
+        "thermal_warmup",
+        lambda duration: events.append((f"warmup_{duration}", depth)),
+    )
+
+    def benchmark(functions: list[object], *, rep: int) -> tuple[float, float]:
+        assert functions == [captured["helion"].replay, captured["provider"].replay]
+        assert rep == 102
+        events.append(("benchmark", depth))
+        return timings
+
+    monkeypatch.setattr(_bench, "bench_pre_captured_cudagraphs", benchmark)
+
+    def invoke() -> dict[str, object]:
+        return runner.run_case(
+            "quack",
+            cast("Any", SimpleNamespace(as_dict=lambda: {"id": "case"})),
+            cast("Any", SimpleNamespace(row_index=0)),
+            cast("Any", SimpleNamespace(index=0)),
+            helion_selection="final_reviewed_aot",
+            cutlass_root=None,
+            deepgemm_root=None,
+        )
+
+    if valid:
+        result = invoke()
+        assert cast("Any", result["timings"])["helion_speedup"] == 2.0
+    else:
+        with pytest.raises(RuntimeError, match="finite and positive"):
+            invoke()
+
+    assert events == [
+        ("make_inputs", 0),
+        ("fork_enter", 0),
+        ("prepare_helion", 1),
+        ("prepare_provider", 1),
+        ("capture_helion", 1),
+        ("capture_provider", 1),
+        ("fork_exit", 0),
+        ("warmup_10000", 0),
+        ("fork_enter", 0),
+        ("benchmark", 1),
+        ("fork_exit", 0),
+    ]
+
+
+def test_validated_capture_uses_warmups_and_rejects_failed_validation(
+    monkeypatch: Any,
+) -> None:
+    prepared = SimpleNamespace(name="implementation")
+    captured = object()
+    calls: list[tuple[object, object]] = []
+    validation = {"ok": True, "poisoned_replay_rewrote_output": True}
+
+    def capture(value: object, *, warmups: int) -> object:
+        calls.append((value, warmups))
+        return captured
+
+    monkeypatch.setattr(common, "capture_implementation", capture)
+    monkeypatch.setattr(common, "validate_capture", lambda *_args: validation)
+    assert runner._validated_capture(cast("Any", prepared), ()) == (
+        captured,
+        validation,
+    )
+    assert calls == [(prepared, 2)]
+
+    validation["ok"] = False
+    validation["poisoned_replay_rewrote_output"] = False
+    with pytest.raises(RuntimeError, match="failed correctness"):
+        runner._validated_capture(cast("Any", prepared), ())
+
+
+def test_validate_capture_fails_when_replay_leaves_poisoned_output(
+    monkeypatch: Any,
+) -> None:
+    output = torch.ones(1, dtype=torch.bfloat16)
+    prepared = common.PreparedImplementation(
+        name="does-not-rewrite",
+        call=lambda: output,
+        output_tensors=lambda result: (cast("torch.Tensor", result),),
+        logical_outputs=lambda result: (cast("torch.Tensor", result),),
+        config={},
+    )
+    captured = common.CapturedImplementation(
+        prepared=prepared,
+        graph=cast("Any", SimpleNamespace(replay=lambda: None)),
+        result=output,
+        owners=(),
+    )
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+    validation = common.validate_capture(captured, (torch.ones(1),))
+
+    assert validation["poisoned_replay_rewrote_output"] is False
+    assert validation["ok"] is False
+
+
+def test_compiler_and_live_selection_use_distinct_kernel_apis(
+    monkeypatch: Any,
+) -> None:
+    policy = runner.LIVE_AUTOTUNE_SEARCH_POLICY
+    base_config = {
+        "tcgen05_grouped_mode": "worklist_nm",
+        "tcgen05_grouped_worklist_source_m_tile": 256,
+    }
+    actions: dict[str, list[str]] = {
+        "compiler_heuristic": [],
+        "live_autotune": [],
+    }
+    bound_caches: dict[str, str] = {}
+    current_mode = ""
+
+    class ConfigSpec:
+        compiler_default_config = SimpleNamespace(config=base_config)
+        compiler_seed_configs = (compiler_default_config,)
+        autotuner_heuristics = ("cute_tcgen05_grouped_worklist",)
+        cute_tcgen05_search_enabled = False
+
+        def default_config(self) -> object:
+            return self.compiler_default_config
+
+        def normalized_config(self, config: object) -> object:
+            return config
+
+    class Bound:
+        def __init__(self, settings: object) -> None:
+            self.settings = settings
+            self.config_spec = ConfigSpec()
+            self.env = SimpleNamespace(config_spec=self.config_spec)
+
+        def set_config(self, _config: object) -> None:
+            actions[current_mode].append("set_config")
+
+        def autotune(self, _args: object, *, force: bool) -> object:
+            assert force
+            actions[current_mode].append("autotune")
+            return SimpleNamespace(config={**base_config, "num_stages": 3})
+
+        def __call__(self, *_args: object) -> torch.Tensor:
+            return torch.empty(1, dtype=torch.bfloat16)
+
+    class Kernel:
+        def __init__(self) -> None:
+            self.settings = SimpleNamespace(
+                autotune_cache="AOTAutotuneCache",
+                autotune_effort=policy["autotune_effort"],
+                autotune_random_seed=policy["random_seed"],
+                autotune_budget_seconds=policy["budget_seconds"],
+                autotune_max_generations=policy["max_generations_override"],
+                autotune_best_of_k=policy["best_of_k"],
+                autotune_accuracy_check=policy["accuracy_check"],
+                autotune_benchmark_subprocess=policy["benchmark_subprocess"],
+                autotune_benchmark_timeout=policy["benchmark_timeout_seconds"],
+                autotune_compile_timeout=policy["configured_compile_timeout_seconds"],
+                autotune_precompile="unset",
+                autotune_adaptive_timeout=policy["adaptive_timeout"],
+                autotune_initial_population_strategy=None,
+                autotune_config_overrides=policy["config_overrides"],
+                autotune_search_acf=policy["advanced_controls_files"],
+                disable_autotuner_heuristics=False,
+            )
+
+        def bind(self, _args: object) -> Bound:
+            bound_caches[current_mode] = self.settings.autotune_cache
+            return Bound(self.settings)
+
+    packed = SimpleNamespace(
+        a=object(),
+        worklist=object(),
+        output_padding_is_zero=lambda _output: True,
+        output_slices=lambda _output: (),
+    )
+    inputs = SimpleNamespace(
+        case=SimpleNamespace(expected_m_per_group=128, id="case"),
+        b_for_layout=lambda _layout: object(),
+    )
+    profile = SimpleNamespace(source_m_tile=256, b_major="k", config_name="test")
+    lfbo = SimpleNamespace(
+        max_generations=policy["effective_max_generations"],
+        initial_population_strategy=policy["initial_population_strategy"],
+        initial_population=policy["initial_population"],
+        copies=policy["copies"],
+        best_available_pad_random=policy["best_available_pad_random"],
+    )
+    monkeypatch.setenv("HELION_AUTOTUNER", str(policy["algorithm"]))
+    monkeypatch.setenv("HELION_SKIP_CACHE", "1")
+    monkeypatch.setattr(common, "pack_compact_rows", lambda *_args: packed)
+    monkeypatch.setattr(
+        grouped_gemm_deepgemm,
+        "create_grouped_gemm_deepgemm_kernel",
+        Kernel,
+    )
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        "helion.autotuner.effort_profile.get_effort_profile",
+        lambda _effort: SimpleNamespace(
+            lfbo_pattern_search=lfbo,
+            finishing_rounds=policy["finishing_rounds"],
+        ),
+    )
+
+    selections = {}
+    for current_mode in actions:
+        selections[current_mode] = runner.prepare_helion(
+            cast("Any", inputs), cast("Any", profile), current_mode
+        ).config
+
+    assert actions == {
+        "compiler_heuristic": ["set_config"],
+        "live_autotune": ["autotune"],
+    }
+    assert bound_caches == {
+        "compiler_heuristic": "AOTAutotuneCache",
+        "live_autotune": runner.LIVE_AUTOTUNE_CACHE,
+    }
+    assert selections["compiler_heuristic"]["selection_api"].startswith(
+        "BoundKernel.set_config"
+    )
+    assert selections["live_autotune"]["selection_api"] == (
+        "BoundKernel.autotune(force=True)"
+    )
+    assert selections["compiler_heuristic"]["live_search"] is None
+    assert selections["live_autotune"]["live_search"] == policy
+
+
+def test_cutlass_uses_tvm_ffi_before_compiling_registry_first(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+
+    class OperatorClass:
+        pass
+
+    class GlobalOptions:
+        enabled = False
+
+        @property
+        def use_tvm_ffi(self) -> bool:
+            return type(self).enabled
+
+        @use_tvm_ffi.setter
+        def use_tvm_ffi(self, value: bool) -> None:
+            type(self).enabled = value
+            events.append("use_tvm_ffi")
+
+    def operator(name: str) -> SimpleNamespace:
+        metadata = SimpleNamespace(
+            design=SimpleNamespace(
+                use_2cta_mma=False,
+                tile_shape=(128, 128, 64),
+                cluster_shape=(1, 1, 1),
+            ),
+            operator_class=OperatorClass,
+            operator_name=name,
+        )
+
+        def compile_operator(_args: object, *, target_sm: str) -> object:
+            events.append(f"compile:{name}")
+            return SimpleNamespace(compiled_for=target_sm)
+
+        return SimpleNamespace(
+            metadata=metadata,
+            compile=Mock(side_effect=compile_operator),
+        )
+
+    first, second = operator("first"), operator("second")
+
+    def get_operators(
+        _args: object,
+        *,
+        metadata_filter: Any,
+        target_sm: str,
+        providers: list[object],
+    ) -> list[SimpleNamespace]:
+        events.append("get_operators")
+        assert GlobalOptions.enabled
+        assert metadata_filter(first.metadata)
+        assert target_sm == cutlass_contiguous_grouped_gemm.CUTLASS_TARGET_SM
+        assert providers == [ops.CuTeDSLProvider]
+        return [first, second]
+
+    ops = SimpleNamespace(
+        __version__=cutlass_contiguous_grouped_gemm.CUTLASS_OPERATOR_API_VERSION,
+        GlobalOptions=GlobalOptions,
+        GroupedGemmArguments=lambda *_args, **_kwargs: object(),
+        get_operators=get_operators,
+        CuTeDSLProvider=object(),
+    )
+    monkeypatch.setattr(
+        cutlass_contiguous_grouped_gemm,
+        "verify_cutlass_checkout",
+        lambda _root: {"head": "test"},
+    )
+    monkeypatch.setattr(
+        cutlass_contiguous_grouped_gemm,
+        "require_cutlass_dependencies",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        cutlass_contiguous_grouped_gemm,
+        "_load_operator_api",
+        lambda _root: (ops, OperatorClass),
+    )
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda _device: (10, 0))
+    monkeypatch.setattr(torch.cuda, "device", lambda _device: nullcontext())
+
+    prepared = cutlass_contiguous_grouped_gemm.prepare_cutlass_default(
+        cast("Any", _Inputs(n=8, k=8)),
+        cutlass_root=tmp_path,
+    )
+
+    assert events == ["use_tvm_ffi", "get_operators", "compile:first"]
+    first.compile.assert_called_once()
+    second.compile.assert_not_called()
+    assert prepared.config["operator_name"] == "first"
+    assert prepared.config["global_options"] == {"use_tvm_ffi": True}
+
+
+def test_cudnn_uses_public_a_fallback_build_and_execute(monkeypatch: Any) -> None:
+    events: list[str] = []
+    float_type = object()
+    mode_a, mode_fallback = object(), object()
+    descriptor = Mock()
+    descriptor.set_uid.return_value = descriptor
+    descriptor.set_output.return_value = descriptor
+    descriptor.set_data_type.return_value = descriptor
+    graph = Mock()
+    graph.tensor.return_value = descriptor
+    graph.moe_grouped_matmul.return_value = descriptor
+    graph.get_workspace_size.return_value = 0
+    graph.build_plans.side_effect = lambda: events.append("build_plans")
+    graph.execute.side_effect = lambda *_args, **_kwargs: events.append("execute")
+    handle = object()
+    cudnn = SimpleNamespace(
+        data_type=SimpleNamespace(
+            FLOAT=float_type,
+            BFLOAT16=object(),
+            INT32=object(),
+        ),
+        moe_grouped_matmul_mode=SimpleNamespace(NONE=object()),
+        heur_mode=SimpleNamespace(A=mode_a, FALLBACK=mode_fallback),
+        create_handle=Mock(return_value=handle),
+        destroy_handle=Mock(),
+        set_stream=Mock(),
+        pygraph=Mock(return_value=graph),
+    )
+    monkeypatch.setattr(
+        cudnn_grouped_gemm,
+        "_validated_cudnn_runtime",
+        lambda: (
+            Path("/cuda/libcudart.so.13"),
+            cudnn,
+            cudnn_grouped_gemm.CUDNN_FRONTEND_VERSION,
+            cudnn_grouped_gemm.CUDNN_BACKEND_VERSION,
+        ),
+    )
+    monkeypatch.setattr(torch.cuda, "device", lambda _device: nullcontext())
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda _device: SimpleNamespace(cuda_stream=1),
+    )
+
+    prepared = cudnn_grouped_gemm.prepare_cudnn_default(
+        cast("Any", _Inputs()),
+        b_layout="k_major",
+    )
+    prepared.call()
+
+    cudnn.pygraph.assert_called_once_with(
+        intermediate_data_type=float_type,
+        compute_data_type=float_type,
+        handle=handle,
+    )
+    assert graph.moe_grouped_matmul.call_args.kwargs["compute_data_type"] is float_type
+    graph.create_execution_plans.assert_called_once_with([mode_a, mode_fallback])
+    assert events == ["build_plans", "execute"]
+    assert prepared.config["plan"]["heuristic_modes"] == ["A", "FALLBACK"]
+
+
+def test_cublaslt_requests_one_heuristic_and_uses_rank_zero(monkeypatch: Any) -> None:
+    capacities: list[int] = []
+
+    def heuristic(*args: object) -> int:
+        capacities.append(cast("int", args[7]))
+        result = cast("Any", args[8])._obj
+        result.workspace_size = 0
+        result.state = 0
+        result.waves_count = 1.0
+        cast("Any", args[9])._obj.value = 1
+        return 0
+
+    library = SimpleNamespace(
+        **{
+            name: Mock(return_value=0)
+            for name in (
+                "cublasLtCreate",
+                "cublasLtDestroy",
+                "cublasLtMatmul",
+                "cublasLtMatmulDescCreate",
+                "cublasLtMatmulDescDestroy",
+                "cublasLtMatmulDescSetAttribute",
+                "cublasLtMatmulPreferenceCreate",
+                "cublasLtMatmulPreferenceDestroy",
+                "cublasLtMatmulPreferenceSetAttribute",
+                "cublasLtMatrixLayoutDestroy",
+            )
+        },
+        cublasLtMatmulAlgoGetHeuristicForStream=heuristic,
+    )
+    monkeypatch.setattr(cublaslt_grouped_gemm, "_distribution", lambda: object())
+    monkeypatch.setattr(
+        cublaslt_grouped_gemm,
+        "_validated_cublaslt_library",
+        lambda: (library, {"library_version": 1}),
+    )
+    monkeypatch.setattr(
+        cublaslt_grouped_gemm,
+        "_create_grouped_matrix_layouts",
+        lambda *_args: (
+            ctypes.c_void_p(1),
+            ctypes.c_void_p(2),
+            ctypes.c_void_p(3),
+        ),
+    )
+    monkeypatch.setattr(
+        cublaslt_grouped_gemm,
+        "_grouped_algorithm_supported",
+        lambda *_args: True,
+    )
+    monkeypatch.setattr(cublaslt_grouped_gemm, "_DEFAULT_WORKSPACE_BYTES", 16)
+    monkeypatch.setattr(torch.cuda, "device", lambda _device: nullcontext())
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda _device: SimpleNamespace(cuda_stream=1, synchronize=lambda: None),
+    )
+
+    prepared = cublaslt_grouped_gemm.prepare_cublaslt_default(
+        cast("Any", _Inputs()),
+        b_layout="k_major",
+    )
+    prepared.call()
+
+    selected = cast("Any", prepared.config["selected_algorithm"])
+    assert capacities == [cublaslt_grouped_gemm.CUBLASLT_HEURISTIC_QUERY_CAPACITY]
+    assert selected["heuristic_rank"] == 0
+    assert prepared.config["heuristic_query_capacity"] == 1
+    library.cublasLtMatmul.assert_called_once()
+
+
+def test_quack_public_default_call_contract(monkeypatch: Any) -> None:
+    inputs = _Inputs()
+    calls: list[dict[str, object]] = []
+    interface = ModuleType("quack.gemm_interface")
+
+    def default_config(device: torch.device) -> _QuackConfig:
+        assert device == inputs.compact_a.device
+        return _QuackConfig()
+
+    def gemm(
+        a: torch.Tensor,
+        b: torch.Tensor,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        calls.append({"a": a, "b": b, **kwargs})
+        return cast("torch.Tensor", kwargs["out"])
+
+    interface.default_config = default_config  # type: ignore[attr-defined]
+    interface.gemm = gemm  # type: ignore[attr-defined]
+    quack = ModuleType("quack")
+    quack.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "quack", quack)
+    monkeypatch.setitem(sys.modules, "quack.gemm_interface", interface)
+    monkeypatch.setattr(
+        quack_grouped_gemm,
+        "_package_identity",
+        lambda: {"module_version": "test"},
+    )
+
+    prepared = quack_grouped_gemm.prepare_quack_default(
+        cast("Any", inputs),
+        b_layout="n_major",
+    )
+    prepared.call()
+    assert len(calls) == 1
+    assert calls[0]["a"] is inputs.compact_a
+    assert calls[0]["cu_seqlens_m"] is inputs.offsets
+    assert calls[0]["dynamic_scheduler"] is False
+    assert calls[0]["tuned"] is False
+    assert calls[0]["split_k"] == 1
+    assert prepared.config["requested_config"] is None
+    assert prepared.config["b_layout"] == "n_major"
+    assert prepared.config["resolved_dynamic_scheduler"] is True
+
+
+@pytest.mark.parametrize(
+    ("profile_major", "reviewed_layout"), (("k", "k_major"), ("n", "n_major"))
+)
+def test_provider_dispatch_uses_one_default_preparer(
+    monkeypatch: Any,
+    profile_major: str,
+    reviewed_layout: str,
+) -> None:
+    inputs = cast("Any", _Inputs())
+    calls: list[tuple[str, str]] = []
+
+    def layout_preparer(provider: str) -> Any:
+        def prepare(_inputs: object, *, b_layout: str) -> object:
+            calls.append((provider, b_layout))
+            return _prepared(provider, b_layout)
+
+        return prepare
+
+    modules = {
+        "benchmarks.cute.cutlass_contiguous_grouped_gemm": (
+            "prepare_cutlass_default",
+            lambda _inputs, *, cutlass_root: (
+                calls.append(("cutlass", str(cutlass_root)))
+                or _prepared("cutlass", "k_major")
+            ),
+        ),
+        "benchmarks.cute.quack_grouped_gemm": (
+            "prepare_quack_default",
+            layout_preparer("quack"),
+        ),
+        "benchmarks.cute.cudnn_grouped_gemm": (
+            "prepare_cudnn_default",
+            layout_preparer("cudnn"),
+        ),
+        "benchmarks.cute.cublaslt_grouped_gemm": (
+            "prepare_cublaslt_default",
+            layout_preparer("cublaslt"),
+        ),
+    }
+    for module_name, (function_name, function) in modules.items():
+        module = ModuleType(module_name)
+        setattr(module, function_name, function)
+        monkeypatch.setitem(sys.modules, module_name, module)
+
+    for provider in tuple(
+        provider for provider in runner.PROVIDERS if provider != "deepgemm"
+    ):
+        prepared = runner.prepare_provider_default(
+            provider,
+            inputs,
+            cast("Any", SimpleNamespace(b_major=profile_major)),
+            cutlass_root=Path("/tmp/cutlass") if provider == "cutlass" else None,
+            deepgemm_root=None,
+        )
+        assert isinstance(prepared, common.PreparedImplementation)
+        assert prepared.config["physical_b_layout_matches_reviewed"] is (
+            provider != "cutlass" or reviewed_layout == "k_major"
+        )
+    assert calls == [
+        ("quack", reviewed_layout),
+        ("cudnn", reviewed_layout),
+        ("cublaslt", reviewed_layout),
+        ("cutlass", "/tmp/cutlass"),
+    ]
+
+
+def test_deepgemm_uses_final_public_api_without_candidate_search(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    from benchmarks.cute import grouped_gemm_deepgemm_support as support
+
+    inputs = cast("Any", _Inputs())
+    launch = Mock()
+    module = SimpleNamespace(m_grouped_bf16_gemm_nt_contiguous=launch)
+    monkeypatch.setattr(
+        support,
+        "import_deepgemm",
+        lambda root, alignment: (
+            module,
+            {"root": str(root), "m_alignment": alignment},
+        ),
+    )
+    prepared = runner.prepare_provider_default(
+        "deepgemm",
+        inputs,
+        cast("Any", SimpleNamespace(b_major="n")),
+        cutlass_root=None,
+        deepgemm_root=tmp_path,
+    )
+    result = prepared.call()
+    a, b, output, layout = launch.call_args.args
+    assert result is output
+    assert prepared.owners[0] is module
+    assert b is inputs.b
+    launch.assert_called_once_with(
+        a,
+        b,
+        output,
+        layout,
+        compiled_dims="nk",
+        use_psum_layout=False,
+        ensure_zero_padding=False,
+    )
+    assert prepared.config["api"] == {
+        "function": "m_grouped_bf16_gemm_nt_contiguous",
+        "compiled_dims": "nk",
+        "use_psum_layout": False,
+        "ensure_zero_padding": False,
+    }
+    assert prepared.config["a_layout"]["alignment"] == 224
+    assert prepared.config["physical_b_layout_matches_reviewed"] is False


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__ #3447 (`6a16fe28`)
 * #3446 (`68226540`)
 * #3445 (`1c012826`)
 * #3444 (`e9ca9174`)
 * #3443 (`27b2ad77`, base `main`)

--- --- ---

## Summary

- Add a selectable grouped-GEMM campaign for DeepGEMM, QuACK, cuDNN, cuBLASLt, and CUTLASS public/default paths.
- Add reviewed-AOT, compiler-heuristic, and forced live-autotune Helion modes.
- Keep setup and thermal warmup outside timing, then collect balanced cold-L2 samples from pre-captured graphs.
- Run every provider and replicate in a fresh process with isolated caches, rotate and reverse provider order across replicates, and validate all outputs against the same FP32 oracle.
- Scrub performance-changing TF32/cuBLAS controls, verify pinned provider module origins, and record source, device, configuration, timing, and provider metadata.
- Document the exact validated Python, CUDA, compiler, and provider environment required to reproduce the campaign.
- Fail the campaign on correctness failures, source/device mismatches, incomplete result identity, or fixed-config drift.

## Test plan

- `./lint.sh check`
- Focused affected tests under both default and CuTe backends
- The definitive stack collected 3,304 tests. Focused boundary validation completed 376 passes, 84 expected backend-gated skips, and 179 subtests with no failures; Ruff, codespell, and Pyrefly were clean.

## Benchmark results and limits

Performance was measured from the clean definitive five-PR head `6a16fe28` (tree `b11260a4`) on an idle NVIDIA B200. Three fresh-process/fresh-cache DeepGEMM replicates per selection mode produced:

| Helion selection | DeepGEMM/Helion geomean | Rows won (3-replicate geomean) | Worst row geomean |
|---|---:|---:|---:|
| Reviewed AOT | `1.0160×` | 7/8 | `0.9945×` |
| Compiler heuristic | `1.0177×` | 7/8 | `0.9922×` |

All 48 row-replicate comparisons passed correctness, and every selected-config hash exactly matched the prior validated set. Both results clear the predeclared 98%-of-historical-median no-regression gates. Each worker used a 10 s warmup and 102 balanced, rotated/reversed cold-L2 samples. Telemetry showed only the previously observed idle/software-power-cap reason classes; no thermal or hardware slowdown reason appeared.

## Historical five-provider complete-stack benchmark

Earlier one-replicate B200 smoke campaigns from source `2e4f90a5` (tree `c255c018`) covered reviewed-AOT and compiler-heuristic modes across eight BF16 shapes and all five provider paths. All 80 comparisons passed correctness.

Each cell below is `provider_time / Helion_time`; values above `1.0×` mean Helion is faster. `M/group` is nominal; exact ragged per-group `M` values were used internally.

### Reviewed AOT

| Case `(groups × nominal M/group × N × K)` | DeepGEMM | QuACK | cuDNN | cuBLASLt | CUTLASS |
|---|---:|---:|---:|---:|---:|
| 4 × 8192 × 6144 × 7168 | `1.0315×` | `1.0118×` | `1.0148×` | `1.1544×` | `1.2356×` |
| 4 × 8192 × 7168 × 3072 | `0.9926×` | `1.0032×` | `1.0183×` | `1.2015×` | `1.3605×` |
| 4 × 8192 × 4096 × 4096 | `1.0165×` | `0.9922×` | `1.0256×` | `1.0922×` | `1.4075×` |
| 4 × 8192 × 4096 × 2048 | `1.0017×` | `1.0041×` | `1.0192×` | `1.2004×` | `1.3832×` |
| 8 × 4096 × 6144 × 7168 | `1.0277×` | `1.0141×` | `1.0370×` | `1.1517×` | `1.1984×` |
| 8 × 4096 × 7168 × 3072 | `1.0137×` | `0.9984×` | `1.0249×` | `1.1892×` | `1.3604×` |
| 8 × 4096 × 4096 × 4096 | `0.9986×` | `1.0046×` | `1.0433×` | `1.1630×` | `1.3657×` |
| 8 × 4096 × 4096 × 2048 | `1.0165×` | `1.0167×` | `1.0870×` | `1.2704×` | `1.3454×` |
| **Geomean** | **`1.0122×`** | **`1.0056×`** | **`1.0335×`** | **`1.1769×`** | **`1.3302×`** |

### Compiler heuristics

| Case `(groups × nominal M/group × N × K)` | DeepGEMM | QuACK | cuDNN | cuBLASLt | CUTLASS |
|---|---:|---:|---:|---:|---:|
| 4 × 8192 × 6144 × 7168 | `1.0308×` | `1.0102×` | `1.0270×` | `1.1456×` | `1.2321×` |
| 4 × 8192 × 7168 × 3072 | `0.9912×` | `0.9934×` | `1.0211×` | `1.1920×` | `1.4093×` |
| 4 × 8192 × 4096 × 4096 | `1.0175×` | `0.9930×` | `1.0248×` | `1.1496×` | `1.4426×` |
| 4 × 8192 × 4096 × 2048 | `1.0025×` | `1.0026×` | `1.0342×` | `1.2408×` | `1.3849×` |
| 8 × 4096 × 6144 × 7168 | `1.0178×` | `1.0121×` | `1.0350×` | `1.1541×` | `1.1979×` |
| 8 × 4096 × 7168 × 3072 | `1.0125×` | `0.9996×` | `1.0266×` | `1.1859×` | `1.3272×` |
| 8 × 4096 × 4096 × 4096 | `0.9987×` | `1.0095×` | `1.0520×` | `1.1655×` | `1.3990×` |
| 8 × 4096 × 4096 × 2048 | `1.0175×` | `1.0229×` | `1.0869×` | `1.3012×` | `1.2869×` |
| **Geomean** | **`1.0110×`** | **`1.0054×`** | **`1.0383×`** | **`1.1908×`** | **`1.3323×`** |

The historical campaign used one GPU, shared logical B values, the reviewed physical B layout where each provider supports it, fixed shapes, and selected public/default provider paths; it did not exhaust provider candidate spaces. It is retained to show all five provider paths, while the exact-head three-replicate check above covers the final code against DeepGEMM. Neither result supports SOTA, beats-all, or unqualified-fastest claims.
