### PR TITLE
[autotuner] harden B200 matmul heuristics for off-corpus kernels

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -14,6 +14,8 @@ from torch.fx.node import Node
 from torch.fx.node import map_arg
 
 from .. import exc
+from ..language.matmul_ops import MATMUL_DIM_BLOCK_IDS_META
+from ..language.matmul_ops import MATMUL_FACT_ID_META
 from ..language.matmul_ops import enforce_dot_requirements
 from .ast_extension import expr_from_string
 from .compile_environment import CompileEnvironment
@@ -485,7 +487,15 @@ def apply_dot_requirements(lowering: AtenLowering, node: Node) -> Lowering:
     assert isinstance(lproxy, torch.Tensor)
     assert isinstance(rproxy, torch.Tensor)
     # Update config spec min sizes for M, N, K
-    enforce_dot_requirements(lproxy, rproxy)
+    fact_id = enforce_dot_requirements(lproxy, rproxy)
+    node.meta[MATMUL_FACT_ID_META] = fact_id
+    fact = CompileEnvironment.current().config_spec.matmul_facts[fact_id]
+    output_ndim = max(fact.lhs_ndim, fact.rhs_ndim)
+    node.meta[MATMUL_DIM_BLOCK_IDS_META] = (
+        *(None for _ in range(output_ndim - 2)),
+        fact.m_block_id,
+        fact.n_block_id,
+    )
     # inputs to the dot operation must be zero-masked
     *maybe_acc, lnode, rnode = node.args
     assert isinstance(lnode, Node)

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import json
 import logging
+from operator import itemgetter
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -23,6 +24,7 @@ from ...autotuner.config_spec import LiveTile
 from ...autotuner.config_spec import LoopAxisFact
 from ...autotuner.config_spec import ReductionCategory
 from ...runtime.config import Config
+from ..compile_environment import _symint_sympy_expr
 from .common import clamp_block_size_targets
 from .common import dedupe_configs
 from .common import matches_hardware
@@ -30,6 +32,8 @@ from .registry import AutotunerHeuristic
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from collections.abc import Collection
+    from collections.abc import Sequence
 
     from ...autotuner.config_spec import BlockSizeSpec
     from ...autotuner.config_spec import ConfigSpec
@@ -55,8 +59,6 @@ class CandidateDotWork(NamedTuple):
 
     total: int
     tcgen05_eligible: int
-    tcgen05_independent: int = 0
-    tcgen05_carried: int = 0
     uncertain: bool = False
 
 
@@ -206,19 +208,6 @@ def _axis_roles(config_spec: ConfigSpec, index: int) -> DotAxes | None:
     if mm is None or index >= len(mm.matmuls):
         return None
     return mm.matmuls[index].axes
-
-
-def _grid_group_for_site(
-    config_spec: ConfigSpec,
-    site: DotSite | None,
-) -> tuple[int, ...]:
-    """Root-grid axes for one dot site, with the flattened legacy fallback."""
-    grid_fact = getattr(config_spec, "kernel_grid_fact", None)
-    if grid_fact is not None and site is not None:
-        group = grid_fact.group_for_graph(site.graph_id)
-        if group:
-            return group
-    return tuple(config_spec.grid_block_ids)
 
 
 def _generalized_static_matmul_fact(config_spec: ConfigSpec) -> MatmulFact | None:
@@ -454,30 +443,6 @@ def _h100_build_block_sizes(
     return out
 
 
-def _h100_pinned_grid(
-    env: CompileEnvironment,
-    fact: MatmulFact,
-    block_of: dict[int, int],
-    grid_block_ids: tuple[int, ...],
-) -> int:
-    """Programs contributed by this dot's non-M/N grid axes.
-
-    A grid axis may cover one config-derived tile rather than one scalar. Split-K,
-    for example, walks K=8192 in 64 fixed partitions of 128 elements. Counting its
-    full extent as 8192 programs makes every output tile look deeply saturated.
-    """
-    pinned_grid = 1
-    for bid in grid_block_ids:
-        if bid in (fact.m_block_id, fact.n_block_id):
-            continue
-        size = env.block_sizes[bid].size
-        if isinstance(size, (int, torch.SymInt)):
-            extent = max(1, env.size_hint(size))
-            block = max(1, block_of.get(bid, 1))
-            pinned_grid *= max(1, -(-extent // block))
-    return pinned_grid
-
-
 def _h100_config(
     spec: ConfigSpec,
     fact: MatmulFact,
@@ -586,6 +551,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
     # column check is inert (which is what keeps sm90 byte-identical).
     TMEM_LANES = 128
     TMEM_COLUMN_BUDGET: int | None = None
+    TMEM_ALLOC_COLUMNS = 0
     # Register-file bytes per thread available to the register-resident live set: the
     # ARCHITECTURAL ceiling of 255 registers x 4 B. This budget answers "will this spill
     # catastrophically", not "is occupancy ideal", so the hard ceiling is the right bound -- and it
@@ -673,10 +639,9 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
     # enabled by a measured architecture subclass.
     SUBSTANTIAL_DOT_WORK = 1 << 20
     TCGEN05_DOT_WORK = 1 << 20
-    # The tcgen work threshold may rise when entering a warpgroup reduces
-    # effective CTA residency, but never with the number of queued launch
-    # waves after that residency is saturated.
-    TCGEN_OCCUPANCY_PENALTY_MAX = 4.0
+    # Every work-driven warp transition pays for any effective CTA residency it
+    # gives up, but never for queued launch waves after residency is saturated.
+    WARP_TRANSITION_OCCUPANCY_PENALTY_MAX = 4.0
     EIGHT_WARP_DOT_WORK = 1 << 26
     NON_TCGEN_WIDE_N = 128
     WARP1_SOFT_PRESSURE = 1.2
@@ -709,7 +674,6 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         num_warps: int,
         num_stages: int,
         l2_grouping: int,
-        pinned_grid: int,
         num_sm: int,
     ) -> dict[str, Any]:
         """Hook for hardware-specific extra Config fields (e.g. sm100 Blackwell levers). The sm90
@@ -778,8 +742,13 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         return max(ring, epilogue) + cls.SMEM_SLACK
 
     @classmethod
-    def _tmem_columns(cls, tiles: list[tuple[int, int, int]]) -> int:
-        """Tensor-memory COLUMNS a set of live fp32 accumulators reserves.
+    def _tmem_columns(
+        cls,
+        tiles: Sequence[tuple[int, int, int] | tuple[int, int, int, int]],
+        *,
+        include_lhs_scratch: bool = False,
+    ) -> int:
+        """Tensor-memory COLUMNS a set of dots reserves.
 
         tcgen05 tensor memory is allocated as ``TMEM_LANES`` (128) lanes x N columns of
         32 bits; a request is denominated in columns, not bytes. Measured on B200 over the
@@ -795,20 +764,49 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         ``OutOfResources: tensor memory, Required: 768, limit 512`` -- exactly
         ``3 x 256`` columns against the 512-column budget.
 
-        ``tiles`` is ``[(bm, bn, itemsize), ...]``. An accumulator whose ``bm`` is below
-        ``TCGEN05_MIN_BM`` is charged nothing: below that the dot lowers to a non-tcgen05
-        path that uses no tensor memory at all (measured ``tmem_size == 0``), and its cost
-        lands on the register file instead -- see ``_register_live_bytes``.
+        ``tiles`` may include K as ``(bm, bn, bk, itemsize)``. With
+        ``include_lhs_scratch``, also reserve each dot's power-of-two LHS promotion
+        allocation. Triton can keep those allocations distinct across dots, just as
+        accumulator allocations can add. The scratch-inclusive value is a hard
+        launchability check; the calibrated residency policy continues to use
+        accumulator columns alone because this all-dot bound is not a reliable
+        peak-residency estimate.
+
+        An accumulator whose ``bm`` is below ``TCGEN05_MIN_BM`` is charged nothing:
+        below that the dot lowers to a non-tcgen05 path that uses no tensor memory at
+        all (measured ``tmem_size == 0``), and its cost lands on the register file
+        instead -- see ``_register_live_bytes``.
         """
+        if include_lhs_scratch:
+            assert all(len(tile) == 4 for tile in tiles), (
+                "BK is required when include_lhs_scratch=True"
+            )
         if cls.TMEM_COLUMN_BUDGET is None:
             return 0
         total = 0
-        for bm, bn, _itemsize in tiles:
+        lhs_columns = 0
+        for tile in tiles:
+            if len(tile) == 3:
+                bm, bn, itemsize = tile
+                bk = None
+            else:
+                bm, bn, bk, itemsize = tile
             if bm < cls.TCGEN05_MIN_BM:
                 continue
             lane_groups = max(1, -(-bm // cls.TMEM_LANES))
             total += lane_groups * bn
-        return total
+            if include_lhs_scratch:
+                assert bk is not None
+                raw_columns = max(
+                    1,
+                    -(-(bm * bk * itemsize) // (cls.TMEM_LANES * 4)),
+                )
+                allocated_columns = 1 << (raw_columns - 1).bit_length()
+                lhs_columns += max(
+                    cls.TMEM_ALLOC_COLUMNS,
+                    allocated_columns,
+                )
+        return total + lhs_columns
 
     @classmethod
     def _warps_for_live_set(
@@ -947,21 +945,27 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         p2 = pressure(2)
         wide_register_accumulator = any(
             rows < cls.TCGEN05_MIN_BM and cols >= cls.NON_TCGEN_WIDE_N
-            for rows, cols, _itemsize in cls._all_dot_acc_tiles(env, block_sizes)
+            for rows, cols, _inner, _itemsize in cls._all_dot_acc_tiles(
+                env, block_sizes
+            )
         )
-        mma_ctas = resident_ctas(2)
-        tcgen_ctas = resident_ctas(cls.TCGEN05_WARPGROUP_WARPS)
-        occupancy_penalty = cls._tcgen_occupancy_penalty(
-            mma_ctas,
-            tcgen_ctas,
-        )
-        if work.tcgen05_eligible >= cls.EIGHT_WARP_DOT_WORK:
-            warps = 8
-        elif work.tcgen05_eligible > cls.TCGEN05_DOT_WORK * occupancy_penalty or (
-            not work.tcgen05_eligible and wide_register_accumulator
+
+        def transition_penalty(lower: int, upper: int) -> float:
+            return cls._warp_transition_occupancy_penalty(
+                resident_ctas(lower),
+                resident_ctas(upper),
+            )
+
+        if work.tcgen05_eligible >= (
+            cls.EIGHT_WARP_DOT_WORK
+            * transition_penalty(cls.TCGEN05_WARPGROUP_WARPS, cls.MAX_NUM_WARPS)
         ):
+            warps = 8
+        elif work.tcgen05_eligible > (
+            cls.TCGEN05_DOT_WORK * transition_penalty(2, cls.TCGEN05_WARPGROUP_WARPS)
+        ) or (not work.tcgen05_eligible and wide_register_accumulator):
             warps = 4
-        elif work.total >= cls.SUBSTANTIAL_DOT_WORK:
+        elif work.total >= (cls.SUBSTANTIAL_DOT_WORK * transition_penalty(1, 2)):
             warps = 2
         else:
             warps = 1 if p1 <= cls.WARP1_SOFT_PRESSURE else 2
@@ -1001,14 +1005,19 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         return min(cls.MAX_NUM_WARPS, max(1, warps))
 
     @classmethod
-    def _tcgen_occupancy_penalty(cls, mma_ctas: int, tcgen_ctas: int) -> float:
-        """Bounded tcgen work penalty for a real effective-residency loss.
+    def _warp_transition_occupancy_penalty(
+        cls, lower_warp_ctas: int, higher_warp_ctas: int
+    ) -> float:
+        """Bounded work penalty for a real effective-residency loss.
 
-        ``mma_ctas`` and ``tcgen_ctas`` already include launch demand, so queued
-        waves beyond resident capacity cannot inflate this value.
+        Both inputs already include launch demand, so queued waves beyond
+        resident capacity cannot inflate this value.
         """
-        ratio = max(1.0, max(1, mma_ctas) / max(1, tcgen_ctas))
-        return min(cls.TCGEN_OCCUPANCY_PENALTY_MAX, ratio)
+        ratio = max(
+            1.0,
+            max(1, lower_warp_ctas) / max(1, higher_warp_ctas),
+        )
+        return min(cls.WARP_TRANSITION_OCCUPANCY_PENALTY_MAX, ratio)
 
     @classmethod
     def _full_block_map(
@@ -1036,16 +1045,9 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         """
         spec = env.config_spec
         out: dict[int, int] = {}
-        base_default = cast(
-            "Callable[[], Config] | None",
-            getattr(spec, "_base_default_config", None),
-        )
-        if base_default is not None:
-            config_dict = dict(base_default().config)
-            config_dict["block_sizes"] = list(block_sizes)
-            candidate = Config.from_dict(config_dict)
-        else:
-            candidate = Config(block_sizes=list(block_sizes))
+        config_dict = dict(spec._base_default_config().config)
+        config_dict["block_sizes"] = block_sizes
+        candidate = Config.from_dict(config_dict)
         # A TUNABLE axis's per-program extent is simply the entry the config carries for it.
         # Read it straight from the list rather than round-tripping through the block-size
         # source: ``LoopSpecBlockSizeSource.from_config`` reaches for
@@ -1055,8 +1057,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         # every footprint by four orders of magnitude.
         for slot in range(len(spec.block_sizes)):
             bs = cast("BlockSizeSpec", spec.block_sizes[slot])
-            if slot < len(block_sizes):
-                out[bs.block_id] = max(1, int(block_sizes[slot]))
+            out[bs.block_id] = block_sizes[slot]
         # Everything else is fixed by its source: an ``hl.grid`` axis is one row per program
         # even though its extent is the whole grid, and a specialized / persistent-reduction
         # axis is its full extent.
@@ -1064,117 +1065,126 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             if bid in out:
                 continue
             info = env.block_sizes[bid]
-            value: object = None
-            try:
-                value = info.block_size_source.from_config(candidate, info)
-                if isinstance(value, torch.SymInt):
-                    expression = getattr(env, "config_value_expressions", {}).get(
-                        value._sympy_()
-                    )
-                    if expression is not None:
-                        value = expression.evaluate(candidate)
-            except Exception:
-                value = None
-            if value is None:
-                value = info.size if isinstance(info.size, (int, torch.SymInt)) else 1
-            try:
-                out[bid] = max(1, int(env.size_hint(value)))  # pyrefly: ignore
-            except Exception:
-                out[bid] = 1
+            value = info.block_size_source.from_config(candidate, info)
+            if isinstance(value, torch.SymInt):
+                expression = env.config_value_expressions.get(_symint_sympy_expr(value))
+                if expression is not None:
+                    value = expression.evaluate(candidate)
+            assert isinstance(value, (int, torch.SymInt))
+            out[bid] = max(1, env.size_hint(value))
         return out
 
     @classmethod
-    def _axis_extent(cls, env: CompileEnvironment, block_id: int) -> int:
-        """Full length of one block axis (not the per-program tile)."""
+    def _axis_extent(cls, env: CompileEnvironment, block_id: int) -> int | None:
+        """Known full length of one block axis, or None when unresolved."""
         if 0 <= block_id < len(env.block_sizes):
             size = env.block_sizes[block_id].size
             if isinstance(size, (int, torch.SymInt)):
                 return max(1, env.size_hint(size))
-        return 1
+        return None
 
     @classmethod
-    def _launch_grid(cls, env: CompileEnvironment, block_sizes: list[int]) -> int:
-        """Logical programs in dot-bearing roots, or all roots without attribution."""
+    def _launch_grid(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        *,
+        graph_ids: tuple[int, ...] | None = None,
+        collapsed_block_ids: Collection[int] = (),
+    ) -> int:
+        """Candidate launch grid for selected roots using only proven grid axes."""
         block_of = cls._full_block_map(env, block_sizes)
-        grid_fact = getattr(env.config_spec, "kernel_grid_fact", None)
+        grid_fact = env.config_spec.kernel_grid_fact
         mm = env.config_spec.kernel_matmul_fact
         groups: tuple[tuple[int, ...], ...] = ()
         if grid_fact is not None:
-            if mm is not None:
+            if graph_ids is not None:
+                groups = grid_fact.groups_for_graphs(graph_ids)
+            elif mm is not None:
                 groups = grid_fact.groups_for_graphs(
                     tuple(resolved.site.graph_id for resolved in mm.matmuls)
                 )
             groups = groups or grid_fact.grid_groups
         if not groups:
             groups = (tuple(env.config_spec.grid_block_ids),)
+        collapsed = set(collapsed_block_ids)
         grid = 0
         for group in groups:
             group_grid = 1
-            for bid in group:
-                extent = cls._axis_extent(env, bid)
-                group_grid *= max(
-                    1,
-                    -(-extent // max(1, block_of.get(bid, 1))),
-                )
+            for block_id in group:
+                if block_id in collapsed:
+                    continue
+                extent = cls._axis_extent(env, block_id)
+                if extent is None:
+                    # TODO(calebmkim): Propagate unknown grid cardinality to callers
+                    # instead of treating it as one; this lower bound can mislead
+                    # occupancy and wave-fill decisions into shrinking unrelated axes.
+                    # Unknown extents contribute no proven launch parallelism.
+                    continue
+                group_grid *= max(1, -(-extent // block_of[block_id]))
             grid += group_grid
         return max(1, grid)
 
     @classmethod
-    def _smem_from_map(
-        cls, env: CompileEnvironment, block_sizes: list[int], num_stages: int
-    ) -> int:
-        """Whole-kernel shared-memory ring under an emitted ``block_sizes`` list.
+    def _smem_region_demands(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        num_stages: int,
+        *,
+        hard_allocation: bool = False,
+    ) -> tuple[int, ...]:
+        """Shared-memory demand of each independently executing region.
 
         Region ring = SUM of the region's loads (the pipeliner gives each load in the body
         its own multi-stage buffer, so within a stage they are all resident) x
         ``num_stages``, PLUS the region's store staging when it stores from inside itself;
-        then MAX across regions, because separate loops run one after the other."""
+        separate loops remain separate entries because resource fixup must be able
+        to relieve tied peaks independently.
+
+        Candidate ranking caps useful depth by known loop trips. Hard launchability
+        accounting charges the emitted global depth because Triton can reserve that
+        allocation even for a shorter loop.
+        """
         mm = env.config_spec.kernel_matmul_fact
-        if mm is None or not (mm.pipelined_regions or mm.resident_regions):
-            return 0
+        assert mm is not None
         block_of = cls._full_block_map(env, block_sizes)
 
         def region_bytes(tiles: tuple[LiveTile, ...], stages: int) -> int:
-            staged_loads = sum(
-                cls._resolve_tile_bytes(t, block_of)
-                for t in tiles
-                if t.kind == "load" and t.stageable is not False
-            )
-            resident_loads = sum(
-                cls._resolve_tile_bytes(t, block_of)
-                for t in tiles
-                if t.kind == "load" and t.stageable is False
-            )
             # A region that STORES inside itself (a state recurrence publishes each chunk
             # from inside the sequential loop) holds its store staging at the same time as
             # the ring, so those bytes ADD. A region with no store is a plain K-loop whose
             # ring is dead by the time the epilogue converts, which is the liveness-packed
             # case the incumbent ``max(ring, epilogue)`` already models.
-            stores = sum(
-                cls._resolve_tile_bytes(t, block_of) for t in tiles if t.kind == "store"
+            return sum(
+                cls._resolve_tile_bytes(tile, block_of)
+                * (
+                    max(1, stages)
+                    if tile.kind == "load" and tile.stageable is not False
+                    else 1
+                )
+                for tile in tiles
+                if tile.kind in ("load", "store")
             )
-            return staged_loads * max(1, stages) + resident_loads + stores
 
-        # MAX across regions: separate loops run one after the other, not together. A LOOP
-        # BODY's loads are multi-buffered ``num_stages`` deep; a load in a NON-loop graph is
-        # issued once, so charging it per stage over-states shared memory -- measured, that
-        # over-charge computed 325632 B for a kernel already at its floor tile and pinned it
-        # there for an overflow that cannot happen.
-        ring = 0
+        # Separate loops run one after the other, not together. A LOOP BODY's
+        # loads are multi-buffered ``num_stages`` deep; a load in a NON-loop
+        # graph is issued once.
+        demands: list[int] = []
         for region in mm.pipelined_regions:
-            trips = cls._resolved_loop_trips(
-                env,
-                block_sizes,
-                region.loop_axes,
-                fallback=max(1, num_stages),
-            )
-            ring = max(
-                ring,
-                region_bytes(region.tiles, min(max(1, num_stages), trips)),
-            )
+            stages = max(1, num_stages)
+            if not hard_allocation:
+                trips = cls._resolved_loop_trips(
+                    env,
+                    block_sizes,
+                    region.loop_axes,
+                )
+                if trips is not None:
+                    stages = min(stages, trips)
+            demands.append(region_bytes(region.tiles, stages))
         for region in mm.resident_regions:
-            ring = max(ring, region_bytes(region.tiles, 1))
-        return ring
+            demands.append(region_bytes(region.tiles, 1))
+        return tuple(demands)
 
     @classmethod
     def _resolved_loop_trips(
@@ -1182,75 +1192,65 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         env: CompileEnvironment,
         block_sizes: list[int],
         loop_axes: tuple[LoopAxisFact, ...],
-        *,
-        fallback: int,
-    ) -> int:
-        """Candidate-real product of enclosing sequential loop trip counts."""
-        trips, _exact = cls._resolved_loop_trips_detail(
-            env,
-            block_sizes,
-            loop_axes,
-            fallback=fallback,
-        )
-        return trips
-
-    @classmethod
-    def _resolved_loop_trips_detail(
-        cls,
-        env: CompileEnvironment,
-        block_sizes: list[int],
-        loop_axes: tuple[LoopAxisFact, ...],
-        *,
-        fallback: int,
-    ) -> tuple[int, bool]:
-        """Resolved trips and whether every enclosing extent was proven."""
+    ) -> int | None:
+        """Candidate-real enclosing loop trips, or unknown when not provable."""
         if not loop_axes:
-            return max(1, fallback), True
+            return 1
         block_of = cls._full_block_map(env, block_sizes)
         trips = 1
         for axis in loop_axes:
-            bound = getattr(axis, "bounded_by_block_id", None)
-            if bound is not None:
-                extent = getattr(axis, "bounded_extent", None)
-                if extent is None:
-                    extent = block_of.get(bound)
-                if extent is None:
-                    return max(1, fallback), False
+            symbolic_bound = axis.symbolic_bound
+            if symbolic_bound is not None:
+                replacements: dict[object, int] = {}
+                for symbol, block_id in symbolic_bound.block_size_symbols:
+                    replacements[symbol] = block_of[block_id]
+                for symbol, outer_block_id in symbolic_bound.tile_id_symbols:
+                    if outer_block_id == axis.block_id:
+                        return None
+                    outer_extent = cls._axis_extent(env, outer_block_id)
+                    if outer_extent is None:
+                        return None
+                    outer_tiles = max(1, -(-outer_extent // block_of[outer_block_id]))
+                    replacements[symbol] = (outer_tiles - 1) // 2
+                value = symbolic_bound.expression.xreplace(replacements)
+                if value.free_symbols or getattr(value, "is_integer", None) is not True:
+                    return None
+                try:
+                    extent = max(1, int(value))
+                except (TypeError, ValueError, OverflowError):
+                    return None
+            elif axis.bounded_by_block_id is not None:
+                extent = axis.bounded_extent or block_of[axis.bounded_by_block_id]
             else:
                 extent = axis.extent
             if extent is None:
-                return max(1, fallback), False
-            block = max(1, block_of.get(axis.block_id, 1))
-            trips *= max(1, -(-extent // block))
-        return trips, True
+                return None
+            trips *= max(1, -(-extent // block_of[axis.block_id]))
+        return trips
 
     @classmethod
-    def _pipelined_loop_trips(
+    def _dot_tile_extents(
         cls,
-        env: CompileEnvironment,
-        block_sizes: list[int],
-        *,
-        fallback: int,
-    ) -> int:
-        """Longest useful pipeline among sibling regions for one global stage knob."""
-        mm = env.config_spec.kernel_matmul_fact
-        if mm is None or not mm.pipelined_regions:
-            return max(1, fallback)
-        return max(
-            cls._resolved_loop_trips(
-                env,
-                block_sizes,
-                region.loop_axes,
-                fallback=fallback,
-            )
-            for region in mm.pipelined_regions
+        fact: MatmulFact,
+        axes: DotAxes,
+        block_of: dict[int, int],
+    ) -> tuple[int, int, int]:
+        def extent(axis: str, block_id: int | None, static: int | None) -> int:
+            if block_id is not None:
+                return block_of[block_id]
+            return max(1, axes.extent(axis) or static or 1)
+
+        return (
+            extent("m", fact.m_block_id, fact.static_m),
+            extent("n", fact.n_block_id, fact.static_n),
+            extent("k", fact.k_block_id, fact.static_k),
         )
 
     @classmethod
     def _all_dot_acc_tiles(
         cls, env: CompileEnvironment, block_sizes: list[int]
-    ) -> list[tuple[int, int, int]]:
-        """EVERY dot's accumulator tile, for the tensor-memory budget.
+    ) -> list[tuple[int, int, int, int]]:
+        """EVERY dot's accumulator and LHS tile, for the tensor-memory budget.
 
         Tensor memory is a static per-CTA reservation, and measured on B200 the compiler does
         not always reuse it across the dots of one kernel: a 5-dot kernel whose PEAK-LIVE dot
@@ -1264,98 +1264,61 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         strict, because the alternative is a config that dies at launch.
         """
         mm = env.config_spec.kernel_matmul_fact
-        if mm is None:
-            return []
+        assert mm is not None
         block_of = cls._full_block_map(env, block_sizes)
 
-        def extent(bid: int | None, axes_extent: int | None, static: int | None) -> int:
-            if bid is not None and bid in block_of:
-                return max(1, block_of[bid])
-            return max(1, axes_extent or static or 1)
-
-        out: list[tuple[int, int, int]] = []
+        out: list[tuple[int, int, int, int]] = []
         for resolved in mm.matmuls:
             f = resolved.fact
-            ax = resolved.axes
-            rows = extent(f.m_block_id, ax.m_extent, f.static_m)
-            cols = extent(f.n_block_id, ax.n_extent, f.static_n)
-            out.append((rows, cols, max(1, f.lhs_dtype.itemsize)))
+            rows, cols, inner = cls._dot_tile_extents(f, resolved.axes, block_of)
+            out.append((rows, cols, inner, max(1, f.lhs_dtype.itemsize)))
         return out
 
     @classmethod
     def _candidate_dot_work(
-        cls, env: CompileEnvironment, block_sizes: list[int]
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        *,
+        indices: Sequence[int] | None = None,
     ) -> CandidateDotWork:
         """Dynamic dot work performed by one CTA under ``block_sizes``.
 
         Per-invocation dimensions use the candidate tile. Enclosing loop axes use
         the matching candidate trip count, so an axis represented by both terms is
         covered once as ``block * ceil(extent / block)`` rather than once at full
-        extent and again as an unresolved loop multiplier.
+        extent and again as an unresolved loop multiplier. ``indices`` restricts
+        the same calculation to selected dots for proposal ranking.
         """
         mm = env.config_spec.kernel_matmul_fact
-        if mm is None:
-            return CandidateDotWork(0, 0)
+        assert mm is not None
         block_of = cls._full_block_map(env, block_sizes)
         total = 0
         tcgen05_eligible = 0
-        tcgen05_independent = 0
-        tcgen05_carried = 0
         uncertain = False
-        for resolved in mm.matmuls:
+        selected = range(len(mm.matmuls)) if indices is None else indices
+        for index in selected:
+            resolved = mm.matmuls[index]
             fact = resolved.fact
-            axes = resolved.axes
-
-            def extent(
-                axis: str,
-                block_id: int | None,
-                static: int | None,
-                dot_axes: DotAxes = axes,
-            ) -> int:
-                if block_id is not None and block_id in block_of:
-                    return max(1, block_of[block_id])
-                return max(1, dot_axes.extent(axis) or static or 1)
-
-            m = extent("m", fact.m_block_id, fact.static_m)
-            n = extent("n", fact.n_block_id, fact.static_n)
-            k = extent("k", fact.k_block_id, fact.static_k)
+            m, n, k = cls._dot_tile_extents(fact, resolved.axes, block_of)
             site = resolved.site
-            fallback = max(1, site.loop_trips) if site is not None else 1
-            loop_axes = getattr(site, "loop_axes", ()) if site is not None else ()
-            exact_loop_trips = (
-                getattr(site, "exact_loop_trips", None) if site is not None else None
-            )
-            if exact_loop_trips is not None:
-                trips = max(1, exact_loop_trips)
-            elif site is not None:
-                resolved_trips, exact = cls._resolved_loop_trips_detail(
+            if site.exact_loop_trips is not None:
+                trips = max(1, site.exact_loop_trips)
+            else:
+                resolved_trips = cls._resolved_loop_trips(
                     env,
                     block_sizes,
-                    loop_axes,
-                    fallback=fallback,
+                    site.loop_axes,
                 )
-                # An unresolved upper bound is safe for stages but is not positive
-                # evidence that tcgen05 setup can be amortized. Use one proven
-                # invocation as the work lower bound and retain the uncertainty.
-                trips = resolved_trips if exact else 1
-                uncertain = uncertain or not exact
-            else:
-                trips = fallback
+                # Unknown work is not evidence that tcgen05 setup can be
+                # amortized. Retain one proven invocation as a lower bound.
+                trips = resolved_trips if resolved_trips is not None else 1
+                uncertain = uncertain or resolved_trips is None
             work = m * n * k * trips
             total += work
             if m >= cls.TCGEN05_MIN_BM:
                 tcgen05_eligible += work
-                if site is not None and site.updates_carry:
-                    tcgen05_carried += work
-                else:
-                    tcgen05_independent += work
-        return CandidateDotWork(
-            total,
-            tcgen05_eligible,
-            tcgen05_independent,
-            tcgen05_carried,
-            uncertain,
-        )
+        return CandidateDotWork(total, tcgen05_eligible, uncertain)
 
     @classmethod
     def _register_live_bytes(
@@ -1392,7 +1355,8 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         Warp-count dependent, so it must be re-asked at each rung of the ladder.
         """
         mm = env.config_spec.kernel_matmul_fact
-        if mm is None or not mm.live_tile_steps:
+        assert mm is not None
+        if not mm.live_tile_steps:
             return 0
         block_of = cls._full_block_map(env, block_sizes)
         ceiling = cls.MAX_NUM_WARPS * 32 * cls.REG_BYTES_PER_THREAD
@@ -1407,7 +1371,17 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
                 if nbytes > ceiling:
                     continue
                 if tile.kind == "dot_out" and tmem_absorbs:
-                    rows = cls._tile_rows(tile, block_of)
+                    rows = 1
+                    for block_id, static in zip(
+                        tile.dim_block_ids[:-1],
+                        tile.static_dims[:-1],
+                        strict=False,
+                    ):
+                        rows *= (
+                            block_of[block_id]
+                            if block_id is not None
+                            else max(1, static or 1)
+                        )
                     if rows >= cls.TCGEN05_MIN_BM:
                         continue
                 total += nbytes
@@ -1415,44 +1389,15 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         return peak
 
     @classmethod
-    def _tile_rows(cls, tile: object, block_of: dict[int, int]) -> int:
-        """The tile's M extent (its second-to-last dim), which decides tcgen05 eligibility."""
-        dims = [
-            max(1, block_of.get(blk, 1)) if blk is not None else max(1, static or 1)
-            for blk, static in zip(
-                tile.dim_block_ids,  # type: ignore[attr-defined]
-                tile.static_dims,  # type: ignore[attr-defined]
-                strict=False,
-            )
-        ]
-        if len(dims) == 1:
-            return 1
-        rows = dims[-2]
-        for lead in dims[:-2]:
-            rows *= lead
-        return rows
-
-    @classmethod
     def _resolve_tile_bytes(cls, tile: object, block_of: dict[int, int]) -> int:
         """Bytes one recorded live tile occupies once the candidate block sizes are known."""
         elems = 1
         for blk, static in zip(tile.dim_block_ids, tile.static_dims, strict=False):  # type: ignore[attr-defined]
             if blk is not None:
-                elems *= max(1, block_of.get(blk, 1))
+                elems *= block_of[blk]
             else:
                 elems *= max(1, static or 1)
         return elems * max(1, tile.itemsize)  # type: ignore[attr-defined]
-
-    @classmethod
-    def _epilogue_smem(cls, env: CompileEnvironment, block_sizes: list[int]) -> int:
-        """Largest conservative fp32 accumulator-staging buffer in the kernel."""
-        return max(
-            (
-                rows * cols * cls.EPILOGUE_ACC_ITEMSIZE
-                for rows, cols, _itemsize in cls._all_dot_acc_tiles(env, block_sizes)
-            ),
-            default=0,
-        )
 
     @classmethod
     def _kernel_smem_bytes(
@@ -1462,9 +1407,35 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         num_stages: int,
     ) -> int:
         """Peak whole-kernel SMEM under one complete block-size candidate."""
-        region_peak = cls._smem_from_map(env, block_sizes, num_stages)
-        epilogue_peak = cls._epilogue_smem(env, block_sizes)
-        return max(region_peak, epilogue_peak) + cls.SMEM_SLACK
+        return max(cls._kernel_smem_demands(env, block_sizes, num_stages))
+
+    @classmethod
+    def _kernel_smem_demands(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        num_stages: int,
+        *,
+        hard_allocation: bool = False,
+    ) -> tuple[int, ...]:
+        """Independently binding SMEM demands under one candidate."""
+        demands = list(
+            cls._smem_region_demands(
+                env,
+                block_sizes,
+                num_stages,
+                hard_allocation=hard_allocation,
+            )
+        )
+        demands.append(
+            max(
+                rows * cols * cls.EPILOGUE_ACC_ITEMSIZE
+                for rows, cols, _inner, _itemsize in cls._all_dot_acc_tiles(
+                    env, block_sizes
+                )
+            )
+        )
+        return tuple(demand + cls.SMEM_SLACK for demand in demands)
 
     @classmethod
     def _apply_knob_roles(
@@ -1738,10 +1709,16 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         num_sm: int,
         shrinkable: list[int],
         largest_first: bool,
-        max_corrections: int,
-        extra_over_budget: Callable[[list[int], int], bool] | None = None,
     ) -> tuple[int, int]:
-        """Reduce stages, then selected block knobs, until hard resources fit."""
+        """Make a candidate legal under the hard SMEM and TMEM budgets.
+
+        Repeatedly lower ``num_stages`` when that relieves a current violation;
+        otherwise try one-step halvings of every shrinkable block knob. A block
+        trial must reduce at least one overflowing demand and is ranked by full
+        legality, violations cleared, retained tcgen05 work, fractional relief,
+        then a stable legacy tie-break. Demands remain separate so relieving one
+        of two tied region peaks still counts as progress.
+        """
         slot_of: dict[int, int] = {}
         floors: dict[int, int] = {}
         for slot in range(len(env.config_spec.block_sizes)):
@@ -1749,60 +1726,146 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             slot_of[bs.block_id] = slot
             floors[bs.block_id] = max(1, bs.min_size, bs.autotuner_min)
 
-        def smem_over() -> bool:
-            return cls.ENFORCE_SMEM_BUDGET and (
-                cls._kernel_smem_bytes(env, block_sizes, num_stages) > cls.SMEM_BUDGET
-            )
-
-        def tmem_over() -> bool:
-            return (
-                cls.TMEM_COLUMN_BUDGET is not None
-                and num_warps >= cls.TCGEN05_WARPGROUP_WARPS
-                and cls._tmem_columns(cls._all_dot_acc_tiles(env, block_sizes))
-                > cls.TMEM_COLUMN_BUDGET
-            )
-
-        def over_budget() -> bool:
-            return (
-                smem_over()
-                or tmem_over()
-                or (
-                    extra_over_budget is not None
-                    and extra_over_budget(block_sizes, num_warps)
+        def hard_resources(
+            candidate: list[int],
+            warps: int,
+            stages: int,
+        ) -> tuple[tuple[int, int], ...]:
+            resources: list[tuple[int, int]] = []
+            if cls.ENFORCE_SMEM_BUDGET:
+                resources.extend(
+                    (demand, cls.SMEM_BUDGET)
+                    for demand in cls._kernel_smem_demands(
+                        env,
+                        candidate,
+                        stages,
+                        hard_allocation=True,
+                    )
                 )
-            )
+            if cls.TMEM_COLUMN_BUDGET is not None:
+                # This scratch-inclusive allocation-unit model also dominates
+                # the old per-dot TMEM byte check.
+                resources.append(
+                    (
+                        (
+                            cls._tmem_columns(
+                                cls._all_dot_acc_tiles(env, candidate),
+                                include_lhs_scratch=True,
+                            )
+                            if warps >= cls.TCGEN05_WARPGROUP_WARPS
+                            else 0
+                        ),
+                        cls.TMEM_COLUMN_BUDGET,
+                    )
+                )
+            return tuple(resources)
 
-        guard = 0
-        while over_budget() and guard < max_corrections:
-            guard += 1
-            if num_stages > cls.MIN_NUM_STAGES and smem_over():
-                num_stages -= 1
-                continue
+        def relief(
+            current: tuple[tuple[int, int], ...],
+            trial: tuple[tuple[int, int], ...],
+        ) -> tuple[int, float] | None:
+            """Measure progress against demands that are currently over budget.
+
+            Return the number made legal and their summed fractional reduction,
+            or ``None`` when the trial does not reduce any current violation.
+            """
+            cleared = 0
+            reduction = 0.0
+            for (demand, budget), (trial_demand, _) in zip(current, trial, strict=True):
+                if demand > budget and trial_demand < demand:
+                    cleared += trial_demand <= budget
+                    reduction += (demand - trial_demand) / demand
+            return (cleared, reduction) if reduction else None
+
+        mm = env.config_spec.kernel_matmul_fact
+        assert mm is not None
+        while True:
+            current = hard_resources(block_sizes, num_warps, num_stages)
+            if all(demand <= budget for demand, budget in current):
+                break
+
+            if num_stages > cls.MIN_NUM_STAGES:
+                trial_stages = num_stages - 1
+                trial_resources = hard_resources(
+                    block_sizes,
+                    num_warps,
+                    trial_stages,
+                )
+                if relief(current, trial_resources) is not None:
+                    num_stages = trial_stages
+                    continue
+
             candidates = [
                 bid
-                for bid in shrinkable
+                for bid in dict.fromkeys(shrinkable)
                 if bid in slot_of
-                and block_sizes[slot_of[bid]] // 2
-                >= max(
-                    floors[bid],
-                    min(cls.DOT_MIN, block_sizes[slot_of[bid]]),
-                )
+                and block_sizes[slot_of[bid]] // 2 >= max(floors[bid], cls.DOT_MIN)
             ]
-            if not candidates:
+            # Keep per-dot work fixed while scoring trials: only crossing the
+            # tcgen05 eligibility boundary should change this preference.
+            dot_weights = tuple(
+                cls._candidate_dot_work(
+                    env,
+                    block_sizes,
+                    indices=(index,),
+                ).total
+                for index in range(len(mm.matmuls))
+            )
+            trials: list[tuple[tuple[int, int, int, float, int], list[int], int]] = []
+            for position, bid in enumerate(candidates):
+                trial = list(block_sizes)
+                trial[slot_of[bid]] //= 2
+                trial_warps = cls._solve_candidate_warps(
+                    env,
+                    trial,
+                    num_warps,
+                    num_stages,
+                    num_sm,
+                )
+                trial_resources = hard_resources(trial, trial_warps, num_stages)
+                impact = relief(
+                    current,
+                    trial_resources,
+                )
+                if impact is None:
+                    continue
+                legal = all(demand <= budget for demand, budget in trial_resources)
+                tcgen05_work = 0
+                if trial_warps >= cls.TCGEN05_WARPGROUP_WARPS:
+                    trial_blocks = cls._full_block_map(env, trial)
+                    tcgen05_work = sum(
+                        weight
+                        for resolved, weight in zip(
+                            mm.matmuls, dot_weights, strict=True
+                        )
+                        if cls._dot_tile_extents(
+                            resolved.fact,
+                            resolved.axes,
+                            trial_blocks,
+                        )[0]
+                        >= cls.TCGEN05_MIN_BM
+                    )
+                legacy_tiebreak = (
+                    block_sizes[slot_of[bid]] if largest_first else -position
+                )
+                cleared, normalized_relief = impact
+                trials.append(
+                    (
+                        (
+                            int(legal),
+                            cleared,
+                            tcgen05_work,
+                            0.0 if legal else normalized_relief,
+                            legacy_tiebreak,
+                        ),
+                        trial,
+                        trial_warps,
+                    )
+                )
+            if not trials:
                 break
-            victim = (
-                max(candidates, key=lambda bid: block_sizes[slot_of[bid]])
-                if largest_first
-                else candidates[0]
-            )
-            block_sizes[slot_of[victim]] //= 2
-            num_warps = cls._solve_candidate_warps(
-                env,
-                block_sizes,
-                num_warps,
-                num_stages,
-                num_sm,
-            )
+            _score, winner, num_warps = max(trials, key=itemgetter(0))
+            block_sizes[:] = winner
 
         num_warps = cls._solve_candidate_warps(
             env,
@@ -1822,6 +1885,9 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         itemsize: int,
         num_sm: int,
         pinned_grid: int = 1,
+        *,
+        launch_grid: Callable[[int, int], int] | None = None,
+        allow_l2_grouping: bool = True,
     ) -> tuple[int, int, int, int, int, int]:
         """Budget/roofline formula: turns ``(M, N, K, operand-width)`` into ``(block_m, block_n,
         block_k, num_warps, num_stages, l2_grouping)`` with no lookup. Reads its budget constants
@@ -1880,8 +1946,21 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
 
         wave_full = cls.WAVE_FULL
 
+        if launch_grid is None:
+            # The standalone formula helper is explicitly a clean GEMM: M and N
+            # are proven grid axes, while ``pinned_grid`` represents the remaining
+            # launch dimensions. Production dot proposals supply the exact
+            # DeviceIR-derived callback below.
+            def launch_grid(_bm: int, _bn: int) -> int:
+                return (
+                    max(1, pinned_grid)
+                    * max(1, -(-m // max(1, _bm)))
+                    * max(1, -(-n // max(1, _bn)))
+                )
+
         def _wave_eff(_bm: int, _bn: int) -> float:
-            g = max(1, pinned_grid) * ((m + _bm - 1) // _bm) * ((n + _bn - 1) // _bn)
+            assert launch_grid is not None
+            g = launch_grid(_bm, _bn)
             waves = (g + num_sm - 1) // num_sm
             return g / (waves * num_sm)
 
@@ -2017,9 +2096,14 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         # (6) l2_grouping: reorder PIDs so a group of M-tiles shares an L2-resident B operand. Helps
         # a tall tile-grid (many M-tiles reuse one B) but hurts a wide/square grid, so gate on the
         # measured crossover grid_m >= L2_TALL_RATIO * grid_n.
-        grid_m = (m + bm - 1) // bm
-        grid_n = (n + bn - 1) // bn
-        l2_grouping = 2 if grid_m > 1 and grid_m >= cls.L2_TALL_RATIO * grid_n else 1
+        if allow_l2_grouping:
+            grid_m = (m + bm - 1) // bm
+            grid_n = (n + bn - 1) // bn
+            l2_grouping = (
+                2 if grid_m > 1 and grid_m >= cls.L2_TALL_RATIO * grid_n else 1
+            )
+        else:
+            l2_grouping = 1
 
         return bm, bn, bk, num_warps, num_stages, l2_grouping
 
@@ -2031,8 +2115,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         axes: DotAxes | None,
         itemsize: int,
         num_sm: int,
-        pinned_grid: int,
-        site: DotSite | None = None,
+        site: DotSite,
     ) -> tuple[int, int, int, int, int, int]:
         """Project one dot-local formula proposal onto the axes the kernel exposes."""
         m_extent = fact.static_m if fact.static_m is not None else None
@@ -2043,9 +2126,8 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         if m_extent is None or n_extent is None:
             return cls.DOT_MIN, cls.DOT_MIN, cls.DOT_MIN, 4, cls.MIN_NUM_STAGES, 1
         mm = env.config_spec.kernel_matmul_fact
-        loop_trips = 1
-        if mm is not None:
-            loop_trips = max(1, mm.sequential_loop_trips)
+        assert mm is not None
+        loop_trips = max(1, mm.sequential_loop_trips)
 
         k_logical = fact.static_k
         k_fixed = axes is not None and axes.k_kind is DotAxisKind.FIXED_FULL_EXTENT
@@ -2054,23 +2136,74 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         elif k_logical is None and axes is not None and axes.k_extent:
             k_logical = axes.k_extent
 
+        spec = env.config_spec
+        bounds: dict[int, tuple[int, int]] = {}
+        slot_of: dict[int, int] = {}
+        for slot in range(len(spec.block_sizes)):
+            block_spec = cast("BlockSizeSpec", spec.block_sizes[slot])
+            slot_of[block_spec.block_id] = slot
+            bounds[block_spec.block_id] = (
+                max(1, block_spec.min_size, block_spec.autotuner_min),
+                block_spec.max_size,
+            )
+        base_blocks = list(
+            cast("list[int]", spec._base_default_config().config["block_sizes"])
+        )
+        graph_ids = (site.graph_id,)
+        grid_group = (
+            spec.kernel_grid_fact.group_for_graph(site.graph_id)
+            if spec.kernel_grid_fact is not None
+            else ()
+        )
+        grid_ids = set(grid_group or spec.grid_block_ids)
+        output_axes = (("m", fact.m_block_id), ("n", fact.n_block_id))
+        allow_l2_grouping = all(
+            block_id is not None
+            and block_id in slot_of
+            and block_id in grid_ids
+            and (axes is None or axes.kind(axis) is DotAxisKind.TUNABLE_TILED)
+            for axis, block_id in output_axes
+        )
+        pinned_grid = cls._launch_grid(
+            env,
+            base_blocks,
+            graph_ids=graph_ids,
+            collapsed_block_ids=tuple(
+                block_id for _axis, block_id in output_axes if block_id is not None
+            ),
+        )
+
+        def candidate_launch_grid(candidate_m: int, candidate_n: int) -> int:
+            block_sizes = list(base_blocks)
+            for block_id, value in (
+                (fact.m_block_id, candidate_m),
+                (fact.n_block_id, candidate_n),
+            ):
+                if block_id is None or block_id not in slot_of:
+                    continue
+                lo, hi = bounds[block_id]
+                block_sizes[slot_of[block_id]] = max(lo, min(hi, value))
+            return cls._launch_grid(
+                env,
+                block_sizes,
+                graph_ids=graph_ids,
+            )
+
         bm, bn, bk, num_warps, num_stages, l2 = cls._matmul_tile(
-            m_extent, n_extent, k_logical or cls.DOT_MIN, itemsize, num_sm, pinned_grid
+            m_extent,
+            n_extent,
+            k_logical or cls.DOT_MIN,
+            itemsize,
+            num_sm,
+            pinned_grid,
+            launch_grid=candidate_launch_grid,
+            allow_l2_grouping=allow_l2_grouping,
         )
 
         if axes is None:
             return bm, bn, bk, num_warps, num_stages, l2
 
         # (2) project
-        spec = env.config_spec
-        bounds: dict[int, tuple[int, int]] = {}
-        for i in range(len(spec.block_sizes)):
-            bs = cast("BlockSizeSpec", spec.block_sizes[i])
-            bounds[bs.block_id] = (
-                max(1, bs.min_size, bs.autotuner_min),
-                bs.max_size,
-            )
-
         def project(axis: str, value: int, bid: int | None) -> int:
             if axes.kind(axis) is DotAxisKind.FIXED_FULL_EXTENT:
                 return max(1, axes.extent(axis) or value)
@@ -2084,10 +2217,8 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         bk = project("k", bk, fact.k_block_id)
 
         # A partitioned K loop exposes many independent partial-output CTAs.
-        site_loop_axes = getattr(site, "loop_axes", ()) if site is not None else ()
         partitioned_k = any(
-            getattr(axis, "bounded_by_block_id", None) is not None
-            for axis in site_loop_axes
+            axis.bounded_by_block_id is not None for axis in site.loop_axes
         )
         if (
             partitioned_k
@@ -2107,8 +2238,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         axes: DotAxes | None,
         itemsize: int,
         num_sm: int,
-        pinned_grid: int,
-        site: DotSite | None = None,
+        site: DotSite,
     ) -> tuple[int, int, int, int, int, int]:
         """Finalize one projected dot against its complete kernel block-size candidate."""
         proposal = cls._projected_tile_for_dot(
@@ -2117,16 +2247,16 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             axes,
             itemsize,
             num_sm,
-            pinned_grid,
             site=site,
         )
         if axes is None:
             return proposal
         bm, bn, bk, num_warps, num_stages, l2 = proposal
         mm = env.config_spec.kernel_matmul_fact
-        loop_trips = max(1, mm.sequential_loop_trips) if mm is not None else 1
+        assert mm is not None
+        loop_trips = max(1, mm.sequential_loop_trips)
         k_fixed = axes.k_kind is DotAxisKind.FIXED_FULL_EXTENT
-        site_loop_axes = getattr(site, "loop_axes", ()) if site is not None else ()
+        site_loop_axes = site.loop_axes
         spec = env.config_spec
         slot_of: dict[int, int] = {}
         for slot in range(len(spec.block_sizes)):
@@ -2134,15 +2264,18 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             slot_of[bs.block_id] = slot
 
         emitted = _h100_build_block_sizes(env.config_spec, fact, bm, bn, bk)
-        if cls.SINGLE_ROLE_AWARE_KNOBS and mm is not None:
+        if cls.SINGLE_ROLE_AWARE_KNOBS:
             cls._apply_knob_roles(env, mm, emitted, num_sm)
         if site_loop_axes:
-            loop_trips = cls._resolved_loop_trips(
+            resolved_loop_trips = cls._resolved_loop_trips(
                 env,
                 emitted,
                 site_loop_axes,
-                fallback=loop_trips,
             )
+            if resolved_loop_trips is not None:
+                loop_trips = resolved_loop_trips
+            elif site.max_loop_trips is not None:
+                loop_trips = max(1, site.max_loop_trips)
 
         if cls.GRADED_STAGES and k_fixed:
             num_stages = cls._solve_candidate_stages(
@@ -2160,26 +2293,6 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             num_sm,
         )
 
-        base_tile = bm, bn, bk
-
-        def dot_tile(block_sizes: list[int]) -> tuple[int, int, int]:
-            def value(block_id: int | None, fallback: int) -> int:
-                if block_id is None or block_id not in slot_of:
-                    return fallback
-                return block_sizes[slot_of[block_id]]
-
-            return (
-                value(fact.m_block_id, base_tile[0]),
-                value(fact.n_block_id, base_tile[1]),
-                value(fact.k_block_id, base_tile[2]),
-            )
-
-        def focal_tmem_over(block_sizes: list[int], warps: int) -> bool:
-            if warps < cls.TCGEN05_WARPGROUP_WARPS or cls.TMEM_BUDGET is None:
-                return False
-            tile_m, tile_n, tile_k = dot_tile(block_sizes)
-            return cls._tmem_bytes(tile_m, tile_n, tile_k, itemsize) > cls.TMEM_BUDGET
-
         shrinkable = [
             block_id
             for axis, block_id in (
@@ -2196,10 +2309,13 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             num_sm=num_sm,
             shrinkable=shrinkable,
             largest_first=False,
-            max_corrections=40,
-            extra_over_budget=focal_tmem_over,
         )
-        bm, bn, bk = dot_tile(emitted)
+        if fact.m_block_id is not None and fact.m_block_id in slot_of:
+            bm = emitted[slot_of[fact.m_block_id]]
+        if fact.n_block_id is not None and fact.n_block_id in slot_of:
+            bn = emitted[slot_of[fact.n_block_id]]
+        if fact.k_block_id is not None and fact.k_block_id in slot_of:
+            bk = emitted[slot_of[fact.k_block_id]]
         return bm, bn, bk, num_warps, num_stages, l2
 
     @classmethod
@@ -2216,21 +2332,8 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         itemsize = max(1, fact.lhs_dtype.itemsize)
         num_sm = max(1, get_num_sm(env.device))
         mm = env.config_spec.kernel_matmul_fact
-        site = mm.matmuls[0].site if mm is not None and mm.matmuls else None
-        base_blocks = list(
-            cast(
-                "list[int]",
-                spec._base_default_config().config.get("block_sizes", []),
-            )
-        )
-        block_of = cls._full_block_map(env, base_blocks)
-        grid_block_ids = _grid_group_for_site(spec, site)
-        pinned_grid = _h100_pinned_grid(
-            env,
-            fact,
-            block_of,
-            grid_block_ids,
-        )
+        assert mm is not None
+        site = mm.matmuls[0].site
         # The budget formula sizes the dot tile under a register/SMEM budget, keyed on
         # (M, N, K, operand-width via itemsize) and the pinned batch grid. ``_tile_for_dot``
         # then projects that proposal onto the axes this kernel actually exposes and
@@ -2238,7 +2341,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         # tunable axes and one live accumulator it returns the proposal unchanged.
         axes = _axis_roles(env.config_spec, 0) if cls.GENERALIZED_AXES else None
         bm, bn, bk, nw, ns, l2 = cls._tile_for_dot(
-            env, fact, axes, itemsize, num_sm, pinned_grid, site=site
+            env, fact, axes, itemsize, num_sm, site=site
         )
 
         def _extra(
@@ -2255,7 +2358,6 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
                 _nw,
                 _ns,
                 _l2,
-                pinned_grid,
                 num_sm,
             )
 
@@ -2469,13 +2571,10 @@ class TritonB200FormulaMatmulHeuristic(TritonH100MatmulHeuristic):
     SINGLE_ROLE_AWARE_KNOBS = True
     ROLE_FLAT_OUTPUT = True
     ROLE_GRID_FILL = True
-    # tcgen05 tensor memory is allocated by ``tcgen05.alloc``, whose column count is a
-    # power of two and AT LEAST 32. An accumulator narrower than 32 columns therefore
-    # reserves 32 columns anyway while issuing half the MMA work per instruction, so 32
-    # is a hardware floor on any knob that sizes an accumulator extent -- not a tuned
-    # constant. Measured: on a reuse-free output axis, 32 beats 16 on every case swept
-    # (wy_delta#2 1.209 vs 1.111, #10 1.192 vs 1.139, #15 1.179 vs 1.090,
-    # wy_delta_varlen#0 1.737 vs 1.460) and beats the un-corrected draft by 1.2-1.8x.
+    # tcgen05 tensor memory allocates at least 32 columns. Use that as the floor
+    # only for a non-grid, reuse-free N output knob: below 32 it reserves the
+    # same tensor memory while issuing less MMA work. M uses the tcgen05 row
+    # threshold, and launch-grid knobs use their legal block minimum.
     TMEM_ALLOC_COLUMNS = 32
 
     @classmethod
@@ -2501,9 +2600,15 @@ class TritonB200FormulaMatmulHeuristic(TritonH100MatmulHeuristic):
         """
         for region in mm.pipelined_regions:
             tiles = region.tiles
-            if not any(block_id in t.dim_block_ids for t in tiles):
+            loop_block_ids = {axis.block_id for axis in region.loop_axes}
+            if block_id not in loop_block_ids and not any(
+                block_id in tile.dim_block_ids for tile in tiles
+            ):
                 continue
-            if any(t.kind == "load" and block_id not in t.dim_block_ids for t in tiles):
+            if any(
+                tile.kind == "load" and block_id not in tile.dim_block_ids
+                for tile in tiles
+            ):
                 return True
         return False
 
@@ -2531,8 +2636,11 @@ class TritonB200FormulaMatmulHeuristic(TritonH100MatmulHeuristic):
           while the launch is below one wave and the shrink strictly improves wave
           utilization.
 
-        The floor is the same quantity in both cases, ``TMEM_ALLOC_COLUMNS``, because
-        it is a hardware allocation granularity rather than a policy choice.
+        Reuse-free N axes stop at the tensor-memory column granularity. M axes
+        stop at ``TCGEN05_MIN_BM`` so this correction does not remove tcgen05
+        from the later regime-aware warp solve. Grid axes stop at their legal
+        block minimum; tensor-memory allocation granularity is not a launch-grid
+        constraint.
         """
         spec = env.config_spec
         grid_ids = set(spec.grid_block_ids)
@@ -2543,17 +2651,24 @@ class TritonB200FormulaMatmulHeuristic(TritonH100MatmulHeuristic):
             slot_of[bs.block_id] = slot
             lo_of[bs.block_id] = max(1, bs.min_size, bs.autotuner_min)
 
-        def claimed_as_output(users: tuple[tuple[int, str], ...]) -> bool:
-            return any(axis in ("m", "n") for _i, axis in users)
+        def output_floor(users: tuple[tuple[int, str], ...]) -> int | None:
+            roles = {axis for _index, axis in users}
+            if "m" in roles:
+                return cls.TCGEN05_MIN_BM
+            if "n" in roles:
+                return cls.TMEM_ALLOC_COLUMNS
+            return None
 
         # (1) reuse-free output knobs -> the allocation floor.
         for bid, users in mm.knob_users if cls.ROLE_FLAT_OUTPUT else ():
             if bid not in slot_of or bid in grid_ids or not users:
                 continue
-            if not claimed_as_output(users) or cls._knob_amortizes(mm, bid):
+            floor = output_floor(users)
+            if floor is None or cls._knob_amortizes(mm, bid):
                 continue
             slot = slot_of[bid]
-            target = min(cls._axis_extent(env, bid), cls.TMEM_ALLOC_COLUMNS)
+            extent = cls._axis_extent(env, bid)
+            target = floor if extent is None else min(extent, floor)
             block_sizes[slot] = max(lo_of[bid], min(block_sizes[slot], target))
 
         # (2) grid knobs -> fill one wave, but only across a favorable wave boundary.
@@ -2575,7 +2690,7 @@ class TritonB200FormulaMatmulHeuristic(TritonH100MatmulHeuristic):
             candidates: list[int] = []
             for bid in grid_knobs:
                 slot = slot_of[bid]
-                if block_sizes[slot] // 2 < max(lo_of[bid], cls.TMEM_ALLOC_COLUMNS):
+                if block_sizes[slot] // 2 < lo_of[bid]:
                     continue
                 trial = list(block_sizes)
                 trial[slot] //= 2
@@ -2680,45 +2795,31 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
         return not any(_is_fp8_matmul_fact(resolved.fact) for resolved in mm.matmuls)
 
     @classmethod
-    def _rank_key(cls, mm: KernelMatmulFact, index: int) -> tuple[int, int, int]:
+    def _rank_key(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        index: int,
+        block_sizes: list[int],
+    ) -> tuple[int, int, int]:
         """Dynamic importance of one dot. Higher wins.
 
         ``updates_carry`` leads because a dot writing a loop-carried accumulator keeps that
-        accumulator resident for the whole loop; ``dot_work`` (``m*n*k`` times executions) is
-        the magnitude term; the dot's own output area breaks remaining ties toward the dot
-        with the most to lose from a bad tile. Untrusted attribution collapses the first term
-        for every dot equally, so ranking degrades to pure work rather than to an arbitrary
-        order."""
+        accumulator resident for the whole loop; candidate-resolved dynamic work is the
+        magnitude term; the dot's own output area breaks remaining ties toward the dot with
+        the most to lose from a bad tile. Untrusted attribution collapses the first term for
+        every dot equally, so ranking degrades to pure work rather than to an arbitrary order."""
         resolved = mm.matmuls[index]
         carry = 1 if (mm.attribution_complete and resolved.site.updates_carry) else 0
         f = resolved.fact
         ax = resolved.axes
         area = (f.static_m or ax.m_extent or 1) * (f.static_n or ax.n_extent or 1)
-        return (carry, mm.dot_work(index), area)
-
-    @classmethod
-    def _proposal_for(
-        cls, env: CompileEnvironment, mm: KernelMatmulFact, index: int, num_sm: int
-    ) -> tuple[int, int, int, int, int, int] | None:
-        """One dot's prior, projected and preconditioned against the whole kernel."""
-        resolved = mm.matmuls[index]
-        fact = resolved.fact
-        ax = resolved.axes
-        if any(
-            ax.kind(a) is DotAxisKind.UNKNOWN or ax.extent(a) is None
-            for a in ("m", "n", "k")
-        ):
-            return None
-        itemsize = max(1, fact.lhs_dtype.itemsize)
-        return cls._tile_for_dot(
+        work = cls._candidate_dot_work(
             env,
-            fact,
-            ax,
-            itemsize,
-            num_sm,
-            max(1, mm.outer_grid),
-            site=resolved.site,
-        )
+            block_sizes,
+            indices=(index,),
+        ).total
+        return (carry, work, area)
 
     @classmethod
     def _draft(
@@ -2730,14 +2831,39 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
         spec = env.config_spec
         num_sm = max(1, get_num_sm(env.device))
         proposals: dict[int, tuple[int, int, int, int, int, int]] = {}
-        for i in range(len(mm.matmuls)):
-            p = cls._proposal_for(env, mm, i, num_sm)
-            if p is not None:
-                proposals[i] = p
+        for index, resolved in enumerate(mm.matmuls):
+            axes = resolved.axes
+            if any(
+                axes.kind(axis) is DotAxisKind.UNKNOWN or axes.extent(axis) is None
+                for axis in ("m", "n", "k")
+            ):
+                continue
+            fact = resolved.fact
+            proposals[index] = cls._tile_for_dot(
+                env,
+                fact,
+                axes,
+                max(1, fact.lhs_dtype.itemsize),
+                num_sm,
+                site=resolved.site,
+            )
         if not proposals:
             return None
 
-        order = sorted(proposals, key=lambda i: cls._rank_key(mm, i), reverse=True)
+        order = sorted(
+            proposals,
+            key=lambda i: cls._rank_key(
+                env,
+                mm,
+                i,
+                _h100_build_block_sizes(
+                    spec,
+                    mm.matmuls[i].fact,
+                    *proposals[i][:3],
+                ),
+            ),
+            reverse=True,
+        )
         rank_of = {i: r for r, i in enumerate(order)}
 
         # --- block sizes: the winning dot's value for each contested knob ---------------
@@ -2745,7 +2871,7 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
         # keeps exactly the size it has today, rather than being pinned by a rule that was
         # never measured on it.
         base = spec._base_default_config()
-        block_sizes = list(cast("list[int]", base.config.get("block_sizes", [])))
+        block_sizes = list(cast("list[int]", base.config["block_sizes"]))
         grid_ids = set(spec.grid_block_ids)
         mn_ids = {resolved.fact.m_block_id for resolved in mm.matmuls} | {
             resolved.fact.n_block_id for resolved in mm.matmuls
@@ -2764,19 +2890,16 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
                 value = (
                     {"m": p[0], "n": p[1], "k": p[2]}[axis]
                     if p is not None
-                    else (block_sizes[slot] if slot < len(block_sizes) else lo)
+                    else block_sizes[slot]
                 )
             elif bid in grid_ids and bid not in mn_ids:
                 # A batch/outer parallel axis: pin to its floor, exactly as front end 1
                 # does, so the per-program budget the proposals were sized under holds.
                 value = lo
             else:
-                value = block_sizes[slot] if slot < len(block_sizes) else lo
+                value = block_sizes[slot]
             value = max(lo, min(bs.max_size, value))
-            if slot < len(block_sizes):
-                block_sizes[slot] = value
-            else:
-                block_sizes.append(value)
+            block_sizes[slot] = value
 
         # The ranked draft sizes every knob as if it were a GEMM's output tile axis.
         # Correct it for what each knob's axis actually is before anything derived from
@@ -2784,19 +2907,26 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
         # The pre-role snapshot is retained only for the ``ROLE_KEEP_STAGES`` ablation.
         stage_ring = list(block_sizes)
         if cls.ROLE_AWARE_KNOBS:
-            pre_role_ring = stage_ring
             cls._apply_knob_roles(env, mm, block_sizes, num_sm)
-            stage_ring = pre_role_ring if cls.ROLE_KEEP_STAGES else list(block_sizes)
+            if not cls.ROLE_KEEP_STAGES:
+                stage_ring = list(block_sizes)
 
         # --- kernel-global scalars: aggregate, not any single dot's ---------------------
-        num_warps = max(proposals[i][3] for i in proposals)
-        num_stages = max(proposals[i][4] for i in proposals)
+        num_warps = max(proposal[3] for proposal in proposals.values())
+        num_stages = max(proposal[4] for proposal in proposals.values())
 
         if cls.GRADED_STAGES:
-            loop_trips = cls._pipelined_loop_trips(
-                env,
-                stage_ring,
-                fallback=max(1, mm.sequential_loop_trips),
+            max_loop_trips = max(1, mm.sequential_loop_trips)
+            resolved_trips = (
+                cls._resolved_loop_trips(env, stage_ring, region.loop_axes)
+                for region in mm.pipelined_regions
+            )
+            loop_trips = max(
+                (
+                    trips if trips is not None else max_loop_trips
+                    for trips in resolved_trips
+                ),
+                default=max_loop_trips,
             )
             num_stages = cls._solve_candidate_stages(
                 env,
@@ -2818,27 +2948,8 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
             "block_sizes": block_sizes,
             "num_warps": num_warps,
             "num_stages": num_stages,
-            "_grid": cls._launch_grid(env, block_sizes),
             "_num_sm": num_sm,
         }
-
-    @classmethod
-    def _fixup(
-        cls, env: CompileEnvironment, mm: KernelMatmulFact, draft: dict[str, Any]
-    ) -> None:
-        """Phase 2: enforce hard budgets on the merged candidate."""
-        block_sizes: list[int] = draft["block_sizes"]
-        draft["num_stages"], draft["num_warps"] = cls._fixup_candidate_resources(
-            env,
-            block_sizes,
-            draft["num_stages"],
-            draft["num_warps"],
-            num_sm=draft["_num_sm"],
-            shrinkable=[bid for bid, _users in mm.knob_users],
-            largest_first=True,
-            max_corrections=64,
-        )
-        draft["_grid"] = cls._launch_grid(env, block_sizes)
 
     @classmethod
     def _multi_ranked(cls, env: CompileEnvironment) -> list[Config]:
@@ -2848,7 +2959,15 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
         draft = cls._draft(env, mm)
         if draft is None:
             return []
-        cls._fixup(env, mm, draft)
+        draft["num_stages"], draft["num_warps"] = cls._fixup_candidate_resources(
+            env,
+            draft["block_sizes"],
+            draft["num_stages"],
+            draft["num_warps"],
+            num_sm=draft["_num_sm"],
+            shrinkable=[bid for bid, _users in mm.knob_users],
+            largest_first=True,
+        )
         primary: dict[str, Any] = {
             "block_sizes": list(draft["block_sizes"]),
             "num_warps": draft["num_warps"],

--- a/helion/_compiler/device_ir_analysis.py
+++ b/helion/_compiler/device_ir_analysis.py
@@ -24,13 +24,18 @@ from ..autotuner.config_spec import PointwiseElementwiseFact
 from ..autotuner.config_spec import ResidentRegion
 from ..autotuner.config_spec import ResolvedMatmulFact
 from ..autotuner.config_spec import RootGridFact
+from ..autotuner.config_spec import SymbolicLoopBound
 from ..language import _tracing_ops
 from .compile_environment import FixedBlockSizeSource
+from .compile_environment import _symint_free_symbols
+from .compile_environment import _symint_sympy_expr
 from .indexing_strategy import subscript_index_scale
 from .indexing_strategy import subscript_tile_info
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    import sympy
 
     from ..autotuner.config_spec import ConfigSpec
     from .compile_environment import CompileEnvironment
@@ -51,6 +56,7 @@ def matmul_operand_positions() -> dict[object, tuple[int, int]]:
         matmul_ops.dot: (0, 1),
         torch.ops.aten.mm.default: (0, 1),
         torch.ops.aten.bmm.default: (0, 1),
+        torch.ops.aten.bmm.dtype: (0, 1),
         torch.ops.aten.addmm.default: (1, 2),
         torch.ops.aten.baddbmm.default: (1, 2),
     }
@@ -313,7 +319,6 @@ class GraphAnalysis:
     block_id_order: tuple[int, ...]
     live_tile_steps: tuple[tuple[LiveTile, ...], ...]
     peak_live_tiles: tuple[LiveTile, ...]
-    peak_dot_output_tiles: tuple[LiveTile, ...]
     dot_nodes: tuple[torch.fx.Node, ...]
     reduction_occurrences: tuple[int, ...]
     reduction_axis_by_node_id: dict[int, int]
@@ -427,37 +432,6 @@ class GraphAnalysis:
                     peak_live_tiles = step
             live = {value for value in live if last_use.get(value, -1) > index}
 
-        dot_details = {
-            node: tile
-            for node in dot_nodes
-            if (
-                tile := _tile_from_tensor(
-                    node.meta.get("val"),
-                    env,
-                    kind="dot_out",
-                )
-            )
-            is not None
-        }
-        best_dot_key = (-1, -1)
-        peak_dot_output_tiles: tuple[LiveTile, ...] = ()
-        live_dots: set[torch.fx.Node] = set()
-        for index, node in enumerate(nodes):
-            if node in dot_details:
-                live_dots.add(node)
-            if live_dots:
-                tiles = tuple(dot_details[value] for value in live_dots)
-                key = (
-                    sum(tile_rank(tile.dim_block_ids) for tile in tiles),
-                    len(tiles),
-                )
-                if key > best_dot_key:
-                    best_dot_key = key
-                    peak_dot_output_tiles = tiles
-            live_dots = {
-                value for value in live_dots if last_use.get(value, len(nodes)) > index
-            }
-
         return cls(
             graph_id=graph_info.graph_id,
             nodes=nodes,
@@ -466,7 +440,6 @@ class GraphAnalysis:
             block_id_order=tuple(getattr(graph_info, "block_ids", ()) or ()),
             live_tile_steps=tuple(live_tile_steps),
             peak_live_tiles=peak_live_tiles,
-            peak_dot_output_tiles=peak_dot_output_tiles,
             dot_nodes=tuple(dot_nodes),
             reduction_occurrences=tuple(reduction_occurrences),
             reduction_axis_by_node_id=reduction_axis_by_node_id,
@@ -650,56 +623,12 @@ class DeviceIRAnalysis:
                     itemsize = width
         return itemsize
 
-    def kernel_peak_live_tiles(self) -> tuple[LiveTile, ...]:
-        """Legacy max-by-rank-profile live set across original graphs."""
-        best: tuple[LiveTile, ...] = ()
-        best_key: tuple[int, ...] = ()
-        for graph in self.non_reduction_graphs:
-            tiles = graph.peak_live_tiles
-            max_rank = max(
-                (tile_rank(tile.dim_block_ids) for tile in tiles),
-                default=0,
-            )
-            key = tile_set_rank_profile(
-                (tile.dim_block_ids for tile in tiles),
-                max_rank,
-            )
-            if key > best_key:
-                best_key = key
-                best = tiles
-        return best
-
     def kernel_live_tile_steps(self) -> tuple[tuple[LiveTile, ...], ...]:
         return tuple(
             step
             for graph in self.non_reduction_graphs
             for step in graph.live_tile_steps
         )
-
-    def kernel_peak_dot_outputs(self) -> tuple[LiveTile, ...]:
-        """Peak dot-output set after adding accumulator ancestor chains."""
-        accumulator_of = {
-            graph.graph_id: graph.peak_dot_output_tiles
-            for graph in self.non_reduction_graphs
-        }
-        best: tuple[LiveTile, ...] = ()
-        best_key = (-1, -1)
-        for graph_id, own in accumulator_of.items():
-            chain = list(own)
-            current = self.parent_of.get(graph_id, -1)
-            seen = {graph_id}
-            while current in accumulator_of and current not in seen:
-                seen.add(current)
-                chain.extend(accumulator_of[current])
-                current = self.parent_of.get(current, -1)
-            key = (
-                sum(tile_rank(tile.dim_block_ids) for tile in chain),
-                len(chain),
-            )
-            if key > best_key:
-                best_key = key
-                best = tuple(chain)
-        return best
 
     def group_live_tiles(
         self,
@@ -1108,6 +1037,126 @@ class DeviceIRAnalysis:
         if not facts:
             return None
 
+        def axis_extent_or_none(block_id: int | None) -> int | None:
+            if block_id is not None and 0 <= block_id < len(env.block_sizes):
+                size = env.block_sizes[block_id].size
+                if isinstance(size, (int, torch.SymInt)):
+                    return max(1, env.size_hint(size))
+            return None
+
+        from ..language.matmul_ops import MATMUL_DIM_BLOCK_IDS_META
+        from ..language.matmul_ops import MATMUL_FACT_ID_META
+
+        nodes_by_fact_id: dict[int, tuple[int, torch.fx.Node]] = {}
+        for graph_id, node in self.dot_nodes:
+            fact_id = node.meta.get(MATMUL_FACT_ID_META)
+            if (
+                isinstance(fact_id, int)
+                and 0 <= fact_id < len(facts)
+                and fact_id not in nodes_by_fact_id
+            ):
+                nodes_by_fact_id[fact_id] = (graph_id, node)
+        attribution_complete = (
+            len(self.dot_nodes) == len(facts) == len(nodes_by_fact_id)
+        )
+
+        if attribution_complete:
+            operand_positions = matmul_operand_positions()
+
+            def shape_block_ids(node: torch.fx.Node) -> tuple[int | None, ...]:
+                value = node.meta.get("val")
+                if not isinstance(value, torch.Tensor):
+                    return ()
+                # Do not use ``resolve_block_id``: matching a concrete padded extent
+                # could assign an unrelated fixed dimension to a reduction axis.
+                result = [env.get_block_id(size) for size in value.shape]
+                annotated = node.meta.get(MATMUL_DIM_BLOCK_IDS_META)
+                if isinstance(annotated, (list, tuple)) and len(annotated) == len(
+                    result
+                ):
+                    for index, block_id in enumerate(annotated):
+                        if isinstance(block_id, int):
+                            result[index] = block_id
+                return tuple(result)
+
+            def choose_axis(
+                original: int | None,
+                *inferred: int | None,
+            ) -> int | None:
+                if original is not None:
+                    return original
+                candidates = {value for value in inferred if value is not None}
+                return candidates.pop() if len(candidates) == 1 else None
+
+            # Keep block identity separate from representative fake sizes. A dot
+            # establishes the identity of its output M/N dimensions; shape-preserving
+            # pointwise operations carry it until a later dot consumes that tensor.
+            for graph in self.graphs:
+                for node in graph.nodes:
+                    value = node.meta.get("val")
+                    if not isinstance(value, torch.Tensor):
+                        continue
+                    result_ids = list(shape_block_ids(node))
+                    fact_id = node.meta.get(MATMUL_FACT_ID_META)
+                    if isinstance(fact_id, int) and fact_id in nodes_by_fact_id:
+                        positions = operand_positions.get(node.target)
+                        if positions is None:
+                            continue
+                        lhs = node.args[positions[0]]
+                        rhs = node.args[positions[1]]
+                        assert isinstance(lhs, torch.fx.Node)
+                        assert isinstance(rhs, torch.fx.Node)
+                        lhs_ids = shape_block_ids(lhs)
+                        rhs_ids = shape_block_ids(rhs)
+                        fact = facts[fact_id]
+                        m_block_id = choose_axis(
+                            fact.m_block_id,
+                            lhs_ids[-2] if len(lhs_ids) >= 2 else None,
+                        )
+                        n_block_id = choose_axis(
+                            fact.n_block_id,
+                            rhs_ids[-1] if rhs_ids else None,
+                        )
+                        k_block_id = choose_axis(
+                            fact.k_block_id,
+                            lhs_ids[-1] if lhs_ids else None,
+                            rhs_ids[-2] if len(rhs_ids) >= 2 else None,
+                        )
+                        fact = fact._replace(
+                            m_block_id=m_block_id,
+                            n_block_id=n_block_id,
+                            k_block_id=k_block_id,
+                            static_m=axis_extent_or_none(m_block_id) or fact.static_m,
+                            static_n=axis_extent_or_none(n_block_id) or fact.static_n,
+                            static_k=axis_extent_or_none(k_block_id) or fact.static_k,
+                        )
+                        facts[fact_id] = fact
+                        if len(result_ids) >= 2:
+                            result_ids[-2:] = [m_block_id, n_block_id]
+                    elif torch.Tag.pointwise in getattr(node.target, "tags", ()):
+                        shape = tuple(map(str, value.shape))
+                        matching_inputs = [
+                            shape_block_ids(input_node)
+                            for input_node in node.all_input_nodes
+                            if isinstance(
+                                input_value := input_node.meta.get("val"), torch.Tensor
+                            )
+                            and tuple(map(str, input_value.shape)) == shape
+                        ]
+                        for index in range(len(result_ids)):
+                            if result_ids[index] is not None:
+                                continue
+                            candidates = {
+                                input_ids[index]
+                                for input_ids in matching_inputs
+                                if len(input_ids) == len(result_ids)
+                                and input_ids[index] is not None
+                            }
+                            if len(candidates) == 1:
+                                result_ids[index] = candidates.pop()
+                    if any(block_id is not None for block_id in result_ids):
+                        node.meta[MATMUL_DIM_BLOCK_IDS_META] = tuple(result_ids)
+
         valid_block_ids = set(spec.block_sizes.valid_block_ids())
 
         def classify_axis(
@@ -1150,18 +1199,44 @@ class DeviceIRAnalysis:
                 if block_id is not None and block_id in valid_block_ids:
                     knob_users.setdefault(block_id, []).append((index, axis))
 
-        def axis_extent_or_none(block_id: int) -> int | None:
-            if 0 <= block_id < len(env.block_sizes):
-                size = env.block_sizes[block_id].size
-                if isinstance(size, (int, torch.SymInt)):
-                    try:
-                        return max(1, int(env.size_hint(size)))
-                    except Exception:
-                        return None
-            return None
+        from .host_function import HostFunction
+        from .variable_origin import BlockSizeOrigin
+        from .variable_origin import TileIdOrigin
 
-        def axis_extent(block_id: int) -> int:
-            return axis_extent_or_none(block_id) or 1
+        origins = HostFunction.current().expr_to_origin
+
+        def symbolic_loop_bound(block_id: int) -> SymbolicLoopBound | None:
+            """Preserve candidate-dependent symbolic loop bounds."""
+            size = env.block_sizes[block_id].size
+            if not isinstance(size, torch.SymInt):
+                return None
+            expr = _symint_sympy_expr(size)
+
+            block_size_symbols: list[tuple[sympy.Symbol, int]] = []
+            tile_id_symbols: list[tuple[sympy.Symbol, int]] = []
+            for symbol in sorted(
+                _symint_free_symbols(size), key=lambda item: item.name
+            ):
+                origin_info = origins.get(symbol)
+                if origin_info is None:
+                    continue
+                origin = origin_info.origin
+                if isinstance(origin, BlockSizeOrigin):
+                    block_size_symbols.append((symbol, origin.block_id))
+                elif isinstance(origin, TileIdOrigin):
+                    tile_id_symbols.append((symbol, origin.block_id))
+            if not block_size_symbols and not tile_id_symbols:
+                return None
+            return SymbolicLoopBound(
+                expr,
+                tuple(block_size_symbols),
+                tuple(tile_id_symbols),
+            )
+
+        symbolic_loop_bounds = {
+            block_id: symbolic_loop_bound(block_id)
+            for block_id in range(len(env.block_sizes))
+        }
 
         grid_block_ids = set(spec.grid_block_ids)
         matmul_output_block_ids = {fact.m_block_id for fact in facts} | {
@@ -1170,50 +1245,61 @@ class DeviceIRAnalysis:
         outer_grid = 1
         for block_id in spec.grid_block_ids:
             if block_id not in matmul_output_block_ids:
-                outer_grid *= axis_extent(block_id)
+                outer_grid *= axis_extent_or_none(block_id) or 1
 
         bounded_by: dict[int, int] = {}
         bounded_extent: dict[int, int] = {}
         for slot in range(len(spec.block_sizes)):
             block_spec = spec.block_sizes[slot]
-            parent = getattr(block_spec, "bounded_by_block_id", None)
-            if isinstance(parent, int):
+            parent = block_spec.bounded_by_block_id
+            if parent is not None:
                 bounded_by[block_spec.block_id] = parent
                 if 0 <= parent < len(env.block_sizes):
                     source = env.block_sizes[parent].block_size_source
-                    value = getattr(source, "value", None)
                     if isinstance(source, FixedBlockSizeSource) and isinstance(
-                        value,
+                        source.value,
                         int,
                     ):
-                        bounded_extent[block_spec.block_id] = max(1, value)
+                        bounded_extent[block_spec.block_id] = max(1, source.value)
 
         def loop_axes_for(graph_id: int) -> tuple[LoopAxisFact, ...]:
             axes_out: list[LoopAxisFact] = []
-            seen_graphs: set[int] = set()
             seen_axes: set[int] = set()
             current = graph_id
-            while current in self.loop_block_ids and current not in seen_graphs:
-                seen_graphs.add(current)
+            while current in self.loop_block_ids:
                 for block_id in sorted(self.loop_block_ids[current]):
                     if block_id in grid_block_ids or block_id in seen_axes:
                         continue
                     seen_axes.add(block_id)
+                    bound = (
+                        None
+                        if block_id in bounded_by
+                        else symbolic_loop_bounds.get(block_id)
+                    )
                     axes_out.append(
                         LoopAxisFact(
-                            block_id,
-                            axis_extent_or_none(block_id),
-                            bounded_by.get(block_id),
-                            bounded_extent.get(block_id),
+                            block_id=block_id,
+                            extent=(
+                                None
+                                if bound is not None
+                                else axis_extent_or_none(block_id)
+                            ),
+                            bounded_by_block_id=bounded_by.get(block_id),
+                            bounded_extent=bounded_extent.get(block_id),
+                            symbolic_bound=bound,
                         )
                     )
                 current = self.parent_of.get(current, -1)
             return tuple(axes_out)
 
-        def trips_for(graph_id: int) -> int:
+        def max_trips_for(graph_id: int) -> int | None:
             trips = 1
             for axis in loop_axes_for(graph_id):
-                extent = axis.extent or 1
+                extent = axis.extent
+                if axis.symbolic_bound is not None:
+                    # There is no candidate-independent upper bound for arbitrary
+                    # symbolic arithmetic.
+                    return None
                 if axis.bounded_by_block_id is not None:
                     extent = (
                         axis.bounded_extent
@@ -1222,8 +1308,10 @@ class DeviceIRAnalysis:
                             spec,
                             axis.bounded_by_block_id,
                         )
-                        or axis_extent(axis.bounded_by_block_id)
+                        or axis_extent_or_none(axis.bounded_by_block_id)
                     )
+                if extent is None:
+                    return None
                 block = _immovable_extent(env, spec, axis.block_id)
                 trips *= max(1, -(-extent // block)) if block else extent
             return trips
@@ -1343,6 +1431,7 @@ class DeviceIRAnalysis:
                 if block_id not in grid_block_ids
                 and axis_extent_or_none(block_id) is None
                 and block_id not in bounded_by
+                and symbolic_loop_bounds.get(block_id) is None
             ]
             enclosing_axes = loop_axes_for(body_graph_id)
             if len(block_ids) != 1 or len(unresolved) != 1 or len(enclosing_axes) != 1:
@@ -1366,16 +1455,30 @@ class DeviceIRAnalysis:
             if len(trip_by_load) >= 2 and len(trips) == 1:
                 inferred_work_trips[(body_graph_id, block_id)] = trips.pop()
 
-        n_dot_nodes = len(self.dot_nodes)
-        attribution_complete = n_dot_nodes == len(facts)
         sites: list[DotSite] = []
         if attribution_complete:
-            for index, (graph_id, node) in enumerate(self.dot_nodes):
+            for index, fact in enumerate(facts):
+                graph_id, node = nodes_by_fact_id[index]
                 value = node.meta.get("val")
                 if isinstance(value, torch.Tensor) and value.ndim >= 2:
                     observed_extents: list[int] = []
-                    for dimension in value.shape[-2:]:
-                        block_id = env.resolve_block_id(dimension)
+                    annotated = node.meta.get(MATMUL_DIM_BLOCK_IDS_META)
+                    annotated_tail = (
+                        annotated[-2:]
+                        if isinstance(annotated, (list, tuple))
+                        and len(annotated) == value.ndim
+                        else (None, None)
+                    )
+                    for dimension, annotated_block_id in zip(
+                        value.shape[-2:],
+                        annotated_tail,
+                        strict=True,
+                    ):
+                        block_id = (
+                            annotated_block_id
+                            if isinstance(annotated_block_id, int)
+                            else env.resolve_block_id(dimension)
+                        )
                         if block_id is not None and 0 <= block_id < len(
                             env.block_sizes
                         ):
@@ -1383,13 +1486,10 @@ class DeviceIRAnalysis:
                         if not isinstance(dimension, (int, torch.SymInt)):
                             observed_extents.append(-1)
                             continue
-                        try:
-                            observed_extents.append(int(env.size_hint(dimension)))
-                        except Exception:
-                            observed_extents.append(-1)
+                        observed_extents.append(env.size_hint(dimension))
                     expected_extents = [
-                        facts[index].static_m,
-                        facts[index].static_n,
+                        fact.static_m,
+                        fact.static_n,
                     ]
                     if any(
                         expected is not None and observed != -1 and expected != observed
@@ -1413,23 +1513,22 @@ class DeviceIRAnalysis:
                 sites.append(
                     DotSite(
                         graph_id,
-                        trips_for(graph_id),
                         updates_carry,
                         loop_axes,
                         exact_loop_trips,
+                        max_trips_for(graph_id),
                     )
                 )
         if not attribution_complete:
-            sites = [DotSite(-1, 1, False, (), None) for _ in facts]
+            sites = [DotSite(-1, False, (), None, None) for _ in facts]
 
         sequential_loop_trips = 1
         for body_graph_id, block_ids in self.loop_block_ids.items():
             if any(block_id in spec.grid_block_ids for block_id in block_ids):
                 continue
-            sequential_loop_trips = max(
-                sequential_loop_trips,
-                trips_for(body_graph_id),
-            )
+            max_trips = max_trips_for(body_graph_id)
+            if max_trips is not None:
+                sequential_loop_trips = max(sequential_loop_trips, max_trips)
 
         pipelined_regions: list[PipelinedRegion] = []
         resident_regions: list[ResidentRegion] = []
@@ -1459,13 +1558,9 @@ class DeviceIRAnalysis:
                 (block_id, tuple(knob_users[block_id]))
                 for block_id in sorted(knob_users)
             ),
-            outer_grid=outer_grid,
             sequential_loop_trips=sequential_loop_trips,
-            live_tiles=tuple(self.kernel_peak_live_tiles()),
-            live_dot_outputs=tuple(self.kernel_peak_dot_outputs()),
             live_tile_steps=tuple(self.kernel_live_tile_steps()),
             pipelined_regions=tuple(pipelined_regions),
             resident_regions=tuple(resident_regions),
-            n_dot_nodes=max(n_dot_nodes, len(facts)),
             attribution_complete=attribution_complete,
         )

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -92,6 +92,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
 
+    import sympy
+
     from .._compiler.backend import Backend
     from ..runtime.config import IndexingLiteral
     from ..runtime.config import PidTypeLiteral
@@ -262,6 +264,19 @@ class LiveTile(NamedTuple):
     stageable: bool | None = None
 
 
+class SymbolicLoopBound(NamedTuple):
+    """A preserved SymPy loop extent and its candidate-dependent symbols.
+
+    The expression remains the one produced by symbolic tracing. Symbol maps
+    identify only leaves a concrete autotuner candidate can resolve; any other
+    free symbol keeps evaluation explicitly unknown.
+    """
+
+    expression: sympy.Expr
+    block_size_symbols: tuple[tuple[sympy.Symbol, int], ...] = ()
+    tile_id_symbols: tuple[tuple[sympy.Symbol, int], ...] = ()
+
+
 class LoopAxisFact(NamedTuple):
     """One tunable or fixed axis in an enclosing device loop.
 
@@ -270,15 +285,19 @@ class LoopAxisFact(NamedTuple):
     ``tile(outer.begin, outer.end)``); in that case the candidate outer block is
     the real extent, not the whole underlying axis. ``bounded_extent`` is set
     only when that outer extent is a literal; a symbolic fixed parent remains
-    explicitly uncertain. The per-program block is deliberately not recorded
-    here: it is a candidate property and must be resolved from the emitted
-    ``block_sizes`` before the trip count is used.
+    explicitly uncertain. ``symbolic_bound`` preserves a candidate-dependent
+    loop bound instead of matching one source expression. Block-size leaves are
+    replaced with the candidate values and tile IDs with the lower-median valid
+    tile before evaluating it. The per-program block is deliberately not
+    recorded here: it is a candidate property and must be resolved from the
+    emitted ``block_sizes`` before the trip count is used.
     """
 
     block_id: int
     extent: int | None
     bounded_by_block_id: int | None = None
     bounded_extent: int | None = None
+    symbolic_bound: SymbolicLoopBound | None = None
 
 
 class PipelinedRegion(NamedTuple):
@@ -359,24 +378,25 @@ class DotSite(NamedTuple):
     - ``graph_id`` — the device graph the dot's node lives in.
       :class:`KernelGridFact` maps that graph to its root grid; the topology is
       intentionally not copied into each site.
-    - ``loop_trips`` — product of the sequential loop trip counts enclosing it, i.e.
-      how many times one program executes this dot.
     - ``updates_carry`` — the dot writes into a value carried by an enclosing loop
       (``acc=`` into a loop-carried accumulator). Such a dot's accumulator is
       resident for the whole loop, which is why it gets ranking priority.
     - ``loop_axes`` — the enclosing loop axes before a candidate block size is
-      selected. Consumers that need an exact execution count resolve these axes
-      against the candidate instead of treating ``loop_trips`` as exact.
+      selected. This is the canonical execution-count representation; consumers
+      resolve it against the candidate they are evaluating.
     - ``exact_loop_trips`` — an exact dynamic execution count proven independently
       of the loop-bound expression. This is used for work estimation only; it does
       not claim that the same loop is a useful software-pipeline opportunity.
+    - ``max_loop_trips`` — an optional conservative upper bound used only by
+      safety-oriented consumers such as pipeline-depth capping. It must not be used
+      as candidate work.
     """
 
     graph_id: int
-    loop_trips: int
     updates_carry: bool
     loop_axes: tuple[LoopAxisFact, ...] = ()
     exact_loop_trips: int | None = None
+    max_loop_trips: int | None = None
 
 
 class ResolvedMatmulFact(NamedTuple):
@@ -404,28 +424,13 @@ class KernelMatmulFact(NamedTuple):
     - ``matmuls`` — the contextual facts, one per dot.
     - ``knob_users`` — for each tunable block id, the ``(dot_index, axis)`` pairs
       whose axis maps onto it, i.e. which dots COMPETE for that knob.
-    - ``outer_grid`` — parallel programs contributed by grid axes that are no dot's
-      M or N tile: the occupancy the kernel already has before any tiling choice.
     - ``sequential_loop_trips`` — product of the trip counts of the kernel's
       sequential (non-grid) loops. For a chunked recurrence this is the number of
       chunks, so ``sequential_loop_trips * fixed_k`` recovers the logical contraction
       length even though each dot only sees one chunk.
-    - ``live_tiles`` — the peak simultaneously-live tile set over the whole kernel
-      (:class:`LiveTile`), from the same last-use liveness sweep the reduction fact
-      uses. The maximum simultaneously-live footprint, NOT the sum of every op.
-    - ``live_dot_outputs`` — the live set at the step holding the most simultaneously
-      live DOT OUTPUT tiles. A separate measurement from ``live_tiles`` because that
-      one's peak is chosen by rank profile (the right question for a reduction's
-      register working set, the wrong one for the accumulator budget: the rank peak can
-      be a step where the heavy loads are live and the accumulators are not). This is
-      what a sum-over-live-accumulators tensor-memory/register term is computed from.
     - ``live_tile_steps`` — the live tile set at EVERY step of the kernel's graphs, deduped.
-      ``live_tiles`` above is one step chosen by RANK PROFILE, which is block-size-free and so
-      the right question when block sizes are unknown; a register estimate is asked later, when
-      the candidate block sizes ARE known, and should pick its peak by resolved BYTES. Keeping
-      every step is what lets it. Selecting by rank instead under-counted a kernel that spills
-      540 registers at one warp while over-counting one that spills none — the ordering
-      inverted, so no threshold on that estimate could separate them.
+      A register estimate resolves each step under the candidate block sizes and selects
+      the peak by bytes.
     - ``pipelined_regions`` — the loads/stores and enclosing loop axes of each LOOP
       BODY. The axes let a candidate cap useful pipeline depth by the iterations it
       actually executes. The SMEM operand ring is charged over every conservatively
@@ -436,21 +441,15 @@ class KernelMatmulFact(NamedTuple):
       ONCE, with no stage multiplier: a load outside a loop is not multi-buffered, and
       charging it per stage over-states shared memory badly enough to shrink a tile to the
       dot minimum for a phantom overflow.
-    - ``n_dot_nodes`` — contraction sites counted spelling-independently, so a kernel
-      whose dots are written as ``torch.matmul``/``@`` is not read as having none.
     - ``attribution_complete`` — post-condition flag described above.
     """
 
     matmuls: tuple[ResolvedMatmulFact, ...]
     knob_users: tuple[tuple[int, tuple[tuple[int, str], ...]], ...]
-    outer_grid: int
     sequential_loop_trips: int
-    live_tiles: tuple[LiveTile, ...]
-    live_dot_outputs: tuple[LiveTile, ...]
     live_tile_steps: tuple[tuple[LiveTile, ...], ...]
     pipelined_regions: tuple[PipelinedRegion, ...]
     resident_regions: tuple[ResidentRegion, ...]
-    n_dot_nodes: int
     attribution_complete: bool
 
     def users_of(self, block_id: int) -> tuple[tuple[int, str], ...]:
@@ -458,22 +457,6 @@ class KernelMatmulFact(NamedTuple):
             if bid == block_id:
                 return users
         return ()
-
-    def dot_work(self, index: int) -> int:
-        """Dynamic work of one dot: ``m*n*k`` per execution times its executions.
-
-        Falls back to the axis classification's per-program extent when the fact's own
-        ``static_*`` is absent, which happens whenever the axis length is dynamic but the
-        per-program extent is not."""
-        resolved = self.matmuls[index]
-        f = resolved.fact
-        ax = resolved.axes
-        m = f.static_m or ax.m_extent or 1
-        n = f.static_n or ax.n_extent or 1
-        k = f.static_k or ax.k_extent or 1
-        site = resolved.site
-        trips = site.exact_loop_trips or site.loop_trips
-        return m * n * k * max(1, trips)
 
 
 class ReductionCategory(enum.Enum):

--- a/helion/language/_decorators.py
+++ b/helion/language/_decorators.py
@@ -129,6 +129,8 @@ class APIFunc(Protocol):
             tracing and compilation.
         _prepare_args: A callable that preprocesses the arguments before they're
             passed to the actual function implementation.
+        _post_create_proxy: An optional callback invoked with the newly created FX
+            node and prepared arguments.
         _get_masked_value: A callable that retrieves the masked value for a node,
         _signature: The function signature for binding and validating arguments.
     """
@@ -144,6 +146,7 @@ class APIFunc(Protocol):
     _codegen: CodegenDict
     _fake_fn: Callable[..., object] | None
     _prepare_args: Callable[[tuple[object, ...]], tuple[object, ...]]
+    _post_create_proxy: Callable[..., None] | None
     _get_masked_value: Callable[[torch.fx.Node], float | bool | None] | None
     _to_device_ir: Callable[..., object] | None
     _allow_host_tensor: bool
@@ -240,6 +243,8 @@ def api(
                         wrapper,
                         *args_to_proxies(tracer, flat_args, {}),
                     )
+                    if api._post_create_proxy is not None:
+                        api._post_create_proxy(proxy_out.node, *flat_args)
                     assert api._fake_fn is not None
                     out = api._fake_fn(*flat_args)
                     proxy_tensor.track_tensor_tree(
@@ -260,6 +265,7 @@ def api(
         api._type_function = None
         api._codegen = CodegenDict()
         api._fake_fn = None
+        api._post_create_proxy = None
         api._get_masked_value = None
         api._to_device_ir = None
         api._allow_host_tensor = allow_host_tensor
@@ -319,6 +325,23 @@ def prepare_args(
             f"{type_propagation.__qualname__} can only be used on API functions"
         )
         original_fn._prepare_args = prep_fn
+        return _no_call
+
+    # pyrefly: ignore [bad-return]
+    return _impl
+
+
+def post_create_proxy(
+    original_fn: Callable[..., object],
+) -> _NoReturnDecorator[None]:
+    """Register a callback that annotates an API call's newly created FX node."""
+
+    def _impl(callback: Callable[..., None]) -> Callable[..., Never]:
+        assert is_api_func(original_fn), (
+            f"{post_create_proxy.__qualname__} can only be used on API functions"
+        )
+        assert original_fn._post_create_proxy is None
+        original_fn._post_create_proxy = callback
         return _no_call
 
     # pyrefly: ignore [bad-return]

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -22,6 +22,9 @@ from .._compiler.matmul_utils import _compute_out_dtype
 from ..autotuner.config_spec import MatmulFact
 from . import _decorators
 
+MATMUL_FACT_ID_META = "helion_matmul_fact_id"
+MATMUL_DIM_BLOCK_IDS_META = "helion_matmul_dim_block_ids"
+
 
 def _static_dim_value(env: CompileEnvironment, size: int | torch.SymInt) -> int | None:
     if isinstance(size, int):
@@ -242,7 +245,7 @@ def _static_problem_extent(
     return _static_dim_value(env, size)
 
 
-def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
+def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> int:
     """Record a matmul fact and apply backend-independent dot constraints."""
     m, n, k = _dot_dimensions(lhs, rhs)
 
@@ -280,6 +283,7 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
                 else:
                     spec.allow_overshoot(SMALL_DIM_BLOCK_SIZE_OVERSHOOT)
 
+    fact_id = len(env.config_spec.matmul_facts)
     env.config_spec.matmul_facts.append(
         MatmulFact(
             lhs_ndim=lhs.ndim,
@@ -308,6 +312,25 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             block_idx = env.get_block_id(leading_dim)
             if block_idx is not None:
                 env.block_sizes[block_idx].update_max_block(1)
+    return fact_id
+
+
+def _associate_latest_matmul_fact(node: torch.fx.Node, *_args: object) -> None:
+    """Attach the fact created by prepare_args to this exact API node."""
+    facts = CompileEnvironment.current().config_spec.matmul_facts
+    fact_id = len(facts) - 1
+    assert fact_id >= 0
+    node.meta[MATMUL_FACT_ID_META] = fact_id
+    fact = facts[fact_id]
+    output_ndim = max(fact.lhs_ndim, fact.rhs_ndim)
+    node.meta[MATMUL_DIM_BLOCK_IDS_META] = (
+        *(None for _ in range(output_ndim - 2)),
+        fact.m_block_id,
+        fact.n_block_id,
+    )
+
+
+_decorators.post_create_proxy(dot)(_associate_latest_matmul_fact)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -781,6 +804,9 @@ def _(
         return acc.new_empty(result_shape)
     resolved_dtype = out_dtype or torch.float32
     return torch.empty(result_shape, dtype=resolved_dtype, device=mat1.device)
+
+
+_decorators.post_create_proxy(dot_scaled)(_associate_latest_matmul_fact)
 
 
 @_decorators.ref(dot_scaled)

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -705,6 +705,205 @@ class TestMatmulFacts(TestCase):
                 self.assertEqual(fact.lhs_dtype, HALF_DTYPE)
                 self.assertEqual(fact.rhs_dtype, HALF_DTYPE)
 
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler matmul facts are not collected in ref eager mode")
+    def test_matmul_fact_identity_does_not_depend_on_graph_walk_order(self) -> None:
+        from helion._compiler.device_ir_analysis import DeviceIRAnalysis
+
+        @helion.kernel(backend="triton", static_shapes=True)
+        def two_matmuls(
+            x0: torch.Tensor,
+            y0: torch.Tensor,
+            x1: torch.Tensor,
+            y1: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            m0, k0 = x0.shape
+            _, n0 = y0.shape
+            out0 = torch.empty([m0, n0], device=x0.device, dtype=x0.dtype)
+            m1, k1 = x1.shape
+            _, n1 = y1.shape
+            out1 = torch.empty([m1, n1], device=x1.device, dtype=x1.dtype)
+            for tile_m0, tile_n0 in hl.tile([m0, n0]):
+                out0[tile_m0, tile_n0] = hl.dot(
+                    x0[tile_m0, :],
+                    y0[:, tile_n0],
+                )
+
+            for tile_m1, tile_n1 in hl.tile([m1, n1]):
+                out1[tile_m1, tile_n1] = hl.dot(
+                    x1[tile_m1, :],
+                    y1[:, tile_n1],
+                )
+            return out0, out1
+
+        args = (
+            torch.empty([64, 32], device=DEVICE, dtype=HALF_DTYPE),
+            torch.empty([32, 96], device=DEVICE, dtype=HALF_DTYPE),
+            torch.empty([128, 64], device=DEVICE, dtype=HALF_DTYPE),
+            torch.empty([64, 160], device=DEVICE, dtype=HALF_DTYPE),
+        )
+        original = DeviceIRAnalysis.kernel_matmul_fact
+
+        def reverse_walk_order(
+            analysis: DeviceIRAnalysis,
+            *method_args: object,
+            **method_kwargs: object,
+        ) -> object:
+            analysis.dot_nodes = analysis.dot_nodes[::-1]
+            return original(analysis, *method_args, **method_kwargs)
+
+        with patch.object(DeviceIRAnalysis, "kernel_matmul_fact", reverse_walk_order):
+            spec = two_matmuls.bind(args).config_spec
+
+        fact = spec.kernel_matmul_fact
+        assert fact is not None
+        self.assertTrue(fact.attribution_complete)
+        self.assertEqual(
+            [
+                (resolved.fact.static_m, resolved.fact.static_n)
+                for resolved in fact.matmuls
+            ],
+            [(64, 96), (128, 160)],
+        )
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler matmul facts are not collected in ref eager mode")
+    def test_bmm_dtype_and_nested_loop_ancestry(self) -> None:
+        @helion.kernel(backend="triton", static_shapes=True)
+        def nested_attention(
+            q: torch.Tensor,
+            k: torch.Tensor,
+            v: torch.Tensor,
+        ) -> torch.Tensor:
+            batches = q.size(0)
+            heads = hl.specialize(q.size(1))
+            queries = q.size(2)
+            keys = k.size(2)
+            dim = hl.specialize(q.size(3))
+            out = torch.empty_like(q)
+            for batch in hl.grid(batches):
+                for tile_q in hl.tile(queries):
+                    query = q[batch, :, tile_q, :]
+                    acc = hl.zeros([heads, tile_q, dim], dtype=torch.float32)
+                    for tile_kv in hl.tile(keys):
+                        key = k[batch, :, tile_kv, :]
+                        value = v[batch, :, tile_kv, :]
+                        scores = torch.bmm(
+                            query,
+                            key.transpose(-2, -1),
+                            torch.float32,
+                        )
+                        acc = acc + torch.bmm(scores.to(value.dtype), value)
+                    out[batch, :, tile_q, :] = acc.to(out.dtype)
+            return out
+
+        args = tuple(
+            torch.empty([2, 4, 128, 64], device=DEVICE, dtype=HALF_DTYPE)
+            for _ in range(3)
+        )
+        spec = nested_attention.bind(args).config_spec
+        fact = spec.kernel_matmul_fact
+        assert fact is not None
+        self.assertEqual(len(spec.matmul_facts), 2)
+        self.assertTrue(fact.attribution_complete)
+
+        query_block_id = spec.matmul_facts[0].m_block_id
+        key_block_id = spec.matmul_facts[0].n_block_id
+        assert query_block_id is not None
+        assert key_block_id is not None
+        qk, pv = fact.matmuls
+        self.assertEqual(
+            (
+                qk.fact.m_block_id,
+                qk.fact.static_m,
+                qk.fact.n_block_id,
+                qk.fact.static_n,
+                qk.fact.k_block_id,
+                qk.fact.static_k,
+            ),
+            (query_block_id, 128, key_block_id, 128, None, 64),
+        )
+        self.assertEqual(
+            (
+                pv.fact.m_block_id,
+                pv.fact.static_m,
+                pv.fact.n_block_id,
+                pv.fact.static_n,
+                pv.fact.k_block_id,
+                pv.fact.static_k,
+            ),
+            (query_block_id, 128, None, 64, key_block_id, 128),
+        )
+        nested_axes = [
+            {axis.block_id for axis in region.loop_axes}
+            for region in fact.pipelined_regions
+        ]
+        self.assertTrue(
+            any({query_block_id, key_block_id}.issubset(axes) for axes in nested_axes)
+        )
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler matmul facts are not collected in ref eager mode")
+    def test_symbolic_loop_bound_retains_expression_and_origins(self) -> None:
+        @helion.kernel(backend="triton", static_shapes=True)
+        def prefix_matmul(
+            lhs: torch.Tensor,
+            rhs: torch.Tensor,
+        ) -> torch.Tensor:
+            rows, _ = lhs.shape
+            cols = hl.specialize(rhs.size(1))
+            block_m = hl.register_block_size(rows)
+            block_k = hl.register_block_size(64, 64)
+            out = torch.empty([rows, cols], device=lhs.device, dtype=lhs.dtype)
+            for tile_m in hl.tile(rows, block_size=block_m):
+                acc = hl.zeros([tile_m, cols], dtype=torch.float32)
+                for tile_k in hl.tile(
+                    (tile_m.id + 2) * block_m,
+                    block_size=block_k,
+                ):
+                    acc = hl.dot(
+                        lhs[tile_m, tile_k],
+                        rhs[tile_k, :],
+                        acc=acc,
+                    )
+                out[tile_m, :] = acc.to(out.dtype)
+            return out
+
+        args = (
+            torch.empty([256, 512], device=DEVICE, dtype=HALF_DTYPE),
+            torch.empty([512, 64], device=DEVICE, dtype=HALF_DTYPE),
+        )
+        spec = prefix_matmul.bind(args).config_spec
+        fact = spec.kernel_matmul_fact
+        assert fact is not None
+        resolved = fact.matmuls[0]
+        inner_block_id = resolved.fact.k_block_id
+        outer_block_id = resolved.fact.m_block_id
+        assert inner_block_id is not None
+        assert outer_block_id is not None
+        axis = next(
+            axis for axis in resolved.site.loop_axes if axis.block_id == inner_block_id
+        )
+        self.assertIsNone(axis.extent)
+        bound = axis.symbolic_bound
+        assert bound is not None
+        self.assertEqual(
+            {block_id for _symbol, block_id in bound.block_size_symbols},
+            {outer_block_id},
+        )
+        self.assertEqual(
+            {block_id for _symbol, block_id in bound.tile_id_symbols},
+            {outer_block_id},
+        )
+        recorded_symbols = {
+            symbol
+            for symbol, _block_id in (
+                *bound.block_size_symbols,
+                *bound.tile_id_symbols,
+            )
+        }
+        self.assertEqual(bound.expression.free_symbols, recorded_symbols)
+
 
 class TestTritonSkinnyGemmHeuristic(TestCase):
     def _make_triton_env_with_block_sizes(
@@ -964,6 +1163,14 @@ class TestTritonH100MatmulHeuristic(TestCase):
         env.settings = Settings()
         return env
 
+    def _attach_matmul(self, env: MagicMock, fact: MatmulFact) -> None:
+        env.config_spec.matmul_facts.append(fact)
+        site = MagicMock(graph_id=-1, loop_axes=(), max_loop_trips=None)
+        env.config_spec.kernel_matmul_fact = MagicMock(
+            matmuls=(MagicMock(site=site),),
+            sequential_loop_trips=1,
+        )
+
     def test_budget_formula_is_deterministic_per_regime(self) -> None:
         # Pure formula (fixed num_sm=132, H100), exercising every lever. Returns the tile
         # tuple (bm, bn, bk, num_warps, num_stages, l2_grouping).
@@ -1035,7 +1242,7 @@ class TestTritonH100MatmulHeuristic(TestCase):
         with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
             # rank-0 (Product A) == get_seed_config; the ranked list has diverse alternates.
             env = self._make_env()
-            env.config_spec.matmul_facts.append(self._matmul_fact())
+            self._attach_matmul(env, self._matmul_fact())
             ranked = TritonH100MatmulHeuristic.get_seed_configs(env, MagicMock())
             primary = TritonH100MatmulHeuristic.get_seed_config(env, MagicMock())
             assert ranked is not None and primary is not None
@@ -1047,13 +1254,9 @@ class TestTritonH100MatmulHeuristic(TestCase):
 
             # 16-bit merge: bf16 and fp16 produce the IDENTICAL seed (width key, not dtype kind).
             env_bf16 = self._make_env()
-            env_bf16.config_spec.matmul_facts.append(
-                self._matmul_fact(dtype=torch.bfloat16)
-            )
+            self._attach_matmul(env_bf16, self._matmul_fact(dtype=torch.bfloat16))
             env_fp16 = self._make_env()
-            env_fp16.config_spec.matmul_facts.append(
-                self._matmul_fact(dtype=torch.float16)
-            )
+            self._attach_matmul(env_fp16, self._matmul_fact(dtype=torch.float16))
             bf16 = TritonH100MatmulHeuristic.get_seed_config(env_bf16, MagicMock())
             fp16 = TritonH100MatmulHeuristic.get_seed_config(env_fp16, MagicMock())
             assert bf16 is not None and fp16 is not None

--- a/test/test_matmul_heuristics.py
+++ b/test/test_matmul_heuristics.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from itertools import starmap
 import json
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
+import sympy
 import torch
 
 import helion
@@ -33,6 +35,7 @@ from helion.autotuner.config_spec import LoopAxisFact
 from helion.autotuner.config_spec import MatmulFact
 from helion.autotuner.config_spec import PipelinedRegion
 from helion.autotuner.config_spec import RootGridFact
+from helion.autotuner.config_spec import SymbolicLoopBound
 
 _SHAPE_BUCKET_KEYS = {
     "dtype",
@@ -416,28 +419,29 @@ def _generalized_spec(
                 axes=axes,
                 site=SimpleNamespace(
                     graph_id=0,
-                    loop_trips=max(1, fact.static_k or 1),
                     updates_carry=False,
                     loop_axes=loop_axes,
+                    exact_loop_trips=None,
+                    max_loop_trips=max(1, fact.static_k or 1),
                 ),
             ),
         ),
         knob_users=(),
-        outer_grid=1,
         sequential_loop_trips=1,
-        live_tiles=(),
-        live_dot_outputs=(),
         live_tile_steps=(),
         pipelined_regions=(),
         resident_regions=(),
-        n_dot_nodes=1,
         attribution_complete=True,
     )
     return SimpleNamespace(
         matmul_facts=[fact],
         kernel_matmul_fact=mm,
+        kernel_grid_fact=None,
         block_sizes=_block_sizes_stub(valid_block_ids),
         grid_block_ids=grid_block_ids,
+        _base_default_config=lambda: helion.Config(
+            block_sizes=[1] * len(valid_block_ids)
+        ),
     )
 
 
@@ -565,6 +569,26 @@ def test_tmem_is_counted_in_columns_and_sums_over_live_accumulators() -> None:
     assert TritonH100MatmulHeuristic._tmem_columns([(128, 256, 2)] * 8) == 0
 
 
+def test_tmem_hard_budget_includes_all_lhs_promotion_scratch() -> None:
+    """Crossing the tcgen05 M threshold also allocates promoted-LHS scratch.
+
+    Five backward-attention accumulators consume exactly 512 columns; the
+    compiler required at least another 64 columns. Omitting LHS scratch emitted
+    a configuration that failed at launch with ``Required: 576, limit: 512``;
+    the hard bound conservatively reserves every dot's allocation.
+    """
+    tiles = [
+        (128, 64, 128, 2),
+        (128, 64, 128, 2),
+        (128, 128, 64, 2),
+        (64, 128, 128, 2),
+        (128, 128, 64, 2),
+    ]
+    assert _FML._tmem_columns(tiles) == 512
+    assert _FML._tmem_columns(tiles, include_lhs_scratch=True) == 736
+    assert _FML._tmem_columns(tiles, include_lhs_scratch=True) > _FML.TMEM_COLUMN_BUDGET
+
+
 def test_register_estimate_picks_its_peak_by_resolved_bytes() -> None:
     """The register estimate must select its peak step by RESOLVED BYTES at the candidate
     config, not by the block-size-free rank profile the reduction liveness machinery uses.
@@ -680,12 +704,46 @@ def test_graded_stage_depth_is_capped_by_the_loop_it_pipelines() -> None:
     )
 
 
-def test_tcgen_occupancy_penalty_uses_effective_residency() -> None:
+def test_warp_transition_penalty_uses_effective_residency() -> None:
     """Queued waves do not increase the penalty after resident capacity is full."""
-    assert _FML._tcgen_occupancy_penalty(1, 1) == 1.0
-    assert _FML._tcgen_occupancy_penalty(4, 4) == 1.0
-    assert _FML._tcgen_occupancy_penalty(4, 2) == 2.0
-    assert _FML._tcgen_occupancy_penalty(32, 1) == _FML.TCGEN_OCCUPANCY_PENALTY_MAX
+    penalty = _FML._warp_transition_occupancy_penalty
+    assert penalty(1, 1) == 1.0
+    assert penalty(4, 4) == 1.0
+    assert penalty(4, 2) == 2.0
+    assert penalty(32, 1) == _FML.WARP_TRANSITION_OCCUPANCY_PENALTY_MAX
+
+
+def test_warp_selection_accounts_for_four_to_eight_residency_loss() -> None:
+    """Eight warps must earn back any residency lost relative to four."""
+    work = SimpleNamespace(
+        total=_FML.EIGHT_WARP_DOT_WORK,
+        tcgen05_eligible=_FML.EIGHT_WARP_DOT_WORK,
+        uncertain=False,
+    )
+
+    def select(eight_warp_residency: int) -> int:
+        residency = {2: 2, 4: 2, 8: eight_warp_residency}
+        with (
+            patch.object(_FML, "_candidate_dot_work", return_value=work),
+            patch.object(_FML, "_register_live_bytes", return_value=0),
+            patch.object(_FML, "_all_dot_acc_tiles", return_value=[]),
+            patch.object(
+                _FML,
+                "_estimated_resident_ctas",
+                side_effect=lambda *_args, num_warps, **_kwargs: residency[num_warps],
+            ),
+        ):
+            return _FML._select_num_warps(
+                1,
+                SimpleNamespace(),
+                [],
+                grid=148,
+                num_sm=148,
+                smem_bytes=0,
+            )
+
+    assert select(2) == 8
+    assert select(1) == 4
 
 
 def test_multi_matmul_ranking_prefers_a_carried_accumulator_then_work() -> None:
@@ -693,49 +751,131 @@ def test_multi_matmul_ranking_prefers_a_carried_accumulator_then_work() -> None:
     loop, so its tile sets the kernel's whole-loop footprint -- hence ranking priority. But
     it is a PREFERENCE: dimensions and execution count must also matter, and a kernel with no
     carried accumulator has to rank purely on work."""
-    big = MatmulFact(2, 2, 0, 1, 2, 256, 256, 256, torch.bfloat16, torch.bfloat16)
-    small = MatmulFact(2, 2, 0, 1, 2, 64, 64, 64, torch.bfloat16, torch.bfloat16)
+    big = MatmulFact(
+        2, 2, None, None, None, 256, 256, 256, torch.bfloat16, torch.bfloat16
+    )
+    small = MatmulFact(
+        2, 2, None, None, None, 64, 64, 64, torch.bfloat16, torch.bfloat16
+    )
 
     def mm(carry: tuple[bool, ...], trips: tuple[int, ...]) -> SimpleNamespace:
         facts = (big, small)
         sites = tuple(
-            SimpleNamespace(graph_id=0, loop_trips=t, updates_carry=c)
+            SimpleNamespace(
+                graph_id=0,
+                updates_carry=c,
+                loop_axes=(LoopAxisFact(0, 64 * t),),
+                exact_loop_trips=None,
+                max_loop_trips=t,
+            )
             for c, t in zip(carry, trips, strict=True)
         )
-        ns = SimpleNamespace(
+        return SimpleNamespace(
             matmuls=tuple(
                 SimpleNamespace(fact=fact, axes=axes, site=site)
                 for fact, axes, site in zip(
                     facts,
-                    (_axes(), _axes()),
+                    (
+                        _axes(
+                            DotAxisKind.FIXED_FULL_EXTENT,
+                            DotAxisKind.FIXED_FULL_EXTENT,
+                            DotAxisKind.FIXED_FULL_EXTENT,
+                            m_extent=256,
+                            n_extent=256,
+                            k_extent=256,
+                        ),
+                        _axes(
+                            DotAxisKind.FIXED_FULL_EXTENT,
+                            DotAxisKind.FIXED_FULL_EXTENT,
+                            DotAxisKind.FIXED_FULL_EXTENT,
+                            m_extent=64,
+                            n_extent=64,
+                            k_extent=64,
+                        ),
+                    ),
                     sites,
                     strict=True,
                 )
             ),
             attribution_complete=True,
         )
-        ns.dot_work = lambda i: (
-            (facts[i].static_m or 1)
-            * (facts[i].static_n or 1)
-            * (facts[i].static_k or 1)
-            * max(1, ns.matmuls[i].site.loop_trips)
+
+    def rank(mm: SimpleNamespace, index: int) -> tuple[int, int, int]:
+        spec = SimpleNamespace(
+            kernel_matmul_fact=mm,
+            block_sizes=_block_sizes_stub([0]),
+            _base_default_config=lambda: helion.Config(block_sizes=[64]),
         )
-        return ns
+        env = SimpleNamespace(
+            config_spec=spec,
+            block_sizes=[SimpleNamespace(size=64 * 4096)],
+            size_hint=int,
+        )
+        return _MULTI._rank_key(env, mm, index, [64])
 
     # The carried dot wins even though it does far less work.
     f = mm((False, True), (1, 1))
-    assert _MULTI._rank_key(f, 1) > _MULTI._rank_key(f, 0)
+    assert rank(f, 1) > rank(f, 0)
     # With no carry anywhere, work decides.
     f = mm((False, False), (1, 1))
-    assert _MULTI._rank_key(f, 0) > _MULTI._rank_key(f, 1)
+    assert rank(f, 0) > rank(f, 1)
     # Execution count is part of work, so a small dot run many times can outrank a big one.
     f = mm((False, False), (1, 4096))
-    assert _MULTI._rank_key(f, 1) > _MULTI._rank_key(f, 0)
+    assert rank(f, 1) > rank(f, 0)
     # Untrusted attribution must collapse the carry term for EVERY dot equally, so ranking
     # degrades to pure work rather than to an arbitrary order.
     f = mm((False, True), (1, 1))
     f.attribution_complete = False
-    assert _MULTI._rank_key(f, 0) > _MULTI._rank_key(f, 1)
+    assert rank(f, 0) > rank(f, 1)
+
+
+def test_candidate_dot_work_counts_serial_attention_axis_once() -> None:
+    """A serial key axis contributes candidate width times candidate trip count."""
+    qk = MatmulFact(2, 2, 0, 1, None, 1024, 1024, 64, torch.bfloat16, torch.bfloat16)
+    pv = MatmulFact(2, 2, 0, None, 1, 1024, 64, 1024, torch.bfloat16, torch.bfloat16)
+    site = SimpleNamespace(
+        graph_id=0,
+        updates_carry=False,
+        loop_axes=(LoopAxisFact(1, 1024),),
+        exact_loop_trips=None,
+        max_loop_trips=1024,
+    )
+    mm = SimpleNamespace(
+        matmuls=(
+            SimpleNamespace(
+                fact=qk,
+                axes=_axes(
+                    k=DotAxisKind.FIXED_FULL_EXTENT,
+                    k_extent=64,
+                ),
+                site=site,
+            ),
+            SimpleNamespace(
+                fact=pv,
+                axes=_axes(
+                    n=DotAxisKind.FIXED_FULL_EXTENT,
+                    n_extent=64,
+                ),
+                site=site,
+            ),
+        ),
+    )
+    spec = SimpleNamespace(
+        kernel_matmul_fact=mm,
+        block_sizes=_block_sizes_stub([0, 1]),
+        _base_default_config=lambda: helion.Config(block_sizes=[128, 64]),
+    )
+    env = SimpleNamespace(
+        config_spec=spec,
+        block_sizes=[SimpleNamespace(size=1024), SimpleNamespace(size=1024)],
+        size_hint=int,
+    )
+
+    work = _FML._candidate_dot_work(env, [128, 64])
+
+    per_dot = 128 * 1024 * 64
+    assert work.total == 2 * per_dot
+    assert work.uncertain is False
 
 
 def test_projection_is_a_no_op_for_a_clean_gemm() -> None:
@@ -746,7 +886,17 @@ def test_projection_is_a_no_op_for_a_clean_gemm() -> None:
     spec = _generalized_spec(fact, _axes(), valid_block_ids=[0, 1, 2])
     env = SimpleNamespace(config_spec=spec, block_sizes=[])
     proposal = _FML._matmul_tile(4096, 4096, 4096, 2, 148, 1)
-    assert _FML._tile_for_dot(env, fact, _axes(), 2, 148, 1) == proposal
+    assert (
+        _FML._tile_for_dot(
+            env,
+            fact,
+            _axes(),
+            2,
+            148,
+            site=spec.kernel_matmul_fact.matmuls[0].site,
+        )
+        == proposal
+    )
 
 
 def _kernel_smem_env(
@@ -780,14 +930,86 @@ def test_kernel_smem_uses_region_peak_and_applies_slack_once() -> None:
     env = _kernel_smem_env(
         (fact,),
         block_ids=[0, 1, 2],
-        pipelined_regions=(PipelinedRegion((), loads),),
+        pipelined_regions=(PipelinedRegion((LoopAxisFact(2, 64),), loads),),
     )
     blocks = [64, 32, 16]
     region_peak = (64 * 16 * 2 + 16 * 32 * 2) * 4
 
-    assert _FML._smem_from_map(env, blocks, 4) == region_peak
-    assert _FML._epilogue_smem(env, blocks) == 64 * 32 * 4
+    assert _FML._smem_region_demands(env, blocks, 4) == (region_peak,)
     assert _FML._kernel_smem_bytes(env, blocks, 4) == region_peak + _FML.SMEM_SLACK
+
+
+def test_kernel_smem_separates_useful_depth_from_hard_allocation() -> None:
+    fact = _matmul_fact()
+    loads = (
+        _live("load", 0, 2),
+        _live("load", 2, 1),
+    )
+    env = _kernel_smem_env(
+        (fact,),
+        block_ids=[0, 1, 2],
+        pipelined_regions=(PipelinedRegion((LoopAxisFact(2, 32),), loads),),
+    )
+    blocks = [64, 32, 16]
+
+    per_stage = 64 * 16 * 2 + 16 * 32 * 2
+    assert _FML._smem_region_demands(env, blocks, 6) == (per_stage * 2,)
+    assert _FML._smem_region_demands(
+        env,
+        blocks,
+        6,
+        hard_allocation=True,
+    ) == (per_stage * 6,)
+
+
+def test_symbolic_loop_bounds_resolve_candidates_and_preserve_unknowns() -> None:
+    outer_block = sympy.Symbol("outer_block", integer=True, positive=True)
+    outer_tile_id = sympy.Symbol("outer_tile_id", integer=True, nonnegative=True)
+    spec = SimpleNamespace(
+        block_sizes=_block_sizes_stub([0, 1]),
+        _base_default_config=lambda: helion.Config(block_sizes=[1, 1]),
+    )
+    env = SimpleNamespace(
+        config_spec=spec,
+        block_sizes=[
+            SimpleNamespace(size=1024),
+            SimpleNamespace(size=object()),
+        ],
+        size_hint=int,
+    )
+    loop_axes = (
+        LoopAxisFact(
+            block_id=1,
+            extent=None,
+            symbolic_bound=SymbolicLoopBound(
+                2 * outer_block * (outer_tile_id + 1) + 16,
+                block_size_symbols=((outer_block, 0),),
+                tile_id_symbols=((outer_tile_id, 0),),
+            ),
+        ),
+    )
+
+    trips = _FML._resolved_loop_trips(
+        env,
+        [128, 64],
+        loop_axes,
+    )
+
+    # Eight outer tiles have lower-median ID 3. The arbitrary bound evaluates
+    # to 2 * 128 * (3 + 1) + 16 = 1040, or 17 inner 64-element tiles.
+    assert trips == 17
+    unresolved = sympy.Symbol("unresolved", integer=True, positive=True)
+    axis = LoopAxisFact(
+        block_id=1,
+        extent=None,
+        symbolic_bound=SymbolicLoopBound(
+            outer_block * (outer_tile_id + 1) + unresolved,
+            block_size_symbols=((outer_block, 0),),
+            tile_id_symbols=((outer_tile_id, 0),),
+        ),
+    )
+
+    assert _FML._resolved_loop_trips(env, [128, 64], (axis,)) is None
 
 
 def test_kernel_smem_uses_latest_complete_map_and_max_dot_epilogue() -> None:
@@ -806,7 +1028,9 @@ def test_kernel_smem_uses_latest_complete_map_and_max_dot_epilogue() -> None:
     )
     env = _kernel_smem_env((first, second), block_ids=[0, 1, 2, 3, 4])
 
-    assert _FML._epilogue_smem(env, [16, 32, 8, 64, 64]) == 64 * 64 * 4
+    assert _FML._kernel_smem_demands(env, [16, 32, 8, 64, 64], 3) == (
+        64 * 64 * 4 + _FML.SMEM_SLACK,
+    )
     assert _FML._kernel_smem_bytes(env, [16, 32, 8, 32, 32], 3) == (
         32 * 32 * 4 + _FML.SMEM_SLACK
     )
@@ -827,7 +1051,14 @@ def test_multi_dot_proposal_preconditions_with_complete_kernel_smem_map() -> Non
         "_kernel_smem_bytes",
         side_effect=record_smem,
     ):
-        assert _MULTI._proposal_for(env, spec.kernel_matmul_fact, 0, 148) is not None
+        _MULTI._tile_for_dot(
+            env,
+            fact,
+            _axes(),
+            2,
+            148,
+            site=spec.kernel_matmul_fact.matmuls[0].site,
+        )
     assert seen
     assert all(len(block_sizes) == len(spec.block_sizes) for block_sizes in seen)
     assert all(block_sizes[3] == 1 for block_sizes in seen)
@@ -900,7 +1131,7 @@ def _knob_spec(
     *,
     knob_users: tuple[tuple[int, tuple[tuple[int, str], ...]], ...],
     block_ids: list[int],
-    extents: dict[int, int],
+    extents: dict[int, object],
     grid_block_ids: tuple[int, ...] = (),
     pipelined_regions: tuple[PipelinedRegion, ...] = (),
 ) -> SimpleNamespace:
@@ -908,14 +1139,10 @@ def _knob_spec(
     mm = SimpleNamespace(
         matmuls=(),
         knob_users=knob_users,
-        outer_grid=1,
         sequential_loop_trips=1,
-        live_tiles=(),
-        live_dot_outputs=(),
         live_tile_steps=(),
         pipelined_regions=pipelined_regions,
         resident_regions=(),
-        n_dot_nodes=len(knob_users),
         attribution_complete=True,
     )
     spec = SimpleNamespace(
@@ -924,14 +1151,16 @@ def _knob_spec(
         kernel_grid_fact=None,
         block_sizes=_block_sizes_stub(block_ids),
         grid_block_ids=grid_block_ids,
-        _base_default_config=lambda: SimpleNamespace(config={}),
+        _base_default_config=lambda: helion.Config(block_sizes=[1] * len(block_ids)),
     )
     env = SimpleNamespace(
         config_spec=spec,
         block_sizes=[
             SimpleNamespace(
                 size=extents.get(b, 1),
-                block_size_source=SimpleNamespace(from_config=lambda *_a: None),
+                block_size_source=SimpleNamespace(
+                    from_config=lambda _config, info: info.size
+                ),
             )
             for b in range(max(extents or {0: 0}) + 1)
         ],
@@ -955,6 +1184,65 @@ def test_launch_grid_counts_only_grid_axes() -> None:
     assert _MULTI._launch_grid(env, [128, 128]) == 1
     assert _MULTI._launch_grid(env, [32, 128]) == 1
     assert _MULTI._launch_grid(env, [128, 32]) == 4
+
+
+def test_dot_proposal_uses_only_proven_grid_axes() -> None:
+    """The formula callback sees only proven grid axes, never serial M/N tiles."""
+    env, mm = _knob_spec(
+        knob_users=((0, ((0, "m"),)), (1, ((0, "n"),))),
+        block_ids=[0, 1],
+        extents={0: 1024, 1: 64},
+        grid_block_ids=(1,),
+    )
+    fact = MatmulFact(
+        2,
+        2,
+        0,
+        1,
+        None,
+        1024,
+        64,
+        64,
+        torch.bfloat16,
+        torch.bfloat16,
+    )
+    axes = _axes(
+        k=DotAxisKind.FIXED_FULL_EXTENT,
+        m_extent=1024,
+        n_extent=64,
+        k_extent=64,
+    )
+    site = SimpleNamespace(graph_id=0, loop_axes=())
+    mm.matmuls = (SimpleNamespace(fact=fact, axes=axes, site=site),)
+    observed: dict[str, object] = {}
+
+    def capture_formula(
+        _m: int,
+        _n: int,
+        _k: int,
+        _itemsize: int,
+        _num_sm: int,
+        _pinned_grid: int,
+        *,
+        launch_grid: Any,
+        allow_l2_grouping: bool,
+    ) -> tuple[int, int, int, int, int, int]:
+        observed["grids"] = (launch_grid(32, 64), launch_grid(512, 64))
+        observed["allow_l2_grouping"] = allow_l2_grouping
+        return 128, 64, 64, 4, 2, 1
+
+    with patch.object(_FML, "_matmul_tile", side_effect=capture_formula):
+        _FML._projected_tile_for_dot(
+            env,
+            fact,
+            axes,
+            itemsize=2,
+            num_sm=148,
+            site=site,
+        )
+
+    assert observed["grids"] == (1, 1)
+    assert observed["allow_l2_grouping"] is False
 
 
 def test_launch_grid_uses_only_dot_bearing_root_groups() -> None:
@@ -1012,6 +1300,21 @@ def test_knob_amortization_separates_reuse_free_from_reuse_bearing() -> None:
     # ...and symmetrically, 3's own loop re-fetches the 4-spanning load, so 3 amortizes too.
     assert _MULTI._knob_amortizes(mm, 3) is True
 
+    _env, mm = _knob_spec(
+        knob_users=((4, ((0, "m"),)),),
+        block_ids=[4, 5],
+        extents={4: 128, 5: 128},
+        pipelined_regions=(
+            PipelinedRegion(
+                (LoopAxisFact(5, 128), LoopAxisFact(4, 128)),
+                (_live("load", 9, 5),),
+            ),
+        ),
+    )
+    # The inner loop's load does not span its enclosing outer axis. Growing
+    # that outer tile therefore amortizes the inner scan.
+    assert _MULTI._knob_amortizes(mm, 4) is True
+
 
 def test_reuse_free_output_knob_drops_to_the_allocation_floor() -> None:
     """A reuse-free knob that sizes a dot OUTPUT extent buys no arithmetic intensity while
@@ -1046,7 +1349,7 @@ def test_reuse_free_output_knob_drops_to_the_allocation_floor() -> None:
 def test_grid_knob_shrinks_only_when_wave_utilization_improves() -> None:
     """A knob that IS the grid trades tile area against occupancy, so it is sized by the
     machine: shrink while the launch grid is under one wave and wave utilization strictly
-    improves, then stop at the allocation granularity rather than at the dot minimum."""
+    improves, then stop at the legal block minimum."""
     env, _mm = _knob_spec(
         knob_users=((0, ((0, "m"), (1, "n"))),),
         block_ids=[0],
@@ -1061,8 +1364,8 @@ def test_grid_knob_shrinks_only_when_wave_utilization_improves() -> None:
     # 8192 / 64 = 128 programs >= 0.8 * 148, so the shrink stops there rather than
     # continuing to the floor.
     assert block_sizes == [64]
-    # When even the floor cannot fill a wave, the granularity floor wins: a narrower
-    # accumulator reserves the same tensor memory while issuing less MMA work.
+    # When even a small tile cannot fill a wave, continue to the legal block
+    # minimum. Tensor-memory column granularity is not a launch-grid constraint.
     env, _mm = _knob_spec(
         knob_users=((0, ((0, "m"), (1, "n"))),),
         block_ids=[0],
@@ -1074,7 +1377,7 @@ def test_grid_knob_shrinks_only_when_wave_utilization_improves() -> None:
     )
     block_sizes = [1024]
     _MULTI._apply_knob_roles(env, env.config_spec.kernel_matmul_fact, block_sizes, 148)
-    assert block_sizes == [_MULTI.TMEM_ALLOC_COLUMNS]
+    assert block_sizes == [8]
     # Do not cross into a second partial wave when that leaves utilization unchanged:
     # 11008/128 = 86 programs in one wave, while 11008/64 = 172 in two waves.
     env, _mm = _knob_spec(


### PR DESCRIPTION
Stacked PRs:
 * __->__#3464
 * #3409


--- --- ---

[autotuner] harden B200 matmul heuristics for off-corpus kernels

Improve B200 matmul seed selection across 75 off-corpus cells. Relative to
the pre-PR default, PR #3409 reaches 1.395x while this change reaches 2.236x.

Ratios below are geometric-mean speedups; values above 1.00x are faster.

Linear attention

This change modifies 46/432 generated configs relative to PR #3409. Of
these, 149 cells have stored pre-tuned comparisons:

| Scope | Cells | Pre-tuned | PR #3409 | This PR |
|---|---:|---:|---:|---:|
| Helion linear attention | 124 | 1.000x | 0.830x | 0.813x |
| SGLang linear attention | 25 | 1.000x | 0.832x | 0.879x |
| Combined | 149 | 1.000x | 0.830x | 0.824x |

The aggregate is nearly neutral, but individual families move materially:

| Kernel | PR #3409 | This PR |
|---|---:|---:|
| chunk_bwd_dqkw_delta | 0.590x | 0.550x |
| chunk_bwd_dstate_delta | 0.792x | 0.689x |
| chunk_bwd_wu_kda | 0.945x | 0.746x |
| chunk_bwd_wy_dL_delta | 0.764x | 0.724x |
| SGLang _chunk_state | 0.847x | 0.881x |
| ReplaySSM decode | 0.719x | 0.911x |

Six additional split_k_matmul configs changed outside the pre-tuned subset;
their changed-cell geomean is 0.853x versus PR #3409. The remaining 386
linear-attention configs are unchanged.

Off-corpus kernels with a pre-existing compiler seed:

| Kernel | Shapes | Existing | PR #3409 | This PR |
|---|---:|---:|---:|---:|
| BF16 x INT16 | 5 | 1.000x | 0.967x | 0.967x |
| Broadcast matmul | 5 | 1.000x | 0.980x | 0.980x |
| Jagged dense BMM* | 5 | 1.000x | 1.000x | 1.236x |
| Overall | 15 | 1.000x | 0.982x | 1.054x |

Off-corpus kernels with a true unseeded default:

| Kernel | Shapes | Default | PR #3409 | This PR |
|---|---:|---:|---:|---:|
| Attention backward | 5 | 1.000x | 1.939x | 2.226x |
| Biased attention forward | 5 | 1.000x | 1.519x | 2.021x |
| Blackwell attention backward | 5 | 1.000x | 2.087x | 2.282x |
| Blackwell attention forward | 5 | 1.000x | 3.460x | 3.369x |
| Causal attention forward | 5 | 1.000x | 1.336x | 2.453x |
| Dense attention forward | 5 | 1.000x | 1.564x | 4.725x |
| Flex attention forward | 5 | 1.000x | 1.384x | 1.630x |
| Jagged HSTU | 5 | 1.000x | 0.141x | 3.149x |
| Gather GEMV | 5 | 1.000x | 2.052x | 2.052x |
| Squeeze-excitation | 5 | 1.000x | 1.432x | 5.048x |
| GDN forward-H | 5 | 1.000x | 2.005x | 2.005x |
| Mamba2 chunk scan | 5 | 1.000x | 3.061x | 3.494x |
| Overall, including HSTU | 60 | 1.000x | 1.523x | 2.699x |
| Overall, excluding HSTU | 55 | 1.000x | 1.892x | 2.661x |

* Jagged dense BMM remains diagnostic because three schedules encounter the
kernel's existing BF16 reduction-order accuracy sensitivity.

Associate each MatmulFact with its exact FX node and recognize variants such
as aten.bmm.dtype. Preserve dimension provenance and all enclosing loop facts
so later dots retain their M/N/K block roles.

Make dynamic work candidate-aware, preserve unknown extents, and evaluate
symbolic loop bounds against candidate blocks. Use one proven launch-grid
calculation for proposal sizing, wave fill, stages, warps, and occupancy so
serial tiles do not create fictitious launch programs.

Account for nested-loop reuse, residency changes, independently executing
SMEM regions, accumulators, and promoted-LHS TMEM scratch. Resource fixup now
shrinks knobs that relieve the binding resource and retains tcgen05 work when
possible.

Validation:
- 102 tests passed, 23 skipped
- Ruff and diff checks passed
- Final cleanup preserved all 432 linear-attention and 75 off-corpus configs
  byte-for-byte relative to the pushed stack/50 branch