### PR TITLE
[CI] Fix Pallas-specific test gating

### DIFF
--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -316,6 +316,13 @@ def skipIfPallas(reason: str) -> Callable[[Callable], Callable]:
     return skipIfFn(lambda: _get_backend() == "pallas", reason)
 
 
+def skipIfPallasTpu(reason: str) -> Callable[[Callable], Callable]:
+    """Skip test only on real Pallas TPU (not in interpret mode)."""
+    return skipIfFn(
+        lambda: _get_backend() == "pallas" and not is_pallas_interpret(), reason
+    )
+
+
 def xfailIfPallas(reason: str) -> Callable[[Callable], Callable]:
     """Mark test as expected failure if running with pallas (TPU or interpret mode)"""
     return xfailIfFn(lambda: _get_backend() == "pallas", reason)

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -31,6 +31,7 @@ from helion._testing import DEVICE
 from helion._testing import RefEagerTestDisabled
 from helion._testing import import_path
 from helion._testing import onlyBackends
+from helion._testing import skipIfPallasTpu
 from helion._testing import skipIfXPU
 from helion._testing import skipUnlessCuteAvailable
 from helion.autotuner.base_search import PopulationBasedSearch
@@ -688,6 +689,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         self.assertIsInstance(loaded[0], _ReturnValue)
         self.assertEqual(loaded[0].value, 3)
 
+    @skipIfPallasTpu("spawned workers cannot acquire an initialized TPU device")
     def test_spawn_precompile_loads_trusted_python_args(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
@@ -721,6 +723,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
                     process.kill()
                     process.join(timeout=5)
 
+    @skipIfPallasTpu("spawned workers cannot acquire an initialized TPU device")
     def test_spawn_loads_source_module_from_file(self) -> None:
         # Regression: a kernel loaded by path / notebook / exec lives under a
         # synthetic module name that only the parent's sys.modules knows about.

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1693,7 +1693,6 @@ class TestExamples(RefEagerTestBase, TestCase):
                     rtol=rtol,
                 )
 
-    @xfailIfPallasTpu("tensor-derived if-predicates not supported")
     def test_grouped_gemm_jagged(self):
         # Build small jagged grouped GEMM inputs
         torch.manual_seed(0)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -855,6 +855,7 @@ class TestPallas(TestCase):
         )
         torch.testing.assert_close(result, x[:, :128] + 1)
 
+    @xfailIfPallasTpu("Mosaic cannot prove alignment of single-row BF16 stores")
     def test_dynamic_window_declines_unaligned_1d_dma(self) -> None:
         table = torch.randn(512, device=DEVICE, dtype=torch.bfloat16)
         starts = torch.tensor([0, 1], device=DEVICE, dtype=torch.int32)

--- a/test/test_pretuned_pallas_kernels.py
+++ b/test/test_pretuned_pallas_kernels.py
@@ -8,11 +8,13 @@ from pretuned_kernels.gdn_decode.gdn_decode import GDN_DECODE_CONFIG
 from pretuned_kernels.gdn_decode.gdn_decode import gdn_decode
 import torch
 
+from helion._testing import skipIfPallasInterpret
 from helion._testing import skipUnlessBackends
 
 pytestmark = skipUnlessBackends(["pallas"])
 
 
+@skipIfPallasInterpret("indirect DMA codegen requires physical TPU lowering")
 def test_causal_conv1d_decode_uses_indirect_dma() -> None:
     tokens, heads, head_dim = 512, 4, 128
     args = (
@@ -32,6 +34,7 @@ def test_causal_conv1d_decode_uses_indirect_dma() -> None:
     assert "one_hot" not in code
 
 
+@skipIfPallasInterpret("indirect DMA codegen requires physical TPU lowering")
 def test_gdn_decode_uses_indirect_dma() -> None:
     tokens, heads, dim = 512, 2, 128
     args = (


### PR DESCRIPTION
## Summary

- skip physical-TPU-only benchmark worker spawn tests on Pallas TPU
- skip indirect-DMA codegen tests in Pallas interpret mode
- remove the stale grouped GEMM jagged TPU xfail
- mark the known Mosaic unaligned-store limitation as an expected physical-TPU failure

## Testing

- git diff --check
- Python compileall for all five changed files
- targeted pytest and Ruff could not run because this clean worktree has no installed pytest/Ruff environment; repository policy prohibits installing packages

Tracks the Pallas wrong-skip failures in #3458.