### PR TITLE
[Pallas] Support packed FP4 inputs in TorchTPU kernels

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -440,6 +440,10 @@ class Backend(abc.ABC):
         """Called during `type_propagation` when processing a `load` memory op on fake tensors"""
         return
 
+    def normalize_input_fake_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Return the tensor metadata used while tracing a kernel input."""
+        return tensor
+
     def fake_subscript_shape(
         self,
         tensor: torch.Tensor,

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -1327,6 +1327,7 @@ class CompileEnvironment:
             result = self.fake_mode.fake_tensor_converter.from_real_tensor(
                 self.fake_mode, tensor, shape_env=self.shape_env, source=source
             )
+        result = self.backend.normalize_input_fake_tensor(result)
         previous_source = self.input_sources.get(result)
         if previous_source is not None and previous_source != source:
             self._ambiguous_tensor_input_source_ids.add(id(result))

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -113,6 +113,7 @@ _TORCH_TO_JAX_DTYPE: dict[str, str] = {
     "torch.float8_e5m2": "jnp.float8_e5m2",
     "torch.float8_e5m2fnuz": "jnp.float8_e5m2fnuz",
     "torch.float8_e8m0fnu": "jnp.float8_e8m0fnu",
+    "torch.float4_e2m1fn_x2": "jnp.float4_e2m1fn",
 }
 
 
@@ -194,6 +195,20 @@ class PallasBackend(Backend):
         if key not in _TORCH_TO_JAX_DTYPE:
             raise ValueError(f"Unsupported dtype for Pallas backend: {dtype}")
         return _TORCH_TO_JAX_DTYPE[key]
+
+    def normalize_input_fake_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Trace packed FP4 inputs with their logical JAX shape.
+
+        Torch stores two E2M1 values in each element of
+        ``float4_e2m1fn_x2``, while TorchTPU presents those values to Pallas as
+        two separate elements on the last axis.  Matching that logical shape
+        during Helion tracing keeps indexing, tiling, and matmul dimensions in
+        the same coordinate system as the generated Pallas program.
+        """
+        if tensor.dtype != torch.float4_e2m1fn_x2 or tensor.ndim == 0:
+            return tensor
+        logical_shape = (*tensor.shape[:-1], tensor.shape[-1] * 2)
+        return torch.empty(logical_shape, dtype=tensor.dtype, device=tensor.device)
 
     def acc_type(self, dtype: torch.dtype) -> str:
         # Promote half-precision types to float32 for numerical stability

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -93,7 +93,8 @@ def dot(
 
     This operation performs matrix multiplication with inputs of various dtypes including
     float16, bfloat16, float32, int8, and FP8 formats (e4m3fn, e5m2). The computation is
-    performed with appropriate precision based on the input dtypes.
+    performed with appropriate precision based on the input dtypes. On Pallas,
+    a packed E2M1 RHS may use ``torch.float4_e2m1fn_x2``.
 
     Args:
         mat1: First matrix (2D or 3D tensor of torch.float16, torch.bfloat16, torch.float32, torch.int8, torch.float8_e4m3fn, or torch.float8_e5m2)
@@ -146,6 +147,8 @@ def _(
         torch.float8_e4m3fn,
         torch.float8_e5m2,
     )
+    if CompileEnvironment.current().backend_name == "pallas":
+        supported_dtypes += (torch.float4_e2m1fn_x2,)
 
     # Validate input types
     if mat1.dtype not in supported_dtypes:

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -79,6 +79,16 @@ def _is_torch_tensor_or_jax_array(x: object) -> TypeGuard[_TorchTensorOrJaxArray
     return hasattr(x, "shape") and hasattr(x, "dtype")
 
 
+def _pallas_logical_shape(tensor: _TorchTensorOrJaxArray) -> tuple[int, ...]:
+    """Return the logical shape exposed to a generated Pallas program."""
+    shape = tuple(int(size) for size in tensor.shape)
+    # Keep this helper free of torch references: it is shared by the direct
+    # TorchTPU launcher and the torch-free standalone JAX launcher slice.
+    if str(tensor.dtype) == "torch.float4_e2m1fn_x2" and shape:
+        return (*shape[:-1], shape[-1] * 2)
+    return shape
+
+
 def _pallas_make_block_spec(
     pl: object,
     jnp: object,
@@ -97,7 +107,7 @@ def _pallas_make_block_spec(
 
     if entry is None:
         ndim = tensor.ndim
-        full_shape = tuple(max(s, 1) for s in tensor.shape)
+        full_shape = tuple(max(s, 1) for s in _pallas_logical_shape(tensor))
 
         def index_map_full(*grid_args: object, _nd: int = ndim) -> tuple[object, ...]:
             # pyrefly: ignore[missing-attribute]
@@ -108,14 +118,15 @@ def _pallas_make_block_spec(
     block_shape_template, grid_dims = entry
     # Clamp to >= 1: empty tensors (zero-work grids) would otherwise produce
     # 0-sized block dims, which the interpret machinery divides by.
+    tensor_shape = _pallas_logical_shape(tensor)
     block_shape = tuple(
-        max(min(bs, tensor.shape[d]) if bs is not None else tensor.shape[d], 1)
+        max(min(bs, tensor_shape[d]) if bs is not None else tensor_shape[d], 1)
         for d, bs in enumerate(block_shape_template)
     )
     # Block indices past the last block are clamped, matching pallas_call's
     # window clamping (index maps may run past the end, e.g. offset reads).
     max_block_index = tuple(
-        max(-(-tensor.shape[d] // bs), 1) - 1 for d, bs in enumerate(block_shape)
+        max(-(-tensor_shape[d] // bs), 1) - 1 for d, bs in enumerate(block_shape)
     )
 
     def _index_for_dim(
@@ -594,6 +605,12 @@ def _jax_placeholder_for_tensor(t: torch.Tensor) -> object:
     on CPU).
     """
     import jax
+
+    if t.dtype == torch.float4_e2m1fn_x2:
+        import jax.numpy as jnp
+
+        return jax.ShapeDtypeStruct(_pallas_logical_shape(t), jnp.float4_e2m1fn)
+
     from torch._inductor.runtime.runtime_utils import torch_dtype_to_jax_runtime
 
     jax_dtype = torch_dtype_to_jax_runtime(t.dtype)
@@ -645,6 +662,7 @@ def _pallas_jnp_dtype_map() -> dict[str, object]:
         "jnp.uint8": jnp.uint8,
         "jnp.bool_": jnp.bool_,
         "jnp.float8_e4m3fn": jnp.float8_e4m3fn,
+        "jnp.float4_e2m1fn": jnp.float4_e2m1fn,
     }
 
 
@@ -982,7 +1000,7 @@ def _pallas_apply_ds_padding_fast(
         a = args[arg_idx] if args_list is None else args_list[arg_idx]
         if not isinstance(a, torch.Tensor):
             continue
-        pad_amount = (-a.shape[dim]) % block_size + extra_pad
+        pad_amount = (-_pallas_logical_shape(a)[dim]) % block_size + extra_pad
         if pad_amount == 0:
             continue
         any_padding = True
@@ -1391,7 +1409,7 @@ def _pallas_apply_ds_padding(
         a = args_list[arg_idx]
         if not isinstance(a, torch.Tensor):
             continue
-        pad_amount = (-a.shape[dim]) % block_size + extra_pad
+        pad_amount = (-_pallas_logical_shape(a)[dim]) % block_size + extra_pad
         if pad_amount == 0:
             continue
         if arg_idx in output_set and arg_idx not in orig_output_tensors:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -153,6 +153,28 @@ def pallas_matmul_bf16(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_fp8_fp4_matmul(
+    x: torch.Tensor, weight: torch.Tensor, output_columns: int
+) -> torch.Tensor:
+    """Multiply FP8 activations by a packed E2M1 RHS on TPU."""
+    output_columns = hl.specialize(output_columns)
+    m, k = x.size()
+    n = output_columns
+    out = torch.empty([m, n], device=x.device, dtype=torch.float32)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(
+                x[tile_m, tile_k],
+                weight[tile_k, tile_n],
+                acc=acc,
+                out_dtype=torch.float32,
+            )
+        out[tile_m, tile_n] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_bmm(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
     b, m, k = A.size()
     b, k, n = B.size()
@@ -926,6 +948,52 @@ class TestPallas(TestCase):
         )
         self.assertIn("jnp.concatenate((", code)
         torch.testing.assert_close(result.cpu(), torch.cat((x, y), dim=1).cpu())
+
+    @skipIfPallasInterpret("packed FP4 execution requires a real TPU")
+    def test_fp8_fp4_matmul(self) -> None:
+        generator = torch.Generator().manual_seed(0)
+        m, k, n = 16, 256, 128
+        x_cpu = torch.randn(m, k, generator=generator).to(torch.float8_e4m3fn)
+        packed_cpu = torch.randint(
+            0,
+            256,
+            (k, n // 2),
+            generator=generator,
+            dtype=torch.uint8,
+        )
+        packed = packed_cpu.to(DEVICE)
+        weight = torch.empty_like(packed, dtype=torch.float4_e2m1fn_x2)
+        weight.copy_(packed.view(dtype=torch.float4_e2m1fn_x2))
+
+        _, result = code_and_output(
+            pallas_fp8_fp4_matmul,
+            (x_cpu.to(DEVICE), weight, n),
+            block_sizes=[16, 128, 256],
+        )
+
+        codes = torch.stack(
+            (packed_cpu & 0x0F, (packed_cpu >> 4) & 0x0F), dim=-1
+        ).reshape(k, n)
+        magnitude = codes & 0x07
+        decoded = torch.where(
+            magnitude < 4,
+            magnitude.float() * 0.5,
+            torch.where(
+                magnitude < 6,
+                magnitude.float() - 2,
+                magnitude.float() * 2 - 8,
+            ),
+        )
+        decoded = torch.where((codes & 0x08) == 0, decoded, -decoded)
+        expected = x_cpu.float() @ decoded
+        actual = result.cpu().float()
+        difference = (actual - expected).abs()
+        relative_mean = difference.mean() / expected.abs().mean().clamp_min(1e-6)
+        cosine = torch.nn.functional.cosine_similarity(
+            actual.flatten(), expected.flatten(), dim=0
+        )
+        self.assertLess(relative_mean.item(), 0.01)
+        self.assertGreater(cosine.item(), 0.999)
 
     def test_aligned_dynamic_window_uses_direct_hbm_dma(self) -> None:
         table = torch.randn(8, 512, device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION
Stacked PRs:
 * #3508
 * #3507
 * #3506
 * __->__#3505


--- --- ---

### [Pallas] Support packed FP4 inputs in TorchTPU kernels


Torch stores two E2M1 values in each `torch.float4_e2m1fn_x2` element, while
Pallas exposes them as separate logical elements. Helion previously rejected
this dtype in `hl.dot`, and its launcher described only the physical packed
shape.

The newly supported source pattern is:

```python
@helion.kernel(backend="pallas", static_shapes=True)
def fp8_fp4_matmul(x, packed_weight, n):
    out = torch.empty((x.size(0), n), device=x.device, dtype=torch.float32)
    for tile_m, tile_n in hl.tile(out.size()):
        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
        for tile_k in hl.tile(x.size(1)):
            acc = hl.dot(
                x[tile_m, tile_k],
                packed_weight[tile_k, tile_n],
                acc=acc,
                out_dtype=torch.float32,
            )
        out[tile_m, tile_n] = acc
    return out
```

Before this change, tracing stopped before Pallas code generation because
`torch.float4_e2m1fn_x2` was not a supported dot or Pallas input dtype. Treating
its physical `[K, N / 2]` shape as logical would also make the generated block
spec and dot dimensions inconsistent.

The Pallas backend now traces packed FP4 inputs using their logical last-axis
extent and maps the dtype to JAX E2M1. The launcher uses the same logical shape
for placeholders, block specs, and padding, so generated code receives an
ordinary E2M1 RHS:

```python
weight = jax.ShapeDtypeStruct((K, N), jnp.float4_e2m1fn)
acc = lax.dot_general(
    x_tile,
    weight_tile,
    dimension_numbers=(((1,), (0,)), ((), ())),
    preferred_element_type=jnp.float32,
)
```

Other backends retain their existing input metadata and dtype behavior.

Testing:

- `test_fp8_fp4_matmul` executes FP8 x packed-E2M1 matmul on real TPU tensors
  and compares it numerically with an explicitly decoded FP4 reference.
- The test passed on all 16 TPU7x ranks.
- `PATH=/home/dunfanlu/.venv/bin:$PATH ./lint.sh check` passes.
