### PR TITLE
[cutedsl] Fix silent fp32 corruption at V>1: retire vec mode, extend unroll to fp32

### DIFF
--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -22,6 +22,7 @@ from torch.fx.node import map_arg
 from ... import exc
 from ...language import _decorators
 from ...language.memory_ops import _CUTE_VECTOR_DTYPES
+from ...language.memory_ops import _CUTE_VECTOR_UNROLL_CARRIER
 from ...language.memory_ops import _CUTE_VECTOR_UNROLL_DTYPES
 from ...language.memory_ops import _codegen_cute_store_permute_lane_loops
 from ...language.memory_ops import _codegen_cute_store_tcgen05_tile
@@ -30,7 +31,6 @@ from ...language.memory_ops import _cute_active_mask_var
 from ...language.memory_ops import _cute_combined_mask
 from ...language.memory_ops import _cute_index_exprs
 from ...language.memory_ops import _cute_index_tuple
-from ...language.memory_ops import _cute_is_byte_packed
 from ...language.memory_ops import _cute_is_unroll_dtype
 from ...language.memory_ops import _cute_register_reduction_unroll_vec_store
 from ...language.memory_ops import _cute_register_tile_unroll_vec_hoist
@@ -39,7 +39,6 @@ from ...language.memory_ops import _cute_scalar_load_expr
 from ...language.memory_ops import _cute_scalar_pointer_expr
 from ...language.memory_ops import _cute_tensor_dim_size_expr
 from ...language.memory_ops import _cute_unique_graph_block_id
-from ...language.memory_ops import _cute_unroll_vec_elem_type
 from ...language.memory_ops import _matching_block_ids
 from ...language.memory_ops import _maybe_codegen_cute_packed_affine_lhs_load
 from ...language.memory_ops import load
@@ -166,18 +165,6 @@ def _cute_scalar_store_expr(
     return f"{_cute_scalar_pointer_expr(tensor_name, index_exprs)}.store({value})"
 
 
-def _cute_unroll_vec_load_dtype_arg(dtype: torch.dtype, vec_width: int) -> str:
-    """The dtype argument to ``cute.arch.load`` for an unroll-mode hoist.
-
-    fp8 loads ``vec_width`` contiguous bytes as ONE packed scalar integer
-    (no ``VectorType`` — avoids the V=8 ``nvvm.load.ext`` ICE and emits a
-    single LDG).  bf16/fp16 load a ``Uint16`` vector of width ``vec_width``.
-    """
-    if _cute_is_byte_packed(dtype):
-        return _cute_unroll_vec_elem_type(dtype, vec_width) + ".mlir_type"
-    return f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type)"
-
-
 _CUTE_EVICTION_POLICY_MAP = {
     "": "",
     "first": "evict_first",
@@ -227,7 +214,7 @@ def _cute_register_unroll_vec_hoist(
     vec_width: int,
     eviction_suffix: str = "",
 ) -> str:
-    """Register a Uint16 vec load to be hoisted above the constexpr V-loop
+    """Register an integer-carrier vec load to be hoisted above the constexpr V-loop
     in the active lane body and return the per-element extract expression.
 
     The hoist runs once per outer-lane iter; the constexpr V-loop's body
@@ -235,6 +222,7 @@ def _cute_register_unroll_vec_hoist(
     cast/mul/accumulate pipeline keeps working unchanged.
     """
     elem_dtype = _CUTE_VECTOR_UNROLL_DTYPES[tensor.dtype]
+    carrier = _CUTE_VECTOR_UNROLL_CARRIER[tensor.dtype]
     base_index_var = getattr(strategy, "_cute_lane_base_index_var", None)
     lane_body = getattr(strategy, "_cute_lane_body", None)
     assert isinstance(base_index_var, str)
@@ -264,7 +252,7 @@ def _cute_register_unroll_vec_hoist(
         cache[cache_key] = (hoist_var, tensor.dtype)
         hoist_stmt = statement_from_string(
             f"{hoist_var} = cute.arch.load({base_ptr_expr}, "
-            f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type)"
+            f"ir.VectorType.get([{vec_width}], {carrier}.mlir_type)"
             f"{eviction_suffix})"
         )
         # Insert the hoist just BEFORE the constexpr V-loop.
@@ -274,7 +262,7 @@ def _cute_register_unroll_vec_hoist(
     assert isinstance(constexpr_loop, ast.For)
     assert isinstance(constexpr_loop.target, ast.Name)
     vec_lane_var = constexpr_loop.target.id
-    return f"cutlass.Uint16({hoist_var}[{vec_lane_var}]).bitcast({elem_dtype})"
+    return f"{carrier}({hoist_var}[{vec_lane_var}]).bitcast({elem_dtype})"
 
 
 def _cute_stack_tensor_offset_expr(
@@ -2122,7 +2110,7 @@ def _cute_vector_load_ctx(
             return None
         if strategy._cute_reduction_lane_extent <= 0:
             return None
-        mode = getattr(strategy, "_cute_reduction_vec_mode", "vec")
+        mode = getattr(strategy, "_cute_reduction_vec_mode", "unroll")
         if mode == "vec":
             if not feeds_reduction:
                 return None
@@ -2131,6 +2119,10 @@ def _cute_vector_load_ctx(
             return vec_width, inner_block_id, "vec"
         if mode == "unroll":
             if tensor.dtype not in _CUTE_VECTOR_UNROLL_DTYPES:
+                return None
+            # Cap at one LDG.128 per hoist (fp32 V=8 would need 32 bytes);
+            # oversized configs stay on the (correct) scalar fallback.
+            if vec_width * tensor.dtype.itemsize > 16:
                 return None
             # Need a lane base index var + a constexpr V-loop var; both
             # are set up by the strategy's codegen_device_loop.
@@ -2160,9 +2152,9 @@ def _cute_vector_load_ctx(
             return None
         if not _cute_is_unroll_dtype(tensor.dtype):
             return None
-        # Widths above 8 (32 bytes per thread for 16-bit dtypes) exceed
-        # the widest gmem access (LDG.128) and are not supported.
-        if vec_width > 8:
+        # Cap at one LDG.128 per hoist: wider than 16 bytes per thread
+        # exceeds the widest gmem access and is not supported.
+        if vec_width * tensor.dtype.itemsize > 16:
             return None
         base_var_by_block = getattr(
             strategy, "_cute_lane_base_index_var_by_block", None

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -147,16 +147,20 @@ def _strategies_concurrent_with_block(
 
 
 def _cute_vec_kernel_mode() -> str:
-    """Return ``"vec"`` when all reduction-feeding loads are vec-eligible
-    without a degrading dtype cast (i.e. fp32 -> fp32 pipeline), ``"unroll"``
-    when at least one load uses the bf16/fp16 -> fp32 cast pattern that the
-    CuTe DSL's ``Float32(vec)`` constructor would silently scalarise, or
-    ``"none"`` when there's no looped reduction at all.
+    """Return the vec-lattice mode for looped reductions: always ``"unroll"``.
 
-    ``"vec"`` lets the strategy emit a single ``cute.arch.load(..., V)`` +
-    V-fold per lane iter.  ``"unroll"`` falls back to a constexpr V-loop
-    around per-element scalar loads — the CUTLASS DSL cannot iterate the
-    elements of a bf16/fp16 vector without crashing during compile.
+    ``"unroll"`` partitions the lane extent into outer x V and walks each
+    V-chunk with a hoisted integer-vector load (Uint16 for bf16/fp16,
+    Uint32 for fp32) plus per-lane bitcasts; loads that cannot vectorize
+    fall back to per-element scalar loads INSIDE the V-loop, which keeps
+    the lattice and the loads consistent.
+
+    The retired ``"vec"`` mode (explicit ``cute.arch.load(..., V)`` +
+    ``_cute_pre_vec_fold``) was selected for pure-fp32 kernels but its
+    load-side gate (``feeds_reduction``) never matched aten reduction
+    targets, so every fp32 config with V > 1 emitted vec-lattice indexing
+    with SCALAR loads — reading 1/V of the row and silently corrupting
+    results (only the autotuner's accuracy check filtered such configs).
     """
     from .host_function import HostFunction
     from .host_function import NoCurrentFunction
@@ -167,30 +171,7 @@ def _cute_vec_kernel_mode() -> str:
         return "none"
     if hf._device_ir is None:
         return "none"
-    cast_targets = {
-        "convert_element_type.default",
-        "convert_element_type",
-        "_to_copy.default",
-        "_to_copy",
-    }
-    from ..language import memory_ops as _memory_ops
-
-    load_target = _memory_ops.load
-    has_cast = False
-    for graph_info in hf.device_ir.graphs:
-        for node in graph_info.graph.nodes:
-            if node.target is not load_target:
-                continue
-            for user in node.users:
-                target_name = getattr(user.target, "__name__", "") or ""
-                if target_name in cast_targets:
-                    has_cast = True
-                    break
-            if has_cast:
-                break
-        if has_cast:
-            break
-    return "unroll" if has_cast else "vec"
+    return "unroll"
 
 
 def _cute_cluster_reduce_smem_vars(
@@ -1238,7 +1219,10 @@ class LoopedReductionStrategy(ReductionStrategy):
         self._cute_reduction_vec_width = 1
         # ``"vec"`` (fp32 fast path) or ``"unroll"`` (bf16/fp16 fallback)
         # — controls how the lane body emits each per-iter load.
-        self._cute_reduction_vec_mode = "vec"
+        # "unroll" is the only live vec mode; the retired "vec" mode
+        # miscompiled (see _cute_vec_kernel_mode) so it must never be the
+        # default a forgotten assignment falls back to.
+        self._cute_reduction_vec_mode = "unroll"
         # Masks queued by vec loads inside the lane loop; consumed by
         # codegen_reduction to wrap the V-fold scalar.
         self._cute_pending_vec_masks: list[str] = []

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -811,14 +811,23 @@ _CUTE_VECTOR_DTYPES: dict[torch.dtype, tuple[str, int]] = {
     torch.bfloat16: ("cutlass.BFloat16", _CUTE_VECTOR_MAX_BYTES // 2),
 }
 
-# ``unroll`` mode loads bf16/fp16 inputs as Uint16 vectors and bitcasts each
-# extracted lane back to the original dtype.  This avoids the CuTe DSL
-# crash that fires when subscripting a bf16/fp16 vector value.  Cutlass
-# scalar type for the extracted lane is paired with the vec-element type
-# name used in ``ir.VectorType.get``.
+# ``unroll`` mode loads inputs as same-width INTEGER vectors (Uint16 for
+# bf16/fp16, Uint32 for fp32) and bitcasts each extracted lane back to the
+# original dtype.  This avoids the CuTe DSL crash that fires when
+# subscripting a bf16/fp16 vector value, and for fp32 sidesteps the retired
+# explicit-vec mode (see ``_cute_vec_kernel_mode``).  Maps the tensor dtype
+# to the cutlass scalar type of the extracted lane.
 _CUTE_VECTOR_UNROLL_DTYPES: dict[torch.dtype, str] = {
     torch.float16: "cutlass.Float16",
     torch.bfloat16: "cutlass.BFloat16",
+    torch.float32: "cutlass.Float32",
+}
+
+# Integer carrier type for an unroll-mode vector load of a given dtype.
+_CUTE_VECTOR_UNROLL_CARRIER: dict[torch.dtype, str] = {
+    torch.float16: "cutlass.Uint16",
+    torch.bfloat16: "cutlass.Uint16",
+    torch.float32: "cutlass.Uint32",
 }
 
 # 1-byte fp8 dtypes also use ``unroll`` mode.  Rather than a
@@ -855,14 +864,15 @@ def _cute_is_unroll_dtype(dtype: torch.dtype) -> bool:
 def _cute_unroll_vec_elem_type(dtype: torch.dtype, vec_width: int = 1) -> str:
     """Cutlass load type for an ``unroll``-mode hoisted vec load.
 
-    fp8 loads ``vec_width`` bytes as a single packed integer; bf16/fp16 load a
-    ``Uint16`` vector element (the ``VectorType`` width is applied by callers).
+    fp8 loads ``vec_width`` bytes as a single packed integer; bf16/fp16/fp32
+    load a same-width integer vector element (the ``VectorType`` width is
+    applied by callers).
     """
     if _cute_is_byte_packed(dtype):
         pack = _CUTE_BYTE_PACK_TYPE.get(vec_width)
         assert pack is not None, f"unsupported fp8 vec_width {vec_width}"
         return pack
-    return "cutlass.Uint16"
+    return _CUTE_VECTOR_UNROLL_CARRIER[dtype]
 
 
 def _cute_lane_axis_pos(strategy: object, block_id: int, index_exprs: list[str]) -> int:
@@ -889,7 +899,7 @@ def _cute_unroll_vec_load_expr(
         return f"cute.arch.load({ptr_expr}, {pack}{eviction_suffix})"
     return (
         f"cute.arch.load({ptr_expr}, "
-        f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type)"
+        f"ir.VectorType.get([{vec_width}], {_cute_unroll_vec_elem_type(dtype)}.mlir_type)"
         f"{eviction_suffix})"
     )
 
@@ -905,7 +915,8 @@ def _cute_unroll_vec_extract(hoist_var: str, idx: str, dtype: torch.dtype) -> st
     if dtype in _CUTE_VECTOR_UNROLL_BYTE_DTYPES:
         return f"cutlass.Uint8(({hoist_var} >> (8 * ({idx}))) & 0xFF)"
     elem_dtype = _CUTE_VECTOR_UNROLL_DTYPES[dtype]
-    return f"cutlass.Uint16({hoist_var}[{idx}]).bitcast({elem_dtype})"
+    carrier = _CUTE_VECTOR_UNROLL_CARRIER[dtype]
+    return f"{carrier}({hoist_var}[{idx}]).bitcast({elem_dtype})"
 
 
 def _cute_lane_vloop_insert_pos(

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6944,6 +6944,26 @@ class TestCuteBackend(TestCase):
         self.assertIn("ir.VectorType.get([4], cutlass.Uint16.mlir_type)", code)
         self.assertIn(".bitcast(cutlass.BFloat16)", code)
 
+    def test_fp32_unroll_mode_emits_uint32_vec_load_and_bitcast(self) -> None:
+        """A pure-fp32 reduction with V=4 loads each V-chunk as a Uint32
+        vector and bitcasts each lane back to fp32.  Regression test: the
+        retired explicit-vec mode emitted vec-lattice indexing with SCALAR
+        loads for this exact config (its load-side gate never matched aten
+        reduction targets), silently reading 1/V of each row."""
+        args = (torch.randn(2, 16384, device=DEVICE, dtype=torch.float32) + 2.0,)
+        code, out = code_and_output(
+            cute_normalize_by_sum,
+            args,
+            block_sizes=[1],
+            reduction_loop=8192,
+            cute_vector_widths=[4],
+        )
+        (x,) = args
+        expected = x / x.sum(-1, keepdim=True)
+        torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+        self.assertIn("ir.VectorType.get([4], cutlass.Uint32.mlir_type)", code)
+        self.assertIn(".bitcast(cutlass.Float32)", code)
+
     def test_two_pass_load_fusion_shape_b_wide_chunk(self) -> None:
         """Shape B: V=1 wide-chunk reduction emits a lane loop inside the
         outer offset loop, and the fuser caches loaded x values across the


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #3560
 * #3559
 * #3558
 * #3557
 * #3556
 * #3555
 * #3554
 * #3541
 * __->__#3540
 * #3539
 * #3538
 * #3537
 * #3536
 * #3535


--- --- ---

[cutedsl] Fix silent fp32 corruption at V>1: retire vec mode, extend unroll to fp32

The explicit-vec reduction mode ('vec': cute.arch.load(..., V) +
_cute_pre_vec_fold) was selected for pure-fp32 rolled kernels, but its
load-side gate (feeds_reduction) walks user targets looking for a
'reduction' token that aten reduction ops (amax/sum/...) never carry, so
the loads always fell back to SCALAR while the strategy kept the
V-partitioned lattice: every fp32 config with cute_vector_widths > 1
read 1/V of each row and silently corrupted results (82% mismatched
elements on the original test kernel; its test only asserted codegen
strings, never values).  Only the autotuner's accuracy check kept these
configs out of tuned results.

Fix: _cute_vec_kernel_mode now always returns 'unroll', whose lattice
emits correct per-element indices even when a load cannot vectorize, and
the unroll hoist gains fp32 support via a Uint32 integer-carrier vector
(bitcast per lane, capped at one LDG.128 per hoist).  fp32 rolled
reductions gain real 128-bit loads for the first time: cross-entropy
32768x2048 fp32 on B200 measures 4766 GB/s with V=4 vs 4606 scalar.
The tile_unroll lane path gains fp32 the same way (byte-based cap
replaces the width-8 cap).

The vec-mode fallback defaults (strategy initializer and the codegen
getattr) are 'unroll' so a forgotten mode assignment can never resurrect
the retired miscompiling 'vec' mode; the dead
_cute_unroll_vec_load_dtype_arg helper is removed.