### PR TITLE
[Pallas] Make decoration capture normalization Dynamo-safe

### DIFF
--- a/helion/runtime/pallas/_tpu_compile_capture.py
+++ b/helion/runtime/pallas/_tpu_compile_capture.py
@@ -221,18 +221,32 @@ def _build_decoration_op(
         # Scalars are constexpr (compile-time constants for the Pallas kernel);
         # otherwise Helion materializes them as device buffers that orphan under
         # capture (torch_tpu aborts: "argument not provided").
-        return tuple(
-            constexpr(a) if k is not None else a
-            for a, k in zip(args, kinds, strict=True)
-        )
+        folded = []
+        for arg, kind in zip(args, kinds, strict=True):
+            if kind is None:
+                folded.append(arg)
+            else:
+                folded.append(constexpr(arg))
+        return tuple(folded)
 
     # validate=True: the AST eligibility check can't see view-aliasing or in-place
     # methods, so the fake re-validates per call and raises a clean compile error.
     fake, impl = _fake_and_impl(kernel, n_out, fold, validate=True)
     op = _define_op(kernel, decl, n_out, fake, impl)
+    parameters = tuple(kernel.signature.parameters.values())
+
+    def normalize_positional(args: tuple[Any, ...]) -> tuple[Any, ...]:
+        if len(args) == len(parameters):
+            return args
+        normalized = list(args)
+        for parameter in parameters[len(args) :]:
+            if parameter.default is inspect.Parameter.empty:
+                raise TypeError(f"missing required argument: {parameter.name}")
+            normalized.append(parameter.default)
+        return tuple(normalized)
 
     def captured(args: tuple[Any, ...]) -> object:
-        return op(*kernel.normalize_args(*args))
+        return op(*normalize_positional(args))
 
     return captured
 

--- a/test/test_compile_capture.py
+++ b/test/test_compile_capture.py
@@ -218,3 +218,15 @@ class TestCompileCaptureRoundtrip(unittest.TestCase):
             x = torch.randn(m, n, device=DEVICE)
             y = torch.randn(m, n, device=DEVICE)
             torch.testing.assert_close(captured((x, y)), _cap_add(x, y))
+
+    def test_captured_callable_is_dynamo_traceable(self) -> None:
+        captured = register_decoration_op(_cap_add)
+        self.assertIsNotNone(captured)
+
+        def invoke(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return captured((x, y))
+
+        compiled = torch.compile(invoke, backend="eager", fullgraph=True)
+        x = torch.randn(16, 16, device=DEVICE)
+        y = torch.randn(16, 16, device=DEVICE)
+        torch.testing.assert_close(compiled(x, y), x + y)


### PR DESCRIPTION
Stacked PRs:
 * #3508
 * #3507
 * #3506
 * #3505
 * #3504
 * #3503
 * __->__#3502


--- --- ---

### [Pallas] Make decoration capture normalization Dynamo-safe


A Pallas kernel can be registered as a Torch custom op so an outer
`torch.compile` graph treats the launch as one opaque operation:

```python
@helion.kernel(backend="pallas", static_shapes=True)
def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
    out = torch.empty_like(x)
    for tile in hl.tile(out.size()):
        out[tile] = x[tile] + y[tile]
    return out

captured = register_decoration_op(add)
result = torch.compile(lambda x, y: captured((x, y)), fullgraph=True)(x, y)
```

The capture wrapper previously normalized each invocation by calling back
through the `Kernel` object:

```python
return op(*kernel.normalize_args(*args))
```

Dynamo cannot inspect that Python object, so tracing failed before Pallas code
was generated:

```text
torch._dynamo.exc.Unsupported: Unsupported python_type() call
HelionKernelVariable() does not implement python_type()
```

Precompute the parameter list when registering the custom op and normalize
positional arguments with tuple/list operations that Dynamo can trace:

```python
parameters = tuple(kernel.signature.parameters.values())
...
return op(*normalize_positional(args))
```

There was no old Pallas body because capture stopped first. After this change,
the same Helion kernel reaches the normal Pallas lowering:

```python
value = jnp.add(x_ref[...], y_ref[...])
out_ref[...] = value
```

The numerical test runs the captured callable through a full-graph
`torch.compile` invocation and compares its result with `x + y`.
