### PR TITLE
[autotuner] add diverse B200 matmul tuning seeds

### DIFF
--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 from operator import itemgetter
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
+from typing import Literal
 from typing import NamedTuple
 from typing import cast
 
@@ -20,6 +22,7 @@ from ...autotuner.config_spec import KernelMatmulFact
 from ...autotuner.config_spec import LiveTile
 from ...autotuner.config_spec import LoopAxisFact
 from ...autotuner.config_spec import ReductionCategory
+from ...exc import InvalidConfig
 from ...runtime.config import Config
 from ..compile_environment import _symint_sympy_expr
 from .common import clamp_block_size_targets
@@ -30,6 +33,7 @@ from .registry import AutotunerHeuristic
 if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Collection
+    from collections.abc import Mapping
     from collections.abc import Sequence
 
     from ...autotuner.config_spec import BlockSizeSpec
@@ -55,6 +59,32 @@ class CandidateDotWork(NamedTuple):
     total: int
     tcgen05_eligible: int
     uncertain: bool = False
+
+
+@dataclass
+class MatmulSeedDraft:
+    block_sizes: list[int]
+    num_warps: int
+    num_stages: int
+    l2_grouping: int = 1
+
+    def copy(self) -> MatmulSeedDraft:
+        return MatmulSeedDraft(
+            list(self.block_sizes),
+            self.num_warps,
+            self.num_stages,
+            self.l2_grouping,
+        )
+
+
+class SeedAxisIds(NamedTuple):
+    m: tuple[int, ...]
+    n: tuple[int, ...]
+    k: tuple[int, ...]
+
+
+MatmulProposal = tuple[int, int, int, int, int, int]
+MatmulResourcePolicy = Literal["strict", "optimistic"]
 
 
 # Heuristic was originally contributed by @umechand-amd
@@ -295,32 +325,6 @@ def _h100_build_block_sizes(
     return out
 
 
-def _h100_config(
-    spec: ConfigSpec,
-    fact: MatmulFact,
-    bm: int,
-    bn: int,
-    bk: int,
-    num_warps: int,
-    num_stages: int,
-    l2_grouping: int = 1,
-    extra: dict[str, Any] | None = None,
-) -> Config:
-    """Assemble a Config from a tile tuple (emit l2_groupings only when grouping > 1).
-    ``extra`` carries any subclass-emitted fields (e.g. the sm100 Blackwell levers:
-    epilogue_subtile / indexing / range_warp_specializes) merged on top."""
-    cfg: dict[str, Any] = {
-        "block_sizes": _h100_build_block_sizes(spec, fact, bm, bn, bk),
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-    }
-    if l2_grouping > 1:
-        cfg["l2_groupings"] = [l2_grouping]
-    if extra:
-        cfg.update(extra)
-    return Config(**cfg)
-
-
 class TritonH100MatmulHeuristic(AutotunerHeuristic):
     """H100 (sm90) seed for any static (possibly batched) ``MatmulFact`` — a budget/roofline
     ``_matmul_tile`` FORMULA (no lookup) so real GEMMs don't fall back to the catastrophic
@@ -488,6 +492,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
     WORK_AWARE_WARPS = False
     REGIME_AWARE_WARPS = False
     SINGLE_ROLE_AWARE_KNOBS = False
+    EXPANDED_SEED_POOL = False
     # Candidate-work regime boundaries. Inactive unless REGIME_AWARE_WARPS is
     # enabled by a measured architecture subclass.
     SUBSTANTIAL_DOT_WORK = 1 << 20
@@ -597,11 +602,11 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
     @classmethod
     def _tmem_columns(
         cls,
-        tiles: Sequence[tuple[int, int, int] | tuple[int, int, int, int]],
+        accumulator_tiles: Sequence[tuple[int, int]],
         *,
-        include_lhs_scratch: bool = False,
+        lhs_scratch_tiles: Sequence[tuple[int, int, int]] = (),
     ) -> int:
-        """Tensor-memory COLUMNS a set of dots reserves.
+        """Tensor-memory COLUMNS reserved by accumulators and computed LHS tiles.
 
         tcgen05 tensor memory is allocated as ``TMEM_LANES`` (128) lanes x N columns of
         32 bits; a request is denominated in columns, not bytes. Measured on B200 over the
@@ -617,49 +622,33 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         ``OutOfResources: tensor memory, Required: 768, limit 512`` -- exactly
         ``3 x 256`` columns against the 512-column budget.
 
-        ``tiles`` may include K as ``(bm, bn, bk, itemsize)``. With
-        ``include_lhs_scratch``, also reserve each dot's power-of-two LHS promotion
-        allocation. Triton can keep those allocations distinct across dots, just as
-        accumulator allocations can add. The scratch-inclusive value is a hard
-        launchability check; the calibrated residency policy continues to use
-        accumulator columns alone because this all-dot bound is not a reliable
-        peak-residency estimate.
+        ``accumulator_tiles`` contains ``(bm, bn)``. ``lhs_scratch_tiles`` contains
+        ``(bm, bk, itemsize)`` for computed dot LHS values that need Triton's
+        power-of-two promotion allocation; direct loads do not belong in that set.
+        Triton can keep those allocations distinct across dots, just as accumulator
+        allocations can add.
 
-        An accumulator whose ``bm`` is below ``TCGEN05_MIN_BM`` is charged nothing:
-        below that the dot lowers to a non-tcgen05 path that uses no tensor memory at
-        all (measured ``tmem_size == 0``), and its cost lands on the register file
-        instead -- see ``_register_live_bytes``.
+        A tile whose ``bm`` is below ``TCGEN05_MIN_BM`` is charged nothing: below that
+        the dot lowers to a non-tcgen05 path that uses no tensor memory at all
+        (measured ``tmem_size == 0``), and its cost lands on the register file instead
+        -- see ``_register_live_bytes``.
         """
-        if include_lhs_scratch:
-            assert all(len(tile) == 4 for tile in tiles), (
-                "BK is required when include_lhs_scratch=True"
-            )
         if cls.TMEM_COLUMN_BUDGET is None:
             return 0
         total = 0
-        lhs_columns = 0
-        for tile in tiles:
-            if len(tile) == 3:
-                bm, bn, itemsize = tile
-                bk = None
-            else:
-                bm, bn, bk, itemsize = tile
+        for bm, bn in accumulator_tiles:
+            if bm >= cls.TCGEN05_MIN_BM:
+                total += max(1, -(-bm // cls.TMEM_LANES)) * bn
+        for bm, bk, itemsize in lhs_scratch_tiles:
             if bm < cls.TCGEN05_MIN_BM:
                 continue
-            lane_groups = max(1, -(-bm // cls.TMEM_LANES))
-            total += lane_groups * bn
-            if include_lhs_scratch:
-                assert bk is not None
-                raw_columns = max(
-                    1,
-                    -(-(bm * bk * itemsize) // (cls.TMEM_LANES * 4)),
-                )
-                allocated_columns = 1 << (raw_columns - 1).bit_length()
-                lhs_columns += max(
-                    cls.TMEM_ALLOC_COLUMNS,
-                    allocated_columns,
-                )
-        return total + lhs_columns
+            raw_columns = max(
+                1,
+                -(-(bm * bk * itemsize) // (cls.TMEM_LANES * 4)),
+            )
+            allocated_columns = 1 << (raw_columns - 1).bit_length()
+            total += max(cls.TMEM_ALLOC_COLUMNS, allocated_columns)
+        return total
 
     @classmethod
     def _warps_for_live_set(
@@ -766,6 +755,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         grid: int,
         num_sm: int,
         smem_bytes: int,
+        resource_policy: MatmulResourcePolicy = "strict",
     ) -> int:
         """Choose a warp regime from dynamic work and soft register pressure.
 
@@ -792,6 +782,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
                 smem_bytes=smem_bytes,
                 grid=grid,
                 num_sm=num_sm,
+                resource_policy=resource_policy,
             )
 
         p1 = pressure(1)
@@ -926,6 +917,16 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             assert isinstance(value, (int, torch.SymInt))
             out[bid] = max(1, env.size_hint(value))
         return out
+
+    @staticmethod
+    def _reference_block_sizes(spec: ConfigSpec) -> list[int]:
+        """Return a mutable copy of the conservative reference block sizes."""
+        return list(
+            cast(
+                "list[int]",
+                spec.autotune_reference_config().config["block_sizes"],
+            )
+        )
 
     @classmethod
     def _axis_extent(cls, env: CompileEnvironment, block_id: int) -> int | None:
@@ -1082,6 +1083,28 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         return trips
 
     @classmethod
+    def _pipelined_loop_trips(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        *,
+        max_loop_trips: int,
+    ) -> int:
+        """Longest candidate-resolved pipeline, with an explicit safety fallback."""
+        mm = env.config_spec.kernel_matmul_fact
+        assert mm is not None
+        return max(
+            (
+                trips if trips is not None else max_loop_trips
+                for region in mm.pipelined_regions
+                for trips in (
+                    cls._resolved_loop_trips(env, block_sizes, region.loop_axes),
+                )
+            ),
+            default=max_loop_trips,
+        )
+
+    @classmethod
     def _dot_tile_extents(
         cls,
         fact: MatmulFact,
@@ -1126,6 +1149,76 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             rows, cols, inner = cls._dot_tile_extents(f, resolved.axes, block_of)
             out.append((rows, cols, inner, max(1, f.lhs_dtype.itemsize)))
         return out
+
+    @classmethod
+    def _candidate_tmem_columns(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        *,
+        include_lhs_scratch: bool,
+        resource_policy: MatmulResourcePolicy,
+    ) -> int:
+        """Candidate TMEM columns under the strict or exploratory policy."""
+        tiles = cls._all_dot_acc_tiles(env, block_sizes)
+        accumulator_tiles = [(bm, bn) for bm, bn, _bk, _itemsize in tiles]
+        if resource_policy == "strict":
+            return cls._tmem_columns(
+                accumulator_tiles,
+                lhs_scratch_tiles=(
+                    [(bm, bk, itemsize) for bm, _bn, bk, itemsize in tiles]
+                    if include_lhs_scratch
+                    else ()
+                ),
+            )
+
+        mm = env.config_spec.kernel_matmul_fact
+        if mm is None:
+            return 0
+        block_of = cls._full_block_map(env, block_sizes)
+
+        def live_accumulator_columns(live: Sequence[LiveTile]) -> int:
+            accumulator_tiles = []
+            for tile in live:
+                shape = cls._single_matrix_shape(tile, block_of)
+                if tile.kind == "dot_out" and shape is not None:
+                    accumulator_tiles.append(shape)
+            return cls._tmem_columns(accumulator_tiles)
+
+        live_sets = tuple(getattr(mm, "live_tile_steps", ()))
+        peak_dot_outputs = tuple(getattr(mm, "live_dot_outputs", ()))
+        accumulator_columns = max(
+            (
+                *(live_accumulator_columns(step) for step in live_sets),
+                live_accumulator_columns(peak_dot_outputs),
+            ),
+            default=0,
+        )
+
+        lhs_columns = 0
+        if include_lhs_scratch:
+
+            def live_lhs_columns(live: Sequence[LiveTile]) -> int:
+                lhs_scratch_tiles = []
+                for tile in live:
+                    shape = cls._single_matrix_shape(tile, block_of)
+                    if tile.promoted_lhs and shape is not None:
+                        rows, columns = shape
+                        lhs_scratch_tiles.append((rows, columns, tile.itemsize))
+                return cls._tmem_columns(
+                    (),
+                    lhs_scratch_tiles=lhs_scratch_tiles,
+                )
+
+            promoted_peak = tuple(getattr(mm, "live_promoted_lhs", ()))
+            lhs_columns = max(
+                (
+                    *(live_lhs_columns(step) for step in live_sets),
+                    live_lhs_columns(promoted_peak),
+                ),
+                default=0,
+            )
+        return accumulator_columns + lhs_columns
 
     @classmethod
     def _candidate_dot_work(
@@ -1224,22 +1317,35 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
                 if nbytes > ceiling:
                     continue
                 if tile.kind == "dot_out" and tmem_absorbs:
-                    rows = 1
-                    for block_id, static in zip(
-                        tile.dim_block_ids[:-1],
-                        tile.static_dims[:-1],
-                        strict=False,
-                    ):
-                        rows *= (
-                            block_of[block_id]
-                            if block_id is not None
-                            else max(1, static or 1)
-                        )
-                    if rows >= cls.TCGEN05_MIN_BM:
+                    shape = cls._single_matrix_shape(tile, block_of)
+                    if shape is not None and shape[0] >= cls.TCGEN05_MIN_BM:
                         continue
                 total += nbytes
             peak = max(peak, total)
         return peak
+
+    @classmethod
+    def _single_matrix_shape(
+        cls,
+        tile: object,
+        block_of: dict[int, int],
+    ) -> tuple[int, int] | None:
+        """Resolved trailing matrix shape when no leading batch extent exceeds one."""
+        dims = cls._resolved_tile_dims(tile, block_of)
+        if len(dims) < 2 or any(extent != 1 for extent in dims[:-2]):
+            return None
+        return dims[-2], dims[-1]
+
+    @staticmethod
+    def _resolved_tile_dims(tile: object, block_of: dict[int, int]) -> list[int]:
+        return [
+            max(1, block_of.get(blk, 1)) if blk is not None else max(1, static or 1)
+            for blk, static in zip(
+                tile.dim_block_ids,  # type: ignore[attr-defined]
+                tile.static_dims,  # type: ignore[attr-defined]
+                strict=False,
+            )
+        ]
 
     @classmethod
     def _resolve_tile_bytes(cls, tile: object, block_of: dict[int, int]) -> int:
@@ -1441,6 +1547,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         grid: int,
         num_sm: int,
         include_tmem: bool = True,
+        resource_policy: MatmulResourcePolicy = "strict",
     ) -> int:
         """Resident CTAs jointly achievable under the candidate's resources.
 
@@ -1477,7 +1584,12 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             and cls.TMEM_COLUMNS_PER_SM is not None
             and warps >= cls.TCGEN05_WARPGROUP_WARPS
         ):
-            columns = cls._tmem_columns(cls._all_dot_acc_tiles(env, block_sizes))
+            columns = cls._candidate_tmem_columns(
+                env,
+                block_sizes,
+                include_lhs_scratch=False,
+                resource_policy=resource_policy,
+            )
             if columns > 0:
                 limits.append(max(1, cls.TMEM_COLUMNS_PER_SM // columns))
 
@@ -1493,6 +1605,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         loop_trips: int,
         num_sm: int,
         stage_block_sizes: list[int] | None = None,
+        resource_policy: MatmulResourcePolicy = "strict",
     ) -> int:
         """Run the graded stage model against a complete kernel candidate."""
         stage_blocks = block_sizes if stage_block_sizes is None else stage_block_sizes
@@ -1508,6 +1621,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             smem_bytes=smem_of(1),
             grid=stage_grid,
             num_sm=num_sm,
+            resource_policy=resource_policy,
         )
 
         def candidate_smem_of(stages: int) -> int:
@@ -1538,18 +1652,70 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         num_warps: int,
         num_stages: int,
         num_sm: int,
+        *,
+        min_warps: int | None = None,
+        max_warps: int | None = None,
+        resource_policy: MatmulResourcePolicy = "strict",
     ) -> int:
         """Refresh the warp count from a complete kernel candidate."""
-        if not cls.WORK_AWARE_WARPS:
-            return num_warps
-        return cls._select_num_warps(
-            num_warps,
-            env,
-            block_sizes,
-            grid=cls._launch_grid(env, block_sizes),
-            num_sm=num_sm,
-            smem_bytes=cls._kernel_smem_bytes(env, block_sizes, num_stages),
-        )
+        selected = num_warps
+        if cls.WORK_AWARE_WARPS:
+            selected = cls._select_num_warps(
+                num_warps,
+                env,
+                block_sizes,
+                grid=cls._launch_grid(env, block_sizes),
+                num_sm=num_sm,
+                smem_bytes=cls._kernel_smem_bytes(env, block_sizes, num_stages),
+                resource_policy=resource_policy,
+            )
+        lower = 1 if min_warps is None else max(1, min_warps)
+        upper = cls.MAX_NUM_WARPS if max_warps is None else max(1, max_warps)
+        if lower > upper:
+            raise ValueError(f"invalid warp bounds: {lower} > {upper}")
+        return max(lower, min(upper, selected))
+
+    @classmethod
+    def _candidate_hard_resources(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        num_warps: int,
+        num_stages: int,
+        *,
+        resource_policy: MatmulResourcePolicy = "strict",
+    ) -> tuple[tuple[int, int], ...]:
+        """Hard SMEM/TMEM demands and their budgets for one complete candidate."""
+        resources: list[tuple[int, int]] = []
+        if cls.ENFORCE_SMEM_BUDGET:
+            resources.extend(
+                (demand, cls.SMEM_BUDGET)
+                for demand in cls._kernel_smem_demands(
+                    env,
+                    block_sizes,
+                    num_stages,
+                    hard_allocation=True,
+                )
+            )
+        if cls.TMEM_COLUMN_BUDGET is not None:
+            # This scratch-inclusive allocation-unit model also dominates
+            # the old per-dot TMEM byte check.
+            resources.append(
+                (
+                    (
+                        cls._candidate_tmem_columns(
+                            env,
+                            block_sizes,
+                            include_lhs_scratch=True,
+                            resource_policy=resource_policy,
+                        )
+                        if num_warps >= cls.TCGEN05_WARPGROUP_WARPS
+                        else 0
+                    ),
+                    cls.TMEM_COLUMN_BUDGET,
+                )
+            )
+        return tuple(resources)
 
     @classmethod
     def _fixup_candidate_resources(
@@ -1562,6 +1728,12 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         num_sm: int,
         shrinkable: list[int],
         largest_first: bool,
+        min_warps: int | None = None,
+        max_warps: int | None = None,
+        refresh_warps: bool = False,
+        min_stages: int | None = None,
+        resource_policy: MatmulResourcePolicy = "strict",
+        solve_final_warps: bool = True,
     ) -> tuple[int, int]:
         """Make a candidate legal under the hard SMEM and TMEM budgets.
 
@@ -1579,39 +1751,30 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             slot_of[bs.block_id] = slot
             floors[bs.block_id] = max(1, bs.min_size, bs.autotuner_min)
 
-        def hard_resources(
+        def solve_warps(
             candidate: list[int],
             warps: int,
             stages: int,
-        ) -> tuple[tuple[int, int], ...]:
-            resources: list[tuple[int, int]] = []
-            if cls.ENFORCE_SMEM_BUDGET:
-                resources.extend(
-                    (demand, cls.SMEM_BUDGET)
-                    for demand in cls._kernel_smem_demands(
-                        env,
-                        candidate,
-                        stages,
-                        hard_allocation=True,
-                    )
+        ) -> int:
+            if min_warps is None and max_warps is None:
+                return cls._solve_candidate_warps(
+                    env,
+                    candidate,
+                    warps,
+                    stages,
+                    num_sm,
+                    resource_policy=resource_policy,
                 )
-            if cls.TMEM_COLUMN_BUDGET is not None:
-                # This scratch-inclusive allocation-unit model also dominates
-                # the old per-dot TMEM byte check.
-                resources.append(
-                    (
-                        (
-                            cls._tmem_columns(
-                                cls._all_dot_acc_tiles(env, candidate),
-                                include_lhs_scratch=True,
-                            )
-                            if warps >= cls.TCGEN05_WARPGROUP_WARPS
-                            else 0
-                        ),
-                        cls.TMEM_COLUMN_BUDGET,
-                    )
-                )
-            return tuple(resources)
+            return cls._solve_candidate_warps(
+                env,
+                candidate,
+                warps,
+                stages,
+                num_sm,
+                min_warps=min_warps,
+                max_warps=max_warps,
+                resource_policy=resource_policy,
+            )
 
         def relief(
             current: tuple[tuple[int, int], ...],
@@ -1633,19 +1796,36 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         mm = env.config_spec.kernel_matmul_fact
         assert mm is not None
         while True:
-            current = hard_resources(block_sizes, num_warps, num_stages)
+            current = cls._candidate_hard_resources(
+                env,
+                block_sizes,
+                num_warps,
+                num_stages,
+                resource_policy=resource_policy,
+            )
             if all(demand <= budget for demand, budget in current):
                 break
 
-            if num_stages > cls.MIN_NUM_STAGES:
+            stage_floor = (
+                cls.MIN_NUM_STAGES if min_stages is None else max(1, min_stages)
+            )
+            if num_stages > stage_floor:
                 trial_stages = num_stages - 1
-                trial_resources = hard_resources(
+                trial_warps = (
+                    solve_warps(block_sizes, num_warps, trial_stages)
+                    if refresh_warps
+                    else num_warps
+                )
+                trial_resources = cls._candidate_hard_resources(
+                    env,
                     block_sizes,
-                    num_warps,
+                    trial_warps,
                     trial_stages,
+                    resource_policy=resource_policy,
                 )
                 if relief(current, trial_resources) is not None:
                     num_stages = trial_stages
+                    num_warps = trial_warps
                     continue
 
             candidates = [
@@ -1668,14 +1848,18 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             for position, bid in enumerate(candidates):
                 trial = list(block_sizes)
                 trial[slot_of[bid]] //= 2
-                trial_warps = cls._solve_candidate_warps(
-                    env,
+                trial_warps = solve_warps(
                     trial,
                     num_warps,
                     num_stages,
-                    num_sm,
                 )
-                trial_resources = hard_resources(trial, trial_warps, num_stages)
+                trial_resources = cls._candidate_hard_resources(
+                    env,
+                    trial,
+                    trial_warps,
+                    num_stages,
+                    resource_policy=resource_policy,
+                )
                 impact = relief(
                     current,
                     trial_resources,
@@ -1720,13 +1904,12 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
             _score, winner, num_warps = max(trials, key=itemgetter(0))
             block_sizes[:] = winner
 
-        num_warps = cls._solve_candidate_warps(
-            env,
-            block_sizes,
-            num_warps,
-            num_stages,
-            num_sm,
-        )
+        if solve_final_warps:
+            num_warps = solve_warps(
+                block_sizes,
+                num_warps,
+                num_stages,
+            )
         return num_stages, num_warps
 
     @classmethod
@@ -1961,6 +2144,364 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         return bm, bn, bk, num_warps, num_stages, l2_grouping
 
     @classmethod
+    def _emit_seed_draft(
+        cls,
+        draft: MatmulSeedDraft,
+        extra: dict[str, Any] | None = None,
+        *,
+        l2_groupings: list[int] | None = None,
+    ) -> Config:
+        config: dict[str, Any] = {
+            "block_sizes": list(draft.block_sizes),
+            "num_warps": draft.num_warps,
+            "num_stages": draft.num_stages,
+        }
+        if l2_groupings is not None:
+            config["l2_groupings"] = list(l2_groupings)
+        elif draft.l2_grouping > 1:
+            config["l2_groupings"] = [draft.l2_grouping]
+        if extra:
+            config.update(extra)
+        return Config(**config)
+
+    @staticmethod
+    def _l2_groupings_for_site(
+        env: CompileEnvironment,
+        site: DotSite | None,
+        grouping: int,
+    ) -> list[int] | None:
+        """Apply one dot's L2 choice to its root while preserving other roots."""
+        spec = env.config_spec
+        count = len(spec.l2_groupings)
+        if count == 0:
+            return None
+        base = cast("Config", spec.autotune_reference_config())
+        values = list(
+            cast(
+                "list[int]",
+                base.config.get("l2_groupings", [1] * count),
+            )
+        )
+        if len(values) != count:
+            values = [1] * count
+
+        grid = getattr(spec, "kernel_grid_fact", None)
+        if grid is None or site is None:
+            return values
+        group = grid.group_for_graph(site.graph_id)
+        for block_id in group:
+            try:
+                slot = spec.l2_groupings.block_id_to_index(block_id)
+            except (KeyError, ValueError):
+                continue
+            values[slot] = grouping
+            break
+        return values
+
+    @staticmethod
+    def _seed_axis_ids(roles: Mapping[int, Collection[str]]) -> SeedAxisIds:
+        def ids_for(axis: str) -> tuple[int, ...]:
+            return tuple(
+                block_id
+                for block_id, block_roles in roles.items()
+                if axis in block_roles
+            )
+
+        return SeedAxisIds(ids_for("m"), ids_for("n"), ids_for("k"))
+
+    @classmethod
+    def _set_seed_block(
+        cls,
+        env: CompileEnvironment,
+        block_sizes: list[int],
+        block_id: int,
+        value: int,
+    ) -> bool:
+        """Set one seed block to an absolute value within its live spec bounds."""
+        try:
+            slot = env.config_spec.block_sizes.block_id_to_index(block_id)
+        except (AttributeError, KeyError, ValueError):
+            return False
+        block_spec = cast("BlockSizeSpec", env.config_spec.block_sizes[slot])
+        floor = max(1, block_spec.min_size, block_spec.autotuner_min)
+        value = max(floor, min(block_spec.max_size, value))
+        changed = value != block_sizes[slot]
+        block_sizes[slot] = value
+        return changed
+
+    @classmethod
+    def _scale_seed_axes(
+        cls,
+        env: CompileEnvironment,
+        draft: MatmulSeedDraft,
+        axis_ids: SeedAxisIds,
+        *,
+        log2_deltas: tuple[int, int, int],
+    ) -> tuple[bool, bool, bool]:
+        """Scale the current M/N/K-role blocks by powers of two."""
+        changed: list[bool] = []
+        for ids, log2_delta in zip(axis_ids, log2_deltas, strict=True):
+            axis_changed = False
+            for block_id in ids:
+                try:
+                    slot = env.config_spec.block_sizes.block_id_to_index(block_id)
+                except (AttributeError, KeyError, ValueError):
+                    continue
+                value = draft.block_sizes[slot]
+                if log2_delta >= 0:
+                    value *= 2**log2_delta
+                else:
+                    value //= 2 ** (-log2_delta)
+                axis_changed = (
+                    cls._set_seed_block(env, draft.block_sizes, block_id, value)
+                    or axis_changed
+                )
+            changed.append(axis_changed)
+        return cast("tuple[bool, bool, bool]", tuple(changed))
+
+    @classmethod
+    def _finalize_seed_draft(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        draft: MatmulSeedDraft,
+        *,
+        num_sm: int,
+        axis_ids: SeedAxisIds,
+        recompute_stages: bool,
+        min_warps: int | None = None,
+        max_warps: int | None = None,
+        keep_tcgen05: bool = False,
+        apply_role_correction: bool = True,
+        protected_block_ids: Collection[int] = (),
+        min_stages: int | None = None,
+        recompute_warps: bool = True,
+        resource_policy: MatmulResourcePolicy = "strict",
+    ) -> MatmulSeedDraft | None:
+        pre_role_blocks = list(draft.block_sizes)
+        if apply_role_correction and getattr(
+            cls,
+            "ROLE_AWARE_KNOBS",
+            cls.SINGLE_ROLE_AWARE_KNOBS,
+        ):
+            cls._apply_knob_roles(env, mm, draft.block_sizes, num_sm)
+
+        m_ids, n_ids, k_ids = axis_ids
+        if keep_tcgen05:
+            for block_id in m_ids:
+                try:
+                    slot = env.config_spec.block_sizes.block_id_to_index(block_id)
+                except (AttributeError, KeyError, ValueError):
+                    continue
+                cls._set_seed_block(
+                    env,
+                    draft.block_sizes,
+                    block_id,
+                    max(draft.block_sizes[slot], cls.TCGEN05_MIN_BM),
+                )
+
+        keep_stage_blocks = recompute_stages and getattr(cls, "ROLE_KEEP_STAGES", False)
+        stage_blocks = pre_role_blocks if keep_stage_blocks else None
+        shrinkable = list(dict.fromkeys((*n_ids, *k_ids, *m_ids)))
+        protected = set(protected_block_ids)
+        shrinkable = [block_id for block_id in shrinkable if block_id not in protected]
+        if keep_tcgen05:
+            shrinkable = [block_id for block_id in shrinkable if block_id not in m_ids]
+
+        seen: set[tuple[tuple[int, ...], int, int]] = set()
+        for _ in range(16):
+            before = (
+                tuple(draft.block_sizes),
+                draft.num_warps,
+                draft.num_stages,
+            )
+            if before in seen:
+                return None
+            seen.add(before)
+            if recompute_warps:
+                draft.num_warps = cls._solve_candidate_warps(
+                    env,
+                    draft.block_sizes,
+                    draft.num_warps,
+                    draft.num_stages,
+                    num_sm,
+                    min_warps=min_warps,
+                    max_warps=max_warps,
+                    resource_policy=resource_policy,
+                )
+            if recompute_stages:
+                stage_candidate = stage_blocks or draft.block_sizes
+                draft.num_stages = cls._solve_candidate_stages(
+                    env,
+                    draft.block_sizes,
+                    num_warps=draft.num_warps,
+                    loop_trips=cls._pipelined_loop_trips(
+                        env,
+                        stage_candidate,
+                        max_loop_trips=max(1, mm.sequential_loop_trips),
+                    ),
+                    num_sm=num_sm,
+                    stage_block_sizes=stage_blocks,
+                    resource_policy=resource_policy,
+                )
+            draft.num_stages, draft.num_warps = cls._fixup_candidate_resources(
+                env,
+                draft.block_sizes,
+                draft.num_stages,
+                draft.num_warps,
+                num_sm=num_sm,
+                shrinkable=shrinkable,
+                largest_first=False,
+                min_warps=min_warps,
+                max_warps=max_warps,
+                refresh_warps=recompute_warps,
+                min_stages=min_stages,
+                resource_policy=resource_policy,
+                solve_final_warps=recompute_warps,
+            )
+            if (
+                tuple(draft.block_sizes),
+                draft.num_warps,
+                draft.num_stages,
+            ) == before:
+                break
+        else:
+            return None
+
+        if keep_tcgen05 and not any(
+            bm >= cls.TCGEN05_MIN_BM
+            for bm, _bn, _bk, _itemsize in cls._all_dot_acc_tiles(
+                env,
+                draft.block_sizes,
+            )
+        ):
+            return None
+        return draft
+
+    @classmethod
+    def _register_mma_seed_drafts(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        base: MatmulSeedDraft,
+        *,
+        num_sm: int,
+        axis_ids: SeedAxisIds,
+    ) -> list[MatmulSeedDraft]:
+        seeds = []
+        for warps in (1, 2):
+            draft = base.copy()
+            targets = (
+                cls.TCGEN05_MIN_BM,
+                warps * cls.TMEM_ALLOC_COLUMNS,
+                warps * cls.DOT_MIN,
+            )
+            for block_ids, target in zip(axis_ids, targets, strict=True):
+                for block_id in block_ids:
+                    cls._set_seed_block(env, draft.block_sizes, block_id, target)
+            draft.num_warps = warps
+            draft.l2_grouping = 1
+            finalized = cls._finalize_seed_draft(
+                env,
+                mm,
+                draft,
+                num_sm=num_sm,
+                axis_ids=axis_ids,
+                recompute_stages=True,
+                min_warps=warps,
+                max_warps=warps,
+            )
+            # Preserve the partially corrected low-warp candidate if correction
+            # cycles; replacing it with the primary would erase this regime.
+            seeds.append(finalized or draft)
+        return seeds
+
+    @classmethod
+    def _aspect_seed_drafts(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        base: MatmulSeedDraft,
+        *,
+        num_sm: int,
+        axis_ids: SeedAxisIds,
+    ) -> list[MatmulSeedDraft]:
+        seeds = []
+        for log2_deltas in ((1, -1, 0), (-1, 1, 0)):
+            draft = base.copy()
+            changed = cls._scale_seed_axes(
+                env,
+                draft,
+                axis_ids=axis_ids,
+                log2_deltas=log2_deltas,
+            )
+            if all(changed[:2]):
+                draft = (
+                    cls._finalize_seed_draft(
+                        env,
+                        mm,
+                        draft,
+                        num_sm=num_sm,
+                        axis_ids=axis_ids,
+                        recompute_stages=True,
+                    )
+                    or base.copy()
+                )
+            else:
+                draft = base.copy()
+            seeds.append(draft)
+        return seeds
+
+    @classmethod
+    def _bk_stage_seed_drafts(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        base: MatmulSeedDraft,
+        *,
+        num_sm: int,
+        axis_ids: SeedAxisIds,
+    ) -> list[MatmulSeedDraft]:
+        def build(
+            log2_deltas: tuple[int, int, int],
+            stage_delta: int,
+            *,
+            keep_tcgen05: bool = False,
+        ) -> MatmulSeedDraft:
+            draft = base.copy()
+            changed = cls._scale_seed_axes(
+                env,
+                draft,
+                axis_ids=axis_ids,
+                log2_deltas=log2_deltas,
+            )
+            if not changed[2]:
+                return base.copy()
+            draft.num_stages = max(
+                cls.MIN_NUM_STAGES,
+                min(cls.HW_MAX_STAGES, draft.num_stages + stage_delta),
+            )
+            return (
+                cls._finalize_seed_draft(
+                    env,
+                    mm,
+                    draft,
+                    num_sm=num_sm,
+                    axis_ids=axis_ids,
+                    recompute_stages=False,
+                    min_warps=(cls.TCGEN05_WARPGROUP_WARPS if keep_tcgen05 else None),
+                    keep_tcgen05=keep_tcgen05,
+                )
+                or base.copy()
+            )
+
+        return [
+            build((0, 0, -1), 1),
+            build((0, 0, 1), -1),
+            build((-1, -1, -1), -1, keep_tcgen05=True),
+        ]
+
+    @classmethod
     def _projected_tile_for_dot(
         cls,
         env: CompileEnvironment,
@@ -1969,6 +2510,8 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         itemsize: int,
         num_sm: int,
         site: DotSite,
+        *,
+        apply_partitioned_k_cap: bool = True,
     ) -> tuple[int, int, int, int, int, int]:
         """Project one dot-local formula proposal onto the axes the kernel exposes."""
         m_extent = fact.static_m if fact.static_m is not None else None
@@ -1999,9 +2542,7 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
                 max(1, block_spec.min_size, block_spec.autotuner_min),
                 block_spec.max_size,
             )
-        base_blocks = list(
-            cast("list[int]", spec._base_default_config().config["block_sizes"])
-        )
+        base_blocks = cls._reference_block_sizes(spec)
         graph_ids = (site.graph_id,)
         grid_group = (
             spec.kernel_grid_fact.group_for_graph(site.graph_id)
@@ -2070,11 +2611,13 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         bk = project("k", bk, fact.k_block_id)
 
         # A partitioned K loop exposes many independent partial-output CTAs.
+        site_loop_axes = getattr(site, "loop_axes", ())
         partitioned_k = any(
-            axis.bounded_by_block_id is not None for axis in site.loop_axes
+            axis.bounded_by_block_id is not None for axis in site_loop_axes
         )
         if (
-            partitioned_k
+            apply_partitioned_k_cap
+            and partitioned_k
             and cls.SAT_PARTITIONED_K_BM is not None
             and cls.SAT_PARTITIONED_K_BN is not None
         ):
@@ -2214,11 +2757,117 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
                 num_sm,
             )
 
-        ranked: list[Config] = [
-            _h100_config(
-                spec, fact, bm, bn, bk, nw, ns, l2, _extra(bm, bn, bk, nw, ns, l2)
+        slot_of = {
+            cast("BlockSizeSpec", spec.block_sizes[slot]).block_id: slot
+            for slot in range(len(spec.block_sizes))
+        }
+
+        def emit(
+            draft: MatmulSeedDraft,
+            fallback: tuple[int, int, int],
+            *,
+            compact_single_root_default: bool = False,
+        ) -> Config:
+            tile = tuple(
+                (
+                    draft.block_sizes[slot_of[block_id]]
+                    if block_id is not None and block_id in slot_of
+                    else fallback[index]
+                )
+                for index, block_id in enumerate(
+                    (fact.m_block_id, fact.n_block_id, fact.k_block_id)
+                )
+            )
+            l2_groupings = cls._l2_groupings_for_site(
+                env,
+                site,
+                draft.l2_grouping,
+            )
+            if compact_single_root_default and l2_groupings == [1]:
+                l2_groupings = None
+            return cls._emit_seed_draft(
+                draft,
+                _extra(
+                    tile[0],
+                    tile[1],
+                    tile[2],
+                    draft.num_warps,
+                    draft.num_stages,
+                    draft.l2_grouping,
+                ),
+                l2_groupings=l2_groupings,
+            )
+
+        primary = MatmulSeedDraft(
+            _h100_build_block_sizes(spec, fact, bm, bn, bk),
+            nw,
+            ns,
+            l2,
+        )
+        ranked = [
+            emit(
+                primary,
+                (bm, bn, bk),
+                compact_single_root_default=True,
             )
         ]
+
+        if cls.EXPANDED_SEED_POOL:
+            raw = cls._projected_tile_for_dot(
+                env,
+                fact,
+                axes,
+                itemsize,
+                num_sm,
+                site=site,
+                apply_partitioned_k_cap=False,
+            )
+            raw_draft = MatmulSeedDraft(
+                _h100_build_block_sizes(spec, fact, raw[0], raw[1], raw[2]),
+                raw[3],
+                raw[4],
+                raw[5],
+            )
+            # This is intentionally the untouched formula prior: projection and
+            # ConfigSpec clamping only, with no role/stage/warp/resource correction.
+            ranked.append(emit(raw_draft, raw[:3]))
+
+            axis_ids = cls._seed_axis_ids(
+                {
+                    block_id: (axis,)
+                    for axis, block_id in zip(
+                        ("m", "n", "k"),
+                        (fact.m_block_id, fact.n_block_id, fact.k_block_id),
+                        strict=True,
+                    )
+                    if block_id is not None
+                }
+            )
+            corrected = [
+                *cls._register_mma_seed_drafts(
+                    env,
+                    mm,
+                    primary,
+                    num_sm=num_sm,
+                    axis_ids=axis_ids,
+                ),
+                *cls._aspect_seed_drafts(
+                    env,
+                    mm,
+                    primary,
+                    num_sm=num_sm,
+                    axis_ids=axis_ids,
+                ),
+                *cls._bk_stage_seed_drafts(
+                    env,
+                    mm,
+                    primary,
+                    num_sm=num_sm,
+                    axis_ids=axis_ids,
+                ),
+            ]
+            ranked.extend(emit(draft, (bm, bn, bk)) for draft in corrected)
+            return dedupe_configs(ranked)
 
         def _warps(_bm: int, _bn: int) -> int:
             return 8 if _bm * _bn >= cls.WARPS_HI_ELEMS else 4
@@ -2252,32 +2901,30 @@ class TritonH100MatmulHeuristic(AutotunerHeuristic):
         ):
             nw2 = _warps(bm2, bn2)
             ranked.append(
-                _h100_config(
-                    spec,
-                    fact,
-                    bm2,
-                    bn2,
-                    bk,
-                    nw2,
-                    ns,
-                    1,
-                    _extra(bm2, bn2, bk, nw2, ns, 1),
+                emit(
+                    MatmulSeedDraft(
+                        _h100_build_block_sizes(spec, fact, bm2, bn2, bk),
+                        nw2,
+                        ns,
+                        1,
+                    ),
+                    (bm2, bn2, bk),
+                    compact_single_root_default=True,
                 )
             )
 
         # alt 2 — shallower num_stages neighbor (perturb down only; skipped at the floor ns==2).
         if ns > 2:
             ranked.append(
-                _h100_config(
-                    spec,
-                    fact,
-                    bm,
-                    bn,
-                    bk,
-                    nw,
-                    ns - 1,
-                    l2,
-                    _extra(bm, bn, bk, nw, ns - 1, l2),
+                emit(
+                    MatmulSeedDraft(
+                        _h100_build_block_sizes(spec, fact, bm, bn, bk),
+                        nw,
+                        ns - 1,
+                        l2,
+                    ),
+                    (bm, bn, bk),
+                    compact_single_root_default=True,
                 )
             )
         return ranked
@@ -2419,6 +3066,7 @@ class TritonB200FormulaMatmulHeuristic(TritonH100MatmulHeuristic):
     # after multi-contraction draft assembly. The multi front end disables the
     # per-dot invocation and applies the shared correction once to its merged draft.
     SINGLE_ROLE_AWARE_KNOBS = True
+    EXPANDED_SEED_POOL = True
     ROLE_FLAT_OUTPUT = True
     ROLE_GRID_FILL = True
     # tcgen05 tensor memory allocates at least 32 columns. Use that as the floor
@@ -2599,6 +3247,9 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
     HARDWARE_TARGETS = (("cuda", "sm100"),)
     promote_seed_to_default = True
     SINGLE_ROLE_AWARE_KNOBS = False
+    COMPILER_SEED_CAP = 20
+    OPTIMISTIC_EXPANSION_STEPS = 1
+    LARGE_K_CAP = 512
 
     # --- knob-role tile sizing (see ``_apply_knob_roles``) ----------------------------
     # Master switch, so the correction can be A/B'd against the plain ranked draft; the
@@ -2668,31 +3319,80 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
         return (carry, work, area)
 
     @classmethod
-    def _draft(
-        cls, env: CompileEnvironment, mm: KernelMatmulFact
-    ) -> dict[str, Any] | None:
-        """Phase 1: assemble a whole-kernel draft from the per-dot proposals."""
-        from ...runtime import get_num_sm
-
-        spec = env.config_spec
-        num_sm = max(1, get_num_sm(env.device))
-        proposals: dict[int, tuple[int, int, int, int, int, int]] = {}
-        for index, resolved in enumerate(mm.matmuls):
-            axes = resolved.axes
-            if any(
-                axes.kind(axis) is DotAxisKind.UNKNOWN or axes.extent(axis) is None
-                for axis in ("m", "n", "k")
-            ):
-                continue
-            fact = resolved.fact
-            proposals[index] = cls._tile_for_dot(
+    def _proposal_for(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        index: int,
+        num_sm: int,
+        *,
+        precondition: bool = True,
+    ) -> MatmulProposal | None:
+        """One dot's prior, projected and preconditioned against the whole kernel."""
+        resolved = mm.matmuls[index]
+        fact = resolved.fact
+        ax = resolved.axes
+        if any(
+            ax.kind(a) is DotAxisKind.UNKNOWN or ax.extent(a) is None
+            for a in ("m", "n", "k")
+        ):
+            return None
+        itemsize = max(1, fact.lhs_dtype.itemsize)
+        if precondition:
+            return cls._tile_for_dot(
                 env,
                 fact,
-                axes,
-                max(1, fact.lhs_dtype.itemsize),
+                ax,
+                itemsize,
                 num_sm,
                 site=resolved.site,
             )
+        return cls._projected_tile_for_dot(
+            env,
+            fact,
+            ax,
+            itemsize,
+            num_sm,
+            site=resolved.site,
+            apply_partitioned_k_cap=False,
+        )
+
+    @classmethod
+    def _proposals(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        *,
+        num_sm: int,
+        precondition: bool,
+    ) -> dict[int, MatmulProposal]:
+        return {
+            index: proposal
+            for index in range(len(mm.matmuls))
+            if (
+                proposal := cls._proposal_for(
+                    env,
+                    mm,
+                    index,
+                    num_sm,
+                    precondition=precondition,
+                )
+            )
+            is not None
+        }
+
+    @classmethod
+    def _draft(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        proposals: dict[int, MatmulProposal],
+        num_sm: int,
+        *,
+        resource_policy: MatmulResourcePolicy = "strict",
+    ) -> MatmulSeedDraft | None:
+        """Phase 1: assemble a whole-kernel draft from cached per-dot proposals."""
+        spec = env.config_spec
         if not proposals:
             return None
 
@@ -2716,8 +3416,7 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
         # Start from the base default so an axis that is NO dot's M/N/K and no grid axis
         # keeps exactly the size it has today, rather than being pinned by a rule that was
         # never measured on it.
-        base = spec._base_default_config()
-        block_sizes = list(cast("list[int]", base.config["block_sizes"]))
+        block_sizes = cls._reference_block_sizes(spec)
         grid_ids = set(spec.grid_block_ids)
         mn_ids = {resolved.fact.m_block_id for resolved in mm.matmuls} | {
             resolved.fact.n_block_id for resolved in mm.matmuls
@@ -2763,16 +3462,10 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
 
         if cls.GRADED_STAGES:
             max_loop_trips = max(1, mm.sequential_loop_trips)
-            resolved_trips = (
-                cls._resolved_loop_trips(env, stage_ring, region.loop_axes)
-                for region in mm.pipelined_regions
-            )
-            loop_trips = max(
-                (
-                    trips if trips is not None else max_loop_trips
-                    for trips in resolved_trips
-                ),
-                default=max_loop_trips,
+            loop_trips = cls._pipelined_loop_trips(
+                env,
+                stage_ring,
+                max_loop_trips=max_loop_trips,
             )
             num_stages = cls._solve_candidate_stages(
                 env,
@@ -2781,6 +3474,7 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
                 loop_trips=loop_trips,
                 num_sm=num_sm,
                 stage_block_sizes=stage_ring,
+                resource_policy=resource_policy,
             )
         num_warps = cls._solve_candidate_warps(
             env,
@@ -2788,45 +3482,434 @@ class TritonB200MultiMatmulHeuristic(TritonB200FormulaMatmulHeuristic):
             num_warps,
             num_stages,
             num_sm,
+            resource_policy=resource_policy,
         )
 
-        return {
-            "block_sizes": block_sizes,
-            "num_warps": num_warps,
-            "num_stages": num_stages,
-            "_num_sm": num_sm,
+        return MatmulSeedDraft(block_sizes, num_warps, num_stages)
+
+    @classmethod
+    def _fixup(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        draft: MatmulSeedDraft,
+        *,
+        num_sm: int,
+        resource_policy: MatmulResourcePolicy = "strict",
+    ) -> None:
+        """Phase 2: enforce hard budgets on the merged candidate."""
+        draft.num_stages, draft.num_warps = cls._fixup_candidate_resources(
+            env,
+            draft.block_sizes,
+            draft.num_stages,
+            draft.num_warps,
+            num_sm=num_sm,
+            shrinkable=[bid for bid, _users in mm.knob_users],
+            largest_first=True,
+            resource_policy=resource_policy,
+        )
+
+    @classmethod
+    def _optimistic_expanded_seed_drafts(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        base: MatmulSeedDraft,
+        *,
+        num_sm: int,
+        axis_ids: SeedAxisIds,
+    ) -> list[MatmulSeedDraft]:
+        """M- and N-expanded merged candidates under optimistic TMEM."""
+        result = []
+        for axis in (0, 1):
+            draft = base.copy()
+            log2_deltas = (
+                (cls.OPTIMISTIC_EXPANSION_STEPS, 0, 0)
+                if axis == 0
+                else (0, cls.OPTIMISTIC_EXPANSION_STEPS, 0)
+            )
+            changed = cls._scale_seed_axes(
+                env,
+                draft,
+                axis_ids,
+                log2_deltas=log2_deltas,
+            )
+            if not changed[axis]:
+                continue
+            finalized = cls._finalize_seed_draft(
+                env,
+                mm,
+                draft,
+                num_sm=num_sm,
+                axis_ids=axis_ids,
+                recompute_stages=True,
+                resource_policy="optimistic",
+            )
+            if finalized is not None:
+                result.append(finalized)
+        return result
+
+    @classmethod
+    def _set_capped_large_k(
+        cls,
+        env: CompileEnvironment,
+        draft: MatmulSeedDraft,
+        k_ids: Collection[int],
+    ) -> bool:
+        changed = False
+        for block_id in k_ids:
+            extent = cls._axis_extent(env, block_id)
+            if extent is None:
+                try:
+                    slot = env.config_spec.block_sizes.block_id_to_index(block_id)
+                    extent = cast(
+                        "BlockSizeSpec",
+                        env.config_spec.block_sizes[slot],
+                    ).max_size
+                except (AttributeError, KeyError, ValueError):
+                    continue
+            target = 1 << (max(1, extent) - 1).bit_length()
+            changed = (
+                cls._set_seed_block(
+                    env,
+                    draft.block_sizes,
+                    block_id,
+                    min(target, cls.LARGE_K_CAP),
+                )
+                or changed
+            )
+        return changed
+
+    @classmethod
+    def _optimistic_frontier_seed_drafts(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        primary: MatmulSeedDraft,
+        register_mma: Sequence[MatmulSeedDraft],
+        *,
+        num_sm: int,
+        axis_ids: SeedAxisIds,
+    ) -> list[MatmulSeedDraft]:
+        """K/stage and high-launch recipes with only their requested fix-ups."""
+        result = []
+        _m_ids, _n_ids, k_ids = axis_ids
+
+        lighter_k = primary.copy()
+        if cls._scale_seed_axes(
+            env,
+            lighter_k,
+            axis_ids,
+            log2_deltas=(0, 0, -1),
+        )[2]:
+            lighter_k.num_stages = min(
+                cls.HW_MAX_STAGES,
+                lighter_k.num_stages + 1,
+            )
+            finalized = cls._finalize_seed_draft(
+                env,
+                mm,
+                lighter_k,
+                num_sm=num_sm,
+                axis_ids=axis_ids,
+                recompute_stages=False,
+                apply_role_correction=False,
+                protected_block_ids=k_ids,
+                min_stages=lighter_k.num_stages,
+                resource_policy="optimistic",
+            )
+            if finalized is not None:
+                result.append(finalized)
+
+        large_k = primary.copy()
+        if cls._set_capped_large_k(env, large_k, k_ids):
+            shallow = large_k.copy()
+            shallow.num_stages = min(2, cls.HW_MAX_STAGES)
+            finalized = cls._finalize_seed_draft(
+                env,
+                mm,
+                shallow,
+                num_sm=num_sm,
+                axis_ids=axis_ids,
+                recompute_stages=False,
+                apply_role_correction=False,
+                protected_block_ids=k_ids,
+                resource_policy="optimistic",
+            )
+            if finalized is not None:
+                result.append(finalized)
+
+            high_launch = large_k.copy()
+            high_launch.num_warps = max(
+                cls.TCGEN05_WARPGROUP_WARPS,
+                high_launch.num_warps,
+            )
+            high_launch.num_stages = min(
+                cls.HW_MAX_STAGES,
+                max(3, high_launch.num_stages + 1),
+            )
+            finalized = cls._finalize_seed_draft(
+                env,
+                mm,
+                high_launch,
+                num_sm=num_sm,
+                axis_ids=axis_ids,
+                recompute_stages=False,
+                min_warps=cls.TCGEN05_WARPGROUP_WARPS,
+                apply_role_correction=False,
+                protected_block_ids=k_ids,
+                min_stages=high_launch.num_stages,
+                resource_policy="optimistic",
+            )
+            if finalized is not None:
+                result.append(finalized)
+
+        if register_mma:
+            small_high_launch = register_mma[0].copy()
+            small_high_launch.num_warps = cls.TCGEN05_WARPGROUP_WARPS
+            small_high_launch.num_stages = min(
+                cls.HW_MAX_STAGES,
+                max(3, small_high_launch.num_stages),
+            )
+            finalized = cls._finalize_seed_draft(
+                env,
+                mm,
+                small_high_launch,
+                num_sm=num_sm,
+                axis_ids=axis_ids,
+                recompute_stages=False,
+                min_warps=cls.TCGEN05_WARPGROUP_WARPS,
+                max_warps=cls.TCGEN05_WARPGROUP_WARPS,
+                apply_role_correction=False,
+                protected_block_ids=tuple(
+                    dict.fromkeys(block_id for ids in axis_ids for block_id in ids)
+                ),
+                min_stages=small_high_launch.num_stages,
+                recompute_warps=False,
+                resource_policy="optimistic",
+            )
+            if finalized is not None:
+                result.append(finalized)
+        return result
+
+    @classmethod
+    def _persistent_seed_config(
+        cls,
+        env: CompileEnvironment,
+        primary: MatmulSeedDraft,
+        *,
+        num_sm: int,
+    ) -> Config | None:
+        spec = env.config_spec
+        if (
+            "persistent_blocked" not in getattr(spec, "allowed_pid_types", ())
+            or cls._launch_grid(env, primary.block_sizes) <= num_sm
+        ):
+            return None
+        config = cls._canonical_seed_config(
+            env,
+            cls._emit_seed_draft(
+                primary,
+                {
+                    "pid_type": "persistent_blocked",
+                    "num_sm_multiplier": 1,
+                },
+            ),
+        )
+        if config is None or config.config.get("pid_type") != "persistent_blocked":
+            return None
+        return config
+
+    @classmethod
+    def _dedupe_seed_pool(
+        cls,
+        env: CompileEnvironment,
+        configs: Sequence[Config],
+    ) -> list[Config]:
+        """Preserve rank zero and deduplicate the tail by live ConfigSpec identity."""
+        if not configs:
+            return []
+        result = [configs[0]]
+        primary = cls._canonical_seed_config(env, configs[0])
+        seen = {primary} if primary is not None else set()
+        for config in configs[1:]:
+            normalized = cls._canonical_seed_config(env, config)
+            if normalized is None or normalized in seen:
+                continue
+            seen.add(normalized)
+            result.append(config)
+        return result
+
+    @classmethod
+    def _canonical_seed_config(
+        cls,
+        env: CompileEnvironment,
+        config: Config,
+    ) -> Config | None:
+        """Fill omitted fields and return the config's live-spec identity."""
+        try:
+            return _materialize_config(
+                config.config,
+                config_spec=env.config_spec,
+            )
+        except (
+            InvalidConfig,
+            ValueError,
+            TypeError,
+            KeyError,
+            AssertionError,
+        ):
+            return None
+
+    @classmethod
+    def _focal_seed_configs(
+        cls,
+        env: CompileEnvironment,
+        mm: KernelMatmulFact,
+        proposals: dict[int, MatmulProposal],
+        *,
+        exclude: Collection[Config] = (),
+    ) -> list[Config]:
+        """Default-filled focal configs in stable dot order, canonically deduplicated."""
+        seen = {
+            normalized
+            for config in exclude
+            if (
+                normalized := cls._canonical_seed_config(
+                    env,
+                    config,
+                )
+            )
+            is not None
         }
+        result = []
+        for index, proposal in proposals.items():
+            blocks = cls._reference_block_sizes(env.config_spec)
+            fact = mm.matmuls[index].fact
+            targets: dict[int, int] = {}
+            for position in (2, 0, 1):  # shared knob priority: K, M, N
+                block_id = (fact.m_block_id, fact.n_block_id, fact.k_block_id)[position]
+                if block_id is not None:
+                    targets.setdefault(block_id, proposal[position])
+            for block_id, target in targets.items():
+                cls._set_seed_block(env, blocks, block_id, target)
+
+            draft = MatmulSeedDraft(blocks, proposal[3], proposal[4], proposal[5])
+            config = cls._canonical_seed_config(
+                env,
+                cls._emit_seed_draft(
+                    draft,
+                    l2_groupings=cls._l2_groupings_for_site(
+                        env,
+                        mm.matmuls[index].site,
+                        proposal[5],
+                    ),
+                ),
+            )
+            if config is None or config in seen:
+                continue
+            seen.add(config)
+            result.append(config)
+        return result
 
     @classmethod
     def _multi_ranked(cls, env: CompileEnvironment) -> list[Config]:
+        from ...runtime import get_num_sm
+
         mm = env.config_spec.kernel_matmul_fact
         if mm is None:
             return []
-        draft = cls._draft(env, mm)
+        num_sm = max(1, get_num_sm(env.device))
+        corrected_proposals = cls._proposals(
+            env,
+            mm,
+            num_sm=num_sm,
+            precondition=True,
+        )
+        raw_proposals = cls._proposals(
+            env,
+            mm,
+            num_sm=num_sm,
+            precondition=False,
+        )
+        draft = cls._draft(env, mm, corrected_proposals, num_sm)
         if draft is None:
             return []
-        draft["num_stages"], draft["num_warps"] = cls._fixup_candidate_resources(
-            env,
-            draft["block_sizes"],
-            draft["num_stages"],
-            draft["num_warps"],
-            num_sm=draft["_num_sm"],
-            shrinkable=[bid for bid, _users in mm.knob_users],
-            largest_first=True,
+        cls._fixup(env, mm, draft, num_sm=num_sm)
+        ranked = [cls._emit_seed_draft(draft)]
+
+        merge_first = cls._draft(env, mm, raw_proposals, num_sm)
+        if merge_first is not None:
+            cls._fixup(env, mm, merge_first, num_sm=num_sm)
+            ranked.append(cls._emit_seed_draft(merge_first))
+
+        axis_ids = cls._seed_axis_ids(
+            {
+                block_id: tuple(axis for _index, axis in users)
+                for block_id, users in mm.knob_users
+            }
         )
-        primary: dict[str, Any] = {
-            "block_sizes": list(draft["block_sizes"]),
-            "num_warps": draft["num_warps"],
-            "num_stages": draft["num_stages"],
-        }
-        ranked = [Config(**primary)]
-        # One shallower-pipeline alternate, the same neighbour front end 1 plants: stage
-        # depth is the knob whose optimum the budget model resolves least sharply.
-        if draft["num_stages"] > 2:
-            alt = dict(primary)
-            alt["num_stages"] = draft["num_stages"] - 1
-            ranked.append(Config(**alt))
-        return dedupe_configs(ranked)
+        register_drafts = cls._register_mma_seed_drafts(
+            env,
+            mm,
+            draft,
+            num_sm=num_sm,
+            axis_ids=axis_ids,
+        )
+        register_mma = [cls._emit_seed_draft(seed) for seed in register_drafts]
+
+        optimistic_expanded: list[Config] = []
+        optimistic_merge = cls._draft(
+            env,
+            mm,
+            corrected_proposals,
+            num_sm,
+            resource_policy="optimistic",
+        )
+        if optimistic_merge is not None:
+            optimistic_expanded = [
+                cls._emit_seed_draft(seed)
+                for seed in cls._optimistic_expanded_seed_drafts(
+                    env,
+                    mm,
+                    optimistic_merge,
+                    num_sm=num_sm,
+                    axis_ids=axis_ids,
+                )
+            ]
+
+        frontier = [
+            cls._emit_seed_draft(seed)
+            for seed in cls._optimistic_frontier_seed_drafts(
+                env,
+                mm,
+                draft,
+                register_drafts,
+                num_sm=num_sm,
+                axis_ids=axis_ids,
+            )
+        ]
+        persistent = cls._persistent_seed_config(
+            env,
+            draft,
+            num_sm=num_sm,
+        )
+        fixed_tail = (
+            register_mma
+            + optimistic_expanded
+            + frontier
+            + ([persistent] if persistent is not None else [])
+        )
+        ranked = cls._dedupe_seed_pool(env, (*ranked, *fixed_tail))
+        ranked.extend(
+            cls._focal_seed_configs(
+                env,
+                mm,
+                raw_proposals,
+                exclude=ranked,
+            )
+        )
+        return ranked[: cls.COMPILER_SEED_CAP]
 
     @classmethod
     def get_seed_config(

--- a/helion/_compiler/device_ir_analysis.py
+++ b/helion/_compiler/device_ir_analysis.py
@@ -33,6 +33,8 @@ from .indexing_strategy import subscript_index_scale
 from .indexing_strategy import subscript_tile_info
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Container
     from collections.abc import Iterable
 
     import sympy
@@ -308,6 +310,24 @@ def _index_depends_on_loop(
     return False
 
 
+def _live_node_steps(
+    nodes: tuple[torch.fx.Node, ...],
+    tracked_nodes: Container[torch.fx.Node],
+    last_use: dict[torch.fx.Node, int],
+    *,
+    last_use_default: int = -1,
+) -> Iterable[set[torch.fx.Node]]:
+    """Yield the tracked nodes live after each graph node is introduced."""
+    live: set[torch.fx.Node] = set()
+    for index, node in enumerate(nodes):
+        if node in tracked_nodes:
+            live.add(node)
+        yield live
+        live = {
+            value for value in live if last_use.get(value, last_use_default) > index
+        }
+
+
 @dataclasses.dataclass
 class GraphAnalysis:
     """Shared structural and liveness observations for one DeviceIR graph."""
@@ -319,6 +339,8 @@ class GraphAnalysis:
     block_id_order: tuple[int, ...]
     live_tile_steps: tuple[tuple[LiveTile, ...], ...]
     peak_live_tiles: tuple[LiveTile, ...]
+    peak_dot_output_tiles: tuple[LiveTile, ...]
+    peak_promoted_lhs_tiles: tuple[LiveTile, ...]
     dot_nodes: tuple[torch.fx.Node, ...]
     reduction_occurrences: tuple[int, ...]
     reduction_axis_by_node_id: dict[int, int]
@@ -339,6 +361,7 @@ class GraphAnalysis:
         *,
         is_reduction_loop: bool,
         dot_targets: frozenset[object],
+        resolve_placeholder: Callable[[torch.fx.Node], torch.fx.Node],
     ) -> GraphAnalysis:
         from ..language import memory_ops
         from .inductor_lowering import ReductionLowering
@@ -347,12 +370,30 @@ class GraphAnalysis:
         nodes = tuple(graph.nodes)
         last_use: dict[torch.fx.Node, int] = {}
         tile_details: dict[torch.fx.Node, LiveTile] = {}
+        dot_details: dict[torch.fx.Node, LiveTile] = {}
+        promoted_lhs_details: dict[torch.fx.Node, LiveTile] = {}
         dot_nodes: list[torch.fx.Node] = []
         reduction_occurrences: list[int] = []
         seen_reductions: set[int] = set()
         reduction_axis_by_node_id: dict[int, int] = {}
         reduction_input_itemsizes: list[tuple[int, int]] = []
         memory_tiles: list[tuple[torch.fx.Node, LiveTile]] = []
+        operand_positions = matmul_operand_positions()
+        promoted_lhs_nodes: set[torch.fx.Node] = set()
+        for node in nodes:
+            positions = operand_positions.get(node.target)
+            if (
+                node.op != "call_function"
+                or positions is None
+                or positions[0] >= len(node.args)
+            ):
+                continue
+            lhs = node.args[positions[0]]
+            if (
+                isinstance(lhs, torch.fx.Node)
+                and resolve_placeholder(lhs).target is not memory_ops.load
+            ):
+                promoted_lhs_nodes.add(lhs)
 
         for index, node in enumerate(nodes):
             for input_node in node.all_input_nodes:
@@ -360,6 +401,11 @@ class GraphAnalysis:
 
             kind = _live_tile_kind(node, dot_targets)
             tile = _tile_from_tensor(node.meta.get("val"), env, kind=kind)
+            if tile is not None and kind == "dot_out":
+                dot_details[node] = tile
+            if tile is not None and node in promoted_lhs_nodes:
+                tile = tile._replace(promoted_lhs=True)
+                promoted_lhs_details[node] = tile
             if tile is not None and any(
                 block_id is not None for block_id in tile.dim_block_ids
             ):
@@ -413,10 +459,7 @@ class GraphAnalysis:
         )
         best_key: tuple[int, ...] = ()
         peak_live_tiles: tuple[LiveTile, ...] = ()
-        live: set[torch.fx.Node] = set()
-        for index, node in enumerate(nodes):
-            if node in tile_details:
-                live.add(node)
+        for live in _live_node_steps(nodes, tile_details, last_use):
             if live:
                 step_key = frozenset(id(value) for value in live)
                 step = tuple(tile_details[value] for value in live)
@@ -430,7 +473,35 @@ class GraphAnalysis:
                 if key > best_key:
                     best_key = key
                     peak_live_tiles = step
-            live = {value for value in live if last_use.get(value, -1) > index}
+
+        def peak_role_tiles(
+            details: dict[torch.fx.Node, LiveTile],
+            *,
+            last_use_default: int = -1,
+        ) -> tuple[LiveTile, ...]:
+            best: tuple[LiveTile, ...] = ()
+            best_key = (-1, -1)
+            for live in _live_node_steps(
+                nodes,
+                details,
+                last_use,
+                last_use_default=last_use_default,
+            ):
+                tiles = tuple(details[value] for value in live)
+                key = (
+                    sum(tile_rank(tile.dim_block_ids) for tile in tiles),
+                    len(tiles),
+                )
+                if key > best_key:
+                    best_key = key
+                    best = tiles
+            return best
+
+        peak_dot_output_tiles = peak_role_tiles(
+            dot_details,
+            last_use_default=len(nodes),
+        )
+        peak_promoted_lhs_tiles = peak_role_tiles(promoted_lhs_details)
 
         return cls(
             graph_id=graph_info.graph_id,
@@ -440,6 +511,8 @@ class GraphAnalysis:
             block_id_order=tuple(getattr(graph_info, "block_ids", ()) or ()),
             live_tile_steps=tuple(live_tile_steps),
             peak_live_tiles=peak_live_tiles,
+            peak_dot_output_tiles=peak_dot_output_tiles,
+            peak_promoted_lhs_tiles=peak_promoted_lhs_tiles,
             dot_nodes=tuple(dot_nodes),
             reduction_occurrences=tuple(reduction_occurrences),
             reduction_axis_by_node_id=reduction_axis_by_node_id,
@@ -509,9 +582,27 @@ class DeviceIRAnalysis:
         env: CompileEnvironment,
     ) -> DeviceIRAnalysis:
         from .device_ir import ForLoopGraphInfo
+        from .device_ir import NodeArgsGraphInfo
         from .device_ir import ReductionLoopGraphInfo
 
         dot_targets = frozenset(matmul_operand_positions())
+        graph_info_by_graph = {
+            graph_info.graph: graph_info for graph_info in device_ir.graphs
+        }
+
+        def resolve_placeholder(node: torch.fx.Node) -> torch.fx.Node:
+            seen: set[torch.fx.Node] = set()
+            while node.op == "placeholder" and node not in seen:
+                seen.add(node)
+                graph_info = graph_info_by_graph.get(node.graph)
+                if not isinstance(graph_info, NodeArgsGraphInfo):
+                    break
+                try:
+                    node = graph_info.placeholder_to_outer_arg(node)
+                except KeyError:
+                    break
+            return node
+
         graphs = tuple(
             GraphAnalysis.build(
                 graph_info,
@@ -521,6 +612,7 @@ class DeviceIRAnalysis:
                     ReductionLoopGraphInfo,
                 ),
                 dot_targets=dot_targets,
+                resolve_placeholder=resolve_placeholder,
             )
             for graph_info in device_ir.graphs
         )
@@ -629,6 +721,39 @@ class DeviceIRAnalysis:
             for graph in self.non_reduction_graphs
             for step in graph.live_tile_steps
         )
+
+    def _kernel_peak_role_tiles(self, field: str) -> tuple[LiveTile, ...]:
+        """Peak role-specific tile set after adding ancestor loop graphs."""
+        tiles_of = {
+            graph.graph_id: cast("tuple[LiveTile, ...]", getattr(graph, field))
+            for graph in self.non_reduction_graphs
+        }
+        best: tuple[LiveTile, ...] = ()
+        best_key = (-1, -1)
+        for graph_id, own in tiles_of.items():
+            chain = list(own)
+            current = self.parent_of.get(graph_id, -1)
+            seen = {graph_id}
+            while current in tiles_of and current not in seen:
+                seen.add(current)
+                chain.extend(tiles_of[current])
+                current = self.parent_of.get(current, -1)
+            key = (
+                sum(tile_rank(tile.dim_block_ids) for tile in chain),
+                len(chain),
+            )
+            if key > best_key:
+                best_key = key
+                best = tuple(chain)
+        return best
+
+    def kernel_peak_dot_outputs(self) -> tuple[LiveTile, ...]:
+        """Peak dot-output set after adding accumulator ancestor chains."""
+        return self._kernel_peak_role_tiles("peak_dot_output_tiles")
+
+    def kernel_peak_promoted_lhs(self) -> tuple[LiveTile, ...]:
+        """Peak transformed-LHS set after adding ancestor loop graphs."""
+        return self._kernel_peak_role_tiles("peak_promoted_lhs_tiles")
 
     def group_live_tiles(
         self,
@@ -1559,6 +1684,8 @@ class DeviceIRAnalysis:
                 for block_id in sorted(knob_users)
             ),
             sequential_loop_trips=sequential_loop_trips,
+            live_dot_outputs=tuple(self.kernel_peak_dot_outputs()),
+            live_promoted_lhs=tuple(self.kernel_peak_promoted_lhs()),
             live_tile_steps=tuple(self.kernel_live_tile_steps()),
             pipelined_regions=tuple(pipelined_regions),
             resident_regions=tuple(resident_regions),

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -272,6 +272,9 @@ class LiveTile(NamedTuple):
     - ``stageable`` — for a loop-body load, whether its index is proven to
       vary with the enclosing loop. ``None`` means uncertain and is charged
       conservatively as stageable.
+    - ``promoted_lhs`` — this live value is the non-load LHS operand of a dot
+      and may require Triton's power-of-two TMEM promotion scratch. This is
+      independent of ``kind`` because a prior ``dot_out`` can also be an LHS.
     """
 
     dim_block_ids: tuple[int | None, ...]
@@ -279,6 +282,7 @@ class LiveTile(NamedTuple):
     itemsize: int
     kind: str
     stageable: bool | None = None
+    promoted_lhs: bool = False
 
 
 class SymbolicLoopBound(NamedTuple):
@@ -445,6 +449,11 @@ class KernelMatmulFact(NamedTuple):
       sequential (non-grid) loops. For a chunked recurrence this is the number of
       chunks, so ``sequential_loop_trips * fixed_k`` recovers the logical contraction
       length even though each dot only sees one chunk.
+    - ``live_dot_outputs`` — the live set at the step holding the most simultaneously
+      live dot-output tiles, including ancestor loop graphs.
+    - ``live_promoted_lhs`` — the peak transformed-LHS set after adding ancestor
+      loop graphs. Direct loads are excluded; values retain their original
+      ``kind`` so a dot output reused as another dot's LHS is counted in both roles.
     - ``live_tile_steps`` — the live tile set at EVERY step of the kernel's graphs, deduped.
       A register estimate resolves each step under the candidate block sizes and selects
       the peak by bytes.
@@ -464,6 +473,8 @@ class KernelMatmulFact(NamedTuple):
     matmuls: tuple[ResolvedMatmulFact, ...]
     knob_users: tuple[tuple[int, tuple[tuple[int, str], ...]], ...]
     sequential_loop_trips: int
+    live_dot_outputs: tuple[LiveTile, ...]
+    live_promoted_lhs: tuple[LiveTile, ...]
     live_tile_steps: tuple[tuple[LiveTile, ...], ...]
     pipelined_regions: tuple[PipelinedRegion, ...]
     resident_regions: tuple[ResidentRegion, ...]

--- a/test/test_matmul_heuristics.py
+++ b/test/test_matmul_heuristics.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from itertools import starmap
 from types import SimpleNamespace
 from typing import Any
+from typing import cast
 from unittest.mock import patch
 
 import sympy
 import torch
 
 import helion
+from helion._compiler.autotuner_heuristics.triton import MatmulSeedDraft
 from helion._compiler.autotuner_heuristics.triton import (
     TritonB200FormulaMatmulHeuristic,
 )
@@ -278,6 +280,9 @@ class _BlockSizesStub(list):
     def valid_block_ids(self) -> list[int]:
         return list(self._ids)
 
+    def block_id_to_index(self, block_id: int) -> int:
+        return self._ids.index(block_id)
+
 
 def _block_sizes_stub(block_ids: list[int]) -> _BlockSizesStub:
     return _BlockSizesStub(block_ids)
@@ -316,7 +321,7 @@ def _generalized_spec(
         resident_regions=(),
         attribution_complete=True,
     )
-    return SimpleNamespace(
+    spec = SimpleNamespace(
         matmul_facts=[fact],
         kernel_matmul_fact=mm,
         kernel_grid_fact=None,
@@ -326,6 +331,8 @@ def _generalized_spec(
             block_sizes=[1] * len(valid_block_ids)
         ),
     )
+    spec.autotune_reference_config = lambda: spec._base_default_config()
+    return spec
 
 
 def test_generalized_gate_admits_a_fixed_contraction_axis() -> None:
@@ -429,27 +436,27 @@ def test_tmem_is_counted_in_columns_and_sums_over_live_accumulators() -> None:
     costs ``ceil(bm/128) * bn`` COLUMNS and a bm<128 accumulator costs the same as a
     full-lane one. Measured on B200: a kernel's ``tmem_size`` equals its accumulator's N
     extent exactly ([64,64] -> 64, [128,128] -> 128, [128,256] -> 256)."""
-    assert _FML._tmem_columns([(64, 64, 2)]) == 64
-    assert _FML._tmem_columns([(128, 128, 2)]) == 128
-    assert _FML._tmem_columns([(128, 256, 2)]) == 256
+    assert _FML._tmem_columns([(64, 64)]) == 64
+    assert _FML._tmem_columns([(128, 128)]) == 128
+    assert _FML._tmem_columns([(128, 256)]) == 256
     # A byte model divides by the lanes a narrow accumulator does not use; the column model
     # does not, which is the whole point.
-    assert _FML._tmem_columns([(64, 256, 2)]) == 256
+    assert _FML._tmem_columns([(64, 256)]) == 256
     # bm past a lane group needs a second one.
-    assert _FML._tmem_columns([(256, 256, 2)]) == 512
+    assert _FML._tmem_columns([(256, 256)]) == 512
     # Live accumulators ADD -- this is the measured failure
     # (``tensor memory, Required: 768, limit 512``) reproduced as arithmetic.
-    assert _FML._tmem_columns([(128, 256, 2)] * 3) == 768
-    assert _FML._tmem_columns([(128, 256, 2)] * 3) > _FML.TMEM_COLUMN_BUDGET
+    assert _FML._tmem_columns([(128, 256)] * 3) == 768
+    assert _FML._tmem_columns([(128, 256)] * 3) > _FML.TMEM_COLUMN_BUDGET
     # ...and one accumulator under the incumbent caps never binds, so the single-GEMM path
     # is unaffected by adding this check.
-    assert _FML._tmem_columns([(128, _FML.BASE_BN_CAP, 2)]) <= _FML.TMEM_COLUMN_BUDGET
+    assert _FML._tmem_columns([(128, _FML.BASE_BN_CAP)]) <= _FML.TMEM_COLUMN_BUDGET
     # Below the tcgen05 minimum the dot uses no tensor memory at all (measured
     # ``tmem_size == 0``), so charging it would reject a tiny tile for a resource it never
     # touches.
-    assert _FML._tmem_columns([(32, 256, 2)]) == 0
+    assert _FML._tmem_columns([(32, 256)]) == 0
     # sm90 has no tensor memory: the check must be completely inert there.
-    assert TritonH100MatmulHeuristic._tmem_columns([(128, 256, 2)] * 8) == 0
+    assert TritonH100MatmulHeuristic._tmem_columns([(128, 256)] * 8) == 0
 
 
 def test_tmem_hard_budget_includes_all_lhs_promotion_scratch() -> None:
@@ -467,9 +474,104 @@ def test_tmem_hard_budget_includes_all_lhs_promotion_scratch() -> None:
         (64, 128, 128, 2),
         (128, 128, 64, 2),
     ]
-    assert _FML._tmem_columns(tiles) == 512
-    assert _FML._tmem_columns(tiles, include_lhs_scratch=True) == 736
-    assert _FML._tmem_columns(tiles, include_lhs_scratch=True) > _FML.TMEM_COLUMN_BUDGET
+    accumulators = [(bm, bn) for bm, bn, _bk, _itemsize in tiles]
+    lhs_scratch = [(bm, bk, itemsize) for bm, _bn, bk, itemsize in tiles]
+    assert _FML._tmem_columns(accumulators) == 512
+    assert _FML._tmem_columns(accumulators, lhs_scratch_tiles=lhs_scratch) == 736
+    assert (
+        _FML._tmem_columns(accumulators, lhs_scratch_tiles=lhs_scratch)
+        > _FML.TMEM_COLUMN_BUDGET
+    )
+
+
+def test_optimistic_tmem_uses_peak_live_accumulators_and_transformed_lhs() -> None:
+    env, mm = _knob_spec(
+        knob_users=(
+            (0, ((0, "m"), (1, "m"))),
+            (1, ((0, "n"), (1, "n"))),
+            (2, ((0, "k"), (1, "k"))),
+        ),
+        block_ids=[0, 1, 2],
+        extents={0: 1024, 1: 1024, 2: 1024},
+    )
+    fact = _matmul_fact()
+    mm.matmuls = (
+        SimpleNamespace(fact=fact, axes=_axes()),
+        SimpleNamespace(fact=fact, axes=_axes()),
+    )
+    output = LiveTile((0, 1), (None, None), 4, "dot_out")
+    transformed_lhs = LiveTile(
+        (0, 2),
+        (None, None),
+        2,
+        "other",
+        promoted_lhs=True,
+    )
+    mm.live_tile_steps = ((output,), (output, transformed_lhs))
+    mm.live_dot_outputs = (output,)
+    mm.live_promoted_lhs = (transformed_lhs,)
+    blocks = [128, 128, 64]
+
+    assert (
+        _FML._candidate_tmem_columns(
+            env,
+            blocks,
+            include_lhs_scratch=True,
+            resource_policy="strict",
+        )
+        == 320
+    )
+    assert (
+        _FML._candidate_tmem_columns(
+            env,
+            blocks,
+            include_lhs_scratch=True,
+            resource_policy="optimistic",
+        )
+        == 160
+    )
+
+    mm.live_tile_steps = ((output, transformed_lhs, transformed_lhs),)
+    mm.live_promoted_lhs = (transformed_lhs, transformed_lhs)
+    assert (
+        _FML._candidate_tmem_columns(
+            env,
+            blocks,
+            include_lhs_scratch=True,
+            resource_policy="optimistic",
+        )
+        == 192
+    )
+
+    mm.live_tile_steps = ((output,), (output,))
+    mm.live_promoted_lhs = ()
+    assert (
+        _FML._candidate_tmem_columns(
+            env,
+            blocks,
+            include_lhs_scratch=True,
+            resource_policy="optimistic",
+        )
+        == 128
+    )
+
+    batched_output = LiveTile(
+        (None, 0, 1),
+        (16, None, None),
+        4,
+        "dot_out",
+    )
+    mm.live_tile_steps = ((batched_output,),)
+    mm.live_dot_outputs = (batched_output,)
+    assert (
+        _FML._candidate_tmem_columns(
+            env,
+            blocks,
+            include_lhs_scratch=True,
+            resource_policy="optimistic",
+        )
+        == 0
+    )
 
 
 def test_register_estimate_picks_its_peak_by_resolved_bytes() -> None:
@@ -532,6 +634,8 @@ def test_register_estimate_picks_its_peak_by_resolved_bytes() -> None:
     # ...and a dot below the tcgen05 minimum stays register-resident at any warp count.
     narrow = (tile("dot_out", 32, 64),)
     assert _FML._register_live_bytes(env_with((narrow,)), [], 8) == 32 * 64 * 4
+    batched = (LiveTile((None, None, None), (2, 64, 64), 4, "dot_out"),)
+    assert _FML._register_live_bytes(env_with((batched,)), [], 4) == 2 * 64 * 64 * 4
 
 
 def test_graded_stage_depth_falls_off_with_outer_parallelism() -> None:
@@ -1036,6 +1140,7 @@ def _knob_spec(
         grid_block_ids=grid_block_ids,
         _base_default_config=lambda: helion.Config(block_sizes=[1] * len(block_ids)),
     )
+    spec.autotune_reference_config = lambda: spec._base_default_config()
     env = SimpleNamespace(
         config_spec=spec,
         block_sizes=[
@@ -1288,6 +1393,237 @@ def test_grid_knob_shrinks_only_when_wave_utilization_improves() -> None:
     block_sizes = [128]
     _MULTI._apply_knob_roles(env, env.config_spec.kernel_matmul_fact, block_sizes, 148)
     assert block_sizes == [128]
+
+
+def test_multi_seed_recipes_use_the_shared_bounded_fixups() -> None:
+    env, mm = _knob_spec(
+        knob_users=(
+            (0, ((0, "m"),)),
+            (1, ((0, "n"),)),
+            (2, ((0, "k"),)),
+        ),
+        block_ids=[0, 1, 2],
+        extents={0: 4096, 1: 4096, 2: 4096},
+    )
+    seen_stage_warps: list[int] = []
+    assert _MULTI._seed_axis_ids({0: ("m",), 1: ("n", "k")}) == (
+        (0,),
+        (1,),
+        (1,),
+    )
+
+    def solve_stages(
+        _env: object,
+        _blocks: list[int],
+        *,
+        num_warps: int,
+        **_kwargs: object,
+    ) -> int:
+        seen_stage_warps.append(num_warps)
+        return 3
+
+    with (
+        patch.object(_FML, "_select_num_warps", return_value=8),
+        patch.object(_FML, "_kernel_smem_bytes", return_value=0),
+        patch.object(_FML, "_solve_candidate_stages", side_effect=solve_stages),
+        patch.object(
+            _FML,
+            "_fixup_candidate_resources",
+            side_effect=lambda _env, _blocks, stages, warps, **_kwargs: (
+                stages,
+                warps,
+            ),
+        ),
+    ):
+        drafts = _FML._register_mma_seed_drafts(
+            env,
+            mm,
+            MatmulSeedDraft([128, 256, 64], 8, 4),
+            num_sm=148,
+            axis_ids=((0,), (1,), (2,)),
+        )
+
+    assert [draft.num_warps for draft in drafts] == [1, 2]
+    assert set(seen_stage_warps) == {1, 2}
+
+
+def test_b200_single_matmul_emits_the_compact_seed_families() -> None:
+    fact = _matmul_fact(static_m=4096, static_n=4096, static_k=4096)
+    spec = _generalized_spec(fact, _axes(), valid_block_ids=[0, 1, 2])
+    spec.kernel_matmul_fact.knob_users = (
+        (0, ((0, "m"),)),
+        (1, ((0, "n"),)),
+        (2, ((0, "k"),)),
+    )
+    spec.grid_block_ids = (7,)
+    spec.kernel_grid_fact = SimpleNamespace(
+        group_for_graph=lambda _graph_id: (7,),
+        groups_for_graphs=lambda _graph_ids: ((7,),),
+        grid_groups=((7,),),
+    )
+    spec.l2_groupings = _block_sizes_stub([0, 7])
+    spec._base_default_config = lambda: helion.Config(
+        block_sizes=[16, 16, 16],
+        l2_groupings=[2, 3],
+        num_warps=4,
+        num_stages=1,
+    )
+    env = SimpleNamespace(
+        config_spec=spec,
+        block_sizes=[],
+        device=None,
+        size_hint=int,
+    )
+
+    with patch("helion.runtime.get_num_sm", return_value=148):
+        ranked = _FML._ranked_configs(env, fact)
+
+    assert ranked[0] == helion.Config(
+        block_sizes=[64, 32, 64],
+        l2_groupings=[2, 1],
+        num_warps=4,
+        num_stages=4,
+    )
+    assert (
+        helion.Config(
+            block_sizes=[128, 256, 64],
+            l2_groupings=[2, 1],
+            num_warps=8,
+            num_stages=4,
+        )
+        in ranked
+    )
+    assert len(ranked) == 9
+    assert all(config["l2_groupings"] == [2, 1] for config in ranked[1:])
+    register_mma = [
+        config
+        for config in ranked
+        if config["num_warps"] <= 2 and config["block_sizes"][2] <= 32
+    ]
+    assert len(register_mma) >= 2
+    assert any(
+        config["num_warps"] >= 4
+        and config["block_sizes"][0] >= _FML.TCGEN05_MIN_BM
+        and config["block_sizes"][2] == 32
+        for config in ranked
+    )
+    assert ranked[-1]["num_warps"] >= _FML.TCGEN05_WARPGROUP_WARPS
+    assert ranked[-1]["block_sizes"][0] >= _FML.TCGEN05_MIN_BM
+
+    spec.kernel_matmul_fact.matmuls[0].site.loop_axes = (
+        LoopAxisFact(2, 4096, bounded_by_block_id=0),
+    )
+    capped = _FML._projected_tile_for_dot(
+        env,
+        fact,
+        _axes(),
+        2,
+        148,
+        site=spec.kernel_matmul_fact.matmuls[0].site,
+    )
+    with patch("helion.runtime.get_num_sm", return_value=148):
+        split_k_ranked = _FML._ranked_configs(env, fact)
+    assert capped[:2] == (
+        _FML.SAT_PARTITIONED_K_BM,
+        _FML.SAT_PARTITIONED_K_BN,
+    )
+    assert ranked[1] in split_k_ranked
+
+
+def test_multi_focal_seeds_default_fill_and_canonical_dedupe() -> None:
+    fact = _matmul_fact()
+    mm = SimpleNamespace(
+        matmuls=tuple(
+            SimpleNamespace(fact=fact, site=SimpleNamespace(graph_id=index % 2))
+            for index in range(15)
+        ),
+        attribution_complete=True,
+    )
+    spec = SimpleNamespace(
+        kernel_matmul_fact=mm,
+        kernel_grid_fact=SimpleNamespace(
+            group_for_graph=lambda graph_id: (0,) if graph_id == 0 else (7,)
+        ),
+        block_sizes=_block_sizes_stub([0, 1, 2, 7]),
+        l2_groupings=_block_sizes_stub([0, 7]),
+        _base_default_config=lambda: helion.Config(
+            block_sizes=[16, 16, 16, 128],
+            l2_groupings=[1, 1],
+            num_warps=4,
+            num_stages=2,
+        ),
+        _flat_fields=lambda: {
+            "block_sizes": None,
+            "l2_groupings": None,
+            "num_warps": None,
+            "num_stages": None,
+        },
+        allowed_pid_types=(),
+    )
+    spec.autotune_reference_config = lambda: spec._base_default_config()
+    current_limit: list[int | None] = [None]
+
+    def normalize(
+        config: helion.Config | dict[str, object],
+        *,
+        _fix_invalid: bool,
+    ) -> None:
+        values = config.config if isinstance(config, helion.Config) else config
+        values.setdefault("l2_groupings", [1, 1])
+        if current_limit[0] is not None:
+            blocks = cast("list[int]", values["block_sizes"])
+            blocks[0] = min(
+                current_limit[0],
+                blocks[0],
+            )
+
+    spec.normalize = normalize
+    spec._shrink_for_numel_constraints = lambda _config: None
+    env = SimpleNamespace(config_spec=spec, block_sizes=[])
+    invalid_primary = helion.Config(block_sizes=[3])
+    alternate = helion.Config(block_sizes=[4])
+    with patch.object(
+        _MULTI,
+        "_canonical_seed_config",
+        side_effect=(None, alternate, alternate),
+    ):
+        assert _MULTI._dedupe_seed_pool(
+            env,
+            (invalid_primary, alternate, alternate),
+        ) == [invalid_primary, alternate]
+    proposals = {
+        index: (
+            16 << (index % 4),
+            16 << (index // 4),
+            16,
+            1,
+            2,
+            1,
+        )
+        for index in range(15)
+    }
+
+    root_configs = _MULTI._focal_seed_configs(
+        env,
+        mm,
+        dict.fromkeys(range(2), (16, 16, 16, 1, 2, 4)),
+    )
+    assert {tuple(config["l2_groupings"]) for config in root_configs} == {
+        (4, 1),
+        (1, 4),
+    }
+
+    for m_limit, expected in ((32, 8), (None, 15)):
+        current_limit[0] = m_limit
+        configs = _MULTI._focal_seed_configs(
+            env,
+            mm,
+            proposals,
+        )
+
+        assert len(configs) == expected
+        assert all(config["block_sizes"][3] == 128 for config in configs)
+        assert all(config["l2_groupings"] == [1, 1] for config in configs)
 
 
 def test_role_correction_runs_once_per_front_end() -> None:


### PR DESCRIPTION
Stacked PRs:
 * __->__#3521
 * #3520


--- --- ---

## Summary

This expands the B200 matmul and multi-matmul compiler seed pools. The goal is
not to prescribe an entire autotuning generation, but to place a compact set of
good, structurally different candidates into the initial population so the
autotuner reaches useful performance sooner.

These seeds are additive to the conservative autotune reference candidate; they
do not replace it.

The implementation uses shared helpers to adjust block sizes, warps, pipeline
stages, and resource limits. Each seed family applies a different combination
of those adjustments without duplicating their implementation.

## Single-Matmul Seeds

The single-matmul path emits up to nine distinct seeds:

1. **Existing primary:** the current default heuristic choice, including its
   normal block-size, warp, pipeline-stage, and resource corrections.
2. **Uncorrected formula choice:** the existing formula's initial choice before
   later whole-kernel adjustments shrink or reshape its blocks and revise its
   warp and stage counts. This retains a more aggressive candidate in case
   those adjustments are too conservative.
3. **High-residency register-MMA choices:** small-block one-warp and two-warp
   configs intended to keep more CTAs resident when a compact MMA schedule is
   preferable to `tcgen05`.
4. **M-heavy and N-heavy choices:** move tile area from N to M, or from M to N,
   to explore the two operand-reuse/aspect-ratio directions around the primary.
5. **K/pipeline tradeoffs:** pair a smaller K block with more pipeline stages,
   and a larger K block with fewer stages.
6. **Small `tcgen05` choice:** reduce the M, N, and K blocks and use fewer
   stages while retaining the `tcgen05` path, covering a higher-residency
   tensor-core regime.

## Multi-Matmul Seeds

A multi-matmul kernel first produces a recommendation for each individual
matmul, then combines those recommendations into one whole-kernel config. The
seed pool explores both parts of that process.

### Different Ways to Combine the Matmuls

1. **Existing combined primary:** the normal whole-kernel heuristic, including
   its block-size, warp, stage, and resource corrections.
2. **Alternative combination order:** a slight adjustment to when the
   individual matmul recommendations are corrected versus combined. These are
   often identical, but can differ when several matmuls compete for the same
   block-size knob.
3. **Individual matmul proposals:** configs centered on each individual
   matmul's recommendation. Other kernel knobs retain their defaults, allowing
   the tuner to start near a good config for one matmul when that operation
   turns out to dominate the kernel.

### Variants of the Combined Config

1. **High-residency register-MMA choices:** small-block one-warp and two-warp
   configs, matching the corresponding single-matmul regime.
2. **Larger-M and larger-N choices:** grow one output-tile direction and apply
   less conservative tensor-memory accounting. These cover cases where the
   primary whole-kernel resource estimate shrinks blocks too aggressively.
3. **Smaller-K/deeper-pipeline choice:** perform less reduction work per stage
   while using more stages to overlap loads.
4. **Large-K choices:** increase reduction blocks up to 512, either with a
   shallow pipeline or with more warps and stages. This covers kernels where
   reducing the number of K-loop trips matters more than preserving small
   blocks.
5. **Small-tile/high-warp choice:** combine compact blocks with more warps and
   stages, rather than assuming small blocks must also use a small launch.
6. **Persistent choice:** use a persistent blocked launch when that mode is
   legal and there is enough grid work for it to be useful.

Duplicate or invalid configs are removed, and the final pool is capped at 20
seeds.

## Resource Modeling

- Candidate-aware loop work is shared by proposal ranking and warp selection.
- Strict primary configs retain conservative whole-kernel resource accounting.
- Exploratory seeds can use an optimistic TMEM policy based on live dot outputs
  and transformed LHS values. A direct load is not charged as promoted-LHS TMEM
  scratch.
- Role correction, stage selection, bounded warp selection, and SMEM/TMEM
  fixups are reusable operations composed by each seed recipe.

## Full-Autotune Results

The main effect is much faster access to reasonably good configs, with
diminishing returns as the target approaches the best latency found by either
run.

| Latency target | No seeds: configs | Expanded seeds: configs | Expanded / no seeds |
| --- | ---: | ---: | ---: |
| Within 50% (`<=1.50x`) | 2,548 | 74 | 0.0290x |
| Within 25% (`<=1.25x`) | 4,919 | 2,082 | 0.4233x |
| Within 12.5% (`<=1.125x`) | 7,362 | 4,257 | 0.5782x |
| Within 5% (`<=1.05x`) | 10,762 | 7,727 | 0.7180x |
| Full run | 19,796 | 16,936 | 0.8555x |

At the broadest target, the expanded pool needed 74 candidates instead of
2,548 across the corpus. The advantage narrows near the optimum, but the
expanded arm still used 28% fewer aggregate candidates to get within 5% and
14.5% fewer benchmarked configs over the full searches.

The final configs had effectively similar performance: in same-GPU replay, the
expanded-seed winners were 1.4% slower by geomean than the no-seed winners
(`1.0142x` latency). The main benefit is therefore reaching good performance
earlier, rather than changing the eventual full-autotune result.

### Methodology

- 38 frozen `(kernel, shape)` cells on NVIDIA B200: 30 multi-matmul and 8
  single-matmul workloads spanning linear attention, attention, GEMM, jagged,
  and SSM kernels.
- Full `LFBOTreeSearch`, random seed 0, initial population 100, and up to 20
  generations, with the same cell selection and physical-GPU assignment.
- The control recorded zero compiler seeds, zero author seeds, and zero
  normalized seeds.
- Each target is computed against the best raw-search latency found by either
  the no-seed or expanded-seed run for that cell. No third arm contributes to
  the target.
- Configs-to-target count terminal candidate attempts, including failed
  attempts. If a run never reached a target, its full attempt count is
  substituted as a right-censored lower bound. `Full run` uses the autotuner's
  benchmarked-config count.
- Measurements were collected on the corresponding pre-rebase implementation
  (`40151a23f` plus the recorded treatment patch); manifests retain the exact
  source fingerprints and search artifacts.

<details>
<summary>38 benchmark cells</summary>

### Single Matmul (8)

- `chunk_bwd_dh_diag_fused#8:B4_T2048_H16_D128`
- `chunk_cumsum_gc_helion#7:B4_T2048_H16_D128`
- `chunk_cumsum_gc_varlen_helion#3:ragged_T8192_H96_D128`
- `chunk_fwd_h_diag_fused#8:B4_T2048_H16_D128`
- `bf16xint16_m1_k4096_n4096`
- `broadcast_matmul_b16_m512_k768_n1024`
- `gather_gemv_b64_s4096_n8`
- `jagged_bmm_b8_l255_d128_k64_bias`

### Multi Matmul (30)

- `chunk_bwd_dk_delta_helion#2:B2_T16384_H16_D128`
- `chunk_bwd_dqk_helion#3:B8_T2048_H32_D256`
- `chunk_bwd_dqkg_scalar_helion#0:B8_T1024_H8_D64`
- `chunk_bwd_dqkw_delta_helion#2:B2_T16384_H16_D128`
- `chunk_bwd_dv_helion#0:B8_T1024_H8_D64`
- `chunk_bwd_gram2_kda_helion#2:B2_T16384_H16_D128`
- `chunk_bwd_o_kda_helion#4:B1_T8192_H96_D128`
- `chunk_bwd_state_dwk_kda_helion#2:B4_T2048_H16_D128`
- `chunk_bwd_wu_kda_helion#3:B8_T2048_H32_D256`
- `chunk_bwd_wy_dL_delta_helion#7:B4_T2048_H16_D128`
- `chunk_fwd_A_diag_anchored_helion#0:B8_T1024_H8_D64`
- `chunk_fwd_A_diag_anchored_varlen_helion#1:ragged_T8192_H64_D128`
- `chunk_fwd_o_diag_anchored_helion#4:B1_T8192_H96_D128`
- `chunk_fwd_o_diag_anchored_varlen_helion#0:uniform_T8192_H64_D128`
- `chunk_fwd_o_helion#2:B2_T16384_H16_D128`
- `attention_backward_b2_h32_s1024_d64_f16`
- `biased_attention_b1_h16_m1024_n2048_d128_bf16`
- `blackwell_attention_backward_b1_h8_s256_d64_f16`
- `blackwell_attention_b4_h32_s2048_d64_bf16`
- `causal_attention_b4_h32_s4096_d128_bf16`
- `attention_b1_h4_m512_n512_d64_f16`
- `flex_dense_b2_h32_s1024_d64_f16`
- `jagged_hstu_b2_l7168_max4096_h16_d64`
- `se_net_m256_n512_k32`
- `gdn_b8_t4096_h80_c256_d64_s128`
- `mamba_scan_b1_h64_g8_t8192_c64_d64_s128`
- `packed_h12_t2048`
- `fixed_h16_t512_float32`
- `ragged_h16_t2048`
- `bf16_regular_h16_b64`

</details>

## Test Plan

- `46 passed` in the focused matmul heuristic test suite on the rebased stack.
- Ruff and `git diff --check` clean.
- CUDA-dependent validation is deferred to PR CI because this host currently
  has no GPU access.
- All 38 no-seed and expanded-seed full-autotune searches completed.
- All 38 same-GPU winner replays passed the autotuner accuracy gate and the
  strict artifact audit.