### PR TITLE
[cutedsl] Add grouped GEMM worklist physical lowering

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -3037,6 +3037,13 @@ def _grouped_rank3_specialized_mma_plan(
     env: CompileEnvironment,
 ) -> _SpecializedMmaPlan | None:
     from .cute.cute_mma import _choose_mma_impl
+    from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+    from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+    from .cute.tcgen05_constants import (
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+    )
+    from .cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    from .cute.tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_shape
     from .host_function import HostFunction
 
     if node.target is not torch.ops.aten.addmm.default:
@@ -3080,13 +3087,32 @@ def _grouped_rank3_specialized_mma_plan(
     lhs_val = lhs_node.meta.get("val")
     if not isinstance(lhs_val, torch.Tensor):
         return None
+    mma_bm = bm
+    mma_bn = bn
+    if config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) == TCGEN05_GROUPED_MODE_WORKLIST_NM:
+        source_m_tile = config.get(
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        )
+        physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
+            cluster_m=config.get("tcgen05_cluster_m", 1),
+            block_k=bk,
+            source_m_tile=source_m_tile,
+        )
+        if physical_shape is None:
+            return None
+        mma_bm, mma_bn = physical_shape
     mma_impl = _choose_mma_impl(
         lhs_val.dtype,
-        bm=bm,
-        bn=bn,
+        bm=mma_bm,
+        bn=mma_bn,
         bk=bk,
         config=config,
         input_device=lhs_val.device,
+        defer_grouped_worklist_smem_check=(
+            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            == TCGEN05_GROUPED_MODE_WORKLIST_NM
+        ),
     )
     if mma_impl != "tcgen05":
         return None

--- a/helion/_compiler/cute/_mlir_compat.py
+++ b/helion/_compiler/cute/_mlir_compat.py
@@ -6,6 +6,6 @@ from typing import Any
 
 from cutlass._mlir import ir as _ir
 
-# CUTLASS 4.6.1 marks this module as typed, but its extension-provided exports
+# CUTLASS 4.7.0 marks this module as typed, but its extension-provided exports
 # do not have declarations for static type checkers.
 ir: Any = _ir

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -48,7 +48,10 @@ from .aux_tensor import analyze_tcgen05_matmul_store_chains
 from .aux_tensor import discover_tcgen05_aux_tensor_descriptors
 from .cute_epilogue import Tcgen05GroupedTailEpilogueMatch
 from .cute_epilogue import find_tcgen05_grouped_tail_epilogue_for_mma
+from .cutedsl_compat import CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION
 from .cutedsl_compat import emit_pipeline_advance
+from .cutedsl_compat import tcgen05_runtime_n_ptx_compatible
+from .cutedsl_compat import warn_tcgen05_runtime_n_ptx_fallback
 from .device_state import CuteDeviceFunctionState
 from .device_state import CuteTcgen05GroupedPlan
 from .device_state import CuteTcgen05MatmulPlan
@@ -126,23 +129,25 @@ from .tcgen05_constants import TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_K
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_SPECIALIZATION_MAX_GROUPS
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
-from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT
-from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
-from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_N_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_PID_TYPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_PROBLEM_SHAPE
+from .tcgen05_constants import TCGEN05_ONE_CTA_MAX_BLOCK_M
 from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
+from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_shape
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
-from .tcgen05_constants import tcgen05_c_smem_bytes_per_cta
+from .tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
 from .tcgen05_lifecycle import Tcgen05LifecycleContext
 from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
@@ -1729,6 +1734,7 @@ def _trace_rank3_grouped_rhs_nt_operand(
     *,
     m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_mn_major: bool = False,
 ) -> _MmaOperandInfo | None:
     """Recognize ``B_grouped[group, tile_n, tile_k].T`` as logical ``[K, N]``.
 
@@ -1842,7 +1848,8 @@ def _trace_rank3_grouped_rhs_nt_operand(
         (source_fake.shape[2], source_fake.shape[1]),
         (source_fake.stride(2), source_fake.stride(1)),
     )
-    if _tcgen05_tma_matrix_major(logical_fake) != "col":
+    matrix_major = _tcgen05_tma_matrix_major(logical_fake)
+    if matrix_major != "col" and not (allow_mn_major and matrix_major == "row"):
         return None
     return _MmaOperandInfo(
         load=load_node,
@@ -1869,6 +1876,7 @@ def _trace_to_mma_operand(
     cg: GenerateAST | None = None,
     rank3_rhs_m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_rank3_rhs_mn_major: bool = False,
 ) -> _MmaOperandInfo | None:
     if role == "rhs" and allow_rank3_rhs_nt:
         rank3_rhs = _trace_rank3_grouped_rhs_nt_operand(
@@ -1876,6 +1884,7 @@ def _trace_to_mma_operand(
             node,
             m_block_id=rank3_rhs_m_block_id,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_mn_major=allow_rank3_rhs_mn_major,
         )
         if rank3_rhs is not None:
             return rank3_rhs
@@ -2399,6 +2408,7 @@ def _has_mma_operands(
     cg: GenerateAST | None = None,
     rank3_rhs_m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_rank3_rhs_mn_major: bool = False,
 ) -> bool:
     """Check if lhs/rhs come from loads with MMA-compatible dtypes."""
     lhs_info = _trace_to_mma_operand(
@@ -2414,6 +2424,7 @@ def _has_mma_operands(
         cg=cg,
         rank3_rhs_m_block_id=rank3_rhs_m_block_id,
         allow_grouped_k_mask=allow_grouped_k_mask,
+        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
     )
     if lhs_info is None or rhs_info is None:
         return False
@@ -2832,6 +2843,9 @@ def _analyze_rank3_rhs_grouped_search_operands(
         rhs_node,
         role="rhs",
         allow_rank3_rhs_nt=True,
+        # This early DeviceIR pass only recovers axes. Complete grouped
+        # semantics are proven by ``_prove_rank3_rhs_grouped_mma``.
+        allow_rank3_rhs_mn_major=True,
         cg=graph_view,
         allow_grouped_k_mask=True,
     )
@@ -2919,6 +2933,7 @@ def is_mma_compatible_aten(
     cg: GenerateAST | None = None,
     rank3_rhs_m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_rank3_rhs_mn_major: bool = False,
 ) -> bool:
     """Check if an aten addmm/mm node can use MMA."""
     args = node.args
@@ -2944,6 +2959,7 @@ def is_mma_compatible_aten(
         cg=cg,
         rank3_rhs_m_block_id=rank3_rhs_m_block_id,
         allow_grouped_k_mask=allow_grouped_k_mask,
+        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
     )
 
 
@@ -3164,6 +3180,7 @@ def can_codegen_cute_mma_aten(
     cg: GenerateAST | None = None,
     rank3_rhs_m_block_id: int | None = None,
     allow_grouped_k_mask: bool = False,
+    allow_rank3_rhs_mn_major: bool = False,
 ) -> bool:
     return (
         is_mma_compatible_aten(
@@ -3173,6 +3190,7 @@ def can_codegen_cute_mma_aten(
             cg=cg,
             rank3_rhs_m_block_id=rank3_rhs_m_block_id,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
         )
         and _mma_result_can_be_deferred(node)
         and _mma_loop_is_exclusive(node)
@@ -3328,6 +3346,7 @@ def _prove_rank3_rhs_grouped_mma(
     with_acc = True
     grouped_mode = _tcgen05_grouped_mode(config)
     allow_grouped_k_mask = grouped_mode is not None
+    allow_rank3_rhs_mn_major = grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
     if not can_codegen_cute_mma_aten(
         node,
         with_acc,
@@ -3335,6 +3354,7 @@ def _prove_rank3_rhs_grouped_mma(
         cg=cg,
         rank3_rhs_m_block_id=axes.m_block_id,
         allow_grouped_k_mask=allow_grouped_k_mask,
+        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
     ):
         return None
     lhs_node = node.args[1] if with_acc else node.args[0]
@@ -3356,6 +3376,7 @@ def _prove_rank3_rhs_grouped_mma(
         cg=cg,
         rank3_rhs_m_block_id=axes.m_block_id,
         allow_grouped_k_mask=allow_grouped_k_mask,
+        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
     )
     if lhs_info is None or rhs_info is None or not rhs_info.rhs_rank3_grouped_nt:
         return None
@@ -3372,7 +3393,7 @@ def _prove_rank3_rhs_grouped_mma(
     if not (
         lhs_fake.dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and _tcgen05_tma_matrix_major(lhs_fake) == "row"
-        and _tcgen05_tma_matrix_major(rhs_fake) == "col"
+        and _tcgen05_tma_matrix_major(rhs_fake) in ("row", "col")
         and rhs_info.rhs_n_block_id == canonical_block_id(axes.n_block_id)
         and rhs_info.rhs_k_block_id == canonical_block_id(axes.k_block_id)
         and (
@@ -3982,7 +4003,9 @@ def prepare_cute_collective_lane_loop_suppression(
     env = CompileEnvironment.current()
     if env.backend_name != "cute":
         return
-    allow_grouped_k_mask = _tcgen05_grouped_mode(cg.device_function.config) is not None
+    grouped_mode = _tcgen05_grouped_mode(cg.device_function.config)
+    allow_grouped_k_mask = grouped_mode is not None
+    allow_rank3_rhs_mn_major = grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
     cute_state = cg.device_function.cute_state
     if not tcgen05_fragment_epilogue_has_unique_anchor(
         cg.codegen_graphs
@@ -4089,6 +4112,7 @@ def prepare_cute_collective_lane_loop_suppression(
                 allow_rank3_rhs_nt=True,
                 cg=cg,
                 allow_grouped_k_mask=allow_grouped_k_mask,
+                allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
             ):
                 continue
         elif node.target is torch.ops.aten.mm.default:
@@ -4101,6 +4125,7 @@ def prepare_cute_collective_lane_loop_suppression(
                 allow_rank3_rhs_nt=True,
                 cg=cg,
                 allow_grouped_k_mask=allow_grouped_k_mask,
+                allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
             ):
                 continue
         elif can_codegen_cute_mma_dot(node):
@@ -4124,6 +4149,7 @@ def prepare_cute_collective_lane_loop_suppression(
             allow_rank3_rhs_nt=True,
             cg=cg,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
         )
         if lhs_info is None or rhs_info is None:
             continue
@@ -4166,6 +4192,29 @@ def prepare_cute_collective_lane_loop_suppression(
                     n_block_id = bid
                 elif bk is None and env.known_equal(size, lhs_fake.shape[1]):
                     bk = int(bs)
+        if rhs_info.rhs_rank3_grouped_nt and m_block_id is None:
+            canonical_block_id = env.canonical_block_id
+            rhs_n_block_id = rhs_info.rhs_n_block_id
+            grouped_leading_block_id = rhs_info.rhs_grouped_leading_block_id
+            if rhs_n_block_id is not None:
+                m_block_ids = [
+                    bid
+                    for bid in grid_state.block_ids
+                    if canonical_block_id(bid) != canonical_block_id(rhs_n_block_id)
+                    and (
+                        grouped_leading_block_id is None
+                        or canonical_block_id(bid)
+                        != canonical_block_id(grouped_leading_block_id)
+                    )
+                ]
+                if len(m_block_ids) == 1:
+                    candidate_m_block_id = m_block_ids[0]
+                    candidate_bm = cg.device_function.resolved_block_size(
+                        candidate_m_block_id
+                    )
+                    if isinstance(candidate_bm, int):
+                        m_block_id = candidate_m_block_id
+                        bm = candidate_bm
         if bm is None or bn is None or bk is None:
             continue
         rhs_rank3_worklist_lhs_info: _Rank3RhsWorklistLhsInfo | None = None
@@ -4173,8 +4222,6 @@ def prepare_cute_collective_lane_loop_suppression(
             if m_block_id is None or n_block_id is None or k_block_id is None:
                 continue
             if device_loop is None:
-                continue
-            if _tcgen05_cluster_m(cg.device_function.config) != 1:
                 continue
             canonical_block_id = env.canonical_block_id
             segment_block_id = None
@@ -4211,6 +4258,11 @@ def prepare_cute_collective_lane_loop_suppression(
             )
             if proof is None:
                 continue
+            if (
+                not proof.is_worklist
+                and _tcgen05_cluster_m(cg.device_function.config) != 1
+            ):
+                continue
             lhs_info = proof.lhs
             rhs_info = proof.rhs
             lhs_fake = lhs_info.logical_fake
@@ -4233,14 +4285,45 @@ def prepare_cute_collective_lane_loop_suppression(
                     is None
                 ):
                     continue
+        collective_bm = bm
+        collective_bn = bn
+        worklist_shape = None
+        if (
+            rhs_rank3_worklist_lhs_info is not None
+            and _requested_tcgen05_grouped_schedule(
+                cast(
+                    "str | None",
+                    cast("_ConfigLike", cg.device_function.config).get(
+                        TCGEN05_GROUPED_MODE_CONFIG_KEY
+                    ),
+                )
+            )
+            is Tcgen05Orientation.NM
+        ):
+            worklist_shape = resolve_tcgen05_grouped_worklist_mma_shape(
+                cluster_m=_tcgen05_cluster_m(cg.device_function.config),
+                block_k=bk,
+                source_m_tile=_tcgen05_config_int(
+                    cg.device_function.config,
+                    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+                    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+                ),
+            )
+            if worklist_shape is None:
+                continue
+            collective_bm, collective_bn = worklist_shape
         if (
             _choose_mma_impl(
                 lhs_fake.dtype,
-                bm=bm,
-                bn=bn,
+                bm=collective_bm,
+                bn=collective_bn,
                 bk=bk,
                 config=cg.device_function.config,
                 input_device=lhs_fake.device,
+                defer_grouped_worklist_smem_check=(
+                    rhs_rank3_worklist_lhs_info is not None
+                    and worklist_shape is not None
+                ),
             )
             != "tcgen05"
         ):
@@ -4628,14 +4711,88 @@ def _build_kloop_pipeline_release_if(
     return statement_from_string(src)
 
 
+_TCGEN05_RUNTIME_MMA_N_GRANULARITY = 16
+# The instruction descriptor stores N in bits [17:23) with its three low bits
+# omitted. Build the static portion with N=0, then insert the runtime field.
+_TCGEN05_INSTR_DESC_N_LOW_BITS = 3
+_TCGEN05_INSTR_DESC_N_FIELD_SHIFT = 17
+
+
+def _tcgen05_runtime_mma_n_expr(valid_m: str, static_mma_n: int) -> str:
+    """Round a worklist tail, mapping zero-valid padding tiles to UMMA-N=16."""
+    assert static_mma_n in TCGEN05_GROUPED_WORKLIST_MMA_N_CHOICES
+    granularity = _TCGEN05_RUNTIME_MMA_N_GRANULARITY
+    # Every scheduler clamps valid_m to static_mma_n, and each admitted static
+    # width is a granularity multiple, so the rounded value cannot exceed it.
+    return (
+        f"((max({valid_m}, cutlass.Int32(1)) + cutlass.Int32({granularity - 1})) "
+        f"// cutlass.Int32({granularity})) * cutlass.Int32({granularity})"
+    )
+
+
 def _build_tcgen05_mma_accumulate_reset_stmt(
     exec_active: str,
     *,
     tiled_mma: str,
+    input_dtype_str: str,
+    acc_dtype_str: str,
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
-) -> ast.stmt:
+    runtime_mma_n: str | None = None,
+    runtime_instr_desc: str | None = None,
+    valid_m: str | None = None,
+    static_mma_m: int | None = None,
+    static_mma_n: int | None = None,
+    a_k_major: bool = True,
+    b_k_major: bool = False,
+) -> list[ast.stmt]:
+    runtime_args = (
+        runtime_mma_n,
+        runtime_instr_desc,
+        valid_m,
+        static_mma_m,
+        static_mma_n,
+    )
+    assert all(arg is None for arg in runtime_args) or all(
+        arg is not None for arg in runtime_args
+    )
+    setup_stmts: list[ast.stmt] = []
+    if runtime_mma_n is not None:
+        assert runtime_instr_desc is not None
+        assert valid_m is not None
+        assert static_mma_m is not None and static_mma_m in (128, 256)
+        assert static_mma_n is not None
+        assert static_mma_n in TCGEN05_GROUPED_WORKLIST_MMA_N_CHOICES
+        a_major = 0 if a_k_major else 1
+        b_major = 0 if b_k_major else 1
+        # A legal over-aligned worklist may schedule a trailing tile with
+        # valid_m=0. Its output is fully masked; clamp the instruction width to
+        # UMMA-N=16 so descriptor encoding never sees invalid N=0. SMEM/TMEM
+        # layouts remain at their static maximum; only bits [17:23) (N >> 3) of
+        # the instruction descriptor vary for a tail work tile.
+        setup_stmts.extend(
+            (
+                statement_from_string(
+                    f"{runtime_mma_n} = cutlass.Int32({static_mma_n})"
+                ),
+                statement_from_string(f"{runtime_instr_desc} = cutlass.Int32(0)"),
+                statement_from_string(
+                    f"if {valid_m} <= cutlass.Int32("
+                    f"{static_mma_n - _TCGEN05_RUNTIME_MMA_N_GRANULARITY}):\n"
+                    f"    {runtime_mma_n} = "
+                    f"{_tcgen05_runtime_mma_n_expr(valid_m, static_mma_n)}\n"
+                    f"    {runtime_instr_desc} = (cutlass.Int32("
+                    "cutlass.experimental.primitives.Tcgen05InstrDesc.build("
+                    f"c_dtype={acc_dtype_str}, a_dtype={input_dtype_str}, "
+                    f"b_dtype={input_dtype_str}, a_major={a_major}, "
+                    f"b_major={b_major}, n_dim=0, m_dim={static_mma_m})) | "
+                    f"(({runtime_mma_n} >> "
+                    f"cutlass.Int32({_TCGEN05_INSTR_DESC_N_LOW_BITS})) << "
+                    f"cutlass.Int32({_TCGEN05_INSTR_DESC_N_FIELD_SHIFT})))"
+                ),
+            )
+        )
     reset_src = f"{tiled_mma}.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, False)"
     predicate = _tcgen05_two_cta_owner_predicate(
         exec_active,
@@ -4644,8 +4801,11 @@ def _build_tcgen05_mma_accumulate_reset_stmt(
         cluster_n=cluster_n,
     )
     if predicate is None:
-        return statement_from_string(reset_src)
-    return statement_from_string(f"if {predicate}:\n    {reset_src}")
+        reset_stmt = statement_from_string(reset_src)
+    else:
+        reset_stmt = statement_from_string(f"if {predicate}:\n    {reset_src}")
+    setup_stmts.append(reset_stmt)
+    return setup_stmts
 
 
 def _build_tcgen05_mma_issue_stmt(
@@ -4656,11 +4816,20 @@ def _build_tcgen05_mma_issue_stmt(
     tcgen05_frag_a: str,
     tcgen05_frag_b: str,
     mma_stage: str,
+    input_dtype_str: str,
+    acc_dtype_str: str,
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
+    runtime_mma_n: str | None = None,
+    runtime_instr_desc: str | None = None,
+    static_mma_n: int | None = None,
 ) -> ast.stmt:
-    issue_src = (
+    runtime_args = (runtime_mma_n, runtime_instr_desc, static_mma_n)
+    assert all(arg is None for arg in runtime_args) or all(
+        arg is not None for arg in runtime_args
+    )
+    full_issue_src = (
         f"for _tcgen05_kblk_idx in range(cute.size({tcgen05_frag_a}, mode=[2])):\n"
         f"    cute.gemm(\n"
         f"        {tiled_mma},\n"
@@ -4671,6 +4840,72 @@ def _build_tcgen05_mma_issue_stmt(
         "    )\n"
         f"    {tiled_mma}.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, True)"
     )
+    issue_src = full_issue_src
+    if runtime_mma_n is not None:
+        assert runtime_instr_desc is not None
+        assert static_mma_n in TCGEN05_GROUPED_WORKLIST_MMA_N_CHOICES
+        if not tcgen05_runtime_n_ptx_compatible():
+            raise exc.BackendUnsupported(
+                "cute",
+                "runtime UMMA-N raw PTX requires exactly "
+                "nvidia-cutlass-dsl=="
+                f"{CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION}; revalidate the "
+                "PTX before enabling it for another CuTe DSL release",
+            )
+        if (input_dtype_str, acc_dtype_str) != (
+            "cutlass.BFloat16",
+            "cutlass.Float32",
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                "runtime UMMA-N raw PTX is validated only for BF16/FP32 under the "
+                f"CuTe {CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION} "
+                "compatibility contract",
+            )
+        # This fallback is covered by the central validated CuTe compatibility
+        # generation in ``cutedsl_compat``. Updating that contract explicitly
+        # requires revalidating this PTX because the typed ``tcgen05_mma`` wrapper
+        # currently lowers this runtime-N form to rejected sm_100a IR.
+        # Descriptor construction and operands still use public typed helpers.
+        tail_issue_src = (
+            f"for _tcgen05_kblk_idx in range(cute.size({tcgen05_frag_a}, mode=[2])):\n"
+            f"    _tcgen05_frag_a_slice = "
+            f"{tcgen05_frag_a}[None, None, cutlass.Int32(_tcgen05_kblk_idx), {mma_stage}]\n"
+            f"    _tcgen05_frag_b_slice = "
+            f"{tcgen05_frag_b}[None, None, cutlass.Int32(_tcgen05_kblk_idx), {mma_stage}]\n"
+            "    _tcgen05_smem_desc_a = "
+            "cute.nvgpu.tcgen05.smem_descriptor_to_int("
+            "_tcgen05_frag_a_slice.iterator)\n"
+            "    _tcgen05_smem_desc_b = "
+            "cute.nvgpu.tcgen05.smem_descriptor_to_int("
+            "_tcgen05_frag_b_slice.iterator)\n"
+            "    with cute.arch.elect_one():\n"
+            "        cutlass.experimental.primitives.inline_ptx(\n"
+            '            "{\\n\\t.reg .pred accumulate;\\n\\t"\n'
+            '            "setp.ne.b32 accumulate, {$r4}, 0;\\n\\t"\n'
+            '            "tcgen05.mma.cta_group::'
+            f'{2 if is_two_cta else 1}.kind::f16 "\n'
+            '            "[{$r0}], {$r1}, {$r2}, {$r3}, accumulate;\\n}",\n'
+            "            read_only_args=[\n"
+            f"                cutlass.Int32({acc_frag}.iterator.toint()),\n"
+            "                cutlass.Int64(_tcgen05_smem_desc_a),\n"
+            "                cutlass.Int64(_tcgen05_smem_desc_b),\n"
+            f"                cutlass.Int32({runtime_instr_desc}),\n"
+            "                cutlass.Int32(\n"
+            f"                    {tiled_mma}.get(\n"
+            "                        cute.nvgpu.tcgen05.Field.ACCUMULATE\n"
+            "                    )\n"
+            "                ),\n"
+            "            ],\n"
+            "        )\n"
+            f"    {tiled_mma}.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, True)"
+        )
+        issue_src = (
+            f"if {runtime_mma_n} == cutlass.Int32({static_mma_n}):\n"
+            f"{textwrap.indent(full_issue_src, '    ')}\n"
+            "else:\n"
+            f"{textwrap.indent(tail_issue_src, '    ')}"
+        )
     predicate = _tcgen05_two_cta_owner_predicate(
         exec_active,
         is_two_cta=is_two_cta,
@@ -5347,73 +5582,6 @@ def _requested_tcgen05_grouped_schedule(
     return Tcgen05Orientation.NM
 
 
-def _append_aligned_smem(offset: int, size: int, alignment: int) -> int:
-    assert offset >= 0 and size >= 0 and alignment > 0
-    return ((offset + alignment - 1) // alignment) * alignment + size
-
-
-def _tcgen05_grouped_worklist_smem_bytes(
-    *,
-    group_count: int,
-    device_split_sizes: bool,
-    sched_stage_count: int,
-    bm: int,
-    bn: int,
-    bk: int,
-    dtype_bytes: int,
-    ab_stages: int,
-    acc_stages: int,
-    c_stages: int,
-    cluster_m: int,
-) -> int:
-    """Exact ordered SMEM footprint of the N,M grouped worklist path.
-
-    Keep this in the same order as the ``cute.arch.alloc_smem`` calls emitted
-    by the grouped scheduler, optional device metadata setup, and tcgen05
-    collective.
-    The BK64/source-224 profile intentionally reaches the 227-KiB opt-in cap,
-    so a coarse reserve would reject a valid compiled kernel while omitting
-    even one mailbox, barrier, TensorMap, or alignment pad is unsafe.
-    """
-    assert group_count > 0 and sched_stage_count > 0 and cluster_m in (1, 2)
-    a_stage_bytes = bm * bk * dtype_bytes
-    b_stage_bytes = bn * bk * dtype_bytes
-    assert a_stage_bytes % cluster_m == 0
-    assert b_stage_bytes % cluster_m == 0
-
-    offset = 0
-    # Scheduler work-tile mailbox, followed by optional device-derived problem
-    # metadata.  Host worklists supply problem sizes and starts from global
-    # wrapper tensors, so they do not allocate either metadata array in SMEM.
-    offset = _append_aligned_smem(
-        offset,
-        TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT * sched_stage_count * 4,
-        16,
-    )
-    if device_split_sizes:
-        offset = _append_aligned_smem(offset, group_count * 4 * 4, 16)
-        offset = _append_aligned_smem(offset, group_count * 4, 16)
-    # TMEM allocator state and accumulator/scheduler pipeline mbarriers.
-    offset = _append_aligned_smem(offset, 4, 4)
-    offset = _append_aligned_smem(offset, 8, 8)
-    offset = _append_aligned_smem(offset, acc_stages * 2 * 8, 8)
-    offset = _append_aligned_smem(offset, sched_stage_count * 2 * 8, 8)
-    # A/B stages, two mutable input TensorMaps, and the AB pipeline barriers.
-    offset = _append_aligned_smem(offset, ab_stages * a_stage_bytes // cluster_m, 128)
-    offset = _append_aligned_smem(offset, ab_stages * b_stage_bytes // cluster_m, 128)
-    offset = _append_aligned_smem(offset, 2 * 128, 128)
-    offset = _append_aligned_smem(offset, ab_stages * 8, 8)
-    # One mutable output TensorMap and the aligned TMA-store ring.
-    offset = _append_aligned_smem(offset, 128, 128)
-    c_smem_bytes = tcgen05_c_smem_bytes_per_cta(
-        epi_tile_m=TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[0],
-        epi_tile_n=TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[1],
-        dtype_bytes=dtype_bytes,
-        c_stages=c_stages,
-    )
-    return _append_aligned_smem(offset, c_smem_bytes, 1024)
-
-
 def _emit_tcgen05_device_split_sizes_setup(
     prefix: list[ast.AST],
     df: DeviceFunction,
@@ -5578,20 +5746,29 @@ def _emit_mma_pipeline(
             and stride_m == source_k
         )
 
-    def _is_contiguous_gnk_source_fake(source_fake: torch.Tensor) -> bool:
+    def _is_contiguous_grouped_rhs_source_fake(
+        source_fake: torch.Tensor,
+        *,
+        k_major: bool,
+    ) -> bool:
+        """Recognize contiguous physical [G,N,K] or [G,K,N] storage."""
         if source_fake.ndim != 3:
             return False
         source_n = _static_int(source_fake.shape[1])
         source_k = _static_int(source_fake.shape[2])
         stride_g = _static_int(source_fake.stride(0))
-        stride_n = _static_int(source_fake.stride(1))
+        contiguous_axis = 2 if k_major else 1
+        outer_axis = 1 if k_major else 2
+        contiguous_extent = source_k if k_major else source_n
+        stride_outer = _static_int(source_fake.stride(outer_axis))
         return (
             source_n is not None
             and source_k is not None
             and stride_g is not None
-            and stride_n is not None
-            and _static_int(source_fake.stride(2)) == 1
-            and stride_n == source_k
+            and contiguous_extent is not None
+            and stride_outer is not None
+            and _static_int(source_fake.stride(contiguous_axis)) == 1
+            and stride_outer == contiguous_extent
             and stride_g == source_n * source_k
         )
 
@@ -5719,6 +5896,7 @@ def _emit_mma_pipeline(
             allow_rank3_rhs_nt=lowering_ctx is not None,
             cg=cg,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_rank3_rhs_mn_major=(grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM),
         )
         if lhs_info is None or rhs_info is None:
             return _unsupported_schedule("MMA operand tracing failed")
@@ -6136,15 +6314,22 @@ def _emit_mma_pipeline(
             return f"{rhs_arg_name}[{leading_global}, {k_expr}, {n_expr}]"
         return f"{rhs_arg_name}[{k_expr}, {n_expr}]"
 
+    tcgen05_cluster_m = _tcgen05_cluster_m(df.config)
     tcgen05_nm_orientation = requested_schedule is Tcgen05Orientation.NM
+    # N,M orientation computes C.T = B @ A.T. Therefore the original grouped
+    # B becomes physical operand A, while packed A becomes physical operand B.
+    tcgen05_mma_a_k_major = not tcgen05_nm_orientation or tcgen05_b_k_major
+    tcgen05_mma_b_k_major = True if tcgen05_nm_orientation else tcgen05_b_k_major
     tcgen05_worklist_source_m_tile: int | None = None
+    tcgen05_one_cta_worklist_shape = False
+    worklist_shape = None
     if tcgen05_nm_orientation:
         if bk not in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES:
             return _unsupported_schedule("block_k must be 64 or 128")
         tcgen05_worklist_source_m_tile = _tcgen05_config_int(
             df.config,
             TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
         )
         if (
             tcgen05_worklist_source_m_tile
@@ -6154,15 +6339,25 @@ def _emit_mma_pipeline(
                 f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY} must be "
                 f"one of {TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES}"
             )
-        tcgen05_mma_bm = TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
-        tcgen05_mma_bn = tcgen05_worklist_source_m_tile
+        worklist_shape = resolve_tcgen05_grouped_worklist_mma_shape(
+            cluster_m=tcgen05_cluster_m,
+            block_k=bk,
+            source_m_tile=tcgen05_worklist_source_m_tile,
+        )
+        if worklist_shape is None:
+            return _unsupported_schedule(
+                "worklist N,M requires cluster_m=2, or cluster_m=1 with "
+                f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY}="
+                f"{TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE}"
+            )
+        tcgen05_mma_bm, tcgen05_mma_bn = worklist_shape
+        tcgen05_one_cta_worklist_shape = tcgen05_cluster_m == 1
         tcgen05_source_bm = tcgen05_worklist_source_m_tile
-        tcgen05_source_bn = TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
+        tcgen05_source_bn = tcgen05_mma_bm
     else:
         tcgen05_mma_bm = tcgen05_source_bm = bm
         tcgen05_mma_bn = tcgen05_source_bn = bn
 
-    tcgen05_cluster_m = _tcgen05_cluster_m(df.config)
     tcgen05_large_bn_proof = _tcgen05_large_bn_proof_enabled(df.config)
     if tcgen05_large_bn_proof and (
         not _tcgen05_large_bn_proof_shape(
@@ -6191,11 +6386,12 @@ def _emit_mma_pipeline(
 
     mma_impl = _choose_mma_impl(
         input_dtype,
-        bm=bm,
-        bn=bn,
+        bm=tcgen05_mma_bm,
+        bn=tcgen05_mma_bn,
         bk=bk,
         config=df.config,
         input_device=lhs_fake.device,
+        defer_grouped_worklist_smem_check=(worklist_shape is not None),
     )
     if (
         mma_impl == "tcgen05"
@@ -6282,6 +6478,7 @@ def _emit_mma_pipeline(
                 bn=bn,
                 bk=bk,
                 config=df.config,
+                defer_grouped_worklist_smem_check=(worklist_shape is not None),
             )
         )
     ):
@@ -6324,11 +6521,24 @@ def _emit_mma_pipeline(
             "tcgen05 matmul with a leading passthrough axis does not support "
             "tcgen05_cluster_n != 1",
         )
-    tcgen05_static_output_tiles = m_size % bm == 0 and n_size % bn == 0
+    # N,M worklists keep the public 256x128 logical scheduler tile, while their
+    # physical output tile is source_m_tile x physical_mma_m. Edge admission
+    # must use that physical orientation for both CTA-group sizes.
+    tcgen05_output_bm = (
+        tcgen05_source_bm if tcgen05_grouped_worklist_static_full_tiles else bm
+    )
+    tcgen05_output_bn = (
+        tcgen05_source_bn if tcgen05_grouped_worklist_static_full_tiles else bn
+    )
+    tcgen05_static_output_tiles = (
+        m_size % tcgen05_output_bm == 0 and n_size % tcgen05_output_bn == 0
+    )
     tcgen05_static_full_tiles = mma_tiles_are_static_full
     tcgen05_has_k_tail = k_total_size > bk and k_total_size % bk != 0
     tcgen05_k_tail_only = tcgen05_static_output_tiles and tcgen05_has_k_tail
-    tcgen05_double_edge_output = m_size % bm != 0 and n_size % bn != 0
+    tcgen05_double_edge_output = (
+        m_size % tcgen05_output_bm != 0 and n_size % tcgen05_output_bn != 0
+    )
     tcgen05_double_edge_tma = (
         mma_impl == "tcgen05"
         and tcgen05_use_tma_pipeline
@@ -6801,8 +7011,16 @@ def _emit_mma_pipeline(
         and _operand_infos_exclusive_for_mma(lhs_info, rhs_info, fx_node)
     )
     tcgen05_grouped_dynamic_ab_tensormap_rank: int | None = None
+    # The selected host-worklist profile can address the packed A, grouped B,
+    # and packed D allocations through one immutable TensorMap each.  Keep this
+    # separate from ``dynamic_ab_tensormap_rank``: that value still describes
+    # the semantic rank used by validation, while this flag controls whether
+    # the device needs per-CTA mutable descriptor storage.
+    tcgen05_grouped_fixed_tensormaps = False
     tcgen05_grouped_d_mode = Tcgen05GroupedDMode.NONE
     tcgen05_grouped_worklist_persistent = False
+    tcgen05_grouped_use_runtime_n_ptx = False
+    grouped_worklist_supported = False
     tcgen05_grouped_device_split_sizes = False
     tcgen05_grouped_layout_arg_name: str | None = None
     tcgen05_grouped_n_sizes_arg_name: str | None = None
@@ -6852,7 +7070,14 @@ def _emit_mma_pipeline(
             _static_int(rhs_source_fake.shape[2]) if rhs_source_fake.ndim == 3 else None
         )
         lhs_contiguous_mk = _is_contiguous_mk_source_fake(lhs_source_fake)
-        rhs_contiguous_gnk = _is_contiguous_gnk_source_fake(rhs_source_fake)
+        rhs_contiguous_gnk = _is_contiguous_grouped_rhs_source_fake(
+            rhs_source_fake,
+            k_major=True,
+        )
+        rhs_contiguous_gkn = _is_contiguous_grouped_rhs_source_fake(
+            rhs_source_fake,
+            k_major=False,
+        )
         worklist_nm_static_checks = {
             "bf16_operands": input_dtype == torch.bfloat16,
             "bf16_store": epi_elem_dtype_str == "cutlass.BFloat16",
@@ -6878,7 +7103,7 @@ def _emit_mma_pipeline(
                 and lhs_source_k == rhs_source_k
             ),
             "contiguous_a_packed": lhs_contiguous_mk,
-            "contiguous_b_grouped": rhs_contiguous_gnk,
+            "contiguous_b_grouped": rhs_contiguous_gnk or rhs_contiguous_gkn,
             "zero_accumulator": zero_acc_expr or acc_expr is None,
         }
         failed_static_checks = [
@@ -6891,10 +7116,15 @@ def _emit_mma_pipeline(
                 f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} is validated only for "
                 "generated BF16 NT contiguous "
                 "segment-worklist kernels: contiguous A_packed[M,K], "
-                "contiguous B_grouped[G,N,K], common K%block_k==0, "
-                "N%32==0, "
-                "CtaGroup.TWO 256x128x(64|128), zero accumulator, and "
-                "identity BF16 "
+                "logical B_grouped[G,N,K] with contiguous K-major or "
+                "MN-major storage, common K%block_k==0, N%32==0, "
+                f"CtaGroup.TWO physical 256x"
+                f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES}x"
+                f"{TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES} or CtaGroup.ONE "
+                f"physical {TCGEN05_ONE_CTA_MAX_BLOCK_M}x"
+                f"{TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE}x"
+                f"{TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES} (logical tile "
+                "256x128), zero accumulator, and identity BF16 "
                 "store; failed checks: " + ", ".join(failed_static_checks),
             )
     if tcgen05_grouped_static_persistent_requested:
@@ -6939,6 +7169,22 @@ def _emit_mma_pipeline(
             and bm == TCGEN05_TWO_CTA_BLOCK_M
             and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
         )
+        grouped_worklist_one_cta = (
+            tcgen05_grouped_worklist_persistent
+            and tcgen05_one_cta_worklist_shape
+            and not tcgen05_grouped_device_split_sizes
+            and not tcgen05_is_two_cta
+            and tcgen05_cluster_m == 1
+            and tcgen05_cluster_n == 1
+            and tcgen05_mma_bm == 128
+            and tcgen05_mma_bn == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+            and bm == TCGEN05_TWO_CTA_BLOCK_M
+            and bn == 128
+            and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+        )
+        grouped_worklist_supported = (
+            grouped_worklist_two_cta or grouped_worklist_one_cta
+        )
         grouped_common_k_pair_allowed = (
             tcgen05_grouped_k_mask is not None
             or tcgen05_grouped_worklist_persistent
@@ -6958,17 +7204,19 @@ def _emit_mma_pipeline(
                 tcgen05_static_full_tiles or tcgen05_grouped_worklist_persistent
             ),
             "persistent_pid": tcgen05_pid_is_persistent,
-            "cluster_m_1_or_worklist_2cta": (
-                tcgen05_cluster_m == 1 or grouped_worklist_two_cta
+            "cluster_m_1_or_supported_worklist": (
+                tcgen05_cluster_m == 1 or grouped_worklist_supported
             ),
             "cluster_n_1": tcgen05_cluster_n == 1,
-            "cta_group_one_or_worklist_2cta": (
-                not tcgen05_is_two_cta or grouped_worklist_two_cta
+            "cta_group_one_or_supported_worklist": (
+                not tcgen05_is_two_cta or grouped_worklist_supported
             ),
             "role_local_body": tcgen05_use_role_local_persistent_body,
             "tma_store_epilogue": tcgen05_use_tma_store_epilogue,
             "zero_accumulator": zero_acc_expr or acc_expr is None,
-            "block_m_128_or_worklist_2cta": (bm == 128 or grouped_worklist_two_cta),
+            "block_m_128_or_supported_worklist": (
+                bm == 128 or grouped_worklist_supported
+            ),
             "block_n_64_or_128": bn in (64, 128),
             "block_k_16_32_or_64_or_128": (
                 bk in TCGEN05_GROUPED_STATIC_BLOCK_K_CHOICES
@@ -7001,7 +7249,7 @@ def _emit_mma_pipeline(
                 not tcgen05_grouped_worklist_persistent
                 or (
                     tcgen05_grouped_dynamic_ab_tensormaps_requested
-                    and (bm == 128 or grouped_worklist_two_cta)
+                    and (bm == 128 or grouped_worklist_supported)
                     and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
                 )
             ),
@@ -7043,35 +7291,6 @@ def _emit_mma_pipeline(
                 "cute",
                 f"{TCGEN05_GROUPED_MODE_CONFIG_KEY} requires at least one RHS group",
             )
-        if requested_schedule is Tcgen05Orientation.NM:
-            grouped_smem_capacity = CuteTcgen05Config.per_cta_smem_capacity_bytes(
-                lhs_info.source_fake.device
-            )
-            grouped_smem_required = _tcgen05_grouped_worklist_smem_bytes(
-                group_count=grouped_count_value,
-                device_split_sizes=tcgen05_grouped_device_split_sizes,
-                sched_stage_count=_tcgen05_config_int(
-                    df.config, TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY, 1
-                ),
-                bm=tcgen05_mma_bm,
-                bn=tcgen05_mma_bn,
-                bk=bk,
-                dtype_bytes=input_dtype.itemsize,
-                ab_stages=tcgen05_ab_stage_count_value,
-                acc_stages=tcgen05_acc_stage_count_value,
-                c_stages=tcgen05_c_stage_count_value,
-                cluster_m=tcgen05_cluster_m,
-            )
-            if (
-                grouped_smem_capacity <= 0
-                or grouped_smem_required > grouped_smem_capacity
-            ):
-                raise exc.BackendUnsupported(
-                    "cute",
-                    "tcgen05 grouped N,M worklist generated allocations "
-                    f"require {grouped_smem_required} bytes of per-CTA "
-                    f"SMEM, exceeding the {grouped_smem_capacity}-byte capacity",
-                )
         if (
             tcgen05_grouped_static_problem_shapes is not None
             and len(tcgen05_grouped_static_problem_shapes) != grouped_count_value
@@ -7189,7 +7408,7 @@ def _emit_mma_pipeline(
                 "dynamic_d_tensormap": (
                     tcgen05_grouped_d_mode is not Tcgen05GroupedDMode.NONE
                 ),
-                "cta_group_two": grouped_worklist_two_cta,
+                "supported_cta_group": grouped_worklist_supported,
                 "no_grouped_k_mask": tcgen05_grouped_k_mask is None,
                 "no_tail_epilogue": tcgen05_grouped_tail_proof is None,
             }
@@ -7203,24 +7422,61 @@ def _emit_mma_pipeline(
                     "cute",
                     f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
                     f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} is validated only "
-                    "for generated BF16 NT contiguous "
-                    "segment-worklist kernels: contiguous A_packed[M,K], "
-                    "contiguous B_grouped[G,N,K], common K%block_k==0, "
-                    "N%32==0, "
-                    "CtaGroup.TWO 256x128x(64|128), dynamic A/B/D TensorMaps, "
-                    "zero accumulator, and identity BF16 store; failed checks: "
-                    + ", ".join(failed_worklist_nm_checks),
+                    "for generated BF16 NT segment-worklist kernels: "
+                    "contiguous A_packed[M,K], logical B_grouped[G,N,K] with "
+                    "contiguous K-major or MN-major storage, common "
+                    "K%block_k==0, N%32==0, "
+                    f"CtaGroup.TWO physical 256x"
+                    f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES}x"
+                    f"{TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES} or "
+                    f"CtaGroup.ONE physical {TCGEN05_ONE_CTA_MAX_BLOCK_M}x"
+                    f"{TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE}x"
+                    f"{TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES} (logical tile "
+                    "256x128), A/B/D TensorMaps with a fixed-map fast path "
+                    "when eligible, zero accumulator, and identity BF16 store; "
+                    "failed checks: " + ", ".join(failed_worklist_nm_checks),
                 )
             assert requested_schedule is not None
+            tcgen05_grouped_use_runtime_n_ptx = tcgen05_runtime_n_ptx_compatible()
+            if not tcgen05_grouped_use_runtime_n_ptx:
+                # Static-width typed MMA remains correct because padded source
+                # rows are independent and the epilogue masks rows past valid_m.
+                warn_tcgen05_runtime_n_ptx_fallback()
         if (
             tcgen05_grouped_dynamic_ab_tensormap_rank is not None
             and not tcgen05_grouped_direct_pointer_metadata_requested
             and _is_contiguous_mk_source_fake(lhs_info.source_fake)
-            and _is_contiguous_gnk_source_fake(rhs_info.source_fake)
+            and (
+                _is_contiguous_grouped_rhs_source_fake(
+                    rhs_info.source_fake,
+                    k_major=True,
+                )
+                or _is_contiguous_grouped_rhs_source_fake(
+                    rhs_info.source_fake,
+                    k_major=False,
+                )
+            )
         ):
             tcgen05_grouped_dynamic_ab_tensormap_rank = 2
+        tcgen05_grouped_fixed_tensormaps = (
+            requested_schedule is Tcgen05Orientation.NM
+            and tcgen05_grouped_worklist_persistent
+            and not tcgen05_grouped_device_split_sizes
+            and tcgen05_grouped_dynamic_ab_tensormap_rank == 2
+            and tcgen05_grouped_d_mode is Tcgen05GroupedDMode.ALL_TILES
+            and tcgen05_worklist_source_m_tile
+            in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+            and n_size % tcgen05_mma_bm == 0
+            and k_total_size % bk == 0
+        )
+        if tcgen05_grouped_fixed_tensormaps:
+            # The host wrapper builds full-allocation descriptors.  Per-group
+            # starts and valid extents remain scheduler metadata, but no longer
+            # require rebasing A/B/D descriptors in the kernel.
+            tcgen05_grouped_d_mode = Tcgen05GroupedDMode.NONE
         nm_deep_ab = (
             requested_schedule is not None
+            and grouped_worklist_supported
             and 4 <= tcgen05_ab_stage_count_value <= 7
             and tcgen05_c_stage_count_value == 2
             and _tcgen05_config_int(
@@ -7300,7 +7556,10 @@ def _emit_mma_pipeline(
         if requested_schedule is not None:
             tcgen05_grouped_valid_m = df.new_var("tcgen05_grouped_valid_m")
             tcgen05_grouped_store_m = df.new_var("tcgen05_grouped_store_m")
-        if tcgen05_grouped_dynamic_ab_tensormap_rank is not None:
+        if (
+            tcgen05_grouped_dynamic_ab_tensormap_rank is not None
+            and not tcgen05_grouped_fixed_tensormaps
+        ):
             tcgen05_grouped_ab_tensormaps = df.new_var("tcgen05_grouped_ab_tensormaps")
             if tcgen05_grouped_d_mode is not Tcgen05GroupedDMode.NONE:
                 tcgen05_grouped_d_tensormap = tcgen05_grouped_ab_tensormaps
@@ -7349,6 +7608,7 @@ def _emit_mma_pipeline(
             direct_strides=tcgen05_grouped_direct_strides,
             d_mode=tcgen05_grouped_d_mode,
             d_tensormap=tcgen05_grouped_d_tensormap,
+            fixed_tensormaps=tcgen05_grouped_fixed_tensormaps,
             source_m_tile=(
                 tcgen05_worklist_source_m_tile if tcgen05_nm_orientation else None
             ),
@@ -7368,9 +7628,37 @@ def _emit_mma_pipeline(
             f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} requires the "
             "generated segment-worklist grouped tcgen05 path",
         )
+    if requested_schedule is Tcgen05Orientation.NM:
+        assert tcgen05_grouped_plan is not None
+        grouped_smem_capacity = CuteTcgen05Config.per_cta_smem_capacity_bytes(
+            lhs_info.source_fake.device
+        )
+        grouped_smem_required = tcgen05_grouped_worklist_smem_bytes(
+            group_count=int(tcgen05_grouped_plan.count),
+            device_split_sizes=tcgen05_grouped_plan.device_split_sizes,
+            sched_stage_count=_tcgen05_config_int(
+                df.config, TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY, 1
+            ),
+            bm=tcgen05_mma_bm,
+            bn=tcgen05_mma_bn,
+            bk=bk,
+            dtype_bytes=input_dtype.itemsize,
+            ab_stages=tcgen05_ab_stage_count_value,
+            acc_stages=tcgen05_acc_stage_count_value,
+            c_stages=tcgen05_c_stage_count_value,
+            cluster_m=tcgen05_cluster_m,
+        )
+        if grouped_smem_capacity <= 0 or grouped_smem_required > grouped_smem_capacity:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped N,M worklist generated allocations "
+                f"require {grouped_smem_required} bytes of per-CTA SMEM, "
+                f"exceeding the {grouped_smem_capacity}-byte capacity",
+            )
     tcgen05_grouped_static_persistent = tcgen05_grouped_plan is not None
     tcgen05_grouped_dynamic_ab_tensormaps = (
         tcgen05_grouped_dynamic_ab_tensormap_rank is not None
+        and not tcgen05_grouped_fixed_tensormaps
     )
     tcgen05_grouped_direct_pointer_metadata = bool(
         tcgen05_grouped_plan is not None
@@ -7382,6 +7670,12 @@ def _emit_mma_pipeline(
     tcgen05_grouped_d_tensormap_tail_store = (
         tcgen05_grouped_d_mode is Tcgen05GroupedDMode.EDGE_ONLY
     )
+    if tcgen05_grouped_fixed_tensormaps:
+        # Runtime worklist validation proves dense source-tile-aligned packed
+        # extents, and this mode additionally requires N to be a whole selected
+        # MMA-M tile and K to be a whole BK tile. Every A/B TMA transaction is
+        # therefore full even when the logical valid-row mask zeros D padding.
+        tcgen05_static_full_tma_fast_path = True
     nm_worklist = tcgen05_nm_orientation
     rhs_rank3_tma_group_expr = rhs_rank3_group_expr
     rhs_rank3_tma_group_setup: list[str] = []
@@ -7575,6 +7869,59 @@ def _emit_mma_pipeline(
     tcgen05_epi_acc_frag_base = df.new_var("tcgen05_epi_acc_frag_base")
     tcgen05_plan = _new_tcgen05_layout_plan(df) if mma_impl == "tcgen05" else None
     tcgen05_cluster_layout_vmnk = df.new_var("tcgen05_cluster_layout_vmnk")
+    tcgen05_runtime_n_specialization = (
+        mma_impl == "tcgen05"
+        and tcgen05_nm_orientation
+        and tcgen05_grouped_plan is not None
+        and tcgen05_grouped_worklist_persistent
+        and tcgen05_grouped_use_runtime_n_ptx
+    )
+    if tcgen05_runtime_n_specialization:
+        assert tcgen05_worklist_source_m_tile is not None
+        # Runtime UMMA-N specialization is a correctness path for ragged
+        # source-M tails, not a tunable choice. The exact BF16/FP32 shape
+        # envelope below fails closed; the pinned CuTe/CUTLASS environment is
+        # validation provenance, and upgrades require revalidating raw PTX.
+        runtime_n_shape_supported = (
+            input_dtype == torch.bfloat16
+            and input_dtype_str == "cutlass.BFloat16"
+            and acc_dtype_str == "cutlass.Float32"
+            and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+            and tcgen05_cluster_n == 1
+            and tcgen05_worklist_source_m_tile
+            in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+            and (
+                (
+                    tcgen05_is_two_cta
+                    and tcgen05_cluster_m == 2
+                    and tcgen05_mma_bm == 256
+                )
+                or (
+                    not tcgen05_is_two_cta
+                    and tcgen05_cluster_m == 1
+                    and tcgen05_mma_bm == 128
+                )
+            )
+        )
+        if not runtime_n_shape_supported:
+            raise exc.BackendUnsupported(
+                "cute",
+                "runtime worklist-NM UMMA-N specialization requires the "
+                "validated BF16/FP32-accumulate CTA1-M128 or CTA2-M256 "
+                "source32/source224/source256 BK64/BK128 shape",
+            )
+        assert tcgen05_use_role_local_mma_exec
+        assert tcgen05_grouped_valid_m is not None
+    tcgen05_runtime_mma_n = (
+        df.new_var("tcgen05_runtime_mma_n")
+        if tcgen05_runtime_n_specialization
+        else None
+    )
+    tcgen05_runtime_instr_desc = (
+        df.new_var("tcgen05_runtime_instr_desc")
+        if tcgen05_runtime_n_specialization
+        else None
+    )
 
     # === outer_prefix: MMA setup + shared memory alloc + accumulator init ===
     prefix = device_loop.outer_prefix
@@ -7762,17 +8109,28 @@ def _emit_mma_pipeline(
             ),
             mma_exec=tcgen05_use_role_local_mma_exec,
         )
-        reset_accumulate_stmt = _build_tcgen05_mma_accumulate_reset_stmt(
+        reset_accumulate_stmts = _build_tcgen05_mma_accumulate_reset_stmt(
             tcgen05_plan.exec_active,
             tiled_mma=tiled_mma,
+            input_dtype_str=input_dtype_str,
+            acc_dtype_str=acc_dtype_str,
             gate_exec_warp=not tcgen05_use_role_local_mma_exec,
             is_two_cta=tcgen05_is_two_cta,
             cluster_n=tcgen05_cluster_n,
+            runtime_mma_n=tcgen05_runtime_mma_n,
+            runtime_instr_desc=tcgen05_runtime_instr_desc,
+            valid_m=(
+                tcgen05_grouped_valid_m if tcgen05_runtime_n_specialization else None
+            ),
+            static_mma_m=(tcgen05_mma_bm if tcgen05_runtime_n_specialization else None),
+            static_mma_n=(tcgen05_mma_bn if tcgen05_runtime_n_specialization else None),
+            a_k_major=tcgen05_mma_a_k_major,
+            b_k_major=tcgen05_mma_b_k_major,
         )
-        prefix.append(reset_accumulate_stmt)
-        per_tile_stmts.append(reset_accumulate_stmt)
+        prefix.extend(reset_accumulate_stmts)
+        per_tile_stmts.extend(reset_accumulate_stmts)
         if tcgen05_use_role_local_mma_exec:
-            mma_exec_role_stmts.append(reset_accumulate_stmt)
+            mma_exec_role_stmts.extend(reset_accumulate_stmts)
 
     mma_participant_linear: str | None = None
     mma_slice_linear: str | None = None
@@ -7786,11 +8144,13 @@ def _emit_mma_pipeline(
     mma_phys_n = _mma_active_n_threads(mma_impl)
     mma_physical_m_threads = _grid_thread_extent(cg, m_block_id)
     tcgen05_cta_thread_count = _grid_cta_thread_count(cg)
-    if tcgen05_grouped_static_persistent and tcgen05_is_two_cta:
-        # Grouped CtaGroup.TWO uses the same physical role topology as the
-        # plain 2CTA path: one warp per role row. The grouped root tile can
-        # otherwise choose a narrower SIMT M axis, leaving role ids 4/5
-        # unlaunched while the generated predicates still depend on them.
+    if tcgen05_grouped_static_persistent and (
+        tcgen05_is_two_cta or tcgen05_nm_orientation
+    ):
+        # Grouped N,M worklists and CtaGroup.TWO use one physical warp per
+        # role row. The grouped root tile can otherwise choose a 16-thread
+        # SIMT M axis, leaving the exec/load/scheduler role ids unlaunched
+        # while the generated predicates still depend on them.
         mma_physical_m_threads = max(mma_physical_m_threads, 32)
         tcgen05_cta_thread_count = max(tcgen05_cta_thread_count, 4 * 32)
     if mma_impl == "tcgen05" and tcgen05_cluster_m * tcgen05_cluster_n > 1:
@@ -7847,7 +8207,7 @@ def _emit_mma_pipeline(
     tcgen05_explicit_d_store_box_n: int | None = None
     tcgen05_d_store_layout = (
         "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
-        if nm_worklist or output_column_major
+        if tcgen05_nm_orientation or output_column_major
         else "cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
     )
     nm_explicit_store_wave = False
@@ -7861,10 +8221,14 @@ def _emit_mma_pipeline(
             and tcgen05_nm_orientation
             and tcgen05_grouped_static_persistent
             and tcgen05_grouped_worklist_persistent
-            and tcgen05_grouped_dynamic_ab_tensormaps
-            and tcgen05_grouped_dynamic_d_tensormap
-            and tcgen05_cluster_m == 2
-            and tcgen05_cluster_n == 1
+            and (
+                tcgen05_grouped_dynamic_ab_tensormaps
+                or tcgen05_grouped_fixed_tensormaps
+            )
+            and (
+                tcgen05_grouped_dynamic_d_tensormap or tcgen05_grouped_fixed_tensormaps
+            )
+            and grouped_worklist_supported
             and tcgen05_warp_spec.scheduler_warps == 0
             and tcgen05_warp_spec.c_input_warps == 0
             and tcgen05_warp_spec.store_warps == 0
@@ -7915,6 +8279,7 @@ def _emit_mma_pipeline(
         if tcgen05_smem_swizzle_a is not None:
             _validate_tcgen05_smem_swizzle_override(
                 operand="a",
+                k_major=tcgen05_mma_a_k_major,
                 swizzle_bytes=tcgen05_smem_swizzle_a,
                 bm=tcgen05_mma_bm,
                 bn=tcgen05_mma_bn,
@@ -7924,6 +8289,7 @@ def _emit_mma_pipeline(
         if tcgen05_smem_swizzle_b is not None:
             _validate_tcgen05_smem_swizzle_override(
                 operand="b",
+                k_major=tcgen05_mma_b_k_major,
                 swizzle_bytes=tcgen05_smem_swizzle_b,
                 bm=tcgen05_mma_bm,
                 bn=tcgen05_mma_bn,
@@ -8071,7 +8437,14 @@ def _emit_mma_pipeline(
         tcgen05_tma_store_full_tiles_only = tcgen05_tma_store_full_tiles_only_for(
             tcgen05_partial_output_tma_store
         )
-        if tcgen05_grouped_tail_proof is not None:
+        if tcgen05_grouped_worklist_persistent:
+            # The worklist output is either covered by an ALL_TILES dynamic
+            # TensorMap or by the validated fixed full-allocation TensorMap.
+            # Preserve that all-TMA contract across this late aux-epilogue
+            # recomputation; the grouped mailbox scheduler does not publish
+            # the two streams required by the generic full/edge store split.
+            tcgen05_tma_store_full_tiles_only = False
+        elif tcgen05_grouped_tail_proof is not None:
             if tcgen05_grouped_static_full_output_tiles_from_metadata:
                 tcgen05_tma_store_full_tiles_only = False
             else:
@@ -8113,7 +8486,7 @@ def _emit_mma_pipeline(
         )
         if nm_worklist:
             nm_worklist_metadata_checks = {
-                "nm_explicit_store": nm_explicit_store_wave,
+                "supported_physical_store": nm_explicit_store_wave,
                 "dynamic_rank2_ab_tensormaps": (
                     tcgen05_grouped_dynamic_ab_tensormap_rank == 2
                 ),
@@ -8139,9 +8512,9 @@ def _emit_mma_pipeline(
                         "cute",
                         "tcgen05 N,M-oriented explicit store is validated only "
                         "for the BF16 grouped worklist TMA-store "
-                        "path with block_m=256, block_n=128, "
-                        "block_k=64 or 128, "
-                        "CtaGroup.TWO, and no auxiliary epilogue tensors",
+                        "path with logical block_m=256, block_n=128, "
+                        "a supported CtaGroup.ONE/TWO physical tile, and no "
+                        "auxiliary epilogue tensors",
                     )
             elif not explicit_epi_tile_supported:
                 raise exc.BackendUnsupported(
@@ -8367,7 +8740,8 @@ def _emit_mma_pipeline(
                 bm,
                 bn,
                 tcgen05_cluster_m=tcgen05_cluster_m,
-                b_k_major=tcgen05_b_k_major,
+                a_k_major=tcgen05_mma_a_k_major,
+                b_k_major=tcgen05_mma_b_k_major,
                 tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
             )
         )
@@ -8544,7 +8918,8 @@ def _emit_mma_pipeline(
                     tcgen05_mma_bm,
                     tcgen05_mma_bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
-                    b_k_major=tcgen05_b_k_major,
+                    a_k_major=tcgen05_mma_a_k_major,
+                    b_k_major=tcgen05_mma_b_k_major,
                     tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
                 )
             )
@@ -8563,7 +8938,8 @@ def _emit_mma_pipeline(
                     bm,
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
-                    b_k_major=tcgen05_b_k_major,
+                    a_k_major=tcgen05_mma_a_k_major,
+                    b_k_major=tcgen05_mma_b_k_major,
                     tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
                 )
             )
@@ -8593,7 +8969,8 @@ def _emit_mma_pipeline(
                 explicit_epi_tile_m=tcgen05_explicit_epi_tile_m,
                 explicit_epi_tile_n=tcgen05_explicit_epi_tile_n,
                 nm_explicit_store_wave=nm_explicit_store_wave,
-                b_k_major=tcgen05_b_k_major,
+                a_k_major=tcgen05_mma_a_k_major,
+                b_k_major=tcgen05_mma_b_k_major,
                 c_layout=tcgen05_d_store_layout,
             )
         )
@@ -9079,6 +9456,21 @@ def _emit_mma_pipeline(
     )
     tma_tensor_a = df.new_var("tma_tensor_a")
     tma_tensor_b = df.new_var("tma_tensor_b")
+    tma_runtime_mma_n = (
+        df.new_var("tcgen05_tma_runtime_mma_n")
+        if tcgen05_runtime_n_specialization and tcgen05_is_two_cta
+        else None
+    )
+    tma_b_peer_delta = (
+        df.new_var("tcgen05_tma_b_peer_delta")
+        if tcgen05_runtime_n_specialization and tcgen05_is_two_cta
+        else None
+    )
+    tma_tensor_b_tail = (
+        df.new_var("tcgen05_tma_tensor_b_tail")
+        if tcgen05_runtime_n_specialization and tcgen05_is_two_cta
+        else None
+    )
     tma_store_tensor = (
         df.new_var("tcgen05_tma_store_tensor") if tcgen05_use_tma_store_epilogue else ""
     )
@@ -9103,7 +9495,7 @@ def _emit_mma_pipeline(
     tma_next_consumer_tile = df.new_var("tcgen05_tma_next_consumer_tile")
 
     def _tcgen05_tma_output_tile_predicate() -> str | None:
-        if tcgen05_grouped_dynamic_ab_tensormaps:
+        if tcgen05_grouped_dynamic_ab_tensormaps or tcgen05_grouped_fixed_tensormaps:
             if tcgen05_grouped_static_full_output_tiles_from_metadata:
                 return None
             predicate_m_tile = tcgen05_source_bm
@@ -9152,7 +9544,11 @@ def _emit_mma_pipeline(
     def _tcgen05_tma_k_tile_predicate(
         *, k_tile_start_expr: str, full_tile_end_expr: str
     ) -> str:
-        if tcgen05_role_local_uses_k_tail_tma or tcgen05_grouped_dynamic_ab_tensormaps:
+        if (
+            tcgen05_role_local_uses_k_tail_tma
+            or tcgen05_grouped_dynamic_ab_tensormaps
+            or tcgen05_grouped_fixed_tensormaps
+        ):
             return f"{k_tile_start_expr} < {tcgen05_k_bound_expr}"
         return f"{full_tile_end_expr} <= {tcgen05_k_bound_expr}"
 
@@ -9462,8 +9858,8 @@ def _emit_mma_pipeline(
                             if grouped_plan.static_problem_shapes is not None
                             else {}
                         ),
-                        "bm": bm,
-                        "bn": bn,
+                        "bm": tcgen05_mma_bm,
+                        "bn": tcgen05_mma_bn,
                         "bk": bk,
                         **(
                             {"source_m_tile": grouped_plan.source_m_tile}
@@ -9513,6 +9909,16 @@ def _emit_mma_pipeline(
                         **(
                             {"worklist_metadata": True}
                             if tcgen05_grouped_worklist_persistent
+                            else {}
+                        ),
+                        **(
+                            {
+                                "fixed_tensormaps": True,
+                                "dynamic_ab_tensormap_rank": 2,
+                                "lhs_name": lhs_arg_name,
+                                "rhs_name": rhs_arg_name,
+                            }
+                            if grouped_plan.fixed_tensormaps
                             else {}
                         ),
                         **(
@@ -9588,6 +9994,12 @@ def _emit_mma_pipeline(
             }
             if nm_worklist:
                 ab_tma_plan["orientation"] = "nm"
+            if tcgen05_grouped_fixed_tensormaps:
+                ab_tma_plan["fixed_ab_tensormaps"] = True
+                if tcgen05_nm_orientation and not tcgen05_b_k_major:
+                    # MN-major logical B cannot flatten [G,N,K] to [G*N,K].
+                    # Preserve one immutable rank-3 full-allocation TensorMap.
+                    ab_tma_plan["fixed_grouped_b_rank3"] = True
             # The bm=128 CtaGroup.TWO family cannot be derived from
             # ``bm == 256`` by the host wrapper, so record the resolved 2-CTA
             # decision on the plan. Only recorded for this family (where the
@@ -9597,10 +10009,11 @@ def _emit_mma_pipeline(
             # derivation. See ``_tcgen05_use_2cta_instrs``.
             if tcgen05_is_two_cta and tcgen05_mma_bm != TCGEN05_TWO_CTA_BLOCK_M:
                 ab_tma_plan["use_2cta_instrs"] = True
-            # K-major (column-major / K-contiguous) B. Only recorded when True
-            # so MN-major (row-major B) wrapper-plan literals stay byte-identical
-            # to the golden.
-            if tcgen05_b_k_major:
+            if not tcgen05_mma_a_k_major:
+                ab_tma_plan["a_k_major"] = False
+            # K-major physical B. Only recorded when True so old wrapper plans
+            # remain byte-identical when the physical B operand is MN-major.
+            if tcgen05_mma_b_k_major:
                 ab_tma_plan["b_k_major"] = True
             if rhs_rank3_group_expr is not None:
                 grouped_operand = "lhs" if tcgen05_nm_orientation else "rhs"
@@ -9651,9 +10064,9 @@ def _emit_mma_pipeline(
             if tcgen05_matmul_plan.is_clc_persistent:
                 ab_tma_plan["use_pdl"] = True
             cg.cute_wrapper_plans.append(ab_tma_plan)
-            if (
-                tcgen05_grouped_static_persistent
-                and tcgen05_grouped_dynamic_ab_tensormaps
+            if tcgen05_grouped_static_persistent and (
+                tcgen05_grouped_dynamic_ab_tensormaps
+                or tcgen05_grouped_fixed_tensormaps
             ):
                 assert tma_warp is not None
                 assert warp_idx is not None
@@ -9860,35 +10273,61 @@ def _emit_mma_pipeline(
             dynamic_ab_tile_trailing_coord = (
                 "" if tcgen05_grouped_dynamic_ab_tensormap_rank == 2 else ", 0"
             )
-            a_tile_coord = (
-                (
-                    f"({tcgen05_grouped_cta_tile_idx_n}, None"
-                    f"{dynamic_ab_tile_trailing_coord})"
-                    if tcgen05_nm_orientation
-                    else f"({tcgen05_grouped_cta_tile_idx_m}, None"
-                    f"{dynamic_ab_tile_trailing_coord})"
+            if tcgen05_grouped_fixed_tensormaps:
+                assert tcgen05_grouped_group_idx is not None
+                assert tcgen05_grouped_global_m_start is not None
+                assert tcgen05_grouped_cta_tile_idx_m is not None
+                assert tcgen05_grouped_cta_tile_idx_n is not None
+                assert tcgen05_worklist_source_m_tile is not None
+                if not tcgen05_b_k_major:
+                    a_tile_coord = (
+                        f"({tcgen05_grouped_cta_tile_idx_n}, None, "
+                        f"{tcgen05_grouped_group_idx})"
+                    )
+                else:
+                    # K-major B can flatten [G,N,K] to [G*N,K].
+                    a_tile_coord = (
+                        f"({tcgen05_grouped_group_idx} * cutlass.Int32("
+                        f"{n_size // tcgen05_mma_bm}) + "
+                        f"{tcgen05_grouped_cta_tile_idx_n}, None)"
+                    )
+                b_tile_coord = (
+                    f"({tcgen05_grouped_global_m_start} // cutlass.Int32("
+                    f"{tcgen05_worklist_source_m_tile}) + "
+                    f"{tcgen05_grouped_cta_tile_idx_m}, None)"
                 )
-                if tcgen05_grouped_dynamic_ab_tensormaps
-                else f"({m_offset_var} // cutlass.Int32({bm}), None)"
-            )
-            b_tile_coord = (
-                (
-                    f"({tcgen05_grouped_cta_tile_idx_m}, None"
-                    f"{dynamic_ab_tile_trailing_coord})"
-                    if tcgen05_nm_orientation
-                    else f"({tcgen05_grouped_cta_tile_idx_n}, None"
-                    f"{dynamic_ab_tile_trailing_coord})"
+            else:
+                a_tile_coord = (
+                    (
+                        f"({tcgen05_grouped_cta_tile_idx_n}, None"
+                        f"{dynamic_ab_tile_trailing_coord})"
+                        if tcgen05_nm_orientation
+                        else f"({tcgen05_grouped_cta_tile_idx_m}, None"
+                        f"{dynamic_ab_tile_trailing_coord})"
+                    )
+                    if tcgen05_grouped_dynamic_ab_tensormaps
+                    else f"({m_offset_var} // cutlass.Int32({bm}), None)"
                 )
-                if tcgen05_grouped_dynamic_ab_tensormaps
-                else (
-                    f"({n_offset_var} // cutlass.Int32({bn}), None, "
-                    f"{rhs_rank3_tma_group_expr})"
-                    if rhs_rank3_tma_group_expr is not None
-                    else f"({n_offset_var} // cutlass.Int32({bn}), None)"
+                b_tile_coord = (
+                    (
+                        f"({tcgen05_grouped_cta_tile_idx_m}, None"
+                        f"{dynamic_ab_tile_trailing_coord})"
+                        if tcgen05_nm_orientation
+                        else f"({tcgen05_grouped_cta_tile_idx_n}, None"
+                        f"{dynamic_ab_tile_trailing_coord})"
+                    )
+                    if tcgen05_grouped_dynamic_ab_tensormaps
+                    else (
+                        f"({n_offset_var} // cutlass.Int32({bn}), None, "
+                        f"{rhs_rank3_tma_group_expr})"
+                        if rhs_rank3_tma_group_expr is not None
+                        else f"({n_offset_var} // cutlass.Int32({bn}), None)"
+                    )
                 )
-            )
             gmem_a_tma_tiler = f"({tcgen05_mma_bm}, {bk})"
             gmem_b_tma_tiler = f"({tcgen05_mma_bn}, {bk})"
+            if tcgen05_grouped_fixed_tensormaps and not tcgen05_b_k_major:
+                gmem_a_tma_tiler = f"({tcgen05_mma_bm}, {bk}, 1)"
             if lhs_operand.is_leading_passthrough:
                 assert leading_global is not None
                 gmem_a_tma_tiler = f"({bm}, {bk}, 1)"
@@ -9901,6 +10340,46 @@ def _emit_mma_pipeline(
                 b_tile_coord = (
                     f"({n_offset_var} // cutlass.Int32({bn}), None, {leading_global})"
                 )
+            gmem_b_tma_tensor = tma_tensor_b
+            if tcgen05_runtime_n_specialization and tcgen05_is_two_cta:
+                assert tcgen05_grouped_valid_m is not None
+                assert tma_runtime_mma_n is not None
+                assert tma_b_peer_delta is not None
+                assert tma_tensor_b_tail is not None
+                assert mma_slice_linear is not None
+                assert tcgen05_worklist_source_m_tile == tcgen05_mma_bn
+                # A CTA-group::2 UMMA-N instruction divides its N rows across
+                # the two peers.  The static partition starts peer 1 at
+                # static_N/2; a narrowed descriptor instead needs it to load
+                # from runtime_N/2.  Offset the base tensor before local_tile:
+                # the tiled tensor's dynamic layout cannot represent this
+                # runtime domain offset directly.
+                _emit_per_tile(
+                    f"{tma_runtime_mma_n} = cutlass.Int32({tcgen05_mma_bn})",
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
+                _emit_per_tile(
+                    f"{tma_b_peer_delta} = cutlass.Int32(0)",
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
+                _emit_per_tile(
+                    f"{tma_tensor_b_tail} = cute.domain_offset("
+                    f"({tma_b_peer_delta}, 0), {tma_tensor_b})",
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
+                _emit_per_tile(
+                    f"if {tcgen05_grouped_valid_m} <= "
+                    f"cutlass.Int32({tcgen05_mma_bn - 16}):\n"
+                    f"    {tma_runtime_mma_n} = "
+                    f"{_tcgen05_runtime_mma_n_expr(tcgen05_grouped_valid_m, tcgen05_mma_bn)}\n"
+                    f"    {tma_b_peer_delta} = {mma_slice_linear} * "
+                    f"({tma_runtime_mma_n} // cutlass.Int32(2) - "
+                    f"cutlass.Int32({tcgen05_mma_bn // 2}))\n"
+                    f"    {tma_tensor_b_tail} = cute.domain_offset("
+                    f"({tma_b_peer_delta}, 0), {tma_tensor_b})",
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
+                gmem_b_tma_tensor = tma_tensor_b_tail
             _emit_per_tile(
                 f"{gmem_a_tma} = cute.local_tile("
                 f"{tma_tensor_a}, {gmem_a_tma_tiler}, "
@@ -9909,7 +10388,7 @@ def _emit_mma_pipeline(
             )
             _emit_per_tile(
                 f"{gmem_b_tma} = cute.local_tile("
-                f"{tma_tensor_b}, {gmem_b_tma_tiler}, "
+                f"{gmem_b_tma_tensor}, {gmem_b_tma_tiler}, "
                 f"{b_tile_coord})",
                 tma_load=tcgen05_use_role_local_tma_producer,
             )
@@ -10644,9 +11123,18 @@ def _emit_mma_pipeline(
                                 tcgen05_frag_a=tcgen05_frag_a,
                                 tcgen05_frag_b=tcgen05_frag_b,
                                 mma_stage=mma_stage,
+                                input_dtype_str=input_dtype_str,
+                                acc_dtype_str=acc_dtype_str,
                                 gate_exec_warp=tcgen05_static_full_tma_fast_path,
                                 is_two_cta=tcgen05_is_two_cta,
                                 cluster_n=tcgen05_cluster_n,
+                                runtime_mma_n=tcgen05_runtime_mma_n,
+                                runtime_instr_desc=tcgen05_runtime_instr_desc,
+                                static_mma_n=(
+                                    tcgen05_mma_bn
+                                    if tcgen05_runtime_n_specialization
+                                    else None
+                                ),
                             )
                         )
                     exec_loop_body.append(
@@ -10823,8 +11311,17 @@ def _emit_mma_pipeline(
                             tcgen05_frag_a=tcgen05_frag_a,
                             tcgen05_frag_b=tcgen05_frag_b,
                             mma_stage=mma_stage,
+                            input_dtype_str=input_dtype_str,
+                            acc_dtype_str=acc_dtype_str,
                             is_two_cta=tcgen05_is_two_cta,
                             cluster_n=tcgen05_cluster_n,
+                            runtime_mma_n=tcgen05_runtime_mma_n,
+                            runtime_instr_desc=tcgen05_runtime_instr_desc,
+                            static_mma_n=(
+                                tcgen05_mma_bn
+                                if tcgen05_runtime_n_specialization
+                                else None
+                            ),
                         )
                     )
                 if tcgen05_use_tma:
@@ -11312,9 +11809,30 @@ def _tcgen05_candidate_exceeds_smem(
     bn: int,
     bk: int,
     config: object | None,
+    defer_grouped_worklist_smem_check: bool = False,
 ) -> bool:
     """Whether tcgen05 A/B staging exceeds the device's per-CTA budget."""
     if input_device is None or config is None:
+        return False
+    worklist_shape = (
+        resolve_tcgen05_grouped_worklist_mma_shape(
+            cluster_m=_tcgen05_cluster_m(config),
+            block_k=bk,
+            source_m_tile=_tcgen05_config_int(
+                config,
+                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+            ),
+        )
+        if defer_grouped_worklist_smem_check
+        else None
+    )
+    if worklist_shape is not None and (bm, bn) == worklist_shape:
+        # The grouped worklist owns scheduler mailboxes, TensorMap storage, and
+        # an explicit C ring. Its conservative allocation upper bound is checked
+        # by ``tcgen05_grouped_worklist_smem_bytes`` in the resolved worklist
+        # lowering. The explicit defer flag prevents unrelated MMA nodes that
+        # share this config from bypassing ordinary AB admission.
         return False
     env_choice = os.environ.get("HELION_CUTE_MMA_IMPL", "auto").strip().lower()
     if env_choice not in ("auto", "tcgen05"):
@@ -11365,6 +11883,7 @@ def _choose_mma_impl(
     bk: int,
     config: object | None = None,
     input_device: torch.device | None = None,
+    defer_grouped_worklist_smem_check: bool = False,
 ) -> str:
     tcgen05_cluster_m = 1
     if config is not None:
@@ -11397,6 +11916,7 @@ def _choose_mma_impl(
                 bn=bn,
                 bk=bk,
                 config=config,
+                defer_grouped_worklist_smem_check=defer_grouped_worklist_smem_check,
             ):
                 return "universal"
             return env_choice
@@ -11422,6 +11942,7 @@ def _choose_mma_impl(
             bn=bn,
             bk=bk,
             config=config,
+            defer_grouped_worklist_smem_check=defer_grouped_worklist_smem_check,
         ):
             return "tcgen05"
     if _mma_impl_matches_problem_shape("warp", input_dtype, bm=bm, bn=bn, bk=bk):
@@ -11441,6 +11962,7 @@ def _make_tiled_mma_setup(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    a_k_major: bool = True,
     b_k_major: bool = False,
     tcgen05_use_2cta_instrs: bool | None = None,
 ) -> list[ast.AST]:
@@ -11458,6 +11980,7 @@ def _make_tiled_mma_setup(
             bm,
             bn,
             tcgen05_cluster_m=tcgen05_cluster_m,
+            a_k_major=a_k_major,
             b_k_major=b_k_major,
             use_2cta_instrs=tcgen05_use_2cta_instrs,
         )
@@ -11488,6 +12011,7 @@ def _tcgen05_tiled_mma_expr(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    a_k_major: bool = True,
     b_k_major: bool = False,
     use_2cta_instrs: bool | None = None,
 ) -> str:
@@ -11502,8 +12026,11 @@ def _tcgen05_tiled_mma_expr(
     cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.ONE"
     if use_2cta_instrs:
         cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.TWO"
-    # A is always K-major. B is MN-major for row-major (N-contiguous) B and
-    # K-major for column-major (K-contiguous) B.
+    a_major_expr = (
+        "cute.nvgpu.OperandMajorMode.K"
+        if a_k_major
+        else "cute.nvgpu.OperandMajorMode.MN"
+    )
     b_major_expr = (
         "cute.nvgpu.OperandMajorMode.K"
         if b_k_major
@@ -11513,7 +12040,7 @@ def _tcgen05_tiled_mma_expr(
         "cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
         f"{input_dtype_str}, "
         f"{input_dtype_str}, "
-        "cute.nvgpu.OperandMajorMode.K, "
+        f"{a_major_expr}, "
         f"{b_major_expr}, "
         f"{acc_dtype_str}, "
         f"{cta_group_expr}, "
@@ -11562,6 +12089,7 @@ def _make_tcgen05_layout_plan_setup(
     explicit_epi_tile_m: int | None = None,
     explicit_epi_tile_n: int | None = None,
     nm_explicit_store_wave: bool = False,
+    a_k_major: bool = True,
     b_k_major: bool = False,
     c_layout: str = "cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
 ) -> list[ast.AST]:
@@ -11616,11 +12144,11 @@ def _make_tcgen05_layout_plan_setup(
     return [
         statement_from_string(
             f"{plan.smem_a_layout} = "
-            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='a', swizzle_override=smem_swizzle_a)}"
+            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='a', swizzle_override=smem_swizzle_a, k_major=a_k_major)}"
         ),
         statement_from_string(
             f"{plan.smem_b_layout} = "
-            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b, b_k_major=b_k_major)}"
+            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b, k_major=b_k_major)}"
         ),
         statement_from_string(f"{plan.c_layout} = {c_layout}"),
         statement_from_string(f"{plan.epi_tile} = {epi_tile_expr}"),
@@ -12116,6 +12644,7 @@ def _emit_tcgen05_aux_pipeline_setup(
 def _validate_tcgen05_smem_swizzle_override(
     *,
     operand: str,
+    k_major: bool,
     swizzle_bytes: int,
     bm: int,
     bn: int,
@@ -12126,12 +12655,8 @@ def _validate_tcgen05_smem_swizzle_override(
 
     CuTe's ``make_smem_layout_atom`` requires the major-mode bytes-per-row
     to be a multiple of the swizzle pattern's contiguous bytes. For
-    Helion's tcgen05 lowering:
-
-    - A is K-major: major-mode = K dimension; bytes-per-row =
-      ``bk * dtype_width_bits / 8``.
-    - B is MN-major: major-mode = N dimension; bytes-per-row =
-      ``bn * dtype_width_bits / 8``.
+    The resolved operand major mode determines the contiguous extent: K-major
+    operands use ``bk``; MN-major A uses ``bm`` and MN-major B uses ``bn``.
 
     This helper computes the active bytes-per-row from the live tile
     shape + dtype and rejects swizzle overrides that violate the atom
@@ -12156,13 +12681,10 @@ def _validate_tcgen05_smem_swizzle_override(
     # the comparison is exact since dtype widths divide 8 for every
     # MMA-supported dtype.)
     dtype_bytes = input_dtype.itemsize
-    if operand == "a":
-        major_mode_extent = bk
-        major_mode_axis = "K"
-    else:
-        assert operand == "b", f"unexpected operand {operand!r}"
-        major_mode_extent = bn
-        major_mode_axis = "N"
+    assert operand in ("a", "b"), f"unexpected operand {operand!r}"
+    major_mode_axis, major_mode_extent = (
+        ("K", bk) if k_major else ("M", bm) if operand == "a" else ("N", bn)
+    )
     major_mode_bytes = major_mode_extent * dtype_bytes
     min_required = smem_swizzle_min_major_mode_bytes(swizzle_bytes)
     if major_mode_bytes % min_required != 0:
@@ -12228,6 +12750,7 @@ def codegen_cute_mma(
             allow_rank3_rhs_nt=True,
             cg=ctx.cg,
             allow_grouped_k_mask=allow_grouped_k_mask,
+            allow_rank3_rhs_mn_major=(grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM),
         )
         if rhs_info is None or not rhs_info.rhs_rank3_grouped_nt:
             return _unsupported_schedule("MMA RHS was not grouped rank-3")

--- a/helion/_compiler/cute/cutedsl_compat.py
+++ b/helion/_compiler/cute/cutedsl_compat.py
@@ -1,28 +1,82 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from functools import lru_cache
 import importlib.metadata
+import logging
 
 from packaging.version import InvalidVersion
 from packaging.version import Version
 
-# The cute backend hard-requires the CuTe DSL 4.5.1 API generation, the
+log = logging.getLogger(__name__)
+
+# The cute backend hard-requires the CuTe DSL 4.7 API generation, the
 # apache-tvm-ffi package, and CUDA >= 13. ``check_cute_backend_requirements``
 # (wired through ``CuteBackend.validate_environment``) enforces this up front so
 # the rest of the backend can assume the modern APIs unconditionally rather than
 # carry per-build compatibility shims and inline workarounds.
 CUTE_MIN_CUDA_VERSION = "13"
-CUTE_MIN_VERSION = Version("4.5.1")
-CUTE_MATH_MIN_MAX_VERSION = Version("4.6.0")
+# Central validated CuTe compatibility generation. A bump must revalidate the
+# raw tcgen05 runtime-N PTX fallback in ``cute_mma`` alongside the typed APIs;
+# the pin-consistency test makes every checked-in DSL upgrade pass this line.
+CUTE_VALIDATED_VERSION = Version("4.7.0")
+CUTE_MIN_VERSION = CUTE_VALIDATED_VERSION
+CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION = CUTE_VALIDATED_VERSION
+
+
+@dataclass(frozen=True)
+class _CuteDSLVersionProbe:
+    version: Version | None = None
+    missing: bool = False
+    invalid: str | None = None
 
 
 @lru_cache(maxsize=1)
-def cute_math_min_max_available() -> bool:
-    """Return whether ``cute.math.min/max`` are available in this CuTe DSL."""
-    return (
-        Version(importlib.metadata.version("nvidia-cutlass-dsl"))
-        >= CUTE_MATH_MIN_MAX_VERSION
-    )
+def _installed_cute_dsl_version() -> _CuteDSLVersionProbe:
+    """Probe and cache the installed DSL version, including failure states."""
+    try:
+        return _CuteDSLVersionProbe(
+            version=Version(importlib.metadata.version("nvidia-cutlass-dsl"))
+        )
+    except importlib.metadata.PackageNotFoundError:
+        return _CuteDSLVersionProbe(missing=True)
+    except InvalidVersion as error:
+        return _CuteDSLVersionProbe(invalid=str(error))
+
+
+def tcgen05_runtime_n_ptx_compatible() -> bool:
+    """Whether the installed DSL matches the raw runtime-N PTX validation."""
+
+    installed = _installed_cute_dsl_version().version
+    if installed is None:
+        return False
+    return installed == CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION
+
+
+@lru_cache(maxsize=1)
+def warn_tcgen05_runtime_n_ptx_fallback() -> None:
+    """Warn once when a grouped worklist needs the newer-DSL fallback.
+
+    This is intentionally separate from the side-effect-free compatibility
+    probe. Callers invoke the warning only after proving a grouped N,M worklist
+    candidate or selecting its explicit runtime-direct codegen path.
+    """
+
+    installed = _installed_cute_dsl_version().version
+    if installed is None:
+        return
+    if installed > CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION:
+        log.warning(
+            "Installed nvidia-cutlass-dsl %s is newer than the exact %s version "
+            "validated for grouped tcgen05 runtime-N PTX. Grouped runtime-N "
+            "compiler seeds and promoted defaults are disabled; explicit "
+            "runtime-direct worklist configs fall back to typed static-width "
+            "MMA, including for ragged source-M tails. Use %s for the validated "
+            "narrow runtime-N path.",
+            installed,
+            CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION,
+            CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION,
+        )
 
 
 @lru_cache(maxsize=1)
@@ -31,18 +85,19 @@ def _cute_backend_requirement_error() -> str | None:
 
     Cached because the answer is fixed for the lifetime of the process.
     """
-    try:
-        installed_version = Version(importlib.metadata.version("nvidia-cutlass-dsl"))
-    except importlib.metadata.PackageNotFoundError:
+    probe = _installed_cute_dsl_version()
+    installed_version = probe.version
+    if probe.missing:
         return (
             "the CuTe DSL is not installed "
             f"(need nvidia-cutlass-dsl >= {CUTE_MIN_VERSION})"
         )
-    except InvalidVersion as e:
+    if probe.invalid is not None:
         return (
             "the installed CuTe DSL version is invalid "
-            f"(need >= {CUTE_MIN_VERSION}): {e}"
+            f"(need >= {CUTE_MIN_VERSION}): {probe.invalid}"
         )
+    assert installed_version is not None
     if installed_version < CUTE_MIN_VERSION:
         return (
             "the installed CuTe DSL is too old "

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -63,6 +63,7 @@ class CuteTcgen05GroupedPlan:
     direct_strides: str | None = None
     d_mode: Tcgen05GroupedDMode = Tcgen05GroupedDMode.NONE
     d_tensormap: str | None = None
+    fixed_tensormaps: bool = False
     # N,M worklists carry their source-row tile explicitly so runtime metadata
     # validation and launch bounds consume the exact schedule selected by the
     # compiler.  For the device-split variant, ``layout`` names the device
@@ -81,6 +82,15 @@ class CuteTcgen05GroupedPlan:
         assert (self.direct_pointers is None) == (self.direct_strides is None)
         assert (self.d_mode is Tcgen05GroupedDMode.NONE) == (self.d_tensormap is None)
         assert not self.device_split_sizes or self.orientation is Tcgen05Orientation.NM
+        if self.orientation is Tcgen05Orientation.NM:
+            assert self.real_groups is not None or self.device_split_sizes
+            assert self.fixed_tensormaps == (self.d_mode is Tcgen05GroupedDMode.NONE)
+        if self.fixed_tensormaps:
+            assert self.orientation is Tcgen05Orientation.NM
+            assert not self.device_split_sizes
+            assert self.d_mode is Tcgen05GroupedDMode.NONE
+            assert self.d_tensormap is None
+            assert self.direct_pointers is None
         if self.static_problem_shapes is not None:
             assert self.orientation is Tcgen05Orientation.MN
             assert self.real_groups is None

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -320,8 +320,9 @@ class Tcgen05LayoutOverrides:
 # - ``64`` → ``{K|MN}_SW64``  (64-byte swizzle pattern)
 # - ``128``→ ``{K|MN}_SW128`` (128-byte swizzle pattern)
 #
-# The K/MN prefix is determined by the operand's major mode (A is K-major,
-# B is MN-major in Helion's tcgen05 lowering today). ``MN_SW128_32B``
+# The K/MN prefix follows the resolved operand mode.  Canonical lowering uses
+# K-major A and MN-major B; grouped N,M can instead select MN-major A and
+# K-major B through the operand's ``k_major`` value. ``MN_SW128_32B``
 # (a fp32-only variant) is intentionally not exposed: Helion's tcgen05
 # path only runs on bf16/fp16 today, and exposing the variant without a
 # matching dtype gate would produce ``ValueError`` at codegen time.
@@ -389,7 +390,7 @@ def tcgen05_smem_layout_expr(
     num_stages: int,
     operand: str,
     swizzle_override: int | None,
-    b_k_major: bool = False,
+    k_major: bool,
 ) -> str:
     """Emit the CuTe expression that builds the staged SMEM layout for A or B.
 
@@ -414,61 +415,36 @@ def tcgen05_smem_layout_expr(
     selection: partition_shape → append num_stages → make atom →
     tile_to_mma_shape with the major-mode-determined ``order``.
 
-    Helion's tcgen05 lowering wires ``OperandMajorMode.K`` for A and
-    ``OperandMajorMode.MN`` for B (see ``make_trivial_tiled_mma``
-    call in ``runtime._append_cute_wrapper_plan``), so the ``order``
-    and atom-kind prefix below are hard-coded to that contract.
+    Helion's canonical tcgen05 lowering wires ``OperandMajorMode.K`` for A
+    and ``OperandMajorMode.MN`` for B. Grouped N,M lowering can transpose
+    those physical operand roles, so ``k_major`` selects the matching atom
+    prefix and axis order for the requested operand.
     """
-    if operand == "a":
-        if swizzle_override is None:
-            return (
-                "cutlass.utils.blackwell_helpers.make_smem_layout_a("
-                f"{tiled_mma}, ({bm}, {bn}, {bk}), {dtype_str}, {num_stages})"
-            )
-        atom_kind = (
-            f"cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_"
-            f"{smem_swizzle_atom_kind_suffix(swizzle_override)}"
-        )
-        # A is K-major: partition shape uses dice (1, None, 1); the
-        # tile_to_mma_shape ``order`` is (1, 2, 3) (matches the
-        # is_k_major=True branch of ``make_smem_layout_a``).
-        return (
-            "cute.nvgpu.tcgen05.tile_to_mma_shape("
-            f"cute.nvgpu.tcgen05.make_smem_layout_atom({atom_kind}, {dtype_str}), "
-            f"cute.append({tiled_mma}.partition_shape_A("
-            f"cute.dice(({bm}, {bn}, {bk}), (1, None, 1))), {num_stages}), "
-            "order=(1, 2, 3))"
-        )
-    assert operand == "b", f"unexpected operand {operand!r}"
-    if b_k_major:
-        # K-major (column-major / K-contiguous) B. Delegate to CuTe's helper
-        # with ``is_k_major=True`` so the SMEM atom selection mirrors the
-        # K-major A path exactly; the smem_swizzle_b override knob is not
-        # plumbed through this path (correctness-first), which is fine
-        # since the fp8 default path uses swizzle_override=None.
-        return (
-            "cutlass.utils.blackwell_helpers.make_smem_layout_b("
-            f"{tiled_mma}, ({bm}, {bn}, {bk}), {dtype_str}, {num_stages}, "
-            "is_k_major=True)"
-        )
+    assert operand in ("a", "b"), f"unexpected operand {operand!r}"
+    helper = f"make_smem_layout_{operand}"
+    canonical_k_major = operand == "a"
     if swizzle_override is None:
+        major_arg = "" if k_major == canonical_k_major else f", is_k_major={k_major}"
         return (
-            "cutlass.utils.blackwell_helpers.make_smem_layout_b("
-            f"{tiled_mma}, ({bm}, {bn}, {bk}), {dtype_str}, {num_stages})"
+            f"cutlass.utils.blackwell_helpers.{helper}("
+            f"{tiled_mma}, ({bm}, {bn}, {bk}), {dtype_str}, {num_stages}"
+            f"{major_arg})"
         )
+
+    major = "K" if k_major else "MN"
+    partition = operand.upper()
+    dice = "(1, None, 1)" if operand == "a" else "(None, 1, 1)"
+    order = "(1, 2, 3)" if k_major else "(2, 1, 3)"
     atom_kind = (
-        f"cute.nvgpu.tcgen05.SmemLayoutAtomKind.MN_"
+        f"cute.nvgpu.tcgen05.SmemLayoutAtomKind.{major}_"
         f"{smem_swizzle_atom_kind_suffix(swizzle_override)}"
     )
-    # B is MN-major: partition shape uses dice (None, 1, 1); the
-    # tile_to_mma_shape ``order`` is (2, 1, 3) (matches the
-    # is_k_major=False branch of ``make_smem_layout_b``).
     return (
         "cute.nvgpu.tcgen05.tile_to_mma_shape("
         f"cute.nvgpu.tcgen05.make_smem_layout_atom({atom_kind}, {dtype_str}), "
-        f"cute.append({tiled_mma}.partition_shape_B("
-        f"cute.dice(({bm}, {bn}, {bk}), (None, 1, 1))), {num_stages}), "
-        "order=(2, 1, 3))"
+        f"cute.append({tiled_mma}.partition_shape_{partition}("
+        f"cute.dice(({bm}, {bn}, {bk}), {dice})), {num_stages}), "
+        f"order={order})"
     )
 
 
@@ -817,7 +793,7 @@ def tcgen05_explicit_d_store_tile_expr(tile_m: int, d_store_box_n: int) -> str:
 # sync with ``VALID_PID_TYPES`` in ``config_spec.py``; widening that
 # tuple without revisiting this helper is a contract drift the assert
 # below catches loudly.
-_KNOWN_PID_TYPES_FOR_PERSISTENCE_MODEL: frozenset[str] = frozenset(
+TCGEN05_PERSISTENCE_MODEL_PID_TYPES: frozenset[str] = frozenset(
     {"flat", "xyz", "persistent_blocked", "persistent_interleaved"}
 )
 
@@ -844,9 +820,9 @@ def derive_persistence_model_from_pid_type(
     loudly instead of silently mapping the new value to
     ``NON_PERSISTENT``.
     """
-    assert pid_type in _KNOWN_PID_TYPES_FOR_PERSISTENCE_MODEL, (
+    assert pid_type in TCGEN05_PERSISTENCE_MODEL_PID_TYPES, (
         f"derive_persistence_model_from_pid_type: unknown pid_type "
-        f"{pid_type!r}; update _KNOWN_PID_TYPES_FOR_PERSISTENCE_MODEL "
+        f"{pid_type!r}; update TCGEN05_PERSISTENCE_MODEL_PID_TYPES "
         "to include the new value (or extend the mapping if the new "
         "pid_type implies a different persistence model)."
     )

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -105,8 +105,11 @@ from .tcgen05_constants import TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_K
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CONFIG_KEY
@@ -141,10 +144,12 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
 from .tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
+from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_shape
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_c_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_default_epilogue_tile_size
 from .tcgen05_constants import tcgen05_direct_entry_stage_tuple_allowed
+from .tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
 from .tcgen05_constants import tcgen05_two_cta_edge_k_tail_seed_overrides
 
 if TYPE_CHECKING:
@@ -862,18 +867,40 @@ class CuteTcgen05Config:
     def _fix_cluster_m2_search_config(self, config: dict[str, object]) -> None:
         if not (self.search_enabled and config.get("tcgen05_cluster_m") == 2):
             return
+        config_view = self._matmul_config_view(config)
+        if config_view is None:
+            config["tcgen05_cluster_m"] = 1
+            return
+        block_sizes, m_index, n_index, k_index = config_view
+
+        def is_grouped_worklist_two_cta() -> bool:
+            return (
+                config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                and config.get("tcgen05_cluster_n", 1) == 1
+                and block_sizes[m_index] == TCGEN05_TWO_CTA_BLOCK_M
+                and block_sizes[n_index] == 128
+                and block_sizes[k_index] in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+                and config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+                in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+            )
+
         constraints = self.cluster_m2_search_constraints
+        if is_grouped_worklist_two_cta():
+            # The selected worklist source-M family owns the validated physical
+            # 256x32/224/256 MMA profile and its K envelope independently of
+            # the generic cluster-M2 policy. Compiler seeds widen the
+            # otherwise-narrow pid fragment, so keep this exact family even
+            # when generic constraints reject it or are absent.
+            config["pid_type"] = TCGEN05_TWO_CTA_SEED_PID_TYPE
+            config.pop("epilogue_subtile", None)
+            return
         if constraints is None:
             config["tcgen05_cluster_m"] = 1
             return
         if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
             config["tcgen05_cluster_m"] = 1
             return
-        config_view = self._matmul_config_view(config)
-        if config_view is None:
-            config["tcgen05_cluster_m"] = 1
-            return
-        block_sizes, m_index, n_index, k_index = config_view
         edge_k_tail_family = constraints.allow_edge_k_tail_family
         is_narrow_clc_aux_tma = self._is_clc_aux_tma_narrow_n_request(config)
         if edge_k_tail_family:
@@ -947,6 +974,17 @@ class CuteTcgen05Config:
     def prepare_normalization(
         self, config: dict[str, object], *, fix_invalid: bool
     ) -> None:
+        grouped_mode = config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+        if (
+            grouped_mode in TCGEN05_GROUPED_MODES
+            and config.get("num_sm_multiplier", 1) != 1
+        ):
+            if fix_invalid:
+                config.pop("num_sm_multiplier", None)
+            else:
+                raise InvalidConfig(
+                    "tcgen05 grouped kernels require num_sm_multiplier=1"
+                )
         source_m_tile_key = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
         source_m_tile = config.get(source_m_tile_key)
         if source_m_tile_key in config and (
@@ -1219,34 +1257,80 @@ class CuteTcgen05Config:
             and all(config.get(key) is None for key in TCGEN05_LAYOUT_OVERRIDES_KEYS)
         )
 
-    def _grouped_worklist_nm_deep_ab_config_matches(
+    def _grouped_worklist_nm_ab_config_matches(
         self, config: dict[str, object], ab_stages: object
     ) -> bool:
-        block_sizes = config.get("block_sizes")
+        config_view = self._matmul_config_view(config)
+        if config_view is None:
+            block_sizes = config.get("block_sizes")
+            if (
+                self.matmul_block_ids is not None
+                or not isinstance(block_sizes, list)
+                or len(block_sizes) != 3
+            ):
+                return False
+            # Reviewed/AOT configs can be normalized by a standalone ConfigSpec
+            # before compiler MMA analysis registers semantic block IDs.  That
+            # schema is exactly the canonical [M, N, K] triple.  Real kernels
+            # always use the registered semantic indices above, including when
+            # their block-size order is permuted.
+            config_view = (block_sizes, 0, 1, 2)
+        block_sizes, m_index, n_index, k_index = config_view
+        cluster_m = config.get("tcgen05_cluster_m")
+        source_m_tile = config.get(
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        )
+        block_k = block_sizes[k_index]
+        physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
+            cluster_m=cluster_m,
+            block_k=block_k,
+            source_m_tile=source_m_tile,
+        )
         if not (
             type(ab_stages) is int
             and 4 <= ab_stages <= 7
-            and config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
-            == TCGEN05_GROUPED_MODE_WORKLIST_NM
-            and config.get("tcgen05_cluster_m") == 2
+            and physical_shape is not None
             and config.get("tcgen05_cluster_n", 1) == 1
             and config.get("tcgen05_acc_stages", 2) == 2
             and config.get("tcgen05_c_stages", 2) == 2
-            and isinstance(block_sizes, list)
-            and block_sizes[:3] == [TCGEN05_TWO_CTA_BLOCK_M, 128, 64]
+            and block_sizes[m_index] == TCGEN05_TWO_CTA_BLOCK_M
+            and block_sizes[n_index] == 128
         ):
             return False
-        if self.ab_stages_three_search_constraints is None:
+        constraints = self.ab_stages_three_search_constraints
+        if constraints is None:
             # Fixed configs can be normalized before their input device is known.
             # CuTe MMA selection applies the real target's SMEM limit at codegen.
             return True
-        return self.ab_stages_three_fits(
-            bm=block_sizes[0],
-            bn=block_sizes[1],
-            bk=block_sizes[2],
-            cluster_m=2,
-            ab_stages=ab_stages,
+        target_capacity_bytes = (
+            constraints.per_cta_smem_budget_bytes
+            + TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
         )
+        sched_stage_count = config.get(TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY, 1)
+        if type(sched_stage_count) is not int or sched_stage_count <= 0:
+            return False
+        physical_bm, physical_bn = physical_shape
+        # The generic AB search budget reserves 28 KiB, which is deliberately
+        # conservative for general matmuls but would reject the valid
+        # BK64/source-224/AB7 worklist at B200's exact 227-KiB cap. Reconstruct
+        # the raw target cap and account for this path's full ordered allocation.
+        # Use the same conservative ordered allocation as codegen. Current
+        # scheduler modes all round to the same final 1024-byte C-ring boundary.
+        required_bytes = tcgen05_grouped_worklist_smem_bytes(
+            group_count=1,
+            device_split_sizes=False,
+            sched_stage_count=sched_stage_count,
+            bm=physical_bm,
+            bn=physical_bn,
+            bk=cast("int", block_k),
+            dtype_bytes=constraints.dtype_bytes,
+            ab_stages=ab_stages,
+            acc_stages=2,
+            c_stages=2,
+            cluster_m=cast("int", cluster_m),
+        )
+        return required_bytes <= target_capacity_bytes
 
     def grouped_dynamic_stages_fit_for_target(
         self,
@@ -1733,11 +1817,11 @@ class CuteTcgen05Config:
             return
         if self._grouped_dynamic_deep_config_matches(config):
             return
-        if self._grouped_worklist_nm_deep_ab_config_matches(config, ab_stages):
+        if self._grouped_worklist_nm_ab_config_matches(config, ab_stages):
             return
-        # ab>3 is only valid on the TVM-FFI direct-entry path, and only for the
-        # (bk, ab, c) stage tuples the direct-entry codegen accepts (bk=64
-        # admits (ab=6, c=4)). Everything else clamps (or rejects) to ab=3.
+        # After the grouped dynamic/worklist exceptions above, ab>3 is only valid
+        # on the TVM-FFI direct-entry path and for its accepted (bk, ab, c) tuples
+        # (bk=64 admits (ab=6, c=4)). Everything else clamps or rejects to ab=3.
         block_sizes = config.get("block_sizes")
         k_block_index = self._direct_entry_k_block_index()
         bk = (
@@ -2137,7 +2221,20 @@ class CuteTcgen05Config:
         config_view = self._matmul_config_view(config)
         if config_view is None:
             return
-        block_sizes, m_index, _, _ = config_view
+        block_sizes, m_index, n_index, k_index = config_view
+        if (
+            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            and config.get("tcgen05_cluster_n", 1) == 1
+            and block_sizes[m_index] == TCGEN05_TWO_CTA_BLOCK_M
+            and block_sizes[n_index] == 128
+            and block_sizes[k_index] in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+            and config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+            == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+        ):
+            # The logical DSL tile remains 256x128 while the N,M-oriented
+            # collective resolves to a physical 128x32 CtaGroup.ONE MMA.
+            return
         constraints = self.cluster_m2_search_constraints
         if constraints is not None and constraints.allow_edge_k_tail_family:
             # persistent_interleaved stays in the flat enum so cluster_m=2
@@ -2659,7 +2756,7 @@ class CuteTcgen05Config:
                 if key in config:
                     if key == "tcgen05_ab_stages" and (
                         self._grouped_dynamic_deep_config_matches(config)
-                        or self._grouped_worklist_nm_deep_ab_config_matches(
+                        or self._grouped_worklist_nm_ab_config_matches(
                             config,
                             config[key],
                         )

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -497,13 +497,21 @@ TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY = (
 TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY = (
     "tcgen05_grouped_worklist_source_m_tile"
 )
-TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE = 224
+# Compact source rows avoid padding small-M experts to the historical 224-row
+# default while retaining the 32-row granularity of the validated store wave.
+TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE = 32
+TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT = 224
 TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE = 256
 TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES = (64, 128)
 TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES = (
-    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+    TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
     TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
 )
+# N,M orientation maps the packed source-M tile onto the physical MMA-N mode.
+# Keep the role-specific alias so descriptor assertions do not appear to be
+# validating an MMA dimension against an unrelated packing knob.
+TCGEN05_GROUPED_WORKLIST_MMA_N_CHOICES = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
 TCGEN05_GROUPED_WORKLIST_MMA_M_TILE = 256
 TCGEN05_GROUPED_WORKLIST_STORE_SHAPE = (128, 32, 32)
 # The grouped scheduler publishes CTA M/N, validity, metadata/group indices,
@@ -528,3 +536,109 @@ TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY = (
 # CtaGroup.ONE tcgen05 MMA covers 64/128 M tiles; 256 M tiles are validated only
 # after projecting onto the CtaGroup.TWO path.
 TCGEN05_ONE_CTA_MAX_BLOCK_M = 128
+
+
+def resolve_tcgen05_grouped_worklist_mma_shape(
+    *,
+    cluster_m: object,
+    block_k: object,
+    source_m_tile: object,
+) -> tuple[int, int] | None:
+    """Resolve the physical ``(M, N)`` UMMA tile for a worklist profile.
+
+    The public DSL tile remains 256x128 for every grouped N,M worklist.  The
+    physical collective is instead 256x``source_m_tile`` for CtaGroup.TWO, or
+    128x32 for the compact CtaGroup.ONE profile.  Keep this policy shared by
+    MMA selection, codegen, and SMEM validation so logical tile dimensions do
+    not accidentally leak into physical resource accounting.
+    """
+    if (
+        type(cluster_m) is not int
+        or type(block_k) is not int
+        or type(source_m_tile) is not int
+        or block_k not in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+        or source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+    ):
+        return None
+    if cluster_m == 1:
+        if source_m_tile != TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE:
+            return None
+        return TCGEN05_ONE_CTA_MAX_BLOCK_M, source_m_tile
+    if cluster_m == 2:
+        return TCGEN05_GROUPED_WORKLIST_MMA_M_TILE, source_m_tile
+    return None
+
+
+def _append_aligned_tcgen05_smem(offset: int, size: int, alignment: int) -> int:
+    assert offset >= 0 and size >= 0 and alignment > 0
+    return ((offset + alignment - 1) // alignment) * alignment + size
+
+
+def tcgen05_grouped_worklist_smem_bytes(
+    *,
+    group_count: int,
+    device_split_sizes: bool,
+    sched_stage_count: int,
+    bm: int,
+    bn: int,
+    bk: int,
+    dtype_bytes: int,
+    ab_stages: int,
+    acc_stages: int,
+    c_stages: int,
+    cluster_m: int,
+) -> int:
+    """Return the conservative ordered SMEM footprint of an N,M worklist.
+
+    Charge the device-search dynamic-TensorMap allocation, the largest current
+    worklist mode. Runtime-direct and fixed-map modes omit some of these objects,
+    but every validated profile rounds to the same total at the final 1024-byte
+    C-ring alignment. Keeping one allocation model avoids coupling resource
+    admission to scheduler implementation details.
+    Keep allocation ordering synchronized with codegen because alignment padding
+    makes reordering observable at the admission boundary.
+    """
+    assert group_count > 0 and sched_stage_count > 0 and cluster_m in (1, 2)
+    assert bm > 0 and bn > 0 and bk > 0 and dtype_bytes > 0
+    assert ab_stages > 0 and acc_stages > 0 and c_stages > 0
+    a_stage_bytes = bm * bk * dtype_bytes
+    b_stage_bytes = bn * bk * dtype_bytes
+    assert a_stage_bytes % cluster_m == 0
+    assert b_stage_bytes % cluster_m == 0
+
+    offset = 0
+    # Scheduler work-tile mailbox, followed by optional device-derived problem
+    # metadata. Host worklists supply problem sizes and starts from global
+    # wrapper tensors, so they do not allocate either metadata array in SMEM.
+    offset = _append_aligned_tcgen05_smem(
+        offset,
+        TCGEN05_GROUPED_WORKLIST_MAILBOX_FIELD_COUNT * sched_stage_count * 4,
+        16,
+    )
+    if device_split_sizes:
+        offset = _append_aligned_tcgen05_smem(offset, group_count * 4 * 4, 16)
+        offset = _append_aligned_tcgen05_smem(offset, group_count * 4, 16)
+    # TMEM allocator state and accumulator/scheduler pipeline mbarriers.
+    offset = _append_aligned_tcgen05_smem(offset, 4, 4)
+    offset = _append_aligned_tcgen05_smem(offset, 8, 8)
+    offset = _append_aligned_tcgen05_smem(offset, acc_stages * 2 * 8, 8)
+    offset = _append_aligned_tcgen05_smem(offset, sched_stage_count * 2 * 8, 8)
+    # A/B stages, mutable input TensorMaps, and AB barriers.
+    offset = _append_aligned_tcgen05_smem(
+        offset, ab_stages * a_stage_bytes // cluster_m, 128
+    )
+    offset = _append_aligned_tcgen05_smem(
+        offset, ab_stages * b_stage_bytes // cluster_m, 128
+    )
+    # Fixed-TensorMap modes overpay the 384 B below at the 227-KiB boundary.
+    offset = _append_aligned_tcgen05_smem(offset, 2 * 128, 128)
+    offset = _append_aligned_tcgen05_smem(offset, ab_stages * 8, 8)
+    # Mutable output TensorMap and the aligned TMA-store ring.
+    offset = _append_aligned_tcgen05_smem(offset, 128, 128)
+    c_smem_bytes = tcgen05_c_smem_bytes_per_cta(
+        epi_tile_m=TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[0],
+        epi_tile_n=TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[1],
+        dtype_bytes=dtype_bytes,
+        c_stages=c_stages,
+    )
+    return _append_aligned_tcgen05_smem(offset, c_smem_bytes, 1024)

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -53,7 +53,6 @@ from .compile_environment import CompileEnvironment
 from .compile_environment import FixedBlockSizeSource
 from .compile_environment import _symint_expr
 from .compile_environment import _symint_sympy_expr
-from .cute.cutedsl_compat import cute_math_min_max_available
 from .device_function import VarInfo
 from .device_function import contains_only_block_size_symbols
 from .node_masking import inductor_masked_value
@@ -1236,15 +1235,6 @@ class GenerateASTFromInductor(DefaultHandler):
         if dtype is not None:
             a = self._create_cast_expr(a, dtype)
             b = self._create_cast_expr(b, dtype)
-        if not cute_math_min_max_available():
-            return self._lift(
-                expr_from_string(
-                    "{a} if {a} != {a} else "
-                    "({b} if {b} != {b} else ({a} if {a} >= {b} else {b}))",
-                    a=self._to_ast(a),
-                    b=self._to_ast(b),
-                )
-            )
         return self._lift(
             expr_from_string(
                 "cute.math.max({a}, {b}, propagate_nan=True)",
@@ -1260,15 +1250,6 @@ class GenerateASTFromInductor(DefaultHandler):
         if dtype is not None:
             a = self._create_cast_expr(a, dtype)
             b = self._create_cast_expr(b, dtype)
-        if not cute_math_min_max_available():
-            return self._lift(
-                expr_from_string(
-                    "{a} if {a} != {a} else "
-                    "({b} if {b} != {b} else ({a} if {a} <= {b} else {b}))",
-                    a=self._to_ast(a),
-                    b=self._to_ast(b),
-                )
-            )
         return self._lift(
             expr_from_string(
                 "cute.math.min({a}, {b}, propagate_nan=True)",

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -2978,6 +2978,8 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
     def _grouped_worklist_nm_valid_store_m_stmts(
         self,
         device_function: DeviceFunction,
+        *,
+        include_store_m: bool = True,
     ) -> list[ast.stmt]:
         plan = self._tcgen05_plan()
         assert plan is not None and plan.accumulator_view == "nm"
@@ -3005,7 +3007,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             remaining_m = (
                 f"max({grouped.problem_m} - {tile_start_var}, cutlass.Int32(0))"
             )
-            return [
+            stmts = [
                 statement_from_string(
                     f"{tile_start_var} = {grouped_cta_tile_idx_m} * "
                     f"cutlass.Int32({source_tile_m})"
@@ -3014,12 +3016,16 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                     f"{grouped_valid_m} = min(cutlass.Int32({source_tile_m}), "
                     f"{remaining_m})"
                 ),
-                statement_from_string(
-                    f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
-                    f"{remaining_m})"
-                ),
             ]
-        return [
+            if include_store_m:
+                stmts.append(
+                    statement_from_string(
+                        f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
+                        f"{remaining_m})"
+                    )
+                )
+            return stmts
+        stmts = [
             statement_from_string(
                 f"{tile_start_var} = {grouped_cta_tile_idx_m} * "
                 f"cutlass.Int32({source_tile_m})"
@@ -3028,11 +3034,15 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 f"{grouped_valid_m} = min(cutlass.Int32({source_tile_m}), "
                 f"max({metadata_load_expr(2)} - {tile_start_var}, cutlass.Int32(0)))"
             ),
-            statement_from_string(
-                f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
-                f"{metadata_load_expr(3)} - {tile_start_var})"
-            ),
         ]
+        if include_store_m:
+            stmts.append(
+                statement_from_string(
+                    f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
+                    f"{metadata_load_expr(3)} - {tile_start_var})"
+                )
+            )
+        return stmts
 
     def _build_specialized_grouped_static_role_local_while(
         self,
@@ -3457,9 +3467,19 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 sched_consumer_state=sched_consumer_state,
             )
 
+        epi_role = role_block.role_predicate == self._tcgen05_epi_role_predicate()
+        mma_exec_role = (
+            role_block.role_predicate == self._tcgen05_mma_exec_role_predicate()
+        )
+        tma_load_role = (
+            role_block.role_predicate == self._tcgen05_tma_load_role_predicate()
+        )
         grouped_valid_store_m_stmts = (
-            self._grouped_worklist_nm_valid_store_m_stmts(device_function)
-            if role_block.role_predicate == self._tcgen05_epi_role_predicate()
+            self._grouped_worklist_nm_valid_store_m_stmts(
+                device_function,
+                include_store_m=epi_role,
+            )
+            if epi_role or mma_exec_role or tma_load_role
             else []
         )
         mailbox_fields = (

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -428,6 +428,31 @@ class TileStrategyDispatch:
                 axis += strategy.thread_axes_used()
         return None
 
+    def strategies_can_coexecute(
+        self, first: TileStrategy, second: TileStrategy
+    ) -> bool:
+        """Whether two strategies occur in at least one common execution branch."""
+        return any(
+            first in branch and second in branch for branch in self._strategy_branches()
+        )
+
+    def executable_reduction_block_ids(self) -> set[int]:
+        """Reduction block IDs that correspond to executable reduction work."""
+        spec = CompileEnvironment.current().config_spec
+        block_ids = set(spec.reduction_loops.valid_block_ids())
+        if spec.reduction_kernel_fact is not None:
+            block_ids.update(
+                reduction.block_id
+                for reduction in spec.reduction_kernel_fact.reductions
+            )
+        if spec.kernel_matmul_fact is not None:
+            block_ids.update(
+                matmul.fact.k_block_id
+                for matmul in spec.kernel_matmul_fact.matmuls
+                if matmul.fact.k_block_id is not None
+            )
+        return block_ids
+
     def thread_axis_for_block_id(self, target_block_id: int) -> int | None:
         """Return the launch thread axis assigned to a specific logical block id."""
         for strategy in self.strategies:

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -2460,7 +2460,33 @@ class BlockSizeTileStrategy(TileStrategy):
         reserved_reduction_axes = max(
             1 if has_reduction_strategy else 0, active_reduction_axes
         )
-        return reserved_reduction_axes + active_non_reduction_axes
+        offset = reserved_reduction_axes + active_non_reduction_axes
+        tile_axes = set(range(offset, offset + self.thread_axes_used()))
+        executable_reductions = self.fn.tile_strategy.executable_reduction_block_ids()
+        for strategy in self.fn.tile_strategy.strategies:
+            if not isinstance(strategy, ReductionStrategy):
+                continue
+            if strategy.block_index not in executable_reductions:
+                continue
+            if not self.fn.tile_strategy.strategies_can_coexecute(self, strategy):
+                continue
+            if not any(size > 1 for size in strategy.thread_block_sizes()):
+                continue
+            reduction_axis = self.fn.tile_strategy.thread_axis_for_strategy(strategy)
+            if reduction_axis is None:
+                continue
+            reduction_axes = set(
+                range(reduction_axis, reduction_axis + strategy.thread_axes_used())
+            )
+            if collision := tile_axes & reduction_axes:
+                axes = ", ".join(map(str, sorted(collision)))
+                raise exc.BackendUnsupported(
+                    env.backend.name,
+                    "thread-axis collision: tile blocks "
+                    f"{self.block_ids} and executable reduction block "
+                    f"{strategy.block_index} both require axis {axes}",
+                )
+        return offset
 
     def select_pid_strategy(self) -> ProgramIDs:
         env = CompileEnvironment.current()

--- a/helion/exc.py
+++ b/helion/exc.py
@@ -321,7 +321,7 @@ class MissingEnableTile(BaseError):
 class CuteBackendUnavailable(BaseError):
     message = (
         "The 'cute' backend cannot run in this environment: {0}\n"
-        "The cute backend requires nvidia-cutlass-dsl >= 4.5.1, the "
+        "The cute backend requires nvidia-cutlass-dsl >= 4.7.0, the "
         "apache-tvm-ffi package, and CUDA >= 13."
     )
 

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -1779,6 +1779,15 @@ def _codegen_cute_store_tcgen05_tile(
         if segment_store
         else ""
     )
+    matmul_plan = df.cute_state.matmul_plan
+    segment_grouped = (
+        matmul_plan.grouped if segment_store and matmul_plan is not None else None
+    )
+    grouped_fixed_d_tensormap = (
+        segment_store
+        and segment_grouped is not None
+        and segment_grouped.fixed_tensormaps
+    )
     tcgen05_source_bm = tcgen05_value.source_tile_m
     tcgen05_source_bn = tcgen05_value.source_tile_n
     tile_coord_m = (
@@ -3328,11 +3337,9 @@ def _codegen_cute_store_tcgen05_tile(
             f"({final_expr}).to({target_dtype})",
         )
 
-    grouped_tma_plan = (
-        df.cute_state.matmul_plan if (grouped_tail_epilogue or segment_store) else None
-    )
+    grouped_tma_plan = matmul_plan if grouped_tail_epilogue or segment_store else None
     grouped_tma = grouped_tma_plan.grouped if grouped_tma_plan is not None else None
-    d_tma_uses_rank3_mnl_tensor = (
+    d_tma_uses_rank3_mnl_tensor = grouped_fixed_d_tensormap or (
         grouped_tma is not None
         and grouped_tma.d_mode is not Tcgen05GroupedDMode.NONE
         and grouped_tma.d_tensormap is not None
@@ -3389,6 +3396,7 @@ def _codegen_cute_store_tcgen05_tile(
                 tcgen05_value.tma_store_tensor,
             ],
             **({"orientation": "nm"} if tcgen05_nm_store else {}),
+            **({"fixed_tensormap": True} if grouped_fixed_d_tensormap else {}),
             **({"rank3_mnl_tensor": True} if d_tma_uses_rank3_mnl_tensor else {}),
             **(
                 {
@@ -3459,10 +3467,7 @@ def _codegen_cute_store_tcgen05_tile(
         if segment_store
         else f"({m_index}) + cutlass.Int32({tcgen05_source_bm}) <= {m_size} "
     ) + f"and ({n_index}) + cutlass.Int32({tcgen05_source_bn}) <= {n_size}"
-    grouped_tail_plan = (
-        df.cute_state.matmul_plan if (grouped_tail_epilogue or segment_store) else None
-    )
-    grouped_tail = grouped_tail_plan.grouped if grouped_tail_plan is not None else None
+    grouped_tail = grouped_tma
     grouped_tail_store = (
         grouped_tail is not None
         and bool(grouped_tail.global_m_start)
@@ -3648,16 +3653,24 @@ def _codegen_cute_store_tcgen05_tile(
             in (tcgen05_aux_tma_store_tensor, tcgen05_aux_tail_tma_store_tensor)
             and rank3_mnl_tensor
         ):
-            source_coord_m = (
-                grouped_tail_cta_tile_idx_m
-                if dynamic_d_tensormap
-                else static_tile_coord_m
-            )
-            source_coord_n = (
-                grouped_tail_cta_tile_idx_n
-                if dynamic_d_tensormap
-                else static_tile_coord_n
-            )
+            if grouped_fixed_d_tensormap:
+                source_coord_m = (
+                    f"{grouped_tail_global_m_start} // "
+                    f"cutlass.Int32({tcgen05_source_bm}) + "
+                    f"{grouped_tail_cta_tile_idx_m}"
+                )
+                source_coord_n = grouped_tail_cta_tile_idx_n
+            else:
+                source_coord_m = (
+                    grouped_tail_cta_tile_idx_m
+                    if dynamic_d_tensormap
+                    else static_tile_coord_m
+                )
+                source_coord_n = (
+                    grouped_tail_cta_tile_idx_n
+                    if dynamic_d_tensormap
+                    else static_tile_coord_n
+                )
             if tcgen05_nm_store:
                 coord_m = source_coord_n
                 coord_n = source_coord_m
@@ -4706,9 +4719,13 @@ def _codegen_cute_store_tcgen05_tile(
         )
         carrier = trs_racc
         store_target = trs_rd
+        worklist_nm_identity_store = bool(
+            worklist_nm_segment_valid_m_bound
+            and (epilogue_chain is None or not epilogue_chain.steps)
+        )
         early_aux_prelude, late_prelude, rhs = _splice_acc_vec(
             carrier,
-            "        ",
+            "            " if worklist_nm_identity_store else "        ",
             safe_direct_aux_with_full_tile=partial_tma_needs_full_tile_guard,
             coord_layout="trs",
         )
@@ -4729,16 +4746,45 @@ def _codegen_cute_store_tcgen05_tile(
         pre_wait_aux = (
             tcgen05_aux_load_placement == TCGEN05_AUX_LOAD_PLACEMENT_PRE_ACC_WAIT
         )
+        if worklist_nm_identity_store:
+            # Identity-store means the epilogue chain is empty, so
+            # ``_splice_acc_vec`` returns no auxiliary-load prelude by
+            # construction.
+            # The generated worklist clamps valid_m to source_tile_m.  Almost
+            # every scheduled tile therefore needs no padding fixup at all.
+            # Keep the existing coordinate-derived predicate only in the
+            # uniform tail branch; this removes identity-tensor partitioning,
+            # predicate construction, and cute.where from full output tiles.
+            full_acc_vec = df.new_var("tcgen05_full_acc_vec")
+            tail_acc_vec = df.new_var("tcgen05_tail_acc_vec")
+            branch_acc_release = textwrap.indent(acc_release, "    ")
+            store_source = (
+                f"        if {worklist_nm_segment_valid_m_bound} == "
+                f"cutlass.Int32({tcgen05_source_bm}):\n"
+                f"            {full_acc_vec} = "
+                f"({carrier}.load()).to({target_dtype})\n"
+                f"{branch_acc_release}"
+                f"            {store_target}.store({full_acc_vec})\n"
+                f"        else:\n"
+                f"{late_prelude}"
+                f"            {tail_acc_vec} = {rhs}\n"
+                f"{branch_acc_release}"
+                f"            {store_target}.store({tail_acc_vec})\n"
+            )
+        else:
+            store_source = (
+                f"{'' if pre_wait_aux else early_aux_prelude}"
+                f"{late_prelude}"
+                f"        {acc_vec} = {rhs}\n"
+                f"{acc_release}"
+                f"        {store_target}.store({acc_vec})\n"
+            )
         return (
             f"{early_aux_prelude if pre_wait_aux else ''}"
             f"{acc_wait}"
             f"        {ttr_tacc_mn} = {ttr_tacc}[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
             f"        cute.copy({tiled_copy_t2r}, {ttr_tacc_mn}, {ttr_racc})\n"
-            f"{'' if pre_wait_aux else early_aux_prelude}"
-            f"{late_prelude}"
-            f"        {acc_vec} = {rhs}\n"
-            f"{acc_release}"
-            f"        {store_target}.store({acc_vec})\n"
+            f"{store_source}"
         )
 
     def tma_store_tail_params(

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -40,7 +40,6 @@ from ..._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
 )
 from ..._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
-from ..._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
 from ..._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES,
 )
@@ -203,12 +202,17 @@ def _tcgen05_grouped_dynamic_ab_tensormap_rank(plan: dict[str, object]) -> int:
     if (
         not isinstance(rank, int)
         or rank not in (2, 3)
-        or (rank == 2 and not bool(plan.get("dynamic_ab_tensormaps")))
+        or (
+            rank == 2
+            and not bool(plan.get("dynamic_ab_tensormaps"))
+            and not bool(plan.get("fixed_ab_tensormaps"))
+            and not bool(plan.get("fixed_tensormaps"))
+        )
     ):
         raise exc.BackendUnsupported(
             "cute",
-            "tcgen05 grouped dynamic A/B TensorMap rank must be 2 or 3, "
-            "and rank 2 requires dynamic A/B TensorMaps",
+            "tcgen05 grouped A/B TensorMap rank must be 2 or 3, and rank 2 "
+            "requires dynamic or fixed full-allocation A/B TensorMaps",
         )
     return rank
 
@@ -760,6 +764,7 @@ def _append_cute_wrapper_plan(
     smem_swizzle_b: int | None = (
         int(smem_swizzle_b_raw) if isinstance(smem_swizzle_b_raw, int) else None
     )
+    a_k_major = bool(plan.get("a_k_major", True))
     # K-major (column-major / K-contiguous) B. Absent on the MN-major
     # (row-major B) default path.
     b_k_major = bool(plan.get("b_k_major"))
@@ -770,13 +775,27 @@ def _append_cute_wrapper_plan(
     orientation = _tcgen05_plan_orientation(plan)
     swapped_nm = orientation == "nm"
     dynamic_ab_tensormaps = bool(plan.get("dynamic_ab_tensormaps"))
-    if swapped_nm and not dynamic_ab_tensormaps:
+    fixed_ab_tensormaps = bool(plan.get("fixed_ab_tensormaps"))
+    fixed_grouped_b_rank3 = bool(plan.get("fixed_grouped_b_rank3"))
+    if fixed_grouped_b_rank3 and not fixed_ab_tensormaps:
+        raise exc.BackendUnsupported(
+            "cute", "rank-3 immutable grouped B requires fixed A/B TensorMaps"
+        )
+    if fixed_ab_tensormaps and (not swapped_nm or dynamic_ab_tensormaps):
         raise exc.BackendUnsupported(
             "cute",
-            "tcgen05 N,M-oriented A/B TensorMaps without dynamic A/B "
-            "TensorMaps are unsupported",
+            "fixed full-allocation A/B TensorMaps require the N,M worklist "
+            "orientation and cannot also be dynamic",
         )
-    dynamic_ab_tensormap_rank2 = _tcgen05_grouped_dynamic_ab_tensormap_rank(plan) == 2
+    if swapped_nm and not (dynamic_ab_tensormaps or fixed_ab_tensormaps):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 N,M-oriented A/B TensorMaps require dynamic per-group or "
+            "fixed full-allocation descriptors",
+        )
+    dynamic_ab_tensormap_rank2 = (
+        dynamic_ab_tensormaps and _tcgen05_grouped_dynamic_ab_tensormap_rank(plan) == 2
+    )
     kernel_args = [str(arg) for arg in cast("list[object]", plan["kernel_args"])]
     assert len(kernel_args) == 4
     tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b = kernel_args
@@ -812,7 +831,12 @@ def _append_cute_wrapper_plan(
     lhs_tma = f"{tma_atom_a}_lhs_tma"
     lhs_tma_arg = (
         lhs_tma
-        if (dynamic_ab_tensormaps or swapped_nm or lhs_tma_order is not None)
+        if (
+            dynamic_ab_tensormaps
+            or fixed_ab_tensormaps
+            or swapped_nm
+            or lhs_tma_order is not None
+        )
         else f"arg{lhs_idx}"
     )
     rhs_tma = f"{tma_atom_b}_rhs_tma"
@@ -822,7 +846,23 @@ def _append_cute_wrapper_plan(
                 "cute",
                 "tcgen05 N,M-oriented A/B TensorMaps require grouped rank-3 logical A",
             )
-        if dynamic_ab_tensormap_rank2:
+        if fixed_ab_tensormaps:
+            if fixed_grouped_b_rank3:
+                lhs_tma_layout = (
+                    f"(arg{lhs_idx}_shape1, arg{lhs_idx}_shape2, "
+                    f"arg{lhs_idx}_shape0), "
+                    f"stride=(arg{lhs_idx}_stride1, arg{lhs_idx}_stride2, "
+                    f"arg{lhs_idx}_stride0)"
+                )
+            else:
+                # K-major grouped B can flatten to one immutable [G*N,K]
+                # allocation. Device coordinates add the group base.
+                lhs_tma_layout = (
+                    f"(arg{lhs_idx}_shape0 * arg{lhs_idx}_shape1, "
+                    f"arg{lhs_idx}_shape2), stride=(arg{lhs_idx}_stride1, "
+                    f"arg{lhs_idx}_stride2)"
+                )
+        elif dynamic_ab_tensormap_rank2:
             lhs_tma_layout = (
                 f"(arg{lhs_idx}_shape1, arg{lhs_idx}_shape2), "
                 f"stride=(arg{lhs_idx}_stride1, arg{lhs_idx}_stride2)"
@@ -834,7 +874,11 @@ def _append_cute_wrapper_plan(
                 f"stride=(arg{lhs_idx}_stride1, arg{lhs_idx}_stride2, "
                 f"arg{lhs_idx}_stride0)"
             )
-        if dynamic_ab_tensormap_rank2 or not dynamic_ab_tensormaps:
+        if (
+            fixed_ab_tensormaps
+            or dynamic_ab_tensormap_rank2
+            or not dynamic_ab_tensormaps
+        ):
             rhs_tma_layout = (
                 f"(arg{rhs_idx}_shape0, arg{rhs_idx}_shape1), "
                 f"stride=(arg{rhs_idx}_stride0, arg{rhs_idx}_stride1)"
@@ -913,6 +957,7 @@ def _append_cute_wrapper_plan(
         num_stages=ab_stage_count,
         operand="a",
         swizzle_override=smem_swizzle_a,
+        k_major=a_k_major,
     )
     smem_b_layout_expr = tcgen05_smem_layout_expr(
         tiled_mma=tiled_mma,
@@ -923,7 +968,7 @@ def _append_cute_wrapper_plan(
         num_stages=ab_stage_count,
         operand="b",
         swizzle_override=smem_swizzle_b,
-        b_k_major=b_k_major,
+        k_major=b_k_major,
     )
     if lhs_tma_order is not None:
         append_permuted_cute_tensor_view(lhs_tma, lhs_idx, lhs_tma_order)
@@ -937,7 +982,11 @@ def _append_cute_wrapper_plan(
                 f"    {tiled_mma} = cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
                 f"{input_dtype}, "
                 f"{input_dtype}, "
-                "cute.nvgpu.OperandMajorMode.K, "
+                + (
+                    "cute.nvgpu.OperandMajorMode.K, "
+                    if a_k_major
+                    else "cute.nvgpu.OperandMajorMode.MN, "
+                )
                 + (
                     "cute.nvgpu.OperandMajorMode.K, "
                     if b_k_major
@@ -2252,10 +2301,12 @@ def _tcgen05_grouped_device_split_total_clusters(
     m_size = _plan_int_value(plan, "m_size")
     n_size = _plan_int_value(plan, "n_size")
     source_m_tile = _plan_int_value(plan, "source_m_tile")
+    physical_mma_m = _plan_int_value(plan, "bm")
     if (
         group_count <= 0
         or m_size <= 0
         or n_size <= 0
+        or physical_mma_m <= 0
         or source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
     ):
         raise exc.BackendUnsupported(
@@ -2263,9 +2314,7 @@ def _tcgen05_grouped_device_split_total_clusters(
             "tcgen05 grouped device split_sizes requires positive G, M, and N "
             "and a validated source M tile",
         )
-    n_clusters = (
-        n_size + TCGEN05_GROUPED_WORKLIST_MMA_M_TILE - 1
-    ) // TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
+    n_clusters = (n_size + physical_mma_m - 1) // physical_mma_m
     packed_m_clusters = (m_size + source_m_tile - 1) // source_m_tile
     total_clusters = n_clusters * group_count * packed_m_clusters
     if total_clusters > torch.iinfo(torch.int32).max:
@@ -2614,10 +2663,22 @@ def _validate_tcgen05_grouped_dynamic_ab_tensormaps(
             "cute",
             "tcgen05 grouped dynamic A/B TensorMaps require K-contiguous A",
         )
-    if rhs.stride(2) != 1:
+    rhs_k_contiguous = rhs.stride(2) == 1
+    rhs_mn_contiguous = (
+        rhs.stride(1) == 1
+        and rhs.stride(2) == rhs.size(1)
+        and rhs.stride(0) == rhs.size(1) * rhs.size(2)
+    )
+    if rhs_mn_contiguous and _tcgen05_plan_orientation(plan) != "nm":
         raise exc.BackendUnsupported(
             "cute",
-            "tcgen05 grouped dynamic A/B TensorMaps require K-contiguous grouped B",
+            "MN-major grouped B is validated only for the N,M worklist path",
+        )
+    if not (rhs_k_contiguous or rhs_mn_contiguous):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped dynamic A/B TensorMaps require contiguous K-major "
+            "or MN-major grouped B",
         )
     if rank == 2:
         if lhs.stride(0) != lhs.size(1):
@@ -2626,7 +2687,14 @@ def _validate_tcgen05_grouped_dynamic_ab_tensormaps(
                 "tcgen05 grouped rank-2 dynamic A/B TensorMaps require "
                 "contiguous A[M,K] outer stride",
             )
-        if rhs.stride(1) != rhs.size(2) or rhs.stride(0) != rhs.size(1) * rhs.size(2):
+        if not (
+            (
+                rhs_k_contiguous
+                and rhs.stride(1) == rhs.size(2)
+                and rhs.stride(0) == rhs.size(1) * rhs.size(2)
+            )
+            or rhs_mn_contiguous
+        ):
             raise exc.BackendUnsupported(
                 "cute",
                 "tcgen05 grouped rank-2 dynamic A/B TensorMaps require "
@@ -2635,18 +2703,109 @@ def _validate_tcgen05_grouped_dynamic_ab_tensormaps(
     alignment = 16
     lhs_stride0_bytes = int(lhs.stride(0)) * lhs.element_size()
     rhs_stride0_bytes = int(rhs.stride(0)) * rhs.element_size()
-    rhs_stride1_bytes = int(rhs.stride(1)) * rhs.element_size()
+    rhs_outer_matrix_stride_bytes = (
+        int(rhs.stride(1) if rhs_k_contiguous else rhs.stride(2)) * rhs.element_size()
+    )
     if (
         int(lhs.data_ptr()) % alignment != 0
         or int(rhs.data_ptr()) % alignment != 0
         or lhs_stride0_bytes % alignment != 0
         or rhs_stride0_bytes % alignment != 0
-        or rhs_stride1_bytes % alignment != 0
+        or rhs_outer_matrix_stride_bytes % alignment != 0
     ):
         raise exc.BackendUnsupported(
             "cute",
             "tcgen05 grouped dynamic A/B TensorMaps require 16-byte-aligned "
             "A/B bases and outer strides",
+        )
+
+
+def _validate_tcgen05_grouped_fixed_tensormaps(
+    cute_kernel: object,
+    plan: dict[str, object],
+    args: tuple[object, ...],
+) -> None:
+    """Validate the immutable full-allocation worklist TensorMap envelope."""
+    if not bool(plan.get("fixed_tensormaps")):
+        return
+    if (
+        _tcgen05_plan_orientation(plan) != "nm"
+        or not bool(plan.get("worklist_metadata"))
+        or _tcgen05_grouped_device_split_sizes(plan)
+        or bool(plan.get("dynamic_ab_tensormaps"))
+        or bool(plan.get("dynamic_d_tensormap"))
+        or _tcgen05_grouped_dynamic_ab_tensormap_rank(plan) != 2
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "fixed full-allocation TensorMaps require a host N,M worklist with "
+            "rank-2 immutable A/B/D descriptors",
+        )
+    _validate_tcgen05_grouped_dynamic_ab_tensormaps(plan, args)
+    lhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A")
+    rhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B")
+    n_size = _plan_int_value(plan, "n_size")
+    k_total_size = _plan_int_value(plan, "k_total_size")
+    bk = _plan_int_value(plan, "bk")
+    physical_mma_m = _plan_int_value(plan, "bm")
+    if (
+        lhs.dtype is not torch.bfloat16
+        or rhs.dtype is not torch.bfloat16
+        or int(lhs.size(1)) != k_total_size
+        or int(rhs.size(1)) != n_size
+        or int(rhs.size(2)) != k_total_size
+        or physical_mma_m not in (128, 256)
+        or n_size % physical_mma_m != 0
+        or k_total_size % bk != 0
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "fixed full-allocation TensorMaps require contiguous BF16 "
+            "A[Mtotal,K] and B[G,N,K], N divisible by the physical MMA-M "
+            "tile, and K divisible by block_k",
+        )
+
+    d_plans = [
+        cast("dict[str, object]", candidate)
+        for candidate in getattr(
+            cast("Any", cute_kernel), "_helion_cute_wrapper_plans", ()
+        )
+        if cast("dict[str, object]", candidate).get("kind") == "tcgen05_d_tma"
+        and bool(cast("dict[str, object]", candidate).get("fixed_tensormap"))
+    ]
+    if len(d_plans) != 1:
+        raise exc.BackendUnsupported(
+            "cute",
+            "fixed full-allocation TensorMaps require exactly one packed D "
+            "TensorMap wrapper plan",
+        )
+    d_idx = d_plans[0].get("d_idx")
+    if not isinstance(d_idx, int) or d_idx >= len(args):
+        raise exc.BackendUnsupported(
+            "cute", "fixed full-allocation D TensorMap argument is missing"
+        )
+    output = args[d_idx]
+    if not isinstance(output, torch.Tensor):
+        raise exc.BackendUnsupported(
+            "cute", "fixed full-allocation D TensorMap argument must be a tensor"
+        )
+    if (
+        output.device.type != "cuda"
+        or output.dtype is not torch.bfloat16
+        or output.ndim != 2
+        or tuple(int(size) for size in output.shape) != (int(lhs.size(0)), n_size)
+        or tuple(int(stride) for stride in output.stride()) != (n_size, 1)
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "fixed full-allocation TensorMaps require contiguous BF16 "
+            "D[Mtotal,N] matching packed A and grouped B",
+        )
+    alignment = 16
+    if int(output.data_ptr()) % alignment != 0:
+        raise exc.BackendUnsupported(
+            "cute",
+            "fixed full-allocation TensorMaps require a 16-byte-aligned D base",
         )
 
 
@@ -2880,6 +3039,7 @@ def _build_tcgen05_grouped_static_metadata(
 ) -> _Tcgen05GroupedStaticMetadataCacheEntry:
     layout = _tcgen05_grouped_static_layout_arg(plan, args)
     _validate_tcgen05_grouped_tensor_devices(layout, args)
+    _validate_tcgen05_grouped_fixed_tensormaps(cute_kernel, plan, args)
     n_sizes_arg = _tcgen05_grouped_static_size_arg(plan, args, "n_sizes")
     k_sizes_arg = _tcgen05_grouped_static_size_arg(plan, args, "k_sizes")
     cache_key = _tcgen05_grouped_static_metadata_cache_key(
@@ -2925,13 +3085,14 @@ def _build_tcgen05_grouped_static_metadata(
                 "cute",
                 "tcgen05 N,M worklist scheduler requires a validated source M tile",
             )
-        scheduler_bm = TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
+        scheduler_bm = bm
         scheduler_bn = worklist_m_tile
     else:
         worklist_m_tile = scheduler_bm = bm
         scheduler_bn = bn
     dynamic_ab_tensormaps = bool(plan.get("dynamic_ab_tensormaps"))
     dynamic_d_tensormap = bool(plan.get("dynamic_d_tensormap"))
+    fixed_tensormaps = bool(plan.get("fixed_tensormaps"))
     direct_pointer_metadata = bool(plan.get("direct_pointer_metadata"))
     external_direct_metadata = _tcgen05_grouped_external_direct_metadata_args(
         plan,
@@ -2988,15 +3149,25 @@ def _build_tcgen05_grouped_static_metadata(
             "tcgen05 grouped scheduler requires common N/K dimensions divisible "
             "by the CTA tile",
         )
-    if worklist_nm and (
-        not dynamic_ab_tensormaps
-        or _tcgen05_grouped_dynamic_ab_tensormap_rank(plan) != 2
-        or not dynamic_d_tensormap
+    if worklist_nm and not (
+        (
+            dynamic_ab_tensormaps
+            and _tcgen05_grouped_dynamic_ab_tensormap_rank(plan) == 2
+            and dynamic_d_tensormap
+            and not fixed_tensormaps
+        )
+        or (
+            fixed_tensormaps
+            and not dynamic_ab_tensormaps
+            and not dynamic_d_tensormap
+            and _tcgen05_grouped_dynamic_ab_tensormap_rank(plan) == 2
+        )
     ):
         raise exc.BackendUnsupported(
             "cute",
-            "tcgen05 N,M worklist metadata requires rank-2 dynamic "
-            "A/B TensorMaps and a dynamic D TensorMap",
+            "tcgen05 N,M worklist metadata requires either rank-2 dynamic "
+            "per-group A/B/D TensorMaps or fixed full-allocation A/B/D "
+            "TensorMaps",
         )
     n_sizes_values: list[int] | None = None
     if n_sizes_arg is not None:

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -19,6 +19,12 @@ from helion._compiler.backend import PallasBackend
 from helion._compiler.backend import TritonBackend
 from helion._compiler.compile_environment import CompileEnvironment
 from helion._compiler.cute.tcgen05_config import Tcgen05AbStagesThreeSearchConstraints
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES,
+)
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DIRECT
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
@@ -34,7 +40,19 @@ from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX,
 )
 from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES,
+)
+from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY,
@@ -43,6 +61,10 @@ from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_SCHED_CONSUMER_WAIT_MODE_WARP_LEADER,
 )
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
+from helion._compiler.cute.tcgen05_constants import (
+    resolve_tcgen05_grouped_worklist_mma_shape,
+)
+from helion._compiler.cute.tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
 from helion._testing import TestCase
 from helion._testing import onlyBackends
 from helion._testing import skipIfXPU
@@ -1003,6 +1025,28 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             )
         return spec
 
+    @staticmethod
+    def _make_permuted_cute_tcgen05_spec():
+        from helion._compiler.backend import CuteBackend
+        from helion.autotuner.config_spec import BlockSizeSpec
+        from helion.autotuner.config_spec import ConfigSpec
+
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.cute_tcgen05_search_enabled = True
+        for block_id, max_size in enumerate((256, 128, 256)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=4096, max_size=max_size)
+            )
+        spec.register_cute_tcgen05_mma_analysis(
+            m_block_id=2,
+            n_block_id=0,
+            k_block_id=1,
+            input_dtype=torch.bfloat16,
+            has_leading_passthrough=False,
+            explicit_epi_tile_compatible=True,
+        )
+        return spec
+
     def test_grouped_static_seed_representation(self) -> None:
         from helion.autotuner.config_generation import ConfigGeneration
 
@@ -1035,17 +1079,23 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
 
     def test_grouped_worklist_source_tile_normalization(self) -> None:
         spec = self._make_cute_tcgen05_spec()
-        config = helion.Config(
-            block_sizes=[256, 128, 128],
-            pid_type="persistent_interleaved",
-            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-            tcgen05_grouped_worklist_source_m_tile=256,
-        )
-        spec.normalize(config)
         self.assertEqual(
-            config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY],
-            256,
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES[0],
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
         )
+        for source_m_tile in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES:
+            with self.subTest(source_m_tile=source_m_tile):
+                config = helion.Config(
+                    block_sizes=[256, 128, 128],
+                    pid_type="persistent_interleaved",
+                    tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                    tcgen05_grouped_worklist_source_m_tile=source_m_tile,
+                )
+                spec.normalize(config)
+                self.assertEqual(
+                    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY],
+                    source_m_tile,
+                )
 
         for invalid_value in (256.0, True, 225):
             wrong_type_config = helion.Config(
@@ -1081,7 +1131,9 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             block_sizes=[256, 128, 128],
             pid_type="persistent_interleaved",
             tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-            tcgen05_grouped_worklist_source_m_tile=256,
+            tcgen05_grouped_worklist_source_m_tile=(
+                TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+            ),
         )
         spec.compiler_seed_configs = [seed]
 
@@ -1089,14 +1141,109 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         [(flat, normalized)] = generation.seed_flat_config_pairs()
         self.assertEqual(
             normalized.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY],
-            256,
+            TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
         )
         generation.encode_config(flat)
         round_trip = generation.unflatten(flat)
         self.assertEqual(
             round_trip.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY],
-            256,
+            TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
         )
+
+    def test_grouped_worklist_one_cta_accepts_bk128_ab5(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+        config = helion.Config(
+            block_sizes=[256, 128, 128],
+            num_stages=7,
+            num_warps=8,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=1,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=5,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_consumer_regs=256,
+            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            tcgen05_grouped_worklist_source_m_tile=(
+                TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+            ),
+        )
+
+        spec.normalize(config)
+
+        self.assertEqual(config.block_sizes[:3], [256, 128, 128])
+        self.assertEqual(config.config["tcgen05_ab_stages"], 5)
+        self.assertEqual(config.config["tcgen05_consumer_regs"], 256)
+
+    def test_grouped_worklist_two_cta_fix_preserves_logical_tile(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+        spec.register_cute_tcgen05_mma_analysis(
+            m_block_id=0,
+            n_block_id=1,
+            k_block_id=2,
+            input_dtype=torch.bfloat16,
+            has_leading_passthrough=False,
+            explicit_epi_tile_compatible=True,
+        )
+        spec.allow_tcgen05_cluster_m2_search(static_k=128)
+        for source_m_tile in (
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+        ):
+            for block_k in (64, 128):
+                config = helion.Config(
+                    block_sizes=[256, 128, block_k],
+                    pid_type="persistent_interleaved",
+                    tcgen05_cluster_m=2,
+                    tcgen05_cluster_n=1,
+                    tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                    tcgen05_grouped_worklist_source_m_tile=source_m_tile,
+                )
+                spec.normalize(config, _fix_invalid=True)
+                self.assertEqual(config.block_sizes[:3], [256, 128, block_k])
+                self.assertEqual(config.config["tcgen05_cluster_m"], 2)
+                self.assertEqual(config.config["pid_type"], "persistent_interleaved")
+
+    def test_grouped_worklist_cluster_m1_fix_uses_semantic_axes(self) -> None:
+        spec = self._make_permuted_cute_tcgen05_spec()
+        config = helion.Config(
+            block_sizes=[128, 64, 256],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=1,
+            tcgen05_cluster_n=1,
+            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            tcgen05_grouped_worklist_source_m_tile=32,
+        )
+        spec._cute_tcgen05_config.fix_search_config(config.config)
+        self.assertEqual(config.block_sizes, [128, 64, 256])
+        self.assertEqual(config.config["tcgen05_cluster_m"], 1)
+
+    def test_grouped_worklist_deep_ab_uses_semantic_axes(self) -> None:
+        spec = self._make_permuted_cute_tcgen05_spec()
+        config = helion.Config(
+            block_sizes=[128, 128, 256],
+            num_stages=7,
+            num_warps=8,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=1,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=5,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_consumer_regs=256,
+            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            tcgen05_grouped_worklist_source_m_tile=32,
+        )
+        spec.normalize(config)
+        self.assertEqual(config.block_sizes, [128, 128, 256])
+        self.assertEqual(config.config["tcgen05_ab_stages"], 5)
+
+        positional_decoy = helion.Config.from_dict(config.config)
+        positional_decoy.config["block_sizes"] = [256, 128, 64]
+        with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
+            spec.normalize(positional_decoy)
 
     def test_tcgen05_search_fields_do_not_leak_to_other_backends(self) -> None:
         from helion._compiler.backend import MetalBackend
@@ -1256,6 +1403,24 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                 repaired.config,
             )
 
+    def test_grouped_rejects_num_sm_multiplier(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+
+        def make_config() -> helion.Config:
+            return helion.Config(
+                block_sizes=[256, 128, 64],
+                num_sm_multiplier=2,
+                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            )
+
+        with self.assertRaisesRegex(exc.InvalidConfig, "num_sm_multiplier=1"):
+            spec.normalize(make_config())
+
+        repaired = make_config()
+        spec.normalize(repaired, _fix_invalid=True)
+        self.assertNotIn("num_sm_multiplier", repaired.config)
+
     def test_grouped_static_problem_signature_envelope(self) -> None:
         spec = self._make_cute_tcgen05_spec()
         key = TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY
@@ -1391,6 +1556,71 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         )
         with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
             constrained_spec.normalize(selected_config())
+
+    def test_grouped_worklist_two_cta_deep_ab_uses_conservative_smem_capacity(
+        self,
+    ) -> None:
+        def selected_config(source_m_tile: int, ab_stages: int) -> helion.Config:
+            return helion.Config(
+                block_sizes=[256, 128, 64],
+                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+                tcgen05_cluster_m=2,
+                tcgen05_ab_stages=ab_stages,
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                tcgen05_grouped_worklist_source_m_tile=source_m_tile,
+            )
+
+        b200_capacity_bytes = TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN
+        constrained_budget_bytes = (
+            b200_capacity_bytes - TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
+        )
+        cases = (
+            (TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT, 7, True, 232_448),
+            (TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE, 6, True, 214_016),
+            (TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE, 7, False, 246_784),
+        )
+        for source_m_tile, ab_stages, should_fit, required_bytes in cases:
+            with self.subTest(
+                source_m_tile=source_m_tile,
+                ab_stages=ab_stages,
+                should_fit=should_fit,
+            ):
+                physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
+                    cluster_m=2,
+                    block_k=64,
+                    source_m_tile=source_m_tile,
+                )
+                self.assertEqual(physical_shape, (256, source_m_tile))
+                assert physical_shape is not None
+                self.assertEqual(
+                    tcgen05_grouped_worklist_smem_bytes(
+                        group_count=1,
+                        device_split_sizes=False,
+                        sched_stage_count=1,
+                        bm=physical_shape[0],
+                        bn=physical_shape[1],
+                        bk=64,
+                        dtype_bytes=2,
+                        ab_stages=ab_stages,
+                        acc_stages=2,
+                        c_stages=2,
+                        cluster_m=2,
+                    ),
+                    required_bytes,
+                )
+
+                spec = self._make_cute_tcgen05_spec()
+                spec._cute_tcgen05_config.ab_stages_three_search_constraints = (
+                    Tcgen05AbStagesThreeSearchConstraints(
+                        dtype_bytes=2,
+                        per_cta_smem_budget_bytes=constrained_budget_bytes,
+                    )
+                )
+                if should_fit:
+                    spec.normalize(selected_config(source_m_tile, ab_stages))
+                else:
+                    with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
+                        spec.normalize(selected_config(source_m_tile, ab_stages))
 
     def test_grouped_dynamic_deep_stage_smem_accounts_for_output_dtype(self) -> None:
         from helion._compiler.backend import CuteBackend

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6,8 +6,10 @@ import dataclasses
 from dataclasses import dataclass
 import gc
 import importlib
+import logging
 import math
 import os
+from pathlib import Path
 import threading
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -6613,7 +6615,7 @@ class TestCuteBackend(TestCase):
         expected = torch.sigmoid(torch.sin(torch.relu(x * y)))
         torch.testing.assert_close(out, expected, rtol=1e-5, atol=1e-5)
 
-    def test_pointwise_minimum_maximum_cutlass_45_fallback(self) -> None:
+    def test_pointwise_minimum_maximum_uses_native_math(self) -> None:
         cases = (
             (
                 torch.tensor(
@@ -6625,31 +6627,35 @@ class TestCuteBackend(TestCase):
             ),
             (
                 torch.tensor(
-                    [[2**25 + 1, -(2**25 + 1)]], device=DEVICE, dtype=torch.int32
+                    [
+                        [
+                            2**25 - 1,
+                            2**25 + 1,
+                            -(2**25 - 1),
+                            -(2**25 + 1),
+                        ]
+                    ],
+                    device=DEVICE,
+                    dtype=torch.int32,
                 ),
-                torch.tensor([[2**25, -(2**25)]], device=DEVICE, dtype=torch.int32),
+                torch.tensor(
+                    [[2**25, 2**25, -(2**25), -(2**25)]],
+                    device=DEVICE,
+                    dtype=torch.int32,
+                ),
             ),
         )
         for args in cases:
             with self.subTest(dtype=str(args[0].dtype)):
-                with patch(
-                    "helion._compiler.inductor_lowering.cute_math_min_max_available",
-                    return_value=False,
-                ):
-                    code, out = code_and_output(cute_minimum_maximum, args)
-                x, y = args
-                torch.testing.assert_close(
-                    out, torch.minimum(torch.maximum(x, y), x), equal_nan=True
-                )
-                if x.is_floating_point():
+                code, out = code_and_output(cute_minimum_maximum, args)
+                expected = torch.minimum(torch.maximum(args[0], args[1]), args[0])
+                torch.testing.assert_close(out, expected, equal_nan=True)
+                if args[0].is_floating_point():
                     torch.testing.assert_close(
-                        torch.signbit(out),
-                        torch.signbit(torch.minimum(torch.maximum(x, y), x)),
+                        torch.signbit(out), torch.signbit(expected)
                     )
-                self.assertNotIn("cute.arch.fmax", code)
-                self.assertNotIn("cute.arch.fmin", code)
-                self.assertNotIn("cute.math.max", code)
-                self.assertNotIn("cute.math.min", code)
+                self.assertIn("cute.math.max", code)
+                self.assertIn("cute.math.min", code)
 
     def test_rms_norm_uses_native_rsqrt(self) -> None:
         x = torch.randn(8, 32, device=DEVICE, dtype=torch.float32)
@@ -9818,8 +9824,15 @@ class TestCuteBackend(TestCase):
             "group_count": 8,
             "m_size": 2048,
             "n_size": 512,
+            "bm": 256,
         }
 
+        self.assertEqual(
+            launcher._tcgen05_grouped_device_split_total_clusters(
+                {**common_plan, "source_m_tile": 32}
+            ),
+            1024,
+        )
         self.assertEqual(
             launcher._tcgen05_grouped_device_split_total_clusters(
                 {**common_plan, "source_m_tile": 224}
@@ -11619,7 +11632,7 @@ class TestCuteConfigValuePriors(TestCase):
 
 
 class TestCuteBackendRequirements(TestCase):
-    """The cute backend hard-requires CuTe DSL >= 4.5.1, apache-tvm-ffi, and
+    """The cute backend hard-requires CuTe DSL >= 4.7.0, apache-tvm-ffi, and
     CUDA >= 13, enforced up front via ``CuteBackend.validate_environment``.
     This module is ``importorskip``-gated on cutlass, so the environment under
     test already satisfies the requirements (the gate must pass here).
@@ -11629,6 +11642,28 @@ class TestCuteBackendRequirements(TestCase):
         from helion._compiler.cute.cutedsl_compat import _cute_backend_requirement_error
 
         self.assertIsNone(_cute_backend_requirement_error())
+
+    def test_validated_version_matches_checked_in_cutlass_pin(self) -> None:
+        from helion._compiler.cute.cutedsl_compat import (
+            CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION,
+        )
+        from helion._compiler.cute.cutedsl_compat import CUTE_VALIDATED_VERSION
+
+        pin = (
+            (
+                Path(__file__).parents[1]
+                / ".github"
+                / "ci_commit_pins"
+                / "nvidia_cutlass_dsl.txt"
+            )
+            .read_text(encoding="utf-8")
+            .strip()
+        )
+        self.assertEqual(str(CUTE_VALIDATED_VERSION), pin)
+        self.assertEqual(
+            CUTE_TCGEN05_RUNTIME_N_PTX_VALIDATED_VERSION,
+            CUTE_VALIDATED_VERSION,
+        )
 
     def test_check_does_not_raise_when_satisfied(self) -> None:
         from helion._compiler.cute.cutedsl_compat import check_cute_backend_requirements
@@ -11640,26 +11675,22 @@ class TestCuteBackendRequirements(TestCase):
 
         CuteBackend().validate_environment()  # must not raise in this environment
 
-    def test_math_min_max_version_guard(self) -> None:
+    def test_pre_47_dsl_is_rejected_before_codegen(self) -> None:
         from helion._compiler.cute import cutedsl_compat
 
-        self.addCleanup(cutedsl_compat.cute_math_min_max_available.cache_clear)
-        for version, expected in (
-            ("4.5.1", False),
-            ("4.6.0", True),
-            ("4.6.1", True),
-            ("4.7.0", True),
+        self.addCleanup(cutedsl_compat._cute_backend_requirement_error.cache_clear)
+        self.addCleanup(cutedsl_compat._installed_cute_dsl_version.cache_clear)
+        cutedsl_compat._cute_backend_requirement_error.cache_clear()
+        cutedsl_compat._installed_cute_dsl_version.cache_clear()
+        with patch.object(
+            cutedsl_compat.importlib.metadata,
+            "version",
+            return_value="4.6.1",
         ):
-            with self.subTest(version=version):
-                cutedsl_compat.cute_math_min_max_available.cache_clear()
-                with patch.object(
-                    cutedsl_compat.importlib.metadata,
-                    "version",
-                    return_value=version,
-                ):
-                    self.assertEqual(
-                        cutedsl_compat.cute_math_min_max_available(), expected
-                    )
+            self.assertEqual(
+                cutedsl_compat._cute_backend_requirement_error(),
+                "the installed CuTe DSL is too old (need >= 4.7.0, found 4.6.1)",
+            )
 
     def test_unmet_requirement_raises_with_actionable_message(self) -> None:
         from helion._compiler.cute import cutedsl_compat
@@ -11676,5 +11707,77 @@ class TestCuteBackendRequirements(TestCase):
         message = str(ctx.exception)
         self.assertIn("apache-tvm-ffi package is required (simulated)", message)
         # The fixed tail names all three requirements so the user knows the set.
-        self.assertIn("nvidia-cutlass-dsl >= 4.5.1", message)
+        self.assertIn("nvidia-cutlass-dsl >= 4.7.0", message)
         self.assertIn("CUDA >= 13", message)
+
+
+def test_newer_cute_dsl_warns_once_only_for_grouped_runtime_n_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from helion._compiler.cute import cutedsl_compat
+
+    cutedsl_compat._installed_cute_dsl_version.cache_clear()
+    cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback.cache_clear()
+    try:
+        with (
+            patch.object(
+                cutedsl_compat.importlib.metadata,
+                "version",
+                return_value="4.7.1",
+            ) as version_probe,
+            caplog.at_level(logging.WARNING, logger=cutedsl_compat.__name__),
+        ):
+            assert not cutedsl_compat.tcgen05_runtime_n_ptx_compatible()
+            assert not cutedsl_compat.tcgen05_runtime_n_ptx_compatible()
+            assert not caplog.records
+            cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback()
+            cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback()
+            assert version_probe.call_count == 1
+    finally:
+        cutedsl_compat._installed_cute_dsl_version.cache_clear()
+        cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback.cache_clear()
+
+    matching = [
+        record
+        for record in caplog.records
+        if "Grouped runtime-N compiler seeds and promoted defaults are disabled"
+        in record.getMessage()
+    ]
+    assert len(matching) == 1
+    assert "4.7.1" in matching[0].getMessage()
+    assert "4.7.0" in matching[0].getMessage()
+    assert "fall back to typed static-width MMA" in matching[0].getMessage()
+
+
+@pytest.mark.parametrize("failure", ("missing", "invalid"))
+def test_failed_cute_dsl_version_probe_is_shared_and_cached(failure: str) -> None:
+    from helion._compiler.cute import cutedsl_compat
+
+    if failure == "missing":
+        error: Exception = cutedsl_compat.importlib.metadata.PackageNotFoundError(
+            "nvidia-cutlass-dsl"
+        )
+        expected = "the CuTe DSL is not installed"
+    else:
+        error = cutedsl_compat.InvalidVersion("not-a-version")
+        expected = "the installed CuTe DSL version is invalid"
+
+    cutedsl_compat._installed_cute_dsl_version.cache_clear()
+    cutedsl_compat._cute_backend_requirement_error.cache_clear()
+    cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback.cache_clear()
+    try:
+        with patch.object(
+            cutedsl_compat.importlib.metadata,
+            "version",
+            side_effect=error,
+        ) as version_probe:
+            assert not cutedsl_compat.tcgen05_runtime_n_ptx_compatible()
+            assert not cutedsl_compat.tcgen05_runtime_n_ptx_compatible()
+            cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback()
+            cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback()
+            assert expected in str(cutedsl_compat._cute_backend_requirement_error())
+            assert version_probe.call_count == 1
+    finally:
+        cutedsl_compat._installed_cute_dsl_version.cache_clear()
+        cutedsl_compat._cute_backend_requirement_error.cache_clear()
+        cutedsl_compat.warn_tcgen05_runtime_n_ptx_fallback.cache_clear()

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -11307,6 +11307,29 @@ def _cute_fp8_gemm_skinny_m(
     return out
 
 
+@helion.kernel(backend="cute", static_shapes=True)
+def _cute_rank_broadcast_reduction_axis_collision(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+) -> torch.Tensor:
+    m, h, d = q.size()
+    n = k.size(0)
+    h = hl.specialize(h)
+    d = hl.specialize(d)
+    out = torch.empty((m, n), dtype=torch.float32, device=q.device)
+    for tile_m, tile_n in hl.tile((m, n)):
+        score = torch.matmul(q[tile_m, :, :], k[tile_n, :].transpose(0, 1))
+        acc = (torch.relu(score.float()) * weights[tile_m, :][:, :, None]).sum(dim=1)
+        in_window = (tile_n.index[None, :] >= ks[tile_m][:, None]) & (
+            tile_n.index[None, :] < ke[tile_m][:, None]
+        )
+        out[tile_m, tile_n] = torch.where(in_window, acc, float("-inf"))
+    return out
+
+
 @onlyBackends(["cute"])
 class TestCuteThreadBudgetRejection(TestCase):
     """The CuTe launcher raises ``BackendUnsupported`` when a config
@@ -11334,6 +11357,35 @@ class TestCuteThreadBudgetRejection(TestCase):
                 num_threads=[0, 256],
                 cute_vector_widths=[1, 4],
             )
+
+    def test_rank_broadcast_reduction_axis_collision_rejected(self) -> None:
+        """Reject a tile/reduction axis collision before emitting a kernel."""
+        q = torch.empty(
+            (1, 32, 128),
+            dtype=torch.bfloat16,
+            device="meta",  # @ignore-device-lint
+        )
+        k = torch.empty(
+            (512, 128),
+            dtype=torch.bfloat16,
+            device="meta",  # @ignore-device-lint
+        )
+        weights = torch.empty(
+            (1, 32),
+            dtype=torch.float32,
+            device="meta",  # @ignore-device-lint
+        )
+        ks = torch.empty((1,), dtype=torch.int32, device="meta")  # @ignore-device-lint
+        ke = torch.empty((1,), dtype=torch.int32, device="meta")  # @ignore-device-lint
+        bound = _cute_rank_broadcast_reduction_axis_collision.bind(
+            (q, k, weights, ks, ke)
+        )
+        with self.assertRaisesRegex(
+            BackendUnsupported,
+            r"thread-axis collision: tile blocks \[0, 1\] and executable "
+            r"reduction block 3 both require axis 1",
+        ):
+            bound.to_triton_code(helion.Config(block_sizes=[1, 128]))
 
     def test_in_budget_multi_row_passes(self) -> None:
         """A multi-row config that DOES fit in 1024 threads must still

--- a/test/test_cute_deepgemm_selected.py
+++ b/test/test_cute_deepgemm_selected.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import os
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -9,22 +10,31 @@ import torch
 
 import helion
 from helion._compat import requires_cuda_version
+from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
 )
 from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+    TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
 )
 from helion._testing import DEVICE
 from helion._testing import matchesBackends
 from helion._testing import patch_cute_mma_support
 from helion._testing import skipUnlessBackends
 import helion.language as hl
+from helion.runtime.cute.launcher import _validate_tcgen05_grouped_dynamic_ab_tensormaps
+from helion.runtime.cute.launcher import _validate_tcgen05_grouped_fixed_tensormaps
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 pytestmark = skipUnlessBackends(["cute"])
 if matchesBackends(["cute"]):
@@ -39,7 +49,30 @@ def _aligned_m(
     return ((actual_m + tile - 1) // tile) * tile
 
 
-def _selected_config(block_k: int = 128) -> helion.Config:
+def _selected_config(
+    block_k: int = 128,
+    source_m_tile: int | None = None,
+    *,
+    ab_stages: int | None = None,
+    cluster_m: int = 2,
+    consumer_regs: int | None = None,
+) -> helion.Config:
+    if source_m_tile is None:
+        source_m_tile = (
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+            if block_k == 128
+            else TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+        )
+    # BK64/source-256 cannot fit the historical AB7 schedule in CTA SMEM.
+    if ab_stages is None:
+        ab_stages = {
+            (64, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE): 7,
+            (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT): 7,
+            (64, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE): 6,
+            (128, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE): 3,
+            (128, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT): 3,
+            (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE): 3,
+        }[(block_k, source_m_tile)]
     config = helion.Config(
         block_sizes=[256, 128, block_k],
         l2_groupings=[1],
@@ -47,19 +80,17 @@ def _selected_config(block_k: int = 128) -> helion.Config:
         num_stages=7,
         num_warps=8,
         pid_type="persistent_interleaved",
-        tcgen05_cluster_m=2,
+        tcgen05_cluster_m=cluster_m,
         tcgen05_cluster_n=1,
-        tcgen05_ab_stages={64: 7, 128: 3}[block_k],
+        tcgen05_ab_stages=ab_stages,
         tcgen05_acc_stages=2,
         tcgen05_c_stages=2,
         tcgen05_num_epi_warps=4,
     )
     config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = TCGEN05_GROUPED_MODE_WORKLIST_NM
-    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = (
-        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
-        if block_k == 128
-        else TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
-    )
+    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = source_m_tile
+    if consumer_regs is not None:
+        config.config["tcgen05_consumer_regs"] = consumer_regs
     return config
 
 
@@ -127,6 +158,7 @@ def _make_args(
     k: int = 128,
     dtype: torch.dtype = torch.bfloat16,
     dirty_padding: bool = False,
+    mn_major_b: bool = False,
     source_m_tile: int = TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     starts: list[int] = []
@@ -143,6 +175,8 @@ def _make_args(
                 start + actual_m : start + _aligned_m(actual_m, source_m_tile)
             ].normal_()
     b_grouped = torch.randn((len(m_sizes), n, k), device=DEVICE, dtype=dtype)
+    if mn_major_b:
+        b_grouped = b_grouped.transpose(1, 2).contiguous().transpose(1, 2)
     work_tile_metadata = torch.tensor(
         [
             [group, start, actual_m, _aligned_m(actual_m, source_m_tile)]
@@ -154,11 +188,27 @@ def _make_args(
     return a_packed, b_grouped, work_tile_metadata
 
 
-def _configured_bound(args: tuple[torch.Tensor, ...], block_k: int = 128):
+def _configured_bound(
+    args: tuple[torch.Tensor, ...],
+    block_k: int = 128,
+    *,
+    ab_stages: int | None = None,
+    source_m_tile: int | None = None,
+    cluster_m: int = 2,
+    consumer_regs: int | None = None,
+):
     _selected_kernel.reset()
     bound = _selected_kernel.bind(args)
     bound.env.config_spec.cute_tcgen05_search_enabled = True
-    bound.set_config(_selected_config(block_k))
+    bound.set_config(
+        _selected_config(
+            block_k,
+            source_m_tile,
+            ab_stages=ab_stages,
+            cluster_m=cluster_m,
+            consumer_regs=consumer_regs,
+        )
+    )
     return bound
 
 
@@ -186,6 +236,30 @@ def _wrapper_plans(code: str) -> list[dict[str, object]]:
     return list(ast.literal_eval(payload))
 
 
+def _call_count(
+    tree: ast.AST,
+    receiver: str,
+    method: str,
+    first_arg: str | None = None,
+) -> int:
+    return sum(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == receiver
+        and node.func.attr == method
+        and (
+            first_arg is None
+            or (
+                bool(node.args)
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id == first_arg
+            )
+        )
+        for node in ast.walk(tree)
+    )
+
+
 def _assert_output(
     out: torch.Tensor,
     args: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
@@ -207,6 +281,52 @@ def _assert_output(
             rtol=0,
             atol=0,
         )
+
+
+def _capture_and_replay(
+    bound: Callable[..., torch.Tensor],
+    args: tuple[torch.Tensor, ...],
+    *,
+    poison: float = float("nan"),
+) -> torch.Tensor:
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = bound(*args)
+    torch.cuda.synchronize()
+
+    captured.fill_(poison)
+    graph.replay()
+    torch.cuda.synchronize()
+    return captured
+
+
+def _run_graph_replay(
+    args: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    block_k: int = 128,
+    *,
+    ab_stages: int | None = None,
+    source_m_tile: int | None = None,
+    cluster_m: int = 2,
+    consumer_regs: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _configured_bound(
+            args,
+            block_k,
+            ab_stages=ab_stages,
+            source_m_tile=source_m_tile,
+            cluster_m=cluster_m,
+            consumer_regs=consumer_regs,
+        )
+        warmup = bound(*args)
+        torch.cuda.synchronize()
+        _assert_output(warmup, args)
+        warmup = warmup.clone()
+        captured = _capture_and_replay(bound, args)
+
+    assert bool(torch.isfinite(captured).all().item())
+    _assert_output(captured, args)
+    return warmup, captured
 
 
 def _require_codegen_cuda() -> None:
@@ -239,7 +359,7 @@ def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
     assert "cute.nvgpu.tcgen05.CtaGroup.TWO" in code
     assert "(256, 256)" in code
     assert "cute.local_tile(tma_tensor_a, (256, 128)" in code
-    assert "cute.local_tile(tma_tensor_b, (256, 128)" in code
+    assert "cute.local_tile(tcgen05_tma_tensor_b_tail, (256, 128)" in code
     assert "cute.local_tile(tcgen05_tma_store_tensor, (256, 256)," in code
     assert "StMatrix8x8x16bOp(transpose=True, num_matrices=4)" in code
     assert "cute.arch.alloc_smem(cutlass.Int32, 9" in code
@@ -271,18 +391,23 @@ def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
 
     config = _selected_config(64)
     config.config.pop(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
-    code = _code_for(
-        _make_args(
-            (1, 127, 224, 256),
-            n=224,
-            k=64,
-            source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
-        ),
-        config,
-    )
+    with patch(
+        "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+        return_value=False,
+    ):
+        code = _code_for(
+            _make_args(
+                (1, 127, 224, 256),
+                n=224,
+                k=64,
+                source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+            ),
+            config,
+        )
 
     assert "(256, 224, 64)" in code
     assert "cute.local_tile(tma_tensor_a, (256, 64)" in code
+    assert "tcgen05_tma_tensor_b_tail" not in code
     assert "cute.local_tile(tma_tensor_b, (224, 64)" in code
     assert "cute.local_tile(tcgen05_tma_store_tensor, (256, 224)," in code
     plan = next(
@@ -291,19 +416,20 @@ def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
         if plan["kind"] == "tcgen05_grouped_static_persistent"
     )
     assert plan["bk"] == 64
-    assert plan["source_m_tile"] == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+    assert plan["source_m_tile"] == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
     d_plan = next(
         plan for plan in _wrapper_plans(code) if plan["kind"] == "tcgen05_d_tma"
     )
     assert (d_plan["bm"], d_plan["bn"], d_plan["orientation"]) == (256, 224, "nm")
 
 
-def test_grouped_worklist_nm_rejects_over_budget_host_metadata_profile() -> None:
+def test_grouped_worklist_nm_codegen_backstop_rejects_generated_smem() -> None:
     _require_codegen_cuda()
 
-    config = _selected_config(64)
-    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = (
-        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+    config = _selected_config(
+        64,
+        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+        ab_stages=7,
     )
     args = _make_args(
         (224, 256),
@@ -311,11 +437,27 @@ def test_grouped_worklist_nm_rejects_over_budget_host_metadata_profile() -> None
         k=64,
         source_m_tile=TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
     )
-    with pytest.raises(
-        helion.exc.BackendUnsupported,
-        match="grouped N,M worklist generated allocations require",
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    bound.env.config_spec._tcgen05_ab_stages_three_search_constraints = None
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+        patch.object(
+            CuteTcgen05Config,
+            "per_cta_smem_capacity_bytes",
+            return_value=1,
+        ),
+        pytest.raises(
+            helion.exc.BackendUnsupported,
+            match=(
+                "tcgen05 grouped N,M worklist generated allocations require .* "
+                "exceeding the 1-byte capacity"
+            ),
+        ),
     ):
-        _code_for(args, config)
+        bound.to_triton_code(config)
 
 
 def test_grouped_worklist_nm_rejects_alpha_scaled_row() -> None:
@@ -338,6 +480,399 @@ def test_grouped_worklist_nm_rejects_alpha_scaled_row() -> None:
 
 
 @pytest.mark.parametrize(
+    ("block_k", "source_m_tile"),
+    (
+        (64, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE),
+        (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT),
+        (64, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE),
+        (128, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE),
+        (128, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT),
+        (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE),
+    ),
+)
+def test_grouped_worklist_nm_runtime_n_tail_descriptors_codegen(
+    block_k: int,
+    source_m_tile: int,
+) -> None:
+    _require_codegen_cuda()
+
+    config = _selected_config(block_k, source_m_tile)
+    with patch(
+        "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+        return_value=True,
+    ):
+        code = _code_for(
+            _make_args((1, 257), n=512, k=128, source_m_tile=source_m_tile),
+            config,
+        )
+
+    assert "cutlass.experimental.primitives.inline_ptx(" in code
+    assert (
+        "tcgen05_tma_b_peer_delta = mma_slice_tidx * "
+        "(tcgen05_tma_runtime_mma_n // cutlass.Int32(2) - "
+        f"cutlass.Int32({source_m_tile // 2}))"
+    ) in code
+    assert (
+        "tcgen05_tma_tensor_b_tail = cute.domain_offset("
+        "(tcgen05_tma_b_peer_delta, 0), tma_tensor_b)"
+    ) in code
+    assert (
+        f"cute.local_tile(tcgen05_tma_tensor_b_tail, ({source_m_tile}, {block_k})"
+        in code
+    )
+    assert "n_dim=0, m_dim=256" in code
+    assert f"if tcgen05_runtime_mma_n == cutlass.Int32({source_m_tile}):" in code
+    assert "tcgen05.mma.cta_group::2.kind::f16" in code
+    tree = ast.parse(code)
+    instr_desc_call = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and ast.unparse(node.func).endswith("Tcgen05InstrDesc.build")
+    )
+    instr_desc_dtypes = {
+        keyword.arg: ast.unparse(keyword.value)
+        for keyword in instr_desc_call.keywords
+        if keyword.arg in {"a_dtype", "b_dtype", "c_dtype"}
+    }
+    assert instr_desc_dtypes == {
+        "a_dtype": "cutlass.BFloat16",
+        "b_dtype": "cutlass.BFloat16",
+        "c_dtype": "cutlass.Float32",
+    }
+    tail_predicate = f"tcgen05_grouped_valid_m <= cutlass.Int32({source_m_tile - 16})"
+    tail_guards = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If) and ast.unparse(node.test) == tail_predicate
+    ]
+    assert len(tail_guards) == 2
+    tma_guard = next(
+        node for node in tail_guards if "tcgen05_tma_b_peer_delta" in ast.unparse(node)
+    )
+    mma_guard = next(
+        node for node in tail_guards if "Tcgen05InstrDesc.build" in ast.unparse(node)
+    )
+    assert "tcgen05_tma_tensor_b_tail" in ast.unparse(tma_guard)
+    assert "Tcgen05InstrDesc.build" not in ast.unparse(tma_guard)
+    assert "tcgen05_tma_b_peer_delta" not in ast.unparse(mma_guard)
+
+    # Keep both sides of the dynamic tail branch on the same CuTe pytree by
+    # normalizing the full-N TensorMap with a DSL-typed zero domain offset.
+    normalized_tail_runs = []
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not isinstance(body, list):
+            continue
+        for index in range(len(body) - 2):
+            run = body[index : index + 3]
+            if (
+                "tcgen05_tma_b_peer_delta = cutlass.Int32(0)" in ast.unparse(run[0])
+                and "tcgen05_tma_tensor_b_tail = cute.domain_offset("
+                in ast.unparse(run[1])
+                and run[2] is tma_guard
+            ):
+                normalized_tail_runs.append(run)
+    assert len(normalized_tail_runs) == 1
+
+
+@pytest.mark.parametrize(
+    ("block_k", "source_m_tile"),
+    (
+        (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT),
+        (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE),
+    ),
+)
+def test_grouped_worklist_nm_fixed_full_allocation_tensormaps_codegen(
+    block_k: int,
+    source_m_tile: int,
+) -> None:
+    _require_codegen_cuda()
+
+    code = _code_for(
+        _make_args((1, 257), n=512, k=128, source_m_tile=source_m_tile),
+        _selected_config(block_k, source_m_tile),
+    )
+
+    assert "TensorMapManager" not in code
+    assert "update_tensormap" not in code
+    assert "tcgen05_grouped_tensormap" not in code
+    assert "tcgen05_grouped_d_tensormap" not in code
+    assert "tcgen05_tma_full_tile =" not in code
+
+    plans = _wrapper_plans(code)
+    grouped_plan = next(
+        plan for plan in plans if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert grouped_plan["source_m_tile"] == source_m_tile
+    assert grouped_plan["fixed_tensormaps"] is True
+    assert grouped_plan["dynamic_ab_tensormap_rank"] == 2
+    assert "dynamic_ab_tensormaps" not in grouped_plan
+    assert "dynamic_d_tensormap" not in grouped_plan
+
+    ab_plan = next(plan for plan in plans if plan["kind"] == "tcgen05_ab_tma")
+    assert ab_plan["bn"] == source_m_tile
+    assert ab_plan["fixed_ab_tensormaps"] is True
+    assert "dynamic_ab_tensormaps" not in ab_plan
+
+    d_plan = next(plan for plan in plans if plan["kind"] == "tcgen05_d_tma")
+    assert d_plan["fixed_tensormap"] is True
+    assert d_plan["rank3_mnl_tensor"] is True
+
+
+def test_grouped_worklist_nm_partial_m_store_builds_identity_mask() -> None:
+    _require_codegen_cuda()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    code = _code_for(
+        _make_args((1, 257), n=512, k=128, source_m_tile=source_m_tile),
+        _selected_config(64, source_m_tile),
+    )
+    tree = ast.parse(code)
+    valid_m_guards = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test)
+        == f"tcgen05_grouped_valid_m == cutlass.Int32({source_m_tile})"
+    ]
+    assert len(valid_m_guards) == 1
+    valid_m_guard = valid_m_guards[0]
+    full_body = ast.Module(body=valid_m_guard.body, type_ignores=[])
+    tail_body = ast.Module(body=valid_m_guard.orelse, type_ignores=[])
+    assert _call_count(full_body, "cute", "make_identity_tensor") == 0
+    assert _call_count(full_body, "cute", "where") == 0
+    assert _call_count(tail_body, "cute", "make_identity_tensor") == 1
+    assert _call_count(tail_body, "cute", "where") == 1
+
+
+@pytest.mark.parametrize(
+    "source_m_tile",
+    (
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+    ),
+)
+def test_grouped_worklist_nm_bk128_ab2_keeps_unsplit_tma_store_codegen(
+    source_m_tile: int,
+) -> None:
+    _require_codegen_cuda()
+
+    config = _selected_config(128, source_m_tile, ab_stages=2)
+    code = _code_for(
+        _make_args(
+            (224, 449, 256),
+            n=512,
+            k=256,
+            source_m_tile=source_m_tile,
+        ),
+        config,
+    )
+
+    assert "while tcgen05_role_local_2_valid:" in code
+    assert "tcgen05_role_local_2_full_valid" not in code
+    assert "tcgen05_role_local_2_edge_valid" not in code
+    assert "tcgen05_edge_src" not in code
+    assert "cute.copy(tcgen05_tma_store_atom" in code
+
+
+@pytest.mark.parametrize("runtime_n_ptx", (False, True))
+def test_grouped_worklist_nm_one_cta_codegen(runtime_n_ptx: bool) -> None:
+    _require_codegen_cuda()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+    config = _selected_config(64, source_m_tile, cluster_m=1)
+    with patch(
+        "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+        return_value=runtime_n_ptx,
+    ):
+        code = _code_for(
+            _make_args((24, 23), n=512, k=128, source_m_tile=source_m_tile),
+            config,
+        )
+
+    assert config.block_sizes[:3] == [256, 128, 64]
+    assert "cute.nvgpu.tcgen05.CtaGroup.ONE" in code
+    assert "cute.nvgpu.tcgen05.CtaGroup.TWO" not in code
+    assert "tcgen05_tma_b_peer_delta" not in code
+    assert "tcgen05_tma_tensor_b_tail" not in code
+    assert "cute.gemm(" in code
+    assert ("cutlass.experimental.primitives.inline_ptx(" in code) is runtime_n_ptx
+    assert ("tcgen05.mma.cta_group::1.kind::f16" in code) is runtime_n_ptx
+    assert "tcgen05.mma.cta_group::2.kind::f16" not in code
+    assert "StaticPersistentGroupTileScheduler.create" in code
+    assert "cute.local_tile(tma_tensor_a, (128, 64)" in code
+    assert f"cute.local_tile(tma_tensor_b, ({source_m_tile}, 64)" in code
+
+    plans = _wrapper_plans(code)
+    grouped_plan = next(
+        plan for plan in plans if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert "num_sm_multiplier" not in grouped_plan
+    assert {
+        "bm": grouped_plan["bm"],
+        "bn": grouped_plan["bn"],
+        "bk": grouped_plan["bk"],
+        "cluster_m": grouped_plan["cluster_m"],
+        "cluster_n": grouped_plan["cluster_n"],
+        "source_m_tile": grouped_plan["source_m_tile"],
+        "fixed_tensormaps": grouped_plan["fixed_tensormaps"],
+    } == {
+        "bm": 128,
+        "bn": source_m_tile,
+        "bk": 64,
+        "cluster_m": 1,
+        "cluster_n": 1,
+        "source_m_tile": source_m_tile,
+        "fixed_tensormaps": True,
+    }
+
+    ab_plan = next(plan for plan in plans if plan["kind"] == "tcgen05_ab_tma")
+    assert (ab_plan["bm"], ab_plan["bn"], ab_plan["bk"]) == (
+        128,
+        source_m_tile,
+        64,
+    )
+    d_plan = next(plan for plan in plans if plan["kind"] == "tcgen05_d_tma")
+    assert (d_plan["bm"], d_plan["bn"]) == (128, source_m_tile)
+
+
+@pytest.mark.parametrize(
+    ("block_k", "ab_stages", "consumer_regs"),
+    ((64, 7, 240), (128, 5, 256)),
+)
+def test_grouped_worklist_nm_one_cta_fixed_tensormap_mn_major_b_codegen(
+    block_k: int,
+    ab_stages: int,
+    consumer_regs: int,
+) -> None:
+    _require_codegen_cuda()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+    config = _selected_config(
+        block_k,
+        source_m_tile,
+        ab_stages=ab_stages,
+        cluster_m=1,
+        consumer_regs=consumer_regs,
+    )
+    code = _code_for(
+        _make_args(
+            (24, 23, 19, 17, 20, 18),
+            n=512,
+            k=2 * block_k,
+            mn_major_b=True,
+            source_m_tile=source_m_tile,
+        ),
+        config,
+    )
+
+    assert "cute.nvgpu.tcgen05.CtaGroup.ONE" in code
+    assert f"cute.local_tile(tma_tensor_a, (128, {block_k}, 1)" in code
+    assert "tcgen05_grouped_cta_tile_idx_n, None, tcgen05_grouped_group_idx" in code
+
+    plans = _wrapper_plans(code)
+    grouped_plan = next(
+        plan for plan in plans if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert grouped_plan["orientation"] == "nm"
+    assert grouped_plan["fixed_tensormaps"] is True
+    assert grouped_plan["bm"] == 128
+    ab_plan = next(plan for plan in plans if plan["kind"] == "tcgen05_ab_tma")
+    assert (ab_plan["bm"], ab_plan["bn"], ab_plan["bk"]) == (
+        128,
+        source_m_tile,
+        block_k,
+    )
+    assert ab_plan["fixed_ab_tensormaps"] is True
+    assert ab_plan["fixed_grouped_b_rank3"] is True
+
+
+def test_grouped_worklist_nm_fixed_tensormap_rejects_misaligned_d() -> None:
+    _require_codegen_cuda()
+
+    m_total = 224
+    n = 256
+    k = 128
+    a_packed = torch.empty((m_total, k), dtype=torch.bfloat16, device=DEVICE)
+    b_grouped = torch.empty((1, n, k), dtype=torch.bfloat16, device=DEVICE)
+    aligned_output = torch.empty((m_total, n), dtype=torch.bfloat16, device=DEVICE)
+    d_storage = torch.empty(m_total * n + 1, dtype=torch.bfloat16, device=DEVICE)
+    output = d_storage[1:].view(m_total, n)
+    assert output.data_ptr() % 16 != 0
+
+    plan: dict[str, object] = {
+        "fixed_tensormaps": True,
+        "orientation": "nm",
+        "worklist_metadata": True,
+        "dynamic_ab_tensormap_rank": 2,
+        "lhs_idx": 0,
+        "rhs_idx": 1,
+        "n_size": n,
+        "k_total_size": k,
+        "bm": 256,
+        "bk": 64,
+    }
+    cute_kernel = type("FixedTensorMapKernel", (), {})()
+    cute_kernel._helion_cute_wrapper_plans = [
+        {"kind": "tcgen05_d_tma", "fixed_tensormap": True, "d_idx": 2}
+    ]
+
+    _validate_tcgen05_grouped_fixed_tensormaps(
+        cute_kernel,
+        plan,
+        (a_packed, b_grouped, aligned_output),
+    )
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="16-byte-aligned D base",
+    ):
+        _validate_tcgen05_grouped_fixed_tensormaps(
+            cute_kernel,
+            plan,
+            (a_packed, b_grouped, output),
+        )
+
+
+def test_grouped_worklist_nm_validator_accepts_exact_mn_major_b_only() -> None:
+    _require_codegen_cuda()
+
+    a_packed = torch.empty((32, 64), dtype=torch.bfloat16, device=DEVICE)
+    physical_gkn = torch.empty((2, 64, 32), dtype=torch.bfloat16, device=DEVICE)
+    mn_major_b = physical_gkn.transpose(1, 2)
+    padded_gkn = torch.empty((2, 64, 33), dtype=torch.bfloat16, device=DEVICE)
+    padded_mn_major_b = padded_gkn[:, :, :32].transpose(1, 2)
+    plan: dict[str, object] = {
+        "fixed_ab_tensormaps": True,
+        "dynamic_ab_tensormap_rank": 2,
+        "orientation": "nm",
+        "lhs_idx": 0,
+        "rhs_idx": 1,
+    }
+
+    _validate_tcgen05_grouped_dynamic_ab_tensormaps(
+        plan,
+        (a_packed, mn_major_b),
+    )
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="only for the N,M worklist path",
+    ):
+        _validate_tcgen05_grouped_dynamic_ab_tensormaps(
+            {**plan, "orientation": "mn"},
+            (a_packed, mn_major_b),
+        )
+    with pytest.raises(
+        helion.exc.BackendUnsupported,
+        match="contiguous K-major or MN-major grouped B",
+    ):
+        _validate_tcgen05_grouped_dynamic_ab_tensormaps(
+            plan,
+            (a_packed, padded_mn_major_b),
+        )
+
+
+@pytest.mark.parametrize(
     ("case", "match"),
     (
         ("fp16", "bf16_operands"),
@@ -356,11 +891,12 @@ def test_grouped_worklist_nm_rejects_ineligible_inputs(case: str, match: str) ->
         args = _make_args(n=196)
     else:
         a_packed, b_grouped, work_tile_metadata = _make_args()
-        strided_b = torch.empty(
-            (b_grouped.size(0), b_grouped.size(2), b_grouped.size(1)),
+        padded_b = torch.empty(
+            (b_grouped.size(0), b_grouped.size(1), 2 * b_grouped.size(2)),
             device=DEVICE,
             dtype=b_grouped.dtype,
-        ).transpose(1, 2)
+        )
+        strided_b = padded_b[:, :, ::2]
         strided_b.copy_(b_grouped)
         args = (a_packed, strided_b, work_tile_metadata)
 
@@ -371,7 +907,7 @@ def test_grouped_worklist_nm_rejects_ineligible_inputs(case: str, match: str) ->
 @pytest.mark.parametrize(
     ("block_k", "source_m_tile"),
     (
-        (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE),
+        (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT),
         (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE),
     ),
 )
@@ -413,3 +949,26 @@ def test_grouped_worklist_nm_runtime_and_graph_replay(
         torch.cuda.synchronize()
 
     _assert_output(captured, args)
+
+
+def test_grouped_worklist_nm_one_cta_mn_major_legacy_graph_replay() -> None:
+    _require_runtime_cuda13_sm100()
+
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+    args = _make_args(
+        (24, 23, 19, 17, 20, 18),
+        n=512,
+        k=128,
+        dirty_padding=True,
+        mn_major_b=True,
+        source_m_tile=source_m_tile,
+    )
+    n, k = args[1].shape[1:]
+    assert tuple(args[1].stride()) == (n * k, 1, n)
+    _run_graph_replay(
+        args,
+        64,
+        source_m_tile=source_m_tile,
+        cluster_m=1,
+        consumer_regs=240,
+    )

--- a/test/test_cute_grouped_gemm_split_sizes.py
+++ b/test/test_cute_grouped_gemm_split_sizes.py
@@ -15,10 +15,10 @@ from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
 )
 from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
 )
 from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
 )
 from helion._testing import DEVICE
 from helion._testing import matchesBackends
@@ -61,7 +61,7 @@ def _selected_config(
             if source_m_tile is not None
             else TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
             if block_k == 128
-            else TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+            else TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
         )
     return config
 
@@ -417,14 +417,16 @@ def _grouped_plan(code: str) -> dict[str, object]:
 
 
 def _bk64_device_split_smem_bytes(group_count: int) -> int:
-    from helion._compiler.cute.cute_mma import _tcgen05_grouped_worklist_smem_bytes
+    from helion._compiler.cute.tcgen05_constants import (
+        tcgen05_grouped_worklist_smem_bytes,
+    )
 
-    return _tcgen05_grouped_worklist_smem_bytes(
+    return tcgen05_grouped_worklist_smem_bytes(
         group_count=group_count,
         device_split_sizes=True,
         sched_stage_count=1,
         bm=256,
-        bn=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+        bn=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
         bk=64,
         dtype_bytes=2,
         ab_stages=7,
@@ -444,9 +446,9 @@ def test_grouped_device_split_smem_accounting_includes_fixed_allocations() -> No
 @pytest.mark.parametrize(
     ("block_k", "source_m_tile"),
     (
-        (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE),
+        (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT),
         (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE),
-        (128, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE),
+        (128, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT),
     ),
 )
 def test_grouped_device_split_sizes_codegen_and_wrapper_plan(

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -14716,6 +14716,42 @@ class TestCuteLowerings(unittest.TestCase):
             block_sizes=[128, 128, 256],
             tcgen05_ab_stages=2,
         )
+        worklist_config = helion.Config(
+            block_sizes=[256, 128, 64],
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=7,
+        )
+        worklist_config.config.update(
+            {
+                "tcgen05_grouped_mode": "worklist_nm",
+                "tcgen05_grouped_worklist_source_m_tile": 224,
+            }
+        )
+        cases = (
+            (torch.float16, 128, 128, 256, config, 200 * 1024, False, "universal"),
+            (torch.float16, 128, 128, 128, config, 200 * 1024, False, "tcgen05"),
+            (torch.float16, 128, 128, 128, config, 100 * 1024, False, "universal"),
+            (
+                torch.bfloat16,
+                256,
+                224,
+                64,
+                worklist_config,
+                200 * 1024,
+                False,
+                "universal",
+            ),
+            (
+                torch.bfloat16,
+                256,
+                224,
+                64,
+                worklist_config,
+                200 * 1024,
+                True,
+                "tcgen05",
+            ),
+        )
         with (
             patch(
                 "helion._compiler.cute.cute_mma.get_cute_mma_support",
@@ -14728,40 +14764,26 @@ class TestCuteLowerings(unittest.TestCase):
             ) as smem_budget,
             patch.dict("os.environ", {"HELION_CUTE_MMA_IMPL": "auto"}, clear=False),
         ):
-            self.assertEqual(
-                _choose_mma_impl(
-                    torch.float16,
-                    bm=128,
-                    bn=128,
-                    bk=256,
-                    config=config,
-                    input_device=torch.device("cuda"),
-                ),
-                "universal",
-            )
-            self.assertEqual(
-                _choose_mma_impl(
-                    torch.float16,
-                    bm=128,
-                    bn=128,
-                    bk=128,
-                    config=config,
-                    input_device=torch.device("cuda"),
-                ),
-                "tcgen05",
-            )
-            smem_budget.return_value = 100 * 1024
-            self.assertEqual(
-                _choose_mma_impl(
-                    torch.float16,
-                    bm=128,
-                    bn=128,
-                    bk=128,
-                    config=config,
-                    input_device=torch.device("cuda"),
-                ),
-                "universal",
-            )
+            for dtype, bm, bn, bk, case_config, budget, defer, expected in cases:
+                with self.subTest(
+                    dtype=str(dtype),
+                    block_sizes=(bm, bn, bk),
+                    budget=budget,
+                    defer=defer,
+                ):
+                    smem_budget.return_value = budget
+                    self.assertEqual(
+                        _choose_mma_impl(
+                            dtype,
+                            bm=bm,
+                            bn=bn,
+                            bk=bk,
+                            config=case_config,
+                            input_device=torch.device("cuda"),
+                            defer_grouped_worklist_smem_check=defer,
+                        ),
+                        expected,
+                    )
 
     def test_tcgen05_thread_counts_match_participants_and_cta(self) -> None:
         # ``_tcgen05_epi_warp_count`` takes a ``Tcgen05WarpSpec`` (G2-B);
@@ -20218,7 +20240,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
 
 @onlyBackends(["cute"])
 class TestCuteDslCompat(unittest.TestCase):
-    """The cute backend hard-requires the 4.5.1 CuTe DSL API (enforced up front
+    """The cute backend hard-requires the 4.7 CuTe DSL API (enforced up front
     by ``CuteBackend.validate_environment``), so the pipeline emitters render
     the native CuTe calls directly with no per-build workarounds."""
 
@@ -21961,6 +21983,8 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
             tcgen05_frag_a="tCrA",
             tcgen05_frag_b="tCrB",
             mma_stage="mma_stage",
+            input_dtype_str="cutlass.BFloat16",
+            acc_dtype_str="cutlass.Float32",
             is_two_cta=True,
         )
         self.assertIsInstance(node, ast.If)
@@ -21977,11 +22001,56 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
             body_src,
         )
 
+    def test_tcgen05_runtime_mma_issue_requires_bf16_fp32(self) -> None:
+        def build(input_dtype_str: str) -> ast.stmt:
+            return _build_tcgen05_mma_issue_stmt(
+                exec_active="exec_active",
+                tiled_mma="tiled_mma",
+                acc_frag="acc_frag",
+                tcgen05_frag_a="tCrA",
+                tcgen05_frag_b="tCrB",
+                mma_stage="mma_stage",
+                input_dtype_str=input_dtype_str,
+                acc_dtype_str="cutlass.Float32",
+                runtime_mma_n="runtime_mma_n",
+                runtime_instr_desc="runtime_instr_desc",
+                static_mma_n=224,
+                is_two_cta=True,
+            )
+
+        node = build("cutlass.BFloat16")
+        self.assertIn(
+            "tcgen05.mma.cta_group::2.kind::f16",
+            ast.unparse(node),
+        )
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "validated only for BF16/FP32",
+        ):
+            build("cutlass.Float16")
+        with (
+            patch(
+                "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+                return_value=False,
+            ),
+            self.assertRaisesRegex(
+                exc.BackendUnsupported,
+                "requires exactly nvidia-cutlass-dsl==4.7.0",
+            ),
+        ):
+            build("cutlass.BFloat16")
+
     def test_tcgen05_mma_accumulate_reset_two_cta_gates_to_leader(self) -> None:
-        node = _build_tcgen05_mma_accumulate_reset_stmt(
-            "exec_active", tiled_mma="tiled_mma", is_two_cta=True
+        stmts = _build_tcgen05_mma_accumulate_reset_stmt(
+            "exec_active",
+            tiled_mma="tiled_mma",
+            input_dtype_str="cutlass.BFloat16",
+            acc_dtype_str="cutlass.Float32",
+            is_two_cta=True,
         )
 
+        self.assertEqual(len(stmts), 1)
+        node = stmts[0]
         self.assertIsInstance(node, ast.If)
         self.assertEqual(
             ast.unparse(node.test),

--- a/test/test_cute_rank3_rhs_b_tma.py
+++ b/test/test_cute_rank3_rhs_b_tma.py
@@ -418,10 +418,20 @@ def _make_mixed_non_row_major_args() -> tuple[torch.Tensor, ...]:
 
 def _make_non_k_contiguous_args() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     a, _b_grouped, layout = _make_full_args()
-    b_grouped = torch.empty(
-        (4, 128, 256), device=DEVICE, dtype=torch.bfloat16
-    ).transpose(1, 2)
+    padded_b = torch.empty((4, 256, 256), device=DEVICE, dtype=torch.bfloat16)
+    b_grouped = padded_b[:, :, ::2]
     assert b_grouped.stride(2) != 1
+    return a, b_grouped, layout
+
+
+def _make_mn_major_args() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    a, b_grouped, layout = _make_full_args()
+    b_grouped = b_grouped.transpose(1, 2).contiguous().transpose(1, 2)
+    assert b_grouped.stride() == (
+        b_grouped.size(1) * b_grouped.size(2),
+        1,
+        b_grouped.size(1),
+    )
     return a, b_grouped, layout
 
 
@@ -1007,13 +1017,14 @@ def test_grouped_proof_rejects_unproven_aten_targets(target: Any) -> None:
     ("kernel", "args_fn", "config_fn"),
     [
         (_rank3_rhs_grouped_nt, _make_non_k_contiguous_args, _rank3_rhs_tma_config),
+        (_rank3_rhs_grouped_nt, _make_mn_major_args, _grouped_config),
         (
             _bad_mn_tail_zero_store,
             _make_mn_tail_args,
             lambda: _grouped_config(block_n=64, block_k=128),
         ),
     ],
-    ids=("strided-rhs", "non-preserving-tail-store"),
+    ids=("strided-rhs", "mn-major-outside-worklist", "non-preserving-tail-store"),
 )
 def test_rank3_rhs_unsafe_patterns_use_generic_fallback(
     kernel: Any, args_fn: Any, config_fn: Any

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1057,6 +1057,10 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @skipIfPallasInterpret("numerical mismatch in JAX interpret mode")
+    @skipIfCute(
+        "rank-broadcasted matmul followed by a broadcast-axis reduction "
+        "requires owner-aware CuTe lane lowering"
+    )
     def test_sparse_attn_indexer_decode(self):
         mod = import_path(EXAMPLES_DIR / "sparse_attn_indexer.py")
         args = mod.indexer_inputs(num_tokens=1, kv_len=512)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3481 (`fdffbedc`)
 * #3480 (`60f746d5`)
 * #3479 (`9ae406fe`)
 * #3478 (`57f0aef4`)
 * __->__ #3477 (`3e0cba9a`)
 * #3483 (`b1945f2e`, base `main`)

--- --- ---

## Summary

- Add CuTe tcgen05 physical lowering for packed-A, rank-3-B grouped GEMM worklists.
- Support one-CTA and two-CTA profiles, fixed full-allocation TensorMaps, K/N-major B layouts, and runtime N-tail instruction descriptors.
- Fail closed on unsupported CuTe DSL, PTX, SMEM, layout, and configuration combinations.

## Validation

- Ruff, codespell, Pyrefly, and diff checks pass.
- Upstream matmul/matmul-fact tests: 50 passed, 4 subtests.
- Grouped heuristic tests: 25 passed, 65 subtests.
- Runtime/specialization and split-size tests: 39 passed, 4 subtests.
- ConfigSpec tests: 32 passed, 96 subtests.
- Provider campaign tests: 63 default and 63 CuTe.
- Fresh adversarial review: LGTM.

## Performance evidence

A publication-eligible GB300 campaign on `252981249b3a2e417e234d99800433d60302049c` used 3 fresh replicates, 8 workloads, 102 paired cold-L2 samples, a 10-second warmup, correctness/replay checks, and clean telemetry. Historical geometric-mean speedups (`provider_ms / Helion_ms`) were:

`Helion ms` is the geometric mean of the 15 Helion medians for that row (5 provider pairings x 3 fresh replicates). Provider columns are `provider_ms / Helion_ms`, geometrically averaged across the three replicates; values above 1 mean Helion is faster.

| Row | G | Actual M per group | N | K | Helion ms | DeepGEMM | QuACK | cuDNN | cuBLASLt | CUTLASS |
|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 4 | `9884, 9459, 7801, 7007` | 6144 | 7168 | 1.7445 | 1.0098x | 1.0285x | 1.0183x | 1.2044x | 1.4062x |
| 1 | 4 | `8247, 7724, 9586, 7225` | 7168 | 3072 | 0.8164 | 1.0114x | 1.0345x | 1.0323x | 1.2329x | 1.4205x |
| 2 | 4 | `8076, 8601, 10197, 8215` | 4096 | 4096 | 0.6566 | 1.0192x | 1.0653x | 1.0305x | 1.1936x | 1.4464x |
| 3 | 4 | `7119, 9449, 8773, 6965` | 4096 | 2048 | 0.2805 | 1.0578x | 1.0651x | 1.0325x | 1.2292x | 1.3825x |
| 4 | 8 | `5102, 5282, 4858, 5084, 3629, 4660, 5076, 4548` | 6144 | 7168 | 1.9696 | 1.0283x | 1.0485x | 1.0170x | 1.2096x | 1.4105x |
| 5 | 8 | `4027, 3114, 3934, 4368, 5111, 5242, 4039, 4993` | 7168 | 3072 | 0.8757 | 1.0176x | 1.0501x | 1.1014x | 1.2488x | 1.4100x |
| 6 | 8 | `3507, 4845, 4215, 2901, 4635, 3847, 4894, 4509` | 4096 | 4096 | 0.6334 | 1.0037x | 1.0560x | 1.0561x | 1.2289x | 1.3593x |
| 7 | 8 | `2870, 4080, 4999, 3466, 3666, 5006, 3336, 4261` | 4096 | 2048 | 0.2846 | 1.0512x | 1.0204x | 1.0380x | 1.2515x | 1.3566x |
| **GM** | -- | -- | -- | -- | **0.7310** | **1.0247x** | **1.0459x** | **1.0404x** | **1.2247x** | **1.3987x** |

All eight rows beat every measured provider. On the final reviewed stack `fdffbedc`, all 8 selected configurations and all 120 archived generated modules reproduce exactly after removing only `# src[...]` provenance comments.

This is archived timing plus exact config/codegen equivalence, not a fresh timing run. PR5 intentionally strengthens cuBLASLt and CUTLASS selection, so their historical ratios are reference values rather than final claims for the new harness. No B200 timing claim is made.