### PR TITLE
[Pallas] Preserve TPU target metadata in Torch exports

### DIFF
--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -1333,18 +1333,41 @@ class _PallasInterpretCallable:
         return tuple(jax_results)
 
 
-def _ensure_cpu_tpu_info() -> None:
-    """Register a synthetic TpuInfo for ``"cpu"`` so that
-    ``emit_pipeline`` / ``fori_loop`` interpret paths don't fail.
+def _ensure_cpu_tpu_info(device_kind: str | None = None) -> None:
+    """Register TPU metadata for Pallas traces that use CPU placeholders.
+
+    Interpret mode uses a TPU7x-compatible default.  The direct TorchTPU
+    launcher passes the physical device kind so hardware-dependent Pallas
+    lowering still targets the attached TPU while JAX remains CPU-only.
     """
     try:
         from jax._src.pallas.mosaic.tpu_info import ChipVersion
+        from jax._src.pallas.mosaic.tpu_info import chip_version_from_device_kind
         from jax._src.pallas.mosaic.tpu_info import get_tpu_info_for_chip
         from jax._src.pallas.mosaic.tpu_info import registry
     except ImportError:
         return
-    if "cpu" not in registry:
-        registry["cpu"] = lambda: get_tpu_info_for_chip(ChipVersion.TPU_7X, 1)
+
+    if device_kind is None:
+        chip_version = ChipVersion.TPU_7X
+    else:
+        # TorchTPU calls the split-core TPU7 device "TPU v7", while JAX calls
+        # the same target "TPU7x".
+        pallas_device_kind = "TPU7x" if device_kind == "TPU v7" else device_kind
+        chip_version = chip_version_from_device_kind(pallas_device_kind)
+        if chip_version is None:
+            raise RuntimeError(f"Unsupported TorchTPU device: {device_kind}")
+    info = get_tpu_info_for_chip(chip_version, 1)
+    registry["cpu"] = lambda: info
+
+
+def _ensure_torch_tpu_cpu_export_info() -> None:
+    """Expose the physical TPU target to a CPU-only JAX export trace."""
+    from torch_tpu._internal.utils.hardware import (  # pyrefly: ignore[missing-import]
+        get_tpu_device_name,
+    )
+
+    _ensure_cpu_tpu_info(get_tpu_device_name())
 
 
 def _pallas_apply_ds_padding(
@@ -2065,6 +2088,8 @@ def _pallas_install_launcher_cache(
     )
     if interpret:
         _ensure_cpu_tpu_info()
+    else:
+        _ensure_torch_tpu_cpu_export_info()
 
     output_indices = _output_indices if _output_indices is not None else []
 
@@ -2705,6 +2730,8 @@ def _pallas_install_compact_launcher_cache(
     )
     if interpret:
         _ensure_cpu_tpu_info()
+    else:
+        _ensure_torch_tpu_cpu_export_info()
     output_indices = _output_indices if _output_indices is not None else []
 
     spec_args = args

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -88,6 +88,14 @@ def pallas_sigmoid(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_sign(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = torch.sign(x[tile])
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_pointwise_chain(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     for tile in hl.tile(out.size()):
@@ -1225,6 +1233,11 @@ class TestPallas(TestCase):
         args = (torch.randn(1024, device=DEVICE), torch.randn(1024, device=DEVICE))
         code, result = code_and_output(add_kernel, args, block_size=256)
         torch.testing.assert_close(result, args[0] + args[1])
+
+    def test_sign(self) -> None:
+        x = torch.linspace(-2, 2, 1024, device=DEVICE)
+        _, result = code_and_output(pallas_sign, (x,), block_size=256)
+        torch.testing.assert_close(result.cpu(), torch.sign(x).cpu())
 
     def test_add_large(self) -> None:
         args = (torch.randn(4096, device=DEVICE), torch.randn(4096, device=DEVICE))


### PR DESCRIPTION
Stacked PRs:
 * #3508
 * #3507
 * #3506
 * #3505
 * __->__#3504


--- --- ---

### [Pallas] Preserve TPU target metadata in Torch exports


Direct TorchTPU launch exports a Pallas program with JAX CPU placeholders.
Hardware-sensitive Mosaic lowering therefore saw the placeholder instead of
the attached TPU:

```python
@helion.kernel(backend="pallas", static_shapes=True)
def sign(x: torch.Tensor) -> torch.Tensor:
    out = torch.empty_like(x)
    for tile in hl.tile(out.size()):
        out[tile] = torch.sign(x[tile])
    return out
```

Before this change, export stopped before producing a Pallas program:

```text
ValueError: Unsupported TPU device kind: cpu
```

Read the physical device name from TorchTPU before installing either direct
launch cache, map TorchTPU's TPU v7 spelling to JAX's spelling, and register
that TpuInfo for the CPU placeholder trace. Interpret mode keeps its existing
TPU7x-compatible default.

The same source now generates and executes the expected Pallas expression:

```python
load = x_ref[...]
value = jnp.sign(load)
out_ref[...] = value
```

Numerical validation:
- Pallas interpret: `test/test_pallas.py::TestPallas::test_sign`
- TPU v7 direct TorchTPU launch: `test/test_pallas.py::TestPallas::test_sign`
