### PR TITLE
[Pallas] Stage scalar-selected HBM panels locally

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -84,6 +84,7 @@ def load_expr(
         return emit_gather(state, plan.plan, active_name)
 
     from helion._compiler.device_function import PallasMemorySpace
+    from helion._compiler.pallas.plan_tiling import SCALAR_PANEL_HBM_LOAD
     from helion._compiler.pallas.plan_tiling import ContiguousRangeIndexPattern
 
     if (
@@ -94,6 +95,7 @@ def load_expr(
             or any(
                 isinstance(pattern, ContiguousRangeIndexPattern) for pattern in patterns
             )
+            or state.fx_node.meta.get(SCALAR_PANEL_HBM_LOAD, False)
         )
     ):
         return _hbm_load_expr(state, subscript, tensor, arg_name)

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -101,6 +101,7 @@ class DimensionTiling:
 
 REMOTE_SRC_INDEXING_PATTERNS = "pallas_remote_src_indexing_patterns"
 REMOTE_DST_INDEXING_PATTERNS = "pallas_remote_dst_indexing_patterns"
+SCALAR_PANEL_HBM_LOAD = "pallas_scalar_panel_hbm_load"
 
 
 def plan_tiling(
@@ -115,6 +116,80 @@ def plan_tiling(
             graph_info, graph_lookup, parent_ids
         )
         _analyze_indexing_expressions(graph_info, config, local_access_keys)
+    _plan_scalar_panel_hbm_loads(graphs)
+
+
+def _plan_scalar_panel_hbm_loads(graphs: list[GraphInfo]) -> None:
+    """Stage aligned read-only panels selected by device scalar indices."""
+    from ...language import memory_ops
+    from ...language.atomic_ops import ATOMIC_OPS
+    from ..device_function import DeviceFunction
+    from ..device_function import PallasMemorySpace
+    from ..host_function import HostFunction
+    from .dma import is_tpu_dma_aligned_shape
+
+    accesses: dict[str | int, list[tuple[torch.Tensor, torch.fx.Node, bool]]] = {}
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            if node.op != "call_function" or node.target not in (
+                ATOMIC_OPS | {memory_ops.load, memory_ops.store}
+            ):
+                continue
+            tensor_node = node.args[0] if node.args else None
+            tensor = (
+                tensor_node.meta.get("val")
+                if isinstance(tensor_node, torch.fx.Node)
+                else None
+            )
+            if not isinstance(tensor, torch.Tensor):
+                continue
+            accesses.setdefault(_tensor_origin_key(tensor), []).append(
+                (tensor, node, node.target is memory_ops.load)
+            )
+
+    device_fn = DeviceFunction.current()
+    host_inputs = HostFunction.current().tensor_to_origin
+    scalar_patterns = (ArbitraryIndexPattern, TileBeginWithOffsetPattern)
+
+    def is_scalar_pattern(pattern: IndexingPattern) -> bool:
+        return isinstance(pattern, scalar_patterns) or (
+            isinstance(pattern, TensorIndexPattern) and pattern.index_ndim == 0
+        )
+
+    for tensor_accesses in accesses.values():
+        if not all(is_load for _tensor, _node, is_load in tensor_accesses):
+            continue
+        candidates: list[tuple[torch.Tensor, torch.fx.Node]] = []
+        for tensor, node, _is_load in tensor_accesses:
+            patterns = node.meta.get("indexing_patterns")
+            value = node.meta.get("val")
+            if (
+                tensor not in host_inputs
+                or not isinstance(patterns, list)
+                or not isinstance(value, torch.Tensor)
+                or not value.shape
+                or not all(isinstance(size, int) for size in value.shape)
+            ):
+                break
+            if not any(is_scalar_pattern(pattern) for pattern in patterns):
+                break
+            if not all(
+                is_scalar_pattern(pattern)
+                or (
+                    isinstance(pattern, ArbitrarySlicePattern)
+                    and pattern.slice == slice(None)
+                )
+                for pattern in patterns
+            ):
+                break
+            shape = cast("tuple[int, ...]", tuple(value.shape))
+            if not is_tpu_dma_aligned_shape(shape, tensor.dtype):
+                break
+            candidates.append((tensor, node))
+        else:
+            for tensor, node in candidates:
+                device_fn.pallas_memory_space[id(tensor)] = PallasMemorySpace.HBM
+                node.meta[SCALAR_PANEL_HBM_LOAD] = True
 
 
 def _tensor_origin_key(tensor: torch.Tensor) -> str | int:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -677,6 +677,40 @@ def pallas_aligned_dynamic_window(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_scalar_selected_panel(
+    table: torch.Tensor, panel_ids: torch.Tensor
+) -> torch.Tensor:
+    rows = panel_ids.size(0)
+    out = torch.empty([rows, 8, 128], dtype=table.dtype, device=table.device)
+    for row in hl.grid(rows):
+        panel = panel_ids[row]
+        out[row, :, :] = table[panel, :, :] + 1
+    return out
+
+
+@helion.kernel(
+    backend="pallas",
+    static_shapes=True,
+    config=helion.Config(
+        pallas_loop_type="fori_loop",
+        pallas_load_buffer_count=[2, 1],
+    ),
+)
+def pallas_scalar_selected_panel_loop(
+    table: torch.Tensor, panel_ids: torch.Tensor
+) -> torch.Tensor:
+    rows = panel_ids.size(0)
+    out = torch.empty([rows, 8, 128], dtype=table.dtype, device=table.device)
+    resident_ids = torch.empty([rows], dtype=torch.int32, device=panel_ids.device)
+    for _program in hl.grid(1):
+        resident_ids[:] = hl.load(panel_ids, [slice(None)])
+        for row in hl.tile(rows, block_size=1):
+            panel = hl.load(resident_ids, [row.begin])
+            out[row, :, :] = table[panel, :, :][None, :, :] + 1
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_aligned_row_window(x: torch.Tensor) -> torch.Tensor:
     rows = hl.specialize(x.size(0))
     out = torch.empty([rows, 128], dtype=x.dtype, device=x.device)
@@ -1007,6 +1041,26 @@ class TestPallas(TestCase):
             [table[:, begin : begin + 128] for begin in range(0, 512, 128)]
         )
         torch.testing.assert_close(result.cpu(), expected.cpu())
+
+    @skipIfPallasInterpret("dynamic HBM panel loads require a real TPU")
+    def test_scalar_selected_panel(self) -> None:
+        table = torch.randn(4, 8, 128, device=DEVICE, dtype=torch.float32)
+        panel_ids = torch.tensor([2, 0, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_scalar_selected_panel,
+            (table, panel_ids),
+        )
+        torch.testing.assert_close(result.cpu(), table[panel_ids.long()].cpu() + 1)
+
+    @skipIfPallasInterpret("dynamic HBM panel loads require a real TPU")
+    def test_scalar_selected_panel_loop(self) -> None:
+        table = torch.randn(4, 8, 128, device=DEVICE, dtype=torch.float32)
+        panel_ids = torch.tensor([2, 0, 3], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            pallas_scalar_selected_panel_loop,
+            (table, panel_ids),
+        )
+        torch.testing.assert_close(result.cpu(), table[panel_ids.long()].cpu() + 1)
 
     def test_aligned_row_window_uses_direct_hbm_dma(self) -> None:
         x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION
Stacked PRs:
 * __->__#3507
 * #3508


--- --- ---

### [Pallas] Stage scalar-selected HBM panels locally


Large read-only inputs sometimes contain fixed-size panels selected by a
device scalar. Keeping the entire input in VMEM is wasteful when only one
panel is used by each program.

This Helion pattern now stages only the selected panel:

```python
@helion.kernel(backend="pallas", static_shapes=True)
def select_panel(table, panel_ids):
    out = torch.empty(
        [panel_ids.size(0), 8, 128], dtype=table.dtype, device=table.device
    )
    for row in hl.grid(panel_ids.size(0)):
        panel = panel_ids[row]
        out[row, :, :] = table[panel, :, :] + 1
    return out
```

Previously, Pallas treated `table` as a normal VMEM input, so the launcher's
working set included the complete table before applying the scalar index:

```python
# Full table is resident in VMEM.
selected = table_ref[panel, :, :]
out_ref[row, :, :] = selected + 1
```

For a grouped scale table shaped `[32, 65536]`, that reserves 8 MiB even
though one program reads only a 256 KiB row.

The Pallas tiling plan now recognizes read-only, DMA-aligned panels whose
prefix is selected by a rank-zero tensor and whose remaining dimensions are
full slices. It leaves the source in HBM and emits an exact-site DMA for the
active panel:

```python
panel_copy = pltpu.make_async_copy(
    table.at[panel, :, :], panel_scratch, panel_sem
)
panel_copy.start()
panel_copy.wait()
out_ref[row, :, :] = panel_scratch[...] + 1
```

The rule applies only when every access to the source is a compatible load,
the selected shape is statically known, and the transfer is TPU-DMA aligned.
Stores, atomic accesses, partial suffix slices, and unaligned shapes keep their
existing lowering.

Testing:

- `test_scalar_selected_panel` executes the source pattern on all 16 TPU7x
  ranks and compares its result with PyTorch indexing.
- The TP16 fused-MoE kernel passes numerical comparison with the BF16
  reference and exact repeated-call determinism with this lowering enabled.
- Pallas-interpret regression tests for aligned dynamic windows and computed
  scalar-index stores pass.
- Ruff formatting and lint checks pass for every changed file.
