### PR TITLE
[compiler] Add cross-loop scheduler

### DIFF
--- a/helion/_compiler/cross_loop_scheduler.py
+++ b/helion/_compiler/cross_loop_scheduler.py
@@ -1,0 +1,2563 @@
+from __future__ import annotations
+
+import dataclasses
+from functools import cached_property
+import itertools
+import operator
+
+import sympy
+
+from .. import exc
+from .tile_dependency import CoordinateDomain
+from .tile_dependency import CoordinateRelation
+from .tile_dependency import DependencyObligation
+from .tile_dependency import TileDependencyGraph
+from .tile_dependency import consumer_to_preceding_site_relation
+from .tile_dependency import coordinate_axis_symbol
+from .tile_dependency import instantiate_symbolic_dependencies
+from .tile_dependency import nested_logical_axes
+
+
+@dataclasses.dataclass(frozen=True)
+class WorkerScheduleSegment:
+    """One symbolic task-family run in a static persistent-worker schedule.
+
+    ``task_order`` maps dense task-order indices to logical tasks.
+    ``dispatch_offset`` places those indices in a linearized range over
+    ``worker_count`` workers::
+
+        dispatch_index = dispatch_offset + task_order_index
+        worker = worker_begin + dispatch_index % worker_count
+        worker_step = dispatch_index // worker_count
+
+    Several segments can describe arbitrary numbers of waves without
+    materializing one schedule entry per runtime task.
+    """
+
+    root: int
+    task_order: CoordinateRelation
+    worker_begin: int
+    worker_count: int
+    dispatch_offset: int
+
+    def __post_init__(self) -> None:
+        if self.root < 0:
+            raise ValueError(f"root must be nonnegative, got {self.root}")
+        if self.worker_begin < 0:
+            raise ValueError(
+                f"worker_begin must be nonnegative, got {self.worker_begin}"
+            )
+        if self.worker_count <= 0:
+            raise ValueError(f"worker_count must be positive, got {self.worker_count}")
+        if self.dispatch_offset < 0:
+            raise ValueError(
+                f"dispatch_offset must be nonnegative, got {self.dispatch_offset}"
+            )
+        if (
+            self.task_order.source_domain.kind != "task_order"
+            or self.task_order.target_domain.kind != "site"
+            or not self.task_order.pieces
+        ):
+            raise ValueError(
+                "symbolic worker schedule relation has incompatible domains"
+            )
+
+    @property
+    def task_count(self) -> int:
+        """Number of dense task-order indices represented by this segment."""
+        return self.task_order.source_domain.size
+
+    def dispatch_index(self, task_order_index: int) -> int:
+        """Return the linearized dispatch index for one ordered task."""
+        if not 0 <= task_order_index < self.task_count:
+            raise IndexError(task_order_index)
+        return self.dispatch_offset + task_order_index
+
+    def occupies(self, worker: int, worker_step: int) -> bool:
+        """Return whether this segment occupies one step on a worker."""
+        worker_offset = worker - self.worker_begin
+        if not 0 <= worker_offset < self.worker_count or worker_step < 0:
+            return False
+        dispatch_index = worker_step * self.worker_count + worker_offset
+        task_order_index = dispatch_index - self.dispatch_offset
+        return 0 <= task_order_index < self.task_count
+
+
+def _flat_domain_index_expression(domain: CoordinateDomain) -> sympy.Expr:
+    """Return the canonical flattened index of a logical coordinate."""
+    result: sympy.Expr = sympy.Integer(0)
+    multiplier = 1
+    for axis in domain.axis_order:
+        result += coordinate_axis_symbol(axis) * multiplier  # pyrefly: ignore[unsupported-operation]
+        multiplier *= domain.axis_counts[axis]
+    return sympy.simplify(result)
+
+
+@dataclasses.dataclass(frozen=True)
+class WorkerSchedule:
+    """Compressed static execution order for all persistent workers."""
+
+    worker_count: int
+    segments: tuple[WorkerScheduleSegment, ...]
+
+    def __post_init__(self) -> None:
+        if self.worker_count <= 0:
+            raise ValueError(f"worker_count must be positive, got {self.worker_count}")
+        for segment in self.segments:
+            if segment.worker_begin + segment.worker_count > self.worker_count:
+                raise ValueError(
+                    "worker schedule segment exceeds the resident worker domain"
+                )
+
+    def root_at(self, worker: int, worker_step: int) -> int | None:
+        """Return the task family occupying one step on a worker."""
+        roots = tuple(
+            segment.root
+            for segment in self.segments
+            if segment.occupies(worker, worker_step)
+        )
+        if len(roots) > 1:
+            raise AssertionError(
+                f"worker {worker} step {worker_step} has multiple tasks"
+            )
+        return roots[0] if roots else None
+
+    def segments_for_root(self, root: int) -> tuple[WorkerScheduleSegment, ...]:
+        """Return the compressed static relation for one task family."""
+        return tuple(segment for segment in self.segments if segment.root == root)
+
+    def workers_for_root(self, root: int) -> frozenset[int]:
+        """Return the compact worker support of one statically placed family."""
+        return frozenset(
+            segment.worker_begin
+            + (segment.dispatch_offset + task_order_index) % segment.worker_count
+            for segment in self.segments_for_root(root)
+            for task_order_index in range(min(segment.task_count, segment.worker_count))
+        )
+
+    def _placement_axes(self) -> tuple[int, int]:
+        maximum = max(
+            (
+                axis
+                for segment in self.segments
+                for domain in (
+                    segment.task_order.source_domain,
+                    segment.task_order.target_domain,
+                )
+                for axis in domain.axis_order
+            ),
+            default=0,
+        )
+        worker_axis = maximum + 1
+        return worker_axis, worker_axis + 1
+
+    @cached_property
+    def placement_domain(self) -> CoordinateDomain:
+        """The worker and worker-step coordinates of static execution."""
+        worker_axis, worker_step_axis = self._placement_axes()
+        maximum_worker_step = max(
+            (
+                segment.dispatch_index(segment.task_count - 1) // segment.worker_count
+                for segment in self.segments
+            ),
+            default=0,
+        )
+        return CoordinateDomain(
+            axis_order=(worker_axis, worker_step_axis),
+            axis_counts_items=(
+                (worker_axis, self.worker_count),
+                (worker_step_axis, maximum_worker_step + 1),
+            ),
+            kind="worker",
+        )
+
+    @cached_property
+    def worker_step_domain(self) -> CoordinateDomain:
+        """The projected worker-step coordinate used for readiness math."""
+        worker_step_axis = self.placement_domain.axis_order[1]
+        return CoordinateDomain(
+            axis_order=(worker_step_axis,),
+            axis_counts_items=(
+                (worker_step_axis, self.placement_domain.axis_counts[worker_step_axis]),
+            ),
+            kind="value",
+        )
+
+    def placement_relation(
+        self,
+        segment: WorkerScheduleSegment,
+    ) -> CoordinateRelation:
+        """Map one segment's task order to workers and worker steps."""
+        relation = segment.task_order
+        task_order_index = _flat_domain_index_expression(relation.source_domain)
+        dispatch_index = segment.dispatch_offset + task_order_index  # pyrefly: ignore[unsupported-operation]
+        worker = segment.worker_begin + sympy.Mod(  # pyrefly: ignore[unsupported-operation]
+            dispatch_index,
+            segment.worker_count,
+        )
+        worker_step = sympy.floor(dispatch_index / segment.worker_count)
+        return CoordinateRelation.point_map(
+            relation.source_domain,
+            self.placement_domain,
+            (  # pyrefly: ignore[bad-argument-type]
+                (
+                    tuple(
+                        (axis, 0, relation.source_domain.axis_counts[axis], 1)
+                        for axis in relation.source_domain.axis_order
+                    ),
+                    (worker, worker_step),
+                ),
+            ),
+        )
+
+    def worker_step_relation(
+        self,
+        segment: WorkerScheduleSegment,
+    ) -> CoordinateRelation | None:
+        """Project one symbolic placement relation to worker step."""
+        return self.placement_relation(segment).project_target(self.worker_step_domain)
+
+    def last_worker_steps_for_root(self, root: int) -> dict[int, int]:
+        """Return each participating worker's final occupied step."""
+        result: dict[int, int] = {}
+        for segment in self.segments_for_root(root):
+            begin = segment.dispatch_offset
+            end = begin + segment.task_count
+            for local_worker in range(segment.worker_count):
+                first = begin + (local_worker - begin) % segment.worker_count
+                if first >= end:
+                    continue
+                last = first + (end - 1 - first) // segment.worker_count * (
+                    segment.worker_count
+                )
+                worker = segment.worker_begin + local_worker
+                result[worker] = max(
+                    result.get(worker, -1),
+                    last // segment.worker_count,
+                )
+        return result
+
+    def worker_step_bounds_for_root(self, root: int) -> tuple[int, int] | None:
+        """Return the first and last occupied worker steps for one root."""
+        segments = self.segments_for_root(root)
+        if not segments:
+            return None
+        worker_steps = tuple(
+            (
+                segment.dispatch_index(0) // segment.worker_count,
+                segment.dispatch_index(segment.task_count - 1) // segment.worker_count,
+            )
+            for segment in segments
+        )
+        return (
+            min(begin for begin, _end in worker_steps),
+            max(end for _begin, end in worker_steps),
+        )
+
+    def dense_assignment(self, root: int) -> tuple[int, int, int, int] | None:
+        """Return one root's dense worker and schedule interval.
+
+        The tuple contains ``worker_begin``, ``worker_count``,
+        ``dispatch_offset``, and ``task_count``.  A root split across different
+        worker ranges or separated schedule intervals is not dense.
+        """
+        segments = sorted(
+            self.segments_for_root(root),
+            key=lambda segment: segment.dispatch_offset,
+        )
+        if not segments:
+            return None
+        worker_begin = segments[0].worker_begin
+        worker_count = segments[0].worker_count
+        dispatch_offset = segments[0].dispatch_offset
+        schedule_end = dispatch_offset
+        for segment in segments:
+            if (
+                segment.worker_begin != worker_begin
+                or segment.worker_count != worker_count
+                or segment.dispatch_offset != schedule_end
+            ):
+                return None
+            schedule_end += segment.task_count
+        return (
+            worker_begin,
+            worker_count,
+            dispatch_offset,
+            schedule_end - dispatch_offset,
+        )
+
+    def contiguous_global_interval(self, root: int) -> tuple[int, int] | None:
+        """Return one dense global schedule interval without task expansion."""
+        assignment = self.dense_assignment(root)
+        if assignment is None:
+            return None
+        worker_begin, worker_count, dispatch_offset, task_count = assignment
+        if worker_begin or worker_count != self.worker_count:
+            return None
+        return dispatch_offset, dispatch_offset + task_count
+
+    def without_roots(self, roots: frozenset[int]) -> WorkerSchedule:
+        """Remove complete locally executed families without task expansion."""
+        if not roots:
+            return self
+        return WorkerSchedule(
+            worker_count=self.worker_count,
+            segments=tuple(
+                segment for segment in self.segments if segment.root not in roots
+            ),
+        )
+
+    def replacing_root(
+        self,
+        root: int,
+        segments: tuple[WorkerScheduleSegment, ...],
+    ) -> WorkerSchedule:
+        """Return a schedule with one task family's placement replaced."""
+        result: list[WorkerScheduleSegment] = []
+        inserted = False
+        for segment in self.segments:
+            if segment.root != root:
+                result.append(segment)
+            elif not inserted:
+                result.extend(segments)
+                inserted = True
+        if not inserted:
+            result.extend(segments)
+        return WorkerSchedule(worker_count=self.worker_count, segments=tuple(result))
+
+
+def build_baseline_worker_schedule(
+    root_domains: tuple[CoordinateDomain, ...],
+    root_task_orders: tuple[CoordinateRelation, ...],
+    worker_count: int,
+) -> WorkerSchedule:
+    """Represent the existing source-ordered persistent task order exactly."""
+    if worker_count <= 0:
+        raise ValueError(f"worker_count must be positive, got {worker_count}")
+    segments: list[WorkerScheduleSegment] = []
+    worker_step_begin = 0
+    if len(root_domains) != len(root_task_orders):
+        raise ValueError("root domains and task orders must have equal length")
+    for root, (domain, task_order) in enumerate(
+        zip(root_domains, root_task_orders, strict=True)
+    ):
+        task_count = domain.size
+        active_workers = min(worker_count, task_count)
+        segments.append(
+            WorkerScheduleSegment(
+                root=root,
+                task_order=task_order,
+                worker_begin=0,
+                worker_count=active_workers,
+                dispatch_offset=worker_step_begin * active_workers,
+            )
+        )
+        worker_step_begin += (task_count + worker_count - 1) // worker_count
+    return WorkerSchedule(worker_count=worker_count, segments=tuple(segments))
+
+
+def _family_placements_at_worker_step(
+    worker_schedule: WorkerSchedule,
+    *,
+    root: int,
+    task_domain: CoordinateDomain,
+    task_order: CoordinateRelation,
+    worker_step: int,
+    unavailable_workers: frozenset[int] = frozenset(),
+) -> tuple[WorkerSchedule, ...]:
+    """Return dense placements for one complete family in free worker runs."""
+    if task_domain.size > worker_schedule.worker_count:
+        return ()
+    # Root bodies are emitted in source order. A modeled placement is therefore
+    # executable only if no earlier root still occupies this worker step or
+    # a later one; codegen cannot move this root ahead of that earlier body.
+    source_order_unavailable_workers = frozenset(
+        worker
+        for preceding_root in range(root)
+        for worker, last_worker_step in worker_schedule.last_worker_steps_for_root(
+            preceding_root
+        ).items()
+        if last_worker_step >= worker_step
+    )
+    free_workers = [
+        worker
+        for worker in range(worker_schedule.worker_count)
+        if worker not in unavailable_workers
+        and worker not in source_order_unavailable_workers
+        and (
+            (occupant_root := worker_schedule.root_at(worker, worker_step)) is None
+            or occupant_root == root
+        )
+    ]
+    result: list[WorkerSchedule] = []
+    run_end = len(free_workers)
+    while run_end:
+        run_begin = run_end - 1
+        while run_begin and free_workers[run_begin - 1] == free_workers[run_begin] - 1:
+            run_begin -= 1
+        if run_end - run_begin >= task_domain.size:
+            worker_begin = free_workers[run_end - task_domain.size]
+            result.append(
+                worker_schedule.replacing_root(
+                    root,
+                    (
+                        WorkerScheduleSegment(
+                            root=root,
+                            task_order=task_order,
+                            worker_begin=worker_begin,
+                            worker_count=task_domain.size,
+                            dispatch_offset=worker_step * task_domain.size,
+                        ),
+                    ),
+                )
+            )
+        run_end = run_begin
+    return tuple(result)
+
+
+def place_ready_families(
+    readiness_graph: ReadinessGraph,
+    original_schedule: WorkerSchedule,
+    worker_schedule: WorkerSchedule,
+    continuations: tuple[FinalArrivalContinuation, ...],
+) -> tuple[WorkerSchedule, tuple[FinalArrivalContinuation, ...]]:
+    """Move complete ready families into idle capacity during a producer tail.
+
+    Final-arrival execution is useful when no separate workers are available.
+    When a complete consumer family fits on workers that are free while some
+    of its static ancestors still have queued work, a direct event wait avoids
+    extending those producer streams.  This is derived from schedule liveness,
+    independent of the roots' operations or graph topology.
+    """
+    result = worker_schedule
+    remaining_continuations = continuations
+    continuation_by_root = _continuations_by_consumer_root(
+        readiness_graph, continuations
+    )
+    candidate_roots = sorted(
+        {
+            readiness_graph.event(continuation.event_id)
+            .consumers[continuation.consumer_index]
+            .consumer_root
+            for continuation in remaining_continuations
+        }
+    )
+    for root in candidate_roots:
+        task_domain = readiness_graph.root_domains[root]
+        if task_domain.size > result.worker_count:
+            continue
+        root_continuations = tuple(
+            continuation
+            for continuation in remaining_continuations
+            if readiness_graph.event(continuation.event_id)
+            .consumers[continuation.consumer_index]
+            .consumer_root
+            == root
+        )
+        if len(root_continuations) != 1:
+            continue
+        continuation = root_continuations[0]
+        continuation_event = readiness_graph.event(continuation.event_id)
+        continuation_consumer = continuation_event.consumers[
+            continuation.consumer_index
+        ]
+        ready_after = _event_ready_after_worker_steps(
+            readiness_graph,
+            continuation_event,
+            worker_schedule=result,
+            continuation_by_root=continuation_by_root,
+        )
+        if ready_after is None:
+            continue
+        ready_after_worker_steps, prerequisite_roots = ready_after
+        consumer_ready_after = continuation_consumer.keys_by_consumer.then(
+            ready_after_worker_steps
+        )
+        readiness_bounds = (
+            None
+            if consumer_ready_after is None
+            else consumer_ready_after.value_bounds()
+        )
+        if readiness_bounds is None:
+            continue
+        prerequisite_worker_steps: set[tuple[int, int]] = set()
+        for prerequisite_root in prerequisite_roots:
+            last_worker_steps = result.last_worker_steps_for_root(prerequisite_root)
+            prerequisite_worker_steps.update(last_worker_steps.items())
+        if not prerequisite_worker_steps:
+            continue
+
+        original_bounds = original_schedule.worker_step_bounds_for_root(root)
+        if original_bounds is None:
+            continue
+        original_worker_step = original_bounds[0]
+        remaining_after_placement = tuple(
+            continuation
+            for continuation in remaining_continuations
+            if continuation not in root_continuations
+        )
+        for worker_step in range(readiness_bounds[0] + 1, original_worker_step):
+            unfinished_workers = frozenset(
+                worker
+                for worker, prerequisite_worker_step in prerequisite_worker_steps
+                if prerequisite_worker_step >= worker_step
+            )
+            if not unfinished_workers:
+                break
+            candidate = next(
+                (
+                    candidate
+                    for candidate in _family_placements_at_worker_step(
+                        result,
+                        root=root,
+                        task_domain=task_domain,
+                        task_order=readiness_graph.root_task_orders[root],
+                        worker_step=worker_step,
+                        unavailable_workers=unfinished_workers,
+                    )
+                ),
+                None,
+            )
+            if candidate is None:
+                continue
+            result = candidate
+            remaining_continuations = remaining_after_placement
+            continuation_by_root.pop(root)
+            break
+    return result, remaining_continuations
+
+
+def build_worker_schedule(
+    readiness_graph: ReadinessGraph,
+    *,
+    worker_count: int,
+) -> tuple[
+    WorkerSchedule,
+    tuple[FinalArrivalContinuation, ...],
+    tuple[ReadinessCounterPlan, ...],
+    ReadinessGraph,
+]:
+    """Derive local and static task placement for one worker count."""
+    baseline = build_baseline_worker_schedule(
+        readiness_graph.root_domains,
+        readiness_graph.root_task_orders,
+        worker_count,
+    )
+    nested_wait_roots = frozenset(
+        readiness_consumer.consumer_root
+        for event in readiness_graph.events
+        for readiness_consumer in event.consumers
+        if readiness_consumer.consumer_site_id is not None
+    )
+    continuations = choose_final_arrival_continuations(
+        readiness_graph,
+        baseline,
+        excluded_roots=nested_wait_roots,
+    )
+    ordered = order_continuation_producers_by_readiness_key(
+        readiness_graph,
+        baseline,
+        continuations,
+    )
+    continuations = choose_final_arrival_continuations(
+        readiness_graph,
+        ordered,
+        excluded_roots=nested_wait_roots,
+    )
+    continuation_roots = frozenset(
+        readiness_consumer.consumer_root
+        for continuation in continuations
+        for readiness_consumer in (
+            readiness_graph.event(continuation.event_id).consumers[
+                continuation.consumer_index
+            ],
+        )
+    )
+    schedule = ordered.without_roots(continuation_roots)
+    schedule, nested_loop_counters = place_nested_loop_consumers(
+        readiness_graph,
+        schedule,
+        continuations,
+    )
+    nested_obligations = frozenset(
+        obligation
+        for counter in nested_loop_counters
+        for readiness_consumer in counter.consumers
+        for obligation in readiness_consumer.covered_obligations
+    )
+    scheduled_readiness_graph = _without_root_consumers_for_obligations(
+        readiness_graph, nested_obligations
+    )
+    schedule, continuations = place_ready_families(
+        scheduled_readiness_graph,
+        ordered,
+        schedule,
+        continuations,
+    )
+    return schedule, continuations, nested_loop_counters, scheduled_readiness_graph
+
+
+@dataclasses.dataclass(frozen=True)
+class FinalArrivalContinuation:
+    """A consumer task executed by whichever producer makes the final arrival."""
+
+    event_id: int
+    consumer_index: int
+
+
+def _continuations_by_consumer_root(
+    readiness_graph: ReadinessGraph,
+    continuations: tuple[FinalArrivalContinuation, ...],
+) -> dict[int, FinalArrivalContinuation]:
+    """Index final-arrival continuations by their consumer root."""
+    return {
+        readiness_graph.event(continuation.event_id)
+        .consumers[continuation.consumer_index]
+        .consumer_root: continuation
+        for continuation in continuations
+    }
+
+
+@dataclasses.dataclass(frozen=True)
+class ReadinessProducer:
+    """One producer execution site's requirements for a readiness event."""
+
+    producer_root: int
+    producers_by_key: CoordinateRelation
+    producer_site_id: int | None = None
+
+    @cached_property
+    def _publication_and_arrival_count_relations(
+        self,
+    ) -> tuple[CoordinateRelation | None, CoordinateRelation | None]:
+        """Derive publication and arrival counts from one target-set proof."""
+        return self.producers_by_key.derive_converse_and_target_counts()
+
+    @property
+    def keys_by_producer(self) -> CoordinateRelation | None:
+        """Return the derived publication relation, when representable."""
+        return self._publication_and_arrival_count_relations[0]
+
+    @property
+    def arrival_count_by_key(self) -> CoordinateRelation | None:
+        """Return the exact symbolic number of arrivals per readiness key."""
+        return self._publication_and_arrival_count_relations[1]
+
+
+def _uniform_arrival_count(
+    producers: tuple[ReadinessProducer, ...],
+) -> int | None:
+    """Return one constant arrival count for an event, when it has one."""
+    total = 0
+    for readiness_producer in producers:
+        cardinality = readiness_producer.arrival_count_by_key
+        count = None if cardinality is None else cardinality.constant_value()
+        if count is None:
+            return None
+        total += count
+    return total
+
+
+@dataclasses.dataclass(frozen=True)
+class ReadinessConsumer:
+    """A consumer execution site's symbolic requirements from one event."""
+
+    consumer_root: int
+    keys_by_consumer: CoordinateRelation
+    covered_obligations: frozenset[DependencyObligation] = frozenset()
+    consumer_site_id: int | None = None
+
+
+def _readiness_key_domain(
+    producers: tuple[ReadinessProducer, ...],
+    consumers: tuple[ReadinessConsumer, ...],
+) -> CoordinateDomain:
+    """Validate and return the shared readiness-key domain of one event."""
+    if not producers:
+        raise ValueError("an event requires at least one producer")
+    readiness_key_domain = producers[0].producers_by_key.source_domain
+    if any(
+        readiness_producer.producers_by_key.source_domain != readiness_key_domain
+        for readiness_producer in producers[1:]
+    ) or any(
+        readiness_consumer.keys_by_consumer.target_domain != readiness_key_domain
+        for readiness_consumer in consumers
+    ):
+        raise ValueError("event relations must share one readiness-key domain")
+    return readiness_key_domain
+
+
+@dataclasses.dataclass(frozen=True)
+class ReadinessEvent:
+    """One symbolic readiness event shared by scheduling and lowering."""
+
+    producers: tuple[ReadinessProducer, ...]
+    consumers: tuple[ReadinessConsumer, ...]
+
+    def __post_init__(self) -> None:
+        readiness_key_domain = _readiness_key_domain(self.producers, self.consumers)
+        if readiness_key_domain.kind != "event":
+            raise ValueError("readiness-key domain must have event kind")
+        if readiness_key_domain.identity is None or readiness_key_domain.identity < 0:
+            raise ValueError("readiness-key domain must have a nonnegative identity")
+        if readiness_key_domain.axis_order != tuple(
+            range(len(readiness_key_domain.axis_order))
+        ):
+            raise ValueError("readiness-key axes must use canonical local indices")
+        if readiness_key_domain.block_sizes_items:
+            raise ValueError("readiness-key domains must not inherit site block sizes")
+
+    @property
+    def readiness_key_domain(self) -> CoordinateDomain:
+        """Return the readiness-key domain owned by every event relation."""
+        return self.producers[0].producers_by_key.source_domain
+
+    @property
+    def event_id(self) -> int:
+        """Return the event identity owned by its readiness-key domain."""
+        identity = self.readiness_key_domain.identity
+        assert identity is not None
+        return identity
+
+    @property
+    def readiness_key_count(self) -> int:
+        return self.readiness_key_domain.size
+
+    @property
+    def root_barrier_producer_root(self) -> int | None:
+        if (
+            self.readiness_key_count == 1
+            and len(self.producers) == 1
+            and self.producers[0].producer_site_id is None
+            and self.producers[0].producers_by_key.is_total()
+        ):
+            return self.producers[0].producer_root
+        return None
+
+
+@dataclasses.dataclass(frozen=True)
+class ReadinessGraph:
+    """Configured symbolic readiness DAG and root task orders."""
+
+    root_task_orders: tuple[CoordinateRelation, ...]
+    events: tuple[ReadinessEvent, ...]
+
+    def __post_init__(self) -> None:
+        for task_order in self.root_task_orders:
+            if (
+                task_order.source_domain.size != task_order.target_domain.size
+                or task_order.source_domain.kind != "task_order"
+                or task_order.target_domain.kind != "site"
+                or not task_order.pieces
+            ):
+                raise ValueError(
+                    "each root task order must have compatible typed domains"
+                )
+        if tuple(event.event_id for event in self.events) != tuple(
+            range(len(self.events))
+        ):
+            raise ValueError("event IDs must be dense and source ordered")
+
+    @property
+    def root_domains(self) -> tuple[CoordinateDomain, ...]:
+        """Return the task domains owned by the configured root task orders."""
+        return tuple(task_order.target_domain for task_order in self.root_task_orders)
+
+    def event(self, event_id: int) -> ReadinessEvent:
+        return self.events[event_id]
+
+
+def _supports_readiness_counter_lowering(
+    readiness_producer: ReadinessProducer,
+) -> bool:
+    """Keep scheduler eligibility identical to counted-event code generation."""
+    publication = readiness_producer.keys_by_producer
+    return (
+        readiness_producer.arrival_count_by_key is not None
+        and publication is not None
+        and publication.canonical_single_valued() is not None
+    )
+
+
+def _canonical_readiness_key_domain(domain: CoordinateDomain) -> CoordinateDomain:
+    """Name quotient coordinates locally rather than borrowing site axes."""
+    if domain.kind != "event" or domain.identity is not None:
+        raise AssertionError("event quotient domain must be unidentified")
+    return CoordinateDomain(
+        axis_order=tuple(range(len(domain.axis_order))),
+        axis_counts_items=tuple(
+            (event_axis, count)
+            for event_axis, (_site_axis, count) in enumerate(domain.axis_counts_items)
+        ),
+        kind="event",
+    )
+
+
+def _record_readiness_event(
+    pending: dict[
+        tuple[CoordinateDomain, tuple[ReadinessProducer, ...]],
+        ReadinessEvent,
+    ],
+    *,
+    readiness_key_domain: CoordinateDomain,
+    producers: tuple[ReadinessProducer, ...],
+    consumers: tuple[ReadinessConsumer, ...],
+    require_counter_lowering: bool = False,
+) -> bool:
+    """Canonicalize and group one semantic event by producer partition.
+
+    Counter-lowering admission runs only after the final event identity is
+    assigned, so later scheduling phases reuse the same relation proofs.
+    """
+    if _readiness_key_domain(producers, consumers) != readiness_key_domain:
+        raise AssertionError("event relations do not share their quotient domain")
+    canonical_domain = _canonical_readiness_key_domain(readiness_key_domain)
+    canonical_producers: list[ReadinessProducer] = []
+    for readiness_producer in producers:
+        producers_by_key = readiness_producer.producers_by_key.rename_source_axes(
+            canonical_domain
+        )
+        if producers_by_key is None:
+            raise AssertionError("event relation does not match its quotient geometry")
+        canonical_producers.append(
+            dataclasses.replace(
+                readiness_producer,
+                producers_by_key=producers_by_key,
+            )
+        )
+    canonical_consumers: list[ReadinessConsumer] = []
+    for readiness_consumer in consumers:
+        keys_by_consumer = readiness_consumer.keys_by_consumer.rename_target_axes(
+            canonical_domain
+        )
+        if keys_by_consumer is None:
+            raise AssertionError("event relation does not match its quotient geometry")
+        canonical_consumers.append(
+            dataclasses.replace(
+                readiness_consumer,
+                keys_by_consumer=keys_by_consumer,
+            )
+        )
+    canonical_producers_tuple = tuple(canonical_producers)
+    signature = canonical_domain, canonical_producers_tuple
+    previous_event = pending.get(signature)
+    if previous_event is None:
+        event_id = len(pending)
+        identified_domain = dataclasses.replace(canonical_domain, identity=event_id)
+        identified_producers: list[ReadinessProducer] = []
+        for readiness_producer in canonical_producers_tuple:
+            producers_by_key = readiness_producer.producers_by_key.rename_source_axes(
+                identified_domain
+            )
+            if producers_by_key is None:
+                raise AssertionError(
+                    "event identity assignment changed readiness-key geometry"
+                )
+            identified_producers.append(
+                dataclasses.replace(
+                    readiness_producer,
+                    producers_by_key=producers_by_key,
+                )
+            )
+        event_producers = tuple(identified_producers)
+        previous_consumers: tuple[ReadinessConsumer, ...] = ()
+    else:
+        event_id = previous_event.event_id
+        identified_domain = previous_event.readiness_key_domain
+        event_producers = previous_event.producers
+        previous_consumers = previous_event.consumers
+
+    if require_counter_lowering and any(
+        not _supports_readiness_counter_lowering(readiness_producer)
+        for readiness_producer in event_producers
+    ):
+        return False
+
+    grouped_consumers = list(previous_consumers)
+    for canonical_consumer in canonical_consumers:
+        keys_by_consumer = canonical_consumer.keys_by_consumer.rename_target_axes(
+            identified_domain
+        )
+        if keys_by_consumer is None:
+            raise AssertionError(
+                "event identity assignment changed readiness-key geometry"
+            )
+        readiness_consumer = dataclasses.replace(
+            canonical_consumer,
+            keys_by_consumer=keys_by_consumer,
+        )
+        matching_index = next(
+            (
+                index
+                for index, previous in enumerate(grouped_consumers)
+                if previous.consumer_root == readiness_consumer.consumer_root
+                and previous.consumer_site_id == readiness_consumer.consumer_site_id
+                and previous.keys_by_consumer == readiness_consumer.keys_by_consumer
+            ),
+            None,
+        )
+        if matching_index is None:
+            grouped_consumers.append(readiness_consumer)
+            continue
+        previous = grouped_consumers[matching_index]
+        grouped_consumers[matching_index] = dataclasses.replace(
+            previous,
+            covered_obligations=(
+                previous.covered_obligations | readiness_consumer.covered_obligations
+            ),
+        )
+    pending[signature] = ReadinessEvent(
+        producers=event_producers,
+        consumers=tuple(grouped_consumers),
+    )
+    return True
+
+
+def _without_root_consumers_for_obligations(
+    readiness_graph: ReadinessGraph,
+    covered_obligations: frozenset[DependencyObligation],
+) -> ReadinessGraph:
+    """Remove root-entry consumers covered by selected nested-loop waits."""
+    if not covered_obligations:
+        return readiness_graph
+    events: list[ReadinessEvent] = []
+    for event in readiness_graph.events:
+        consumers: list[ReadinessConsumer] = []
+        for readiness_consumer in event.consumers:
+            if readiness_consumer.consumer_site_id is not None:
+                consumers.append(readiness_consumer)
+                continue
+            remaining = readiness_consumer.covered_obligations - covered_obligations
+            if remaining:
+                consumers.append(
+                    dataclasses.replace(
+                        readiness_consumer,
+                        covered_obligations=remaining,
+                    )
+                )
+        events.append(dataclasses.replace(event, consumers=tuple(consumers)))
+    return dataclasses.replace(readiness_graph, events=tuple(events))
+
+
+@dataclasses.dataclass(frozen=True)
+class ReadinessCounterPlan:
+    """A readiness-key space receiving arrivals from one or more roots.
+
+    Each producer has an independently proved readiness-key-to-producer
+    relation. The
+    expected count is derived from its producer sets, so the event represents
+    both ordinary continuations and generic multi-predecessor joins.
+    Consumers are independent of event identity. ``continuation_consumer_index``
+    identifies the optional consumer executed by the final arriving producer.
+    """
+
+    producers: tuple[ReadinessProducer, ...]
+    consumers: tuple[ReadinessConsumer, ...]
+    continuation_consumer_index: int | None = None
+
+    def __post_init__(self) -> None:
+        _readiness_key_domain(self.producers, self.consumers)
+
+    @property
+    def readiness_key_domain(self) -> CoordinateDomain:
+        """Return the readiness-key domain owned by every event relation."""
+        return self.producers[0].producers_by_key.source_domain
+
+    @property
+    def continuation_consumer(self) -> ReadinessConsumer | None:
+        if self.continuation_consumer_index is None:
+            return None
+        return self.consumers[self.continuation_consumer_index]
+
+    @property
+    def readiness_key_count(self) -> int:
+        """Return the complete readiness-key count."""
+        return self.readiness_key_domain.size
+
+    def uniform_arrival_count(self) -> int | None:
+        """Return constant fan-in without enumerating readiness keys."""
+        return _uniform_arrival_count(self.producers)
+
+
+@dataclasses.dataclass(frozen=True)
+class _NestedLoopReadiness:
+    """Configured readiness of one nested loop in task-local program order."""
+
+    event: ReadinessEvent
+    readiness_consumer: ReadinessConsumer
+    ready_after_worker_step: CoordinateRelation
+    prerequisite_worker_steps: frozenset[tuple[int, int]]
+
+
+def _merge_relations_by_root(
+    relations: tuple[tuple[int, CoordinateRelation], ...],
+) -> tuple[tuple[int, CoordinateRelation], ...] | None:
+    merged: dict[int, CoordinateRelation] = {}
+    for root, relation in relations:
+        previous = merged.get(root)
+        if previous is None:
+            merged[root] = relation
+            continue
+        union = previous.union(relation)
+        if union is None:
+            return None
+        merged[root] = union
+    return tuple(sorted(merged.items()))
+
+
+def _static_producer_relations(
+    readiness_graph: ReadinessGraph,
+    *,
+    root: int,
+    site_id: int | None,
+    readiness_keys: CoordinateRelation,
+    continuation_by_root: dict[int, FinalArrivalContinuation],
+    visiting: frozenset[int] = frozenset(),
+) -> tuple[tuple[int, CoordinateRelation], ...] | None:
+    """Contract continuations to relations from statically scheduled roots."""
+    root_domain = readiness_graph.root_domains[root]
+    root_keys = (
+        readiness_keys
+        if site_id is None
+        else readiness_keys.project_source(root_domain)
+    )
+    if root_keys is None:
+        return None
+    continuation = continuation_by_root.get(root)
+    if continuation is None:
+        return ((root, root_keys),)
+    if root in visiting:
+        return None
+    continuation_event = readiness_graph.event(continuation.event_id)
+    continuation_consumer = continuation_event.consumers[continuation.consumer_index]
+    converse_consumer = continuation_consumer.keys_by_consumer.converse()
+    key_to_target = (
+        None if converse_consumer is None else converse_consumer.then(root_keys)
+    )
+    if key_to_target is None:
+        return None
+    expanded: list[tuple[int, CoordinateRelation]] = []
+    for readiness_producer in continuation_event.producers:
+        publication = readiness_producer.keys_by_producer
+        upstream_keys = None if publication is None else publication.then(key_to_target)
+        if upstream_keys is None:
+            return None
+        upstream = _static_producer_relations(
+            readiness_graph,
+            root=readiness_producer.producer_root,
+            site_id=readiness_producer.producer_site_id,
+            readiness_keys=upstream_keys,
+            continuation_by_root=continuation_by_root,
+            visiting=visiting | frozenset((root,)),
+        )
+        if upstream is None:
+            return None
+        expanded.extend(upstream)
+    return _merge_relations_by_root(tuple(expanded))
+
+
+def _event_static_producers(
+    readiness_graph: ReadinessGraph,
+    event: ReadinessEvent,
+    continuation_by_root: dict[int, FinalArrivalContinuation],
+) -> tuple[tuple[int, CoordinateRelation], ...] | None:
+    expanded: list[tuple[int, CoordinateRelation]] = []
+    for readiness_producer in event.producers:
+        publication = readiness_producer.keys_by_producer
+        if publication is None:
+            return None
+        static_relations = _static_producer_relations(
+            readiness_graph,
+            root=readiness_producer.producer_root,
+            site_id=readiness_producer.producer_site_id,
+            readiness_keys=publication,
+            continuation_by_root=continuation_by_root,
+        )
+        if static_relations is None:
+            return None
+        expanded.extend(static_relations)
+    return _merge_relations_by_root(tuple(expanded))
+
+
+def _transitive_static_prerequisite_roots(
+    readiness_graph: ReadinessGraph,
+    static_relations: tuple[tuple[int, CoordinateRelation], ...],
+    continuation_by_root: dict[int, FinalArrivalContinuation],
+) -> frozenset[int] | None:
+    """Close static producers through waits earlier in task-local program order."""
+    roots = {root for root, _relation in static_relations}
+    pending = list(roots)
+    while pending:
+        consumer_root = pending.pop()
+        for event in readiness_graph.events:
+            if not any(
+                readiness_consumer.consumer_root == consumer_root
+                for readiness_consumer in event.consumers
+            ):
+                continue
+            upstream = _event_static_producers(
+                readiness_graph,
+                event,
+                continuation_by_root,
+            )
+            if upstream is None:
+                return None
+            for producer_root, _relation in upstream:
+                if producer_root == consumer_root:
+                    return None
+                if producer_root not in roots:
+                    roots.add(producer_root)
+                    pending.append(producer_root)
+    return frozenset(roots)
+
+
+def _event_ready_after_worker_steps(
+    readiness_graph: ReadinessGraph,
+    event: ReadinessEvent,
+    *,
+    worker_schedule: WorkerSchedule,
+    continuation_by_root: dict[int, FinalArrivalContinuation],
+) -> tuple[CoordinateRelation, frozenset[int]] | None:
+    """Return when each readiness key becomes ready and its static producers."""
+    static_relations = _event_static_producers(
+        readiness_graph,
+        event,
+        continuation_by_root,
+    )
+    if static_relations is None or any(
+        not relation.has_total_source() for _root, relation in static_relations
+    ):
+        return None
+    prerequisite_roots = _transitive_static_prerequisite_roots(
+        readiness_graph,
+        static_relations,
+        continuation_by_root,
+    )
+    if prerequisite_roots is None:
+        return None
+    maxima: list[CoordinateRelation] = []
+    for root, keys_by_task in static_relations:
+        root_domain = readiness_graph.root_domains[root]
+        if keys_by_task.source_domain != root_domain:
+            return None
+        for segment in worker_schedule.segments_for_root(root):
+            task_order = segment.task_order
+            if task_order.target_domain != root_domain:
+                return None
+            keys_by_task_order = task_order.then(keys_by_task)
+            converse = (
+                None if keys_by_task_order is None else keys_by_task_order.converse()
+            )
+            worker_steps = worker_schedule.worker_step_relation(segment)
+            maximum = (
+                None
+                if converse is None or worker_steps is None
+                else converse.max_target_value_by_source(worker_steps)
+            )
+            if maximum is None:
+                return None
+            maxima.append(maximum)
+    if not maxima:
+        return None
+    combined = maxima[0]
+    for relation in maxima[1:]:
+        union = combined.union(relation)
+        if union is None:
+            return None
+        combined = union
+    identity = CoordinateRelation.identity(
+        worker_schedule.worker_step_domain,
+        worker_schedule.worker_step_domain,
+    )
+    maximum = combined.max_target_value_by_source(identity)
+    return None if maximum is None else (maximum, prerequisite_roots)
+
+
+def _nested_loop_readiness(
+    readiness_graph: ReadinessGraph,
+    event: ReadinessEvent,
+    readiness_consumer: ReadinessConsumer,
+    *,
+    worker_schedule: WorkerSchedule,
+    continuation_by_root: dict[int, FinalArrivalContinuation],
+) -> _NestedLoopReadiness | None:
+    """Map each nested-loop iteration to its prerequisite worker step."""
+    assert readiness_consumer.consumer_site_id is not None
+    domain = readiness_consumer.keys_by_consumer.source_domain
+    nested_axes = nested_logical_axes(
+        readiness_graph.root_domains[readiness_consumer.consumer_root], domain
+    )
+    if len(nested_axes) != 1:
+        return None
+
+    event_ready_after = _event_ready_after_worker_steps(
+        readiness_graph,
+        event,
+        worker_schedule=worker_schedule,
+        continuation_by_root=continuation_by_root,
+    )
+    if event_ready_after is None:
+        return None
+    ready_after_worker_steps, prerequisite_roots = event_ready_after
+    iteration_ready_after_worker_step = readiness_consumer.keys_by_consumer.then(
+        ready_after_worker_steps
+    )
+    if (
+        iteration_ready_after_worker_step is None
+        or not iteration_ready_after_worker_step.is_total_function()
+    ):
+        return None
+    prerequisite_worker_steps: set[tuple[int, int]] = set()
+    for root in prerequisite_roots:
+        last_worker_steps = worker_schedule.last_worker_steps_for_root(root)
+        prerequisite_worker_steps.update(last_worker_steps.items())
+    return _NestedLoopReadiness(
+        event=event,
+        readiness_consumer=readiness_consumer,
+        ready_after_worker_step=iteration_ready_after_worker_step,
+        prerequisite_worker_steps=frozenset(prerequisite_worker_steps),
+    )
+
+
+def _segmented_nested_loop_counter(
+    readiness_graph: ReadinessGraph,
+    event: ReadinessEvent,
+    readiness_consumer: ReadinessConsumer,
+    boundaries: tuple[int, ...],
+) -> ReadinessCounterPlan | None:
+    """Coarsen one exact nested dependency into contiguous loop segments."""
+    consumer_site_id = readiness_consumer.consumer_site_id
+    assert consumer_site_id is not None
+    domain = readiness_consumer.keys_by_consumer.source_domain
+    nested_axes = nested_logical_axes(
+        readiness_graph.root_domains[readiness_consumer.consumer_root], domain
+    )
+    if len(nested_axes) != 1:
+        return None
+    (nested_axis,) = nested_axes
+    segments = tuple(itertools.pairwise(boundaries))
+    if not segments or any(begin >= end for begin, end in segments):
+        return None
+    used_axes = readiness_consumer.keys_by_consumer.source_axes_affecting_targets()
+    if used_axes is None or nested_axis not in used_axes:
+        return None
+    reduced_domain = CoordinateDomain(
+        axis_order=used_axes,
+        axis_counts_items=tuple((axis, domain.axis_counts[axis]) for axis in used_axes),
+        block_sizes_items=tuple(
+            (axis, domain.block_sizes[axis])
+            for axis in used_axes
+            if axis in domain.block_sizes
+        ),
+        kind="site",
+        identity=domain.identity,
+    )
+    outer_axes = tuple(axis for axis in used_axes if axis != nested_axis)
+    readiness_key_domain = CoordinateDomain(
+        axis_order=tuple(range(len(outer_axes) + 1)),
+        axis_counts_items=(
+            (0, len(segments)),
+            *(
+                (event_axis, reduced_domain.axis_counts[source_axis])
+                for event_axis, source_axis in enumerate(outer_axes, start=1)
+            ),
+        ),
+        kind="event",
+    )
+    keys_by_reduced_iteration = CoordinateRelation.point_map(
+        reduced_domain,
+        readiness_key_domain,
+        tuple(
+            (
+                tuple(
+                    (
+                        (axis, segment_begin, segment_end, 1)
+                        if axis == nested_axis
+                        else (axis, 0, reduced_domain.axis_counts[axis], 1)
+                    )
+                    for axis in reduced_domain.axis_order
+                ),
+                (
+                    sympy.Integer(stage),
+                    *(coordinate_axis_symbol(axis) for axis in outer_axes),
+                ),
+            )
+            for stage, (segment_begin, segment_end) in enumerate(segments)
+        ),
+    )
+    converse_consumer = readiness_consumer.keys_by_consumer.converse()
+    reduced_converse = (
+        None
+        if converse_consumer is None
+        else converse_consumer.project_target(reduced_domain)
+    )
+    key_coarsening = (
+        None
+        if reduced_converse is None
+        else reduced_converse.then(keys_by_reduced_iteration)
+    )
+    if key_coarsening is None:
+        return None
+    # This is a scheduling-derived coarsening of an already lowerable event,
+    # not a second dependency fact. Derive producer publication from the
+    # authoritative producer sets, compose it with the segment map, then
+    # take the exact converse back into the representation owned by the plan.
+    publication_relations = tuple(
+        (
+            None
+            if readiness_producer.keys_by_producer is None
+            else readiness_producer.keys_by_producer.then(key_coarsening)
+        )
+        for readiness_producer in event.producers
+    )
+    if any(relation is None for relation in publication_relations):
+        return None
+    producers_by_key_relations = tuple(
+        None if relation is None else relation.converse()
+        for relation in publication_relations
+    )
+    if any(relation is None for relation in producers_by_key_relations):
+        return None
+    keys_by_consumer = keys_by_reduced_iteration.lift_source(domain)
+    if keys_by_consumer is None:
+        return None
+
+    return ReadinessCounterPlan(
+        producers=tuple(
+            ReadinessProducer(
+                producer_root=readiness_producer.producer_root,
+                producer_site_id=readiness_producer.producer_site_id,
+                producers_by_key=relation,
+            )
+            for readiness_producer, relation in zip(
+                event.producers,
+                producers_by_key_relations,
+                strict=True,
+            )
+            if relation is not None
+        ),
+        consumers=(
+            ReadinessConsumer(
+                consumer_root=readiness_consumer.consumer_root,
+                covered_obligations=readiness_consumer.covered_obligations,
+                consumer_site_id=readiness_consumer.consumer_site_id,
+                keys_by_consumer=keys_by_consumer,
+            ),
+        ),
+    )
+
+
+def _split_nested_loop_at_readiness(
+    readiness_graph: ReadinessGraph,
+    nested_readiness: _NestedLoopReadiness,
+    *,
+    consumer_worker_step: int,
+) -> ReadinessCounterPlan | None:
+    """Split a nested loop at the first iteration not yet ready."""
+    domain = nested_readiness.readiness_consumer.keys_by_consumer.source_domain
+    consumer_site_id = nested_readiness.readiness_consumer.consumer_site_id
+    assert consumer_site_id is not None
+    nested_axes = nested_logical_axes(
+        readiness_graph.root_domains[nested_readiness.readiness_consumer.consumer_root],
+        domain,
+    )
+    if len(nested_axes) != 1:
+        return None
+    (nested_axis,) = nested_axes
+    nested_iterations_per_task = domain.axis_counts[nested_axis]
+
+    def ready(nested_iteration: int) -> bool | None:
+        value_bounds = nested_readiness.ready_after_worker_step.value_bounds(
+            {nested_axis: nested_iteration}
+        )
+        if value_bounds is None:
+            return None
+        # Producers at the same worker step execute concurrently on other
+        # workers. They permit placement at this step, but are not ready at
+        # admission: their consumer iterations belong after the split.
+        # ``prerequisite_worker_steps`` separately prevents self-deadlock on a
+        # producer's own worker.
+        return value_bounds[1] < consumer_worker_step
+
+    first_ready = ready(0)
+    last_ready = ready(nested_iterations_per_task - 1)
+    if first_ready is None or last_ready is None:
+        return None
+    if not first_ready:
+        split_iteration = 0
+    elif last_ready:
+        split_iteration = nested_iterations_per_task
+    else:
+        lower = 0
+        upper = nested_iterations_per_task - 1
+        while lower + 1 < upper:
+            midpoint = (lower + upper) // 2
+            midpoint_ready = ready(midpoint)
+            if midpoint_ready is None:
+                return None
+            if midpoint_ready:
+                lower = midpoint
+            else:
+                upper = midpoint
+        split_iteration = upper
+    boundaries = tuple(sorted({0, split_iteration, nested_iterations_per_task}))
+    return _segmented_nested_loop_counter(
+        readiness_graph,
+        nested_readiness.event,
+        nested_readiness.readiness_consumer,
+        boundaries,
+    )
+
+
+def _nested_loop_entry_counter(
+    readiness_graph: ReadinessGraph,
+    event: ReadinessEvent,
+    readiness_consumer: ReadinessConsumer,
+) -> ReadinessCounterPlan | None:
+    """Coarsen exact iteration readiness to one wait per owning root task."""
+    consumer_site_id = readiness_consumer.consumer_site_id
+    assert consumer_site_id is not None
+    domain = readiness_consumer.keys_by_consumer.source_domain
+    nested_axes = nested_logical_axes(
+        readiness_graph.root_domains[readiness_consumer.consumer_root], domain
+    )
+    if len(nested_axes) != 1:
+        return None
+    nested_iterations_per_task = domain.axis_counts[nested_axes[0]]
+    return _segmented_nested_loop_counter(
+        readiness_graph,
+        event,
+        readiness_consumer,
+        (0, nested_iterations_per_task),
+    )
+
+
+def place_nested_loop_consumers(
+    readiness_graph: ReadinessGraph,
+    worker_schedule: WorkerSchedule,
+    continuations: tuple[FinalArrivalContinuation, ...],
+) -> tuple[WorkerSchedule, tuple[ReadinessCounterPlan, ...]]:
+    """Place root tasks with nested waits and derive their readiness counters.
+
+    Exact nested-iteration dependencies remain the semantic source of truth.
+    This pass uses only worker steps and task-local program order to select one
+    split point for the original nested loop.
+    It does not inspect operation kinds or recognize a graph topology.
+    """
+    consumers_by_root: dict[
+        int,
+        list[tuple[ReadinessEvent, ReadinessConsumer]],
+    ] = {}
+    continuation_by_root = _continuations_by_consumer_root(
+        readiness_graph, continuations
+    )
+    for event in readiness_graph.events:
+        for readiness_consumer in event.consumers:
+            if readiness_consumer.consumer_site_id is not None:
+                consumers_by_root.setdefault(
+                    readiness_consumer.consumer_root, []
+                ).append((event, readiness_consumer))
+
+    result = worker_schedule
+    plans: list[ReadinessCounterPlan] = []
+    for consumer_root, event_consumers in sorted(consumers_by_root.items()):
+        task_domain = readiness_graph.root_domains[consumer_root]
+
+        # A preceding site may already carry every dependency obligation needed by
+        # a later site.  The implication was proved from DeviceIR program
+        # order when the readiness graph was built, so the later wait is redundant.
+        uncovered_consumers: list[tuple[ReadinessEvent, ReadinessConsumer]] = []
+        preceding_obligations: set[DependencyObligation] = set()
+        for event, readiness_consumer in sorted(
+            event_consumers,
+            key=lambda item: (
+                item[1].consumer_site_id
+                if item[1].consumer_site_id is not None
+                else -1,
+                item[0].event_id,
+            ),
+        ):
+            if (
+                readiness_consumer.covered_obligations
+                and readiness_consumer.covered_obligations <= (preceding_obligations)
+            ):
+                continue
+            uncovered_consumers.append((event, readiness_consumer))
+            preceding_obligations.update(readiness_consumer.covered_obligations)
+
+        nested_loop_entry_plans = tuple(
+            plan
+            for event, readiness_consumer in uncovered_consumers
+            if (
+                plan := _nested_loop_entry_counter(
+                    readiness_graph, event, readiness_consumer
+                )
+            )
+            is not None
+        )
+        if task_domain.size > result.worker_count:
+            plans.extend(nested_loop_entry_plans)
+            continue
+
+        nested_readiness = tuple(
+            _nested_loop_readiness(
+                readiness_graph,
+                event,
+                readiness_consumer,
+                worker_schedule=result,
+                continuation_by_root=continuation_by_root,
+            )
+            for event, readiness_consumer in uncovered_consumers
+        )
+        if not nested_readiness or any(item is None for item in nested_readiness):
+            plans.extend(nested_loop_entry_plans)
+            continue
+        ordered_readiness = tuple(item for item in nested_readiness if item is not None)
+
+        current_consumer_bounds = result.worker_step_bounds_for_root(consumer_root)
+        if current_consumer_bounds is None:
+            plans.extend(nested_loop_entry_plans)
+            continue
+        original_worker_step = current_consumer_bounds[0]
+        readiness_bounds = tuple(
+            item.ready_after_worker_step.value_bounds() for item in ordered_readiness
+        )
+        if any(bounds is None for bounds in readiness_bounds):
+            plans.extend(nested_loop_entry_plans)
+            continue
+        earliest_ready_after_step = min(
+            bounds[0] for bounds in readiness_bounds if bounds is not None
+        )
+        prerequisite_worker_steps = frozenset(
+            placement
+            for item in ordered_readiness
+            for placement in item.prerequisite_worker_steps
+        )
+        chosen: tuple[WorkerSchedule, tuple[ReadinessCounterPlan, ...]] | None = None
+        for worker_step in range(earliest_ready_after_step + 1, original_worker_step):
+            busy_workers = frozenset(
+                worker
+                for worker, prerequisite_worker_step in prerequisite_worker_steps
+                if prerequisite_worker_step >= worker_step
+            )
+            candidate = next(
+                (
+                    candidate
+                    for candidate in _family_placements_at_worker_step(
+                        result,
+                        root=consumer_root,
+                        task_domain=task_domain,
+                        task_order=readiness_graph.root_task_orders[consumer_root],
+                        worker_step=worker_step,
+                        unavailable_workers=busy_workers,
+                    )
+                ),
+                None,
+            )
+            if candidate is None:
+                continue
+            milestone_results = tuple(
+                _split_nested_loop_at_readiness(
+                    readiness_graph,
+                    item,
+                    consumer_worker_step=worker_step,
+                )
+                for item in ordered_readiness
+            )
+            if any(item is None for item in milestone_results):
+                continue
+            chosen = (
+                candidate,
+                tuple(plan for plan in milestone_results if plan is not None),
+            )
+            break
+        if chosen is None:
+            plans.extend(nested_loop_entry_plans)
+            continue
+        result, nested_loop_plans = chosen
+        plans.extend(nested_loop_plans)
+    return result, tuple(plans)
+
+
+@dataclasses.dataclass(frozen=True)
+class StaticPipelinePlan:
+    """Pure graph-derived choices consumed by persistent-kernel lowering."""
+
+    worker_schedule: WorkerSchedule
+    readiness_counters: tuple[ReadinessCounterPlan, ...]
+    root_barrier_edges: frozenset[tuple[int, int]]
+
+
+def choose_final_arrival_continuations(
+    readiness_graph: ReadinessGraph,
+    worker_schedule: WorkerSchedule,
+    *,
+    excluded_roots: frozenset[int] = frozenset(),
+) -> tuple[FinalArrivalContinuation, ...]:
+    """Choose final-arrival execution from complete exact task readiness.
+
+    A one-task family has no task-level parallelism to expose, so it remains in
+    the static schedule. Downstream event granularity does not change whether
+    an otherwise exact-ready family is eligible for a continuation.
+    """
+    return tuple(
+        continuation
+        for continuation in derive_final_arrival_continuations(
+            readiness_graph, worker_schedule
+        )
+        if (
+            readiness_consumer := readiness_graph.event(
+                continuation.event_id
+            ).consumers[continuation.consumer_index]
+        ).consumer_root
+        not in excluded_roots
+        and readiness_graph.root_domains[readiness_consumer.consumer_root].size > 1
+    )
+
+
+def choose_readiness_counters(
+    readiness_graph: ReadinessGraph,
+    continuations: tuple[FinalArrivalContinuation, ...],
+    *,
+    excluded_obligations: frozenset[DependencyObligation] = frozenset(),
+) -> tuple[ReadinessCounterPlan, ...]:
+    """Select root-entry events representable by readiness counters.
+
+    Nested consumers keep their execution-site lowering. Excluding one
+    consumer does not discard independent consumers of the same semantic
+    event. A one-key event is a root barrier and remains on the aggregated
+    root-barrier path unless it owns a final-arrival continuation. Unsupported
+    relations monotonically fall back to a root barrier during coverage
+    selection.
+    """
+    continuation_consumers = {
+        (continuation.event_id, continuation.consumer_index)
+        for continuation in continuations
+    }
+    selected: list[ReadinessCounterPlan] = []
+    for event in readiness_graph.events:
+        if event.root_barrier_producer_root is not None or any(
+            not _supports_readiness_counter_lowering(readiness_producer)
+            for readiness_producer in event.producers
+        ):
+            continue
+        retained_consumers: list[ReadinessConsumer] = []
+        continuation_consumer_indices: list[int] = []
+        for consumer_index, readiness_consumer in enumerate(event.consumers):
+            if (
+                readiness_consumer.consumer_site_id is not None
+                or readiness_consumer.keys_by_consumer.canonical_single_valued() is None
+            ):
+                continue
+            remaining = readiness_consumer.covered_obligations - excluded_obligations
+            is_continuation = (
+                event.event_id,
+                consumer_index,
+            ) in continuation_consumers
+            if not is_continuation and not remaining:
+                continue
+            if is_continuation:
+                continuation_consumer_indices.append(len(retained_consumers))
+            retained_consumers.append(
+                ReadinessConsumer(
+                    consumer_root=readiness_consumer.consumer_root,
+                    keys_by_consumer=readiness_consumer.keys_by_consumer,
+                    covered_obligations=(
+                        readiness_consumer.covered_obligations
+                        if is_continuation
+                        else frozenset(remaining)
+                    ),
+                )
+            )
+        if len(continuation_consumer_indices) > 1:
+            raise ValueError("one readiness counter cannot have multiple continuations")
+        continuation_consumer_index = (
+            continuation_consumer_indices[0] if continuation_consumer_indices else None
+        )
+        if not retained_consumers or (
+            continuation_consumer_index is None and event.readiness_key_count <= 1
+        ):
+            continue
+        selected.append(
+            ReadinessCounterPlan(
+                producers=event.producers,
+                consumers=tuple(retained_consumers),
+                continuation_consumer_index=continuation_consumer_index,
+            )
+        )
+    selected_continuation_count = sum(
+        counter_plan.continuation_consumer_index is not None
+        for counter_plan in selected
+    )
+    if selected_continuation_count != len(continuation_consumers):
+        raise AssertionError(
+            "not every final-arrival continuation has a readiness counter"
+        )
+    return tuple(selected)
+
+
+def build_readiness_events(
+    dependency_graph: TileDependencyGraph,
+    *,
+    root_domains: tuple[CoordinateDomain, ...],
+    site_domains: tuple[CoordinateDomain | None, ...],
+    publishable_site_ids: frozenset[int] | None = None,
+) -> tuple[ReadinessEvent, ...]:
+    """Build canonical symbolic readiness events from memory dependencies.
+
+    This is the sole event-construction path. It never constructs a per-task
+    producer set. Unsupported relations coarsen to one root-barrier
+    event for the affected root pair.
+    """
+    symbolic_dependencies = instantiate_symbolic_dependencies(
+        dependency_graph,
+        root_domains=root_domains,
+        site_domains=site_domains,
+    )
+    site_by_id = {site.site_id: site for site in dependency_graph.execution_sites}
+    exact_dependencies = tuple(
+        dependency
+        for dependency in symbolic_dependencies
+        if dependency.producers_by_consumer is not None
+        and dependency.producers_by_consumer.source_axes_affecting_targets() is not None
+    )
+    all_obligations_by_pair: dict[tuple[int, int], set[DependencyObligation]] = {}
+    for edge in dependency_graph.edges:
+        pair = (edge.producer_root, edge.consumer_root)
+        for access_dependency in edge.access_dependencies:
+            all_obligations_by_pair.setdefault(pair, set()).update(
+                dependency_graph.dependency_obligations(access_dependency)
+            )
+
+    implied_obligations: dict[DependencyObligation, set[DependencyObligation]] = {}
+    for preceding_dependency in exact_dependencies:
+        preceding_site_id = preceding_dependency.consumer_site_id
+        if preceding_site_id is None or site_by_id[preceding_site_id].is_root:
+            continue
+        preceding_producers = preceding_dependency.producers_by_consumer
+        assert preceding_producers is not None
+        preceding_obligation = (
+            preceding_dependency.dependency_id,
+            preceding_dependency.producer_site_id,
+            preceding_site_id,
+        )
+        for later_dependency in exact_dependencies:
+            later_site_id = later_dependency.consumer_site_id
+            later_producers = later_dependency.producers_by_consumer
+            if (
+                later_dependency is preceding_dependency
+                or later_site_id is None
+                or later_producers is None
+                or preceding_dependency.consumer_root != later_dependency.consumer_root
+                or preceding_dependency.producer_root != later_dependency.producer_root
+                or preceding_dependency.producer_site_id
+                != later_dependency.producer_site_id
+                or preceding_producers.target_domain != later_producers.target_domain
+            ):
+                continue
+            preceding = consumer_to_preceding_site_relation(
+                dependency_graph,
+                site_domains=site_domains,
+                preceding_site_id=preceding_site_id,
+                consumer_site_id=later_site_id,
+                consumer_access_id=later_dependency.consumer_access_id,
+            )
+            acquired = (
+                None if preceding is None else preceding.then(preceding_producers)
+            )
+            if acquired is not None and acquired.covers(later_producers):
+                implied_obligations.setdefault(preceding_obligation, set()).add(
+                    (
+                        later_dependency.dependency_id,
+                        later_dependency.producer_site_id,
+                        later_site_id,
+                    )
+                )
+
+    exact_relations: dict[
+        tuple[int, int | None, CoordinateDomain],
+        dict[
+            tuple[int, int | None, CoordinateDomain],
+            list[tuple[CoordinateRelation, DependencyObligation]],
+        ],
+    ] = {}
+
+    def add_exact_relation(
+        *,
+        producer_root: int,
+        producer_site_id: int | None,
+        consumer_root: int,
+        consumer_site_id: int | None,
+        relation: CoordinateRelation,
+        covered_obligations: frozenset[DependencyObligation],
+    ) -> None:
+        consumer = (consumer_root, consumer_site_id, relation.source_domain)
+        producer = (producer_root, producer_site_id, relation.target_domain)
+        exact_relations.setdefault(consumer, {}).setdefault(producer, []).extend(
+            (relation, obligation) for obligation in covered_obligations
+        )
+
+    for dependency in exact_dependencies:
+        relation = dependency.producers_by_consumer
+        assert relation is not None
+        obligation = (
+            dependency.dependency_id,
+            dependency.producer_site_id,
+            dependency.consumer_site_id,
+        )
+        exact_obligations = frozenset(
+            (obligation, *implied_obligations.get(obligation, ()))
+        )
+        producer_site = (
+            None
+            if dependency.producer_site_id is None
+            else site_by_id[dependency.producer_site_id]
+        )
+        consumer_site = (
+            None
+            if dependency.consumer_site_id is None
+            else site_by_id[dependency.consumer_site_id]
+        )
+        producer_is_root = producer_site is None or producer_site.is_root
+        consumer_is_root = consumer_site is None or consumer_site.is_root
+        producer_site_is_usable = producer_is_root or (
+            producer_site is not None
+            and producer_site.can_split_loop
+            and (
+                publishable_site_ids is None
+                or dependency.producer_site_id in publishable_site_ids
+            )
+        )
+        consumer_site_is_usable = consumer_is_root or (
+            consumer_site is not None and consumer_site.can_split_loop
+        )
+        if producer_site_is_usable and consumer_site_is_usable:
+            add_exact_relation(
+                producer_root=dependency.producer_root,
+                producer_site_id=(
+                    None if producer_is_root else dependency.producer_site_id
+                ),
+                consumer_root=dependency.consumer_root,
+                consumer_site_id=(
+                    None if consumer_is_root else dependency.consumer_site_id
+                ),
+                relation=relation,
+                covered_obligations=exact_obligations,
+            )
+
+        if producer_is_root and consumer_is_root:
+            continue
+        root_relation = relation
+        if not consumer_is_root:
+            projected = root_relation.project_source(
+                root_domains[dependency.consumer_root]
+            )
+            if projected is None:
+                continue
+            root_relation = projected
+        if not producer_is_root:
+            projected = root_relation.project_target(
+                root_domains[dependency.producer_root]
+            )
+            if projected is None:
+                continue
+            root_relation = projected
+        add_exact_relation(
+            producer_root=dependency.producer_root,
+            producer_site_id=None,
+            consumer_root=dependency.consumer_root,
+            consumer_site_id=None,
+            relation=root_relation,
+            covered_obligations=exact_obligations,
+        )
+
+    pending_events: dict[
+        tuple[CoordinateDomain, tuple[ReadinessProducer, ...]],
+        ReadinessEvent,
+    ] = {}
+    represented_obligations: set[DependencyObligation] = set()
+
+    def record_readiness_event(
+        *,
+        readiness_key_domain: CoordinateDomain,
+        producers: tuple[ReadinessProducer, ...],
+        consumers: tuple[ReadinessConsumer, ...],
+        require_counter_lowering: bool = False,
+    ) -> bool:
+        if not _record_readiness_event(
+            pending_events,
+            readiness_key_domain=readiness_key_domain,
+            producers=producers,
+            consumers=consumers,
+            require_counter_lowering=require_counter_lowering,
+        ):
+            return False
+        for readiness_consumer in consumers:
+            represented_obligations.update(readiness_consumer.covered_obligations)
+        return True
+
+    def add_producer_key_events(
+        *,
+        consumer_root: int,
+        consumer_site_id: int | None,
+        relations: list[
+            tuple[
+                tuple[int, int | None, CoordinateDomain],
+                CoordinateRelation,
+                frozenset[DependencyObligation],
+            ]
+        ],
+    ) -> None:
+        """Keep finer readiness keys when a consumer quotient needs fanout."""
+        for producer, relation, obligations in relations:
+            producer_root, producer_site_id, producer_domain = producer
+            readiness_key_domain = dataclasses.replace(
+                producer_domain,
+                kind="event",
+                identity=None,
+            )
+            keys_by_consumer = relation.rename_target_axes(readiness_key_domain)
+            if keys_by_consumer is None:
+                raise AssertionError("producer-keyed readiness geometry must match")
+            record_readiness_event(
+                readiness_key_domain=readiness_key_domain,
+                producers=(
+                    ReadinessProducer(
+                        producer_root=producer_root,
+                        producer_site_id=producer_site_id,
+                        producers_by_key=CoordinateRelation.identity(
+                            readiness_key_domain,
+                            producer_domain,
+                        ),
+                    ),
+                ),
+                consumers=(
+                    ReadinessConsumer(
+                        consumer_root=consumer_root,
+                        consumer_site_id=consumer_site_id,
+                        keys_by_consumer=keys_by_consumer,
+                        covered_obligations=obligations,
+                    ),
+                ),
+            )
+
+    for consumer, producers in sorted(
+        exact_relations.items(),
+        key=lambda item: (
+            item[0][0],
+            -1 if item[0][1] is None else item[0][1],
+        ),
+    ):
+        consumer_root, consumer_site_id, consumer_domain = consumer
+        merged_relations: list[
+            tuple[
+                tuple[int, int | None, CoordinateDomain],
+                CoordinateRelation,
+                frozenset[DependencyObligation],
+            ]
+        ] = []
+        readiness_key_axis_set: set[int] = set()
+        quotient_is_supported = True
+        for producer, relation_points in sorted(
+            producers.items(),
+            key=lambda item: (
+                item[0][0],
+                -1 if item[0][1] is None else item[0][1],
+            ),
+        ):
+            relation, first_point = relation_points[0]
+            obligations = {first_point}
+            for next_relation, obligation in relation_points[1:]:
+                union = relation.union(next_relation)
+                if union is None:
+                    quotient_is_supported = False
+                    break
+                relation = union
+                obligations.add(obligation)
+            if not quotient_is_supported:
+                break
+            used_axes = relation.source_axes_affecting_targets()
+            if used_axes is None:
+                quotient_is_supported = False
+                break
+            readiness_key_axis_set.update(used_axes)
+            merged_relations.append((producer, relation, frozenset(obligations)))
+
+        if not quotient_is_supported:
+            add_producer_key_events(
+                consumer_root=consumer_root,
+                consumer_site_id=consumer_site_id,
+                relations=[
+                    (producer, relation, frozenset((obligation,)))
+                    for producer, relation_points in sorted(
+                        producers.items(),
+                        key=lambda item: (
+                            item[0][0],
+                            -1 if item[0][1] is None else item[0][1],
+                        ),
+                    )
+                    for relation, obligation in relation_points
+                ],
+            )
+            continue
+
+        if any(
+            left_points & right_points
+            for left_index, (_left, _left_relation, left_points) in enumerate(
+                merged_relations
+            )
+            for _right, _right_relation, right_points in merged_relations[
+                left_index + 1 :
+            ]
+        ):
+            # The same memory obligation was represented at more than one
+            # producer site. These are alternative synchronization points,
+            # not independent arrivals to one joined event.
+            add_producer_key_events(
+                consumer_root=consumer_root,
+                consumer_site_id=consumer_site_id,
+                relations=merged_relations,
+            )
+            continue
+
+        readiness_key_axes = tuple(
+            axis
+            for axis in consumer_domain.axis_order
+            if axis in readiness_key_axis_set
+        )
+        consumer_counts = consumer_domain.axis_counts
+        consumer_blocks = consumer_domain.block_sizes
+        readiness_key_domain = CoordinateDomain(
+            axis_order=readiness_key_axes,
+            axis_counts_items=tuple(
+                (axis, consumer_counts[axis]) for axis in readiness_key_axes
+            ),
+            block_sizes_items=tuple(
+                (axis, consumer_blocks[axis])
+                for axis in readiness_key_axes
+                if axis in consumer_blocks
+            ),
+            kind="event",
+        )
+        keys_by_consumer = CoordinateRelation.projection(
+            consumer_domain, readiness_key_domain
+        )
+        if keys_by_consumer is None:
+            add_producer_key_events(
+                consumer_root=consumer_root,
+                consumer_site_id=consumer_site_id,
+                relations=merged_relations,
+            )
+            continue
+        event_producers: list[ReadinessProducer] = []
+        covered_obligations: set[DependencyObligation] = set()
+        for producer, relation, relation_points in merged_relations:
+            producer_root, producer_site_id, _producer_domain = producer
+            producers_by_key = relation.factor_through(keys_by_consumer)
+            if producers_by_key is None:
+                break
+            event_producers.append(
+                ReadinessProducer(
+                    producer_root=producer_root,
+                    producer_site_id=producer_site_id,
+                    producers_by_key=producers_by_key,
+                )
+            )
+            covered_obligations.update(relation_points)
+        else:
+            if not record_readiness_event(
+                readiness_key_domain=readiness_key_domain,
+                producers=tuple(event_producers),
+                consumers=(
+                    ReadinessConsumer(
+                        consumer_root=consumer_root,
+                        consumer_site_id=consumer_site_id,
+                        keys_by_consumer=keys_by_consumer,
+                        covered_obligations=frozenset(covered_obligations),
+                    ),
+                ),
+                require_counter_lowering=True,
+            ):
+                add_producer_key_events(
+                    consumer_root=consumer_root,
+                    consumer_site_id=consumer_site_id,
+                    relations=merged_relations,
+                )
+            continue
+
+        if len(event_producers) != len(merged_relations):
+            add_producer_key_events(
+                consumer_root=consumer_root,
+                consumer_site_id=consumer_site_id,
+                relations=merged_relations,
+            )
+            continue
+
+    failed_consumers_by_producer: dict[int, dict[int, set[DependencyObligation]]] = {}
+    for (
+        producer_root,
+        consumer_root,
+    ), obligations in all_obligations_by_pair.items():
+        remaining_obligations = obligations - represented_obligations
+        if not remaining_obligations:
+            continue
+        failed_consumers_by_producer.setdefault(producer_root, {})[consumer_root] = (
+            remaining_obligations
+        )
+    for producer_root, obligations_by_consumer in sorted(
+        failed_consumers_by_producer.items()
+    ):
+        readiness_key_domain = CoordinateDomain(
+            axis_order=(),
+            axis_counts_items=(),
+            kind="event",
+        )
+        producer_domain = root_domains[producer_root]
+        consumers: list[ReadinessConsumer] = []
+        for consumer_root, obligations in sorted(obligations_by_consumer.items()):
+            consumers.append(
+                ReadinessConsumer(
+                    consumer_root=consumer_root,
+                    consumer_site_id=None,
+                    keys_by_consumer=CoordinateRelation.total(
+                        root_domains[consumer_root],
+                        readiness_key_domain,
+                    ),
+                    covered_obligations=frozenset(obligations),
+                )
+            )
+        _record_readiness_event(
+            pending_events,
+            readiness_key_domain=readiness_key_domain,
+            producers=(
+                ReadinessProducer(
+                    producer_root=producer_root,
+                    producer_site_id=None,
+                    producers_by_key=CoordinateRelation.total(
+                        readiness_key_domain,
+                        producer_domain,
+                    ),
+                ),
+            ),
+            consumers=tuple(consumers),
+        )
+    return tuple(pending_events.values())
+
+
+def build_readiness_graph(
+    dependency_graph: TileDependencyGraph,
+    *,
+    root_task_orders: tuple[CoordinateRelation, ...],
+    site_domains: tuple[CoordinateDomain | None, ...],
+    publishable_site_ids: frozenset[int] | None = None,
+) -> ReadinessGraph:
+    """Bind the symbolic readiness DAG for one selected configuration."""
+    root_domains = tuple(task_order.target_domain for task_order in root_task_orders)
+    events = build_readiness_events(
+        dependency_graph,
+        root_domains=root_domains,
+        site_domains=site_domains,
+        publishable_site_ids=publishable_site_ids,
+    )
+    return ReadinessGraph(
+        root_task_orders=root_task_orders,
+        events=events,
+    )
+
+
+def derive_final_arrival_continuations(
+    readiness_graph: ReadinessGraph,
+    worker_schedule: WorkerSchedule,
+) -> tuple[FinalArrivalContinuation, ...]:
+    """Select complete one-task-per-readiness-key continuations."""
+    required_obligations_by_root: dict[int, set[DependencyObligation]] = {}
+    for event in readiness_graph.events:
+        for readiness_consumer in event.consumers:
+            if readiness_consumer.consumer_site_id is None:
+                required_obligations_by_root.setdefault(
+                    readiness_consumer.consumer_root, set()
+                ).update(readiness_consumer.covered_obligations)
+
+    candidates: list[
+        tuple[
+            int,
+            int,
+            int,
+            ReadinessEvent,
+            ReadinessConsumer,
+            tuple[tuple[int, CoordinateRelation], ...],
+        ]
+    ] = []
+    for event in readiness_graph.events:
+        if (
+            event.root_barrier_producer_root is not None
+            or len(event.consumers) != 1
+            or any(
+                readiness_producer.producer_site_id is not None
+                for readiness_producer in event.producers
+            )
+        ):
+            continue
+        if any(
+            not _supports_readiness_counter_lowering(readiness_producer)
+            for readiness_producer in event.producers
+        ):
+            continue
+        consumer_index = 0
+        readiness_consumer = event.consumers[consumer_index]
+        if readiness_consumer.consumer_site_id is not None:
+            continue
+        fan_in = _uniform_arrival_count(event.producers)
+        if fan_in is None or fan_in <= 0:
+            continue
+        converse_consumer = readiness_consumer.keys_by_consumer.converse()
+        if (
+            not readiness_consumer.covered_obligations.issuperset(
+                required_obligations_by_root.get(readiness_consumer.consumer_root, ())
+            )
+            or not readiness_consumer.keys_by_consumer.is_total_function()
+            or converse_consumer is None
+            or not converse_consumer.is_total_function()
+        ):
+            continue
+        producer_relations = _merge_relations_by_root(
+            tuple(
+                (readiness_producer.producer_root, publication)
+                for readiness_producer in event.producers
+                if (publication := readiness_producer.keys_by_producer) is not None
+            )
+        )
+        if producer_relations is None or len(producer_relations) != len(
+            {item.producer_root for item in event.producers}
+        ):
+            continue
+
+        candidates.append(
+            (
+                readiness_consumer.consumer_root,
+                event.event_id,
+                consumer_index,
+                event,
+                readiness_consumer,
+                producer_relations,
+            )
+        )
+
+    conflicting_candidates: set[tuple[int, int]] = set()
+    candidates_by_consumer_root: dict[int, list[tuple[int, int]]] = {}
+    for consumer_root, event_id, consumer_index, *_rest in candidates:
+        candidates_by_consumer_root.setdefault(consumer_root, []).append(
+            (event_id, consumer_index)
+        )
+    for root_candidates in candidates_by_consumer_root.values():
+        if len(root_candidates) > 1:
+            conflicting_candidates.update(root_candidates)
+    candidates_by_producer_root: dict[
+        int,
+        list[tuple[int, CoordinateRelation]],
+    ] = {}
+    for candidate_index, candidate in enumerate(candidates):
+        for producer_root, relation in candidate[-1]:
+            candidates_by_producer_root.setdefault(producer_root, []).append(
+                (candidate_index, relation)
+            )
+    for root_candidates in candidates_by_producer_root.values():
+        for (left_index, left), (right_index, right) in itertools.combinations(
+            root_candidates, 2
+        ):
+            if not left.has_disjoint_source_support(right):
+                conflicting_candidates.update(
+                    (
+                        (candidates[left_index][1], candidates[left_index][2]),
+                        (candidates[right_index][1], candidates[right_index][2]),
+                    )
+                )
+
+    possible_workers_by_root = {
+        root: worker_schedule.workers_for_root(root)
+        for root in range(len(readiness_graph.root_domains))
+    }
+
+    result: list[FinalArrivalContinuation] = []
+    for (
+        _consumer_root,
+        event_id,
+        consumer_index,
+        event,
+        readiness_consumer,
+        _producer_relations,
+    ) in sorted(candidates, key=operator.itemgetter(slice(3))):
+        if (event_id, consumer_index) in conflicting_candidates:
+            continue
+        possible_workers = frozenset(
+            worker
+            for readiness_producer in event.producers
+            for worker in possible_workers_by_root[readiness_producer.producer_root]
+        )
+        if not possible_workers:
+            continue
+        possible_workers_by_root[readiness_consumer.consumer_root] = possible_workers
+        result.append(
+            FinalArrivalContinuation(
+                event_id=event_id,
+                consumer_index=consumer_index,
+            )
+        )
+    return tuple(result)
+
+
+def order_continuation_producers_by_readiness_key(
+    readiness_graph: ReadinessGraph,
+    worker_schedule: WorkerSchedule,
+    continuations: tuple[FinalArrivalContinuation, ...],
+) -> WorkerSchedule:
+    """Order eligible static producers by readiness key.
+
+    Readiness-key-major ordering completes one readiness key at a time so
+    final-arrival work becomes ready as early as possible. It is legal only
+    when one producer compactly enumerates a complete static task family; all
+    other families keep their existing task order.
+    """
+    continuation_roots = {
+        readiness_graph.event(continuation.event_id)
+        .consumers[continuation.consumer_index]
+        .consumer_root
+        for continuation in continuations
+    }
+    replacement_by_root: dict[int, tuple[WorkerScheduleSegment, ...]] = {}
+
+    for continuation in continuations:
+        event = readiness_graph.event(continuation.event_id)
+        if len(event.producers) != 1:
+            continue
+        readiness_producer = event.producers[0]
+        if readiness_producer.producer_site_id is not None:
+            continue
+        root = readiness_producer.producer_root
+        if root in continuation_roots or root in replacement_by_root:
+            continue
+        task_domain = readiness_graph.root_domains[root]
+        task_order = readiness_producer.producers_by_key.enumerate_targets_by_source()
+        if (
+            task_order is None
+            or task_order.target_domain != task_domain
+            or task_order.source_domain.size != task_domain.size
+        ):
+            continue
+
+        schedule_interval = worker_schedule.contiguous_global_interval(root)
+        if (
+            schedule_interval is None
+            or schedule_interval[1] - schedule_interval[0] != task_domain.size
+        ):
+            continue
+        replacement_by_root[root] = (
+            WorkerScheduleSegment(
+                root=root,
+                task_order=task_order,
+                worker_begin=0,
+                worker_count=worker_schedule.worker_count,
+                dispatch_offset=schedule_interval[0],
+            ),
+        )
+
+    if not replacement_by_root:
+        return worker_schedule
+    segments: list[WorkerScheduleSegment] = []
+    inserted_roots: set[int] = set()
+    for segment in worker_schedule.segments:
+        replacement = replacement_by_root.get(segment.root)
+        if replacement is None:
+            segments.append(segment)
+        elif segment.root not in inserted_roots:
+            segments.extend(replacement)
+            inserted_roots.add(segment.root)
+    return WorkerSchedule(worker_schedule.worker_count, tuple(segments))
+
+
+def build_static_pipeline_plan(
+    *,
+    dependency_graph: TileDependencyGraph,
+    root_task_orders: tuple[CoordinateRelation, ...],
+    site_domains: tuple[CoordinateDomain | None, ...],
+    worker_count: int,
+    publishable_site_ids: frozenset[int] | None = None,
+) -> StaticPipelinePlan:
+    """Derive all generic readiness strategies without inspecting root bodies."""
+    readiness_graph = build_readiness_graph(
+        dependency_graph,
+        root_task_orders=root_task_orders,
+        site_domains=site_domains,
+        publishable_site_ids=publishable_site_ids,
+    )
+    try:
+        (
+            worker_schedule,
+            continuations,
+            nested_loop_counters,
+            readiness_graph,
+        ) = build_worker_schedule(
+            readiness_graph,
+            worker_count=worker_count,
+        )
+    except ValueError as error:
+        raise exc.InvalidConfig(
+            f"the num_sm_multiplier grid of {worker_count} workers does not "
+            "admit a progress-safe cross-loop schedule"
+        ) from error
+
+    nested_loop_obligations = frozenset(
+        obligation
+        for plan in nested_loop_counters
+        for readiness_consumer in plan.consumers
+        for obligation in readiness_consumer.covered_obligations
+    )
+    readiness_counters = (
+        *choose_readiness_counters(
+            readiness_graph,
+            continuations,
+            excluded_obligations=nested_loop_obligations,
+        ),
+        *nested_loop_counters,
+    )
+    covered_obligations = frozenset(
+        obligation
+        for counter_plan in readiness_counters
+        for readiness_consumer in counter_plan.consumers
+        for obligation in readiness_consumer.covered_obligations
+    )
+    # Recompute coverage from the mechanisms that will actually be emitted.
+    # Dependency analysis may prove a finer relation than the selected emitter
+    # can materialize. Such a relation must monotonically coarsen to root
+    # barrier; retaining a task-ready classification without an emitter
+    # would remove the dependency entirely.
+    root_barrier_edges = _select_root_barrier_edges(
+        dependency_graph=dependency_graph,
+        covered_obligations=covered_obligations,
+    )
+    root_order_edges = set(root_barrier_edges)
+    retained_readiness_counters: list[ReadinessCounterPlan] = []
+    for counter_plan in readiness_counters:
+        retained_consumer_indices = tuple(
+            consumer_index
+            for consumer_index, readiness_consumer in enumerate(counter_plan.consumers)
+            if consumer_index == counter_plan.continuation_consumer_index
+            or not all(
+                _is_ordered_by_root_barrier(
+                    readiness_producer.producer_root,
+                    readiness_consumer.consumer_root,
+                    root_order_edges,
+                )
+                for readiness_producer in counter_plan.producers
+            )
+        )
+        if not retained_consumer_indices:
+            continue
+        retained_readiness_counters.append(
+            dataclasses.replace(
+                counter_plan,
+                consumers=tuple(
+                    counter_plan.consumers[index] for index in retained_consumer_indices
+                ),
+                continuation_consumer_index=(
+                    retained_consumer_indices.index(
+                        counter_plan.continuation_consumer_index
+                    )
+                    if counter_plan.continuation_consumer_index is not None
+                    else None
+                ),
+            )
+        )
+    readiness_counters = tuple(retained_readiness_counters)
+    covered_obligations = frozenset(
+        obligation
+        for counter_plan in readiness_counters
+        for readiness_consumer in counter_plan.consumers
+        for obligation in readiness_consumer.covered_obligations
+    )
+    _validate_schedule_coverage(
+        dependency_graph=dependency_graph,
+        covered_obligations=covered_obligations,
+        root_barrier_edges=root_barrier_edges,
+    )
+    return StaticPipelinePlan(
+        worker_schedule=worker_schedule,
+        readiness_counters=readiness_counters,
+        root_barrier_edges=root_barrier_edges,
+    )
+
+
+def _validate_schedule_coverage(
+    *,
+    dependency_graph: TileDependencyGraph,
+    covered_obligations: frozenset[DependencyObligation],
+    root_barrier_edges: frozenset[tuple[int, int]],
+) -> None:
+    """Verify that every dependence has an emitted synchronization path."""
+    root_order_edges = set(root_barrier_edges)
+    for dependency in dependency_graph.edges:
+        pair = (dependency.producer_root, dependency.consumer_root)
+        if _is_ordered_by_root_barrier(*pair, root_order_edges):
+            continue
+        uncovered = tuple(
+            obligation
+            for access_dependency in dependency.access_dependencies
+            for obligation in dependency_graph.dependency_obligations(access_dependency)
+            if obligation not in covered_obligations
+        )
+        if not uncovered:
+            continue
+        raise exc.CrossLoopSchedulingError(
+            f"{dependency.producer_root}->{dependency.consumer_root} through "
+            f"allocations {sorted(dependency.tensor_names)!r} has no cross-loop "
+            f"synchronization path for dependencies {uncovered!r}"
+        )
+
+
+def _select_root_barrier_edges(
+    *,
+    dependency_graph: TileDependencyGraph,
+    covered_obligations: frozenset[DependencyObligation],
+) -> frozenset[tuple[int, int]]:
+    """Choose the minimal source-ordered root-barrier fallback edges."""
+    selected_edges: set[tuple[int, int]] = set()
+    ordered_root_edges: set[tuple[int, int]] = set()
+    for dependency in sorted(
+        dependency_graph.edges,
+        key=lambda edge: (
+            edge.consumer_root - edge.producer_root,
+            edge.producer_root,
+            edge.consumer_root,
+        ),
+    ):
+        pair = (dependency.producer_root, dependency.consumer_root)
+        if all(
+            dependency_graph.dependency_obligations(access_dependency)
+            <= covered_obligations
+            for access_dependency in dependency.access_dependencies
+        ):
+            continue
+        if _is_ordered_by_root_barrier(*pair, ordered_root_edges):
+            continue
+        selected_edges.add(pair)
+        ordered_root_edges.add(pair)
+    return frozenset(selected_edges)
+
+
+def _is_ordered_by_root_barrier(
+    producer: int,
+    consumer: int,
+    edges: set[tuple[int, int]],
+) -> bool:
+    """Return whether whole-root ordering transitively covers one pair."""
+    pending = [producer]
+    visited: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if current == consumer:
+            return True
+        if current in visited:
+            continue
+        visited.add(current)
+        pending.extend(target for source, target in edges if source == current)
+    return False

--- a/test/test_cross_loop_scheduler.py
+++ b/test/test_cross_loop_scheduler.py
@@ -1,0 +1,3011 @@
+from __future__ import annotations
+
+import dataclasses
+import itertools
+from typing import Literal
+from unittest import mock
+
+import sympy
+
+from helion._compiler.cross_loop_scheduler import FinalArrivalContinuation
+from helion._compiler.cross_loop_scheduler import ReadinessConsumer
+from helion._compiler.cross_loop_scheduler import ReadinessCounterPlan
+from helion._compiler.cross_loop_scheduler import ReadinessEvent
+from helion._compiler.cross_loop_scheduler import ReadinessGraph
+from helion._compiler.cross_loop_scheduler import ReadinessProducer
+from helion._compiler.cross_loop_scheduler import WorkerSchedule
+from helion._compiler.cross_loop_scheduler import WorkerScheduleSegment
+from helion._compiler.cross_loop_scheduler import _select_root_barrier_edges
+from helion._compiler.cross_loop_scheduler import (
+    build_baseline_worker_schedule as _build_baseline_worker_schedule,
+)
+from helion._compiler.cross_loop_scheduler import (
+    build_readiness_events as _build_readiness_events,
+)
+from helion._compiler.cross_loop_scheduler import (
+    build_readiness_graph as _build_readiness_graph,
+)
+from helion._compiler.cross_loop_scheduler import (
+    build_static_pipeline_plan as _build_static_pipeline_plan,
+)
+from helion._compiler.cross_loop_scheduler import choose_final_arrival_continuations
+from helion._compiler.cross_loop_scheduler import choose_readiness_counters
+from helion._compiler.cross_loop_scheduler import derive_final_arrival_continuations
+from helion._compiler.cross_loop_scheduler import (
+    order_continuation_producers_by_readiness_key,
+)
+from helion._compiler.cross_loop_scheduler import place_nested_loop_consumers
+from helion._compiler.tile_dependency import CoordinateDomain
+from helion._compiler.tile_dependency import CoordinateRelation
+from helion._compiler.tile_dependency import ExecutionSite
+from helion._compiler.tile_dependency import TileAccess
+from helion._compiler.tile_dependency import _CoordinateRelationPiece
+from helion._compiler.tile_dependency import (
+    build_tile_dependency_graph as _build_tile_dependency_graph,
+)
+from helion._compiler.tile_dependency import coordinate_axis_symbol
+from helion._compiler.tile_dependency import instantiate_coordinate_domains
+from helion._compiler.tile_dependency import instantiate_symbolic_dependencies
+from helion._compiler.tile_dependency import pid_task_order
+from helion._testing import TestCase
+
+
+def readiness_consumer_source_order(
+    readiness_graph: ReadinessGraph,
+    readiness_consumer: ReadinessConsumer,
+) -> tuple[int, ...]:
+    """Return one consumer's exhaustive source order for test materialization."""
+    root_axes = readiness_graph.root_domains[
+        readiness_consumer.consumer_root
+    ].axis_order
+    if readiness_consumer.consumer_site_id is None:
+        return root_axes
+    nested_axes = tuple(
+        axis
+        for axis in readiness_consumer.keys_by_consumer.source_domain.axis_order
+        if axis not in root_axes
+    )
+    return (*nested_axes, *root_axes)
+
+
+def required_keys_by_task(
+    readiness_graph: ReadinessGraph,
+    readiness_consumer: ReadinessConsumer,
+) -> CoordinateRelation | None:
+    """Project a test readiness consumer onto its owning root tasks."""
+    root_domain = readiness_graph.root_domains[readiness_consumer.consumer_root]
+    if readiness_consumer.consumer_site_id is None:
+        if readiness_consumer.keys_by_consumer.source_domain != root_domain:
+            raise ValueError("root readiness consumer has the wrong source domain")
+        return readiness_consumer.keys_by_consumer
+    return readiness_consumer.keys_by_consumer.project_source(root_domain)
+
+
+def segment_task_at_index(
+    segment: WorkerScheduleSegment,
+    task_order_index: int,
+) -> int:
+    """Materialize one task-order index for small scheduler tests."""
+    if not 0 <= task_order_index < segment.task_count:
+        raise IndexError(task_order_index)
+    source_coordinates = segment.task_order.source_domain.coordinates(task_order_index)
+    targets = segment.task_order.target_coordinates(source_coordinates)
+    if len(targets) != 1:
+        raise AssertionError("task-order index does not map to one logical task")
+    return segment.task_order.target_domain.index(
+        dict(
+            zip(
+                segment.task_order.target_domain.axis_order,
+                next(iter(targets)),
+                strict=True,
+            )
+        )
+    )
+
+
+def segment_placement(
+    segment: WorkerScheduleSegment,
+    task: int,
+) -> tuple[int, int] | None:
+    """Materialize one task's placement for small scheduler tests."""
+    converse = segment.task_order.converse()
+    task_order_indices = (
+        converse.targets(task)
+        if converse is not None
+        else frozenset(
+            task_order_index
+            for task_order_index in range(segment.task_count)
+            if segment_task_at_index(segment, task_order_index) == task
+        )
+    )
+    if len(task_order_indices) > 1:
+        raise AssertionError("symbolic schedule maps one task more than once")
+    if not task_order_indices:
+        return None
+    dispatch_index = segment.dispatch_index(next(iter(task_order_indices)))
+    return (
+        segment.worker_begin + dispatch_index % segment.worker_count,
+        dispatch_index // segment.worker_count,
+    )
+
+
+def segment_task_at(
+    segment: WorkerScheduleSegment,
+    worker: int,
+    worker_step: int,
+) -> int | None:
+    """Materialize the task at one segment worker step for small tests."""
+    worker_offset = worker - segment.worker_begin
+    if not 0 <= worker_offset < segment.worker_count or worker_step < 0:
+        return None
+    task_order_index = (
+        worker_step * segment.worker_count + worker_offset - segment.dispatch_offset
+    )
+    if not 0 <= task_order_index < segment.task_count:
+        return None
+    return segment_task_at_index(segment, task_order_index)
+
+
+def placement(
+    schedule: WorkerSchedule,
+    root: int,
+    task: int,
+) -> tuple[int, int] | None:
+    """Materialize one task's placement for small scheduler tests."""
+    placements = tuple(
+        result
+        for segment in schedule.segments_for_root(root)
+        if (result := segment_placement(segment, task)) is not None
+    )
+    if len(placements) > 1:
+        raise AssertionError(f"task ({root}, {task}) has multiple placements")
+    return placements[0] if placements else None
+
+
+def task_at(
+    schedule: WorkerSchedule,
+    worker: int,
+    worker_step: int,
+) -> tuple[int, int] | None:
+    """Materialize the task at one worker step for small tests."""
+    tasks = tuple(
+        (segment.root, task)
+        for segment in schedule.segments
+        if (task := segment_task_at(segment, worker, worker_step)) is not None
+    )
+    if len(tasks) > 1:
+        raise AssertionError(f"worker {worker} step {worker_step} has multiple tasks")
+    return tasks[0] if tasks else None
+
+
+def task_order(schedule: WorkerSchedule, root: int) -> tuple[int, ...]:
+    """Materialize one root's order for small scheduler tests."""
+    placed_tasks: list[tuple[int, int]] = []
+    for segment in schedule.segments_for_root(root):
+        for task_order_index in range(segment.task_count):
+            dispatch_index = segment.dispatch_index(task_order_index)
+            task = segment_task_at_index(segment, task_order_index)
+            placed_tasks.append((dispatch_index, task))
+    placed_tasks.sort()
+    if any(
+        left_offset == right_offset
+        for (left_offset, _), (right_offset, _) in itertools.pairwise(placed_tasks)
+    ):
+        raise AssertionError(f"root {root} has overlapping schedule segments")
+    return tuple(task for _offset, task in placed_tasks)
+
+
+def _materialized_producer_tasks_by_key(
+    readiness_graph: ReadinessGraph,
+    event_id: int,
+) -> tuple[frozenset[tuple[int, int]], ...]:
+    event = readiness_graph.event(event_id)
+    result: list[set[tuple[int, int]]] = [
+        set() for _ in range(event.readiness_key_count)
+    ]
+    for readiness_producer in event.producers:
+        key_to_tasks = readiness_producer.producers_by_key.project_target(
+            readiness_graph.root_domains[readiness_producer.producer_root]
+        )
+        if key_to_tasks is None:
+            raise ValueError("readiness producer cannot be projected onto root tasks")
+        tasks_by_key = key_to_tasks.materialize()
+        for readiness_key, tasks in enumerate(tasks_by_key):
+            result[readiness_key].update(
+                (readiness_producer.producer_root, task) for task in tasks
+            )
+    return tuple(frozenset(tasks) for tasks in result)
+
+
+def _continuation_producers(
+    readiness_graph: ReadinessGraph,
+    continuations: tuple[FinalArrivalContinuation, ...],
+) -> dict[tuple[int, int], frozenset[tuple[int, int]]]:
+    result: dict[tuple[int, int], frozenset[tuple[int, int]]] = {}
+    for continuation in continuations:
+        event = readiness_graph.event(continuation.event_id)
+        readiness_consumer = event.consumers[continuation.consumer_index]
+        producers_by_key = _materialized_producer_tasks_by_key(
+            readiness_graph,
+            continuation.event_id,
+        )
+        for consumer_task, required_keys in enumerate(
+            readiness_consumer.keys_by_consumer.materialize(
+                source_axis_order=readiness_consumer_source_order(
+                    readiness_graph, readiness_consumer
+                )
+            )
+        ):
+            if len(required_keys) != 1:
+                raise ValueError(
+                    "a final-arrival continuation requires one readiness key per task"
+                )
+            readiness_key = next(iter(required_keys))
+            task = (readiness_consumer.consumer_root, consumer_task)
+            if task in result:
+                raise ValueError(
+                    f"task {task} has multiple final-arrival continuations"
+                )
+            result[task] = producers_by_key[readiness_key]
+    return result
+
+
+def _static_ancestors(
+    task: tuple[int, int],
+    *,
+    worker_schedule: WorkerSchedule,
+    continuation_producers: dict[tuple[int, int], frozenset[tuple[int, int]]],
+    cache: dict[tuple[int, int], frozenset[tuple[int, int]]],
+    visiting: frozenset[tuple[int, int]] = frozenset(),
+) -> frozenset[tuple[int, int]]:
+    if task in cache:
+        return cache[task]
+    if placement(worker_schedule, *task) is not None:
+        result = frozenset((task,))
+    elif task in visiting:
+        raise ValueError("final-arrival continuation graph contains a cycle")
+    elif (producer_tasks := continuation_producers.get(task)) is None:
+        result = frozenset()
+    else:
+        result = frozenset(
+            ancestor
+            for producer_task in producer_tasks
+            for ancestor in _static_ancestors(
+                producer_task,
+                worker_schedule=worker_schedule,
+                continuation_producers=continuation_producers,
+                cache=cache,
+                visiting=visiting | frozenset((task,)),
+            )
+        )
+    cache[task] = result
+    return result
+
+
+def validate_worker_schedule(
+    readiness_graph: ReadinessGraph,
+    worker_schedule: WorkerSchedule,
+    continuations: tuple[FinalArrivalContinuation, ...] = (),
+) -> None:
+    """Exhaustively validate small schedules without entering production."""
+    task_nodes = {
+        (root, task)
+        for root, domain in enumerate(readiness_graph.root_domains)
+        for task in range(domain.size)
+    }
+    continuation_producers = _continuation_producers(readiness_graph, continuations)
+    static_tasks = task_nodes - continuation_producers.keys()
+    tasks_by_worker: list[list[tuple[int, tuple[int, int]]]] = [
+        [] for _ in range(worker_schedule.worker_count)
+    ]
+    for root, task in sorted(task_nodes):
+        task_placement = placement(worker_schedule, root, task)
+        if (root, task) in continuation_producers:
+            if task_placement is not None:
+                raise ValueError(
+                    f"locally executed task ({root}, {task}) also has a static placement"
+                )
+            continue
+        if task_placement is None:
+            raise ValueError(f"task ({root}, {task}) has no static placement")
+        worker, worker_step = task_placement
+        tasks_by_worker[worker].append((worker_step, (root, task)))
+
+    graph_nodes = {("task", root, task) for root, task in static_tasks}
+    successors: dict[tuple[str, int, int], set[tuple[str, int, int]]] = {
+        node: set() for node in graph_nodes
+    }
+    indegree = dict.fromkeys(graph_nodes, 0)
+    static_ancestors_cache: dict[
+        tuple[int, int],
+        frozenset[tuple[int, int]],
+    ] = {}
+
+    def add_edge(
+        producer: tuple[str, int, int],
+        consumer: tuple[str, int, int],
+    ) -> None:
+        if producer not in successors:
+            successors[producer] = set()
+            indegree[producer] = 0
+        if consumer not in successors:
+            successors[consumer] = set()
+            indegree[consumer] = 0
+        if producer == consumer or consumer in successors[producer]:
+            return
+        successors[producer].add(consumer)
+        indegree[consumer] += 1
+
+    for worker_tasks in tasks_by_worker:
+        worker_tasks.sort()
+        if any(
+            left_worker_step == right_worker_step
+            for (left_worker_step, _), (right_worker_step, _) in itertools.pairwise(
+                worker_tasks
+            )
+        ):
+            raise ValueError("multiple tasks occupy one worker step")
+        for (_, producer), (_, consumer) in itertools.pairwise(worker_tasks):
+            add_edge(("task", *producer), ("task", *consumer))
+
+    for event in readiness_graph.events:
+        producers_by_key = _materialized_producer_tasks_by_key(
+            readiness_graph,
+            event.event_id,
+        )
+        consumers_by_key: list[set[tuple[int, int]]] = [
+            set() for _ in range(event.readiness_key_count)
+        ]
+        for readiness_consumer in event.consumers:
+            keys_by_task = required_keys_by_task(readiness_graph, readiness_consumer)
+            if keys_by_task is None:
+                raise ValueError(
+                    "readiness consumer cannot be projected onto root tasks"
+                )
+            for consumer_task, required_keys in enumerate(keys_by_task.materialize()):
+                consumer = (readiness_consumer.consumer_root, consumer_task)
+                if consumer in continuation_producers:
+                    continue
+                for readiness_key in required_keys:
+                    consumers_by_key[readiness_key].add(consumer)
+        for readiness_key, consumers in enumerate(consumers_by_key):
+            if not consumers:
+                continue
+            event_node = ("event", event.event_id, readiness_key)
+            for producer in producers_by_key[readiness_key]:
+                ancestors = _static_ancestors(
+                    producer,
+                    worker_schedule=worker_schedule,
+                    continuation_producers=continuation_producers,
+                    cache=static_ancestors_cache,
+                )
+                if not ancestors:
+                    raise ValueError(f"task {producer} has no executor")
+                for ancestor in ancestors:
+                    add_edge(("task", *ancestor), event_node)
+            for consumer in consumers:
+                add_edge(event_node, ("task", *consumer))
+
+    ready = [task for task, degree in indegree.items() if degree == 0]
+    visited = 0
+    while ready:
+        task = ready.pop()
+        visited += 1
+        for successor in successors[task]:
+            indegree[successor] -= 1
+            if indegree[successor] == 0:
+                ready.append(successor)
+    if visited != len(indegree):
+        blocked = sorted(node for node, degree in indegree.items() if degree)
+        raise ValueError(
+            f"worker schedule contains a dependency/order cycle involving {blocked[:8]}"
+        )
+
+
+def _domain(
+    *axis_specs: tuple[int, ...],
+    kind: Literal[
+        "site", "allocation", "event", "task_order", "worker", "value"
+    ] = "site",
+    identity: int | None = None,
+) -> CoordinateDomain:
+    return CoordinateDomain(
+        tuple(axis for axis, *_ in axis_specs),
+        tuple((axis, count) for axis, count, *_ in axis_specs),
+        tuple(
+            (axis_spec[0], axis_spec[2])
+            for axis_spec in axis_specs
+            if len(axis_spec) == 3
+        ),
+        kind=kind,
+        identity=identity,
+    )
+
+
+def _full_point_map(
+    source: CoordinateDomain,
+    target: CoordinateDomain,
+    *target_coordinates: sympy.Expr,
+) -> CoordinateRelation:
+    return CoordinateRelation.point_map(
+        source,
+        target,
+        (
+            (
+                tuple(
+                    (axis, 0, source.axis_counts[axis], 1) for axis in source.axis_order
+                ),
+                target_coordinates,
+            ),
+        ),
+    )
+
+
+def _axis_geometry(
+    root_domains: tuple[CoordinateDomain, ...],
+) -> dict[int, tuple[int, int]]:
+    return {
+        axis: (domain.axis_counts[axis], domain.block_sizes[axis])
+        for domain in root_domains
+        for axis in domain.axis_order
+    }
+
+
+def _identify_root_domains(
+    root_domains: tuple[CoordinateDomain, ...],
+) -> tuple[CoordinateDomain, ...]:
+    return tuple(
+        dataclasses.replace(domain, identity=root)
+        for root, domain in enumerate(root_domains)
+    )
+
+
+def _configured_domains(
+    graph,
+    axis_geometry: dict[int, tuple[int, int]],
+) -> tuple[tuple[CoordinateDomain, ...], tuple[CoordinateDomain | None, ...]]:
+    configured_roots, site_domains = instantiate_coordinate_domains(
+        graph,
+        axis_geometry=axis_geometry,
+    )
+    assert all(domain is not None for domain in configured_roots)
+    return (
+        tuple(domain for domain in configured_roots if domain is not None),
+        site_domains,
+    )
+
+
+def _default_root_task_orders(
+    root_domains: tuple[CoordinateDomain, ...],
+    pid_axis_orders: tuple[tuple[int, ...], ...] | None = None,
+) -> tuple[CoordinateRelation, ...]:
+    if pid_axis_orders is None:
+        pid_axis_orders = tuple(domain.axis_order for domain in root_domains)
+    return tuple(
+        itertools.starmap(
+            pid_task_order,
+            zip(
+                root_domains,
+                pid_axis_orders,
+                strict=True,
+            ),
+        )
+    )
+
+
+def _readiness_graph(
+    root_domains: tuple[CoordinateDomain, ...],
+    *events: ReadinessEvent,
+) -> ReadinessGraph:
+    return ReadinessGraph(
+        root_task_orders=_default_root_task_orders(root_domains),
+        events=events,
+    )
+
+
+def _segment(
+    root: int,
+    task_order: CoordinateRelation,
+    *,
+    workers: tuple[int, int],
+    dispatch_offset: int,
+) -> WorkerScheduleSegment:
+    return WorkerScheduleSegment(
+        root=root,
+        task_order=task_order,
+        worker_begin=workers[0],
+        worker_count=workers[1],
+        dispatch_offset=dispatch_offset,
+    )
+
+
+def _schedule(worker_count: int, *segments: WorkerScheduleSegment) -> WorkerSchedule:
+    return WorkerSchedule(worker_count=worker_count, segments=segments)
+
+
+def _access(
+    *,
+    root: int,
+    allocation_id: int = 0,
+    kind: Literal["load", "store"],
+    shape: tuple[int, ...] = (128,),
+    strides: tuple[int, ...] | None = None,
+    block_ids: tuple[int | None, ...] = (0,),
+    scales: tuple[int, ...] | None = None,
+    offsets: tuple[int | None, ...] | None = None,
+    scalar: tuple[bool, ...] | None = None,
+    full_slice: tuple[bool, ...] | None = None,
+    static_extents: tuple[int | None, ...] | None = None,
+    masked: bool = False,
+    tensor_name: str = "tmp",
+    storage_offset: int = 0,
+    layout_is_static: bool = True,
+) -> TileAccess:
+    if strides is None:
+        stride = 1
+        reversed_strides = []
+        for extent in reversed(shape):
+            reversed_strides.append(stride)
+            stride *= extent
+        strides = tuple(reversed(reversed_strides))
+    if scales is None:
+        scales = (1,) * len(block_ids)
+    if offsets is None:
+        offsets = (0,) * len(block_ids)
+    return TileAccess(
+        access_id=-1,
+        memory_op_index=-1,
+        graph_id=root,
+        root=root,
+        allocation_id=allocation_id,
+        kind=kind,
+        tensor_name=tensor_name,
+        tensor_shape=shape,
+        tensor_strides=strides,
+        storage_offset=storage_offset,
+        subscript_dims=tuple(range(len(block_ids))),
+        subscript_affine_block_ids=block_ids,
+        subscript_index_scales=scales,
+        subscript_offsets=offsets,
+        subscript_is_scalar=scalar or tuple(False for _ in block_ids),
+        has_explicit_mask=masked,
+        subscript_is_full_slice=full_slice or tuple(False for _ in block_ids),
+        subscript_static_extents=static_extents or (),
+        layout_is_static=layout_is_static,
+    )
+
+
+def _dependency_graph(
+    root_axes: list[list[int]],
+    *accesses: TileAccess,
+):
+    return _build_tile_dependency_graph(
+        tuple(
+            dataclasses.replace(
+                access,
+                access_id=access_id,
+                memory_op_index=access_id,
+            )
+            for access_id, access in enumerate(accesses)
+        ),
+        root_axes,
+    )
+
+
+def _one_dimensional_domains(
+    *,
+    producer_count: int = 8,
+    consumer_count: int = 8,
+    producer_block: int = 16,
+    consumer_block: int = 16,
+) -> tuple[CoordinateDomain, CoordinateDomain]:
+    return (
+        _domain((10, producer_count, producer_block)),
+        _domain((20, consumer_count, consumer_block)),
+    )
+
+
+def _configured_readiness_graph(
+    graph,
+    root_domains: tuple[CoordinateDomain, ...],
+    *,
+    axis_geometry: dict[int, tuple[int, int]] | None = None,
+    pid_axis_orders: tuple[tuple[int, ...], ...] | None = None,
+    publishable_site_ids: frozenset[int] | None = None,
+) -> ReadinessGraph:
+    if axis_geometry is None:
+        axis_geometry = _axis_geometry(root_domains)
+    configured_root_domains, site_domains = _configured_domains(graph, axis_geometry)
+    return _build_readiness_graph(
+        graph,
+        root_task_orders=_default_root_task_orders(
+            configured_root_domains,
+            pid_axis_orders,
+        ),
+        site_domains=site_domains,
+        publishable_site_ids=publishable_site_ids,
+    )
+
+
+def _configured_readiness_events(
+    graph,
+    *,
+    axis_geometry: dict[int, tuple[int, int]],
+    publishable_site_ids: frozenset[int] | None = None,
+):
+    root_domains, site_domains = _configured_domains(graph, axis_geometry)
+    return _build_readiness_events(
+        graph,
+        root_domains=root_domains,
+        site_domains=site_domains,
+        publishable_site_ids=publishable_site_ids,
+    )
+
+
+def _baseline_worker_schedule(
+    root_domains: tuple[CoordinateDomain, ...],
+    worker_count: int,
+    *,
+    root_task_orders: tuple[CoordinateRelation, ...] | None = None,
+    pid_axis_orders: tuple[tuple[int, ...], ...] | None = None,
+) -> WorkerSchedule:
+    root_domains = _identify_root_domains(root_domains)
+    if root_task_orders is None:
+        root_task_orders = _default_root_task_orders(
+            root_domains,
+            pid_axis_orders,
+        )
+    return _build_baseline_worker_schedule(
+        root_domains,
+        root_task_orders,
+        worker_count,
+    )
+
+
+def _configured_static_pipeline_plan(
+    *,
+    dependency_graph,
+    root_domains: tuple[CoordinateDomain, ...],
+    axis_geometry: dict[int, tuple[int, int]],
+    root_task_orders: tuple[CoordinateRelation, ...] | None = None,
+    pid_axis_orders: tuple[tuple[int, ...], ...] | None = None,
+    **kwargs,
+):
+    root_domains = _identify_root_domains(root_domains)
+    if root_task_orders is None:
+        root_task_orders = _default_root_task_orders(
+            root_domains,
+            pid_axis_orders,
+        )
+    site_domains = instantiate_coordinate_domains(
+        dependency_graph,
+        axis_geometry=axis_geometry,
+    )[1]
+    return _build_static_pipeline_plan(
+        dependency_graph=dependency_graph,
+        root_task_orders=root_task_orders,
+        site_domains=site_domains,
+        **kwargs,
+    )
+
+
+def _one_dimensional_task_range(
+    domain: CoordinateDomain,
+    begin: int,
+    count: int,
+) -> CoordinateRelation:
+    (axis,) = domain.axis_order
+    task_order_domain = _domain((axis, count), kind="task_order")
+    return _full_point_map(
+        task_order_domain, domain, coordinate_axis_symbol(axis) + begin
+    )
+
+
+def _expected_arrivals(
+    readiness_key_domain: CoordinateDomain,
+    producers: tuple[ReadinessProducer, ...],
+) -> tuple[int, ...]:
+    result = [0] * readiness_key_domain.size
+    for readiness_producer in producers:
+        for readiness_key, producer_tasks in enumerate(
+            readiness_producer.producers_by_key.materialize()
+        ):
+            result[readiness_key] += len(producer_tasks)
+    return tuple(result)
+
+
+def _readiness_producer_from_publication(
+    producer_root: int,
+    publication: CoordinateRelation,
+    producer_site_id: int | None = None,
+) -> ReadinessProducer:
+    producers_by_key = publication.converse()
+    assert producers_by_key is not None
+    return ReadinessProducer(
+        producer_root=producer_root,
+        producer_site_id=producer_site_id,
+        producers_by_key=producers_by_key,
+    )
+
+
+def _publication(readiness_producer: ReadinessProducer) -> CoordinateRelation:
+    publication = readiness_producer.keys_by_producer
+    assert publication is not None
+    return publication
+
+
+class TestCrossLoopScheduler(TestCase):
+    def test_large_affine_schedule_never_materializes_task_orders(self) -> None:
+        size = 319_488
+        plan = _dependency_graph(
+            [[10], [20]],
+            _access(root=0, kind="store", shape=(size,), block_ids=(10,)),
+            _access(root=1, kind="load", shape=(size,), block_ids=(20,)),
+        )
+        root_domains = _one_dimensional_domains(
+            producer_count=size // 16,
+            consumer_count=size // 512,
+            producer_block=16,
+            consumer_block=512,
+        )
+
+        with mock.patch.object(
+            CoordinateRelation,
+            "materialize",
+            side_effect=AssertionError("production scheduling expanded a relation"),
+        ):
+            schedule = _configured_static_pipeline_plan(
+                dependency_graph=plan,
+                root_domains=root_domains,
+                axis_geometry={10: (size // 16, 16), 20: (size // 512, 512)},
+                worker_count=148,
+            )
+
+        self.assertLessEqual(
+            sum(
+                len(readiness_producer.producers_by_key.pieces)
+                for event in schedule.readiness_counters
+                for readiness_producer in event.producers
+            ),
+            4,
+        )
+
+    def test_symbolic_readiness_event_keeps_relations_compact(self) -> None:
+        plan = _dependency_graph(
+            [[10], [20]],
+            _access(root=0, kind="store", shape=(65,), block_ids=(10,)),
+            _access(root=1, kind="load", shape=(65,), block_ids=(20,)),
+        )
+
+        events = _configured_readiness_events(
+            plan,
+            axis_geometry={10: (5, 16), 20: (3, 32)},
+        )
+
+        self.assertIsNotNone(events)
+        assert events is not None
+        (event,) = events
+        self.assertEqual(event.readiness_key_count, 3)
+        self.assertEqual(len(event.producers[0].producers_by_key.pieces), 1)
+        self.assertEqual(len(event.consumers[0].keys_by_consumer.pieces), 1)
+        self.assertEqual(
+            event.consumers[0].keys_by_consumer.materialize(),
+            (frozenset((0,)), frozenset((1,)), frozenset((2,))),
+        )
+        self.assertEqual(
+            _publication(event.producers[0]).materialize(),
+            (
+                frozenset((0,)),
+                frozenset((0,)),
+                frozenset((1,)),
+                frozenset((1,)),
+                frozenset((2,)),
+            ),
+        )
+
+    def test_symbolic_readiness_event_joins_multiple_producers(self) -> None:
+        plan = _dependency_graph(
+            [[10], [20], [30]],
+            _access(root=0, kind="store", shape=(64,), block_ids=(10,)),
+            _access(
+                root=1, allocation_id=1, kind="store", shape=(64,), block_ids=(20,)
+            ),
+            _access(root=2, kind="load", shape=(64,), block_ids=(30,)),
+            _access(root=2, allocation_id=1, kind="load", shape=(64,), block_ids=(30,)),
+        )
+
+        events = _configured_readiness_events(
+            plan,
+            axis_geometry={10: (4, 16), 20: (4, 16), 30: (2, 32)},
+        )
+
+        self.assertIsNotNone(events)
+        assert events is not None
+        (event,) = events
+        self.assertEqual(event.readiness_key_count, 2)
+        self.assertEqual(len(event.producers), 2)
+        self.assertEqual(
+            tuple(
+                _publication(readiness_producer).materialize()
+                for readiness_producer in event.producers
+            ),
+            (
+                (
+                    frozenset((0,)),
+                    frozenset((0,)),
+                    frozenset((1,)),
+                    frozenset((1,)),
+                ),
+            )
+            * 2,
+        )
+        self.assertEqual(len(event.consumers[0].covered_obligations), 2)
+
+    def test_symbolic_readiness_event_drops_irrelevant_consumer_axis(self) -> None:
+        plan = _dependency_graph(
+            [[10, 11], [20, 21, 22]],
+            _access(root=0, kind="store", shape=(2, 64), block_ids=(10, 11)),
+            _access(root=1, kind="load", shape=(2, 64), block_ids=(20, 22)),
+        )
+
+        events = _configured_readiness_events(
+            plan,
+            axis_geometry={
+                10: (2, 1),
+                11: (4, 16),
+                20: (2, 1),
+                21: (4, 1),
+                22: (4, 16),
+            },
+        )
+
+        self.assertIsNotNone(events)
+        assert events is not None
+        (event,) = events
+        self.assertEqual(event.readiness_key_domain.axis_order, (0, 1))
+        self.assertEqual(event.readiness_key_domain.block_sizes_items, ())
+        self.assertEqual(event.readiness_key_count, 8)
+        for consumer_task in range(
+            event.consumers[0].keys_by_consumer.source_domain.size
+        ):
+            consumer_coordinates = event.consumers[
+                0
+            ].keys_by_consumer.source_domain.coordinates(consumer_task)
+            expected_key = consumer_coordinates[20] + 2 * consumer_coordinates[22]
+            self.assertEqual(
+                event.consumers[0].keys_by_consumer.targets(consumer_task),
+                frozenset((expected_key,)),
+            )
+
+    def test_symbolic_readiness_event_coalesces_equivalent_fanout(self) -> None:
+        plan = _dependency_graph(
+            [[10, 11], [20, 21, 22], [30, 31, 32]],
+            _access(root=0, kind="store", shape=(2, 64), block_ids=(10, 11)),
+            _access(root=1, kind="load", shape=(2, 64), block_ids=(20, 22)),
+            _access(root=2, kind="load", shape=(2, 64), block_ids=(30, 32)),
+        )
+
+        events = _configured_readiness_events(
+            plan,
+            axis_geometry={
+                10: (2, 1),
+                11: (4, 16),
+                20: (2, 1),
+                21: (3, 7),
+                22: (4, 16),
+                30: (2, 1),
+                31: (5, 11),
+                32: (4, 16),
+            },
+        )
+
+        self.assertIsNotNone(events)
+        assert events is not None
+        (event,) = events
+        self.assertEqual(event.readiness_key_domain.axis_order, (0, 1))
+        self.assertEqual(event.readiness_key_count, 8)
+        self.assertEqual(
+            {
+                readiness_consumer.consumer_root
+                for readiness_consumer in event.consumers
+            },
+            {1, 2},
+        )
+
+    def test_symbolic_readiness_event_does_not_coalesce_swapped_axes(self) -> None:
+        plan = _dependency_graph(
+            [[10, 11], [20, 21], [30, 31]],
+            _access(root=0, kind="store", shape=(2, 2), block_ids=(10, 11)),
+            _access(root=1, kind="load", shape=(2, 2), block_ids=(20, 21)),
+            _access(root=2, kind="load", shape=(2, 2), block_ids=(31, 30)),
+        )
+
+        events = _configured_readiness_events(
+            plan,
+            axis_geometry=dict.fromkeys((10, 11, 20, 21, 30, 31), (2, 1)),
+        )
+
+        self.assertIsNotNone(events)
+        assert events is not None
+        self.assertEqual(len(events), 2)
+        self.assertEqual(
+            [
+                {
+                    readiness_consumer.consumer_root
+                    for readiness_consumer in event.consumers
+                }
+                for event in events
+            ],
+            [{1}, {2}],
+        )
+        self.assertNotEqual(
+            events[0].producers[0].producers_by_key,
+            events[1].producers[0].producers_by_key,
+        )
+
+    def test_symbolic_readiness_event_uses_one_chart_for_multi_producer_join(
+        self,
+    ) -> None:
+        plan = _dependency_graph(
+            [[10, 11], [20, 21], [30, 31], [40, 41]],
+            _access(root=0, kind="store", shape=(2, 2), block_ids=(10, 11)),
+            _access(
+                root=1, allocation_id=1, kind="store", shape=(2, 2), block_ids=(20, 21)
+            ),
+            _access(root=2, kind="load", shape=(2, 2), block_ids=(30, 31)),
+            _access(
+                root=2, allocation_id=1, kind="load", shape=(2, 2), block_ids=(30, 31)
+            ),
+            _access(root=3, kind="load", shape=(2, 2), block_ids=(40, 41)),
+            _access(
+                root=3, allocation_id=1, kind="load", shape=(2, 2), block_ids=(41, 40)
+            ),
+        )
+
+        events = _configured_readiness_events(
+            plan,
+            axis_geometry=dict.fromkeys((10, 11, 20, 21, 30, 31, 40, 41), (2, 1)),
+        )
+
+        self.assertIsNotNone(events)
+        assert events is not None
+        self.assertEqual(len(events), 2)
+        self.assertTrue(all(len(event.producers) == 2 for event in events))
+        self.assertEqual(
+            [
+                {
+                    readiness_consumer.consumer_root
+                    for readiness_consumer in event.consumers
+                }
+                for event in events
+            ],
+            [{2}, {3}],
+        )
+
+    def test_symbolic_readiness_event_unions_disjoint_producer_ranges(self) -> None:
+        plan = _dependency_graph(
+            [[10], [20]],
+            _access(root=0, kind="store", shape=(64,), block_ids=(10,)),
+            _access(root=1, kind="load", shape=(64,), block_ids=(20,)),
+            _access(root=1, kind="load", shape=(64,), block_ids=(20,), offsets=(32,)),
+        )
+
+        events = _configured_readiness_events(
+            plan,
+            axis_geometry={10: (32, 2), 20: (2, 16)},
+        )
+
+        self.assertIsNotNone(events)
+        assert events is not None
+        (event,) = events
+        self.assertEqual(event.readiness_key_count, 2)
+        self.assertEqual(len(event.producers), 1)
+        self.assertEqual(len(event.producers[0].producers_by_key.pieces), 2)
+        expected = tuple(frozenset((producer // 8 % 2,)) for producer in range(32))
+        self.assertEqual(_publication(event.producers[0]).materialize(), expected)
+
+    def test_unsupported_symbolic_event_coarsens_to_family_done(self) -> None:
+        plan = _dependency_graph(
+            [[10], [20]],
+            _access(root=0, kind="store", shape=(64,), block_ids=(10,)),
+            _access(root=1, kind="load", shape=(64,), block_ids=(20,), masked=True),
+        )
+
+        events = _configured_readiness_events(
+            plan,
+            axis_geometry={10: (4, 16), 20: (2, 32)},
+        )
+
+        self.assertIsNotNone(events)
+        assert events is not None
+        (event,) = events
+        self.assertEqual(event.readiness_key_count, 1)
+        self.assertEqual(event.producers[0].producer_root, 0)
+        self.assertEqual(
+            _publication(event.producers[0]).materialize(),
+            (frozenset((0,)),) * 4,
+        )
+        self.assertEqual(
+            event.consumers[0].keys_by_consumer.materialize(),
+            (frozenset((0,)),) * 2,
+        )
+
+    def test_unsupported_event_quotient_does_not_coarsen_unrelated_edges(
+        self,
+    ) -> None:
+        plan = _dependency_graph(
+            [[10], [20], [30], [40]],
+            _access(root=0, kind="store", shape=(64,), block_ids=(10,)),
+            _access(root=1, kind="load", shape=(64,), block_ids=(20,)),
+            _access(root=1, kind="load", shape=(64,), block_ids=(20,)),
+            _access(
+                root=2, allocation_id=1, kind="store", shape=(64,), block_ids=(30,)
+            ),
+            _access(root=3, allocation_id=1, kind="load", shape=(64,), block_ids=(40,)),
+        )
+
+        original_union = CoordinateRelation.union
+        failed_once = False
+
+        def fail_first_union(
+            left: CoordinateRelation,
+            right: CoordinateRelation,
+        ) -> CoordinateRelation | None:
+            nonlocal failed_once
+            if not failed_once:
+                failed_once = True
+                return None
+            return original_union(left, right)
+
+        with mock.patch.object(CoordinateRelation, "union", fail_first_union):
+            events = _configured_readiness_events(
+                plan,
+                axis_geometry={
+                    10: (4, 16),
+                    20: (2, 32),
+                    30: (4, 16),
+                    40: (2, 32),
+                },
+            )
+
+        unrelated = [
+            event
+            for event in events
+            if any(
+                readiness_producer.producer_root == 2
+                for readiness_producer in event.producers
+            )
+        ]
+        self.assertEqual(len(unrelated), 1)
+        self.assertEqual(unrelated[0].readiness_key_count, 2)
+        self.assertIsNone(unrelated[0].root_barrier_producer_root)
+
+    def test_semantic_readiness_graph_composes_arbitrary_chain_depth(self) -> None:
+        graph = _dependency_graph(
+            [[10], [20], [30], [40]],
+            _access(root=0, kind="store", block_ids=(10,)),
+            _access(root=1, kind="load", block_ids=(20,)),
+            _access(root=1, allocation_id=1, kind="store", block_ids=(20,)),
+            _access(root=2, allocation_id=1, kind="load", block_ids=(30,)),
+            _access(root=2, allocation_id=2, kind="store", block_ids=(30,)),
+            _access(root=3, allocation_id=2, kind="load", block_ids=(40,)),
+        )
+
+        self.assertEqual(len(graph.task_families), 4)
+        configured = _configured_readiness_graph(
+            graph,
+            tuple(_domain((block_id, 4, 1)) for block_id in (10, 20, 30, 40)),
+        )
+        self.assertEqual(len(configured.events), 3)
+        self.assertEqual(
+            tuple(
+                _expected_arrivals(event.readiness_key_domain, event.producers)
+                for event in configured.events
+            ),
+            ((1, 1, 1, 1),) * 3,
+        )
+        baseline = _build_baseline_worker_schedule(
+            configured.root_domains,
+            configured.root_task_orders,
+            worker_count=4,
+        )
+        continuations = derive_final_arrival_continuations(configured, baseline)
+        self.assertEqual(
+            tuple(
+                configured.event(continuation.event_id)
+                .consumers[continuation.consumer_index]
+                .consumer_root
+                for continuation in continuations
+            ),
+            (1, 2, 3),
+        )
+        validate_worker_schedule(
+            configured,
+            baseline.without_roots(frozenset((1, 2, 3))),
+            continuations,
+        )
+
+    def test_final_arrival_continuations_allow_disjoint_uses_of_one_producer_family(
+        self,
+    ) -> None:
+        domains = tuple(
+            _domain((axis, count), identity=root)
+            for root, (axis, count) in enumerate(((10, 4), (20, 2), (30, 2)))
+        )
+        key_domains = tuple(
+            _domain((0, 2), kind="event", identity=event) for event in range(2)
+        )
+
+        def keys(
+            domain: CoordinateDomain,
+            readiness_key_domain: CoordinateDomain,
+            begin: int,
+            end: int,
+        ) -> CoordinateRelation:
+            (axis,) = domain.axis_order
+            return CoordinateRelation.point_map(
+                domain,
+                readiness_key_domain,
+                (
+                    (
+                        ((axis, begin, end, 1),),
+                        (coordinate_axis_symbol(axis) - begin,),
+                    ),
+                ),
+            )
+
+        readiness_graph = ReadinessGraph(
+            root_task_orders=tuple(
+                pid_task_order(domain, domain.axis_order) for domain in domains
+            ),
+            events=(
+                ReadinessEvent(
+                    producers=(
+                        _readiness_producer_from_publication(
+                            0,
+                            keys(domains[0], key_domains[0], 0, 2),
+                        ),
+                    ),
+                    consumers=(
+                        ReadinessConsumer(1, keys(domains[1], key_domains[0], 0, 2)),
+                    ),
+                ),
+                ReadinessEvent(
+                    producers=(
+                        _readiness_producer_from_publication(
+                            0,
+                            keys(domains[0], key_domains[1], 2, 4),
+                        ),
+                        _readiness_producer_from_publication(
+                            1,
+                            keys(domains[1], key_domains[1], 0, 2),
+                        ),
+                    ),
+                    consumers=(
+                        ReadinessConsumer(2, keys(domains[2], key_domains[1], 0, 2)),
+                    ),
+                ),
+            ),
+        )
+        baseline = _build_baseline_worker_schedule(
+            domains,
+            readiness_graph.root_task_orders,
+            worker_count=4,
+        )
+
+        continuations = derive_final_arrival_continuations(readiness_graph, baseline)
+
+        self.assertEqual(
+            tuple(
+                readiness_graph.event(continuation.event_id)
+                .consumers[continuation.consumer_index]
+                .consumer_root
+                for continuation in continuations
+            ),
+            (1, 2),
+        )
+
+        overlapping = dataclasses.replace(
+            readiness_graph,
+            events=(
+                readiness_graph.events[0],
+                dataclasses.replace(
+                    readiness_graph.events[1],
+                    producers=(
+                        _readiness_producer_from_publication(
+                            0,
+                            keys(domains[0], key_domains[1], 1, 3),
+                        ),
+                        readiness_graph.events[1].producers[1],
+                    ),
+                ),
+            ),
+        )
+        self.assertEqual(derive_final_arrival_continuations(overlapping, baseline), ())
+
+    def test_final_arrival_continuation_requires_counter_lowerability(
+        self,
+    ) -> None:
+        producer_domain = _domain((10, 4), identity=0)
+        consumer_domain = _domain((20, 2), identity=1)
+        readiness_key_domain = _domain((0, 2), kind="event", identity=0)
+        readiness_producer = ReadinessProducer(
+            producer_root=0,
+            producers_by_key=CoordinateRelation(
+                readiness_key_domain,
+                producer_domain,
+                (
+                    _CoordinateRelationPiece(
+                        ((0, 0, 2, 1),),
+                        (
+                            (
+                                10,
+                                2 * coordinate_axis_symbol(0),
+                                2 * coordinate_axis_symbol(0) + 1,
+                                1,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        readiness_graph = ReadinessGraph(
+            root_task_orders=(
+                pid_task_order(producer_domain, (10,)),
+                pid_task_order(consumer_domain, (20,)),
+            ),
+            events=(
+                ReadinessEvent(
+                    (readiness_producer,),
+                    (
+                        ReadinessConsumer(
+                            1,
+                            _full_point_map(
+                                consumer_domain,
+                                readiness_key_domain,
+                                coordinate_axis_symbol(20),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        baseline = _build_baseline_worker_schedule(
+            readiness_graph.root_domains,
+            readiness_graph.root_task_orders,
+            worker_count=4,
+        )
+
+        publication = readiness_producer.keys_by_producer
+        self.assertIsNotNone(publication)
+        assert publication is not None
+        self.assertIsNone(publication.canonical_single_valued())
+        self.assertEqual(
+            derive_final_arrival_continuations(readiness_graph, baseline), ()
+        )
+        self.assertEqual(choose_readiness_counters(readiness_graph, ()), ())
+
+    def test_large_final_arrival_continuation_ignores_downstream_event_granularity(
+        self,
+    ) -> None:
+        graph = _dependency_graph(
+            [[10], [20], [30]],
+            _access(root=0, kind="store", block_ids=(10,)),
+            _access(root=1, kind="load", block_ids=(20,)),
+            _access(
+                root=1,
+                allocation_id=1,
+                kind="store",
+                block_ids=(20,),
+                layout_is_static=False,
+            ),
+            _access(
+                root=2,
+                allocation_id=1,
+                kind="load",
+                block_ids=(30,),
+                layout_is_static=False,
+            ),
+        )
+        root_domains = _identify_root_domains(
+            (
+                _domain((10, 8, 1)),
+                _domain((20, 8, 1)),
+                _domain((30, 1, 1)),
+            )
+        )
+        readiness_graph = _configured_readiness_graph(graph, root_domains)
+        baseline = _build_baseline_worker_schedule(
+            root_domains,
+            readiness_graph.root_task_orders,
+            worker_count=4,
+        )
+
+        continuations = choose_final_arrival_continuations(readiness_graph, baseline)
+
+        self.assertGreater(root_domains[1].size, baseline.worker_count)
+        self.assertEqual(readiness_graph.events[1].root_barrier_producer_root, 1)
+        self.assertEqual(len(continuations), 1)
+        readiness_consumer = readiness_graph.event(continuations[0].event_id).consumers[
+            continuations[0].consumer_index
+        ]
+        self.assertEqual(readiness_consumer.consumer_root, 1)
+
+    def test_semantic_readiness_graph_represents_diamond_without_path_matching(
+        self,
+    ) -> None:
+        graph = _dependency_graph(
+            [[10], [20], [30], [40]],
+            _access(root=0, kind="store", block_ids=(10,)),
+            _access(root=0, allocation_id=1, kind="store", block_ids=(10,)),
+            _access(root=1, kind="load", block_ids=(20,)),
+            _access(root=1, allocation_id=2, kind="store", block_ids=(20,)),
+            _access(root=2, allocation_id=1, kind="load", block_ids=(30,)),
+            _access(root=2, allocation_id=3, kind="store", block_ids=(30,)),
+            _access(root=3, allocation_id=2, kind="load", block_ids=(40,)),
+            _access(root=3, allocation_id=3, kind="load", block_ids=(40,)),
+        )
+
+        configured = _configured_readiness_graph(
+            graph,
+            tuple(_domain((block_id, 4, 1)) for block_id in (10, 20, 30, 40)),
+        )
+        (root_zero_event,) = tuple(
+            event
+            for event in configured.events
+            if any(
+                readiness_producer.producer_root == 0
+                for readiness_producer in event.producers
+            )
+        )
+        self.assertEqual(
+            {
+                readiness_consumer.consumer_root
+                for readiness_consumer in root_zero_event.consumers
+            },
+            {1, 2},
+        )
+        continuations = derive_final_arrival_continuations(
+            configured,
+            _build_baseline_worker_schedule(
+                configured.root_domains,
+                configured.root_task_orders,
+                worker_count=4,
+            ),
+        )
+        self.assertEqual(
+            {
+                configured.event(continuation.event_id)
+                .consumers[continuation.consumer_index]
+                .consumer_root
+                for continuation in continuations
+            },
+            {3},
+        )
+
+    def test_exact_and_family_done_dependencies_can_share_one_consumer(
+        self,
+    ) -> None:
+        graph = _dependency_graph(
+            [[10], [20], [30]],
+            _access(root=0, kind="store", block_ids=(10,), layout_is_static=False),
+            _access(root=1, allocation_id=1, kind="store", block_ids=(20,)),
+            _access(root=2, kind="load", block_ids=(30,), layout_is_static=False),
+            _access(root=2, allocation_id=1, kind="load", block_ids=(30,)),
+        )
+
+        configured = _configured_readiness_graph(
+            graph,
+            tuple(_domain((block_id, 4, 1)) for block_id in (10, 20, 30)),
+        )
+        configured_uses = tuple(
+            readiness_consumer
+            for event in configured.events
+            for readiness_consumer in event.consumers
+            if readiness_consumer.consumer_root == 2
+        )
+        self.assertEqual(len(configured_uses), 2)
+        family_event = next(
+            event
+            for event in configured.events
+            if event.root_barrier_producer_root is not None
+        )
+        self.assertEqual(family_event.root_barrier_producer_root, 0)
+        self.assertEqual(
+            _expected_arrivals(
+                family_event.readiness_key_domain, family_event.producers
+            ),
+            (4,),
+        )
+        baseline = _build_baseline_worker_schedule(
+            configured.root_domains,
+            configured.root_task_orders,
+            worker_count=4,
+        )
+        self.assertEqual(derive_final_arrival_continuations(configured, baseline), ())
+
+    def test_dependency_coverage_distinguishes_producer_callsites(self) -> None:
+        graph = _dependency_graph(
+            [[10], [20]],
+            _access(root=0, kind="store", block_ids=(10,)),
+            _access(root=1, kind="load", block_ids=(20,)),
+        )
+        sites = (
+            ExecutionSite(0, 0, 0, (), None, "root", (), (10,), True, False),
+            ExecutionSite(
+                1,
+                0,
+                0,
+                ((0, 0),),
+                None,
+                "root",
+                (),
+                (10,),
+                False,
+                False,
+            ),
+            ExecutionSite(2, 1, 1, (), None, "root", (), (20,), True, False),
+        )
+        graph = dataclasses.replace(
+            graph,
+            execution_sites=sites,
+            site_ids_by_access=((0, 1), (2,)),
+        )
+        access_dependency = graph.edges[0].access_dependencies[0]
+        self.assertEqual(
+            graph.dependency_obligations(access_dependency),
+            frozenset(
+                (
+                    (access_dependency.dependency_id, 0, 2),
+                    (access_dependency.dependency_id, 1, 2),
+                )
+            ),
+        )
+        axis_geometry = {10: (4, 32), 20: (4, 32)}
+        configured_root_domains, configured_site_domains = (
+            instantiate_coordinate_domains(
+                graph,
+                axis_geometry=axis_geometry,
+            )
+        )
+        exact_dependencies = instantiate_symbolic_dependencies(
+            graph,
+            root_domains=configured_root_domains,
+            site_domains=configured_site_domains,
+        )
+        self.assertEqual(len(exact_dependencies), 1)
+
+        events = _configured_readiness_events(graph, axis_geometry=axis_geometry)
+
+        self.assertIsNotNone(events)
+        assert events is not None
+        self.assertEqual(len(events), 2)
+        exact_event = next(
+            event for event in events if event.root_barrier_producer_root is None
+        )
+        family_event = next(
+            event for event in events if event.root_barrier_producer_root is not None
+        )
+        dependency_id = access_dependency.dependency_id
+        self.assertEqual(
+            exact_event.consumers[0].covered_obligations,
+            frozenset(((dependency_id, 0, 2),)),
+        )
+        self.assertEqual(
+            family_event.consumers[0].covered_obligations,
+            frozenset(((dependency_id, 1, 2),)),
+        )
+
+        root_domains = tuple(
+            domain for domain in configured_root_domains if domain is not None
+        )
+        readiness_graph = ReadinessGraph(
+            root_task_orders=tuple(
+                pid_task_order(domain, domain.axis_order) for domain in root_domains
+            ),
+            events=events,
+        )
+        baseline = _build_baseline_worker_schedule(
+            root_domains,
+            readiness_graph.root_task_orders,
+            worker_count=4,
+        )
+        self.assertEqual(
+            derive_final_arrival_continuations(readiness_graph, baseline), ()
+        )
+        readiness_counters = choose_readiness_counters(readiness_graph, ())
+        covered_obligations = frozenset(
+            obligation
+            for counter_plan in readiness_counters
+            for readiness_consumer in counter_plan.consumers
+            for obligation in readiness_consumer.covered_obligations
+        )
+        self.assertEqual(
+            _select_root_barrier_edges(
+                dependency_graph=graph,
+                covered_obligations=covered_obligations,
+            ),
+            frozenset(((0, 1),)),
+        )
+
+    def test_baseline_worker_schedule_preserves_source_order(self) -> None:
+        root_domains = (
+            _domain((10, 3, 1)),
+            _domain((20, 5, 1)),
+        )
+
+        schedule = _baseline_worker_schedule(root_domains, worker_count=4)
+
+        self.assertEqual(placement(schedule, 0, 0), (0, 0))
+        self.assertEqual(placement(schedule, 0, 2), (2, 0))
+        self.assertEqual(placement(schedule, 1, 0), (0, 1))
+        self.assertEqual(placement(schedule, 1, 4), (0, 2))
+        self.assertEqual(task_at(schedule, 3, 0), None)
+        self.assertEqual(task_at(schedule, 3, 1), (1, 3))
+
+    def test_root_task_orders_require_compatible_domains(self) -> None:
+        task_domain = _domain((10, 2), identity=0)
+        task_order_domain = _domain((-1, 1), kind="task_order", identity=0)
+        wrong_size = _full_point_map(task_order_domain, task_domain, sympy.Integer(0))
+
+        with self.assertRaisesRegex(ValueError, "compatible typed domains"):
+            ReadinessGraph(
+                root_task_orders=(wrong_size,),
+                events=(),
+            )
+        with self.assertRaisesRegex(ValueError, "incompatible domains"):
+            converse = wrong_size.converse()
+            assert converse is not None
+            _segment(0, converse, workers=(0, 2), dispatch_offset=0)
+
+    def test_baseline_worker_schedule_preserves_pid_task_order(self) -> None:
+        root_domains = (_domain((10, 4, 1), identity=0),)
+        task_order_domain = _domain((-1, 4), kind="task_order", identity=0)
+        task_order_relation = CoordinateRelation.point_map(
+            task_order_domain,
+            root_domains[0],
+            tuple(
+                (
+                    ((-1, task_order_index, task_order_index + 1, 1),),
+                    (sympy.Integer(task),),
+                )
+                for task_order_index, task in enumerate((0, 2, 1, 3))
+            ),
+        )
+
+        schedule = _baseline_worker_schedule(
+            root_domains,
+            worker_count=2,
+            root_task_orders=(task_order_relation,),
+        )
+
+        self.assertEqual(placement(schedule, 0, 0), (0, 0))
+        self.assertEqual(placement(schedule, 0, 2), (1, 0))
+        self.assertEqual(placement(schedule, 0, 1), (0, 1))
+        self.assertEqual(placement(schedule, 0, 3), (1, 1))
+
+    def test_worker_schedule_segment_uses_symbolic_order_across_rounds(self) -> None:
+        task_axis = 10
+        task_order_axis = 20
+        task_domain = _domain((task_axis, 15), identity=2)
+        task_order_domain = _domain((task_order_axis, 3), kind="task_order")
+        segment = _segment(
+            2,
+            _full_point_map(
+                task_order_domain,
+                task_domain,
+                10 + 2 * coordinate_axis_symbol(task_order_axis),
+            ),
+            workers=(2, 2),
+            dispatch_offset=0,
+        )
+
+        self.assertEqual(segment_placement(segment, 10), (2, 0))
+        self.assertEqual(segment_placement(segment, 12), (3, 0))
+        self.assertEqual(segment_placement(segment, 14), (2, 1))
+        self.assertEqual(segment_placement(segment, 11), None)
+        self.assertEqual(segment_task_at(segment, 2, 1), 14)
+
+    def test_worker_support_excludes_unused_segment_capacity(self) -> None:
+        task_domain = _domain((10, 2), identity=0)
+        schedule = _schedule(
+            6,
+            _segment(
+                0,
+                _one_dimensional_task_range(task_domain, 0, 2),
+                workers=(1, 4),
+                dispatch_offset=2,
+            ),
+        )
+
+        self.assertEqual(schedule.workers_for_root(0), frozenset((3, 4)))
+        self.assertEqual(schedule.dense_assignment(0), (1, 4, 2, 2))
+        self.assertIsNone(schedule.contiguous_global_interval(0))
+
+    def test_continuation_producers_preserve_key_major_order(self) -> None:
+        root_domains = (
+            _domain((10, 4, 1)),
+            _domain((20, 2, 1)),
+        )
+        producer_domain, consumer_domain = _identify_root_domains(root_domains)
+        readiness_key_domain = _domain((0, 2), kind="event", identity=0)
+        producer_axis = coordinate_axis_symbol(10)
+        consumer_axis = coordinate_axis_symbol(20)
+        readiness_graph = _readiness_graph(
+            (producer_domain, consumer_domain),
+            ReadinessEvent(
+                producers=(
+                    _readiness_producer_from_publication(
+                        producer_root=0,
+                        producer_site_id=None,
+                        publication=_full_point_map(
+                            producer_domain,
+                            readiness_key_domain,
+                            sympy.floor(producer_axis / 2),
+                        ),
+                    ),
+                ),
+                consumers=(
+                    ReadinessConsumer(
+                        consumer_root=1,
+                        consumer_site_id=None,
+                        keys_by_consumer=_full_point_map(
+                            consumer_domain, readiness_key_domain, consumer_axis
+                        ),
+                    ),
+                ),
+            ),
+        )
+        baseline = _baseline_worker_schedule(
+            readiness_graph.root_domains,
+            worker_count=2,
+        )
+        continuations = derive_final_arrival_continuations(readiness_graph, baseline)
+
+        schedule = order_continuation_producers_by_readiness_key(
+            readiness_graph,
+            baseline,
+            continuations,
+        )
+
+        self.assertEqual(task_order(schedule, 0), (0, 1, 2, 3))
+
+    def test_worker_schedule_detects_dependency_order_cycle(self) -> None:
+        graph = _dependency_graph(
+            [[10], [20]],
+            _access(root=0, kind="store", block_ids=(10,)),
+            _access(root=1, kind="load", block_ids=(20,)),
+        )
+        root_domains = (
+            _domain((10, 1, 1)),
+            _domain((20, 1, 1)),
+        )
+        readiness_graph = _configured_readiness_graph(graph, root_domains)
+
+        validate_worker_schedule(
+            readiness_graph,
+            _baseline_worker_schedule(
+                readiness_graph.root_domains,
+                worker_count=1,
+            ),
+        )
+        reversed_schedule = _schedule(
+            1,
+            _segment(
+                1,
+                readiness_graph.root_task_orders[1],
+                workers=(0, 1),
+                dispatch_offset=0,
+            ),
+            _segment(
+                0,
+                readiness_graph.root_task_orders[0],
+                workers=(0, 1),
+                dispatch_offset=1,
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "dependency/order cycle"):
+            validate_worker_schedule(readiness_graph, reversed_schedule)
+
+    def test_readiness_counter_supports_independent_consumers(self) -> None:
+        producer_domain = _domain((10, 2), identity=0)
+        first_consumer = _domain((20, 1), identity=1)
+        second_consumer = _domain((30, 2), identity=2)
+        readiness_key_domain = _domain(kind="event", identity=0)
+        event = ReadinessCounterPlan(
+            producers=(
+                _readiness_producer_from_publication(
+                    producer_root=0,
+                    publication=CoordinateRelation.total(
+                        producer_domain, readiness_key_domain
+                    ),
+                ),
+            ),
+            consumers=(
+                ReadinessConsumer(
+                    consumer_root=1,
+                    keys_by_consumer=CoordinateRelation.total(
+                        first_consumer, readiness_key_domain
+                    ),
+                ),
+                ReadinessConsumer(
+                    consumer_root=2,
+                    keys_by_consumer=CoordinateRelation.total(
+                        second_consumer, readiness_key_domain
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(event.readiness_key_count, 1)
+        self.assertEqual(event.uniform_arrival_count(), 2)
+        self.assertIsNone(event.continuation_consumer)
+        self.assertEqual(
+            tuple(
+                readiness_consumer.consumer_root
+                for readiness_consumer in event.consumers
+            ),
+            (1, 2),
+        )
+
+    def test_readiness_counter_selection_keeps_independent_direct_consumers(
+        self,
+    ) -> None:
+        root_domains = tuple(_domain((axis, 2, 1)) for axis in (10, 20, 30))
+        root_domains = _identify_root_domains(root_domains)
+        readiness_key_domain = _domain((0, 2), kind="event", identity=0)
+        readiness_graph = _readiness_graph(
+            root_domains,
+            ReadinessEvent(
+                producers=(
+                    _readiness_producer_from_publication(
+                        producer_root=0,
+                        producer_site_id=None,
+                        publication=_full_point_map(
+                            root_domains[0],
+                            readiness_key_domain,
+                            coordinate_axis_symbol(10),
+                        ),
+                    ),
+                ),
+                consumers=tuple(
+                    ReadinessConsumer(
+                        consumer_root=root,
+                        consumer_site_id=None,
+                        keys_by_consumer=_full_point_map(
+                            root_domains[root],
+                            readiness_key_domain,
+                            coordinate_axis_symbol(10 * (root + 1)),
+                        ),
+                        covered_obligations=frozenset(((root - 1, None, None),)),
+                    )
+                    for root in (1, 2)
+                ),
+            ),
+        )
+        (selected,) = choose_readiness_counters(
+            readiness_graph,
+            (),
+            excluded_obligations=frozenset(((0, None, None),)),
+        )
+
+        self.assertEqual(selected.readiness_key_count, 2)
+        self.assertEqual(
+            tuple(
+                readiness_consumer.consumer_root
+                for readiness_consumer in selected.consumers
+            ),
+            (2,),
+        )
+
+    def test_readiness_counter_lowering_is_derived_from_the_semantic_graph(
+        self,
+    ) -> None:
+        root_domains = (
+            _domain((10, 4, 1)),
+            _domain((20, 2, 2)),
+        )
+        root_domains = _identify_root_domains(root_domains)
+        readiness_key_domain = _domain((0, 2), kind="event", identity=0)
+        readiness_graph = _readiness_graph(
+            root_domains,
+            ReadinessEvent(
+                producers=(
+                    _readiness_producer_from_publication(
+                        producer_root=0,
+                        producer_site_id=None,
+                        publication=_full_point_map(
+                            root_domains[0],
+                            readiness_key_domain,
+                            sympy.floor(coordinate_axis_symbol(10) / 2),
+                        ),
+                    ),
+                ),
+                consumers=(
+                    ReadinessConsumer(
+                        consumer_root=1,
+                        consumer_site_id=None,
+                        keys_by_consumer=_full_point_map(
+                            root_domains[1],
+                            readiness_key_domain,
+                            coordinate_axis_symbol(20),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        baseline = _baseline_worker_schedule(
+            root_domains,
+            worker_count=4,
+        )
+        continuations = derive_final_arrival_continuations(readiness_graph, baseline)
+
+        (lowered,) = choose_readiness_counters(readiness_graph, continuations)
+
+        self.assertEqual(
+            _publication(lowered.producers[0]).materialize(),
+            (
+                frozenset((0,)),
+                frozenset((0,)),
+                frozenset((1,)),
+                frozenset((1,)),
+            ),
+        )
+        self.assertEqual(
+            lowered.consumers[0].keys_by_consumer.materialize(),
+            (frozenset((0,)), frozenset((1,))),
+        )
+        self.assertEqual(lowered.uniform_arrival_count(), 2)
+        self.assertEqual(lowered.continuation_consumer_index, 0)
+
+    def test_nonstatic_layout_falls_back_to_root_readiness(self) -> None:
+        plan = _dependency_graph(
+            [[10], [20]],
+            _access(root=0, kind="store", block_ids=(10,), layout_is_static=False),
+            _access(root=1, kind="load", block_ids=(20,)),
+        )
+
+        (event,) = _configured_readiness_graph(plan, _one_dimensional_domains()).events
+        self.assertIsNotNone(event.root_barrier_producer_root)
+        self.assertEqual(event.root_barrier_producer_root, 0)
+
+    def test_fanout_keeps_one_edge_per_consumer(self) -> None:
+        plan = _dependency_graph(
+            [[0], [1], [2]],
+            _access(root=0, kind="store"),
+            _access(root=1, kind="load", block_ids=(1,)),
+            _access(root=2, kind="load", block_ids=(2,)),
+        )
+
+        self.assertEqual(
+            [(edge.producer_root, edge.consumer_root) for edge in plan.edges],
+            [(0, 1), (0, 2)],
+        )
+        configured = _configured_readiness_graph(
+            plan,
+            (
+                _domain((0, 8, 16)),
+                _domain((1, 8, 16)),
+                _domain((2, 8, 16)),
+            ),
+        )
+        (event,) = tuple(
+            event
+            for event in configured.events
+            if any(
+                readiness_producer.producer_root == 0
+                for readiness_producer in event.producers
+            )
+        )
+        self.assertIsNone(event.root_barrier_producer_root)
+        self.assertEqual(
+            {
+                readiness_consumer.consumer_root
+                for readiness_consumer in event.consumers
+            },
+            {1, 2},
+        )
+
+    def test_mixed_accesses_retain_exact_and_conservative_readiness(self) -> None:
+        plan = _dependency_graph(
+            [[0], [1]],
+            _access(root=0, kind="store"),
+            _access(root=1, kind="load", block_ids=(1,)),
+            _access(root=0, allocation_id=1, kind="store"),
+            _access(root=1, allocation_id=1, kind="load", block_ids=(1,), scales=(-1,)),
+        )
+
+        self.assertEqual(len(plan.edges), 2)
+        configured = _configured_readiness_graph(
+            plan,
+            (
+                _domain((0, 8, 16)),
+                _domain((1, 8, 16)),
+            ),
+        )
+        self.assertEqual(len(configured.events), 2)
+        family_event = next(
+            event
+            for event in configured.events
+            if event.root_barrier_producer_root is not None
+        )
+        self.assertEqual(family_event.root_barrier_producer_root, 0)
+
+    def test_mixed_exact_and_unknown_accesses_use_root_barrier(self) -> None:
+        dependency_graph = _dependency_graph(
+            [[10, 11], [20]],
+            _access(root=0, kind="store", shape=(1, 64), block_ids=(10, 11)),
+            _access(root=1, kind="load", shape=(1, 64), block_ids=(20, 21)),
+            _access(
+                root=1,
+                kind="load",
+                shape=(1, 64),
+                block_ids=(None, None),
+                offsets=(None, None),
+                masked=True,
+            ),
+        )
+        schedule = _configured_static_pipeline_plan(
+            dependency_graph=dependency_graph,
+            root_domains=(
+                _domain((10, 1, 1), (11, 4, 16)),
+                _domain((20, 1, 1)),
+            ),
+            axis_geometry={10: (1, 1), 11: (4, 16), 20: (1, 1), 21: (4, 16)},
+            worker_count=2,
+        )
+
+        self.assertEqual(schedule.root_barrier_edges, frozenset(((0, 1),)))
+
+    def test_singleton_producer_uses_root_barrier(self) -> None:
+        dependency_graph = _dependency_graph(
+            [[10], [20]],
+            _access(root=0, kind="store", block_ids=(10,)),
+            _access(root=1, kind="load", block_ids=(20,)),
+        )
+        schedule = _configured_static_pipeline_plan(
+            dependency_graph=dependency_graph,
+            root_domains=(
+                _domain((10, 1, 128)),
+                _domain((20, 4, 32)),
+            ),
+            axis_geometry={10: (1, 128), 20: (4, 32)},
+            worker_count=4,
+        )
+
+        self.assertEqual(schedule.root_barrier_edges, frozenset(((0, 1),)))
+
+    def test_root_barrier_path_elides_redundant_exact_task_wait(self) -> None:
+        dependency_graph = _dependency_graph(
+            [[10], [20], [30], [40]],
+            _access(root=0, kind="store", block_ids=(10,)),
+            _access(root=1, kind="load", block_ids=(None,), offsets=(None,)),
+            _access(root=1, allocation_id=1, kind="store", block_ids=(20,)),
+            _access(
+                root=2, allocation_id=1, kind="load", block_ids=(None,), offsets=(None,)
+            ),
+            _access(root=2, allocation_id=2, kind="store", block_ids=(30,)),
+            _access(
+                root=3, allocation_id=2, kind="load", block_ids=(None,), offsets=(None,)
+            ),
+            _access(root=3, kind="load", block_ids=(40,)),
+        )
+        root_domains = tuple(_domain((10 + root * 10, 8, 16)) for root in range(4))
+
+        schedule = _configured_static_pipeline_plan(
+            dependency_graph=dependency_graph,
+            root_domains=root_domains,
+            axis_geometry={
+                10: (8, 16),
+                20: (8, 16),
+                30: (8, 16),
+                40: (8, 16),
+            },
+            worker_count=8,
+        )
+
+        self.assertEqual(
+            schedule.root_barrier_edges,
+            frozenset(((0, 1), (1, 2), (2, 3))),
+        )
+
+    def test_worker_schedule_derives_access_ready_overlap(self) -> None:
+        dependency_graph = _dependency_graph(
+            [[10, 11], [20, 21], [30]],
+            _access(root=0, kind="store", shape=(1, 128), block_ids=(10, 11)),
+            _access(root=1, kind="load", shape=(1, 128), block_ids=(20, 21)),
+            _access(
+                root=1,
+                allocation_id=1,
+                kind="store",
+                shape=(1, 128),
+                block_ids=(20, 21),
+            ),
+            _access(
+                root=2, allocation_id=1, kind="load", shape=(1, 128), block_ids=(30, 31)
+            ),
+        )
+        dependency_graph = dataclasses.replace(
+            dependency_graph,
+            execution_sites=(
+                ExecutionSite(
+                    0, 0, 0, (), None, "root", (10, 11), (10, 11), True, False
+                ),
+                ExecutionSite(
+                    1, 1, 1, (), None, "root", (20, 21), (20, 21), True, False
+                ),
+                ExecutionSite(2, 2, 2, (), None, "root", (30,), (30,), True, False),
+                ExecutionSite(
+                    3,
+                    2,
+                    3,
+                    ((0, 0),),
+                    2,
+                    "loop",
+                    (31,),
+                    (30, 31),
+                    True,
+                    True,
+                ),
+            ),
+            site_ids_by_access=((0,), (1,), (1,), (3,)),
+        )
+        root_domains = (
+            _domain((10, 1, 1), (11, 8, 16)),
+            _domain((20, 1, 1), (21, 4, 32)),
+            _domain((30, 1, 1)),
+        )
+        kwargs = {
+            "dependency_graph": dependency_graph,
+            "root_domains": root_domains,
+            "axis_geometry": {
+                10: (1, 1),
+                11: (8, 16),
+                20: (1, 1),
+                21: (4, 32),
+                30: (1, 1),
+                31: (4, 32),
+            },
+            "worker_count": 8,
+        }
+
+        schedule = _configured_static_pipeline_plan(**{**kwargs, "worker_count": 6})
+
+        root_events = tuple(
+            plan
+            for plan in schedule.readiness_counters
+            if all(
+                readiness_consumer.consumer_site_id is None
+                for readiness_consumer in plan.consumers
+            )
+        )
+        self.assertEqual(len(root_events), 1)
+        event = root_events[0]
+        self.assertEqual(
+            (
+                event.producers[0].producer_root,
+                event.consumers[0].consumer_root,
+                event.continuation_consumer.consumer_root
+                if event.continuation_consumer is not None
+                else None,
+                event.uniform_arrival_count(),
+            ),
+            (0, 1, 1, 2),
+        )
+        local_events = tuple(
+            plan
+            for plan in schedule.readiness_counters
+            if plan.continuation_consumer is not None
+        )
+        self.assertEqual(len(local_events), 1)
+        self.assertEqual(local_events[0].continuation_consumer_index, 0)
+        assert local_events[0].continuation_consumer is not None
+        self.assertEqual(local_events[0].continuation_consumer.consumer_root, 1)
+        self.assertEqual(schedule.worker_schedule.worker_count, 6)
+        nested_loop_events = tuple(
+            plan
+            for plan in schedule.readiness_counters
+            if any(
+                readiness_consumer.consumer_site_id is not None
+                for readiness_consumer in plan.consumers
+            )
+        )
+        self.assertEqual(len(nested_loop_events), 1)
+        self.assertEqual(
+            _expected_arrivals(
+                nested_loop_events[0].readiness_key_domain,
+                nested_loop_events[0].producers,
+            ),
+            (3, 1),
+        )
+        self.assertEqual(placement(schedule.worker_schedule, 2, 0), (5, 1))
+        self.assertEqual(placement(schedule.worker_schedule, 0, 6), (0, 1))
+
+        exact = _configured_static_pipeline_plan(**{**kwargs, "worker_count": 7})
+        self.assertEqual(exact.worker_schedule.worker_count, 7)
+        self.assertNotEqual(exact.worker_schedule, schedule.worker_schedule)
+
+        default_schedule = _configured_static_pipeline_plan(**kwargs)
+        self.assertEqual(len(default_schedule.readiness_counters), 2)
+        self.assertEqual(
+            default_schedule.root_barrier_edges,
+            frozenset(),
+        )
+        short_domains = (
+            dataclasses.replace(
+                root_domains[0],
+                axis_counts_items=((10, 1), (11, 4)),
+                block_sizes_items=((10, 1), (11, 32)),
+            ),
+            dataclasses.replace(
+                root_domains[1],
+                axis_counts_items=((20, 1), (21, 2)),
+                block_sizes_items=((20, 1), (21, 64)),
+            ),
+            root_domains[2],
+        )
+        short_schedule = _configured_static_pipeline_plan(
+            **{
+                **kwargs,
+                "root_domains": short_domains,
+                "axis_geometry": {
+                    10: (1, 1),
+                    11: (4, 32),
+                    20: (1, 1),
+                    21: (2, 64),
+                    30: (1, 1),
+                    31: (2, 64),
+                },
+            }
+        )
+        self.assertEqual(len(short_schedule.readiness_counters), 2)
+        self.assertEqual(
+            short_schedule.root_barrier_edges,
+            frozenset(),
+        )
+
+    def test_nested_split_nested_loop_at_readiness_follow_worker_readiness(
+        self,
+    ) -> None:
+        root_domains = (
+            _domain((10, 4, 1)),
+            _domain((20, 1, 1)),
+        )
+        root_domains = _identify_root_domains(root_domains)
+        nested_loop_domain = _domain((20, 1, 1), (21, 4, 1), identity=7)
+        readiness_key_domain = _domain((0, 4), kind="event", identity=0)
+        readiness_graph = _readiness_graph(
+            root_domains,
+            ReadinessEvent(
+                producers=(
+                    _readiness_producer_from_publication(
+                        producer_root=0,
+                        producer_site_id=None,
+                        publication=_full_point_map(
+                            root_domains[0],
+                            readiness_key_domain,
+                            coordinate_axis_symbol(10),
+                        ),
+                    ),
+                ),
+                consumers=(
+                    ReadinessConsumer(
+                        consumer_root=1,
+                        consumer_site_id=7,
+                        keys_by_consumer=_full_point_map(
+                            nested_loop_domain,
+                            readiness_key_domain,
+                            coordinate_axis_symbol(21),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        schedule = _schedule(
+            4,
+            _segment(
+                0,
+                _one_dimensional_task_range(root_domains[0], 0, 3),
+                workers=(0, 3),
+                dispatch_offset=0,
+            ),
+            _segment(
+                0,
+                _one_dimensional_task_range(root_domains[0], 3, 1),
+                workers=(0, 1),
+                dispatch_offset=1,
+            ),
+            _segment(
+                1,
+                readiness_graph.root_task_orders[1],
+                workers=(3, 1),
+                dispatch_offset=2,
+            ),
+        )
+
+        placed, plans = place_nested_loop_consumers(readiness_graph, schedule, ())
+
+        self.assertEqual(placement(placed, 1, 0), (3, 1))
+        self.assertEqual(len(plans), 1)
+        plan = plans[0]
+        self.assertEqual(
+            _expected_arrivals(plan.readiness_key_domain, plan.producers),
+            (3, 1),
+        )
+        self.assertEqual(
+            _publication(plan.producers[0]).materialize(),
+            (
+                frozenset((0,)),
+                frozenset((0,)),
+                frozenset((0,)),
+                frozenset((1,)),
+            ),
+        )
+        self.assertEqual(
+            plan.consumers[0].keys_by_consumer.materialize(),
+            (
+                frozenset((0,)),
+                frozenset((0,)),
+                frozenset((0,)),
+                frozenset((1,)),
+            ),
+        )
+        self.assertEqual(plan.consumers[0].consumer_site_id, 7)
+
+    def test_nested_nested_loop_entry_counter_survives_without_early_placement(
+        self,
+    ) -> None:
+        producer_domain = _domain((10, 2, 1), (11, 4, 1), identity=0)
+        consumer_domain = _domain((20, 2, 1), identity=1)
+        nested_loop_domain = _domain((20, 2, 1), (21, 4, 1), identity=7)
+        readiness_key_domain = _domain((0, 2), (1, 4), kind="event", identity=0)
+        readiness_graph = ReadinessGraph(
+            root_task_orders=(
+                pid_task_order(producer_domain, (10, 11)),
+                pid_task_order(consumer_domain, (20,)),
+            ),
+            events=(
+                ReadinessEvent(
+                    producers=(
+                        _readiness_producer_from_publication(
+                            producer_root=0,
+                            publication=_full_point_map(
+                                producer_domain,
+                                readiness_key_domain,
+                                coordinate_axis_symbol(10),
+                                coordinate_axis_symbol(11),
+                            ),
+                        ),
+                    ),
+                    consumers=(
+                        ReadinessConsumer(
+                            consumer_root=1,
+                            consumer_site_id=7,
+                            keys_by_consumer=_full_point_map(
+                                nested_loop_domain,
+                                readiness_key_domain,
+                                coordinate_axis_symbol(20),
+                                coordinate_axis_symbol(21),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        for worker_count in (1, 2):
+            with self.subTest(worker_count=worker_count):
+                schedule = _build_baseline_worker_schedule(
+                    readiness_graph.root_domains,
+                    readiness_graph.root_task_orders,
+                    worker_count=worker_count,
+                )
+
+                placed, plans = place_nested_loop_consumers(
+                    readiness_graph,
+                    schedule,
+                    (),
+                )
+
+                self.assertEqual(placed, schedule)
+                self.assertEqual(len(plans), 1)
+                self.assertEqual(plans[0].readiness_key_count, 2)
+                self.assertEqual(
+                    _expected_arrivals(
+                        plans[0].readiness_key_domain,
+                        plans[0].producers,
+                    ),
+                    (4, 4),
+                )
+                self.assertEqual(plans[0].consumers[0].consumer_site_id, 7)
+
+    def test_nested_site_identity_readiness_uses_one_split_point(self) -> None:
+        """Per-iteration readiness is coarsened to one compact split point."""
+        root_domains = (
+            _domain((10, 4, 1)),
+            _domain((20, 1, 1)),
+        )
+        root_domains = _identify_root_domains(root_domains)
+        nested_loop_domain = _domain((20, 1, 1), (21, 4, 1), identity=7)
+        readiness_key_domain = _domain((0, 4), kind="event", identity=0)
+        readiness_graph = _readiness_graph(
+            root_domains,
+            ReadinessEvent(
+                producers=(
+                    _readiness_producer_from_publication(
+                        producer_root=0,
+                        publication=_full_point_map(
+                            root_domains[0],
+                            readiness_key_domain,
+                            coordinate_axis_symbol(10),
+                        ),
+                    ),
+                ),
+                consumers=(
+                    ReadinessConsumer(
+                        consumer_root=1,
+                        consumer_site_id=7,
+                        keys_by_consumer=_full_point_map(
+                            nested_loop_domain,
+                            readiness_key_domain,
+                            coordinate_axis_symbol(21),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        schedule = _schedule(
+            4,
+            _segment(
+                0,
+                readiness_graph.root_task_orders[0],
+                workers=(0, 1),
+                dispatch_offset=0,
+            ),
+            _segment(
+                1,
+                readiness_graph.root_task_orders[1],
+                workers=(3, 1),
+                dispatch_offset=5,
+            ),
+        )
+
+        placed, plans = place_nested_loop_consumers(readiness_graph, schedule, ())
+
+        self.assertEqual(placement(placed, 1, 0), (3, 1))
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(
+            _expected_arrivals(plans[0].readiness_key_domain, plans[0].producers),
+            (1, 3),
+        )
+
+    def test_nested_loop_placement_keeps_transitive_worker_liveness(
+        self,
+    ) -> None:
+        """A moved wait must not block an upstream prerequisite on its worker."""
+        root_domains = (
+            _domain((10, 4, 1)),
+            _domain((20, 4, 1)),
+            _domain((30, 1, 1)),
+        )
+        root_domains = _identify_root_domains(root_domains)
+        nested_loop_domain = _domain((30, 1, 1), (31, 4, 1), identity=7)
+
+        def identity_keys(
+            source_domain: CoordinateDomain,
+            source_axis: int,
+            event_id: int,
+        ) -> tuple[CoordinateDomain, CoordinateRelation]:
+            readiness_key_domain = _domain((0, 4), kind="event", identity=event_id)
+            return readiness_key_domain, CoordinateRelation.point_map(
+                source_domain,
+                readiness_key_domain,
+                (
+                    (
+                        tuple(
+                            (axis, 0, source_domain.axis_counts[axis], 1)
+                            for axis in source_domain.axis_order
+                        ),
+                        (coordinate_axis_symbol(source_axis),),
+                    ),
+                ),
+            )
+
+        first_keys, a_to_first = identity_keys(root_domains[0], 10, 0)
+        _, first_use = identity_keys(root_domains[1], 20, 0)
+        second_keys, b_to_second = identity_keys(root_domains[1], 20, 1)
+        _, nested_keys_by_consumer = identity_keys(nested_loop_domain, 31, 1)
+        readiness_graph = _readiness_graph(
+            root_domains,
+            ReadinessEvent(
+                producers=(_readiness_producer_from_publication(0, a_to_first),),
+                consumers=(ReadinessConsumer(1, first_use),),
+            ),
+            ReadinessEvent(
+                producers=(_readiness_producer_from_publication(1, b_to_second),),
+                consumers=(
+                    ReadinessConsumer(2, nested_keys_by_consumer, consumer_site_id=7),
+                ),
+            ),
+        )
+
+        def task_segment(
+            root: int,
+            task_begin: int,
+            task_count: int,
+            worker: int,
+            worker_step: int,
+        ) -> WorkerScheduleSegment:
+            return _segment(
+                root,
+                _one_dimensional_task_range(root_domains[root], task_begin, task_count),
+                workers=(worker, task_count),
+                dispatch_offset=worker_step * task_count,
+            )
+
+        schedule = _schedule(
+            4,
+            task_segment(0, 0, 3, 0, 0),
+            task_segment(0, 3, 1, 3, 3),
+            task_segment(1, 0, 3, 0, 1),
+            task_segment(1, 3, 1, 0, 4),
+            task_segment(2, 0, 1, 3, 6),
+        )
+
+        placed, plans = place_nested_loop_consumers(readiness_graph, schedule, ())
+
+        # Worker 3 looks idle at step 2, but its A task at step 3 is a
+        # prerequisite of B task 3. Placing C there would form C -> B -> A
+        # while A remains later on C's blocked worker. Worker 2 is safe.
+        self.assertEqual(placement(placed, 2, 0), (2, 2))
+        self.assertEqual(len(plans), 1)
+        validate_worker_schedule(readiness_graph, placed)
+
+    def test_nested_loop_placement_preserves_source_order_on_each_worker(
+        self,
+    ) -> None:
+        root_domains = _identify_root_domains(
+            (
+                _domain((10, 5, 1)),
+                _domain((20, 4, 1)),
+                _domain((30, 1, 1)),
+            )
+        )
+        nested_loop_domain = _domain((30, 1, 1), (31, 5, 1), identity=7)
+        nested_key_domain = _domain((0, 5), kind="event", identity=0)
+        producer_to_key = _full_point_map(
+            root_domains[0], nested_key_domain, coordinate_axis_symbol(10)
+        )
+        producers_by_key = producer_to_key.converse()
+        assert producers_by_key is not None
+        keys_by_nested_iteration = _full_point_map(
+            nested_loop_domain, nested_key_domain, coordinate_axis_symbol(31)
+        )
+        family_done_domain = _domain(kind="event", identity=1)
+        readiness_graph = _readiness_graph(
+            root_domains,
+            ReadinessEvent(
+                producers=(ReadinessProducer(0, producers_by_key),),
+                consumers=(
+                    ReadinessConsumer(2, keys_by_nested_iteration, consumer_site_id=7),
+                ),
+            ),
+            ReadinessEvent(
+                producers=(
+                    ReadinessProducer(
+                        1, CoordinateRelation.total(family_done_domain, root_domains[1])
+                    ),
+                ),
+                consumers=(
+                    ReadinessConsumer(
+                        2, CoordinateRelation.total(root_domains[2], family_done_domain)
+                    ),
+                ),
+            ),
+        )
+        baseline = _build_baseline_worker_schedule(
+            readiness_graph.root_domains,
+            readiness_graph.root_task_orders,
+            worker_count=4,
+        )
+
+        placed, plans = place_nested_loop_consumers(readiness_graph, baseline, ())
+
+        self.assertEqual(placement(baseline, 2, 0), (0, 3))
+        self.assertEqual(placement(placed, 2, 0), (0, 3))
+        self.assertEqual(len(plans), 1)
+        validate_worker_schedule(readiness_graph, placed)
+
+    def test_nested_split_nested_loop_at_readiness_compose_sibling_sites(self) -> None:
+        root_domains = (
+            _domain((10, 4, 1)),
+            _domain((20, 4, 1)),
+            _domain((30, 1, 1)),
+        )
+        root_domains = _identify_root_domains(root_domains)
+        nested_loop_domains = tuple(
+            _domain((30, 1, 1), (nested_axis, 4, 1), identity=site_id)
+            for site_id, nested_axis in ((7, 31), (8, 32))
+        )
+        site_domains: tuple[CoordinateDomain | None, ...] = (
+            *(None for _ in range(7)),
+            *nested_loop_domains,
+        )
+        events = []
+        for producer_root, site_id, nested_axis in ((0, 7, 31), (1, 8, 32)):
+            readiness_key_domain = _domain((0, 4), kind="event", identity=producer_root)
+            events.append(
+                ReadinessEvent(
+                    producers=(
+                        _readiness_producer_from_publication(
+                            producer_root=producer_root,
+                            producer_site_id=None,
+                            publication=_full_point_map(
+                                root_domains[producer_root],
+                                readiness_key_domain,
+                                coordinate_axis_symbol(
+                                    root_domains[producer_root].axis_order[0]
+                                ),
+                            ),
+                        ),
+                    ),
+                    consumers=(
+                        ReadinessConsumer(
+                            consumer_root=2,
+                            consumer_site_id=site_id,
+                            keys_by_consumer=_full_point_map(
+                                site_domains[site_id],
+                                readiness_key_domain,
+                                coordinate_axis_symbol(nested_axis),
+                            ),
+                            covered_obligations=frozenset(
+                                ((producer_root, None, site_id),)
+                            ),
+                        ),
+                    ),
+                )
+            )
+        readiness_graph = _readiness_graph(root_domains, *events)
+        schedule = _schedule(
+            4,
+            _segment(
+                0,
+                _one_dimensional_task_range(root_domains[0], 0, 4),
+                workers=(0, 4),
+                dispatch_offset=0,
+            ),
+            _segment(
+                1,
+                _one_dimensional_task_range(root_domains[1], 0, 3),
+                workers=(0, 4),
+                dispatch_offset=4,
+            ),
+            _segment(
+                1,
+                _one_dimensional_task_range(root_domains[1], 3, 1),
+                workers=(0, 4),
+                dispatch_offset=8,
+            ),
+            _segment(
+                2,
+                readiness_graph.root_task_orders[2],
+                workers=(3, 1),
+                dispatch_offset=3,
+            ),
+        )
+
+        placed, plans = place_nested_loop_consumers(readiness_graph, schedule, ())
+
+        self.assertEqual(placement(placed, 2, 0), (3, 1))
+        self.assertEqual(len(plans), 2)
+        plans_by_site = {plan.consumers[0].consumer_site_id: plan for plan in plans}
+        self.assertEqual(
+            _expected_arrivals(
+                plans_by_site[7].readiness_key_domain,
+                plans_by_site[7].producers,
+            ),
+            (4,),
+        )
+        self.assertEqual(
+            plans_by_site[7].consumers[0].keys_by_consumer.materialize(),
+            (frozenset((0,)),) * 4,
+        )
+        self.assertEqual(
+            _expected_arrivals(
+                plans_by_site[8].readiness_key_domain,
+                plans_by_site[8].producers,
+            ),
+            (4,),
+        )
+        self.assertEqual(
+            plans_by_site[8].consumers[0].keys_by_consumer.materialize(),
+            (
+                frozenset((0,)),
+                frozenset((0,)),
+                frozenset((0,)),
+                frozenset((0,)),
+            ),
+        )
+
+    def test_multi_producer_join_uses_one_readiness_event(self) -> None:
+        dependency_graph = _dependency_graph(
+            [[10], [20], [30]],
+            _access(root=0, kind="store", block_ids=(10,)),
+            _access(root=1, allocation_id=1, kind="store", block_ids=(20,)),
+            _access(root=2, kind="load", block_ids=(30,)),
+            _access(root=2, allocation_id=1, kind="load", block_ids=(30,)),
+        )
+        root_domains = tuple(
+            _domain((block_id, 8, 16)) for root, block_id in enumerate((10, 20, 30))
+        )
+
+        schedule = _configured_static_pipeline_plan(
+            dependency_graph=dependency_graph,
+            root_domains=root_domains,
+            axis_geometry={10: (8, 16), 20: (8, 16), 30: (8, 16)},
+            worker_count=8,
+        )
+
+        self.assertEqual(schedule.root_barrier_edges, frozenset())
+        self.assertEqual(len(schedule.readiness_counters), 1)
+        event = schedule.readiness_counters[0]
+        self.assertEqual(event.consumers[0].consumer_root, 2)
+        self.assertEqual(event.uniform_arrival_count(), 2)
+        self.assertEqual(
+            [
+                (
+                    readiness_producer.producer_root,
+                    readiness_producer.arrival_count_by_key.constant_value()
+                    if readiness_producer.arrival_count_by_key is not None
+                    else None,
+                )
+                for readiness_producer in event.producers
+            ],
+            [(0, 1), (1, 1)],
+        )
+
+    def test_repeated_join_producers_coalesce_consumer_tasks(self) -> None:
+        dependency_graph = _dependency_graph(
+            [[10], [30], [22, 20, 21]],
+            _access(root=0, kind="store", shape=(32,), block_ids=(10,)),
+            _access(root=1, allocation_id=1, kind="store", shape=(8,), block_ids=(30,)),
+            _access(root=2, kind="load", shape=(8, 4), block_ids=(20, 21)),
+            _access(root=2, allocation_id=1, kind="load", shape=(8,), block_ids=(20,)),
+        )
+        root_domains = (
+            _domain((10, 32, 1)),
+            _domain((30, 8, 1)),
+            _domain((22, 4, 1), (20, 8, 1), (21, 1, 4)),
+        )
+
+        schedule = _configured_static_pipeline_plan(
+            dependency_graph=dependency_graph,
+            root_domains=root_domains,
+            axis_geometry={
+                10: (32, 1),
+                20: (8, 1),
+                21: (1, 4),
+                22: (4, 1),
+                30: (8, 1),
+            },
+            worker_count=32,
+        )
+
+        self.assertEqual(schedule.root_barrier_edges, frozenset())
+        self.assertEqual(len(schedule.readiness_counters), 1)
+        self.assertFalse(
+            any(
+                event.continuation_consumer is not None
+                for event in schedule.readiness_counters
+            )
+        )
+        event = schedule.readiness_counters[0]
+        self.assertIsNone(event.continuation_consumer)
+        self.assertEqual(event.readiness_key_count, 8)
+        self.assertEqual(event.uniform_arrival_count(), 5)
+        self.assertEqual(
+            event.consumers[0].keys_by_consumer.materialize(),
+            tuple(frozenset((i // 4,)) for i in range(32)),
+        )
+        self.assertEqual(
+            [
+                readiness_producer.arrival_count_by_key.constant_value()
+                if readiness_producer.arrival_count_by_key is not None
+                else None
+                for readiness_producer in event.producers
+            ],
+            [4, 1],
+        )
+
+    def test_large_flattened_ready_groups_have_no_task_product_cutoff(self) -> None:
+        heads = 513
+        width = 4
+        splits = 4
+        elements = heads * width
+        dependency_graph = _dependency_graph(
+            [[10], [22, 20, 21]],
+            _access(root=0, kind="store", shape=(elements,), block_ids=(10,)),
+            _access(root=1, kind="load", shape=(heads, width), block_ids=(20, 21)),
+        )
+        root_domains = (
+            _domain((10, elements, 1)),
+            _domain((22, splits, 1), (20, heads, 1), (21, 1, width)),
+        )
+
+        schedule = _configured_static_pipeline_plan(
+            dependency_graph=dependency_graph,
+            root_domains=root_domains,
+            axis_geometry={
+                10: (elements, 1),
+                20: (heads, 1),
+                21: (1, width),
+                22: (splits, 1),
+            },
+            worker_count=128,
+        )
+
+        self.assertEqual(schedule.root_barrier_edges, frozenset())
+        self.assertEqual(len(schedule.readiness_counters), 1)
+        event = schedule.readiness_counters[0]
+        self.assertEqual(event.readiness_key_count, heads)
+        self.assertEqual(event.uniform_arrival_count(), width)
+        self.assertEqual(
+            event.consumers[0].keys_by_consumer.materialize(),
+            tuple(frozenset((task // splits,)) for task in range(heads * splits)),
+        )
+        self.assertEqual(len(event.producers[0].producers_by_key.pieces), 1)
+        self.assertEqual(len(event.consumers[0].keys_by_consumer.pieces), 1)
+
+    def test_strided_ready_groups_use_exact_coordinates_with_overlapping_hulls(
+        self,
+    ) -> None:
+        columns = 8
+        splits = 4
+        dependency_graph = _dependency_graph(
+            [[10], [22, 20]],
+            _access(
+                root=0,
+                kind="store",
+                shape=(2, columns),
+                block_ids=(None, 10),
+                full_slice=(True, False),
+            ),
+            _access(
+                root=1,
+                kind="load",
+                shape=(2, columns),
+                block_ids=(None, 20),
+                full_slice=(True, False),
+            ),
+        )
+        root_domains = (
+            _domain((10, columns, 1)),
+            _domain((22, splits, 1), (20, columns, 1)),
+        )
+
+        schedule = _configured_static_pipeline_plan(
+            dependency_graph=dependency_graph,
+            root_domains=root_domains,
+            axis_geometry={10: (columns, 1), 20: (columns, 1), 22: (splits, 1)},
+            worker_count=32,
+        )
+
+        self.assertEqual(schedule.root_barrier_edges, frozenset())
+        self.assertEqual(len(schedule.readiness_counters), 1)
+        event = schedule.readiness_counters[0]
+        self.assertEqual(event.readiness_key_count, columns)
+        self.assertEqual(event.uniform_arrival_count(), 1)
+        self.assertEqual(
+            event.consumers[0].keys_by_consumer.materialize(),
+            tuple(frozenset((task // splits,)) for task in range(columns * splits)),
+        )
+
+    def test_multiple_access_events_in_one_root_fall_back_together(self) -> None:
+        dependency_graph = _dependency_graph(
+            [[10, 11], [20, 21], [30]],
+            # Deliberately incomplete affine metadata forces conservative fallback.
+            _access(
+                root=0,
+                kind="store",
+                shape=(1, 128),
+                block_ids=(10, 11),
+                scales=(1,),
+                offsets=(0,),
+            ),
+            _access(
+                root=1,
+                allocation_id=1,
+                kind="store",
+                shape=(1, 128),
+                block_ids=(20, 21),
+                scales=(1,),
+                offsets=(0,),
+            ),
+            _access(
+                root=2,
+                kind="load",
+                shape=(1, 128),
+                block_ids=(30, 31),
+                scales=(1,),
+                offsets=(0,),
+            ),
+            _access(
+                root=2,
+                allocation_id=1,
+                kind="load",
+                shape=(1, 128),
+                block_ids=(30, 32),
+                scales=(1,),
+                offsets=(0,),
+            ),
+        )
+        root_domains = (
+            _domain((10, 1, 1), (11, 8, 16)),
+            _domain((20, 1, 1), (21, 8, 16)),
+            _domain((30, 1, 1)),
+        )
+
+        schedule = _configured_static_pipeline_plan(
+            dependency_graph=dependency_graph,
+            root_domains=root_domains,
+            axis_geometry={
+                10: (1, 1),
+                11: (8, 16),
+                20: (1, 1),
+                21: (8, 16),
+                30: (1, 1),
+                31: (8, 16),
+                32: (8, 16),
+            },
+            worker_count=4,
+        )
+
+        self.assertEqual(
+            schedule.root_barrier_edges,
+            frozenset(((0, 2), (1, 2))),
+        )
+
+    def test_worker_schedule_handles_independent_components(self) -> None:
+        accesses: list[TileAccess] = []
+        root_domains: list[CoordinateDomain] = []
+        axis_geometry: dict[int, tuple[int, int]] = {}
+        for component in range(2):
+            root_base = component * 3
+            block_base = 10 + component * 30
+            access_base = component * 4
+            allocation_base = component * 2
+            accesses.extend(
+                (
+                    _access(
+                        root=root_base,
+                        allocation_id=allocation_base,
+                        kind="store",
+                        shape=(1, 128),
+                        block_ids=(block_base, block_base + 1),
+                    ),
+                    _access(
+                        root=root_base + 1,
+                        allocation_id=allocation_base,
+                        kind="load",
+                        shape=(1, 128),
+                        block_ids=(block_base + 10, block_base + 11),
+                    ),
+                    _access(
+                        root=root_base + 1,
+                        allocation_id=allocation_base + 1,
+                        kind="store",
+                        shape=(1, 128),
+                        block_ids=(block_base + 10, block_base + 11),
+                    ),
+                    _access(
+                        root=root_base + 2,
+                        allocation_id=allocation_base + 1,
+                        kind="load",
+                        shape=(1, 128),
+                        block_ids=(block_base + 20, block_base + 21),
+                    ),
+                )
+            )
+            root_domains.extend(
+                (
+                    _domain((block_base, 1, 1), (block_base + 1, 8, 16)),
+                    _domain((block_base + 10, 1, 1), (block_base + 11, 4, 32)),
+                    _domain((block_base + 20, 1, 1)),
+                )
+            )
+            axis_geometry.update(
+                {
+                    block_base: (1, 1),
+                    block_base + 1: (8, 16),
+                    block_base + 10: (1, 1),
+                    block_base + 11: (4, 32),
+                    block_base + 20: (1, 1),
+                    block_base + 21: (4, 32),
+                }
+            )
+
+        dependency_graph = _dependency_graph(
+            [list(domain.axis_order) for domain in root_domains], *tuple(accesses)
+        )
+        root_sites = tuple(
+            ExecutionSite(
+                site_id=root,
+                root=root,
+                graph_id=root,
+                callsite_path=(),
+                parent_site_id=None,
+                kind="root",
+                local_axis_order=domain.axis_order,
+                logical_axis_order=domain.axis_order,
+                executes_unconditionally=True,
+                can_split_loop=False,
+            )
+            for root, domain in enumerate(root_domains)
+        )
+        nested_loops = tuple(
+            ExecutionSite(
+                site_id=6 + component,
+                root=component * 3 + 2,
+                graph_id=6 + component,
+                callsite_path=((0, 0),),
+                parent_site_id=component * 3 + 2,
+                kind="loop",
+                local_axis_order=(10 + component * 30 + 21,),
+                logical_axis_order=(
+                    10 + component * 30 + 20,
+                    10 + component * 30 + 21,
+                ),
+                executes_unconditionally=True,
+                can_split_loop=True,
+            )
+            for component in range(2)
+        )
+        site_ids_by_access: list[tuple[int, ...]] = [()] * len(accesses)
+        for component in range(2):
+            root_base = component * 3
+            access_base = component * 4
+            site_ids_by_access[access_base] = (root_base,)
+            site_ids_by_access[access_base + 1] = (root_base + 1,)
+            site_ids_by_access[access_base + 2] = (root_base + 1,)
+            site_ids_by_access[access_base + 3] = (6 + component,)
+        dependency_graph = dataclasses.replace(
+            dependency_graph,
+            execution_sites=(*root_sites, *nested_loops),
+            site_ids_by_access=tuple(site_ids_by_access),
+        )
+        kwargs = {
+            "dependency_graph": dependency_graph,
+            "root_domains": tuple(root_domains),
+            "axis_geometry": axis_geometry,
+            "worker_count": 8,
+        }
+
+        schedule = _configured_static_pipeline_plan(**kwargs)
+        self.assertEqual(len(schedule.readiness_counters), 4)
+        self.assertEqual(
+            schedule.root_barrier_edges,
+            frozenset(),
+        )
+        overlapped = _configured_static_pipeline_plan(**{**kwargs, "worker_count": 6})
+        self.assertEqual(overlapped.worker_schedule.worker_count, 6)
+        nested_loop_events = tuple(
+            plan
+            for plan in overlapped.readiness_counters
+            if any(
+                readiness_consumer.consumer_site_id is not None
+                for readiness_consumer in plan.consumers
+            )
+        )
+        self.assertEqual(
+            [
+                (
+                    plan.producers[0].producer_root,
+                    plan.consumers[0].consumer_root,
+                    _expected_arrivals(plan.readiness_key_domain, plan.producers),
+                )
+                for plan in nested_loop_events
+            ],
+            [(1, 2, (3, 1)), (4, 5, (3, 1))],
+        )
+        self.assertEqual(overlapped.root_barrier_edges, frozenset())
+        self.assertEqual(placement(overlapped.worker_schedule, 2, 0), (5, 1))
+        self.assertEqual(placement(overlapped.worker_schedule, 5, 0), (5, 5))


### PR DESCRIPTION
This diff stack provides an initial design for scheduling thread blocks across separate outer loops, in order to reduce cross kernel bubbles (i.e. megakernel scheduling).

This specific PR adds the symbolic scheduler that consumes the tile-dependency model introduced by the previous PR. Keep in mind, this PR does **not** do the lowering. that will be a follow-up PR. The scheduler answers three questions:

1. Which tasks should execute on each persistent worker?
2. When is each consumer task ready to execute?
3. Which producer should publish the final readiness signal?

The scheduler stores the first answer in a `WorkerSchedule`. It stores the second and third answers in `ReadinessEvents` and `ReadinessCounterPlans`. The final result is a `StaticPipelinePlan`.

This second PR contains the scheduling machinery, but does not do any code generation or runtime lowering.

The scheduler has these stages:

```text
TileDependencyGraph and configured CoordinateRelations
        ↓
Logical task order for each outer loop
        ↓
Symbolic readiness events
        ↓
Static worker placement
        ↓
Readiness counters and final-arrival continuations
        ↓
StaticPipelinePlan
```

A `WorkerSchedule` assigns logical tasks to a fixed set of persistent workers. It stores compressed schedule segments rather than one entry per task.

For a task-order index, the placement is:
```python
dispatch index = dispatch offset + task-order index
worker = worker begin + dispatch index % worker count
worker step = dispatch index // worker count
```
This representation supports arbitrarily large task domains without materializing a task-sized schedule.

A `ReadinessEvent` describes a symbolic synchronization point shared by one or more producers and consumers.

Each event has a readiness-key coordinate domain. A producer relation maps each readiness key to the producer tasks that must arrive. A consumer relation maps each consumer task to the readiness key it must observe.

The expected counter value is derived symbolically from the producer relation. It is not computed by enumerating producer tasks.

A `ReadinessCounterPlan` selects the events that can be lowered to counted readiness signals. A consumer can wait for its key, or the producer that performs the final arrival can execute the consumer directly as a `FinalArrivalContinuation`.

Nested execution sites use the same model. The scheduler can place a wait at a nested loop entry or split a nested loop at the first iteration whose dependencies are ready.

When an exact relation cannot be represented or lowered safely, the scheduler conservatively coarsens that dependency to family completion or a root barrier. It does not discard the dependency.

Let's continue the routed FFN example from the tile-dependency PR.

For consumer task (r, b), the tile-dependency model produces:
$$R(r, b) = (r, [16b, 16b + 16)) \cup (r, [16b + 128, 16b + 144))$$

Each SwiGLU task therefore requires 32 W13 tasks.

The scheduler can use $(r, b)$ as a readiness key:

```text
readiness key:     (r, b)
producer arrivals: 32 W13 tasks
consumer:          SwiGLU task (r, b)
expected count:    32

```

Once those 32 arrivals have completed, $(r, b)$ is ready even if unrelated W13 tasks are still running. The worker performing the final arrival can continue directly into that SwiGLU task when the placement is progress-safe.

This exposes overlap between the W13 and SwiGLU outer loops without changing their dependency semantics or requiring a kernel boundary.

This PR is intentionally not connected to a config parameter, generated Triton, persistent runtime state, or the launcher. The follow-up static-pipeline PR lowers `StaticPipelinePlan` into one persistent kernel.

The tests use an independent materialized oracle for small domains and cover joins, fanout, nested loops, partial and strided accesses, mixed exact and conservative readiness, cycles, continuations, and independent graph components. Large-domain tests verify that scheduling remains symbolic.