### PR TITLE
[cutedsl] Register-resident SIMT row reductions: vec stores, strided lanes, one reduce per sweep, thread-block clusters

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -8,6 +8,8 @@ from .cute import CuteFlashAttentionHeuristic
 from .cute import CuteFp8GemmSkinnyMHeuristic
 from .cute import CuteReductionTileHeuristic
 from .cute import CuteReductionWideChunkHeuristic
+from .cute import CuteResidentMultiRowHeuristic
+from .cute import CuteResidentRowHeuristic
 from .cute import CuteTcgen05ClusterM2FfiHeuristic
 from .cute import CuteTcgen05ClusterM2Heuristic
 from .cute import CuteTcgen05GroupedDynamicBk64Heuristic
@@ -57,6 +59,8 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteTileVecHeuristic,
         CuteTileVecWarpReduceHeuristic,
         CuteTileVecWarpPerRowHeuristic,
+        CuteResidentRowHeuristic,
+        CuteResidentMultiRowHeuristic,
     ),
     "triton": (
         # H100 dense matmul seed FIRST so its budget-formula config is the rank-0

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -157,21 +157,15 @@ class CuteReductionTileHeuristic(AutotunerHeuristic):
 def _cute_tile_seed_vec_width_for_dtype(dtype: torch.dtype | None) -> int:
     """V seed for ``PerThreadNDTileStrategy`` lane-loop vec on a given dtype.
 
-    Returns 4 for fp32 (LDG.128 = 16 bytes), 4 for fp16/bf16 (LDG.64,
-    8 bytes per thread per outer iter).  Note: V=8 for fp16/bf16 IS now
-    supported via a 2x V=4 split (see
-    ``_cute_register_tile_unroll_vec_hoist_split2``), but the autotuner
-    seed stays at 4 because the split emits two LDG.64s rather than a
-    single LDG.128 — empirically the per-element bookkeeping in the 8-
-    iter constexpr V-loop and the doubled fuser cache offset the
-    extra bytes-per-load.  The split path stays available as a
-    reachable point in the autotuner's V search space for shapes where
-    it does win.
+    Seeds a full 16-byte LDG.128 per thread per outer iter: V=4 for fp32,
+    V=8 for fp16/bf16 (a single ``cute.arch.load(..., V=8)``; the old 4+4
+    split workaround for the ``nvvm.load.ext`` ICE is gone as of cutlass
+    4.7).
     """
     if dtype is torch.float32:
         return 4
     if dtype in (torch.float16, torch.bfloat16):
-        return 4
+        return 8
     return 1
 
 
@@ -359,6 +353,173 @@ class CuteTileVecWarpReduceHeuristic(AutotunerHeuristic):
             "block_sizes": [1, block_n],
             "num_threads": [0, 32],
             "cute_vector_widths": [1, vec],
+        }
+        try:
+            return Config(**seed)
+        except Exception:
+            return None
+
+
+class CuteResidentRowHeuristic(AutotunerHeuristic):
+    """Register-resident whole-row seed for softmax-shaped tile kernels.
+
+    Seeds ``block_sizes=[1, N]`` (the whole reduction axis as one tile) with
+    a multi-warp thread block, V=8 vec loads/stores, and the strided
+    (coalesced) lane layout.  With the single-trip tile loop the cross-sweep
+    load fuser caches the row in a register fragment (one gmem read for the
+    whole kernel), the lane-reduce collapse runs ONE grouped reduction per
+    sweep, and the vec-store flush writes 128-bit stores.  Measured ~2x over
+    the warp-reduce family on (32768, 4096..16384) bf16 rows on B200.
+    """
+
+    name = "cute_resident_row"
+    backend = "cute"
+
+    @classmethod
+    def _plan(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> tuple[int, int, int, int] | None:
+        """Return ``(row_extent, num_threads, vec, cluster_n)`` or None."""
+        spec = env.config_spec
+        if spec.matmul_facts:
+            return None
+        if len(spec.block_sizes) != 2 or spec.reduction_loops:
+            return None
+        inner = cast("Any", spec.block_sizes[1])
+        inner_block_id = inner.block_ids[0] if hasattr(inner, "block_ids") else None
+        if inner_block_id is None:
+            return None
+        if inner_block_id not in spec.cute_vector_widths.valid_block_ids():
+            return None
+        if inner_block_id not in spec.cute_lane_layouts.valid_block_ids():
+            return None
+        dtype = _cute_tile_inner_block_dtype(env, device_ir, inner_block_id)
+        vec = _cute_tile_seed_vec_width_for_dtype(dtype)
+        if vec <= 1:
+            return None
+        try:
+            n = int(env.block_sizes[inner_block_id].numel)
+        except (TypeError, ValueError):
+            return None
+        # The whole-row block must be a reachable block size (power of 2)
+        # and fit the per-thread register budget at some thread count.
+        if n & (n - 1) or n <= 0:
+            return None
+        bn_fragment = inner._fragment(spec)
+        bn_high = getattr(bn_fragment, "high", None)
+        if not isinstance(bn_high, int) or bn_high < n:
+            return None
+        # Prefer <=64 elements per thread (no spills) at 256 threads, using
+        # the smallest cluster that fits — a 256-thread CTA with a wider
+        # cluster measures well ahead of a 512-thread CTA at the same
+        # per-thread footprint (5090 vs 3374 GB/s on 32768x32768 bf16).
+        # Each cluster CTA owns a contiguous register-resident slice; one
+        # DSM cluster reduce per sweep.
+        for threads in (256, 512, 128):
+            for cluster_n in (1, 2, 4, 8, 16):
+                per_cta = n // cluster_n
+                if per_cta % (threads * vec) == 0 and per_cta // threads <= 64:
+                    return n, threads, vec, cluster_n
+        return None
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return cls._plan(env, device_ir) is not None
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        plan = cls._plan(env, device_ir)
+        if plan is None:
+            return None
+        n, threads, vec, cluster_n = plan
+        seed: dict[str, Any] = {
+            "block_sizes": [1, n],
+            "num_threads": [0, threads],
+            "cute_vector_widths": [1, vec],
+            "cute_lane_layouts": ["blocked", "strided"],
+        }
+        if cluster_n > 1:
+            seed["cute_cluster_n"] = cluster_n
+        if cluster_n >= 4:
+            # Wide clusters need occupancy over registers (measured +9-27%
+            # at cluster 4-16 on B200).
+            seed["cute_min_blocks_per_mp"] = 3
+        try:
+            return Config(**seed)
+        except Exception:
+            return None
+
+
+class CuteResidentMultiRowHeuristic(AutotunerHeuristic):
+    """Multi-row variant of ``CuteResidentRowHeuristic`` for short rows.
+
+    A short reduction axis (N <= 2048) leaves a whole-row CTA with too few
+    threads/CTAs doing too little work each; packing several rows per CTA
+    with one warp per row keeps the reduction a pure warp shuffle (no
+    shared memory) while restoring the CTA size.
+    """
+
+    name = "cute_resident_multi_row"
+    backend = "cute"
+
+    _ROWS_PER_CTA = 4
+    _THREADS_PER_ROW = 32
+    _MAX_ROW_EXTENT = 2048
+
+    @classmethod
+    def _plan(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> tuple[int, int] | None:
+        spec = env.config_spec
+        if spec.matmul_facts:
+            return None
+        if len(spec.block_sizes) != 2 or spec.reduction_loops:
+            return None
+        inner = cast("Any", spec.block_sizes[1])
+        inner_block_id = inner.block_ids[0] if hasattr(inner, "block_ids") else None
+        if inner_block_id is None:
+            return None
+        if inner_block_id not in spec.cute_vector_widths.valid_block_ids():
+            return None
+        if inner_block_id not in spec.cute_lane_layouts.valid_block_ids():
+            return None
+        dtype = _cute_tile_inner_block_dtype(env, device_ir, inner_block_id)
+        vec = _cute_tile_seed_vec_width_for_dtype(dtype)
+        if vec <= 1:
+            return None
+        try:
+            n = int(env.block_sizes[inner_block_id].numel)
+        except (TypeError, ValueError):
+            return None
+        if n & (n - 1) or n <= 0 or n > cls._MAX_ROW_EXTENT:
+            return None
+        if n % (cls._THREADS_PER_ROW * vec) != 0:
+            return None
+        bn_fragment = inner._fragment(spec)
+        bn_high = getattr(bn_fragment, "high", None)
+        if not isinstance(bn_high, int) or bn_high < n:
+            return None
+        return n, vec
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return cls._plan(env, device_ir) is not None
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        plan = cls._plan(env, device_ir)
+        if plan is None:
+            return None
+        n, vec = plan
+        seed: dict[str, Any] = {
+            "block_sizes": [cls._ROWS_PER_CTA, n],
+            "num_threads": [cls._ROWS_PER_CTA, cls._THREADS_PER_ROW],
+            "cute_vector_widths": [1, vec],
+            "cute_lane_layouts": ["blocked", "strided"],
         }
         try:
             return Config(**seed)

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -709,6 +709,11 @@ class Backend(abc.ABC):
         """Cast a lane variable for addition to an index expression."""
         raise exc.BackendUnsupported(self.name, "lane offset")
 
+    def thread_index_expr(self, *, axis: int) -> str:
+        """Bare thread index expression (no elements-per-thread stride),
+        used by the strided lane layout."""
+        raise exc.BackendUnsupported(self.name, "thread index")
+
     def reduction_combine_expr(
         self,
         reduction_type: str,

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -905,6 +905,9 @@ class CuteBackend(Backend):
         if (
             key == "num_threads"
             or key == "cute_vector_widths"
+            or key == "cute_lane_layouts"
+            or key == "cute_cluster_n"
+            or key == "cute_min_blocks_per_mp"
             or key.startswith(("tcgen05_", "cute_flash_"))
         ):
             return True
@@ -924,6 +927,8 @@ class CuteBackend(Backend):
             # does not support scalar dereference for its 4-bit type yet, so
             # SIMT scalar loads treat the tensor as raw byte storage.
             return "cutlass.Uint8"
+        if dtype is torch.uint32:
+            return "cutlass.Uint32"
         if dtype is torch.uint64:
             return "cutlass.Int64"
 
@@ -1149,6 +1154,7 @@ class CuteBackend(Backend):
             "_cute_grouped_reduce_shared_tree": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_shared_tree",
             "_cute_grouped_reduce_shared_two_stage": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_shared_two_stage",
             "_cute_grouped_reduce_warp": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_warp",
+            "_cute_grouped_reduce_cluster": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_cluster",
             "_cute_pre_vec_fold": "from helion._compiler.cute.reduce_helpers import _cute_pre_vec_fold",
             "_cute_store_shared_remote_x4": "from helion._compiler.cute.cluster_helpers import store_shared_remote_x4 as _cute_store_shared_remote_x4",
             "_cute_issue_clc_query_nomulticast": "from helion._compiler.cute.clc_helpers import issue_clc_query_nomulticast as _cute_issue_clc_query_nomulticast",
@@ -1158,6 +1164,7 @@ class CuteBackend(Backend):
             "_cute_float4_e2m1fn_x2_to_float32": "from helion._compiler.cute.quantized_helpers import float4_e2m1fn_x2_to_float32 as _cute_float4_e2m1fn_x2_to_float32",
             "_cute_float4_e2m1fn_x16_to_float16": "from helion._compiler.cute.quantized_helpers import float4_e2m1fn_x16_to_float16 as _cute_float4_e2m1fn_x16_to_float16",
             "_cute_bfloat16_x16_to_float16": "from helion._compiler.cute.quantized_helpers import bfloat16_x16_to_float16 as _cute_bfloat16_x16_to_float16",
+            "_cute_store_u16_vec": "from helion._compiler.cute.vec_utils import store_u16_vec as _cute_store_u16_vec",
             "_cute_grid_barrier": "from helion._compiler.cute.grid_barrier import grid_barrier as _cute_grid_barrier",
             "_cute_atomic_max_float32": "from helion._compiler.cute.atomic_helpers import atomic_max_float32 as _cute_atomic_max_float32",
             "_cute_atomic_min_float32": "from helion._compiler.cute.atomic_helpers import atomic_min_float32 as _cute_atomic_min_float32",
@@ -1240,6 +1247,12 @@ class CuteBackend(Backend):
 
     def lane_offset_expr(self, lane_var: str) -> str:
         return f"cutlass.Int32({lane_var})"
+
+    def thread_index_expr(self, *, axis: int) -> str:
+        from ..compile_environment import CompileEnvironment
+
+        index_dtype = CompileEnvironment.current().index_type()
+        return f"{index_dtype}(cute.arch.thread_idx()[{axis}])"
 
     def sympy_printer_expr(self, expr: sympy.Expr) -> str:
         from .printer import cute_texpr
@@ -1349,6 +1362,19 @@ class CuteBackend(Backend):
         return f"cutlass.Int32(cute.arch.thread_idx()[{axis}]) < ({block_size_var})"
 
     def force_tile_mask(self) -> bool:
+        # Masks are elided per-axis when the extent is a known multiple of
+        # the block size (same rule as the Triton backend) AND the launch
+        # cannot run the axis wider than the tile (see
+        # ``launches_surplus_tile_threads``).  Every per-element mask costs
+        # a compare + select in the SIMT lane loop, which is significant
+        # for memory-bound reduction kernels.
+        return False
+
+    def launches_surplus_tile_threads(self) -> bool:
+        # Mutually exclusive kernel sections (e.g. persistent stages around
+        # an ``hl.barrier()``) share one launch whose block dims are the
+        # elementwise max across sections, so a section can run with more
+        # threads on an axis than its own tile is wide.
         return True
 
     def full_expr(

--- a/helion/_compiler/cute/cluster_helpers.py
+++ b/helion/_compiler/cute/cluster_helpers.py
@@ -85,3 +85,35 @@ def store_shared_remote_x4(
         has_side_effects=True,
         is_align_stack=False,
     )
+
+
+@dsl_user_op
+def store_shared_remote_f32(
+    val: Float32,
+    smem_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    peer_cta_rank_in_cluster: Int32,
+    *,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> None:
+    """Store one f32 into another CTA's SMEM and complete the mbarrier tx."""
+
+    remote_smem_ptr_i32 = _set_block_rank(
+        smem_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    remote_mbar_ptr_i32 = _set_block_rank(
+        mbar_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    llvm.inline_asm(
+        None,
+        [
+            remote_smem_ptr_i32,
+            Float32(val).ir_value(loc=loc, ip=ip),
+            remote_mbar_ptr_i32,
+        ],
+        "st.async.shared::cluster.mbarrier::complete_tx::bytes.f32 [$0], $1, [$2];",
+        "r,f,r",
+        has_side_effects=True,
+        is_align_stack=False,
+    )

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -496,6 +496,15 @@ class CuteDeviceFunctionState:
     """CuTe-owned state for one DeviceFunction codegen instance."""
 
     def __init__(self) -> None:
+        # SIMT reduction-kernel thread-block cluster width (from the
+        # ``cute_cluster_n`` config knob, applied by
+        # ``PerThreadNDTileStrategy`` when a lane-looped axis is split
+        # across cluster CTAs).  1 = no cluster.
+        self.simt_cluster_n: int = 1
+        # Number of DSM cluster-reduce call sites emitted; > 0 makes the
+        # device function emit one mbarrier fence + cluster arrive/wait
+        # after the preamble (covering every site's mbarrier init).
+        self.simt_cluster_reduce_sites: int = 0
         self._tcgen05_store_values: dict[str, CuteTcgen05StoreValue] = {}
         self._tcgen05_grouped_tail_proofs: dict[
             torch.fx.Node, Tcgen05GroupedTailEpilogueMatch

--- a/helion/_compiler/cute/fuse_two_pass_loads.py
+++ b/helion/_compiler/cute/fuse_two_pass_loads.py
@@ -206,6 +206,24 @@ def _node_text(node: ast.AST) -> str:
     return ast.unparse(node)
 
 
+def _unmasked_load_tensor_dtype(
+    node: ast.AST, tensor_dtypes: dict[str, str]
+) -> str | None:
+    """Dtype for caching an unmasked scalar ``(x.iterator + ...).load()``:
+    the BASE TENSOR's own element dtype (looked up from the kernel's
+    tensor arguments), so the cache roundtrip is bit-exact for every
+    consumer regardless of how they cast the value.  Returns None when the
+    base tensor cannot be identified (no fusion)."""
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Attribute)
+            and sub.attr == "iterator"
+            and isinstance(sub.value, ast.Name)
+        ):
+            return tensor_dtypes.get(sub.value.id)
+    return None
+
+
 def _rewrite_vec_extract(
     node: ast.AST,
     hoist_var: str,
@@ -273,10 +291,15 @@ class _CuteFuseTwoPassLoads:
         self,
         constexpr_values: dict[str, int] | None = None,
         thread_block_dims: tuple[int, int, int] = (1, 1, 1),
+        tensor_dtypes: dict[str, str] | None = None,
     ) -> None:
         super().__init__()
         self._counter = 0
         self._constexpr_values = constexpr_values or {}
+        # Kernel tensor-arg name -> backend dtype string (e.g.
+        # "cutlass.Float32"); resolves the cache dtype for unmasked
+        # scalar loads.
+        self._tensor_dtypes = tensor_dtypes or {}
         # Per-axis thread dims for the CUDA thread block.  Used by the
         # SMEM-backed cache path to (a) size the SMEM allocation by
         # total thread count and (b) emit a linear per-thread slot
@@ -319,9 +342,17 @@ class _CuteFuseTwoPassLoads:
         """
         body = outer_loop.body
         assert isinstance(outer_loop.target, ast.Name)
-        cache_index_outer = (
-            f"({outer_loop.target.id} - ({_node_text(start)})) // ({_node_text(step)})"
-        )
+        if trip == 1:
+            # Single-trip outer loop (e.g. a whole-row tile): the outer
+            # index folds to a literal 0 so the cache slot expression stays
+            # a compile-time constant — the fragment then lives in
+            # registers instead of dynamically-indexed local memory.
+            cache_index_outer = "0"
+        else:
+            cache_index_outer = (
+                f"({outer_loop.target.id} - ({_node_text(start)})) "
+                f"// ({_node_text(step)})"
+            )
         for_children = [s for s in body if isinstance(s, ast.For)]
         if not for_children:
             return body, cache_index_outer, trip
@@ -499,30 +530,38 @@ class _CuteFuseTwoPassLoads:
                 continue
             start, end, step = range_args
             trip = _trip_count_for(start, end, step, self._constexpr_values)
-            # Require a static, bounded, non-trivial trip count.  The
-            # ``cache_size`` cap is enforced below (and is now SMEM-
-            # aware), so we allow large trip counts here — the SMEM
-            # backing path covers caches that wouldn't fit in a per-
-            # thread register fragment.
-            if trip is None or trip <= 1 or trip > 2048:
+            # Require a static, bounded trip count.  Single-trip loops
+            # (whole-row tiles) are the most profitable case: the cache
+            # index folds to a constant and the fragment stays in
+            # registers.  The ``cache_size`` cap is enforced below (and
+            # is SMEM-aware), so we allow large trip counts here — the
+            # SMEM backing path covers caches that wouldn't fit in a
+            # per-thread register fragment.
+            if trip is None or trip < 1 or trip > 2048:
                 continue
 
-            second_idx = group[1]
-            second_loop = new_body[second_idx]
-            assert isinstance(second_loop, ast.For)
-            # Resolve the load-container for each sweep: usually the for
-            # body itself, but for wide-chunk / vec configs the loads sit
-            # inside a nested lane for-loop.  Track the (load_container,
-            # cache_index) pair so the rewrite handles both shapes.
             first_ctx = self._resolve_load_container(first_loop, start, step, trip)
-            second_ctx = self._resolve_load_container(second_loop, start, step, trip)
-            if first_ctx is None or second_ctx is None:
+            if first_ctx is None:
                 continue
             first_container, first_cache_index, first_cache_size = first_ctx
-            second_container, second_cache_index, second_cache_size = second_ctx
-            if first_cache_size != second_cache_size:
-                continue
             cache_size = first_cache_size
+
+            # Gather ALL subsequent sweeps in the group that share the
+            # first sweep's container shape.  Multi-pass kernels (e.g.
+            # 3-pass softmax: max sweep, sum sweep, normalize sweep)
+            # re-load the same values in every later sweep, so each one
+            # should read the cache instead.
+            sweeps: list[tuple[int, list[ast.stmt], str, dict[str, str]]] = []
+            for body_idx in group[1:]:
+                loop_k = new_body[body_idx]
+                assert isinstance(loop_k, ast.For)
+                ctx_k = self._resolve_load_container(loop_k, start, step, trip)
+                if ctx_k is None or ctx_k[2] != cache_size:
+                    continue
+                alias_k = self._build_second_alias(first_loop, loop_k)
+                sweeps.append((body_idx, ctx_k[0], ctx_k[1], alias_k))
+            if not sweeps:
+                continue
             # Default policy: register-backed cache only when
             # ``cache_size <= 64``; otherwise skip fusion.
             #
@@ -565,13 +604,6 @@ class _CuteFuseTwoPassLoads:
                     continue
                 use_smem = False
             cache_index = first_cache_index
-            second_cache_index_str = second_cache_index
-
-            # Build a canonical-form alias map that smooths over per-sweep
-            # variable renames (``reduction_lane_base_1`` vs
-            # ``reduction_lane_base_2``, lane var counters, etc.) so the
-            # two sweeps' loads compare equal by text.
-            second_alias = self._build_second_alias(first_loop, second_loop)
 
             # Collect tracked loads from the first container.  Vec loads
             # (the ``unroll`` mode's U16 vec hoist) cache via a *scalar*
@@ -591,6 +623,14 @@ class _CuteFuseTwoPassLoads:
                     if kind is None:
                         continue
                     dtype = self._dtype_for_load_kind(s.value, kind)
+                    if dtype is None and kind == "unmasked":
+                        # An unmasked scalar load (mask elided because the
+                        # extent divides the block) carries no dtype in its
+                        # text; cache in the base tensor's OWN dtype so the
+                        # roundtrip is exact for every consumer.
+                        dtype = _unmasked_load_tensor_dtype(
+                            s.value, self._tensor_dtypes
+                        )
                     if dtype is None:
                         continue
                     v_width = _vec_width(s.value) if kind == "vec" else 1
@@ -606,23 +646,28 @@ class _CuteFuseTwoPassLoads:
             if not tracked:
                 continue
 
-            # Match loads in the second container.
-            assignments_to_rewrite: list[tuple[int, str, str]] = []
-            for j, s in enumerate(second_container):
-                if (
-                    isinstance(s, ast.Assign)
-                    and len(s.targets) == 1
-                    and isinstance(s.targets[0], ast.Name)
-                ):
-                    kind = _load_kind(s.value)
-                    if kind is None:
-                        continue
-                    # Canonicalise the second sweep's load text against the
-                    # first sweep's variable names before keying.
-                    key = _canonical_load_text(s.value, second_alias)
-                    if key in tracked:
-                        assignments_to_rewrite.append((j, s.targets[0].id, key))
-            if not assignments_to_rewrite:
+            # Match loads in each subsequent sweep's container.
+            per_sweep_matches: list[list[tuple[int, str, str]]] = []
+            matched_keys: set[str] = set()
+            for _body_idx, container_k, _cache_index_k, alias_k in sweeps:
+                matches: list[tuple[int, str, str]] = []
+                for j, s in enumerate(container_k):
+                    if (
+                        isinstance(s, ast.Assign)
+                        and len(s.targets) == 1
+                        and isinstance(s.targets[0], ast.Name)
+                    ):
+                        kind = _load_kind(s.value)
+                        if kind is None:
+                            continue
+                        # Canonicalise this sweep's load text against the
+                        # first sweep's variable names before keying.
+                        key = _canonical_load_text(s.value, alias_k)
+                        if key in tracked:
+                            matches.append((j, s.targets[0].id, key))
+                            matched_keys.add(key)
+                per_sweep_matches.append(matches)
+            if not matched_keys:
                 continue
 
             # Build cache declarations.  For vec loads, allocate
@@ -634,7 +679,7 @@ class _CuteFuseTwoPassLoads:
             #     latency, no sync needed, fits in registers.
             #   - SMEM tensor for larger caches: allocated once at the
             #     top, indexed per-thread.  Sync inserted between the
-            #     two sweeps so the consume read sees populated slots.
+            #     sweeps so the consume reads see populated slots.
             cache_names: dict[str, tuple[str, int]] = {}
             cache_decls: list[ast.stmt] = []
             # Build the linear per-thread index expression covering all
@@ -654,7 +699,7 @@ class _CuteFuseTwoPassLoads:
                 )
             tid_expr = " + ".join(tid_terms)
             for key, (_j, _name, _kind, dtype, vec_w) in tracked.items():
-                if not any(akey == key for _, _, akey in assignments_to_rewrite):
+                if key not in matched_keys:
                     continue
                 if dtype is None or vec_w is None:
                     continue
@@ -747,52 +792,62 @@ class _CuteFuseTwoPassLoads:
                             )
             first_container[:] = new_first_body
 
-            # Rewrite the second container: replace each matched load.
-            # Scalar loads become a single cache read.  Vec loads are
-            # eliminated entirely (the consume sweep's hoist disappears)
-            # and any downstream ``hoist_var[vi]`` extracts inside the
-            # nested constexpr V-loop are rewritten to read from the cache
-            # at the appropriate slot expression.
-            vec_extract_rewrites: list[tuple[str, str, str, int, bool, int, str]] = []
-            new_second_body: list[ast.stmt] = []
-            for s in second_container:
-                if (
-                    isinstance(s, ast.Assign)
-                    and len(s.targets) == 1
-                    and isinstance(s.targets[0], ast.Name)
-                ):
-                    kind = _load_kind(s.value)
-                    if kind is not None:
-                        key = _canonical_load_text(s.value, second_alias)
-                        entry = cache_names.get(key)
-                        if entry is not None:
-                            cache, vec_w = entry
-                            name = s.targets[0].id
-                            if vec_w == 1:
-                                slot = _slot_expr(second_cache_index_str, 1, "0")
-                                new_second_body.append(
-                                    statement_from_string(f"{name} = {cache}[{slot}]")
-                                )
-                            else:
-                                # Drop the hoist entirely; remember that
-                                # ``name[vi]`` needs to be rewritten to a
-                                # cache read in subsequent statements
-                                # (especially inside the constexpr V-loop).
-                                vec_extract_rewrites.append(
-                                    (
-                                        name,
-                                        cache,
-                                        second_cache_index_str,
-                                        vec_w,
-                                        use_smem,
-                                        cache_size,
-                                        tid_expr,
+            # Rewrite each subsequent sweep's container: replace each
+            # matched load.  Scalar loads become a single cache read.
+            # Vec loads are eliminated entirely (the consume sweep's
+            # hoist disappears) and any downstream ``hoist_var[vi]``
+            # extracts inside the nested constexpr V-loop are rewritten
+            # to read from the cache at the appropriate slot expression.
+            smem_barrier_positions: list[int] = []
+            for (body_idx, container_k, cache_index_k, alias_k), matches in zip(
+                sweeps, per_sweep_matches, strict=True
+            ):
+                if not matches:
+                    continue
+                vec_extract_rewrites: list[
+                    tuple[str, str, str, int, bool, int, str]
+                ] = []
+                new_sweep_body: list[ast.stmt] = []
+                for s in container_k:
+                    if (
+                        isinstance(s, ast.Assign)
+                        and len(s.targets) == 1
+                        and isinstance(s.targets[0], ast.Name)
+                    ):
+                        kind = _load_kind(s.value)
+                        if kind is not None:
+                            key = _canonical_load_text(s.value, alias_k)
+                            entry = cache_names.get(key)
+                            if entry is not None:
+                                cache, vec_w = entry
+                                name = s.targets[0].id
+                                if vec_w == 1:
+                                    slot = _slot_expr(cache_index_k, 1, "0")
+                                    new_sweep_body.append(
+                                        statement_from_string(
+                                            f"{name} = {cache}[{slot}]"
+                                        )
                                     )
-                                )
-                            continue
-                new_second_body.append(s)
-            # Apply the vec extract rewrites recursively to ``new_second_body``.
-            if vec_extract_rewrites:
+                                else:
+                                    # Drop the hoist entirely; remember
+                                    # that ``name[vi]`` needs to be
+                                    # rewritten to a cache read in
+                                    # subsequent statements (especially
+                                    # inside the constexpr V-loop).
+                                    vec_extract_rewrites.append(
+                                        (
+                                            name,
+                                            cache,
+                                            cache_index_k,
+                                            vec_w,
+                                            use_smem,
+                                            cache_size,
+                                            tid_expr,
+                                        )
+                                    )
+                                continue
+                    new_sweep_body.append(s)
+                # Apply the vec extract rewrites recursively.
                 for (
                     hoist_var,
                     cache,
@@ -802,7 +857,7 @@ class _CuteFuseTwoPassLoads:
                     cache_size_,
                     tid_expr_,
                 ) in vec_extract_rewrites:
-                    for stmt in new_second_body:
+                    for stmt in new_sweep_body:
                         _rewrite_vec_extract(
                             stmt,
                             hoist_var,
@@ -813,30 +868,25 @@ class _CuteFuseTwoPassLoads:
                             cache_size=cache_size_,
                             tid_expr=tid_expr_,
                         )
-            second_container[:] = new_second_body
+                container_k[:] = new_sweep_body
+                smem_barrier_positions.append(body_idx)
+
+            # SMEM-backed cache requires a CTA-wide barrier after the
+            # populate sweep and before each consume sweep.  Insert in
+            # descending position order so earlier insertions don't
+            # shift later positions.
+            if use_smem:
+                for pos in sorted(smem_barrier_positions, reverse=True):
+                    new_body.insert(
+                        pos,
+                        statement_from_string("cute.arch.sync_threads()"),
+                    )
 
             # Insert cache declarations before the first loop, in
             # original order (so ``alloc_smem`` precedes
-            # ``make_tensor``).  Insert at incrementing positions
-            # rather than reusing ``first_idx`` (which would reverse
-            # them).
+            # ``make_tensor``).
             for offset, decl in enumerate(cache_decls):
                 new_body.insert(first_idx + offset, decl)
-                # Adjust the second-loop index forward.
-                second_idx += 1
-            if use_smem:
-                # SMEM-backed cache requires a CTA-wide barrier after the
-                # first sweep populates the cache and before the second
-                # sweep reads it back. The two-pass kernels' inter-sweep
-                # code (computing the row-wise reduction result, etc.)
-                # may write to ``mi``/``di`` registers but doesn't touch
-                # SMEM, so one barrier just before the consume loop is
-                # sufficient.
-                new_body.insert(
-                    second_idx,
-                    statement_from_string("cute.arch.sync_threads()"),
-                )
-                second_idx += 1
             any_fused = True
 
         if not any_fused:
@@ -849,6 +899,7 @@ def fuse_two_pass_loads(
     constexpr_values: dict[str, int] | None = None,
     *,
     thread_block_dims: tuple[int, int, int] = (1, 1, 1),
+    tensor_dtypes: dict[str, str] | None = None,
 ) -> list[ast.stmt]:
     """Apply two-pass load fusion to a list of statements (the device kernel
     body). Returns the (possibly modified) body.
@@ -870,6 +921,7 @@ def fuse_two_pass_loads(
     transformer = _CuteFuseTwoPassLoads(
         constexpr_values=constexpr_values,
         thread_block_dims=thread_block_dims,
+        tensor_dtypes=tensor_dtypes,
     )
     new_body = transformer._try_fuse(body)
     if new_body is None:

--- a/helion/_compiler/cute/hoist_warp_reduce.py
+++ b/helion/_compiler/cute/hoist_warp_reduce.py
@@ -40,6 +40,7 @@ unexpected.
 from __future__ import annotations
 
 import ast
+import re
 from typing import cast
 
 from ..ast_extension import statement_from_string
@@ -65,13 +66,46 @@ _REDUCE_COMBINE: dict[str, str] = {
 }
 
 
+# Grouped-reduction helper names (multi-warp shared-memory reductions and
+# the interleaved grouped warp reduce).  These take the reduction op as a
+# string literal in args[1] and the identity element in args[2]; the pass
+# hoists them exactly like ``cute.arch.warp_reduction_*``.  Without this a
+# multi-warp config (group_span > 32) runs a full two-barrier block
+# reduction per V-lane per reduce.
+_GROUPED_REDUCE_FUNCS: frozenset[str] = frozenset(
+    {
+        "_cute_grouped_reduce_shared_two_stage",
+        "_cute_grouped_reduce_shared_tree",
+        "_cute_grouped_reduce_warp",
+        "_cute_grouped_reduce_cluster",
+    }
+)
+_GROUPED_OP_TO_KEY: dict[str, str] = {
+    "sum": "warp_reduction_sum",
+    "max": "warp_reduction_max",
+    "min": "warp_reduction_min",
+}
+
+
 def _looks_like_warp_reduce_call(node: ast.AST) -> tuple[str, ast.expr] | None:
-    """If ``node`` is ``cute.arch.warp_reduction_<op>(INPUT, threads_in_group=T)``,
-    return ``("warp_reduction_<op>", INPUT)``.  Otherwise None.
+    """If ``node`` is ``cute.arch.warp_reduction_<op>(INPUT, threads_in_group=T)``
+    or a grouped-reduce helper call ``_cute_grouped_reduce_*(INPUT, '<op>',
+    IDENTITY, ...)``, return ``("warp_reduction_<op>", INPUT)``.  Otherwise
+    None.
     """
     if not isinstance(node, ast.Call):
         return None
     func = node.func
+    if isinstance(func, ast.Name) and func.id in _GROUPED_REDUCE_FUNCS:
+        if len(node.args) < 3:
+            return None
+        op_arg = node.args[1]
+        if not (isinstance(op_arg, ast.Constant) and isinstance(op_arg.value, str)):
+            return None
+        op_key = _GROUPED_OP_TO_KEY.get(op_arg.value)
+        if op_key is None:
+            return None
+        return op_key, node.args[0]
     if not isinstance(func, ast.Attribute):
         return None
     if func.attr not in _REDUCE_IDENTITY:
@@ -376,6 +410,20 @@ def _try_hoist_one_vloop(
 
         identity = _REDUCE_IDENTITY[op]
         combine_template = _REDUCE_COMBINE[op]
+        acc_dtype_probe = _infer_input_dtype(input_def_rhs)
+        if acc_dtype_probe in (
+            "cutlass.Float32",
+            "cutlass.Float16",
+            "cutlass.BFloat16",
+        ):
+            # Python ``max``/``min`` lower to a compare + select (2 SASS
+            # insts); the hardware FMNMX is one.  fmax/fmin drop NaN
+            # instead of propagating it, matching quack's row_reduce (the
+            # warp shuffle reduction already uses the same semantics).
+            if op == "warp_reduction_max":
+                combine_template = "cute.arch.fmax(({a}), ({b}))"
+            elif op == "warp_reduction_min":
+                combine_template = "cute.arch.fmin(({a}), ({b}))"
         # Decide how to hoist the reduce.  Three cases:
         #
         #  (b) The input is a matmul-fallback PER-THREAD RUNNING SUM, flagged
@@ -404,6 +452,7 @@ def _try_hoist_one_vloop(
 
         vloop_body: list[ast.stmt] = []
         v_members = sorted(v_loop_members[reduce_pos])
+        acc_dtype: str | None = None
         if input_is_loop_carried:
             acc_name = input_name
             for j in v_members:
@@ -449,7 +498,9 @@ def _try_hoist_one_vloop(
         new_stmts.append(new_vloop_template)
 
         # Emit the reduce stmt with input -> acc.
-        new_reduce_stmt = _replace_reduce_input(reduce_stmt, call_node, acc_name)
+        new_reduce_stmt = _replace_reduce_input(
+            reduce_stmt, call_node, acc_name, acc_dtype
+        )
         if new_reduce_stmt is None:
             return None
         new_stmts.append(new_reduce_stmt)
@@ -477,7 +528,8 @@ def _rewrite_cast_wrapper(rhs: ast.expr, new_dtype: str) -> ast.expr:
     if (
         isinstance(rhs, ast.Call)
         and isinstance(rhs.func, ast.Attribute)
-        and ast.unparse(rhs.func).startswith("cutlass.Float")
+        and ast.unparse(rhs.func)
+        in ("cutlass.Float16", "cutlass.BFloat16", "cutlass.Float32")
     ):
         # Rewrite the cast wrapper to use new_dtype.
         # Parse "<new_dtype>(<args>)" template.
@@ -502,27 +554,34 @@ def _infer_input_dtype(rhs: ast.expr) -> str | None:
         return _infer_input_dtype(rhs.body)
     if isinstance(rhs, ast.Call) and isinstance(rhs.func, ast.Attribute):
         func_text = ast.unparse(rhs.func)
-        # Promote fp16/bf16 accumulators to fp32 for better perf and accuracy:
-        # the downstream uses convert to fp32 anyway, and fp16 max is no
-        # cheaper than fp32 max on B200.  Sum benefits from fp32 to avoid
-        # losing precision over the V-fold.
-        if func_text in ("cutlass.Float16", "cutlass.BFloat16"):
-            return "cutlass.Float32"
-        if func_text.startswith("cutlass.Float"):
-            return func_text
-        if func_text.startswith("cutlass.Int"):
-            return func_text
-        if func_text.startswith("cutlass.Uint"):
+        # Only match a bare dtype constructor (``cutlass.<Dtype>``); a
+        # compound expression like ``cutlass.Uint16(v[i]).bitcast`` is NOT
+        # a dtype wrapper and must fall through to the fp32 default.
+        if re.fullmatch(r"cutlass\.(?:B?Float|U?Int)\d+", func_text):
+            # Promote fp16/bf16 accumulators to fp32 for better perf and
+            # accuracy: the downstream uses convert to fp32 anyway, and
+            # fp16 max is no cheaper than fp32 max on B200.  Sum benefits
+            # from fp32 to avoid losing precision over the V-fold.
+            if func_text in ("cutlass.Float16", "cutlass.BFloat16"):
+                return "cutlass.Float32"
             return func_text
     # Conservative default — sufficient for sum/max in fp32 accumulators.
     return "cutlass.Float32"
 
 
 def _replace_reduce_input(
-    reduce_stmt: ast.stmt, call_node: ast.Call, acc_name: str
+    reduce_stmt: ast.stmt,
+    call_node: ast.Call,
+    acc_name: str,
+    acc_dtype: str | None = None,
 ) -> ast.stmt | None:
     """Return a copy of ``reduce_stmt`` with ``call_node``'s first arg replaced
     by ``Name(acc_name)``.
+
+    For grouped-reduce helper calls, the identity element (args[2]) must
+    match the input dtype (the helpers derive their smem dtype from it), so
+    when ``acc_dtype`` is given the identity's dtype wrapper is rewritten to
+    it (e.g. ``cutlass.BFloat16(float('-inf'))`` -> ``cutlass.Float32(...)``).
     """
     if not isinstance(reduce_stmt, ast.Assign):
         return None
@@ -535,6 +594,13 @@ def _replace_reduce_input(
             if node is call_node and not self.done:
                 self.done = True
                 new_args = [ast.Name(id=acc_name, ctx=ast.Load()), *node.args[1:]]
+                if (
+                    acc_dtype is not None
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id in _GROUPED_REDUCE_FUNCS
+                    and len(new_args) >= 3
+                ):
+                    new_args[2] = _rewrite_cast_wrapper(new_args[2], acc_dtype)
                 new_call = ast.Call(
                     func=node.func, args=new_args, keywords=node.keywords
                 )
@@ -585,6 +651,7 @@ def hoist_warp_reduce_from_vloop(
     body: list[ast.stmt],
     *,
     running_sum_accumulators: set[str] | None = None,
+    rename_groups: dict[str, str] | None = None,
 ) -> list[ast.stmt]:
     """Apply the hoist pass to a list of kernel-body statements.
 
@@ -598,5 +665,448 @@ def hoist_warp_reduce_from_vloop(
     after the loop rather than V-folded — the producer tells us authoritatively
     that the value already accumulates across V-lanes, so we don't re-derive it
     by pattern-matching the AST.
+
+    After the per-V-loop hoist, a second walk collapses the remaining
+    per-lane-iteration reduces: a static lane loop that runs ``REDUCE`` +
+    ``carry = combine(carry, result)`` once per iteration is rewritten to
+    fold the per-thread accumulator across ALL lane iterations and reduce
+    ONCE after the loop.  For multi-warp grouped reductions this removes
+    ``L-1`` two-barrier shared-memory reductions per sweep.
     """
-    return _hoist_in_body(body, [0], running_sum_accumulators or set())
+    new_body = _hoist_in_body(body, [0], running_sum_accumulators or set())
+    import os
+
+    if os.environ.get("HELION_DISABLE_LANE_REDUCE_COLLAPSE") != "1":
+        new_body = _collapse_in_body(new_body, new_body, rename_groups or {})
+    return new_body
+
+
+# ---------------------------------------------------------------------------
+# Lane-loop reduce collapse (second stage)
+# ---------------------------------------------------------------------------
+
+
+def _is_static_range_loop(node: ast.stmt) -> int | None:
+    """If ``node`` is ``for X in range(<int>): ...`` (a static lane loop as
+    emitted by ``_create_lane_loop``), return the trip count."""
+    if not isinstance(node, ast.For) or node.orelse:
+        return None
+    it = node.iter
+    if not (
+        isinstance(it, ast.Call)
+        and isinstance(it.func, ast.Name)
+        and it.func.id == "range"
+        and len(it.args) == 1
+        and isinstance(it.args[0], ast.Constant)
+        and isinstance(it.args[0].value, int)
+    ):
+        return None
+    if not isinstance(node.target, ast.Name):
+        return None
+    return it.args[0].value
+
+
+_COLLAPSE_UPDATE_OPS: dict[str, str] = {
+    "warp_reduction_sum": "add",
+    "warp_reduction_max": "max",
+    "warp_reduction_min": "min",
+}
+
+
+def _strip_dtype_wrap(expr: ast.expr) -> ast.expr:
+    """Peel ``cutlass.<Dtype>(x)`` wrappers off ``expr``."""
+    while (
+        isinstance(expr, ast.Call)
+        and len(expr.args) == 1
+        and not expr.keywords
+        and isinstance(expr.func, ast.Attribute)
+        and isinstance(expr.func.value, ast.Name)
+        and expr.func.value.id == "cutlass"
+    ):
+        expr = expr.args[0]
+    return expr
+
+
+def _match_carry_update(
+    stmt: ast.stmt, result_name: str, op_kind: str
+) -> tuple[str, str] | None:
+    """Match ``CARRY = combine(SRC, result_name)`` for ``op_kind``.
+
+    Returns ``(carry_name, src_name)`` (operand order-insensitive) or None.
+    """
+    if not (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+    ):
+        return None
+    carry_name = stmt.targets[0].id
+    rhs = stmt.value
+    operands: list[ast.expr] | None = None
+    if op_kind == "add":
+        if isinstance(rhs, ast.BinOp) and isinstance(rhs.op, ast.Add):
+            operands = [rhs.left, rhs.right]
+    elif isinstance(rhs, ast.Call):
+        func_text = ast.unparse(rhs.func)
+        if (
+            (
+                op_kind == "max"
+                and func_text in ("max", "cute.math.max", "cute.arch.fmax")
+            )
+            or (op_kind == "min" and func_text in ("min", "cute.math.min"))
+        ) and len(rhs.args) == 2:
+            operands = list(rhs.args)
+    if operands is None:
+        return None
+    names = [
+        inner.id if isinstance(inner := _strip_dtype_wrap(o), ast.Name) else None
+        for o in operands
+    ]
+    if result_name not in names:
+        return None
+    other = names[1 - names.index(result_name)]
+    if other is None:
+        return None
+    return carry_name, other
+
+
+def _count_name_reads(node: ast.AST | list[ast.stmt]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    nodes = node if isinstance(node, list) else [node]
+    for n in nodes:
+        for sub in ast.walk(n):
+            if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Load):
+                counts[sub.id] = counts.get(sub.id, 0) + 1
+    return counts
+
+
+def _try_collapse_lane_reduce(
+    loop: ast.For,
+    root: list[ast.stmt],
+    rename_groups: dict[str, str],
+) -> list[ast.stmt] | None:
+    """Collapse per-lane-iteration reduces in a static lane loop.
+
+    Matches the post-hoist shape::
+
+        for LANE in range(L):
+            <pre stmts>
+            ACC = <dtype>(<identity>)
+            for V in cutlass.range_constexpr(V): ... ACC = combine(ACC, x)
+            <reduce-arg scalars (loop-invariant)>
+            R = REDUCE(ACC, ...)
+            <casts of R>
+            COPY = CARRY            # optional
+            CARRY = combine(COPY | CARRY, cast(R))
+
+    and rewrites it so ``ACC`` folds across all ``L`` iterations and the
+    reduce + carry update run once after the loop.  Valid because the
+    grouped/warp reduce distributes over its own combine op (max of maxes,
+    sum of sums).
+    """
+    body = loop.body
+    assert isinstance(loop.target, ast.Name)
+    lane_var = loop.target.id
+
+    import os as _os
+
+    _dbg = _os.environ.get("HELION_DEBUG_COLLAPSE") == "1"
+    if _dbg:
+        import sys as _sys
+
+        print("=== collapse attempt ===", file=_sys.stderr)
+        for _i, _s in enumerate(body):
+            print(_i, ast.unparse(_s)[:100].replace("\n", " | "), file=_sys.stderr)
+
+    # Locate reduce statements at the top level of the loop body.
+    reduce_entries: list[tuple[int, str, str, ast.Call, str]] = []
+    for i, stmt in enumerate(body):
+        rhs = _assignment_rhs(stmt)
+        lhs = _assignment_lhs_name(stmt)
+        if rhs is None or lhs is None:
+            continue
+        found = _find_warp_reduce_in_expr(rhs)
+        if found is None:
+            continue
+        op, input_expr, call_node = found
+        if not isinstance(input_expr, ast.Name):
+            return None
+        reduce_entries.append((i, lhs, op, call_node, input_expr.id))
+    if not reduce_entries:
+        return None
+
+    loop_written: set[str] = set()
+    for stmt in body:
+        loop_written |= _names_written(stmt)
+
+    # Global read counts over the whole kernel body (to prove that the
+    # names we move / consume have no other consumers).
+    global_reads = _count_name_reads(root)
+
+    remove_indices: set[int] = set()
+    move_out: list[int] = []  # loop-invariant reduce-arg producers, in order
+    prefix: list[ast.stmt] = []
+    tail: list[ast.stmt] = []
+
+    for idx, result_name, op, call_node, acc_name in reduce_entries:
+        op_kind = _COLLAPSE_UPDATE_OPS.get(op)
+        if op_kind is None:
+            return None
+        # (1) The accumulator: defined once by an identity init, combined
+        # only inside a single constexpr V-loop, and read only by that
+        # combine and the reduce call.
+        init_idx = None
+        for j in range(idx - 1, -1, -1):
+            if acc_name in _names_written(body[j]):
+                init_idx = j
+                break
+        if init_idx is None:
+            return None
+        init_rhs = _assignment_rhs(body[init_idx])
+        if init_rhs is None:
+            return None
+        init_text = ast.unparse(_strip_dtype_wrap(init_rhs))
+        expected_identity = _REDUCE_IDENTITY[op]
+        if init_text not in (expected_identity, f"({expected_identity})"):
+            return None
+        vloop_idx = None
+        for j in range(init_idx + 1, idx):
+            stmt = body[j]
+            if isinstance(stmt, ast.For) and _is_constexpr_v_loop(stmt) is not None:
+                if acc_name in _names_written_recursive(stmt):
+                    if vloop_idx is not None:
+                        return None
+                    vloop_idx = j
+            elif acc_name in _names_written(stmt) or acc_name in _names_read(stmt):
+                return None
+        if vloop_idx is None:
+            return None
+        # acc reads: the V-loop combine(s) + the reduce call. Anything else
+        # (elsewhere in the kernel) makes the collapse unsafe.
+        vloop_acc_reads = _count_name_reads(body[vloop_idx]).get(acc_name, 0)
+        if global_reads.get(acc_name, 0) != vloop_acc_reads + 1:
+            return None
+
+        # (2) The cast chain from R to the value consumed by the carry
+        # update, and the update itself.
+        chain_names = [result_name]
+        chain_indices: list[int] = []
+        update_idx = None
+        carry_name = src_name = None
+        j = idx + 1
+        while j < len(body) and update_idx is None:
+            stmt = body[j]
+            matched = _match_carry_update(stmt, chain_names[-1], op_kind)
+            if matched is not None:
+                update_idx = j
+                carry_name, src_name = matched
+                break
+            lhs = _assignment_lhs_name(stmt)
+            rhs = _assignment_rhs(stmt)
+            if (
+                lhs is not None
+                and rhs is not None
+                and isinstance(inner := _strip_dtype_wrap(rhs), ast.Name)
+                and inner.id == chain_names[-1]
+            ):
+                chain_indices.append(j)
+                chain_names.append(lhs)
+                j += 1
+                continue
+            return None
+        if update_idx is None or carry_name is None or src_name is None:
+            return None
+        # (3) The carry source: the carry itself, or a chain of in-loop
+        # copies of it.  Pre-rename ASTs thread loop-carried values through
+        # alias vars (``mi_copy = mi; mi_copy_0 = mi_copy; v_1 = max(
+        # mi_copy_0, ...)`` where ``v_1`` later renames to ``mi``), so
+        # resolve both ends through ``rename_groups`` canonical names.
+        carry_canon = rename_groups.get(carry_name, carry_name)
+        copy_chain: list[int] = []
+        carry_root = src_name
+        while rename_groups.get(carry_root, carry_root) != carry_canon:
+            if len(copy_chain) > 4:
+                return None
+            def_idx = None
+            for j in range(update_idx - 1, -1, -1):
+                if carry_root in _names_written(body[j]):
+                    def_idx = j
+                    break
+            if def_idx is None:
+                return None
+            rhs = _assignment_rhs(body[def_idx])
+            if rhs is None or not isinstance(inner := _strip_dtype_wrap(rhs), ast.Name):
+                return None
+            if global_reads.get(carry_root, 0) != 1:
+                return None
+            copy_chain.append(def_idx)
+            carry_root = inner.id
+        # (4) Every chain name (the reduce result and each cast link,
+        # INCLUDING a chain of length one) is consumed exactly once, by
+        # the next link / the update; the carried value's root name is
+        # read exactly once inside the loop (by the first copy, or the
+        # update itself); and nothing inside the loop reads the update's
+        # RESULT (a per-iteration consumer of the running value, e.g.
+        # ``acc = acc + f(mi)``, must keep the per-iteration update).
+        for name in chain_names:
+            if global_reads.get(name, 0) != 1:
+                return None
+        loop_reads = _count_name_reads(body)
+        if loop_reads.get(carry_root, 0) != 1:
+            return None
+        if loop_reads.get(carry_name, 0) != 0:
+            return None
+        # (5) Reduce-arg producers (e.g. the grouped reduce's lane index
+        # vars): the backward slice of the reduce call minus the acc chain.
+        # They must be loop-invariant to move out.
+        arg_names = set()
+        for arg in [*call_node.args[1:], *[kw.value for kw in call_node.keywords]]:
+            for sub in ast.walk(arg):
+                if isinstance(sub, ast.Name) and isinstance(sub.ctx, ast.Load):
+                    arg_names.add(sub.id)
+        closure = _compute_dependency_closure(
+            body, {i for i in range(len(body)) if _names_written(body[i]) & arg_names}
+        )
+        closure_written: set[str] = set()
+        for j in closure:
+            closure_written |= _names_written(body[j])
+        for j in sorted(closure):
+            stmt = body[j]
+            if j in remove_indices or j in move_out:
+                continue
+            # The whole closure moves out together, so reads of names other
+            # closure members write are fine; only reads of names the loop
+            # still writes (or of the lane var) make the move unsafe.
+            reads = _names_read(stmt)
+            if lane_var in reads or reads & (loop_written - closure_written):
+                return None
+            move_out.append(j)
+
+        # Build the rewritten pieces.
+        prefix.append(body[init_idx])
+        remove_indices.add(init_idx)
+        remove_indices.add(idx)
+        remove_indices.update(chain_indices)
+        remove_indices.add(update_idx)
+        remove_indices.update(copy_chain)
+        tail.append(body[idx])
+        tail.extend(body[j] for j in chain_indices)
+        tail.extend(body[j] for j in sorted(copy_chain))
+        tail.append(body[update_idx])
+
+    if not tail:
+        return None
+    remove_indices.update(move_out)
+    moved = [body[j] for j in sorted(move_out)]
+    new_loop_body = [s for i, s in enumerate(body) if i not in remove_indices]
+    if not new_loop_body:
+        return None
+    # Mutate the loop in place (preserves lane-loop marker attributes that
+    # later passes key on).
+    loop.body = new_loop_body
+    return [*prefix, loop, *moved, *tail]
+
+
+def _names_written_recursive(node: ast.AST) -> set[str]:
+    written: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.stmt):
+            written |= _names_written(sub)
+    return written
+
+
+def _collapse_in_body(
+    body: list[ast.stmt],
+    root: list[ast.stmt],
+    rename_groups: dict[str, str],
+) -> list[ast.stmt]:
+    new_body: list[ast.stmt] = []
+    for stmt in body:
+        if isinstance(stmt, ast.For):
+            stmt.body = _collapse_in_body(stmt.body, root, rename_groups)
+            stmt.orelse = _collapse_in_body(stmt.orelse, root, rename_groups)
+            if _is_static_range_loop(stmt) is not None:
+                replacement = _try_collapse_lane_reduce(stmt, root, rename_groups)
+                if replacement is not None:
+                    new_body.extend(replacement)
+                    continue
+            new_body.append(stmt)
+        elif isinstance(stmt, ast.If):
+            stmt.body = _collapse_in_body(stmt.body, root, rename_groups)
+            stmt.orelse = _collapse_in_body(stmt.orelse, root, rename_groups)
+            new_body.append(stmt)
+        elif isinstance(stmt, (ast.With, ast.FunctionDef)):
+            stmt.body = _collapse_in_body(stmt.body, root, rename_groups)
+            new_body.append(stmt)
+        else:
+            new_body.append(stmt)
+    return new_body
+
+
+def _static_trip_count(
+    loop: ast.For, constexpr_values: dict[str, int] | None
+) -> int | None:
+    """Static trip count of a ``range(...)`` / ``cutlass.range_constexpr``
+    for-loop, or None when unknown."""
+    from .fuse_two_pass_loads import _range_bounds
+    from .fuse_two_pass_loads import _trip_count_for
+
+    it = loop.iter
+    if (
+        isinstance(it, ast.Call)
+        and isinstance(it.func, ast.Attribute)
+        and it.func.attr == "range_constexpr"
+    ):
+        # Unrolled at trace time, but a call statement inside still
+        # references the SAME preamble-allocated mbarrier on every
+        # unrolled iteration — so for once-per-kernel placement purposes
+        # the trip count is the unroll factor, not 1.
+        if (
+            it.args
+            and isinstance(it.args[0], ast.Constant)
+            and isinstance(it.args[0].value, int)
+        ):
+            return it.args[0].value
+        return None
+    bounds = _range_bounds(it)
+    if bounds is None:
+        return None
+    return _trip_count_for(*bounds, constexpr_values or {})
+
+
+def validate_cluster_reduce_placement(
+    body: list[ast.stmt], constexpr_values: dict[str, int] | None
+) -> None:
+    """Raise ``BackendUnsupported`` when a ``_cute_grouped_reduce_cluster``
+    call site can execute more than once per kernel (its single-phase
+    mbarrier would deadlock on the second execution)."""
+    from ... import exc
+
+    def walk(stmts: list[ast.stmt], multi_trip: bool) -> None:
+        for stmt in stmts:
+            inner_multi = multi_trip
+            if isinstance(stmt, ast.For):
+                trips = _static_trip_count(stmt, constexpr_values)
+                inner_multi = multi_trip or trips is None or trips > 1
+            if inner_multi:
+                for sub in ast.walk(stmt):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Name)
+                        and sub.func.id == "_cute_grouped_reduce_cluster"
+                    ):
+                        raise exc.BackendUnsupported(
+                            "cute",
+                            "cute_cluster_n > 1 requires the cluster reduce "
+                            "to run exactly once per kernel; this config "
+                            "leaves it inside a multi-trip loop",
+                        )
+            for field in ("body", "orelse", "finalbody"):
+                nested = getattr(stmt, field, None)
+                if isinstance(nested, list) and nested:
+                    walk(
+                        cast("list[ast.stmt]", nested),
+                        inner_multi,
+                    )
+
+    walk(body, False)

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -33,7 +33,7 @@ from ...language.memory_ops import _cute_index_tuple
 from ...language.memory_ops import _cute_is_byte_packed
 from ...language.memory_ops import _cute_is_unroll_dtype
 from ...language.memory_ops import _cute_register_tile_unroll_vec_hoist
-from ...language.memory_ops import _cute_register_tile_unroll_vec_hoist_split2
+from ...language.memory_ops import _cute_register_tile_unroll_vec_store
 from ...language.memory_ops import _cute_scalar_load_expr
 from ...language.memory_ops import _cute_scalar_pointer_expr
 from ...language.memory_ops import _cute_tensor_dim_size_expr
@@ -1821,10 +1821,43 @@ def _(state: CodegenState) -> ast.AST:
     if isinstance(topk_lane_expr, str) and isinstance(topk_k, int):
         index_exprs[-1] = topk_lane_expr
     store_uses_pointer = "None" not in index_exprs
+    mask_expr = _cute_combined_mask(state, subscript, extra_mask, tensor=tensor)
+
+    # Vectorized store: when this store's stride-1 axis is a vec-partitioned
+    # lane loop (same predicates as the vec-load hoist, so the per-element
+    # mask is provably uniform across the V lanes), collect the per-lane
+    # values and emit one ST.64/ST.128 after the constexpr V-loop instead of
+    # V scalar 2-byte stores.
+    if (
+        store_uses_pointer
+        and topk_lane_expr is None
+        and extra_mask is None
+        and tensor.dtype in (torch.float16, torch.bfloat16)
+    ):
+        vec_ctx = _cute_vector_load_ctx(state, tensor, subscript, index_exprs, None)
+        if vec_ctx is not None and vec_ctx[2] == "tile_unroll":
+            from ..tile_strategy import BlockSizeTileStrategy
+
+            _vec_width, vec_block_id, _mode = vec_ctx
+            loops = state.codegen.active_device_loops.get(vec_block_id)
+            assert loops
+            strategy = loops[-1].strategy
+            assert isinstance(strategy, BlockSizeTileStrategy)
+            append_stmt = _cute_register_tile_unroll_vec_store(
+                state,
+                strategy,
+                vec_block_id,
+                tensor_name,
+                index_exprs,
+                ast.unparse(value),
+                mask_expr,
+            )
+            if append_stmt is not None:
+                state.add_statement(append_stmt)
+                return ast.Constant(value=None)
+
     store_expr = _cute_scalar_store_expr(tensor_name, index_exprs, "{value}")
     assign_expr = expr_from_string(store_expr, value=value)
-
-    mask_expr = _cute_combined_mask(state, subscript, extra_mask, tensor=tensor)
     if isinstance(topk_lane_expr, str) and isinstance(topk_k, int):
         topk_mask = f"({topk_lane_expr}) < {topk_k}"
         mask_expr = topk_mask if mask_expr is None else f"({mask_expr}) and {topk_mask}"
@@ -2053,12 +2086,6 @@ def _cute_vector_load_ctx(
         if mode == "unroll":
             if tensor.dtype not in _CUTE_VECTOR_UNROLL_DTYPES:
                 return None
-            # The CuTe DSL's ``nvvm.load.ext`` only supports vec sizes 2
-            # and 4 for bf16/fp16 (V=8 raises ICE).  Cap effective V
-            # here so the autotuner's V=8 seed still compiles instead
-            # of crashing.
-            if vec_width > 4:
-                return None
             # Need a lane base index var + a constexpr V-loop var; both
             # are set up by the strategy's codegen_device_loop.
             if (
@@ -2087,17 +2114,9 @@ def _cute_vector_load_ctx(
             return None
         if not _cute_is_unroll_dtype(tensor.dtype):
             return None
-        # The CuTe DSL's ``nvvm.load.ext`` ICEs at V=8 for fp16/bf16 (and
-        # for the V=8 ``Uint8`` vector used by fp8), so widths > 4 cannot
-        # use a single ``cute.arch.load``.  V=8 still
-        # gets full LDG.128 throughput via the ``tile_unroll_split2``
-        # mode: two back-to-back ``cute.arch.load(..., V=4)`` calls
-        # (covering vec lanes 0-3 and 4-7) emit as two LDG.64s that the
-        # SASS scheduler can overlap.  Wider Vs (16, 32, ...) are not
-        # supported.
+        # Widths above 8 (32 bytes per thread for 16-bit dtypes) exceed
+        # the widest gmem access (LDG.128) and are not supported.
         if vec_width > 8:
-            return None
-        if vec_width == 8 and vec_width % 4 != 0:
             return None
         base_var_by_block = getattr(
             strategy, "_cute_lane_base_index_var_by_block", None
@@ -2131,17 +2150,25 @@ def _cute_vector_load_ctx(
             # pyrefly: ignore [missing-attribute]
             strategy._cute_lane_axis_pos_by_block = pos_by_block
         pos_by_block[inner_block_id] = lane_axis_pos
-        # fp8 loads a packed Uint64 (V=8) / Uint32 (V=4) in the regular
-        # ``tile_unroll`` path — no ``VectorType`` so no V=8 ICE, hence no
-        # split2 needed.  bf16/fp16 V=8 still needs the 2x V=4 split.
-        if vec_width == 8 and not _cute_is_byte_packed(tensor.dtype):
-            return vec_width, inner_block_id, "tile_unroll_split2"
         return vec_width, inner_block_id, "tile_unroll"
     return None
 
 
 @_decorators.codegen(load, "cute")
 def _(state: CodegenState) -> object:
+    # A store to this tensor earlier in the same loop body followed by this
+    # load is a cross-thread read-after-write on global memory; emit a CTA
+    # barrier so the store is visible before the read.  Marked loads sit in
+    # uniform control flow (mark_intra_loop_raw_barriers skips divergent
+    # branches for cute; masks are ternary expressions and loop trip counts
+    # are uniform), so the convergent barrier is legal here.
+    from ..loop_dependency_checker import INTRA_LOOP_RAW_BARRIER_META
+
+    if state.fx_node is not None and state.fx_node.meta.get(
+        INTRA_LOOP_RAW_BARRIER_META
+    ):
+        state.add_statement(statement_from_string("cute.arch.sync_threads()"))
+
     tensor = state.proxy_arg(0)
     subscript = state.proxy_arg(1)
     assert isinstance(subscript, (list, tuple))
@@ -2291,31 +2318,14 @@ def _(state: CodegenState) -> object:
                 index_exprs,
                 vec_width,
             )
-        elif vec_mode == "tile_unroll":
+        else:
+            assert vec_mode == "tile_unroll"
             # Same hoist protocol as ``LoopedReductionStrategy``'s
             # ``unroll`` mode but for ``PerThreadNDTileStrategy`` lane loops.
             from ..tile_strategy import BlockSizeTileStrategy
 
             assert isinstance(strategy, BlockSizeTileStrategy)
             load_expr = _cute_register_tile_unroll_vec_hoist(
-                state,
-                strategy,
-                vec_block_id,
-                tensor,
-                tensor_name,
-                index_exprs,
-                vec_width,
-            )
-        else:
-            assert vec_mode == "tile_unroll_split2"
-            # V=8 fp16/bf16: emit two back-to-back ``cute.arch.load(...,
-            # V=4)`` calls (lanes 0-3 and 4-7).  Works around the CuTe
-            # DSL's ``nvvm.load.ext`` ICE on V=8 while still issuing the
-            # full LDG.128 of bytes-per-thread-per-outer-iter.
-            from ..tile_strategy import BlockSizeTileStrategy
-
-            assert isinstance(strategy, BlockSizeTileStrategy)
-            load_expr = _cute_register_tile_unroll_vec_hoist_split2(
                 state,
                 strategy,
                 vec_block_id,

--- a/helion/_compiler/cute/online_to_3pass.py
+++ b/helion/_compiler/cute/online_to_3pass.py
@@ -753,16 +753,20 @@ class _OnlineToThreePassTransformer(ast.NodeTransformer):
 
 def _min_n_for_rewrite() -> int:
     """The reduction-axis extent (``N``) at or above which the 3-pass form
-    is profitable.  Defaults to 2048; set ``HELION_ONLINE_TO_3PASS_MIN_N``
-    to override (e.g. ``0`` to always fire, useful for A/B tests).
+    is profitable.  Defaults to 0 (always rewrite): with the lane-reduce
+    collapse (one grouped reduce per sweep) and cross-sweep load fusion,
+    the 3-pass form beats the online merge even at N=1024 on B200
+    (measured +10% on both the warp-looped and resident-row config
+    families).  Set ``HELION_ONLINE_TO_3PASS_MIN_N`` to override (useful
+    for A/B tests).
     """
     val = os.environ.get("HELION_ONLINE_TO_3PASS_MIN_N")
     if val is None:
-        return 2048
+        return 0
     try:
         return int(val)
     except ValueError:
-        return 2048
+        return 0
 
 
 def _reduction_axis_extent(func: HostFunction) -> int | None:

--- a/helion/_compiler/cute/reduce_helpers.py
+++ b/helion/_compiler/cute/reduce_helpers.py
@@ -728,3 +728,105 @@ def _cute_pre_vec_fold(vec: object, reduction_type: str, *, V: int) -> object:
     if reduction_type == "prod":
         return _cute_pre_vec_fold_prod(vec, V=V)
     raise ValueError(f"unsupported CuTe pre-vec-fold type: {reduction_type!r}")
+
+
+@cute.jit
+def _cute_grouped_reduce_cluster_body(
+    input_value: cute.Numeric,
+    warp_op: object,
+    combine: object,
+    identity: cute.Numeric,
+    lane_var: cutlass.Int32,
+    buf_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    group_span: int,
+    cluster_n: int,
+) -> cute.Numeric:
+    """Combine ``input_value`` across ``group_span`` CTA threads AND the
+    ``cluster_n`` CTAs of the thread-block cluster that cooperate on one
+    reduction group (e.g. one softmax row split across the cluster).
+
+    Every warp's partial is warp-reduced, then pushed into EVERY peer CTA's
+    SMEM receive buffer with ``st.async`` + an mbarrier transaction count;
+    after the mbarrier wait each CTA folds all ``warps * cluster_n``
+    partials locally.  Each (textual) call site must execute exactly once
+    per kernel — the mbarrier is single-phase.
+
+    ``buf_ptr`` (``warps * cluster_n`` Float32 slots) and ``mbar_ptr`` (one
+    Int64 mbarrier, arrival count 1) must be allocated and initialized in
+    the kernel preamble, followed by ``mbarrier_init_fence`` +
+    ``cluster_arrive_relaxed`` + ``cluster_wait`` so peers' barriers are
+    live before the first remote store (the device-function codegen emits
+    this once for all sites).
+
+    ``identity``'s dtype must be Float32 (the hoist pass rewrites the
+    identity to the fp32 accumulator dtype).
+    """
+    from helion._compiler.cute.cluster_helpers import store_shared_remote_f32
+
+    warps = group_span // 32
+    slots = warps * cluster_n
+    buf = cute.make_tensor(buf_ptr, (slots,))
+    mbar = mbar_ptr
+    warp_partial = warp_op(input_value, threads_in_group=32)
+    rank = cutlass.Int32(cute.arch.block_idx_in_cluster())
+    warp = lane_var // 32
+    lane = lane_var % 32
+    if warp == 0:
+        with cute.arch.elect_one():
+            cute.arch.mbarrier_arrive_and_expect_tx(mbar, slots * 4)
+    if lane < cluster_n:
+        store_shared_remote_f32(
+            cutlass.Float32(warp_partial),
+            buf.iterator + (rank * warps + warp),
+            mbar,
+            lane,
+        )
+    cute.arch.mbarrier_wait(mbar, phase=0)
+    result = identity
+    for i in cutlass.range_constexpr(slots):
+        result = combine(result, buf[i])
+    return result
+
+
+def _cute_scalar_combine_max(a: cute.Numeric, b: cute.Numeric) -> cute.Numeric:
+    return cute.arch.fmax(a, b)
+
+
+def _cute_scalar_combine_min(a: cute.Numeric, b: cute.Numeric) -> cute.Numeric:
+    return min(b, a)
+
+
+_CLUSTER_DISPATCH = {
+    "sum": (_warp_reduce_sum, operator.add),
+    "max": (_warp_reduce_max, _cute_scalar_combine_max),
+    "min": (_warp_reduce_min, _cute_scalar_combine_min),
+}
+
+
+def _cute_grouped_reduce_cluster(
+    input_value: cute.Numeric,
+    reduction_type: str,
+    identity: cute.Numeric,
+    lane_var: cutlass.Int32,
+    buf_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    *,
+    group_span: int,
+    cluster_n: int,
+) -> cute.Numeric:
+    impl = _CLUSTER_DISPATCH.get(reduction_type)
+    if impl is None:
+        raise ValueError(f"unsupported CuTe reduction type: {reduction_type!r}")
+    warp_op, combine = impl
+    return _cute_grouped_reduce_cluster_body(
+        input_value,
+        warp_op,
+        combine,
+        identity,
+        lane_var,
+        buf_ptr,
+        mbar_ptr,
+        group_span,
+        cluster_n,
+    )

--- a/helion/_compiler/cute/vec_utils.py
+++ b/helion/_compiler/cute/vec_utils.py
@@ -1,0 +1,26 @@
+# pyrefly: ignore-errors
+"""Vector pack/store helpers for CuTe codegen.
+
+Called during ``@cute.kernel`` tracing (plain Python; builds MLIR IR
+directly), so no ``@cute.jit`` wrapper is needed.
+"""
+
+from __future__ import annotations
+
+import cutlass
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import vector as _vector_dialect
+import cutlass.cute as cute
+
+
+def store_u16_vec(ptr: object, vals: list) -> None:
+    """Pack ``len(vals)`` ``cutlass.Uint16`` scalars into one vector value
+    and store it through ``ptr`` (a ``cute.Pointer``), emitting a single
+    ST.32/ST.64/ST.128 instead of per-element 2-byte stores.
+
+    ``vals`` is a compile-time Python list collected across an unrolled
+    ``cutlass.range_constexpr(V)`` lane loop.
+    """
+    vecty = ir.VectorType.get([len(vals)], cutlass.Uint16.mlir_type)
+    packed = _vector_dialect.from_elements(vecty, [v.ir_value() for v in vals])
+    cute.arch.store(ptr, packed)

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -987,11 +987,21 @@ class DeviceFunction:
         )
         if function_decorator:
             decorators.append(expr_from_string(function_decorator))
+        cluster_sync: list[ast.stmt] = []
+        if getattr(self.cute_state, "simt_cluster_reduce_sites", 0) > 0:
+            # One fence + cluster barrier covering every cluster-reduce
+            # site's mbarrier init (emitted into the preamble above).
+            cluster_sync = [
+                statement_from_string("cute.arch.mbarrier_init_fence()"),
+                statement_from_string("cute.arch.cluster_arrive_relaxed()"),
+                statement_from_string("cute.arch.cluster_wait()"),
+            ]
         kernel_body: list[ast.stmt] = cast(
             "list[ast.stmt]",
             [
                 *scalar_preamble,
                 *self.preamble,
+                *cluster_sync,
                 *self.body,
             ],
         )
@@ -1033,10 +1043,16 @@ class DeviceFunction:
                 )
             except Exception:
                 thread_block_dims = (1, 1, 1)
+            tensor_dtypes = {
+                arg.name: backend.dtype_str(arg.fake_value.dtype)
+                for arg in self.arguments
+                if isinstance(arg, TensorArg)
+            }
             kernel_body = fuse_two_pass_loads(
                 kernel_body,
                 constexpr_values,
                 thread_block_dims=thread_block_dims,
+                tensor_dtypes=tensor_dtypes,
             )
             # Hoist warp reductions out of constexpr V-loops to collapse
             # 4 per-V-lane warp reductions into 1 V-fold + 1 warp reduce.
@@ -1044,8 +1060,13 @@ class DeviceFunction:
             # from ~396 to ~99 (4x fewer SHFL trees).
             from .cute.hoist_warp_reduce import hoist_warp_reduce_from_vloop
 
+            # The collapse stage needs the post-rename canonical map to see
+            # through loop-carried alias vars (``v_1`` renaming to ``mi``).
+            rename_groups = {k: v[0] for k, v in self._variable_renames.items()}
             kernel_body = hoist_warp_reduce_from_vloop(
-                kernel_body, running_sum_accumulators=self.cute_matmul_running_sums
+                kernel_body,
+                running_sum_accumulators=self.cute_matmul_running_sums,
+                rename_groups=rename_groups,
             )
             # Merge adjacent constexpr V-loops that share an identical
             # statement prefix.  Caches the last common per-V-lane value
@@ -1099,7 +1120,18 @@ class DeviceFunction:
             kernel_body = pipeline_inner_loads(
                 kernel_body, constexpr_values, rename_groups=rename_groups
             )
-        return [
+            # The DSM cluster reduce uses a single-phase mbarrier, so each
+            # call site must execute exactly ONCE per kernel.  The
+            # lane-reduce collapse normally hoists it out of the (staged,
+            # multi-trip) lane loop; when the collapse bails for a config,
+            # the call would run once per lane iteration and DEADLOCK in
+            # ``mbarrier_wait`` (an unkillable kernel that wedges the
+            # autotuner's benchmark worker).  Reject such configs loudly so
+            # the autotuner skips them.
+            from .cute.hoist_warp_reduce import validate_cluster_reduce_placement
+
+            validate_cluster_reduce_placement(kernel_body, constexpr_values)
+        result = [
             *prefix,
             ast_rename(
                 create(
@@ -1113,6 +1145,29 @@ class DeviceFunction:
                 {k: v[0] for k, v in self._variable_renames.items()},
             ),
         ]
+        simt_cluster_n = getattr(self.cute_state, "simt_cluster_n", 1)
+        if simt_cluster_n > 1:
+            # The CuTe launcher reads this attribute to launch the kernel
+            # with a (1, cluster_n, 1) thread-block cluster.
+            result.append(
+                statement_from_string(
+                    f"{self.name}._helion_cute_cluster_shape = (1, {simt_cluster_n}, 1)"
+                )
+            )
+        min_blocks = self.config.config.get("cute_min_blocks_per_mp", 0)
+        if (
+            CompileEnvironment.current().backend.name == "cute"
+            and isinstance(min_blocks, int)
+            and min_blocks > 0
+        ):
+            # ptxas ``minnctapersm``: caps registers so ``min_blocks`` CTAs
+            # stay resident per SM (occupancy over spills).
+            result.append(
+                statement_from_string(
+                    f"{self.name}._helion_cute_min_blocks_per_mp = {min_blocks}"
+                )
+            )
+        return result
 
     def codegen_function_call(self) -> ast.AST:
         env = CompileEnvironment.current()
@@ -1139,6 +1194,20 @@ class DeviceFunction:
         assert pid is not None
 
         call_grid_expr = pid.codegen_grid()
+        simt_cluster_n = getattr(self.cute_state, "simt_cluster_n", 1)
+        if simt_cluster_n > 1:
+            # The cluster splits each row across ``cluster_n`` CTAs on a new
+            # trailing grid dim.  Only a 1-D grid can host the cluster dim.
+            if not (
+                isinstance(call_grid_expr, ast.Tuple) and len(call_grid_expr.elts) == 1
+            ):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "cute_cluster_n > 1 requires a 1-D launch grid",
+                )
+            call_grid_expr = expr_from_string(
+                f"(*{{grid}}, {simt_cluster_n})", grid=call_grid_expr
+            )
         # Extra params are positional and must come before any keyword args that
         # build_launcher_args appends (e.g. num_warps=, num_stages=).
         args.extend(self.codegen._extra_params)

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -34,6 +34,7 @@ from .. import language as hl
 from ..autotuner.config_spec import FULL_EXTENT_CATEGORIES
 from ..autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
 from ..autotuner.config_spec import CoResidencyGroup
+from ..autotuner.config_spec import CuteLaneLayoutSpec
 from ..autotuner.config_spec import CuteVectorWidthSpec
 from ..autotuner.config_spec import MatmulWithReductionEpilogueFact
 from ..autotuner.config_spec import ReductionCategory
@@ -1022,6 +1023,9 @@ class DeviceIR:
                             size_hint=rdim.size_hint(),
                         )
                     )
+                    env.config_spec.cute_lane_layouts.append(
+                        CuteLaneLayoutSpec(block_id=rdim.block_id)
+                    )
             graphs_with_rolled_rdim |= used_graphs
 
         # Track which rdims appear as the reduction axis of an indexed
@@ -1089,6 +1093,9 @@ class DeviceIR:
                     block_id=tile_bs.block_id,
                     size_hint=size_hint_val,
                 )
+            )
+            env.config_spec.cute_lane_layouts.append(
+                CuteLaneLayoutSpec(block_id=tile_bs.block_id)
             )
 
     def _categorize_reduction(
@@ -2836,22 +2843,26 @@ def _register_cute_lane_vector_width_specs(config_spec: ConfigSpec) -> None:
     lane-looped simply keep ``V=1`` (the slot's default), which the tile
     strategy ignores.
     """
+    from ..autotuner.config_spec import CuteLaneLayoutSpec
     from ..autotuner.config_spec import CuteVectorWidthSpec
 
     num_thread_block_ids = set(config_spec.num_threads.valid_block_ids())
     existing = set(config_spec.cute_vector_widths.valid_block_ids())
+    existing_layouts = set(config_spec.cute_lane_layouts.valid_block_ids())
     for spec in config_spec.block_sizes:
         block_id = spec.block_id
-        if block_id not in num_thread_block_ids or block_id in existing:
-            continue
         # ``max_size`` bounds the largest block_size the autotuner may pick;
         # only blocks that can exceed a single thread can ever be lane-looped.
-        if spec.max_size <= 1:
+        if block_id not in num_thread_block_ids or spec.max_size <= 1:
             continue
-        config_spec.cute_vector_widths.append(
-            CuteVectorWidthSpec(block_id=block_id, size_hint=spec.size_hint)
-        )
-        existing.add(block_id)
+        if block_id not in existing:
+            config_spec.cute_vector_widths.append(
+                CuteVectorWidthSpec(block_id=block_id, size_hint=spec.size_hint)
+            )
+            existing.add(block_id)
+        if block_id not in existing_layouts:
+            config_spec.cute_lane_layouts.append(CuteLaneLayoutSpec(block_id=block_id))
+            existing_layouts.add(block_id)
 
 
 def lower_to_device_ir(func: HostFunction) -> DeviceIR:

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -274,19 +274,28 @@ class GenerateAST(NodeVisitor, CodegenInterface):
 
     def _compute_intra_loop_barriers(self) -> None:
         """Mark loads that read a tensor an earlier store in the same body wrote,
-        so the Triton ``load`` codegen emits a ``tl.debug_barrier()`` before them.
+        so the Triton ``load`` codegen emits a ``tl.debug_barrier()`` before them
+        (the CuTe ``load`` codegen emits ``cute.arch.sync_threads()``).
 
-        Gated on Triton for the same reason as ``_compute_inter_loop_barriers``:
+        TileIR is excluded for the same reason as ``_compute_inter_loop_barriers``:
         ``tl.debug_barrier()`` lowers to ``ttg.barrier`` which the TileIR pass
         pipeline does not legalize.
         """
         from .loop_dependency_checker import mark_intra_loop_raw_barriers
 
         env = CompileEnvironment.current()
-        if env.codegen_name != "triton" or env.backend.name == "tileir":
+        if env.backend.name != "cute" and (
+            env.codegen_name != "triton" or env.backend.name == "tileir"
+        ):
             return
         mark_intra_loop_raw_barriers(
-            self.codegen_graphs, self.host_function.device_ir.root_ids
+            self.codegen_graphs,
+            self.host_function.device_ir.root_ids,
+            # A CuTe SIMT branch condition can vary per thread, and the
+            # convergent ``sync_threads`` barrier deadlocks in a divergent
+            # branch.  Triton branches are uniform per program, so the
+            # barrier is always placeable there.
+            mark_in_divergent_control_flow=env.backend.name != "cute",
         )
 
     def _triton_global_barrier_tensor_names(self, names: frozenset[str]) -> set[str]:

--- a/helion/_compiler/loop_dependency_checker.py
+++ b/helion/_compiler/loop_dependency_checker.py
@@ -18,7 +18,10 @@ INTRA_LOOP_RAW_BARRIER_META = "_needs_debug_barrier_before"
 
 
 def mark_intra_loop_raw_barriers(
-    graphs: list[GraphInfo], root_graph_ids: list[int]
+    graphs: list[GraphInfo],
+    root_graph_ids: list[int],
+    *,
+    mark_in_divergent_control_flow: bool = True,
 ) -> None:
     """Mark loads that read storage written earlier in a device-loop body.
 
@@ -33,20 +36,34 @@ def mark_intra_loop_raw_barriers(
     guarantee to a store->load *within* one loop body.
 
     We mark the load's FX node; the Triton ``load`` codegen emits a
-    ``tl.debug_barrier()`` before it. The barrier flushes every prior write in the
+    ``tl.debug_barrier()`` before it (the CuTe codegen a
+    ``cute.arch.sync_threads()``). The barrier flushes every prior write in the
     block, so once emitted the pending-write set is cleared and later loads need a
     new store to re-arm. Storage identity comes from the fake tensor's underlying
     storage, so distinct FX nodes for aliases and views compare equal. The walk
     follows Helion control-flow subgraphs and merges pending writes at joins.
+
+    ``mark_in_divergent_control_flow=False`` skips marking loads inside ``hl.if``
+    / while bodies: a CuTe SIMT branch condition can vary per thread, and a
+    convergent CTA barrier inside a divergent branch deadlocks.  Loop bodies stay
+    markable — Helion device-loop trip structure is uniform across the CTA.
     """
-    marker = _IntraLoopRawBarrierMarker(graphs)
+    marker = _IntraLoopRawBarrierMarker(
+        graphs, mark_in_divergent_control_flow=mark_in_divergent_control_flow
+    )
     for graph_id in root_graph_ids:
         marker.run_graph(graph_id, set())
 
 
 class _IntraLoopRawBarrierMarker:
-    def __init__(self, graphs: list[GraphInfo]) -> None:
+    def __init__(
+        self,
+        graphs: list[GraphInfo],
+        *,
+        mark_in_divergent_control_flow: bool = True,
+    ) -> None:
         self.graphs = graphs
+        self.mark_in_divergent_control_flow = mark_in_divergent_control_flow
 
     def _storage_ids(self, graph_id: int, obj: object) -> set[int]:
         import torch
@@ -79,7 +96,9 @@ class _IntraLoopRawBarrierMarker:
             result.update(self._storage_ids(graph_id, arg))
         return result
 
-    def run_graph(self, graph_id: int, written: set[int]) -> set[int]:
+    def run_graph(
+        self, graph_id: int, written: set[int], *, divergent: bool = False
+    ) -> set[int]:
         from ..language import memory_ops
         from ..language._tracing_ops import _for_loop
         from ..language._tracing_ops import _for_loop_step
@@ -100,6 +119,10 @@ class _IntraLoopRawBarrierMarker:
                 if node.meta.get(INTRA_LOOP_RAW_BARRIER_META):
                     pending.clear()
                 elif pending & self._storage_ids(graph_id, node.args[0]):
+                    if divergent and not self.mark_in_divergent_control_flow:
+                        # Cannot place a convergent barrier here; leave the
+                        # hazard pending so a later uniform load re-arms it.
+                        continue
                     node.meta[INTRA_LOOP_RAW_BARRIER_META] = True
                     pending.clear()
                 continue
@@ -108,7 +131,7 @@ class _IntraLoopRawBarrierMarker:
                 assert isinstance(if_graph_id, int)
                 if_info = self.graphs[if_graph_id]
                 assert isinstance(if_info, IfGraphInfo)
-                if_pending = self.run_graph(if_graph_id, pending)
+                if_pending = self.run_graph(if_graph_id, pending, divergent=True)
                 if if_info.else_branch is None:
                     pending |= if_pending
                 else:
@@ -117,7 +140,9 @@ class _IntraLoopRawBarrierMarker:
                         if isinstance(if_info.else_branch, int)
                         else if_info.else_branch.graph_id
                     )
-                    else_pending = self.run_graph(else_graph_id, pending)
+                    else_pending = self.run_graph(
+                        else_graph_id, pending, divergent=True
+                    )
                     pending = if_pending | else_pending
                 continue
             if node.target in (_for_loop, _for_loop_step):
@@ -126,7 +151,9 @@ class _IntraLoopRawBarrierMarker:
                 loop_info = self.graphs[loop_graph_id]
                 assert isinstance(loop_info, ForLoopGraphInfo)
                 loop_input = set() if loop_info.needs_barrier_before else pending
-                loop_pending = self.run_graph(loop_graph_id, loop_input)
+                loop_pending = self.run_graph(
+                    loop_graph_id, loop_input, divergent=divergent
+                )
                 # Without a pre-loop barrier, zero iterations preserve the input state.
                 pending = (
                     loop_pending
@@ -139,8 +166,12 @@ class _IntraLoopRawBarrierMarker:
                 assert isinstance(body_graph_id, int)
                 body_info = self.graphs[body_graph_id]
                 assert isinstance(body_info, WhileLoopGraphInfo)
-                condition_pending = self.run_graph(body_info.cond_graph_id, pending)
-                body_pending = self.run_graph(body_graph_id, condition_pending)
+                condition_pending = self.run_graph(
+                    body_info.cond_graph_id, pending, divergent=True
+                )
+                body_pending = self.run_graph(
+                    body_graph_id, condition_pending, divergent=True
+                )
                 # The condition executes at least once; the body may not execute.
                 pending = condition_pending | body_pending
         return pending

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -301,6 +301,24 @@ class ReductionStrategy(TileStrategy):
                     return True
         return False
 
+    def _lane_reduce_cluster_n(self) -> int:
+        """Thread-block-cluster width of the lane-looped strategy that
+        distributes this reduction block, or 1 when not cluster-split."""
+        codegen = getattr(self, "_codegen", None)
+        if codegen is None:
+            return 1
+        for loops in codegen.active_device_loops.values():
+            for loop_state in loops:
+                if (
+                    isinstance(loop_state, DeviceLoopState)
+                    and self.block_index in loop_state.lane_loop_blocks
+                ):
+                    strategy = loop_state.strategy
+                    cluster_by_block = getattr(strategy, "_cute_cluster_by_block", None)
+                    if isinstance(cluster_by_block, dict):
+                        return cluster_by_block.get(self.block_index, 1)
+        return 1
+
     def _lane_reduce_threads_in_group(self) -> int | None:
         """Return ``threads_in_group`` for a two-pass lane reduction over this
         block, or ``None`` when this reduction is not over a lane-distributed
@@ -2250,6 +2268,16 @@ class BlockReductionStrategy(ReductionStrategy):
                     > smem_budget_bytes
                 ):
                     return None
+                if self._lane_reduce_cluster_n() > 1 and (pre != 1 or group_count != 1):
+                    # The cluster split covers the whole CTA; an
+                    # interleaved / multi-group reduce cannot combine
+                    # across the cluster and would silently drop the
+                    # peer CTAs' contributions.
+                    raise exc.BackendUnsupported(
+                        "cute",
+                        "cute_cluster_n > 1 requires a whole-CTA reduce "
+                        "group (pre == 1 and group_count == 1)",
+                    )
                 return self._strided_thread_reduction_expr_shared_two_stage(
                     state=state,
                     input_name=input_name,
@@ -2270,6 +2298,12 @@ class BlockReductionStrategy(ReductionStrategy):
                 > smem_budget_bytes
             ):
                 return None
+            if self._lane_reduce_cluster_n() > 1:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "cute_cluster_n > 1 is not supported with the "
+                    "shared-tree reduction layout",
+                )
             return self._strided_thread_reduction_expr_shared_tree(
                 state=state,
                 input_name=input_name,
@@ -2285,6 +2319,12 @@ class BlockReductionStrategy(ReductionStrategy):
                 group_count=group_count,
             )
 
+        if self._lane_reduce_cluster_n() > 1:
+            raise exc.BackendUnsupported(
+                "cute",
+                "cute_cluster_n > 1 requires a cross-warp reduce group; "
+                "this config reduces within single warps",
+            )
         return (
             "_cute_grouped_reduce_warp("
             f"{input_name}, {reduction_type!r}, {identity_expr}, {lane_expr}, "
@@ -2307,6 +2347,43 @@ class BlockReductionStrategy(ReductionStrategy):
         group_count: int,
     ) -> str:
         result_var = self.fn.new_var("strided_reduce_result", dce=True)
+        cluster_n = self._lane_reduce_cluster_n()
+        if cluster_n > 1 and pre == 1 and group_count == 1:
+            # The reduced axis is additionally split across the CTAs of a
+            # thread-block cluster (``cute_cluster_n``): combine within-CTA
+            # warps and across the cluster with one DSM exchange.  The SMEM
+            # receive buffer and mbarrier are allocated + initialized in the
+            # kernel preamble; ``codegen_function_def`` emits ONE
+            # ``mbarrier_init_fence`` + cluster arrive/wait covering every
+            # site (a per-site cluster barrier costs ~10% of kernel time at
+            # cluster_n=16).
+            slots = (group_span // 32) * cluster_n
+            buf_var = self.fn.new_var("_cluster_red_buf", dce=False)
+            mbar_var = self.fn.new_var("_cluster_red_mbar", dce=False)
+            self.fn.preamble.append(
+                statement_from_string(
+                    f"{buf_var} = cute.arch.alloc_smem(cutlass.Float32, {slots})"
+                )
+            )
+            self.fn.preamble.append(
+                statement_from_string(
+                    f"{mbar_var} = cute.arch.alloc_smem(cutlass.Int64, 1)"
+                )
+            )
+            self.fn.preamble.append(
+                statement_from_string(
+                    "if cutlass.Int32(cute.arch.thread_idx()[0]) == 0:"
+                    f"\n    cute.arch.mbarrier_init({mbar_var}, 1)"
+                )
+            )
+            self.fn.cute_state.simt_cluster_reduce_sites += 1
+            state.add_statement(
+                f"{result_var} = _cute_grouped_reduce_cluster("
+                f"{input_name}, {reduction_type!r}, {identity_expr}, "
+                f"{lane_var}, {buf_var}, {mbar_var}, "
+                f"group_span={group_span}, cluster_n={cluster_n})"
+            )
+            return result_var
         state.add_statement(
             f"{result_var} = _cute_grouped_reduce_shared_two_stage("
             f"{input_name}, {reduction_type!r}, {identity_expr}, "
@@ -2401,6 +2478,13 @@ class BlockReductionStrategy(ReductionStrategy):
                     constant_repr(default), _dtype_str(acc_dtype)
                 )
                 group_params = self._lane_loop_cross_warp_group_params()
+                cluster_n = self._lane_reduce_cluster_n()
+                if cluster_n > 1 and group_params is None:
+                    raise exc.BackendUnsupported(
+                        "cute",
+                        "cute_cluster_n > 1 requires the cross-warp "
+                        "grouped reduce path",
+                    )
                 if group_params is not None:
                     # The reduce group is spread across warps (the reduced tile
                     # dim sits ABOVE a sibling tile axis on the linear thread
@@ -2418,6 +2502,7 @@ class BlockReductionStrategy(ReductionStrategy):
                         group_span=group_span,
                         group_lane_expr=group_lane_expr,
                         group_count=group_count,
+                        group_cluster_n=cluster_n,
                     )
                 else:
                     expr = _lane_reduce_marker_expr(

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -520,6 +520,61 @@ class TileStrategyDispatch:
                     return size
         return None
 
+    def has_surplus_threads_for_strategy(self, strategy: TileStrategy) -> bool:
+        """Whether the launch may run any of a strategy's thread axes wider
+        than the strategy requested.
+
+        Mutually exclusive kernel sections (e.g. two persistent stages around
+        an ``hl.barrier()``) share one launch whose block dims are the
+        elementwise max across sections, so a section can execute with more
+        threads on an axis than its own tile is wide.  Those surplus threads
+        index past the tile, so bounds masks for the axis must not be elided.
+        """
+        base_axis = self.thread_axis_for_strategy(strategy)
+        if base_axis is None:
+            return False
+        dims = self.thread_block_dims()
+        for _block_id, local_axis, size, _expr in self._iter_strategy_thread_axes(
+            strategy
+        ):
+            axis = base_axis + local_axis
+            # ``size is None`` means the extent is dynamic; the static launch
+            # dims cannot prove the launch matches, so keep the mask.
+            if size is None or axis >= len(dims) or dims[axis] > size:
+                return True
+        return False
+
+    def has_surplus_threads_for_block_id(self, target_block_id: int) -> bool:
+        """Per-block variant of :meth:`has_surplus_threads_for_strategy`.
+
+        ``False`` for blocks that do not claim a thread axis: their index is
+        uniform across the CTA, so extra launched threads only duplicate the
+        owning thread's in-bounds work.
+        """
+        for strategy in self.strategies:
+            if target_block_id not in strategy.block_ids or isinstance(
+                strategy, ReductionStrategy
+            ):
+                continue
+            base_axis = self.thread_axis_for_strategy(strategy)
+            if base_axis is None:
+                return False
+            dims = self.thread_block_dims()
+            for (
+                block_id,
+                local_axis,
+                size,
+                _expr,
+            ) in self._iter_strategy_thread_axes(strategy):
+                if block_id != target_block_id:
+                    continue
+                axis = base_axis + local_axis
+                if size is None or axis >= len(dims):
+                    return True
+                return dims[axis] > size
+            return False
+        return False
+
     def thread_axis_sizes(self) -> dict[int, int]:
         dims = self.thread_block_dims()
         return {axis: size for axis, size in enumerate(dims) if size > 1}

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -118,6 +118,7 @@ def _lane_reduce_marker_expr(
     group_span: int = 0,
     group_lane_expr: str = "",
     group_count: int = 1,
+    group_cluster_n: int = 1,
 ) -> str:
     # ``group_*`` (optional) carry the parameters of a strided grouped
     # reduction. They are required when the reduction's live thread axis is
@@ -134,7 +135,7 @@ def _lane_reduce_marker_expr(
     return (
         f"{_HELION_LANE_REDUCE_MARKER}({input_name}, {reduction_type!r}, "
         f"{identity_expr}, {threads_in_group}, {group_pre}, {group_span}, "
-        f"{group_lane_expr!r}, {group_count})"
+        f"{group_lane_expr!r}, {group_count}, {group_cluster_n})"
     )
 
 
@@ -160,6 +161,9 @@ class _LaneReduceMarker:
     group_span: int = 0
     group_lane_expr: str = ""
     group_count: int = 1
+    # > 1 when the reduction group is additionally split across the CTAs of
+    # a thread-block cluster; the finalize then uses the DSM cluster reduce.
+    group_cluster_n: int = 1
 
     def finalize_expr(self, reduced: str) -> str:
         return self.wrap_template.replace("__HELION_FINALIZED__", f"({reduced})")
@@ -204,7 +208,7 @@ def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
     if not isinstance(target, ast.Name):
         return None
     call = _find_lane_reduce_call(stmt.value)
-    if call is None or len(call.args) != 8:
+    if call is None or len(call.args) not in (8, 9):
         return None
     (
         input_node,
@@ -215,7 +219,9 @@ def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
         group_span_node,
         group_lane_node,
         group_count_node,
+        *rest,
     ) = call.args
+    group_cluster_n = int(ast.literal_eval(rest[0])) if rest else 1
     input_name = ast.unparse(input_node)
     reduction_type = ast.literal_eval(type_node)
     identity_expr = ast.unparse(identity_node)
@@ -239,6 +245,7 @@ def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
         group_span=group_span,
         group_lane_expr=group_lane_expr,
         group_count=group_count,
+        group_cluster_n=group_cluster_n,
     )
 
 
@@ -346,6 +353,20 @@ def _finalize_lane_reduce_marker(m: _LaneReduceMarker, acc_var: str) -> list[ast
     * a plain consecutive-lane warp reduction otherwise;
     * the accumulator unchanged when there is no live thread axis to combine.
     """
+    if m.group_cluster_n > 1:
+        # The two-pass marker finalize has no access to the preamble
+        # buffer/mbarrier plumbing the DSM cluster reduce needs (only the
+        # strided-thread-reduction path emits that), so a cluster-split
+        # reduce landing here cannot be combined across the cluster —
+        # reject the config loudly.
+        from .. import exc
+
+        raise exc.BackendUnsupported(
+            "cute",
+            "cute_cluster_n > 1 is not supported for the two-pass lane "
+            "reduction finalize; only the strided cross-warp reduce path "
+            "can perform the cluster combine",
+        )
     if m.group_span > 32 and m.group_span % 32 == 0 and m.group_lane_expr:
         # Cross-warp: the reduce group is spread across warps, so fold the
         # per-lane accumulator with the two-stage shared-memory reduction.
@@ -2580,15 +2601,18 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
         assert isinstance(block_size, (int, torch.SymInt))
         super().__init__(fn, block_ids, block_size, loop_order)
         env = CompileEnvironment.current()
-        if not env.backend.force_tile_mask() and env.known_multiple(
+        self._mask_elidable = not env.backend.force_tile_mask() and env.known_multiple(
             functools.reduce(  # pyrefly: ignore[incompatible-overload-residual]
                 operator.mul, [env.block_sizes[i].numel for i in block_ids]
             ),
             block_size,
-        ):
-            self._mask_var = None
-        else:
-            self._mask_var: str | None = self.new_var("mask", dce=True)
+        )
+        # Elision also requires that no sibling section launches this
+        # strategy's thread axis wider than the tile, which is unknowable
+        # until every strategy is registered in the dispatch — ``mask_var``
+        # decides lazily on first use during codegen.
+        self._mask_elision_decided = False
+        self._mask_var: str | None = self.new_var("mask", dce=True)
         self._offsets_var = self.new_var("offsets", dce=True)
 
         key = (*self.block_ids,)
@@ -2606,6 +2630,13 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
         raise NotImplementedError("offset_var not used in FlattenedTileStrategy")
 
     def mask_var(self, block_idx: int) -> str | None:
+        if not self._mask_elision_decided:
+            self._mask_elision_decided = True
+            if self._mask_elidable and not (
+                CompileEnvironment.current().backend.launches_surplus_tile_threads()
+                and self.fn.tile_strategy.has_surplus_threads_for_strategy(self)
+            ):
+                self._mask_var = None
         return self._mask_var
 
     def block_size_var(self, block_idx: int) -> str:
@@ -3621,6 +3652,10 @@ class NDTileStrategy(_BaseNDTileStrategy):
             not env.backend.force_tile_mask()
             and env.block_sizes[block_idx].known_multiple(block_size)
             and not env.is_jagged_tile(block_idx)
+            and not (
+                env.backend.launches_surplus_tile_threads()
+                and self.fn.tile_strategy.has_surplus_threads_for_block_id(block_idx)
+            )
         ):
             self.mask_vars[block_idx] = None
             return None
@@ -3734,6 +3769,26 @@ class PerThreadNDTileStrategy(NDTileStrategy):
         # ``insert(len(lane_body)-1, hoist_stmt)`` to splice the vec
         # load just before the inner V-loop.
         self._cute_lane_body_by_block: dict[int, list] = {}
+        # Per-block constexpr V-loop AST node.  memory_ops locates it in
+        # ``lane_body`` to splice vec-load hoists BEFORE it and vec-store
+        # flushes AFTER it (position-independent, so both can coexist).
+        self._cute_lane_vloop_by_block: dict[int, ast.For] = {}
+        # Per-block cache of vec-store flush sites:
+        # (tensor_name, base_ptr_expr) -> list_var_name.
+        self._cute_lane_vec_stores_by_block: dict[int, dict] = {}
+        # Per-block lane layout ("blocked" | "strided") from the
+        # ``cute_lane_layouts`` config knob.  Only differs from blocked
+        # when the lane loop has more than one iteration.
+        self._cute_lane_layout_by_block: dict[int, str] = {}
+        # Lazy one-shot guard for ``_maybe_apply_cute_cluster``.
+        self._cute_cluster_checked: bool = False
+        # Per-block thread-block-cluster split (from ``cute_cluster_n``):
+        # the axis's elements are divided across ``cl`` cluster CTAs in
+        # addition to the CTA's own threads.  Applied only to a single
+        # lane-looped axis when the tile covers the full extent (single
+        # trip, so cluster reduces run exactly once per call site) and all
+        # sibling axes have thread extent 1.
+        self._cute_cluster_by_block: dict[int, int] = {}
         # Shared per-block hoist cache: (tensor_name, base_ptr_expr) ->
         # (hoist_var, dtype).  Same shape as
         # ``LoopedReductionStrategy._cute_lane_vec_loads``.
@@ -3743,6 +3798,10 @@ class PerThreadNDTileStrategy(NDTileStrategy):
             cute_vec_widths_cfg = cast(
                 "list[int]",
                 fn.config.config.get("cute_vector_widths", []) or [],
+            )
+            cute_lane_layouts_cfg = cast(
+                "list[str]",
+                fn.config.config.get("cute_lane_layouts", []) or [],
             )
             for block_id, nt, bs in zip(
                 block_ids, num_threads, block_size, strict=True
@@ -3759,6 +3818,15 @@ class PerThreadNDTileStrategy(NDTileStrategy):
                     self._lane_var_by_block[block_id] = self.fn.new_var(
                         f"lane_{block_id}"
                     )
+                    if (
+                        block_id
+                        in env_local.config_spec.cute_lane_layouts.valid_block_ids()
+                    ):
+                        layout = env_local.config_spec.cute_lane_layouts.config_get(
+                            cute_lane_layouts_cfg, block_id, "blocked"
+                        )
+                        if isinstance(layout, str):
+                            self._cute_lane_layout_by_block[block_id] = layout
                     elements_per_thread = static_bs // nt
                     # Vec slot is registered eagerly in device-IR analysis; read
                     # the tuned V.  Never append here — growing the spec during
@@ -3806,8 +3874,74 @@ class PerThreadNDTileStrategy(NDTileStrategy):
             return None
         return int(block_size_expr)
 
+    def _maybe_apply_cute_cluster(
+        self, env: CompileEnvironment, state: CodegenState
+    ) -> None:
+        """Decide whether the ``cute_cluster_n`` knob applies to this loop
+        (invoked lazily on the first ``codegen_device_loop`` call so the
+        active grid state is visible).
+
+        See ``_cute_cluster_by_block``.  When applied, the owning
+        ``DeviceFunction``'s ``cute_state.simt_cluster_n`` is set so the
+        host-side call emits the extra grid dim + cluster launch shape.
+        """
+        if self._cute_cluster_checked:
+            return
+        self._cute_cluster_checked = True
+        if env.backend_name != "cute" or self.mma_mode:
+            return
+        cl = self.fn.config.config.get("cute_cluster_n", 1)
+        if not isinstance(cl, int) or cl <= 1:
+            return
+        if getattr(self.fn.cute_state, "simt_cluster_n", 1) > 1:
+            # Another device loop's strategy already claimed the cluster
+            # rank; splitting a second axis on the same rank would leave
+            # only the diagonal rank x rank blocks covered.
+            return
+        if len(self._lane_var_by_block) != 1:
+            return
+        # The cluster reduce combines across the WHOLE CTA, so the grid
+        # strategy must not put sibling axes on thread dims (e.g. a
+        # multi-row grid tile with block_m > 1) — those rows would be
+        # folded together.
+        grid_axis_sizes = getattr(
+            state.codegen.current_grid_state, "thread_axis_sizes", None
+        )
+        if isinstance(grid_axis_sizes, dict) and any(
+            size > 1 for size in grid_axis_sizes.values()
+        ):
+            return
+        [block_id] = self._lane_var_by_block.keys()
+        vec = self._cute_lane_vec_width_by_block.get(block_id, 1)
+        idx = self.block_ids.index(block_id)
+        nt = self.num_threads[idx]
+        static_bs = self._configured_block_size_int(self.block_size[idx])
+        if static_bs is None or nt <= 0 or nt % 32 != 0:
+            return
+        numel = env.block_sizes[block_id].numel
+        try:
+            numel_int = int(numel)
+        except (TypeError, ValueError):
+            return
+        # Single trip (the whole extent in one tile) so each cluster reduce
+        # call site executes exactly once (fixed mbarrier phase), and the
+        # per-CTA slice must keep a whole vec chunk per thread.
+        if static_bs < numel_int or static_bs % (nt * cl * vec) != 0:
+            return
+        # All sibling axes must not use a thread axis (the cluster reduce
+        # combines across the whole CTA).
+        for other_id, other_bs in zip(self.block_ids, self.block_size, strict=True):
+            if other_id == block_id:
+                continue
+            extent = self._static_thread_extent_for_block(other_id, other_bs)
+            if extent is not None and extent != 1:
+                return
+        self._cute_cluster_by_block[block_id] = cl
+        self.fn.cute_state.simt_cluster_n = cl
+
     def _elements_per_thread_for_block(self, block_id: int) -> int:
-        """Elements per thread for *block_id* (derived from num_threads)."""
+        """Elements per thread for *block_id* (derived from num_threads and
+        the cluster split)."""
         if block_id in self.inactive_block_ids:
             return 1
         idx = self.block_ids.index(block_id)
@@ -3816,7 +3950,7 @@ class PerThreadNDTileStrategy(NDTileStrategy):
             return 1
         bs = self._configured_block_size_int(self.block_size[idx])
         assert isinstance(bs, int)  # validated by _thread_extent_for_axis
-        return bs // nt
+        return bs // nt // self._cute_cluster_by_block.get(block_id, 1)
 
     def _thread_extent_for_axis(
         self, block_id: int, block_size: SymIntLike
@@ -4093,6 +4227,7 @@ class PerThreadNDTileStrategy(NDTileStrategy):
 
         block_ids = self.block_ids
         env = CompileEnvironment.current()
+        self._maybe_apply_cute_cluster(env, state)
         dtype = env.index_type()
         block_sizes = self.block_size
         user_body: list[ast.AST] = []
@@ -4136,6 +4271,7 @@ class PerThreadNDTileStrategy(NDTileStrategy):
                 # the same protocol ``LoopedReductionStrategy`` uses.
                 lane_body: list[ast.AST] = [inner_for]
                 self._cute_lane_body_by_block[block_id] = lane_body
+                self._cute_lane_vloop_by_block[block_id] = inner_for
                 outer_extent = extent // vec_width
                 # Always emit the outer lane loop even when ``outer_extent
                 # == 1`` (i.e. EPT == V): the lane-base index expression
@@ -4240,6 +4376,35 @@ class PerThreadNDTileStrategy(NDTileStrategy):
                 idx_expr = offset_var
             block_vec_width = self._cute_lane_vec_width_by_block.get(block_idx, 1)
             vec_lane_var = self._cute_vec_lane_var_by_block.get(block_idx)
+            # Strided lane layout: thread ``t`` owns V-wide chunks strided by
+            # the thread count instead of one contiguous EPT-element span, so
+            # each warp instruction touches consecutive chunks (coalesced).
+            lane_strided = (
+                self._cute_lane_layout_by_block.get(block_idx, "blocked") == "strided"
+                and uses_thread_axis
+                and isinstance(static_extent, int)
+            )
+            # Cluster split: each of the ``cluster_n`` CTAs in the cluster
+            # owns a contiguous ``block/cluster_n`` slice of the tile (the
+            # launch adds a grid dim of ``cluster_n`` CTAs per outer index).
+            # The slice offset folds into the tile offset; the per-CTA lane
+            # layout applies within the slice unchanged
+            # (``_elements_per_thread_for_block`` already divides by the
+            # cluster width).
+            lane_cluster_n = self._cute_cluster_by_block.get(block_idx, 1)
+            if lane_cluster_n > 1:
+                assert uses_thread_axis and isinstance(static_extent, int)
+                cluster_block = self._configured_block_size_int(block_size)
+                assert isinstance(cluster_block, int)
+                slice_len = cluster_block // lane_cluster_n
+                offset_var = (
+                    f"({offset_var} + "
+                    f"{env.backend.program_id_expr(1, index_dtype=dtype)}"
+                    f" * {slice_len})"
+                )
+                idx_expr = env.backend.lane_index_expr(
+                    offset_var, elements_per_thread, axis=axis
+                )
             if lane_var := self._lane_var_by_block.get(block_idx):
                 if block_vec_width > 1 and vec_lane_var is not None:
                     # Composite per-element lane index = outer*V + inner.
@@ -4261,10 +4426,21 @@ class PerThreadNDTileStrategy(NDTileStrategy):
                     # at the same level by memory_ops.
                     lane_body_list = self._cute_lane_body_by_block.get(block_idx)
                     if lane_body_list is not None:
-                        base_expr = (
-                            f"{idx_expr} + {env.backend.lane_offset_expr(lane_var)} "
-                            f"* {block_vec_width}"
-                        )
+                        if lane_strided:
+                            # ``base = offset + (outer*NT + tid) * V``
+                            base_expr = (
+                                f"{offset_var} + "
+                                f"({env.backend.lane_offset_expr(lane_var)} "
+                                f"* {static_extent} + "
+                                f"{env.backend.thread_index_expr(axis=axis)}) "
+                                f"* {block_vec_width}"
+                            )
+                        else:
+                            base_expr = (
+                                f"{idx_expr} + "
+                                f"{env.backend.lane_offset_expr(lane_var)} "
+                                f"* {block_vec_width}"
+                            )
                         lane_body_list.insert(
                             0,
                             statement_from_string(f"{base_index_var} = {base_expr}"),
@@ -4274,6 +4450,13 @@ class PerThreadNDTileStrategy(NDTileStrategy):
                     # pipeline (mask + cast + reduce-or-store) keeps
                     # working unchanged.
                     idx_expr = f"{base_index_var} + cutlass.Int32({vec_lane_var})"
+                elif lane_strided:
+                    # ``idx = offset + tid + lane * NT``
+                    idx_expr = (
+                        f"{offset_var} + {env.backend.thread_index_expr(axis=axis)}"
+                        f" + {env.backend.lane_offset_expr(lane_var)}"
+                        f" * {static_extent}"
+                    )
                 else:
                     idx_expr = f"{idx_expr} + {env.backend.lane_offset_expr(lane_var)}"
             index_setup.append(statement_from_string(f"{index_var} = {idx_expr}"))

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -816,6 +816,9 @@ BACKEND_SPECIFIC_KEYS: frozenset[str] = (
     | {
         "num_threads",
         "cute_vector_widths",
+        "cute_lane_layouts",
+        "cute_cluster_n",
+        "cute_min_blocks_per_mp",
         "load_cache_modifiers",
         "store_cache_modifiers",
         "pallas_loop_type",
@@ -854,6 +857,9 @@ VALID_KEYS: frozenset[str] = frozenset(
         "pallas_indirect_access_mode",
         "pallas_pre_broadcast",
         "cute_vector_widths",
+        "cute_lane_layouts",
+        "cute_cluster_n",
+        "cute_min_blocks_per_mp",
         *BACKEND_TUNABLE_KEYS,
         "advanced_controls_file",
         "epilogue_subtile",
@@ -1003,6 +1009,7 @@ class ConfigSpec:
         self.cute_vector_widths: BlockIdSequence[CuteVectorWidthSpec] = (
             BlockIdSequence()
         )
+        self.cute_lane_layouts: BlockIdSequence[CuteLaneLayoutSpec] = BlockIdSequence()
         self.range_unroll_factors: BlockIdSequence[RangeUnrollFactorSpec] = (
             BlockIdSequence()
         )
@@ -1409,6 +1416,9 @@ class ConfigSpec:
             self._normalize_cute_flash_default_sequence(config, "l2_groupings", 1)
             self._normalize_cute_flash_default_sequence(config, "num_threads", 0)
             self._normalize_cute_flash_default_sequence(config, "cute_vector_widths", 1)
+            self._normalize_cute_flash_default_sequence(
+                config, "cute_lane_layouts", "blocked"
+            )
             self._normalize_cute_flash_default_loop_orders(config)
             config.pop("epilogue_subtile", None)
         elif not self._is_cute_flash_config_envelope(config, block_size_targets):
@@ -1871,6 +1881,7 @@ class ConfigSpec:
             ("l2_groupings", 1),
             ("num_threads", 0),
             ("cute_vector_widths", 1),
+            ("cute_lane_layouts", "blocked"),
         ):
             value = config.get(key)
             if value and (
@@ -2319,6 +2330,7 @@ class ConfigSpec:
             ("loop_orders", self.loop_orders, False),
             ("reduction_loops", self.reduction_loops, True),
             ("cute_vector_widths", self.cute_vector_widths, True),
+            ("cute_lane_layouts", self.cute_lane_layouts, True),
             ("range_unroll_factors", self.range_unroll_factors, True),
             ("range_warp_specializes", self.range_warp_specialize, True),
             ("range_num_stages", self.range_num_stages, True),
@@ -2524,6 +2536,7 @@ class ConfigSpec:
             "flatten_loops",
             "reduction_loops",
             "cute_vector_widths",
+            "cute_lane_layouts",
             "range_unroll_factors",
             "range_warp_specializes",
             "range_num_stages",
@@ -3230,6 +3243,37 @@ class ConfigSpec:
                     and len(self.cute_vector_widths) > 0
                 ):
                     fields["cute_vector_widths"] = self.cute_vector_widths
+                # Per-block lane layout (blocked vs strided per-thread
+                # element assignment) for lane loops with more than one
+                # iteration; strided gives fully coalesced warp accesses.
+                if (
+                    self.supports_config_key("cute_lane_layouts")
+                    and len(self.cute_lane_layouts) > 0
+                ):
+                    fields["cute_lane_layouts"] = self.cute_lane_layouts
+                # Thread-block cluster width for SIMT reduction kernels:
+                # splits a whole-extent lane-looped axis across cluster
+                # CTAs (register-resident slices) with a DSM cluster
+                # reduce.  Ignored (cluster 1) when the config shape
+                # doesn't qualify — see
+                # ``PerThreadNDTileStrategy._maybe_apply_cute_cluster``.
+                if (
+                    self.supports_config_key("cute_cluster_n")
+                    and len(self.cute_lane_layouts) > 0
+                    and not self.matmul_facts
+                ):
+                    fields["cute_cluster_n"] = EnumFragment(choices=(1, 2, 4, 8, 16))
+                # Minimum resident CTAs per SM (ptxas ``minnctapersm``):
+                # caps registers per thread so more CTAs fit, trading
+                # spills for occupancy.  0 leaves ptxas free.
+                if (
+                    self.supports_config_key("cute_min_blocks_per_mp")
+                    and len(self.cute_lane_layouts) > 0
+                    and not self.matmul_facts
+                ):
+                    fields["cute_min_blocks_per_mp"] = EnumFragment(
+                        choices=(0, 1, 2, 3, 4)
+                    )
             if (
                 not self.cute_flash_search_enabled
                 and self.epilogue_subtile_autotune_choices is not None
@@ -3823,6 +3867,43 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
 
 
 _CUTE_VECTOR_WIDTH_CHOICES: tuple[int, ...] = (1, 2, 4, 8)
+_CUTE_LANE_LAYOUT_CHOICES: tuple[str, ...] = ("blocked", "strided")
+
+
+class CuteLaneLayoutSpec(_BlockIdItem):
+    """Per-block per-thread element assignment for CuTe lane loops.
+
+    ``"blocked"``: thread ``t`` owns ``EPT`` contiguous elements
+    (``base = offset + t*EPT + lane*V``).  Consecutive threads in a warp
+    touch addresses ``EPT*elem_size`` bytes apart, so a warp's loads/stores
+    of one lane iter span many cache lines (poor per-instruction
+    coalescing; only acceptable when the lane loop has a single iteration,
+    where both layouts coincide).
+
+    ``"strided"``: thread ``t`` owns V-wide chunks strided by the thread
+    count (``base = offset + (lane*NT + t)*V``).  Consecutive threads touch
+    consecutive V-chunks, so each warp instruction is fully coalesced.
+    """
+
+    def __init__(
+        self,
+        *,
+        block_id: int,
+    ) -> None:
+        super().__init__([block_id])
+
+    def _fragment(self, base: ConfigSpec) -> EnumFragment:
+        return EnumFragment(choices=_CUTE_LANE_LAYOUT_CHOICES)
+
+    def _normalize(self, name: str, value: object) -> str:
+        if value not in _CUTE_LANE_LAYOUT_CHOICES:
+            raise InvalidConfig(
+                f"{name} must be one of {_CUTE_LANE_LAYOUT_CHOICES}, got {value!r}"
+            )
+        return str(value)
+
+    def _fill_missing(self) -> str:
+        return "blocked"
 
 
 class CuteVectorWidthSpec(_BlockIdItem):

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -892,6 +892,93 @@ def _cute_unroll_vec_extract(hoist_var: str, idx: str, dtype: torch.dtype) -> st
     return f"cutlass.Uint16({hoist_var}[{idx}]).bitcast({elem_dtype})"
 
 
+def _cute_lane_vloop_insert_pos(
+    strategy: object, block_id: int, lane_body: list
+) -> int:
+    """Insertion position for statements that must run just BEFORE the
+    constexpr V-loop in ``lane_body``.
+
+    Uses the strategy's recorded V-loop node when available (the V-loop is
+    no longer guaranteed to be the last entry once vec-store flushes are
+    appended after it); falls back to ``len(lane_body) - 1``.
+    """
+    vloop_by_block = getattr(strategy, "_cute_lane_vloop_by_block", None)
+    vloop = None
+    if isinstance(vloop_by_block, dict):
+        vloop = vloop_by_block.get(block_id)
+    if vloop is not None:
+        for i, stmt in enumerate(lane_body):
+            if stmt is vloop:
+                return i
+    return len(lane_body) - 1
+
+
+def _cute_register_tile_unroll_vec_store(
+    state: CodegenState,
+    strategy: object,  # BlockSizeTileStrategy (PerThreadNDTileStrategy)
+    block_id: int,
+    tensor_name: str,
+    index_exprs: list[str],
+    value_expr: str,
+    mask_expr: str | None,
+) -> ast.stmt | None:
+    """Vector-store counterpart of ``_cute_register_tile_unroll_vec_hoist``.
+
+    Replaces the per-lane scalar ``(ptr).store(value)`` inside the constexpr
+    V-loop with an append onto a compile-time Python list, and splices ONE
+    ``_cute_store_u16_vec(base_ptr, vals)`` flush AFTER the V-loop, emitting
+    an ST.64/ST.128 instead of V scalar 2-byte stores.
+
+    Caller must guarantee the per-element mask is uniform across the V
+    lanes (``numel % V == 0``, no extra_mask); the flush reuses the scalar
+    mask expression, whose per-element vars hold the last unrolled lane's
+    (uniform) value after the V-loop.
+
+    Returns the per-lane append statement, or None when the lane context
+    isn't available.
+    """
+    base_var_by_block = getattr(strategy, "_cute_lane_base_index_var_by_block", {})
+    lane_body_by_block = getattr(strategy, "_cute_lane_body_by_block", {})
+    base_index_var = base_var_by_block.get(block_id)
+    lane_body = lane_body_by_block.get(block_id)
+    if not isinstance(base_index_var, str) or not isinstance(lane_body, list):
+        return None
+    vloop_by_block = getattr(strategy, "_cute_lane_vloop_by_block", None)
+    if not isinstance(vloop_by_block, dict) or vloop_by_block.get(block_id) is None:
+        return None
+    lane_pos = _cute_lane_axis_pos(strategy, block_id, index_exprs)
+    base_exprs = list(index_exprs)
+    base_exprs[lane_pos] = base_index_var
+    base_ptr_expr = _cute_scalar_pointer_expr(tensor_name, base_exprs)
+    sites_by_block = getattr(strategy, "_cute_lane_vec_stores_by_block", None)
+    if sites_by_block is None:
+        sites_by_block = {}
+        # pyrefly: ignore [missing-attribute]
+        strategy._cute_lane_vec_stores_by_block = sites_by_block
+    sites = sites_by_block.setdefault(block_id, [])
+    site_index = len(sites)
+    list_var = state.device_function.new_var(
+        f"_tile_store_vals_{block_id}_{site_index}", dce=False
+    )
+    sites.append(list_var)
+    vloop_pos = _cute_lane_vloop_insert_pos(strategy, block_id, lane_body)
+    lane_body.insert(vloop_pos, statement_from_string(f"{list_var} = []"))
+    flush_expr = f"_cute_store_u16_vec({base_ptr_expr}, {list_var})"
+    if mask_expr is not None:
+        flush_stmt = statement_from_string(f"if {mask_expr}:\n    {flush_expr}")
+    else:
+        flush_stmt = statement_from_string(flush_expr)
+    # Insert after the V-loop AND after any earlier sites' flushes so the
+    # emitted store order matches the source order.
+    lane_body.insert(
+        _cute_lane_vloop_insert_pos(strategy, block_id, lane_body) + 1 + site_index,
+        flush_stmt,
+    )
+    return statement_from_string(
+        f"{list_var}.append(({value_expr}).bitcast(cutlass.Uint16))"
+    )
+
+
 def _cute_register_tile_unroll_vec_hoist(
     state: CodegenState,
     strategy: object,  # BlockSizeTileStrategy (PerThreadNDTileStrategy)
@@ -952,143 +1039,54 @@ def _cute_register_tile_unroll_vec_hoist(
         env_local = CompileEnvironment.current()
         numel = env_local.block_sizes[block_id].numel
         numel_expr = state.sympy_expr(numel)
-        # Build the "anchor" pointer: same index_exprs but with the
-        # inner reduction-axis index forced to 0.  This is the
-        # ``tile_offset == 0, lane_var == 0, vec_lane_var == 0`` base
-        # for the very first outer-tile iter, which is always in-bounds
-        # for any grid block.
-        anchor_exprs = list(index_exprs)
-        anchor_exprs[lane_pos] = "0"
-        anchor_ptr_expr = _cute_scalar_pointer_expr(tensor_name, anchor_exprs)
-        guarded_ptr = (
-            f"({base_ptr_expr} if {base_index_var} < {numel_expr} "
-            f"else {anchor_ptr_expr})"
+        mask_vars = getattr(strategy, "mask_vars", None)
+        block_pos = strategy.block_ids.index(block_id)  # pyrefly: ignore
+        static_bs = strategy._configured_block_size_int(  # pyrefly: ignore
+            strategy.block_size[block_pos]  # pyrefly: ignore
         )
+        try:
+            numel_int = int(numel)
+        except (TypeError, ValueError):
+            numel_int = None
+        if (
+            isinstance(mask_vars, dict)
+            and block_id in mask_vars
+            and (mask_vars[block_id] is None)
+            and isinstance(static_bs, int)
+            and numel_int is not None
+            and static_bs >= numel_int
+        ):
+            # Single-trip tile loop whose block provably covers the extent
+            # (the strategy elided the bounds mask): every per-thread vec
+            # base is in-bounds and there is no next-iteration prefetch to
+            # clamp (the software-pipelining pass, which prefetches one
+            # tile PAST the loop end, needs the guard on multi-trip
+            # loops).  Dropping the pointer select saves ~14 registers per
+            # thread on the resident-row softmax family.
+            guarded_ptr = base_ptr_expr
+        else:
+            # Build the "anchor" pointer: same index_exprs but with the
+            # inner reduction-axis index forced to 0.  This is the
+            # ``tile_offset == 0, lane_var == 0, vec_lane_var == 0`` base
+            # for the very first outer-tile iter, which is always
+            # in-bounds for any grid block.
+            anchor_exprs = list(index_exprs)
+            anchor_exprs[lane_pos] = "0"
+            anchor_ptr_expr = _cute_scalar_pointer_expr(tensor_name, anchor_exprs)
+            guarded_ptr = (
+                f"({base_ptr_expr} if {base_index_var} < {numel_expr} "
+                f"else {anchor_ptr_expr})"
+            )
         hoist_stmt = statement_from_string(
             f"{hoist_var} = {_cute_unroll_vec_load_expr(guarded_ptr, tensor.dtype, vec_width)}"
         )
-        # Insert the hoist just BEFORE the constexpr V-loop (the last
-        # entry in lane_body).
-        lane_body.insert(len(lane_body) - 1, hoist_stmt)
+        # Insert the hoist just BEFORE the constexpr V-loop.
+        lane_body.insert(
+            _cute_lane_vloop_insert_pos(strategy, block_id, lane_body), hoist_stmt
+        )
     else:
         hoist_var, _ = cache[cache_key]
     return _cute_unroll_vec_extract(hoist_var, vec_lane_var, tensor.dtype)
-
-
-def _cute_register_tile_unroll_vec_hoist_split2(
-    state: CodegenState,
-    strategy: object,  # BlockSizeTileStrategy (PerThreadNDTileStrategy)
-    block_id: int,
-    tensor: torch.Tensor,
-    tensor_name: str,
-    index_exprs: list[str],
-    vec_width: int,
-) -> str:
-    """Split-2 variant of ``_cute_register_tile_unroll_vec_hoist`` for V=8
-    on fp16/bf16.
-
-    The CuTe DSL's ``nvvm.load.ext`` ICEs at V=8 for these dtypes, so the
-    full 16-byte LDG.128 is decomposed into TWO back-to-back V=4 loads
-    (lanes 0-3 and 4-7).  The SASS scheduler is free to overlap the two
-    LDGs, so the per-thread bytes-per-load grows from 8 (V=4) to the
-    full 16 (effective V=8) without invoking the DSL bug.
-
-    Returns a per-vec-lane expression of the form::
-
-        (
-            cutlass.Uint16(_tile_unroll_vec_ < n > _ < m > _a[vi]).bitcast(dtype)
-            if vi < 4
-            else cutlass.Uint16(_tile_unroll_vec_ < n > _ < m > _b[vi - 4]).bitcast(
-                dtype
-            )
-        )
-
-    Because ``vec_lane_var`` is the target of a ``cutlass.range_constexpr(8)``
-    loop, it is a Python-int constant at each unrolled iter, so the
-    ``if vi < 4`` branch folds away at trace time and the emitted SASS
-    contains only the active load's extract.
-    """
-    assert vec_width == 8, (
-        "tile_unroll_split2 expects V=8 (4+4); other widths use tile_unroll"
-    )
-    half = vec_width // 2
-    vec_elem_type = _cute_unroll_vec_elem_type(tensor.dtype)
-    base_var_by_block = getattr(strategy, "_cute_lane_base_index_var_by_block", {})
-    lane_body_by_block = getattr(strategy, "_cute_lane_body_by_block", {})
-    vec_lane_var_by_block = getattr(strategy, "_cute_vec_lane_var_by_block", {})
-    base_index_var = base_var_by_block.get(block_id)
-    lane_body = lane_body_by_block.get(block_id)
-    vec_lane_var = vec_lane_var_by_block.get(block_id)
-    assert isinstance(base_index_var, str)
-    assert isinstance(lane_body, list)
-    assert isinstance(vec_lane_var, str)
-    lane_pos = _cute_lane_axis_pos(strategy, block_id, index_exprs)
-    base_exprs = list(index_exprs)
-    base_exprs[lane_pos] = base_index_var
-    base_ptr_expr_a = _cute_scalar_pointer_expr(tensor_name, base_exprs)
-    # The second-half pointer points 4 elements past the first.  Build
-    # it by substituting ``base_index_var + half`` for the inner index.
-    base_exprs_b = list(index_exprs)
-    base_exprs_b[lane_pos] = f"({base_index_var} + {half})"
-    base_ptr_expr_b = _cute_scalar_pointer_expr(tensor_name, base_exprs_b)
-    cache_key = (tensor_name, base_ptr_expr_a, "split2")
-    cache_by_block = getattr(strategy, "_cute_lane_vec_loads_by_block", None)
-    if cache_by_block is None:
-        cache_by_block = {}
-        # pyrefly: ignore [missing-attribute]
-        strategy._cute_lane_vec_loads_by_block = cache_by_block
-    cache = cache_by_block.setdefault(block_id, {})
-    if cache_key not in cache:
-        slot = len(cache)
-        hoist_var_a = state.device_function.new_var(
-            f"_tile_unroll_vec_{block_id}_{slot}_a", dce=False
-        )
-        hoist_var_b = state.device_function.new_var(
-            f"_tile_unroll_vec_{block_id}_{slot}_b", dce=False
-        )
-        # Stash both names plus the split marker so this entry doesn't
-        # collide with the V=4 cache_key shape.  Downstream readers
-        # don't introspect this tuple — it's just a sentinel.
-        cache[cache_key] = ((hoist_var_a, hoist_var_b), tensor.dtype)
-        env_local = CompileEnvironment.current()
-        numel = env_local.block_sizes[block_id].numel
-        numel_expr = state.sympy_expr(numel)
-        anchor_exprs = list(index_exprs)
-        anchor_exprs[lane_pos] = "0"
-        anchor_ptr_expr = _cute_scalar_pointer_expr(tensor_name, anchor_exprs)
-        # The first-half OOB guard checks the same V-aligned base used by
-        # the V=4 path; the second-half pointer is ``base + 4`` and only
-        # needs guarding when ``base + 4 < numel``.  Reuse the same
-        # anchor pointer for both halves' fallbacks (the per-element
-        # mask gate downstream drops any anchor-fetched bytes anyway).
-        guarded_ptr_a = (
-            f"({base_ptr_expr_a} if {base_index_var} < {numel_expr} "
-            f"else {anchor_ptr_expr})"
-        )
-        guarded_ptr_b = (
-            f"({base_ptr_expr_b} if ({base_index_var} + {half}) < {numel_expr} "
-            f"else {anchor_ptr_expr})"
-        )
-        hoist_stmt_a = statement_from_string(
-            f"{hoist_var_a} = cute.arch.load({guarded_ptr_a}, "
-            f"ir.VectorType.get([{half}], {vec_elem_type}.mlir_type))"
-        )
-        hoist_stmt_b = statement_from_string(
-            f"{hoist_var_b} = cute.arch.load({guarded_ptr_b}, "
-            f"ir.VectorType.get([{half}], {vec_elem_type}.mlir_type))"
-        )
-        # Insert both hoists just BEFORE the constexpr V-loop (the last
-        # entry in lane_body).  Emit them back-to-back so the SASS
-        # scheduler can issue the two LDGs together.
-        lane_body.insert(len(lane_body) - 1, hoist_stmt_a)
-        lane_body.insert(len(lane_body) - 1, hoist_stmt_b)
-    else:
-        (hoist_var_a, hoist_var_b), _ = cache[cache_key]
-    extract_a = _cute_unroll_vec_extract(hoist_var_a, vec_lane_var, tensor.dtype)
-    extract_b = _cute_unroll_vec_extract(
-        hoist_var_b, f"{vec_lane_var} - {half}", tensor.dtype
-    )
-    return f"({extract_a} if {vec_lane_var} < {half} else {extract_b})"
 
 
 def _cute_combined_mask(

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -1359,7 +1359,12 @@ def _create_cute_wrapper(
     # occupancy and enables the reallocation (=1 avoids the smem-carveout path >1 would
     # trigger). NOT applied to ws_overlap (256-thread): forcing 1 CTA/SM there cuts its
     # 2-blocks/SM occupancy and regresses it ~4pp.
-    if any(plan.get("topology") == "fa4" for plan in wrapper_plans):
+    explicit_min_blocks = getattr(
+        cast("Any", cute_kernel), "_helion_cute_min_blocks_per_mp", None
+    )
+    if isinstance(explicit_min_blocks, int) and explicit_min_blocks > 0:
+        launch_suffix += f", min_blocks_per_mp={explicit_min_blocks}"
+    elif any(plan.get("topology") == "fa4" for plan in wrapper_plans):
         launch_suffix += ", min_blocks_per_mp=1"
     body.extend(
         (

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -11264,7 +11264,15 @@ class TestCuteAutotuner(TestCase):
         # Triton-style knobs that the CuTe path does not consume.
         self.assertEqual(
             flat_keys,
-            {"block_sizes", "num_threads", "loop_orders", "cute_vector_widths"},
+            {
+                "block_sizes",
+                "num_threads",
+                "loop_orders",
+                "cute_vector_widths",
+                "cute_lane_layouts",
+                "cute_cluster_n",
+                "cute_min_blocks_per_mp",
+            },
         )
 
         repaired = gen.unflatten(
@@ -11278,7 +11286,15 @@ class TestCuteAutotuner(TestCase):
         for config in configs:
             self.assertLessEqual(
                 set(config.config),
-                {"block_sizes", "num_threads", "loop_orders", "cute_vector_widths"},
+                {
+                    "block_sizes",
+                    "num_threads",
+                    "loop_orders",
+                    "cute_vector_widths",
+                    "cute_lane_layouts",
+                    "cute_cluster_n",
+                    "cute_min_blocks_per_mp",
+                },
             )
             self.assertNotIn("persistent", config.pid_type)
             explicit_threads = [nt for nt in config.num_threads if nt > 0]
@@ -11948,6 +11964,7 @@ class TestCuteAutotuner(TestCase):
             long_gen.encode_config(flat)
             expected = dict(config.config)
             expected.pop("cute_vector_widths", None)
+            expected.pop("cute_lane_layouts", None)
             self.assertEqual(long_gen.unflatten(flat).config, expected)
 
         random_configs = [long_gen.random_config() for _ in range(24)]

--- a/test/test_cute_online_to_3pass.py
+++ b/test/test_cute_online_to_3pass.py
@@ -3,8 +3,9 @@
 The CuTe backend pre-processes the user's AST before tracing.  When
 the body matches the canonical two-loop online softmax pattern
 (a running ``mi``/``di`` update sweep followed by a normalize sweep)
-AND the reduction-axis extent is at or above the cutoff (default 2048),
-the pass rewrites the body into THREE inner ``for tile_n`` loops:
+AND the reduction-axis extent is at or above the cutoff (default 0 —
+always rewrite; override via ``HELION_ONLINE_TO_3PASS_MIN_N``), the pass
+rewrites the body into THREE inner ``for tile_n`` loops:
 
   1. max-only sweep
   2. sum-only sweep
@@ -119,12 +120,15 @@ class TestCuteOnlineTo3PassRewrite(TestCase):
         # 3 inner sweeps now (was 2 in the original online form).
         self.assertEqual(self._generated_loop_count(code), 3)
 
-    def test_shape_gate_skips_small_n(self) -> None:
-        """For (4096, 256) the rewrite MUST be skipped by the
-        reduction-axis-extent gate (256 < default cutoff 2048), so the
-        generated kernel still has TWO inner sweeps (the original
-        online form).
+    def test_shape_gate_env_override_skips_small_n(self) -> None:
+        """With ``HELION_ONLINE_TO_3PASS_MIN_N=2048``, (4096, 256) MUST
+        be skipped by the reduction-axis-extent gate, so the generated
+        kernel still has TWO inner sweeps (the original online form).
+        (The default cutoff is 0 — always rewrite — since the
+        lane-reduce collapse made the 3-pass form win at every measured
+        extent.)
         """
+        self._set_env("HELION_ONLINE_TO_3PASS_MIN_N", "2048")
         x = torch.randn(4096, 256, device=DEVICE, dtype=HALF_DTYPE)
         code, out = code_and_output(
             _online_two_pass_kernel,

--- a/test/test_cute_softmax_perf.py
+++ b/test/test_cute_softmax_perf.py
@@ -163,13 +163,11 @@ class TestCuteSoftmaxVecHoist(TestCase):
         # And the per-V-lane extract is a bitcast back to Float16.
         self.assertIn("bitcast(cutlass.Float16)", code)
 
-    def test_vec_hoist_v8_uses_4plus4_split(self) -> None:
-        """V=8 fp16/bf16 cannot use a single ``cute.arch.load`` (the CuTe
-        DSL's ``nvvm.load.ext`` ICEs at V=8), so the codegen lowers it as
-        TWO back-to-back ``cute.arch.load(..., V=4)`` calls (covering vec
-        lanes 0-3 and 4-7).  The SASS scheduler is free to overlap the
-        two LDGs, so per-thread bytes-per-load still hit the full
-        LDG.128 (16 bytes) without invoking the DSL bug.
+    def test_vec_hoist_v8_single_load(self) -> None:
+        """V=8 fp16/bf16 emits ONE ``cute.arch.load(..., V=8)`` (LDG.128)
+        per outer-lane iter.  (Older CuTe DSL builds ICE'd on V=8
+        ``nvvm.load.ext`` and needed a 4+4 split; that bug is fixed in
+        cutlass 4.7.)
         """
         x = torch.randn(4096, 8192, device=DEVICE, dtype=HALF_DTYPE)
         code, out = code_and_output(
@@ -181,32 +179,12 @@ class TestCuteSoftmaxVecHoist(TestCase):
         )
         ref = torch.nn.functional.softmax(x, dim=1)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # The single-V=8 load form is still NOT emitted (would ICE).
-        self.assertNotIn("ir.VectorType.get([8]", code)
-        # The split-2 path emits TWO V=4 vec loads per outer-lane iter
-        # with the ``_a`` / ``_b`` suffix on the hoist var names.  When
-        # the P18 load-pipeline pass fires, the ``_a`` load assignment
-        # text gets rewritten to ``_tile_unroll_vec_1_0_a = _pipe_load_*``
-        # with the actual ``cute.arch.load`` hoisted into the prologue
-        # and an explicit per-iter prefetch; the ``_b`` load is left as
-        # an inline ``cute.arch.load`` call (it's not the first inner
-        # load).  Accept either form.
-        self.assertTrue(
-            "_tile_unroll_vec_1_0_a = cute.arch.load(" in code
-            or "_tile_unroll_vec_1_0_a = _pipe_load_" in code,
-            "expected _a hoist var either as inline load or pipeline snapshot",
-        )
-        self.assertIn("_tile_unroll_vec_1_0_b = cute.arch.load(", code)
-        # Both halves use V=4.
-        self.assertGreaterEqual(
-            code.count("ir.VectorType.get([4], cutlass.Uint16.mlir_type)"),
-            2,
-        )
-        # The constexpr V-loop now runs 8 iters (not 4).
+        self.assertIn("ir.VectorType.get([8], cutlass.Uint16.mlir_type)", code)
+        # No 4+4 split vars.
+        self.assertNotIn("_tile_unroll_vec_1_0_a", code)
+        self.assertNotIn("_tile_unroll_vec_1_0_b", code)
+        # The constexpr V-loop runs 8 iters.
         self.assertIn("cutlass.range_constexpr(8)", code)
-        # The per-vec-lane extract uses the if-else split selector so the
-        # constexpr loop unroller picks the right half per iter.
-        self.assertIn("if vec_lane_1 < 4 else", code)
 
     def test_vec_hoist_bf16(self) -> None:
         """The vec hoist must also fire for bf16 (also a uint16-backed type)."""
@@ -1022,13 +1000,12 @@ class TestCuteMultiRowInvestigation(TestCase):
         # Warp reduce, no shared-mem reduction.
         self.assertIn("cute.arch.warp_reduction_max", code)
         self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
-        # The two-pass fuser must fire here so the consume sweep
-        # reads x from a register cache (only one ``cute.arch.load``).
-        # For (4096, 128) with block_size 128, trip = 1 → fuser bails;
-        # but the larger N=256 path with block_size=128 has trip=2
-        # which fires the fuser.  Document the trip-1 case here so the
-        # fuser path stays explicit.
-        self.assertEqual(code.count("cute.arch.load("), 2)
+        # The two-pass fuser fires (trip=1 is the most profitable case:
+        # the cache index folds to a constant so the fragment stays in
+        # registers) — the consume sweep reads x from the register cache
+        # and only ONE ``cute.arch.load`` of x remains.
+        self.assertEqual(code.count("cute.arch.load("), 1)
+        self.assertIn("cute.make_rmem_tensor", code)
 
 
 # A second, separately-decorated kernel so the P21 tests below can
@@ -1135,12 +1112,13 @@ class TestCuteOnlineTo3PassRewrite(TestCase):
         # 3 inner sweeps now (was 2 in the original online form).
         self.assertEqual(self._generated_loop_count(code), 3)
 
-    def test_shape_gate_skips_small_n(self) -> None:
-        """For (4096, 256) the rewrite MUST be skipped by the
-        reduction-axis-extent gate (256 < default cutoff 2048), so the
-        generated kernel still has TWO inner sweeps (the original
-        online form).
+    def test_shape_gate_env_override_skips_small_n(self) -> None:
+        """With ``HELION_ONLINE_TO_3PASS_MIN_N=2048``, (4096, 256) MUST be
+        skipped by the reduction-axis-extent gate, so the generated kernel
+        still has TWO inner sweeps (the original online form).  (The
+        default cutoff is 0 — always rewrite.)
         """
+        self._set_env("HELION_ONLINE_TO_3PASS_MIN_N", "2048")
         x = torch.randn(4096, 256, device=DEVICE, dtype=HALF_DTYPE)
         code, out = code_and_output(
             softmax_two_pass_kernel_for_3pass,

--- a/test/test_cute_tile_loop_vec_hoist.py
+++ b/test/test_cute_tile_loop_vec_hoist.py
@@ -6,15 +6,15 @@ reads per-lane scalars via bitcast extracts from the hoist var. This
 replaces V scalar fp16 loads with one V*2-byte vec load per thread per
 outer iter.
 
-The hoist is gated to V<=4 for fp16/bf16 (the CuTe DSL's
-``nvvm.load.ext`` ICEs at V=8); V=8 falls back to a 2x V=4 split with
-``_a`` / ``_b`` suffixed hoist vars covering vec lanes 0-3 and 4-7.
+V=8 emits a single 16-byte load (LDG.128).  Stores through the same
+vec-partitioned lane axis are collected per V-loop and flushed as one
+``_cute_store_u16_vec`` vector store (ST.64/ST.128) after the loop.
 
 Lives in ``helion/_compiler/tile_strategy.py``
 (``PerThreadNDTileStrategy._cute_*_by_block`` hooks) and
-``helion/language/memory_ops.py`` (``_cute_register_tile_unroll_vec_hoist``
-and ``_cute_vector_load_ctx`` ``"tile_unroll"`` / ``"tile_unroll_split2"``
-modes).
+``helion/language/memory_ops.py`` (``_cute_register_tile_unroll_vec_hoist``,
+``_cute_register_tile_unroll_vec_store`` and ``_cute_vector_load_ctx``'s
+``"tile_unroll"`` mode).
 """
 
 from __future__ import annotations
@@ -152,11 +152,11 @@ class TestCuteTileLoopVecHoist(TestCase):
         # And the per-V-lane extract is a bitcast back to Float16.
         self.assertIn("bitcast(cutlass.Float16)", code)
 
-    def test_vec_hoist_v8_uses_4plus4_split(self) -> None:
-        """V=8 fp16/bf16 cannot use a single ``cute.arch.load`` (the CuTe
-        DSL's ``nvvm.load.ext`` ICEs at V=8), so the codegen lowers it as
-        TWO back-to-back ``cute.arch.load(..., V=4)`` calls (covering vec
-        lanes 0-3 and 4-7).
+    def test_vec_hoist_v8_single_load(self) -> None:
+        """V=8 fp16/bf16 emits ONE ``cute.arch.load(..., V=8)`` (LDG.128)
+        per outer-lane iter.  (Older CuTe DSL builds ICE'd on V=8
+        ``nvvm.load.ext`` and needed a 4+4 split; that bug is fixed in
+        cutlass 4.7.)
         """
         x = torch.randn(4096, 8192, device=DEVICE, dtype=HALF_DTYPE)
         code, out = code_and_output(
@@ -168,30 +168,12 @@ class TestCuteTileLoopVecHoist(TestCase):
         )
         ref = torch.nn.functional.softmax(x, dim=1)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # The single-V=8 load form is still NOT emitted (would ICE).
-        self.assertNotIn("ir.VectorType.get([8]", code)
-        # The split-2 path emits TWO V=4 vec loads per outer-lane iter
-        # with the ``_a`` / ``_b`` suffix on the hoist var names.  When
-        # the load-pipeline pass fires, the ``_a`` load assignment text
-        # gets rewritten to ``_tile_unroll_vec_1_0_a = _pipe_load_*``
-        # with the actual ``cute.arch.load`` hoisted into the prologue;
-        # the ``_b`` load is left as an inline ``cute.arch.load`` call.
-        self.assertTrue(
-            "_tile_unroll_vec_1_0_a = cute.arch.load(" in code
-            or "_tile_unroll_vec_1_0_a = _pipe_load_" in code,
-            "expected _a hoist var either as inline load or pipeline snapshot",
-        )
-        self.assertIn("_tile_unroll_vec_1_0_b = cute.arch.load(", code)
-        # Both halves use V=4.
-        self.assertGreaterEqual(
-            code.count("ir.VectorType.get([4], cutlass.Uint16.mlir_type)"),
-            2,
-        )
-        # The constexpr V-loop now runs 8 iters (not 4).
+        self.assertIn("ir.VectorType.get([8], cutlass.Uint16.mlir_type)", code)
+        # No 4+4 split vars.
+        self.assertNotIn("_tile_unroll_vec_1_0_a", code)
+        self.assertNotIn("_tile_unroll_vec_1_0_b", code)
+        # The constexpr V-loop runs 8 iters.
         self.assertIn("cutlass.range_constexpr(8)", code)
-        # The per-vec-lane extract uses the if-else split selector so the
-        # constexpr loop unroller picks the right half per iter.
-        self.assertIn("if vec_lane_1 < 4 else", code)
 
     def test_vec_hoist_bf16(self) -> None:
         """The vec hoist must also fire for bf16 (also a uint16-backed type)."""
@@ -358,3 +340,39 @@ class TestCuteTileLoopVecHoist(TestCase):
         ref = torch.nn.functional.softmax(x, dim=1)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
         self.assertNotIn("_tile_unroll_vec_", code)
+
+    def test_vec_store_flush_after_vloop(self) -> None:
+        """Stores through a vec-partitioned lane axis are collected into a
+        compile-time list inside the constexpr V-loop and flushed as ONE
+        ``_cute_store_u16_vec`` vector store after the loop (ST.64/ST.128
+        instead of V scalar 2-byte stores).
+        """
+        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        self.assertIn("_tile_store_vals_1_0 = []", code)
+        self.assertIn("_tile_store_vals_1_0.append(", code)
+        self.assertIn("_cute_store_u16_vec(", code)
+        # No scalar per-element store of the output remains.
+        self.assertNotIn(").store(cutlass.", code)
+
+    def test_scalar_store_when_vec_width_is_one(self) -> None:
+        """When V=1 the vec store must NOT fire — scalar stores remain."""
+        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 1],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        self.assertNotIn("_cute_store_u16_vec(", code)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3515
 * #3514
 * #3513
 * #3512
 * #3511
 * #3510
 * #3509
 * #3498
 * #3497
 * __->__#3496
 * #3495
 * #3494


--- --- ---

[cutedsl] Register-resident SIMT row reductions: vec stores, strided lanes, one reduce per sweep, thread-block clusters

General codegen + autotuner improvements for SIMT reduction kernels on
the CuTe backend, developed against examples/softmax.py::softmax_two_pass
bf16 rows on B200 (cold-autotuned 1.6x-3.8x over the previous backend
state across (32768..8192) x (1024..262144); ties or beats the
hand-written Quack CuTe softmax on 1024/16384 and lands within 3-8%
elsewhere).  All measured effects below are forced-config A/B runs in
separate processes on one GPU.

Memory access:
- Vectorized stores: a store through a vec-partitioned lane axis collects
  its per-lane values into a compile-time list inside the constexpr
  V-loop and flushes ONE _cute_store_u16_vec (ST.64/ST.128,
  vector.from_elements) after it, replacing V scalar 2-byte stores
  (helion/_compiler/cute/vec_utils.py).  Same predicates as the vec-load
  hoist (numel % V == 0, no extra mask), so the flush can reuse the
  scalar mask uniformly.  Scalar 2B stores were the single largest defect
  (1492 -> 3953 GB/s on a hand-written probe kernel).
- Single V=8 vector loads: the nvvm.load.ext V=8 ICE that forced the
  2x V=4 split is fixed in cutlass 4.7; emit one LDG.128 and delete the
  split2 machinery.  Also lift the V<=4 cap on the looped-reduction
  unroll path and seed V=8 for 16-bit dtypes.
- cute_lane_layouts per-block knob ("blocked" | "strided"): strided
  assigns each thread V-wide chunks strided by the worker count so every
  warp access is fully coalesced (1639 -> 2933 GB/s on the whole-row
  config).  Default stays "blocked" (bit-compatible); autotuned.
- Guard elision for hoisted vec loads on single-trip whole-extent tiles:
  the OOB pointer select kept a second address live (94 -> 80 regs/thread
  measured); provably in-bounds there.  Multi-trip loops keep the guard —
  the software-pipelining pass prefetches one tile past the loop end.
- Mask elision: force_tile_mask() now False for cute; per-axis masks are
  emitted only when the extent is not a known multiple of the block size
  (same rule as Triton).  hoist_warp_reduce's dtype inference now
  requires a bare dtype constructor so unmasked bitcast extracts don't
  parse as cast wrappers, and the fuser infers unmasked scalar load cache
  dtypes from their first consumer cast.

Reductions:
- hoist_warp_reduce extensions: grouped shared-memory reductions
  (_cute_grouped_reduce_*) hoist out of constexpr V-loops like plain warp
  reductions (identity argument rewritten to the fp32 accumulator dtype),
  and a second collapse stage folds the per-lane-iteration accumulator
  across the whole static lane loop, running the reduce + pure carry
  update (mi = max(mi, r) / di = di + r) ONCE per sweep — this removes
  L-1 two-barrier block reductions per sweep (2702 -> 4539 GB/s with
  fusion).  Sees through pre-rename loop-carried aliases via the
  device function's rename map.
- fp max/min V-lane folds combine with cute.arch.fmax/fmin (one FMNMX)
  instead of Python max/min (compare + select): +12% on the resident-row
  softmax.  NaN semantics match quack's row_reduce.
- fuse_two_pass_loads: fuse ALL subsequent sweeps of a loop group (the
  3-pass softmax re-loads x in two later sweeps) and allow single-trip
  outer loops with the cache index folded to a constant so the fragment
  stays register-resident (one gmem read for the whole kernel; fusion is
  worth +38% once the collapse is in).
- online_to_3pass default MIN_N 2048 -> 0: with the collapse the 3-pass
  form wins at every measured extent (+10% at N=1024 on both config
  families).  HELION_ONLINE_TO_3PASS_MIN_N still overrides.

Thread-block clusters (large rows):
- cute_cluster_n knob: a whole-extent lane-looped axis splits into
  contiguous per-CTA slices across a (1, cluster_n, 1) cluster; each CTA
  keeps its slice register-resident and the reduction combines within-CTA
  warps and across the cluster in one DSM exchange (st.async remote SMEM
  stores + mbarrier tx-count) per sweep via _cute_grouped_reduce_cluster.
  Receive buffers/mbarriers are allocated per call site in the kernel
  preamble with a single mbarrier_init_fence + cluster arrive/wait
  covering all sites.  The launcher reads _helion_cute_cluster_shape off
  the kernel; the host emits the extra grid dim (1-D grids only).
  Applied only when the tile covers the extent (single trip => each
  single-phase mbarrier site runs exactly once), no sibling axis in the
  loop uses threads, and — decided lazily at codegen_device_loop so the
  grid state is visible — the grid strategy has no non-trivial thread
  axes (a multi-row grid tile would otherwise be silently folded into
  one row's reduction).  Every reduce path that cannot perform the
  cluster combine (warp-only, shared-tree, interleaved/multi-group
  two-stage, two-pass marker) raises BackendUnsupported, and a final
  placement check rejects configs that leave a cluster-reduce call
  inside a multi-trip loop (the single-phase mbarrier would deadlock —
  observed as an unkillable benchmark worker during autotuning).
- cute_min_blocks_per_mp knob (ptxas minnctapersm via the launch's
  min_blocks_per_mp): caps registers to keep N CTAs resident; +9-27%
  at cluster 4-16 where the resident-row register footprint drops
  occupancy to 2 CTAs/SM.

Autotuner:
- New seed heuristics: CuteResidentRowHeuristic (whole-row resident;
  prefers 256-thread CTAs and the smallest cluster giving <= 64 elems
  per thread; min_blocks_per_mp=3 from cluster 4 up) and
  CuteResidentMultiRowHeuristic (short rows, 4 rows/CTA, warp-per-row).
- Full cold-autotune runs find the resident/cluster families on their
  own for all eight benchmark shapes.

Review hardening (subagent review of the initial version of this
commit): the lane-loop collapse now also bails when anything inside the
loop reads the carry update's result or when the reduce result has extra
consumers (both would read stale values post-rename); the cluster
placement validator counts constexpr-unrolled loops by their unroll
factor (each unrolled iteration re-executes the same preamble mbarrier);
the two-pass marker finalize rejects cluster configs outright (it has no
buffer/mbarrier plumbing); only one device loop per kernel may claim the
cluster rank; unmasked scalar loads fuse using the base tensor's own
dtype (a first-consumer-cast guess could round int64 index loads through
an fp32 cache); and multiple vec-store flushes keep source order.