### PR TITLE
[cutedsl] tcgen05 matmul: fp32-as-tf32, CLC dynamic persistence, clamped-TMA edges, deep-AB bk=64, 4-CTA clusters

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -70,7 +70,9 @@ from .fragment_epilogue import analyze_tcgen05_fragment_epilogue_plan
 from .layout import MatmulExecutionKind
 from .layout import MatmulExecutionPlan
 from .matmul_utils import analyze_direct_grouped_n_loads
+from .mma_support import cute_fp32_dot_uses_tf32
 from .mma_support import get_cute_mma_support
+from .mma_support import tcgen05_supports_input_dtype
 from .strategies import TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY
 from .strategies import TCGEN05_LEGAL_SMEM_SWIZZLE_BYTES
 from .strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
@@ -152,6 +154,7 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
 from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_profile
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
+from .tcgen05_constants import tcgen05_l2_grouping_cluster_consistent
 from .tcgen05_lifecycle import Tcgen05LifecycleContext
 from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
@@ -4522,6 +4525,14 @@ def prepare_cute_collective_lane_loop_suppression(
                 != "tcgen05"
             ):
                 continue
+            if lhs_fake.dtype == torch.float32 and _tcgen05_fp32_lowering_blocked(
+                cg,
+                node,
+                lhs_operand=lhs_operand,
+                rhs_operand=rhs_operand,
+                config=cg.device_function.config,
+            ):
+                continue
             if analysis.has_leading_passthrough and not _mma_tiles_are_static_full(
                 analysis, bm=bm, bn=bn, bk=bk
             ):
@@ -4768,6 +4779,14 @@ def prepare_cute_collective_lane_loop_suppression(
                 defer_grouped_worklist_smem_check=worklist_profile is not None,
             )
             != "tcgen05"
+        ):
+            continue
+        if lhs_fake.dtype == torch.float32 and _tcgen05_fp32_lowering_blocked(
+            cg,
+            node,
+            lhs_operand=lhs_info,
+            rhs_operand=rhs_info,
+            config=cg.device_function.config,
         ):
             continue
         if not _operand_infos_exclusive_for_mma(lhs_info, rhs_info, node):
@@ -5858,6 +5877,53 @@ def _analyze_mma_output_stores(
     )
 
 
+def _tcgen05_fp32_lowering_blocked(
+    cg: GenerateAST,
+    node: Node,
+    *,
+    lhs_operand: _MmaOperandInfo,
+    rhs_operand: _MmaOperandInfo,
+    config: object,
+) -> bool:
+    """Whether an fp32 (tf32) matmul must keep the exact universal lowering.
+
+    fp32 reaches tcgen05 only through the TMA AB pipeline (the descriptors
+    recast Float32 -> TFloat32 via ``internal_type``; the SIMT-staged AB path
+    has no such recast), only when every consuming store chain is on the
+    fused-epilogue splice whitelist (the tcgen05 grid does not bind the
+    per-block-id index/mask vars the SIMT store fallback needs, so a rejected
+    chain is otherwise a hard ``BackendUnsupported``), and only when the config
+    does not request ``epilogue_subtile`` (the splice emits exactly one store
+    per output tile). Everything blocked here keeps the exact universal (SIMT)
+    lowering fp32 matmuls used before the tf32 path existed; 16-bit/fp8 keep
+    their historical loud-failure behavior.
+
+    Called by both ``prepare_cute_collective_lane_loop_suppression`` and
+    ``_emit_mma_pipeline`` — the two must agree, otherwise suppression would
+    drop the index/mask definitions the universal fallback needs (see the
+    mirror-bailout comment in the suppression planner).
+    """
+    if not (
+        lhs_operand.matrix_major == "row" and rhs_operand.matrix_major in ("row", "col")
+    ):
+        return True
+    # Batched (leading-passthrough) and grouped/worklist/rank-3 forms are
+    # validated 16-bit/fp8 families only.
+    if (
+        lhs_operand.is_leading_passthrough
+        or rhs_operand.is_leading_passthrough
+        or rhs_operand.rhs_rank3_grouped_nt
+        or rhs_operand.rhs_segment_group is not None
+        or rhs_operand.rhs_packed_group is not None
+        or _tcgen05_grouped_mode(cast("_ConfigLike", config)) is not None
+    ):
+        return True
+    subtile = cast("_ConfigLike", config).get("epilogue_subtile")
+    if subtile is not None and (isinstance(subtile, bool) or subtile != 1):
+        return True
+    return analyze_tcgen05_matmul_store_chains(cg.codegen_graphs, node) is None
+
+
 def _rank3_rhs_worklist_store_info(
     cg: GenerateAST,
     mma_node: Node,
@@ -6564,7 +6630,7 @@ def _emit_mma_pipeline(
         torch.float16,
         torch.bfloat16,
         torch.float8_e4m3fn,
-    )
+    ) or (input_dtype == torch.float32 and cute_fp32_dot_uses_tf32())
     _lhs_major = lhs_operand.matrix_major
     _rhs_major = rhs_operand.matrix_major
     # A must be row-major (M,K) K-contiguous == "row"; the K-major A SMEM
@@ -6895,6 +6961,41 @@ def _emit_mma_pipeline(
         input_device=lhs_fake.device,
         defer_grouped_worklist_smem_check=worklist_profile is not None,
     )
+    if mma_impl == "tcgen05" and input_dtype == torch.float32:
+        # fp32 operands run the tcgen05 MMA as tf32 (permitted by
+        # settings.dot_precision, checked in _mma_impl_matches_problem_shape).
+        # GMEM tensors stay Float32; the TMA descriptors recast to TFloat32 via
+        # internal_type (see the launcher's tcgen05_ab_tma emission), so the
+        # SMEM staging, tiled MMA, and layout plan all use TFloat32. The
+        # SIMT-staged (non-TMA) AB path would load Float32 into TFloat32 SMEM
+        # without that recast, so it stays unsupported for fp32; such kernels
+        # keep the exact universal lowering fp32 used before the tf32 path
+        # (the suppression planner applies the same gate, so no root lane
+        # loops were suppressed for a demoted config).
+        fp32_blocked = (
+            not tcgen05_use_tma_pipeline
+            or fx_node is None
+            or _tcgen05_fp32_lowering_blocked(
+                cg,
+                fx_node,
+                lhs_operand=lhs_operand,
+                rhs_operand=rhs_operand,
+                config=df.config,
+            )
+        )
+        if fp32_blocked:
+            if (
+                os.environ.get("HELION_CUTE_MMA_IMPL", "auto").strip().lower()
+                == "tcgen05"
+            ):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "fp32 (tf32) tcgen05 matmul requires TMA-eligible A/B "
+                    "layouts and whitelisted fused-epilogue store chains",
+                )
+            mma_impl = "universal"
+        else:
+            input_dtype_str = "cutlass.TFloat32"
     if (
         mma_impl == "tcgen05"
         and fx_node is not None
@@ -7046,7 +7147,7 @@ def _emit_mma_pipeline(
         and tcgen05_use_tma_pipeline
         and tcgen05_pid_is_persistent
         and tcgen05_cluster_m == 2
-        and tcgen05_cluster_n_requested == 1
+        and tcgen05_cluster_n_requested in (1, 2)
         and tcgen05_requested_two_cta
         and tcgen05_double_edge_output
         and (k_total_size % bk == 0 or tcgen05_has_k_tail)
@@ -7088,7 +7189,7 @@ def _emit_mma_pipeline(
         and tcgen05_use_tma_pipeline
         and tcgen05_pid_is_persistent
         and tcgen05_cluster_m == 2
-        and tcgen05_cluster_n_requested == 1
+        and tcgen05_cluster_n_requested in (1, 2)
         and tcgen05_requested_two_cta
         and tcgen05_k_tail_only
     )
@@ -7097,7 +7198,7 @@ def _emit_mma_pipeline(
         and tcgen05_use_tma_pipeline
         and tcgen05_pid_is_persistent
         and tcgen05_cluster_m == 2
-        and tcgen05_cluster_n_requested == 1
+        and tcgen05_cluster_n_requested in (1, 2)
         and tcgen05_requested_two_cta
         and m_size % bm != 0
         and n_size % bn == 0
@@ -7191,19 +7292,39 @@ def _emit_mma_pipeline(
         tcgen05_cluster_n = 1
     else:
         tcgen05_cluster_n = tcgen05_cluster_n_requested
+    if tcgen05_cluster_n > 1 and not tcgen05_l2_grouping_cluster_consistent(
+        l2_grouping=_l2_grouping_value(df.config),
+        num_pid_m=(m_size + bm - 1) // bm,
+        num_pid_n=(n_size + bn - 1) // bn,
+        cluster_n=tcgen05_cluster_n,
+    ):
+        # Helion's l2_groupings remap permutes the linear tile index per-CTA
+        # without cluster awareness: the two cluster-N peers (vpids exactly
+        # num_pid_m apart) can decode DIFFERENT tile_m, and the A multicast
+        # then fills each peer's SMEM half with the wrong A tile (silent
+        # corruption, max rel err ~1.4). Reject the config unless the remap
+        # provably keeps every N-pair inside one L2 group row.
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05_cluster_n=2 with this l2_grouping/grid combination breaks "
+            "the cluster-N peer pairing that the A multicast requires "
+            "(cluster_n * num_pid_m must divide l2_grouping * num_pid_n, and "
+            "l2_grouping must divide num_pid_m). Use l2_groupings=[1] or "
+            "tcgen05_cluster_n=1 for this shape.",
+        )
     tcgen05_role_local_k_tail_tma = (
         tcgen05_preserve_tma_for_two_cta_k_tail
         and tcgen05_is_two_cta
-        and tcgen05_cluster_n == 1
+        and tcgen05_cluster_n in (1, 2)
     )
     # Mirror the K-tail role-local guard so later cluster demotion or
     # cluster_n enablement cannot silently admit unvalidated edge ownership.
     tcgen05_role_local_m_edge_tma = (
-        tcgen05_m_edge_only and tcgen05_is_two_cta and tcgen05_cluster_n == 1
+        tcgen05_m_edge_only and tcgen05_is_two_cta and tcgen05_cluster_n in (1, 2)
     )
     tcgen05_role_local_n_edge_tma = tcgen05_n_edge_only and tcgen05_cluster_n == 1
     tcgen05_role_local_double_edge_tma = (
-        tcgen05_double_edge_tma and tcgen05_is_two_cta and tcgen05_cluster_n == 1
+        tcgen05_double_edge_tma and tcgen05_is_two_cta and tcgen05_cluster_n in (1, 2)
     )
     tcgen05_role_local_uses_k_tail_tma = tcgen05_role_local_k_tail_tma or (
         tcgen05_role_local_double_edge_tma and tcgen05_has_k_tail
@@ -7293,8 +7414,36 @@ def _emit_mma_pipeline(
         if tcgen05_use_pure_matmul_role_lifecycle
         else "cutlass.pipeline"
     )
+    # The role-local CtaGroup.TWO edge/K-tail families keep every
+    # per-iteration K-loop predicate the slow path would emit constant-true:
+    # the persistent scheduler only publishes in-grid tiles (a tile origin is
+    # always < the problem extent, so the M/N-edge "issue TMA over the partial
+    # stripe" predicates always hold), the K loop runs ceil(K/bk) iterations
+    # so every k_tile start is in range, and partial A/B stripes plus the K
+    # tail are TMA boxes that clamp against the descriptor's true extents and
+    # zero-fill SMEM (zeros accumulate as no-ops through the MMA). Take the
+    # predicate-free fast path (hoisted V-leader gate, unguarded pipeline
+    # waits/releases) instead of paying the per-iteration branch tax on every
+    # tile; the store-side full-tile/fringe split is governed separately by
+    # the TMA-store epilogue flags.
+    # Aux kernels stay on the predicated slow path: their guarded epilogue
+    # aux loads and the aux-TMA hybrid store protocol were validated with the
+    # per-iteration predicates present (removing them deadlocks the aux edge
+    # hybrid TMA-store runtime test), and only plain kernels were measured.
     tcgen05_static_full_tma_fast_path = (
-        tcgen05_static_full_tiles
+        (
+            tcgen05_static_full_tiles
+            or (
+                tcgen05_is_two_cta
+                and not env.config_spec.cute_tcgen05_aux_kernel_detected
+                and (
+                    tcgen05_role_local_k_tail_tma
+                    or tcgen05_role_local_m_edge_tma
+                    or tcgen05_role_local_n_edge_tma
+                    or tcgen05_role_local_double_edge_tma
+                )
+            )
+        )
         and tcgen05_use_tma_pipeline
         and not tcgen05_grouped_static_persistent_requested
     )
@@ -7435,8 +7584,24 @@ def _emit_mma_pipeline(
     tcgen05_acc_stage_count_value = _tcgen05_config_int(
         df.config, "tcgen05_acc_stages", _tcgen05_acc_stage_count(tcgen05_mma_bn)
     )
+    # Budget-driven admission for the output-edge TMA-store epilogue's extra
+    # C ring: the flat <=2 AB-stage cap was calibrated for the residual
+    # (source-C) family's (128, 64) epilogue tile; plain kernels stage a
+    # (128, 32) tile whose ring fits comfortably next to a 3-stage AB
+    # pipeline, and a deeper AB pipeline is worth ~15-25% on edge shapes.
+    # ``c_stages_fits`` fails CLOSED (False without a recorded budget), so
+    # keep the legacy cap as the fallback admission.
     tcgen05_output_edge_tma_store_fits_smem = (
         tcgen05_ab_stage_count_value <= TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
+        or env.config_spec._cute_tcgen05_config.c_stages_fits(
+            bm=tcgen05_source_bm,
+            bn=tcgen05_source_bn,
+            bk=bk,
+            cluster_m=tcgen05_cluster_m,
+            ab_stages=tcgen05_ab_stage_count_value,
+            c_stages=tcgen05_c_stage_count_value,
+            has_source_c=True,
+        )
     )
     # ``tcgen05_is_two_cta`` below gates only the hybrid output-store protocol,
     # not role-local edge-TMA input loading. The mixed full-tile TMA-store plus
@@ -9025,16 +9190,26 @@ def _emit_mma_pipeline(
         )
         # CuTe's TMA descriptor bounds checks correctly suppress partial M/N
         # output stores for the admitted aux-TMA output-edge family, so keep
-        # those edge tiles on the same TMA-store path as full tiles. Kernels
-        # without a productive aux-TMA body keep the original predicated
+        # those edge tiles on the same TMA-store path as full tiles. The same
+        # holds for epilogues with no aux GMEM operands at all (plain store of
+        # the accumulator, possibly through thread-local transforms): with
+        # nothing to read out of bounds, the D descriptor's clamping is the
+        # complete edge story and every tile can take the TMA-store path
+        # instead of draining fringe tiles through the predicated SIMT store.
+        # Kernels with unstaged aux operands keep the original predicated
         # full-tile/edge split.
         tcgen05_partial_output_tma_store = (
             tcgen05_use_tma_store_epilogue
             and tcgen05_use_output_edge_tma_store_for_full_tiles
             and not tcgen05_static_output_tiles
-            and df.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
-            == TCGEN05_AUX_LOAD_MODE_TMA
-            and aux_tma_productive_body_gate_open
+            and (
+                (
+                    df.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
+                    == TCGEN05_AUX_LOAD_MODE_TMA
+                    and aux_tma_productive_body_gate_open
+                )
+                or not aux_tensor_descriptors_value
+            )
         )
         tcgen05_tma_store_full_tiles_only = tcgen05_tma_store_full_tiles_only_for(
             tcgen05_partial_output_tma_store
@@ -12340,6 +12515,15 @@ def _tcgen05_use_2cta_instrs(
     return bm == 128 and is_fp8
 
 
+def _l2_grouping_value(config: object) -> int:
+    groupings = getattr(config, "config", config)
+    if isinstance(groupings, dict):
+        groupings = groupings.get("l2_groupings")
+    if isinstance(groupings, list) and groupings and isinstance(groupings[0], int):
+        return groupings[0]
+    return 1
+
+
 def _tcgen05_epi_warp_count(
     warp_spec: Tcgen05WarpSpec, *, cta_thread_count: int
 ) -> int:
@@ -12384,10 +12568,18 @@ def _mma_impl_matches_problem_shape(
     if mma_impl == "universal":
         return True
     is_fp8 = input_dtype == torch.float8_e4m3fn
-    min_n = 16 if is_fp8 else 8
+    is_tf32 = input_dtype == torch.float32 and cute_fp32_dot_uses_tf32()
+    # tf32 needs bn >= 32: the (128, 8|16) tf32 epilogue corrupts inside the
+    # CUTLASS tmem/epilogue-tile helpers (bn is power-of-two constrained, so
+    # 32 closes the whole unsafe set); narrower fp32 tiles keep the exact
+    # universal/SIMT lowering.
+    min_n = 16 if is_fp8 else (32 if is_tf32 else 8)
     n_multiple = 16 if is_fp8 else 8
     if (
-        input_dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
+        (
+            input_dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
+            and not is_tf32
+        )
         or bn < min_n
         or bn % n_multiple != 0
     ):
@@ -12405,19 +12597,20 @@ def _mma_impl_matches_problem_shape(
         return False
     if mma_impl == "warp":
         # Warp MMA atom is fixed-K (16 elements per BF16/FP16 instruction);
-        # fp8 is only wired through tcgen05.
-        if is_fp8:
+        # fp8 and tf32 are only wired through tcgen05.
+        if is_fp8 or is_tf32:
             return False
         return bk == 16 and bm >= 16 and bm % 16 == 0 and bn == 8
     if mma_impl == "tcgen05":
-        # tcgen05 mma instruction K is 16 elements for BF16/FP16 (32 for FP8),
+        # tcgen05 mma instruction K is 16 elements for BF16/FP16 (32 for FP8,
+        # 8 for fp32-as-tf32: 256 bits of K per instruction / operand width),
         # but the tile's K can be any positive multiple of that (the inner
         # cute.gemm loop just runs more instructions per K iteration). Larger
         # tile_k roughly halves the per-K-iter overhead per doubling.
         # Production remains capped at block_n=256 to keep AB SMEM staging
         # budget sane; the explicit G4 proof key admits only the smallest
         # 512-N candidate.
-        mma_k = 32 if is_fp8 else 16
+        mma_k = 32 if is_fp8 else (8 if is_tf32 else 16)
         if bk < mma_k or bk > 256 or bk % mma_k != 0:
             return False
         if bm in (64, 128):
@@ -12486,11 +12679,7 @@ def _tcgen05_candidate_exceeds_smem(
     ):
         return False
     support = get_cute_mma_support()
-    if not (
-        support.tcgen05_f8
-        if input_dtype == torch.float8_e4m3fn
-        else support.tcgen05_f16bf16
-    ):
+    if not tcgen05_supports_input_dtype(support, input_dtype):
         return False
     budget = CuteTcgen05Config.per_cta_smem_budget_bytes(input_device)
     if budget <= 0:
@@ -12567,11 +12756,7 @@ def _choose_mma_impl(
         tcgen05_cluster_m=tcgen05_cluster_m,
         tcgen05_large_bn_proof=tcgen05_large_bn_proof,
     ):
-        tcgen05_ok = (
-            support.tcgen05_f8
-            if input_dtype == torch.float8_e4m3fn
-            else support.tcgen05_f16bf16
-        )
+        tcgen05_ok = tcgen05_supports_input_dtype(support, input_dtype)
         if tcgen05_ok and not _tcgen05_candidate_exceeds_smem(
             input_dtype,
             input_device=input_device,

--- a/helion/_compiler/cute/mma_support.py
+++ b/helion/_compiler/cute/mma_support.py
@@ -12,6 +12,7 @@ class CuteMmaSupport:
     warpgroup_f16bf16: bool
     tcgen05_f16bf16: bool
     tcgen05_f8: bool = False
+    tcgen05_tf32: bool = False
 
     @property
     def supported_impls(self) -> tuple[str, ...]:
@@ -92,6 +93,26 @@ def _probe_tcgen05_f16bf16() -> bool:
         return False
 
 
+def _probe_tcgen05_tf32() -> bool:
+    try:
+        from cutlass.cute.nvgpu import OperandMajorMode
+        from cutlass.cute.nvgpu import tcgen05
+
+        # fp32 operands run on tcgen05 as tf32 with MMA-K=8 (256 bits of K per
+        # instruction / 32-bit operands). The op takes no a/acc dtype args:
+        # tf32 in, f32 accumulate is the only shape.
+        tcgen05.MmaTF32Op(
+            (128, 8, 8),
+            tcgen05.CtaGroup.ONE,
+            tcgen05.OperandSource.SMEM,
+            OperandMajorMode.K,
+            OperandMajorMode.K,
+        )
+        return True
+    except Exception:
+        return False
+
+
 def _probe_tcgen05_f8() -> tuple[bool, str | None]:
     try:
         import cutlass
@@ -123,6 +144,7 @@ def get_cute_mma_support() -> CuteMmaSupport:
             warpgroup_f16bf16=False,
             tcgen05_f16bf16=False,
             tcgen05_f8=False,
+            tcgen05_tf32=False,
         )
 
     cutlass_arch = _current_cutlass_arch_name()
@@ -136,4 +158,38 @@ def get_cute_mma_support() -> CuteMmaSupport:
         warpgroup_f16bf16=_probe_warpgroup_f16bf16(),
         tcgen05_f16bf16=_probe_tcgen05_f16bf16(),
         tcgen05_f8=tcgen05_f8_ok,
+        tcgen05_tf32=_probe_tcgen05_tf32(),
     )
+
+
+def tcgen05_supports_input_dtype(
+    support: CuteMmaSupport, input_dtype: torch.dtype
+) -> bool:
+    """Per-dtype tcgen05 capability lookup.
+
+    A free function (not a CuteMmaSupport method) so callers keep working with
+    the duck-typed SimpleNamespace doubles tests patch in for
+    ``get_cute_mma_support``; those predate the tf32 field, hence the getattr
+    default.
+    """
+    if input_dtype == torch.float8_e4m3fn:
+        return support.tcgen05_f8
+    if input_dtype == torch.float32:
+        return getattr(support, "tcgen05_tf32", False)
+    return support.tcgen05_f16bf16
+
+
+def cute_fp32_dot_uses_tf32() -> bool:
+    """Whether fp32 matmul operands may be computed as tf32 on tensor cores.
+
+    Helion's default ``settings.dot_precision`` maps to ``"tf32"`` (matching
+    triton's ``tl.dot`` default), which permits the tcgen05 tf32 MMA path for
+    fp32 inputs. ``"ieee"``/``"tf32x3"`` keep fp32 matmuls on the exact SIMT /
+    universal-FMA lowerings.
+    """
+    from ..compile_environment import CompileEnvironment
+
+    if not CompileEnvironment.has_current():
+        return False
+    env = CompileEnvironment.current()
+    return env.backend.map_dot_precision(env.settings.dot_precision) == "tf32"

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -130,6 +130,7 @@ from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNTS
 from .tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
+from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_CLC_AUX_TMA_ACC_STAGES
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_CLC_AUX_TMA_K_RANGE_FLATTEN
@@ -140,6 +141,7 @@ from .tcgen05_constants import (
     TCGEN05_TWO_CTA_EDGE_K_TAIL_CLC_AUX_TMA_K_RANGE_WARP_SPECIALIZE,
 )
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_CLC_AUX_TMA_L2_GROUPING
+from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_DEEP_BLOCK_K
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_ACC_STAGES
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_K
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_N
@@ -580,9 +582,13 @@ class CuteTcgen05Config:
         if bk <= 0:
             return False
         if constraints.allow_edge_k_tail_family:
+            # bk=64 halves the per-stage AB SMEM so a 16-bit edge kernel can
+            # run a 5-deep AB pipeline (bf16 5000^3: 948 vs 815 TFLOP/s at the
+            # bk=128 seed); the K tail stays a clamped TMA box either way.
             return (
                 bk
                 in (
+                    TCGEN05_TWO_CTA_EDGE_K_TAIL_DEEP_BLOCK_K,
                     TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K,
                     TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_K,
                 )
@@ -803,6 +809,227 @@ class CuteTcgen05Config:
                 ]
         return Config(**seed_config)
 
+    def _plain_clc_seed_config(self) -> Config | None:
+        """Autotune seed for the plain full-tile cluster_m=2 CLC family.
+
+        Mirrors ``_c_input_seed_config``'s full-tile branch but for kernels
+        without aux operands: ROLE_LOCAL_WITH_SCHEDULER + a scheduler warp
+        driving CLC dynamic persistence, no C-input warp. Besides giving the
+        search a head start, this seed widens the strategy/scheduler-warps/
+        persistence fragments via the compiler-seed mechanism so neighboring
+        configs stay explorable.
+        """
+        if not self._plain_clc_persistence_search_enabled():
+            return None
+        if not self._clc_persistence_search_enabled():
+            return None
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None:
+            return None
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return None
+        fragments = self._matmul_block_fragments()
+        if fragments is None:
+            return None
+        bm_fragment, bn_fragment, bk_fragment = fragments
+        if not (
+            bm_fragment.low <= TCGEN05_TWO_CTA_BLOCK_M <= bm_fragment.high
+            and bn_fragment.low <= TCGEN05_TWO_CTA_BLOCK_N <= bn_fragment.high
+        ):
+            return None
+        bk = bk_fragment.high
+        while bk >= bk_fragment.low:
+            if self.cluster_m2_bk_is_valid(bk, constraints):
+                break
+            bk //= 2
+        else:
+            return None
+        ab_stages = (
+            3
+            if self.ab_stages_three_fits(
+                bm=TCGEN05_TWO_CTA_BLOCK_M,
+                bn=TCGEN05_TWO_CTA_BLOCK_N,
+                bk=bk,
+                cluster_m=2,
+            )
+            else 2
+        )
+        seed_config: dict[str, Any] = {
+            "block_sizes": [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                bk,
+            ],
+            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            # L2 grouping matters even under the hardware scheduler: CLC
+            # preserves the interleaved rasterization order it cancels into,
+            # and l2_groupings=[1] costs ~13% at fp16 16384^3 (780 vs 899
+            # TFLOP/s pinned) vs the measured-good [4].
+            "l2_groupings": [4],
+            "tcgen05_cluster_m": 2,
+            "tcgen05_num_epi_warps": 4,
+            "tcgen05_ab_stages": ab_stages,
+            TCGEN05_STRATEGY_CONFIG_KEY: (
+                Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+            ),
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
+                Tcgen05PersistenceModel.CLC_PERSISTENT.value
+            ),
+            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: 1,
+        }
+        if self.config_spec.indexing.length == 3:
+            seed_config["indexing"] = ["tensor_descriptor"] * 3
+        return Config(**seed_config)
+
+    def _plain_edge_deep_ab_stages(self, bk: int) -> int:
+        """Deepest AB pipeline that leaves room for the TMA-store epilogue's
+        C ring on the 256x256 cluster_m=2 tile.
+
+        Overflowing the C ring silently demotes the kernel to the much slower
+        all-SIMT store (ab=6 fits bare AB at bk=64 but not AB + C, and
+        measures far below ab=5 + TMA store), so walk down from the bare-AB
+        maximum until AB + C fits.
+        """
+        ab_stages = self.max_ab_stages_that_fit(
+            bm=TCGEN05_TWO_CTA_BLOCK_M,
+            bn=TCGEN05_TWO_CTA_BLOCK_N,
+            bk=bk,
+            cluster_m=2,
+        )
+        while (
+            ab_stages > TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES
+            and not self.c_stages_fits(
+                bm=TCGEN05_TWO_CTA_BLOCK_M,
+                bn=TCGEN05_TWO_CTA_BLOCK_N,
+                bk=bk,
+                cluster_m=2,
+                ab_stages=ab_stages,
+                c_stages=2,
+                has_source_c=False,
+            )
+        ):
+            ab_stages -= 1
+        return ab_stages
+
+    def _plain_edge_seed_config(self) -> Config | None:
+        """Autotune seed for the plain (no-aux) edge+K-tail cluster_m=2 family.
+
+        The deep-AB edge regime: bk=64 halves per-stage AB SMEM so a 16-bit
+        kernel fits a 5-stage AB pipeline (bf16 5000^3: 948 TFLOP/s vs 815 at
+        the bk=128/ab=2 projection). Partial stripes and the K tail stay
+        clamped TMA boxes; the TMA-store epilogue covers fringe output tiles
+        via descriptor clamping. Seeding also widens the ab-stages fragment
+        via the compiler-seed mechanism so nearby depths stay explorable.
+        """
+        if self.aux_kernel_detected or self.matmul_has_leading_passthrough:
+            return None
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None or not constraints.allow_edge_k_tail_family:
+            return None
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return None
+        fragments = self._matmul_block_fragments()
+        if fragments is None:
+            return None
+        bm_fragment, bn_fragment, bk_fragment = fragments
+        if not (
+            bm_fragment.low <= TCGEN05_TWO_CTA_BLOCK_M
+            and bn_fragment.low <= TCGEN05_TWO_CTA_BLOCK_N
+        ):
+            return None
+        bk = TCGEN05_TWO_CTA_EDGE_K_TAIL_DEEP_BLOCK_K
+        if not (
+            bk_fragment.low <= bk <= bk_fragment.high
+            and self.cluster_m2_bk_is_valid(bk, constraints)
+        ):
+            bk = TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
+            if not (
+                bk_fragment.low <= bk <= bk_fragment.high
+                and self.cluster_m2_bk_is_valid(bk, constraints)
+            ):
+                return None
+        ab_stages = self._plain_edge_deep_ab_stages(bk)
+        if ab_stages <= 0:
+            return None
+        seed_config: dict[str, Any] = {
+            "block_sizes": [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                bk,
+            ],
+            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            "l2_groupings": [4],
+            "tcgen05_cluster_m": 2,
+            "tcgen05_num_epi_warps": 4,
+            "tcgen05_ab_stages": ab_stages,
+        }
+        if self._clc_persistence_search_enabled():
+            # CLC dynamic persistence also wins on the deep-AB edge family
+            # (bf16 5000^3: 883 vs 859 TFLOP/s static, same-GPU pair).
+            seed_config[TCGEN05_STRATEGY_CONFIG_KEY] = (
+                Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+            )
+            seed_config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY] = (
+                Tcgen05PersistenceModel.CLC_PERSISTENT.value
+            )
+            seed_config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 1
+        if self.config_spec.indexing.length == 3:
+            seed_config["indexing"] = ["tensor_descriptor"] * 3
+        return Config(**seed_config)
+
+    def _plain_cluster_n2_seed_config(self) -> Config | None:
+        """Autotune seed for the 4-CTA (cluster 2x2) multicast family.
+
+        B multicast on top of the 2-CTA A multicast halves B traffic, which
+        wins on B-heavy full-tile shapes (fp16 4096x4096x32768: 911 vs 824
+        TFLOP/s); cuBLAS's nvjet picks 2x2 clusters for the same shape. CLC
+        is cluster_n=1-only, so this seeds the static-persistent monolithic
+        family; the search's terminal refinement arbitrates between them.
+        """
+        if self.aux_kernel_detected or self.matmul_has_leading_passthrough:
+            return None
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None or constraints.allow_edge_k_tail_family:
+            return None
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return None
+        fragments = self._matmul_block_fragments()
+        if fragments is None:
+            return None
+        bm_fragment, bn_fragment, bk_fragment = fragments
+        if not (
+            bm_fragment.low <= TCGEN05_TWO_CTA_BLOCK_M <= bm_fragment.high
+            and bn_fragment.low <= TCGEN05_TWO_CTA_BLOCK_N <= bn_fragment.high
+        ):
+            return None
+        bk = bk_fragment.high
+        while bk >= bk_fragment.low:
+            if self.cluster_m2_bk_is_valid(bk, constraints):
+                break
+            bk //= 2
+        else:
+            return None
+        seed_config: dict[str, Any] = {
+            "block_sizes": [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                bk,
+            ],
+            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            "l2_groupings": [4],
+            "tcgen05_cluster_m": 2,
+            "tcgen05_cluster_n": 2,
+            "tcgen05_num_epi_warps": 4,
+            # ab=3 only where the SMEM-budget gate admits it (B200-class
+            # optin); sub-B200 devices keep the known-good ab=2 envelope.
+            "tcgen05_ab_stages": (
+                3 if self.ab_stages_three_search_constraints is not None else 2
+            ),
+        }
+        if self.config_spec.indexing.length == 3:
+            seed_config["indexing"] = ["tensor_descriptor"] * 3
+        return Config(**seed_config)
+
     def _aux_tma_edge_search_enabled(self) -> bool:
         # The TMA aux producer's original admission: the validated Target8-style
         # double-edge + K-tail family with ``cluster_m=2``. The CLC-persistent
@@ -971,6 +1198,15 @@ class CuteTcgen05Config:
 
     def autotune_seed_configs(self) -> list[Config]:
         seeds: list[Config] = []
+        plain_clc_seed = self._plain_clc_seed_config()
+        if plain_clc_seed is not None:
+            seeds.append(plain_clc_seed)
+        plain_edge_seed = self._plain_edge_seed_config()
+        if plain_edge_seed is not None:
+            seeds.append(plain_edge_seed)
+        plain_cluster_n2_seed = self._plain_cluster_n2_seed_config()
+        if plain_cluster_n2_seed is not None:
+            seeds.append(plain_cluster_n2_seed)
         c_input_seed = self._c_input_seed_config()
         if c_input_seed is not None:
             seeds.append(c_input_seed)
@@ -1033,11 +1269,21 @@ class CuteTcgen05Config:
         edge_k_tail_family = constraints.allow_edge_k_tail_family
         is_narrow_clc_aux_tma = self._is_clc_aux_tma_narrow_n_request(config)
         if edge_k_tail_family:
-            block_sizes[k_index] = (
-                TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_K
-                if is_narrow_clc_aux_tma
-                else TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
-            )
+            # Plain (no-aux) kernels may keep a sampled deep-AB bk (the
+            # bk=64/ab=5 family, see _plain_edge_deep_ab_stages); aux kernels
+            # stay projected onto their validated bk=128/256 regimes.
+            sampled_bk = block_sizes[k_index]
+            if not (
+                not self.aux_kernel_detected
+                and isinstance(sampled_bk, int)
+                and not isinstance(sampled_bk, bool)
+                and self.cluster_m2_bk_is_valid(sampled_bk, constraints)
+            ):
+                block_sizes[k_index] = (
+                    TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_BLOCK_K
+                    if is_narrow_clc_aux_tma
+                    else TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
+                )
         bk = block_sizes[k_index]
         if not isinstance(bk, int) or isinstance(bk, bool):
             config["tcgen05_cluster_m"] = 1
@@ -1082,6 +1328,20 @@ class CuteTcgen05Config:
         else:
             block_sizes[n_index] = TCGEN05_TWO_CTA_BLOCK_N
         if edge_k_tail_family:
+            if (
+                not self.aux_kernel_detected
+                and not is_narrow_clc_aux_tma
+                and bk == TCGEN05_TWO_CTA_EDGE_K_TAIL_DEEP_BLOCK_K
+            ):
+                # Plain deep-AB edge family (bk=64): pin the AB depth to the
+                # deepest stage count that still fits next to the TMA-store
+                # epilogue's C ring (the measured winner; bf16 5000^3 runs
+                # 948 TFLOP/s at ab=5 vs 815 for the legacy bk=128/ab=2
+                # projection below). Other knobs keep their sampled values —
+                # the legacy placement overrides were calibrated for the
+                # shallow bk=128 pipeline and measure neutral here.
+                config["tcgen05_ab_stages"] = self._plain_edge_deep_ab_stages(bk)
+                return
             # This family is pinned to measured production stage/pipeline
             # values after search projection.
             # Placement keys remain available for non-edge diagnostic/search
@@ -1927,7 +2187,12 @@ class CuteTcgen05Config:
             config["tcgen05_ab_stages"] = 2
 
     def _fix_with_scheduler_search_config(self, config: dict[str, object]) -> None:
-        if not (self.search_enabled and self.aux_kernel_detected):
+        if not (
+            self.search_enabled
+            and (
+                self.aux_kernel_detected or self._plain_clc_persistence_search_enabled()
+            )
+        ):
             return
         strategy = config.get(TCGEN05_STRATEGY_CONFIG_KEY)
         scheduler_warps = config.get(TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY)
@@ -2042,18 +2307,40 @@ class CuteTcgen05Config:
         )
 
     def _clc_persistence_search_enabled(self) -> bool:
-        """CLC search is the sm100+ slice of the aux-TMA edge+K-tail gate.
+        """CLC (hardware tile-scheduler) persistence search gate, sm100+ only.
 
-        Cycle 46 widened ``_aux_tma_search_enabled`` to also admit the full-tile
-        cluster_m=2 family, but the CLC-persistent perf knobs and validated
-        candidate shape are still scoped to ``_aux_tma_edge_search_enabled``.
+        Two validated families: the aux-TMA edge+K-tail family (its original
+        scope) and the plain full-tile cluster_m=2 family (see
+        ``_plain_clc_persistence_search_enabled``).
         """
-        if not self._aux_tma_edge_search_enabled():
-            return False
         capability = self.config_spec.target_device_capability
         if capability is None:
             return False
-        return capability[0] >= 10 and "flat" in self.allowed_pid_types
+        if capability[0] < 10 or "flat" not in self.allowed_pid_types:
+            return False
+        return (
+            self._aux_tma_edge_search_enabled()
+            or self._plain_clc_persistence_search_enabled()
+        )
+
+    def _plain_clc_persistence_search_enabled(self) -> bool:
+        """Full-tile cluster_m=2 CLC for matmuls without aux operands.
+
+        The CLC scheduler warp replaces the static tile sweep with the
+        hardware tile scheduler, which keeps CTAs fed as tiles finish at
+        uneven rates. On B200 this wins across full-tile shapes (fp16
+        16384^3: 890 vs 738 TFLOP/s; bf16 8192x28672x8192: 956 vs 906; fp16
+        2048x128256x4096: 914 vs 878; fp16 4096^3: 1038 vs 981 — same-GPU
+        probe pairs) and on the deep-AB edge family (bf16 5000^3: 883 vs 859),
+        matching quack's is_dynamic_persistent=True default. The aux families
+        keep their own aux-TMA/CLC regimes.
+        """
+        constraints = self.cluster_m2_search_constraints
+        return (
+            not self.aux_kernel_detected
+            and not self.matmul_has_leading_passthrough
+            and constraints is not None
+        )
 
     def _is_clc_aux_tma_request(self, config: dict[str, object]) -> bool:
         return (
@@ -2140,12 +2427,14 @@ class CuteTcgen05Config:
             )
         ):
             return
-        # FP8 (1-byte) operands fit a deeper AB pipeline than the bf16-tuned
-        # cap of 3; admit ab_stages > 3 for fp8 as long as the AB SMEM fits the
-        # per-CTA budget. This lets Helion emit the same deeply-pipelined
-        # CtaGroup.TWO kernel CUTLASS uses for fp8 compute-bound GEMMs.
+        # Operands whose AB SMEM fits the per-CTA budget can run a deeper AB
+        # pipeline than the historical bk=128-tuned cap of 3: fp8 (1-byte)
+        # always could, and 16-bit operands fit 4-5 stages at bk=64 (worth
+        # ~5-25% on edge shapes where the K-tail already forces bk=64/128).
+        # This lets Helion emit the same deeply-pipelined CtaGroup.TWO kernel
+        # CUTLASS uses for compute-bound GEMMs.
         constraints = self.ab_stages_three_search_constraints
-        if constraints is not None and constraints.dtype_bytes == 1:  # FP8
+        if constraints is not None:
             config_view = self._matmul_config_view(config)
             cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
             if config_view is not None:
@@ -2175,6 +2464,37 @@ class CuteTcgen05Config:
     ) -> bool:
         if not self._clc_persistence_search_enabled():
             return False
+        if self._plain_clc_persistence_search_enabled():
+            # Plain (no-aux) families: scheduler warp only, no C-input warp
+            # (there is no source-C / aux producer to feed). Accept the
+            # full-tile candidate shape or the edge family's projected
+            # cluster_m=2 shape (bm/bn are forced to the 256x256 tile and bk
+            # to a valid edge bk by _fix_cluster_m2_search_config).
+            if not (
+                self._is_validated_cluster_m2_full_tile_search_candidate(config)
+                or self._is_validated_cluster_m2_edge_search_candidate(config)
+            ):
+                return False
+            if config.get("pid_type") != TCGEN05_TWO_CTA_SEED_PID_TYPE:
+                return False
+            if config.get("tcgen05_cluster_n", 1) != 1:
+                return False
+            if (
+                config.get(TCGEN05_STRATEGY_CONFIG_KEY)
+                != Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+                or config.get(TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY) != 1
+                or config.get(TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY, 0) != 0
+            ):
+                return False
+            if self.config_spec.supports_config_key("indexing"):
+                indexing = config.get("indexing")
+                if (
+                    not isinstance(indexing, list)
+                    or indexing
+                    != ["tensor_descriptor"] * self.config_spec.indexing.length
+                ):
+                    return False
+            return True
         if not self._is_validated_cluster_m2_edge_search_candidate(config):
             return False
         if config.get("pid_type") != TCGEN05_TWO_CTA_SEED_PID_TYPE:
@@ -2635,7 +2955,19 @@ class CuteTcgen05Config:
             cluster_m_choices = self.cluster_m_search_choices
         else:
             cluster_m_choices = (1, 2)
-        cluster_n_choices: tuple[int, ...] = (1,) if for_search else (1, 2)
+        # cluster_n=2 (the Quack-canonical 4-CTA cluster: B multicast on top
+        # of the 2-CTA A multicast) is searchable on full-tile shapes — it
+        # wins big on B-heavy problems (fp16 4096x4096x32768: 911 vs 824
+        # TFLOP/s) and cuBLAS's nvjet picks 2x2 clusters for the same shape.
+        # Edge/K-tail shapes keep the (1,) surface: their double-edge SIMT
+        # epilogue and CLC scheduler broadcast are cluster_n=1-only.
+        cluster_n_full_tile_searchable = (
+            self.cluster_m2_search_constraints is not None
+            and not self.cluster_m2_search_constraints.allow_edge_k_tail_family
+        )
+        cluster_n_choices: tuple[int, ...] = (
+            (1, 2) if not for_search or cluster_n_full_tile_searchable else (1,)
+        )
         if for_search and self.num_epi_warps_search_choices is not None:
             num_epi_warps_fragment: ConfigSpecFragment = EnumFragment(
                 self.num_epi_warps_search_choices
@@ -2673,16 +3005,17 @@ class CuteTcgen05Config:
             # sampled ab=3 that does not fit (the residual/source-C ring overflows;
             # cluster_m=1 256x256 overflows bare-AB) before codegen, so admission is
             # free but an overflowing kernel is never generated.
-            ab_stages_max = 3
-            # FP8 (1-byte) operands fit a deeper AB pipeline; widen the
-            # validation range so an explicit deep-staged fp8 config is
-            # accepted (``_validate_direct_entry_ab_stage_envelope`` clamps it to
-            # the actual per-CTA SMEM budget for the chosen block sizes).
+            # Search up to the dtype's hardware-validated stage cap (6 for
+            # 16-bit, 12 for fp8): smaller K tiles (bk=64) fit deep AB
+            # pipelines that win on edge shapes (bf16 5000^3: ab=5/bk=64 at
+            # 948 TFLOP/s vs the ab=2/bk=128 seed's 815), and the
+            # budget-aware ``_validate_direct_entry_ab_stage_envelope``
+            # fix-invalid pass clamps any sampled depth to the per-CTA SMEM
+            # fit for the chosen block sizes, so over-deep samples degrade to
+            # the old behavior instead of overflowing.
             constraints = self.ab_stages_three_search_constraints
-            if constraints is not None and constraints.dtype_bytes == 1:  # FP8
-                ab_stages_max = self._get_dtype_ab_stages_hard_cap(
-                    constraints.dtype_bytes
-                )
+            assert constraints is not None
+            ab_stages_max = self._get_dtype_ab_stages_hard_cap(constraints.dtype_bytes)
         else:
             ab_stages_max = 2
         if for_search:
@@ -2943,6 +3276,17 @@ class CuteTcgen05Config:
             )
             scheduler_warps_choices: tuple[int, ...] = (0, 1)
             c_input_warps_choices: tuple[int, ...] = (0, 1)
+        elif self._plain_clc_persistence_search_enabled():
+            # Plain full-tile cluster_m=2 matmuls search the scheduler-warp
+            # strategy too (its CLC dynamic persistence wins on large grids;
+            # see _plain_clc_persistence_search_enabled). No C-input warp:
+            # there is no aux/source-C producer to host.
+            strategy_choices = (
+                Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+                Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+            )
+            scheduler_warps_choices = (0, 1)
+            c_input_warps_choices = (0,)
         else:
             strategy_choices = (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,)
             scheduler_warps_choices = (0,)
@@ -3182,10 +3526,18 @@ class CuteTcgen05Config:
                 config, fix_invalid=fix_invalid
             )
         else:
-            for key in optional_fragments:
+            for key, fragment in optional_fragments.items():
                 if key not in config:
                     continue
-                if fix_invalid:
+                # Cross-shape config reuse (``Kernel.configs`` pinning, the
+                # autotune cache) legitimately carries default-valued tcgen05
+                # keys tuned on a tcgen05-capable bind onto binds that are not
+                # (e.g. a unit-sized M); inert defaults are dropped. Values
+                # that encode a real tcgen05 strategy still fail loudly — the
+                # config cannot be honored and silently changing strategy
+                # could mask a miscompute (see
+                # ``test_batched_two_cta_partial_edge_tiles_rejected``).
+                if fix_invalid or config[key] == fragment.default():
                     config.pop(key, None)
                 else:
                     raise InvalidConfig(
@@ -3200,7 +3552,15 @@ class CuteTcgen05Config:
             ):
                 if key not in config:
                     continue
-                if fix_invalid:
+                strategy_fragment = strategy_validation_fragments.get(key)
+                default_value = (
+                    strategy_fragment.default()
+                    if strategy_fragment is not None
+                    # The layout-override keys have no fragment here; ``None``
+                    # is their inert value.
+                    else None
+                )
+                if fix_invalid or config[key] == default_value:
                     config.pop(key, None)
                 else:
                     raise InvalidConfig(

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -37,6 +37,10 @@ TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM = 4096
 TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K = 128
 TCGEN05_TWO_CTA_EDGE_K_TAIL_AB_STAGES = 2
 TCGEN05_TWO_CTA_EDGE_K_TAIL_ACC_STAGES = 1
+# Half-depth K tile for the deep-AB edge family: bk=64 halves the per-stage
+# AB SMEM so 16-bit operands fit a 5-stage AB pipeline within the B200 budget
+# (bf16 5000^3 measures 948 vs 815 TFLOP/s against the bk=128 edge seed).
+TCGEN05_TWO_CTA_EDGE_K_TAIL_DEEP_BLOCK_K = 64
 # The post row-vector-staging Target8 CLC + aux-TMA edge rows now measure
 # fastest with two accumulator stages. Keep the historical edge-family default
 # above for non-CLC/non-aux variants. Narrow-N keeps a separate value above.
@@ -711,3 +715,28 @@ def tcgen05_grouped_worklist_smem_bytes(
         c_stages=c_stages,
     )
     return _append_aligned_tcgen05_smem(offset, c_smem_bytes, 1024)
+
+
+def tcgen05_l2_grouping_cluster_consistent(
+    *,
+    l2_grouping: int,
+    num_pid_m: int,
+    num_pid_n: int,
+    cluster_n: int,
+) -> bool:
+    """Whether Helion's l2_groupings remap preserves cluster-N peer pairing.
+
+    The CUTLASS persistent scheduler hands the two cluster-N peers the same
+    tile_m and adjacent tile_n, i.e. linear tile ids exactly ``num_pid_m``
+    apart. Helion's grouped decode permutes the flat id space in rows of
+    ``l2_grouping * num_pid_n``; a pair stays consistent (same decoded
+    tile_m) only when every pair sits inside one row —
+    ``cluster_n * num_pid_m`` must divide the row length — and the last
+    group must not shrink (``l2_grouping`` divides ``num_pid_m``).
+    """
+    if cluster_n <= 1 or l2_grouping <= 1:
+        return True
+    effective_group = min(l2_grouping, num_pid_m)
+    if num_pid_m % effective_group != 0:
+        return False
+    return (effective_group * num_pid_n) % (cluster_n * num_pid_m) == 0

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -460,13 +460,20 @@ def _plan_cute_tcgen05_search_candidate(
     m_hint = static_m if static_m is not None else env.size_hint(m)
     n_hint = static_n if static_n is not None else env.size_hint(n)
     k_hint = static_k if static_k is not None else env.size_hint(k)
+    from .._compiler.cute.mma_support import cute_fp32_dot_uses_tf32
+
     is_fp8 = lhs.dtype == torch.float8_e4m3fn
-    mma_k = 32 if is_fp8 else 16
-    min_tcgen05_n = 16 if is_fp8 else 8
+    is_tf32 = lhs.dtype == torch.float32 and cute_fp32_dot_uses_tf32()
+    mma_k = 32 if is_fp8 else (8 if is_tf32 else 16)
+    # tf32's bn >= 32 floor mirrors _mma_impl_matches_problem_shape.
+    min_tcgen05_n = 16 if is_fp8 else (32 if is_tf32 else 8)
     is_small_n = static_n is not None and static_n < min_tcgen05_n
     if (
         env.backend_name != "cute"
-        or lhs.dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
+        or (
+            lhs.dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
+            and not is_tf32
+        )
         or rhs.dtype != lhs.dtype
         or m_hint < 64
         # Size-one tile axes are fixed to block size one before this analysis,
@@ -489,7 +496,9 @@ def _plan_cute_tcgen05_search_candidate(
     from .._compiler.cute.mma_support import get_cute_mma_support
 
     support = get_cute_mma_support()
-    if not (support.tcgen05_f8 if is_fp8 else support.tcgen05_f16bf16):
+    from .._compiler.cute.mma_support import tcgen05_supports_input_dtype
+
+    if not tcgen05_supports_input_dtype(support, lhs.dtype):
         return reject()
 
     def pow2_floor_at_least(value: int, minimum: int) -> int:

--- a/helion/runtime/cute/launcher.py
+++ b/helion/runtime/cute/launcher.py
@@ -837,6 +837,14 @@ def _append_cute_wrapper_plan(
     cluster_n = plan_int("cluster_n", 1)
     input_dtype = str(plan["input_dtype"])
     acc_dtype = str(plan["acc_dtype"])
+    # fp32 GMEM operands run the MMA as tf32: the A/B cute tensors keep their
+    # torch-derived Float32 element type, and the TMA descriptors recast to
+    # the plan's TFloat32 via ``internal_type`` (both are 4 bytes wide, so the
+    # SMEM layout/byte math is unchanged). Mirrors quack's gemm_sm100 fp32
+    # handling.
+    tma_internal_type_arg = (
+        ", internal_type=cutlass.TFloat32" if input_dtype == "cutlass.TFloat32" else ""
+    )
     ab_stage_count = plan_int("ab_stage_count", 2)
     # Optional ``smem_swizzle_*`` overrides recorded by the device-side
     # codegen when the user opts into a non-default A/B SMEM atom
@@ -1113,6 +1121,7 @@ def _append_cute_wrapper_plan(
                 f"cute.slice_({smem_a_layout}, (None, None, None, 0)), "
                 f"({bm}, {bn}, {bk}), {tiled_mma}"
                 + (f", {cluster_layout_vmnk}.shape" if cluster_n > 1 else "")
+                + tma_internal_type_arg
                 + ")"
             ),
             # See the asymmetry comment above ``make_tiled_tma_atom_A``
@@ -1124,7 +1133,8 @@ def _append_cute_wrapper_plan(
                 f"{cluster_shape}, {tiled_mma}.thr_id), "
                 f"{rhs_tma}, "
                 f"cute.slice_({smem_b_layout}, (None, None, None, 0)), "
-                f"({bm}, {bn}, {bk}), {tiled_mma}, {cluster_layout_vmnk}.shape)"
+                f"({bm}, {bn}, {bk}), {tiled_mma}, {cluster_layout_vmnk}.shape"
+                f"{tma_internal_type_arg})"
             ),
         )
     )

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -294,7 +294,13 @@ class _CompilerSeedSpecializationExtractor:
 
     def for_device(self, device: torch.device) -> Hashable:
         from . import get_num_sm
+        from .settings import is_pallas_interpret
 
+        if device.type == "cpu" and not is_pallas_interpret():
+            # CPU tensors bound on a GPU backend (e.g. type-propagation debug
+            # binds) have no SM count and can never launch; any stable key
+            # keeps the specialization cache coherent.
+            return self.fact, 0
         if self.fact == "device_num_sm":
             return self.fact, get_num_sm(device)
         assert self.fact == "config_num_sm"

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -8386,12 +8386,13 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             for_search=True
         )["tcgen05_ab_stages"]
         self.assertIsInstance(search_ab_stages_fragment, IntegerFragment)
-        # Cycle 97: the for_search ab cap is BUDGET-AWARE — lifted to 3 wherever
-        # ab=3 is admissible (the SMEM-budget constraints were recorded at bind
-        # time, i.e. bf16/fp16 on a B200-class optin cap), else 2. Conditioning on
-        # the recorded constraints keeps the assertion deterministic across hosts.
+        # The for_search ab cap is BUDGET-AWARE — lifted to the 16-bit hard cap
+        # (6) wherever deep AB is admissible (the SMEM-budget constraints were
+        # recorded at bind time, i.e. bf16/fp16 on a B200-class optin cap),
+        # else 2. Conditioning on the recorded constraints keeps the assertion
+        # deterministic across hosts.
         expected_search_ab_high = (
-            3
+            6
             if bound.config_spec._cute_tcgen05_config.ab_stages_three_search_constraints
             is not None
             else 2
@@ -10133,11 +10134,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertTrue(residual_tcfg.aux_kernel_detected)
         self.assertTrue(residual_tcfg.exact_shape_aux_kernel_detected)
 
-        # The for_search ab fragment is lifted to 3 (the budget was recorded at
-        # bind via the mocked B200 cap) for every family.
+        # The for_search ab fragment is lifted to the 16-bit hard cap (the
+        # budget was recorded at bind via the mocked B200 cap) for every
+        # family; sampled depths are budget-clamped at fix-invalid time.
         for tcfg in (plain_tcfg, bias_tcfg, residual_tcfg):
             ab_fragment = tcfg.optional_fragments(for_search=True)["tcgen05_ab_stages"]
-            self.assertEqual(ab_fragment.high, 3)
+            self.assertEqual(ab_fragment.high, 6)
 
         def _ab3_config(cluster_m: int = 2) -> helion.Config:
             return helion.Config(

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -3624,9 +3624,14 @@ class TestCuteLowerings(unittest.TestCase):
         )
         bound = cute_matmul_role_local_monolithic_4096_bf16.bind(args)
         bound.env.config_spec.cute_tcgen05_search_enabled = True
+        # fp32 operands historically forced the non-tcgen05 fallback (the
+        # "requires active-K-loop tcgen05 MMA lowering" rejection); with the
+        # tf32 tcgen05 path they instead reach the flat-role guard, which
+        # rejects them for being outside the 16-bit guarded family. Either
+        # way flat_role_coordinates=True must fail loudly for this config.
         with self.assertRaisesRegex(
             exc.BackendUnsupported,
-            r"requires active-K-loop tcgen05 MMA lowering",
+            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY,
         ):
             bound.to_triton_code(cfg)
 
@@ -17768,7 +17773,16 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         self.assertNotIn("tcgen05_edge_src = cute.logical_divide(", code)
 
     def test_aux_tma_mode_without_aux_keeps_full_edge_store_split(self) -> None:
-        """A stale aux-TMA config key alone does not enable partial TMA stores."""
+        """A no-aux edge kernel stores every tile through the clamping TMA path.
+
+        Historically the partial-output TMA store was admitted only for the
+        productive aux-TMA family and this test pinned the hybrid
+        full-tile/SIMT-fringe split for a stale aux-TMA key without aux
+        operands. With no aux GMEM operands there is nothing to read out of
+        bounds, so the D descriptor's clamping now covers fringe tiles too:
+        the kernel must NOT emit the hybrid dispatch or the SIMT edge-copy
+        fallback.
+        """
 
         @helion.kernel(backend="cute")
         def cute_matmul_no_aux(
@@ -17810,8 +17824,8 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
 
         self.assertNotIn("'kind': 'tcgen05_aux_tma'", code)
         self.assertIn("'kind': 'tcgen05_d_tma'", code)
-        self.assertIn("if tcgen05_full_tile:", code)
-        self.assertIn("tcgen05_edge_src = cute.logical_divide(", code)
+        self.assertNotIn("if tcgen05_full_tile:", code)
+        self.assertNotIn("tcgen05_edge_src = cute.logical_divide(", code)
 
     def test_aux_tma_partial_store_keeps_guard_for_unaligned_rowvec_tail(
         self,
@@ -19675,11 +19689,19 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             bound = cute_matmul_pure.bind(args)
         self.assertFalse(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
         frags = bound.env.config_spec._tcgen05_strategy_autotune_fragments()
+        # Pure matmuls on a full-tile cluster_m=2 shape now search the
+        # scheduler-warp strategy too (its CLC dynamic persistence is the
+        # plain-matmul family; see _plain_clc_persistence_search_enabled),
+        # but the C-input warp surface stays narrowed to 0: with no aux /
+        # source-C operand there is nothing for that warp to produce.
         self.assertEqual(
             frags["tcgen05_strategy"].choices,
-            (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,),
+            (
+                Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+                Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+            ),
         )
-        self.assertEqual(frags["tcgen05_warp_spec_scheduler_warps"].choices, (0,))
+        self.assertEqual(frags["tcgen05_warp_spec_scheduler_warps"].choices, (0, 1))
         self.assertEqual(frags["tcgen05_warp_spec_c_input_warps"].choices, (0,))
 
     def test_aux_autotune_surface_does_not_narrow_for_multistore_fanout(

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -24,6 +24,9 @@ from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
 from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_TWO_CTA_EDGE_K_TAIL_DEEP_BLOCK_K,
+)
+from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M,
 )
 from helion._compiler.cute.tcgen05_constants import (
@@ -908,13 +911,14 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(constraints.per_cta_smem_budget_bytes, b200_budget_bytes)
 
         search_fragments = spec._tcgen05_optional_fragments(for_search=True)
-        # Cycle 97: ab=3 is BUDGET-AWARE-SEARCHABLE — the for_search cap is lifted
-        # to 3 wherever the SMEM-budget constraints were recorded (here: the mocked
-        # B200 budget), so the autotuner can SAMPLE ab=3 directly. A sampled ab=3
-        # that does not fit is then demoted by ``_fix_ab_stages_search_config`` (the
-        # over-budget cases below). The validation surface is independently 3 for
-        # explicit configs.
-        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 3)
+        # Where the SMEM-budget constraints were recorded (here: the mocked B200
+        # budget), the for_search cap is lifted to the dtype's hardware-validated
+        # stage cap (6 for 16-bit) so the autotuner can SAMPLE deep-AB pipelines
+        # (bk=64/ab=5 wins on edge shapes) directly. A sampled depth that does
+        # not fit is then demoted by ``_fix_ab_stages_search_config`` /
+        # budget-clamped by ``_validate_direct_entry_ab_stage_envelope`` (the
+        # over-budget cases below).
+        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 6)
         validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
         # 16-bit 4096^3 is FFI-eligible (fp16 == bf16 parity), so the validation
         # surface admits the deeper FFI direct-entry stage tuples — up to ab=6
@@ -1008,10 +1012,15 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         # round-trip even on a device the gate is off for.
         validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
         self.assertEqual(validation_fragments["tcgen05_ab_stages"].high, 3)
-        # The cluster_m2 seed exists but does *not* carry ab=3.
+        # The full-tile cluster_m=2 family now seeds three configs (the
+        # canonical static-persistent seed, the CLC dynamic-persistence
+        # scheduler seed, and the 4-CTA cluster_n=2 seed) — none of which may
+        # carry ab=3 when the gate is off.
         seeds = spec.compiler_seed_configs
-        self.assertEqual(len(seeds), 1)
+        self.assertEqual(len(seeds), 3)
         self.assertNotIn("tcgen05_ab_stages", seeds[0].config)
+        for seed in seeds:
+            self.assertNotEqual(seed.config.get("tcgen05_ab_stages"), 3)
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_ab_stages_three_uses_analyzed_block_indices(
@@ -1035,7 +1044,8 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                 )
             self.assertIsNotNone(spec._tcgen05_ab_stages_three_search_constraints)
             search_fragments = spec._tcgen05_optional_fragments(for_search=True)
-            self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 3)
+            # Constraints recorded -> search cap is the 16-bit hard cap.
+            self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 6)
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_ab_stages_three_seeded_in_initial_population(
@@ -1614,7 +1624,15 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                 constraints,
             )
         )
-        self.assertFalse(spec._tcgen05_cluster_m2_bk_is_valid(64, constraints))
+        # The deep-AB family admits bk=64 on the edge/K-tail family; other
+        # K tiles stay out of the validated set.
+        self.assertTrue(
+            spec._tcgen05_cluster_m2_bk_is_valid(
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_DEEP_BLOCK_K,
+                constraints,
+            )
+        )
+        self.assertFalse(spec._tcgen05_cluster_m2_bk_is_valid(32, constraints))
 
     def test_tcgen05_edge_tile_detection_skips_unknown_dims(self) -> None:
         config_spec = SimpleNamespace(
@@ -1854,7 +1872,15 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                 constraints,
             )
         )
-        self.assertFalse(spec._tcgen05_cluster_m2_bk_is_valid(64, constraints))
+        # The deep-AB family admits bk=64 on the edge/K-tail family; other
+        # K tiles stay out of the validated set.
+        self.assertTrue(
+            spec._tcgen05_cluster_m2_bk_is_valid(
+                TCGEN05_TWO_CTA_EDGE_K_TAIL_DEEP_BLOCK_K,
+                constraints,
+            )
+        )
+        self.assertFalse(spec._tcgen05_cluster_m2_bk_is_valid(32, constraints))
 
     def test_restrict_tcgen05_num_epi_warps_search_helper(self) -> None:
         """Direct unit test for ``restrict_tcgen05_num_epi_warps_search``.

--- a/test/test_epilogue_subtiling.py
+++ b/test/test_epilogue_subtiling.py
@@ -279,8 +279,13 @@ class TestEpilogueSubtiling(TestCase):
         _, out_s4 = code_and_output(
             matmul_with_bias, args, block_sizes=[64, 64, 64], epilogue_subtile=4
         )
-        torch.testing.assert_close(out_none, out_s2, atol=1e-5, rtol=1e-5)
-        torch.testing.assert_close(out_none, out_s4, atol=1e-5, rtol=1e-5)
+        # The subtile variants must agree bit-tightly with each other: subtiling
+        # only splits the store. The no-subtile config may take a different MMA
+        # lowering (on cute, fp32 without epilogue_subtile runs tcgen05 as tf32
+        # while subtile configs keep the exact SIMT lowering), so it is compared
+        # at tf32-friendly tolerance instead.
+        torch.testing.assert_close(out_s2, out_s4, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(out_none, out_s2, atol=1e-1, rtol=1e-2)
 
     @onlyBackends("triton")
     @skipIfRefEager("test checks generated backend code")


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3544
 * #3532
 * #3531
 * #3530
 * __->__#3529
 * #3528
 * #3527


--- --- ---

[cutedsl] tcgen05 matmul: fp32-as-tf32, CLC dynamic persistence, clamped-TMA edges, deep-AB bk=64, 4-CTA clusters

Matmul hillclimb backend work (B200, benchmarks/cute/matmul_plan.md has the
measurement narrative; all wins verified by cold full autotunes + interleaved
ABAB runs):

1. fp32 matmul on the tensor cores as tf32 when settings.dot_precision maps
   to 'tf32' (Helion's default, matching triton tl.dot): MmaTF32Op via
   make_trivial_tiled_mma(TFloat32) with MMA-K=8, GMEM stays Float32 and the
   TMA descriptors recast via internal_type, budget math keys on itemsize.
   dot_precision='ieee'/'tf32x3' keep the exact SIMT lowering. tf32 tcgen05
   is floored at bn>=32: the CUTLASS narrow-N epilogue helpers corrupt
   (128, 8|16) tf32 tiles, and bn is power-of-two so 32 closes the unsafe
   set. fp32 4096^3: 0.01x -> 0.99x of the best baseline (cuBLAS tf32).

2. CLC (hardware tile scheduler) dynamic persistence opens to plain matmuls:
   full-tile and edge cluster_m=2 families under ROLE_LOCAL_WITH_SCHEDULER +
   one scheduler warp, matching quack's is_dynamic_persistent default.
   Same-GPU pairs: fp16 16384^3 890 vs 738 static; bf16 8192x28672x8192 956
   vs 906; fp32-tf32 4096^3 522 vs 488. Compiler seeds (256x256, l2
   grouping 4) keep the family in the population and the widened fragments
   explorable; pure-matmul strategy surface widens accordingly.

3. Predicate-free clamped-TMA edge handling: epilogues with no aux GMEM
   operands store every output tile through the bounds-checked TMA store
   (fringe tiles leave the per-thread SIMT store), and the role-local edge/
   K-tail families take the K-loop fast path - the persistent scheduler only
   publishes in-grid tiles and partial stripes/K tails are clamping TMA
   boxes, so the slow path's per-iteration predicates are constant-true.
   Aux kernels keep the predicated path (their hybrid store protocol
   requires it). K-tail-only cost drops from -17% to -8%.

4. Deep-AB bk=64 edge family: budget-driven admission replaces two flat
   caps (the TMA-store epilogue's ab<=2 gate becomes c_stages_fits; the
   ab>3 validation exception widens from fp8-only to any dtype fitting the
   per-CTA budget), the search's AB cap lifts to the dtype hard cap with
   budget-aware clamping, and the edge family admits bk=64 with a deepest-
   fit seed. bf16 5000^3: 686 -> 846 TFLOP/s cold-autotuned.

5. cluster_n=2 (4-CTA clusters, B-heavy shapes; nvjet picks 2x2 for the
   same shapes) becomes searchable + seeded on full-tile shapes and legal on
   the edge families. Root-caused and gated a PRE-EXISTING silent-wrong-
   output bug: Helion's l2_groupings remap permutes the linear tile index
   per-CTA without cluster awareness, so cluster-N peers can decode
   different tile_m and the A multicast fills SMEM halves with the wrong A
   tile (max rel err ~1.4). Codegen now rejects configs unless every N-pair
   provably stays inside one L2 group row
   (tcgen05_l2_grouping_cluster_consistent; predicate matches the 9-shape
   empirical correct/wrong split). fp16 4096x4096x32768: 911 vs 824.

Test updates: the pure-matmul autotune-surface pin widens to the scheduler
strategy, fp32 flat_role rejection reaches the 16-bit-family guard (fp32 is
tcgen05-capable now), and the no-aux edge store pin asserts the all-TMA
epilogue.