### PR TITLE
[autotuner] Time the final-verification shortlist with the paired interleaved bench

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -1273,6 +1273,9 @@ class PopulationBasedSearch(BaseSearch):
     def _final_rebenchmark_cache_policy(self) -> dict[str, object]:
         return {
             "enabled": True,
+            # 2: the non-isolated finalist shootout uses paired interleaved
+            # timing instead of sequential steady windows.
+            "timing_version": 2,
             "top_k": self._final_rebenchmark_top_k(),
             "target_ms": self._final_rebenchmark_target_ms(),
             "isolated": self._final_rebenchmark_use_isolated(),
@@ -2010,11 +2013,13 @@ class PopulationBasedSearch(BaseSearch):
             return min(live_finalists, key=performance, default=fallback)
 
         before = min(finalists, key=performance)
-        # Finalists have already survived the normal benchmark path. Measure the
-        # last shortlist with steady per-candidate timing by default so the
-        # selected config matches standalone benchmark replay. If a user
-        # explicitly opts back into isolated finalist timing, keep suspicious
-        # confirmation enabled for the in-process fallback.
+        # Finalists have already survived the normal benchmark path. Time the
+        # last shortlist with the paired event-based interleaved bench so
+        # clock/thermal drift between per-candidate timing windows cannot
+        # mis-rank near-tied finalists (unpaired sequential steady windows
+        # measured 1-3% apart on identical configs). If a user explicitly
+        # opts into isolated finalist timing, keep suspicious confirmation
+        # enabled for the in-process fallback.
         use_isolated = self._final_rebenchmark_use_isolated()
         self.rebenchmark(
             finalists,
@@ -2022,7 +2027,7 @@ class PopulationBasedSearch(BaseSearch):
             target_ms=self._final_rebenchmark_target_ms(),
             use_isolated=use_isolated,
             confirm_suspicious=use_isolated,
-            use_interleaved=False,
+            use_interleaved=not use_isolated,
         )
         live_finalists = [member for member in finalists if math.isfinite(member.perf)]
         if not live_finalists:
@@ -2175,7 +2180,14 @@ class PopulationBasedSearch(BaseSearch):
                         if _backend is not None
                         else None
                     ) or interleaved_bench
-                    benchmark_function = interleaved_benchmark
+                    # ``repeat`` is sized from candidate kernel time alone; for
+                    # microsecond kernels the fixed per-call overhead dominates
+                    # and the capped repeat count can take minutes of wall
+                    # clock. Keep the whole pass near the sequential-window
+                    # budget it replaced (target_ms per candidate).
+                    benchmark_function = functools.partial(
+                        interleaved_benchmark, max_total_ms=target_ms * len(members)
+                    )
                 if self.settings.autotune_progress_bar:
                     new_timings = benchmark_function(iterator, repeat=repeat, desc=desc)
                 else:

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -8,6 +8,7 @@ import logging
 import math
 import os
 import statistics
+import sys
 import tempfile
 import time
 from typing import TYPE_CHECKING
@@ -234,12 +235,37 @@ def compute_repeat_generic(
     return max(min_repeat, min(max_repeat, max(1, repeat)))
 
 
+def _interleaved_repeat_cap(
+    fns: list[Callable[[], object]],
+    clear_cache: Callable[[], None],
+    max_total_ms: float,
+) -> int:
+    """Bound interleaved repeats by the measured cost of one full sweep.
+
+    Repeat counts are sized from candidate kernel time alone, but for
+    microsecond kernels the fixed per-call cost (L2 flush, launch and wrapper
+    overhead) dominates, so an unbounded repeat can take minutes of wall clock
+    on slow hosts. One timed sweep captures the true per-iteration cost.
+    """
+    synchronize_device()
+    start = time.perf_counter()
+    for fn in fns:
+        clear_cache()
+        fn()
+    synchronize_device()
+    sweep_ms = (time.perf_counter() - start) * 1000
+    if not math.isfinite(sweep_ms) or sweep_ms <= 0:
+        return sys.maxsize
+    return max(3, int(max_total_ms / sweep_ms))
+
+
 def interleaved_bench(
     fns: list[Callable[[], object]],
     *,
     repeat: int,
     desc: str | None = None,
     default_cudagraph: bool = False,
+    max_total_ms: float | None = None,
 ) -> list[float]:
     """
     Benchmark multiple functions at once, interleaving their executions to reduce
@@ -250,6 +276,8 @@ def interleaved_bench(
         fns: List of functions to benchmark
         repeat: Number of times to repeat each benchmark
         desc: Optional description for progress bar
+        max_total_ms: Optional wall-clock budget for the whole timed loop;
+            ``repeat`` is lowered so one measured sweep times ``repeat`` fits
     """
     from triton import runtime
 
@@ -262,6 +290,8 @@ def interleaved_bench(
     )
     clear_cache()
     di = runtime.driver.active.get_device_interface()  # type: ignore[attr-defined]
+    if max_total_ms is not None:
+        repeat = min(repeat, _interleaved_repeat_cap(fns, clear_cache, max_total_ms))
     start_events = [
         [di.Event(enable_timing=True) for _ in range(repeat)] for _ in range(len(fns))
     ]
@@ -307,6 +337,7 @@ def interleaved_bench_generic(
     repeat: int,
     desc: str | None = None,
     default_cudagraph: bool = False,  # accepted for API symmetry; wall-clock timing doesn't use CG
+    max_total_ms: float | None = None,
 ) -> list[float]:
     """
     Benchmark multiple functions using wall-clock timing.
@@ -319,6 +350,8 @@ def interleaved_bench_generic(
     synchronize_device()
 
     clear_l2 = _make_l2_cache_clearer()
+    if max_total_ms is not None:
+        repeat = min(repeat, _interleaved_repeat_cap(fns, clear_l2, max_total_ms))
     all_times: list[list[float]] = [[] for _ in range(len(fns))]
 
     iterator = iter_with_progress(

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -9880,6 +9880,50 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             ],
         )
 
+    def test_rebenchmark_bounds_interleaved_wall_clock(self) -> None:
+        settings = Settings(
+            autotune_log_level=logging.CRITICAL,
+            autotune_suspicious_rebenchmark_ratio=0,
+        )
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.settings = settings
+        search.args = ()
+        search.log = AutotuningLogger(settings)
+        search.best_perf_so_far = 100.0
+        search.benchmark_provider = SimpleNamespace(mutated_arg_indices=[])
+        search.kernel = SimpleNamespace(env=SimpleNamespace(process_group_name=None))
+        bench_calls: list[dict[str, object]] = []
+
+        def fake_interleaved_bench(
+            fns: list[Callable[[], object]],
+            *,
+            repeat: int,
+            desc: str | None = None,
+            max_total_ms: float | None = None,
+        ) -> list[float]:
+            bench_calls.append({"repeat": repeat, "max_total_ms": max_total_ms})
+            return [100.0] * len(fns)
+
+        search.config_spec = SimpleNamespace(
+            backend=SimpleNamespace(
+                get_interleaved_bench=lambda: fake_interleaved_bench
+            )
+        )
+        member_a = PopulationMember(lambda: None, [100.0], [], helion.Config())
+        member_b = PopulationMember(lambda: None, [101.0], [], helion.Config())
+        search.rebenchmark(
+            [member_a, member_b],
+            target_ms=5000.0,
+            use_isolated=False,
+            confirm_suspicious=False,
+            use_interleaved=True,
+        )
+
+        self.assertEqual(len(bench_calls), 1)
+        # The wall-clock budget preserves the sequential-window budget the
+        # interleaved shootout replaced: target_ms per candidate.
+        self.assertEqual(bench_calls[0]["max_total_ms"], 10000.0)
+
     def test_final_rebenchmark_can_restore_earlier_stable_best(self) -> None:
         settings = Settings(
             autotune_log_level=logging.CRITICAL,
@@ -9915,7 +9959,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             self.assertEqual(target_ms, 5000.0)
             self.assertFalse(use_isolated)
             self.assertFalse(confirm_suspicious)
-            self.assertFalse(use_interleaved)
+            self.assertTrue(use_interleaved)
             for member in members:
                 member.perfs.append(10.0 if member is stable else 12.0)
 

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -185,6 +185,57 @@ def test_mirrored_bench_generic_bounds_fast_kernel_trace(monkeypatch) -> None:
     assert trace.medians_ms == pytest.approx([0.001])
 
 
+def test_interleaved_bench_generic_bounds_wall_clock(monkeypatch) -> None:
+    calls = [0, 0]
+    clock = [0.0]
+
+    def make_fn(index: int):
+        def fn() -> None:
+            calls[index] += 1
+            clock[0] += 0.000_01  # 0.01ms per call
+
+        return fn
+
+    monkeypatch.setattr(benchmarking, "_make_l2_cache_clearer", lambda: lambda: None)
+    monkeypatch.setattr(benchmarking, "synchronize_device", lambda: None)
+    monkeypatch.setattr(benchmarking.time, "perf_counter", lambda: clock[0])
+
+    # One sweep over both fns costs 0.02ms, so a 10ms budget caps the
+    # kernel-perf-sized repeat of 20k at 500 sweeps.
+    times = benchmarking.interleaved_bench_generic(
+        [make_fn(0), make_fn(1)],
+        repeat=20_000,
+        max_total_ms=10.0,
+    )
+
+    assert times == pytest.approx([0.01, 0.01])
+    # warmup + calibration sweep + 500 timed sweeps
+    assert calls == [502, 502]
+
+
+def test_interleaved_bench_generic_repeat_cap_keeps_minimum_samples(
+    monkeypatch,
+) -> None:
+    clock = [0.0]
+
+    def fn() -> None:
+        clock[0] += 1.0  # 1s per call dwarfs any budget
+
+    monkeypatch.setattr(benchmarking, "_make_l2_cache_clearer", lambda: lambda: None)
+    monkeypatch.setattr(benchmarking, "synchronize_device", lambda: None)
+    monkeypatch.setattr(benchmarking.time, "perf_counter", lambda: clock[0])
+
+    times = benchmarking.interleaved_bench_generic(
+        [fn],
+        repeat=100,
+        max_total_ms=1.0,
+    )
+
+    # The budget cannot force fewer than 3 samples per candidate.
+    assert times == pytest.approx([1000.0])
+    assert clock[0] == pytest.approx(5.0)
+
+
 class _FakeStream:
     def wait_stream(self, stream):
         self.waited_stream = stream


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3522
 * #3524
 * __->__#3523


--- --- ---

[autotuner] Time the final-verification shortlist with the paired interleaved bench

The end-of-search shootout over the top-k finalists timed each candidate in
its own sequential steady do_bench window (~5s each). Unpaired sequential
windows drift with clocks and thermals: identical configs measured 1-3%
apart across windows on B200, which is the same order as the gaps between
near-tied finalists, so the shootout could pick the wrong winner. Study
diagnosis showed measurable selection regret concentrated on
context-sensitive kernels (crossentropy, splitk, welford).

Use the paired event-based interleaved bench for the finalist shootout
instead (drift affects all candidates equally within a pass), keeping the
explicit HELION_AUTOTUNE_FINAL_REBENCHMARK_ISOLATED opt-in unchanged, and
record the methodology as timing_version in the final-rebenchmark cache
policy. Measured across the study suite this halves mean selection regret
(selected vs own-shortlist-oracle, 1.035 -> 1.014).