### PR TITLE
Treat tunable parameters as constexpr

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -332,6 +332,8 @@ class CompileEnvironment:
         self.kernel_min_element_bits: int = 32  # smallest dtype bits across all tensors
         self.specialized_vars: set[sympy.Symbol] = set()
         self.specialized_strides: set[TensorPropertySource] = set()
+        # Config-backed values created by hl.register_tunable().
+        self.tunable_symbols: set[sympy.Symbol] = set()
         self.tensor_descriptor_layout_guards: dict[
             Source, TensorDescriptorLayoutGuard
         ] = {}

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -264,7 +264,7 @@ class DeviceFunction:
         self._tensor_descriptor_args: dict[
             tuple[torch.Tensor, str], TensorDescriptorArg
         ] = {}
-        self._expr_args: dict[sympy.Expr, SymbolArgument] = {}
+        self._expr_args: dict[sympy.Expr, NumericArgument] = {}
         self._constexpr_args: dict[str, ConstExprArg] = {}
         self._constexpr_host_defs: set[str] = set()
         self._scratch_args: list[ScratchArg] = []
@@ -779,9 +779,16 @@ class DeviceFunction:
             self._tensor_descriptor_args[key] = arg
         return self._tensor_descriptor_args[key]
 
-    def expr_arg(self, sym: sympy.Expr, origin: Origin) -> SymbolArgument:
+    def expr_arg(self, sym: sympy.Expr, origin: Origin) -> NumericArgument:
         if sym not in self._expr_args:
-            arg = SymbolArgument(
+            tunable_symbols = CompileEnvironment.current().tunable_symbols
+            # A tunable-only expression is constant for each compiled config.
+            arg_type = (
+                ConstExprArg
+                if sym.free_symbols and sym.free_symbols <= tunable_symbols
+                else SymbolArgument
+            )
+            arg = arg_type(
                 name=self.new_var(origin.suggest_var_name()),
                 _host_str=origin.host_str(),
             )

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -785,7 +785,7 @@ class DeviceFunction:
             # A tunable-only expression is constant for each compiled config.
             arg_type = (
                 ConstExprArg
-                if sym.free_symbols and sym.free_symbols <= tunable_symbols
+                if sym.free_symbols and sym.free_symbols.issubset(tunable_symbols)
                 else SymbolArgument
             )
             arg = arg_type(

--- a/helion/language/tunable_ops.py
+++ b/helion/language/tunable_ops.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import sympy
 import torch
 from torch._inductor.codegen.simd import constant_repr
 from torch._inductor.runtime.runtime_utils import next_power_of_2
@@ -178,7 +179,12 @@ def _register_tunable_type(
     python_type = type(fragment_val.default())
     if not issubclass(python_type, (int, float, bool)):
         raise exc.TunableTypeNotSupported(python_type)
-    return NumericType.subtype(python_type).new_unbacked(origin)
+    result = NumericType.subtype(python_type).new_unbacked(origin)
+    # Codegen uses this provenance to annotate device arguments as constexpr.
+    for symbol in result.value._sympy_().free_symbols:
+        assert isinstance(symbol, sympy.Symbol)
+        env.tunable_symbols.add(symbol)
+    return result
 
 
 @_decorators.codegen(register_tunable, "common")

--- a/test/test_register_tunable.py
+++ b/test/test_register_tunable.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import unittest
 from unittest.mock import patch
 
@@ -13,7 +14,9 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfRefEager
 from helion._testing import skipIfSharedMemoryLessThan
+from helion.autotuner import BooleanFragment
 from helion.autotuner import EnumFragment
 from helion.autotuner import IntegerFragment
 from helion.autotuner import PowerOfTwoFragment
@@ -92,6 +95,40 @@ class TestRegisterTunable(RefEagerTestBase, TestCase):
         result = kernel_with_enum(x)
         expected = x * 2.0
         torch.testing.assert_close(result, expected)
+
+    @skipIfRefEager("to_triton_code is not supported in ref eager mode")
+    def test_tunable_device_arguments_are_constexpr(self):
+        """Config-backed tunables must be compile-time device arguments."""
+
+        @helion.kernel(static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            (n,) = x.size()
+            out = torch.empty_like(x)
+            multiplier = hl.register_tunable("multiplier", IntegerFragment(1, 8, 2))
+            use_add = hl.register_tunable("use_add", BooleanFragment())
+
+            for tile in hl.tile(n):
+                if use_add:
+                    out[tile] = x[tile] + multiplier
+                else:
+                    out[tile] = x[tile] * multiplier
+            return out
+
+        x = torch.randn(128, device=DEVICE)
+        bound = fn.bind((x,))
+
+        for use_add in (False, True):
+            config = helion.Config(block_sizes=[64], multiplier=3, use_add=use_add)
+            code = bound.to_triton_code(config)
+            signature = re.search(r"^def _helion_fn\((.*)\):$", code, re.MULTILINE)
+            assert signature is not None
+            constexpr_type = bound.env.backend.constexpr_type
+            self.assertIn(f"multiplier: {constexpr_type}", signature.group(1))
+            self.assertIn(f"use_add: {constexpr_type}", signature.group(1))
+
+            result = bound.compile_config(config)(x)
+            expected = x + 3 if use_add else x * 3
+            torch.testing.assert_close(result, expected)
 
     def test_tensor_allocated_with_block_size(self):
         @helion.kernel()


### PR DESCRIPTION
## Summary

- track the symbolic values created by `hl.register_tunable()`
- emit device arguments derived only from tunables as backend constexpr arguments
- add regression coverage for integer and boolean tunables on Triton and CuTe

Closes #3451.

## Benchmark

Benchmark script: https://gist.github.com/yushangdi/537418e2b89c5728f9db6ff6fbabe8dd

Measured on an NVIDIA B200 using the benchmark path from `pretuned_kernels/_bench.py`: CUDA graph replay with the L2 cache cleared before every replay. The benchmark matches the issue's control flow by placing the `swap_ab` branch around the two `tl.dot` alternatives inside the K loop. Results use FP16, block sizes `[32, 128, 64]`, 4 warps, 4 stages, a 3-second thermal warmup, `rep=100`, and three alternating-order rounds.

| M x K x N | swap_ab | Runtime flag | `tl.constexpr` | Speedup |
|---|---:|---:|---:|---:|
| 32 x 256 x 128 | false | 9.534 us | 4.497 us | 2.120x |
| 32 x 256 x 128 | true | 9.504 us | 4.582 us | 2.074x |
| 256 x 4096 x 4096 | false | 136.597 us | 41.745 us | 3.272x |
| 256 x 4096 x 4096 | true | 136.791 us | 41.981 us | 3.258x |
| 1024 x 4096 x 4096 | false | 342.840 us | 72.482 us | 4.730x |
| 1024 x 4096 x 4096 | true | 344.090 us | 72.083 us | 4.774x |

The same sweep with block sizes `[32, 64, 64]` measured 2.00x-3.10x speedups.

## Test plan

- `pytest test/test_register_tunable.py test/test_constexpr.py -x -vv -s` (19 passed)
- `HELION_BACKEND=cute pytest test/test_register_tunable.py -x -vv -s` (6 passed)
- Ruff format and lint checks on all changed files
