### PR TITLE
[CI] Fail test jobs when pytest fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,7 +265,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          set -o pipefail
+          set -e -o pipefail
           source .venv/bin/activate
           uv pip install pytest-xdist
           uv pip install pytest-rerunfailures


### PR DESCRIPTION
## Summary

- enable Bash `errexit` in the main test step
- preserve the existing `pipefail` behavior for the pytest-to-tee pipeline
- ensure a nonzero pytest exit marks the GitHub Actions job as failed

## Context

The workflow uses the custom shell `bash -l {0}`, so it does not receive GitHub Actions' usual implicit `-e`. Although the test script enabled `pipefail`, it continued after a failed pytest pipeline. The trailing conditional blocks then returned zero and caused the step to be marked successful.

This happened in the B200 CuTe check for #3410: the log ended with `6 failed`, including the grouped-GEMM correctness regression tracked in #3216, while the check itself was reported as successful.

## Testing

- verified the previous shell sequence returns status 0 after a failed pipeline
- verified `set -e -o pipefail` returns status 1 immediately
- parsed `.github/workflows/test.yml` successfully with PyYAML