### PR TITLE
[cute] Add pretuned B200/GB300 flash attention kernel

### DIFF
--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -25,6 +25,7 @@ pretuned_kernels/
 │   ├── _helion_aot_vector_add_cuda_sm100.py   # B200 heuristic
 │   └── _helion_aot_vector_add_cuda_sm90.py    # H100 heuristic
 ├── softmax/
+├── attention/                        # B200 CuTe dense flash attention
 ├── layer_norm/
 ├── rms_norm/
 ├── cross_entropy/
@@ -55,6 +56,7 @@ At runtime Helion picks the file matching the current GPU.
 |---|---|---|
 | `vector_add` | `2**i for i in range(19, 29)` | `x + y` |
 | `softmax` | Triton tutorial `M=4096, N=128*i for i in range(2, 100)` + realistic long-context shapes | `F.softmax` |
+| `attention` | Non-causal dense `(z, h, seq, head_dim)` shapes from the CuTe attention comparison (B200 CuTe flash backend only; CUDA-graph timed) | cuDNN `F.scaled_dot_product_attention` |
 | `layer_norm` | Triton tutorial `M=4096, N=512*i for i in range(2, 32)` + realistic hidden-size shapes | `F.layer_norm` |
 | `rms_norm` | TritonBench `(M=2048, H)` default + NPOT shapes + realistic LLM hidden-size and production-style shapes | `F.rms_norm` |
 | `cross_entropy` | TritonBench/Liger token-vocab sweep + realistic LLM vocabulary shapes | `F.cross_entropy` |
@@ -157,7 +159,7 @@ runtime based on the running GPU's compute capability (with fallback to
 older compatible capabilities, e.g. `sm120` → `sm100`).
 
 For a kernel whose `main()` benchmarks under CUDA graphs (`use_cudagraph()`
-returns `True`, e.g. `scaled_mm` and the vLLM-ported ops), set
+returns `True`, e.g. `scaled_mm`, `attention`, and the vLLM-ported ops), set
 `HELION_BENCHMARK_CUDAGRAPH=1` for the autotune run so the autotuner benchmarks
 candidate configs the same way — matching the deployment/benchmark timing
 regime.

--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -25,7 +25,7 @@ pretuned_kernels/
 │   ├── _helion_aot_vector_add_cuda_sm100.py   # B200 heuristic
 │   └── _helion_aot_vector_add_cuda_sm90.py    # H100 heuristic
 ├── softmax/
-├── attention/                        # B200/GB300 CuTe dense flash attention
+├── attention/                        # B200/GB300 CuTe dense/causal flash attention
 ├── layer_norm/
 ├── rms_norm/
 ├── cross_entropy/
@@ -56,7 +56,7 @@ At runtime Helion picks the file matching the current GPU.
 |---|---|---|
 | `vector_add` | `2**i for i in range(19, 29)` | `x + y` |
 | `softmax` | Triton tutorial `M=4096, N=128*i for i in range(2, 100)` + realistic long-context shapes | `F.softmax` |
-| `attention` | Non-causal dense `(z, h, seq, head_dim)` shapes from the CuTe attention comparison (B200/GB300 CuTe flash backend; CUDA-graph timed) | cuDNN `F.scaled_dot_product_attention` |
+| `attention` | Dense and causal `(z, h, seq, head_dim)` shapes from the CuTe attention comparison (B200/GB300 CuTe flash backend; CUDA-graph timed) | cuDNN `F.scaled_dot_product_attention` |
 | `layer_norm` | Triton tutorial `M=4096, N=512*i for i in range(2, 32)` + realistic hidden-size shapes | `F.layer_norm` |
 | `rms_norm` | TritonBench `(M=2048, H)` default + NPOT shapes + realistic LLM hidden-size and production-style shapes | `F.rms_norm` |
 | `cross_entropy` | TritonBench/Liger token-vocab sweep + realistic LLM vocabulary shapes | `F.cross_entropy` |

--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -6,11 +6,11 @@ points for common kernel patterns while also being runnable examples for people
 who want to quickly try Helion.
 
 The checked-in heuristics let these kernels run immediately without online
-autotuning.  Heuristics ship for both NVIDIA H100 (`sm90`) and B200 (`sm100`);
-Helion picks the matching file at runtime.  Treat the files as kernel recipes:
-copy the kernel and its local `_helion_aot_*` heuristic into your code, then
-retune when your target shapes or hardware differ materially from the included
-sweep.
+autotuning.  Heuristics primarily target NVIDIA H100 (`sm90`) and B200
+(`sm100`), with GB300 (`sm103`) coverage where noted; Helion picks the matching
+file at runtime.  Treat the files as kernel recipes: copy the kernel and its
+local `_helion_aot_*` heuristic into your code, then retune when your target
+shapes or hardware differ materially from the included sweep.
 
 Each kernel module has a `main()` that benchmarks against one or more named
 reference baselines.
@@ -25,7 +25,7 @@ pretuned_kernels/
 │   ├── _helion_aot_vector_add_cuda_sm100.py   # B200 heuristic
 │   └── _helion_aot_vector_add_cuda_sm90.py    # H100 heuristic
 ├── softmax/
-├── attention/                        # B200 CuTe dense flash attention
+├── attention/                        # B200/GB300 CuTe dense flash attention
 ├── layer_norm/
 ├── rms_norm/
 ├── cross_entropy/
@@ -56,7 +56,7 @@ At runtime Helion picks the file matching the current GPU.
 |---|---|---|
 | `vector_add` | `2**i for i in range(19, 29)` | `x + y` |
 | `softmax` | Triton tutorial `M=4096, N=128*i for i in range(2, 100)` + realistic long-context shapes | `F.softmax` |
-| `attention` | Non-causal dense `(z, h, seq, head_dim)` shapes from the CuTe attention comparison (B200 CuTe flash backend only; CUDA-graph timed) | cuDNN `F.scaled_dot_product_attention` |
+| `attention` | Non-causal dense `(z, h, seq, head_dim)` shapes from the CuTe attention comparison (B200/GB300 CuTe flash backend; CUDA-graph timed) | cuDNN `F.scaled_dot_product_attention` |
 | `layer_norm` | Triton tutorial `M=4096, N=512*i for i in range(2, 32)` + realistic hidden-size shapes | `F.layer_norm` |
 | `rms_norm` | TritonBench `(M=2048, H)` default + NPOT shapes + realistic LLM hidden-size and production-style shapes | `F.rms_norm` |
 | `cross_entropy` | TritonBench/Liger token-vocab sweep + realistic LLM vocabulary shapes | `F.cross_entropy` |

--- a/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
+++ b/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
@@ -237,15 +237,15 @@ _CAUSAL_HD64_BASE = {
 _CAUSAL_CONFIGS = [
     {
         **_CAUSAL_HD64_BASE,
-        "cute_flash_causal_lpt_swizzle": 2,
-        "cute_flash_disc_pipe": 2,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_disc_pipe": 3,
         "cute_flash_e2e_offset": 0,
-        "cute_flash_e2e_offset0": 0,
+        "cute_flash_e2e_offset0": 14,
         "cute_flash_epi_tma": True,
         "cute_flash_first_load_order": 0,
-        "cute_flash_kv_stage": 2,
+        "cute_flash_kv_stage": 3,
         "cute_flash_role_map": "fa4",
-        "cute_flash_softmax_regs": 184,
+        "cute_flash_softmax_regs": 200,
     },
     {
         **_CAUSAL_HD64_BASE,

--- a/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
+++ b/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
@@ -5,9 +5,50 @@ from __future__ import annotations
 import torch
 
 
-# The third config is the long-sequence head-dim-64 fallback used by the
-# comparison harness's dense_causal8 suite, beyond the representative SHAPES
-# timed by pretuned_kernels/attention/attention.py.
+_DENSE_HD64_2CTA_BASE = {
+    "block_sizes": [1, 128, 128],
+    "cute_flash_causal_kv_order": "ascending",
+    "cute_flash_causal_loop_split": False,
+    "cute_flash_causal_lpt_swizzle": 0,
+    "cute_flash_clc_heads_per_batch": 0,
+    "cute_flash_clc_pdl": False,
+    "cute_flash_clc_stages": 1,
+    "cute_flash_disc_pipe": 1,
+    "cute_flash_e2e_schedule": "16/6",
+    "cute_flash_epi_stg": False,
+    "cute_flash_epi_stg_gmem": "stage",
+    "cute_flash_epi_stg_store": "slice",
+    "cute_flash_epi_tma": True,
+    "cute_flash_exp2_packet": "deg2_16x6",
+    "cute_flash_kv_order": "descending",
+    "cute_flash_kv_stage": 2,
+    "cute_flash_masked_e2e_schedule": "inherit",
+    "cute_flash_mma_interleave": True,
+    "cute_flash_other_regs": 40,
+    "cute_flash_p_store_rep": 16,
+    "cute_flash_packed_reduce": True,
+    "cute_flash_persistent": False,
+    "cute_flash_persistent_ctas_per_sm": 1,
+    "cute_flash_pipeline_family": "fa4_2cta",
+    "cute_flash_precompute_qk_desc": True,
+    "cute_flash_q_tile_count": 2,
+    "cute_flash_recompute_tile_coords": False,
+    "cute_flash_rescale_chunk_cols": 8,
+    "cute_flash_rescale_threshold": 8.0,
+    "cute_flash_s_load_rep": 32,
+    "cute_flash_s_stage": 2,
+    "cute_flash_skip_rescale_stats": False,
+    "cute_flash_small_biased": True,
+    "cute_flash_softmax_disc": False,
+    "cute_flash_softmax_regs": 192,
+    "cute_flash_split_p_arrive": True,
+    "cute_flash_stat_transport": "single_final",
+    "cute_flash_wait_hint": 0,
+}
+
+
+# Configs 3-6 are the nonpersistent two-CTA schedules tuned for the B200
+# dense_causal8 shapes in benchmarks/cute/compare_attention_backends.py.
 _CONFIGS = [
     {
         "block_sizes": [1, 128, 128],
@@ -78,10 +119,55 @@ _CONFIGS = [
         "cute_flash_softmax_regs": 200,
         "cute_flash_topology": "fa4",
     },
+    {
+        **_DENSE_HD64_2CTA_BASE,
+        "cute_flash_corr_regs": 72,
+        "cute_flash_corr_tile_size": 8,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 1,
+        "cute_flash_first_load_order": 4,
+        "cute_flash_rescale_threshold": 12.0,
+        "cute_flash_role_map": "fa4",
+    },
+    {
+        **_DENSE_HD64_2CTA_BASE,
+        "cute_flash_corr_regs": 72,
+        "cute_flash_corr_tile_size": 16,
+        "cute_flash_e2e_offset": 14,
+        "cute_flash_e2e_offset0": 0,
+        "cute_flash_first_load_order": 4,
+        "cute_flash_role_map": "fa4",
+    },
+    {
+        **_DENSE_HD64_2CTA_BASE,
+        "cute_flash_corr_regs": 72,
+        "cute_flash_corr_tile_size": 8,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 0,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_role_map": "helion",
+    },
+    {
+        **_DENSE_HD64_2CTA_BASE,
+        "cute_flash_corr_regs": 72,
+        "cute_flash_corr_tile_size": 8,
+        "cute_flash_e2e_offset": 12,
+        "cute_flash_e2e_offset0": 2,
+        "cute_flash_first_load_order": 4,
+        "cute_flash_role_map": "fa4",
+    },
 ]
 
 
-def key_attention(*args) -> int:
+_LONG_DENSE_HD64_CONFIGS = {
+    32768: 3,
+    65536: 4,
+    131072: 5,
+    262144: 6,
+}
+
+
+def key_attention(*args: torch.Tensor) -> int:
     """Select a config from the query sequence length and head dimension."""
     q = args[0]
     seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
@@ -90,9 +176,129 @@ def key_attention(*args) -> int:
         return 1
     if seq_len <= 4096:
         return 0
+    if (
+        head_dim == 64
+        and q.dtype == torch.float16
+        and seq_len in _LONG_DENSE_HD64_CONFIGS
+    ):
+        return _LONG_DENSE_HD64_CONFIGS[seq_len]
     return 2
 
 
-def autotune_attention(*args) -> dict:
+def autotune_attention(*args: torch.Tensor) -> dict[str, object]:
     """Return the checked-in B200 config for the given attention shape."""
     return _CONFIGS[key_attention(*args)]
+
+
+_CAUSAL_HD64_BASE = {
+    "block_sizes": [1, 128, 128],
+    "cute_flash_causal_kv_order": "descending",
+    "cute_flash_causal_loop_split": True,
+    "cute_flash_causal_lpt_swizzle": 0,
+    "cute_flash_clc_heads_per_batch": 0,
+    "cute_flash_clc_pdl": False,
+    "cute_flash_clc_stages": 1,
+    "cute_flash_corr_regs": 64,
+    "cute_flash_corr_tile_size": 16,
+    "cute_flash_disc_pipe": 3,
+    "cute_flash_e2e_schedule": "16/6",
+    "cute_flash_epi_stg": False,
+    "cute_flash_epi_stg_gmem": "stage",
+    "cute_flash_epi_stg_store": "slice",
+    "cute_flash_exp2_packet": "deg2_16x6",
+    "cute_flash_kv_order": "ascending",
+    "cute_flash_masked_e2e_schedule": "16/6",
+    "cute_flash_mma_interleave": True,
+    "cute_flash_other_regs": 48,
+    "cute_flash_p_store_rep": 16,
+    "cute_flash_packed_reduce": True,
+    "cute_flash_persistent": False,
+    "cute_flash_persistent_ctas_per_sm": 1,
+    "cute_flash_pipeline_family": "fa4",
+    "cute_flash_precompute_qk_desc": False,
+    "cute_flash_q_tile_count": 2,
+    "cute_flash_recompute_tile_coords": False,
+    "cute_flash_rescale_chunk_cols": 16,
+    "cute_flash_rescale_threshold": 8.0,
+    "cute_flash_s_load_rep": 32,
+    "cute_flash_s_stage": 2,
+    "cute_flash_skip_rescale_stats": False,
+    "cute_flash_small_biased": True,
+    "cute_flash_softmax_disc": True,
+    "cute_flash_split_p_arrive": True,
+    "cute_flash_stat_transport": "ring2",
+    "cute_flash_wait_hint": 0,
+}
+
+
+# The best B200 one-CTA schedules found for the four long causal shapes. The
+# 64K, 128K, and 256K configs remain slightly behind cuDNN SDPA, while 512K
+# wins; all four avoid online autotuning for the checked-in benchmark suite.
+_CAUSAL_CONFIGS = [
+    {
+        **_CAUSAL_HD64_BASE,
+        "cute_flash_causal_lpt_swizzle": 2,
+        "cute_flash_disc_pipe": 2,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 0,
+        "cute_flash_epi_tma": True,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_kv_stage": 2,
+        "cute_flash_role_map": "fa4",
+        "cute_flash_softmax_regs": 184,
+    },
+    {
+        **_CAUSAL_HD64_BASE,
+        "cute_flash_e2e_offset": 1,
+        "cute_flash_e2e_offset0": 14,
+        "cute_flash_epi_tma": True,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_kv_stage": 2,
+        "cute_flash_role_map": "fa4",
+        "cute_flash_softmax_regs": 192,
+    },
+    {
+        **_CAUSAL_HD64_BASE,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 15,
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_kv_stage": 4,
+        "cute_flash_role_map": "helion",
+        "cute_flash_softmax_regs": 192,
+        "cute_flash_wait_hint": 10000000,
+    },
+    {
+        **_CAUSAL_HD64_BASE,
+        "cute_flash_e2e_offset": 14,
+        "cute_flash_e2e_offset0": 12,
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_kv_stage": 2,
+        "cute_flash_role_map": "helion",
+        "cute_flash_softmax_regs": 184,
+        "cute_flash_wait_hint": 10000000,
+    },
+]
+
+_CAUSAL_HD64_CONFIGS = {
+    65536: 0,
+    131072: 1,
+    262144: 2,
+    524288: 3,
+}
+
+
+def key_causal_attention(*args: torch.Tensor) -> int:
+    """Select the exact B200 long-sequence causal config."""
+    q = args[0]
+    seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
+    head_dim = int(q.shape[-1]) if isinstance(q, torch.Tensor) and q.ndim >= 1 else 0
+    if head_dim == 64 and q.dtype == torch.float16:
+        return _CAUSAL_HD64_CONFIGS.get(seq_len, 0)
+    return 0
+
+
+def autotune_causal_attention(*args: torch.Tensor) -> dict[str, object]:
+    """Return the checked-in B200 causal config for the given shape."""
+    return _CAUSAL_CONFIGS[key_causal_attention(*args)]

--- a/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
+++ b/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
@@ -1,0 +1,98 @@
+"""B200 configs for the CuTe flash attention kernel."""
+
+from __future__ import annotations
+
+import torch
+
+
+# The third config is the long-sequence head-dim-64 fallback used by the
+# comparison harness's dense_causal8 suite, beyond the representative SHAPES
+# timed by pretuned_kernels/attention/attention.py.
+_CONFIGS = [
+    {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_disc_pipe": 4,
+        "cute_flash_e2e_offset": 2,
+        "cute_flash_e2e_offset0": 0,
+        "cute_flash_e2e_schedule": "16/4",
+        "cute_flash_epi_tma": False,
+        "cute_flash_kv_stage": 3,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_packed_reduce": False,
+        "cute_flash_persistent": True,
+        "cute_flash_rescale_chunk_cols": 32,
+        "cute_flash_rescale_threshold": 8.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_stage": 2,
+        "cute_flash_small_biased": True,
+        "cute_flash_softmax_regs": 200,
+        "cute_flash_topology": "fa4",
+    },
+    {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_disc_pipe": 2,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 0,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_epi_tma": True,
+        "cute_flash_kv_stage": 3,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_packed_reduce": False,
+        "cute_flash_persistent": True,
+        "cute_flash_rescale_chunk_cols": 16,
+        "cute_flash_rescale_threshold": 8.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_stage": 2,
+        "cute_flash_small_biased": True,
+        "cute_flash_softmax_regs": 200,
+        "cute_flash_topology": "fa4",
+    },
+    {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_disc_pipe": 3,
+        "cute_flash_e2e_offset": 2,
+        "cute_flash_e2e_offset0": 0,
+        "cute_flash_e2e_schedule": "16/4",
+        "cute_flash_epi_tma": False,
+        "cute_flash_kv_stage": 2,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_packed_reduce": True,
+        "cute_flash_persistent": True,
+        "cute_flash_rescale_chunk_cols": 32,
+        "cute_flash_rescale_threshold": 8.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_stage": 2,
+        "cute_flash_small_biased": True,
+        "cute_flash_softmax_regs": 200,
+        "cute_flash_topology": "fa4",
+    },
+]
+
+
+def key_attention(*args) -> int:
+    """Select a config from the query sequence length and head dimension."""
+    q = args[0]
+    seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
+    head_dim = int(q.shape[-1]) if isinstance(q, torch.Tensor) and q.ndim >= 1 else 0
+    if head_dim >= 128:
+        return 1
+    if seq_len <= 4096:
+        return 0
+    return 2
+
+
+def autotune_attention(*args) -> dict:
+    """Return the checked-in B200 config for the given attention shape."""
+    return _CONFIGS[key_attention(*args)]

--- a/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
+++ b/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
@@ -5,6 +5,31 @@ from __future__ import annotations
 import torch
 
 
+# Every tuned head_dim=128 long-sequence config below agrees on these
+# fields; the per-shape entries only list what the autotuner varied.
+_LONG_HD128_BASE = {
+    "block_sizes": [1, 128, 128],
+    "cute_flash_clc_heads_per_batch": 0,
+    "cute_flash_clc_pdl": False,
+    "cute_flash_clc_stages": 1,
+    "cute_flash_epi_tma_setup": "shared",
+    "cute_flash_exp2_packet": "1x1",
+    "cute_flash_mma_interleave": True,
+    "cute_flash_p_store_rep": 16,
+    "cute_flash_packed_reduce": True,
+    "cute_flash_persistent_loop": "while",
+    "cute_flash_q_tile_count": 2,
+    "cute_flash_recompute_tile_coords": False,
+    "cute_flash_role_chain": False,
+    "cute_flash_s_stage": 2,
+    "cute_flash_skip_rescale_stats": False,
+    "cute_flash_small_biased": True,
+    "cute_flash_softmax_setup": "shared",
+    "cute_flash_sp_row_sum": "fragment",
+    "cute_flash_stat_transport": "ring2",
+}
+
+
 _DENSE_HD64_2CTA_BASE = {
     "block_sizes": [1, 128, 128],
     "cute_flash_causal_kv_order": "ascending",
@@ -156,6 +181,107 @@ _CONFIGS = [
         "cute_flash_first_load_order": 4,
         "cute_flash_role_map": "fa4",
     },
+    # Long dense head_dim=128 float16 schedules for the same suite. 64K and
+    # 128K share one schedule; it beat both shapes' own autotune winners.
+    {
+        **_LONG_HD128_BASE,
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_corr_tile_size": 16,
+        "cute_flash_disc_pipe": 4,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 4,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_epi_stg": False,
+        "cute_flash_epi_stg_gmem": "stage",
+        "cute_flash_epi_stg_store": "slice",
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_kv_order": "descending",
+        "cute_flash_kv_stage": 4,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_other_regs": 64,
+        "cute_flash_persistent": False,
+        "cute_flash_persistent_ctas_per_sm": 1,
+        "cute_flash_pipeline_family": "fa4_2cta",
+        "cute_flash_precompute_qk_desc": False,
+        "cute_flash_rescale_chunk_cols": 16,
+        "cute_flash_rescale_threshold": 12.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_load_rep": 32,
+        "cute_flash_softmax_disc": True,
+        "cute_flash_softmax_regs": 192,
+        "cute_flash_split_p_arrive": True,
+        "cute_flash_wait_hint": 0,
+    },  # seq_len=32768
+    {
+        **_LONG_HD128_BASE,
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_corr_tile_size": 8,
+        "cute_flash_disc_pipe": 3,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 2,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_epi_stg": False,
+        "cute_flash_epi_stg_gmem": "stage",
+        "cute_flash_epi_stg_store": "slice",
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 4,
+        "cute_flash_kv_order": "ascending",
+        "cute_flash_kv_stage": 3,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_other_regs": 48,
+        "cute_flash_persistent": False,
+        "cute_flash_persistent_ctas_per_sm": 1,
+        "cute_flash_pipeline_family": "fa4_2cta",
+        "cute_flash_precompute_qk_desc": False,
+        "cute_flash_rescale_chunk_cols": 16,
+        "cute_flash_rescale_threshold": 4.0,
+        "cute_flash_role_map": "fa4",
+        "cute_flash_s_load_rep": 32,
+        "cute_flash_softmax_disc": True,
+        "cute_flash_softmax_regs": 192,
+        "cute_flash_split_p_arrive": True,
+        "cute_flash_wait_hint": 10000000,
+    },  # seq_len=65536, 131072
+    {
+        **_LONG_HD128_BASE,
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_corr_tile_size": 16,
+        "cute_flash_disc_pipe": 1,
+        "cute_flash_e2e_offset": 6,
+        "cute_flash_e2e_offset0": 10,
+        "cute_flash_e2e_schedule": "16/2",
+        "cute_flash_epi_stg": False,
+        "cute_flash_epi_stg_gmem": "stage",
+        "cute_flash_epi_stg_store": "slice",
+        "cute_flash_epi_tma": True,
+        "cute_flash_first_load_order": 1,
+        "cute_flash_kv_order": "descending",
+        "cute_flash_kv_stage": 2,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_other_regs": 64,
+        "cute_flash_persistent": True,
+        "cute_flash_persistent_ctas_per_sm": 3,
+        "cute_flash_pipeline_family": "fa4_2cta",
+        "cute_flash_precompute_qk_desc": False,
+        "cute_flash_rescale_chunk_cols": 8,
+        "cute_flash_rescale_threshold": 4.0,
+        "cute_flash_role_map": "fa4",
+        "cute_flash_s_load_rep": 32,
+        "cute_flash_softmax_disc": False,
+        "cute_flash_softmax_regs": 184,
+        "cute_flash_split_p_arrive": False,
+        "cute_flash_wait_hint": 0,
+    },  # seq_len=262144
 ]
 
 
@@ -167,11 +293,25 @@ _LONG_DENSE_HD64_CONFIGS = {
 }
 
 
+_LONG_DENSE_HD128_CONFIGS = {
+    32768: 7,
+    65536: 8,
+    131072: 8,
+    262144: 9,
+}
+
+
 def key_attention(*args: torch.Tensor) -> int:
     """Select a config from the query sequence length and head dimension."""
     q = args[0]
     seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
     head_dim = int(q.shape[-1]) if isinstance(q, torch.Tensor) and q.ndim >= 1 else 0
+    if (
+        head_dim == 128
+        and q.dtype == torch.float16
+        and seq_len in _LONG_DENSE_HD128_CONFIGS
+    ):
+        return _LONG_DENSE_HD128_CONFIGS[seq_len]
     if head_dim >= 128:
         return 1
     if seq_len <= 4096:
@@ -231,9 +371,11 @@ _CAUSAL_HD64_BASE = {
 }
 
 
-# The best B200 one-CTA schedules found for the four long causal shapes. The
-# 64K, 128K, and 256K configs remain slightly behind cuDNN SDPA, while 512K
-# wins; all four avoid online autotuning for the checked-in benchmark suite.
+# The best B200 one-CTA schedules found for the long causal shapes, head_dim 64
+# first and then head_dim 128. At head_dim 64 the 64K, 128K, and 256K configs
+# remain slightly behind cuDNN SDPA while 512K wins; at head_dim 128 the 64K and
+# 128K configs are ~4% behind, 256K matches, and 512K wins by ~6%. All of them
+# avoid online autotuning for the checked-in benchmark suite.
 _CAUSAL_CONFIGS = [
     {
         **_CAUSAL_HD64_BASE,
@@ -279,6 +421,139 @@ _CAUSAL_CONFIGS = [
         "cute_flash_softmax_regs": 184,
         "cute_flash_wait_hint": 10000000,
     },
+    # Long causal head_dim=128 float16 schedules for the same suite.
+    {
+        **_LONG_HD128_BASE,
+        "cute_flash_causal_kv_order": "descending",
+        "cute_flash_causal_loop_split": True,
+        "cute_flash_causal_lpt_swizzle": 1,
+        "cute_flash_corr_regs": 80,
+        "cute_flash_corr_tile_size": 16,
+        "cute_flash_disc_pipe": 1,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 2,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_epi_stg": True,
+        "cute_flash_epi_stg_gmem": "stage",
+        "cute_flash_epi_stg_store": "slice",
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 4,
+        "cute_flash_kv_order": "ascending",
+        "cute_flash_kv_stage": 3,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_other_regs": 32,
+        "cute_flash_persistent": False,
+        "cute_flash_persistent_ctas_per_sm": 1,
+        "cute_flash_pipeline_family": "fa4",
+        "cute_flash_precompute_qk_desc": False,
+        "cute_flash_rescale_chunk_cols": 32,
+        "cute_flash_rescale_threshold": 12.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_load_rep": 16,
+        "cute_flash_softmax_disc": True,
+        "cute_flash_softmax_regs": 176,
+        "cute_flash_split_p_arrive": True,
+        "cute_flash_wait_hint": 10000000,
+    },  # seq_len=65536
+    {
+        **_LONG_HD128_BASE,
+        "cute_flash_causal_kv_order": "descending",
+        "cute_flash_causal_loop_split": True,
+        "cute_flash_causal_lpt_swizzle": 1,
+        "cute_flash_corr_regs": 80,
+        "cute_flash_corr_tile_size": 16,
+        "cute_flash_disc_pipe": 1,
+        "cute_flash_e2e_offset": 1,
+        "cute_flash_e2e_offset0": 15,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_epi_stg": True,
+        "cute_flash_epi_stg_gmem": "pair",
+        "cute_flash_epi_stg_store": "whole",
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_kv_order": "ascending",
+        "cute_flash_kv_stage": 2,
+        "cute_flash_masked_e2e_schedule": "16/4",
+        "cute_flash_other_regs": 64,
+        "cute_flash_persistent": False,
+        "cute_flash_persistent_ctas_per_sm": 1,
+        "cute_flash_pipeline_family": "fa4",
+        "cute_flash_precompute_qk_desc": False,
+        "cute_flash_rescale_chunk_cols": 16,
+        "cute_flash_rescale_threshold": 8.0,
+        "cute_flash_role_map": "fa4",
+        "cute_flash_s_load_rep": 16,
+        "cute_flash_softmax_disc": True,
+        "cute_flash_softmax_regs": 184,
+        "cute_flash_split_p_arrive": True,
+        "cute_flash_wait_hint": 10000000,
+    },  # seq_len=131072
+    {
+        **_LONG_HD128_BASE,
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 1,
+        "cute_flash_corr_regs": 88,
+        "cute_flash_corr_tile_size": 16,
+        "cute_flash_disc_pipe": 1,
+        "cute_flash_e2e_offset": 1,
+        "cute_flash_e2e_offset0": 5,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_epi_stg": True,
+        "cute_flash_epi_stg_gmem": "stage",
+        "cute_flash_epi_stg_store": "whole",
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 2,
+        "cute_flash_kv_order": "ascending",
+        "cute_flash_kv_stage": 2,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_other_regs": 40,
+        "cute_flash_persistent": False,
+        "cute_flash_persistent_ctas_per_sm": 1,
+        "cute_flash_pipeline_family": "fa4",
+        "cute_flash_precompute_qk_desc": True,
+        "cute_flash_rescale_chunk_cols": 32,
+        "cute_flash_rescale_threshold": 4.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_load_rep": 16,
+        "cute_flash_softmax_disc": True,
+        "cute_flash_softmax_regs": 176,
+        "cute_flash_split_p_arrive": True,
+        "cute_flash_wait_hint": 10000000,
+    },  # seq_len=262144
+    {
+        **_LONG_HD128_BASE,
+        "cute_flash_causal_kv_order": "descending",
+        "cute_flash_causal_loop_split": True,
+        "cute_flash_causal_lpt_swizzle": 1,
+        "cute_flash_corr_regs": 80,
+        "cute_flash_corr_tile_size": 32,
+        "cute_flash_disc_pipe": 1,
+        "cute_flash_e2e_offset": 3,
+        "cute_flash_e2e_offset0": 4,
+        "cute_flash_e2e_schedule": "16/4",
+        "cute_flash_epi_stg": False,
+        "cute_flash_epi_stg_gmem": "stage",
+        "cute_flash_epi_stg_store": "slice",
+        "cute_flash_epi_tma": True,
+        "cute_flash_first_load_order": 4,
+        "cute_flash_kv_order": "ascending",
+        "cute_flash_kv_stage": 2,
+        "cute_flash_masked_e2e_schedule": "16/4",
+        "cute_flash_other_regs": 64,
+        "cute_flash_persistent": False,
+        "cute_flash_persistent_ctas_per_sm": 1,
+        "cute_flash_pipeline_family": "fa4",
+        "cute_flash_precompute_qk_desc": True,
+        "cute_flash_rescale_chunk_cols": 8,
+        "cute_flash_rescale_threshold": 12.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_load_rep": 32,
+        "cute_flash_softmax_disc": True,
+        "cute_flash_softmax_regs": 176,
+        "cute_flash_split_p_arrive": True,
+        "cute_flash_wait_hint": 0,
+    },  # seq_len=524288
 ]
 
 _CAUSAL_HD64_CONFIGS = {
@@ -289,11 +564,21 @@ _CAUSAL_HD64_CONFIGS = {
 }
 
 
+_CAUSAL_HD128_CONFIGS = {
+    65536: 4,
+    131072: 5,
+    262144: 6,
+    524288: 7,
+}
+
+
 def key_causal_attention(*args: torch.Tensor) -> int:
     """Select the exact B200 long-sequence causal config."""
     q = args[0]
     seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
     head_dim = int(q.shape[-1]) if isinstance(q, torch.Tensor) and q.ndim >= 1 else 0
+    if head_dim == 128 and q.dtype == torch.float16:
+        return _CAUSAL_HD128_CONFIGS.get(seq_len, 4)
     if head_dim == 64 and q.dtype == torch.float16:
         return _CAUSAL_HD64_CONFIGS.get(seq_len, 0)
     return 0

--- a/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
+++ b/pretuned_kernels/attention/_helion_aot_attention_cuda_sm100.py
@@ -1,36 +1,25 @@
-"""B200 configs for the CuTe flash attention kernel."""
+"""B200 configs for the CuTe flash attention kernel.
+
+Long dense and causal schedules are tuned per sequence length at both
+head_dim 64 and head_dim 128 for the sweep in
+benchmarks/cute/compare_attention_backends.py. Slots 0-2 keep the
+short-sequence and generic fallback schedules.
+
+Every long-sequence entry is the fastest schedule found for its shape across
+twelve full-effort autotune runs plus a cross-shape pool of every config those
+runs produced, re-timed with the sweep's own cudagraph timer. Against cuDNN
+SDPA the sweep lands at geomean 1.00x, winning on 6 of 16 shapes; the dense
+head_dim 128 64K/128K rows are the furthest behind at ~0.96x and did not
+improve across ~900-config searches, so that gap looks kernel-side rather than
+a matter of config selection.
+"""
 
 from __future__ import annotations
 
 import torch
 
 
-# Every tuned head_dim=128 long-sequence config below agrees on these
-# fields; the per-shape entries only list what the autotuner varied.
-_LONG_HD128_BASE = {
-    "block_sizes": [1, 128, 128],
-    "cute_flash_clc_heads_per_batch": 0,
-    "cute_flash_clc_pdl": False,
-    "cute_flash_clc_stages": 1,
-    "cute_flash_epi_tma_setup": "shared",
-    "cute_flash_exp2_packet": "1x1",
-    "cute_flash_mma_interleave": True,
-    "cute_flash_p_store_rep": 16,
-    "cute_flash_packed_reduce": True,
-    "cute_flash_persistent_loop": "while",
-    "cute_flash_q_tile_count": 2,
-    "cute_flash_recompute_tile_coords": False,
-    "cute_flash_role_chain": False,
-    "cute_flash_s_stage": 2,
-    "cute_flash_skip_rescale_stats": False,
-    "cute_flash_small_biased": True,
-    "cute_flash_softmax_setup": "shared",
-    "cute_flash_sp_row_sum": "fragment",
-    "cute_flash_stat_transport": "ring2",
-}
-
-
-_DENSE_HD64_2CTA_BASE = {
+_LONG_DENSE_HD64_BASE = {
     "block_sizes": [1, 128, 128],
     "cute_flash_causal_kv_order": "ascending",
     "cute_flash_causal_loop_split": False,
@@ -38,6 +27,8 @@ _DENSE_HD64_2CTA_BASE = {
     "cute_flash_clc_heads_per_batch": 0,
     "cute_flash_clc_pdl": False,
     "cute_flash_clc_stages": 1,
+    "cute_flash_corr_regs": 72,
+    "cute_flash_corr_tile_size": 8,
     "cute_flash_disc_pipe": 1,
     "cute_flash_e2e_schedule": "16/6",
     "cute_flash_epi_stg": False,
@@ -59,7 +50,6 @@ _DENSE_HD64_2CTA_BASE = {
     "cute_flash_q_tile_count": 2,
     "cute_flash_recompute_tile_coords": False,
     "cute_flash_rescale_chunk_cols": 8,
-    "cute_flash_rescale_threshold": 8.0,
     "cute_flash_s_load_rep": 32,
     "cute_flash_s_stage": 2,
     "cute_flash_skip_rescale_stats": False,
@@ -72,8 +62,46 @@ _DENSE_HD64_2CTA_BASE = {
 }
 
 
-# Configs 3-6 are the nonpersistent two-CTA schedules tuned for the B200
-# dense_causal8 shapes in benchmarks/cute/compare_attention_backends.py.
+_LONG_DENSE_HD128_BASE = {
+    "block_sizes": [1, 128, 128],
+    "cute_flash_causal_kv_order": "ascending",
+    "cute_flash_causal_loop_split": False,
+    "cute_flash_causal_lpt_swizzle": 0,
+    "cute_flash_clc_heads_per_batch": 0,
+    "cute_flash_clc_pdl": False,
+    "cute_flash_clc_stages": 1,
+    "cute_flash_e2e_schedule": "8/2",
+    "cute_flash_epi_stg": False,
+    "cute_flash_epi_stg_gmem": "stage",
+    "cute_flash_epi_stg_store": "slice",
+    "cute_flash_epi_tma": False,
+    "cute_flash_epi_tma_setup": "shared",
+    "cute_flash_exp2_packet": "1x1",
+    "cute_flash_masked_e2e_schedule": "inherit",
+    "cute_flash_mma_interleave": True,
+    "cute_flash_p_store_rep": 16,
+    "cute_flash_packed_reduce": True,
+    "cute_flash_persistent": False,
+    "cute_flash_persistent_ctas_per_sm": 1,
+    "cute_flash_persistent_loop": "while",
+    "cute_flash_pipeline_family": "fa4_2cta",
+    "cute_flash_precompute_qk_desc": False,
+    "cute_flash_q_tile_count": 2,
+    "cute_flash_recompute_tile_coords": False,
+    "cute_flash_role_chain": False,
+    "cute_flash_s_load_rep": 32,
+    "cute_flash_s_stage": 2,
+    "cute_flash_skip_rescale_stats": False,
+    "cute_flash_small_biased": True,
+    "cute_flash_softmax_disc": True,
+    "cute_flash_softmax_regs": 192,
+    "cute_flash_softmax_setup": "shared",
+    "cute_flash_sp_row_sum": "fragment",
+    "cute_flash_split_p_arrive": True,
+    "cute_flash_stat_transport": "ring2",
+}
+
+
 _CONFIGS = [
     {
         "block_sizes": [1, 128, 128],
@@ -97,7 +125,7 @@ _CONFIGS = [
         "cute_flash_small_biased": True,
         "cute_flash_softmax_regs": 200,
         "cute_flash_topology": "fa4",
-    },
+    },  # slot 0
     {
         "block_sizes": [1, 128, 128],
         "cute_flash_causal_kv_order": "ascending",
@@ -120,7 +148,7 @@ _CONFIGS = [
         "cute_flash_small_biased": True,
         "cute_flash_softmax_regs": 200,
         "cute_flash_topology": "fa4",
-    },
+    },  # slot 1
     {
         "block_sizes": [1, 128, 128],
         "cute_flash_causal_kv_order": "ascending",
@@ -143,159 +171,111 @@ _CONFIGS = [
         "cute_flash_small_biased": True,
         "cute_flash_softmax_regs": 200,
         "cute_flash_topology": "fa4",
-    },
+    },  # slot 2
+    # Long dense head_dim=64 schedules.
     {
-        **_DENSE_HD64_2CTA_BASE,
-        "cute_flash_corr_regs": 72,
-        "cute_flash_corr_tile_size": 8,
+        **_LONG_DENSE_HD64_BASE,
         "cute_flash_e2e_offset": 0,
         "cute_flash_e2e_offset0": 1,
         "cute_flash_first_load_order": 4,
         "cute_flash_rescale_threshold": 12.0,
         "cute_flash_role_map": "fa4",
-    },
+    },  # seq_len=32768, 65536
     {
-        **_DENSE_HD64_2CTA_BASE,
-        "cute_flash_corr_regs": 72,
-        "cute_flash_corr_tile_size": 16,
-        "cute_flash_e2e_offset": 14,
-        "cute_flash_e2e_offset0": 0,
-        "cute_flash_first_load_order": 4,
-        "cute_flash_role_map": "fa4",
-    },
-    {
-        **_DENSE_HD64_2CTA_BASE,
-        "cute_flash_corr_regs": 72,
-        "cute_flash_corr_tile_size": 8,
+        **_LONG_DENSE_HD64_BASE,
         "cute_flash_e2e_offset": 0,
         "cute_flash_e2e_offset0": 0,
         "cute_flash_first_load_order": 0,
+        "cute_flash_rescale_threshold": 8.0,
         "cute_flash_role_map": "helion",
-    },
+    },  # seq_len=131072
     {
-        **_DENSE_HD64_2CTA_BASE,
-        "cute_flash_corr_regs": 72,
-        "cute_flash_corr_tile_size": 8,
+        **_LONG_DENSE_HD64_BASE,
         "cute_flash_e2e_offset": 12,
         "cute_flash_e2e_offset0": 2,
         "cute_flash_first_load_order": 4,
+        "cute_flash_rescale_threshold": 8.0,
         "cute_flash_role_map": "fa4",
-    },
-    # Long dense head_dim=128 float16 schedules for the same suite. 64K and
-    # 128K share one schedule; it beat both shapes' own autotune winners.
+    },  # seq_len=262144
+    # Long dense head_dim=128 schedules.
     {
-        **_LONG_HD128_BASE,
-        "cute_flash_causal_kv_order": "ascending",
-        "cute_flash_causal_loop_split": False,
-        "cute_flash_causal_lpt_swizzle": 0,
+        **_LONG_DENSE_HD128_BASE,
         "cute_flash_corr_regs": 64,
         "cute_flash_corr_tile_size": 16,
         "cute_flash_disc_pipe": 4,
         "cute_flash_e2e_offset": 0,
         "cute_flash_e2e_offset0": 4,
-        "cute_flash_e2e_schedule": "8/2",
-        "cute_flash_epi_stg": False,
-        "cute_flash_epi_stg_gmem": "stage",
-        "cute_flash_epi_stg_store": "slice",
-        "cute_flash_epi_tma": False,
         "cute_flash_first_load_order": 0,
         "cute_flash_kv_order": "descending",
         "cute_flash_kv_stage": 4,
-        "cute_flash_masked_e2e_schedule": "inherit",
         "cute_flash_other_regs": 64,
-        "cute_flash_persistent": False,
-        "cute_flash_persistent_ctas_per_sm": 1,
-        "cute_flash_pipeline_family": "fa4_2cta",
-        "cute_flash_precompute_qk_desc": False,
         "cute_flash_rescale_chunk_cols": 16,
         "cute_flash_rescale_threshold": 12.0,
         "cute_flash_role_map": "helion",
-        "cute_flash_s_load_rep": 32,
-        "cute_flash_softmax_disc": True,
-        "cute_flash_softmax_regs": 192,
-        "cute_flash_split_p_arrive": True,
         "cute_flash_wait_hint": 0,
     },  # seq_len=32768
     {
-        **_LONG_HD128_BASE,
-        "cute_flash_causal_kv_order": "ascending",
-        "cute_flash_causal_loop_split": False,
-        "cute_flash_causal_lpt_swizzle": 0,
+        **_LONG_DENSE_HD128_BASE,
         "cute_flash_corr_regs": 64,
-        "cute_flash_corr_tile_size": 8,
+        "cute_flash_corr_tile_size": 32,
         "cute_flash_disc_pipe": 3,
-        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset": 2,
         "cute_flash_e2e_offset0": 2,
-        "cute_flash_e2e_schedule": "8/2",
-        "cute_flash_epi_stg": False,
-        "cute_flash_epi_stg_gmem": "stage",
-        "cute_flash_epi_stg_store": "slice",
-        "cute_flash_epi_tma": False,
-        "cute_flash_first_load_order": 4,
+        "cute_flash_first_load_order": 2,
         "cute_flash_kv_order": "ascending",
-        "cute_flash_kv_stage": 3,
-        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_kv_stage": 4,
         "cute_flash_other_regs": 48,
-        "cute_flash_persistent": False,
-        "cute_flash_persistent_ctas_per_sm": 1,
-        "cute_flash_pipeline_family": "fa4_2cta",
-        "cute_flash_precompute_qk_desc": False,
-        "cute_flash_rescale_chunk_cols": 16,
-        "cute_flash_rescale_threshold": 4.0,
-        "cute_flash_role_map": "fa4",
-        "cute_flash_s_load_rep": 32,
-        "cute_flash_softmax_disc": True,
-        "cute_flash_softmax_regs": 192,
-        "cute_flash_split_p_arrive": True,
-        "cute_flash_wait_hint": 10000000,
-    },  # seq_len=65536, 131072
-    {
-        **_LONG_HD128_BASE,
-        "cute_flash_causal_kv_order": "ascending",
-        "cute_flash_causal_loop_split": False,
-        "cute_flash_causal_lpt_swizzle": 0,
-        "cute_flash_corr_regs": 64,
-        "cute_flash_corr_tile_size": 16,
-        "cute_flash_disc_pipe": 1,
-        "cute_flash_e2e_offset": 6,
-        "cute_flash_e2e_offset0": 10,
-        "cute_flash_e2e_schedule": "16/2",
-        "cute_flash_epi_stg": False,
-        "cute_flash_epi_stg_gmem": "stage",
-        "cute_flash_epi_stg_store": "slice",
-        "cute_flash_epi_tma": True,
-        "cute_flash_first_load_order": 1,
-        "cute_flash_kv_order": "descending",
-        "cute_flash_kv_stage": 2,
-        "cute_flash_masked_e2e_schedule": "inherit",
-        "cute_flash_other_regs": 64,
-        "cute_flash_persistent": True,
-        "cute_flash_persistent_ctas_per_sm": 3,
-        "cute_flash_pipeline_family": "fa4_2cta",
-        "cute_flash_precompute_qk_desc": False,
         "cute_flash_rescale_chunk_cols": 8,
         "cute_flash_rescale_threshold": 4.0,
         "cute_flash_role_map": "fa4",
-        "cute_flash_s_load_rep": 32,
-        "cute_flash_softmax_disc": False,
-        "cute_flash_softmax_regs": 184,
-        "cute_flash_split_p_arrive": False,
+        "cute_flash_wait_hint": 10000000,
+    },  # seq_len=65536
+    {
+        **_LONG_DENSE_HD128_BASE,
+        "cute_flash_corr_regs": 80,
+        "cute_flash_corr_tile_size": 16,
+        "cute_flash_disc_pipe": 4,
+        "cute_flash_e2e_offset": 3,
+        "cute_flash_e2e_offset0": 2,
+        "cute_flash_first_load_order": 4,
+        "cute_flash_kv_order": "descending",
+        "cute_flash_kv_stage": 4,
+        "cute_flash_other_regs": 48,
+        "cute_flash_rescale_chunk_cols": 16,
+        "cute_flash_rescale_threshold": 12.0,
+        "cute_flash_role_map": "helion",
         "cute_flash_wait_hint": 0,
+    },  # seq_len=131072
+    {
+        **_LONG_DENSE_HD128_BASE,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_corr_tile_size": 32,
+        "cute_flash_disc_pipe": 3,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 2,
+        "cute_flash_first_load_order": 4,
+        "cute_flash_kv_order": "ascending",
+        "cute_flash_kv_stage": 3,
+        "cute_flash_other_regs": 64,
+        "cute_flash_rescale_chunk_cols": 16,
+        "cute_flash_rescale_threshold": 8.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_wait_hint": 10000000,
     },  # seq_len=262144
 ]
 
 
 _LONG_DENSE_HD64_CONFIGS = {
     32768: 3,
-    65536: 4,
-    131072: 5,
-    262144: 6,
+    65536: 3,
+    131072: 4,
+    262144: 5,
 }
 
 
 _LONG_DENSE_HD128_CONFIGS = {
-    32768: 7,
-    65536: 8,
+    32768: 6,
+    65536: 7,
     131072: 8,
     262144: 9,
 }
@@ -306,22 +286,15 @@ def key_attention(*args: torch.Tensor) -> int:
     q = args[0]
     seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
     head_dim = int(q.shape[-1]) if isinstance(q, torch.Tensor) and q.ndim >= 1 else 0
-    if (
-        head_dim == 128
-        and q.dtype == torch.float16
-        and seq_len in _LONG_DENSE_HD128_CONFIGS
-    ):
-        return _LONG_DENSE_HD128_CONFIGS[seq_len]
+    if q.dtype == torch.float16:
+        if head_dim == 64 and seq_len in _LONG_DENSE_HD64_CONFIGS:
+            return _LONG_DENSE_HD64_CONFIGS[seq_len]
+        if head_dim == 128 and seq_len in _LONG_DENSE_HD128_CONFIGS:
+            return _LONG_DENSE_HD128_CONFIGS[seq_len]
     if head_dim >= 128:
         return 1
     if seq_len <= 4096:
         return 0
-    if (
-        head_dim == 64
-        and q.dtype == torch.float16
-        and seq_len in _LONG_DENSE_HD64_CONFIGS
-    ):
-        return _LONG_DENSE_HD64_CONFIGS[seq_len]
     return 2
 
 
@@ -330,22 +303,21 @@ def autotune_attention(*args: torch.Tensor) -> dict[str, object]:
     return _CONFIGS[key_attention(*args)]
 
 
-_CAUSAL_HD64_BASE = {
+_LONG_CAUSAL_HD64_BASE = {
     "block_sizes": [1, 128, 128],
     "cute_flash_causal_kv_order": "descending",
     "cute_flash_causal_loop_split": True,
-    "cute_flash_causal_lpt_swizzle": 0,
     "cute_flash_clc_heads_per_batch": 0,
     "cute_flash_clc_pdl": False,
     "cute_flash_clc_stages": 1,
     "cute_flash_corr_regs": 64,
-    "cute_flash_corr_tile_size": 16,
-    "cute_flash_disc_pipe": 3,
+    "cute_flash_e2e_offset": 0,
     "cute_flash_e2e_schedule": "16/6",
     "cute_flash_epi_stg": False,
     "cute_flash_epi_stg_gmem": "stage",
     "cute_flash_epi_stg_store": "slice",
     "cute_flash_exp2_packet": "deg2_16x6",
+    "cute_flash_first_load_order": 0,
     "cute_flash_kv_order": "ascending",
     "cute_flash_masked_e2e_schedule": "16/6",
     "cute_flash_mma_interleave": True,
@@ -355,11 +327,11 @@ _CAUSAL_HD64_BASE = {
     "cute_flash_persistent": False,
     "cute_flash_persistent_ctas_per_sm": 1,
     "cute_flash_pipeline_family": "fa4",
-    "cute_flash_precompute_qk_desc": False,
     "cute_flash_q_tile_count": 2,
     "cute_flash_recompute_tile_coords": False,
     "cute_flash_rescale_chunk_cols": 16,
     "cute_flash_rescale_threshold": 8.0,
+    "cute_flash_role_map": "fa4",
     "cute_flash_s_load_rep": 32,
     "cute_flash_s_stage": 2,
     "cute_flash_skip_rescale_stats": False,
@@ -371,217 +343,148 @@ _CAUSAL_HD64_BASE = {
 }
 
 
-# The best B200 one-CTA schedules found for the long causal shapes, head_dim 64
-# first and then head_dim 128. At head_dim 64 the 64K, 128K, and 256K configs
-# remain slightly behind cuDNN SDPA while 512K wins; at head_dim 128 the 64K and
-# 128K configs are ~4% behind, 256K matches, and 512K wins by ~6%. All of them
-# avoid online autotuning for the checked-in benchmark suite.
+_LONG_CAUSAL_HD128_BASE = {
+    "block_sizes": [1, 128, 128],
+    "cute_flash_causal_kv_order": "descending",
+    "cute_flash_causal_loop_split": True,
+    "cute_flash_causal_lpt_swizzle": 1,
+    "cute_flash_clc_heads_per_batch": 0,
+    "cute_flash_clc_pdl": False,
+    "cute_flash_clc_stages": 1,
+    "cute_flash_corr_regs": 80,
+    "cute_flash_disc_pipe": 1,
+    "cute_flash_e2e_schedule": "8/2",
+    "cute_flash_epi_stg_gmem": "stage",
+    "cute_flash_epi_stg_store": "slice",
+    "cute_flash_epi_tma_setup": "shared",
+    "cute_flash_exp2_packet": "1x1",
+    "cute_flash_kv_order": "ascending",
+    "cute_flash_mma_interleave": True,
+    "cute_flash_p_store_rep": 16,
+    "cute_flash_packed_reduce": True,
+    "cute_flash_persistent": False,
+    "cute_flash_persistent_ctas_per_sm": 1,
+    "cute_flash_persistent_loop": "while",
+    "cute_flash_pipeline_family": "fa4",
+    "cute_flash_precompute_qk_desc": False,
+    "cute_flash_q_tile_count": 2,
+    "cute_flash_recompute_tile_coords": False,
+    "cute_flash_role_chain": False,
+    "cute_flash_role_map": "helion",
+    "cute_flash_s_load_rep": 16,
+    "cute_flash_s_stage": 2,
+    "cute_flash_skip_rescale_stats": False,
+    "cute_flash_small_biased": True,
+    "cute_flash_softmax_disc": True,
+    "cute_flash_softmax_setup": "shared",
+    "cute_flash_sp_row_sum": "fragment",
+    "cute_flash_split_p_arrive": True,
+    "cute_flash_stat_transport": "ring2",
+    "cute_flash_wait_hint": 10000000,
+}
+
+
 _CAUSAL_CONFIGS = [
+    # Long causal head_dim=64 schedules.
     {
-        **_CAUSAL_HD64_BASE,
+        **_LONG_CAUSAL_HD64_BASE,
         "cute_flash_causal_lpt_swizzle": 0,
-        "cute_flash_disc_pipe": 3,
-        "cute_flash_e2e_offset": 0,
-        "cute_flash_e2e_offset0": 14,
-        "cute_flash_epi_tma": True,
-        "cute_flash_first_load_order": 0,
-        "cute_flash_kv_stage": 3,
-        "cute_flash_role_map": "fa4",
-        "cute_flash_softmax_regs": 200,
-    },
-    {
-        **_CAUSAL_HD64_BASE,
-        "cute_flash_e2e_offset": 1,
-        "cute_flash_e2e_offset0": 14,
-        "cute_flash_epi_tma": True,
-        "cute_flash_first_load_order": 0,
-        "cute_flash_kv_stage": 2,
-        "cute_flash_role_map": "fa4",
-        "cute_flash_softmax_regs": 192,
-    },
-    {
-        **_CAUSAL_HD64_BASE,
-        "cute_flash_e2e_offset": 0,
-        "cute_flash_e2e_offset0": 15,
-        "cute_flash_epi_tma": False,
-        "cute_flash_first_load_order": 0,
-        "cute_flash_kv_stage": 4,
-        "cute_flash_role_map": "helion",
-        "cute_flash_softmax_regs": 192,
-        "cute_flash_wait_hint": 10000000,
-    },
-    {
-        **_CAUSAL_HD64_BASE,
-        "cute_flash_e2e_offset": 14,
-        "cute_flash_e2e_offset0": 12,
-        "cute_flash_epi_tma": False,
-        "cute_flash_first_load_order": 0,
-        "cute_flash_kv_stage": 2,
-        "cute_flash_role_map": "helion",
-        "cute_flash_softmax_regs": 184,
-        "cute_flash_wait_hint": 10000000,
-    },
-    # Long causal head_dim=128 float16 schedules for the same suite.
-    {
-        **_LONG_HD128_BASE,
-        "cute_flash_causal_kv_order": "descending",
-        "cute_flash_causal_loop_split": True,
-        "cute_flash_causal_lpt_swizzle": 1,
-        "cute_flash_corr_regs": 80,
         "cute_flash_corr_tile_size": 16,
-        "cute_flash_disc_pipe": 1,
+        "cute_flash_disc_pipe": 3,
+        "cute_flash_e2e_offset0": 14,
+        "cute_flash_epi_tma": True,
+        "cute_flash_kv_stage": 3,
+        "cute_flash_precompute_qk_desc": False,
+        "cute_flash_softmax_regs": 200,
+    },  # seq_len=65536
+    {
+        **_LONG_CAUSAL_HD64_BASE,
+        "cute_flash_causal_lpt_swizzle": 1,
+        "cute_flash_corr_tile_size": 8,
+        "cute_flash_disc_pipe": 2,
+        "cute_flash_e2e_offset0": 13,
+        "cute_flash_epi_tma": False,
+        "cute_flash_epi_tma_setup": "shared",
+        "cute_flash_kv_stage": 2,
+        "cute_flash_persistent_loop": "while",
+        "cute_flash_precompute_qk_desc": True,
+        "cute_flash_role_chain": False,
+        "cute_flash_softmax_regs": 192,
+        "cute_flash_softmax_setup": "shared",
+        "cute_flash_sp_row_sum": "fragment",
+    },  # seq_len=131072, 262144, 524288
+    # Long causal head_dim=128 schedules.
+    {
+        **_LONG_CAUSAL_HD128_BASE,
+        "cute_flash_corr_tile_size": 16,
         "cute_flash_e2e_offset": 0,
         "cute_flash_e2e_offset0": 2,
-        "cute_flash_e2e_schedule": "8/2",
         "cute_flash_epi_stg": True,
-        "cute_flash_epi_stg_gmem": "stage",
-        "cute_flash_epi_stg_store": "slice",
         "cute_flash_epi_tma": False,
         "cute_flash_first_load_order": 4,
-        "cute_flash_kv_order": "ascending",
         "cute_flash_kv_stage": 3,
         "cute_flash_masked_e2e_schedule": "inherit",
         "cute_flash_other_regs": 32,
-        "cute_flash_persistent": False,
-        "cute_flash_persistent_ctas_per_sm": 1,
-        "cute_flash_pipeline_family": "fa4",
-        "cute_flash_precompute_qk_desc": False,
         "cute_flash_rescale_chunk_cols": 32,
         "cute_flash_rescale_threshold": 12.0,
-        "cute_flash_role_map": "helion",
-        "cute_flash_s_load_rep": 16,
-        "cute_flash_softmax_disc": True,
         "cute_flash_softmax_regs": 176,
-        "cute_flash_split_p_arrive": True,
-        "cute_flash_wait_hint": 10000000,
     },  # seq_len=65536
     {
-        **_LONG_HD128_BASE,
-        "cute_flash_causal_kv_order": "descending",
-        "cute_flash_causal_loop_split": True,
-        "cute_flash_causal_lpt_swizzle": 1,
-        "cute_flash_corr_regs": 80,
-        "cute_flash_corr_tile_size": 16,
-        "cute_flash_disc_pipe": 1,
-        "cute_flash_e2e_offset": 1,
-        "cute_flash_e2e_offset0": 15,
-        "cute_flash_e2e_schedule": "8/2",
-        "cute_flash_epi_stg": True,
-        "cute_flash_epi_stg_gmem": "pair",
-        "cute_flash_epi_stg_store": "whole",
-        "cute_flash_epi_tma": False,
+        **_LONG_CAUSAL_HD128_BASE,
+        "cute_flash_corr_tile_size": 32,
+        "cute_flash_e2e_offset": 5,
+        "cute_flash_e2e_offset0": 3,
+        "cute_flash_epi_stg": False,
+        "cute_flash_epi_tma": True,
         "cute_flash_first_load_order": 0,
-        "cute_flash_kv_order": "ascending",
         "cute_flash_kv_stage": 2,
-        "cute_flash_masked_e2e_schedule": "16/4",
-        "cute_flash_other_regs": 64,
-        "cute_flash_persistent": False,
-        "cute_flash_persistent_ctas_per_sm": 1,
-        "cute_flash_pipeline_family": "fa4",
-        "cute_flash_precompute_qk_desc": False,
+        "cute_flash_masked_e2e_schedule": "xu",
+        "cute_flash_other_regs": 40,
         "cute_flash_rescale_chunk_cols": 16,
         "cute_flash_rescale_threshold": 8.0,
-        "cute_flash_role_map": "fa4",
-        "cute_flash_s_load_rep": 16,
-        "cute_flash_softmax_disc": True,
         "cute_flash_softmax_regs": 184,
-        "cute_flash_split_p_arrive": True,
-        "cute_flash_wait_hint": 10000000,
-    },  # seq_len=131072
+    },  # seq_len=131072, 524288
     {
-        **_LONG_HD128_BASE,
-        "cute_flash_causal_kv_order": "ascending",
-        "cute_flash_causal_loop_split": False,
-        "cute_flash_causal_lpt_swizzle": 1,
-        "cute_flash_corr_regs": 88,
+        **_LONG_CAUSAL_HD128_BASE,
         "cute_flash_corr_tile_size": 16,
-        "cute_flash_disc_pipe": 1,
-        "cute_flash_e2e_offset": 1,
-        "cute_flash_e2e_offset0": 5,
-        "cute_flash_e2e_schedule": "8/2",
-        "cute_flash_epi_stg": True,
-        "cute_flash_epi_stg_gmem": "stage",
-        "cute_flash_epi_stg_store": "whole",
-        "cute_flash_epi_tma": False,
-        "cute_flash_first_load_order": 2,
-        "cute_flash_kv_order": "ascending",
-        "cute_flash_kv_stage": 2,
-        "cute_flash_masked_e2e_schedule": "inherit",
-        "cute_flash_other_regs": 40,
-        "cute_flash_persistent": False,
-        "cute_flash_persistent_ctas_per_sm": 1,
-        "cute_flash_pipeline_family": "fa4",
-        "cute_flash_precompute_qk_desc": True,
-        "cute_flash_rescale_chunk_cols": 32,
-        "cute_flash_rescale_threshold": 4.0,
-        "cute_flash_role_map": "helion",
-        "cute_flash_s_load_rep": 16,
-        "cute_flash_softmax_disc": True,
-        "cute_flash_softmax_regs": 176,
-        "cute_flash_split_p_arrive": True,
-        "cute_flash_wait_hint": 10000000,
-    },  # seq_len=262144
-    {
-        **_LONG_HD128_BASE,
-        "cute_flash_causal_kv_order": "descending",
-        "cute_flash_causal_loop_split": True,
-        "cute_flash_causal_lpt_swizzle": 1,
-        "cute_flash_corr_regs": 80,
-        "cute_flash_corr_tile_size": 32,
-        "cute_flash_disc_pipe": 1,
-        "cute_flash_e2e_offset": 3,
-        "cute_flash_e2e_offset0": 4,
-        "cute_flash_e2e_schedule": "16/4",
+        "cute_flash_e2e_offset": 2,
+        "cute_flash_e2e_offset0": 2,
         "cute_flash_epi_stg": False,
-        "cute_flash_epi_stg_gmem": "stage",
-        "cute_flash_epi_stg_store": "slice",
         "cute_flash_epi_tma": True,
         "cute_flash_first_load_order": 4,
-        "cute_flash_kv_order": "ascending",
         "cute_flash_kv_stage": 2,
-        "cute_flash_masked_e2e_schedule": "16/4",
-        "cute_flash_other_regs": 64,
-        "cute_flash_persistent": False,
-        "cute_flash_persistent_ctas_per_sm": 1,
-        "cute_flash_pipeline_family": "fa4",
-        "cute_flash_precompute_qk_desc": True,
-        "cute_flash_rescale_chunk_cols": 8,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_other_regs": 56,
+        "cute_flash_rescale_chunk_cols": 32,
         "cute_flash_rescale_threshold": 12.0,
-        "cute_flash_role_map": "helion",
-        "cute_flash_s_load_rep": 32,
-        "cute_flash_softmax_disc": True,
         "cute_flash_softmax_regs": 176,
-        "cute_flash_split_p_arrive": True,
-        "cute_flash_wait_hint": 0,
-    },  # seq_len=524288
+    },  # seq_len=262144
 ]
 
 _CAUSAL_HD64_CONFIGS = {
     65536: 0,
     131072: 1,
-    262144: 2,
-    524288: 3,
+    262144: 1,
+    524288: 1,
 }
 
 
 _CAUSAL_HD128_CONFIGS = {
-    65536: 4,
-    131072: 5,
-    262144: 6,
-    524288: 7,
+    65536: 2,
+    131072: 3,
+    262144: 4,
+    524288: 3,
 }
 
 
 def key_causal_attention(*args: torch.Tensor) -> int:
-    """Select the exact B200 long-sequence causal config."""
+    """Select the B200 long-sequence causal config."""
     q = args[0]
     seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
     head_dim = int(q.shape[-1]) if isinstance(q, torch.Tensor) and q.ndim >= 1 else 0
-    if head_dim == 128 and q.dtype == torch.float16:
-        return _CAUSAL_HD128_CONFIGS.get(seq_len, 4)
-    if head_dim == 64 and q.dtype == torch.float16:
-        return _CAUSAL_HD64_CONFIGS.get(seq_len, 0)
-    return 0
+    if q.dtype == torch.float16 and head_dim == 128:
+        return _CAUSAL_HD128_CONFIGS.get(seq_len, 2)
+    return _CAUSAL_HD64_CONFIGS.get(seq_len, 0)
 
 
 def autotune_causal_attention(*args: torch.Tensor) -> dict[str, object]:

--- a/pretuned_kernels/attention/_helion_aot_attention_cuda_sm103.py
+++ b/pretuned_kernels/attention/_helion_aot_attention_cuda_sm103.py
@@ -1,0 +1,201 @@
+"""GB300 configs for the CuTe flash attention kernel."""
+
+from __future__ import annotations
+
+import torch
+
+_DENSE_HD64_2CTA_BASE = {
+    "block_sizes": [1, 128, 128],
+    "cute_flash_causal_kv_order": "ascending",
+    "cute_flash_causal_loop_split": False,
+    "cute_flash_causal_lpt_swizzle": 0,
+    "cute_flash_clc_heads_per_batch": 0,
+    "cute_flash_clc_pdl": False,
+    "cute_flash_clc_stages": 1,
+    "cute_flash_disc_pipe": 1,
+    "cute_flash_epi_stg": False,
+    "cute_flash_epi_stg_gmem": "stage",
+    "cute_flash_epi_stg_store": "slice",
+    "cute_flash_epi_tma": True,
+    "cute_flash_kv_order": "descending",
+    "cute_flash_kv_stage": 6,
+    "cute_flash_masked_e2e_schedule": "inherit",
+    "cute_flash_mma_interleave": True,
+    "cute_flash_p_store_rep": 16,
+    "cute_flash_packed_reduce": True,
+    "cute_flash_persistent": False,
+    "cute_flash_persistent_ctas_per_sm": 1,
+    "cute_flash_pipeline_family": "fa4_2cta",
+    "cute_flash_precompute_qk_desc": True,
+    "cute_flash_q_tile_count": 2,
+    "cute_flash_recompute_tile_coords": False,
+    "cute_flash_rescale_chunk_cols": 8,
+    "cute_flash_rescale_threshold": 8.0,
+    "cute_flash_role_map": "helion",
+    "cute_flash_s_load_rep": 32,
+    "cute_flash_s_stage": 2,
+    "cute_flash_skip_rescale_stats": False,
+    "cute_flash_small_biased": True,
+    "cute_flash_softmax_disc": False,
+    "cute_flash_split_p_arrive": True,
+    "cute_flash_wait_hint": 10000000,
+}
+
+
+# Configs 3-6 are the nonpersistent two-CTA schedules used by the comparison
+# harness's long dense suite. Two CTAs cooperate on 256 query rows and share
+# each K/V fetch, which is the winning schedule family for these shapes.
+_CONFIGS = [
+    {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_disc_pipe": 4,
+        "cute_flash_e2e_offset": 2,
+        "cute_flash_e2e_offset0": 0,
+        "cute_flash_e2e_schedule": "16/4",
+        "cute_flash_epi_tma": False,
+        "cute_flash_kv_stage": 3,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_packed_reduce": False,
+        "cute_flash_persistent": True,
+        "cute_flash_rescale_chunk_cols": 32,
+        "cute_flash_rescale_threshold": 8.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_stage": 2,
+        "cute_flash_small_biased": True,
+        "cute_flash_softmax_regs": 200,
+        "cute_flash_topology": "fa4",
+    },
+    {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_disc_pipe": 2,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 0,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_epi_tma": True,
+        "cute_flash_kv_stage": 3,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_packed_reduce": False,
+        "cute_flash_persistent": True,
+        "cute_flash_rescale_chunk_cols": 16,
+        "cute_flash_rescale_threshold": 8.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_stage": 2,
+        "cute_flash_small_biased": True,
+        "cute_flash_softmax_regs": 200,
+        "cute_flash_topology": "fa4",
+    },
+    {
+        "block_sizes": [1, 128, 128],
+        "cute_flash_causal_kv_order": "ascending",
+        "cute_flash_causal_loop_split": False,
+        "cute_flash_causal_lpt_swizzle": 0,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_disc_pipe": 3,
+        "cute_flash_e2e_offset": 2,
+        "cute_flash_e2e_offset0": 0,
+        "cute_flash_e2e_schedule": "16/4",
+        "cute_flash_epi_tma": False,
+        "cute_flash_kv_stage": 2,
+        "cute_flash_masked_e2e_schedule": "inherit",
+        "cute_flash_packed_reduce": True,
+        "cute_flash_persistent": True,
+        "cute_flash_rescale_chunk_cols": 32,
+        "cute_flash_rescale_threshold": 8.0,
+        "cute_flash_role_map": "helion",
+        "cute_flash_s_stage": 2,
+        "cute_flash_small_biased": True,
+        "cute_flash_softmax_regs": 200,
+        "cute_flash_topology": "fa4",
+    },
+    {
+        **_DENSE_HD64_2CTA_BASE,
+        "cute_flash_corr_regs": 64,
+        "cute_flash_corr_tile_size": 8,
+        "cute_flash_e2e_offset": 5,
+        "cute_flash_e2e_offset0": 1,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_exp2_packet": "deg1_8x2_corr10",
+        "cute_flash_first_load_order": 0,
+        "cute_flash_other_regs": 40,
+        "cute_flash_softmax_regs": 200,
+        "cute_flash_stat_transport": "single",
+    },
+    {
+        **_DENSE_HD64_2CTA_BASE,
+        "cute_flash_corr_regs": 72,
+        "cute_flash_corr_tile_size": 16,
+        "cute_flash_e2e_offset": 2,
+        "cute_flash_e2e_offset0": 1,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_exp2_packet": "deg1_8x2_corr10",
+        "cute_flash_first_load_order": 4,
+        "cute_flash_other_regs": 40,
+        "cute_flash_role_map": "fa4",
+        "cute_flash_softmax_regs": 200,
+        "cute_flash_stat_transport": "single",
+    },
+    {
+        **_DENSE_HD64_2CTA_BASE,
+        "cute_flash_corr_regs": 72,
+        "cute_flash_corr_tile_size": 8,
+        "cute_flash_e2e_offset": 2,
+        "cute_flash_e2e_offset0": 1,
+        "cute_flash_e2e_schedule": "8/2",
+        "cute_flash_exp2_packet": "deg1_8x2_corr10",
+        "cute_flash_first_load_order": 0,
+        "cute_flash_other_regs": 40,
+        "cute_flash_softmax_regs": 200,
+        "cute_flash_stat_transport": "single",
+    },
+    {
+        **_DENSE_HD64_2CTA_BASE,
+        "cute_flash_corr_regs": 80,
+        "cute_flash_corr_tile_size": 8,
+        "cute_flash_e2e_offset": 0,
+        "cute_flash_e2e_offset0": 10,
+        "cute_flash_e2e_schedule": "16/8",
+        "cute_flash_exp2_packet": "deg1_16x8",
+        "cute_flash_first_load_order": 4,
+        "cute_flash_other_regs": 32,
+        "cute_flash_softmax_regs": 192,
+        "cute_flash_stat_transport": "single_final",
+    },
+]
+
+_LONG_DENSE_HD64_CONFIGS = {
+    32768: 3,
+    65536: 4,
+    131072: 5,
+    262144: 6,
+}
+
+
+def key_attention(*args: torch.Tensor) -> int:
+    """Select a config from the query sequence length and head dimension."""
+    q = args[0]
+    seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
+    head_dim = int(q.shape[-1]) if isinstance(q, torch.Tensor) and q.ndim >= 1 else 0
+    if head_dim >= 128:
+        return 1
+    if seq_len <= 4096:
+        return 0
+    if (
+        head_dim == 64
+        and q.dtype == torch.float16
+        and seq_len in _LONG_DENSE_HD64_CONFIGS
+    ):
+        return _LONG_DENSE_HD64_CONFIGS[seq_len]
+    return 2
+
+
+def autotune_attention(*args: torch.Tensor) -> dict[str, object]:
+    """Return the checked-in GB300 config for the given attention shape."""
+    return _CONFIGS[key_attention(*args)]

--- a/pretuned_kernels/attention/_helion_aot_attention_cuda_sm103.py
+++ b/pretuned_kernels/attention/_helion_aot_attention_cuda_sm103.py
@@ -199,3 +199,113 @@ def key_attention(*args: torch.Tensor) -> int:
 def autotune_attention(*args: torch.Tensor) -> dict[str, object]:
     """Return the checked-in GB300 config for the given attention shape."""
     return _CONFIGS[key_attention(*args)]
+
+
+_CAUSAL_HD64_BASE = {
+    "block_sizes": [1, 128, 128],
+    "cute_flash_causal_kv_order": "descending",
+    "cute_flash_causal_loop_split": True,
+    "cute_flash_causal_lpt_swizzle": 0,
+    "cute_flash_clc_heads_per_batch": 0,
+    "cute_flash_clc_pdl": False,
+    "cute_flash_clc_stages": 1,
+    "cute_flash_corr_regs": 64,
+    "cute_flash_corr_tile_size": 16,
+    "cute_flash_disc_pipe": 3,
+    "cute_flash_e2e_schedule": "16/6",
+    "cute_flash_epi_stg": False,
+    "cute_flash_epi_stg_gmem": "stage",
+    "cute_flash_epi_stg_store": "slice",
+    "cute_flash_exp2_packet": "deg2_16x6",
+    "cute_flash_kv_order": "ascending",
+    "cute_flash_masked_e2e_schedule": "16/6",
+    "cute_flash_mma_interleave": True,
+    "cute_flash_other_regs": 48,
+    "cute_flash_p_store_rep": 16,
+    "cute_flash_packed_reduce": True,
+    "cute_flash_persistent": False,
+    "cute_flash_persistent_ctas_per_sm": 1,
+    "cute_flash_pipeline_family": "fa4",
+    "cute_flash_precompute_qk_desc": False,
+    "cute_flash_q_tile_count": 2,
+    "cute_flash_recompute_tile_coords": False,
+    "cute_flash_rescale_chunk_cols": 16,
+    "cute_flash_rescale_threshold": 8.0,
+    "cute_flash_s_load_rep": 32,
+    "cute_flash_s_stage": 2,
+    "cute_flash_skip_rescale_stats": False,
+    "cute_flash_small_biased": True,
+    "cute_flash_softmax_disc": True,
+    "cute_flash_split_p_arrive": True,
+    "cute_flash_stat_transport": "ring2",
+    "cute_flash_wait_hint": 0,
+}
+
+
+# The four one-CTA causal schedules from the comparison harness's
+# dense_causal8 suite. Unlike the dense winners, these use diagonal-first
+# traversal and split masked/unmasked loops.
+_CAUSAL_CONFIGS = [
+    {
+        **_CAUSAL_HD64_BASE,
+        "cute_flash_e2e_offset": 15,
+        "cute_flash_e2e_offset0": 3,
+        "cute_flash_epi_tma": True,
+        "cute_flash_first_load_order": 2,
+        "cute_flash_kv_stage": 8,
+        "cute_flash_role_map": "fa4",
+        "cute_flash_softmax_regs": 200,
+    },
+    {
+        **_CAUSAL_HD64_BASE,
+        "cute_flash_e2e_offset": 1,
+        "cute_flash_e2e_offset0": 14,
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_kv_stage": 3,
+        "cute_flash_role_map": "fa4",
+        "cute_flash_softmax_regs": 184,
+    },
+    {
+        **_CAUSAL_HD64_BASE,
+        "cute_flash_e2e_offset": 14,
+        "cute_flash_e2e_offset0": 12,
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_kv_stage": 3,
+        "cute_flash_role_map": "fa4",
+        "cute_flash_softmax_regs": 184,
+    },
+    {
+        **_CAUSAL_HD64_BASE,
+        "cute_flash_e2e_offset": 14,
+        "cute_flash_e2e_offset0": 12,
+        "cute_flash_epi_tma": False,
+        "cute_flash_first_load_order": 0,
+        "cute_flash_kv_stage": 6,
+        "cute_flash_role_map": "helion",
+        "cute_flash_softmax_regs": 184,
+    },
+]
+
+_CAUSAL_HD64_CONFIGS = {
+    65536: 0,
+    131072: 1,
+    262144: 2,
+    524288: 3,
+}
+
+
+def key_causal_attention(*args: torch.Tensor) -> int:
+    """Select the exact long-sequence causal config."""
+    q = args[0]
+    seq_len = int(q.shape[-2]) if isinstance(q, torch.Tensor) and q.ndim >= 2 else 0
+    head_dim = int(q.shape[-1]) if isinstance(q, torch.Tensor) and q.ndim >= 1 else 0
+    if head_dim == 64 and q.dtype == torch.float16:
+        return _CAUSAL_HD64_CONFIGS.get(seq_len, 0)
+    return 0
+
+
+def autotune_causal_attention(*args: torch.Tensor) -> dict[str, object]:
+    """Return the checked-in GB300 causal config for the given shape."""
+    return _CAUSAL_CONFIGS[key_causal_attention(*args)]

--- a/pretuned_kernels/attention/attention.py
+++ b/pretuned_kernels/attention/attention.py
@@ -1,9 +1,10 @@
-"""Scaled dot-product attention for the B200 CuTe flash backend.
+"""Scaled dot-product attention for the B200/GB300 CuTe flash backend.
 
 This is the output-only dense attention kernel from ``examples/attention.py``.
 It is pretuned for the non-causal shapes used by
 ``benchmarks/cute/compare_attention_backends.py`` and compares against a single
-cuDNN SDPA baseline.
+cuDNN SDPA baseline.  On GB300 the default sweep uses the long dense sequence
+lengths whose nonpersistent two-CTA schedules outperform SDPA.
 """
 
 from __future__ import annotations
@@ -71,15 +72,38 @@ def attention(
     return out.view(q_in.size())
 
 
-# Non-causal dense shapes from benchmarks/cute/compare_attention_backends.py.
-SHAPES = [
+AttentionShape = tuple[int, int, int, int, torch.dtype]
+
+
+# Original B200 representative sweep.
+B200_SHAPES: tuple[AttentionShape, ...] = (
     (1, 4, 512, 64, torch.float16),
     (2, 8, 512, 64, torch.float16),
     (2, 32, 1024, 64, torch.float16),
     (2, 32, 2048, 64, torch.float16),
     (4, 32, 4096, 128, torch.bfloat16),
     (8, 32, 8192, 128, torch.bfloat16),
-]
+)
+
+# Non-causal half of the comparison harness's dense_causal8 suite. Each shape
+# selects a distinct sm103 nonpersistent two-CTA config.
+GB300_SHAPES: tuple[AttentionShape, ...] = (
+    (2, 32, 32768, 64, torch.float16),
+    (2, 32, 65536, 64, torch.float16),
+    (2, 32, 131072, 64, torch.float16),
+    (2, 32, 262144, 64, torch.float16),
+)
+
+
+def _benchmark_spec(
+    compute_capability: tuple[int, int],
+) -> tuple[tuple[AttentionShape, ...], int]:
+    """Return the target-specific shapes and CUDA-graph repetitions."""
+    if compute_capability == (10, 3):
+        # These kernels take up to roughly one second, so ten samples are
+        # sufficient and keep the standalone sweep practical.
+        return GB300_SHAPES, 10
+    return B200_SHAPES, 200
 
 
 def _make_inputs(
@@ -104,11 +128,18 @@ def use_cudagraph() -> bool:
 def correctness_check() -> None:
     """Check every checked-in config branch against cuDNN SDPA."""
     torch.manual_seed(0)
-    shapes = (
+    shapes: tuple[AttentionShape, ...] = (
         (1, 2, 256, 64, torch.float16),
         (1, 2, 256, 128, torch.bfloat16),
         (1, 1, 8192, 64, torch.float16),
     )
+    if torch.cuda.get_device_capability() == (10, 3):
+        # Exercise all four sm103 long-sequence selectors with a small
+        # batch/head count so correctness does not require the benchmark's
+        # full-size allocation.
+        shapes += tuple(
+            (1, 1, seq, 64, torch.float16) for seq in (32768, 65536, 131072, 262144)
+        )
     for shape in shapes:
         args = _make_inputs(*shape)
         actual = attention(*args)
@@ -123,7 +154,9 @@ def main(verbose: bool = True) -> dict:
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from _bench import run_sweep  # pyrefly: ignore[missing-import]
 
-    def make_calls(shape: tuple[int, int, int, int, torch.dtype]) -> tuple:
+    shapes, rep = _benchmark_spec(torch.cuda.get_device_capability())
+
+    def make_calls(shape: AttentionShape) -> tuple:
         z, h, seq_len, head_dim, dtype = shape
         q, k, v = _make_inputs(z, h, seq_len, head_dim, dtype)
 
@@ -140,11 +173,11 @@ def main(verbose: bool = True) -> dict:
         )
 
     return run_sweep(
-        SHAPES,
+        shapes,
         make_calls,
         use_cudagraph=use_cudagraph(),
         warmup=50,
-        rep=200,
+        rep=rep,
         verbose=verbose,
         shape_header=f"{'z':>2s}  {'h':>3s}  {'seq':>6s}  {'d':>4s}",
     )

--- a/pretuned_kernels/attention/attention.py
+++ b/pretuned_kernels/attention/attention.py
@@ -192,8 +192,8 @@ def correctness_check() -> None:
         ((1, 2, 256, 128, torch.bfloat16, False), attention),
         ((1, 1, 8192, 64, torch.float16, False), attention),
     )
-    if torch.cuda.get_device_capability() == (10, 3):
-        # Exercise all eight sm103 long-sequence selectors with a small
+    if torch.cuda.get_device_capability() in ((10, 0), (10, 3)):
+        # Exercise all eight SM100/SM103 long-sequence selectors with a small
         # batch/head count so correctness does not require the benchmark's
         # full-size allocation.
         checks += tuple(
@@ -235,8 +235,10 @@ def main(verbose: bool = True) -> dict:
         return (
             helion_call,
             [("sdpa", sdpa_call)],
-            f"{'causal' if is_causal else 'dense':>6s}  "
-            f"{z:>2d}  {h:>3d}  {seq_len:>6d}  {head_dim:>4d}",
+            (
+                f"{'causal' if is_causal else 'dense':>6s}  "
+                f"{z:>2d}  {h:>3d}  {seq_len:>6d}  {head_dim:>4d}"
+            ),
         )
 
     return run_sweep(

--- a/pretuned_kernels/attention/attention.py
+++ b/pretuned_kernels/attention/attention.py
@@ -1,0 +1,155 @@
+"""Scaled dot-product attention for the B200 CuTe flash backend.
+
+This is the output-only dense attention kernel from ``examples/attention.py``.
+It is pretuned for the non-causal shapes used by
+``benchmarks/cute/compare_attention_backends.py`` and compares against a single
+cuDNN SDPA baseline.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+import helion
+import helion.language as hl
+
+
+def _attention_sdpa(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> torch.Tensor:
+    """Run the same cuDNN SDPA baseline as the backend comparison harness."""
+    with torch.nn.attention.sdpa_kernel(
+        [torch.nn.attention.SDPBackend.CUDNN_ATTENTION]
+    ):
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+
+@helion.aot_kernel(backend="cute", static_shapes=True)
+def attention(
+    q_in: torch.Tensor,
+    k_in: torch.Tensor,
+    v_in: torch.Tensor,
+) -> torch.Tensor:
+    """Compute dense scaled dot-product attention without an auxiliary LSE."""
+    m_dim = q_in.size(-2)
+    n_dim = k_in.size(-2)
+    assert n_dim == v_in.size(-2)
+    head_dim = hl.specialize(q_in.size(-1))
+    assert head_dim == k_in.size(-1) == v_in.size(-1)
+    q_view = q_in.reshape([-1, m_dim, head_dim])
+    v_view = v_in.reshape([-1, n_dim, head_dim])
+    k_view = k_in.reshape([-1, n_dim, head_dim])
+    out = torch.empty_like(q_view)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    qk_scale = sm_scale * 1.44269504  # 1/log(2)
+    for tile_b, tile_m in hl.tile([q_view.size(0), m_dim]):
+        m_i = hl.full([tile_b, tile_m], float("-inf"), dtype=torch.float32)
+        l_i = torch.full_like(m_i, 1.0)
+        acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+        q = q_view[tile_b, tile_m, :]
+        for tile_n in hl.tile(v_view.size(1)):
+            q_scaled = q * qk_scale
+            k = k_view[tile_b, tile_n, :]
+            qk = torch.bmm(q_scaled, k.transpose(1, 2), torch.float32)
+            m_ij = torch.maximum(m_i, torch.amax(qk, -1))
+            qk = qk - m_ij[:, :, None]
+            p = torch.exp2(qk)
+            l_ij = torch.sum(p, -1)
+            alpha = torch.exp2(m_i - m_ij)
+            l_i = l_i * alpha + l_ij
+            acc = acc * alpha[:, :, None]
+            v = v_view[tile_b, tile_n, :]
+            p = p.to(v.dtype)
+            acc = torch.baddbmm(acc, p, v)
+            m_i = m_ij
+        acc = acc / l_i[:, :, None]
+        out[tile_b, tile_m, :] = acc.to(out.dtype)
+    return out.view(q_in.size())
+
+
+# Non-causal dense shapes from benchmarks/cute/compare_attention_backends.py.
+SHAPES = [
+    (1, 4, 512, 64, torch.float16),
+    (2, 8, 512, 64, torch.float16),
+    (2, 32, 1024, 64, torch.float16),
+    (2, 32, 2048, 64, torch.float16),
+    (4, 32, 4096, 128, torch.bfloat16),
+    (8, 32, 8192, 128, torch.bfloat16),
+]
+
+
+def _make_inputs(
+    z: int,
+    h: int,
+    seq_len: int,
+    head_dim: int,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    shape = (z, h, seq_len, head_dim)
+    q = torch.randn(shape, device="cuda", dtype=dtype)
+    k = torch.randn(shape, device="cuda", dtype=dtype)
+    v = torch.randn(shape, device="cuda", dtype=dtype)
+    return q, k, v
+
+
+def use_cudagraph() -> bool:
+    """Benchmark kernel-only latency without CuTe AOT dispatch overhead."""
+    return True
+
+
+def correctness_check() -> None:
+    """Check every checked-in config branch against cuDNN SDPA."""
+    torch.manual_seed(0)
+    shapes = (
+        (1, 2, 256, 64, torch.float16),
+        (1, 2, 256, 128, torch.bfloat16),
+        (1, 1, 8192, 64, torch.float16),
+    )
+    for shape in shapes:
+        args = _make_inputs(*shape)
+        actual = attention(*args)
+        expected = _attention_sdpa(*args)
+        torch.testing.assert_close(actual, expected, atol=5e-2, rtol=2e-2)
+
+
+def main(verbose: bool = True) -> dict:
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep  # pyrefly: ignore[missing-import]
+
+    def make_calls(shape: tuple[int, int, int, int, torch.dtype]) -> tuple:
+        z, h, seq_len, head_dim, dtype = shape
+        q, k, v = _make_inputs(z, h, seq_len, head_dim, dtype)
+
+        def helion_call() -> torch.Tensor:
+            return attention(q, k, v)
+
+        def sdpa_call() -> torch.Tensor:
+            return _attention_sdpa(q, k, v)
+
+        return (
+            helion_call,
+            [("sdpa", sdpa_call)],
+            f"{z:>2d}  {h:>3d}  {seq_len:>6d}  {head_dim:>4d}",
+        )
+
+    return run_sweep(
+        SHAPES,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        warmup=50,
+        rep=200,
+        verbose=verbose,
+        shape_header=f"{'z':>2s}  {'h':>3s}  {'seq':>6s}  {'d':>4s}",
+    )
+
+
+if __name__ == "__main__":
+    correctness_check()
+    main()

--- a/pretuned_kernels/attention/attention.py
+++ b/pretuned_kernels/attention/attention.py
@@ -1,10 +1,10 @@
 """Scaled dot-product attention for the B200/GB300 CuTe flash backend.
 
-This is the output-only dense attention kernel from ``examples/attention.py``.
-It is pretuned for the non-causal shapes used by
-``benchmarks/cute/compare_attention_backends.py`` and compares against a single
-cuDNN SDPA baseline.  On GB300 the default sweep uses the long dense sequence
-lengths whose nonpersistent two-CTA schedules outperform SDPA.
+These are the output-only dense and causal attention kernels from
+``examples/attention.py``. They are pretuned for shapes used by
+``benchmarks/cute/compare_attention_backends.py`` and compare against a single
+cuDNN SDPA baseline. On GB300 the default sweep uses the long dense and causal
+sequence lengths from that benchmark's eight-shape comparison.
 """
 
 from __future__ import annotations
@@ -21,12 +21,16 @@ def _attention_sdpa(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
+    *,
+    is_causal: bool = False,
 ) -> torch.Tensor:
     """Run the same cuDNN SDPA baseline as the backend comparison harness."""
     with torch.nn.attention.sdpa_kernel(
         [torch.nn.attention.SDPBackend.CUDNN_ATTENTION]
     ):
-        return torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        return torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, is_causal=is_causal
+        )
 
 
 @helion.aot_kernel(backend="cute", static_shapes=True)
@@ -72,26 +76,81 @@ def attention(
     return out.view(q_in.size())
 
 
-AttentionShape = tuple[int, int, int, int, torch.dtype]
+@helion.aot_kernel(backend="cute", static_shapes=True)
+def causal_attention(
+    q_in: torch.Tensor,
+    k_in: torch.Tensor,
+    v_in: torch.Tensor,
+) -> torch.Tensor:
+    """Compute causal scaled dot-product attention without an auxiliary LSE."""
+    m_dim = q_in.size(-2)
+    n_dim = k_in.size(-2)
+    assert n_dim == v_in.size(-2)
+    head_dim = hl.specialize(q_in.size(-1))
+    assert head_dim == k_in.size(-1) == v_in.size(-1)
+    q_view = q_in.reshape([-1, m_dim, head_dim])
+    v_view = v_in.reshape([-1, n_dim, head_dim])
+    k_view = k_in.reshape([-1, n_dim, head_dim])
+    out = torch.empty_like(q_view)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    qk_scale = sm_scale * 1.44269504  # 1/log(2)
+    for tile_b, tile_m in hl.tile([q_view.size(0), m_dim]):
+        m_i = hl.full([tile_b, tile_m], float("-inf"), dtype=torch.float32)
+        l_i = torch.full_like(m_i, 1.0)
+        acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+        q = q_view[tile_b, tile_m, :]
+        for tile_n in hl.tile(v_view.size(1)):
+            q_scaled = q * qk_scale
+            k = k_view[tile_b, tile_n, :]
+            qk = torch.bmm(q_scaled, k.transpose(1, 2), torch.float32)
+            qk = torch.where(
+                tile_m.index[None, :, None] >= tile_n.index[None, None, :],
+                qk,
+                float("-inf"),
+            )
+            m_ij_keepdim = torch.maximum(
+                m_i[:, :, None], torch.amax(qk, -1, keepdim=True)
+            )
+            qk = qk - m_ij_keepdim
+            m_ij = m_ij_keepdim.squeeze(-1)
+            p = torch.exp2(qk)
+            l_ij = torch.sum(p, -1)
+            alpha = torch.exp2(m_i - m_ij)
+            l_i = l_i * alpha + l_ij
+            acc = acc * alpha[:, :, None]
+            v = v_view[tile_b, tile_n, :]
+            p = p.to(v.dtype)
+            acc = torch.baddbmm(acc, p, v)
+            m_i = m_ij
+        acc = acc / l_i[:, :, None]
+        out[tile_b, tile_m, :] = acc.to(out.dtype)
+    return out.view(q_in.size())
+
+
+AttentionShape = tuple[int, int, int, int, torch.dtype, bool]
 
 
 # Original B200 representative sweep.
 B200_SHAPES: tuple[AttentionShape, ...] = (
-    (1, 4, 512, 64, torch.float16),
-    (2, 8, 512, 64, torch.float16),
-    (2, 32, 1024, 64, torch.float16),
-    (2, 32, 2048, 64, torch.float16),
-    (4, 32, 4096, 128, torch.bfloat16),
-    (8, 32, 8192, 128, torch.bfloat16),
+    (1, 4, 512, 64, torch.float16, False),
+    (2, 8, 512, 64, torch.float16, False),
+    (2, 32, 1024, 64, torch.float16, False),
+    (2, 32, 2048, 64, torch.float16, False),
+    (4, 32, 4096, 128, torch.bfloat16, False),
+    (8, 32, 8192, 128, torch.bfloat16, False),
 )
 
-# Non-causal half of the comparison harness's dense_causal8 suite. Each shape
-# selects a distinct sm103 nonpersistent two-CTA config.
+# The comparison harness's dense_causal8 suite. Dense shapes select sm103
+# nonpersistent two-CTA configs; causal shapes select one-CTA configs.
 GB300_SHAPES: tuple[AttentionShape, ...] = (
-    (2, 32, 32768, 64, torch.float16),
-    (2, 32, 65536, 64, torch.float16),
-    (2, 32, 131072, 64, torch.float16),
-    (2, 32, 262144, 64, torch.float16),
+    (2, 32, 32768, 64, torch.float16, False),
+    (2, 32, 65536, 64, torch.float16, False),
+    (2, 32, 131072, 64, torch.float16, False),
+    (2, 32, 262144, 64, torch.float16, False),
+    (2, 32, 65536, 64, torch.float16, True),
+    (2, 32, 131072, 64, torch.float16, True),
+    (2, 32, 262144, 64, torch.float16, True),
+    (2, 32, 524288, 64, torch.float16, True),
 )
 
 
@@ -128,22 +187,28 @@ def use_cudagraph() -> bool:
 def correctness_check() -> None:
     """Check every checked-in config branch against cuDNN SDPA."""
     torch.manual_seed(0)
-    shapes: tuple[AttentionShape, ...] = (
-        (1, 2, 256, 64, torch.float16),
-        (1, 2, 256, 128, torch.bfloat16),
-        (1, 1, 8192, 64, torch.float16),
+    checks = (
+        ((1, 2, 256, 64, torch.float16, False), attention),
+        ((1, 2, 256, 128, torch.bfloat16, False), attention),
+        ((1, 1, 8192, 64, torch.float16, False), attention),
     )
     if torch.cuda.get_device_capability() == (10, 3):
-        # Exercise all four sm103 long-sequence selectors with a small
+        # Exercise all eight sm103 long-sequence selectors with a small
         # batch/head count so correctness does not require the benchmark's
         # full-size allocation.
-        shapes += tuple(
-            (1, 1, seq, 64, torch.float16) for seq in (32768, 65536, 131072, 262144)
+        checks += tuple(
+            ((1, 1, seq, 64, torch.float16, False), attention)
+            for seq in (32768, 65536, 131072, 262144)
         )
-    for shape in shapes:
-        args = _make_inputs(*shape)
-        actual = attention(*args)
-        expected = _attention_sdpa(*args)
+        checks += tuple(
+            ((1, 1, seq, 64, torch.float16, True), causal_attention)
+            for seq in (65536, 131072, 262144, 524288)
+        )
+    for shape, kernel in checks:
+        z, h, seq_len, head_dim, dtype, is_causal = shape
+        args = _make_inputs(z, h, seq_len, head_dim, dtype)
+        actual = kernel(*args)
+        expected = _attention_sdpa(*args, is_causal=is_causal)
         torch.testing.assert_close(actual, expected, atol=5e-2, rtol=2e-2)
 
 
@@ -157,18 +222,20 @@ def main(verbose: bool = True) -> dict:
     shapes, rep = _benchmark_spec(torch.cuda.get_device_capability())
 
     def make_calls(shape: AttentionShape) -> tuple:
-        z, h, seq_len, head_dim, dtype = shape
+        z, h, seq_len, head_dim, dtype, is_causal = shape
         q, k, v = _make_inputs(z, h, seq_len, head_dim, dtype)
+        kernel = causal_attention if is_causal else attention
 
         def helion_call() -> torch.Tensor:
-            return attention(q, k, v)
+            return kernel(q, k, v)
 
         def sdpa_call() -> torch.Tensor:
-            return _attention_sdpa(q, k, v)
+            return _attention_sdpa(q, k, v, is_causal=is_causal)
 
         return (
             helion_call,
             [("sdpa", sdpa_call)],
+            f"{'causal' if is_causal else 'dense':>6s}  "
             f"{z:>2d}  {h:>3d}  {seq_len:>6d}  {head_dim:>4d}",
         )
 
@@ -179,7 +246,7 @@ def main(verbose: bool = True) -> dict:
         warmup=50,
         rep=rep,
         verbose=verbose,
-        shape_header=f"{'z':>2s}  {'h':>3s}  {'seq':>6s}  {'d':>4s}",
+        shape_header=(f"{'kind':>6s}  {'z':>2s}  {'h':>3s}  {'seq':>6s}  {'d':>4s}"),
     )
 
 

--- a/pretuned_kernels/attention/attention.py
+++ b/pretuned_kernels/attention/attention.py
@@ -4,7 +4,8 @@ These are the output-only dense and causal attention kernels from
 ``examples/attention.py``. They are pretuned for shapes used by
 ``benchmarks/cute/compare_attention_backends.py`` and compare against a single
 cuDNN SDPA baseline. On B200 and GB300 the default sweep uses the long dense
-and causal sequence lengths from that benchmark's eight-shape comparison.
+and causal sequence lengths from that benchmark's eight-shape comparison, at
+both head_dim 64 and head_dim 128.
 """
 
 from __future__ import annotations
@@ -140,8 +141,9 @@ B200_SHAPES: tuple[AttentionShape, ...] = (
     (8, 32, 8192, 128, torch.bfloat16, False),
 )
 
-# The comparison harness's dense_causal8 suite. Dense shapes select
-# nonpersistent two-CTA configs; causal shapes select one-CTA configs.
+# The comparison harness's dense_causal8 suite at head_dim 64, plus the same
+# eight sequence lengths at head_dim 128. Every entry has its own checked-in
+# schedule, so the sweep never falls back to online autotuning.
 LONG_SHAPES: tuple[AttentionShape, ...] = (
     (2, 32, 32768, 64, torch.float16, False),
     (2, 32, 65536, 64, torch.float16, False),
@@ -151,6 +153,14 @@ LONG_SHAPES: tuple[AttentionShape, ...] = (
     (2, 32, 131072, 64, torch.float16, True),
     (2, 32, 262144, 64, torch.float16, True),
     (2, 32, 524288, 64, torch.float16, True),
+    (2, 32, 32768, 128, torch.float16, False),
+    (2, 32, 65536, 128, torch.float16, False),
+    (2, 32, 131072, 128, torch.float16, False),
+    (2, 32, 262144, 128, torch.float16, False),
+    (2, 32, 65536, 128, torch.float16, True),
+    (2, 32, 131072, 128, torch.float16, True),
+    (2, 32, 262144, 128, torch.float16, True),
+    (2, 32, 524288, 128, torch.float16, True),
 )
 
 
@@ -193,17 +203,18 @@ def correctness_check() -> None:
         ((1, 1, 8192, 64, torch.float16, False), attention),
     )
     if torch.cuda.get_device_capability() in ((10, 0), (10, 3)):
-        # Exercise all eight SM100/SM103 long-sequence selectors with a small
+        # Exercise all sixteen SM100/SM103 long-sequence selectors with a small
         # batch/head count so correctness does not require the benchmark's
         # full-size allocation.
-        checks += tuple(
-            ((1, 1, seq, 64, torch.float16, False), attention)
-            for seq in (32768, 65536, 131072, 262144)
-        )
-        checks += tuple(
-            ((1, 1, seq, 64, torch.float16, True), causal_attention)
-            for seq in (65536, 131072, 262144, 524288)
-        )
+        for head_dim in (64, 128):
+            checks += tuple(
+                ((1, 1, seq, head_dim, torch.float16, False), attention)
+                for seq in (32768, 65536, 131072, 262144)
+            )
+            checks += tuple(
+                ((1, 1, seq, head_dim, torch.float16, True), causal_attention)
+                for seq in (65536, 131072, 262144, 524288)
+            )
     for shape, kernel in checks:
         z, h, seq_len, head_dim, dtype, is_causal = shape
         args = _make_inputs(z, h, seq_len, head_dim, dtype)

--- a/pretuned_kernels/attention/attention.py
+++ b/pretuned_kernels/attention/attention.py
@@ -3,8 +3,8 @@
 These are the output-only dense and causal attention kernels from
 ``examples/attention.py``. They are pretuned for shapes used by
 ``benchmarks/cute/compare_attention_backends.py`` and compare against a single
-cuDNN SDPA baseline. On GB300 the default sweep uses the long dense and causal
-sequence lengths from that benchmark's eight-shape comparison.
+cuDNN SDPA baseline. On B200 and GB300 the default sweep uses the long dense
+and causal sequence lengths from that benchmark's eight-shape comparison.
 """
 
 from __future__ import annotations
@@ -140,9 +140,9 @@ B200_SHAPES: tuple[AttentionShape, ...] = (
     (8, 32, 8192, 128, torch.bfloat16, False),
 )
 
-# The comparison harness's dense_causal8 suite. Dense shapes select sm103
+# The comparison harness's dense_causal8 suite. Dense shapes select
 # nonpersistent two-CTA configs; causal shapes select one-CTA configs.
-GB300_SHAPES: tuple[AttentionShape, ...] = (
+LONG_SHAPES: tuple[AttentionShape, ...] = (
     (2, 32, 32768, 64, torch.float16, False),
     (2, 32, 65536, 64, torch.float16, False),
     (2, 32, 131072, 64, torch.float16, False),
@@ -158,10 +158,10 @@ def _benchmark_spec(
     compute_capability: tuple[int, int],
 ) -> tuple[tuple[AttentionShape, ...], int]:
     """Return the target-specific shapes and CUDA-graph repetitions."""
-    if compute_capability == (10, 3):
+    if compute_capability in ((10, 0), (10, 3)):
         # These kernels take up to roughly one second, so ten samples are
         # sufficient and keep the standalone sweep practical.
-        return GB300_SHAPES, 10
+        return LONG_SHAPES, 10
     return B200_SHAPES, 200
 
 

--- a/pretuned_kernels/run.py
+++ b/pretuned_kernels/run.py
@@ -68,7 +68,7 @@ KERNELS = [
 
 # Map a compute capability (heuristic file suffix) to a hardware alias. The
 # nightly runs one GPU per alias.
-_HARDWARE_BY_COMPUTE = {"sm90": "h100", "sm100": "b200"}
+_HARDWARE_BY_COMPUTE = {"sm90": "h100", "sm100": "b200", "sm103": "gb300"}
 
 
 def parse_kernel_names(value: str) -> list[str]:

--- a/pretuned_kernels/run.py
+++ b/pretuned_kernels/run.py
@@ -44,6 +44,7 @@ KERNELS = [
     "rms_norm",
     "layer_norm",
     "softmax",
+    "attention",
     "scaled_mm",
     "scale_mm_cute",
     "nvfp4_gemv",

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -507,10 +507,44 @@ class TestPretunedCuteCodegen(TestCase):
         bf16_q = torch.empty((2, 32, 32768, 64), device="meta", dtype=torch.bfloat16)
         self.assertEqual(heuristic.key_attention(bf16_q, bf16_q, bf16_q), 2)
 
-    def test_attention_gb300_benchmark_uses_long_dense_configs(self) -> None:
+    def test_attention_long_causal_uses_one_cta_configs(self) -> None:
+        path = (
+            PRETUNED_KERNELS_DIR / "attention" / "_helion_aot_attention_cuda_sm103.py"
+        )
+        spec = importlib.util.spec_from_file_location("_causal_attention_aot", path)
+        assert spec is not None and spec.loader is not None
+        heuristic = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(heuristic)
+
+        for expected_index, seq_len in enumerate((65536, 131072, 262144, 524288)):
+            with self.subTest(seq_len=seq_len):
+                q = torch.empty(
+                    (2, 32, seq_len, 64), device="meta", dtype=torch.float16
+                )
+                self.assertEqual(
+                    heuristic.key_causal_attention(q, q, q), expected_index
+                )
+                config = heuristic.autotune_causal_attention(q, q, q)
+                self.assertEqual(config["cute_flash_pipeline_family"], "fa4")
+                self.assertFalse(config["cute_flash_persistent"])
+                self.assertTrue(config["cute_flash_causal_loop_split"])
+
+    def test_attention_gb300_benchmark_uses_dense_and_causal_configs(self) -> None:
         module = _import_pretuned_kernel_module("attention")
         shapes, rep = module._benchmark_spec((10, 3))
-        self.assertEqual([shape[2] for shape in shapes], [32768, 65536, 131072, 262144])
+        self.assertEqual(
+            [(shape[2], shape[5]) for shape in shapes],
+            [
+                (32768, False),
+                (65536, False),
+                (131072, False),
+                (262144, False),
+                (65536, True),
+                (131072, True),
+                (262144, True),
+                (524288, True),
+            ],
+        )
         self.assertEqual(rep, 10)
 
     def test_tcgen05_fragment_epilogues_are_registered_for_b200(self) -> None:

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -669,6 +669,24 @@ class TestPretunedCuteCodegen(TestCase):
         )
         self.assertEqual(rep, 10)
 
+    def test_attention_b200_benchmark_uses_dense_and_causal_configs(self) -> None:
+        module = _import_pretuned_kernel_module("attention")
+        shapes, rep = module._benchmark_spec((10, 0))
+        self.assertEqual(
+            [(shape[2], shape[5]) for shape in shapes],
+            [
+                (32768, False),
+                (65536, False),
+                (131072, False),
+                (262144, False),
+                (65536, True),
+                (131072, True),
+                (262144, True),
+                (524288, True),
+            ],
+        )
+        self.assertEqual(rep, 10)
+
     def test_tcgen05_fragment_epilogues_are_registered_for_b200(self) -> None:
         path = PRETUNED_KERNELS_DIR / "run.py"
         spec = importlib.util.spec_from_file_location("_pretuned_runner", path)

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -468,6 +468,21 @@ class TestPretunedCuteCodegen(TestCase):
     def test_interleaved_swiglu(self) -> None:
         self._run_tcgen05_fragment_epilogue_correctness("interleaved_swiglu")
 
+    def test_attention(self) -> None:
+        if not is_cuda() or torch.cuda.get_device_capability() < (10, 0):
+            self.skipTest("attention requires the B200 CuTe flash backend.")
+        module = _import_pretuned_kernel_module("attention")
+        module.correctness_check()
+
+    def test_attention_is_registered_for_b200(self) -> None:
+        path = PRETUNED_KERNELS_DIR / "run.py"
+        spec = importlib.util.spec_from_file_location("_pretuned_runner", path)
+        assert spec is not None and spec.loader is not None
+        runner = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(runner)
+        self.assertIn("attention", runner.KERNELS)
+        self.assertEqual(runner._supported_hardware("attention"), {"b200"})
+
     def test_tcgen05_fragment_epilogues_are_registered_for_b200(self) -> None:
         path = PRETUNED_KERNELS_DIR / "run.py"
         spec = importlib.util.spec_from_file_location("_pretuned_runner", path)

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -529,6 +529,128 @@ class TestPretunedCuteCodegen(TestCase):
                 self.assertFalse(config["cute_flash_persistent"])
                 self.assertTrue(config["cute_flash_causal_loop_split"])
 
+    def test_attention_b200_long_configs(self) -> None:
+        path = (
+            PRETUNED_KERNELS_DIR / "attention" / "_helion_aot_attention_cuda_sm100.py"
+        )
+        spec = importlib.util.spec_from_file_location("_attention_b200_aot", path)
+        assert spec is not None and spec.loader is not None
+        heuristic = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(heuristic)
+
+        dense_expected = {
+            32768: {
+                "cute_flash_corr_regs": 72,
+                "cute_flash_corr_tile_size": 8,
+                "cute_flash_e2e_offset": 0,
+                "cute_flash_e2e_offset0": 1,
+                "cute_flash_first_load_order": 4,
+                "cute_flash_rescale_threshold": 12.0,
+                "cute_flash_role_map": "fa4",
+            },
+            65536: {
+                "cute_flash_corr_regs": 72,
+                "cute_flash_corr_tile_size": 16,
+                "cute_flash_e2e_offset": 14,
+                "cute_flash_e2e_offset0": 0,
+                "cute_flash_first_load_order": 4,
+                "cute_flash_role_map": "fa4",
+            },
+            131072: {
+                "cute_flash_corr_regs": 72,
+                "cute_flash_corr_tile_size": 8,
+                "cute_flash_e2e_offset": 0,
+                "cute_flash_e2e_offset0": 0,
+                "cute_flash_first_load_order": 0,
+                "cute_flash_role_map": "helion",
+            },
+            262144: {
+                "cute_flash_corr_regs": 72,
+                "cute_flash_corr_tile_size": 8,
+                "cute_flash_e2e_offset": 12,
+                "cute_flash_e2e_offset0": 2,
+                "cute_flash_first_load_order": 4,
+                "cute_flash_role_map": "fa4",
+            },
+        }
+        for expected_index, (seq_len, expected) in enumerate(
+            dense_expected.items(), start=3
+        ):
+            with self.subTest(kind="dense", seq_len=seq_len):
+                q = torch.empty(
+                    (2, 32, seq_len, 64), device="meta", dtype=torch.float16
+                )
+                self.assertEqual(heuristic.key_attention(q, q, q), expected_index)
+                config = heuristic.autotune_attention(q, q, q)
+                self.assertEqual(config["cute_flash_pipeline_family"], "fa4_2cta")
+                self.assertEqual(config["cute_flash_kv_stage"], 2)
+                self.assertEqual(config["cute_flash_e2e_schedule"], "16/6")
+                for key, value in expected.items():
+                    self.assertEqual(config[key], value)
+
+        causal_expected = {
+            65536: {
+                "cute_flash_causal_lpt_swizzle": 2,
+                "cute_flash_disc_pipe": 2,
+                "cute_flash_e2e_offset": 0,
+                "cute_flash_e2e_offset0": 0,
+                "cute_flash_epi_tma": True,
+                "cute_flash_kv_stage": 2,
+                "cute_flash_role_map": "fa4",
+                "cute_flash_softmax_regs": 184,
+                "cute_flash_wait_hint": 0,
+            },
+            131072: {
+                "cute_flash_causal_lpt_swizzle": 0,
+                "cute_flash_disc_pipe": 3,
+                "cute_flash_e2e_offset": 1,
+                "cute_flash_e2e_offset0": 14,
+                "cute_flash_epi_tma": True,
+                "cute_flash_kv_stage": 2,
+                "cute_flash_role_map": "fa4",
+                "cute_flash_softmax_regs": 192,
+                "cute_flash_wait_hint": 0,
+            },
+            262144: {
+                "cute_flash_causal_lpt_swizzle": 0,
+                "cute_flash_disc_pipe": 3,
+                "cute_flash_e2e_offset": 0,
+                "cute_flash_e2e_offset0": 15,
+                "cute_flash_epi_tma": False,
+                "cute_flash_kv_stage": 4,
+                "cute_flash_role_map": "helion",
+                "cute_flash_softmax_regs": 192,
+                "cute_flash_wait_hint": 10000000,
+            },
+            524288: {
+                "cute_flash_causal_lpt_swizzle": 0,
+                "cute_flash_disc_pipe": 3,
+                "cute_flash_e2e_offset": 14,
+                "cute_flash_e2e_offset0": 12,
+                "cute_flash_epi_tma": False,
+                "cute_flash_kv_stage": 2,
+                "cute_flash_role_map": "helion",
+                "cute_flash_softmax_regs": 184,
+                "cute_flash_wait_hint": 10000000,
+            },
+        }
+        for expected_index, (seq_len, expected) in enumerate(causal_expected.items()):
+            with self.subTest(kind="causal", seq_len=seq_len):
+                q = torch.empty(
+                    (2, 32, seq_len, 64), device="meta", dtype=torch.float16
+                )
+                self.assertEqual(
+                    heuristic.key_causal_attention(q, q, q), expected_index
+                )
+                config = heuristic.autotune_causal_attention(q, q, q)
+                self.assertEqual(config["cute_flash_pipeline_family"], "fa4")
+                self.assertTrue(config["cute_flash_causal_loop_split"])
+                for key, value in expected.items():
+                    self.assertEqual(config[key], value)
+
+        bf16_q = torch.empty((2, 32, 32768, 64), device="meta", dtype=torch.bfloat16)
+        self.assertEqual(heuristic.key_attention(bf16_q, bf16_q, bf16_q), 2)
+
     def test_attention_gb300_benchmark_uses_dense_and_causal_configs(self) -> None:
         module = _import_pretuned_kernel_module("attention")
         shapes, rep = module._benchmark_spec((10, 3))

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -470,18 +470,48 @@ class TestPretunedCuteCodegen(TestCase):
 
     def test_attention(self) -> None:
         if not is_cuda() or torch.cuda.get_device_capability() < (10, 0):
-            self.skipTest("attention requires the B200 CuTe flash backend.")
+            self.skipTest("attention requires the SM100+ CuTe flash backend.")
         module = _import_pretuned_kernel_module("attention")
         module.correctness_check()
 
-    def test_attention_is_registered_for_b200(self) -> None:
+    def test_attention_is_registered_for_b200_and_gb300(self) -> None:
         path = PRETUNED_KERNELS_DIR / "run.py"
         spec = importlib.util.spec_from_file_location("_pretuned_runner", path)
         assert spec is not None and spec.loader is not None
         runner = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(runner)
         self.assertIn("attention", runner.KERNELS)
-        self.assertEqual(runner._supported_hardware("attention"), {"b200"})
+        self.assertEqual(runner._supported_hardware("attention"), {"b200", "gb300"})
+
+    def test_attention_long_dense_uses_two_cta_configs(self) -> None:
+        path = (
+            PRETUNED_KERNELS_DIR / "attention" / "_helion_aot_attention_cuda_sm103.py"
+        )
+        spec = importlib.util.spec_from_file_location("_attention_aot", path)
+        assert spec is not None and spec.loader is not None
+        heuristic = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(heuristic)
+
+        for expected_index, seq_len in enumerate(
+            (32768, 65536, 131072, 262144), start=3
+        ):
+            with self.subTest(seq_len=seq_len):
+                q = torch.empty(
+                    (2, 32, seq_len, 64), device="meta", dtype=torch.float16
+                )
+                self.assertEqual(heuristic.key_attention(q, q, q), expected_index)
+                config = heuristic.autotune_attention(q, q, q)
+                self.assertEqual(config["cute_flash_pipeline_family"], "fa4_2cta")
+                self.assertFalse(config["cute_flash_persistent"])
+
+        bf16_q = torch.empty((2, 32, 32768, 64), device="meta", dtype=torch.bfloat16)
+        self.assertEqual(heuristic.key_attention(bf16_q, bf16_q, bf16_q), 2)
+
+    def test_attention_gb300_benchmark_uses_long_dense_configs(self) -> None:
+        module = _import_pretuned_kernel_module("attention")
+        shapes, rep = module._benchmark_spec((10, 3))
+        self.assertEqual([shape[2] for shape in shapes], [32768, 65536, 131072, 262144])
+        self.assertEqual(rep, 10)
 
     def test_tcgen05_fragment_epilogues_are_registered_for_b200(self) -> None:
         path = PRETUNED_KERNELS_DIR / "run.py"

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -590,14 +590,14 @@ class TestPretunedCuteCodegen(TestCase):
 
         causal_expected = {
             65536: {
-                "cute_flash_causal_lpt_swizzle": 2,
-                "cute_flash_disc_pipe": 2,
+                "cute_flash_causal_lpt_swizzle": 0,
+                "cute_flash_disc_pipe": 3,
                 "cute_flash_e2e_offset": 0,
-                "cute_flash_e2e_offset0": 0,
+                "cute_flash_e2e_offset0": 14,
                 "cute_flash_epi_tma": True,
-                "cute_flash_kv_stage": 2,
+                "cute_flash_kv_stage": 3,
                 "cute_flash_role_map": "fa4",
-                "cute_flash_softmax_regs": 184,
+                "cute_flash_softmax_regs": 200,
                 "cute_flash_wait_hint": 0,
             },
             131072: {


### PR DESCRIPTION
## Summary

- add output-only dense and causal CuTe attention kernels to `pretuned_kernels`
- retain checked-in B200 AOT configs for the representative dense sweep
- add GB300 (`sm103`) AOT configs for the eight long-context shapes from `dense_causal8`
- use nonpersistent two-CTA schedules for dense attention and tuned one-CTA, diagonal-first schedules for causal attention
- make the standalone GB300 benchmark cover dense 32K–256K and causal 64K–512K while preserving the original B200 sweep
- register GB300 in the aggregate pretuned runner and cover every new selector with correctness and dispatch tests

## GB300 performance

Cold-L2 CUDA-graph timing against cuDNN SDPA on NVIDIA GB300:

| Kind | Shape `(z, h, seq, d)` | Helion | SDPA | Speedup |
|---|---|---:|---:|---:|
| dense | `(2, 32, 32768, 64)` | 12.643 ms | 15.329 ms | 1.21x |
| dense | `(2, 32, 65536, 64)` | 54.491 ms | 62.844 ms | 1.15x |
| dense | `(2, 32, 131072, 64)` | 218.386 ms | 253.196 ms | 1.16x |
| dense | `(2, 32, 262144, 64)` | 916.930 ms | 1014.089 ms | 1.11x |
| causal | `(2, 32, 65536, 64)` | 26.048 ms | 29.080 ms | 1.12x |
| causal | `(2, 32, 131072, 64)` | 104.363 ms | 117.407 ms | 1.12x |
| causal | `(2, 32, 262144, 64)` | 437.082 ms | 467.507 ms | 1.07x |
| causal | `(2, 32, 524288, 64)` | 1626.705 ms | 1854.543 ms | 1.14x |

Helion wins 8/8 shapes with a 1.135x geometric-mean speedup. The 512K row was measured in an isolated process because a resident service occupied about 259 GiB of each GB300; the exact 512K config also passed reduced-batch correctness.

## Testing

- `CUDA_VISIBLE_DEVICES=3 HELION_BACKEND=cute python -m pytest test/test_pretuned_kernels.py::TestPretunedCuteCodegen::test_attention test/test_pretuned_kernels.py::TestPretunedCuteCodegen::test_attention_long_dense_uses_two_cta_configs test/test_pretuned_kernels.py::TestPretunedCuteCodegen::test_attention_long_causal_uses_one_cta_configs test/test_pretuned_kernels.py::TestPretunedCuteCodegen::test_attention_gb300_benchmark_uses_dense_and_causal_configs -q` (4 passed)
- verified all four causal AOT dictionaries exactly match the sm103 compiler seed configs
- targeted Ruff checks, `py_compile`, and `git diff --check`
