### PR TITLE
[autotuner] Round-2 study: shortlist diagnosis tooling and report

### DIFF
--- a/benchmarks/autotuner_study/NOTES.md
+++ b/benchmarks/autotuner_study/NOTES.md
@@ -172,3 +172,93 @@ tree. What shipped (see REPORT.md section 8): a flag-free improved default
 population, stagnation stop) were removed after review. The final change
 set is the EnumFragment robustness fixes, uniform-list ListOf neighbors
 (pattern_version 2), and the four LFBO search-loop fixes (lfbo_version 2).
+
+# Round 2 (2026-08-31): robustness — consistently closer to 1.0x
+
+Round 1 shipped as 4 PRs (dev 062bd4a1 = new baseline). Round-2 goal per
+Jason: recompute the baseline at HEAD and make final quality consistently
+closer to 1.0x. All round-2 campaign data lives under
+/tmp/autotuner_study/round2/; prototypes live on branch autotuner-r2.
+
+## Rebaseline
+
+- 154 runs: 8 seeds (201-208) default + 3 seeds PatternSearch per case,
+  14 triton cases, GPUs 1-7 (one case pinned per GPU as before).
+
+## Mechanism findings before the arm campaigns
+
+- Selection vs exploration: joining round-1 winners pools with each run's
+  full evaluated-config set shows runs almost never evaluate-and-reject a
+  config that head-to-head beats their selection — different seeds end in
+  disjoint local optima, so the residual gap is dominated by exploration,
+  not final-pick noise. New tools measure_shortlists.py (times every run's
+  finalist shortlist head-to-head, two A/B passes for a per-case noise
+  floor) and diagnose.py (per-run selected vs shortlist-oracle vs case-best
+  decomposition) make this measurable per run.
+- Metric noise floor: two repeat=200 interleaved passes still disagree by
+  1-2% per config on fast kernels; single-pass regret numbers at repeat=50
+  produced a phantom 3.9% selection regret on rmsnorm whose finalists are
+  actually tied within noise. All regret claims must clear the A/B floor.
+- Timing methodology: the CUDA final shootout (final_rebenchmark_best)
+  times the top-8 shortlist with *unpaired sequential* steady windows;
+  paired interleaved timing and steady timing genuinely disagree on
+  tiering for some kernels (rmsnorm steady shows two tiers 2% apart where
+  interleaved says tied).
+- Early collective stall: most runs stop improving by generation ~3 while
+  searching to 8-17 (confirmatory tail); splitk-32768 collapses at
+  generation 2 with all five copies stalling under patience=1.
+- Accuracy-gate false rejections (the big one): the default accuracy check
+  compares candidates against the kernel's own default-config output with
+  fixed atol=rtol=1e-2. On matmul_split_k (K=32768, fp16) ~85% of
+  candidates — including every split_k>1 config — fail at ~30 of 4096
+  elements, always the same near-zero elements at the same magnitudes:
+  legitimate accumulation-order noise proportional to the global output
+  scale (~N(0,181) here), not element magnitude. fp64 ground-truth check:
+  default config is maxabs 0.24 from truth, split_k=4..32 are 0.4-0.8 —
+  the same numerical class; the gate rejects configs as accurate as its
+  own baseline. The search was structurally confined to split_k=1 in every
+  campaign to date.
+
+## Round-2 prototype arms (env-gated on autotuner-r2)
+
+- HELION_SCALED_ATOL=1 ("acc"): scale the accuracy atol floor by
+  max(1, rms(expected)) per tensor, never tightening. Smoke: splitk search
+  reaches split_k=8 at 0.0215ms vs 0.0380ms baseline-search best (~43%
+  faster), selected config verified against fp64.
+- HELION_AUTOTUNE_POLISH=10 ("polish"): full-neighborhood pattern descent
+  from the incumbent after the main loop (no surrogate pruning), until a
+  round fails to improve. Cheap: most of the neighborhood is already
+  visited (rmsnorm smoke: 26 new evals).
+- HELION_FINAL_INTERLEAVED=1 ("fsel"): paired event-based interleaved
+  timing for the final shortlist shootout instead of unpaired steady
+  windows.
+- HELION_AUTOTUNE_RESTARTS=3 ("hop"): after all copies stall with
+  generation budget left, benchmark 20 radius-2 multi-key kicks of the
+  incumbent and descend from the best kick (basin hopping). Splitk smoke:
+  ran but all kicks failed the (unfixed) accuracy gate — restarts need the
+  acc fix on gate-limited cases.
+- Arm campaign: 5 arms (acc, polish, fsel, hop, all) x 4 seeds x 14 cases,
+  every arm carries the acc fix so non-splitk cases isolate the search
+  changes.
+
+## Round-2 results and ship decision
+
+- Single arms (4 seeds x 14): all four beat baseline on full-14 mean
+  (acc 1.109, polish 1.100, fsel 1.107, hop 1.098 vs baseline 1.194);
+  fsel halves selection regret (1.035 -> 1.014) as predicted by the
+  timing-methodology probe.
+- Bundles (8 seeds x 14): pfa (acc+polish+fsel) 1.077/1.046
+  (full-14/stable-12 means) at 781 evals beats all (=pfa+hop)
+  1.083/1.051 at 888 evals. hop rejected. PatternSearch reference
+  1.228/1.058 at 1538 evals.
+- pfa vs baseline per case (8 seeds): improves or ties 12/14; splitk
+  2.58 -> 1.33, matmul-wide 1.24 -> 1.11, welford 1.14 -> 1.06,
+  crossentropy 1.28 -> 1.19; regressions within noise (attention-4k128
+  +0.7% vs 1.1% floor) or single-seed (softmax one 1.084).
+- Wall time: baseline 295s mean/run, pfa 327s (+11% for +29% evals;
+  parallel compile absorbs most of it), PatternSearch 466s.
+- Ship shape (branch autotuner-r2-ship): scaled atol applies whenever the
+  user didn't pin autotune_baseline_atol (explicit tolerances stay exact),
+  finalist shootout interleaved unless isolated opt-in, polish_rounds=10
+  constructor arg, hop code removed, lfbo_version 3, +2 accuracy unit
+  tests; 343 tests pass.

--- a/benchmarks/autotuner_study/REPORT.md
+++ b/benchmarks/autotuner_study/REPORT.md
@@ -239,3 +239,106 @@ worst-seed 1.065 vs 1.106, evals 621 vs 759. The eval-count-focused knobs
   autotuner test suite passes at every step.
 - Additional campaign roots: `/tmp/autotuner_study/{v2s,cute-base,cute-v2s}`,
   head-to-head sessions `winners3.json` (triton) and `cutewinners.json` (cute).
+
+## 10. Round 2: robustness — consistently closer to 1.0x (2026-08-31/09-01)
+
+Round 1 shipped as four PRs; round 2 rebaselined at that HEAD (062bd4a1) and
+asked where the remaining gap to 1.0x lives. All quality numbers below are
+head-to-head: every run's selected config (plus each run's finalist
+shortlist) re-measured per case in one interleaved batch on the case's
+pinned GPU, two independent passes to establish a per-case noise floor
+(`measure_shortlists.py` + `diagnose.py`). Lower is better; 1.000 = best
+config any run found. Baseline campaign: 8 seeds default + 3 seeds
+PatternSearch x 14 cases; arm campaigns: 4 seeds per single arm, 8 seeds
+per bundle; ~750 autotune runs total in round 2.
+
+### 10.1 Where the round-1 gap lives (baseline diagnosis)
+
+* Exploration, not selection: decomposing each run's gap into selection
+  error (final shootout picked the wrong finalist) vs exploration error
+  (nothing near case-best ever reached the shortlist) shows the gap is
+  dominated by exploration everywhere except the context-sensitive kernels
+  (splitk, crossentropy, welford), where the unpaired steady final shootout
+  also mis-ranks. Different seeds end in disjoint local optima; e.g.
+  matmul-wide's good basin (block [128-256, 256, 32] + persistent_interleaved)
+  was found by 3/3 PatternSearch runs and 0/8 LFBO runs.
+* Early collective stall: most runs stop improving by generation ~3 while
+  searching to 8-17; the worst attention seed (1.371) stalled at
+  generation 5 of 20 with the rest of its budget unused.
+* Accuracy-gate false rejection (the largest single find): the default
+  check compares candidates to the kernel's own default-config output with
+  fixed elementwise atol=rtol=1e-2. Near-zero elements of large reductions
+  legitimately differ across accumulation orders in proportion to the
+  *global* output scale, so on matmul_split_k (K=32768, fp16) ~85% of
+  candidates — including every split_k>1 config — were falsely rejected
+  (all failures at the same ~30/4096 near-zero elements; fp64 ground truth
+  shows the rejected configs are exactly as accurate as the baseline
+  itself). The search was structurally confined to split_k=1 in every
+  campaign ever run on this kernel.
+
+### 10.2 What was tried (single arms, 4 seeds x 14 cases each)
+
+| arm | change | full-14 mean | stable-12 mean | evals |
+|---|---|---|---|---|
+| baseline | round-1 default | 1.194 | 1.072 | 593 |
+| acc | scale accuracy atol floor by max(1, rms(expected)) | 1.109 | 1.059 | 642 |
+| polish | full-neighborhood descent after the main loop stalls | 1.100 | 1.050 | 777 |
+| fsel | paired interleaved timing for the finalist shootout | 1.107 | 1.075 | 621 |
+| hop | basin-hop restarts reinvesting unused generation budget | 1.098 | 1.052 | 771 |
+
+(4-seed single-arm numbers carry ~±0.01-0.02 of seed luck; the bundles
+below are the 8-seed decision data. fsel cannot change the search
+trajectory — it only re-times the final shortlist — and it halves measured
+selection regret, mean 1.035 -> 1.014.)
+
+### 10.3 Bundles (8 seeds x 14 cases each)
+
+| bundle | full-14 mean / worst-seed | stable-12 mean / worst-seed | evals | wall |
+|---|---|---|---|---|
+| baseline | 1.194 / 1.309 | 1.072 / 1.138 | 593 | 295s |
+| pfa = acc+polish+fsel | **1.077 / 1.192** | **1.046 / 1.111** | 781 | 327s |
+| all = pfa+hop | 1.083 / 1.215 | 1.051 / 1.102 | 888 | 379s |
+| PatternSearch (ref) | 1.228 / 1.249 | 1.058 / 1.072 | 1538 | 466s |
+
+pfa improves or ties 12 of 14 cases at 8 seeds (splitk 2.58 -> 1.33,
+matmul-wide 1.24 -> 1.11, welford 1.14 -> 1.06, crossentropy 1.28 -> 1.19,
+matmul-4096 1.055 -> 1.031, layernorm 1.088 -> 1.060); the two regressions
+are within the case noise floor (attention-4k128 +0.7% vs 1.1% floor) or a
+single-seed miss (softmax 1.084 once, mean 1.013). It beats PatternSearch's
+mean at half the evals and 70% of the wall time. hop was evaluated and
+rejected: inside the bundle it costs ~12% more evals without improving the
+mean.
+
+### 10.4 What ships (flag-free, on top of the round-1 stack)
+
+1. Scale-aware accuracy tolerance: when the user has not pinned an explicit
+   `autotune_baseline_atol`, each tensor leaf's absolute-tolerance floor
+   becomes `atol * max(1, rms(expected))` — never tighter than before,
+   correctly looser for large-magnitude accumulations, still rejects
+   corruption at the output's own scale. User-specified tolerances remain
+   exact.
+2. Polish descent (`polish_rounds=10`): after the surrogate-guided main
+   loop stalls, plain pattern-search descent benchmarks the entire
+   deterministic radius-1 neighborhood (no surrogate pruning) and moves to
+   the best neighbor until a round fails to improve.
+3. Paired finalist timing: the final-verification shortlist is timed with
+   the event-based interleaved bench instead of unpaired sequential steady
+   windows (which drifted 1-3% between candidates and mis-ranked near-tied
+   finalists).
+
+lfbo_version bumped to 3. Cute-flash searches are unaffected by polish
+(they run their own terminal refinement) and pick up the scaled tolerance
+and paired finalist timing.
+
+### 10.5 Remaining gaps / future work
+
+* splitk residual variance: even in the unlocked space, seeds split between
+  the split_k=8 family (~0.021ms) and lesser basins (worst 2.05). The
+  initial population never seeds structured split_k variants.
+* attention-2k64 worst seed is still 1.27: early collective stall in a bad
+  basin; hop attacked this but did not pay for itself overall. A smarter
+  restart trigger (only when generations remain AND the incumbent is far
+  from the surrogate's frontier) may do better.
+* crossentropy/gathergemv timing context-sensitivity (up to 60% across
+  process/batch composition) still limits both the search's own signal and
+  any single-number quality claim.

--- a/benchmarks/autotuner_study/diagnose.py
+++ b/benchmarks/autotuner_study/diagnose.py
@@ -1,0 +1,196 @@
+"""Decompose per-run final-quality gaps into selection vs exploration error.
+
+Joins campaign run directories with the head-to-head shortlist measurements
+from measure_shortlists.py. For every run:
+
+  * selected_ratio   = h2h(selected config) / h2h(case best config)
+  * oracle_ratio     = min over the run's finalist shortlist of h2h / case best
+  * selection_regret = selected_ratio / oracle_ratio
+        (>1 means the final shootout picked the wrong finalist under noise)
+  * exploration gap  = oracle_ratio - 1.0
+        (>0 means nothing near the case best ever reached the shortlist)
+  * saw_best         = whether the case-best config was *evaluated at all*
+        during the run (exact config match over the full per-candidate CSV)
+
+Each case must appear in exactly one shortlists file (the per-GPU split
+produced by measure_shortlists.py); duplicate cases across files are not
+merged - the last file wins.
+
+Usage:
+    python benchmarks/autotuner_study/diagnose.py \
+        --roots /tmp/autotuner_study/round2/baseline \
+        --shortlists shortlists_gpu1.json shortlists_gpu2.json ... [--json out.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import json
+from pathlib import Path
+import statistics
+import sys
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def canonical(config: dict[str, Any]) -> str:
+    return json.dumps(config, sort_keys=True, default=str)
+
+
+def load_shortlists(paths: list[Path]) -> dict[str, dict[str, Any]]:
+    """case -> {perf_by_key, best_ms, best_key, refs_by_run}."""
+    cases: dict[str, dict[str, Any]] = {}
+    for path in paths:
+        for case, entries in json.loads(path.read_text()).items():
+            perf_by_key: dict[str, float] = {}
+            refs_by_run: dict[str, list[tuple[str, dict[str, Any]]]] = (
+                collections.defaultdict(list)
+            )
+            spreads: list[float] = []
+            for entry in entries:
+                key = canonical(entry["config"])
+                perf_by_key[key] = entry["perf_ms"]
+                if "perf_ms_a" in entry:
+                    spreads.append(
+                        abs(entry["perf_ms_a"] - entry["perf_ms_b"]) / entry["perf_ms"]
+                    )
+                for run_id, ref in entry["refs"].items():
+                    refs_by_run[run_id].append((key, ref))
+            best_key = min(perf_by_key, key=perf_by_key.get)  # type: ignore[arg-type]
+            spreads.sort()
+            noise_floor = (
+                spreads[min(len(spreads) - 1, int(0.9 * len(spreads)))]
+                if spreads
+                else 0.0
+            )
+            cases[case] = {
+                "perf_by_key": perf_by_key,
+                "best_ms": perf_by_key[best_key],
+                "best_key": best_key,
+                "noise_floor": noise_floor,
+                "refs_by_run": dict(refs_by_run),
+            }
+    return cases
+
+
+def run_evaluated_keys(run_dir: Path) -> set[str]:
+    """Canonical keys of every config that got a terminal ok/fail row."""
+    import helion
+
+    csv_path = run_dir / "autotune.csv"
+    reprs: set[str] = set()
+    with csv_path.open() as f:
+        for row in csv.DictReader(f):
+            if row["status"] != "started":
+                reprs.add(row["config"])
+    keys: set[str] = set()
+    for config_repr in reprs:
+        config = eval(config_repr, {"Config": helion.Config})
+        keys.add(canonical(config.config))
+    return keys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--roots", nargs="+", required=True)
+    parser.add_argument("--shortlists", nargs="+", required=True)
+    parser.add_argument("--json", default=None)
+    args = parser.parse_args()
+
+    cases = load_shortlists([Path(p) for p in args.shortlists])
+
+    rows: list[dict[str, Any]] = []
+    for root in [Path(r) for r in args.roots]:
+        for run_dir in sorted(root.iterdir()):
+            summary_path = run_dir / "summary.json"
+            spec_path = run_dir / "spec.json"
+            if not summary_path.exists():
+                continue
+            summary = json.loads(summary_path.read_text())
+            spec = json.loads(spec_path.read_text()) if spec_path.exists() else {}
+            case = summary["case"]
+            if case not in cases:
+                continue
+            info = cases[case]
+            run_id = f"{root.name}/{run_dir.name}"
+            refs = info["refs_by_run"].get(run_id, [])
+            selected_keys = [k for k, ref in refs if ref.get("selected")]
+            shortlist_keys = [k for k, ref in refs if "rank" in ref]
+            if not selected_keys:
+                continue
+            best_ms = info["best_ms"]
+            selected_ms = info["perf_by_key"][selected_keys[0]]
+            oracle_candidates = [
+                info["perf_by_key"][k] for k in {*selected_keys, *shortlist_keys}
+            ]
+            oracle_ms = min(oracle_candidates)
+            saw_best = info["best_key"] in run_evaluated_keys(run_dir)
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "case": case,
+                    "algorithm": (spec.get("algorithm") or "default")
+                    + (f"-{spec['tag']}" if spec.get("tag") else ""),
+                    "seed": spec.get("seed"),
+                    "selected_ratio": selected_ms / best_ms,
+                    "oracle_ratio": oracle_ms / best_ms,
+                    "selection_regret": selected_ms / oracle_ms,
+                    "noise_floor": info["noise_floor"],
+                    "real_regret": (selected_ms / oracle_ms - 1.0)
+                    > max(0.01, info["noise_floor"]),
+                    "saw_best": saw_best,
+                }
+            )
+
+    by_group: dict[tuple[str, str], list[dict[str, Any]]] = collections.defaultdict(
+        list
+    )
+    for row in rows:
+        by_group[(row["case"], row["algorithm"])].append(row)
+
+    header = (
+        f"{'case':<20}{'algorithm':<24}{'n':>3}{'sel mean':>9}{'sel max':>9}"
+        f"{'orc mean':>9}{'orc max':>9}{'noise':>7}{'regret':>7}{'saw_best':>9}"
+    )
+    print(header)
+    agg: dict[str, list[float]] = collections.defaultdict(list)
+    for (case, algorithm), group in sorted(by_group.items()):
+        sel = [g["selected_ratio"] for g in group]
+        orc = [g["oracle_ratio"] for g in group]
+        regret = sum(g["real_regret"] for g in group)
+        saw = sum(g["saw_best"] for g in group)
+        print(
+            f"{case:<20}{algorithm:<24}{len(group):>3}"
+            f"{statistics.mean(sel):>9.3f}{max(sel):>9.3f}"
+            f"{statistics.mean(orc):>9.3f}{max(orc):>9.3f}"
+            f"{group[0]['noise_floor']:>7.3f}"
+            f"{regret:>7}{saw:>6}/{len(group)}"
+        )
+        agg[algorithm + "|sel"].extend(sel)
+        agg[algorithm + "|orc"].extend(orc)
+        agg[algorithm + "|regret"].extend(g["selection_regret"] for g in group)
+
+    print("\noverall by algorithm:")
+    algorithms = sorted({key.split("|")[0] for key in agg})
+    for algorithm in algorithms:
+        sel = agg[algorithm + "|sel"]
+        orc = agg[algorithm + "|orc"]
+        regret = agg[algorithm + "|regret"]
+        print(
+            f"  {algorithm:<24} n={len(sel):<4} selected mean {statistics.mean(sel):.3f}"
+            f" max {max(sel):.3f} | oracle mean {statistics.mean(orc):.3f}"
+            f" max {max(orc):.3f} | mean regret {statistics.mean(regret):.3f}"
+        )
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(rows, indent=2))
+        print(f"wrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/autotuner_study/measure_shortlists.py
+++ b/benchmarks/autotuner_study/measure_shortlists.py
@@ -1,0 +1,174 @@
+"""Head-to-head measurement of every run's finalist shortlist.
+
+For each run under the given campaign roots, reconstruct the configs the
+final-verification shootout chose between (the top-N configs by best observed
+in-search timing, plus the selected config), dedupe them per kernel case, and
+time all of them together with interleaved_bench on the current GPU. Combined
+with the per-candidate CSVs this lets diagnose.py decompose each run's final
+quality gap into selection error (the shootout picked the wrong finalist) and
+exploration error (no finalist was near the case best).
+
+Run one instance per GPU with a --cases filter matching the campaign's
+case->GPU pinning so timings stay apples-to-apples with the runs.
+
+The reconstruction approximates the runtime shootout: --top defaults to the
+Triton finalist count (8; CuTe uses 32), ranks by best observed in-search
+perf rather than the runtime's deduped finalist-history perf, and does not
+model pinned finalists, so diagnose.py's oracle is an approximation of the
+set the shootout actually timed.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=3 python benchmarks/autotuner_study/measure_shortlists.py \
+        --roots /tmp/autotuner_study/round2/baseline --out shortlists_gpu3.json \
+        [--cases a,b] [--top 10] [--repeat 150]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import functools
+import gc
+import json
+import math
+import operator
+from pathlib import Path
+import sys
+from typing import Any
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def run_shortlist(run_dir: Path, top: int) -> tuple[str, dict[str, Any]] | None:
+    """Return (case, {selected_config, ranked: [(config_repr, best_ms)]})."""
+    summary_path = run_dir / "summary.json"
+    csv_path = run_dir / "autotune.csv"
+    if not summary_path.exists() or not csv_path.exists():
+        return None
+    summary = json.loads(summary_path.read_text())
+    best_by_repr: dict[str, float] = {}
+    with csv_path.open() as f:
+        for row in csv.DictReader(f):
+            if row["status"] != "ok" or not row["perf_ms"]:
+                continue
+            perf = float(row["perf_ms"])
+            if not math.isfinite(perf):
+                continue
+            config_repr = row["config"]
+            if perf < best_by_repr.get(config_repr, math.inf):
+                best_by_repr[config_repr] = perf
+    ranked = sorted(best_by_repr.items(), key=operator.itemgetter(1))[:top]
+    return summary["case"], {
+        "selected_config": summary["selected_config"],
+        "ranked": ranked,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--roots", nargs="+", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--cases", default=None)
+    # Default matches _FINAL_REBENCHMARK_TOP_K_DEFAULT (Triton).
+    parser.add_argument("--top", type=int, default=8)
+    parser.add_argument("--repeat", type=int, default=200)
+    args = parser.parse_args()
+
+    from kernels import KERNEL_CASES  # pyrefly: ignore [missing-import]
+    from kernels import load_kernel  # pyrefly: ignore [missing-import]
+    import torch
+
+    import helion
+    from helion.autotuner.benchmarking import interleaved_bench
+
+    wanted = set(args.cases.split(",")) if args.cases else None
+
+    # case -> canonical config json -> {"config": dict, "refs": {run_id: ref}}
+    pool: dict[str, dict[str, dict[str, Any]]] = {}
+
+    def add_ref(
+        case: str, config: dict[str, Any], run_id: str, ref: dict[str, Any]
+    ) -> None:
+        key = json.dumps(config, sort_keys=True, default=str)
+        entry = pool.setdefault(case, {}).setdefault(
+            key, {"config": config, "refs": {}}
+        )
+        entry["refs"].setdefault(run_id, {}).update(ref)
+
+    for root in [Path(r) for r in args.roots]:
+        for run_dir in sorted(root.iterdir()):
+            if not run_dir.is_dir():
+                continue
+            loaded = run_shortlist(run_dir, args.top)
+            if loaded is None:
+                continue
+            case, data = loaded
+            if wanted is not None and case not in wanted:
+                continue
+            run_id = f"{root.name}/{run_dir.name}"
+            add_ref(case, data["selected_config"], run_id, {"selected": True})
+            for rank, (config_repr, best_ms) in enumerate(data["ranked"]):
+                config = eval(config_repr, {"Config": helion.Config})
+                add_ref(
+                    case,
+                    config.config,
+                    run_id,
+                    {"rank": rank, "observed_ms": best_ms},
+                )
+
+    device = torch.device("cuda")
+    results: dict[str, Any] = {}
+    for case_name, entries in sorted(pool.items()):
+        case = KERNEL_CASES[case_name]
+        kernel = load_kernel(case)
+        kernel_args = case.make_args(device)
+        bound = kernel.bind(kernel_args)  # pyrefly: ignore [missing-attribute]
+        default_config = bound.config_spec.default_config().config
+        add_ref(case_name, default_config, "<default>", {})
+        keys = list(entries.keys())
+        fns: list[Callable[[], object]] = []
+        keep: list[str] = []
+        for key in keys:
+            try:
+                compiled = bound.compile_config(helion.Config(**entries[key]["config"]))
+                fns.append(functools.partial(compiled, *kernel_args))
+                keep.append(key)
+            except Exception as e:  # compile failures are data, not fatal
+                print(f"{case_name}: compile failed ({e}) for {entries[key]['refs']}")
+        for fn in fns:
+            fn()
+        torch.cuda.synchronize()
+        print(f"{case_name}: timing {len(fns)} unique configs")
+        # Two independent interleaved passes: their per-config disagreement is
+        # the measurement noise floor diagnose.py uses to separate real
+        # selection regret from phantom regret on near-tied finalists.
+        timings_a = interleaved_bench(fns, repeat=args.repeat)
+        timings_b = interleaved_bench(fns, repeat=args.repeat)
+        case_result = []
+        for key, perf_a, perf_b in zip(keep, timings_a, timings_b, strict=True):
+            case_result.append(
+                {
+                    "perf_ms": (perf_a + perf_b) / 2,
+                    "perf_ms_a": perf_a,
+                    "perf_ms_b": perf_b,
+                    "config": entries[key]["config"],
+                    "refs": entries[key]["refs"],
+                }
+            )
+        case_result.sort(key=operator.itemgetter("perf_ms"))
+        results[case_name] = case_result
+        best = case_result[0]["perf_ms"] if case_result else float("nan")
+        print(f"{case_name}: best {best:.5f} ms over {len(case_result)} configs")
+        del kernel_args, fns, bound
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    Path(args.out).write_text(json.dumps(results, indent=2, default=str))
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3525
 * #3524
 * #3523
 * #3522
 * #3519
 * #3518
 * #3517
 * #3516


--- --- ---

[autotuner] Round-2 study: shortlist diagnosis tooling and report

measure_shortlists.py reconstructs each study run's finalist shortlist
(top-N configs by best observed in-search timing, plus the selected config)
from the per-candidate CSV, dedupes per kernel case, and times every unique
config head-to-head in two independent interleaved passes, giving each case
a measured noise floor. diagnose.py joins those measurements back to the
runs and decomposes each run's final-quality gap into selection error (the
final shootout picked the wrong finalist, counted only above the noise
floor) and exploration error (nothing near the case best ever reached the
shortlist), plus whether the case-best config was evaluated at all. The
reconstruction approximates the runtime shootout (top-N by best observed
in-search perf; pinned finalists and history-perf ranking not modeled) and
the docstrings say so.

REPORT.md section 10 and NOTES.md document the round-2 campaigns (~750
autotune runs over 14 cases): the rebaseline at the round-1 stack, the
mechanism findings (exploration-dominated gap, early collective stalls,
the accuracy-gate false rejections, and timing-methodology disagreement),
the four prototype arms, the 8-seed bundle validation behind the three
shipped changes, and the rejected basin-hopping restarts.