### PR TITLE
[cutedsl] Enable SM103 causal resident softmax and 2-CTA at head_dim=128

### DIFF
--- a/benchmarks/cute/kernel.py
+++ b/benchmarks/cute/kernel.py
@@ -1,0 +1,142 @@
+"""Standalone reproducer for the head_dim=128 causal CuTe flash attention win.
+
+Runs `examples.attention.causal_attention_output` on the GB300 (sm103) shape the
+PR is measured on, with the exact config the compiler-promoted resident seed
+resolves to, and reports TFLOP/s against torch SDPA.
+
+    python benchmarks/cute/kernel.py
+
+BEST_CONFIG below is the compiler-promoted resident seed for this shape, exactly
+as the harness resolves it from ``config_spec.compiler_seed_configs``. It must be
+passed verbatim: the resident softmax lowering only engages when the config
+matches the promoted seed exactly (``causal_seed_matches``), so changing any
+single field silently drops the kernel to the STANDARD lowering and costs ~11%.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import torch
+
+import helion
+from examples.attention import causal_attention_output
+
+# Shape the PR measures: z=2, h=32, head_dim=128, FP16 causal.
+Z, H, SEQ_LEN, HEAD_DIM = 2, 32, 65536, 128
+
+# Effective config resolved by the promoted resident seed on sm103 for this
+# shape. Captured from the harness JSON of the measured run.
+#
+# Note the resident lowering rewrites several of these internally (see
+# `_flash_resident_softmax_config`): softmax_disc -> False, disc_pipe -> 1,
+# e2e_schedule -> "xu", stat_transport -> "single". The values below are the
+# requested config, which is what `causal_seed_matches` compares against.
+BEST_CONFIG = helion.Config(
+    block_sizes=[1, 128, 128],
+    cute_flash_causal_kv_order="descending",
+    cute_flash_causal_loop_split=True,
+    cute_flash_causal_lpt_swizzle=1,
+    cute_flash_clc_heads_per_batch=0,
+    cute_flash_clc_pdl=False,
+    cute_flash_clc_stages=1,
+    cute_flash_corr_regs=64,
+    cute_flash_corr_tile_size=16,
+    cute_flash_disc_pipe=2,
+    cute_flash_e2e_offset=0,
+    cute_flash_e2e_offset0=0,
+    cute_flash_e2e_schedule="8/2",
+    cute_flash_epi_stg=False,
+    cute_flash_epi_stg_gmem="stage",
+    cute_flash_epi_stg_store="slice",
+    cute_flash_epi_tma=False,
+    cute_flash_epi_tma_setup="shared",
+    cute_flash_exp2_packet="1x1",
+    cute_flash_first_load_order=2,
+    cute_flash_kv_order="ascending",
+    cute_flash_kv_stage=3,
+    cute_flash_masked_e2e_schedule="inherit",
+    cute_flash_mma_interleave=True,
+    cute_flash_other_regs=48,
+    cute_flash_p_store_rep=16,
+    cute_flash_packed_reduce=True,
+    cute_flash_persistent=False,
+    cute_flash_persistent_ctas_per_sm=1,
+    cute_flash_persistent_loop="while",
+    cute_flash_pipeline_family="fa4",
+    cute_flash_precompute_qk_desc=False,
+    cute_flash_q_tile_count=2,
+    cute_flash_recompute_tile_coords=False,
+    cute_flash_rescale_chunk_cols=16,
+    cute_flash_rescale_threshold=8.0,
+    cute_flash_role_chain=False,
+    cute_flash_role_map="fa4",
+    cute_flash_s_load_rep=32,
+    cute_flash_s_stage=2,
+    cute_flash_skip_rescale_stats=False,
+    cute_flash_small_biased=True,
+    cute_flash_softmax_disc=True,
+    cute_flash_softmax_regs=200,
+    cute_flash_softmax_setup="shared",
+    cute_flash_sp_row_sum="fragment",
+    cute_flash_split_p_arrive=True,
+    cute_flash_stat_transport="ring2",
+    cute_flash_wait_hint=0,
+)
+
+
+def causal_flops(z: int, h: int, seq_len: int, head_dim: int) -> float:
+    """QK and PV matmuls only, halved for the causal mask (harness FLOP model)."""
+    return 4.0 * z * h * seq_len * seq_len * head_dim * 0.5
+
+
+def benchmark(fn, *args, warmup_ms: int = 1000, rep_ms: int = 500) -> float:
+    """Median milliseconds via Triton do_bench, matching the harness protocol."""
+    from triton.testing import do_bench
+
+    return do_bench(lambda: fn(*args), warmup=warmup_ms, rep=rep_ms)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seq-len", type=int, default=SEQ_LEN)
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+    shape = (Z, H, args.seq_len, HEAD_DIM)
+    q, k, v = (
+        torch.randn(shape, dtype=torch.float16, device="cuda") for _ in range(3)
+    )
+
+    kernel = helion.kernel(
+        causal_attention_output.fn,
+        config=BEST_CONFIG,
+        static_shapes=True,
+        backend="cute",
+    )
+
+    out = kernel(q, k, v)
+    expected = torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, scale=1.0 / math.sqrt(HEAD_DIM), is_causal=True
+    )
+    torch.testing.assert_close(out, expected, atol=5e-2, rtol=2e-2)
+
+    flops = causal_flops(Z, H, args.seq_len, HEAD_DIM)
+    helion_ms = benchmark(kernel, q, k, v)
+    sdpa_ms = benchmark(
+        lambda a, b, c: torch.nn.functional.scaled_dot_product_attention(
+            a, b, c, scale=1.0 / math.sqrt(HEAD_DIM), is_causal=True
+        ),
+        q,
+        k,
+        v,
+    )
+
+    print(f"shape z={Z} h={H} seq_len={args.seq_len} head_dim={HEAD_DIM} fp16 causal")
+    print(f"helion-cute         {flops / (helion_ms * 1e9):8.1f} TF/s")
+    print(f"torch SDPA          {flops / (sdpa_ms * 1e9):8.1f} TF/s")
+
+
+if __name__ == "__main__":
+    main()

--- a/helion/_compiler/cute/cute_flash.py
+++ b/helion/_compiler/cute/cute_flash.py
@@ -2559,7 +2559,10 @@ def resolve_flash_config(
         requested_causal_two_cta
         and is_causal
         and topology == "fa4"
-        and head_dim == 64
+        # hd128 causal had no 2-CTA path at all, though the lowering already
+        # special-cases head_dim==128 under use_2cta_instrs and fa4_2cta is
+        # legal for hd128 dense.
+        and head_dim in (64, 128)
         and dtype is torch.float16
         and num_kv % 4 == 0
     )
@@ -3631,6 +3634,32 @@ def _flash_causal_degree2_template_values(
     }
 
 
+def _flash_causal_resident_template_values(
+    *,
+    e2e_offset: int,
+    e2e_offset0: int,
+    role_map: str,
+    epi_tma: bool,
+) -> dict[str, object]:
+    """Values for the head-dim-agnostic resident causal seed template.
+
+    Mirrors the degree-2 template but omits the FP16/hd64-only compound exp2
+    packet and its 16/6 split schedule: the resident lowering rewrites both to
+    "1x1"/xu in _flash_resident_softmax_config, so pinning them here would be
+    dead weight that also drags in the hd64 restriction.
+    """
+    return {
+        FLASH_PIPELINE_FAMILY_KEY: "fa4",
+        FLASH_E2E_OFFSET_KEY: e2e_offset,
+        FLASH_E2E_OFFSET0_KEY: e2e_offset0,
+        FLASH_WAIT_HINT_KEY: 0,
+        FLASH_EPI_TMA_KEY: epi_tma,
+        FLASH_RESCALE_CHUNK_COLS_KEY: 16,
+        FLASH_CAUSAL_LPT_SWIZZLE_KEY: 1,
+        FLASH_ROLE_MAP_KEY: role_map,
+    }
+
+
 def _flash_dense_tuning_overrides(
     policy: FlashDenseTuningPolicy,
 ) -> dict[str, object]:
@@ -3672,12 +3701,16 @@ def _flash_dense_tuning_overrides(
 def _flash_causal_tuning_overrides(
     policy: FlashCausalTuningPolicy,
 ) -> dict[str, object]:
-    if policy.seed_template is not FlashCausalSeedTemplate.DEGREE2_V1:
+    if policy.seed_template is FlashCausalSeedTemplate.RESIDENT_V1:
+        template_values = _flash_causal_resident_template_values
+    elif policy.seed_template is FlashCausalSeedTemplate.DEGREE2_V1:
+        template_values = _flash_causal_degree2_template_values
+    else:
         raise AssertionError(
             f"unsupported causal seed template: {policy.seed_template!r}"
         )
     overrides = {
-        **_flash_causal_degree2_template_values(
+        **template_values(
             e2e_offset=policy.e2e_offset,
             e2e_offset0=policy.e2e_offset0,
             role_map=policy.role_map,

--- a/helion/_compiler/cute/flash_policy.py
+++ b/helion/_compiler/cute/flash_policy.py
@@ -5,11 +5,13 @@ import enum
 
 from .flash_arch import FlashHardwareCapabilities
 from .flash_tuning import FlashCausalTuningPolicy
+from .flash_tuning import FlashCausalSeedTemplate
 from .flash_tuning import FlashDenseTuningPolicy
 from .flash_tuning import FlashPackedExp2Mode
 from .flash_tuning import FlashSoftmaxLowering
 from .flash_tuning import FlashTuningDType
 from .flash_tuning import FlashTuningPolicy
+from .flash_tuning import FlashTuningWorkload
 
 
 @dataclasses.dataclass(frozen=True)
@@ -252,6 +254,76 @@ _FLASH_TARGET_POLICIES = {
                     softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
                     softmax_regs=184,
                     first_load_order=0,
+                ),
+            ),
+        ),
+        additional_tunings=(
+            # SM103 registered resident-softmax seeds only for hd64/FP16
+            # (#3416-#3419), so head_dim=128 falls back to the STANDARD softmax
+            # lowering. Seed an hd128 causal entry with the head-dim-agnostic
+            # resident template so the same RESIDENT_VALUE_GRAPH lowering that
+            # hd64 uses is reachable at hd128. Values come from the best
+            # measured 1-CTA hd128 config (the resident path requires
+            # not use_2cta_instrs).
+            FlashTuningPolicy(
+                workload=FlashTuningWorkload(
+                    head_dim=128, dtype=FlashTuningDType.FLOAT16
+                ),
+                tmem_row_reduce_min_kv=256,
+                causal_policies=(
+                    FlashCausalTuningPolicy(
+                        num_kv=512,
+                        kv_stage=3,
+                        seed_template=FlashCausalSeedTemplate.RESIDENT_V1,
+                        e2e_offset=0,
+                        e2e_offset0=0,
+                        role_map="fa4",
+                        epi_tma=False,
+                        softmax_lowering=(
+                            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+                        ),
+                        softmax_regs=200,
+                        first_load_order=2,
+                    ),                    FlashCausalTuningPolicy(
+                        num_kv=1024,
+                        kv_stage=3,
+                        seed_template=FlashCausalSeedTemplate.RESIDENT_V1,
+                        e2e_offset=0,
+                        e2e_offset0=0,
+                        role_map="fa4",
+                        epi_tma=False,
+                        softmax_lowering=(
+                            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+                        ),
+                        softmax_regs=200,
+                        first_load_order=2,
+                    ),                    FlashCausalTuningPolicy(
+                        num_kv=2048,
+                        kv_stage=3,
+                        seed_template=FlashCausalSeedTemplate.RESIDENT_V1,
+                        e2e_offset=0,
+                        e2e_offset0=0,
+                        role_map="fa4",
+                        epi_tma=False,
+                        softmax_lowering=(
+                            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+                        ),
+                        softmax_regs=200,
+                        first_load_order=2,
+                    ),                    FlashCausalTuningPolicy(
+                        num_kv=4096,
+                        kv_stage=3,
+                        seed_template=FlashCausalSeedTemplate.RESIDENT_V1,
+                        e2e_offset=0,
+                        e2e_offset0=0,
+                        role_map="fa4",
+                        epi_tma=True,
+                        softmax_lowering=(
+                            FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+                        ),
+                        softmax_regs=200,
+                        first_load_order=2,
+                    ),
                 ),
             ),
         ),

--- a/helion/_compiler/cute/flash_tuning.py
+++ b/helion/_compiler/cute/flash_tuning.py
@@ -79,6 +79,11 @@ class FlashCausalSeedTemplate(str, enum.Enum):
     """Versioned causal seed implementation families."""
 
     DEGREE2_V1 = "degree2_v1"
+    # Resident-softmax seed family. DEGREE2_V1 pins the degree-2 compound exp2
+    # packet, which is legal only at FP16/hd64; the resident lowering replaces
+    # exp2_packet with "1x1"/xu anyway (see _flash_resident_softmax_config), so
+    # a resident seed does not need that packet and is not hd64-bound.
+    RESIDENT_V1 = "resident_v1"
 
 
 class FlashTuningDType(str, enum.Enum):
@@ -325,10 +330,22 @@ class FlashCausalTuningPolicy:
         if self.e2e_offset < 0 or self.e2e_offset0 < 0:
             raise ValueError("causal end-to-end offsets must be nonnegative")
         if type(self.seed_template) is not FlashCausalSeedTemplate or (
-            self.seed_template is not FlashCausalSeedTemplate.DEGREE2_V1
+            self.seed_template
+            not in (
+                FlashCausalSeedTemplate.DEGREE2_V1,
+                FlashCausalSeedTemplate.RESIDENT_V1,
+            )
         ):
             raise ValueError(
                 f"unsupported causal seed template: {self.seed_template!r}"
+            )
+        if (
+            self.seed_template is FlashCausalSeedTemplate.RESIDENT_V1
+            and self.softmax_lowering is FlashSoftmaxLowering.STANDARD
+        ):
+            raise ValueError(
+                "the resident causal seed template requires a resident "
+                "softmax lowering"
             )
         if type(self.softmax_lowering) is not FlashSoftmaxLowering or (
             self.softmax_lowering
@@ -362,8 +379,9 @@ class FlashCausalTuningPolicy:
     @property
     def requires_fp16_hd64(self) -> bool:
         """Whether this policy's seed template is limited to FP16/hd64."""
-        # DEGREE2_V1 is currently the only implemented causal seed template and
-        # its emitter is specialized to the FP16/head-dim-64 workload.
+        # DEGREE2_V1's emitter pins the degree-2 compound exp2 packet, which is
+        # specialized to the FP16/head-dim-64 workload. RESIDENT_V1 emits only
+        # head-dim-agnostic values, so it carries no such restriction.
         return self.seed_template is FlashCausalSeedTemplate.DEGREE2_V1
 
 

--- a/test/test_cute_flash_arch.py
+++ b/test/test_cute_flash_arch.py
@@ -30,6 +30,41 @@ if TYPE_CHECKING:
     from helion._compiler.device_function import DeviceFunction
 
 
+def test_resident_causal_seed_template_is_head_dim_agnostic() -> None:
+    """RESIDENT_V1 must not inherit DEGREE2_V1's FP16/hd64 restriction.
+
+    DEGREE2_V1 pins the degree-2 compound exp2 packet, which only exists at
+    FP16/hd64. The resident lowering rewrites exp2_packet to "1x1" anyway, so a
+    resident seed carries no such restriction and may be registered for other
+    workloads (e.g. head_dim=128).
+    """
+    resident = FlashCausalTuningPolicy(
+        num_kv=512,
+        kv_stage=3,
+        seed_template=FlashCausalSeedTemplate.RESIDENT_V1,
+        softmax_lowering=FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH,
+    )
+    assert not resident.requires_fp16_hd64
+
+    degree2 = FlashCausalTuningPolicy(num_kv=512, kv_stage=3)
+    assert degree2.seed_template is FlashCausalSeedTemplate.DEGREE2_V1
+    assert degree2.requires_fp16_hd64
+
+    # A resident seed template without a resident lowering is contradictory.
+    with pytest.raises(ValueError, match="resident causal seed template"):
+        FlashCausalTuningPolicy(
+            num_kv=512,
+            kv_stage=3,
+            seed_template=FlashCausalSeedTemplate.RESIDENT_V1,
+            softmax_lowering=FlashSoftmaxLowering.STANDARD,
+        )
+
+    # The resident template must not emit the hd64-only compound exp2 packet.
+    overrides = cute_flash._flash_causal_tuning_overrides(resident)
+    assert cute_flash.FLASH_EXP2_PACKET_KEY not in overrides
+    assert overrides[cute_flash.FLASH_PIPELINE_FAMILY_KEY] == "fa4"
+
+
 def test_sm103_flash_target_policy() -> None:
     target_policy = get_flash_target_policy((10, 3))
     capabilities = target_policy.hardware
@@ -46,12 +81,29 @@ def test_sm103_flash_target_policy() -> None:
         )
         is not None
     )
+    # head_dim=128 FP16 now carries causal resident-softmax seeds, so it
+    # resolves a policy identity like head_dim=64 does.
     assert (
         flash_target_policy_cache_identity(
             (10, 3), head_dim=128, torch_dtype="float16", num_kv=256
         )
-        is None
+        is not None
     )
+    hd128_tuning = target_policy.tuning_for_cute(128, "cutlass.Float16")
+    assert hd128_tuning is not None
+    assert hd128_tuning.workload == FlashTuningWorkload(
+        head_dim=128, dtype=FlashTuningDType.FLOAT16
+    )
+    assert hd128_tuning.dense_policies == ()
+    hd128_causal = hd128_tuning.causal_policy(512)
+    assert hd128_causal is not None
+    assert hd128_causal.seed_template is FlashCausalSeedTemplate.RESIDENT_V1
+    assert (
+        hd128_causal.softmax_lowering
+        is FlashSoftmaxLowering.RESIDENT_VALUE_GRAPH
+    )
+    # The resident template must not carry the FP16/hd64-only restriction.
+    assert not hd128_causal.requires_fp16_hd64
     assert (
         flash_target_policy_cache_identity(
             (10, 3), head_dim=64, torch_dtype="bfloat16", num_kv=256


### PR DESCRIPTION
## Summary

The SM103 attention work (#3416–#3419) added resident softmax lowerings and promoted seeds, but registered a tuning policy only for the **FP16/head_dim=64** workload. `head_dim=128` therefore fell back to the `STANDARD` softmax lowering, and it was the only one of the four (head_dim × causal) combinations with **no 2-CTA pipeline family at all**.

This PR enables both at head_dim=128 causal.

### 1. `causal_two_cta` allowed at head_dim=128

`causal_two_cta` required `head_dim == 64`, even though the lowering already special-cases `head_dim == 128` under `use_2cta_instrs` and `fa4_2cta` is legal for hd128 *dense*. This looks like an oversight rather than a hardware limit — with the gate relaxed, a fresh autotune *chooses* `fa4_2cta_causal` on its own from two independent tuner seeds.

### 2. New `RESIDENT_V1` causal seed template + hd128 policies

`DEGREE2_V1` is marked FP16/hd64-only via `requires_fp16_hd64`, because it pins the degree-2 compound exp2 packet that exists only at hd64. But the resident lowering rewrites `exp2_packet` to `"1x1"`/`xu` in `_flash_resident_softmax_config`, so **a resident seed never needs that packet** and carries no head-dim restriction.

`RESIDENT_V1` emits only head-dim-agnostic values, and is rejected if paired with a `STANDARD` lowering. hd128 FP16 causal policies are registered for `num_kv` 512/1024/2048/4096.

## Measurements

GB300 (sm103), FP16 causal, `z=2 h=32 head_dim=128`, seq 64K, 5 samples, 1000 ms warmup / 500 ms rep, CUDA-event timing, all three interleaved on one verified-idle GPU:

| impl | TF/s | runs |
| --- | ---: | --- |
| **Helion (this PR)** | **1657.1** | 1658.3 / 1659.2 / 1654.3 / 1656.7 |
| Helion (before) | 1546.8 | |
| FA4 | 1630.4 | 1635.4 / 1626.8 / 1628.9 |
| SDPA | 1690.2 | 1690.6 / 1690.2 / 1689.7 |

- **+7.1%** from the resident seeds; **+10.7%** total versus the pre-change autotuned config (1497.4).
- Helion now **beats FA4 by 1.6%**. SDPA remains **2.0% ahead** — this PR does not close that gap.
- All three stable to +/-0.3% across reps, so the remaining gap to SDPA is real, not noise.
- FA4 reproduces its previously recorded baseline (1631.2) almost exactly, which validates the setup.
- Correctness passes the harness standard, repeat and stress checks on every measurement.

Caveat: `num_kv` 1024/2048/4096 policies are registered but were measured under GPU contention, so those numbers are not reported here and need a clean re-run.

## Reproducer

`benchmarks/cute/kernel.py` runs the kernel on the measured shape with the exact
promoted-seed config, checks correctness against SDPA, and prints both:

```
$ python benchmarks/cute/kernel.py
shape z=2 h=32 seq_len=65536 head_dim=128 fp16 causal
helion-cute           1618.0 TF/s
torch SDPA            1647.2 TF/s
```

(Absolutes run slightly below the harness numbers because this uses plain
`do_bench` rather than the harness's 5-sample protocol; the ratio matches.)

One sharp edge worth knowing: the config must be passed **verbatim**. The
resident lowering only engages when the config matches the promoted seed exactly
(`causal_seed_matches`), so changing any single field silently drops the kernel
to the STANDARD lowering (~1470 vs ~1650 TF/s). That also means a promoted seed
cannot be tuned through `--helion-config` -- every seed experiment here required
editing the policy.

## Known test interaction (why this is a draft)

`test_flash_full_population_is_length_invariant[div4-compiler-seeded-fp16-d128-causal]` **regresses** with this change.

The test asserts the compiler-seeded population is identical across sequence lengths. Registering per-`num_kv` causal seeds makes the seeded population vary with length, which breaks that invariant by construction.

Note the **same test already fails on main for `d64-causal`** — hd64 has per-`num_kv` causal seeds for exactly the same reason. So this PR extends an existing pattern and its existing test breakage to hd128, rather than introducing a new class of problem. I'd like reviewer guidance on the intended resolution: either the invariance test should exclude workloads with per-length seeds, or per-length seeding needs a different representation.

Also pre-existing on main (unrelated to this PR, fails identically with the source reverted):
- `test_flash_terminal_coordinate_surface_catalog_is_length_invariant[causal]`
- `test_flash_full_population_is_length_invariant[div4-compiler-seeded-fp16-d64-causal]`

## Testing

- `test_cute_flash_arch.py` — updated `test_sm103_flash_target_policy` (it asserted hd128 has *no* policy, which is what this PR changes) and added `test_resident_causal_seed_template_is_head_dim_agnostic`. 9 passed.
- `test_cute_flash_arch/schedule/exp2` + `test_cute_causal_range` — 193 passed, 29 skipped.
- `test_cute_flash_generalization_runtime` + `test_cute_flash_length_invariance` — 380 passed, 21 skipped, 3 failed (2 pre-existing, 1 discussed above).
- `benchmarks/cute/kernel.py` runs clean at seq 8192 and 65536.
- `./lint.sh` **not run** — `ruff`/`pyrefly` are not installed in this environment and installing them was not possible here. Style was checked manually (line length ≤88, import ordering).
