### PR TITLE
Optimize tcgen05 AB consumer waits

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -82,6 +82,7 @@ from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_PHASE1
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODE_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODE_DIRECT
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODE_SKIP
 from .tcgen05_constants import TCGEN05_AB_INITIAL_PRODUCER_ACQUIRE_MODE_CONFIG_KEY
@@ -4251,6 +4252,7 @@ class _PerKiterTmaArgs:
     exec_active: str
     scalar_load_a: ast.stmt
     scalar_load_b: ast.stmt
+    direct_consumer_wait: bool = False
     # ``cluster_n`` is only consulted when ``is_two_cta=True`` to pick the
     # V-leader vs cluster-leader form for the AB consumer-release predicate
     # (cute_plan.md §6.12.7). Default 1 preserves byte-identity for the
@@ -4429,6 +4431,8 @@ def _build_kloop_pipeline_consumer_if(
         )
     if args.skip_consumer_wait:
         consumer_src = "pass"
+    elif args.direct_consumer_wait:
+        consumer_src = f"{args.tma_pipeline}.consumer_wait({args.tma_consumer_state})"
     else:
         consumer_src = ""
         if not use_existing_try_token:
@@ -4478,6 +4482,7 @@ def _build_kloop_pipeline_consumer_prefetch_stmts(
 ) -> list[ast.stmt]:
     """Peek the next AB full barrier after advancing the consumer state."""
     assert args.is_two_cta, "AB consumer prefetch is validated for CtaGroup.TWO"
+    assert not args.direct_consumer_wait, "direct AB waits do not prefetch a token"
     predicate = args.tma_next_consumer_tile
     owner_predicate = _tcgen05_two_cta_owner_predicate(
         args.exec_active,
@@ -6650,6 +6655,9 @@ def _emit_mma_pipeline(
         TCGEN05_AB_CONSUMER_WAIT_MODE_CONFIG_KEY,
         TCGEN05_AB_CONSUMER_WAIT_MODE_NORMAL,
     )
+    tcgen05_use_direct_ab_consumer_wait = (
+        tcgen05_ab_consumer_wait_mode == TCGEN05_AB_CONSUMER_WAIT_MODE_DIRECT
+    )
     diagnose_skip_ab_consumer_wait = (
         tcgen05_ab_consumer_wait_mode == TCGEN05_AB_CONSUMER_WAIT_MODE_SKIP
     )
@@ -6677,13 +6685,25 @@ def _emit_mma_pipeline(
             f"{TCGEN05_AB_CONSUMER_PHASE_MODE_PHASE1!r} requires the guarded "
             "cluster_m=2, CtaGroup.ONE, 128x256x128 bridge shape",
         )
-    # Static-full CtaGroup.TWO keeps a prefetched AB consumer token live
-    # across the accumulator acquire and each K-loop issue. CtaGroup.ONE
-    # keeps the older adjacent try-wait/wait sequence.
-    tcgen05_use_role_local_ab_consumer_prefetch = (
+    # Static-full CtaGroup.TWO normally keeps a prefetched AB consumer token
+    # live across the accumulator acquire and each K-loop issue. The direct
+    # mode avoids that speculative poll and waits on the current stage only.
+    tcgen05_role_local_ab_consumer_wait = (
         tcgen05_use_role_local_mma_exec
         and tcgen05_is_two_cta
         and tcgen05_use_tma_pipeline
+    )
+    if tcgen05_use_direct_ab_consumer_wait and not (
+        tcgen05_role_local_ab_consumer_wait and tcgen05_static_full_tma_fast_path
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            f"{TCGEN05_AB_CONSUMER_WAIT_MODE_CONFIG_KEY}="
+            f"{TCGEN05_AB_CONSUMER_WAIT_MODE_DIRECT!r} requires the role-local "
+            "static-full CtaGroup.TWO TMA path",
+        )
+    tcgen05_use_role_local_ab_consumer_prefetch = (
+        tcgen05_role_local_ab_consumer_wait and not tcgen05_use_direct_ab_consumer_wait
     )
     # Keep a distinct name so future epi-role gating changes are localized.
     tcgen05_use_role_local_epi = (
@@ -10565,6 +10585,7 @@ def _emit_mma_pipeline(
                 skip_producer_acquire=diagnose_skip_ab_producer_acquire,
                 skip_producer_advance=diagnose_skip_ab_producer_advance,
                 skip_consumer_wait=diagnose_skip_ab_consumer_wait,
+                direct_consumer_wait=tcgen05_use_direct_ab_consumer_wait,
                 exec_active=tcgen05_plan.exec_active,
                 scalar_load_a=scalar_load_a,
                 scalar_load_b=scalar_load_b,
@@ -10698,7 +10719,7 @@ def _emit_mma_pipeline(
                                 )
                             )
                         )
-                    else:
+                    elif not tcgen05_use_direct_ab_consumer_wait:
                         exec_loop_body.append(
                             statement_from_string(
                                 f"{tma_consumer_try_token} = cutlass.Boolean(0)"

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -47,6 +47,7 @@ from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODES
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODE_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODE_DIRECT
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODES
 from .tcgen05_constants import TCGEN05_AB_INITIAL_PRODUCER_ACQUIRE_MODE_CONFIG_KEY
@@ -2843,7 +2844,16 @@ class CuteTcgen05Config:
             ),
         ):
             self._validate_diagnostic_mode(
-                config, key, modes, normal_mode, fix_invalid=fix_invalid
+                config,
+                key,
+                modes,
+                normal_mode,
+                safe_non_normal_modes=(
+                    (TCGEN05_AB_CONSUMER_WAIT_MODE_DIRECT,)
+                    if key == TCGEN05_AB_CONSUMER_WAIT_MODE_CONFIG_KEY
+                    else ()
+                ),
+                fix_invalid=fix_invalid,
             )
 
         self._validate_bool_config(
@@ -2998,6 +3008,7 @@ class CuteTcgen05Config:
         modes: tuple[str, ...],
         normal_mode: str,
         *,
+        safe_non_normal_modes: tuple[str, ...] = (),
         fix_invalid: bool,
     ) -> None:
         if key not in config:
@@ -3015,7 +3026,7 @@ class CuteTcgen05Config:
                 return
             raise InvalidConfig(f"{key} must be one of {modes!r}, got {config[key]!r}")
         if (
-            config[key] != normal_mode
+            config[key] not in (normal_mode, *safe_non_normal_modes)
             and config.get(TCGEN05_DIAGNOSTIC_INVALID_OUTPUT_CONFIG_KEY) is not True
         ):
             if fix_invalid:

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -367,11 +367,17 @@ TCGEN05_AB_PRODUCER_ADVANCE_MODES = (
 )
 TCGEN05_AB_CONSUMER_WAIT_MODE_CONFIG_KEY = "tcgen05_ab_consumer_wait_mode"
 TCGEN05_AB_CONSUMER_WAIT_MODE_NORMAL = "normal"
+# Wait directly on the current AB stage instead of issuing a speculative
+# ``consumer_try_wait`` and carrying its token across the MMA loop. This is a
+# correctness-preserving codegen choice for the role-local static-full
+# CtaGroup.TWO path.
+TCGEN05_AB_CONSUMER_WAIT_MODE_DIRECT = "direct"
 # Invalid-output diagnostic for the guarded clustered CtaGroup.ONE bridge:
 # removes only AB consumer try-wait/wait edges.
 TCGEN05_AB_CONSUMER_WAIT_MODE_SKIP = "skip"
 TCGEN05_AB_CONSUMER_WAIT_MODES = (
     TCGEN05_AB_CONSUMER_WAIT_MODE_NORMAL,
+    TCGEN05_AB_CONSUMER_WAIT_MODE_DIRECT,
     TCGEN05_AB_CONSUMER_WAIT_MODE_SKIP,
 )
 TCGEN05_AB_CONSUMER_PHASE_MODE_CONFIG_KEY = "tcgen05_ab_consumer_phase_mode"

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -169,6 +169,7 @@ _M64_SWAP_CONFIGS = {
         "tcgen05_static_work_grid_clusters": 32,
         "tcgen05_static_work_iterations": 3,
         "tcgen05_launch_warps": 7,
+        "tcgen05_ab_consumer_wait_mode": "direct",
         "tcgen05_aux_load_placement": "subtile_pre_acc_wait",
     },
     (64, 5120, 51200): {

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -124,6 +124,7 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_AB_CONSUMER_WAIT_MODE_CONFIG_KEY,
 )
+from helion._compiler.cute.tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODE_DIRECT
 from helion._compiler.cute.tcgen05_constants import TCGEN05_AB_CONSUMER_WAIT_MODE_SKIP
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_AB_INITIAL_PRODUCER_ACQUIRE_MODE_CONFIG_KEY,
@@ -10071,6 +10072,14 @@ class TestCuteLowerings(unittest.TestCase):
                     ),
                 }
             )
+
+        config_spec.normalize(
+            {
+                TCGEN05_AB_CONSUMER_WAIT_MODE_CONFIG_KEY: (
+                    TCGEN05_AB_CONSUMER_WAIT_MODE_DIRECT
+                ),
+            }
+        )
 
     def test_tcgen05_ab_consumer_phase_mode_config_validation(self) -> None:
         """Invalid-output AB phase diagnostic is rejected unless opted in."""
@@ -21563,6 +21572,7 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
         use_tma_a: bool = True,
         use_tma_b: bool = True,
         static_full_tiles: bool = False,
+        direct_consumer_wait: bool = False,
     ) -> _PerKiterTmaArgs:
         if use_tma_b_mcast_mask is None:
             use_tma_b_mcast_mask = cluster_m > 1 or is_two_cta
@@ -21597,6 +21607,7 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
             exec_active="exec_active",
             scalar_load_a=self._scalar_load_a(),
             scalar_load_b=self._scalar_load_b(),
+            direct_consumer_wait=direct_consumer_wait,
             static_full_tiles=static_full_tiles,
         )
 
@@ -21833,6 +21844,18 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
             "ab_pipeline.consumer_wait(ab_consumer_state, ab_consumer_try_token)",
             body_src,
         )
+
+    def test_pipeline_consumer_if_can_wait_without_try_token(self) -> None:
+        args = self._make_args(direct_consumer_wait=True)
+        node = _build_kloop_pipeline_consumer_if(
+            args,
+            gate_exec_warp=False,
+            include_scalar_fallback=False,
+        )
+
+        body_src = ast.unparse(ast.Module(body=node.body, type_ignores=[]))
+        self.assertNotIn("consumer_try_wait", body_src)
+        self.assertIn("ab_pipeline.consumer_wait(ab_consumer_state)", body_src)
 
     def test_pipeline_consumer_prefetch_two_cta_gates_try_wait_to_leader(
         self,

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -588,6 +588,7 @@ class TestPretunedCuteCodegen(TestCase):
                     "tcgen05_static_work_grid_clusters",
                     "tcgen05_static_work_iterations",
                     "tcgen05_launch_warps",
+                    "tcgen05_ab_consumer_wait_mode",
                 )
             },
             {
@@ -595,6 +596,7 @@ class TestPretunedCuteCodegen(TestCase):
                 "tcgen05_static_work_grid_clusters": 32,
                 "tcgen05_static_work_iterations": 3,
                 "tcgen05_launch_warps": 7,
+                "tcgen05_ab_consumer_wait_mode": "direct",
             },
         )
         fallback_index = heuristic._select(
@@ -640,6 +642,10 @@ class TestPretunedCuteCodegen(TestCase):
         self.assertIn("(4, 32, 1)", code)
         self.assertIn("block=(32, 7, 1)", code)
         self.assertNotIn("StaticPersistentTileScheduler", code)
+        self.assertNotIn("tcgen05_ab_pipeline.consumer_try_wait", code)
+        self.assertIn(
+            "tcgen05_ab_pipeline.consumer_wait(tcgen05_ab_consumer_state)", code
+        )
         aux_load = code.index("tcgen05_aux_loaded_0 = tcgen05_aux_rmem_0.load()")
         acc_wait = code.index(
             "tcgen05_acc_pipeline.consumer_wait(tcgen05_acc_consumer_state)"
@@ -675,6 +681,7 @@ class TestPretunedCuteCodegen(TestCase):
             tcgen05_static_work_grid_clusters=1,
             tcgen05_static_work_iterations=2,
             tcgen05_launch_warps=7,
+            tcgen05_ab_consumer_wait_mode="direct",
             tcgen05_aux_load_placement="subtile_pre_acc_wait",
         )
         bound = module.scale_mm_cute_swap_ab.bind(swap_args)


### PR DESCRIPTION
Stacked PRs:
 * __->__#3454
 * #3453


--- --- ---

### Optimize tcgen05 AB consumer waits


IKET profiling of the four-CTA M64 K4096 N24576 kernel showed that speculative consumer_try_wait bookkeeping consumed the MMA loop's unattributed time without shortening the tensor-core critical path. Waiting directly on the current AB stage moved the dependency latency into consumer_wait and removed the redundant token setup.

Add an opt-in direct AB consumer wait mode, gate it to the role-local static-full CtaGroup.TWO path, and select it for the exact pretuned shape. Codegen also drops the now-dead next-consumer-tile predicate.

B200 cold-L2 CUDA-graph benchmark, 15 paired rounds (median):

Old compiler: 24.3743 us

New compiler: 23.9970 us (1.0157x)

CUTLASS: 24.4248 us (1.0178x)