### PR TITLE
[cutedsl] Rolled-reduction SIMT codegen: per-rdim thread-count knob, vec stores in consume sweeps, square-shape lane resolution, prefetch OOB clamp

### DIFF
--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -32,6 +32,7 @@ from ...language.memory_ops import _cute_index_exprs
 from ...language.memory_ops import _cute_index_tuple
 from ...language.memory_ops import _cute_is_byte_packed
 from ...language.memory_ops import _cute_is_unroll_dtype
+from ...language.memory_ops import _cute_register_reduction_unroll_vec_store
 from ...language.memory_ops import _cute_register_tile_unroll_vec_hoist
 from ...language.memory_ops import _cute_register_tile_unroll_vec_store
 from ...language.memory_ops import _cute_scalar_load_expr
@@ -239,6 +240,12 @@ def _cute_register_unroll_vec_hoist(
         cache = {}
         # pyrefly: ignore [missing-attribute]
         strategy._cute_lane_vec_loads = cache
+    # Locate the constexpr V-loop: prefer the node recorded by
+    # codegen_device_loop (vec-store flushes may sit after it, so it is not
+    # guaranteed to be the last lane_body entry).
+    constexpr_loop = getattr(strategy, "_cute_lane_vloop", None)
+    if constexpr_loop is None or constexpr_loop not in lane_body:
+        constexpr_loop = lane_body[-1]
     if cache_key not in cache:
         hoist_var = state.device_function.new_var(
             f"_unroll_vec_{len(cache)}", dce=False
@@ -248,13 +255,10 @@ def _cute_register_unroll_vec_hoist(
             f"{hoist_var} = cute.arch.load({base_ptr_expr}, "
             f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type))"
         )
-        # Insert the hoist just BEFORE the constexpr V-loop (the last entry
-        # in lane_body).  ``lane_body[-1]`` is the constexpr loop.
-        lane_body.insert(len(lane_body) - 1, hoist_stmt)
+        # Insert the hoist just BEFORE the constexpr V-loop.
+        lane_body.insert(lane_body.index(constexpr_loop), hoist_stmt)
     else:
         hoist_var, _ = cache[cache_key]
-    # The constexpr V-loop's target var is the last element's loop var.
-    constexpr_loop = lane_body[-1]
     assert isinstance(constexpr_loop, ast.For)
     assert isinstance(constexpr_loop.target, ast.Name)
     vec_lane_var = constexpr_loop.target.id
@@ -1855,6 +1859,25 @@ def _(state: CodegenState) -> ast.AST:
             if append_stmt is not None:
                 state.add_statement(append_stmt)
                 return ast.Constant(value=None)
+        elif vec_ctx is not None and vec_ctx[2] == "unroll":
+            from ..reduction_strategy import LoopedReductionStrategy
+
+            _vec_width, vec_block_id, _mode = vec_ctx
+            loops = state.codegen.active_device_loops.get(vec_block_id)
+            assert loops
+            red_strategy = loops[-1].strategy
+            if isinstance(red_strategy, LoopedReductionStrategy):
+                append_stmt = _cute_register_reduction_unroll_vec_store(
+                    state,
+                    red_strategy,
+                    tensor_name,
+                    index_exprs,
+                    ast.unparse(value),
+                    mask_expr,
+                )
+                if append_stmt is not None:
+                    state.add_statement(append_stmt)
+                    return ast.Constant(value=None)
 
     store_expr = _cute_scalar_store_expr(tensor_name, index_exprs, "{value}")
     assign_expr = expr_from_string(store_expr, value=value)
@@ -2026,6 +2049,7 @@ def _cute_vector_load_ctx(
         elif isinstance(idx, slice) and idx == slice(None):
             if tensor_dim < tensor.ndim:
                 dim_size = tensor.shape[tensor_dim]
+                matches: list[int] = []
                 for cand_bid, bs in enumerate(env.block_sizes):
                     if not isinstance(bs.size, (int, torch.SymInt)):
                         continue
@@ -2057,10 +2081,20 @@ def _cute_vector_load_ctx(
                     if env.known_equal(
                         bs_int, dim_int
                     ) and state.codegen.active_device_loops.get(cand_bid):
-                        if tensor_dim == stride1_tensor_dim or inner_block_id is None:
-                            inner_block_id = cand_bid
-                            lane_axis_pos = expr_pos
-                        break
+                        matches.append(cand_bid)
+                if matches:
+                    # Matching by extent alone is ambiguous when a
+                    # non-reduction tile dim happens to have the same
+                    # extent (e.g. a square MxN input): a full-slice
+                    # subscript is a reduction axis whenever a reduction
+                    # block of that extent exists, so prefer it.
+                    cand = next(
+                        (bid for bid in matches if env.block_sizes[bid].reduction),
+                        matches[0],
+                    )
+                    if tensor_dim == stride1_tensor_dim or inner_block_id is None:
+                        inner_block_id = cand
+                        lane_axis_pos = expr_pos
         tensor_dim += 1
     if inner_block_id is None or lane_axis_pos is None:
         return None

--- a/helion/_compiler/cute/pipeline_inner_loads.py
+++ b/helion/_compiler/cute/pipeline_inner_loads.py
@@ -491,9 +491,24 @@ def _try_pipeline_one_outer_loop(
 
     snapshot_lane_base = statement_from_string(f"{lane_base_name} = {pipe_lane_base}")
     snapshot_load = statement_from_string(f"{load_var_name} = {pipe_load}")
-    prefetch_lane_base = statement_from_string(
-        f"{pipe_lane_base} = {ast.unparse(next_lane_base_rhs)}"
-    )
+    # The last iteration's speculative prefetch would read one STEP past
+    # the end of the swept region.  Masked loads (an ``IfExp`` inside the
+    # load expression) already fall through to a safe in-bounds address;
+    # for UNMASKED loads (extent known to divide the chunk, so codegen
+    # elides the mask) clamp the prefetch base back to the current
+    # (in-bounds) lane base — the prefetched value is never consumed on
+    # the final iteration, it just must not fault.
+    load_has_guard = any(isinstance(sub, ast.IfExp) for sub in ast.walk(load_rhs))
+    if load_has_guard:
+        prefetch_lane_base = statement_from_string(
+            f"{pipe_lane_base} = {ast.unparse(next_lane_base_rhs)}"
+        )
+    else:
+        prefetch_lane_base = statement_from_string(
+            f"{pipe_lane_base} = ({ast.unparse(next_lane_base_rhs)}) "
+            f"if ({tile_var} + ({ast.unparse(step_expr)})) < ({ast.unparse(end_expr)}) "
+            f"else {lane_base_name}"
+        )
     prefetch_load = statement_from_string(f"{pipe_load} = {ast.unparse(next_load_rhs)}")
 
     new_inner_body: list[ast.stmt] = [

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -35,8 +35,10 @@ from ..autotuner.config_spec import FULL_EXTENT_CATEGORIES
 from ..autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
 from ..autotuner.config_spec import CoResidencyGroup
 from ..autotuner.config_spec import CuteLaneLayoutSpec
+from ..autotuner.config_spec import CuteReductionReloadSpec
 from ..autotuner.config_spec import CuteVectorWidthSpec
 from ..autotuner.config_spec import MatmulWithReductionEpilogueFact
+from ..autotuner.config_spec import NumThreadsSpec
 from ..autotuner.config_spec import ReductionCategory
 from ..autotuner.config_spec import ReductionDescriptor
 from ..autotuner.config_spec import ReductionKernelFact
@@ -1025,6 +1027,19 @@ class DeviceIR:
                     )
                     env.config_spec.cute_lane_layouts.append(
                         CuteLaneLayoutSpec(block_id=rdim.block_id)
+                    )
+                    env.config_spec.cute_reduction_reloads.append(
+                        CuteReductionReloadSpec(block_id=rdim.block_id)
+                    )
+                    # Rolled reduction dims get a thread-count knob: fewer
+                    # threads per row (with more elements per thread) is
+                    # often faster for memory-bound row reductions. 0 = auto
+                    # (derive from the loop chunk, the legacy behavior).
+                    env.config_spec.num_threads.append(
+                        NumThreadsSpec(
+                            block_id=rdim.block_id,
+                            size_hint=rdim.size_hint(),
+                        )
                     )
             graphs_with_rolled_rdim |= used_graphs
 

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -1181,6 +1181,18 @@ class LoopedReductionStrategy(ReductionStrategy):
             ):
                 max_threads = min(max_threads, _CUTE_WARP_REDUCTION_THREADS)
             thread_count = next_power_of_2(min(block_size, max_threads))
+            if env.backend.name == "cute":
+                # Autotunable per-rdim thread count: fewer threads per row
+                # (each covering more elements via the lane loop) is often
+                # faster for memory-bound row reductions. 0 = auto (keep the
+                # chunk-derived count above).
+                requested = env.config_spec.num_threads.config_get(
+                    cast("list[int]", fn.config.config.get("num_threads", []) or []),
+                    block_index,
+                    0,
+                )
+                if isinstance(requested, int) and 0 < requested < thread_count:
+                    thread_count = requested
         else:
             thread_count = 0
         tile_dispatch = getattr(fn, "tile_strategy", None)
@@ -1400,6 +1412,13 @@ class LoopedReductionStrategy(ReductionStrategy):
         # in ``unroll`` mode — the dispatcher uses this to compute the vec
         # pointer offset once.
         self._cute_lane_base_index_var: str | None = None
+        # The constexpr V-loop node of the current lane body (see
+        # codegen_device_loop); used to position vec hoists and vec-store
+        # flushes relative to the V-loop.
+        self._cute_lane_vloop: ast.For | None = None
+        # Vec-store flush sites already spliced into the current lane body
+        # (list of list-var names), in source order.
+        self._cute_lane_vec_stores: list[str] = []
         vec_lane_var: str | None = None
         base_expr: str = ""
         if reduction_lane_var is not None:
@@ -1466,6 +1485,10 @@ class LoopedReductionStrategy(ReductionStrategy):
                         lane_body,
                     )
                 ]
+                # Record the V-loop node so hoists (inserted before it) and
+                # vec-store flushes (appended after it) can locate it even
+                # once it is no longer the last lane_body entry.
+                self._cute_lane_vloop = vec_for
                 # Stash the lane body list so the dispatcher can splice
                 # hoists in (BETWEEN base_stmt and vec_for) as it runs.
                 self._cute_lane_body = lane_body

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -979,6 +979,71 @@ def _cute_register_tile_unroll_vec_store(
     )
 
 
+def _cute_register_reduction_unroll_vec_store(
+    state: CodegenState,
+    strategy: object,  # LoopedReductionStrategy at runtime
+    tensor_name: str,
+    index_exprs: list[str],
+    value_expr: str,
+    mask_expr: str | None,
+) -> ast.stmt | None:
+    """Reduction-lane variant of ``_cute_register_tile_unroll_vec_store``.
+
+    Consume sweeps of rolled reductions (layernorm / rmsnorm epilogues)
+    store one fp16/bf16 element per constexpr V-loop iter; this collects
+    the V per-lane values into a compile-time list and flushes them with a
+    single ``_cute_store_u16_vec`` after the V-loop (ST.64/ST.128 instead
+    of V scalar 2-byte stores).
+
+    Same mask precondition as the tile variant: the caller only reaches
+    this when ``strategy._mask_var is None`` (uniform, mask-free lanes), so
+    ``mask_expr`` can wrap the flush as a whole.
+    """
+    base_index_var = getattr(strategy, "_cute_lane_base_index_var", None)
+    lane_body = getattr(strategy, "_cute_lane_body", None)
+    vloop = getattr(strategy, "_cute_lane_vloop", None)
+    if (
+        not isinstance(base_index_var, str)
+        or not isinstance(lane_body, list)
+        or vloop is None
+    ):
+        return None
+
+    def _vloop_pos() -> int:
+        for i, stmt in enumerate(lane_body):
+            if stmt is vloop:
+                return i
+        return len(lane_body) - 1
+
+    # The inner reduction-axis index_expr is the last entry (same layout as
+    # ``_cute_register_unroll_vec_hoist``).
+    base_exprs = list(index_exprs)
+    base_exprs[-1] = base_index_var
+    base_ptr_expr = _cute_scalar_pointer_expr(tensor_name, base_exprs)
+    sites = getattr(strategy, "_cute_lane_vec_stores", None)
+    if not isinstance(sites, list):
+        sites = []
+        # pyrefly: ignore [missing-attribute]
+        strategy._cute_lane_vec_stores = sites
+    site_index = len(sites)
+    list_var = state.device_function.new_var(
+        f"_reduction_store_vals_{site_index}", dce=False
+    )
+    sites.append(list_var)
+    lane_body.insert(_vloop_pos(), statement_from_string(f"{list_var} = []"))
+    flush_expr = f"_cute_store_u16_vec({base_ptr_expr}, {list_var})"
+    if mask_expr is not None:
+        flush_stmt = statement_from_string(f"if {mask_expr}:\n    {flush_expr}")
+    else:
+        flush_stmt = statement_from_string(flush_expr)
+    # Insert after the V-loop AND after any earlier sites' flushes so the
+    # emitted store order matches the source order.
+    lane_body.insert(_vloop_pos() + 1 + site_index, flush_stmt)
+    return statement_from_string(
+        f"{list_var}.append(({value_expr}).bitcast(cutlass.Uint16))"
+    )
+
+
 def _cute_register_tile_unroll_vec_hoist(
     state: CodegenState,
     strategy: object,  # BlockSizeTileStrategy (PerThreadNDTileStrategy)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3515
 * #3514
 * #3513
 * #3512
 * #3511
 * __->__#3510
 * #3509


--- --- ---

[cutedsl] Rolled-reduction SIMT codegen: per-rdim thread-count knob, vec stores in consume sweeps, square-shape lane resolution, prefetch OOB clamp

- num_threads gains a per-rolled-rdim slot on cute (0 = auto): fewer
  threads per row with more elements per thread via the lane loop is
  often faster for memory-bound row reductions (quack's threads_per_row).
- Consume sweeps of rolled reductions (layernorm/rmsnorm epilogues) now
  pack fp16/bf16 stores into one ST.64/ST.128 via _cute_store_u16_vec
  instead of V scalar 2-byte stores (reduction-lane counterpart of the
  tile-loop vec store).
- Slice lane-axis block resolution prefers reduction blocks: on square
  inputs (m == n) the extent-equality match picked the m tile block and
  silently disabled all vec machinery.
- The software-pipelined prefetch clamps its final speculative lane base
  back in bounds for UNMASKED loads (extent divides the chunk): it used
  to read one chunk past the swept region, an OOB access on the last row.