### PR TITLE
[Pallas] Lower static prefix sums with vector shifts

### DIFF
--- a/helion/_compiler/pallas/_codegen_modules.py
+++ b/helion/_compiler/pallas/_codegen_modules.py
@@ -19,5 +19,6 @@ from . import distributed_ops  # noqa: F401
 from . import gelu_tanh_approx  # noqa: F401
 from . import matmul_ops  # noqa: F401
 from . import memory_ops  # noqa: F401
+from . import scan_ops  # noqa: F401
 from . import tracing_ops  # noqa: F401
 from . import view_ops  # noqa: F401

--- a/helion/_compiler/pallas/scan_ops.py
+++ b/helion/_compiler/pallas/scan_ops.py
@@ -1,0 +1,90 @@
+"""Pallas code generation for prefix scans."""
+
+from __future__ import annotations
+
+import operator
+from typing import TYPE_CHECKING
+from typing import cast
+
+import torch
+
+from ... import exc
+from ...language import _decorators
+from ...language.scan_ops import _associative_scan
+from ..ast_extension import expr_from_string
+from ..ast_extension import statement_from_string
+from ..compile_environment import CompileEnvironment
+
+if TYPE_CHECKING:
+    import ast
+
+    from ..device_ir import HelperFunctionGraphInfo
+    from ..inductor_lowering import CodegenState
+
+
+def _is_add_scan(helper: HelperFunctionGraphInfo) -> bool:
+    add_targets = (
+        operator.add,
+        torch.add,
+        torch.ops.aten.add.Tensor,
+        torch.ops.aten.add.Scalar,
+    )
+    calls = [node for node in helper.graph.nodes if node.op == "call_function"]
+    return len(calls) == 1 and calls[0].target in add_targets
+
+
+@_decorators.codegen(_associative_scan, "pallas")
+def _(state: CodegenState) -> ast.AST:
+    from ..device_ir import HelperFunctionGraphInfo
+
+    combine_graph_id = cast("int", state.proxy_arg(0))
+    dim = cast("int", state.proxy_arg(2))
+    reverse = bool(state.proxy_arg(3))
+    is_tuple_input = bool(state.proxy_arg(4))
+    if is_tuple_input:
+        raise exc.BackendUnsupported("pallas", "tuple associative_scan input")
+
+    helper = state.get_graph(combine_graph_id)
+    assert isinstance(helper, HelperFunctionGraphInfo)
+    if not _is_add_scan(helper):
+        raise exc.BackendUnsupported("pallas", "non-add associative_scan")
+
+    fx_node = state.fx_node
+    if fx_node is None:
+        raise exc.BackendUnsupported("pallas", "associative_scan without FX node")
+    value = fx_node.meta.get("val")
+    if not isinstance(value, torch.Tensor):
+        raise exc.BackendUnsupported("pallas", "associative_scan input")
+    if dim < 0:
+        dim += value.ndim
+    if dim != value.ndim - 1:
+        raise exc.BackendUnsupported("pallas", "associative_scan on a non-last axis")
+
+    extent = value.shape[dim]
+    if isinstance(extent, torch.SymInt):
+        extent = CompileEnvironment.current().size_hint(extent)
+    if not isinstance(extent, int):
+        raise exc.BackendUnsupported("pallas", "dynamic associative_scan extent")
+
+    result = state.codegen.device_function.new_var("scan")
+    state.codegen.add_statement(
+        statement_from_string(f"{result} = {{value}}", value=state.ast_arg(1))
+    )
+    offset = 1
+    while offset < extent:
+        next_result = state.codegen.device_function.new_var("scan")
+        combined = f"jnp.add({result}[..., :-{offset}], {result}[..., {offset}:])"
+        if reverse:
+            expression = (
+                f"jnp.concatenate(({combined}, {result}[..., -{offset}:]), axis=-1)"
+            )
+        else:
+            expression = (
+                f"jnp.concatenate(({result}[..., :{offset}], {combined}), axis=-1)"
+            )
+        state.codegen.add_statement(
+            statement_from_string(f"{next_result} = {expression}")
+        )
+        result = next_result
+        offset *= 2
+    return expr_from_string(result)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -854,6 +854,19 @@ def _topk_pallas_kernel(x: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Te
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def _prefix_sum_pallas_kernel(
+    x: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    forward = torch.empty_like(x)
+    reverse = torch.empty_like(x)
+    for _program in hl.grid(1):
+        values = x[:]
+        forward[:] = torch.cumsum(values, dim=-1)
+        reverse[:] = hl.cumsum(values, dim=-1, reverse=True)
+    return forward, reverse
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def _constant_pad_pallas_kernel(x: torch.Tensor) -> torch.Tensor:
     """F.pad -> aten.constant_pad_nd -> jnp.pad on the pallas backend (pad the
     lane dim, mirroring the spec-decode sampler's in-kernel output padding)."""
@@ -880,6 +893,21 @@ def _constant_pad_neg_inf_pallas_kernel(x: torch.Tensor) -> torch.Tensor:
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
+    def test_prefix_sum(self) -> None:
+        x = torch.arange(256, device=DEVICE, dtype=torch.int32) % 7
+        _code, (forward, reverse) = code_and_output(
+            _prefix_sum_pallas_kernel,
+            (x,),
+            block_sizes=[],
+        )
+        torch.testing.assert_close(forward, torch.cumsum(x, dim=-1).to(x.dtype))
+        torch.testing.assert_close(
+            reverse,
+            torch.flip(torch.cumsum(torch.flip(x, dims=(-1,)), dim=-1), dims=(-1,)).to(
+                x.dtype
+            ),
+        )
+
     def test_cat_columns(self) -> None:
         x = torch.randn(128, 64, device=DEVICE, dtype=torch.bfloat16)
         y = torch.randn(128, 64, device=DEVICE, dtype=torch.bfloat16)


### PR DESCRIPTION
Stacked PRs:
 * #3508
 * #3507
 * #3506
 * #3505
 * #3504
 * #3503
 * #3502
 * __->__#3501


--- --- ---

### [Pallas] Lower static prefix sums with vector shifts


Pallas had no code generation for Helion's existing associative-scan operation,
so a source kernel using `torch.cumsum` failed before it could generate JAX:

```python
for _program in hl.grid(1):
    counts = torch.nn.functional.one_hot(ids[:], expert_count).sum(dim=0)
    starts = torch.cumsum(counts, dim=-1) - counts
```

The failure was:

```text
BackendImplementationMissing: codegen for API function _associative_scan
```

Lower single-tensor additive scans over a static last axis with a
Hillis-Steele prefix sum. Each stage combines values separated by a
power-of-two offset. The generated Pallas/JAX is ordinary vector slicing,
addition, and concatenation:

```python
scan = counts
scan_1 = jnp.concatenate(
    (scan[..., :1], jnp.add(scan[..., :-1], scan[..., 1:])), axis=-1
)
scan_2 = jnp.concatenate(
    (scan_1[..., :2], jnp.add(scan_1[..., :-2], scan_1[..., 2:])), axis=-1
)
```

The same lowering handles reverse prefix sums by preserving the trailing
window at each stage. Tuple scans, non-add combine functions, dynamic extents,
and non-last axes remain explicitly unsupported.

The numerical test executes forward and reverse 256-element prefix sums and
compares every element with PyTorch. It passes in Pallas interpret mode and on
an actual TPU7x device.

Validation:

```text
HELION_BACKEND=pallas HELION_PALLAS_INTERPRET=1 \
  python -m pytest -q test/test_pallas.py::TestPallas::test_prefix_sum
1 passed

HELION_BACKEND=pallas HELION_AUTOTUNE_EFFORT=none \
  python -m pytest -q test/test_pallas.py::TestPallas::test_prefix_sum
1 passed on TPU7x

ruff check helion/_compiler/pallas/scan_ops.py test/test_pallas.py
All checks passed!
```
