### PR TITLE
[autotuner] Propose uniform-list neighbors for ListOf config keys

### DIFF
--- a/helion/autotuner/config_fragment.py
+++ b/helion/autotuner/config_fragment.py
@@ -530,6 +530,23 @@ class ListOf(ConfigSpecFragment):
                 neighbor = current.copy()
                 neighbor[i] = neighbor_value
                 neighbors.append(neighbor)
+        # Also propose uniform lists (every element set to the same value):
+        # element-at-a-time moves can require crossing worse mixed
+        # configurations (e.g. flipping five memory ops from pointer to
+        # tensor_descriptor one by one), while the uniform move jumps straight
+        # across the valley.
+        if self.length > 1:
+            values: list[object] = []
+            for value in [
+                self.inner.default(),
+                *self.inner.pattern_neighbors(self.inner.default(), radius),
+            ]:
+                if value not in values:
+                    values.append(value)
+            for value in values:
+                uniform = [value] * self.length
+                if uniform != current and uniform not in neighbors:
+                    neighbors.append(uniform)
         return neighbors
 
     def differential_mutation(self, a: object, b: object, c: object) -> list[object]:

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -90,7 +90,8 @@ class PatternSearch(PopulationBasedSearch):
 
     def _algorithm_cache_policy(self) -> dict[str, object]:
         return {
-            "pattern_version": 1,
+            # 2: ListOf.pattern_neighbors also proposes uniform lists.
+            "pattern_version": 2,
             "initial_population": self.initial_population,
             "copies": self.copies,
             "max_generations": self.max_generations,

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1749,12 +1749,14 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         # ListOf: radius is forwarded to inner fragment
         list_frag = ListOf(inner=IntegerFragment(1, 10, 5), length=2)
         neighbors = list_frag.pattern_neighbors([5, 5], radius=2)
-        # Each position yields 4 neighbors (3,4,6,7), total 8
-        self.assertEqual(len(neighbors), 8)
-        # All neighbors differ from base in exactly one position
-        for neighbor in neighbors:
-            diffs = sum(1 for a, b in zip(neighbor, [5, 5], strict=True) if a != b)
-            self.assertEqual(diffs, 1)
+        # Each position yields 4 neighbors (3,4,6,7) = 8 single-position
+        # changes, plus uniform lists (all elements set to the same value
+        # near the inner default): [3,3], [4,4], [6,6], [7,7].
+        single = [n for n in neighbors if n.count(5) == 1]
+        uniform = [n for n in neighbors if n.count(5) == 0]
+        self.assertEqual(len(single), 8)
+        self.assertEqual(sorted(uniform), [[3, 3], [4, 4], [6, 6], [7, 7]])
+        self.assertEqual(len(neighbors), 12)
 
     def test_lfbo_flash_terminal_coordinate_refinement_runs_two_rounds(self):
         def make_fn(source_id: int):

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -215,7 +215,7 @@ class TestPallasLoadBufferCountConfig(TestCase):
         spec = self._config_spec(2)
         field = spec._flat_fields()["pallas_load_buffer_count"]
         self.assertEqual(field.default(), [1, 1])
-        self.assertEqual(field.pattern_neighbors([1, 1]), [[2, 1], [1, 2]])
+        self.assertEqual(field.pattern_neighbors([1, 1]), [[2, 1], [1, 2], [2, 2]])
         self.assertIn(
             ("pallas_load_buffer_count", *field.fingerprint()),
             spec.structural_fingerprint(),


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3519
 * #3524
 * #3523
 * #3522
 * #3518
 * __->__#3517
 * #3516


--- --- ---

[autotuner] Propose uniform-list neighbors for ListOf config keys

Element-at-a-time neighbors force multi-slot keys like `indexing` (one
slot per memory op) to cross from e.g. all-pointer to all-tensor_descriptor
through intermediate mixed configurations that are often worse, stalling
pattern search in a valley; audited attention runs needed exactly this
transition to reach the winning basin. ListOf.pattern_neighbors now also
proposes uniform lists (every element set to the same value near the inner
default), crossing such valleys in one move.

This changes default PatternSearch/LFBO behavior, so pattern_version is
bumped for the cute-flash search-policy cache key.

Part of the autotuner study (see benchmarks/autotuner_study/REPORT.md in a
follow-up commit): combined with the LFBO search-loop fixes this improves
head-to-head final-config quality vs best-known from 1.056x to 1.039x
(worst-seed 1.106x -> 1.065x) at 18% fewer unique candidates over 11
kernels on B200.