### PR TITLE
[cutedsl] Reuse warmed nested-input kernels under torch.compile and isolate backend tests from shared cache and capability state

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -134,6 +134,79 @@ class _FastDispatchEntry(NamedTuple):
     specialization_generation: int
 
 
+def _nested_fast_dispatch_key(
+    value: object, *, specialize_numeric: bool = False
+) -> tuple[Hashable, bool] | None:
+    """Return a specialization-safe key and whether ``value`` contains a tensor."""
+    value_type = type(value)
+    if value_type is torch.Tensor or value_type is torch.nn.Parameter:
+        if specialize_numeric:
+            # A constexpr-annotated argument specializes on the raw container,
+            # so tensor identity (not metadata) drives the full key; a
+            # metadata-based fast key would conflate keys the full key
+            # distinguishes.
+            return None
+        tensor = cast("torch.Tensor", value)
+        static_indices = getattr(tensor, "_dynamo_static_indices", None)
+        return (
+            (
+                tensor.dtype,
+                tensor.shape,
+                tensor.stride(),
+                tensor.device,
+                None if static_indices is None else frozenset(static_indices),
+            ),
+            True,
+        )
+    if value_type in (int, float, bool):
+        return ((value_type, value) if specialize_numeric else value_type), False
+    if value_type is str:
+        return (value_type, value), False
+    if isinstance(value, ConstExpr):
+        try:
+            hash(value.value)
+        except TypeError:
+            return None
+        return (value_type, value.value), False
+    if value is None:
+        return None, False
+    if value_type is torch.dtype or value_type is torch.device:
+        return cast("Hashable", value), False
+    if value_type is tuple or value_type is list:
+        items: list[Hashable] = []
+        has_tensor = False
+        for item in cast("Sequence[object]", value):
+            nested = _nested_fast_dispatch_key(
+                item, specialize_numeric=specialize_numeric
+            )
+            if nested is None:
+                return None
+            item_key, item_has_tensor = nested
+            items.append(item_key)
+            has_tensor = has_tensor or item_has_tensor
+        return (value_type, tuple(items)), has_tensor
+    if value_type is dict:
+        entries: list[tuple[str | int, Hashable]] = []
+        has_tensor = False
+        for item_key, item_value in cast("dict[object, object]", value).items():
+            if type(item_key) not in (str, int):
+                return None
+            nested = _nested_fast_dispatch_key(
+                item_value, specialize_numeric=specialize_numeric
+            )
+            if nested is None:
+                return None
+            value_key, value_has_tensor = nested
+            entries.append((cast("str | int", item_key), value_key))
+            has_tensor = has_tensor or value_has_tensor
+        try:
+            entries.sort()
+        except TypeError:
+            return None
+        return (value_type, tuple(entries)), has_tensor
+    return None
+
+
 class _SpecializationAlias:
     """An omitted-default signature backed by a normalized signature."""
 
@@ -163,59 +236,105 @@ def _make_prepared_arg_guard(
 ) -> Callable[[tuple[object, ...]], bool]:
     namespace: dict[str, object] = {}
     checks = [f"len(args) == {len(args)}"]
-    for index, arg in enumerate(args):
-        prefix = f"args[{index}]"
-        namespace[f"type_{index}"] = type(arg)
-        checks.append(f"type({prefix}) is type_{index}")
-        if type(arg) in (torch.Tensor, torch.nn.Parameter):
-            assert isinstance(arg, torch.Tensor)
-            namespace[f"dtype_{index}"] = arg.dtype
-            namespace[f"shape_{index}"] = arg.shape
-            namespace[f"stride_{index}"] = arg.stride()
-            namespace[f"device_{index}"] = arg.device
+    counter = itertools.count()
+
+    def append_checks(
+        value: object,
+        prefix: str,
+        annotation: object | None = None,
+    ) -> None:
+        token = next(counter)
+        value_type = type(value)
+        namespace[f"type_{token}"] = value_type
+        checks.append(f"type({prefix}) is type_{token}")
+        if value_type in (torch.Tensor, torch.nn.Parameter):
+            assert isinstance(value, torch.Tensor)
+            namespace[f"dtype_{token}"] = value.dtype
+            namespace[f"shape_{token}"] = value.shape
+            namespace[f"stride_{token}"] = value.stride()
+            namespace[f"device_{token}"] = value.device
             checks.extend(
                 (
-                    f"{prefix}.dtype is dtype_{index}",
-                    f"{prefix}.shape == shape_{index}",
-                    f"{prefix}.stride() == stride_{index}",
-                    f"{prefix}.device == device_{index}",
+                    f"{prefix}.dtype is dtype_{token}",
+                    f"{prefix}.shape == shape_{token}",
+                    f"{prefix}.stride() == stride_{token}",
+                    f"{prefix}.device == device_{token}",
                 )
             )
-            static_indices = getattr(arg, "_dynamo_static_indices", None)
+            static_indices = getattr(value, "_dynamo_static_indices", None)
             if static_indices is None:
                 checks.append(
                     f"getattr({prefix}, '_dynamo_static_indices', None) is None"
                 )
             else:
-                namespace[f"static_indices_{index}"] = frozenset(static_indices)
+                namespace[f"static_indices_{token}"] = frozenset(static_indices)
                 checks.extend(
                     (
                         f"getattr({prefix}, '_dynamo_static_indices', None) is not None",
-                        f"frozenset({prefix}._dynamo_static_indices) == static_indices_{index}",
+                        f"frozenset({prefix}._dynamo_static_indices) == static_indices_{token}",
                     )
                 )
-        elif type(arg) in (bool, int, float):
+        elif value_type is tuple or value_type is list:
+            sequence = cast("Sequence[object]", value)
+            checks.append(f"len({prefix}) == {len(sequence)}")
+            for item_index, item in enumerate(sequence):
+                append_checks(
+                    item,
+                    f"{prefix}[{item_index}]",
+                    annotation,
+                )
+        elif value_type is dict:
+            mapping = cast("dict[str | int, object]", value)
+            checks.append(f"len({prefix}) == {len(mapping)}")
+            for item_key, item_value in mapping.items():
+                key_name = f"key_{token}_{len(namespace)}"
+                namespace[key_name] = item_key
+                checks.append(f"{key_name} in {prefix}")
+                append_checks(
+                    item_value,
+                    f"{prefix}[{key_name}]",
+                    annotation,
+                )
+        elif value_type in (bool, int, float):
             # Ordinary numeric arguments are runtime values in Helion's base
             # specialization.  A constexpr annotation is the one exception;
             # hl.specialize() constraints are covered by ``_extra_guards``.
-            if kernel._annotations[index] is ConstExpr:
-                if type(arg) is float and arg != arg:
+            if annotation is ConstExpr:
+                if value_type is float and value != value:
                     # Python's equality/hash behavior does not provide a stable
                     # equivalence class for constexpr NaNs.  Keep those calls on
                     # the regular specialization path rather than weakening its
                     # semantics in the prepared guard.
                     raise TypeError("constexpr NaN cannot use a prepared call")
-                namespace[f"value_{index}"] = arg.hex() if type(arg) is float else arg
-                checks.append(
-                    f"{prefix}.hex() == value_{index}"
-                    if type(arg) is float
-                    else f"{prefix} == value_{index}"
+                namespace[f"value_{token}"] = (
+                    cast("float", value).hex() if value_type is float else value
                 )
-        elif type(arg) in (str, type(None), torch.dtype, torch.device):
-            namespace[f"value_{index}"] = arg
-            checks.append(f"{prefix} == value_{index}")
+                checks.append(
+                    f"{prefix}.hex() == value_{token}"
+                    if value_type is float
+                    else f"{prefix} == value_{token}"
+                )
+        elif value_type in (str, type(None), torch.dtype, torch.device):
+            namespace[f"value_{token}"] = value
+            checks.append(f"{prefix} == value_{token}")
+        elif isinstance(value, ConstExpr):
+            inner = value.value
+            if type(inner) is float:
+                if inner != inner:
+                    # Match the constexpr-annotation path above: NaN has no
+                    # stable equivalence class, so keep those calls on the
+                    # regular specialization path.
+                    raise TypeError("constexpr NaN cannot use a prepared call")
+                namespace[f"value_{token}"] = inner.hex()
+                checks.append(f"{prefix}.value.hex() == value_{token}")
+            else:
+                namespace[f"value_{token}"] = inner
+                checks.append(f"{prefix}.value == value_{token}")
         else:
-            raise TypeError(f"unsupported prepared-call argument: {type(arg)!r}")
+            raise TypeError(f"unsupported prepared-call argument: {value_type!r}")
+
+    for index, arg in enumerate(args):
+        append_checks(arg, f"args[{index}]", kernel._annotations[index])
     return eval(f"lambda args: {' and '.join(checks)}", namespace)
 
 
@@ -729,11 +848,12 @@ class Kernel(Generic[_R]):
         _extra_guards: list[tuple[Callable[[Sequence[object]], Hashable], Hashable]]
         | None = None,
     ) -> tuple[Hashable, ...] | None:
-        """Build the exact eager dispatch key, optionally collecting its guards."""
+        """Build a specialization-safe eager key, optionally collecting guards."""
         key: list[Hashable] = []
         has_tensor = False
-        for a in args:
+        for index, a in enumerate(args):
             t = type(a)
+            annotation = self._annotations[index] if index < self._num_params else None
             if t is torch.Tensor or t is torch.nn.Parameter:
                 tensor = cast("torch.Tensor", a)
                 has_tensor = True
@@ -747,12 +867,30 @@ class Kernel(Generic[_R]):
                         None if si is None else frozenset(si),
                     )
                 )
-            elif t is int or t is float or t is bool or t is str:
+            elif t is int or t is float or t is bool:
+                key.append((t, a) if annotation is ConstExpr else t)
+            elif t is str:
                 key.append((t, a))
+            elif isinstance(a, ConstExpr):
+                try:
+                    hash(a.value)
+                except TypeError:
+                    return None
+                key.append((t, a.value))
             elif a is None:
                 key.append(None)
             elif t is torch.dtype or t is torch.device:
                 key.append(a)
+            elif t is tuple or t is list or t is dict:
+                nested = _nested_fast_dispatch_key(
+                    a,
+                    specialize_numeric=annotation is ConstExpr,
+                )
+                if nested is None:
+                    return None
+                nested_key, nested_has_tensor = nested
+                key.append(nested_key)
+                has_tensor = has_tensor or nested_has_tensor
             else:
                 return None
         if not has_tensor:
@@ -789,19 +927,21 @@ class Kernel(Generic[_R]):
         Build a cheap dispatch key for the fast-path cache in ``__call__``.
 
         The key records exact per-argument metadata (dtype/shape/stride/device
-        for tensors, type and value for scalars), which is strictly finer than
-        the full specialization key: any two argument lists that produce
-        different full keys also produce different fast keys.  That makes it
-        safe to map a fast key directly to the BoundKernel that a full
-        ``bind()`` resolved for the same arguments.
+        for tensors), exact values for specialized arguments, and types for
+        ordinary runtime numeric values. It refines the full specialization
+        key: any two argument lists that produce different full keys also
+        produce different fast keys. That makes it safe to map a fast key
+        directly to the BoundKernel that a full ``bind()`` resolved for the
+        same arguments.
 
         If a base signature has extra specialization extractors, their results
         are appended to preserve the same no-collision invariant for
         value-based specializations.
 
-        Returns None when an argument type is not handled (tensor subclasses,
-        containers, ...), or when there is no tensor argument to pin down the
-        device; callers must then take the regular ``bind()`` path.
+        Returns None when an argument type is not handled (for example, tensor
+        subclasses or unsupported objects nested in a container), or when there
+        is no tensor argument to pin down the device; callers must then take the
+        regular ``bind()`` path.
         """
         specialization_generation = self._specialization_generation
         extra_guards: list[tuple[Callable[[Sequence[object]], Hashable], Hashable]] = []

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -226,6 +226,14 @@ KERNELS = {
 
 @onlyBackends(["triton", "cute"])
 class TestCache(RefEagerTestDisabled, TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        cache_dir = self._test_stack.enter_context(tempfile.TemporaryDirectory())
+        self._test_stack.enter_context(
+            patch.dict(os.environ, {"HELION_CACHE_DIR": cache_dir}, clear=False)
+        )
+        os.environ.pop(_backend_cache_dir_env(), None)
+
     @parametrize(
         "name",
         ("add", "matmul", "welford", "list_tensor", "list_tensor_different_shapes"),
@@ -793,6 +801,14 @@ class FailingBackend(RemoteCacheBackend):
 
 @onlyBackends(["triton"])
 class TestRemoteCache(RefEagerTestDisabled, TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        cache_dir = self._test_stack.enter_context(tempfile.TemporaryDirectory())
+        self._test_stack.enter_context(
+            patch.dict(os.environ, {"HELION_CACHE_DIR": cache_dir}, clear=False)
+        )
+        os.environ.pop(_backend_cache_dir_env(), None)
+
     def _make_remote_cache_fn(self, backend):
         from helion.autotuner.remote_cache import RemoteAutotuneCache
 

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -12813,6 +12813,7 @@ class TestCuteLowerings(unittest.TestCase):
             env={},
         )
         env = SimpleNamespace(resolve_block_id=lambda size: None)
+        codegen = hl.dot._codegen["cute"]
 
         with (
             patch.object(CompileEnvironment, "current", return_value=env),
@@ -12829,7 +12830,7 @@ class TestCuteLowerings(unittest.TestCase):
                 return_value=ast.Name(id="dot_result", ctx=ast.Load()),
             ) as emit,
         ):
-            result = hl.dot._codegen["cute"](state)
+            result = codegen(state)
 
         self.assertEqual(ast.unparse(result), "dot_result")
         self.assertEqual(emit.call_args.kwargs["out_dtype"], torch.float32)
@@ -12874,6 +12875,7 @@ class TestCuteLowerings(unittest.TestCase):
             env={},
         )
         env = SimpleNamespace(resolve_block_id=lambda size: None)
+        codegen = hl.dot._codegen["cute"]
 
         with (
             patch.object(CompileEnvironment, "current", return_value=env),
@@ -12891,7 +12893,7 @@ class TestCuteLowerings(unittest.TestCase):
             ) as emit,
             self.assertRaisesRegex(exc.BackendUnsupported, "hl.dot"),
         ):
-            hl.dot._codegen["cute"](state)
+            codegen(state)
 
         emit.assert_not_called()
 
@@ -12931,6 +12933,7 @@ class TestCuteLowerings(unittest.TestCase):
             env={},
         )
         env = SimpleNamespace(resolve_block_id=lambda size: None)
+        codegen = hl.dot._codegen["cute"]
 
         with (
             patch.object(CompileEnvironment, "current", return_value=env),
@@ -12951,7 +12954,7 @@ class TestCuteLowerings(unittest.TestCase):
                 TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY,
             ),
         ):
-            hl.dot._codegen["cute"](state)
+            codegen(state)
 
         emit.assert_not_called()
 
@@ -12993,6 +12996,7 @@ class TestCuteLowerings(unittest.TestCase):
             env={},
         )
         env = SimpleNamespace(resolve_block_id=lambda size: None)
+        codegen = hl.dot._codegen["cute"]
 
         with (
             patch.object(CompileEnvironment, "current", return_value=env),
@@ -13009,7 +13013,7 @@ class TestCuteLowerings(unittest.TestCase):
                 return_value=ast.Name(id="dot_result", ctx=ast.Load()),
             ) as emit,
         ):
-            hl.dot._codegen["cute"](state)
+            codegen(state)
 
         self.assertEqual(emit.call_args.kwargs["out_dtype"], torch.float32)
 
@@ -13061,6 +13065,7 @@ class TestCuteLowerings(unittest.TestCase):
         env = SimpleNamespace(
             resolve_block_id=lambda size: 11 if int(size) == 8 else None
         )
+        codegen = hl.dot._codegen["cute"]
 
         with (
             patch.object(CompileEnvironment, "current", return_value=env),
@@ -13077,7 +13082,7 @@ class TestCuteLowerings(unittest.TestCase):
                 return_value=ast.Name(id="dot_result", ctx=ast.Load()),
             ) as emit,
         ):
-            result = hl.dot._codegen["cute"](state)
+            result = codegen(state)
 
         self.assertEqual(ast.unparse(result), "dot_result")
         self.assertIsNone(emit.call_args.kwargs["k_block_id"])
@@ -13135,6 +13140,7 @@ class TestCuteLowerings(unittest.TestCase):
         env = SimpleNamespace(
             resolve_block_id=lambda size: 11 if int(size) == 8 else None
         )
+        codegen = hl.dot._codegen["cute"]
 
         with (
             patch.object(CompileEnvironment, "current", return_value=env),
@@ -13147,7 +13153,7 @@ class TestCuteLowerings(unittest.TestCase):
                 return_value=ast.Name(id="dot_result", ctx=ast.Load()),
             ) as emit,
         ):
-            result = hl.dot._codegen["cute"](state)
+            result = codegen(state)
 
         self.assertEqual(ast.unparse(result), "dot_result")
         self.assertEqual(emit.call_args.kwargs["k_block_id"], 11)
@@ -15965,6 +15971,11 @@ class TestCuteLowerings(unittest.TestCase):
             ),
             patch.object(
                 cute_mma_module, "_mma_tiles_are_static_full", return_value=True
+            ),
+            patch.object(
+                cute_mma_module,
+                "warp_spec_from_config",
+                return_value=SimpleNamespace(store_warps=0),
             ),
             patch.object(
                 cute_mma_module,

--- a/test/test_cute_rank3_rhs_b_tma.py
+++ b/test/test_cute_rank3_rhs_b_tma.py
@@ -523,6 +523,7 @@ def _seed_configs(
     args: tuple[torch.Tensor, ...],
     mode: str,
 ) -> tuple[Any, list[dict[str, Any]], list[dict[str, Any]]]:
+    kernel.reset()
     with (
         patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
         patch_cute_mma_support(),

--- a/test/test_fast_dispatch_key.py
+++ b/test/test_fast_dispatch_key.py
@@ -1,22 +1,21 @@
 """Tests for ``Kernel._fast_dispatch_key``, the cheap dispatch key that backs
 the ``Kernel.__call__`` fast-path cache (``_dispatch_cache``).
 
-The correctness argument for the cache is that the fast key is *strictly finer*
-than the full specialization key: any two argument lists that produce different
-full keys also produce different fast keys, so a fast-key hit can never dispatch
-to a BoundKernel that a full ``bind()`` would not have resolved for those
-arguments. "Strictly" finer because the converse fails -- the fast key
-distinguishes argument lists (e.g. scalar values, or dynamic-shape sizes that
-bucket together) that the full key deliberately collapses.
+The correctness argument for the cache is that the fast key refines the full
+specialization key: any two argument lists that produce different full keys also
+produce different fast keys, so a fast-key hit can never dispatch to a
+BoundKernel that a full ``bind()`` would not have resolved for those arguments.
+The fast key remains strictly finer for exact tensor metadata that the dynamic
+specialization key deliberately buckets together.
 
 These tests pin down:
 1. Refinement: across a matrix of dtype/shape/stride variants, distinct full
    keys always imply distinct fast keys.
-2. Strictness under two witnesses that share a full key but not a fast key:
-   scalar value (full key records only ``type``) and dynamic-shape bucketing.
-3. The documented ``None`` returns: unhandled argument types and the
+2. Runtime scalar values share a key, while constexpr values remain distinct.
+3. Strictness under dynamic-shape bucketing.
+4. The documented ``None`` returns: unhandled argument types and the
    no-tensor-to-pin-the-device case.
-4. ``key=`` functions feed into the fast key.
+5. ``key=`` functions feed into the fast key.
 
 The key is pure argument-metadata bookkeeping, so it needs no compilation and
 runs on CPU-only bots.
@@ -30,6 +29,7 @@ import torch
 
 import helion
 import helion.language as hl
+from helion.runtime.kernel import _make_prepared_arg_guard
 
 
 @helion.kernel(static_shapes=True)
@@ -53,6 +53,22 @@ def _dynamic_add_scalar(x: torch.Tensor, s: int) -> torch.Tensor:
     out = torch.empty_like(x)
     for tile in hl.tile(x.size(0)):
         out[tile] = x[tile] + s
+    return out
+
+
+@helion.kernel(static_shapes=False)
+def _dynamic_add_constexpr(x: torch.Tensor, s: hl.constexpr) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + s
+    return out
+
+
+@helion.kernel(static_shapes=False)
+def _dynamic_add_scalar_list(x: torch.Tensor, values: list[int]) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + values[0]
     return out
 
 
@@ -90,11 +106,7 @@ class TestFastDispatchKey(unittest.TestCase):
                     )
         self.assertTrue(saw_distinct_full)
 
-    def test_strictly_finer_via_scalar_value(self) -> None:
-        """Witness that the fast key is *strictly* finer: two calls whose only
-        difference is a scalar's value share a full key (which records only the
-        scalar's ``type``) but get distinct fast keys (which record its value).
-        """
+    def test_runtime_scalar_values_share_fast_key(self) -> None:
         x = torch.empty(64, dtype=torch.float32)
         a = (x, 1)
         b = (x, 2)
@@ -102,9 +114,70 @@ class TestFastDispatchKey(unittest.TestCase):
             _dynamic_add_scalar.specialization_key(a),
             _dynamic_add_scalar.specialization_key(b),
         )
-        self.assertNotEqual(
+        self.assertEqual(
             _dynamic_add_scalar._fast_dispatch_key(a),
             _dynamic_add_scalar._fast_dispatch_key(b),
+        )
+        self.assertEqual(
+            len(
+                {
+                    _dynamic_add_scalar._fast_dispatch_key((x, value))
+                    for value in (True, 1, 1.0)
+                }
+            ),
+            3,
+        )
+
+    def test_constexpr_scalar_values_have_distinct_fast_keys(self) -> None:
+        x = torch.empty(64, dtype=torch.float32)
+        self.assertNotEqual(
+            _dynamic_add_constexpr._fast_dispatch_key((x, 1)),
+            _dynamic_add_constexpr._fast_dispatch_key((x, 2)),
+        )
+        self.assertNotEqual(
+            _dynamic_add_scalar._fast_dispatch_key((x, hl.constexpr(1))),
+            _dynamic_add_scalar._fast_dispatch_key((x, hl.constexpr(2))),
+        )
+
+    def test_nested_runtime_scalar_values_share_fast_key(self) -> None:
+        x = torch.empty(64, dtype=torch.float32)
+        self.assertEqual(
+            _dynamic_add_scalar_list._fast_dispatch_key((x, [1, 2])),
+            _dynamic_add_scalar_list._fast_dispatch_key((x, [3, 4])),
+        )
+
+    def test_prepared_guard_preserves_nested_constexpr_values(self) -> None:
+        x = torch.empty(64, dtype=torch.float32)
+        guard = _make_prepared_arg_guard(_dynamic_add_constexpr, (x, (1, 2)))
+
+        self.assertTrue(guard((x, (1, 2))))
+        self.assertFalse(guard((x, (3, 4))))
+
+    def test_prepared_guard_supports_constexpr_wrapped_values(self) -> None:
+        x = torch.empty(64, dtype=torch.float32)
+        guard = _make_prepared_arg_guard(_dynamic_add_scalar, (x, hl.constexpr(2)))
+
+        self.assertTrue(guard((x, hl.constexpr(2))))
+        self.assertFalse(guard((x, hl.constexpr(3))))
+        self.assertFalse(guard((x, 2)))
+
+        fguard = _make_prepared_arg_guard(_dynamic_add_scalar, (x, hl.constexpr(0.0)))
+        self.assertTrue(fguard((x, hl.constexpr(0.0))))
+        self.assertFalse(fguard((x, hl.constexpr(-0.0))))
+        with self.assertRaises(TypeError):
+            _make_prepared_arg_guard(
+                _dynamic_add_scalar, (x, hl.constexpr(float("nan")))
+            )
+
+    def test_constexpr_container_with_tensor_returns_none(self) -> None:
+        """A constexpr-annotated container specializes on the raw argument, so
+        tensor identity drives the full key; a metadata fast key would conflate
+        keys the full key distinguishes, so there must be no fast key."""
+        x = torch.empty(64, dtype=torch.float32)
+        t = torch.empty(8, dtype=torch.float32)
+        self.assertIsNone(_dynamic_add_constexpr._fast_dispatch_key((x, (t, 1))))
+        self.assertIsNone(
+            _dynamic_add_constexpr._fast_dispatch_key((x, {"weights": t}))
         )
 
     def test_strictly_finer_via_dynamic_shape_bucketing(self) -> None:
@@ -137,11 +210,54 @@ class TestFastDispatchKey(unittest.TestCase):
         self.assertIs(type(entry[1]), torch.Size)
 
     def test_returns_none_for_unhandled_arg_type(self) -> None:
-        """A container / unsupported argument type forces the slow ``bind()``
-        path by returning ``None``."""
+        """An unsupported nested argument forces the slow ``bind()`` path."""
         x = torch.empty(64, dtype=torch.float32)
-        self.assertIsNone(_static_add1._fast_dispatch_key((x, [1, 2, 3])))
+        self.assertIsNone(_static_add1._fast_dispatch_key((x, [object()])))
         self.assertIsNone(_static_add1._fast_dispatch_key((x, object())))
+
+    def test_nested_containers_record_structure_and_tensor_metadata(self) -> None:
+        x = torch.empty(64, dtype=torch.float32)
+        y = torch.empty(128, dtype=torch.float32)
+
+        tuple_key = _static_add1._fast_dispatch_key(((x, y),))
+        list_key = _static_add1._fast_dispatch_key(([x, y],))
+        dict_key = _static_add1._fast_dispatch_key(({"x": x, "y": y},))
+        reordered_dict_key = _static_add1._fast_dispatch_key(({"y": y, "x": x},))
+        nested_key = _static_add1._fast_dispatch_key(({"pair": [x, y]},))
+
+        self.assertIsNotNone(tuple_key)
+        self.assertIsNotNone(list_key)
+        self.assertIsNotNone(nested_key)
+        self.assertNotEqual(tuple_key, list_key)
+        self.assertEqual(dict_key, reordered_dict_key)
+        self.assertNotEqual(
+            tuple_key,
+            _static_add1._fast_dispatch_key(((x, torch.empty_like(x)),)),
+        )
+
+    def test_nested_container_without_tensor_returns_none(self) -> None:
+        self.assertIsNone(_dynamic_add_scalar._fast_dispatch_key((([1, 2],),)))
+
+    def test_prepared_guard_recurses_through_nested_containers(self) -> None:
+        x = torch.empty(64, dtype=torch.float32)
+        y = torch.empty(128, dtype=torch.float32)
+        args = ({"pair": [x, y], "scale": 2},)
+        guard = _make_prepared_arg_guard(_static_add1, args)
+
+        self.assertTrue(
+            guard(
+                (
+                    {
+                        "scale": 3,
+                        "pair": [torch.empty_like(x), torch.empty_like(y)],
+                    },
+                )
+            )
+        )
+        self.assertFalse(guard(({"pair": (x, y), "scale": 2},)))
+        self.assertFalse(guard(({"pair": [x], "scale": 2},)))
+        self.assertFalse(guard(({"pair": [x, y], "other": 2},)))
+        self.assertFalse(guard(({"pair": [x, torch.empty_like(x)], "scale": 2},)))
 
     def test_returns_none_without_tensor_to_pin_device(self) -> None:
         """With no tensor argument there is nothing to pin the device, so the
@@ -150,12 +266,11 @@ class TestFastDispatchKey(unittest.TestCase):
         self.assertIsNone(_dynamic_add_scalar._fast_dispatch_key(()))
 
     def test_scalar_and_none_entries(self) -> None:
-        """Handled non-tensor arguments contribute (type, value) for scalars
-        and a bare ``None`` for ``None``, provided a tensor pins the device."""
+        """Runtime scalars contribute their type and ``None`` stays bare."""
         x = torch.empty(64, dtype=torch.float32)
         key = _dynamic_add_scalar._fast_dispatch_key((x, 7))
         assert isinstance(key, tuple)
-        self.assertEqual(key[1], (int, 7))
+        self.assertIs(key[1], int)
 
         none_key = _static_add1._fast_dispatch_key((x, None))
         assert isinstance(none_key, tuple)

--- a/test/test_prepared_call.py
+++ b/test/test_prepared_call.py
@@ -168,12 +168,17 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         )
 
         for value in variants:
+            static_indices_value = getattr(value, "_dynamo_static_indices", None)
             with (
                 self.subTest(
-                    shape=value.shape,
-                    stride=value.stride(),
-                    dtype=value.dtype,
-                    static_indices=getattr(value, "_dynamo_static_indices", None),
+                    shape=tuple(value.shape),
+                    stride=tuple(value.stride()),
+                    dtype=str(value.dtype),
+                    static_indices=(
+                        tuple(sorted(static_indices_value))
+                        if static_indices_value is not None
+                        else None
+                    ),
                 ),
                 patch.object(
                     add_one,
@@ -236,6 +241,41 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         constexpr_nan = float("nan")
         self.assertTrue(torch.isnan(scale_constexpr(x, constexpr_nan)).all())
         self.assertIsNone(scale_constexpr._prepared_call)  # type: ignore[attr-defined]
+
+    def test_nested_constexpr_values_do_not_reuse_preparation(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def add_constexpr(x: torch.Tensor, values: hl.constexpr) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + values[0]
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(add_constexpr(x, (1.0, 2.0)), x + 1.0)
+        torch.testing.assert_close(add_constexpr(x, (3.0, 4.0)), x + 3.0)
+        self.assertEqual(len(add_constexpr._bound_kernels), 2)  # type: ignore[attr-defined]
+
+    def test_constexpr_wrapped_scalars_use_prepared_call(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64]),
+        )
+        def scale(x: torch.Tensor, value: int) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] * value
+            return out
+
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(scale(x, hl.constexpr(2)), x * 2)
+        prepared = scale._prepared_call  # type: ignore[attr-defined]
+        self.assertIsNotNone(prepared)
+        torch.testing.assert_close(scale(x, hl.constexpr(2)), x * 2)
+        self.assertIs(scale._prepared_call, prepared)  # type: ignore[attr-defined]
+        torch.testing.assert_close(scale(x, hl.constexpr(3)), x * 3)
 
     def test_custom_key_is_evaluated_once_and_disables_preparation(self) -> None:
         state = {"key": 0}
@@ -1030,6 +1070,9 @@ class TestPreparedCall(RefEagerTestDisabled, TestCase):
         "requires Helion's torch.compile fusion integration",
     )
     def test_fullgraph_capture_preserves_eager_caches(self) -> None:
+        if not supports_torch_compile_fusion():
+            self.skipTest("torch.compile fusion is unavailable")
+
         @helion.kernel(
             static_shapes=True,
             config=helion.Config(block_sizes=[64]),


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3470
 * #3469
 * #3468
 * __->__#3467


--- --- ---

[cutedsl] Reuse warmed nested-input kernels under torch.compile and isolate backend tests from shared cache and capability state