### PR TITLE
[CI] Avoid redundant dependency cache uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,23 +99,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          restore-cache: true
+          # Pull requests can consume caches published by main/release pushes,
+          # but should not occupy accelerator runners uploading new archives.
+          save-cache: ${{ github.event_name == 'push' }}
 
       - name: Create virtual environment
         run: |
           uv venv --python ${{ matrix.python-version }}
-
-      - name: Get current month
-        id: date
-        run: echo "month=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cache/uv
-            ~/.venv
-          key: ${{ matrix.python-version }}-${{ matrix.runtime-version }}-${{ matrix.pytorch-version }}-${{ matrix.backend }}-${{ hashFiles('.github/workflows/test.yml') }}-${{ steps.date.outputs.month }}
 
       # TPU installs its (pinned) torch via the install-pytorch-for-torchtpu composite
       # action below; every other runtime installs torch here.
@@ -368,6 +359,8 @@ jobs:
         with:
           python-version: "3.12"
           enable-cache: true
+          restore-cache: true
+          save-cache: ${{ github.event_name == 'push' }}
 
       - name: Create virtual environment
         run: |
@@ -377,19 +370,6 @@ jobs:
         run: |
           source .venv/bin/activate
           uv pip install pip
-
-      - name: Get current month
-        id: date
-        run: echo "month=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cache/uv
-            ~/.venv
-          key: notebooks-3.12-cu130-${{ hashFiles('.github/workflows/test.yml') }}-${{ steps.date.outputs.month }}
 
       - name: Install notebook execution tools
         run: |


### PR DESCRIPTION
## Summary

- Remove the redundant explicit `actions/cache` steps from test and notebook jobs.
- Continue restoring the pruned UV cache through `setup-uv`.
- Publish refreshed caches only from `push` workflows (`main` and `release/*`), not from pull-request jobs.

## Motivation

The explicit cache overlaps `setup-uv` but runs its post hook first, before `setup-uv` prunes the UV cache. In [job 96743818348](https://github.com/pytorch/helion/actions/runs/32469977233/job/96743818348), it compressed and uploaded a 3.47 GB archive after the tests had completed. The post step took 58m33s, including an approximately 50-minute stalled upload segment.

The second configured path, `~/.venv`, does not contain the workspace virtual environment, so it provides no benefit. Pull requests can still restore caches published by the target/default branch, while requested package versions continue to be installed normally.

## Validation

- Parsed `.github/workflows/test.yml` and verified both jobs retain cache restore with PR cache saves disabled.
- `pre-commit run --files .github/workflows/test.yml`
- `./lint.sh check`
- `git diff --check`
