### PR TITLE
[Pallas] Keep scalar tensor axes out of VMEM extracts

### DIFF
--- a/helion/_compiler/pallas/vmem_scalar_load.py
+++ b/helion/_compiler/pallas/vmem_scalar_load.py
@@ -53,9 +53,12 @@ class VmemScalarLoad:
 
 def _is_scalar_index_pattern(pattern: object) -> bool:
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.plan_tiling import TensorIndexPattern
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
 
-    return isinstance(pattern, (ArbitraryIndexPattern, TileBeginWithOffsetPattern))
+    return isinstance(pattern, (ArbitraryIndexPattern, TileBeginWithOffsetPattern)) or (
+        isinstance(pattern, TensorIndexPattern) and pattern.index_ndim == 0
+    )
 
 
 def _is_32bit(dtype: torch.dtype) -> bool:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2600,6 +2600,38 @@ class TestPallas(TestCase):
         )
         torch.testing.assert_close(result, expected)
 
+    @skipIfPallasInterpret("JAX Pallas interpret cannot dynamically slice a VMEM Ref")
+    def test_scalar_tensor_index_with_minor_dimension_selects(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def select_member_and_minor_dimensions(
+            table: torch.Tensor,
+            member_ids: torch.Tensor,
+        ) -> torch.Tensor:
+            blocks = member_ids.size(0)
+            rows = table.size(1)
+            cols = table.size(3)
+            out = torch.empty(
+                [blocks, rows, cols], dtype=table.dtype, device=table.device
+            )
+            for block in hl.grid(blocks):
+                member = member_ids[block]
+                for tile_m, tile_n in hl.tile([rows, cols]):
+                    out[block, tile_m, tile_n] = table[member, tile_m, 0, tile_n, 1]
+            return out
+
+        table = torch.randn(4, 8, 2, 128, 2, device=DEVICE, dtype=torch.bfloat16)
+        member_ids = torch.tensor([2, 0, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            select_member_and_minor_dimensions,
+            (table, member_ids),
+            block_sizes=[8, 128],
+        )
+
+        expected = torch.stack(
+            [table[2, :, 0, :, 1], table[0, :, 0, :, 1], table[3, :, 0, :, 1]]
+        )
+        torch.testing.assert_close(result, expected)
+
     def test_tensor_index_atomic_add_raises(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def atomic_add_tensor_index(


### PR DESCRIPTION
Stacked PRs:
 * #3508
 * #3507
 * #3506
 * #3505
 * #3504
 * #3503
 * #3502
 * #3501
 * __->__#3500


--- --- ---

### [Pallas] Keep scalar tensor axes out of VMEM extracts


A rank-zero tensor index behaves like an ordinary scalar even when the same
load also selects minor dimensions:

```python
for block in hl.grid(member_ids.size(0)):
    member = member_ids[block]
    for tile_m, tile_n in hl.tile([rows, cols]):
        out[block, tile_m, tile_n] = table[
            member, tile_m, 0, tile_n, 1
        ]
```

Pallas stages the selected table window in VMEM before applying the final
minor-dimension selection. The scalar tensor axis was still counted as a live
window dimension, so the generated extract had one index too many:

```python
table[member, pl.ds(m, block_m), 0, pl.ds(n, block_n), :][:, :, :, 1]
```

JAX rejected that form because the first selection returns a rank-three value,
not rank four:

```text
IndexError: Too many indices: array is 3-dimensional, but 4 were indexed
```

Classify rank-zero `TensorIndexPattern` values as scalar dimensions in the
existing VMEM scalar-load lowering. The HBM selection is unchanged, while the
local extract now addresses only the dimensions that remain in the staged
window:

```python
table[member, pl.ds(m, block_m), 0, pl.ds(n, block_n), :][:, :, 1]
```

Rank-one and larger tensor indices keep the existing gather behavior. This
adds no Helion API.

Testing:

- TPU7x: `test_scalar_tensor_index_with_minor_dimension_selects` executes the
  five-dimensional load and matches PyTorch numerically for members
  `[2, 0, 3]`.
- The test is skipped in Pallas interpret because JAX interpret cannot
  dynamically slice the VMEM Ref used by this valid TPU lowering.
- The two-rank TorchTPU fused-MoE prototype passes under
  `torch.compile(backend="tpu", fullgraph=True)` with exact repeated outputs.
- `ruff format --check` and `ruff check --no-fix` pass.
