### PR TITLE
Work around sm100 misaligned address in dots with TMEM-promoted LHS

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -617,6 +617,28 @@ def _fp8_block_ptr_padding_broken() -> bool:
     return version.parse("3.8.0") <= triton_version < version.parse("3.9.0")
 
 
+def sm100_dot_tmem_lhs_broken(device: torch.device) -> bool:
+    # call private func we can patch in testing
+    return _sm100_dot_tmem_lhs_broken(device)
+
+
+def _sm100_dot_tmem_lhs_broken(device: torch.device) -> bool:
+    """Whether ``tl.dot`` crashes with a misaligned address on sm100 when its LHS
+    operand is promoted to tensor memory and the accumulator is wider than 256.
+
+    On Blackwell, Triton's ``PromoteLHSToTMem`` pass places any dot LHS that is
+    not a plain load (e.g. the result of another dot, or any elementwise op) in
+    tensor memory.  With an M block of 64 the resulting TMEM allocation must
+    share rows with the accumulator, but an accumulator wider than 256 columns
+    is interleaved across both row halves, which the tcgen05 lowering
+    mishandles (triton-lang/triton#10309, unfixed as of triton 3.8/main).
+    Worked around in ``emit_tl_dot_with_padding`` by splitting the dot into two
+    M=32 halves; drop the workaround once the upstream fix ships.
+    """
+    capability = target_device_capability(device)
+    return capability is not None and capability[0] == 10
+
+
 @functools.cache
 def _regs_per_block() -> int:
     """Max 32-bit registers per block on the current CUDA device."""

--- a/helion/_compiler/matmul_utils.py
+++ b/helion/_compiler/matmul_utils.py
@@ -6,6 +6,7 @@ import sympy
 import torch
 
 from .._compat import min_dot_size
+from .._compat import sm100_dot_tmem_lhs_broken
 from .ast_extension import expr_from_string
 from .compile_environment import CompileEnvironment
 from .device_function import DeviceFunction
@@ -246,6 +247,57 @@ def _resolve_dim_size(
     return v
 
 
+def _dot_lhs_stays_in_smem(node: torch.fx.Node) -> bool:
+    """Whether Triton keeps this ``tl.dot`` LHS operand out of tensor memory.
+
+    Mirrors Triton's ``PromoteLHSToTMem`` heuristic on sm100: an LHS that is a
+    plain load (possibly through casts/transposes, including values passed in
+    from an enclosing graph) stays in shared memory; anything else (another
+    dot's output, elementwise math, constants) is staged through tensor
+    memory, which is broken for wide accumulators there (see
+    ``sm100_dot_tmem_lhs_broken``).  Loop-carried values resolve to their
+    initial value, so an LHS that starts as a load but is rebound to computed
+    values across iterations can be misclassified as safe.
+    """
+    # Imported here to avoid circular imports with helion.language.
+    from ..language._tracing_ops import _new_var
+    from ..language.memory_ops import load
+    from .device_ir import NodeArgsGraphInfo
+    from .host_function import HostFunction
+
+    transparent_targets = (
+        _new_var,
+        torch.ops.prims.convert_element_type.default,
+        torch.ops.aten._to_copy.default,
+        torch.ops.aten.permute.default,
+        torch.ops.aten.t.default,
+        torch.ops.aten.transpose.int,
+    )
+    # Codegen interprets per-config graph copies, but placeholder_to_outer_arg
+    # on a copy returns nodes from the original traced graphs, so search both.
+    graphs = [
+        *DeviceFunction.current().codegen.codegen_graphs,
+        *HostFunction.current().device_ir.graphs,
+    ]
+    while True:
+        if node.op == "placeholder":
+            graph_info = next((g for g in graphs if g.graph is node.graph), None)
+            if isinstance(graph_info, NodeArgsGraphInfo):
+                node = graph_info.placeholder_to_outer_arg(node)
+                continue
+            return False
+        if node.op != "call_function":
+            return False
+        if node.target is load:
+            return True
+        if node.target in transparent_targets and isinstance(
+            node.args[0], torch.fx.Node
+        ):
+            node = node.args[0]
+            continue
+        return False
+
+
 def _pad_tensor(
     tensor: ast.AST,
     pad_dim: int,
@@ -281,6 +333,7 @@ def emit_tl_dot_with_padding(
     lhs_shape: list[int | torch.SymInt],
     rhs_shape: list[int | torch.SymInt],
     acc_shape: list[int | torch.SymInt] | None = None,
+    lhs_fx_node: torch.fx.Node | None = None,
 ) -> ast.AST:
     device_fn = DeviceFunction.current()
     shape_str = device_fn.tile_strategy.shape_str
@@ -372,14 +425,71 @@ def emit_tl_dot_with_padding(
         pad_needed[d] = dim_value is not None and dim_value < min_sizes[d]
     need_padding = any(pad_needed.values())
 
-    if not need_padding:
-        result = _emit_tl_dot(
-            lhs_cast,
-            rhs_cast,
-            acc=acc_for_dot,
-            input_precision=input_precision,
-            out_dtype=dot_out_dtype,
+    # Triton crashes with a misaligned address on sm100 when a tl.dot LHS is
+    # promoted to tensor memory while the accumulator is wider than 256
+    # columns (triton-lang/triton#10309).  Split such dots into two M=32
+    # halves; splitting along N instead runs out of tensor memory because both
+    # halves' accumulators are live at the join.
+    split_m = (
+        lhs_fx_node is not None
+        and isinstance(m, int)
+        and m == 64
+        and isinstance(n, int)
+        and n > 256
+        and common_dtype.itemsize in (2, 4)
+        and (len(lhs_shape_list) == 2 or need_squeeze_dim)
+        and not (pad_needed["m"] or pad_needed["n"])
+        and env.backend.name == "triton"
+        and sm100_dot_tmem_lhs_broken(env.device)
+        and not _dot_lhs_stays_in_smem(lhs_fx_node)
+    )
+
+    def emit_dot(
+        lhs_final: ast.AST,
+        rhs_final: ast.AST,
+        acc_final: ast.AST | None,
+        k_final: int | torch.SymInt | sympy.Expr,
+    ) -> ast.AST:
+        if not split_m:
+            return _emit_tl_dot(
+                lhs_final,
+                rhs_final,
+                acc=acc_final,
+                input_precision=input_precision,
+                out_dtype=dot_out_dtype,
+            )
+
+        def split_half(x: ast.AST, last_dim: object, index: int) -> ast.AST:
+            # pyrefly: ignore [bad-argument-type]
+            shape = shape_str([2, 32, last_dim])
+            return expr_from_string(
+                f"tl.split(tl.permute(tl.reshape({{x}}, {shape}), [1, 2, 0]))[{index}]",
+                x=x,
+            )
+
+        halves = []
+        for index in (0, 1):
+            halves.append(
+                _emit_tl_dot(
+                    split_half(lhs_final, k_final, index),
+                    rhs_final,
+                    acc=split_half(acc_final, n, index)
+                    if acc_final is not None
+                    else None,
+                    input_precision=input_precision,
+                    out_dtype=dot_out_dtype,
+                )
+            )
+        # pyrefly: ignore [bad-argument-type]
+        out_shape = shape_str([m, n])
+        return expr_from_string(
+            f"tl.reshape(tl.permute(tl.join({{lo}}, {{hi}}), [2, 0, 1]), {out_shape})",
+            lo=halves[0],
+            hi=halves[1],
         )
+
+    if not need_padding:
+        result = emit_dot(lhs_cast, rhs_cast, acc_for_dot, k)
     else:
         lhs_pad, rhs_pad, acc_pad = lhs_cast, rhs_cast, acc_for_dot
         pad_specs = [
@@ -407,13 +517,7 @@ def emit_tl_dot_with_padding(
                     # pyrefly: ignore [unbound-name]
                     acc_pad = _pad_tensor(acc_pad, axis, cur, min_dim, other)
 
-        result = _emit_tl_dot(
-            lhs_pad,
-            rhs_pad,
-            acc=acc_pad,
-            input_precision=input_precision,
-            out_dtype=dot_out_dtype,
-        )
+        result = emit_dot(lhs_pad, rhs_pad, acc_pad, min_k if pad_needed["k"] else k)
 
         unpad_specs = [
             (

--- a/helion/_compiler/triton/aten_lowering.py
+++ b/helion/_compiler/triton/aten_lowering.py
@@ -239,6 +239,7 @@ def reduce_3d_dot(ctx: LoweringContext, node: Node, with_acc: bool) -> ast.AST:
         lhs_shape=lhs_shape,
         rhs_shape=rhs_shape,
         acc_shape=acc_shape,
+        lhs_fx_node=lhs_node,
     )
 
 

--- a/helion/_compiler/triton/matmul_ops.py
+++ b/helion/_compiler/triton/matmul_ops.py
@@ -67,6 +67,8 @@ def _(state: CodegenState) -> object:
     acc_arg = None if is_acc_none else acc_ast
     acc_dtype_arg = acc_dtype if not is_acc_none else None
 
+    lhs_fx_node = state.fx_node.args[0] if state.fx_node is not None else None
+
     # Perform dot with optional padding
     return emit_tl_dot_with_padding(
         lhs_ast,
@@ -79,6 +81,7 @@ def _(state: CodegenState) -> object:
         rhs_shape=rhs_shape,
         acc_shape=acc_shape,
         out_dtype=out_dtype,
+        lhs_fx_node=lhs_fx_node if isinstance(lhs_fx_node, torch.fx.Node) else None,
     )
 
 

--- a/test/test_dot.py
+++ b/test/test_dot.py
@@ -6,6 +6,7 @@ import itertools
 import os
 from typing import Callable
 import unittest
+from unittest.mock import patch
 
 import torch
 from torch.testing._internal.common_utils import instantiate_parametrized_tests
@@ -17,6 +18,7 @@ if _get_backend() in ("triton", "tileir"):
     import triton
 
 import helion
+from helion import _compat
 from helion._compat import min_dot_size
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
@@ -1099,6 +1101,133 @@ class TestDot(RefEagerTestBase, TestCase):
         self._test_reshape_n_2(
             lambda acc, a, b: acc + torch.matmul(a, b), rtol=1e-2, atol=5e-2
         )
+
+    def _make_chained_dot_kernel(self, with_acc: bool = False):
+        """Chained dot whose second dot has a dot-derived LHS and N=512.
+
+        Repro for https://github.com/pytorch/helion/issues/3472: on sm100
+        Triton promotes the dot-derived LHS to tensor memory and crashes with
+        a misaligned address when the accumulator is wider than 256 columns.
+        The wide dimension only appears in the second dot's RHS so the kernel
+        also fits in shared memory on smaller GPUs (e.g. A10G).
+        """
+
+        @helion.kernel(
+            autotune_effort="none",
+            static_shapes=True,
+            dot_precision=get_test_dot_precision(),
+        )
+        def chained_dot(
+            q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+        ) -> torch.Tensor:
+            m_dim, _ = q.size()
+            n_dim, _ = k.size()
+            _, out_dim = v.size()
+            out = torch.empty([m_dim, out_dim], dtype=q.dtype, device=q.device)
+            for tile_m in hl.tile(m_dim, block_size=64):
+                q_tile = q[tile_m, :]
+                acc = hl.zeros([tile_m, out_dim], dtype=torch.float32)
+                for tile_n in hl.tile(n_dim, block_size=32):
+                    k_tile = k[tile_n, :]
+                    v_tile = v[tile_n, :]
+                    qk = hl.dot(q_tile, torch.transpose(k_tile, 0, 1))
+                    acc = hl.dot(qk.to(q_tile.dtype), v_tile, acc=acc)
+                out[tile_m, :] = acc.to(q.dtype)
+            return out
+
+        @helion.kernel(
+            autotune_effort="none",
+            static_shapes=True,
+            dot_precision=get_test_dot_precision(),
+        )
+        def chained_dot_no_acc(
+            q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+        ) -> torch.Tensor:
+            m_dim, _ = q.size()
+            n_dim, _ = k.size()
+            _, out_dim = v.size()
+            out = torch.empty([m_dim, out_dim], dtype=q.dtype, device=q.device)
+            for tile_m in hl.tile(m_dim, block_size=64):
+                q_tile = q[tile_m, :]
+                for tile_n in hl.tile(n_dim, block_size=32):
+                    k_tile = k[tile_n, :]
+                    v_tile = v[tile_n, :]
+                    qk = hl.dot(q_tile, torch.transpose(k_tile, 0, 1))
+                    qk2 = hl.dot(qk.to(q_tile.dtype), v_tile)
+                    out[tile_m, :] = qk2
+            return out
+
+        return chained_dot if with_acc else chained_dot_no_acc
+
+    @staticmethod
+    def _make_chained_dot_args(
+        with_acc: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        # A single inner iteration for the no-acc kernel so its full-slice
+        # store is written exactly once (order-independent reference).
+        n_dim = 64 if with_acc else 32
+        q = torch.randn(32, 64, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.randn(n_dim, 64, device=DEVICE, dtype=torch.bfloat16)
+        v = torch.randn(n_dim, 512, device=DEVICE, dtype=torch.bfloat16)
+        return q, k, v
+
+    @staticmethod
+    def _chained_dot_ref(
+        q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+    ) -> torch.Tensor:
+        acc = torch.zeros(q.size(0), v.size(1), dtype=torch.float32, device=q.device)
+        for i in range(0, k.size(0), 32):
+            k_tile = k[i : i + 32].float()
+            v_tile = v[i : i + 32].float()
+            qk = (q.float() @ k_tile.T).to(q.dtype)
+            acc = acc + qk.float() @ v_tile
+        return acc.to(q.dtype)
+
+    def test_chained_dot_wide_n(self):
+        # https://github.com/pytorch/helion/issues/3472: misaligned address on
+        # sm100 with the default config; exercises the split-M workaround there.
+        for with_acc in (False, True):
+            kernel = self._make_chained_dot_kernel(with_acc)
+            args = self._make_chained_dot_args(with_acc)
+            _, result = code_and_output(kernel, args)
+            ref = self._chained_dot_ref(*args)
+            torch.testing.assert_close(result, ref, atol=1.0, rtol=0.02)
+
+    @skipIfRefEager("tests generated code")
+    @skipIfNotTriton("workaround is triton-specific")
+    @patch.object(_compat, "_sm100_dot_tmem_lhs_broken", lambda device: True)
+    def test_chained_dot_wide_n_split_m_codegen(self):
+        # With the sm100 workaround forced on, a dot-derived LHS with N=512
+        # must be split into two M=32 dots (tl.join of the halves)...
+        for with_acc in (False, True):
+            kernel = self._make_chained_dot_kernel(with_acc)
+            args = self._make_chained_dot_args(with_acc)
+            code, result = code_and_output(kernel, args)
+            self.assertIn("tl.join", code)
+            ref = self._chained_dot_ref(*args)
+            torch.testing.assert_close(result, ref, atol=1.0, rtol=0.02)
+
+        # ...while a plain load-fed dot with the same shape must not be split.
+        @helion.kernel(
+            autotune_effort="none",
+            static_shapes=True,
+            dot_precision=get_test_dot_precision(),
+        )
+        def plain_dot(a: torch.Tensor, k: torch.Tensor) -> torch.Tensor:
+            m_dim, n_dim = a.size()
+            _, d_dim = k.size()
+            out = torch.empty([m_dim, d_dim], dtype=a.dtype, device=a.device)
+            for tile_m in hl.tile(m_dim, block_size=64):
+                a_tile = a[tile_m, :]
+                out[tile_m, :] = hl.dot(a_tile, k[:, :]).to(a.dtype)
+            return out
+
+        a = torch.randn(64, 32, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.randn(32, 512, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(plain_dot, (a, k))
+        self.assertNotIn("tl.join", code)
+        ref = (a.float() @ k.float()).to(a.dtype)
+        torch.testing.assert_close(result, ref, atol=1.0, rtol=0.02)
 
     def test_scalar_arg_specialization_not_reused_across_values(self):
         """A runtime scalar epilogue arg must not poison later calls.


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#3534


--- --- ---

Work around sm100 misaligned address in dots with TMEM-promoted LHS

Fixes #3472

On Blackwell (sm100), Triton's PromoteLHSToTMem pass places any tl.dot
LHS that is not a plain load (e.g. another dot's output, or elementwise
math) in tensor memory. With an M block of 64 the TMEM operand must
share rows with the accumulator, but an accumulator wider than 256
columns is interleaved across both TMEM row halves, which the tcgen05
lowering mishandles and crashes with a CUDA misaligned address at
runtime (triton-lang/triton#10309, unfixed as of triton 3.8/main).
This broke both the default config and autotuning for kernels chaining
hl.dot/torch.matmul results into another dot with N >= 512, since the
crash poisons the CUDA context.

Work around it in emit_tl_dot_with_padding by splitting the affected
dot into two M=32 dots rejoined with tl.split/tl.join (M=32 avoids the
broken numRows==64 TMEM row-constraint path; splitting along N instead
runs out of tensor memory because both halves' accumulators are live at
the join). The split only fires when a new _compat predicate reports
the broken hardware and an FX provenance walk mirroring Triton's
comesFromLoadOrBlockArg heuristic says the LHS would be promoted, so
plain load-fed GEMMs are never split. Drop the workaround once the
upstream fix ships.

Verified on B200: the issue's repro is bit-exact vs a torch reference,
autotuning completes cleanly, and block_size=128 still reports Triton's
legitimate tensor-memory OutOfResources at compile time.