### PR TITLE
[autotuner] Tolerate normalization-off-surface enum values in search fragments

### DIFF
--- a/helion/autotuner/config_fragment.py
+++ b/helion/autotuner/config_fragment.py
@@ -332,8 +332,10 @@ class EnumFragment(ConfigSpecFragment):
         return random.choice(self._active_choices())
 
     def pattern_neighbors(self, current: object, radius: int = 1) -> list[object]:
-        if current not in self.choices:
-            raise ValueError(f"{current!r} not a valid choice")
+        # `current` can be outside `choices` when config normalization rewrote
+        # the knob to a value off the searched surface (e.g. cute tcgen05
+        # knobs on configs that opt out of tcgen05); every searched choice is
+        # then a neighbor so the search can step back onto the surface.
         return [choice for choice in self._active_choices() if choice != current]
 
     def differential_mutation(self, a: object, b: object, c: object) -> object:
@@ -374,14 +376,17 @@ class EnumFragment(ConfigSpecFragment):
         return tuple(result)
 
     def encode(self, value: object) -> list[float]:
-        """Encode enum values as their index."""
+        """Encode enum values as a one-hot vector.
+
+        Values outside ``choices`` encode as all zeros rather than raising:
+        config normalization can legally rewrite a knob to a value outside
+        the searched surface (e.g. cute tcgen05 knobs on configs that opt
+        out of tcgen05), and this encoding only feeds surrogate models.
+        """
         try:
             choice_idx = self.choices.index(value)
         except ValueError:
-            raise ValueError(
-                f"Invalid enum value {value!r} for EnumFragment. "
-                f"Valid choices: {self.choices}"
-            ) from None
+            choice_idx = -1
         return [1.0 if i == choice_idx else 0.0 for i in range(len(self.choices))]
 
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3519
 * #3524
 * #3523
 * #3522
 * #3518
 * #3517
 * __->__#3516


--- --- ---

[autotuner] Tolerate normalization-off-surface enum values in search fragments

Config normalization can legally rewrite a knob to a value outside the
searched enum surface (e.g. cute tcgen05 knobs on configs that opt out of
tcgen05: tcgen05_tvm_ffi_launch is pinned to (True,) while opted-out
configs normalize to False). Two EnumFragment methods raised on such
values, aborting every cute matmul/bmm autotune run:

- encode() (feeds the LFBO surrogate) now encodes unknown values as a zero
  one-hot instead of raising.
- pattern_neighbors() now treats every searched choice as a neighbor of an
  off-surface value, letting the search step back onto the surface.