### PR TITLE
[cutedsl] Add a reproducible grouped GEMM provider campaign

### DIFF
--- a/benchmarks/cute/compare_grouped_gemm_backends.py
+++ b/benchmarks/cute/compare_grouped_gemm_backends.py
@@ -1,15 +1,36 @@
 # ruff: noqa: ANN401, E402
-"""Compare Helion with CUTLASS CuTeDSL grouped GEMM.
+"""Compare Helion grouped GEMM with reproducible backend baselines.
 
-The comparison is intentionally narrow: FP16 NT grouped GEMM, a 128x64 MMA
-tile, a 1x1 cluster, and seven CUTLASS-example-derived heterogeneous validation
-cases (3--4 GEMMs, including M/N tails). Every case runs in a fresh subprocess
-with fresh compiler caches. Both implementations consume the same A/B tensors,
+``--provider-defaults`` runs the fixed BF16 publication protocol against
+DeepGEMM, QuACK, cuDNN, cuBLASLt, and CUTLASS. Use
+``--provider-defaults-plan`` to inspect that protocol without a GPU.
+CUTLASS has no ranked public default, so its adapter tunes every supported
+public-registry operator before the final paired measurement. Dependency
+versions follow Helion's validated project pins.
+
+Inspect or run the fixed protocol::
+
+    python benchmarks/cute/compare_grouped_gemm_backends.py \
+      --provider-defaults-plan
+
+    CUDA_VISIBLE_DEVICES=0 python \
+      benchmarks/cute/compare_grouped_gemm_backends.py \
+      --provider-defaults \
+      --provider-output-dir /path/to/results \
+      --provider-deepgemm-root /path/to/DeepGEMM \
+      --provider-quack-root /path/to/quack \
+      --provider-cutlass-root /path/to/cutlass
+
+The original CUTLASS comparison remains available without either provider
+flag. It is intentionally narrow: FP16 NT grouped GEMM, a 128x64 MMA tile, a
+1x1 cluster, and seven CUTLASS-example-derived heterogeneous validation cases
+(3--4 GEMMs, including M/N tails). Every case runs in a fresh subprocess with
+fresh compiler caches. Both implementations consume the same A/B tensors,
 write the same output buffers sequentially, and are timed through the shared
 cold-L2 CUDA graph-replay timer. The comparison times only device work, with
 every pointer table initialized before graph capture.
 
-Use ``grouped_gemm.py`` from NVIDIA/cutlass commit
+For the original mode, use ``grouped_gemm.py`` from NVIDIA/cutlass commit
 ``db1c288993354c88e551c40c19a8fb93a774a241``::
 
     CUDA_VISIBLE_DEVICES=0 python benchmarks/cute/compare_grouped_gemm_backends.py \
@@ -44,9 +65,36 @@ if TYPE_CHECKING:
 hl: Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-if str(REPO_ROOT) not in sys.path:
+
+
+def _prioritize_repo_root() -> None:
+    repo_path = str(REPO_ROOT)
+
+    def is_competing_checkout(entry: str) -> bool:
+        root = Path(entry).resolve()
+        return root != REPO_ROOT and any(
+            (root / relative).is_file()
+            for relative in (
+                "benchmarks/__init__.py",
+                "pretuned_kernels/__init__.py",
+                "benchmarks/cute/grouped_gemm_provider_campaign.py",
+            )
+        )
+
+    sys.path[:] = [
+        entry
+        for entry in sys.path
+        if entry != repo_path and not is_competing_checkout(entry)
+    ]
+    sys.path.insert(0, repo_path)
+
+
+if __name__ == "__main__":
+    _prioritize_repo_root()
+elif str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from benchmarks.cute.grouped_gemm_workloads import PROVIDER_CLI_MODES
 from pretuned_kernels._bench import bench_pre_captured_cudagraphs
 from pretuned_kernels._bench import thermal_warmup
 
@@ -791,8 +839,13 @@ def _run_all(args: argparse.Namespace) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if arguments and arguments[0] in PROVIDER_CLI_MODES:
+        from benchmarks.cute import grouped_gemm_provider_campaign
+
+        return grouped_gemm_provider_campaign.main(arguments)
     parser = _parser()
-    args = parser.parse_args(argv)
+    args = parser.parse_args(arguments)
     args.out_dir = args.out_dir.expanduser().resolve()
     if args.list_cases:
         cases = _selected_cases(args)

--- a/benchmarks/cute/cublaslt_grouped_gemm.py
+++ b/benchmarks/cute/cublaslt_grouped_gemm.py
@@ -1,0 +1,617 @@
+from __future__ import annotations
+
+import ctypes
+from dataclasses import asdict
+from dataclasses import dataclass
+import functools
+from pathlib import Path
+from typing import TYPE_CHECKING
+import weakref
+
+from benchmarks.cute import grouped_gemm_benchmark as common
+from benchmarks.cute.grouped_gemm_workloads import BENCHMARK_B_LAYOUT
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+
+
+CUBLASLT_DISTRIBUTION = common.CUDA_CUBLAS_DISTRIBUTION
+CUBLASLT_DISTRIBUTION_VERSION = common.CUDA_CUBLAS_VERSION
+CUBLASLT_LIBRARY_RELATIVE_PATH = common.CUDA_CUBLASLT_LIBRARY_RELATIVE_PATH
+# These ABI values are from the CUDA 13.6 cuBLASLt API shipped by the pinned
+# nvidia-cublas distribution below. The grouped extension is version-gated by
+# cublasLtGetVersion before any descriptor is created.
+_CUBLAS_STATUS_SUCCESS = 0
+_CUBLAS_OP_N = 0
+_CUBLAS_OP_T = 1
+_CUDA_R_32F = 0
+_CUDA_R_16BF = 14
+_CUBLAS_COMPUTE_32F = 68
+_CUBLASLT_POINTER_MODE_DEVICE = 1
+_CUBLASLT_MATMUL_DESC_POINTER_MODE = 2
+_CUBLASLT_MATMUL_DESC_TRANSA = 3
+_CUBLASLT_MATMUL_DESC_TRANSB = 4
+_CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES = 1
+_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_A_BYTES = 5
+_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_B_BYTES = 6
+_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES = 7
+_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES = 8
+_CUBLASLT_MATMUL_PREF_GROUPED_AVERAGE_REDUCTION_DIM = 13
+_CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_ROWS = 14
+_CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_COLS = 15
+_CUBLASLT_ALGO_CAP_POINTER_ARRAY_GROUPED_SUPPORT = 23
+_CUBLASLT_GROUPED_MATRIX_LAYOUT_ROWS_COLS_ARRAY_INTEGER_WIDTH = 12
+_CUBLASLT_GROUPED_MATRIX_LAYOUT_LD_ARRAY_INTEGER_WIDTH = 13
+_CUBLASLT_INTEGER_WIDTH_32 = 0
+_DEFAULT_WORKSPACE_BYTES = 64 * 1024 * 1024
+_WORKSPACE_ALIGNMENT = 256
+CUBLASLT_HEURISTIC_QUERY_CAPACITY = 1
+CUBLASLT_LIBRARY_VERSION = 130601
+
+
+class _CublasLtMatmulAlgo(ctypes.Structure):
+    _fields_ = [("data", ctypes.c_uint64 * 8)]
+
+
+class _CublasLtHeuristicResult(ctypes.Structure):
+    _fields_ = [
+        ("algo", _CublasLtMatmulAlgo),
+        ("workspace_size", ctypes.c_size_t),
+        ("state", ctypes.c_int),
+        ("waves_count", ctypes.c_float),
+        ("reserved", ctypes.c_int * 4),
+    ]
+
+
+@dataclass(frozen=True, slots=True)
+class _CublasLtAlgorithm:
+    serialized_hex: str
+    workspace_bytes: int
+    waves_count: float
+    heuristic_rank: int
+
+
+def _check_cublas(status: int, operation: str) -> None:
+    if status != _CUBLAS_STATUS_SUCCESS:
+        raise RuntimeError(f"{operation} failed with cuBLAS status {status}")
+
+
+def _pointer_alignment(pointer: int) -> int:
+    return min(pointer & -pointer, 256)
+
+
+def _configure_library(library: ctypes.CDLL) -> None:
+    v, i, s = ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t
+    pv, pi, ps = ctypes.POINTER(v), ctypes.POINTER(i), ctypes.POINTER(s)
+    pa = ctypes.POINTER(_CublasLtMatmulAlgo)
+    ph = ctypes.POINTER(_CublasLtHeuristicResult)
+    signatures = (
+        ("cublasLtCreate", (pv,), i),
+        ("cublasLtDestroy", (v,), i),
+        ("cublasLtGetVersion", (), s),
+        ("cublasLtMatmulDescCreate", (pv, i, i), i),
+        ("cublasLtMatmulDescDestroy", (v,), i),
+        ("cublasLtMatmulDescSetAttribute", (v, i, v, s), i),
+        ("cublasLtGroupedMatrixLayoutCreate", (pv, i, i, v, v, v), i),
+        ("cublasLtMatrixLayoutSetAttribute", (v, i, v, s), i),
+        ("cublasLtMatrixLayoutDestroy", (v,), i),
+        ("cublasLtMatmulPreferenceCreate", (pv,), i),
+        ("cublasLtMatmulPreferenceDestroy", (v,), i),
+        ("cublasLtMatmulPreferenceSetAttribute", (v, i, v, s), i),
+        ("cublasLtMatmulAlgoGetHeuristicForStream", (v,) * 7 + (i, ph, pi, v), i),
+        ("cublasLtMatmulAlgoCapGetAttribute", (pa, i, v, s, ps), i),
+        ("cublasLtMatmul", (v,) * 12 + (pa, v, s, v), i),
+    )
+    for name, argtypes, restype in signatures:
+        function = getattr(library, name)
+        function.argtypes = list(argtypes)
+        function.restype = restype
+
+
+@functools.cache
+def _validated_cublaslt_library() -> tuple[ctypes.CDLL, dict[str, object]]:
+    distribution = common.require_pinned_distribution(
+        CUBLASLT_DISTRIBUTION,
+        CUBLASLT_DISTRIBUTION_VERSION,
+    )
+    path = common.distribution_file(
+        CUBLASLT_DISTRIBUTION,
+        distribution,
+        CUBLASLT_LIBRARY_RELATIVE_PATH,
+    )
+    library = ctypes.CDLL(str(path))
+    loaded_path = Path(str(library._name)).resolve(strict=True)
+    if loaded_path != path:
+        raise RuntimeError(
+            f"cuBLASLt loaded {loaded_path}, expected distribution library {path}"
+        )
+    mapped = common.mapped_library_paths("libcublasLt.so")
+    if mapped != (path,):
+        raise RuntimeError(
+            f"mapped cuBLASLt libraries are {tuple(map(str, mapped))}, "
+            f"expected {(str(path),)}"
+        )
+    _configure_library(library)
+    library_version = int(library.cublasLtGetVersion())
+    if library_version != CUBLASLT_LIBRARY_VERSION:
+        raise RuntimeError(
+            f"cuBLASLt library is {library_version}, "
+            f"expected {CUBLASLT_LIBRARY_VERSION}"
+        )
+    return library, {
+        "distribution": CUBLASLT_DISTRIBUTION,
+        "package_version": distribution.version,
+        "library_version": library_version,
+    }
+
+
+def _destroy_resources(
+    library: ctypes.CDLL,
+    matrix_layouts: tuple[ctypes.c_void_p, ...],
+    operation: ctypes.c_void_p,
+    handle: ctypes.c_void_p,
+) -> None:
+    for layout in reversed(matrix_layouts):
+        library.cublasLtMatrixLayoutDestroy(layout)
+    library.cublasLtMatmulDescDestroy(operation)
+    library.cublasLtDestroy(handle)
+
+
+def _set_attribute(
+    function: Callable[..., int],
+    descriptor: ctypes.c_void_p,
+    attribute: int,
+    value: ctypes.c_int | ctypes.c_uint32 | ctypes.c_uint64,
+    operation: str,
+) -> None:
+    _check_cublas(
+        function(descriptor, attribute, ctypes.byref(value), ctypes.sizeof(value)),
+        operation,
+    )
+
+
+def _create_grouped_matrix_layout(
+    library: ctypes.CDLL,
+    group_count: int,
+    rows: torch.Tensor,
+    columns: torch.Tensor,
+    leading_dimensions: torch.Tensor,
+) -> ctypes.c_void_p:
+    layout = ctypes.c_void_p()
+    _check_cublas(
+        library.cublasLtGroupedMatrixLayoutCreate(
+            ctypes.byref(layout),
+            _CUDA_R_16BF,
+            group_count,
+            ctypes.c_void_p(rows.data_ptr()),
+            ctypes.c_void_p(columns.data_ptr()),
+            ctypes.c_void_p(leading_dimensions.data_ptr()),
+        ),
+        "cublasLtGroupedMatrixLayoutCreate",
+    )
+    try:
+        for attribute, label in (
+            (
+                _CUBLASLT_GROUPED_MATRIX_LAYOUT_ROWS_COLS_ARRAY_INTEGER_WIDTH,
+                "rows/columns",
+            ),
+            (_CUBLASLT_GROUPED_MATRIX_LAYOUT_LD_ARRAY_INTEGER_WIDTH, "LD"),
+        ):
+            _set_attribute(
+                library.cublasLtMatrixLayoutSetAttribute,
+                layout,
+                attribute,
+                ctypes.c_int(_CUBLASLT_INTEGER_WIDTH_32),
+                f"set grouped matrix {label} integer width",
+            )
+    except Exception:
+        library.cublasLtMatrixLayoutDestroy(layout)
+        raise
+    return layout
+
+
+def _create_grouped_matrix_layouts(
+    library: ctypes.CDLL,
+    group_count: int,
+    dimension_arrays: dict[str, torch.Tensor],
+) -> tuple[ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]:
+    layouts: list[ctypes.c_void_p] = []
+    try:
+        for prefix in ("a", "b", "output"):
+            layouts.append(
+                _create_grouped_matrix_layout(
+                    library,
+                    group_count,
+                    dimension_arrays[f"{prefix}_rows"],
+                    dimension_arrays[f"{prefix}_columns"],
+                    dimension_arrays[f"{prefix}_leading_dimensions"],
+                )
+            )
+    except Exception:
+        for layout in reversed(layouts):
+            library.cublasLtMatrixLayoutDestroy(layout)
+        raise
+    return layouts[0], layouts[1], layouts[2]
+
+
+def _grouped_algorithm_supported(
+    library: ctypes.CDLL,
+    algorithm: _CublasLtMatmulAlgo,
+) -> bool:
+    value = ctypes.c_int32()
+    written = ctypes.c_size_t()
+    status = library.cublasLtMatmulAlgoCapGetAttribute(
+        ctypes.byref(algorithm),
+        _CUBLASLT_ALGO_CAP_POINTER_ARRAY_GROUPED_SUPPORT,
+        ctypes.byref(value),
+        ctypes.sizeof(value),
+        ctypes.byref(written),
+    )
+    return (
+        status == _CUBLAS_STATUS_SUCCESS
+        and written.value == ctypes.sizeof(value)
+        and value.value != 0
+    )
+
+
+def cublaslt_layout_values(
+    problems: tuple[tuple[int, int, int, int], ...],
+) -> tuple[int, dict[str, list[int]]]:
+    # cuBLASLt is column-major. Swap logical A/B so row-major A @ B.T becomes
+    # column-major B @ A.T, producing the same row-major output allocation.
+    m_values = [m for m, _n, _k, _batch in problems]
+    n_values = [n for _m, n, _k, _batch in problems]
+    k_values = [k for _m, _n, k, _batch in problems]
+    return _CUBLAS_OP_T, {
+        "a_rows": k_values,
+        "a_columns": n_values,
+        "a_leading_dimensions": k_values,
+        "b_rows": k_values,
+        "b_columns": m_values,
+        "b_leading_dimensions": k_values,
+        "output_rows": n_values,
+        "output_columns": m_values,
+        "output_leading_dimensions": n_values,
+    }
+
+
+def cublaslt_grouped_preference_values(
+    problems: tuple[tuple[int, int, int, int], ...],
+) -> dict[str, int]:
+    """Return floor-mean uint32 shape hints for grouped heuristic selection."""
+
+    if not problems:
+        raise ValueError("cuBLASLt grouped preferences require at least one problem")
+    group_count = len(problems)
+    return {
+        "average_reduction_dim": sum(k for _m, _n, k, _batch in problems)
+        // group_count,
+        # The column-major descriptor D is N x M after the row-major mapping in
+        # ``cublaslt_layout_values``.
+        "average_output_rows": sum(n for _m, n, _k, _batch in problems) // group_count,
+        "average_output_columns": sum(m for m, _n, _k, _batch in problems)
+        // group_count,
+    }
+
+
+def _set_grouped_preference_attributes(
+    library: ctypes.CDLL,
+    preference: ctypes.c_void_p,
+    values: dict[str, int],
+) -> None:
+    for attribute, name in (
+        (
+            _CUBLASLT_MATMUL_PREF_GROUPED_AVERAGE_REDUCTION_DIM,
+            "average_reduction_dim",
+        ),
+        (
+            _CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_ROWS,
+            "average_output_rows",
+        ),
+        (
+            _CUBLASLT_MATMUL_PREF_GROUPED_DESC_D_AVERAGE_COLS,
+            "average_output_columns",
+        ),
+    ):
+        _set_attribute(
+            library.cublasLtMatmulPreferenceSetAttribute,
+            preference,
+            attribute,
+            ctypes.c_uint32(values[name]),
+            f"set grouped {name}",
+        )
+
+
+class _CublasLtGroupedGemm:
+    def __init__(
+        self,
+        inputs: GroupedGemmInputs,
+    ) -> None:
+        if any(actual_m <= 0 for actual_m in inputs.case.actual_ms):
+            raise ValueError("cuBLASLt requires every group to contain a row")
+        library, library_identity = _validated_cublaslt_library()
+        problems = tuple(
+            (actual_m, inputs.case.n, inputs.case.k, 1)
+            for actual_m in inputs.case.actual_ms
+        )
+        group_a = inputs.compact_a_slices()
+        group_b = inputs.b.unbind()
+        outputs = tuple(
+            torch.empty(
+                (actual_m, inputs.case.n),
+                device=inputs.compact_a.device,
+                dtype=torch.bfloat16,
+            )
+            for actual_m in inputs.case.actual_ms
+        )
+        device = inputs.compact_a.device
+
+        workspace_storage = torch.empty(
+            _DEFAULT_WORKSPACE_BYTES + _WORKSPACE_ALIGNMENT - 1,
+            device=device,
+            dtype=torch.uint8,
+        )
+        offset = (-workspace_storage.data_ptr()) % _WORKSPACE_ALIGNMENT
+        workspace = workspace_storage[offset : offset + _DEFAULT_WORKSPACE_BYTES]
+
+        group_count = len(problems)
+        transa, dimension_values = cublaslt_layout_values(problems)
+        grouped_preferences = cublaslt_grouped_preference_values(problems)
+        with torch.cuda.device(device):
+            query_stream = torch.cuda.current_stream(device)
+            dimension_arrays = {
+                name: torch.tensor(values, device=device, dtype=torch.int32)
+                for name, values in dimension_values.items()
+            }
+            a_pointers = torch.tensor(
+                [tensor.data_ptr() for tensor in group_b],
+                device=device,
+                dtype=torch.int64,
+            )
+            b_pointers = torch.tensor(
+                [tensor.data_ptr() for tensor in group_a],
+                device=device,
+                dtype=torch.int64,
+            )
+            output_pointers = torch.tensor(
+                [tensor.data_ptr() for tensor in outputs],
+                device=device,
+                dtype=torch.int64,
+            )
+            alpha = torch.tensor(1.0, device=device, dtype=torch.float32)
+            beta = torch.tensor(0.0, device=device, dtype=torch.float32)
+            query_stream.synchronize()
+
+        handle = ctypes.c_void_p()
+        operation = ctypes.c_void_p()
+        preference = ctypes.c_void_p()
+        layouts: list[ctypes.c_void_p] = []
+        initialized = False
+        try:
+            _check_cublas(library.cublasLtCreate(ctypes.byref(handle)), "create")
+            _check_cublas(
+                library.cublasLtMatmulDescCreate(
+                    ctypes.byref(operation), _CUBLAS_COMPUTE_32F, _CUDA_R_32F
+                ),
+                "create matmul descriptor",
+            )
+            for attribute, value, label in (
+                (
+                    _CUBLASLT_MATMUL_DESC_POINTER_MODE,
+                    ctypes.c_int(_CUBLASLT_POINTER_MODE_DEVICE),
+                    "pointer mode",
+                ),
+                (_CUBLASLT_MATMUL_DESC_TRANSA, ctypes.c_int(transa), "TRANSA"),
+                (_CUBLASLT_MATMUL_DESC_TRANSB, ctypes.c_int(_CUBLAS_OP_N), "TRANSB"),
+            ):
+                _set_attribute(
+                    library.cublasLtMatmulDescSetAttribute,
+                    operation,
+                    attribute,
+                    value,
+                    f"set {label}",
+                )
+            _check_cublas(
+                library.cublasLtMatmulPreferenceCreate(ctypes.byref(preference)),
+                "create preference",
+            )
+            _set_attribute(
+                library.cublasLtMatmulPreferenceSetAttribute,
+                preference,
+                _CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                ctypes.c_uint64(_DEFAULT_WORKSPACE_BYTES),
+                "set workspace",
+            )
+            output_alignment = min(
+                _pointer_alignment(tensor.data_ptr()) for tensor in outputs
+            )
+            alignments = {
+                "A": min(_pointer_alignment(tensor.data_ptr()) for tensor in group_b),
+                "B": min(_pointer_alignment(tensor.data_ptr()) for tensor in group_a),
+                "C": output_alignment,
+                "D": output_alignment,
+            }
+            for attribute, operand in (
+                (_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_A_BYTES, "A"),
+                (_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_B_BYTES, "B"),
+                (_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES, "C"),
+                (_CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES, "D"),
+            ):
+                _set_attribute(
+                    library.cublasLtMatmulPreferenceSetAttribute,
+                    preference,
+                    attribute,
+                    ctypes.c_uint32(alignments[operand]),
+                    f"set {operand} alignment",
+                )
+            _set_grouped_preference_attributes(
+                library,
+                preference,
+                grouped_preferences,
+            )
+            created_layouts = _create_grouped_matrix_layouts(
+                library, group_count, dimension_arrays
+            )
+            layouts.extend(created_layouts)
+            a_layout, b_matrix_layout, output_layout = created_layouts
+            result = _CublasLtHeuristicResult()
+            returned_count = ctypes.c_int()
+            _check_cublas(
+                library.cublasLtMatmulAlgoGetHeuristicForStream(
+                    handle,
+                    operation,
+                    a_layout,
+                    b_matrix_layout,
+                    output_layout,
+                    output_layout,
+                    preference,
+                    CUBLASLT_HEURISTIC_QUERY_CAPACITY,
+                    ctypes.byref(result),
+                    ctypes.byref(returned_count),
+                    ctypes.c_void_p(query_stream.cuda_stream),
+                ),
+                "query grouped algorithms",
+            )
+            if returned_count.value != 1:
+                raise RuntimeError(
+                    "cuBLASLt did not return exactly one default heuristic result"
+                )
+            serialized = bytes(result.algo).hex()
+            if (
+                result.state != _CUBLAS_STATUS_SUCCESS
+                or result.workspace_size > _DEFAULT_WORKSPACE_BYTES
+                or not _grouped_algorithm_supported(library, result.algo)
+            ):
+                raise RuntimeError(
+                    "cuBLASLt rank-zero heuristic result is not usable for grouped GEMM"
+                )
+            selected_algorithm = _CublasLtAlgorithm(
+                serialized,
+                int(result.workspace_size),
+                float(result.waves_count),
+                0,
+            )
+            initialized = True
+        finally:
+            if preference:
+                library.cublasLtMatmulPreferenceDestroy(preference)
+            if not initialized:
+                for layout in reversed(layouts):
+                    library.cublasLtMatrixLayoutDestroy(layout)
+                if operation:
+                    library.cublasLtMatmulDescDestroy(operation)
+                if handle:
+                    library.cublasLtDestroy(handle)
+
+        self.library = library
+        self.library_identity = library_identity
+        self.handle = handle
+        self.operation = operation
+        self.a_layout = a_layout
+        self.b_layout_descriptor = b_matrix_layout
+        self.output_layout = output_layout
+        self._finalizer = weakref.finalize(
+            self,
+            _destroy_resources,
+            library,
+            tuple(layouts),
+            operation,
+            handle,
+        )
+        self.outputs = outputs
+        self.inputs = inputs
+        self.device = device
+        self.dimension_arrays = dimension_arrays
+        self.a_pointers = a_pointers
+        self.b_pointers = b_pointers
+        self.output_pointers = output_pointers
+        self.alpha = alpha
+        self.beta = beta
+        self.workspace_storage = workspace_storage
+        self.workspace = workspace
+        self.grouped_preferences = grouped_preferences
+        self.selected_algorithm = selected_algorithm
+
+    def prepared_implementation(
+        self,
+    ) -> PreparedImplementation:
+        selected = self.selected_algorithm
+        algorithm = _CublasLtMatmulAlgo.from_buffer_copy(
+            bytes.fromhex(selected.serialized_hex)
+        )
+
+        def call() -> None:
+            self(algorithm, selected)
+
+        config = common.provider_config(
+            "cublaslt",
+            {
+                "baseline": "cublaslt_native_heterogeneous_grouped_matmul",
+                "api": "cublasLtGroupedMatrixLayoutCreate/cublasLtMatmul",
+                "library": self.library_identity,
+                "group_count": self.inputs.case.groups,
+                "workspace_bytes": _DEFAULT_WORKSPACE_BYTES,
+                "grouped_average_preferences": self.grouped_preferences,
+                "grouped_average_preference_rounding": "integer_floor",
+                "heuristic_query_capacity": CUBLASLT_HEURISTIC_QUERY_CAPACITY,
+                "selected_algorithm": asdict(selected),
+                "a_layout": {
+                    "kind": "compact_group_views",
+                    "shared_compact_allocation": True,
+                    "logical_values_bitwise_equal": True,
+                },
+                "numerics": "BF16 inputs, FP32 accumulation, BF16 output",
+            },
+        )
+        return common.PreparedImplementation(
+            name=f"cublaslt-{BENCHMARK_B_LAYOUT}-rank-{selected.heuristic_rank}",
+            call=call,
+            output_tensors=lambda _result: self.outputs,
+            logical_outputs=lambda _result: self.outputs,
+            config=config,
+        )
+
+    def __call__(
+        self,
+        algorithm: _CublasLtMatmulAlgo,
+        metadata: _CublasLtAlgorithm,
+    ) -> None:
+        with torch.cuda.device(self.device):
+            workspace_pointer = ctypes.c_void_p(self.workspace.data_ptr())
+            _check_cublas(
+                self.library.cublasLtMatmul(
+                    self.handle,
+                    self.operation,
+                    ctypes.c_void_p(self.alpha.data_ptr()),
+                    ctypes.c_void_p(self.a_pointers.data_ptr()),
+                    self.a_layout,
+                    ctypes.c_void_p(self.b_pointers.data_ptr()),
+                    self.b_layout_descriptor,
+                    ctypes.c_void_p(self.beta.data_ptr()),
+                    ctypes.c_void_p(self.output_pointers.data_ptr()),
+                    self.output_layout,
+                    ctypes.c_void_p(self.output_pointers.data_ptr()),
+                    self.output_layout,
+                    ctypes.byref(algorithm),
+                    workspace_pointer,
+                    _DEFAULT_WORKSPACE_BYTES,
+                    ctypes.c_void_p(torch.cuda.current_stream(self.device).cuda_stream),
+                ),
+                f"cublasLtMatmul grouped algorithm rank {metadata.heuristic_rank}",
+            )
+
+
+def prepare_cublaslt_default(
+    inputs: GroupedGemmInputs,
+) -> PreparedImplementation:
+    """Use only cuBLASLt's rank-zero grouped-GEMM heuristic result."""
+
+    with torch.cuda.device(inputs.compact_a.device):
+        core = _CublasLtGroupedGemm(inputs)
+    if core.selected_algorithm.heuristic_rank != 0:
+        raise RuntimeError("cuBLASLt default result was not heuristic rank zero")
+    return core.prepared_implementation()

--- a/benchmarks/cute/cudnn_grouped_gemm.py
+++ b/benchmarks/cute/cudnn_grouped_gemm.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+import weakref
+
+from benchmarks.cute import grouped_gemm_benchmark as common
+from benchmarks.cute.grouped_gemm_workloads import BENCHMARK_B_LAYOUT
+import torch
+
+if TYPE_CHECKING:
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+
+
+CUDNN_GROUPED_BASELINE = "cudnn_moe_grouped_matmul"
+CUDNN_FRONTEND_DISTRIBUTION = "nvidia-cudnn-frontend"
+CUDNN_FRONTEND_VERSION = "1.27.0"
+CUDNN_BACKEND_DISTRIBUTION = "nvidia-cudnn-cu13"
+CUDNN_BACKEND_DISTRIBUTION_VERSION = "9.24.0.43"
+CUDNN_BACKEND_VERSION = 92400
+CUDNN_CUDART_ENVIRONMENT_VARIABLE = "CUDNN_FRONTEND_CUDART_LIB_NAME"
+CUDNN_LIBRARY_RELATIVE_PATH = Path("nvidia/cudnn/lib/libcudnn.so.9")
+
+# cuDNN graph tensor UIDs are arbitrary, stable identifiers within this graph.
+_TOKEN_UID = 20
+_WEIGHT_UID = 21
+_FIRST_TOKEN_OFFSET_UID = 22
+_OUTPUT_UID = 100
+
+
+def configure_cudnn_cudart_library() -> dict[str, str]:
+    """Select the CUDA runtime used by the frontend shim before import."""
+
+    distribution = common.require_pinned_distribution(
+        common.CUDA_RUNTIME_DISTRIBUTION,
+        common.CUDA_RUNTIME_VERSION,
+    )
+    default = common.distribution_file(
+        common.CUDA_RUNTIME_DISTRIBUTION,
+        distribution,
+        common.CUDA_RUNTIME_LIBRARY_RELATIVE_PATH,
+    )
+    path = Path(os.environ.get(CUDNN_CUDART_ENVIRONMENT_VARIABLE, default)).resolve()
+    if path != default:
+        raise RuntimeError(
+            f"{CUDNN_CUDART_ENVIRONMENT_VARIABLE} must resolve to {default}"
+        )
+    os.environ[CUDNN_CUDART_ENVIRONMENT_VARIABLE] = str(path)
+    return {
+        "distribution": common.CUDA_RUNTIME_DISTRIBUTION,
+        "package_version": distribution.version,
+        "path": str(path),
+    }
+
+
+def _import_cudnn() -> object:
+    try:
+        return importlib.import_module("cudnn")
+    except (ImportError, OSError) as error:
+        raise RuntimeError("cuDNN frontend is unavailable") from error
+
+
+def _backend_version_string(version: int) -> str:
+    major, remainder = divmod(version, 10_000)
+    minor, patch = divmod(remainder, 100)
+    return f"{major}.{minor}.{patch}"
+
+
+def _distribution_identity(identity: dict[str, str]) -> dict[str, str]:
+    return {key: identity[key] for key in ("distribution", "package_version")}
+
+
+def _backend_library_identities() -> dict[str, object]:
+    distribution = common.require_pinned_distribution(
+        CUDNN_BACKEND_DISTRIBUTION,
+        CUDNN_BACKEND_DISTRIBUTION_VERSION,
+    )
+    expected = {
+        Path(str(distribution.locate_file(path))).resolve(strict=True)
+        for path in distribution.files or ()
+        if Path(str(path)).name.startswith("libcudnn")
+        and ".so.9" in Path(str(path)).name
+    }
+    loaded = set(common.mapped_library_paths("libcudnn"))
+    main_library = common.distribution_file(
+        CUDNN_BACKEND_DISTRIBUTION,
+        distribution,
+        CUDNN_LIBRARY_RELATIVE_PATH,
+    )
+    if main_library not in loaded or not loaded.issubset(expected):
+        raise RuntimeError(
+            "loaded cuDNN libraries are not all from the pinned distribution: "
+            f"{sorted(map(str, loaded))}"
+        )
+    return {
+        "distribution": CUDNN_BACKEND_DISTRIBUTION,
+        "package_version": distribution.version,
+    }
+
+
+def _loaded_cuda_runtime_identity() -> dict[str, str]:
+    expected_identity = configure_cudnn_cudart_library()
+    expected = Path(expected_identity["path"])
+    loaded = common.mapped_library_paths("libcudart.so")
+    if loaded != (expected,):
+        raise RuntimeError(
+            "loaded CUDA runtimes are "
+            f"{tuple(map(str, loaded))}, expected {(str(expected),)}"
+        )
+    return _distribution_identity(expected_identity)
+
+
+def _frontend_identity(cudnn: object) -> dict[str, object]:
+    cudnn = cast("Any", cudnn)
+    distribution = common.require_pinned_distribution(
+        CUDNN_FRONTEND_DISTRIBUTION,
+        CUDNN_FRONTEND_VERSION,
+    )
+    expected_module = common.distribution_file(
+        CUDNN_FRONTEND_DISTRIBUTION,
+        distribution,
+        Path("cudnn/__init__.py"),
+    )
+    module = Path(str(cudnn.__file__)).resolve(strict=True)
+    if module != expected_module:
+        raise RuntimeError(
+            f"cuDNN frontend imported from {module}, expected {expected_module}"
+        )
+    extension = Path(str(cudnn._pybind_module.__file__)).resolve(strict=True)
+    if not extension.is_relative_to(expected_module.parent):
+        raise RuntimeError(
+            "cuDNN frontend extension was imported outside its distribution: "
+            f"{extension}"
+        )
+    return {
+        "distribution": CUDNN_FRONTEND_DISTRIBUTION,
+        "package_version": distribution.version,
+    }
+
+
+def _validated_cudnn_runtime() -> tuple[Any, str, int, dict[str, object]]:
+    cudart = configure_cudnn_cudart_library()
+    cudnn = cast("Any", _import_cudnn())
+    frontend_version = str(cudnn.__version__)
+    backend_version = int(cudnn.backend_version())
+    if frontend_version != CUDNN_FRONTEND_VERSION:
+        raise RuntimeError(
+            f"cuDNN frontend is {frontend_version}, expected {CUDNN_FRONTEND_VERSION}"
+        )
+    if backend_version != CUDNN_BACKEND_VERSION:
+        raise RuntimeError(
+            "cuDNN backend is "
+            f"{_backend_version_string(backend_version)}, expected "
+            f"{_backend_version_string(CUDNN_BACKEND_VERSION)}"
+        )
+    return (
+        cudnn,
+        frontend_version,
+        backend_version,
+        {
+            "frontend": _frontend_identity(cudnn),
+            "requested_cuda_runtime": _distribution_identity(cudart),
+        },
+    )
+
+
+def _selected_plan_identity(graph: object) -> dict[str, object]:
+    graph = cast("Any", graph)
+    selected_index = int(graph._plan_index)
+    engine_id, knobs = graph.get_engine_and_knobs_at_index(selected_index)
+    return {
+        "candidate_count": int(graph.get_execution_plan_count()),
+        "selected_index": selected_index,
+        "name": str(graph.get_plan_name_at_index(selected_index)),
+        "engine_id": int(engine_id),
+        "knobs": [
+            {"type": str(knob), "value": int(value)}
+            for knob, value in sorted(knobs.items(), key=lambda pair: str(pair[0]))
+        ],
+    }
+
+
+class _CudnnLaunch:
+    def __init__(
+        self,
+        inputs: GroupedGemmInputs,
+    ) -> None:
+        cudnn, frontend_version, backend_version, runtime_identity = (
+            _validated_cudnn_runtime()
+        )
+        self.inputs = inputs
+        a = inputs.compact_a
+        b = inputs.b
+        self.output = torch.empty(
+            (inputs.case.total_m, inputs.case.n),
+            device=a.device,
+            dtype=torch.bfloat16,
+        )
+        self.device = a.device
+        self._cudnn = cudnn
+        # PreparedImplementation.config intentionally retains this dict by
+        # reference so the first execution can append loaded-library provenance.
+        self._runtime_identity = runtime_identity
+        self._loaded_runtime_validated = False
+
+        with torch.cuda.device(self.device):
+            self.token = a.unsqueeze(0)
+            # The frontend ABI is [G,K,N], so use a zero-copy transpose of the
+            # benchmark's canonical K-major [G,N,K] storage.
+            self.weight = b.transpose(1, 2)
+            # The MOE descriptor consumes one start per group, not an indptr
+            # sentinel. Group extents come from the token tensor and next start.
+            self.first_token_offsets = inputs.offsets[:-1].view(
+                inputs.case.groups, 1, 1
+            )
+            self.output_3d = self.output.unsqueeze(0)
+            self.handle = cudnn.create_handle()
+            self._handle_finalizer = weakref.finalize(
+                self, cudnn.destroy_handle, self.handle
+            )
+            cudnn.set_stream(
+                handle=self.handle,
+                stream=torch.cuda.current_stream(self.device).cuda_stream,
+            )
+            graph = cudnn.pygraph(
+                intermediate_data_type=cudnn.data_type.FLOAT,
+                compute_data_type=cudnn.data_type.FLOAT,
+                handle=self.handle,
+            )
+            token_desc = graph.tensor(
+                name="token",
+                dim=list(self.token.shape),
+                stride=list(self.token.stride()),
+                data_type=cudnn.data_type.BFLOAT16,
+                uid=_TOKEN_UID,
+            )
+            weight_desc = graph.tensor(
+                name="weight",
+                dim=list(self.weight.shape),
+                stride=list(self.weight.stride()),
+                data_type=cudnn.data_type.BFLOAT16,
+                uid=_WEIGHT_UID,
+            )
+            offsets_desc = graph.tensor(
+                name="first_token_offset",
+                dim=list(self.first_token_offsets.shape),
+                stride=list(self.first_token_offsets.stride()),
+                data_type=cudnn.data_type.INT32,
+                uid=_FIRST_TOKEN_OFFSET_UID,
+            )
+            accum = graph.moe_grouped_matmul(
+                name="cudnn_moe_grouped_gemm",
+                token=token_desc,
+                weight=weight_desc,
+                first_token_offset=offsets_desc,
+                mode=cudnn.moe_grouped_matmul_mode.NONE,
+                compute_data_type=cudnn.data_type.FLOAT,
+            )
+            accum.set_uid(_OUTPUT_UID).set_output(True).set_data_type(
+                cudnn.data_type.BFLOAT16
+            )
+            graph.validate()
+            graph.build_operation_graph()
+            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+            graph.check_support()
+            graph.build_plans()
+            self.selected_plan = _selected_plan_identity(graph)
+            self.workspace_bytes = int(graph.get_workspace_size())
+            self.graph = graph
+            self.workspace = torch.empty(
+                self.workspace_bytes,
+                device=self.device,
+                dtype=torch.uint8,
+            )
+            self._variant_pack = {
+                _TOKEN_UID: self.token,
+                _WEIGHT_UID: self.weight,
+                _FIRST_TOKEN_OFFSET_UID: self.first_token_offsets,
+                _OUTPUT_UID: self.output_3d,
+            }
+        self.base_provenance: dict[str, object] = {
+            "baseline": CUDNN_GROUPED_BASELINE,
+            "frontend_version": frontend_version,
+            "backend_version": backend_version,
+            "backend_version_string": _backend_version_string(backend_version),
+            "runtime": runtime_identity,
+            "numerics": "BF16 inputs, FP32 accumulation, BF16 output",
+        }
+
+    def run(self) -> torch.Tensor:
+        with torch.cuda.device(self.device):
+            # A captured graph may replay on a different current stream than
+            # graph construction, so bind the frontend handle on every call.
+            self._cudnn.set_stream(
+                handle=self.handle,
+                stream=torch.cuda.current_stream(self.device).cuda_stream,
+            )
+            self.graph.execute(
+                self._variant_pack,
+                self.workspace,
+                handle=self.handle,
+            )
+        if not self._loaded_runtime_validated:
+            self._runtime_identity.update(
+                {
+                    "backend_libraries": _backend_library_identities(),
+                    "loaded_cuda_runtime": _loaded_cuda_runtime_identity(),
+                }
+            )
+            self._loaded_runtime_validated = True
+        return self.output
+
+    def prepared_implementation(self) -> PreparedImplementation:
+        return common.PreparedImplementation(
+            name=f"cudnn-{BENCHMARK_B_LAYOUT}-graph-default",
+            call=self.run,
+            output_tensors=lambda _result: (self.output,),
+            logical_outputs=lambda _result: self.inputs.compact_output_slices(
+                self.output
+            ),
+            config=common.provider_config(
+                "cudnn",
+                {
+                    **self.base_provenance,
+                    "plan": {
+                        "selection": "graph_build_default",
+                        "heuristic_modes": ["A", "FALLBACK"],
+                        **self.selected_plan,
+                        "workspace_bytes": self.workspace_bytes,
+                    },
+                    "a_layout": common.compact_contiguous_a_layout(),
+                },
+            ),
+        )
+
+
+def prepare_cudnn_default(
+    inputs: GroupedGemmInputs,
+) -> PreparedImplementation:
+    """Build and execute cuDNN's first buildable A/FALLBACK plan."""
+
+    return _CudnnLaunch(inputs).prepared_implementation()

--- a/benchmarks/cute/cutlass_contiguous_grouped_gemm.py
+++ b/benchmarks/cute/cutlass_contiguous_grouped_gemm.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import replace
+import importlib
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+from benchmarks.cute import grouped_gemm_benchmark as common
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+
+
+CUTLASS_REPOSITORY = "https://github.com/NVIDIA/cutlass"
+# Match Helion's repository-wide, validated CuTe DSL pin.
+CUTLASS_RELEASE_TAG = "v4.7.0"
+CUTLASS_COMMIT = "dcf215af68a2d08d305076c152a06f201728cd53"
+CUTLASS_DSL_VERSION = "4.7.0"
+CUTLASS_OPERATOR_API_VERSION = "0.2.0"
+CUTLASS_SELECTION_MIN_REPETITIONS = 32
+CUTLASS_SELECTION_CAPTURE_WARMUPS = 2
+CUTLASS_TARGET_SMS = {
+    (10, 0): "100a",
+    (10, 3): "103a",
+}
+CUTLASS_OPERATOR_BASELINE = "cutlass_operator_contiguous_offset_bf16"
+_OPERATOR_MODULE = (
+    "cutlass.operators.providers.cutedsl.gemm.sm100_contiguous_offset_2d3d_dense_gemm"
+)
+_PINNED_DEPENDENCIES = {
+    "nvidia-cutlass-dsl": CUTLASS_DSL_VERSION,
+    "nvidia-cutlass-dsl-libs-base": CUTLASS_DSL_VERSION,
+    "nvidia-cutlass-dsl-libs-core": CUTLASS_DSL_VERSION,
+    "nvidia-cutlass-dsl-libs-cu13": CUTLASS_DSL_VERSION,
+    "apache-tvm-ffi": "0.1.13.post3",
+    "torch-c-dlpack-ext": "0.1.5",
+}
+
+
+@dataclass(frozen=True)
+class _CutlassCandidate:
+    registry_index: int
+    operator_name: str
+    compiled_for: str
+    prepared: PreparedImplementation
+
+
+def _int3(values: Sequence[int], name: str) -> tuple[int, int, int]:
+    result = tuple(int(value) for value in values)
+    if len(result) != 3 or any(value <= 0 for value in result):
+        raise RuntimeError(f"CUTLASS {name} must contain three positive integers")
+    first, second, third = result
+    return first, second, third
+
+
+def cutlass_target_sm(capability: tuple[int, int]) -> str:
+    """Return the CUTLASS architecture target for a validated device."""
+
+    try:
+        return CUTLASS_TARGET_SMS[capability]
+    except KeyError as error:
+        raise RuntimeError(
+            "CUTLASS grouped adapter targets B200/SM100 or GB300/SM103"
+        ) from error
+
+
+def require_cutlass_dependencies() -> None:
+    """Require the exact package set used for publication."""
+
+    common.require_pinned_distributions(
+        _PINNED_DEPENDENCIES,
+        "CUTLASS Operator adapter dependencies are unavailable",
+    )
+
+
+def verify_cutlass_checkout(cutlass_root: Path) -> tuple[Path, str]:
+    """Require the clean pinned CUTLASS source used by the public campaign."""
+
+    root = cutlass_root.expanduser().resolve(strict=True)
+    commit = common.clean_checkout(root, CUTLASS_COMMIT, "CUTLASS")
+    if not (root / "operators" / "cutlass").is_dir():
+        raise RuntimeError(f"CUTLASS Operator API package is missing below {root}")
+    return root, commit
+
+
+def _load_operator_api(
+    cutlass_root: Path,
+) -> tuple[Any, type[object]]:
+    package_root = (cutlass_root / "operators" / "cutlass").resolve()
+    cutlass = importlib.import_module("cutlass")
+    package_path = cutlass.__path__
+    value = str(package_root)
+    # Providers run in fresh subprocesses, so extending the installed CUTLASS
+    # namespace with the pinned source checkout is intentionally process-local.
+    cutlass.__path__ = [
+        value,
+        *(str(path) for path in package_path if str(Path(path).resolve()) != value),
+    ]
+    importlib.invalidate_caches()
+    try:
+        ops = cast("Any", importlib.import_module("cutlass.operators"))
+        module = importlib.import_module(_OPERATOR_MODULE)
+        operator_class = cast(
+            "type[object]", module.ContiguousOffset2D3DGemmDenseOperator
+        )
+    except (AttributeError, ImportError, OSError) as error:
+        raise RuntimeError("failed to import CUTLASS grouped operators") from error
+    if operator_class.__module__ != _OPERATOR_MODULE:
+        raise RuntimeError(
+            "CUTLASS grouped operator class came from "
+            f"{operator_class.__module__!r}, expected {_OPERATOR_MODULE!r}"
+        )
+    common.validate_module_source(
+        ops, cutlass_root, "CUTLASS module 'cutlass.operators'"
+    )
+    common.validate_module_source(
+        module, cutlass_root, f"CUTLASS module {_OPERATOR_MODULE!r}"
+    )
+    return ops, operator_class
+
+
+def _operator_config(metadata: object) -> dict[str, object]:
+    metadata = cast("Any", metadata)
+    return {
+        "use_2cta_mma": bool(metadata.design.use_2cta_mma),
+        "tile_shape": _int3(metadata.design.tile_shape, "operator tile_shape"),
+        "cluster_shape": _int3(metadata.design.cluster_shape, "operator cluster_shape"),
+    }
+
+
+def _tune_candidates(
+    candidates: Sequence[_CutlassCandidate],
+    oracle: Sequence[torch.Tensor],
+) -> dict[str, object]:
+    """Validate and cold-L2 time every supported CUTLASS operator."""
+
+    from pretuned_kernels import _bench
+
+    if not candidates:
+        raise ValueError("CUTLASS tuning requires at least one candidate")
+    captures = []
+    for candidate in candidates:
+        captured = common.capture_implementation(
+            candidate.prepared,
+            warmups=CUTLASS_SELECTION_CAPTURE_WARMUPS,
+        )
+        evidence = common.validate_capture(captured, oracle)
+        if not evidence["ok"]:
+            raise RuntimeError(
+                f"CUTLASS candidate {candidate.operator_name!r} failed correctness: "
+                f"{evidence}"
+            )
+        captures.append(captured)
+
+    cycle = 2 * len(candidates)
+    repetitions = (CUTLASS_SELECTION_MIN_REPETITIONS + cycle - 1) // cycle * cycle
+    selection_ms = _bench.bench_pre_captured_cudagraphs(
+        [capture.replay for capture in captures],
+        rep=repetitions,
+    )
+    if len(selection_ms) != len(candidates) or any(
+        not isinstance(value, int | float)
+        or isinstance(value, bool)
+        or not math.isfinite(value)
+        or value <= 0
+        for value in selection_ms
+    ):
+        raise RuntimeError("CUTLASS candidate timings must be finite and positive")
+
+    selected_index = min(
+        range(len(candidates)),
+        key=lambda index: (selection_ms[index], candidates[index].operator_name),
+    )
+    evidence: dict[str, object] = {
+        "method": "all_supported_operators_cold_l2",
+        "timer": "bench_pre_captured_cudagraphs",
+        "capture_warmups": CUTLASS_SELECTION_CAPTURE_WARMUPS,
+        "repetitions": repetitions,
+        "selected_candidate_index": selected_index,
+        "candidates": [
+            {
+                "registry_index": candidate.registry_index,
+                "operator_name": candidate.operator_name,
+                "config": candidate.prepared.config,
+                "compiled_for": candidate.compiled_for,
+                "selection_median_ms": float(elapsed_ms),
+                "correctness_checked": True,
+            }
+            for candidate, elapsed_ms in zip(
+                candidates,
+                selection_ms,
+                strict=True,
+            )
+        ],
+    }
+    return evidence
+
+
+def _prepared_candidate(
+    inputs: GroupedGemmInputs,
+    args: object,
+    output: torch.Tensor,
+    operator: object,
+    artifact: object,
+    *,
+    name: str,
+    config: dict[str, Any],
+) -> PreparedImplementation:
+    device = inputs.compact_a.device
+    operator_api = cast("Any", operator)
+
+    def call() -> torch.Tensor:
+        with torch.cuda.device(device):
+            operator_api.run(
+                args,
+                compiled_artifact=artifact,
+                stream=torch.cuda.current_stream(device),
+                assume_supported_args=True,
+            )
+        return output
+
+    return common.PreparedImplementation(
+        name=name,
+        call=call,
+        output_tensors=lambda _result: (output,),
+        logical_outputs=lambda _result: inputs.compact_output_slices(output),
+        config=config,
+    )
+
+
+def prepare_cutlass_default(
+    inputs: GroupedGemmInputs,
+    *,
+    cutlass_root: Path,
+) -> PreparedImplementation:
+    """Tune every supported public-registry operator outside final timing."""
+
+    cutlass_root, commit = verify_cutlass_checkout(cutlass_root)
+    require_cutlass_dependencies()
+    device = inputs.compact_a.device
+    target_sm = cutlass_target_sm(torch.cuda.get_device_capability(device))
+    if inputs.case.k % 8 or inputs.case.n % 8:
+        raise ValueError("CUTLASS BF16 K and N must be multiples of 8")
+
+    a = inputs.compact_a
+    b_kn = inputs.b.transpose(1, 2)
+    offsets = inputs.offsets[1:]
+    output = torch.empty(
+        (inputs.case.total_m, inputs.case.n),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    ops, operator_class = _load_operator_api(cutlass_root)
+    operator_api_version = str(ops.__version__)
+    if operator_api_version != CUTLASS_OPERATOR_API_VERSION:
+        raise RuntimeError(
+            "CUTLASS Operator API version is "
+            f"{operator_api_version}, expected {CUTLASS_OPERATOR_API_VERSION}"
+        )
+    global_options = ops.GlobalOptions()
+    global_options.use_tvm_ffi = True
+    if ops.GlobalOptions().use_tvm_ffi is not True:
+        raise RuntimeError("CUTLASS global use_tvm_ffi option did not persist")
+    with torch.cuda.device(device):
+        args = ops.GroupedGemmArguments(
+            a,
+            b_kn,
+            output,
+            accumulator_type=torch.float32,
+            offsets=offsets,
+        )
+        discovered = ops.get_operators(
+            args,
+            metadata_filter=lambda metadata: metadata.operator_class is operator_class,
+            target_sm=target_sm,
+            providers=[ops.CuTeDSLProvider],
+        )
+    if not discovered:
+        raise RuntimeError(
+            f"CUTLASS returned no {operator_class.__name__} operator for the workload"
+        )
+    indexed_operators = sorted(
+        enumerate(discovered),
+        key=lambda item: str(item[1].metadata.operator_name),
+    )
+    operator_names = [
+        str(operator.metadata.operator_name) for _, operator in indexed_operators
+    ]
+    if len(operator_names) != len(set(operator_names)):
+        raise RuntimeError("CUTLASS returned duplicate supported operator names")
+
+    candidates = []
+    for candidate_index, (registry_index, operator) in enumerate(indexed_operators):
+        operator_name = str(operator.metadata.operator_name)
+        config = _operator_config(operator.metadata)
+        with torch.cuda.device(device):
+            artifact = operator.compile(args, target_sm=target_sm)
+        compiled_for = str(artifact.compiled_for)
+        candidates.append(
+            _CutlassCandidate(
+                registry_index=registry_index,
+                operator_name=operator_name,
+                compiled_for=compiled_for,
+                prepared=_prepared_candidate(
+                    inputs,
+                    args,
+                    output,
+                    operator,
+                    artifact,
+                    name=f"{CUTLASS_OPERATOR_BASELINE}-candidate-{candidate_index}",
+                    config=config,
+                ),
+            )
+        )
+
+    selection = _tune_candidates(candidates, inputs.oracle)
+    selected_index = selection.get("selected_candidate_index")
+    if type(selected_index) is not int or not 0 <= selected_index < len(candidates):
+        raise RuntimeError("CUTLASS tuning returned an invalid selected candidate")
+    selected = candidates[selected_index]
+    return replace(
+        selected.prepared,
+        name=f"{CUTLASS_OPERATOR_BASELINE}_cold_l2_tuned",
+        config=common.provider_config(
+            "cutlass",
+            {
+                "baseline": CUTLASS_OPERATOR_BASELINE,
+                "benchmark_label": "CUTLASS supported-operator cold-L2 tuned",
+                "repository": CUTLASS_REPOSITORY,
+                "release_tag": CUTLASS_RELEASE_TAG,
+                "commit": commit,
+                "operator_api_version": operator_api_version,
+                "global_options": {"use_tvm_ffi": True},
+                "target_sm": target_sm,
+                "registry_tuning": selection,
+                "a_layout": common.compact_contiguous_a_layout(),
+                "numerics": "BF16 inputs, FP32 accumulation, BF16 output",
+            },
+        ),
+    )

--- a/benchmarks/cute/deepgemm_selected_path.py
+++ b/benchmarks/cute/deepgemm_selected_path.py
@@ -10,34 +10,35 @@ import importlib
 import json
 import os
 from pathlib import Path
-import random
 import statistics
 import subprocess
 import sys
 import tempfile
 import time
 from typing import Any
-from typing import NamedTuple
 from typing import Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_COMMIT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_CUTLASS_COMMIT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_M_ALIGNMENT as M_ALIGNMENT
+from benchmarks.cute.grouped_gemm_workloads import OFFICIAL_SHAPES
+from benchmarks.cute.grouped_gemm_workloads import OfficialShape
+from benchmarks.cute.grouped_gemm_workloads import official_actual_ms
 import torch
 
 import helion
 import helion.language as hl
 import helion.runtime as helion_runtime
 
+# Pin the historical DeepGEMM-selected BK64 schedule. This benchmark must not
+# silently change when compiler defaults evolve.
 DEEPGEMM_SELECTED_TILE_M = 256
 DEEPGEMM_SELECTED_TILE_N = 128
 DEEPGEMM_SELECTED_TILE_K = 64
-# Pin the historical DeepGEMM-selected BK64 schedule.  This benchmark must not
-# silently change when compiler defaults evolve.
-M_ALIGNMENT = 224
-DEEPGEMM_COMMIT = "559d79fb6994a58b8a15b4b93bf13ccc16edf247"
-DEEPGEMM_CUTLASS_COMMIT = "f3fde58372d33e9a5650ba7b80fc48b3b49d40c8"
 DEFAULT_L2_FLUSH_BYTES = 8_000_000_000
 CACHE_DIRS = {
     "CUDA_CACHE_PATH": "cuda",
@@ -49,26 +50,6 @@ CACHE_DIRS = {
     "TORCH_EXTENSIONS_DIR": "torch_extensions",
     "XDG_CACHE_HOME": "xdg",
 }
-
-
-class OfficialShape(NamedTuple):
-    row_index: int
-    groups: int
-    expected_m_per_group: int
-    n: int
-    k: int
-
-
-OFFICIAL_SHAPES = (
-    OfficialShape(0, 4, 8192, 6144, 7168),
-    OfficialShape(1, 4, 8192, 7168, 3072),
-    OfficialShape(2, 4, 8192, 4096, 4096),
-    OfficialShape(3, 4, 8192, 4096, 2048),
-    OfficialShape(4, 8, 4096, 6144, 7168),
-    OfficialShape(5, 8, 4096, 7168, 3072),
-    OfficialShape(6, 8, 4096, 4096, 4096),
-    OfficialShape(7, 8, 4096, 4096, 2048),
-)
 
 
 def align(value: int, alignment: int) -> int:
@@ -99,17 +80,6 @@ def parse_rows(value: str) -> list[int]:
         )
         raise argparse.ArgumentTypeError(message)
     return result
-
-
-def official_actual_ms(seed: int = 0) -> tuple[tuple[int, ...], ...]:
-    rng = random.Random(seed)
-    return tuple(
-        tuple(
-            int(shape.expected_m_per_group * rng.uniform(0.7, 1.3))
-            for _ in range(shape.groups)
-        )
-        for shape in OFFICIAL_SHAPES
-    )
 
 
 def selected_key(

--- a/benchmarks/cute/grouped_gemm_benchmark.py
+++ b/benchmarks/cute/grouped_gemm_benchmark.py
@@ -1,0 +1,680 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import dataclass
+from hashlib import sha256
+import importlib.metadata
+from itertools import accumulate
+from itertools import starmap
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+from typing import TYPE_CHECKING
+from typing import Any
+
+from benchmarks.cute.grouped_gemm_workloads import BENCHMARK_B_LAYOUT
+from benchmarks.cute.grouped_gemm_workloads import OFFICIAL_SHAPES
+from benchmarks.cute.grouped_gemm_workloads import PROVIDER_SELECTION_MODES
+from benchmarks.cute.grouped_gemm_workloads import official_actual_ms
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Mapping
+    from collections.abc import Sequence
+
+
+ORACLE_FLOAT32_MATMUL_PRECISION = "highest"
+CORRECTNESS_MAX_NORMALIZED_DIFF = 1e-5
+CORRECTNESS_RTOL = 2e-2
+CORRECTNESS_ATOL = 2e-2
+SUPPORTED_DEVICE_CAPABILITIES = {
+    "NVIDIA B200": (10, 0),
+    "NVIDIA GB300": (10, 3),
+}
+CUDA_RUNTIME_DISTRIBUTION = "nvidia-cuda-runtime"
+CUDA_RUNTIME_VERSION = "13.3.29"
+CUDA_NVCC_DISTRIBUTION = "nvidia-cuda-nvcc"
+CUDA_NVVM_DISTRIBUTION = "nvidia-nvvm"
+CUDA_CRT_DISTRIBUTION = "nvidia-cuda-crt"
+CUDA_CCCL_DISTRIBUTION = "nvidia-cuda-cccl"
+CUDA_CCCL_VERSION = "13.3.3.4.1"
+CUDA_NVRTC_DISTRIBUTION = "nvidia-cuda-nvrtc"
+CUDA_NVRTC_VERSION = "13.3.33"
+CUDA_CUBLAS_DISTRIBUTION = "nvidia-cublas"
+CUDA_CUBLAS_VERSION = "13.6.1.10"
+CUDA_COMPILER_VERSION = "13.3.73"
+CUDA_TOOLKIT_RELEASE = "13.3"
+CUDA_RUNTIME_LIBRARY_RELATIVE_PATH = Path("nvidia/cu13/lib/libcudart.so.13")
+CUDA_NVCC_EXECUTABLE_RELATIVE_PATH = Path("nvidia/cu13/bin/nvcc")
+CUDA_NVVM_LIBRARY_RELATIVE_PATH = Path("nvidia/cu13/lib/libnvvm.so.4")
+CUDA_CRT_HEADER_RELATIVE_PATH = Path("nvidia/cu13/include/crt/host_config.h")
+CUDA_CCCL_TARGET_HEADER_RELATIVE_PATH = Path("nvidia/cu13/include/nv/target")
+CUDA_CCCL_VERSION_HEADER_RELATIVE_PATH = Path(
+    "nvidia/cu13/include/cccl/cuda/std/version"
+)
+CUDA_NVRTC_LIBRARY_RELATIVE_PATH = Path("nvidia/cu13/lib/libnvrtc.so.13")
+CUDA_CUBLAS_LIBRARY_RELATIVE_PATH = Path("nvidia/cu13/lib/libcublas.so.13")
+CUDA_CUBLASLT_LIBRARY_RELATIVE_PATH = Path("nvidia/cu13/lib/libcublasLt.so.13")
+CUDA_STACK_DISTRIBUTION_VERSIONS = {
+    CUDA_RUNTIME_DISTRIBUTION: CUDA_RUNTIME_VERSION,
+    CUDA_NVCC_DISTRIBUTION: CUDA_COMPILER_VERSION,
+    CUDA_NVVM_DISTRIBUTION: CUDA_COMPILER_VERSION,
+    CUDA_CRT_DISTRIBUTION: CUDA_COMPILER_VERSION,
+    CUDA_CCCL_DISTRIBUTION: CUDA_CCCL_VERSION,
+    CUDA_NVRTC_DISTRIBUTION: CUDA_NVRTC_VERSION,
+    CUDA_CUBLAS_DISTRIBUTION: CUDA_CUBLAS_VERSION,
+}
+CUDA_STACK_REQUIRED_ARTIFACTS = {
+    "cudart": (CUDA_RUNTIME_DISTRIBUTION, CUDA_RUNTIME_LIBRARY_RELATIVE_PATH),
+    "nvcc": (CUDA_NVCC_DISTRIBUTION, CUDA_NVCC_EXECUTABLE_RELATIVE_PATH),
+    "nvvm": (CUDA_NVVM_DISTRIBUTION, CUDA_NVVM_LIBRARY_RELATIVE_PATH),
+    "crt_header": (CUDA_CRT_DISTRIBUTION, CUDA_CRT_HEADER_RELATIVE_PATH),
+    "cccl_target_header": (
+        CUDA_CCCL_DISTRIBUTION,
+        CUDA_CCCL_TARGET_HEADER_RELATIVE_PATH,
+    ),
+    "cccl_version_header": (
+        CUDA_CCCL_DISTRIBUTION,
+        CUDA_CCCL_VERSION_HEADER_RELATIVE_PATH,
+    ),
+    "nvrtc": (CUDA_NVRTC_DISTRIBUTION, CUDA_NVRTC_LIBRARY_RELATIVE_PATH),
+    "cublas": (CUDA_CUBLAS_DISTRIBUTION, CUDA_CUBLAS_LIBRARY_RELATIVE_PATH),
+    "cublaslt": (CUDA_CUBLAS_DISTRIBUTION, CUDA_CUBLASLT_LIBRARY_RELATIVE_PATH),
+}
+CUDA_STACK_PRELOAD_LIBRARY_PREFIXES = {
+    "cudart": "libcudart.so",
+    "cublas": "libcublas.so",
+    "cublaslt": "libcublasLt.so",
+    "nvrtc": "libnvrtc.so",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedGemmCase:
+    """One official BF16 variable-M grouped ``A @ B.T`` case."""
+
+    id: str
+    row_index: int
+    groups: int
+    expected_m_per_group: int
+    n: int
+    k: int
+    actual_ms: tuple[int, ...]
+
+    @property
+    def total_m(self) -> int:
+        return sum(self.actual_ms)
+
+    def as_dict(self) -> dict[str, object]:
+        return {**asdict(self), "actual_ms": list(self.actual_ms)}
+
+
+def official_cases() -> tuple[GroupedGemmCase, ...]:
+    """Return the eight public shapes and their deterministic seed-0 M values."""
+
+    return tuple(
+        GroupedGemmCase(
+            id=(
+                f"deepgemm-large-g{shape.groups}-m{shape.expected_m_per_group}-"
+                f"n{shape.n}-k{shape.k}"
+            ),
+            row_index=shape.row_index,
+            groups=shape.groups,
+            expected_m_per_group=shape.expected_m_per_group,
+            n=shape.n,
+            k=shape.k,
+            actual_ms=actual_ms,
+        )
+        for shape, actual_ms in zip(
+            OFFICIAL_SHAPES,
+            official_actual_ms(seed=0),
+            strict=True,
+        )
+    )
+
+
+@dataclass(frozen=True)
+class GroupedGemmInputs:
+    """Deterministic compact logical BF16 inputs and their FP32 oracle."""
+
+    case: GroupedGemmCase
+    compact_a: torch.Tensor
+    b: torch.Tensor
+    offsets: torch.Tensor
+    oracle: tuple[torch.Tensor, ...]
+
+    def compact_a_slices(self) -> tuple[torch.Tensor, ...]:
+        return self.compact_a.split(self.case.actual_ms)
+
+    def compact_output_slices(self, output: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        expected_shape = (self.case.total_m, self.case.n)
+        if tuple(output.shape) != expected_shape:
+            raise ValueError(
+                f"compact output has shape {tuple(output.shape)}, "
+                f"expected {expected_shape}"
+            )
+        return output.split(self.case.actual_ms)
+
+
+@dataclass(frozen=True)
+class PackedRows:
+    """One aligned physical-A representation prepared outside timing."""
+
+    a: torch.Tensor
+    worklist: torch.Tensor
+    starts: tuple[int, ...]
+    actual_ms: tuple[int, ...]
+
+    def output_slices(self, output: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        if output.ndim != 2:
+            raise ValueError(f"packed output must be rank two, got {output.shape}")
+        return tuple(
+            output[start : start + valid_m]
+            for start, valid_m in zip(self.starts, self.actual_ms, strict=True)
+        )
+
+    def output_padding_is_zero(self, output: torch.Tensor) -> bool:
+        """Return whether every physical row outside the logical groups is zero."""
+
+        if output.ndim != 2:
+            raise ValueError(f"packed output must be rank two, got {output.shape}")
+        if output.size(0) != self.a.size(0):
+            raise ValueError(
+                f"packed output has {output.size(0)} rows, expected {self.a.size(0)}"
+            )
+        if not self.starts or self.starts[0] != 0:
+            raise ValueError("packed output row metadata must start at row zero")
+        group_ends = (*self.starts[1:], output.size(0))
+        for start, valid_m, stored_end in zip(
+            self.starts,
+            self.actual_ms,
+            group_ends,
+            strict=True,
+        ):
+            valid_end = start + valid_m
+            if not 0 <= start <= valid_end <= stored_end <= output.size(0):
+                raise ValueError("packed output row metadata is inconsistent")
+            padding = output[valid_end:stored_end]
+            if not torch.equal(padding, torch.zeros_like(padding)):
+                return False
+        return True
+
+
+@dataclass
+class PreparedImplementation:
+    """A compiled or compilable implementation with stable output mapping."""
+
+    name: str
+    call: Callable[[], object]
+    output_tensors: Callable[[object], tuple[torch.Tensor, ...]]
+    logical_outputs: Callable[[object], tuple[torch.Tensor, ...]]
+    config: dict[str, Any]
+    track_cute_graph: bool = False
+
+
+@dataclass
+class CapturedImplementation:
+    """A prepared implementation captured into one CUDA graph."""
+
+    prepared: PreparedImplementation
+    graph: torch.cuda.CUDAGraph
+    result: object
+
+    def replay(self) -> None:
+        self.graph.replay()
+
+
+def provider_config(
+    provider: str,
+    details: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Add the invariant public-provider benchmark contract to its details."""
+
+    return {
+        **details,
+        "provider": provider,
+        "selection_mode": PROVIDER_SELECTION_MODES[provider],
+        "selection_timed": False,
+        "preprocessing_timed": False,
+        "b_layout": BENCHMARK_B_LAYOUT,
+        "logical_b_values_bitwise_equal": True,
+    }
+
+
+def configure_oracle_precision() -> str:
+    """Force IEEE FP32 internal matmul precision for the shared oracle."""
+
+    torch.set_float32_matmul_precision(ORACLE_FLOAT32_MATMUL_PRECISION)
+    actual = torch.get_float32_matmul_precision()
+    if actual != ORACLE_FLOAT32_MATMUL_PRECISION:
+        raise RuntimeError(
+            "FP32 oracle precision is "
+            f"{actual!r}, expected {ORACLE_FLOAT32_MATMUL_PRECISION!r}"
+        )
+    return actual
+
+
+def align(value: int, alignment: int) -> int:
+    if value < 0:
+        raise ValueError("value must be non-negative")
+    if alignment <= 0:
+        raise ValueError("alignment must be positive")
+    return (value + alignment - 1) // alignment * alignment
+
+
+def make_inputs(
+    case: GroupedGemmCase,
+    device: torch.device,
+    *,
+    seed: int,
+) -> GroupedGemmInputs:
+    """Create seeded logical inputs without coupling to ambient RNG state."""
+
+    generator = torch.Generator(device=device).manual_seed(seed)
+    compact_a = torch.randn(
+        (case.total_m, case.k),
+        device=device,
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    b = torch.randn(
+        (case.groups, case.n, case.k),
+        device=device,
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    oracle = []
+    start = 0
+    for group, actual_m in enumerate(case.actual_ms):
+        end = start + actual_m
+        oracle.append(compact_a[start:end].float() @ b[group].float().T)
+        start = end
+    offsets = torch.tensor(
+        (0, *accumulate(case.actual_ms)),
+        device=device,
+        dtype=torch.int32,
+    )
+    return GroupedGemmInputs(case, compact_a, b, offsets, tuple(oracle))
+
+
+def compact_contiguous_a_layout() -> dict[str, str | bool]:
+    return {
+        "kind": "compact_contiguous",
+        "shared_compact_allocation": True,
+        "logical_values_bitwise_equal": True,
+    }
+
+
+def pack_compact_rows(inputs: GroupedGemmInputs, alignment: int) -> PackedRows:
+    """Repack compact A into aligned physical rows without changing values."""
+
+    stored_ms = tuple(align(actual_m, alignment) for actual_m in inputs.case.actual_ms)
+    packed = torch.zeros(
+        (sum(stored_ms), inputs.case.k),
+        device=inputs.compact_a.device,
+        dtype=inputs.compact_a.dtype,
+    )
+    starts: list[int] = []
+    rows: list[tuple[int, int, int, int]] = []
+    compact_start = 0
+    packed_start = 0
+    for group, (actual_m, stored_m) in enumerate(
+        zip(inputs.case.actual_ms, stored_ms, strict=True)
+    ):
+        compact_end = compact_start + actual_m
+        packed[packed_start : packed_start + actual_m].copy_(
+            inputs.compact_a[compact_start:compact_end]
+        )
+        starts.append(packed_start)
+        rows.append((group, packed_start, actual_m, stored_m))
+        compact_start = compact_end
+        packed_start += stored_m
+    worklist = torch.tensor(
+        rows,
+        device=inputs.compact_a.device,
+        dtype=torch.int32,
+    )
+    return PackedRows(packed, worklist, tuple(starts), inputs.case.actual_ms)
+
+
+def capture_implementation(
+    prepared: PreparedImplementation,
+    *,
+    warmups: int,
+) -> CapturedImplementation:
+    """Warm and capture one implementation."""
+
+    if warmups < 0:
+        raise ValueError("warmups must be non-negative")
+    for _ in range(warmups):
+        prepared.call()
+    torch.cuda.synchronize()
+    if prepared.track_cute_graph:
+        import helion.runtime as helion_runtime
+
+        with helion_runtime.cute_cuda_graph() as graph:
+            result = prepared.call()
+    else:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            result = prepared.call()
+    torch.cuda.synchronize()
+    return CapturedImplementation(
+        prepared=prepared,
+        graph=graph,
+        result=result,
+    )
+
+
+def poison_and_replay(captured: CapturedImplementation) -> bool:
+    """Poison captured outputs and prove that replay rewrites logical rows."""
+
+    for output in captured.prepared.output_tensors(captured.result):
+        output.fill_(float("nan"))
+    captured.replay()
+    torch.cuda.synchronize()
+    logical = captured.prepared.logical_outputs(captured.result)
+    return all(not bool(torch.isnan(output).any().item()) for output in logical)
+
+
+def replay_is_repeatable(captured: CapturedImplementation) -> bool:
+    """Require two consecutive graph replays to produce identical outputs."""
+
+    first = tuple(
+        output.clone() for output in captured.prepared.logical_outputs(captured.result)
+    )
+    captured.replay()
+    torch.cuda.synchronize()
+    second = captured.prepared.logical_outputs(captured.result)
+    return len(first) == len(second) and all(
+        starmap(torch.equal, zip(first, second, strict=True))
+    )
+
+
+def normalized_difference(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    """Return the symmetric normalized difference used by correctness checks."""
+
+    actual64 = actual.double()
+    expected64 = expected.double()
+    denominator = (actual64.square() + expected64.square()).sum()
+    denominator_value = float(denominator.item())
+    if not math.isfinite(denominator_value):
+        return math.inf
+    if denominator_value == 0.0:
+        return 0.0
+    value = float((1 - 2 * (actual64 * expected64).sum() / denominator).item())
+    return max(0.0, value) if math.isfinite(value) else math.inf
+
+
+def check_logical_outputs(
+    actual: Sequence[torch.Tensor],
+    oracle: Sequence[torch.Tensor],
+    *,
+    max_diff: float = CORRECTNESS_MAX_NORMALIZED_DIFF,
+    rtol: float = CORRECTNESS_RTOL,
+    atol: float = CORRECTNESS_ATOL,
+) -> dict[str, Any]:
+    """Compare every logical group against the shared FP32 oracle."""
+
+    if len(actual) != len(oracle):
+        raise ValueError(
+            f"implementation produced {len(actual)} groups, expected {len(oracle)}"
+        )
+    failed_groups: list[dict[str, Any]] = []
+    passed = True
+    max_abs = 0.0
+    max_normalized_diff = 0.0
+    mismatch_count = 0
+    for group, (output, expected) in enumerate(zip(actual, oracle, strict=True)):
+        shape_ok = output.shape == expected.shape
+        dtype_ok = output.dtype is torch.bfloat16 and expected.dtype is torch.float32
+        device_ok = output.device == expected.device
+        if not (shape_ok and dtype_ok and device_ok):
+            failed_groups.append(
+                {
+                    "group": group,
+                    "ok": False,
+                    "shape_ok": shape_ok,
+                    "dtype_ok": dtype_ok,
+                    "device_ok": device_ok,
+                    "normalized_diff": math.inf,
+                    "max_abs": math.inf,
+                    "mismatch_count": output.numel(),
+                }
+            )
+            passed = False
+            max_abs = math.inf
+            max_normalized_diff = math.inf
+            mismatch_count += output.numel()
+            continue
+        output_fp32 = output.float()
+        difference = (output_fp32 - expected).abs()
+        group_max_abs = float(difference.max().item()) if difference.numel() else 0.0
+        finite = bool(
+            torch.isfinite(output_fp32).all().item()
+            and torch.isfinite(expected).all().item()
+        )
+        if not finite:
+            group_max_abs = math.inf
+        normalized_diff = (
+            normalized_difference(output_fp32, expected) if finite else math.inf
+        )
+        close = torch.isclose(output_fp32, expected, rtol=rtol, atol=atol)
+        group_mismatch_count = int((~close).sum().item()) if finite else output.numel()
+        group_ok = finite and normalized_diff <= max_diff and group_mismatch_count == 0
+        if not group_ok:
+            failed_groups.append(
+                {
+                    "group": group,
+                    "ok": False,
+                    "shape_ok": shape_ok,
+                    "dtype_ok": dtype_ok,
+                    "device_ok": device_ok,
+                    "normalized_diff": normalized_diff,
+                    "max_abs": group_max_abs,
+                    "mismatch_count": group_mismatch_count,
+                }
+            )
+        passed = passed and group_ok
+        max_abs = max(max_abs, group_max_abs)
+        max_normalized_diff = max(max_normalized_diff, normalized_diff)
+        mismatch_count += group_mismatch_count
+    result: dict[str, Any] = {
+        "ok": passed,
+        "group_count": len(actual),
+        "max_normalized_diff": max_normalized_diff,
+        "max_abs": max_abs,
+        "mismatch_count": mismatch_count,
+        "rtol": rtol,
+        "atol": atol,
+    }
+    if failed_groups:
+        result["groups"] = failed_groups
+    return result
+
+
+def check_correctness(
+    captured: CapturedImplementation,
+    oracle: Sequence[torch.Tensor],
+    *,
+    max_diff: float = CORRECTNESS_MAX_NORMALIZED_DIFF,
+    rtol: float = CORRECTNESS_RTOL,
+    atol: float = CORRECTNESS_ATOL,
+) -> dict[str, Any]:
+    """Compare a captured implementation's logical groups with the oracle."""
+
+    return check_logical_outputs(
+        captured.prepared.logical_outputs(captured.result),
+        oracle,
+        max_diff=max_diff,
+        rtol=rtol,
+        atol=atol,
+    )
+
+
+def validate_capture(
+    captured: CapturedImplementation,
+    oracle: Sequence[torch.Tensor],
+) -> dict[str, Any]:
+    rewritten = poison_and_replay(captured)
+    repeatable = replay_is_repeatable(captured)
+    correctness = check_correctness(captured, oracle)
+    return {
+        **correctness,
+        "poisoned_replay_rewrote_output": rewritten,
+        "repeat_replay_exact": repeatable,
+        "ok": rewritten and repeatable and bool(correctness["ok"]),
+    }
+
+
+def file_sha256(path: Path) -> str:
+    """Return the SHA256 digest of one required provider artifact."""
+
+    digest = sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def distribution_file(
+    name: str,
+    distribution: importlib.metadata.Distribution,
+    relative_path: Path,
+) -> Path:
+    """Resolve one unique regular file owned by a distribution."""
+
+    matches = [
+        Path(str(distribution.locate_file(path))).resolve(strict=True)
+        for path in distribution.files or ()
+        if Path(str(path)) == relative_path
+    ]
+    if len(matches) != 1 or not matches[0].is_file():
+        raise RuntimeError(f"{name} must contain exactly one {relative_path}")
+    return matches[0]
+
+
+def validate_module_source(
+    module: object,
+    root: Path,
+    label: str,
+) -> None:
+    """Require a Python module to come from ``root``."""
+
+    module_file = getattr(module, "__file__", None)
+    if module_file is None:
+        raise RuntimeError(f"{label} has no source origin")
+    origin = Path(module_file).resolve(strict=True)
+    root = root.resolve(strict=True)
+    if not origin.is_relative_to(root):
+        raise RuntimeError(f"{label} was imported outside {root}: {origin}")
+
+
+def require_pinned_distribution(
+    name: str,
+    expected_version: str,
+) -> importlib.metadata.Distribution:
+    """Return an installed distribution only when its version is exact."""
+
+    return require_pinned_distributions({name: expected_version}, "")[name]
+
+
+def require_pinned_distributions(
+    expected_versions: Mapping[str, str],
+    label: str,
+) -> dict[str, importlib.metadata.Distribution]:
+    """Require an exact set of package versions and report all mismatches."""
+
+    distributions = {}
+    problems = []
+    for name, expected_version in expected_versions.items():
+        try:
+            distribution = importlib.metadata.distribution(name)
+        except importlib.metadata.PackageNotFoundError:
+            problems.append(f"{name} is not installed")
+            continue
+        if distribution.version != expected_version:
+            problems.append(
+                f"{name} is {distribution.version}, expected {expected_version}"
+            )
+        distributions[name] = distribution
+    if problems:
+        prefix = f"{label}: " if label else ""
+        raise RuntimeError(prefix + "; ".join(problems))
+    return distributions
+
+
+def mapped_library_paths(name_prefix: str) -> tuple[Path, ...]:
+    """Return unique loaded shared libraries whose basename starts with a prefix."""
+
+    paths = {
+        path.resolve(strict=True)
+        for line in Path("/proc/self/maps").read_text().splitlines()
+        if (path := Path(line.rsplit(maxsplit=1)[-1])).is_absolute()
+        and path.name.startswith(name_prefix)
+    }
+    return tuple(sorted(paths))
+
+
+def require_single_visible_device(value: str | None = None) -> str:
+    """Require one explicit ``CUDA_VISIBLE_DEVICES`` entry."""
+
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES") if value is None else value
+    if visible is None:
+        raise RuntimeError("CUDA_VISIBLE_DEVICES must select exactly one GPU")
+    entries = tuple(item.strip() for item in visible.split(",") if item.strip())
+    if len(entries) != 1:
+        raise RuntimeError(
+            f"CUDA_VISIBLE_DEVICES must contain exactly one entry, got {visible!r}"
+        )
+    return entries[0]
+
+
+def is_supported_grouped_gemm_device(
+    device_kind: object,
+    name: object,
+    capability: object,
+) -> bool:
+    """Return whether identity matches a validated grouped-GEMM target."""
+
+    return (
+        device_kind == "cuda"
+        and isinstance(name, str)
+        and isinstance(capability, list | tuple)
+        and tuple(capability) == SUPPORTED_DEVICE_CAPABILITIES.get(name)
+    )
+
+
+def clean_checkout(root: Path, expected_commit: str, label: str) -> str:
+    """Require a provider checkout at its expected clean commit."""
+
+    root = root.expanduser().resolve(strict=True)
+    head = subprocess.check_output(
+        ("git", "-C", str(root), "rev-parse", "HEAD"), text=True
+    ).strip()
+    status = subprocess.check_output(
+        (
+            "git",
+            "-C",
+            str(root),
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ),
+        text=True,
+    ).strip()
+    if head != expected_commit:
+        raise RuntimeError(f"{label} HEAD is {head}, expected {expected_commit}")
+    if status:
+        raise RuntimeError(f"{label} checkout must be clean")
+    return head
+
+
+def write_result(path: Path, result: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(result, allow_nan=False, indent=2, sort_keys=True) + "\n"
+    )

--- a/benchmarks/cute/grouped_gemm_deepgemm_support.py
+++ b/benchmarks/cute/grouped_gemm_deepgemm_support.py
@@ -1,0 +1,234 @@
+"""Small, reproducible helpers for the grouped-GEMM DeepGEMM comparison."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.machinery
+import os
+from pathlib import Path
+import sys
+from typing import Any
+from typing import Protocol
+from typing import cast
+
+from benchmarks.cute import grouped_gemm_benchmark as common
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_COMMIT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_CUTLASS_COMMIT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_FMT_COMMIT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_M_ALIGNMENT as M_ALIGNMENT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_VERSION
+import torch
+
+_ALLOWED_DEEPGEMM_ENVIRONMENT = frozenset({"DG_JIT_CACHE_DIR"})
+
+
+class _DeepGemmRuntime(Protocol):
+    def set_num_sms(self, value: int) -> None: ...
+
+    def get_num_sms(self) -> int: ...
+
+    def set_tc_util(self, value: int) -> None: ...
+
+    def get_tc_util(self) -> int: ...
+
+    def set_pdl(self, value: bool) -> None: ...
+
+    def get_pdl(self) -> bool: ...
+
+    def set_ignore_compile_dims(self, value: bool) -> None: ...
+
+    def set_block_size_multiple_of(self, value: int) -> None: ...
+
+
+def _native_extension(root: Path) -> Path:
+    extensions = sorted((root / "deep_gemm").glob("_C*.so"))
+    if len(extensions) != 1:
+        raise RuntimeError(
+            "DeepGEMM requires exactly one native _C*.so artifact; "
+            f"found {len(extensions)}"
+        )
+    extension_link = extensions[0]
+    extension = extension_link.resolve(strict=True)
+    if not extension.is_file() or not extension.is_relative_to(root.resolve()):
+        raise RuntimeError(
+            "DeepGEMM native extension must resolve to a regular file within "
+            "the checkout"
+        )
+    suffixes = [
+        suffix
+        for suffix in importlib.machinery.EXTENSION_SUFFIXES
+        if extension_link.name == f"_C{suffix}"
+    ]
+    if len(suffixes) != 1:
+        raise RuntimeError(
+            "DeepGEMM native extension does not match the active Python ABI"
+        )
+    return extension
+
+
+def _reset_public_runtime(module: _DeepGemmRuntime) -> dict[str, object]:
+    """Reset process-global DeepGEMM controls to the upstream public defaults."""
+
+    requested = {
+        "num_sms": 0,
+        "tc_util": 100,
+        "pdl": False,
+        "ignore_compile_dims": False,
+        "block_size_multiple_of": 1,
+    }
+    module.set_num_sms(0)
+    module.set_tc_util(100)
+    module.set_pdl(False)
+    module.set_ignore_compile_dims(False)
+    module.set_block_size_multiple_of(1)
+    observed: dict[str, object] = {
+        "num_sms": int(module.get_num_sms()),
+        "tc_util": int(module.get_tc_util()),
+        "pdl": bool(module.get_pdl()),
+    }
+    if observed["tc_util"] != 100 or observed["pdl"] is not False:
+        raise RuntimeError(f"DeepGEMM runtime controls did not reset: {observed}")
+    return {"requested": requested, "observed": observed}
+
+
+def import_deepgemm(root: Path, m_alignment: int) -> tuple[Any, dict[str, object]]:
+    """Import the pinned public DeepGEMM API and record its native artifact."""
+    unexpected_environment = sorted(
+        name
+        for name in os.environ
+        if name.startswith("DG_") and name not in _ALLOWED_DEEPGEMM_ENVIRONMENT
+    )
+    if unexpected_environment:
+        raise RuntimeError(
+            f"DeepGEMM control environment must be unset: {unexpected_environment}"
+        )
+    root = root.expanduser().resolve(strict=True)
+    source = {
+        "git_head": common.clean_checkout(root, DEEPGEMM_COMMIT, "DeepGEMM"),
+        "cutlass_head": common.clean_checkout(
+            root / "third-party" / "cutlass",
+            DEEPGEMM_CUTLASS_COMMIT,
+            "DeepGEMM CUTLASS",
+        ),
+        "fmt_head": common.clean_checkout(
+            root / "third-party" / "fmt",
+            DEEPGEMM_FMT_COMMIT,
+            "DeepGEMM fmt",
+        ),
+    }
+    extension = _native_extension(root)
+    extension_sha256 = common.file_sha256(extension)
+    original_path = list(sys.path)
+    sys.path.insert(0, str(root))
+    try:
+        module = importlib.import_module("deep_gemm")
+    finally:
+        sys.path[:] = original_path
+    module_file = module.__file__
+    native_file = module._C.__file__
+    if module_file is None or native_file is None:
+        raise RuntimeError("DeepGEMM module has no import origin")
+    module_origin = Path(module_file).resolve()
+    native_origin = Path(native_file).resolve()
+    if not module_origin.is_relative_to(root) or native_origin != extension:
+        raise RuntimeError("DeepGEMM imported outside the validated checkout")
+    if str(module.__version__) != DEEPGEMM_VERSION:
+        raise RuntimeError(
+            f"DeepGEMM version is {module.__version__}, expected {DEEPGEMM_VERSION}"
+        )
+    theoretical_alignment = int(
+        module.get_theoretical_mk_alignment_for_contiguous_layout()
+    )
+    if theoretical_alignment != m_alignment:
+        raise RuntimeError(
+            "DeepGEMM theoretical contiguous alignment is "
+            f"{theoretical_alignment}, expected {m_alignment}"
+        )
+    module.set_mk_alignment_for_contiguous_layout(m_alignment)
+    effective = int(module.get_mk_alignment_for_contiguous_layout())
+    if effective != m_alignment:
+        raise RuntimeError(f"DeepGEMM alignment is {effective}, expected {m_alignment}")
+    runtime = _reset_public_runtime(cast("_DeepGemmRuntime", module))
+    if (
+        _native_extension(root) != extension
+        or common.file_sha256(extension) != extension_sha256
+    ):
+        raise RuntimeError("DeepGEMM native extension changed while importing")
+    return module, {
+        **source,
+        "version": str(module.__version__),
+        "native_extension_sha256": extension_sha256,
+        "python_version": sys.version.split()[0],
+        "torch_version": torch.__version__,
+        "torch_cuda_version": torch.version.cuda,
+        "m_alignment": effective,
+        "theoretical_m_alignment": theoretical_alignment,
+        "runtime_controls": runtime,
+        "environment_controls": dict.fromkeys(
+            sorted(_ALLOWED_DEEPGEMM_ENVIRONMENT & os.environ.keys()), True
+        ),
+    }
+
+
+def prepare_deepgemm_default(
+    inputs: common.GroupedGemmInputs,
+    *,
+    deepgemm_root: Path,
+) -> common.PreparedImplementation:
+    """Prepare DeepGEMM's pinned public contiguous grouped API."""
+
+    deep_gemm, provenance = import_deepgemm(deepgemm_root, M_ALIGNMENT)
+    packed = common.pack_compact_rows(inputs, M_ALIGNMENT)
+    layout = torch.full(
+        (packed.a.size(0),),
+        -1,
+        device=packed.a.device,
+        dtype=torch.int32,
+    )
+    for group, (start, actual_m) in enumerate(
+        zip(packed.starts, packed.actual_ms, strict=True)
+    ):
+        layout[start : start + actual_m] = group
+    output = torch.empty(
+        (packed.a.size(0), inputs.case.n),
+        device=packed.a.device,
+        dtype=packed.a.dtype,
+    )
+
+    def call() -> torch.Tensor:
+        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
+            packed.a,
+            inputs.b,
+            output,
+            layout,
+            compiled_dims="nk",
+            use_psum_layout=False,
+            ensure_zero_padding=False,
+        )
+        return output
+
+    return common.PreparedImplementation(
+        name="deepgemm-public-default",
+        call=call,
+        output_tensors=lambda result: (cast("torch.Tensor", result),),
+        logical_outputs=lambda result: packed.output_slices(
+            cast("torch.Tensor", result)
+        ),
+        config=common.provider_config(
+            "deepgemm",
+            {
+                "api": {
+                    "function": "m_grouped_bf16_gemm_nt_contiguous",
+                    "compiled_dims": "nk",
+                    "use_psum_layout": False,
+                    "ensure_zero_padding": False,
+                },
+                "a_layout": {
+                    "kind": "aligned_contiguous_layout",
+                    "alignment": M_ALIGNMENT,
+                    "logical_values_bitwise_equal": True,
+                },
+                "provenance": provenance,
+            },
+        ),
+    )

--- a/benchmarks/cute/grouped_gemm_provider_campaign.py
+++ b/benchmarks/cute/grouped_gemm_provider_campaign.py
@@ -1,0 +1,1991 @@
+"""Compare Helion grouped GEMM with reproducible public provider baselines.
+
+The public command launches one fresh worker process per provider/replicate.
+Each worker validates and captures both implementations, performs a 10-second
+thermal warmup, and records 102 cold-L2 paired samples with balanced ordering.
+Compilation, packing, provider selection, and Helion selection stay outside
+the timed region.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from contextlib import suppress
+from dataclasses import dataclass
+import importlib.metadata
+import json
+import math
+from operator import itemgetter
+import os
+from pathlib import Path
+import re
+import signal
+import statistics
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+from benchmarks.cute import cublaslt_grouped_gemm as cublaslt
+from benchmarks.cute import cudnn_grouped_gemm as cudnn
+from benchmarks.cute import cutlass_contiguous_grouped_gemm as cutlass
+from benchmarks.cute import grouped_gemm_benchmark as common
+from benchmarks.cute import quack_grouped_gemm as quack
+from benchmarks.cute.grouped_gemm_workloads import BENCHMARK_B_LAYOUT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_COMMIT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_CUTLASS_COMMIT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_FMT_COMMIT
+from benchmarks.cute.grouped_gemm_workloads import DEEPGEMM_VERSION
+from benchmarks.cute.grouped_gemm_workloads import PROVIDER_CLI_MODES
+from benchmarks.cute.grouped_gemm_workloads import PROVIDER_DEFAULTS_MODE
+from benchmarks.cute.grouped_gemm_workloads import PROVIDER_DEFAULTS_PLAN_MODE
+from benchmarks.cute.grouped_gemm_workloads import PROVIDER_DEFAULTS_WORKER_MODE
+from benchmarks.cute.grouped_gemm_workloads import PROVIDER_SELECTION_MODES
+import torch
+
+hl: Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmCase
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+
+    from helion.runtime.kernel import Kernel
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RESULT_SCHEMA = "helion-grouped-gemm-provider-defaults-v10"
+SUMMARY_SCHEMA = "helion-grouped-gemm-provider-summary-v15"
+BENCHMARK_REPETITIONS = 102
+PUBLICATION_REPLICATES = 3
+THERMAL_WARMUP_MS = 10_000
+CAPTURE_WARMUPS = 2
+TELEMETRY_INTERVAL_SECONDS = 5
+COMPUTE_APPLICATION_INTERVAL_SECONDS = 1
+POST_WORKER_IDLE_GRACE_SECONDS = 5
+NVCC_RELEASE_PATTERN = re.compile(r"\brelease\s+(\d+\.\d+),\s+V([0-9.]+)")
+PROVIDERS = ("deepgemm", "quack", "cudnn", "cublaslt", "cutlass")
+SOURCE_BACKED_PROVIDERS = ("deepgemm", "quack", "cutlass")
+QUACK_SELECTION_FIELDS = frozenset(
+    {
+        "selected_config",
+        "resolved_dynamic_scheduler",
+        "resolved_split_k",
+        "dispatch_plan",
+    }
+)
+CUTLASS_SELECTION_MEASUREMENT_FIELDS = frozenset({"selection_median_ms"})
+_MISSING = object()
+
+
+def _provider_requirements(provider: str) -> dict[str, object]:
+    if provider == "deepgemm":
+        return {
+            "api": {
+                "function": "m_grouped_bf16_gemm_nt_contiguous",
+                "compiled_dims": "nk",
+                "use_psum_layout": False,
+                "ensure_zero_padding": False,
+            },
+            "provenance.git_head": DEEPGEMM_COMMIT,
+            "provenance.cutlass_head": DEEPGEMM_CUTLASS_COMMIT,
+            "provenance.fmt_head": DEEPGEMM_FMT_COMMIT,
+            "provenance.version": DEEPGEMM_VERSION,
+            "provenance.native_extension_sha256": str,
+        }
+    if provider == "quack":
+        return {
+            "benchmark_label": quack.QUACK_BENCHMARK_LABEL,
+            "selection_api": "gemm(default tuned=True)",
+            "requested_config": None,
+            "requested_dynamic_scheduler": False,
+            "tuned": True,
+            "resolved_split_k": 1,
+            "selected_config.b_layout": BENCHMARK_B_LAYOUT,
+            "dispatch_plan.type": "quack.gemm._GemmPlan",
+            "package.source_provenance": {
+                "kind": "upstream_main_snapshot",
+                "repository": quack.QUACK_REPOSITORY,
+                "commit": quack.QUACK_COMMIT,
+                "base_release_tag": quack.QUACK_BASE_RELEASE_TAG,
+                "is_formal_release": False,
+                "benchmark_label": quack.QUACK_BENCHMARK_LABEL,
+            },
+            "package.upstream_commit": quack.QUACK_COMMIT,
+            "package.distribution_version": quack.QUACK_PACKAGE_METADATA_VERSION,
+            "package.dependency_versions": quack.QUACK_DEPENDENCY_VERSIONS,
+            "package.module_version": quack.QUACK_PACKAGE_METADATA_VERSION,
+            "package.installation": str,
+        }
+    if provider == "cudnn":
+        return {
+            "baseline": cudnn.CUDNN_GROUPED_BASELINE,
+            "frontend_version": cudnn.CUDNN_FRONTEND_VERSION,
+            "backend_version": cudnn.CUDNN_BACKEND_VERSION,
+            "runtime.frontend": {
+                "distribution": cudnn.CUDNN_FRONTEND_DISTRIBUTION,
+                "package_version": cudnn.CUDNN_FRONTEND_VERSION,
+            },
+            "runtime.requested_cuda_runtime": {
+                "distribution": common.CUDA_RUNTIME_DISTRIBUTION,
+                "package_version": common.CUDA_RUNTIME_VERSION,
+            },
+            "plan.selection": "graph_build_default",
+        }
+    if provider == "cublaslt":
+        return {
+            "library": {
+                "distribution": cublaslt.CUBLASLT_DISTRIBUTION,
+                "package_version": cublaslt.CUBLASLT_DISTRIBUTION_VERSION,
+                "library_version": cublaslt.CUBLASLT_LIBRARY_VERSION,
+            },
+            "heuristic_query_capacity": cublaslt.CUBLASLT_HEURISTIC_QUERY_CAPACITY,
+            "group_count": int,
+            "grouped_average_preferences": dict,
+            "selected_algorithm.serialized_hex": str,
+            "selected_algorithm.heuristic_rank": 0,
+        }
+    if provider == "cutlass":
+        return {
+            "repository": cutlass.CUTLASS_REPOSITORY,
+            "release_tag": cutlass.CUTLASS_RELEASE_TAG,
+            "commit": cutlass.CUTLASS_COMMIT,
+            "operator_api_version": cutlass.CUTLASS_OPERATOR_API_VERSION,
+            "target_sm": str,
+            "registry_tuning": dict,
+        }
+    return {}
+
+
+def publication_runs() -> tuple[tuple[str, int], ...]:
+    """Return the fixed execution order shared by the plan and controller."""
+
+    return tuple(
+        (provider, replicate)
+        for replicate in range(PUBLICATION_REPLICATES)
+        for provider in PROVIDERS
+    )
+
+
+def _quack_provenance(config: dict[str, Any]) -> dict[str, object]:
+    """Return provider identity excluding QuACK's fresh autotune selection."""
+
+    missing = QUACK_SELECTION_FIELDS - config.keys()
+    if missing:
+        raise RuntimeError(
+            f"QuACK configuration is missing selection fields: {sorted(missing)}"
+        )
+    return {
+        key: value for key, value in config.items() if key not in QUACK_SELECTION_FIELDS
+    }
+
+
+def _cutlass_provenance(config: dict[str, Any]) -> dict[str, object]:
+    """Return CUTLASS selection identity without replicate measurements."""
+
+    tuning = config.get("registry_tuning")
+    if not isinstance(tuning, dict) or not isinstance(tuning.get("candidates"), list):
+        raise RuntimeError("CUTLASS configuration is missing registry tuning evidence")
+    candidates = []
+    for candidate in tuning["candidates"]:
+        if not isinstance(candidate, dict):
+            raise RuntimeError("CUTLASS registry candidate evidence is invalid")
+        candidates.append(
+            {
+                key: value
+                for key, value in candidate.items()
+                if key not in CUTLASS_SELECTION_MEASUREMENT_FIELDS
+            }
+        )
+    stable_tuning = {**tuning, "candidates": candidates}
+    return {**config, "registry_tuning": stable_tuning}
+
+
+def _all_equal(values: Sequence[object]) -> bool:
+    return bool(values) and all(value == values[0] for value in values[1:])
+
+
+def _nested_value(value: dict[str, Any], path: str) -> object:
+    current: object = value
+    for field in path.split("."):
+        if not isinstance(current, dict) or field not in current:
+            return _MISSING
+        current = current[field]
+    return current
+
+
+def _matches_requirement(value: object, required: object) -> bool:
+    if isinstance(required, type):
+        return type(value) is required and (required is not str or bool(value))
+    if isinstance(required, dict):
+        return (
+            isinstance(value, dict)
+            and value.keys() == required.keys()
+            and all(
+                _matches_requirement(value[key], item) for key, item in required.items()
+            )
+        )
+    return type(value) is type(required) and value == required
+
+
+def _valid_provider_contract(
+    value: object,
+    provider: str,
+    *,
+    expected_case: dict[str, Any] | None = None,
+    device: dict[str, Any] | None = None,
+    complete: bool = False,
+) -> bool:
+    requirements = _provider_requirements(provider)
+    if not isinstance(value, dict) or not requirements:
+        return False
+    if not all(
+        type(actual := value.get(key)) is type(required) and actual == required
+        for key, required in common.provider_config(provider, {}).items()
+    ) or not all(
+        _matches_requirement(_nested_value(value, path), required)
+        for path, required in requirements.items()
+    ):
+        return False
+    if provider == "deepgemm":
+        return (
+            re.fullmatch(
+                r"[0-9a-f]{64}", value["provenance"]["native_extension_sha256"]
+            )
+            is not None
+        )
+    if provider == "quack":
+        return value["package"]["installation"] in {
+            "editable",
+            "installed_distribution_with_source_override",
+        }
+    if provider == "cudnn":
+        runtime = value["runtime"]
+        if not complete:
+            return True
+        return (
+            runtime.get("backend_libraries")
+            == {
+                "distribution": cudnn.CUDNN_BACKEND_DISTRIBUTION,
+                "package_version": cudnn.CUDNN_BACKEND_DISTRIBUTION_VERSION,
+            }
+            and runtime.get("loaded_cuda_runtime") == runtime["requested_cuda_runtime"]
+        )
+    if provider == "cublaslt":
+        valid = value["group_count"] > 0
+        if not valid or expected_case is None:
+            return valid
+        problems = tuple(
+            (m, expected_case["n"], expected_case["k"], 1)
+            for m in expected_case["actual_ms"]
+        )
+        return value["group_count"] == expected_case["groups"] and value[
+            "grouped_average_preferences"
+        ] == cublaslt.cublaslt_grouped_preference_values(problems)
+    target_sm = value["target_sm"]
+    return (
+        isinstance(target_sm, str)
+        and target_sm in cutlass.CUTLASS_TARGET_SMS.values()
+        and (
+            device is None
+            or target_sm == cutlass.CUTLASS_TARGET_SMS.get(tuple(device["capability"]))
+        )
+        and _valid_cutlass_tuning_evidence(value)
+    )
+
+
+@dataclass(frozen=True)
+class _ComputeApplication:
+    pid: int
+    process_name: str
+
+
+HELION_SELECTION = "compiler_heuristic"
+GROUPED_WORKLIST_HEURISTIC = "cute_tcgen05_grouped_worklist"
+SOURCE_M_TILE = 256
+BLOCK_M = 256
+BLOCK_N = 128
+BLOCK_K_CHOICES = (64, 128)
+BENCHMARK_LAYOUT_POLICY = f"canonical_{BENCHMARK_B_LAYOUT}_for_all_implementations"
+_COMMON_PROTOCOL = {
+    "capture_warmups": CAPTURE_WARMUPS,
+    "thermal_warmup_ms": THERMAL_WARMUP_MS,
+    "paired_cold_l2_samples": BENCHMARK_REPETITIONS,
+    "fresh_process_and_caches_per_provider_replicate": True,
+    "balanced_rotated_reversed_order": True,
+    "correctness_rtol": common.CORRECTNESS_RTOL,
+    "correctness_atol": common.CORRECTNESS_ATOL,
+    "max_normalized_diff": common.CORRECTNESS_MAX_NORMALIZED_DIFF,
+    "poison_replay_rewrite_check": True,
+    "exact_repeat_replay_check": True,
+    "helion_padding_zero_check": True,
+}
+HELION_SELECTION_ENVIRONMENT_VARIABLES = (
+    "HELION_AUTOTUNE_EFFORT",
+    "HELION_BACKEND",
+    "HELION_CUTE_MMA_IMPL",
+)
+HELION_SELECTION_STARTUP_ENVIRONMENT = {
+    name: os.environ.get(name) for name in HELION_SELECTION_ENVIRONMENT_VARIABLES
+}
+WORKER_CACHE_NAMES = {
+    "CUDA_CACHE_PATH": "cuda",
+    "CUTE_DSL_CACHE_DIR": "cute_dsl",
+    "DG_JIT_CACHE_DIR": "deepgemm_jit",
+    "HELION_CACHE_DIR": "helion",
+    "QUACK_CACHE_DIR": "quack",
+    "TORCHINDUCTOR_CACHE_DIR": "torchinductor",
+    "TORCH_EXTENSIONS_DIR": "torch_extensions",
+    "TRITON_CACHE_DIR": "triton",
+    "XDG_CACHE_HOME": "xdg",
+}
+WORKER_CONTROL_PREFIXES = (
+    "CUBLAS_",
+    "CUDA_",
+    "CUDNN_",
+    "CUTE_DSL_",
+    "CUTLASS_",
+    "DG_",
+    "HELION_",
+    "LD_",
+    "NVIDIA_",
+    "QUACK_",
+    "PYTORCH_",
+    "TORCH_",
+    "TORCHINDUCTOR_",
+    "TRITON_",
+)
+COMPILER_AND_LOADER_CONTROLS = frozenset(
+    {
+        "CC",
+        "CFLAGS",
+        "CMAKE_CUDA_COMPILER",
+        "CMAKE_CXX_COMPILER",
+        "CMAKE_C_COMPILER",
+        "CMAKE_INCLUDE_PATH",
+        "CMAKE_LIBRARY_PATH",
+        "CMAKE_PREFIX_PATH",
+        "CMAKE_TOOLCHAIN_FILE",
+        "COMPILER_PATH",
+        "CPATH",
+        "CPPFLAGS",
+        "CPLUS_INCLUDE_PATH",
+        "CUDACXX",
+        "CUDNN_FRONTEND_CUDART_LIB_NAME",
+        "CUDAFLAGS",
+        "CUDAHOSTCXX",
+        "CXX",
+        "CXXFLAGS",
+        "C_INCLUDE_PATH",
+        "GCC_EXEC_PREFIX",
+        "GLIBC_TUNABLES",
+        "LDFLAGS",
+        "LIBRARY_PATH",
+        "NVCC",
+        "NVCC_APPEND_FLAGS",
+        "NVCC_CCBIN",
+        "NVCC_PREPEND_FLAGS",
+        "OBJC_INCLUDE_PATH",
+        "PKG_CONFIG_LIBDIR",
+        "PKG_CONFIG_PATH",
+        "PKG_CONFIG_SYSROOT_DIR",
+        "SDKROOT",
+        "TORCH_CUDA_ARCH_LIST",
+    }
+)
+TELEMETRY_FIELDS = (
+    "uuid",
+    "pstate",
+    "clocks.sm",
+    "clocks.mem",
+    "power.draw",
+    "power.limit",
+    "clocks_event_reasons.active",
+)
+WORKER_TERMINATION_GRACE_SECONDS = 5
+NVIDIA_SMI_TIMEOUT_SECONDS = 10
+GPU_IDLE_CLOCK_EVENT_REASON = 0x1
+SW_POWER_CAP_CLOCK_EVENT_REASON = 0x4
+ALLOWED_CLOCK_EVENT_REASONS = (
+    GPU_IDLE_CLOCK_EVENT_REASON | SW_POWER_CAP_CLOCK_EVENT_REASON
+)
+
+
+class _CampaignInterrupted(Exception):
+    def __init__(self, signum: int) -> None:
+        super().__init__(signum)
+        self.signum = signum
+
+
+@dataclass(frozen=True)
+class _TelemetrySample:
+    pstate: str
+    sm_clock_mhz: float
+    memory_clock_mhz: float
+    power_draw_watts: float
+    power_limit_watts: float
+    active_clock_event_reasons: int
+
+
+def _make_helion_kernel() -> Kernel[torch.Tensor]:
+    """Create the benchmark kernel through the ordinary compiler path."""
+
+    global hl
+
+    import helion
+    import helion.language as hl
+
+    @helion.kernel(backend="cute", static_shapes=True, autotune_effort="none")
+    def grouped_gemm(
+        a_packed: torch.Tensor,
+        b_grouped: torch.Tensor,
+        worklist: torch.Tensor,
+    ) -> torch.Tensor:
+        m_total, k = a_packed.shape
+        _groups, n, k2 = b_grouped.shape
+        assert k == k2
+        assert worklist.size(1) == 4
+        block_m = hl.register_block_size(BLOCK_M)
+        block_n = hl.register_block_size(BLOCK_N)
+        block_k = hl.register_block_size(*BLOCK_K_CHOICES)
+        out = torch.empty(
+            (m_total, n),
+            dtype=a_packed.dtype,
+            device=a_packed.device,
+        )
+        for work_tile, tile_m, tile_n in hl.tile(
+            [worklist.size(0), BLOCK_M, n],
+            block_size=[1, block_m, block_n],
+        ):
+            work_id = work_tile.begin
+            group_id = worklist[work_id, 0]
+            global_m_start = worklist[work_id, 1]
+            valid_m = worklist[work_id, 2]
+            store_m = worklist[work_id, 3]
+            local_m = tile_m.index
+            row_index = global_m_start + local_m
+            valid_rows = local_m < valid_m
+            store_rows = local_m < store_m
+            acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+            for tile_k in hl.tile(k, block_size=block_k):
+                a_block = hl.load(
+                    a_packed,
+                    [row_index, tile_k],
+                    extra_mask=valid_rows[:, None],  # pyrefly: ignore[bad-index]
+                )
+                acc = torch.addmm(
+                    acc,
+                    a_block,
+                    b_grouped[group_id, tile_n, tile_k].T,
+                )
+            hl.store(
+                out,
+                [row_index, tile_n],
+                acc.to(out.dtype),
+                extra_mask=store_rows[:, None],  # pyrefly: ignore[bad-index]
+            )
+        return out
+
+    return grouped_gemm
+
+
+def prepare_helion(
+    inputs: GroupedGemmInputs,
+) -> PreparedImplementation:
+    """Bind Helion and select its ordinary compiler default."""
+
+    packed = common.pack_compact_rows(inputs, SOURCE_M_TILE)
+    b = inputs.b
+    kernel_args = (
+        packed.a,
+        b,
+        packed.worklist,
+    )
+    kernel = _make_helion_kernel()
+    bound = kernel.bind(kernel_args)
+    config_spec = bound.config_spec
+    compiler_default = config_spec.compiler_default_config
+    if compiler_default is None:
+        raise RuntimeError(
+            "grouped GEMM compiler heuristics produced no primary config"
+        )
+    compiler_default_config = compiler_default.config
+    if (
+        compiler_default_config.get("tcgen05_grouped_mode") != "worklist_nm"
+        or compiler_default_config.get("tcgen05_grouped_worklist_source_m_tile")
+        != SOURCE_M_TILE
+    ):
+        raise RuntimeError("compiler primary config is not grouped-worklist NM")
+    if config_spec.autotuner_heuristics.count(GROUPED_WORKLIST_HEURISTIC) != 1:
+        raise RuntimeError(
+            "grouped-worklist compiler heuristic did not fire exactly once"
+        )
+    selected_config = config_spec.default_config()
+    selected_effective = dict(selected_config.config)
+    if any(
+        key not in selected_effective or selected_effective[key] != value
+        for key, value in compiler_default_config.items()
+    ):
+        raise RuntimeError("effective config is not the grouped-worklist default")
+    bound.set_config(selected_config)
+    selection_evidence = {
+        "selection_mode": HELION_SELECTION,
+        "autotuned": False,
+        "b_layout": BENCHMARK_B_LAYOUT,
+        "selection_api": "BoundKernel.set_config(ConfigSpec.default_config())",
+        "config": selected_effective,
+        "a_layout": {
+            "kind": "aligned_contiguous_worklist",
+            "alignment": SOURCE_M_TILE,
+            "logical_values_bitwise_equal": True,
+        },
+    }
+    torch.cuda.synchronize()
+
+    def output_tensors(result: object) -> tuple[torch.Tensor, ...]:
+        if not isinstance(result, torch.Tensor):
+            raise TypeError("Helion grouped GEMM returned a non-tensor")
+        return (result,)
+
+    def logical_outputs(result: object) -> tuple[torch.Tensor, ...]:
+        if not isinstance(result, torch.Tensor):
+            raise TypeError("Helion grouped GEMM returned a non-tensor")
+        if not packed.output_padding_is_zero(result):
+            raise RuntimeError("Helion did not zero aligned output padding")
+        return packed.output_slices(result)
+
+    def call() -> torch.Tensor:
+        return bound(*kernel_args)
+
+    return common.PreparedImplementation(
+        name=f"helion-compiler-heuristic-{inputs.case.id}",
+        call=call,
+        output_tensors=output_tensors,
+        logical_outputs=logical_outputs,
+        config=selection_evidence,
+        track_cute_graph=True,
+    )
+
+
+def prepare_provider_default(
+    provider: str,
+    inputs: GroupedGemmInputs,
+    *,
+    cutlass_root: Path | None,
+    deepgemm_root: Path | None,
+    quack_root: Path | None = None,
+) -> PreparedImplementation:
+    """Prepare one documented provider comparison implementation."""
+
+    if provider == "deepgemm":
+        from benchmarks.cute.grouped_gemm_deepgemm_support import (
+            prepare_deepgemm_default,
+        )
+
+        if deepgemm_root is None:
+            raise ValueError(
+                "--provider-deepgemm-root is required for the DeepGEMM provider"
+            )
+        prepared = prepare_deepgemm_default(
+            inputs,
+            deepgemm_root=deepgemm_root,
+        )
+    elif provider == "cutlass":
+        from benchmarks.cute.cutlass_contiguous_grouped_gemm import (
+            prepare_cutlass_default,
+        )
+
+        if cutlass_root is None:
+            raise ValueError(
+                "--provider-cutlass-root is required for the CUTLASS provider"
+            )
+        prepared = prepare_cutlass_default(inputs, cutlass_root=cutlass_root)
+    elif provider == "quack":
+        from benchmarks.cute.quack_grouped_gemm import prepare_quack_default
+
+        prepared = prepare_quack_default(
+            inputs,
+            quack_root=quack_root,
+        )
+    elif provider == "cudnn":
+        from benchmarks.cute.cudnn_grouped_gemm import prepare_cudnn_default
+
+        prepared = prepare_cudnn_default(inputs)
+    elif provider == "cublaslt":
+        from benchmarks.cute.cublaslt_grouped_gemm import prepare_cublaslt_default
+
+        prepared = prepare_cublaslt_default(inputs)
+    else:
+        raise ValueError(f"unsupported provider {provider!r}")
+    if not _valid_provider_contract(prepared.config, provider):
+        raise RuntimeError(f"{provider} produced an invalid selection contract")
+    return prepared
+
+
+def _validated_capture(
+    prepared: PreparedImplementation,
+    oracle: Sequence[torch.Tensor],
+) -> tuple[common.CapturedImplementation, dict[str, Any]]:
+    captured = common.capture_implementation(prepared, warmups=CAPTURE_WARMUPS)
+    correctness = common.validate_capture(captured, oracle)
+    if not correctness["ok"]:
+        raise RuntimeError(f"{prepared.name} failed correctness: {correctness}")
+    return captured, correctness
+
+
+def run_case(
+    provider: str,
+    case: GroupedGemmCase,
+    device: torch.device,
+    *,
+    cutlass_root: Path | None,
+    deepgemm_root: Path | None,
+    quack_root: Path | None = None,
+) -> dict[str, object]:
+    """Validate and time one selected Helion/provider-default pair."""
+
+    from pretuned_kernels import _bench
+
+    inputs = common.make_inputs(case, device, seed=case.row_index)
+    # Provider imports, compilation, graph capture, and timing must not perturb
+    # the deterministic per-row input streams.
+    with torch.random.fork_rng(devices=[device.index]):
+        helion = prepare_helion(inputs)
+        provider_impl = prepare_provider_default(
+            provider,
+            inputs,
+            cutlass_root=cutlass_root,
+            deepgemm_root=deepgemm_root,
+            quack_root=quack_root,
+        )
+        helion_capture, helion_correctness = _validated_capture(helion, inputs.oracle)
+        provider_capture, provider_correctness = _validated_capture(
+            provider_impl,
+            inputs.oracle,
+        )
+    _bench.thermal_warmup(THERMAL_WARMUP_MS)
+    with torch.random.fork_rng(devices=[device.index]):
+        helion_ms, provider_ms = _bench.bench_pre_captured_cudagraphs(
+            [helion_capture.replay, provider_capture.replay],
+            rep=BENCHMARK_REPETITIONS,
+        )
+    post_timing_checks = {
+        "helion": common.check_correctness(helion_capture, inputs.oracle),
+        "provider": common.check_correctness(provider_capture, inputs.oracle),
+    }
+    for implementation, check in post_timing_checks.items():
+        if not check["ok"]:
+            raise RuntimeError(
+                f"{implementation} output changed during benchmark timing: {check}"
+            )
+    helion_correctness["post_timing"] = post_timing_checks["helion"]
+    provider_correctness["post_timing"] = post_timing_checks["provider"]
+    if not all(
+        math.isfinite(value) and value > 0.0 for value in (helion_ms, provider_ms)
+    ):
+        raise RuntimeError("benchmark timings must be finite and positive")
+    return {
+        "case": case.as_dict(),
+        "configs": {
+            "helion": helion.config,
+            "provider": provider_impl.config,
+        },
+        "correctness": {
+            "helion": helion_correctness,
+            "provider": provider_correctness,
+        },
+        "timings": {
+            "helion_ms": helion_ms,
+            "provider_ms": provider_ms,
+        },
+    }
+
+
+def _nonnegative_int(text: str) -> int:
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative integer")
+    return value
+
+
+def _git_value(*arguments: str) -> str:
+    completed = subprocess.run(
+        ("git", "-C", str(REPO_ROOT), *arguments),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(f"git {' '.join(arguments)} failed: {detail}")
+    return completed.stdout.strip()
+
+
+def _source_identity() -> str:
+    if _git_value("status", "--porcelain=v1", "--untracked-files=all"):
+        raise RuntimeError("benchmark requires a clean Helion checkout")
+    return _git_value("rev-parse", "HEAD")
+
+
+def _device_info(device: torch.device) -> dict[str, object]:
+    properties = torch.cuda.get_device_properties(device)
+    capability = torch.cuda.get_device_capability(device)
+    if not common.is_supported_grouped_gemm_device(
+        device.type, properties.name, capability
+    ):
+        raise RuntimeError(
+            "grouped-GEMM defaults benchmark requires NVIDIA B200/SM100 or "
+            "NVIDIA GB300/SM103, got "
+            f"{properties.name!r} capability {capability}"
+        )
+    uuid = str(properties.uuid)
+    return {
+        "visible": common.require_single_visible_device(),
+        "name": properties.name,
+        "capability": list(capability),
+        "uuid": uuid if uuid.startswith("GPU-") else f"GPU-{uuid}",
+        "multi_processor_count": properties.multi_processor_count,
+        "total_memory": properties.total_memory,
+    }
+
+
+def _worker_cache_directories(run_dir: Path) -> dict[str, str]:
+    caches = {}
+    for variable, relative in WORKER_CACHE_NAMES.items():
+        path = run_dir / "cache" / relative
+        path.mkdir(parents=True)
+        caches[variable] = str(path)
+    return caches
+
+
+def _selection_environment() -> dict[str, str]:
+    return {
+        "HELION_AUTOTUNE_EFFORT": "none",
+        "HELION_BACKEND": "cute",
+        "HELION_CUTE_MMA_IMPL": "tcgen05",
+    }
+
+
+def _restore_provider_import_path(provider: str, quack_root: Path | None) -> None:
+    """Restore a validated source override removed by direct-script startup."""
+
+    if provider != "quack" or quack_root is None:
+        return
+    root = str(quack_root.resolve(strict=True))
+    if root not in sys.path:
+        sys.path.insert(1, root)
+
+
+def _run_worker(args: argparse.Namespace) -> int:
+    _restore_provider_import_path(args.provider, args.quack_root)
+    selection_environment = _selection_environment()
+    expected_selection_environment = {
+        key: selection_environment.get(key)
+        for key in HELION_SELECTION_ENVIRONMENT_VARIABLES
+    }
+    if expected_selection_environment != HELION_SELECTION_STARTUP_ENVIRONMENT:
+        raise RuntimeError("Helion selection environment was not set before startup")
+    if os.environ.get("HELION_HEURISTIC_DIR"):
+        raise RuntimeError(
+            "--provider-defaults-worker does not permit HELION_HEURISTIC_DIR"
+        )
+    run_dir = args.run_dir.expanduser().resolve()
+    if not run_dir.is_dir() or (run_dir / "result.json").exists():
+        raise RuntimeError(f"worker requires a fresh run directory: {run_dir}")
+
+    common.require_single_visible_device()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+    device_info = _device_info(device)
+    cuda_stack = _cuda_toolchain_identity()
+    common.configure_oracle_precision()
+
+    cases = common.official_cases()
+    if len(cases) != 8:
+        raise RuntimeError("benchmark requires exactly eight official cases")
+    rows = [
+        run_case(
+            args.provider,
+            case,
+            device,
+            cutlass_root=args.cutlass_root,
+            deepgemm_root=args.deepgemm_root,
+            quack_root=args.quack_root,
+        )
+        for case in cases
+    ]
+    _validate_mapped_cuda_libraries(_installed_cuda_stack()[1])
+    result = {
+        "schema": RESULT_SCHEMA,
+        "provider": args.provider,
+        "replicate": args.replicate,
+        "device": device_info,
+        "source": _source_identity(),
+        "versions": {
+            "python": sys.version.split()[0],
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "cutlass_dsl": importlib.metadata.version("nvidia-cutlass-dsl"),
+            "triton": importlib.metadata.version("triton"),
+            "cuda_driver": _cuda_driver_version(cast("str", device_info["uuid"])),
+            "cuda_stack": cuda_stack,
+        },
+        "rows": rows,
+    }
+    common.write_result(run_dir / "result.json", result)
+    return 0
+
+
+def _provider_roots(args: argparse.Namespace) -> dict[str, Path]:
+    roots = {
+        provider: cast("Path", vars(args)[f"{provider}_root"]).expanduser().resolve()
+        for provider in SOURCE_BACKED_PROVIDERS
+    }
+    missing = [
+        f"{provider}: {root}" for provider, root in roots.items() if not root.is_dir()
+    ]
+    if missing:
+        raise ValueError("provider roots must be directories: " + "; ".join(missing))
+    return roots
+
+
+def _worker_environment(
+    run_dir: Path,
+    *,
+    cuda_visible_devices: str,
+    quack_root: Path | None = None,
+) -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in tuple(environment):
+        if name.startswith((*WORKER_CONTROL_PREFIXES, "PYTHON")) or (
+            name in COMPILER_AND_LOADER_CONTROLS
+        ):
+            environment.pop(name)
+    cuda_home, artifacts = _installed_cuda_stack()
+    cudart = artifacts["cudart"]
+    environment.update(_selection_environment())
+    environment.update(_worker_cache_directories(run_dir))
+    environment["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
+    environment["CUDA_HOME"] = str(cuda_home)
+    environment["CUDA_PATH"] = str(cuda_home)
+    environment["CUDNN_FRONTEND_CUDART_LIB_NAME"] = str(cudart)
+    environment["LD_PRELOAD"] = os.pathsep.join(
+        str(artifacts[name]) for name in common.CUDA_STACK_PRELOAD_LIBRARY_PREFIXES
+    )
+    environment["PYTHONHASHSEED"] = "0"
+    environment["PYTHONNOUSERSITE"] = "1"
+    environment["PYTHONSAFEPATH"] = "1"
+    environment["PYTHONUTF8"] = "1"
+    environment["PATH"] = os.pathsep.join(
+        (
+            str(cuda_home / "bin"),
+            str(Path(sys.executable).resolve().parent),
+            "/usr/local/sbin",
+            "/usr/local/bin",
+            "/usr/sbin",
+            "/usr/bin",
+            "/sbin",
+            "/bin",
+        )
+    )
+    python_paths = [str(REPO_ROOT)]
+    if quack_root is not None:
+        python_paths.append(str(quack_root.resolve(strict=True)))
+    environment["PYTHONPATH"] = os.pathsep.join(python_paths)
+    return environment
+
+
+def _cuda_toolkit_identity(cuda_home: Path) -> dict[str, str]:
+    nvcc = cuda_home / "bin" / "nvcc"
+    completed = subprocess.run(
+        (str(nvcc), "--version"),
+        check=False,
+        capture_output=True,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        timeout=30,
+    )
+    output = f"{completed.stdout}\n{completed.stderr}".strip()
+    match = NVCC_RELEASE_PATTERN.search(output)
+    if completed.returncode or match is None:
+        raise RuntimeError(f"could not identify CUDA toolkit nvcc at {nvcc}")
+    return {
+        "release": match.group(1),
+        "compiler_version": match.group(2),
+    }
+
+
+def _installed_cuda_stack() -> tuple[Path, dict[str, Path]]:
+    distributions = common.require_pinned_distributions(
+        common.CUDA_STACK_DISTRIBUTION_VERSIONS,
+        "CUDA stack is not pinned",
+    )
+    artifacts = {
+        label: common.distribution_file(distribution, distributions[distribution], path)
+        for label, (distribution, path) in common.CUDA_STACK_REQUIRED_ARTIFACTS.items()
+    }
+    roots = {
+        artifact.parents[len(common.CUDA_STACK_REQUIRED_ARTIFACTS[label][1].parts) - 3]
+        for label, artifact in artifacts.items()
+    }
+    if len(roots) != 1:
+        raise RuntimeError(
+            f"CUDA stack distributions use different roots: {sorted(map(str, roots))}"
+        )
+    cuda_home = roots.pop()
+    return cuda_home, artifacts
+
+
+def _validate_mapped_cuda_libraries(artifacts: dict[str, Path]) -> None:
+    for label, prefix in common.CUDA_STACK_PRELOAD_LIBRARY_PREFIXES.items():
+        expected = artifacts[label]
+        loaded = common.mapped_library_paths(prefix)
+        if loaded != (expected,):
+            raise RuntimeError(
+                f"worker loaded {label} libraries {tuple(map(str, loaded))}, "
+                f"expected {(str(expected),)}"
+            )
+
+
+def _cuda_toolchain_identity() -> dict[str, object]:
+    expected_cuda_home, artifacts = _installed_cuda_stack()
+    expected_cudart = artifacts["cudart"]
+    cuda_home_text = os.environ.get("CUDA_HOME")
+    cudart_text = os.environ.get("CUDNN_FRONTEND_CUDART_LIB_NAME")
+    if cuda_home_text is None or cudart_text is None:
+        raise RuntimeError("worker CUDA toolkit environment is incomplete")
+    cuda_home = Path(cuda_home_text).resolve(strict=True)
+    cudart = Path(cudart_text).resolve(strict=True)
+    if cuda_home != expected_cuda_home or cudart != expected_cudart:
+        raise RuntimeError("worker CUDA toolkit environment changed after validation")
+    _validate_mapped_cuda_libraries(artifacts)
+    toolkit = _cuda_toolkit_identity(cuda_home)
+    if (
+        toolkit["release"] != common.CUDA_TOOLKIT_RELEASE
+        or toolkit["compiler_version"] != common.CUDA_COMPILER_VERSION
+    ):
+        raise RuntimeError(
+            "nvcc reports release "
+            f"{toolkit['release']} V{toolkit['compiler_version']}, expected release "
+            f"{common.CUDA_TOOLKIT_RELEASE} V{common.CUDA_COMPILER_VERSION}"
+        )
+    return {
+        "release": toolkit["release"],
+        "compiler_version": toolkit["compiler_version"],
+        "distribution_versions": dict(common.CUDA_STACK_DISTRIBUTION_VERSIONS),
+    }
+
+
+def _worker_command(
+    provider: str,
+    replicate: int,
+    run_dir: Path,
+    roots: dict[str, Path],
+) -> list[str]:
+    command = [
+        sys.executable,
+        "-u",
+        "-X",
+        f"pycache_prefix={run_dir / 'cache' / 'pycache'}",
+        str(Path(__file__).with_name("compare_grouped_gemm_backends.py").resolve()),
+        "--provider-defaults-worker",
+        "--provider",
+        provider,
+        "--provider-replicate",
+        str(replicate),
+        "--provider-run-dir",
+        str(run_dir),
+    ]
+    if provider in roots:
+        command.extend((f"--provider-{provider}-root", str(roots[provider])))
+    return command
+
+
+def _nvidia_smi(*arguments: str) -> str:
+    completed = subprocess.run(
+        ("nvidia-smi", *arguments),
+        check=False,
+        capture_output=True,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        timeout=NVIDIA_SMI_TIMEOUT_SECONDS,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(f"nvidia-smi failed ({completed.returncode}): {detail}")
+    return completed.stdout
+
+
+def _cuda_driver_version(device_uuid: str) -> str:
+    output = _nvidia_smi(
+        "-i",
+        device_uuid,
+        "--query-gpu=driver_version",
+        "--format=csv,noheader,nounits",
+    )
+    rows = [line.strip() for line in output.splitlines() if line.strip()]
+    if len(rows) != 1:
+        raise RuntimeError(f"could not identify CUDA driver for {device_uuid}")
+    return rows[0]
+
+
+def _resolve_target_gpu(cuda_visible_devices: str) -> str:
+    selector = common.require_single_visible_device(cuda_visible_devices)
+    output = _nvidia_smi(
+        "-i",
+        selector,
+        "--query-gpu=uuid",
+        "--format=csv,noheader,nounits",
+    )
+    rows = [line.strip() for line in output.splitlines() if line.strip()]
+    if len(rows) != 1 or not rows[0].startswith("GPU-"):
+        raise RuntimeError("target GPU UUID query did not return one physical GPU")
+    return rows[0]
+
+
+def _query_compute_applications(
+    target_gpu_uuid: str,
+) -> tuple[_ComputeApplication, ...]:
+    output = _nvidia_smi(
+        "--query-compute-apps=gpu_uuid,pid,process_name",
+        "--format=csv,noheader,nounits",
+    )
+    applications: list[_ComputeApplication] = []
+    for row in (line.strip() for line in output.splitlines() if line.strip()):
+        fields = tuple(field.strip() for field in row.split(",", maxsplit=2))
+        if len(fields) != 3:
+            raise RuntimeError("compute-application query returned malformed CSV")
+        if fields[0] == target_gpu_uuid:
+            try:
+                pid = int(fields[1])
+            except ValueError as error:
+                raise RuntimeError(
+                    "compute-application query returned an invalid PID"
+                ) from error
+            if pid <= 0:
+                raise RuntimeError("compute-application query returned an invalid PID")
+            applications.append(
+                _ComputeApplication(
+                    pid=pid,
+                    process_name=fields[2],
+                )
+            )
+    return tuple(applications)
+
+
+def _require_target_gpu_idle(target_gpu_uuid: str) -> None:
+    applications = _query_compute_applications(target_gpu_uuid)
+    if applications:
+        application = applications[0]
+        raise RuntimeError(
+            "target GPU is not idle: "
+            f"{target_gpu_uuid}, {application.pid}, {application.process_name}"
+        )
+
+
+def _check_compute_applications(
+    *,
+    target_gpu_uuid: str,
+    worker_process_group: int,
+    known_worker_pids: set[int],
+) -> None:
+    foreign: list[tuple[_ComputeApplication, int | None]] = []
+    for application in _query_compute_applications(target_gpu_uuid):
+        try:
+            process_group: int | None = os.getpgid(application.pid)
+        except ProcessLookupError:
+            process_group = None
+        if process_group == worker_process_group:
+            known_worker_pids.add(application.pid)
+        elif not (process_group is None and application.pid in known_worker_pids):
+            foreign.append((application, process_group))
+    if foreign:
+        details = "; ".join(
+            f"pid={application.pid} pgid={process_group} "
+            f"name={application.process_name!r}"
+            for application, process_group in foreign
+        )
+        raise RuntimeError(
+            f"target GPU {target_gpu_uuid} has a compute application outside "
+            f"worker process group {worker_process_group}: {details}"
+        )
+
+
+def _query_telemetry(target_gpu_uuid: str) -> _TelemetrySample:
+    fields = ",".join(TELEMETRY_FIELDS)
+    output = _nvidia_smi(
+        "-i",
+        target_gpu_uuid,
+        f"--query-gpu={fields}",
+        "--format=csv,noheader,nounits",
+    )
+    rows = [line.strip() for line in output.splitlines() if line.strip()]
+    if len(rows) != 1:
+        raise RuntimeError("nvidia-smi telemetry query did not return one row")
+    values = tuple(field.strip() for field in rows[0].split(","))
+    if len(values) != len(TELEMETRY_FIELDS) or values[0] != target_gpu_uuid:
+        raise RuntimeError("telemetry query did not return the target GPU UUID")
+    try:
+        return _TelemetrySample(
+            pstate=values[1],
+            sm_clock_mhz=float(values[2]),
+            memory_clock_mhz=float(values[3]),
+            power_draw_watts=float(values[4]),
+            power_limit_watts=float(values[5]),
+            active_clock_event_reasons=int(values[6], 0),
+        )
+    except ValueError as error:
+        raise RuntimeError(
+            "telemetry query returned an invalid numeric value"
+        ) from error
+
+
+def _summarize_telemetry(
+    samples: Sequence[_TelemetrySample],
+) -> dict[str, object]:
+    if not samples:
+        raise RuntimeError("GPU telemetry is empty")
+    if any(not sample.pstate or sample.pstate.startswith("[") for sample in samples):
+        raise RuntimeError("GPU telemetry returned an invalid pstate")
+    if any(
+        any(
+            not math.isfinite(value) or value < 0
+            for value in (
+                sample.power_draw_watts,
+                sample.sm_clock_mhz,
+                sample.memory_clock_mhz,
+            )
+        )
+        for sample in samples
+    ):
+        raise RuntimeError("GPU telemetry contains an invalid power or clock value")
+    power_limits = {sample.power_limit_watts for sample in samples}
+    if any(not math.isfinite(value) or value <= 0 for value in power_limits):
+        raise RuntimeError("GPU telemetry contains an invalid power limit")
+    if len(power_limits) != 1:
+        raise RuntimeError("GPU power limit changed")
+    active_reasons = Counter(
+        f"0x{sample.active_clock_event_reasons:x}"
+        for sample in samples
+        if sample.active_clock_event_reasons
+    )
+    disallowed = Counter(
+        f"0x{reason:x}"
+        for sample in samples
+        if (
+            reason := (sample.active_clock_event_reasons & ~ALLOWED_CLOCK_EVENT_REASONS)
+        )
+    )
+    if disallowed:
+        raise RuntimeError(
+            "GPU telemetry reported disallowed clock-event reasons: "
+            f"{dict(sorted(disallowed.items()))}"
+        )
+
+    def metric(values: Sequence[float]) -> dict[str, float]:
+        return {
+            "minimum": min(values),
+            "mean": statistics.fmean(values),
+            "maximum": max(values),
+        }
+
+    return {
+        "sample_count": len(samples),
+        "power_draw_watts": metric([s.power_draw_watts for s in samples]),
+        "sm_clock_mhz": metric([s.sm_clock_mhz for s in samples]),
+        "memory_clock_mhz": metric([s.memory_clock_mhz for s in samples]),
+        "power_limit_watts": next(iter(power_limits)),
+        "pstates": dict(sorted(Counter(sample.pstate for sample in samples).items())),
+        "sample_scope": "whole_worker_including_setup_and_post_exit",
+        "active_clock_event_reason_sample_count": sum(active_reasons.values()),
+        "active_clock_event_reasons": dict(sorted(active_reasons.items())),
+    }
+
+
+def _wait_for_target_gpu_idle(target_gpu_uuid: str) -> None:
+    deadline = time.monotonic() + POST_WORKER_IDLE_GRACE_SECONDS
+    while True:
+        try:
+            _require_target_gpu_idle(target_gpu_uuid)
+        except RuntimeError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.25)
+        else:
+            return
+
+
+def _process_group_exists(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _terminate_process(process: subprocess.Popen[bytes]) -> None:
+    previous_interrupt = signal.signal(signal.SIGINT, signal.SIG_IGN)
+    previous_terminate = signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    try:
+        if not _process_group_exists(process.pid):
+            process.wait()
+            return
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGTERM)
+        deadline = time.monotonic() + WORKER_TERMINATION_GRACE_SECONDS
+        while _process_group_exists(process.pid) and time.monotonic() < deadline:
+            process.poll()
+            time.sleep(0.1)
+        if _process_group_exists(process.pid):
+            with suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+    finally:
+        signal.signal(signal.SIGINT, previous_interrupt)
+        signal.signal(signal.SIGTERM, previous_terminate)
+
+
+def _run_monitored_worker(
+    command: Sequence[str],
+    *,
+    environment: dict[str, str],
+    log_path: Path,
+    target_gpu_uuid: str,
+) -> tuple[int, list[_TelemetrySample], int]:
+    telemetry: list[_TelemetrySample] = []
+    compute_application_samples = 0
+    worker_error: BaseException | None = None
+    _require_target_gpu_idle(target_gpu_uuid)
+    try:
+        with log_path.open("xb") as log:
+            process = subprocess.Popen(
+                command,
+                cwd=REPO_ROOT,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            known_worker_pids = {process.pid}
+            try:
+                next_telemetry_sample = time.monotonic()
+                next_compute_application_sample = next_telemetry_sample
+                while process.poll() is None:
+                    now = time.monotonic()
+                    if now >= next_compute_application_sample:
+                        _check_compute_applications(
+                            target_gpu_uuid=target_gpu_uuid,
+                            worker_process_group=process.pid,
+                            known_worker_pids=known_worker_pids,
+                        )
+                        compute_application_samples += 1
+                        next_compute_application_sample = (
+                            now + COMPUTE_APPLICATION_INTERVAL_SECONDS
+                        )
+                    if now >= next_telemetry_sample:
+                        telemetry.append(_query_telemetry(target_gpu_uuid))
+                        next_telemetry_sample = now + TELEMETRY_INTERVAL_SECONDS
+                    next_sample = min(
+                        next_compute_application_sample, next_telemetry_sample
+                    )
+                    time.sleep(min(0.25, max(0.0, next_sample - time.monotonic())))
+                _check_compute_applications(
+                    target_gpu_uuid=target_gpu_uuid,
+                    worker_process_group=process.pid,
+                    known_worker_pids=known_worker_pids,
+                )
+                compute_application_samples += 1
+                telemetry.append(_query_telemetry(target_gpu_uuid))
+                returncode = process.wait()
+                return (
+                    returncode,
+                    telemetry,
+                    compute_application_samples,
+                )
+            finally:
+                _terminate_process(process)
+    except BaseException as error:
+        worker_error = error
+        raise
+    finally:
+        try:
+            _wait_for_target_gpu_idle(target_gpu_uuid)
+        except RuntimeError:
+            if worker_error is None:
+                raise
+
+
+def _geomean(values: Sequence[float]) -> float:
+    if not values or any(not math.isfinite(value) or value <= 0 for value in values):
+        raise ValueError("geomean requires finite positive values")
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def _valid_accuracy_check(value: object, group_count: int) -> bool:
+    if not isinstance(value, dict) or value.get("ok") is not True:
+        return False
+    if (
+        type(value.get("group_count")) is not int
+        or value["group_count"] != group_count
+        or value.get("rtol") != common.CORRECTNESS_RTOL
+        or value.get("atol") != common.CORRECTNESS_ATOL
+        or type(value.get("mismatch_count")) is not int
+        or value["mismatch_count"] != 0
+    ):
+        return False
+    return (
+        all(
+            isinstance(metric, int | float)
+            and not isinstance(metric, bool)
+            and math.isfinite(metric)
+            and metric >= 0
+            for metric in (value.get("max_abs"), value.get("max_normalized_diff"))
+        )
+        and value["max_normalized_diff"] <= common.CORRECTNESS_MAX_NORMALIZED_DIFF
+    )
+
+
+def _valid_capture_evidence(value: object, group_count: int) -> bool:
+    return (
+        isinstance(value, dict)
+        and _valid_accuracy_check(value, group_count)
+        and value.get("poisoned_replay_rewrote_output") is True
+        and value.get("repeat_replay_exact") is True
+        and _valid_accuracy_check(value.get("post_timing"), group_count)
+    )
+
+
+def _valid_cutlass_tuning_evidence(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    tuning = value.get("registry_tuning")
+    if not isinstance(tuning, dict) or tuning.keys() != {
+        "method",
+        "timer",
+        "capture_warmups",
+        "repetitions",
+        "selected_candidate_index",
+        "candidates",
+    }:
+        return False
+    candidates = tuning.get("candidates")
+    selected_index = tuning.get("selected_candidate_index")
+    repetitions = tuning.get("repetitions")
+    if (
+        tuning.get("method") != "all_supported_operators_cold_l2"
+        or tuning.get("timer") != "bench_pre_captured_cudagraphs"
+        or tuning.get("capture_warmups") != cutlass.CUTLASS_SELECTION_CAPTURE_WARMUPS
+        or not isinstance(candidates, list)
+        or not candidates
+        or type(selected_index) is not int
+        or not 0 <= selected_index < len(candidates)
+        or type(repetitions) is not int
+        or repetitions < cutlass.CUTLASS_SELECTION_MIN_REPETITIONS
+        or repetitions % (2 * len(candidates))
+    ):
+        return False
+    for candidate in candidates:
+        if (
+            not isinstance(candidate, dict)
+            or candidate.keys()
+            != {
+                "registry_index",
+                "operator_name",
+                "config",
+                "compiled_for",
+                "selection_median_ms",
+                "correctness_checked",
+            }
+            or type(candidate.get("registry_index")) is not int
+            or candidate["registry_index"] < 0
+            or not isinstance(candidate.get("operator_name"), str)
+            or not candidate["operator_name"]
+            or not isinstance(candidate.get("config"), dict)
+            or candidate["config"].keys()
+            != {"use_2cta_mma", "tile_shape", "cluster_shape"}
+            or not isinstance(candidate.get("compiled_for"), str)
+            or not candidate["compiled_for"]
+            or not isinstance(candidate.get("selection_median_ms"), int | float)
+            or isinstance(candidate["selection_median_ms"], bool)
+            or not math.isfinite(candidate["selection_median_ms"])
+            or candidate["selection_median_ms"] <= 0
+            or candidate.get("correctness_checked") is not True
+        ):
+            return False
+    operator_names = [
+        cast("str", candidate["operator_name"]) for candidate in candidates
+    ]
+    if operator_names != sorted(operator_names) or len(operator_names) != len(
+        set(operator_names)
+    ):
+        return False
+    best_index = min(
+        range(len(candidates)),
+        key=lambda index: (
+            cast("float", candidates[index]["selection_median_ms"]),
+            operator_names[index],
+        ),
+    )
+    return selected_index == best_index
+
+
+def _validate_worker_result(
+    result: object,
+    provider: str,
+    replicate: int,
+    *,
+    expected_source: str | None = None,
+    expected_device: dict[str, Any] | None = None,
+    expected_versions: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    if not isinstance(result, dict):
+        raise RuntimeError(f"{provider} result identity is inconsistent")
+    if (
+        result.get("schema") != RESULT_SCHEMA
+        or result.get("provider") != provider
+        or result.get("replicate") != replicate
+    ):
+        raise RuntimeError(f"{provider} result identity is inconsistent")
+    source = result.get("source")
+    if not isinstance(source, str) or not source:
+        raise RuntimeError("campaign worker is missing Helion source identity")
+    if expected_source is not None and source != expected_source:
+        raise RuntimeError("Helion source identity changed across campaign workers")
+    device = result.get("device")
+    if (
+        not isinstance(device, dict)
+        or not isinstance(device.get("uuid"), str)
+        or not device["uuid"]
+        or not isinstance(device.get("name"), str)
+        or not device["name"]
+        or not isinstance(device.get("capability"), list)
+        or len(device["capability"]) != 2
+        or any(type(value) is not int for value in device["capability"])
+        or not common.is_supported_grouped_gemm_device(
+            "cuda", device["name"], tuple(device["capability"])
+        )
+    ):
+        raise RuntimeError("campaign worker is missing GPU identity")
+    if expected_device is not None and device != expected_device:
+        raise RuntimeError("GPU identity changed across campaign workers")
+    versions = result.get("versions")
+    version_names = ("python", "torch", "torch_cuda", "cutlass_dsl", "triton")
+    if (
+        not isinstance(versions, dict)
+        or any(
+            not isinstance(versions.get(name), str) or not versions[name]
+            for name in version_names
+        )
+        or not isinstance(versions.get("cuda_driver"), str)
+        or not versions["cuda_driver"]
+        or not isinstance(versions.get("cuda_stack"), dict)
+        or versions["cuda_stack"].get("release") != common.CUDA_TOOLKIT_RELEASE
+        or versions["cuda_stack"].get("compiler_version")
+        != common.CUDA_COMPILER_VERSION
+        or versions["cuda_stack"].get("distribution_versions")
+        != common.CUDA_STACK_DISTRIBUTION_VERSIONS
+    ):
+        raise RuntimeError("campaign worker is missing software versions")
+    if expected_versions is not None and versions != expected_versions:
+        raise RuntimeError("software versions changed across campaign workers")
+    expected_cases = tuple(case.as_dict() for case in common.official_cases())
+    rows = result.get("rows")
+    if not isinstance(rows, list) or len(rows) != len(expected_cases):
+        raise RuntimeError(
+            f"{provider} result does not contain {len(expected_cases)} rows"
+        )
+    for row_index, (row, expected_case) in enumerate(
+        zip(rows, expected_cases, strict=True)
+    ):
+        if not isinstance(row, dict) or row.get("case") != expected_case:
+            raise RuntimeError(f"{provider} row {row_index} changed the workload")
+        configs = row.get("configs")
+        correctness = row.get("correctness")
+        timings = row.get("timings")
+        if (
+            not isinstance(configs, dict)
+            or not isinstance(configs.get("helion"), dict)
+            or not isinstance(configs["helion"].get("config"), dict)
+            or not isinstance(configs.get("provider"), dict)
+        ):
+            raise RuntimeError(f"{provider} row {row_index} is missing configurations")
+        helion_config = configs["helion"]
+        if (
+            helion_config.get("selection_mode") != HELION_SELECTION
+            or helion_config.get("autotuned") is not False
+            or helion_config.get("b_layout") != BENCHMARK_B_LAYOUT
+            or helion_config.get("selection_api")
+            != "BoundKernel.set_config(ConfigSpec.default_config())"
+            or helion_config["config"].get("tcgen05_grouped_mode") != "worklist_nm"
+            or helion_config["config"].get("tcgen05_grouped_worklist_source_m_tile")
+            != SOURCE_M_TILE
+        ):
+            raise RuntimeError(f"{provider} row {row_index} changed Helion selection")
+        if not _valid_provider_contract(
+            configs["provider"],
+            provider,
+            expected_case=expected_case,
+            device=device,
+            complete=True,
+        ):
+            raise RuntimeError(f"{provider} row {row_index} changed provider selection")
+        if not isinstance(correctness, dict) or any(
+            not _valid_capture_evidence(
+                correctness.get(implementation), cast("int", expected_case["groups"])
+            )
+            for implementation in ("helion", "provider")
+        ):
+            raise RuntimeError(
+                f"{provider} row {row_index} is missing correctness evidence"
+            )
+        if not isinstance(timings, dict) or any(
+            not isinstance(value, int | float)
+            or isinstance(value, bool)
+            or not math.isfinite(value)
+            or value <= 0
+            for value in (timings.get("helion_ms"), timings.get("provider_ms"))
+        ):
+            raise RuntimeError(f"{provider} result contains invalid timings")
+    return source, device, versions
+
+
+def summarize_results(
+    results: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    expected_runs = publication_runs()
+    expected_cases = tuple(
+        cast("dict[str, Any]", case.as_dict()) for case in common.official_cases()
+    )
+    row_count = len(expected_cases)
+    if row_count != 8:
+        raise RuntimeError("benchmark requires exactly eight official cases")
+    if len(results) != len(expected_runs):
+        raise RuntimeError("campaign produced an unexpected worker result count")
+    results_by_provider: dict[str, list[dict[str, Any]]] = {
+        provider: [] for provider in PROVIDERS
+    }
+    identity: tuple[str, dict[str, Any], dict[str, Any]] | None = None
+    for result, (provider, replicate) in zip(results, expected_runs, strict=True):
+        expected_source, expected_device, expected_versions = (
+            identity if identity is not None else (None, None, None)
+        )
+        worker_identity = _validate_worker_result(
+            result,
+            provider,
+            replicate,
+            expected_source=expected_source,
+            expected_device=expected_device,
+            expected_versions=expected_versions,
+        )
+        if identity is None:
+            identity = worker_identity
+        results_by_provider[provider].append(result)
+    if identity is None:
+        raise RuntimeError("campaign produced no worker results")
+    source, device, software_stack = identity
+    provider_summaries = {}
+    helion_configs: list[list[object]] = [[] for _ in range(row_count)]
+    for provider in PROVIDERS:
+        provider_results = results_by_provider[provider]
+        row_speedups: list[list[float]] = [[] for _ in range(row_count)]
+        row_helion_ms: list[list[float]] = [[] for _ in range(row_count)]
+        row_provider_ms: list[list[float]] = [[] for _ in range(row_count)]
+        provider_configs: list[list[object]] = [[] for _ in range(row_count)]
+        for result in provider_results:
+            rows = cast("list[dict[str, Any]]", result["rows"])
+            timing_rows = [cast("dict[str, float]", row["timings"]) for row in rows]
+            helion_times = [float(timings["helion_ms"]) for timings in timing_rows]
+            provider_times = [float(timings["provider_ms"]) for timings in timing_rows]
+            speedups = [
+                provider_ms / helion_ms
+                for helion_ms, provider_ms in zip(
+                    helion_times, provider_times, strict=True
+                )
+            ]
+            for row_index, (row, helion_ms, provider_ms, speedup) in enumerate(
+                zip(rows, helion_times, provider_times, speedups, strict=True)
+            ):
+                row_speedups[row_index].append(speedup)
+                row_helion_ms[row_index].append(helion_ms)
+                row_provider_ms[row_index].append(provider_ms)
+                helion_configs[row_index].append(row["configs"]["helion"]["config"])
+                provider_config = row["configs"]["provider"]
+                provider_configs[row_index].append(provider_config)
+        row_summaries = [
+            {
+                "row_index": row_index,
+                "geomean_speedup": _geomean(speedups),
+                "helion_ms_by_replicate": row_helion_ms[row_index],
+                "provider_ms_by_replicate": row_provider_ms[row_index],
+            }
+            for row_index, speedups in enumerate(row_speedups)
+        ]
+        all_speedups = [speedup for row in row_speedups for speedup in row]
+        worst_row = min(row_summaries, key=itemgetter("geomean_speedup"))
+        comparable_configs = provider_configs
+        if provider == "quack":
+            if not all(
+                _all_equal(
+                    [
+                        _quack_provenance(cast("dict[str, Any]", config))
+                        for config in configs
+                    ]
+                )
+                for configs in provider_configs
+            ):
+                raise RuntimeError(f"{provider} provenance changed across replicates")
+            selection_stability = "fresh_autotuned"
+            varying_config_rows = [
+                row_index
+                for row_index, configs in enumerate(provider_configs)
+                if not _all_equal(configs)
+            ]
+        elif provider == "cutlass":
+            comparable_configs = [
+                [
+                    _cutlass_provenance(cast("dict[str, Any]", config))
+                    for config in configs
+                ]
+                for configs in provider_configs
+            ]
+            varying_config_rows = [
+                row_index
+                for row_index, configs in enumerate(comparable_configs)
+                if not _all_equal(configs)
+            ]
+            if varying_config_rows:
+                raise RuntimeError(
+                    "cutlass selected config changed across fresh tuning replicates"
+                )
+            selection_stability = "fresh_tuned_reproducible"
+        else:
+            varying_config_rows = [
+                row_index
+                for row_index, configs in enumerate(comparable_configs)
+                if not _all_equal(configs)
+            ]
+            if varying_config_rows:
+                raise RuntimeError(
+                    f"{provider} selected config changed across replicates"
+                )
+            selection_stability = "fixed"
+        provider_summary = {
+            "selection": PROVIDER_SELECTION_MODES[provider],
+            "selection_stability": selection_stability,
+            "cross_replicate_geomean": _geomean(all_speedups),
+            "row_wins": sum(row["geomean_speedup"] > 1.0 for row in row_summaries),
+            "worst_row": worst_row,
+            "rows": row_summaries,
+            "varying_config_rows": varying_config_rows,
+        }
+        benchmark_labels = [
+            cast("dict[str, Any]", config).get("benchmark_label")
+            for configs in provider_configs
+            for config in configs
+        ]
+        if not _all_equal(benchmark_labels):
+            raise RuntimeError(
+                f"{provider} benchmark label changed across rows or replicates"
+            )
+        benchmark_label = benchmark_labels[0]
+        if benchmark_label is not None and (
+            not isinstance(benchmark_label, str) or not benchmark_label
+        ):
+            raise RuntimeError(f"{provider} benchmark label is invalid")
+        if benchmark_label:
+            provider_summary["benchmark_label"] = benchmark_label
+        provider_summaries[provider] = provider_summary
+    if not all(_all_equal(configs) for configs in helion_configs):
+        raise RuntimeError("fixed Helion config changed across fresh workers")
+    return {
+        "schema": SUMMARY_SCHEMA,
+        "providers": list(PROVIDERS),
+        "replicates": PUBLICATION_REPLICATES,
+        "helion_selection": HELION_SELECTION,
+        "cases": list(expected_cases),
+        "device": device,
+        "software_stack": software_stack,
+        "speedup_definition": "provider_ms / helion_ms; higher favors Helion",
+        "protocol": {
+            **_COMMON_PROTOCOL,
+            "rows_per_replicate": row_count,
+            "row_timing_statistic": "median_ms",
+            "raw_paired_samples_retained": False,
+            "post_timing_correctness_check": True,
+            "protocol_evidence": "clean_worker_source_and_fixed_constants",
+            "oracle_float32_matmul_precision": common.ORACLE_FLOAT32_MATMUL_PRECISION,
+            "layout_policy": BENCHMARK_LAYOUT_POLICY,
+        },
+        "provider_results": provider_summaries,
+    }
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    row_count = summary["protocol"]["rows_per_replicate"]
+    print("\nprovider   geomean  wins  worst")
+    for provider in summary["providers"]:
+        result = summary["provider_results"][provider]
+        worst = result["worst_row"]
+        print(
+            f"{provider:<10} {result['cross_replicate_geomean']:>7.3f}x "
+            f"{result['row_wins']:>2}/{row_count}  row {worst['row_index']}: "
+            f"{worst['geomean_speedup']:.3f}x"
+        )
+        if result["varying_config_rows"]:
+            print(
+                f"  {result['selection_stability']} config variation on rows "
+                f"{result['varying_config_rows']}"
+            )
+        if benchmark_label := result.get("benchmark_label"):
+            print(f"  benchmark: {benchmark_label}")
+    monitoring = summary["monitoring"]
+    print(
+        "\nGPU telemetry (whole worker, including setup): "
+        f"power {monitoring['power_draw_watts']['mean']:.1f} W, "
+        f"SM clock {monitoring['sm_clock_mhz']['mean']:.0f} MHz, "
+        f"memory clock {monitoring['memory_clock_mhz']['mean']:.0f} MHz"
+    )
+    if reasons := monitoring["active_clock_event_reasons"]:
+        print(f"  allowed active GPU clock-event reasons: {reasons}")
+
+
+def _run_campaign(args: argparse.Namespace) -> int:
+    roots = _provider_roots(args)
+    target_gpu_uuid = _resolve_target_gpu(args.cuda_visible_devices)
+    output_dir = args.output_dir.expanduser().resolve()
+    if output_dir.is_relative_to(REPO_ROOT):
+        raise ValueError("output directory must be outside the Helion checkout")
+    source = _source_identity()
+    output_dir.mkdir(parents=True, exist_ok=False)
+    results: list[dict[str, Any]] = []
+    compute_application_sample_count = 0
+    campaign_telemetry: list[_TelemetrySample] = []
+    per_run_telemetry: dict[str, dict[str, object]] = {}
+    campaign_device: dict[str, Any] | None = None
+    campaign_versions: dict[str, Any] | None = None
+    for provider, replicate in publication_runs():
+        run_id = f"{provider}-r{replicate}"
+        run_dir = output_dir / run_id
+        run_dir.mkdir()
+        command = _worker_command(provider, replicate, run_dir, roots)
+        log_path = run_dir / "worker.log"
+        print(f"=== {run_id} ===", flush=True)
+        returncode, run_telemetry, compute_application_samples = _run_monitored_worker(
+            command,
+            environment=_worker_environment(
+                run_dir,
+                cuda_visible_devices=target_gpu_uuid,
+                quack_root=(roots.get("quack") if provider == "quack" else None),
+            ),
+            log_path=log_path,
+            target_gpu_uuid=target_gpu_uuid,
+        )
+        if returncode:
+            tail = "".join(log_path.read_text(errors="replace").splitlines(True)[-30:])
+            raise RuntimeError(f"{run_id} failed with {returncode}:\n{tail}")
+        result_path = run_dir / "result.json"
+        if not result_path.is_file():
+            raise RuntimeError(f"{run_id} did not produce result.json")
+        result = json.loads(result_path.read_text())
+        _, worker_device, worker_versions = _validate_worker_result(
+            result,
+            provider,
+            replicate,
+            expected_source=source,
+            expected_device=campaign_device,
+            expected_versions=campaign_versions,
+        )
+        if campaign_device is None:
+            campaign_device = worker_device
+            campaign_versions = worker_versions
+        if (
+            worker_device.get("uuid") != target_gpu_uuid
+            or worker_device.get("visible") != target_gpu_uuid
+        ):
+            raise RuntimeError(f"{run_id} worker used the wrong GPU: {worker_device}")
+        # Validate each worker immediately so a bad run aborts before the
+        # remaining fresh-process campaign is launched.
+        run_monitoring = _summarize_telemetry(run_telemetry)
+        run_monitoring["compute_application_sample_count"] = compute_application_samples
+        per_run_telemetry[run_id] = run_monitoring
+        campaign_telemetry.extend(run_telemetry)
+        compute_application_sample_count += compute_application_samples
+        results.append(result)
+        if _source_identity() != source:
+            raise RuntimeError("Helion checkout changed during the campaign")
+    summary = summarize_results(results)
+    summary["source"] = source
+    monitoring = _summarize_telemetry(campaign_telemetry)
+    monitoring.update(
+        {
+            "target_gpu_idle_before_after_each_run": True,
+            "compute_application_sample_interval_seconds": (
+                COMPUTE_APPLICATION_INTERVAL_SECONDS
+            ),
+            "telemetry_sample_interval_seconds": TELEMETRY_INTERVAL_SECONDS,
+            "compute_application_sample_count": compute_application_sample_count,
+            "allowed_clock_event_reason_mask": f"0x{ALLOWED_CLOCK_EVENT_REASONS:x}",
+            "by_provider_replicate": per_run_telemetry,
+        }
+    )
+    summary["monitoring"] = monitoring
+    common.write_result(output_dir / "summary.json", summary)
+    if _source_identity() != source:
+        raise RuntimeError("Helion checkout changed while writing the summary")
+    _print_summary(summary)
+    print(f"\nWrote {output_dir / 'summary.json'}")
+    return 0
+
+
+def campaign_plan() -> dict[str, object]:
+    """Return the CPU-only, immutable publication protocol plan."""
+
+    from benchmarks.cute.cublaslt_grouped_gemm import CUBLASLT_DISTRIBUTION_VERSION
+    from benchmarks.cute.cublaslt_grouped_gemm import CUBLASLT_LIBRARY_VERSION
+    from benchmarks.cute.cudnn_grouped_gemm import CUDNN_BACKEND_DISTRIBUTION_VERSION
+    from benchmarks.cute.cudnn_grouped_gemm import CUDNN_FRONTEND_VERSION
+    from benchmarks.cute.cutlass_contiguous_grouped_gemm import CUTLASS_COMMIT
+    from benchmarks.cute.cutlass_contiguous_grouped_gemm import CUTLASS_RELEASE_TAG
+    from benchmarks.cute.grouped_gemm_deepgemm_support import DEEPGEMM_COMMIT
+    from benchmarks.cute.grouped_gemm_deepgemm_support import DEEPGEMM_VERSION
+    from benchmarks.cute.quack_grouped_gemm import QUACK_BASE_RELEASE_TAG
+    from benchmarks.cute.quack_grouped_gemm import QUACK_COMMIT
+
+    cases = common.official_cases()
+    return {
+        "schema": "helion-grouped-gemm-provider-plan-v3",
+        "providers": list(PROVIDERS),
+        "replicates": PUBLICATION_REPLICATES,
+        "worker_count": len(PROVIDERS) * PUBLICATION_REPLICATES,
+        "run_order": [
+            {"provider": provider, "replicate": replicate}
+            for provider, replicate in publication_runs()
+        ],
+        "cases": [case.as_dict() for case in cases],
+        "helion": {
+            "selection": HELION_SELECTION,
+            "kernel_api": "helion.kernel",
+            "required_heuristic": GROUPED_WORKLIST_HEURISTIC,
+            "source_m_tile": SOURCE_M_TILE,
+            "b_layout": BENCHMARK_B_LAYOUT,
+        },
+        "provider_pins": {
+            "deepgemm": {"version": DEEPGEMM_VERSION, "commit": DEEPGEMM_COMMIT},
+            "quack": {
+                "base_release": QUACK_BASE_RELEASE_TAG,
+                "commit": QUACK_COMMIT,
+            },
+            "cudnn": {
+                "frontend": CUDNN_FRONTEND_VERSION,
+                "backend": CUDNN_BACKEND_DISTRIBUTION_VERSION,
+            },
+            "cublaslt": {
+                "distribution": CUBLASLT_DISTRIBUTION_VERSION,
+                "library": CUBLASLT_LIBRARY_VERSION,
+            },
+            "cutlass": {"release": CUTLASS_RELEASE_TAG, "commit": CUTLASS_COMMIT},
+        },
+        "provider_selections": dict(PROVIDER_SELECTION_MODES),
+        "provenance": {
+            "clean_helion_commit": True,
+            "cuda_toolkit_release": common.CUDA_TOOLKIT_RELEASE,
+            "cuda_compiler_version": common.CUDA_COMPILER_VERSION,
+            "cuda_distributions": common.CUDA_STACK_DISTRIBUTION_VERSIONS,
+            "cuda_loaded_libraries_validated": True,
+            "provider_versions_commits_and_configs_recorded": True,
+        },
+        "protocol": {
+            **_COMMON_PROTOCOL,
+            "fail_closed_source_gpu_stack_and_telemetry": True,
+        },
+    }
+
+
+def build_arg_parser(mode: str) -> argparse.ArgumentParser:
+    """Build the strict parser for one provider campaign mode."""
+
+    parser = argparse.ArgumentParser(
+        prog=f"{Path(sys.argv[0]).name} {mode}",
+        description=__doc__,
+        allow_abbrev=False,
+    )
+    if mode == PROVIDER_DEFAULTS_PLAN_MODE:
+        return parser
+    roots_required = mode == PROVIDER_DEFAULTS_MODE
+    for provider in SOURCE_BACKED_PROVIDERS:
+        parser.add_argument(
+            f"--provider-{provider}-root",
+            dest=f"{provider}_root",
+            type=Path,
+            required=roots_required,
+        )
+    if mode == PROVIDER_DEFAULTS_MODE:
+        parser.add_argument(
+            "--provider-output-dir", dest="output_dir", type=Path, required=True
+        )
+        parser.add_argument(
+            "--cuda-visible-devices",
+            default=os.environ.get("CUDA_VISIBLE_DEVICES"),
+            help="one CUDA_VISIBLE_DEVICES entry (GPU UUID or index)",
+        )
+        return parser
+    parser.add_argument(
+        "--provider", choices=PROVIDERS, required=True, help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        "--provider-replicate",
+        dest="replicate",
+        type=_nonnegative_int,
+        required=True,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--provider-run-dir",
+        dest="run_dir",
+        type=Path,
+        required=True,
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def main(argv: Sequence[str]) -> int:
+    """Parse and execute a provider mode selected by the public entrypoint."""
+
+    arguments = list(argv)
+    if not arguments or arguments[0] not in PROVIDER_CLI_MODES:
+        raise ValueError("provider campaign mode is required")
+    mode = arguments.pop(0)
+    args = build_arg_parser(mode).parse_args(arguments)
+    if mode == PROVIDER_DEFAULTS_PLAN_MODE:
+        print(json.dumps(campaign_plan(), indent=2, sort_keys=True))
+        return 0
+    if mode == PROVIDER_DEFAULTS_WORKER_MODE:
+        return _run_worker(args)
+    if args.cuda_visible_devices is None:
+        raise ValueError("set CUDA_VISIBLE_DEVICES or --cuda-visible-devices")
+    common.require_single_visible_device(args.cuda_visible_devices)
+
+    def handle_signal(signum: int, _frame: object) -> None:
+        raise _CampaignInterrupted(signum)
+
+    previous_handlers = {
+        signum: signal.signal(signum, handle_signal)
+        for signum in (signal.SIGINT, signal.SIGTERM)
+    }
+    try:
+        return _run_campaign(args)
+    except _CampaignInterrupted as error:
+        return 128 + error.signum
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)

--- a/benchmarks/cute/grouped_gemm_workloads.py
+++ b/benchmarks/cute/grouped_gemm_workloads.py
@@ -1,0 +1,61 @@
+"""Shared workload and provider metadata for grouped-GEMM benchmarks."""
+
+from __future__ import annotations
+
+import random
+from typing import NamedTuple
+
+DEEPGEMM_VERSION = "2.6.1"
+DEEPGEMM_COMMIT = "559d79fb6994a58b8a15b4b93bf13ccc16edf247"
+DEEPGEMM_CUTLASS_COMMIT = "f3fde58372d33e9a5650ba7b80fc48b3b49d40c8"
+DEEPGEMM_FMT_COMMIT = "553ec11ec06fbe0beebfbb45f9dc3c9eabd83d28"
+DEEPGEMM_M_ALIGNMENT = 224
+BENCHMARK_B_LAYOUT = "k_major"
+PROVIDER_DEFAULTS_MODE = "--provider-defaults"
+PROVIDER_DEFAULTS_PLAN_MODE = "--provider-defaults-plan"
+PROVIDER_DEFAULTS_WORKER_MODE = "--provider-defaults-worker"
+PROVIDER_CLI_MODES = (
+    PROVIDER_DEFAULTS_MODE,
+    PROVIDER_DEFAULTS_PLAN_MODE,
+    PROVIDER_DEFAULTS_WORKER_MODE,
+)
+PROVIDER_SELECTION_MODES = {
+    "deepgemm": "public_kmajor_nk_no_psum_zero_padding_off",
+    "quack": "public_api_default_tuned",
+    "cudnn": "public_a_fallback_build_execute",
+    "cublaslt": "grouped_shape_hints_heuristic_result_zero_requested_one",
+    "cutlass": "all_supported_registry_operators_cold_l2_tuned",
+}
+
+
+class OfficialShape(NamedTuple):
+    row_index: int
+    groups: int
+    expected_m_per_group: int
+    n: int
+    k: int
+
+
+OFFICIAL_SHAPES = (
+    OfficialShape(0, 4, 8192, 6144, 7168),
+    OfficialShape(1, 4, 8192, 7168, 3072),
+    OfficialShape(2, 4, 8192, 4096, 4096),
+    OfficialShape(3, 4, 8192, 4096, 2048),
+    OfficialShape(4, 8, 4096, 6144, 7168),
+    OfficialShape(5, 8, 4096, 7168, 3072),
+    OfficialShape(6, 8, 4096, 4096, 4096),
+    OfficialShape(7, 8, 4096, 4096, 2048),
+)
+
+
+def official_actual_ms(seed: int = 0) -> tuple[tuple[int, ...], ...]:
+    """Return the deterministic DeepGEMM-compatible logical M sizes."""
+
+    rng = random.Random(seed)
+    return tuple(
+        tuple(
+            int(shape.expected_m_per_group * rng.uniform(0.7, 1.3))
+            for _ in range(shape.groups)
+        )
+        for shape in OFFICIAL_SHAPES
+    )

--- a/benchmarks/cute/quack_grouped_gemm.py
+++ b/benchmarks/cute/quack_grouped_gemm.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import is_dataclass
+from enum import Enum
+import importlib
+import importlib.metadata
+import json
+from pathlib import Path
+import sys
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+from urllib.parse import unquote
+from urllib.parse import urlparse
+
+from benchmarks.cute import grouped_gemm_benchmark as common
+from benchmarks.cute.grouped_gemm_workloads import BENCHMARK_B_LAYOUT
+import torch
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from benchmarks.cute.grouped_gemm_benchmark import GroupedGemmInputs
+    from benchmarks.cute.grouped_gemm_benchmark import PreparedImplementation
+
+_NATIVE_FILE_MARKERS = (".so", ".dylib", ".dll", ".pyd")
+QUACK_REPOSITORY = "https://github.com/Dao-AILab/quack"
+# The pinned post-release source still reports the preceding release version.
+QUACK_PACKAGE_METADATA_VERSION = "0.6.4"
+QUACK_BASE_RELEASE_TAG = "v0.6.4"
+QUACK_COMMIT = "c8ec3170057987da0ec99883736f381ea1937cf3"
+QUACK_BENCHMARK_LABEL = (
+    f"quack-main@{QUACK_COMMIT[:8]} (post-{QUACK_BASE_RELEASE_TAG}, non-release)"
+)
+QUACK_DEPENDENCY_VERSIONS = {
+    "nvidia-cutlass-dsl": "4.7.0",
+    "apache-tvm-ffi": "0.1.13.post3",
+    "torch-c-dlpack-ext": "0.1.5",
+    "einops": "0.8.2",
+}
+
+
+def _source_provenance() -> dict[str, object]:
+    return {
+        "kind": "upstream_main_snapshot",
+        "repository": QUACK_REPOSITORY,
+        "commit": QUACK_COMMIT,
+        "base_release_tag": QUACK_BASE_RELEASE_TAG,
+        "is_formal_release": False,
+        "benchmark_label": QUACK_BENCHMARK_LABEL,
+    }
+
+
+def _validate_loaded_quack_modules(root: Path) -> None:
+    for name, module in sorted(sys.modules.items()):
+        if module is not None and (name == "quack" or name.startswith("quack.")):
+            common.validate_module_source(module, root, f"QuACK module {name!r}")
+
+
+def _editable_root(distribution: importlib.metadata.Distribution) -> Path:
+    direct_url_text = distribution.read_text("direct_url.json")
+    if direct_url_text is None:
+        raise RuntimeError("QuACK must be installed from an editable checkout")
+    try:
+        direct_url = json.loads(direct_url_text)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("QuACK direct_url.json is invalid") from error
+    url = direct_url.get("url") if isinstance(direct_url, dict) else None
+    directory = direct_url.get("dir_info") if isinstance(direct_url, dict) else None
+    parsed = urlparse(url) if isinstance(url, str) else None
+    if (
+        parsed is None
+        or parsed.scheme != "file"
+        or parsed.netloc not in ("", "localhost")
+        or not isinstance(directory, dict)
+        or directory.get("editable") is not True
+    ):
+        raise RuntimeError(
+            "QuACK distribution is not installed from an editable checkout"
+        )
+    return Path(unquote(parsed.path)).resolve(strict=True)
+
+
+def _native_distribution_files(
+    distribution: importlib.metadata.Distribution,
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            str(path)
+            for path in distribution.files or ()
+            if any(marker in Path(str(path)).name for marker in _NATIVE_FILE_MARKERS)
+        )
+    )
+
+
+def _dependency_versions() -> dict[str, str]:
+    distributions = common.require_pinned_distributions(
+        QUACK_DEPENDENCY_VERSIONS,
+        "QuACK dependencies are not pinned",
+    )
+    return {name: distribution.version for name, distribution in distributions.items()}
+
+
+def verify_quack_installation(
+    quack_root: Path | None = None,
+) -> dict[str, object]:
+    """Verify the installed QuACK distribution and pinned Python source."""
+
+    distribution = common.require_pinned_distribution(
+        "quack-kernels",
+        QUACK_PACKAGE_METADATA_VERSION,
+    )
+    native_files = _native_distribution_files(distribution)
+    installation = "editable"
+    root = _editable_root(distribution) if quack_root is None else quack_root.resolve()
+    if quack_root is not None:
+        if native_files:
+            raise RuntimeError(
+                "--quack-root cannot override a distribution with native artifacts: "
+                f"{native_files}"
+            )
+        installation = "installed_distribution_with_source_override"
+    if str(root) not in sys.path:
+        raise RuntimeError(
+            "QuACK checkout must be present on the worker import path so "
+            "compile subprocesses use the validated source"
+        )
+    dependency_versions = _dependency_versions()
+    commit = common.clean_checkout(root, QUACK_COMMIT, "QuACK")
+    module = _import_quack_from_root(root)
+    common.validate_module_source(
+        module,
+        root,
+        "QuACK module 'quack'",
+    )
+
+    return {
+        "repository": QUACK_REPOSITORY,
+        "upstream_commit": commit,
+        "source_provenance": _source_provenance(),
+        "distribution_version": distribution.version,
+        "distribution_requirements": sorted(distribution.requires or ()),
+        "dependency_versions": dependency_versions,
+        "installation": installation,
+        "source_root": str(root),
+    }
+
+
+def _import_quack_from_root(root: Path, name: str = "quack") -> ModuleType:
+    _validate_loaded_quack_modules(root)
+    root_text = str(root)
+    sys.path.insert(0, root_text)
+    try:
+        module = importlib.import_module(name)
+    finally:
+        sys.path.pop(0)
+    _validate_loaded_quack_modules(root)
+    return module
+
+
+def _package_identity(quack_root: Path | None = None) -> dict[str, object]:
+    identity = verify_quack_installation(quack_root)
+    module = cast("Any", sys.modules["quack"])
+    module_version = str(module.__version__)
+    if module_version != QUACK_PACKAGE_METADATA_VERSION:
+        raise RuntimeError(
+            "QuACK module is "
+            f"{module_version!r}, expected {QUACK_PACKAGE_METADATA_VERSION!r}"
+        )
+    return {
+        **identity,
+        "module_version": module_version,
+    }
+
+
+def _stable_dispatch_value(value: object) -> object:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Enum):
+        return {
+            "type": f"{type(value).__module__}.{type(value).__qualname__}",
+            "name": value.name,
+            "value": _stable_dispatch_value(value.value),
+        }
+    if is_dataclass(value) and not isinstance(value, type):
+        return _stable_dispatch_value(asdict(value))
+    if isinstance(value, dict):
+        return {
+            str(key): _stable_dispatch_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_stable_dispatch_value(item) for item in value]
+    as_dict = getattr(value, "_asdict", None)
+    if as_dict is not None:
+        return _stable_dispatch_value(as_dict())
+    return {"type": f"{type(value).__module__}.{type(value).__qualname__}"}
+
+
+def _dispatch_identity(dispatch_plan: object) -> dict[str, object]:
+    fields = cast("Any", dispatch_plan)._asdict()
+    compiled_fn = fields.pop("compiled_fn")
+    return {
+        "type": f"{type(dispatch_plan).__module__}.{type(dispatch_plan).__qualname__}",
+        "compiled_callable_type": (
+            f"{type(compiled_fn).__module__}.{type(compiled_fn).__qualname__}"
+        ),
+        "fields": _stable_dispatch_value(fields),
+    }
+
+
+def prepare_quack_default(
+    inputs: GroupedGemmInputs,
+    *,
+    quack_root: Path | None = None,
+) -> PreparedImplementation:
+    """Select QuACK's public tuned default before capture, then replay it."""
+
+    package = _package_identity(quack_root)
+    source_root = Path(cast("str", package.pop("source_root")))
+    try:
+        interface = cast(
+            "Any", _import_quack_from_root(source_root, "quack.gemm_interface")
+        )
+    except (ImportError, OSError) as error:
+        raise RuntimeError(
+            "QuACK requires the optional quack-kernels package"
+        ) from error
+    _validate_loaded_quack_modules(source_root)
+    gemm = interface.gemm
+    gemm_tuned = interface.gemm_tuned
+
+    b_kn = inputs.b.transpose(1, 2)
+    output = torch.empty(
+        (inputs.case.total_m, inputs.case.n),
+        device=inputs.compact_a.device,
+        dtype=torch.bfloat16,
+    )
+    # This is the public API with the snapshot's actual defaults:
+    # ``tuned=True``, ``dynamic_scheduler=False``, and ``split_k=1``. Run it
+    # once during preparation so candidate compilation and benchmarking cannot
+    # enter this benchmark's captured/timed replay.
+    selected_output = gemm(
+        inputs.compact_a,
+        b_kn,
+        out=output,
+        cu_seqlens_m=inputs.offsets,
+    )
+    if selected_output is not output:
+        raise RuntimeError("QuACK public GEMM replaced the provided output")
+    selected_config = gemm_tuned.best_config.kwargs["config"]
+    resolved_config, resolved_split_k, resolved_dynamic_scheduler, dispatch_plan = (
+        gemm_tuned.fn(
+            inputs.compact_a,
+            b_kn,
+            output,
+            cu_seqlens_m=inputs.offsets,
+            config=selected_config,
+        )
+    )
+    if resolved_config != selected_config:
+        raise RuntimeError("QuACK replay did not preserve the autotuned config")
+    serialized = asdict(resolved_config)
+    dispatch_identity = _dispatch_identity(dispatch_plan)
+
+    def call() -> torch.Tensor:
+        replay_config, replay_split_k, replay_dynamic, replay_dispatch = gemm_tuned.fn(
+            inputs.compact_a,
+            b_kn,
+            output,
+            cu_seqlens_m=inputs.offsets,
+            config=resolved_config,
+        )
+        if (
+            replay_config != resolved_config
+            or replay_split_k != resolved_split_k
+            or replay_dynamic != resolved_dynamic_scheduler
+            or replay_dispatch is not dispatch_plan
+        ):
+            raise RuntimeError("QuACK resolved replay plan changed after selection")
+        return output
+
+    return common.PreparedImplementation(
+        name=(
+            f"quack-main-{QUACK_COMMIT[:8]}-public-default-tuned-{BENCHMARK_B_LAYOUT}"
+        ),
+        call=call,
+        output_tensors=lambda result: (cast("torch.Tensor", result),),
+        logical_outputs=lambda result: inputs.compact_output_slices(
+            cast("torch.Tensor", result)
+        ),
+        config=common.provider_config(
+            "quack",
+            {
+                "benchmark_label": QUACK_BENCHMARK_LABEL,
+                "selection_api": "gemm(default tuned=True)",
+                "replay_api": "gemm_tuned.fn(resolved config)",
+                "requested_config": None,
+                "selected_config": {**serialized, "b_layout": BENCHMARK_B_LAYOUT},
+                "requested_dynamic_scheduler": False,
+                "resolved_dynamic_scheduler": bool(resolved_dynamic_scheduler),
+                "tuned": True,
+                "resolved_split_k": int(resolved_split_k),
+                "dispatch_plan": dispatch_identity,
+                "package": package,
+                "a_layout": common.compact_contiguous_a_layout(),
+                "numerics": "BF16 inputs, FP32 accumulation, BF16 output",
+            },
+        ),
+    )

--- a/test/test_grouped_gemm_provider_campaign.py
+++ b/test/test_grouped_gemm_provider_campaign.py
@@ -1,0 +1,1100 @@
+from __future__ import annotations
+
+import argparse
+from contextlib import nullcontext
+from dataclasses import replace
+import inspect
+from itertools import starmap
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from typing import cast
+
+from benchmarks.cute import compare_grouped_gemm_backends
+from benchmarks.cute import cublaslt_grouped_gemm
+from benchmarks.cute import cudnn_grouped_gemm
+from benchmarks.cute import cutlass_contiguous_grouped_gemm
+from benchmarks.cute import grouped_gemm_benchmark as common
+from benchmarks.cute import grouped_gemm_deepgemm_support
+from benchmarks.cute import grouped_gemm_provider_campaign as campaign
+from benchmarks.cute import quack_grouped_gemm
+import pytest
+import torch
+
+SOURCE_IDENTITY = "commit"
+TELEMETRY_SAMPLE = campaign._TelemetrySample(
+    pstate="P0",
+    sm_clock_mhz=1000.0,
+    memory_clock_mhz=2000.0,
+    power_draw_watts=500.0,
+    power_limit_watts=1000.0,
+    active_clock_event_reasons=0,
+)
+PROVIDER_ADAPTERS = (
+    (
+        "deepgemm",
+        grouped_gemm_deepgemm_support,
+        "prepare_deepgemm_default",
+        "deepgemm_root",
+    ),
+    ("quack", quack_grouped_gemm, "prepare_quack_default", "quack_root"),
+    ("cudnn", cudnn_grouped_gemm, "prepare_cudnn_default", None),
+    ("cublaslt", cublaslt_grouped_gemm, "prepare_cublaslt_default", None),
+    (
+        "cutlass",
+        cutlass_contiguous_grouped_gemm,
+        "prepare_cutlass_default",
+        "cutlass_root",
+    ),
+)
+OFFICIAL_CASES = common.official_cases()
+
+
+@pytest.fixture
+def cuda_stack(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> tuple[Path, dict[str, Path]]:
+    cuda_home = tmp_path / "cuda"
+    artifacts = {
+        name: cuda_home / "lib" / f"{name}.so"
+        for name in common.CUDA_STACK_PRELOAD_LIBRARY_PREFIXES
+    }
+    for artifact in artifacts.values():
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.touch()
+    monkeypatch.setattr(
+        campaign, "_installed_cuda_stack", lambda: (cuda_home, artifacts)
+    )
+    return cuda_home, artifacts
+
+
+def _accuracy_evidence(
+    *, replay: bool = False, group_count: int = 1
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "ok": True,
+        "group_count": group_count,
+        "rtol": common.CORRECTNESS_RTOL,
+        "atol": common.CORRECTNESS_ATOL,
+        "max_normalized_diff": 0.0,
+        "max_abs": 0.0,
+        "mismatch_count": 0,
+    }
+    if replay:
+        result.update(
+            poisoned_replay_rewrote_output=True,
+            repeat_replay_exact=True,
+            post_timing=_accuracy_evidence(group_count=group_count),
+        )
+    return result
+
+
+def _prepared_provider(provider: str) -> common.PreparedImplementation:
+    return common.PreparedImplementation(
+        name=provider,
+        call=lambda: None,
+        output_tensors=lambda _result: (),
+        logical_outputs=lambda _result: (),
+        config=_provider_config(provider, 0),
+    )
+
+
+def _versions(*, driver: str = "590.00") -> dict[str, object]:
+    return {
+        "python": "3.12.0",
+        "torch": "2.10.0.dev",
+        "torch_cuda": "13.0",
+        "triton": "3.6.0",
+        "cutlass_dsl": "4.7.0",
+        "cuda_driver": driver,
+        "cuda_stack": {
+            "distribution_versions": dict(common.CUDA_STACK_DISTRIBUTION_VERSIONS),
+            "release": common.CUDA_TOOLKIT_RELEASE,
+            "compiler_version": common.CUDA_COMPILER_VERSION,
+        },
+    }
+
+
+def _provider_config(provider: str, row_index: int) -> dict[str, object]:
+    case = OFFICIAL_CASES[row_index]
+    if provider == "deepgemm":
+        details = {
+            "api": {
+                "function": "m_grouped_bf16_gemm_nt_contiguous",
+                "compiled_dims": "nk",
+                "use_psum_layout": False,
+                "ensure_zero_padding": False,
+            },
+            "provenance": {
+                "git_head": grouped_gemm_deepgemm_support.DEEPGEMM_COMMIT,
+                "cutlass_head": grouped_gemm_deepgemm_support.DEEPGEMM_CUTLASS_COMMIT,
+                "fmt_head": grouped_gemm_deepgemm_support.DEEPGEMM_FMT_COMMIT,
+                "version": grouped_gemm_deepgemm_support.DEEPGEMM_VERSION,
+                "native_extension_sha256": "0" * 64,
+            },
+        }
+    elif provider == "quack":
+        details = {
+            "benchmark_label": quack_grouped_gemm.QUACK_BENCHMARK_LABEL,
+            "selection_api": "gemm(default tuned=True)",
+            "requested_config": None,
+            "selected_config": {"b_layout": campaign.BENCHMARK_B_LAYOUT},
+            "requested_dynamic_scheduler": False,
+            "resolved_dynamic_scheduler": False,
+            "tuned": True,
+            "resolved_split_k": 1,
+            "dispatch_plan": {"type": "quack.gemm._GemmPlan"},
+            "package": {
+                "source_provenance": {
+                    "kind": "upstream_main_snapshot",
+                    "repository": quack_grouped_gemm.QUACK_REPOSITORY,
+                    "commit": quack_grouped_gemm.QUACK_COMMIT,
+                    "base_release_tag": quack_grouped_gemm.QUACK_BASE_RELEASE_TAG,
+                    "is_formal_release": False,
+                    "benchmark_label": quack_grouped_gemm.QUACK_BENCHMARK_LABEL,
+                },
+                "upstream_commit": quack_grouped_gemm.QUACK_COMMIT,
+                "distribution_version": quack_grouped_gemm.QUACK_PACKAGE_METADATA_VERSION,
+                "dependency_versions": quack_grouped_gemm.QUACK_DEPENDENCY_VERSIONS,
+                "module_version": quack_grouped_gemm.QUACK_PACKAGE_METADATA_VERSION,
+                "installation": "editable",
+            },
+        }
+    elif provider == "cudnn":
+        cudart = {
+            "distribution": common.CUDA_RUNTIME_DISTRIBUTION,
+            "package_version": common.CUDA_RUNTIME_VERSION,
+        }
+        details = {
+            "baseline": cudnn_grouped_gemm.CUDNN_GROUPED_BASELINE,
+            "frontend_version": cudnn_grouped_gemm.CUDNN_FRONTEND_VERSION,
+            "backend_version": cudnn_grouped_gemm.CUDNN_BACKEND_VERSION,
+            "runtime": {
+                "frontend": {
+                    "distribution": cudnn_grouped_gemm.CUDNN_FRONTEND_DISTRIBUTION,
+                    "package_version": cudnn_grouped_gemm.CUDNN_FRONTEND_VERSION,
+                },
+                "requested_cuda_runtime": cudart,
+                "backend_libraries": {
+                    "distribution": cudnn_grouped_gemm.CUDNN_BACKEND_DISTRIBUTION,
+                    "package_version": (
+                        cudnn_grouped_gemm.CUDNN_BACKEND_DISTRIBUTION_VERSION
+                    ),
+                },
+                "loaded_cuda_runtime": cudart,
+            },
+            "plan": {"selection": "graph_build_default"},
+        }
+    elif provider == "cublaslt":
+        problems = tuple((m, case.n, case.k, 1) for m in case.actual_ms)
+        details = {
+            "library": {
+                "distribution": cublaslt_grouped_gemm.CUBLASLT_DISTRIBUTION,
+                "package_version": cublaslt_grouped_gemm.CUBLASLT_DISTRIBUTION_VERSION,
+                "library_version": cublaslt_grouped_gemm.CUBLASLT_LIBRARY_VERSION,
+            },
+            "group_count": case.groups,
+            "grouped_average_preferences": (
+                cublaslt_grouped_gemm.cublaslt_grouped_preference_values(problems)
+            ),
+            "heuristic_query_capacity": (
+                cublaslt_grouped_gemm.CUBLASLT_HEURISTIC_QUERY_CAPACITY
+            ),
+            "selected_algorithm": {"serialized_hex": "00", "heuristic_rank": 0},
+        }
+    else:
+        details = {
+            "repository": cutlass_contiguous_grouped_gemm.CUTLASS_REPOSITORY,
+            "release_tag": cutlass_contiguous_grouped_gemm.CUTLASS_RELEASE_TAG,
+            "commit": cutlass_contiguous_grouped_gemm.CUTLASS_COMMIT,
+            "operator_api_version": (
+                cutlass_contiguous_grouped_gemm.CUTLASS_OPERATOR_API_VERSION
+            ),
+            "target_sm": "100a",
+            "registry_tuning": {
+                "method": "all_supported_operators_cold_l2",
+                "timer": "bench_pre_captured_cudagraphs",
+                "capture_warmups": 2,
+                "repetitions": 32,
+                "selected_candidate_index": 0,
+                "candidates": [
+                    {
+                        "registry_index": index,
+                        "operator_name": f"cutlass.candidate.{index}",
+                        "config": {
+                            "use_2cta_mma": False,
+                            "tile_shape": [128 * (index + 1), 128, 64],
+                            "cluster_shape": [1, 1, 1],
+                        },
+                        "compiled_for": "sm100",
+                        "selection_median_ms": 1.0 + index,
+                        "correctness_checked": True,
+                    }
+                    for index in range(2)
+                ],
+            },
+        }
+    return common.provider_config(provider, details)
+
+
+def _helion_config(row_index: int) -> dict[str, object]:
+    return {
+        "selection_mode": campaign.HELION_SELECTION,
+        "autotuned": False,
+        "b_layout": campaign.BENCHMARK_B_LAYOUT,
+        "selection_api": "BoundKernel.set_config(ConfigSpec.default_config())",
+        "config": {
+            "row": row_index,
+            "block": 128,
+            "tcgen05_grouped_mode": "worklist_nm",
+            "tcgen05_grouped_worklist_source_m_tile": campaign.SOURCE_M_TILE,
+        },
+    }
+
+
+def _result(provider: str, replicate: int) -> dict[str, Any]:
+    return {
+        "schema": campaign.RESULT_SCHEMA,
+        "provider": provider,
+        "replicate": replicate,
+        "device": {
+            "visible": "GPU-test",
+            "name": "NVIDIA B200",
+            "capability": [10, 0],
+            "uuid": "GPU-test",
+            "multi_processor_count": 148,
+            "total_memory": 192_000_000_000,
+        },
+        "source": SOURCE_IDENTITY,
+        "versions": _versions(),
+        "rows": [
+            {
+                "case": case.as_dict(),
+                "configs": {
+                    "helion": _helion_config(case.row_index),
+                    "provider": _provider_config(provider, case.row_index),
+                },
+                "correctness": {
+                    "helion": _accuracy_evidence(replay=True, group_count=case.groups),
+                    "provider": _accuracy_evidence(
+                        replay=True, group_count=case.groups
+                    ),
+                },
+                "timings": {"helion_ms": 1.0, "provider_ms": 2.0},
+            }
+            for case in OFFICIAL_CASES
+        ],
+    }
+
+
+def _campaign_results() -> list[dict[str, Any]]:
+    return list(starmap(_result, campaign.publication_runs()))
+
+
+def _campaign_result(
+    results: list[dict[str, Any]], provider: str, replicate: int
+) -> dict[str, Any]:
+    return next(
+        result
+        for result in results
+        if result["provider"] == provider and result["replicate"] == replicate
+    )
+
+
+PROVIDER_PIN_PATHS = (
+    ("deepgemm", ("provenance", "git_head")),
+    ("quack", ("package", "upstream_commit")),
+    ("cudnn", ("plan", "selection")),
+    ("cublaslt", ("selected_algorithm", "heuristic_rank")),
+    ("cutlass", ("commit",)),
+)
+
+
+def test_cli_smokes_fixed_plan_and_legacy_dispatch(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert compare_grouped_gemm_backends.main(["--provider-defaults-plan"]) == 0
+    plan = json.loads(capsys.readouterr().out)
+    assert plan["providers"] == list(campaign.PROVIDERS)
+    assert plan["replicates"] == campaign.PUBLICATION_REPLICATES
+    assert plan["worker_count"] == len(campaign.publication_runs())
+    assert plan["run_order"] == [
+        {"provider": provider, "replicate": replicate}
+        for provider, replicate in campaign.publication_runs()
+    ]
+    assert plan["cases"] == [case.as_dict() for case in OFFICIAL_CASES]
+    assert plan["helion"]["selection"] == campaign.HELION_SELECTION
+    assert plan["helion"]["required_heuristic"] == campaign.GROUPED_WORKLIST_HEURISTIC
+    assert plan["provider_selections"] == dict(campaign.PROVIDER_SELECTION_MODES)
+    assert plan["protocol"]["balanced_rotated_reversed_order"] is True
+    assert plan["protocol"]["fail_closed_source_gpu_stack_and_telemetry"] is True
+
+    assert compare_grouped_gemm_backends.main(["--list-cases", "--json"]) == 0
+    legacy_cases = json.loads(capsys.readouterr().out)
+    assert legacy_cases
+    assert {"name", "shape_label", "problems"} <= legacy_cases[0].keys()
+
+
+def test_helion_requires_grouped_compiler_primary_and_effective_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compiler_default = {
+        "tcgen05_grouped_mode": "worklist_nm",
+        "tcgen05_grouped_worklist_source_m_tile": campaign.SOURCE_M_TILE,
+        "optional": None,
+    }
+    config_spec = SimpleNamespace(
+        compiler_default_config=SimpleNamespace(config=compiler_default),
+        autotuner_heuristics=[campaign.GROUPED_WORKLIST_HEURISTIC],
+        default_config=lambda: SimpleNamespace(config={}),
+    )
+    kernel = SimpleNamespace(
+        bind=lambda _args: SimpleNamespace(config_spec=config_spec)
+    )
+    inputs = SimpleNamespace(b=object())
+    packed = SimpleNamespace(a=object(), worklist=object())
+    monkeypatch.setattr(campaign, "_make_helion_kernel", lambda: kernel)
+    monkeypatch.setattr(common, "pack_compact_rows", lambda *_args: packed)
+
+    config_spec.autotuner_heuristics = []
+    with pytest.raises(RuntimeError, match="did not fire exactly once"):
+        campaign.prepare_helion(cast("Any", inputs))
+    config_spec.autotuner_heuristics = [campaign.GROUPED_WORKLIST_HEURISTIC]
+    for invalid_compiler_default in (
+        {},
+        {"tcgen05_grouped_mode": "worklist_nm"},
+        {
+            "tcgen05_grouped_mode": "worklist_nm",
+            "tcgen05_grouped_worklist_source_m_tile": 128,
+        },
+    ):
+        config_spec.compiler_default_config = SimpleNamespace(
+            config=invalid_compiler_default
+        )
+        config_spec.default_config = lambda: SimpleNamespace(config=compiler_default)
+        with pytest.raises(RuntimeError, match="primary config"):
+            campaign.prepare_helion(cast("Any", inputs))
+    config_spec.compiler_default_config = SimpleNamespace(config=compiler_default)
+    for effective in (
+        {},
+        {"tcgen05_grouped_mode": "worklist_nm"},
+        {
+            "tcgen05_grouped_mode": "worklist_nm",
+            "tcgen05_grouped_worklist_source_m_tile": campaign.SOURCE_M_TILE,
+        },
+    ):
+        config_spec.default_config = lambda effective=effective: SimpleNamespace(
+            config=effective
+        )
+        with pytest.raises(RuntimeError, match="not the grouped-worklist default"):
+            campaign.prepare_helion(cast("Any", inputs))
+    config_spec.autotuner_heuristics *= 2
+    with pytest.raises(RuntimeError, match="did not fire exactly once"):
+        campaign.prepare_helion(cast("Any", inputs))
+
+
+@pytest.mark.parametrize(
+    ("provider", "module", "preparer", "root_parameter"), PROVIDER_ADAPTERS
+)
+def test_provider_dispatches_all_public_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    module: object,
+    preparer: str,
+    root_parameter: str | None,
+) -> None:
+    assert tuple(case[0] for case in PROVIDER_ADAPTERS) == campaign.PROVIDERS
+    calls: list[tuple[object, dict[str, object]]] = []
+    inputs = cast("Any", object())
+    roots = {name: Path(f"/{name}") for name in ("deepgemm", "quack", "cutlass")}
+    prepared = _prepared_provider(provider)
+
+    def prepare(
+        actual_inputs: object, **kwargs: object
+    ) -> common.PreparedImplementation:
+        calls.append((actual_inputs, kwargs))
+        return prepared
+
+    monkeypatch.setattr(module, preparer, prepare)
+
+    def dispatch() -> common.PreparedImplementation:
+        return campaign.prepare_provider_default(
+            provider,
+            inputs,
+            deepgemm_root=roots["deepgemm"],
+            quack_root=roots["quack"],
+            cutlass_root=roots["cutlass"],
+        )
+
+    result = dispatch()
+    expected_kwargs = (
+        {} if root_parameter is None else {root_parameter: roots[provider]}
+    )
+    assert calls == [(inputs, expected_kwargs)]
+    assert result is prepared
+    prepared.config["b_layout"] = "n_major"
+    with pytest.raises(RuntimeError, match="invalid selection contract"):
+        dispatch()
+
+
+def test_source_identity_rejects_dirty_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        campaign,
+        "_git_value",
+        lambda *arguments: "dirty.py" if arguments[0] == "status" else "identity",
+    )
+
+    with pytest.raises(RuntimeError, match="clean Helion checkout"):
+        campaign._source_identity()
+
+
+@pytest.mark.parametrize(
+    "provider_output_ok", (True, False), ids=("success", "timing-mutation")
+)
+def test_run_case_preserves_validation_and_rejects_timing_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_output_ok: bool,
+) -> None:
+    from pretuned_kernels import _bench
+
+    events: list[tuple[object, ...]] = []
+    case = OFFICIAL_CASES[0]
+    device = torch.device("cuda", 0)
+    inputs = SimpleNamespace(oracle=(object(),))
+    helion = SimpleNamespace(name="helion", config={"config": "helion"})
+    provider = SimpleNamespace(name="provider", config={})
+
+    def helion_replay() -> None:
+        raise AssertionError("the test timer must not execute GPU work")
+
+    def provider_replay() -> None:
+        raise AssertionError("the test timer must not execute GPU work")
+
+    captures = {
+        "helion": SimpleNamespace(replay=helion_replay, name="helion"),
+        "provider": SimpleNamespace(replay=provider_replay, name="provider"),
+    }
+
+    def make_inputs(
+        actual_case: common.GroupedGemmCase,
+        actual_device: torch.device,
+        *,
+        seed: int,
+    ) -> object:
+        events.append(("inputs", actual_case.id, actual_device, seed))
+        return inputs
+
+    def validated_capture(prepared: Any, oracle: object) -> tuple[object, object]:
+        assert oracle is inputs.oracle
+        events.append(("validate", prepared.name))
+        return captures[prepared.name], _accuracy_evidence(replay=True)
+
+    def benchmark(calls: Any, *, rep: int) -> list[float]:
+        callbacks = list(calls)
+        events.append(
+            (
+                "timer",
+                rep,
+                callbacks[0] is helion_replay,
+                callbacks[1] is provider_replay,
+            )
+        )
+        return [1.0, 2.0]
+
+    failed_check: dict[str, object] = {
+        "ok": False,
+        "groups": [],
+        "max_abs_diff": 1.0,
+    }
+    checks = iter(
+        (
+            _accuracy_evidence(),
+            _accuracy_evidence() if provider_output_ok else failed_check,
+        )
+    )
+
+    def check(captured: Any, oracle: object) -> dict[str, object]:
+        assert oracle is inputs.oracle
+        events.append(("post", captured.name))
+        return next(checks)
+
+    monkeypatch.setattr(common, "make_inputs", make_inputs)
+    monkeypatch.setattr(
+        campaign,
+        "prepare_helion",
+        lambda _inputs: events.append(("prepare", "helion")) or helion,
+    )
+    monkeypatch.setattr(
+        campaign,
+        "prepare_provider_default",
+        lambda name, _inputs, **_kwargs: events.append(("prepare", name)) or provider,
+    )
+    monkeypatch.setattr(campaign, "_validated_capture", validated_capture)
+    monkeypatch.setattr(torch.random, "fork_rng", lambda **_kwargs: nullcontext())
+    monkeypatch.setattr(
+        _bench,
+        "thermal_warmup",
+        lambda duration: events.append(("thermal_warmup", duration)),
+    )
+    monkeypatch.setattr(_bench, "bench_pre_captured_cudagraphs", benchmark)
+    monkeypatch.setattr(common, "check_correctness", check)
+
+    def run() -> dict[str, object]:
+        return campaign.run_case(
+            "cudnn",
+            case,
+            device,
+            cutlass_root=None,
+            deepgemm_root=None,
+        )
+
+    if not provider_output_ok:
+        with pytest.raises(RuntimeError, match="provider output changed during"):
+            run()
+        return
+
+    row = run()
+
+    assert events == [
+        ("inputs", case.id, device, case.row_index),
+        ("prepare", "helion"),
+        ("prepare", "cudnn"),
+        ("validate", "helion"),
+        ("validate", "provider"),
+        ("thermal_warmup", 10_000),
+        ("timer", 102, True, True),
+        ("post", "helion"),
+        ("post", "provider"),
+    ]
+    assert row["timings"] == {"helion_ms": 1.0, "provider_ms": 2.0}
+
+
+def test_worker_environment_scrubs_controls_and_uses_fresh_caches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    cuda_stack: tuple[Path, dict[str, Path]],
+) -> None:
+    cuda_home, artifacts = cuda_stack
+    monkeypatch.setenv("HELION_BACKEND", "triton")
+    monkeypatch.setenv("PYTHONPATH", "/stale")
+    monkeypatch.setenv("LD_PRELOAD", "/stale.so")
+    first = campaign._worker_environment(
+        tmp_path / "first",
+        cuda_visible_devices="GPU-test",
+    )
+    second = campaign._worker_environment(
+        tmp_path / "second",
+        cuda_visible_devices="GPU-test",
+    )
+
+    assert first["HELION_BACKEND"] == "cute"
+    assert first["PYTHONPATH"] == str(campaign.REPO_ROOT)
+    assert first["PYTHONNOUSERSITE"] == "1"
+    assert first["CUDA_VISIBLE_DEVICES"] == "GPU-test"
+    assert first["CUDA_HOME"] == first["CUDA_PATH"] == str(cuda_home)
+    assert first["CUDNN_FRONTEND_CUDART_LIB_NAME"] == str(artifacts["cudart"])
+    assert first["PATH"].split(os.pathsep)[0] == str(cuda_home / "bin")
+    assert first["LD_PRELOAD"].split(os.pathsep) == [
+        str(artifacts[name]) for name in common.CUDA_STACK_PRELOAD_LIBRARY_PREFIXES
+    ]
+    first_caches = {first[name] for name in campaign.WORKER_CACHE_NAMES}
+    second_caches = {second[name] for name in campaign.WORKER_CACHE_NAMES}
+    assert first_caches.isdisjoint(second_caches)
+    assert all(Path(path).is_dir() for path in first_caches | second_caches)
+
+
+def test_cuda_toolchain_identity_validates_nvcc_once(
+    monkeypatch: pytest.MonkeyPatch,
+    cuda_stack: tuple[Path, dict[str, Path]],
+) -> None:
+    cuda_home, artifacts = cuda_stack
+    toolkit_calls: list[Path] = []
+
+    def toolkit_identity(root: Path) -> dict[str, str]:
+        toolkit_calls.append(root)
+        return {
+            "release": common.CUDA_TOOLKIT_RELEASE,
+            "compiler_version": common.CUDA_COMPILER_VERSION,
+        }
+
+    monkeypatch.setattr(
+        campaign,
+        "_cuda_toolkit_identity",
+        toolkit_identity,
+    )
+    artifacts_by_prefix = {
+        prefix: artifacts[name]
+        for name, prefix in common.CUDA_STACK_PRELOAD_LIBRARY_PREFIXES.items()
+    }
+    monkeypatch.setattr(
+        common,
+        "mapped_library_paths",
+        lambda prefix: (artifacts_by_prefix[prefix],),
+    )
+    monkeypatch.setenv("CUDA_HOME", str(cuda_home))
+    monkeypatch.setenv("CUDNN_FRONTEND_CUDART_LIB_NAME", str(artifacts["cudart"]))
+    assert "artifact" not in json.dumps(campaign._cuda_toolchain_identity())
+    assert toolkit_calls == [cuda_home]
+    monkeypatch.setattr(common, "mapped_library_paths", lambda _prefix: ())
+    with pytest.raises(RuntimeError, match="worker loaded"):
+        campaign._cuda_toolchain_identity()
+
+
+def test_worker_revalidates_cuda_libraries_after_all_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    events: list[object] = []
+    artifacts = {"cudart": tmp_path / "libcudart.so"}
+    device_info = {
+        "visible": "GPU-test",
+        "name": "NVIDIA B200",
+        "capability": [10, 0],
+        "uuid": "GPU-test",
+        "multi_processor_count": 148,
+        "total_memory": 192_000_000_000,
+    }
+    startup_environment = campaign._selection_environment()
+    monkeypatch.setattr(
+        campaign,
+        "HELION_SELECTION_STARTUP_ENVIRONMENT",
+        startup_environment,
+    )
+    monkeypatch.delenv("HELION_HEURISTIC_DIR", raising=False)
+    monkeypatch.setattr(common, "require_single_visible_device", lambda: "GPU-test")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "set_device", lambda _device: None)
+    monkeypatch.setattr(campaign, "_device_info", lambda _device: device_info)
+    monkeypatch.setattr(
+        campaign,
+        "_cuda_toolchain_identity",
+        lambda: events.append("startup") or _versions()["cuda_stack"],
+    )
+    monkeypatch.setattr(common, "configure_oracle_precision", lambda: "highest")
+    monkeypatch.setattr(
+        campaign, "_installed_cuda_stack", lambda: (tmp_path, artifacts)
+    )
+    monkeypatch.setattr(
+        campaign,
+        "_validate_mapped_cuda_libraries",
+        lambda actual: events.append(("post", actual)),
+    )
+    monkeypatch.setattr(
+        campaign,
+        "run_case",
+        lambda _provider, case, _device, **_kwargs: (
+            events.append(("row", case.row_index)) or {}
+        ),
+    )
+    monkeypatch.setattr(campaign, "_source_identity", lambda: SOURCE_IDENTITY)
+    monkeypatch.setattr(campaign, "_cuda_driver_version", lambda _uuid: "590.00")
+    monkeypatch.setattr(campaign.importlib.metadata, "version", lambda _name: "1.0")
+
+    assert (
+        campaign._run_worker(
+            argparse.Namespace(
+                provider="cudnn",
+                replicate=0,
+                run_dir=run_dir,
+                deepgemm_root=None,
+                quack_root=None,
+                cutlass_root=None,
+            )
+        )
+        == 0
+    )
+    assert events == [
+        "startup",
+        *(("row", case.row_index) for case in OFFICIAL_CASES),
+        ("post", artifacts),
+    ]
+
+
+def test_cublaslt_layout_maps_k_major_storage() -> None:
+    transpose, dimensions = cublaslt_grouped_gemm.cublaslt_layout_values(
+        ((2, 3, 4, 1), (5, 6, 7, 1))
+    )
+
+    assert transpose == cublaslt_grouped_gemm._CUBLAS_OP_T
+    assert dimensions == {
+        "a_rows": [4, 7],
+        "a_columns": [3, 6],
+        "a_leading_dimensions": [4, 7],
+        "b_rows": [4, 7],
+        "b_columns": [2, 5],
+        "b_leading_dimensions": [4, 7],
+        "output_rows": [3, 6],
+        "output_columns": [2, 5],
+        "output_leading_dimensions": [3, 6],
+    }
+    assert cublaslt_grouped_gemm.cublaslt_grouped_preference_values(
+        ((2, 3, 4, 1), (5, 6, 7, 1))
+    ) == {
+        "average_reduction_dim": 5,
+        "average_output_rows": 4,
+        "average_output_columns": 3,
+    }
+
+
+def test_cutlass_tunes_every_candidate_with_balanced_cold_l2_timing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pretuned_kernels import _bench
+
+    candidates = tuple(
+        cutlass_contiguous_grouped_gemm._CutlassCandidate(
+            registry_index=10 + index,
+            operator_name=name,
+            compiled_for="sm100",
+            prepared=common.PreparedImplementation(
+                name=name,
+                call=lambda: None,
+                output_tensors=lambda _result: (),
+                logical_outputs=lambda _result: (),
+                config={"tile": index},
+            ),
+        )
+        for index, name in enumerate(("alpha", "beta", "gamma"))
+    )
+    captures = {
+        candidate.operator_name: SimpleNamespace(replay=object())
+        for candidate in candidates
+    }
+    captured_names: list[str] = []
+
+    def capture(prepared: common.PreparedImplementation, *, warmups: int) -> object:
+        assert warmups == 2
+        captured_names.append(prepared.name)
+        return captures[prepared.name]
+
+    def benchmark(calls: object, *, rep: int) -> list[float]:
+        assert list(cast("Any", calls)) == [
+            captures[name].replay for name in ("alpha", "beta", "gamma")
+        ]
+        assert rep == 36
+        return [2.0, 1.0, 1.0]
+
+    monkeypatch.setattr(common, "capture_implementation", capture)
+    monkeypatch.setattr(
+        common,
+        "validate_capture",
+        lambda *_args: _accuracy_evidence(replay=True),
+    )
+    monkeypatch.setattr(_bench, "bench_pre_captured_cudagraphs", benchmark)
+
+    evidence = cutlass_contiguous_grouped_gemm._tune_candidates(
+        candidates,
+        cast("tuple[torch.Tensor, ...]", (object(),)),
+    )
+
+    assert evidence["repetitions"] == 36
+    assert evidence["selected_candidate_index"] == 1
+    candidate_evidence = cast("list[dict[str, object]]", evidence["candidates"])
+    assert [candidate["selection_median_ms"] for candidate in candidate_evidence] == [
+        2.0,
+        1.0,
+        1.0,
+    ]
+    assert captured_names == ["alpha", "beta", "gamma"]
+
+
+def test_campaign_has_no_reviewed_profile_or_aot_dependency() -> None:
+    source = inspect.getsource(campaign) + inspect.getsource(campaign.common)
+
+    assert "reviewed_profiles" not in source
+    assert "aot_kernel" not in source
+    assert "deepgemm_selected_path" not in inspect.getsource(campaign.common)
+
+
+def test_summary_happy_path_and_documented_tuning_variation() -> None:
+    results = _campaign_results()
+    for row in _campaign_result(results, "quack", 1)["rows"]:
+        row["configs"]["provider"]["selected_config"]["block"] = 256
+    cutlass_tuning = _campaign_result(results, "cutlass", 1)["rows"][0]["configs"][
+        "provider"
+    ]["registry_tuning"]
+    cutlass_tuning["candidates"][0]["selection_median_ms"] = 1.5
+
+    summary = campaign.summarize_results(results)
+
+    assert summary["cases"] == [case.as_dict() for case in OFFICIAL_CASES]
+    assert set(summary["provider_results"]) == set(campaign.PROVIDERS)
+    quack = summary["provider_results"]["quack"]
+    assert quack["varying_config_rows"] == list(range(len(OFFICIAL_CASES)))
+    assert quack["cross_replicate_geomean"] == pytest.approx(2.0)
+    assert quack["row_wins"] == len(OFFICIAL_CASES)
+    assert summary["provider_results"]["cutlass"]["varying_config_rows"] == []
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    (
+        ("schema", "result identity is inconsistent"),
+        ("provider", "changed provider selection"),
+        ("timing", "invalid timings"),
+        ("correctness", "missing correctness evidence"),
+        ("helion", "fixed Helion config changed"),
+    ),
+)
+def test_summary_fails_closed_on_material_evidence(
+    mutation: str,
+    error: str,
+) -> None:
+    results = _campaign_results()
+    row = results[0]["rows"][0]
+    if mutation == "schema":
+        results[0]["schema"] = "wrong"
+    elif mutation == "provider":
+        row["configs"]["provider"]["provenance"]["git_head"] = "wrong"
+    elif mutation == "timing":
+        row["timings"]["helion_ms"] = float("nan")
+    elif mutation == "correctness":
+        row["correctness"]["provider"]["post_timing"]["ok"] = False
+    else:
+        _campaign_result(results, "deepgemm", 1)["rows"][0]["configs"]["helion"][
+            "config"
+        ]["block"] = 256
+
+    with pytest.raises(RuntimeError, match=error):
+        campaign.summarize_results(results)
+
+
+@pytest.mark.parametrize(("provider", "path"), PROVIDER_PIN_PATHS)
+def test_provider_contract_rejects_changed_pin(
+    provider: str,
+    path: tuple[str, ...],
+) -> None:
+    case = OFFICIAL_CASES[0]
+    config = _provider_config(provider, 0)
+    device = _result(provider, 0)["device"]
+    assert campaign._valid_provider_contract(
+        config,
+        provider,
+        expected_case=case.as_dict(),
+        device=device,
+        complete=True,
+    )
+    parent: dict[str, Any] = config
+    for field in path[:-1]:
+        parent = cast("dict[str, Any]", parent[field])
+    parent[path[-1]] = 1 if parent[path[-1]] == 0 else "wrong"
+    assert not campaign._valid_provider_contract(
+        config,
+        provider,
+        expected_case=case.as_dict(),
+        device=device,
+        complete=True,
+    )
+
+
+def test_summary_rejects_selection_identity_drift() -> None:
+    results = _campaign_results()
+    quack = _campaign_result(results, "quack", 1)["rows"][0]["configs"]["provider"]
+    quack["package"]["build_identity"] = "different"
+    with pytest.raises(RuntimeError, match="provenance changed across replicates"):
+        campaign.summarize_results(results)
+
+    results = _campaign_results()
+    tuning = _campaign_result(results, "cutlass", 1)["rows"][0]["configs"]["provider"][
+        "registry_tuning"
+    ]
+    tuning["candidates"][0]["selection_median_ms"] = 2.0
+    tuning["candidates"][1]["selection_median_ms"] = 1.0
+    tuning["selected_candidate_index"] = 1
+    with pytest.raises(RuntimeError, match="cutlass selected config changed"):
+        campaign.summarize_results(results)
+
+
+def test_monitored_worker_rejects_transient_foreign_application(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    process = SimpleNamespace(pid=1234, poll=lambda: None)
+    clean = (campaign._ComputeApplication(1234, "worker"),)
+    foreign = (campaign._ComputeApplication(9999, "foreign"),)
+    samples = iter((clean, foreign))
+    terminated: list[object] = []
+    monkeypatch.setattr(campaign, "COMPUTE_APPLICATION_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(
+        campaign.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: process,
+    )
+    monkeypatch.setattr(
+        campaign,
+        "_query_telemetry",
+        lambda _uuid: TELEMETRY_SAMPLE,
+    )
+    monkeypatch.setattr(
+        campaign,
+        "_query_compute_applications",
+        lambda _uuid: next(samples),
+    )
+    monkeypatch.setattr(
+        campaign.os,
+        "getpgid",
+        lambda pid: 1234 if pid == 1234 else 9999,
+    )
+    monkeypatch.setattr(campaign, "_terminate_process", terminated.append)
+    monkeypatch.setattr(campaign, "_require_target_gpu_idle", lambda _uuid: None)
+    monkeypatch.setattr(campaign, "_wait_for_target_gpu_idle", lambda _uuid: None)
+    monkeypatch.setattr(campaign.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(campaign.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(RuntimeError, match="outside worker process group 1234"):
+        campaign._run_monitored_worker(
+            ("worker",),
+            environment={},
+            log_path=tmp_path / "worker.log",
+            target_gpu_uuid="GPU-test",
+        )
+
+    assert terminated == [process]
+
+
+def test_gpu_idle_gate_rejects_existing_application(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        campaign,
+        "_query_compute_applications",
+        lambda _uuid: (campaign._ComputeApplication(9999, "foreign"),),
+    )
+
+    with pytest.raises(RuntimeError, match="target GPU is not idle"):
+        campaign._require_target_gpu_idle("GPU-test")
+
+
+def test_live_telemetry_is_compact_and_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        campaign,
+        "_nvidia_smi",
+        lambda *_args: "GPU-test, P0, 1000, 2000, 500, 1000, 0x1\n",
+    )
+    sample = campaign._query_telemetry("GPU-test")
+    second = replace(
+        sample,
+        pstate="P1",
+        sm_clock_mhz=800.0,
+        memory_clock_mhz=1800.0,
+        power_draw_watts=400.0,
+        active_clock_event_reasons=0,
+    )
+    summary = campaign._summarize_telemetry((sample, second))
+    assert cast("dict[str, float]", summary["power_draw_watts"])["mean"] == 450.0
+    assert summary["active_clock_event_reasons"] == {"0x1": 1}
+    for changed, message in (
+        (replace(sample, power_draw_watts=-1.0), "invalid power or clock value"),
+        (replace(sample, power_limit_watts=900.0), "power limit changed"),
+        (replace(sample, active_clock_event_reasons=0x9), "disallowed"),
+    ):
+        with pytest.raises(RuntimeError, match=message):
+            campaign._summarize_telemetry((sample, changed))
+    with pytest.raises(RuntimeError, match="target GPU UUID"):
+        campaign._query_telemetry("GPU-other")
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error", "expected_launch_count"),
+    (
+        ("provider", "changed provider selection", 1),
+        ("source", "source identity changed", 2),
+        ("device", "GPU identity changed", 2),
+        ("versions", "software versions changed", 2),
+    ),
+)
+def test_campaign_validates_each_worker_before_launching_the_next(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mutation: str,
+    error: str,
+    expected_launch_count: int,
+) -> None:
+    launches: list[tuple[str, int]] = []
+
+    def run_worker(
+        command: list[str], **_kwargs: object
+    ) -> tuple[int, list[campaign._TelemetrySample], int]:
+        provider = command[command.index("--provider") + 1]
+        replicate = int(command[command.index("--provider-replicate") + 1])
+        launches.append((provider, replicate))
+        result = _result(provider, replicate)
+        if mutation == "provider":
+            result["rows"][0]["configs"]["provider"]["provenance"]["git_head"] = "wrong"
+        elif len(launches) == 2:
+            if mutation == "source":
+                result["source"] = "other-commit"
+            elif mutation == "device":
+                result["device"]["multi_processor_count"] += 1
+            else:
+                result["versions"]["cuda_driver"] = "591.00"
+        run_dir = Path(command[command.index("--provider-run-dir") + 1])
+        common.write_result(run_dir / "result.json", result)
+        return 0, [TELEMETRY_SAMPLE], 1
+
+    monkeypatch.setattr(campaign, "_provider_roots", lambda _args: {})
+    monkeypatch.setattr(campaign, "_resolve_target_gpu", lambda _selector: "GPU-test")
+    monkeypatch.setattr(campaign, "_source_identity", lambda: SOURCE_IDENTITY)
+    monkeypatch.setattr(campaign, "_worker_environment", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(campaign, "_run_monitored_worker", run_worker)
+
+    with pytest.raises(RuntimeError, match=error):
+        campaign._run_campaign(
+            argparse.Namespace(
+                cuda_visible_devices="0", output_dir=tmp_path / "campaign"
+            )
+        )
+
+    assert launches == list(campaign.publication_runs()[:expected_launch_count])
+
+
+def test_campaign_records_compact_per_run_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output_dir = tmp_path / "campaign"
+
+    def run_worker(
+        command: list[str], **_kwargs: object
+    ) -> tuple[int, list[campaign._TelemetrySample], int]:
+        provider = command[command.index("--provider") + 1]
+        replicate = int(command[command.index("--provider-replicate") + 1])
+        run_dir = Path(command[command.index("--provider-run-dir") + 1])
+        common.write_result(run_dir / "result.json", _result(provider, replicate))
+        return 0, [TELEMETRY_SAMPLE], replicate + 1
+
+    monkeypatch.setattr(campaign, "_provider_roots", lambda _args: {})
+    monkeypatch.setattr(campaign, "_resolve_target_gpu", lambda _selector: "GPU-test")
+    monkeypatch.setattr(campaign, "_source_identity", lambda: SOURCE_IDENTITY)
+    monkeypatch.setattr(campaign, "_worker_environment", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(campaign, "_run_monitored_worker", run_worker)
+    monkeypatch.setattr(campaign, "_print_summary", lambda _summary: None)
+
+    assert (
+        campaign._run_campaign(
+            argparse.Namespace(cuda_visible_devices="0", output_dir=output_dir)
+        )
+        == 0
+    )
+    monitoring = json.loads((output_dir / "summary.json").read_text())["monitoring"]
+    per_run = monitoring["by_provider_replicate"]
+    assert {
+        run_id: (entry["sample_count"], entry["compute_application_sample_count"])
+        for run_id, entry in per_run.items()
+    } == {
+        f"{provider}-r{replicate}": (1, replicate + 1)
+        for provider, replicate in campaign.publication_runs()
+    }
+    assert monitoring["compute_application_sample_count"] == sum(
+        replicate + 1 for _provider, replicate in campaign.publication_runs()
+    )
+    assert all("samples" not in entry for entry in per_run.values())


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__ #3481 (`fdffbedc`)
 * #3480 (`60f746d5`)
 * #3479 (`9ae406fe`)
 * #3478 (`57f0aef4`)
 * #3477 (`3e0cba9a`)
 * #3483 (`b1945f2e`, base `main`)

--- --- ---

## Summary

- Add a fixed eight-workload campaign comparing Helion with pinned DeepGEMM, QuACK, cuDNN, cuBLASLt, and CUTLASS paths.
- Run each provider/replicate in a fresh process with a 10-second warmup and 102 balanced paired cold-L2 samples.
- Keep compilation, packing, provider selection, and Helion selection outside the timed region.
- Validate correctness, poisoned/exact replay, padding, dependency provenance, dispatch identity, GPU exclusivity, and clock/power telemetry.
- Fail closed on incomplete provider evidence and validate each worker immediately.

## Validation

- Ruff, codespell, Pyrefly, and diff checks pass.
- Upstream matmul/matmul-fact tests: 50 passed, 4 subtests.
- Grouped heuristic tests: 25 passed, 65 subtests.
- Runtime/specialization and split-size tests: 39 passed, 4 subtests.
- ConfigSpec tests: 32 passed, 96 subtests.
- Provider campaign tests: 63 default and 63 CuTe.
- Fresh adversarial review: LGTM.

## Performance evidence

A publication-eligible GB300 campaign on `252981249b3a2e417e234d99800433d60302049c` used 3 fresh replicates, 8 workloads, 102 paired cold-L2 samples, a 10-second warmup, correctness/replay checks, and clean telemetry. Historical geometric-mean speedups (`provider_ms / Helion_ms`) were:

`Helion ms` is the geometric mean of the 15 Helion medians for that row (5 provider pairings x 3 fresh replicates). Provider columns are `provider_ms / Helion_ms`, geometrically averaged across the three replicates; values above 1 mean Helion is faster.

| Row | G | Actual M per group | N | K | Helion ms | DeepGEMM | QuACK | cuDNN | cuBLASLt | CUTLASS |
|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 | 4 | `9884, 9459, 7801, 7007` | 6144 | 7168 | 1.7445 | 1.0098x | 1.0285x | 1.0183x | 1.2044x | 1.4062x |
| 1 | 4 | `8247, 7724, 9586, 7225` | 7168 | 3072 | 0.8164 | 1.0114x | 1.0345x | 1.0323x | 1.2329x | 1.4205x |
| 2 | 4 | `8076, 8601, 10197, 8215` | 4096 | 4096 | 0.6566 | 1.0192x | 1.0653x | 1.0305x | 1.1936x | 1.4464x |
| 3 | 4 | `7119, 9449, 8773, 6965` | 4096 | 2048 | 0.2805 | 1.0578x | 1.0651x | 1.0325x | 1.2292x | 1.3825x |
| 4 | 8 | `5102, 5282, 4858, 5084, 3629, 4660, 5076, 4548` | 6144 | 7168 | 1.9696 | 1.0283x | 1.0485x | 1.0170x | 1.2096x | 1.4105x |
| 5 | 8 | `4027, 3114, 3934, 4368, 5111, 5242, 4039, 4993` | 7168 | 3072 | 0.8757 | 1.0176x | 1.0501x | 1.1014x | 1.2488x | 1.4100x |
| 6 | 8 | `3507, 4845, 4215, 2901, 4635, 3847, 4894, 4509` | 4096 | 4096 | 0.6334 | 1.0037x | 1.0560x | 1.0561x | 1.2289x | 1.3593x |
| 7 | 8 | `2870, 4080, 4999, 3466, 3666, 5006, 3336, 4261` | 4096 | 2048 | 0.2846 | 1.0512x | 1.0204x | 1.0380x | 1.2515x | 1.3566x |
| **GM** | -- | -- | -- | -- | **0.7310** | **1.0247x** | **1.0459x** | **1.0404x** | **1.2247x** | **1.3987x** |

All eight rows beat every measured provider. On the final reviewed stack `fdffbedc`, all 8 selected configurations and all 120 archived generated modules reproduce exactly after removing only `# src[...]` provenance comments.

This is archived timing plus exact config/codegen equivalence, not a fresh timing run. PR5 intentionally strengthens cuBLASLt and CUTLASS selection, so their historical ratios are reference values rather than final claims for the new harness. No B200 timing claim is made.