### PR TITLE
Port the legacy visitor hooks and allow-lists off the removed ast classes

### DIFF
--- a/helion/_compiler/ast_read_writes.py
+++ b/helion/_compiler/ast_read_writes.py
@@ -251,21 +251,6 @@ class _PureExpressionVisitor(ast.NodeVisitor):
     def visit_Constant(self, node: ast.Constant) -> None:
         pass
 
-    def visit_Num(self, node: ast.Num) -> None:
-        pass
-
-    def visit_Str(self, node: ast.Str) -> None:
-        pass
-
-    def visit_Bytes(self, node: ast.Bytes) -> None:
-        pass
-
-    def visit_NameConstant(self, node: ast.NameConstant) -> None:
-        pass
-
-    def visit_Ellipsis(self, node: ast.Ellipsis) -> None:
-        pass
-
     def visit_Name(self, node: ast.Name) -> None:
         pass
 


### PR DESCRIPTION
Summary:
`ast.Num`, `ast.Str`, `ast.Bytes`, `ast.NameConstant` and `ast.Ellipsis` are gone
in 3.14, as are the `.s` / `.n` aliases on `ast.Constant`.

Reviewed By: ambv

Differential Revision: D114500505


