### PR TITLE
[CI] Gate unsupported ROCm and XPU tests

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -35,6 +35,7 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfPyTorchBaseVerLessThan
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
+from helion._testing import skipIfXPU
 from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 from helion.runtime.settings import _get_backend
@@ -1106,6 +1107,7 @@ class TestMisc(RefEagerTestBase, TestCase):
         if _get_backend() == "triton":
             self.assertIn("tl.associative_scan", code)
 
+    @skipIfXPU("Triton topk produces incorrect values on XPU")
     def test_torch_topk_in_kernel(self):
         """Test that torch.topk works inside Helion kernels.
 
@@ -1136,6 +1138,7 @@ class TestMisc(RefEagerTestBase, TestCase):
             # Uses tl.topk for largest=True
             self.assertIn("tl.topk", code)
 
+    @skipIfXPU("Triton sort produces incorrect values on XPU")
     def test_torch_topk_smallest(self):
         """Test torch.topk with largest=False (k smallest elements)."""
 

--- a/test/test_prepared_call.py
+++ b/test/test_prepared_call.py
@@ -7,11 +7,13 @@ import importlib
 import threading
 from typing import TYPE_CHECKING
 from typing import cast
+import unittest
 from unittest.mock import patch
 
 import torch
 
 import helion
+from helion._compat import supports_torch_compile_fusion
 from helion._compiler._dynamo.variables import infer_output_spec
 from helion._compiler.cute.backend import CuteBackend
 from helion._compiler.pallas.backend import PallasBackend
@@ -670,6 +672,10 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
 
         self.assertFalse(add_one._bound_kernels)
 
+    @unittest.skipUnless(
+        supports_torch_compile_fusion(),
+        "requires Helion's torch.compile fusion integration",
+    )
     def test_inductor_lowering_bind_does_not_wait_for_bind_lock(self) -> None:
         from helion._compiler._inductor.template_buffer import _bind_kernel_for_lowering
 
@@ -1019,6 +1025,10 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         is_compiling.assert_called_once_with()
         torch.testing.assert_close(out, x + 1)
 
+    @unittest.skipUnless(
+        supports_torch_compile_fusion(),
+        "requires Helion's torch.compile fusion integration",
+    )
     def test_fullgraph_capture_preserves_eager_caches(self) -> None:
         @helion.kernel(
             static_shapes=True,

--- a/test/test_torch_compile.py
+++ b/test/test_torch_compile.py
@@ -3807,6 +3807,8 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
     ):
         """Test: kernel returning (tensor, scalar) called twice with different scalar literals
         inside the compile region. Verifies no helion recompilation."""
+        if not allow_torch_compile_fusion and not supports_torch_compile_fusion():
+            self.skipTest("fullgraph capture requires Helion's fusion integration")
 
         def f(
             x: torch.Tensor, *, _kernels=(k_scale_with_scalar_output,)
@@ -4452,6 +4454,8 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
     @skipIfTileIR("torch.compile missing kernel metadata on tileir")
     def test_kernel_with_tuple_input(self, allow_torch_compile_fusion):
         """Test: kernel with tuple of tensors as input."""
+        if not allow_torch_compile_fusion and not supports_torch_compile_fusion():
+            self.skipTest("fullgraph capture requires Helion's fusion integration")
 
         @helion.kernel(autotune_effort="none")
         def k_sum_tuple(tensors: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
@@ -4524,6 +4528,8 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
     @skipIfTileIR("torch.compile missing kernel metadata on tileir")
     def test_kernel_with_dict_input(self, allow_torch_compile_fusion):
         """Test: kernel with dict of tensors as input."""
+        if not allow_torch_compile_fusion and not supports_torch_compile_fusion():
+            self.skipTest("fullgraph capture requires Helion's fusion integration")
 
         @helion.kernel(autotune_effort="none")
         def k_sum_dict(tensors: dict[str, torch.Tensor]) -> torch.Tensor:


### PR DESCRIPTION
## Summary

- gate fullgraph prepared-call tests on Helion torch.compile fusion support
- skip the no-fusion tuple, dict, and scalar-literal variants when that integration is unavailable
- skip Triton topk and sort correctness tests on XPU, where those operations currently produce incorrect values

## Why

The newly enforced pytest exit status exposed tests that assume capabilities unavailable in the ROCm and XPU matrix builds. These are backend capability gaps rather than regressions in the tested Helion paths.

## Testing

- git diff --check
- Python compileall for all three changed files
- targeted pytest and Ruff could not run because this clean worktree has no installed pytest/Ruff environment; repository policy prohibits installing packages

Tracks the ROCm/XPU wrong-skip failures in #3458.