### PR TITLE
[triton] Support scalar load eviction policies

### DIFF
--- a/helion/_compiler/triton/memory_ops.py
+++ b/helion/_compiler/triton/memory_ops.py
@@ -131,8 +131,13 @@ def _(state: CodegenState) -> ast.AST:
     # If no explicit eviction_policy and we're in device code, use tunable
     if eviction_policy is None and state.codegen.on_device:
         policies = state.config.load_eviction_policies
-        if load_idx < len(policies):
+        if isinstance(policies, str):
+            policy_value = policies
+        elif load_idx < len(policies):
             policy_value = policies[load_idx]
+        else:
+            policy_value = None
+        if policy_value is not None:
             eviction_policy = _EVICTION_POLICY_MAP.get(policy_value, policy_value)
 
     if eviction_policy is not None:

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2615,7 +2615,10 @@ class ConfigSpec:
             "indexing",
             "atomic_indexing",
         ):
-            if not config.get(name):
+            value = config.get(name)
+            if name == "load_eviction_policies" and value == "":
+                continue
+            if not value:
                 config.pop(name, None)
 
         # Remove unsupported keys before setting defaults

--- a/helion/runtime/config.py
+++ b/helion/runtime/config.py
@@ -44,7 +44,9 @@ class Config(Mapping[str, object]):
         range_flattens: list[bool | None] | None = None,
         static_ranges: list[bool] | None = None,
         pallas_load_buffer_count: list[int] | None = None,
-        load_eviction_policies: list[EvictionPolicyLiteral] | None = None,
+        load_eviction_policies: (
+            EvictionPolicyLiteral | list[EvictionPolicyLiteral] | None
+        ) = None,
         load_cache_modifiers: list[LoadCacheModifierLiteral] | None = None,
         store_cache_modifiers: list[StoreCacheModifierLiteral] | None = None,
         num_warps: int | None = None,
@@ -79,7 +81,9 @@ class Config(Mapping[str, object]):
             pallas_load_buffer_count: Pallas-only load buffer count (1 or 2) for
                 each input tensor. Tensors without an existing DMA route use the
                 ordinary path.
-            load_eviction_policies: Eviction policies for load operations ("", "first", "last").
+            load_eviction_policies: Eviction policies for load operations. A single
+                value applies to every load; a list specifies one value per load.
+                Valid values are "", "first", and "last".
             load_cache_modifiers: Cache modifiers for load operations ("", ".cg").
             store_cache_modifiers: Cache modifiers for store operations ("", ".cs", ".wt").
             num_warps: Number of warps per block.
@@ -343,9 +347,12 @@ class Config(Mapping[str, object]):
         return cast("list[int]", self.config.get("pallas_load_buffer_count", []))
 
     @property
-    def load_eviction_policies(self) -> list[EvictionPolicyLiteral]:
+    def load_eviction_policies(
+        self,
+    ) -> EvictionPolicyLiteral | list[EvictionPolicyLiteral]:
         return cast(
-            "list[EvictionPolicyLiteral]", self.config.get("load_eviction_policies", [])
+            "EvictionPolicyLiteral | list[EvictionPolicyLiteral]",
+            self.config.get("load_eviction_policies", []),
         )
 
     @property

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -1096,6 +1096,22 @@ class TestHardwareConfigSpecRanges(TestCase):
             ("", "first", "last"),
         )
 
+    def test_scalar_empty_eviction_policy_survives_normalization(self) -> None:
+        from helion._compiler.backend import TritonBackend
+        from helion.autotuner.config_spec import ConfigSpec
+
+        with patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=False,
+        ):
+            config_spec = ConfigSpec(backend=TritonBackend())
+        config_spec.load_eviction_policies.length = 2
+        config = helion.Config(load_eviction_policies="")
+
+        config_spec.normalize(config)
+
+        self.assertEqual(config.load_eviction_policies, "")
+
     def test_load_cache_modifier_choices_do_not_leak_mocked_amd_state(self) -> None:
         """Mocked AMD capability detection should not poison later Triton specs."""
         from helion._compiler.backend import TritonBackend

--- a/test/test_eviction_policy.py
+++ b/test/test_eviction_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import contextlib
 import unittest
 from unittest import mock
@@ -134,6 +135,40 @@ class TestEvictionPolicy(RefEagerTestBase, TestCase):
 
             # Check that evict_last appears in the generated code
             self.assertIn("evict_last", code)
+
+    @skipIfRefEager("Generated code inspection not applicable in ref eager mode")
+    @skipIfTileIR("tileir backend will ignore `eviction_policy` hint")
+    @skipIfRocm("ROCm does not support eviction policy")
+    def test_scalar_eviction_policy_applies_to_every_load(self) -> None:
+        @helion.kernel(
+            config={
+                "block_size": 16,
+                "load_eviction_policies": "last",
+                "indexing": "pointer",
+            }
+        )
+        def kernel_with_eviction(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        x = torch.randn([128], device=DEVICE, dtype=torch.float32)
+        y = torch.randn([128], device=DEVICE, dtype=torch.float32)
+
+        code, result = code_and_output(kernel_with_eviction, (x, y))
+
+        torch.testing.assert_close(result, x + y)
+        self.assertEqual(
+            sum(
+                isinstance(node, ast.keyword)
+                and node.arg == "eviction_policy"
+                and isinstance(node.value, ast.Constant)
+                and node.value.value == "evict_last"
+                for node in ast.walk(ast.parse(code))
+            ),
+            2,
+        )
 
     @parametrize("indexing", ("pointer", "block_ptr", "tensor_descriptor"))
     @skipIfTileIR("tileir backend will ignore `eviction_policy` hint")


### PR DESCRIPTION
Allow load_eviction_policies to accept either a per-load list or a scalar value broadcast to every load, i.e.

```python
helion.Config(load_eviction_policies = "")
```
 Preserve "" during config normalization so callers can explicitly disable eviction hints for all loads.

This matches the existing scalar behavior of indexing overrides and makes configs reusable across kernels with different numbers of load operations.
