### PR TITLE
[cutedsl] Cluster row-split for rolled reductions

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -11,6 +11,7 @@ from .cute import CuteReductionWideChunkHeuristic
 from .cute import CuteResidentMultiRowHeuristic
 from .cute import CuteResidentRowHeuristic
 from .cute import CuteResidentRowWideClusterHeuristic
+from .cute import CuteRolledClusterLadderHeuristic
 from .cute import CuteRolledRowLadderHeuristic
 from .cute import CuteTcgen05ClusterM2FfiHeuristic
 from .cute import CuteTcgen05ClusterM2Heuristic
@@ -57,6 +58,7 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteReductionTileHeuristic,
         CuteReductionWideChunkHeuristic,
         CuteRolledRowLadderHeuristic,
+        CuteRolledClusterLadderHeuristic,
         CuteTileVecHeuristic,
         CuteTileVecWarpReduceHeuristic,
         CuteTileVecWarpPerRowHeuristic,

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -826,6 +826,90 @@ class CuteRolledRowLadderHeuristic(AutotunerHeuristic):
         return Config(**seed)
 
 
+class CuteRolledClusterLadderHeuristic(AutotunerHeuristic):
+    """Cluster row-split seed for very wide rolled row reductions: split
+    each row across a thread-block cluster so every CTA rolls a ~16k-element
+    slice (one DSM exchange combines the partials; every CTA gets the full
+    result and consumes only its slice).
+
+    Below the cluster the single-CTA rolled form must reload the whole row
+    for the consume sweep from gmem — at multi-hundred-KB rows that second
+    read misses L2 and costs ~1.5x DRAM traffic.  The 16k-element slice
+    target matches both the Quack rmsnorm heuristic (cluster_n =
+    N/16384 capped at 16) and the B200 hand-transplant measurements
+    (see benchmarks/cute/compare_rmsnorm_backends.py): 128 threads/CTA,
+    single roll trip over the slice.
+    """
+
+    name = "cute_rolled_cluster_ladder"
+    backend = "cute"
+
+    _SLICE_TARGET = 16384
+    _MAX_CLUSTER = 16
+    _THREADS_PER_ROW = 128
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        if not is_canonical_row_reduction(env):
+            return False
+        spec = env.config_spec
+        rl_spec = cast("ReductionLoopSpec", spec.reduction_loops[0])
+        return rl_spec.size_hint >= 4 * cls._SLICE_TARGET
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        spec = env.config_spec
+        rl_spec = cast("ReductionLoopSpec", spec.reduction_loops[0])
+        size_hint = rl_spec.size_hint
+        vec = _cute_seed_vec_width(
+            env, rl_spec, spec.max_reduction_threads or 1024, size_hint, device_ir
+        )
+        # Power of two only: the cute_cluster_n EnumFragment enumerates
+        # {1,2,4,8,16}, and an off-surface value would one-hot encode as
+        # all zeros in the search surrogate.
+        cluster_n = 1 << (
+            min(cls._MAX_CLUSTER, size_hint // cls._SLICE_TARGET).bit_length() - 1
+        )
+        threads_per_row = cls._THREADS_PER_ROW
+        # The rolled cluster split requires every CTA to roll whole chunks
+        # of its own contiguous slice (see LoopedReductionStrategy).
+        while cluster_n > 1 and size_hint % (cluster_n * threads_per_row * max(vec, 1)):
+            cluster_n //= 2
+        if cluster_n <= 1:
+            return None
+        # A chunk a few trips smaller than the slice schedules better than
+        # one whole-slice trip (measured on B200 at N=262144: 4616 vs
+        # 4350 GB/s) — the shorter unrolled body overlaps its loads across
+        # roll iterations instead of one long dependency chain.
+        slice_len = size_hint // cluster_n
+        chunk = max(threads_per_row * max(vec, 1), min(4096, slice_len))
+        while slice_len % chunk:
+            chunk //= 2
+        rdim_id = rl_spec.block_id
+        tile_id = spec.block_sizes[0].block_id
+        seed: dict[str, Any] = {
+            "block_sizes": [1],
+            "num_threads": _seq_config_list(
+                spec.num_threads, {tile_id: 1, rdim_id: threads_per_row}
+            ),
+            "reduction_loops": [chunk],
+            "cute_cluster_n": cluster_n,
+            "cute_lane_layouts": _seq_config_list(
+                spec.cute_lane_layouts, {rdim_id: "strided"}
+            ),
+        }
+        if vec > 1:
+            seed["cute_vector_widths"] = _seq_config_list(
+                spec.cute_vector_widths, {rdim_id: vec}
+            )
+        try:
+            return Config(**seed)
+        except Exception:
+            return None
+
+
 def _block_size_value_reachable(
     spec: ConfigSpec,
     block_index: int,

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -746,16 +746,7 @@ def _fx_trace_tensor_arg_rw_names(
     return out2
 
 
-def _reduction_fx_inter_loop_rw_names(
-    graph: torch.fx.Graph,
-    host: HostFunction,
-) -> tuple[frozenset[str], frozenset[str]]:
-    """Infer host buffer names read/written in a rolled reduction FX subgraph.
-
-    Resolves every hl.load / hl.store / atomic_* tensor arg back to host-named buffers.
-    Args not resolving to a host name are device-internal temporaries (no cross-wavefront
-    coherence) and are excluded.
-    """
+def _atomic_funcs() -> frozenset[Callable[..., object]]:
     from ..language import atomic_add
     from ..language import atomic_and
     from ..language import atomic_cas
@@ -764,9 +755,8 @@ def _reduction_fx_inter_loop_rw_names(
     from ..language import atomic_or
     from ..language import atomic_xchg
     from ..language import atomic_xor
-    from ..language import memory_ops
 
-    atomic_funcs = frozenset(
+    return frozenset(
         {
             atomic_add,
             atomic_and,
@@ -778,6 +768,21 @@ def _reduction_fx_inter_loop_rw_names(
             atomic_xor,
         }
     )
+
+
+def _reduction_fx_inter_loop_rw_names(
+    graph: torch.fx.Graph,
+    host: HostFunction,
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Infer host buffer names read/written in a rolled reduction FX subgraph.
+
+    Resolves every hl.load / hl.store / atomic_* tensor arg back to host-named buffers.
+    Args not resolving to a host name are device-internal temporaries (no cross-wavefront
+    coherence) and are excluded.
+    """
+    from ..language import memory_ops
+
+    atomic_funcs = _atomic_funcs()
     reads: set[str] = set()
     writes: set[str] = set()
 
@@ -816,6 +821,24 @@ class DeviceIR:
         self.noncanonical_task_origin_block_ids: set[int] = set()
         # Owning HostFunction (captured in ``lower_to_device_ir``).
         self.host_function: HostFunction | None = None
+        self._has_atomic_ops: bool | None = None
+
+    def has_atomic_ops(self) -> bool:
+        """True when any FX graph contains an ``hl.atomic_*`` call.
+
+        Used to gate optimizations that would replay side effects — e.g.
+        the CuTe cluster row-split executes every non-rolled statement once
+        per cluster CTA, which is benign for plain (idempotent) stores but
+        would repeat a read-modify-write ``cluster_n`` times.
+        """
+        if self._has_atomic_ops is None:
+            atomic_funcs = _atomic_funcs()
+            self._has_atomic_ops = any(
+                node.op == "call_function" and node.target in atomic_funcs
+                for info in self.graphs
+                for node in info.graph.nodes
+            )
+        return self._has_atomic_ops
 
     def __str__(self) -> str:
         return "\n\n".join(map(str, self.graphs))

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -193,6 +193,36 @@ def _cute_vec_kernel_mode() -> str:
     return "unroll" if has_cast else "vec"
 
 
+def _cute_cluster_reduce_smem_vars(
+    fn: DeviceFunction, group_span: int, cluster_n: int
+) -> tuple[str, str]:
+    """Allocate + initialize the SMEM receive buffer and single-phase
+    mbarrier for one ``_cute_grouped_reduce_cluster`` site in the kernel
+    preamble, and count the site so ``codegen_function_def`` emits ONE
+    ``mbarrier_init_fence`` + cluster arrive/wait covering every site (a
+    per-site cluster barrier costs ~10% of kernel time at cluster_n=16).
+    """
+    slots = (group_span // 32) * cluster_n
+    buf_var = fn.new_var("_cluster_red_buf", dce=False)
+    mbar_var = fn.new_var("_cluster_red_mbar", dce=False)
+    fn.preamble.append(
+        statement_from_string(
+            f"{buf_var} = cute.arch.alloc_smem(cutlass.Float32, {slots})"
+        )
+    )
+    fn.preamble.append(
+        statement_from_string(f"{mbar_var} = cute.arch.alloc_smem(cutlass.Int64, 1)")
+    )
+    fn.preamble.append(
+        statement_from_string(
+            "if cutlass.Int32(cute.arch.thread_idx()[0]) == 0:"
+            f"\n    cute.arch.mbarrier_init({mbar_var}, 1)"
+        )
+    )
+    fn.cute_state.simt_cluster_reduce_sites += 1
+    return buf_var, mbar_var
+
+
 def _block_has_indexed_reduction(fn: DeviceFunction, block_index: int) -> bool:
     """Return True when ``block_index`` is the reduction axis of any
     argmin/argmax in the device IR.
@@ -1267,6 +1297,79 @@ class LoopedReductionStrategy(ReductionStrategy):
         )
         self.offset_vars[block_index] = fn.new_var(f"roffset_{block_index}", dce=True)
         self.index_vars[block_index] = fn.new_var(f"rindex_{block_index}", dce=True)
+        # ``cute_cluster_n`` split of the rolled range across a thread-block
+        # cluster; decided lazily at the first ``codegen_device_loop`` (see
+        # ``_maybe_apply_cute_rolled_cluster``).
+        self._cute_rolled_cluster_n = 1
+        self._cute_rolled_cluster_checked = False
+
+    def _maybe_apply_cute_rolled_cluster(self, state: CodegenState) -> None:
+        """Decide whether ``cute_cluster_n`` applies to this rolled
+        reduction (mirrors ``PerThreadNDTileStrategy._maybe_apply_cute_cluster``
+        for the tile-loop form).
+
+        When applied, each of the ``cluster_n`` CTAs of a thread-block
+        cluster rolls over its own contiguous ``numel/cluster_n`` slice of
+        the reduction range, the finalize combines the partials across the
+        cluster with one DSM exchange (every CTA receives the full result,
+        so downstream row-scalar stores stay redundant-but-identical), and
+        the consume sweep re-iterates only the CTA's slice — so loads and
+        stores are sliced automatically.  The owning ``DeviceFunction``'s
+        ``cute_state.simt_cluster_n`` is set so the host-side call emits the
+        extra grid dim + cluster launch shape.
+        """
+        if self._cute_rolled_cluster_checked:
+            return
+        self._cute_rolled_cluster_checked = True
+        env = CompileEnvironment.current()
+        if env.backend.name != "cute":
+            return
+        cl = self.fn.config.config.get("cute_cluster_n", 1)
+        if not isinstance(cl, int) or cl <= 1:
+            return
+        if getattr(self.fn.cute_state, "simt_cluster_n", 1) > 1:
+            # Another device loop's strategy already claimed the cluster
+            # rank; splitting a second axis on the same rank would leave
+            # only the diagonal rank x rank slices covered.
+            return
+        # The finalize must go through the cross-warp two-stage path (the
+        # warp-shuffle path never crosses CTAs), and argreduce has no
+        # cluster combine.
+        if (
+            self._thread_count <= 32
+            or self._thread_count % 32 != 0
+            or _block_has_indexed_reduction(self.fn, self.block_index)
+        ):
+            return
+        # A masked roll cannot be cluster-split: the mask compares against
+        # the full extent, so a partial trailing chunk would read into the
+        # next rank's slice and double-count it.
+        if self._mask_var is not None:
+            return
+        # Statements outside the roll loop execute once per cluster CTA —
+        # benign for plain (idempotent) stores, but a read-modify-write
+        # would repeat ``cluster_n`` times.
+        if HostFunction.current().device_ir.has_atomic_ops():
+            return
+        # Sibling thread axes (e.g. a multi-row grid tile with block_m > 1)
+        # would make the whole-CTA cluster reduce fold unrelated rows.
+        grid_axis_sizes = getattr(
+            state.codegen.current_grid_state, "thread_axis_sizes", None
+        )
+        if isinstance(grid_axis_sizes, dict) and any(
+            size > 1 for size in grid_axis_sizes.values()
+        ):
+            return
+        numel = env.block_sizes[self.block_index].numel
+        try:
+            numel_int = int(numel)
+        except (TypeError, ValueError):
+            return
+        # Each CTA must roll whole chunks of its own contiguous slice.
+        if numel_int % (cl * self._loop_block_size) != 0:
+            return
+        self._cute_rolled_cluster_n = cl
+        self.fn.cute_state.simt_cluster_n = cl
 
     def _reduction_thread_count(self) -> int:
         return self._thread_count
@@ -1305,11 +1408,25 @@ class LoopedReductionStrategy(ReductionStrategy):
     ) -> str | None:
         env = CompileEnvironment.current()
         backend = env.backend
+        # Once ``_maybe_apply_cute_rolled_cluster`` sliced the roll range,
+        # every CTA holds only a partial sum — any fallback to a
+        # non-cluster reduction would silently drop the peer CTAs'
+        # contributions, so every bail-out below must hard-fail instead.
+        cluster_n = self._cute_rolled_cluster_n
+
+        def unsupported(reason: str) -> None:
+            if cluster_n > 1:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    f"cute_cluster_n > 1 rolled reduction: {reason}",
+                )
+
         if (
             backend.name != "cute"
             or self._thread_count <= 32
             or backend.is_indexed_reduction(reduction_type)
         ):
+            unsupported("requires a cross-warp non-indexed reduce")
             return None
 
         axis_sizes = self._active_thread_axis_sizes(state, device_loop)
@@ -1322,6 +1439,7 @@ class LoopedReductionStrategy(ReductionStrategy):
             num_threads *= size
         group_span = self._thread_count
         if num_threads % group_span != 0:
+            unsupported("thread axes do not tile the reduce group")
             return None
         # The two-stage shared-memory reduction assumes its ``lane_var`` is
         # the linear thread index across ALL of the launch block's threads.
@@ -1333,15 +1451,51 @@ class LoopedReductionStrategy(ReductionStrategy):
         planned_dims = self._planned_thread_dims()
         planned_block_threads = planned_dims[0] * planned_dims[1] * planned_dims[2]
         if num_threads != planned_block_threads:
+            unsupported("another strategy contributes unentered thread axes")
             return None
         lane_expr = backend.thread_linear_index_expr(axis_sizes)
         if lane_expr is None:
+            unsupported("no linear thread index for the block layout")
             return None
 
         identity_expr = backend.cast_expr(
             constant_repr(default_value), _dtype_str(dtype)
         )
         group_count = num_threads // group_span
+        if cluster_n > 1:
+            if group_count != 1:
+                # The cluster reduce combines across the WHOLE CTA; a
+                # multi-group reduce (several rows per CTA) would fold
+                # unrelated rows together.
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "cute_cluster_n > 1 requires a whole-CTA reduce group "
+                    "for the rolled reduction",
+                )
+            if reduction_type not in ("sum", "max", "min"):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    f"cute_cluster_n > 1 does not support {reduction_type!r} "
+                    "rolled reductions",
+                )
+            if dtype != torch.float32:
+                # The cluster exchange buffers every partial as Float32
+                # (see _cute_grouped_reduce_cluster) — a wider accumulator
+                # would silently lose precision through the round trip.
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "cute_cluster_n > 1 requires an fp32 reduction "
+                    f"accumulator, got {dtype}",
+                )
+            return self._emit_rolled_cluster_reduce(
+                device_loop=device_loop,
+                input_name=input_name,
+                reduction_type=reduction_type,
+                identity_expr=identity_expr,
+                lane_expr=lane_expr,
+                group_span=group_span,
+                cluster_n=cluster_n,
+            )
         lane_var = self.fn.new_var("looped_reduce_lane", dce=True)
         lane_in_group_var = self.fn.new_var("looped_reduce_lane_in_group", dce=True)
         lane_mod_pre_var = self.fn.new_var("looped_reduce_lane_mod_pre", dce=True)
@@ -1365,8 +1519,45 @@ class LoopedReductionStrategy(ReductionStrategy):
         )
         return result_var
 
+    def _emit_rolled_cluster_reduce(
+        self,
+        *,
+        device_loop: DeviceLoopState,
+        input_name: str,
+        reduction_type: str,
+        identity_expr: str,
+        lane_expr: str,
+        group_span: int,
+        cluster_n: int,
+    ) -> str:
+        """Finalize a cluster-split rolled reduction: combine the CTA's
+        partial across its warps AND the ``cluster_n`` peer CTAs with one
+        DSM exchange (every CTA receives the full result).  The SMEM
+        receive buffer and mbarrier are allocated + initialized in the
+        kernel preamble; ``codegen_function_def`` emits ONE
+        ``mbarrier_init_fence`` + cluster arrive/wait covering every site.
+        """
+        buf_var, mbar_var = _cute_cluster_reduce_smem_vars(
+            self.fn, group_span, cluster_n
+        )
+        lane_var = self.fn.new_var("looped_reduce_lane", dce=True)
+        result_var = self.fn.new_var("looped_reduce_result", dce=True)
+        device_loop.outer_suffix.append(
+            statement_from_string(f"{lane_var} = {lane_expr}")
+        )
+        device_loop.outer_suffix.append(
+            statement_from_string(
+                f"{result_var} = _cute_grouped_reduce_cluster("
+                f"{input_name}, {reduction_type!r}, {identity_expr}, "
+                f"{lane_var}, {buf_var}, {mbar_var}, "
+                f"group_span={group_span}, cluster_n={cluster_n})"
+            )
+        )
+        return result_var
+
     def codegen_device_loop(self, state: CodegenState) -> DeviceLoopState:
         env = CompileEnvironment.current()
+        self._maybe_apply_cute_rolled_cluster(state)
         block_index = self.block_index
         numel = env.block_sizes[block_index].numel
         offset_var = self.offset_var(block_index)
@@ -1501,6 +1692,17 @@ class LoopedReductionStrategy(ReductionStrategy):
                     )
                 ]
 
+        range_begin = "0"
+        range_end = state.sympy_expr(numel)
+        if self._cute_rolled_cluster_n > 1:
+            # Cluster split: each of the ``cluster_n`` CTAs rolls over its
+            # own contiguous slice (the launch adds a grid dim of
+            # ``cluster_n`` CTAs per outer index); the finalize combines
+            # the partials across the cluster.
+            slice_len = int(numel) // self._cute_rolled_cluster_n
+            rank_expr = env.backend.program_id_expr(1, index_dtype="cutlass.Int32")
+            range_begin = f"{rank_expr} * {slice_len}"
+            range_end = f"{rank_expr} * {slice_len} + {slice_len}"
         for_node = create(
             ast.For,
             target=create(ast.Name, id=offset_var, ctx=ast.Store()),
@@ -1508,8 +1710,8 @@ class LoopedReductionStrategy(ReductionStrategy):
                 self.get_range_call_str(
                     state.config,
                     [self.block_index],
-                    begin="0",
-                    end=state.sympy_expr(numel),
+                    begin=range_begin,
+                    end=range_end,
                     step=block_size_var,
                 ),
             ),
@@ -2374,32 +2576,20 @@ class BlockReductionStrategy(ReductionStrategy):
         if cluster_n > 1 and pre == 1 and group_count == 1:
             # The reduced axis is additionally split across the CTAs of a
             # thread-block cluster (``cute_cluster_n``): combine within-CTA
-            # warps and across the cluster with one DSM exchange.  The SMEM
-            # receive buffer and mbarrier are allocated + initialized in the
-            # kernel preamble; ``codegen_function_def`` emits ONE
-            # ``mbarrier_init_fence`` + cluster arrive/wait covering every
-            # site (a per-site cluster barrier costs ~10% of kernel time at
-            # cluster_n=16).
-            slots = (group_span // 32) * cluster_n
-            buf_var = self.fn.new_var("_cluster_red_buf", dce=False)
-            mbar_var = self.fn.new_var("_cluster_red_mbar", dce=False)
-            self.fn.preamble.append(
-                statement_from_string(
-                    f"{buf_var} = cute.arch.alloc_smem(cutlass.Float32, {slots})"
+            # warps and across the cluster with one DSM exchange.
+            acc_dtype = get_computation_dtype(fake_input.dtype)
+            if acc_dtype != torch.float32:
+                # The cluster exchange buffers every partial as Float32
+                # (see _cute_grouped_reduce_cluster) — a wider accumulator
+                # would silently lose precision through the round trip.
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "cute_cluster_n > 1 requires an fp32 reduction "
+                    f"accumulator, got {acc_dtype}",
                 )
+            buf_var, mbar_var = _cute_cluster_reduce_smem_vars(
+                self.fn, group_span, cluster_n
             )
-            self.fn.preamble.append(
-                statement_from_string(
-                    f"{mbar_var} = cute.arch.alloc_smem(cutlass.Int64, 1)"
-                )
-            )
-            self.fn.preamble.append(
-                statement_from_string(
-                    "if cutlass.Int32(cute.arch.thread_idx()[0]) == 0:"
-                    f"\n    cute.arch.mbarrier_init({mbar_var}, 1)"
-                )
-            )
-            self.fn.cute_state.simt_cluster_reduce_sites += 1
             state.add_statement(
                 f"{result_var} = _cute_grouped_reduce_cluster("
                 f"{input_name}, {reduction_type!r}, {identity_expr}, "

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -3920,6 +3920,13 @@ class PerThreadNDTileStrategy(NDTileStrategy):
             return
         if len(self._lane_var_by_block) != 1:
             return
+        # Statements outside the cluster-split loop execute once per
+        # cluster CTA — benign for plain (idempotent) stores, but a
+        # read-modify-write would repeat ``cluster_n`` times.
+        from .host_function import HostFunction
+
+        if HostFunction.current().device_ir.has_atomic_ops():
+            return
         # The cluster reduce combines across the WHOLE CTA, so the grid
         # strategy must not put sibling axes on thread dims (e.g. a
         # multi-row grid tile with block_m > 1) — those rows would be

--- a/test/test_cute_rolled_cluster.py
+++ b/test/test_cute_rolled_cluster.py
@@ -1,0 +1,225 @@
+"""Tests for the ``cute_cluster_n`` split of rolled (LoopedReductionStrategy)
+row reductions.
+
+For a rolled row reduction (rmsnorm/layernorm family: one grid tile over
+rows, the full reduction dim rolled in a loop), ``cute_cluster_n > 1``
+splits each row's roll range across the CTAs of a thread-block cluster;
+one DSM exchange combines the partials (every CTA receives the full
+result) and the consume sweep stores only the CTA's slice.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@helion.kernel(backend="cute")
+def rms_norm_rolled_kernel(
+    x: torch.Tensor, weight: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Mirrors ``examples/rms_norm.py::rms_norm_fwd``."""
+    m, n = x.size()
+    out = torch.empty_like(x)
+    inv_rms = torch.empty([m], dtype=torch.float32, device=x.device)
+    for tile_m in hl.tile(m):
+        x_tile = x[tile_m, :].to(torch.float32)
+        mean_x_squared = torch.mean(x_tile * x_tile, dim=-1)
+        inv_rms_tile = torch.rsqrt(mean_x_squared + 1e-6)
+        out[tile_m, :] = (
+            x_tile * inv_rms_tile[:, None] * weight[:].to(torch.float32)
+        ).to(out.dtype)
+        inv_rms[tile_m] = inv_rms_tile
+    return out, inv_rms
+
+
+@helion.kernel(backend="cute")
+def row_amax_rolled_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty([m], dtype=torch.float32, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = torch.amax(x[tile_m, :].to(torch.float32), dim=-1)
+    return out
+
+
+@helion.kernel(backend="cute")
+def int_rowsum_rolled_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty([m], dtype=torch.int64, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = torch.sum(x[tile_m, :].to(torch.int64), dim=-1)
+    return out
+
+
+@helion.kernel(backend="cute")
+def rowsum_atomic_total_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    total = torch.zeros([1], dtype=torch.float32, device=x.device)
+    for tile_m in hl.tile(m):
+        s = torch.sum(x[tile_m, :].to(torch.float32), dim=-1)
+        hl.atomic_add(total, [0], s.sum())
+    return total
+
+
+def _rms_ref(
+    x: torch.Tensor, weight: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    xf = x.float()
+    inv_rms = torch.rsqrt(xf.square().mean(dim=-1) + 1e-6)
+    return (xf * inv_rms[:, None] * weight.float()).to(x.dtype), inv_rms
+
+
+@onlyBackends(["cute"])
+class TestCuteRolledCluster(TestCase):
+    def test_rolled_cluster_fires_bf16_cl4(self) -> None:
+        """bf16 rmsnorm with ``cute_cluster_n=4``: the roll range is sliced
+        by the cluster rank, the finalize is one DSM cluster exchange, and
+        the launch carries the cluster shape."""
+        x = torch.randn(32, 8192, device=DEVICE, dtype=torch.bfloat16)
+        weight = torch.randn(8192, device=DEVICE, dtype=torch.bfloat16)
+        code, (out, inv_rms) = code_and_output(
+            rms_norm_rolled_kernel,
+            (x, weight),
+            block_sizes=[1],
+            num_threads=[1, 128],
+            reduction_loops=[2048],
+            cute_vector_widths=[8, 1],
+            cute_cluster_n=4,
+        )
+        ref_out, ref_inv_rms = _rms_ref(x, weight)
+        torch.testing.assert_close(out, ref_out, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(inv_rms, ref_inv_rms, rtol=1e-3, atol=1e-3)
+        self.assertIn("_cute_grouped_reduce_cluster(", code)
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage(", code)
+        # Rank-sliced roll range (slice = 8192 / 4) on both sweeps.
+        self.assertEqual(code.count("cute.arch.block_idx()[1]) * 2048"), 4)
+        self.assertIn("_helion_cute_cluster_shape = (1, 4, 1)", code)
+
+    def test_rolled_cluster_correct_fp32_cl2_multitrip(self) -> None:
+        """fp32 (vec mode) with two roll trips per slice."""
+        x = torch.randn(16, 8192, device=DEVICE, dtype=torch.float32)
+        weight = torch.randn(8192, device=DEVICE, dtype=torch.float32)
+        code, (out, inv_rms) = code_and_output(
+            rms_norm_rolled_kernel,
+            (x, weight),
+            block_sizes=[1],
+            num_threads=[1, 128],
+            reduction_loops=[2048],
+            cute_vector_widths=[4, 1],
+            cute_cluster_n=2,
+        )
+        ref_out, ref_inv_rms = _rms_ref(x, weight)
+        torch.testing.assert_close(out, ref_out, rtol=1e-4, atol=1e-4)
+        torch.testing.assert_close(inv_rms, ref_inv_rms, rtol=1e-4, atol=1e-4)
+        self.assertIn("_cute_grouped_reduce_cluster(", code)
+        self.assertIn("_helion_cute_cluster_shape = (1, 2, 1)", code)
+
+    def test_rolled_cluster_max_reduction(self) -> None:
+        x = torch.randn(32, 8192, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            row_amax_rolled_kernel,
+            (x,),
+            block_sizes=[1],
+            num_threads=[1, 128],
+            reduction_loops=[2048],
+            cute_vector_widths=[8, 1],
+            cute_cluster_n=2,
+        )
+        torch.testing.assert_close(out, x.float().amax(dim=-1))
+        self.assertIn("_cute_grouped_reduce_cluster(", code)
+
+    def test_rolled_cluster_skipped_indivisible(self) -> None:
+        """When the extent does not split into whole per-CTA chunk multiples
+        the knob is silently inert (single-CTA rolled codegen, still
+        correct)."""
+        x = torch.randn(32, 6144, device=DEVICE, dtype=torch.bfloat16)
+        weight = torch.randn(6144, device=DEVICE, dtype=torch.bfloat16)
+        code, (out, inv_rms) = code_and_output(
+            rms_norm_rolled_kernel,
+            (x, weight),
+            block_sizes=[1],
+            num_threads=[1, 128],
+            reduction_loops=[2048],
+            cute_vector_widths=[8, 1],
+            cute_cluster_n=4,
+        )
+        ref_out, ref_inv_rms = _rms_ref(x, weight)
+        torch.testing.assert_close(out, ref_out, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(inv_rms, ref_inv_rms, rtol=1e-3, atol=1e-3)
+        self.assertNotIn("_cute_grouped_reduce_cluster(", code)
+        self.assertNotIn("_helion_cute_cluster_shape", code)
+
+    def test_rolled_cluster_skipped_multirow_cta(self) -> None:
+        """Multiple rows per CTA (a sibling thread axis) would make the
+        whole-CTA cluster reduce fold unrelated rows — the knob must stay
+        inert."""
+        x = torch.randn(32, 4096, device=DEVICE, dtype=torch.bfloat16)
+        weight = torch.randn(4096, device=DEVICE, dtype=torch.bfloat16)
+        code, (out, inv_rms) = code_and_output(
+            rms_norm_rolled_kernel,
+            (x, weight),
+            block_sizes=[4],
+            num_threads=[4, 64],
+            reduction_loops=[1024],
+            cute_vector_widths=[8, 1],
+            cute_cluster_n=2,
+        )
+        ref_out, ref_inv_rms = _rms_ref(x, weight)
+        torch.testing.assert_close(out, ref_out, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(inv_rms, ref_inv_rms, rtol=1e-3, atol=1e-3)
+        self.assertNotIn("_cute_grouped_reduce_cluster(", code)
+        self.assertNotIn("_helion_cute_cluster_shape", code)
+
+    def test_rolled_cluster_rejects_non_fp32_acc(self) -> None:
+        """The cluster exchange buffers partials as fp32; a wider
+        accumulator must hard-fail instead of silently losing precision."""
+        x = torch.randint(0, 4, (16, 4096), device=DEVICE, dtype=torch.int32)
+        cfg = {
+            "block_sizes": [1],
+            "num_threads": [1, 128],
+            "reduction_loops": [1024],
+            "cute_vector_widths": [1, 1],
+        }
+        # Same config runs (exactly) without the cluster.
+        code, out = code_and_output(
+            int_rowsum_rolled_kernel, (x,), **cfg, cute_cluster_n=1
+        )
+        self.assertTrue(torch.equal(out, x.to(torch.int64).sum(dim=-1)))
+        with self.assertRaisesRegex(
+            helion.exc.BackendUnsupported, "fp32 reduction accumulator"
+        ):
+            code_and_output(int_rowsum_rolled_kernel, (x,), **cfg, cute_cluster_n=2)
+
+    def test_rolled_cluster_skipped_with_atomics(self) -> None:
+        """Statements outside the roll loop run once per cluster CTA, so a
+        kernel using atomics (read-modify-write would replay cluster_n
+        times) must keep the knob inert."""
+        x = torch.randn(16, 4096, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            rowsum_atomic_total_kernel,
+            (x,),
+            block_sizes=[1],
+            num_threads=[1, 128],
+            reduction_loops=[1024],
+            cute_vector_widths=[1, 1],
+            cute_cluster_n=2,
+        )
+        torch.testing.assert_close(out[0], x.float().sum(), rtol=1e-2, atol=1.0)
+        self.assertNotIn("_cute_grouped_reduce_cluster(", code)
+        self.assertNotIn("_helion_cute_cluster_shape", code)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3560
 * #3559
 * #3558
 * #3557
 * #3556
 * #3555
 * #3554
 * #3541
 * #3540
 * #3539
 * #3538
 * #3537
 * __->__#3536
 * #3535


--- --- ---

[cutedsl] Cluster row-split for rolled reductions

For a rolled (LoopedReductionStrategy) row reduction, cute_cluster_n > 1
now splits each row's roll range across the CTAs of a thread-block
cluster: every CTA rolls a contiguous numel/cluster_n slice, one DSM
exchange (_cute_grouped_reduce_cluster) combines the partials so every
CTA receives the full result, and the consume sweep re-iterates only the
CTA's slice — so loads and stores are sliced automatically. Previously
the knob only applied to the tile-loop (PerThreadNDTileStrategy) form.

This removes the second full-row gmem read that the single-CTA rolled
form pays for the consume sweep at multi-hundred-KB rows (where the
reload misses L2): on B200 bf16 rmsnorm fwd it lifts 8192x262144 from
3786 to 4599 GB/s and 16384x131072 from 4057 to 4746 GB/s (cold full
autotune), matching or beating the best Quack config sweep.

The gate mirrors the tile-form _maybe_apply_cute_cluster: single claimant
of the cluster rank, cross-warp non-indexed sum/max/min reduce spanning
the whole CTA, unmasked roll, and the extent splitting into whole
per-CTA chunk multiples — otherwise the knob is silently inert. Once the
range is sliced, any fallback to a non-cluster reduce hard-fails instead
of silently dropping peer CTAs' partials (validate_cluster_reduce_placement
still backstops multi-trip placements).

CuteRolledClusterLadderHeuristic seeds the search for wide rows
(>= 64k elements): cluster_n targeting ~16k-element slices (capped at
16), 128 threads per row, and a ~4096-element chunk, matching both the
Quack rmsnorm heuristic ladder and B200 hand-transplant measurements.