### PR TITLE
Disable CUDAGraph timing for ROCm benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -198,6 +198,14 @@ jobs:
           mkdir -p "$TEST_REPORTS_DIR"
           echo "$TEST_REPORTS_DIR"
 
+          CUDAGRAPH_ARGS=(--cudagraph)
+          if [[ "${{ inputs.runtime-version }}" == rocm* ]]; then
+            # Repeated PyTorch CUDAGraph timing can abort ROCm queues with
+            # HSA_STATUS_ERROR_INVALID_PACKET_FORMAT. Use Triton's regular
+            # event-based benchmarker on ROCm while retaining graphs on CUDA.
+            CUDAGRAPH_ARGS=()
+          fi
+
           KERNEL_LIST="${{ inputs.kernels }}"
           for kernel in ${KERNEL_LIST//,/ }; do
             echo "=========================================="
@@ -237,7 +245,7 @@ jobs:
                 --metrics speedup,accuracy,latency \
                 --measure-compile-time \
                 --latency-measure-mode triton_do_bench \
-                --cudagraph \
+                "${CUDAGRAPH_ARGS[@]}" \
                 --only $IMPLS \
                 --only-match-mode prefix-with-baseline \
                 --baseline $BASELINE \


### PR DESCRIPTION
## Summary
- omit `--cudagraph` from TritonBench invocations when the runtime version starts with `rocm`
- retain CUDAGraph timing for CUDA benchmarks
- keep `--latency-measure-mode triton_do_bench` and the existing TritonBench pin unchanged

## Motivation
PyTorch 2.13 with ROCm 7.1 can abort MI350 benchmark processes during repeated CUDAGraph timing with `HSA_STATUS_ERROR_INVALID_PACKET_FORMAT` or a segmentation fault. Reducing `--rep` does not eliminate the failure because even a small captured graph can hit the broken graph lifecycle/queue path.

This makes ROCm use Triton standard event timing instead of `_do_bench_cudagraph_with_cache_clear`.

Observed failures:
- https://github.com/pytorch/helion/actions/runs/32991722149/job/98250642811
- https://github.com/pytorch/helion/actions/runs/32991722149/job/98250642682

## Validation
- Parsed `.github/workflows/benchmark.yml` successfully as YAML.
- Verified the Bash argument array expands to no graph flag for `rocm7.1` and to `--cudagraph` for `cu130`.
- Locally reproduced a segmentation fault when repeatedly measuring MI350 softmax with the CUDAGraph path.
- The same MI350 softmax benchmark produced numeric event-based results without CUDAGraph.

`./lint.sh check` was unavailable because ruff and pyrefly are not installed in the local environment.