### PR TITLE
Fix Triton precompile cache compatibility

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -219,7 +219,7 @@ if triton_is_available():
             if not torch.xpu.is_available():
                 return False
 
-            return version.parse(triton.__version__) >= version.parse("3.5")
+            return get_triton_version() >= version.parse("3.5")
 
         if not (_cuda_tensor_desc_available() or _xpu_tensor_desc_available()):
             return False
@@ -340,6 +340,14 @@ else:
 
     def use_tileir_tunables() -> bool:  # type: ignore[misc]
         return False
+
+
+@functools.cache
+def get_triton_version() -> version.Version:
+    """Return the installed Triton version as a parsed, cached value."""
+    import triton
+
+    return version.parse(triton.__version__)
 
 
 def supports_tensor_descriptor() -> bool:
@@ -605,9 +613,7 @@ def _fp8_block_ptr_padding_broken() -> bool:
     """
     if not triton_is_available():
         return False
-    import triton
-
-    triton_version = version.parse(triton.__version__)
+    triton_version = get_triton_version()
     return version.parse("3.8.0") <= triton_version < version.parse("3.9.0")
 
 

--- a/helion/runtime/precompile_shim.py
+++ b/helion/runtime/precompile_shim.py
@@ -7,6 +7,7 @@ from typing import cast
 
 from .._compat import get_triton_find_paths_if
 from .._compat import get_triton_iterable_path
+from .._compat import get_triton_version
 from ..autotuner.logger import classify_triton_exception
 from ..autotuner.logger import format_triton_compile_failure
 
@@ -50,9 +51,20 @@ def make_precompiler(
         kwargs["debug"] = (
             kwargs.get("debug", fn.debug) or os.environ.get("TRITON_DEBUG", "0") == "1"
         )
-        kernel_cache, *_, target, backend, binder = fn.device_caches[device]
+        kernel_cache, kernel_key_cache, target, backend, binder = fn.device_caches[
+            device
+        ]
         bound_args, specialization, options = binder(*args, **kwargs)
-        key = str(specialization) + str(options)
+        # Keep this key and the packed compile inputs identical to
+        # JITFunction.run(). Triton 3.7 changed both; using the old hand-rolled
+        # forms makes the benchmark worker compile every candidate a second time.
+        use_runtime_argument_packing = get_triton_version().release >= (3, 7)
+        if use_runtime_argument_packing:
+            from triton.runtime.jit import compute_cache_key
+
+            key = compute_cache_key(kernel_key_cache, specialization, options)
+        else:
+            key = str(specialization) + str(options)
         kernel = kernel_cache.get(key, None)
         if kernel is not None:
             return (
@@ -61,28 +73,34 @@ def make_precompiler(
                 else already_compiled_fail
             )  # cache hit
 
-        options = backend.parse_options(kwargs)
-        sigkeys = [x.name for x in fn.params]
-        sigvals = [x[0] for x in specialization]
-        signature = dict(zip(sigkeys, sigvals, strict=False))
-        find_paths_if = get_triton_find_paths_if()
-        get_iterable_path = get_triton_iterable_path()
-        constexpr_paths = cast(
-            "list[tuple[int, ...]]",
-            find_paths_if(sigvals, lambda _, val: val == "constexpr"),
-        )
-        constexprs = {
-            path: get_iterable_path(list(bound_args.values()), path)
-            for path in constexpr_paths
-        }
-        attrvals = [x[1] for x in specialization]
-        attr_paths = cast(
-            "list[tuple[int, ...]]",
-            find_paths_if(attrvals, lambda _, x: isinstance(x, str)),
-        )
-        attrs = {
-            k: backend.parse_attr(get_iterable_path(attrvals, k)) for k in attr_paths
-        }
+        if use_runtime_argument_packing:
+            options, signature, constexprs, attrs = fn._pack_args(  # pyrefly: ignore[missing-attribute]
+                backend, kwargs, bound_args, specialization, options
+            )
+        else:
+            options = backend.parse_options(kwargs)
+            sigkeys = [x.name for x in fn.params]
+            sigvals = [x[0] for x in specialization]
+            signature = dict(zip(sigkeys, sigvals, strict=False))
+            find_paths_if = get_triton_find_paths_if()
+            get_iterable_path = get_triton_iterable_path()
+            constexpr_paths = cast(
+                "list[tuple[int, ...]]",
+                find_paths_if(sigvals, lambda _, val: val == "constexpr"),
+            )
+            constexprs = {
+                path: get_iterable_path(list(bound_args.values()), path)
+                for path in constexpr_paths
+            }
+            attrvals = [x[1] for x in specialization]
+            attr_paths = cast(
+                "list[tuple[int, ...]]",
+                find_paths_if(attrvals, lambda _, x: isinstance(x, str)),
+            )
+            attrs = {
+                k: backend.parse_attr(get_iterable_path(attrvals, k))
+                for k in attr_paths
+            }
 
         def finish_it(in_child_process: bool = True) -> bool:
             src = fn.ASTSource(fn, signature, constexprs, attrs)

--- a/test/test_precompile_shim.py
+++ b/test/test_precompile_shim.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+import importlib
+from types import SimpleNamespace
+import unittest
+from unittest.mock import ANY
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from packaging.version import Version
+
+from helion._utils import triton_is_available
+from helion.runtime.config import Config
+from helion.runtime.precompile_shim import make_precompiler
+
+
+@unittest.skipUnless(triton_is_available(), "requires Triton")
+class TestPrecompileShim(unittest.TestCase):
+    def test_matches_triton_runtime_cache_key_and_argument_packing(self) -> None:
+        kernel_cache: dict[object, object] = {}
+        kernel_key_cache = object()
+        target = object()
+        backend = Mock()
+        specialization = [("*fp32", "D")]
+        bound_args = OrderedDict((("x", object()),))
+        binder_options = SimpleNamespace(binder=True)
+        packed_options = SimpleNamespace(packed=True)
+        binder = Mock(return_value=(bound_args, specialization, binder_options))
+        compiled_kernel = Mock()
+        fn = Mock()
+        fn.debug = False
+        fn.device_caches = {
+            0: (kernel_cache, kernel_key_cache, target, backend, binder)
+        }
+        fn._pack_args.return_value = (
+            packed_options,
+            {"x": "*fp32"},
+            {},
+            {(0,): "tt.divisibility"},
+        )
+        fn.ASTSource.return_value = "source"
+        fn.compile.return_value = compiled_kernel
+        kernel_module = importlib.import_module("helion.runtime.kernel")
+
+        with (
+            patch.object(kernel_module, "_find_device", return_value=0),
+            patch(
+                "helion.runtime.precompile_shim.get_triton_version",
+                return_value=Version("3.7.0"),
+            ),
+            patch(
+                "triton.runtime.jit.compute_cache_key",
+                return_value="runtime-cache-key",
+            ) as compute_cache_key,
+        ):
+            precompile = make_precompiler(fn, Config(), Mock())(object())
+            self.assertTrue(precompile(in_child_process=False))
+
+        compute_cache_key.assert_called_once_with(
+            kernel_key_cache, specialization, binder_options
+        )
+        fn._pack_args.assert_called_once_with(
+            backend, ANY, bound_args, specialization, binder_options
+        )
+        fn.ASTSource.assert_called_once_with(
+            fn,
+            {"x": "*fp32"},
+            {},
+            {(0,): "tt.divisibility"},
+        )
+        fn.compile.assert_called_once_with(
+            "source", target=target, options={"packed": True}
+        )
+        self.assertIs(kernel_cache["runtime-cache-key"], compiled_kernel)
+        compiled_kernel._init_handles.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue

The MI350 benchmark run showed severe Softmax and RoPE autotuning slowdowns and timeouts. Helion precompiles each candidate in a forked subprocess, but `precompile_shim.py` was still reproducing the older Triton JIT cache-key and argument-packing logic.

Triton 3.7 changed `JITFunction.run()` to use `compute_cache_key()` and `JITFunction._pack_args()`. Because Helion generated a different key, the benchmark worker could not reuse the precompiled artifact and compiled each candidate again. Expensive RoPE configurations then exceeded the 30-second worker timeout, causing worker termination and respawn cascades.

Failed run: https://github.com/pytorch/helion/actions/runs/32999376022

## Fix

- Add a cached `get_triton_version()` compatibility helper and select the new runtime path for Triton 3.7 and newer.
- Use Triton runtime `compute_cache_key()` so fork precompile and benchmark execution address the same cache entry.
- Use `JITFunction._pack_args()` so compile options, signatures, constexprs, and attributes match `JITFunction.run()`.
- Preserve the previous implementation for older Triton versions.
- Add a regression test that verifies the runtime cache key and argument-packing path are used.

This addresses duplicate compilation and false autotuning timeouts. It does not change the separate ROCm CUDAGraph malformed-AQL behavior.

## MI350X autotuning benchmarks

| Benchmark | Before | With fix | Change |
| --- | ---: | ---: | ---: |
| Softmax `(4096, 256)` | 392.1 s, 590 configs, 1.52 configs/s | 333.8 s, 743 configs, 2.26 configs/s | 14.9% less time; 48.7% higher throughput |
| RoPE `(H=512, T=2048)` | 1034.7 s, 1030 configs, 4 worker failures | 692.0 s, 1619 configs, 0 worker failures | 33.1% less time while evaluating 57.2% more configs |

The patched RoPE run completed all 20 generations and produced a correct result. Some Triton 3.7 RoPE configurations still produce genuine HIP illegal-memory-access errors; benchmark-worker isolation detects and skips those separately.

## Testing

- `python -m ruff check helion/_compat.py helion/runtime/precompile_shim.py test/test_precompile_shim.py`
- `python -m ruff format --check helion/_compat.py helion/runtime/precompile_shim.py test/test_precompile_shim.py`
- `python -m pytest test/test_precompile_shim.py test/test_benchmark_worker.py -x -q`
  - 67 passed, 1 skipped
