### PR TITLE
[autotuner] Robustness fixes exposed by cute matmul full autotunes

### DIFF
--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -12,6 +12,7 @@ import json
 import math
 from math import inf
 import os
+import pickle
 import tempfile
 import time
 from typing import TYPE_CHECKING
@@ -525,6 +526,10 @@ class LocalBenchmarkProvider(BenchmarkProvider):
     provider created by ``BaseSearch._prepare()``.
     """
 
+    # Class-level default: tests construct partially-initialized providers, so
+    # the picklability flag must resolve even before setup()/__init__ set it.
+    _args_unpicklable: bool = False
+
     def __init__(
         self,
         kernel: _AutotunableKernel,
@@ -549,6 +554,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._worker_failure_config_ids: list[int] = []
         self._precompile_tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._precompile_args_path: str | None = None
+        self._args_unpicklable: bool = False
         self._precompile_baseline_path: str | None = None
         self._precompile_result_counter: count[int] = count()
         self._benchmark_worker: BenchmarkWorker | None = None
@@ -902,8 +908,23 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             or self._subprocess_benchmark_enabled()
         ):
             args_path = os.path.join(self._precompile_tmpdir.name, "args.pt")
-            torch.save(self.args, args_path)
-            self._precompile_args_path = args_path
+            try:
+                torch.save(self.args, args_path)
+            except (pickle.PicklingError, AttributeError, TypeError) as e:
+                # Kernel args holding lambdas/closures (e.g. an epilogue
+                # callable) cannot cross a spawn boundary. Fall back to the
+                # in-process benchmark/accuracy path instead of failing the
+                # whole autotune; spawn-mode precompile keeps its hard error
+                # since it cannot run at all without the args file.
+                if self.settings.autotune_precompile == "spawn":
+                    raise
+                self._args_unpicklable = True
+                self.log.warning(
+                    f"Autotune args are not picklable ({e}); benchmarking "
+                    "in-process instead of in a killable subprocess."
+                )
+            else:
+                self._precompile_args_path = args_path
         if self._subprocess_accuracy_check_enabled():
             baseline_path = os.path.join(self._precompile_tmpdir.name, "baseline.pt")
             torch.save(self._baseline_output, baseline_path)
@@ -991,6 +1012,8 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         """Subprocess benchmark path is opt-in and skipped for distributed /
         mutated-arg kernels where the worker's simple job shape doesn't fit."""
         if not self.settings.autotune_benchmark_subprocess:
+            return False
+        if self._args_unpicklable:
             return False
         if dist.is_initialized():
             return False

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -222,11 +222,29 @@ class PatternSearch(PopulationBasedSearch):
                 n_random = max(0, self.initial_population - len(pop))
                 pop.extend(self.config_gen.random_flat() for _ in range(n_random))
             return pop
-        return self.config_gen.random_population_flat(
+        population = self.config_gen.random_population_flat(
             self.initial_population,
             user_seed_configs=self._autotune_seed_configs(),
             log_func=self.log,
         )
+        # Pin the seed/default configs into final verification (mirroring the
+        # FROM_BEST_AVAILABLE path): a seed's single in-search reading is often
+        # burst-inflated, and without the pin a 2-6% real winner dies to a
+        # noisy rival before the steady final rebenchmark can arbitrate.
+        pinned_seed_configs = [
+            config
+            for _flat, config in (
+                *self.config_gen.user_seed_flat_config_pairs(
+                    self._autotune_seed_configs()
+                ),
+                *self.config_gen.seed_flat_config_pairs(),
+            )
+        ]
+        pinned_seed_configs.append(
+            self.config_gen.unflatten(self.config_gen.default_flat())
+        )
+        self.pin_finalist_configs(pinned_seed_configs)
+        return population
 
     def _autotune(self) -> Config:
         initial_population_name = self.initial_population_strategy.name

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -8403,8 +8403,8 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             config_gen.flatten(unflatten(flat)),
             unflatten(flat),
         )
-        config_gen.user_seed_flat_config_pairs = lambda _configs, _log: []
-        config_gen.seed_flat_config_pairs = lambda _log: []
+        config_gen.user_seed_flat_config_pairs = lambda _configs, _log=None: []
+        config_gen.seed_flat_config_pairs = lambda _log=None: []
         config_gen.random_flat = Mock(
             side_effect=AssertionError("an enumerated space must not draw randomly")
         )
@@ -8417,6 +8417,8 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         random_search.initial_population = 5
         random_search._autotune_seed_configs = list
         random_search.log = Mock()
+        # FROM_RANDOM now pins seed/default configs into final verification.
+        random_search._pinned_finalist_configs = set()
         random_population = random_search._generate_initial_population_flat()
         random_unique = [
             list(flat)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3544
 * #3532
 * #3531
 * #3530
 * #3529
 * __->__#3528
 * #3527


--- --- ---

[autotuner] Robustness fixes exposed by cute matmul full autotunes

Two failure modes, each of which killed or degraded an entire cold
full-autotune run (the companion EnumFragment out-of-domain tolerance
landed separately as #3516):

- benchmark_provider: unpicklable kernel args (e.g. a lambda epilogue in
  the bound args) crashed setup() with PicklingError inside the default
  subprocess-benchmark path. Try the args save and degrade to the
  in-process benchmark/accuracy path instead; explicit spawn-mode
  precompile keeps its hard error (it cannot run without the args file).
  The picklability flag is a class attribute so partially-initialized
  test providers resolve it.
- pattern_search: FROM_RANDOM searches now pin seed/default configs into
  final verification (mirroring FROM_BEST_AVAILABLE). A compiler seed's
  single in-search reading is often burst-inflated on sub-ms kernels,
  and without the pin a 2-6% real winner died to a noisy rival before
  the steady final rebenchmark could arbitrate (measured: the CLC seed
  pinned at 1150 TFLOP/s vs the 1111 search-returned pick at fp16 qkv).