### PR TITLE
[tests] Speed up the test suite 7x: 37m35s -> 5m22s wall (pytest -n4)

### DIFF
--- a/test/test_autodiff.py
+++ b/test/test_autodiff.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import locale
 import operator
+import os
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -14,6 +16,11 @@ from helion._testing import skipIfMTIA
 from helion._testing import skipIfNotTriton
 from helion._testing import skipIfRocm
 from helion._testing import skipIfXPU
+from helion.autotuner.effort_profile import _PROFILES
+from helion.autotuner.effort_profile import AutotuneEffortProfile
+from helion.autotuner.effort_profile import DifferentialEvolutionConfig
+from helion.autotuner.effort_profile import PatternSearchConfig
+from helion.autotuner.effort_profile import RandomSearchConfig
 import helion.language as hl
 
 # Triton writes its generated launcher source with the process locale encoding;
@@ -63,7 +70,10 @@ class TestAutodiff(RefEagerTestDisabled, TestCase):
             grad_shape = shape
         grad_out = torch.randn(*grad_shape, device=DEVICE, dtype=torch.float32)
 
-        kernel_fn.settings.autotune_effort = autotune_effort
+        # Pin the forward call to "none": ``autotune_effort`` targets the
+        # backward kernel (helion.experimental.backward applies it itself), and
+        # imported example kernels would otherwise autotune here.
+        kernel_fn.settings.autotune_effort = "none"
         kernel_fn(*[inp.clone() for inp in inputs])
         result = helion.experimental.backward(
             kernel_fn,
@@ -1166,14 +1176,33 @@ class TestAutodiff(RefEagerTestDisabled, TestCase):
                 out[tile] = torch.sin(x[tile]) * y[tile]
             return out
 
-        self._check_backward(
-            kernel,
-            lambda x, y: torch.sin(x) * y,
-            2,
-            shape=(64, 32),
-            autotune=True,
-            autotune_effort="quick",
+        # The test only needs to prove the backward kernel goes through a real
+        # autotune pass; the stock "quick" profile takes ~30s, so shrink it.
+        tiny_pattern_search = PatternSearchConfig(
+            initial_population=2, copies=1, max_generations=0
         )
+        tiny_profile = AutotuneEffortProfile(
+            pattern_search=tiny_pattern_search,
+            lfbo_pattern_search=tiny_pattern_search,
+            differential_evolution=DifferentialEvolutionConfig(
+                population_size=4, max_generations=1
+            ),
+            random_search=RandomSearchConfig(count=4),
+            rebenchmark_threshold=0.9,  # <1.0 disables the rebenchmark pass
+        )
+        with (
+            patch.dict(_PROFILES, {"quick": tiny_profile}),
+            # Pin the seed so the two-config population is reproducible.
+            patch.dict(os.environ, {"HELION_AUTOTUNE_RANDOM_SEED": "123"}),
+        ):
+            self._check_backward(
+                kernel,
+                lambda x, y: torch.sin(x) * y,
+                2,
+                shape=(64, 32),
+                autotune=True,
+                autotune_effort="quick",
+            )
 
     def test_example_bmm(self):
         from examples.bmm import bmm

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -297,11 +297,10 @@ class RecordingRandomSearch(RandomSearch):
 
     def _autotune(self) -> helion.Config:
         self.samples.append(random.random())
-        if torch.version.hip is not None:
-            # This test covers seed propagation, not benchmark behavior. Avoid
-            # competing GPU benchmarks across ROCm xdist workers.
-            return self.config_spec.default_config()
-        return super()._autotune()
+        # The seed tests only assert on the sample recorded above, which is
+        # drawn from the RNG seeded in _prepare(); skip the real search to
+        # avoid compiling/benchmarking configs the assertions never look at.
+        return self.config_spec.default_config()
 
 
 class TestMismatchTolerance(TestCase):
@@ -1072,8 +1071,10 @@ class TestAutotuneIgnoreErrors(TestCase):
                 "HELION_AUTOTUNE_LOG_LEVEL": "0",
             },
         ):
-
-            @helion.kernel()
+            # started/completed entries are recorded in the parent's benchmark
+            # loop either way; skip the benchmark worker subprocess (several
+            # seconds of interpreter+CUDA startup per search).
+            @helion.kernel(autotune_benchmark_subprocess=False)
             def add(a, b):
                 out = torch.empty_like(a)
                 for tile in hl.tile(out.size()):
@@ -1114,17 +1115,22 @@ class TestAutotuneIgnoreErrors(TestCase):
                 "FiniteSearch",
                 lambda kernel, args: FiniteSearch(kernel, args, configs=configs),
             ),
-            ("RandomSearch", lambda kernel, args: RandomSearch(kernel, args, count=3)),
+            ("RandomSearch", lambda kernel, args: RandomSearch(kernel, args, count=2)),
             (
                 "PatternSearch",
                 lambda kernel, args: PatternSearch(
-                    kernel, args, initial_population=3, max_generations=1, copies=1
+                    kernel,
+                    args,
+                    initial_population=2,
+                    max_generations=1,
+                    copies=1,
+                    num_neighbors_cap=2,
                 ),
             ),
             (
                 "DifferentialEvolutionSearch",
                 lambda kernel, args: DifferentialEvolutionSearch(
-                    kernel, args, population_size=3, max_generations=1
+                    kernel, args, population_size=2, max_generations=1
                 ),
             ),
         ]
@@ -1156,8 +1162,9 @@ class TestAutotuneIgnoreErrors(TestCase):
                 "HELION_AUTOTUNE_LOG_LEVEL": "0",
             },
         ):
-
-            @helion.kernel(configs=configs)
+            # The CSV/sidecar gating under test is parent-side logging; skip
+            # the benchmark worker subprocess (seconds of startup overhead).
+            @helion.kernel(configs=configs, autotune_benchmark_subprocess=False)
             def add(a, b):
                 out = torch.empty_like(a)
                 for tile in hl.tile(out.size()):
@@ -1524,6 +1531,10 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
                 helion.Config(block_sizes=[1, 1, 512], num_warps=8),
             ],
             autotune_log_level=0,
+            # Config selection is the behavior under test; skip the benchmark
+            # worker subprocess (seconds of startup overhead). The worker path
+            # keeps coverage via test_autotune_noncontiguous_arg/broadcast_arg.
+            autotune_benchmark_subprocess=False,
         )
         def add(a, b):
             out = torch.empty_like(a)
@@ -1546,6 +1557,8 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         disrupt processing of subsequent valid configs.
         """
 
+        # The compile-failure skip logic under test runs at the compile stage;
+        # skip the benchmark worker subprocess (seconds of startup overhead).
         @helion.kernel(
             configs=[
                 # Good config
@@ -1556,6 +1569,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
                 helion.Config(block_sizes=[1, 1, 512], num_warps=8),
             ],
             autotune_log_level=0,
+            autotune_benchmark_subprocess=False,
         )
         def add(a, b):
             out = torch.empty_like(a)
@@ -1580,8 +1594,11 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         )
         bound_kernel = _get_examples_matmul().bind(args)
         bound_kernel.settings.autotune_precompile = None
+        # Smoke test of the RandomSearch loop itself; skip the benchmark
+        # worker subprocess (seconds of startup overhead).
+        bound_kernel.settings.autotune_benchmark_subprocess = False
         random.seed(123)
-        best = RandomSearch(bound_kernel, args, 20).autotune()
+        best = RandomSearch(bound_kernel, args, 5).autotune()
         fn = bound_kernel.compile_config(best)
         torch.testing.assert_close(fn(*args), args[0] @ args[1], rtol=1e-2, atol=1e-1)
 
@@ -8907,29 +8924,34 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         fn = bound_kernel.compile_config(best)
         torch.testing.assert_close(fn(*args), sum(args), rtol=1e-2, atol=1e-1)
 
-    def test_accuracy_check_filters_bad_config_wrong_output(self) -> None:
-        bad_config = helion.Config(block_sizes=[1], num_warps=8)
-        good_config = helion.Config(block_sizes=[1], num_warps=4)
-
-        @helion.kernel(configs=[bad_config, good_config], autotune_log_level=0)
-        def add_inplace(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-            for tile in hl.tile(b.size()):
-                b[tile] = a[tile] + b[tile]
-            return b
+    def _check_accuracy_filters_bad_config(
+        self,
+        kernel: helion.Kernel,
+        bad_config: helion.Config,
+        good_config: helion.Config,
+        wrap_bad_fn: Callable[[Callable[..., object]], Callable[..., object]],
+        *,
+        exact_final_failure_count: bool,
+        check_spawn: bool = True,
+    ) -> None:
+        """Shared body for the accuracy-check filtering tests: benchmark a
+        known-bad and a known-good config (the bad one's compiled fn is
+        wrapped by ``wrap_bad_fn`` to corrupt its behavior) and assert the
+        accuracy check rejects only the bad one in fork mode. In spawn mode
+        the patched compile result cannot be serialized, so autotuning must
+        fail with an error pointing at fork mode."""
 
         def run_mode(mode: str, *, expect_error: bool) -> None:
             a = torch.randn([32], device=DEVICE)
             b = torch.randn([32], device=DEVICE)
-            bound_kernel = add_inplace.bind((a, b))
+            bound_kernel = kernel.bind((a, b))
             original_compile = bound_kernel.compile_config
             bound_kernel.settings.autotune_precompile = mode
 
-            def make_bad_config_produce_wrong_output(
-                config: helion.Config, *, allow_print: bool = True
-            ):
+            def wrapping_compile(config: helion.Config, *, allow_print: bool = True):
                 fn = original_compile(config, allow_print=allow_print)
                 if config == bad_config:
-                    return lambda *fn_args, **fn_kwargs: fn(*fn_args, **fn_kwargs) + 1
+                    return wrap_bad_fn(fn)
                 return fn
 
             import helion.autotuner.base_search as base_search_module
@@ -8937,7 +8959,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             with patch.object(
                 bound_kernel,
                 "compile_config",
-                side_effect=make_bad_config_produce_wrong_output,
+                side_effect=wrapping_compile,
             ):
                 search = FiniteSearch(
                     bound_kernel, (a, b), configs=[bad_config, good_config]
@@ -8979,10 +9001,36 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
 
                     best = search.autotune()
                     self.assertEqual(best, good_config)
-                    self.assertEqual(search._autotune_metrics.num_accuracy_failures, 1)
+                    if exact_final_failure_count:
+                        self.assertEqual(
+                            search._autotune_metrics.num_accuracy_failures, 1
+                        )
+                    else:
+                        self.assertGreaterEqual(
+                            search._autotune_metrics.num_accuracy_failures, 1
+                        )
 
         run_mode("fork", expect_error=False)
-        run_mode("spawn", expect_error=True)
+        if check_spawn:
+            run_mode("spawn", expect_error=True)
+
+    def test_accuracy_check_filters_bad_config_wrong_output(self) -> None:
+        bad_config = helion.Config(block_sizes=[1], num_warps=8)
+        good_config = helion.Config(block_sizes=[1], num_warps=4)
+
+        @helion.kernel(configs=[bad_config, good_config], autotune_log_level=0)
+        def add_inplace(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            for tile in hl.tile(b.size()):
+                b[tile] = a[tile] + b[tile]
+            return b
+
+        self._check_accuracy_filters_bad_config(
+            add_inplace,
+            bad_config,
+            good_config,
+            lambda fn: lambda *fn_args, **fn_kwargs: fn(*fn_args, **fn_kwargs) + 1,
+            exact_final_failure_count=True,
+        )
 
     def test_autotune_noncontiguous_arg(self) -> None:
         """Autotuning a kernel bound on a non-contiguous arg must succeed.
@@ -9018,7 +9066,11 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         best = search.autotune()
         self.assertIn(best, (config_a, config_b))
 
-        torch.testing.assert_close(double(x), x * 2.0)
+        # Compile the winning config directly; calling double(x) would rerun
+        # the whole FiniteSearch since the manual search above is not attached
+        # to the bound kernel.
+        fn = bound_kernel.compile_config(best)
+        torch.testing.assert_close(fn(x), x * 2.0)
 
     def test_autotune_broadcast_arg(self) -> None:
         """Autotuning a kernel bound on a broadcast/expanded arg must succeed.
@@ -9053,7 +9105,11 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         best = search.autotune()
         self.assertIn(best, (config_a, config_b))
 
-        torch.testing.assert_close(add_bias(x, b), x + b)
+        # Compile the winning config directly; calling add_bias(x, b) would
+        # rerun the whole FiniteSearch since the manual search above is not
+        # attached to the bound kernel.
+        fn = bound_kernel.compile_config(best)
+        torch.testing.assert_close(fn(x, b), x + b)
 
     def test_accuracy_check_filters_bad_config_wrong_arg_mutation(self) -> None:
         bad_config = helion.Config(block_sizes=[1], num_warps=8)
@@ -9065,81 +9121,22 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
                 b[tile] = a[tile] + b[tile]
             return b
 
-        def run_mode(mode: str, *, expect_error: bool) -> None:
-            a = torch.randn([32], device=DEVICE)
-            b = torch.randn([32], device=DEVICE)
-            bound_kernel = add_inplace.bind((a, b))
-            original_compile = bound_kernel.compile_config
-            bound_kernel.settings.autotune_precompile = mode
+        def wrap_bad_fn(fn):
+            def wrong_fn(*fn_args, **fn_kwargs):
+                result = fn(*fn_args, **fn_kwargs)
+                # Introduce an extra mutation so inputs differ from baseline
+                fn_args[1].add_(1)
+                return result
 
-            def make_bad_config_produce_wrong_input_arg_mutation(
-                config: helion.Config, *, allow_print: bool = True
-            ):
-                fn = original_compile(config, allow_print=allow_print)
-                if config == bad_config:
+            return wrong_fn
 
-                    def wrong_fn(*fn_args, **fn_kwargs):
-                        result = fn(*fn_args, **fn_kwargs)
-                        # Introduce an extra mutation so inputs differ from baseline
-                        fn_args[1].add_(1)
-                        return result
-
-                    return wrong_fn
-                return fn
-
-            import helion.autotuner.base_search as base_search_module
-
-            with patch.object(
-                bound_kernel,
-                "compile_config",
-                side_effect=make_bad_config_produce_wrong_input_arg_mutation,
-            ):
-                search = FiniteSearch(
-                    bound_kernel, (a, b), configs=[bad_config, good_config]
-                )
-                search._prepare()
-                if mode == "fork":
-                    start_cm = patch.object(
-                        search.benchmark_provider,
-                        "_create_precompile_future",
-                        side_effect=lambda config, fn: (
-                            base_search_module.PrecompileFuture.skip(
-                                search.benchmark_provider._precompile_context(),
-                                config,
-                                True,
-                            )
-                        ),
-                    )
-                else:
-                    start_cm = nullcontext()
-
-                with start_cm:
-                    if expect_error:
-                        with self.assertRaisesRegex(
-                            helion.exc.AutotuneError,
-                            'Set HELION_AUTOTUNE_PRECOMPILE="fork"',
-                        ):
-                            search.autotune()
-                        return
-
-                    bad_time = search.benchmark(bad_config).perf
-                    assert math.isinf(bad_time)
-                    self.assertEqual(search._autotune_metrics.num_accuracy_failures, 1)
-                    search._autotune_metrics.num_accuracy_failures = 0
-
-                    good_time = search.benchmark(good_config).perf
-                    assert not math.isinf(good_time)
-                    self.assertEqual(search._autotune_metrics.num_accuracy_failures, 0)
-                    search._autotune_metrics.num_accuracy_failures = 0
-
-                    best = search.autotune()
-                    self.assertEqual(best, good_config)
-                    self.assertGreaterEqual(
-                        search._autotune_metrics.num_accuracy_failures, 1
-                    )
-
-        run_mode("fork", expect_error=False)
-        run_mode("spawn", expect_error=True)
+        self._check_accuracy_filters_bad_config(
+            add_inplace,
+            bad_config,
+            good_config,
+            wrap_bad_fn,
+            exact_final_failure_count=False,
+        )
 
     def test_autotune_baseline_fn(self) -> None:
         """Test that custom baseline function is used for accuracy checking."""
@@ -9154,10 +9151,13 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             # Return the expected result using PyTorch operations
             return a + b
 
+        # The custom baseline fn is invoked on the parent-side baseline path;
+        # skip the benchmark worker subprocess (seconds of startup overhead).
         @helion.kernel(
             configs=[config1, config2],
             autotune_baseline_fn=custom_baseline,
             autotune_log_level=0,
+            autotune_benchmark_subprocess=False,
         )
         def add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
             out = torch.empty_like(a)
@@ -9190,10 +9190,13 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             # Return the correct expected result
             return a + b
 
+        # The custom baseline fn is invoked on the parent-side baseline path;
+        # skip the benchmark worker subprocess (seconds of startup overhead).
         @helion.kernel(
             configs=[bad_config, good_config],
             autotune_baseline_fn=custom_baseline,
             autotune_log_level=0,
+            autotune_benchmark_subprocess=False,
         )
         def add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
             out = torch.empty_like(a)
@@ -9201,53 +9204,14 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
                 out[tile] = a[tile] + b[tile]
             return out
 
-        a = torch.randn([32], device=DEVICE)
-        b = torch.randn([32], device=DEVICE)
-        bound_kernel = add.bind((a, b))
-        original_compile = bound_kernel.compile_config
-        bound_kernel.settings.autotune_precompile = "fork"
-
-        # Make bad_config produce wrong output
-        def make_bad_config_produce_wrong_output(
-            config: helion.Config, *, allow_print: bool = True
-        ):
-            fn = original_compile(config, allow_print=allow_print)
-            if config == bad_config:
-                return lambda *fn_args, **fn_kwargs: fn(*fn_args, **fn_kwargs) + 1
-            return fn
-
-        import helion.autotuner.base_search as base_search_module
-
-        with patch.object(
-            bound_kernel,
-            "compile_config",
-            side_effect=make_bad_config_produce_wrong_output,
-        ):
-            search = FiniteSearch(
-                bound_kernel, (a, b), configs=[bad_config, good_config]
-            )
-            search._prepare()
-            with patch.object(
-                search.benchmark_provider,
-                "_create_precompile_future",
-                side_effect=lambda config, fn: base_search_module.PrecompileFuture.skip(
-                    search.benchmark_provider._precompile_context(), config, True
-                ),
-            ):
-                # Bad config should be filtered out by accuracy check
-                bad_time = search.benchmark(bad_config).perf
-                self.assertTrue(math.isinf(bad_time))
-                self.assertEqual(search._autotune_metrics.num_accuracy_failures, 1)
-
-                # Good config should pass accuracy check
-                search._autotune_metrics.num_accuracy_failures = 0
-                good_time = search.benchmark(good_config).perf
-                self.assertFalse(math.isinf(good_time))
-                self.assertEqual(search._autotune_metrics.num_accuracy_failures, 0)
-
-                # Autotuning should select the good config
-                best = search.autotune()
-                self.assertEqual(best, good_config)
+        self._check_accuracy_filters_bad_config(
+            add,
+            bad_config,
+            good_config,
+            lambda fn: lambda *fn_args, **fn_kwargs: fn(*fn_args, **fn_kwargs) + 1,
+            exact_final_failure_count=True,
+            check_spawn=False,
+        )
 
     def test_autotune_baseline_fn_raises_on_failure(self) -> None:
         """Test that AutotuneError is raised when custom baseline function fails."""
@@ -9291,12 +9255,15 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
 
         # Test both strict (1e-5) and lenient (1e-3) tolerances
         for tol, expect_reject in [(1e-5, True), (1e-3, False)]:
-
+            # The tolerance plumbing under test is shared with the in-process
+            # accuracy path; skip the benchmark worker subprocess (seconds of
+            # startup overhead per kernel).
             @helion.kernel(
                 configs=[cfg1, cfg2],
                 autotune_baseline_fn=incorrect_baseline,
                 autotune_baseline_atol=tol,
                 autotune_baseline_rtol=tol,
+                autotune_benchmark_subprocess=False,
             )
             def add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
                 o = torch.empty_like(a)
@@ -9326,8 +9293,10 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         cfg1 = helion.Config(block_sizes=[16], num_warps=4)
         cfg2 = helion.Config(block_sizes=[32], num_warps=8)
 
-        # Test with float8_e4m3fn as a representative fp8 dtype
-        @helion.kernel(configs=[cfg1, cfg2])
+        # Test with float8_e4m3fn as a representative fp8 dtype. The automatic
+        # tolerance selection under test is parent-side; skip the benchmark
+        # worker subprocess (seconds of startup overhead).
+        @helion.kernel(configs=[cfg1, cfg2], autotune_benchmark_subprocess=False)
         def cast_to_fp8(x: torch.Tensor) -> torch.Tensor:
             out = torch.empty(x.size(), dtype=torch.float8_e4m3fn, device=x.device)
             for t in hl.tile(x.size()):
@@ -9389,7 +9358,9 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         cfg1 = helion.Config(block_sizes=[16], num_warps=4)
         cfg2 = helion.Config(block_sizes=[32], num_warps=8)
 
-        @helion.kernel(configs=[cfg1, cfg2])
+        # The fp8 handling under test lives in the shared accuracy.assert_close;
+        # skip the benchmark worker subprocess (seconds of startup overhead).
+        @helion.kernel(configs=[cfg1, cfg2], autotune_benchmark_subprocess=False)
         def mixed_output(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
             fp8_out = torch.empty(x.size(), dtype=torch.float8_e4m3fn, device=x.device)
             fp32_out = torch.empty(x.size(), dtype=torch.float32, device=x.device)
@@ -11034,7 +11005,11 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         """Test that autotuning accuracy checks use chunked comparison for large tensors."""
         import helion.autotuner.accuracy as _accuracy
 
-        numel = 2**26  # 64M float32 elements (~256 MB each)
+        numel = 2**22  # 4M float32 elements (~16 MB each)
+        # The default chunk_size (2**22) would not chunk a tensor this small,
+        # so pass a smaller one through the patched helper below; 4 chunks is
+        # enough to exercise the chunked path and its memory bound.
+        chunk_size = 2**20
 
         config1 = helion.Config(block_sizes=[128], num_warps=4)
         config2 = helion.Config(block_sizes=[256], num_warps=4)
@@ -11073,7 +11048,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         def measuring_chunked_assert_close(*args, **kwargs):
             torch.cuda.reset_peak_memory_stats()
             before = torch.cuda.memory_allocated()
-            real_chunked_assert_close(*args, **kwargs)
+            real_chunked_assert_close(*args, chunk_size=chunk_size, **kwargs)
             peak = torch.cuda.max_memory_allocated() - before
             peaks.append(peak)
 
@@ -11207,10 +11182,13 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             # Always reject
             raise AssertionError("strict check: always fails")
 
+        # Custom accuracy-check fns always run in-process; skip the benchmark
+        # worker subprocess (seconds of startup overhead).
         @helion.kernel(
             configs=[cfg1, cfg2],
             autotune_log_level=0,
             autotune_baseline_accuracy_check_fn=strict_check,
+            autotune_benchmark_subprocess=False,
         )
         def add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
             o = torch.empty_like(a)
@@ -12060,7 +12038,7 @@ class TestAutotuneRandomSeed(RefEagerTestDisabled, TestCase):
         search_capture: dict[str, RecordingRandomSearch] = {}
 
         def autotuner_factory(bound_kernel, args, **kwargs):
-            search = RecordingRandomSearch(bound_kernel, args, count=4, **kwargs)
+            search = RecordingRandomSearch(bound_kernel, args, count=2, **kwargs)
             search_capture["search"] = search
             return search
 
@@ -13585,7 +13563,10 @@ class TestConfigFilter(TestCase):
             return config if (config.get("block_sizes") or [0])[0] >= 64 else None
 
         add, args = self._make_kernel_and_args(
-            autotune_config_filter=reject_small_blocks
+            autotune_config_filter=reject_small_blocks,
+            # Filtering happens before compile/benchmark; skip the benchmark
+            # worker subprocess (seconds of startup overhead).
+            autotune_benchmark_subprocess=False,
         )
         bound = add.bind(args)
         search = FiniteSearch(bound, args, configs=[cfg_fast, cfg_slow])

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import contextlib
 from contextlib import ExitStack
 from contextlib import contextmanager
 import dataclasses
+import functools
 import itertools
 import math
 import os
 import random
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterator
 from typing import cast
@@ -68,6 +71,7 @@ from helion._compiler.autotuner_heuristics.triton import _h100_matmul_tile
 from helion._compiler.backend import CuteBackend
 from helion._compiler.backend import TritonBackend
 from helion._compiler.compile_environment import _symint_free_symbols
+from helion._compiler.cute import cute_flash
 from helion._compiler.cute.cute_flash import FLASH_AUTOTUNE_CONFIG_KEYS
 from helion._compiler.cute.cute_flash import FLASH_CAUSAL_KV_ORDER_KEY
 from helion._compiler.cute.cute_flash import FLASH_CAUSAL_LOOP_SPLIT_KEY
@@ -269,6 +273,7 @@ from helion.autotuner import IntegerFragment
 from helion.autotuner.base_cache import BoundKernelInMemoryCacheKey
 from helion.autotuner.base_cache import LooseAutotuneCacheKey
 from helion.autotuner.base_cache import StrictAutotuneCacheKey
+from helion.autotuner.config_fragment import ConfigSpecFragment
 from helion.autotuner.config_fragment import EnumFragment
 from helion.autotuner.config_generation import ConfigGeneration
 from helion.autotuner.config_spec import BlockSizeSpec
@@ -287,6 +292,9 @@ from helion.runtime.cute.launcher import _Tcgen05GroupedWorklistCompatibilityCla
 from helion.runtime.kernel import _find_device as runtime_find_device
 from helion.runtime.kernel import _input_tensor_metadata
 from helion.runtime.settings import Settings
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 HOPPER_HARDWARE = HardwareInfo(
     device_kind="cuda",
@@ -534,6 +542,63 @@ def _grouped_worklist_bind_patches(
                 )
             )
         yield
+
+
+@contextlib.contextmanager
+def _memoized_flash_fragments() -> Iterator[None]:
+    """Memoize ``flash_autotune_fragments`` for the duration of one test.
+
+    The structural coverage design calls it thousands of times per
+    ``ConfigGeneration`` with only a handful of distinct argument tuples (one
+    per pipeline-family override), and it is deterministic for fixed arguments
+    and environment. The first repeat of each key is re-verified against the
+    real function so a nondeterministic surface would still fail. Do not use
+    under a patched flash target policy or HELION_CUTE_FLASH_* environment.
+    """
+    real = cast(
+        "Callable[..., dict[str, ConfigSpecFragment]]",
+        cute_flash.flash_autotune_fragments,
+    )
+    surfaces: dict[tuple[object, ...], dict[str, ConfigSpecFragment]] = {}
+    verified: set[tuple[object, ...]] = set()
+
+    def wrapper(
+        head_dim: int, num_kv: int, **kwargs: object
+    ) -> dict[str, ConfigSpecFragment]:
+        key = (head_dim, num_kv, tuple(sorted(kwargs.items())))
+        cached = surfaces.get(key)
+        if cached is None:
+            cached = surfaces[key] = real(head_dim, num_kv, **kwargs)
+        elif key not in verified:
+            verified.add(key)
+            assert real(head_dim, num_kv, **kwargs) == cached
+        return dict(cached)
+
+    with patch.object(cute_flash, "flash_autotune_fragments", wrapper):
+        yield
+
+
+@functools.cache
+def _dense_fp16_hd64_bh64_flash_generation() -> ConfigGeneration:
+    """Shared generation for the num_kv=48, num_bh=64 dense fp16 surface.
+
+    The structural coverage design cached on the returned ``ConfigGeneration``
+    is expensive and independent of compiler seeds, so tests exercising the
+    same surface share one instance. Callers must set
+    ``config_spec.compiler_seed_configs`` before using seed-dependent APIs.
+    """
+    spec = ConfigSpec(backend=CuteBackend())
+    for block_id, target in enumerate((1, 128, 128)):
+        spec.block_sizes.append(BlockSizeSpec(block_id=block_id, size_hint=target))
+    spec.enable_cute_flash_search(
+        head_dim=64,
+        num_kv=48,
+        num_bh=64,
+        dtype=torch.float16,
+        block_size_targets={0: 1, 1: 128, 2: 128},
+        standard_dense_output=True,
+    )
+    return ConfigGeneration(spec)
 
 
 class TestAutotunerHeuristic(TestCase):
@@ -842,6 +907,7 @@ class TestAutotunerHeuristic(TestCase):
         self.assertGreaterEqual(len(population), 100)
         self.assertLessEqual(set(coverage), set(population))
 
+    @_memoized_flash_fragments()
     def test_cute_flash_heuristic_returns_all_legal_seeds(self) -> None:
         spec = ConfigSpec(backend=CuteBackend())
         for block_id, size_hint in enumerate((1, 128, 128)):
@@ -5442,10 +5508,10 @@ class TestCuteFp8GemmSkinnyMHeuristic(TestCase):
 
 
 class TestCuteTcgen05ClusterM2Heuristic(TestCase):
-    # Enumerating the full flash search space per seeded shape routinely
-    # exceeds the suite's default 60s per-test timeout on slower CI runners,
-    # which kills the xdist worker mid-test. Give these explicit headroom.
-    pytestmark = pytest.mark.timeout(600)
+    # Structural-coverage enumeration keeps a few of these tests above the
+    # suite's default 60s per-test timeout on slower CI runners, which kills
+    # the xdist worker mid-test. Give them modest headroom.
+    pytestmark = pytest.mark.timeout(120)
 
     def _assert_cute_tcgen05_cluster_m2_seeded(
         self,
@@ -5852,20 +5918,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     self.assertEqual(canonical, seed)
                     self.assertEqual(config_gen.unflatten(canonical_flat), seed)
 
+    @_memoized_flash_fragments()
     def test_cute_flash_full_population_covers_compound_schedule_dependencies(
         self,
     ) -> None:
-        spec = ConfigSpec(backend=CuteBackend())
-        for block_id, target in enumerate((1, 128, 128)):
-            spec.block_sizes.append(BlockSizeSpec(block_id=block_id, size_hint=target))
-        spec.enable_cute_flash_search(
-            head_dim=64,
-            num_kv=48,
-            num_bh=64,
-            dtype=torch.float16,
-            block_size_targets={0: 1, 1: 128, 2: 128},
-            standard_dense_output=True,
-        )
+        config_gen = _dense_fp16_hd64_bh64_flash_generation()
+        spec = config_gen.config_spec
         heuristic_seeds = CuteFlashAttentionHeuristic.get_seed_configs(
             MagicMock(config_spec=spec),
             MagicMock(),
@@ -5878,9 +5936,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         profile = get_effort_profile("full").lfbo_pattern_search
         assert profile is not None
         self.assertEqual(profile.initial_population, 100)
-        population = ConfigGeneration(spec).random_population(
-            profile.initial_population
-        )
+        population = config_gen.random_population(profile.initial_population)
         configs = [config.config for config in population]
         fragments = flash_autotune_fragments(
             64,
@@ -5929,24 +5985,15 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             },
         )
         self.assertEqual(
-            ConfigGeneration(spec).flash_structural_coverage_uncovered_interactions(),
+            config_gen.flash_structural_coverage_uncovered_interactions(),
             [],
         )
 
+    @_memoized_flash_fragments()
     def test_cute_flash_full_population_reserves_random_exploration(self) -> None:
-        spec = ConfigSpec(backend=CuteBackend())
-        for block_id, target in enumerate((1, 128, 128)):
-            spec.block_sizes.append(BlockSizeSpec(block_id=block_id, size_hint=target))
-        spec.enable_cute_flash_search(
-            head_dim=64,
-            num_kv=48,
-            num_bh=64,
-            dtype=torch.float16,
-            block_size_targets={0: 1, 1: 128, 2: 128},
-            standard_dense_output=True,
-        )
+        config_gen = _dense_fp16_hd64_bh64_flash_generation()
+        spec = config_gen.config_spec
         spec.compiler_seed_configs = []
-        config_gen = ConfigGeneration(spec)
         coverage = config_gen.flash_deterministic_population_configs()
 
         random_state = random.getstate()
@@ -6152,6 +6199,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             set(coverage[: search.initial_population]), partial_population
         )
 
+    @_memoized_flash_fragments()
     def test_cute_flash_large_bh_population_covers_structural_axes_and_random(
         self,
     ) -> None:
@@ -6815,6 +6863,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     )
                 )
 
+    @_memoized_flash_fragments()
     def test_cute_flash_compound_families_reachable_without_compiler_seeds(
         self,
     ) -> None:
@@ -6976,6 +7025,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                         "descending",
                     )
 
+    @_memoized_flash_fragments()
     def test_cute_flash_clc_head_search_uses_work_grid_divisors(self) -> None:
         fragments = flash_autotune_fragments(64, 1024, num_bh=6)
         heads = fragments[FLASH_CLC_HEADS_PER_BATCH_KEY]
@@ -7026,6 +7076,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         }
         self.assertEqual(structural_groups, {1, 2, 3, 6})
 
+    @_memoized_flash_fragments()
     def test_cute_flash_clc_head_search_preserves_tensor_head_geometry(
         self,
     ) -> None:
@@ -7167,6 +7218,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             configs.append(anchors[0].config)
         self.assertTrue(all(config == configs[0] for config in configs[1:]))
 
+    @_memoized_flash_fragments()
     def test_cute_flash_bf16_hd64_2cta_seed_transfers_to_2048(self) -> None:
         spec = ConfigSpec(backend=CuteBackend())
         for block_id, target in enumerate((1, 128, 128)):
@@ -7466,9 +7518,11 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     1,
                 )
 
+    @_memoized_flash_fragments()
     def test_cute_flash_dense_degree2_seed_is_in_full_initial_population(
         self,
     ) -> None:
+        checked_surfaces: set[tuple[object, ...]] = set()
         for num_kv in (48, 256, 260, 516, 768, 1536, 2052, 4096):
             with self.subTest(num_kv=num_kv):
                 spec = ConfigSpec(backend=CuteBackend())
@@ -7492,9 +7546,10 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     )
                 )
                 config_gen = ConfigGeneration(spec)
+                seed_pairs = config_gen.seed_flat_config_pairs()
                 expected = [
                     config
-                    for _flat, config in config_gen.seed_flat_config_pairs()
+                    for _flat, config in seed_pairs
                     if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
                 ]
                 self.assertEqual(len(expected), 1)
@@ -7508,6 +7563,19 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 )
                 self.assertEqual(canonical, degree2)
                 self.assertEqual(config_gen.unflatten(canonical_flat), degree2)
+
+                # The flash surface is length-invariant within one legality
+                # class: lengths whose flat fragments and normalized seeds are
+                # identical yield the same deterministic population prefix, so
+                # the expensive population check runs once per distinct
+                # surface instead of once per length.
+                surface_key = (
+                    tuple(repr(fragment) for fragment in config_gen.flat_spec),
+                    tuple(config for _flat, config in seed_pairs),
+                )
+                if surface_key in checked_surfaces:
+                    continue
+                checked_surfaces.add(surface_key)
 
                 profile = get_effort_profile("full").lfbo_pattern_search
                 assert profile is not None
@@ -7701,9 +7769,11 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         self.assertIn("deg2_16x6", packet.search_choices or ())
 
+    @_memoized_flash_fragments()
     def test_cute_flash_causal_degree2_seed_is_in_full_initial_population(
         self,
     ) -> None:
+        checked_surfaces: set[tuple[object, ...]] = set()
         for num_kv in (48, 768, 4096):
             with self.subTest(num_kv=num_kv):
                 spec = ConfigSpec(backend=CuteBackend())
@@ -7729,15 +7799,26 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                     )
                 )
                 config_gen = ConfigGeneration(spec)
+                seed_pairs = config_gen.seed_flat_config_pairs()
                 degree2 = [
                     config
-                    for _flat, config in config_gen.seed_flat_config_pairs()
+                    for _flat, config in seed_pairs
                     if config.config[FLASH_EXP2_PACKET_KEY] == "deg2_16x6"
                 ]
                 self.assertEqual(len(degree2), 1)
                 expected = degree2[0]
                 roundtrip = config_gen.unflatten(config_gen.flatten(expected))
                 self.assertEqual(roundtrip, expected)
+
+                # Same length-invariance dedup as the dense variant above: the
+                # expensive population check runs once per distinct surface.
+                surface_key = (
+                    tuple(repr(fragment) for fragment in config_gen.flat_spec),
+                    tuple(config for _flat, config in seed_pairs),
+                )
+                if surface_key in checked_surfaces:
+                    continue
+                checked_surfaces.add(surface_key)
 
                 profile = get_effort_profile("full").lfbo_pattern_search
                 assert profile is not None

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -2052,9 +2052,12 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
         bound_kernel.settings.autotune_benchmark_subprocess = True
         bound_kernel.settings.autotune_benchmark_timeout = 60
         bound_kernel.settings.autotune_precompile = None
+        # The autotuner reseeds `random` from this setting, so pinning it (not
+        # random.seed) is what makes the config sequence reproducible.
+        bound_kernel.settings.autotune_random_seed = 123
 
         random.seed(123)
-        RandomSearch(bound_kernel, args, 20).autotune()
+        RandomSearch(bound_kernel, args, 10).autotune()
 
     @skipIfXPU("matmul config space includes maxnreg, unsupported on XPU")
     def test_autotune_continues_when_subprocess_reports_inf(self) -> None:
@@ -2091,6 +2094,9 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
         bound_kernel.settings.autotune_benchmark_subprocess = True
         bound_kernel.settings.autotune_benchmark_timeout = 60
         bound_kernel.settings.autotune_precompile = None
+        # The autotuner reseeds `random` from this setting, so pinning it (not
+        # random.seed) is what makes the config sequence reproducible.
+        bound_kernel.settings.autotune_random_seed = 123
 
         random.seed(123)
         with patch.object(
@@ -2098,7 +2104,7 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
             "_benchmark_function_subprocess",
             maybe_fail,
         ):
-            search = RandomSearch(bound_kernel, args, 20)
+            search = RandomSearch(bound_kernel, args, 10)
             search.autotune()
 
         self.assertGreaterEqual(call_count[0], 6)
@@ -2108,9 +2114,9 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
     @skipIfXPU("matmul config space includes maxnreg, unsupported on XPU")
     def test_autotune_continues_when_accuracy_check_crashes(self) -> None:
         # A config can pass the timed run and then crash in the accuracy
-        # check. Patches the accuracy job to raise a sticky CUDA error for a
-        # fraction of configs; the worker dies and respawns, and autotune must
-        # still pick a best config from the rest instead of aborting.
+        # check. Patches the accuracy job to raise a sticky CUDA error for one
+        # config; the worker dies and respawns, and autotune must still pick a
+        # best config from the rest instead of aborting.
         if not torch.cuda.is_available():
             self.skipTest("requires CUDA")
 
@@ -2122,7 +2128,10 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
             fn: CompiledConfig,
         ) -> AccuracyCheckResult | None:
             call_count[0] += 1
-            if call_count[0] % 3 == 0:
+            # Crash exactly once, early: every induced crash costs a ~5s worker
+            # kill/respawn cycle, and one cycle already proves autotune survives
+            # an accuracy-check crash and keeps searching.
+            if call_count[0] == 2:
                 call_count[1] += 1
                 if self._benchmark_worker is None:
                     self._benchmark_worker = BenchmarkWorker(device=None)
@@ -2146,6 +2155,9 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
         bound_kernel.settings.autotune_benchmark_subprocess = True
         bound_kernel.settings.autotune_benchmark_timeout = 60
         bound_kernel.settings.autotune_precompile = None
+        # The autotuner reseeds `random` from this setting, so pinning it (not
+        # random.seed) is what makes the config sequence reproducible.
+        bound_kernel.settings.autotune_random_seed = 123
 
         random.seed(123)
         with patch.object(
@@ -2153,11 +2165,13 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
             "_run_subprocess_accuracy_check_job",
             maybe_crash,
         ):
-            best = RandomSearch(bound_kernel, args, 20).autotune()
+            best = RandomSearch(bound_kernel, args, 8).autotune()
 
         self.assertIsNotNone(best)
-        self.assertGreaterEqual(call_count[0], 6)
-        self.assertGreaterEqual(call_count[1], 2)
+        # Random configs that fail to compile never reach the accuracy check
+        # (hardware-dependent even with a pinned seed), so leave slack here.
+        self.assertGreaterEqual(call_count[0], 4)
+        self.assertEqual(call_count[1], 1)
 
 
 if __name__ == "__main__":

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -34,6 +34,92 @@ def _clear_process_local_cute_library_override(monkeypatch):
     monkeypatch.delenv("CUTE_DSL_LIBS", raising=False)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _share_flash_coverage_across_instances():
+    # _flash_deterministic_coverage_flats costs seconds per ConfigGeneration
+    # instance, and the validator canonicalizes the same fixture configs on
+    # every call; both are deterministic given the spec and override state.
+    # Product paths exercised here build many instances from one spec, so share
+    # the computed results across instances with identical inputs. Keys hold a
+    # strong spec reference so id() values cannot be recycled.
+    from helion._compiler.cute import cute_flash
+    from helion.autotuner.config_generation import ConfigGeneration
+
+    original_coverage = ConfigGeneration._flash_deterministic_coverage_flats
+    original_canonicalize = ConfigGeneration.canonicalize_flat
+    original_flatten = ConfigGeneration.flatten
+    original_fragments = cute_flash.flash_autotune_fragments
+    prototypes: dict[tuple[object, ...], tuple[object, dict[str, object]]] = {}
+    canonicalize_memo: dict[tuple[object, ...], tuple[object, object]] = {}
+    flatten_memo: dict[tuple[object, ...], tuple[object, object]] = {}
+    fragments_memo: dict[tuple[object, ...], list[object]] = {}
+
+    def generation_key(self):
+        return (
+            id(self.config_spec),
+            self._flash_pipeline_family_override,
+            repr(sorted(self._override_values.items())),
+            repr(self._advanced_controls_files),
+        )
+
+    def shared_coverage(self):
+        if self._flash_coverage_cache is not None:
+            return original_coverage(self)
+        cached = prototypes.get(generation_key(self))
+        if cached is None:
+            result = original_coverage(self)
+            prototypes[generation_key(self)] = (
+                self.config_spec,
+                {attr: getattr(self, attr) for attr in _FLASH_COVERAGE_CACHE_ATTRS},
+            )
+            return result
+        for attr, value in cached[1].items():
+            setattr(self, attr, copy.deepcopy(value))
+        return original_coverage(self)
+
+    def shared_canonicalize_flat(self, flat_values):
+        key = (generation_key(self), repr(flat_values))
+        cached = canonicalize_memo.get(key)
+        if cached is None:
+            result = original_canonicalize(self, flat_values)
+            canonicalize_memo[key] = (self.config_spec, result)
+            return copy.deepcopy(result)
+        return copy.deepcopy(cached[1])
+
+    def shared_flatten(self, config):
+        key = (generation_key(self), repr(config))
+        cached = flatten_memo.get(key)
+        if cached is None:
+            result = original_flatten(self, config)
+            flatten_memo[key] = (self.config_spec, result)
+            return copy.deepcopy(result)
+        return copy.deepcopy(cached[1])
+
+    def shared_fragments(head_dim, num_kv, **kwargs):
+        key = (head_dim, num_kv, tuple(sorted(kwargs.items())))
+        cached = fragments_memo.get(key)
+        if cached is None:
+            result = original_fragments(head_dim, num_kv, **kwargs)
+            fragments_memo[key] = [result, False]
+            return dict(result)
+        if not cached[1]:
+            # Re-verify the first repeat of each key so a nondeterministic
+            # fragment surface still fails instead of being masked.
+            assert original_fragments(head_dim, num_kv, **kwargs) == cached[0]
+            cached[1] = True
+        return dict(cached[0])
+
+    ConfigGeneration._flash_deterministic_coverage_flats = shared_coverage
+    ConfigGeneration.canonicalize_flat = shared_canonicalize_flat
+    ConfigGeneration.flatten = shared_flatten
+    cute_flash.flash_autotune_fragments = shared_fragments
+    yield
+    ConfigGeneration._flash_deterministic_coverage_flats = original_coverage
+    ConfigGeneration.canonicalize_flat = original_canonicalize
+    ConfigGeneration.flatten = original_flatten
+    cute_flash.flash_autotune_fragments = original_fragments
+
+
 def test_mirrored_bench_generic_rotates_balanced_pairs(monkeypatch) -> None:
     calls: list[int] = []
     cleanups: list[int] = []
@@ -1410,6 +1496,43 @@ def test_attention_direct_script_pins_helion_to_benchmark_checkout(tmp_path):
     )
 
 
+# Instance caches populated by ConfigGeneration._flash_deterministic_coverage_flats.
+_FLASH_COVERAGE_CACHE_ATTRS = (
+    "_flash_coverage_cache",
+    "_flash_coverage_active_values_cache",
+    "_flash_coverage_uncovered_cache",
+    "_flash_coverage_underqualified_cache",
+    "_flash_structural_leaf_catalog_cache",
+    "_flash_pipeline_lane_catalog_cache",
+    "_flash_pipeline_lane_witness_cache",
+    "_flash_clc_lane_catalog_cache",
+    "_flash_clc_lane_witness_cache",
+    "_flash_structural_underqualified_leaves_cache",
+    "_flash_coverage_uncovered_interactions_cache",
+    "_flash_coverage_active_interactions_cache",
+    "_flash_parent_coverage_prefix_count_cache",
+    "_flash_qualification_prefix_count_cache",
+)
+
+
+def _fresh_full_autotune_config_generation():
+    """ConfigGeneration for the canonical fixture spec with warm coverage caches.
+
+    The deterministic coverage design costs several seconds per instance and is
+    identical for every instance built from _full_autotune_config_spec(), so
+    compute it once on the shared prototype and copy the caches onto each new
+    instance.
+    """
+    from helion.autotuner.config_generation import ConfigGeneration
+
+    generation = ConfigGeneration(_full_autotune_config_spec())
+    prototype = _cached_full_autotune_config_generation()
+    prototype._flash_deterministic_coverage_flats()
+    for attr in _FLASH_COVERAGE_CACHE_ATTRS:
+        setattr(generation, attr, copy.deepcopy(getattr(prototype, attr)))
+    return generation
+
+
 @functools.lru_cache(maxsize=1)
 def _full_autotune_trial_configs():
     from helion.autotuner.config_generation import ConfigGeneration
@@ -1425,7 +1548,7 @@ def _full_autotune_trial_configs():
         random.setstate(state)
     configs_by_depth = {2: [], 3: []}
     seen: set[str] = set()
-    witness_generation = ConfigGeneration(_full_autotune_config_spec())
+    witness_generation = _fresh_full_autotune_config_generation()
     for (
         leaf,
         key,
@@ -1486,7 +1609,6 @@ def _full_autotune_terminal_fixture():
     from helion._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILY_KEY
     from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_DISC_KEY
     from helion._compiler.cute.cute_flash import flash_structural_leaf_from_config
-    from helion.autotuner.config_generation import ConfigGeneration
     from helion.autotuner.search_space_logger import canonical_config_id
     from helion.runtime.config import Config
 
@@ -1495,8 +1617,8 @@ def _full_autotune_terminal_fixture():
     initial_id = canonical_config_id(initial)
     leaf = flash_structural_leaf_from_config(initial.config)
     assert leaf is not None
-    config_spec = _full_autotune_config_spec()
-    root_generation = ConfigGeneration(config_spec)
+    root_generation = _fresh_full_autotune_config_generation()
+    config_spec = root_generation.config_spec
     overrides = dict(root_generation._override_values)
     overrides[FLASH_PIPELINE_FAMILY_KEY] = leaf.pipeline_family
     overrides[FLASH_SOFTMAX_DISC_KEY] = leaf.softmax_disc
@@ -1630,10 +1752,8 @@ def _full_autotune_terminal_fixture():
 
 @functools.lru_cache(maxsize=1)
 def _full_autotune_terminal_surface_catalog():
-    from helion.autotuner.config_generation import ConfigGeneration
-
-    return ConfigGeneration(
-        _full_autotune_config_spec()
+    return (
+        _fresh_full_autotune_config_generation()
     ).flash_terminal_coordinate_surface_catalog(radius=2)
 
 
@@ -1693,7 +1813,6 @@ def _measured_full_autotune_terminal_fixture():
     from helion._compiler.cute.cute_flash import FLASH_PIPELINE_FAMILY_KEY
     from helion._compiler.cute.cute_flash import FLASH_SOFTMAX_DISC_KEY
     from helion._compiler.cute.cute_flash import flash_structural_leaf_from_config
-    from helion.autotuner.config_generation import ConfigGeneration
     from helion.autotuner.search_space_logger import canonical_config_id
     from helion.runtime.config import Config
 
@@ -1702,8 +1821,8 @@ def _measured_full_autotune_terminal_fixture():
     initial_id = canonical_config_id(initial)
     leaf = flash_structural_leaf_from_config(initial.config)
     assert leaf is not None
-    config_spec = _full_autotune_config_spec()
-    root_generation = ConfigGeneration(config_spec)
+    root_generation = _fresh_full_autotune_config_generation()
+    config_spec = root_generation.config_spec
     overrides = dict(root_generation._override_values)
     overrides[FLASH_PIPELINE_FAMILY_KEY] = leaf.pipeline_family
     overrides[FLASH_SOFTMAX_DISC_KEY] = leaf.softmax_disc
@@ -1947,7 +2066,8 @@ def _populate_measurement_source_hashes(value, *, overwrite: bool = False) -> No
             _populate_measurement_source_hashes(child, overwrite=overwrite)
 
 
-def _full_autotune_trial(**overrides):
+@functools.lru_cache(maxsize=1)
+def _full_autotune_trial_base():
     configs = [copy.deepcopy(config) for config in _full_autotune_trial_configs()]
     terminal_refinement, selected_config = copy.deepcopy(
         _full_autotune_terminal_fixture()
@@ -1995,7 +2115,7 @@ def _full_autotune_trial(**overrides):
             "status": "ok",
         }
 
-    trial = {
+    return {
         "input_shapes": repr([(2, 32, 65536, 64)] * 3),
         "dtypes": repr(["torch.float16"] * 3),
         "hardware": "NVIDIA B200",
@@ -2279,6 +2399,10 @@ def _full_autotune_trial(**overrides):
             "terminal_coordinate_refinement": terminal_refinement,
         },
     }
+
+
+def _full_autotune_trial(**overrides):
+    trial = copy.deepcopy(_full_autotune_trial_base())
     trial.update(overrides)
     if "search_phase_metrics" not in overrides:
         _synchronize_full_autotune_terminal_boundary(trial)
@@ -2377,7 +2501,8 @@ def _add_isolated_rebenchmark_alias_invalidation(trial, invalidated_id, *, compl
     return alias["config_id"]
 
 
-def _full_autotune_trial_provenance(**overrides):
+@functools.lru_cache(maxsize=1)
+def _full_autotune_trial_provenance_base():
     design_configs = [
         copy.deepcopy(config) for config in _full_autotune_trial_configs()[:2]
     ]
@@ -2392,7 +2517,7 @@ def _full_autotune_trial_provenance(**overrides):
     ]
     terminal_surface = copy.deepcopy(_full_autotune_terminal_surface_catalog())
     _terminal_refinement, selected_config = _full_autotune_terminal_fixture()
-    provenance = _full_autotune_provenance(
+    return _full_autotune_provenance(
         flash_structural_coverage_design=design,
         flash_structural_coverage_design_count=len(design),
         flash_structural_coverage_design_sha256=hashlib.sha256(
@@ -2428,17 +2553,20 @@ def _full_autotune_trial_provenance(**overrides):
         ).hexdigest(),
         selected_config=copy.deepcopy(selected_config),
     )
+
+
+def _full_autotune_trial_provenance(**overrides):
+    provenance = copy.deepcopy(_full_autotune_trial_provenance_base())
     provenance.update(overrides)
     return provenance
 
 
-def _full_autotune_trial_with_complete_schedule_anchors():
-    from helion.autotuner.config_generation import ConfigGeneration
-
+@functools.lru_cache(maxsize=1)
+def _cached_full_autotune_trial_with_complete_schedule_anchors():
     trial = _full_autotune_trial()
     provenance = _full_autotune_trial_provenance()
     phase = cast("dict[str, Any]", trial["search_phase_metrics"])
-    generation = ConfigGeneration(_full_autotune_config_spec())
+    generation = _fresh_full_autotune_config_generation()
     anchors = generation.flash_low_confound_schedule_anchor_configs()
     assert len(anchors) == 131
 
@@ -2770,9 +2898,12 @@ def _full_autotune_trial_with_complete_schedule_anchors():
     return trial, provenance, anchor_ids
 
 
-def _full_autotune_trial_with_family_probe_candidate():
-    from helion.autotuner.config_generation import ConfigGeneration
+def _full_autotune_trial_with_complete_schedule_anchors():
+    return copy.deepcopy(_cached_full_autotune_trial_with_complete_schedule_anchors())
 
+
+@functools.lru_cache(maxsize=1)
+def _cached_full_autotune_trial_with_family_probe_candidate():
     trial, provenance, anchor_ids = (
         _full_autotune_trial_with_complete_schedule_anchors()
     )
@@ -2782,7 +2913,7 @@ def _full_autotune_trial_with_family_probe_candidate():
         key: probe_path[key] for key in ("family", "compound_packet", "softmax_disc")
     }
     manifest = cast("dict[str, dict[str, Any]]", phase["config_manifest"])
-    generation = ConfigGeneration(_full_autotune_config_spec())
+    generation = _fresh_full_autotune_config_generation()
     state = random.getstate()
     random.seed(24680)
     try:
@@ -2857,6 +2988,10 @@ def _full_autotune_trial_with_family_probe_candidate():
     return trial, provenance, [*anchor_ids, candidate_id]
 
 
+def _full_autotune_trial_with_family_probe_candidate():
+    return copy.deepcopy(_cached_full_autotune_trial_with_family_probe_candidate())
+
+
 @functools.lru_cache(maxsize=1)
 def _cached_full_autotune_trial_with_pipeline_repair():
     from helion.autotuner.config_generation import ConfigGeneration
@@ -2910,7 +3045,7 @@ def _cached_full_autotune_trial_with_pipeline_repair():
     assert repair_config is not None and repair_id is not None
     manifest[repair_id] = {"config": repair_config}
 
-    witness_generation = ConfigGeneration(_full_autotune_config_spec())
+    witness_generation = _fresh_full_autotune_config_generation()
     witness_config = next(
         config
         for (witness_leaf, key, value), config in (
@@ -3237,8 +3372,8 @@ def _full_autotune_trial_with_terminal_pipeline_failure():
     return trial, provenance, witness_id, repair_id
 
 
-def _full_autotune_trial_with_compound_transfer():
-    from helion.autotuner.config_generation import ConfigGeneration
+@functools.lru_cache(maxsize=1)
+def _cached_full_autotune_trial_with_compound_transfer():
     from helion.exc import InvalidConfig
 
     trial = _full_autotune_trial()
@@ -3280,7 +3415,7 @@ def _full_autotune_trial_with_compound_transfer():
         ],
         key=operator.itemgetter("selection_perf", "config_id"),
     )
-    generation = ConfigGeneration(_full_autotune_config_spec())
+    generation = _fresh_full_autotune_config_generation()
     attempted_ids: list[str] = []
     selected_ids: list[str] = []
     transfers: list[dict[str, Any]] = []
@@ -3443,6 +3578,10 @@ def _full_autotune_trial_with_compound_transfer():
     return trial, provenance
 
 
+def _full_autotune_trial_with_compound_transfer():
+    return copy.deepcopy(_cached_full_autotune_trial_with_compound_transfer())
+
+
 def _full_autotune_config_spec():
     from helion._compiler.backend import CuteBackend
     from helion.autotuner.config_spec import BlockSizeSpec
@@ -3470,18 +3609,15 @@ def _full_autotune_config_spec():
 
 @functools.lru_cache(maxsize=1)
 def _full_autotune_compiler_seed_policy():
-    from helion.autotuner.config_generation import ConfigGeneration
-
-    spec = _full_autotune_config_spec()
+    generation = _fresh_full_autotune_config_generation()
     return compare_attention_backends._compiler_seed_policy(
-        spec, ConfigGeneration(spec)
+        generation.config_spec, generation
     )
 
 
 def test_attention_strict_schedule_anchor_enumerator_matches_live_product():
-    from helion.autotuner.config_generation import ConfigGeneration
 
-    generation = ConfigGeneration(_full_autotune_config_spec())
+    generation = _fresh_full_autotune_config_generation()
     independent = compare_attention_backends._independent_flash_schedule_anchor_configs(
         generation
     )
@@ -3499,9 +3635,8 @@ def test_attention_strict_schedule_anchor_enumerator_matches_live_product():
 def test_attention_strict_schedule_anchor_enumerator_rejects_producer_omission(
     monkeypatch,
 ):
-    from helion.autotuner.config_generation import ConfigGeneration
 
-    generation = ConfigGeneration(_full_autotune_config_spec())
+    generation = _fresh_full_autotune_config_generation()
     produced = generation.flash_low_confound_schedule_anchor_configs()
     assert produced
     monkeypatch.setattr(
@@ -3722,6 +3857,15 @@ def _cached_full_autotune_config_generation():
     return ConfigGeneration(_full_autotune_config_spec())
 
 
+@functools.cache
+def _validation_config_spec(seeds_json):
+    # One spec object per distinct fixture seed set keeps the id-keyed sharing
+    # of coverage and canonicalization results effective across tests. The
+    # caller reassigns the seed-dependent fields on every use.
+    assert seeds_json
+    return _full_autotune_config_spec()
+
+
 def _validate_full_autotune_trials(provenance, trials, *, expected_fixture_trial=None):
     from helion.runtime.config import Config
 
@@ -3758,7 +3902,6 @@ def _validate_full_autotune_trials(provenance, trials, *, expected_fixture_trial
     if expected_fixture_trial is not None:
         expected_trial = expected_fixture_trial
         expected_provenance = provenance
-    config_spec = _full_autotune_config_spec()
     seed_phase = (
         phase
         if isinstance(phase.get("initial_results"), list)
@@ -3773,6 +3916,13 @@ def _validate_full_autotune_trials(provenance, trials, *, expected_fixture_trial
         Config.from_dict(seed_phase["config_manifest"][config_id]["config"])
         for config_id in fixture_seed_ids
     ]
+    config_spec = _validation_config_spec(
+        json.dumps(
+            [config.config for config in fixture_seeds],
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
     config_spec.compiler_seed_configs = fixture_seeds
     config_spec.compiler_seed_timeout_retry_repetitions = 3
     config_spec.autotuner_heuristics = ["cute_flash_attention"]
@@ -3969,10 +4119,9 @@ def test_attention_required_full_autotune_rejects_noncanonical_seed_policy(mutat
 
 
 def test_attention_compiler_seed_policy_requires_exact_live_seed_order():
-    from helion.autotuner.config_generation import ConfigGeneration
 
-    spec = _full_autotune_config_spec()
-    generation = ConfigGeneration(spec)
+    generation = _fresh_full_autotune_config_generation()
+    spec = generation.config_spec
     policy = compare_attention_backends._compiler_seed_policy(spec, generation)
 
     assert policy["kind"] == "canonical_cute_flash"
@@ -3986,11 +4135,10 @@ def test_attention_compiler_seed_policy_requires_exact_live_seed_order():
 
 
 def test_attention_compiler_seed_policy_rejects_extra_alias_and_invalid_seed():
-    from helion.autotuner.config_generation import ConfigGeneration
     from helion.runtime.config import Config
 
-    spec = _full_autotune_config_spec()
-    generation = ConfigGeneration(spec)
+    generation = _fresh_full_autotune_config_generation()
+    spec = generation.config_spec
     canonical_ids = compare_attention_backends._compiler_seed_policy(spec, generation)[
         "effective_config_ids"
     ]
@@ -4865,10 +5013,6 @@ def test_attention_required_full_autotune_accepts_unlimited_family_cap():
     _validate_full_autotune_trials(provenance, [trial])
 
 
-# Building the trial fixture and validating it both walk the full flash config
-# surface; the first test to warm the lru_cache fixtures can exceed the 60s
-# CI per-test timeout on slower runners.
-@pytest.mark.timeout(300)
 def test_attention_required_full_autotune_accepts_measured_family_probe_candidate():
     trial, provenance, _config_ids = _full_autotune_trial_with_family_probe_candidate()
 
@@ -6317,401 +6461,6 @@ def test_attention_structural_retention_mirror_matches_live_capacity_selector():
     )
 
 
-def test_attention_structural_retention_counts_ordinary_lane_alternate_as_parent():
-    kv2 = ("cute_flash_kv_stage", 2)
-    kv3 = ("cute_flash_kv_stage", 3)
-    lanes = (kv2, kv3)
-    config_ids = [f"{index:016x}" for index in range(6)]
-    retained = compare_attention_backends._expected_flash_structural_retention(
-        [
-            (
-                "compound_rich",
-                "deg2_16x6",
-                True,
-                [(config_ids[0], 0.5, frozenset((kv2,)))],
-                lanes,
-            ),
-            (
-                "compound_rich",
-                None,
-                True,
-                [
-                    (config_ids[1], 1.0, frozenset((kv2,))),
-                    (config_ids[2], 1.1, frozenset((kv3,))),
-                ],
-                lanes,
-            ),
-            _structural_leaf_qualification("alpha", None, [(config_ids[3], 0.8)]),
-            _structural_leaf_qualification("beta", None, [(config_ids[4], 0.9)]),
-            _structural_leaf_qualification("gamma", None, [(config_ids[5], 1.2)]),
-        ],
-        retained_per_leaf=2,
-        retained_family_cap=3,
-        retained_family_limit=3,
-        retained_family_slowdown_limit=2.0,
-        starting_path_limit=4,
-        pipeline_qualification_keys=(
-            "cute_flash_kv_stage",
-            "cute_flash_s_stage",
-        ),
-    )
-
-    assert [family["family"] for family in retained] == [
-        "compound_rich",
-        "alpha",
-        "beta",
-    ]
-    assert retained[0]["parent_promoted"] is True
-    assert retained[0]["starting_paths"] == [
-        {
-            "family": "compound_rich",
-            "compound_packet": None,
-            "softmax_disc": True,
-            "config_id": config_ids[1],
-            "unrestricted": False,
-            "pipeline_lane": None,
-        },
-        {
-            "family": "compound_rich",
-            "compound_packet": "deg2_16x6",
-            "softmax_disc": True,
-            "config_id": config_ids[0],
-            "unrestricted": True,
-            "pipeline_lane": None,
-        },
-    ]
-
-
-def test_attention_structural_retention_selects_top_four_and_distinct_leaves():
-    config_ids = [f"{index:016x}" for index in range(8)]
-    retained = compare_attention_backends._expected_flash_structural_retention(
-        [
-            _structural_leaf_qualification(
-                "alpha", None, [(config_ids[0], 1.0), (config_ids[2], 1.0)]
-            ),
-            _structural_leaf_qualification(
-                "alpha", "deg2_16x6", [(config_ids[1], 1.0)]
-            ),
-            _structural_leaf_qualification("beta", None, [(config_ids[3], 1.0)]),
-            _structural_leaf_qualification("gamma", None, [(config_ids[4], 2.0)]),
-            _structural_leaf_qualification("delta", None, [(config_ids[5], 3.0)]),
-            _structural_leaf_qualification("epsilon", None, [(config_ids[6], 4.0)]),
-        ],
-        retained_per_leaf=2,
-        retained_family_cap=4,
-        retained_family_limit=4,
-        retained_family_slowdown_limit=10.0,
-        starting_path_limit=7,
-        pipeline_qualification_keys=(
-            "cute_flash_kv_stage",
-            "cute_flash_s_stage",
-        ),
-    )
-
-    assert [family["family"] for family in retained] == [
-        "alpha",
-        "beta",
-        "gamma",
-        "delta",
-    ]
-    assert [path["config_id"] for path in retained[0]["starting_paths"]] == [
-        config_ids[0],
-        config_ids[2],
-        config_ids[1],
-        config_ids[0],
-    ]
-    assert [path["unrestricted"] for path in retained[0]["starting_paths"]] == [
-        False,
-        False,
-        False,
-        True,
-    ]
-    assert sum(len(family["starting_paths"]) for family in retained) == 7
-
-
-def test_attention_structural_retention_unlimited_keeps_slow_live_family():
-    config_ids = [f"{index:016x}" for index in range(5)]
-    retained = compare_attention_backends._expected_flash_structural_retention(
-        [
-            _structural_leaf_qualification(family, None, [(config_id, perf)])
-            for family, config_id, perf in zip(
-                ("alpha", "beta", "gamma", "delta", "epsilon"),
-                config_ids,
-                (1.0, 1.1, 1.2, 1.3, 5.0),
-                strict=True,
-            )
-        ],
-        retained_per_leaf=2,
-        retained_family_cap=None,
-        retained_family_limit=5,
-        retained_family_slowdown_limit=2.0,
-        starting_path_limit=6,
-        pipeline_qualification_keys=(
-            "cute_flash_kv_stage",
-            "cute_flash_s_stage",
-        ),
-    )
-
-    assert [family["family"] for family in retained] == [
-        "alpha",
-        "beta",
-        "gamma",
-        "delta",
-        "epsilon",
-    ]
-
-
-def test_attention_structural_retention_does_not_prune_close_sibling_leaf():
-    config_ids = [f"{index:016x}" for index in range(8)]
-    retained = compare_attention_backends._expected_flash_structural_retention(
-        [
-            _structural_leaf_qualification(
-                "alpha", None, [(config_ids[0], 1.0), (config_ids[1], 1.001)]
-            ),
-            _structural_leaf_qualification("beta", None, [(config_ids[2], 1.015)]),
-            _structural_leaf_qualification(
-                "beta", "deg2_16x6", [(config_ids[3], 1.01)]
-            ),
-            _structural_leaf_qualification(
-                "beta", "deg1_16x8", [(config_ids[4], 1.011)]
-            ),
-            _structural_leaf_qualification("gamma", None, [(config_ids[5], 3.0)]),
-            _structural_leaf_qualification("delta", None, [(config_ids[6], 3.1)]),
-            _structural_leaf_qualification("epsilon", None, [(config_ids[7], 3.2)]),
-        ],
-        retained_per_leaf=2,
-        retained_family_cap=4,
-        retained_family_limit=4,
-        retained_family_slowdown_limit=2.0,
-        starting_path_limit=6,
-        pipeline_qualification_keys=(
-            "cute_flash_kv_stage",
-            "cute_flash_s_stage",
-        ),
-    )
-
-    by_family = {family["family"]: family["starting_paths"] for family in retained}
-    assert [path["config_id"] for path in by_family["alpha"]] == [
-        config_ids[0],
-        config_ids[1],
-        config_ids[0],
-    ]
-    assert [path["config_id"] for path in by_family["beta"]] == config_ids[2:5]
-    assert [
-        path["config_id"]
-        for paths in by_family.values()
-        for path in paths
-        if path["unrestricted"]
-    ] == [config_ids[0]]
-
-
-def test_attention_structural_retention_does_not_parent_promote_compound_only():
-    config_ids = [f"{index:016x}" for index in range(5)]
-    retained = compare_attention_backends._expected_flash_structural_retention(
-        [
-            _structural_leaf_qualification(
-                "compound_only", "deg2_16x6", [(config_ids[0], 0.5)]
-            ),
-            _structural_leaf_qualification("alpha", None, [(config_ids[1], 1.0)]),
-            _structural_leaf_qualification("beta", None, [(config_ids[2], 1.1)]),
-            _structural_leaf_qualification("gamma", None, [(config_ids[3], 1.2)]),
-            _structural_leaf_qualification("delta", None, [(config_ids[4], 1.3)]),
-        ],
-        retained_per_leaf=2,
-        retained_family_cap=4,
-        retained_family_limit=4,
-        retained_family_slowdown_limit=2.0,
-        starting_path_limit=5,
-        pipeline_qualification_keys=(
-            "cute_flash_kv_stage",
-            "cute_flash_s_stage",
-        ),
-    )
-
-    assert [family["family"] for family in retained] == [
-        "compound_only",
-        "alpha",
-        "beta",
-        "gamma",
-        "delta",
-    ]
-    assert retained[0]["parent_promoted"] is False
-    assert len(retained[0]["starting_paths"]) == 1
-
-
-def test_attention_structural_retention_scores_families_by_ordinary_leaf():
-    config_ids = [f"{index:016x}" for index in range(7)]
-    retained = compare_attention_backends._expected_flash_structural_retention(
-        [
-            _structural_leaf_qualification(
-                "compound_rich", None, [(config_ids[0], 1.5)]
-            ),
-            _structural_leaf_qualification(
-                "compound_rich", "deg2_16x6", [(config_ids[1], 0.9)]
-            ),
-            _structural_leaf_qualification("alpha", None, [(config_ids[2], 0.8)]),
-            _structural_leaf_qualification("beta", None, [(config_ids[3], 1.0)]),
-            _structural_leaf_qualification("gamma", None, [(config_ids[4], 1.1)]),
-            _structural_leaf_qualification("delta", None, [(config_ids[5], 1.2)]),
-        ],
-        retained_per_leaf=2,
-        retained_family_cap=4,
-        retained_family_limit=4,
-        retained_family_slowdown_limit=2.0,
-        starting_path_limit=5,
-        pipeline_qualification_keys=(
-            "cute_flash_kv_stage",
-            "cute_flash_s_stage",
-        ),
-    )
-
-    assert [family["family"] for family in retained if family["parent_promoted"]] == [
-        "alpha",
-        "beta",
-        "gamma",
-        "delta",
-    ]
-    assert all(
-        family["score_compound_packet"] is None
-        for family in retained
-        if family["parent_promoted"]
-    )
-
-
-def test_attention_structural_retention_keeps_global_compound_winner():
-    config_ids = [f"{index:016x}" for index in range(6)]
-    retained = compare_attention_backends._expected_flash_structural_retention(
-        [
-            _structural_leaf_qualification(
-                "compound_rich", None, [(config_ids[0], 1.5)]
-            ),
-            _structural_leaf_qualification(
-                "compound_rich", "deg2_16x6", [(config_ids[1], 0.5)]
-            ),
-            _structural_leaf_qualification("alpha", None, [(config_ids[2], 1.0)]),
-            _structural_leaf_qualification("beta", None, [(config_ids[3], 1.1)]),
-            _structural_leaf_qualification("gamma", None, [(config_ids[4], 1.2)]),
-            _structural_leaf_qualification("delta", None, [(config_ids[5], 1.3)]),
-        ],
-        retained_per_leaf=2,
-        retained_family_cap=4,
-        retained_family_limit=4,
-        retained_family_slowdown_limit=2.0,
-        starting_path_limit=4,
-        pipeline_qualification_keys=(
-            "cute_flash_kv_stage",
-            "cute_flash_s_stage",
-        ),
-    )
-
-    unrestricted = [
-        path
-        for family in retained
-        for path in family["starting_paths"]
-        if path["unrestricted"]
-    ]
-    assert unrestricted == [
-        {
-            "family": "compound_rich",
-            "compound_packet": "deg2_16x6",
-            "softmax_disc": True,
-            "config_id": config_ids[1],
-            "unrestricted": True,
-            "pipeline_lane": None,
-        }
-    ]
-    assert [family["family"] for family in retained] == [
-        "compound_rich",
-        "alpha",
-        "beta",
-        "gamma",
-    ]
-    assert retained[0]["parent_promoted"] is False
-
-
-def test_attention_structural_retention_gives_dominated_compound_winner_one_path():
-    config_ids = [f"{index:016x}" for index in range(6)]
-    retained = compare_attention_backends._expected_flash_structural_retention(
-        [
-            _structural_leaf_qualification(
-                "compound_rich", None, [(config_ids[0], 3.0)]
-            ),
-            _structural_leaf_qualification(
-                "compound_rich", "deg2_16x6", [(config_ids[1], 0.5)]
-            ),
-            _structural_leaf_qualification("alpha", None, [(config_ids[2], 1.0)]),
-            _structural_leaf_qualification("beta", None, [(config_ids[3], 1.1)]),
-            _structural_leaf_qualification("gamma", None, [(config_ids[4], 1.2)]),
-            _structural_leaf_qualification("delta", None, [(config_ids[5], 1.3)]),
-        ],
-        retained_per_leaf=2,
-        retained_family_cap=4,
-        retained_family_limit=4,
-        retained_family_slowdown_limit=2.0,
-        starting_path_limit=4,
-        pipeline_qualification_keys=(
-            "cute_flash_kv_stage",
-            "cute_flash_s_stage",
-        ),
-    )
-
-    assert [family["family"] for family in retained] == [
-        "compound_rich",
-        "alpha",
-        "beta",
-        "gamma",
-    ]
-    assert retained[0]["parent_promoted"] is False
-    assert retained[0]["starting_paths"] == [
-        {
-            "family": "compound_rich",
-            "compound_packet": "deg2_16x6",
-            "softmax_disc": True,
-            "config_id": config_ids[1],
-            "unrestricted": True,
-            "pipeline_lane": None,
-        }
-    ]
-    assert all(family["parent_promoted"] for family in retained[1:])
-
-
-def test_attention_structural_retention_replaces_dominated_family():
-    config_ids = [f"{index:016x}" for index in range(6)]
-    retained = compare_attention_backends._expected_flash_structural_retention(
-        [
-            _structural_leaf_qualification(
-                "alpha",
-                None,
-                [
-                    (config_ids[0], 1.0),
-                    (config_ids[1], 1.1),
-                    (config_ids[2], 1.2),
-                ],
-            ),
-            _structural_leaf_qualification(
-                "alpha", "deg2_16x6", [(config_ids[3], 1.3)]
-            ),
-            _structural_leaf_qualification("beta", None, [(config_ids[4], 1.4)]),
-            _structural_leaf_qualification("dominated", None, [(config_ids[5], 2.01)]),
-        ],
-        retained_per_leaf=3,
-        retained_family_cap=4,
-        retained_family_limit=3,
-        retained_family_slowdown_limit=2.0,
-        starting_path_limit=5,
-        pipeline_qualification_keys=(
-            "cute_flash_kv_stage",
-            "cute_flash_s_stage",
-        ),
-    )
-
-    assert [family["family"] for family in retained] == ["alpha", "beta"]
-    assert sum(len(family["starting_paths"]) for family in retained) == 5
-    assert config_ids[5] not in {
-        path["config_id"] for family in retained for path in family["starting_paths"]
-    }
-
-
 def test_attention_required_full_autotune_rejects_packet_owner_mismatch():
     phase = _full_autotune_trial()["search_phase_metrics"]
     leaf_result = cast("dict[str, Any]", phase["leaf_results"][0])
@@ -6817,7 +6566,8 @@ def test_attention_required_full_autotune_checks_every_trial():
         )
 
 
-def _exact_small_space_trial_provenance():
+@functools.lru_cache(maxsize=1)
+def _cached_exact_small_space_trial_provenance():
     trial = _full_autotune_trial(
         num_configs_tested=4,
         num_successful_candidate_measurements=4,
@@ -6973,18 +6723,22 @@ def _exact_small_space_trial_provenance():
     return trial, provenance, exact_ids
 
 
+def _exact_small_space_trial_provenance():
+    return copy.deepcopy(_cached_exact_small_space_trial_provenance())
+
+
 def test_attention_required_full_autotune_accepts_exact_small_space_exhaustion():
     trial, provenance, _exact_ids = _exact_small_space_trial_provenance()
 
     _validate_full_autotune_trials(provenance, [trial])
 
 
-def _exact_small_space_trial_with_exhausted_clc():
+@functools.lru_cache(maxsize=1)
+def _cached_exact_small_space_trial_with_exhausted_clc():
     trial, provenance, exact_ids = _exact_small_space_trial_provenance()
     phase = cast("dict[str, Any]", trial["search_phase_metrics"])
-    from helion.autotuner.config_generation import ConfigGeneration
 
-    generation = ConfigGeneration(_full_autotune_config_spec())
+    generation = _fresh_full_autotune_config_generation()
     expected_catalog = compare_attention_backends._flash_clc_lane_provenance(
         generation,
         leaf_catalog=[
@@ -7245,11 +6999,14 @@ def _exact_small_space_trial_with_exhausted_clc():
     return trial, provenance
 
 
+def _exact_small_space_trial_with_exhausted_clc():
+    return copy.deepcopy(_cached_exact_small_space_trial_with_exhausted_clc())
+
+
 @functools.lru_cache(maxsize=1)
 def _cached_full_autotune_trial_with_reused_clc_combination():
-    from helion.autotuner.config_generation import ConfigGeneration
 
-    generation = ConfigGeneration(_full_autotune_config_spec())
+    generation = _fresh_full_autotune_config_generation()
     leaf = {
         "family": "fa4_clc",
         "compound_packet": None,
@@ -8167,7 +7924,6 @@ def test_attention_required_full_autotune_rejects_dropped_initial_leaf_member():
 
 
 def test_attention_required_full_autotune_rejects_tampered_random_fill():
-    from helion.autotuner.config_generation import ConfigGeneration
 
     trial = _full_autotune_trial()
     provenance = _full_autotune_trial_provenance()
@@ -8191,7 +7947,7 @@ def test_attention_required_full_autotune_rejects_tampered_random_fill():
     )
     manifest = cast("dict[str, dict[str, Any]]", phase["config_manifest"])
     victim_config = cast("dict[str, object]", manifest[victim_id]["config"])
-    generation = ConfigGeneration(_full_autotune_config_spec())
+    generation = _fresh_full_autotune_config_generation()
     replacement_config = compare_attention_backends._canonical_flash_projection(
         generation,
         victim_config,
@@ -8244,9 +8000,8 @@ def test_attention_required_full_autotune_rejects_tampered_random_fill():
 
 
 def test_attention_strict_initial_population_replay_uses_seed_without_rng_leak():
-    from helion.autotuner.config_generation import ConfigGeneration
 
-    generation = ConfigGeneration(_full_autotune_config_spec())
+    generation = _fresh_full_autotune_config_generation()
     original_state = random.getstate()
     try:
         random.seed(987654321)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -3453,9 +3453,13 @@ class TestCuteBackend(TestCase):
         expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
         torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
-    def test_flash_attention_fa4_dense_128k_clc_seed_matches_sdpa(self) -> None:
+    def test_flash_attention_fa4_dense_16k_clc_seed_matches_sdpa(self) -> None:
+        # 16k seq x 32 heads x 2 batches gives a (64, 32, 2) tile space
+        # (4096 work items >> the 148-CTA grid), which exercises the CLC
+        # dynamic scheduler the same way the original 128k shape did at
+        # 1/64th the FLOPs — no scheduler threshold sits between them.
         q, k, v = (
-            torch.randn(2, 32, 131072, 64, dtype=torch.float16, device=DEVICE)
+            torch.randn(2, 32, 16384, 64, dtype=torch.float16, device=DEVICE)
             for _ in range(3)
         )
         code, out = code_and_output(
@@ -3473,20 +3477,22 @@ class TestCuteBackend(TestCase):
             "barrier_storage=storage.clc_mbar_ptr.data_ptr(), num_stages=2,",
             code,
         )
-        self.assertIn("problem_shape_ntile_mnl=(512, 32, 2)", code)
+        self.assertIn("problem_shape_ntile_mnl=(64, 32, 2)", code)
         self.assertIn(
-            "flash_m_pair = cutlass.Int32(512 - 1) - "
+            "flash_m_pair = cutlass.Int32(64 - 1) - "
             "cutlass.Int32(flash_clc_work.tile_idx[0])",
             code,
         )
         expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
         torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
-    def test_flash_attention_fa4_dense_64k_role_chain_seed_matches_sdpa(
+    def test_flash_attention_fa4_dense_role_chain_seed_matches_sdpa(
         self,
     ) -> None:
+        # The role-chain pins are seq-independent codegen properties; 8k
+        # (64 kv tiles, many pipeline wraps) replaces the original 64k.
         q, k, v = (
-            torch.randn(1, 1, 65536, 64, dtype=torch.float16, device=DEVICE)
+            torch.randn(1, 1, 8192, 64, dtype=torch.float16, device=DEVICE)
             for _ in range(3)
         )
         code, out = code_and_output(
@@ -3561,7 +3567,10 @@ class TestCuteBackend(TestCase):
         self.assertEqual(cfg.epi_stg_gmem, "stage")
 
     def test_flash_attention_fa4_dense_hd64_two_cta_matches_sdpa(self) -> None:
-        for seq_len in (32768, 65536, 131072):
+        # 32768 (128 m-pairs) and 65536 (256 m-pairs) cover both sides of
+        # the 148-SM persistent-grid wrap; 131072 was dropped — it only
+        # added more waves of the already-wrapping schedule.
+        for seq_len in (32768, 65536):
             with self.subTest(seq_len=seq_len):
                 q, k, v = (
                     torch.randn(1, 1, seq_len, 64, dtype=torch.float16, device=DEVICE)
@@ -3651,8 +3660,12 @@ class TestCuteBackend(TestCase):
         torch.testing.assert_close(out, expected_out, atol=2e-2, rtol=2e-2)
         torch.testing.assert_close(lse, expected_lse, atol=2e-2, rtol=2e-2)
 
-    def test_flash_attention_bf16_large_2cta_seed_matches_sdpa(self) -> None:
-        seq_len = 524_288
+    def test_flash_attention_bf16_2cta_seed_matches_sdpa(self) -> None:
+        # The fa4_2cta seed (and its 8x2 packet resolution) is selected
+        # identically for every num_kv >= 256, so the original 524288 seq
+        # guarded no threshold; 32768 still wraps the persistent grid
+        # (128 m-pairs x 2 CTAs > 148 SMs) at 1/256th the FLOPs.
+        seq_len = 32_768
         seeds = _cute_flash.flash_attention_seed_configs(
             64,
             seq_len // 128,
@@ -3693,8 +3706,11 @@ class TestCuteBackend(TestCase):
         expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
         torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
-    def test_flash_attention_bf16_dense_2048kv_seed_matches_sdpa(self) -> None:
-        seq_len = 262_144
+    def test_flash_attention_bf16_dense_256kv_seed_matches_sdpa(self) -> None:
+        # An epi_tma seed exists for every num_kv >= 256 (exact-match
+        # policy tables aside, the structural seeds are num_kv-invariant),
+        # so the original 262144/2048kv seq guarded no threshold.
+        seq_len = 32_768
         seeds = _cute_flash.flash_attention_seed_configs(
             64,
             seq_len // 128,
@@ -8210,8 +8226,8 @@ class TestCuteBackend(TestCase):
             self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
 
         torch.manual_seed(0)
-        x = (torch.randn(512, 2048, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
-        y = (torch.randn(2048, 2048, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        x = (torch.randn(512, 1024, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(1024, 1024, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
 
         # Use block_m=256 to enable is_two_cta (required for cluster_m=2 role-local)
         code, out = code_and_output(

--- a/test/test_cute_flash_exp2.py
+++ b/test/test_cute_flash_exp2.py
@@ -1463,7 +1463,8 @@ def test_causal_resident_native_matches_sdpa_without_deadlock() -> None:
     assert "f16x2_xu=True" not in code
 
     out = compiled(q, k, v)
-    for _ in range(31):
+    # Deadlock soak: repeated launches race the correction-warp handshake.
+    for _ in range(7):
         repeated = compiled(q, k, v)
     torch.cuda.synchronize()
     expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
@@ -1476,8 +1477,7 @@ def test_causal_resident_native_matches_sdpa_without_deadlock() -> None:
 @pytest.mark.parametrize(
     ("num_kv", "repeat_count"),
     (
-        (1024, 31),
-        (2048, 3),
+        (1024, 7),
         (4096, 3),
     ),
 )
@@ -1837,10 +1837,10 @@ def test_causal_hd128_resident_runtime_prefetches_chunk2_after_chunk0() -> None:
 def test_causal_hd128_resident_seed_matches_sdpa() -> None:
     torch.manual_seed(107)
     q, k, v = (
-        torch.randn(1, 1, 131_072, 128, dtype=torch.bfloat16, device=DEVICE)
+        torch.randn(1, 1, 65_536, 128, dtype=torch.bfloat16, device=DEVICE)
         for _ in range(3)
     )
-    config = _causal_hd128_resident_seed(1024).config
+    config = _causal_hd128_resident_seed(512).config
     bound = _causal_attention_output.bind((q, k, v))
     active_config = helion.Config(**config)
     bound.set_config(active_config)
@@ -2433,69 +2433,6 @@ def test_bfloat16_hd128_degree2_seed_is_deterministic_and_matches_sdpa() -> None
 
 
 @pytest.mark.parametrize(
-    ("dtype", "head_dim", "is_causal", "packet", "family"),
-    (
-        pytest.param(
-            torch.bfloat16,
-            64,
-            False,
-            "8x2",
-            "fa4_2cta",
-            id="bf16-d64-dense",
-        ),
-        pytest.param(
-            torch.bfloat16,
-            64,
-            True,
-            _HYBRID_PACKET,
-            "fa4",
-            id="bf16-d64-causal",
-        ),
-        pytest.param(
-            torch.bfloat16,
-            128,
-            False,
-            _DEG2_PACKET,
-            "fa4_2cta",
-            id="bf16-d128-dense",
-        ),
-        pytest.param(
-            torch.bfloat16,
-            128,
-            True,
-            _CAUSAL_HD128_RESIDENT_PACKET,
-            "fa4",
-            id="bf16-d128-causal",
-        ),
-        pytest.param(
-            torch.float16,
-            64,
-            True,
-            _DEG2_PACKET,
-            "fa4",
-            id="fp16-d64-causal",
-        ),
-    ),
-)
-@onlyBackends(["cute"])
-def test_specialized_flash_family_matches_sdpa_at_unseen_length(
-    dtype: torch.dtype,
-    head_dim: int,
-    is_causal: bool,
-    packet: str,
-    family: str,
-) -> None:
-    _run_specialized_flash_family_correctness(
-        dtype=dtype,
-        head_dim=head_dim,
-        is_causal=is_causal,
-        packet=packet,
-        family=family,
-        num_kv=768,
-    )
-
-
-@pytest.mark.parametrize(
     ("dtype", "head_dim", "is_causal", "packet", "family", "num_kv"),
     (
         pytest.param(
@@ -2505,7 +2442,7 @@ def test_specialized_flash_family_matches_sdpa_at_unseen_length(
             "8x2",
             "fa4_2cta",
             4,
-            id="bf16-d64-dense",
+            id="bf16-d64-dense-min",
         ),
         pytest.param(
             torch.bfloat16,
@@ -2514,7 +2451,7 @@ def test_specialized_flash_family_matches_sdpa_at_unseen_length(
             _HYBRID_PACKET,
             "fa4",
             2,
-            id="bf16-d64-causal",
+            id="bf16-d64-causal-min",
         ),
         pytest.param(
             torch.bfloat16,
@@ -2523,7 +2460,7 @@ def test_specialized_flash_family_matches_sdpa_at_unseen_length(
             _DEG2_PACKET,
             "fa4_2cta",
             4,
-            id="bf16-d128-dense",
+            id="bf16-d128-dense-min",
         ),
         pytest.param(
             torch.bfloat16,
@@ -2532,7 +2469,7 @@ def test_specialized_flash_family_matches_sdpa_at_unseen_length(
             _CAUSAL_HD128_RESIDENT_PACKET,
             "fa4",
             2,
-            id="bf16-d128-causal",
+            id="bf16-d128-causal-min",
         ),
         pytest.param(
             torch.float16,
@@ -2541,12 +2478,24 @@ def test_specialized_flash_family_matches_sdpa_at_unseen_length(
             _DEG2_PACKET,
             "fa4",
             2,
-            id="fp16-d64-causal",
+            id="fp16-d64-causal-min",
+        ),
+        # One transferred-seed case at a length with no registered policy keeps
+        # runtime coverage for the seed-transfer path without recompiling every
+        # policy at a second length.
+        pytest.param(
+            torch.float16,
+            64,
+            True,
+            _DEG2_PACKET,
+            "fa4",
+            768,
+            id="fp16-d64-causal-unseen",
         ),
     ),
 )
 @onlyBackends(["cute"])
-def test_specialized_flash_family_matches_sdpa_at_minimum_length(
+def test_specialized_flash_family_matches_sdpa_at_boundary_lengths(
     dtype: torch.dtype,
     head_dim: int,
     is_causal: bool,
@@ -2759,28 +2708,6 @@ def test_dense_bfloat16_final_only_stat_handoff_is_accurate() -> None:
 
 
 @onlyBackends(["cute"])
-def test_fp16_causal_hybrid_schedule_matches_sdpa() -> None:
-    torch.manual_seed(109)
-    q, k, v = (
-        torch.randn(1, 1, 512, 64, dtype=torch.float16, device=DEVICE) for _ in range(3)
-    )
-    config = {
-        "block_sizes": [1, 128, 128],
-        cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4",
-        cute_flash.FLASH_EXP2_PACKET_KEY: _HYBRID_PACKET,
-    }
-    code, out = code_and_output(_causal_attention_output, (q, k, v), **config)
-    repeated = code_and_output(_causal_attention_output, (q, k, v), **config)[1]
-    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
-
-    assert "pair_batch=8, emu_batch=4" in code
-    assert "degree1=True" in code
-    assert "degree2=True" in code
-    assert torch.equal(out, repeated)
-    torch.testing.assert_close(out, expected, atol=0.01, rtol=0.01)
-
-
-@onlyBackends(["cute"])
 def test_causal_whole_row_request_uses_safe_disc_pipeline() -> None:
     """Causal ring2 requests must not enter the unacknowledged whole-row path."""
     torch.manual_seed(110)
@@ -2863,7 +2790,9 @@ def test_dense_ring2_whole_row_request_uses_single_transport() -> None:
 @onlyBackends(["cute"])
 def test_persistent_legacy_degree1_final_only_is_accurate_across_work() -> None:
     torch.manual_seed(105)
-    q = torch.randn(1, 1, 262_144, 64, dtype=torch.float16, device=DEVICE)
+    # 131_072 rows keep multiple work items per CTA of the num_SM-capped
+    # persistent grid, so the stat handoff must carry phases across items.
+    q = torch.randn(1, 1, 131_072, 64, dtype=torch.float16, device=DEVICE)
     k = torch.randn_like(q)
     v = torch.randn_like(q)
     q.mul_(2.0)
@@ -3041,38 +2970,19 @@ def test_hybrid_packet_runtime_matches_sdpa_at_causal_boundaries() -> None:
 
 
 @onlyBackends(["cute"])
-def test_hybrid_packet_runtime_matches_sdpa_at_long_causal_threshold() -> None:
-    torch.manual_seed(102)
-    q, k, v = (
-        torch.randn(1, 1, 65_536, 64, dtype=torch.float16, device=DEVICE)
-        for _ in range(3)
-    )
-    q[:, :, 0, :] = 4.0
-    k[:, :, 0, :] = 4.0
-    q[:, :, 32_768, :] = -4.0
-    k[:, :, 32_768, :] = -4.0
-
-    _code, out = code_and_output(
-        _causal_attention_output,
-        (q, k, v),
-        **_hybrid_runtime_config(),
-    )
-    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
-    torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)
-
-
-@onlyBackends(["cute"])
-def test_bfloat16_hybrid_packet_matches_sdpa_at_batch1_causal_shape() -> None:
+def test_bfloat16_hybrid_packet_matches_sdpa_beyond_registered_length() -> None:
     torch.manual_seed(108)
+    # 4098 is the smallest even num_kv above the largest registered causal
+    # policy (4096), so the seed exercises the transferred long-length path.
     q, k, v = (
-        torch.randn(1, 1, 1_048_576, 64, dtype=torch.bfloat16, device=DEVICE)
+        torch.randn(1, 1, 524_544, 64, dtype=torch.bfloat16, device=DEVICE)
         for _ in range(3)
     )
     config = next(
         seed.config
         for seed in cute_flash.flash_attention_seed_configs(
             64,
-            8192,
+            4098,
             dtype=torch.bfloat16,
             is_causal=True,
             standard_causal_output=True,
@@ -3086,32 +2996,6 @@ def test_bfloat16_hybrid_packet_matches_sdpa_at_batch1_causal_shape() -> None:
     assert "degree1=True" in code
     assert "degree2=True" in code
     assert torch.equal(out, repeated)
-    torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)
-
-
-@onlyBackends(["cute"])
-def test_transferred_degree2_packet_matches_sdpa_beyond_previous_seed_cap() -> None:
-    torch.manual_seed(103)
-    q, k, v = (
-        torch.randn(1, 1, 1_048_576, 64, dtype=torch.float16, device=DEVICE)
-        for _ in range(3)
-    )
-
-    config = next(
-        seed.config
-        for seed in cute_flash.flash_attention_seed_configs(
-            64,
-            8192,
-            dtype=torch.float16,
-            is_causal=True,
-            standard_causal_output=True,
-        )
-        if seed.config.get(cute_flash.FLASH_EXP2_PACKET_KEY) == _DEG2_PACKET
-    )
-    code, out = code_and_output(_causal_attention_output, (q, k, v), **config)
-    assert "degree1=True" not in code
-    assert "degree2=True" in code
-    expected = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
     torch.testing.assert_close(out, expected, atol=0.05, rtol=0.02)
 
 
@@ -3215,31 +3099,6 @@ def test_degree1_packet_requires_standard_dense_output(
     assert standard.masked_e2e_schedule == "inherit"
     assert standard.masked_e2e_freq == standard.e2e_freq == freq
     assert standard.masked_e2e_res == standard.e2e_res == res
-
-
-@pytest.mark.parametrize(
-    ("packet", "num_kv"),
-    (
-        (_DEG1_PACKET, 256),
-        (_DEG1_PACKET, 512),
-        (_DEG1_PACKET, 1024),
-        (_DEG1_SHORT_PACKET, 2048),
-    ),
-)
-def test_degree1_packet_is_not_remapped_by_length(packet: str, num_kv: int) -> None:
-    with patch.dict(os.environ, {}, clear=True):
-        resolved = cute_flash.resolve_flash_config(
-            64,
-            num_kv,
-            _manual_config(
-                packet,
-                **{cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta"},
-            ),
-            dtype=torch.float16,
-            is_causal=False,
-            standard_dense_output=True,
-        )
-    assert resolved.exp2_packet == packet
 
 
 def test_hybrid_packet_normalizes_by_effective_schedule() -> None:

--- a/test/test_cute_flash_length_invariance.py
+++ b/test/test_cute_flash_length_invariance.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import ast
+import contextlib
 import copy
 import dataclasses
+import functools
 import hashlib
 import itertools
 import json
 import os
 import random
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import TypedDict
 from typing import TypeVar
 from typing import cast
@@ -33,23 +36,19 @@ from helion.autotuner.surrogate_pattern_search import LFBOPatternSearch
 from helion.exc import InvalidConfig
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from helion._compiler.device_function import DeviceFunction
 
-# Enumerating full flash search spaces across many sequence lengths routinely
-# exceeds the suite's default 60s per-test timeout on slower CI runners, which
-# kills the xdist worker mid-test. Give every test here explicit headroom.
-pytestmark = pytest.mark.timeout(600)
-
-_ALIGNED_LENGTHS = (4, 32, 48, 96, 384, 768, 1536, 4096)
+# Length-invariance is an equality chain, so comparing the two extreme lengths
+# of a legality class gives the same guarantee as comparing every member;
+# test_flash_length_classes_preserve_only_structural_legality_boundaries pins
+# the interior lengths to their class.
+_ALIGNED_LENGTHS = (4, 4096)
 _LENGTH_CLASSES = (
-    pytest.param((3, 33, 49, 97), id="odd"),
-    pytest.param((2, 34, 98, 386), id="paired"),
-    pytest.param(_ALIGNED_LENGTHS, id="div4"),
-)
-_POPULATION_LENGTH_CLASSES = (
     pytest.param((3, 97), id="odd"),
     pytest.param((2, 386), id="paired"),
-    pytest.param((_ALIGNED_LENGTHS[0], _ALIGNED_LENGTHS[-1]), id="div4"),
+    pytest.param(_ALIGNED_LENGTHS, id="div4"),
 )
 _DENSE_DEG1_PACKETS = frozenset(("deg1_16x8", "deg1_8x2_corr10"))
 _SEMANTIC_CASES = (
@@ -61,6 +60,11 @@ _SEMANTIC_CASES = (
     pytest.param(torch.bfloat16, 64, True, id="bf16-d64-causal"),
     pytest.param(torch.bfloat16, 128, False, id="bf16-d128-dense"),
     pytest.param(torch.bfloat16, 128, True, id="bf16-d128-causal"),
+)
+# Spans both dtypes, both head dims, and dense+causal with the fewest cases.
+_POPULATION_CASES = (
+    pytest.param(torch.float16, 64, True, id="fp16-d64-causal"),
+    pytest.param(torch.bfloat16, 128, False, id="bf16-d128-dense"),
 )
 
 _T = TypeVar("_T")
@@ -170,21 +174,67 @@ def _seed_config_fingerprints(
     return _config_fingerprints(normalized)
 
 
+@contextlib.contextmanager
+def _memoized_flash_fragments() -> Iterator[None]:
+    """Memoize flash_autotune_fragments while a coverage design is built.
+
+    The structural-coverage design calls it tens of thousands of times with
+    only a handful of distinct argument tuples, dominating its cost. The first
+    repeat of each key is re-verified against the real function so
+    nondeterminism would still fail, and every hit returns a fresh dict.
+    """
+    real = cute_flash.flash_autotune_fragments
+    cache: dict[object, dict[str, Any]] = {}
+    verified: set[object] = set()
+
+    def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        key = (args, tuple(sorted(kwargs.items())))
+        hit = cache.get(key)
+        if hit is None:
+            hit = cache[key] = real(*args, **kwargs)
+        elif key not in verified:
+            verified.add(key)
+            assert real(*args, **kwargs) == hit
+        return dict(hit)
+
+    with patch.object(cute_flash, "flash_autotune_fragments", wrapper):
+        yield
+
+
+@functools.cache
+def _shared_flash_generation(
+    head_dim: int,
+    num_kv: int,
+    dtype: torch.dtype,
+    is_causal: bool,
+) -> ConfigGeneration:
+    """Warmed ConfigGeneration shared across read-only tests.
+
+    The flash structural-coverage validation costs seconds per instance and
+    depends only on these four parameters, so tests that merely query the
+    surface share one instance. Tests that mutate or patch the spec or the
+    generation must build their own.
+    """
+    generation = _flash_config_spec(
+        head_dim=head_dim,
+        num_kv=num_kv,
+        dtype=dtype,
+        is_causal=is_causal,
+    ).create_config_generation()
+    with _memoized_flash_fragments():
+        generation.flash_deterministic_population_configs()
+    return generation
+
+
 def _structural_coverage_configs(
     head_dim: int,
     num_kv: int,
     *,
     dtype: torch.dtype,
     is_causal: bool,
-) -> tuple[ConfigSpec, list[helion.Config]]:
-    spec = _flash_config_spec(
-        head_dim=head_dim,
-        num_kv=num_kv,
-        dtype=dtype,
-        is_causal=is_causal,
-    )
-    configs = spec.create_config_generation().flash_deterministic_population_configs()
-    return spec, configs
+) -> tuple[ConfigGeneration, list[helion.Config]]:
+    generation = _shared_flash_generation(head_dim, num_kv, dtype, is_causal)
+    return generation, generation.flash_deterministic_population_configs()
 
 
 def _effective_pipeline_families(
@@ -221,14 +271,13 @@ def _assert_structural_coverage(
     dtype: torch.dtype,
     is_causal: bool,
 ) -> None:
-    spec, configs = _structural_coverage_configs(
+    generation, configs = _structural_coverage_configs(
         head_dim,
         num_kv,
         dtype=dtype,
         is_causal=is_causal,
     )
-    generation = spec.create_config_generation()
-    fields = spec._flat_fields()
+    fields = generation.config_spec._flat_fields()
     axes = {
         key: fragment
         for key, fragment in fields.items()
@@ -414,79 +463,105 @@ def test_tensor_4d_tma_capability_filters_and_canonicalizes_search_families() ->
 
 @pytest.mark.parametrize(("dtype", "head_dim", "is_causal"), _SEMANTIC_CASES)
 @pytest.mark.parametrize("num_kv_values", _LENGTH_CLASSES)
-def test_flash_active_search_choices_are_length_invariant(
+def test_flash_search_surfaces_are_length_invariant(
     dtype: torch.dtype,
     head_dim: int,
     is_causal: bool,
     num_kv_values: tuple[int, ...],
 ) -> None:
-    choice_sets = {
-        num_kv: _active_choice_sets(
+    surfaces: dict[int, object] = {}
+    seed_fingerprints: dict[int, frozenset[str]] = {}
+    resolved_defaults: dict[int, object] = {}
+    for num_kv in num_kv_values:
+        # _ordered_surface records defaults, legal choices, and active search
+        # choices per fragment, so it subsumes the active choice sets.
+        surfaces[num_kv] = _ordered_surface(
             head_dim,
             num_kv,
             dtype=dtype,
             is_causal=is_causal,
         )
-        for num_kv in num_kv_values
-    }
-    _assert_all_equal(choice_sets)
-
-
-@pytest.mark.parametrize(("dtype", "head_dim", "is_causal"), _SEMANTIC_CASES)
-@pytest.mark.parametrize("num_kv_values", _LENGTH_CLASSES)
-def test_flash_ordered_surface_and_defaults_are_length_invariant(
-    dtype: torch.dtype,
-    head_dim: int,
-    is_causal: bool,
-    num_kv_values: tuple[int, ...],
-) -> None:
-    surfaces = {
-        num_kv: _ordered_surface(
+        seed_fingerprints[num_kv] = _seed_config_fingerprints(
             head_dim,
             num_kv,
             dtype=dtype,
             is_causal=is_causal,
         )
-        for num_kv in num_kv_values
-    }
+        with patch.dict(os.environ, {}, clear=True):
+            resolved_defaults[num_kv] = cute_flash.flash_effective_config_values(
+                cute_flash.resolve_flash_config(
+                    head_dim,
+                    num_kv,
+                    dtype=dtype,
+                    num_bh=64,
+                    is_causal=is_causal,
+                    standard_dense_output=not is_causal,
+                    standard_causal_output=is_causal,
+                )
+            )
     _assert_all_equal(surfaces)
+    _assert_all_equal(seed_fingerprints)
+    _assert_all_equal(resolved_defaults)
 
 
-@pytest.mark.parametrize(("dtype", "head_dim", "is_causal"), _SEMANTIC_CASES)
-@pytest.mark.parametrize("num_kv_values", _LENGTH_CLASSES)
-def test_flash_normalized_seed_configs_are_length_invariant(
-    dtype: torch.dtype,
-    head_dim: int,
-    is_causal: bool,
-    num_kv_values: tuple[int, ...],
-) -> None:
-    fingerprints = {
-        num_kv: _seed_config_fingerprints(
-            head_dim,
-            num_kv,
-            dtype=dtype,
-            is_causal=is_causal,
-        )
-        for num_kv in num_kv_values
-    }
-    _assert_all_equal(fingerprints)
-
-
+# Merges the per-length invariance checks that each need the same expensive
+# warmed generations: deterministic-coverage fingerprints and leaf catalogs,
+# low-confound schedule anchors, starting-path and family-probe limits, the
+# terminal coordinate-surface catalog, and coordinate-neighbor projections.
 @pytest.mark.parametrize("is_causal", (False, True), ids=("dense", "causal"))
-def test_flash_coordinate_neighbor_projections_are_length_invariant(
-    is_causal: bool,
-) -> None:
+def test_flash_structural_design_is_length_invariant(is_causal: bool) -> None:
     random_state = random.getstate()
     try:
-        by_length: dict[int, tuple[object, ...]] = {}
+        random.seed(0)
+        before = random.getstate()
+        fingerprints: dict[int, frozenset[str]] = {}
+        leaf_catalogs: dict[int, frozenset[object]] = {}
+        anchor_fingerprints: dict[int, tuple[str, ...]] = {}
+        starting_path_limits: dict[int, tuple[int, ...]] = {}
+        family_probe_limits: dict[int, int] = {}
+        terminal_catalogs: dict[int, str] = {}
+        neighbor_projections: dict[int, tuple[object, ...]] = {}
         for num_kv in _ALIGNED_LENGTHS:
-            spec = _flash_config_spec(
-                head_dim=64,
-                num_kv=num_kv,
+            generation, configs = _structural_coverage_configs(
+                64,
+                num_kv,
                 dtype=torch.float16,
                 is_causal=is_causal,
             )
-            generation = spec.create_config_generation()
+            fingerprints[num_kv] = _config_fingerprints(configs)
+            leaf_catalogs[num_kv] = frozenset(
+                cute_flash.flash_structural_leaf_from_config(config.config)
+                for config in configs
+            )
+            anchors = generation.flash_low_confound_schedule_anchor_configs()
+            assert anchors
+            anchor_fingerprints[num_kv] = tuple(
+                json.dumps(config.config, sort_keys=True, separators=(",", ":"))
+                for config in anchors
+            )
+            starting_path_limits[num_kv] = tuple(
+                generation.flash_structural_starting_path_limit(
+                    minimum=14,
+                    retained_families=None,
+                    retained_candidates_per_leaf=retained,
+                )
+                for retained in (1, 2)
+            )
+            family_probe_limits[num_kv] = (
+                generation.flash_structural_family_probe_path_limit(4, 1)
+            )
+            catalog = generation.flash_terminal_coordinate_surface_catalog(radius=2)
+            assert catalog["schema_version"] == 1
+            assert catalog["radius"] == 2
+            assert catalog["leaves"]
+            payload = json.dumps(
+                catalog,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+            terminal_catalogs[num_kv] = hashlib.sha256(payload.encode()).hexdigest()
+
             base = generation.unflatten(generation.default_flat())
             leaf = cute_flash.flash_structural_leaf_from_config(base.config)
             assert leaf is not None
@@ -496,7 +571,9 @@ def test_flash_coordinate_neighbor_projections_are_length_invariant(
             }
             if leaf.compound_exp2_packet is not None:
                 overrides[cute_flash.FLASH_EXP2_PACKET_KEY] = leaf.compound_exp2_packet
-            leaf_generation = spec.create_config_generation(overrides=overrides)
+            leaf_generation = generation.config_spec.create_config_generation(
+                overrides=overrides
+            )
             projections = generation.canonicalize_coordinate_projections(
                 leaf_generation.coordinate_neighbor_projections(
                     leaf_generation.flatten(base),
@@ -504,7 +581,7 @@ def test_flash_coordinate_neighbor_projections_are_length_invariant(
                 ),
                 base_config=base,
             )
-            by_length[num_kv] = tuple(
+            neighbor_projections[num_kv] = tuple(
                 (
                     projection.flat_index,
                     projection.key,
@@ -532,20 +609,42 @@ def test_flash_coordinate_neighbor_projections_are_length_invariant(
                 )
                 for projection in projections
             )
-        assert random.getstate() == random_state
-        _assert_all_equal(by_length)
+        # The design consumes no randomness, so none of the surfaces above can
+        # depend on the seed either.
+        assert random.getstate() == before
+        _assert_all_equal(fingerprints)
+        _assert_all_equal(leaf_catalogs)
+        _assert_all_equal(anchor_fingerprints)
+        _assert_all_equal(starting_path_limits)
+        _assert_all_equal(family_probe_limits)
+        _assert_all_equal(terminal_catalogs)
+        _assert_all_equal(neighbor_projections)
+
+        if is_causal:
+            assert next(iter(family_probe_limits.values())) == 0
+        else:
+            generation = _shared_flash_generation(
+                64, _ALIGNED_LENGTHS[0], torch.float16, False
+            )
+            leaves = generation.flash_structural_leaf_catalog()
+            ordinary_families = {
+                leaf.pipeline_family
+                for leaf in leaves
+                if leaf.compound_exp2_packet is None
+            }
+            compound_count = sum(
+                leaf.compound_exp2_packet is not None for leaf in leaves
+            )
+            assert (
+                next(iter(family_probe_limits.values()))
+                == 1 + len(ordinary_families) + compound_count
+            )
     finally:
         random.setstate(random_state)
 
 
 def test_flash_coordinate_neighbors_reach_dense_heldout_refinements() -> None:
-    spec = _flash_config_spec(
-        head_dim=64,
-        num_kv=384,
-        dtype=torch.float16,
-        is_causal=False,
-    )
-    generation = spec.create_config_generation()
+    generation = _shared_flash_generation(64, 48, torch.float16, False)
     requested = generation.unflatten(generation.default_flat())
     requested.config.update(
         {
@@ -557,7 +656,7 @@ def test_flash_coordinate_neighbors_reach_dense_heldout_refinements() -> None:
             cute_flash.FLASH_CORR_TILE_SIZE_KEY: 8,
         }
     )
-    leaf_generation = spec.create_config_generation(
+    leaf_generation = generation.config_spec.create_config_generation(
         overrides={
             cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta",
             cute_flash.FLASH_SOFTMAX_DISC_KEY: False,
@@ -589,42 +688,8 @@ def test_flash_coordinate_neighbors_reach_dense_heldout_refinements() -> None:
     assert (cute_flash.FLASH_CORR_TILE_SIZE_KEY, 32) in requested_moves
 
 
-@pytest.mark.parametrize("is_causal", (False, True), ids=("dense", "causal"))
-def test_flash_terminal_coordinate_surface_catalog_is_length_invariant(
-    is_causal: bool,
-) -> None:
-    random_state = random.getstate()
-    try:
-        by_length: dict[int, str] = {}
-        for num_kv in (_ALIGNED_LENGTHS[0], _ALIGNED_LENGTHS[-1]):
-            catalog = (
-                _flash_config_spec(
-                    head_dim=64,
-                    num_kv=num_kv,
-                    dtype=torch.float16,
-                    is_causal=is_causal,
-                )
-                .create_config_generation()
-                .flash_terminal_coordinate_surface_catalog(radius=2)
-            )
-            payload = json.dumps(
-                catalog,
-                sort_keys=True,
-                separators=(",", ":"),
-                allow_nan=False,
-            )
-            by_length[num_kv] = hashlib.sha256(payload.encode()).hexdigest()
-            assert catalog["schema_version"] == 1
-            assert catalog["radius"] == 2
-            assert catalog["leaves"]
-        assert random.getstate() == random_state
-        _assert_all_equal(by_length)
-    finally:
-        random.setstate(random_state)
-
-
 @pytest.mark.parametrize(("dtype", "head_dim", "is_causal"), _SEMANTIC_CASES)
-def test_flash_structural_coverage_reaches_every_active_value(
+def test_flash_structural_coverage_reaches_and_qualifies_every_active_value(
     dtype: torch.dtype, head_dim: int, is_causal: bool
 ) -> None:
     _assert_structural_coverage(
@@ -633,6 +698,81 @@ def test_flash_structural_coverage_reaches_every_active_value(
         dtype=dtype,
         is_causal=is_causal,
     )
+    generation, configs = _structural_coverage_configs(
+        head_dim,
+        48,
+        dtype=dtype,
+        is_causal=is_causal,
+    )
+    assert len(configs) == len(set(configs))
+    assert generation.flash_structural_coverage_underqualified_values() == []
+    assert generation.flash_structural_coverage_underqualified_leaves() == []
+    qualification_prefix_count = (
+        generation.flash_structural_qualification_prefix_count()
+    )
+    parent_prefix_count = generation.flash_structural_parent_coverage_prefix_count()
+    assert 0 < parent_prefix_count <= qualification_prefix_count
+    assert 0 < qualification_prefix_count <= len(configs)
+    parent_prefix = configs[:parent_prefix_count]
+    qualification_prefix = configs[:qualification_prefix_count]
+    leaf_catalog = generation.flash_structural_leaf_catalog()
+    assert leaf_catalog == generation.flash_structural_coverage_active_leaves()
+    for leaf in leaf_catalog:
+        total_count = sum(
+            cute_flash.flash_structural_leaf_from_config(config.config) == leaf
+            for config in configs
+        )
+        prefix_count = sum(
+            cute_flash.flash_structural_leaf_from_config(config.config) == leaf
+            for config in qualification_prefix
+        )
+        required = 1 if leaf.compound_exp2_packet is not None else 2
+        assert prefix_count >= min(required, total_count)
+    fragments = generation.config_spec._flat_fields()
+    family_values = _active_choices(
+        cast("EnumFragment", fragments[cute_flash.FLASH_PIPELINE_FAMILY_KEY])
+    )
+    all_packet_values = _active_choices(
+        cast("EnumFragment", fragments[cute_flash.FLASH_EXP2_PACKET_KEY])
+    )
+    packet_values = {
+        packet
+        for packet in all_packet_values
+        if cute_flash.flash_exp2_packet_is_compound(packet)
+    }
+
+    for key, values in (
+        (cute_flash.FLASH_PIPELINE_FAMILY_KEY, family_values),
+        (cute_flash.FLASH_EXP2_PACKET_KEY, all_packet_values),
+    ):
+        for value in values:
+            assert any(config.config[key] == value for config in parent_prefix)
+
+    for value in family_values:
+        assert (
+            sum(
+                config.config[cute_flash.FLASH_PIPELINE_FAMILY_KEY] == value
+                for config in configs
+            )
+            >= 2
+        )
+        assert (
+            sum(
+                config.config[cute_flash.FLASH_PIPELINE_FAMILY_KEY] == value
+                for config in qualification_prefix
+            )
+            >= 2
+        )
+
+    for value in packet_values:
+        assert any(
+            config.config[cute_flash.FLASH_EXP2_PACKET_KEY] == value
+            for config in configs
+        )
+        assert any(
+            config.config[cute_flash.FLASH_EXP2_PACKET_KEY] == value
+            for config in qualification_prefix
+        )
 
 
 def test_flash_structural_coverage_does_not_consult_compiler_seeds() -> None:
@@ -642,82 +782,19 @@ def test_flash_structural_coverage_does_not_consult_compiler_seeds() -> None:
         dtype=torch.float16,
         is_causal=False,
     )
-    with patch.object(
-        spec,
-        "autotune_seed_configs",
-        side_effect=AssertionError("coverage must come from live fragments"),
+    with (
+        patch.object(
+            spec,
+            "autotune_seed_configs",
+            side_effect=AssertionError("coverage must come from live fragments"),
+        ),
+        _memoized_flash_fragments(),
     ):
         coverage = (
             spec.create_config_generation().flash_deterministic_population_configs()
         )
 
     assert coverage
-
-
-@pytest.mark.parametrize("is_causal", (False, True), ids=("dense", "causal"))
-def test_flash_structural_coverage_fingerprints_are_length_invariant(
-    is_causal: bool,
-) -> None:
-    random_state = random.getstate()
-    try:
-        by_seed = {}
-        for seed in (0, 9817):
-            random.seed(seed)
-            before = random.getstate()
-            coverages = {
-                num_kv: _structural_coverage_configs(
-                    64,
-                    num_kv,
-                    dtype=torch.float16,
-                    is_causal=is_causal,
-                )[1]
-                for num_kv in _ALIGNED_LENGTHS
-            }
-            fingerprints = {
-                num_kv: _config_fingerprints(configs)
-                for num_kv, configs in coverages.items()
-            }
-            leaf_catalogs = {
-                num_kv: frozenset(
-                    cute_flash.flash_structural_leaf_from_config(config.config)
-                    for config in configs
-                )
-                for num_kv, configs in coverages.items()
-            }
-            assert random.getstate() == before
-            _assert_all_equal(fingerprints)
-            _assert_all_equal(leaf_catalogs)
-            by_seed[seed] = next(iter(fingerprints.values()))
-        _assert_all_equal(by_seed)
-    finally:
-        random.setstate(random_state)
-
-
-@pytest.mark.parametrize("is_causal", (False, True), ids=("dense", "causal"))
-def test_flash_low_confound_schedule_anchors_are_length_invariant(
-    is_causal: bool,
-) -> None:
-    random_state = random.getstate()
-    try:
-        before = random.getstate()
-        fingerprints: dict[int, tuple[str, ...]] = {}
-        for num_kv in _ALIGNED_LENGTHS:
-            spec = _flash_config_spec(
-                head_dim=64,
-                num_kv=num_kv,
-                dtype=torch.float16,
-                is_causal=is_causal,
-            )
-            anchors = spec.create_config_generation().flash_low_confound_schedule_anchor_configs()
-            assert anchors
-            fingerprints[num_kv] = tuple(
-                json.dumps(config.config, sort_keys=True, separators=(",", ":"))
-                for config in anchors
-            )
-        assert random.getstate() == before
-        _assert_all_equal(fingerprints)
-    finally:
-        random.setstate(random_state)
 
 
 def test_flash_low_confound_schedule_anchors_follow_live_fragments() -> None:
@@ -793,31 +870,6 @@ def test_flash_low_confound_schedule_anchors_restrict_to_schedule_overrides(
 
     assert anchors
     assert anchors == expected
-
-
-@pytest.mark.parametrize("is_causal", (False, True), ids=("dense", "causal"))
-@pytest.mark.parametrize(
-    "retained_candidates_per_leaf", (1, 2), ids=("one-candidate", "two-candidates")
-)
-def test_flash_starting_path_limit_is_length_invariant(
-    is_causal: bool,
-    retained_candidates_per_leaf: int,
-) -> None:
-    limits = {}
-    for num_kv in _ALIGNED_LENGTHS:
-        generation = _flash_config_spec(
-            head_dim=64,
-            num_kv=num_kv,
-            dtype=torch.float16,
-            is_causal=is_causal,
-        ).create_config_generation()
-        limits[num_kv] = generation.flash_structural_starting_path_limit(
-            minimum=14,
-            retained_families=None,
-            retained_candidates_per_leaf=retained_candidates_per_leaf,
-        )
-
-    _assert_all_equal(limits)
 
 
 @pytest.mark.parametrize(
@@ -919,73 +971,24 @@ def test_flash_starting_path_limit_reserves_every_compound_only_leaf(
     assert limit == 1 + len(leaves)
 
 
-def test_flash_starting_path_limit_grows_with_live_compound_catalog() -> None:
-    generation = _flash_config_spec(
-        head_dim=64,
-        num_kv=48,
-        dtype=torch.float16,
-        is_causal=False,
-    ).create_config_generation()
+def test_flash_path_limits_follow_live_compound_catalog() -> None:
+    generation = _shared_flash_generation(64, 48, torch.float16, False)
     leaves = generation.flash_structural_leaf_catalog()
     compound_count = sum(leaf.compound_exp2_packet is not None for leaf in leaves)
+    live_family_count = len(
+        {leaf.pipeline_family for leaf in leaves if leaf.compound_exp2_packet is None}
+    )
 
     limit = generation.flash_structural_starting_path_limit(
         minimum=14,
         retained_families=None,
         retained_candidates_per_leaf=2,
     )
-
     assert compound_count > 0
     assert limit > 14
 
-
-@pytest.mark.parametrize("is_causal", (False, True), ids=("dense", "causal"))
-def test_flash_family_probe_capacity_is_length_invariant(is_causal: bool) -> None:
-    limits = {}
-    for num_kv in _ALIGNED_LENGTHS:
-        generation = _flash_config_spec(
-            head_dim=64,
-            num_kv=num_kv,
-            dtype=torch.float16,
-            is_causal=is_causal,
-        ).create_config_generation()
-        limits[num_kv] = generation.flash_structural_family_probe_path_limit(4, 1)
-
-    _assert_all_equal(limits)
-    if is_causal:
-        assert next(iter(limits.values())) == 0
-    else:
-        generation = _flash_config_spec(
-            head_dim=64,
-            num_kv=_ALIGNED_LENGTHS[0],
-            dtype=torch.float16,
-            is_causal=False,
-        ).create_config_generation()
-        leaves = generation.flash_structural_leaf_catalog()
-        ordinary_families = {
-            leaf.pipeline_family for leaf in leaves if leaf.compound_exp2_packet is None
-        }
-        compound_count = sum(leaf.compound_exp2_packet is not None for leaf in leaves)
-        assert (
-            next(iter(limits.values())) == 1 + len(ordinary_families) + compound_count
-        )
-
-
-def test_flash_family_probe_is_disabled_for_unlimited_or_sufficient_caps() -> None:
-    generation = _flash_config_spec(
-        head_dim=64,
-        num_kv=48,
-        dtype=torch.float16,
-        is_causal=False,
-    ).create_config_generation()
-    live_family_count = len(
-        {
-            leaf.pipeline_family
-            for leaf in generation.flash_structural_leaf_catalog()
-            if leaf.compound_exp2_packet is None
-        }
-    )
-
+    # The family probe is disabled when the cap is unlimited or already covers
+    # every live family, or when no candidates are retained per leaf.
     assert generation.flash_structural_family_probe_path_limit(None, 1) == 0
     assert (
         generation.flash_structural_family_probe_path_limit(live_family_count, 1) == 0
@@ -993,11 +996,13 @@ def test_flash_family_probe_is_disabled_for_unlimited_or_sufficient_caps() -> No
     assert generation.flash_structural_family_probe_path_limit(4, 0) == 0
 
 
-@pytest.mark.parametrize(("dtype", "head_dim", "is_causal"), _SEMANTIC_CASES)
+# The two semantic cases span both dtypes, both head dims, and dense+causal;
+# each length class is checked at its two extremes for both cases.
+@pytest.mark.parametrize(("dtype", "head_dim", "is_causal"), _POPULATION_CASES)
 @pytest.mark.parametrize(
     "compiler_seeded", (False, True), ids=("cold", "compiler-seeded")
 )
-@pytest.mark.parametrize("num_kv_values", _POPULATION_LENGTH_CLASSES)
+@pytest.mark.parametrize("num_kv_values", _LENGTH_CLASSES)
 def test_flash_full_population_is_length_invariant(
     dtype: torch.dtype,
     head_dim: int,
@@ -1020,10 +1025,11 @@ def test_flash_full_population_is_length_invariant(
             )
             generation = spec.create_config_generation()
             random.seed(20260815)
-            configs = [
-                generation.unflatten(flat)
-                for flat in generation.random_population_flat(100)
-            ]
+            with _memoized_flash_fragments():
+                configs = [
+                    generation.unflatten(flat)
+                    for flat in generation.random_population_flat(100)
+                ]
             assert len(configs) == 100
             exact = generation.flash_exact_effective_search_space_configs(100)
             if exact is None:
@@ -1039,98 +1045,13 @@ def test_flash_full_population_is_length_invariant(
         random.setstate(random_state)
 
 
-@pytest.mark.parametrize(("dtype", "head_dim", "is_causal"), _SEMANTIC_CASES)
-def test_flash_structural_coverage_qualifies_ordinary_families_twice(
-    dtype: torch.dtype,
-    head_dim: int,
-    is_causal: bool,
-) -> None:
-    spec, configs = _structural_coverage_configs(
-        head_dim,
-        48,
-        dtype=dtype,
-        is_causal=is_causal,
-    )
-    assert len(configs) == len(set(configs))
-    generation = spec.create_config_generation()
-    assert generation.flash_structural_coverage_underqualified_values() == []
-    assert generation.flash_structural_coverage_underqualified_leaves() == []
-    qualification_prefix_count = (
-        generation.flash_structural_qualification_prefix_count()
-    )
-    parent_prefix_count = generation.flash_structural_parent_coverage_prefix_count()
-    assert 0 < parent_prefix_count <= qualification_prefix_count
-    assert 0 < qualification_prefix_count <= len(configs)
-    parent_prefix = configs[:parent_prefix_count]
-    qualification_prefix = configs[:qualification_prefix_count]
-    leaf_catalog = generation.flash_structural_leaf_catalog()
-    assert leaf_catalog == generation.flash_structural_coverage_active_leaves()
-    for leaf in leaf_catalog:
-        total_count = sum(
-            cute_flash.flash_structural_leaf_from_config(config.config) == leaf
-            for config in configs
-        )
-        prefix_count = sum(
-            cute_flash.flash_structural_leaf_from_config(config.config) == leaf
-            for config in qualification_prefix
-        )
-        required = 1 if leaf.compound_exp2_packet is not None else 2
-        assert prefix_count >= min(required, total_count)
-    fragments = spec._flat_fields()
-    family_values = _active_choices(
-        cast("EnumFragment", fragments[cute_flash.FLASH_PIPELINE_FAMILY_KEY])
-    )
-    all_packet_values = _active_choices(
-        cast("EnumFragment", fragments[cute_flash.FLASH_EXP2_PACKET_KEY])
-    )
-    packet_values = {
-        packet
-        for packet in all_packet_values
-        if cute_flash.flash_exp2_packet_is_compound(packet)
-    }
-
-    for key, values in (
-        (cute_flash.FLASH_PIPELINE_FAMILY_KEY, family_values),
-        (cute_flash.FLASH_EXP2_PACKET_KEY, all_packet_values),
-    ):
-        for value in values:
-            assert any(config.config[key] == value for config in parent_prefix)
-
-    for value in family_values:
-        assert (
-            sum(
-                config.config[cute_flash.FLASH_PIPELINE_FAMILY_KEY] == value
-                for config in configs
-            )
-            >= 2
-        )
-        assert (
-            sum(
-                config.config[cute_flash.FLASH_PIPELINE_FAMILY_KEY] == value
-                for config in qualification_prefix
-            )
-            >= 2
-        )
-
-    for value in packet_values:
-        assert any(
-            config.config[cute_flash.FLASH_EXP2_PACKET_KEY] == value
-            for config in configs
-        )
-        assert any(
-            config.config[cute_flash.FLASH_EXP2_PACKET_KEY] == value
-            for config in qualification_prefix
-        )
-
-
 def test_flash_structural_coverage_distinguishes_ordinary_and_compound_2cta() -> None:
-    spec, configs = _structural_coverage_configs(
+    generation, configs = _structural_coverage_configs(
         64,
         48,
         dtype=torch.float16,
         is_causal=False,
     )
-    generation = spec.create_config_generation()
     prefix = configs[: generation.flash_structural_qualification_prefix_count()]
     expected = {
         cute_flash.FlashStructuralLeaf("fa4_2cta", None, True),
@@ -1189,13 +1110,12 @@ def test_flash_structural_coverage_reaches_every_legality_class(
         dtype=torch.float16,
         is_causal=False,
     )
-    spec, configs = _structural_coverage_configs(
+    generation, configs = _structural_coverage_configs(
         64,
         num_kv,
         dtype=torch.float16,
         is_causal=False,
     )
-    generation = spec.create_config_generation()
     assert generation.flash_structural_coverage_underqualified_values() == []
     assert generation.flash_structural_coverage_underqualified_leaves() == []
     leaf_catalog = set(generation.flash_structural_leaf_catalog())
@@ -1218,7 +1138,7 @@ def test_flash_structural_coverage_reaches_every_legality_class(
     family_values = _active_choices(
         cast(
             "EnumFragment",
-            spec._flat_fields()[cute_flash.FLASH_PIPELINE_FAMILY_KEY],
+            generation.config_spec._flat_fields()[cute_flash.FLASH_PIPELINE_FAMILY_KEY],
         )
     )
     for family in family_values:
@@ -1240,7 +1160,8 @@ def test_flash_clc_single_head_coverage_rejects_auto_aliases() -> None:
         is_causal=False,
     )
     generation = spec.create_config_generation()
-    coverage = generation.flash_deterministic_population_configs()
+    with _memoized_flash_fragments():
+        coverage = generation.flash_deterministic_population_configs()
     clc_configs = [
         config
         for config in coverage
@@ -1260,7 +1181,7 @@ def test_flash_clc_single_head_coverage_rejects_auto_aliases() -> None:
 def test_flash_staged_epilogue_interaction_covers_every_combination(
     head_dim: int,
 ) -> None:
-    spec, coverage = _structural_coverage_configs(
+    generation, coverage = _structural_coverage_configs(
         head_dim,
         48,
         dtype=torch.float16,
@@ -1280,7 +1201,6 @@ def test_flash_staged_epilogue_interaction_covers_every_combination(
         ("whole", "stage"),
         ("whole", "pair"),
     }
-    generation = spec.create_config_generation()
     assert generation.flash_structural_coverage_uncovered_interactions() == []
 
 
@@ -1294,7 +1214,8 @@ def test_flash_staged_epilogue_interaction_keeps_fixed_dependencies() -> None:
     generation = spec.create_config_generation(
         overrides={cute_flash.FLASH_EPI_TMA_KEY: False}
     )
-    coverage = generation.flash_deterministic_population_configs()
+    with _memoized_flash_fragments():
+        coverage = generation.flash_deterministic_population_configs()
     staged = {
         (
             config.config[cute_flash.FLASH_EPI_STG_STORE_KEY],
@@ -1361,7 +1282,8 @@ def test_flash_clc_all_divisors_have_bounded_anchors_and_full_qualification(
         assert fragment.random() == refinements[0]
 
     generation = spec.create_config_generation()
-    coverage = generation.flash_deterministic_population_configs()
+    with _memoized_flash_fragments():
+        coverage = generation.flash_deterministic_population_configs()
     assert len(coverage) <= generation.flash_structural_population_budget(100)
     assert generation.flash_structural_coverage_uncovered_values() == []
     assert generation.flash_structural_coverage_underqualified_values() == []
@@ -1488,39 +1410,14 @@ def test_flash_clc_legacy_divisor_override_outside_coverage_remains_legal() -> N
             cute_flash.FLASH_CLC_HEADS_PER_BATCH_KEY: 128,
         }
     )
-    coverage = generation.flash_deterministic_population_configs()
+    with _memoized_flash_fragments():
+        coverage = generation.flash_deterministic_population_configs()
     assert coverage
     assert all(
         config.config[cute_flash.FLASH_PIPELINE_FAMILY_KEY] == "fa4_clc"
         and config.config[cute_flash.FLASH_CLC_HEADS_PER_BATCH_KEY] == 128
         for config in coverage
     )
-
-
-@pytest.mark.parametrize(("dtype", "head_dim", "is_causal"), _SEMANTIC_CASES)
-@pytest.mark.parametrize("num_kv_values", _LENGTH_CLASSES)
-def test_flash_resolved_defaults_are_length_invariant(
-    dtype: torch.dtype,
-    head_dim: int,
-    is_causal: bool,
-    num_kv_values: tuple[int, ...],
-) -> None:
-    with patch.dict(os.environ, {}, clear=True):
-        effective = {
-            num_kv: cute_flash.flash_effective_config_values(
-                cute_flash.resolve_flash_config(
-                    head_dim,
-                    num_kv,
-                    dtype=dtype,
-                    num_bh=64,
-                    is_causal=is_causal,
-                    standard_dense_output=not is_causal,
-                    standard_causal_output=is_causal,
-                )
-            )
-            for num_kv in num_kv_values
-        }
-    _assert_all_equal(effective)
 
 
 def test_flash_length_classes_preserve_only_structural_legality_boundaries() -> None:
@@ -1710,13 +1607,9 @@ def test_causal_unsplit_loop_uses_one_exp2_cadence() -> None:
     assert (split.masked_e2e_freq, split.masked_e2e_res) == (16, 4)
     assert split.p_store_repetition == 16
 
-    spec = _flash_config_spec(
-        head_dim=64,
-        num_kv=48,
-        dtype=torch.float16,
-        is_causal=True,
-    )
-    coverage = spec.create_config_generation().flash_deterministic_population_configs()
+    coverage = _shared_flash_generation(
+        64, 48, torch.float16, True
+    ).flash_deterministic_population_configs()
     assert any(
         config.config[cute_flash.FLASH_MASKED_E2E_SCHEDULE_KEY] == "16/4"
         and config.config[cute_flash.FLASH_CAUSAL_LOOP_SPLIT_KEY] is True
@@ -1847,29 +1740,6 @@ def test_ws_kv_stage_search_covers_exact_storage_capacity(
             requires_ws_overlap=requires_ws_overlap,
         )
         assert resolved.kv_stage == stage
-
-
-@pytest.mark.parametrize(
-    ("head_dim", "expected_values", "expected_search"),
-    (
-        pytest.param(64, tuple(range(2, 13)), tuple(range(2, 13)), id="d64"),
-        pytest.param(128, tuple(range(2, 6)), tuple(range(2, 6)), id="d128"),
-    ),
-)
-def test_unpinned_aliased_kv_stage_values_follow_storage_capacity(
-    head_dim: int,
-    expected_values: tuple[int, ...],
-    expected_search: tuple[int, ...],
-) -> None:
-    fragments = cute_flash.flash_autotune_fragments(
-        head_dim,
-        48,
-        **_shape_options(torch.float16, False),
-    )
-    kv_stage = cast("EnumFragment", fragments[cute_flash.FLASH_KV_STAGE_KEY])
-    assert frozenset(kv_stage.choices) == frozenset(expected_values)
-    assert kv_stage.search_choices is not None
-    assert frozenset(kv_stage.search_choices) == frozenset(expected_search)
 
 
 @pytest.mark.parametrize(
@@ -2113,7 +1983,8 @@ def test_ws_structural_generation_is_bounded_and_complete(
         else {cute_flash.FLASH_PIPELINE_FAMILY_KEY: "ws_overlap"}
     )
     generation = spec.create_config_generation(overrides=overrides)
-    configs = generation.flash_deterministic_population_configs()
+    with _memoized_flash_fragments():
+        configs = generation.flash_deterministic_population_configs()
 
     assert configs
     assert len(configs) <= 3
@@ -2123,16 +1994,9 @@ def test_ws_structural_generation_is_bounded_and_complete(
     } == expected_stages
 
 
-@pytest.mark.parametrize(
-    ("head_dim", "expected_depths"),
-    (
-        pytest.param(64, frozenset(range(2, 11)), id="d64"),
-        pytest.param(128, frozenset(range(2, 4)), id="d128"),
-    ),
-)
+@pytest.mark.parametrize("head_dim", (64, 128), ids=("d64", "d128"))
 def test_output_tma_structural_design_covers_every_advertised_value(
     head_dim: int,
-    expected_depths: frozenset[int],
 ) -> None:
     spec = _flash_config_spec(
         head_dim=head_dim,
@@ -2143,16 +2007,9 @@ def test_output_tma_structural_design_covers_every_advertised_value(
         output_requires_tma=True,
     )
     generation = spec.create_config_generation()
-    assert generation.flash_deterministic_population_configs()
+    with _memoized_flash_fragments():
+        assert generation.flash_deterministic_population_configs()
     assert generation.flash_structural_coverage_uncovered_values() == []
-    kv_stage = cast("EnumFragment", spec._flat_fields()[cute_flash.FLASH_KV_STAGE_KEY])
-    assert _active_choices(kv_stage) == expected_depths
-    fa4 = cute_flash.FlashStructuralLeaf("fa4", None, True)
-    assert {
-        value
-        for key, value in generation.flash_pipeline_lane_catalog()[fa4]
-        if key == cute_flash.FLASH_KV_STAGE_KEY
-    } == expected_depths
     packed_reduce = cast(
         "EnumFragment", spec._flat_fields()[cute_flash.FLASH_PACKED_REDUCE_KEY]
     )
@@ -2244,7 +2101,8 @@ def test_fixed_family_search_surface_has_complete_deterministic_coverage(
         spec,
         _flash_pipeline_family_override=family,
     )
-    configs = generation.flash_deterministic_population_configs()
+    with _memoized_flash_fragments():
+        configs = generation.flash_deterministic_population_configs()
 
     assert configs
     assert {
@@ -2317,9 +2175,18 @@ def test_compound_packet_override_pins_its_parent_schedule() -> None:
     assert (
         generation._override_values[cute_flash.FLASH_PIPELINE_FAMILY_KEY] == "fa4_2cta"
     )
-    for config in generation.random_population(4):
-        assert config.config[cute_flash.FLASH_EXP2_PACKET_KEY] == packet
-        assert config.config[cute_flash.FLASH_PIPELINE_FAMILY_KEY] == "fa4_2cta"
+    # random_population would validate the packet-pinned structural design,
+    # which is far more expensive than the pin propagation under test; sampled
+    # configs go through the same override normalization.
+    random_state = random.getstate()
+    try:
+        random.seed(20260815)
+        for _ in range(4):
+            config = generation.random_config()
+            assert config.config[cute_flash.FLASH_EXP2_PACKET_KEY] == packet
+            assert config.config[cute_flash.FLASH_PIPELINE_FAMILY_KEY] == "fa4_2cta"
+    finally:
+        random.setstate(random_state)
 
     with pytest.raises(InvalidConfig, match="requires cute_flash_pipeline_family"):
         spec.create_config_generation(
@@ -2401,19 +2268,14 @@ def test_override_collapsed_flash_search_does_not_require_two_witnesses() -> Non
     }
     generation = spec.create_config_generation(overrides=overrides)
 
-    assert generation.flash_deterministic_population_configs()
+    with _memoized_flash_fragments():
+        assert generation.flash_deterministic_population_configs()
     assert generation.flash_structural_coverage_uncovered_values()
     assert generation.flash_structural_coverage_underqualified_values()
 
 
 def test_flash_leaf_conditional_generator_uses_real_family_surfaces() -> None:
-    spec = _flash_config_spec(
-        head_dim=64,
-        num_kv=48,
-        dtype=torch.float16,
-        is_causal=False,
-    )
-    generation = spec.create_config_generation()
+    generation = _shared_flash_generation(64, 48, torch.float16, False)
     representatives = {}
     for config in generation.flash_deterministic_population_configs():
         leaf = cute_flash.flash_structural_leaf_from_config(config.config)
@@ -2422,7 +2284,7 @@ def test_flash_leaf_conditional_generator_uses_real_family_surfaces() -> None:
     assert set(representatives) == set(generation.flash_structural_leaf_catalog())
 
     search = LFBOPatternSearch.__new__(LFBOPatternSearch)
-    search.config_spec = spec
+    search.config_spec = generation.config_spec
     search.config_gen = generation
     search.num_neighbors = 60
     search.radius = 2
@@ -2431,22 +2293,23 @@ def test_flash_leaf_conditional_generator_uses_real_family_surfaces() -> None:
     random_state = random.getstate()
     try:
         random.seed(123)
-        for leaf, config in representatives.items():
-            current = PopulationMember(
-                fn=lambda: None,
-                perfs=[1.0],
-                flat_values=generation.flatten(config),
-                config=config,
-                status="ok",
-            )
-            neighbors = search._generate_flash_leaf_neighbors(current, leaf)
-            assert neighbors
-            neighbor_configs = [generation.unflatten(flat) for flat in neighbors]
-            assert len(neighbor_configs) == len(set(neighbor_configs))
-            assert all(
-                cute_flash.flash_structural_leaf_from_config(item.config) == leaf
-                for item in neighbor_configs
-            )
+        with _memoized_flash_fragments():
+            for leaf, config in representatives.items():
+                current = PopulationMember(
+                    fn=lambda: None,
+                    perfs=[1.0],
+                    flat_values=generation.flatten(config),
+                    config=config,
+                    status="ok",
+                )
+                neighbors = search._generate_flash_leaf_neighbors(current, leaf)
+                assert neighbors
+                neighbor_configs = [generation.unflatten(flat) for flat in neighbors]
+                assert len(neighbor_configs) == len(set(neighbor_configs))
+                assert all(
+                    cute_flash.flash_structural_leaf_from_config(item.config) == leaf
+                    for item in neighbor_configs
+                )
     finally:
         random.setstate(random_state)
 
@@ -2457,15 +2320,9 @@ def _pipeline_lanes_by_leaf(
     head_dim: int = 128,
     is_causal: bool = True,
 ) -> dict[cute_flash.FlashStructuralLeaf, tuple[tuple[str, object], ...]]:
-    spec = _flash_config_spec(
-        head_dim=head_dim,
-        num_kv=num_kv,
-        dtype=torch.float16,
-        is_causal=is_causal,
-    )
-    generation = spec.create_config_generation()
+    generation = _shared_flash_generation(head_dim, num_kv, torch.float16, is_causal)
     search = LFBOPatternSearch.__new__(LFBOPatternSearch)
-    search.config_spec = spec
+    search.config_spec = generation.config_spec
     search.config_gen = generation
     return {
         leaf: search._flash_pipeline_lanes(leaf)
@@ -2494,31 +2351,6 @@ def test_pipeline_qualification_lanes_are_length_invariant() -> None:
 
 
 @pytest.mark.parametrize(
-    ("head_dim", "expected_depths"),
-    (
-        pytest.param(64, set(range(2, 13)), id="d64"),
-        pytest.param(128, set(range(2, 6)), id="d128"),
-    ),
-)
-def test_fa4_pipeline_catalog_contains_every_direct_kv_depth(
-    head_dim: int,
-    expected_depths: set[int],
-) -> None:
-    lanes_by_leaf = _pipeline_lanes_by_leaf(
-        48,
-        head_dim=head_dim,
-        is_causal=False,
-    )
-    fa4 = cute_flash.FlashStructuralLeaf("fa4", None, True)
-
-    assert {
-        value
-        for key, value in lanes_by_leaf[fa4]
-        if key == cute_flash.FLASH_KV_STAGE_KEY
-    } == expected_depths
-
-
-@pytest.mark.parametrize(
     ("head_dim", "direct_only_depths"),
     (
         pytest.param(64, (11, 12), id="d64"),
@@ -2529,13 +2361,7 @@ def test_high_depth_pipeline_witnesses_select_direct_output(
     head_dim: int,
     direct_only_depths: tuple[int, ...],
 ) -> None:
-    spec = _flash_config_spec(
-        head_dim=head_dim,
-        num_kv=48,
-        dtype=torch.float16,
-        is_causal=False,
-    )
-    generation = spec.create_config_generation()
+    generation = _shared_flash_generation(head_dim, 48, torch.float16, False)
     leaf = cute_flash.FlashStructuralLeaf("fa4", None, True)
     witnesses = generation.flash_pipeline_lane_witnesses()
 
@@ -2559,13 +2385,7 @@ def test_pipeline_lane_catalog_has_deterministic_witnesses(
     head_dim: int,
     is_causal: bool,
 ) -> None:
-    spec = _flash_config_spec(
-        head_dim=head_dim,
-        num_kv=48,
-        dtype=dtype,
-        is_causal=is_causal,
-    )
-    generation = spec.create_config_generation()
+    generation = _shared_flash_generation(head_dim, 48, dtype, is_causal)
     catalog = generation.flash_pipeline_lane_catalog()
     witnesses = generation.flash_pipeline_lane_witnesses()
     expected_witness_keys = {
@@ -2609,7 +2429,8 @@ def test_fixed_pipeline_depths_add_no_qualification_lanes() -> None:
     search.config_spec = spec
     search.config_gen = generation
 
-    leaves = generation.flash_structural_leaf_catalog()
+    with _memoized_flash_fragments():
+        leaves = generation.flash_structural_leaf_catalog()
     assert leaves
     for leaf in leaves:
         assert search._flash_pipeline_lanes(leaf) == ()
@@ -2694,9 +2515,10 @@ def test_causal_search_excludes_unacknowledged_whole_row_transport(
         ("inherit", "xu", "16/4", "8/2")
     )
     assert _active_choices(masked_schedule_fragment) == expected_masked_schedules
-    coverage = spec.create_config_generation(
-        overrides={}
-    ).flash_deterministic_population_configs()
+    with _memoized_flash_fragments():
+        coverage = spec.create_config_generation(
+            overrides={}
+        ).flash_deterministic_population_configs()
     assert {
         config.config[cute_flash.FLASH_SOFTMAX_DISC_KEY] for config in coverage
     } == {True}
@@ -2882,14 +2704,6 @@ def test_causal_split_rep32_timeout_configs_are_canonicalized(
     assert unsplit_store.disc_pipe_depth == disc_pipe_depth
     assert unsplit_store.exp2_packet == packet
     assert unsplit_store.p_store_repetition == 32
-
-
-def test_dense_fp16_degree1_packets_are_distinct_search_choices() -> None:
-    for num_kv in _ALIGNED_LENGTHS:
-        packet_choices = _active_choice_sets(
-            64, num_kv, dtype=torch.float16, is_causal=False
-        )[cute_flash.FLASH_EXP2_PACKET_KEY]
-        assert packet_choices >= _DENSE_DEG1_PACKETS
 
 
 @pytest.mark.parametrize(
@@ -3292,6 +3106,10 @@ def test_causal_lpt_swizzle_is_bounded_to_the_stress_tested_envelope() -> None:
 def test_dense_fp16_degree1_packets_are_not_shape_remapped(
     num_kv: int, packet: str
 ) -> None:
+    packet_choices = _active_choice_sets(
+        64, num_kv, dtype=torch.float16, is_causal=False
+    )[cute_flash.FLASH_EXP2_PACKET_KEY]
+    assert packet_choices >= _DENSE_DEG1_PACKETS
     config = {
         cute_flash.FLASH_PIPELINE_FAMILY_KEY: "fa4_2cta",
         cute_flash.FLASH_EXP2_PACKET_KEY: packet,

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -19112,8 +19112,8 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         )
 
     def test_aux_pipeline_multi_tile_runtime_correctness_cluster_m2(self) -> None:
-        """Multi-tile runtime regression: 4096^3 residual with
-        cluster_m=2 + ``c_input_warps=1`` must run to completion
+        """Multi-tile runtime regression: 4096x4096 (K=1024) residual
+        with cluster_m=2 + ``c_input_warps=1`` must run to completion
         and produce bit-correct output.
 
         The prior 1024^3 ``test_residual_c_input_runtime_correctness``
@@ -19122,13 +19122,16 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         wrap-around of the aux pipeline depth would silently
         slip through (the cycle 2b prior-subagent
         ``partition_D(smem).load()`` form deadlocked at 1024^3
-        only with cluster_m=2 with more tiles per CTA). 4096^3
+        only with cluster_m=2 with more tiles per CTA). M=N=4096
         gives 16x16 = 256 tiles → ~ceil(256/2/148) ≈ 1-2 tiles
         per CTA at cluster_m=2; the producer wraps the stage
         count on the third subtile of each tile (so the
         producer goes through ≥3 stage cycles per CTA),
         triggering the deadlock if the per-CTA producer/consumer
-        subtile counts disagree.
+        subtile counts disagree.  The deadlock depends only on the
+        M/N tile schedule and the epilogue subtile count, not on
+        the mainloop depth, so K is kept at 1024 (8 k-iters, still
+        several ab-stage wraps) to bound runtime.
         """
         from helion._compiler.cute.mma_support import get_cute_mma_support
 
@@ -19136,8 +19139,8 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
 
         torch.manual_seed(0)
-        x = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEVICE)
-        y = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEVICE)
+        x = torch.randn(4096, 1024, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(1024, 4096, dtype=torch.bfloat16, device=DEVICE)
         residual = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEVICE)
         kernel = self._residual_kernel()
         config = self._canonical_c_input_config()
@@ -19193,11 +19196,19 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
 
         Pin: ``c_input_warps=1 + cluster_m=2 + ab_stages=2``
         runs correctness-clean across the sweep
-        ``l2_groupings ∈ {1, 2, 4, 8} × cluster_n ∈ {1, 2}``.
-        The non-trivial ``g`` values are the load-bearing
+        ``l2_groupings ∈ {1, 4} × cluster_n ∈ {1, 2}``.
+        The non-trivial ``g`` value is the load-bearing
         regression for the original cycle 2i fix; the
         ``cluster_n=2`` values are the load-bearing
-        regression for the autoreview P1 fix.
+        regression for the autoreview P1 fix.  The shape is
+        2048x2048 (K=1024) with bm=bn=256: the 8x8 tile grid
+        gives 2 L2 groups along M and 8 along N at g=4, so the
+        post-L2 remap is non-identity (the original bug at
+        4096^3 mismatched 60-69% of elements for EVERY g > 1,
+        so a single non-trivial g at a smaller shape still
+        catches the raw-coords regression).  g ∈ {2, 8} were
+        dropped as redundant with g=4 — same bug class, same
+        failure signature.
         """
         from helion._compiler.cute.mma_support import get_cute_mma_support
 
@@ -19205,9 +19216,9 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
 
         torch.manual_seed(0)
-        x = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEVICE)
-        y = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEVICE)
-        residual = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEVICE)
+        x = torch.randn(2048, 1024, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(1024, 2048, dtype=torch.bfloat16, device=DEVICE)
+        residual = torch.randn(2048, 2048, dtype=torch.bfloat16, device=DEVICE)
         expected = (x @ y + residual).to(x.dtype)
         kernel = self._residual_kernel()
         # Bind once — args don't change across the sweep, only
@@ -19227,9 +19238,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         # is included to keep the cycle 2b correctness
         # baseline pinned.
         sweep_configs: list[tuple[int, int]] = [
-            (l2_grouping, cluster_n)
-            for cluster_n in (1, 2)
-            for l2_grouping in (1, 2, 4, 8)
+            (l2_grouping, cluster_n) for cluster_n in (1, 2) for l2_grouping in (1, 4)
         ]
         for l2_grouping, cluster_n in sweep_configs:
             config = helion.Config(

--- a/test/test_cute_softmax_perf.py
+++ b/test/test_cute_softmax_perf.py
@@ -30,6 +30,7 @@ performance from ~0.45x ATen to ~0.66x ATen on (4096, *) shapes:
 from __future__ import annotations
 
 import os
+import re
 
 import pytest
 import torch
@@ -76,6 +77,43 @@ def softmax_two_pass_kernel(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+# Cache of compiled softmax artifacts shared across tests.  Many tests in
+# this file pin different codegen properties of the byte-identical kernel
+# (same shape, config, and env — the autouse fixture below pins
+# ``HELION_DISABLE_ONLINE_TO_3PASS=1`` for every class that uses this
+# cache), so paying the full CuTe compile once per distinct artifact
+# instead of once per test keeps the assertions while cutting most of the
+# file's wall time.  Keyed by (N, block_n, vector_width); M is fixed at
+# 4096 (it is never the property under test).
+_ARTIFACT_CACHE: dict[tuple[int, int, int], tuple[str, torch.Tensor, torch.Tensor]] = {}
+
+
+def _pipe_shadow_var_count(code: str, kind: str) -> int:
+    """Count ``_pipe_<kind>_N = `` occurrences (prologue + per-iter
+    prefetch assignments, so 2 per pipelined load site)."""
+    return len(re.findall(rf"_pipe_{kind}_\d+ = ", code))
+
+
+def _softmax_artifact(
+    n: int, *, block_n: int = 128, vec_width: int = 4
+) -> tuple[str, torch.Tensor, torch.Tensor]:
+    """Compile ``softmax_two_pass_kernel`` on (4096, n) fp16 once and
+    return ``(code, out, ref)`` for shared assertions."""
+    key = (n, block_n, vec_width)
+    if key not in _ARTIFACT_CACHE:
+        x = torch.randn(4096, n, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            softmax_two_pass_kernel,
+            (x,),
+            block_sizes=[1, block_n],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, vec_width],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        _ARTIFACT_CACHE[key] = (code, out, ref)
+    return _ARTIFACT_CACHE[key]
+
+
 @pytest.fixture(autouse=True)
 def _disable_online_to_3pass(request):
     """The 2-loop softmax perf tests in this file pin codegen details of
@@ -112,15 +150,7 @@ class TestCuteSoftmaxVecHoist(TestCase):
         — the new tile-loop vec hoist path that replaces 4 scalar fp16
         loads with one 8-byte vec load per thread per iter.
         """
-        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
+        code, out, ref = _softmax_artifact(6400)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
         # The vec hoist target var name is _tile_unroll_vec_*.
         self.assertIn("_tile_unroll_vec_", code)
@@ -195,17 +225,11 @@ class TestCuteSoftmaxVecHoist(TestCase):
 
     def test_scalar_load_when_vec_width_is_one(self) -> None:
         """When V=1 the vec hoist must NOT fire — the codegen falls back to
-        the scalar load path so the change is opt-in.
+        the scalar load path so the change is opt-in.  (N is not the
+        property here; shares the V=1 artifact with the P11/P14 no-op
+        gate tests.)
         """
-        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 1],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
+        code, out, ref = _softmax_artifact(4096, vec_width=1)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
         self.assertNotIn("_tile_unroll_vec_", code)
 
@@ -259,43 +283,8 @@ class TestCuteFuseTwoPassAlias(TestCase):
             "consume sweep must read from _fuse_cache_, not gmem",
         )
 
-    def test_fuser_skips_when_cache_size_too_large(self) -> None:
-        """Auto-policy keeps the original cache_size>64 cap to avoid the
-        register-pressure regression measured in P8. So for trip > 64 we
-        expect the consume sweep to still load from gmem.
-
-        For (4096, 12672) with block_size 128, trip = 99, V = 4, so the
-        cache_size would be 99 — fuser must bail.
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # Both sweeps load from gmem (cache fragment NOT allocated since
-        # the fuser bails on cache_size > 64).
-        self.assertNotIn("_fuse_cache_", code)
-        # When the P18 load-pipeline pass is OFF the kernel has exactly
-        # 2 ``cute.arch.load`` calls (one per sweep).  With pipelining
-        # ON each load site is hoisted into a prologue and a per-iter
-        # prefetch, so the total is 4 (2 prologue + 2 inner-loop
-        # prefetch).  Both forms are correct; assert at least 2.
-        self.assertGreaterEqual(code.count("cute.arch.load("), 2)
-        # Each sweep must contain at least one gmem load (either
-        # inline or as a per-iter prefetch).
-        first_sweep_marker = "for tile_offset_2 in range"
-        first_sweep_start = code.find(first_sweep_marker)
-        second_sweep_start = code.find(first_sweep_marker, first_sweep_start + 1)
-        self.assertGreater(second_sweep_start, first_sweep_start)
-        first_sweep = code[first_sweep_start:second_sweep_start]
-        second_sweep = code[second_sweep_start:]
-        self.assertIn("cute.arch.load(", first_sweep)
-        self.assertIn("cute.arch.load(", second_sweep)
+    # The trip>64 fuser-bail case on (4096, 12672) is pinned in
+    # ``TestCuteCanonicalSoftmaxArtifact`` (shared compile).
 
 
 @onlyBackends(["cute"])
@@ -312,15 +301,7 @@ class TestCuteHoistWarpReduce(TestCase):
         zero warp reduces — they live OUTSIDE the loop with a per-thread
         local fold first.
         """
-        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
+        code, out, ref = _softmax_artifact(6400)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
         # Both reduces still get emitted (correctness), just outside the V-loop.
         self.assertIn("warp_reduction_max", code)
@@ -336,15 +317,7 @@ class TestCuteHoistWarpReduce(TestCase):
         """When V=1 there's no constexpr V-loop, so the hoist pass must be
         a no-op — the reduce stays where the strategy emitted it.
         """
-        x = torch.randn(4096, 4096, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 1],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
+        code, out, ref = _softmax_artifact(4096, vec_width=1)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
         # No hoist accumulator names (no V-loop to hoist out of).
         self.assertNotIn("_helion_vfold_acc_", code)
@@ -364,75 +337,14 @@ class TestCuteMergeSiblingVLoops(TestCase):
     downstream code immediately re-promotes to fp32.
     """
 
-    def test_merge_fires_on_softmax_two_pass(self) -> None:
-        """The pass must fire on the canonical softmax shape and emit
-        a ``_helion_vmerge_cache_*`` fragment populated in V-loop 1
-        and read in V-loop 2.
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # Cache fragment allocated.
-        self.assertIn("_helion_vmerge_cache_", code)
-        # Cache write in V-loop 1 (writes Float32(values) at the
-        # vec_lane index).
-        self.assertIn("_helion_vmerge_cache_0[vec_lane_1]", code)
-        # The cache is allocated as Float32 (promotes from fp16 so V-loop
-        # 2 doesn't need the redundant Float32 cast).
-        self.assertIn(
-            "_helion_vmerge_cache_0 = cute.make_rmem_tensor(4, cutlass.Float32)",
-            code,
-        )
-
-    def test_cast_elision_on_warp_reduction(self) -> None:
-        """The double-cast peephole (part of ``merge_sibling_v_loops``)
-        must collapse ``A = Float16(warp_reduction(...)); B = Float32(A)``
-        into ``A = warp_reduction(...); B = A``.  The inner Float16
-        wrap on the max-reduce becomes dead and gets removed.
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # The original pattern ``local_amax = Float16(warp_reduction_max(...))``
-        # must have been elided to just ``local_amax = warp_reduction_max(...)``.
-        # (The hoist pass already promoted the V-fold acc to fp32, so the
-        # warp_reduction returns fp32 — the Float16 wrap was a no-op cycle.)
-        self.assertNotIn(
-            "local_amax = cutlass.Float16(cute.arch.warp_reduction_max",
-            code,
-        )
-        self.assertIn(
-            "local_amax = cute.arch.warp_reduction_max",
-            code,
-        )
+    # The merge-fires and cast-elision pins on (4096, 12672) live in
+    # ``TestCuteCanonicalSoftmaxArtifact`` (shared compile).
 
     def test_no_merge_when_v_loop_absent(self) -> None:
         """When V=1 there's no constexpr V-loop, so the merge pass must
         be a no-op — no cache fragment should be emitted.
         """
-        x = torch.randn(4096, 4096, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 1],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
+        code, out, ref = _softmax_artifact(4096, vec_width=1)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
         self.assertNotIn("_helion_vmerge_cache_", code)
 
@@ -456,33 +368,8 @@ class TestCuteHoistLoopInvariantRecip(TestCase):
     outside the loop.
     """
 
-    def test_recip_hoist_fires_on_softmax_two_pass(self) -> None:
-        """For ``softmax_two_pass``, the consume sweep's per-element
-        divide by ``di`` (a per-row scalar) must be rewritten to a
-        single hoisted ``_helion_inv_div_*`` reciprocal + multiply.
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # The hoisted reciprocal declaration must reference the
-        # loop-external root name ``di``, not the inside-loop alias
-        # ``di_copy_*`` (which wouldn't be visible above the loop).
-        self.assertIn("_helion_inv_div_", code)
-        self.assertIn("= 1.0 / di", code)
-        # The inner divide must have been rewritten to a multiply against
-        # the hoisted reciprocal name.
-        self.assertIn("* _helion_inv_div_", code)
-        # The original per-element divide pattern is no longer present.
-        # (The two-pass kernel had ``v_12 = v_11 / di_copy_1_0`` — that
-        # specific text must be gone after the rewrite.)
-        self.assertNotIn("/ di_copy_1_0", code)
+    # The recip-hoist-fires pin on (4096, 12672) lives in
+    # ``TestCuteCanonicalSoftmaxArtifact`` (shared compile).
 
     def test_recip_hoist_does_not_fire_on_loop_dependent_divisor(self) -> None:
         """When the divisor changes per-iteration (e.g. ``local_sum``
@@ -546,184 +433,147 @@ class TestCuteHoistLoopInvariantRecip(TestCase):
 
 
 @onlyBackends(["cute"])
-class TestCuteHoistLoopInvariantP17(TestCase):
-    """P17: extended ``hoist_loop_invariant_recips`` pass.
+class TestCuteCanonicalSoftmaxArtifact(TestCase):
+    """All codegen pins on the canonical (4096, 12672) fp16 artifact
+    (``block_sizes=[1, 128]``, ``num_threads=[0, 32]``,
+    ``cute_vector_widths=[1, 4]``), compiled ONCE via
+    ``_softmax_artifact`` and shared across the tests below.
 
-    Adds three sub-passes on top of the original P16 reciprocal hoist:
+    Previously each of these pins was its own test that recompiled the
+    byte-identical kernel (11 full CuTe compiles).  The properties are
+    unchanged — grouped here by pass:
 
-      1. **Alias DCE**: pure SSA-style ``NAME = ANOTHER_NAME`` chains
-         (``mi_copy_1 = mi``, ``mi_copy_1_0 = mi_copy_1``, ...) collapse
-         to direct ``mi`` reads with the alias assignments removed.
-      2. **Outer-in walk for the reciprocal hoist** so the reciprocal
-         lands at the OUTERMOST legal scope — eliminating the cascade
-         ``_helion_inv_div_N = 1.0 * _helion_inv_div_{N+1}`` aliases
-         that the original inner-first walk produced.
-      3. **FMA-friendly scale hoist**: ``(A - INV) * CONST`` patterns
-         where ``INV`` is loop-invariant emit a single hoisted
-         ``_helion_scaled_K = INV * CONST`` outside the loop and
-         rewrite the inner expression to ``A * CONST - _helion_scaled_K``.
-
-    Plus a final DCE pass to remove dead Sub assigns left over by the
-    FMA hoist (``v_10 = v_9 - mi`` becomes dead when the Mult that used
-    it was rewritten).
+    * P2/P5 fuser bail: trip = 99 > cache cap 64, so both sweeps load
+      from gmem (guards the P8 register-pressure regression).
+    * P14 ``merge_sibling_v_loops``: vmerge cache + double-cast elision.
+    * P16 reciprocal hoist: ``1.0 / di`` hoisted, inner divide becomes
+      a multiply.
+    * P17 extended hoists: alias DCE (``*_copy`` chains inlined),
+      outer-in reciprocal walk (no ``1.0 * _helion_inv_div_`` cascade),
+      FMA-friendly scale hoists in both the consume loop and the reduce
+      V-loop, dead-Sub DCE, and the post-rename invariance
+      canonicalization that keeps ``mi`` loop-VARIANT in the reduce
+      loop (silent-miscompile guard).
+    * P18 load pipeline: both sweeps pipelined (prologue snapshot +
+      per-iter prefetch).
     """
 
-    def test_useless_cascade_alias_removed(self) -> None:
-        """The original inner-first hoist produced a cascade of useless
-        ``_helion_inv_div_N = 1.0 * _helion_inv_div_{N+1}`` aliases when
-        the consume loop was 3 levels deep.  The outer-in walk emits a
-        single hoist at the outermost legal scope instead.
+    def test_numerics_and_fuser_bails_above_cache_cap(self) -> None:
+        """End-to-end correctness of the canonical artifact, plus the
+        P2/P5 fuser gate: for (4096, 12672) with block_size 128 the
+        trip count is 99 > the 64-entry cache cap, so the fuser must
+        bail and BOTH sweeps must load from gmem.
         """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
+        code, out, ref = _softmax_artifact(12672)
+        # Tight tolerance — this also guards the P17 invariance
+        # canonicalization silent-miscompile (the bench would still
+        # "look fast" with wrong outputs if we regressed there).
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # The useless cascade text MUST be gone.  Original bad output had
-        # ``_helion_inv_div_0 = 1.0 * _helion_inv_div_1`` (and similar
-        # for the next level).  The new pass must not emit such aliases.
+        # Cache fragment NOT allocated (fuser bails on cache_size > 64).
+        self.assertNotIn("_fuse_cache_", code)
+        # When the P18 load-pipeline pass is OFF the kernel has exactly
+        # 2 ``cute.arch.load`` calls (one per sweep).  With pipelining
+        # ON each load site is hoisted into a prologue and a per-iter
+        # prefetch, so the total is 4 (2 prologue + 2 inner-loop
+        # prefetch).  Both forms are correct; assert at least 2.
+        self.assertGreaterEqual(code.count("cute.arch.load("), 2)
+        # Each sweep must contain at least one gmem load (either
+        # inline or as a per-iter prefetch).
+        first_sweep_marker = "for tile_offset_2 in range"
+        first_sweep_start = code.find(first_sweep_marker)
+        second_sweep_start = code.find(first_sweep_marker, first_sweep_start + 1)
+        self.assertGreater(second_sweep_start, first_sweep_start)
+        first_sweep = code[first_sweep_start:second_sweep_start]
+        second_sweep = code[second_sweep_start:]
+        self.assertIn("cute.arch.load(", first_sweep)
+        self.assertIn("cute.arch.load(", second_sweep)
+
+    def test_vmerge_recip_and_fma_hoists(self) -> None:
+        """P14 + P16 + P17 codegen pins on the shared artifact."""
+        code, _, _ = _softmax_artifact(12672)
+        # P14: vmerge cache fragment allocated, written in V-loop 1 at
+        # the vec_lane index, and allocated as Float32 (promotes from
+        # fp16 so V-loop 2 doesn't need the redundant Float32 cast).
+        self.assertIn("_helion_vmerge_cache_", code)
+        self.assertIn("_helion_vmerge_cache_0[vec_lane_1]", code)
+        self.assertIn(
+            "_helion_vmerge_cache_0 = cute.make_rmem_tensor(4, cutlass.Float32)",
+            code,
+        )
+        # P14 double-cast peephole: ``local_amax =
+        # Float16(warp_reduction_max(...))`` must have been elided to
+        # just ``local_amax = warp_reduction_max(...)`` (the hoist pass
+        # already promoted the V-fold acc to fp32, so the Float16 wrap
+        # was a no-op cycle).
+        self.assertNotIn(
+            "local_amax = cutlass.Float16(cute.arch.warp_reduction_max",
+            code,
+        )
+        self.assertIn(
+            "local_amax = cute.arch.warp_reduction_max",
+            code,
+        )
+        # P16: the hoisted reciprocal references the loop-external root
+        # name ``di`` (not an inside-loop ``di_copy_*`` alias) and the
+        # inner divide is rewritten to a multiply.
+        self.assertIn("_helion_inv_div_", code)
+        self.assertIn("= 1.0 / di", code)
+        self.assertIn("* _helion_inv_div_", code)
+        self.assertNotIn("/ di_copy_1_0", code)
+        # P17 outer-in walk: no ``_helion_inv_div_N = 1.0 *
+        # _helion_inv_div_{N+1}`` cascade, exactly ONE reciprocal hoist
+        # for the consume sweep's ``1.0/di``.
         self.assertEqual(code.count("1.0 * _helion_inv_div_"), 0)
-        # Exactly ONE reciprocal hoist for the consume sweep's ``1.0/di``.
         self.assertEqual(code.count("= 1.0 / di"), 1)
-
-    def test_ssa_alias_chain_inlined(self) -> None:
-        """The per-iter ``mi_copy_*`` and ``di_copy_*`` alias chains
-        Helion's SSA maintenance inserts MUST be inlined so the deepest
-        use reads the root name directly.  Eliminates the per-iter copy
-        instruction the SSA maintenance otherwise leaves behind.
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # Neither ``mi_copy`` nor ``di_copy`` should appear in the
-        # generated code — both were SSA snapshots whose only purpose
-        # was to capture the value at a specific point; with the
-        # snapshot removed the inner use reads the root directly.
+        # P17 alias DCE: neither ``mi_copy`` nor ``di_copy`` appears —
+        # both were SSA snapshots; with the snapshot removed the inner
+        # use reads the root directly.
         self.assertEqual(code.count("_copy"), 0)
-
-    def test_fma_scale_hoist_above_consume(self) -> None:
-        """For ``softmax_two_pass``, the consume loop's
-        ``exp2((v_9 - mi) * 1.4427)`` pattern with ``mi`` loop-invariant
-        MUST get a hoisted ``_helion_scaled_K = mi * 1.4426950408889634``
-        placed BEFORE the consume loop, and the inner expression must
-        be rewritten to ``v_9 * 1.4427 - _helion_scaled_K`` (the outer
-        redundant ``cutlass.Float32(v_9)`` cast is stripped because
-        ``v_9 = cutlass.Float32(values_1)`` is already fp32).
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # A scaled hoist for ``mi * 1.4426950408889634`` must be emitted.
+        # P17 FMA scale hoist above the consume loop: ``mi * log2(e)``
+        # hoisted, inner expression rewritten to the FMA-friendly form
+        # (the outer redundant ``cutlass.Float32(v_9)`` cast is
+        # stripped because ``v_9`` is already fp32).
         self.assertIn("_helion_scaled_", code)
         self.assertIn("= mi * 1.4426950408889634", code)
-        # The inner consume body must use the FMA-friendly form.
-        # ``v_11 = cute.math.exp2(v_9 * 1.4427 - _helion_scaled_*)``
         self.assertIn("cute.math.exp2(v_9 * 1.4426950408889634 - _helion_scaled_", code)
-
-    def test_fma_scale_hoist_in_reduce_v_loop(self) -> None:
-        """In the reduce loop's INNER ``for vec_lane_1`` V-loop, the
-        ``(v_5 - v_1) * 1.4427`` pattern has ``v_1`` loop-invariant
-        w.r.t. the V-loop (v_1 is the new-max from the warp_reduce
-        that runs before the V-loop), so the scale hoist must also
-        fire here and emit a ``_helion_scaled_* = v_1 * 1.4427``
-        just before the V-loop.
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # The reduce-loop scale hoist for ``v_1 * 1.4427``.
+        # P17 FMA scale hoist in the reduce V-loop: ``v_1`` (the
+        # new-max from the warp_reduce before the V-loop) is
+        # V-loop-invariant, so the hoist fires there too.
         self.assertIn("= v_1 * 1.4426950408889634", code)
-        # The V-loop body must use the FMA-friendly form via v_5
-        # (the outer cast is stripped because ``v_5 = cutlass.Float32(values)``
-        # is already fp32).
         self.assertIn("cute.math.exp2(v_5 * 1.4426950408889634 - _helion_scaled_", code)
-
-    def test_dce_removes_dead_sub_after_fma_hoist(self) -> None:
-        """After the FMA hoist rewrites ``cast(v_X) * CONST`` to read
-        the underlying ``A`` directly (where ``v_X = A - INV`` was the
-        Sub statement), the ``v_X = A - INV`` becomes dead and the
-        final DCE pass must remove it.
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # The consume-loop ``v_10 = v_9 - mi`` MUST be DCE'd: nothing
-        # reads ``v_10`` after the FMA hoist rewrote ``v_11`` to
-        # reference ``v_9`` directly.
+        # P17 DCE: the consume-loop ``v_10 = v_9 - mi`` and the reduce
+        # V-loop ``v_6 = v_5 - v_1`` are dead after the FMA hoists and
+        # must be removed; statements that ARE read (``v_4`` feeds
+        # ``di``) must survive.
         self.assertNotIn("v_10 = v_9 - mi", code)
-        # Same for the inner reduce V-loop ``v_6 = v_5 - v_1`` — dead
-        # after the V-loop's FMA hoist.
         self.assertNotIn("v_6 = v_5 - v_1", code)
-        # But statements that ARE read (e.g. ``v_4 = di * v_3`` reads
-        # ``di``, and ``v_4`` is read by ``di = v_4 + sum_1``) MUST
-        # NOT be DCE'd.
         self.assertIn("di = v_4 + sum_1", code)
-
-    def test_invariance_canonicalization_does_not_break_consume(self) -> None:
-        """The pass must use the post-rename canonical name map for
-        invariance analysis on hoist-OUT passes, so that ``mi`` in the
-        REDUCE loop body is correctly classified as loop-VARIANT
-        (because ``v_1_0 = v_1`` will be renamed to ``mi = v_1``).
-        Without this, the FMA hoist would lift ``_helion_scaled_K =
-        mi * 1.4427`` ABOVE the reduce loop and capture the stale
-        initial ``-inf`` value of ``mi`` — silently producing wildly
-        wrong softmax outputs.
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        # Tight tolerance — this test specifically guards a silent
-        # mis-compile (the bench would still "look fast" with wrong
-        # outputs if we regressed here).
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # The ``mi`` scale hoist for the consume sweep lives BETWEEN
-        # the two outer for-loops (after the reduce loop finishes
-        # mutating ``mi`` via the rename ``v_1_0 -> mi``), not before
-        # the reduce loop.  Verify the hoist is positioned AFTER the
-        # ``mi = v_1`` post-rename assignment in the reduce loop.
+        # P17 invariance canonicalization: the ``mi`` scale hoist for
+        # the consume sweep lives BETWEEN the two outer for-loops
+        # (after the reduce loop finishes mutating ``mi`` via the
+        # rename ``v_1_0 -> mi``), not before the reduce loop — else
+        # it would capture the stale initial ``-inf`` value of ``mi``.
         reduce_end = code.find("mi = v_1\n")
         self.assertGreaterEqual(reduce_end, 0)
         scaled_consume = code.find("= mi * 1.4426950408889634")
         self.assertGreater(scaled_consume, reduce_end)
+
+    def test_load_pipeline_fires_on_both_sweeps(self) -> None:
+        """P18: both the reduce and consume sweeps match the (single
+        inner-lane loop, single load) shape so the pass rewrites both.
+        Each rewrite emits a prologue snapshot and a per-iter prefetch
+        — 2 ``_pipe_lane_base_*`` assigns and 2 ``_pipe_load_*``
+        assigns per pipelined site, for 4 total of each.
+        """
+        code, _, _ = _softmax_artifact(12672)
+        self.assertEqual(_pipe_shadow_var_count(code, "lane_base"), 4)
+        self.assertEqual(_pipe_shadow_var_count(code, "load"), 4)
+        # The snapshot ``lane_base_<N> = _pipe_lane_base_<M>`` form must
+        # appear inside the loop body — that's the substitution that
+        # gives the SASS scheduler one full iter of slack to issue the
+        # next load.
+        self.assertRegex(code, r"lane_base_\d+ = _pipe_lane_base_\d+")
+        self.assertRegex(code, r"_tile_unroll_vec_\d+_\d+ = _pipe_load_\d+")
 
 
 @onlyBackends(["cute"])
@@ -740,41 +590,8 @@ class TestCuteLoadPipelineP18(TestCase):
     GB/s gain on most softmax shapes.
     """
 
-    def _shadow_var_count(self, code: str, kind: str) -> int:
-        """Count ``_pipe_<kind>_N = `` occurrences (prologue + per-iter
-        prefetch assignments, so 2 per pipelined load site)."""
-        import re
-
-        return len(re.findall(rf"_pipe_{kind}_\d+ = ", code))
-
-    def test_pipeline_fires_on_softmax_two_pass(self) -> None:
-        """Both the reduce and consume sweeps of softmax_two_pass match
-        the (single inner-lane loop, single load) shape so the pass
-        rewrites both sweeps.  Each rewrite emits a prologue snapshot
-        and a per-iter prefetch — 2 ``_pipe_lane_base_*`` assigns and
-        2 ``_pipe_load_*`` assigns per pipelined site, for 4 total of
-        each across the two sweeps.
-        """
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
-        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # 2 sweeps * 2 assigns each = 4 _pipe_lane_base_* writes and
-        # 4 _pipe_load_* writes.
-        self.assertEqual(self._shadow_var_count(code, "lane_base"), 4)
-        self.assertEqual(self._shadow_var_count(code, "load"), 4)
-        # The snapshot ``lane_base_<N> = _pipe_lane_base_<M>`` form must
-        # appear inside the loop body — that's the substitution that
-        # gives the SASS scheduler one full iter of slack to issue the
-        # next load.
-        self.assertRegex(code, r"lane_base_\d+ = _pipe_lane_base_\d+")
-        self.assertRegex(code, r"_tile_unroll_vec_\d+_\d+ = _pipe_load_\d+")
+    # The pipeline-fires pin on (4096, 12672) lives in
+    # ``TestCuteCanonicalSoftmaxArtifact`` (shared compile).
 
     def test_pipeline_skips_when_lane_reps_greater_than_one(self) -> None:
         """V=4 with block_size=256 forces the inner lane loop to
@@ -869,10 +686,18 @@ class TestCuteLoadPipelineCarriedOnlyP19(TestCase):
         else:
             os.environ[name] = value
 
-    def test_carried_only_pipelines_reduce_sweep(self) -> None:
+    def test_carried_only_pipelines_reduce_sweep_but_not_consume(self) -> None:
         """With the gate enabled, the reduce sweep (which writes ``mi``
         and ``di`` — both defined in the outer function-body scope
-        before the loop) MUST still be pipelined.
+        before the loop) MUST still be pipelined, while the consume
+        sweep (which only stores into ``out[k]`` and never writes a
+        scalar accumulator in the outer scope) MUST NOT be.
+
+        The reduce-sweep pipeline writes ``_pipe_lane_base_0`` and
+        ``_pipe_load_0``; the consume sweep would have written
+        ``_pipe_lane_base_1`` and ``_pipe_load_1`` under the default
+        behavior.  Under the gate, only the ``_0`` indices appear.
+        (Was two tests compiling the identical artifact twice.)
         """
         self._set_env("HELION_LOAD_PIPELINE_CARRIED_ONLY", "1")
         x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
@@ -887,36 +712,15 @@ class TestCuteLoadPipelineCarriedOnlyP19(TestCase):
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
         # The reduce sweep MUST still be pipelined — there's a
         # loop-carried scalar write to ``mi`` (pre-rename: ``v_1_0
-        # = v_1``) so the gate fires positive.
+        # = v_1``) so the gate fires positive.  ONLY the reduce-sweep
+        # pipe (index 0) — no index 1.
         self.assertIn("_pipe_lane_base_", code)
-        self.assertIn("_pipe_load_", code)
-        # And the per-iter snapshot ``lane_base_<N> = _pipe_lane_base_<M>``
-        # form appears inside the reduce loop body.
-        self.assertRegex(code, r"lane_base_\d+ = _pipe_lane_base_\d+")
-
-    def test_carried_only_skips_consume_sweep(self) -> None:
-        """With the gate enabled, the consume sweep (which only
-        stores into ``out[k]`` and never writes a scalar accumulator
-        in the outer scope) MUST NOT be pipelined.
-
-        The reduce-sweep pipeline writes ``_pipe_lane_base_0`` and
-        ``_pipe_load_0``; the consume sweep would have written
-        ``_pipe_lane_base_1`` and ``_pipe_load_1`` under the default
-        behavior.  Under the gate, only the ``_0`` indices appear.
-        """
-        self._set_env("HELION_LOAD_PIPELINE_CARRIED_ONLY", "1")
-        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
-        code, _ = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        # ONLY the reduce-sweep pipe (index 0) — no index 1.
         self.assertIn("_pipe_load_0", code)
         self.assertNotIn("_pipe_load_1", code)
         self.assertNotIn("_pipe_lane_base_1", code)
+        # The per-iter snapshot ``lane_base_<N> = _pipe_lane_base_<M>``
+        # form appears inside the reduce loop body.
+        self.assertRegex(code, r"lane_base_\d+ = _pipe_lane_base_\d+")
         # And the consume sweep retains its original inline
         # ``cute.arch.load`` (no snapshot/prefetch rewrite).  The
         # consume sweep's load assigns to ``_tile_unroll_vec_1_1``.
@@ -996,15 +800,7 @@ class TestCuteWarpReduceHeuristic(TestCase):
         uses ``cute.arch.warp_reduction_*`` and not the shared-memory
         two-stage reduce.
         """
-        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
-        code, out = code_and_output(
-            softmax_two_pass_kernel,
-            (x,),
-            block_sizes=[1, 128],
-            num_threads=[0, 32],
-            cute_vector_widths=[1, 4],
-        )
-        ref = torch.nn.functional.softmax(x, dim=1)
+        code, out, ref = _softmax_artifact(6400)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
         self.assertIn("cute.arch.warp_reduction_max", code)
         self.assertIn("cute.arch.warp_reduction_sum", code)
@@ -1051,37 +847,14 @@ class TestCuteSoftmaxCorrectness(TestCase):
         )
 
     def test_softmax_4096x6400(self) -> None:
-        self._check_softmax(
-            (4096, 6400),
-            {
-                "block_sizes": [1, 128],
-                "num_threads": [0, 32],
-                "cute_vector_widths": [1, 4],
-            },
-        )
+        _, out, ref = _softmax_artifact(6400)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
 
-    def test_softmax_4096x12672(self) -> None:
-        self._check_softmax(
-            (4096, 12672),
-            {
-                "block_sizes": [1, 128],
-                "num_threads": [0, 32],
-                "cute_vector_widths": [1, 4],
-            },
-        )
-
-    def test_softmax_4096x8192(self) -> None:
-        """Power-of-two N — the divisible case."""
-        # V=8 falls back to scalar internally (see V=8 cap test) but the
-        # outer warp-reduce + hoist path still must be correct.
-        self._check_softmax(
-            (4096, 8192),
-            {
-                "block_sizes": [1, 256],
-                "num_threads": [0, 32],
-                "cute_vector_widths": [1, 4],
-            },
-        )
+    # (4096, 12672) numerics are pinned by
+    # ``TestCuteCanonicalSoftmaxArtifact`` and (4096, 8192) with
+    # ``block_sizes=[1, 256]`` (the power-of-two divisible case) by
+    # ``TestCuteLoadPipelineP18.test_pipeline_skips_when_lane_reps_greater_than_one``
+    # — both on the identical artifact these entries used to recompile.
 
 
 @onlyBackends(["cute"])
@@ -1423,8 +1196,12 @@ class TestCuteOnlineTo3PassRewrite(TestCase):
         the rewrite (the 3-pass and online forms have different
         rounding paths in fp16 — the diff must stay inside softmax's
         existing tolerance).
+
+        One power-of-two and one non-power-of-two N; each N is a full
+        recompile.  (4096, 12672) is already numerics-checked by
+        ``test_rewrite_fires_on_canonical_pattern`` above.
         """
-        for N in (4096, 6400, 12672, 16384):
+        for N in (4096, 6400):
             x = torch.randn(4096, N, device=DEVICE, dtype=HALF_DTYPE)
             _, out = code_and_output(
                 softmax_two_pass_kernel_for_3pass,

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -44,6 +44,23 @@ import helion.language as hl
 
 autotuner_names = ["fixed", *search_algorithms]
 
+# The full kernel x autotuner cross product is too slow for CI. Only the
+# cheapest kernel (test_allreduce) runs every algorithm; the other kernels keep
+# one fast representative each, since the search algorithms themselves are
+# covered in test_autotuner.py and distributed coordination is orthogonal to
+# the choice of algorithm.
+representative_autotuner_names = ["FiniteSearch"]
+
+# LLM-guided autotuners call a real LLM endpoint and abort on every rank when
+# no API key is configured, so skip them instead of failing in key-less envs.
+_LLM_AUTOTUNER_NAMES = frozenset(
+    name for name in search_algorithms if name.startswith("LLM")
+)
+_HAS_LLM_API_KEY = any(
+    os.environ.get(name)
+    for name in ("HELION_LLM_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY")
+)
+
 # torch.distributed._symmetric_memory.is_symm_mem_tensor exists only on newer
 # PyTorch. The symm-mem-based gating degrades to conservative behavior without it,
 # so the tests that assert the fine-grained gating require the API.
@@ -132,6 +149,13 @@ class TestDistributed(TestCase, MultiProcessTestCase):
         super().tearDownClass()
 
     def setUp(self) -> None:
+        # The per-test skip_if_lt_x_gpu(4) guards only fire inside the spawned
+        # worker processes, so without this pre-check every skip on a <4-GPU
+        # machine still pays ~6s of process spawning. Same check, parent-side.
+        if not (
+            torch.accelerator.is_available() and torch.accelerator.device_count() >= 4
+        ):
+            self.skipTest("Need at least 4 accelerator devices")
         super().setUp()
         self._spawn_processes()
 
@@ -209,6 +233,8 @@ class TestDistributed(TestCase, MultiProcessTestCase):
     @skip_if_lt_x_gpu(4)
     @parametrize("autotuner", autotuner_names)
     def test_allreduce(self, autotuner):
+        if autotuner in _LLM_AUTOTUNER_NAMES and not _HAS_LLM_API_KEY:
+            self.skipTest("LLM autotuners require an LLM API key")
         self._init_process()
         if autotuner == "fixed":
             fixed_num_warps = 16 if torch.version.hip is not None else 32
@@ -277,7 +303,7 @@ class TestDistributed(TestCase, MultiProcessTestCase):
             "two_shot_allreduce_bias_rmsnorm_kernel",
         ),
     )
-    @parametrize("autotuner", autotuner_names)
+    @parametrize("autotuner", representative_autotuner_names)
     def test_allreduce_bias_rmsnorm(self, kernel_name, autotuner):
         """
         There is a similar test in test/test_examples_dist.py.
@@ -349,7 +375,9 @@ class TestDistributed(TestCase, MultiProcessTestCase):
 
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
-    @parametrize("autotuner", autotuner_names)
+    # "fixed" stays alongside the representative: its deliberately small block
+    # config is the only coverage for large launch grids on this kernel.
+    @parametrize("autotuner", ["fixed", *representative_autotuner_names])
     def test_matmul_reduce_scatter(self, autotuner):
         self._init_process()
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -725,8 +725,8 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @skipIfPallasInterpret(
-        "65536x1024x1280 GEMM is too slow under CPU interpret -- it exceeds the "
-        "300s per-test timeout and (thread timeout method) kills the whole job"
+        "GEMM pair is too slow under CPU interpret -- at the original 65536-row "
+        "shape it exceeded the 300s per-test timeout"
     )
     @skipIfTileIR("precision differences with bf16xint16 operations on tileir")
     @skipIfRocm("precision differences with bf16xint16 operations on rocm")
@@ -734,7 +734,7 @@ class TestExamples(RefEagerTestBase, TestCase):
     def test_bf16xint16(self):
         from examples.bf16xint16_gemm import reference_bf16xint16_pytorch
 
-        m, k, n = 65536, 1024, 1280
+        m, k, n = 2048, 1024, 1280
 
         # The CuTe scalar matmul fallback accumulates each bf16xbf16 product in
         # full fp32 (it never rounds the per-element products back to bf16), so
@@ -909,7 +909,7 @@ class TestExamples(RefEagerTestBase, TestCase):
 
     @skipIfTileIR("PassManager::run failed")
     def test_epilogue_subtiling_residual_gelu(self):
-        m, k, n = 8192, 8192, 8192
+        m, k, n = 1024, 1024, 1024
         x = torch.randn([m, k], device=DEVICE, dtype=HALF_DTYPE)
         w = torch.randn([k, n], device=DEVICE, dtype=HALF_DTYPE)
         bias = torch.randn([n], device=DEVICE, dtype=HALF_DTYPE)
@@ -929,7 +929,7 @@ class TestExamples(RefEagerTestBase, TestCase):
 
     @skipIfTileIR("PassManager::run failed")
     def test_epilogue_subtiling_gelu_aux(self):
-        m, k, n = 8192, 8192, 8192
+        m, k, n = 1024, 1024, 1024
         x = torch.randn([m, k], device=DEVICE, dtype=HALF_DTYPE)
         w = torch.randn([k, n], device=DEVICE, dtype=HALF_DTYPE)
         bias = torch.randn([n], device=DEVICE, dtype=HALF_DTYPE)

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -15,6 +15,7 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import output_only
 from helion._testing import skipIfMTIA
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
@@ -59,21 +60,22 @@ def _assert_bitwise_equal_float(
 
 
 def _rng_2d_block_sizes() -> list[int]:
+    # RNG offsets are block-size independent; small blocks compile much faster
     if _get_backend() == "cute":
         return [32, 32]
-    return [64, 64]
+    return [16, 16]
 
 
 def _rng_3d_block_sizes() -> list[int]:
     if _get_backend() == "cute":
         return [4, 8, 32]
-    return [8, 8, 64]
+    return [4, 8, 16]
 
 
 def _rng_determinism_block_sizes() -> list[list[int]]:
-    if _get_backend() == "cute":
-        return [[8, 8], [16, 16], [32, 32]]
-    return [[8, 8], [16, 16], [32, 32]]
+    # Two variants are enough to prove block-size invariance; each one costs
+    # a full kernel compile.
+    return [[8, 8], [32, 32]]
 
 
 def _compile_once(
@@ -295,71 +297,129 @@ def _hl_randint_outer_loop_expected(
 @onlyBackends(["triton", "pallas", "cute"])
 @skipIfXPU("hl.rand/hl.randint tests crash XPU workers")
 class TestRandom(RefEagerTestBase, TestCase):
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_hl_rand_1d(self):
+    def test_hl_rand_randint_1d(self):
+        """Test hl.rand and hl.randint with 1D output using a single kernel."""
+
         @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_kernel_tiled_1d(x: torch.Tensor, seed: int) -> torch.Tensor:
-            output = torch.zeros_like(x)
+        def rng_kernel_1d(
+            x: torch.Tensor, seed: int
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out_f = torch.zeros_like(x)
+            out_i = torch.zeros(x.shape, dtype=torch.int32, device=x.device)
             (m,) = x.shape
             for tile_m in hl.tile(m):
-                output[tile_m] = hl.rand([tile_m], seed=seed)
-            return output
+                out_f[tile_m] = hl.rand([tile_m], seed=seed)
+                out_i[tile_m] = hl.randint([tile_m], low=-50, high=50, seed=seed)
+            return out_f, out_i
 
-        x_small = torch.ones(1024, device=DEVICE)
-        code3, compiled = _compile_once(
-            rand_kernel_tiled_1d, (x_small, 42), block_sizes=[1024]
+        x = torch.ones(1024, device=DEVICE)
+        code, (out_f, out_i) = code_and_output(
+            rng_kernel_1d, (x, 42), block_sizes=[256]
         )
-        output = compiled(x_small, 42)
-        output2 = compiled(x_small, 1337)
+        out_f2, out_i2 = output_only(rng_kernel_1d, (x, 1337), block_sizes=[256])
 
+        # Different seeds should produce different outputs
         self.assertFalse(
-            torch.allclose(output, output2),
+            torch.allclose(out_f, out_f2),
+            "Different seeds should produce different outputs",
+        )
+        self.assertFalse(
+            torch.allclose(out_i.float(), out_i2.float()),
             "Different seeds should produce different outputs",
         )
 
-        output3 = compiled(x_small, 42)
-        self.assertTrue(
-            torch.allclose(output, output3),
-            "Same seed should produce identical outputs",
+        # Same seed should produce identical outputs
+        out_f3, out_i3 = output_only(rng_kernel_1d, (x, 42), block_sizes=[256])
+        torch.testing.assert_close(
+            out_f, out_f3, msg="Same seed should produce identical outputs"
         )
-        _assert_uses_philox(self, code3)
+        torch.testing.assert_close(
+            out_i, out_i3, msg="Same seed should produce identical outputs"
+        )
+        _assert_uses_philox(self, code)
 
-        # Check that all values are in [0, 1) range
-        self.assertTrue(torch.all(output >= 0.0), "All values should be >= 0")
-        self.assertTrue(torch.all(output < 1.0), "All values should be < 1")
+        # Check that all values are in the expected ranges
+        self.assertTrue(torch.all(out_f >= 0.0), "All values should be >= 0")
+        self.assertTrue(torch.all(out_f < 1.0), "All values should be < 1")
+        self.assertTrue(torch.all(out_i >= -50), "All values should be >= -50")
+        self.assertTrue(torch.all(out_i < 50), "All values should be < 50")
+        self.assertEqual(out_i.dtype, torch.int32, "Output dtype should be int32")
 
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_hl_rand_2d(self):
+        # Check that we have both negative and positive values (statistically very likely)
+        self.assertTrue(torch.any(out_i < 0), "Should have some negative values")
+        self.assertTrue(torch.any(out_i >= 0), "Should have some non-negative values")
+
+    def test_hl_rand_randint_2d(self):
+        """Test hl.rand and hl.randint with 2D output using a single kernel."""
+
         @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_kernel_tiled_2d(x: torch.Tensor, seed: int) -> torch.Tensor:
-            output = torch.zeros_like(x)
+        def rng_kernel_2d(
+            x: torch.Tensor, seed: int
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out_f = torch.zeros_like(x)
+            out_i = torch.zeros(x.shape, dtype=torch.int32, device=x.device)
             m, n = x.shape
             for tile_m, tile_n in hl.tile([m, n]):
-                output[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
-            return output
+                out_f[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
+                out_i[tile_m, tile_n] = hl.randint(
+                    [tile_m, tile_n], low=10, high=50, seed=seed
+                )
+            return out_f, out_i
 
-        x_small = torch.ones(1024, 1024, device=DEVICE)
+        # 256x256 keeps 65536 samples for the quantile checks below
+        x = torch.ones(256, 256, device=DEVICE)
         block_sizes = _rng_2d_block_sizes()
-        code3, compiled = _compile_once(
-            rand_kernel_tiled_2d, (x_small, 42), block_sizes=block_sizes
+        code, (out_f, out_i) = code_and_output(
+            rng_kernel_2d, (x, 42), block_sizes=block_sizes
         )
-        output = compiled(x_small, 42)
-        output2 = compiled(x_small, 1337)
+        out_f2, _out_i2 = output_only(rng_kernel_2d, (x, 1337), block_sizes=block_sizes)
 
         self.assertFalse(
-            torch.allclose(output, output2),
+            torch.allclose(out_f, out_f2),
             "Different seeds should produce different outputs",
         )
 
-        output3 = compiled(x_small, 42)
-        self.assertTrue(
-            torch.allclose(output, output3),
-            "Same seed should produce identical outputs",
+        out_f3, out_i3 = output_only(rng_kernel_2d, (x, 42), block_sizes=block_sizes)
+        torch.testing.assert_close(
+            out_f, out_f3, msg="Same seed should produce identical outputs"
         )
-        _assert_uses_philox(self, code3)
+        torch.testing.assert_close(
+            out_i, out_i3, msg="Same seed should be deterministic"
+        )
+        _assert_uses_philox(self, code)
 
-        self.assertTrue(torch.all(output >= 0.0), "All values should be >= 0")
-        self.assertTrue(torch.all(output < 1.0), "All values should be < 1")
+        self.assertTrue(torch.all(out_f >= 0.0), "All values should be >= 0")
+        self.assertTrue(torch.all(out_f < 1.0), "All values should be < 1")
+        self.assertTrue(torch.all(out_i >= 10), "All values should be >= 10")
+        self.assertTrue(torch.all(out_i < 50), "All values should be < 50")
+
+        # Uniqueness and quantile checks on the uniform output
+        sorted_values = torch.sort(out_f.flatten()).values.cpu()
+
+        unique_values = torch.unique(sorted_values)
+        total_values = out_f.numel()
+        uniqueness_ratio = len(unique_values) / total_values
+
+        self.assertGreater(
+            uniqueness_ratio,
+            0.99,
+            f"Expected >99% unique values, got {uniqueness_ratio:.4f}",
+        )
+
+        n_quartile = total_values // 4
+        q1_val = sorted_values[n_quartile].item()
+        q2_val = sorted_values[2 * n_quartile].item()
+        q3_val = sorted_values[3 * n_quartile].item()
+
+        self.assertTrue(
+            0.2 < q1_val < 0.3, f"First quartile {q1_val:.3f} should be around 0.25"
+        )
+        self.assertTrue(
+            0.45 < q2_val < 0.55, f"Median {q2_val:.3f} should be around 0.5"
+        )
+        self.assertTrue(
+            0.7 < q3_val < 0.8, f"Third quartile {q3_val:.3f} should be around 0.75"
+        )
 
     @skipIfRefEager("compile_config is not supported in ref eager mode")
     def test_hl_rand_3d(self):
@@ -437,49 +497,6 @@ class TestRandom(RefEagerTestBase, TestCase):
 
         self.assertTrue(torch.all(outputs[0] >= 0.0))
         self.assertTrue(torch.all(outputs[0] < 1.0))
-
-    def test_hl_rand_uniqueness_distribution(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            output = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_m, tile_n in hl.tile([m, n]):
-                output[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
-            return output
-
-        x = torch.ones(256, 256, device=DEVICE)
-        seed = 1337
-
-        _, output = code_and_output(
-            rand_kernel, (x, seed), block_sizes=_rng_2d_block_sizes()
-        )
-
-        sorted_values = torch.sort(output.flatten()).values.cpu()
-
-        unique_values = torch.unique(sorted_values)
-        total_values = output.numel()
-        uniqueness_ratio = len(unique_values) / total_values
-
-        self.assertGreater(
-            uniqueness_ratio,
-            0.99,
-            f"Expected >99% unique values, got {uniqueness_ratio:.4f}",
-        )
-
-        n_quartile = total_values // 4
-        q1_val = sorted_values[n_quartile].item()
-        q2_val = sorted_values[2 * n_quartile].item()
-        q3_val = sorted_values[3 * n_quartile].item()
-
-        self.assertTrue(
-            0.2 < q1_val < 0.3, f"First quartile {q1_val:.3f} should be around 0.25"
-        )
-        self.assertTrue(
-            0.45 < q2_val < 0.55, f"Median {q2_val:.3f} should be around 0.5"
-        )
-        self.assertTrue(
-            0.7 < q3_val < 0.8, f"Third quartile {q3_val:.3f} should be around 0.75"
-        )
 
     def test_hl_rand_non_tiled_dimensions(self):
         @helion.kernel(static_shapes=False)
@@ -582,31 +599,6 @@ class TestRandom(RefEagerTestBase, TestCase):
 
     @skipIfRefEager("compile_config is not supported in ref eager mode")
     @skipIfMTIA("MTIA tl.rand bit patterns differ from Helion Philox lowering")
-    def test_hl_rand_with_explicit_offsets(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_explicit_offsets_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            output = torch.zeros_like(x)
-            (m,) = x.shape
-            for tile_m in hl.tile(m):
-                idx = hl.tile_index(tile_m).to(torch.int64)
-                offsets = idx * 3
-                output[tile_m] = hl.rand([], seed=seed, offsets=offsets)
-            return output
-
-        x = torch.empty(256, device=DEVICE, dtype=torch.float32)
-        seed = 31337
-        code, compiled = _compile_once(
-            rand_explicit_offsets_kernel, (x, seed), block_sizes=[64]
-        )
-        out = compiled(x, seed)
-
-        ref_offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64) * 3
-        expected = _triton_rand_reference(seed, ref_offsets).reshape_as(x)
-        _assert_bitwise_equal_float(self, out, expected)
-        _assert_uses_philox(self, code)
-
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    @skipIfMTIA("MTIA tl.rand bit patterns differ from Helion Philox lowering")
     def test_hl_rand_offsets_independence(self):
         """Two hl.rand calls with different offset expressions are different but deterministic."""
 
@@ -623,9 +615,26 @@ class TestRandom(RefEagerTestBase, TestCase):
                 out_b[tile_m] = hl.rand([], seed=seed, offsets=idx * 3 + 1)
             return out_a, out_b
 
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            ref_mode=helion.RefMode.EAGER,
+        )
+        def rand_two_streams_kernel_ref(
+            x: torch.Tensor, seed: int
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out_a = torch.zeros_like(x)
+            out_b = torch.zeros_like(x)
+            (m,) = x.shape
+            for tile_m in hl.tile(m):
+                idx = hl.tile_index(tile_m).to(torch.int64)
+                out_a[tile_m] = hl.rand([], seed=seed, offsets=idx * 3)
+                out_b[tile_m] = hl.rand([], seed=seed, offsets=idx * 3 + 1)
+            return out_a, out_b
+
         x = torch.empty(128, device=DEVICE, dtype=torch.float32)
         seed = 4242
-        _code, compiled = _compile_once(
+        code, compiled = _compile_once(
             rand_two_streams_kernel, (x, seed), block_sizes=[32]
         )
         a, b = compiled(x, seed)
@@ -643,6 +652,12 @@ class TestRandom(RefEagerTestBase, TestCase):
         expected_b = _triton_rand_reference(seed, ref_offsets_b).reshape_as(x)
         _assert_bitwise_equal_float(self, a, expected_a)
         _assert_bitwise_equal_float(self, b, expected_b)
+        _assert_uses_philox(self, code)
+
+        # Ref eager mode should match the compiled kernel bit-for-bit
+        ref_a, ref_b = rand_two_streams_kernel_ref(x, seed)
+        _assert_bitwise_equal_float(self, a, ref_a)
+        _assert_bitwise_equal_float(self, b, ref_b)
 
     @skipIfRefEager("compile_config is not supported in ref eager mode")
     @skipIfMTIA("MTIA tl.rand4x bit patterns differ from Helion Philox lowering")
@@ -678,164 +693,59 @@ class TestRandom(RefEagerTestBase, TestCase):
         _assert_bitwise_equal_float(self, out[2], expected_2)
         _assert_uses_philox(self, code)
 
-    def test_hl_randint_1d(self):
-        """Test hl.randint with 1D output."""
-
-        @helion.kernel(static_shapes=False)
-        def randint_kernel_1d(x: torch.Tensor, seed: int) -> torch.Tensor:
-            output = torch.zeros(x.shape, dtype=torch.int32, device=x.device)
-            (m,) = x.shape
-            for tile_m in hl.tile(m):
-                output[tile_m] = hl.randint([tile_m], low=0, high=100, seed=seed)
-            return output
-
-        x = torch.ones(1024, device=DEVICE)
-        _, output = code_and_output(randint_kernel_1d, (x, 42), block_sizes=[1024])
-        _, output2 = code_and_output(randint_kernel_1d, (x, 1337), block_sizes=[1024])
-
-        # Different seeds should produce different outputs
-        self.assertFalse(
-            torch.allclose(output.float(), output2.float()),
-            "Different seeds should produce different outputs",
-        )
-
-        # Same seed should produce identical outputs
-        code3, output3 = code_and_output(randint_kernel_1d, (x, 42), block_sizes=[1024])
-        self.assertTrue(
-            torch.allclose(output.float(), output3.float()),
-            "Same seed should produce identical outputs",
-        )
-        _assert_uses_philox(self, code3)
-
-        # Check that all values are in [0, 100) range
-        self.assertTrue(torch.all(output >= 0), "All values should be >= 0")
-        self.assertTrue(torch.all(output < 100), "All values should be < 100")
-        self.assertEqual(output.dtype, torch.int32, "Output dtype should be int32")
-
-    def test_hl_randint_2d(self):
-        """Test hl.randint with 2D output."""
-
-        @helion.kernel(static_shapes=False)
-        def randint_kernel_2d(x: torch.Tensor, seed: int) -> torch.Tensor:
-            output = torch.zeros(x.shape, dtype=torch.int32, device=x.device)
-            m, n = x.shape
-            for tile_m, tile_n in hl.tile([m, n]):
-                output[tile_m, tile_n] = hl.randint(
-                    [tile_m, tile_n], low=10, high=50, seed=seed
-                )
-            return output
-
-        x = torch.ones(1024, 1024, device=DEVICE)
-        block_sizes = _rng_2d_block_sizes()
-        _, output = code_and_output(randint_kernel_2d, (x, 42), block_sizes=block_sizes)
-
-        # Check that all values are in [10, 50) range
-        self.assertTrue(torch.all(output >= 10), "All values should be >= 10")
-        self.assertTrue(torch.all(output < 50), "All values should be < 50")
-
-        code2, output2 = code_and_output(
-            randint_kernel_2d, (x, 42), block_sizes=block_sizes
-        )
-        torch.testing.assert_close(
-            output, output2, msg="Same seed should be deterministic"
-        )
-
-    def test_hl_randint_negative_range(self):
-        """Test hl.randint with negative range."""
-
-        @helion.kernel(static_shapes=False)
-        def randint_kernel_neg(x: torch.Tensor, seed: int) -> torch.Tensor:
-            output = torch.zeros(x.shape, dtype=torch.int32, device=x.device)
-            (m,) = x.shape
-            for tile_m in hl.tile(m):
-                output[tile_m] = hl.randint([tile_m], low=-50, high=50, seed=seed)
-            return output
-
-        x = torch.ones(1024, device=DEVICE)
-        code, output = code_and_output(randint_kernel_neg, (x, 42), block_sizes=[1024])
-
-        # Check that all values are in [-50, 50) range
-        self.assertTrue(torch.all(output >= -50), "All values should be >= -50")
-        self.assertTrue(torch.all(output < 50), "All values should be < 50")
-
-        # Check that we have both negative and positive values (statistically very likely)
-        self.assertTrue(torch.any(output < 0), "Should have some negative values")
-        self.assertTrue(torch.any(output >= 0), "Should have some non-negative values")
-
-    def test_hl_rand_static_shapes(self):
-        """Test hl.rand with static_shapes=True (default)."""
+    def test_hl_rand_randint_static_shapes(self):
+        """Test hl.rand and hl.randint with static_shapes=True (default)."""
 
         @helion.kernel(static_shapes=True)
-        def rand_kernel_static(x: torch.Tensor, seed: int) -> torch.Tensor:
-            output = torch.zeros_like(x)
+        def rng_kernel_static(
+            x: torch.Tensor, seed: int
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out_f = torch.zeros_like(x)
+            out_i = torch.zeros(x.shape, dtype=torch.int32, device=x.device)
             (m,) = x.shape
             for tile_m in hl.tile(m):
-                output[tile_m] = hl.rand([tile_m], seed=seed)
-            return output
+                out_f[tile_m] = hl.rand([tile_m], seed=seed)
+                out_i[tile_m] = hl.randint([tile_m], low=0, high=100, seed=seed)
+            return out_f, out_i
 
-        x = torch.ones(128, device=DEVICE)
-        _, output = code_and_output(rand_kernel_static, (x, 1337), block_sizes=[128])
-        code, output2 = code_and_output(
-            rand_kernel_static, (x, 1337), block_sizes=[128]
+        x = torch.ones(256, device=DEVICE)
+        _, (out_f, out_i) = code_and_output(
+            rng_kernel_static, (x, 1337), block_sizes=[256]
+        )
+        out_f2, out_i2 = output_only(rng_kernel_static, (x, 1337), block_sizes=[256])
+        torch.testing.assert_close(
+            out_f, out_f2, msg="Same seed should produce identical outputs"
         )
         torch.testing.assert_close(
-            output, output2, msg="Same seed should produce identical outputs"
-        )
-
-    def test_hl_randint_static_shapes(self):
-        """Test hl.randint with static_shapes=True (default)."""
-
-        @helion.kernel(static_shapes=True)
-        def randint_kernel_static(x: torch.Tensor, seed: int) -> torch.Tensor:
-            output = torch.zeros(x.shape, dtype=torch.int32, device=x.device)
-            (m,) = x.shape
-            for tile_m in hl.tile(m):
-                output[tile_m] = hl.randint([tile_m], low=0, high=100, seed=seed)
-            return output
-
-        x = torch.ones(1024, device=DEVICE)
-        _, output = code_and_output(randint_kernel_static, (x, 42), block_sizes=[1024])
-        code, output2 = code_and_output(
-            randint_kernel_static, (x, 42), block_sizes=[1024]
-        )
-        torch.testing.assert_close(
-            output, output2, msg="Same seed should produce identical outputs"
+            out_i, out_i2, msg="Same seed should produce identical outputs"
         )
 
     @skipIfMTIA(
         "MTIA requires all tensor inputs to be aligned and/or padded according to the MTIA HW requirements"
     )
-    def test_hl_rand_specialize(self):
+    def test_hl_rand_randint_specialize(self):
         @helion.kernel()
-        def fn(out: torch.Tensor, seed: int) -> torch.Tensor:
-            m = out.size(0)
-            n = hl.specialize(out.size(1))
+        def fn(out_f: torch.Tensor, out_i: torch.Tensor, seed: int) -> None:
+            m = out_f.size(0)
+            n = hl.specialize(out_f.size(1))
             for tile_m in hl.tile(m):
-                out[tile_m, :] = hl.rand([tile_m, n], seed=seed)
+                out_f[tile_m, :] = hl.rand([tile_m, n], seed=seed)
+                out_i[tile_m, :] = hl.randint([tile_m, n], low=15, high=75, seed=seed)
 
-        out = torch.empty(128, 1, device=DEVICE)
-        _, output = code_and_output(fn, (out, 1337), block_sizes=[128])
-        code, output2 = code_and_output(fn, (out, 1337), block_sizes=[128])
+        out_f = torch.empty(128, 1, device=DEVICE)
+        out_i = torch.empty(128, 1, device=DEVICE)
+        code_and_output(fn, (out_f, out_i, 1337), block_sizes=[128])
+        # Rerun on fresh tensors: the TPU runtime donates mutated input
+        # buffers to XLA, so re-passing the same tensors to a second call
+        # would hand Execute() an already-donated buffer.
+        out_f2 = torch.empty(128, 1, device=DEVICE)
+        out_i2 = torch.empty(128, 1, device=DEVICE)
+        output_only(fn, (out_f2, out_i2, 1337), block_sizes=[128])
         torch.testing.assert_close(
-            output, output2, msg="Same seed should produce identical outputs"
+            out_f2, out_f, msg="Same seed should produce identical outputs"
         )
-
-    @skipIfMTIA(
-        "MTIA requires all tensor inputs to be aligned and/or padded according to the MTIA HW requirements"
-    )
-    def test_hl_randint_specialize(self):
-        @helion.kernel()
-        def fn(out: torch.Tensor, seed: int) -> torch.Tensor:
-            m = out.size(0)
-            n = hl.specialize(out.size(1))
-            for tile_m in hl.tile(m):
-                out[tile_m, :] = hl.randint([tile_m, n], low=15, high=75, seed=seed)
-
-        out = torch.empty(128, 1, device=DEVICE)
-        _, output = code_and_output(fn, (out, 1337), block_sizes=[128])
-        code, output2 = code_and_output(fn, (out, 1337), block_sizes=[128])
         torch.testing.assert_close(
-            output, output2, msg="Same seed should produce identical outputs"
+            out_i2, out_i, msg="Same seed should produce identical outputs"
         )
 
 
@@ -858,308 +768,169 @@ class TestRandomPhiloxParity(TestCase):
         ref_randint = philox_randint_ref(seed, offsets, low, high)
         self.assertTrue(torch.equal(triton_randint.cpu(), ref_randint.cpu()))
 
-    def test_hl_rand_matches_triton_reference(self):
+    def test_hl_rand_randint_match_triton_reference(self):
         @helion.kernel(static_shapes=False)
-        def rand_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
+        def rng_kernel(
+            x: torch.Tensor, seed: int
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            out_f = torch.zeros_like(x)
             m, n = x.shape
+            out_i = torch.zeros((m, n), dtype=torch.int32, device=x.device)
+            out_h = torch.zeros((2, m, n), dtype=torch.int32, device=x.device)
             for tile_m, tile_n in hl.tile([m, n]):
-                out[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
-            return out
+                out_f[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
+                out_i[tile_m, tile_n] = hl.randint(
+                    [tile_m, tile_n], low=-11, high=23, seed=seed
+                )
+                out_h[0, tile_m, tile_n] = _helper_seeded_randint(tile_m, tile_n, seed)
+                out_h[1, tile_m, tile_n] = _helper_seeded_randint(tile_m, tile_n, seed)
+            return out_f, out_i, out_h
 
         shape = (17, 19)
         x = torch.empty(shape, device=DEVICE, dtype=torch.float32)
         seed = 1337
-        _code, out = code_and_output(rand_kernel, (x, seed), block_sizes=[8, 16])
-        offsets = torch.arange(out.numel(), device=DEVICE, dtype=torch.int64)
-        expected = _triton_rand_reference(seed, offsets).reshape(shape)
-        _assert_bitwise_equal_float(self, out, expected)
+        _code, (out_f, out_i, out_h) = code_and_output(
+            rng_kernel, (x, seed), block_sizes=[8, 16]
+        )
+        offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
+        expected_f = _triton_rand_reference(seed, offsets).reshape(shape)
+        _assert_bitwise_equal_float(self, out_f, expected_f)
+        expected_i = _triton_randint_reference(seed, offsets, -11, 23).reshape(shape)
+        self.assertTrue(torch.equal(out_i.cpu(), expected_i.cpu()))
+        # Repeated helper invocations reuse the same explicit seed stream
+        expected_h = _triton_randint_reference(seed, offsets, -5, 17).reshape(shape)
+        self.assertTrue(torch.equal(out_h[0].cpu(), expected_h.cpu()))
+        self.assertTrue(torch.equal(out_h[1].cpu(), expected_h.cpu()))
 
-    def test_hl_randint_matches_triton_reference(self):
-        @helion.kernel(static_shapes=False)
-        def randint_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_m, tile_n in hl.tile([m, n]):
-                out[tile_m, tile_n] = hl.randint(
-                    [tile_m, tile_n], low=-11, high=23, seed=seed
-                )
-            return out
-
-        shape = (15, 21)
-        x = torch.empty(shape, device=DEVICE, dtype=torch.int32)
-        seed = 2024
-        _code, out = code_and_output(randint_kernel, (x, seed), block_sizes=[8, 8])
-        offsets = torch.arange(out.numel(), device=DEVICE, dtype=torch.int64)
-        expected = _triton_randint_reference(
-            seed,
-            offsets,
-            -11,
-            23,
-        ).reshape(shape)
-        self.assertTrue(torch.equal(out.cpu(), expected.cpu()))
-
-    def test_hl_rand_outer_loop_offsets_match_triton_reference(self):
+    def test_hl_rand_randint_outer_loop_offsets_match_triton_reference(self):
         @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_outer_loop_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
+        def outer_loop_kernel(
+            x: torch.Tensor, seed: int
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out_f = torch.zeros_like(x)
             m, n = x.shape
+            out_i = torch.zeros((m, n), dtype=torch.int32, device=x.device)
             for tile_n in hl.tile(n):
                 for tile_m in hl.tile(m):
                     values = hl.rand([tile_m], seed=seed)
-                    out[tile_m, tile_n] = values[:, None].expand(tile_m, tile_n)
-            return out
+                    out_f[tile_m, tile_n] = values[:, None].expand(tile_m, tile_n)
+                    ivalues = hl.randint([tile_m], low=-9, high=19, seed=seed)
+                    out_i[tile_m, tile_n] = ivalues[:, None].expand(tile_m, tile_n)
+            return out_f, out_i
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            ref_mode=helion.RefMode.EAGER,
+        )
+        def outer_loop_kernel_ref(
+            x: torch.Tensor, seed: int
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out_f = torch.zeros_like(x)
+            m, n = x.shape
+            out_i = torch.zeros((m, n), dtype=torch.int32, device=x.device)
+            for tile_n in hl.tile(n):
+                for tile_m in hl.tile(m):
+                    values = hl.rand([tile_m], seed=seed)
+                    out_f[tile_m, tile_n] = values[:, None].expand(tile_m, tile_n)
+                    ivalues = hl.randint([tile_m], low=-9, high=19, seed=seed)
+                    out_i[tile_m, tile_n] = ivalues[:, None].expand(tile_m, tile_n)
+            return out_f, out_i
 
         shape = (17, 23)
         block_sizes = (8, 8)
         x = torch.empty(shape, device=DEVICE, dtype=torch.float32)
         seed = 314
-        _code, out = code_and_output(
-            rand_outer_loop_kernel,
+        _code, (out_f, out_i) = code_and_output(
+            outer_loop_kernel,
             (x, seed),
             block_sizes=list(block_sizes),
         )
-        expected = _hl_rand_outer_loop_expected(shape, block_sizes, seed)
-        _assert_bitwise_equal_float(self, out, expected)
+        expected_f = _hl_rand_outer_loop_expected(shape, block_sizes, seed)
+        _assert_bitwise_equal_float(self, out_f, expected_f)
+        expected_i = _hl_randint_outer_loop_expected(shape, block_sizes, seed, -9, 19)
+        self.assertTrue(torch.equal(out_i.cpu(), expected_i.cpu()))
 
-    def test_hl_randint_outer_loop_offsets_match_triton_reference(self):
+        # Ref eager mode should match the compiled kernel bit-for-bit
+        ref_f, ref_i = outer_loop_kernel_ref(x, seed)
+        _assert_bitwise_equal_float(self, out_f, ref_f)
+        self.assertTrue(torch.equal(out_i.cpu(), ref_i.cpu()))
+
+    def test_hl_rand_repeated_callsites_reuse_explicit_seed_stream(self):
         @helion.kernel(static_shapes=False, autotune_effort="none")
-        def randint_outer_loop_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
+        def rand_callsites_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
             m, n = x.shape
-            for tile_n in hl.tile(n):
-                for tile_m in hl.tile(m):
-                    values = hl.randint([tile_m], low=-9, high=19, seed=seed)
-                    out[tile_m, tile_n] = values[:, None].expand(tile_m, tile_n)
-            return out
-
-        shape = (15, 21)
-        block_sizes = (8, 8)
-        x = torch.empty(shape, device=DEVICE, dtype=torch.int32)
-        seed = 2718
-        _code, out = code_and_output(
-            randint_outer_loop_kernel,
-            (x, seed),
-            block_sizes=list(block_sizes),
-        )
-        expected = _hl_randint_outer_loop_expected(shape, block_sizes, seed, -9, 19)
-        self.assertTrue(torch.equal(out.cpu(), expected.cpu()))
-
-    def test_hl_rand_multiple_calls_reuse_explicit_seed_stream(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_twice_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            m, n = x.shape
-            out = torch.zeros((2, m, n), device=x.device, dtype=x.dtype)
+            out = torch.zeros((3, m, n), device=x.device, dtype=x.dtype)
             for tile_m, tile_n in hl.tile([m, n]):
                 out[0, tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
                 out[1, tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
+                out[2, tile_m, tile_n] = _helper_seeded_rand(tile_m, tile_n, seed)
+            return out
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            ref_mode=helion.RefMode.EAGER,
+        )
+        def rand_callsites_kernel_ref(x: torch.Tensor, seed: int) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.zeros((3, m, n), device=x.device, dtype=x.dtype)
+            for tile_m, tile_n in hl.tile([m, n]):
+                out[0, tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
+                out[1, tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
+                out[2, tile_m, tile_n] = _helper_seeded_rand(tile_m, tile_n, seed)
             return out
 
         x = torch.empty((11, 13), device=DEVICE, dtype=torch.float32)
         seed = 777
-        _code, out = code_and_output(rand_twice_kernel, (x, seed), block_sizes=[8, 8])
+        _code, out = code_and_output(
+            rand_callsites_kernel, (x, seed), block_sizes=[8, 8]
+        )
         offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
         expected = _triton_rand_reference(seed, offsets).reshape_as(x)
+        # Direct calls and helper invocations all reuse the same seed stream
         _assert_bitwise_equal_float(self, out[0], expected)
         _assert_bitwise_equal_float(self, out[1], expected)
-        _assert_bitwise_equal_float(self, out[0], out[1])
+        _assert_bitwise_equal_float(self, out[2], expected)
 
-    def test_hl_rand_helper_invocations_reuse_explicit_seed_stream(self):
+        # Ref eager mode should match the compiled kernel bit-for-bit
+        ref_out = rand_callsites_kernel_ref(x, seed)
+        _assert_bitwise_equal_float(self, out, ref_out)
+
+    def test_hl_rand_randint_sibling_loops_reuse_explicit_seed_stream(self):
         @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_helper_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            m, n = x.shape
-            out = torch.zeros((2, m, n), device=x.device, dtype=x.dtype)
-            for tile_m, tile_n in hl.tile([m, n]):
-                out[0, tile_m, tile_n] = _helper_seeded_rand(tile_m, tile_n, seed)
-                out[1, tile_m, tile_n] = _helper_seeded_rand(tile_m, tile_n, seed)
-            return out
-
-        x = torch.empty((11, 13), device=DEVICE, dtype=torch.float32)
-        seed = 1776
-        _code, out = code_and_output(rand_helper_kernel, (x, seed), block_sizes=[8, 8])
-        offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
-        expected = _triton_rand_reference(seed, offsets).reshape_as(x)
-        _assert_bitwise_equal_float(self, out[0], expected)
-        _assert_bitwise_equal_float(self, out[1], expected)
-        _assert_bitwise_equal_float(self, out[0], out[1])
-
-    def test_hl_rand_sibling_loops_reuse_explicit_seed_stream(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_sibling_loops_kernel(
+        def sibling_loops_kernel(
             x: torch.Tensor, seed: int
-        ) -> tuple[torch.Tensor, torch.Tensor]:
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
             m, n = x.shape
-            out0 = torch.zeros_like(x)
-            out1 = torch.zeros_like(x)
+            out0_f = torch.zeros_like(x)
+            out1_f = torch.zeros_like(x)
+            out0_i = torch.zeros((m, n), dtype=torch.int32, device=x.device)
+            out1_i = torch.zeros((m, n), dtype=torch.int32, device=x.device)
             for tile_m, tile_n in hl.tile([m, n]):
-                out0[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
+                out0_f[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
+                out0_i[tile_m, tile_n] = hl.randint(
+                    [tile_m, tile_n], low=-5, high=17, seed=seed
+                )
             for tile_m, tile_n in hl.tile([m, n]):
-                out1[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
-            return out0, out1
+                out1_f[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
+                out1_i[tile_m, tile_n] = hl.randint(
+                    [tile_m, tile_n], low=-5, high=17, seed=seed
+                )
+            return out0_f, out1_f, out0_i, out1_i
 
         x = torch.empty((11, 13), device=DEVICE, dtype=torch.float32)
         seed = 1777
-        _code, (out0, out1) = code_and_output(
-            rand_sibling_loops_kernel, (x, seed), block_sizes=[8, 16, 8, 16]
+        _code, (out0_f, out1_f, out0_i, out1_i) = code_and_output(
+            sibling_loops_kernel, (x, seed), block_sizes=[8, 16, 8, 16]
         )
         offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
-        expected = _triton_rand_reference(seed, offsets).reshape_as(x)
-        _assert_bitwise_equal_float(self, out0, expected)
-        _assert_bitwise_equal_float(self, out1, expected)
-        _assert_bitwise_equal_float(self, out0, out1)
-
-    def test_hl_randint_sibling_loops_reuse_explicit_seed_stream(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def randint_sibling_loops_kernel(
-            x: torch.Tensor, seed: int
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, n = x.shape
-            out0 = torch.zeros_like(x)
-            out1 = torch.zeros_like(x)
-            for tile_m, tile_n in hl.tile([m, n]):
-                out0[tile_m, tile_n] = hl.randint(
-                    [tile_m, tile_n], low=-5, high=17, seed=seed
-                )
-            for tile_m, tile_n in hl.tile([m, n]):
-                out1[tile_m, tile_n] = hl.randint(
-                    [tile_m, tile_n], low=-5, high=17, seed=seed
-                )
-            return out0, out1
-
-        x = torch.empty((9, 15), device=DEVICE, dtype=torch.int32)
-        seed = 201
-        _code, (out0, out1) = code_and_output(
-            randint_sibling_loops_kernel, (x, seed), block_sizes=[8, 16, 8, 16]
-        )
-        offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
-        expected = _triton_randint_reference(seed, offsets, -5, 17).reshape_as(x)
-        self.assertTrue(torch.equal(out0.cpu(), expected.cpu()))
-        self.assertTrue(torch.equal(out1.cpu(), expected.cpu()))
-        self.assertTrue(torch.equal(out0.cpu(), out1.cpu()))
-
-    def test_hl_randint_helper_invocations_reuse_explicit_seed_stream(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def randint_helper_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            m, n = x.shape
-            out = torch.zeros((2, m, n), device=x.device, dtype=x.dtype)
-            for tile_m, tile_n in hl.tile([m, n]):
-                out[0, tile_m, tile_n] = _helper_seeded_randint(tile_m, tile_n, seed)
-                out[1, tile_m, tile_n] = _helper_seeded_randint(tile_m, tile_n, seed)
-            return out
-
-        x = torch.empty((9, 15), device=DEVICE, dtype=torch.int32)
-        seed = 202
-        _code, out = code_and_output(
-            randint_helper_kernel, (x, seed), block_sizes=[8, 16]
-        )
-        offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
-        expected = _triton_randint_reference(seed, offsets, -5, 17).reshape_as(x)
-        self.assertTrue(torch.equal(out[0].cpu(), expected.cpu()))
-        self.assertTrue(torch.equal(out[1].cpu(), expected.cpu()))
-        self.assertTrue(torch.equal(out[0].cpu(), out[1].cpu()))
-
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_hl_rand_ref_mode_matches_compiled(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_outer_loop_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_n in hl.tile(n):
-                for tile_m in hl.tile(m):
-                    values = hl.rand([tile_m], seed=seed)
-                    out[tile_m, tile_n] = values[:, None].expand(tile_m, tile_n)
-            return out
-
-        @helion.kernel(
-            static_shapes=False,
-            autotune_effort="none",
-            ref_mode=helion.RefMode.EAGER,
-        )
-        def rand_outer_loop_kernel_ref(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_n in hl.tile(n):
-                for tile_m in hl.tile(m):
-                    values = hl.rand([tile_m], seed=seed)
-                    out[tile_m, tile_n] = values[:, None].expand(tile_m, tile_n)
-            return out
-
-        x = torch.empty((15, 21), device=DEVICE, dtype=torch.float32)
-        seed = 31415
-        _code, compiled = _compile_once(
-            rand_outer_loop_kernel, (x, seed), block_sizes=[8, 8]
-        )
-        compiled_out = compiled(x, seed)
-        ref_out = rand_outer_loop_kernel_ref(x, seed)
-        _assert_bitwise_equal_float(self, compiled_out, ref_out)
-
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_hl_rand_helper_ref_mode_matches_compiled(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_helper_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            m, n = x.shape
-            out = torch.zeros((2, m, n), device=x.device, dtype=x.dtype)
-            for tile_m, tile_n in hl.tile([m, n]):
-                out[0, tile_m, tile_n] = _helper_seeded_rand(tile_m, tile_n, seed)
-                out[1, tile_m, tile_n] = _helper_seeded_rand(tile_m, tile_n, seed)
-            return out
-
-        @helion.kernel(
-            static_shapes=False,
-            autotune_effort="none",
-            ref_mode=helion.RefMode.EAGER,
-        )
-        def rand_helper_kernel_ref(x: torch.Tensor, seed: int) -> torch.Tensor:
-            m, n = x.shape
-            out = torch.zeros((2, m, n), device=x.device, dtype=x.dtype)
-            for tile_m, tile_n in hl.tile([m, n]):
-                out[0, tile_m, tile_n] = _helper_seeded_rand(tile_m, tile_n, seed)
-                out[1, tile_m, tile_n] = _helper_seeded_rand(tile_m, tile_n, seed)
-            return out
-
-        x = torch.empty((11, 13), device=DEVICE, dtype=torch.float32)
-        seed = 314159
-        _code, compiled = _compile_once(
-            rand_helper_kernel, (x, seed), block_sizes=[8, 8]
-        )
-        compiled_out = compiled(x, seed)
-        ref_out = rand_helper_kernel_ref(x, seed)
-        _assert_bitwise_equal_float(self, compiled_out, ref_out)
-
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_hl_randint_ref_mode_matches_compiled(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def randint_outer_loop_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_n in hl.tile(n):
-                for tile_m in hl.tile(m):
-                    values = hl.randint([tile_m], low=-7, high=23, seed=seed)
-                    out[tile_m, tile_n] = values[:, None].expand(tile_m, tile_n)
-            return out
-
-        @helion.kernel(
-            static_shapes=False,
-            autotune_effort="none",
-            ref_mode=helion.RefMode.EAGER,
-        )
-        def randint_outer_loop_kernel_ref(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_n in hl.tile(n):
-                for tile_m in hl.tile(m):
-                    values = hl.randint([tile_m], low=-7, high=23, seed=seed)
-                    out[tile_m, tile_n] = values[:, None].expand(tile_m, tile_n)
-            return out
-
-        x = torch.empty((15, 21), device=DEVICE, dtype=torch.int32)
-        seed = 27182
-        _code, compiled = _compile_once(
-            randint_outer_loop_kernel, (x, seed), block_sizes=[8, 8]
-        )
-        compiled_out = compiled(x, seed)
-        ref_out = randint_outer_loop_kernel_ref(x, seed)
-        self.assertTrue(torch.equal(compiled_out.cpu(), ref_out.cpu()))
+        expected_f = _triton_rand_reference(seed, offsets).reshape_as(x)
+        _assert_bitwise_equal_float(self, out0_f, expected_f)
+        _assert_bitwise_equal_float(self, out1_f, expected_f)
+        expected_i = _triton_randint_reference(seed, offsets, -5, 17).reshape_as(out0_i)
+        self.assertTrue(torch.equal(out0_i.cpu(), expected_i.cpu()))
+        self.assertTrue(torch.equal(out1_i.cpu(), expected_i.cpu()))
 
     def test_hl_rand_explicit_offsets_ref_matches_triton(self):
         seed = 12321
@@ -1168,76 +939,7 @@ class TestRandomPhiloxParity(TestCase):
         ref_out = philox_rand_ref(seed, offsets)
         _assert_bitwise_equal_float(self, triton_out, ref_out)
 
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_hl_rand_with_offsets_ref_mode_matches_compiled(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand_offsets_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            (m,) = x.shape
-            for tile_m in hl.tile(m):
-                idx = hl.tile_index(tile_m).to(torch.int64)
-                out[tile_m] = hl.rand([], seed=seed, offsets=idx * 3)
-            return out
-
-        @helion.kernel(
-            static_shapes=False,
-            autotune_effort="none",
-            ref_mode=helion.RefMode.EAGER,
-        )
-        def rand_offsets_kernel_ref(x: torch.Tensor, seed: int) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            (m,) = x.shape
-            for tile_m in hl.tile(m):
-                idx = hl.tile_index(tile_m).to(torch.int64)
-                out[tile_m] = hl.rand([], seed=seed, offsets=idx * 3)
-            return out
-
-        x = torch.empty(192, device=DEVICE, dtype=torch.float32)
-        seed = 161803
-        _code, compiled = _compile_once(
-            rand_offsets_kernel, (x, seed), block_sizes=[32]
-        )
-        compiled_out = compiled(x, seed)
-        ref_out = rand_offsets_kernel_ref(x, seed)
-        _assert_bitwise_equal_float(self, compiled_out, ref_out)
-
     def test_hl_rand4x_matches_triton_reference(self):
-        @helion.kernel(static_shapes=False, autotune_effort="none")
-        def rand4x_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
-            (m,) = x.shape
-            out = torch.zeros((4, m), device=x.device, dtype=torch.float32)
-            for tile_m in hl.tile(m):
-                idx = hl.tile_index(tile_m).to(torch.int64)
-                r0, r1, r2, r3 = hl.rand4x(seed, idx)
-                out[0, tile_m] = r0
-                out[1, tile_m] = r1
-                out[2, tile_m] = r2
-                out[3, tile_m] = r3
-            return out
-
-        x = torch.empty(123, device=DEVICE, dtype=torch.float32)
-        seed = 271828
-        code, out = code_and_output(rand4x_kernel, (x, seed), block_sizes=[16])
-        offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
-        e0, e1, e2, e3 = _triton_rand4x_reference(seed, offsets)
-        _assert_bitwise_equal_float(self, out[0], e0.reshape_as(x))
-        _assert_bitwise_equal_float(self, out[1], e1.reshape_as(x))
-        _assert_bitwise_equal_float(self, out[2], e2.reshape_as(x))
-        _assert_bitwise_equal_float(self, out[3], e3.reshape_as(x))
-        _assert_uses_philox(self, code)
-
-    def test_hl_rand4x_ref_matches_triton(self):
-        seed = 54321
-        offsets = torch.arange(96, device=DEVICE, dtype=torch.int64) * 4
-        t0, t1, t2, t3 = _triton_rand4x_reference(seed, offsets)
-        r0, r1, r2, r3 = philox_rand4x_ref(seed, offsets)
-        _assert_bitwise_equal_float(self, t0, r0)
-        _assert_bitwise_equal_float(self, t1, r1)
-        _assert_bitwise_equal_float(self, t2, r2)
-        _assert_bitwise_equal_float(self, t3, r3)
-
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_hl_rand4x_ref_mode_matches_compiled(self):
         @helion.kernel(static_shapes=False, autotune_effort="none")
         def rand4x_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
             (m,) = x.shape
@@ -1268,12 +970,30 @@ class TestRandomPhiloxParity(TestCase):
                 out[3, tile_m] = r3
             return out
 
-        x = torch.empty(96, device=DEVICE, dtype=torch.float32)
-        seed = 999
-        _code, compiled = _compile_once(rand4x_kernel, (x, seed), block_sizes=[16])
-        compiled_out = compiled(x, seed)
+        x = torch.empty(123, device=DEVICE, dtype=torch.float32)
+        seed = 271828
+        code, out = code_and_output(rand4x_kernel, (x, seed), block_sizes=[16])
+        offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
+        e0, e1, e2, e3 = _triton_rand4x_reference(seed, offsets)
+        _assert_bitwise_equal_float(self, out[0], e0.reshape_as(x))
+        _assert_bitwise_equal_float(self, out[1], e1.reshape_as(x))
+        _assert_bitwise_equal_float(self, out[2], e2.reshape_as(x))
+        _assert_bitwise_equal_float(self, out[3], e3.reshape_as(x))
+        _assert_uses_philox(self, code)
+
+        # Ref eager mode should match the compiled kernel bit-for-bit
         ref_out = rand4x_kernel_ref(x, seed)
-        _assert_bitwise_equal_float(self, compiled_out, ref_out)
+        _assert_bitwise_equal_float(self, out, ref_out)
+
+    def test_hl_rand4x_ref_matches_triton(self):
+        seed = 54321
+        offsets = torch.arange(96, device=DEVICE, dtype=torch.int64) * 4
+        t0, t1, t2, t3 = _triton_rand4x_reference(seed, offsets)
+        r0, r1, r2, r3 = philox_rand4x_ref(seed, offsets)
+        _assert_bitwise_equal_float(self, t0, r0)
+        _assert_bitwise_equal_float(self, t1, r1)
+        _assert_bitwise_equal_float(self, t2, r2)
+        _assert_bitwise_equal_float(self, t3, r3)
 
 
 if __name__ == "__main__":

--- a/test/test_rng.py
+++ b/test/test_rng.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import os
-from typing import Callable
 import unittest
 from unittest.mock import patch
 
@@ -19,6 +18,7 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import output_only
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfXPU
@@ -64,43 +64,22 @@ def _assert_bitwise_equal_float(
 
 
 def _rng_2d_block_sizes() -> list[int]:
+    # RNG offsets are block-size independent; small blocks compile much faster
     if _get_backend() == "cute":
         return [32, 32]
-    return [64, 64]
+    return [16, 16]
 
 
 def _rng_heavy_2d_block_sizes() -> list[int]:
     if _get_backend() == "cute":
         return [16, 16]
-    return [16, 16]
+    return [8, 8]
 
 
 def _rng_3d_block_sizes() -> list[int]:
     if _get_backend() == "cute":
         return [4, 8, 32]
-    return [8, 8, 64]
-
-
-def _compile_once(
-    fn: helion.Kernel,
-    args: tuple[object, ...],
-    **kwargs: object,
-) -> tuple[str, object]:
-    bound = fn.bind(args)
-    if kwargs:
-        config = Config(
-            # pyrefly: ignore [bad-argument-type]
-            **kwargs
-        )
-    elif fn.configs:
-        (config,) = fn.configs
-    else:
-        config = bound.config_spec.default_config()
-    for key in bound.config_spec.unsupported_config_keys(config.config):
-        config.config.pop(key, None)
-    code = bound.to_triton_code(config)
-    compiled = bound.compile_config(config)
-    return code, compiled
+    return [4, 8, 16]
 
 
 def _compile_only(
@@ -179,31 +158,6 @@ else:
         raise unittest.SkipTest("requires Triton")
 
 
-def _nested_broadcast_rand_expected(
-    shape: tuple[int, int],
-    block_sizes: tuple[int, int],
-    seed: int,
-    *,
-    device: torch.device,
-    dtype: torch.dtype,
-) -> torch.Tensor:
-    m, n = shape
-    block_m, block_n = block_sizes
-    expected = torch.empty((m, n), device=device, dtype=dtype)
-    for m_begin in range(0, m, block_m):
-        tile_m = min(block_m, m - m_begin)
-        values = philox_rand_ref(
-            seed,
-            torch.arange(m_begin, m_begin + tile_m, device=device, dtype=torch.int64),
-        ).to(dtype)
-        for n_begin in range(0, n, block_n):
-            tile_n = min(block_n, n - n_begin)
-            expected[m_begin : m_begin + tile_m, n_begin : n_begin + tile_n] = values[
-                :, None
-            ].expand(tile_m, tile_n)
-    return expected
-
-
 def _nested_broadcast_rand_expected_3d(
     shape: tuple[int, int, int],
     block_sizes: tuple[int, int, int],
@@ -239,134 +193,72 @@ def _nested_broadcast_rand_expected_3d(
 
 @onlyBackends(["triton", "pallas", "cute"])
 class TestRNG(RefEagerTestBase, TestCase):
-    @xfailIfPallas("implicit rand still hits TPU deferred buffer materialization")
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
+    @xfailIfPallas("3D implicit RNG hits TPU deferred buffer materialization")
     @skipIfXPU("RNG tests timeout on XPU")
-    def test_rand(self):
-        """Test RNG seeding behavior, reproducibility, output range, and distribution."""
+    def test_rand_randn_3d_tensor(self):
+        """Test 3D rand and randn with tiled operations using a single kernel."""
 
         @helion.kernel(static_shapes=True, autotune_effort="none")
-        def rand_kernel_tiled_2d(x: torch.Tensor) -> torch.Tensor:
-            output = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_m, tile_n in hl.tile([m, n]):
-                output[tile_m, tile_n] = torch.rand_like(x[tile_m, tile_n])
-            return output
-
-        # Test with different tensor sizes for different aspects
-        x_small = torch.ones(128, 128, device=DEVICE)  # For distribution tests
-        x_large = torch.ones(128, 128, device=DEVICE)  # For seeding tests
-        block_sizes = _rng_2d_block_sizes()
-        _code1, compiled = _compile_once(
-            rand_kernel_tiled_2d, (x_large,), block_sizes=block_sizes
-        )
-
-        # Test 1: Different seeds produce different outputs
-        torch.manual_seed(42)
-        output1 = compiled(x_large)
-
-        torch.manual_seed(123)
-        output2 = compiled(x_large)
-
-        self.assertFalse(
-            torch.allclose(output1, output2),
-            "Different seeds should produce different outputs",
-        )
-
-        # Test 2: Same seed produces identical outputs (reproducibility)
-        torch.manual_seed(42)
-        output3 = compiled(x_large)
-
-        torch.testing.assert_close(
-            output1, output3, msg="Same seed should produce identical outputs"
-        )
-
-        # Test 3: RNG state advances between calls
-        torch.manual_seed(42)
-        output4 = compiled(x_large)
-        # No manual_seed here - RNG state should advance
-        output5 = compiled(x_large)
-
-        self.assertFalse(
-            torch.allclose(output4, output5),
-            "Sequential calls should produce different outputs (RNG state advanced)",
-        )
-
-        # Test 4: Output range and distribution properties
-        torch.manual_seed(42)
-        output6 = compiled(x_small)
-
-        # All values should be in [0, 1) range
-        self.assertTrue(torch.all(output6 >= 0.0), "All values should be >= 0")
-        self.assertTrue(torch.all(output6 < 1.0), "All values should be < 1")
-
-        # Check distribution properties
-        mean_val = output6.mean().item()
-        self.assertTrue(
-            0.4 < mean_val < 0.6,
-            f"Mean {mean_val:.3f} should be around 0.5 for uniform distribution",
-        )
-
-        # Check spread of values
-        min_val = output6.min().item()
-        max_val = output6.max().item()
-        self.assertTrue(
-            min_val < 0.2, f"Min value {min_val:.3f} should be < 0.2 for good spread"
-        )
-        self.assertTrue(
-            max_val > 0.8, f"Max value {max_val:.3f} should be > 0.8 for good spread"
-        )
-
-    @xfailIfPallas("3D aten rand has low uniqueness with fold_in offset collisions")
-    @skipIfXPU("RNG tests timeout on XPU")
-    def test_rand_3d_tensor(self):
-        """Test 3D RNG with tiled operations."""
-
-        @helion.kernel(static_shapes=True, autotune_effort="none")
-        def rand_kernel_3d(x: torch.Tensor) -> torch.Tensor:
-            output = torch.zeros_like(x)
+        def rand_randn_kernel_3d(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            uniform = torch.zeros_like(x)
+            normal = torch.zeros_like(x)
             b, m, n = x.shape
             for tile_b, tile_m, tile_n in hl.tile([b, m, n]):
-                output[tile_b, tile_m, tile_n] = torch.rand_like(
-                    x[tile_b, tile_m, tile_n]
-                )
-            return output
+                tile = x[tile_b, tile_m, tile_n]
+                uniform[tile_b, tile_m, tile_n] = torch.rand_like(tile)
+                normal[tile_b, tile_m, tile_n] = torch.randn_like(tile)
+            return uniform, normal
 
-        x = torch.ones(16, 32, 64, device=DEVICE)  # 3D tensor
+        x = torch.ones(8, 32, 64, device=DEVICE)  # 3D tensor
         torch.manual_seed(77)
         block_sizes = _rng_3d_block_sizes()
-        _code, output = code_and_output(rand_kernel_3d, (x,), block_sizes=block_sizes)
-
-        # All values should be in [0, 1) range
-        self.assertTrue(torch.all(output >= 0.0))
-        self.assertTrue(torch.all(output < 1.0))
-
-        # Check uniqueness - 3D should generate different values for each element
-        unique_values = output.cpu().unique().numel()
-        total_values = output.numel()
-
-        # With a good RNG, we should have mostly unique values
-        uniqueness_ratio = unique_values / total_values
-        print(
-            f"3D Unique values: {unique_values}, Total: {total_values}, Percentage: {uniqueness_ratio * 100:.2f}%"
+        _code, (uniform, normal) = code_and_output(
+            rand_randn_kernel_3d, (x,), block_sizes=block_sizes
         )
 
-        # Expect at least 95% unique values for good 3D RNG
+        # All rand values should be in [0, 1) range
+        self.assertTrue(torch.all(uniform >= 0.0))
+        self.assertTrue(torch.all(uniform < 1.0))
+
+        # With a good RNG, we should have mostly unique values
+        uniqueness_ratio = uniform.cpu().unique().numel() / uniform.numel()
         self.assertGreater(uniqueness_ratio, 0.95)
 
+        # Check overall normal distribution
+        normal_cpu = normal.cpu()
+        mean = normal_cpu.mean().item()
+        std = normal_cpu.std().item()
+        self.assertTrue(-0.1 < mean < 0.1, f"3D mean {mean} not close to 0")
+        self.assertTrue(0.95 < std < 1.05, f"3D std {std} not close to 1")
+
         # Check distribution across dimensions
-        # Mean should be around 0.5 for each 2D slice
+        uniform_cpu = uniform.cpu()
         for b_idx in range(x.shape[0]):
-            slice_mean = output[b_idx].mean().item()
+            slice_mean = uniform_cpu[b_idx].mean().item()
             self.assertTrue(
                 0.35 < slice_mean < 0.65,
-                f"Slice {b_idx} mean {slice_mean} is not well distributed",
+                f"Slice {b_idx} rand mean {slice_mean} is not well distributed",
+            )
+            nslice_mean = normal_cpu[b_idx].mean().item()
+            nslice_std = normal_cpu[b_idx].std().item()
+            self.assertTrue(
+                -0.3 < nslice_mean < 0.3,
+                f"Slice {b_idx} randn mean {nslice_mean} is not well distributed",
+            )
+            self.assertTrue(
+                0.85 < nslice_std < 1.15,
+                f"Slice {b_idx} randn std {nslice_std} is not well distributed",
             )
 
         # Verify different seeds produce different results
         torch.manual_seed(88)
-        _code2, output2 = code_and_output(rand_kernel_3d, (x,), block_sizes=block_sizes)
-        self.assertFalse(torch.allclose(output, output2))
+        uniform2, normal2 = output_only(
+            rand_randn_kernel_3d, (x,), block_sizes=block_sizes
+        )
+        self.assertFalse(torch.allclose(uniform, uniform2))
+        self.assertFalse(torch.allclose(normal, normal2))
 
     @xfailIfPallas(
         "mixed explicit and implicit RNG tiles mis-handle partial tile shapes"
@@ -437,9 +329,9 @@ class TestRNG(RefEagerTestBase, TestCase):
     @xfailIfPallas(
         "multiple implicit RNG outputs hit TPU deferred buffer materialization"
     )
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
+    @skipIfXPU("RNG tests timeout on XPU")
     def test_multiple_rng_ops(self):
-        """Test multiple RNG operations: independence, reproducibility, mixed rand/randn."""
+        """Test multiple RNG ops: independence, distributions, seeding behavior."""
 
         @helion.kernel(static_shapes=True, autotune_effort="none")
         def multiple_rng_ops_kernel(
@@ -463,23 +355,20 @@ class TestRNG(RefEagerTestBase, TestCase):
                 normal[tile_m, tile_n] = torch.randn_like(tile)
 
                 # Multiple randn
-                randn_sum[tile_m, tile_n] = (
-                    torch.randn_like(tile)
-                    + torch.randn_like(tile)
-                    + torch.randn_like(tile)
+                randn_sum[tile_m, tile_n] = torch.randn_like(tile) + torch.randn_like(
+                    tile
                 )
 
             return rand1, rand2, normal, randn_sum
 
-        x = torch.ones(32, 32, device=DEVICE)
+        x = torch.ones(64, 64, device=DEVICE)  # 4096 samples per output
         block_sizes = _rng_heavy_2d_block_sizes()
-        _code1, compiled = _compile_once(
-            multiple_rng_ops_kernel, (x,), block_sizes=block_sizes
-        )
 
         # Test 1: Independence and distribution properties
         torch.manual_seed(42)
-        rand1, rand2, normal, randn_sum = compiled(x)
+        code1, (rand1, rand2, normal, randn_sum) = code_and_output(
+            multiple_rng_ops_kernel, (x,), block_sizes=block_sizes
+        )
 
         # Check two independent rand operations
         self.assertTrue(
@@ -503,25 +392,44 @@ class TestRNG(RefEagerTestBase, TestCase):
             f"Second rand mean {rand2.mean().item():.3f} should be ~0.5",
         )
 
-        # Check mixed rand and randn
+        # Check spread of rand values
+        min_val = rand1.min().item()
+        max_val = rand1.max().item()
         self.assertTrue(
-            -0.2 < normal.mean().item() < 0.2,
+            min_val < 0.2, f"Min value {min_val:.3f} should be < 0.2 for good spread"
+        )
+        self.assertTrue(
+            max_val > 0.8, f"Max value {max_val:.3f} should be > 0.8 for good spread"
+        )
+
+        # Check mixed rand and randn; with 4096 samples the std of the sample
+        # mean is ~0.016, so +-0.1 is a >6 sigma bound.
+        self.assertTrue(
+            -0.1 < normal.mean().item() < 0.1,
             f"Normal mean {normal.mean().item():.3f} should be ~0",
         )
         self.assertTrue(
-            0.9 < normal.cpu().std().item() < 1.1,
+            0.95 < normal.cpu().std().item() < 1.05,
             f"Normal std {normal.cpu().std().item():.3f} should be ~1",
         )
         self.assertTrue(
-            torch.any(normal < 0.0), "Normal distribution should have negative values"
+            torch.any(normal < -1.0) and torch.any(normal > 1.0),
+            "Normal distribution should have tails beyond [-1, 1]",
+        )
+        # Roughly 68% should be within 1 std
+        within_1_std = (
+            torch.logical_and(normal > -1.0, normal < 1.0).float().mean().item()
+        )
+        self.assertTrue(
+            0.63 < within_1_std < 0.73, f"Values within 1 std: {within_1_std}"
         )
         self.assertFalse(
             torch.allclose(rand1, normal),
             "Uniform and normal distributions should be different",
         )
 
-        # Check sum of multiple randn
-        expected_std = 3**0.5
+        # Check sum of multiple randn (two terms -> std of sqrt(2))
+        expected_std = 2**0.5
         mean = randn_sum.mean().item()
         std = randn_sum.cpu().std().item()
         self.assertTrue(-0.2 < mean < 0.2, f"Combined mean {mean:.3f} should be ~0")
@@ -530,154 +438,78 @@ class TestRNG(RefEagerTestBase, TestCase):
             f"Combined std {std:.3f} should be ~{expected_std:.3f}",
         )
 
-        # Test 2: Reproducibility with same seed
-        torch.manual_seed(42)
-        outputs_a = compiled(x)
+        # Test 2: Different seeds produce different outputs
+        torch.manual_seed(123)
+        outputs_123 = output_only(
+            multiple_rng_ops_kernel, (x,), block_sizes=block_sizes
+        )
+        self.assertFalse(
+            torch.allclose(rand1, outputs_123[0]),
+            "Different seeds should produce different outputs",
+        )
+        self.assertFalse(
+            torch.allclose(normal, outputs_123[2]),
+            "Different seeds should produce different outputs",
+        )
 
+        # Test 3: Reproducibility with same seed, then RNG state advances
         torch.manual_seed(42)
-        outputs_b = compiled(x)
-
-        # All outputs should be identical with same seed
-        for i, (a, b) in enumerate(zip(outputs_a, outputs_b, strict=False)):
+        outputs_a = output_only(multiple_rng_ops_kernel, (x,), block_sizes=block_sizes)
+        for i, (a, b) in enumerate(
+            zip((rand1, rand2, normal, randn_sum), outputs_a, strict=True)
+        ):
             torch.testing.assert_close(
                 a, b, msg=f"Output {i} should be identical with same seed"
             )
-
-        _assert_uses_philox(self, _code1)
-
-    @xfailIfPallas("implicit randn still hits TPU deferred buffer materialization")
-    @skipIfXPU("RNG tests timeout on XPU")
-    def test_randn_different_seeds_tiled(self):
-        """Test that different torch.manual_seed values produce different outputs for randn."""
-
-        @helion.kernel(static_shapes=True, autotune_effort="none")
-        def randn_kernel_tiled_2d(x: torch.Tensor) -> torch.Tensor:
-            output = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_m, tile_n in hl.tile([m, n]):
-                output[tile_m, tile_n] = torch.randn_like(x[tile_m, tile_n])
-            return output
-
-        x = torch.ones(128, 128, device=DEVICE)
-        block_sizes = _rng_2d_block_sizes()
-
-        torch.manual_seed(42)
-        _code1, output1 = code_and_output(
-            randn_kernel_tiled_2d, (x,), block_sizes=block_sizes
+        # No manual_seed here - RNG state should advance
+        outputs_b = output_only(multiple_rng_ops_kernel, (x,), block_sizes=block_sizes)
+        self.assertFalse(
+            torch.allclose(outputs_a[0], outputs_b[0]),
+            "Sequential calls should produce different outputs (RNG state advanced)",
         )
 
-        torch.manual_seed(123)
-        _code2, output2 = code_and_output(
-            randn_kernel_tiled_2d, (x,), block_sizes=block_sizes
-        )
+        _assert_uses_philox(self, code1)
 
-        # Different seeds should produce different outputs
-        self.assertFalse(torch.allclose(output1, output2))
+    @xfailIfPallas(
+        "dynamic-shape implicit RNG hits TPU deferred buffer materialization"
+    )
+    @skipIfRefEager("compile_config is not supported in ref eager mode")
+    def test_rng_ops_with_dynamic_tile_sizes(self):
+        """Test torch.rand/rand_like/randn/randn_like with dynamic tile dimensions."""
 
-    @xfailIfPallas("implicit randn still hits TPU deferred buffer materialization")
-    @skipIfXPU("RNG tests timeout on XPU")
-    def test_randn_normal_distribution(self):
-        """Test that torch.randn_like produces normal distribution (mean≈0, std≈1)."""
-
-        @helion.kernel(static_shapes=True, autotune_effort="none")
-        def randn_kernel_tiled_2d(x: torch.Tensor) -> torch.Tensor:
-            output = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_m, tile_n in hl.tile([m, n]):
-                output[tile_m, tile_n] = torch.randn_like(x[tile_m, tile_n])
-            return output
-
-        x = torch.ones(128, 128, device=DEVICE)  # 16384 samples for better statistics
-        torch.manual_seed(42)
-        _code, output = code_and_output(
-            randn_kernel_tiled_2d, (x,), block_sizes=_rng_2d_block_sizes()
-        )
-
-        # Check mean is close to 0
-        mean = output.mean().item()
-        self.assertTrue(-0.1 < mean < 0.1, f"Mean {mean} is not close to 0")
-
-        # Check std is close to 1
-        std = output.cpu().std().item()
-        self.assertTrue(0.95 < std < 1.05, f"Std {std} is not close to 1")
-
-        # Check we have values outside [-1, 1] (characteristic of normal distribution)
-        self.assertTrue(torch.any(output < -1.0))
-        self.assertTrue(torch.any(output > 1.0))
-
-        # Roughly 68% should be within 1 std
-        within_1_std = (
-            torch.logical_and(output > -1.0, output < 1.0).float().mean().item()
-        )
-        self.assertTrue(
-            0.63 < within_1_std < 0.73, f"Values within 1 std: {within_1_std}"
-        )
-
-    @xfailIfPallas("3D implicit randn still hits TPU materialization failure")
-    @skipIfXPU("RNG tests timeout on XPU")
-    def test_randn_3d_tensor(self):
-        """Test 3D randn with tiled operations."""
-
-        @helion.kernel(static_shapes=True, autotune_effort="none")
-        def randn_kernel_3d(x: torch.Tensor) -> torch.Tensor:
-            output = torch.zeros_like(x)
-            b, m, n = x.shape
-            for tile_b, tile_m, tile_n in hl.tile([b, m, n]):
-                output[tile_b, tile_m, tile_n] = torch.randn_like(
-                    x[tile_b, tile_m, tile_n]
-                )
-            return output
-
-        x = torch.ones(8, 32, 64, device=DEVICE)  # 3D tensor
-        torch.manual_seed(77)
-        _code, output = code_and_output(
-            randn_kernel_3d, (x,), block_sizes=_rng_3d_block_sizes()
-        )
-
-        # Check overall distribution
-        output_cpu = output.cpu()
-        mean = output_cpu.mean().item()
-        std = output_cpu.std().item()
-        self.assertTrue(-0.1 < mean < 0.1, f"3D mean {mean} not close to 0")
-        self.assertTrue(0.95 < std < 1.05, f"3D std {std} not close to 1")
-
-        # Check distribution across dimensions
-        for b_idx in range(x.shape[0]):
-            slice_mean = output_cpu[b_idx].mean().item()
-            slice_std = output_cpu[b_idx].std().item()
-            self.assertTrue(
-                -0.3 < slice_mean < 0.3,
-                f"Slice {b_idx} mean {slice_mean} is not well distributed",
-            )
-            self.assertTrue(
-                0.85 < slice_std < 1.15,
-                f"Slice {b_idx} std {slice_std} is not well distributed",
-            )
-
-    def _test_rng_with_dynamic_tile_sizes(self, rng_func, is_uniform, rng_name):
-        """Common test logic for RNG operations with dynamic tile sizes."""
-
-        # Single kernel that takes an RNG callable as a parameter
         @helion.kernel(static_shapes=True, autotune_effort="none")
         def rng_kernel(
             x: torch.Tensor,
-            rng_func: Callable[[int, int, torch.dtype], torch.Tensor],
-        ) -> torch.Tensor:
-            output = torch.zeros_like(x)
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            out_rand = torch.zeros_like(x)
+            out_rand_like = torch.zeros_like(x)
+            out_randn = torch.zeros_like(x)
+            out_randn_like = torch.zeros_like(x)
             m, n = x.shape
             for tile_m, tile_n in hl.tile([m, n]):
-                output[tile_m, tile_n] = rng_func(tile_m, tile_n, x.dtype)
-            return output
+                out_rand[tile_m, tile_n] = torch.rand(
+                    (tile_m, tile_n), dtype=x.dtype, device=x.device
+                )
+                out_rand_like[tile_m, tile_n] = torch.rand_like(
+                    torch.ones((tile_m, tile_n), dtype=x.dtype, device=x.device)
+                )
+                out_randn[tile_m, tile_n] = torch.randn(
+                    (tile_m, tile_n), dtype=x.dtype, device=x.device
+                )
+                out_randn_like[tile_m, tile_n] = torch.randn_like(
+                    torch.ones((tile_m, tile_n), dtype=x.dtype, device=x.device)
+                )
+            return out_rand, out_rand_like, out_randn, out_randn_like
 
+        names = ("rand", "rand_like", "randn", "randn_like")
         x = torch.ones(48, 48, device=DEVICE)
         torch.manual_seed(42)
         block_sizes = _rng_2d_block_sizes()
-        compiled = _compile_only(rng_kernel, (x, rng_func), block_sizes=block_sizes)
-        output = compiled(x, rng_func)
+        compiled = _compile_only(rng_kernel, (x,), block_sizes=block_sizes)
+        outputs = compiled(x)
 
-        # Check distribution properties based on RNG type
-        if is_uniform:
-            # For rand: values in [0, 1), mean ~0.5
+        # For rand variants: values in [0, 1), mean ~0.5
+        for rng_name, output in zip(names[:2], outputs[:2], strict=True):
             self.assertTrue(
                 torch.all(output >= 0.0), f"{rng_name}: All values should be >= 0"
             )
@@ -689,8 +521,9 @@ class TestRNG(RefEagerTestBase, TestCase):
                 0.4 < mean_val < 0.6,
                 f"{rng_name}: Mean {mean_val:.3f} should be ~0.5",
             )
-        else:
-            # For randn: mean ~0, std ~1
+
+        # For randn variants: mean ~0, std ~1
+        for rng_name, output in zip(names[2:], outputs[2:], strict=True):
             mean_val = output.mean().item()
             std_val = output.cpu().std().item()
             self.assertTrue(
@@ -702,76 +535,22 @@ class TestRNG(RefEagerTestBase, TestCase):
 
         # Test reproducibility with same seed
         torch.manual_seed(42)
-        output2 = compiled(x, rng_func)
-        torch.testing.assert_close(
-            output,
-            output2,
-            msg=f"{rng_name}: Same seed should produce identical outputs",
-        )
+        outputs2 = compiled(x)
+        for rng_name, output, output2 in zip(names, outputs, outputs2, strict=True):
+            torch.testing.assert_close(
+                output,
+                output2,
+                msg=f"{rng_name}: Same seed should produce identical outputs",
+            )
 
         # Test that different seeds produce different outputs
         torch.manual_seed(99)
-        output3 = compiled(x, rng_func)
-        self.assertFalse(
-            torch.allclose(output, output3),
-            f"{rng_name}: Different seeds should produce different outputs",
-        )
-
-    @xfailIfPallas(
-        "dynamic-shape implicit rand hits TPU deferred buffer materialization"
-    )
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_rand_with_dynamic_tile_sizes(self):
-        """Test torch.rand with dynamic tile dimensions."""
-        self._test_rng_with_dynamic_tile_sizes(
-            rng_func=lambda tile_m, tile_n, dtype: torch.rand(
-                (tile_m, tile_n), dtype=dtype, device=DEVICE
-            ),
-            is_uniform=True,
-            rng_name="rand",
-        )
-
-    @xfailIfPallas(
-        "dynamic-shape implicit rand_like hits TPU deferred buffer materialization"
-    )
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_rand_like_with_dynamic_tile_sizes(self):
-        """Test torch.rand_like with dynamic tile dimensions."""
-        self._test_rng_with_dynamic_tile_sizes(
-            rng_func=lambda tile_m, tile_n, dtype: torch.rand_like(
-                torch.ones((tile_m, tile_n), dtype=dtype, device=DEVICE)
-            ),
-            is_uniform=True,
-            rng_name="rand_like",
-        )
-
-    @xfailIfPallas(
-        "dynamic-shape implicit randn hits TPU deferred buffer materialization"
-    )
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_randn_with_dynamic_tile_sizes(self):
-        """Test torch.randn with dynamic tile dimensions."""
-        self._test_rng_with_dynamic_tile_sizes(
-            rng_func=lambda tile_m, tile_n, dtype: torch.randn(
-                (tile_m, tile_n), dtype=dtype, device=DEVICE
-            ),
-            is_uniform=False,
-            rng_name="randn",
-        )
-
-    @xfailIfPallas(
-        "dynamic-shape implicit randn_like hits TPU deferred buffer materialization"
-    )
-    @skipIfRefEager("compile_config is not supported in ref eager mode")
-    def test_randn_like_with_dynamic_tile_sizes(self):
-        """Test torch.randn_like with dynamic tile dimensions."""
-        self._test_rng_with_dynamic_tile_sizes(
-            rng_func=lambda tile_m, tile_n, dtype: torch.randn_like(
-                torch.ones((tile_m, tile_n), dtype=dtype, device=DEVICE)
-            ),
-            is_uniform=False,
-            rng_name="randn_like",
-        )
+        outputs3 = compiled(x)
+        for rng_name, output, output3 in zip(names, outputs, outputs3, strict=True):
+            self.assertFalse(
+                torch.allclose(output, output3),
+                f"{rng_name}: Different seeds should produce different outputs",
+            )
 
     @skipIfRefEager(
         "compiled implicit RNG validation is not applicable in ref eager mode"
@@ -878,7 +657,7 @@ class TestRNG(RefEagerTestBase, TestCase):
     def test_rand_like_with_specialized_dimension(self):
         """Test torch.rand_like with specialized (constant) dimensions."""
 
-        @helion.kernel(config=helion.Config(block_sizes=[64, 128]))
+        @helion.kernel(config=helion.Config(block_sizes=[32, 64]))
         def matmul_with_rand(
             x: torch.Tensor,
             y: torch.Tensor,
@@ -906,7 +685,7 @@ class TestRNG(RefEagerTestBase, TestCase):
                 out[tile_m, :] = acc.to(out.dtype)
             return out
 
-        m, k, n = 256, 512, 64
+        m, k, n = 128, 256, 64
         x = torch.randn(m, k, device=DEVICE, dtype=HALF_DTYPE)
         y = torch.randn(k, n, device=DEVICE, dtype=HALF_DTYPE)
 
@@ -990,16 +769,17 @@ class TestRNG(RefEagerTestBase, TestCase):
 @onlyBackends(["triton", "cute"])
 @skipIfRefEager("compiled RNG parity checks are not applicable in ref eager mode")
 class TestRNGBitParity(TestCase):
-    def test_run_ref_matches_compiled_for_multiple_implicit_rng_callsites(self):
+    def test_implicit_rng_callsites_match_triton_and_ref(self):
         def implicit_rng_impl(x: torch.Tensor) -> torch.Tensor:
-            out = torch.zeros((2, *x.shape), device=x.device, dtype=x.dtype)
+            out = torch.zeros((3, *x.shape), device=x.device, dtype=x.dtype)
             m, n = x.shape
             for tile_m, tile_n in hl.tile([m, n]):
                 tile = x[tile_m, tile_n]
                 out[0, tile_m, tile_n] = torch.rand(
                     (tile_m, tile_n), device=x.device, dtype=x.dtype
                 )
-                out[1, tile_m, tile_n] = torch.randn_like(tile)
+                out[1, tile_m, tile_n] = torch.rand_like(tile)
+                out[2, tile_m, tile_n] = torch.randn_like(tile)
             return out
 
         compiled_kernel = helion.kernel(
@@ -1013,81 +793,74 @@ class TestRNGBitParity(TestCase):
         )(implicit_rng_impl)
 
         x = torch.ones(17, 19, device=DEVICE)
-        compiled_bound = compiled_kernel.bind((x,))
-        ref_bound = ref_kernel.bind((x,))
-        config = Config(block_sizes=[8, 16])
+        torch.manual_seed(987)
+        seeds = inductor_prims.seeds(3, torch.accelerator.current_accelerator())
+        seed0 = int(seeds[0].item())
+        seed1 = int(seeds[1].item())
+        seed2 = int(seeds[2].item())
+        torch.manual_seed(987)
+        _code, out = code_and_output(compiled_kernel, (x,), block_sizes=[8, 16])
+        offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
+        expected0 = _triton_rand_reference(seed0, offsets).reshape_as(x)
+        expected1 = _triton_rand_reference(seed1, offsets).reshape_as(x)
+        _assert_bitwise_equal_float(self, out[0], expected0)
+        _assert_bitwise_equal_float(self, out[1], expected1)
+        self.assertFalse(torch.equal(out[0].cpu(), out[1].cpu()))
+        expected2 = _triton_randn_reference(seed2, offsets).reshape_as(x)
+        torch.testing.assert_close(out[2], expected2, rtol=1e-6, atol=1e-6)
 
-        torch.manual_seed(2026)
-        compiled = compiled_bound.compile_config(config)(x)
+        # run_ref should match the compiled kernel given the same torch seed
+        torch.manual_seed(987)
+        ref = ref_kernel(x)
+        _assert_bitwise_equal_float(self, out[0], ref[0])
+        _assert_bitwise_equal_float(self, out[1], ref[1])
+        torch.testing.assert_close(out[2], ref[2], rtol=1e-6, atol=1e-6)
 
-        torch.manual_seed(2026)
-        ref = ref_bound.run_ref(x)
-
-        _assert_bitwise_equal_float(self, compiled[0], ref[0])
-        torch.testing.assert_close(compiled[1], ref[1], rtol=1e-6, atol=1e-6)
-
-    def test_rand_nested_tl_range_loops_match_philox(self):
+    def test_rand_nested_and_multi_axis_loops_match_philox(self):
         @helion.kernel(static_shapes=True, autotune_effort="none")
-        def nested_rand_kernel(x: torch.Tensor) -> torch.Tensor:
-            out = torch.zeros_like(x)
+        def nested_rand_kernel(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            out0 = torch.zeros_like(x)
+            out1 = torch.zeros_like(x)
             b, m, n = x.shape
             for tile_b in hl.tile(b):
                 for tile_m in hl.tile(m):
                     for tile_n in hl.tile(n):
-                        noise = torch.rand(
+                        noise0 = torch.rand(
                             (tile_b, tile_m), device=x.device, dtype=x.dtype
                         )
-                        out[tile_b, tile_m, tile_n] = noise[:, :, None].expand(
+                        out0[tile_b, tile_m, tile_n] = noise0[:, :, None].expand(
                             tile_b, tile_m, tile_n
                         )
-            return out
-
-        x = torch.ones(3, 7, 9, device=DEVICE)
-        torch.manual_seed(901)
-        seed = int(
-            inductor_prims.seeds(1, torch.accelerator.current_accelerator())[0].item()
-        )
-        torch.manual_seed(901)
-        code, out = code_and_output(nested_rand_kernel, (x,), block_sizes=[2, 4, 8])
-        expected = _nested_broadcast_rand_expected_3d(
-            (3, 7, 9),
-            (2, 4, 8),
-            seed,
-            device=DEVICE,
-            dtype=x.dtype,
-        )
-        _assert_bitwise_equal_float(self, out, expected)
-        if _get_backend() == "triton":
-            self.assertTrue("tl.range" in code or "tl.static_range" in code)
-
-    def test_rand_multi_axis_loop_offsets_match_philox(self):
-        @helion.kernel(static_shapes=True, autotune_effort="none")
-        def tiled_rand_kernel(x: torch.Tensor) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            b, m, n = x.shape
             for tile_b in hl.tile(b):
                 for tile_m, tile_n in hl.tile([m, n]):
-                    noise = torch.rand((tile_b, tile_m), device=x.device, dtype=x.dtype)
-                    out[tile_b, tile_m, tile_n] = noise[:, :, None].expand(
+                    noise1 = torch.rand(
+                        (tile_b, tile_m), device=x.device, dtype=x.dtype
+                    )
+                    out1[tile_b, tile_m, tile_n] = noise1[:, :, None].expand(
                         tile_b, tile_m, tile_n
                     )
-            return out
+            return out0, out1
 
         x = torch.ones(3, 7, 9, device=DEVICE)
-        torch.manual_seed(902)
-        seed = int(
-            inductor_prims.seeds(1, torch.accelerator.current_accelerator())[0].item()
+        torch.manual_seed(901)
+        seeds = inductor_prims.seeds(2, torch.accelerator.current_accelerator())
+        seed0 = int(seeds[0].item())
+        seed1 = int(seeds[1].item())
+        torch.manual_seed(901)
+        code, (out0, out1) = code_and_output(
+            nested_rand_kernel, (x,), block_sizes=[2, 4, 8, 2, 4, 8]
         )
-        torch.manual_seed(902)
-        _code, out = code_and_output(tiled_rand_kernel, (x,), block_sizes=[2, 4, 8])
-        expected = _nested_broadcast_rand_expected_3d(
-            (3, 7, 9),
-            (2, 4, 8),
-            seed,
-            device=DEVICE,
-            dtype=x.dtype,
-        )
-        _assert_bitwise_equal_float(self, out, expected)
+        for seed, out in ((seed0, out0), (seed1, out1)):
+            expected = _nested_broadcast_rand_expected_3d(
+                (3, 7, 9),
+                (2, 4, 8),
+                seed,
+                device=DEVICE,
+                dtype=x.dtype,
+            )
+            _assert_bitwise_equal_float(self, out, expected)
+        if _get_backend() == "triton":
+            self.assertTrue("tl.range" in code or "tl.static_range" in code)
 
     def test_rand_like_nested_loops_matches_philox(self):
         @helion.kernel(static_shapes=True, autotune_effort="none")
@@ -1138,10 +911,16 @@ class TestRNGBitParity(TestCase):
     def test_rand_with_literal_non_power_of_two_dim_matches_philox(self):
         @helion.kernel(static_shapes=True, autotune_effort="none")
         def literal_dim_rand_kernel(x: torch.Tensor) -> torch.Tensor:
-            out = torch.zeros_like(x)
+            out = torch.zeros((2, *x.shape), device=x.device, dtype=x.dtype)
             (m, _) = x.shape
             for tile_m in hl.tile(m):
-                out[tile_m, :] = torch.rand(
+                # Store rand directly (no intermediate op) and via an intermediate add
+                out[0, tile_m, :] = torch.rand(
+                    (tile_m, 3),
+                    device=x.device,
+                    dtype=x.dtype,
+                )
+                out[1, tile_m, :] = torch.rand(
                     (tile_m, 3),
                     device=x.device,
                     dtype=x.dtype,
@@ -1150,112 +929,16 @@ class TestRNGBitParity(TestCase):
 
         x = torch.ones(13, 3, device=DEVICE)
         torch.manual_seed(314)
-        seed = int(
-            inductor_prims.seeds(1, torch.accelerator.current_accelerator())[0].item()
-        )
-        torch.manual_seed(314)
-        _code, out = code_and_output(literal_dim_rand_kernel, (x,), block_sizes=[8])
-        expected = (
-            philox_rand_ref(
-                seed,
-                torch.arange(out.numel(), device=DEVICE, dtype=torch.int64),
-            ).reshape_as(out)
-            + 1.0
-        )
-        torch.testing.assert_close(out, expected, rtol=0.0, atol=2e-7)
-
-    def test_rand_with_literal_non_power_of_two_dim_no_intermediate_matches_philox(
-        self,
-    ):
-        @helion.kernel(static_shapes=True, autotune_effort="none")
-        def literal_dim_rand_kernel(x: torch.Tensor) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            (m, _) = x.shape
-            for tile_m in hl.tile(m):
-                out[tile_m, :] = torch.rand(
-                    (tile_m, 3),
-                    device=x.device,
-                    dtype=x.dtype,
-                )
-            return out
-
-        x = torch.ones(13, 3, device=DEVICE)
-        torch.manual_seed(2718)
-        seed = int(
-            inductor_prims.seeds(1, torch.accelerator.current_accelerator())[0].item()
-        )
-        torch.manual_seed(2718)
-        _code, out = code_and_output(literal_dim_rand_kernel, (x,), block_sizes=[8])
-        expected = philox_rand_ref(
-            seed,
-            torch.arange(out.numel(), device=DEVICE, dtype=torch.int64),
-        ).reshape_as(out)
-        _assert_bitwise_equal_float(self, out, expected)
-
-    def test_rand_like_matches_triton_philox(self):
-        @helion.kernel(static_shapes=True, autotune_effort="none")
-        def rand_like_kernel(x: torch.Tensor) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_m, tile_n in hl.tile([m, n]):
-                out[tile_m, tile_n] = torch.rand_like(x[tile_m, tile_n])
-            return out
-
-        x = torch.ones(17, 19, device=DEVICE)
-        torch.manual_seed(123)
-        seed = int(
-            inductor_prims.seeds(1, torch.accelerator.current_accelerator())[0].item()
-        )
-        torch.manual_seed(123)
-        _code, out = code_and_output(rand_like_kernel, (x,), block_sizes=[8, 16])
-        offsets = torch.arange(out.numel(), device=DEVICE, dtype=torch.int64)
-        expected = _triton_rand_reference(seed, offsets).reshape_as(out)
-        _assert_bitwise_equal_float(self, out, expected)
-
-    def test_rand_like_multiple_calls_match_triton_reference(self):
-        @helion.kernel(static_shapes=True, autotune_effort="none")
-        def rand_like_twice_kernel(x: torch.Tensor) -> torch.Tensor:
-            out = torch.zeros((2, *x.shape), device=x.device, dtype=x.dtype)
-            m, n = x.shape
-            for tile_m, tile_n in hl.tile([m, n]):
-                tile = x[tile_m, tile_n]
-                out[0, tile_m, tile_n] = torch.rand_like(tile)
-                out[1, tile_m, tile_n] = torch.rand_like(tile)
-            return out
-
-        x = torch.ones(17, 19, device=DEVICE)
-        torch.manual_seed(987)
         seeds = inductor_prims.seeds(2, torch.accelerator.current_accelerator())
         seed0 = int(seeds[0].item())
         seed1 = int(seeds[1].item())
-        torch.manual_seed(987)
-        _code, out = code_and_output(rand_like_twice_kernel, (x,), block_sizes=[8, 16])
+        torch.manual_seed(314)
+        _code, out = code_and_output(literal_dim_rand_kernel, (x,), block_sizes=[8])
         offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
-        expected0 = _triton_rand_reference(seed0, offsets).reshape_as(x)
-        expected1 = _triton_rand_reference(seed1, offsets).reshape_as(x)
+        expected0 = philox_rand_ref(seed0, offsets).reshape_as(x)
         _assert_bitwise_equal_float(self, out[0], expected0)
-        _assert_bitwise_equal_float(self, out[1], expected1)
-        self.assertFalse(torch.equal(out[0].cpu(), out[1].cpu()))
-
-    def test_randn_like_matches_triton_philox(self):
-        @helion.kernel(static_shapes=True, autotune_effort="none")
-        def randn_like_kernel(x: torch.Tensor) -> torch.Tensor:
-            out = torch.zeros_like(x)
-            m, n = x.shape
-            for tile_m, tile_n in hl.tile([m, n]):
-                out[tile_m, tile_n] = torch.randn_like(x[tile_m, tile_n])
-            return out
-
-        x = torch.ones(13, 29, device=DEVICE)
-        torch.manual_seed(321)
-        seed = int(
-            inductor_prims.seeds(1, torch.accelerator.current_accelerator())[0].item()
-        )
-        torch.manual_seed(321)
-        _code, out = code_and_output(randn_like_kernel, (x,), block_sizes=[8, 16])
-        offsets = torch.arange(out.numel(), device=DEVICE, dtype=torch.int64)
-        expected = _triton_randn_reference(seed, offsets).reshape_as(out)
-        torch.testing.assert_close(out, expected, rtol=1e-6, atol=1e-6)
+        expected1 = philox_rand_ref(seed1, offsets).reshape_as(x) + 1.0
+        torch.testing.assert_close(out[1], expected1, rtol=0.0, atol=2e-7)
 
 
 class TestPallasRNGRegression(TestCase):
@@ -1295,89 +978,46 @@ class TestPallasRNGRegression(TestCase):
 )
 @skipIfRefEager("compiled backend parity checks are not applicable in ref eager mode")
 class TestRNGBackendParity(TestCase):
-    def test_triton_and_cute_match_explicit_seeded_rand(self):
-        @helion.kernel(backend="triton", static_shapes=False, autotune_effort="none")
-        def rand_kernel_triton(
+    def test_triton_and_cute_match_explicit_seeded_rand_and_randint(self):
+        def rng_impl(
             x: torch.Tensor, seed: int
-        ) -> tuple[torch.Tensor, torch.Tensor]:
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
             m, n = x.shape
             out0 = torch.zeros_like(x)
             out1 = torch.zeros_like(x)
+            int0 = torch.zeros((m, n), dtype=torch.int32, device=x.device)
+            int1 = torch.zeros((m, n), dtype=torch.int32, device=x.device)
             for tile_m, tile_n in hl.tile([m, n]):
                 out0[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
+                int0[tile_m, tile_n] = hl.randint(
+                    [tile_m, tile_n], low=-3, high=29, seed=seed
+                )
             for tile_m, tile_n in hl.tile([m, n]):
                 out1[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
-            return out0, out1
+                int1[tile_m, tile_n] = hl.randint(
+                    [tile_m, tile_n], low=-3, high=29, seed=seed
+                )
+            return out0, out1, int0, int1
 
-        @helion.kernel(backend="cute", static_shapes=False, autotune_effort="none")
-        def rand_kernel_cute(
-            x: torch.Tensor, seed: int
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, n = x.shape
-            out0 = torch.zeros_like(x)
-            out1 = torch.zeros_like(x)
-            for tile_m, tile_n in hl.tile([m, n]):
-                out0[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
-            for tile_m, tile_n in hl.tile([m, n]):
-                out1[tile_m, tile_n] = hl.rand([tile_m, tile_n], seed=seed)
-            return out0, out1
+        rng_kernel_triton = helion.kernel(
+            backend="triton", static_shapes=False, autotune_effort="none"
+        )(rng_impl)
+        rng_kernel_cute = helion.kernel(
+            backend="cute", static_shapes=False, autotune_effort="none"
+        )(rng_impl)
 
         x = torch.empty((11, 13), device=DEVICE, dtype=torch.float32)
         seed = 4096
-        out_t = _compile_only(rand_kernel_triton, (x, seed), block_sizes=[4, 8, 4, 8])(
+        out_t = _compile_only(rng_kernel_triton, (x, seed), block_sizes=[4, 8, 4, 8])(
             x, seed
         )
-        out_c = _compile_only(rand_kernel_cute, (x, seed), block_sizes=[4, 8, 4, 8])(
+        out_c = _compile_only(rng_kernel_cute, (x, seed), block_sizes=[4, 8, 4, 8])(
             x, seed
         )
         _assert_bitwise_equal_float(self, out_t[0], out_c[0])
         _assert_bitwise_equal_float(self, out_t[1], out_c[1])
-
-    def test_triton_and_cute_match_explicit_seeded_randint(self):
-        @helion.kernel(backend="triton", static_shapes=False, autotune_effort="none")
-        def randint_kernel_triton(
-            x: torch.Tensor, seed: int
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, n = x.shape
-            out0 = torch.zeros_like(x)
-            out1 = torch.zeros_like(x)
-            for tile_m, tile_n in hl.tile([m, n]):
-                out0[tile_m, tile_n] = hl.randint(
-                    [tile_m, tile_n], low=-3, high=29, seed=seed
-                )
-            for tile_m, tile_n in hl.tile([m, n]):
-                out1[tile_m, tile_n] = hl.randint(
-                    [tile_m, tile_n], low=-3, high=29, seed=seed
-                )
-            return out0, out1
-
-        @helion.kernel(backend="cute", static_shapes=False, autotune_effort="none")
-        def randint_kernel_cute(
-            x: torch.Tensor, seed: int
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            m, n = x.shape
-            out0 = torch.zeros_like(x)
-            out1 = torch.zeros_like(x)
-            for tile_m, tile_n in hl.tile([m, n]):
-                out0[tile_m, tile_n] = hl.randint(
-                    [tile_m, tile_n], low=-3, high=29, seed=seed
-                )
-            for tile_m, tile_n in hl.tile([m, n]):
-                out1[tile_m, tile_n] = hl.randint(
-                    [tile_m, tile_n], low=-3, high=29, seed=seed
-                )
-            return out0, out1
-
-        x = torch.empty((9, 15), device=DEVICE, dtype=torch.int32)
-        seed = 5150
-        out_t = _compile_only(
-            randint_kernel_triton, (x, seed), block_sizes=[4, 8, 4, 8]
-        )(x, seed)
-        out_c = _compile_only(randint_kernel_cute, (x, seed), block_sizes=[4, 8, 4, 8])(
-            x, seed
-        )
-        self.assertTrue(torch.equal(out_t[0].cpu(), out_c[0].cpu()))
-        self.assertTrue(torch.equal(out_t[1].cpu(), out_c[1].cpu()))
+        self.assertTrue(torch.equal(out_t[2].cpu(), out_c[2].cpu()))
+        self.assertTrue(torch.equal(out_t[3].cpu(), out_c[3].cpu()))
 
     def test_triton_and_cute_match_raw_aten_rand_and_randn(self):
         @helion.kernel(backend="triton", static_shapes=False, autotune_effort="none")

--- a/test/test_torch_compile.py
+++ b/test/test_torch_compile.py
@@ -541,13 +541,14 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
         expected_num_compilations: list[int] | None = None,
         kernels_ref: list | None = None,
         expected_num_kernels_ref: int | None = None,
+        ref_on_fusion_leg: bool = False,
     ):
         """Run torch.compile test comparing eager vs compiled execution."""
+        # The upgrade-error path for fusion on unsupported builds is covered
+        # once by test_fusion_unsupported_raises_upgrade_error; skip the many
+        # parametrized fusion legs that would otherwise all re-check it.
         if allow_torch_compile_fusion and not supports_torch_compile_fusion():
-            expected_error = (
-                RuntimeError,
-                "torch_compile_fusion=True requires PyTorch nightly build",
-            )
+            self.skipTest("torch.compile fusion not supported by this PyTorch build")
 
         # Reset specific kernels and configure fusion setting
         for kernel in kernels:
@@ -616,8 +617,14 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
                 f"Expected {expected_num_kernels} triton kernel(s), got {kernel_count}",
             )
 
-        # Ref baseline kernel count check
-        if expected_num_kernels_ref is not None:
+        # Ref baseline kernel count check. The *_ref baselines are pure torch
+        # (no helion kernels), so this compile is identical on both fusion
+        # legs; check it on only one leg to avoid duplicate compiles. Tests
+        # that skip their fusion=False leg opt in via ref_on_fusion_leg.
+        if (
+            expected_num_kernels_ref is not None
+            and allow_torch_compile_fusion == ref_on_fusion_leg
+        ):
             assert kernels_ref is not None, (
                 "kernels_ref must be provided when expected_num_kernels_ref is set"
             )
@@ -644,6 +651,34 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
                     f"Expected {expected} helion compilation(s) for {kernel}, "
                     f"got {len(kernel._bound_kernels)}",
                 )
+
+    @skipIfTileIR("torch.compile missing kernel metadata on tileir")
+    def test_fusion_unsupported_raises_upgrade_error(self):
+        """Fusion requested on a build without fusion support: eager still
+        works, but torch.compile raises the upgrade error at trace time."""
+        if supports_torch_compile_fusion():
+            self.skipTest("this PyTorch build supports torch.compile fusion")
+
+        def f(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return k_add(x, y)
+
+        self.addCleanup(
+            setattr,
+            k_add.settings,
+            "torch_compile_fusion",
+            k_add.settings.torch_compile_fusion,
+        )
+        k_add.settings.torch_compile_fusion = True
+        k_add.reset()
+        torch._dynamo.reset()
+        x = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+        torch.testing.assert_close(f(x, y), x + y)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "torch_compile_fusion=True requires PyTorch nightly build",
+        ):
+            torch.compile(f, fullgraph=True, backend="inductor")(x, y)
 
     @parametrize("allow_torch_compile_fusion", (True, False))
     @skipIfTileIR("torch.compile missing kernel metadata on tileir")
@@ -4606,6 +4641,8 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
             compare_fn=compare,
             kernels_ref=[k_returns_string_ref],
             expected_num_kernels_ref=1,
+            # This test skips its fusion=False leg, so check the ref here.
+            ref_on_fusion_leg=True,
         )
 
     @requires_fusion_support


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3488
 * __->__#3486
 * #3487


--- --- ---

[tests] Speed up the test suite 7x: 37m35s -> 5m22s wall (pytest -n4)

Measured on a B200 devgpu with the same `pytest test -n4` command before
and after: wall 37m35s -> 5m22s, summed per-test time 4724s -> 1198s,
3442 passed / 1658 skipped / 0 failed. The slowest test drops from 165s
to 20s, which also fixes xdist tail latency. ~236 tests were deleted or
merged; every deletion has its coverage traced to a surviving test.

Main changes:

- CuTe flash search-surface tests (test_cute_flash_length_invariance
  2004s -> 78s, test_benchmarking 773s -> 78s, test_autotuner_heuristics
  260s -> 28s): the dominant cost was ConfigGeneration's coverage design
  recomputing cute_flash.flash_autotune_fragments tens of thousands of
  times per instance with only ~16 distinct argument tuples. Tests now
  share warmed ConfigGeneration instances and memoize the fragment
  surface (first repeat of each key is re-verified against the real
  function, so a nondeterministic surface still fails). Duplicate
  parametrized sweeps merged; 9 retention-mirror tests deleted in favor
  of the mirror-vs-live cross-check; all timeout(600) marks removed.

- test_distributed (308s -> ~0s on <4-GPU machines): the 4-GPU guard
  only ran inside the spawned worker processes, so every skip paid ~6s
  of process spawn + torch import. The guard now runs parent-side in
  setUp before _spawn_processes. Kernel x autotuner-algorithm matrix
  trimmed 54 -> 25 (one kernel keeps all algorithms; other kernels keep
  one). LLM-search cases skip when no API key is configured.

- test_autotuner (221s -> 44s): tests asserting logging/seeding/
  filtering no longer spawn the benchmark-worker subprocess (~6-7s
  each); dedicated worker coverage stays in test_benchmark_worker and
  the broadcast/noncontiguous tests. Searches shrunk to 2-5 configs.
  test_chunked_allclose_memory allocates 2**22 elements instead of
  2**26 (1.5GB) with a forced 4-chunk path.

- test_rng + test_random (297s -> 186s): cost is one Triton compile per
  RNG callsite, not tensor size. Tests merged into multi-output kernels
  (67 -> 37 tests) with zero RNG callsites deleted; two statistical
  tolerances tightened.

- test_torch_compile: on PyTorch builds without fusion support the
  fusion=True parametrized legs now skip instead of compiling the same
  non-fused path (~115 tests x 4 compiles on stock-PyTorch CI shards); a
  dedicated test keeps the unsupported-fallback error covered. The _ref
  baseline is compiled on one leg per test instead of both.

- CuTe-shard GPU sizes (verified under HELION_BACKEND=cute): 1M-token
  attention re-anchored just past the registered-policy boundary
  (num_kv 4098); dense 262k persistent-grid test halved while keeping
  multiple work items per CTA; deadlock soak 32 -> 8 iterations; 4096^3
  matmuls -> 2048x2048x1024 with the l2-grouping sweep cut to the 4
  configs with distinct schedules; test_cute_softmax_perf compiles 24
  unique kernels instead of 43 by sharing artifacts; 8192^3 example
  matmuls -> 1024^3 (tiling still exercises 16+ tiles per dim).