### PR TITLE
[CI] Gate backend-specific codegen tests

### DIFF
--- a/test/test_cute_epilogue.py
+++ b/test/test_cute_epilogue.py
@@ -16,6 +16,7 @@ from helion._compiler.cute.tcgen05_constants import (
 )
 from helion._testing import DEVICE
 from helion._testing import patch_cute_mma_support
+from helion._testing import skipUnlessBackends
 import helion.language as hl
 
 
@@ -191,6 +192,7 @@ class TestCuteEpilogue(unittest.TestCase):
                 "",
             )
 
+    @skipUnlessBackends(["cute"])
     def test_tcgen05_fused_auxiliary_product_codegen(self) -> None:
         """An explicitly grouped pair of scale loads stays one epilogue step."""
 
@@ -236,6 +238,7 @@ class TestCuteEpilogue(unittest.TestCase):
         acc_pos = code.index("tcgen05_acc_loaded", loop_pos)
         self.assertLess(product_pos, acc_pos)
 
+    @skipUnlessBackends(["cute"])
     def test_tcgen05_fused_reused_auxiliary_load_codegen(self) -> None:
         """Repeated uses of one FX load retain distinct leaf-to-local bindings."""
 
@@ -283,6 +286,7 @@ class TestCuteEpilogue(unittest.TestCase):
         self.assertIn("tcgen05_aux_loaded_0", chain_lines[0])
         self.assertIn("tcgen05_aux_loaded_1", chain_lines[1])
 
+    @skipUnlessBackends(["cute"])
     def test_tcgen05_fused_auxiliary_unary_expr_codegen(self) -> None:
         """Whitelisted unary ops can consume a grouped auxiliary expression."""
 
@@ -384,6 +388,7 @@ class TestCuteEpilogue(unittest.TestCase):
             with self.assertRaises(exc.BackendUnsupported):
                 int_scalar_bound.to_triton_code(int_scalar_cfg)
 
+    @skipUnlessBackends(["cute"])
     def test_tcgen05_bm256_broadcast_scales_reuse_auxiliary_loads(self) -> None:
         """The four-CTA full-tile epilogue reuses both broadcast scales."""
 

--- a/test/test_pretuned_pallas_kernels.py
+++ b/test/test_pretuned_pallas_kernels.py
@@ -8,6 +8,10 @@ from pretuned_kernels.gdn_decode.gdn_decode import GDN_DECODE_CONFIG
 from pretuned_kernels.gdn_decode.gdn_decode import gdn_decode
 import torch
 
+from helion._testing import skipUnlessBackends
+
+pytestmark = skipUnlessBackends(["pallas"])
+
 
 def test_causal_conv1d_decode_uses_indirect_dma() -> None:
     tokens, heads, head_dim = 512, 4, 128


### PR DESCRIPTION
## Summary

- run the four TCGen05 CuTe codegen tests only when `HELION_BACKEND=cute`
- run the pretuned Pallas codegen test module only when `HELION_BACKEND=pallas`
- retain the backend-independent CuTe epilogue helper tests on every backend

## Why

The Triton A10G job exposed six tests that were executing code for backends not installed in that environment:

- four CuTe tests failed with `CuteBackendUnavailable` because `nvidia-cutlass-dsl` is not installed
- two Pallas tests failed with `No module named jax`

Failing job: https://github.com/pytorch/helion/actions/runs/32761965857/job/97542696410

## Testing

- `HELION_BACKEND=triton python -m pytest -q -ra test/test_cute_epilogue.py test/test_pretuned_pallas_kernels.py`
  - `3 passed, 6 skipped, 2 subtests passed`
- `ruff check test/test_cute_epilogue.py test/test_pretuned_pallas_kernels.py`
- `ruff format --check test/test_cute_epilogue.py test/test_pretuned_pallas_kernels.py`