### PR TITLE
[autotuner] Scale the accuracy-check atol floor by the baseline output RMS

### DIFF
--- a/helion/autotuner/accuracy.py
+++ b/helion/autotuner/accuracy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import torch
 from torch.utils._pytree import tree_flatten
 from torch.utils._pytree import tree_map_only
@@ -17,8 +19,25 @@ def is_fp8_dtype(dtype: torch.dtype) -> bool:
     return dtype in _FP8_DTYPES
 
 
-def assert_close(actual: object, expected: object, atol: float, rtol: float) -> None:
-    """Like torch.testing.assert_close, with fp8 and large tensor handling."""
+def assert_close(
+    actual: object,
+    expected: object,
+    atol: float,
+    rtol: float,
+    *,
+    scale_atol_by_expected_rms: bool = False,
+) -> None:
+    """Like torch.testing.assert_close, with fp8 and large tensor handling.
+
+    With ``scale_atol_by_expected_rms`` (used when the caller did not specify
+    an explicit atol), the absolute-tolerance floor for each tensor leaf is
+    ``atol * max(1, rms(expected))``: a near-zero element of a large reduction
+    legitimately differs across accumulation orders by an amount proportional
+    to the global output scale, not to the element's own magnitude, so a fixed
+    elementwise atol falsely rejects every config that restructures the
+    reduction (e.g. all split_k > 1 matmul configs). The scaling never
+    tightens the check.
+    """
 
     def convert(t: torch.Tensor) -> torch.Tensor:
         return t.view(torch.uint8) if t.dtype in _FP8_DTYPES else t
@@ -44,7 +63,13 @@ def assert_close(actual: object, expected: object, atol: float, rtol: float) -> 
                     "Output leaf type mismatch during autotuner accuracy check: "
                     f"actual is Tensor, expected is {type(expected_leaf).__name__}"
                 )
-            _chunked_assert_close(actual_leaf, expected_leaf, atol=atol, rtol=rtol)
+            _chunked_assert_close(
+                actual_leaf,
+                expected_leaf,
+                atol=atol,
+                rtol=rtol,
+                scale_atol_by_expected_rms=scale_atol_by_expected_rms,
+            )
         elif isinstance(actual_leaf, str):
             if not isinstance(expected_leaf, str):
                 raise AssertionError(f"Type mismatch {actual_leaf} vs {expected_leaf}")
@@ -60,12 +85,39 @@ def _assert_close(actual: object, expected: object, atol: float, rtol: float) ->
     assert_close(actual, expected, atol=atol, rtol=rtol)
 
 
+_RMS_CACHE_ATTR = "_helion_accuracy_rms"
+
+
+def _chunked_rms(t: torch.Tensor, chunk_size: int) -> float:
+    # The autotuner compares hundreds of candidates against one fixed
+    # baseline per run; memoize the RMS on the tensor (keyed by its mutation
+    # version) instead of re-reading the whole output for every candidate.
+    cached = getattr(t, _RMS_CACHE_ATTR, None)
+    if cached is not None and cached[0] == t._version:
+        return cached[1]
+    flat = t.reshape(-1)
+    if flat.numel() == 0:
+        return 0.0
+    # Accumulate in float64 so large-magnitude outputs cannot overflow the
+    # sum of squares. MPS has no float64; use float32 there — an overflow to
+    # inf makes the RMS non-finite, and the caller then keeps the unscaled
+    # atol floor.
+    acc_dtype = torch.float32 if t.device.type == "mps" else torch.float64
+    total = 0.0
+    for start in range(0, flat.numel(), chunk_size):
+        total += float(flat[start : start + chunk_size].to(acc_dtype).square().sum())
+    rms = math.sqrt(total / flat.numel())
+    setattr(t, _RMS_CACHE_ATTR, (t._version, rms))
+    return rms
+
+
 def _chunked_assert_close(
     actual: torch.Tensor,
     expected: torch.Tensor,
     atol: float,
     rtol: float,
     chunk_size: int = 2**22,
+    scale_atol_by_expected_rms: bool = False,
 ) -> None:
     """Memory-efficient assert_close for large tensors."""
     if actual.shape != expected.shape:
@@ -73,6 +125,12 @@ def _chunked_assert_close(
             f"Tensor shape mismatch during autotuner accuracy check: "
             f"{tuple(actual.shape)} != {tuple(expected.shape)}"
         )
+    if scale_atol_by_expected_rms and expected.dtype.is_floating_point:
+        rms = _chunked_rms(expected, chunk_size)
+        # A non-finite RMS (inf in the baseline output) must not disable the
+        # gate; keep the unscaled floor in that case.
+        if math.isfinite(rms):
+            atol = atol * max(1.0, rms)
     if actual.numel() <= chunk_size:
         torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
         return

--- a/helion/autotuner/benchmark_job.py
+++ b/helion/autotuner/benchmark_job.py
@@ -76,6 +76,7 @@ class AccuracyCheckJob:
     baseline_path: str
     atol: float
     rtol: float
+    scale_atol: bool = False
 
     def __call__(self) -> AccuracyCheckResult:
         # Keep compile/launch diagnostics out of the autotune progress stream.
@@ -90,7 +91,13 @@ class AccuracyCheckJob:
                 _unload_compiled_fn(fn)
 
         try:
-            assert_close(output, baseline_output, atol=self.atol, rtol=self.rtol)
+            assert_close(
+                output,
+                baseline_output,
+                atol=self.atol,
+                rtol=self.rtol,
+                scale_atol_by_expected_rms=self.scale_atol,
+            )
         except AssertionError as e:
             return AccuracyCheckResult(ok=False, message=str(e))
         return AccuracyCheckResult(ok=True)

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -579,6 +579,9 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._effective_atol, self._effective_rtol = (
             self._compute_effective_tolerances()
         )
+        # Scale the atol floor per tensor only when the user did not pin an
+        # explicit absolute tolerance (see accuracy.assert_close).
+        self._scale_atol = self.settings.autotune_baseline_atol is None
         self._jobs = self._decide_num_jobs()
 
     def _record_accuracy_failure(self, config: Config) -> None:
@@ -1028,6 +1031,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     self._baseline_output,
                     atol=self._effective_atol,
                     rtol=self._effective_rtol,
+                    scale_atol_by_expected_rms=self._scale_atol,
                 )
                 if os.getenv("CHECK_INPUT_ACCURACY", "1") == "1":
                     if len(self.mutated_arg_indices) > 0:
@@ -1040,6 +1044,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                             self._baseline_post_args,
                             atol=self._effective_atol,
                             rtol=self._effective_rtol,
+                            scale_atol_by_expected_rms=self._scale_atol,
                         )
         except AssertionError as e:
             if not self.settings.autotune_ignore_errors:
@@ -1884,6 +1889,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             baseline_path=self._precompile_baseline_path,
             atol=self._effective_atol,
             rtol=self._effective_rtol,
+            scale_atol=self._scale_atol,
         )
         return cast(
             "AccuracyCheckResult",

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -783,13 +783,17 @@ class Settings(_Settings):
         ),
         "autotune_baseline_atol": (
             "Absolute tolerance for baseline output comparison during autotuning accuracy checks. "
-            "Defaults to 1e-2, or 0.0 for fp8 dtypes (automatic bitwise comparison). "
+            "When unset, defaults to 1e-2 scaled per output tensor by max(1, rms(baseline)) "
+            "so large-magnitude reductions tolerate accumulation-order noise, or 0.0 for fp8 "
+            "dtypes (automatic bitwise comparison). Setting an explicit value disables the "
+            "RMS scaling and is applied exactly. "
             "Pass as @helion.kernel(..., autotune_baseline_atol=1e-3)."
         ),
         "autotune_baseline_rtol": (
             "Relative tolerance for baseline output comparison during autotuning accuracy checks. "
             "Defaults to 1e-2, or 0.0 for fp8 dtypes (automatic bitwise comparison). "
-            "Pass as @helion.kernel(..., autotune_baseline_rtol=1e-3)."
+            "Pass as @helion.kernel(..., autotune_baseline_rtol=1e-3). "
+            "See autotune_baseline_atol for how the absolute-tolerance floor scales when unset."
         ),
         "autotune_baseline_accuracy_check_fn": (
             "Custom accuracy check function for comparing autotuning candidate outputs against the baseline. "

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -329,6 +329,65 @@ class TestMismatchTolerance(TestCase):
                 max_mismatched_abs_diff=5.0,
             )
 
+    def test_accuracy_scaled_atol_tolerates_reduction_noise(self) -> None:
+        from helion.autotuner.accuracy import assert_close
+
+        # A large-K reduction output: elements have scale ~200, and near-zero
+        # elements legitimately differ across accumulation orders by amounts
+        # far above a fixed elementwise atol.
+        torch.manual_seed(0)
+        expected = torch.randn(64, 64, device=DEVICE) * 200.0
+        expected[0, 0] = 0.05  # near-zero element from cancellation
+        actual = expected.clone()
+        actual[0, 0] = -0.05  # reorder-scale wobble on the near-zero element
+
+        # The fixed elementwise default rejects the wobble...
+        with self.assertRaises(AssertionError):
+            assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+        # ...the scaled floor (atol * max(1, rms(expected))) accepts it...
+        assert_close(
+            actual, expected, atol=1e-2, rtol=1e-2, scale_atol_by_expected_rms=True
+        )
+        # ...but a genuinely wrong element at the output's own scale still fails.
+        actual[1, 1] = expected[1, 1] + 100.0
+        with self.assertRaises(AssertionError):
+            assert_close(
+                actual, expected, atol=1e-2, rtol=1e-2, scale_atol_by_expected_rms=True
+            )
+
+    def test_accuracy_scaled_atol_survives_inf_in_baseline(self) -> None:
+        from helion.autotuner.accuracy import assert_close
+
+        # An inf element in the baseline (log-space outputs, masked rows) must
+        # not blow the RMS up to inf and disable the gate for the rest of the
+        # tensor.
+        expected = torch.randn(64, device=DEVICE)
+        expected[0] = float("-inf")
+        actual = expected.clone()
+        actual[1] = expected[1] + 1e6
+        with self.assertRaises(AssertionError):
+            assert_close(
+                actual, expected, atol=1e-2, rtol=1e-2, scale_atol_by_expected_rms=True
+            )
+
+    def test_accuracy_scaled_atol_no_op_for_small_scale_outputs(self) -> None:
+        from helion.autotuner.accuracy import assert_close
+
+        # Outputs with rms <= 1 (e.g. probabilities) keep the exact tolerance:
+        # max(1, rms) == 1, so scaling never loosens well-scaled checks.
+        expected = torch.full((32,), 0.5, device=DEVICE)
+        actual = expected.clone()
+        actual[0] += 0.05
+        for scale in (False, True):
+            with self.assertRaises(AssertionError):
+                assert_close(
+                    actual,
+                    expected,
+                    atol=1e-2,
+                    rtol=1e-2,
+                    scale_atol_by_expected_rms=scale,
+                )
+
 
 @onlyBackends(["triton"])
 class TestAutotuneIgnoreErrors(TestCase):

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -752,6 +752,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         provider._precompile_baseline_path = "/tmp/baseline.pt"
         provider._effective_atol = 0.0
         provider._effective_rtol = 0.0
+        provider._scale_atol = True
         provider._benchmark_worker = Mock()
         provider._benchmark_worker.run.return_value = object()
         provider._subprocess_accuracy_check_enabled = lambda: True


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3522


--- --- ---

[autotuner] Scale the accuracy-check atol floor by the baseline output RMS

The autotuner validates every candidate against the kernel's own
default-config output with torch.testing-style elementwise tolerances
(atol=rtol=1e-2 by default). A near-zero element of a large reduction
legitimately differs across accumulation orders by an amount proportional
to the *global* output scale, not to the element's own magnitude, so the
fixed elementwise atol falsely rejects every config that restructures the
reduction. On matmul_split_k (K=32768, fp16) ~85% of candidates - including
all split_k > 1 configs - failed the check at the same ~30 of 4096 near-zero
elements, while being no farther from the fp64 ground truth than the
baseline config itself; the search has been structurally confined to
split_k=1 on that kernel in every campaign to date.

When the user has not pinned an explicit autotune_baseline_atol, scale each
tensor leaf's absolute-tolerance floor to atol * max(1, rms(expected)):
never tighter than before, correctly looser for large-magnitude
accumulations, and still rejecting corruption at the output's own scale
(the rtol term is unchanged). User-specified tolerances remain exact and
disable the scaling. The flag is plumbed through both the in-process check
and the isolated AccuracyCheckJob. The RMS accumulates in float64 (no
overflow), is left unapplied when non-finite (an inf in the baseline must
not disable the gate), and is memoized on the baseline tensor since one
baseline is compared against hundreds of candidates per run.

Head-to-head validation (8 seeds x 14 kernel cases, B200): splitk-32768
selected-config quality improves from 2.58x of best-known to 1.33x; the
search now reaches split_k=8/32 configs ~43% faster than the best
split_k=1 config it was previously confined to. No other case in the suite
had accuracy-gated candidates; behavior there is unchanged.