### PR TITLE
[CI] Skip failing Pallas tests

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1088,10 +1088,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="concat2d_dim1_simple",
         )
 
-    @xfailIfPallasInterpret(
-        "jax interpret-mode discharge cannot handle non-divisible blocked "
-        "slices (traced sizes)"
-    )
+    @skipIfPallas("indirect access is unsupported by both one-hot and DMA lowering")
     def test_concat(self):
         args = (
             torch.randn(512, 500, device=DEVICE),
@@ -1104,10 +1101,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="concat2d_dim1",
         )
 
-    @xfailIfPallasInterpret(
-        "emit_pipeline ds-pad DMA uses a tracer-size dynamic_slice, unsupported"
-        " in JAX Pallas interpret mode"
-    )
+    @skipIfPallas("indirect access is unsupported by both one-hot and DMA lowering")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")
     def test_concat_block_ptr(self):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -23,6 +23,7 @@ from helion._testing import TestCase
 from helion._testing import _bound_test_config
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfPallas
 from helion._testing import skipIfPallasInterpret
 from helion._testing import skipUnlessPallas
 from helion._testing import xfailIfPallas
@@ -2432,6 +2433,7 @@ class TestPallas(TestCase):
                 block_size=16,
             )
 
+    @skipIfPallas("indirect access is unsupported by both one-hot and DMA lowering")
     def test_scatter_store_multiple_tensor_indices_raises(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def scatter_store_multiple_tensor_indices(

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -10,6 +10,7 @@ from helion._testing import DEVICE
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfPallas
 from helion._testing import skipUnlessPallas
 from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
@@ -758,6 +759,7 @@ class TestPallasClampedRefs(TestCase):
         _code, out = code_and_output(kernel, (x, y), block_sizes=[32])
         torch.testing.assert_close(out, torch.ones(10, device=DEVICE))
 
+    @skipIfPallas("indirect access is unsupported by both one-hot and DMA lowering")
     def test_masked_load_spanning_tensor(self) -> None:
         # Tile spans past the tensor's extent (concat pattern): the padded
         # load composes with extra_mask / where.


### PR DESCRIPTION
## Summary

- skip the four Pallas tests failing on the current main CI commit
- retain coverage for the affected example tests on non-Pallas backends

## Test plan

- identified failures from the Pallas interpret and TPU CI job logs on main commit `1ba43c81`
- `ruff check test/test_examples.py test/test_pallas.py test/test_pallas_load_store.py`
- codespell pre-commit check