### PR TITLE
[cute] Fix NM grouped D-TMA store orientation

### DIFF
--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -1799,6 +1799,17 @@ def _codegen_cute_store_tcgen05_tile(
         if compact_fragment_epilogue is not None
         else tcgen05_source_bn
     )
+    # NM grouped stores expose transposed logical source dimensions, while the
+    # wrapper already applies the NM orientation when constructing the D
+    # TensorMap. Keep the descriptor and device local tile in the physical MMA
+    # orientation; MN compact-fragment stores still use their proven
+    # destination shape.
+    tcgen05_tma_store_bm = (
+        tcgen05_value.bm if tcgen05_nm_store else tcgen05_destination_bm
+    )
+    tcgen05_tma_store_bn = (
+        tcgen05_value.bn if tcgen05_nm_store else tcgen05_destination_bn
+    )
     tile_coord_n = f"({n_index}) // cutlass.Int32({tcgen05_destination_bn})"
     static_tile_coord_m = tile_coord_m
     static_tile_coord_n = tile_coord_n
@@ -3330,8 +3341,8 @@ def _codegen_cute_store_tcgen05_tile(
         d_tma_plan: dict[str, object] = {
             "kind": "tcgen05_d_tma",
             "d_name": tensor_name,
-            "bm": tcgen05_destination_bm,
-            "bn": tcgen05_destination_bn,
+            "bm": tcgen05_tma_store_bm,
+            "bn": tcgen05_tma_store_bn,
             "c_stage_count": tcgen05_value.c_stage_count,
             "output_dtype": target_dtype,
             "kernel_args": [
@@ -3538,8 +3549,8 @@ def _codegen_cute_store_tcgen05_tile(
     ) -> tuple[list[str], list[str]]:
         if rank3_mnl_tensor is None:
             rank3_mnl_tensor = d_tma_uses_rank3_mnl_tensor
-        store_bm = tcgen05_destination_bm if tma_store else tcgen05_bm
-        store_bn = tcgen05_destination_bn if tma_store else tcgen05_bn
+        store_bm = tcgen05_tma_store_bm if tma_store else tcgen05_bm
+        store_bn = tcgen05_tma_store_bn if tma_store else tcgen05_bn
         epi_tile_expr = tcgen05_store_epi_tile_expr
         static_setup = [
             (

--- a/test/test_cute_deepgemm_selected.py
+++ b/test/test_cute_deepgemm_selected.py
@@ -240,6 +240,7 @@ def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
     assert "(256, 256)" in code
     assert "cute.local_tile(tma_tensor_a, (256, 128)" in code
     assert "cute.local_tile(tma_tensor_b, (256, 128)" in code
+    assert "cute.local_tile(tcgen05_tma_store_tensor, (256, 256)," in code
     assert "StMatrix8x8x16bOp(transpose=True, num_matrices=4)" in code
     assert "cute.arch.alloc_smem(cutlass.Int32, 9" in code
 
@@ -259,6 +260,10 @@ def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
         "dynamic_ab_tensormaps": True,
         "dynamic_d_tensormap": True,
     }
+    d_plan = next(
+        plan for plan in _wrapper_plans(code) if plan["kind"] == "tcgen05_d_tma"
+    )
+    assert (d_plan["bm"], d_plan["bn"], d_plan["orientation"]) == (256, 256, "nm")
 
 
 def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
@@ -279,6 +284,7 @@ def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
     assert "(256, 224, 64)" in code
     assert "cute.local_tile(tma_tensor_a, (256, 64)" in code
     assert "cute.local_tile(tma_tensor_b, (224, 64)" in code
+    assert "cute.local_tile(tcgen05_tma_store_tensor, (256, 224)," in code
     plan = next(
         plan
         for plan in _wrapper_plans(code)
@@ -286,6 +292,10 @@ def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
     )
     assert plan["bk"] == 64
     assert plan["source_m_tile"] == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+    d_plan = next(
+        plan for plan in _wrapper_plans(code) if plan["kind"] == "tcgen05_d_tma"
+    )
+    assert (d_plan["bm"], d_plan["bn"], d_plan["orientation"]) == (256, 224, "nm")
 
 
 def test_grouped_worklist_nm_rejects_over_budget_host_metadata_profile() -> None:


### PR DESCRIPTION
Fixes B200 grouped-GEMM correctness failures introduced by #3410.

NM stores now retain the physical MMA tile dimensions when building the D-TMA descriptor and device-side tile. MN compact-fragment stores continue using their destination dimensions.        
