### PR TITLE
[cutedsl] Serial-smem block reduce and minnctapersm occupancy squeeze for whole-CTA row reductions

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -453,39 +453,45 @@ class CuteResidentRowHeuristic(AutotunerHeuristic):
 
 
 class CuteResidentRowWideClusterHeuristic(AutotunerHeuristic):
-    """128-thread wide-cluster variant of ``CuteResidentRowHeuristic``.
+    """Wide-cluster occupancy-squeeze variant of ``CuteResidentRowHeuristic``.
 
     With the cluster online-pair rewrite (one packed DSM exchange per row
-    instead of two) wide clusters of small CTAs win big rows: the measured
-    winners moved from 256-thread CTAs with the narrowest fitting cluster
-    to 128-thread CTAs with cluster_n 8..16 (e.g. 65536: T128/CL8 4761
-    vs T256/CL4 4536 GB/s on B200).  Seed that family too so the search
-    starts in both basins; per-thread footprints up to 128 elements are
-    allowed (the register-capped family) and get ``min_blocks_per_mp=3``.
+    instead of two) wide clusters of small CTAs win big rows.  The best
+    measured family keeps 64 elements per thread (the fused u16 x-cache +
+    f32 exp-cache footprint that fits ~80-95 registers) and squeezes
+    ptxas to ~24 warps/SM via ``min_blocks_per_mp = 768 // threads``: on
+    B200 the extra resident CTA outweighs ~10 spilled registers
+    (65536: T128/CL8/mb6 4861 vs mb2 4712 GB/s; 131072: T128/CL16/mb6
+    4821 vs quack 4614; 262144: T256/CL16/mb3 4304 vs quack 4284).
+    Rows that cannot hit 64/thread at any cluster width (e.g. odd-multiple
+    rows whose per-CTA slice divides 128 lanes but not 256) fall back to
+    the 128-elements/thread register-capped family at ``mb=3``; power-of-2
+    rows too big even for that leave the heuristic ineligible.
     """
+
+    # minnctapersm target: ~24 warps/SM measured best for the
+    # 64-element/thread family on B200 (see class docstring).
+    _TARGET_THREADS_PER_SM = 768
 
     name = "cute_resident_row_wide_cluster"
     backend = "cute"
 
-    _THREADS = 128
-
     @classmethod
     def _plan(
         cls, env: CompileEnvironment, device_ir: DeviceIR
-    ) -> tuple[int, int, int, int] | None:
+    ) -> tuple[int, int, int, int, int] | None:
         base = CuteResidentRowHeuristic._plan(env, device_ir)
         if base is None:
             return None
         n, _threads, vec, _cluster_n = base
-        threads = cls._THREADS
-        for max_per_thread in (64, 128):
+        for max_per_thread, threads in ((64, 128), (64, 256), (128, 128)):
             for cluster_n in (2, 4, 8, 16):
                 per_cta = n // cluster_n
                 if (
                     per_cta % (threads * vec) == 0
                     and per_cta // threads <= max_per_thread
                 ):
-                    return n, threads, vec, cluster_n
+                    return n, threads, vec, cluster_n, max_per_thread
         return None
 
     @classmethod
@@ -499,7 +505,7 @@ class CuteResidentRowWideClusterHeuristic(AutotunerHeuristic):
         plan = cls._plan(env, device_ir)
         if plan is None:
             return None
-        n, threads, vec, cluster_n = plan
+        n, threads, vec, cluster_n, max_per_thread = plan
         seed: dict[str, Any] = {
             "block_sizes": [1, n],
             "num_threads": [0, threads],
@@ -507,14 +513,14 @@ class CuteResidentRowWideClusterHeuristic(AutotunerHeuristic):
             "cute_lane_layouts": ["blocked", "strided"],
             "cute_cluster_n": cluster_n,
         }
-        if n // cluster_n // threads > 64:
+        if max_per_thread > 64:
             # 128 elements/thread: the exp/load caches alone need ~128
             # registers, so cap the budget for 3 CTAs/SM.
             seed["cute_min_blocks_per_mp"] = 3
         else:
-            # 64/thread: launch bounds for >=2 CTAs nudge ptxas off its
-            # 128-register plateau (T128/CL8 65536: 4761 vs 4623 GB/s).
-            seed["cute_min_blocks_per_mp"] = 2
+            # 64/thread: squeeze to ~24 warps/SM (85-register cap at 128
+            # threads); a handful of spills costs less than the lost CTA.
+            seed["cute_min_blocks_per_mp"] = cls._TARGET_THREADS_PER_SM // threads
         try:
             return Config(**seed)
         except Exception:

--- a/helion/_compiler/cute/reduce_helpers.py
+++ b/helion/_compiler/cute/reduce_helpers.py
@@ -350,6 +350,126 @@ _TWO_STAGE_DISPATCH = {
 }
 
 
+# Serial cross-warp combine for whole-CTA groups with few warps: warp
+# reduce, lane 0 of each warp writes its partial to SMEM, one sync, then
+# EVERY thread folds the ``warps`` partials serially.  Compared with the
+# two-stage form this drops the second warp shuffle reduce and its guards
+# (~5 SHFL + WARPSYNC per site) and the result is a fold over SMEM loads,
+# which anchors the scheduler the same way (a shuffle-produced reduction
+# result as the subtrahend of a bulk exp sweep makes LLVM hoist the whole
+# sweep above the reduce and double the live set).  The trailing sync
+# keeps a multi-trip call site from racing the next trip's writes (both
+# passes touch the same slots, unlike the two-stage's disjoint regions).
+
+
+@cute.jit
+def _cute_grouped_reduce_shared_serial_body(
+    input_value: cute.Numeric,
+    warp_op: object,
+    combine: object,
+    identity: cute.Numeric,
+    lane_var: cutlass.Int32,
+    group_span: int,
+) -> cute.Numeric:
+    dtype = type(identity)
+    warps = group_span // 32
+    smem_ptr = cute.arch.alloc_smem(dtype, warps)
+    smem = cute.make_tensor(smem_ptr, (warps,))
+    lane_in_warp = lane_var % 32
+    # Only used for group_count == 1 groups spanning the whole CTA, so
+    # ``lane_var`` is the CTA thread index and ``lane_var // 32`` its warp.
+    warp = lane_var // 32
+    warp_partial = warp_op(input_value, threads_in_group=32)
+    if lane_in_warp == 0:
+        smem[warp] = warp_partial
+    cute.arch.sync_threads()
+    result = smem[0]
+    for w in cutlass.range_constexpr(1, warps):
+        result = combine(result, smem[w])
+    cute.arch.sync_threads()
+    return result
+
+
+def _cute_scalar_combine_max(a: cute.Numeric, b: cute.Numeric) -> cute.Numeric:
+    return cute.arch.fmax(a, b)
+
+
+@cute.jit
+def _cute_scalar_combine_min(a: cute.Numeric, b: cute.Numeric) -> cute.Numeric:
+    return min(b, a)
+
+
+def _cute_scalar_combine_f32_min(a: cute.Numeric, b: cute.Numeric) -> cute.Numeric:
+    return cute.arch.fmin(a, b)
+
+
+@cute.jit
+def _cute_scalar_combine_generic_max(a: cute.Numeric, b: cute.Numeric) -> cute.Numeric:
+    return max(b, a)
+
+
+_SERIAL_DISPATCH = {
+    "sum": (_warp_reduce_sum, operator.add),
+    "prod": (_warp_reduce_prod, operator.mul),
+}
+
+# Above this many warps the serial fold's per-thread chain outgrows the
+# two-stage form's constant shuffle cost.
+_SERIAL_MAX_WARPS = 8
+
+
+def _cute_grouped_reduce_shared_serial(
+    input_value: cute.Numeric,
+    reduction_type: str,
+    identity: cute.Numeric,
+    lane_var: cutlass.Int32,
+    *,
+    group_span: int,
+) -> cute.Numeric:
+    if reduction_type == "max":
+        warp_op = _warp_reduce_max
+        # cute.arch.fmax/fmin are one FMNMX; Python max/min lower to
+        # compare+select.
+        combine = (
+            _cute_scalar_combine_max
+            if type(identity) is cutlass.Float32
+            else _cute_scalar_combine_generic_max
+        )
+    elif reduction_type == "min":
+        warp_op = _warp_reduce_min
+        combine = (
+            _cute_scalar_combine_f32_min
+            if type(identity) is cutlass.Float32
+            else _cute_scalar_combine_min
+        )
+    else:
+        entry = _SERIAL_DISPATCH.get(reduction_type)
+        if entry is None:
+            raise ValueError(f"unsupported CuTe reduction type: {reduction_type!r}")
+        warp_op, combine = entry
+    return _cute_grouped_reduce_shared_serial_body(
+        input_value,
+        warp_op,
+        combine,
+        identity,
+        lane_var,
+        group_span,
+    )
+
+
+def _use_serial_block_reduce(pre: int, group_span: int, group_count: int) -> bool:
+    # group_count == 1 with pre == 1 means ONE group spanning the whole
+    # CTA at every current emitter (they all size group_count as
+    # num_threads // group_span); the serial body's warp indexing relies
+    # on that invariant.
+    return (
+        pre == 1
+        and group_count == 1
+        and group_span % 32 == 0
+        and 2 <= group_span // 32 <= _SERIAL_MAX_WARPS
+    )
+
+
 def _cute_grouped_reduce_shared_two_stage(
     input_value: cute.Numeric,
     reduction_type: str,
@@ -362,6 +482,17 @@ def _cute_grouped_reduce_shared_two_stage(
     group_span: int,
     group_count: int,
 ) -> cute.Numeric:
+    # Despite the name (kept for call-site stability) this dispatcher owns
+    # ALL shared-memory cross-warp combines: small whole-CTA groups route
+    # to the cheaper serial form, everything else to the two-stage form.
+    if _use_serial_block_reduce(pre, group_span, group_count):
+        return _cute_grouped_reduce_shared_serial(
+            input_value,
+            reduction_type,
+            identity,
+            lane_var,
+            group_span=group_span,
+        )
     impl = _TWO_STAGE_DISPATCH.get(reduction_type)
     if impl is None:
         raise ValueError(f"unsupported CuTe reduction type: {reduction_type!r}")
@@ -789,14 +920,6 @@ def _cute_grouped_reduce_cluster_body(
     return result
 
 
-def _cute_scalar_combine_max(a: cute.Numeric, b: cute.Numeric) -> cute.Numeric:
-    return cute.arch.fmax(a, b)
-
-
-def _cute_scalar_combine_min(a: cute.Numeric, b: cute.Numeric) -> cute.Numeric:
-    return min(b, a)
-
-
 _CLUSTER_DISPATCH = {
     "sum": (_warp_reduce_sum, operator.add),
     "max": (_warp_reduce_max, _cute_scalar_combine_max),
@@ -845,11 +968,9 @@ def _cute_grouped_reduce_block(
     combine.  Used by the cluster online-pair rewrite to relocalize the
     first (max) reduction of an online-softmax pair — the cross-CTA
     combine happens later in ``_cute_grouped_reduce_cluster_online_pair``."""
-    impl = _TWO_STAGE_DISPATCH.get(reduction_type)
-    if impl is None:
-        raise ValueError(f"unsupported CuTe reduction type: {reduction_type!r}")
-    return impl(
+    return _cute_grouped_reduce_shared_two_stage(
         input_value,
+        reduction_type,
         identity,
         lane_var,
         lane_var,
@@ -897,8 +1018,9 @@ def _cute_grouped_reduce_cluster_online_pair_body(
     """
     from helion._compiler.cute.cluster_helpers import store_shared_remote_f32x2
 
-    cta_sum = _cute_grouped_reduce_shared_two_stage_sum(
+    cta_sum = _cute_grouped_reduce_shared_two_stage(
         local_sum,
+        "sum",
         cutlass.Float32(0.0),
         lane_var,
         lane_var,
@@ -925,23 +1047,35 @@ def _cute_grouped_reduce_cluster_online_pair_body(
             lane32,
         )
     cute.arch.mbarrier_wait(mbar_ptr, phase=0)
-    # Warp-parallel fold: each lane owns one received pair, two warp
-    # reductions combine them.  A serial constexpr fold would batch
-    # ``cluster_n`` LDS.128 loads into one register burst (32 registers at
-    # cluster_n=16) right where the cached exp values already peak the
-    # live set — this keeps the fold's register profile flat.
-    lane_in_warp = lane32 % 32
-    slot = lane_in_warp % cluster_n
-    pair_max = vals[2 * slot]
-    pair_sum = vals[2 * slot + 1]
-    if lane_in_warp >= cluster_n:
-        pair_max = -cutlass.Float32.inf
-        pair_sum = cutlass.Float32(0.0)
-    group_max = cute.arch.warp_reduction_max(pair_max, threads_in_group=32)
-    rescaled = pair_sum * cute.math.exp2(
-        (pair_max - group_max) * scale, fastmath=fastmath
-    )
-    group_sum = cute.arch.warp_reduction_sum(rescaled, threads_in_group=32)
+    if cutlass.const_expr(cluster_n <= 8):
+        # Serial fold over the received pairs: no shuffles, and the small
+        # LDS burst (<= 8 pairs) stays under the live-set peak.
+        group_max = vals[0]
+        for w in cutlass.range_constexpr(1, cluster_n):
+            group_max = cute.arch.fmax(group_max, vals[2 * w])
+        group_sum = cutlass.Float32(0.0)
+        for w in cutlass.range_constexpr(cluster_n):
+            group_sum = group_sum + vals[2 * w + 1] * cute.math.exp2(
+                (vals[2 * w] - group_max) * scale, fastmath=fastmath
+            )
+    else:
+        # cluster_n = 16: warp-parallel fold — each lane owns one received
+        # pair, two warp reductions combine them.  At this width a serial
+        # constexpr fold batches the 16 pair loads into one register burst
+        # (32 registers) right where the cached exp values already peak
+        # the live set; the warp shuffles keep the register profile flat.
+        lane_in_warp = lane32 % 32
+        slot = lane_in_warp % cluster_n
+        pair_max = vals[2 * slot]
+        pair_sum = vals[2 * slot + 1]
+        if lane_in_warp >= cluster_n:
+            pair_max = -cutlass.Float32.inf
+            pair_sum = cutlass.Float32(0.0)
+        group_max = cute.arch.warp_reduction_max(pair_max, threads_in_group=32)
+        rescaled = pair_sum * cute.math.exp2(
+            (pair_max - group_max) * scale, fastmath=fastmath
+        )
+        group_sum = cute.arch.warp_reduction_sum(rescaled, threads_in_group=32)
     return group_max, group_sum
 
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -3265,14 +3265,17 @@ class ConfigSpec:
                     fields["cute_cluster_n"] = EnumFragment(choices=(1, 2, 4, 8, 16))
                 # Minimum resident CTAs per SM (ptxas ``minnctapersm``):
                 # caps registers per thread so more CTAs fit, trading
-                # spills for occupancy.  0 leaves ptxas free.
+                # spills for occupancy.  0 leaves ptxas free.  6 is a
+                # hard squeeze (at 128 threads it caps registers at 85 ->
+                # 24 warps/SM); measured on B200 softmax rows, one extra
+                # resident CTA beats ~10 spilled registers.
                 if (
                     self.supports_config_key("cute_min_blocks_per_mp")
                     and len(self.cute_lane_layouts) > 0
                     and not self.matmul_facts
                 ):
                     fields["cute_min_blocks_per_mp"] = EnumFragment(
-                        choices=(0, 1, 2, 3, 4)
+                        choices=(0, 1, 2, 3, 4, 6)
                     )
             if (
                 not self.cute_flash_search_enabled

--- a/test/test_cute_cluster_online_pair.py
+++ b/test/test_cute_cluster_online_pair.py
@@ -167,6 +167,24 @@ class TestCuteClusterOnlinePair(TestCase):
         torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-3)
         self.assertNotIn("fastmath=True", code)
 
+    def test_serial_block_reduce_routing(self) -> None:
+        """Pin the serial-vs-two-stage dispatch contract: the cheap serial
+        cross-warp combine only serves single whole-CTA groups of 2..8
+        warps; everything else must keep the two-stage form."""
+        from helion._compiler.cute.reduce_helpers import _use_serial_block_reduce
+
+        self.assertTrue(_use_serial_block_reduce(1, 128, 1))
+        self.assertTrue(_use_serial_block_reduce(1, 256, 1))
+        # 16 warps: serial chain outgrows the two-stage shuffle cost.
+        self.assertFalse(_use_serial_block_reduce(1, 512, 1))
+        # single warp: the warp path handles it without shared memory.
+        self.assertFalse(_use_serial_block_reduce(1, 32, 1))
+        # pre-grouped or multi-group reductions keep the two-stage form.
+        self.assertFalse(_use_serial_block_reduce(2, 128, 1))
+        self.assertFalse(_use_serial_block_reduce(1, 128, 4))
+        # non-warp-multiple spans keep the two-stage form.
+        self.assertFalse(_use_serial_block_reduce(1, 48, 1))
+
     def test_single_site_keeps_two_exchange_form(self) -> None:
         """A cluster kernel without the (max, sum-of-exp) pair keeps the
         plain per-site cluster exchange."""


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3515
 * #3514
 * #3513
 * #3512
 * #3511
 * #3510
 * #3509
 * __->__#3498
 * #3497
 * #3496
 * #3495
 * #3494


--- --- ---

[cutedsl] Serial-smem block reduce and minnctapersm occupancy squeeze for whole-CTA row reductions

Two changes that close the last gap to quack on big softmax rows (B200):

1. Serial cross-warp combine for whole-CTA groups with <= 8 warps: warp
   reduce -> lane0 writes SMEM -> one sync -> every thread folds the warp
   partials serially, replacing the two-stage form's second shuffle
   reduce and its guards (~5 SHFL + WARPSYNC per site; SASS for the
   65536-row softmax kernel drops 848 -> 672 instructions).  Routed
   transparently in the shared-reduce dispatcher (pre==1, group_count==1),
   so every cute reduction call site benefits; two-stage remains for
   pre>1 / multi-group / >8-warp shapes.  The cluster online-pair helper
   uses the same route for its CTA sum and folds received pairs serially
   at cluster_n <= 8.  4096/8192 rows flipped to a cluster-free
   T128 winner on the strength of this alone (1.044 -> 1.069, 1.021 ->
   1.040 vs quack).

2. cute_min_blocks_per_mp gains choice 6: at 128 threads that caps
   registers at 85 -> 6 CTAs/SM (24 warps), and ~10 spilled registers
   cost less than the missing CTA on memory-bound rows (65536:
   T128/CL8/mb6 4816-4861 vs quack 4777-4796 interleaved; previously
   0.978 at mb2/95 regs/5 CTAs, ncu 28.3% vs quack 34.2% occupancy).
   The wide-cluster seed heuristic now prefers 64-element/thread
   geometries (T128 first, then T256 for rows too big for cluster 16 x
   128 threads) and seeds mb = 768 // threads to start the search at
   that occupancy point.

Cold full autotune finds the new winners on its own: all 8 benchmark
shapes now measure at-or-above quack (geomean 1.034), including the
three that were reproducibly behind (65536 1.007, 131072 1.036,
262144 1.004; interleaved ABAB verification for every shape within 2%
of the bar).