### PR TITLE
[Pallas] Preserve scalar HBM addresses in device loops

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -753,10 +753,19 @@ def _generated_index_code(
         )
 
     if isinstance(pattern, TensorIndexPattern):
+        # A surrounding DMA loop has already selected this scalar-addressed
+        # HBM window. Index the staged VMEM window at its local scalar slot
+        # instead of applying the global scalar address a second time.
+        if in_pipeline and pipeline_scalar_indices_local and pattern.index_ndim == 0:
+            return "0"
         if tensor_indices_are_scalars:
             return _index_expr_from_ast(state, subscript_index, ast_subscripts)
         if pattern.index_ndim == 0:
             assert isinstance(idx, torch.Tensor)
+            from helion._compiler.host_function import HostFunction
+
+            if idx not in HostFunction.current().tensor_to_origin:
+                return _index_expr_from_ast(state, subscript_index, ast_subscripts)
             scalar_arg = state.device_function.tensor_arg(idx)
             return f"{scalar_arg.name}[0]"
         from helion._compiler.pallas.tensorcore_plan import TENSORCORE_PLAN_META

--- a/helion/_compiler/pallas/tensorcore_plan.py
+++ b/helion/_compiler/pallas/tensorcore_plan.py
@@ -161,6 +161,16 @@ def build_dma_access_spec(
         not isinstance(index_access, MemoryAccess)
         or index_access.node is not index_node
     ):
+        from ...language import memory_ops
+
+        # Indirect DMA planning requires a vector metadata load. A scalar
+        # computed inside the device program is a direct Ref address instead.
+        if (
+            index_node.op != "call_function"
+            or index_node.target is not memory_ops.load
+            or len(index_node.args) < 2
+        ):
+            return None
         index_access = build_pallas_memory_access(index_node)
     index = memory_access_value(index_access)
     if (

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -642,6 +642,84 @@ def _classify_loop_tensors(
     return loaded_tensors, stored_tensors
 
 
+def _scalar_address_expr(
+    value: object,
+    *,
+    state: CodegenState,
+    captured_exprs: dict[torch.fx.Node, str],
+) -> str | None:
+    """Render a scalar HBM address captured by an inner device loop."""
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, torch.SymInt):
+        return state.device_function.literal_expr(value)
+    if not isinstance(value, torch.fx.Node):
+        return None
+    if value.op == "placeholder":
+        return captured_exprs.get(value)
+    if value.op != "call_function":
+        return None
+    if value.target is _new_var and value.args:
+        return _scalar_address_expr(
+            value.args[0], state=state, captured_exprs=captured_exprs
+        )
+
+    from ...language import memory_ops
+
+    if value.target is memory_ops.load:
+        tensor_node, subscript = value.args[:2]
+        if not isinstance(tensor_node, torch.fx.Node):
+            return None
+        tensor = tensor_node.meta.get("val")
+        if not isinstance(tensor, torch.Tensor):
+            return None
+        if not isinstance(subscript, (list, tuple)) or len(subscript) != 1:
+            return None
+        index = _scalar_address_expr(
+            subscript[0], state=state, captured_exprs=captured_exprs
+        )
+        if index is None:
+            return None
+        name = state.device_function.tensor_arg(tensor).name
+        return f"{name}[{index}]"
+
+    binary_operators = {
+        operator.add: "+",
+        operator.floordiv: "//",
+        operator.mod: "%",
+        operator.mul: "*",
+        operator.sub: "-",
+        torch.ops.aten.add.Scalar: "+",
+        torch.ops.aten.add.Tensor: "+",
+        torch.ops.aten.mul.Scalar: "*",
+        torch.ops.aten.mul.Tensor: "*",
+        torch.ops.aten.sub.Scalar: "-",
+        torch.ops.aten.sub.Tensor: "-",
+    }
+    if value.target not in binary_operators or len(value.args) < 2:
+        return None
+    if (
+        value.target
+        in (
+            torch.ops.aten.add.Scalar,
+            torch.ops.aten.add.Tensor,
+            torch.ops.aten.sub.Scalar,
+            torch.ops.aten.sub.Tensor,
+        )
+        and value.kwargs.get("alpha", 1) != 1
+    ):
+        return None
+    lhs = _scalar_address_expr(
+        value.args[0], state=state, captured_exprs=captured_exprs
+    )
+    rhs = _scalar_address_expr(
+        value.args[1], state=state, captured_exprs=captured_exprs
+    )
+    if lhs is None or rhs is None:
+        return None
+    return f"({lhs}) {binary_operators[value.target]} ({rhs})"
+
+
 def _dma_plan_for_node(node: torch.fx.Node) -> DmaAccessPlan | None:
     from .tensorcore_plan import TENSORCORE_PLAN_META
 
@@ -3609,6 +3687,22 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
 
     loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
+    placeholders = list(graph_info.graph.find_nodes(op="placeholder"))
+    placeholder_exprs = {
+        placeholder: ast.unparse(arg)
+        for placeholder, arg in zip(placeholders, args, strict=True)
+    }
+    scalar_index_nodes: dict[int, torch.fx.Node] = {}
+    for _fake, load_node, _subscript in loaded_tensors.values():
+        load_indices = load_node.args[1]
+        if not isinstance(load_indices, (list, tuple)):
+            continue
+        for index_node in load_indices:
+            if not isinstance(index_node, torch.fx.Node):
+                continue
+            index_value = index_node.meta.get("val")
+            if isinstance(index_value, torch.Tensor) and index_value.ndim == 0:
+                scalar_index_nodes[id(index_value)] = index_node
     contiguous_ranges = _contiguous_range_patterns(loaded_tensors)
     begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
         state, block_ids, block_size_vars
@@ -4088,7 +4182,17 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                 from helion._utils import is_scalar_index
 
                 if is_scalar_index(idx_meta):
-                    offset_expr = state.device_function.literal_expr(idx_meta)
+                    offset_expr = None
+                    if isinstance(idx_meta, torch.Tensor):
+                        index_node = scalar_index_nodes.get(id(idx_meta))
+                        if index_node is not None:
+                            offset_expr = _scalar_address_expr(
+                                index_node,
+                                state=state,
+                                captured_exprs=placeholder_exprs,
+                            )
+                    if offset_expr is None:
+                        offset_expr = state.device_function.literal_expr(idx_meta)
                     hbm_parts.append(
                         offset_expr if resident_source else f"pl.ds({offset_expr}, 1)"
                     )

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2536,6 +2536,70 @@ class TestPallas(TestCase):
         expected[2] = values
         torch.testing.assert_close(result, expected)
 
+    def test_computed_scalar_tensor_index_store(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def computed_scalar_tensor_index_store(
+            values: torch.Tensor, output_row: torch.Tensor
+        ) -> torch.Tensor:
+            m, n = values.size()
+            out = torch.zeros([4, m, n], dtype=values.dtype, device=values.device)
+            row = (output_row[0] + 1) % 4
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[row, tile_m, tile_n] = values[tile_m, tile_n]
+            return out
+
+        values = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        output_row = torch.tensor([2], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            computed_scalar_tensor_index_store,
+            (values, output_row),
+            block_sizes=[8, 128],
+        )
+
+        expected = torch.zeros(4, 8, 128, device=DEVICE)
+        expected[3] = values
+        torch.testing.assert_close(result, expected)
+
+    def test_computed_scalar_selects_staged_matmul_weight(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def dynamic_weight_matmul(
+            values: torch.Tensor,
+            weights: torch.Tensor,
+            expert_ids: torch.Tensor,
+        ) -> torch.Tensor:
+            blocks, rows, k = values.size()
+            n = weights.size(2)
+            out = torch.empty(
+                [blocks, rows, n], dtype=values.dtype, device=values.device
+            )
+            for block in hl.grid(blocks):
+                expert = expert_ids[block]
+                for tile_m, tile_n in hl.tile([rows, n]):
+                    acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                    for tile_k in hl.tile(k):
+                        acc = torch.addmm(
+                            acc,
+                            values[block, tile_m, tile_k],
+                            weights[expert, tile_k, tile_n],
+                        )
+                    out[block, tile_m, tile_n] = acc
+            return out
+
+        values = torch.randn(3, 8, 256, device=DEVICE, dtype=torch.bfloat16)
+        weights = torch.randn(4, 256, 128, device=DEVICE, dtype=torch.bfloat16)
+        expert_ids = torch.tensor([2, 0, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            dynamic_weight_matmul,
+            (values, weights, expert_ids),
+            block_sizes=[8, 128, 128],
+            pallas_loop_type="fori_loop",
+        )
+
+        expected = torch.stack(
+            [values[0] @ weights[2], values[1] @ weights[0], values[2] @ weights[3]]
+        )
+        torch.testing.assert_close(result, expected)
+
     def test_tensor_index_atomic_add_raises(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def atomic_add_tensor_index(


### PR DESCRIPTION
Stacked PRs:
 * #3508
 * #3507
 * #3506
 * #3505
 * #3504
 * #3503
 * #3502
 * #3501
 * #3500
 * __->__#3499


--- --- ---

### [Pallas] Preserve scalar HBM addresses in device loops


A scalar loaded outside a tiled reduction can select one runtime HBM window:

```python
for block in hl.grid(blocks):
    expert = expert_ids[block]
    for tile_m, tile_n in hl.tile([rows, n]):
        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
        for tile_k in hl.tile(k):
            acc = torch.addmm(
                acc,
                values[block, tile_m, tile_k],
                weights[expert, tile_k, tile_n],
            )
```

The Pallas DMA planner previously assumed that every tensor-valued index was a
vector metadata load. A rank-zero scalar derived in the device program instead
reached `build_pallas_memory_access()` without a load subscript and failed with:

```text
ValueError: not enough values to unpack (expected 2, got 1)
```

Simply bypassing that candidate was also incorrect. The staged weight window
has length one on the selected expert axis, but generated code applied the
global expert index again:

```python
weight = jax.lax.dot_general(
    jax.nn.one_hot(expert, weights_buf.shape[0]),
    weights_buf,
    ...,
)
```

For any expert other than zero, that one-hot vector is all zero.

Treat rank-zero computed indices as direct Ref addresses. Preserve their source
expression when a device loop captures them, use that expression for the HBM
DMA window, and address the resulting one-element VMEM window at slot zero:

```python
copy = pltpu.make_async_copy(
    weights.at[pl.ds(expert, 1), pl.ds(k, block_k), pl.ds(n, block_n)],
    weights_buf,
    weights_sem,
)
copy.start()
copy.wait()
weight = weights_buf[0, :, :]
```

Vector tensor indices keep the existing one-hot or indirect-DMA lowering. This
adds no Helion API and is useful for grouped matmuls, embedding tables, and
other kernels that choose one HBM member at runtime.

Testing:

- Pallas interpret: the scalar-index store, computed scalar-index store, and
  dynamic-weight matmul tests pass numerically.
- TPU7x: the same three tests pass on real TPU tensors; the dynamic matmul
  selects experts `[2, 0, 3]` and matches PyTorch.
- `PATH=/home/dunfanlu/.venv/bin:$PATH ./lint.sh check` passes.