### PR TITLE
[Pallas] Capture process group names in Torch graphs

### DIFF
--- a/helion/runtime/pallas/_tpu_compile_capture.py
+++ b/helion/runtime/pallas/_tpu_compile_capture.py
@@ -28,6 +28,7 @@ import torch
 from ..._compiler._dynamo.variables import _detect_mutated_inputs
 from ..._compiler._dynamo.variables import infer_output_spec
 from ...language import constexpr
+from ...language.constexpr import ProcessGroupName
 
 if TYPE_CHECKING:
     from ..kernel import Kernel
@@ -40,7 +41,12 @@ _op_counter = 0
 _op_cache: dict[Any, Callable[..., Any] | None] = {}
 
 # Python scalar types that map directly to a torch.library schema type.
-_SCHEMA_TYPES: dict[type, str] = {float: "float", int: "int", bool: "bool"}
+_SCHEMA_TYPES: dict[type, str] = {
+    float: "float",
+    int: "int",
+    bool: "bool",
+    ProcessGroupName: "str",
+}
 
 # Sentinel: tells Kernel.__call__ to run its normal dispatch path.
 RUN_NORMAL = object()
@@ -223,7 +229,7 @@ def _build_decoration_op(
         # capture (torch_tpu aborts: "argument not provided").
         folded = []
         for arg, kind in zip(args, kinds, strict=True):
-            if kind is None:
+            if kind is None or kind is ProcessGroupName:
                 folded.append(arg)
             else:
                 folded.append(constexpr(arg))

--- a/test/test_compile_capture.py
+++ b/test/test_compile_capture.py
@@ -41,6 +41,19 @@ def _cap_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(
+    backend="pallas", static_shapes=True, config=helion.Config(block_sizes=[16])
+)
+def _cap_add_process_group(
+    x: torch.Tensor,
+    group_name: hl.ProcessGroupName,
+) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size()):
+        out[tile] = x[tile] + 1
+    return out
+
+
 def _body(src: str) -> list[ast.stmt]:
     return ast.parse(src).body
 
@@ -182,6 +195,12 @@ class TestDecorationSchema:
 
         assert _decoration_schema(_pallas_kernel(k, config=_C16)) == ([None, float], 2)
 
+    def test_process_group_name_uses_string_schema(self) -> None:
+        assert _decoration_schema(_cap_add_process_group) == (
+            [None, hl.ProcessGroupName],
+            1,
+        )
+
     def test_unannotated_return_is_ineligible(self) -> None:
         def k(x: torch.Tensor):  # no return annotation
             return x
@@ -230,3 +249,14 @@ class TestCompileCaptureRoundtrip(unittest.TestCase):
         x = torch.randn(16, 16, device=DEVICE)
         y = torch.randn(16, 16, device=DEVICE)
         torch.testing.assert_close(compiled(x, y), x + y)
+
+    def test_process_group_name_is_capturable(self) -> None:
+        captured = register_decoration_op(_cap_add_process_group)
+        self.assertIsNotNone(captured)
+
+        def invoke(x: torch.Tensor) -> torch.Tensor:
+            return captured((x, "test_process_group"))
+
+        compiled = torch.compile(invoke, backend="eager", fullgraph=True)
+        x = torch.randn(64, device=DEVICE)
+        torch.testing.assert_close(compiled(x), x + 1)


### PR DESCRIPTION
Stacked PRs:
 * #3508
 * #3507
 * #3506
 * #3505
 * #3504
 * __->__#3503


--- --- ---

### [Pallas] Capture process group names in Torch graphs


A distributed Helion kernel already selects its Torch process group through the
existing `hl.ProcessGroupName` annotation:

```python
@helion.kernel(backend="pallas", static_shapes=True, distributed=True)
def exchange(x: torch.Tensor, group_name: hl.ProcessGroupName) -> torch.Tensor:
    out = torch.empty_like(x)
    for tile in hl.tile(x.size()):
        out[tile] = x[tile] + 1
    return out
```

The TPU capture schema previously recognized only tensor and numeric scalar
arguments. Registration therefore skipped this kernel, and an outer
`torch.compile` call entered the fallback cache lookup instead of the custom
op:

```text
torch._dynamo.exc.Unsupported: Failed to trace builtin operator hash
  File "_tpu_compile_capture.py", line 265, in _signature
    hash(key)
```

Map the existing process-group annotation to a Torch custom-op `str` argument
and pass the raw string back to Helion when the op runs:

```python
if annotation is hl.ProcessGroupName:
    schema_type = "str"
...
kernel_args.append(arg)
```

There was no old Pallas body because custom-op registration was rejected. With
the string captured, the kernel reaches its normal Pallas lowering:

```python
value = jnp.add(x_ref[...], 1)
out_ref[...] = value
```

Distributed kernels still use logical device IDs in their Pallas body. The
captured name only selects the process group used by compilation and launch.
The numerical test invokes the captured kernel through a full-graph Dynamo
trace and compares the complete tensor with `x + 1`.
