### PR TITLE
[cutedsl] Cluster online-pair reduce: one packed DSM exchange per softmax row; exp2 fastmath under the fast_math setting

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -10,6 +10,7 @@ from .cute import CuteReductionTileHeuristic
 from .cute import CuteReductionWideChunkHeuristic
 from .cute import CuteResidentMultiRowHeuristic
 from .cute import CuteResidentRowHeuristic
+from .cute import CuteResidentRowWideClusterHeuristic
 from .cute import CuteTcgen05ClusterM2FfiHeuristic
 from .cute import CuteTcgen05ClusterM2Heuristic
 from .cute import CuteTcgen05GroupedDynamicBk64Heuristic
@@ -60,6 +61,7 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteTileVecWarpReduceHeuristic,
         CuteTileVecWarpPerRowHeuristic,
         CuteResidentRowHeuristic,
+        CuteResidentRowWideClusterHeuristic,
         CuteResidentMultiRowHeuristic,
     ),
     "triton": (

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -452,6 +452,75 @@ class CuteResidentRowHeuristic(AutotunerHeuristic):
             return None
 
 
+class CuteResidentRowWideClusterHeuristic(AutotunerHeuristic):
+    """128-thread wide-cluster variant of ``CuteResidentRowHeuristic``.
+
+    With the cluster online-pair rewrite (one packed DSM exchange per row
+    instead of two) wide clusters of small CTAs win big rows: the measured
+    winners moved from 256-thread CTAs with the narrowest fitting cluster
+    to 128-thread CTAs with cluster_n 8..16 (e.g. 65536: T128/CL8 4761
+    vs T256/CL4 4536 GB/s on B200).  Seed that family too so the search
+    starts in both basins; per-thread footprints up to 128 elements are
+    allowed (the register-capped family) and get ``min_blocks_per_mp=3``.
+    """
+
+    name = "cute_resident_row_wide_cluster"
+    backend = "cute"
+
+    _THREADS = 128
+
+    @classmethod
+    def _plan(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> tuple[int, int, int, int] | None:
+        base = CuteResidentRowHeuristic._plan(env, device_ir)
+        if base is None:
+            return None
+        n, _threads, vec, _cluster_n = base
+        threads = cls._THREADS
+        for max_per_thread in (64, 128):
+            for cluster_n in (2, 4, 8, 16):
+                per_cta = n // cluster_n
+                if (
+                    per_cta % (threads * vec) == 0
+                    and per_cta // threads <= max_per_thread
+                ):
+                    return n, threads, vec, cluster_n
+        return None
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return cls._plan(env, device_ir) is not None
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        plan = cls._plan(env, device_ir)
+        if plan is None:
+            return None
+        n, threads, vec, cluster_n = plan
+        seed: dict[str, Any] = {
+            "block_sizes": [1, n],
+            "num_threads": [0, threads],
+            "cute_vector_widths": [1, vec],
+            "cute_lane_layouts": ["blocked", "strided"],
+            "cute_cluster_n": cluster_n,
+        }
+        if n // cluster_n // threads > 64:
+            # 128 elements/thread: the exp/load caches alone need ~128
+            # registers, so cap the budget for 3 CTAs/SM.
+            seed["cute_min_blocks_per_mp"] = 3
+        else:
+            # 64/thread: launch bounds for >=2 CTAs nudge ptxas off its
+            # 128-register plateau (T128/CL8 65536: 4761 vs 4623 GB/s).
+            seed["cute_min_blocks_per_mp"] = 2
+        try:
+            return Config(**seed)
+        except Exception:
+            return None
+
+
 class CuteResidentMultiRowHeuristic(AutotunerHeuristic):
     """Multi-row variant of ``CuteResidentRowHeuristic`` for short rows.
 

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -1155,6 +1155,8 @@ class CuteBackend(Backend):
             "_cute_grouped_reduce_shared_two_stage": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_shared_two_stage",
             "_cute_grouped_reduce_warp": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_warp",
             "_cute_grouped_reduce_cluster": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_cluster",
+            "_cute_grouped_reduce_block": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_block",
+            "_cute_grouped_reduce_cluster_online_pair": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_cluster_online_pair",
             "_cute_pre_vec_fold": "from helion._compiler.cute.reduce_helpers import _cute_pre_vec_fold",
             "_cute_store_shared_remote_x4": "from helion._compiler.cute.cluster_helpers import store_shared_remote_x4 as _cute_store_shared_remote_x4",
             "_cute_issue_clc_query_nomulticast": "from helion._compiler.cute.clc_helpers import issue_clc_query_nomulticast as _cute_issue_clc_query_nomulticast",

--- a/helion/_compiler/cute/cluster_helpers.py
+++ b/helion/_compiler/cute/cluster_helpers.py
@@ -117,3 +117,39 @@ def store_shared_remote_f32(
         has_side_effects=True,
         is_align_stack=False,
     )
+
+
+@dsl_user_op
+def store_shared_remote_f32x2(
+    val0: Float32,
+    val1: Float32,
+    smem_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    peer_cta_rank_in_cluster: Int32,
+    *,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> None:
+    """Store an (f32, f32) pair into another CTA's SMEM and complete the
+    mbarrier tx.  ``smem_ptr`` must be 8-byte aligned (allocate the receive
+    buffer as ``Int64`` slots)."""
+
+    remote_smem_ptr_i32 = _set_block_rank(
+        smem_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    remote_mbar_ptr_i32 = _set_block_rank(
+        mbar_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    llvm.inline_asm(
+        None,
+        [
+            remote_smem_ptr_i32,
+            Float32(val0).ir_value(loc=loc, ip=ip),
+            Float32(val1).ir_value(loc=loc, ip=ip),
+            remote_mbar_ptr_i32,
+        ],
+        "st.async.shared::cluster.mbarrier::complete_tx::bytes.v2.f32 [$0], {$1, $2}, [$3];",
+        "r,f,f,r",
+        has_side_effects=True,
+        is_align_stack=False,
+    )

--- a/helion/_compiler/cute/cluster_online_pair.py
+++ b/helion/_compiler/cute/cluster_online_pair.py
@@ -1,0 +1,783 @@
+# pyrefly: ignore-errors
+"""Fuse the two DSM cluster exchanges of an online-softmax reduction pair
+into ONE packed ``(max, sum)`` exchange.
+
+After the lane-reduce collapse, a cluster-split online-softmax row does:
+
+    sweep A:  acc0 = fold(max, x)      ; m  = _cute_grouped_reduce_cluster(acc0, 'max', ...)
+    sweep B:  acc1 = fold(+, exp2(f(x) - m*C)) ; s = _cute_grouped_reduce_cluster(acc1, 'sum', ...)
+    sweep C:  out  = exp2(f(x) - m*C) * g(s)
+
+i.e. TWO cluster-wide mbarrier round-trips per row, and sweep B stalls on
+the cross-cluster max before it can start.  Quack's hand kernel does the
+standard online-softmax combine instead: each CTA reduces its slice
+locally, exchanges the ``(local_max, local_sum)`` pair ONCE, and folds
+with the rescale ``s += s_r * exp2((m_r - m) * C)``.  On a B200 this is
+worth +5..9% at cluster_n 2..16 (one fewer cluster round-trip, and a
+``cluster_n``-slot fold instead of ``warps * cluster_n``).
+
+This pass rewrites the emitted AST into that shape when it can prove the
+pattern:
+
+  * site A becomes a CTA-local block reduce (``_cute_grouped_reduce_block``),
+    so ``m`` holds the CTA-slice max and sweep B starts without waiting on
+    the cluster,
+  * sweep B's ``exp2`` values are cached in a new register fragment (they
+    are exact partial results of sweep C: ``out_i = e_i * exp2(m_local*C -
+    m_global*C) * g(s)``, softmax being shift-invariant),
+  * site B becomes ``_cute_grouped_reduce_cluster_online_pair`` which
+    block-reduces the local sum, exchanges the packed pair once, folds
+    with the rescale, and returns the GLOBAL ``(max, sum)``; the max
+    variable is reassigned so every later read sees the global value,
+  * sweep C's ``exp2`` recompute is replaced by the cached value times the
+    (CTA-uniform) rescale factor.
+
+Every rewrite condition fails closed: if any structural check does not
+match, the kernel keeps the two-exchange form.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import dataclasses
+from typing import Callable
+
+_CLUSTER_REDUCE = "_cute_grouped_reduce_cluster"
+_BLOCK_REDUCE = "_cute_grouped_reduce_block"
+_PAIR_REDUCE = "_cute_grouped_reduce_cluster_online_pair"
+
+# Module aliases / builtins that appear as Name loads in emitted code but
+# are not kernel-local values.
+_IGNORED_NAMES = frozenset(
+    {
+        "cutlass",
+        "cute",
+        "ir",
+        "math",
+        "mlir_math",
+        "operator",
+        "torch",
+        "hl",
+        "helion",
+        "float",
+        "int",
+        "bool",
+        "min",
+        "max",
+        "range",
+    }
+)
+
+
+def _local_loads(node: ast.AST) -> list[str]:
+    return [
+        n
+        for n in _loads(node)
+        if n not in _IGNORED_NAMES and not n.startswith("_cute_")
+    ]
+
+
+def _stmt(src: str) -> ast.stmt:
+    return ast.parse(src).body[0]
+
+
+def _reparse_expr(node: ast.expr) -> ast.expr:
+    """Plain-ast copy of an expression (``copy.deepcopy`` fails on the
+    ExtendedAST nodes the emitter produces)."""
+    return ast.parse(ast.unparse(node), mode="eval").body
+
+
+def _is_name_assign(stmt: ast.stmt) -> bool:
+    return (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+    )
+
+
+def _loads(node: ast.AST) -> list[str]:
+    return [
+        n.id
+        for n in ast.walk(node)
+        if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+    ]
+
+
+def _int_kw(call: ast.Call, name: str) -> int | None:
+    for kw in call.keywords:
+        if kw.arg == name and isinstance(kw.value, ast.Constant):
+            value = kw.value.value
+            if isinstance(value, int):
+                return value
+    return None
+
+
+class _Site:
+    def __init__(
+        self,
+        top_idx: int,
+        stmt_idx: int,
+        for_node: ast.For,
+        assign: ast.Assign,
+        call: ast.Call,
+    ) -> None:
+        self.top_idx = top_idx
+        self.stmt_idx = stmt_idx
+        self.for_node = for_node
+        self.assign = assign
+        self.call = call
+        self.target: str = assign.targets[0].id  # type: ignore[attr-defined]
+        self.op: str = call.args[1].value  # type: ignore[attr-defined]
+        self.buf_name: str = call.args[4].id  # type: ignore[attr-defined]
+        self.mbar_name: str = call.args[5].id  # type: ignore[attr-defined]
+        self.group_span = _int_kw(call, "group_span")
+        self.cluster_n = _int_kw(call, "cluster_n")
+
+
+def _find_sites(body: list[ast.stmt]) -> list[_Site] | None:
+    """All ``_cute_grouped_reduce_cluster`` sites, in order.  Returns None
+    when any site does not have the exact shape the rewrite understands
+    (a single-Name-target Assign directly inside a top-level For)."""
+    sites: list[_Site] = []
+    seen = 0
+    for i, top in enumerate(body):
+        for node in ast.walk(top):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == _CLUSTER_REDUCE
+            ):
+                seen += 1
+        if not isinstance(top, ast.For):
+            continue
+        for j, inner in enumerate(top.body):
+            if not (_is_name_assign(inner) and isinstance(inner.value, ast.Call)):
+                continue
+            call = inner.value
+            if not (
+                isinstance(call.func, ast.Name) and call.func.id == _CLUSTER_REDUCE
+            ):
+                continue
+            if (
+                len(call.args) != 6
+                or not isinstance(call.args[1], ast.Constant)
+                or not isinstance(call.args[4], ast.Name)
+                or not isinstance(call.args[5], ast.Name)
+            ):
+                return None
+            sites.append(_Site(i, j, top, inner, call))
+    if seen != len(sites):
+        return None
+    return sites
+
+
+class _Inliner(ast.NodeTransformer):
+    """Substitute vec-body local single-assignment names into an expression
+    (bounded depth, load context only)."""
+
+    def __init__(self, defs: dict[str, ast.expr], depth: int = 0) -> None:
+        self.defs = defs
+        self.depth = depth
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if isinstance(node.ctx, ast.Load) and node.id in self.defs and self.depth < 10:
+            replacement = _reparse_expr(self.defs[node.id])
+            return _Inliner(self.defs, self.depth + 1).visit(replacement)
+        return node
+
+
+def _inline_locals(expr: ast.expr, block: list[ast.stmt], upto: ast.stmt) -> ast.expr:
+    defs: dict[str, ast.expr] = {}
+    for stmt in block:
+        if stmt is upto:
+            break
+        if _is_name_assign(stmt):
+            name = stmt.targets[0].id  # type: ignore[attr-defined]
+            if name not in _loads(stmt.value):
+                defs[name] = stmt.value
+    inlined = _Inliner(defs).visit(_reparse_expr(expr))
+    ast.fix_missing_locations(inlined)
+    return inlined
+
+
+def _canonical_src(expr: ast.expr, rename: dict[str, str]) -> str:
+    node = _reparse_expr(expr)
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name) and sub.id in rename:
+            sub.id = rename[sub.id]
+    return ast.unparse(node)
+
+
+def _is_exp2(call: ast.AST) -> bool:
+    return (
+        isinstance(call, ast.Call)
+        and len(call.args) == 1
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == "exp2"
+        and isinstance(call.func.value, ast.Attribute)
+        and call.func.value.attr == "math"
+        and isinstance(call.func.value.value, ast.Name)
+        and call.func.value.value.id == "cute"
+    )
+
+
+def _is_pure(expr: ast.AST) -> bool:
+    for node in ast.walk(expr):
+        if isinstance(
+            node,
+            (
+                ast.Name,
+                ast.Constant,
+                ast.Load,
+                ast.BinOp,
+                ast.UnaryOp,
+                ast.Subscript,
+                ast.Attribute,
+                ast.Tuple,
+                ast.operator,
+                ast.unaryop,
+                ast.expr_context,
+            ),
+        ):
+            continue
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr == "bitcast":
+                continue
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                if func.value.id in ("cutlass", "cute"):
+                    continue
+            if isinstance(func, ast.Name):
+                continue
+            return False
+        if isinstance(node, ast.keyword):
+            continue
+        return False
+    return True
+
+
+def _prune_dead_assigns(block: list[ast.stmt], external_readers: list[ast.AST]) -> None:
+    """Remove pure single-Name assignments in ``block`` whose target is
+    never loaded again (in the block or by any of ``external_readers``)."""
+    changed = True
+    while changed:
+        changed = False
+        for idx in range(len(block) - 1, -1, -1):
+            stmt = block[idx]
+            if not (_is_name_assign(stmt) and _is_pure(stmt.value)):
+                continue
+            name = stmt.targets[0].id  # type: ignore[attr-defined]
+            read = False
+            for other in block:
+                node = other.value if other is stmt else other
+                if name in _loads(node):
+                    read = True
+                    break
+            if not read:
+                for reader in external_readers:
+                    if name in _loads(reader):
+                        read = True
+                        break
+            if not read:
+                del block[idx]
+                changed = True
+
+
+@dataclasses.dataclass
+class _VecExpMatch:
+    vec_for: ast.For
+    exp_stmt: ast.stmt
+    exp_call: ast.Call
+    scaled_name: str
+    slot: ast.expr
+    canonical: str
+
+
+def _find_vec_exp(
+    root: ast.stmt,
+    stop_at: ast.stmt | None,
+    scaled_names: set[str],
+    cache_names: set[str],
+) -> _VecExpMatch | None:
+    """Find the (unique) constexpr vec loop under ``root`` (searching
+    statements before ``stop_at`` only) whose body computes
+    ``cute.math.exp2(<expr> - <scaled>)`` reading exactly one fuse-cache
+    slot; return its canonical form."""
+    matches: list[_VecExpMatch] = []
+    for node in ast.walk(root):
+        if node is stop_at:
+            continue
+        if not isinstance(node, ast.For):
+            continue
+        it = node.iter
+        if not (
+            isinstance(it, ast.Call)
+            and isinstance(it.func, ast.Attribute)
+            and it.func.attr == "range_constexpr"
+        ):
+            continue
+        if not isinstance(node.target, ast.Name):
+            continue
+        vec_var = node.target.id
+        for stmt in node.body:
+            for sub in ast.walk(stmt):
+                if not _is_exp2(sub):
+                    continue
+                arg = sub.args[0]
+                if not (
+                    isinstance(arg, ast.BinOp)
+                    and isinstance(arg.op, ast.Sub)
+                    and isinstance(arg.right, ast.Name)
+                    and arg.right.id in scaled_names
+                ):
+                    continue
+                inlined = _inline_locals(arg, node.body, stmt)
+                cache_slots = [
+                    s
+                    for s in ast.walk(inlined)
+                    if isinstance(s, ast.Subscript)
+                    and isinstance(s.value, ast.Name)
+                    and s.value.id in cache_names
+                ]
+                if len(cache_slots) != 1:
+                    continue
+                canonical = _canonical_src(
+                    inlined, {vec_var: "_V_", arg.right.id: "_S_"}
+                )
+                matches.append(
+                    _VecExpMatch(
+                        node,
+                        stmt,
+                        sub,
+                        arg.right.id,
+                        copy.deepcopy(cache_slots[0].slice),
+                        canonical,
+                    )
+                )
+    # Multiple textual exp2 sites are fine when they are the SAME
+    # computation (the emitter duplicates the exp2 into the accumulator
+    # update); they must agree on the vec loop, canonical form, and scaled
+    # var.  Prefer the standalone ``name = exp2(...)`` match.
+    if not matches:
+        return None
+    first = matches[0]
+    for m in matches:
+        if (
+            m.vec_for is not first.vec_for
+            or m.canonical != first.canonical
+            or m.scaled_name != first.scaled_name
+        ):
+            return None
+    for m in matches:
+        if _is_name_assign(m.exp_stmt) and m.exp_stmt.value is m.exp_call:
+            return m
+    return first
+
+
+def fuse_cluster_online_pair(
+    body: list[ast.stmt],
+    constexpr_values: dict[str, int] | None,
+    rename_groups: dict[str, str] | None = None,
+    fast_math: bool = False,
+) -> list[ast.stmt]:
+    renames = rename_groups or {}
+
+    def canon(name: str) -> str:
+        return renames.get(name, name)
+
+    sites = _find_sites(body)
+    if not sites or len(sites) < 2:
+        return body
+
+    # Top-level register-fragment caches (fuse_two_pass_loads output).
+    caches: dict[str, tuple[int, int, str]] = {}
+    for i, top in enumerate(body):
+        if not (_is_name_assign(top) and isinstance(top.value, ast.Call)):
+            continue
+        call = top.value
+        if (
+            isinstance(call.func, ast.Attribute)
+            and call.func.attr == "make_rmem_tensor"
+            and len(call.args) == 2
+            and isinstance(call.args[0], ast.Constant)
+            and isinstance(call.args[0].value, int)
+        ):
+            caches[top.targets[0].id] = (  # type: ignore[attr-defined]
+                call.args[0].value,
+                i,
+                ast.unparse(call.args[1]),
+            )
+
+    for pair_idx in range(len(sites) - 1):
+        site_a, site_b = sites[pair_idx], sites[pair_idx + 1]
+        if (
+            site_a.op != "max"
+            or site_b.op != "sum"
+            or site_a.cluster_n is None
+            or site_a.cluster_n <= 1
+            or site_a.cluster_n != site_b.cluster_n
+            or site_a.group_span is None
+            or site_a.group_span != site_b.group_span
+            or site_a.top_idx >= site_b.top_idx
+        ):
+            continue
+        if _try_rewrite_pair(
+            body, site_a, site_b, caches, constexpr_values, canon, pair_idx, fast_math
+        ):
+            # Sites list is stale after a rewrite; one online pair per
+            # kernel is the supported shape (softmax/logsumexp).
+            break
+    return body
+
+
+def _try_rewrite_pair(
+    body: list[ast.stmt],
+    site_a: _Site,
+    site_b: _Site,
+    caches: dict[str, tuple[int, int]],
+    constexpr_values: dict[str, int] | None,
+    canon: Callable[[str], str],
+    k: int,
+    fast_math: bool,
+) -> bool:
+    from .hoist_warp_reduce import _static_trip_count
+
+    if _static_trip_count(site_a.for_node, constexpr_values) != 1:
+        return False
+    if _static_trip_count(site_b.for_node, constexpr_values) != 1:
+        return False
+
+    # --- max carrier chain: everything after site A in sweep A must be a
+    # linear cast/accumulate chain ending at the max variable ``mi``.
+    tail = site_a.for_node.body[site_a.stmt_idx + 1 :]
+    if not tail or not all(_is_name_assign(s) for s in tail):
+        return False
+    chain_targets = [s.targets[0].id for s in tail]  # type: ignore[attr-defined]
+    mi_name = canon(chain_targets[-1])
+    allowed = {canon(a) for a in {site_a.target, mi_name} | set(chain_targets)}
+    for stmt in tail:
+        if any(canon(n) not in allowed for n in _local_loads(stmt.value)):
+            return False
+    intermediates = {site_a.target} | {t for t in chain_targets if canon(t) != mi_name}
+
+    # ``mi`` must start at -inf (single trip => mi ends as a cast of the
+    # site-A result).
+    init_found = False
+    for top in body[: site_a.top_idx]:
+        if _is_name_assign(top) and canon(top.targets[0].id) == mi_name:  # type: ignore[attr-defined]
+            init_found = "-inf" in ast.unparse(top.value)
+    if not init_found:
+        return False
+
+    # No escape of the local-valued intermediates past sweep A.
+    for top in body[site_a.top_idx + 1 :]:
+        for name in _loads(top):
+            if canon(name) in {canon(x) for x in intermediates}:
+                return False
+
+    # --- reads of ``mi`` between the sweeps: only ``scaled = mi * C``
+    # assigns (or dead assigns).  Collect the scaled candidates.
+    scaled_before: dict[str, float] = {}
+    region: list[tuple[ast.stmt, bool]] = [
+        (stmt, False) for stmt in body[site_a.top_idx + 1 : site_b.top_idx]
+    ]
+    region.extend((stmt, True) for stmt in site_b.for_node.body[: site_b.stmt_idx])
+
+    def _read_anywhere(name: str) -> bool:
+        target_canon = canon(name)
+        for top in body:
+            for other in ast.walk(top):
+                if (
+                    isinstance(other, ast.Name)
+                    and isinstance(other.ctx, ast.Load)
+                    and canon(other.id) == target_canon
+                ):
+                    return True
+        return False
+
+    for stmt, _in_sweep_b in region:
+        for sub_stmt in ast.walk(stmt):
+            if not isinstance(sub_stmt, ast.Assign):
+                continue
+            if not any(canon(n) == mi_name for n in _loads(sub_stmt.value)):
+                continue
+            value = sub_stmt.value
+            if (
+                _is_name_assign(sub_stmt)
+                and isinstance(value, ast.BinOp)
+                and isinstance(value.op, ast.Mult)
+                and isinstance(value.left, ast.Name)
+                and canon(value.left.id) == mi_name
+                and isinstance(value.right, ast.Constant)
+                and isinstance(value.right.value, float)
+            ):
+                scaled_before[sub_stmt.targets[0].id] = value.right.value  # type: ignore[attr-defined]
+                continue
+            # Dead alias copies (e.g. ``mi_copy = mi``) are harmless.
+            if _is_name_assign(sub_stmt) and not _read_anywhere(
+                sub_stmt.targets[0].id  # type: ignore[attr-defined]
+            ):
+                continue
+            return False
+        # Statements that read mi outside any Assign (calls, stores)?
+        assign_reads = set()
+        for sub_stmt in ast.walk(stmt):
+            if isinstance(sub_stmt, ast.Assign):
+                assign_reads.update(id(n) for n in ast.walk(sub_stmt.value))
+                for tgt in sub_stmt.targets:
+                    assign_reads.update(id(n) for n in ast.walk(tgt))
+        for node in ast.walk(stmt):
+            if (
+                isinstance(node, ast.Name)
+                and isinstance(node.ctx, ast.Load)
+                and canon(node.id) == mi_name
+                and id(node) not in assign_reads
+            ):
+                return False
+    if not scaled_before:
+        return False
+
+    # --- sweep B: the vec-loop exp2 keyed by one of the scaled vars.
+    match_b = _find_vec_exp(
+        site_b.for_node, site_b.assign, set(scaled_before), set(caches)
+    )
+    if match_b is None:
+        return False
+    scaled0 = match_b.scaled_name
+    scale_const = scaled_before[scaled0]
+    # No OTHER scaled candidate may feed anything (they'd keep local-max
+    # values alive with unknown consumers).
+    for name in scaled_before:
+        if name != scaled0 and _read_anywhere(name):
+            return False
+
+    # The accumulator update in the same vec body must add exactly this
+    # exp2 to the site-B input.
+    exp_src = ast.unparse(match_b.exp_call)
+    acc_name = None
+    if isinstance(site_b.call.args[0], ast.Name):
+        acc_name = site_b.call.args[0].id
+    if acc_name is None:
+        return False
+    acc_stmt = None
+    for stmt in match_b.vec_for.body:
+        if (
+            _is_name_assign(stmt)
+            and canon(stmt.targets[0].id) == canon(acc_name)  # type: ignore[attr-defined]
+            and any(
+                _is_exp2(node) and ast.unparse(node) == exp_src
+                for node in ast.walk(stmt.value)
+            )
+        ):
+            acc_stmt = stmt
+            break
+    if acc_stmt is None:
+        return False
+
+    # --- sweep C: a later top-level loop recomputing the same exp2 with a
+    # different (post-exchange) scaled variable.
+    scaled_after: dict[str, tuple[float, int]] = {}
+    for i in range(site_b.top_idx + 1, len(body)):
+        top = body[i]
+        if (
+            _is_name_assign(top)
+            and isinstance(top.value, ast.BinOp)
+            and isinstance(top.value.op, ast.Mult)
+            and isinstance(top.value.left, ast.Name)
+            and canon(top.value.left.id) == mi_name
+            and isinstance(top.value.right, ast.Constant)
+            and top.value.right.value == scale_const
+        ):
+            scaled_after[top.targets[0].id] = (top.value.right.value, i)  # type: ignore[attr-defined]
+    if not scaled_after:
+        return False
+    match_c = None
+    sweep_c_top_idx = None
+    for i in range(site_b.top_idx + 1, len(body)):
+        top = body[i]
+        if not isinstance(top, ast.For):
+            continue
+        found = _find_vec_exp(top, None, set(scaled_after), set(caches))
+        if found is not None:
+            if match_c is not None:
+                return False
+            match_c = found
+            sweep_c_top_idx = i
+    if match_c is None or match_c.canonical != match_b.canonical:
+        return False
+    scaled1 = match_c.scaled_name
+    if canon(scaled1) == canon(scaled0):
+        return False
+    # The sweep-C exp2 must be the whole RHS of a Name assignment so the
+    # cached value can substitute for it.
+    if not (
+        _is_name_assign(match_c.exp_stmt) and match_c.exp_stmt.value is match_c.exp_call
+    ):
+        return False
+
+    # --- everything matched; apply the rewrite. -------------------------
+    cache_size = None
+    cache_alloc_idx = None
+    inlined_b = _inline_locals(
+        match_b.exp_call.args[0], match_b.vec_for.body, match_b.exp_stmt
+    )
+    for sub in ast.walk(inlined_b):
+        if (
+            isinstance(sub, ast.Subscript)
+            and isinstance(sub.value, ast.Name)
+            and sub.value.id in caches
+        ):
+            cache_size, cache_alloc_idx = caches[sub.value.id][:2]
+    if cache_size is None:
+        return False
+
+    exp_cache = f"_pair_exp_cache_{k}"
+    rescale = f"_pair_rescale_{k}"
+    gmax = f"_pair_gmax_{k}"
+
+    # 1) site A -> CTA-local block reduce (drop buf/mbar args).
+    block_args = ", ".join(ast.unparse(a) for a in site_a.call.args[:4])
+    site_a.assign.value = _stmt(
+        f"_x = {_BLOCK_REDUCE}({block_args}, group_span={site_a.group_span})"
+    ).value
+    ast.fix_missing_locations(site_a.assign)
+
+    # 2) sweep B: name the exp2 (reuse an existing ``v = exp2(...)`` if the
+    # emitter already produced one), cache it, and reference it in the
+    # accumulator update.
+    vec_body = match_b.vec_for.body
+    exp_assign: ast.stmt | None = None
+    for stmt in vec_body:
+        if stmt is acc_stmt:
+            break
+        if (
+            _is_name_assign(stmt)
+            and _is_exp2(stmt.value)
+            and ast.unparse(stmt.value) == exp_src
+        ):
+            exp_assign = stmt
+    if exp_assign is not None:
+        exp_name = exp_assign.targets[0].id  # type: ignore[attr-defined]
+    else:
+        exp_name = f"_pair_e_{k}"
+        exp_assign = _stmt(f"{exp_name} = {exp_src}")
+        vec_body.insert(vec_body.index(acc_stmt), exp_assign)
+    store = _stmt(f"{exp_cache}[{ast.unparse(match_b.slot)}] = {exp_name}")
+    vec_body.insert(vec_body.index(exp_assign) + 1, store)
+
+    class _SwapExp(ast.NodeTransformer):
+        def visit_Call(self, node: ast.Call) -> ast.AST:
+            self.generic_visit(node)
+            if _is_exp2(node) and ast.unparse(node) == exp_src:
+                return ast.Name(id=exp_name, ctx=ast.Load())
+            return node
+
+    acc_stmt.value = _SwapExp().visit(acc_stmt.value)
+    ast.fix_missing_locations(acc_stmt)
+
+    # 3) site B -> single packed pair exchange + global-max reassignment.
+    pair_call_src = (
+        f"{gmax}, {site_b.target} = {_PAIR_REDUCE}("
+        f"{ast.unparse(site_b.call.args[0])}, {mi_name}, "
+        f"{ast.unparse(site_b.call.args[3])}, {site_b.buf_name}, "
+        f"{site_b.mbar_name}, group_span={site_b.group_span}, "
+        f"cluster_n={site_b.cluster_n}, scale={scale_const!r}, "
+        f"fastmath={fast_math})"
+    )
+    site_b.for_node.body[site_b.stmt_idx : site_b.stmt_idx + 1] = [
+        _stmt(pair_call_src),
+        _stmt(f"{mi_name} = {gmax}"),
+    ]
+
+    # 4) sweep C: the cached exp replaces the recompute.  When the exp
+    # feeds exactly one multiply by a scalar that is only read inside this
+    # sweep (the hoisted ``1/denom``), fold the CTA-uniform rescale into
+    # that scalar instead of paying a per-element multiply.
+    exp_target = match_c.exp_stmt.targets[0].id  # type: ignore[attr-defined]
+    scaled1_idx = scaled_after[scaled1][1]
+    fold_scalar = None
+    exp_reads = sum(
+        n == exp_target
+        for stmt in body[sweep_c_top_idx].body  # type: ignore[attr-defined]
+        for n in _loads(stmt)
+    )
+    if exp_reads == 1:
+        for stmt in match_c.vec_for.body:
+            if not (_is_name_assign(stmt) and isinstance(stmt.value, ast.BinOp)):
+                continue
+            value = stmt.value
+            if not isinstance(value.op, ast.Mult):
+                continue
+            names = [o.id for o in (value.left, value.right) if isinstance(o, ast.Name)]
+            if exp_target in names and len(names) == 2:
+                other = next(n for n in names if n != exp_target)
+                read_elsewhere = any(
+                    other in _loads(top)
+                    for j, top in enumerate(body)
+                    if j != sweep_c_top_idx
+                )
+                defined_before = any(
+                    _is_name_assign(top) and top.targets[0].id == other  # type: ignore[attr-defined]
+                    for top in body[: scaled1_idx + 1]
+                )
+                if not read_elsewhere and defined_before:
+                    fold_scalar = other
+                break
+    if fold_scalar is not None:
+        match_c.exp_stmt.value = _stmt(
+            f"_x = {exp_cache}[{ast.unparse(match_c.slot)}]"
+        ).value
+    else:
+        match_c.exp_stmt.value = _stmt(
+            f"_x = {exp_cache}[{ast.unparse(match_c.slot)}] * {rescale}"
+        ).value
+    ast.fix_missing_locations(match_c.exp_stmt)
+    _prune_dead_assigns(
+        match_c.vec_for.body,
+        [body[sweep_c_top_idx], *body[sweep_c_top_idx + 1 :]],
+    )
+
+    # 5) top-level declarations: the f32 exp cache next to the load cache,
+    # and the rescale factor after the post-exchange scaled var.
+    rescale_stmts = [_stmt(f"{rescale} = cute.math.exp2({scaled0} - {scaled1})")]
+    if fold_scalar is not None:
+        rescale_stmts.append(_stmt(f"{fold_scalar} = {fold_scalar} * {rescale}"))
+    body[scaled1_idx + 1 : scaled1_idx + 1] = rescale_stmts
+    body.insert(
+        cache_alloc_idx + 1,
+        _stmt(f"{exp_cache} = cute.make_rmem_tensor({cache_size}, cutlass.Float32)"),
+    )
+
+    # 6) preamble: site B's receive buffer becomes ``cluster_n`` Int64 pair
+    # slots; site A's buffer/mbarrier (now unused) are removed.
+    for top in body:
+        if _is_name_assign(top) and top.targets[0].id == site_b.buf_name:  # type: ignore[attr-defined]
+            top.value = _stmt(
+                f"_x = cute.arch.alloc_smem(cutlass.Int64, {site_b.cluster_n})"
+            ).value
+            ast.fix_missing_locations(top)
+    removable: list[int] = []
+    for i, top in enumerate(body):
+        if (
+            _is_name_assign(top)
+            and top.targets[0].id
+            in (  # type: ignore[attr-defined]
+                site_a.buf_name,
+                site_a.mbar_name,
+            )
+            or isinstance(top, ast.If)
+            and site_a.mbar_name in _loads(top)
+        ):
+            removable.append(i)
+    kept = [top for i, top in enumerate(body) if i not in removable]
+    leftover_reads = [
+        name
+        for top in kept
+        for name in _loads(top)
+        if name in (site_a.buf_name, site_a.mbar_name)
+    ]
+    if not leftover_reads:
+        for i in reversed(removable):
+            del body[i]
+    return True

--- a/helion/_compiler/cute/exp2_fastmath.py
+++ b/helion/_compiler/cute/exp2_fastmath.py
@@ -1,0 +1,42 @@
+# pyrefly: ignore-errors
+"""Apply ``fastmath=True`` to every ``cute.math.exp2`` call in the kernel
+body when the ``fast_math`` SETTING is enabled.
+
+This is deliberately a setting (``helion.Settings.fast_math`` /
+``HELION_FAST_MATH=1``) and not an autotuner config knob: it changes
+numerics, and tuned configs must never change numerics.
+
+The default exp2 lowering guards the denormal output range: each call
+costs an extra FSETP plus two predicated FMULs per element and lengthens
+live ranges (the input must survive until the fixup).  ``ex2.approx.ftz``
+skips the fixup; exp results below the normal f32 range flush to zero.
+For exp-of-shifted-value reductions (softmax and friends) those elements
+contribute nothing to the sum and round to zero in a 16-bit output anyway
+— measured +1.7% on register-resident softmax rows on B200.
+"""
+
+from __future__ import annotations
+
+import ast
+
+
+def apply_exp2_fastmath(body: list[ast.stmt]) -> list[ast.stmt]:
+    for top in body:
+        for node in ast.walk(top):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "exp2"
+                and isinstance(node.func.value, ast.Attribute)
+                and node.func.value.attr == "math"
+                and isinstance(node.func.value.value, ast.Name)
+                and node.func.value.value.id == "cute"
+            ):
+                continue
+            if any(kw.arg == "fastmath" for kw in node.keywords):
+                continue
+            node.keywords.append(
+                ast.keyword(arg="fastmath", value=ast.Constant(value=True))
+            )
+            ast.fix_missing_locations(node)
+    return body

--- a/helion/_compiler/cute/hoist_warp_reduce.py
+++ b/helion/_compiler/cute/hoist_warp_reduce.py
@@ -1093,7 +1093,11 @@ def validate_cluster_reduce_placement(
                     if (
                         isinstance(sub, ast.Call)
                         and isinstance(sub.func, ast.Name)
-                        and sub.func.id == "_cute_grouped_reduce_cluster"
+                        and sub.func.id
+                        in (
+                            "_cute_grouped_reduce_cluster",
+                            "_cute_grouped_reduce_cluster_online_pair",
+                        )
                     ):
                         raise exc.BackendUnsupported(
                             "cute",

--- a/helion/_compiler/cute/reduce_helpers.py
+++ b/helion/_compiler/cute/reduce_helpers.py
@@ -830,3 +830,141 @@ def _cute_grouped_reduce_cluster(
         group_span,
         cluster_n,
     )
+
+
+def _cute_grouped_reduce_block(
+    input_value: cute.Numeric,
+    reduction_type: str,
+    identity: cute.Numeric,
+    lane_var: cutlass.Int32,
+    *,
+    group_span: int,
+) -> cute.Numeric:
+    """CTA-local grouped reduce over one group spanning the whole CTA
+    (``pre == 1``, ``group_count == 1``): warp reduce + SMEM cross-warp
+    combine.  Used by the cluster online-pair rewrite to relocalize the
+    first (max) reduction of an online-softmax pair — the cross-CTA
+    combine happens later in ``_cute_grouped_reduce_cluster_online_pair``."""
+    impl = _TWO_STAGE_DISPATCH.get(reduction_type)
+    if impl is None:
+        raise ValueError(f"unsupported CuTe reduction type: {reduction_type!r}")
+    return impl(
+        input_value,
+        identity,
+        lane_var,
+        lane_var,
+        cutlass.Int32(0),
+        pre=1,
+        group_span=group_span,
+        group_count=1,
+    )
+
+
+@cute.jit
+def _cute_grouped_reduce_cluster_online_pair_body(
+    local_sum: cute.Numeric,
+    local_max: cute.Numeric,
+    lane_var: cutlass.Int32,
+    buf_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    group_span: int,
+    cluster_n: int,
+    scale: float,
+    fastmath: bool,
+) -> tuple[cute.Numeric, cute.Numeric]:
+    """Single-exchange cluster combine for an online-softmax (max, sum)
+    pair.  ``local_max`` is this CTA's slice max (CTA-uniform; relocalized
+    site-A result) and ``local_sum`` is the per-thread partial of
+    ``sum(exp2(f(x) - local_max * scale))`` over the CTA's slice.
+
+    The per-thread sum is block-reduced within the CTA, then ONE
+    ``st.async`` v2.f32 exchange pushes the ``(local_max, cta_sum)`` pair
+    into every peer CTA's ``cluster_n``-slot receive buffer; after the
+    mbarrier wait every CTA folds the pairs with the online-softmax
+    rescale ``sum += s_r * exp2((m_r - m) * scale)``.  Compared with two
+    ``_cute_grouped_reduce_cluster`` calls this saves a full cluster
+    round-trip and shrinks the fold from ``warps * cluster_n`` to
+    ``cluster_n`` slots.
+
+    ``buf_ptr`` must point at ``cluster_n`` SMEM ``Int64`` slots (8-byte
+    aligned pairs) and ``mbar_ptr`` at one initialized mbarrier; like
+    ``_cute_grouped_reduce_cluster`` the mbarrier is single-phase, so each
+    (textual) call site must execute exactly once per kernel.
+
+    Returns ``(group_max, group_sum)``: the cluster-wide max and the sum
+    rescaled into the ``group_max`` frame — ``sum_j exp2(f(x_j) -
+    group_max * scale)`` over the whole cluster row.
+    """
+    from helion._compiler.cute.cluster_helpers import store_shared_remote_f32x2
+
+    cta_sum = _cute_grouped_reduce_shared_two_stage_sum(
+        local_sum,
+        cutlass.Float32(0.0),
+        lane_var,
+        lane_var,
+        cutlass.Int32(0),
+        pre=1,
+        group_span=group_span,
+        group_count=1,
+    )
+    pairs = cute.make_tensor(buf_ptr, (cluster_n,))
+    vals = cute.make_tensor(
+        cute.recast_ptr(buf_ptr, dtype=cutlass.Float32), (2 * cluster_n,)
+    )
+    rank = cutlass.Int32(cute.arch.block_idx_in_cluster())
+    lane32 = cutlass.Int32(lane_var)
+    if lane32 // 32 == 0:
+        with cute.arch.elect_one():
+            cute.arch.mbarrier_arrive_and_expect_tx(mbar_ptr, cluster_n * 8)
+    if lane32 < cluster_n:
+        store_shared_remote_f32x2(
+            cutlass.Float32(local_max),
+            cutlass.Float32(cta_sum),
+            pairs.iterator + rank,
+            mbar_ptr,
+            lane32,
+        )
+    cute.arch.mbarrier_wait(mbar_ptr, phase=0)
+    # Warp-parallel fold: each lane owns one received pair, two warp
+    # reductions combine them.  A serial constexpr fold would batch
+    # ``cluster_n`` LDS.128 loads into one register burst (32 registers at
+    # cluster_n=16) right where the cached exp values already peak the
+    # live set — this keeps the fold's register profile flat.
+    lane_in_warp = lane32 % 32
+    slot = lane_in_warp % cluster_n
+    pair_max = vals[2 * slot]
+    pair_sum = vals[2 * slot + 1]
+    if lane_in_warp >= cluster_n:
+        pair_max = -cutlass.Float32.inf
+        pair_sum = cutlass.Float32(0.0)
+    group_max = cute.arch.warp_reduction_max(pair_max, threads_in_group=32)
+    rescaled = pair_sum * cute.math.exp2(
+        (pair_max - group_max) * scale, fastmath=fastmath
+    )
+    group_sum = cute.arch.warp_reduction_sum(rescaled, threads_in_group=32)
+    return group_max, group_sum
+
+
+def _cute_grouped_reduce_cluster_online_pair(
+    local_sum: cute.Numeric,
+    local_max: cute.Numeric,
+    lane_var: cutlass.Int32,
+    buf_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    *,
+    group_span: int,
+    cluster_n: int,
+    scale: float,
+    fastmath: bool = False,
+) -> tuple[cute.Numeric, cute.Numeric]:
+    return _cute_grouped_reduce_cluster_online_pair_body(
+        local_sum,
+        local_max,
+        lane_var,
+        buf_ptr,
+        mbar_ptr,
+        group_span,
+        cluster_n,
+        scale,
+        fastmath,
+    )

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -1043,11 +1043,20 @@ class DeviceFunction:
                 )
             except Exception:
                 thread_block_dims = (1, 1, 1)
-            tensor_dtypes = {
-                arg.name: backend.dtype_str(arg.fake_value.dtype)
-                for arg in self.arguments
-                if isinstance(arg, TensorArg)
-            }
+            # Best-effort map for the fuser's cache-dtype resolution;
+            # ``dtype_str`` raises for dtypes the cute backend has no
+            # canonical spelling for (e.g. uint32 barrier flags, which
+            # SIMT loads treat as raw bytes) — such tensors simply don't
+            # participate in load fusion.
+            tensor_dtypes = {}
+            for arg in self.arguments:
+                if isinstance(arg, TensorArg):
+                    try:
+                        tensor_dtypes[arg.name] = backend.dtype_str(
+                            arg.fake_value.dtype
+                        )
+                    except ValueError:
+                        continue
             kernel_body = fuse_two_pass_loads(
                 kernel_body,
                 constexpr_values,
@@ -1120,6 +1129,28 @@ class DeviceFunction:
             kernel_body = pipeline_inner_loads(
                 kernel_body, constexpr_values, rename_groups=rename_groups
             )
+            # Fuse an online-softmax (max, sum) pair of cluster reduces into
+            # ONE packed DSM exchange: the max reduce relocalizes to a
+            # CTA-local block reduce, the sum site exchanges the
+            # ``(local_max, local_sum)`` pair once and folds with the
+            # online-softmax rescale, and the write sweep reuses the sum
+            # sweep's cached exp values.  Saves a full cluster round-trip
+            # per row (+5..9% at cluster_n 2..16 on B200 softmax).
+            from .cute.cluster_online_pair import fuse_cluster_online_pair
+
+            kernel_body = fuse_cluster_online_pair(
+                kernel_body,
+                constexpr_values,
+                rename_groups=rename_groups,
+                fast_math=CompileEnvironment.current().settings.fast_math,
+            )
+            # ``ex2.approx.ftz`` is a numerics change (denormal exp outputs
+            # flush to zero), so it is gated on the fast_math SETTING —
+            # tuned configs must never change numerics.
+            if CompileEnvironment.current().settings.fast_math:
+                from .cute.exp2_fastmath import apply_exp2_fastmath
+
+                kernel_body = apply_exp2_fastmath(kernel_body)
             # The DSM cluster reduce uses a single-phase mbarrier, so each
             # call site must execute exactly ONCE per kernel.  The
             # lane-reduce collapse normally hoists it out of the (staged,

--- a/test/test_cute_cluster_online_pair.py
+++ b/test/test_cute_cluster_online_pair.py
@@ -1,0 +1,192 @@
+"""Tests for the cluster online-pair rewrite (``cluster_online_pair``).
+
+For an online-softmax reduction pair split across a thread-block cluster,
+the rewrite replaces the two DSM cluster exchanges (max, then sum) with a
+CTA-local block reduce plus ONE packed ``(max, sum)`` exchange folded with
+the online-softmax rescale, and reuses the sum sweep's cached exp values
+in the write sweep.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@helion.kernel(backend="cute")
+def softmax_two_pass_kernel(x: torch.Tensor) -> torch.Tensor:
+    """Mirrors ``examples/softmax.py::softmax_two_pass``."""
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@helion.kernel(backend="cute", fast_math=True)
+def softmax_fast_math_kernel(x: torch.Tensor) -> torch.Tensor:
+    """Same as ``softmax_two_pass_kernel`` but with the fast_math setting."""
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@helion.kernel(backend="cute")
+def rowsum_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty([m], dtype=torch.float32, device=x.device)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        acc = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            acc = acc + x[tile_m, tile_n].to(torch.float32).sum(dim=1)
+        out[tile_m] = acc
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCuteClusterOnlinePair(TestCase):
+    def test_pair_rewrite_fires_bf16_cl2(self) -> None:
+        """The softmax pattern with ``cute_cluster_n=2`` must compile to a
+        single packed pair exchange: a CTA-local block reduce for the max,
+        ``_cute_grouped_reduce_cluster_online_pair`` for the sum, an exp
+        cache written by the sum sweep, and a rescale in the write sweep
+        instead of an exp2 recompute."""
+        x = torch.randn(64, 32768, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            softmax_two_pass_kernel,
+            (x,),
+            block_sizes=[1, 32768],
+            num_threads=[0, 256],
+            cute_vector_widths=[1, 8],
+            cute_lane_layouts=["blocked", "strided"],
+            cute_cluster_n=2,
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-3)
+        self.assertIn("_cute_grouped_reduce_cluster_online_pair(", code)
+        self.assertIn("_cute_grouped_reduce_block(", code)
+        # Both two-exchange call sites must be gone (exact-name match; the
+        # pair helper's name extends it, so check the call spelling).
+        self.assertEqual(code.count("_cute_grouped_reduce_cluster("), 0)
+        self.assertIn("_pair_exp_cache_0", code)
+        self.assertIn("_pair_rescale_0", code)
+        # The pair exchange receives cluster_n Int64 (8-byte pair) slots.
+        self.assertIn("cute.arch.alloc_smem(cutlass.Int64, 2)", code)
+
+    def test_pair_rewrite_correct_fp16_cl4(self) -> None:
+        x = torch.randn(32, 65536, device=DEVICE, dtype=torch.float16)
+        code, out = code_and_output(
+            softmax_two_pass_kernel,
+            (x,),
+            block_sizes=[1, 65536],
+            num_threads=[0, 256],
+            cute_vector_widths=[1, 8],
+            cute_lane_layouts=["blocked", "strided"],
+            cute_cluster_n=4,
+            cute_min_blocks_per_mp=3,
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-3)
+        self.assertIn("_cute_grouped_reduce_cluster_online_pair(", code)
+
+    def test_exp2_fastmath_setting(self) -> None:
+        """The ``fast_math`` SETTING (not a config — configs must not
+        change numerics) puts ``fastmath=True`` on every emitted
+        ``cute.math.exp2`` call; the default keeps the exact
+        (denormal-preserving) lowering."""
+        x = torch.randn(64, 8192, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            softmax_fast_math_kernel,
+            (x,),
+            block_sizes=[1, 8192],
+            num_threads=[0, 128],
+            cute_vector_widths=[1, 8],
+            cute_lane_layouts=["blocked", "strided"],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-3)
+        self.assertGreater(code.count("cute.math.exp2("), 0)
+        self.assertEqual(code.count("cute.math.exp2("), code.count("fastmath=True"))
+
+    def test_exp2_exact_by_default(self) -> None:
+        """Without the setting, no config may introduce fastmath exp2 —
+        including the cluster pair rewrite's helper fold."""
+        x = torch.randn(64, 32768, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            softmax_two_pass_kernel,
+            (x,),
+            block_sizes=[1, 32768],
+            num_threads=[0, 256],
+            cute_vector_widths=[1, 8],
+            cute_lane_layouts=["blocked", "strided"],
+            cute_cluster_n=2,
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-3)
+        self.assertNotIn("fastmath=True", code)
+
+    def test_single_site_keeps_two_exchange_form(self) -> None:
+        """A cluster kernel without the (max, sum-of-exp) pair keeps the
+        plain per-site cluster exchange."""
+        x = torch.randn(64, 32768, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            rowsum_kernel,
+            (x,),
+            block_sizes=[1, 32768],
+            num_threads=[0, 256],
+            cute_vector_widths=[1, 8],
+            cute_lane_layouts=["blocked", "strided"],
+            cute_cluster_n=2,
+        )
+        ref = x.to(torch.float32).sum(dim=1)
+        torch.testing.assert_close(out, ref, rtol=1e-3, atol=1e-2)
+        self.assertIn("_cute_grouped_reduce_cluster(", code)
+        self.assertNotIn("_cute_grouped_reduce_cluster_online_pair(", code)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3515
 * #3514
 * #3513
 * #3512
 * #3511
 * #3510
 * #3509
 * #3498
 * __->__#3497
 * #3496
 * #3495
 * #3494


--- --- ---

[cutedsl] Cluster online-pair reduce: one packed DSM exchange per softmax row; exp2 fastmath under the fast_math setting

Round 2 of the softmax hillclimb. A cluster-split online-softmax row
previously paid TWO DSM cluster exchanges (max, then sum), and the sum
sweep stalled on the cross-cluster max; the deficit vs the hand-written
quack kernel grew with cluster_n. This lands the standard online-softmax
cluster combine as general codegen:

- cluster_online_pair AST pass: when the emitted 3-pass shape is provably
  the (max-reduce, sum-of-exp-reduce) pair, the max site relocalizes to a
  CTA-local block reduce (_cute_grouped_reduce_block), the sum sweep's
  exp2 values are cached in a f32 register fragment, and the sum site
  becomes _cute_grouped_reduce_cluster_online_pair: CTA-local sum, ONE
  st.async v2.f32 (local_max, local_sum) exchange over cluster_n Int64
  slots, and a warp-parallel rescale fold (each lane owns a pair; a
  serial constexpr fold batched cluster_n LDS.128 into a 32-register
  burst at cluster_n=16). The max variable is reassigned to the folded
  global, and the write sweep reads the exp cache times a CTA-uniform
  rescale (folded into the hoisted 1/denom when it is provably the sole
  consumer). Every structural check fails closed to the two-exchange
  form; single-site cluster kernels are untouched.
  Why CTA-local (not warp-local like quack): a warp-shuffle-produced
  subtrahend lets the scheduler hoist the whole x*log2e sweep above the
  warp reduce (78 -> 170 regs, 12% occupancy, measured); an SMEM-after-
  barrier subtrahend anchors the schedule.

- exp2 fastmath under the existing fast_math SETTING (HELION_FAST_MATH=1,
  default off), NOT an autotuner config knob — tuned configs must never
  change numerics. When enabled, every emitted cute.math.exp2 (and the
  pair helper's rescale fold) uses ex2.approx.ftz: drops the per-element
  denormal-range fixup (FSETP + 2 predicated FMULs) and shortens live
  ranges enough that ptxas leaves its 128-register plateau on the
  resident-row family. Exp results below the f32 normal range flush to 0
  (consistent with the setting's documented contract).

- CuteResidentRowWideClusterHeuristic: second autotuner seed (128-thread
  CTAs, widest cluster at <=64..128 elems/thread, min_blocks_per_mp 2/3)
  — the pair exchange makes wide clusters cheap and moved the measured
  winners from T256/narrow-CL to T128/CL8..16; without this seed the
  65536 cold autotune stayed in the T256/CL4 basin.

- Fix a latent crash from the round-1 tensor-dtype map: uint32 tensor
  args (test_barrier) have no cute dtype spelling; such tensors now just
  skip load fusion.

Cold-full-autotune results on B200 850W (bf16 rows, GB/s, HELION_FAST_MATH=1,
quack measured in the same run on the same GPU): 32768x1024 5035/5011,
x4096 5889/5641, x8192 5788/5672, x16384 5873/5363, x32768 5023/5041,
x65536 4630/4755, 16384x131072 4462/4554, 8192x262144 4169/4232 —
geomean 1.012 vs quack (round 1: 0.97). Full cute suite 1803 passed;
triton-side autotuner/reductions/barrier suites green.