### PR TITLE
[cutedsl] tcgen05 M-paired tiles (block_m=512), 2x2 super-tile, deep-stage seed

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -317,6 +317,10 @@ class _Tcgen05LayoutPlan:
     acc_producer_state: str
     acc_consumer_state: str
     epilogue_rest_mode: str
+    # Second acc producer state for M-paired tiles (m_subtile_count == 2):
+    # offset by one stage so the two subtiles own the two acc stages, each
+    # advancing by two per work tile (phase flips per tile as usual).
+    acc_producer_state2: str = ""
 
 
 @dataclass(frozen=True)
@@ -4878,24 +4882,38 @@ class _PerKiterTmaArgs:
     tma_desc_ptr_a: str | None = None
     tma_desc_ptr_b: str | None = None
     tma_desc_acquire_fence_src: str | None = None
+    # M-paired tiles: second A staging buffer's (gmem, smem) TMA partitions.
+    # Empty strings when m_subtile_count == 1.
+    tma_gA2: str = ""
+    tma_sA2: str = ""
 
 
 def _kloop_tma_copy_a_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
     """Per-K-iter TMA copy source for A; ``""`` when A is not TMA-loaded.
 
     A only multicasts in 2-CTA mode (asymmetric vs. B, which can also
-    multicast across cluster CTAs).
+    multicast across cluster CTAs). With M-paired tiles a second copy fills
+    the paired subtile's A buffer from the adjacent M tile (same barrier /
+    transaction, tx_count covers both).
     """
     if not args.use_tma_a:
         return ""
     mcast = f", mcast_mask={args.tma_a_mcast_mask}" if args.is_two_cta else ""
     desc = f", tma_desc_ptr={args.tma_desc_ptr_a}" if args.tma_desc_ptr_a else ""
-    return (
+    src = (
         f"    cute.copy({args.tma_atom_a}, "
         f"{args.tma_gA}[None, {k_offset}], "
         f"{args.tma_sA}[None, {args.tma_producer_state}.index], "
         f"tma_bar_ptr={args.tma_barrier_ptr}{mcast}{desc})\n"
     )
+    if args.tma_gA2:
+        src += (
+            f"    cute.copy({args.tma_atom_a}, "
+            f"{args.tma_gA2}[None, {k_offset}], "
+            f"{args.tma_sA2}[None, {args.tma_producer_state}.index], "
+            f"tma_bar_ptr={args.tma_barrier_ptr}{mcast}{desc})\n"
+        )
+    return src
 
 
 def _kloop_tma_copy_b_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
@@ -5512,6 +5530,9 @@ class _InitialPrefetchTmaArgs:
     skip_producer_advance: bool
     tma_desc_ptr_a: str | None = None
     tma_desc_ptr_b: str | None = None
+    # M-paired tiles: second A staging buffer's (gmem, smem) TMA partitions.
+    tma_gA2: str = ""
+    tma_sA2: str = ""
 
 
 def _initial_prefetch_copy_a_src(
@@ -5522,16 +5543,25 @@ def _initial_prefetch_copy_a_src(
     A only multicasts in 2-CTA mode (asymmetric vs. B, which can also
     multicast across cluster CTAs); matches the asymmetry pinned by
     ``test_mcast_mask_asymmetry_between_a_and_b`` for the per-K-iter
-    builders.
+    builders. With M-paired tiles a second copy fills the paired subtile's
+    A buffer (same barrier / transaction).
     """
     mcast = f", mcast_mask={args.tma_a_mcast_mask}" if args.is_two_cta else ""
     desc = f", tma_desc_ptr={args.tma_desc_ptr_a}" if args.tma_desc_ptr_a else ""
-    return (
+    src = (
         f"    cute.copy({args.tma_atom_a}, "
         f"{args.tma_gA}[None, {k_offset}], "
         f"{args.tma_sA}[None, {args.tma_producer_state}.index], "
         f"tma_bar_ptr={args.tma_barrier_ptr}{mcast}{desc})\n"
     )
+    if args.tma_gA2:
+        src += (
+            f"    cute.copy({args.tma_atom_a}, "
+            f"{args.tma_gA2}[None, {k_offset}], "
+            f"{args.tma_sA2}[None, {args.tma_producer_state}.index], "
+            f"tma_bar_ptr={args.tma_barrier_ptr}{mcast}{desc})\n"
+        )
+    return src
 
 
 def _initial_prefetch_copy_b_src(
@@ -6924,6 +6954,16 @@ def _emit_mma_pipeline(
     else:
         tcgen05_mma_bm = tcgen05_source_bm = bm
         tcgen05_mma_bn = tcgen05_source_bn = bn
+        if bm == 2 * TCGEN05_TWO_CTA_BLOCK_M:
+            # M-paired tiles (nvjet's B-reuse design): block_m=512 lowers as
+            # TWO 256-row CtaGroup.TWO UMMA subtiles per work tile. B is
+            # staged once per K stage and shared by both subtiles, halving
+            # B's SMEM/L2/DRAM traffic; each subtile owns one TMEM
+            # accumulator (the two acc stages) and the epilogue drains both.
+            # Full eligibility (plain full-tile static family) is enforced
+            # after the family flags are derived below.
+            tcgen05_mma_bm = TCGEN05_TWO_CTA_BLOCK_M
+    tcgen05_m_subtile_count = bm // tcgen05_mma_bm if not tcgen05_nm_orientation else 1
 
     tcgen05_large_bn_proof = _tcgen05_large_bn_proof_enabled(df.config)
     if tcgen05_large_bn_proof and (
@@ -7325,6 +7365,28 @@ def _emit_mma_pipeline(
     tcgen05_role_local_uses_k_tail_tma = tcgen05_role_local_k_tail_tma or (
         tcgen05_role_local_double_edge_tma and tcgen05_has_k_tail
     )
+    if (
+        tcgen05_cluster_n > 1
+        and (
+            tcgen05_double_edge_tma
+            or tcgen05_m_edge_only
+            or tcgen05_n_edge_only
+            or tcgen05_k_tail_only
+        )
+        and l2_swizzle_size_from_config(df.config) > 1
+    ):
+        # The edge/K-tail family's split full/fringe scheduler does not
+        # compose with the CUTLASS scheduler swizzle under a 4-CTA cluster:
+        # swizzle=8 HANGS at bf16 5000^3 (unkillable kernel) and swizzle=4
+        # fails NVVM compilation. Reject rather than hang; swizzle=1 is the
+        # measured-best edge configuration anyway.
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05_cluster_n=2 on edge/K-tail shapes requires "
+            "tcgen05_l2_swizzle_size=1 (the split full/fringe scheduler "
+            "does not compose with the scheduler swizzle under a 4-CTA "
+            "cluster).",
+        )
     tcgen05_diagnose_cluster_m2_one_cta_role_local = bool(
         df.config.get(TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY, False)
     )
@@ -7580,6 +7642,37 @@ def _emit_mma_pipeline(
     tcgen05_acc_stage_count_value = _tcgen05_config_int(
         df.config, "tcgen05_acc_stages", _tcgen05_acc_stage_count(tcgen05_mma_bn)
     )
+    if tcgen05_m_subtile_count > 1:
+        # M-paired tiles: validated envelope is the plain (no-aux, no
+        # leading passthrough) full-tile static role-local CtaGroup.TWO
+        # family; cluster_n=2 composes (the 2x2 super-tile: A multicast
+        # across the cluster-N pairs on top of the SMEM-shared B within
+        # each pair). Both TMEM accumulator stages are repurposed as the
+        # two subtiles' accumulators, so acc_stages must be 2 (the pipeline
+        # still double-buffers ACROSS work tiles at the pair granularity
+        # via the two stages' phase flips).
+        if not (
+            mma_impl == "tcgen05"
+            and tcgen05_is_two_cta
+            and tcgen05_cluster_m == 2
+            and tcgen05_cluster_n in (1, 2)
+            and tcgen05_static_full_tiles
+            and tcgen05_use_tma_pipeline
+            and tcgen05_pid_is_persistent
+            and not env.config_spec.cute_tcgen05_aux_kernel_detected
+            and (analysis is None or not analysis.has_leading_passthrough)
+            and tcgen05_acc_stage_count_value == 2
+            and input_dtype in (torch.float16, torch.bfloat16)
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                "block_m=512 (tcgen05 M-paired tiles) requires the plain "
+                "16-bit full-tile static persistent CtaGroup.TWO family: "
+                "tcgen05_cluster_m=2, tcgen05_cluster_n in (1, 2), "
+                "tcgen05_acc_stages=2, M/N/K divisible by "
+                "block_m/block_n/block_k, TMA pipeline, and no aux/batch "
+                "operands. Use block_m=256 otherwise.",
+            )
     # Budget-driven admission for the output-edge TMA-store epilogue's extra
     # C ring: the flat <=2 AB-stage cap was calibrated for the residual
     # (source-C) family's (128, 64) epilogue tile; plain kernels stage a
@@ -8621,8 +8714,10 @@ def _emit_mma_pipeline(
 
     # Variable names
     tiled_mma = df.new_var("tiled_mma")
+    tiled_mma2 = df.new_var("tcgen05_msub_tiled_mma")
     thr_mma = df.new_var("thr_mma")
     acc_frag = df.new_var("acc_frag")
+    acc_frag2 = df.new_var("tcgen05_msub_acc_frag")
     acc_frag_base = df.new_var("acc_frag_base")
     tcgen05_exec_acc_frag_base = df.new_var("tcgen05_exec_acc_frag_base")
     tcgen05_exec_acc_tmem_ptr = df.new_var("tcgen05_exec_acc_tmem_ptr")
@@ -8833,6 +8928,13 @@ def _emit_mma_pipeline(
             f"{tcgen05_plan.acc_producer_state}.index]",
             mma_exec=tcgen05_use_role_local_mma_exec,
         )
+        if tcgen05_m_subtile_count > 1:
+            _emit_per_tile(
+                f"{acc_frag2} = "
+                f"{tcgen05_exec_acc_frag_base}[None, None, None, "
+                f"{tcgen05_plan.acc_producer_state2}.index]",
+                mma_exec=tcgen05_use_role_local_mma_exec,
+            )
         if tcgen05_use_role_local_ab_consumer_prefetch:
             ab_consumer_prefetch_owner_predicate = _tcgen05_two_cta_owner_predicate(
                 tcgen05_plan.exec_active,
@@ -8872,6 +8974,19 @@ def _emit_mma_pipeline(
             ),
             mma_exec=tcgen05_use_role_local_mma_exec,
         )
+        if tcgen05_m_subtile_count > 1:
+            # Acquire the paired subtile's acc stage up front: both subtiles
+            # accumulate across the same K loop, so both stages must be free
+            # (the epilogue drained the previous pair) before UMMAs issue.
+            _emit_per_tile(
+                _tcgen05_emit_optional_gate(
+                    f"{tcgen05_plan.acc_pipeline}.producer_acquire("
+                    f"{tcgen05_plan.acc_producer_state2})",
+                    tcgen05_mma_owner_active,
+                    indent="",
+                ),
+                mma_exec=tcgen05_use_role_local_mma_exec,
+            )
         reset_accumulate_stmts = _build_tcgen05_mma_accumulate_reset_stmt(
             tcgen05_plan.exec_active,
             tiled_mma=tiled_mma,
@@ -8894,6 +9009,27 @@ def _emit_mma_pipeline(
         per_tile_stmts.extend(reset_accumulate_stmts)
         if tcgen05_use_role_local_mma_exec:
             mma_exec_role_stmts.extend(reset_accumulate_stmts)
+        if tcgen05_m_subtile_count > 1:
+            reset_accumulate_stmts2 = _build_tcgen05_mma_accumulate_reset_stmt(
+                tcgen05_plan.exec_active,
+                tiled_mma=tiled_mma2,
+                input_dtype_str=input_dtype_str,
+                acc_dtype_str=acc_dtype_str,
+                gate_exec_warp=not tcgen05_use_role_local_mma_exec,
+                is_two_cta=tcgen05_is_two_cta,
+                cluster_n=tcgen05_cluster_n,
+                runtime_mma_n=None,
+                runtime_instr_desc=None,
+                valid_m=None,
+                static_mma_m=None,
+                static_mma_n=None,
+                a_k_major=tcgen05_mma_a_k_major,
+                b_k_major=tcgen05_mma_b_k_major,
+            )
+            prefix.extend(reset_accumulate_stmts2)
+            per_tile_stmts.extend(reset_accumulate_stmts2)
+            if tcgen05_use_role_local_mma_exec:
+                mma_exec_role_stmts.extend(reset_accumulate_stmts2)
 
     mma_participant_linear: str | None = None
     mma_slice_linear: str | None = None
@@ -9407,6 +9543,7 @@ def _emit_mma_pipeline(
             cluster_n=tcgen05_cluster_n,
             l2_swizzle_size=tcgen05_l2_swizzle_size_value,
             tma_store_full_tiles_only=tcgen05_tma_store_full_tiles_only,
+            m_subtile_count=tcgen05_m_subtile_count,
             aux_tensor_descriptors=aux_tensor_descriptors_value,
             flat_role_launch_warp_count=8
             if tcgen05_use_flat_role_coordinates
@@ -9692,6 +9829,24 @@ def _emit_mma_pipeline(
                     tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
                 )
             )
+            if tcgen05_m_subtile_count > 1:
+                # Second tiled MMA object for the M-paired subtile so each
+                # subtile's ACCUMULATE flag is tracked independently.
+                prefix.append(
+                    statement_from_string(
+                        f"{tiled_mma2} = "
+                        + _tcgen05_tiled_mma_expr(
+                            input_dtype_str,
+                            acc_dtype_str,
+                            tcgen05_mma_bm,
+                            tcgen05_mma_bn,
+                            tcgen05_cluster_m=tcgen05_cluster_m,
+                            a_k_major=tcgen05_mma_a_k_major,
+                            b_k_major=tcgen05_mma_b_k_major,
+                            use_2cta_instrs=tcgen05_is_two_cta,
+                        )
+                    )
+                )
         else:
             prefix.append(
                 statement_from_string(f"{tma_warp} = {warp_idx} == cutlass.Int32(0)")
@@ -9820,6 +9975,16 @@ def _emit_mma_pipeline(
                 f"cutlass.pipeline.PipelineUserType.Producer, {tcgen05_acc_stage_count_value})"
             )
         )
+        if tcgen05_m_subtile_count > 1:
+            prefix.append(
+                statement_from_string(
+                    f"{tcgen05_plan.acc_producer_state2} = {tcgen05_pipeline_state_ns}.make_pipeline_state("
+                    f"cutlass.pipeline.PipelineUserType.Producer, {tcgen05_acc_stage_count_value})"
+                )
+            )
+            prefix.append(
+                statement_from_string(f"{tcgen05_plan.acc_producer_state2}.advance()")
+            )
         prefix.append(
             statement_from_string(
                 f"{tcgen05_plan.acc_consumer_state} = {tcgen05_pipeline_state_ns}.make_pipeline_state("
@@ -10201,6 +10366,13 @@ def _emit_mma_pipeline(
     # per-iteration shared-memory state; hoisting them outside the lane loops
     # regresses the existing lane-loop coverage.
     smem_a_ptr = df.new_var("smem_a")
+    smem_a2_ptr = df.new_var("tcgen05_msub_smem_a")
+    smem_a2 = df.new_var("tcgen05_msub_sA")
+    gmem_a2_tma = df.new_var("tcgen05_msub_gA_tma")
+    gmem_a2_tma_part = df.new_var("tcgen05_msub_gA_tma_part")
+    tma_gA2 = df.new_var("tcgen05_msub_tma_gA")
+    tma_sA2 = df.new_var("tcgen05_msub_tma_sA")
+    tcgen05_frag_a2 = df.new_var("tcgen05_msub_tCrA")
     smem_b_ptr = df.new_var("smem_b")
     smem_a = df.new_var("sA")
     smem_b = df.new_var("sB")
@@ -10917,11 +11089,33 @@ def _emit_mma_pipeline(
                 f"{tcgen05_plan.smem_b_layout}.outer)"
             )
         )
+        if tcgen05_m_subtile_count > 1:
+            # Second A staging buffer for the M-paired subtile; B is staged
+            # once per K stage and shared by both subtiles.
+            prefix.append(
+                statement_from_string(
+                    f"{smem_a2_ptr} = cute.arch.alloc_smem("
+                    f"{input_dtype_str}, cute.cosize({tcgen05_plan.smem_a_layout}.outer), alignment=128)"
+                )
+            )
+            prefix.append(
+                statement_from_string(
+                    f"{smem_a2} = cute.make_tensor("
+                    f"cute.recast_ptr({smem_a2_ptr}, {tcgen05_plan.smem_a_layout}.inner, dtype={input_dtype_str}), "
+                    f"{tcgen05_plan.smem_a_layout}.outer)"
+                )
+            )
         prefix.append(
             statement_from_string(
                 f"{tcgen05_frag_a} = {tiled_mma}.make_fragment_A({smem_a})"
             )
         )
+        if tcgen05_m_subtile_count > 1:
+            prefix.append(
+                statement_from_string(
+                    f"{tcgen05_frag_a2} = {tiled_mma}.make_fragment_A({smem_a2})"
+                )
+            )
         prefix.append(
             statement_from_string(
                 f"{tcgen05_frag_b} = {tiled_mma}.make_fragment_B({smem_b})"
@@ -11107,7 +11301,7 @@ def _emit_mma_pipeline(
                         f"{dynamic_ab_tile_trailing_coord})"
                     )
                     if tcgen05_grouped_dynamic_ab_tensormaps
-                    else f"({m_offset_var} // cutlass.Int32({bm}), None)"
+                    else f"({m_offset_var} // cutlass.Int32({tcgen05_mma_bm}), None)"
                 )
                 b_tile_coord = (
                     (
@@ -11188,6 +11382,17 @@ def _emit_mma_pipeline(
                 f"{a_tile_coord})",
                 tma_load=tcgen05_use_role_local_tma_producer,
             )
+            if tcgen05_m_subtile_count > 1:
+                a2_tile_coord = (
+                    f"({m_offset_var} // cutlass.Int32({tcgen05_mma_bm})"
+                    " + cutlass.Int32(1), None)"
+                )
+                _emit_per_tile(
+                    f"{gmem_a2_tma} = cute.local_tile("
+                    f"{tma_tensor_a}, {gmem_a_tma_tiler}, "
+                    f"{a2_tile_coord})",
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
             _emit_per_tile(
                 f"{gmem_b_tma} = cute.local_tile("
                 f"{gmem_b_tma_tensor}, {gmem_b_tma_tiler}, "
@@ -11198,6 +11403,11 @@ def _emit_mma_pipeline(
                 f"{gmem_a_tma_part} = {tma_thr_mma}.partition_A({gmem_a_tma})",
                 tma_load=tcgen05_use_role_local_tma_producer,
             )
+            if tcgen05_m_subtile_count > 1:
+                _emit_per_tile(
+                    f"{gmem_a2_tma_part} = {tma_thr_mma}.partition_A({gmem_a2_tma})",
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
             _emit_per_tile(
                 f"{gmem_b_tma_part} = {tma_thr_mma}.partition_B({gmem_b_tma})",
                 tma_load=tcgen05_use_role_local_tma_producer,
@@ -11291,6 +11501,15 @@ def _emit_mma_pipeline(
                 f"cute.rank({gmem_a_tma_part}) - 1))",
                 tma_load=tcgen05_use_role_local_tma_producer,
             )
+            if tcgen05_m_subtile_count > 1:
+                _emit_per_tile(
+                    f"{tma_sA2}, {tma_gA2} = cute.nvgpu.cpasync.tma_partition("
+                    f"{tma_atom_a}, {tma_a_cta_coord_expr}, {tma_a_cta_layout_expr}, "
+                    f"cute.group_modes({smem_a2}, 0, cute.rank({smem_a2}) - 1), "
+                    f"cute.group_modes({gmem_a2_tma_part}, 0, "
+                    f"cute.rank({gmem_a2_tma_part}) - 1))",
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
             _emit_per_tile(
                 f"{tma_sB}, {tma_gB} = cute.nvgpu.cpasync.tma_partition("
                 f"{tma_atom_b}, {tma_b_cta_coord_expr}, {tma_b_cta_layout_expr}, "
@@ -11320,7 +11539,7 @@ def _emit_mma_pipeline(
             prefix.append(
                 statement_from_string(
                     f"{tma_pipeline_tx_count} = "
-                    f"({'cute.size_in_bytes(' + input_dtype_str + ', ' + tma_smem_a_layout + ')' if tcgen05_use_tma_a else '0'} + "
+                    f"({'cute.size_in_bytes(' + input_dtype_str + ', ' + tma_smem_a_layout + ')' + (' * ' + str(tcgen05_m_subtile_count) if tcgen05_m_subtile_count > 1 else '') if tcgen05_use_tma_a else '0'} + "
                     f"{'cute.size_in_bytes(' + input_dtype_str + ', ' + tma_smem_b_layout + ')' if tcgen05_use_tma_b else '0'})"
                     + (
                         f" * cute.size({tiled_mma}.thr_id.shape)"
@@ -11412,6 +11631,8 @@ def _emit_mma_pipeline(
                             if tcgen05_grouped_dynamic_ab_tensormaps
                             else None
                         ),
+                        tma_gA2=tma_gA2 if tcgen05_m_subtile_count > 1 else "",
+                        tma_sA2=tma_sA2 if tcgen05_m_subtile_count > 1 else "",
                     )
                     _emit_per_tile(
                         f"{tma_initial_full_tile} = "
@@ -11769,6 +11990,8 @@ def _emit_mma_pipeline(
                 scalar_load_b=scalar_load_b,
                 cluster_n=tcgen05_cluster_n,
                 static_full_tiles=tcgen05_static_full_tma_fast_path,
+                tma_gA2=tma_gA2 if tcgen05_m_subtile_count > 1 else "",
+                tma_sA2=tma_sA2 if tcgen05_m_subtile_count > 1 else "",
                 tma_desc_ptr_a=(
                     grouped_tensormap_a_desc_ptr
                     if tcgen05_grouped_dynamic_ab_tensormaps
@@ -11939,6 +12162,27 @@ def _emit_mma_pipeline(
                                 ),
                             )
                         )
+                        if tcgen05_m_subtile_count > 1:
+                            # Paired subtile: same B stage, second A buffer,
+                            # second accumulator/tiled-mma.
+                            exec_loop_body.append(
+                                _build_tcgen05_mma_issue_stmt(
+                                    exec_active=tcgen05_plan.exec_active,
+                                    tiled_mma=tiled_mma2,
+                                    acc_frag=acc_frag2,
+                                    tcgen05_frag_a=tcgen05_frag_a2,
+                                    tcgen05_frag_b=tcgen05_frag_b,
+                                    mma_stage=mma_stage,
+                                    input_dtype_str=input_dtype_str,
+                                    acc_dtype_str=acc_dtype_str,
+                                    gate_exec_warp=tcgen05_static_full_tma_fast_path,
+                                    is_two_cta=tcgen05_is_two_cta,
+                                    cluster_n=tcgen05_cluster_n,
+                                    runtime_mma_n=None,
+                                    runtime_instr_desc=None,
+                                    static_mma_n=None,
+                                )
+                            )
                     exec_loop_body.append(
                         _build_kloop_pipeline_release_if(
                             tma_kloop_args,
@@ -12126,6 +12370,24 @@ def _emit_mma_pipeline(
                             ),
                         )
                     )
+                    if tcgen05_m_subtile_count > 1:
+                        cg.add_statement(
+                            _build_tcgen05_mma_issue_stmt(
+                                exec_active=tcgen05_plan.exec_active,
+                                tiled_mma=tiled_mma2,
+                                acc_frag=acc_frag2,
+                                tcgen05_frag_a=tcgen05_frag_a2,
+                                tcgen05_frag_b=tcgen05_frag_b,
+                                mma_stage=mma_stage,
+                                input_dtype_str=input_dtype_str,
+                                acc_dtype_str=acc_dtype_str,
+                                is_two_cta=tcgen05_is_two_cta,
+                                cluster_n=tcgen05_cluster_n,
+                                runtime_mma_n=None,
+                                runtime_instr_desc=None,
+                                static_mma_n=None,
+                            )
+                        )
                 if tcgen05_use_tma:
                     assert tma_kloop_args is not None
                     if tcgen05_use_tma_pipeline:
@@ -12220,16 +12482,34 @@ def _emit_mma_pipeline(
             per_tile_stmts.append(suffix_stmt)
             if tcgen05_use_role_local_mma_exec:
                 mma_exec_role_stmts.append(suffix_stmt)
+            if tcgen05_m_subtile_count > 1:
+                suffix_stmt2 = statement_from_string(
+                    _tcgen05_emit_optional_gate(
+                        f"{tcgen05_plan.acc_pipeline}.producer_commit("
+                        f"{tcgen05_plan.acc_producer_state2})",
+                        tcgen05_mma_owner_active,
+                        indent="",
+                    )
+                )
+                suffix.append(suffix_stmt2)
+                per_tile_stmts.append(suffix_stmt2)
+                if tcgen05_use_role_local_mma_exec:
+                    mma_exec_role_stmts.append(suffix_stmt2)
             # Bridge-only invalid-output diagnostic: preserve producer_commit
             # while removing only the acc producer PipelineState advance edge.
             if not diagnose_skip_acc_producer_advance:
-                advance_stmt = statement_from_string(
-                    emit_pipeline_advance(tcgen05_plan.acc_producer_state)
-                )
-                suffix.append(advance_stmt)
-                per_tile_stmts.append(advance_stmt)
-                if tcgen05_use_role_local_mma_exec:
-                    mma_exec_role_stmts.append(advance_stmt)
+                advance_states = [tcgen05_plan.acc_producer_state]
+                if tcgen05_m_subtile_count > 1:
+                    advance_states.append(tcgen05_plan.acc_producer_state2)
+                for advance_state in advance_states:
+                    for _ in range(tcgen05_m_subtile_count):
+                        advance_stmt = statement_from_string(
+                            emit_pipeline_advance(advance_state)
+                        )
+                        suffix.append(advance_stmt)
+                        per_tile_stmts.append(advance_stmt)
+                        if tcgen05_use_role_local_mma_exec:
+                            mma_exec_role_stmts.append(advance_stmt)
             # The tcgen05 epilogue + allocator teardown is emitted by
             # `_codegen_cute_store_tcgen05_tile` when the kernel stores
             # `out[tile_m, tile_n] = result`. Static-full flat and validated
@@ -12602,7 +12882,16 @@ def _mma_impl_matches_problem_shape(
             return False
         if bm in (64, 128):
             return True
-        return bm == TCGEN05_TWO_CTA_BLOCK_M and tcgen05_cluster_m == 2
+        if bm == TCGEN05_TWO_CTA_BLOCK_M and tcgen05_cluster_m == 2:
+            return True
+        # block_m=512 lowers as two 256-row M-paired CtaGroup.TWO subtiles
+        # (16-bit only); the codegen envelope gate rejects ineligible
+        # families with a loud BackendUnsupported.
+        return (
+            bm == 2 * TCGEN05_TWO_CTA_BLOCK_M
+            and tcgen05_cluster_m == 2
+            and input_dtype in (torch.float16, torch.bfloat16)
+        )
     return False
 
 
@@ -12878,6 +13167,7 @@ def _new_tcgen05_layout_plan(df: DeviceFunction) -> _Tcgen05LayoutPlan:
         acc_producer_state=df.new_var("tcgen05_acc_producer_state"),
         acc_consumer_state=df.new_var("tcgen05_acc_consumer_state"),
         epilogue_rest_mode=df.new_var("tcgen05_epilogue_rest_mode"),
+        acc_producer_state2=df.new_var("tcgen05_msub_acc_producer_state"),
     )
 
 

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -327,6 +327,10 @@ class CuteTcgen05MatmulPlan(_CuteTcgen05OrientationMixin):
     cluster_n: int = 1
     l2_swizzle_size: int = 1
     tma_store_full_tiles_only: bool = False
+    # M-paired tiles: number of 256-row UMMA subtiles per work tile along M
+    # (block_m // mma tile M). 2 stages B once per K stage and shares it
+    # across both subtiles, with one TMEM accumulator stage per subtile.
+    m_subtile_count: int = 1
     flat_role_launch_warp_count: int | None = None
     grouped: CuteTcgen05GroupedPlan | None = None
     # Per-anchor auxiliary descriptors discovered by the forward FX walker. This

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -600,6 +600,30 @@ class CuteTcgen05Config:
             return constraints.static_k // bk <= constraints.max_k_tiles
         return False
 
+    def _m_pair_block_m_is_valid(self) -> bool:
+        """Whether block_m=512 (M-paired tiles) is admissible for this kernel.
+
+        The codegen envelope is the plain 16-bit full-tile static family:
+        M divisible by 512 with the canonical 256-wide N tile (the fix pass
+        projects bn to 256 and validates bk). Aux kernels and edge families
+        keep block_m=256.
+        """
+        if self.aux_kernel_detected or self.matmul_has_leading_passthrough:
+            return False
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None or constraints.allow_edge_k_tail_family:
+            return False
+        for fact in self.config_spec.matmul_facts:
+            if (
+                fact.static_m is not None
+                and fact.static_m % (2 * TCGEN05_TWO_CTA_BLOCK_M) == 0
+                and fact.static_n is not None
+                and fact.static_n % TCGEN05_TWO_CTA_BLOCK_N == 0
+                and fact.lhs_dtype in (torch.float16, torch.bfloat16)
+            ):
+                return True
+        return False
+
     def full_tile_direct_entry_seed_bk(self) -> int | None:
         """Largest valid full-tile direct-entry K tile for the live shape.
 
@@ -877,6 +901,62 @@ class CuteTcgen05Config:
             ),
             TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: 1,
         }
+        if self.config_spec.indexing.length == 3:
+            seed_config["indexing"] = ["tensor_descriptor"] * 3
+        return Config(**seed_config)
+
+    def _plain_m_pair_seed_config(self) -> Config | None:
+        """Autotune seed for block_m=512 M-paired tiles (nvjet's B-reuse).
+
+        Two 256-row CtaGroup.TWO subtiles share each K stage's B buffer,
+        halving B's SMEM/L2/DRAM traffic. Measured fp16 16384^3: 986-990
+        TFLOP/s vs the block_m=256 CLC winner's 908 (co-timed vs cuBLAS's
+        971-981). The doubled A staging fits ab=2 at bk=128 under the B200
+        SMEM cap. Rides the CLC WITH_SCHEDULER shape when enabled, else the
+        static persistent default.
+        """
+        if not self._m_pair_block_m_is_valid():
+            return None
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None:
+            return None
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return None
+        fragments = self._matmul_block_fragments()
+        if fragments is None:
+            return None
+        bm_fragment, bn_fragment, bk_fragment = fragments
+        pair_bm = 2 * TCGEN05_TWO_CTA_BLOCK_M
+        if not (
+            bm_fragment.low <= pair_bm <= bm_fragment.high
+            and bn_fragment.low <= TCGEN05_TWO_CTA_BLOCK_N <= bn_fragment.high
+        ):
+            return None
+        bk = TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
+        if not (bk_fragment.low <= bk <= bk_fragment.high):
+            return None
+        if not self.cluster_m2_bk_is_valid(bk, constraints):
+            return None
+        seed_config: dict[str, Any] = {
+            "block_sizes": [pair_bm, TCGEN05_TWO_CTA_BLOCK_N, bk],
+            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            "l2_groupings": [4],
+            "tcgen05_cluster_m": 2,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_num_epi_warps": 4,
+            "tcgen05_ab_stages": 2,
+            "tcgen05_acc_stages": 2,
+        }
+        if self._plain_clc_persistence_search_enabled() and (
+            self._clc_persistence_search_enabled()
+        ):
+            seed_config[TCGEN05_STRATEGY_CONFIG_KEY] = (
+                Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+            )
+            seed_config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY] = (
+                Tcgen05PersistenceModel.CLC_PERSISTENT.value
+            )
+            seed_config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 1
         if self.config_spec.indexing.length == 3:
             seed_config["indexing"] = ["tensor_descriptor"] * 3
         return Config(**seed_config)
@@ -1205,6 +1285,39 @@ class CuteTcgen05Config:
         plain_edge_seed = self._plain_edge_seed_config()
         if plain_edge_seed is not None:
             seeds.append(plain_edge_seed)
+            # Edge-family 4-CTA multicast variant: with the generalized CLC
+            # broadcast this is quack's winning 5000^3 shape (dynamic
+            # persistence + cluster 2x2), measured 907 vs the cluster_n=1
+            # edge seed's 852 TFLOP/s.
+            edge_n2_seed_config: dict[str, Any] = dict(plain_edge_seed.config)
+            edge_n2_seed_config["tcgen05_cluster_n"] = 2
+            seeds.append(Config(**edge_n2_seed_config))
+        if plain_clc_seed is not None:
+            # Deep-staged bk=64 variant of the plain CLC seed: halving the K
+            # tile and doubling the AB pipeline depth absorbs UMMA latency on
+            # SHORT-K shapes where the per-tile K loop is otherwise too short
+            # to hide the drain (fp16 8192x6144x4096: ratio 1.002 vs cuBLAS
+            # at ab=6/bk=64/c=2, from 0.980 at the ab=3/bk=128 pick). cuBLAS
+            # nvjet uses the same 64x6 staging for this shape class.
+            deep_seed_config: dict[str, Any] = dict(plain_clc_seed.config)
+            deep_block_sizes = list(cast("list[int]", deep_seed_config["block_sizes"]))
+            deep_block_sizes[-1] = 64
+            constraints = self.cluster_m2_search_constraints
+            if (
+                constraints is not None
+                and self.cluster_m2_bk_is_valid(64, constraints)
+                and self.ab_stages_three_fits(
+                    bm=deep_block_sizes[0],
+                    bn=deep_block_sizes[1],
+                    bk=64,
+                    cluster_m=2,
+                    ab_stages=6,
+                )
+            ):
+                deep_seed_config["block_sizes"] = deep_block_sizes
+                deep_seed_config["tcgen05_ab_stages"] = 6
+                deep_seed_config["tcgen05_c_stages"] = 2
+                seeds.append(Config(**deep_seed_config))
         plain_cluster_n2_seed = self._plain_cluster_n2_seed_config()
         if plain_cluster_n2_seed is not None:
             seeds.append(plain_cluster_n2_seed)
@@ -1212,10 +1325,25 @@ class CuteTcgen05Config:
                 # 4-CTA multicast + CLC dynamic persistence (Quack's
                 # dynamic-persistent 2x2 topology): reuse the validated CLC
                 # seed shape (WITH_SCHEDULER + scheduler warp) and add the
-                # cluster-N multicast on top.
+                # cluster-N multicast on top. l2_groupings=[8] keeps the
+                # concurrent wave square in TILES (G rows x ~2G tile-cols of
+                # half-width boxes): measured best across the full-tile
+                # cn2+CLC probes (fp16 6144^3 994 vs 962 at [4]; fp16 deepK
+                # 934 vs 898; fp16 16384^3 899 vs 881).
                 clc_n2_seed_config: dict[str, Any] = dict(plain_clc_seed.config)
                 clc_n2_seed_config["tcgen05_cluster_n"] = 2
+                clc_n2_seed_config["l2_groupings"] = [8]
                 seeds.append(Config(**clc_n2_seed_config))
+        plain_m_pair_seed = self._plain_m_pair_seed_config()
+        if plain_m_pair_seed is not None:
+            seeds.append(plain_m_pair_seed)
+            # 2x2 super-tile: A multicast across the cluster-N pairs on top
+            # of the SMEM-shared B within each M-paired tile. Wins on
+            # K-dominated shapes (fp16 4096x4096x32768: ratio 1.016 vs
+            # cuBLAS, from 0.919 at block_m=256/cluster_n=1).
+            m_pair_cn2_seed_config: dict[str, Any] = dict(plain_m_pair_seed.config)
+            m_pair_cn2_seed_config["tcgen05_cluster_n"] = 2
+            seeds.append(Config(**m_pair_cn2_seed_config))
         c_input_seed = self._c_input_seed_config()
         if c_input_seed is not None:
             seeds.append(c_input_seed)
@@ -1329,7 +1457,18 @@ class CuteTcgen05Config:
             block_sizes[m_index] = TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
             block_sizes[n_index] = TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
             return
-        block_sizes[m_index] = TCGEN05_TWO_CTA_BLOCK_M
+        if (
+            block_sizes[m_index] == 2 * TCGEN05_TWO_CTA_BLOCK_M
+            and not edge_k_tail_family
+            and self._m_pair_block_m_is_valid()
+        ):
+            # Keep the sampled block_m=512 (M-paired tiles) and pin the knob
+            # its codegen envelope requires: both TMEM acc stages repurposed
+            # as the pair's accumulators. cluster_n stays searchable in
+            # {1, 2} (the 2x2 super-tile).
+            config["tcgen05_acc_stages"] = 2
+        else:
+            block_sizes[m_index] = TCGEN05_TWO_CTA_BLOCK_M
         # Only the fully validated narrow-N CLC+aux-TMA seed may keep
         # block_n=128; other candidates use the canonical block_n=256.
         if is_narrow_clc_aux_tma:
@@ -2830,7 +2969,11 @@ class CuteTcgen05Config:
         if config_view is None:
             return False
         block_sizes, m_index, n_index, k_index = config_view
-        if block_sizes[m_index] != TCGEN05_TWO_CTA_BLOCK_M:
+        if block_sizes[m_index] not in (
+            TCGEN05_TWO_CTA_BLOCK_M,
+            # M-paired tiles: two 256-row subtiles per work tile.
+            2 * TCGEN05_TWO_CTA_BLOCK_M,
+        ):
             return False
         if block_sizes[n_index] != TCGEN05_TWO_CTA_BLOCK_N:
             return False
@@ -2967,17 +3110,15 @@ class CuteTcgen05Config:
         else:
             cluster_m_choices = (1, 2)
         # cluster_n=2 (the Quack-canonical 4-CTA cluster: B multicast on top
-        # of the 2-CTA A multicast) is searchable on full-tile shapes — it
-        # wins big on B-heavy problems (fp16 4096x4096x32768: 911 vs 824
-        # TFLOP/s) and cuBLAS's nvjet picks 2x2 clusters for the same shape.
-        # Edge/K-tail shapes keep the (1,) surface: their double-edge SIMT
-        # epilogue and CLC scheduler broadcast are cluster_n=1-only.
-        cluster_n_full_tile_searchable = (
-            self.cluster_m2_search_constraints is not None
-            and not self.cluster_m2_search_constraints.allow_edge_k_tail_family
-        )
+        # of the 2-CTA A multicast) is searchable on every cluster_m=2
+        # family — it wins big on B-heavy problems (fp16 4096x4096x32768:
+        # 911 vs 824 TFLOP/s; cuBLAS's nvjet picks 2x2 clusters for the same
+        # shape) and, with the generalized 4-CTA CLC broadcast, closes the
+        # edge-family gap too (bf16 5000^3: 907 vs 852 TFLOP/s, matching
+        # quack's dynamic-persistent 2x2 within 1%).
+        cluster_n_searchable = self.cluster_m2_search_constraints is not None
         cluster_n_choices: tuple[int, ...] = (
-            (1, 2) if not for_search or cluster_n_full_tile_searchable else (1,)
+            (1, 2) if not for_search or cluster_n_searchable else (1,)
         )
         if for_search and self.num_epi_warps_search_choices is not None:
             num_epi_warps_fragment: ConfigSpecFragment = EnumFragment(

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -517,6 +517,21 @@ def _plan_cute_tcgen05_search_candidate(
         if static_m is None
         else min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
     )
+    # block_m=512 (tcgen05 M-paired tiles): two 256-row CtaGroup.TWO UMMA
+    # subtiles share each K stage's B buffer, halving B's SMEM/L2/DRAM
+    # traffic (fp16 16384^3: 0.92 -> 1.01 vs cuBLAS). Only searchable on the
+    # 16-bit full-tile plain family the codegen validates; the tcgen05
+    # config projections demote ineligible 512 samples back to 256.
+    if (
+        max_tcgen05_m == 256
+        and not is_fp8
+        and not is_tf32
+        and static_m is not None
+        and static_m % 512 == 0
+        and static_n is not None
+        and max_tcgen05_n >= 128
+    ):
+        max_search_m = 512
     max_search_n = max_tcgen05_n
     max_search_k = (
         128 if static_k is None else min(128, pow2_floor_at_least(static_k, mma_k))

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -1890,6 +1890,14 @@ def _codegen_cute_store_tcgen05_tile(
     tile_coord_n = f"({n_index}) // cutlass.Int32({tcgen05_destination_bn})"
     static_tile_coord_m = tile_coord_m
     static_tile_coord_n = tile_coord_n
+    # M-paired tiles: the epilogue body is wrapped in a two-iteration
+    # ``_tcgen05_msub`` loop (one per 256-row subtile); each iteration drains
+    # its own acc stage at the subtile's M tile coordinate.
+    tcgen05_m_subtile_count = (
+        matmul_plan.m_subtile_count if matmul_plan is not None else 1
+    )
+    if tcgen05_m_subtile_count > 1:
+        static_tile_coord_m = f"({tile_coord_m} + cutlass.Int32(_tcgen05_msub))"
     full_tile = df.new_var("tcgen05_full_tile")
 
     gmem_tile = df.new_var("tcgen05_gC")
@@ -4004,10 +4012,23 @@ def _codegen_cute_store_tcgen05_tile(
     # fallback edge tiles do not perturb the C-pipeline SMEM stage sequence.
     tma_c_buffer_expr = "cutlass.Int32(_tcgen05_subtile)"
     if tcgen05_value.role_local_tile_counter:
-        tma_c_buffer_expr = (
-            f"{tcgen05_value.role_local_tile_counter} * "
-            f"cutlass.Int32({subtile_count}) + cutlass.Int32(_tcgen05_subtile)"
-        )
+        if tcgen05_m_subtile_count > 1:
+            # The role-local tile counter advances once per WORK tile; fold
+            # the M-subtile index in so the C-ring parity stays continuous
+            # across the two drained subtiles regardless of subtile_count
+            # parity.
+            tma_c_buffer_expr = (
+                f"{tcgen05_value.role_local_tile_counter} * "
+                f"cutlass.Int32({tcgen05_m_subtile_count}) * "
+                f"cutlass.Int32({subtile_count}) + "
+                f"cutlass.Int32(_tcgen05_msub) * cutlass.Int32({subtile_count})"
+                " + cutlass.Int32(_tcgen05_subtile)"
+            )
+        else:
+            tma_c_buffer_expr = (
+                f"{tcgen05_value.role_local_tile_counter} * "
+                f"cutlass.Int32({subtile_count}) + cutlass.Int32(_tcgen05_subtile)"
+            )
     simt_store_edge_coord_preloaded = simt_edge_only and bool(aux_steps_in_chain)
     if simt_edge_only:
         simt_store_copy_source = _simt_edge_logical_divide_copy_source(
@@ -5766,9 +5787,20 @@ def _codegen_cute_store_tcgen05_tile(
         else:
             sync_before_stmt = statement_from_string("cute.arch.sync_threads()")
             sync_after_stmt = statement_from_string("cute.arch.sync_threads()")
-            main_stmt = statement_from_string(
-                "if True:\n" + textwrap.indent("\n".join(store_body_core), "    ")
-            )
+            if tcgen05_m_subtile_count > 1:
+                # M-paired tiles: drain both 256-row subtiles per work tile
+                # (their acc stages committed together after the shared-B K
+                # loop). ``unroll_full`` keeps ``_tcgen05_msub`` a trace-time
+                # Python int so tile coordinates stay static expressions.
+                main_stmt = statement_from_string(
+                    f"for _tcgen05_msub in cutlass.range("
+                    f"{tcgen05_m_subtile_count}, unroll_full=True):\n"
+                    + textwrap.indent("\n".join(store_body_core), "    ")
+                )
+            else:
+                main_stmt = statement_from_string(
+                    "if True:\n" + textwrap.indent("\n".join(store_body_core), "    ")
+                )
             df.cute_state.register_tcgen05_per_tile_stmts(
                 [sync_before_stmt, main_stmt, sync_after_stmt]
             )

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -5554,24 +5554,48 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         ]
         # FFI-eligible shapes have both DEFAULT-layout and direct-entry seeds.
         # Callers decide whether both are expected in the supplied population;
-        # every cluster_m=2 seed must still match the common tile envelope.
+        # every cluster_m=2 seed must still match one of the validated tile
+        # envelopes: the canonical 256x256 tile, the M-paired block_m=512 tile
+        # (two 256-row subtiles sharing B; baseline ab=2 only), or the
+        # deep-staged short-K variant (bk=64 with the ab=6 pipeline). At least
+        # one canonical-envelope seed must be present.
         self.assertGreaterEqual(len(seeded), 1)
+        canonical: list[dict[str, object]] = []
         for seed in seeded:
-            self.assertEqual(
-                seed["block_sizes"][:3],
-                [
-                    TCGEN05_TWO_CTA_BLOCK_M,
-                    TCGEN05_TWO_CTA_BLOCK_N,
-                    expected_block_k,
-                ],
-            )
+            block_sizes = seed["block_sizes"][:3]
+            if block_sizes[0] == 2 * TCGEN05_TWO_CTA_BLOCK_M:
+                self.assertEqual(
+                    block_sizes,
+                    [
+                        2 * TCGEN05_TWO_CTA_BLOCK_M,
+                        TCGEN05_TWO_CTA_BLOCK_N,
+                        expected_block_k,
+                    ],
+                )
+                self.assertEqual(seed["tcgen05_ab_stages"], 2)
+            elif seed.get("tcgen05_ab_stages") == 6:
+                self.assertEqual(
+                    block_sizes,
+                    [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, 64],
+                )
+            else:
+                self.assertEqual(
+                    block_sizes,
+                    [
+                        TCGEN05_TWO_CTA_BLOCK_M,
+                        TCGEN05_TWO_CTA_BLOCK_N,
+                        expected_block_k,
+                    ],
+                )
+                canonical.append(seed)
             self.assertEqual(
                 seed["indexing"],
                 ["tensor_descriptor"] * expected_indexing_length,
             )
             self.assertEqual(seed["pid_type"], "persistent_interleaved")
             self.assertEqual(seed["tcgen05_num_epi_warps"], 4)
-        return seeded[0]
+        self.assertGreaterEqual(len(canonical), 1)
+        return canonical[0]
 
     def _assert_cute_tcgen05_edge_k_tail_seed_overrides(
         self,

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -11038,6 +11038,204 @@ class TestCuteLowerings(unittest.TestCase):
                 expected = args[0] @ args[1]
                 torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
 
+    def test_tcgen05_m_pair_tiles_runtime_correctness(self) -> None:
+        """block_m=512 M-paired tiles (nvjet's B-reuse design).
+
+        Two 256-row CtaGroup.TWO UMMA subtiles share each K stage's B
+        buffer; the two TMEM acc stages hold the pair's accumulators and
+        the epilogue drains both subtiles per work tile. Covers CLC and
+        static persistence, bf16/fp16, an l2-grouped raster, and the
+        deep-AB bk=64 shape.
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_m_pair(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        torch.manual_seed(0)
+        cases = [
+            # (m, n, k, dtype, l2g, bk, ab, persistence, strategy, sched)
+            (
+                2048,
+                1024,
+                512,
+                torch.float16,
+                2,
+                128,
+                2,
+                "clc_persistent",
+                "role_local_with_scheduler",
+                1,
+            ),
+            (
+                2048,
+                1024,
+                512,
+                torch.bfloat16,
+                1,
+                128,
+                2,
+                "static_persistent",
+                "role_local_monolithic",
+                0,
+            ),
+            (
+                1024,
+                512,
+                256,
+                torch.float16,
+                1,
+                64,
+                4,
+                "clc_persistent",
+                "role_local_with_scheduler",
+                1,
+            ),
+        ]
+        for m, n, k, dtype, l2g, bk, ab, persistence, strategy, sched in cases:
+            with self.subTest(
+                m=m,
+                n=n,
+                k=k,
+                dtype=str(dtype),
+                l2g=l2g,
+                bk=bk,
+                persistence=persistence,
+            ):
+                args = (
+                    torch.randn(m, k, device=DEVICE, dtype=dtype),
+                    torch.randn(k, n, device=DEVICE, dtype=dtype),
+                )
+                with patch_cute_mma_support():
+                    bound = cute_matmul_m_pair.bind(args)
+                    bound.env.config_spec.cute_tcgen05_search_enabled = True
+                    cfg = _make_tcgen05_persistent_config(
+                        block_sizes=[512, 256, bk],
+                        l2_groupings=[l2g],
+                        pid_type="persistent_interleaved",
+                        tcgen05_cluster_m=2,
+                        tcgen05_cluster_n=1,
+                        tcgen05_ab_stages=ab,
+                        tcgen05_acc_stages=2,
+                        tcgen05_c_stages=2,
+                        tcgen05_persistence_model=persistence,
+                        tcgen05_strategy=strategy,
+                        tcgen05_warp_spec_scheduler_warps=sched,
+                    )
+                    bound.set_config(cfg)
+                    out = bound(*args)
+                expected = args[0] @ args[1]
+                torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
+    def test_tcgen05_m_pair_tiles_codegen_markers(self) -> None:
+        """block_m=512 emits the dual-A / dual-acc / paired-epilogue shape."""
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_m_pair_markers(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.randn(2048, 512, device=DEVICE, dtype=torch.bfloat16),
+            torch.randn(512, 1024, device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_m_pair_markers.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            cfg = _make_tcgen05_persistent_config(
+                block_sizes=[512, 256, 128],
+                l2_groupings=[1],
+                pid_type="persistent_interleaved",
+                tcgen05_cluster_m=2,
+                tcgen05_cluster_n=1,
+                tcgen05_ab_stages=2,
+                tcgen05_acc_stages=2,
+                tcgen05_c_stages=2,
+                tcgen05_persistence_model="clc_persistent",
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+            )
+            code = bound.to_triton_code(cfg)
+        # Dual A staging + fragment, per-K-stage dual copy, dual acc state,
+        # and the two-subtile epilogue loop.
+        self.assertIn("tcgen05_msub_sA", code)
+        self.assertIn("tcgen05_msub_tCrA", code)
+        self.assertIn("tcgen05_msub_acc_producer_state", code)
+        self.assertIn("for _tcgen05_msub in cutlass.range(2, unroll_full=True):", code)
+        self.assertEqual(code.count("cute.copy(tma_atom_a"), 6)
+
+    def test_tcgen05_m_pair_tiles_rejects_ineligible(self) -> None:
+        """block_m=512 outside the plain full-tile static family raises."""
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_m_pair_reject(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        # M=1280 is not divisible by 512: the pair grid would need a partial
+        # pair, which the M-paired family does not support.
+        args = (
+            torch.randn(1280, 512, device=DEVICE, dtype=torch.bfloat16),
+            torch.randn(512, 1024, device=DEVICE, dtype=torch.bfloat16),
+        )
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[512, 256, 128],
+            l2_groupings=[1],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_persistence_model="clc_persistent",
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_m_pair_reject.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            with self.assertRaisesRegex(exc.BackendUnsupported, "M-paired tiles"):
+                bound.to_triton_code(cfg)
+
     def test_tcgen05_clc_cluster_n2_codegen_broadcast_markers(self) -> None:
         """CLC 4-CTA broadcast codegen pins.
 

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -349,8 +349,10 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         spec = bound.config_spec
         self.assertEqual([x.min_size for x in spec.block_sizes], [128, 8, 16])
         # tile_k upper bound is now 128 (the static_k=8192 case; capped at 128
-        # to keep AB SMEM staging budget sane).
-        self.assertEqual([x.max_size for x in spec.block_sizes], [256, 256, 128])
+        # to keep AB SMEM staging budget sane). block_m's upper bound is 512:
+        # this fp16 full-tile shape (8192 % 512 == 0) admits the M-paired
+        # tiles envelope (two 256-row CtaGroup.TWO subtiles sharing B).
+        self.assertEqual([x.max_size for x in spec.block_sizes], [512, 256, 128])
         default_block_sizes = spec.default_config().config["block_sizes"]
         self.assertGreaterEqual(default_block_sizes[2], 16)
         self.assertLessEqual(default_block_sizes[2], 128)
@@ -1012,15 +1014,19 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         # round-trip even on a device the gate is off for.
         validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
         self.assertEqual(validation_fragments["tcgen05_ab_stages"].high, 3)
-        # The full-tile cluster_m=2 family now seeds four configs (the
+        # The full-tile cluster_m=2 family now seeds six configs (the
         # canonical static-persistent seed, the CLC dynamic-persistence
-        # scheduler seed, the 4-CTA cluster_n=2 seed, and the CLC + cluster_n=2
-        # seed) — none of which may carry ab=3 when the gate is off.
+        # scheduler seed, the 4-CTA cluster_n=2 seed, the CLC + cluster_n=2
+        # seed, and the two M-paired block_m=512 seeds) — none of which may
+        # deepen the AB pipeline past the baseline ab=2 when the gate is off.
+        # In particular the deep-staged bk=64/ab=6 CLC variant must NOT be
+        # seeded: its admission goes through ``ab_stages_three_fits``, which
+        # rejects every depth once the budget helper reports 0.
         seeds = spec.compiler_seed_configs
-        self.assertEqual(len(seeds), 4)
+        self.assertEqual(len(seeds), 6)
         self.assertNotIn("tcgen05_ab_stages", seeds[0].config)
         for seed in seeds:
-            self.assertNotEqual(seed.config.get("tcgen05_ab_stages"), 3)
+            self.assertIn(seed.config.get("tcgen05_ab_stages"), (None, 2))
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_ab_stages_three_uses_analyzed_block_indices(
@@ -1072,22 +1078,43 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         spec = bound.config_spec
 
         # 16-bit 4096^3 is FFI-eligible (fp16 == bf16 parity), so the initial
-        # population now carries TWO cluster_m=2 seeds: the DEFAULT-layout
-        # cluster_m=2 ab=3 seed and the generalized TVM-FFI direct-entry seed.
-        # Both must carry the canonical ab=3 fast-config envelope (the point of
-        # this test — that ab=3 is seeded rather than discovered by mutation).
+        # population carries several cluster_m=2 seeds: the DEFAULT-layout
+        # cluster_m=2 ab=3 seed, the generalized TVM-FFI direct-entry seed,
+        # and the CLC / cluster_n=2 variants. Every seed on the canonical
+        # 256x256x128 tile must carry the ab=3 fast-config envelope (the point
+        # of this test — that ab=3 is seeded rather than discovered by
+        # mutation).
         cluster_m2_seeds = [
             config.config
             for config in spec.compiler_seed_configs
             if config.config.get("tcgen05_cluster_m") == 2
         ]
         self.assertGreaterEqual(len(cluster_m2_seeds), 1)
-        for seed in cluster_m2_seeds:
-            self.assertEqual(
-                seed["block_sizes"][:3],
-                [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, 128],
-            )
+        canonical_seeds = [
+            seed
+            for seed in cluster_m2_seeds
+            if seed["block_sizes"][:3]
+            == [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, 128]
+        ]
+        self.assertGreaterEqual(len(canonical_seeds), 2)
+        for seed in canonical_seeds:
             self.assertEqual(seed["tcgen05_ab_stages"], 3)
+        # The same SMEM gate admits the deep-staged short-K variant, which must
+        # be seeded alongside the canonical family: bk=64 with the ab=6
+        # pipeline (nvjet's 64x6 staging).
+        deep_seeds = [seed for seed in cluster_m2_seeds if seed["block_sizes"][2] == 64]
+        self.assertEqual(len(deep_seeds), 1)
+        self.assertEqual(deep_seeds[0]["tcgen05_ab_stages"], 6)
+        # M-paired block_m=512 seeds keep the baseline ab=2: the doubled A
+        # staging leaves no headroom for a deeper AB pipeline at bk=128.
+        m_pair_seeds = [
+            seed
+            for seed in cluster_m2_seeds
+            if seed["block_sizes"][0] == 2 * TCGEN05_TWO_CTA_BLOCK_M
+        ]
+        self.assertGreaterEqual(len(m_pair_seeds), 1)
+        for seed in m_pair_seeds:
+            self.assertEqual(seed["tcgen05_ab_stages"], 2)
 
     @onlyBackends(["cute"])
     def test_cute_universal_matmul_lane_loop_correctness(self) -> None:


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3544
 * __->__#3532


--- --- ---

[cutedsl] tcgen05 M-paired tiles (block_m=512), 2x2 super-tile, deep-stage seed

block_m=512 lowers as TWO 256-row CtaGroup.TWO UMMA subtiles per work
tile: B is TMA-staged once per K stage and shared by both subtiles
(halving B's SMEM/L2/DRAM traffic - cuBLAS nvjet's design, identified
from its SMEM bank-write and DRAM counters at fp16 16384^3: nvjet
writes 13.0G banks vs our 17.3G = exactly half of B's staging), each
subtile owns one of the two TMEM accumulator stages (dual tiled-MMA
objects track ACCUMULATE independently; both stages are acquired before
the shared K loop and committed together), and the epilogue drains both
subtiles per work tile with a continuous C-ring parity. The pair grid
comes for free from the block size: pid decode, l2 grouping, scheduler
dims, and launch grid all see cdiv(M, 512) work tiles. The doubled A
staging fits ab=2 at bk=128 (ab=4 at bk=64) under the B200 SMEM cap;
the existing budget validators model it exactly since they take
block_m. Envelope: plain 16-bit full-tile static persistent
CtaGroup.TWO (loud BackendUnsupported otherwise; search projections
demote ineligible 512 samples to 256).

cluster_n=2 composes with the M-pair as the 2x2 super-tile (A multicast
across the cluster-N pairs on top of the SMEM-shared B), winning
K-dominated shapes. cluster_n=2 search is also widened to the
edge/K-tail family (the generalized CLC broadcast made it profitable),
with the edge 4-CTA CLC shape seeded; edge-family cluster_n=2 is gated
to l2 swizzle 1 (swizzle=8 hangs unkillably at bf16 5000^3, swizzle=4
fails NVVM). A deep-staged bk=64/ab=6/c=2 plain-CLC seed covers short-K
shapes where the per-tile K loop cannot hide the drain (nvjet's 64x6
staging).

Measured (co-timed ABAB on pinned GPUs, cold-autotune-found): fp16
16384^3 908.6 -> 977.8 TFLOP/s (ratio 0.912 -> 1.000 vs cuBLAS); fp16
6144^3 -> 1015.0 (0.942 -> 0.991); bf16 8192^3 -> 1071.1 (1.003 ->
1.039); bf16 ffn-down-70b -> 1049.3 (0.926 -> 0.997); fp16 smallM ->
960.2 (0.981 -> 1.020); fp16 lmhead -> 1139.4 (0.987 -> 0.993); bf16
ffn-down-7b -> 1177.8 (0.965 -> 1.028 vs helion-triton); fp16 deepK
(2x2 super-tile) -> 1026.2 (0.919 -> 1.019); fp16 qkv (deep bk64/ab6)
-> 1127.5 (0.984 -> 0.996). Bit-exact on the correctness gauntlets
(CLC/static, bf16/fp16, l2 groupings, bk=64 deep-AB, small grids).