### PR TITLE
[cutedsl] matmul benchmark: fp32-as-tf32 semantics, picklable identity epilogue, ABAB verify tool

### DIFF
--- a/benchmarks/cute/compare_matmul_backends.py
+++ b/benchmarks/cute/compare_matmul_backends.py
@@ -956,7 +956,11 @@ def _check_close(
     actual: torch.Tensor, expected: torch.Tensor, dtype: torch.dtype
 ) -> None:
     if dtype == torch.float32:
-        torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+        # fp32 matmul is benchmarked under Helion's default semantics: fp32
+        # data with tf32 tensor-core compute (settings.dot_precision == "tf32",
+        # matching triton's tl.dot default). The reference is strict fp32, so
+        # allow tf32-level accumulation error (~2^-11 relative per element).
+        torch.testing.assert_close(actual, expected, atol=5e-2, rtol=1e-2)
     elif _is_fp8(dtype):
         # fp8 (e4m3) operands carry ~2 decimal digits, so the GEMM accumulates
         # substantial quantization error; use a relative-error tolerance like
@@ -1077,6 +1081,11 @@ def _result(
 
 def _benchmark_aten(args: argparse.Namespace) -> dict[str, Any]:
     dtype, a, b, bias, residual = _make_matmul_problem(args)
+    if dtype == torch.float32:
+        # Match Helion's default fp32 semantics (tf32 compute): benchmark the
+        # cuBLAS tf32 GEMM, not the strict-fp32 FFMA path, so aten is the
+        # apples-to-apples SOTA baseline for the fp32 variants.
+        torch.backends.cuda.matmul.allow_tf32 = True
     if args.epilogue == "scaled_mm":
         # ATen's fp8 rowwise GEMM is torch._scaled_mm — the SOTA baseline to
         # time against (a dequantized f32 matmul would be a misleadingly slow
@@ -1443,6 +1452,33 @@ class BiasEpilogue(NamedTuple):
         return self.fn.__closure__
 
 
+class IdentityEpilogue(NamedTuple):
+    """Explicit no-op epilogue for the ``none`` case.
+
+    Passing this instead of relying on the kernel's default lambda keeps the
+    bound args picklable, so the autotuner's killable subprocess benchmark
+    (with its per-config timeout) stays available — with the lambda default
+    the autotuner falls back to in-process benchmarking, where one hung or
+    pathologically slow config wedges the whole run.
+    """
+
+    @property
+    def fn(self) -> Callable[[torch.Tensor, tuple[torch.Tensor, ...]], torch.Tensor]:
+        def epilogue(acc: torch.Tensor, tile: tuple[torch.Tensor, ...]) -> torch.Tensor:
+            return acc
+
+        return epilogue
+
+    def __call__(
+        self, acc: torch.Tensor, tile: tuple[torch.Tensor, ...]
+    ) -> torch.Tensor:
+        return self.fn(acc, tile)
+
+    @property
+    def __closure__(self) -> tuple[Any, ...] | None:
+        return self.fn.__closure__
+
+
 class ReluEpilogue(NamedTuple):
     @property
     def fn(self) -> Callable[[torch.Tensor, tuple[torch.Tensor, ...]], torch.Tensor]:
@@ -1580,7 +1616,7 @@ def _helion_matmul_args(
     residual: torch.Tensor | None,
 ) -> tuple[Any, ...]:
     if args.epilogue == "none":
-        return (a, b)
+        return (a, b, IdentityEpilogue())
     if args.epilogue == "bias":
         assert bias is not None
         return (a, b, BiasEpilogue(bias))

--- a/benchmarks/cute/matmul_abab_verify.py
+++ b/benchmarks/cute/matmul_abab_verify.py
@@ -1,0 +1,151 @@
+"""Interleaved ABAB verify for one matmul variant: helion-cute vs a baseline.
+
+Runs both implementations alternately in ONE process on ONE GPU so thermal
+drift hits both sides equally; reports per-round pairs and the median ratio.
+This is the ground-truth measurement for variants near the goal bar, where
+one-sided drift between separately-run processes is enough to flip a verdict.
+
+Usage:
+    python benchmarks/cute/matmul_abab_verify.py \
+        --m 4096 --n 4096 --k 4096 --dtype bfloat16 \
+        --helion-config-file <path with helion.Config(...) repr> \
+        --baseline aten --rounds 5
+
+For --baseline quack-direct, pass --quack-config '{"tile_m": 256, ...}'.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import time
+from typing import Any
+from typing import Callable
+
+os.environ["HELION_BACKEND"] = "cute"
+
+import torch
+
+import helion
+
+
+def _thermal_warmup(seconds: float) -> None:
+    w = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
+    t0 = time.time()
+    while time.time() - t0 < seconds:
+        for _ in range(40):
+            w = w @ w
+        torch.cuda.synchronize()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--m", type=int, required=True)
+    parser.add_argument("--n", type=int, required=True)
+    parser.add_argument("--k", type=int, required=True)
+    parser.add_argument(
+        "--dtype", choices=("float16", "bfloat16", "float32"), required=True
+    )
+    parser.add_argument("--helion-config-file", required=True)
+    parser.add_argument("--baseline", choices=("aten", "quack-direct"), required=True)
+    parser.add_argument("--quack-config", default=None)
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--warmup-ms", type=int, default=400)
+    parser.add_argument("--rep-ms", type=int, default=400)
+    args = parser.parse_args()
+
+    from triton.testing import do_bench
+
+    dtype = {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+    }[args.dtype]
+    torch.manual_seed(0)
+    a = torch.randn(args.m, args.k, device="cuda", dtype=dtype)
+    b = torch.randn(args.k, args.n, device="cuda", dtype=dtype)
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from compare_matmul_backends import IdentityEpilogue  # pyrefly: ignore
+    from examples.matmul import matmul
+
+    config_src = Path(args.helion_config_file).read_text().strip()
+    helion_config = eval(config_src, {"helion": helion})
+    kernel_args = (a, b, IdentityEpilogue())
+    bound = matmul.bind(kernel_args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    bound.set_config(helion_config)
+    helion_fn = lambda: bound(*kernel_args)  # noqa: E731
+
+    baseline_fn: Callable[[], object]
+    if args.baseline == "aten":
+        if dtype == torch.float32:
+            torch.backends.cuda.matmul.allow_tf32 = True
+        baseline_fn = lambda: a @ b  # noqa: E731
+    else:
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "quack"))
+        from quack.gemm import gemm as gemm_dispatch  # pyrefly: ignore
+
+        qcfg: dict[str, Any] = json.loads(args.quack_config)
+        out = torch.empty((1, args.m, args.n), dtype=dtype, device="cuda")
+        a_d = a.unsqueeze(0)
+        b_d = b.mT.unsqueeze(0)
+
+        def baseline_fn() -> torch.Tensor:
+            gemm_dispatch(
+                a_d,
+                b_d,
+                out,
+                None,
+                None,
+                qcfg["tile_m"],
+                qcfg["tile_n"],
+                qcfg["cluster_m"],
+                qcfg["cluster_n"],
+                pingpong=qcfg["pingpong"],
+                persistent=qcfg["persistent"],
+                is_dynamic_persistent=qcfg["is_dynamic_persistent"],
+                max_swizzle_size=qcfg["max_swizzle_size"],
+                rowvec_bias=None,
+            )
+            return out[0]
+
+    for fn in (helion_fn, baseline_fn):
+        for _ in range(3):
+            fn()
+    torch.cuda.synchronize()
+    _thermal_warmup(8.0)
+
+    flops = 2.0 * args.m * args.n * args.k
+    helion_ms: list[float] = []
+    base_ms: list[float] = []
+    for r in range(args.rounds):
+        hm = do_bench(helion_fn, warmup=args.warmup_ms, rep=args.rep_ms)
+        bm = do_bench(baseline_fn, warmup=args.warmup_ms, rep=args.rep_ms)
+        assert isinstance(hm, float) and isinstance(bm, float)
+        helion_ms.append(hm)
+        base_ms.append(bm)
+        print(
+            f"round{r}: helion {flops / hm / 1e9:.1f} TF "
+            f"baseline {flops / bm / 1e9:.1f} TF ratio {bm / hm:.4f}",
+            flush=True,
+        )
+    hmed = statistics.median(helion_ms)
+    bmed = statistics.median(base_ms)
+    result = {
+        "helion_median_ms": hmed,
+        "baseline_median_ms": bmed,
+        "helion_tflops": flops / hmed / 1e9,
+        "baseline_tflops": flops / bmed / 1e9,
+        "ratio": bmed / hmed,
+        "paired_ratios": [bm / hm for hm, bm in zip(helion_ms, base_ms, strict=True)],
+    }
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3544
 * #3532
 * #3531
 * #3530
 * #3529
 * #3528
 * __->__#3527


--- --- ---

[cutedsl] matmul benchmark: fp32-as-tf32 semantics, picklable identity epilogue, ABAB verify tool

- fp32 matmul rows benchmark under Helion's default semantics (fp32 data,
  tf32 compute, settings.dot_precision == 'tf32' matching triton's tl.dot
  default): the aten baseline runs the cuBLAS tf32 GEMM and the fp32
  correctness tolerance admits tf32 accumulation error against the strict
  fp32 reference.
- epilogue=none passes a module-level IdentityEpilogue instead of relying on
  the kernel's default lambda: with the lambda in the bound args the
  autotuner falls back to in-process benchmarking (no killable subprocess),
  where one hung or pathologically slow config wedges the whole run for
  hours. Verified config- and perf-neutral vs the lambda at effort=none.
- matmul_abab_verify.py: interleaved ABAB verify for one variant (pinned
  helion-cute config vs aten or quack-direct) in one process on one GPU, so
  thermal drift hits both sides equally; the median paired ratio is the
  ground-truth measurement for variants near the goal bar.