### PR TITLE
[autotuner] Add a full-neighborhood polish descent after the LFBO main loop

### DIFF
--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -193,6 +193,7 @@ class LFBOPatternSearch(PatternSearch):
         best_available_pad_random: bool = PATTERN_SEARCH_DEFAULTS.best_available_pad_random,
         num_neighbors_cap: int = -1,
         finishing_rounds: int = 0,
+        polish_rounds: int = 10,
         compile_timeout_lower_bound: float = PATTERN_SEARCH_DEFAULTS.compile_timeout_lower_bound,
         compile_timeout_quantile: float = PATTERN_SEARCH_DEFAULTS.compile_timeout_quantile,
         flash_structural_search: FlashStructuralSearchConfig | None = None,
@@ -228,6 +229,7 @@ class LFBOPatternSearch(PatternSearch):
         self.frac_selected = frac_selected
         self.patience = patience
         self.similarity_penalty = similarity_penalty
+        self.polish_rounds = polish_rounds
         self.surrogate: RandomForestClassifier | None = None
 
         # Save training data
@@ -284,7 +286,10 @@ class LFBOPatternSearch(PatternSearch):
                 # 2: benchmarked-only visited set, per-copy selection floor,
                 # incumbent retention, and rebenchmark-synced surrogate labels
                 # became unconditional.
-                "lfbo_version": 2,
+                # 3: a full-neighborhood polish descent runs after the main
+                # loop (see polish_rounds).
+                "lfbo_version": 3,
+                "polish_rounds": self.polish_rounds,
                 "num_neighbors": self.num_neighbors,
                 "radius": self.radius,
                 "frac_selected": self.frac_selected,
@@ -777,8 +782,49 @@ class LFBOPatternSearch(PatternSearch):
                 # Fit model
                 self._fit_surrogate()
 
+        self._polish_descent(visited)
         # Final verification, finishing phase, and (TPU-only) final-pick re-rank.
         return self._finalize()
+
+    def _polish_descent(self, visited: set[Config]) -> None:
+        """Full-neighborhood descent after the surrogate-guided main loop.
+
+        Run plain pattern-search descent from the incumbent: benchmark the
+        *entire* deterministic radius-1 neighborhood (no surrogate pruning)
+        and move to the best neighbor until a round fails to improve, up to
+        ``polish_rounds`` rounds. Recovers local wins the surrogate's
+        selection fraction skipped, at a bounded extra eval cost.
+        """
+        rounds = self.polish_rounds
+        if rounds <= 0 or self.config_spec.cute_flash_search_enabled:
+            return
+        current = self.best
+        for round_num in self._budgeted_range(1, rounds + 1):
+            candidates = [current]
+            for flat_config in PatternSearch._generate_neighbors(
+                self, current.flat_values
+            ):
+                member = self.make_unbenchmarked(flat_config)
+                if member is not None and member.config not in visited:
+                    visited.add(member.config)
+                    candidates.append(member)
+            if len(candidates) <= 1:
+                self.log(f"Polish round {round_num}: no unvisited neighbors")
+                break
+            self.set_generation(self._autotune_metrics.num_generations + 1)
+            self.benchmark_population(candidates[1:], desc=f"Polish round {round_num}")
+            self.rebenchmark_population(
+                candidates, desc=f"Polish round {round_num}: verifying"
+            )
+            self.population.extend(candidates[1:])
+            best = min(candidates, key=performance)
+            self.log(
+                f"Polish round {round_num}: {len(candidates) - 1} neighbors, "
+                f"best {self.format_performance(best.perf)}"
+            )
+            if self._check_early_stopping(best, current):
+                break
+            current = best
 
     @staticmethod
     def _flash_structural_leaf(
@@ -4949,6 +4995,7 @@ class LFBOTreeSearch(LFBOPatternSearch):
         best_available_pad_random: bool = PATTERN_SEARCH_DEFAULTS.best_available_pad_random,
         num_neighbors_cap: int = -1,
         finishing_rounds: int = 0,
+        polish_rounds: int = 10,
         compile_timeout_lower_bound: float = PATTERN_SEARCH_DEFAULTS.compile_timeout_lower_bound,
         compile_timeout_quantile: float = PATTERN_SEARCH_DEFAULTS.compile_timeout_quantile,
         flash_structural_search: FlashStructuralSearchConfig | None = None,
@@ -4970,6 +5017,7 @@ class LFBOTreeSearch(LFBOPatternSearch):
             best_available_pad_random=best_available_pad_random,
             num_neighbors_cap=num_neighbors_cap,
             finishing_rounds=finishing_rounds,
+            polish_rounds=polish_rounds,
             compile_timeout_lower_bound=compile_timeout_lower_bound,
             compile_timeout_quantile=compile_timeout_quantile,
             flash_structural_search=flash_structural_search,

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -3823,6 +3823,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search.make_unbenchmarked = Mock(return_value=anchor)
@@ -3944,6 +3945,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search.train_source_hashes = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
@@ -4026,6 +4028,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -4112,6 +4115,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -4192,6 +4196,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -4263,6 +4268,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._pruned_pattern_search_from = Mock(
@@ -4341,6 +4347,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         generated: list[PopulationMember] = []
@@ -4917,6 +4924,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search.config_gen = SimpleNamespace(
@@ -5082,6 +5090,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         typed_leaves = []
@@ -5219,6 +5228,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search.config_gen = SimpleNamespace(
@@ -5317,6 +5327,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._budgeted_range = lambda *args: range(*args)
@@ -5390,6 +5401,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search.config_gen = SimpleNamespace(
@@ -5563,6 +5575,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -5702,6 +5715,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -5837,6 +5851,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             search.train_x = []
             search.train_y = []
             search._train_members = []
+            search.polish_rounds = 0
             search.train_configs = []
             search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
             search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -5961,6 +5976,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: (
@@ -6115,6 +6131,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -6263,6 +6280,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             search.train_x = []
             search.train_y = []
             search._train_members = []
+            search.polish_rounds = 0
             search.train_configs = []
             search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
             search._flash_pipeline_lanes = lambda _leaf: ()
@@ -6428,6 +6446,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ()
@@ -6656,6 +6675,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: (
@@ -6778,6 +6798,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._budgeted_range = lambda *args: range(*args)
@@ -6896,6 +6917,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = Mock(
@@ -7189,6 +7211,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -7299,6 +7322,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: ((stage_key, 2),)
@@ -7474,6 +7498,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: (
@@ -7785,6 +7810,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._autotune_metrics = SimpleNamespace(search_phase_metrics=None)
         search._flash_pipeline_lanes = lambda _leaf: (
@@ -7999,6 +8025,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = None
         search.train_source_hashes = None
         search._fit_surrogate = Mock()
@@ -8050,6 +8077,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search.train_source_hashes = []
         search._fit_surrogate = Mock()
@@ -8115,6 +8143,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._fit_surrogate = Mock()
         search.config_spec = _cute_flash_test_config_spec()
@@ -8177,6 +8206,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         search.train_x = []
         search.train_y = []
         search._train_members = []
+        search.polish_rounds = 0
         search.train_configs = []
         search._fit_surrogate = Mock()
         search.config_spec = _cute_flash_test_config_spec()
@@ -12350,6 +12380,7 @@ class TestCuteFlashSearchPolicyCacheKey(unittest.TestCase):
         search.quantile = 0.1
         search.patience = 1
         search.similarity_penalty = 1.0
+        search.polish_rounds = 10
         search.compile_timeout_lower_bound = pattern.compile_timeout_lower_bound
         search.compile_timeout_quantile = pattern.compile_timeout_quantile
         search.flash_structural_search = profile.flash_structural_search
@@ -12457,14 +12488,14 @@ class TestCuteFlashSearchPolicyCacheKey(unittest.TestCase):
         search.config_spec.cute_flash_search_enabled = False
         search._cute_flash_lane_policy_enabled = False
         non_flash = search._algorithm_cache_policy()
-        self.assertEqual(non_flash["lfbo_version"], 2)
+        self.assertEqual(non_flash["lfbo_version"], 3)
         self.assertNotIn("cute_flash_lane_policy_version", non_flash)
         self.assertIsNone(non_flash["flash_structural_search"])
 
         search.config_spec.cute_flash_search_enabled = True
         search._cute_flash_lane_policy_enabled = True
         cute_flash_policy = search._algorithm_cache_policy()
-        self.assertEqual(cute_flash_policy["lfbo_version"], 2)
+        self.assertEqual(cute_flash_policy["lfbo_version"], 3)
         self.assertEqual(cute_flash_policy["cute_flash_lane_policy_version"], 14)
         self.assertEqual(cute_flash_policy["cute_flash_starting_path_limit"], 17)
         self.assertEqual(cute_flash_policy["cute_flash_family_probe_path_limit"], 18)
@@ -12495,7 +12526,7 @@ class TestCuteFlashSearchPolicyCacheKey(unittest.TestCase):
         quick_policy = search._algorithm_cache_policy()
         self.assertNotIn("cute_flash_lane_policy_version", quick_policy)
         self.assertIsNone(quick_policy["flash_structural_search"])
-        self.assertEqual(quick_policy["lfbo_version"], 2)
+        self.assertEqual(quick_policy["lfbo_version"], 3)
 
     def test_unlimited_and_finite_family_retention_have_distinct_cache_keys(
         self,
@@ -15691,6 +15722,91 @@ class TestSelectedSourceMetrics(TestCase):
         self.assertFalse(provider.has_measured_source_hash("failed"))
         self.assertFalse(provider.has_measured_source_hash("nonfinite"))
         self.assertFalse(provider.has_measured_source_hash("missing"))
+
+
+class TestPolishDescent(TestCase):
+    def _make_search(self, polish_rounds: int) -> LFBOTreeSearch:
+        search = object.__new__(LFBOTreeSearch)
+        search.polish_rounds = polish_rounds
+        search.config_spec = SimpleNamespace(cute_flash_search_enabled=False)
+        search.min_improvement_delta = 0.001
+        search.log = Mock()
+        search._budgeted_range = lambda *args: iter(range(*args))
+        search.set_generation = Mock()
+        search._autotune_metrics = SimpleNamespace(num_generations=5)
+        search.format_performance = lambda perf: f"{perf:.4f}"
+        search.rebenchmark_population = Mock()
+        return search
+
+    @staticmethod
+    def _member(perf: float | None, num_warps: int) -> PopulationMember:
+        return PopulationMember(
+            lambda: None,
+            [] if perf is None else [perf],
+            (num_warps,),
+            helion.Config(num_warps=num_warps),
+            status="ok",
+        )
+
+    def test_polish_descends_and_stops_when_no_round_improves(self) -> None:
+        search = self._make_search(polish_rounds=10)
+        start = self._member(10.0, 1)
+        better = self._member(None, 2)
+        visited_member = self._member(None, 3)
+        worse = self._member(None, 4)
+        search.population = [start]
+        visited = {start.config, visited_member.config}
+
+        # Round 1 proposes {better, visited_member}; visited_member must be
+        # skipped. Round 2 (from better) proposes only worse -> stall -> stop.
+        neighbors_by_round = [
+            [better.flat_values, visited_member.flat_values],
+            [worse.flat_values],
+        ]
+        members_by_flat = {
+            better.flat_values: better,
+            visited_member.flat_values: visited_member,
+            worse.flat_values: worse,
+        }
+        perfs = {id(better): 8.0, id(worse): 11.0}
+
+        def fake_benchmark(members, desc="") -> None:
+            for member in members:
+                member.perfs.append(perfs[id(member)])
+
+        search.benchmark_population = fake_benchmark
+        with (
+            patch.object(
+                PatternSearch,
+                "_generate_neighbors",
+                side_effect=lambda self_, base: neighbors_by_round[
+                    0 if base == start.flat_values else 1
+                ],
+            ),
+            patch.object(search, "make_unbenchmarked", side_effect=members_by_flat.get),
+        ):
+            search._polish_descent(visited)
+
+        # Descended to the better neighbor and benchmarked only unvisited ones.
+        self.assertIs(search.best, better)
+        self.assertIn(better, search.population)
+        self.assertIn(worse, search.population)
+        self.assertNotIn(visited_member, search.population)
+        self.assertEqual(len(better.perfs), 1)
+        self.assertEqual(len(visited_member.perfs), 0)
+        # Both proposed configs entered visited.
+        self.assertIn(better.config, visited)
+        self.assertIn(worse.config, visited)
+
+    def test_polish_disabled_or_cute_flash_is_a_no_op(self) -> None:
+        for rounds, cute in ((0, False), (10, True)):
+            search = self._make_search(polish_rounds=rounds)
+            search.config_spec = SimpleNamespace(cute_flash_search_enabled=cute)
+            start = self._member(10.0, 1)
+            search.population = [start]
+            with patch.object(PatternSearch, "_generate_neighbors") as generate:
+                search._polish_descent({start.config})
+            generate.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3522
 * __->__#3524
 * #3523


--- --- ---

[autotuner] Add a full-neighborhood polish descent after the LFBO main loop

LFBO's surrogate-guided proposals benchmark only ~10% of generated
neighbors, so runs routinely stall a couple of local moves short of the
basin PatternSearch reaches by exhaustive descent: in the round-2 baseline,
matmul-wide's best family (block [128-256, 256, 32] + persistent_interleaved)
was found by 3/3 PatternSearch runs and 0/8 LFBO runs, and most runs stop
improving by generation ~3 while searching to 8-17.

After the main loop finishes, run plain pattern-search descent from the
incumbent: benchmark the entire deterministic radius-1 neighborhood
(single-key moves plus block-size pairs, no surrogate pruning) and move to
the best neighbor, repeating until a round fails to improve, up to
polish_rounds (default 10). Most of the neighborhood is usually already
visited, so the marginal cost is bounded (~+30% candidate evals suite-wide,
+11% wall time with parallel compile). CuTe-flash searches keep their own
terminal refinement and are unaffected. lfbo_version bumped to 3.

Head-to-head validation of this change bundled with the two previous
commits (acc+polish+fsel, 8 seeds x 14 cases, B200): mean selected-config
quality 1.194 -> 1.077 of best-known (stable-12 subset 1.072 -> 1.046),
per-case worst-seed mean 1.309 -> 1.192 (stable-12 1.138 -> 1.111),
improving or tying 12 of 14 cases; beats PatternSearch's mean (1.058
stable-12 at 1652 evals) at half the evals. Basin-hopping restarts were
also prototyped and rejected: bundled on top they cost ~12% more evals
without improving the mean (see benchmarks/autotuner_study/NOTES.md).