### PR TITLE
[cutedsl] cute_reduction_reloads knob: register vs gmem reload for multi-sweep reductions

### DIFF
--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -906,6 +906,7 @@ class CuteBackend(Backend):
             key == "num_threads"
             or key == "cute_vector_widths"
             or key == "cute_lane_layouts"
+            or key == "cute_reduction_reloads"
             or key == "cute_cluster_n"
             or key == "cute_min_blocks_per_mp"
             or key.startswith(("tcgen05_", "cute_flash_"))

--- a/helion/_compiler/cute/fuse_two_pass_loads.py
+++ b/helion/_compiler/cute/fuse_two_pass_loads.py
@@ -292,10 +292,15 @@ class _CuteFuseTwoPassLoads:
         constexpr_values: dict[str, int] | None = None,
         thread_block_dims: tuple[int, int, int] = (1, 1, 1),
         tensor_dtypes: dict[str, str] | None = None,
+        reload_modes: dict[int, str] | None = None,
     ) -> None:
         super().__init__()
         self._counter = 0
         self._constexpr_values = constexpr_values or {}
+        # Autotuner-selected reload mode per rolled-reduction block id
+        # ("auto" / "register" / "gmem").  Sweep loops are matched back to
+        # their block id via the ``roffset_<id>`` loop offset variable.
+        self._reload_modes = reload_modes or {}
         # Kernel tensor-arg name -> backend dtype string (e.g.
         # "cutlass.Float32"); resolves the cache dtype for unmasked
         # scalar loads.
@@ -588,19 +593,47 @@ class _CuteFuseTwoPassLoads:
             #     plumbed correctly from the dispatch layer.
             import os
 
-            _fuser_mode = os.environ.get("HELION_FUSER_MODE", "auto")
+            # Effective per-thread cache footprint in ELEMENTS: for vec
+            # loads each cache slot fans out into V scalar lanes, so the
+            # raw slot count understates the register cost by V.
+            _vec_m = re.search(r"VectorType\.get\(\[(\d+)\]", ast.unparse(first_loop))
+            cache_elems = cache_size * (int(_vec_m.group(1)) if _vec_m else 1)
+            # Rolled-reduction sweeps use ``roffset_<block_id>`` offset
+            # vars; tile-loop sweeps use ``tile_offset_<n>``.  Only the
+            # former have a reload-mode knob.
+            _bid_m = (
+                re.match(r"roffset_(\d+)", first_loop.target.id)
+                if isinstance(first_loop.target, ast.Name)
+                else None
+            )
+            is_reduction_sweep = _bid_m is not None
+            _fuser_mode = os.environ.get("HELION_FUSER_MODE")
+            if _fuser_mode is None:
+                _fuser_mode = (
+                    self._reload_modes.get(int(_bid_m.group(1)), "auto")
+                    if _bid_m is not None
+                    else "auto"
+                )
+                # The config knob spells "never fuse" as ``"gmem"``
+                # (re-load later sweeps from gmem/L2).
+                if _fuser_mode == "gmem":
+                    _fuser_mode = "disabled"
             if _fuser_mode == "disabled":
                 continue
             if _fuser_mode == "register":
                 use_smem = False
-                if cache_size > 1024:
+                if cache_elems > 1024:
                     continue
             elif _fuser_mode == "smem":
                 use_smem = True
-                if cache_size > 1024:
+                if cache_elems > 1024:
                     continue
             else:  # auto
-                if cache_size > 64:
+                # Reduction sweeps cap on the true element footprint (the
+                # vec path multiplies slots by V); tile-loop sweeps keep
+                # the historical slot-count cap their tunings were
+                # calibrated against.
+                if (cache_elems if is_reduction_sweep else cache_size) > 64:
                     continue
                 use_smem = False
             cache_index = first_cache_index
@@ -900,6 +933,7 @@ def fuse_two_pass_loads(
     *,
     thread_block_dims: tuple[int, int, int] = (1, 1, 1),
     tensor_dtypes: dict[str, str] | None = None,
+    reload_modes: dict[int, str] | None = None,
 ) -> list[ast.stmt]:
     """Apply two-pass load fusion to a list of statements (the device kernel
     body). Returns the (possibly modified) body.
@@ -922,6 +956,7 @@ def fuse_two_pass_loads(
         constexpr_values=constexpr_values,
         thread_block_dims=thread_block_dims,
         tensor_dtypes=tensor_dtypes,
+        reload_modes=reload_modes,
     )
     new_body = transformer._try_fuse(body)
     if new_body is None:

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -1057,11 +1057,28 @@ class DeviceFunction:
                         )
                     except ValueError:
                         continue
+            # Autotuner-selected reload mode per rolled reduction dim
+            # ("auto" / "register" / "gmem"); the fuser keys the sweep
+            # loops back to their block id via the ``roffset_<id>`` /
+            # ``tile_offset_<id>`` loop offset variable.
+            env = CompileEnvironment.current()
+            reload_cfg = cast(
+                "list[str]",
+                self.config.config.get("cute_reduction_reloads", []) or [],
+            )
+            reload_modes = {
+                block_id: env.config_spec.cute_reduction_reloads.config_get(
+                    reload_cfg, block_id, "auto"
+                )
+                or "auto"
+                for block_id in env.config_spec.cute_reduction_reloads.valid_block_ids()
+            }
             kernel_body = fuse_two_pass_loads(
                 kernel_body,
                 constexpr_values,
                 thread_block_dims=thread_block_dims,
                 tensor_dtypes=tensor_dtypes,
+                reload_modes=reload_modes,
             )
             # Hoist warp reductions out of constexpr V-loops to collapse
             # 4 per-V-lane warp reductions into 1 V-fold + 1 warp reduce.

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -817,6 +817,7 @@ BACKEND_SPECIFIC_KEYS: frozenset[str] = (
         "num_threads",
         "cute_vector_widths",
         "cute_lane_layouts",
+        "cute_reduction_reloads",
         "cute_cluster_n",
         "cute_min_blocks_per_mp",
         "load_cache_modifiers",
@@ -858,6 +859,7 @@ VALID_KEYS: frozenset[str] = frozenset(
         "pallas_pre_broadcast",
         "cute_vector_widths",
         "cute_lane_layouts",
+        "cute_reduction_reloads",
         "cute_cluster_n",
         "cute_min_blocks_per_mp",
         *BACKEND_TUNABLE_KEYS,
@@ -1010,6 +1012,9 @@ class ConfigSpec:
             BlockIdSequence()
         )
         self.cute_lane_layouts: BlockIdSequence[CuteLaneLayoutSpec] = BlockIdSequence()
+        self.cute_reduction_reloads: BlockIdSequence[CuteReductionReloadSpec] = (
+            BlockIdSequence()
+        )
         self.range_unroll_factors: BlockIdSequence[RangeUnrollFactorSpec] = (
             BlockIdSequence()
         )
@@ -2331,6 +2336,7 @@ class ConfigSpec:
             ("reduction_loops", self.reduction_loops, True),
             ("cute_vector_widths", self.cute_vector_widths, True),
             ("cute_lane_layouts", self.cute_lane_layouts, True),
+            ("cute_reduction_reloads", self.cute_reduction_reloads, True),
             ("range_unroll_factors", self.range_unroll_factors, True),
             ("range_warp_specializes", self.range_warp_specialize, True),
             ("range_num_stages", self.range_num_stages, True),
@@ -2537,6 +2543,7 @@ class ConfigSpec:
             "reduction_loops",
             "cute_vector_widths",
             "cute_lane_layouts",
+            "cute_reduction_reloads",
             "range_unroll_factors",
             "range_warp_specializes",
             "range_num_stages",
@@ -3251,6 +3258,14 @@ class ConfigSpec:
                     and len(self.cute_lane_layouts) > 0
                 ):
                     fields["cute_lane_layouts"] = self.cute_lane_layouts
+                # Where multi-sweep rolled reductions keep re-read values
+                # (register fragment vs gmem/L2 reload); see
+                # ``CuteReductionReloadSpec``.
+                if (
+                    self.supports_config_key("cute_reduction_reloads")
+                    and len(self.cute_reduction_reloads) > 0
+                ):
+                    fields["cute_reduction_reloads"] = self.cute_reduction_reloads
                 # Thread-block cluster width for SIMT reduction kernels:
                 # splits a whole-extent lane-looped axis across cluster
                 # CTAs (register-resident slices) with a DSM cluster
@@ -3871,6 +3886,36 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
 
 _CUTE_VECTOR_WIDTH_CHOICES: tuple[int, ...] = (1, 2, 4, 8)
 _CUTE_LANE_LAYOUT_CHOICES: tuple[str, ...] = ("blocked", "strided")
+_CUTE_REDUCTION_RELOAD_CHOICES: tuple[str, ...] = ("auto", "register", "gmem")
+
+
+class CuteReductionReloadSpec(_BlockIdItem):
+    """Where a multi-sweep rolled reduction keeps the values it re-reads.
+
+    LayerNorm/RMSNorm-style kernels sweep the same input several times
+    (reduce, then consume).  ``"register"`` caches the first sweep's loads
+    in a per-thread register fragment (fastest when the per-thread slice
+    is small; spills to local memory when it is not).  ``"gmem"`` re-loads
+    from global memory on later sweeps (the row is usually still resident
+    in L2, and no registers are burned).  ``"auto"`` (default) keeps the
+    legacy size heuristic in ``fuse_two_pass_loads``.
+    """
+
+    def __init__(self, *, block_id: int) -> None:
+        super().__init__([block_id])
+
+    def _fragment(self, base: ConfigSpec) -> EnumFragment:
+        return EnumFragment(choices=_CUTE_REDUCTION_RELOAD_CHOICES)
+
+    def _normalize(self, name: str, value: object) -> str:
+        if value not in _CUTE_REDUCTION_RELOAD_CHOICES:
+            raise InvalidConfig(
+                f"{name} must be one of {_CUTE_REDUCTION_RELOAD_CHOICES}, got {value!r}"
+            )
+        return str(value)
+
+    def _fill_missing(self) -> str:
+        return "auto"
 
 
 class CuteLaneLayoutSpec(_BlockIdItem):


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3515
 * #3514
 * #3513
 * #3512
 * __->__#3511
 * #3510
 * #3509


--- --- ---

[cutedsl] cute_reduction_reloads knob: register vs gmem reload for multi-sweep reductions

Multi-sweep rolled reductions (layernorm: mean sweep, variance sweep,
normalize sweep) re-read the same input. The fuse-cache pass kept the
values in a per-thread register fragment with a slot-count cap that
undercounted vec loads by V, so wide rows spilled to local memory
(16384x131072 ran at 761 GB/s). New per-rdim knob:

- "register": force the register fragment (autotuner learns when it
  spills),
- "gmem": skip fusion; later sweeps re-load from gmem and hit L2
  (fastest for rows too wide to keep resident, 3178 GB/s at 131072),
- "auto" (default): legacy heuristic, with the cap now counting true
  per-thread ELEMENTS for reduction sweeps (tile-loop sweeps keep the
  historical slot cap their tunings were calibrated against).