### PR TITLE
[cutedsl] Autotunable L1 eviction hints on vectorized loads

### DIFF
--- a/helion/_compiler/cute/fuse_two_pass_loads.py
+++ b/helion/_compiler/cute/fuse_two_pass_loads.py
@@ -202,8 +202,14 @@ def _trip_count_for(
 
 
 def _node_text(node: ast.AST) -> str:
-    """Stable text key for matching AST nodes."""
-    return ast.unparse(node)
+    """Stable text key for matching AST nodes.
+
+    Per-load-site L1 eviction hints are stripped from the key: the same
+    logical load in different sweeps carries a different (independently
+    tunable) hint, and the hint must not defeat cross-sweep fusion — the
+    surviving first-sweep load keeps its own hint.
+    """
+    return re.sub(r",\s*level1_eviction_priority='[a-z_]+'", "", ast.unparse(node))
 
 
 def _unmasked_load_tensor_dtype(
@@ -276,7 +282,9 @@ def _canonical_load_text(node: ast.AST, lane_var_alias: dict[str, str]) -> str:
     textual form modulo the rename — otherwise identical loads compare
     unequal and fusion bails.
     """
-    text = ast.unparse(node)
+    # Per-load-site eviction hints differ between sweeps and must not
+    # defeat matching (see _node_text).
+    text = re.sub(r",\s*level1_eviction_priority='[a-z_]+'", "", ast.unparse(node))
     for old, new in lane_var_alias.items():
         # Word-boundary replacement so suffixed vars don't pick up matches
         # for shorter prefixes.

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -178,17 +178,27 @@ def _cute_unroll_vec_load_dtype_arg(dtype: torch.dtype, vec_width: int) -> str:
     return f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type)"
 
 
+_CUTE_EVICTION_POLICY_MAP = {
+    "": "",
+    "first": "evict_first",
+    "last": "evict_last",
+}
+
+
 def _cute_vector_load_expr(
     tensor_name: str,
     index_exprs: list[str],
     dtype: torch.dtype,
     *,
     vec_width: int,
+    eviction_suffix: str = "",
 ) -> str:
     elem_str, _ = _CUTE_VECTOR_DTYPES[dtype]
     ptr = _cute_scalar_pointer_expr(tensor_name, index_exprs)
     return (
-        f"cute.arch.load({ptr}, ir.VectorType.get([{vec_width}], {elem_str}.mlir_type))"
+        f"cute.arch.load({ptr}, "
+        f"ir.VectorType.get([{vec_width}], {elem_str}.mlir_type)"
+        f"{eviction_suffix})"
     )
 
 
@@ -215,6 +225,7 @@ def _cute_register_unroll_vec_hoist(
     tensor_name: str,
     index_exprs: list[str],
     vec_width: int,
+    eviction_suffix: str = "",
 ) -> str:
     """Register a Uint16 vec load to be hoisted above the constexpr V-loop
     in the active lane body and return the per-element extract expression.
@@ -253,7 +264,8 @@ def _cute_register_unroll_vec_hoist(
         cache[cache_key] = (hoist_var, tensor.dtype)
         hoist_stmt = statement_from_string(
             f"{hoist_var} = cute.arch.load({base_ptr_expr}, "
-            f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type))"
+            f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type)"
+            f"{eviction_suffix})"
         )
         # Insert the hoist just BEFORE the constexpr V-loop.
         lane_body.insert(lane_body.index(constexpr_loop), hoist_stmt)
@@ -2318,6 +2330,19 @@ def _(state: CodegenState) -> object:
         tensor=tensor,
         include_tensor_index_masks=False,
     )
+    # Autotunable per-load-site L1 eviction hint, applied to the vectorized
+    # load forms (``cute.arch.load``); scalar ``(ptr).load()`` sites ignore
+    # it.  Same site-order indexing scheme as the Triton backend.
+    eviction_suffix = ""
+    if state.codegen.on_device:
+        device_fn = state.device_function
+        load_idx = device_fn.device_load_index
+        device_fn.device_load_index += 1
+        policies = state.config.load_eviction_policies
+        if load_idx < len(policies):
+            mapped = _CUTE_EVICTION_POLICY_MAP.get(policies[load_idx], "")
+            if mapped:
+                eviction_suffix = f", level1_eviction_priority={mapped!r}"
     vec_ctx = _cute_vector_load_ctx(state, tensor, subscript, index_exprs, extra_mask)
     if vec_ctx is not None:
         vec_width, vec_block_id, vec_mode = vec_ctx
@@ -2327,7 +2352,11 @@ def _(state: CodegenState) -> object:
         strategy = loops[-1].strategy if loops else None
         if vec_mode == "vec":
             load_expr = _cute_vector_load_expr(
-                tensor_name, index_exprs, tensor.dtype, vec_width=vec_width
+                tensor_name,
+                index_exprs,
+                tensor.dtype,
+                vec_width=vec_width,
+                eviction_suffix=eviction_suffix,
             )
             # The mask is deferred to the post-fold scalar in
             # codegen_reduction.  The vec load itself is unconditional; the
@@ -2351,6 +2380,7 @@ def _(state: CodegenState) -> object:
                 tensor_name,
                 index_exprs,
                 vec_width,
+                eviction_suffix=eviction_suffix,
             )
         else:
             assert vec_mode == "tile_unroll"
@@ -2367,6 +2397,7 @@ def _(state: CodegenState) -> object:
                 tensor_name,
                 index_exprs,
                 vec_width,
+                eviction_suffix=eviction_suffix,
             )
     else:
         load_expr = _cute_scalar_load_expr(tensor_name, index_exprs, tensor.dtype)

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -922,6 +922,12 @@ _CUTE_IMPLICIT_DEFAULT_KEYS: frozenset[str] = frozenset(
 def get_valid_eviction_policies(backend_name: str) -> tuple[str, ...]:
     if backend_name == "triton" and not supports_amd_cdna_tunables():
         return ("", "first", "last")
+    if backend_name == "cute":
+        # Lowered to ld.global L1 eviction hints
+        # (level1_eviction_priority=evict_first/evict_last) on the
+        # vectorized load sites.  Pays off for reload-from-gmem sweeps
+        # (keep re-read rows resident, evict on the final pass).
+        return ("", "first", "last")
     return ("",)
 
 
@@ -3248,6 +3254,14 @@ class ConfigSpec:
                     and len(self.reduction_loops) > 0
                 ):
                     fields["reduction_loops"] = self.reduction_loops
+                # Per-load-site L1 eviction hints (streamed rows want
+                # evict_first; re-read rows want evict_last until the
+                # final sweep).
+                if (
+                    self.supports_config_key("load_eviction_policies")
+                    and self.load_eviction_policies.length > 0
+                ):
+                    fields["load_eviction_policies"] = self.load_eviction_policies
                 # Universal pid emission honors ``loop_orders`` and the
                 # better order is shape-dependent. tcgen05 exposes the same
                 # field from CuteTcgen05Config.flat_fields().

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -866,15 +866,16 @@ def _cute_lane_axis_pos(strategy: object, block_id: int, index_exprs: list[str])
 
 
 def _cute_unroll_vec_load_expr(
-    ptr_expr: str, dtype: torch.dtype, vec_width: int
+    ptr_expr: str, dtype: torch.dtype, vec_width: int, eviction_suffix: str = ""
 ) -> str:
     """Build the ``cute.arch.load(...)`` RHS for an unroll-mode hoist."""
     if _cute_is_byte_packed(dtype):
         pack = _cute_unroll_vec_elem_type(dtype, vec_width)
-        return f"cute.arch.load({ptr_expr}, {pack})"
+        return f"cute.arch.load({ptr_expr}, {pack}{eviction_suffix})"
     return (
         f"cute.arch.load({ptr_expr}, "
-        f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type))"
+        f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type)"
+        f"{eviction_suffix})"
     )
 
 
@@ -1052,6 +1053,7 @@ def _cute_register_tile_unroll_vec_hoist(
     tensor_name: str,
     index_exprs: list[str],
     vec_width: int,
+    eviction_suffix: str = "",
 ) -> str:
     """Tile-loop variant of ``_cute_register_unroll_vec_hoist`` for
     ``PerThreadNDTileStrategy`` lane loops.
@@ -1143,7 +1145,7 @@ def _cute_register_tile_unroll_vec_hoist(
                 f"else {anchor_ptr_expr})"
             )
         hoist_stmt = statement_from_string(
-            f"{hoist_var} = {_cute_unroll_vec_load_expr(guarded_ptr, tensor.dtype, vec_width)}"
+            f"{hoist_var} = {_cute_unroll_vec_load_expr(guarded_ptr, tensor.dtype, vec_width, eviction_suffix)}"
         )
         # Insert the hoist just BEFORE the constexpr V-loop.
         lane_body.insert(

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -11260,8 +11260,10 @@ class TestCuteAutotuner(TestCase):
         }
         # ``loop_orders`` is exposed for the CuTe non-tcgen05 search
         # surface. ``cute_vector_widths`` is the per-axis vec width slot
-        # registered for non-reduction tile blocks. The set still excludes
-        # Triton-style knobs that the CuTe path does not consume.
+        # registered for non-reduction tile blocks.
+        # ``load_eviction_policies`` carries per-load-site L1 eviction
+        # hints (lowered on the vectorized load forms). The set still
+        # excludes Triton-style knobs that the CuTe path does not consume.
         self.assertEqual(
             flat_keys,
             {
@@ -11272,6 +11274,7 @@ class TestCuteAutotuner(TestCase):
                 "cute_lane_layouts",
                 "cute_cluster_n",
                 "cute_min_blocks_per_mp",
+                "load_eviction_policies",
             },
         )
 
@@ -11294,6 +11297,7 @@ class TestCuteAutotuner(TestCase):
                     "cute_lane_layouts",
                     "cute_cluster_n",
                     "cute_min_blocks_per_mp",
+                    "load_eviction_policies",
                 },
             )
             self.assertNotIn("persistent", config.pid_type)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3515
 * #3514
 * #3513
 * #3512
 * #3511
 * #3510
 * #3509


--- --- ---

[cutedsl] Autotunable L1 eviction hints on vectorized loads

Enables the load_eviction_policies config key for the cute backend:
per-load-site "first"/"last" lower to level1_eviction_priority
evict_first/evict_last on the cute.arch.load vec sites (scalar
(ptr).load() sites ignore the knob).  The fuse pass strips the hint
from its cross-sweep matching keys so per-sweep hints don't defeat
load fusion.  This is the knob behind helion-triton's remaining edge
on 32768x1024 (its winner loses exactly its 4% without evictions);
on cute it measures neutral so far, but the search can now explore it.