### PR TITLE
[CI] Use PyTorch's prebuilt Triton XPU wheel

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -101,9 +101,7 @@
       "container-options": "--group-add 109 --device=/dev/mem --device=/dev/dri -e ZE_AFFINITY_MASK",
       "pytorch-version": "pytorch-2.13",
       "alias": "xpu",
-      "backend": "triton",
-      "triton-repo": "https://github.com/intel/intel-xpu-backend-for-triton.git",
-      "triton-pin": "5fcc14d918045eb2c866336b55229d1253d6d60c"
+      "backend": "triton"
     },
     {
       "runner": "linux.rocm.gpu.ecosystem.mi350.1",


### PR DESCRIPTION
## Summary

Remove the XPU-specific Triton source override and keep the official `triton-xpu==3.7.2` wheel that PyTorch 2.13 already installs.

## Motivation

The current XPU lane downloads the compatible official wheel with PyTorch, immediately uninstalls it, and then spends roughly 5–6 minutes cloning and rebuilding the immediately preceding Triton source commit.

Upstream `triton-xpu` 3.7.2 is exactly one commit newer than the old `5fcc14d9` pin. Its only change makes an unsupported column-major descriptor case fall back instead of asserting.

## Validation

- PR XPU job on the previous combined head retained `triton-xpu==3.7.2`, skipped the source build, and found one healthy XPU device.
- Raw pytest results matched current main exactly: 12 failed, 2120 passed, 1628 skipped, 24 rerun.
- Setup-to-tests improved by 5m45s and total job time improved by 5m04s.
- `python -m json.tool .github/matrix.json`
- `pre-commit run --files .github/matrix.json`
- `./lint.sh check`
- `git diff --check`

The attempted TileIR 13.3 wheel upgrade was removed from this PR after B200 validation found a deterministic new `flex_attention` compilation failure. TileIR remains on its existing source pin.
