### PR TITLE
[cutedsl] Reject conflicting thread-axis layouts

### DIFF
--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -428,6 +428,31 @@ class TileStrategyDispatch:
                 axis += strategy.thread_axes_used()
         return None
 
+    def strategies_can_coexecute(
+        self, first: TileStrategy, second: TileStrategy
+    ) -> bool:
+        """Whether two strategies occur in at least one common execution branch."""
+        return any(
+            first in branch and second in branch for branch in self._strategy_branches()
+        )
+
+    def executable_reduction_block_ids(self) -> set[int]:
+        """Reduction block IDs that correspond to executable reduction work."""
+        spec = CompileEnvironment.current().config_spec
+        block_ids = set(spec.reduction_loops.valid_block_ids())
+        if spec.reduction_kernel_fact is not None:
+            block_ids.update(
+                reduction.block_id
+                for reduction in spec.reduction_kernel_fact.reductions
+            )
+        if spec.kernel_matmul_fact is not None:
+            block_ids.update(
+                matmul.fact.k_block_id
+                for matmul in spec.kernel_matmul_fact.matmuls
+                if matmul.fact.k_block_id is not None
+            )
+        return block_ids
+
     def thread_axis_for_block_id(self, target_block_id: int) -> int | None:
         """Return the launch thread axis assigned to a specific logical block id."""
         for strategy in self.strategies:

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -2460,7 +2460,33 @@ class BlockSizeTileStrategy(TileStrategy):
         reserved_reduction_axes = max(
             1 if has_reduction_strategy else 0, active_reduction_axes
         )
-        return reserved_reduction_axes + active_non_reduction_axes
+        offset = reserved_reduction_axes + active_non_reduction_axes
+        tile_axes = set(range(offset, offset + self.thread_axes_used()))
+        executable_reductions = self.fn.tile_strategy.executable_reduction_block_ids()
+        for strategy in self.fn.tile_strategy.strategies:
+            if not isinstance(strategy, ReductionStrategy):
+                continue
+            if strategy.block_index not in executable_reductions:
+                continue
+            if not self.fn.tile_strategy.strategies_can_coexecute(self, strategy):
+                continue
+            if not any(size > 1 for size in strategy.thread_block_sizes()):
+                continue
+            reduction_axis = self.fn.tile_strategy.thread_axis_for_strategy(strategy)
+            if reduction_axis is None:
+                continue
+            reduction_axes = set(
+                range(reduction_axis, reduction_axis + strategy.thread_axes_used())
+            )
+            if collision := tile_axes & reduction_axes:
+                axes = ", ".join(map(str, sorted(collision)))
+                raise exc.BackendUnsupported(
+                    env.backend.name,
+                    "thread-axis collision: tile blocks "
+                    f"{self.block_ids} and executable reduction block "
+                    f"{strategy.block_index} both require axis {axes}",
+                )
+        return offset
 
     def select_pid_strategy(self) -> ProgramIDs:
         env = CompileEnvironment.current()

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -11307,6 +11307,29 @@ def _cute_fp8_gemm_skinny_m(
     return out
 
 
+@helion.kernel(backend="cute", static_shapes=True)
+def _cute_rank_broadcast_reduction_axis_collision(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    ks: torch.Tensor,
+    ke: torch.Tensor,
+) -> torch.Tensor:
+    m, h, d = q.size()
+    n = k.size(0)
+    h = hl.specialize(h)
+    d = hl.specialize(d)
+    out = torch.empty((m, n), dtype=torch.float32, device=q.device)
+    for tile_m, tile_n in hl.tile((m, n)):
+        score = torch.matmul(q[tile_m, :, :], k[tile_n, :].transpose(0, 1))
+        acc = (torch.relu(score.float()) * weights[tile_m, :][:, :, None]).sum(dim=1)
+        in_window = (tile_n.index[None, :] >= ks[tile_m][:, None]) & (
+            tile_n.index[None, :] < ke[tile_m][:, None]
+        )
+        out[tile_m, tile_n] = torch.where(in_window, acc, float("-inf"))
+    return out
+
+
 @onlyBackends(["cute"])
 class TestCuteThreadBudgetRejection(TestCase):
     """The CuTe launcher raises ``BackendUnsupported`` when a config
@@ -11334,6 +11357,35 @@ class TestCuteThreadBudgetRejection(TestCase):
                 num_threads=[0, 256],
                 cute_vector_widths=[1, 4],
             )
+
+    def test_rank_broadcast_reduction_axis_collision_rejected(self) -> None:
+        """Reject a tile/reduction axis collision before emitting a kernel."""
+        q = torch.empty(
+            (1, 32, 128),
+            dtype=torch.bfloat16,
+            device="meta",  # @ignore-device-lint
+        )
+        k = torch.empty(
+            (512, 128),
+            dtype=torch.bfloat16,
+            device="meta",  # @ignore-device-lint
+        )
+        weights = torch.empty(
+            (1, 32),
+            dtype=torch.float32,
+            device="meta",  # @ignore-device-lint
+        )
+        ks = torch.empty((1,), dtype=torch.int32, device="meta")  # @ignore-device-lint
+        ke = torch.empty((1,), dtype=torch.int32, device="meta")  # @ignore-device-lint
+        bound = _cute_rank_broadcast_reduction_axis_collision.bind(
+            (q, k, weights, ks, ke)
+        )
+        with self.assertRaisesRegex(
+            BackendUnsupported,
+            r"thread-axis collision: tile blocks \[0, 1\] and executable "
+            r"reduction block 3 both require axis 1",
+        ):
+            bound.to_triton_code(helion.Config(block_sizes=[1, 128]))
 
     def test_in_budget_multi_row_passes(self) -> None:
         """A multi-row config that DOES fit in 1024 threads must still

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1057,6 +1057,10 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @skipIfPallasInterpret("numerical mismatch in JAX interpret mode")
+    @skipIfCute(
+        "rank-broadcasted matmul followed by a broadcast-axis reduction "
+        "requires owner-aware CuTe lane lowering"
+    )
     def test_sparse_attn_indexer_decode(self):
         mod = import_path(EXAMPLES_DIR / "sparse_attn_indexer.py")
         args = mod.indexer_inputs(num_tokens=1, kv_len=512)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3481 (`a67b1826`)
 * #3480 (`12dfccf3`)
 * #3479 (`1f004249`)
 * #3478 (`ded9b6e9`)
 * #3477 (`3e0cba9a`)
 * __->__ #3483 (`b1945f2e`, base `main`)

--- --- ---

## Summary

- reject co-executing CuTe tile/reduction strategies that claim the same hardware thread axis before emitting code
- keep mutually exclusive branch strategies eligible to reuse an axis
- skip only the unsupported sparse-attention decode path on CuTe until owner-aware lane-reduction lowering is implemented
- add a meta-only regression that proves the unsafe rank-broadcast layout fails closed

This fixes the first `CUDA_ERROR_ILLEGAL_ADDRESS` in the CuTe B200 suite. The old lowering launched `(128, 4, 1)` threads while indexing a 128x128 shared-memory tile as high as element 32767, poisoning the CUDA context and causing hundreds of cascading failures.

## Testing

- `HELION_BACKEND=cute pytest -q test/test_cute_backend.py -k 'thread_budget or tile or reduction'` (23 passed)
- CuTe sparse examples (1 passed, 1 intended skip)
- Triton sparse examples (2 passed)
- `./lint.sh check`
- adversarial review: LGTM