### PR TITLE
[benchmark] Use rep=1 on MI350X

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -191,7 +191,11 @@ jobs:
       alias: mi350x
       kernels: ${{ matrix.kernels }}
       env-vars: ${{ github.event.inputs.env_vars }}
-      custom-args: ${{ github.event.inputs.custom_args }}
+      # Limit the target measurement window so TritonBench captures a bounded
+      # number of repetitions in each HIP graph on MI350X.
+      custom-args: >-
+        --rep 1
+        ${{ github.event.inputs.custom_args }}
 
   run-tpu:
     if: ${{ github.event.inputs.run_tpu == 'true' }}


### PR DESCRIPTION
## Summary

- keep the existing TritonBench pin unchanged
- retain the existing `triton_do_bench --cudagraph` timing path
- pass `--rep 1` only to MI350X benchmark jobs
- leave all other benchmark platforms unchanged

## Motivation

TritonBench derives the captured repetition count as approximately `rep / estimate_ms`. Its default target is 100 ms for sub-millisecond kernels, so a 0.006 ms eager baseline can produce a graph with roughly 16,000 repetitions, plus cache-clearing nodes. With the newer PyTorch/ROCm stack, these oversized HIP graphs can terminate with SIGSEGV before Helion runs.

Using a 1 ms target reduces the same example to roughly 166 repetitions while preserving the previously working timer, cache-clearing behavior, and comparable speedup calculation. This is a Helion-only workaround and does not modify or update TritonBench.

Latest affected nightly: https://github.com/pytorch/helion/actions/runs/32825465848

## Why not `gpu_events`

The initial experiment used `gpu_events`, but run https://github.com/pytorch/helion/actions/runs/32900824511 did not produce valid measurements:

- CUDAGraph measurements require `grad_to_none=None` and `skip_cache_clearing=True`; the existing invocation does not satisfy those requirements.
- Non-CUDAGraph operators failed in the ROCm `sleep_amd` stream-blocking helper.
- `--keep-going` embedded those errors in CSV cells, and the Helion converter represented the nonnumeric values as `0.0`, causing the jobs to appear successful despite invalid results.

The run therefore cannot be used for performance comparison. Its final grouped-GEMM shard was later cancelled by the six-hour job timeout.

## Testing

- verified the TritonBench pin remains `0e36d8aaf6a4b3c99c04efc054da8ac76399ec4c`
- verified `--rep 1` is scoped only to the MI350X workflow call
- `git diff --check`
- a fresh MI350X benchmark run is required after updating the PR branch