### PR TITLE
[compiler] Allow torch.matmul rank broadcasting; add sparse-attention indexer example

### DIFF
--- a/examples/sparse_attn_indexer.py
+++ b/examples/sparse_attn_indexer.py
@@ -1,0 +1,164 @@
+"""
+Sparse Attention Indexer Logits
+===============================
+
+The scoring step of the sparse-attention indexer used by DeepSeek V3.2 / V4,
+GLM-5.2 and MiniMax M3: a small multi-query attention whose scores decide which
+KV positions the real attention reads.
+
+    logits[m, n] = sum_h relu(q[m, h, :] @ k[n, :]) * weights[m, h]
+
+for ``H`` index heads of width ``D``, masked to the row's window ``[ks[m], ke[m])``.
+``einsum("mhd,nd->hmn")`` would materialise an ``[H, M, N]`` tensor; both kernels
+accumulate over heads inside the tile instead.
+
+``mqa_logits`` runs one matmul per head, with the key tile hoisted out of the head
+loop. ``mqa_logits_decode`` folds the heads into one batched matmul, which is
+faster when there are few query rows -- on an A800 the two cross at 32 rows.
+"""
+
+# %%
+from __future__ import annotations
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import run_example
+import helion.language as hl
+
+
+# %%
+@helion.kernel(static_shapes=True)
+def mqa_logits(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+) -> torch.Tensor:
+    """Indexer logits, one matmul per index head.
+
+    Args:
+        q: Index queries, ``[M, H, D]``
+        k: Shared index keys, ``[N, D]``
+        weights: Per-(row, head) score weights, ``[M, H]`` float32
+        ks: Inclusive window start per query row, ``[M]``
+        ke: Exclusive window end per query row, ``[M]``
+
+    Returns:
+        ``[M, N]`` float32 logits, ``-inf`` outside each row's window.
+    """
+    m_dim, h_dim, d_dim = q.size()
+    n_dim = k.size(0)
+    h_dim = hl.specialize(h_dim)
+    d_dim = hl.specialize(d_dim)
+    out = torch.empty([m_dim, n_dim], dtype=torch.float32, device=q.device)
+    for tile_m, tile_n in hl.tile([m_dim, n_dim]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        kt = k[tile_n, :]
+        for h in hl.grid(h_dim):
+            score = torch.matmul(q[tile_m, h, :], kt.transpose(0, 1)).to(torch.float32)
+            acc = acc + torch.relu(score) * weights[tile_m, h][:, None]
+        in_window = (tile_n.index[None, :] >= ks[tile_m][:, None]) & (
+            tile_n.index[None, :] < ke[tile_m][:, None]
+        )
+        out[tile_m, tile_n] = torch.where(in_window, acc, float("-inf"))
+    return out
+
+
+# %%
+@helion.kernel(static_shapes=True)
+def mqa_logits_decode(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+) -> torch.Tensor:
+    """Indexer logits with the head axis folded into one batched matmul.
+
+    Same arguments and result as :func:`mqa_logits`. Prefer this one when there
+    are few query rows; see the module docstring.
+    """
+    m_dim, h_dim, d_dim = q.size()
+    n_dim = k.size(0)
+    h_dim = hl.specialize(h_dim)
+    d_dim = hl.specialize(d_dim)
+    out = torch.empty([m_dim, n_dim], dtype=torch.float32, device=q.device)
+    for tile_m, tile_n in hl.tile([m_dim, n_dim]):
+        kt = k[tile_n, :].transpose(0, 1)
+        # [tile_m, H, D] @ [D, tile_n] -> [tile_m, H, tile_n]
+        score = torch.matmul(q[tile_m, :, :], kt).to(torch.float32)
+        acc = (torch.relu(score) * weights[tile_m, :][:, :, None]).sum(dim=1)
+        in_window = (tile_n.index[None, :] >= ks[tile_m][:, None]) & (
+            tile_n.index[None, :] < ke[tile_m][:, None]
+        )
+        out[tile_m, tile_n] = torch.where(in_window, acc, float("-inf"))
+    return out
+
+
+# %%
+def ref_mqa_logits(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+) -> torch.Tensor:
+    """PyTorch reference. The einsum runs in the input dtype so that it and the
+    kernels differ by the schedule alone, not by accumulation width."""
+    pos = torch.arange(0, k.size(0), device=q.device)
+    in_window = (pos[None, :] >= ks[:, None]) & (pos[None, :] < ke[:, None])
+    score = torch.einsum("mhd,nd->hmn", q, k).float()
+    logits = (score.relu() * weights.unsqueeze(-1).transpose(0, 1)).sum(dim=0)
+    return logits.masked_fill(~in_window, float("-inf"))
+
+
+# %%
+def indexer_inputs(
+    num_tokens: int,
+    kv_len: int,
+    num_heads: int = 32,
+    head_dim: int = 128,
+) -> tuple[torch.Tensor, ...]:
+    """DeepSeek V3.2 indexer geometry by default (H=32, D=128)."""
+    q = torch.randn(
+        num_tokens, num_heads, head_dim, device=DEVICE, dtype=torch.bfloat16
+    )
+    k = torch.randn(kv_len, head_dim, device=DEVICE, dtype=torch.bfloat16)
+    weights = torch.randn(num_tokens, num_heads, device=DEVICE, dtype=torch.float32)
+    ks = torch.zeros(num_tokens, dtype=torch.int32, device=DEVICE)
+    ke = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE) + (
+        kv_len - num_tokens
+    )
+    return q, k, weights, ks, ke
+
+
+# %%
+def check(num_tokens: int, kv_len: int) -> None:
+    args = indexer_inputs(num_tokens, kv_len)
+    run_example(
+        {"helion": mqa_logits, "helion_decode": mqa_logits_decode},
+        {
+            "torch": ref_mqa_logits,
+            "torch_compile": torch.compile(ref_mqa_logits, dynamic=False),
+        },
+        args,
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+
+# %%
+def main() -> None:
+    # decode: few query rows against a long KV window
+    check(1, 4096)
+    check(8, 16384)
+    # prefill: the whole sequence scored at once
+    check(512, 4096)
+    check(4096, 8192)
+
+
+if __name__ == "__main__":
+    main()

--- a/helion/_compiler/matmul_utils.py
+++ b/helion/_compiler/matmul_utils.py
@@ -25,9 +25,16 @@ def torch_matmul_replacement(
             "torch.matmul(..., out=...) is not supported in Helion kernel"
         )
     if a.dim() != b.dim():
-        raise NotImplementedError(
-            "torch.matmul with different input tensor dims is not supported in Helion kernel"
-        )
+        # torch.matmul broadcasts a 2-D operand against a 3-D one; expand the
+        # smaller side so the batched path below sees matching ranks.
+        if a.dim() == 3 and b.dim() == 2:
+            b = b.unsqueeze(0).expand(a.size(0), -1, -1)
+        elif a.dim() == 2 and b.dim() == 3:
+            a = a.unsqueeze(0).expand(b.size(0), -1, -1)
+        else:
+            raise NotImplementedError(
+                "torch.matmul with different input tensor dims is not supported in Helion kernel"
+            )
     if a.dim() == 2 and b.dim() == 2:
         return original_matmul(a, b)
     if a.dim() == 3 and b.dim() == 3:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1045,6 +1045,28 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[1, 64, 32],
         )
 
+    def test_sparse_attn_indexer(self):
+        mod = import_path(EXAMPLES_DIR / "sparse_attn_indexer.py")
+        args = mod.indexer_inputs(num_tokens=128, kv_len=512)
+        check_example(
+            "sparse_attn_indexer",
+            args,
+            mod.ref_mqa_logits(*args),
+            fn_name="mqa_logits",
+            block_sizes=[16, 128],
+        )
+
+    def test_sparse_attn_indexer_decode(self):
+        mod = import_path(EXAMPLES_DIR / "sparse_attn_indexer.py")
+        args = mod.indexer_inputs(num_tokens=1, kv_len=512)
+        check_example(
+            "sparse_attn_indexer",
+            args,
+            mod.ref_mqa_logits(*args),
+            fn_name="mqa_logits_decode",
+            block_sizes=[1, 128],
+        )
+
     def test_xsa(self):
         args = (
             torch.randn(2, 32, 1024, 64, dtype=HALF_DTYPE, device=DEVICE),

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -539,6 +539,49 @@ class TestMatmul(RefEagerTestBase, TestCase):
         expected = (x.float() @ weight.T).to(x.dtype)
         torch.testing.assert_close(result, expected, atol=1e-1, rtol=1e-2)
 
+    def test_matmul_3d_2d_broadcast(self):
+        """torch.matmul broadcasts a 2-D rhs across a 3-D lhs's batch."""
+
+        @helion.kernel(static_shapes=True)
+        def bmm_3d_2d(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            bsz, m, _ = a.size()
+            n = b.size(1)
+            out = torch.empty([bsz, m, n], dtype=torch.float32, device=a.device)
+            for tile_b, tile_m, tile_n in hl.tile([bsz, m, n]):
+                out[tile_b, tile_m, tile_n] = torch.matmul(
+                    a[tile_b, tile_m, :], b[:, tile_n]
+                ).to(torch.float32)
+            return out
+
+        a = torch.randn(4, 64, 32, device=DEVICE, dtype=torch.bfloat16)
+        b = torch.randn(32, 48, device=DEVICE, dtype=torch.bfloat16)
+        # batch tile of 2: the 2-D operand is broadcast across a tile, not a row.
+        _code, result = code_and_output(bmm_3d_2d, (a, b), block_sizes=[2, 32, 16])
+        torch.testing.assert_close(
+            result, torch.matmul(a.float(), b.float()), rtol=1e-2, atol=1e-2
+        )
+
+    def test_matmul_2d_3d_broadcast(self):
+        """torch.matmul broadcasts a 2-D lhs across a 3-D rhs's batch."""
+
+        @helion.kernel(static_shapes=True)
+        def bmm_2d_3d(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            m, _ = a.size()
+            bsz, _, n = b.size()
+            out = torch.empty([bsz, m, n], dtype=torch.float32, device=a.device)
+            for tile_b, tile_m, tile_n in hl.tile([bsz, m, n]):
+                out[tile_b, tile_m, tile_n] = torch.matmul(
+                    a[tile_m, :], b[tile_b, :, tile_n]
+                ).to(torch.float32)
+            return out
+
+        a = torch.randn(64, 32, device=DEVICE, dtype=torch.bfloat16)
+        b = torch.randn(4, 32, 48, device=DEVICE, dtype=torch.bfloat16)
+        _code, result = code_and_output(bmm_2d_3d, (a, b), block_sizes=[2, 32, 16])
+        torch.testing.assert_close(
+            result, torch.matmul(a.float(), b.float()), rtol=1e-2, atol=1e-2
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Purpose

Add the sparse-attention indexer scoring kernel as an example. Its decode form needs `torch.matmul` to broadcast a 2-D operand against a 3-D one, which Helion rejects today.

## What changed

1. `matmul_utils.py`: expand the lower-rank operand when ranks differ, then use the existing `bmm` path. Covers `[B,M,K] @ [K,N]` and `[M,K] @ [B,K,N]`.
2. `examples/sparse_attn_indexer.py`: `logits[m,n] = sum_h relu(q[m,h,:] @ k[n,:]) * weights[m,h]`, masked per row. `mqa_logits` matmuls per head, `mqa_logits_decode` batches them.
3. Tests for both broadcast directions and both kernels.

## Test Plan

```
pytest test/test_matmul.py test/test_examples.py -k "broadcast or sparse_attn_indexer"
python -m examples.sparse_attn_indexer
pytest -q --ignore=test/test_examples_dist.py --ignore=test/test_pallas.py \
       --ignore=test/test_remote_copy.py --ignore=test/test_distributed.py
```

## Test Result

A800 (sm80), torch 2.15.0.dev20260820+cu130, triton 3.8.0, H=32 D=128 bf16, one cold autotune per
shape at effort `full`. A second independent draw moved the Helion numbers by up to 17%.

| M | N | torch | torch.compile | `mqa_logits` | `mqa_logits_decode` |
|---|---|---|---|---|---|
| 1 | 4096 | 134.1 us | 12.3 us | 16.4 us (+33.3%) | **7.2 us (-41.5%)** |
| 8 | 16384 | 143.4 us | 38.9 us | 24.6 us (-36.8%) | **23.6 us (-39.3%)** |
| 32 | 16384 | 416.8 us | 87.0 us | **42.0 us (-51.7%)** | 53.2 us (-38.9%) |
| 512 | 4096 | 1437.7 us | 288.8 us | **106.5 us (-63.1%)** | 192.5 us (-33.3%) |
| 2048 | 4096 | 5652.5 us | 1172.5 us | **379.9 us (-67.6%)** | 624.6 us (-46.7%) |
| 4096 | 8192 | 22593.0 us | 4650.0 us | **1457.2 us (-68.7%)** | 2725.9 us (-41.4%) |

M=512 N=1024, one call:

| | kernels | peak extra alloc |
|---|---|---|
| torch | 13 | 201,859,072 B |
| torch.compile | 3 | 37,748,736 B |
| Helion, either | 1 | 2,097,152 B (the output) |

Max `1 - cos_sim` vs the reference over those shapes, `-inf` positions identical:
`mqa_logits` 5.0e-15, `mqa_logits_decode` 3.1e-15, `torch.compile` 3.3e-15.

Full suite: 6 failed, 2292 passed, 1125 skipped; the same 6 on `main` (4 `tcgen05`, 2 Pallas).
ruff clean; pyrefly adds no errors.
