### PR TITLE
[cutedsl] CLC dynamic persistence for cluster_n=2 (4-CTA) tcgen05 matmuls

### DIFF
--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -984,15 +984,13 @@ _STRATEGY_SUPPORTED_CLUSTER_N: dict[Tcgen05Strategy, frozenset[int]] = {
 # (strategy, persistence_model)-conditional cluster_n accept set. Used to
 # reject combinations where the (strategy, persistence) pair has a
 # cluster-broadcast topology that has not been generalized to cluster_n>1.
-# Today's only entry: ``CLC_PERSISTENT`` under ``ROLE_LOCAL_WITH_SCHEDULER``
-# is cluster_m-only — the CLC scheduler-warp body iterates lanes
-# ``< cluster_m`` to publish to peer CTAs (see ``program_id.py``
-# ``_build_scheduler_warp_role_local_while_clc``); cluster_n>1 CTAs would
-# never receive the CLC mailbox publish and would hang on the
-# ``producer_acquire`` wait. Generalizing the CLC broadcast to cluster_n>1
-# is out of scope for cycle 33 (deferred to a future cycle alongside the
-# ``cluster_n>1`` C-input pipeline work). When a (strategy, persistence)
-# pair appears here, it overrides the per-strategy
+# ``CLC_PERSISTENT`` under ``ROLE_LOCAL_WITH_SCHEDULER`` now supports the
+# full 4-CTA cluster: the CLC leader's scheduler-warp broadcast iterates
+# lanes ``< cluster_m * cluster_n`` and publishes each peer's own (M, N)
+# tile coordinates (see ``program_id.py``
+# ``_build_scheduler_warp_role_local_while_clc``), matching Quack's
+# dynamic-persistent 2x2 topology. When a (strategy, persistence) pair
+# appears here, it overrides the per-strategy
 # ``_STRATEGY_SUPPORTED_CLUSTER_N`` entry; missing entries fall back to
 # the per-strategy capability.
 _STRATEGY_PERSISTENCE_SUPPORTED_CLUSTER_N: dict[
@@ -1001,7 +999,7 @@ _STRATEGY_PERSISTENCE_SUPPORTED_CLUSTER_N: dict[
     (
         Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
         Tcgen05PersistenceModel.CLC_PERSISTENT,
-    ): frozenset({1}),
+    ): frozenset({1, 2}),
 }
 
 

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -982,9 +982,10 @@ class CuteTcgen05Config:
 
         B multicast on top of the 2-CTA A multicast halves B traffic, which
         wins on B-heavy full-tile shapes (fp16 4096x4096x32768: 911 vs 824
-        TFLOP/s); cuBLAS's nvjet picks 2x2 clusters for the same shape. CLC
-        is cluster_n=1-only, so this seeds the static-persistent monolithic
-        family; the search's terminal refinement arbitrates between them.
+        TFLOP/s); cuBLAS's nvjet picks 2x2 clusters for the same shape. This
+        seeds the static-persistent monolithic family; a CLC-persistent
+        variant is layered on in ``autotune_seed_configs`` and the search's
+        terminal refinement arbitrates between them.
         """
         if self.aux_kernel_detected or self.matmul_has_leading_passthrough:
             return None
@@ -1207,6 +1208,14 @@ class CuteTcgen05Config:
         plain_cluster_n2_seed = self._plain_cluster_n2_seed_config()
         if plain_cluster_n2_seed is not None:
             seeds.append(plain_cluster_n2_seed)
+            if plain_clc_seed is not None:
+                # 4-CTA multicast + CLC dynamic persistence (Quack's
+                # dynamic-persistent 2x2 topology): reuse the validated CLC
+                # seed shape (WITH_SCHEDULER + scheduler warp) and add the
+                # cluster-N multicast on top.
+                clc_n2_seed_config: dict[str, Any] = dict(plain_clc_seed.config)
+                clc_n2_seed_config["tcgen05_cluster_n"] = 2
+                seeds.append(Config(**clc_n2_seed_config))
         c_input_seed = self._c_input_seed_config()
         if c_input_seed is not None:
             seeds.append(c_input_seed)
@@ -2477,7 +2486,9 @@ class CuteTcgen05Config:
                 return False
             if config.get("pid_type") != TCGEN05_TWO_CTA_SEED_PID_TYPE:
                 return False
-            if config.get("tcgen05_cluster_n", 1) != 1:
+            # cluster_n=2 rides the generalized 4-CTA CLC leader broadcast
+            # (Quack's dynamic-persistent 2x2 topology).
+            if config.get("tcgen05_cluster_n", 1) not in (1, 2):
                 return False
             if (
                 config.get(TCGEN05_STRATEGY_CONFIG_KEY)

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -4787,13 +4787,37 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             sched_producer_state if staged_work_tile_mailbox else sched_consumer_state
         )
         producer_smem_ptr = self._tcgen05_work_tile_producer_smem_ptr(layout)
+        # Full cluster size for the leader broadcast: with cluster_n > 1 the
+        # CLC leader must feed every CTA in the (cluster_m x cluster_n)
+        # cluster, publishing each peer's own (M, N) tile coordinates.
+        # CUDA cluster ranks are x-fastest, so peer rank r sits at
+        # ``(r % cluster_m, r // cluster_m)`` in the cluster.
+        sched_cluster_size = layout.cluster_m * layout.cluster_n
         if layout.cluster_m > 1:
             sched_barrier_ptr = device_function.new_var("tcgen05_clc_sched_barrier_ptr")
             sched_peer_rank = device_function.new_var("tcgen05_clc_sched_peer_rank")
             sched_peer_m = device_function.new_var("tcgen05_clc_sched_peer_m")
+            if layout.cluster_n > 1:
+                sched_peer_n = device_function.new_var("tcgen05_clc_sched_peer_n")
+                peer_coord_stmts = [
+                    statement_from_string(
+                        f"{sched_peer_m} = "
+                        f"{sched_peer_rank} % cutlass.Int32({layout.cluster_m})"
+                    ),
+                    statement_from_string(
+                        f"{sched_peer_n} = "
+                        f"{sched_peer_rank} // cutlass.Int32({layout.cluster_m})"
+                    ),
+                ]
+                publish_bidy_expr = f"{cluster_bidy_var} + {sched_peer_n}"
+            else:
+                peer_coord_stmts = [
+                    statement_from_string(f"{sched_peer_m} = {sched_peer_rank}")
+                ]
+                publish_bidy_expr = cluster_bidy_var
             # Whole-warp prelude: every lane runs ``producer_acquire``
             # (mbarrier wait) and computes the warp-uniform barrier
-            # pointer + lane id. Lanes ``cluster_m..31`` no-op past
+            # pointer + lane id. Lanes ``cluster_size..31`` no-op past
             # the per-peer broadcast branch.
             per_tile_publish_warp = [
                 statement_from_string(
@@ -4809,10 +4833,10 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 create(
                     ast.If,
                     test=expr_from_string(
-                        f"{sched_peer_rank} < cutlass.Int32({layout.cluster_m})"
+                        f"{sched_peer_rank} < cutlass.Int32({sched_cluster_size})"
                     ),
                     body=[
-                        statement_from_string(f"{sched_peer_m} = {sched_peer_rank}"),
+                        *peer_coord_stmts,
                         statement_from_string(
                             "cute.arch.mbarrier_arrive_and_expect_tx("
                             f"{sched_barrier_ptr}, 16, {sched_peer_rank})"
@@ -4820,7 +4844,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                         statement_from_string(
                             f"_cute_store_shared_remote_x4("
                             f"{cluster_bidx_var} + {sched_peer_m}, "
-                            f"{cluster_bidy_var}, "
+                            f"{publish_bidy_expr}, "
                             f"{cluster_bidz_var}, "
                             f"{valid_var}, "
                             f"smem_ptr={producer_smem_ptr}, "
@@ -5013,7 +5037,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 create(
                     ast.If,
                     test=expr_from_string(
-                        f"{sched_peer_rank} < cutlass.Int32({layout.cluster_m})"
+                        f"{sched_peer_rank} < cutlass.Int32({sched_cluster_size})"
                     ),
                     body=[
                         statement_from_string(

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -10979,6 +10979,120 @@ class TestCuteLowerings(unittest.TestCase):
         # the validator-surface coverage lives in
         # ``test_cute_tcgen05_strategy_invariants_cluster_n``).
 
+    def test_tcgen05_clc_cluster_n2_runtime_correctness(self) -> None:
+        """CLC dynamic persistence with the 4-CTA (2x2) cluster.
+
+        The CLC leader's scheduler warp broadcasts each work tile to all
+        ``cluster_m * cluster_n`` peers with per-peer (M, N) coordinates
+        (Quack's dynamic-persistent 2x2 topology). Before the broadcast was
+        generalized, cluster-N peers never received the mailbox publish and
+        the kernel hung; the strategy invariant rejected the combination.
+        Runs a full-tile grid AND an l2-grouped peer-splitting grid so the
+        publish composes with the cluster-aware l2 decode.
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_clc_cluster_n2(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        torch.manual_seed(0)
+        for m, n, k, l2g in ((1024, 1024, 256, 1), (4096, 1024, 256, 4)):
+            with self.subTest(m=m, n=n, k=k, l2g=l2g):
+                args = (
+                    torch.randn(m, k, device=DEVICE, dtype=torch.bfloat16),
+                    torch.randn(k, n, device=DEVICE, dtype=torch.bfloat16),
+                )
+                with patch_cute_mma_support():
+                    bound = cute_matmul_clc_cluster_n2.bind(args)
+                    bound.env.config_spec.cute_tcgen05_search_enabled = True
+                    cfg = _make_tcgen05_persistent_config(
+                        block_sizes=[256, 256, 128],
+                        l2_groupings=[l2g],
+                        pid_type="persistent_interleaved",
+                        tcgen05_cluster_m=2,
+                        tcgen05_cluster_n=2,
+                        tcgen05_ab_stages=2,
+                        tcgen05_acc_stages=2,
+                        tcgen05_c_stages=2,
+                        tcgen05_persistence_model="clc_persistent",
+                        tcgen05_strategy="role_local_with_scheduler",
+                        tcgen05_warp_spec_scheduler_warps=1,
+                    )
+                    bound.set_config(cfg)
+                    out = bound(*args)
+                expected = args[0] @ args[1]
+                torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
+    def test_tcgen05_clc_cluster_n2_codegen_broadcast_markers(self) -> None:
+        """CLC 4-CTA broadcast codegen pins.
+
+        The scheduler-warp publish must fan out to all four peers
+        (``lane < 4``) and derive each peer's (M, N) offsets from the
+        x-fastest cluster rank. The cluster_n=1 emission stays on the
+        two-peer M-only form.
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_clc_n2_markers(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.randn(1024, 128, device=DEVICE, dtype=torch.bfloat16),
+            torch.randn(128, 1024, device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_clc_n2_markers.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            cfg = _make_tcgen05_persistent_config(
+                block_sizes=[256, 256, 128],
+                l2_groupings=[1],
+                pid_type="persistent_interleaved",
+                tcgen05_cluster_m=2,
+                tcgen05_cluster_n=2,
+                tcgen05_ab_stages=2,
+                tcgen05_acc_stages=2,
+                tcgen05_c_stages=2,
+                tcgen05_persistence_model="clc_persistent",
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+            )
+            code = bound.to_triton_code(cfg)
+        self.assertIn("tcgen05_clc_sched_peer_n", code)
+        peer_rank_var = "tcgen05_clc_sched_peer_rank"
+        self.assertIn(f"{peer_rank_var} < cutlass.Int32(4)", code)
+        self.assertIn("% cutlass.Int32(2)", code)
+        self.assertIn("// cutlass.Int32(2)", code)
+
     def test_tcgen05_persistent_cluster_n2_two_cta_runtime_correctness(
         self,
     ) -> None:

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -1012,12 +1012,12 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         # round-trip even on a device the gate is off for.
         validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
         self.assertEqual(validation_fragments["tcgen05_ab_stages"].high, 3)
-        # The full-tile cluster_m=2 family now seeds three configs (the
+        # The full-tile cluster_m=2 family now seeds four configs (the
         # canonical static-persistent seed, the CLC dynamic-persistence
-        # scheduler seed, and the 4-CTA cluster_n=2 seed) — none of which may
-        # carry ab=3 when the gate is off.
+        # scheduler seed, the 4-CTA cluster_n=2 seed, and the CLC + cluster_n=2
+        # seed) — none of which may carry ab=3 when the gate is off.
         seeds = spec.compiler_seed_configs
-        self.assertEqual(len(seeds), 3)
+        self.assertEqual(len(seeds), 4)
         self.assertNotIn("tcgen05_ab_stages", seeds[0].config)
         for seed in seeds:
             self.assertNotEqual(seed.config.get("tcgen05_ab_stages"), 3)
@@ -2744,16 +2744,16 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
     def test_cute_tcgen05_strategy_invariants_clc_persistent_cluster_n(
         self,
     ) -> None:
-        """``CLC_PERSISTENT`` + ``cluster_n>1`` is rejected.
+        """``CLC_PERSISTENT`` cluster_n accept set is ``{1, 2}``.
 
-        The CLC scheduler-warp body in
+        The CLC leader's scheduler-warp broadcast in
         ``program_id._build_scheduler_warp_role_local_while_clc``
-        publishes the work tile to peer CTAs by iterating lanes
-        ``< cluster_m``; cluster_n>1 CTAs would never receive the
-        CLC mailbox publish and would hang at ``producer_acquire``.
-        The paired ``(strategy, persistence_model)`` invariant
-        rejects this combination at validate time so the runtime
-        path is unreachable.
+        iterates lanes ``< cluster_m * cluster_n`` and publishes each
+        peer's own (M, N) tile coordinates, so the full 4-CTA cluster
+        (cluster_n=2) is dynamic-persistence capable. Values outside
+        the validated set are still rejected by the paired
+        ``(strategy, persistence_model)`` invariant so an unvalidated
+        cluster shape cannot reach the runtime.
         """
         with_sched = dataclasses.replace(
             ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC, scheduler_warps=1
@@ -2789,9 +2789,9 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         )
         self.assertEqual(errors, [], msg=str(errors))
 
-        # Negative control: CLC + cluster_n=2 rejected. The CLC
-        # broadcast is cluster_m-only; second-N-lane CTAs never
-        # receive the mailbox publish.
+        # Positive control: CLC + cluster_n=2 accepts (the generalized
+        # 4-CTA leader broadcast publishes per-peer tile coordinates to
+        # all cluster_m * cluster_n peers).
         errors = validate_tcgen05_strategy_invariants(
             strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
             persistence_model=Tcgen05PersistenceModel.CLC_PERSISTENT,
@@ -2803,9 +2803,25 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             cluster_n=2,
             arch_major=10,
         )
+        self.assertEqual(errors, [], msg=str(errors))
+
+        # Negative control: CLC + cluster_n=4 rejected — outside the
+        # validated {1, 2} accept set of the paired
+        # (strategy, persistence_model) invariant.
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
+            persistence_model=Tcgen05PersistenceModel.CLC_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=with_sched,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="persistent_blocked",
+            cluster_m=2,
+            cluster_n=4,
+            arch_major=10,
+        )
         self.assertTrue(
             any(
-                "clc_persistent" in e and "tcgen05_cluster_n in [1]" in e
+                "clc_persistent" in e and "tcgen05_cluster_n in [1, 2]" in e
                 for e in errors
             ),
             msg=str(errors),


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3544
 * #3532
 * __->__#3531
 * #3530
 * #3529
 * #3528
 * #3527


--- --- ---

[cutedsl] CLC dynamic persistence for cluster_n=2 (4-CTA) tcgen05 matmuls

The CLC leader's scheduler-warp broadcast only fed the cluster_m peers,
so cluster_n=2 could not use CLC dynamic persistence at all (the
strategy invariant rejected it) and 4-CTA configs were stuck on static
persistence, which both loses CLC's tail/steal advantage (+21% at fp16
16384^3) and oversubscribes the capped static launch. Quack's best
5000^3 config (dynamic-persistent 2x2 + swizzle) was unreachable.

Generalize the broadcast to all cluster_m * cluster_n peers: lane r
publishes to peer r with per-peer (M, N) tile coordinates derived from
the x-fastest cluster rank (bidx + r % cluster_m, bidy + r //
cluster_m); the sentinel fans out the same way. The consumer-side
arrive counts and leader mask routing were already sized by
cluster_m * cluster_n. cluster_n=1 emission is byte-identical.

Widen the (ROLE_LOCAL_WITH_SCHEDULER, CLC_PERSISTENT) cluster_n accept
set to {1, 2}, admit cluster_n=2 in the plain CLC search family, and
seed the CLC+cluster_n=2 shape alongside the static one.

Measured (co-timed ABAB, pinned GPUs): bf16 5000^3 852 -> 907 TFLOP/s
(0.930 -> 0.990 vs quack's dynamic-persistent 2x2); fp16 6144^3
955 -> 994 (0.934 -> 0.977 vs aten); fp16 deepK 927 -> 934. Bit-exact
on the correctness gauntlet incl. l2-grouped peer-splitting grids and
tf32.