### PR TITLE
[autotuner] Add the autotuner study harness, analysis tooling, and report

### DIFF
--- a/benchmarks/autotuner_study/NOTES.md
+++ b/benchmarks/autotuner_study/NOTES.md
@@ -1,0 +1,264 @@
+# Autotuner study working notes
+
+Campaign artifacts live in /tmp/autotuner_study/ (not committed).
+This file accumulates evidence and design decisions as the study progresses.
+
+## Setup
+
+- 14 kernel cases (benchmarks/autotuner_study/kernels.py), B200, triton backend.
+- Audit: per case, default LFBOTreeSearch x4 seeds, PatternSearch x3, DE x2
+  (126 runs), HELION_SKIP_CACHE=1, fixed seeds, per-candidate CSV logging,
+  case pinned to one GPU. Independent post-search measurement of selected and
+  default config via interleaved_bench(repeat=50).
+- Metrics: quality = independently measured selected-config latency;
+  cost = unique configs evaluated (distinct config_id in autotune.csv).
+
+## Mid-campaign observations (default = LFBOTreeSearch, full effort)
+
+1. Seed-to-seed final-quality variance is the dominant quality problem on
+   compute-bound kernels: attention-2k64 selected 0.279 / 0.303 / 0.362 ms
+   across 3 seeds (worst +29%); gathergemv 0.083-0.101 (+21%). The worst
+   attention run also stopped earliest (308 unique evals) - premature
+   convergence into a bad structural basin (pointer indexing +
+   persistent_interleaved), not budget exhaustion.
+2. Memory-bound kernels (layernorm, rmsnorm, bmm, softmax): the default
+   config or a compiler seed is already within a few % of the final answer;
+   400-1300 unique candidates buy 0-7% over the default config. bmm reached
+   within 5% of best-known at candidate #1 in all 4 runs.
+3. Tail waste: 30-76% of unique candidates are evaluated after the run is
+   already within 1% of its own final result.
+4. Initial population composition (attention): default config 2.6 ms,
+   compiler heuristic seed 0.386 ms, best random-of-97 ~0.37-0.53 ms. The
+   ~100 uniform-random configs contribute almost nothing over the compiler
+   seed; the local search phase (0.386 -> 0.279) is where good runs win.
+5. Structural valley: `indexing` etc. are ListOf fragments whose
+   pattern_neighbors change ONE list slot at a time; moving all 5 memory ops
+   from pointer to tensor_descriptor requires stepping through mixed configs.
+   Winning attention config differs from the compiler seed in block_sizes
+   (2 dims), indexing (3+ slots), num_warps, num_stages simultaneously.
+
+## Code-level issues found by reading (to validate with data)
+
+- LFBO `visited` poisoning: in the non-flash path every *generated* neighbor
+  is added to `visited`, even the ~90% never selected/benchmarked
+  (surrogate_pattern_search.py:4801-4804). The surrogate can permanently
+  blacklist candidates it mis-scored early.
+- Copy death by quantization: n_sorted = int(len(candidates) * 0.10) is 0
+  when <10 fresh candidates remain, ending the copy even when improvement
+  was still happening (surrogate_pattern_search.py:4807-4812).
+- `current` can be dropped by _surrogate_select, letting a copy move to a
+  worse `current` (min over selected only).
+- Stale surrogate labels: train_y keeps the first one-shot perf; rebenchmark
+  refinements never propagate back (except inf-repairs).
+- PatternSearch block-size pair cross-product adds ~4*C(B,2) candidates per
+  generation regardless of observed sensitivity.
+- Initial random population has no dedup (non-flash) and randomizes ALL
+  knobs including <1% ones, adding aliasing + noise.
+- DE re-benchmarks duplicate trial vectors (no config-level memoization).
+
+## Prototype directions (to be driven by full audit data)
+
+- P1 better seeding: replace most of the 100 uniform-random initial configs
+  with a small deterministic structural coverage design over high-impact
+  knobs (pid_type x indexing-uniform x canonical block shapes x warps),
+  anchored at default + compiler seeds; dedup by canonical config; keep loow
+  -impact knobs at defaults in seeds.
+- P2 tiered search: classify fragments into impact tiers (data:
+  impact.py matched pairs); main search mutates only high/medium tier
+  coordinates; a final coordinate-descent sweep handles low-tier knobs
+  (cardinality 2-4 each) on the incumbent.
+- P3 tail/stuck fixes: global early-stop on stagnation; min selection >= 1
+  to avoid quantization death; allow re-proposal (no visited-poisoning);
+  uniform-change neighbors for ListOf keys (set all slots at once).
+- P4 surrogate fixes: re-sync train_y before fit; global selection across
+  copies instead of per-copy quotas.
+
+## Plateau-breakout analysis (91 audit runs)
+
+Simulating a hard stagnation stop on per-generation best-so-far curves
+(threshold 0.5%/gen): patience=3 would end 28/91 runs >1% worse than the
+full run (p95 +14%, max +39%); patience=5 still hurts 16/91 (p95 +7%).
+Late breakouts after long plateaus are real (some are 10-40% gains,
+mostly attention/matmul-class). A pure generation-count stop rule trades
+quality for evaluations; escape mechanisms (multi-slot uniform moves,
+diverse seeds/restarts) should come first, with any stop rule kept
+conservative. The v2 ablation tests patience=3 explicitly (v2 vs v2-nostop).
+
+## Full audit results (99 runs, 11 cases; matmul-class rerun pending)
+
+Quality = mean independently measured selected-config latency / case best
+known; evals = mean unique configs. Summary (default LFBOTreeSearch vs
+PatternSearch vs DE):
+
+- default: quality 1.00-1.38 (attention-2k64 1.10, gathergemv 1.38, bmm
+  1.08, crossentropy 1.09, fp8gemm 1.10), evals 400-1200.
+- PatternSearch: usually the best final quality (attention-2k64 1.001,
+  fp8gemm 1.05, welford 1.01) but 2-3x the evals (1200-2100).
+- DE: fixed 1600 evals; excellent on attention (1.001-1.01), catastrophic
+  on fp8gemm (1.56), gathergemv (1.44), welford (1.19).
+- gathergemv: no algorithm reliably finds the best basin (block [32,64],
+  1 warp, 7 stages); 7/9 runs land 30-60% off.
+- Tail waste 70-94% on memory-bound cases for all algorithms.
+
+Conclusion: the surrogate saves evaluations but gives up real quality vs
+plain pattern search; the v2 goal is PatternSearch-level quality at
+LFBO-level (or lower) evaluation counts.
+
+## Complete audit aggregate (126 runs, 14 cases)
+
+Geomean over cases of (mean selected latency / case best-known); evals =
+mean unique configs per run:
+
+| algorithm      | quality | evals | wall(s) |
+|----------------|---------|-------|---------|
+| default (LFBO) | 1.075   | 744   | 352     |
+| PatternSearch  | 1.054   | 1419  | 426     |
+| DE             | 1.113   | 1598  | 640     |
+
+v2 target: quality <= 1.03 at evals <= 600.
+
+## Ablation + validation results (238 + 84 runs; head-to-head re-measured)
+
+Aggregate over the 11 measurement-stable cases (splitk/gathergemv/
+crossentropy excluded for context-sensitive timing; full-14 tables in
+REPORT.md). quality = geomean over cases of mean head-to-head perf ratio
+vs case best; worst = geomean of per-case worst seed.
+
+| variant             | quality | worst | evals |
+|---------------------|---------|-------|-------|
+| default (old)       | 1.057   | 1.106 | 759   |
+| v2 bundle (p3)      | 1.045   | 1.065 | 512   |
+| v2 no stop          | 1.041   | 1.057 | 591   |
+| v2 fixes only       | 1.043   | 1.075 | 663   |
+| v2 no freeze        | 1.043   | 1.055 | 529   |
+| v2 no seed          | 1.053   | 1.090 | 489   |
+| PatternSearch (old) | 1.030   | 1.049 | 1623  |
+| PatternSearch + v2  | 1.046   | 1.067 | 952   |
+
+Attribution: fixes+uniform moves carry most of the quality gain; structured
+population is protective on attention-4k128/matmul-wide; probe+freeze
+rescues crossentropy/welford; patience-3 stop saves ~15% evals at ~0.4%
+mean quality (cost concentrated in occasional stuck attention runs -
+patience 5 does not fix those; restart-on-stagnation is the right future
+work). Session-to-session head-to-head instability on splitk/gathergemv/
+crossentropy (10-40% context-sensitive swings) is itself a finding: the
+autotuner's objective (isolated do_bench with L2 clears) and deployment-like
+interleaved timing can disagree substantially on those kernels.
+
+## Simplified variant + cute validation (follow-up)
+
+- Branch autotuner-v2-simple (merged to dev): probe/freeze/sweep removed
+  (~284 net lines vs ~535). LFBO fixes + uniform ListOf neighbors are now
+  unconditional (pattern_version/lfbo_version bumped); structured population
+  + stagnation stop stay behind HELION_AUTOTUNER_V2=1.
+- Triton re-validation, stable-11, fresh head-to-head session: old default
+  1.056/1.106/759; simplified default (no flag) 1.039/1.065/621; +flag
+  1.048/1.059/517; old PatternSearch 1.029/1.044/1623.
+- Cute: two pre-existing crashes in the OLD autotuner fixed (EnumFragment
+  encode + pattern_neighbors raised on normalization-off-surface values,
+  aborting every cute matmul/bmm autotune). Post-fix: v2 equal-or-better
+  (crossentropy 1.060 vs 1.227; matmul-class surfaces nearly fully pinned,
+  4-8 unique configs; welford is a rare-basin coin flip). Cute
+  attention-2k64 autotuning fails for all algorithms: hung candidates ->
+  unkillable benchmark worker (D-state) -> run aborts; worker-layer
+  robustness bug, filed as future work.
+
+## Final state correction
+
+This file is a chronological log; sections above describe intermediate
+states and cite pre-fix line numbers that no longer correspond to the final
+tree. What shipped (see REPORT.md section 8): a flag-free improved default
+- the HELION_AUTOTUNER_V2 flag and both features behind it (structured
+population, stagnation stop) were removed after review. The final change
+set is the EnumFragment robustness fixes, uniform-list ListOf neighbors
+(pattern_version 2), and the four LFBO search-loop fixes (lfbo_version 2).
+
+# Round 2 (2026-08-31): robustness — consistently closer to 1.0x
+
+Round 1 shipped as 4 PRs (dev 062bd4a1 = new baseline). Round-2 goal per
+Jason: recompute the baseline at HEAD and make final quality consistently
+closer to 1.0x. All round-2 campaign data lives under
+/tmp/autotuner_study/round2/; prototypes live on branch autotuner-r2.
+
+## Rebaseline
+
+- 154 runs: 8 seeds (201-208) default + 3 seeds PatternSearch per case,
+  14 triton cases, GPUs 1-7 (one case pinned per GPU as before).
+
+## Mechanism findings before the arm campaigns
+
+- Selection vs exploration: joining round-1 winners pools with each run's
+  full evaluated-config set shows runs almost never evaluate-and-reject a
+  config that head-to-head beats their selection — different seeds end in
+  disjoint local optima, so the residual gap is dominated by exploration,
+  not final-pick noise. New tools measure_shortlists.py (times every run's
+  finalist shortlist head-to-head, two A/B passes for a per-case noise
+  floor) and diagnose.py (per-run selected vs shortlist-oracle vs case-best
+  decomposition) make this measurable per run.
+- Metric noise floor: two repeat=200 interleaved passes still disagree by
+  1-2% per config on fast kernels; single-pass regret numbers at repeat=50
+  produced a phantom 3.9% selection regret on rmsnorm whose finalists are
+  actually tied within noise. All regret claims must clear the A/B floor.
+- Timing methodology: the CUDA final shootout (final_rebenchmark_best)
+  times the top-8 shortlist with *unpaired sequential* steady windows;
+  paired interleaved timing and steady timing genuinely disagree on
+  tiering for some kernels (rmsnorm steady shows two tiers 2% apart where
+  interleaved says tied).
+- Early collective stall: most runs stop improving by generation ~3 while
+  searching to 8-17 (confirmatory tail); splitk-32768 collapses at
+  generation 2 with all five copies stalling under patience=1.
+- Accuracy-gate false rejections (the big one): the default accuracy check
+  compares candidates against the kernel's own default-config output with
+  fixed atol=rtol=1e-2. On matmul_split_k (K=32768, fp16) ~85% of
+  candidates — including every split_k>1 config — fail at ~30 of 4096
+  elements, always the same near-zero elements at the same magnitudes:
+  legitimate accumulation-order noise proportional to the global output
+  scale (~N(0,181) here), not element magnitude. fp64 ground-truth check:
+  default config is maxabs 0.24 from truth, split_k=4..32 are 0.4-0.8 —
+  the same numerical class; the gate rejects configs as accurate as its
+  own baseline. The search was structurally confined to split_k=1 in every
+  campaign to date.
+
+## Round-2 prototype arms (env-gated on autotuner-r2)
+
+- HELION_SCALED_ATOL=1 ("acc"): scale the accuracy atol floor by
+  max(1, rms(expected)) per tensor, never tightening. Smoke: splitk search
+  reaches split_k=8 at 0.0215ms vs 0.0380ms baseline-search best (~43%
+  faster), selected config verified against fp64.
+- HELION_AUTOTUNE_POLISH=10 ("polish"): full-neighborhood pattern descent
+  from the incumbent after the main loop (no surrogate pruning), until a
+  round fails to improve. Cheap: most of the neighborhood is already
+  visited (rmsnorm smoke: 26 new evals).
+- HELION_FINAL_INTERLEAVED=1 ("fsel"): paired event-based interleaved
+  timing for the final shortlist shootout instead of unpaired steady
+  windows.
+- HELION_AUTOTUNE_RESTARTS=3 ("hop"): after all copies stall with
+  generation budget left, benchmark 20 radius-2 multi-key kicks of the
+  incumbent and descend from the best kick (basin hopping). Splitk smoke:
+  ran but all kicks failed the (unfixed) accuracy gate — restarts need the
+  acc fix on gate-limited cases.
+- Arm campaign: 5 arms (acc, polish, fsel, hop, all) x 4 seeds x 14 cases,
+  every arm carries the acc fix so non-splitk cases isolate the search
+  changes.
+
+## Round-2 results and ship decision
+
+- Single arms (4 seeds x 14): all four beat baseline on full-14 mean
+  (acc 1.109, polish 1.100, fsel 1.107, hop 1.098 vs baseline 1.194);
+  fsel halves selection regret (1.035 -> 1.014) as predicted by the
+  timing-methodology probe.
+- Bundles (8 seeds x 14): pfa (acc+polish+fsel) 1.077/1.046
+  (full-14/stable-12 means) at 781 evals beats all (=pfa+hop)
+  1.083/1.051 at 888 evals. hop rejected. PatternSearch reference
+  1.228/1.058 at 1538 evals.
+- pfa vs baseline per case (8 seeds): improves or ties 12/14; splitk
+  2.58 -> 1.33, matmul-wide 1.24 -> 1.11, welford 1.14 -> 1.06,
+  crossentropy 1.28 -> 1.19; regressions within noise (attention-4k128
+  +0.7% vs 1.1% floor) or single-seed (softmax one 1.084).
+- Wall time: baseline 295s mean/run, pfa 327s (+11% for +29% evals;
+  parallel compile absorbs most of it), PatternSearch 466s.
+- Ship shape (branch autotuner-r2-ship): scaled atol applies whenever the
+  user didn't pin autotune_baseline_atol (explicit tolerances stay exact),
+  finalist shootout interleaved unless isolated opt-in, polish_rounds=10
+  constructor arg, hop code removed, lfbo_version 3, +2 accuracy unit
+  tests; 343 tests pass.

--- a/benchmarks/autotuner_study/REPORT.md
+++ b/benchmarks/autotuner_study/REPORT.md
@@ -1,0 +1,344 @@
+# Helion autotuner study: audit, redesign, and results
+
+*2026-08-30, B200 (8x), triton backend. All artifacts under `/tmp/autotuner_study/`;
+tooling in `benchmarks/autotuner_study/`; prototype code on branch
+`autotuner-v2-fixes` (worktree `/data/users/jansel/ws7/helion-proto2`).*
+
+## 1. Method
+
+- 14 kernel cases (memory- and compute-bound, no overhead-bound shapes):
+  matmul 4096^3 + wide, attention 2k/d64 + 4k/d128, softmax two-pass, rms/layer
+  norm, cross-entropy 131k vocab, bmm, split-k, long-sum, fp8 gemm,
+  gather-gemv, welford.
+- Every run: fresh subprocess, pinned GPU (each case always on the same GPU),
+  fixed seed, `HELION_SKIP_CACHE=1`, per-candidate CSV via
+  `HELION_AUTOTUNE_LOG`, plus an independent post-search measurement of the
+  selected and default configs.
+- Cost metric: unique configs evaluated (distinct `config_id` per run).
+- Quality metric: the selected config of *every* run of a case re-timed
+  head-to-head in one process/one interleaved batch on the case's GPU
+  (`measure_winners.py`), normalized to the best config that any run of any
+  algorithm found for that case.
+- 5 campaigns, 468 autotuning runs total: audit (126 runs: default
+  LFBOTreeSearch x4 seeds, PatternSearch x3, DifferentialEvolution x2 per
+  case), v2 ablation (238 runs: 5 LFBO variants + PatternSearch-v2, 3/2 seeds),
+  v3/v4 validation (84 runs), sequential wall-time (20 runs).
+
+## 2. What the audit of the current autotuner showed
+
+1. **The default (LFBOTreeSearch) trades real quality for fewer evals.**
+   Geomean final quality 1.085x of best-known at ~744 unique evals/run; plain
+   PatternSearch reaches 1.070 but needs ~1419 evals; DE 1.108 at ~1600.
+2. **Seed variance is the dominant quality failure.** attention-2k64 default
+   runs landed at 0.279/0.303/0.322/0.362 ms (worst +29%); the worst run also
+   *stopped earliest* — premature convergence into a bad structural basin
+   (pointer indexing + persistent_interleaved), not budget exhaustion.
+3. **The 100-config uniform-random initial population is nearly useless.**
+   In attention runs, best random config ~0.37-0.53 ms vs the compiler
+   heuristic seed at 0.386 ms; in layernorm/rmsnorm runs *nothing* random beat
+   the default config. All the differentiating work happens in local search.
+4. **30-94% of evaluations are tail waste** (spent after the run is already
+   within 1% of its own final answer), yet hard early stopping is dangerous:
+   simulating a patience-3 generation stop on the audit curves would end
+   28/91 runs >1% worse (p95 +14%) because late breakouts are real.
+5. **Structural valleys stall the search.** ListOf keys (e.g. `indexing` with
+   5 memory ops) only had element-at-a-time neighbors; crossing from
+   all-`pointer` to all-`tensor_descriptor` required stepping through worse
+   mixed configs. Winning attention configs differ from the compiler seed in
+   block_sizes, indexing, num_warps, and num_stages simultaneously.
+6. **Measurement noise is comparable to tail gains.** Identical configs
+   re-measured across runs vary 1-3.5% (median) and up to ~10% (p90, short
+   kernels); split-k timings are context-sensitive by up to 60% between
+   benchmark harnesses/processes, so late search decisions are noise-driven.
+7. **LFBO implementation issues** (found by reading, confirmed by data):
+   rejected proposals permanently poisoned the `visited` set; per-copy
+   selection quota `int(n*0.10)` truncates to 0 and kills copies when <10
+   fresh neighbors remain; the incumbent can be dropped by surrogate
+   selection so a copy can drift to worse configs; surrogate labels never
+   updated with rebenchmarked timings.
+
+## 3. The v2 feature bundle (all opt-in flags; `HELION_AUTOTUNER_V2=1`)
+
+| Flag | What it does |
+|------|--------------|
+| `search_fixes` (LFBO) | only benchmarked configs enter `visited`; per-copy selection floor (incumbent + >=1 real neighbor); incumbent always retained; surrogate labels re-synced from rebenchmarked members before each fit |
+| `HELION_LISTOF_UNIFORM_NEIGHBORS` | ListOf keys also propose uniform lists (all slots set to one value) so multi-slot valleys are crossed in one move |
+| `structured_population` | FROM_RANDOM initial population = default + seeds + perturbations of the *default* that randomize only high-impact keys (block sizes, reduction loops, warps, stages, pid_type, indexing, ...), low-impact keys stay at defaults; ~25% fully-random tail; deduplicated by canonical config |
+| `probe_first_generation` + `adaptive_freeze_threshold=0.02` | copy 0's first generation is a deterministic single-coordinate probe (batch-median offset-normalized); low-impact coordinates whose measured solo effect stays <2% are frozen for the rest of the main search |
+| `finishing_sweep_rounds=2` | coordinate-descent passes over frozen/low-impact keys around the winner at the end |
+| `stagnation_patience` | stop the main loop after N generations without >max(0.1%, 0.5%) improvement |
+
+## 4. Results (head-to-head re-measured quality)
+
+Every run's selected config from all 448 campaign runs was re-timed in one
+interleaved batch per case. Aggregate = geomean over cases of mean-over-seeds
+quality (1.000 = best config any run found for that case); worst-seed =
+geomean of per-case worst seed; evals = mean unique configs per run.
+
+Over the 11 measurement-stable cases (splitk, gathergemv, and crossentropy
+excluded: their timings swing 10-40% with measurement context, equally for
+all algorithms — see section 5.1):
+
+| algorithm | quality | worst-seed | evals |
+|-----------|---------|------------|-------|
+| default LFBOTreeSearch (old) | 1.057 | 1.106 | 759 |
+| PatternSearch (old) | 1.030 | 1.049 | 1623 |
+| DifferentialEvolution (old) | 1.092 | 1.111 | 1598 |
+| **v2 bundle, patience 3 (new)** | **1.045** | **1.065** | **512** |
+| v2 bundle, no stop | 1.041 | 1.057 | 591 |
+| v2 bundle, patience 5 | 1.060 | 1.087 | 536 |
+| v2 fixes only | 1.043 | 1.075 | 663 |
+| v2 without freeze/probe | 1.043 | 1.055 | 529 |
+| v2 without structured population | 1.053 | 1.090 | 489 |
+| PatternSearch + v2 | 1.046 | 1.067 | 952 |
+
+Headline: **the v2 bundle beats the old default on every axis — ~1.2% faster
+final configs on average, 4pp lower worst-seed regret, and 33% fewer unique
+candidates evaluated.** It reaches within ~1.5% of old PatternSearch's
+quality at less than a third of its evaluations. (Full-14-case aggregates
+show the same ordering: old default 1.093 @ 744 evals vs v2 1.076 @ 498.)
+Raising stop patience to 5 did NOT help — the runs the softer stop was meant
+to save are stuck in bad basins that more grinding does not escape.
+
+Ablation attribution (LFBO base, per-case numbers in the campaign JSONs):
+the search fixes + uniform-list moves carry most of the quality gain
+(attention-2k64 old 1.121 -> fixonly 1.077 -> v2 1.007; fp8gemm 1.096 ->
+fixonly 1.026); the probe/freeze rescues crossentropy (nofreeze 1.359 vs v2
+1.268) and welford (nofreeze-with-probe 1.019 vs fixonly 1.033); structured
+population is protective on attention-4k128 (noseed 1.157 vs 1.052) and
+matmul-wide (1.216 vs 1.106); the patience-3 stop converts tail waste into a
+~14% eval saving at ~0.4% mean quality cost.
+
+## 5. Wall-time (sequential, one run at a time, GPU 1)
+
+5 cases x 2 seeds, strictly one autotuning run at a time, alternating
+baseline/v2 to balance thermal drift, full host available for compilation:
+
+| pair geomean (v2 / baseline) | ratio |
+|------------------------------|-------|
+| wall time | **0.80** |
+| unique candidates | 0.87 |
+| selected-config latency | 1.01 (within noise) |
+
+v2 autotuned 20% faster by wall-clock on this subset (up to 44% faster on
+matmul-4096); one v2 gathergemv run found the rare fast basin (0.0654 ms vs
+baseline's 0.082-0.086). The larger parallel campaigns (all 14 cases) show
+the bigger 33% eval reduction; this sequential subset skews toward cases
+where the baseline is already lean.
+
+### 5.1 Measurement findings that matter beyond this study
+
+- In-search one-shot timings carry a systematic offset vs rebenchmarked
+  values (the coordinate probe needed batch-median normalization), and
+  identical configs vary 1-3.5% median run-to-run.
+- split-k / gather-gemv / cross-entropy timings are context-sensitive by up
+  to 60% between processes and batch compositions (L2/cache state), so the
+  search objective (isolated do_bench with L2 clears) and deployment-style
+  interleaved timing can disagree about which config is best. Future quality
+  evaluations should re-measure candidate winners head-to-head in a single
+  process, as done here.
+
+## 6. Recommendations
+
+1. **Adopt the v2 bundle** (branch `autotuner-v2-fixes`) as the default
+   search behavior after a soak period behind `HELION_AUTOTUNER_V2=1`:
+   better quality, variance, evals, and wall time than the current default.
+   All flags stay independently controllable, and default behavior + cache
+   keys are unchanged when disabled.
+2. **Keep the stop rule at patience 3** for the eval/wall-time win; quality-
+   priority users can set `stagnation_patience=0` (~0.4% better at ~15% more
+   evals) or use PatternSearch+v2 (1.046 at 952 evals) / old PatternSearch
+   (1.030 at 1623 evals).
+3. **Future work, in expected-value order:**
+   - Restart-on-stagnation: instead of stopping a stagnant search, reseed a
+     copy from a structurally different basin (e.g. the best member of the
+     2nd-best structural family). The remaining quality gap is concentrated
+     in occasional stuck runs (attention-2k64: ~1 in 3 seeds lands 15-30%
+     off for every algorithm, old and new).
+   - Cross-run warm starting: seed the surrogate training set from prior
+     runs' per-candidate logs (`seed_training_data` already exists).
+   - Objective fidelity: for cache-context-sensitive kernels, interleave the
+     incumbent into candidate timing batches so the search optimizes
+     deployment-like latency.
+
+## 7. Simplified variant and cute-backend validation (follow-up)
+
+The probe/freeze/sweep machinery was removed after the ablation showed it
+marginal, producing branch `autotuner-v2-simple` (~284 net lines vs ~535):
+
+- **Now unconditional** (they only remove search pathologies and never
+  measured worse): the LFBO fixes (benchmarked-only visited set, per-copy
+  selection floor, incumbent retention, rebenchmark-synced surrogate labels)
+  and uniform ListOf neighbors. `pattern_version`/`lfbo_version` bumped.
+- **Behind `HELION_AUTOTUNER_V2=1`**: structured_population and
+  stagnation_patience=3.
+
+Triton re-validation (84 runs, fresh head-to-head session, 11 stable cases):
+
+| arm | quality | worst-seed | evals |
+|-----|---------|------------|-------|
+| old default | 1.056 | 1.106 | 759 |
+| simplified default (fixes only, no flag) | **1.039** | 1.065 | 621 |
+| simplified + flag (seed+stop) | 1.048 | **1.059** | **517** |
+| old PatternSearch | 1.029 | 1.044 | 1623 |
+
+The simplified branch's *default* behavior is already the quality leader
+among LFBO variants at 18% fewer evals than the old default; the flag adds
+the remaining eval savings (-32% total) and the best worst-seed variance.
+
+Cute-backend validation (7 non-flash cases x 3 seeds x 2 arms, 45 runs)
+surfaced two pre-existing crashes in the *old* autotuner before any
+comparison could run: config normalization writes values outside the
+searched enum surface on tcgen05 matmuls (e.g. `tcgen05_tvm_ffi_launch`
+pinned to `(True,)` while opted-out configs hold `False`), crashing both
+`EnumFragment.encode` and `EnumFragment.pattern_neighbors` — every cute
+matmul/bmm autotune aborted. Both are fixed (out-of-domain values encode as
+zero one-hot / neighbor onto the full surface). With the fixes, head-to-head
+results: cute matmul/bmm search surfaces are nearly fully pinned (4-8 unique
+configs; both arms find the same optimum), crossentropy is a clear v2 win
+(1.060 vs 1.227 of case best), gathergemv/rmsnorm tie, and welford is a
+rare-basin coin flip (1 of 6 runs across both arms found a 2.5x faster
+config). Aggregate 1.17 vs 1.16 — v2 generalizes safely (equal or better,
+no regressions, same eval counts); the mechanisms are backend-agnostic but
+matter less where cute pins most knobs. Separately, cute attention-2k64
+autotuning is broken for *all* algorithms in this environment: hung
+candidate kernels leave benchmark workers unkillable (D-state) and the run
+aborts (3/3 baseline failures) — a robustness bug worth fixing in the
+benchmark-worker layer.
+
+## 8. Final state: flag removed (follow-up 2)
+
+The `HELION_AUTOTUNER_V2` flag and both features behind it (structured
+initial population, stagnation stop) were removed: with a quality-first
+posture the stop rule's ~1% mean quality cost buys nothing we want, and the
+flag-off configuration was the measured quality leader. The shipped result
+is a **flag-free improved default** — net 74 insertions / 31 deletions vs
+the pre-study baseline across 3 files:
+
+- `config_fragment.py`: uniform-list ListOf neighbors; EnumFragment
+  encode/pattern_neighbors tolerate normalization-off-surface values
+  (fixes cute matmul autotune crashes).
+- `surrogate_pattern_search.py`: benchmarked-only visited set, per-copy
+  selection floor, incumbent retention, rebenchmark-synced surrogate labels.
+- `pattern_search.py`: version bump for cute-flash cache-policy keys.
+
+Measured (head-to-head, 11 stable kernels): quality 1.039 vs old 1.056,
+worst-seed 1.065 vs 1.106, evals 621 vs 759. The eval-count-focused knobs
+(smaller budgets) remain available through the existing effort profiles.
+
+## 9. Artifacts
+
+- Tooling: `benchmarks/autotuner_study/` (registry, campaign runner,
+  analyzers, head-to-head measurement, wall-time driver); findings log in
+  `NOTES.md`.
+- Campaigns (per-run CSVs + summaries):
+  `/tmp/autotuner_study/{audit,v2,v2b,v3,v4,walltime}`; head-to-head
+  measurements `winners2.json`; reports `*_report.json`.
+- Code history: branches `autotuner-v2` -> `autotuner-v2-fixes` (full
+  bundle) -> `autotuner-v2-simple` -> final flag-free default on dev; full
+  autotuner test suite passes at every step.
+- Additional campaign roots: `/tmp/autotuner_study/{v2s,cute-base,cute-v2s}`,
+  head-to-head sessions `winners3.json` (triton) and `cutewinners.json` (cute).
+
+## 10. Round 2: robustness — consistently closer to 1.0x (2026-08-31/09-01)
+
+Round 1 shipped as four PRs; round 2 rebaselined at that HEAD (062bd4a1) and
+asked where the remaining gap to 1.0x lives. All quality numbers below are
+head-to-head: every run's selected config (plus each run's finalist
+shortlist) re-measured per case in one interleaved batch on the case's
+pinned GPU, two independent passes to establish a per-case noise floor
+(`measure_shortlists.py` + `diagnose.py`). Lower is better; 1.000 = best
+config any run found. Baseline campaign: 8 seeds default + 3 seeds
+PatternSearch x 14 cases; arm campaigns: 4 seeds per single arm, 8 seeds
+per bundle; ~750 autotune runs total in round 2.
+
+### 10.1 Where the round-1 gap lives (baseline diagnosis)
+
+* Exploration, not selection: decomposing each run's gap into selection
+  error (final shootout picked the wrong finalist) vs exploration error
+  (nothing near case-best ever reached the shortlist) shows the gap is
+  dominated by exploration everywhere except the context-sensitive kernels
+  (splitk, crossentropy, welford), where the unpaired steady final shootout
+  also mis-ranks. Different seeds end in disjoint local optima; e.g.
+  matmul-wide's good basin (block [128-256, 256, 32] + persistent_interleaved)
+  was found by 3/3 PatternSearch runs and 0/8 LFBO runs.
+* Early collective stall: most runs stop improving by generation ~3 while
+  searching to 8-17; the worst attention seed (1.371) stalled at
+  generation 5 of 20 with the rest of its budget unused.
+* Accuracy-gate false rejection (the largest single find): the default
+  check compares candidates to the kernel's own default-config output with
+  fixed elementwise atol=rtol=1e-2. Near-zero elements of large reductions
+  legitimately differ across accumulation orders in proportion to the
+  *global* output scale, so on matmul_split_k (K=32768, fp16) ~85% of
+  candidates — including every split_k>1 config — were falsely rejected
+  (all failures at the same ~30/4096 near-zero elements; fp64 ground truth
+  shows the rejected configs are exactly as accurate as the baseline
+  itself). The search was structurally confined to split_k=1 in every
+  campaign ever run on this kernel.
+
+### 10.2 What was tried (single arms, 4 seeds x 14 cases each)
+
+| arm | change | full-14 mean | stable-12 mean | evals |
+|---|---|---|---|---|
+| baseline | round-1 default | 1.194 | 1.072 | 593 |
+| acc | scale accuracy atol floor by max(1, rms(expected)) | 1.109 | 1.059 | 642 |
+| polish | full-neighborhood descent after the main loop stalls | 1.100 | 1.050 | 777 |
+| fsel | paired interleaved timing for the finalist shootout | 1.107 | 1.075 | 621 |
+| hop | basin-hop restarts reinvesting unused generation budget | 1.098 | 1.052 | 771 |
+
+(4-seed single-arm numbers carry ~±0.01-0.02 of seed luck; the bundles
+below are the 8-seed decision data. fsel cannot change the search
+trajectory — it only re-times the final shortlist — and it halves measured
+selection regret, mean 1.035 -> 1.014.)
+
+### 10.3 Bundles (8 seeds x 14 cases each)
+
+| bundle | full-14 mean / worst-seed | stable-12 mean / worst-seed | evals | wall |
+|---|---|---|---|---|
+| baseline | 1.194 / 1.309 | 1.072 / 1.138 | 593 | 295s |
+| pfa = acc+polish+fsel | **1.077 / 1.192** | **1.046 / 1.111** | 781 | 327s |
+| all = pfa+hop | 1.083 / 1.215 | 1.051 / 1.102 | 888 | 379s |
+| PatternSearch (ref) | 1.228 / 1.249 | 1.058 / 1.072 | 1538 | 466s |
+
+pfa improves or ties 12 of 14 cases at 8 seeds (splitk 2.58 -> 1.33,
+matmul-wide 1.24 -> 1.11, welford 1.14 -> 1.06, crossentropy 1.28 -> 1.19,
+matmul-4096 1.055 -> 1.031, layernorm 1.088 -> 1.060); the two regressions
+are within the case noise floor (attention-4k128 +0.7% vs 1.1% floor) or a
+single-seed miss (softmax 1.084 once, mean 1.013). It beats PatternSearch's
+mean at half the evals and 70% of the wall time. hop was evaluated and
+rejected: inside the bundle it costs ~12% more evals without improving the
+mean.
+
+### 10.4 What ships (flag-free, on top of the round-1 stack)
+
+1. Scale-aware accuracy tolerance: when the user has not pinned an explicit
+   `autotune_baseline_atol`, each tensor leaf's absolute-tolerance floor
+   becomes `atol * max(1, rms(expected))` — never tighter than before,
+   correctly looser for large-magnitude accumulations, still rejects
+   corruption at the output's own scale. User-specified tolerances remain
+   exact.
+2. Polish descent (`polish_rounds=10`): after the surrogate-guided main
+   loop stalls, plain pattern-search descent benchmarks the entire
+   deterministic radius-1 neighborhood (no surrogate pruning) and moves to
+   the best neighbor until a round fails to improve.
+3. Paired finalist timing: the final-verification shortlist is timed with
+   the event-based interleaved bench instead of unpaired sequential steady
+   windows (which drifted 1-3% between candidates and mis-ranked near-tied
+   finalists).
+
+lfbo_version bumped to 3. Cute-flash searches are unaffected by polish
+(they run their own terminal refinement) and pick up the scaled tolerance
+and paired finalist timing.
+
+### 10.5 Remaining gaps / future work
+
+* splitk residual variance: even in the unlocked space, seeds split between
+  the split_k=8 family (~0.021ms) and lesser basins (worst 2.05). The
+  initial population never seeds structured split_k variants.
+* attention-2k64 worst seed is still 1.27: early collective stall in a bad
+  basin; hop attacked this but did not pay for itself overall. A smarter
+  restart trigger (only when generations remain AND the incumbent is far
+  from the surrogate's frontier) may do better.
+* crossentropy/gathergemv timing context-sensitivity (up to 60% across
+  process/batch composition) still limits both the search's own signal and
+  any single-number quality claim.

--- a/benchmarks/autotuner_study/analyze.py
+++ b/benchmarks/autotuner_study/analyze.py
@@ -1,0 +1,265 @@
+"""Analyze autotuner study campaign output.
+
+Reads run directories produced by campaign.py and reports:
+  * per-run: unique candidates evaluated, best-so-far curve, failure mix
+  * per case x algorithm: final quality (independent measurement), candidate
+    counts, wall time, variance across seeds
+  * evals-to-quality: unique candidates needed to get within X% of the best
+    perf any run found for the case
+  * per-config-key impact tiers from matched pairs (configs differing in
+    exactly one key)
+
+Usage:
+    python benchmarks/autotuner_study/analyze.py --root /tmp/autotuner_study/audit [--json out.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import json
+import math
+from pathlib import Path
+import statistics
+import sys
+from typing import Any
+
+TERMINAL_OK = "ok"
+NON_CANDIDATE_STATUSES = {"started"}
+
+
+def load_run(run_dir: Path) -> dict[str, Any] | None:
+    summary_path = run_dir / "summary.json"
+    spec_path = run_dir / "spec.json"
+    csv_path = run_dir / "autotune.csv"
+    if not summary_path.exists() or not csv_path.exists():
+        return None
+    summary = json.loads(summary_path.read_text())
+    spec = json.loads(spec_path.read_text()) if spec_path.exists() else {}
+
+    with csv_path.open() as f:
+        rows: list[dict[str, str]] = list(csv.DictReader(f))
+
+    # Terminal rows in order; unique candidate index assigned at first
+    # terminal appearance of each config_id.
+    seen: dict[str, int] = {}
+    events: list[dict[str, Any]] = []  # per terminal row
+    for row in rows:
+        status = row["status"]
+        if status in NON_CANDIDATE_STATUSES:
+            continue
+        config_id = row["config_id"]
+        if config_id not in seen:
+            seen[config_id] = len(seen)
+        perf = float(row["perf_ms"]) if row["perf_ms"] else math.inf
+        events.append(
+            {
+                "config_id": config_id,
+                "unique_idx": seen[config_id],
+                "generation": int(row["generation"] or 0),
+                "status": status,
+                "perf_ms": perf,
+                "timestamp_s": float(row["timestamp_s"] or 0.0),
+            }
+        )
+
+    # Best-so-far curve indexed by number of unique candidates evaluated.
+    best_curve: list[tuple[int, float]] = []  # (n_unique_evaluated, best_perf)
+    best = math.inf
+    n_unique = 0
+    for ev in events:
+        n_unique = max(n_unique, ev["unique_idx"] + 1)
+        if ev["status"] == TERMINAL_OK and ev["perf_ms"] < best:
+            best = ev["perf_ms"]
+            best_curve.append((n_unique, best))
+
+    status_counts = collections.Counter(ev["status"] for ev in events)
+    gen_counts = collections.Counter(ev["generation"] for ev in events)
+
+    # Measurement-noise floor: spread among repeated ok-measurements of the
+    # same config within this run.
+    perfs_by_config: dict[str, list[float]] = collections.defaultdict(list)
+    for ev in events:
+        if ev["status"] == TERMINAL_OK and math.isfinite(ev["perf_ms"]):
+            perfs_by_config[ev["config_id"]].append(ev["perf_ms"])
+    noise_ratios = sorted(
+        max(perfs) / min(perfs)
+        for perfs in perfs_by_config.values()
+        if len(perfs) >= 2 and min(perfs) > 0
+    )
+
+    # Phase attribution: best ok perf within the initial population (gen 0).
+    gen0_best = min(
+        (
+            ev["perf_ms"]
+            for ev in events
+            if ev["generation"] == 0 and ev["status"] == TERMINAL_OK
+        ),
+        default=math.inf,
+    )
+    gen0_unique = len({ev["config_id"] for ev in events if ev["generation"] == 0})
+
+    metrics = summary.get("metrics") or [{}]
+    return {
+        "run_id": run_dir.name,
+        "case": summary["case"],
+        "algorithm": (spec.get("algorithm") or "default")
+        + (f"-{spec['tag']}" if spec.get("tag") else ""),
+        "seed": int(summary.get("seed") or 0),
+        "selected_perf_ms": summary.get("selected_perf_ms"),
+        "default_perf_ms": summary.get("default_perf_ms"),
+        "wall_time_s": summary.get("wall_time_s"),
+        "n_unique": n_unique,
+        "n_attempts": len(events),
+        "status_counts": dict(status_counts),
+        "gen_counts": dict(sorted(gen_counts.items())),
+        "best_curve": best_curve,
+        "final_search_best": best,
+        "gen0_best": gen0_best,
+        "gen0_unique": gen0_unique,
+        "noise_ratio_p50": (
+            noise_ratios[len(noise_ratios) // 2] if noise_ratios else None
+        ),
+        "noise_ratio_p90": (
+            noise_ratios[min(len(noise_ratios) - 1, int(0.9 * len(noise_ratios)))]
+            if noise_ratios
+            else None
+        ),
+        "metrics": metrics[0] if metrics else {},
+    }
+
+
+def evals_to_reach(best_curve: list[tuple[int, float]], target: float) -> int | None:
+    for n_unique, best in best_curve:
+        if best <= target:
+            return n_unique
+    return None
+
+
+def fmt(x: float | None, digits: int = 3) -> str:
+    if x is None:
+        return "-"
+    return f"{x:.{digits}f}"
+
+
+def summarize(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    by_case: dict[str, list[dict[str, Any]]] = collections.defaultdict(list)
+    for run in runs:
+        by_case[run["case"]].append(run)
+
+    report: dict[str, Any] = {"cases": {}}
+    for case, case_runs in sorted(by_case.items()):
+        # Best independently-measured perf across all runs of this case.
+        best_known = min(
+            (r["selected_perf_ms"] for r in case_runs if r["selected_perf_ms"]),
+            default=None,
+        )
+        case_report: dict[str, Any] = {"best_known_ms": best_known, "algorithms": {}}
+        by_alg: dict[str, list[dict[str, Any]]] = collections.defaultdict(list)
+        for run in case_runs:
+            by_alg[run["algorithm"]].append(run)
+        for alg, alg_runs in sorted(by_alg.items()):
+            perfs = [r["selected_perf_ms"] for r in alg_runs if r["selected_perf_ms"]]
+            uniques = [r["n_unique"] for r in alg_runs]
+            walls = [r["wall_time_s"] for r in alg_runs if r["wall_time_s"]]
+            # candidates needed to get search-best within 5% of case best-known
+            reach5 = []
+            if best_known:
+                for r in alg_runs:
+                    reach5.append(evals_to_reach(r["best_curve"], best_known * 1.05))
+            # Fraction of the unique-candidate budget spent after the search
+            # was already within 1% of its own final best (wasted tail).
+            tails = []
+            gen0_fracs = []
+            for r in alg_runs:
+                if r["best_curve"] and r["n_unique"]:
+                    n_at = evals_to_reach(
+                        r["best_curve"], r["final_search_best"] * 1.01
+                    )
+                    if n_at is not None:
+                        tails.append(1.0 - n_at / r["n_unique"])
+                if (
+                    r["default_perf_ms"]
+                    and math.isfinite(r["gen0_best"])
+                    and math.isfinite(r["final_search_best"])
+                    and r["default_perf_ms"] > r["final_search_best"]
+                ):
+                    total_gain = r["default_perf_ms"] - r["final_search_best"]
+                    gen0_gain = max(0.0, r["default_perf_ms"] - r["gen0_best"])
+                    gen0_fracs.append(min(1.0, gen0_gain / total_gain))
+            case_report["algorithms"][alg] = {
+                "n_runs": len(alg_runs),
+                "tail_waste_mean": statistics.mean(tails) if tails else None,
+                "gen0_gain_frac_mean": (
+                    statistics.mean(gen0_fracs) if gen0_fracs else None
+                ),
+                "perf_ms_mean": statistics.mean(perfs) if perfs else None,
+                "perf_ms_max": max(perfs) if perfs else None,
+                "perf_ms_min": min(perfs) if perfs else None,
+                "vs_best_known_mean": (
+                    statistics.mean(p / best_known for p in perfs)
+                    if perfs and best_known
+                    else None
+                ),
+                "unique_mean": statistics.mean(uniques) if uniques else None,
+                "wall_s_mean": statistics.mean(walls) if walls else None,
+                "reach_5pct": reach5,
+                "seeds": sorted(r["seed"] for r in alg_runs),
+            }
+        report["cases"][case] = case_report
+    return report
+
+
+def print_report(report: dict[str, Any]) -> None:
+    for case, case_report in report["cases"].items():
+        best_known = case_report["best_known_ms"]
+        print(f"\n=== {case} (best known {fmt(best_known, 4)} ms) ===")
+        header = (
+            f"{'algorithm':<32}{'runs':>5}{'perf(ms) mean':>15}{'worst':>9}"
+            f"{'vs best':>9}{'#unique':>9}{'wall(s)':>9}{'tail':>7}{'gen0':>7}  reach5%"
+        )
+        print(header)
+        for alg, stats in case_report["algorithms"].items():
+            reach = ",".join(str(n) if n else "-" for n in stats["reach_5pct"])
+            print(
+                f"{alg:<32}{stats['n_runs']:>5}"
+                f"{fmt(stats['perf_ms_mean'], 4):>15}"
+                f"{fmt(stats['perf_ms_max'], 4):>9}"
+                f"{fmt(stats['vs_best_known_mean'], 3):>9}"
+                f"{fmt(stats['unique_mean'], 0):>9}"
+                f"{fmt(stats['wall_s_mean'], 0):>9}"
+                f"{fmt(stats['tail_waste_mean'], 2):>7}"
+                f"{fmt(stats['gen0_gain_frac_mean'], 2):>7}  {reach}"
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--json", default=None)
+    args = parser.parse_args()
+
+    root = Path(args.root)
+    runs = []
+    for run_dir in sorted(root.iterdir()):
+        if not run_dir.is_dir():
+            continue
+        run = load_run(run_dir)
+        if run is not None:
+            runs.append(run)
+    if not runs:
+        print("no completed runs found", file=sys.stderr)
+        return
+    print(f"loaded {len(runs)} completed runs")
+
+    report = summarize(runs)
+    print_report(report)
+    if args.json:
+        report["runs"] = runs
+        Path(args.json).write_text(json.dumps(report, indent=2, default=str))
+        print(f"\nwrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/campaign.py
+++ b/benchmarks/autotuner_study/campaign.py
@@ -1,0 +1,214 @@
+"""Orchestrate many autotuning runs across GPUs for the autotuner study.
+
+Each run executes run_one.py in a fresh subprocess with a pinned GPU, a fixed
+random seed, cache disabled, and per-candidate CSV logging enabled. Runs for
+the same kernel case are always assigned the same GPU so timings are
+apples-to-apples; different cases run in parallel on different GPUs.
+
+Usage:
+    python benchmarks/autotuner_study/campaign.py --plan audit --out /tmp/autotuner_study/audit
+    python benchmarks/autotuner_study/campaign.py --plan-file plan.json --out DIR
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from kernels import KERNEL_CASES  # noqa: E402  # pyrefly: ignore [missing-import]
+
+PRECOMPILE_JOBS = 48  # keep host CPU load fair across up to 8 concurrent runs
+
+
+def default_gpus() -> list[int]:
+    """All visible GPUs. On shared machines pass --gpus to avoid busy devices."""
+    import torch
+
+    return list(range(max(1, torch.cuda.device_count())))
+
+
+@dataclasses.dataclass
+class RunSpec:
+    case: str
+    algorithm: str | None  # None = default autotuner (LFBOTreeSearch)
+    seed: int
+    autotune_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
+    extra_env: dict[str, str] = dataclasses.field(default_factory=dict)
+    tag: str = ""
+
+    @property
+    def run_id(self) -> str:
+        alg = self.algorithm or "default"
+        tag = f"-{self.tag}" if self.tag else ""
+        return f"{self.case}--{alg}{tag}--s{self.seed}"
+
+
+def audit_plan() -> list[RunSpec]:
+    """~126 runs auditing current algorithms across 14 kernel cases."""
+    runs: list[RunSpec] = []
+    for case in KERNEL_CASES:
+        for seed in (101, 102, 103, 104):
+            runs.append(RunSpec(case, None, seed))
+        for seed in (101, 102, 103):
+            runs.append(RunSpec(case, "PatternSearch", seed))
+        for seed in (101, 102):
+            runs.append(RunSpec(case, "DifferentialEvolutionSearch", seed))
+    return runs
+
+
+def run_env(spec: RunSpec, gpu: int, run_dir: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    env.update(
+        {
+            "CUDA_VISIBLE_DEVICES": str(gpu),
+            "HELION_AUTOTUNE_RANDOM_SEED": str(spec.seed),
+            "HELION_SKIP_CACHE": "1",
+            "HELION_AUTOTUNE_LOG": str(run_dir / "autotune"),
+            "HELION_AUTOTUNE_LOG_DETAILS": "1",
+            "HELION_AUTOTUNE_PRECOMPILE_JOBS": str(PRECOMPILE_JOBS),
+            "HELION_AUTOTUNE_PROGRESS_BAR": "0",
+        }
+    )
+    if spec.algorithm is not None:
+        env["HELION_AUTOTUNER"] = spec.algorithm
+    else:
+        env.pop("HELION_AUTOTUNER", None)
+    env.update(spec.extra_env)
+    return env
+
+
+def execute_run(spec: RunSpec, gpu: int, out_root: Path) -> dict[str, Any]:
+    run_dir = out_root / spec.run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    # The autotune log sink appends; clear any telemetry left by a failed
+    # earlier attempt so analyzers never merge two attempts into one run.
+    for stale in run_dir.glob("autotune.*"):
+        stale.unlink()
+    (run_dir / "spec.json").write_text(json.dumps(dataclasses.asdict(spec), indent=2))
+    log_path = run_dir / "run.log"
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "benchmarks" / "autotuner_study" / "run_one.py"),
+        "--case",
+        spec.case,
+        "--out",
+        str(run_dir),
+        "--autotune-kwargs",
+        json.dumps(spec.autotune_kwargs),
+    ]
+    start = time.time()
+    with log_path.open("w") as log_file:
+        proc = subprocess.run(
+            cmd,
+            env=run_env(spec, gpu, run_dir),
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            cwd=str(REPO_ROOT),
+            check=False,
+        )
+    return {
+        "run_id": spec.run_id,
+        "gpu": gpu,
+        "returncode": proc.returncode,
+        "elapsed_s": time.time() - start,
+    }
+
+
+def worker(
+    gpu: int,
+    queue: list[RunSpec],
+    lock: threading.Lock,
+    out_root: Path,
+    results: list[dict[str, Any]],
+) -> None:
+    while True:
+        with lock:
+            if not queue:
+                return
+            spec = queue.pop(0)
+        done_marker = out_root / spec.run_id / "summary.json"
+        if done_marker.exists():
+            print(f"[gpu{gpu}] SKIP (done) {spec.run_id}", flush=True)
+            continue
+        print(f"[gpu{gpu}] START {spec.run_id}", flush=True)
+        result = execute_run(spec, gpu, out_root)
+        status = "OK" if result["returncode"] == 0 else f"FAIL({result['returncode']})"
+        print(
+            f"[gpu{gpu}] {status} {spec.run_id} in {result['elapsed_s']:.0f}s",
+            flush=True,
+        )
+        with lock:
+            results.append(result)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plan", choices=["audit"], default=None)
+    parser.add_argument("--plan-file", default=None)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--gpus", default=None, help="comma-separated GPU indices")
+    parser.add_argument("--cases", default=None, help="comma-separated case filter")
+    args = parser.parse_args()
+
+    if args.plan == "audit":
+        runs = audit_plan()
+    elif args.plan_file:
+        raw = json.loads(Path(args.plan_file).read_text())
+        runs = [RunSpec(**spec) for spec in raw]
+    else:
+        raise SystemExit("need --plan or --plan-file")
+
+    if args.cases:
+        wanted = set(args.cases.split(","))
+        runs = [r for r in runs if r.case in wanted]
+
+    gpus = [int(g) for g in args.gpus.split(",")] if args.gpus else default_gpus()
+    out_root = Path(args.out)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    # Pin every run of a case to one GPU (stable across invocations and
+    # case filters: the mapping is derived from the full registry).
+    all_cases = sorted(KERNEL_CASES)
+    case_gpu = {case: gpus[i % len(gpus)] for i, case in enumerate(all_cases)}
+    queues: dict[int, list[RunSpec]] = {gpu: [] for gpu in gpus}
+    for run in runs:
+        queues[case_gpu[run.case]].append(run)
+
+    print(f"{len(runs)} runs over GPUs {gpus}")
+    for gpu in gpus:
+        print(f"  gpu{gpu}: {len(queues[gpu])} runs")
+
+    lock = threading.Lock()
+    results: list[dict[str, Any]] = []
+    threads = [
+        threading.Thread(
+            target=worker, args=(gpu, queues[gpu], lock, out_root, results)
+        )
+        for gpu in gpus
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    (out_root / "campaign_results.json").write_text(json.dumps(results, indent=2))
+    failed = [r for r in results if r["returncode"] != 0]
+    print(f"complete: {len(results)} executed, {len(failed)} failed")
+    for r in failed:
+        print(f"  FAILED {r['run_id']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/diagnose.py
+++ b/benchmarks/autotuner_study/diagnose.py
@@ -1,0 +1,196 @@
+"""Decompose per-run final-quality gaps into selection vs exploration error.
+
+Joins campaign run directories with the head-to-head shortlist measurements
+from measure_shortlists.py. For every run:
+
+  * selected_ratio   = h2h(selected config) / h2h(case best config)
+  * oracle_ratio     = min over the run's finalist shortlist of h2h / case best
+  * selection_regret = selected_ratio / oracle_ratio
+        (>1 means the final shootout picked the wrong finalist under noise)
+  * exploration gap  = oracle_ratio - 1.0
+        (>0 means nothing near the case best ever reached the shortlist)
+  * saw_best         = whether the case-best config was *evaluated at all*
+        during the run (exact config match over the full per-candidate CSV)
+
+Each case must appear in exactly one shortlists file (the per-GPU split
+produced by measure_shortlists.py); duplicate cases across files are not
+merged - the last file wins.
+
+Usage:
+    python benchmarks/autotuner_study/diagnose.py \
+        --roots /tmp/autotuner_study/round2/baseline \
+        --shortlists shortlists_gpu1.json shortlists_gpu2.json ... [--json out.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import json
+from pathlib import Path
+import statistics
+import sys
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def canonical(config: dict[str, Any]) -> str:
+    return json.dumps(config, sort_keys=True, default=str)
+
+
+def load_shortlists(paths: list[Path]) -> dict[str, dict[str, Any]]:
+    """case -> {perf_by_key, best_ms, best_key, refs_by_run}."""
+    cases: dict[str, dict[str, Any]] = {}
+    for path in paths:
+        for case, entries in json.loads(path.read_text()).items():
+            perf_by_key: dict[str, float] = {}
+            refs_by_run: dict[str, list[tuple[str, dict[str, Any]]]] = (
+                collections.defaultdict(list)
+            )
+            spreads: list[float] = []
+            for entry in entries:
+                key = canonical(entry["config"])
+                perf_by_key[key] = entry["perf_ms"]
+                if "perf_ms_a" in entry:
+                    spreads.append(
+                        abs(entry["perf_ms_a"] - entry["perf_ms_b"]) / entry["perf_ms"]
+                    )
+                for run_id, ref in entry["refs"].items():
+                    refs_by_run[run_id].append((key, ref))
+            best_key = min(perf_by_key, key=perf_by_key.get)  # type: ignore[arg-type]
+            spreads.sort()
+            noise_floor = (
+                spreads[min(len(spreads) - 1, int(0.9 * len(spreads)))]
+                if spreads
+                else 0.0
+            )
+            cases[case] = {
+                "perf_by_key": perf_by_key,
+                "best_ms": perf_by_key[best_key],
+                "best_key": best_key,
+                "noise_floor": noise_floor,
+                "refs_by_run": dict(refs_by_run),
+            }
+    return cases
+
+
+def run_evaluated_keys(run_dir: Path) -> set[str]:
+    """Canonical keys of every config that got a terminal ok/fail row."""
+    import helion
+
+    csv_path = run_dir / "autotune.csv"
+    reprs: set[str] = set()
+    with csv_path.open() as f:
+        for row in csv.DictReader(f):
+            if row["status"] != "started":
+                reprs.add(row["config"])
+    keys: set[str] = set()
+    for config_repr in reprs:
+        config = eval(config_repr, {"Config": helion.Config})
+        keys.add(canonical(config.config))
+    return keys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--roots", nargs="+", required=True)
+    parser.add_argument("--shortlists", nargs="+", required=True)
+    parser.add_argument("--json", default=None)
+    args = parser.parse_args()
+
+    cases = load_shortlists([Path(p) for p in args.shortlists])
+
+    rows: list[dict[str, Any]] = []
+    for root in [Path(r) for r in args.roots]:
+        for run_dir in sorted(root.iterdir()):
+            summary_path = run_dir / "summary.json"
+            spec_path = run_dir / "spec.json"
+            if not summary_path.exists():
+                continue
+            summary = json.loads(summary_path.read_text())
+            spec = json.loads(spec_path.read_text()) if spec_path.exists() else {}
+            case = summary["case"]
+            if case not in cases:
+                continue
+            info = cases[case]
+            run_id = f"{root.name}/{run_dir.name}"
+            refs = info["refs_by_run"].get(run_id, [])
+            selected_keys = [k for k, ref in refs if ref.get("selected")]
+            shortlist_keys = [k for k, ref in refs if "rank" in ref]
+            if not selected_keys:
+                continue
+            best_ms = info["best_ms"]
+            selected_ms = info["perf_by_key"][selected_keys[0]]
+            oracle_candidates = [
+                info["perf_by_key"][k] for k in {*selected_keys, *shortlist_keys}
+            ]
+            oracle_ms = min(oracle_candidates)
+            saw_best = info["best_key"] in run_evaluated_keys(run_dir)
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "case": case,
+                    "algorithm": (spec.get("algorithm") or "default")
+                    + (f"-{spec['tag']}" if spec.get("tag") else ""),
+                    "seed": spec.get("seed"),
+                    "selected_ratio": selected_ms / best_ms,
+                    "oracle_ratio": oracle_ms / best_ms,
+                    "selection_regret": selected_ms / oracle_ms,
+                    "noise_floor": info["noise_floor"],
+                    "real_regret": (selected_ms / oracle_ms - 1.0)
+                    > max(0.01, info["noise_floor"]),
+                    "saw_best": saw_best,
+                }
+            )
+
+    by_group: dict[tuple[str, str], list[dict[str, Any]]] = collections.defaultdict(
+        list
+    )
+    for row in rows:
+        by_group[(row["case"], row["algorithm"])].append(row)
+
+    header = (
+        f"{'case':<20}{'algorithm':<24}{'n':>3}{'sel mean':>9}{'sel max':>9}"
+        f"{'orc mean':>9}{'orc max':>9}{'noise':>7}{'regret':>7}{'saw_best':>9}"
+    )
+    print(header)
+    agg: dict[str, list[float]] = collections.defaultdict(list)
+    for (case, algorithm), group in sorted(by_group.items()):
+        sel = [g["selected_ratio"] for g in group]
+        orc = [g["oracle_ratio"] for g in group]
+        regret = sum(g["real_regret"] for g in group)
+        saw = sum(g["saw_best"] for g in group)
+        print(
+            f"{case:<20}{algorithm:<24}{len(group):>3}"
+            f"{statistics.mean(sel):>9.3f}{max(sel):>9.3f}"
+            f"{statistics.mean(orc):>9.3f}{max(orc):>9.3f}"
+            f"{group[0]['noise_floor']:>7.3f}"
+            f"{regret:>7}{saw:>6}/{len(group)}"
+        )
+        agg[algorithm + "|sel"].extend(sel)
+        agg[algorithm + "|orc"].extend(orc)
+        agg[algorithm + "|regret"].extend(g["selection_regret"] for g in group)
+
+    print("\noverall by algorithm:")
+    algorithms = sorted({key.split("|")[0] for key in agg})
+    for algorithm in algorithms:
+        sel = agg[algorithm + "|sel"]
+        orc = agg[algorithm + "|orc"]
+        regret = agg[algorithm + "|regret"]
+        print(
+            f"  {algorithm:<24} n={len(sel):<4} selected mean {statistics.mean(sel):.3f}"
+            f" max {max(sel):.3f} | oracle mean {statistics.mean(orc):.3f}"
+            f" max {max(orc):.3f} | mean regret {statistics.mean(regret):.3f}"
+        )
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(rows, indent=2))
+        print(f"wrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/final_table.py
+++ b/benchmarks/autotuner_study/final_table.py
@@ -1,0 +1,146 @@
+"""Build the final old-vs-new comparison table for the autotuner study.
+
+Quality comes from the head-to-head winners measurement (measure_winners.py
+output): each run's selected config was re-timed in one interleaved batch per
+case, removing cross-process measurement bias. Cost comes from each run's
+per-candidate CSV (unique config_ids). Wall time comes from run summaries
+(only comparable for sequentially executed campaigns).
+
+Usage:
+    python benchmarks/autotuner_study/final_table.py \
+        --winners /tmp/autotuner_study/winners.json \
+        --roots /tmp/autotuner_study/audit /tmp/autotuner_study/v2 ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import json
+import math
+from pathlib import Path
+import statistics
+from typing import Any
+
+
+def load_runs(roots: list[Path]) -> list[dict[str, Any]]:
+    runs = []
+    for root in roots:
+        for run_dir in sorted(root.iterdir()):
+            summary_path = run_dir / "summary.json"
+            csv_path = run_dir / "autotune.csv"
+            spec_path = run_dir / "spec.json"
+            if not summary_path.exists() or not csv_path.exists():
+                continue
+            summary = json.loads(summary_path.read_text())
+            spec = json.loads(spec_path.read_text()) if spec_path.exists() else {}
+            unique = set()
+            with csv_path.open() as f:
+                for row in csv.DictReader(f):
+                    if row["status"] != "started":
+                        unique.add(row["config_id"])
+            label = (spec.get("algorithm") or "default") + (
+                f"-{spec['tag']}" if spec.get("tag") else ""
+            )
+            runs.append(
+                {
+                    "root": root.name,
+                    "run_id": f"{root.name}/{run_dir.name}",
+                    "case": summary["case"],
+                    "label": label,
+                    "config_key": json.dumps(
+                        summary["selected_config"], sort_keys=True, default=str
+                    ),
+                    "n_unique": len(unique),
+                    "wall_time_s": summary.get("wall_time_s"),
+                }
+            )
+    return runs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--winners", required=True)
+    parser.add_argument("--roots", nargs="+", required=True)
+    parser.add_argument("--labels", default=None, help="comma-separated label filter")
+    args = parser.parse_args()
+
+    winners = json.loads(Path(args.winners).read_text())
+    # case -> config_key -> head-to-head measured perf
+    measured: dict[str, dict[str, float]] = {}
+    case_best: dict[str, float] = {}
+    for case, entries in winners.items():
+        table = {}
+        for entry in entries:
+            key = json.dumps(entry["config"], sort_keys=True, default=str)
+            table[key] = entry["perf_ms"]
+        measured[case] = table
+        case_best[case] = min(table.values())
+
+    runs = load_runs([Path(r) for r in args.roots])
+    wanted = set(args.labels.split(",")) if args.labels else None
+
+    # per label per case: quality ratios (head-to-head), evals
+    by_label: dict[str, dict[str, list[dict[str, Any]]]] = collections.defaultdict(
+        lambda: collections.defaultdict(list)
+    )
+    missing = 0
+    for run in runs:
+        if wanted is not None and run["label"] not in wanted:
+            continue
+        table = measured.get(run["case"])
+        if table is None:
+            continue
+        perf = table.get(run["config_key"])
+        if perf is None:
+            missing += 1
+            continue
+        run["h2h_perf"] = perf
+        run["quality"] = perf / case_best[run["case"]]
+        by_label[run["label"]][run["case"]].append(run)
+    if missing:
+        print(f"note: {missing} runs' configs missing from winners measurement")
+
+    labels = sorted(by_label)
+    cases = sorted({c for label in labels for c in by_label[label]})
+    print("\nPer-case quality (head-to-head perf / case best; mean over seeds):")
+    header = f"{'case':<20}" + "".join(f"{label:>22}" for label in labels)
+    print(header)
+    for case in cases:
+        row = f"{case:<20}"
+        for label in labels:
+            runs_here = by_label[label].get(case, [])
+            if runs_here:
+                q = statistics.mean(r["quality"] for r in runs_here)
+                e = statistics.mean(r["n_unique"] for r in runs_here)
+                row += f"{q:>14.3f} ({e:>4.0f})"
+            else:
+                row += f"{'-':>22}"
+        print(row)
+
+    print("\nAggregate (geomean quality, mean/median evals, worst-case quality):")
+    for label in labels:
+        quals = []
+        evals = []
+        worst = []
+        for case in cases:
+            runs_here = by_label[label].get(case, [])
+            if not runs_here:
+                continue
+            quals.append(statistics.mean(r["quality"] for r in runs_here))
+            worst.append(max(r["quality"] for r in runs_here))
+            evals.extend(r["n_unique"] for r in runs_here)
+        if not quals:
+            continue
+        geo = math.exp(sum(math.log(q) for q in quals) / len(quals))
+        geo_worst = math.exp(sum(math.log(q) for q in worst) / len(worst))
+        print(
+            f"  {label:<28} quality {geo:.3f}  worst-seed {geo_worst:.3f}  "
+            f"evals mean {statistics.mean(evals):.0f} median {statistics.median(evals):.0f}"
+            f"  ({len(quals)} cases)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/impact.py
+++ b/benchmarks/autotuner_study/impact.py
@@ -1,0 +1,155 @@
+"""Per-config-key performance impact analysis from campaign logs.
+
+For each kernel case, pools every (config, perf) observation across all runs
+(joining autotune.csv rows to the .meta.jsonl config map), then finds matched
+pairs: configs identical except for exactly one config key. The distribution
+of perf ratios within those pairs measures how much that key matters for that
+kernel, which drives the impact-tier classification of config knobs.
+
+Usage:
+    python benchmarks/autotuner_study/impact.py --root /tmp/autotuner_study/audit
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import json
+import math
+from pathlib import Path
+import statistics
+from typing import Any
+
+
+def canon(value: object) -> str:
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+def frac_gt(ratios: list[float], threshold: float) -> float:
+    return sum(r > threshold for r in ratios) / len(ratios)
+
+
+def load_case_observations(
+    root: Path,
+) -> dict[str, dict[str, tuple[dict[str, Any], float]]]:
+    """case -> config_id -> (config dict, best finite perf observed)."""
+    cases: dict[str, dict[str, tuple[dict[str, Any], float]]] = collections.defaultdict(
+        dict
+    )
+    for run_dir in sorted(root.iterdir()):
+        summary_path = run_dir / "summary.json"
+        meta_path = run_dir / "autotune.meta.jsonl"
+        csv_path = run_dir / "autotune.csv"
+        if not (summary_path.exists() and meta_path.exists() and csv_path.exists()):
+            continue
+        case = json.loads(summary_path.read_text())["case"]
+        configs: dict[str, dict[str, Any]] = {}
+        with meta_path.open() as f:
+            for line in f:
+                record = json.loads(line)
+                configs.update(record.get("configs", {}))
+        with csv_path.open() as f:
+            for row in csv.DictReader(f):
+                if row["status"] != "ok" or not row["perf_ms"]:
+                    continue
+                config_id = row["config_id"]
+                config = configs.get(config_id)
+                if config is None:
+                    continue
+                perf = float(row["perf_ms"])
+                prev = cases[case].get(config_id)
+                if prev is None or perf < prev[1]:
+                    cases[case][config_id] = (config, perf)
+    return cases
+
+
+def matched_pair_impact(
+    observations: dict[str, tuple[dict[str, Any], float]],
+) -> dict[str, list[float]]:
+    """key -> list of pairwise max/min perf ratios among configs differing only in key."""
+    all_keys: set[str] = set()
+    for config, _perf in observations.values():
+        all_keys.update(config)
+    impact: dict[str, list[float]] = collections.defaultdict(list)
+    for key in sorted(all_keys):
+        buckets: dict[str, list[tuple[str, float]]] = collections.defaultdict(list)
+        for config, perf in observations.values():
+            if not math.isfinite(perf):
+                continue
+            rest = canon({k: v for k, v in config.items() if k != key})
+            buckets[rest].append((canon(config.get(key)), perf))
+        for group in buckets.values():
+            by_value: dict[str, float] = {}
+            for value, perf in group:
+                if value not in by_value or perf < by_value[value]:
+                    by_value[value] = perf
+            if len(by_value) < 2:
+                continue
+            perfs = sorted(by_value.values())
+            impact[key].append(perfs[-1] / perfs[0])
+    return impact
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--json", default=None)
+    args = parser.parse_args()
+
+    cases = load_case_observations(Path(args.root))
+    result: dict[str, Any] = {}
+    agg: dict[str, list[float]] = collections.defaultdict(list)
+    for case, observations in sorted(cases.items()):
+        impact = matched_pair_impact(observations)
+        print(f"\n=== {case} ({len(observations)} unique configs) ===")
+        print(
+            f"{'key':<28}{'pairs':>7}{'median':>9}{'p90':>9}{'max':>9}{'>1%':>7}{'>5%':>7}{'>20%':>7}"
+        )
+        rows = []
+        for key, ratios in sorted(
+            impact.items(), key=lambda kv: -statistics.median(kv[1])
+        ):
+            ratios.sort()
+            n = len(ratios)
+            median = statistics.median(ratios)
+            p90 = ratios[min(n - 1, int(0.9 * n))]
+            print(
+                f"{key:<28}{n:>7}{median:>9.3f}{p90:>9.3f}{ratios[-1]:>9.2f}"
+                f"{frac_gt(ratios, 1.01):>7.0%}{frac_gt(ratios, 1.05):>7.0%}{frac_gt(ratios, 1.20):>7.0%}"
+            )
+            rows.append(
+                {
+                    "key": key,
+                    "pairs": n,
+                    "median": median,
+                    "p90": p90,
+                    "max": ratios[-1],
+                    "frac_gt_1pct": frac_gt(ratios, 1.01),
+                    "frac_gt_5pct": frac_gt(ratios, 1.05),
+                    "frac_gt_20pct": frac_gt(ratios, 1.20),
+                }
+            )
+            agg[key].extend(ratios)
+        result[case] = rows
+
+    print("\n=== aggregate across cases ===")
+    print(
+        f"{'key':<28}{'pairs':>7}{'median':>9}{'p90':>9}{'>1%':>7}{'>5%':>7}{'>20%':>7}"
+    )
+    for key, ratios in sorted(agg.items(), key=lambda kv: -statistics.median(kv[1])):
+        ratios.sort()
+        n = len(ratios)
+        p90 = ratios[min(n - 1, int(0.9 * n))]
+        print(
+            f"{key:<28}{n:>7}{statistics.median(ratios):>9.3f}{p90:>9.3f}"
+            f"{frac_gt(ratios, 1.01):>7.0%}{frac_gt(ratios, 1.05):>7.0%}{frac_gt(ratios, 1.20):>7.0%}"
+        )
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(result, indent=2))
+        print(f"wrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/kernels.py
+++ b/benchmarks/autotuner_study/kernels.py
@@ -1,0 +1,161 @@
+"""Kernel/shape registry for autotuner study campaigns.
+
+Each entry names an example kernel and builds concrete arguments for one
+shape. Shapes are chosen to be memory- or compute-bound (not overhead-bound)
+so autotuning quality differences are measurable.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+from typing import Callable
+
+import torch
+
+
+def identity_epilogue(
+    acc: torch.Tensor, tile: tuple[torch.Tensor, ...]
+) -> torch.Tensor:
+    """Picklable stand-in for the examples' default epilogue lambda (the
+    benchmark worker torch.save()s kernel args, and lambdas don't pickle)."""
+    return acc
+
+
+@dataclasses.dataclass(frozen=True)
+class KernelCase:
+    name: str  # unique "<kernel>-<shape>" identifier
+    module: str  # examples module name (no .py)
+    attr: str  # kernel attribute inside the module
+    make_args: Callable[[torch.device], tuple[Any, ...]]
+
+
+def _matmul_4096(device: torch.device) -> tuple[Any, ...]:
+    x = torch.randn(4096, 4096, device=device, dtype=torch.float16)
+    y = torch.randn(4096, 4096, device=device, dtype=torch.float16)
+    return (x, y, identity_epilogue)
+
+
+def _matmul_wide(device: torch.device) -> tuple[Any, ...]:
+    x = torch.randn(8192, 1024, device=device, dtype=torch.float16)
+    y = torch.randn(1024, 8192, device=device, dtype=torch.float16)
+    return (x, y, identity_epilogue)
+
+
+def _attention_2k(device: torch.device) -> tuple[Any, ...]:
+    q, k, v = (
+        torch.randn(4, 32, 2048, 64, device=device, dtype=torch.float16)
+        for _ in range(3)
+    )
+    return (q, k, v)
+
+
+def _attention_4k128(device: torch.device) -> tuple[Any, ...]:
+    q, k, v = (
+        torch.randn(2, 16, 4096, 128, device=device, dtype=torch.float16)
+        for _ in range(3)
+    )
+    return (q, k, v)
+
+
+def _softmax_two_pass(device: torch.device) -> tuple[Any, ...]:
+    return (torch.randn(8192, 8192, device=device, dtype=torch.float32),)
+
+
+def _rms_norm(device: torch.device) -> tuple[Any, ...]:
+    x = torch.randn(8192, 8192, device=device, dtype=torch.float16)
+    weight = torch.randn(8192, device=device, dtype=torch.float16)
+    return (x, weight)
+
+
+def _layer_norm(device: torch.device) -> tuple[Any, ...]:
+    x = torch.randn(4096, 10240, device=device, dtype=torch.float16)
+    weight = torch.randn(10240, device=device, dtype=torch.float16)
+    bias = torch.randn(10240, device=device, dtype=torch.float16)
+    return (x, [10240], weight, bias)
+
+
+def _cross_entropy(device: torch.device) -> tuple[Any, ...]:
+    n, v = 16384, 131072
+    logits = torch.randn(n, v, device=device, dtype=torch.float32)
+    labels = torch.randint(0, v, (n,), device=device, dtype=torch.int64)
+    return (logits, labels)
+
+
+def _bmm(device: torch.device) -> tuple[Any, ...]:
+    a = torch.randn(16, 512, 768, device=device, dtype=torch.float16)
+    b = torch.randn(16, 768, 1024, device=device, dtype=torch.float16)
+    return (a, b)
+
+
+def _matmul_split_k(device: torch.device) -> tuple[Any, ...]:
+    x = torch.randn(64, 32768, device=device, dtype=torch.float16)
+    y = torch.randn(32768, 64, device=device, dtype=torch.float16)
+    return (x, y, identity_epilogue)
+
+
+def _longsum(device: torch.device) -> tuple[Any, ...]:
+    return (torch.randn(256, 262144, device=device, dtype=torch.float32),)
+
+
+def _fp8_gemm(device: torch.device) -> tuple[Any, ...]:
+    x = torch.randn(4096, 4096, device=device, dtype=torch.float32)
+    y = torch.randn(4096, 4096, device=device, dtype=torch.float32)
+    x_fp8 = x.to(torch.float8_e4m3fn)
+    y_fp8 = y.T.contiguous().T.to(torch.float8_e4m3fn)
+    return (x_fp8, y_fp8)
+
+
+def _gather_gemv(device: torch.device) -> tuple[Any, ...]:
+    b, s, n = 8, 8192, 4
+    w = torch.randn(b, s, s, device=device, dtype=torch.float16)
+    idx = torch.randint(0, b, (n,), device=device, dtype=torch.int32)
+    x = torch.randn(s, device=device, dtype=torch.float16)
+    return (w, idx, x)
+
+
+def _welford(device: torch.device) -> tuple[Any, ...]:
+    s, d = 262144, 1024
+    weight = torch.rand(d, device=device, dtype=torch.float32)
+    bias = torch.rand(d, device=device, dtype=torch.float32)
+    x = torch.randn(s, d, device=device, dtype=torch.float32)
+    return (weight, bias, x)
+
+
+KERNEL_CASES: dict[str, KernelCase] = {
+    case.name: case
+    for case in [
+        KernelCase("matmul-4096", "matmul", "matmul", _matmul_4096),
+        KernelCase("matmul-wide", "matmul", "matmul", _matmul_wide),
+        KernelCase("attention-2k64", "attention", "attention", _attention_2k),
+        KernelCase("attention-4k128", "attention", "attention", _attention_4k128),
+        KernelCase("softmax2p-8192", "softmax", "softmax_two_pass", _softmax_two_pass),
+        KernelCase("rmsnorm-8192", "rms_norm", "rms_norm_fwd", _rms_norm),
+        KernelCase("layernorm-10240", "layer_norm", "layer_norm_fwd", _layer_norm),
+        KernelCase(
+            "crossentropy-131k", "cross_entropy", "cross_entropy", _cross_entropy
+        ),
+        KernelCase("bmm-16x512", "bmm", "bmm", _bmm),
+        KernelCase("splitk-32768", "matmul_split_k", "matmul_split_k", _matmul_split_k),
+        KernelCase("longsum-256x262k", "long_sum", "longsum", _longsum),
+        KernelCase("fp8gemm-4096", "fp8_gemm", "fp8_gemm", _fp8_gemm),
+        KernelCase("gathergemv-8192", "gather_gemv", "gather_gemv", _gather_gemv),
+        KernelCase("welford-262kx1k", "welford", "welford", _welford),
+    ]
+}
+
+
+def load_kernel(case: KernelCase) -> object:
+    import importlib
+
+    module = importlib.import_module(f"examples.{case.module}")
+    return getattr(module, case.attr)
+
+
+def main() -> None:
+    for name in KERNEL_CASES:
+        print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/measure_shortlists.py
+++ b/benchmarks/autotuner_study/measure_shortlists.py
@@ -1,0 +1,174 @@
+"""Head-to-head measurement of every run's finalist shortlist.
+
+For each run under the given campaign roots, reconstruct the configs the
+final-verification shootout chose between (the top-N configs by best observed
+in-search timing, plus the selected config), dedupe them per kernel case, and
+time all of them together with interleaved_bench on the current GPU. Combined
+with the per-candidate CSVs this lets diagnose.py decompose each run's final
+quality gap into selection error (the shootout picked the wrong finalist) and
+exploration error (no finalist was near the case best).
+
+Run one instance per GPU with a --cases filter matching the campaign's
+case->GPU pinning so timings stay apples-to-apples with the runs.
+
+The reconstruction approximates the runtime shootout: --top defaults to the
+Triton finalist count (8; CuTe uses 32), ranks by best observed in-search
+perf rather than the runtime's deduped finalist-history perf, and does not
+model pinned finalists, so diagnose.py's oracle is an approximation of the
+set the shootout actually timed.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=3 python benchmarks/autotuner_study/measure_shortlists.py \
+        --roots /tmp/autotuner_study/round2/baseline --out shortlists_gpu3.json \
+        [--cases a,b] [--top 10] [--repeat 150]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import functools
+import gc
+import json
+import math
+import operator
+from pathlib import Path
+import sys
+from typing import Any
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def run_shortlist(run_dir: Path, top: int) -> tuple[str, dict[str, Any]] | None:
+    """Return (case, {selected_config, ranked: [(config_repr, best_ms)]})."""
+    summary_path = run_dir / "summary.json"
+    csv_path = run_dir / "autotune.csv"
+    if not summary_path.exists() or not csv_path.exists():
+        return None
+    summary = json.loads(summary_path.read_text())
+    best_by_repr: dict[str, float] = {}
+    with csv_path.open() as f:
+        for row in csv.DictReader(f):
+            if row["status"] != "ok" or not row["perf_ms"]:
+                continue
+            perf = float(row["perf_ms"])
+            if not math.isfinite(perf):
+                continue
+            config_repr = row["config"]
+            if perf < best_by_repr.get(config_repr, math.inf):
+                best_by_repr[config_repr] = perf
+    ranked = sorted(best_by_repr.items(), key=operator.itemgetter(1))[:top]
+    return summary["case"], {
+        "selected_config": summary["selected_config"],
+        "ranked": ranked,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--roots", nargs="+", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--cases", default=None)
+    # Default matches _FINAL_REBENCHMARK_TOP_K_DEFAULT (Triton).
+    parser.add_argument("--top", type=int, default=8)
+    parser.add_argument("--repeat", type=int, default=200)
+    args = parser.parse_args()
+
+    from kernels import KERNEL_CASES  # pyrefly: ignore [missing-import]
+    from kernels import load_kernel  # pyrefly: ignore [missing-import]
+    import torch
+
+    import helion
+    from helion.autotuner.benchmarking import interleaved_bench
+
+    wanted = set(args.cases.split(",")) if args.cases else None
+
+    # case -> canonical config json -> {"config": dict, "refs": {run_id: ref}}
+    pool: dict[str, dict[str, dict[str, Any]]] = {}
+
+    def add_ref(
+        case: str, config: dict[str, Any], run_id: str, ref: dict[str, Any]
+    ) -> None:
+        key = json.dumps(config, sort_keys=True, default=str)
+        entry = pool.setdefault(case, {}).setdefault(
+            key, {"config": config, "refs": {}}
+        )
+        entry["refs"].setdefault(run_id, {}).update(ref)
+
+    for root in [Path(r) for r in args.roots]:
+        for run_dir in sorted(root.iterdir()):
+            if not run_dir.is_dir():
+                continue
+            loaded = run_shortlist(run_dir, args.top)
+            if loaded is None:
+                continue
+            case, data = loaded
+            if wanted is not None and case not in wanted:
+                continue
+            run_id = f"{root.name}/{run_dir.name}"
+            add_ref(case, data["selected_config"], run_id, {"selected": True})
+            for rank, (config_repr, best_ms) in enumerate(data["ranked"]):
+                config = eval(config_repr, {"Config": helion.Config})
+                add_ref(
+                    case,
+                    config.config,
+                    run_id,
+                    {"rank": rank, "observed_ms": best_ms},
+                )
+
+    device = torch.device("cuda")
+    results: dict[str, Any] = {}
+    for case_name, entries in sorted(pool.items()):
+        case = KERNEL_CASES[case_name]
+        kernel = load_kernel(case)
+        kernel_args = case.make_args(device)
+        bound = kernel.bind(kernel_args)  # pyrefly: ignore [missing-attribute]
+        default_config = bound.config_spec.default_config().config
+        add_ref(case_name, default_config, "<default>", {})
+        keys = list(entries.keys())
+        fns: list[Callable[[], object]] = []
+        keep: list[str] = []
+        for key in keys:
+            try:
+                compiled = bound.compile_config(helion.Config(**entries[key]["config"]))
+                fns.append(functools.partial(compiled, *kernel_args))
+                keep.append(key)
+            except Exception as e:  # compile failures are data, not fatal
+                print(f"{case_name}: compile failed ({e}) for {entries[key]['refs']}")
+        for fn in fns:
+            fn()
+        torch.cuda.synchronize()
+        print(f"{case_name}: timing {len(fns)} unique configs")
+        # Two independent interleaved passes: their per-config disagreement is
+        # the measurement noise floor diagnose.py uses to separate real
+        # selection regret from phantom regret on near-tied finalists.
+        timings_a = interleaved_bench(fns, repeat=args.repeat)
+        timings_b = interleaved_bench(fns, repeat=args.repeat)
+        case_result = []
+        for key, perf_a, perf_b in zip(keep, timings_a, timings_b, strict=True):
+            case_result.append(
+                {
+                    "perf_ms": (perf_a + perf_b) / 2,
+                    "perf_ms_a": perf_a,
+                    "perf_ms_b": perf_b,
+                    "config": entries[key]["config"],
+                    "refs": entries[key]["refs"],
+                }
+            )
+        case_result.sort(key=operator.itemgetter("perf_ms"))
+        results[case_name] = case_result
+        best = case_result[0]["perf_ms"] if case_result else float("nan")
+        print(f"{case_name}: best {best:.5f} ms over {len(case_result)} configs")
+        del kernel_args, fns, bound
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    Path(args.out).write_text(json.dumps(results, indent=2, default=str))
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/measure_winners.py
+++ b/benchmarks/autotuner_study/measure_winners.py
@@ -1,0 +1,122 @@
+"""Head-to-head re-measurement of autotuning winners for the final report.
+
+Collects the selected config from every completed run under one or more
+campaign roots, dedups them per kernel case, compiles each, and times them
+together with interleaved_bench on the current GPU (run with
+CUDA_VISIBLE_DEVICES=<idle gpu>, one instance at a time). This removes
+run-to-run measurement bias so final-quality comparisons across algorithms
+and campaigns are apples-to-apples.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=3 python benchmarks/autotuner_study/measure_winners.py \
+        --roots /tmp/autotuner_study/audit /tmp/autotuner_study/proto1 \
+        --out /tmp/autotuner_study/winners.json [--cases a,b] [--repeat 200]
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import gc
+import json
+import operator
+from pathlib import Path
+import sys
+from typing import Any
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def collect_configs(roots: list[Path]) -> dict[str, dict[str, dict[str, Any]]]:
+    """case -> canonical config json -> {config, runs: [run ids]}."""
+    by_case: dict[str, dict[str, dict[str, Any]]] = {}
+    for root in roots:
+        for run_dir in sorted(root.iterdir()):
+            summary_path = run_dir / "summary.json"
+            if not summary_path.exists():
+                continue
+            summary = json.loads(summary_path.read_text())
+            case = summary["case"]
+            config = summary["selected_config"]
+            key = json.dumps(config, sort_keys=True, default=str)
+            entry = by_case.setdefault(case, {}).setdefault(
+                key, {"config": config, "runs": []}
+            )
+            entry["runs"].append(f"{root.name}/{run_dir.name}")
+    return by_case
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--roots", nargs="+", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--cases", default=None)
+    parser.add_argument("--repeat", type=int, default=200)
+    args = parser.parse_args()
+
+    from kernels import KERNEL_CASES  # pyrefly: ignore [missing-import]
+    from kernels import load_kernel  # pyrefly: ignore [missing-import]
+    import torch
+
+    import helion
+    from helion.autotuner.benchmarking import interleaved_bench
+
+    by_case = collect_configs([Path(r) for r in args.roots])
+    wanted = set(args.cases.split(",")) if args.cases else None
+
+    device = torch.device("cuda")
+    results: dict[str, Any] = {}
+    for case_name, entries in sorted(by_case.items()):
+        if wanted is not None and case_name not in wanted:
+            continue
+        case = KERNEL_CASES[case_name]
+        kernel = load_kernel(case)
+        kernel_args = case.make_args(device)
+        bound = kernel.bind(kernel_args)  # pyrefly: ignore [missing-attribute]
+        configs = [entry["config"] for entry in entries.values()]
+        labels = [entry["runs"] for entry in entries.values()]
+        default_config = bound.config_spec.default_config().config
+        default_key = json.dumps(default_config, sort_keys=True, default=str)
+        if default_key in entries:
+            entries[default_key]["runs"].append("<default>")
+        else:
+            configs.append(default_config)
+            labels.append(["<default>"])
+        fns: list[Callable[[], object]] = []
+        keep: list[int] = []
+        for i, config in enumerate(configs):
+            try:
+                compiled = bound.compile_config(helion.Config(**config))
+                fns.append(functools.partial(compiled, *kernel_args))
+                keep.append(i)
+            except Exception as e:
+                print(f"{case_name}: compile failed for {labels[i]}: {e}")
+        # Warm up each once so compilation/caching is out of the timing loop.
+        for fn in fns:
+            fn()
+        torch.cuda.synchronize()
+        timings = interleaved_bench(fns, repeat=args.repeat)
+        case_result = []
+        for idx, timing in zip(keep, timings, strict=True):
+            case_result.append(
+                {
+                    "runs": labels[idx],
+                    "config": configs[idx],
+                    "perf_ms": timing,
+                }
+            )
+            print(f"{case_name}: {timing:.5f} ms  {labels[idx]}")
+        results[case_name] = sorted(case_result, key=operator.itemgetter("perf_ms"))
+        del kernel_args, fns, bound
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    Path(args.out).write_text(json.dumps(results, indent=2, default=str))
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/run_one.py
+++ b/benchmarks/autotuner_study/run_one.py
@@ -1,0 +1,102 @@
+"""Run one autotuning run for the autotuner study and record its artifacts.
+
+Expected to run in a fresh subprocess with the environment already prepared by
+campaign.py (CUDA_VISIBLE_DEVICES, HELION_AUTOTUNE_RANDOM_SEED,
+HELION_SKIP_CACHE, HELION_AUTOTUNE_LOG, HELION_AUTOTUNER, ...).
+
+Writes <out>/summary.json next to the per-candidate CSV written by the
+autotune log sink.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import time
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--case", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument(
+        "--autotune-kwargs",
+        default="{}",
+        help="JSON kwargs forwarded to kernel.autotune (search constructor)",
+    )
+    args = parser.parse_args()
+
+    from kernels import KERNEL_CASES  # pyrefly: ignore [missing-import]
+    from kernels import load_kernel  # pyrefly: ignore [missing-import]
+    import torch
+
+    from helion.autotuner.metrics import AutotuneMetrics
+    from helion.autotuner.metrics import register_post_autotune_hook
+
+    case = KERNEL_CASES[args.case]
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    device = torch.device("cuda")
+    kernel = load_kernel(case)
+    kernel_args = case.make_args(device)
+
+    collected: list[dict[str, Any]] = []
+
+    def on_metrics(metrics: AutotuneMetrics) -> None:
+        collected.append(metrics.to_dict())
+
+    register_post_autotune_hook(on_metrics)
+
+    autotune_kwargs = json.loads(args.autotune_kwargs)
+    start = time.perf_counter()
+    config = kernel.autotune(kernel_args, force=True, **autotune_kwargs)
+    wall_time = time.perf_counter() - start
+
+    # Independent post-search measurements on this GPU: the selected config and
+    # the spec default config, each timed with the same interleaved harness so
+    # run-to-run quality comparisons don't rely on in-search low-water marks.
+    from helion.autotuner.benchmarking import interleaved_bench
+
+    bound = kernel.bind(kernel_args)
+    default_config = bound.config_spec.default_config()
+    selected_fn = bound.compile_config(config)
+    fns = [lambda: selected_fn(*kernel_args)]
+    default_error: str | None = None
+    try:
+        default_fn = bound.compile_config(default_config)
+        fns.append(lambda: default_fn(*kernel_args))
+    except Exception as e:
+        default_error = f"{type(e).__name__}: {e}"
+    timings = interleaved_bench(fns, repeat=50)
+    selected_perf_ms = timings[0]
+    default_perf_ms = timings[1] if len(timings) > 1 else None
+
+    summary: dict[str, Any] = {
+        "case": args.case,
+        "algorithm": os.environ.get("HELION_AUTOTUNER", "LFBOTreeSearch(default)"),
+        "seed": os.environ.get("HELION_AUTOTUNE_RANDOM_SEED"),
+        "gpu": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        "autotune_kwargs": autotune_kwargs,
+        "wall_time_s": wall_time,
+        "selected_config": config.config,
+        "selected_perf_ms": selected_perf_ms,
+        "default_perf_ms": default_perf_ms,
+        "default_error": default_error,
+        "default_config": default_config.config,
+        "metrics": collected,
+    }
+    (out_dir / "summary.json").write_text(json.dumps(summary, indent=2, default=str))
+    print(f"DONE {args.case} wall={wall_time:.1f}s runs_recorded={len(collected)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/walltime.py
+++ b/benchmarks/autotuner_study/walltime.py
@@ -1,0 +1,115 @@
+"""Sequential wall-time comparison: baseline vs v2 bundle, one run at a time.
+
+Historical study artifact: the --v2-tree it drives must be a checkout of the
+autotuner-v2-fixes/-simple study branches, which carried the
+HELION_AUTOTUNER_V2 / HELION_LISTOF_UNIFORM_NEIGHBORS flags (removed from
+the final tree). Runs alternate baseline and v2 so thermal/clock drift
+affects both arms equally; exactly one autotuning run executes at a time on
+the given GPU.
+
+Usage:
+    python benchmarks/autotuner_study/walltime.py --gpu 1 \
+        --baseline-tree /data/users/jansel/ws7/helion \
+        --v2-tree /data/users/jansel/ws7/helion-proto2 \
+        --out /tmp/autotuner_study/walltime
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+CASES = [
+    "attention-2k64",
+    "matmul-4096",
+    "gathergemv-8192",
+    "layernorm-10240",
+    "crossentropy-131k",
+]
+SEEDS = [401, 402]
+
+
+def run_one(
+    tree: Path, case: str, seed: int, gpu: int, run_dir: Path, v2: bool
+) -> dict[str, object]:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    env.update(
+        {
+            "CUDA_VISIBLE_DEVICES": str(gpu),
+            "HELION_AUTOTUNE_RANDOM_SEED": str(seed),
+            "HELION_SKIP_CACHE": "1",
+            "HELION_AUTOTUNE_LOG": str(run_dir / "autotune"),
+            "HELION_AUTOTUNE_LOG_DETAILS": "1",
+            "HELION_AUTOTUNE_PROGRESS_BAR": "0",
+        }
+    )
+    env.pop("HELION_AUTOTUNER", None)
+    env.pop("HELION_AUTOTUNER_V2", None)
+    env.pop("HELION_LISTOF_UNIFORM_NEIGHBORS", None)
+    env.pop("HELION_AUTOTUNE_PRECOMPILE_JOBS", None)  # full host for wall time
+    if v2:
+        env["HELION_AUTOTUNER_V2"] = "1"
+    start = time.time()
+    with (run_dir / "run.log").open("w") as log:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(tree / "benchmarks" / "autotuner_study" / "run_one.py"),
+                "--case",
+                case,
+                "--out",
+                str(run_dir),
+            ],
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            cwd=str(tree),
+            check=False,
+        )
+    return {
+        "case": case,
+        "seed": seed,
+        "variant": "v2" if v2 else "baseline",
+        "returncode": proc.returncode,
+        "elapsed_s": time.time() - start,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gpu", type=int, required=True)
+    parser.add_argument("--baseline-tree", required=True)
+    parser.add_argument("--v2-tree", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    out_root = Path(args.out)
+    out_root.mkdir(parents=True, exist_ok=True)
+    results = []
+    for case in CASES:
+        for seed in SEEDS:
+            for v2 in (False, True):  # alternate to balance drift
+                name = f"{case}--{'v2' if v2 else 'baseline'}--s{seed}"
+                run_dir = out_root / name
+                if (run_dir / "summary.json").exists():
+                    print(f"SKIP {name}", flush=True)
+                    continue
+                tree = Path(args.v2_tree if v2 else args.baseline_tree)
+                print(f"START {name}", flush=True)
+                result = run_one(tree, case, seed, args.gpu, run_dir, v2)
+                print(
+                    f"DONE {name} rc={result['returncode']} {result['elapsed_s']:.0f}s",
+                    flush=True,
+                )
+                results.append(result)
+    (out_root / "walltime_results.json").write_text(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3519
 * #3524
 * #3523
 * #3522
 * #3518
 * #3517
 * #3516


--- --- ---

[autotuner] Add the autotuner study harness, analysis tooling, and report

Tooling behind the 500+-run autotuner study that produced the preceding
search fixes, plus its findings:

- kernels.py / run_one.py / campaign.py: registry of 14 memory- and
  compute-bound example kernel cases and a campaign runner that executes
  autotuning runs in fresh subprocesses with pinned GPUs, fixed seeds,
  cache disabled, and per-candidate CSV logging (HELION_AUTOTUNE_LOG).
- analyze.py / impact.py: per-run best-so-far curves, tail-waste and
  phase attribution, measurement-noise floors, and matched-pair per-config-
  key impact analysis.
- measure_winners.py / final_table.py: head-to-head re-measurement of every
  run's selected config in a single interleaved batch per kernel (required:
  split-k/gather-gemv timings swing 10-60% with process and batch context),
  and the final quality/evals comparison tables.
- walltime.py: strictly sequential one-at-a-time wall-clock comparison.
- REPORT.md / NOTES.md: full study - audit of PatternSearch, DE, and the
  default LFBOTreeSearch; ablations of candidate search features (structured
  initial population, adaptive coordinate freezing, stagnation stop -
  evaluated and intentionally not shipped); cute-backend validation; and
  future-work list (restart-on-stagnation, cross-run surrogate warm-start,
  benchmark-worker robustness on hung cute kernels).