### PR TITLE
[Pallas] Stage computed indirect gathers in device loops

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -26,11 +26,28 @@ if TYPE_CHECKING:
     from helion._compiler.tile_strategy import ForiLoopState
 
 
+def _host_tensor_arg_name(state: CodegenState, tensor: torch.Tensor) -> str | None:
+    """Return the Pallas argument name for a host-backed tensor."""
+    from helion._compiler.host_function import HostFunction
+
+    if tensor not in HostFunction.current().tensor_to_origin:
+        return None
+    return state.device_function.tensor_arg(tensor).name
+
+
 def _load_route(
     state: CodegenState, tensor: torch.Tensor
 ) -> tuple[str, str, list[object]]:
-    arg_name = state.device_function.pallas_tensor_ref_name(tensor)
-    active_name = vmem_name(state, arg_name)
+    arg_name = state.device_function.pallas_internal_scratch_name(tensor)
+    if arg_name is None:
+        arg_name = _host_tensor_arg_name(state, tensor)
+    if arg_name is None:
+        # Tensors computed by an enclosing device region are passed to an
+        # inner loop as ordinary closure arguments, not host tensor arguments.
+        arg_name = ast.unparse(state.ast_arg(0))
+        active_name = arg_name
+    else:
+        active_name = vmem_name(state, arg_name)
     state.device_function.device_load_index += 1
     state.device_function.device_memory_op_index += 1
     assert state.fx_node is not None
@@ -45,7 +62,7 @@ def load_expr(
 ) -> ast.AST:
     """Emit a normal Pallas load or a selected TensorCore gather."""
     from helion import exc
-    from helion._compiler.pallas.dma import emit_grid_indirect_transfer
+    from helion._compiler.pallas.dma import emit_immediate_indirect_transfer
     from helion._compiler.pallas.gather import emit_gather
     from helion._compiler.pallas.tensorcore_plan import TENSORCORE_PLAN_META
     from helion._compiler.pallas.tensorcore_plan import DmaGatherPlan
@@ -61,7 +78,7 @@ def load_expr(
             raise exc.InvalidConfig(
                 "indirect DMA load was not admitted by the active scheduler"
             )
-        emit_grid_indirect_transfer(state, plan, arg_name)
+        emit_immediate_indirect_transfer(state, plan, arg_name)
         return expr_from_string(f"{dma_ref}[...]")
     if isinstance(plan, OneHotGatherPlan):
         return emit_gather(state, plan.plan, active_name)
@@ -81,7 +98,13 @@ def load_expr(
     ):
         return _hbm_load_expr(state, subscript, tensor, arg_name)
 
-    parts, none_dims = index_parts(state, subscript, tensor)
+    parts, none_dims = index_parts(
+        state,
+        subscript,
+        tensor,
+        indexing_patterns=patterns,
+        tensor_name=arg_name,
+    )
     scalar_load = classify_vmem_scalar_load(state, tensor, parts, patterns)
     if scalar_load is None:
         result = expr_from_string(f"{active_name}[{', '.join(parts)}]")
@@ -179,7 +202,7 @@ def resident_ref_load_expr(
     """Keep a proven direct VMEM load as a Pallas Ref."""
     from helion import exc
     from helion._compiler.device_function import PallasMemorySpace
-    from helion._compiler.pallas.dma import emit_grid_indirect_transfer
+    from helion._compiler.pallas.dma import emit_immediate_indirect_transfer
     from helion._compiler.pallas.tensorcore_plan import TENSORCORE_PLAN_META
     from helion._compiler.pallas.tensorcore_plan import DmaGatherPlan
     from helion._compiler.pallas.tensorcore_plan import OneHotGatherPlan
@@ -195,7 +218,7 @@ def resident_ref_load_expr(
             raise exc.InvalidConfig(
                 "resident Ref indirect gather was not admitted by a DMA scheduler"
             )
-        emit_grid_indirect_transfer(state, plan, arg_name)
+        emit_immediate_indirect_transfer(state, plan, arg_name)
         return expr_from_string(dma_ref)
     if isinstance(plan, OneHotGatherPlan):
         raise exc.InvalidConfig(
@@ -380,7 +403,9 @@ def _tensor_routed_to_fori_scratch(state: CodegenState, tensor: torch.Tensor) ->
     """True if ``tensor``'s store destination ref is a fori_loop DMA scratch."""
     from helion._compiler.tile_strategy import ForiLoopState
 
-    name = state.codegen.device_function.tensor_arg(tensor).name
+    name = _host_tensor_arg_name(state, tensor)
+    if name is None:
+        return False
     loop, _ref = _find_dma_scratch_loop(state, name)
     return isinstance(loop, ForiLoopState)
 
@@ -501,7 +526,11 @@ def _padded_value_for_load(
     block-sized, not clamped) and size-1 dims (they broadcast; zero-padding
     would break that).
     """
-    name = state.codegen.device_function.tensor_arg(tensor).name
+    name = _host_tensor_arg_name(state, tensor)
+    if name is None:
+        # A tensor produced by an enclosing device region is already a local
+        # VMEM value. It has no host BlockSpec whose extent could be clamped.
+        return value
     if _find_dma_scratch_loop(state, name)[0] is not None:
         return value
 
@@ -552,6 +581,8 @@ def _can_tile_dimension(state: CodegenState, tensor_dim: int) -> bool:
     assert isinstance(tensor_val, torch.Tensor)
 
     dim_tilings = state.device_function.pallas_tensor_dim_tilings.get(id(tensor_val))
+    if dim_tilings is None:
+        return False
     assert isinstance(dim_tilings, list)
     assert tensor_dim < len(dim_tilings)
     from helion._compiler.pallas.plan_tiling import DimensionTiling
@@ -579,6 +610,7 @@ def index_parts(
     pipeline_scalar_indices_local: bool = True,
     tensor_indices_are_scalars: bool = False,
     raw_hbm_ref: bool = False,
+    tensor_name: str | None = None,
 ) -> tuple[list[str], list[int]]:
     """Build a JAX/Pallas index string from a Helion subscript list.
 
@@ -602,7 +634,8 @@ def index_parts(
     # only tensors present in the loop's _tensor_to_dma_scratch mapping were
     # routed through the inner DMA / Buffered BlockSpec.  Others stay on
     # their outer BlockSpec and fall through to pl.ds().
-    tensor_name = state.codegen.device_function.tensor_arg(tensor).name
+    if tensor_name is None:
+        tensor_name = state.codegen.device_function.tensor_arg(tensor).name
     in_pipeline = False
     pipeline_block_ids: set[int] = set()
     for loop, _ref in _iter_dma_scratch_loops(state, tensor_name):
@@ -1178,6 +1211,17 @@ def memory_op_dma_scratch(state: CodegenState) -> str | None:
         return resources.scratch_ref(stage)
     resources = grid_memory_op_dma_binding(state)
     return resources.scratch if resources is not None else None
+
+
+def fori_memory_op_dma_binding(state: CodegenState) -> DmaResources | None:
+    """Return a fori-owned single-stage DMA binding for immediate use."""
+    found = _memory_op_fori_binding(state)
+    if found is None:
+        return None
+    _loop, resources = found
+    if resources.buffer_count != 1:
+        return None
+    return resources
 
 
 def grid_memory_op_dma_binding(state: CodegenState) -> DmaResources | None:

--- a/helion/_compiler/pallas/dma.py
+++ b/helion/_compiler/pallas/dma.py
@@ -199,16 +199,18 @@ def indirect_group_statements(
     return result
 
 
-def emit_grid_indirect_transfer(
+def emit_immediate_indirect_transfer(
     state: CodegenState,
     plan: DmaAccessPlan,
     name: str,
 ) -> None:
-    """Emit the immediate start/wait policy for a root-grid DMA plan."""
+    """Emit a start/wait transfer at an indirect load or store site."""
     from . import codegen as pallas_codegen
     from .memory_access import MemoryAccessKind
 
     resources = pallas_codegen.grid_memory_op_dma_binding(state)
+    if resources is None and plan.spec.index_access is None:
+        resources = pallas_codegen.fori_memory_op_dma_binding(state)
     if resources is None:
         return
     ast_subscripts = state.ast_args[1]

--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 @_decorators.codegen(store, "pallas")
 def _(state: CodegenState) -> None:
     from ... import exc
-    from .dma import emit_grid_indirect_transfer
+    from .dma import emit_immediate_indirect_transfer
     from .tensorcore_plan import TENSORCORE_PLAN_META
     from .tensorcore_plan import DmaScatterPlan
     from .tensorcore_plan import OneHotScatterPlan
@@ -62,7 +62,7 @@ def _(state: CodegenState) -> None:
         )
         # The fori scheduler emits the writeback after the body. Root grids
         # have no enclosing scheduler, so this call emits it immediately.
-        emit_grid_indirect_transfer(state, plan, arg_name)
+        emit_immediate_indirect_transfer(state, plan, arg_name)
         return
     from .gather import emit_scatter_store
 

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -330,6 +330,7 @@ def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
 
     is_all_scalar = all(
         isinstance(p, (ArbitraryIndexPattern, TileBeginWithOffsetPattern, NonePattern))
+        or (isinstance(p, TensorIndexPattern) and p.index_ndim == 0)
         for p in indexing_patterns
     )
     has_contiguous_hbm_window = any(

--- a/helion/_compiler/pallas/tensorcore_plan.py
+++ b/helion/_compiler/pallas/tensorcore_plan.py
@@ -39,18 +39,15 @@ class DmaAccessSpec:
     """Config-independent structural eligibility for one indirect access."""
 
     access: MemoryAccess
-    index_access: MemoryAccess
-    index_block_id: int
+    index_node: torch.fx.Node
+    index_access: MemoryAccess | None
+    index_block_id: int | None
     selected_starts: tuple[int, ...]
     selected_extents: tuple[int, ...]
 
     @property
     def node(self) -> torch.fx.Node:
         return self.access.node
-
-    @property
-    def index_node(self) -> torch.fx.Node:
-        return self.index_access.node
 
 
 @dataclass(frozen=True)
@@ -163,22 +160,33 @@ def build_dma_access_spec(
     ):
         from ...language import memory_ops
 
-        # Indirect DMA planning requires a vector metadata load. A scalar
-        # computed inside the device program is a direct Ref address instead.
         if (
             index_node.op != "call_function"
             or index_node.target is not memory_ops.load
             or len(index_node.args) < 2
         ):
-            return None
-        index_access = build_pallas_memory_access(index_node)
-    index = memory_access_value(index_access)
-    if (
+            index_access = None
+        else:
+            index_access = build_pallas_memory_access(index_node)
+    index = (
+        memory_access_value(index_access)
+        if index_access is not None
+        else index_node.meta.get("val")
+    )
+    if not isinstance(index, torch.Tensor) or index.ndim != 1:
+        return None
+    if index.dtype != torch.int32:
+        return None
+    if index_access is not None and (
         index_access.kind is not MemoryAccessKind.LOAD
-        or index is None
-        or index.ndim != 1
-        or index.dtype != torch.int32
         or memory_access_mask(index_access) is not None
+    ):
+        return None
+    # A computed index is available only when the gather itself is emitted.
+    # It therefore supports immediate gathers, not paired scatter writeback.
+    if index_access is None and (
+        access.kind is not MemoryAccessKind.LOAD
+        or index_node.graph is not access.node.graph
     ):
         return None
 
@@ -186,8 +194,17 @@ def build_dma_access_spec(
     if not env.settings.static_shapes:
         return None
     block_id = env.resolve_block_id(index.shape[0])
-    if block_id is None or _metadata_dma_block_id(index_access) != block_id:
+    if index_access is not None and (
+        block_id is None or _metadata_dma_block_id(index_access) != block_id
+    ):
         return None
+    if (
+        index_access is None
+        and block_id is None
+        and not isinstance(env.try_concretize_symint(index.shape[0]), int)
+    ):
+        return None
+
     backend = env.backend
     assert isinstance(backend, PallasBackend)
     if len(access.subscript) > access.tensor.ndim:
@@ -202,14 +219,15 @@ def build_dma_access_spec(
             else slice(None)
         )
         value = item.meta.get("val") if isinstance(item, torch.fx.Node) else item
+        dim_size = env.try_concretize_symint(access.tensor.shape[tensor_dim])
+        if not isinstance(dim_size, int):
+            return None
         if not isinstance(value, slice) or value.step not in (None, 1):
             return None
-        dim_size = env.try_concretize_symint(access.tensor.shape[tensor_dim])
         start = 0 if value.start is None else value.start
         stop = dim_size if value.stop is None else value.stop
         if (
-            not isinstance(dim_size, int)
-            or not isinstance(start, int)
+            not isinstance(start, int)
             or not isinstance(stop, int)
             or not 0 <= start <= stop <= dim_size
         ):
@@ -250,6 +268,7 @@ def build_dma_access_spec(
         return None
     return DmaAccessSpec(
         access,
+        index_node,
         index_access,
         block_id,
         tuple(selected_starts),
@@ -355,6 +374,9 @@ def build_dma_access_candidates(
             current = build_dma_access_spec(access)
             if current is None:
                 break
+            if current.index_access is None:
+                specs.append(current)
+                continue
             metadata = current.index_access.tensor
             metadata_layout = _exact_dma_layout(metadata)
             metadata_accesses = accesses_by_storage.get(
@@ -427,8 +449,37 @@ def dma_access_admission(
     """Admit candidates sharing at least one jointly legal block size."""
 
     grouped: dict[int, list[tuple[DmaAccessCandidate, set[int]]]] = {}
+    result: set[torch.fx.Node] = set()
     for candidate in candidates:
         spec = candidate.load
+        if spec.index_access is None:
+            index = spec.index_node.meta.get("val")
+            table_rows = spec.access.tensor.shape[0]
+            if not isinstance(index, torch.Tensor) or not isinstance(table_rows, int):
+                continue
+            if spec.index_block_id is None:
+                group_count = index.shape[0]
+                if isinstance(group_count, int) and 0 < group_count <= table_rows:
+                    result.add(spec.node)
+                continue
+            bounds = block_size_ranges.get(spec.index_block_id)
+            if bounds is None:
+                from ..compile_environment import CompileEnvironment
+
+                group_count = CompileEnvironment.current().size_hint(index.shape[0])
+                if 0 < group_count <= table_rows:
+                    result.add(spec.node)
+                continue
+            block_size, maximum = bounds
+            legal = set()
+            while block_size <= maximum:
+                if block_size <= table_rows:
+                    legal.add(block_size)
+                block_size *= 2
+            if legal:
+                grouped.setdefault(spec.index_block_id, []).append((candidate, legal))
+            continue
+        assert spec.index_block_id is not None
         extent = owner_block_extents.get(candidate.graph_id, {}).get(
             spec.index_block_id
         )
@@ -447,7 +498,6 @@ def dma_access_admission(
         if legal:
             grouped.setdefault(spec.index_block_id, []).append((candidate, legal))
 
-    result: set[torch.fx.Node] = set()
     legal_sizes: dict[int, tuple[int, ...]] = {}
     for block_id, entries in grouped.items():
         common = set.intersection(*(sizes for _candidate, sizes in entries))
@@ -695,7 +745,11 @@ def build_dma_access_plan(
     # Raw HBM refs have no BlockSpec to apply data-member TilePatterns.
     if any(isinstance(pattern, TilePattern) for pattern in access.patterns):
         return None
-    index = memory_access_value(spec.index_access)
+    index = (
+        memory_access_value(spec.index_access)
+        if spec.index_access is not None
+        else spec.index_node.meta.get("val")
+    )
     value = memory_access_value(access)
     if index is None or value is None:
         return None

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -647,6 +647,10 @@ def _scalar_address_expr(
     *,
     state: CodegenState,
     captured_exprs: dict[torch.fx.Node, str],
+    block_ids: list[int] | None = None,
+    begin_exprs: list[str] | None = None,
+    iter_step_exprs: list[str] | None = None,
+    iteration_indices: list[str] | None = None,
 ) -> str | None:
     """Render a scalar HBM address captured by an inner device loop."""
     if isinstance(value, int):
@@ -661,10 +665,33 @@ def _scalar_address_expr(
         return None
     if value.target is _new_var and value.args:
         return _scalar_address_expr(
-            value.args[0], state=state, captured_exprs=captured_exprs
+            value.args[0],
+            state=state,
+            captured_exprs=captured_exprs,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
         )
 
     from ...language import memory_ops
+    from ...language.tile_ops import tile_begin
+
+    if (
+        value.target is tile_begin
+        and block_ids is not None
+        and begin_exprs is not None
+        and iter_step_exprs is not None
+        and iteration_indices is not None
+    ):
+        return _contiguous_range_base_expr(
+            value,
+            state=state,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
+        )
 
     if value.target is memory_ops.load:
         tensor_node, subscript = value.args[:2]
@@ -676,11 +703,40 @@ def _scalar_address_expr(
         if not isinstance(subscript, (list, tuple)) or len(subscript) != 1:
             return None
         index = _scalar_address_expr(
-            subscript[0], state=state, captured_exprs=captured_exprs
+            subscript[0],
+            state=state,
+            captured_exprs=captured_exprs,
+            block_ids=block_ids,
+            begin_exprs=begin_exprs,
+            iter_step_exprs=iter_step_exprs,
+            iteration_indices=iteration_indices,
         )
         if index is None:
             return None
-        name = state.device_function.tensor_arg(tensor).name
+        captured_tensor_node = tensor_node
+        while (
+            captured_tensor_node.op == "call_function"
+            and captured_tensor_node.target is _new_var
+            and captured_tensor_node.args
+            and isinstance(captured_tensor_node.args[0], torch.fx.Node)
+        ):
+            captured_tensor_node = captured_tensor_node.args[0]
+        name = captured_exprs.get(captured_tensor_node)
+        if name is None:
+            name = state.device_function.tensor_arg(tensor).name
+        from .vmem_scalar_load import classify_vmem_scalar_load
+        from .vmem_scalar_load import emit_vmem_scalar_load
+
+        scalar_load = classify_vmem_scalar_load(
+            state,
+            tensor,
+            [index],
+            list(value.meta.get("indexing_patterns") or ()),
+        )
+        if scalar_load is not None:
+            return ast.unparse(
+                emit_vmem_scalar_load(tensor, name, [index], scalar_load)
+            )
         return f"{name}[{index}]"
 
     binary_operators = {
@@ -710,10 +766,22 @@ def _scalar_address_expr(
     ):
         return None
     lhs = _scalar_address_expr(
-        value.args[0], state=state, captured_exprs=captured_exprs
+        value.args[0],
+        state=state,
+        captured_exprs=captured_exprs,
+        block_ids=block_ids,
+        begin_exprs=begin_exprs,
+        iter_step_exprs=iter_step_exprs,
+        iteration_indices=iteration_indices,
     )
     rhs = _scalar_address_expr(
-        value.args[1], state=state, captured_exprs=captured_exprs
+        value.args[1],
+        state=state,
+        captured_exprs=captured_exprs,
+        block_ids=block_ids,
+        begin_exprs=begin_exprs,
+        iter_step_exprs=iter_step_exprs,
+        iteration_indices=iteration_indices,
     )
     if lhs is None or rhs is None:
         return None
@@ -768,6 +836,22 @@ def _collect_indirect_accesses(
             assert plan is not None
             node = spec.node
             tensor = plan.access.tensor
+            if plan.spec.index_access is None:
+                if plan.spec.index_node.graph is not graph_info.graph:
+                    raise InvalidConfig(
+                        "computed indirect DMA indices must be produced in the "
+                        "same device region as their gather"
+                    )
+                admitted.append(
+                    IndirectDmaTransfer(
+                        tensor=tensor,
+                        subscript=tuple(_extract_subscript_vals(node.args[1])),
+                        direction="load",
+                        plan=plan,
+                    )
+                )
+                continue
+            assert plan.spec.index_block_id is not None
             extent = block_extents.get(plan.spec.index_block_id)
             if plan.spec.index_block_id not in block_ids or extent is None:
                 raise InvalidConfig(
@@ -852,9 +936,12 @@ def _collect_fori_indirect_accesses(
         return [], set()
     begin, end = _get_loop_begin_and_end(state, 0)
     try:
-        extent = int(end) - int(begin)
+        block_extents = {block_ids[0]: int(end) - int(begin)}
     except (TypeError, ValueError):
-        return [], set()
+        # Locally computed DMA indices do not depend on a static loop trip
+        # count. Memory-backed metadata still requires an entry here and is
+        # rejected by _collect_indirect_accesses when the bound is dynamic.
+        block_extents = {}
 
     active_block_ids = {
         block_id
@@ -865,7 +952,7 @@ def _collect_fori_indirect_accesses(
         list(state.codegen.codegen_graphs),
         graph_info,
         block_ids,
-        {block_ids[0]: extent},
+        block_extents,
         active_block_ids,
     )
     from ..device_function import DeviceFunction
@@ -3852,6 +3939,10 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
     for transfer, vmem_shape in dma_transfers:
         fake = transfer.tensor
         storage_id = id(fake.untyped_storage())
+        computed_indirect_index = (
+            isinstance(transfer, IndirectDmaTransfer)
+            and transfer.plan.spec.index_access is None
+        )
         input_slots = input_slots_by_id.get(
             id(fake), input_slots_by_storage.get(storage_id)
         )
@@ -3859,6 +3950,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             state.config.pallas_load_buffer_count[input_slots[0]]
             if load_buffer_counts_active
             and transfer.direction == "load"
+            and not computed_indirect_index
             and storage_id not in stored_tensor_storages
             and storage_id not in indirect_store_storages
             and input_slots is not None
@@ -3933,7 +4025,7 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
             dma_stores.append(scheduled)
         elif uses_load_prefetch:
             prefetched_loads.append(scheduled)
-        elif isinstance(transfer, IndirectDmaTransfer):
+        elif isinstance(transfer, IndirectDmaTransfer) and not computed_indirect_index:
             immediate_loads.append(scheduled)
 
     # ``all_tensor_info`` represents a read-modify-write tensor only by its
@@ -4190,6 +4282,10 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
                                 index_node,
                                 state=state,
                                 captured_exprs=placeholder_exprs,
+                                block_ids=block_ids,
+                                begin_exprs=begin_exprs,
+                                iter_step_exprs=iter_step_exprs,
+                                iteration_indices=iteration_indices,
                             )
                     if offset_expr is None:
                         offset_expr = state.device_function.literal_expr(idx_meta)
@@ -4275,6 +4371,8 @@ def _codegen_fori_loop(state: CodegenState, *, static_unroll: bool = False) -> o
 
         plan = transfer.plan
         index_access = plan.spec.index_access
+        if index_access is None:
+            raise AssertionError("computed-index DMA is emitted at the gather site")
         metadata_fake = index_access.tensor
         metadata_patterns = list(index_access.patterns)
         hbm_name = state.device_function.tensor_arg(transfer.tensor).name

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2689,6 +2689,29 @@ class TestPallas(TestCase):
         expected[3] = values
         torch.testing.assert_close(result, expected)
 
+    def test_scalar_tensor_index_loads_metadata(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def load_metadata(values: torch.Tensor, starts: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                [starts.size(0), 8], dtype=values.dtype, device=values.device
+            )
+            for block in hl.grid(starts.size(0)):
+                start = starts[block]
+                for lane in hl.static_range(8):
+                    out[block, lane] = values[start + lane]
+            return out
+
+        values = torch.arange(64, device=DEVICE, dtype=torch.int32)
+        starts = torch.tensor([0, 8, 24, 48], device=DEVICE, dtype=torch.int32)
+        _, result = code_and_output(
+            load_metadata,
+            (values, starts),
+            pallas_loop_type="fori_loop",
+        )
+
+        expected = torch.stack([values[start : start + 8] for start in starts.tolist()])
+        torch.testing.assert_close(result, expected)
+
     def test_computed_scalar_selects_staged_matmul_weight(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def dynamic_weight_matmul(
@@ -7037,6 +7060,43 @@ class TestPallasIndirectGather(TestCase):
             result,
             table.cpu()[indices.long().cpu()].to(device=DEVICE),
         )
+
+    @skipIfPallasInterpret("computed grouped HBM DMA requires TPU lowering")
+    def test_computed_fori_indirect_gather_tpu_correctness(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def gather_state(table: torch.Tensor) -> torch.Tensor:
+            rows = 32
+            out = torch.empty(
+                [rows, *table.shape[1:]],
+                dtype=table.dtype,
+                device=table.device,
+            )
+            for _ in hl.grid(1):
+                for tile_b in hl.tile(rows, block_size=8):
+                    selected = ((tile_b.index * 3 + 5) % table.size(0)).to(torch.int32)
+                    out[tile_b, :, :, :] = hl.load(
+                        table,
+                        [selected, slice(None), slice(None), slice(None)],
+                    )
+            return out
+
+        table = torch.randn(
+            512,
+            3,
+            4,
+            128,
+            device=DEVICE,
+            dtype=torch.bfloat16,
+        )
+        _, result = code_and_output(
+            gather_state,
+            (table,),
+            pallas_loop_type="fori_loop",
+            pallas_load_buffer_count=[1],
+            pallas_indirect_access_mode="dma",
+        )
+        indices = (torch.arange(32) * 3 + 5) % table.size(0)
+        torch.testing.assert_close(result.cpu(), table.cpu()[indices])
 
     @skipIfPallasInterpret("grouped HBM DMA requires TPU lowering")
     def test_indirect_roundtrip_uses_shared_state_scratch(self) -> None:

--- a/test/test_pallas_tensorcore_plan.py
+++ b/test/test_pallas_tensorcore_plan.py
@@ -52,7 +52,7 @@ def _spec(
         (),
         None,
     )
-    return DmaAccessSpec(access, index_access, block_id, (0, 0), (2, 128))
+    return DmaAccessSpec(access, index_node, index_access, block_id, (0, 0), (2, 128))
 
 
 def test_dma_access_candidate_block_admission() -> None:
@@ -68,6 +68,7 @@ def test_dma_access_candidate_block_admission() -> None:
             (),
             None,
         ),
+        load.index_node,
         load.index_access,
         load.index_block_id,
         load.selected_starts,
@@ -119,8 +120,12 @@ def test_dma_access_candidate_requires_exact_store_pair() -> None:
     )
     store_access = build_memory_access(store, table, subscript, patterns)
     store.meta[MEMORY_ACCESS_META] = store_access
-    load_spec = DmaAccessSpec(load_access, index_access, 0, (0, 0), (2, 128))
-    store_spec = DmaAccessSpec(store_access, index_access, 0, (0, 0), (2, 128))
+    load_spec = DmaAccessSpec(
+        load_access, index_load, index_access, 0, (0, 0), (2, 128)
+    )
+    store_spec = DmaAccessSpec(
+        store_access, index_load, index_access, 0, (0, 0), (2, 128)
+    )
     owner = cast("GraphInfo", SimpleNamespace(graph=graph, graph_id=7))
 
     def spec(access: MemoryAccess) -> DmaAccessSpec | None:
@@ -134,7 +139,9 @@ def test_dma_access_candidate_requires_exact_store_pair() -> None:
             DmaAccessCandidate(7, load_spec, store_spec, frozenset({id(indices)})),
         )
 
-        mismatched = DmaAccessSpec(store_access, index_access, 0, (0, 128), (2, 128))
+        mismatched = DmaAccessSpec(
+            store_access, index_load, index_access, 0, (0, 128), (2, 128)
+        )
         with patch(
             "helion._compiler.pallas.tensorcore_plan.build_dma_access_spec",
             side_effect=lambda access: {
@@ -179,8 +186,10 @@ def test_dma_access_candidate_rejects_distinct_input_aliases() -> None:
     store_access = build_memory_access(store, table, list(subscript), [])
     store.meta[MEMORY_ACCESS_META] = store_access
     specs = {
-        load: DmaAccessSpec(load_access, index_access, 0, (0, 0), (2, 128)),
-        store: DmaAccessSpec(store_access, index_access, 0, (0, 0), (2, 128)),
+        load: DmaAccessSpec(load_access, index_load, index_access, 0, (0, 0), (2, 128)),
+        store: DmaAccessSpec(
+            store_access, index_load, index_access, 0, (0, 0), (2, 128)
+        ),
     }
     owner = cast("GraphInfo", SimpleNamespace(graph=graph, graph_id=0))
     with patch(


### PR DESCRIPTION

An indirect index computed inside a device loop is already a local Pallas
value. It is not host metadata, but the indirect-access planner previously
treated every tensor index as a host-loaded vector. The DMA plan therefore
rejected this existing Helion pattern:

```python
for _ in hl.grid(1):
    for tile_b in hl.tile(rows, block_size=8):
        selected = ((tile_b.index * 3 + 5) % table.size(0)).to(torch.int32)
        out[tile_b, :, :, :] = hl.load(
            table, [selected, slice(None), slice(None), slice(None)]
        )
```

The previous lowering could neither use its host-metadata DMA path nor lower
the four-dimensional value through one-hot selection, and stopped with:

```text
Backend 'pallas' does not support: an indirect access is unsupported by both
one-hot and DMA lowering
```

Allow the existing DMA planner to accept a local, computed index for an
immediate read. The loop owns one VMEM stage, and the generated Pallas starts
one HBM-to-VMEM copy for each selected row:

```python
for _dma_member in range(32):
    copy = pltpu.make_async_copy(
        hidden_states.at[token_indices[_dma_member], :, :],
        hidden_states_gather_buf.at[_dma_member],
        hidden_states_gather_sem,
    )
    copy.start()

wait = pltpu.make_async_copy(
    hidden_states.at[pl.ds(0, 32), :, :],
    hidden_states_gather_buf,
    hidden_states_gather_sem,
)
wait.wait()
```

The new route is deliberately narrow: the index must be a local computed
vector, the transfer must be used immediately in the same device loop, and
the access must be a read. Scatter writeback and host-metadata pipelines keep
their existing lowering.

The tests execute numerical cases for a computed grouped gather and scalar
metadata loads used as addresses. The TPU-only gather test uses real HBM DMA
rather than generated-code assertions.
