### PR TITLE
[Pallas] Advance resident scalar indices in device loops

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -866,6 +866,8 @@ def _tile_begin_with_offset_pattern_code(
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.tile_strategy import DeviceLoopState
+    from helion._compiler.tile_strategy import EmitPipelineLoopState
+    from helion._compiler.tile_strategy import ForiLoopState
 
     assert isinstance(pattern, TileBeginWithOffsetPattern)
 
@@ -889,7 +891,10 @@ def _tile_begin_with_offset_pattern_code(
     assert isinstance(pattern.offset, int)
 
     loops = state.codegen.active_device_loops.get(block_id)
-    if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):
+    if loops and any(
+        isinstance(loop, (DeviceLoopState, EmitPipelineLoopState, ForiLoopState))
+        for loop in loops
+    ):
         offset = state.codegen.offset_var(block_id)
         if pattern.offset != 0:
             offset = f"{offset} + {pattern.offset}"

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -125,15 +125,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, grid_2d_pytorch(args[0], args[1]))
 
     @skipIfMetal("aten.addmm not yet registered for Metal backend")
-    @xfailIfPallas(
-        "Nested hl.grid + emit_pipeline corrupts output: only the first "
-        "hl.grid level becomes a pallas_call grid axis (sliced by BlockSpec); "
-        "subsequent hl.grid levels become outer emit_pipeline bodies whose "
-        "iteration index isn't bound to a stable name before inner bodies "
-        "shadow `_pipeline_indices`. Inner indexing falls back to literal 0 "
-        "for those dims, so only the (0, 0, ...) slot of the output is "
-        "correct."
-    )
     def test_grid_2d_idx_nested(self):
         @helion.kernel(static_shapes=True)
         def grid_2d_idx_nested(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2071,6 +2071,26 @@ class TestPallas(TestCase):
         self.assertIn("[pl.ds(1, 2), :, :]", code)
         torch.testing.assert_close(out, torch.full_like(out, 8.0))
 
+    def test_resident_fori_loop_scalar_index_uses_current_iteration(self) -> None:
+        """A scalar row index into a resident tensor advances with the loop."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def select_rows(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for _request in hl.grid(1):
+                for row in hl.tile(x.size(1), block_size=1):
+                    hl.store(out, [0, row.begin, slice(None)], x[0, row.begin, :] + 1)
+            return out
+
+        x = torch.arange(4 * 128, device=DEVICE, dtype=torch.float32).reshape(1, 4, 128)
+        _, actual = code_and_output(
+            select_rows,
+            (x,),
+            pallas_loop_type="fori_loop",
+            pallas_load_buffer_count=[1],
+        )
+        torch.testing.assert_close(actual, x + 1)
+
     def test_resident_subview_of_untiled_dimension(self) -> None:
         """A direct run may address any aligned dimension of the resident Ref."""
 

--- a/test/test_remote_copy.py
+++ b/test/test_remote_copy.py
@@ -298,6 +298,49 @@ def _pipeline_remote_copy(
 
 @helion.kernel(
     static_shapes=True,
+    config=helion.Config(
+        block_sizes=[],
+        pallas_loop_type="fori_loop",
+        pallas_load_buffer_count=[2, 1, 1, 1],
+    ),
+)
+def _nested_computed_row_remote_copy(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    peers: torch.Tensor,
+    valid_counts: torch.Tensor,
+) -> torch.Tensor:
+    """Send each row of a computed VMEM tile from a nested device loop."""
+    num_steps = hl.specialize(src.size(1))
+    num_rows = hl.specialize(src.size(2))
+    width = hl.specialize(src.size(3))
+    stage = torch.empty(
+        (num_rows, 1, width),
+        dtype=src.dtype,
+        device=src.device,
+    )
+    for _program in hl.grid(1):
+        hl.remote_barrier(peers[0, 0])
+        for step in hl.tile(num_steps, block_size=1):
+            valid_count = hl.load(valid_counts, [step.begin])
+            stage[:, 0, :] = hl.zeros([num_rows, width], dtype=stage.dtype)
+            if valid_count > 0:
+                stage[:, 0, :] = src[0, step.begin, :, :] + 1
+            for row in hl.tile(num_rows, block_size=1):
+                copy = hl.make_async_remote_copy(
+                    stage,
+                    [row.begin],
+                    peers[0, 0],
+                    dst=dst,
+                    dst_index=[0, step.begin, row.begin],
+                )
+                copy.start()
+                copy.wait()
+    return dst
+
+
+@helion.kernel(
+    static_shapes=True,
     config=helion.Config(block_sizes=[]),
 )
 def _computed_fp8_remote_copy(
@@ -1715,6 +1758,32 @@ def _remote_copy_torch_tpu_worker(rank: int, world_size: int, master_port: int) 
         result = gather_op(local_values, gathered, peers, slots)
         expected = torch.from_numpy(_expected_all_gather(world_size)).unsqueeze(1)
         assert result.shape == (world_size, 1, _GATHER_ROWS, _WIDTH)
+        torch.testing.assert_close(result.cpu(), expected)
+
+        rank_value = torch.tensor(rank * 1000, dtype=torch.float32, device=device)
+        steps = torch.arange(
+            _PIPELINE_STEPS, dtype=torch.float32, device=device
+        ).reshape(1, _PIPELINE_STEPS, 1, 1)
+        rows = torch.arange(_GATHER_ROWS, dtype=torch.float32, device=device).reshape(
+            1, 1, _GATHER_ROWS, 1
+        )
+        columns = torch.arange(_WIDTH, dtype=torch.float32, device=device).reshape(
+            1, 1, 1, _WIDTH
+        )
+        src = rank_value + steps * 100 + rows * 10 + columns
+        dst = torch.full(
+            (1, _PIPELINE_STEPS, _GATHER_ROWS, 1, _WIDTH),
+            -7,
+            dtype=torch.float32,
+            device=device,
+        )
+        peers = torch.tensor(
+            [[(rank + 1) % world_size]], dtype=torch.int32, device=device
+        )
+        valid_counts = torch.ones(_PIPELINE_STEPS, dtype=torch.int32, device=device)
+        result = _nested_computed_row_remote_copy(src, dst, peers, valid_counts)
+        previous_rank = (rank - 1) % world_size
+        expected = (src.cpu() - rank * 1000 + previous_rank * 1000 + 1).unsqueeze(-2)
         torch.testing.assert_close(result.cpu(), expected)
 
     run_checks()


### PR DESCRIPTION
Stacked PRs:
 * #3508
 * #3507
 * __->__#3506


--- --- ---

### [Pallas] Advance resident scalar indices in device loops


A tensor kept resident in VMEM can be indexed by a scalar tile inside a
generated `fori_loop` or emit-pipeline loop. For example:

```python
@helion.kernel(
    backend="pallas",
    static_shapes=True,
    config=helion.Config(
        pallas_loop_type="fori_loop",
        pallas_load_buffer_count=[1],
    ),
)
def add_one_per_row(x: torch.Tensor) -> torch.Tensor:
    out = torch.empty_like(x)
    for _batch in hl.grid(1):
        for row in hl.tile(x.size(1), block_size=1):
            out[0, row.begin, :] = x[0, row.begin, :] + 1
    return out
```

The Pallas index renderer previously advanced a scalar tile index only for a
`DeviceLoopState`. It did not recognize the Pallas-specific `ForiLoopState` or
`EmitPipelineLoopState`, so generated code reused row zero on every iteration:

```python
def loop_body(row, ...):
    value = x_ref[0, 0, :]
    out_ref[0, 0, :] = value + 1
```

Treat the two Pallas loop states as active device loops too. The generated body
now uses the current loop offset:

```python
def loop_body(row, ...):
    value = x_ref[0, row, :]
    out_ref[0, row, :] = value + 1
```

This fixes the shared resident-tensor indexing path rather than any one kernel.
Ordinary loads and stores, as well as remote-copy sources, use the corrected
index rendering.

Numerical validation covers a small resident row loop, the existing nested
`hl.grid` matrix multiplication, and a nested remote-copy consumer. Before the
change, the nested-grid test mismatches about 75% of its output; afterward it
passes on Pallas interpret and TPU7x, so its obsolete Pallas xfail is removed.
