### PR TITLE
[cutedsl] Cluster-aware l2_groupings decode for tcgen05 cluster_n=2

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -154,7 +154,6 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
 from .tcgen05_constants import resolve_tcgen05_grouped_worklist_mma_profile
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_grouped_worklist_smem_bytes
-from .tcgen05_constants import tcgen05_l2_grouping_cluster_consistent
 from .tcgen05_lifecycle import Tcgen05LifecycleContext
 from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
@@ -7292,25 +7291,22 @@ def _emit_mma_pipeline(
         tcgen05_cluster_n = 1
     else:
         tcgen05_cluster_n = tcgen05_cluster_n_requested
-    if tcgen05_cluster_n > 1 and not tcgen05_l2_grouping_cluster_consistent(
-        l2_grouping=_l2_grouping_value(df.config),
-        num_pid_m=(m_size + bm - 1) // bm,
-        num_pid_n=(n_size + bn - 1) // bn,
-        cluster_n=tcgen05_cluster_n,
-    ):
-        # Helion's l2_groupings remap permutes the linear tile index per-CTA
-        # without cluster awareness: the two cluster-N peers (vpids exactly
-        # num_pid_m apart) can decode DIFFERENT tile_m, and the A multicast
-        # then fills each peer's SMEM half with the wrong A tile (silent
-        # corruption, max rel err ~1.4). Reject the config unless the remap
-        # provably keeps every N-pair inside one L2 group row.
+    if tcgen05_cluster_n > 1 and ((n_size + bn - 1) // bn) % tcgen05_cluster_n != 0:
+        # The CUTLASS persistent scheduler builds its cluster grid with
+        # ceil_div and reports work validity at CLUSTER granularity, so
+        # when the N tile count is not divisible by cluster_n the padded
+        # trailing cluster hands its second CTA an out-of-range tile_n
+        # marked valid — an unmasked out-of-bounds store on the full-tile
+        # TMA path. (The l2_groupings remap itself is cluster-aware — see
+        # ``L2GroupingProgramIDs.codegen`` — so any grouping is fine on
+        # divisible grids.)
         raise exc.BackendUnsupported(
             "cute",
-            "tcgen05_cluster_n=2 with this l2_grouping/grid combination breaks "
-            "the cluster-N peer pairing that the A multicast requires "
-            "(cluster_n * num_pid_m must divide l2_grouping * num_pid_n, and "
-            "l2_grouping must divide num_pid_m). Use l2_groupings=[1] or "
-            "tcgen05_cluster_n=1 for this shape.",
+            "tcgen05_cluster_n=2 requires the N tile count (cdiv(N, block_n)) "
+            "to be divisible by cluster_n; the persistent scheduler would "
+            "otherwise pad a partial cluster whose trailing CTA computes an "
+            "out-of-range tile. Use tcgen05_cluster_n=1 or a block_n that "
+            "gives an even N tile count.",
         )
     tcgen05_role_local_k_tail_tma = (
         tcgen05_preserve_tma_for_two_cta_k_tail
@@ -12513,15 +12509,6 @@ def _tcgen05_use_2cta_instrs(
         return True
     is_fp8 = input_dtype == torch.float8_e4m3fn or input_dtype == "cutlass.Float8E4M3FN"
     return bm == 128 and is_fp8
-
-
-def _l2_grouping_value(config: object) -> int:
-    groupings = getattr(config, "config", config)
-    if isinstance(groupings, dict):
-        groupings = groupings.get("l2_groupings")
-    if isinstance(groupings, list) and groupings and isinstance(groupings[0], int):
-        return groupings[0]
-    return 1
 
 
 def _tcgen05_epi_warp_count(

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -715,28 +715,3 @@ def tcgen05_grouped_worklist_smem_bytes(
         c_stages=c_stages,
     )
     return _append_aligned_tcgen05_smem(offset, c_smem_bytes, 1024)
-
-
-def tcgen05_l2_grouping_cluster_consistent(
-    *,
-    l2_grouping: int,
-    num_pid_m: int,
-    num_pid_n: int,
-    cluster_n: int,
-) -> bool:
-    """Whether Helion's l2_groupings remap preserves cluster-N peer pairing.
-
-    The CUTLASS persistent scheduler hands the two cluster-N peers the same
-    tile_m and adjacent tile_n, i.e. linear tile ids exactly ``num_pid_m``
-    apart. Helion's grouped decode permutes the flat id space in rows of
-    ``l2_grouping * num_pid_n``; a pair stays consistent (same decoded
-    tile_m) only when every pair sits inside one row —
-    ``cluster_n * num_pid_m`` must divide the row length — and the last
-    group must not shrink (``l2_grouping`` divides ``num_pid_m``).
-    """
-    if cluster_n <= 1 or l2_grouping <= 1:
-        return True
-    effective_group = min(l2_grouping, num_pid_m)
-    if num_pid_m % effective_group != 0:
-        return False
-    return (effective_group * num_pid_n) % (cluster_n * num_pid_m) == 0

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -889,22 +889,75 @@ class L2GroupingProgramIDs(ProgramIDs):
             inner_2d_assignments.append((inner_2d_pid, pid))
 
         assignments.extend(inner_2d_assignments)
-        assignments.extend(
-            [
-                (num_pid_in_group, f"{self.group_size} * {num_pid_n}"),
-                (group_id, f"{inner_2d_pid} // {num_pid_in_group}"),
-                (first_pid_m, f"{group_id} * {self.group_size}"),
-                (group_size_m, f"min({num_pid_m} - {first_pid_m}, {self.group_size})"),
-                (
-                    parent_pids[fastest_m_idx].pid_var,
-                    f"{first_pid_m} + (({inner_2d_pid} % {num_pid_in_group}) % {group_size_m})",
-                ),
-                (
-                    parent_pids[fastest_n_idx].pid_var,
-                    f"({inner_2d_pid} % {num_pid_in_group}) // {group_size_m}",
-                ),
-            ]
-        )
+        cluster_n = self._decode_cluster_n()
+        if cluster_n > 1:
+            # Cluster-aware grouped decode (tcgen05 cluster_n > 1). The
+            # CUTLASS persistent scheduler hands the ``cluster_n`` CTAs
+            # paired along the cluster's N axis the same tile_m and
+            # consecutive tile_n — virtual pids exactly ``num_pid_m``
+            # apart — and the A multicast fills every peer's SMEM half
+            # from one TMA load issued for that shared tile_m. The plain
+            # grouped decode below permutes each CTA's virtual pid
+            # independently, so peers can decode DIFFERENT tile_m and
+            # silently corrupt the multicast. Decode at cluster-box
+            # granularity instead ((1 M tile) x (cluster_n N tiles)):
+            # peers collapse to one box pid, the grouped raster permutes
+            # whole boxes, and the within-box lane recovers each peer's
+            # N tile. Reduces to the plain decode at cluster_n=1.
+            lane_n = new_var("cluster_lane_n", dce=True)
+            box_pid = new_var("cluster_box_pid", dce=True)
+            num_box_n = new_var("num_cluster_box_n", dce=True)
+            assignments.extend(
+                [
+                    (lane_n, f"({inner_2d_pid} // {num_pid_m}) % {cluster_n}"),
+                    (
+                        box_pid,
+                        (
+                            f"(({inner_2d_pid} // {num_pid_m}) // {cluster_n})"
+                            f" * {num_pid_m} + {inner_2d_pid} % {num_pid_m}"
+                        ),
+                    ),
+                    (num_box_n, f"({num_pid_n} + {cluster_n - 1}) // {cluster_n}"),
+                    (num_pid_in_group, f"{self.group_size} * {num_box_n}"),
+                    (group_id, f"{box_pid} // {num_pid_in_group}"),
+                    (first_pid_m, f"{group_id} * {self.group_size}"),
+                    (
+                        group_size_m,
+                        f"min({num_pid_m} - {first_pid_m}, {self.group_size})",
+                    ),
+                    (
+                        parent_pids[fastest_m_idx].pid_var,
+                        f"{first_pid_m} + (({box_pid} % {num_pid_in_group}) % {group_size_m})",
+                    ),
+                    (
+                        parent_pids[fastest_n_idx].pid_var,
+                        (
+                            f"(({box_pid} % {num_pid_in_group}) // {group_size_m})"
+                            f" * {cluster_n} + {lane_n}"
+                        ),
+                    ),
+                ]
+            )
+        else:
+            assignments.extend(
+                [
+                    (num_pid_in_group, f"{self.group_size} * {num_pid_n}"),
+                    (group_id, f"{inner_2d_pid} // {num_pid_in_group}"),
+                    (first_pid_m, f"{group_id} * {self.group_size}"),
+                    (
+                        group_size_m,
+                        f"min({num_pid_m} - {first_pid_m}, {self.group_size})",
+                    ),
+                    (
+                        parent_pids[fastest_m_idx].pid_var,
+                        f"{first_pid_m} + (({inner_2d_pid} % {num_pid_in_group}) % {group_size_m})",
+                    ),
+                    (
+                        parent_pids[fastest_n_idx].pid_var,
+                        f"({inner_2d_pid} % {num_pid_in_group}) // {group_size_m}",
+                    ),
+                ]
+            )
 
         # Process remaining dimensions (if any) using standard decomposition
         for i in range(2, num_dims):
@@ -928,6 +981,29 @@ class L2GroupingProgramIDs(ProgramIDs):
             *statements,
             *state.codegen.statements_stack[-1],
         ]
+
+    def _decode_cluster_n(self) -> int:
+        """The cluster-N width the grouped decode must respect.
+
+        Only the tcgen05 persistent scheduler pairs CTAs along a cluster N
+        axis (A-multicast peers must decode the same tile_m). This runs at
+        grid-lowering time, before the tcgen05 matmul plan is registered,
+        so ``_tcgen05_cluster_n`` reads the config knob. Safe because the
+        pid strategy and the mma lowering derive the tcgen05 choice from
+        the same ``_kernel_specialized_mma_impl`` probe: when this parent
+        is ``Tcgen05PersistentProgramIDs`` and the kernel compiles, the
+        launch uses the knob's cluster_n — cute_mma raises
+        ``BackendUnsupported`` on the tcgen05 cluster_n demotion paths,
+        and a late non-tcgen05 fallback never registers a matmul plan,
+        which the tcgen05 persistent layout asserts on before any launch.
+        The padding gate in cute_mma (N tile count divisible by
+        cluster_n) keeps the box decode a bijection over in-range tiles
+        for every launchable grid.
+        """
+        parent = self.parent_strategy
+        if isinstance(parent, Tcgen05PersistentProgramIDs):
+            return parent._tcgen05_cluster_n()
+        return 1
 
     @property
     def virtual_program_id(self) -> str:
@@ -1585,7 +1661,39 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         virtual_pid = self._tcgen05_linear_virtual_pid_expr(work_tile_var)
         num_pid_m = m_pid.num_pids_expr(is_device=True)
         l2_group = l2_grouping()
-        if l2_group > 1:
+        cluster_n = self._tcgen05_cluster_n()
+        if l2_group > 1 and cluster_n > 1:
+            # Mirror ``L2GroupingProgramIDs.codegen``'s cluster-aware box
+            # decode exactly: the predicate must classify tiles by the same
+            # post-remap (pid_m, pid_n) the consumer decodes, or grouped PID
+            # order sends fringe tiles down the full-tile TMA-store path.
+            num_pid_n = n_pid.num_pids_expr(is_device=True)
+            lane_n = (
+                f"((({virtual_pid}) // ({num_pid_m})) % cutlass.Int32({cluster_n}))"
+            )
+            box_pid = (
+                f"(((({virtual_pid}) // ({num_pid_m})) // cutlass.Int32({cluster_n}))"
+                f" * ({num_pid_m}) + ({virtual_pid}) % ({num_pid_m}))"
+            )
+            num_box_n = (
+                f"((({num_pid_n}) + cutlass.Int32({cluster_n - 1}))"
+                f" // cutlass.Int32({cluster_n}))"
+            )
+            num_pid_in_group = f"cutlass.Int32({l2_group}) * ({num_box_n})"
+            group_id = f"({box_pid}) // ({num_pid_in_group})"
+            first_pid_m = f"({group_id}) * cutlass.Int32({l2_group})"
+            group_size_m = (
+                f"min(({num_pid_m}) - ({first_pid_m}), cutlass.Int32({l2_group}))"
+            )
+            m_coord = (
+                f"({first_pid_m}) + "
+                f"((({box_pid}) % ({num_pid_in_group})) % ({group_size_m}))"
+            )
+            n_coord = (
+                f"(((({box_pid}) % ({num_pid_in_group})) // ({group_size_m}))"
+                f" * cutlass.Int32({cluster_n}) + {lane_n})"
+            )
+        elif l2_group > 1:
             num_pid_n = n_pid.num_pids_expr(is_device=True)
             num_pid_in_group = f"cutlass.Int32({l2_group}) * ({num_pid_n})"
             group_id = f"({virtual_pid}) // ({num_pid_in_group})"

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -11041,6 +11041,250 @@ class TestCuteLowerings(unittest.TestCase):
         expected = args[0] @ args[1]
         torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
 
+    def test_tcgen05_cluster_n2_l2_grouped_decode_properties(self) -> None:
+        """Pure-python mirror of the cluster-aware l2_groupings decode.
+
+        ``L2GroupingProgramIDs.codegen`` (and the matching predicate in
+        ``_tcgen05_output_full_tile_expr_for_work_tile``) must (a) stay a
+        bijection over the tile grid and (b) hand the two cluster-N peers
+        (virtual pids exactly ``num_pid_m`` apart, paired as consecutive
+        tile_n) the SAME decoded tile_m — the A multicast fills both peers'
+        SMEM from one TMA load for that tile_m. The plain per-CTA decode
+        violates (b) on many grids (empirically wrong at 16x4, 32x24 and
+        128x16 M-x-N tile grids, max rel err ~1.4); the box decode holds on
+        every LAUNCHABLE grid — the cute_mma padding gate requires the N
+        tile count to be divisible by cluster_n, and the negative check at
+        the end shows why (odd N tile counts break the bijection, matching
+        the CUTLASS scheduler's own padded-cluster hole).
+        """
+
+        def decode(
+            vpid: int, *, num_pid_m: int, num_pid_n: int, group: int, cluster_n: int
+        ) -> tuple[int, int]:
+            if cluster_n > 1:
+                lane_n = (vpid // num_pid_m) % cluster_n
+                box_pid = (
+                    (vpid // num_pid_m) // cluster_n
+                ) * num_pid_m + vpid % num_pid_m
+                num_box_n = (num_pid_n + cluster_n - 1) // cluster_n
+                num_pid_in_group = group * num_box_n
+                group_id = box_pid // num_pid_in_group
+                first_pid_m = group_id * group
+                group_size_m = min(num_pid_m - first_pid_m, group)
+                pid_m = first_pid_m + ((box_pid % num_pid_in_group) % group_size_m)
+                pid_n = (
+                    (box_pid % num_pid_in_group) // group_size_m
+                ) * cluster_n + lane_n
+                return pid_m, pid_n
+            num_pid_in_group = group * num_pid_n
+            group_id = vpid // num_pid_in_group
+            first_pid_m = group_id * group
+            group_size_m = min(num_pid_m - first_pid_m, group)
+            pid_m = first_pid_m + ((vpid % num_pid_in_group) % group_size_m)
+            pid_n = (vpid % num_pid_in_group) // group_size_m
+            return pid_m, pid_n
+
+        cluster_n = 2
+        grids = [
+            # The empirically-wrong grids under the old per-CTA decode ...
+            (16, 4),
+            (32, 24),
+            (128, 16),
+            # ... the empirically-correct ones ...
+            (8, 4),
+            (4, 8),
+            (8, 8),
+            (16, 16),
+            (4, 32),
+            (64, 64),
+            # ... and non-power-of-two / degenerate coverage.
+            (1, 2),
+            (3, 2),
+            (5, 6),
+            (13, 10),
+            (7, 62),
+        ]
+        for num_pid_m, num_pid_n in grids:
+            for group in (1, 2, 3, 4, 8, 16):
+                with self.subTest(
+                    num_pid_m=num_pid_m, num_pid_n=num_pid_n, group=group
+                ):
+                    seen: dict[tuple[int, int], int] = {}
+                    for vpid in range(num_pid_m * num_pid_n):
+                        coord = decode(
+                            vpid,
+                            num_pid_m=num_pid_m,
+                            num_pid_n=num_pid_n,
+                            group=group,
+                            cluster_n=cluster_n,
+                        )
+                        self.assertNotIn(coord, seen, "decode is not a bijection")
+                        seen[coord] = vpid
+                        self.assertLess(coord[0], num_pid_m)
+                        self.assertLess(coord[1], num_pid_n)
+                    # Peer consistency: the scheduler pairs vpids
+                    # ``m + (q*cluster_n + lane) * num_pid_m`` over lanes.
+                    for m in range(num_pid_m):
+                        for q in range(num_pid_n // cluster_n):
+                            pair = [
+                                decode(
+                                    m + (q * cluster_n + lane) * num_pid_m,
+                                    num_pid_m=num_pid_m,
+                                    num_pid_n=num_pid_n,
+                                    group=group,
+                                    cluster_n=cluster_n,
+                                )
+                                for lane in range(cluster_n)
+                            ]
+                            self.assertEqual(
+                                len({pid_m for pid_m, _ in pair}),
+                                1,
+                                "cluster-N peers decoded different tile_m",
+                            )
+                            for lane, (_, pid_n) in enumerate(pair):
+                                self.assertEqual(
+                                    pid_n % cluster_n,
+                                    lane,
+                                    "peer lane must map to its own N slot",
+                                )
+                            self.assertEqual(
+                                len({pid_n // cluster_n for _, pid_n in pair}),
+                                1,
+                                "cluster-N peers left their N box",
+                            )
+                    # cluster_n=1 must also stay a bijection (the codegen
+                    # branch for cluster_n=1 is byte-identical to the legacy
+                    # decode; this covers the mirror's else-branch).
+                    legacy = {
+                        decode(
+                            vpid,
+                            num_pid_m=num_pid_m,
+                            num_pid_n=num_pid_n,
+                            group=group,
+                            cluster_n=1,
+                        )
+                        for vpid in range(num_pid_m * num_pid_n)
+                    }
+                    self.assertEqual(len(legacy), num_pid_m * num_pid_n)
+        # Negative check: on an ODD N tile count the box decode maps some
+        # in-range vpid OUT of range (num_pid_m=2, num_pid_n=3, group=1:
+        # vpid=3 -> lane=1, box (0,1) -> pid_n=3 >= 3). This is exactly why
+        # cute_mma gates cluster_n=2 on cdiv(N, block_n) % cluster_n == 0 —
+        # the CUTLASS scheduler would pad a partial cluster there anyway.
+        odd_coords = [
+            decode(vpid, num_pid_m=2, num_pid_n=3, group=1, cluster_n=2)
+            for vpid in range(2 * 3)
+        ]
+        self.assertTrue(any(pid_n >= 3 for _, pid_n in odd_coords))
+
+    def test_tcgen05_persistent_cluster_n2_l2_grouped_runtime_correctness(
+        self,
+    ) -> None:
+        """cluster_n=2 + l2_groupings>1 on a peer-splitting grid is correct.
+
+        4096x1024x256 bf16 at bm=bn=256 gives a 16x4 M-x-N tile grid — one
+        of the empirically-corrupting grids under the old cluster-oblivious
+        l2_groupings decode (the two cluster-N peers decoded different
+        tile_m, so the A multicast filled one peer's SMEM with the wrong A
+        tile; max rel err ~1.4, and the interim gate rejected the config
+        outright). The cluster-aware box decode must make this exact
+        combination numerically correct.
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_cluster_n2_l2_grouped(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        torch.manual_seed(0)
+        args = (
+            torch.randn(4096, 256, device=DEVICE, dtype=torch.bfloat16),
+            torch.randn(256, 1024, device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_cluster_n2_l2_grouped.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            cfg = _make_tcgen05_persistent_config(
+                block_sizes=[256, 256, 128],
+                l2_groupings=[4],
+                pid_type="persistent_interleaved",
+                tcgen05_cluster_m=2,
+                tcgen05_cluster_n=2,
+                tcgen05_ab_stages=2,
+                tcgen05_acc_stages=2,
+                tcgen05_c_stages=2,
+            )
+            bound.set_config(cfg)
+            out = bound(*args)
+        expected = args[0] @ args[1]
+        torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
+    def test_tcgen05_cluster_n2_odd_n_tile_count_rejected(self) -> None:
+        """cluster_n=2 with an odd N tile count must be rejected.
+
+        The CUTLASS persistent scheduler ceil-divs the cluster grid and
+        reports validity at cluster granularity, so a padded trailing
+        cluster hands its second CTA an out-of-range tile_n marked valid —
+        an unmasked out-of-bounds store on the full-tile TMA path (this was
+        silently reachable through ``l2_groupings=[1]`` before the gate).
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_cluster_n2_odd_n_tiles(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        # N=768 at bn=256 gives 3 N tiles: cluster_n=2 pads a partial cluster.
+        args = (
+            torch.randn(1024, 128, device=DEVICE, dtype=torch.bfloat16),
+            torch.randn(128, 768, device=DEVICE, dtype=torch.bfloat16),
+        )
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_cluster_n2_odd_n_tiles.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            with self.assertRaisesRegex(
+                exc.BackendUnsupported, "divisible by cluster_n"
+            ):
+                bound.to_triton_code(cfg)
+
     def test_tcgen05_persistent_cluster_m2_two_cta_grid_caps_for_recycling(
         self,
     ) -> None:


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3544
 * #3532
 * #3531
 * __->__#3530
 * #3529
 * #3528
 * #3527


--- --- ---

[cutedsl] Cluster-aware l2_groupings decode for tcgen05 cluster_n=2

The l2_groupings grouped-raster decode permuted each CTA's linear tile
id independently, but the CUTLASS persistent scheduler pairs the
cluster_n=2 CTAs along the cluster's N axis (same tile_m, consecutive
tile_n -- vpids exactly num_pid_m apart) and the A-operand TMA multicast
fills both peers' SMEM from one load for that shared tile_m: on grids
where a pair straddled a group row the peers decoded different tile_m
and the kernel silently produced wrong output (max rel err ~1.4,
pre-existing; an interim gate rejected the affected combos).

Decode at cluster-box granularity instead ((1 M tile) x (cluster_n N
tiles)): peers collapse to one box pid, the grouped raster permutes
whole boxes, and the within-box lane recovers each peer's N tile. The
full/fringe-tile scheduler predicate mirrors the same decode. The
cluster_n=1 emission is byte-identical to before.

The old consistency gate is removed -- every l2_grouping is now legal
with cluster_n=2 (wider search space). It is replaced by an exact
scheduler-padding gate: CUTLASS's StaticPersistentTileScheduler reports
validity at cluster granularity, so an N tile count not divisible by
cluster_n hands the padded trailing CTA an out-of-range tile marked
valid (previously reachable via l2_groupings=[1]); such configs now
raise BackendUnsupported.

Verified: decode property test (bijection + peer tile_m consistency
across 14 grids x 6 groupings incl. the empirically-corrupting ones),
runtime correctness on a previously-corrupting grid, padding-gate
rejection test; old-vs-new co-timed ABAB on the three cn2+l2g autotune
winners (ffn-down-7b, deepK, smallM) shows no perf regression.