### PR TITLE
[cutedsl] Discover grouped GEMM structure and generalize runtime specialization

### DIFF
--- a/helion/_argument_device.py
+++ b/helion/_argument_device.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+from typing import Hashable
+from typing import Literal
+from typing import NamedTuple
+from typing import cast
+from typing import overload
+
+import torch
+
+from . import exc
+from .language.constexpr import ConstExpr
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class _DevicePathStep(NamedTuple):
+    """One validated hop through an argument container."""
+
+    kind: Literal["sequence", "mapping"]
+    key: int | Hashable
+    container_type: type[object]
+    position: int
+
+
+_DevicePath = tuple[_DevicePathStep, ...]
+
+
+def _has_argument_device(value: object) -> bool:
+    """Return whether normal kernel traversal would find a device in ``value``."""
+    if isinstance(value, (torch.device, torch.Tensor)):
+        return True
+    if isinstance(value, ConstExpr):
+        return False
+    if isinstance(value, (tuple, list)):
+        return any(_has_argument_device(item) for item in value)
+    if isinstance(value, dict):
+        return any(_has_argument_device(item) for item in value.values())
+    return False
+
+
+def _leaf_device(value: object) -> torch.device | None:
+    if isinstance(value, torch.device):
+        return value
+    if isinstance(value, torch.Tensor):
+        return value.device
+    return None
+
+
+def _find_argument_device_with_path(
+    values: Sequence[object],
+) -> tuple[torch.device, _DevicePath] | None:
+    """Find the first device-bearing value and its container path."""
+
+    def visit(
+        value: object,
+        path: _DevicePath,
+    ) -> tuple[torch.device, _DevicePath] | None:
+        if (device := _leaf_device(value)) is not None:
+            return device, path
+        if isinstance(value, ConstExpr):
+            return None
+        if isinstance(value, (tuple, list)):
+            container_type = type(value)
+            for index, item in enumerate(value):
+                step = _DevicePathStep(
+                    "sequence",
+                    index,
+                    container_type,
+                    index,
+                )
+                if result := visit(item, (*path, step)):
+                    return result
+        elif isinstance(value, dict):
+            container_type = type(value)
+            for position, (key, item) in enumerate(value.items()):
+                step = _DevicePathStep(
+                    "mapping",
+                    cast("Hashable", key),
+                    container_type,
+                    position,
+                )
+                if result := visit(item, (*path, step)):
+                    return result
+        return None
+
+    return visit(values, ())
+
+
+def _find_argument_device(values: Sequence[object]) -> torch.device:
+    """Return the first device found by normal kernel argument traversal."""
+    result = _find_argument_device_with_path(values)
+    if result is None:
+        raise exc.NoTensorArgs
+    return result[0]
+
+
+def _mapping_key_matches(actual: object, expected: object) -> bool:
+    if actual is expected:
+        return True
+    try:
+        return bool(actual == expected)
+    except (RuntimeError, TypeError, ValueError):
+        # Tensor-valued or otherwise non-scalar mapping keys may not define a
+        # usable boolean equality. Treat that as a cache-path miss; the caller
+        # falls back to a complete argument traversal.
+        return False
+
+
+def _device_at_path(values: Sequence[object], path: _DevicePath) -> torch.device | None:
+    """Read a cached device path after validating structure and precedence."""
+    value: object = values
+    for step in path:
+        if type(value) is not step.container_type:
+            return None
+        if step.kind == "sequence":
+            if not isinstance(value, (tuple, list)) or not isinstance(step.key, int):
+                return None
+            if step.key < 0 or step.key >= len(value):
+                return None
+            if any(_has_argument_device(item) for item in value[: step.key]):
+                return None
+            value = value[step.key]
+            continue
+
+        if not isinstance(value, dict):
+            return None
+        for position, (key, item) in enumerate(value.items()):
+            if position == step.position:
+                if not _mapping_key_matches(key, step.key):
+                    return None
+                value = item
+                break
+            if _has_argument_device(item):
+                return None
+        else:
+            return None
+
+    return _leaf_device(value)
+
+
+def _current_device_index(device_type: str) -> int:
+    device_module = getattr(torch, device_type, None)
+    is_available = getattr(device_module, "is_available", None)
+    available = None if not callable(is_available) else is_available()
+    current_device = getattr(device_module, "current_device", None)
+    if available is not False and callable(current_device):
+        return cast("int", current_device())
+
+    accelerator_device = torch.accelerator.current_accelerator(check_available=True)
+    if accelerator_device is not None and accelerator_device.type == device_type:
+        return torch.accelerator.current_device_index()
+    raise exc.InvalidAPIUsage(
+        f"no current indexed accelerator is available for {device_type!r}"
+    )
+
+
+@overload
+def _canonicalize_argument_device(device: None) -> None: ...
+
+
+@overload
+def _canonicalize_argument_device(device: torch.device) -> torch.device: ...
+
+
+def _canonicalize_argument_device(
+    device: torch.device | None,
+) -> torch.device | None:
+    """Resolve an indexless accelerator while preserving discovery fallback."""
+    if device is None:
+        return None
+    if device.index is not None or device.type in ("cpu", "meta", "mps"):
+        return device
+    try:
+        index = _current_device_index(device.type)
+    except exc.InvalidAPIUsage:
+        # Preserve device kinds without PyTorch current-device support. Their
+        # existing backend-specific discovery remains authoritative.
+        return device
+    return torch.device(device.type, index)
+
+
+@dataclasses.dataclass
+class _ArgumentDeviceResolver:
+    """Cache the first argument-device path while preserving traversal semantics."""
+
+    path: _DevicePath | None = None
+
+    @classmethod
+    def from_values(cls, values: Sequence[object]) -> _ArgumentDeviceResolver:
+        result = _find_argument_device_with_path(values)
+        if result is None:
+            raise exc.NoTensorArgs
+        return cls(result[1])
+
+    def resolve(self, values: Sequence[object]) -> torch.device | None:
+        device = None if self.path is None else _device_at_path(values, self.path)
+        if device is None:
+            result = _find_argument_device_with_path(values)
+            if result is None:
+                self.path = None
+                return None
+            device, self.path = result
+        return _canonicalize_argument_device(device)
+
+    def __call__(self, values: Sequence[object]) -> torch.device:
+        device = self.resolve(values)
+        if device is None:
+            raise exc.NoTensorArgs
+        return device

--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -12,6 +12,7 @@ from .cute import CuteTcgen05ClusterM2FfiHeuristic
 from .cute import CuteTcgen05ClusterM2Heuristic
 from .cute import CuteTcgen05GroupedDynamicBk64Heuristic
 from .cute import CuteTcgen05GroupedStaticCommonKHeuristic
+from .cute import CuteTcgen05GroupedWorklistHeuristic
 from .cute import CuteTcgen05ThreadLocalEpilogueHeuristic
 from .cute import CuteTileVecHeuristic
 from .cute import CuteTileVecWarpPerRowHeuristic
@@ -32,10 +33,13 @@ from .triton import TritonUserTiledReductionHeuristicSM90
 from .triton import TritonUserTiledReductionHeuristicSM100
 
 if TYPE_CHECKING:
+    import torch
+
     from ...runtime.config import Config
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
     from .registry import AutotunerHeuristicType
+    from .registry import CompilerHeuristicSpecializationFact
 
 # All active heuristics by backend
 HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
@@ -44,6 +48,7 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteFlashAttentionHeuristic,
         CuteTcgen05ClusterM2FfiHeuristic,
         CuteTcgen05ClusterM2Heuristic,
+        CuteTcgen05GroupedWorklistHeuristic,
         CuteTcgen05GroupedStaticCommonKHeuristic,
         CuteTcgen05GroupedDynamicBk64Heuristic,
         CuteTcgen05ThreadLocalEpilogueHeuristic,
@@ -87,18 +92,95 @@ def get_heuristics(backend: str) -> tuple[AutotunerHeuristicType, ...]:
     return HEURISTICS_BY_BACKEND.get(backend, ())
 
 
+def compiler_promotion_specialization_key(
+    backend: str,
+    device: torch.device,
+) -> tuple[tuple[str, str | None], ...]:
+    """Return named-target facts that can change a promoted compiler default.
+
+    Compute capability is already part of the bound-kernel specialization key.
+    Only heuristics with an additional named-target promotion fence need more
+    device identity.  Non-matching products share the ``None`` bucket because
+    they all decline that promotion; capability-only heuristics add no key at
+    all. ``get_hardware_info`` is cached per canonical device.
+    """
+    registry_signature = []
+    for heuristic in get_heuristics(backend):
+        named_targets = heuristic.PROMOTE_NAMED_TARGETS
+        if heuristic.promote_seed_to_default and named_targets:
+            registry_signature.append((heuristic.name, named_targets))
+    if not registry_signature:
+        return ()
+
+    from ..._argument_device import _canonicalize_argument_device
+    from ..._hardware import get_hardware_info
+
+    try:
+        hardware = get_hardware_info(_canonicalize_argument_device(device))
+        hardware_identity = (
+            hardware.device_kind,
+            hardware.hardware_name,
+            hardware.compute_capability,
+        )
+    except RuntimeError:
+        hardware_identity = None
+    return tuple(
+        (
+            heuristic_name,
+            hardware_identity[1]
+            if hardware_identity is not None
+            and (
+                hardware_identity in named_targets
+                or (*hardware_identity[:2], None) in named_targets
+            )
+            else None,
+        )
+        for heuristic_name, named_targets in registry_signature
+    )
+
+
+def compiler_seed_specialization_facts(
+    backend: str,
+    fired_heuristics: tuple[str, ...] | list[str],
+) -> frozenset[CompilerHeuristicSpecializationFact]:
+    """Return device facts needed by compiler seeds that actually fired.
+
+    Eligibility is known only after tracing the kernel.  Deferring this lookup
+    until then avoids putting SM count in every bound-kernel key merely because
+    one heuristic registered for the backend happens to depend on it.
+    """
+    fired = frozenset(fired_heuristics)
+    return frozenset(
+        fact
+        for heuristic in get_heuristics(backend)
+        if heuristic.name in fired
+        for fact in heuristic.CACHE_SPECIALIZATION_FACTS
+    )
+
+
 def compiler_seed_configs(
     env: CompileEnvironment,
     device_ir: DeviceIR,
 ) -> list[Config]:
     configs: list[Config] = []
+    heuristics = get_heuristics(env.backend_name)
+    registered_fact_specialization_facts: set[CompilerHeuristicSpecializationFact] = (
+        set()
+    )
+    for heuristic in heuristics:
+        registered_fact_specialization_facts.update(
+            heuristic.register_facts(env, device_ir)
+        )
+    env.compiler_fact_specialization_facts = frozenset(
+        registered_fact_specialization_facts
+    )
     env.config_spec.autotuner_heuristics = []
     env.config_spec.compiler_default_config = None
     env.config_spec.compiler_seed_timeout_retry_repetitions = None
     if env.settings.disable_autotuner_heuristics:
         return configs
 
-    for heuristic in get_heuristics(env.backend_name):
+    for heuristic in heuristics:
         try:
             if not heuristic.is_eligible(env, device_ir):
                 continue

--- a/helion/_compiler/autotuner_heuristics/common.py
+++ b/helion/_compiler/autotuner_heuristics/common.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from ..compile_environment import CompileEnvironment
 
 HardwareTarget = tuple[str, str | None]
+NamedHardwareTarget = tuple[str, str, str | None]
 
 # Reduction op name tokens used to detect a reduction in a traced graph. Shared
 # by the Triton split/join heuristic and the LLM workload-trait detection.
@@ -69,8 +70,11 @@ def dedupe_configs(configs: Iterable[Config]) -> list[Config]:
 
 def matches_hardware(
     env: CompileEnvironment,
-    targets: tuple[HardwareTarget, ...],
+    targets: tuple[HardwareTarget, ...] | None,
+    *,
+    named_targets: frozenset[NamedHardwareTarget] | None = None,
 ) -> bool:
+    from ..._argument_device import _canonicalize_argument_device
     from ..._hardware import get_hardware_info
 
     # A device Helion cannot classify raises RuntimeError here (e.g. MTIA, which
@@ -81,13 +85,29 @@ def matches_hardware(
     # is called outside the try/except that guards is_eligible, where an escaping
     # RuntimeError fails the whole compile.
     try:
-        hardware = get_hardware_info(env.device)
+        hardware = get_hardware_info(_canonicalize_argument_device(env.device))
     except RuntimeError:
         return False
-    return (hardware.device_kind, hardware.compute_capability) in targets or (
-        hardware.device_kind,
-        None,
-    ) in targets
+    if (
+        named_targets is not None
+        and (
+            hardware.device_kind,
+            hardware.hardware_name,
+            hardware.compute_capability,
+        )
+        not in named_targets
+        and (
+            hardware.device_kind,
+            hardware.hardware_name,
+            None,
+        )
+        not in named_targets
+    ):
+        return False
+    return targets is None or (
+        (hardware.device_kind, hardware.compute_capability) in targets
+        or (hardware.device_kind, None) in targets
+    )
 
 
 def clamp_block_size_targets(

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -2,19 +2,37 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Literal
 from typing import cast
 
 import torch
 
 from ...runtime.config import Config
+from ..cute.cutedsl_compat import tcgen05_runtime_n_ptx_compatible
+from ..cute.cutedsl_compat import warn_tcgen05_runtime_n_ptx_fallback
+from ..cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from ..cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
+from ..cute.strategies import TCGEN05_STRATEGY_CONFIG_KEY
+from ..cute.strategies import TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
 from ..cute.strategies import Tcgen05PersistenceModel
+from ..cute.strategies import Tcgen05Strategy
 from ..cute.tcgen05_config import TCGEN05_GROUPED_DYNAMIC_AB4_STAGE
+from ..cute.tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS
 from ..cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
@@ -23,16 +41,21 @@ from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_L2_GROUPING
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from ..cute.tcgen05_constants import tcgen05_two_cta_edge_k_tail_seed_overrides
+from .common import dedupe_configs
 from .common import is_canonical_row_reduction
 from .registry import AutotunerHeuristic
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from ...autotuner.config_fragment import BlockSizeFragment
     from ...autotuner.config_spec import ConfigSpec
     from ...autotuner.config_spec import MatmulFact
     from ...autotuner.config_spec import ReductionLoopSpec
     from ..compile_environment import CompileEnvironment
+    from ..cute.cute_mma import Tcgen05GroupedWorklistAnalysis
     from ..device_ir import DeviceIR
+    from .registry import CompilerHeuristicSpecializationFact
 
 
 def _cute_seed_vec_width(
@@ -237,13 +260,8 @@ class CuteTileVecHeuristic(AutotunerHeuristic):
         # SM100 warp + L2 hit cadence) when reachable, else cap at the
         # inner tile's fragment.high.  ``num_threads`` is sized so the
         # lane_extent equals V (one vec load per thread per outer iter).
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
-        block_n: int
-        if isinstance(bn_high, int):
-            block_n = 1024 if bn_high >= 1024 else max(bn_high, vec)
-        else:
-            block_n = 1024
+        bn_high = spec.block_sizes[1]._fragment(spec).high
+        block_n = 1024 if bn_high >= 1024 else max(bn_high, vec)
         # Threads = block_n // V so each thread owns V contiguous elts.
         nt_n = max(1, block_n // vec)
         seed: dict[str, Any] = {
@@ -307,9 +325,8 @@ class CuteTileVecWarpReduceHeuristic(AutotunerHeuristic):
         # against the launch cost (and an autotuner-picked warp lattice
         # can hold the row).  We use the inner block fragment's high
         # bound as a proxy for the reduction extent.
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
-        return isinstance(bn_high, int) and bn_high >= vec * 32
+        bn_high = spec.block_sizes[1]._fragment(spec).high
+        return bn_high >= vec * 32
 
     @classmethod
     def get_seed_config(
@@ -330,10 +347,9 @@ class CuteTileVecWarpReduceHeuristic(AutotunerHeuristic):
         # Each thread owns V contiguous elements; one warp = 32 threads
         # = 32 * V elements per outer-tile iter. Cap by the fragment's
         # high bound so the seed is reachable for short reduction axes.
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
+        bn_high = spec.block_sizes[1]._fragment(spec).high
         block_n = vec * 32
-        if isinstance(bn_high, int) and bn_high < block_n:
+        if bn_high < block_n:
             return None
         seed: dict[str, Any] = {
             "block_sizes": [1, block_n],
@@ -397,18 +413,13 @@ class CuteTileVecWarpPerRowHeuristic(AutotunerHeuristic):
         vec = _cute_tile_seed_vec_width_for_dtype(dtype)
         if vec <= 1:
             return False
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
-        if not isinstance(bn_high, int) or bn_high < vec * 32:
+        bn_high = spec.block_sizes[1]._fragment(spec).high
+        if bn_high < vec * 32:
             return False
         # Outer (M) fragment must admit M=2 (warp-per-row launches 2
         # warps per CTA so each row is one warp).
-        bm_fragment = cast("Any", spec.block_sizes[0])._fragment(spec)
-        bm_low = getattr(bm_fragment, "low", 1)
-        bm_high = getattr(bm_fragment, "high", None)
-        if not isinstance(bm_high, int):
-            return False
-        return bm_low <= 2 <= bm_high
+        bm_fragment = spec.block_sizes[0]._fragment(spec)
+        return bm_fragment.low <= 2 <= bm_fragment.high
 
     @classmethod
     def get_seed_config(
@@ -426,10 +437,9 @@ class CuteTileVecWarpPerRowHeuristic(AutotunerHeuristic):
         vec = _cute_tile_seed_vec_width_for_dtype(dtype)
         if vec <= 1:
             return None
-        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
-        bn_high = getattr(bn_fragment, "high", None)
+        bn_high = spec.block_sizes[1]._fragment(spec).high
         block_n = vec * 32
-        if isinstance(bn_high, int) and bn_high < block_n:
+        if bn_high < block_n:
             return None
         seed: dict[str, Any] = {
             "block_sizes": [2, block_n],
@@ -500,10 +510,28 @@ def _block_size_value_reachable(
 ) -> bool:
     if block_index < 0 or block_index >= len(spec.block_sizes):
         return False
-    fragment = cast("Any", spec.block_sizes[block_index])._fragment(spec)
-    low = getattr(fragment, "low", None)
-    high = getattr(fragment, "high", None)
-    return isinstance(low, int) and isinstance(high, int) and low <= value <= high
+    fragment = spec.block_sizes[block_index]._fragment(spec)
+    return fragment.low <= value <= fragment.high
+
+
+def _filter_reachable_block_size_configs(
+    spec: ConfigSpec,
+    configs: Sequence[Config],
+) -> list[Config]:
+    """Keep seeds whose block sizes are reachable in the live config spec."""
+    result: list[Config] = []
+    for config in configs:
+        block_sizes = config.config.get("block_sizes")
+        if not isinstance(block_sizes, list) or len(block_sizes) != len(
+            spec.block_sizes
+        ):
+            continue
+        if all(
+            type(value) is int and _block_size_value_reachable(spec, index, value)
+            for index, value in enumerate(block_sizes)
+        ):
+            result.append(config)
+    return result
 
 
 def _tcgen05_grouped_fact(env: CompileEnvironment) -> MatmulFact | None:
@@ -514,7 +542,7 @@ def _tcgen05_grouped_fact(env: CompileEnvironment) -> MatmulFact | None:
         or len(spec.block_sizes) != 3
     ):
         return None
-    fact = spec.matmul_facts[0]
+    fact = _tcgen05_fact_with_static_provenance(spec, spec.matmul_facts[0])
     if fact.lhs_dtype is not fact.rhs_dtype or fact.lhs_dtype not in (
         torch.float16,
         torch.bfloat16,
@@ -542,6 +570,65 @@ def _tcgen05_grouped_fact(env: CompileEnvironment) -> MatmulFact | None:
     if fact.static_m % 128 != 0 or fact.static_n % 64 != 0:
         return None
     return fact
+
+
+def _tcgen05_fact_with_static_provenance(
+    spec: ConfigSpec,
+    fact: MatmulFact,
+) -> MatmulFact:
+    static_extents = spec._tcgen05_matmul_compile_time_static_extents()
+    if static_extents is None:
+        return fact
+    return fact._replace(
+        static_m=static_extents[0],
+        static_n=static_extents[1],
+        static_k=static_extents[2],
+    )
+
+
+def _tcgen05_grouped_worklist_structural_fact(
+    env: CompileEnvironment,
+) -> MatmulFact | None:
+    """Return structural grouped facts before dynamic shape hints are frozen."""
+    spec = env.config_spec
+    if len(spec.matmul_facts) != 1 or len(spec.block_sizes) != 3:
+        return None
+    fact = _tcgen05_fact_with_static_provenance(spec, spec.matmul_facts[0])
+    if fact.lhs_dtype is not torch.bfloat16 or fact.rhs_dtype is not torch.bfloat16:
+        return None
+    if (
+        fact.m_block_id is None
+        or (fact.k_block_id is None and fact.static_k != 0)
+        or (fact.n_block_id is None and fact.static_n != 0)
+    ):
+        return None
+    if fact.k_block_id is None:
+        # A statically empty reduction erases the K block association from the
+        # matmul fact, but the registered third block axis remains its source.
+        # Recover it so the full grouped-worklist proof below can decide whether
+        # this kernel needs input-metadata specialization.
+        fact = fact._replace(k_block_id=spec.block_sizes[2].block_id)
+    try:
+        assert fact.m_block_id is not None
+        assert fact.k_block_id is not None
+        m_index = spec.block_sizes.block_id_to_index(fact.m_block_id)
+        k_index = spec.block_sizes.block_id_to_index(fact.k_block_id)
+        n_index = (
+            None
+            if fact.n_block_id is None
+            else spec.block_sizes.block_id_to_index(fact.n_block_id)
+        )
+    except KeyError:
+        return None
+    return fact if (m_index, n_index, k_index) in ((0, 1, 2), (0, None, 2)) else None
+
+
+def _tcgen05_grouped_worklist_fact(
+    env: CompileEnvironment,
+) -> MatmulFact | None:
+    if not env.config_spec.cute_tcgen05_search_enabled:
+        return None
+    return _tcgen05_grouped_worklist_structural_fact(env)
 
 
 def _tcgen05_grouped_dynamic_bk64_fact(env: CompileEnvironment) -> MatmulFact | None:
@@ -622,6 +709,659 @@ def _tcgen05_grouped_seed_config(bk: int) -> Config:
         Tcgen05PersistenceModel.STATIC_PERSISTENT.value
     )
     return config
+
+
+GroupedBMajor = Literal["k", "n"]
+
+_TCGEN05_GROUPED_B200_REFERENCE_NUM_SMS = 148
+_TCGEN05_GROUPED_B200_LOW_RESERVED_SMS = 32
+_TCGEN05_GROUPED_B200_HIGH_RESERVED_SMS = 52
+_TCGEN05_GROUPED_B200_PANEL_RESERVED_SMS = 20
+# Grouped tcgen05 lowering is supported on both Blackwell compute capabilities;
+# target-specific seed ranking remains separate from this architecture gate.
+_TCGEN05_GROUPED_SUPPORTED_CAPABILITIES = frozenset({"sm100", "sm103"})
+# These measurements rank the initial seed population only. Other SM counts are
+# scaled proportionally, and live autotuning remains authoritative.
+
+# Exhaustive schema for the side-effect-free grouped-worklist config builder.
+_TCGEN05_GROUPED_WORKLIST_CONFIG_KEYS = frozenset(
+    {
+        "block_sizes",
+        "l2_groupings",
+        "loop_orders",
+        "num_stages",
+        "num_warps",
+        "pid_type",
+        "tcgen05_cluster_m",
+        "tcgen05_cluster_n",
+        "tcgen05_ab_stages",
+        "tcgen05_acc_stages",
+        "tcgen05_c_stages",
+        "tcgen05_num_epi_warps",
+        TCGEN05_CONSUMER_REGS_CONFIG_KEY,
+        TCGEN05_GROUPED_MODE_CONFIG_KEY,
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+        TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+        TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY,
+        TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+        TCGEN05_STRATEGY_CONFIG_KEY,
+        TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY,
+        TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY,
+    }
+)
+
+
+def tcgen05_grouped_worklist_config_values(
+    source_m_tile: int,
+    block_k: int,
+    ab_stages: int,
+    consumer_regs: int,
+    *,
+    runtime_direct: bool = True,
+    l2_swizzle_size: int | None = None,
+    reserved_sms: int | None = None,
+    clc: bool = False,
+) -> dict[str, object]:
+    """Return the exact values used by the grouped-worklist seed builder.
+
+    This side-effect-free seam exposes compiler seed values without depending on
+    the compiler's private builder.
+    """
+    if clc and not runtime_direct:
+        raise ValueError("grouped worklist CLC requires runtime_direct=True")
+    cluster_m = (
+        1 if source_m_tile == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE else 2
+    )
+    values: dict[str, object] = {
+        "block_sizes": [256, 128, block_k],
+        "l2_groupings": [1],
+        "loop_orders": [[0, 1, 2]],
+        "num_stages": 7,
+        "num_warps": 8,
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": cluster_m,
+        "tcgen05_cluster_n": 1,
+        "tcgen05_ab_stages": ab_stages,
+        "tcgen05_acc_stages": 2,
+        "tcgen05_c_stages": 2,
+        "tcgen05_num_epi_warps": 4,
+        TCGEN05_CONSUMER_REGS_CONFIG_KEY: consumer_regs,
+        TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_WORKLIST_NM,
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY: source_m_tile,
+    }
+    if runtime_direct:
+        values[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = True
+    if l2_swizzle_size is not None:
+        values[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = l2_swizzle_size
+    if reserved_sms is not None:
+        values[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = reserved_sms
+    if clc:
+        values.update(
+            {
+                TCGEN05_STRATEGY_CONFIG_KEY: (
+                    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+                ),
+                TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: 1,
+                TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
+                    Tcgen05PersistenceModel.CLC_PERSISTENT.value
+                ),
+            }
+        )
+    if missing_schema_keys := values.keys() - _TCGEN05_GROUPED_WORKLIST_CONFIG_KEYS:
+        raise RuntimeError(
+            "grouped-worklist config builder emitted keys missing from its schema: "
+            f"{sorted(missing_schema_keys)!r}"
+        )
+    return values
+
+
+def _tcgen05_grouped_worklist_config(
+    source_m_tile: int,
+    block_k: int,
+    ab_stages: int,
+    consumer_regs: int,
+    *,
+    runtime_direct: bool = True,
+    l2_swizzle_size: int | None = None,
+    reserved_sms: int | None = None,
+    clc: bool = False,
+) -> Config:
+    return Config.from_dict(
+        tcgen05_grouped_worklist_config_values(
+            source_m_tile,
+            block_k,
+            ab_stages,
+            consumer_regs,
+            runtime_direct=runtime_direct,
+            l2_swizzle_size=l2_swizzle_size,
+            reserved_sms=reserved_sms,
+            clc=clc,
+        )
+    )
+
+
+def tcgen05_grouped_worklist_config_keys() -> frozenset[str]:
+    """Return the exhaustive grouped-worklist compiler-seed schema."""
+    return _TCGEN05_GROUPED_WORKLIST_CONFIG_KEYS
+
+
+def _tcgen05_grouped_scaled_reserved_sms(
+    num_sm: int,
+    b200_reserved_sms: int,
+) -> int:
+    value = round(num_sm * b200_reserved_sms / _TCGEN05_GROUPED_B200_REFERENCE_NUM_SMS)
+    # The reviewed B200 occupancy splits were selected on a two-SM reservation
+    # lattice.  Preserve that lattice after proportional scaling; an odd rounded
+    # value moves up so the seed never reserves less than the scaled reference.
+    value += value % 2
+    return min(
+        max(value, 0),
+        max(num_sm - 2, 0),
+        TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX,
+    )
+
+
+def _tcgen05_grouped_small_m_reserved_sms(
+    *,
+    groups: int,
+    work_clusters: int,
+    num_sm: int,
+) -> tuple[int, int]:
+    """Rank low/high reserved-SM seeds scaled from B200 occupancy splits."""
+    low = _tcgen05_grouped_scaled_reserved_sms(
+        num_sm,
+        _TCGEN05_GROUPED_B200_LOW_RESERVED_SMS,
+    )
+    high = _tcgen05_grouped_scaled_reserved_sms(
+        num_sm,
+        _TCGEN05_GROUPED_B200_HIGH_RESERVED_SMS,
+    )
+    active_high = num_sm - high
+    high_first = (
+        groups <= 8
+        and work_clusters > num_sm
+        and active_high > 0
+        and work_clusters % active_high == 0
+    )
+    return (high, low) if high_first else (low, high)
+
+
+def tcgen05_grouped_worklist_seed_configs(
+    *,
+    groups: int,
+    packed_m: int,
+    n: int,
+    k: int,
+    b_major: GroupedBMajor,
+    source_m_tile: int,
+    num_sm: int,
+) -> list[Config]:
+    """Build ranked, tile-compatible grouped-worklist compiler seeds."""
+    if any(
+        type(value) is not int or value <= 0
+        for value in (groups, packed_m, n, k, num_sm)
+    ):
+        raise ValueError("grouped seed dimensions and num_sm must be positive integers")
+    if b_major not in ("k", "n"):
+        raise ValueError(f"unsupported grouped B major {b_major!r}")
+    if source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES:
+        raise ValueError(f"unsupported grouped source M tile {source_m_tile!r}")
+    if packed_m % source_m_tile != 0:
+        raise ValueError("packed M extent must be divisible by source_m_tile")
+
+    if source_m_tile == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE:
+        logical_n_per_cluster = 128
+        work_clusters = (packed_m // source_m_tile) * (
+            (n + logical_n_per_cluster - 1) // logical_n_per_cluster
+        )
+        preferred_reservation, alternate_reservation = (
+            _tcgen05_grouped_small_m_reserved_sms(
+                groups=groups,
+                work_clusters=work_clusters,
+                num_sm=num_sm,
+            )
+        )
+        high_reservation = _tcgen05_grouped_scaled_reserved_sms(
+            num_sm,
+            _TCGEN05_GROUPED_B200_HIGH_RESERVED_SMS,
+        )
+        panel_reservation = _tcgen05_grouped_scaled_reserved_sms(
+            num_sm,
+            _TCGEN05_GROUPED_B200_PANEL_RESERVED_SMS,
+        )
+        bk128 = {
+            "preferred_reserved": _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                128,
+                5,
+                256,
+                reserved_sms=preferred_reservation,
+            ),
+            "alternate_reserved": _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                128,
+                5,
+                256,
+                reserved_sms=alternate_reservation,
+            ),
+            "unreserved": _tcgen05_grouped_worklist_config(source_m_tile, 128, 5, 256),
+        }
+        bk64 = {
+            "high_reserved": _tcgen05_grouped_worklist_config(
+                source_m_tile, 64, 7, 240, reserved_sms=high_reservation
+            ),
+            "direct": _tcgen05_grouped_worklist_config(source_m_tile, 64, 7, 240),
+            "panel4": _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                64,
+                7,
+                240,
+                l2_swizzle_size=4,
+                reserved_sms=panel_reservation,
+            ),
+            "panel8": _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                64,
+                7,
+                240,
+                l2_swizzle_size=8,
+                reserved_sms=panel_reservation,
+            ),
+            "mailbox": _tcgen05_grouped_worklist_config(
+                source_m_tile, 64, 7, 240, runtime_direct=False
+            ),
+        }
+        if groups >= 16:
+            if n > k:
+                primary = bk64["panel8"]
+            elif n < k:
+                primary = bk64["panel4"]
+            else:
+                primary = bk64["direct"]
+        elif n >= 9 * k // 4:
+            primary = bk128["alternate_reserved"]
+        elif n >= 2 * k:
+            primary = bk64["high_reserved"]
+        elif k > n:
+            primary = bk64["direct"]
+        else:
+            primary = bk128["preferred_reserved"]
+        return dedupe_configs([primary, *bk128.values(), *bk64.values()])
+
+    if source_m_tile == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT:
+        # Source-224 keeps the reviewed panel-8 direct config as its deterministic
+        # primary; the remaining mailbox/BK128 variants are fallback seeds.
+        panel8_direct = _tcgen05_grouped_worklist_config(
+            source_m_tile,
+            64,
+            7,
+            256,
+            l2_swizzle_size=8,
+        )
+        mailbox_by_ab_stages = {
+            ab_stages: _tcgen05_grouped_worklist_config(
+                source_m_tile, 64, ab_stages, 240, runtime_direct=False
+            )
+            for ab_stages in range(7, 3, -1)
+        }
+        bk128_direct = _tcgen05_grouped_worklist_config(source_m_tile, 128, 3, 240)
+        return dedupe_configs(
+            [panel8_direct, *mailbox_by_ab_stages.values(), bk128_direct]
+        )
+
+    logical_n_per_cluster = 256
+    work_clusters = (packed_m // source_m_tile) * (
+        (n + logical_n_per_cluster - 1) // logical_n_per_cluster
+    )
+    bk128 = {
+        "mailbox": _tcgen05_grouped_worklist_config(
+            source_m_tile, 128, 3, 240, runtime_direct=False
+        ),
+        "direct": _tcgen05_grouped_worklist_config(source_m_tile, 128, 3, 240),
+        "panel8": _tcgen05_grouped_worklist_config(
+            source_m_tile, 128, 3, 240, l2_swizzle_size=8
+        ),
+    }
+    bk64 = {
+        "mailbox_regs224": _tcgen05_grouped_worklist_config(
+            source_m_tile, 64, 6, 224, runtime_direct=False
+        ),
+        "mailbox_regs240": _tcgen05_grouped_worklist_config(
+            source_m_tile, 64, 6, 240, runtime_direct=False
+        ),
+        "direct_regs240": _tcgen05_grouped_worklist_config(source_m_tile, 64, 6, 240),
+        "panel16_regs224": _tcgen05_grouped_worklist_config(
+            source_m_tile, 64, 6, 224, l2_swizzle_size=16
+        ),
+        "panel8_stage5_regs224": _tcgen05_grouped_worklist_config(
+            source_m_tile, 64, 5, 224, l2_swizzle_size=8
+        ),
+    }
+    # Runtime CLC uses fixed full-allocation TensorMaps.  In N,M orientation,
+    # logical N is the physical MMA-M dimension, so the immutable descriptor
+    # path requires a whole 256-row physical tile.  Keep tail-N shapes on the
+    # dynamic-TensorMap runtime-direct or mailbox families.
+    clc_by_consumer_regs = (
+        {
+            consumer_regs: _tcgen05_grouped_worklist_config(
+                source_m_tile,
+                64,
+                6,
+                consumer_regs,
+                l2_swizzle_size=8,
+                clc=True,
+            )
+            for consumer_regs in (240, 256)
+        }
+        if (
+            n % logical_n_per_cluster == 0
+            and work_clusters <= TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS
+        )
+        else {}
+    )
+    clc_configs = list(clc_by_consumer_regs.values())
+    # Ranking-only splits fitted from the reviewed B200 source-256 cases:
+    # 16 groups marks high fan-out, N/K=2 and 9/4 are aspect buckets, and
+    # 8/24 tiles per group separate short, medium, and long expert waves.
+    tiles_per_group = packed_m // source_m_tile // groups
+    clc_ready = bool(clc_configs) and work_clusters >= num_sm
+    if groups >= 16:
+        if k > n or n >= 9 * k // 4:
+            primary = bk128["mailbox"]
+        elif n >= 2 * k:
+            primary = bk64["direct_regs240"]
+        else:
+            primary = bk64["mailbox_regs224"]
+    elif tiles_per_group >= 8:
+        if k > n and clc_ready:
+            preferred_clc_consumer_regs = 256 if groups <= 4 else 240
+            primary = clc_by_consumer_regs[preferred_clc_consumer_regs]
+        elif n >= 9 * k // 4:
+            primary = bk64["panel16_regs224"] if b_major == "n" else bk128["panel8"]
+        elif n >= 2 * k:
+            primary = (
+                clc_by_consumer_regs[240]
+                if b_major == "n" and clc_ready
+                else bk64["direct_regs240"]
+            )
+        elif n == k:
+            primary = (
+                bk128["direct"]
+                if tiles_per_group >= 24
+                else bk64["panel8_stage5_regs224"]
+            )
+        else:
+            primary = bk64["mailbox_regs240"]
+    elif b_major == "n" and n >= 2 * k:
+        primary = bk64["direct_regs240"]
+    else:
+        primary = bk64["mailbox_regs240"]
+    return dedupe_configs([primary, *clc_configs, *bk64.values(), *bk128.values()])
+
+
+def _tcgen05_grouped_worklist_source_m_tiles(
+    env: CompileEnvironment,
+    analysis: Tcgen05GroupedWorklistAnalysis,
+) -> tuple[int, ...]:
+    """Return legal source-M schedule families for one recognized input layout."""
+    if analysis.input_kind == "device_split_sizes":
+        # Compact A has no physical source-tile constraint. Source-32 currently
+        # requires the one-CTA path, which is not valid for device split sizes.
+        return (
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+        )
+
+    facts = analysis.seed_facts
+    from ..cute.grouped_worklist import (
+        has_tcgen05_grouped_worklist_runtime_specialization,
+    )
+
+    if not has_tcgen05_grouped_worklist_runtime_specialization(
+        env, analysis.metadata_tensor
+    ):
+        return ()
+    worklist = env.runtime_value_for_tensor(analysis.metadata_tensor)
+    if not isinstance(worklist, torch.Tensor):
+        return ()
+    from torch._subclasses import FakeTensor
+    from torch._subclasses.fake_tensor import unset_fake_temporarily
+
+    from ..cute.grouped_worklist import (
+        tcgen05_grouped_worklist_compatible_source_m_tiles,
+    )
+    from ..cute.grouped_worklist import (
+        tcgen05_grouped_worklist_source_m_tiles_by_preference,
+    )
+
+    if isinstance(worklist, FakeTensor):
+        if not isinstance(worklist.constant, torch.Tensor):
+            return ()
+        worklist = worklist.constant
+    with unset_fake_temporarily():
+        rows = (
+            cast("list[list[int]]", worklist.detach().cpu().tolist())
+            if worklist.ndim == 2 and worklist.shape[1] == 4
+            else []
+        )
+    compatible = tcgen05_grouped_worklist_compatible_source_m_tiles(
+        rows,
+        group_count=facts.groups_hint,
+        packed_m=facts.packed_m_hint,
+    )
+    return tcgen05_grouped_worklist_source_m_tiles_by_preference(compatible)
+
+
+_TCGEN05_GROUPED_WORKLIST_AUTOMATIC_SEED_LIMIT = 8
+
+
+def _bounded_grouped_worklist_seed_families(
+    families: Sequence[Sequence[Config]],
+) -> list[Config]:
+    """Keep every legal family represented without expanding tuning startup."""
+    nonempty = [family for family in families if family]
+    if not nonempty:
+        return []
+    ranked = [
+        family[index]
+        for index in range(max(map(len, nonempty)))
+        for family in nonempty
+        if index < len(family)
+    ]
+    return dedupe_configs(ranked)[:_TCGEN05_GROUPED_WORKLIST_AUTOMATIC_SEED_LIMIT]
+
+
+class CuteTcgen05GroupedWorklistHeuristic(AutotunerHeuristic):
+    """Rank general grouped-worklist configs while preserving live tuning."""
+
+    name = "cute_tcgen05_grouped_worklist"
+    backend = "cute"
+    promote_seed_to_default = True
+    PROMOTE_TARGETS = (("cuda", "sm100"), ("cuda", "sm103"))
+    CACHE_SPECIALIZATION_FACTS = frozenset({"config_num_sm", "input_tensor_metadata"})
+
+    @classmethod
+    def register_facts(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> frozenset[CompilerHeuristicSpecializationFact]:
+        """Record grouped SMEM facts independently of seed generation.
+
+        Grouped semantics are discovered from DeviceIR rather than a user
+        annotation. Publish seed specialization even when an empty first
+        binding cannot emit seeds, and input specialization when heuristics are
+        disabled but correctness facts still depend on runtime metadata.
+        """
+        spec = env.config_spec
+        fact = _tcgen05_grouped_worklist_structural_fact(env)
+        if fact is None:
+            return frozenset()
+        from ..cute.cute_mma import analyze_tcgen05_grouped_worklist
+
+        analysis = analyze_tcgen05_grouped_worklist(
+            env,
+            device_ir,
+            fact,
+        )
+        if analysis is None:
+            return frozenset()
+        seed_facts = analysis.seed_facts
+        if analysis.input_kind == "external_worklist":
+            from ..cute.grouped_worklist import (
+                register_tcgen05_grouped_worklist_runtime_specialization,
+            )
+
+            register_tcgen05_grouped_worklist_runtime_specialization(
+                env,
+                analysis.metadata_tensor,
+                grouped_tensor=analysis.grouped_tensor,
+                packed_tensor=analysis.packed_tensor,
+            )
+        if seed_facts.groups_hint > 0:
+            spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+                group_count=seed_facts.groups_hint,
+                device_split_sizes=seed_facts.device_split_sizes,
+            )
+        if env.settings.disable_autotuner_heuristics:
+            return frozenset({"input_tensor_metadata"})
+        return cls.CACHE_SPECIALIZATION_FACTS
+
+    @classmethod
+    def _eligible_inputs(
+        cls,
+        env: CompileEnvironment,
+        device_ir: DeviceIR,
+    ) -> tuple[MatmulFact, Tcgen05GroupedWorklistAnalysis] | None:
+        spec = env.config_spec
+        fact = _tcgen05_grouped_worklist_fact(env)
+        if (
+            fact is None
+            or (fact.static_n is not None and fact.static_n % 32 != 0)
+            or spec.target_device_capability is None
+            or f"sm{spec.target_device_capability[0]}{spec.target_device_capability[1]}"
+            not in _TCGEN05_GROUPED_SUPPORTED_CAPABILITIES
+            or not _block_size_value_reachable(spec, 0, 256)
+            or not _block_size_value_reachable(spec, 1, 128)
+            or not any(
+                _block_size_value_reachable(spec, 2, block_k)
+                for block_k in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+            )
+        ):
+            return None
+        from ..cute.cute_mma import analyze_tcgen05_grouped_worklist
+
+        analysis = analyze_tcgen05_grouped_worklist(env, device_ir, fact)
+        if (
+            analysis is None
+            or min(
+                analysis.seed_facts.groups_hint,
+                analysis.seed_facts.packed_m_hint,
+                analysis.seed_facts.n_hint,
+                analysis.seed_facts.k_hint,
+            )
+            <= 0
+            or analysis.seed_facts.n_hint % 32 != 0
+        ):
+            return None
+        if not tcgen05_runtime_n_ptx_compatible():
+            warn_tcgen05_runtime_n_ptx_fallback()
+            return None
+        return fact, analysis
+
+    @classmethod
+    def _seed_configs(
+        cls,
+        env: CompileEnvironment,
+        device_ir: DeviceIR,
+    ) -> list[Config]:
+        eligible = cls._eligible_inputs(env, device_ir)
+        if eligible is None:
+            return []
+        _fact, analysis = eligible
+        spec = env.config_spec
+        seed_facts = analysis.seed_facts
+        source_m_tiles = _tcgen05_grouped_worklist_source_m_tiles(env, analysis)
+        if not source_m_tiles:
+            return []
+        families: list[list[Config]] = []
+        for source_m_tile in source_m_tiles:
+            # ``packed_m_hint`` remains the exact compiler fact. Seed selection
+            # only needs a tile-wave estimate, so round this local ranking input
+            # upward. Runtime/codegen validation never consumes the rounded value.
+            ranking_quantum = (
+                seed_facts.groups_hint * source_m_tile
+                if seed_facts.device_split_sizes
+                else source_m_tile
+            )
+            ranking_packed_m = (
+                (seed_facts.packed_m_hint + ranking_quantum - 1) // ranking_quantum
+            ) * ranking_quantum
+            family = tcgen05_grouped_worklist_seed_configs(
+                groups=seed_facts.groups_hint,
+                packed_m=ranking_packed_m,
+                n=seed_facts.n_hint,
+                k=seed_facts.k_hint,
+                b_major=seed_facts.b_major,
+                source_m_tile=source_m_tile,
+                num_sm=spec.num_sm,
+            )
+            if seed_facts.device_split_sizes:
+                # Device split-size kernels derive group rows on device and are
+                # supported only by the scheduler-mailbox family. Convert direct
+                # seeds rather than dropping useful BK/reservation variants;
+                # panel swizzles and CLC have no mailbox equivalent.
+                mailbox_family: list[Config] = []
+                for config in family:
+                    values = dict(config.config)
+                    l2_swizzle_size = values.get(
+                        TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY,
+                        1,
+                    )
+                    if values.get(
+                        TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
+                    ) == Tcgen05PersistenceModel.CLC_PERSISTENT.value or (
+                        type(l2_swizzle_size) is int and l2_swizzle_size > 1
+                    ):
+                        continue
+                    values.pop(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY, None)
+                    mailbox_family.append(Config.from_dict(values))
+                family = dedupe_configs(mailbox_family)
+            family = [
+                config
+                for config in family
+                if seed_facts.k_hint
+                % cast("list[int]", config.config["block_sizes"])[2]
+                == 0
+            ]
+            family = _filter_reachable_block_size_configs(spec, family)
+            families.append(family)
+        return _bounded_grouped_worklist_seed_families(families)
+
+    @classmethod
+    def should_promote(cls, env: CompileEnvironment) -> bool:
+        fact = _tcgen05_grouped_worklist_fact(env)
+        return (
+            tcgen05_runtime_n_ptx_compatible()
+            and fact is not None
+            and fact.static_k is not None
+            and super().should_promote(env)
+        )
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return cls._eligible_inputs(env, device_ir) is not None
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        configs = cls._seed_configs(env, device_ir)
+        return configs[0] if configs else None
+
+    @classmethod
+    def get_seed_configs(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> list[Config] | None:
+        return cls._seed_configs(env, device_ir)
 
 
 class CuteTcgen05GroupedStaticCommonKHeuristic(AutotunerHeuristic):
@@ -850,6 +1590,7 @@ class CuteTcgen05ThreadLocalEpilogueHeuristic(AutotunerHeuristic):
 class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
     name = "cute_tcgen05_cluster_m2"
     backend = "cute"
+    CACHE_SPECIALIZATION_FACTS = frozenset({"device_num_sm"})
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:

--- a/helion/_compiler/autotuner_heuristics/registry.py
+++ b/helion/_compiler/autotuner_heuristics/registry.py
@@ -2,12 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import ClassVar
+from typing import Literal
 
 if TYPE_CHECKING:
     from ...runtime.config import Config
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
     from .common import HardwareTarget
+    from .common import NamedHardwareTarget
+
+
+CompilerHeuristicSpecializationFact = Literal[
+    "config_num_sm",
+    "device_num_sm",
+    "input_tensor_metadata",
+]
 
 
 class AutotunerHeuristic:
@@ -24,6 +33,46 @@ class AutotunerHeuristic:
     # be offered everywhere as a search candidate but only defaulted on validated
     # arches.
     PROMOTE_TARGETS: ClassVar[tuple[HardwareTarget, ...] | None] = None
+    # Optional exact product targets for seeds validated on one named device.
+    # This never limits where a seed fires, only where it becomes the default.
+    PROMOTE_NAMED_TARGETS: ClassVar[frozenset[NamedHardwareTarget] | None] = None
+    # Runtime facts that can change this heuristic's emitted seed configs.  The
+    # bound-kernel cache adds these facts only after the heuristic actually
+    # fires, so a shape- or SM-sensitive heuristic does not force unrelated
+    # kernels on the same backend to specialize on those facts.
+    #
+    # ``device_num_sm`` is the physical count returned by get_num_sm(device).
+    # ``config_num_sm`` is ConfigSpec.num_sm, which also applies the kernel's
+    # persistent_reserved_sms setting.
+    # ``input_tensor_metadata`` is the exact shape and stride of every input
+    # tensor. Dynamic kernels request it when first-binding shape/layout hints
+    # affect their seed population or the generated schedule's validity. It
+    # intentionally creates a distinct bound kernel for each metadata tuple;
+    # heuristics should request it only when coarser reuse would be unsound.
+    CACHE_SPECIALIZATION_FACTS: ClassVar[
+        frozenset[CompilerHeuristicSpecializationFact]
+    ] = frozenset()
+
+    @classmethod
+    def register_facts(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> frozenset[CompilerHeuristicSpecializationFact]:
+        """Register correctness facts before optional seed generation.
+
+        Overrides must be idempotent because callers may regenerate compiler
+        seeds for the same bound kernel. This hook runs even when autotuner
+        heuristics are disabled; it must not itself add or promote seed configs.
+        Exceptions intentionally propagate and fail binding because silently
+        dropping correctness facts could make later normalization unsound.
+
+        Return the runtime facts that can change either the registration
+        outcome or the registered correctness facts. An input-dependent hook
+        must return its requirements even when this binding registers nothing,
+        so a later binding that would register facts cannot reuse it. These
+        requirements are independent of ``CACHE_SPECIALIZATION_FACTS``, which
+        applies only when this heuristic actually emits seeds.
+        """
+        return frozenset()
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
@@ -38,15 +87,18 @@ class AutotunerHeuristic:
     @classmethod
     def should_promote(cls, env: CompileEnvironment) -> bool:
         """Whether this heuristic's seed should become the autotune-off default
-        on the current device. Gates the (possibly arch-agnostic) seed's
-        promotion to ``PROMOTE_TARGETS`` without changing where the seed fires."""
+        on the current device. Target gates do not change where the seed fires."""
         if not cls.promote_seed_to_default:
             return False
-        if cls.PROMOTE_TARGETS is None:
+        if cls.PROMOTE_TARGETS is None and cls.PROMOTE_NAMED_TARGETS is None:
             return True
         from .common import matches_hardware
 
-        return matches_hardware(env, cls.PROMOTE_TARGETS)
+        return matches_hardware(
+            env,
+            cls.PROMOTE_TARGETS,
+            named_targets=cls.PROMOTE_NAMED_TARGETS,
+        )
 
     @classmethod
     def get_seed_configs(

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -485,6 +485,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
     name = "triton_h100_matmul"
     backend = "triton"
     promote_seed_to_default = True
+    CACHE_SPECIALIZATION_FACTS = frozenset({"device_num_sm"})
     # Annotated so a hardware-specific subclass may override the arch (e.g. sm100).
     HARDWARE_TARGETS: ClassVar[tuple[tuple[str, str], ...]] = (("cuda", "sm90"),)
 
@@ -3021,6 +3022,7 @@ class TritonPointwiseSeedHeuristic(AutotunerHeuristic):
 
     name = "triton_pointwise"
     backend = "triton"
+    CACHE_SPECIALIZATION_FACTS = frozenset({"device_num_sm"})
     # Fires arch-agnostically (is_eligible keys only on the pointwise fact), but
     # its byte/register constants were hill-climbed and validated on H100 (sm90).
     # Promote to the autotune-off default ONLY on the arches the correctness hunt
@@ -3420,6 +3422,7 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     """
 
     backend = "triton"
+    CACHE_SPECIALIZATION_FACTS = frozenset({"device_num_sm"})
     # Widen the declared type so the sm100 subclass can retarget it (the base is sm90-only).
     HARDWARE_TARGETS: ClassVar[tuple[HardwareTarget, ...]] = (("cuda", "sm90"),)
     # Promote the reduction seed to the compiler default (autotune off) for every tuned track

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -29,6 +29,9 @@ from .cute.attention_plan import SOFTCAP_KIND
 from .cute.attention_plan import TENSOR_BIAS_KIND
 from .cute.attention_plan import AttentionScoreModifier
 from .cute.attention_plan import AttentionScorePlan
+from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from .cute.tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_profile
 
 if TYPE_CHECKING:
     import ast
@@ -3037,13 +3040,7 @@ def _grouped_rank3_specialized_mma_plan(
     env: CompileEnvironment,
 ) -> _SpecializedMmaPlan | None:
     from .cute.cute_mma import _choose_mma_impl
-    from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
-    from .cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
-    from .cute.tcgen05_constants import (
-        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-    )
-    from .cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
-    from .cute.tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_shape
+    from .cute.cute_mma import _rank3_grouped_root_axes
     from .host_function import HostFunction
 
     if node.target is not torch.ops.aten.addmm.default:
@@ -3052,14 +3049,34 @@ def _grouped_rank3_specialized_mma_plan(
     if len(device_ir.grid_block_ids) != 1:
         return None
     root_grid_ids = device_ir.grid_block_ids[0]
-    if len(root_grid_ids) == 2:
-        segment_root_grid_id = None
-        mn_root_grid_ids = root_grid_ids
-    elif len(root_grid_ids) == 3:
-        segment_root_grid_id = root_grid_ids[0]
-        mn_root_grid_ids = root_grid_ids[1:]
-    else:
+    axes = None
+    semantic_block_ids = env.config_spec._tcgen05_matmul_block_ids()
+    if semantic_block_ids is not None:
+        m_block_id, n_block_id, semantic_k_block_id = semantic_block_ids
+        if env.canonical_block_id(semantic_k_block_id) == env.canonical_block_id(
+            k_block_id
+        ):
+            axes = _rank3_grouped_root_axes(
+                env,
+                device_ir,
+                m_block_id=m_block_id,
+                n_block_id=n_block_id,
+                k_block_id=k_block_id,
+            )
+    if semantic_block_ids is not None and axes is None:
         return None
+    if axes is None:
+        if len(root_grid_ids) == 2:
+            segment_root_grid_id = None
+            mn_root_grid_ids = root_grid_ids
+        elif len(root_grid_ids) == 3:
+            segment_root_grid_id = root_grid_ids[0]
+            mn_root_grid_ids = root_grid_ids[1:]
+        else:
+            return None
+    else:
+        segment_root_grid_id = axes.segment_block_id
+        mn_root_grid_ids = [axes.m_block_id, axes.n_block_id]
     if segment_root_grid_id is not None:
         segment_block = env.block_sizes[segment_root_grid_id].from_config(config)
         if segment_block != 1:
@@ -3089,19 +3106,17 @@ def _grouped_rank3_specialized_mma_plan(
         return None
     mma_bm = bm
     mma_bn = bn
-    if config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) == TCGEN05_GROUPED_MODE_WORKLIST_NM:
-        source_m_tile = config.get(
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-        )
-        physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
-            cluster_m=config.get("tcgen05_cluster_m", 1),
-            block_k=bk,
-            source_m_tile=source_m_tile,
-        )
-        if physical_shape is None:
-            return None
-        mma_bm, mma_bn = physical_shape
+    worklist_profile = resolve_tcgen05_grouped_worklist_mma_profile(
+        config,
+        block_k=bk,
+    )
+    if (
+        config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) == TCGEN05_GROUPED_MODE_WORKLIST_NM
+        and worklist_profile is None
+    ):
+        return None
+    if worklist_profile is not None:
+        mma_bm, mma_bn = worklist_profile.mma_m, worklist_profile.mma_n
     mma_impl = _choose_mma_impl(
         lhs_val.dtype,
         bm=mma_bm,
@@ -3109,10 +3124,7 @@ def _grouped_rank3_specialized_mma_plan(
         bk=bk,
         config=config,
         input_device=lhs_val.device,
-        defer_grouped_worklist_smem_check=(
-            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
-            == TCGEN05_GROUPED_MODE_WORKLIST_NM
-        ),
+        defer_grouped_worklist_smem_check=worklist_profile is not None,
     )
     if mma_impl != "tcgen05":
         return None

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -89,6 +89,22 @@ class TensorDescriptorLayoutGuard:
     atomic_op_indices: set[int] = dataclasses.field(default_factory=set)
 
 
+@dataclasses.dataclass(frozen=True)
+class RuntimeInputSpecialization:
+    """Internal runtime-input projection used to extend a kernel cache key.
+
+    ``classifier_identity`` distinguishes classifier semantics when compiler
+    discovery registers the same named projection more than once. Runtime cache
+    state is deliberately excluded from descriptor equality.
+    """
+
+    sources: tuple[Source, ...]
+    classifier_identity: typing.Hashable
+    classifier: typing.Callable[[typing.Sequence[object]], typing.Hashable] = (
+        dataclasses.field(compare=False, repr=False)
+    )
+
+
 def _is_supported_tensor_input_source(source: Source) -> bool:
     if isinstance(source, LocalSource):
         return True
@@ -232,6 +248,7 @@ if TYPE_CHECKING:
 
     from .. import Config
     from ..runtime.settings import Settings
+    from .autotuner_heuristics.registry import CompilerHeuristicSpecializationFact
     from .backend import Backend
     from .pallas.compact_worklist import CompactWorklistPlan
     from .pallas.compact_worklist import ResidentCacheDecision
@@ -327,6 +344,7 @@ class CompileEnvironment:
         # TODO(jansel): check for guards in the shapeenv
         self.fake_mode = FakeTensorMode(shape_env=self.shape_env)
         self.input_sources: dict[torch.Tensor, Source] = {}
+        self._ambiguous_tensor_input_source_ids: set[int] = set()
         self._runtime_arg_values_by_name: contextvars.ContextVar[
             dict[str, object] | None
         ] = contextvars.ContextVar(
@@ -360,6 +378,13 @@ class CompileEnvironment:
             num_sm=_num_sm,
             log_restrictions_verbose=settings.autotune_log_search_space_verbose,
         )
+        # Correctness facts registered by compiler heuristics can depend on
+        # dynamic runtime inputs even when seed generation is disabled or later
+        # found ineligible. Bound-kernel caching consumes this set separately
+        # from specialization requirements of heuristics that emitted seeds.
+        self.compiler_fact_specialization_facts: frozenset[
+            CompilerHeuristicSpecializationFact
+        ] = frozenset()
         # TODO(hinriksnaer): tracing state, not env config. move to CompilerState?
         self.kernel_tensor_sizes: dict[tuple[sympy.Expr, ...], int] = (
             collections.Counter()
@@ -373,6 +398,7 @@ class CompileEnvironment:
         self.tensor_descriptor_layout_guards: dict[
             Source, TensorDescriptorLayoutGuard
         ] = {}
+        self.runtime_input_specializations: dict[str, RuntimeInputSpecialization] = {}
         self._tensor_input_source_cache: dict[int, Source | None] = {}
         self.jagged_tile_parent_ids: dict[int, list[int]] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
@@ -588,6 +614,9 @@ class CompileEnvironment:
         cache_key = id(fake_tensor)
         if cache_key in self._tensor_input_source_cache:
             return self._tensor_input_source_cache[cache_key]
+        if cache_key in self._ambiguous_tensor_input_source_ids:
+            self._tensor_input_source_cache[cache_key] = None
+            return None
 
         source = self.input_sources.get(fake_tensor)
         from .host_function import HostFunction
@@ -613,6 +642,23 @@ class CompileEnvironment:
 
         self._tensor_input_source_cache[cache_key] = result
         return result
+
+    def runtime_value_for_tensor(self, fake_tensor: torch.Tensor) -> object | None:
+        """Replay a traced tensor's input source against the current real arguments."""
+        source = self.tensor_input_source(fake_tensor)
+        if source is None:
+            return None
+        return _replay_tensor_input_source(source, self.runtime_arg_values_by_name)
+
+    def register_runtime_input_specialization(
+        self,
+        key: str,
+        specialization: RuntimeInputSpecialization,
+    ) -> None:
+        """Register an internal projection from runtime inputs to a cache-key fact."""
+        previous = self.runtime_input_specializations.setdefault(key, specialization)
+        if previous != specialization:
+            raise RuntimeError(f"conflicting runtime input specializations for {key!r}")
 
     def tensor_descriptor_layout_signature(
         self, fake_tensor: torch.Tensor
@@ -1281,7 +1327,12 @@ class CompileEnvironment:
             result = self.fake_mode.fake_tensor_converter.from_real_tensor(
                 self.fake_mode, tensor, shape_env=self.shape_env, source=source
             )
-        self.input_sources[result] = source
+        previous_source = self.input_sources.get(result)
+        if previous_source is not None and previous_source != source:
+            self._ambiguous_tensor_input_source_ids.add(id(result))
+            self._tensor_input_source_cache.pop(id(result), None)
+        else:
+            self.input_sources[result] = source
         if isinstance(source, LocalSource):
             for i, s in enumerate(result.size()):
                 if isinstance(s, torch.SymInt) and isinstance(

--- a/helion/_compiler/cute/aux_tensor.py
+++ b/helion/_compiler/cute/aux_tensor.py
@@ -304,57 +304,19 @@ def discover_tcgen05_aux_tensor_descriptors(
 def host_function_has_tcgen05_aux_kernel_pattern(
     host_function: HostFunction,
 ) -> bool:
-    """Conservative pre-codegen detector for kernels whose tcgen05
-    matmul is followed by an aux-fused store
+    """Pre-codegen detector for kernels whose tcgen05 matmul is followed
+    by an aux-fused store
     (``out[tile] = (acc + residual[tile]).to(...)`` and the
     bias / rowvec variants — see :class:`_AuxiliaryTensorLoadExpr`
     for the accepted forms).
 
-    Runs at autotune-surface configuration time (post-FX-graph
-    build, pre-autotune-sample) where the
-    :func:`discover_tcgen05_aux_tensor_descriptors` walker is
-    unavailable — that walker requires a populated
-    ``DeviceFunction.cute_state.matmul_fx_nodes`` set, which
-    is only registered at MMA-codegen time per config sample.
-    The aux pipeline only fires when the productive-body gate
-    sees aux descriptors, so the autotune surface only needs
-    to widen ``tcgen05_warp_spec_c_input_warps`` when this
-    detector returns True; otherwise the C-input warp is
-    inert and sampling ``c_input_warps=1`` would be a strict
-    resource cost for pure-matmul kernels (the inert warp
-    occupies an SM slot without delivering work).
-
-    Implementation: walk every FX graph in
-    ``host_function.device_ir.graphs`` and look for the
-    coarse pattern "the kernel has at least one MMA-anchor
-    call AND at least one ``memory_ops.load`` call whose
-    result is NOT used as one of the MMA operands". MMA
-    anchors include both the aten paths
-    (``aten.addmm`` / ``aten.baddbmm`` / ``aten.mm`` /
-    ``aten.bmm``) AND the ``hl.dot`` HOP — both ends up
-    in the tcgen05 MMA lowering, and the canonical Helion
-    residual kernel uses ``hl.dot``. Operand resolution
-    traces through the same ``convert_element_type``
-    wrappers the MMA codegen accepts
-    (``cute_mma._trace_to_load`` /
-    ``_TRACE_THROUGH_TARGETS``); without this trace,
-    kernels written as ``lhs.to(dtype) @ rhs.to(dtype)``
-    would have their operand loads classified as aux and
-    the detector would over-fire on pure matmul.
-
-    The detector is **conservative**: a false positive
-    only widens the autotune search by one enum value
-    (the productive-body safety gates handle the resulting
-    invalid combinations at codegen time and the
-    inert-body fallback handles invalid runs); a false
-    negative would miss the residual c_input=1 win. The
-    chain analyzer at codegen time
-    (``analyze_tcgen05_unary_epilogue_chain``) remains the
-    source of truth for which aux shapes are *accepted*
-    by the productive-body codegen; this detector
-    intentionally over-approximates so the autotune surface
-    admits the productive shape whenever any aux load is
-    plausibly involved.
+    This runs after the FX graphs are built but before an autotune sample has
+    registered its MMA nodes in ``DeviceFunction.cute_state``. Use the MMA
+    anchors already present in the host graphs and the same store-chain
+    analyzer as codegen so only loads in an accepted per-subtile epilogue widen
+    the search surface. Unrelated loads used for scheduler metadata, indirect
+    indices, or masks must not expose aux-only knobs such as
+    ``tcgen05_aux_load_placement``.
 
     Caught patterns include:
 
@@ -369,22 +331,15 @@ def host_function_has_tcgen05_aux_kernel_pattern(
     if not graphs:
         return False
 
-    mma_nodes, operand_load_nodes = _tcgen05_aux_detector_mma_facts(graphs)
+    mma_nodes = _tcgen05_aux_detector_mma_nodes(graphs)
     if not mma_nodes:
         return False
-    # Second pass: any ``memory_ops.load`` call whose result
-    # is NOT a resolved MMA-operand load is treated as aux.
-    # Operand loads feed the dot directly (after optional
-    # casts); aux loads feed an arithmetic op that combines
-    # with the dot's result on the way to a store.
-    for graph_info in graphs:
-        for node in graph_info.graph.nodes:
-            if (
-                node.op == "call_function"
-                and node.target is memory_ops.load
-                and node not in operand_load_nodes
-            ):
-                return True
+    for mma_node in mma_nodes:
+        analyzed_stores = analyze_tcgen05_matmul_store_chains(graphs, mma_node)
+        if analyzed_stores is not None and any(
+            chain.auxiliary_tensor_loads for _, chain in analyzed_stores
+        ):
+            return True
     return False
 
 
@@ -415,7 +370,7 @@ def host_function_has_tcgen05_exact_shape_aux_kernel_pattern(
     if not graphs:
         return False
 
-    mma_nodes, _operand_load_nodes = _tcgen05_aux_detector_mma_facts(graphs)
+    mma_nodes = _tcgen05_aux_detector_mma_nodes(graphs)
     if not mma_nodes:
         return False
 
@@ -435,13 +390,11 @@ def host_function_has_tcgen05_exact_shape_aux_kernel_pattern(
     )
 
 
-def _tcgen05_aux_detector_mma_facts(
+def _tcgen05_aux_detector_mma_nodes(
     graphs: Sequence[GraphInfo],
-) -> tuple[set[torch.fx.Node], set[torch.fx.Node]]:
-    # MMA anchor targets: both the aten paths and the ``hl.dot`` HOP
-    # (the canonical Helion API entrypoint).
+) -> set[torch.fx.Node]:
+    """Return aten and ``hl.dot`` MMA anchors from the host FX graphs."""
     mma_nodes: set[torch.fx.Node] = set()
-    operand_load_nodes: set[torch.fx.Node] = set()
     for graph_info in graphs:
         for node in graph_info.graph.nodes:
             if (
@@ -450,14 +403,7 @@ def _tcgen05_aux_detector_mma_facts(
             ):
                 continue
             mma_nodes.add(node)
-            # Treat every positional arg that resolves through the same operand
-            # trace accepted by MMA codegen as an operand load.
-            for arg in node.args:
-                if isinstance(arg, torch.fx.Node):
-                    load_node = _trace_to_load_through_casts(arg)
-                    if load_node is not None:
-                        operand_load_nodes.add(load_node)
-    return mma_nodes, operand_load_nodes
+    return mma_nodes
 
 
 def host_function_matmul_has_non_tcgen05_operand(

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -192,6 +192,7 @@ def _detect_grouped_rank3_specialized_mma_loop(
 ) -> bool:
     from ..compile_environment import CompileEnvironment
     from ..host_function import HostFunction
+    from .cute_mma import _rank3_grouped_root_axes
 
     device_ir = HostFunction.current().device_ir
     if len(device_ir.grid_block_ids) != 1 or len(block_ids) != 1:
@@ -199,7 +200,25 @@ def _detect_grouped_rank3_specialized_mma_loop(
     root_grid_ids = device_ir.grid_block_ids[0]
     if any(block_id in root_grid_ids for block_id in block_ids):
         return False
-    if len(root_grid_ids) == 2:
+    env = CompileEnvironment.current()
+    semantic_block_ids = env.config_spec._tcgen05_matmul_block_ids()
+    axes = None
+    if semantic_block_ids is not None:
+        m_block_id, n_block_id, k_block_id = semantic_block_ids
+        if env.canonical_block_id(k_block_id) == env.canonical_block_id(block_ids[0]):
+            axes = _rank3_grouped_root_axes(
+                env,
+                device_ir,
+                m_block_id=m_block_id,
+                n_block_id=n_block_id,
+                k_block_id=block_ids[0],
+            )
+    if semantic_block_ids is not None and axes is None:
+        return False
+    if axes is not None:
+        segment_root_grid_id = axes.segment_block_id
+        mn_root_grid_ids = [axes.m_block_id, axes.n_block_id]
+    elif len(root_grid_ids) == 2:
         segment_root_grid_id = None
         mn_root_grid_ids = root_grid_ids
     elif len(root_grid_ids) == 3:
@@ -207,8 +226,6 @@ def _detect_grouped_rank3_specialized_mma_loop(
         mn_root_grid_ids = root_grid_ids[1:]
     else:
         return False
-
-    env = CompileEnvironment.current()
     if segment_root_grid_id is not None:
         segment_block = env.block_sizes[segment_root_grid_id].from_config(config)
         segment_threads = env.config_spec.num_threads.config_get(

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -28,6 +28,8 @@ import os
 import textwrap
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Literal
+from typing import NamedTuple
 from typing import cast
 
 import torch
@@ -136,7 +138,6 @@ from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_N_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
-from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
@@ -148,7 +149,7 @@ from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
-from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_shape
+from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_profile
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
 from .tcgen05_lifecycle import Tcgen05LifecycleContext
@@ -449,9 +450,14 @@ class _Rank3RhsPackedGroupInfo:
 
 @dataclass(frozen=True)
 class _Rank3RhsPackedSplitInfo:
-    """Proof that compact A rows are partitioned by device split sizes."""
+    """Proof that compact A rows are partitioned by a device segment layout.
 
-    split_sizes_tensor: torch.Tensor
+    Both ``split_sizes[G]`` and ``offsets[G + 1]`` are normalized to the same
+    kernel-local scheduler table before the persistent loop starts.
+    """
+
+    layout_tensor: torch.Tensor
+    layout_kind: Literal["split_sizes", "offsets"]
 
 
 @dataclass(frozen=True)
@@ -506,6 +512,64 @@ class _Rank3RhsGroupedProof:
     @property
     def is_worklist(self) -> bool:
         return self.worklist_lhs is not None
+
+    @property
+    def requires_explicit_grouped_mode(self) -> bool:
+        """Whether lowering must explicitly enable grouped semantics."""
+        return self.k_mask is not None or self.tail_epilogue is not None
+
+    @property
+    def requires_worklist_nm_schedule(self) -> bool:
+        """Whether lowering needs the N,M-oriented worklist schedule."""
+        return (
+            self.rhs.matrix_major == "row"
+            or self.packed_split is not None
+            or (
+                self.worklist_store is not None
+                and self.worklist_store.uses_scheduler_store_extent
+            )
+        )
+
+
+class Tcgen05GroupedWorklistSeedFacts(NamedTuple):
+    """Structural proof plus first-binding hints for worklist seed ranking.
+
+    The integer fields are deliberately named ``*_hint``: they are not static
+    compiler facts and must not escape the grouped-worklist heuristic.
+    """
+
+    groups_hint: int
+    packed_m_hint: int
+    n_hint: int
+    k_hint: int
+    b_major: Literal["k", "n"]
+    device_split_sizes: bool
+
+
+@dataclass(frozen=True)
+class Tcgen05GroupedWorklistAnalysis:
+    """Schedule-independent compiler facts for a grouped worklist input.
+
+    ``metadata_tensor`` is the traced fake tensor for either a compact device
+    segment layout or the external ``[segments, 4]`` worklist described by
+    ``input_kind``. ``packed_tensor`` and ``grouped_tensor`` provide replayable
+    runtime sources for the dimensions that define that layout.
+    """
+
+    seed_facts: Tcgen05GroupedWorklistSeedFacts
+    metadata_tensor: torch.Tensor
+    packed_tensor: torch.Tensor
+    grouped_tensor: torch.Tensor
+    device_layout_kind: Literal["split_sizes", "offsets"] | None = None
+
+    @property
+    def input_kind(self) -> Literal["device_split_sizes", "external_worklist"]:
+        """Return the semantic form of the traced scheduling input."""
+        return (
+            "device_split_sizes"
+            if self.seed_facts.device_split_sizes
+            else "external_worklist"
+        )
 
 
 @dataclass(frozen=True)
@@ -1150,7 +1214,7 @@ def _rank3_rhs_segment_metadata_load(
         not isinstance(metadata, torch.Tensor)
         or metadata.ndim != 2
         or metadata.dtype not in (torch.int32, torch.int64)
-        or metadata.shape[1] < 4
+        or metadata.shape[1] != 4
         or (expected_tensor is not None and metadata is not expected_tensor)
         or not isinstance(loaded, torch.Tensor)
         or loaded.ndim != 0
@@ -1363,6 +1427,139 @@ def _rank3_rhs_lhs_scaffold(
     )
 
 
+def _rank3_rhs_is_group_plus_one(
+    cg: GenerateAST,
+    node: Node,
+    *,
+    group_index: Node,
+) -> bool:
+    import operator
+
+    root = _trace_to_outer_graph_arg(cg, node)
+    if (
+        root.op != "call_function"
+        or root.target not in (operator.add, torch.ops.aten.add.Tensor)
+        or len(root.args) != 2
+        or root.kwargs
+    ):
+        return False
+    lhs, rhs = root.args
+    return (
+        isinstance(lhs, Node)
+        and _trace_to_outer_graph_arg(cg, lhs) is group_index
+        and type(rhs) is int
+        and rhs == 1
+    ) or (
+        isinstance(rhs, Node)
+        and _trace_to_outer_graph_arg(cg, rhs) is group_index
+        and type(lhs) is int
+        and lhs == 1
+    )
+
+
+def _rank3_rhs_packed_offsets_lhs_info(
+    cg: GenerateAST,
+    lhs_scaffold: _Rank3RhsLhsScaffold,
+    *,
+    group_index: Node,
+    group_count: int,
+) -> tuple[_Rank3RhsWorklistLhsInfo, _Rank3RhsPackedSplitInfo] | None:
+    """Match ``offsets[g] + local_m`` with extent ``offsets[g+1]-offsets[g]``."""
+    import operator
+
+    start_loaded = _rank3_rhs_packed_split_load(
+        cg,
+        lhs_scaffold.row_offset,
+        expected_index=group_index,
+    )
+    if start_loaded is None:
+        return None
+    offsets, start_load = start_loaded
+    if offsets.shape[0] != group_count + 1:
+        return None
+
+    extent = lhs_scaffold.valid_extent
+    if (
+        extent.op != "call_function"
+        or extent.target not in (operator.sub, torch.ops.aten.sub.Tensor)
+        or len(extent.args) != 2
+        or extent.kwargs
+        or not all(isinstance(arg, Node) for arg in extent.args)
+    ):
+        return None
+    end_value, start_value = cast("tuple[Node, Node]", extent.args)
+    if (
+        _trace_to_outer_graph_arg(cg, start_value) is not start_load
+        and _rank3_rhs_packed_split_load(
+            cg,
+            start_value,
+            expected_tensor=offsets,
+            expected_index=group_index,
+        )
+        is None
+    ):
+        return None
+    end_loaded = _rank3_rhs_packed_split_load(
+        cg,
+        end_value,
+        expected_tensor=offsets,
+    )
+    if end_loaded is None:
+        return None
+    _offsets, end_load = end_loaded
+    end_indices = end_load.args[1] if len(end_load.args) >= 2 else None
+    if (
+        not isinstance(end_indices, list | tuple)
+        or len(end_indices) != 1
+        or not isinstance(end_indices[0], Node)
+        or not _rank3_rhs_is_group_plus_one(
+            cg,
+            end_indices[0],
+            group_index=group_index,
+        )
+    ):
+        return None
+
+    dependency_nodes = tuple(
+        dict.fromkeys(
+            (
+                group_index,
+                *(
+                    dependency
+                    for dependency in _collect_node_dependencies(lhs_scaffold.row_index)
+                    if dependency.op == "call_function"
+                    and isinstance(dependency.meta.get("val"), torch.Tensor)
+                    and cast("torch.Tensor", dependency.meta["val"]).ndim == 0
+                ),
+                *(
+                    dependency
+                    for dependency in _collect_node_dependencies(lhs_scaffold.valid_m)
+                    if dependency.op == "call_function"
+                    and isinstance(dependency.meta.get("val"), torch.Tensor)
+                    and cast("torch.Tensor", dependency.meta["val"]).ndim == 0
+                ),
+                lhs_scaffold.row_offset,
+                extent,
+                lhs_scaffold.row_index,
+                lhs_scaffold.valid_m,
+            )
+        )
+    )
+    return (
+        _Rank3RhsWorklistLhsInfo(
+            row_start=start_load,
+            group_m=extent,
+            row_index=lhs_scaffold.row_index,
+            valid_m=lhs_scaffold.valid_m,
+            dependency_nodes=dependency_nodes,
+        ),
+        _Rank3RhsPackedSplitInfo(
+            layout_tensor=offsets,
+            layout_kind="offsets",
+        ),
+    )
+
+
 def _rank3_rhs_packed_split_lhs_info(
     cg: GenerateAST,
     lhs_info: _MmaOperandInfo,
@@ -1421,6 +1618,14 @@ def _rank3_rhs_packed_split_lhs_info(
     )
     if lhs_scaffold is None:
         return None
+    offsets_lhs = _rank3_rhs_packed_offsets_lhs_info(
+        cg,
+        lhs_scaffold,
+        group_index=packed_group.group_index,
+        group_count=group_count,
+    )
+    if offsets_lhs is not None:
+        return offsets_lhs
     group_m_loaded = _rank3_rhs_packed_split_load(
         cg,
         lhs_scaffold.valid_extent,
@@ -1502,7 +1707,8 @@ def _rank3_rhs_packed_split_lhs_info(
             dependency_nodes=dependency_nodes,
         ),
         _Rank3RhsPackedSplitInfo(
-            split_sizes_tensor=split_sizes,
+            layout_tensor=split_sizes,
+            layout_kind="split_sizes",
         ),
     )
 
@@ -2608,6 +2814,11 @@ def tcgen05_fragment_epilogue_source_tiles_reachable(
     """
     if not candidate.requires_fragment_epilogue:
         return True
+    static_m = plan.static_m
+    static_n = plan.static_n
+    static_k = plan.static_k
+    if static_m is None or static_n is None or static_k is None:
+        return False
 
     def reachable_values(block_id: int, low: int, high: int) -> tuple[int, ...]:
         if block_id not in config_spec.block_sizes.valid_block_ids():
@@ -2645,9 +2856,9 @@ def tcgen05_fragment_epilogue_source_tiles_reachable(
             bn=bn,
             input_dtype=analysis.lhs.source_fake.dtype,
         )
-        and plan.static_m % bm == 0
-        and plan.static_n % bn == 0
-        and plan.static_k % bk == 0
+        and static_m % bm == 0
+        and static_n % bn == 0
+        and static_k % bk == 0
         for bm in block_values[0]
         for bn in block_values[1]
         for bk in block_values[2]
@@ -2847,7 +3058,7 @@ def _analyze_rank3_rhs_grouped_search_operands(
         role="rhs",
         allow_rank3_rhs_nt=True,
         # This early DeviceIR pass only recovers axes. Complete grouped
-        # semantics are proven by ``_prove_rank3_rhs_grouped_mma``.
+        # semantics are proven by ``_analyze_rank3_rhs_grouped_mma``.
         allow_rank3_rhs_mn_major=True,
         cg=graph_view,
         allow_grouped_k_mask=True,
@@ -2864,6 +3075,16 @@ def _analyze_rank3_rhs_grouped_search_operands(
     canonical_block_id = env.canonical_block_id
     n_block_id = canonical_block_id(rhs.rhs_n_block_id)
     k_block_id = canonical_block_id(rhs.rhs_k_block_id)
+    lhs_indices = lhs.load.args[1] if len(lhs.load.args) > 1 else None
+    lhs_k_block_id = (
+        _rank3_rhs_exact_index_block_id(lhs_indices[-1], reduction=None)
+        if isinstance(lhs_indices, list | tuple)
+        and lhs_indices
+        and isinstance(lhs_indices[-1], Node)
+        else None
+    )
+    if lhs_k_block_id is None or canonical_block_id(lhs_k_block_id) != k_block_id:
+        return None
     if len(device_ir.grid_block_ids) != 1:
         return None
     root_grid_ids = device_ir.grid_block_ids[0]
@@ -2923,9 +3144,67 @@ def _analyze_rank3_rhs_grouped_search_operands(
     )
     if lhs.source_fake.dtype != rhs.source_fake.dtype:
         return None
-    if not env.known_equal(lhs.source_fake.size(-1), rhs.source_fake.size(-1)):
-        return None
+    # Dynamic inputs can carry distinct K symbols. Admission relies on the
+    # proven shared reduction block-id above, never coincidentally equal size
+    # hints; the host K-equality guard and full grouped proof stay authoritative.
     return _MmaOperandAnalysis(lhs=lhs, rhs=rhs)
+
+
+def _rank3_grouped_root_axes(
+    env: CompileEnvironment,
+    device_ir: DeviceIR,
+    *,
+    m_block_id: int,
+    n_block_id: int,
+    k_block_id: int,
+) -> _GroupedMmaAxes | None:
+    """Resolve grouped matrix axes by identity, independent of root order.
+
+    The persistent grouped scheduler replaces the original three-dimensional
+    root traversal, so source order is not semantic.  It still requires one
+    unique M axis, one unique N axis, and (for a three-axis root) one remaining
+    work/group axis; aliases and a root-carried K axis fail closed.
+    """
+    if len(device_ir.grid_block_ids) != 1:
+        return None
+    root_block_ids = device_ir.grid_block_ids[0]
+    if len(root_block_ids) not in (2, 3):
+        return None
+    canonical_block_id = env.canonical_block_id
+    canonical_m = canonical_block_id(m_block_id)
+    canonical_n = canonical_block_id(n_block_id)
+    canonical_root = tuple(map(canonical_block_id, root_block_ids))
+    if (
+        canonical_m == canonical_n
+        or canonical_block_id(k_block_id) in canonical_root
+        or len(set(canonical_root)) != len(canonical_root)
+    ):
+        return None
+    m_root_ids = [
+        block_id
+        for block_id in root_block_ids
+        if canonical_block_id(block_id) == canonical_m
+    ]
+    n_root_ids = [
+        block_id
+        for block_id in root_block_ids
+        if canonical_block_id(block_id) == canonical_n
+    ]
+    if len(m_root_ids) != 1 or len(n_root_ids) != 1:
+        return None
+    remaining = [
+        block_id
+        for block_id in root_block_ids
+        if block_id not in (m_root_ids[0], n_root_ids[0])
+    ]
+    if len(remaining) != len(root_block_ids) - 2:
+        return None
+    return _GroupedMmaAxes(
+        m_block_id=m_root_ids[0],
+        n_block_id=n_root_ids[0],
+        k_block_id=k_block_id,
+        segment_block_id=remaining[0] if remaining else None,
+    )
 
 
 def is_mma_compatible_aten(
@@ -3272,6 +3551,35 @@ def analyze_cute_mma_node(
                             worklist_store,
                             graphs=device_ir.graphs,
                         )
+            elif (segment_group := operands.rhs.rhs_segment_group) is not None:
+                graph_view = cast(
+                    "GenerateAST",
+                    _MmaSearchGraphView(device_ir.graphs),
+                )
+                segment_lhs = _rank3_rhs_segment_lhs_info(
+                    graph_view,
+                    operands.lhs,
+                    operands.rhs,
+                    segment_block_id=segment_group.segment_block_id,
+                    m_block_id=operands.m_block_id,
+                    k_block_id=operands.k_block_id,
+                )
+                if segment_lhs is not None:
+                    worklist_store = _rank3_rhs_worklist_store_info(
+                        graph_view,
+                        node,
+                        segment_lhs,
+                        segment_group,
+                        n_block_id=operands.n_block_id,
+                        allow_store_extent_metadata=True,
+                    )
+                    if worklist_store is not None:
+                        output_store_analysis = _analyze_packed_split_mma_output_store(
+                            node,
+                            operands,
+                            worklist_store,
+                            graphs=device_ir.graphs,
+                        )
             else:
                 output_store_analysis = _analyze_mma_output_stores(
                     node,
@@ -3330,47 +3638,47 @@ def analyze_cute_mma_node(
     )
 
 
-def _prove_rank3_rhs_grouped_mma(
+def _node_has_static_empty_tensor_result(node: Node) -> bool:
+    value = node.meta.get("val")
+    return isinstance(value, torch.Tensor) and any(
+        type(size) is int and size == 0 for size in value.shape
+    )
+
+
+def _analyze_rank3_rhs_grouped_mma(
     cg: GenerateAST,
     node: Node,
     *,
-    config: _ConfigLike,
     axes: _GroupedMmaAxes,
+    allow_missing_empty_store: bool = False,
 ) -> _Rank3RhsGroupedProof | None:
-    """Prove the graph semantics required by rank-3 RHS grouped lowering."""
+    """Analyze rank-3 RHS grouped semantics independently of a schedule."""
     from ..compile_environment import CompileEnvironment
 
-    # The grouped lowering is proven only for the rank-2 addmm form emitted by
-    # Helion's tiled reduction. Other Aten MMA forms remain supported by the
-    # ordinary collective path, but must not enter this grouped proof through
-    # only a subset of the compiler phases.
+    # Grouped semantics are recognized only for the rank-2 addmm form emitted
+    # by Helion's tiled reduction. Other Aten MMA forms remain supported by the
+    # ordinary collective path, but must not enter this analysis through only a
+    # subset of the compiler phases.
     if node.target is not torch.ops.aten.addmm.default:
         return None
-    with_acc = True
-    grouped_mode = _tcgen05_grouped_mode(config)
-    allow_grouped_k_mask = grouped_mode is not None
-    allow_rank3_rhs_mn_major = grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
     if not can_codegen_cute_mma_aten(
         node,
-        with_acc,
+        True,
         allow_rank3_rhs_nt=True,
         cg=cg,
         rank3_rhs_m_block_id=axes.m_block_id,
-        allow_grouped_k_mask=allow_grouped_k_mask,
-        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
+        allow_grouped_k_mask=True,
+        allow_rank3_rhs_mn_major=True,
     ):
         return None
-    lhs_node = node.args[1] if with_acc else node.args[0]
-    rhs_node = node.args[2] if with_acc else node.args[1]
+    lhs_node = node.args[1]
+    rhs_node = node.args[2]
     assert isinstance(lhs_node, Node) and isinstance(rhs_node, Node)
-    allow_segment_store_extent_metadata = (
-        grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
-    )
     lhs_info = _trace_to_mma_operand(
         lhs_node,
         role="lhs",
         cg=cg,
-        allow_grouped_k_mask=allow_grouped_k_mask,
+        allow_grouped_k_mask=True,
     )
     rhs_info = _trace_to_mma_operand(
         rhs_node,
@@ -3378,8 +3686,8 @@ def _prove_rank3_rhs_grouped_mma(
         allow_rank3_rhs_nt=True,
         cg=cg,
         rank3_rhs_m_block_id=axes.m_block_id,
-        allow_grouped_k_mask=allow_grouped_k_mask,
-        allow_rank3_rhs_mn_major=allow_rank3_rhs_mn_major,
+        allow_grouped_k_mask=True,
+        allow_rank3_rhs_mn_major=True,
     )
     if lhs_info is None or rhs_info is None or not rhs_info.rhs_rank3_grouped_nt:
         return None
@@ -3393,25 +3701,20 @@ def _prove_rank3_rhs_grouped_mma(
         lhs_info.grouped_k_mask is not None or rhs_info.grouped_k_mask is not None
     ) and k_mask is None:
         return None
+    rhs_major = _tcgen05_tma_matrix_major(rhs_fake)
     if not (
         lhs_fake.dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and _tcgen05_tma_matrix_major(lhs_fake) == "row"
-        and _tcgen05_tma_matrix_major(rhs_fake) in ("row", "col")
+        and rhs_major in ("row", "col")
         and rhs_info.rhs_n_block_id == canonical_block_id(axes.n_block_id)
         and rhs_info.rhs_k_block_id == canonical_block_id(axes.k_block_id)
-        and (
-            not with_acc
-            or (isinstance(node.args[0], Node) and _is_zero_init_acc_node(node.args[0]))
-        )
+        and isinstance(node.args[0], Node)
+        and _is_zero_init_acc_node(node.args[0])
     ):
         return None
 
     tail_epilogue = None
-    if (
-        allow_grouped_k_mask
-        and rhs_info.rhs_group_index is not None
-        and rhs_info.rhs_safe_group is not None
-    ):
+    if rhs_info.rhs_group_index is not None and rhs_info.rhs_safe_group is not None:
         tail_epilogue = find_tcgen05_grouped_tail_epilogue_for_mma(
             node,
             cg.codegen_graphs,
@@ -3437,8 +3740,6 @@ def _prove_rank3_rhs_grouped_mma(
     worklist_store = None
     packed_split = None
     if rhs_info.rhs_packed_group is not None:
-        if grouped_mode != TCGEN05_GROUPED_MODE_WORKLIST_NM:
-            return None
         packed_group = rhs_info.rhs_packed_group
         if axes.segment_block_id is None or canonical_block_id(
             packed_group.group_block_id
@@ -3478,7 +3779,7 @@ def _prove_rank3_rhs_grouped_mma(
             worklist_store,
             uses_scheduler_store_extent=True,
         )
-        layout_tensor = packed_split.split_sizes_tensor
+        layout_tensor = packed_split.layout_tensor
     elif segment_group is not None:
         if axes.segment_block_id is None:
             return None
@@ -3498,9 +3799,11 @@ def _prove_rank3_rhs_grouped_mma(
             worklist_lhs,
             segment_group,
             n_block_id=axes.n_block_id,
-            allow_store_extent_metadata=allow_segment_store_extent_metadata,
+            allow_store_extent_metadata=True,
         )
-        if worklist_store is None:
+        if worklist_store is None and not (
+            allow_missing_empty_store and _node_has_static_empty_tensor_result(node)
+        ):
             return None
         layout_tensor = segment_group.metadata_tensor
     else:
@@ -3534,6 +3837,160 @@ def _prove_rank3_rhs_grouped_mma(
     )
 
 
+def _rank3_rhs_grouped_schedule_is_legal(
+    proof: _Rank3RhsGroupedProof,
+    *,
+    grouped_mode: str | None,
+) -> bool:
+    """Return whether a requested grouped schedule can lower a semantic proof."""
+    if grouped_mode is None and proof.requires_explicit_grouped_mode:
+        return False
+    return not (
+        grouped_mode != TCGEN05_GROUPED_MODE_WORKLIST_NM
+        and proof.requires_worklist_nm_schedule
+    )
+
+
+def _prove_rank3_rhs_grouped_mma(
+    cg: GenerateAST,
+    node: Node,
+    *,
+    config: _ConfigLike,
+    axes: _GroupedMmaAxes,
+) -> _Rank3RhsGroupedProof | None:
+    """Compatibility wrapper for config-specific grouped MMA admission."""
+    proof = _analyze_rank3_rhs_grouped_mma(cg, node, axes=axes)
+    if proof is None or not _rank3_rhs_grouped_schedule_is_legal(
+        proof,
+        grouped_mode=_tcgen05_grouped_mode(config),
+    ):
+        return None
+    return proof
+
+
+def analyze_tcgen05_grouped_worklist(
+    env: CompileEnvironment,
+    device_ir: DeviceIR,
+    fact: MatmulFact,
+) -> Tcgen05GroupedWorklistAnalysis | None:
+    """Analyze a grouped worklist without assuming a compiler config."""
+    from ..compile_environment import CompileEnvironment
+
+    host_function = device_ir.host_function
+    if (
+        host_function is None
+        or fact.m_block_id is None
+        or fact.k_block_id is None
+        or len(device_ir.root_ids) != 1
+        or len(device_ir.grid_block_ids) != 1
+        or len(device_ir.grid_block_ids[0]) != 3
+    ):
+        return None
+    if fact.n_block_id is None and fact.static_n != 0:
+        return None
+    graph_view = _MmaSearchGraphView(device_ir.graphs)
+    if CompileEnvironment.has_current():
+        assert CompileEnvironment.current() is env, (
+            "grouped worklist analysis must use the provided compile environment"
+        )
+        env_context = contextlib.nullcontext()
+    else:
+        env_context = env
+    with env_context, host_function:
+        for graph_info in device_ir.graphs:
+            for node in graph_info.graph.nodes:
+                if (
+                    node.op != "call_function"
+                    or node.target is not torch.ops.aten.addmm.default
+                ):
+                    continue
+                lhs_node = node.args[1] if len(node.args) > 1 else None
+                rhs_node = node.args[2] if len(node.args) > 2 else None
+                if not isinstance(lhs_node, Node) or not isinstance(rhs_node, Node):
+                    continue
+                operands = _analyze_rank3_rhs_grouped_search_operands(
+                    lhs_node,
+                    rhs_node,
+                    env,
+                    device_ir,
+                )
+                if operands is None:
+                    continue
+                axes = _rank3_grouped_root_axes(
+                    env,
+                    device_ir,
+                    m_block_id=operands.m_block_id,
+                    n_block_id=operands.n_block_id,
+                    k_block_id=operands.k_block_id,
+                )
+                segment_block_id = operands.leading_passthrough_block_id
+                if (
+                    axes is None
+                    or axes.segment_block_id is None
+                    or segment_block_id is None
+                    or env.canonical_block_id(axes.segment_block_id)
+                    != env.canonical_block_id(segment_block_id)
+                ):
+                    continue
+                canonical_block_id = env.canonical_block_id
+                if (
+                    canonical_block_id(operands.m_block_id)
+                    != canonical_block_id(fact.m_block_id)
+                    or canonical_block_id(operands.k_block_id)
+                    != canonical_block_id(fact.k_block_id)
+                    or (
+                        fact.n_block_id is not None
+                        and canonical_block_id(operands.n_block_id)
+                        != canonical_block_id(fact.n_block_id)
+                    )
+                ):
+                    continue
+                proof = _analyze_rank3_rhs_grouped_mma(
+                    cast("GenerateAST", graph_view),
+                    node,
+                    axes=axes,
+                    allow_missing_empty_store=True,
+                )
+                if proof is None or not proof.is_worklist:
+                    continue
+                rhs_major = proof.rhs.matrix_major
+                if rhs_major == "col":
+                    b_major: Literal["k", "n"] = "k"
+                elif rhs_major == "row":
+                    b_major = "n"
+                else:
+                    continue
+                groups = env.size_hint(proof.rhs.source_fake.shape[0])
+                packed_m = env.size_hint(proof.lhs.source_fake.shape[0])
+                n = env.size_hint(proof.rhs.source_fake.shape[1])
+                k = env.size_hint(proof.rhs.source_fake.shape[2])
+                device_split_sizes = proof.packed_split is not None
+                # Resolve and cache the input path while HostFunction is active.
+                # Seed ranking later replays this path against real bind values.
+                env.tensor_input_source(proof.layout_tensor)
+                env.tensor_input_source(proof.lhs.source_fake)
+                env.tensor_input_source(proof.rhs.source_fake)
+                return Tcgen05GroupedWorklistAnalysis(
+                    seed_facts=Tcgen05GroupedWorklistSeedFacts(
+                        groups,
+                        packed_m,
+                        n,
+                        k,
+                        b_major,
+                        device_split_sizes,
+                    ),
+                    metadata_tensor=proof.layout_tensor,
+                    packed_tensor=proof.lhs.source_fake,
+                    grouped_tensor=proof.rhs.source_fake,
+                    device_layout_kind=(
+                        proof.packed_split.layout_kind
+                        if proof.packed_split is not None
+                        else None
+                    ),
+                )
+    return None
+
+
 def _tcgen05_grouped_static_seed_has_proof(
     env: CompileEnvironment,
     device_ir: DeviceIR,
@@ -3557,17 +4014,9 @@ def _tcgen05_grouped_static_seed_has_proof(
         k_block_id=fact.k_block_id,
     )
 
-    probe_config = {
-        "block_sizes": [128, 64, 64 if require_exact_k else 16],
-        "pid_type": "persistent_interleaved",
-        "tcgen05_cluster_m": 1,
-        "tcgen05_cluster_n": 1,
-        TCGEN05_GROUPED_MODE_CONFIG_KEY: (
-            TCGEN05_GROUPED_MODE_DYNAMIC
-            if require_exact_k
-            else TCGEN05_GROUPED_MODE_STATIC
-        ),
-    }
+    grouped_mode = (
+        TCGEN05_GROUPED_MODE_DYNAMIC if require_exact_k else TCGEN05_GROUPED_MODE_STATIC
+    )
     graph_view = _MmaSearchGraphView(device_ir.graphs)
     env_context = contextlib.nullcontext() if CompileEnvironment.has_current() else env
     with env_context, host_function:
@@ -3577,13 +4026,15 @@ def _tcgen05_grouped_static_seed_has_proof(
                     continue
                 if node.target is not torch.ops.aten.addmm.default:
                     continue
-                proof = _prove_rank3_rhs_grouped_mma(
+                proof = _analyze_rank3_rhs_grouped_mma(
                     cast("GenerateAST", graph_view),
                     node,
-                    config=probe_config,
                     axes=axes,
                 )
-                if proof is None:
+                if proof is None or not _rank3_rhs_grouped_schedule_is_legal(
+                    proof,
+                    grouped_mode=grouped_mode,
+                ):
                     continue
                 proof_matches = (
                     proof.k_mask is not None
@@ -4248,10 +4699,9 @@ def prepare_cute_collective_lane_loop_suppression(
                     or cg.device_function.resolved_block_size(segment_block_id) != 1
                 ):
                     continue
-            proof = _prove_rank3_rhs_grouped_mma(
+            proof = _analyze_rank3_rhs_grouped_mma(
                 cg,
                 node,
-                config=cg.device_function.config,
                 axes=_GroupedMmaAxes(
                     m_block_id=m_block_id,
                     n_block_id=n_block_id,
@@ -4259,7 +4709,10 @@ def prepare_cute_collective_lane_loop_suppression(
                     segment_block_id=segment_block_id,
                 ),
             )
-            if proof is None:
+            if proof is None or not _rank3_rhs_grouped_schedule_is_legal(
+                proof,
+                grouped_mode=grouped_mode,
+            ):
                 continue
             if (
                 not proof.is_worklist
@@ -4288,33 +4741,22 @@ def prepare_cute_collective_lane_loop_suppression(
                     is None
                 ):
                     continue
-        collective_bm = bm
-        collective_bn = bn
-        worklist_shape = None
-        if (
+        worklist_lowering = (
             rhs_rank3_worklist_lhs_info is not None
-            and _requested_tcgen05_grouped_schedule(
-                cast(
-                    "str | None",
-                    cast("_ConfigLike", cg.device_function.config).get(
-                        TCGEN05_GROUPED_MODE_CONFIG_KEY
-                    ),
-                )
-            )
-            is Tcgen05Orientation.NM
-        ):
-            worklist_shape = resolve_tcgen05_grouped_worklist_mma_shape(
-                cluster_m=_tcgen05_cluster_m(cg.device_function.config),
+            and grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
+        )
+        worklist_profile = (
+            resolve_tcgen05_grouped_worklist_mma_profile(
+                cg.device_function.config,
                 block_k=bk,
-                source_m_tile=_tcgen05_config_int(
-                    cg.device_function.config,
-                    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-                    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-                ),
             )
-            if worklist_shape is None:
-                continue
-            collective_bm, collective_bn = worklist_shape
+            if worklist_lowering
+            else None
+        )
+        if worklist_lowering and worklist_profile is None:
+            continue
+        collective_bm = worklist_profile.mma_m if worklist_profile is not None else bm
+        collective_bn = worklist_profile.mma_n if worklist_profile is not None else bn
         if (
             _choose_mma_impl(
                 lhs_fake.dtype,
@@ -4323,10 +4765,7 @@ def prepare_cute_collective_lane_loop_suppression(
                 bk=bk,
                 config=cg.device_function.config,
                 input_device=lhs_fake.device,
-                defer_grouped_worklist_smem_check=(
-                    rhs_rank3_worklist_lhs_info is not None
-                    and worklist_shape is not None
-                ),
+                defer_grouped_worklist_smem_check=worklist_profile is not None,
             )
             != "tcgen05"
         ):
@@ -5585,25 +6024,36 @@ def _requested_tcgen05_grouped_schedule(
     return Tcgen05Orientation.NM
 
 
-def _emit_tcgen05_device_split_sizes_setup(
+def _emit_tcgen05_device_segments_setup(
     prefix: list[ast.AST],
     df: DeviceFunction,
     grouped: CuteTcgen05GroupedPlan,
     *,
     n_size: int,
     k_size: int,
-    split_dtype: torch.dtype,
+    layout_dtype: torch.dtype,
 ) -> None:
-    """Materialize clipped source intervals from device split sizes in SMEM."""
+    """Materialize clipped source intervals from a compact device layout."""
     assert grouped.device_split_sizes
     assert grouped.m_size is not None
-    assert split_dtype in (torch.int32, torch.int64)
-    split_int_type = "cutlass.Int64" if split_dtype is torch.int64 else "cutlass.Int32"
+    assert grouped.device_layout_kind in ("split_sizes", "offsets")
+    assert layout_dtype in (torch.int32, torch.int64)
+    layout_int_type = (
+        "cutlass.Int64" if layout_dtype is torch.int64 else "cutlass.Int32"
+    )
     group_count = int(grouped.count)
     problem_sizes_ptr = df.new_var("tcgen05_grouped_problem_sizes_smem_ptr")
     starts_ptr = df.new_var("tcgen05_grouped_starts_smem_ptr")
-    running_start = df.new_var("tcgen05_grouped_running_start")
-    raw_split_value = df.new_var("tcgen05_grouped_raw_split_value")
+    if grouped.device_layout_kind == "offsets":
+        running_start = None
+        raw_split_value = None
+        raw_start = df.new_var("tcgen05_grouped_raw_start")
+        raw_extent = df.new_var("tcgen05_grouped_raw_extent")
+    else:
+        running_start = df.new_var("tcgen05_grouped_running_start")
+        raw_split_value = df.new_var("tcgen05_grouped_raw_split_value")
+        raw_start = None
+        raw_extent = None
     raw_end = df.new_var("tcgen05_grouped_raw_end")
     source_end = df.new_var("tcgen05_grouped_source_end")
     visible_start = df.new_var("tcgen05_grouped_visible_start")
@@ -5631,36 +6081,91 @@ def _emit_tcgen05_device_split_sizes_setup(
         ]
     )
     setup_lines = [
-        "if cute.arch.thread_idx()[0] == 0:",
-        f"    {running_start} = {split_int_type}(0)",
+        (
+            "if (cute.arch.thread_idx()[0] == 0) and "
+            "(cute.arch.thread_idx()[1] == 0) and "
+            "(cute.arch.thread_idx()[2] == 0):"
+        )
     ]
+    if grouped.device_layout_kind == "split_sizes":
+        assert running_start is not None
+        setup_lines.append(f"    {running_start} = {layout_int_type}(0)")
     for group_idx in range(group_count):
-        split_load = (
+        layout_load = (
             f"({grouped.layout}.iterator + cutlass.Int64({group_idx}) * "
             f"cutlass.Int64({grouped.layout}.layout.stride[0])).load()"
         )
+        if grouped.device_layout_kind == "offsets":
+            assert raw_start is not None and raw_extent is not None
+            next_layout_load = (
+                f"({grouped.layout}.iterator + cutlass.Int64({group_idx + 1}) * "
+                f"cutlass.Int64({grouped.layout}.layout.stride[0])).load()"
+            )
+            setup_lines.extend(
+                [
+                    f"    {raw_start} = {layout_int_type}({layout_load})",
+                    f"    {raw_end} = {layout_int_type}({next_layout_load})",
+                    (
+                        f"    {raw_extent} = max({raw_end} - {raw_start}, "
+                        f"{layout_int_type}(0))"
+                    ),
+                    (
+                        f"    {source_end} = {raw_start} + min({raw_extent}, "
+                        f"{layout_int_type}({grouped.m_size}))"
+                    ),
+                ]
+            )
+            setup_lines.extend(
+                [
+                    (
+                        f"    {visible_start} = min(max({raw_start}, "
+                        f"{layout_int_type}(0)), "
+                        f"{layout_int_type}({grouped.m_size}))"
+                    ),
+                    (
+                        f"    {visible_end} = min(max({source_end}, "
+                        f"{layout_int_type}(0)), "
+                        f"{layout_int_type}({grouped.m_size}))"
+                    ),
+                    (
+                        f"    {visible_extent} = max({visible_end} - "
+                        f"{visible_start}, {layout_int_type}(0)) if "
+                        f"{raw_extent} > {layout_int_type}(0) else "
+                        f"{layout_int_type}(0)"
+                    ),
+                ]
+            )
+        else:
+            assert running_start is not None and raw_split_value is not None
+            setup_lines.extend(
+                [
+                    f"    {raw_split_value} = {layout_int_type}({layout_load})",
+                    f"    {raw_end} = {running_start} + {raw_split_value}",
+                    (
+                        f"    {source_end} = {running_start} + min(max("
+                        f"{raw_split_value}, {layout_int_type}(0)), "
+                        f"{layout_int_type}({grouped.m_size}))"
+                    ),
+                    (
+                        f"    {visible_start} = min(max({running_start}, "
+                        f"{layout_int_type}(0)), "
+                        f"{layout_int_type}({grouped.m_size}))"
+                    ),
+                    (
+                        f"    {visible_end} = min(max({source_end}, "
+                        f"{layout_int_type}(0)), "
+                        f"{layout_int_type}({grouped.m_size}))"
+                    ),
+                    (
+                        f"    {visible_extent} = max({visible_end} - "
+                        f"{visible_start}, {layout_int_type}(0)) if "
+                        f"{raw_split_value} > {layout_int_type}(0) else "
+                        f"{layout_int_type}(0)"
+                    ),
+                ]
+            )
         setup_lines.extend(
             [
-                f"    {raw_split_value} = {split_int_type}({split_load})",
-                f"    {raw_end} = {running_start} + {raw_split_value}",
-                (
-                    f"    {source_end} = {running_start} + min(max("
-                    f"{raw_split_value}, {split_int_type}(0)), "
-                    f"{split_int_type}({grouped.m_size}))"
-                ),
-                (
-                    f"    {visible_start} = min(max({running_start}, "
-                    f"{split_int_type}(0)), {split_int_type}({grouped.m_size}))"
-                ),
-                (
-                    f"    {visible_end} = min(max({source_end}, {split_int_type}(0)), "
-                    f"{split_int_type}({grouped.m_size}))"
-                ),
-                (
-                    f"    {visible_extent} = max({visible_end} - {visible_start}, "
-                    f"{split_int_type}(0)) if {raw_split_value} > "
-                    f"{split_int_type}(0) else {split_int_type}(0)"
-                ),
                 (
                     f"    {grouped.starts}[cutlass.Int32({group_idx})] = "
                     f"cutlass.Int32({visible_start})"
@@ -5681,9 +6186,11 @@ def _emit_tcgen05_device_split_sizes_setup(
                     f"    {grouped.problem_sizes}[cutlass.Int32({group_idx}), "
                     "cutlass.Int32(3)] = cutlass.Int32(1)"
                 ),
-                f"    {running_start} = {raw_end}",
             ]
         )
+        if grouped.device_layout_kind == "split_sizes":
+            assert running_start is not None
+            setup_lines.append(f"    {running_start} = {raw_end}")
     prefix.extend(
         [
             statement_from_string("\n".join(setup_lines)),
@@ -6229,10 +6736,9 @@ def _emit_mma_pipeline(
                 return _unsupported_schedule(
                     "segment metadata work axis block size was not 1"
                 )
-        rhs_rank3_grouped_proof = _prove_rank3_rhs_grouped_mma(
+        rhs_rank3_grouped_proof = _analyze_rank3_rhs_grouped_mma(
             cg,
             fx_node,
-            config=df.config,
             axes=_GroupedMmaAxes(
                 m_block_id=m_block_id,
                 n_block_id=n_block_id,
@@ -6241,6 +6747,11 @@ def _emit_mma_pipeline(
             ),
         )
         if rhs_rank3_grouped_proof is None:
+            return _unsupported_schedule("rank3 grouped semantic proof failed")
+        if not _rank3_rhs_grouped_schedule_is_legal(
+            rhs_rank3_grouped_proof,
+            grouped_mode=grouped_mode,
+        ):
             return _unsupported_schedule("rank3 grouped semantic proof failed")
         lhs_info = rhs_rank3_grouped_proof.lhs
         rhs_info = rhs_rank3_grouped_proof.rhs
@@ -6323,37 +6834,25 @@ def _emit_mma_pipeline(
     # B becomes physical operand A, while packed A becomes physical operand B.
     tcgen05_mma_a_k_major = not tcgen05_nm_orientation or tcgen05_b_k_major
     tcgen05_mma_b_k_major = True if tcgen05_nm_orientation else tcgen05_b_k_major
+    worklist_profile = None
     tcgen05_worklist_source_m_tile: int | None = None
     tcgen05_one_cta_worklist_shape = False
-    worklist_shape = None
     if tcgen05_nm_orientation:
-        if bk not in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES:
-            return _unsupported_schedule("block_k must be 64 or 128")
-        tcgen05_worklist_source_m_tile = _tcgen05_config_int(
+        worklist_profile = resolve_tcgen05_grouped_worklist_mma_profile(
             df.config,
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-        )
-        if (
-            tcgen05_worklist_source_m_tile
-            not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
-        ):
-            return _unsupported_schedule(
-                f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY} must be "
-                f"one of {TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES}"
-            )
-        worklist_shape = resolve_tcgen05_grouped_worklist_mma_shape(
-            cluster_m=tcgen05_cluster_m,
             block_k=bk,
-            source_m_tile=tcgen05_worklist_source_m_tile,
         )
-        if worklist_shape is None:
+        if worklist_profile is None:
             return _unsupported_schedule(
-                "worklist N,M requires cluster_m=2, or cluster_m=1 with "
+                "worklist N,M requires block_k in (64, 128), cluster_m=2, "
+                "or cluster_m=1 with "
                 f"{TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY}="
                 f"{TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE}"
             )
-        tcgen05_mma_bm, tcgen05_mma_bn = worklist_shape
+        tcgen05_cluster_m = worklist_profile.cluster_m
+        tcgen05_worklist_source_m_tile = worklist_profile.source_m_tile
+        tcgen05_mma_bm = worklist_profile.mma_m
+        tcgen05_mma_bn = worklist_profile.mma_n
         tcgen05_one_cta_worklist_shape = tcgen05_cluster_m == 1
         tcgen05_source_bm = tcgen05_worklist_source_m_tile
         tcgen05_source_bn = tcgen05_mma_bm
@@ -6394,7 +6893,7 @@ def _emit_mma_pipeline(
         bk=bk,
         config=df.config,
         input_device=lhs_fake.device,
-        defer_grouped_worklist_smem_check=(worklist_shape is not None),
+        defer_grouped_worklist_smem_check=worklist_profile is not None,
     )
     if (
         mma_impl == "tcgen05"
@@ -6481,7 +6980,7 @@ def _emit_mma_pipeline(
                 bn=bn,
                 bk=bk,
                 config=df.config,
-                defer_grouped_worklist_smem_check=(worklist_shape is not None),
+                defer_grouped_worklist_smem_check=worklist_profile is not None,
             )
         )
     ):
@@ -7024,6 +7523,7 @@ def _emit_mma_pipeline(
     tcgen05_grouped_worklist_persistent = False
     grouped_worklist_supported = False
     tcgen05_grouped_device_split_sizes = False
+    tcgen05_grouped_device_layout_kind: Literal["split_sizes", "offsets"] | None = None
     tcgen05_grouped_layout_arg_name: str | None = None
     tcgen05_grouped_n_sizes_arg_name: str | None = None
     tcgen05_grouped_k_sizes_arg_name: str | None = None
@@ -7150,6 +7650,11 @@ def _emit_mma_pipeline(
         tcgen05_grouped_device_split_sizes = (
             rhs_rank3_grouped_proof.packed_split is not None
         )
+        tcgen05_grouped_device_layout_kind = (
+            rhs_rank3_grouped_proof.packed_split.layout_kind
+            if rhs_rank3_grouped_proof.packed_split is not None
+            else None
+        )
         tcgen05_grouped_worklist_persistent = (
             rhs_rank3_grouped_proof.is_worklist
             and tcgen05_grouped_dynamic_ab_tensormaps_requested
@@ -7157,6 +7662,7 @@ def _emit_mma_pipeline(
         if (
             tcgen05_grouped_worklist_persistent
             and not tcgen05_grouped_device_split_sizes
+            and not tcgen05_grouped_runtime_nm_direct
         ):
             if grouped_layout_tensor.ndim != 2 or grouped_layout_tensor.shape[1] != 4:
                 raise exc.BackendUnsupported(
@@ -7706,12 +8212,14 @@ def _emit_mma_pipeline(
                 tcgen05_worklist_source_m_tile if tcgen05_nm_orientation else None
             ),
             m_size=m_size if tcgen05_grouped_device_split_sizes else None,
+            device_layout_kind=tcgen05_grouped_device_layout_kind,
         )
     if requested_schedule is not None and (
         tcgen05_grouped_plan is None
         or (
             tcgen05_grouped_plan.real_groups is None
             and not tcgen05_grouped_plan.device_split_sizes
+            and not tcgen05_grouped_plan.uses_runtime_tile_table
         )
         or tcgen05_grouped_plan.orientation is not requested_schedule
     ):
@@ -7769,7 +8277,6 @@ def _emit_mma_pipeline(
         # MMA-M tile and K to be a whole BK tile. Every A/B TMA transaction is
         # therefore full even when the logical valid-row mask zeros D padding.
         tcgen05_static_full_tma_fast_path = True
-    nm_worklist = tcgen05_nm_orientation
     rhs_rank3_tma_group_expr = rhs_rank3_group_expr
     rhs_rank3_tma_group_setup: list[str] = []
     if (
@@ -7868,7 +8375,7 @@ def _emit_mma_pipeline(
                     and rhs_rank3_grouped_proof.packed_split is not None
                 )
                 if (
-                    rhs_rank3_grouped_proof.packed_split.split_sizes_tensor.dtype
+                    rhs_rank3_grouped_proof.packed_split.layout_tensor.dtype
                     is torch.int64
                 ):
                     # Int64 split sizes lower these exact proof nodes to an
@@ -7972,10 +8479,11 @@ def _emit_mma_pipeline(
     )
     if tcgen05_runtime_n_specialization:
         assert tcgen05_worklist_source_m_tile is not None
-        # Runtime UMMA-N specialization is a correctness path for ragged
-        # source-M tails, not a tunable choice. The exact BF16/FP32 shape
-        # envelope below fails closed; the pinned CuTe/CUTLASS environment is
-        # validation provenance, and upgrades require revalidating raw PTX.
+        # Runtime UMMA-N narrows ragged runtime-direct source-M tails.  Mailbox
+        # scheduling and the newer-DSL fallback retain public typed static-width
+        # MMA. The exact BF16/FP32 shape envelope below fails closed; the pinned
+        # CuTe/CUTLASS environment is validation provenance, and upgrades require
+        # revalidating raw PTX.
         runtime_n_shape_supported = (
             input_dtype == torch.bfloat16
             and input_dtype_str == "cutlass.BFloat16"
@@ -8025,13 +8533,13 @@ def _emit_mma_pipeline(
             rhs_rank3_grouped_proof is not None
             and rhs_rank3_grouped_proof.packed_split is not None
         )
-        _emit_tcgen05_device_split_sizes_setup(
+        _emit_tcgen05_device_segments_setup(
             prefix,
             df,
             tcgen05_grouped_plan,
             n_size=n_size,
             k_size=k_total_size,
-            split_dtype=rhs_rank3_grouped_proof.packed_split.split_sizes_tensor.dtype,
+            layout_dtype=rhs_rank3_grouped_proof.packed_split.layout_tensor.dtype,
         )
     # This call corresponds to one MMA FX-node lowering. The later
     # register_tcgen05_kloop_owned_stmts slice starts here, so pre-existing
@@ -8311,8 +8819,7 @@ def _emit_mma_pipeline(
         tcgen05_warp_spec = warp_spec_from_config(df.config)
         # The public NM profile reserves its scheduler warp internally.
         nm_scheduler_decode = (
-            nm_worklist
-            and tcgen05_nm_orientation
+            tcgen05_nm_orientation
             and tcgen05_grouped_static_persistent
             and tcgen05_grouped_worklist_persistent
             and (
@@ -8579,7 +9086,7 @@ def _emit_mma_pipeline(
             )
             and explicit_epi_aux_supported
         )
-        if nm_worklist:
+        if tcgen05_nm_orientation:
             nm_worklist_metadata_checks = {
                 "supported_physical_store": nm_explicit_store_wave,
                 "dynamic_rank2_ab_tensormaps": (
@@ -9987,6 +10494,7 @@ def _emit_mma_pipeline(
                         **(
                             {
                                 "device_split_sizes": True,
+                                "device_layout_kind": grouped_plan.device_layout_kind,
                                 "m_size": cast("int", grouped_plan.m_size),
                             }
                             if grouped_plan.device_split_sizes
@@ -10027,7 +10535,7 @@ def _emit_mma_pipeline(
                             if grouped_plan.static_group_quota_args
                             else {}
                         ),
-                        **({"orientation": "nm"} if nm_worklist else {}),
+                        **({"orientation": "nm"} if tcgen05_nm_orientation else {}),
                         **(
                             {"worklist_metadata": True}
                             if tcgen05_grouped_worklist_persistent
@@ -10114,7 +10622,7 @@ def _emit_mma_pipeline(
                 "k_total_size": k_total_size,
                 "kernel_args": [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b],
             }
-            if nm_worklist:
+            if tcgen05_nm_orientation:
                 ab_tma_plan["orientation"] = "nm"
             if tcgen05_grouped_fixed_tensormaps:
                 ab_tma_plan["fixed_ab_tensormaps"] = True
@@ -10491,7 +10999,8 @@ def _emit_mma_pipeline(
                 )
                 _emit_per_tile(
                     f"if {tcgen05_grouped_valid_m} <= "
-                    f"cutlass.Int32({tcgen05_mma_bn - 16}):\n"
+                    f"cutlass.Int32("
+                    f"{tcgen05_mma_bn - _TCGEN05_RUNTIME_MMA_N_GRANULARITY}):\n"
                     f"    {tma_runtime_mma_n} = "
                     f"{_tcgen05_runtime_mma_n_expr(tcgen05_grouped_valid_m, tcgen05_mma_bn)}\n"
                     f"    {tma_b_peer_delta} = {mma_slice_linear} * "
@@ -11054,7 +11563,7 @@ def _emit_mma_pipeline(
                 )
                 and tcgen05_static_full_tiles
                 and tcgen05_is_two_cta
-                and (bk == 64 or nm_worklist)
+                and (bk == 64 or tcgen05_nm_orientation)
             )
             tma_kloop_args = _PerKiterTmaArgs(
                 tma_pipeline=tma_pipeline,
@@ -11607,7 +12116,7 @@ def _emit_mma_pipeline(
             segment_store_actual_m = (
                 tcgen05_grouped_store_m
                 if (
-                    nm_worklist
+                    tcgen05_nm_orientation
                     and tcgen05_grouped_store_m
                     and rhs_rank3_worklist_store_info.uses_scheduler_store_extent
                 )
@@ -11615,21 +12124,30 @@ def _emit_mma_pipeline(
             )
             segment_store_valid_m_bound = (
                 tcgen05_grouped_valid_m
-                if nm_worklist and tcgen05_grouped_valid_m
+                if tcgen05_nm_orientation and tcgen05_grouped_valid_m
                 else rhs_rank3_worklist_lhs_info.group_m.name
             )
             segment_store_node = rhs_rank3_worklist_store_info.store_node
             segment_store_row_index = rhs_rank3_worklist_store_info.row_index
             segment_store_valid_m = rhs_rank3_worklist_store_info.valid_m
+        if analysis is not None:
+            output_block_ids = analysis.output_block_ids
+        elif rhs_rank3_grouped_proof is not None:
+            grouped_output_segment = (
+                rhs_rank3_grouped_proof.rhs.rhs_grouped_leading_block_id
+            )
+            output_block_ids = (
+                *(() if grouped_output_segment is None else (grouped_output_segment,)),
+                m_block_id,
+                n_block_id,
+            )
+        else:
+            output_block_ids = tuple(grid_state.block_ids)
         df.cute_state.register_tcgen05_store_value(
             result_var,
             CuteTcgen05StoreValue(
                 lifecycle_context=tcgen05_lifecycle_context,
-                output_block_ids=(
-                    analysis.output_block_ids
-                    if analysis is not None
-                    else tuple(grid_state.block_ids)
-                ),
+                output_block_ids=output_block_ids,
                 pure_matmul_object=tcgen05_pure_matmul_object,
                 bm=tcgen05_mma_bm,
                 bn=tcgen05_mma_bn,
@@ -11936,20 +12454,17 @@ def _tcgen05_candidate_exceeds_smem(
     """Whether tcgen05 A/B staging exceeds the device's per-CTA budget."""
     if input_device is None or config is None:
         return False
-    worklist_shape = (
-        resolve_tcgen05_grouped_worklist_mma_shape(
-            cluster_m=_tcgen05_cluster_m(config),
-            block_k=bk,
-            source_m_tile=_tcgen05_config_int(
-                config,
-                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
-                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-            ),
+    worklist_profile = (
+        resolve_tcgen05_grouped_worklist_mma_profile(
+            cast("_ConfigLike", config), block_k=bk
         )
         if defer_grouped_worklist_smem_check
         else None
     )
-    if worklist_shape is not None and (bm, bn) == worklist_shape:
+    if worklist_profile is not None and (bm, bn) == (
+        worklist_profile.mma_m,
+        worklist_profile.mma_n,
+    ):
         # The grouped worklist owns scheduler mailboxes, TensorMap storage, and
         # an explicit C ring. Its conservative allocation upper bound is checked
         # by ``tcgen05_grouped_worklist_smem_bytes`` in the resolved worklist
@@ -12776,8 +13291,8 @@ def _validate_tcgen05_smem_swizzle_override(
     """Reject illegal ``smem_swizzle_a/b`` overrides at codegen time.
 
     CuTe's ``make_smem_layout_atom`` requires the major-mode bytes-per-row
-    to be a multiple of the swizzle pattern's contiguous bytes. For
-    The resolved operand major mode determines the contiguous extent: K-major
+    to be a multiple of the swizzle pattern's contiguous bytes. The resolved
+    operand major mode determines the contiguous extent: K-major
     operands use ``bk``; MN-major A uses ``bm`` and MN-major B uses ``bn``.
 
     This helper computes the active bytes-per-row from the live tile

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -4,6 +4,7 @@ import ast
 import dataclasses
 import enum
 from typing import TYPE_CHECKING
+from typing import Literal
 from typing import Protocol
 from typing import cast
 
@@ -85,12 +86,14 @@ class CuteTcgen05GroupedPlan:
     fixed_tensormaps: bool = False
     # N,M worklists carry their source-row tile explicitly so runtime metadata
     # validation and launch bounds consume the exact schedule selected by the
-    # compiler.  For the device-split variant, ``layout`` names the device
-    # ``split_sizes[G]`` tensor while ``problem_sizes`` and ``starts`` are
-    # kernel-local SMEM tensors.  ``m_size`` lets the launcher derive a safe
-    # static cluster bound without reading split values on the host.
+    # compiler.  For compact device layouts, ``layout`` names either the
+    # ``split_sizes[G]`` or ``offsets[G + 1]`` tensor while ``problem_sizes``
+    # and ``starts`` are kernel-local SMEM tensors.  ``m_size`` lets the
+    # launcher derive a safe static cluster bound without reading layout
+    # values on the host.
     source_m_tile: int | None = None
     m_size: int | None = None
+    device_layout_kind: Literal["split_sizes", "offsets"] | None = None
 
     def __post_init__(self) -> None:
         assert (self.valid_m is None) == (self.store_m is None)
@@ -101,6 +104,8 @@ class CuteTcgen05GroupedPlan:
         assert (self.direct_pointers is None) == (self.direct_strides is None)
         assert (self.d_mode is Tcgen05GroupedDMode.NONE) == (self.d_tensormap is None)
         assert not self.device_split_sizes or self.orientation is Tcgen05Orientation.NM
+        assert self.device_layout_kind in (None, "split_sizes", "offsets")
+        assert (self.device_layout_kind is not None) == self.device_split_sizes
         assert (self.runtime_tile_records is None) == (
             self.runtime_total_clusters is None
         )

--- a/helion/_compiler/cute/grouped_worklist.py
+++ b/helion/_compiler/cute/grouped_worklist.py
@@ -1,0 +1,255 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from torch._dynamo.source import TensorProperty
+from torch._dynamo.source import TensorPropertySource
+
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import torch
+    from torch._guards import Source
+
+    from ..compile_environment import CompileEnvironment
+
+
+class Tcgen05GroupedWorklistValidationError(ValueError):
+    """A value-level violation of the grouped-worklist contract."""
+
+
+def _tcgen05_grouped_worklist_runtime_specialization_key(source: Source) -> str:
+    return f"cute_tcgen05_grouped_worklist:{source!r}"
+
+
+def register_tcgen05_grouped_worklist_runtime_specialization(
+    env: CompileEnvironment,
+    fake_tensor: torch.Tensor,
+    *,
+    grouped_tensor: torch.Tensor,
+    packed_tensor: torch.Tensor,
+) -> bool:
+    """Register the runtime cache-key projection for an external worklist."""
+    from ...runtime.cute.launcher import _Tcgen05GroupedWorklistCompatibilityClassifier
+    from ..compile_environment import RuntimeInputSpecialization
+
+    source = env.tensor_input_source(fake_tensor)
+    if source is None:
+        return False
+
+    def dimension_source(tensor: torch.Tensor) -> Source | int | None:
+        tensor_source = env.tensor_input_source(tensor)
+        if tensor_source is not None:
+            return TensorPropertySource(tensor_source, TensorProperty.SIZE, 0)
+        if env.settings.static_shapes:
+            return env.size_hint(tensor.shape[0])
+        return None
+
+    group_count = dimension_source(grouped_tensor)
+    packed_m = dimension_source(packed_tensor)
+    if group_count is None or packed_m is None:
+        return False
+
+    sources = [source]
+    if isinstance(group_count, int):
+        static_group_count = group_count
+    else:
+        static_group_count = None
+        sources.append(group_count)
+    if isinstance(packed_m, int):
+        static_packed_m = packed_m
+    else:
+        static_packed_m = None
+        sources.append(packed_m)
+    classifier = _Tcgen05GroupedWorklistCompatibilityClassifier(
+        static_group_count,
+        static_packed_m,
+    )
+    env.register_runtime_input_specialization(
+        _tcgen05_grouped_worklist_runtime_specialization_key(source),
+        RuntimeInputSpecialization(
+            sources=tuple(sources),
+            classifier_identity=(static_group_count, static_packed_m),
+            classifier=classifier,
+        ),
+    )
+    return True
+
+
+def has_tcgen05_grouped_worklist_runtime_specialization(
+    env: CompileEnvironment,
+    fake_tensor: torch.Tensor,
+) -> bool:
+    """Whether external-worklist runtime specialization registered successfully."""
+    source = env.tensor_input_source(fake_tensor)
+    return source is not None and (
+        _tcgen05_grouped_worklist_runtime_specialization_key(source)
+        in env.runtime_input_specializations
+    )
+
+
+_TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_PREFERENCE = (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+    TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+    TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+)
+assert set(_TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_PREFERENCE) == set(
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+)
+
+
+def tcgen05_grouped_worklist_source_m_tiles_by_preference(
+    source_m_tiles: Sequence[int],
+) -> tuple[int, ...]:
+    """Order compatible source-M tiles from established to fallback profiles."""
+    return tuple(
+        sorted(
+            source_m_tiles,
+            key=_TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_PREFERENCE.index,
+        )
+    )
+
+
+def _analyze_tcgen05_grouped_worklist_rows(
+    rows: Sequence[Sequence[int]],
+    *,
+    group_count: int,
+    packed_m: int,
+    required_source_m_tile: int | None,
+) -> tuple[int, ...]:
+    if len(rows) != group_count:
+        raise Tcgen05GroupedWorklistValidationError(
+            "tcgen05 N,M worklist row count must match B_grouped"
+        )
+    compatible_source_m_tiles = list(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES)
+    expected_store_end = 0
+    seen_groups: set[int] = set()
+    for row in rows:
+        if len(row) != 4:
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist rows must have four fields"
+            )
+        try:
+            real_group, start, actual_m, aligned_m = (int(value) for value in row)
+        except (TypeError, ValueError, OverflowError) as error:
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist fields must be integers"
+            ) from error
+        if real_group < 0 or real_group >= group_count:
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist real group id is outside B_grouped"
+            )
+        if real_group in seen_groups:
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist requires unique real group ids"
+            )
+        seen_groups.add(real_group)
+        if start < 0 or (
+            required_source_m_tile is not None and start % required_source_m_tile != 0
+        ):
+            if required_source_m_tile is None:
+                raise Tcgen05GroupedWorklistValidationError(
+                    "tcgen05 N,M worklist requires nonnegative group starts"
+                )
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist requires group starts aligned to "
+                f"{required_source_m_tile} rows"
+            )
+        compatible_source_m_tiles = [
+            source_m_tile
+            for source_m_tile in compatible_source_m_tiles
+            if start % source_m_tile == 0
+        ]
+        if actual_m < 0 or actual_m > aligned_m:
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist requires 0 <= actual_m <= aligned_m"
+            )
+        if aligned_m < 0 or (
+            required_source_m_tile is not None
+            and aligned_m % required_source_m_tile != 0
+        ):
+            if required_source_m_tile is None:
+                raise Tcgen05GroupedWorklistValidationError(
+                    "tcgen05 N,M worklist requires nonnegative aligned_m"
+                )
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist requires aligned_m to be a nonnegative "
+                f"multiple of {required_source_m_tile}"
+            )
+        compatible_source_m_tiles = [
+            source_m_tile
+            for source_m_tile in compatible_source_m_tiles
+            if aligned_m % source_m_tile == 0
+        ]
+        if (actual_m == 0) != (aligned_m == 0):
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist requires actual_m and aligned_m to be zero "
+                "together"
+            )
+        if start + aligned_m > packed_m:
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist aligned extent exceeds A extent"
+            )
+        if aligned_m == 0:
+            continue
+        if start < expected_store_end:
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist has overlapping A rows"
+            )
+        if start > expected_store_end:
+            raise Tcgen05GroupedWorklistValidationError(
+                "tcgen05 N,M worklist has row holes"
+            )
+        expected_store_end = start + aligned_m
+    if expected_store_end != packed_m:
+        raise Tcgen05GroupedWorklistValidationError(
+            "tcgen05 N,M worklist aligned extents must cover A rows"
+        )
+    return tuple(compatible_source_m_tiles)
+
+
+def tcgen05_grouped_worklist_compatible_source_m_tiles(
+    rows: Sequence[Sequence[int]],
+    *,
+    group_count: int,
+    packed_m: int,
+) -> tuple[int, ...]:
+    """Return source-M tile choices compatible with a valid ``[G, 4]`` worklist.
+
+    Invalid worklist values have no compatible tile choices.
+    """
+    try:
+        return _analyze_tcgen05_grouped_worklist_rows(
+            rows,
+            group_count=group_count,
+            packed_m=packed_m,
+            required_source_m_tile=None,
+        )
+    except Tcgen05GroupedWorklistValidationError:
+        return ()
+
+
+def validate_tcgen05_grouped_worklist_rows(
+    rows: Sequence[Sequence[int]],
+    *,
+    group_count: int,
+    packed_m: int,
+    source_m_tile: int,
+) -> None:
+    """Validate worklist values for one selected source-M tile."""
+    _analyze_tcgen05_grouped_worklist_rows(
+        rows,
+        group_count=group_count,
+        packed_m=packed_m,
+        required_source_m_tile=source_m_tile,
+    )

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import NamedTuple
+from typing import TypeVar
 from typing import cast
 
 import torch
@@ -25,6 +27,7 @@ from .strategies import TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY
 from .strategies import TCGEN05_LEGAL_L2_SWIZZLE_SIZES
 from .strategies import TCGEN05_LEGAL_SMEM_SWIZZLE_BYTES
 from .strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
+from .strategies import TCGEN05_PERSISTENCE_MODEL_PID_TYPES
 from .strategies import TCGEN05_STRATEGY_CONFIG_KEY
 from .strategies import TCGEN05_STRATEGY_CONFIG_KEYS
 from .strategies import TCGEN05_WARP_SPEC_AB_LOAD_WARPS_KEY
@@ -108,7 +111,6 @@ from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
 from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
-from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
 from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
@@ -156,7 +158,9 @@ from .tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
 from .tcgen05_constants import tcgen05_two_cta_edge_k_tail_seed_overrides
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Mapping
+    from collections.abc import Sequence
 
     from ...autotuner.block_id_sequence import BlockIdSequence
     from ...autotuner.config_fragment import BlockSizeFragment
@@ -189,8 +193,121 @@ class Tcgen05AbStagesThreeSearchConstraints(NamedTuple):
     per_cta_smem_budget_bytes: int
 
 
+class Tcgen05GroupedWorklistSmemFacts(NamedTuple):
+    group_count: int
+    device_split_sizes: bool
+
+
 TCGEN05_GROUPED_DYNAMIC_AB4_STAGE = 4
 TCGEN05_GROUPED_DYNAMIC_STAGE_TUPLES = ((4, 2), (8, 4))
+
+
+_SeedValue = TypeVar("_SeedValue", bound=Hashable)
+
+
+def _compiler_seed_values(
+    seeds: Sequence[Config],
+    key: str,
+    value_type: type[_SeedValue],
+    is_valid: Callable[[_SeedValue], bool],
+    *,
+    exact_type: bool = True,
+    is_valid_for_seed: Callable[[Config, _SeedValue], bool] | None = None,
+) -> tuple[_SeedValue, ...]:
+    return tuple(
+        dict.fromkeys(
+            cast("_SeedValue", value)
+            for seed in seeds
+            for value in (seed.config.get(key),)
+            if (
+                type(value) is value_type
+                if exact_type
+                else isinstance(value, value_type)
+            )
+            and is_valid(cast("_SeedValue", value))
+            and (
+                is_valid_for_seed is None
+                or is_valid_for_seed(seed, cast("_SeedValue", value))
+            )
+        )
+    )
+
+
+def _integer_fragment_with_seed_values(
+    fragment: IntegerFragment,
+    seed_values: tuple[int, ...],
+) -> ConfigSpecFragment:
+    seed_only_values = tuple(
+        value
+        for value in dict.fromkeys(seed_values)
+        if value < fragment.low or value > fragment.high
+    )
+    return (
+        fragment
+        if not seed_only_values
+        else _CompilerSeedIntegerFragment(fragment, seed_only_values)
+    )
+
+
+class _CompilerSeedIntegerFragment(IntegerFragment):
+    """An integer search range that can also encode frozen compiler seeds."""
+
+    def __init__(
+        self,
+        fragment: IntegerFragment,
+        seed_only_values: tuple[int, ...],
+    ) -> None:
+        super().__init__(fragment.low, fragment.high, fragment.default_val)
+        self.seed_only_values = seed_only_values
+
+    def pattern_neighbors(self, current: object, radius: int = 1) -> list[object]:
+        if type(current) is not int:
+            raise TypeError(f"Expected int, got {type(current).__name__}")
+        if self.low <= current <= self.high:
+            return super().pattern_neighbors(current, radius)
+        if current not in self.seed_only_values:
+            raise ValueError(f"{current!r} is not a compiler-seed integer value")
+        boundary = self.clamp(current)
+        return [boundary, *super().pattern_neighbors(boundary, radius)]
+
+    def encode(self, value: object) -> list[float]:
+        if type(value) is not int:
+            raise TypeError(f"Expected int, got {type(value).__name__}")
+        if not (self.low <= value <= self.high or value in self.seed_only_values):
+            raise ValueError(f"{value!r} is not a compiler-seed integer value")
+        return [float(value)]
+
+    def fingerprint(self) -> tuple[str | int, ...]:
+        return (
+            "compiler_seed_integer",
+            self.low,
+            self.high,
+            self.default_val,
+            *self.seed_only_values,
+        )
+
+
+def _enum_fragment_with_seed_values(
+    base_choices: tuple[object, ...],
+    seed_values: tuple[Hashable, ...],
+    *,
+    search_choices: tuple[object, ...],
+    original: EnumFragment | None = None,
+    search_only_if_widened: bool = False,
+) -> EnumFragment:
+    choices = tuple(dict.fromkeys((*base_choices, *seed_values)))
+    if original is not None and choices == base_choices:
+        return original
+    return EnumFragment(
+        choices,
+        search_choices=(
+            None
+            if search_only_if_widened and choices == base_choices
+            else search_choices
+        ),
+    )
+
+
 # The generated grouped kernel's non-operand allocations are about 1.6 KiB
 # (pipeline barriers, TensorMap staging, and TMEM bookkeeping). Keep a small
 # margin while still admitting CUTLASS's max-fit AB8/C4 pipeline on B200.
@@ -278,6 +395,11 @@ class CuteTcgen05Config:
         self.config_spec = config_spec
         self.search_enabled: bool = False
         self.matmul_block_ids: tuple[int, int, int] | None = None
+        # DeviceIR may later replace missing MatmulFact extents with runtime
+        # hints. Keep the preflight plan's compile-time provenance for CuTe.
+        self.matmul_compile_time_static_extents: (
+            tuple[int | None, int | None, int | None] | None
+        ) = None
         self.matmul_input_dtype: torch.dtype | None = None
         self.matmul_has_leading_passthrough: bool = False
         self.matmul_explicit_epi_tile_compatible: bool | None = None
@@ -296,6 +418,7 @@ class CuteTcgen05Config:
         self.ab_stages_three_search_constraints: (
             Tcgen05AbStagesThreeSearchConstraints | None
         ) = None
+        self.grouped_worklist_smem_facts: Tcgen05GroupedWorklistSmemFacts | None = None
         self.deep_direct_entry_validation_enabled: bool = False
         self.num_epi_warps_search_choices: tuple[int, ...] | None = None
         self.num_epi_warps_validation_choices: tuple[int, ...] | None = None
@@ -322,6 +445,7 @@ class CuteTcgen05Config:
         m_block_id: int,
         n_block_id: int,
         k_block_id: int,
+        compile_time_static_extents: tuple[int | None, int | None, int | None],
         input_dtype: torch.dtype,
         has_leading_passthrough: bool,
         explicit_epi_tile_compatible: bool,
@@ -329,6 +453,7 @@ class CuteTcgen05Config:
         """Record semantic axes from the structurally accepted MMA candidate."""
         assert self.matmul_block_ids is None, "tcgen05 MMA analysis registered twice"
         self.matmul_block_ids = (m_block_id, n_block_id, k_block_id)
+        self.matmul_compile_time_static_extents = compile_time_static_extents
         self.matmul_input_dtype = input_dtype
         self.matmul_has_leading_passthrough = has_leading_passthrough
         self.matmul_explicit_epi_tile_compatible = explicit_epi_tile_compatible
@@ -931,23 +1056,6 @@ class CuteTcgen05Config:
         # their sub-paths; doing it once here covers the full-tile and
         # small-grid paths too.
         config.pop("epilogue_subtile", None)
-        if (
-            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
-            == TCGEN05_GROUPED_MODE_WORKLIST_NM
-            and config.get("tcgen05_cluster_n", 1) == 1
-            and block_sizes[m_index] == TCGEN05_TWO_CTA_BLOCK_M
-            and block_sizes[n_index] == 128
-            and bk in TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
-            and config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
-            in (
-                TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
-                TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
-            )
-        ):
-            # Worklist configs keep their 256x128 logical DSL tile. Their
-            # source-M metadata selects the physical 256x224/256 MMA profile
-            # through ``resolve_tcgen05_grouped_worklist_mma_profile``.
-            return
         # fp8 small-grid family: a sampled bm<=128 routes to the fp8-validated
         # per-CTA 64xbn 2-CTA tile (bm=128/bn=128) instead of the bm=256 full
         # tile, which underfills the device on small/wave-limited fp8 GEMMs. The
@@ -992,6 +1100,89 @@ class CuteTcgen05Config:
                     TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_L2_GROUPING
                 ]
 
+    def _fix_grouped_worklist_search_config(self, config: dict[str, object]) -> None:
+        """Project worklist search neighbors onto the validated logical tile."""
+        if not self.search_enabled:
+            return
+        if (
+            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            != TCGEN05_GROUPED_MODE_WORKLIST_NM
+        ):
+            return
+        source_m_tile = config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+        if (
+            type(source_m_tile) is not int
+            or source_m_tile not in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
+        ):
+            return
+        config_view = self._matmul_config_view(config)
+        if config_view is None:
+            return
+        block_sizes, m_index, n_index, k_index = config_view
+        block_sizes[m_index] = TCGEN05_TWO_CTA_BLOCK_M
+        block_sizes[n_index] = 128
+        sampled_bk = block_sizes[k_index]
+        block_k_choices = TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES
+        known_static_ks = {
+            fact.static_k
+            for fact in self.config_spec.matmul_facts
+            if self._config_block_index(fact.k_block_id) == k_index
+            and fact.static_k is not None
+        }
+        constraints = self.cluster_m2_search_constraints
+        if constraints is not None:
+            known_static_ks.add(constraints.static_k)
+        if known_static_ks:
+            # Worklists require exact K divisibility but own an independent
+            # stage/tile-count envelope from generic cluster-M2 search. Filter
+            # only by that shared structural requirement: importing generic
+            # max-tile or edge-tail policy would rewrite valid worklist BKs.
+            constrained_choices = tuple(
+                block_k
+                for block_k in block_k_choices
+                if all(static_k % block_k == 0 for static_k in known_static_ks)
+            )
+            if not constrained_choices:
+                static_k_values = tuple(sorted(known_static_ks))
+                raise InvalidConfig(
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} has no supported "
+                    f"block_k in {TCGEN05_GROUPED_WORKLIST_BLOCK_K_CHOICES} "
+                    f"that divides every known static K in {static_k_values}"
+                )
+            block_k_choices = constrained_choices
+        block_sizes[k_index] = (
+            min(
+                block_k_choices,
+                key=lambda block_k: (abs(block_k - sampled_bk), block_k),
+            )
+            if type(sampled_bk) is int
+            else block_k_choices[0]
+        )
+        if source_m_tile != TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE:
+            # Only the compact source-32 profile supports CtaGroup.ONE. The
+            # reviewed source-224/256 profiles are CtaGroup.TWO even when a
+            # pattern neighbor independently mutates the cluster fragment.
+            config["tcgen05_cluster_m"] = 2
+
+    @staticmethod
+    def _is_grouped_clc_config(config: dict[str, object]) -> bool:
+        return (
+            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) in TCGEN05_GROUPED_MODES
+            and config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+            == Tcgen05PersistenceModel.CLC_PERSISTENT.value
+        )
+
+    @staticmethod
+    def _is_grouped_runtime_direct_clc_config(config: dict[str, object]) -> bool:
+        return (
+            CuteTcgen05Config._is_grouped_clc_config(config)
+            and config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            and config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
+            and TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY not in config
+        )
+
     def prepare_normalization(
         self, config: dict[str, object], *, fix_invalid: bool
     ) -> None:
@@ -1006,26 +1197,8 @@ class CuteTcgen05Config:
                 raise InvalidConfig(
                     "tcgen05 grouped kernels require num_sm_multiplier=1"
                 )
-        grouped_clc = (
-            grouped_mode in TCGEN05_GROUPED_MODES
-            and config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
-            == Tcgen05PersistenceModel.CLC_PERSISTENT.value
-        )
-        if grouped_clc and (
-            config.get(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, 0) != 0
-        ):
-            if fix_invalid:
-                config.pop(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, None)
-            else:
-                raise InvalidConfig(
-                    "tcgen05 grouped CLC launches its exact full tile-record grid; "
-                    "reserved_sms cannot limit that grid"
-                )
-        if grouped_clc and not (
-            grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
-            and config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
-            and TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY not in config
-        ):
+        grouped_clc = self._is_grouped_clc_config(config)
+        if grouped_clc and not self._is_grouped_runtime_direct_clc_config(config):
             if fix_invalid:
                 config.pop(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY, None)
                 config[TCGEN05_STRATEGY_CONFIG_KEY] = (
@@ -1040,6 +1213,17 @@ class CuteTcgen05Config:
                     f"{TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY}=True, and no "
                     f"{TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY}; the "
                     "launcher must build an exact one-record-per-cluster tile table"
+                )
+        grouped_clc = self._is_grouped_clc_config(config)
+        if grouped_clc and (
+            config.get(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, 0) != 0
+        ):
+            if fix_invalid:
+                config.pop(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, None)
+            else:
+                raise InvalidConfig(
+                    "tcgen05 grouped CLC launches its exact full tile-record grid; "
+                    "reserved_sms cannot limit that grid"
                 )
         source_m_tile_key = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
         source_m_tile = config.get(source_m_tile_key)
@@ -1174,6 +1358,21 @@ class CuteTcgen05Config:
             dtype_bytes=dtype_bytes,
             per_cta_smem_budget_bytes=budget_bytes,
         )
+
+    def register_grouped_worklist_smem_facts(
+        self, *, group_count: int, device_split_sizes: bool
+    ) -> None:
+        if group_count <= 0:
+            raise ValueError(
+                "grouped worklist SMEM facts require a positive group count"
+            )
+        facts = Tcgen05GroupedWorklistSmemFacts(group_count, device_split_sizes)
+        if self.grouped_worklist_smem_facts not in (None, facts):
+            raise RuntimeError(
+                "conflicting grouped worklist SMEM facts were registered for one "
+                "ConfigSpec"
+            )
+        self.grouped_worklist_smem_facts = facts
 
     def allow_deep_direct_entry_validation(self, *, device: torch.device) -> None:
         self.deep_direct_entry_validation_enabled = (
@@ -1388,6 +1587,25 @@ class CuteTcgen05Config:
             constraints.per_cta_smem_budget_bytes
             + TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
         )
+        smem_facts = self.grouped_worklist_smem_facts
+        if smem_facts is None:
+            # Compiler-owned seeds register scheduler-specific allocation facts
+            # and are rejected here when their exact footprint is too large.  An
+            # explicit config may be normalized without a discovered worklist
+            # contract, so those facts can legitimately be absent. Admit only when the
+            # physical AB ring itself fits the raw target capacity, then defer
+            # scheduler/mailbox allocations to the resolved worklist codegen
+            # check.  That check proves the single grouped matmul and computes
+            # its exact footprint before emitting any allocations.
+            required_ab_bytes = tcgen05_ab_smem_bytes_per_cta(
+                bm=profile.mma_m,
+                bn=profile.mma_n,
+                bk=cast("int", block_k),
+                dtype_bytes=constraints.dtype_bytes,
+                ab_stages=ab_stages,
+                cluster_m=profile.cluster_m,
+            )
+            return required_ab_bytes <= target_capacity_bytes
         sched_stage_count = config.get(TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY, 1)
         if type(sched_stage_count) is not int or sched_stage_count <= 0:
             return False
@@ -1398,8 +1616,8 @@ class CuteTcgen05Config:
         # the raw target cap and apply the same conservative worklist upper bound
         # across scheduler modes as codegen.
         required_bytes = tcgen05_grouped_worklist_smem_bytes(
-            group_count=1,
-            device_split_sizes=False,
+            group_count=smem_facts.group_count,
+            device_split_sizes=smem_facts.device_split_sizes,
             sched_stage_count=sched_stage_count,
             bm=physical_bm,
             bn=physical_bn,
@@ -2007,6 +2225,8 @@ class CuteTcgen05Config:
             config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
             != Tcgen05PersistenceModel.CLC_PERSISTENT.value
         ):
+            return
+        if self._is_grouped_runtime_direct_clc_config(config):
             return
         if self._is_validated_clc_persistence_search_candidate(config):
             return
@@ -2622,24 +2842,23 @@ class CuteTcgen05Config:
         even though ``_aux_tma_search_enabled`` was widened (see
         ``aux_stages_autotune_fragments``).
         """
-        seed_choices = tuple(
-            dict.fromkeys(
-                value
-                for config in self.config_spec.compiler_seed_configs
-                if (value := config.config.get(TCGEN05_CONSUMER_REGS_CONFIG_KEY))
-                in TCGEN05_CONSUMER_REGS_CHOICES
-            )
+        seed_choices = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            TCGEN05_CONSUMER_REGS_CONFIG_KEY,
+            int,
+            lambda value: value in TCGEN05_CONSUMER_REGS_CHOICES,
         )
         if not self._aux_tma_edge_search_enabled():
-            if not seed_choices:
+            if not any(
+                choice != TCGEN05_CONSUMER_REGS_DEFAULT for choice in seed_choices
+            ):
                 return {}
-            choices = tuple(
-                dict.fromkeys((TCGEN05_CONSUMER_REGS_DEFAULT, *seed_choices))
-            )
             return {
-                TCGEN05_CONSUMER_REGS_CONFIG_KEY: EnumFragment(
-                    choices,
+                TCGEN05_CONSUMER_REGS_CONFIG_KEY: _enum_fragment_with_seed_values(
+                    (TCGEN05_CONSUMER_REGS_DEFAULT,),
+                    seed_choices,
                     search_choices=(TCGEN05_CONSUMER_REGS_DEFAULT,),
+                    search_only_if_widened=True,
                 )
             }
         return {
@@ -2649,36 +2868,61 @@ class CuteTcgen05Config:
         }
 
     def persistence_model_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
-        default_model = derive_persistence_model_from_pid_type(
-            self.allowed_pid_types[0]
-        ).value
-        seed_override_models = tuple(
+        pid_default_models = tuple(
             dict.fromkeys(
-                model
-                for config in self.config_spec.compiler_seed_configs
-                if isinstance(
-                    model := config.config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY),
-                    str,
-                )
-                and model in {item.value for item in Tcgen05PersistenceModel}
-                and model
-                != self.persistence_model_default_from_config(config.config).value
+                derive_persistence_model_from_pid_type(pid_type).value
+                for pid_type in self.allowed_pid_types
             )
         )
+        seed_pid_types = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            "pid_type",
+            str,
+            lambda pid_type: pid_type in TCGEN05_PERSISTENCE_MODEL_PID_TYPES,
+            exact_type=False,
+        )
+        seed_pid_default_models = tuple(
+            dict.fromkeys(
+                derive_persistence_model_from_pid_type(pid_type).value
+                for pid_type in seed_pid_types
+            )
+        )
+
+        def seed_default_model(seed: Config) -> str:
+            pid_type = seed.config.get("pid_type")
+            if (
+                isinstance(pid_type, str)
+                and pid_type in TCGEN05_PERSISTENCE_MODEL_PID_TYPES
+            ):
+                return derive_persistence_model_from_pid_type(pid_type).value
+            return self.persistence_model_default_from_config(seed.config).value
+
+        seed_override_models = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY,
+            str,
+            lambda model: model in {item.value for item in Tcgen05PersistenceModel},
+            exact_type=False,
+            is_valid_for_seed=lambda seed, model: model != seed_default_model(seed),
+        )
         if not self._clc_persistence_search_enabled():
-            if not seed_override_models:
+            seed_pid_defaults_widen_domain = any(
+                model not in pid_default_models for model in seed_pid_default_models
+            )
+            if not seed_override_models and not seed_pid_defaults_widen_domain:
                 return {}
-            choices = tuple(dict.fromkeys((default_model, *seed_override_models)))
             return {
-                TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: EnumFragment(
-                    choices,
-                    search_choices=(default_model,),
+                TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: _enum_fragment_with_seed_values(
+                    pid_default_models,
+                    (*seed_pid_default_models, *seed_override_models),
+                    search_choices=pid_default_models,
+                    search_only_if_widened=True,
                 )
             }
         choices = tuple(
             dict.fromkeys(
                 (
-                    default_model,
+                    *pid_default_models,
                     Tcgen05PersistenceModel.NON_PERSISTENT.value,
                     Tcgen05PersistenceModel.STATIC_PERSISTENT.value,
                     Tcgen05PersistenceModel.CLC_PERSISTENT.value,
@@ -2703,35 +2947,18 @@ class CuteTcgen05Config:
             strategy_choices = (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,)
             scheduler_warps_choices = (0,)
             c_input_warps_choices = (0,)
-        strategy_seed_choices = tuple(
-            dict.fromkeys(
-                strategy
-                for config in self.config_spec.compiler_seed_configs
-                if isinstance(
-                    strategy := config.config.get(TCGEN05_STRATEGY_CONFIG_KEY),
-                    str,
-                )
-                and strategy in {item.value for item in Tcgen05Strategy}
-            )
+        strategy_seed_choices = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            TCGEN05_STRATEGY_CONFIG_KEY,
+            str,
+            lambda strategy: strategy in {item.value for item in Tcgen05Strategy},
+            exact_type=False,
         )
-        scheduler_seed_choices = tuple(
-            dict.fromkeys(
-                scheduler_warps
-                for config in self.config_spec.compiler_seed_configs
-                if type(
-                    scheduler_warps := config.config.get(
-                        TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
-                    )
-                )
-                is int
-                and scheduler_warps in (0, 1)
-            )
-        )
-        all_strategy_choices = tuple(
-            dict.fromkeys((*strategy_choices, *strategy_seed_choices))
-        )
-        all_scheduler_warps_choices = tuple(
-            dict.fromkeys((*scheduler_warps_choices, *scheduler_seed_choices))
+        scheduler_seed_choices = _compiler_seed_values(
+            self.config_spec.compiler_seed_configs,
+            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY,
+            int,
+            lambda scheduler_warps: scheduler_warps in (0, 1),
         )
         # The store-warp slot stays narrowed to ``0`` in the autotune surface —
         # only an explicit ``helion.Config(tcgen05_warp_spec_store_warps=1)``
@@ -2749,25 +2976,21 @@ class CuteTcgen05Config:
         else:
             layout_choices = (Tcgen05LayoutStrategy.DEFAULT.value,)
         return {
-            TCGEN05_STRATEGY_CONFIG_KEY: EnumFragment(
-                all_strategy_choices,
-                search_choices=(
-                    strategy_choices
-                    if all_strategy_choices != strategy_choices
-                    else None
-                ),
+            TCGEN05_STRATEGY_CONFIG_KEY: _enum_fragment_with_seed_values(
+                strategy_choices,
+                strategy_seed_choices,
+                search_choices=strategy_choices,
+                search_only_if_widened=True,
             ),
             TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: EnumFragment(layout_choices),
             TCGEN05_WARP_SPEC_MMA_WARPS_KEY: EnumFragment((1,)),
             TCGEN05_WARP_SPEC_AB_LOAD_WARPS_KEY: EnumFragment((1,)),
             TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY: EnumFragment((0,)),
-            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: EnumFragment(
-                all_scheduler_warps_choices,
-                search_choices=(
-                    scheduler_warps_choices
-                    if all_scheduler_warps_choices != scheduler_warps_choices
-                    else None
-                ),
+            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: _enum_fragment_with_seed_values(
+                scheduler_warps_choices,
+                scheduler_seed_choices,
+                search_choices=scheduler_warps_choices,
+                search_only_if_widened=True,
             ),
             TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: EnumFragment(c_input_warps_choices),
             TCGEN05_WARP_SPEC_STORE_WARPS_KEY: EnumFragment(store_warps_choices),
@@ -3280,6 +3503,7 @@ class CuteTcgen05Config:
             )
 
     def fix_search_config(self, config: dict[str, object]) -> None:
+        self._fix_grouped_worklist_search_config(config)
         self._fix_aux_edge_search_config(config)
         self._fix_cluster_m2_search_config(config)
         self._fix_cluster_m1_persistent_search_config(config)
@@ -3394,97 +3618,77 @@ class CuteTcgen05Config:
         ):
             fields["loop_orders"] = self.config_spec.loop_orders
         fields.update(self.optional_fragments(for_search=True))
-        seed_l2_swizzles = tuple(
-            dict.fromkeys(
-                value
-                for config in self.config_spec.compiler_seed_configs
-                if type(value := config.config.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY))
-                is int
-                and value in TCGEN05_LEGAL_L2_SWIZZLE_SIZES
+        seeds = self.config_spec.compiler_seed_configs
+        if isinstance(fragment := fields.get("tcgen05_ab_stages"), IntegerFragment):
+            fields["tcgen05_ab_stages"] = _integer_fragment_with_seed_values(
+                fragment,
+                _compiler_seed_values(
+                    seeds, "tcgen05_ab_stages", int, lambda value: value > 0
+                ),
             )
+        l2_key = TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
+        if isinstance(fragment := fields.get(l2_key), EnumFragment):
+            fields[l2_key] = _enum_fragment_with_seed_values(
+                fragment.choices,
+                _compiler_seed_values(
+                    seeds,
+                    l2_key,
+                    int,
+                    lambda value: value in TCGEN05_LEGAL_L2_SWIZZLE_SIZES,
+                ),
+                search_choices=fragment.search_choices or fragment.choices,
+                original=fragment,
+            )
+        modes = _compiler_seed_values(
+            seeds,
+            TCGEN05_GROUPED_MODE_CONFIG_KEY,
+            str,
+            lambda value: value in TCGEN05_GROUPED_MODES,
+            exact_type=False,
         )
-        l2_swizzle_fragment = fields.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
-        if seed_l2_swizzles and isinstance(l2_swizzle_fragment, EnumFragment):
-            choices = tuple(
-                dict.fromkeys((*l2_swizzle_fragment.choices, *seed_l2_swizzles))
-            )
-            if choices != l2_swizzle_fragment.choices:
-                fields[TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY] = EnumFragment(
+        if any(mode in TCGEN05_GROUPED_DYNAMIC_MODES for mode in modes):
+            choices = TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
+            fields[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = (
+                _enum_fragment_with_seed_values(
                     choices,
-                    search_choices=(
-                        l2_swizzle_fragment.search_choices
-                        or l2_swizzle_fragment.choices
+                    _compiler_seed_values(
+                        seeds,
+                        TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+                        int,
+                        lambda value: (
+                            0 <= value <= TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
+                        ),
                     ),
+                    search_choices=choices,
                 )
-        grouped_seed_modes = tuple(
-            dict.fromkeys(
-                mode
-                for config in self.config_spec.compiler_seed_configs
-                if (mode := config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY))
-                in TCGEN05_GROUPED_MODES
             )
+        if modes:
+            fields[TCGEN05_GROUPED_MODE_CONFIG_KEY] = _enum_fragment_with_seed_values(
+                (None,), modes, search_choices=(None,)
+            )
+        runtime_direct = _compiler_seed_values(
+            seeds,
+            TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+            bool,
+            lambda value: value is True,
         )
-        has_grouped_dynamic_seed = any(
-            mode in TCGEN05_GROUPED_DYNAMIC_MODES for mode in grouped_seed_modes
+        if runtime_direct:
+            fields[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = (
+                _enum_fragment_with_seed_values(
+                    (False,), runtime_direct, search_choices=(False,)
+                )
+            )
+        source_m_tiles = _compiler_seed_values(
+            seeds,
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+            int,
+            lambda value: value in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES,
         )
-        if has_grouped_dynamic_seed:
-            seed_reserved_sms = tuple(
-                dict.fromkeys(
-                    reserved_sms
-                    for config in self.config_spec.compiler_seed_configs
-                    if type(
-                        reserved_sms := config.config.get(
-                            TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
-                        )
-                    )
-                    is int
-                    and 0 <= reserved_sms <= TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
+        if source_m_tiles:
+            fields[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = (
+                _enum_fragment_with_seed_values(
+                    (None,), source_m_tiles, search_choices=(None,)
                 )
-            )
-            reserved_sms_choices = tuple(
-                dict.fromkeys(
-                    (
-                        *TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
-                        *seed_reserved_sms,
-                    )
-                )
-            )
-            fields[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = EnumFragment(
-                reserved_sms_choices,
-                search_choices=TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
-            )
-        if grouped_seed_modes:
-            # Seed-only encoding: random/default search stays off the grouped
-            # path, while exact-proof compiler seeds survive flatten/unflatten.
-            fields[TCGEN05_GROUPED_MODE_CONFIG_KEY] = EnumFragment(
-                (None, *grouped_seed_modes),
-                search_choices=(None,),
-            )
-        if any(
-            config.config.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
-            for config in self.config_spec.compiler_seed_configs
-        ):
-            fields[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = EnumFragment(
-                (False, True),
-                search_choices=(False,),
-            )
-        grouped_source_m_tiles = tuple(
-            dict.fromkeys(
-                source_m_tile
-                for config in self.config_spec.compiler_seed_configs
-                if (
-                    source_m_tile := config.config.get(
-                        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
-                    )
-                )
-                and type(source_m_tile) is int
-                and source_m_tile in TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CHOICES
-            )
-        )
-        if grouped_source_m_tiles:
-            fields[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY] = EnumFragment(
-                (None, *grouped_source_m_tiles),
-                search_choices=(None,),
             )
         fields.update(self.strategy_autotune_fragments())
         fields.update(self.aux_load_mode_autotune_fragments())
@@ -3492,21 +3696,17 @@ class CuteTcgen05Config:
         fields.update(self.consumer_regs_autotune_fragments())
         fields.update(self.persistence_model_autotune_fragments())
         if self.config_spec.supports_config_key("pid_type"):
-            seed_pid_types = tuple(
-                cast("PidTypeLiteral", pid_type)
-                for seed in self.config_spec.compiler_seed_configs
-                if isinstance(pid_type := seed.config.get("pid_type"), str)
-            )
-            pid_type_choices = tuple(
-                dict.fromkeys((*self.allowed_pid_types, *seed_pid_types))
-            )
-            pid_type_search_choices = (
-                self.allowed_pid_types
-                if pid_type_choices != self.allowed_pid_types
-                else None
-            )
-            fields["pid_type"] = EnumFragment(
-                pid_type_choices, search_choices=pid_type_search_choices
+            fields["pid_type"] = _enum_fragment_with_seed_values(
+                self.allowed_pid_types,
+                _compiler_seed_values(
+                    seeds,
+                    "pid_type",
+                    str,
+                    lambda _value: True,
+                    exact_type=False,
+                ),
+                search_choices=self.allowed_pid_types,
+                search_only_if_widened=True,
             )
         if (
             self.config_spec.supports_config_key("indexing")

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -83,6 +83,7 @@ from .type_info import _eval_unary
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from collections.abc import Collection
     from collections.abc import Iterable
     from collections.abc import Mapping
     from collections.abc import Sequence
@@ -90,6 +91,7 @@ if TYPE_CHECKING:
     from ..autotuner.config_spec import AccumulatorFact
     from ..autotuner.config_spec import ConfigSpec
     from ..autotuner.config_spec import MemoryOpFact
+    from ..language.matmul_ops import _CuteTcgen05SearchPlanningResult
     from .cute.layout import CuTeGridExecutionPlan
     from .device_ir_analysis import DeviceIRAnalysis
 
@@ -100,6 +102,23 @@ if TYPE_CHECKING:
 tls: _TLS = cast("_TLS", threading.local())
 
 log = logging.getLogger(__name__)
+
+
+def _finalize_cute_tcgen05_search_planning(
+    env: CompileEnvironment,
+    planning_results: Sequence[_CuteTcgen05SearchPlanningResult],
+    analysis_keys: Collection[object],
+) -> bool:
+    """Publish every guard and report whether one cache-safe analysis remains."""
+    env.specialized_vars.update(
+        symbol
+        for result in planning_results
+        for symbol in result.required_specialized_vars
+    )
+    return (
+        all(result.guards_complete for result in planning_results)
+        and len(analysis_keys) == 1
+    )
 
 
 def _lerp_scalar_decomp(
@@ -2922,8 +2941,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                     supports_tensor_4d_tma=flash_shape.supports_tensor_4d_tma,
                 )
             else:
+                from ..language.matmul_ops import _plan_cute_tcgen05_search_candidate
                 from ..language.matmul_ops import enable_cute_tcgen05_search
-                from ..language.matmul_ops import plan_cute_tcgen05_search
+                from .cute.cute_mma import _rank3_grouped_root_axes
                 from .cute.cute_mma import analyze_cute_mma_node
                 from .cute.cute_mma import (
                     tcgen05_fragment_epilogue_source_tiles_reachable,
@@ -2939,13 +2959,33 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                 for graph_info in device_ir.graphs:
                     for node in graph_info.graph.nodes:
                         candidate = analyze_cute_mma_node(node, device_ir=device_ir)
+                        if candidate is None or candidate.requires_accumulator_seed:
+                            continue
                         if (
-                            candidate is None
-                            or candidate.requires_accumulator_seed
-                            or candidate.operands.output_block_ids
+                            candidate.operands.output_block_ids
                             not in root_grid_block_ids
                         ):
-                            continue
+                            if not candidate.operands.rhs.rhs_rank3_grouped_nt:
+                                continue
+                            env = CompileEnvironment.current()
+                            grouped_axes = _rank3_grouped_root_axes(
+                                env,
+                                device_ir,
+                                m_block_id=candidate.operands.m_block_id,
+                                n_block_id=candidate.operands.n_block_id,
+                                k_block_id=candidate.operands.k_block_id,
+                            )
+                            leading_block_id = (
+                                candidate.operands.leading_passthrough_block_id
+                            )
+                            if (
+                                grouped_axes is None
+                                or grouped_axes.segment_block_id is None
+                                or leading_block_id is None
+                                or env.canonical_block_id(grouped_axes.segment_block_id)
+                                != env.canonical_block_id(leading_block_id)
+                            ):
+                                continue
                         lhs = candidate.lhs.meta.get("val")
                         rhs = candidate.rhs.meta.get("val")
                         if not (
@@ -2963,8 +3003,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                     for candidate, _lhs, _rhs, _node in mma_candidates
                 )
                 search_candidates = []
+                planning_results = []
                 for candidate, lhs, rhs, _node in mma_candidates:
-                    search_plan = plan_cute_tcgen05_search(
+                    planning_result = _plan_cute_tcgen05_search_candidate(
                         lhs,
                         rhs,
                         has_leading_passthrough=(
@@ -2976,7 +3017,12 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                         supports_small_n_scalar_fallback=(
                             supports_small_n_scalar_fallback
                         ),
+                        allow_dynamic_hints=(
+                            candidate.operands.rhs.rhs_segment_group is not None
+                        ),
                     )
+                    planning_results.append(planning_result)
+                    search_plan = planning_result.plan
                     if (
                         search_plan is None
                         or not candidate.supports_tcgen05_search_plan(search_plan)
@@ -2995,7 +3041,15 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                     )
                     for candidate, _lhs, _plan in search_candidates
                 }
-                if len(analysis_keys) == 1:
+                # Every dynamic candidate can change the accepted analysis-key
+                # set on a later binding. Publish all source-backed guards only
+                # after every candidate has observed the same compile state.
+                env = CompileEnvironment.current()
+                if _finalize_cute_tcgen05_search_planning(
+                    env,
+                    planning_results,
+                    analysis_keys,
+                ):
                     candidate, lhs, search_plan = search_candidates[0]
                     enable_cute_tcgen05_search(
                         lhs,

--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -118,10 +118,29 @@ class BoundKernelInMemoryCacheKey(CacheKeyBase):
     specialization_key: Information about all kernel inputs.
                         For tensors this means their device, shape, size etc.
     extra_results: Information regarding `hl.specialize` decisions
+    compiler_seed_results: Device facts consumed by compiler seed heuristics
+                           that fired for this bound kernel.
     """
 
     specialization_key: tuple[Hashable, ...]
     extra_results: tuple[Hashable, ...]
+    compiler_seed_results: tuple[Hashable, ...] = dataclasses.field(
+        default=(),
+        repr=False,
+        kw_only=True,
+    )
+
+    def _repr_body(self) -> str:
+        auto_fields = [field for field in dataclasses.fields(self) if field.repr]
+        body = ", ".join(
+            f"{field.name}={getattr(self, field.name)!r}" for field in auto_fields
+        )
+        if self.compiler_seed_results:
+            body = f"{body}, compiler_seed_results={self.compiler_seed_results!r}"
+        return body
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self._repr_body()})"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -160,19 +179,15 @@ class LooseAutotuneCacheKey(BoundKernelInMemoryCacheKey):
     search_policy_hash: str = dataclasses.field(default="", repr=False)
 
     def __repr__(self) -> str:
-        # Reproduce the dataclass-generated repr for all auto-repr fields, then
-        # append ``best_of_k`` only when it is non-default. This preserves the
-        # byte-identical hash for K=1 entries written before the field existed.
-        auto_fields = [f for f in dataclasses.fields(self) if f.repr]
-        body = ", ".join(f"{f.name}={getattr(self, f.name)!r}" for f in auto_fields)
+        # Append ``best_of_k`` only when it is non-default. ``_repr_body`` does
+        # the same for compiler seed results, preserving historical hashes when
+        # both extensions have their defaults.
+        body = self._repr_body()
         if self.best_of_k != 1:
             body = f"{body}, best_of_k={self.best_of_k!r}"
         if self.search_policy_hash:
             body = f"{body}, search_policy_hash={self.search_policy_hash!r}"
         return f"{type(self).__name__}({body})"
-
-    def stable_hash(self) -> str:
-        return hashlib.sha256(repr(self).encode("utf-8")).hexdigest()
 
 
 @dataclasses.dataclass(frozen=True, repr=False)

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -156,6 +156,17 @@ def _record_restriction(
 _TARGET_DEVICE_CAPABILITY_UNSET = object()
 
 
+def _copy_config_structure(value: object) -> object:
+    """Copy built-in config containers while preserving opaque leaf objects."""
+    if type(value) is dict:
+        return {key: _copy_config_structure(item) for key, item in value.items()}
+    if type(value) is list:
+        return [_copy_config_structure(item) for item in value]
+    if type(value) is tuple:
+        return tuple(_copy_config_structure(item) for item in value)
+    return value
+
+
 class TensorNumelConstraint(NamedTuple):
     """Tensor element count must stay within Triton's max numel limit."""
 
@@ -165,7 +176,12 @@ class TensorNumelConstraint(NamedTuple):
 
 
 class MatmulFact(NamedTuple):
-    """Shape facts recorded when matmul requirements are applied."""
+    """Shape facts recorded when matmul requirements are applied.
+
+    ``static_m``, ``static_n``, and ``static_k`` initially contain proven
+    compile-time extents. DeviceIR analysis may later fill missing values with
+    representative runtime hints for whole-kernel matmul sizing.
+    """
 
     lhs_ndim: int
     rhs_ndim: int
@@ -1892,6 +1908,7 @@ class ConfigSpec:
         m_block_id: int,
         n_block_id: int,
         k_block_id: int,
+        compile_time_static_extents: tuple[int | None, int | None, int | None],
         input_dtype: torch.dtype,
         has_leading_passthrough: bool,
         explicit_epi_tile_compatible: bool,
@@ -1900,6 +1917,7 @@ class ConfigSpec:
             m_block_id=m_block_id,
             n_block_id=n_block_id,
             k_block_id=k_block_id,
+            compile_time_static_extents=compile_time_static_extents,
             input_dtype=input_dtype,
             has_leading_passthrough=has_leading_passthrough,
             explicit_epi_tile_compatible=explicit_epi_tile_compatible,
@@ -1909,6 +1927,14 @@ class ConfigSpec:
         self,
     ) -> tuple[BlockSizeFragment, BlockSizeFragment, BlockSizeFragment] | None:
         return self._cute_tcgen05_config._matmul_block_fragments()
+
+    def _tcgen05_matmul_block_ids(self) -> tuple[int, int, int] | None:
+        return self._cute_tcgen05_config.matmul_block_ids
+
+    def _tcgen05_matmul_compile_time_static_extents(
+        self,
+    ) -> tuple[int | None, int | None, int | None] | None:
+        return self._cute_tcgen05_config.matmul_compile_time_static_extents
 
     def _tcgen05_matmul_seed_block_sizes(
         self, *, bm: int, bn: int, bk: int
@@ -1984,6 +2010,14 @@ class ConfigSpec:
         self._cute_tcgen05_config.allow_ab_stages_three_search(
             dtype_bytes=dtype_bytes,
             device=device,
+        )
+
+    def register_cute_tcgen05_grouped_worklist_smem_facts(
+        self, *, group_count: int, device_split_sizes: bool
+    ) -> None:
+        self._cute_tcgen05_config.register_grouped_worklist_smem_facts(
+            group_count=group_count,
+            device_split_sizes=device_split_sizes,
         )
 
     @staticmethod
@@ -2153,6 +2187,21 @@ class ConfigSpec:
 
     def is_supported_config(self, config: Mapping[str, object]) -> bool:
         return not self.unsupported_config_keys(config)
+
+    def normalized_config(
+        self,
+        config: helion.Config | Mapping[str, object],
+    ) -> helion.Config:
+        """Return a normalized copy without mutating the requested config."""
+        values = config.config if isinstance(config, helion.Config) else config
+        copied_values = {
+            key: _copy_config_structure(value) for key, value in values.items()
+        }
+        normalized = helion.Config(
+            **copied_values  # pyrefly: ignore[bad-argument-type]
+        )
+        self.normalize(normalized)
+        return normalized
 
     def normalize(
         self, config: helion.Config | dict[str, object], *, _fix_invalid: bool = False

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -255,10 +255,12 @@ class LocalAutotuneCache(AutotuneCacheBase):
             )
             specialization_key = in_memory_cache_key.specialization_key
             extra_results = in_memory_cache_key.extra_results
+            compiler_seed_results = in_memory_cache_key.compiler_seed_results
             dev = extract_device(self.args)
         else:
             specialization_key = multi_args.workload_key
             extra_results = ()
+            compiler_seed_results = ()
             dev = multi_args.cases[0][0].env.device
         kernel_source = textwrap.dedent(inspect.getsource(self.kernel.kernel.fn))
         kernel_source_hash = hashlib.sha256(kernel_source.encode("utf-8")).hexdigest()
@@ -313,6 +315,7 @@ class LocalAutotuneCache(AutotuneCacheBase):
         return LooseAutotuneCacheKey(
             specialization_key=specialization_key,
             extra_results=extra_results,
+            compiler_seed_results=compiler_seed_results,
             kernel_source_hash=kernel_source_hash,
             hardware=hardware,
             runtime_name=runtime_name,

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import dataclasses
 from itertools import zip_longest
+from typing import TYPE_CHECKING
 
 import torch
 
 from .. import exc
 from .._compat import min_dot_size
 from .._compiler.compile_environment import CompileEnvironment
+from .._compiler.compile_environment import _symint_free_symbols
 from .._compiler.compile_environment import _to_sympy
 from .._compiler.compile_environment import format_shape
 from .._compiler.compile_environment import shape_env_var_hints
@@ -24,6 +26,9 @@ from . import _decorators
 
 MATMUL_FACT_ID_META = "helion_matmul_fact_id"
 MATMUL_DIM_BLOCK_IDS_META = "helion_matmul_dim_block_ids"
+
+if TYPE_CHECKING:
+    import sympy
 
 
 def _static_dim_value(env: CompileEnvironment, size: int | torch.SymInt) -> int | None:
@@ -234,15 +239,29 @@ def _dot_dimensions(
     return m, n, k
 
 
-def _static_problem_extent(
+def _problem_extent(
     env: CompileEnvironment, size: int | torch.SymInt
-) -> int | None:
+) -> int | torch.SymInt | None:
+    """Return the resolved problem extent represented by one tile dimension.
+
+    ``AutoSize`` and ``None`` block sizes are deliberately unresolved: treating
+    the tile symbol's current hint as a problem extent would record a false
+    static ``MatmulFact``.
+    """
     block_idx = env.get_block_id(size)
     if block_idx is not None:
         block_size = env.block_sizes[block_idx].size
         if isinstance(block_size, (int, torch.SymInt)):
-            return _static_dim_value(env, block_size)
-    return _static_dim_value(env, size)
+            return block_size
+        return None
+    return size
+
+
+def _static_problem_extent(
+    env: CompileEnvironment, size: int | torch.SymInt
+) -> int | None:
+    problem_extent = _problem_extent(env, size)
+    return None if problem_extent is None else _static_dim_value(env, problem_extent)
 
 
 def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> int:
@@ -335,14 +354,19 @@ _decorators.post_create_proxy(dot)(_associate_latest_matmul_fact)
 
 @dataclasses.dataclass(frozen=True)
 class CuteTcgen05SearchPlan:
-    """Side-effect-free tcgen05 search limits for one MMA candidate."""
+    """Immutable tcgen05 search limits for one MMA candidate.
+
+    Planning does not mutate shared compile state. ``static_*`` are proven
+    compile-time extents; dynamic cache requirements live in the surrounding
+    planning result so rejected candidates retain them too.
+    """
 
     m: int | torch.SymInt
     n: int | torch.SymInt
     k: int | torch.SymInt
-    static_m: int
-    static_n: int
-    static_k: int
+    static_m: int | None
+    static_n: int | None
+    static_k: int | None
     leading_work_multiplier: int
     is_fp8: bool
     is_small_n: bool
@@ -361,20 +385,78 @@ class CuteTcgen05SearchPlan:
     min_search_n: int
 
 
-def plan_cute_tcgen05_search(
+@dataclasses.dataclass(frozen=True)
+class _CuteTcgen05SearchPlanningResult:
+    """One side-effect-free candidate decision and its cache requirements.
+
+    ``guards_complete`` is false when a dynamic extent cannot be traced back to
+    runtime inputs. Such a candidate makes the whole tcgen05 search unsafe to
+    cache, even when this particular binding rejects the candidate.
+    """
+
+    plan: CuteTcgen05SearchPlan | None
+    required_specialized_vars: frozenset[sympy.Symbol]
+    guards_complete: bool
+
+
+def _plan_cute_tcgen05_search_candidate(
     lhs: torch.Tensor,
     rhs: torch.Tensor,
     *,
     has_leading_passthrough: bool,
     supports_small_n_role_local_tma: bool = False,
     supports_small_n_scalar_fallback: bool = False,
-) -> CuteTcgen05SearchPlan | None:
-    """Return search limits without mutating the shared ``ConfigSpec``."""
+    allow_dynamic_hints: bool = False,
+) -> _CuteTcgen05SearchPlanningResult:
+    """Plan one candidate and retain guards even when the candidate is rejected."""
     m, n, k = _dot_dimensions(lhs, rhs)
     env = CompileEnvironment.current()
-    static_m = _static_problem_extent(env, m)
-    static_n = _static_problem_extent(env, n)
-    static_k = _static_problem_extent(env, k)
+
+    problem_extents = tuple(_problem_extent(env, size) for size in (m, n, k))
+    static_m, static_n, static_k = (
+        None if problem_extent is None else _static_dim_value(env, problem_extent)
+        for problem_extent in problem_extents
+    )
+    required_specialized_vars: set[sympy.Symbol] = set()
+    guards_complete = True
+    if allow_dynamic_hints:
+        for problem_extent, static_size in zip(
+            problem_extents,
+            (static_m, static_n, static_k),
+            strict=True,
+        ):
+            if static_size is not None:
+                continue
+            if not isinstance(problem_extent, torch.SymInt):
+                guards_complete = False
+                continue
+            dynamic_symbols = _symint_free_symbols(problem_extent)
+            if not dynamic_symbols:
+                guards_complete = False
+                continue
+            for symbol in dynamic_symbols:
+                if env.shape_env.var_to_sources.get(symbol):
+                    required_specialized_vars.add(symbol)
+                else:
+                    guards_complete = False
+    frozen_required_specialized_vars = frozenset(required_specialized_vars)
+
+    def reject() -> _CuteTcgen05SearchPlanningResult:
+        return _CuteTcgen05SearchPlanningResult(
+            plan=None,
+            required_specialized_vars=frozen_required_specialized_vars,
+            guards_complete=guards_complete,
+        )
+
+    if not guards_complete:
+        return reject()
+    if not allow_dynamic_hints and (
+        static_m is None or static_n is None or static_k is None
+    ):
+        return reject()
+    m_hint = static_m if static_m is not None else env.size_hint(m)
+    n_hint = static_n if static_n is not None else env.size_hint(n)
+    k_hint = static_k if static_k is not None else env.size_hint(k)
     is_fp8 = lhs.dtype == torch.float8_e4m3fn
     mma_k = 32 if is_fp8 else 16
     min_tcgen05_n = 16 if is_fp8 else 8
@@ -383,22 +465,20 @@ def plan_cute_tcgen05_search(
         env.backend_name != "cute"
         or lhs.dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         or rhs.dtype != lhs.dtype
-        or static_m is None
-        or static_n is None
-        or static_k is None
-        or static_m < 64
+        or m_hint < 64
         # Size-one tile axes are fixed to block size one before this analysis,
         # so they cannot carry the minimum tcgen05 instruction tile.
-        or static_n < 2
+        or (static_n is not None and static_n < 2)
+        or (static_n is None and n_hint < min_tcgen05_n)
         or (
             is_small_n
             and not (
                 supports_small_n_role_local_tma or supports_small_n_scalar_fallback
             )
         )
-        or static_k < mma_k
+        or k_hint < mma_k
     ):
-        return None
+        return reject()
     small_n_requires_role_local_tma = (
         is_small_n and not supports_small_n_scalar_fallback
     )
@@ -407,18 +487,35 @@ def plan_cute_tcgen05_search(
 
     support = get_cute_mma_support()
     if not (support.tcgen05_f8 if is_fp8 else support.tcgen05_f16bf16):
-        return None
+        return reject()
 
     def pow2_floor_at_least(value: int, minimum: int) -> int:
         return 1 << (max(minimum, value).bit_length() - 1)
 
-    max_tcgen05_n = min(256, pow2_floor_at_least(static_n, min_tcgen05_n))
-    max_tcgen05_m = 256 if max_tcgen05_n >= 128 and static_m >= 256 else 128
-    max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
+    max_tcgen05_n = (
+        256
+        if static_n is None
+        else min(256, pow2_floor_at_least(static_n, min_tcgen05_n))
+    )
+    max_tcgen05_m = (
+        256 if max_tcgen05_n >= 128 and (static_m is None or static_m >= 256) else 128
+    )
+    max_search_m = (
+        max_tcgen05_m
+        if static_m is None
+        else min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
+    )
     max_search_n = max_tcgen05_n
-    max_search_k = min(128, pow2_floor_at_least(static_k, mma_k))
+    max_search_k = (
+        128 if static_k is None else min(128, pow2_floor_at_least(static_k, mma_k))
+    )
     min_search_m = 128 if max_tcgen05_m >= 256 else 64
-    if is_small_n and supports_small_n_scalar_fallback and not is_fp8:
+    if (
+        static_n is not None
+        and is_small_n
+        and supports_small_n_scalar_fallback
+        and not is_fp8
+    ):
         min_search_n = 1 << (static_n - 1).bit_length()
     else:
         min_search_n = min_tcgen05_n
@@ -428,44 +525,77 @@ def plan_cute_tcgen05_search(
         static_leading = _static_problem_extent(env, leading_operand.shape[0])
         if static_leading is not None:
             leading_work_multiplier = max(static_leading, 1)
-        if static_m % min_search_m != 0:
-            min_search_m = 64
-        max_search_m = min(max_search_m, static_m & -static_m)
-        max_search_n = min(max_search_n, static_n & -static_n)
-        max_search_k = min(max_search_k, static_k & -static_k)
-        if (
-            max_search_m < min_search_m
-            or max_search_n < min_search_n
-            or max_search_k < mma_k
-        ):
-            return None
-    if static_m % max_search_m != 0 and static_n % max_search_n != 0:
+        if static_m is not None and static_n is not None and static_k is not None:
+            if static_m % min_search_m != 0:
+                min_search_m = 64
+            max_search_m = min(max_search_m, static_m & -static_m)
+            max_search_n = min(max_search_n, static_n & -static_n)
+            max_search_k = min(max_search_k, static_k & -static_k)
+            if (
+                max_search_m < min_search_m
+                or max_search_n < min_search_n
+                or max_search_k < mma_k
+            ):
+                return reject()
+    if (
+        static_m is not None
+        and static_n is not None
+        and static_m % max_search_m != 0
+        and static_n % max_search_n != 0
+    ):
         max_search_m = min(max_search_m, 128)
     if small_n_requires_role_local_tma and (
-        static_m % max_search_m != 0 or static_k % max_search_k != 0
+        static_m is None
+        or static_k is None
+        or static_m % max_search_m != 0
+        or static_k % max_search_k != 0
     ):
-        return None
-    return CuteTcgen05SearchPlan(
-        m=m,
-        n=n,
-        k=k,
-        static_m=static_m,
-        static_n=static_n,
-        static_k=static_k,
-        leading_work_multiplier=leading_work_multiplier,
-        is_fp8=is_fp8,
-        is_small_n=is_small_n,
-        small_n_supports_role_local_tma=supports_small_n_role_local_tma,
-        small_n_requires_role_local_tma=small_n_requires_role_local_tma,
-        mma_k=mma_k,
-        max_tcgen05_m=max_tcgen05_m,
-        max_tcgen05_n=max_tcgen05_n,
-        max_search_m=max_search_m,
-        max_search_n=max_search_n,
-        max_search_k=max_search_k,
-        min_search_m=min_search_m,
-        min_search_n=min_search_n,
+        return reject()
+    return _CuteTcgen05SearchPlanningResult(
+        plan=CuteTcgen05SearchPlan(
+            m=m,
+            n=n,
+            k=k,
+            static_m=static_m,
+            static_n=static_n,
+            static_k=static_k,
+            leading_work_multiplier=leading_work_multiplier,
+            is_fp8=is_fp8,
+            is_small_n=is_small_n,
+            small_n_supports_role_local_tma=supports_small_n_role_local_tma,
+            small_n_requires_role_local_tma=small_n_requires_role_local_tma,
+            mma_k=mma_k,
+            max_tcgen05_m=max_tcgen05_m,
+            max_tcgen05_n=max_tcgen05_n,
+            max_search_m=max_search_m,
+            max_search_n=max_search_n,
+            max_search_k=max_search_k,
+            min_search_m=min_search_m,
+            min_search_n=min_search_n,
+        ),
+        required_specialized_vars=frozen_required_specialized_vars,
+        guards_complete=True,
     )
+
+
+def plan_cute_tcgen05_search(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    *,
+    has_leading_passthrough: bool,
+    supports_small_n_role_local_tma: bool = False,
+    supports_small_n_scalar_fallback: bool = False,
+    allow_dynamic_hints: bool = False,
+) -> CuteTcgen05SearchPlan | None:
+    """Return search limits without mutating shared compilation state."""
+    return _plan_cute_tcgen05_search_candidate(
+        lhs,
+        rhs,
+        has_leading_passthrough=has_leading_passthrough,
+        supports_small_n_role_local_tma=supports_small_n_role_local_tma,
+        supports_small_n_scalar_fallback=supports_small_n_scalar_fallback,
+        allow_dynamic_hints=allow_dynamic_hints,
+    ).plan
 
 
 def enable_cute_tcgen05_search(
@@ -486,6 +616,7 @@ def enable_cute_tcgen05_search(
         m_block_id=m_block_id,
         n_block_id=n_block_id,
         k_block_id=k_block_id,
+        compile_time_static_extents=(plan.static_m, plan.static_n, plan.static_k),
         input_dtype=input_dtype,
         has_leading_passthrough=has_leading_passthrough,
         explicit_epi_tile_compatible=explicit_epi_tile_compatible,
@@ -497,52 +628,60 @@ def enable_cute_tcgen05_search(
     max_search_n = plan.max_search_n
     max_search_k = plan.max_search_k
     spec.cute_tcgen05_search_enabled = True
-    allow_full_tile_persistent_pid_types = (
-        static_m % max_search_m == 0
-        and static_n % max_search_n == 0
-        and static_k % max_search_k == 0
-    )
-    allow_small_n_persistent_pid_types = (
-        plan.is_small_n
-        and plan.small_n_supports_role_local_tma
-        and 0 < static_n < max_search_n
-        and static_m % max_search_m == 0
-        and static_k % max_search_k == 0
-    )
     max_cluster_m2_search_k = TCGEN05_TWO_CTA_MAX_K_TILES * max_search_k
-    allow_full_tile_cluster_m2_search = (
-        allow_full_tile_persistent_pid_types
-        and max_search_m >= TCGEN05_TWO_CTA_BLOCK_M
-        and max_search_n >= TCGEN05_TWO_CTA_BLOCK_N
-        and static_k <= max_cluster_m2_search_k
-    )
-    allow_edge_cluster_m2_search = (
-        not has_leading_passthrough
-        and not allow_full_tile_persistent_pid_types
-        and plan.max_tcgen05_m >= TCGEN05_TWO_CTA_BLOCK_M
-        and plan.max_tcgen05_n >= TCGEN05_TWO_CTA_BLOCK_N
-        and static_m >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
-        and static_n >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
-        and static_k >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
-        and static_k <= max_cluster_m2_search_k
-        and static_m % TCGEN05_TWO_CTA_BLOCK_M != 0
-        and static_n % TCGEN05_TWO_CTA_BLOCK_N != 0
-        and static_k % max_search_k != 0
-    )
-    allow_fp8_small_grid_cluster_m2_search = (
-        not has_leading_passthrough
-        and plan.is_fp8
-        and allow_full_tile_persistent_pid_types
-        and max_search_m >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
-        and max_search_n >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
-        and static_k <= max_cluster_m2_search_k
-    )
+    if static_m is None or static_n is None or static_k is None:
+        allow_full_tile_persistent_pid_types = False
+        allow_small_n_persistent_pid_types = False
+        allow_full_tile_cluster_m2_search = False
+        allow_edge_cluster_m2_search = False
+        allow_fp8_small_grid_cluster_m2_search = False
+    else:
+        allow_full_tile_persistent_pid_types = (
+            static_m % max_search_m == 0
+            and static_n % max_search_n == 0
+            and static_k % max_search_k == 0
+        )
+        allow_small_n_persistent_pid_types = (
+            plan.is_small_n
+            and plan.small_n_supports_role_local_tma
+            and 0 < static_n < max_search_n
+            and static_m % max_search_m == 0
+            and static_k % max_search_k == 0
+        )
+        allow_full_tile_cluster_m2_search = (
+            allow_full_tile_persistent_pid_types
+            and max_search_m >= TCGEN05_TWO_CTA_BLOCK_M
+            and max_search_n >= TCGEN05_TWO_CTA_BLOCK_N
+            and static_k <= max_cluster_m2_search_k
+        )
+        allow_edge_cluster_m2_search = (
+            not has_leading_passthrough
+            and not allow_full_tile_persistent_pid_types
+            and plan.max_tcgen05_m >= TCGEN05_TWO_CTA_BLOCK_M
+            and plan.max_tcgen05_n >= TCGEN05_TWO_CTA_BLOCK_N
+            and static_m >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
+            and static_n >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
+            and static_k >= TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
+            and static_k <= max_cluster_m2_search_k
+            and static_m % TCGEN05_TWO_CTA_BLOCK_M != 0
+            and static_n % TCGEN05_TWO_CTA_BLOCK_N != 0
+            and static_k % max_search_k != 0
+        )
+        allow_fp8_small_grid_cluster_m2_search = (
+            not has_leading_passthrough
+            and plan.is_fp8
+            and allow_full_tile_persistent_pid_types
+            and max_search_m >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
+            and max_search_n >= TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
+            and static_k <= max_cluster_m2_search_k
+        )
     allow_cluster_m2_search = (
         allow_full_tile_cluster_m2_search
         or allow_edge_cluster_m2_search
         or allow_fp8_small_grid_cluster_m2_search
     )
     if allow_cluster_m2_search:
+        assert static_m is not None and static_n is not None and static_k is not None
         num_sms = _cuda_num_sms_or_zero(lhs.device)
         if num_sms > 0:
             if allow_fp8_small_grid_cluster_m2_search:

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from contextlib import suppress
 import contextvars
 from dataclasses import dataclass
+from dataclasses import field
 import hashlib
 import importlib
 import inspect
@@ -31,9 +32,17 @@ from typing import cast
 import weakref
 
 import torch
+from torch._subclasses import FakeTensor
+from torch._subclasses.fake_tensor import unset_fake_temporarily
+from torch.utils.weak import WeakIdKeyDictionary
 
 from ... import exc
 from ..._compiler.cute.device_state import Tcgen05GroupedSchedulerMode
+from ..._compiler.cute.grouped_worklist import Tcgen05GroupedWorklistValidationError
+from ..._compiler.cute.grouped_worklist import (
+    tcgen05_grouped_worklist_compatible_source_m_tiles,
+)
+from ..._compiler.cute.grouped_worklist import validate_tcgen05_grouped_worklist_rows
 from ..._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from ..._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from ..._compiler.cute.strategies import tcgen05_smem_layout_expr
@@ -53,7 +62,9 @@ from ..._compiler.cute.tcgen05_constants import Tcgen05GroupedRuntimeTileField
 from ..triton.launcher import get_num_sm
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
     from collections.abc import Iterator
+    from collections.abc import Sequence
 
     from torch.cuda import _POOL_HANDLE
 
@@ -2105,6 +2116,19 @@ def _tcgen05_grouped_device_split_sizes(plan: dict[str, object]) -> bool:
     return bool(plan.get("device_split_sizes"))
 
 
+def _tcgen05_grouped_device_layout_kind(
+    plan: dict[str, object],
+) -> str:
+    kind = plan.get("device_layout_kind", "split_sizes")
+    if kind not in ("split_sizes", "offsets"):
+        raise exc.BackendUnsupported(
+            "cute",
+            f"unknown tcgen05 grouped device layout kind: {kind!r}",
+        )
+    assert isinstance(kind, str)
+    return kind
+
+
 def _tcgen05_grouped_host_metadata_plans(
     cute_kernel: object,
 ) -> list[dict[str, object]]:
@@ -2321,7 +2345,7 @@ def _tcgen05_grouped_static_layout_arg(
         if layout.ndim != 1:
             raise exc.BackendUnsupported(
                 "cute",
-                "tcgen05 grouped device split_sizes must have shape [G]",
+                "tcgen05 grouped compact device layout must be rank 1",
             )
     elif worklist_metadata:
         if layout.ndim != 2 or layout.size(1) != 4:
@@ -2345,10 +2369,13 @@ def _validate_tcgen05_grouped_device_split_sizes(
     split_sizes: torch.Tensor,
 ) -> None:
     group_count = _plan_int_value(plan, "group_count")
-    if int(split_sizes.numel()) != group_count:
+    layout_kind = _tcgen05_grouped_device_layout_kind(plan)
+    expected_values = group_count + (layout_kind == "offsets")
+    if int(split_sizes.numel()) != expected_values:
+        expected_shape = "[G + 1]" if layout_kind == "offsets" else "[G]"
         raise exc.BackendUnsupported(
             "cute",
-            "tcgen05 grouped device split_sizes length must match group count",
+            f"tcgen05 grouped device {layout_kind} must have shape {expected_shape}",
         )
     if _tcgen05_plan_orientation(plan) != "nm":
         raise exc.BackendUnsupported(
@@ -2719,6 +2746,81 @@ def _tcgen05_grouped_tensor_mutation_key(
     return ("values", tuple(tensor.detach().reshape(-1).cpu().tolist()))
 
 
+@dataclass(frozen=True)
+class _Tcgen05GroupedWorklistCompatibilityClassifier:
+    """Project packed worklist values onto compatible source-M tile families."""
+
+    static_group_count: int | None
+    static_packed_m: int | None
+    cache: WeakIdKeyDictionary = field(
+        default_factory=WeakIdKeyDictionary,
+        compare=False,
+        repr=False,
+    )
+
+    def __call__(self, values: Sequence[object]) -> Hashable:
+        tensor = values[0]
+        if not isinstance(tensor, torch.Tensor):
+            return (
+                "not_tensor",
+                type(tensor).__module__,
+                type(tensor).__name__,
+            )
+        if isinstance(tensor, FakeTensor):
+            if not isinstance(tensor.constant, torch.Tensor):
+                return ()
+            tensor = tensor.constant
+
+        value_index = 1
+        group_count = self.static_group_count
+        if group_count is None:
+            group_count = cast("int", values[value_index])
+            value_index += 1
+        packed_m = self.static_packed_m
+        if packed_m is None:
+            packed_m = cast("int", values[value_index])
+
+        inference_values: tuple[int, ...] | None = None
+        is_inference = torch.is_inference(tensor)
+        with unset_fake_temporarily():
+            tensor_key = _tcgen05_grouped_tensor_cache_key(
+                "worklist",
+                tensor,
+                include_version=not is_inference,
+            )
+            if is_inference:
+                mutation_key = _tcgen05_grouped_tensor_mutation_key(tensor)
+                inference_values = cast("tuple[int, ...]", mutation_key[1])
+        input_key = (tensor_key, inference_values, group_count, packed_m)
+        try:
+            cached_input_key, cached_result = self.cache[tensor]
+        except KeyError:
+            pass
+        else:
+            if cached_input_key == input_key:
+                return cast("tuple[int, ...]", cached_result)
+        if tensor.ndim != 2 or tensor.shape[1] != 4:
+            rows = []
+        elif inference_values is not None:
+            rows = [
+                list(inference_values[index : index + 4])
+                for index in range(0, len(inference_values), 4)
+            ]
+        else:
+            with unset_fake_temporarily():
+                rows = cast(
+                    "list[list[int]]",
+                    tensor.detach().reshape(-1, 4).cpu().tolist(),
+                )
+        result = tcgen05_grouped_worklist_compatible_source_m_tiles(
+            rows,
+            group_count=group_count,
+            packed_m=packed_m,
+        )
+        self.cache[tensor] = (input_key, result)
+        return result
+
+
 def _validate_tcgen05_grouped_direct_d_tensormap(
     tensor: torch.Tensor,
 ) -> None:
@@ -2928,72 +3030,18 @@ def _validate_tcgen05_grouped_worklist_nm(
     lhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A")
     rhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B")
     source_m_tile = _plan_int_value(plan, "source_m_tile")
-    expected_store_end = 0
-    seen_groups: set[int] = set()
-    for row in rows:
-        real_group, start, actual_m, aligned_m = (int(value) for value in row)
-        if real_group < 0 or real_group >= int(rhs.size(0)):
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist real group id is outside B_grouped",
-            )
-        if real_group in seen_groups:
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist requires unique real group ids",
-            )
-        seen_groups.add(real_group)
-        if start < 0 or start % source_m_tile != 0:
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist requires group starts aligned "
-                f"to {source_m_tile} rows",
-            )
-        if actual_m < 0 or actual_m > aligned_m:
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist requires 0 <= actual_m <= aligned_m",
-            )
-        if aligned_m < 0 or aligned_m % source_m_tile != 0:
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist requires aligned_m to be a "
-                f"nonnegative multiple of {source_m_tile}",
-            )
-        if (actual_m == 0) != (aligned_m == 0):
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist requires actual_m and aligned_m to be "
-                "zero together",
-            )
-        if start + aligned_m > int(lhs.size(0)):
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist aligned extent exceeds A extent",
-            )
-        if aligned_m == 0:
-            continue
-        if start < expected_store_end:
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist has overlapping A rows",
-            )
-        if start > expected_store_end:
-            raise exc.BackendUnsupported(
-                "cute",
-                "tcgen05 N,M worklist has row holes",
-            )
-        expected_store_end = start + aligned_m
-    if expected_store_end != int(lhs.size(0)):
+    try:
+        validate_tcgen05_grouped_worklist_rows(
+            rows,
+            group_count=int(rhs.size(0)),
+            packed_m=int(lhs.size(0)),
+            source_m_tile=source_m_tile,
+        )
+    except Tcgen05GroupedWorklistValidationError as error:
         raise exc.BackendUnsupported(
             "cute",
-            "tcgen05 N,M worklist aligned extents must cover A rows",
-        )
-    if seen_groups and seen_groups != set(range(len(seen_groups))):
-        raise exc.BackendUnsupported(
-            "cute",
-            "tcgen05 N,M worklist requires dense real group ids",
-        )
+            str(error),
+        ) from None
 
 
 def _validate_tcgen05_grouped_runtime_direct_clc_grid(total_clusters: int) -> None:

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -44,11 +44,17 @@ from torch.utils._pytree import tree_map_only
 from torch.utils.weak import WeakIdKeyDictionary
 
 from .. import exc
+from .._argument_device import _ArgumentDeviceResolver
+from .._argument_device import _canonicalize_argument_device
+from .._argument_device import _current_device_index
+from .._argument_device import _find_argument_device as _find_device
 from .._compat import shape_env_size_hint
 from .._compat import target_device_capability
 from .._compile_time import measure
 from .._compiler.ast_extension import unparse
+from .._compiler.autotuner_heuristics import compiler_promotion_specialization_key
 from .._compiler.autotuner_heuristics import compiler_seed_configs
+from .._compiler.autotuner_heuristics import compiler_seed_specialization_facts
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.compile_environment import TensorDescriptorLayoutGuard
 from .._compiler.compile_environment import _is_supported_tensor_input_source
@@ -76,10 +82,12 @@ from .settings import Settings
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-    from collections.abc import Hashable
 
     from torch._guards import Source
 
+    from .._compiler.autotuner_heuristics.registry import (
+        CompilerHeuristicSpecializationFact,
+    )
     from .._compiler.host_function import HostFunction
     from ..autotuner import ConfigSpec
     from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
@@ -207,6 +215,113 @@ def _nested_fast_dispatch_key(
     return None
 
 
+_TensorMetadataPathStep = (
+    tuple[Literal["sequence"], type[object], int]
+    | tuple[Literal["mapping"], type[object], type[object], Hashable]
+    | tuple[Literal["dataclass"], type[object], str]
+)
+
+
+def _mapping_metadata_sort_key(key: object) -> tuple[str, str, str]:
+    key_type = type(key)
+    return key_type.__module__, key_type.__qualname__, repr(key)
+
+
+def _walk_input_tensors(
+    value: object,
+    path: tuple[_TensorMetadataPathStep, ...] = (),
+) -> Generator[tuple[tuple[_TensorMetadataPathStep, ...], torch.Tensor], None, None]:
+    """Yield input tensors with deterministic structural roles."""
+    if isinstance(value, torch.Tensor):
+        yield path, value
+        return
+    if isinstance(value, ConstExpr):
+        return
+    container_type = type(value)
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        for field in dataclasses.fields(value):
+            yield from _walk_input_tensors(
+                getattr(value, field.name),
+                (*path, ("dataclass", container_type, field.name)),
+            )
+    elif isinstance(value, (tuple, list)):
+        for index, item in enumerate(value):
+            yield from _walk_input_tensors(
+                item,
+                (*path, ("sequence", container_type, index)),
+            )
+    elif isinstance(value, dict):
+        for key, item in sorted(
+            value.items(),
+            key=lambda entry: _mapping_metadata_sort_key(entry[0]),
+        ):
+            yield from _walk_input_tensors(
+                item,
+                (
+                    *path,
+                    ("mapping", container_type, type(key), cast("Hashable", key)),
+                ),
+            )
+
+
+def _input_tensor_metadata(values: Sequence[object]) -> tuple[Hashable, ...]:
+    """Return exact tensor metadata keyed by deterministic structural roles."""
+    return tuple(
+        (path, _hashable_dims(tensor.size()), _hashable_dims(tensor.stride()))
+        for path, tensor in _walk_input_tensors(values)
+    )
+
+
+def _input_tensor_aliases(values: Sequence[object]) -> tuple[int, ...] | None:
+    """Return a canonical key only when tensor arguments alias."""
+    aliases: list[int] = []
+    unique_tensors: list[torch.Tensor] = []
+    for _path, tensor in _walk_input_tensors(values):
+        for index, previous_tensor in enumerate(unique_tensors):
+            if tensor is previous_tensor:
+                aliases.append(index)
+                break
+        else:
+            aliases.append(len(unique_tensors))
+            unique_tensors.append(tensor)
+    return tuple(aliases) if len(set(aliases)) != len(aliases) else None
+
+
+@dataclasses.dataclass(frozen=True)
+class _CompilerSeedSpecializationExtractor:
+    fact: CompilerHeuristicSpecializationFact
+    reserved_sms: int
+
+    def for_device(self, device: torch.device) -> Hashable:
+        from . import get_num_sm
+
+        if self.fact == "device_num_sm":
+            return self.fact, get_num_sm(device)
+        assert self.fact == "config_num_sm"
+        return self.fact, get_num_sm(device, reserved_sms=self.reserved_sms)
+
+    def __call__(self, values: Sequence[object]) -> Hashable:
+        if self.fact == "input_tensor_metadata":
+            return self.fact, _input_tensor_metadata(values)
+
+        device = _canonicalize_argument_device(_find_device(tuple(values)))
+        return self.for_device(device)
+
+
+def _compiler_seed_specialization_extractors(
+    facts: frozenset[CompilerHeuristicSpecializationFact],
+    reserved_sms: int,
+    *,
+    static_shapes: bool,
+) -> tuple[_CompilerSeedSpecializationExtractor, ...]:
+    if static_shapes:
+        facts = frozenset(fact for fact in facts if fact != "input_tensor_metadata")
+    return tuple(
+        _CompilerSeedSpecializationExtractor(fact, reserved_sms)
+        for fact in sorted(facts)
+    )
+
+
 class _SpecializationAlias:
     """An omitted-default signature backed by a normalized signature."""
 
@@ -237,6 +352,7 @@ def _make_prepared_arg_guard(
     namespace: dict[str, object] = {}
     checks = [f"len(args) == {len(args)}"]
     counter = itertools.count()
+    tensor_paths: list[tuple[str, torch.Tensor]] = []
 
     def append_checks(
         value: object,
@@ -249,6 +365,10 @@ def _make_prepared_arg_guard(
         checks.append(f"type({prefix}) is type_{token}")
         if value_type in (torch.Tensor, torch.nn.Parameter):
             assert isinstance(value, torch.Tensor)
+            for previous_prefix, previous_tensor in tensor_paths:
+                relation = "is" if value is previous_tensor else "is not"
+                checks.append(f"{prefix} {relation} {previous_prefix}")
+            tensor_paths.append((prefix, value))
             namespace[f"dtype_{token}"] = value.dtype
             namespace[f"shape_{token}"] = value.shape
             namespace[f"stride_{token}"] = value.stride()
@@ -431,24 +551,6 @@ class _PreparedCall:
             return False
 
 
-def _current_device_index(device_type: str) -> int:
-    device_module = getattr(torch, device_type, None)
-    current_device = getattr(device_module, "current_device", None)
-    if callable(current_device):
-        return cast("int", current_device())
-
-    accelerator = getattr(torch, "accelerator", None)
-    current_accelerator = getattr(accelerator, "current_accelerator", None)
-    current_device_index = getattr(accelerator, "current_device_index", None)
-    if callable(current_accelerator) and callable(current_device_index):
-        accelerator_device = cast("torch.device", current_accelerator())
-        if accelerator_device.type == device_type:
-            return cast("int", current_device_index())
-    raise exc.InvalidAPIUsage(
-        f"autotune_multi requires a current indexed accelerator, got {device_type!r}"
-    )
-
-
 def _canonicalize_multi_shape_device(device: torch.device) -> torch.device:
     if device.type in ("cpu", "meta", "mps"):
         raise exc.InvalidAPIUsage(
@@ -456,7 +558,14 @@ def _canonicalize_multi_shape_device(device: torch.device) -> torch.device:
         )
     if device.index is not None:
         return device
-    return torch.device(device.type, _current_device_index(device.type))
+    try:
+        index = _current_device_index(device.type)
+    except exc.InvalidAPIUsage as error:
+        raise exc.InvalidAPIUsage(
+            "autotune_multi requires a current indexed accelerator, "
+            f"got {device.type!r}"
+        ) from error
+    return torch.device(device.type, index)
 
 
 def _has_unspecialized_numeric_value(value: object) -> bool:
@@ -510,19 +619,33 @@ def _resolve_index_dtype(
 
 def _device_specialization_key(
     args: Sequence[object],
-) -> tuple[str | None, tuple[int, int] | None]:
+    *,
+    backend: str,
+    compiler_heuristics_enabled: bool,
+) -> tuple[
+    str | None,
+    tuple[int, int] | None,
+    tuple[tuple[str, str | None], ...],
+]:
     """Return the recursive argument device key used by bound-kernel caching.
 
     `_find_device` intentionally searches tensors and bare `torch.device`
     objects inside supported containers to match binding device selection.
-    Capability splits mixed-sm cache entries. Device index remains excluded so
-    same-capability devices share bound kernels, matching prior behavior.
+    Capability splits mixed-sm cache entries. Exact hardware identity is added
+    only when an active compiler heuristic uses it to gate default promotion.
+    Device index remains excluded so otherwise-compatible devices share bound
+    kernels, matching prior behavior.
     """
     try:
-        device = _find_device(tuple(args))
+        device = _canonicalize_argument_device(_find_device(tuple(args)))
     except exc.NoTensorArgs:
-        return None, None
-    return device.type, target_device_capability(device)
+        return None, None, ()
+    promotion_key = (
+        compiler_promotion_specialization_key(backend, device)
+        if compiler_heuristics_enabled
+        else ()
+    )
+    return device.type, target_device_capability(device), promotion_key
 
 
 @dataclasses.dataclass
@@ -593,6 +716,9 @@ class Kernel(Generic[_R]):
         self._prepared_call: _PreparedCall | None = None
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
+        ] = {}
+        self._compiler_seed_specialize_extra: dict[
+            Hashable, tuple[_CompilerSeedSpecializationExtractor, ...]
         ] = {}
         self._specialization_aliases: dict[
             tuple[Hashable, ...], _SpecializationAlias
@@ -666,7 +792,14 @@ class Kernel(Generic[_R]):
         extra_results = self._stable_specialization_extra_results(args, signature)
         if extra_results is None:
             return None
-        return BoundKernelInMemoryCacheKey(signature, extra_results)
+        compiler_seed_results = self._stable_compiler_seed_results(args, signature)
+        if compiler_seed_results is None:
+            return None
+        return BoundKernelInMemoryCacheKey(
+            signature,
+            extra_results,
+            compiler_seed_results=compiler_seed_results,
+        )
 
     def _stable_specialization_extra_results(
         self,
@@ -689,6 +822,28 @@ class Kernel(Generic[_R]):
                 ):
                     return extra_results
 
+    def _stable_compiler_seed_results(
+        self,
+        args: Sequence[object],
+        signature: tuple[Hashable, ...],
+    ) -> tuple[Hashable, ...] | None:
+        while True:
+            with self._specialize_extra_lock:
+                extractors = self._compiler_seed_specialize_extra.get(signature)
+                generation = self._specialization_generation
+            results = (
+                None
+                if extractors is None
+                else tuple(extractor(args) for extractor in extractors)
+            )
+            with self._specialize_extra_lock:
+                if (
+                    self._specialization_generation == generation
+                    and self._compiler_seed_specialize_extra.get(signature)
+                    is extractors
+                ):
+                    return results
+
     def _create_bound_kernel_cache_key(
         self,
         bound_kernel: BoundKernel,
@@ -701,9 +856,15 @@ class Kernel(Generic[_R]):
 
         if extra_fns is None:
             extra_fns = bound_kernel._specialize_extra()
+        compiler_seed_fns = bound_kernel._compiler_seed_specialization_extractors
         if not bound_kernel._cache_managed:
             extra_results = tuple(s(args) for s in extra_fns)
-            return BoundKernelInMemoryCacheKey(signature, extra_results)
+            compiler_seed_results = tuple(s(args) for s in compiler_seed_fns)
+            return BoundKernelInMemoryCacheKey(
+                signature,
+                extra_results,
+                compiler_seed_results=compiler_seed_results,
+            )
 
         # Autotune cache keys can be generated outside eager binding, so
         # schema synchronization must not wait for the eager bind lock or hold
@@ -712,11 +873,15 @@ class Kernel(Generic[_R]):
             with self._specialize_extra_lock:
                 if bound_kernel._reset_generation != self._reset_generation:
                     active_extra_fns = extra_fns
+                    active_compiler_seed_fns = compiler_seed_fns
                     generation = None
                 else:
                     published_extra_fns = self._specialize_extra.get(signature)
                     if published_extra_fns is None:
                         self._specialize_extra[signature] = extra_fns
+                        self._compiler_seed_specialize_extra[signature] = (
+                            compiler_seed_fns
+                        )
                         if extra_fns:
                             self._has_specialization_extras = True
                     else:
@@ -724,10 +889,23 @@ class Kernel(Generic[_R]):
                         # bound is constructed. The published list is the
                         # authoritative schema.
                         extra_fns = published_extra_fns
+                    active_compiler_seed_fns = self._compiler_seed_specialize_extra.get(
+                        signature
+                    )
+                    if active_compiler_seed_fns is None:
+                        active_compiler_seed_fns = compiler_seed_fns
+                        self._compiler_seed_specialize_extra[signature] = (
+                            active_compiler_seed_fns
+                        )
                     generation = self._specialization_generation
                     active_extra_fns = extra_fns
             extra_results = tuple(s(args) for s in active_extra_fns)
-            cache_key = BoundKernelInMemoryCacheKey(signature, extra_results)
+            compiler_seed_results = tuple(s(args) for s in active_compiler_seed_fns)
+            cache_key = BoundKernelInMemoryCacheKey(
+                signature,
+                extra_results,
+                compiler_seed_results=compiler_seed_results,
+            )
             if generation is None:
                 return cache_key
             with self._specialize_extra_lock:
@@ -736,6 +914,8 @@ class Kernel(Generic[_R]):
                 if (
                     self._specialization_generation == generation
                     and self._specialize_extra.get(signature) is active_extra_fns
+                    and self._compiler_seed_specialize_extra.get(signature)
+                    is active_compiler_seed_fns
                 ):
                     return cache_key
 
@@ -767,12 +947,21 @@ class Kernel(Generic[_R]):
                     *self._specialize_extra.get(signature, []),
                     *extractors,
                 ]
+                compiler_seed_fns = self._compiler_seed_specialize_extra.get(
+                    signature,
+                    (),
+                )
                 with unset_fake_temporarily():
                     current_results = tuple(
                         extractor(full_args) for extractor in updated_extractors
                     )
+                    current_compiler_seed_results = tuple(
+                        extractor(full_args) for extractor in compiler_seed_fns
+                    )
                     updated_cache_key = BoundKernelInMemoryCacheKey(
-                        signature, current_results
+                        signature,
+                        current_results,
+                        compiler_seed_results=current_compiler_seed_results,
                     )
                     hash(updated_cache_key)
                     for alias_signature, alias in aliases.items():
@@ -786,10 +975,15 @@ class Kernel(Generic[_R]):
                             extractor(alias_normalized_args)
                             for extractor in updated_extractors
                         )
+                        alias_compiler_seed_results = tuple(
+                            extractor(alias_normalized_args)
+                            for extractor in compiler_seed_fns
+                        )
                         hash(
                             BoundKernelInMemoryCacheKey(
                                 alias_signature,
                                 (alias_results,),
+                                compiler_seed_results=alias_compiler_seed_results,
                             )
                         )
 
@@ -800,6 +994,9 @@ class Kernel(Generic[_R]):
                 self._specialize_extra[signature] = updated_extractors
                 for alias_signature, alias in aliases.items():
                     self._specialize_extra[alias_signature] = [alias]
+                    self._compiler_seed_specialize_extra[alias_signature] = (
+                        compiler_seed_fns
+                    )
                 self._specialization_generation += 1
 
             affected_signatures = {signature, *aliases}
@@ -904,6 +1101,8 @@ class Kernel(Generic[_R]):
             )
         if self._key_fn is not None:
             key.append(self._key_fn(*args) if signature is None else signature[-1])
+        if (tensor_aliases := _input_tensor_aliases(args)) is not None:
+            key.append(("input_tensor_aliases", tensor_aliases))
         if signature is not None:
             extra_fns = self._specialize_extra.get(signature)
             if extra_fns:
@@ -1141,7 +1340,18 @@ class Kernel(Generic[_R]):
                 result.append(value)
             else:
                 result.append(self._specialization_key(value))
-        device_type, device_capability = _device_specialization_key(args)
+        if (tensor_aliases := _input_tensor_aliases(args)) is not None:
+            result.append(("input_tensor_aliases", tensor_aliases))
+        device_type, device_capability, promotion_hardware_key = (
+            _device_specialization_key(
+                args,
+                backend=self.settings.backend,
+                compiler_heuristics_enabled=(
+                    not self.settings.disable_autotuner_heuristics
+                ),
+            )
+        )
+        promotion_key = (promotion_hardware_key,) if promotion_hardware_key else ()
         if is_distributed is None:
             is_distributed = self._compute_is_distributed(args)
         if self._key_fn is not None:
@@ -1151,10 +1361,17 @@ class Kernel(Generic[_R]):
                 *result,
                 device_type,
                 device_capability,
+                *promotion_key,
                 is_distributed,
                 cast("Hashable", custom_key),
             )
-        return (*result, device_type, device_capability, is_distributed)
+        return (
+            *result,
+            device_type,
+            device_capability,
+            *promotion_key,
+            is_distributed,
+        )
 
     def specialization_key(self, args: Sequence[object]) -> tuple[Hashable, ...]:
         """
@@ -1173,7 +1390,13 @@ class Kernel(Generic[_R]):
         """
         base = self._base_specialization_key(args)
         extra_results = self._stable_specialization_extra_results(args, base)
-        return base if extra_results is None else (*base, *extra_results)
+        compiler_seed_results = self._stable_compiler_seed_results(args, base)
+        compiler_seed_key = (
+            ()
+            if compiler_seed_results is None or not compiler_seed_results
+            else (("compiler_seed_results", compiler_seed_results),)
+        )
+        return (*base, *compiler_seed_key, *(extra_results or ()))
 
     def _specialization_key(self, obj: object) -> Hashable:
         """
@@ -1469,7 +1692,11 @@ class Kernel(Generic[_R]):
                 relative_to,
                 cache_tag,
                 tuple(
-                    (case_key.specialization_key, case_key.extra_results)
+                    (
+                        case_key.specialization_key,
+                        case_key.extra_results,
+                        case_key.compiler_seed_results,
+                    )
                     for case_key in case_keys
                 ),
             ),
@@ -1654,6 +1881,7 @@ class Kernel(Generic[_R]):
                 # Replace rather than clear: in-flight omitted-default aliases
                 # retain the old schema mapping while new work starts fresh.
                 self._specialize_extra = {}
+                self._compiler_seed_specialize_extra = {}
                 self._specialization_aliases = {}
                 self._cute_grouped_static_tail_extra_descriptors = {}
                 self._has_specialization_extras = False
@@ -1729,6 +1957,19 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         )
         self._run: Callable[..., _R] | None = None
         self._config: Config | None = None
+        self._compiler_seed_specialization_extractors: tuple[
+            _CompilerSeedSpecializationExtractor, ...
+        ] = ()
+        self._compiler_seed_specialization_results: tuple[Hashable, ...] = ()
+        # Direct BoundKernel calls bypass Kernel's dispatch cache. Remember the
+        # first device-bearing argument path and the immutable SM-derived facts
+        # per device so their hot path does not recursively walk args or query
+        # device properties on every launch.
+        self._compiler_seed_device_resolver: _ArgumentDeviceResolver | None = None
+        self._compiler_seed_device_results: dict[
+            torch.device,
+            tuple[Hashable | None, ...],
+        ] = {}
         self._compile_cache: dict[Config, CompiledConfig] = {}
         self._cache_path_map: dict[Config, str | None] = {}
         self._host_semantic_fingerprints: dict[
@@ -1750,7 +1991,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         # symmetric-memory call from ever aliasing a non-distributed compiled
         # kernel of the same shape. See GitHub issue #3024.
         self._env = CompileEnvironment(
-            _find_device(args),
+            _canonicalize_argument_device(_find_device(args)),
             self.kernel.settings,
             index_dtype=_resolve_index_dtype(self.kernel.settings, args),
             is_distributed=is_distributed,
@@ -1811,10 +2052,44 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                 self.env.restrict_pid_types_for_persistent(args)
 
                 self.env.config_spec.configure_epilogue_subtile_autotune(args)
-                self.env.config_spec.compiler_seed_configs = compiler_seed_configs(
-                    self.env,
-                    self.host_function.device_ir,
+                runtime_args = dict(
+                    zip(self.kernel.signature.parameters, args, strict=False)
                 )
+                with self.env.use_runtime_arg_values(runtime_args):
+                    self.env.config_spec.compiler_seed_configs = compiler_seed_configs(
+                        self.env,
+                        self.host_function.device_ir,
+                    )
+                self._compiler_seed_specialization_extractors = (
+                    _compiler_seed_specialization_extractors(
+                        compiler_seed_specialization_facts(
+                            self.env.backend_name,
+                            self.config_spec.autotuner_heuristics,
+                        )
+                        | self.env.compiler_fact_specialization_facts,
+                        self.settings.persistent_reserved_sms,
+                        static_shapes=self.settings.static_shapes,
+                    )
+                )
+                self._compiler_seed_specialization_results = tuple(
+                    extractor(args)
+                    for extractor in self._compiler_seed_specialization_extractors
+                )
+                if any(
+                    extractor.fact != "input_tensor_metadata"
+                    for extractor in self._compiler_seed_specialization_extractors
+                ):
+                    self._compiler_seed_device_resolver = (
+                        _ArgumentDeviceResolver.from_values(args)
+                    )
+                    self._compiler_seed_device_results[self.env.device] = tuple(
+                        (None if extractor.fact == "input_tensor_metadata" else result)
+                        for extractor, result in zip(
+                            self._compiler_seed_specialization_extractors,
+                            self._compiler_seed_specialization_results,
+                            strict=True,
+                        )
+                    )
 
                 # Post-compile FX-graph scan to detect kernels
                 # whose tcgen05 matmul is followed by an
@@ -1916,10 +2191,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         return Config(**config)
 
     def _normalized_config_copy(self, config: ConfigLike) -> Config:
-        normalized = self._normalize_config(config)
-        normalized = Config(**normalized.config)  # pyrefly: ignore[bad-argument-type]
-        self.env.config_spec.normalize(normalized)
-        return normalized
+        return self.env.config_spec.normalized_config(self._normalize_config(config))
 
     def format_kernel_decorator(self, config: Config, settings: Settings) -> str:
         """Return the @helion.kernel decorator snippet capturing configs and settings that influence Triton code generation."""
@@ -2347,10 +2619,24 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         Returns:
             Config: The best configuration found during autotuning.
         """
+        normalized_args = self.kernel.normalize_args(*args)
+        if self._cache_managed:
+            rebound = self.kernel.bind(normalized_args)
+            if rebound is not self:
+                return rebound.autotune(
+                    normalized_args,
+                    force=force,
+                    **kwargs,
+                )
         ephemeral = self.env.backend.make_ephemeral_cache()
         ctx = ephemeral if ephemeral is not None else contextlib.nullcontext()
         with ctx:
-            config = self.env.backend.autotune(self, args, force=force, **kwargs)
+            config = self.env.backend.autotune(
+                self,
+                normalized_args,
+                force=force,
+                **kwargs,
+            )
         if ephemeral is not None:
             self.env.backend.finalize_ephemeral_cache(self, config)
         self.set_config(config)
@@ -2384,6 +2670,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             not self.env.specialized_vars
             and not self.env.specialized_strides
             and not self.env.tensor_descriptor_layout_guards
+            and not self.env.runtime_input_specializations
         ):
             return []
 
@@ -2494,6 +2781,28 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                 )
 
             extractors.append(td_layout_extractor)
+
+        for _key, specialization in sorted(
+            self.env.runtime_input_specializations.items(),
+        ):
+            source_extractors = tuple(
+                make_extractor(source) for source in specialization.sources
+            )
+
+            def runtime_input_specialization_extractor(
+                args: Sequence[object],
+                _source_extractors: tuple[
+                    Callable[[Sequence[object]], Hashable], ...
+                ] = source_extractors,
+                _classifier: Callable[
+                    [Sequence[object]], Hashable
+                ] = specialization.classifier,
+            ) -> Hashable:
+                return _classifier(
+                    tuple(extract(args) for extract in _source_extractors)
+                )
+
+            extractors.append(runtime_input_specialization_extractor)
         return extractors
 
     @contextlib.contextmanager
@@ -2642,6 +2951,40 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         Returns:
             _R: The result of the kernel execution.
         """
+        if self._cache_managed and self._compiler_seed_specialization_extractors:
+            device_results: tuple[Hashable | None, ...] | None = None
+            new_compiler_seed_device = False
+            if self._compiler_seed_device_resolver is not None:
+                device = self._compiler_seed_device_resolver(args)
+                device_results = self._compiler_seed_device_results.get(device)
+                if device_results is None:
+                    new_compiler_seed_device = True
+                    device_results = tuple(
+                        (
+                            None
+                            if extractor.fact == "input_tensor_metadata"
+                            else extractor.for_device(device)
+                        )
+                        for extractor in self._compiler_seed_specialization_extractors
+                    )
+                    self._compiler_seed_device_results[device] = device_results
+            compiler_seed_results = tuple(
+                (
+                    extractor(args)
+                    if extractor.fact == "input_tensor_metadata"
+                    else cast("tuple[Hashable | None, ...]", device_results)[index]
+                )
+                for index, extractor in enumerate(
+                    self._compiler_seed_specialization_extractors
+                )
+            )
+            if (
+                new_compiler_seed_device
+                or compiler_seed_results != self._compiler_seed_specialization_results
+            ):
+                rebound = self.kernel.bind(args)
+                if rebound is not self:
+                    return rebound(*args)
         if self._cache_managed and self.kernel._has_specialization_extras:
             rebound = self.kernel.bind(args)
             if rebound is not self:
@@ -3216,38 +3559,6 @@ _specialization_extractors: dict[
     ConstExpr: lambda fn, x: x.value,
     type(None): lambda fn, x: None,
 }
-
-
-def _find_device(args: tuple[object, ...]) -> torch.device:
-    """
-    Extract the device from the arguments.
-
-    Args:
-        args: The arguments to extract the device from.
-
-    Returns:
-        torch.device: The extracted device
-    """
-    for arg in args:
-        if isinstance(arg, torch.device):
-            return arg
-        if isinstance(arg, torch.Tensor):
-            return arg.device
-        if isinstance(arg, ConstExpr):
-            continue  # a constexpr-wrapped value carries no device; skip it
-        if isinstance(arg, (tuple, list)):
-            for item in arg:
-                try:
-                    return _find_device((item,))
-                except exc.NoTensorArgs:
-                    pass
-        elif isinstance(arg, dict):
-            for item in arg.values():
-                try:
-                    return _find_device((item,))
-                except exc.NoTensorArgs:
-                    pass
-    raise exc.NoTensorArgs
 
 
 def _maybe_skip_dtype_check_in_meta_registrations() -> (

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -762,8 +762,9 @@ class Settings(_Settings):
             "without constraining the search space."
         ),
         "disable_autotuner_heuristics": (
-            "If True, disable compiler/autotuner heuristics such as compiler seed "
-            "configs. User-provided autotune_seed_configs are unaffected. "
+            "If True, disable compiler seed generation and promotion. Correctness "
+            "fact hooks still run so explicit configs normalize safely. User-provided "
+            "autotune_seed_configs are unaffected. "
             "Set HELION_DISABLE_AUTOTUNER_HEURISTICS=1 to disable globally."
         ),
         "allow_warp_specialize": "If True, allow warp specialization for tl.range calls on CUDA devices.",

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -366,6 +366,41 @@ class TestAutotuneIgnoreErrors(TestCase):
             search._prepare()
         return search
 
+    def _make_compile_failure_search(self) -> BaseSearch:
+        search = self._make_search(
+            Settings(
+                autotune_precompile=None,
+                autotune_log_level=logging.CRITICAL,
+            )
+        )
+        search.kernel.env = SimpleNamespace(process_group_name=None)
+        search.kernel.compile_config = None
+        return search
+
+    def _run_late_compile_failures(
+        self,
+        late_configs: Sequence[str],
+        error_for: Callable[[str], Exception],
+    ) -> tuple[list[object], list[object]]:
+        search = self._make_compile_failure_search()
+
+        def compile_config(config: str, **_kwargs: object) -> Callable[..., None]:
+            if config == "valid":
+                return lambda *args, **kwargs: None
+            raise error_for(config)
+
+        with (
+            patch.object(search.kernel, "compile_config", side_effect=compile_config),
+            patch.object(
+                search.benchmark_provider,
+                "_benchmark_function",
+                return_value=1.0,
+            ),
+        ):
+            initial = search.benchmark_batch(["valid"], desc="initial")
+            late = search.benchmark_batch(list(late_configs), desc="late")
+        return initial, late
+
     def test_settings_flag_from_env(self):
         with patch.dict(
             os.environ, {"HELION_AUTOTUNE_IGNORE_ERRORS": "1"}, clear=False
@@ -665,6 +700,57 @@ class TestAutotuneIgnoreErrors(TestCase):
         self.assertEqual(results[1].status, "error")
         self.assertEqual(results[2].perf, 1.0)
         self.assertEqual(search._autotune_metrics.num_compile_failures, 1)
+
+    def test_initial_compile_failures_raise(self) -> None:
+        cases: tuple[tuple[str, type[Exception], str, Exception], ...] = (
+            (
+                "invalid",
+                exc.InvalidConfig,
+                "invalid initial config",
+                exc.InvalidConfig("invalid initial config"),
+            ),
+            (
+                "runtime",
+                RuntimeError,
+                "initial compiler failure",
+                RuntimeError("initial compiler failure"),
+            ),
+        )
+        for config, error_type, message, error in cases:
+            with self.subTest(config=config):
+                search = self._make_compile_failure_search()
+                with (
+                    patch.object(
+                        search.kernel,
+                        "compile_config",
+                        side_effect=error,
+                    ),
+                    self.assertRaisesRegex(error_type, message),
+                ):
+                    search.benchmark_batch([config], desc="initial")
+
+    def test_late_compile_failures_are_skipped(self) -> None:
+        cases = (
+            (
+                "invalid",
+                lambda config: exc.InvalidConfig(f"invalid late neighbor: {config}"),
+            ),
+            ("runtime", lambda config: RuntimeError("late compiler failure")),
+            (
+                "unsupported",
+                lambda config: exc.BackendUnsupported(
+                    "cute", f"unsupported late neighbor {config}"
+                ),
+            ),
+        )
+        for prefix, error_for in cases:
+            with self.subTest(prefix=prefix):
+                initial, late = self._run_late_compile_failures(
+                    (f"{prefix}_a", f"{prefix}_b"), error_for
+                )
+                self.assertEqual(initial[0].perf, 1.0)
+                self.assertEqual([result.perf for result in late], [float("inf")] * 2)
+                self.assertEqual([result.status for result in late], ["error"] * 2)
 
     def test_autotune_log_sink_writes_csv_and_log(self):
         tmpdir = tempfile.TemporaryDirectory()
@@ -12779,6 +12865,37 @@ class TestAutotuneBestOfK(RefEagerTestDisabled, TestCase):
             best_of_k=5,
         )
         self.assertNotEqual(k1_aliased.stable_hash(), k5.stable_hash())
+
+    def test_strict_cache_key_tracks_nondefault_best_of_k(self) -> None:
+        from helion.autotuner.base_cache import StrictAutotuneCacheKey
+
+        common_kwargs = {
+            "specialization_key": (),
+            "extra_results": (),
+            "kernel_source_hash": "abc",
+            "hardware": "B200",
+            "runtime_name": "12.6",
+            "backend": "triton",
+            "config_spec_hash": "h1",
+            "extra_cache_key": "",
+            "helion_key": "helion",
+            "torch_key": "torch",
+            "triton_key": "triton",
+        }
+        k1 = StrictAutotuneCacheKey(**common_kwargs, best_of_k=1)
+        k5 = StrictAutotuneCacheKey(**common_kwargs, best_of_k=5)
+        expected_k1_repr = (
+            "StrictAutotuneCacheKey("
+            "specialization_key=(), extra_results=(), "
+            "kernel_source_hash='abc', hardware='B200', "
+            "runtime_name='12.6', backend='triton', "
+            "config_spec_hash='h1', extra_cache_key='', "
+            "helion_key='helion', torch_key='torch', triton_key='triton')"
+        )
+
+        self.assertEqual(repr(k1), expected_k1_repr)
+        self.assertIn("best_of_k=5", repr(k5))
+        self.assertNotEqual(k1.stable_hash(), k5.stable_hash())
 
     def test_best_of_k_gt_1_without_factory_raises(self) -> None:
         """The bare ``Cache(autotuner)`` constructor must reject K>1 at

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -5,6 +5,8 @@ import itertools
 import math
 import os
 import random
+from typing import Any
+from typing import Callable
 from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -13,11 +15,31 @@ import pytest
 import torch
 
 import helion
+from helion._argument_device import _ArgumentDeviceResolver as _DeviceResolver
+from helion._compiler.autotuner_heuristics import compiler_promotion_specialization_key
 from helion._compiler.autotuner_heuristics import compiler_seed_configs
+from helion._compiler.autotuner_heuristics import compiler_seed_specialization_facts
 from helion._compiler.autotuner_heuristics.cute import CuteFlashAttentionHeuristic
 from helion._compiler.autotuner_heuristics.cute import CuteFp8GemmSkinnyMHeuristic
 from helion._compiler.autotuner_heuristics.cute import CuteTcgen05ClusterM2Heuristic
+from helion._compiler.autotuner_heuristics.cute import (
+    CuteTcgen05GroupedWorklistHeuristic,
+)
+from helion._compiler.autotuner_heuristics.cute import (
+    _bounded_grouped_worklist_seed_families,
+)
+from helion._compiler.autotuner_heuristics.cute import (
+    _filter_reachable_block_size_configs,
+)
+from helion._compiler.autotuner_heuristics.cute import _tcgen05_grouped_fact
+from helion._compiler.autotuner_heuristics.cute import _tcgen05_grouped_worklist_fact
+from helion._compiler.autotuner_heuristics.cute import (
+    tcgen05_grouped_worklist_seed_configs,
+)
 from helion._compiler.autotuner_heuristics.registry import AutotunerHeuristic
+from helion._compiler.autotuner_heuristics.registry import (
+    CompilerHeuristicSpecializationFact,
+)
 from helion._compiler.autotuner_heuristics.triton import TritonH100MatmulHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonNarrowReductionHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonPointwiseSeedHeuristic
@@ -30,6 +52,9 @@ from helion._compiler.autotuner_heuristics.triton import (
 )
 from helion._compiler.autotuner_heuristics.triton import (
     TritonUserTiledReductionHeuristicSM90,
+)
+from helion._compiler.autotuner_heuristics.triton import (
+    TritonUserTiledReductionHeuristicSM100,
 )
 from helion._compiler.autotuner_heuristics.triton import _h100_matmul_tile
 from helion._compiler.backend import CuteBackend
@@ -99,11 +124,16 @@ from helion._compiler.cute.flash_policy import get_flash_target_policy
 from helion._compiler.cute.flash_tuning import FlashCausalTuningPolicy
 from helion._compiler.cute.flash_tuning import FlashDenseTuningPolicy
 from helion._compiler.cute.flash_tuning import FlashSoftmaxLowering
+from helion._compiler.cute.grouped_worklist import (
+    tcgen05_grouped_worklist_compatible_source_m_tiles,
+)
+from helion._compiler.cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY
 from helion._compiler.cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
+from helion._compiler.cute.strategies import TCGEN05_STRATEGY_CONFIG_KEY
 from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY
 from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
 from helion._compiler.cute.strategies import Tcgen05LayoutStrategy
@@ -120,13 +150,43 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._compiler.cute.tcgen05_constants import TCGEN05_AUX_LOAD_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_AUX_LOAD_MODE_TMA
 from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_C_ACQUIRE_PLACEMENT_CONFIG_KEY,
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_C_ACQUIRE_PLACEMENT_FIRST_IN_LOOP,
 )
+from helion._compiler.cute.tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
 )
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
@@ -188,6 +248,9 @@ from helion._testing import patch_cute_mma_support
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 from helion.autotuner import IntegerFragment
+from helion.autotuner.base_cache import BoundKernelInMemoryCacheKey
+from helion.autotuner.base_cache import LooseAutotuneCacheKey
+from helion.autotuner.base_cache import StrictAutotuneCacheKey
 from helion.autotuner.config_fragment import EnumFragment
 from helion.autotuner.config_generation import ConfigGeneration
 from helion.autotuner.config_spec import BlockSizeSpec
@@ -202,6 +265,8 @@ from helion.autotuner.effort_profile import get_effort_profile
 from helion.autotuner.pattern_search import InitialPopulationStrategy
 from helion.autotuner.pattern_search import PatternSearch
 import helion.language as hl
+from helion.runtime.kernel import _find_device as runtime_find_device
+from helion.runtime.kernel import _input_tensor_metadata
 from helion.runtime.settings import Settings
 
 HOPPER_HARDWARE = HardwareInfo(
@@ -222,6 +287,12 @@ BLACKWELL_HARDWARE = HardwareInfo(
     runtime_version="12.8",
     compute_capability="sm100",
 )
+GB300_HARDWARE = HardwareInfo(
+    device_kind="cuda",
+    hardware_name="NVIDIA GB300",
+    runtime_version="12.8",
+    compute_capability="sm103",
+)
 A100_HARDWARE = HardwareInfo(
     device_kind="cuda",
     hardware_name="NVIDIA A100",
@@ -230,7 +301,137 @@ A100_HARDWARE = HardwareInfo(
 )
 
 
+def _grouped_worklist_with_viewed_inputs(
+    a_storage: torch.Tensor,
+    b_storage: torch.Tensor,
+    worklist: torch.Tensor,
+) -> torch.Tensor:
+    a_packed = a_storage.view(-1, a_storage.size(2))
+    b_grouped = b_storage.view(-1, b_storage.size(2), b_storage.size(3))
+    m_total, k = a_packed.shape
+    _groups, n, k2 = b_grouped.shape
+    assert k == k2
+    block_m = hl.register_block_size(256)
+    block_n = hl.register_block_size(128)
+    block_k = hl.register_block_size(64, 128)
+    out = torch.empty([m_total, n], dtype=a_packed.dtype, device=a_packed.device)
+    for work_tile, tile_m, tile_n in hl.tile(
+        [worklist.size(0), 256, n],
+        block_size=[1, block_m, block_n],
+    ):
+        work_id = work_tile.begin
+        group_id = worklist[work_id, 0]
+        start = worklist[work_id, 1]
+        valid_m = worklist[work_id, 2]
+        store_m = worklist[work_id, 3]
+        local_m = tile_m.index
+        row = start + local_m
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k, block_size=block_k):
+            a_block = hl.load(
+                a_packed,
+                [row, tile_k],
+                extra_mask=(local_m < valid_m)[:, None],  # pyrefly: ignore[bad-index]
+            )
+            acc = torch.addmm(
+                acc,
+                a_block,
+                b_grouped[group_id, tile_n, tile_k].T,
+            )
+        hl.store(
+            out,
+            [row, tile_n],
+            acc.to(out.dtype),
+            extra_mask=(local_m < store_m)[:, None],  # pyrefly: ignore[bad-index]
+        )
+    return out
+
+
+def _grouped_worklist_kernel_body(
+    a_packed: torch.Tensor,
+    b_grouped: torch.Tensor,
+    worklist: torch.Tensor,
+) -> torch.Tensor:
+    """Plain grouped-GEMM body used by compiler-discovery tests."""
+    m_total, k = a_packed.shape
+    _groups, n, k2 = b_grouped.shape
+    assert k == k2
+    block_m = hl.register_block_size(256)
+    block_n = hl.register_block_size(128)
+    block_k = hl.register_block_size(64, 128)
+    out = torch.empty([m_total, n], dtype=a_packed.dtype, device=a_packed.device)
+    for work_tile, tile_m, tile_n in hl.tile(
+        [worklist.size(0), 256, n],
+        block_size=[1, block_m, block_n],
+    ):
+        work_id = work_tile.begin
+        group_id = worklist[work_id, 0]
+        start = worklist[work_id, 1]
+        valid_m = worklist[work_id, 2]
+        store_m = worklist[work_id, 3]
+        local_m = tile_m.index
+        row = start + local_m
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k, block_size=block_k):
+            a_block = hl.load(
+                a_packed,
+                [row, tile_k],
+                extra_mask=(local_m < valid_m)[:, None],  # pyrefly: ignore[bad-index]
+            )
+            acc = torch.addmm(
+                acc,
+                a_block,
+                b_grouped[group_id, tile_n, tile_k].T,
+            )
+        hl.store(
+            out,
+            [row, tile_n],
+            acc.to(out.dtype),
+            extra_mask=(local_m < store_m)[:, None],  # pyrefly: ignore[bad-index]
+        )
+    return out
+
+
 class TestAutotunerHeuristic(TestCase):
+    @staticmethod
+    def _heuristic(name: str, **attributes: object) -> type[AutotunerHeuristic]:
+        return type(
+            f"_{name.title().replace('_', '')}",
+            (AutotunerHeuristic,),
+            {"name": name, "backend": "triton", **attributes},
+        )
+
+    @staticmethod
+    def _grouped_worklist_seed_families() -> dict[str, list[helion.Config]]:
+        def seeds(
+            groups: int, n: int, k: int, b_major: str, source_m_tile: int
+        ) -> list[helion.Config]:
+            return tcgen05_grouped_worklist_seed_configs(
+                groups=groups,
+                packed_m=groups * (32 if source_m_tile == 32 else 4096),
+                n=n,
+                k=k,
+                b_major=b_major,
+                source_m_tile=source_m_tile,
+                num_sm=148,
+            )
+
+        return {
+            "small_k": seeds(6, 4096, 4096, "k", 32),
+            "small_n": seeds(6, 4096, 4096, "n", 32),
+            "source224": tcgen05_grouped_worklist_seed_configs(
+                groups=6,
+                packed_m=6 * 224,
+                n=7168,
+                k=3072,
+                b_major="k",
+                source_m_tile=224,
+                num_sm=148,
+            ),
+            "source256_k": seeds(8, 4096, 2048, "k", 256),
+            "source256_n": seeds(8, 4096, 2048, "n", 256),
+        }
+
     def test_disable_autotuner_heuristics_setting_env(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("HELION_DISABLE_AUTOTUNER_HEURISTICS", None)
@@ -335,6 +536,82 @@ class TestAutotunerHeuristic(TestCase):
         self.assertEqual(configs, [])
         self.assertEqual(env.config_spec.autotuner_heuristics, [])
         self.assertIsNone(env.config_spec.compiler_seed_timeout_retry_repetitions)
+
+    def test_compiler_fact_hook_runs_once_before_disabled_return(self) -> None:
+        fact_calls: list[tuple[object, object]] = []
+
+        class FactOwningHeuristic(AutotunerHeuristic):
+            name = "fact_owning_heuristic"
+            backend = "synthetic"
+
+            @classmethod
+            def register_facts(
+                cls, env: object, device_ir: object
+            ) -> frozenset[CompilerHeuristicSpecializationFact]:
+                fact_calls.append((env, device_ir))
+                return frozenset({"input_tensor_metadata"})
+
+            @classmethod
+            def is_eligible(cls, env: object, device_ir: object) -> bool:
+                raise AssertionError("disabled heuristics should not be queried")
+
+        class PassiveHeuristic(AutotunerHeuristic):
+            name = "passive_heuristic"
+            backend = "synthetic"
+
+            @classmethod
+            def is_eligible(cls, env: object, device_ir: object) -> bool:
+                raise AssertionError("disabled heuristics should not be queried")
+
+        env = MagicMock()
+        env.backend_name = "synthetic"
+        env.config_spec = MagicMock()
+        env.settings = Settings(disable_autotuner_heuristics=True)
+        device_ir = MagicMock()
+
+        with patch(
+            "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+            {"synthetic": (FactOwningHeuristic, PassiveHeuristic)},
+        ):
+            self.assertEqual(compiler_seed_configs(env, device_ir), [])
+
+        self.assertEqual(fact_calls, [(env, device_ir)])
+        self.assertEqual(
+            env.compiler_fact_specialization_facts,
+            frozenset({"input_tensor_metadata"}),
+        )
+
+    def test_compiler_fact_hook_failure_propagates(self) -> None:
+        class FailingFactHeuristic(AutotunerHeuristic):
+            name = "failing_fact_heuristic"
+            backend = "synthetic"
+
+            @classmethod
+            def register_facts(
+                cls, env: object, device_ir: object
+            ) -> frozenset[CompilerHeuristicSpecializationFact]:
+                raise RuntimeError("synthetic correctness-fact failure")
+
+            @classmethod
+            def is_eligible(cls, env: object, device_ir: object) -> bool:
+                raise AssertionError("fact registration must fail first")
+
+        env = MagicMock()
+        env.backend_name = "synthetic"
+        env.config_spec = MagicMock()
+        env.settings = Settings(disable_autotuner_heuristics=True)
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"synthetic": (FailingFactHeuristic,)},
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "synthetic correctness-fact failure",
+            ),
+        ):
+            compiler_seed_configs(env, MagicMock())
 
     def test_cute_flash_disable_heuristics_keeps_structural_coverage(self) -> None:
         spec = ConfigSpec(backend=CuteBackend())
@@ -509,35 +786,42 @@ class TestAutotunerHeuristic(TestCase):
         # default) on PROMOTE_TARGETS, independently of where the seed fires.
         env = MagicMock()
         env.device = "cuda"
-
-        class _AllArches(AutotunerHeuristic):
-            promote_seed_to_default = True
-            PROMOTE_TARGETS = None  # promote wherever it fires (back-compat)
-
-        class _Sm90Only(AutotunerHeuristic):
-            promote_seed_to_default = True
-            PROMOTE_TARGETS = (("cuda", "sm90"),)
-
-        class _NotPromoting(AutotunerHeuristic):
-            promote_seed_to_default = False
-            PROMOTE_TARGETS = (("cuda", "sm90"),)
+        all_arches = self._heuristic("all_arches", promote_seed_to_default=True)
+        sm90_only = self._heuristic(
+            "sm90_only",
+            promote_seed_to_default=True,
+            PROMOTE_TARGETS=(("cuda", "sm90"),),
+        )
+        not_promoting = self._heuristic(
+            "not_promoting",
+            promote_seed_to_default=False,
+            PROMOTE_TARGETS=(("cuda", "sm90"),),
+        )
+        b200_only = self._heuristic(
+            "b200_only",
+            promote_seed_to_default=True,
+            PROMOTE_NAMED_TARGETS=frozenset({("cuda", "NVIDIA B200", "sm100")}),
+        )
 
         # PROMOTE_TARGETS=None promotes without consulting hardware.
-        self.assertTrue(_AllArches.should_promote(env))
-
-        # A target list restricts promotion to the matching arch...
-        with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
-            self.assertTrue(_Sm90Only.should_promote(env))
-        # ...and declines on an off-target arch (seed still fires; only the
-        # promotion is gated).
-        with patch(
-            "helion._hardware.get_hardware_info", return_value=BLACKWELL_HARDWARE
+        self.assertTrue(all_arches.should_promote(env))
+        for name, heuristic, hardware, expected in (
+            ("matching arch", sm90_only, HOPPER_HARDWARE, True),
+            ("off-target arch", sm90_only, BLACKWELL_HARDWARE, False),
+            ("promotion disabled", not_promoting, HOPPER_HARDWARE, False),
+            ("matching hardware", b200_only, BLACKWELL_HARDWARE, True),
+            (
+                "different hardware",
+                b200_only,
+                dataclasses.replace(GB300_HARDWARE, compute_capability="sm100"),
+                False,
+            ),
         ):
-            self.assertFalse(_Sm90Only.should_promote(env))
-
-        # promote_seed_to_default=False vetoes regardless of the target list.
-        with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
-            self.assertFalse(_NotPromoting.should_promote(env))
+            with (
+                self.subTest(name=name),
+                patch("helion._hardware.get_hardware_info", return_value=hardware),
+            ):
+                self.assertIs(heuristic.should_promote(env), expected)
 
     def test_should_promote_declines_on_unclassifiable_device(self) -> None:
         # On a device Helion cannot classify (e.g. MTIA), get_hardware_info raises
@@ -546,9 +830,11 @@ class TestAutotunerHeuristic(TestCase):
         env = MagicMock()
         env.device = "mtia"
 
-        class _Sm90Only(AutotunerHeuristic):
-            promote_seed_to_default = True
-            PROMOTE_TARGETS = (("cuda", "sm90"),)
+        sm90_only = self._heuristic(
+            "sm90_only",
+            promote_seed_to_default=True,
+            PROMOTE_TARGETS=(("cuda", "sm90"),),
+        )
 
         with patch(
             "helion._hardware.get_hardware_info",
@@ -557,7 +843,2284 @@ class TestAutotunerHeuristic(TestCase):
                 "Helion requires CUDA, ROCm, XPU, or TPU."
             ),
         ):
-            self.assertFalse(_Sm90Only.should_promote(env))
+            self.assertFalse(sm90_only.should_promote(env))
+
+    def test_promotion_specialization_key_tracks_only_exact_name_gates(self) -> None:
+        arch_only = self._heuristic(
+            "arch_only",
+            promote_seed_to_default=True,
+            PROMOTE_TARGETS=(("cuda", "sm100"),),
+        )
+        b200_only = self._heuristic(
+            "b200_only",
+            promote_seed_to_default=True,
+            PROMOTE_NAMED_TARGETS=frozenset({("cuda", "NVIDIA B200", "sm100")}),
+        )
+
+        device = torch.device("cuda:0")
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": (arch_only,)},
+            ),
+            patch("helion._hardware.get_hardware_info") as hardware_info,
+        ):
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device), ()
+            )
+            hardware_info.assert_not_called()
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": (arch_only, b200_only)},
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                side_effect=(
+                    BLACKWELL_HARDWARE,
+                    GB300_HARDWARE,
+                    BLACKWELL_HARDWARE,
+                ),
+            ) as hardware_info,
+        ):
+            b200_key = compiler_promotion_specialization_key("triton", device)
+            gb300_key = compiler_promotion_specialization_key("triton", device)
+            b200_key_again = compiler_promotion_specialization_key("triton", device)
+            self.assertEqual(hardware_info.call_count, 3)
+
+        self.assertEqual(b200_key, (("b200_only", "NVIDIA B200"),))
+        self.assertEqual(gb300_key, (("b200_only", None),))
+        self.assertEqual(b200_key_again, b200_key)
+
+    def test_promotion_key_canonicalizes_indexless_current_device(self) -> None:
+        b200_only = self._heuristic(
+            "b200_only",
+            promote_seed_to_default=True,
+            PROMOTE_NAMED_TARGETS=frozenset({("cuda", "NVIDIA B200", "sm100")}),
+        )
+
+        devices = (torch.device("cuda:0"), torch.device("cuda:1"))
+        hardware_by_device = {
+            devices[0]: BLACKWELL_HARDWARE,
+            devices[1]: GB300_HARDWARE,
+        }
+        observed_devices: list[torch.device] = []
+
+        def get_hardware_info(device: torch.device) -> HardwareInfo:
+            observed_devices.append(device)
+            return hardware_by_device[device]
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": (b200_only,)},
+            ),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.current_device", side_effect=(0, 1)),
+            patch(
+                "helion._hardware.get_hardware_info",
+                side_effect=get_hardware_info,
+            ),
+        ):
+            indexless = torch.device("cuda")
+            b200_key = compiler_promotion_specialization_key("triton", indexless)
+            gb300_key = compiler_promotion_specialization_key("triton", indexless)
+
+        self.assertEqual(b200_key, (("b200_only", "NVIDIA B200"),))
+        self.assertEqual(gb300_key, (("b200_only", None),))
+        self.assertEqual(observed_devices, list(devices))
+
+    def test_promotion_key_cache_tracks_mutated_registry_policy(self) -> None:
+        mutable_promotion = self._heuristic(
+            "mutable_promotion",
+            promote_seed_to_default=True,
+            PROMOTE_NAMED_TARGETS=frozenset({("cuda", "NVIDIA B200", "sm100")}),
+        )
+
+        device = torch.device("cuda:0")
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": (mutable_promotion,)},
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                side_effect=(
+                    BLACKWELL_HARDWARE,
+                    BLACKWELL_HARDWARE,
+                    dataclasses.replace(
+                        GB300_HARDWARE,
+                        compute_capability="sm103",
+                    ),
+                    dataclasses.replace(
+                        GB300_HARDWARE,
+                        compute_capability="sm103",
+                    ),
+                ),
+            ) as hardware_info,
+        ):
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device),
+                (("mutable_promotion", "NVIDIA B200"),),
+            )
+            mutable_promotion.PROMOTE_NAMED_TARGETS = frozenset(
+                {("cuda", "NVIDIA B200", "sm103")}
+            )
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device),
+                (("mutable_promotion", None),),
+            )
+            mutable_promotion.PROMOTE_NAMED_TARGETS = frozenset(
+                {("cuda", "NVIDIA GB300", "sm100")}
+            )
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device),
+                (("mutable_promotion", None),),
+            )
+            mutable_promotion.PROMOTE_NAMED_TARGETS = frozenset(
+                {("cuda", "NVIDIA GB300", "sm103")}
+            )
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device),
+                (("mutable_promotion", "NVIDIA GB300"),),
+            )
+            mutable_promotion.promote_seed_to_default = False
+            self.assertEqual(
+                compiler_promotion_specialization_key("triton", device), ()
+            )
+            self.assertEqual(hardware_info.call_count, 4)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler seed specialization is not used in ref eager mode")
+    def test_compiler_seed_specialization_rebinds_only_eligible_kernels(
+        self,
+    ) -> None:
+        device_num_sm_sensitive = self._heuristic(
+            "device_num_sm_sensitive",
+            CACHE_SPECIALIZATION_FACTS=frozenset({"device_num_sm"}),
+        )
+        config_num_sm_sensitive = self._heuristic(
+            "config_num_sm_sensitive",
+            CACHE_SPECIALIZATION_FACTS=frozenset({"config_num_sm"}),
+        )
+        input_metadata_sensitive = self._heuristic(
+            "input_tensor_metadata_sensitive",
+            CACHE_SPECIALIZATION_FACTS=frozenset({"input_tensor_metadata"}),
+        )
+        unrelated = self._heuristic("unrelated")
+
+        self.assertEqual(
+            CuteTcgen05GroupedWorklistHeuristic.CACHE_SPECIALIZATION_FACTS,
+            frozenset({"config_num_sm", "input_tensor_metadata"}),
+        )
+        for heuristic in (
+            CuteTcgen05ClusterM2Heuristic,
+            TritonH100MatmulHeuristic,
+            TritonPointwiseSeedHeuristic,
+            TritonStandardReductionHeuristicSM90,
+            TritonStandardReductionHeuristicSM100,
+            TritonUserTiledReductionHeuristicSM90,
+            TritonUserTiledReductionHeuristicSM100,
+        ):
+            self.assertEqual(
+                heuristic.CACHE_SPECIALIZATION_FACTS,
+                frozenset({"device_num_sm"}),
+            )
+
+        heuristics = (
+            device_num_sm_sensitive,
+            config_num_sm_sensitive,
+            input_metadata_sensitive,
+            unrelated,
+        )
+        with patch(
+            "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+            {"triton": heuristics},
+        ):
+            for heuristic, expected in (
+                (device_num_sm_sensitive, frozenset({"device_num_sm"})),
+                (config_num_sm_sensitive, frozenset({"config_num_sm"})),
+                (
+                    input_metadata_sensitive,
+                    frozenset({"input_tensor_metadata"}),
+                ),
+                (unrelated, frozenset()),
+            ):
+                self.assertEqual(
+                    compiler_seed_specialization_facts("triton", [heuristic.name]),
+                    expected,
+                )
+
+        current_num_sm = 148
+
+        def get_num_sm(
+            _device: torch.device,
+            *,
+            reserved_sms: int = 0,
+        ) -> int:
+            return max(current_num_sm - reserved_sms, 1)
+
+        def make_kernel(
+            heuristic_name: str,
+            *,
+            persistent_reserved_sms: int = 0,
+            static_shapes: bool = True,
+        ) -> tuple[
+            helion.Kernel,
+            Callable[[MagicMock, object], list[helion.Config]],
+        ]:
+            @helion.kernel(
+                backend="triton",
+                persistent_reserved_sms=persistent_reserved_sms,
+                static_shapes=static_shapes,
+            )
+            def identity(x: torch.Tensor) -> torch.Tensor:
+                out = torch.empty_like(x)
+                for tile in hl.tile(x.shape):
+                    out[tile] = x[tile]
+                return out
+
+            def seed_configs(env: MagicMock, _device_ir: object) -> list[helion.Config]:
+                env.config_spec.autotuner_heuristics = [heuristic_name]
+                return []
+
+            return identity, seed_configs
+
+        x = torch.empty([8], device=DEVICE)
+        wider_x = torch.empty([16], device=DEVICE)
+
+        def bind_kernel(
+            heuristic_name: str,
+            cases: tuple[tuple[tuple[torch.Tensor, ...], int], ...],
+            *,
+            persistent_reserved_sms: int = 0,
+            static_shapes: bool = True,
+        ) -> tuple[helion.Kernel, list[Any]]:
+            nonlocal current_num_sm
+            kernel, seed_configs = make_kernel(
+                heuristic_name,
+                persistent_reserved_sms=persistent_reserved_sms,
+                static_shapes=static_shapes,
+            )
+            bounds = []
+            with patch(
+                "helion.runtime.kernel.compiler_seed_configs",
+                side_effect=seed_configs,
+            ):
+                for args, num_sm in cases:
+                    current_num_sm = num_sm
+                    bounds.append(kernel.bind(args))
+            return kernel, bounds
+
+        def specialization_values(kernel: helion.Kernel, fact: str) -> set[object]:
+            values = set()
+            for key in kernel._bound_kernels:
+                [(name, value)] = cast(
+                    "tuple[tuple[str, object], ...]",
+                    key.compiler_seed_results,
+                )
+                self.assertEqual(name, fact)
+                values.add(value)
+            return values
+
+        def assert_bind_case(
+            heuristic_name: str,
+            cases: tuple[tuple[tuple[torch.Tensor, ...], int], ...],
+            *,
+            same: tuple[tuple[int, int], ...] = (),
+            different: tuple[tuple[int, int], ...] = (),
+            fact: str | None = None,
+            expected_values: set[object] | None = None,
+            persistent_reserved_sms: int = 0,
+            static_shapes: bool = True,
+        ) -> tuple[helion.Kernel, list[Any]]:
+            kernel, bounds = bind_kernel(
+                heuristic_name,
+                cases,
+                persistent_reserved_sms=persistent_reserved_sms,
+                static_shapes=static_shapes,
+            )
+            for pairs, assertion in (
+                (same, self.assertIs),
+                (different, self.assertIsNot),
+            ):
+                for first_index, second_index in pairs:
+                    assertion(bounds[first_index], bounds[second_index])
+            if fact is None:
+                self.assertFalse(
+                    any(key.compiler_seed_results for key in kernel._bound_kernels)
+                )
+            else:
+                self.assertEqual(specialization_values(kernel, fact), expected_values)
+            return kernel, bounds
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.HEURISTICS_BY_BACKEND",
+                {"triton": heuristics},
+            ),
+            patch(
+                "helion.runtime.get_num_sm", side_effect=get_num_sm
+            ) as get_num_sm_mock,
+        ):
+            sensitive, (first, second, rebound) = bind_kernel(
+                device_num_sm_sensitive.name,
+                (((x,), 148), ((x,), 132), ((x,), 148)),
+            )
+
+            self.assertIsNot(first, second)
+            self.assertIs(rebound, first)
+            self.assertEqual(len(sensitive._bound_kernels), 2)
+            self.assertEqual(
+                specialization_values(sensitive, "device_num_sm"),
+                {132, 148},
+            )
+            self.assertTrue(
+                all(not key.extra_results for key in sensitive._bound_kernels)
+            )
+            first._run = lambda value: value
+            second._run = lambda value: value
+            current_num_sm = 148
+            get_num_sm_calls = get_num_sm_mock.call_count
+            with (
+                patch.object(sensitive, "bind", wraps=sensitive.bind) as bind,
+                patch(
+                    "helion.runtime.kernel._find_device",
+                    wraps=runtime_find_device,
+                ) as find_device,
+            ):
+                self.assertIs(first(x), x)
+                self.assertIs(first(x), x)
+            self.assertEqual(bind.call_count, 0)
+            self.assertEqual(find_device.call_count, 0)
+            self.assertEqual(get_num_sm_mock.call_count, get_num_sm_calls)
+
+            current_num_sm = 132
+            different_device = torch.device("cuda", (x.device.index or 0) + 1)
+            first._compiler_seed_device_resolver = MagicMock(
+                return_value=different_device
+            )
+            with patch.object(sensitive, "bind", return_value=second) as bind:
+                self.assertIs(first(x), x)
+            bind.assert_called_once_with((x,))
+            self.assertEqual(get_num_sm_mock.call_count, get_num_sm_calls + 1)
+
+            current_num_sm = 148
+            same_num_sm_device = torch.device("cuda", (x.device.index or 0) + 2)
+            first._compiler_seed_device_resolver = MagicMock(
+                return_value=same_num_sm_device
+            )
+            same_num_sm_calls = get_num_sm_mock.call_count
+            with patch.object(sensitive, "bind", wraps=sensitive.bind) as bind:
+                self.assertIs(first(x), x)
+                calls_after_new_device = get_num_sm_mock.call_count
+                self.assertIs(first(x), x)
+            bind.assert_called_once_with((x,))
+            self.assertEqual(calls_after_new_device, same_num_sm_calls + 2)
+            self.assertEqual(get_num_sm_mock.call_count, calls_after_new_device)
+
+            assert_bind_case(
+                config_num_sm_sensitive.name,
+                (((x,), 148), ((x,), 132)),
+                different=((0, 1),),
+                fact="config_num_sm",
+                expected_values={124, 140},
+                persistent_reserved_sms=8,
+            )
+
+            _metadata_sensitive, metadata_bounds = assert_bind_case(
+                input_metadata_sensitive.name,
+                (
+                    ((x,), 148),
+                    ((wider_x,), 148),
+                    ((torch.empty_like(x),), 148),
+                ),
+                same=((0, 2),),
+                different=((0, 1),),
+                fact="input_tensor_metadata",
+                expected_values={
+                    (((("sequence", tuple, 0),), (8,), (1,)),),
+                    (((("sequence", tuple, 0),), (16,), (1,)),),
+                },
+                static_shapes=False,
+            )
+            first_metadata, second_metadata, _rebound_metadata = metadata_bounds
+            first_metadata._run = lambda _value: x
+            second_metadata._run = lambda _value: wider_x
+            self.assertIs(first_metadata(wider_x), wider_x)
+
+            assert_bind_case(
+                input_metadata_sensitive.name,
+                (((x,), 148), ((wider_x,), 148)),
+                different=((0, 1),),
+            )
+
+            for static_shapes, cases in (
+                (True, (((x,), 148), ((x,), 132))),
+                (False, (((x,), 148), ((wider_x,), 148))),
+            ):
+                with self.subTest(unrelated_static_shapes=static_shapes):
+                    kernel, _bounds = assert_bind_case(
+                        unrelated.name,
+                        cases,
+                        same=((0, 1),),
+                        static_shapes=static_shapes,
+                    )
+                    self.assertEqual(len(kernel._bound_kernels), 1)
+
+    def test_argument_device_resolver_canonicalizes_indexless_cuda(self) -> None:
+        resolver = _DeviceResolver.from_values((torch.device("cuda"),))
+
+        with (
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.current_device", side_effect=(0, 1)) as current_device,
+        ):
+            self.assertEqual(
+                resolver((torch.device("cuda"),)),
+                torch.device("cuda", 0),
+            )
+            self.assertEqual(
+                resolver((torch.device("cuda"),)),
+                torch.device("cuda", 1),
+            )
+
+        self.assertEqual(current_device.call_count, 2)
+
+    def test_argument_device_resolver_relearns_invalid_mapping_paths(self) -> None:
+        cpu = torch.device("cpu")
+        meta = torch.device("meta")
+        resolver = _DeviceResolver.from_values(({"empty": None, "device": meta},))
+        first_path = resolver.path
+
+        self.assertEqual(resolver(({"empty": None, "device": meta},)), meta)
+        self.assertEqual(resolver.path, first_path)
+
+        # Moving the selected key invalidates its learned mapping position even
+        # when the selected device is unchanged.
+        self.assertEqual(resolver(({"device": meta, "empty": None},)), meta)
+        reordered_path = resolver.path
+        self.assertNotEqual(reordered_path, first_path)
+
+        # A missing key and a changed container type both trigger discovery of
+        # the first device under the new structure.
+        self.assertEqual(resolver(({"replacement": cpu},)), cpu)
+        self.assertEqual(resolver(([None, meta],)), meta)
+
+    def test_input_tensor_metadata_tracks_roles_not_mapping_order(self) -> None:
+        narrow = torch.empty_strided((8, 4), (4, 1))
+        wide = torch.empty_strided((16, 4), (5, 1))
+        original = _input_tensor_metadata(
+            ({"lhs": narrow, "rhs": wide},),
+        )
+        reordered = _input_tensor_metadata(
+            ({"rhs": wide, "lhs": narrow},),
+        )
+        swapped_roles = _input_tensor_metadata(
+            ({"rhs": narrow, "lhs": wide},),
+        )
+
+        self.assertEqual(original, reordered)
+        self.assertNotEqual(original, swapped_roles)
+        self.assertEqual(
+            {record[0][-1][-1] for record in original},
+            {"lhs", "rhs"},
+        )
+
+    def test_input_tensor_metadata_tracks_dataclass_field_roles(self) -> None:
+        @dataclasses.dataclass
+        class Inputs:
+            lhs: torch.Tensor
+            rhs: torch.Tensor
+
+        narrow = torch.empty_strided((8, 4), (4, 1))
+        wide = torch.empty_strided((16, 4), (5, 1))
+        original = _input_tensor_metadata((Inputs(narrow, wide),))
+        swapped_roles = _input_tensor_metadata((Inputs(wide, narrow),))
+
+        self.assertNotEqual(original, swapped_roles)
+        self.assertEqual(
+            {record[0][-1][-1] for record in original},
+            {"lhs", "rhs"},
+        )
+
+    def test_compiler_seed_specialization_is_in_cache_hash(self) -> None:
+        bound_keys = [
+            BoundKernelInMemoryCacheKey(
+                (),
+                (),
+                compiler_seed_results=(("config_num_sm", num_sm),),
+            )
+            for num_sm in (132, 148)
+        ]
+
+        self.assertNotEqual(bound_keys[0].stable_hash(), bound_keys[1].stable_hash())
+        self.assertIn("compiler_seed_results", repr(bound_keys[0]))
+        self.assertEqual(
+            repr(BoundKernelInMemoryCacheKey((), ())),
+            "BoundKernelInMemoryCacheKey(specialization_key=(), extra_results=())",
+        )
+
+        common = {
+            "specialization_key": (),
+            "extra_results": (),
+            "kernel_source_hash": "source",
+            "hardware": "NVIDIA B200",
+            "runtime_name": "13.0",
+            "backend": "cute",
+        }
+        keys = [
+            LooseAutotuneCacheKey(
+                **common,
+                compiler_seed_results=(
+                    ("config_num_sm", 148),
+                    (
+                        "input_tensor_metadata",
+                        (((("sequence", tuple, 0),), (size,), (1,)),),
+                    ),
+                ),
+            )
+            for size in (8, 16)
+        ]
+
+        self.assertNotEqual(keys[0].stable_hash(), keys[1].stable_hash())
+        self.assertIn("compiler_seed_results", repr(keys[0]))
+
+        strict_keys = [
+            StrictAutotuneCacheKey(
+                **common,
+                compiler_seed_results=(("config_num_sm", num_sm),),
+                helion_key="helion",
+                torch_key="torch",
+                triton_key="triton",
+            )
+            for num_sm in (132, 148)
+        ]
+        self.assertNotEqual(
+            strict_keys[0].stable_hash(),
+            strict_keys[1].stable_hash(),
+        )
+        self.assertIn("compiler_seed_results", repr(strict_keys[0]))
+
+    def test_grouped_worklist_compatible_source_tiles_validate_rows(self) -> None:
+        valid_cases = (
+            (
+                [[0, 0, 17, 32], [1, 32, 11, 32]],
+                64,
+                (TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,),
+            ),
+            (
+                [[0, 0, 17, 224], [1, 224, 11, 224]],
+                448,
+                (
+                    TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+                    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+                ),
+            ),
+            (
+                [[0, 0, 17, 256], [1, 256, 11, 256]],
+                512,
+                (
+                    TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+                    TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+                ),
+            ),
+        )
+        for rows, packed_m, expected in valid_cases:
+            with self.subTest(rows=rows):
+                self.assertEqual(
+                    tcgen05_grouped_worklist_compatible_source_m_tiles(
+                        rows,
+                        group_count=2,
+                        packed_m=packed_m,
+                    ),
+                    expected,
+                )
+
+        invalid_cases = (
+            ("row_count", [[0, 0, 17, 32]], 64),
+            ("row_width", [[0, 0, 17], [1, 32, 11, 32]], 64),
+            ("row_hole", [[0, 0, 17, 32], [1, 64, 11, 32]], 96),
+            ("row_overlap", [[0, 0, 17, 64], [1, 32, 11, 64]], 96),
+        )
+        for name, rows, packed_m in invalid_cases:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    tcgen05_grouped_worklist_compatible_source_m_tiles(
+                        rows,
+                        group_count=2,
+                        packed_m=packed_m,
+                    ),
+                    (),
+                )
+
+    def test_grouped_worklist_seeds_are_packing_compatible_and_ranked(self) -> None:
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.cute_tcgen05_search_enabled = True
+        for block_id, size_hint in enumerate((256, 4096, 4096)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+            )
+        fact = MatmulFact(
+            lhs_ndim=2,
+            rhs_ndim=3,
+            m_block_id=0,
+            n_block_id=1,
+            k_block_id=2,
+            static_m=256,
+            static_n=4096,
+            static_k=4096,
+            lhs_dtype=torch.bfloat16,
+            rhs_dtype=torch.bfloat16,
+        )
+        spec.matmul_facts = [fact]
+        env = MagicMock(config_spec=spec)
+        self.assertIs(_tcgen05_grouped_fact(env), fact)
+        self.assertIs(_tcgen05_grouped_worklist_fact(env), fact)
+        dynamic_fact = fact._replace(static_n=None, static_k=None)
+        spec.matmul_facts = [dynamic_fact]
+        self.assertIsNone(_tcgen05_grouped_fact(env))
+        self.assertIs(_tcgen05_grouped_worklist_fact(env), dynamic_fact)
+        fp16_fact = fact._replace(
+            lhs_dtype=torch.float16,
+            rhs_dtype=torch.float16,
+        )
+        spec.matmul_facts = [fp16_fact]
+        self.assertIs(_tcgen05_grouped_fact(env), fp16_fact)
+        self.assertIsNone(_tcgen05_grouped_worklist_fact(env))
+
+        families = self._grouped_worklist_seed_families()
+        small = families["small_k"]
+        k_major = families["source256_k"]
+        legacy = families["source224"]
+        n_major = families["source256_n"]
+
+        for configs, key, expected in (
+            (small, TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, 52),
+            (k_major, TCGEN05_CONSUMER_REGS_CONFIG_KEY, 240),
+            (n_major, TCGEN05_CONSUMER_REGS_CONFIG_KEY, 240),
+            (legacy, TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY, 8),
+            (legacy, TCGEN05_CONSUMER_REGS_CONFIG_KEY, 256),
+        ):
+            self.assertEqual(configs[0].config[key], expected)
+        self.assertNotIn(
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY,
+            k_major[0].config,
+        )
+        self.assertEqual(
+            n_major[0].config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY],
+            Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+        )
+        for source_m_tile, configs in (
+            (32, small),
+            (224, legacy),
+            (256, k_major),
+            (256, n_major),
+        ):
+            self.assertTrue(configs)
+            self.assertTrue(
+                all(
+                    config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY]
+                    == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                    and config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY]
+                    == source_m_tile
+                    for config in configs
+                )
+            )
+
+    def test_grouped_worklist_seed_family_covers_reviewed_variants(self) -> None:
+        def block_k(values: dict[str, object]) -> int:
+            return cast("list[int]", values["block_sizes"])[2]
+
+        families = self._grouped_worklist_seed_families()
+        small = families["small_n"]
+        source224 = families["source224"]
+        source256 = families["source256_n"]
+
+        small_values = [config.config for config in small]
+        self.assertTrue(
+            {32, 52}.issubset(
+                {
+                    values.get(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY)
+                    for values in small_values
+                    if block_k(values) == 128
+                }
+            )
+        )
+        self.assertTrue(
+            any(
+                block_k(values) == 128
+                and TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY not in values
+                for values in small_values
+            )
+        )
+        self.assertTrue(
+            {4, 8}.issubset(
+                {
+                    values.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
+                    for values in small_values
+                    if values.get(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY) == 20
+                }
+            )
+        )
+        self.assertTrue(
+            any(
+                block_k(values) == 64
+                and values.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is True
+                and TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY not in values
+                for values in small_values
+            )
+        )
+        self.assertTrue(
+            any(
+                values.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is not True
+                for values in small_values
+            )
+        )
+
+        source224_values = [config.config for config in source224]
+        self.assertEqual(
+            {
+                values["tcgen05_ab_stages"]
+                for values in source224_values
+                if values.get(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY) is not True
+            },
+            {4, 5, 6, 7},
+        )
+        self.assertTrue(
+            any(
+                values.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY) == 8
+                and values.get(TCGEN05_CONSUMER_REGS_CONFIG_KEY) == 256
+                for values in source224_values
+            )
+        )
+        self.assertTrue(any(block_k(values) == 128 for values in source224_values))
+
+        source256_values = [config.config for config in source256]
+        self.assertEqual(
+            {
+                (block_k(values), values["tcgen05_ab_stages"])
+                for values in source256_values
+            },
+            {(64, 5), (64, 6), (128, 3)},
+        )
+        self.assertTrue(
+            {224, 240, 256}.issubset(
+                {
+                    values.get(TCGEN05_CONSUMER_REGS_CONFIG_KEY)
+                    for values in source256_values
+                }
+            )
+        )
+        self.assertTrue(
+            {8, 16}.issubset(
+                {
+                    values.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
+                    for values in source256_values
+                }
+            )
+        )
+        self.assertTrue(
+            any(
+                values.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+                == Tcgen05PersistenceModel.CLC_PERSISTENT.value
+                for values in source256_values
+            )
+        )
+
+    def test_grouped_worklist_automatic_seed_cap_round_robins_families(self) -> None:
+        families = [
+            [helion.Config(block_sizes=[family, index]) for index in range(length)]
+            for family, length in ((1, 6), (2, 4), (3, 3))
+        ]
+
+        self.assertEqual(
+            _bounded_grouped_worklist_seed_families(families),
+            [
+                families[0][0],
+                families[1][0],
+                families[2][0],
+                families[0][1],
+                families[1][1],
+                families[2][1],
+                families[0][2],
+                families[1][2],
+            ],
+        )
+
+    def test_grouped_worklist_clc_requires_full_physical_n_tile(self) -> None:
+        configs = tcgen05_grouped_worklist_seed_configs(
+            groups=8,
+            packed_m=20_480,
+            n=416,
+            k=192,
+            b_major="n",
+            source_m_tile=256,
+            num_sm=148,
+        )
+
+        self.assertTrue(configs)
+        self.assertTrue(
+            all(
+                config.config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+                != Tcgen05PersistenceModel.CLC_PERSISTENT.value
+                for config in configs
+            )
+        )
+        self.assertNotEqual(
+            configs[0].config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY),
+            Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+        )
+
+    def test_grouped_worklist_clc_respects_cuda_grid_z_limit(self) -> None:
+        for m_tiles, n_tiles, expect_clc in (
+            (257, 255, True),
+            (258, 255, False),
+        ):
+            with self.subTest(
+                m_tiles=m_tiles,
+                n_tiles=n_tiles,
+                expect_clc=expect_clc,
+            ):
+                configs = tcgen05_grouped_worklist_seed_configs(
+                    groups=1,
+                    packed_m=m_tiles * 256,
+                    n=n_tiles * 256,
+                    k=65_536,
+                    b_major="n",
+                    source_m_tile=256,
+                    num_sm=148,
+                )
+                clc_configs = [
+                    config
+                    for config in configs
+                    if config.config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+                    == Tcgen05PersistenceModel.CLC_PERSISTENT.value
+                ]
+
+                self.assertEqual(bool(clc_configs), expect_clc)
+                self.assertEqual(
+                    m_tiles * n_tiles
+                    <= TCGEN05_GROUPED_RUNTIME_DIRECT_CLC_MAX_CLUSTERS,
+                    expect_clc,
+                )
+                if expect_clc:
+                    self.assertEqual(
+                        configs[0].config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY),
+                        Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+                    )
+                else:
+                    self.assertNotEqual(
+                        configs[0].config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY),
+                        Tcgen05PersistenceModel.CLC_PERSISTENT.value,
+                    )
+
+    def test_grouped_worklist_seeds_filter_unreachable_block_k(self) -> None:
+        configs = tcgen05_grouped_worklist_seed_configs(
+            groups=8,
+            packed_m=8 * 4096,
+            n=4096,
+            k=2048,
+            b_major="n",
+            source_m_tile=256,
+            num_sm=148,
+        )
+
+        for block_k in (64, 128):
+            spec = ConfigSpec(backend=CuteBackend())
+            for block_id, value in enumerate((256, 128, block_k)):
+                spec.block_sizes.append(
+                    BlockSizeSpec(
+                        block_id=block_id,
+                        size_hint=value,
+                        min_size=value,
+                        max_size=value,
+                    )
+                )
+            reachable = _filter_reachable_block_size_configs(spec, configs)
+            self.assertTrue(reachable)
+            self.assertTrue(
+                all(
+                    cast("list[int]", config.config["block_sizes"])[2] == block_k
+                    for config in reachable
+                )
+            )
+        bk128_only = ConfigSpec(
+            backend=CuteBackend(),
+            target_device_capability=(10, 0),
+        )
+        bk128_only.cute_tcgen05_search_enabled = True
+        for block_id, value in enumerate((256, 128, 128)):
+            bk128_only.block_sizes.append(
+                BlockSizeSpec(
+                    block_id=block_id,
+                    size_hint=value,
+                    min_size=value,
+                    max_size=value,
+                )
+            )
+        bk128_only.matmul_facts = [
+            MatmulFact(
+                lhs_ndim=2,
+                rhs_ndim=3,
+                m_block_id=0,
+                n_block_id=1,
+                k_block_id=2,
+                static_m=256,
+                static_n=None,
+                static_k=None,
+                lhs_dtype=torch.bfloat16,
+                rhs_dtype=torch.bfloat16,
+            )
+        ]
+        env = MagicMock(config_spec=bk128_only)
+        analysis = MagicMock()
+        analysis.seed_facts.groups_hint = 1
+        analysis.seed_facts.packed_m_hint = 256
+        analysis.seed_facts.n_hint = 128
+        analysis.seed_facts.k_hint = 128
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cute_mma.analyze_tcgen05_grouped_worklist",
+                return_value=analysis,
+            ),
+        ):
+            self.assertEqual(
+                CuteTcgen05GroupedWorklistHeuristic._eligible_inputs(env, MagicMock()),
+                (bk128_only.matmul_facts[0], analysis),
+            )
+            bk128_only.target_device_capability = (10, 3)
+            self.assertEqual(
+                CuteTcgen05GroupedWorklistHeuristic._eligible_inputs(env, MagicMock()),
+                (bk128_only.matmul_facts[0], analysis),
+            )
+            bk128_only.target_device_capability = (10, 4)
+            self.assertIsNone(
+                CuteTcgen05GroupedWorklistHeuristic._eligible_inputs(env, MagicMock())
+            )
+            bk128_only.target_device_capability = (10, 3)
+            bk128_only.matmul_facts = [bk128_only.matmul_facts[0]._replace(static_n=33)]
+            self.assertIsNone(
+                CuteTcgen05GroupedWorklistHeuristic._eligible_inputs(env, MagicMock())
+            )
+            bk128_only.matmul_facts = [
+                bk128_only.matmul_facts[0]._replace(static_n=None)
+            ]
+            self.assertEqual(
+                CuteTcgen05GroupedWorklistHeuristic._eligible_inputs(env, MagicMock()),
+                (bk128_only.matmul_facts[0], analysis),
+            )
+
+    def test_grouped_worklist_seed_only_controls_survive_flattening(self) -> None:
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.cute_tcgen05_search_enabled = True
+        spec.allowed_pid_types = ("flat",)
+        families = self._grouped_worklist_seed_families()
+        spec.compiler_seed_configs = [
+            *families["small_k"],
+            *families["source256_n"],
+            *families["source256_k"],
+        ]
+        fields = spec._cute_tcgen05_config.flat_fields()
+
+        def enum(key: str) -> EnumFragment:
+            fragment = fields[key]
+            self.assertIsInstance(fragment, EnumFragment)
+            return cast("EnumFragment", fragment)
+
+        ab_stages = cast("IntegerFragment", fields["tcgen05_ab_stages"])
+        self.assertIsInstance(ab_stages, IntegerFragment)
+        grouped_mode = enum(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+        runtime_direct = enum(TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY)
+        reserved = enum(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY)
+        consumer_regs = enum(TCGEN05_CONSUMER_REGS_CONFIG_KEY)
+        strategy = enum(TCGEN05_STRATEGY_CONFIG_KEY)
+        persistence = enum(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+        scheduler_warps = enum(TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY)
+        source_m_tile = enum(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+        l2_swizzle = enum(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY)
+        pid_type = enum("pid_type")
+        seed_ab_stages = max(
+            cast("int", seed.config["tcgen05_ab_stages"])
+            for seed in spec.compiler_seed_configs
+        )
+        self.assertGreater(seed_ab_stages, ab_stages.high)
+        self.assertEqual(ab_stages.default(), 2)
+        self.assertEqual(ab_stages.cardinality(), 2)
+        self.assertEqual(ab_stages.search_values(), [1, 2])
+        self.assertEqual(ab_stages.dim(), 1)
+        self.assertEqual(ab_stages.encode(seed_ab_stages), [float(seed_ab_stages)])
+        self.assertEqual(ab_stages.pattern_neighbors(seed_ab_stages), [2, 1])
+        self.assertEqual(
+            ab_stages.differential_mutation(seed_ab_stages, 1, 1),
+            seed_ab_stages,
+        )
+        self.assertEqual(ab_stages.differential_mutation(seed_ab_stages, 1, 2), 2)
+        self.assertEqual(ab_stages.differential_mutation(seed_ab_stages, 2, 1), 2)
+        self.assertTrue(all(ab_stages.random() in (1, 2) for _ in range(32)))
+        self.assertEqual(grouped_mode.search_choices, (None,))
+        self.assertEqual(runtime_direct.search_choices, (False,))
+        self.assertIn(52, reserved.choices)
+        self.assertEqual(
+            reserved.search_choices,
+            TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES,
+        )
+        self.assertEqual(consumer_regs.search_choices, (256,))
+        self.assertEqual(
+            strategy.search_choices,
+            (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,),
+        )
+        self.assertIn(Tcgen05PersistenceModel.CLC_PERSISTENT.value, persistence.choices)
+        self.assertEqual(
+            scheduler_warps.search_choices,
+            (0,),
+        )
+        self.assertEqual(set(source_m_tile.choices), {None, 32, 256})
+        self.assertEqual(source_m_tile.search_choices, (None,))
+        self.assertIn(16, l2_swizzle.choices)
+        self.assertEqual(l2_swizzle.search_choices, (1, 2, 4, 8))
+        self.assertEqual(pid_type.search_choices, ("flat",))
+
+    def test_grouped_worklist_primary_promotes_on_supported_blackwell_arches(
+        self,
+    ) -> None:
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.cute_tcgen05_search_enabled = True
+        for block_id, size_hint in enumerate((256, 256, 128)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+            )
+        static_fact = MatmulFact(
+            lhs_ndim=2,
+            rhs_ndim=2,
+            m_block_id=0,
+            n_block_id=1,
+            k_block_id=2,
+            static_m=256,
+            static_n=256,
+            static_k=128,
+            lhs_dtype=torch.bfloat16,
+            rhs_dtype=torch.bfloat16,
+        )
+        spec.matmul_facts = [static_fact]
+        env = MagicMock(device=DEVICE, config_spec=spec)
+        for hardware in (BLACKWELL_HARDWARE, GB300_HARDWARE):
+            with (
+                self.subTest(compute_capability=hardware.compute_capability),
+                patch(
+                    "helion._compiler.autotuner_heuristics.cute."
+                    "tcgen05_runtime_n_ptx_compatible",
+                    return_value=True,
+                ),
+                patch("helion._hardware.get_hardware_info", return_value=hardware),
+            ):
+                self.assertTrue(CuteTcgen05GroupedWorklistHeuristic.should_promote(env))
+        spec.matmul_facts = [static_fact._replace(static_k=None)]
+        self.assertFalse(CuteTcgen05GroupedWorklistHeuristic.should_promote(env))
+        spec.matmul_facts = [
+            static_fact._replace(
+                lhs_dtype=torch.float16,
+                rhs_dtype=torch.float16,
+            )
+        ]
+        self.assertFalse(CuteTcgen05GroupedWorklistHeuristic.should_promote(env))
+
+    def test_grouped_worklist_seeds_require_validated_runtime_n_ptx(self) -> None:
+        spec = ConfigSpec(
+            backend=CuteBackend(),
+            target_device_capability=(10, 0),
+            num_sm=148,
+        )
+        spec.cute_tcgen05_search_enabled = True
+        for block_id, size_hint in enumerate((256, 256, 128)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+            )
+        spec.matmul_facts = [
+            MatmulFact(
+                lhs_ndim=2,
+                rhs_ndim=3,
+                m_block_id=0,
+                n_block_id=1,
+                k_block_id=2,
+                static_m=256,
+                static_n=256,
+                static_k=128,
+                lhs_dtype=torch.bfloat16,
+                rhs_dtype=torch.bfloat16,
+            )
+        ]
+        env = MagicMock(device=DEVICE, config_spec=spec)
+        device_ir = MagicMock()
+        grouped_fact = spec.matmul_facts[0]
+        worklist_analysis = MagicMock()
+        worklist_analysis.seed_facts.groups_hint = 1
+        worklist_analysis.seed_facts.packed_m_hint = 256
+        worklist_analysis.seed_facts.n_hint = 256
+        worklist_analysis.seed_facts.k_hint = 128
+
+        with (
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=False,
+            ),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "warn_tcgen05_runtime_n_ptx_fallback"
+            ) as warn_fallback,
+            patch(
+                "helion._compiler.cute.cute_mma.analyze_tcgen05_grouped_worklist"
+            ) as analyze_worklist,
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            spec.matmul_facts = []
+            self.assertFalse(
+                CuteTcgen05GroupedWorklistHeuristic.is_eligible(env, device_ir)
+            )
+            warn_fallback.assert_not_called()
+
+            spec.matmul_facts = [grouped_fact]
+            analyze_worklist.return_value = None
+            self.assertFalse(
+                CuteTcgen05GroupedWorklistHeuristic.is_eligible(env, device_ir)
+            )
+            warn_fallback.assert_not_called()
+
+            analyze_worklist.return_value = worklist_analysis
+            self.assertFalse(
+                CuteTcgen05GroupedWorklistHeuristic.is_eligible(env, device_ir)
+            )
+            warn_fallback.assert_called_once_with()
+            self.assertIsNone(
+                CuteTcgen05GroupedWorklistHeuristic.get_seed_config(env, device_ir)
+            )
+            self.assertEqual(
+                CuteTcgen05GroupedWorklistHeuristic.get_seed_configs(env, device_ir),
+                [],
+            )
+            self.assertFalse(CuteTcgen05GroupedWorklistHeuristic.should_promote(env))
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_dynamic_hints_do_not_narrow_search(self) -> None:
+        from helion.language.matmul_ops import _plan_cute_tcgen05_search_candidate
+
+        def make_args(packed_m: int) -> tuple[object, ...]:
+            rows_per_group = packed_m // 6
+            self.assertEqual(packed_m, 6 * rows_per_group)
+            self.assertEqual(rows_per_group % 32, 0)
+            return (
+                torch.empty(
+                    [packed_m, 128],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.empty(
+                    [6, 256, 128],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.tensor(
+                    [
+                        [group, group * rows_per_group, rows_per_group, rows_per_group]
+                        for group in range(6)
+                    ],
+                    device=DEVICE,
+                    dtype=torch.int32,
+                ),
+            )
+
+        kernel = helion.kernel(
+            _grouped_worklist_kernel_body,
+            backend="cute",
+            static_shapes=False,
+        )
+        plans = []
+
+        def capture_plan(*args: object, **kwargs: object):
+            result = _plan_cute_tcgen05_search_candidate(  # pyrefly: ignore
+                *args, **kwargs
+            )
+            if result.plan is not None:
+                plans.append(result.plan)
+            return result
+
+        first_args = make_args(6 * 32)
+        rebound_args = make_args(12 * 32)
+
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion.language.matmul_ops._plan_cute_tcgen05_search_candidate",
+                side_effect=capture_plan,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            first = kernel.bind(first_args)
+            rebound = kernel.bind(rebound_args)
+            first._run = lambda *_args: cast("torch.Tensor", first_args[0])
+            rebound._run = lambda *_args: cast("torch.Tensor", rebound_args[0])
+            self.assertIs(first(*rebound_args), rebound_args[0])
+
+        self.assertIsNot(rebound, first)
+        self.assertEqual(len(plans), 2)
+        for plan in plans:
+            self.assertEqual(
+                (plan.static_m, plan.static_n, plan.static_k),
+                (256, None, None),
+            )
+        fact = _tcgen05_grouped_worklist_fact(first.env)
+        assert fact is not None
+        self.assertEqual(
+            (fact.static_m, fact.static_n, fact.static_k),
+            (256, None, None),
+        )
+        self.assertEqual(first.config_spec.allowed_pid_types, ("flat",))
+        self.assertEqual(first.config_spec._tcgen05_cluster_m_search_choices, (1,))
+        self.assertIsNone(first.config_spec._tcgen05_cluster_m2_search_constraints)
+        self.assertIsNone(first.config_spec.compiler_default_config)
+        # The worklist's group/start/extent loads feed scheduling, indices, and
+        # masks rather than the matmul's store value. They must not be mistaken
+        # for per-subtile epilogue aux loads, which would expose a
+        # ``pre_acc_wait`` search point that every identity-store config rejects.
+        self.assertFalse(first.config_spec.cute_tcgen05_aux_kernel_detected)
+        self.assertNotIn(
+            TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+            first.config_spec._flat_fields(),
+        )
+        self.assertTrue(
+            any(
+                config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                for config in first.config_spec.compiler_seed_configs
+            )
+        )
+        transfer_errors: list[str] = []
+        generation = first.config_spec.create_config_generation()
+        seed_pairs = generation.seed_flat_config_pairs(transfer_errors.append)
+        self.assertFalse(transfer_errors)
+        self.assertTrue(seed_pairs)
+        for flat, normalized in seed_pairs:
+            self.assertEqual(generation.unflatten([*flat]), normalized)
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_dynamic_inputs_rebind_without_promotion(self) -> None:
+        def make_args(
+            *,
+            n: int = 256,
+            k: int = 256,
+            b_major: str = "k",
+            source_m_tile: int = 32,
+        ) -> tuple[object, ...]:
+            if b_major == "k":
+                b_grouped = torch.empty(
+                    [6, n, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                )
+            else:
+                self.assertEqual(b_major, "n")
+                b_grouped = torch.empty(
+                    [6, k, n],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ).transpose(1, 2)
+            worklist = torch.tensor(
+                [
+                    [
+                        group,
+                        group * source_m_tile,
+                        source_m_tile,
+                        source_m_tile,
+                    ]
+                    for group in range(6)
+                ],
+                device=DEVICE,
+                dtype=torch.int32,
+            )
+            return (
+                torch.empty(
+                    [6 * source_m_tile, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                b_grouped,
+                worklist,
+            )
+
+        kernel = helion.kernel(
+            _grouped_worklist_kernel_body,
+            backend="cute",
+            static_shapes=False,
+        )
+        current_num_sm = 148
+
+        def get_num_sm(
+            _device: torch.device,
+            *,
+            reserved_sms: int = 0,
+        ) -> int:
+            return max(current_num_sm - reserved_sms, 1)
+
+        zero_k_args = make_args(k=0)
+        first_args = make_args(k=128)
+        different_k_args = make_args(k=192)
+        different_n_args = make_args(n=240)
+        different_layout_args = make_args(b_major="n")
+        source224_args = make_args(k=128, source_m_tile=224)
+        # Reuse one dynamic schema across packed shapes, then change only the
+        # worklist values while keeping the larger tensor metadata unchanged.
+        shape_kernel = helion.kernel(
+            _grouped_worklist_kernel_body,
+            backend="cute",
+            static_shapes=False,
+        )
+
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+            patch("helion.runtime.get_num_sm", side_effect=get_num_sm),
+        ):
+            zero_k = kernel.bind(zero_k_args)
+            first = kernel.bind(first_args)
+            different_k = kernel.bind(different_k_args)
+            different_n = kernel.bind(different_n_args)
+            different_layout = kernel.bind(different_layout_args)
+            shape_source32 = shape_kernel.bind(first_args)
+            shape_source224 = shape_kernel.bind(source224_args)
+
+            compact_extents = (32, 32, 32, 32, 32, 1184)
+            compact_rows = []
+            start = 0
+            for group, extent in enumerate(compact_extents):
+                compact_rows.append([group, start, extent, extent])
+                start += extent
+            cast("torch.Tensor", source224_args[2]).copy_(
+                cast("torch.Tensor", source224_args[2]).new_tensor(compact_rows)
+            )
+            shape_compact = shape_kernel.bind(source224_args)
+
+            first_output = cast("torch.Tensor", first_args[0])
+            different_k_output = cast("torch.Tensor", different_k_args[0])
+            different_n_output = cast("torch.Tensor", different_n_args[0])
+            different_layout_output = cast("torch.Tensor", different_layout_args[0])
+            first._run = lambda *_args: first_output
+            different_k._run = lambda *_args: different_k_output
+            different_n._run = lambda *_args: different_n_output
+            different_layout._run = lambda *_args: different_layout_output
+            self.assertIs(zero_k(*first_args), first_output)
+            self.assertIs(first(*different_k_args), different_k_output)
+            self.assertIs(first(*different_n_args), different_n_output)
+            self.assertIs(first(*different_layout_args), different_layout_output)
+
+            current_num_sm = 132
+            smaller_sm = kernel.bind(different_k_args)
+
+        self.assertIsNot(zero_k, first)
+        self.assertIsNot(different_k, first)
+        self.assertIsNot(different_n, first)
+        self.assertIsNot(different_layout, first)
+        self.assertIsNot(smaller_sm, first)
+        self.assertIsNot(smaller_sm, different_k)
+        self.assertEqual(len(kernel._bound_kernels), 6)
+        self.assertIsNot(shape_source224, shape_source32)
+        self.assertTrue(
+            any(
+                config.config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+                == 224
+                for config in shape_source224.config_spec.compiler_seed_configs
+            )
+        )
+        self.assertIsNot(shape_compact, shape_source224)
+        self.assertEqual(
+            {
+                config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY]
+                for config in shape_compact.config_spec.compiler_seed_configs
+                if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            },
+            {32},
+        )
+
+        def specialization_results(bound: object) -> dict[str, object]:
+            matches = [
+                dict(
+                    cast(
+                        "tuple[tuple[str, object], ...]",
+                        key.compiler_seed_results,
+                    )
+                )
+                for key, candidate in kernel._bound_kernels.items()
+                if candidate is bound
+            ]
+            self.assertEqual(len(matches), 1)
+            return matches[0]
+
+        zero_k_results = specialization_results(zero_k)
+        first_results = specialization_results(first)
+        different_k_results = specialization_results(different_k)
+        different_n_results = specialization_results(different_n)
+        different_layout_results = specialization_results(different_layout)
+        smaller_sm_results = specialization_results(smaller_sm)
+        self.assertEqual(
+            set(zero_k_results),
+            {"config_num_sm", "input_tensor_metadata"},
+        )
+        self.assertEqual(first_results["config_num_sm"], 148)
+        self.assertEqual(different_k_results["config_num_sm"], 148)
+        self.assertEqual(different_n_results["config_num_sm"], 148)
+        self.assertEqual(different_layout_results["config_num_sm"], 148)
+        self.assertEqual(smaller_sm_results["config_num_sm"], 132)
+        first_metadata = first_results["input_tensor_metadata"]
+        self.assertNotEqual(
+            different_k_results["input_tensor_metadata"], first_metadata
+        )
+        self.assertNotEqual(
+            different_n_results["input_tensor_metadata"], first_metadata
+        )
+        self.assertNotEqual(
+            different_layout_results["input_tensor_metadata"], first_metadata
+        )
+        self.assertEqual(
+            smaller_sm_results["input_tensor_metadata"],
+            different_k_results["input_tensor_metadata"],
+        )
+        grouped_fact = _tcgen05_grouped_worklist_fact(first.env)
+        assert grouped_fact is not None
+        self.assertIsNone(grouped_fact.static_k)
+        self.assertNotIn(
+            CuteTcgen05GroupedWorklistHeuristic.name,
+            zero_k.config_spec.autotuner_heuristics,
+        )
+        self.assertIn(
+            CuteTcgen05GroupedWorklistHeuristic.name,
+            first.config_spec.autotuner_heuristics,
+        )
+        self.assertIsNone(first.config_spec.compiler_default_config)
+        self.assertEqual(
+            {
+                cast("list[int]", config.config["block_sizes"])[2]
+                for config in first.config_spec.compiler_seed_configs
+                if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            },
+            {64, 128},
+        )
+        self.assertEqual(
+            {
+                cast("list[int]", config.config["block_sizes"])[2]
+                for config in different_k.config_spec.compiler_seed_configs
+                if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            },
+            {64},
+        )
+        self.assertFalse(
+            any(
+                config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                for config in different_n.config_spec.compiler_seed_configs
+            )
+        )
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_view_dimension_guard_fallback(self) -> None:
+        groups = 6
+        source_m_tile = 224
+        n = 256
+        k = 128
+        static_viewed_inputs = helion.kernel(
+            _grouped_worklist_with_viewed_inputs,
+            backend="cute",
+            static_shapes=True,
+        )
+        dynamic_viewed_inputs = helion.kernel(
+            _grouped_worklist_with_viewed_inputs,
+            backend="cute",
+            static_shapes=False,
+        )
+
+        args = (
+            torch.empty(
+                [groups, source_m_tile, k],
+                device=DEVICE,
+                dtype=torch.bfloat16,
+            ),
+            torch.empty([1, groups, n, k], device=DEVICE, dtype=torch.bfloat16),
+            torch.tensor(
+                [
+                    [
+                        group,
+                        group * source_m_tile,
+                        source_m_tile,
+                        source_m_tile,
+                    ]
+                    for group in range(groups)
+                ],
+                device=DEVICE,
+                dtype=torch.int32,
+            ),
+        )
+
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            static_bound = static_viewed_inputs.bind(args)
+            dynamic_bound = dynamic_viewed_inputs.bind(args)
+
+        self.assertTrue(static_bound.env.runtime_input_specializations)
+        self.assertTrue(
+            any(
+                config.config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+                == source_m_tile
+                for config in static_bound.config_spec.compiler_seed_configs
+            )
+        )
+        self.assertFalse(dynamic_bound.env.runtime_input_specializations)
+        self.assertFalse(
+            any(
+                config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                for config in dynamic_bound.config_spec.compiler_seed_configs
+            )
+        )
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_smem_facts_register_with_heuristics_disabled(
+        self,
+    ) -> None:
+        source_m_tile = 224
+        k = 128
+
+        def make_args(
+            groups: int,
+            *,
+            n: int = 256,
+            extents: tuple[int, ...] | None = None,
+        ) -> tuple[object, ...]:
+            if extents is None:
+                extents = (source_m_tile,) * groups
+            self.assertEqual(len(extents), groups)
+            self.assertEqual(sum(extents), groups * source_m_tile)
+            starts: list[int] = []
+            start = 0
+            for extent in extents:
+                starts.append(start)
+                start += extent
+            return (
+                torch.empty(
+                    [groups * source_m_tile, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.empty(
+                    [groups, n, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.tensor(
+                    [
+                        [group, starts[group], extent, extent]
+                        for group, extent in enumerate(extents)
+                    ],
+                    device=DEVICE,
+                    dtype=torch.int32,
+                ),
+            )
+
+        groups = 6
+        empty_args = make_args(groups, n=0)
+        args = make_args(groups)
+        compact_args = make_args(
+            groups,
+            extents=(32, 32, 32, 32, 32, groups * source_m_tile - 5 * 32),
+        )
+        different_groups = 7
+        different_args = make_args(different_groups)
+        explicit_configs = [
+            tcgen05_grouped_worklist_seed_configs(
+                groups=groups,
+                packed_m=groups * source_m_tile,
+                n=256,
+                k=k,
+                b_major="k",
+                source_m_tile=tile,
+                num_sm=148,
+            )[0]
+            for tile in (source_m_tile, 32)
+        ]
+        kernel = helion.kernel(
+            _grouped_worklist_kernel_body,
+            backend="cute",
+            static_shapes=False,
+            disable_autotuner_heuristics=True,
+            configs=explicit_configs,
+        )
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            empty_bound = kernel.bind(empty_args)
+            bound = kernel.bind(args)
+            compact_bound = kernel.bind(compact_args)
+            rebound = kernel.bind(different_args)
+
+        self.assertEqual(
+            empty_bound.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts,
+            (groups, False),
+        )
+        self.assertIsNot(bound, empty_bound)
+        self.assertEqual(bound.config_spec.compiler_seed_configs, [])
+        self.assertEqual(bound.config_spec.autotuner_heuristics, [])
+        self.assertTrue(bound.env.runtime_input_specializations)
+        self.assertIsNot(compact_bound, bound)
+        self.assertEqual(compact_bound.config_spec.compiler_seed_configs, [])
+        self.assertEqual(compact_bound.config_spec.autotuner_heuristics, [])
+        self.assertTrue(compact_bound.env.runtime_input_specializations)
+        self.assertEqual(
+            compiler_seed_configs(bound.env, bound.host_function.device_ir),
+            [],
+        )
+        self.assertEqual(
+            bound.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts,
+            (groups, False),
+        )
+        self.assertIsNot(rebound, bound)
+        self.assertEqual(
+            rebound.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts,
+            (different_groups, False),
+        )
+        self.assertEqual(
+            [
+                extractor.fact
+                for extractor in empty_bound._compiler_seed_specialization_extractors
+            ],
+            ["input_tensor_metadata"],
+        )
+        bound_output = cast("torch.Tensor", args[0])
+        bound._run = lambda *_args: bound_output
+        self.assertIs(empty_bound(*args), bound_output)
+        rebound_output = cast("torch.Tensor", different_args[0])
+        rebound._run = lambda *_args: rebound_output
+        self.assertIs(bound(*different_args), rebound_output)
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_fact_registration_ignores_plain_matmul(self) -> None:
+        @helion.kernel(
+            backend="cute",
+            static_shapes=False,
+            disable_autotuner_heuristics=True,
+        )
+        def plain_matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(
+                        acc,
+                        x[tile_m, tile_k],
+                        y[tile_k, tile_n],
+                    )
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        def make_args(size: int, k: int = 128) -> tuple[torch.Tensor, torch.Tensor]:
+            return (
+                torch.empty(
+                    [size, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+                torch.empty(
+                    [k, size],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ),
+            )
+
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            zero = plain_matmul.bind(make_args(128, 0))
+            first = plain_matmul.bind(make_args(128))
+            rebound = plain_matmul.bind(make_args(256))
+
+        self.assertIsNot(first, zero)
+        self.assertIs(rebound, first)
+        self.assertEqual(len(plain_matmul._bound_kernels), 2)
+        self.assertEqual(zero._compiler_seed_specialization_extractors, ())
+        self.assertEqual(first._compiler_seed_specialization_extractors, ())
+        self.assertIsNone(
+            first.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts
+        )
+
+    @onlyBackends(["cute"])
+    def test_grouped_worklist_unannotated_prepacked_seeds_and_rebind(self) -> None:
+        from helion._compiler.cute.cute_mma import analyze_tcgen05_grouped_worklist
+
+        @helion.kernel(backend="cute", static_shapes=True)
+        def unannotated_packing_kernel(
+            a_packed: torch.Tensor,
+            b_grouped: torch.Tensor,
+            worklist: torch.Tensor,
+            unused: torch.Tensor,
+        ) -> torch.Tensor:
+            m_total, k = a_packed.shape
+            _groups, n, k2 = b_grouped.shape
+            assert k == k2
+            block_m = hl.register_block_size(256)
+            block_n = hl.register_block_size(128)
+            block_k = hl.register_block_size(64, 128)
+            out = torch.empty(
+                [m_total, n],
+                dtype=a_packed.dtype,
+                device=a_packed.device,
+            )
+            for work_tile, tile_m, tile_n in hl.tile(
+                [worklist.size(0), 256, n],
+                block_size=[1, block_m, block_n],
+            ):
+                work_id = work_tile.begin
+                group_id = worklist[work_id, 0]
+                start = worklist[work_id, 1]
+                valid_m = worklist[work_id, 2]
+                store_m = worklist[work_id, 3]
+                local_m = tile_m.index
+                row = start + local_m
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k, block_size=block_k):
+                    a_block = hl.load(
+                        a_packed,
+                        [row, tile_k],
+                        extra_mask=(local_m < valid_m)[:, None],  # pyrefly: ignore[bad-index]
+                    )
+                    acc = torch.addmm(
+                        acc,
+                        a_block,
+                        b_grouped[group_id, tile_n, tile_k].T,
+                    )
+                hl.store(
+                    out,
+                    [row, tile_n],
+                    acc.to(out.dtype),
+                    extra_mask=(local_m < store_m)[:, None],  # pyrefly: ignore[bad-index]
+                )
+            return out
+
+        def make_args(
+            source_m_tile: int,
+            b_major: str,
+            k: int = 128,
+            packed_m: int | None = None,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            groups, n = 6, 256
+            total_m = groups * source_m_tile if packed_m is None else packed_m
+            a_packed = torch.empty(
+                [total_m, k],
+                device=DEVICE,
+                dtype=torch.bfloat16,
+            )
+            if b_major == "k":
+                b_grouped = torch.empty(
+                    [groups, n, k],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                )
+            else:
+                b_grouped = torch.empty(
+                    [groups, k, n],
+                    device=DEVICE,
+                    dtype=torch.bfloat16,
+                ).transpose(1, 2)
+            worklist = torch.tensor(
+                [
+                    [
+                        group,
+                        group * source_m_tile,
+                        source_m_tile,
+                        source_m_tile,
+                    ]
+                    for group in range(groups)
+                ],
+                device=DEVICE,
+                dtype=torch.int32,
+            )
+            unused = torch.empty([1], device=DEVICE, dtype=torch.bfloat16)
+            return a_packed, b_grouped, worklist, unused
+
+        def grouped_seeds(spec: ConfigSpec, source_m_tile: int) -> list[helion.Config]:
+            return [
+                config
+                for config in spec.compiler_seed_configs
+                if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                and config.config.get(TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY)
+                == source_m_tile
+            ]
+
+        def transferred_seed_pairs(spec: ConfigSpec) -> tuple[Any, list[Any]]:
+            transfer_errors: list[str] = []
+            generation = spec.create_config_generation()
+            transferred = generation.seed_flat_config_pairs(transfer_errors.append)
+            self.assertFalse(transfer_errors)
+            for flat, normalized in transferred:
+                self.assertEqual(generation.unflatten([*flat]), normalized)
+            return generation, transferred
+
+        def seed_pipeline(
+            bound: Any,
+            source_m_tile: int,
+            compatible_source_m_tiles: set[int],
+            *,
+            clear_cluster_constraints: bool = False,
+            expected_block_k: int | None = None,
+            compile_default: bool = False,
+        ) -> tuple[ConfigSpec, list[helion.Config], helion.Config, Any, list[Any]]:
+            spec = bound.config_spec
+            self.assertTrue(spec.cute_tcgen05_search_enabled)
+            grouped = [
+                config
+                for config in spec.compiler_seed_configs
+                if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            ]
+            self.assertLessEqual(len(grouped), 8)
+            self.assertEqual(
+                {
+                    config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY]
+                    for config in grouped
+                },
+                compatible_source_m_tiles,
+            )
+            self.assertIn(
+                CuteTcgen05GroupedWorklistHeuristic.name,
+                spec.autotuner_heuristics,
+            )
+            seeds = grouped_seeds(spec, source_m_tile)
+            self.assertTrue(seeds)
+            if expected_block_k is not None:
+                self.assertTrue(
+                    all(
+                        cast("list[int]", seed.config["block_sizes"])[2]
+                        == expected_block_k
+                        for seed in seeds
+                    )
+                )
+            if clear_cluster_constraints:
+                spec._cute_tcgen05_config.cluster_m2_search_constraints = None
+            generation, transferred = transferred_seed_pairs(spec)
+            self.assertGreaterEqual(len(transferred), len(seeds))
+            promoted = spec.compiler_default_config
+            self.assertIsNotNone(promoted)
+            assert promoted is not None
+            self.assertEqual(promoted, seeds[0])
+            self.assertIn(
+                generation.canonicalize_flat(generation.flatten(promoted)),
+                transferred,
+            )
+            effective = spec.default_config()
+            self.assertEqual(
+                effective.config["block_sizes"], promoted.config["block_sizes"]
+            )
+            if compile_default:
+                self.assertTrue(
+                    callable(bound.compile_config(effective, allow_print=False))
+                )
+            return spec, seeds, promoted, effective, transferred
+
+        compatible_source_m_tiles = {
+            32: {32},
+            224: {32, 224},
+            256: {32, 256},
+        }
+        bounds = []
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            for source_m_tile, b_major in (
+                (32, "k"),
+                (32, "n"),
+                (224, "k"),
+                (224, "n"),
+                (256, "k"),
+                (256, "n"),
+            ):
+                with self.subTest(source_m_tile=source_m_tile, b_major=b_major):
+                    bound = unannotated_packing_kernel.bind(
+                        make_args(source_m_tile, b_major)
+                    )
+                    bounds.append(bound)
+                    expect_cluster2 = source_m_tile in (224, 256)
+                    spec, _seeds, promoted, effective, transferred = seed_pipeline(
+                        bound,
+                        source_m_tile,
+                        compatible_source_m_tiles[source_m_tile],
+                        clear_cluster_constraints=expect_cluster2,
+                        compile_default=True,
+                    )
+                    for _flat, normalized in transferred:
+                        normalized_source_m_tile = normalized.config.get(
+                            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+                        )
+                        if normalized_source_m_tile in (224, 256):
+                            self.assertEqual(
+                                normalized.config["tcgen05_cluster_m"],
+                                2,
+                            )
+                        elif normalized_source_m_tile == 32:
+                            self.assertEqual(
+                                normalized.config["tcgen05_cluster_m"],
+                                1,
+                            )
+                    self.assertIsNot(effective, promoted)
+                    self.assertGreater(len(effective.config), len(promoted.config))
+                    self.assertEqual(
+                        effective.config[
+                            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
+                        ],
+                        source_m_tile,
+                    )
+                    self.assertEqual(
+                        effective.config["block_sizes"],
+                        promoted.config["block_sizes"],
+                    )
+                    self.assertEqual(
+                        cast("list[int]", effective.config["block_sizes"])[:2],
+                        [256, 128],
+                    )
+                    if expect_cluster2:
+                        self.assertIsNone(
+                            spec._cute_tcgen05_config.cluster_m2_search_constraints
+                        )
+                        self.assertEqual(promoted.config["tcgen05_cluster_m"], 2)
+                        self.assertEqual(effective.config["tcgen05_cluster_m"], 2)
+
+            mutable_args = make_args(224, "k")
+            original_worklist = mutable_args[2].clone()
+            original_bound = unannotated_packing_kernel.bind(mutable_args)
+            self.assertIs(original_bound, bounds[2])
+            compact_extents = (32, 32, 32, 32, 32, 1184)
+            compact_rows = []
+            start = 0
+            for group, extent in enumerate(compact_extents):
+                compact_rows.append([group, start, extent, extent])
+                start += extent
+            mutable_args[2].copy_(mutable_args[2].new_tensor(compact_rows))
+            compact_bound = unannotated_packing_kernel.bind(mutable_args)
+            self.assertIsNot(compact_bound, original_bound)
+            seed_pipeline(compact_bound, 32, {32})
+            selected = helion.Config(block_sizes=[256, 128, 64])
+            with patch.object(
+                compact_bound,
+                "autotune",
+                return_value=selected,
+            ) as rebound_autotune:
+                self.assertIs(
+                    original_bound.autotune(mutable_args, force=False),
+                    selected,
+                )
+            rebound_autotune.assert_called_once_with(
+                mutable_args,
+                force=False,
+            )
+            original_output = mutable_args[0]
+            compact_output = mutable_args[1]
+            original_bound._run = lambda *_args: original_output
+            compact_bound._run = lambda *_args: compact_output
+            self.assertIs(original_bound(*mutable_args), compact_output)
+            mutable_args[2].copy_(original_worklist)
+            self.assertIs(
+                unannotated_packing_kernel.bind(mutable_args),
+                original_bound,
+            )
+            self.assertIs(compact_bound(*mutable_args), original_output)
+
+            dynamic_kernel = helion.kernel(
+                unannotated_packing_kernel.fn,
+                backend="cute",
+                static_shapes=False,
+            )
+            aliased_args = make_args(224, "k")
+            aliased_worklist = aliased_args[2]
+            aliased_args = (*aliased_args[:3], aliased_worklist)
+            aliased_bound = dynamic_kernel.bind(aliased_args)
+            self.assertEqual(
+                grouped_seeds(aliased_bound.config_spec, 224),
+                [],
+            )
+            compact_worklist = cast("torch.Tensor", aliased_worklist).new_tensor(
+                compact_rows
+            )
+            dealiased_args = (
+                aliased_args[0],
+                aliased_args[1],
+                compact_worklist,
+                aliased_worklist,
+            )
+            dealiased_bound = dynamic_kernel.bind(dealiased_args)
+            self.assertIsNot(dealiased_bound, aliased_bound)
+            self.assertTrue(grouped_seeds(dealiased_bound.config_spec, 32))
+            restored_args = (
+                aliased_args[0],
+                aliased_args[1],
+                aliased_worklist.clone(),
+                aliased_worklist,
+            )
+            restored_bound = dynamic_kernel.bind(restored_args)
+            self.assertIsNot(restored_bound, dealiased_bound)
+            self.assertTrue(grouped_seeds(restored_bound.config_spec, 224))
+            aliased_output = aliased_args[0]
+            dealiased_output = dealiased_args[1]
+            restored_output = restored_args[2]
+            aliased_bound._run = lambda *_args: aliased_output
+            dealiased_bound._run = lambda *_args: dealiased_output
+            restored_bound._run = lambda *_args: restored_output
+            self.assertIs(dynamic_kernel(*aliased_args), aliased_output)
+            self.assertIsNotNone(dynamic_kernel._prepared_call)
+            self.assertEqual(len(dynamic_kernel._dispatch_cache), 1)
+            self.assertIs(dynamic_kernel(*dealiased_args), dealiased_output)
+            self.assertIsNotNone(dynamic_kernel._prepared_call)
+            self.assertEqual(len(dynamic_kernel._dispatch_cache), 2)
+            self.assertIs(dynamic_kernel(*restored_args), restored_output)
+            self.assertIsNotNone(dynamic_kernel._prepared_call)
+            self.assertEqual(len(dynamic_kernel._dispatch_cache), 3)
+
+            renamed_args = make_args(224, "n")
+            plain_kernel = helion.kernel(
+                _grouped_worklist_kernel_body,
+                backend="cute",
+                static_shapes=False,
+            )
+            plain_bound = plain_kernel.bind(renamed_args[:3])
+            self.assertIsNone(plain_bound.config_spec.compiler_default_config)
+            self.assertEqual(
+                grouped_seeds(plain_bound.config_spec, 224),
+                grouped_seeds(bounds[3].config_spec, 224),
+            )
+            b200_256_bound = bounds[-1]
+            self.assertIsNotNone(b200_256_bound.config_spec.compiler_default_config)
+
+            for source_m_tile in (32, 256):
+                with self.subTest(source_m_tile=source_m_tile, k=192):
+                    bound = unannotated_packing_kernel.bind(
+                        make_args(source_m_tile, "n", k=192)
+                    )
+                    seed_pipeline(
+                        bound,
+                        source_m_tile,
+                        compatible_source_m_tiles[source_m_tile],
+                        expected_block_k=64,
+                        compile_default=True,
+                    )
+
+            for source_m_tile in (224, 256):
+                with self.subTest(
+                    source_m_tile=source_m_tile,
+                    packed_m="non_aligned",
+                ):
+                    exact_packed_m = 6 * source_m_tile + 1
+                    bound = unannotated_packing_kernel.bind(
+                        make_args(
+                            source_m_tile,
+                            "n",
+                            packed_m=exact_packed_m,
+                        )
+                    )
+                    self.assertEqual(
+                        [
+                            config
+                            for config in bound.config_spec.compiler_seed_configs
+                            if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+                            == TCGEN05_GROUPED_MODE_WORKLIST_NM
+                        ],
+                        [],
+                    )
+                    host_function = bound.host_function
+                    self.assertIsNotNone(host_function)
+                    assert host_function is not None
+                    analysis = analyze_tcgen05_grouped_worklist(
+                        bound.env,
+                        host_function.device_ir,
+                        bound.config_spec.matmul_facts[0],
+                    )
+                    self.assertIsNotNone(analysis)
+                    assert analysis is not None
+                    self.assertEqual(
+                        analysis.seed_facts.packed_m_hint,
+                        exact_packed_m,
+                    )
+
+        source32_host = bounds[0].host_function
+        self.assertIsNotNone(source32_host)
+        assert source32_host is not None
+        source32_analysis = analyze_tcgen05_grouped_worklist(
+            bounds[0].env,
+            source32_host.device_ir,
+            bounds[0].config_spec.matmul_facts[0],
+        )
+        self.assertIsNotNone(source32_analysis)
+        assert source32_analysis is not None
+        self.assertEqual(source32_analysis.seed_facts.packed_m_hint, 6 * 32)
+        with (
+            bounds[1].env,
+            self.assertRaisesRegex(
+                AssertionError,
+                "must use the provided compile environment",
+            ),
+        ):
+            analyze_tcgen05_grouped_worklist(
+                bounds[0].env,
+                source32_host.device_ir,
+                bounds[0].config_spec.matmul_facts[0],
+            )
+        with (
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch("helion._hardware.get_hardware_info", return_value=GB300_HARDWARE),
+        ):
+            gb300_bound = unannotated_packing_kernel.bind(make_args(256, "n"))
+        self.assertIs(gb300_bound, b200_256_bound)
+        gb300_seeds = grouped_seeds(gb300_bound.config_spec, 256)
+        self.assertTrue(gb300_seeds)
+        self.assertEqual(
+            gb300_bound.config_spec.compiler_default_config,
+            gb300_seeds[0],
+        )
+        unannotated_packing_kernel.reset()
+        with (
+            torch.inference_mode(),
+            patch_cute_mma_support(),
+            patch(
+                "helion._compiler.autotuner_heuristics.cute."
+                "tcgen05_runtime_n_ptx_compatible",
+                return_value=True,
+            ),
+            patch(
+                "helion._compiler.cute.cutedsl_compat.check_cute_backend_requirements"
+            ),
+            patch(
+                "helion._hardware.get_hardware_info",
+                return_value=BLACKWELL_HARDWARE,
+            ),
+        ):
+            inference_args = make_args(224, "k")
+            inference_bound = unannotated_packing_kernel.bind(inference_args)
+            seed_pipeline(inference_bound, 224, {32, 224})
+            self.assertIs(
+                unannotated_packing_kernel.bind(inference_args),
+                inference_bound,
+            )
+            inference_output = inference_args[0]
+            inference_bound._run = lambda *_args: inference_output
+            self.assertIs(
+                unannotated_packing_kernel(*inference_args),
+                inference_output,
+            )
+            inference_args[2].copy_(inference_args[2].new_tensor(compact_rows))
+            compact_inference_bound = unannotated_packing_kernel.bind(inference_args)
+            self.assertIsNot(compact_inference_bound, inference_bound)
+            seed_pipeline(compact_inference_bound, 32, {32})
+            self.assertIs(
+                unannotated_packing_kernel.bind(inference_args),
+                compact_inference_bound,
+            )
+            compact_inference_output = inference_args[1]
+            compact_inference_bound._run = lambda *_args: compact_inference_output
+            self.assertIs(
+                unannotated_packing_kernel(*inference_args),
+                compact_inference_output,
+            )
+            with (
+                patch(
+                    "helion.runtime.cute.launcher._cuda_stream_capture_context",
+                    return_value=(123, 456),
+                ),
+                self.assertRaisesRegex(
+                    helion.exc.BackendUnsupported,
+                    "inference tensor grouped metadata.*capture",
+                ),
+            ):
+                unannotated_packing_kernel.bind(inference_args)
 
     @onlyBackends(["triton"])
     @skipIfRefEager("Compiler pointwise facts are not collected in ref eager mode")
@@ -6135,8 +8698,14 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             bound = cute_matmul_and_elementwise_store.bind(args)
 
         spec = bound.config_spec
-        self.assertTrue(spec.cute_tcgen05_aux_kernel_detected)
+        # The residual load belongs to a separate elementwise store, not the
+        # matmul epilogue, so no aux-only matmul search axis is productive.
+        self.assertFalse(spec.cute_tcgen05_aux_kernel_detected)
         self.assertFalse(spec.cute_tcgen05_exact_shape_aux_kernel_detected)
+        self.assertNotIn(
+            TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+            {key for key, _count, _is_sequence in spec.flat_key_layout()},
+        )
         self.assertFalse(
             any(
                 config.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
@@ -6172,8 +8741,14 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             bound = cute_matmul_partial_residual.bind(args)
 
         spec = bound.config_spec
-        self.assertTrue(spec.cute_tcgen05_aux_kernel_detected)
+        # The partial rank-2 load is outside the accepted per-subtile epilogue
+        # contract, so codegen cannot use the C-input or placement controls.
+        self.assertFalse(spec.cute_tcgen05_aux_kernel_detected)
         self.assertFalse(spec.cute_tcgen05_exact_shape_aux_kernel_detected)
+        self.assertNotIn(
+            TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+            {key for key, _count, _is_sequence in spec.flat_key_layout()},
+        )
         self.assertFalse(
             any(
                 config.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
@@ -6211,8 +8786,14 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             bound = cute_matmul_scrambled_residual.bind(args)
 
         spec = bound.config_spec
-        self.assertTrue(spec.cute_tcgen05_aux_kernel_detected)
+        # Reordered tile indices are rejected by the same chain analyzer used
+        # at codegen, so they must not widen the aux search surface at bind.
+        self.assertFalse(spec.cute_tcgen05_aux_kernel_detected)
         self.assertFalse(spec.cute_tcgen05_exact_shape_aux_kernel_detected)
+        self.assertNotIn(
+            TCGEN05_AUX_LOAD_PLACEMENT_CONFIG_KEY,
+            {key for key, _count, _is_sequence in spec.flat_key_layout()},
+        )
         self.assertFalse(
             any(
                 config.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -6,6 +6,8 @@ import os
 import pickle
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Callable
+from typing import cast
 import unittest
 from unittest.mock import patch
 
@@ -16,6 +18,9 @@ import torch
 
 import helion
 from helion import exc
+from helion._compiler.autotuner_heuristics.cute import (
+    tcgen05_grouped_worklist_seed_configs,
+)
 from helion._compiler.backend import PallasBackend
 from helion._compiler.backend import TritonBackend
 from helion._compiler.compile_environment import CompileEnvironment
@@ -67,7 +72,7 @@ from helion._compiler.cute.tcgen05_constants import (
 )
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from helion._compiler.cute.tcgen05_constants import (
-    resolve_tcgen05_grouped_worklist_mma_shape,
+    resolve_tcgen05_grouped_worklist_mma_profile,
 )
 from helion._compiler.cute.tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
 from helion._testing import TestCase
@@ -76,6 +81,8 @@ from helion._testing import skipIfXPU
 from helion._testing import skipUnlessCuteAvailable
 from helion.autotuner.config_fragment import EnumFragment
 from helion.autotuner.config_spec import ConfigSpec
+from helion.autotuner.config_spec import LoopOrderSpec
+from helion.autotuner.config_spec import MatmulFact
 import helion.language as hl
 
 if TYPE_CHECKING:
@@ -307,18 +314,48 @@ class TestConfigAPI(TestCase):
         # latter is memoized behind _target_device_capability, mirroring the
         # is_hip / _is_hip pattern where tests mock the public wrapper, not
         # the cached inner query.
-        with patch(
-            "helion.runtime.kernel.target_device_capability", return_value=(9, 0)
+        with (
+            patch(
+                "helion.runtime.kernel.target_device_capability", return_value=(9, 0)
+            ),
+            patch(
+                "helion.runtime.kernel.compiler_promotion_specialization_key",
+                return_value=(),
+            ),
         ):
             sm90_key = device_key_kernel._base_specialization_key((device,))
-        with patch(
-            "helion.runtime.kernel.target_device_capability", return_value=(10, 0)
+        with (
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch(
+                "helion.runtime.kernel.compiler_promotion_specialization_key",
+                return_value=(),
+            ),
         ):
             sm100_key = device_key_kernel._base_specialization_key((device,))
 
         self.assertEqual(sm90_key[-3:], ("cuda", (9, 0), False))
         self.assertEqual(sm100_key[-3:], ("cuda", (10, 0), False))
         self.assertNotEqual(sm90_key, sm100_key)
+
+        promotion = (("synthetic", "NVIDIA B200"),)
+        with (
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch(
+                "helion.runtime.kernel.compiler_promotion_specialization_key",
+                return_value=promotion,
+            ),
+        ):
+            promoted_key = device_key_kernel._base_specialization_key((device,))
+        self.assertEqual(
+            promoted_key[-4:],
+            ("cuda", (10, 0), promotion, False),
+        )
 
     def test_config_constructor_signature_contains_expected_kwargs(self) -> None:
         # Keep this list in sync with public kwargs; removal/rename should fail tests
@@ -1015,6 +1052,46 @@ class TestHardwareConfigSpecRanges(TestCase):
         self.assertEqual(nvidia_spec.store_cache_modifiers.inner.choices, ("",))
 
 
+class TestConfigSpecNormalizedCopy(TestCase):
+    def test_nested_containers_are_copied_without_copying_opaque_leaves(self) -> None:
+        class NonCopyable:
+            def __deepcopy__(self, memo: object) -> None:
+                raise AssertionError("opaque config leaves must not be deep-copied")
+
+        spec = ConfigSpec(
+            backend=TritonBackend(),
+            user_defined_tunables={"metadata": EnumFragment((None,))},
+        )
+        spec.loop_orders.append(LoopOrderSpec([0, 1]))
+        opaque = NonCopyable()
+        tensor = torch.empty(0)
+        requested = helion.Config(
+            loop_orders=[[0, 1]],
+            metadata={"nested": ([opaque, tensor],)},
+        )
+        requested_values = dict(requested.config)
+
+        normalized = spec.normalized_config(requested)
+
+        self.assertIsNot(normalized, requested)
+        self.assertEqual(requested.config, requested_values)
+        self.assertEqual(normalized.config["num_warps"], 4)
+        self.assertEqual(normalized.config["num_stages"], 1)
+        self.assertEqual(normalized.config["pid_type"], "flat")
+        normalized.loop_orders[0][0] = 1
+        normalized_metadata = cast("dict[str, object]", normalized["metadata"])
+        normalized_tuple = cast("tuple[object, ...]", normalized_metadata["nested"])
+        normalized_nested = cast("list[object]", normalized_tuple[0])
+        normalized_nested.append("normalized-only")
+        requested_metadata = cast("dict[str, object]", requested["metadata"])
+        requested_tuple = cast("tuple[object, ...]", requested_metadata["nested"])
+        requested_nested = cast("list[object]", requested_tuple[0])
+        self.assertEqual(requested.loop_orders, [[0, 1]])
+        self.assertEqual(len(requested_nested), 2)
+        self.assertIs(normalized_nested[0], opaque)
+        self.assertIs(normalized_nested[1], tensor)
+
+
 class TestCuteTcgen05ConfigSpecSplit(TestCase):
     @staticmethod
     def _make_cute_tcgen05_spec():
@@ -1040,21 +1117,130 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         from helion.autotuner.config_spec import BlockSizeSpec
         from helion.autotuner.config_spec import ConfigSpec
 
+        # Config order is [N, K, M], while semantic MMA axes are M=2, N=0, K=1.
         spec = ConfigSpec(backend=CuteBackend())
         spec.cute_tcgen05_search_enabled = True
         for block_id, max_size in enumerate((256, 128, 256)):
             spec.block_sizes.append(
-                BlockSizeSpec(block_id=block_id, size_hint=4096, max_size=max_size)
+                BlockSizeSpec(
+                    block_id=block_id,
+                    size_hint=4096,
+                    max_size=max_size,
+                )
             )
         spec.register_cute_tcgen05_mma_analysis(
             m_block_id=2,
             n_block_id=0,
             k_block_id=1,
+            compile_time_static_extents=(4096, 4096, 4096),
             input_dtype=torch.bfloat16,
             has_leading_passthrough=False,
             explicit_epi_tile_compatible=True,
         )
         return spec
+
+    @staticmethod
+    def _register_default_cute_tcgen05_mma_analysis(spec):
+        spec.register_cute_tcgen05_mma_analysis(
+            m_block_id=0,
+            n_block_id=1,
+            k_block_id=2,
+            compile_time_static_extents=(4096, 4096, 4096),
+            input_dtype=torch.bfloat16,
+            has_leading_passthrough=False,
+            explicit_epi_tile_compatible=True,
+        )
+        return spec
+
+    @staticmethod
+    def _add_cute_tcgen05_matmul_fact(
+        spec,
+        *,
+        static_k: int,
+        k_block_id: int = 2,
+    ) -> None:
+        spec.matmul_facts.append(
+            MatmulFact(
+                lhs_ndim=2,
+                rhs_ndim=3,
+                m_block_id=0,
+                n_block_id=1,
+                k_block_id=k_block_id,
+                static_m=256,
+                static_n=None,
+                static_k=static_k,
+                lhs_dtype=torch.bfloat16,
+                rhs_dtype=torch.bfloat16,
+            )
+        )
+
+    @staticmethod
+    def _grouped_worklist_config(
+        *,
+        block_sizes: tuple[int, int, int] | list[int] = (256, 128, 64),
+        source_m_tile: int = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        cluster_m: int = 2,
+        **overrides: Any,
+    ) -> helion.Config:
+        values: dict[str, Any] = {
+            "block_sizes": list(block_sizes),
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": cluster_m,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_grouped_mode": TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            "tcgen05_grouped_worklist_source_m_tile": source_m_tile,
+        }
+        values.update(overrides)
+        return helion.Config(**values)
+
+    def _grouped_worklist_generation(
+        self,
+        spec: Any,
+        *,
+        source_m_tile: int,
+        cluster_m: int = 2,
+    ) -> tuple[Any, list[Any], int, int, int]:
+        from helion.autotuner.config_generation import ConfigGeneration
+
+        spec.compiler_seed_configs = [
+            self._grouped_worklist_config(
+                source_m_tile=source_m_tile,
+                cluster_m=cluster_m,
+            )
+        ]
+        generation = ConfigGeneration(spec)
+        [(flat, _normalized)] = generation.seed_flat_config_pairs()
+        _m_flat, n_flat, k_flat = generation.block_size_indices[:3]
+        [cluster_flat], _ = generation._key_to_flat_indices["tcgen05_cluster_m"]
+        return generation, flat, n_flat, k_flat, cluster_flat
+
+    def _constrained_grouped_worklist_spec(self, smem_budget: int) -> Any:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        spec._cute_tcgen05_config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=2,
+                per_cta_smem_budget_bytes=smem_budget,
+            )
+        )
+        return spec
+
+    @staticmethod
+    def _enum_fragment(fragment: object) -> EnumFragment:
+        assert isinstance(fragment, EnumFragment)
+        return fragment
+
+    def test_normalized_config_drops_none_core_values(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+        requested = helion.Config.from_dict(
+            {"block_sizes": [256, 128, 128], "xcd_remap": None}
+        )
+
+        normalized = spec.normalized_config(requested)
+
+        self.assertNotIn("xcd_remap", normalized.config)
+        self.assertIsNone(requested.config["xcd_remap"])
 
     def test_grouped_static_seed_representation(self) -> None:
         from helion.autotuner.config_generation import ConfigGeneration
@@ -1122,7 +1308,10 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             wrong_type_config.config[
                 TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY
             ] = invalid_value
-            with self.assertRaisesRegex(exc.InvalidConfig, "source_m_tile"):
+            with self.assertRaisesRegex(
+                exc.InvalidConfig,
+                r"source_m_tile.*\(32, 224, 256\)",
+            ):
                 spec.normalize(wrong_type_config)
 
         invalid = helion.Config(
@@ -1141,122 +1330,116 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
     def test_grouped_runtime_direct_normalization(self) -> None:
         spec = self._make_cute_tcgen05_spec()
         spec.target_device_capability = (10, 0)
+
+        def grouped_config(
+            *,
+            block_k: int = 64,
+            grouped_mode: str = TCGEN05_GROUPED_MODE_WORKLIST_NM,
+            runtime_direct: bool = True,
+            clc: bool = False,
+            static_signature: bool = False,
+        ) -> helion.Config:
+            config = helion.Config(
+                block_sizes=[256, 128, block_k],
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=grouped_mode,
+                tcgen05_grouped_runtime_direct=runtime_direct,
+                **(
+                    {
+                        "tcgen05_strategy": "role_local_with_scheduler",
+                        "tcgen05_warp_spec_scheduler_warps": 1,
+                        "tcgen05_persistence_model": "clc_persistent",
+                    }
+                    if clc
+                    else {}
+                ),
+            )
+            if static_signature:
+                config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
+                    1,
+                    256,
+                    128,
+                    64,
+                ]
+            return config
+
+        def rejected_and_repaired(
+            factory: Callable[[], helion.Config], message: str
+        ) -> helion.Config:
+            with self.assertRaisesRegex(exc.InvalidConfig, message):
+                spec.normalize(factory())
+            repaired = factory()
+            spec.normalize(repaired, _fix_invalid=True)
+            return repaired
+
         for enabled in (False, True):
             with self.subTest(enabled=enabled):
-                config = helion.Config(
-                    block_sizes=[256, 128, 128],
-                    pid_type="persistent_interleaved",
-                    tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-                    tcgen05_grouped_runtime_direct=enabled,
-                )
+                config = grouped_config(block_k=128, runtime_direct=enabled)
                 spec.normalize(config)
                 self.assertIs(
                     config.config[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY],
                     enabled,
                 )
 
-        invalid = helion.Config(
-            block_sizes=[256, 128, 128],
-            pid_type="persistent_interleaved",
-            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-            tcgen05_grouped_runtime_direct=True,
-        )
+        invalid = grouped_config(block_k=128)
         invalid.config[TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY] = 1
         with self.assertRaisesRegex(exc.InvalidConfig, "must be a boolean"):
             spec.normalize(invalid)
 
-        def unsupported_runtime_direct(
-            *,
-            grouped_mode: str = TCGEN05_GROUPED_MODE_DYNAMIC,
-            static_signature: bool = False,
-        ) -> helion.Config:
-            config = helion.Config(
-                block_sizes=[256, 128, 64],
-                pid_type="persistent_interleaved",
-                tcgen05_grouped_mode=grouped_mode,
-                tcgen05_grouped_runtime_direct=True,
-            )
-            if static_signature:
-                config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
-                    1,
-                    256,
-                    128,
-                    64,
-                ]
-            return config
-
         unsupported_cases = (
-            (TCGEN05_GROUPED_MODE_DYNAMIC, False),
-            (TCGEN05_GROUPED_MODE_WORKLIST_NM, True),
+            {"grouped_mode": TCGEN05_GROUPED_MODE_DYNAMIC},
+            {"static_signature": True},
         )
-        for grouped_mode, static_signature in unsupported_cases:
-            unsupported = unsupported_runtime_direct(
-                grouped_mode=grouped_mode,
-                static_signature=static_signature,
-            )
-            with (
-                self.subTest(config=unsupported.config),
-                self.assertRaisesRegex(
-                    exc.InvalidConfig,
+        for case in unsupported_cases:
+            with self.subTest(unsupported=case):
+                repaired = rejected_and_repaired(
+                    lambda case=case: grouped_config(**case),
                     "must not silently fall back",
-                ),
-            ):
-                spec.normalize(unsupported)
-            repaired = unsupported_runtime_direct(
-                grouped_mode=grouped_mode,
-                static_signature=static_signature,
-            )
-            spec.normalize(repaired, _fix_invalid=True)
+                )
             self.assertNotIn(
                 TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
                 repaired.config,
             )
 
-        def clc_config(
-            *,
-            grouped_mode: str = TCGEN05_GROUPED_MODE_WORKLIST_NM,
-            runtime_direct: bool = True,
-            static_signature: bool = False,
-        ) -> helion.Config:
-            config = helion.Config(
-                block_sizes=[256, 128, 64],
-                pid_type="persistent_interleaved",
-                tcgen05_grouped_mode=grouped_mode,
-                tcgen05_grouped_runtime_direct=runtime_direct,
-                tcgen05_strategy="role_local_with_scheduler",
-                tcgen05_warp_spec_scheduler_warps=1,
-                tcgen05_persistence_model="clc_persistent",
+        for fix_invalid in (False, True):
+            valid_clc = grouped_config(clc=True)
+            spec.normalize(valid_clc, _fix_invalid=fix_invalid)
+            self.assertEqual(
+                valid_clc.config["tcgen05_persistence_model"], "clc_persistent"
             )
-            if static_signature:
-                config.config[TCGEN05_GROUPED_STATIC_PROBLEM_SIGNATURE_CONFIG_KEY] = [
-                    1,
-                    256,
-                    128,
-                    64,
-                ]
-            return config
+            self.assertEqual(valid_clc.config["tcgen05_warp_spec_scheduler_warps"], 1)
 
-        valid_clc = clc_config()
-        spec.normalize(valid_clc)
-        self.assertEqual(
-            valid_clc.config["tcgen05_persistence_model"], "clc_persistent"
+        invalid_clc_cases = (
+            {"runtime_direct": False},
+            {"grouped_mode": TCGEN05_GROUPED_MODE_DYNAMIC},
+            {"static_signature": True},
         )
-        self.assertEqual(valid_clc.config["tcgen05_warp_spec_scheduler_warps"], 1)
-
-        invalid_clc_configs = (
-            clc_config(runtime_direct=False),
-            clc_config(grouped_mode=TCGEN05_GROUPED_MODE_DYNAMIC),
-            clc_config(static_signature=True),
-        )
-        for invalid_clc in invalid_clc_configs:
-            with (
-                self.subTest(config=invalid_clc.config),
-                self.assertRaisesRegex(
-                    exc.InvalidConfig,
+        for case in invalid_clc_cases:
+            with self.subTest(invalid_clc=case):
+                repaired_clc = rejected_and_repaired(
+                    lambda case=case: grouped_config(clc=True, **case),
                     "exact one-record-per-cluster tile table",
-                ),
-            ):
-                spec.normalize(invalid_clc)
+                )
+            self.assertNotEqual(
+                repaired_clc.config.get("tcgen05_persistence_model"),
+                "clc_persistent",
+            )
+
+        repaired_with_reservation = grouped_config(clc=True, runtime_direct=False)
+        repaired_with_reservation.config[
+            TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+        ] = 52
+        spec.normalize(repaired_with_reservation, _fix_invalid=True)
+        self.assertNotEqual(
+            repaired_with_reservation.config.get("tcgen05_persistence_model"),
+            "clc_persistent",
+        )
+        self.assertEqual(
+            repaired_with_reservation.config[
+                TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+            ],
+            52,
+        )
 
     def test_grouped_worklist_panel_requires_runtime_direct(self) -> None:
         spec = self._make_cute_tcgen05_spec()
@@ -1332,23 +1515,20 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                 self.assertEqual(generation.unflatten(flat).config[key], expected)
 
     def test_grouped_worklist_one_cta_accepts_bk128_ab5(self) -> None:
-        spec = self._make_cute_tcgen05_spec()
-        config = helion.Config(
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        config = self._grouped_worklist_config(
             block_sizes=[256, 128, 128],
+            source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+            cluster_m=1,
             num_stages=7,
             num_warps=8,
-            pid_type="persistent_interleaved",
-            tcgen05_cluster_m=1,
-            tcgen05_cluster_n=1,
             tcgen05_ab_stages=5,
             tcgen05_acc_stages=2,
             tcgen05_c_stages=2,
             tcgen05_num_epi_warps=4,
             tcgen05_consumer_regs=256,
-            tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-            tcgen05_grouped_worklist_source_m_tile=(
-                TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
-            ),
         )
 
         spec.normalize(config)
@@ -1363,6 +1543,7 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             m_block_id=0,
             n_block_id=1,
             k_block_id=2,
+            compile_time_static_extents=(4096, 4096, 4096),
             input_dtype=torch.bfloat16,
             has_leading_passthrough=False,
             explicit_epi_tile_compatible=True,
@@ -1425,6 +1606,258 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         positional_decoy.config["block_sizes"] = [256, 128, 64]
         with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
             spec.normalize(positional_decoy)
+
+    def test_grouped_worklist_search_fix_projects_semantic_tile(self) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        cases = (
+            (32, 1, [128, 256, 32], [256, 128, 64], 1),
+            (32, 2, [128, 256, 256], [256, 128, 128], 2),
+            # BK=96 is equidistant; the deterministic tie breaks toward 64.
+            (224, 1, [128, 256, 96], [256, 128, 64], 2),
+            # Exact canary family: a BN neighbor must return to logical BN=128.
+            (224, 2, [256, 256, 128], [256, 128, 128], 2),
+            (256, 1, [64, 64, 256], [256, 128, 128], 2),
+        )
+        for source_m_tile, cluster_m, block_sizes, expected, expected_cluster in cases:
+            with self.subTest(
+                source_m_tile=source_m_tile,
+                cluster_m=cluster_m,
+                block_sizes=block_sizes,
+            ):
+                config = self._grouped_worklist_config(
+                    block_sizes=[*block_sizes],
+                    source_m_tile=source_m_tile,
+                    cluster_m=cluster_m,
+                )
+
+                spec._cute_tcgen05_config.fix_search_config(config.config)
+
+                self.assertEqual(config.block_sizes[:3], expected)
+                self.assertEqual(config.config["tcgen05_cluster_m"], expected_cluster)
+
+    def test_grouped_worklist_search_fix_rejects_no_divisible_block_k(self) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        spec.allow_tcgen05_cluster_m2_search(static_k=96)
+        config = self._grouped_worklist_config(
+            block_sizes=[256, 256, 128],
+            source_m_tile=224,
+        )
+
+        with self.assertRaisesRegex(exc.InvalidConfig, "no supported block_k"):
+            spec.normalize(config, _fix_invalid=True)
+
+    def test_grouped_worklist_config_generation_canonicalizes_neighbors(
+        self,
+    ) -> None:
+        cases = (
+            (32, 1, 256, 32, 1, 64),
+            (32, 2, 256, 256, 2, 128),
+            (224, 1, 256, 32, 2, 64),
+            (224, 2, 256, 128, 2, 128),
+            (256, 1, 64, 256, 2, 128),
+        )
+        for (
+            source_m_tile,
+            sampled_cluster,
+            sampled_bn,
+            sampled_bk,
+            expected_cluster,
+            expected_bk,
+        ) in cases:
+            with self.subTest(
+                source_m_tile=source_m_tile,
+                sampled_cluster=sampled_cluster,
+                sampled_bk=sampled_bk,
+            ):
+                spec = self._register_default_cute_tcgen05_mma_analysis(
+                    self._make_cute_tcgen05_spec()
+                )
+                generation, flat, n_flat, k_flat, cluster_flat = (
+                    self._grouped_worklist_generation(
+                        spec,
+                        source_m_tile=source_m_tile,
+                    )
+                )
+                neighbor = [*flat]
+                neighbor[n_flat] = sampled_bn
+                neighbor[k_flat] = sampled_bk
+                neighbor[cluster_flat] = sampled_cluster
+
+                canonical_flat, normalized = generation.canonicalize_flat(neighbor)
+
+                self.assertEqual(normalized.block_sizes[:3], [256, 128, expected_bk])
+                self.assertEqual(
+                    normalized.config["tcgen05_cluster_m"], expected_cluster
+                )
+                self.assertEqual(canonical_flat[n_flat], 128)
+                self.assertEqual(canonical_flat[k_flat], expected_bk)
+                self.assertEqual(canonical_flat[cluster_flat], expected_cluster)
+
+    def test_grouped_worklist_config_generation_uses_fact_static_k(self) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        self._add_cute_tcgen05_matmul_fact(spec, static_k=192)
+        # A fact for another semantic K block must not constrain this MMA.
+        self._add_cute_tcgen05_matmul_fact(
+            spec,
+            static_k=96,
+            k_block_id=1,
+        )
+        self.assertIsNone(spec._cute_tcgen05_config.cluster_m2_search_constraints)
+        generation, flat, _n_flat, k_flat, _cluster_flat = (
+            self._grouped_worklist_generation(
+                spec,
+                source_m_tile=224,
+            )
+        )
+        neighbor = [*flat]
+        neighbor[k_flat] = 128
+
+        canonical_flat, normalized = generation.canonicalize_flat(neighbor)
+
+        self.assertEqual(normalized.block_sizes[:3], [256, 128, 64])
+        self.assertEqual(canonical_flat[k_flat], 64)
+
+    def test_grouped_worklist_config_generation_uses_aliased_fact_static_k(
+        self,
+    ) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        k_spec = spec.block_sizes[2]
+        k_spec.block_ids.append(7)
+        spec.block_sizes[2] = k_spec
+        self._add_cute_tcgen05_matmul_fact(spec, static_k=192, k_block_id=7)
+        generation, flat, _n_flat, k_flat, _cluster_flat = (
+            self._grouped_worklist_generation(
+                spec,
+                source_m_tile=224,
+            )
+        )
+        neighbor = [*flat]
+        neighbor[k_flat] = 128
+
+        canonical_flat, normalized = generation.canonicalize_flat(neighbor)
+
+        self.assertEqual(normalized.block_sizes[:3], [256, 128, 64])
+        self.assertEqual(canonical_flat[k_flat], 64)
+
+    def test_grouped_worklist_fact_static_k_rejects_without_constraints(
+        self,
+    ) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        self._add_cute_tcgen05_matmul_fact(spec, static_k=96)
+        self.assertIsNone(spec._cute_tcgen05_config.cluster_m2_search_constraints)
+        config = self._grouped_worklist_config(source_m_tile=224)
+
+        with self.assertRaisesRegex(exc.InvalidConfig, "no supported block_k"):
+            spec.normalize(config, _fix_invalid=True)
+
+    def test_grouped_worklist_config_generation_respects_k_constraints(
+        self,
+    ) -> None:
+        cases = (
+            # BK128 does not divide K192, so choose the exact BK64 profile.
+            (192, None, False, 224, 2, 1, 128, 2, 64),
+            # Generic max-K-tile limits must not rewrite a valid one-CTA BK64.
+            (32768, None, False, 32, 1, 1, 64, 1, 64),
+            # Generic edge-tail policy must not select a non-dividing worklist BK.
+            (192, None, True, 224, 2, 2, 128, 2, 64),
+            # The source-32 two-CTA profile owns the same exact-divisibility rule.
+            (192, None, True, 32, 2, 2, 128, 2, 64),
+            # Generic constraints and matching semantic facts are intersected.
+            (256, 192, False, 224, 2, 2, 128, 2, 64),
+        )
+        for (
+            static_k,
+            fact_static_k,
+            allow_edge_k_tail_family,
+            source_m_tile,
+            seed_cluster,
+            sampled_cluster,
+            sampled_bk,
+            expected_cluster,
+            expected_bk,
+        ) in cases:
+            with self.subTest(
+                static_k=static_k,
+                allow_edge_k_tail_family=allow_edge_k_tail_family,
+                source_m_tile=source_m_tile,
+                sampled_cluster=sampled_cluster,
+            ):
+                spec = self._register_default_cute_tcgen05_mma_analysis(
+                    self._make_cute_tcgen05_spec()
+                )
+                if fact_static_k is not None:
+                    self._add_cute_tcgen05_matmul_fact(
+                        spec,
+                        static_k=fact_static_k,
+                    )
+                spec.allow_tcgen05_cluster_m2_search(
+                    static_k=static_k,
+                    allow_edge_k_tail_family=allow_edge_k_tail_family,
+                )
+                generation, flat, n_flat, k_flat, cluster_flat = (
+                    self._grouped_worklist_generation(
+                        spec,
+                        source_m_tile=source_m_tile,
+                        cluster_m=seed_cluster,
+                    )
+                )
+                neighbor = [*flat]
+                neighbor[n_flat] = 256
+                neighbor[k_flat] = sampled_bk
+                neighbor[cluster_flat] = sampled_cluster
+
+                canonical_flat, normalized = generation.canonicalize_flat(neighbor)
+
+                self.assertEqual(normalized.block_sizes[:3], [256, 128, expected_bk])
+                self.assertEqual(
+                    normalized.config["tcgen05_cluster_m"], expected_cluster
+                )
+                self.assertEqual(canonical_flat[n_flat], 128)
+                self.assertEqual(canonical_flat[k_flat], expected_bk)
+                self.assertEqual(canonical_flat[cluster_flat], expected_cluster)
+
+    def test_grouped_worklist_two_cta_seed_survives_without_generic_constraints(
+        self,
+    ) -> None:
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
+        )
+        self.assertIsNone(spec._cute_tcgen05_config.cluster_m2_search_constraints)
+
+        for source_m_tile in (
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+        ):
+            with self.subTest(source_m_tile=source_m_tile):
+                generation, flat, _n_flat, _k_flat, _cluster_flat = (
+                    self._grouped_worklist_generation(
+                        spec,
+                        source_m_tile=source_m_tile,
+                    )
+                )
+                [seed] = spec.compiler_seed_configs
+                spec.compiler_default_config = seed
+
+                effective = spec.default_config()
+                self.assertEqual(effective.config["tcgen05_cluster_m"], 2)
+                self.assertEqual(effective.config["block_sizes"][:3], [256, 128, 64])
+
+                [(seed_flat, normalized)] = generation.seed_flat_config_pairs()
+                self.assertEqual(seed_flat, flat)
+                self.assertEqual(normalized.config["tcgen05_cluster_m"], 2)
+                unflattened = generation.unflatten([*flat])
+                self.assertEqual(unflattened.config["tcgen05_cluster_m"], 2)
+                self.assertEqual(unflattened.config["block_sizes"][:3], [256, 128, 64])
 
     def test_tcgen05_search_fields_do_not_leak_to_other_backends(self) -> None:
         from helion._compiler.backend import MetalBackend
@@ -1701,39 +2134,40 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
 
     def test_deep_ab_stage_mode_envelopes_and_stage7_roundtrip(self) -> None:
         def selected_config() -> helion.Config:
-            return helion.Config(
-                block_sizes=[256, 128, 64],
+            return self._grouped_worklist_config(
                 pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-                tcgen05_cluster_m=2,
+                num_stages=7,
+                num_warps=8,
                 tcgen05_ab_stages=7,
-                **{
-                    TCGEN05_GROUPED_MODE_CONFIG_KEY: (TCGEN05_GROUPED_MODE_WORKLIST_NM),
-                },
+                tcgen05_acc_stages=2,
+                tcgen05_c_stages=2,
+                tcgen05_num_epi_warps=4,
+                tcgen05_consumer_regs=240,
             )
 
-        spec = self._make_cute_tcgen05_spec()
-        grouped_ab4 = helion.Config(
-            block_sizes=[128, 64, 64],
-            pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            tcgen05_ab_stages=4,
-            **{
-                TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_DYNAMIC,
-            },
+        def dynamic_config(
+            ab_stages: int, c_stages: int | None = None
+        ) -> helion.Config:
+            config = helion.Config(
+                block_sizes=[128, 64, 64],
+                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+                tcgen05_ab_stages=ab_stages,
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_DYNAMIC,
+            )
+            if c_stages is not None:
+                config.config["tcgen05_c_stages"] = c_stages
+            return config
+
+        spec = self._register_default_cute_tcgen05_mma_analysis(
+            self._make_cute_tcgen05_spec()
         )
+        grouped_ab4 = dynamic_config(4)
         spec.normalize(grouped_ab4)
         grouped_ab4.config["tcgen05_ab_stages"] = 4.0
         with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
             spec.normalize(grouped_ab4)
 
-        grouped_ab8 = helion.Config(
-            block_sizes=[128, 64, 64],
-            pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            tcgen05_ab_stages=8,
-            tcgen05_c_stages=4,
-            **{
-                TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_DYNAMIC,
-            },
-        )
+        grouped_ab8 = dynamic_config(8, 4)
         spec.normalize(grouped_ab8)
         self.assertEqual(grouped_ab8.config["tcgen05_ab_stages"], 8)
         minimized_ab8 = grouped_ab8.minimize(spec)
@@ -1742,15 +2176,7 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         self.assertEqual(minimized_ab8.config["tcgen05_c_stages"], 4)
 
         for ab_stages, c_stages in ((8, 2), (4, 4)):
-            mismatched = helion.Config(
-                block_sizes=[128, 64, 64],
-                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-                tcgen05_ab_stages=ab_stages,
-                tcgen05_c_stages=c_stages,
-            )
-            mismatched.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = (
-                TCGEN05_GROUPED_MODE_DYNAMIC
-            )
+            mismatched = dynamic_config(ab_stages, c_stages)
             with (
                 self.subTest(ab_stages=ab_stages, c_stages=c_stages),
                 self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"),
@@ -1759,6 +2185,8 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
 
         config = selected_config()
         spec.normalize(config)
+        self.assertEqual(config.block_sizes, [256, 128, 64])
+        self.assertEqual(config.config["tcgen05_ab_stages"], 7)
         minimized = config.minimize(spec)
         self.assertNotIn("tcgen05_cluster_n", minimized.config)
         self.assertNotIn("tcgen05_acc_stages", minimized.config)
@@ -1766,13 +2194,7 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         spec.normalize(minimized)
         self.assertEqual(minimized.config["tcgen05_ab_stages"], 7)
 
-        constrained_spec = self._make_cute_tcgen05_spec()
-        constrained_spec._cute_tcgen05_config.ab_stages_three_search_constraints = (
-            Tcgen05AbStagesThreeSearchConstraints(
-                dtype_bytes=2,
-                per_cta_smem_budget_bytes=1,
-            )
-        )
+        constrained_spec = self._constrained_grouped_worklist_spec(1)
         with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
             constrained_spec.normalize(selected_config())
 
@@ -1780,14 +2202,25 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         self,
     ) -> None:
         def selected_config(source_m_tile: int, ab_stages: int) -> helion.Config:
-            return helion.Config(
-                block_sizes=[256, 128, 64],
+            return self._grouped_worklist_config(
+                source_m_tile=source_m_tile,
                 pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
-                tcgen05_cluster_m=2,
                 tcgen05_ab_stages=ab_stages,
-                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
-                tcgen05_grouped_worklist_source_m_tile=source_m_tile,
             )
+
+        for invalid_cluster_m in (True, 4):
+            with self.subTest(invalid_cluster_m=invalid_cluster_m):
+                invalid = selected_config(
+                    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+                    7,
+                )
+                invalid.config["tcgen05_cluster_m"] = invalid_cluster_m
+                self.assertIsNone(
+                    resolve_tcgen05_grouped_worklist_mma_profile(
+                        invalid,
+                        block_k=64,
+                    )
+                )
 
         b200_capacity_bytes = TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN
         constrained_budget_bytes = (
@@ -1804,20 +2237,20 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                 ab_stages=ab_stages,
                 should_fit=should_fit,
             ):
-                physical_shape = resolve_tcgen05_grouped_worklist_mma_shape(
-                    cluster_m=2,
+                config = selected_config(source_m_tile, ab_stages)
+                profile = resolve_tcgen05_grouped_worklist_mma_profile(
+                    config,
                     block_k=64,
-                    source_m_tile=source_m_tile,
                 )
-                self.assertEqual(physical_shape, (256, source_m_tile))
-                assert physical_shape is not None
+                assert profile is not None
+                self.assertEqual((profile.mma_m, profile.mma_n), (256, source_m_tile))
                 self.assertEqual(
                     tcgen05_grouped_worklist_smem_bytes(
                         group_count=1,
                         device_split_sizes=False,
                         sched_stage_count=1,
-                        bm=physical_shape[0],
-                        bn=physical_shape[1],
+                        bm=profile.mma_m,
+                        bn=profile.mma_n,
                         bk=64,
                         dtype_bytes=2,
                         ab_stages=ab_stages,
@@ -1828,18 +2261,82 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
                     required_bytes,
                 )
 
-                spec = self._make_cute_tcgen05_spec()
-                spec._cute_tcgen05_config.ab_stages_three_search_constraints = (
-                    Tcgen05AbStagesThreeSearchConstraints(
-                        dtype_bytes=2,
-                        per_cta_smem_budget_bytes=constrained_budget_bytes,
-                    )
+                spec = self._constrained_grouped_worklist_spec(constrained_budget_bytes)
+                spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+                    group_count=1,
+                    device_split_sizes=False,
                 )
                 if should_fit:
-                    spec.normalize(selected_config(source_m_tile, ab_stages))
+                    spec.normalize(config)
                 else:
                     with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
-                        spec.normalize(selected_config(source_m_tile, ab_stages))
+                        spec.normalize(config)
+
+    def test_grouped_worklist_deep_ab_normalization_uses_device_split_facts(
+        self,
+    ) -> None:
+        config = self._grouped_worklist_config(
+            pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            tcgen05_ab_stages=7,
+        )
+        constrained_budget_bytes = (
+            TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN
+            - TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
+        )
+        for group_count, should_fit in ((20, True), (21, False)):
+            with self.subTest(group_count=group_count, should_fit=should_fit):
+                spec = self._constrained_grouped_worklist_spec(constrained_budget_bytes)
+                spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+                    group_count=group_count,
+                    device_split_sizes=True,
+                )
+                if should_fit:
+                    spec.normalize(helion.Config.from_dict(config.config))
+                else:
+                    with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
+                        spec.normalize(helion.Config.from_dict(config.config))
+
+    def test_reviewed_grouped_worklist_seeds_fit_conservative_b200_smem(self) -> None:
+        seed_inputs = (
+            (6, 6 * 32, 4096, 4096, "k", 32),
+            (6, 6 * 224, 7168, 3072, "k", 224),
+            (8, 8 * 4096, 4096, 2048, "k", 256),
+            (8, 8 * 4096, 4096, 2048, "n", 256),
+        )
+        reviewed_configs = [
+            config
+            for groups, packed_m, n, k, b_major, source_m_tile in seed_inputs
+            for config in tcgen05_grouped_worklist_seed_configs(
+                groups=groups,
+                packed_m=packed_m,
+                n=n,
+                k=k,
+                b_major=b_major,
+                source_m_tile=source_m_tile,
+                num_sm=148,
+            )
+        ]
+        spec = self._constrained_grouped_worklist_spec(
+            TCGEN05_AB_STAGES_THREE_MIN_DEVICE_SMEM_OPTIN
+            - TCGEN05_AB_STAGES_THREE_RESERVED_SMEM_BYTES
+        )
+        spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+            group_count=8,
+            device_split_sizes=False,
+        )
+
+        for config in reviewed_configs:
+            with self.subTest(config=config.config):
+                ab_stages = config.config["tcgen05_ab_stages"]
+                assert isinstance(ab_stages, int)
+                # AB1-3 use the ordinary admission path; deeper reviewed seeds
+                # must pass the conservative all-scheduler SMEM upper bound.
+                self.assertTrue(
+                    ab_stages < 4
+                    or spec._cute_tcgen05_config._grouped_worklist_nm_ab_config_matches(
+                        config.config, ab_stages
+                    )
+                )
 
     def test_grouped_dynamic_deep_stage_smem_accounts_for_output_dtype(self) -> None:
         from helion._compiler.backend import CuteBackend
@@ -1928,10 +2425,7 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         tcgen05_config = spec._cute_tcgen05_config
 
         def choices(fragments: Mapping[str, object], key: str) -> tuple[object, ...]:
-            fragment = fragments[key]
-            self.assertIsInstance(fragment, EnumFragment)
-            assert isinstance(fragment, EnumFragment)
-            return fragment.choices
+            return self._enum_fragment(fragments[key]).choices
 
         narrow = tcgen05_config.strategy_autotune_fragments()
         self.assertEqual(
@@ -1949,6 +2443,174 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             choices(widened, "tcgen05_warp_spec_c_input_warps"),
             (0, 1),
         )
+
+    def test_compiler_seed_fragments_preserve_base_search_choices(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+        spec.compiler_seed_configs = [
+            helion.Config(
+                pid_type="flat",
+                tcgen05_consumer_regs=240,
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+                tcgen05_persistence_model="non_persistent",
+            ),
+            helion.Config(
+                pid_type="persistent_interleaved",
+                tcgen05_persistence_model="clc_persistent",
+            ),
+            helion.Config.from_dict(
+                {
+                    "tcgen05_consumer_regs": True,
+                    "tcgen05_strategy": "invalid",
+                    "tcgen05_warp_spec_scheduler_warps": True,
+                    "tcgen05_persistence_model": "invalid",
+                }
+            ),
+        ]
+        tcgen05_config = spec._cute_tcgen05_config
+
+        consumer = self._enum_fragment(
+            tcgen05_config.consumer_regs_autotune_fragments()["tcgen05_consumer_regs"]
+        )
+        strategy = tcgen05_config.strategy_autotune_fragments()
+        persistence = self._enum_fragment(
+            tcgen05_config.persistence_model_autotune_fragments()[
+                "tcgen05_persistence_model"
+            ]
+        )
+        strategy_fragment = self._enum_fragment(strategy["tcgen05_strategy"])
+        scheduler_fragment = self._enum_fragment(
+            strategy["tcgen05_warp_spec_scheduler_warps"]
+        )
+
+        self.assertEqual(consumer.choices, (256, 240))
+        self.assertEqual(consumer.search_choices, (256,))
+        self.assertEqual(
+            strategy_fragment.choices,
+            ("role_local_monolithic", "role_local_with_scheduler"),
+        )
+        self.assertEqual(strategy_fragment.search_choices, ("role_local_monolithic",))
+        self.assertEqual(scheduler_fragment.choices, (0, 1))
+        self.assertEqual(scheduler_fragment.search_choices, (0,))
+        self.assertEqual(
+            persistence.choices,
+            ("non_persistent", "static_persistent", "clc_persistent"),
+        )
+        self.assertEqual(
+            persistence.search_choices,
+            ("non_persistent", "static_persistent"),
+        )
+
+    def test_default_seed_values_do_not_add_degenerate_fragments(self) -> None:
+        baseline = self._make_cute_tcgen05_spec()
+        baseline_hash = baseline.structural_fingerprint_hash()
+
+        spec = self._make_cute_tcgen05_spec()
+        spec.compiler_seed_configs = [
+            helion.Config(
+                pid_type="flat",
+                tcgen05_consumer_regs=256,
+                tcgen05_persistence_model="non_persistent",
+            )
+        ]
+        fields = spec._cute_tcgen05_config.flat_fields()
+
+        self.assertNotIn("tcgen05_consumer_regs", fields)
+        self.assertNotIn("tcgen05_persistence_model", fields)
+        self.assertEqual(spec.structural_fingerprint_hash(), baseline_hash)
+
+        spec.compiler_seed_configs = [
+            helion.Config(
+                pid_type="flat",
+                tcgen05_persistence_model="static_persistent",
+            )
+        ]
+        persistence = self._enum_fragment(
+            spec._cute_tcgen05_config.flat_fields()["tcgen05_persistence_model"]
+        )
+        self.assertEqual(
+            persistence.choices,
+            ("non_persistent", "static_persistent"),
+        )
+        self.assertIsNone(persistence.search_choices)
+        self.assertNotEqual(spec.structural_fingerprint_hash(), baseline_hash)
+        self.assertIn(
+            (
+                "tcgen05_persistence_model",
+                "enum",
+                repr("non_persistent"),
+                repr("static_persistent"),
+            ),
+            spec.structural_fingerprint(),
+        )
+
+    def test_mixed_grouped_persistence_seed_search_domain(self) -> None:
+        from helion.autotuner.config_generation import ConfigGeneration
+
+        spec = self._make_cute_tcgen05_spec()
+        spec.target_device_capability = (10, 0)
+        spec.allowed_pid_types = ("flat",)
+        spec.compiler_seed_configs = [
+            helion.Config(
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                tcgen05_grouped_runtime_direct=True,
+            ),
+            helion.Config(
+                pid_type="persistent_interleaved",
+                tcgen05_grouped_mode=TCGEN05_GROUPED_MODE_WORKLIST_NM,
+                tcgen05_grouped_runtime_direct=True,
+                tcgen05_persistence_model="clc_persistent",
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+            ),
+        ]
+
+        generation = ConfigGeneration(spec)
+        [persistence_index], _ = generation._key_to_flat_indices[
+            "tcgen05_persistence_model"
+        ]
+        persistence = self._enum_fragment(generation.flat_spec[persistence_index])
+        self.assertEqual(
+            persistence.choices,
+            ("non_persistent", "static_persistent", "clc_persistent"),
+        )
+        self.assertEqual(
+            persistence.search_choices,
+            ("non_persistent",),
+        )
+        self.assertEqual(
+            persistence.search_values(),
+            ["non_persistent"],
+        )
+        self.assertIn(
+            (
+                "tcgen05_persistence_model",
+                "enum",
+                repr("non_persistent"),
+                repr("static_persistent"),
+                repr("clc_persistent"),
+                "search",
+                repr("non_persistent"),
+            ),
+            spec.structural_fingerprint(),
+        )
+
+        pairs = generation.seed_flat_config_pairs()
+        self.assertEqual(len(pairs), 2)
+        by_model = {
+            normalized.config["tcgen05_persistence_model"]: flat
+            for flat, normalized in pairs
+        }
+        self.assertEqual(set(by_model), {"static_persistent", "clc_persistent"})
+        feature_dim = sum(fragment.dim() for fragment in generation.flat_spec)
+        for flat in by_model.values():
+            self.assertEqual(len(generation.encode_config(flat)), feature_dim)
+        for model in ("static_persistent", "clc_persistent"):
+            self.assertEqual(
+                persistence.pattern_neighbors(by_model[model][persistence_index]),
+                ["non_persistent"],
+            )
 
 
 if __name__ == "__main__":

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6,7 +6,7 @@ import dataclasses
 from dataclasses import dataclass
 import gc
 import importlib
-import linecache
+import inspect
 import logging
 import math
 import os
@@ -2392,6 +2392,31 @@ def _launch_entry(
     return helion_runtime._CuteLaunchArgCacheEntry(
         schema, launch_args, (), owned_tensors
     )
+
+
+def _grouped_metadata_plan(**overrides: object) -> dict[str, object]:
+    plan: dict[str, object] = {
+        "kind": "tcgen05_grouped_static_persistent",
+        "layout_idx": 0,
+        "n_sizes_idx": 1,
+        "group_count": 2,
+        "bm": 128,
+        "bn": 64,
+        "bk": 128,
+        "n_size": 256,
+        "k_total_size": 128,
+        "problem_sizes_arg": "problem_sizes",
+        "starts_arg": "starts",
+        "total_clusters_arg": "total_clusters",
+    }
+    plan.update(overrides)
+    return plan
+
+
+def _cute_kernel_for_plan(plan: Any) -> Any:
+    kernel = type("DummyCuteKernel", (), {})()
+    kernel._helion_cute_wrapper_plans = [plan]
+    return kernel
 
 
 def _runtime_identity_kernel() -> Any:
@@ -7720,8 +7745,14 @@ class TestCuteBackend(TestCase):
             torch.randn(4, 64, 256, device=DEVICE, dtype=HALF_DTYPE),
             torch.randn(4, 64, 256, device=DEVICE, dtype=HALF_DTYPE),
         )
+        cute_batched_dot_tcgen05.reset()
         with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
-            clean_bound = cute_batched_dot_tcgen05.bind(clean)
+            with patch(
+                "helion._compiler.cute.cute_mma."
+                "_analyze_rank3_rhs_grouped_search_operands",
+                side_effect=AssertionError("grouped-RHS fallback must not run"),
+            ):
+                clean_bound = cute_batched_dot_tcgen05.bind(clean)
             rejected_bound = cute_transposed_operand_batched_dot_tcgen05.bind(rejected)
             shifted_bound = cute_shifted_batched_dot_tcgen05.bind(clean)
             # Same rank (3-D dot), opposite enablement -> the gate is structural.
@@ -9072,22 +9103,16 @@ class TestCuteBackend(TestCase):
     def test_grouped_static_active_clusters_honors_reserved_sms(self) -> None:
         launcher = importlib.import_module("helion.runtime.cute.launcher")
 
-        self.assertEqual(
-            launcher._tcgen05_grouped_static_active_clusters(
-                num_sm=148,
-                cluster_m=1,
-                reserved_sms=0,
-            ),
-            148,
-        )
-        self.assertEqual(
-            launcher._tcgen05_grouped_static_active_clusters(
-                num_sm=148,
-                cluster_m=2,
-                reserved_sms=4,
-            ),
-            72,
-        )
+        for cluster_m, reserved_sms, expected in ((1, 0, 148), (2, 4, 72)):
+            with self.subTest(cluster_m=cluster_m, reserved_sms=reserved_sms):
+                self.assertEqual(
+                    launcher._tcgen05_grouped_static_active_clusters(
+                        num_sm=148,
+                        cluster_m=cluster_m,
+                        reserved_sms=reserved_sms,
+                    ),
+                    expected,
+                )
 
     def test_cute_launcher_reuses_compiled_wrapper(self) -> None:
         cute_kernel = type("DummyCuteKernel", (), {})()
@@ -9130,17 +9155,6 @@ class TestCuteBackend(TestCase):
     def test_cute_runtime_leading_extent_wrapper_bakes_tail_layout(self) -> None:
         launcher = importlib.import_module("helion.runtime.cute.launcher")
         cute_kernel = type("DummyCuteKernel", (), {})()
-        captured_source: list[str] = []
-        wrapper = object()
-
-        def fake_exec(code: Any, namespace: dict[str, Any]) -> None:
-            source = "".join(linecache.getlines(code.co_filename))
-            captured_source.append(source)
-            definition = next(
-                line for line in source.splitlines() if line.startswith("def ")
-            )
-            namespace[definition[4:].split("(", 1)[0]] = wrapper
-
         schema = (
             (
                 "wrapper_tensor_runtime_leading_extent",
@@ -9151,16 +9165,8 @@ class TestCuteBackend(TestCase):
                 (10, 1),
             ),
         )
-        with patch("builtins.exec", side_effect=fake_exec):
-            created = launcher._create_cute_wrapper(
-                cute_kernel,
-                schema,
-                (32, 1, 1),
-            )
-
-        self.assertIs(created, wrapper)
-        self.assertEqual(len(captured_source), 1)
-        source = captured_source[0]
+        wrapper = launcher._create_cute_wrapper(cute_kernel, schema, (32, 1, 1))
+        source = inspect.getsource(wrapper)
         self.assertIn("runtime_tile_records_shape0: cutlass.Int64", source)
         self.assertNotIn("runtime_tile_records_shape1:", source)
         self.assertNotIn("runtime_tile_records_stride0:", source)
@@ -9532,8 +9538,7 @@ class TestCuteBackend(TestCase):
         if not torch.cuda.is_available():
             self.skipTest("dynamic TensorMap workspace test needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [
+        cute_kernel = _cute_kernel_for_plan(
             {
                 "kind": "tcgen05_grouped_static_persistent",
                 "scheduler_mode": (
@@ -9542,7 +9547,7 @@ class TestCuteBackend(TestCase):
                 "layout_idx": 0,
                 "dynamic_ab_tensormaps": True,
             }
-        ]
+        )
         layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
         streams = [
             torch.cuda.Stream(device=DEVICE)
@@ -9594,8 +9599,7 @@ class TestCuteBackend(TestCase):
     def test_grouped_static_capture_query_fails_closed(self) -> None:
         if DEVICE.type != "cuda":
             self.skipTest("grouped capture context test needs CUDA")
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [
+        cute_kernel = _cute_kernel_for_plan(
             {
                 "kind": "tcgen05_grouped_static_persistent",
                 "scheduler_mode": (
@@ -9603,7 +9607,7 @@ class TestCuteBackend(TestCase):
                 ),
                 "layout_idx": 0,
             }
-        ]
+        )
         layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
 
         with (
@@ -9619,8 +9623,7 @@ class TestCuteBackend(TestCase):
         if not torch.cuda.is_available():
             self.skipTest("dynamic TensorMap workspace test needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [
+        cute_kernel = _cute_kernel_for_plan(
             {
                 "kind": "tcgen05_grouped_static_persistent",
                 "scheduler_mode": (
@@ -9629,7 +9632,7 @@ class TestCuteBackend(TestCase):
                 "layout_idx": 0,
                 "dynamic_ab_tensormaps": True,
             }
-        ]
+        )
         layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
         args = (layout,)
         grid = (1, 1, 1)
@@ -9783,11 +9786,9 @@ class TestCuteBackend(TestCase):
         launcher = importlib.import_module("helion.runtime.cute.launcher")
         host_plan = {
             "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
         }
         device_plan = {
             "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "device_split_sizes": True,
         }
         unrelated_plan = {"kind": "unrelated"}
@@ -9841,23 +9842,12 @@ class TestCuteBackend(TestCase):
         if not torch.cuda.is_available():
             self.skipTest("grouped capture ownership test needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        plan = {
-            "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
-            "layout_idx": 0,
-            "n_sizes_idx": 1,
-            "group_count": 2,
-            "bm": 128,
-            "bn": 64,
-            "bk": 128,
-            "n_size": 256,
-            "k_total_size": 128,
-            "problem_sizes_arg": "tcgen05_grouped_problem_sizes_0",
-            "starts_arg": "tcgen05_grouped_starts_0",
-            "total_clusters_arg": "tcgen05_grouped_total_clusters_0",
-        }
-        cute_kernel._helion_cute_wrapper_plans = [plan]
+        plan = _grouped_metadata_plan(
+            problem_sizes_arg="tcgen05_grouped_problem_sizes_0",
+            starts_arg="tcgen05_grouped_starts_0",
+            total_clusters_arg="tcgen05_grouped_total_clusters_0",
+        )
+        cute_kernel = _cute_kernel_for_plan(plan)
 
         def make_args(signature: int) -> tuple[torch.Tensor, torch.Tensor]:
             first_group_size = 128 * (signature + 1)
@@ -9997,7 +9987,6 @@ class TestCuteBackend(TestCase):
         runtime_mod = importlib.import_module("helion.runtime")
         plan = {
             "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "layout_idx": 2,
             "lhs_idx": 0,
             "rhs_idx": 1,
@@ -10014,8 +10003,7 @@ class TestCuteBackend(TestCase):
             "real_groups_arg": "real_groups",
             "total_clusters_arg": "total_clusters",
         }
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [plan]
+        cute_kernel = _cute_kernel_for_plan(plan)
         layout = torch.tensor(((0, 0, 128, 0),), dtype=torch.int32, device=DEVICE)
         rhs = torch.empty((1, 64, 64), dtype=torch.bfloat16, device=DEVICE)
 
@@ -10054,24 +10042,14 @@ class TestCuteBackend(TestCase):
             "bm": 256,
         }
 
-        self.assertEqual(
-            launcher._tcgen05_grouped_device_split_total_clusters(
-                {**common_plan, "source_m_tile": 32}
-            ),
-            1024,
-        )
-        self.assertEqual(
-            launcher._tcgen05_grouped_device_split_total_clusters(
-                {**common_plan, "source_m_tile": 224}
-            ),
-            160,
-        )
-        self.assertEqual(
-            launcher._tcgen05_grouped_device_split_total_clusters(
-                {**common_plan, "source_m_tile": 256}
-            ),
-            128,
-        )
+        for source_m_tile, expected in ((32, 1024), (224, 160), (256, 128)):
+            with self.subTest(source_m_tile=source_m_tile):
+                self.assertEqual(
+                    launcher._tcgen05_grouped_device_split_total_clusters(
+                        {**common_plan, "source_m_tile": source_m_tile}
+                    ),
+                    expected,
+                )
 
     def test_grouped_device_split_dimensions_must_fit_int32(self) -> None:
         launcher = importlib.import_module("helion.runtime.cute.launcher")
@@ -10098,21 +10076,7 @@ class TestCuteBackend(TestCase):
         if DEVICE.type != "cuda":
             self.skipTest("grouped static problem-shape guard needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
-        base_plan = {
-            "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
-            "layout_idx": 0,
-            "n_sizes_idx": 1,
-            "group_count": 2,
-            "bm": 128,
-            "bn": 64,
-            "bk": 128,
-            "n_size": 256,
-            "k_total_size": 128,
-            "problem_sizes_arg": "problem_sizes",
-            "starts_arg": "starts",
-            "total_clusters_arg": "total_clusters",
-        }
+        base_plan = _grouped_metadata_plan()
         layout = torch.cat(
             (
                 torch.zeros(128, dtype=torch.int32, device=DEVICE),
@@ -10124,8 +10088,7 @@ class TestCuteBackend(TestCase):
         actual_shapes = ((128, 64, 128), (128, 256, 128))
 
         matching_plan = {**base_plan, "static_problem_shapes": actual_shapes}
-        matching_kernel = type("MatchingDummyCuteKernel", (), {})()
-        matching_kernel._helion_cute_wrapper_plans = [matching_plan]
+        matching_kernel = _cute_kernel_for_plan(matching_plan)
         runtime_mod._build_tcgen05_grouped_static_metadata(
             matching_kernel, matching_plan, args
         )
@@ -10138,8 +10101,7 @@ class TestCuteBackend(TestCase):
         for expected_shapes in mismatches:
             with self.subTest(expected_shapes=expected_shapes):
                 plan = {**base_plan, "static_problem_shapes": expected_shapes}
-                cute_kernel = type("MismatchedDummyCuteKernel", (), {})()
-                cute_kernel._helion_cute_wrapper_plans = [plan]
+                cute_kernel = _cute_kernel_for_plan(plan)
                 with self.assertRaisesRegex(
                     BackendUnsupported,
                     "static problem-shape specialization",
@@ -10153,23 +10115,8 @@ class TestCuteBackend(TestCase):
             self.skipTest("grouped inference metadata test needs CUDA")
         runtime_mod = importlib.import_module("helion.runtime")
         kernel_mod = importlib.import_module("helion.runtime.kernel")
-        plan = {
-            "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
-            "layout_idx": 0,
-            "n_sizes_idx": 1,
-            "group_count": 2,
-            "bm": 128,
-            "bn": 64,
-            "bk": 128,
-            "n_size": 256,
-            "k_total_size": 128,
-            "problem_sizes_arg": "problem_sizes",
-            "starts_arg": "starts",
-            "total_clusters_arg": "total_clusters",
-        }
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        cute_kernel._helion_cute_wrapper_plans = [plan]
+        plan = _grouped_metadata_plan()
+        cute_kernel = _cute_kernel_for_plan(plan)
 
         with torch.inference_mode():
             layout = torch.cat(
@@ -10802,6 +10749,11 @@ class TestCuteBackend(TestCase):
             ):
                 launcher._tcgen05_grouped_scheduler_mode(invalid_plan)
 
+        self.assertIs(
+            launcher._tcgen05_grouped_scheduler_mode({}),
+            Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH,
+        )
+
     def test_kernel_late_cute_specialization_rekeys_bound_kernel(self) -> None:
         identity = _runtime_identity_kernel()
         x = torch.empty(1)
@@ -10811,7 +10763,6 @@ class TestCuteBackend(TestCase):
         signature = identity._base_specialization_key(args)
         plan: dict[str, object] = {
             "kind": "tcgen05_grouped_static_persistent",
-            "scheduler_mode": Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value,
             "layout_bind_idx": 1,
             "group_count": 1,
             "bm": 128,
@@ -11230,8 +11181,7 @@ class TestCuteBackend(TestCase):
         )
         for plan, disable_bake, expected_baked in cases:
             with self.subTest(plan=plan, disable_bake=disable_bake):
-                kernel = type("DummyCuteKernel", (), {})()
-                kernel._helion_cute_wrapper_plans = [plan]
+                kernel = _cute_kernel_for_plan(plan)
                 kernel._helion_cute_disable_bake_tensor_shapes = disable_bake
                 launch = helion_runtime._build_cute_schema_and_args(
                     kernel, (tensor,), (128, 2, 1)
@@ -12065,8 +12015,10 @@ def test_newer_cute_dsl_warns_once_only_for_grouped_runtime_n_fallback(
 def test_failed_cute_dsl_version_probe_is_shared_and_cached(failure: str) -> None:
     from helion._compiler.cute import cutedsl_compat
 
+    error: Exception
+    expected: str
     if failure == "missing":
-        error: Exception = cutedsl_compat.importlib.metadata.PackageNotFoundError(
+        error = cutedsl_compat.importlib.metadata.PackageNotFoundError(
             "nvidia-cutlass-dsl"
         )
         expected = "the CuTe DSL is not installed"

--- a/test/test_cute_deepgemm_selected.py
+++ b/test/test_cute_deepgemm_selected.py
@@ -11,6 +11,8 @@ import torch
 
 import helion
 from helion._compat import requires_cuda_version
+from helion._compiler.cute.cute_mma import _TCGEN05_INSTR_DESC_N_FIELD_SHIFT
+from helion._compiler.cute.cute_mma import _TCGEN05_INSTR_DESC_N_LOW_BITS
 from helion._compiler.cute.device_state import Tcgen05GroupedSchedulerMode
 from helion._compiler.cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
@@ -88,14 +90,14 @@ def _selected_config(
         )
     # BK64/source-256 cannot fit the historical AB7 schedule in CTA SMEM.
     if ab_stages is None:
-        ab_stages = {
-            (64, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE): 7,
-            (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT): 7,
-            (64, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE): 6,
-            (128, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE): 3,
-            (128, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT): 3,
-            (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE): 3,
-        }[(block_k, source_m_tile)]
+        if block_k == 64:
+            ab_stages = (
+                6
+                if source_m_tile == TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
+                else 7
+            )
+        else:
+            ab_stages = 3
     config = helion.Config(
         block_sizes=[256, 128, block_k],
         l2_groupings=[1],
@@ -135,11 +137,12 @@ def _selected_kernel(
     b_grouped: torch.Tensor,
     work_tile_metadata: torch.Tensor,
     row_alpha: hl.constexpr = 1,  # pyrefly: ignore[bad-function-definition]
+    mask_offset: hl.constexpr = 0,  # pyrefly: ignore[bad-function-definition]
 ) -> torch.Tensor:
     m_total_aligned, k = a_packed.shape
     _g, n, k2 = b_grouped.shape
     assert k == k2
-    assert work_tile_metadata.size(1) == 4
+    assert work_tile_metadata.size(1) >= 4
     block_m = hl.register_block_size(256)
     block_n = hl.register_block_size(128)
     block_k = hl.register_block_size(64)
@@ -164,6 +167,10 @@ def _selected_kernel(
         else:
             row_index = torch.add(global_m_start, local_m, alpha=2)
         valid_rows = local_m < valid_m
+        if mask_offset != 0:
+            valid_rows = (
+                local_m + mask_offset < valid_m  # pyrefly: ignore[unsupported-operation]
+            )
         store_rows = local_m < store_m
         acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
         for tile_k in hl.tile(k, block_size=block_k):
@@ -255,10 +262,8 @@ def _configured_bound(
 
 def _code_for(
     args: tuple[torch.Tensor, ...],
-    config: helion.Config | None = None,
+    config: helion.Config,
 ) -> str:
-    if config is None:
-        config = _selected_config(runtime_direct=True)
     _selected_kernel.reset()
     bound = _selected_kernel.bind(args)
     bound.env.config_spec.cute_tcgen05_search_enabled = True
@@ -356,30 +361,9 @@ def _call_count(
     )
 
 
-def _expected_panel_coords(
-    *,
-    m_tiles: int,
-    n_tiles: int,
-    configured_panel_size: int,
-) -> list[tuple[int, int]]:
-    result: list[tuple[int, int]] = []
-    panel_size = min(configured_panel_size, n_tiles)
-    panel_span = panel_size * m_tiles
-    for linear in range(m_tiles * n_tiles):
-        panel = linear // panel_span
-        within = linear % panel_span
-        width = min(panel_size, n_tiles - panel * panel_size)
-        tile_m = within // width
-        tile_n = panel * panel_size + within % width
-        if panel % 2 == 1:
-            tile_m = m_tiles - 1 - tile_m
-        result.append((tile_m, tile_n))
-    return result
-
-
 def test_grouped_worklist_nm_runtime_tile_table_mapping() -> None:
     rows = [[2, 0, 257, 448], [0, 448, 513, 672], [1, 1120, 65, 224]]
-    problem_sizes = [(2560, row[3], 128, 1) for row in rows]
+    problem_sizes = [(12_800, row[3], 128, 1) for row in rows]
     records = _tcgen05_grouped_runtime_nm_tile_records(
         rows,
         problem_sizes,
@@ -387,51 +371,57 @@ def test_grouped_worklist_nm_runtime_tile_table_mapping() -> None:
         source_tile_n=256,
         l2_swizzle_size=8,
     )
+    assert records.shape[1] == TCGEN05_GROUPED_RUNTIME_TILE_FIELD_COUNT
 
     cursor = 0
     for metadata_idx, (real_group, start, actual_m, aligned_m) in enumerate(rows):
         m_tiles = aligned_m // 224
-        n_tiles = 10
+        n_tiles = 50
         count = m_tiles * n_tiles
         group_records = records[cursor : cursor + count].tolist()
-        assert [(record[0], record[1]) for record in group_records] == (
-            _expected_panel_coords(
-                m_tiles=m_tiles,
-                n_tiles=n_tiles,
-                configured_panel_size=8,
+        coords = [
+            (
+                record[Tcgen05GroupedRuntimeTileField.CTA_M],
+                record[Tcgen05GroupedRuntimeTileField.CTA_N],
             )
-        )
+            for record in group_records
+        ]
+        assert sorted(coords) == [
+            (tile_m, tile_n) for tile_m in range(m_tiles) for tile_n in range(n_tiles)
+        ]
+        if metadata_idx == 0:
+            assert coords[:32] == [
+                *((tile_m, tile_n) for tile_m in (0, 1) for tile_n in range(8)),
+                *((tile_m, tile_n) for tile_m in (1, 0) for tile_n in range(8, 16)),
+            ]
         for record in group_records:
-            tile_m = record[0]
-            assert tuple(record[2:8]) == (
+            tile_m = record[Tcgen05GroupedRuntimeTileField.CTA_M]
+            assert tuple(
+                record[field]
+                for field in (
+                    Tcgen05GroupedRuntimeTileField.METADATA_IDX,
+                    Tcgen05GroupedRuntimeTileField.GROUP_IDX,
+                    Tcgen05GroupedRuntimeTileField.PROBLEM_M,
+                    Tcgen05GroupedRuntimeTileField.PROBLEM_N,
+                    Tcgen05GroupedRuntimeTileField.PROBLEM_K,
+                    Tcgen05GroupedRuntimeTileField.GLOBAL_M_START,
+                )
+            ) == (
                 metadata_idx,
                 real_group,
                 aligned_m,
-                2560,
+                12_800,
                 128,
                 start,
             )
-            assert record[8] == min(224, max(actual_m - tile_m * 224, 0))
-            assert record[9] == min(224, aligned_m - tile_m * 224)
+            assert record[Tcgen05GroupedRuntimeTileField.VALID_M] == min(
+                224, max(actual_m - tile_m * 224, 0)
+            )
+            assert record[Tcgen05GroupedRuntimeTileField.STORE_M] == min(
+                224, aligned_m - tile_m * 224
+            )
         cursor += count
     assert cursor == len(records)
-
-
-@pytest.mark.parametrize("l2_swizzle_size", (1, 8))
-def test_grouped_worklist_nm_tile_table_excludes_zero_tile_groups(
-    l2_swizzle_size: int,
-) -> None:
-    records = _tcgen05_grouped_runtime_nm_tile_records(
-        [[0, 0, 0, 0], [1, 0, 33, 224]],
-        [(256, 0, 128, 1), (256, 224, 128, 1)],
-        source_tile_m=224,
-        source_tile_n=256,
-        l2_swizzle_size=l2_swizzle_size,
-    )
-
-    # The zero-tile row is absent before either raster path performs division
-    # or modulo; the surviving row retains its original metadata index.
-    assert records.tolist() == [[0, 0, 1, 1, 224, 256, 128, 0, 33, 224]]
 
 
 @pytest.mark.parametrize(
@@ -455,6 +445,67 @@ def test_grouped_worklist_nm_runtime_tile_table_rejects_invalid_problem_shape(
             source_tile_n=128,
             l2_swizzle_size=1,
         )
+
+
+def test_grouped_worklist_nm_small_tile_table_matches_reference() -> None:
+    rows = [[2, 0, 33, 64], [0, 64, 65, 96]]
+    problem_sizes = [(896, row[3], 128, 1) for row in rows]
+    records = _tcgen05_grouped_runtime_nm_tile_records(
+        rows,
+        problem_sizes,
+        source_tile_m=32,
+        source_tile_n=128,
+        l2_swizzle_size=3,
+    )
+
+    expected: list[list[int]] = []
+    for metadata_idx, (real_group, start, actual_m, aligned_m) in enumerate(rows):
+        m_tiles = aligned_m // 32
+        n_tiles = 7
+        panel_size = 3
+        for local_idx in range(m_tiles * n_tiles):
+            panel_span = panel_size * m_tiles
+            panel_idx = local_idx // panel_span
+            panel_linear = local_idx % panel_span
+            panel_width = min(panel_size, n_tiles - panel_idx * panel_size)
+            tile_m = panel_linear // panel_width
+            tile_n = panel_idx * panel_size + panel_linear % panel_width
+            if panel_idx % 2:
+                tile_m = m_tiles - 1 - tile_m
+            expected.append(
+                [
+                    tile_m,
+                    tile_n,
+                    metadata_idx,
+                    real_group,
+                    aligned_m,
+                    896,
+                    128,
+                    start,
+                    min(32, max(actual_m - tile_m * 32, 0)),
+                    32,
+                ]
+            )
+
+    assert len(records) == 35
+    assert records.tolist() == expected
+
+
+@pytest.mark.parametrize("l2_swizzle_size", (1, 8))
+def test_grouped_worklist_nm_tile_table_excludes_zero_tile_groups(
+    l2_swizzle_size: int,
+) -> None:
+    records = _tcgen05_grouped_runtime_nm_tile_records(
+        [[0, 0, 0, 0], [1, 0, 33, 224]],
+        [(256, 0, 128, 1), (256, 224, 128, 1)],
+        source_tile_m=224,
+        source_tile_n=256,
+        l2_swizzle_size=l2_swizzle_size,
+    )
+
+    # The zero-tile row is absent before either raster path performs division
+    # or modulo; the surviving row retains its original metadata index.
+    assert records.tolist() == [[0, 0, 1, 1, 224, 256, 128, 0, 33, 224]]
 
 
 def test_grouped_worklist_nm_runtime_direct_clc_checks_grid_z_limit() -> None:
@@ -545,6 +596,50 @@ def _run_graph_replay(
     return warmup, captured
 
 
+def _run_standard_graph_replay_case(
+    m_sizes: tuple[int, ...],
+    *,
+    n: int,
+    k: int,
+    source_m_tile: int,
+    block_k: int = 64,
+    ab_stages: int | None = None,
+    cluster_m: int = 2,
+    consumer_regs: int | None = None,
+    mn_major_b: bool = False,
+    l2_swizzle_size: int | None = None,
+    runtime_direct: bool | None = None,
+    expected_metadata: list[list[int]] | None = None,
+    exact_replay: bool = False,
+) -> None:
+    _require_runtime_cuda13_sm100_or_newer()
+    args = _make_args(
+        m_sizes,
+        n=n,
+        k=k,
+        dirty_padding=True,
+        mn_major_b=mn_major_b,
+        source_m_tile=source_m_tile,
+    )
+    expected_b_stride = (n * k, 1, n) if mn_major_b else (n * k, k, 1)
+    assert tuple(args[1].stride()) == expected_b_stride
+    if expected_metadata is not None:
+        assert args[2].cpu().tolist() == expected_metadata
+
+    warmup, captured = _run_graph_replay(
+        args,
+        block_k,
+        ab_stages=ab_stages,
+        source_m_tile=source_m_tile,
+        cluster_m=cluster_m,
+        consumer_regs=consumer_regs,
+        l2_swizzle_size=l2_swizzle_size,
+        runtime_direct=runtime_direct,
+    )
+    if exact_replay:
+        torch.testing.assert_close(captured, warmup, rtol=0, atol=0)
+
+
 def _refresh_worklist_without_recompile(
     bound: Any,
     args: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
@@ -575,7 +670,7 @@ def _require_codegen_cuda() -> None:
         pytest.skip("tcgen05 selected-path codegen needs CUDA fake inputs")
 
 
-def _require_runtime_cuda13_sm100() -> None:
+def _require_runtime_cuda13_sm100_or_newer() -> None:
     _require_codegen_cuda()
     if not requires_cuda_version("13"):
         pytest.skip("tcgen05 selected-path runtime needs CUDA >= 13")
@@ -592,7 +687,10 @@ def _require_runtime_cuda13_sm100() -> None:
 def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
     _require_codegen_cuda()
 
-    code = _code_for(_make_args((1, 127, 224, 256), n=224, k=128))
+    code = _code_for(
+        _make_args((1, 127, 224, 256), n=224, k=128),
+        _selected_config(runtime_direct=True),
+    )
 
     assert "StaticPersistentGroupTileScheduler.create" not in code
     assert "tcgen05_grouped_runtime_tile_records.iterator" in code
@@ -633,6 +731,15 @@ def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
         plan for plan in _wrapper_plans(code) if plan["kind"] == "tcgen05_d_tma"
     )
     assert (d_plan["bm"], d_plan["bn"], d_plan["orientation"]) == (256, 256, "nm")
+    assert not {
+        "problem_sizes_arg",
+        "starts_arg",
+        "real_groups_arg",
+    }.intersection(plan)
+    wrapper_body: list[str] = []
+    wrapper_call_args: list[str] = []
+    _append_cute_wrapper_plan(wrapper_body, wrapper_call_args, plan, num_sm=148)
+    assert plan["sched_params_arg"] not in wrapper_call_args
 
 
 def test_grouped_worklist_nm_runtime_direct_clc_uses_exact_record_ids() -> None:
@@ -735,6 +842,7 @@ def test_grouped_worklist_nm_runtime_direct_clc_uses_exact_record_ids() -> None:
         num_sm=148,
     )
     assert "    grid_z = tcgen05_grouped_total_clusters" in wrapper_body
+    assert grouped_plan["sched_params_arg"] not in wrapper_call_args
     assert not any(
         "StaticPersistentGroupTileScheduler.get_grid_shape" in line
         for line in wrapper_body
@@ -810,13 +918,25 @@ def test_grouped_worklist_nm_can_retain_scheduler_mailbox() -> None:
 
     _require_codegen_cuda()
 
-    code = _code_for(
-        _make_args((1, 127, 224, 256), n=224, k=128),
-        _selected_config(runtime_direct=False),
-    )
+    with (
+        patch(
+            "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+            return_value=False,
+        ),
+        patch(
+            "helion._compiler.cute.cute_mma.warn_tcgen05_runtime_n_ptx_fallback"
+        ) as warn_fallback,
+    ):
+        code = _code_for(
+            _make_args((1, 127, 224, 256), n=224, k=128),
+            _selected_config(runtime_direct=False),
+        )
 
     assert "StaticPersistentGroupTileScheduler.create" in code
     assert "tcgen05_grouped_runtime_tile_records.iterator" not in code
+    assert "cutlass.experimental.primitives.inline_ptx(" not in code
+    assert "cute.gemm(" in code
+    warn_fallback.assert_not_called()
     assert "tcgen05_work_tile_smem" in code
     assert (
         "cutlass.Int32(0) < tcgen05_grouped_selected_source_m_tiles <= "
@@ -895,10 +1015,6 @@ def test_grouped_worklist_nm_can_retain_scheduler_mailbox() -> None:
     assert (
         plan["scheduler_mode"] == Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value
     )
-    d_plan = next(
-        plan for plan in _wrapper_plans(code) if plan["kind"] == "tcgen05_d_tma"
-    )
-    assert (d_plan["bm"], d_plan["bn"], d_plan["orientation"]) == (256, 256, "nm")
 
 
 def test_grouped_worklist_nm_codegen_backstop_rejects_generated_smem() -> None:
@@ -957,6 +1073,32 @@ def test_grouped_worklist_nm_rejects_alpha_scaled_row() -> None:
         bound.to_triton_code(_selected_config())
 
 
+def test_tcgen05_runtime_instr_desc_n_field_matches_cutlass() -> None:
+    import cutlass
+    from cutlass.experimental.primitives import Tcgen05InstrDesc
+
+    def build(n_dim: int) -> int:
+        # Mirror the pinned BF16/F32 K-major layout used by the grouped tail.
+        return int(
+            Tcgen05InstrDesc.build(
+                c_dtype=cutlass.Float32,
+                a_dtype=cutlass.BFloat16,
+                b_dtype=cutlass.BFloat16,
+                a_major=0,
+                b_major=0,
+                n_dim=n_dim,
+                m_dim=256,
+            )
+        )
+
+    runtime_n = 32
+    encoded = build(0) | (
+        (runtime_n >> _TCGEN05_INSTR_DESC_N_LOW_BITS)
+        << _TCGEN05_INSTR_DESC_N_FIELD_SHIFT
+    )
+    assert encoded == build(runtime_n)
+
+
 @pytest.mark.parametrize(
     ("block_k", "source_m_tile"),
     (
@@ -974,7 +1116,15 @@ def test_grouped_worklist_nm_runtime_n_tail_descriptors_codegen(
 ) -> None:
     _require_codegen_cuda()
 
-    config = _selected_config(block_k, source_m_tile, runtime_direct=True)
+    config = _selected_config(
+        block_k,
+        source_m_tile,
+        ab_stages=3,
+        cluster_m=(
+            1 if source_m_tile == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE else 2
+        ),
+        runtime_direct=True,
+    )
     with patch(
         "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
         return_value=True,
@@ -984,23 +1134,29 @@ def test_grouped_worklist_nm_runtime_n_tail_descriptors_codegen(
             config,
         )
 
+    is_two_cta = source_m_tile != TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
     assert "cutlass.experimental.primitives.inline_ptx(" in code
-    assert (
-        "tcgen05_tma_b_peer_delta = mma_slice_tidx * "
-        "(tcgen05_tma_runtime_mma_n // cutlass.Int32(2) - "
-        f"cutlass.Int32({source_m_tile // 2}))"
-    ) in code
-    assert (
-        "tcgen05_tma_tensor_b_tail = cute.domain_offset("
-        "(tcgen05_tma_b_peer_delta, 0), tma_tensor_b)"
-    ) in code
-    assert (
-        f"cute.local_tile(tcgen05_tma_tensor_b_tail, ({source_m_tile}, {block_k})"
-        in code
-    )
-    assert "n_dim=0, m_dim=256" in code
+    if is_two_cta:
+        assert (
+            "tcgen05_tma_b_peer_delta = mma_slice_tidx * "
+            "(tcgen05_tma_runtime_mma_n // cutlass.Int32(2) - "
+            f"cutlass.Int32({source_m_tile // 2}))"
+        ) in code
+        assert (
+            "tcgen05_tma_tensor_b_tail = cute.domain_offset("
+            "(tcgen05_tma_b_peer_delta, 0), tma_tensor_b)"
+        ) in code
+        assert (
+            f"cute.local_tile(tcgen05_tma_tensor_b_tail, "
+            f"({source_m_tile}, {block_k})" in code
+        )
+    else:
+        assert "tcgen05_tma_b_peer_delta" not in code
+        assert "tcgen05_tma_tensor_b_tail" not in code
+        assert f"cute.local_tile(tma_tensor_b, ({source_m_tile}, {block_k})" in code
+    assert f"n_dim=0, m_dim={256 if is_two_cta else 128}" in code
     assert f"if tcgen05_runtime_mma_n == cutlass.Int32({source_m_tile}):" in code
-    assert "tcgen05.mma.cta_group::2.kind::f16" in code
+    assert f"tcgen05.mma.cta_group::{2 if is_two_cta else 1}.kind::f16" in code
     tree = ast.parse(code)
     instr_desc_call = next(
         node
@@ -1024,34 +1180,36 @@ def test_grouped_worklist_nm_runtime_n_tail_descriptors_codegen(
         for node in ast.walk(tree)
         if isinstance(node, ast.If) and ast.unparse(node.test) == tail_predicate
     ]
-    assert len(tail_guards) == 2
-    tma_guard = next(
-        node for node in tail_guards if "tcgen05_tma_b_peer_delta" in ast.unparse(node)
-    )
+    assert len(tail_guards) == (2 if is_two_cta else 1)
     mma_guard = next(
         node for node in tail_guards if "Tcgen05InstrDesc.build" in ast.unparse(node)
     )
-    assert "tcgen05_tma_tensor_b_tail" in ast.unparse(tma_guard)
-    assert "Tcgen05InstrDesc.build" not in ast.unparse(tma_guard)
     assert "tcgen05_tma_b_peer_delta" not in ast.unparse(mma_guard)
-
-    # Keep both sides of the dynamic tail branch on the same CuTe pytree by
-    # normalizing the full-N TensorMap with a DSL-typed zero domain offset.
-    normalized_tail_runs = []
-    for node in ast.walk(tree):
-        body = getattr(node, "body", None)
-        if not isinstance(body, list):
-            continue
-        for index in range(len(body) - 2):
-            run = body[index : index + 3]
-            if (
-                "tcgen05_tma_b_peer_delta = cutlass.Int32(0)" in ast.unparse(run[0])
-                and "tcgen05_tma_tensor_b_tail = cute.domain_offset("
-                in ast.unparse(run[1])
-                and run[2] is tma_guard
-            ):
-                normalized_tail_runs.append(run)
-    assert len(normalized_tail_runs) == 1
+    if is_two_cta:
+        tma_guard = next(
+            node
+            for node in tail_guards
+            if "tcgen05_tma_b_peer_delta" in ast.unparse(node)
+        )
+        assert "tcgen05_tma_tensor_b_tail" in ast.unparse(tma_guard)
+        assert "Tcgen05InstrDesc.build" not in ast.unparse(tma_guard)
+        # Keep both sides of the dynamic tail branch on the same CuTe pytree by
+        # normalizing the full-N TensorMap with a DSL-typed zero domain offset.
+        normalized_tail_runs = []
+        for node in ast.walk(tree):
+            body = getattr(node, "body", None)
+            if not isinstance(body, list):
+                continue
+            for index in range(len(body) - 2):
+                run = body[index : index + 3]
+                if (
+                    "tcgen05_tma_b_peer_delta = cutlass.Int32(0)" in ast.unparse(run[0])
+                    and "tcgen05_tma_tensor_b_tail = cute.domain_offset("
+                    in ast.unparse(run[1])
+                    and run[2] is tma_guard
+                ):
+                    normalized_tail_runs.append(run)
+        assert len(normalized_tail_runs) == 1
 
 
 @pytest.mark.parametrize(
@@ -1165,49 +1323,73 @@ def test_grouped_worklist_nm_bk128_ab2_keeps_unsplit_tma_store_codegen(
     assert "cute.copy(tcgen05_tma_store_atom" in code
 
 
-def test_grouped_worklist_nm_one_cta_codegen() -> None:
+@pytest.mark.parametrize("runtime_direct", (False, True))
+def test_grouped_worklist_nm_one_cta_codegen(runtime_direct: bool) -> None:
     _require_codegen_cuda()
 
     source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
-    config = _selected_config(64, source_m_tile, cluster_m=1)
-    code = _code_for(
-        _make_args((24, 23), n=512, k=128, source_m_tile=source_m_tile),
-        config,
+    config = _selected_config(
+        64,
+        source_m_tile,
+        cluster_m=1,
+        runtime_direct=runtime_direct,
     )
+    with patch(
+        "helion._compiler.cute.cute_mma.tcgen05_runtime_n_ptx_compatible",
+        return_value=True,
+    ):
+        code = _code_for(
+            _make_args((24, 23), n=512, k=128, source_m_tile=source_m_tile),
+            config,
+        )
 
+    assert config.block_sizes[:3] == [256, 128, 64]
     assert "cute.nvgpu.tcgen05.CtaGroup.ONE" in code
     assert "cute.nvgpu.tcgen05.CtaGroup.TWO" not in code
-    assert config.block_sizes[:3] == [256, 128, 64]
     assert "tcgen05_tma_b_peer_delta" not in code
     assert "tcgen05_tma_tensor_b_tail" not in code
     assert "cute.gemm(" in code
-    assert "cutlass.experimental.primitives.inline_ptx(" not in code
-    assert "tcgen05.mma.cta_group::1.kind::f16" not in code
+    assert ("cutlass.experimental.primitives.inline_ptx(" in code) is runtime_direct
+    assert ("tcgen05.mma.cta_group::1.kind::f16" in code) is runtime_direct
     assert "tcgen05.mma.cta_group::2.kind::f16" not in code
-    assert "StaticPersistentGroupTileScheduler.create" in code
     assert "cute.local_tile(tma_tensor_a, (128, 64)" in code
     assert f"cute.local_tile(tma_tensor_b, ({source_m_tile}, 64)" in code
+    tma_role_predicate = (
+        "cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(5)"
+    )
+    tma_role_sources = [
+        ast.unparse(node)
+        for node in ast.walk(ast.parse(code))
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == tma_role_predicate
+        and "while tcgen05_role_local_0" in ast.unparse(node)
+    ]
+    assert len(tma_role_sources) == 1
+    assert "tcgen05_grouped_valid_m =" not in tma_role_sources[0]
 
     plans = _wrapper_plans(code)
     grouped_plan = next(
         plan for plan in plans if plan["kind"] == "tcgen05_grouped_static_persistent"
     )
-    assert (
-        grouped_plan["scheduler_mode"]
-        == Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH.value
+    expected_scheduler = (
+        Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT
+        if runtime_direct
+        else Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH
     )
-    assert "StaticPersistentGroupTileScheduler.create" in code
-    assert "tcgen05_grouped_runtime_tile_records.iterator" not in code
-    from helion._compiler.program_id import _literal_mailbox_access_fields
+    assert grouped_plan["scheduler_mode"] == expected_scheduler.value
+    assert ("StaticPersistentGroupTileScheduler.create" in code) is not runtime_direct
+    assert ("tcgen05_grouped_runtime_tile_records.iterator" in code) is runtime_direct
+    if not runtime_direct:
+        from helion._compiler.program_id import _literal_mailbox_access_fields
 
-    consumer_fields, producer_fields = _literal_mailbox_access_fields(
-        ast.parse(code), "tcgen05_work_tile_smem"
-    )
-    assert consumer_fields == producer_fields == {0, 1, 2, 3, 4, 8}
-    assert _scheduler_mailbox_publish_fields(code) == (
-        {0, 1, 2, 3, 4, 8},
-        {2},
-    )
+        consumer_fields, producer_fields = _literal_mailbox_access_fields(
+            ast.parse(code), "tcgen05_work_tile_smem"
+        )
+        assert consumer_fields == producer_fields == {0, 1, 2, 3, 4, 8}
+        assert _scheduler_mailbox_publish_fields(code) == (
+            {0, 1, 2, 3, 4, 8},
+            {2},
+        )
     assert "num_sm_multiplier" not in grouped_plan
     assert {
         "bm": grouped_plan["bm"],
@@ -1351,17 +1533,17 @@ def test_grouped_worklist_nm_one_cta_runtime_direct_upper_n_record_count() -> No
     ]
     records = _tcgen05_grouped_runtime_nm_tile_records(
         rows,
-        [(4096, 32, 2048, 1)] * len(rows),
+        [(7168, 32, 2048, 1)] * len(rows),
         source_tile_m=32,
         source_tile_n=128,
         l2_swizzle_size=1,
     )
 
-    assert len(records) == 6 * 32
+    assert len(records) == 6 * 56
     for metadata_idx in range(6):
-        group_records = records[metadata_idx * 32 : (metadata_idx + 1) * 32].tolist()
-        assert [record[1] for record in group_records] == list(range(32))
-        assert {record[2] for record in group_records} == {metadata_idx}
+        group_records = records[metadata_idx * 56 : (metadata_idx + 1) * 56]
+        assert group_records[:, 1].tolist() == list(range(56))
+        assert set(group_records[:, 2].tolist()) == {metadata_idx}
 
 
 def test_grouped_worklist_nm_panel_raster_codegen_and_mapping() -> None:
@@ -1392,22 +1574,6 @@ def test_grouped_worklist_nm_panel_raster_codegen_and_mapping() -> None:
     )
     panel_l2_swizzle_size = grouped_plan["l2_swizzle_size"]
     assert panel_l2_swizzle_size == 8
-    runtime_records = _tcgen05_grouped_runtime_nm_tile_records(
-        [[0, 0, 257, 448], [1, 448, 513, 672]],
-        [(2560, 448, 128, 1), (2560, 672, 128, 1)],
-        source_tile_m=source_m_tile,
-        source_tile_n=256,
-        l2_swizzle_size=panel_l2_swizzle_size,
-    )
-    runtime_record_rows = runtime_records.tolist()
-    assert runtime_record_rows
-    assert [(record[0], record[1]) for record in runtime_record_rows[:20]] == (
-        _expected_panel_coords(
-            m_tiles=2,
-            n_tiles=10,
-            configured_panel_size=8,
-        )
-    )
 
 
 def test_grouped_worklist_nm_fixed_tensormap_rejects_misaligned_d() -> None:
@@ -1418,32 +1584,33 @@ def test_grouped_worklist_nm_fixed_tensormap_rejects_misaligned_d() -> None:
     k = 128
     a_packed = torch.empty((m_total, k), dtype=torch.bfloat16, device=DEVICE)
     b_grouped = torch.empty((1, n, k), dtype=torch.bfloat16, device=DEVICE)
+    work_tile_metadata = torch.tensor(
+        [[0, 0, m_total, m_total]],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
     aligned_output = torch.empty((m_total, n), dtype=torch.bfloat16, device=DEVICE)
     d_storage = torch.empty(m_total * n + 1, dtype=torch.bfloat16, device=DEVICE)
     output = d_storage[1:].view(m_total, n)
     assert output.data_ptr() % 16 != 0
 
-    plan: dict[str, object] = {
-        "fixed_tensormaps": True,
-        "orientation": "nm",
-        "worklist_metadata": True,
-        "dynamic_ab_tensormap_rank": 2,
-        "lhs_idx": 0,
-        "rhs_idx": 1,
-        "n_size": n,
-        "k_total_size": k,
-        "bm": 256,
-        "bk": 64,
-    }
+    code = _code_for(
+        (a_packed, b_grouped, work_tile_metadata),
+        _selected_config(64, m_total),
+    )
+    plans = _wrapper_plans(code)
+    plan = next(
+        candidate
+        for candidate in plans
+        if candidate["kind"] == "tcgen05_grouped_static_persistent"
+    )
     cute_kernel = type("FixedTensorMapKernel", (), {})()
-    cute_kernel._helion_cute_wrapper_plans = [
-        {"kind": "tcgen05_d_tma", "fixed_tensormap": True, "d_idx": 2}
-    ]
+    cute_kernel._helion_cute_wrapper_plans = plans
 
     _validate_tcgen05_grouped_fixed_tensormaps(
         cute_kernel,
         plan,
-        (a_packed, b_grouped, aligned_output),
+        (work_tile_metadata, a_packed, b_grouped, aligned_output),
     )
     with pytest.raises(
         helion.exc.BackendUnsupported,
@@ -1452,7 +1619,7 @@ def test_grouped_worklist_nm_fixed_tensormap_rejects_misaligned_d() -> None:
         _validate_tcgen05_grouped_fixed_tensormaps(
             cute_kernel,
             plan,
-            (a_packed, b_grouped, output),
+            (work_tile_metadata, a_packed, b_grouped, output),
         )
 
 
@@ -1530,6 +1697,85 @@ def test_grouped_worklist_nm_legacy_bk64_codegen() -> None:
     assert (d_plan["bm"], d_plan["bn"], d_plan["orientation"]) == (256, 224, "nm")
 
 
+def test_grouped_worklist_nm_compiler_facts_reject_over_budget_profile() -> None:
+    _require_codegen_cuda()
+
+    # Source-256/BK64/AB7 exceeds the exact B200 worklist footprint.  Compiler
+    # seeds register the host allocation facts, so normalization rejects this
+    # profile before the generated-allocation backstop.
+    config = _selected_config(
+        64,
+        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+        ab_stages=7,
+    )
+    args = _make_args(
+        (224, 256),
+        n=224,
+        k=64,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+    )
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    bound.env.config_spec.register_cute_tcgen05_grouped_worklist_smem_facts(
+        group_count=int(args[2].size(0)),
+        device_split_sizes=False,
+    )
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+        pytest.raises(
+            helion.exc.InvalidConfig,
+            match="tcgen05_ab_stages",
+        ),
+    ):
+        bound.to_triton_code(config)
+
+
+def test_grouped_worklist_nm_rejects_shifted_load_mask() -> None:
+    _require_codegen_cuda()
+
+    args = (*_make_args((224, 256), n=224, k=128), 1, 1)
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    assert not bound.env.config_spec.cute_tcgen05_search_enabled
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+        pytest.raises(
+            helion.exc.BackendUnsupported,
+            match="rank3 grouped semantic proof failed",
+        ),
+    ):
+        bound.to_triton_code(_selected_config())
+
+
+def test_grouped_worklist_nm_rejects_extra_metadata_columns() -> None:
+    _require_codegen_cuda()
+
+    a_packed, b_grouped, worklist = _make_args((224, 256), n=224, k=128)
+    extra_column = torch.zeros(
+        (worklist.size(0), 1),
+        dtype=worklist.dtype,
+        device=worklist.device,
+    )
+    args = (a_packed, b_grouped, torch.cat((worklist, extra_column), dim=1))
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    assert not bound.env.config_spec.cute_tcgen05_search_enabled
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+        pytest.raises(
+            helion.exc.BackendUnsupported,
+            match="rank3 grouped semantic proof failed|MMA RHS was not grouped rank-3",
+        ),
+    ):
+        bound.to_triton_code(_selected_config())
+
+
 @pytest.mark.parametrize(
     ("case", "match"),
     (
@@ -1559,7 +1805,7 @@ def test_grouped_worklist_nm_rejects_ineligible_inputs(case: str, match: str) ->
         args = (a_packed, strided_b, work_tile_metadata)
 
     with pytest.raises(helion.exc.BackendUnsupported, match=match):
-        _code_for(args)
+        _code_for(args, _selected_config())
 
 
 @pytest.mark.parametrize(
@@ -1567,19 +1813,21 @@ def test_grouped_worklist_nm_rejects_ineligible_inputs(case: str, match: str) ->
     (
         (64, TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT),
         (128, TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE),
+        (64, TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE),
     ),
 )
 def test_grouped_worklist_nm_runtime_and_graph_replay(
     block_k: int,
     source_m_tile: int,
 ) -> None:
-    _require_runtime_cuda13_sm100()
+    _require_runtime_cuda13_sm100_or_newer()
 
-    m_sizes = (224, 449, 256)
+    small_source = source_m_tile == TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
+    m_sizes = (24, 23, 19, 17, 20, 18) if small_source else (224, 449, 256)
     args = _make_args(
         m_sizes,
-        n=512,
-        k=2 * block_k,
+        n=4096 if small_source else 512,
+        k=2048 if small_source else 2 * block_k,
         dirty_padding=True,
         source_m_tile=source_m_tile,
     )
@@ -1610,12 +1858,16 @@ def test_grouped_worklist_nm_runtime_and_graph_replay(
         # and a non-identity metadata-row-to-group mapping.  Total aligned M is
         # unchanged, so this exercises the scheduler metadata refresh rather
         # than recompilation or a new allocation shape.
-        mutated_m_sizes = (
-            (225, 224, 449)
-            if source_m_tile == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
-            else (257, 224, 256)
-        )
-        mutated_group_ids = (2, 0, 1)
+        if small_source:
+            mutated_m_sizes = (15, 20, 17, 19, 23, 24)
+            mutated_group_ids = (5, 4, 3, 2, 1, 0)
+        else:
+            mutated_m_sizes = (
+                (225, 224, 449)
+                if source_m_tile == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+                else (257, 224, 256)
+            )
+            mutated_group_ids = (2, 0, 1)
         _refresh_worklist_without_recompile(
             bound,
             args,
@@ -1628,13 +1880,23 @@ def test_grouped_worklist_nm_runtime_and_graph_replay(
         captured = _capture_and_replay(bound, args, poison=-7.0)
 
     _assert_output(captured, args)
+    if small_source:
+        a_packed, b_grouped, work_tile_metadata = args
+        for group, start, valid_m, _store_m in work_tile_metadata.cpu().tolist():
+            oracle = (
+                a_packed[start : start + valid_m].float() @ b_grouped[group].float().T
+            ).double()
+            actual = captured[start : start + valid_m].double()
+            denominator = (actual.square() + oracle.square()).sum()
+            diff = 1 - 2 * (actual * oracle).sum() / denominator
+            assert float(diff.item()) <= 1e-5
 
 
 @pytest.mark.parametrize("runtime_direct", (False, True))
 def test_grouped_worklist_nm_zero_token_groups_runtime_and_graph_replay(
     runtime_direct: bool,
 ) -> None:
-    _require_runtime_cuda13_sm100()
+    _require_runtime_cuda13_sm100_or_newer()
 
     source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
     args = _make_args(
@@ -1660,7 +1922,7 @@ def test_grouped_worklist_nm_zero_token_groups_runtime_and_graph_replay(
 
 
 def test_grouped_worklist_nm_zero_valid_tail_runtime_and_graph_replay() -> None:
-    _require_runtime_cuda13_sm100()
+    _require_runtime_cuda13_sm100_or_newer()
 
     source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
     n = 256
@@ -1706,60 +1968,99 @@ def test_grouped_worklist_nm_zero_valid_tail_runtime_and_graph_replay() -> None:
     )
 
 
-def test_grouped_worklist_nm_nonzero_overlap_is_rejected_at_launch() -> None:
-    _require_runtime_cuda13_sm100()
+@pytest.mark.parametrize(
+    ("m_sizes", "overlap", "ab_stages", "match"),
+    (
+        pytest.param(
+            (224, 224),
+            True,
+            None,
+            "overlapping A rows",
+            id="overlap",
+        ),
+        pytest.param((0, 0), False, 3, "all-empty worklist", id="all-empty"),
+    ),
+)
+def test_grouped_worklist_nm_invalid_metadata_is_rejected_at_launch(
+    m_sizes: tuple[int, ...],
+    overlap: bool,
+    ab_stages: int | None,
+    match: str,
+) -> None:
+    _require_runtime_cuda13_sm100_or_newer()
 
     source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
     args = _make_args(
-        (224, 224),
+        m_sizes,
         n=512,
         k=128,
         source_m_tile=source_m_tile,
     )
-    args[2][1, 1] = 0
+    if overlap:
+        args[2][1, 1] = 0
     with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
         bound = _configured_bound(
             args,
             64,
-            ab_stages=3,
+            ab_stages=ab_stages,
             source_m_tile=source_m_tile,
             runtime_direct=True,
         )
         with pytest.raises(
             helion.exc.BackendUnsupported,
-            match="overlapping A rows",
+            match=match,
         ):
             bound(*args)
 
 
-def test_grouped_worklist_nm_all_empty_is_rejected_at_launch() -> None:
-    _require_runtime_cuda13_sm100()
+@pytest.mark.parametrize(
+    ("source_m_tile", "mn_major_b", "consumer_regs", "l2_swizzle_size"),
+    (
+        pytest.param(
+            TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+            True,
+            224,
+            16,
+            id="source224-n-major-r224-panel16",
+        ),
+        pytest.param(
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+            True,
+            224,
+            16,
+            id="source256-n-major-r224-panel16",
+        ),
+        pytest.param(
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+            False,
+            256,
+            8,
+            id="source256-k-major-r256-panel8",
+        ),
+        pytest.param(
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+            False,
+            240,
+            1,
+            id="source256-k-major-r240-panel1",
+        ),
+        pytest.param(
+            TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+            False,
+            256,
+            1,
+            id="source256-k-major-r256-panel1",
+        ),
+    ),
+)
+def test_grouped_worklist_nm_clc_runtime_and_graph_replay(
+    source_m_tile: int,
+    mn_major_b: bool,
+    consumer_regs: int,
+    l2_swizzle_size: int,
+) -> None:
+    _require_runtime_cuda13_sm100_or_newer()
 
-    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
-    args = _make_args(
-        (0, 0),
-        n=512,
-        k=128,
-        source_m_tile=source_m_tile,
-    )
-    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
-        bound = _configured_bound(
-            args,
-            64,
-            source_m_tile=source_m_tile,
-            runtime_direct=True,
-        )
-        with pytest.raises(
-            helion.exc.BackendUnsupported,
-            match="all-empty worklist",
-        ):
-            bound(*args)
-
-
-def test_grouped_worklist_nm_runtime_direct_clc_runtime_and_graph_replay() -> None:
-    _require_runtime_cuda13_sm100()
-
-    source_m_tile = TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE
     m_sizes = (1024, 1024, 1024)
     n = 4096
     args = _make_args(
@@ -1767,6 +2068,7 @@ def test_grouped_worklist_nm_runtime_direct_clc_runtime_and_graph_replay() -> No
         n=n,
         k=128,
         dirty_padding=True,
+        mn_major_b=mn_major_b,
         source_m_tile=source_m_tile,
     )
     logical_clusters = sum(
@@ -1782,8 +2084,8 @@ def test_grouped_worklist_nm_runtime_direct_clc_runtime_and_graph_replay() -> No
             64,
             ab_stages=6,
             source_m_tile=source_m_tile,
-            consumer_regs=256,
-            l2_swizzle_size=8,
+            consumer_regs=consumer_regs,
+            l2_swizzle_size=l2_swizzle_size,
             runtime_direct=True,
             clc=True,
         )
@@ -1808,127 +2110,58 @@ def test_grouped_worklist_nm_runtime_direct_clc_runtime_and_graph_replay() -> No
 
 
 def test_grouped_worklist_nm_panel_raster_runtime_and_graph_replay() -> None:
-    _require_runtime_cuda13_sm100()
-
-    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
-    args = _make_args(
+    _run_standard_graph_replay_case(
         (257, 513),
         n=2560,
         k=128,
-        dirty_padding=True,
-        source_m_tile=source_m_tile,
-    )
-    warmup, captured = _run_graph_replay(
-        args,
-        64,
-        source_m_tile=source_m_tile,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
         l2_swizzle_size=8,
         runtime_direct=True,
+        exact_replay=True,
     )
-    torch.testing.assert_close(captured, warmup, rtol=0, atol=0)
 
 
 def test_grouped_worklist_nm_bk128_ab2_runtime_and_graph_replay() -> None:
-    _require_runtime_cuda13_sm100()
-
-    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
-    args = _make_args(
+    _run_standard_graph_replay_case(
         (224, 449, 256),
         n=512,
         k=256,
-        dirty_padding=True,
-        source_m_tile=source_m_tile,
-    )
-    _run_graph_replay(
-        args,
-        128,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        block_k=128,
         ab_stages=2,
-        source_m_tile=source_m_tile,
     )
-
-
-def test_grouped_worklist_nm_small_source_public_profile_graph_replay() -> None:
-    _require_runtime_cuda13_sm100()
-
-    args = _make_args(
-        (24, 23, 19, 17, 20, 18),
-        n=4096,
-        k=2048,
-        dirty_padding=True,
-        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
-    )
-    assert args[2].cpu().tolist() == [
-        [0, 0, 24, 32],
-        [1, 32, 23, 32],
-        [2, 64, 19, 32],
-        [3, 96, 17, 32],
-        [4, 128, 20, 32],
-        [5, 160, 18, 32],
-    ]
-    _, captured = _run_graph_replay(
-        args,
-        64,
-        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
-    )
-    a_packed, b_grouped, work_tile_metadata = args
-    for group, start, valid_m, _store_m in work_tile_metadata.cpu().tolist():
-        oracle = a_packed[start : start + valid_m].float() @ b_grouped[group].float().T
-        actual = captured[start : start + valid_m].double()
-        oracle = oracle.double()
-        denominator = (actual.square() + oracle.square()).sum()
-        diff = 1 - 2 * (actual * oracle).sum() / denominator
-        assert float(diff.item()) <= 1e-5
 
 
 def test_grouped_worklist_nm_one_cta_mn_major_legacy_graph_replay() -> None:
-    _require_runtime_cuda13_sm100()
-
-    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
-    args = _make_args(
+    _run_standard_graph_replay_case(
         (24, 23, 19, 17, 20, 18),
         n=512,
         k=128,
-        dirty_padding=True,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
         mn_major_b=True,
-        source_m_tile=source_m_tile,
-    )
-    n, k = args[1].shape[1:]
-    assert tuple(args[1].stride()) == (n * k, 1, n)
-    _run_graph_replay(
-        args,
-        64,
-        source_m_tile=source_m_tile,
         cluster_m=1,
         consumer_regs=240,
     )
 
 
 def test_grouped_worklist_nm_one_cta_direct_graph_replay() -> None:
-    _require_runtime_cuda13_sm100()
-
     source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
     # Include a <=16-row group so CTA-group::1 exercises its runtime UMMA-N=16
     # descriptor path in addition to the full physical N=32 path.
     actual_ms = (24, 23, 19, 17, 20, 15)
-    args = _make_args(
-        actual_ms,
-        n=4096,
-        k=2048,
-        dirty_padding=True,
-        source_m_tile=source_m_tile,
-    )
     expected_metadata = []
     start = 0
     for group, actual_m in enumerate(actual_ms):
         expected_metadata.append([group, start, actual_m, source_m_tile])
         start += source_m_tile
-    assert args[2].cpu().tolist() == expected_metadata
-    _run_graph_replay(
-        args,
-        64,
+    _run_standard_graph_replay_case(
+        actual_ms,
+        n=4096,
+        k=2048,
         source_m_tile=source_m_tile,
         cluster_m=1,
         runtime_direct=True,
+        expected_metadata=expected_metadata,
     )
 
 
@@ -1945,51 +2178,31 @@ def test_grouped_worklist_nm_one_cta_promoted_profiles_graph_replay(
     consumer_regs: int,
     mn_major_b: bool,
 ) -> None:
-    _require_runtime_cuda13_sm100()
-
-    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
-    args = _make_args(
+    _run_standard_graph_replay_case(
         (24, 23, 19, 17, 20, 18),
         n=512,
         k=2 * block_k,
-        dirty_padding=True,
-        mn_major_b=mn_major_b,
-        source_m_tile=source_m_tile,
-    )
-    n, k = args[1].shape[1:]
-    expected_b_stride = (n * k, 1, n) if mn_major_b else (n * k, k, 1)
-    assert tuple(args[1].stride()) == expected_b_stride
-    warmup, captured = _run_graph_replay(
-        args,
-        block_k,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
+        block_k=block_k,
         ab_stages=ab_stages,
-        source_m_tile=source_m_tile,
         cluster_m=1,
         consumer_regs=consumer_regs,
+        mn_major_b=mn_major_b,
         runtime_direct=True,
+        exact_replay=True,
     )
-    torch.testing.assert_close(captured, warmup, rtol=0, atol=0)
 
 
 def test_grouped_worklist_nm_one_cta_multitile_dynamic_graph_replay() -> None:
-    _require_runtime_cuda13_sm100()
-
-    source_m_tile = TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE
-    args = _make_args(
+    _run_standard_graph_replay_case(
         (65, 33),
         n=160,
         k=128,
-        dirty_padding=True,
-        source_m_tile=source_m_tile,
-    )
-    assert args[2].cpu().tolist() == [
-        [0, 0, 65, 96],
-        [1, 96, 33, 64],
-    ]
-    warmup, captured = _run_graph_replay(
-        args,
-        64,
-        source_m_tile=source_m_tile,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SMALL_SOURCE_M_TILE,
         cluster_m=1,
+        expected_metadata=[
+            [0, 0, 65, 96],
+            [1, 96, 33, 64],
+        ],
+        exact_replay=True,
     )
-    torch.testing.assert_close(captured, warmup, rtol=0, atol=0)

--- a/test/test_cute_device_state.py
+++ b/test/test_cute_device_state.py
@@ -15,6 +15,7 @@ from torch.fx import Graph
 from helion import exc
 from helion._compiler.ast_extension import statement_from_string
 from helion._compiler.cute.cute_mma import _collective_load_dependency_nodes
+from helion._compiler.cute.cute_mma import _emit_tcgen05_device_segments_setup
 from helion._compiler.cute.cutedsl_compat import emit_pipeline_advance
 from helion._compiler.cute.device_state import CuteDeviceFunctionState
 from helion._compiler.cute.device_state import CuteTcgen05GroupedPlan
@@ -78,6 +79,20 @@ def _grouped_plan(**overrides: object) -> CuteTcgen05GroupedPlan:
     }
     kwargs.update(overrides)
     return CuteTcgen05GroupedPlan(**kwargs)
+
+
+def _runtime_direct_grouped_plan() -> CuteTcgen05GroupedPlan:
+    return _grouped_plan(
+        orientation=Tcgen05Orientation.NM,
+        scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
+        runtime_tile_records="runtime_tile_records",
+        runtime_total_clusters="runtime_total_clusters",
+        valid_m="valid_m",
+        store_m="store_m",
+        source_m_tile=32,
+        d_mode=Tcgen05GroupedDMode.ALL_TILES,
+        d_tensormap="d_tensormap",
+    )
 
 
 def _lifecycle(**overrides: object) -> Tcgen05LifecycleContext:
@@ -179,36 +194,37 @@ class TestCuteDeviceFunctionState(unittest.TestCase):
         device_search = _grouped_plan()
         self.assertFalse(device_search.uses_runtime_tile_table)
 
-        runtime_direct = _grouped_plan(
-            orientation=Tcgen05Orientation.NM,
-            scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
-            runtime_tile_records="runtime_tile_records",
-            runtime_total_clusters="runtime_total_clusters",
-            real_groups="real_groups",
-            valid_m="valid_m",
-            store_m="store_m",
-            source_m_tile=32,
-            d_mode=Tcgen05GroupedDMode.ALL_TILES,
-            d_tensormap="d_tensormap",
-        )
+        runtime_direct = _runtime_direct_grouped_plan()
         self.assertTrue(runtime_direct.uses_runtime_tile_table)
 
-        with self.assertRaises(AssertionError):
-            dataclasses.replace(
+        invalid_replacements = (
+            lambda: dataclasses.replace(
                 runtime_direct,
                 scheduler_mode=Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH,
-            )
-        with self.assertRaises(AssertionError):
-            _grouped_plan(
+            ),
+            lambda: _grouped_plan(
                 scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
-            )
-        with self.assertRaises(AssertionError):
-            _grouped_plan(fixed_tensormaps=True)
-        with self.assertRaises(AssertionError):
-            dataclasses.replace(
+            ),
+            lambda: _grouped_plan(fixed_tensormaps=True),
+            lambda: _grouped_plan(
+                orientation=Tcgen05Orientation.NM,
+                valid_m="valid_m",
+                store_m="store_m",
+                source_m_tile=32,
+                m_size=128,
+                real_groups="real_groups",
+                d_mode=Tcgen05GroupedDMode.ALL_TILES,
+                d_tensormap="d_tensormap",
+            ),
+            lambda: _grouped_plan(device_layout_kind="split_sizes"),
+            lambda: dataclasses.replace(
                 runtime_direct,
                 scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_CLC,
-            )
+            ),
+        )
+        for make_invalid in invalid_replacements:
+            with self.assertRaises(AssertionError):
+                make_invalid()
 
         runtime_clc = dataclasses.replace(
             runtime_direct,
@@ -219,19 +235,39 @@ class TestCuteDeviceFunctionState(unittest.TestCase):
         )
         self.assertTrue(runtime_clc.uses_runtime_tile_table)
 
-    def test_grouped_runtime_mode_matches_parent_warp_topology(self) -> None:
-        runtime_direct = _grouped_plan(
+    def test_grouped_device_metadata_setup_uses_one_physical_thread(self) -> None:
+        grouped = _grouped_plan(
             orientation=Tcgen05Orientation.NM,
-            scheduler_mode=Tcgen05GroupedSchedulerMode.RUNTIME_DIRECT,
-            runtime_tile_records="runtime_tile_records",
-            runtime_total_clusters="runtime_total_clusters",
-            real_groups="real_groups",
             valid_m="valid_m",
             store_m="store_m",
             source_m_tile=32,
+            m_size=33,
+            device_layout_kind="split_sizes",
             d_mode=Tcgen05GroupedDMode.ALL_TILES,
             d_tensormap="d_tensormap",
         )
+        prefix: list[ast.AST] = []
+        device_function = SimpleNamespace(new_var=lambda name: name)
+
+        _emit_tcgen05_device_segments_setup(
+            prefix,
+            cast("Any", device_function),
+            grouped,
+            n_size=64,
+            k_size=64,
+            layout_dtype=torch.int32,
+        )
+
+        source = ast.unparse(ast.Module(body=prefix, type_ignores=[]))
+        self.assertIn(
+            "if cute.arch.thread_idx()[0] == 0 and cute.arch.thread_idx()[1] == 0 "
+            "and (cute.arch.thread_idx()[2] == 0):",
+            source,
+        )
+        self.assertNotIn("if cute.arch.thread_idx()[0] == 0:\n", source)
+
+    def test_grouped_runtime_mode_matches_parent_warp_topology(self) -> None:
+        runtime_direct = _runtime_direct_grouped_plan()
         _plan(grouped=runtime_direct)
         with self.assertRaises(AssertionError):
             _plan(grouped=runtime_direct, scheduler_warp_count=1)
@@ -241,6 +277,7 @@ class TestCuteDeviceFunctionState(unittest.TestCase):
             scheduler_mode=Tcgen05GroupedSchedulerMode.DEVICE_GROUP_SEARCH,
             runtime_tile_records=None,
             runtime_total_clusters=None,
+            real_groups="real_groups",
         )
         _plan(grouped=device_search_nm, scheduler_warp_count=1)
         with self.assertRaises(AssertionError):

--- a/test/test_cute_grouped_gemm_split_sizes.py
+++ b/test/test_cute_grouped_gemm_split_sizes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import itertools
 import os
 from unittest.mock import patch
 
@@ -9,8 +10,13 @@ import torch
 
 import helion
 from helion._compat import requires_cuda_version
+from helion._compiler.cute.cute_mma import analyze_tcgen05_grouped_worklist
+from helion._compiler.cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY,
+)
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
 )
@@ -20,6 +26,7 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
 )
+from helion._hardware import HardwareInfo
 from helion._testing import DEVICE
 from helion._testing import matchesBackends
 from helion._testing import patch_cute_mma_support
@@ -110,6 +117,139 @@ def _device_split_sizes_kernel(
             + torch.where(group > 2, s2, 0)
             + torch.where(group > 3, s3, 0)
         )
+        local_m = tile_m.index
+        row_index = group_start + local_m
+        valid_rows = local_m < group_m
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k, block_size=block_k):
+            a_blk = hl.load(
+                a_packed,
+                [row_index, tile_k],
+                extra_mask=valid_rows[:, None],  # pyrefly: ignore[bad-index]
+            )
+            acc = torch.addmm(
+                acc,
+                a_blk,
+                b_grouped[group, tile_n, tile_k].T,
+            )
+        hl.store(
+            out,
+            [row_index, tile_n],
+            acc.to(out.dtype),
+            extra_mask=valid_rows[:, None],  # pyrefly: ignore[bad-index]
+        )
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _device_offsets_kernel(
+    a_packed: torch.Tensor,
+    b_grouped: torch.Tensor,
+    offsets: torch.Tensor,
+) -> torch.Tensor:
+    m_total, k = a_packed.shape
+    groups, n, k2 = b_grouped.shape
+    assert k == k2
+    assert groups == 8
+    assert offsets.size(0) == 9
+    block_m = hl.register_block_size(256)
+    block_n = hl.register_block_size(128)
+    block_k = hl.register_block_size(64)
+    out = torch.empty(
+        m_total,
+        n,
+        dtype=a_packed.dtype,
+        device=a_packed.device,
+    )
+    for group_tile, tile_m, tile_n in hl.tile(
+        [groups, m_total, n],
+        block_size=[1, block_m, block_n],
+    ):
+        group = group_tile.index.sum()
+        group_start = offsets[group]
+        # Repeat the start load to ensure recognition follows tensor/index
+        # provenance rather than requiring one shared FX load node.
+        group_m = offsets[group + 1] - offsets[group]
+        local_m = tile_m.index
+        row_index = group_start + local_m
+        valid_rows = local_m < group_m
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k, block_size=block_k):
+            a_blk = hl.load(
+                a_packed,
+                [row_index, tile_k],
+                extra_mask=valid_rows[:, None],  # pyrefly: ignore[bad-index]
+            )
+            acc = torch.addmm(
+                acc,
+                a_blk,
+                b_grouped[group, tile_n, tile_k].T,
+            )
+        hl.store(
+            out,
+            [row_index, tile_n],
+            acc.to(out.dtype),
+            extra_mask=valid_rows[:, None],  # pyrefly: ignore[bad-index]
+        )
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def _device_offsets_axis_order_kernel(
+    a_packed: torch.Tensor,
+    b_grouped: torch.Tensor,
+    offsets: torch.Tensor,
+    axis_order: hl.constexpr,
+) -> torch.Tensor:
+    """Equivalent offsets kernel with every root-grid axis permutation."""
+    m_total, k = a_packed.shape
+    groups, n, k2 = b_grouped.shape
+    assert k == k2
+    assert groups == 8
+    assert offsets.size(0) == 9
+    block_m = hl.register_block_size(256)
+    block_n = hl.register_block_size(128)
+    block_k = hl.register_block_size(64)
+    out = torch.empty(
+        m_total,
+        n,
+        dtype=a_packed.dtype,
+        device=a_packed.device,
+    )
+    if axis_order == 0:
+        grid_shape = [groups, m_total, n]
+        grid_blocks = [1, block_m, block_n]
+    elif axis_order == 1:
+        grid_shape = [groups, n, m_total]
+        grid_blocks = [1, block_n, block_m]
+    elif axis_order == 2:
+        grid_shape = [m_total, groups, n]
+        grid_blocks = [block_m, 1, block_n]
+    elif axis_order == 3:
+        grid_shape = [m_total, n, groups]
+        grid_blocks = [block_m, block_n, 1]
+    elif axis_order == 4:
+        grid_shape = [n, groups, m_total]
+        grid_blocks = [block_n, 1, block_m]
+    else:
+        grid_shape = [n, m_total, groups]
+        grid_blocks = [block_n, block_m, 1]
+    for axis0, axis1, axis2 in hl.tile(grid_shape, block_size=grid_blocks):
+        if axis_order == 0:
+            group_tile, tile_m, tile_n = axis0, axis1, axis2
+        elif axis_order == 1:
+            group_tile, tile_n, tile_m = axis0, axis1, axis2
+        elif axis_order == 2:
+            tile_m, group_tile, tile_n = axis0, axis1, axis2
+        elif axis_order == 3:
+            tile_m, tile_n, group_tile = axis0, axis1, axis2
+        elif axis_order == 4:
+            tile_n, group_tile, tile_m = axis0, axis1, axis2
+        else:
+            tile_n, tile_m, group_tile = axis0, axis1, axis2
+        group = group_tile.index.sum()
+        group_start = offsets[group]
+        group_m = offsets[group + 1] - offsets[group]
         local_m = tile_m.index
         row_index = group_start + local_m
         valid_rows = local_m < group_m
@@ -333,6 +473,33 @@ def _make_device_split_sizes_args(
     return a_packed, b_grouped, split_sizes
 
 
+def _make_device_offsets_args(
+    m_sizes: tuple[int, ...],
+    *,
+    n: int = 128,
+    k: int = 128,
+    offsets_dtype: torch.dtype = torch.int32,
+    offsets_stride: int = 1,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    a_packed, b_grouped, _split_sizes = _make_device_split_sizes_args(
+        m_sizes,
+        n=n,
+        k=k,
+        split_dtype=offsets_dtype,
+    )
+    offsets_storage = torch.empty(
+        (len(m_sizes) + 1) * offsets_stride,
+        device=DEVICE,
+        dtype=offsets_dtype,
+    )
+    offsets = offsets_storage[::offsets_stride]
+    offset_values = [0]
+    for size in m_sizes:
+        offset_values.append(offset_values[-1] + size)
+    offsets.copy_(torch.tensor(offset_values, device=DEVICE, dtype=offsets_dtype))
+    return a_packed, b_grouped, offsets
+
+
 def _configured_device_split_sizes_bound(
     args: tuple[torch.Tensor, ...], block_k: int = 128
 ):
@@ -389,6 +556,24 @@ def _assert_device_split_sizes_output(
     assert start == a_packed.size(0)
 
 
+def _assert_device_offsets_output(
+    out: torch.Tensor,
+    args: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+) -> None:
+    a_packed, b_grouped, offsets = args
+    offset_values = offsets.cpu().tolist()
+    for group, (start, end) in enumerate(itertools.pairwise(offset_values)):
+        expected = (a_packed[start:end].float() @ b_grouped[group].float().T).to(
+            out.dtype
+        )
+        torch.testing.assert_close(
+            out[start:end],
+            expected,
+            rtol=3e-2,
+            atol=3e-2,
+        )
+
+
 def _require_codegen_cuda() -> None:
     if DEVICE.type != "cuda":
         pytest.skip("tcgen05 grouped split-size codegen needs CUDA fake inputs")
@@ -416,6 +601,14 @@ def _grouped_plan(code: str) -> dict[str, object]:
     )
 
 
+def _assert_plan_fields(plan: dict[str, object], **expected: object) -> None:
+    for name, value in expected.items():
+        if isinstance(value, bool):
+            assert plan[name] is value
+        else:
+            assert plan[name] == value
+
+
 def _bk64_device_split_smem_bytes(group_count: int) -> int:
     from helion._compiler.cute.tcgen05_constants import (
         tcgen05_grouped_worklist_smem_bytes,
@@ -441,6 +634,259 @@ def test_grouped_device_split_smem_accounting_includes_fixed_allocations() -> No
     # mailboxes, TensorMaps, barriers, and alignment are included.
     assert _bk64_device_split_smem_bytes(8) == 227 * 1024
     assert _bk64_device_split_smem_bytes(51) > 227 * 1024
+
+
+def test_grouped_device_split_automatic_seed_families_use_mailbox_scheduler() -> None:
+    _require_codegen_cuda()
+    with torch.cuda.device(DEVICE):
+        capability = torch.cuda.get_device_capability(DEVICE)
+    hardware_names = {(10, 0): "NVIDIA B200", (10, 3): "NVIDIA GB300"}
+    if capability not in hardware_names:
+        pytest.skip("grouped worklist compiler seeds require SM100 or SM103")
+
+    args = _make_device_split_sizes_args(
+        (0, 1, 127, 224, 256, 449, 0, 991),
+        n=512,
+        k=64,
+    )
+    _device_split_sizes_kernel.reset()
+    with (
+        patch_cute_mma_support(),
+        patch(
+            "helion._hardware.get_hardware_info",
+            return_value=HardwareInfo(
+                device_kind="cuda",
+                hardware_name=hardware_names[capability],
+                runtime_version="13.0",
+                compute_capability=f"sm{capability[0]}{capability[1]}",
+            ),
+        ),
+    ):
+        bound = _device_split_sizes_kernel.bind(args)
+
+    assert bound.host_function is not None
+    analysis = analyze_tcgen05_grouped_worklist(
+        bound.env,
+        bound.host_function.device_ir,
+        bound.config_spec.matmul_facts[0],
+    )
+    assert analysis is not None
+    seed_facts = analysis.seed_facts
+    assert seed_facts.device_split_sizes
+    assert bound.config_spec._cute_tcgen05_config.grouped_worklist_smem_facts == (
+        8,
+        True,
+    )
+    seeds = [
+        config
+        for config in bound.config_spec.compiler_seed_configs
+        if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+        == TCGEN05_GROUPED_MODE_WORKLIST_NM
+    ]
+    assert seeds
+    assert {
+        config.config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY]
+        for config in seeds
+    } == {
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        TCGEN05_GROUPED_WORKLIST_LARGE_SOURCE_M_TILE,
+    }
+    assert (
+        seeds[0].config[TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_CONFIG_KEY]
+        == TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT
+    )
+    assert all(
+        TCGEN05_GROUPED_RUNTIME_DIRECT_CONFIG_KEY not in config.config
+        for config in seeds
+    )
+    assert all(
+        config.config.get(TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY, 1) == 1
+        for config in seeds
+    )
+    assert bound.config_spec.compiler_default_config == seeds[0]
+
+
+def test_grouped_device_offsets_are_recognized_and_normalized() -> None:
+    _require_codegen_cuda()
+    with torch.cuda.device(DEVICE):
+        capability = torch.cuda.get_device_capability(DEVICE)
+    hardware_names = {(10, 0): "NVIDIA B200", (10, 3): "NVIDIA GB300"}
+    if capability not in hardware_names:
+        pytest.skip("grouped worklist compiler seeds require SM100 or SM103")
+
+    args = _make_device_offsets_args(
+        (0, 1, 127, 224, 256, 449, 0, 991),
+        n=512,
+        k=64,
+        offsets_dtype=torch.int64,
+        offsets_stride=2,
+    )
+    _device_offsets_kernel.reset()
+    with (
+        patch_cute_mma_support(),
+        patch(
+            "helion._hardware.get_hardware_info",
+            return_value=HardwareInfo(
+                device_kind="cuda",
+                hardware_name=hardware_names[capability],
+                runtime_version="13.0",
+                compute_capability=f"sm{capability[0]}{capability[1]}",
+            ),
+        ),
+    ):
+        bound = _device_offsets_kernel.bind(args)
+
+    assert bound.host_function is not None
+    analysis = analyze_tcgen05_grouped_worklist(
+        bound.env,
+        bound.host_function.device_ir,
+        bound.config_spec.matmul_facts[0],
+    )
+    assert analysis is not None
+    seed_facts = analysis.seed_facts
+    assert seed_facts.device_split_sizes
+    seeds = [
+        config
+        for config in bound.config_spec.compiler_seed_configs
+        if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+        == TCGEN05_GROUPED_MODE_WORKLIST_NM
+    ]
+    assert seeds
+
+    code = _code_for(_device_offsets_kernel, args, _selected_config(64))
+    plan = _grouped_plan(code)
+    _assert_plan_fields(
+        plan,
+        device_split_sizes=True,
+        device_layout_kind="offsets",
+        group_count=8,
+        bm=256,
+        bn=224,
+        bk=64,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        m_size=args[0].size(0),
+        orientation="nm",
+    )
+    assert "iterator + cutlass.Int64(8) * cutlass.Int64(" in code
+
+
+@pytest.mark.parametrize(
+    "axis_order",
+    range(6),
+    ids=("g-m-n", "g-n-m", "m-g-n", "m-n-g", "n-g-m", "n-m-g"),
+)
+def test_grouped_device_offsets_root_axis_order_is_semantic(
+    axis_order: int,
+) -> None:
+    _require_codegen_cuda()
+    args = (
+        *_make_device_offsets_args(
+            (0, 1, 127, 224, 256, 449, 0, 991),
+            n=512,
+            k=64,
+        ),
+        axis_order,
+    )
+    _device_offsets_axis_order_kernel.reset()
+    with (
+        patch_cute_mma_support(),
+        patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+        patch(
+            "helion.runtime.kernel.target_device_capability",
+            return_value=(10, 0),
+        ),
+        patch(
+            "helion._compiler.compile_environment.target_device_capability",
+            return_value=(10, 0),
+        ),
+        patch(
+            "helion._hardware.get_hardware_info",
+            return_value=HardwareInfo(
+                device_kind="cuda",
+                hardware_name="NVIDIA B200",
+                runtime_version="13.0",
+                compute_capability="sm100",
+            ),
+        ),
+    ):
+        bound = _device_offsets_axis_order_kernel.bind(args)
+
+    assert bound.host_function is not None
+    analysis = analyze_tcgen05_grouped_worklist(
+        bound.env,
+        bound.host_function.device_ir,
+        bound.config_spec.matmul_facts[0],
+    )
+    assert analysis is not None
+    assert analysis.device_layout_kind == "offsets"
+    assert any(
+        config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+        == TCGEN05_GROUPED_MODE_WORKLIST_NM
+        for config in bound.config_spec.compiler_seed_configs
+    )
+
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+    ):
+        code = bound.to_triton_code(_selected_config(64))
+    _assert_plan_fields(
+        _grouped_plan(code),
+        device_split_sizes=True,
+        device_layout_kind="offsets",
+        group_count=8,
+        bm=256,
+        bn=224,
+        bk=64,
+        source_m_tile=TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE_DEFAULT,
+        m_size=args[0].size(0),
+        orientation="nm",
+    )
+
+
+def test_grouped_device_offsets_root_axes_fail_closed() -> None:
+    _require_codegen_cuda()
+    args = (
+        *_make_device_offsets_args(
+            (32, 64, 96, 128, 160, 192, 224, 256),
+            n=224,
+            k=64,
+        ),
+        0,
+    )
+    _device_offsets_axis_order_kernel.reset()
+    bound = _device_offsets_axis_order_kernel.bind(args)
+    assert bound.host_function is not None
+    device_ir = bound.host_function.device_ir
+    fact = bound.config_spec.matmul_facts[0]
+    assert fact.m_block_id is not None
+    assert fact.n_block_id is not None
+    root_block_ids = device_ir.grid_block_ids[0]
+    canonical_block_id = bound.env.canonical_block_id
+    m_block_id = next(
+        block_id
+        for block_id in root_block_ids
+        if canonical_block_id(block_id) == canonical_block_id(fact.m_block_id)
+    )
+    n_block_id = next(
+        block_id
+        for block_id in root_block_ids
+        if canonical_block_id(block_id) == canonical_block_id(fact.n_block_id)
+    )
+    segment_block_id = next(
+        block_id
+        for block_id in root_block_ids
+        if canonical_block_id(block_id)
+        not in (canonical_block_id(m_block_id), canonical_block_id(n_block_id))
+    )
+    for malformed in (
+        [segment_block_id, m_block_id],
+        [segment_block_id, m_block_id, m_block_id],
+        [segment_block_id, n_block_id, n_block_id],
+        [m_block_id, n_block_id, n_block_id],
+    ):
+        with patch.object(device_ir, "grid_block_ids", [malformed]):
+            assert analyze_tcgen05_grouped_worklist(bound.env, device_ir, fact) is None
 
 
 @pytest.mark.parametrize(
@@ -483,33 +929,21 @@ def test_grouped_device_split_sizes_codegen_and_wrapper_plan(
     assert "tcgen05_grouped_real_groups" not in kernel_args
 
     plan = _grouped_plan(code)
-    assert {
-        "device_split_sizes": plan["device_split_sizes"],
-        "group_count": plan["group_count"],
-        "bk": plan["bk"],
-        "source_m_tile": plan["source_m_tile"],
-        "cluster_m": plan["cluster_m"],
-        "cluster_n": plan["cluster_n"],
-        "m_size": plan["m_size"],
-        "orientation": plan["orientation"],
-        "worklist_metadata": plan["worklist_metadata"],
-        "dynamic_ab_tensormaps": plan["dynamic_ab_tensormaps"],
-        "dynamic_ab_tensormap_rank": plan["dynamic_ab_tensormap_rank"],
-        "dynamic_d_tensormap": plan["dynamic_d_tensormap"],
-    } == {
-        "device_split_sizes": True,
-        "group_count": 8,
-        "bk": block_k,
-        "source_m_tile": source_m_tile,
-        "cluster_m": 2,
-        "cluster_n": 1,
-        "m_size": args[0].size(0),
-        "orientation": "nm",
-        "worklist_metadata": True,
-        "dynamic_ab_tensormaps": True,
-        "dynamic_ab_tensormap_rank": 2,
-        "dynamic_d_tensormap": True,
-    }
+    _assert_plan_fields(
+        plan,
+        device_split_sizes=True,
+        group_count=8,
+        bk=block_k,
+        source_m_tile=source_m_tile,
+        cluster_m=2,
+        cluster_n=1,
+        m_size=args[0].size(0),
+        orientation="nm",
+        worklist_metadata=True,
+        dynamic_ab_tensormaps=True,
+        dynamic_ab_tensormap_rank=2,
+        dynamic_d_tensormap=True,
+    )
     assert "real_groups_arg" not in plan
     assert "iterator + cutlass.Int64(7) * cutlass.Int64(" in code
 
@@ -549,10 +983,84 @@ def test_grouped_device_split_sizes_two_group_codegen() -> None:
     code = _code_for(_device_split_sizes_two_groups_kernel, args)
 
     plan = _grouped_plan(code)
-    assert plan["device_split_sizes"] is True
-    assert plan["group_count"] == 2
-    assert plan["m_size"] == args[0].size(0)
-    assert plan["orientation"] == "nm"
+    _assert_plan_fields(
+        plan,
+        device_split_sizes=True,
+        group_count=2,
+        m_size=args[0].size(0),
+        orientation="nm",
+    )
+
+
+def test_grouped_device_offsets_runtime() -> None:
+    _require_runtime_cuda13_sm100()
+
+    args = _make_device_offsets_args(
+        (0, 224, 17, 0, 449, 1, 256, 1101),
+        n=224,
+        k=128,
+        offsets_dtype=torch.int64,
+        offsets_stride=2,
+    )
+    _device_offsets_kernel.reset()
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _device_offsets_kernel.bind(args)
+        bound.set_config(_selected_config(64))
+        result = bound(*args)
+        torch.cuda.synchronize()
+        _assert_device_offsets_output(result, args)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = bound(*args)
+        torch.cuda.synchronize()
+
+        # A negative start expands the raw offset interval beyond the source
+        # kernel's finite local-M domain. The normalized scheduler must cap the
+        # source extent before clipping it to visible rows.
+        m_total = args[0].size(0)
+        args[0].normal_()
+        args[2].copy_(args[2].new_tensor((-50, *(m_total for _ in range(8)))))
+        captured.fill_(-7.0)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        visible_rows = m_total - 50
+        expected = (args[0][:visible_rows].float() @ args[1][0].float().T).to(
+            captured.dtype
+        )
+        torch.testing.assert_close(
+            captured[:visible_rows],
+            expected,
+            rtol=3e-2,
+            atol=3e-2,
+        )
+        torch.testing.assert_close(
+            captured[visible_rows:],
+            torch.full_like(captured[visible_rows:], -7.0),
+            rtol=0,
+            atol=0,
+        )
+
+
+def test_grouped_device_offsets_reordered_root_axes_runtime() -> None:
+    _require_runtime_cuda13_sm100()
+
+    tensor_args = _make_device_offsets_args(
+        (0, 224, 17, 0, 449, 1, 256, 1101),
+        n=224,
+        k=128,
+        offsets_dtype=torch.int64,
+        offsets_stride=2,
+    )
+    args = (*tensor_args, 5)
+    _device_offsets_axis_order_kernel.reset()
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _device_offsets_axis_order_kernel.bind(args)
+        bound.set_config(_selected_config(64))
+        result = bound(*args)
+        torch.cuda.synchronize()
+    _assert_device_offsets_output(result, tensor_args)
 
 
 def test_grouped_device_split_sizes_without_grouped_mode_falls_back() -> None:
@@ -661,13 +1169,16 @@ def test_grouped_device_split_sizes_runtime_edges_and_graph_replay(
             captured = bound(*args)
         torch.cuda.synchronize()
 
+        def replay(split_sizes: tuple[int, ...]) -> None:
+            args[0].normal_()
+            args[2].copy_(args[2].new_tensor(split_sizes))
+            captured.fill_(-7.0)
+            graph.replay()
+            torch.cuda.synchronize()
+
         new_split_sizes = (113, 0, 224, 200, 0, 1, 300, 1210)
         assert sum(new_split_sizes) == args[0].size(0)
-        args[0].normal_()
-        args[2].copy_(torch.tensor(new_split_sizes, device=DEVICE, dtype=args[2].dtype))
-        captured.fill_(-7.0)
-        graph.replay()
-        torch.cuda.synchronize()
+        replay(new_split_sizes)
 
         _assert_device_split_sizes_output(captured, args)
 
@@ -675,13 +1186,7 @@ def test_grouped_device_split_sizes_runtime_edges_and_graph_replay(
         # length exceeds M.  The replacement scheduler must preserve that
         # finite extent rather than constructing an out-of-bounds TensorMap.
         oversized_split_sizes = (args[0].size(0) + 1, 0, 0, 0, 0, 0, 0, 0)
-        args[0].normal_()
-        args[2].copy_(
-            torch.tensor(oversized_split_sizes, device=DEVICE, dtype=args[2].dtype)
-        )
-        captured.fill_(-7.0)
-        graph.replay()
-        torch.cuda.synchronize()
+        replay(oversized_split_sizes)
 
         expected = (args[0].float() @ args[1][0].float().T).to(captured.dtype)
         torch.testing.assert_close(captured, expected, rtol=3e-2, atol=3e-2)
@@ -699,13 +1204,7 @@ def test_grouped_device_split_sizes_runtime_edges_and_graph_replay(
             0,
             0,
         )
-        args[0].normal_()
-        args[2].copy_(
-            torch.tensor(negative_split_sizes, device=DEVICE, dtype=args[2].dtype)
-        )
-        captured.fill_(-7.0)
-        graph.replay()
-        torch.cuda.synchronize()
+        replay(negative_split_sizes)
 
         visible_rows = args[0].size(0) - 50
         expected = (args[0][:visible_rows].float() @ args[1][2].float().T).to(
@@ -735,13 +1234,7 @@ def test_grouped_device_split_sizes_runtime_edges_and_graph_replay(
                 0,
                 0,
             )
-            args[0].normal_()
-            args[2].copy_(
-                torch.tensor(wide_split_sizes, device=DEVICE, dtype=args[2].dtype)
-            )
-            captured.fill_(-7.0)
-            graph.replay()
-            torch.cuda.synchronize()
+            replay(wide_split_sizes)
 
             expected = (args[0].float() @ args[1][0].float().T).to(captured.dtype)
             torch.testing.assert_close(captured, expected, rtol=3e-2, atol=3e-2)

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -36,6 +36,7 @@ from helion._compiler.backend import CuteBackend
 from helion._compiler.backend import PallasBackend
 from helion._compiler.backend import TritonBackend
 from helion._compiler.backend import _loop_contains_matmul
+from helion._compiler.compile_environment import AutoSize
 from helion._compiler.compile_environment import CompileEnvironment
 from helion._compiler.cute.argreduce import codegen_cute_tile_argreduce
 from helion._compiler.cute.aten_lowering import codegen_baddbmm_cute
@@ -1160,6 +1161,20 @@ class TestCuteLowerings(unittest.TestCase):
                     supports_small_n_scalar_fallback=True,
                 )
             )
+
+    def test_static_problem_extent_rejects_unresolved_registered_blocks(self) -> None:
+        from helion.language.matmul_ops import _static_problem_extent
+
+        for unresolved_size in (AutoSize(), None):
+            with self.subTest(size=type(unresolved_size).__name__):
+                env = SimpleNamespace(
+                    get_block_id=lambda _size: 0,
+                    block_sizes=[SimpleNamespace(size=unresolved_size)],
+                )
+                self.assertIsNone(_static_problem_extent(env, 64))
+
+        unregistered_env = SimpleNamespace(get_block_id=lambda _size: None)
+        self.assertEqual(_static_problem_extent(unregistered_env, 64), 64)
 
     def test_tcgen05_swapped_matmul_small_n_runtime(self) -> None:
         """Swapped operands use tcgen05 with a column-major small-N output."""
@@ -16018,8 +16033,37 @@ class TestCuteLowerings(unittest.TestCase):
                         config=config,
                     )
                 )
-
         self.assertEqual(analyze.call_count, 2)
+
+    def test_tcgen05_fragment_source_tiles_reject_dynamic_problem_shape(
+        self,
+    ) -> None:
+        from helion._compiler.cute import cute_mma as cute_mma_module
+
+        candidate = cast("Any", SimpleNamespace(requires_fragment_epilogue=True))
+        static_extents = {"static_m": 128, "static_n": 128, "static_k": 64}
+        for dynamic_extent in static_extents:
+            with (
+                self.subTest(dynamic_extent=dynamic_extent),
+                patch.object(
+                    cute_mma_module,
+                    "_tcgen05_fragment_epilogue_operands_supported",
+                ) as operands_supported,
+            ):
+                plan = SimpleNamespace(
+                    **{
+                        **static_extents,
+                        dynamic_extent: None,
+                    }
+                )
+                self.assertFalse(
+                    cute_mma_module.tcgen05_fragment_epilogue_source_tiles_reachable(
+                        candidate,
+                        cast("Any", plan),
+                        cast("Any", SimpleNamespace()),
+                    )
+                )
+                operands_supported.assert_not_called()
 
     def test_tcgen05_fragment_projection_rotary_codegen(self) -> None:
         dtype = torch.bfloat16
@@ -17017,7 +17061,35 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
 
         return cute_matmul_residual_c_input
 
-    def _canonical_c_input_config(self) -> helion.Config:
+    def _fanout_kernel(self):  # type: ignore[no-untyped-def]
+        @helion.kernel(backend="cute")
+        def cute_matmul_residual_fanout(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            residual_a: torch.Tensor,
+            residual_b: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            m, k = x.size()
+            _, n = y.size()
+            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
+                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
+            return out_a, out_b
+
+        return cute_matmul_residual_fanout
+
+    def _square_args(self, count: int) -> tuple[torch.Tensor, ...]:
+        return tuple(
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16)
+            for _ in range(count)
+        )
+
+    def _canonical_c_input_config(self, *, ab_stages: int = 2) -> helion.Config:
         return helion.Config(
             block_sizes=[256, 256, 128],
             l2_groupings=[1],
@@ -17025,7 +17097,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             num_sm_multiplier=1,
             pid_type="persistent_interleaved",
             tcgen05_cluster_m=2,
-            tcgen05_ab_stages=2,
+            tcgen05_ab_stages=ab_stages,
             tcgen05_acc_stages=2,
             tcgen05_c_stages=2,
             tcgen05_num_epi_warps=4,
@@ -17849,35 +17921,12 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
     def test_aux_tma_load_rejects_multi_store_fanout(self) -> None:
         """Explicit aux TMA rejects multi-store fan-out instead of falling back."""
 
-        @helion.kernel(backend="cute")
-        def cute_matmul_residual_fanout(
-            x: torch.Tensor,
-            y: torch.Tensor,
-            residual_a: torch.Tensor,
-            residual_b: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, k = x.size()
-            _, n = y.size()
-            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
-                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
-            return out_a, out_b
-
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        kernel = self._fanout_kernel()
+        args = self._square_args(4)
         config = self._canonical_c_input_config()
         config.config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_TMA
         with patch_cute_mma_support():
-            bound = cute_matmul_residual_fanout.bind(args)
+            bound = kernel.bind(args)
             bound.env.config_spec.cute_tcgen05_search_enabled = True
             with self.assertRaises(exc.BackendUnsupported) as cm:
                 bound.to_triton_code(config)
@@ -19327,34 +19376,11 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         directly.
         """
 
-        @helion.kernel(backend="cute")
-        def cute_matmul_residual_fanout(
-            x: torch.Tensor,
-            y: torch.Tensor,
-            residual_a: torch.Tensor,
-            residual_b: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, k = x.size()
-            _, n = y.size()
-            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
-                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
-            return out_a, out_b
-
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        kernel = self._fanout_kernel()
+        args = self._square_args(4)
         config = self._canonical_c_input_config()
         with patch_cute_mma_support():
-            bound = cute_matmul_residual_fanout.bind(args)
+            bound = kernel.bind(args)
             bound.env.config_spec.cute_tcgen05_search_enabled = True
             code = bound.to_triton_code(config)
 
@@ -19423,31 +19449,8 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         explicit rejection assertion.
         """
         kernel = self._residual_kernel()
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
-        config = helion.Config(
-            block_sizes=[256, 256, 128],
-            l2_groupings=[1],
-            num_warps=4,
-            num_sm_multiplier=1,
-            pid_type="persistent_interleaved",
-            tcgen05_cluster_m=2,
-            tcgen05_ab_stages=3,
-            tcgen05_acc_stages=2,
-            tcgen05_c_stages=2,
-            tcgen05_num_epi_warps=4,
-            tcgen05_strategy="role_local_with_scheduler",
-            tcgen05_warp_spec_scheduler_warps=1,
-            tcgen05_warp_spec_c_input_warps=1,
-            indexing=[
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-        )
+        args = self._square_args(3)
+        config = self._canonical_c_input_config(ab_stages=3)
         with patch_cute_mma_support():
             bound = kernel.bind(args)
             bound.env.config_spec.cute_tcgen05_search_enabled = True
@@ -19479,11 +19482,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         and silently disable the cycle 2b productive body.
         """
         kernel = self._residual_kernel()
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        args = self._square_args(3)
         # The canonical cycle 2b config from
         # ``_canonical_c_input_config`` already uses
         # ``ab_stages=2`` + ``c_input_warps=1``.
@@ -19543,58 +19542,16 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         rejection cannot have fired on this path).
         """
 
-        @helion.kernel(backend="cute")
-        def cute_matmul_residual_fanout(
-            x: torch.Tensor,
-            y: torch.Tensor,
-            residual_a: torch.Tensor,
-            residual_b: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, k = x.size()
-            _, n = y.size()
-            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
-                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
-            return out_a, out_b
-
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        kernel = self._fanout_kernel()
+        args = self._square_args(4)
         # Same canonical config as
         # ``test_aux_pipeline_ab_stages_3_with_c_input_rejected``
         # — only difference is the fan-out kernel shape, which
         # should close the productive-body gate and prevent
         # the rejection from firing.
-        config = helion.Config(
-            block_sizes=[256, 256, 128],
-            l2_groupings=[1],
-            num_warps=4,
-            num_sm_multiplier=1,
-            pid_type="persistent_interleaved",
-            tcgen05_cluster_m=2,
-            tcgen05_ab_stages=3,
-            tcgen05_acc_stages=2,
-            tcgen05_c_stages=2,
-            tcgen05_num_epi_warps=4,
-            tcgen05_strategy="role_local_with_scheduler",
-            tcgen05_warp_spec_scheduler_warps=1,
-            tcgen05_warp_spec_c_input_warps=1,
-            indexing=[
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-        )
+        config = self._canonical_c_input_config(ab_stages=3)
         with patch_cute_mma_support():
-            bound = cute_matmul_residual_fanout.bind(args)
+            bound = kernel.bind(args)
             bound.env.config_spec.cute_tcgen05_search_enabled = True
             # Must not raise BackendUnsupported on the fan-out
             # path despite carrying ``ab_stages=3`` +
@@ -19617,10 +19574,9 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
 
         The productive C-input warp is reachable from the
         normal Helion autotune path when the bound kernel's
-        FX graphs contain a tcgen05 matmul AND at least one
-        ``memory_ops.load`` whose target isn't one of the
-        matmul operands (the residual / bias / chained
-        residual_relu pattern). Pin:
+        FX graphs contain an accepted matmul-to-store chain with at least one
+        per-subtile auxiliary load (the residual / bias / chained
+        residual-relu pattern). Pin:
           - ``cute_tcgen05_aux_kernel_detected`` is True after
             bind.
           - ``tcgen05_strategy`` autotune fragment widens to
@@ -19633,11 +19589,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         from helion._compiler.cute.strategies import Tcgen05Strategy
 
         kernel = self._residual_kernel()
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        args = self._square_args(3)
         with patch_cute_mma_support():
             bound = kernel.bind(args)
         self.assertTrue(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
@@ -19725,37 +19677,13 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         codegen already prevents the over-budget compile.
         """
 
-        @helion.kernel(backend="cute")
-        def cute_matmul_residual_fanout(
-            x: torch.Tensor,
-            y: torch.Tensor,
-            residual_a: torch.Tensor,
-            residual_b: torch.Tensor,
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, k = x.size()
-            _, n = y.size()
-            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
-                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
-            return out_a, out_b
-
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        kernel = self._fanout_kernel()
+        args = self._square_args(4)
         with patch_cute_mma_support():
-            bound = cute_matmul_residual_fanout.bind(args)
-        # Detector is intentionally coarse and DOES flag
-        # fan-out as aux (it has aux loads). The
-        # productive-body safety gate at codegen suppresses
-        # the productive body for fan-out specifically.
+            bound = kernel.bind(args)
+        # Both stores have accepted aux-fused chains, so the detector flags the
+        # kernel even though the productive-body safety gate suppresses the
+        # dedicated C-input pipeline for multi-store fan-out specifically.
         self.assertTrue(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
 
     def test_aux_autotune_fixup_demotes_ab3_c_input1(self) -> None:
@@ -19778,11 +19706,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         from helion._compiler.cute.strategies import Tcgen05Strategy
 
         kernel = self._residual_kernel()
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
+        args = self._square_args(3)
         with patch_cute_mma_support():
             bound = kernel.bind(args)
         # Manually craft the over-budget combo.
@@ -20063,25 +19987,11 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
     def test_aux_autotune_surface_stays_narrow_for_wrapped_cast_pure_matmul(
         self,
     ) -> None:
-        """Operand-cast wrappers (``lhs.to(dtype) @ rhs.to(dtype)``)
-        are traced through to the underlying ``memory_ops.load``
-        nodes so the detector classifies them as MMA-operand
-        loads, not aux loads.
+        """Operand-cast wrappers do not create an aux-fused store chain.
 
-        Without operand-trace, the detector's "every
-        ``memory_ops.load`` that isn't the exact node arg of
-        the MMA call is aux" rule misclassifies the underlying
-        load behind a ``convert_element_type`` wrapper as aux
-        and the autotune surface widens on a kernel where no
-        true aux load exists — autotune then samples the
-        strictly-worse inert C-input warp on pure matmul.
-
-        Pin: a pure matmul with explicit operand casts (fp32
-        operand tensors cast to bf16 before the dot) keeps
-        the detector flag False — the cast wrapper is walked
-        through to the underlying load via
-        ``_trace_to_load_through_casts`` and the load is
-        classified as an MMA operand, not an aux load.
+        Pin: a pure matmul with explicit fp32-to-bf16 operand casts keeps the
+        detector flag False because its accepted store chain is still an
+        identity epilogue with no auxiliary steps.
         """
         from helion._compiler.cute.strategies import Tcgen05Strategy
 

--- a/test/test_matmul_heuristics.py
+++ b/test/test_matmul_heuristics.py
@@ -182,9 +182,10 @@ def test_triton_b200_matmul_heuristic_gates_on_hardware() -> None:
     with patch(
         "helion._hardware.get_hardware_info",
         return_value=b200,
-    ):
+    ) as get_hardware_info:
         assert TritonB200MatmulHeuristic.is_eligible(env, SimpleNamespace())
         seed = TritonB200MatmulHeuristic.get_seed_config(env, SimpleNamespace())
+        get_hardware_info.assert_called_once_with(None)
 
     assert seed is not None
     assert dict(seed)["block_sizes"] == [128, 64, 64]
@@ -192,8 +193,9 @@ def test_triton_b200_matmul_heuristic_gates_on_hardware() -> None:
     with patch(
         "helion._hardware.get_hardware_info",
         return_value=h100,
-    ):
+    ) as get_hardware_info:
         assert not TritonB200MatmulHeuristic.is_eligible(env, SimpleNamespace())
+        get_hardware_info.assert_called_once_with(None)
 
 
 def test_b200_formula_subsumes_table_promotion_wiring() -> None:

--- a/test/test_multi_shape_autotune.py
+++ b/test/test_multi_shape_autotune.py
@@ -425,8 +425,16 @@ class TestMultiShapeRuntime(unittest.TestCase):
             _RuntimeBoundKernel(backend, settings),
         ]
         case_keys = [
-            SimpleNamespace(specialization_key=("shape", 8), extra_results=()),
-            SimpleNamespace(specialization_key=("shape", 16), extra_results=()),
+            SimpleNamespace(
+                specialization_key=("shape", 8),
+                extra_results=(),
+                compiler_seed_results=(),
+            ),
+            SimpleNamespace(
+                specialization_key=("shape", 16),
+                extra_results=(),
+                compiler_seed_results=(),
+            ),
         ]
         kernel = object.__new__(Kernel)
         kernel.settings = settings  # pyrefly: ignore [bad-assignment]
@@ -453,7 +461,7 @@ class TestMultiShapeRuntime(unittest.TestCase):
                 "geomean",
                 None,
                 "numeric-shapes-v1",
-                ((("shape", 8), ()), (("shape", 16), ())),
+                ((("shape", 8), (), ()), (("shape", 16), (), ())),
             ),
         )
         self.assertEqual(backend.finalized, bounds)

--- a/test/test_runtime_input_specialization.py
+++ b/test/test_runtime_input_specialization.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Hashable
+from typing import cast
+import unittest
+from unittest.mock import patch
+
+import sympy
+import torch
+from torch._dynamo.source import LocalSource
+from torch._dynamo.source import TensorProperty
+from torch._dynamo.source import TensorPropertySource
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.symbolic_shapes import DimDynamic
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+from helion._compiler.compile_environment import CompileEnvironment
+from helion._compiler.compile_environment import RuntimeInputSpecialization
+from helion._compiler.compile_environment import _symint_free_symbols
+from helion._compiler.device_ir import _finalize_cute_tcgen05_search_planning
+from helion._testing import DEVICE
+from helion._testing import onlyBackends
+from helion.language.matmul_ops import _plan_cute_tcgen05_search_candidate
+from helion.runtime.cute.launcher import _Tcgen05GroupedWorklistCompatibilityClassifier
+from helion.runtime.kernel import BoundKernel
+from helion.runtime.kernel import _input_tensor_aliases
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+@dataclasses.dataclass(frozen=True)
+class _PrefixClassifier:
+    prefix: str
+
+    def __call__(self, values: Sequence[object]) -> Hashable:
+        return self.prefix, tuple(values)
+
+
+@onlyBackends(["cute"])
+class TestCuteRuntimeInputSpecialization(unittest.TestCase):
+    def test_conflicting_tcgen05_analysis_keys_still_publish_all_guards(self) -> None:
+        first = sympy.Symbol("first")
+        second = sympy.Symbol("second")
+        env = SimpleNamespace(specialized_vars=set())
+        planning_results = (
+            SimpleNamespace(
+                required_specialized_vars=frozenset({first}),
+                guards_complete=True,
+            ),
+            SimpleNamespace(
+                required_specialized_vars=frozenset({second}),
+                guards_complete=True,
+            ),
+        )
+
+        self.assertFalse(
+            _finalize_cute_tcgen05_search_planning(
+                cast("CompileEnvironment", env),
+                cast("Any", planning_results),
+                {("first",), ("second",)},
+            )
+        )
+        self.assertEqual(env.specialized_vars, {first, second})
+
+        third = sympy.Symbol("third")
+        incomplete = SimpleNamespace(
+            required_specialized_vars=frozenset({third}),
+            guards_complete=False,
+        )
+        self.assertFalse(
+            _finalize_cute_tcgen05_search_planning(
+                cast("CompileEnvironment", env),
+                cast("Any", (planning_results[0], incomplete)),
+                {("shared",)},
+            )
+        )
+        self.assertEqual(env.specialized_vars, {first, second, third})
+
+    def test_dynamic_tcgen05_candidate_plans_are_idempotent_and_specialized(
+        self,
+    ) -> None:
+        shape_env = ShapeEnv()
+
+        def backed_size(name: str, dim: int, hint: int) -> torch.SymInt:
+            source = TensorPropertySource(
+                LocalSource(name, is_input=True),
+                TensorProperty.SIZE,
+                dim,
+            )
+            symbol = shape_env.create_symbol(
+                hint,
+                source,
+                dynamic_dim=DimDynamic.DYNAMIC,
+            )
+            return cast(
+                "torch.SymInt",
+                shape_env.create_symintnode(symbol, hint=hint, source=source),
+            )
+
+        tile_m = shape_env.create_unbacked_symint()
+        tile_n = shape_env.create_unbacked_symint()
+        tile_k = shape_env.create_unbacked_symint()
+        problem_m = backed_size("lhs", 0, 256)
+        problem_n = backed_size("rhs", 1, 512)
+        problem_k = backed_size("lhs", 1, 128)
+        with FakeTensorMode(shape_env=shape_env):
+            lhs = torch.empty((tile_m, tile_k), device=DEVICE, dtype=torch.bfloat16)
+            rhs = torch.empty((tile_k, tile_n), device=DEVICE, dtype=torch.bfloat16)
+        hints = {str(tile_m): 256, str(tile_n): 512, str(tile_k): 128}
+        block_ids = {str(tile_m): 0, str(tile_n): 1, str(tile_k): 2}
+        env = SimpleNamespace(
+            backend_name="cute",
+            settings=SimpleNamespace(static_shapes=False),
+            shape_env=shape_env,
+            specialized_vars=set(),
+            specialized_strides=set(),
+            tensor_descriptor_layout_guards={},
+            runtime_input_specializations={},
+            specialize_expr=lambda expr: expr,
+            size_hint=lambda size: hints[str(size)],
+            get_block_id=lambda size: block_ids.get(str(size)),
+            block_sizes=[
+                SimpleNamespace(size=problem_m),
+                SimpleNamespace(size=problem_n),
+                SimpleNamespace(size=problem_k),
+            ],
+        )
+
+        with (
+            patch.object(CompileEnvironment, "current", return_value=env),
+            patch(
+                "helion._compiler.cute.mma_support.get_cute_mma_support",
+                return_value=SimpleNamespace(tcgen05_f8=True, tcgen05_f16bf16=True),
+            ),
+        ):
+            planning_results = []
+            for m_hint, expected_plan in ((32, False), (256, True)):
+                with self.subTest(m_hint=m_hint):
+                    hints[str(tile_m)] = m_hint
+                    env.specialized_vars.clear()
+                    planning_result = _plan_cute_tcgen05_search_candidate(
+                        lhs,
+                        rhs,
+                        has_leading_passthrough=False,
+                        allow_dynamic_hints=True,
+                    )
+                    plan = planning_result.plan
+
+                    self.assertEqual(plan is not None, expected_plan)
+                    self.assertTrue(planning_result.guards_complete)
+                    self.assertFalse(env.specialized_vars)
+                    planning_results.append(planning_result)
+                    if plan is not None:
+                        # DeviceIR may inspect multiple compatible MMAs before
+                        # deciding whether there is one shared analysis. Each
+                        # candidate must see the same compile state.
+                        repeated_result = _plan_cute_tcgen05_search_candidate(
+                            lhs,
+                            rhs,
+                            has_leading_passthrough=False,
+                            allow_dynamic_hints=True,
+                        )
+                        repeated_plan = repeated_result.plan
+                        assert repeated_plan is not None
+                        self.assertEqual(
+                            (plan.static_m, plan.static_n, plan.static_k),
+                            (None, None, None),
+                        )
+                        self.assertEqual(planning_result, repeated_result)
+            self.assertEqual(len(planning_results), 2)
+            required_specialized_vars = frozenset().union(
+                *(result.required_specialized_vars for result in planning_results)
+            )
+            self.assertEqual(
+                required_specialized_vars,
+                frozenset().union(
+                    _symint_free_symbols(problem_m),
+                    _symint_free_symbols(problem_n),
+                    _symint_free_symbols(problem_k),
+                ),
+            )
+            env.specialized_vars.update(required_specialized_vars)
+            self.assertEqual(
+                env.specialized_vars,
+                set().union(
+                    _symint_free_symbols(problem_m),
+                    _symint_free_symbols(problem_n),
+                    _symint_free_symbols(problem_k),
+                ),
+            )
+            bound = cast("BoundKernel[Any]", object.__new__(BoundKernel))
+            bound._env = cast("CompileEnvironment", env)
+            bound._config = None
+            bound.kernel = cast(
+                "Any",
+                SimpleNamespace(
+                    signature=inspect.signature(lambda lhs, rhs: None),
+                    settings=SimpleNamespace(
+                        autotune_effort="max", force_autotune=False
+                    ),
+                    configs=[],
+                ),
+            )
+            extractors = bound._specialize_extra()
+            real_lhs = torch.empty((256, 128))
+            real_rhs = torch.empty((128, 512))
+            self.assertEqual(
+                sorted(
+                    cast("int", extractor((real_lhs, real_rhs)))
+                    for extractor in extractors
+                ),
+                [128, 256, 512],
+            )
+
+            env.block_sizes[1].size = None
+            env.specialized_vars.clear()
+            missing_result = _plan_cute_tcgen05_search_candidate(
+                lhs,
+                rhs,
+                has_leading_passthrough=False,
+                allow_dynamic_hints=True,
+            )
+            self.assertIsNone(missing_result.plan)
+            self.assertFalse(missing_result.guards_complete)
+            self.assertFalse(env.specialized_vars)
+
+            env.block_sizes[1].size = shape_env.create_unbacked_symint()
+            unbacked_result = _plan_cute_tcgen05_search_candidate(
+                lhs,
+                rhs,
+                has_leading_passthrough=False,
+                allow_dynamic_hints=True,
+            )
+            self.assertIsNone(unbacked_result.plan)
+            self.assertFalse(unbacked_result.guards_complete)
+            self.assertFalse(env.specialized_vars)
+
+    def test_worklist_classifier_invalidates_on_storage_rebind(self) -> None:
+        classifier = _Tcgen05GroupedWorklistCompatibilityClassifier(2, 448)
+        worklist = torch.tensor(
+            [[0, 0, 224, 224], [1, 224, 224, 224]], dtype=torch.int32
+        )
+        replacement = torch.tensor(
+            [[0, 0, 256, 256], [1, 256, 192, 192]], dtype=torch.int32
+        )
+        version = worklist._version
+        original_data_ptr = worklist.data_ptr()
+
+        self.assertEqual(classifier((worklist,)), (32, 224))
+        worklist.data = replacement.data
+
+        self.assertEqual(worklist._version, version)
+        self.assertNotEqual(worklist.data_ptr(), original_data_ptr)
+        self.assertEqual(classifier((worklist,)), (32,))
+
+
+class TestRuntimeInputSpecialization(unittest.TestCase):
+    def test_tensor_alias_key_is_dynamo_safe_for_temporary_views(self) -> None:
+        def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            assert _input_tensor_aliases((x.T, y.T)) is None
+            return x + y
+
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        x = torch.randn(4, 8)
+        y = torch.randn(4, 8)
+        self.assertEqual(_input_tensor_aliases((x, x, y)), (0, 0, 1))
+        torch.testing.assert_close(compiled(x, y), x + y)
+
+    def test_extractors_have_deterministic_key_order(self) -> None:
+        first = LocalSource("first", is_input=True)
+        second = LocalSource("second", is_input=True)
+        entries = (
+            (
+                "z",
+                RuntimeInputSpecialization(
+                    sources=(second,),
+                    classifier_identity="z",
+                    classifier=_PrefixClassifier("z"),
+                ),
+            ),
+            (
+                "a",
+                RuntimeInputSpecialization(
+                    sources=(first,),
+                    classifier_identity="a",
+                    classifier=_PrefixClassifier("a"),
+                ),
+            ),
+        )
+
+        def results(
+            ordered_entries: Sequence[tuple[str, RuntimeInputSpecialization]],
+        ) -> tuple[Hashable, ...]:
+            env = SimpleNamespace(
+                specialized_vars=set(),
+                specialized_strides=set(),
+                tensor_descriptor_layout_guards={},
+                runtime_input_specializations=dict(ordered_entries),
+            )
+            kernel = SimpleNamespace(
+                signature=inspect.signature(lambda first, second: None)
+            )
+            bound = SimpleNamespace(
+                _env=env,
+                env=env,
+                kernel=kernel,
+                _fixed_config_for_td_layout_guards=lambda: None,
+            )
+            extractors = BoundKernel._specialize_extra(
+                cast("BoundKernel[object]", bound)
+            )
+            return tuple(extractor((11, 22)) for extractor in extractors)
+
+        expected = (("a", (11,)), ("z", (22,)))
+        self.assertEqual(results(entries), expected)
+        self.assertEqual(results(tuple(reversed(entries))), expected)
+
+    def test_equivalent_registration_is_idempotent(self) -> None:
+        env = object.__new__(CompileEnvironment)
+        env.runtime_input_specializations = {}
+        source = LocalSource("value", is_input=True)
+        first = RuntimeInputSpecialization(
+            sources=(source,),
+            classifier_identity="same",
+            classifier=_PrefixClassifier("same"),
+        )
+        equivalent = RuntimeInputSpecialization(
+            sources=(source,),
+            classifier_identity="same",
+            classifier=_PrefixClassifier("same"),
+        )
+
+        env.register_runtime_input_specialization("key", first)
+        env.register_runtime_input_specialization("key", equivalent)
+
+        self.assertEqual(len(env.runtime_input_specializations), 1)
+        self.assertIs(env.runtime_input_specializations["key"], first)
+
+    def test_conflicting_registration_raises(self) -> None:
+        env = object.__new__(CompileEnvironment)
+        env.runtime_input_specializations = {}
+        source = LocalSource("value", is_input=True)
+        first = RuntimeInputSpecialization(
+            sources=(source,),
+            classifier_identity="first",
+            classifier=_PrefixClassifier("first"),
+        )
+        env.register_runtime_input_specialization("key", first)
+
+        conflicts = (
+            RuntimeInputSpecialization(
+                sources=(source,),
+                classifier_identity="different",
+                classifier=_PrefixClassifier("different"),
+            ),
+            RuntimeInputSpecialization(
+                sources=(LocalSource("other", is_input=True),),
+                classifier_identity="first",
+                classifier=_PrefixClassifier("first"),
+            ),
+        )
+        for conflict in conflicts:
+            with (
+                self.subTest(conflict=conflict),
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "conflicting runtime input specializations",
+                ),
+            ):
+                env.register_runtime_input_specialization("key", conflict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_specialize.py
+++ b/test/test_specialize.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 import math
+from typing import Any
+from typing import cast
 import unittest
 
 import torch
@@ -754,6 +756,32 @@ class TestMarkStatic(RefEagerTestBase, TestCase):
         key_a_after = fn.specialization_key((a,))
         key_b_after = fn.specialization_key((b,))
         self.assertNotEqual(key_a_after, key_b_after)
+
+    @skipIfRefEager("Specialization-key schemas are not used in ref eager mode")
+    def test_specialization_key_keeps_independent_extra_schemas(self) -> None:
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        a = torch.empty([8], device=DEVICE)
+        b = torch.empty([16], device=DEVICE)
+        signature = fn._base_specialization_key((a,))
+        dynamic_fn = cast("Any", fn)
+
+        dynamic_fn._specialize_extra[signature] = [
+            lambda values: cast("torch.Tensor", values[0]).size(0)
+        ]
+        dynamic_fn._compiler_seed_specialize_extra.pop(signature, None)
+        self.assertNotEqual(fn.specialization_key((a,)), fn.specialization_key((b,)))
+
+        dynamic_fn._specialize_extra.pop(signature)
+        dynamic_fn._compiler_seed_specialize_extra[signature] = (
+            lambda values: (
+                "config_num_sm",
+                cast("torch.Tensor", values[0]).size(0),
+            ),
+        )
+        self.assertNotEqual(fn.specialization_key((a,)), fn.specialization_key((b,)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3481 (`fdffbedc`)
 * #3480 (`60f746d5`)
 * __->__ #3479 (`9ae406fe`)
 * #3478 (`57f0aef4`)
 * #3477 (`3e0cba9a`)
 * #3483 (`b1945f2e`, base `main`)

--- --- ---

## Summary

- Recognize grouped GEMM from DeviceIR structure without user-authored metadata.
- Recognize external `[G, 4]` worklists and compact `split_sizes[G]` or `offsets[G + 1]` inputs.
- Add reusable runtime-input specialization and precise cache guards for value-dependent compiler decisions.
- Generate bounded compiler seed families while preserving live autotuning and failing closed on ambiguous structures.
- Integrate with upstream multi-matmul analysis while preserving original compile-time-static provenance for grouped promotion.

## Validation

- Ruff, codespell, Pyrefly, and diff checks pass.
- Upstream matmul/matmul-fact tests: 50 passed, 4 subtests.
- Grouped heuristic tests: 25 passed, 65 subtests.
- Runtime/specialization and split-size tests: 39 passed, 4 subtests.
- ConfigSpec tests: 32 passed, 96 subtests.
- Provider campaign tests: 63 default and 63 CuTe.
- Fresh adversarial review: LGTM.

## Performance evidence

A publication-eligible GB300 campaign on `252981249b3a2e417e234d99800433d60302049c` used 3 fresh replicates, 8 workloads, 102 paired cold-L2 samples, a 10-second warmup, correctness/replay checks, and clean telemetry. Historical geometric-mean speedups (`provider_ms / Helion_ms`) were:

`Helion ms` is the geometric mean of the 15 Helion medians for that row (5 provider pairings x 3 fresh replicates). Provider columns are `provider_ms / Helion_ms`, geometrically averaged across the three replicates; values above 1 mean Helion is faster.

| Row | G | Actual M per group | N | K | Helion ms | DeepGEMM | QuACK | cuDNN | cuBLASLt | CUTLASS |
|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 4 | `9884, 9459, 7801, 7007` | 6144 | 7168 | 1.7445 | 1.0098x | 1.0285x | 1.0183x | 1.2044x | 1.4062x |
| 1 | 4 | `8247, 7724, 9586, 7225` | 7168 | 3072 | 0.8164 | 1.0114x | 1.0345x | 1.0323x | 1.2329x | 1.4205x |
| 2 | 4 | `8076, 8601, 10197, 8215` | 4096 | 4096 | 0.6566 | 1.0192x | 1.0653x | 1.0305x | 1.1936x | 1.4464x |
| 3 | 4 | `7119, 9449, 8773, 6965` | 4096 | 2048 | 0.2805 | 1.0578x | 1.0651x | 1.0325x | 1.2292x | 1.3825x |
| 4 | 8 | `5102, 5282, 4858, 5084, 3629, 4660, 5076, 4548` | 6144 | 7168 | 1.9696 | 1.0283x | 1.0485x | 1.0170x | 1.2096x | 1.4105x |
| 5 | 8 | `4027, 3114, 3934, 4368, 5111, 5242, 4039, 4993` | 7168 | 3072 | 0.8757 | 1.0176x | 1.0501x | 1.1014x | 1.2488x | 1.4100x |
| 6 | 8 | `3507, 4845, 4215, 2901, 4635, 3847, 4894, 4509` | 4096 | 4096 | 0.6334 | 1.0037x | 1.0560x | 1.0561x | 1.2289x | 1.3593x |
| 7 | 8 | `2870, 4080, 4999, 3466, 3666, 5006, 3336, 4261` | 4096 | 2048 | 0.2846 | 1.0512x | 1.0204x | 1.0380x | 1.2515x | 1.3566x |
| **GM** | -- | -- | -- | -- | **0.7310** | **1.0247x** | **1.0459x** | **1.0404x** | **1.2247x** | **1.3987x** |

All eight rows beat every measured provider. On the final reviewed stack `fdffbedc`, all 8 selected configurations and all 120 archived generated modules reproduce exactly after removing only `# src[...]` provenance comments.

This is archived timing plus exact config/codegen equivalence, not a fresh timing run. PR5 intentionally strengthens cuBLASLt and CUTLASS selection, so their historical ratios are reference values rather than final claims for the new harness. No B200 timing claim is made.