### PR TITLE
[cutedsl] Fix surplus-thread mask elision, reduction-thread budget miscount, and launcher hardening

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -1070,7 +1070,6 @@ class DeviceFunction:
                 block_id: env.config_spec.cute_reduction_reloads.config_get(
                     reload_cfg, block_id, "auto"
                 )
-                or "auto"
                 for block_id in env.config_spec.cute_reduction_reloads.valid_block_ids()
             }
             kernel_body = fuse_two_pass_loads(

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2477,8 +2477,16 @@ class ConfigSpec:
         ):
             nt_list = cast("list[int]", config.get("num_threads", []) or [])
             bs_list = cast("list[int]", config.get("block_sizes", []) or [])
+            # ``num_threads`` also carries per-rolled-rdim slots (the
+            # reduction's own thread count); only NON-reduction tile axes
+            # consume the budget the reduction competes for.  Tile slots
+            # are registered in ``block_sizes`` order, so pairing the i-th
+            # num_threads slot with block_sizes[i] stays valid for them.
+            reduction_block_ids = {spec.block_id for spec in self.reduction_loops}
             other_threads = 1
-            for i, _ in enumerate(self.num_threads):
+            for i, nt_spec in enumerate(self.num_threads):
+                if nt_spec.block_id in reduction_block_ids:
+                    continue
                 nt = nt_list[i] if i < len(nt_list) else 0
                 if not isinstance(nt, int) or nt <= 0:
                     bs = bs_list[i] if i < len(bs_list) else 1

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -15,6 +15,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from contextlib import suppress
 import contextvars
+import ctypes
 from dataclasses import dataclass
 from dataclasses import field
 import hashlib
@@ -25,6 +26,7 @@ import linecache
 import logging
 import os
 import sys
+import threading
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
@@ -4434,8 +4436,6 @@ class _CuteFastRelaunch:
         last_raw: int,
         keepalive: tuple[object, ...],
     ) -> None:
-        import threading
-
         self.executor = executor
         self.exe_args = exe_args
         self.tensor_guards = tensor_guards
@@ -4538,8 +4538,6 @@ def _cute_build_fast_relaunch(
     launch: _CuteLaunchArgCacheEntry,
     compiled: object,
 ) -> _CuteFastRelaunch | None:
-    import ctypes
-
     if not isinstance(compiled, _CompiledCuteLauncher):
         return None
     dsl_fn = cast("Any", compiled)._compiled
@@ -4620,7 +4618,12 @@ def _cute_build_fast_relaunch(
         stable = [a == b for a, b in zip(n1, n2, strict=True)]
 
         def deref(addr: object) -> int | None:
-            if isinstance(addr, int) and addr > 0xFFFF:
+            # Only dereference values that plausibly ARE host heap
+            # addresses (ctypes cell storage): 8-aligned and above the
+            # low canonical range.  Large by-value integers (e.g. tensor
+            # extents) must never be dereferenced — from_address on a
+            # non-address segfaults uncatchably.
+            if isinstance(addr, int) and addr > (1 << 40) and addr % 8 == 0:
                 return int(ctypes.c_uint64.from_address(addr).value)
             return None
 
@@ -4685,6 +4688,10 @@ def _cute_build_fast_relaunch(
             for i, (a, b) in enumerate(zip(n1, n3, strict=True))
             if stable[i] and a != b
         ]
+        # The wrapper takes ONE stream parameter; its handle can surface in
+        # at most a couple of exe slots (a by-value copy plus a by-ref
+        # cell).  More differing slots means the marshalling isn't the
+        # shape we probe-verified — fall back.
         if not slots or len(slots) > 2:
             return None
         by_ref_writers: list[object] = []
@@ -4697,15 +4704,8 @@ def _cute_build_fast_relaunch(
             # By-reference: the slot holds the address of an 8-byte cell
             # containing the handle.  Verify BOTH probes' cells before
             # trusting the address.
-            if (
-                isinstance(a, int)
-                and isinstance(b, int)
-                and a > 0xFFFF
-                and b > 0xFFFF
-                and ctypes.c_uint64.from_address(a).value == raw0
-                and ctypes.c_uint64.from_address(b).value == alt_raw
-            ):
-                by_ref_writers.append(ctypes.c_uint64.from_address(a))
+            if deref(a) == raw0 and deref(b) == alt_raw:
+                by_ref_writers.append(ctypes.c_uint64.from_address(cast("int", a)))
                 continue
             return None
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3515
 * __->__#3514
 * #3513
 * #3512
 * #3511
 * #3510
 * #3509


--- --- ---

[cutedsl] Fix surplus-thread mask elision, reduction-thread budget miscount, and launcher hardening

- Tile bounds masks are no longer elided when the tile's CUDA thread
  axis is launched wider than its own extent (mutually-exclusive branch
  sharing, e.g. split-k's two phases): the surplus threads index past
  the tensor on the last tile, so the elision introduced OOB writes.
  Fixes test_split_k_barrier{,_accuracy}, a pre-existing regression from
  the softmax hillclimb's force_tile_mask=False change (847e9109a).
- The cute reduction-thread budget clamp no longer multiplies the
  per-rdim num_threads slots into 'other_threads' (it corrupted
  persistent reductions into chunk-2 rolled loops or spuriously raised
  InvalidConfig for legal rdim thread counts).
- Launcher fastpath hardening from review: deref probes only touch
  8-aligned high-canonical addresses (a large by-value int must never be
  dereferenced), stream-slot count bound documented, ctypes/threading
  imports hoisted to module level, dead 'or' dropped.