### PR TITLE
[autotuner] Fix LFBO search-loop pathologies

### DIFF
--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -217,6 +217,10 @@ class LFBOPatternSearch(PatternSearch):
             compile_timeout_lower_bound=compile_timeout_lower_bound,
             compile_timeout_quantile=compile_timeout_quantile,
         )
+        # Parallel to train_x/train_y: the live member behind each training
+        # row (None for externally seeded rows). Used to sync labels with
+        # rebenchmarked timings before each surrogate fit.
+        self._train_members: list[PopulationMember | None] = []
 
         # Number of neighbors and how many to evalaute
         self.num_neighbors = num_neighbors
@@ -277,7 +281,10 @@ class LFBOPatternSearch(PatternSearch):
         policy = super()._algorithm_cache_policy()
         policy.update(
             {
-                "lfbo_version": 1,
+                # 2: benchmarked-only visited set, per-copy selection floor,
+                # incumbent retention, and rebenchmark-synced surrogate labels
+                # became unconditional.
+                "lfbo_version": 2,
                 "num_neighbors": self.num_neighbors,
                 "radius": self.radius,
                 "frac_selected": self.frac_selected,
@@ -369,9 +376,11 @@ class LFBOPatternSearch(PatternSearch):
         perf: float,
         config: Config,
         fn: object,
+        member: PopulationMember | None = None,
     ) -> None:
         self.train_x.append(encoded)
         self.train_y.append(perf)
+        self._train_members.append(member)
         if self.train_configs is None:
             return
         if self.train_source_hashes is None:
@@ -420,7 +429,18 @@ class LFBOPatternSearch(PatternSearch):
             ):
                 self.train_y[index] = math.inf
 
+    def _sync_training_labels(self) -> None:
+        """Refresh train_y from live members so rebenchmarked timings (which
+        replace noisy one-shot measurements) are what the surrogate learns
+        from. Rows without a live member keep their recorded label."""
+        for index, member in enumerate(self._train_members):
+            if member is None or index >= len(self.train_y):
+                continue
+            if member.perfs and math.isfinite(self.train_y[index]):
+                self.train_y[index] = member.perf
+
     def _fit_surrogate(self) -> None:
+        self._sync_training_labels()
         train_x = np.array(self.train_x)
         train_y = np.array(self.train_y)
 
@@ -642,6 +662,7 @@ class LFBOPatternSearch(PatternSearch):
                 member.perf,
                 member.config,
                 member.fn,
+                member=member,
             )
 
         # Fit model
@@ -698,9 +719,6 @@ class LFBOPatternSearch(PatternSearch):
                     disable_early_stopping=self._path_exhausts_generation_budget(
                         constraints
                     ),
-                    selected_only_visited=bool(
-                        self._cute_flash_lane_policy_enabled and not constraints
-                    ),
                 )
             )
 
@@ -754,6 +772,7 @@ class LFBOPatternSearch(PatternSearch):
                         member.perf,
                         member.config,
                         member.fn,
+                        member=member,
                     )
                 # Fit model
                 self._fit_surrogate()
@@ -1517,6 +1536,7 @@ class LFBOPatternSearch(PatternSearch):
                         member.perf,
                         member.config,
                         member.fn,
+                        member=member,
                     )
                 self._fit_surrogate()
                 self.population.sort(key=performance)
@@ -3065,7 +3085,6 @@ class LFBOPatternSearch(PatternSearch):
                     required_leaf=required_leaf,
                     conditional_surface=required_leaf is not None,
                     disable_early_stopping=True,
-                    selected_only_visited=unrestricted,
                 )
             )
 
@@ -4729,7 +4748,6 @@ class LFBOPatternSearch(PatternSearch):
         conditional_surface: bool = False,
         disable_early_stopping: bool = False,
         neighbor_limit: int | None = None,
-        selected_only_visited: bool = False,
     ) -> Iterator[list[PopulationMember]]:
         """
         Run a single copy of pattern search from the given starting point.
@@ -4798,25 +4816,23 @@ class LFBOPatternSearch(PatternSearch):
                 ):
                     candidates.append(new_member)
                     generated_configs.add(new_member.config)
-                    if not constraints and not selected_only_visited:
-                        # Preserve historical LFBO behavior outside the CuTe
-                        # structural-qualification path.
-                        visited.add(new_member.config)
 
-            # score candidates
+            # Score candidates. Only the selected (i.e. benchmarked)
+            # candidates enter `visited`, so proposals the surrogate rejects
+            # can be re-proposed after it learns more. The incumbent is always
+            # retained and at least one real neighbor is selected so a copy
+            # cannot die from selection-quota truncation.
             n_sorted = int(len(candidates) * self.frac_selected)
-            if constraints and len(candidates) > 1:
+            if len(candidates) > 1:
                 n_sorted = max(2, n_sorted)
             if selected_limit is not None:
                 n_sorted = min(n_sorted, selected_limit)
             candidates = self._surrogate_select(candidates, n_sorted)
-            if constraints or selected_only_visited:
-                selected_neighbors = [
-                    member for member in candidates if member.config != current.config
-                ]
-                candidates = [current, *selected_neighbors[: max(0, n_sorted - 1)]]
-            if constraints or selected_only_visited:
-                visited.update(member.config for member in candidates)
+            selected_neighbors = [
+                member for member in candidates if member.config != current.config
+            ]
+            candidates = [current, *selected_neighbors[: max(0, n_sorted - 1)]]
+            visited.update(member.config for member in candidates)
 
             if len(candidates) <= 1:
                 self.log(f"Copy {copy_idx} finish because of no candidates")

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -3822,6 +3822,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = 2
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search.make_unbenchmarked = Mock(return_value=anchor)
@@ -3942,6 +3943,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(generated)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search.train_source_hashes = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
@@ -4023,6 +4025,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -4108,6 +4111,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -4187,6 +4191,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -4257,6 +4262,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = 7
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._pruned_pattern_search_from = Mock(
@@ -4334,6 +4340,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(exact_space)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         generated: list[PopulationMember] = []
@@ -4909,6 +4916,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search.config_gen = SimpleNamespace(
@@ -5073,6 +5081,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         typed_leaves = []
@@ -5105,7 +5114,6 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             required_leaf=None,
             conditional_surface=False,
             disable_early_stopping=False,
-            selected_only_visited=False,
         ):
             self.assertTrue(disable_early_stopping)
             if selected_limit == 5:
@@ -5117,11 +5125,9 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
                 return iter(((current, first), (first, second)))
             self.assertEqual(selected_limit, 20)
             self.assertIsNone(neighbor_limit)
-            if selected_only_visited:
-                self.assertIsNone(required_leaf)
+            if required_leaf is None:
                 self.assertFalse(conditional_surface)
                 return iter(((current, global_probe_child),))
-            assert required_leaf is not None
             self.assertTrue(conditional_surface)
             return iter(
                 ((current, constrained_probe_children[required_leaf.pipeline_family]),)
@@ -5212,6 +5218,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search.config_gen = SimpleNamespace(
@@ -5309,6 +5316,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._budgeted_range = lambda *args: range(*args)
@@ -5381,6 +5389,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search.config_gen = SimpleNamespace(
@@ -5553,6 +5562,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -5691,6 +5701,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -5825,6 +5836,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             search.initial_population = len(search.population)
             search.train_x = []
             search.train_y = []
+            search._train_members = []
             search.train_configs = []
             search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
             search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -5948,6 +5960,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: (
@@ -6101,6 +6114,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = 1
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -6248,6 +6262,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             search.initial_population = 1
             search.train_x = []
             search.train_y = []
+            search._train_members = []
             search.train_configs = []
             search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
             search._flash_pipeline_lanes = lambda _leaf: ()
@@ -6412,6 +6427,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ()
@@ -6639,6 +6655,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: (
@@ -6760,6 +6777,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = 1
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._budgeted_range = lambda *args: range(*args)
@@ -6877,6 +6895,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = Mock(
@@ -7169,6 +7188,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -7278,6 +7298,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -7452,6 +7473,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: (
@@ -7762,6 +7784,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.initial_population = len(search.population)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: (
@@ -7975,6 +7998,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.config_gen = SimpleNamespace(encode_config=lambda _flat: [0.0])
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = None
         search.train_source_hashes = None
         search._fit_surrogate = Mock()
@@ -8025,6 +8049,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.config_gen = SimpleNamespace(encode_config=lambda flat: flat)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search.train_source_hashes = []
         search._fit_surrogate = Mock()
@@ -8089,6 +8114,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.config_gen = SimpleNamespace(encode_config=lambda flat: flat)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._fit_surrogate = Mock()
         search.config_spec = _cute_flash_test_config_spec()
@@ -8113,10 +8139,8 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         self.assertEqual(len(calls), 2)
         self.assertIsNone(calls[0].kwargs["required_leaf"])
         self.assertFalse(calls[0].kwargs["conditional_surface"])
-        self.assertTrue(calls[0].kwargs["selected_only_visited"])
         self.assertEqual(calls[1].kwargs["required_leaf"], constrained_leaf)
         self.assertTrue(calls[1].kwargs["conditional_surface"])
-        self.assertFalse(calls[1].kwargs["selected_only_visited"])
 
     def test_lfbo_flash_wall_budget_returns_best_before_required_probe(self):
         config = helion.Config(
@@ -8152,6 +8176,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.config_gen = SimpleNamespace(encode_config=lambda flat: flat)
         search.train_x = []
         search.train_y = []
+        search._train_members = []
         search.train_configs = []
         search._fit_surrogate = Mock()
         search.config_spec = _cute_flash_test_config_spec()
@@ -8588,8 +8613,9 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         self.assertIn(unselected.config, reordered_visited)
         self.assertNotIn(retained.config, reordered_visited)
 
-        # Unconstrained/non-flash paths preserve historical eager visited
-        # bookkeeping, including candidates discarded by the surrogate.
+        # Unconstrained/non-flash paths also record only selected candidates
+        # as visited, so proposals the surrogate discards can be re-proposed
+        # once it has learned more.
         search.frac_selected = 0.5
         search._surrogate_select = lambda candidates, count: candidates[:count]
         search._generate_neighbors = lambda _base: [
@@ -8604,7 +8630,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         self.assertEqual(next(unconstrained), [current, rejected])
         self.assertEqual(
             unconstrained_visited,
-            {rejected.config, retained.config, unselected.config},
+            {current.config, rejected.config},
         )
 
         # CuTe's unrestricted continuation runs after constrained paths in each
@@ -8618,7 +8644,6 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             0,
             current,
             selected_only_visited,
-            selected_only_visited=True,
             disable_early_stopping=True,
         )
         self.assertEqual(next(selected_only), [current, rejected])
@@ -12388,14 +12413,14 @@ class TestCuteFlashSearchPolicyCacheKey(unittest.TestCase):
         search.config_spec.cute_flash_search_enabled = False
         search._cute_flash_lane_policy_enabled = False
         non_flash = search._algorithm_cache_policy()
-        self.assertEqual(non_flash["lfbo_version"], 1)
+        self.assertEqual(non_flash["lfbo_version"], 2)
         self.assertNotIn("cute_flash_lane_policy_version", non_flash)
         self.assertIsNone(non_flash["flash_structural_search"])
 
         search.config_spec.cute_flash_search_enabled = True
         search._cute_flash_lane_policy_enabled = True
         cute_flash_policy = search._algorithm_cache_policy()
-        self.assertEqual(cute_flash_policy["lfbo_version"], 1)
+        self.assertEqual(cute_flash_policy["lfbo_version"], 2)
         self.assertEqual(cute_flash_policy["cute_flash_lane_policy_version"], 14)
         self.assertEqual(cute_flash_policy["cute_flash_starting_path_limit"], 17)
         self.assertEqual(cute_flash_policy["cute_flash_family_probe_path_limit"], 18)
@@ -12426,7 +12451,7 @@ class TestCuteFlashSearchPolicyCacheKey(unittest.TestCase):
         quick_policy = search._algorithm_cache_policy()
         self.assertNotIn("cute_flash_lane_policy_version", quick_policy)
         self.assertIsNone(quick_policy["flash_structural_search"])
-        self.assertEqual(quick_policy["lfbo_version"], 1)
+        self.assertEqual(quick_policy["lfbo_version"], 2)
 
     def test_unlimited_and_finite_family_retention_have_distinct_cache_keys(
         self,


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3519
 * #3524
 * #3523
 * #3522
 * __->__#3518
 * #3517
 * #3516


--- --- ---

[autotuner] Fix LFBO search-loop pathologies

Four defects in LFBOPatternSearch/LFBOTreeSearch (the default autotuner)
found by a 468-run autotuning study on B200:

- visited-set poisoning: every *generated* neighbor was permanently added
  to `visited`, even the ~90% the surrogate never selected for
  benchmarking, so an early surrogate mis-score blacklisted a config for
  the rest of the run. Only selected (benchmarked) candidates enter
  `visited` now; rejected proposals can be re-proposed once the surrogate
  has learned more.
- selection-quota truncation: n_sorted = int(len(candidates) * 0.10) hits 0
  once fewer than 10 fresh neighbors remain, silently killing a search copy
  mid-improvement. Each copy now always keeps its incumbent plus at least
  one real neighbor.
- incumbent loss: _surrogate_select could drop the incumbent, letting a
  copy drift to a worse current config. The incumbent is always retained.
- stale surrogate labels: train_y kept the first noisy one-shot timing for
  each config; rebenchmarked refinements never propagated back. Labels are
  re-synced from live members before each surrogate fit.

These behaviors match what the CuTe-flash structural path already did
(selected_only_visited), so that flag is now the universal behavior and is
removed. lfbo_version is bumped for the cute-flash search-policy cache key.

Measured together with the uniform-list neighbor change (head-to-head
re-benchmarked winners, 11 kernels, B200/triton): final-config quality vs
best-known 1.056x -> 1.039x, worst-seed 1.106x -> 1.065x, unique configs
evaluated 759 -> 621 per run. On the cute backend: equal or better on all
7 non-flash cases measured (cross-entropy 1.06x vs 1.23x).