### PR TITLE
Allow host values as hl.register_block_size bounds

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -55,6 +55,39 @@ if TYPE_CHECKING:
     from .type_info import TensorType
 
 
+def _flatten_starred_args(args: list[ast.expr]) -> list[ast.expr]:
+    """Expand ``f(*xs)`` into per-element nodes (``xs[0]``, ``xs[1]``, ...).
+
+    Type propagation flattens starred args the same way (see
+    `TypePropagation.visit_Call`), so host codegen must match it to keep the ast
+    args aligned with the proxy args of an API function.
+    """
+    from .type_info import SequenceType
+
+    if not any(isinstance(arg, ast.Starred) for arg in args):
+        return args
+    result: list[ast.expr] = []
+    for arg in args:
+        if not isinstance(arg, ast.Starred):
+            result.append(arg)
+            continue
+        value = arg.value
+        assert isinstance(value, ExtendedAST)
+        seq_type = value._type_info
+        assert isinstance(seq_type, SequenceType)
+        for i, element_type in enumerate(seq_type.unpack()):
+            result.append(
+                create(
+                    ast.Subscript,
+                    value=value,
+                    slice=create(ast.Constant, value=i, kind=None),
+                    ctx=ast.Load(),
+                    _type_info=element_type,
+                )
+            )
+    return result
+
+
 @dataclasses.dataclass(frozen=True)
 class ResidentPrepLowering:
     hoist: ResidentPrepHoist
@@ -1074,8 +1107,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                         assert isinstance(iter_node, ast.Call)
                         args = []
                         kwargs = {}
-                        for arg_node in iter_node.args:
-                            assert not isinstance(arg_node, ast.Starred)
+                        for arg_node in _flatten_starred_args(iter_node.args):
                             assert isinstance(arg_node, ExtendedAST)
                             assert arg_node._type_info is not None
                             args.append(arg_node._type_info.proxy())
@@ -1294,8 +1326,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             ast_kwargs = {}
             proxy_args = []
             proxy_kwargs = {}
-            for arg in node.args:
-                assert not isinstance(arg, ast.Starred)
+            for arg in _flatten_starred_args(node.args):
                 assert isinstance(arg, ExtendedAST)
                 assert arg._type_info is not None
                 ast_args.append(arg)

--- a/helion/language/tunable_ops.py
+++ b/helion/language/tunable_ops.py
@@ -51,7 +51,8 @@ def register_block_size(min_or_max: int, max_or_none: int | None = None, /) -> i
         hl.register_block_size(min, max)
 
     Where min and max are integers that control the range of block_sizes searched by
-    the autotuner.  Max may be a symbolic shape, but min must be a constant integer.
+    the autotuner.  Both may be symbolic shapes, in which case their size hints are
+    used to bound the search.
     """
     raise exc.NotInsideKernel
 
@@ -77,11 +78,16 @@ def _(
         raise exc.IncorrectTileUsage(
             f"expected max to be an integer or size, got {max_proxy!s}"
         )
-    if not isinstance(min_proxy, int):
+    if not isinstance(min_proxy, (int, torch.SymInt)):
         raise exc.IncorrectTileUsage(
-            f"expected min to be an integer constant, got {min_proxy!s}"
+            f"expected min to be an integer or size, got {min_proxy!s}"
         )
     env = CompileEnvironment.current()
+    # Host scalars (globals, int arguments, `*args` unpacked from a tuple) are
+    # faked into SymInts during type propagation, so min may arrive symbolic even
+    # when the user wrote a constant.  Both bounds only shape the autotuner search
+    # space, so resolve them to hints the same way.
+    min_proxy = env.size_hint(min_proxy)
     existing_block_id = (
         env.get_block_id(max_proxy) if isinstance(max_proxy, torch.SymInt) else None
     )

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -38,6 +38,7 @@ import helion.language as hl
 datadir = Path(__file__).parent / "data"
 basic_kernels = import_path(datadir / "basic_kernels.py")
 FIXED_BLOCK_SIZE = 16
+BLOCK_SIZE_CHOICES = (32, 256)
 
 
 @helion.kernel
@@ -521,6 +522,49 @@ class TestLoops(RefEagerTestBase, TestCase):
         self.assertEqual(spec.size_hint, 1024)
         self.assertEqual(spec.min_size, 32)
         self.assertEqual(spec.max_size, 256)
+
+    @xfailIfPallas("config_spec introspection not applicable on pallas")
+    @skipIfRefEager(
+        "Accessing config_spec.block_sizes is not supported in ref eager mode"
+    )
+    def test_register_block_size_host_bounds(self):
+        # min/max may come from host values rather than literals, including via
+        # `*args` unpacking of a global tuple.
+        @helion.kernel()
+        def starred(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            bs = hl.register_block_size(*BLOCK_SIZE_CHOICES)
+            for tile0 in hl.tile(x.size(0), block_size=bs):
+                out[tile0] = x[tile0] + 1
+            return out
+
+        @helion.kernel()
+        def indexed(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            bs = hl.register_block_size(BLOCK_SIZE_CHOICES[0], BLOCK_SIZE_CHOICES[1])
+            for tile0 in hl.tile(x.size(0), block_size=bs):
+                out[tile0] = x[tile0] + 1
+            return out
+
+        args = (torch.randn([1024], device=DEVICE, dtype=torch.float32),)
+        for fn in (starred, indexed):
+            code, result = code_and_output(fn, args, block_size=64)
+            torch.testing.assert_close(result, args[0] + 1)
+            spec = fn.bind(args).config_spec.block_sizes[0]
+            self.assertEqual((spec.min_size, spec.max_size), BLOCK_SIZE_CHOICES)
+
+    def test_tile_starred_args(self):
+        @helion.kernel()
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            sizes = [x.size(0), x.size(1)]
+            for tile0, tile1 in hl.tile(*[sizes]):
+                out[tile0, tile1] = x[tile0, tile1] + 1
+            return out
+
+        args = (torch.randn([64, 64], device=DEVICE, dtype=torch.float32),)
+        code, result = code_and_output(fn, args, block_sizes=[16, 16])
+        torch.testing.assert_close(result, args[0] + 1)
 
     @skipIfTileIR("Result mismatch with tileir backend")
     @skipIfFn(


### PR DESCRIPTION
## Problem

```python
CHOICES = (64, 128)

@helion.kernel(static_shapes=True)
def k(a, b):
    block_k = hl.register_block_size(*CHOICES)   # fails
    ...
```

```
helion.exc.IncorrectTileUsage: ... expected min to be an integer constant, got u0
```

The equivalent `hl.register_block_size(64, 128)` works fine.

## Root cause

Two independent bugs, both surfaced by the same repro.

**1. Type propagation rejected a non-literal `min`** (`helion/language/tunable_ops.py`)

Host scalars (globals, int arguments, values unpacked from a global tuple) are faked into unbacked SymInts by `CompileEnvironment.to_fake`, so `min` arrives symbolic even though the user wrote a constant. `max` was already resolved via `env.size_hint(...)`; `min` now goes through the same path. Both bounds only shape the autotuner search space, so this is consistent.

This was not specific to `*args` — these failed identically:

```python
hl.register_block_size(MIN_GLOBAL, MAX_GLOBAL)
hl.register_block_size(CHOICES[0], CHOICES[1])
```

**2. Host codegen asserted on starred args** (`helion/_compiler/generate_ast.py`)

With (1) fixed, compilation reached codegen and hit `assert not isinstance(arg, ast.Starred)`. Type propagation (`TypePropagation.visit_Call`) and `device_ir` both flatten `*args`; host codegen did not. Added `_flatten_starred_args`, which expands `f(*xs)` into `xs[0], xs[1], ...` nodes carrying the per-element type info, so ast args stay aligned with proxy args. Applied at both host-codegen sites: the API-function call path and the `for ... in hl.tile(*args)` device-loop path.

## Verification

Literal and starred forms now produce identical block size specs and correct results:

```
triton/literal: [(64, 128), (1, 512), (1, 512)] correct=True
triton/starred: [(64, 128), (1, 512), (1, 512)] correct=True
cute/literal:   [(64, 128), (128, 256), (8, 256)] correct=True
cute/starred:   [(64, 128), (128, 256), (8, 256)] correct=True
```

## Tests

Added to `test/test_loops.py`, next to the existing `register_block_size` bound tests:

- `test_register_block_size_host_bounds` — starred and indexed global bounds produce the expected `(min_size, max_size)` spec
- `test_tile_starred_args` — covers the `for ... in hl.tile(*args)` codegen path

Passing: `test_loops.py`, `test_register_tunable.py`, `test_constexpr.py`, `test_errors.py`, `test_type_propagation.py`, `test_misc.py`, `test_indexing.py`, plus `test_loops.py` under `HELION_BACKEND=cute` and `HELION_INTERPRET=1`.
