### PR TITLE
[cutedsl] Time CuTe benchmarks with CUDA events and equalize GPU thermal state before harness measurements

### DIFF
--- a/benchmarks/cute/compare_attention_backends.py
+++ b/benchmarks/cute/compare_attention_backends.py
@@ -163,6 +163,8 @@ ALL_IMPLS = (
 )
 HELION_IMPLS = ("helion-cute", "helion-tileir", "helion-triton")
 _STRICT_FINAL_CORRECTNESS_LAUNCHES = 64
+_DEFAULT_MEASURE_COOLDOWN_MARGIN_C = 3.0
+_COOLDOWN_MAX_WAIT_S = 300.0
 _CUTE_FLASH_LANE_POLICY_VERSION = 14
 _FLASH_TERMINAL_REFINEMENT_SCHEMA_VERSION = 2
 _FLASH_TERMINAL_REFINEMENT_POLICY_VERSION = 2
@@ -615,44 +617,188 @@ def _validate_strict_gpu_selection(require_full_autotune: bool) -> None:
         )
 
 
+def _selected_physical_gpu() -> str:
+    """The physical GPU index the benchmark runs on, for nvidia-smi -i."""
+    visible = _physical_gpu_selection()
+    physical_gpu = visible.split(",", 1)[0].strip()
+    if not physical_gpu:
+        if not torch.cuda.is_available():
+            raise RuntimeError("no CUDA device selected")
+        physical_gpu = str(torch.cuda.current_device())
+    return physical_gpu
+
+
+def _query_gpu_field(field: str) -> float:
+    """Query one numeric nvidia-smi field for the selected physical GPU.
+
+    Raises on any failure; callers decide whether that is fatal.
+    """
+    proc = subprocess.run(
+        [
+            "nvidia-smi",
+            "-i",
+            _selected_physical_gpu(),
+            f"--query-gpu={field}",
+            "--format=csv,noheader,nounits",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    output_lines = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return float(output_lines[0])
+
+
 def _verify_power_cap_w(requested: int | None) -> int | None:
     """Return the measured power limit, rejecting mislabeled benchmark runs."""
     if requested is None:
         return None
 
-    visible = _physical_gpu_selection()
-    physical_gpu = visible.split(",", 1)[0].strip()
-    if not physical_gpu:
-        if not torch.cuda.is_available():
-            raise SystemExit("cannot verify a GPU power cap without CUDA")
-        physical_gpu = str(torch.cuda.current_device())
     try:
-        proc = subprocess.run(
-            [
-                "nvidia-smi",
-                "-i",
-                physical_gpu,
-                "--query-gpu=power.limit",
-                "--format=csv,noheader,nounits",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        output_lines = [
-            line.strip() for line in proc.stdout.splitlines() if line.strip()
-        ]
-        actual = float(output_lines[0])
-    except (IndexError, OSError, subprocess.CalledProcessError, ValueError) as exc:
+        actual = _query_gpu_field("power.limit")
+    except (
+        IndexError,
+        OSError,
+        RuntimeError,
+        subprocess.SubprocessError,
+        ValueError,
+    ) as exc:
         raise SystemExit(
-            f"failed to verify the power limit for physical GPU {physical_gpu}"
+            "failed to verify the power limit for physical GPU "
+            f"{_physical_gpu_selection() or '<current>'}"
         ) from exc
     if abs(actual - requested) > 0.5:
         raise SystemExit(
-            f"physical GPU {physical_gpu} has a {actual:g} W power limit; "
-            f"requested benchmark label is {requested} W"
+            f"physical GPU {_selected_physical_gpu()} has a {actual:g} W power "
+            f"limit; requested benchmark label is {requested} W"
         )
     return int(round(actual))
+
+
+def _gpu_temperature_c() -> float | None:
+    """Current core temperature of the selected physical GPU, or None."""
+    try:
+        return _query_gpu_field("temperature.gpu")
+    except (
+        IndexError,
+        OSError,
+        RuntimeError,
+        subprocess.SubprocessError,
+        ValueError,
+    ):
+        return None
+
+
+_STARTUP_GPU_TEMP_C: float | None = None
+
+
+def _capture_startup_gpu_temperature() -> None:
+    """Record the GPU temperature before this process does any GPU work.
+
+    The pre-measurement cooldown targets this reference plus a small margin:
+    "restore the thermal state the process started in" is the invariant that
+    makes a row measured after hours of in-process work (a full autotune
+    search) comparable to a baseline measured in a fresh process, and unlike
+    an absolute threshold it holds on chassis with different idle
+    temperatures. Leaves the reference as None (disabling the cooldown) when
+    the temperature cannot be read.
+    """
+    global _STARTUP_GPU_TEMP_C
+    _STARTUP_GPU_TEMP_C = _gpu_temperature_c()
+
+
+def _wait_for_gpu_cooldown(
+    max_temp_c: float,
+    *,
+    timeout_s: float = _COOLDOWN_MAX_WAIT_S,
+    poll_s: float = 5.0,
+    plateau_window_s: float = 30.0,
+    plateau_delta_c: float = 1.0,
+) -> dict[str, Any] | None:
+    """Idle until the GPU cools to ``max_temp_c`` (or plateaus / times out).
+
+    Sustained load before a measurement (a multi-hour autotune search, or a
+    long-running prior benchmark) heat-soaks the GPU; under a power cap a
+    heat-soaked B200 sustains ~1% lower attention throughput than one that
+    starts near idle temperature, and that bias lands only on the impls that
+    do heavy pre-measurement work. Cooling back to the target (in practice
+    the process-startup temperature plus a margin) keeps such rows comparable
+    to baselines measured in fresh processes. The plateau exit covers targets
+    made unreachable by ambient drift, and ``timeout_s`` is a hard wall-clock
+    cap: every iteration advances ``waited`` by at least ``poll_s``, so the
+    wait is bounded by ``timeout_s`` plus one poll no matter what the
+    temperature does. Returns a provenance dict describing the wait, or None
+    when the GPU temperature cannot be read.
+    """
+    start_temp = _gpu_temperature_c()
+    if start_temp is None:
+        return None
+    provenance: dict[str, Any] = {
+        "requested_max_temp_c": max_temp_c,
+        "startup_reference_c": _STARTUP_GPU_TEMP_C,
+        "start_temp_c": start_temp,
+    }
+    started_at = time.perf_counter()
+    window: list[tuple[float, float]] = [(0.0, start_temp)]
+    waited = 0.0
+    temp = start_temp
+    reason = "already_cool" if start_temp <= max_temp_c else None
+    if reason is None:
+        print(
+            f"cooldown: idling until the GPU cools from {start_temp:g}C to "
+            f"{max_temp_c:g}C (plateau/timeout fallbacks, up to {timeout_s:g}s)",
+            file=sys.stderr,
+            flush=True,
+        )
+    while reason is None:
+        if waited >= timeout_s:
+            reason = "timeout"
+            break
+        time.sleep(poll_s)
+        waited = time.perf_counter() - started_at
+        polled = _gpu_temperature_c()
+        if polled is None:
+            reason = "temperature_unavailable"
+            break
+        temp = polled
+        if temp <= max_temp_c:
+            reason = "reached"
+            break
+        window.append((waited, temp))
+        window = [(t, c) for t, c in window if waited - t <= plateau_window_s]
+        if (
+            waited - window[0][0] >= plateau_window_s - poll_s / 2
+            # A plateau requires the temperature to have stopped falling
+            # (flat counts); a RISING trace (another process heating the
+            # GPU) must keep waiting until the timeout rather than exit hot.
+            and 0.0 <= window[0][1] - temp < plateau_delta_c
+        ):
+            reason = "plateau"
+            break
+    provenance["end_temp_c"] = temp
+    provenance["waited_s"] = waited
+    provenance["reason"] = reason
+    if waited > 0:
+        print(
+            f"cooldown: {start_temp:g}C -> {temp:g}C after {waited:.0f}s "
+            f"({reason}; threshold {max_temp_c:g}C)",
+            file=sys.stderr,
+            flush=True,
+        )
+    return provenance
+
+
+def _cooldown_target_temp_c(args: argparse.Namespace) -> float | None:
+    """Cooldown target: the process-startup GPU temperature plus a margin.
+
+    Returns None (cooldown disabled) when the margin is negative or the
+    startup reference was never captured / could not be read.
+    """
+    margin = getattr(args, "measure_cooldown_margin_c", None)
+    if margin is None or float(margin) < 0 or _STARTUP_GPU_TEMP_C is None:
+        return None
+    return _STARTUP_GPU_TEMP_C + float(margin)
 
 
 def _attention_flops(args: argparse.Namespace) -> float:
@@ -1592,21 +1738,31 @@ def _bench_steady(
     do_bench_fn: Callable[..., Any] | None = None,
     cache_warmup_calls: int = 5,
     thermal_warmup_ms: int = 10000,
+    cooldown_max_temp_c: float | None = None,
 ) -> dict[str, Any]:
     """Steady-state benchmark.
 
-    1. Cache warmup: call fn() a few times to populate per-launch caches.
-    2. Thermal warmup: drive the GPU to a stable clock state.
-    3. Measurement: ``num_runs`` of do_bench(warmup, rep). Returns
+    1. Cooldown (optional): idle until the GPU sheds heat soak from earlier
+       work in this process, so every impl measures from the same near-idle
+       thermal state regardless of how much pre-measurement work it did.
+    2. Cache warmup: call fn() a few times to populate per-launch caches.
+    3. Thermal warmup: drive the GPU to a stable clock state.
+    4. Measurement: ``num_runs`` of do_bench(warmup, rep). Returns
        best/mom-median/mean across runs; mom-median is the gate metric,
-       best-of-N is diagnostic only. CuTe can inject the backend wall-clock
-       timer here because CUDA-event timing mis-times CuTe kernels on Blackwell.
+       best-of-N is diagnostic only. CuTe can inject a synchronized
+       wall-clock timer here (``--helion-cute-benchmark-timer wall``) for
+       cross-checks against the default CUDA-event path.
     """
     bench_fn = do_bench_fn
     if bench_fn is None:
         from triton.testing import do_bench
 
         bench_fn = cast("Callable[..., Any]", do_bench)
+
+    cooldown = None
+    if cooldown_max_temp_c is not None and cooldown_max_temp_c > 0:
+        torch.cuda.synchronize()
+        cooldown = _wait_for_gpu_cooldown(cooldown_max_temp_c)
 
     for _ in range(cache_warmup_calls):
         fn()
@@ -1626,13 +1782,16 @@ def _bench_steady(
         assert isinstance(ms, float)
         runs.append(ms)
 
-    return {
+    stats: dict[str, Any] = {
         "best_ms": min(runs),
         "median_ms": statistics.median(runs),
         "mean_ms": sum(runs) / len(runs),
         "std_ms": statistics.stdev(runs) if len(runs) > 1 else 0.0,
         "runs_ms": runs,
     }
+    if cooldown is not None:
+        stats["thermal_cooldown"] = cooldown
+    return stats
 
 
 def _result(
@@ -1676,6 +1835,8 @@ def _result(
                 "mom_median_tflops": _tflops(args, stats["median_ms"]),
             }
         )
+        if "thermal_cooldown" in stats:
+            payload["thermal_cooldown"] = stats["thermal_cooldown"]
     if config is not None:
         payload["config"] = config
     if codegen is not None:
@@ -9699,6 +9860,7 @@ def _benchmark_sdpa(args: argparse.Namespace) -> dict[str, Any]:
             num_runs=args.num_runs,
             warmup_ms=args.warmup_ms,
             rep_ms=args.rep_ms,
+            cooldown_max_temp_c=_cooldown_target_temp_c(args),
         )
     return _result(
         "sdpa",
@@ -10016,6 +10178,7 @@ def _benchmark_kernelagent(args: argparse.Namespace) -> dict[str, Any]:
                 num_runs=args.num_runs,
                 warmup_ms=args.warmup_ms,
                 rep_ms=args.rep_ms,
+                cooldown_max_temp_c=_cooldown_target_temp_c(args),
             )
 
     selection = manifest.get("selection", {})
@@ -10206,6 +10369,7 @@ def _benchmark_flexattention(args: argparse.Namespace) -> dict[str, Any]:
             num_runs=args.num_runs,
             warmup_ms=args.warmup_ms,
             rep_ms=args.rep_ms,
+            cooldown_max_temp_c=_cooldown_target_temp_c(args),
         )
     return _result(
         impl,
@@ -10290,6 +10454,7 @@ def _benchmark_gluon(args: argparse.Namespace) -> dict[str, Any]:
         num_runs=args.num_runs,
         warmup_ms=args.warmup_ms,
         rep_ms=args.rep_ms,
+        cooldown_max_temp_c=_cooldown_target_temp_c(args),
     )
     return _result(
         "gluon",
@@ -10338,6 +10503,7 @@ def _benchmark_tlx(args: argparse.Namespace) -> dict[str, Any]:
         num_runs=args.num_runs,
         warmup_ms=args.warmup_ms,
         rep_ms=args.rep_ms,
+        cooldown_max_temp_c=_cooldown_target_temp_c(args),
     )
     best_config = getattr(module._attn_fwd_ws, "best_config", None)
     return _result(
@@ -10502,6 +10668,7 @@ def _benchmark_fa4(args: argparse.Namespace) -> dict[str, Any]:
             num_runs=args.num_runs,
             warmup_ms=args.warmup_ms,
             rep_ms=args.rep_ms,
+            cooldown_max_temp_c=_cooldown_target_temp_c(args),
         )
     notes = (
         ["Timed eager torch.relu after FA4; ReLU FLOPs are excluded."]
@@ -10549,6 +10716,7 @@ def _benchmark_tilegym_tileir(args: argparse.Namespace) -> dict[str, Any]:
         num_runs=args.num_runs,
         warmup_ms=args.warmup_ms,
         rep_ms=args.rep_ms,
+        cooldown_max_temp_c=_cooldown_target_temp_c(args),
     )
     best_config = get_best_config()
     config = (
@@ -10575,30 +10743,26 @@ def _benchmark_tilegym_tileir(args: argparse.Namespace) -> dict[str, Any]:
 
 def _helion_benchmark_timer(args: argparse.Namespace, backend: str) -> str:
     if backend == "cute":
-        return str(getattr(args, "helion_cute_benchmark_timer", "wall"))
+        return str(getattr(args, "helion_cute_benchmark_timer", "event"))
     return "event"
 
 
-def _validate_strict_helion_benchmark_timer(
-    args: argparse.Namespace, backend: str
-) -> None:
-    if (
-        backend == "cute"
-        and bool(getattr(args, "helion_require_full_autotune", 0))
-        and _helion_benchmark_timer(args, backend) != "wall"
-    ):
-        raise SystemExit(
-            "--helion-require-full-autotune requires "
-            "--helion-cute-benchmark-timer=wall because CUDA events can mis-time "
-            "CuTe kernels on Blackwell"
-        )
-
-
 def _helion_do_bench_fn(
-    bound: object, args: argparse.Namespace, backend: str
+    args: argparse.Namespace, backend: str
 ) -> Callable[..., Any] | None:
+    # ``event`` (default) uses the same CUDA-event do_bench as every other
+    # backend; event timing was re-validated against synchronized wall-clock
+    # timing on B200 (<0.1ms delta across flash families, including CLC+PDL
+    # and multi-second kernels) once compiled launchers removed the ~200ms
+    # per-launch host dispatch that originally made events unusable. ``wall``
+    # remains available for cross-checks but charges the compiled-launcher
+    # host overhead to the kernel (measured ~0.2ms per launch on B200: the
+    # same kernel reads 48.86ms wall vs 48.67ms event), which the event timer
+    # and the other backends' rows do not.
     if _helion_benchmark_timer(args, backend) == "wall":
-        return cast("Any", bound).env.backend.get_do_bench()
+        from helion.autotuner.benchmarking import do_bench_generic
+
+        return do_bench_generic
     return None
 
 
@@ -10634,9 +10798,6 @@ def _benchmark_helion(args: argparse.Namespace) -> dict[str, Any]:
     """
     _validate_epilogue_workload(args)
     require_full_autotune = bool(getattr(args, "helion_require_full_autotune", 0))
-    _validate_strict_helion_benchmark_timer(
-        args, str(getattr(args, "helion_backend", "cute"))
-    )
     _validate_strict_gpu_selection(require_full_autotune)
     initial_source: dict[str, object] | None = None
     if require_full_autotune:
@@ -10845,7 +11006,8 @@ def _benchmark_helion_in_environment(
             num_runs=args.num_runs,
             warmup_ms=args.warmup_ms,
             rep_ms=args.rep_ms,
-            do_bench_fn=_helion_do_bench_fn(bound, args, backend),
+            do_bench_fn=_helion_do_bench_fn(args, backend),
+            cooldown_max_temp_c=_cooldown_target_temp_c(args),
         )
         if require_full_autotune:
             _validate_post_measurement_source(autotune_provenance)
@@ -10958,7 +11120,13 @@ def _build_subprocess_cmd(args: argparse.Namespace, impl: str) -> list[str]:
         "--helion-return-lse",
         str(int(getattr(args, "helion_return_lse", 0))),
         "--helion-cute-benchmark-timer",
-        str(getattr(args, "helion_cute_benchmark_timer", "wall")),
+        str(getattr(args, "helion_cute_benchmark_timer", "event")),
+        "--measure-cooldown-margin-c",
+        str(
+            getattr(
+                args, "measure_cooldown_margin_c", _DEFAULT_MEASURE_COOLDOWN_MARGIN_C
+            )
+        ),
         "--json",
     ]
     power_cap_w = getattr(args, "power_cap_w", None)
@@ -12086,7 +12254,13 @@ def _run_shape_subprocess(
         "--helion-return-lse",
         str(int(getattr(args, "helion_return_lse", 0))),
         "--helion-cute-benchmark-timer",
-        str(getattr(args, "helion_cute_benchmark_timer", "wall")),
+        str(getattr(args, "helion_cute_benchmark_timer", "event")),
+        "--measure-cooldown-margin-c",
+        str(
+            getattr(
+                args, "measure_cooldown_margin_c", _DEFAULT_MEASURE_COOLDOWN_MARGIN_C
+            )
+        ),
         "--json",
     ]
     power_cap_w = getattr(args, "power_cap_w", None)
@@ -12442,13 +12616,28 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--measure-cooldown-margin-c",
+        type=float,
+        default=_DEFAULT_MEASURE_COOLDOWN_MARGIN_C,
+        help=(
+            "Before the measurement phase, idle until the GPU core "
+            "temperature returns to its process-startup value plus this "
+            "margin, so heavy pre-measurement work (e.g. a full autotune "
+            "search) cannot heat-soak the GPU and depress only that impl's "
+            "numbers. A no-op for processes that start near idle. Bounded "
+            f"by plateau detection and a hard {_COOLDOWN_MAX_WAIT_S:g}s "
+            "cap; set to a negative value to disable."
+        ),
+    )
+    parser.add_argument(
         "--helion-cute-benchmark-timer",
         choices=("wall", "event"),
-        default="wall",
+        default="event",
         help=(
-            "Timer for Helion-CuTe benchmark samples. The default wall-clock "
-            "path matches CuTe autotune timing; event mode uses the same CUDA "
-            "event timing path as FlexAttention/SDPA/FA4 for opt-in comparisons."
+            "Timer for Helion-CuTe benchmark samples. The default event mode "
+            "uses the same CUDA event timing path as FlexAttention/SDPA/FA4; "
+            "wall mode uses synchronized wall-clock timing for cross-checks "
+            "(it additionally charges per-launch host overhead to the kernel)."
         ),
     )
     parser.add_argument(
@@ -12555,6 +12744,10 @@ def main() -> None:
     if args.merge_json:
         _run_merge_json(args)
         return
+    # Sample the thermal reference before any GPU work; the pre-measurement
+    # cooldown restores this state so long-running setup (autotune) cannot
+    # bias the measurement.
+    _capture_startup_gpu_temperature()
     _validate_epilogue_workload(args)
     if args.all_shapes:
         _validate_all_shapes_full_autotune(args)

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -14,7 +14,6 @@ import re
 import tempfile
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import Sequence
 
 import sympy
@@ -1054,23 +1053,15 @@ class CuteBackend(Backend):
             return "warn"
         return None
 
-    def get_do_bench(self) -> Callable[..., float | tuple[float, ...]]:
-        # The default Triton do_bench uses CUDA events that mis-time the CuTe
-        # path on Blackwell - launches show up as ~5ms when the kernel is
-        # actually 250ms+. Use synchronized wall-clock timing instead so
-        # autotune scores reflect real performance.
-        from ...autotuner.benchmarking import do_bench_generic
-
-        return do_bench_generic
-
-    def get_interleaved_bench(self) -> Callable[..., list[float]]:
-        # Same rationale as get_do_bench: the default interleaved bench uses
-        # CUDA events that mis-time the CuTe path. Use the synchronized
-        # wall-clock fallback so the autotuner's interleaved compare path
-        # produces real timings.
-        from ...autotuner.benchmarking import interleaved_bench_generic
-
-        return interleaved_bench_generic
+    # Note: this backend intentionally does NOT override get_do_bench /
+    # get_interleaved_bench. CUDA-event timing once mis-read CuTe launches
+    # (~5ms reported for 250ms kernels) because the pre-compiled-launcher
+    # per-call ``@cute.jit`` dispatch path spent ~200ms on the host per
+    # launch; with ``_CompiledCuteLauncher`` kernels launch on the Torch
+    # current stream and event timing matches synchronized wall-clock timing
+    # to <0.1ms on B200 across flash families (including CLC+PDL and
+    # multi-second launches). Event timing avoids charging per-launch host
+    # overhead to the kernel, which the wall path does.
 
     def autotune(
         self,

--- a/helion/autotuner/benchmark_job.py
+++ b/helion/autotuner/benchmark_job.py
@@ -42,30 +42,14 @@ class BenchmarkJob:
                 bench = do_bench_generic if self.use_wall_clock else do_bench
                 # return_mode="median" guarantees a float return.
                 benchmark_fn = functools.partial(fn, *args)
-                if self.use_wall_clock and self.probe_long_kernel:
-                    result = do_bench_generic(
-                        benchmark_fn,
-                        return_mode="median",
-                        warmup=self.warmup,
-                        rep=self.rep,
-                        fixed_repetitions=self.fixed_repetitions,
-                        probe_long_kernel=True,
-                    )
-                elif self.fixed_repetitions is None:
-                    result = bench(
-                        benchmark_fn,
-                        return_mode="median",
-                        warmup=self.warmup,
-                        rep=self.rep,
-                    )
-                else:
-                    result = bench(
-                        benchmark_fn,
-                        return_mode="median",
-                        warmup=self.warmup,
-                        rep=self.rep,
-                        fixed_repetitions=self.fixed_repetitions,
-                    )
+                result = bench(
+                    benchmark_fn,
+                    return_mode="median",
+                    warmup=self.warmup,
+                    rep=self.rep,
+                    fixed_repetitions=self.fixed_repetitions,
+                    probe_long_kernel=self.probe_long_kernel,
+                )
                 return cast(
                     "float",
                     result,

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -954,6 +954,10 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self.budget_exceeded_fn = _never_exceeded
 
     def _subprocess_benchmark_uses_wall_clock(self) -> bool:
+        # Always False for the stock cute backend since it inherits the
+        # default (event-timed) get_do_bench; this hook remains for a backend
+        # that opts into wall-clock timing while still supporting the simple
+        # subprocess benchmark job shape.
         backend = getattr(self.config_spec, "backend", None)
         if backend is None:
             return False
@@ -961,10 +965,11 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         return backend.name == "cute" and custom_bench is do_bench_generic
 
     def _probe_long_cute_flash_kernel(self) -> bool:
-        return bool(
-            self.config_spec.cute_flash_search_enabled
-            and self._subprocess_benchmark_uses_wall_clock()
-        )
+        # Flash attention candidates can run for multiple seconds per launch;
+        # probing from a single call (instead of the 5-call estimate loop)
+        # keeps those benchmarks to ~3 launches on both the event-timed and
+        # wall-clock paths.
+        return bool(self.config_spec.cute_flash_search_enabled)
 
     def _effective_source_dedup_enabled(self) -> bool:
         """Whether this provider may collapse source-identical candidates.
@@ -1597,11 +1602,10 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 benchmark_runner = (
                     _backend.get_do_bench() if _backend is not None else None
                 ) or do_bench
-                if (
-                    benchmark_runner is do_bench_generic
-                    and self._probe_long_cute_flash_kernel()
-                ):
-                    res = do_bench_generic(
+                # Only the cute backend enables flash search, and it uses the
+                # default do_bench, which accepts probe_long_kernel.
+                if self._probe_long_cute_flash_kernel():
+                    res = benchmark_runner(
                         functools.partial(benchmark_function, *working_args),
                         return_mode="median",
                         warmup=1,  # we are already warmed up above

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -62,12 +62,12 @@ def _mirrored_bench_call_layout(desired_calls: int) -> tuple[int, int, int]:
 def _make_l2_cache_clearer() -> Callable[[], None]:
     """Return a callable that flushes the GPU L2 cache, or a no-op.
 
-    The generic (wall-clock) bench used by the CuTe backend otherwise times
-    kernels with the operands resident in L2 (warm), biasing the autotuner
-    toward shallow-prefetch configs that starve the pipeline in the cold-L2 /
-    streamed-once regime that deployment and tritonbench (which clears L2 by
-    default) actually measure. Flushing L2 between timed calls makes the
-    autotune regime match the deployment regime.
+    The generic (wall-clock) bench for backends without event timing
+    otherwise times kernels with the operands resident in L2 (warm), biasing
+    the autotuner toward shallow-prefetch configs that starve the pipeline in
+    the cold-L2 / streamed-once regime that deployment and tritonbench (which
+    clears L2 by default) actually measure. Flushing L2 between timed calls
+    makes the autotune regime match the deployment regime.
 
     Uses Triton's CUDA-only cache-clear primitive. Returns a no-op when not on
     CUDA (e.g. TPU/Pallas backends that also use the generic bench).
@@ -632,6 +632,7 @@ def do_bench(
     *,
     default_cudagraph: bool = False,
     fixed_repetitions: int | None = None,
+    probe_long_kernel: bool = False,
 ) -> float | tuple[float, ...]:
     """
     Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with
@@ -651,6 +652,10 @@ def do_bench(
     :type return_mode: str
     :param fixed_repetitions: Skip adaptive estimation and time exactly this many
         calls after the initial setup call.
+    :param probe_long_kernel: Estimate from a single call first and skip the
+        four remaining estimate calls when that call already exceeds both
+        timing windows; CuTe flash enables it for multi-second attention
+        candidates.
     """
     from triton import runtime
     from triton.testing import _summarize_statistics
@@ -671,7 +676,27 @@ def do_bench(
 
     cache = runtime.driver.active.get_empty_cache_for_benchmark()  # pyrefly: ignore
 
-    if fixed_repetitions is None:
+    if fixed_repetitions is None and probe_long_kernel:
+
+        def run_estimate_batch(count: int) -> float:
+            batch_start = di.Event(enable_timing=True)
+            batch_end = di.Event(enable_timing=True)
+            batch_start.record()
+            for _ in range(count):
+                runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
+                benchmark_function()
+            batch_end.record()
+            di.synchronize()
+            return float(batch_start.elapsed_time(batch_end))
+
+        estimate_ms, n_warmup = _estimate_runtime_and_warmup(
+            run_estimate_batch,
+            warmup=warmup,
+            rep=rep,
+            process_group_name=process_group_name,
+        )
+        n_repeat = max(1, int(rep / estimate_ms))
+    elif fixed_repetitions is None:
         # Estimate the runtime of the function
         start_event = di.Event(enable_timing=True)
         end_event = di.Event(enable_timing=True)

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -15183,15 +15183,23 @@ class TestAutotuneBudget(TestCase):
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
         self.assertFalse(provider.budget_exceeded_fn())
 
-    def test_cute_wall_clock_benchmark_uses_subprocess_worker(self) -> None:
+    def test_cute_benchmark_uses_event_timed_subprocess_worker(self) -> None:
+        # CuTe inherits the default (None) do_bench hooks: compiled launchers
+        # run on the Torch current stream, so CUDA-event timing is accurate
+        # and subprocess benchmark jobs must NOT switch to the wall-clock
+        # path that charges per-launch host overhead to the kernel.
         from helion._compiler.backend import CuteBackend
+
+        backend = CuteBackend()
+        self.assertIsNone(backend.get_do_bench())
+        self.assertIsNone(backend.get_interleaved_bench())
 
         provider = self._make_stub_provider()
         provider.kernel.supports_subprocess_benchmark = lambda: True
-        provider.config_spec = SimpleNamespace(backend=CuteBackend())
+        provider.config_spec = SimpleNamespace(backend=backend)
 
         self.assertTrue(provider._subprocess_benchmark_enabled())
-        self.assertTrue(provider._subprocess_benchmark_uses_wall_clock())
+        self.assertFalse(provider._subprocess_benchmark_uses_wall_clock())
 
     def test_non_cute_custom_benchmark_stays_in_process(self) -> None:
         from helion.autotuner.benchmarking import do_bench_generic

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -339,8 +339,8 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         load_args.assert_called_once_with("/tmp/args.pt")
         event_bench.assert_not_called()
         wall_clock_bench.assert_called_once()
-        self.assertNotIn("fixed_repetitions", wall_clock_bench.call_args.kwargs)
-        self.assertNotIn("probe_long_kernel", wall_clock_bench.call_args.kwargs)
+        self.assertIsNone(wall_clock_bench.call_args.kwargs["fixed_repetitions"])
+        self.assertIs(wall_clock_bench.call_args.kwargs["probe_long_kernel"], False)
 
     def test_wall_clock_fixed_repetitions_run_setup_and_measurements(self) -> None:
         invocation_count = 0
@@ -392,6 +392,58 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
             )()
 
         self.assertIs(wall_clock_bench.call_args.kwargs["probe_long_kernel"], True)
+
+    def test_benchmark_job_forwards_long_kernel_probe_on_event_path(self) -> None:
+        fn = _ReturnValue(torch.empty(()))
+
+        with (
+            patch(
+                "helion.autotuner.benchmark_job._load_compiled_fn",
+                return_value=fn,
+            ),
+            patch(
+                "helion.autotuner.benchmark_job.load_trusted_kernel_args",
+                return_value=(),
+            ),
+            patch(
+                "helion.autotuner.benchmark_job.do_bench",
+                return_value=1.25,
+            ) as event_bench,
+            patch("helion.autotuner.benchmark_job.do_bench_generic") as wall_bench,
+        ):
+            BenchmarkJob(
+                fn_spec=cast("SerializedCompiledFunction", object()),
+                args_path="/tmp/args.pt",
+                use_wall_clock=False,
+                probe_long_kernel=True,
+            )()
+
+        wall_bench.assert_not_called()
+        self.assertIs(event_bench.call_args.kwargs["probe_long_kernel"], True)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_event_timed_long_kernel_skips_redundant_estimates(self) -> None:
+        # A kernel longer than both timing windows must be measured with
+        # setup + single-call estimate + one timed repeat (3 launches), not
+        # the 5-call estimate loop.
+        invocation_count = 0
+        sleep_cycles = int(50e6)  # tens of ms at ~GHz clocks
+
+        def fn() -> None:
+            nonlocal invocation_count
+            invocation_count += 1
+            torch.cuda._sleep(sleep_cycles)
+
+        result = do_bench(
+            fn,
+            warmup=1,
+            rep=1,
+            return_mode="median",
+            probe_long_kernel=True,
+        )
+
+        self.assertEqual(invocation_count, 3)
+        self.assertGreater(cast("float", result), 1.0)
 
     def test_wall_clock_long_kernel_skips_redundant_estimates(self) -> None:
         invocation_count = 0
@@ -1040,8 +1092,10 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         self.assertEqual(provider._benchmark_worker.run.call_args.kwargs["timeout"], 17)
 
     def test_long_kernel_probe_is_cute_flash_gated(self) -> None:
+        # The probe applies to flash searches on both timer paths: the
+        # event-timed do_bench now short-circuits its estimate loop the same
+        # way do_bench_generic does for multi-second candidates.
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
-        provider._subprocess_benchmark_uses_wall_clock = lambda: True
         provider.config_spec = SimpleNamespace(cute_flash_search_enabled=False)
         self.assertFalse(provider._probe_long_cute_flash_kernel())
 

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -406,6 +406,147 @@ def test_bench_steady_scores_every_timer_on_median(monkeypatch) -> None:
     assert backend_stats["runs_ms"] == [1.0, 1.0]
 
 
+def test_wait_for_gpu_cooldown_reasons(monkeypatch) -> None:
+    clock = {"now": 0.0}
+    monkeypatch.setattr(
+        compare_attention_backends.time,
+        "sleep",
+        lambda s: clock.__setitem__("now", clock["now"] + s),
+    )
+    monkeypatch.setattr(
+        compare_attention_backends.time, "perf_counter", lambda: clock["now"]
+    )
+
+    def temps(sequence):
+        it = iter(sequence)
+        return lambda: next(it)
+
+    monkeypatch.setattr(compare_attention_backends, "_gpu_temperature_c", temps([45.0]))
+    result = compare_attention_backends._wait_for_gpu_cooldown(55.0)
+    assert result["reason"] == "already_cool"
+    assert result["waited_s"] == 0.0
+    assert result["start_temp_c"] == 45.0
+
+    monkeypatch.setattr(
+        compare_attention_backends, "_gpu_temperature_c", temps([70.0, 60.0, 54.0])
+    )
+    result = compare_attention_backends._wait_for_gpu_cooldown(55.0)
+    assert result["reason"] == "reached"
+    assert result["end_temp_c"] == 54.0
+
+    # Temperature stuck just above the threshold plateaus out instead of
+    # spinning until the timeout (ambient may make the threshold unreachable).
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_gpu_temperature_c",
+        temps([70.0] + [69.9] * 100),
+    )
+    result = compare_attention_backends._wait_for_gpu_cooldown(55.0)
+    assert result["reason"] == "plateau"
+    assert result["end_temp_c"] == 69.9
+
+    monkeypatch.setattr(
+        compare_attention_backends,
+        "_gpu_temperature_c",
+        temps([90.0, 85.0, 80.0, 75.0]),
+    )
+    result = compare_attention_backends._wait_for_gpu_cooldown(55.0, timeout_s=10.0)
+    assert result["reason"] == "timeout"
+
+    # Hard cap: a temperature that rises forever (never reaches the target,
+    # never plateaus) must still terminate at the default timeout.
+    state = {"temp": 60.0}
+
+    def rising():
+        state["temp"] += 1.0
+        return state["temp"]
+
+    monkeypatch.setattr(compare_attention_backends, "_gpu_temperature_c", rising)
+    result = compare_attention_backends._wait_for_gpu_cooldown(55.0)
+    assert result["reason"] == "timeout"
+    assert result["waited_s"] <= compare_attention_backends._COOLDOWN_MAX_WAIT_S + 5.0
+
+    monkeypatch.setattr(compare_attention_backends, "_gpu_temperature_c", temps([None]))
+    assert compare_attention_backends._wait_for_gpu_cooldown(55.0) is None
+
+
+def test_bench_steady_reports_cooldown_provenance(monkeypatch) -> None:
+    marker = {"reason": "reached", "waited_s": 42.0}
+    calls = []
+
+    def fake_cooldown(max_temp_c):
+        calls.append(max_temp_c)
+        return dict(marker)
+
+    def fake_bench(fn, *, warmup, rep, return_mode):
+        return 1.0
+
+    triton_testing = pytest.importorskip(
+        "triton.testing", reason="default do_bench path requires triton"
+    )
+    monkeypatch.setattr(compare_attention_backends, "_gpu_warmup", lambda ms: None)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(triton_testing, "do_bench", fake_bench)
+    monkeypatch.setattr(
+        compare_attention_backends, "_wait_for_gpu_cooldown", fake_cooldown
+    )
+
+    stats = compare_attention_backends._bench_steady(
+        lambda: None,
+        num_runs=1,
+        warmup_ms=1,
+        rep_ms=1,
+        cache_warmup_calls=1,
+        thermal_warmup_ms=0,
+        cooldown_max_temp_c=55.0,
+    )
+    assert calls == [55.0]
+    assert stats["thermal_cooldown"] == marker
+
+    stats = compare_attention_backends._bench_steady(
+        lambda: None,
+        num_runs=1,
+        warmup_ms=1,
+        rep_ms=1,
+        cache_warmup_calls=1,
+        thermal_warmup_ms=0,
+    )
+    assert calls == [55.0]
+    assert "thermal_cooldown" not in stats
+
+
+def test_cooldown_target_is_startup_reference_plus_margin(monkeypatch) -> None:
+    args = SimpleNamespace(measure_cooldown_margin_c=3.0)
+
+    # No startup reference captured (or unreadable) -> cooldown disabled.
+    monkeypatch.setattr(compare_attention_backends, "_STARTUP_GPU_TEMP_C", None)
+    assert compare_attention_backends._cooldown_target_temp_c(args) is None
+
+    monkeypatch.setattr(compare_attention_backends, "_STARTUP_GPU_TEMP_C", 41.0)
+    assert compare_attention_backends._cooldown_target_temp_c(args) == pytest.approx(
+        44.0
+    )
+    # Negative margin disables; a missing attribute (bare namespace) disables.
+    assert (
+        compare_attention_backends._cooldown_target_temp_c(
+            SimpleNamespace(measure_cooldown_margin_c=-1.0)
+        )
+        is None
+    )
+    assert compare_attention_backends._cooldown_target_temp_c(SimpleNamespace()) is None
+
+
+def test_capture_startup_gpu_temperature(monkeypatch) -> None:
+    monkeypatch.setattr(compare_attention_backends, "_STARTUP_GPU_TEMP_C", None)
+    monkeypatch.setattr(compare_attention_backends, "_gpu_temperature_c", lambda: 39.0)
+    compare_attention_backends._capture_startup_gpu_temperature()
+    assert compare_attention_backends._STARTUP_GPU_TEMP_C == 39.0
+
+    monkeypatch.setattr(compare_attention_backends, "_gpu_temperature_c", lambda: None)
+    compare_attention_backends._capture_startup_gpu_temperature()
+    assert compare_attention_backends._STARTUP_GPU_TEMP_C is None
+
+
 def test_attention_epilogue_shape_metadata_preserves_identity_schema():
     args = _attention_subprocess_args(biased=0)
 
@@ -611,6 +752,8 @@ def test_attention_subprocess_forwards_helion_cute_timer(monkeypatch):
 
     flag_index = cmd.index("--helion-cute-benchmark-timer")
     assert cmd[flag_index + 1] == "event"
+    cooldown_index = cmd.index("--measure-cooldown-margin-c")
+    assert cmd[cooldown_index + 1] == "3.0"
     power_index = cmd.index("--power-cap-w")
     assert cmd[power_index + 1] == "750"
     seed_index = cmd.index("--helion-seed-config")
@@ -621,17 +764,21 @@ def test_attention_subprocess_forwards_helion_cute_timer(monkeypatch):
     assert cmd[truth_index + 1] == "0"
 
 
-def test_attention_strict_cute_benchmark_requires_wall_timer():
-    args = _attention_subprocess_args(
-        helion_cute_benchmark_timer="event",
-        helion_require_full_autotune=1,
+def test_attention_helion_cute_timer_defaults_to_event(monkeypatch):
+    # Event timing is the default so helion-cute samples use the exact same
+    # CUDA-event do_bench path as the SDPA/FlexAttention/FA4 baselines; the
+    # wall timer stays available for cross-checks only.
+    monkeypatch.setattr(
+        compare_attention_backends.sys,
+        "argv",
+        ["compare_attention_backends.py", "--impl", "helion-cute"],
     )
-
-    with pytest.raises(SystemExit, match="requires.*timer=wall"):
-        compare_attention_backends._validate_strict_helion_benchmark_timer(args, "cute")
-
-    args.helion_cute_benchmark_timer = "wall"
-    compare_attention_backends._validate_strict_helion_benchmark_timer(args, "cute")
+    parser_args = compare_attention_backends.parse_args()
+    assert parser_args.helion_cute_benchmark_timer == "event"
+    assert (
+        compare_attention_backends._helion_benchmark_timer(parser_args, "cute")
+        == "event"
+    )
 
 
 def test_attention_subprocess_limits_strict_autotune_to_helion_cute(monkeypatch):
@@ -8491,33 +8638,18 @@ def test_attention_selected_source_code_preserves_repro_setting(print_output_cod
 
 
 def test_attention_helion_cute_timer_selects_bench_fn():
-    calls = []
-
-    def wall_timer(*args, **kwargs):
-        return 1.0
-
-    backend = SimpleNamespace(
-        get_do_bench=lambda: calls.append("get_do_bench") or wall_timer
-    )
-    bound = SimpleNamespace(env=SimpleNamespace(backend=backend))
+    from helion.autotuner.benchmarking import do_bench_generic
 
     wall_args = SimpleNamespace(helion_cute_benchmark_timer="wall")
     assert (
-        compare_attention_backends._helion_do_bench_fn(bound, wall_args, "cute")
-        is wall_timer
+        compare_attention_backends._helion_do_bench_fn(wall_args, "cute")
+        is do_bench_generic
     )
-    assert calls == ["get_do_bench"]
 
     event_args = SimpleNamespace(helion_cute_benchmark_timer="event")
-    assert (
-        compare_attention_backends._helion_do_bench_fn(bound, event_args, "cute")
-        is None
-    )
-    assert (
-        compare_attention_backends._helion_do_bench_fn(bound, wall_args, "triton")
-        is None
-    )
-    assert calls == ["get_do_bench"]
+    assert compare_attention_backends._helion_do_bench_fn(event_args, "cute") is None
+    # Non-cute backends always use the default CUDA-event do_bench.
+    assert compare_attention_backends._helion_do_bench_fn(wall_args, "triton") is None
 
 
 @pytest.mark.parametrize(
@@ -9768,6 +9900,7 @@ def test_attention_power_cap_is_verified(monkeypatch):
         "check": True,
         "capture_output": True,
         "text": True,
+        "timeout": 30,
     }
 
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3484


--- --- ---

[cutedsl] Time CuTe benchmarks with CUDA events and equalize GPU thermal state before harness measurements

CuTe autotuning and the attention comparison harness both timed CuTe kernels
with a synchronized wall-clock path (do_bench_generic) because CUDA events
once mis-read CuTe launches (~5ms reported for 250ms kernels). That
observation predates the compiled launcher: the per-call @cute.jit dispatch
spent ~200ms on the host per launch, so events saw only the enqueued kernel.
With _CompiledCuteLauncher kernels launch on the Torch current stream, and
event timing now matches synchronized wall-clock timing to <0.1ms on B200
across flash families (validated on the fa4, fa4_2cta-persistent, and
CLC+PDL lanes and on multi-second launches).

Wall-clock timing is not free: it charges per-launch host overhead (~0.2ms
for the CuTe launch path) and a per-sample idle sync gap to the kernel,
biasing autotune scores and benchmark rows against CuTe relative to
event-timed baselines (~0.4% on a 48ms kernel, ~0.8% at 24ms). This change:

- Drops the CuTe backend's get_do_bench/get_interleaved_bench overrides so
  candidate measurement, rebenchmarking, and subprocess benchmark jobs use
  the default event-timed do_bench/interleaved_bench. The wall-clock helpers
  remain for backends without event support and for cross-checks.
- Ports the long-kernel probe (setup + single-call estimate + one timed
  repeat when a candidate exceeds both timing windows) from do_bench_generic
  to do_bench, and gates it on flash search alone, so multi-second flash
  candidates still cost ~3 launches per benchmark instead of ~8.
- Defaults the attention harness --helion-cute-benchmark-timer to event and
  drops the strict-mode wall requirement, making helion-cute samples use the
  exact CUDA-event do_bench path of the SDPA/FlexAttention/FA4 baselines.
- Adds a pre-measurement thermal cooldown: the harness samples the GPU
  temperature at process startup (before any GPU work) and idles until the
  GPU returns to that reference plus --measure-cooldown-margin-c (default
  3C) before the warmup/measurement phase, with a plateau exit and a hard
  300s wall-clock cap, recording the wait per row as thermal_cooldown.
  Under a power cap a heat-soaked B200 sustains ~1% lower attention
  throughput than one starting near idle temperature, and strict rows were
  previously measured immediately after multi-hour autotune searches while
  every baseline ran on an idle GPU. Targeting the process-startup state
  makes the cooldown ambient-independent and a no-op for cold fresh
  processes, so retained baseline rows stay comparable.