### PR TITLE
[benchmark] Set cuBLASLt grouped shape hints as uint64

### DIFF
--- a/benchmarks/cute/cublaslt_grouped_gemm.py
+++ b/benchmarks/cute/cublaslt_grouped_gemm.py
@@ -317,11 +317,13 @@ def _set_grouped_preference_attributes(
             "average_output_columns",
         ),
     ):
+        # cublasLt.h documents these as uint32_t, but cuBLASLt 13.6 rejects a
+        # four-byte write with CUBLAS_STATUS_INVALID_VALUE and accepts eight.
         _set_attribute(
             library.cublasLtMatmulPreferenceSetAttribute,
             preference,
             attribute,
-            ctypes.c_uint32(values[name]),
+            ctypes.c_uint64(values[name]),
             f"set grouped {name}",
         )
 


### PR DESCRIPTION
## Summary

Every `cublaslt` worker in the BF16 grouped-GEMM provider campaign dies before
it measures anything:

```
RuntimeError: set grouped average_reduction_dim failed with cuBLAS status 7
```

Status 7 is `CUBLAS_STATUS_INVALID_VALUE`. `cublasLt.h` documents
`CUBLASLT_MATMUL_PREF_GROUPED_AVERAGE_REDUCTION_DIM` and the two average D
extents as `uint32_t`, but cuBLASLt 13.6.1.10 rejects a four-byte write to them
and accepts an eight-byte one.

This is specific to those three attributes, not a property of the preference
API. Probing the pinned library directly -- setting each attribute with a
4-byte and an 8-byte buffer, and asking
`cublasLtMatmulPreferenceGetAttribute(..., NULL, 0, &sizeWritten)` what size it
expects:

| attr | name | documented type | set 4B | set 8B | expects |
| ---: | --- | --- | ---: | ---: | --- |
| 1 | `MAX_WORKSPACE_BYTES` | `uint64_t` | 7 | 0 | 8 bytes, matches docs |
| 5 | `MIN_ALIGNMENT_A_BYTES` | `uint32_t` | 0 | 7 | 4 bytes, matches docs |
| 6 | `MIN_ALIGNMENT_B_BYTES` | `uint32_t` | 0 | 7 | 4 bytes, matches docs |
| 9 | `MAX_WAVES_COUNT` | `float` | 0 | 7 | 4 bytes, matches docs |
| 12 | `IMPL_MASK` | `uint64_t` | 7 | 0 | 8 bytes, matches docs |
| 13 | `GROUPED_AVERAGE_REDUCTION_DIM` | `uint32_t` | 7 | 0 | **8 bytes, contradicts docs** |
| 14 | `GROUPED_DESC_D_AVERAGE_ROWS` | `uint32_t` | 7 | 0 | **8 bytes, contradicts docs** |
| 15 | `GROUPED_DESC_D_AVERAGE_COLS` | `uint32_t` | 7 | 0 | **8 bytes, contradicts docs** |

The size check is per-attribute and agrees with the documented type for every
attribute except the three grouped ones, all of which are marked
`/** Experimental: ... */` in the header. The value round-trips correctly once
the width is right:

```
attr 13: set status=0, get status=0, sizeWritten=8, value=7168
```

so the hint is stored rather than silently dropped or truncated.

Pass the three grouped shape hints as `uint64`. The comment names the library
version deliberately: the campaign pins `nvidia-cublas==13.6.1.10` and fails
closed on any other version, so this does not need to be version-adaptive.

## Validation

- `pytest -q test/test_grouped_gemm_provider_campaign.py test/test_cute_grouped_gemm_benchmark.py` (63 passed)
- `ruff check` and `ruff format --check` clean on the changed file
- with this fix the `cublaslt` workers complete: the three-replicate BF16
  provider campaign runs end to end on B200 across all five providers and eight
  workloads, correctness checks passing
